### PR TITLE
[fix] TrenchBitmapPattern.define return type Python 3.8 compatibility

### DIFF
--- a/fibsem/milling/patterning/patterns2.py
+++ b/fibsem/milling/patterning/patterns2.py
@@ -141,7 +141,7 @@ class TrenchBitmapPattern(BasePattern[FibsemBitmapSettings]):
 
     name: ClassVar[str] = "TrenchBitmap"
 
-    def define(self) -> list[FibsemBitmapSettings]:
+    def define(self) -> List[FibsemBitmapSettings]:
         path: Optional[str] = self.path.strip()
         if not path:
             path = None


### PR DESCRIPTION
I noticed that `TrenchBitmapPattern` was using `list` rather than `List` in the return type of `define`, which won't work for Python 3.8 as `from __future__ import annotations` is not defined at the top of the file.