### PR TITLE
Add configurable Tescan preset restoration, reduce default FIB imaging current, and refactor beam wait logic

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -554,9 +554,9 @@ class FibsemMicroscope(ABC):
         logging.debug({"msg": "get", "key": key, "beam_type": beam_name, "value": value})
         return value
 
-    def set(self, key: str, value: Union[str, float, int, tuple, list, Point], beam_type: Optional[BeamType] = None) -> None:
+    def set(self, key: str, value: Union[str, float, int, tuple, list, Point], beam_type: Optional[BeamType] = None, **kwargs) -> None:
         """Set wrapper for logging"""
-        self._set(key, value, beam_type)
+        self._set(key, value, beam_type, **kwargs)
         beam_name = "None" if beam_type is None else beam_type.name
         logging.debug({"msg": "set", "key": key, "beam_type": beam_name, "value": value})
 
@@ -565,7 +565,7 @@ class FibsemMicroscope(ABC):
         pass
 
     @abstractmethod
-    def _set(self, key: str, value: Union[str, float, int, list, tuple, Point], beam_type: Optional[BeamType] = None) -> None:
+    def _set(self, key: str, value: Union[str, float, int, list, tuple, Point], beam_type: Optional[BeamType] = None, **kwargs) -> None:
         pass
 
     # TODO: i dont think this is needed, you set the beam settings and detector settings separately

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1047,9 +1047,9 @@ class FibsemMicroscope(ABC):
         self.set("detector_brightness", brightness, beam_type)
         return self.get("detector_brightness", beam_type)
 
-    def set_preset(self, preset: str, beam_type: BeamType) -> str:
+    def set_preset(self, preset: str, beam_type: BeamType, preserve_settings=True) -> str:
         """Set the preset for the specified beam type."""
-        self.set("preset", preset, beam_type)
+        self.set("preset", preset, beam_type, preserve_settings=preserve_settings)
         return self.get("preset", beam_type)
 
     def _get_compucentric_rotation_offset(self) -> FibsemStagePosition:

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -554,9 +554,9 @@ class FibsemMicroscope(ABC):
         logging.debug({"msg": "get", "key": key, "beam_type": beam_name, "value": value})
         return value
 
-    def set(self, key: str, value: Union[str, float, int, tuple, list, Point], beam_type: Optional[BeamType] = None, **kwargs) -> None:
+    def set(self, key: str, value: Union[str, float, int, tuple, list, Point], beam_type: Optional[BeamType] = None) -> None:
         """Set wrapper for logging"""
-        self._set(key, value, beam_type, **kwargs)
+        self._set(key, value, beam_type)
         beam_name = "None" if beam_type is None else beam_type.name
         logging.debug({"msg": "set", "key": key, "beam_type": beam_name, "value": value})
 
@@ -565,7 +565,7 @@ class FibsemMicroscope(ABC):
         pass
 
     @abstractmethod
-    def _set(self, key: str, value: Union[str, float, int, list, tuple, Point], beam_type: Optional[BeamType] = None, **kwargs) -> None:
+    def _set(self, key: str, value: Union[str, float, int, list, tuple, Point], beam_type: Optional[BeamType] = None) -> None:
         pass
 
     # TODO: i dont think this is needed, you set the beam settings and detector settings separately
@@ -1047,9 +1047,9 @@ class FibsemMicroscope(ABC):
         self.set("detector_brightness", brightness, beam_type)
         return self.get("detector_brightness", beam_type)
 
-    def set_preset(self, preset: str, beam_type: BeamType, preserve_settings=True) -> str:
+    def set_preset(self, preset: str, beam_type: BeamType) -> str:
         """Set the preset for the specified beam type."""
-        self.set("preset", preset, beam_type, preserve_settings=preserve_settings)
+        self.set("preset", preset, beam_type)
         return self.get("preset", beam_type)
 
     def _get_compucentric_rotation_offset(self) -> FibsemStagePosition:

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -1111,7 +1111,7 @@ class TescanMicroscope(FibsemMicroscope):
             imaging_current (float): The current to use for imaging in amps.
         # """
         try:
