### PR TITLE
TaskConfigEditor: highlight sync button when protocol is edited

### DIFF
--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -255,22 +255,25 @@ class FeatureFlags:
     sample_holder_widget: bool = False
 
 @dataclass
-class PathPreferences:
-    default_experiment_directory: str = ""
-    last_experiment_path: str = ""
-    default_protocol_path: str = ""
-
-@dataclass
 class MovementPreferences:
     acquire_sem_after_stage_movement: bool = True
     acquire_fib_after_stage_movement: bool = True
 
 @dataclass
+class ExperimentPreferences:
+    default_experiment_directory: str = ""
+    default_protocol_path: str = ""
+    last_experiment_path: str = ""
+    user: str = ""
+    project: str = ""
+    organisation: str = ""
+
+@dataclass
 class UserPreferences:
     display: DisplayPreferences = field(default_factory=DisplayPreferences)
     features: FeatureFlags = field(default_factory=FeatureFlags)
-    paths: PathPreferences = field(default_factory=PathPreferences)
     movement: MovementPreferences = field(default_factory=MovementPreferences)
+    experiment: ExperimentPreferences = field(default_factory=ExperimentPreferences)
 
     def to_dict(self) -> dict:
         return dataclasses.asdict(self)
@@ -278,24 +281,23 @@ class UserPreferences:
     @classmethod
     def from_dict(cls, d: dict) -> "UserPreferences":
         """Reconstruct from a dict, handling both nested and legacy flat formats."""
-        # If the dict has nested sub-dicts, reconstruct directly
-        if any(k in d for k in ("display", "features", "paths", "movement")):
+        if any(k in d for k in ("display", "features", "movement", "experiment")):
             return cls(
                 display=_sub_from_dict(DisplayPreferences, d.get("display", {})),
                 features=_sub_from_dict(FeatureFlags, d.get("features", {})),
-                paths=_sub_from_dict(PathPreferences, d.get("paths", {})),
                 movement=_sub_from_dict(MovementPreferences, d.get("movement", {})),
+                experiment=_sub_from_dict(ExperimentPreferences, d.get("experiment", {})),
             )
-        # Legacy flat format (4-key YAML from previous version)
+        # Legacy flat format
         prefs = cls()
         if "acquire_sem_after_stage_movement" in d:
             prefs.movement.acquire_sem_after_stage_movement = d["acquire_sem_after_stage_movement"]
         if "acquire_fib_after_stage_movement" in d:
             prefs.movement.acquire_fib_after_stage_movement = d["acquire_fib_after_stage_movement"]
         if "experiment_directory" in d:
-            prefs.paths.default_experiment_directory = d["experiment_directory"]
+            prefs.experiment.default_experiment_directory = d["experiment_directory"]
         if "last_experiment_path" in d:
-            prefs.paths.last_experiment_path = d["last_experiment_path"]
+            prefs.experiment.last_experiment_path = d["last_experiment_path"]
         return prefs
 
 

--- a/fibsem/ui/widgets/autolamella_create_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_create_experiment_widget.py
@@ -88,13 +88,21 @@ class AutoLamellaCreateExperimentWidget(QtWidgets.QDialog):
         # Experiment Directory
         self.lineEdit_experiment_directory = QDirectoryLineEdit()
         prefs = load_user_preferences()
-        pref_dir = prefs.paths.default_experiment_directory
+        pref_dir = prefs.experiment.default_experiment_directory
         if pref_dir and os.path.isdir(pref_dir):
             self.lineEdit_experiment_directory.setText(pref_dir)
         else:
             if pref_dir:
                 logging.warning(f"Preference default_experiment_directory '{pref_dir}' does not exist; using default.")
             self.lineEdit_experiment_directory.setText(str(cfg.LOG_PATH))
+
+        exp_prefs = prefs.experiment
+        if exp_prefs.user:
+            self.lineEdit_experiment_user.setText(exp_prefs.user)
+        if exp_prefs.project:
+            self.lineEdit_experiment_project.setText(exp_prefs.project)
+        if exp_prefs.organisation:
+            self.lineEdit_experiment_organisation.setText(exp_prefs.organisation)
 
         exp_form_layout.addRow("Name", self.lineEdit_experiment_name)
         exp_form_layout.addRow("Description", self.lineEdit_experiment_description)
