### PR TITLE
[refactor] introduce task-based milling architecture

### DIFF
--- a/fibsem/milling/MILLING_TASK_REFACTOR.md
+++ b/fibsem/milling/MILLING_TASK_REFACTOR.md
@@ -1,0 +1,140 @@
+# Milling Task Architecture Refactor
+
+## Overview
+
+This refactor introduces a task-based architecture for milling operations, consolidating parameters that had 'soft' requirements to be the same across all stages into a higher-level `FibsemMillingTask` wrapper.
+
+## Problem Statement
+
+Previously, milling stages had several parameters that:
+- **Had 'soft' requirements to be the same** across all stages (e.g., field of view, milling channel, alignment settings)
+- **Should be set consistently** for all stages in a sequence (e.g., imaging settings, post-milling acquisition)
+- **Created parameter duplication** and potential inconsistency between stages
+
+## Changes Made
+
+### New Architecture
+
+1. **FibsemMillingTaskConfig** - Encapsulates task-level parameters:
+   - `hfw` (field of view) - Should be consistent across stages
+   - `milling_channel` - Beam type for milling operations
+   - `acquire_after_milling` - Whether to acquire images after milling
+   - `alignment` - Alignment settings for drift correction
+   - `imaging` - Settings for post-milling image acquisition
+
+2. **FibsemMillingTask** - Higher-level wrapper that orchestrates stage execution:
+   - Contains task-level configuration
+   - Manages list of stages
+   - Owns reference image for alignment
+   - Provides unique task ID for tracking
+
+### Key Benefits
+
+- **Eliminates parameter duplication** - Task-level settings defined once
+- **Ensures consistency** - All stages use the same task-level parameters
+- **Clean separation of concerns** - Task orchestration vs. stage execution
+- **Better dependency management** - Strategies receive config without knowing full task structure
+
+## Usage Example
+
+### Before (Old Architecture)
+```python
+# Had to set parameters on each stage individually
+stage1 = FibsemMillingStage(
+    name="Rough Mill",
+    milling=FibsemMillingSettings(hfw=150e-6, milling_channel=BeamType.ION),
+    alignment=MillingAlignment(enabled=True),
+    imaging=ImageSettings(path="/data/images")
+)
+
+stage2 = FibsemMillingStage(
+    name="Fine Mill", 
+    milling=FibsemMillingSettings(hfw=150e-6, milling_channel=BeamType.ION),  # Duplication!
+    alignment=MillingAlignment(enabled=True),  # Duplication!
+    imaging=ImageSettings(path="/data/images")  # Duplication!
+)
+```
+
+### After (New Architecture)
+```python
+from fibsem.milling.base import FibsemMillingTask, FibsemMillingTaskConfig
+
+# Define task-level configuration once
+config = FibsemMillingTaskConfig(
+    hfw=150e-6,
+    milling_channel=BeamType.ION,
+    acquire_after_milling=True,
+    alignment=MillingAlignment(enabled=True),
+    imaging=ImageSettings(path="/data/images")
+)
+
+# Create stages with only stage-specific parameters
+stage1 = FibsemMillingStage(
+    name="Rough Mill",
+    milling=FibsemMillingSettings(milling_current=1e-9),
+    pattern=RectanglePattern(width=10e-6, height=5e-6)
+)
+
+stage2 = FibsemMillingStage(
+    name="Fine Mill",
+    milling=FibsemMillingSettings(milling_current=100e-12),
+    pattern=RectanglePattern(width=8e-6, height=4e-6)
+)
+
+# Create and run task
+task = FibsemMillingTask(
+    name="Lamella Preparation",
+    config=config,
+    stages=[stage1, stage2]
+)
+
+# Execute the task
+task.run(microscope=microscope)
+```
+
+## Technical Implementation
+
+### Parameter Application
+Task-level parameters are applied to stages during the `setup_milling` phase:
+```python
+def setup_milling(microscope, milling_stage, config, reference_image=None):
+    # Apply task-level configuration to stage
+    milling_stage.milling.hfw = config.hfw
+    milling_stage.milling.milling_channel = config.milling_channel
+    
+    # Setup microscope with updated settings
+    microscope.setup_milling(mill_settings=milling_stage.milling)
+```
+
+### Strategy Integration
+Milling strategies now receive task configuration directly:
+```python
+def run(self, microscope, stage, config: FibsemMillingTaskConfig, 
+        reference_image=None, **kwargs):
+    # Strategy has access to task-level config without knowing about full task
+    setup_milling(microscope, stage, config, reference_image)
+```
+
+## Migration Path
+
+The refactor maintains backward compatibility through a wrapper function:
+```python
+def mill_stages(microscope, stages, parent_ui=None):
+    """Backwards compatible wrapper function to mill stages."""
+    # Automatically creates task config from first stage
+    config = FibsemMillingTaskConfig(
+        hfw=stages[0].milling.hfw,
+        alignment=stages[0].alignment,
+        # ... other parameters
+    )
+    
+    task = FibsemMillingTask(config=config, stages=stages)
+    task.run(microscope=microscope, parent_ui=parent_ui)
+```
+
+## Additional Improvements
+
+- **Unique Task IDs** - Each task gets a UUID for tracking and logging
+- **Better Error Handling** - Clear error messages for missing reference images
+- **Cleaner Serialization** - Task and config objects support `to_dict()`/`from_dict()`
+- **Reference Image Ownership** - Task owns and manages reference images for alignment

