### PR TITLE
Bitmap resize fixes

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -2924,13 +2924,13 @@ class ThermoMicroscope(FibsemMicroscope):
         resized_points = np.empty((*new_shape, 2), dtype=object)
 
         resized_points[:, :, 0] = transform.resize(
-            points[:, :, 0].reshape(points.shape[0], points.shape[1]),
+            points[:, :, 0].reshape(points.shape[0], points.shape[1]).astype(np.float_),
             output_shape=new_shape,
             order=order,
             preserve_range=True,
         ).astype(np.float_)
         resized_points[:, :, 1] = transform.resize(
-            points[:, :, 1].reshape(points.shape[0], points.shape[1]),
+            points[:, :, 1].reshape(points.shape[0], points.shape[1]).astype(np.uint8),
             output_shape=new_shape,
             order=0,
             preserve_range=True,


### PR DESCRIPTION
Hi Patrick,

Came across a couple of errors while testing the bitmap resizing, due to differences in how the bitmap was being loaded vs how I'd been testing it.

Changes:
- More explicitly defines the expected shape of the dwell time and blanking arrays (using `reshape(points.shape[0], points.shape[1])` rather than `.squeeze(-1)`).
- Casts the arrays to the appropriate type so that `transform.resize` doesn't reject the arrays. The expected bitmap array is `object` type, as it can contain multiple dtypes that way, but the internal parts are `np.float_` and `np.uint8`, so this doesn't change any values.