@@ -220,7 +228,7 @@ class AutoLamellaCreateExperimentWidget(QtWidgets.QDialog):
     def _load_default_protocol(self):
         """Load the default task protocol, preferring the path set in user preferences."""
         prefs = load_user_preferences()
-        pref_protocol = prefs.paths.default_protocol_path
+        pref_protocol = prefs.experiment.default_protocol_path
         if pref_protocol and os.path.isfile(pref_protocol):
             protocol_path_to_load = pref_protocol
         else:
@@ -403,7 +411,7 @@ class AutoLamellaCreateExperimentWidget(QtWidgets.QDialog):
 
             # Save last used experiment path
             prefs = load_user_preferences()
-            prefs.paths.last_experiment_path = str(self.experiment.path)
+            prefs.experiment.last_experiment_path = str(self.experiment.path)
             save_user_preferences(prefs)
 
             # Accept the dialog

--- a/fibsem/ui/widgets/autolamella_create_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_create_experiment_widget.py
@@ -87,7 +87,14 @@ class AutoLamellaCreateExperimentWidget(QtWidgets.QDialog):
 
         # Experiment Directory
         self.lineEdit_experiment_directory = QDirectoryLineEdit()
-        self.lineEdit_experiment_directory.setText(str(cfg.LOG_PATH))
+        prefs = load_user_preferences()
+        pref_dir = prefs.paths.default_experiment_directory
+        if pref_dir and os.path.isdir(pref_dir):
+            self.lineEdit_experiment_directory.setText(pref_dir)
+        else:
+            if pref_dir:
+                logging.warning(f"Preference default_experiment_directory '{pref_dir}' does not exist; using default.")
+            self.lineEdit_experiment_directory.setText(str(cfg.LOG_PATH))
 
         exp_form_layout.addRow("Name", self.lineEdit_experiment_name)
         exp_form_layout.addRow("Description", self.lineEdit_experiment_description)
@@ -211,20 +218,30 @@ class AutoLamellaCreateExperimentWidget(QtWidgets.QDialog):
             self.label_validation_warning.setText("")
 
     def _load_default_protocol(self):
-        """Load the default task protocol."""
-        if os.path.exists(cfg.TASK_PROTOCOL_PATH):
-            try:
-                self.protocol = AutoLamellaTaskProtocol.load(str(cfg.TASK_PROTOCOL_PATH))
-                self.protocol_path = str(cfg.TASK_PROTOCOL_PATH)
-                self._update_protocol_display()
-                logging.info(f"Default protocol loaded from {cfg.TASK_PROTOCOL_PATH}")
-            except Exception as e:
-                logging.error(f"Failed to load default protocol: {e}")
-                QtWidgets.QMessageBox.warning(
-                    self,
-                    "Protocol Load Error",
-                    "The default protocol file could not be loaded. It may be corrupted or incorrectly formatted.\n\nPlease select a valid protocol file manually."
-                )
+        """Load the default task protocol, preferring the path set in user preferences."""
+        prefs = load_user_preferences()
+        pref_protocol = prefs.paths.default_protocol_path
+        if pref_protocol and os.path.isfile(pref_protocol):
+            protocol_path_to_load = pref_protocol
+        else:
+            if pref_protocol:
+                logging.warning(f"Preference default_protocol_path '{pref_protocol}' does not exist; using default.")
+            if not os.path.exists(cfg.TASK_PROTOCOL_PATH):
+                return
+            protocol_path_to_load = str(cfg.TASK_PROTOCOL_PATH)
+
+        try:
+            self.protocol = AutoLamellaTaskProtocol.load(protocol_path_to_load)
+            self.protocol_path = protocol_path_to_load
+            self._update_protocol_display()
+            logging.info(f"Default protocol loaded from {protocol_path_to_load}")
+        except Exception as e:
+            logging.error(f"Failed to load default protocol: {e}")
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Protocol Load Error",
+                "The default protocol file could not be loaded. It may be corrupted or incorrectly formatted.\n\nPlease select a valid protocol file manually."
+            )
 
     def _select_protocol(self):
         """Open dialog to select a protocol file."""

