### PR TITLE
[fix][FIB-230] fix Python 3.8 annotation compatibility

### DIFF
--- a/fibsem/correlation/test_correlation_v2.py
+++ b/fibsem/correlation/test_correlation_v2.py
@@ -6,6 +6,8 @@ Usage
 -----
     python fibsem/correlation/test_correlation_v2.py
 """
+from __future__ import annotations
+
 import os
 import pandas as pd
 

--- a/fibsem/correlation/tests/eval_lut_precision.py
+++ b/fibsem/correlation/tests/eval_lut_precision.py
@@ -1,4 +1,5 @@
 """Compare full-precision vs 2dp LUT: file size, load time, interpolation accuracy."""
+from __future__ import annotations
 
 import time
 import os

--- a/fibsem/correlation/ui/widgets/test_correlation_point_picker_widget.py
+++ b/fibsem/correlation/ui/widgets/test_correlation_point_picker_widget.py
@@ -7,6 +7,8 @@ Usage
 -----
     python fibsem/correlation/ui/widgets/test_correlation_point_picker_widget.py
 """
+from __future__ import annotations
+
 import os
 import sys
 

--- a/fibsem/correlation/ui/widgets/test_fm_image_display_widget.py
+++ b/fibsem/correlation/ui/widgets/test_fm_image_display_widget.py
@@ -6,6 +6,8 @@ Usage
 -----
     python fibsem/correlation/ui/widgets/test_fm_image_display_widget.py
 """
+from __future__ import annotations
+
 import os
 import sys
 

--- a/fibsem/correlation/ui/widgets/test_image_point_canvas.py
+++ b/fibsem/correlation/ui/widgets/test_image_point_canvas.py
@@ -8,6 +8,8 @@ Usage
 -----
     python fibsem/correlation/ui/widgets/test_image_point_canvas.py
 """
+from __future__ import annotations
+
 import sys
 
 import numpy as np

--- a/fibsem/correlation/util.py
+++ b/fibsem/correlation/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import List, Tuple
 

--- a/fibsem/fm/calibration.py
+++ b/fibsem/fm/calibration.py
@@ -4,6 +4,7 @@ This module provides focus measure algorithms used in focus stacking and autofoc
 applications. Different algorithms are suitable for different types of samples
 and imaging conditions.
 """
+from __future__ import annotations
 
 import logging
 import threading

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import threading
 import time

--- a/fibsem/ui/fm/widgets/overview_parameters_widget.py
+++ b/fibsem/ui/fm/widgets/overview_parameters_widget.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Optional

--- a/fibsem/ui/widgets/hud_ticker.py
+++ b/fibsem/ui/widgets/hud_ticker.py
@@ -10,6 +10,7 @@ Usage::
 
 The ticker resizes itself to always match the parent's width.
 """
+from __future__ import annotations
 
 import math
 from typing import Optional

--- a/fibsem/ui/widgets/image_settings_widget.py
+++ b/fibsem/ui/widgets/image_settings_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
     QCheckBox,

--- a/fibsem/ui/widgets/tests/test-spinner-icon.py
+++ b/fibsem/ui/widgets/tests/test-spinner-icon.py
@@ -1,4 +1,6 @@
 """Test script for SVG spinner icons using superqt's QIconifyIcon + QTimer rotation."""
+from __future__ import annotations
+
 import sys
 from PyQt5.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QHBoxLayout,

--- a/fibsem/ui/widgets/tests/test_alignment_comparison.py
+++ b/fibsem/ui/widgets/tests/test_alignment_comparison.py
@@ -16,6 +16,7 @@ Outputs:
     - /tmp/alignment_comparison.png  — debug plot (v2 layout)
     - /tmp/alignment_comparison_agreement.png — agreement scatter plot
 """
+from __future__ import annotations
 
 import argparse
 import os


### PR DESCRIPTION
## Summary

- Adds `from __future__ import annotations` to 13 files that used built-in generic type hints (`tuple[...]`, `list[...]`, `dict[...]`) without it
- Built-in generics as subscriptable types require Python 3.9+; the future import enables lazy annotation evaluation on Python 3.8
- Fixes `TypeError: 'type' object is not subscriptable` that was breaking CI for py38

## Files changed

| File | Issue |
|------|-------|
| `fibsem/correlation/util.py` | `-> tuple[int, int, int, 'plt.Figure']` |
| `fibsem/correlation/test_correlation_v2.py` | `-> list[Coordinate]` |
| `fibsem/correlation/tests/eval_lut_precision.py` | `-> tuple[pd.DataFrame, float]` |
| `fibsem/correlation/ui/widgets/test_correlation_point_picker_widget.py` | `-> list[Coordinate]` |
| `fibsem/correlation/ui/widgets/test_fm_image_display_widget.py` | `: list[Coordinate]` |
| `fibsem/correlation/ui/widgets/test_image_point_canvas.py` | `list[...]`, `dict[...]` annotations |
| `fibsem/fm/calibration.py` | `: list[Axes]` |
| `fibsem/fm/microscope.py` | `: list[str]` |
| `fibsem/ui/fm/widgets/overview_parameters_widget.py` | `-> tuple[int, int]` |
| `fibsem/ui/widgets/hud_ticker.py` | `: list[tuple[str, str]]` |
| `fibsem/ui/widgets/image_settings_widget.py` | `: list[QWidget]` |
| `fibsem/ui/widgets/tests/test-spinner-icon.py` | `: list[SpinnerLabel]` |
| `fibsem/ui/widgets/tests/test_alignment_comparison.py` | `list[...]` annotations |

## Reviewer notes

No behaviour change — `from __future__ import annotations` only affects how annotations are evaluated at runtime (as strings rather than eagerly), which is transparent to all existing code.

Closes [FIB-230](https://linear.app/fibsemos/issue/FIB-230/ci-fails-for-py38-because-of-annotation-issues-investigate-other)