--- a/fibsem/milling/__init__.py
+++ b/fibsem/milling/__init__.py
@@ -7,6 +7,8 @@ from fibsem.milling.base import (
     get_strategy,
     estimate_milling_time,
     estimate_total_milling_time,
+    FibsemMillingTask, 
+    FibsemMillingTaskConfig
 )
 from fibsem.milling.core import (
     draw_pattern,

--- a/fibsem/milling/strategy/standard.py
+++ b/fibsem/milling/strategy/standard.py
@@ -1,13 +1,18 @@
 import logging
+import time
 from dataclasses import dataclass
+from typing import Optional
 
 from fibsem.microscope import FibsemMicroscope
-from fibsem.milling import (draw_patterns, run_milling,
-                            setup_milling)
-from fibsem.milling.base import (FibsemMillingStage, MillingStrategy,
-                                 MillingStrategyConfig)
+from fibsem.milling import draw_patterns, run_milling, setup_milling
+from fibsem.milling.base import (
+    FibsemMillingStage,
+    FibsemMillingTaskConfig,
+    MillingStrategy,
+    MillingStrategyConfig,
+)
+from fibsem.structures import FibsemImage
 
-import time
 
 @dataclass
 class StandardMillingConfig(MillingStrategyConfig):
@@ -25,11 +30,17 @@ class StandardMillingStrategy(MillingStrategy[StandardMillingConfig]):
         self,
         microscope: FibsemMicroscope,
         stage: FibsemMillingStage,
+        config: FibsemMillingTaskConfig,
+        reference_image: Optional[FibsemImage] = None,
         asynch: bool = False,
         parent_ui = None,
     ) -> None:
+        """Run the standard milling strategy on the given microscope."""
         logging.info(f"Running {self.name} Milling Strategy for {stage.name}")
-        setup_milling(microscope, milling_stage=stage)
+        setup_milling(microscope=microscope,
+                      milling_stage=stage,
+                      config=config,
+                      reference_image=reference_image)
 
         draw_patterns(microscope, stage.pattern.define())
 


### PR DESCRIPTION
Consolidate task-level parameters that had 'soft' requirements to be consistent across stages into FibsemMillingTaskConfig wrapper. Move hfw, milling_channel, alignment, imaging, and acquire_after_milling from stage-level to task-level to eliminate duplication and ensure consistency.

Key changes:
- Add FibsemMillingTaskConfig for task-level parameter encapsulation
- Add FibsemMillingTask wrapper with unique task IDs for orchestration
- Update MillingStrategy interface to receive task config and reference image
- Refactor setup_milling to apply task config to stages at execution time
- Add proper error handling for missing reference images
- Maintain backward compatibility through mill_stages wrapper function