--- a/fibsem/ui/widgets/autolamella_load_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_load_experiment_widget.py
@@ -232,7 +232,7 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         # Default to last used experiment directory if available
         default_path = str(cfg.LOG_PATH)
         prefs = load_user_preferences()
-        last_path = prefs.paths.last_experiment_path
+        last_path = prefs.experiment.last_experiment_path
         if last_path and os.path.exists(last_path):
             default_path = last_path
 
@@ -385,7 +385,7 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
 
         # Save last used experiment path
         prefs = load_user_preferences()
-        prefs.paths.last_experiment_path = str(self.experiment.path)
+        prefs.experiment.last_experiment_path = str(self.experiment.path)
         save_user_preferences(prefs)
 
         # Accept the dialog

--- a/fibsem/ui/widgets/autolamella_task_config_editor.py
+++ b/fibsem/ui/widgets/autolamella_task_config_editor.py
@@ -228,6 +228,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         self.pushButton_sync_to_lamella = QPushButton("Apply Config to Existing Lamella")
         self.pushButton_sync_to_lamella.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         self.pushButton_sync_to_lamella.setToolTip("Update all existing lamella with the current task configuration")
+        self._protocol_dirty = False
 
         self.pushButton_open_global_editor = QPushButton("Global Edit")
         self.pushButton_open_global_editor.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
@@ -293,6 +294,19 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
         self._main_layout.addWidget(splitter)
 
+    def _set_protocol_dirty(self, dirty: bool):
+        self._protocol_dirty = dirty
+        if dirty and self.pushButton_sync_to_lamella.isEnabled():
+            self.pushButton_sync_to_lamella.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+            self.pushButton_sync_to_lamella.setToolTip(
+                "Protocol edited — click to apply current task configuration to existing lamella."
+            )
+        else:
+            self.pushButton_sync_to_lamella.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+            self.pushButton_sync_to_lamella.setToolTip(
+                "Update all existing lamella with the current task configuration"
+            )
+
     def _setup_connections(self):
         """Setup signal connections - called once during initialization."""
         self.task_list_widget.task_selected.connect(lambda _: self._on_selected_task_changed())
@@ -345,6 +359,8 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         if is_fluorescence_task:
             self.fluorescence_acquisition_task_config_widget.set_task_config(task_config)
 
+        self._set_protocol_dirty(False)
+
         # special handling for spot burn fiducial task
         # is_spot_burn_task = isinstance(task_config, SpotBurnFiducialTaskConfig)
         # self.spot_burn_coordinates_widget.setVisible(is_spot_burn_task)
@@ -353,7 +369,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
     def _on_milling_settings_changed(self, config: 'FibsemMillingTaskConfig'):
         """Callback when the milling task config is changed."""
-
+        self._set_protocol_dirty(True)
         selected_task_name = self.task_list_widget.selected_task
         key = self._current_milling_key
         if key and selected_task_name in self.experiment.task_protocol.task_config:
@@ -365,6 +381,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
     def _on_task_parameters_config_changed(self, field_name: str, new_value: Any):
         """Callback when the task parameters config is updated."""
+        self._set_protocol_dirty(True)
         selected_task_name = self.task_list_widget.selected_task
         logging.info(f"Updated {selected_task_name} Task Parameters: {field_name} = {new_value}")
 
@@ -376,6 +393,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
     def _on_ref_image_settings_changed(self, settings: 'ReferenceImageParameters'):
         """Callback when the image settings are changed."""
+        self._set_protocol_dirty(True)
         # Update the image settings in the task config
         selected_task_name = self.task_list_widget.selected_task
         self.experiment.task_protocol.task_config[selected_task_name].reference_imaging = settings
@@ -385,7 +403,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
     def _on_fluorescence_acquisition_settings_changed(self, config: 'AcquireFluorescenceImageConfig'):
         """Callback when the fluorescence acquisition settings are changed."""