-            default_preset = "30 keV; 150 pA"
+            default_preset = "30 keV; 10 pA"
             self.set("preset", default_preset, BeamType.ION)
             self.connection.DrawBeam.UnloadLayer()
             logging.debug(f"Finished milling, restored preset to {default_preset}")

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -1112,7 +1112,7 @@ class TescanMicroscope(FibsemMicroscope):
         # """
         try:
             default_preset = "30 keV; 150 pA"
-            self.connection.FIB.Preset.Activate(default_preset) # TODO: restore the default preset?
+            self.set("preset", default_preset, BeamType.ION)
             self.connection.DrawBeam.UnloadLayer()
             logging.debug(f"Finished milling, restored preset to {default_preset}")
         except Exception as e:
@@ -1322,6 +1322,18 @@ class TescanMicroscope(FibsemMicroscope):
         if beam_type is BeamType.ION:
             return self.connection.FIB
 
+    def _wait_for_beam_ready(self, beam: Union['Automation.SEM', 'Automation.FIB'], beam_type: BeamType, operation: str = "operation") -> None:
+        """Wait for the beam to become ready (not busy)."""
+        start_time = time.monotonic()
+        while beam.IsBusy():
+            logging.debug(f"Waiting for the {beam_type.name} beam to become ready after {operation}.")
+            if time.monotonic() - start_time > TESCAN_BEAM_READY_TIMEOUT:
+                raise TimeoutError(
+                    f"{beam_type.name} beam is not ready after {operation}. "
+                    f"Timeout of {TESCAN_BEAM_READY_TIMEOUT} seconds expired."
+                )
+            time.sleep(1)
+
     def _prepare_beam(self, beam_type: BeamType) -> Union['Automation.SEM', 'Automation.FIB']:
         """Prepare the beam for imaging, milling, or other operations."""
         beam = self._get_beam(beam_type)
@@ -1334,15 +1346,7 @@ class TescanMicroscope(FibsemMicroscope):
         # stop the scanning before we start scanning or before automatic procedures,
         beam.Scan.Stop()
 
-        start_time = time.monotonic()
-        while (beam.IsBusy()):
-            logging.debug(f"Waiting for the {beam_type.name} beam to become ready.")
-            if time.monotonic() - start_time > TESCAN_BEAM_READY_TIMEOUT:
-                raise TimeoutError(
-                    f"{beam_type.name} beam is not ready. "
-                    f"Timeout of {TESCAN_BEAM_READY_TIMEOUT} seconds expired."
-                )
-            time.sleep(1)
+        self._wait_for_beam_ready(beam, beam_type, operation="preparation")
 
         return beam
 
@@ -1528,8 +1532,31 @@ class TescanMicroscope(FibsemMicroscope):
         logging.warning(f"Unknown key: {key} ({beam_type})")
         return None   
 
-    def _set(self, key: str, value, beam_type: BeamType = None) -> None:
-        """Set a property of the microscope."""
+    def _set(self, key: str, value, beam_type: BeamType = None, **kwargs) -> None:
+        """
+        Set a property of the microscope.
+        
+        Special handling for preset changes:
+            When key="preset", you can use the preserve_settings keyword argument:
+            
+        Args:
+            key: The property key to set.
+            value: The value to set.
+            beam_type: The beam type (ELECTRON or ION).
+            **kwargs: Additional keyword arguments.
+                preserve_settings (bool): For preset changes, whether to preserve
+                    rotation, FOV, and shift. Defaults to True.
+            
+        Examples:
+            # Preserve settings (default behavior)
+            microscope.set("preset", "30 keV; 10 pA", BeamType.ION)
+            
+            # Don't preserve settings - let preset fully control all parameters
+            microscope.set("preset", "30 keV; 10 pA", BeamType.ION, preserve_settings=False)
+            
+            # Explicitly preserve settings
+            microscope.set("preset", "30 keV; 10 pA", BeamType.ION, preserve_settings=True)
+        """
         if beam_type is not None:
             beam: Union[Automation.SEM, Automation.FIB] = self._get_beam(beam_type)
             self._prepare_beam(beam_type)
@@ -1624,12 +1651,56 @@ class TescanMicroscope(FibsemMicroscope):
             return
 
         if key == "preset":
