### PR TITLE
[fix] check control type when creating controls

### DIFF
--- a/fibsem/ui/widgets/milling_stage_editor_widget.py
+++ b/fibsem/ui/widgets/milling_stage_editor_widget.py
@@ -314,6 +314,7 @@ class FibsemMillingStageWidget(QWidget):
             if conf.get("hidden", False) is True:
                 continue
             # QUERY: use a data structure for field metadata instead of dict?
+            type_ = conf.get("type")
             label_text = conf.get("label") or name.replace("_", " ").title()
             scale = conf.get("scale")
             units = conf.get("unit")
@@ -349,14 +350,14 @@ class FibsemMillingStageWidget(QWidget):
                 control = _create_combobox_control(value, items, units, format_fn)
 
             # add line edit controls
-            elif isinstance(value, str):
+            elif type_ is str or isinstance(value, str):
                 if is_filepath:
                     control = QFilePathLineEdit()
                 else:
                     control = QLineEdit()
                 control.setText(value)
             # add checkbox controls
-            elif isinstance(value, bool):
+            elif type_ is bool or isinstance(value, bool):
                 control = QCheckBox()
                 control.setChecked(value)
             elif isinstance(value, (float, int)):


### PR DESCRIPTION
Should mean empty fields are created correctly.

Currently the AP field for model path is not being created in the GUI because the default is "", which is then read as None so is not created. I've also included a similar check for boolean fields to match how it's done in pattern_settings_widget.py.