-
+        self._set_protocol_dirty(True)
         # Update the task config
         selected_task_name = self.task_list_widget.selected_task
         self.experiment.task_protocol.task_config[selected_task_name] = config
@@ -581,6 +599,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
             # Save the experiment
             self._save_experiment()
+            self._set_protocol_dirty(False)
 
             # Show success message
             QMessageBox.information(

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -109,7 +109,48 @@ class QDirectoryLineEdit(QWidget):
     def setText(self, text: str) -> None:
         self.lineEdit.setText(text)
 
-def _create_combobox_control(value: Union[str, int, float, Enum], 
+class QFileLineEdit(QWidget):
+    """Line edit with a browse button that opens a file picker dialog."""
+
+    textChanged = pyqtSignal(str)
+    editingFinished = pyqtSignal()
+
+    def __init__(self, filter: str = "YAML files (*.yaml *.yml)", parent=None):
+        super().__init__(parent)
+        self._filter = filter
+
+        layout = QHBoxLayout(self)
+        self.lineEdit = QLineEdit(self)
+        self.button_browse = QToolButton(self)
+        self.button_browse.setText("...")
+        self.button_browse.setMaximumWidth(80)
+        layout.addWidget(self.lineEdit)
+        layout.addWidget(self.button_browse)
+
+        self.setContentsMargins(0, 0, 0, 0)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+
+        self.button_browse.clicked.connect(self.browse_file)
+        self.lineEdit.textChanged.connect(self.textChanged.emit)
+        self.lineEdit.editingFinished.connect(self.editingFinished.emit)
+
+    def browse_file(self):
+        start = self.lineEdit.text() or ""
+        path, _ = QFileDialog.getOpenFileName(self, "Select File", start, self._filter)
+        if path:
+            self.lineEdit.setText(path)
+            self.textChanged.emit(path)
+            self.editingFinished.emit()
+
+    def text(self) -> str:
+        return self.lineEdit.text()
+
+    def setText(self, text: str) -> None:
+        self.lineEdit.setText(text)
+
+
+def _create_combobox_control(value: Union[str, int, float, Enum],
                              items: list, 
                              units: Optional[str], 
                              format_fn: Optional[Callable] = None, 

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -2076,7 +2076,7 @@ def main():
     microscope, settings = utils.setup_session()
     import os
 
-    path = load_user_preferences().paths.last_experiment_path
+    path = load_user_preferences().experiment.last_experiment_path
     exp = Experiment.load(os.path.join(path, "experiment.yaml"))
 
     widget = FluorescenceCoincidenceViewerWidget(microscope=microscope, experiment=exp)

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem.config import UserPreferences
-from fibsem.ui.widgets.custom_widgets import QDirectoryLineEdit, TitledPanel
+from fibsem.ui.widgets.custom_widgets import QDirectoryLineEdit, QFileLineEdit, TitledPanel
 
 
 class PreferencesDialog(QDialog):
@@ -69,7 +69,7 @@ class PreferencesDialog(QDialog):
         paths_content = QWidget()
         paths_form = QFormLayout(paths_content)
         self._dir_experiment = QDirectoryLineEdit()
-        self._dir_protocol = QDirectoryLineEdit()
+        self._dir_protocol = QFileLineEdit()
         paths_form.addRow("Default experiment directory", self._dir_experiment)
         paths_form.addRow("Default protocol path", self._dir_protocol)
         content_layout.addWidget(

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -5,6 +5,7 @@ from PyQt5.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QFormLayout,
+    QLineEdit,
     QMessageBox,
     QScrollArea,
     QVBoxLayout,
@@ -65,15 +66,21 @@ class PreferencesDialog(QDialog):
             TitledPanel("Feature Flags", content=features_content, collapsible=False)
         )
 
-        # --- Paths ---
-        paths_content = QWidget()
-        paths_form = QFormLayout(paths_content)
+        # --- Experiment Defaults ---
+        experiment_content = QWidget()
+        experiment_form = QFormLayout(experiment_content)
         self._dir_experiment = QDirectoryLineEdit()
         self._dir_protocol = QFileLineEdit()
-        paths_form.addRow("Default experiment directory", self._dir_experiment)
-        paths_form.addRow("Default protocol path", self._dir_protocol)
+        self._edit_exp_user = QLineEdit()
+        self._edit_exp_project = QLineEdit()
+        self._edit_exp_organisation = QLineEdit()
+        experiment_form.addRow("Default experiment directory", self._dir_experiment)
+        experiment_form.addRow("Default protocol path", self._dir_protocol)
+        experiment_form.addRow("User", self._edit_exp_user)
+        experiment_form.addRow("Project", self._edit_exp_project)
+        experiment_form.addRow("Organisation", self._edit_exp_organisation)
         content_layout.addWidget(
-            TitledPanel("Paths", content=paths_content, collapsible=False)
+            TitledPanel("Experiment Defaults", content=experiment_content, collapsible=False)
         )
 
         # --- Movement ---
@@ -111,9 +118,12 @@ class PreferencesDialog(QDialog):
         self._chk_coincidence_milling.setChecked(f.coincidence_milling_enabled)
         self._chk_sample_holder.setChecked(f.sample_holder_widget)
 
-        p = prefs.paths
-        self._dir_experiment.setText(p.default_experiment_directory)
-        self._dir_protocol.setText(p.default_protocol_path)
+        e = prefs.experiment
+        self._dir_experiment.setText(e.default_experiment_directory)
+        self._dir_protocol.setText(e.default_protocol_path)
+        self._edit_exp_user.setText(e.user)
+        self._edit_exp_project.setText(e.project)
+        self._edit_exp_organisation.setText(e.organisation)
 
         m = prefs.movement
         self._chk_acquire_sem.setChecked(m.acquire_sem_after_stage_movement)
@@ -134,9 +144,9 @@ class PreferencesDialog(QDialog):
         """Build a UserPreferences instance from current widget state."""
         from fibsem.config import (
             DisplayPreferences,
+            ExperimentPreferences,
             FeatureFlags,
             MovementPreferences,
-            PathPreferences,
         )
 
         return UserPreferences(
@@ -152,13 +162,16 @@ class PreferencesDialog(QDialog):
                 coincidence_milling_enabled=self._chk_coincidence_milling.isChecked(),
                 sample_holder_widget=self._chk_sample_holder.isChecked(),
             ),
-            paths=PathPreferences(
-                default_experiment_directory=self._dir_experiment.text(),
-                last_experiment_path=self._preferences.paths.last_experiment_path,
-                default_protocol_path=self._dir_protocol.text(),
-            ),
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),
                 acquire_fib_after_stage_movement=self._chk_acquire_fib.isChecked(),
+            ),
+            experiment=ExperimentPreferences(
+                default_experiment_directory=self._dir_experiment.text(),
+                default_protocol_path=self._dir_protocol.text(),
+                last_experiment_path=self._preferences.experiment.last_experiment_path,
+                user=self._edit_exp_user.text(),
+                project=self._edit_exp_project.text(),
+                organisation=self._edit_exp_organisation.text(),
             ),
         )

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -5,15 +5,17 @@ from PyQt5.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QFormLayout,
+    QHBoxLayout,
     QLineEdit,