-            # check if value is in available
+            # Get preserve_settings from kwargs, default to True
+            preserve_settings = kwargs.get("preserve_settings", True)
+            
+            # Check if preset is available
             if not beam.Preset.IsAvailable(value):
                 logging.warning(f"Preset {value} not available for {beam_type}.")
                 return
-            beam.Preset.Activate(value)
-            logging.info(f"Preset {value} activated for {beam_type}.")
+            
+            # Save current settings if they should be preserved
+            image_rotation = None
+            view_field = None
+            image_shift_x = None
+            image_shift_y = None
+            
+            if preserve_settings:
+                image_rotation = beam.Optics.GetImageRotation()
+                logging.debug(f"Image rotation before changing preset: {image_rotation}.")
+                view_field = beam.Optics.GetViewfield()
+                logging.debug(f"FOV before changing preset: {view_field}.")
+                image_shift_x, image_shift_y = beam.Optics.GetImageShift()
+                logging.debug(f"XY shift before changing preset: {image_shift_x}, {image_shift_y}.")
+
+            try:
+                # Activate preset
+                beam.Preset.Activate(value)
+                logging.info(f"Preset {value} activated for {beam_type}.")
+                
+                # Wait for preset to fully apply
+                self._wait_for_beam_ready(beam, beam_type, operation="preset activation")
+                
+                # Update internal state
+                self._beam_parameters[beam_type].preset = value
+                
+            except Exception as e:
+                logging.error(f"Failed to activate preset {value} for {beam_type}: {e}")
+                raise  # Re-raise to ensure finally block runs and then propagate error
+                
+            finally:
+                # Restore settings if requested (runs whether success or failure)
+                if preserve_settings:
+                    try:
+                        beam.Optics.SetImageRotation(image_rotation)
+                        logging.debug(f"Restored image rotation after changing preset to {image_rotation}.")
+                        beam.Optics.SetViewfield(view_field)
+                        logging.debug(f"Restored FOV after changing preset to {view_field}.")
+                        beam.Optics.SetImageShift(image_shift_x, image_shift_y)
+                        logging.debug(f"Restored XY shift after changing preset to {image_shift_x}, {image_shift_y}.")
+                    except Exception as restore_error:
+                        logging.error(f"Failed to restore beam settings: {restore_error}")
+
             return
 
         if key in ["resolution", "dwell_time", "stigmation"]:

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -1112,7 +1112,7 @@ class TescanMicroscope(FibsemMicroscope):
         # """
         try:
             default_preset = "30 keV; 10 pA"
-            self.set("preset", default_preset, BeamType.ION)
+            self.set_preset(default_preset, BeamType.ION)
             self.connection.DrawBeam.UnloadLayer()
             logging.debug(f"Finished milling, restored preset to {default_preset}")
         except Exception as e:
@@ -1532,6 +1532,55 @@ class TescanMicroscope(FibsemMicroscope):
         logging.warning(f"Unknown key: {key} ({beam_type})")
         return None   
 
