### PR TITLE
[ui] add post-workflow summary dialog

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -97,10 +97,13 @@ from fibsem.applications.autolamella.workflows.tasks.hooks import (
     NotificationHook,
 )
 from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+from fibsem.ui.widgets.workflow_summary_dialog import WorkflowSummaryDialog
 from psygnal import EmissionInfo
 from superqt import ensure_main_thread
 
 if TYPE_CHECKING:
+    import pandas as pd
+
     from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
         AutoLamellaSingleWindowUI,
     )
@@ -216,6 +219,7 @@ class AutoLamellaUI(QMainWindow):
         self._workflow_stop_event: threading.Event = threading.Event()
         self._task_worker_thread: Optional[threading.Thread] = None
         self._task_manager: Optional[TaskManager] = None
+        self._last_run_summary: Optional["pd.DataFrame"] = None
 
         # setup connections
         self.setup_connections()
@@ -1064,6 +1068,13 @@ class AutoLamellaUI(QMainWindow):
 
         finally:
             cancelled = self._task_manager is not None and self._task_manager.is_stopped
+            # capture the per-run summary before the manager is torn down
+            if self._task_manager is not None:
+                try:
+                    self._last_run_summary = self._task_manager.build_run_summary_dataframe()
+                except Exception as e:
+                    logging.warning(f"Failed to build workflow run summary: {e}")
+                    self._last_run_summary = None
             self._task_manager = None
             self._task_worker_thread = None
             self._workflow_finished_signal.emit(cancelled)  # type: ignore
@@ -1854,6 +1865,21 @@ class AutoLamellaUI(QMainWindow):
         self.image_widget.restore_active_layer_for_movement()
 
         self.set_current_workflow_message(msg=None, show=False)
+
+        # show the post-workflow summary of tasks run this session
+        self._show_workflow_summary()
+
+    def _show_workflow_summary(self) -> None:
+        """Show a modal summary dialog of the tasks run in the last workflow."""
+        summary = self._last_run_summary
+        self._last_run_summary = None
+        if summary is None or summary.empty:
+            return
+        try:
+            dialog = WorkflowSummaryDialog(summary, parent=self)
+            dialog.exec_()
+        except Exception as e:
+            logging.warning(f"Failed to show workflow summary dialog: {e}")
 
     def handle_workflow_update(self, info: dict) -> None:
         """Update the UI with the given information, ready for user interaction"""

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -5,6 +5,8 @@ import threading
 import time
 from typing import TYPE_CHECKING, List, Optional
 
+import pandas as pd
+
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
 from fibsem.applications.autolamella.workflows.tasks.hooks import HookContext, HookEvent, HookManager
 from fibsem.applications.autolamella.workflows.tasks.queue import TaskQueue
@@ -139,6 +141,35 @@ class TaskManager:
         self._fire_workflow_hook(HookEvent.WORKFLOW_COMPLETED)
         update_status_ui(self.parent_ui, "", workflow_info="All tasks completed.")
         print(self.experiment.task_history_dataframe())
+
+    def build_run_summary_dataframe(self) -> pd.DataFrame:
+        """Build a per-run summary of attempted tasks from the queue snapshot.
+
+        One row per (lamella, task) attempted in this run, including skipped
+        tasks (which are absent from the experiment task history). The
+        completed_at and duration values are pulled from the lamella's task
+        history where available, and left blank for skipped tasks.
+        """
+        rows: List[dict] = []
+        for item in self.queue.items:
+            lamella = self.experiment.get_lamella_by_name(item.lamella_name)
+            completed_at = ""
+            duration = None
+            if lamella is not None:
+                # most recent matching history entry for this task
+                for task in reversed(lamella.task_history):
+                    if task.name == item.task_name:
+                        completed_at = task.completed_at
+                        duration = task.duration
+                        break
+            rows.append({
+                "lamella_name": item.lamella_name,
+                "task_name": item.task_name,
+                "task_status": item.status.name,
+                "completed_at": completed_at,
+                "duration": duration,
+            })
+        return pd.DataFrame(rows)
 
     def stop(self) -> None:
         """Signal the manager to stop after current task completes."""