+    QListWidget,
     QMessageBox,
-    QScrollArea,
+    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )
 
 from fibsem.config import UserPreferences
-from fibsem.ui.widgets.custom_widgets import QDirectoryLineEdit, QFileLineEdit, TitledPanel
+from fibsem.ui.widgets.custom_widgets import QDirectoryLineEdit, QFileLineEdit
 
 
 class PreferencesDialog(QDialog):
@@ -31,14 +33,24 @@ class PreferencesDialog(QDialog):
     def _setup_ui(self):
         layout = QVBoxLayout(self)
 
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        content = QWidget()
-        content_layout = QVBoxLayout(content)
+        # Sidebar + stack
+        body = QWidget()
+        body_layout = QHBoxLayout(body)
+        body_layout.setContentsMargins(0, 0, 0, 0)
+
+        self._sidebar = QListWidget()
+        self._sidebar.setFixedWidth(120)
+        self._sidebar.addItems(["Display", "Features", "Experiment", "Movement"])
+        self._sidebar.setCurrentRow(0)
+
+        self._stack = QStackedWidget()
+        body_layout.addWidget(self._sidebar)
+        body_layout.addWidget(self._stack)
+        layout.addWidget(body)
 
         # --- Display ---
-        display_content = QWidget()
-        display_form = QFormLayout(display_content)
+        display_page = QWidget()
+        display_form = QFormLayout(display_page)
         self._chk_sound = QCheckBox()
         self._chk_toasts = QCheckBox()
         self._chk_border = QCheckBox()