+    def _activate_preset(self, beam: Union['Automation.SEM', 'Automation.FIB'], beam_type: BeamType, preset_name: str, preserve_settings: bool) -> None:
+        """Activate a preset and optionally preserve beam settings."""
+        # Check if preset is available
+        if not beam.Preset.IsAvailable(preset_name):
+            logging.warning(f"Preset {preset_name} not available for {beam_type}.")
+            return
+        
+        # Save current settings if they should be preserved
+        image_rotation = None
+        view_field = None
+        image_shift_x = None
+        image_shift_y = None
+        
+        if preserve_settings:
+            image_rotation = beam.Optics.GetImageRotation()
+            logging.debug(f"Image rotation before changing preset: {image_rotation}.")
+            view_field = beam.Optics.GetViewfield()
+            logging.debug(f"FOV before changing preset: {view_field}.")
+            image_shift_x, image_shift_y = beam.Optics.GetImageShift()
+            logging.debug(f"XY shift before changing preset: {image_shift_x}, {image_shift_y}.")
+
+        try:
+            # Activate preset
+            beam.Preset.Activate(preset_name)
+            logging.info(f"Preset {preset_name} activated for {beam_type}.")
+            
+            # Wait for preset to fully apply
+            self._wait_for_beam_ready(beam, beam_type, operation="preset activation")
+            
+            # Update internal state
+            self._beam_parameters[beam_type].preset = preset_name
+            
+        except Exception as e:
+            logging.error(f"Failed to activate preset {preset_name} for {beam_type}: {e}")
+            raise  # Re-raise to ensure finally block runs and then propagate error
+            
+        finally:
+            # Restore settings if requested
+            if preserve_settings:
+                try:
+                    beam.Optics.SetImageRotation(image_rotation)
+                    logging.debug(f"Restored image rotation after changing preset to {image_rotation}.")
+                    beam.Optics.SetViewfield(view_field)
+                    logging.debug(f"Restored FOV after changing preset to {view_field}.")
+                    beam.Optics.SetImageShift(image_shift_x, image_shift_y)
+                    logging.debug(f"Restored XY shift after changing preset to {image_shift_x}, {image_shift_y}.")
+                except Exception as restore_error:
+                    logging.error(f"Failed to restore beam settings: {restore_error}")
+
     def _set(self, key: str, value, beam_type: BeamType = None, **kwargs) -> None:
         """
         Set a property of the microscope.
@@ -1651,56 +1700,9 @@ class TescanMicroscope(FibsemMicroscope):
             return
 
         if key == "preset":
-            # Get preserve_settings from kwargs, default to True
+            # Get preserve_settings from kwargs, defaults to True
             preserve_settings = kwargs.get("preserve_settings", True)
-            
-            # Check if preset is available
-            if not beam.Preset.IsAvailable(value):
-                logging.warning(f"Preset {value} not available for {beam_type}.")
-                return
-            
-            # Save current settings if they should be preserved
-            image_rotation = None
-            view_field = None
-            image_shift_x = None
-            image_shift_y = None
-            
-            if preserve_settings:
-                image_rotation = beam.Optics.GetImageRotation()
-                logging.debug(f"Image rotation before changing preset: {image_rotation}.")
-                view_field = beam.Optics.GetViewfield()
-                logging.debug(f"FOV before changing preset: {view_field}.")
-                image_shift_x, image_shift_y = beam.Optics.GetImageShift()
-                logging.debug(f"XY shift before changing preset: {image_shift_x}, {image_shift_y}.")
-
-            try:
-                # Activate preset
-                beam.Preset.Activate(value)
-                logging.info(f"Preset {value} activated for {beam_type}.")
-                
-                # Wait for preset to fully apply
-                self._wait_for_beam_ready(beam, beam_type, operation="preset activation")
-                
-                # Update internal state
-                self._beam_parameters[beam_type].preset = value
-                
-            except Exception as e:
-                logging.error(f"Failed to activate preset {value} for {beam_type}: {e}")
-                raise  # Re-raise to ensure finally block runs and then propagate error
-                
-            finally:
-                # Restore settings if requested (runs whether success or failure)
-                if preserve_settings:
-                    try:
-                        beam.Optics.SetImageRotation(image_rotation)
-                        logging.debug(f"Restored image rotation after changing preset to {image_rotation}.")
-                        beam.Optics.SetViewfield(view_field)
-                        logging.debug(f"Restored FOV after changing preset to {view_field}.")
-                        beam.Optics.SetImageShift(image_shift_x, image_shift_y)
-                        logging.debug(f"Restored XY shift after changing preset to {image_shift_x}, {image_shift_y}.")
-                    except Exception as restore_error:
-                        logging.error(f"Failed to restore beam settings: {restore_error}")
-
+            self._activate_preset(beam, beam_type, value, preserve_settings)
             return
 
         if key in ["resolution", "dwell_time", "stigmation"]:

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -14,7 +14,8 @@ import fibsem.constants as constants
 from fibsem.microscope import FibsemMicroscope
 
 TESCAN_API_AVAILABLE = False
-TESCAN_BEAM_READY_TIMEOUT = 60        # Max time in seconds to wait for the beam to become ready (busy-wait when using Tescanautomation API)
+TESCAN_BEAM_READY_TIMEOUT = 60                     # Max time in seconds to wait for the beam to become ready (busy-wait when using Tescanautomation API)
+TESCAN_PRESERVE_SETTINGS_ON_PRESET_CHANGE = True   # Restore rotation/FOV/shift across preset changes, if false, use the values stored in the preset
 
 try:
     import tescanautomation
@@ -264,6 +265,7 @@ class TescanMicroscope(FibsemMicroscope):
         self.system: SystemSettings = system_settings
         self.milling_channel: BeamType = BeamType.ION
         self.stage_is_compustage: bool = False
+        self._preserve_settings_on_preset_change: bool = TESCAN_PRESERVE_SETTINGS_ON_PRESET_CHANGE
         self._last_imaging_settings: ImageSettings = ImageSettings()
 
         # user, experiment metadata
@@ -1532,12 +1534,14 @@ class TescanMicroscope(FibsemMicroscope):
         logging.warning(f"Unknown key: {key} ({beam_type})")
         return None   
 
-    def _activate_preset(self, beam: Union['Automation.SEM', 'Automation.FIB'], beam_type: BeamType, preset_name: str, preserve_settings: bool) -> None:
-        """Activate a preset and optionally preserve beam settings."""
+    def _activate_preset(self, beam: Union['Automation.SEM', 'Automation.FIB'], beam_type: BeamType, preset_name: str) -> None:
+        """Activate a preset, preserving rotation/FOV/shift when self._preserve_settings_on_preset_change is set."""
         # Check if preset is available
         if not beam.Preset.IsAvailable(preset_name):
             logging.warning(f"Preset {preset_name} not available for {beam_type}.")
             return
+        
+        preserve_settings = self._preserve_settings_on_preset_change
         
         # Save current settings if they should be preserved
         image_rotation = None
@@ -1581,31 +1585,8 @@ class TescanMicroscope(FibsemMicroscope):
                 except Exception as restore_error:
                     logging.error(f"Failed to restore beam settings: {restore_error}")
 
-    def _set(self, key: str, value, beam_type: BeamType = None, **kwargs) -> None:
-        """
-        Set a property of the microscope.
-        
-        Special handling for preset changes:
-            When key="preset", you can use the preserve_settings keyword argument:
-            
-        Args:
-            key: The property key to set.
-            value: The value to set.
-            beam_type: The beam type (ELECTRON or ION).
-            **kwargs: Additional keyword arguments.
-                preserve_settings (bool): For preset changes, whether to preserve
-                    rotation, FOV, and shift. Defaults to True.
-            
-        Examples:
-            # Preserve settings (default behavior)
-            microscope.set("preset", "30 keV; 10 pA", BeamType.ION)
-            
-            # Don't preserve settings - let preset fully control all parameters
-            microscope.set("preset", "30 keV; 10 pA", BeamType.ION, preserve_settings=False)
-            
-            # Explicitly preserve settings
-            microscope.set("preset", "30 keV; 10 pA", BeamType.ION, preserve_settings=True)
-        """
+    def _set(self, key: str, value, beam_type: BeamType = None) -> None:
+        """Set a property of the microscope."""
         if beam_type is not None:
             beam: Union[Automation.SEM, Automation.FIB] = self._get_beam(beam_type)
             self._prepare_beam(beam_type)
@@ -1700,9 +1681,7 @@ class TescanMicroscope(FibsemMicroscope):
             return
 
         if key == "preset":
-            # Get preserve_settings from kwargs, defaults to True
-            preserve_settings = kwargs.get("preserve_settings", True)
-            self._activate_preset(beam, beam_type, value, preserve_settings)
+            self._activate_preset(beam, beam_type, value)
             return
 
         if key in ["resolution", "dwell_time", "stigmation"]:


### PR DESCRIPTION
Improves preset handling in the Tescan microscope driver by preserving imaging parameters during preset changes, refactoring beam readiness checks, and reducing the default FIB imaging current to 10 pA.

**Changes:**

1. **Improved preset activation**

* Added `_activate_preset()` to preserve rotation, field of view, and image shift
* Preservation is controlled by `TESCAN_PRESERVE_SETTINGS_ON_PRESET_CHANGE` and defaults to enabled

2. **Refactored beam readiness checks**

* Added `_wait_for_beam_ready()` to remove duplicated waiting logic
* Reused it in beam preparation and preset activation

3. **Safer default FIB preset**

* Changed the post-milling preset from `30 keV; 150 pA` to `30 keV; 10 pA`
* Uses `set_preset()` for consistency with parameter preservation
