### PR TITLE
[fix] update np.float_ (unsupported by NumPy 2) to np.float64

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -3254,7 +3254,7 @@ class ThermoMicroscope(FibsemMicroscope):
 
     def _resize_bitmap_to_pattern(
         self, pattern_settings: FibsemBitmapSettings
-    ) -> NDArray[np.float_ | np.uint8]:
+    ) -> NDArray[np.float64 | np.uint8]:
         points = pattern_settings.bitmap
 
         if points is None:
@@ -3293,11 +3293,11 @@ class ThermoMicroscope(FibsemMicroscope):
         resized_points = np.empty((*new_shape, 2), dtype=object)
 
         resized_points[:, :, 0] = transform.resize(
-            points[:, :, 0].reshape(points.shape[0], points.shape[1]).astype(np.float_),
+            points[:, :, 0].reshape(points.shape[0], points.shape[1]).astype(np.float64),
             output_shape=new_shape,
             order=order,
             preserve_range=True,
-        ).astype(np.float_)
+        ).astype(np.float64)
         resized_points[:, :, 1] = transform.resize(
             points[:, :, 1].reshape(points.shape[0], points.shape[1]).astype(np.uint8),
             output_shape=new_shape,

--- a/fibsem/milling/patterning/plotting.py
+++ b/fibsem/milling/patterning/plotting.py
@@ -356,7 +356,7 @@ def _add_bitmap_mpl(
     if shape.flip_y:
         bitmap = np.flip(bitmap, axis=0)
 
-    dwell_time_array = bitmap[:, :, 0].astype(np.float_)
+    dwell_time_array = bitmap[:, :, 0].astype(np.float64)
     blanking_array = bitmap[:, :, 1] == 1
 
     # Ensure no rectangles will be subpixel (these are not displayed)
@@ -892,7 +892,7 @@ def draw_bitmap_shape(
         image_resized = image_resized.rotate(pattern_settings.rotation, expand=True)
 
     # Create base rectangle shape
-    shape = np.asarray(image_resized, dtype=np.float_)
+    shape = np.asarray(image_resized, dtype=np.float64)
 
     # get pattern centre in image coordinates
     pos = Point(x=cx, y=cy)


### PR DESCRIPTION
@patrickcleeve2

We tried to test bitmap milling and hit errors due to `np.float_` no longer existing in NumPy 2.