@@ -49,26 +61,22 @@ class PreferencesDialog(QDialog):
         display_form.addRow("Workflow border", self._chk_border)
         display_form.addRow("Workflow timeline", self._chk_timeline)
         display_form.addRow("Development mode", self._chk_dev_mode)
-        content_layout.addWidget(
-            TitledPanel("Display", content=display_content, collapsible=False)
-        )
+        self._stack.addWidget(display_page)
 
         # --- Feature Flags ---
-        features_content = QWidget()
-        features_form = QFormLayout(features_content)
+        features_page = QWidget()
+        features_form = QFormLayout(features_page)
         self._chk_lamella_live = QCheckBox()
         self._chk_coincidence_milling = QCheckBox()
         self._chk_sample_holder = QCheckBox()
         features_form.addRow("Lamella position on live view", self._chk_lamella_live)
         features_form.addRow("Coincidence milling viewer", self._chk_coincidence_milling)
         features_form.addRow("Sample holder widget", self._chk_sample_holder)
-        content_layout.addWidget(
-            TitledPanel("Feature Flags", content=features_content, collapsible=False)
-        )
+        self._stack.addWidget(features_page)
 
         # --- Experiment Defaults ---
-        experiment_content = QWidget()
-        experiment_form = QFormLayout(experiment_content)
+        experiment_page = QWidget()
+        experiment_form = QFormLayout(experiment_page)
         self._dir_experiment = QDirectoryLineEdit()
         self._dir_protocol = QFileLineEdit()
         self._edit_exp_user = QLineEdit()
@@ -79,24 +87,18 @@ class PreferencesDialog(QDialog):
         experiment_form.addRow("User", self._edit_exp_user)
         experiment_form.addRow("Project", self._edit_exp_project)
         experiment_form.addRow("Organisation", self._edit_exp_organisation)
-        content_layout.addWidget(
-            TitledPanel("Experiment Defaults", content=experiment_content, collapsible=False)
-        )
+        self._stack.addWidget(experiment_page)
 
         # --- Movement ---
-        movement_content = QWidget()
-        movement_form = QFormLayout(movement_content)
+        movement_page = QWidget()
+        movement_form = QFormLayout(movement_page)
         self._chk_acquire_sem = QCheckBox()
         self._chk_acquire_fib = QCheckBox()
         movement_form.addRow("Acquire SEM after movement", self._chk_acquire_sem)
         movement_form.addRow("Acquire FIB after movement", self._chk_acquire_fib)
-        content_layout.addWidget(
-            TitledPanel("Movement", content=movement_content, collapsible=False)
-        )
+        self._stack.addWidget(movement_page)
 
-        content_layout.addStretch()
-        scroll.setWidget(content)
-        layout.addWidget(scroll)
+        self._sidebar.currentRowChanged.connect(self._stack.setCurrentIndex)
 
         # Buttons
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)


### PR DESCRIPTION
## Summary

- When any protocol value is edited in the task config editor (task parameters, milling, reference imaging, or fluorescence acquisition), `pushButton_sync_to_lamella` switches from gray to blue to prompt the user to apply changes to existing lamella
- Button returns to gray after a successful sync or when switching to a different task
- Cancelling the sync confirmation dialog leaves the button highlighted (no changes were propagated)
- Button is only highlighted when it is enabled (i.e. lamella exist to apply to)