--- a/fibsem/ui/widgets/task_history_table_widget.py
+++ b/fibsem/ui/widgets/task_history_table_widget.py
@@ -2,11 +2,15 @@
 Widget for displaying experiment task history in a sortable table.
 """
 from typing import Optional
-import pandas as pd
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton, QHBoxLayout, QCheckBox
 
 from fibsem.applications.autolamella.structures import Experiment, AutoLamellaTaskStatus
 from fibsem.ui.widgets.dataframe_table_widget import DataFrameTableWidget
+from fibsem.ui.widgets.task_summary_formatting import (
+    COLUMN_NAME_MAPPING,
+    format_duration_short,
+    make_status_cell_formatter,
+)
 
 
 class TaskHistoryTableWidget(QWidget):
@@ -110,56 +114,13 @@ class TaskHistoryTableWidget(QWidget):
 
         # Format duration column as MMm:SSs
         if 'duration' in df.columns:
-            def format_duration(seconds):
-                """Format duration in seconds as MMm:SSs."""
-                if pd.isna(seconds):
-                    return ""
-                try:
-                    total_seconds = int(float(seconds))
-                    minutes = total_seconds // 60
-                    secs = total_seconds % 60
-                    return f"{minutes:02d}m:{secs:02d}s"
-                except (ValueError, TypeError):
-                    return str(seconds)
-
-            df['duration'] = df['duration'].apply(format_duration)
+            df['duration'] = df['duration'].apply(format_duration_short)
 
         # Rename columns to nice titles
-        column_name_mapping = {
-            'lamella_name': 'Lamella',
-            'task_name': 'Task Name',
-            # 'task_type': 'Type',
-            'task_status': 'Status',
-            'task_status_message': 'Status Message',
-            'completed_at': 'Completed At',
-            'duration': 'Duration'
-        }
-        df = df.rename(columns=column_name_mapping)
+        df = df.rename(columns=COLUMN_NAME_MAPPING)
 
-        # Define cell formatter for conditional formatting
-        def format_cell(row_idx: int, col_idx: int, value) -> dict:
-            """Format cells based on their values."""
-            format_dict = {}
-
-            # Get the status column index
-            if 'Status' in df.columns:
-                status_col_idx = df.columns.get_loc('Status')
-                status_value = str(df.iloc[row_idx, status_col_idx])
-
-                # Make Failed rows red
-                if status_value == 'Failed':
-                    format_dict['color'] = 'red'
-                # Make Completed rows green
-                elif status_value == 'Completed':
-                    format_dict['color'] = 'white'
-                # Make InProgress rows blue
-                elif status_value == 'InProgress':
-                    format_dict['color'] = 'cyan'
-
-            return format_dict
-
-        # Update the table with formatter
-        self.table_widget.set_dataframe(df, cell_formatter=format_cell)
+        # Update the table with status-based cell colouring
+        self.table_widget.set_dataframe(df, cell_formatter=make_status_cell_formatter(df))
 
     def clear(self):
         """Clear the table."""

--- a/fibsem/ui/widgets/task_summary_formatting.py
+++ b/fibsem/ui/widgets/task_summary_formatting.py
@@ -1,0 +1,106 @@
+"""
+Shared formatting helpers for task summary / task history tables.
+
+Used by both TaskHistoryTableWidget (full experiment history) and
+WorkflowSummaryDialog (per-run summary) so the two stay visually consistent.
+"""
+from typing import Callable, List, Optional
+
+import pandas as pd
+
+# Default per-run summary columns (in display order)
+SUMMARY_COLUMNS: List[str] = [
+    "lamella_name",
+    "task_name",
+    "task_status",
+    "completed_at",
+    "duration",
+]
+
+# Map raw dataframe columns to nice display titles
+COLUMN_NAME_MAPPING = {
+    "lamella_name": "Lamella",
+    "task_name": "Task Name",
+    "task_status": "Status",
+    "task_status_message": "Status Message",
+    "completed_at": "Completed At",
+    "duration": "Duration",
+}
+
+# Foreground colour for each status value (plain table cells)
+STATUS_COLORS = {
+    "Failed": "red",
+    "Completed": "white",
+    "Skipped": "gray",
+    "InProgress": "cyan",
+}
+
+# Semantic badge colours (matching the fibsem.ui.stylesheets palette) used by
+# the workflow summary dialog: status -> (dot/strong colour, muted text colour).
+STATUS_BADGE_COLORS = {
+    "Completed": ("#4caf50", "#7fd083"),
+    "Failed": ("#d04040", "#e08585"),
+    "Skipped": ("#868e93", "#aeb4b9"),
+    "InProgress": ("#50a6ff", "#9cc7f5"),
+}
+
+# Status order for count chips (these three are always shown, even at zero)
+STATUS_CHIP_ORDER = ["Completed", "Failed", "Skipped"]
+
+
+def format_duration_short(seconds) -> str:
+    """Format a duration in seconds as MMm:SSs (blank for missing values)."""
+    if seconds is None or seconds == "" or pd.isna(seconds):
+        return ""
+    try:
+        total_seconds = int(float(seconds))
+        minutes = total_seconds // 60
+        secs = total_seconds % 60
+        return f"{minutes:02d}m:{secs:02d}s"
+    except (ValueError, TypeError):
+        return str(seconds)
+
+
+def prepare_summary_dataframe(df: Optional[pd.DataFrame],
+                              columns: Optional[List[str]] = None) -> Optional[pd.DataFrame]:
+    """Select summary columns, format the duration column, and rename to display titles.
+
+    Args:
+        df: raw dataframe (e.g. from task_history_dataframe / build_run_summary_dataframe)
+        columns: raw column names to keep (defaults to SUMMARY_COLUMNS)
+
+    Returns:
+        A new dataframe with display titles, or the input unchanged if empty/None.
+    """
+    if df is None or df.empty:
+        return df
+
+    if columns is None:
+        columns = SUMMARY_COLUMNS
+
+    available = [col for col in columns if col in df.columns]
+    df = df[available].copy()
+
+    if "duration" in df.columns:
+        df["duration"] = df["duration"].apply(format_duration_short)
+
+    return df.rename(columns=COLUMN_NAME_MAPPING)
+
+
+def make_status_cell_formatter(df: pd.DataFrame) -> Callable[[int, int, object], dict]:
+    """Return a DataFrameTableWidget cell_formatter that colours rows by Status.
+
+    The dataframe passed here must already use display titles (i.e. have a
+    'Status' column), as produced by prepare_summary_dataframe.
+    """
+    def format_cell(row_idx: int, col_idx: int, value) -> dict:
+        format_dict: dict = {}
+        if "Status" in df.columns:
+            status_col_idx = df.columns.get_loc("Status")
+            status_value = str(df.iloc[row_idx, status_col_idx])
+            color = STATUS_COLORS.get(status_value)
+            if color:
+                format_dict["color"] = color
+        return format_dict
+
+    return format_cell

--- a/fibsem/ui/widgets/workflow_summary_dialog.py
+++ b/fibsem/ui/widgets/workflow_summary_dialog.py
@@ -1,0 +1,279 @@
+"""
+Modal dialog showing a summary of the tasks run in a single workflow run.
+
+Displays one row per (lamella, task) attempted in the run with status,
+completion time and duration, count chips and a primary OK button.
+"""
+from typing import List, Optional
+
+import pandas as pd
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor, QFont
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.ui.stylesheets import PRIMARY_BUTTON_STYLESHEET
+from fibsem.ui.widgets.task_summary_formatting import (
+    STATUS_BADGE_COLORS,
+    STATUS_CHIP_ORDER,
+    format_duration_short,
+)
+
+# Palette (matching fibsem.ui.stylesheets napari theme)
+_BG = "#262930"
+_PANEL = "#1e2027"
+_ROW_ALT = "#2b2f38"
+_BORDER = "#3d4251"
+_TEXT = "#d6d6d6"
+_TEXT_STRONG = "#f0f1f2"
+_TEXT_MUTED = "#868e93"
+
+_TABLE_STYLE = f"""
+QTableWidget {{
+    background-color: {_BG};
+    alternate-background-color: {_ROW_ALT};
+    border: 1px solid {_BORDER};
+    border-radius: 6px;
+    color: {_TEXT};
+    gridline-color: transparent;
+    outline: none;
+}}
+QTableWidget::item {{
+    padding: 6px 10px;
+    border: none;
+}}
+QTableWidget::item:selected {{
+    background-color: #2d3f5c;
+    color: {_TEXT_STRONG};
+}}
+QHeaderView::section {{
+    background-color: {_PANEL};
+    color: {_TEXT_MUTED};
+    padding: 7px 10px;
+    border: none;
+    border-bottom: 1px solid {_BORDER};
+    font-weight: 500;
+}}
+"""
+
+_COLUMNS = ["Lamella", "Task", "Status", "Completed", "Duration"]
+
+
+class _NumericItem(QTableWidgetItem):
+    """Table item that sorts by its numeric Qt.UserRole value rather than text.
+
+    Lets the Duration column (displayed as 'MMm:SSs') sort by the underlying
+    seconds, so e.g. '100m:00s' sorts after '99m:00s'.
+    """
+
+    def __lt__(self, other: QTableWidgetItem) -> bool:
+        a = self.data(Qt.UserRole)
+        b = other.data(Qt.UserRole)
+        if a is not None and b is not None:
+            return a < b
+        return super().__lt__(other)
+
+
+class WorkflowSummaryDialog(QDialog):
+    """A modal dialog that displays a per-run task summary table with an OK button."""
+
+    def __init__(self, dataframe: pd.DataFrame, parent: Optional[QWidget] = None):
+        """
+        Args:
+            dataframe: raw run-summary dataframe with columns
+                lamella_name, task_name, task_status, completed_at, duration
+            parent: the parent widget
+        """
+        super().__init__(parent)
+        self.setWindowTitle("Workflow Summary")
+        self.resize(780, 460)
+        self.setStyleSheet(f"QDialog {{ background-color: {_BG}; }}")
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(18, 16, 18, 14)
+        layout.setSpacing(12)
+        self.setLayout(layout)
+
+        # header: title + meta line
+        header_layout = QHBoxLayout()
+        title_label = QLabel("Workflow summary")
+        title_label.setStyleSheet(f"font-size: 16px; font-weight: 500; color: {_TEXT_STRONG};")
+        header_layout.addWidget(title_label)
+        header_layout.addStretch()
+        meta_label = QLabel(self._format_meta(dataframe))
+        meta_label.setStyleSheet(f"font-size: 12px; color: {_TEXT_MUTED};")
+        header_layout.addWidget(meta_label)
+        layout.addLayout(header_layout)
+
+        # count chips
+        layout.addLayout(self._build_chip_row(dataframe))
+
+        # table
+        self.table = self._build_table(dataframe)
+        layout.addWidget(self.table)
+
+        # footer: primary OK button
+        footer_layout = QHBoxLayout()
+        footer_layout.addStretch()
+        ok_button = QPushButton("OK")
+        ok_button.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
+        ok_button.setMinimumWidth(80)
+        ok_button.setDefault(True)
+        ok_button.clicked.connect(self.accept)
+        footer_layout.addWidget(ok_button)
+        layout.addLayout(footer_layout)
+
+    # --- builders ---
+
+    def _build_chip_row(self, df: Optional[pd.DataFrame]) -> QHBoxLayout:
+        """Build the row of status count chips."""
+        chip_layout = QHBoxLayout()
+        chip_layout.setSpacing(8)
+
+        counts = {}
+        if df is not None and not df.empty and "task_status" in df.columns:
+            counts = df["task_status"].value_counts().to_dict()
+
+        # always show the standard three, plus any other statuses that appear
+        statuses = list(STATUS_CHIP_ORDER)
+        for status in counts:
+            if status not in statuses:
+                statuses.append(status)
+
+        for status in statuses:
+            chip_layout.addWidget(self._make_chip(status, int(counts.get(status, 0))))
+        chip_layout.addStretch()
+        return chip_layout
+
+    @staticmethod
+    def _make_chip(status: str, count: int) -> QLabel:
+        """A pill label: coloured dot + 'N status'."""
+        dot_color, text_color = STATUS_BADGE_COLORS.get(status, ("#868e93", "#aeb4b9"))
+        bg = QColor(dot_color)
+        bg_rgba = f"rgba({bg.red()}, {bg.green()}, {bg.blue()}, 0.15)"
+        chip = QLabel(f'<span style="color:{dot_color};">&#9679;</span> {count} {status.lower()}')
+        chip.setStyleSheet(
+            f"background-color: {bg_rgba}; color: {text_color};"
+            f"padding: 3px 10px; border-radius: 10px; font-size: 12px;"
+        )
+        return chip
+
+    def _build_table(self, df: Optional[pd.DataFrame]) -> QTableWidget:
+        """Build the styled summary table from the raw dataframe."""
+        table = QTableWidget()
+        table.setStyleSheet(_TABLE_STYLE)
+        table.setColumnCount(len(_COLUMNS))
+        table.setHorizontalHeaderLabels(_COLUMNS)
+        table.verticalHeader().setVisible(False)
+        table.setShowGrid(False)
+        table.setAlternatingRowColors(True)
+        table.setSortingEnabled(True)
+        table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        table.setSelectionMode(QAbstractItemView.SingleSelection)
+        table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        table.setFocusPolicy(Qt.NoFocus)
+
+        mono_font = QFont("Menlo")
+        mono_font.setStyleHint(QFont.Monospace)
+
+        rows = [] if df is None or df.empty else df.to_dict("records")
+        table.setRowCount(len(rows))
+        for i, row in enumerate(rows):
+            status = str(row.get("task_status", ""))
+            _dot_color, text_color = STATUS_BADGE_COLORS.get(status, (_TEXT, _TEXT))
+
+            lamella_item = QTableWidgetItem(str(row.get("lamella_name", "")))
+            lamella_item.setForeground(QColor(_TEXT_STRONG))
+
+            task_item = QTableWidgetItem(str(row.get("task_name", "")))
+
+            status_item = QTableWidgetItem(f"● {status}")
+            status_item.setForeground(QColor(text_color))
+
+            completed_item = QTableWidgetItem(str(row.get("completed_at", "") or ""))
+            completed_item.setForeground(QColor(_TEXT_MUTED))
+
+            dur_seconds = row.get("duration")
+            duration_item = _NumericItem(format_duration_short(dur_seconds))
+            try:
+                sort_value = float(dur_seconds) if not pd.isna(dur_seconds) else -1.0
+            except (TypeError, ValueError):
+                sort_value = -1.0
+            duration_item.setData(Qt.UserRole, sort_value)
+            duration_item.setForeground(QColor(_TEXT_MUTED))
+            duration_item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+            duration_item.setFont(mono_font)
+
+            for col, item in enumerate(
+                [lamella_item, task_item, status_item, completed_item, duration_item]
+            ):
+                table.setItem(i, col, item)
+
+        # fixed widths for the narrow columns; Task stretches into the remainder
+        # so long task names stay readable without a horizontal scrollbar.
+        header = table.horizontalHeader()
+        header.setStretchLastSection(False)
+        fixed_widths = {0: 155, 2: 140, 3: 115, 4: 100}
+        for col, width in fixed_widths.items():
+            header.setSectionResizeMode(col, QHeaderView.Interactive)
+            table.setColumnWidth(col, width)
+        header.setSectionResizeMode(1, QHeaderView.Stretch)
+        table.verticalHeader().setDefaultSectionSize(34)
+        return table
+
+    # --- helpers ---
+
+    @staticmethod
+    def _format_meta(df: Optional[pd.DataFrame]) -> str:
+        """Build the 'N tasks · M lamellae · T total' meta line."""
+        if df is None or df.empty:
+            return "No tasks were run"
+
+        n_tasks = len(df)
+        parts: List[str] = [f"{n_tasks} task" + ("" if n_tasks == 1 else "s")]
+
+        if "lamella_name" in df.columns:
+            n_lamellae = int(df["lamella_name"].nunique())
+            parts.append(f"{n_lamellae} lamella" + ("" if n_lamellae == 1 else "e"))
+
+        if "duration" in df.columns:
+            total = pd.to_numeric(df["duration"], errors="coerce").fillna(0).sum()
+            if total > 0:
+                parts.append(f"{format_duration_short(total)} total")
+
+        return " · ".join(parts)
+
+
+def main():
+    """Standalone demo with sample data (no UI/workflow required)."""
+    import sys
+
+    from PyQt5.QtWidgets import QApplication
+
+    df = pd.DataFrame(
+        [
+            {"lamella_name": "01-nice-mako", "task_name": "Setup Lamella Position", "task_status": "Completed", "completed_at": "01:37 PM", "duration": 24.0},
+            {"lamella_name": "02-awake-stork", "task_name": "Setup Lamella Position", "task_status": "Completed", "completed_at": "01:37 PM", "duration": 23.0},
+            {"lamella_name": "01-nice-mako", "task_name": "Mill Fiducial", "task_status": "Failed", "completed_at": "01:38 PM", "duration": 39.0},
+            {"lamella_name": "02-awake-stork", "task_name": "Mill Fiducial", "task_status": "Skipped", "completed_at": "", "duration": None},
+        ]
+    )
+
+    app = QApplication(sys.argv)
+    dialog = WorkflowSummaryDialog(df)
+    dialog.exec_()
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_workflow_summary_dialog.py
+++ b/scripts/test_workflow_summary_dialog.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Standalone test/runner for WorkflowSummaryDialog — no napari/workflow required.
+
+Builds a synthetic per-run summary dataframe (the same shape produced by
+TaskManager.build_run_summary_dataframe) and shows the modal summary dialog.
+
+Usage:
+    python scripts/test_workflow_summary_dialog.py
+    python scripts/test_workflow_summary_dialog.py --empty   # test the empty case
+"""
+
+import argparse
+import sys
+
+import pandas as pd
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.workflow_summary_dialog import WorkflowSummaryDialog
+
+
+def sample_dataframe() -> pd.DataFrame:
+    """A representative run summary: completed, failed and skipped tasks."""
+    return pd.DataFrame(
+        [
+            {"lamella_name": "lamella-01", "task_name": "Mill Trench", "task_status": "Completed", "completed_at": "10:31 AM", "duration": 182.4},
+            {"lamella_name": "lamella-01", "task_name": "Mill Undercut", "task_status": "Completed", "completed_at": "10:45 AM", "duration": 405.1},
+            {"lamella_name": "lamella-02", "task_name": "Mill Trench", "task_status": "Failed", "completed_at": "10:52 AM", "duration": 60.0},
+            {"lamella_name": "lamella-02", "task_name": "Mill Undercut", "task_status": "Skipped", "completed_at": "", "duration": None},
+            {"lamella_name": "lamella-03", "task_name": "Mill Trench", "task_status": "Completed", "completed_at": "11:05 AM", "duration": 175.9},
+            {"lamella_name": "lamella-03", "task_name": "Mill Undercut", "task_status": "Completed", "completed_at": "11:20 AM", "duration": 398.7},
+        ]
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="WorkflowSummaryDialog test runner")
+    parser.add_argument("--empty", action="store_true", help="show the dialog with no tasks")
+    args = parser.parse_args()
+
+    df = pd.DataFrame() if args.empty else sample_dataframe()
+
+    app = QApplication(sys.argv)
+    dialog = WorkflowSummaryDialog(df)
+    dialog.setWindowTitle("Workflow Summary (test)")
+    result = dialog.exec_()
+    print(f"Dialog closed with result={result}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

When a workflow finishes (including on cancel), show a modal summary of the tasks run in that session: one row per (lamella, task) with status, completed-at and duration, status count chips, and a meta line.

## Changes

- **`TaskManager.build_run_summary_dataframe()`** — builds a per-run summary from the `TaskQueue` snapshot (so it includes **skipped** tasks, which never enter the experiment task history), enriched with `completed_at`/`duration` from each lamella's task history.
- **`WorkflowSummaryDialog`** — custom `QTableWidget` styled to the existing napari dark theme (`fibsem.ui.stylesheets`): status count chips, dot+label status, monospace right-aligned duration with numeric sort, and a primary OK button.
- **`task_summary_formatting`** — shared duration/column/status formatting helpers; `TaskHistoryTableWidget` refactored to use them so the two tables stay consistent.
- **`AutoLamellaUI`** — captures the run summary on the worker thread before the `TaskManager` is torn down, then shows the dialog on the GUI thread in `_workflow_finished()`.
- **`scripts/test_workflow_summary_dialog.py`** — standalone test runner (no UI/workflow needed): `python scripts/test_workflow_summary_dialog.py` (or `--empty`).

## Testing

- Rendered the dialog offscreen and verified layout (no truncation / no horizontal scrollbar), status colouring, count chips, and empty-state.
- Verified numeric duration sort orders `100m:00s` after `99m:00s` (string sort would invert them) and sinks blank/skipped rows.