### PR TITLE
[ui] Extract Selected Lamella panel into standalone widgets

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -45,13 +45,10 @@ from fibsem.ui.fm.widgets import FMImageViewerWidget
 from fibsem.ui import utils as fui
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
-    QComboBox,
     QGridLayout,
-    QHBoxLayout,
     QLabel,
     QLineEdit,
     QMainWindow,
-    QMenu,
     QMessageBox,
     QPushButton,
     QSizePolicy,
@@ -59,12 +56,8 @@ from PyQt5.QtWidgets import (
     QTabWidget,
     QWidget,
 )
-from fibsem.ui.widgets.custom_widgets import (
-    IconToolButton,
-    LamellaNameListWidget,
-    TitledPanel,
-    ValueSpinBox,
-)
+from fibsem.ui.widgets.custom_widgets import LamellaNameListWidget
+from fibsem.ui.widgets.selected_lamella_widget import SelectedLamellaWidget
 
 if (
     DETECTION_AVAILABLE
@@ -252,56 +245,15 @@ class AutoLamellaUI(QMainWindow):
         self.lamella_list.enable_update_action(True)
         self.lamella_list.enable_remove_button(True)
 
-        self.label_lamella_objective_position = QLabel("Objective Position")
-        self.doubleSpinBox_lamella_objective_position = ValueSpinBox(
-            suffix="µm", decimals=1, step=1.0, minimum=-20000.0, maximum=20000.0
-        )
-        self.btn_lamella_objective_actions = IconToolButton(
-            "mdi:dots-horizontal", tooltip="Actions"
-        )
-        self.btn_lamella_objective_actions.setPopupMode(IconToolButton.InstantPopup)
-        self.btn_lamella_objective_actions.setStyleSheet(
-            "QToolButton::menu-indicator { image: none; }"
-        )
-        _obj_menu = QMenu(self)
-        self._action_use_current_obj_pos = _obj_menu.addAction("Use Current Objective Position")
-        self._action_apply_obj_to_all = _obj_menu.addAction("Apply to All Lamella")
-        self.btn_lamella_objective_actions.setMenu(_obj_menu)
-
-        self.label_lamella_pose = QLabel("Pose")
-        self.comboBox_lamella_pose = QComboBox()
-
-        self.label_lamella_pose_position = QLabel("Pose Position")
-        self.pushButton_lamella_set_pose = QPushButton("Set Current Pose")
-        self.pushButton_lamella_move_to_pose = QPushButton("Move to Pose")
         # --- Selected Lamella panel (row 6, colspan 2) ---
-        selected_content = QWidget()
-        selected_layout = QGridLayout(selected_content)
-        selected_layout.setContentsMargins(0, 0, 0, 0)
-        _obj_row = QWidget()
-        _obj_row_layout = QHBoxLayout(_obj_row)
-        _obj_row_layout.setContentsMargins(0, 0, 0, 0)
-        _obj_row_layout.setSpacing(2)
-        _obj_row_layout.addWidget(self.doubleSpinBox_lamella_objective_position)
-        _obj_row_layout.addWidget(self.btn_lamella_objective_actions)
-        selected_layout.addWidget(self.label_lamella_objective_position, 0, 0)
-        selected_layout.addWidget(_obj_row, 0, 1)
-        selected_layout.addWidget(self.label_lamella_pose, 1, 0)
-        selected_layout.addWidget(self.comboBox_lamella_pose, 1, 1)
-        selected_layout.addWidget(self.label_lamella_pose_position, 2, 0, 1, 2)
-        selected_layout.addWidget(self.pushButton_lamella_set_pose, 3, 0)
-        selected_layout.addWidget(self.pushButton_lamella_move_to_pose, 3, 1)
-
-        self.selected_lamella_content = TitledPanel(
-            "Selected Lamella", content=selected_content, collapsible=False
-        )
+        self.selected_lamella_widget = SelectedLamellaWidget()
 
         self.grid_layout_experiment.addWidget(self.label_experiment_name, 0, 0)
         self.grid_layout_experiment.addWidget(self.lineEdit_experiment_name, 0, 1)
         self.grid_layout_experiment.addWidget(self.label_protocol_name, 1, 0)
         self.grid_layout_experiment.addWidget(self.lineEdit_protocol_name, 1, 1)
         self.grid_layout_experiment.addWidget(self.lamella_list, 2, 0, 1, 2)
-        self.grid_layout_experiment.addWidget(self.selected_lamella_content, 3, 0, 1, 2)
+        self.grid_layout_experiment.addWidget(self.selected_lamella_widget, 3, 0, 1, 2)
 
         # Vertical spacer (row 7)
         self.grid_layout_experiment.addItem(
@@ -382,37 +334,21 @@ class AutoLamellaUI(QMainWindow):
         # refresh ui
         self.update_ui()
 
-        self.doubleSpinBox_lamella_objective_position.valueChanged.connect(
+        self.selected_lamella_widget.objective_position_changed.connect(
             self.update_lamella_objective_position
         )
-        self._action_use_current_obj_pos.triggered.connect(
+        self.selected_lamella_widget.use_current_objective_requested.connect(
             self._use_current_objective_position
         )
-        self._action_apply_obj_to_all.triggered.connect(
+        self.selected_lamella_widget.apply_objective_to_all_requested.connect(
             self._apply_objective_position_to_all
         )
-
-        self.comboBox_lamella_pose.currentIndexChanged.connect(
-            self._on_lamella_pose_combobox_changed
-        )
-        self.pushButton_lamella_set_pose.clicked.connect(
+        self.selected_lamella_widget.pose_update_requested.connect(
             self._set_current_position_as_pose
         )
-        self.pushButton_lamella_set_pose.setToolTip(
-            "Set the current stage position as the lamella pose position."
+        self.selected_lamella_widget.pose_move_to_requested.connect(
+            self._move_to_lamella_pose
         )
-
-        self.pushButton_lamella_move_to_pose.clicked.connect(self._move_to_lamella_pose)
-        self.pushButton_lamella_move_to_pose.setToolTip(
-            "Move the stage to the lamella pose position."
-        )
-        self.pushButton_lamella_set_pose.setStyleSheet(
-            stylesheets.SECONDARY_BUTTON_STYLESHEET
-        )
-        self.pushButton_lamella_move_to_pose.setStyleSheet(
-            stylesheets.SECONDARY_BUTTON_STYLESHEET
-        )
-        self.label_lamella_pose_position.setWordWrap(True)
 
     ##########
 
@@ -1111,7 +1047,7 @@ class AutoLamellaUI(QMainWindow):
         """Update the ui based on the current state of the application."""
 
         if self.is_workflow_running:
-            self.selected_lamella_content.setEnabled(False)
+            self.selected_lamella_widget.setEnabled(False)
 
             return
 
@@ -1146,19 +1082,14 @@ class AutoLamellaUI(QMainWindow):
 
         # buttons
         self.lamella_list.setEnabled(is_experiment_ready)
-        self.selected_lamella_content.setEnabled(is_experiment_ready)
+        self.selected_lamella_widget.setEnabled(is_experiment_ready)
 
-        enable_pose_controls = bool(has_lamella)
-        self.label_lamella_pose.setVisible(enable_pose_controls)
-        self.comboBox_lamella_pose.setVisible(enable_pose_controls)
-        self.label_lamella_pose_position.setVisible(enable_pose_controls)
-        self.pushButton_lamella_move_to_pose.setVisible(enable_pose_controls)
-        self.pushButton_lamella_set_pose.setVisible(enable_pose_controls)
-        self.label_lamella_objective_position.setVisible(False)
-        self.doubleSpinBox_lamella_objective_position.setVisible(False)
+        # clear the panel when no lamella is selected; populated by update_lamella_ui otherwise
+        if not has_lamella:
+            self.selected_lamella_widget.set_lamella(None)
 
         # disable lamella controls while workflow is running
-        self.selected_lamella_content.setEnabled(not self.is_workflow_running)
+        self.selected_lamella_widget.setEnabled(not self.is_workflow_running)
 
         # Current Lamella Status
         if has_lamella and self.experiment is not None:
@@ -1228,50 +1159,8 @@ class AutoLamellaUI(QMainWindow):
         lamella: Lamella = self.experiment.positions[idx]
         logging.info(f"Updating Lamella UI for {lamella.status_info}")
 
-        # set objective position (show as µm)
-        obj_pos = (
-            lamella.fluorescence_pose.objective_position
-            if lamella.fluorescence_pose is not None
-            else None
-        )
-        obj_controls_enabled = obj_pos is not None
-        if obj_controls_enabled:
-            self.doubleSpinBox_lamella_objective_position.blockSignals(True)
-            self.doubleSpinBox_lamella_objective_position.setValue(obj_pos * METRE_TO_MICRON)
-            self.doubleSpinBox_lamella_objective_position.blockSignals(False)
-        self.label_lamella_objective_position.setVisible(obj_controls_enabled)
-        self.doubleSpinBox_lamella_objective_position.setVisible(obj_controls_enabled)
-        self.btn_lamella_objective_actions.setVisible(obj_controls_enabled)
-
-        # set lamella pose display
-        if lamella.poses:
-            self.comboBox_lamella_pose.blockSignals(True)
-            current_text = self.comboBox_lamella_pose.currentText()
-            self.comboBox_lamella_pose.clear()
-            self.comboBox_lamella_pose.addItems(list(lamella.poses.keys()))
-
-            # restore
-            if current_text in lamella.poses:
-                self.comboBox_lamella_pose.setCurrentText(current_text)
-            else:
-                self.comboBox_lamella_pose.setCurrentIndex(0)
-
-            current_pose = self.comboBox_lamella_pose.currentText()
-            pose = lamella.poses.get(current_pose, None)
-
-            txt = "Pose: Unknown"
-            if pose is not None and pose.stage_position is not None:
-                txt = f"Pose: {pose.stage_position.pretty}"
-            self.label_lamella_pose_position.setText(txt)
-            self.comboBox_lamella_pose.blockSignals(False)
-
-        # hide pose controls if no poses
-        enable_pose_controls = bool(lamella.poses)
-        self.label_lamella_pose.setVisible(enable_pose_controls)
-        self.comboBox_lamella_pose.setVisible(enable_pose_controls)
-        self.label_lamella_pose_position.setVisible(enable_pose_controls)
-        self.pushButton_lamella_move_to_pose.setVisible(enable_pose_controls)
-        self.pushButton_lamella_set_pose.setVisible(enable_pose_controls)
+        # refresh objective position + pose display for the selected lamella
+        self.selected_lamella_widget.set_lamella(lamella)
 
         self._update_minimap_data(selected_name=lamella.name)
         self._update_lamella_display(selected_name=lamella.name)
@@ -1497,26 +1386,8 @@ class AutoLamellaUI(QMainWindow):
         self.experiment.save()
         self.experiment.positions.events.changed.emit()
 
-    def _on_lamella_pose_combobox_changed(self):
-        """Update the pose position label when the pose combobox is changed."""
-
-        lamella: Lamella
-        if self.experiment is None or self.experiment.positions == []:
-            return
-        idx = self.lamella_list.selected_index
-        if idx == -1:
-            return
-        lamella = self.experiment.positions[idx]
-        pose_name = self.comboBox_lamella_pose.currentText()
-        if pose_name not in lamella.poses:
-            return
-        pose = lamella.poses[pose_name]
-        if pose.stage_position is None:
-            return
-        self.label_lamella_pose_position.setText(f"Pose: {pose.stage_position.pretty}")
-
-    def _set_current_position_as_pose(self):
-        """Set the current stage position as the selected pose for the current lamella."""
+    def _set_current_position_as_pose(self, pose_name: str):
+        """Set the current stage position as the given pose for the current lamella."""
 
         if self.microscope is None:
             notification_service.show_toast("No microscope connected.", "warning")
@@ -1529,7 +1400,6 @@ class AutoLamellaUI(QMainWindow):
             notification_service.show_toast("No lamella selected.", "warning")
             return
         lamella: Lamella = self.experiment.positions[idx]
-        pose_name = self.comboBox_lamella_pose.currentText()
         if pose_name == "":
             notification_service.show_toast("No pose selected.", "warning")
             return
@@ -1553,13 +1423,13 @@ class AutoLamellaUI(QMainWindow):
 
         lamella.poses[pose_name] = state
         self.experiment.save()
-        self.label_lamella_pose_position.setText(f"{state.stage_position.pretty}")
+        self.selected_lamella_widget.refresh_pose(pose_name, state.stage_position.pretty)
         notification_service.show_toast(
             f"Set current position as pose '{pose_name}' for {lamella.name}.", "info"
         )
 
-    def _move_to_lamella_pose(self):
-        """Move the stage to the selected pose for the current lamella."""
+    def _move_to_lamella_pose(self, pose_name: str):
+        """Move the stage to the given pose for the current lamella."""
 
         if self.microscope is None:
             notification_service.show_toast("No microscope connected.", "warning")
@@ -1575,7 +1445,6 @@ class AutoLamellaUI(QMainWindow):
             notification_service.show_toast("No lamella selected.", "warning")
             return
         lamella: Lamella = self.experiment.positions[idx]
-        pose_name = self.comboBox_lamella_pose.currentText()
         if pose_name == "":
             notification_service.show_toast("No pose selected.", "warning")
             return
@@ -1626,9 +1495,7 @@ class AutoLamellaUI(QMainWindow):
             return
         lamella.fluorescence_pose.objective_position = value_m
         self.experiment.save()
-        self.doubleSpinBox_lamella_objective_position.blockSignals(True)
-        self.doubleSpinBox_lamella_objective_position.setValue(value_m * METRE_TO_MICRON)
-        self.doubleSpinBox_lamella_objective_position.blockSignals(False)
+        self.selected_lamella_widget.set_objective_value_um(value_m * METRE_TO_MICRON)
         notification_service.show_toast(
             f"Set objective position to {value_m * METRE_TO_MICRON:.1f} µm for {lamella.name}.", "info"
         )
@@ -1653,7 +1520,7 @@ class AutoLamellaUI(QMainWindow):
         """Copy the current spinbox objective position to all lamella that have a fluorescence pose."""
         if self.experiment is None:
             return
-        value_um = self.doubleSpinBox_lamella_objective_position.value()
+        value_um = self.selected_lamella_widget.objective_value_um()
         value_m = value_um * MICRON_TO_METRE
         count = 0
         for lamella in self.experiment.positions:

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1421,6 +1421,13 @@ class AutoLamellaUI(QMainWindow):
         if ret != QMessageBox.Yes:
             return
 
+        # preserve the configured objective (focus) position of the existing pose:
+        # get_microscope_state() does not capture the objective position, so replacing
+        # the pose outright would wipe the fluorescence pose's focus setting.
+        existing_pose = lamella.poses.get(pose_name)
+        if existing_pose is not None and existing_pose.objective_position is not None:
+            state.objective_position = existing_pose.objective_position
+
         lamella.poses[pose_name] = state
         self.experiment.save()
         self.selected_lamella_widget.refresh_pose(pose_name, state.stage_position.pretty)

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1502,7 +1502,8 @@ class AutoLamellaUI(QMainWindow):
             return
         lamella.fluorescence_pose.objective_position = value_m
         self.experiment.save()
-        self.selected_lamella_widget.set_objective_value_um(value_m * METRE_TO_MICRON)
+        # full refresh so the objective value shows and "Apply to All" re-enables
+        self.selected_lamella_widget.set_lamella(lamella)
         notification_service.show_toast(
             f"Set objective position to {value_m * METRE_TO_MICRON:.1f} µm for {lamella.name}.", "info"
         )

--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -16,7 +16,7 @@ from fibsem.applications.autolamella.workflows.ui import (
     ask_user,
 )
 from fibsem.fm.acquisition import acquire_image, run_autofocus
-from fibsem.fm.structures import AutoFocusSettings, ChannelSettings, ZParameters
+from fibsem.fm.structures import AutoFocusResult, AutoFocusSettings, ChannelSettings, ZParameters
 
 
 @dataclass
@@ -84,7 +84,10 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
 
         # Run autofocus if requested
         if self.config.autofocus_settings.fine_enabled:
-            self._run_autofocus()
+            result = self._run_autofocus()
+            # autofocus found a better focus — make it the lamella's saved objective position
+            if result is not None and self.lamella.fluorescence_pose is not None:
+                self.lamella.fluorescence_pose.objective_position = result.best_z
 
         # Generate timestamp-based filename
         timestamp = utils.current_timestamp_v3(timeonly=True)
@@ -104,8 +107,8 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
         self._update_fluorescence_pose()
 
 
-    def _run_autofocus(self,):
-        """Run autofocus with the specified settings."""
+    def _run_autofocus(self) -> Optional[AutoFocusResult]:
+        """Run autofocus with the specified settings, returning the result."""
         # Find autofocus channel by name if specified in autofocus_settings
         autofocus_channel = None
         if self.config.autofocus_settings.channel_name:
@@ -150,6 +153,8 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
             result.plot(save_path)
         except Exception as e:
             logging.warning(f"Failed to plot autofocus result: {e}")
+
+        return result
 
     def _move_to_stage_position(self):
         """Move the stage to the fluorescence pose stage position, or the lamella stage position if fluorescence pose is not set."""

--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -100,9 +100,8 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
                                 stop_event=self._stop_event,
                                 filename=filename)
 
-        # store the fluorescence pose
-        self.lamella.fluorescence_pose = self.microscope.get_microscope_state()
-        self.lamella.fluorescence_pose.objective_position = self.microscope.fm.objective.position
+        # refresh the recorded fluorescence pose (preserving the configured objective position)
+        self._update_fluorescence_pose()
 
 
     def _run_autofocus(self,):

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -237,6 +237,22 @@ class AutoLamellaTask(ABC):
         if self._stop_event is not None and self._stop_event.is_set():
             raise InterruptedError("Workflow aborted by user.")
 
+    def _update_fluorescence_pose(self) -> None:
+        """Refresh the lamella's recorded fluorescence pose from the current microscope state.
+
+        The configured objective (focus) position is preserved: get_microscope_state()
+        does not capture the objective position, so overwriting the pose here (and
+        re-reading the live objective position) previously wiped the user's configured
+        focus.
+        """
+        configured_objective_position = (
+            self.lamella.fluorescence_pose.objective_position
+            if self.lamella.fluorescence_pose is not None
+            else None
+        )
+        self.lamella.fluorescence_pose = self.microscope.get_microscope_state()
+        self.lamella.fluorescence_pose.objective_position = configured_objective_position
+
     def update_milling_config_ui(self,
                                  milling_config: FibsemMillingTaskConfig,
                                  msg: str = "Run Milling",

--- a/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
+++ b/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
@@ -109,7 +109,10 @@ class MillCoincidentTask(AutoLamellaTask):
             raise ValueError(
                 "Microscope does not have a fluorescence microscope attached. Cannot run MillCoincidentTask."
             )
-        if self.lamella.objective_position is None:
+        if (
+            self.lamella.fluorescence_pose is None
+            or self.lamella.fluorescence_pose.objective_position is None
+        ):
             raise ValueError(
                 f"Lamella {self.lamella.name} does not have an objective position set. Cannot run MillCoincidentTask."
             )
@@ -164,7 +167,7 @@ class MillCoincidentTask(AutoLamellaTask):
             return
 
         # Move stage to the saved stage position and objective position
-        self.microscope.fm.objective.move_absolute(self.lamella.objective_position)
+        self.microscope.fm.objective.move_absolute(self.lamella.fluorescence_pose.objective_position)
 
         # mill coincident
         self.log_status_message("MILL_COINCIDENT", "Milling Coincident Lamella...")

--- a/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
@@ -72,7 +72,6 @@ class SelectFluorescencePositionTask(AutoLamellaTask):
                 )
             self.microscope.fm.stop_acquisition()
 
-        # store the fluorescence pose
-        self.lamella.fluorescence_pose = self.microscope.get_microscope_state()
-        self.lamella.fluorescence_pose.objective_position = self.microscope.fm.objective.position
+        # refresh the recorded fluorescence pose (preserving the configured objective position)
+        self._update_fluorescence_pose()
 

--- a/fibsem/ui/widgets/lamella_pose_list_widget.py
+++ b/fibsem/ui/widgets/lamella_pose_list_widget.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from PyQt5.QtCore import QSize, Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.applications.autolamella.structures import Lamella
+from fibsem.ui import stylesheets
+from fibsem.ui.widgets.custom_widgets import IconToolButton
+
+_NAME_WIDTH = 110
+_BTN_SIZE = QSize(32, 32)
+_ROW_HEIGHT = 40
+_BTN_SPACER_WIDTH = _BTN_SIZE.width() * 2 + 8  # 2 buttons + 1 gap
+
+# Preferred display order; poses not listed keep their insertion order after these.
+_POSE_ORDER = ["MILLING", "FLUORESCENCE"]
+
+
+class LamellaPoseRowWidget(QWidget):
+    """A single pose row: name, pretty position, update and move-to buttons."""
+
+    update_clicked = pyqtSignal(str)   # pose name
+    move_to_clicked = pyqtSignal(str)  # pose name
+
+    def __init__(self, pose_name: str, pretty: str, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.pose_name = pose_name
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(6, 3, 6, 3)
+        layout.setSpacing(8)
+
+        self.name_label = QLabel(pose_name.capitalize())
+        self.name_label.setFixedWidth(_NAME_WIDTH)
+        self.name_label.setStyleSheet("background: transparent;")
+        layout.addWidget(self.name_label)
+
+        self.position_label = QLabel(pretty)
+        self.position_label.setStyleSheet("background: transparent; color: #909090;")
+        layout.addWidget(self.position_label, 1)
+
+        self.btn_update = IconToolButton(
+            icon="mdi:map-marker-check",
+            tooltip="Update Position",
+            size=_BTN_SIZE.width(),
+        )
+        layout.addWidget(self.btn_update)
+
+        self.btn_move_to = IconToolButton(
+            icon="mdi:crosshairs-gps",
+            tooltip="Move to Position",
+            size=_BTN_SIZE.width(),
+        )
+        layout.addWidget(self.btn_move_to)
+
+        self.btn_update.clicked.connect(lambda: self.update_clicked.emit(self.pose_name))
+        self.btn_move_to.clicked.connect(lambda: self.move_to_clicked.emit(self.pose_name))
+
+    def set_pretty(self, pretty: str) -> None:
+        self.position_label.setText(pretty)
+
+
+class _LamellaPoseListHeader(QWidget):
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setStyleSheet("background: #1e2124;")
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(6, 4, 6, 4)
+        layout.setSpacing(8)
+
+        name_header = QLabel("Pose")
+        name_header.setFixedWidth(_NAME_WIDTH)
+        name_header.setStyleSheet("font-weight: bold; background: transparent;")
+        layout.addWidget(name_header)
+
+        position_header = QLabel("Position")
+        position_header.setStyleSheet("font-weight: bold; background: transparent;")
+        layout.addWidget(position_header, 1)
+
+        spacer = QWidget()
+        spacer.setFixedWidth(_BTN_SPACER_WIDTH)
+        spacer.setStyleSheet("background: transparent;")
+        layout.addWidget(spacer)
+
+
+class LamellaPoseListWidget(QWidget):
+    """List widget displaying a Lamella's poses with name, position and actions.
+
+    Self-contained: holds only the pose names of the lamella set via
+    :meth:`set_lamella`. Emits :attr:`update_requested` / :attr:`move_to_requested`
+    with the pose name when the row buttons are clicked.
+    """
+
+    update_requested = pyqtSignal(str)   # pose name
+    move_to_requested = pyqtSignal(str)  # pose name
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self._header = _LamellaPoseListHeader()
+        layout.addWidget(self._header)
+
+        sep = QFrame()
+        sep.setFrameShape(QFrame.HLine)
+        sep.setStyleSheet("color: #3a3d42;")
+        layout.addWidget(sep)
+
+        self._list = QListWidget()
+        self._list.setSpacing(0)
+        self._list.setStyleSheet(stylesheets.LIST_WIDGET_STYLESHEET)
+        self._list.setAlternatingRowColors(False)
+        self._list.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._list.setFocusPolicy(Qt.NoFocus)
+        layout.addWidget(self._list)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_lamella(self, lamella: Optional[Lamella]) -> None:
+        """Rebuild the rows from the lamella's existing poses."""
+        self._list.clear()
+        if lamella is None or not lamella.poses:
+            return
+        for pose_name in self._sorted_pose_names(lamella.poses):
+            self._add_row(pose_name, self._pretty(lamella.poses[pose_name]))
+
+    def refresh_pose(self, pose_name: str, pretty: str) -> None:
+        """Update the displayed position for an existing pose row, in place.
+
+        Avoids rebuilding the list so row selection/scroll state is preserved.
+        No-op if no row matches *pose_name*.
+        """
+        for i in range(self._list.count()):
+            row = self._list.itemWidget(self._list.item(i))
+            if isinstance(row, LamellaPoseRowWidget) and row.pose_name == pose_name:
+                row.set_pretty(pretty)
+                return
+
+    def clear(self) -> None:
+        self._list.clear()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _sorted_pose_names(poses) -> list:
+        """Order poses by _POSE_ORDER first; remaining keep insertion order after."""
+        def key(name: str):
+            try:
+                return (0, _POSE_ORDER.index(name))
+            except ValueError:
+                return (1, 0)
+        return sorted(poses.keys(), key=key)
+
+    @staticmethod
+    def _pretty(pose) -> str:
+        if pose is not None and pose.stage_position is not None:
+            return pose.stage_position.pretty
+        return "Unknown"
+
+    def _add_row(self, pose_name: str, pretty: str) -> LamellaPoseRowWidget:
+        row = LamellaPoseRowWidget(pose_name, pretty)
+        item = QListWidgetItem()
+        item.setSizeHint(QSize(0, _ROW_HEIGHT))
+        self._list.addItem(item)
+        self._list.setItemWidget(item, row)
+        row.update_clicked.connect(self.update_requested)
+        row.move_to_clicked.connect(self.move_to_requested)
+        return row

--- a/fibsem/ui/widgets/selected_lamella_widget.py
+++ b/fibsem/ui/widgets/selected_lamella_widget.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import (
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QMenu,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.applications.autolamella.structures import Lamella
+from fibsem.constants import METRE_TO_MICRON
+from fibsem.ui.widgets.custom_widgets import (
+    IconToolButton,
+    TitledPanel,
+    ValueSpinBox,
+)
+from fibsem.ui.widgets.lamella_pose_list_widget import LamellaPoseListWidget
+
+
+class SelectedLamellaWidget(QWidget):
+    """Presentational panel for the currently selected lamella.
+
+    Shows the objective-position control and the lamella's poses. This is a
+    view: it reads display state from the lamella passed to :meth:`set_lamella`
+    and emits signals for user actions. All microscope/experiment side effects
+    are handled by the parent (AutoLamellaUI) via the connected signals.
+    """
+
+    objective_position_changed = pyqtSignal(float)     # value in µm
+    use_current_objective_requested = pyqtSignal()
+    apply_objective_to_all_requested = pyqtSignal()
+    pose_update_requested = pyqtSignal(str)            # pose name
+    pose_move_to_requested = pyqtSignal(str)           # pose name
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+
+        # --- objective position row ---
+        self.label_objective_position = QLabel("Objective Position")
+        self.spinbox_objective_position = ValueSpinBox(
+            suffix="µm", decimals=1, step=1.0, minimum=-20000.0, maximum=20000.0
+        )
+        self.btn_objective_actions = IconToolButton(
+            "mdi:dots-horizontal", tooltip="Actions"
+        )
+        self.btn_objective_actions.setPopupMode(IconToolButton.InstantPopup)
+        self.btn_objective_actions.setStyleSheet(
+            "QToolButton::menu-indicator { image: none; }"
+        )
+        obj_menu = QMenu(self)
+        self._action_use_current_obj_pos = obj_menu.addAction(
+            "Use Current Objective Position"
+        )
+        self._action_apply_obj_to_all = obj_menu.addAction("Apply to All Lamella")
+        self.btn_objective_actions.setMenu(obj_menu)
+
+        # --- pose list ---
+        self.pose_list = LamellaPoseListWidget()
+
+        # --- layout ---
+        content = QWidget()
+        content_layout = QGridLayout(content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        obj_row = QWidget()
+        obj_row_layout = QHBoxLayout(obj_row)
+        obj_row_layout.setContentsMargins(0, 0, 0, 0)
+        obj_row_layout.setSpacing(2)
+        obj_row_layout.addWidget(self.spinbox_objective_position)
+        obj_row_layout.addWidget(self.btn_objective_actions)
+        content_layout.addWidget(self.label_objective_position, 0, 0)
+        content_layout.addWidget(obj_row, 0, 1)
+        content_layout.addWidget(self.pose_list, 1, 0, 1, 2)
+
+        self._panel = TitledPanel(
+            "Selected Lamella", content=content, collapsible=False
+        )
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.addWidget(self._panel)
+
+        # --- wire internal widgets to public signals ---
+        self.spinbox_objective_position.valueChanged.connect(
+            self.objective_position_changed
+        )
+        self._action_use_current_obj_pos.triggered.connect(
+            self.use_current_objective_requested
+        )
+        self._action_apply_obj_to_all.triggered.connect(
+            self.apply_objective_to_all_requested
+        )
+        self.pose_list.update_requested.connect(self.pose_update_requested)
+        self.pose_list.move_to_requested.connect(self.pose_move_to_requested)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_lamella(self, lamella: Optional[Lamella]) -> None:
+        """Refresh the panel display from *lamella* (or clear it if None)."""
+        if lamella is None:
+            self.label_objective_position.setVisible(False)
+            self.spinbox_objective_position.setVisible(False)
+            self.btn_objective_actions.setVisible(False)
+            self.pose_list.set_lamella(None)
+            self.pose_list.setVisible(False)
+            return
+
+        # objective position (shown in µm); controls visible only when set
+        obj_pos = (
+            lamella.fluorescence_pose.objective_position
+            if lamella.fluorescence_pose is not None
+            else None
+        )
+        obj_controls_enabled = obj_pos is not None
+        if obj_controls_enabled:
+            self.set_objective_value_um(obj_pos * METRE_TO_MICRON)
+        self.label_objective_position.setVisible(obj_controls_enabled)
+        self.spinbox_objective_position.setVisible(obj_controls_enabled)
+        self.btn_objective_actions.setVisible(obj_controls_enabled)
+
+        # poses
+        self.pose_list.set_lamella(lamella)
+        self.pose_list.setVisible(bool(lamella.poses))
+
+    def refresh_pose(self, pose_name: str, pretty: str) -> None:
+        """Update one pose row's position in place, without rebuilding the list."""
+        self.pose_list.refresh_pose(pose_name, pretty)
+
+    def objective_value_um(self) -> float:
+        """Current objective spinbox value, in µm."""
+        return self.spinbox_objective_position.value()
+
+    def set_objective_value_um(self, um: float) -> None:
+        """Set the objective spinbox value (µm) without emitting a change."""
+        self.spinbox_objective_position.blockSignals(True)
+        self.spinbox_objective_position.setValue(um)
+        self.spinbox_objective_position.blockSignals(False)

--- a/fibsem/ui/widgets/selected_lamella_widget.py
+++ b/fibsem/ui/widgets/selected_lamella_widget.py
@@ -126,6 +126,10 @@ class SelectedLamellaWidget(QWidget):
         self.label_objective_position.setVisible(has_fluorescence_pose)
         self.spinbox_objective_position.setVisible(has_fluorescence_pose)
         self.btn_objective_actions.setVisible(has_fluorescence_pose)
+        # "Apply to All" copies the current value to every lamella; disable it when the
+        # objective is unset so the 0.0 placeholder cannot clobber other lamellae's focus.
+        # "Use Current Objective Position" stays enabled as the recovery path.
+        self._action_apply_obj_to_all.setEnabled(obj_pos is not None)
 
         # poses
         self.pose_list.set_lamella(lamella)

--- a/fibsem/ui/widgets/selected_lamella_widget.py
+++ b/fibsem/ui/widgets/selected_lamella_widget.py
@@ -111,18 +111,21 @@ class SelectedLamellaWidget(QWidget):
             self.pose_list.setVisible(False)
             return
 
-        # objective position (shown in µm); controls visible only when set
+        # objective position (shown in µm). The controls are shown whenever the
+        # lamella has a fluorescence pose, so the objective can still be set/restored
+        # (e.g. via "Use Current Objective Position") even when the position is unset.
+        # If it were gated on obj_pos being set, a wiped (None) objective would hide
+        # the only UI to recover it.
+        has_fluorescence_pose = lamella.fluorescence_pose is not None
         obj_pos = (
             lamella.fluorescence_pose.objective_position
-            if lamella.fluorescence_pose is not None
+            if has_fluorescence_pose
             else None
         )
-        obj_controls_enabled = obj_pos is not None
-        if obj_controls_enabled:
-            self.set_objective_value_um(obj_pos * METRE_TO_MICRON)
-        self.label_objective_position.setVisible(obj_controls_enabled)
-        self.spinbox_objective_position.setVisible(obj_controls_enabled)
-        self.btn_objective_actions.setVisible(obj_controls_enabled)
+        self.set_objective_value_um(obj_pos * METRE_TO_MICRON if obj_pos is not None else 0.0)
+        self.label_objective_position.setVisible(has_fluorescence_pose)
+        self.spinbox_objective_position.setVisible(has_fluorescence_pose)
+        self.btn_objective_actions.setVisible(has_fluorescence_pose)
 
         # poses
         self.pose_list.set_lamella(lamella)

--- a/fibsem/ui/widgets/tests/test-selected-lamella.py
+++ b/fibsem/ui/widgets/tests/test-selected-lamella.py
@@ -1,0 +1,133 @@
+"""Test script for SelectedLamellaWidget (objective + pose list)."""
+import sys
+from pathlib import Path
+
+from PyQt5.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.applications.autolamella.structures import Lamella
+from fibsem.structures import FibsemStagePosition, MicroscopeState
+from fibsem.ui.widgets.selected_lamella_widget import SelectedLamellaWidget
+
+
+def _pose(x: float, y: float, z: float, r: float = 0.0, t: float = 0.0,
+          objective: float = None) -> MicroscopeState:
+    state = MicroscopeState(
+        stage_position=FibsemStagePosition(x=x, y=y, z=z, r=r, t=t)
+    )
+    if objective is not None:
+        state.objective_position = objective
+    return state
+
+
+def _make_lamella(number: int, petname: str, with_objective: bool,
+                  with_fluorescence: bool) -> Lamella:
+    lamella = Lamella(path=Path(f"/tmp/test/{petname}"), number=number, petname=petname)
+    lamella.milling_pose = _pose(1e-3 * number, 2e-3, 3e-3, r=0.1, t=0.2)
+    if with_fluorescence:
+        # objective in metres (500 µm) when requested
+        lamella.fluorescence_pose = _pose(
+            1e-3 * number, 2e-3, 3.5e-3, objective=5e-4 if with_objective else None
+        )
+    return lamella
+
+
+SAMPLE = {
+    "A — milling + fluorescence + objective": _make_lamella(
+        1, "01-humble-molly", with_objective=True, with_fluorescence=True
+    ),
+    "B — milling + fluorescence (no objective)": _make_lamella(
+        2, "02-jolly-koala", with_objective=False, with_fluorescence=True
+    ),
+    "C — milling only": _make_lamella(
+        3, "03-brave-falcon", with_objective=False, with_fluorescence=False
+    ),
+}
+
+
+class TestWindow(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Selected Lamella Widget — Test")
+        self.setStyleSheet("background: #262930; color: #d6d6d6;")
+        self.resize(480, 360)
+
+        root = QVBoxLayout(self)
+        root.setSpacing(8)
+
+        title = QLabel("Selected Lamella — Test")
+        title.setStyleSheet("font-size: 13px; font-weight: bold; padding: 4px 6px;")
+        root.addWidget(title)
+
+        self.widget = SelectedLamellaWidget()
+        root.addWidget(self.widget)
+
+        self.log_label = QLabel("(events will appear here)")
+        self.log_label.setStyleSheet("color: #888; font-size: 11px; padding: 4px 6px;")
+        self.log_label.setWordWrap(True)
+        root.addWidget(self.log_label)
+
+        # one button per sample lamella, plus a clear-to-None button
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(6)
+        for label, lamella in SAMPLE.items():
+            btn = QPushButton(label.split(" ", 1)[0])  # "A" / "B" / "C"
+            btn.setToolTip(label)
+            btn.clicked.connect(lambda _=False, lam=lamella: self._select(lam))
+            btn_row.addWidget(btn)
+        btn_none = QPushButton("None")
+        btn_none.clicked.connect(lambda: self._select(None))
+        btn_row.addWidget(btn_none)
+        btn_row.addStretch()
+        root.addLayout(btn_row)
+
+        root.addStretch()
+
+        # log all five signals; mutate the model where the real app would
+        self.widget.objective_position_changed.connect(
+            lambda v: self._log(f"objective_position_changed: {v:.1f} µm")
+        )
+        self.widget.use_current_objective_requested.connect(
+            lambda: self._log("use_current_objective_requested")
+        )
+        self.widget.apply_objective_to_all_requested.connect(
+            lambda: self._log("apply_objective_to_all_requested")
+        )
+        self.widget.pose_update_requested.connect(self._on_pose_update)
+        self.widget.pose_move_to_requested.connect(
+            lambda name: self._log(f"pose_move_to_requested: {name}")
+        )
+
+        self._current: Lamella = None
+        self._select(SAMPLE["A — milling + fluorescence + objective"])
+
+    def _select(self, lamella) -> None:
+        self._current = lamella
+        self.widget.set_lamella(lamella)
+        self._log(f"set_lamella: {lamella.name if lamella else None}")
+
+    def _on_pose_update(self, name: str) -> None:
+        """Mimic AutoLamellaUI: store a new pose then refresh the row in place."""
+        if self._current is None:
+            return
+        new_state = _pose(9e-3, 8e-3, 7e-3)
+        self._current.poses[name] = new_state
+        self.widget.refresh_pose(name, new_state.stage_position.pretty)
+        self._log(f"pose_update_requested: {name} (refreshed in place)")
+
+    def _log(self, msg: str) -> None:
+        self.log_label.setText(msg)
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    app.setStyle("Fusion")
+    w = TestWindow()
+    w.show()
+    sys.exit(app.exec_())

--- a/tests/autolamella/test_fluorescence_pose.py
+++ b/tests/autolamella/test_fluorescence_pose.py
@@ -5,6 +5,7 @@ position was lost (reset to None or overwritten with the live objective
 position), which made the Selected Lamella objective control disappear.
 """
 import os
+import types
 from pathlib import Path
 
 import pytest
@@ -106,6 +107,29 @@ def test_update_fluorescence_pose_without_existing_pose_does_not_crash(
 
     assert lamella.fluorescence_pose is not None
     assert lamella.fluorescence_pose.objective_position is None
+
+
+def test_acquire_fluorescence_persists_autofocus_result(
+    fm_microscope: FibsemMicroscope, tmp_path: Path, monkeypatch
+) -> None:
+    """When autofocus runs, its refined objective (best_z) is saved to the pose,
+    overriding the pre-run configured value (and surviving the pose refresh)."""
+    import fibsem.applications.autolamella.workflows.tasks.acquire_fluorescence as af
+
+    refined = 0.0055  # differs from the configured value
+    assert refined != pytest.approx(CONFIGURED_OBJECTIVE)
+
+    lamella = _make_lamella(tmp_path, CONFIGURED_OBJECTIVE)
+    task = _acquire_task(fm_microscope, lamella)
+    assert task.config.autofocus_settings.fine_enabled  # default; drives the autofocus branch
+
+    # stub the heavy work: autofocus returns a known best_z, image acquisition is a no-op
+    monkeypatch.setattr(task, "_run_autofocus", lambda: types.SimpleNamespace(best_z=refined))
+    monkeypatch.setattr(af, "acquire_image", lambda **kwargs: None)
+
+    task._run()
+
+    assert lamella.fluorescence_pose.objective_position == pytest.approx(refined)
 
 
 def test_mill_coincident_requires_objective_position(

--- a/tests/autolamella/test_fluorescence_pose.py
+++ b/tests/autolamella/test_fluorescence_pose.py
@@ -1,0 +1,121 @@
+"""Tests for objective (focus) position handling in the fluorescence workflow tasks.
+
+Regression coverage for the bug where a lamella's configured objective focus
+position was lost (reset to None or overwritten with the live objective
+position), which made the Selected Lamella objective control disappear.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+import fibsem.config as fconfig
+from fibsem import utils
+from fibsem.applications.autolamella.structures import Lamella
+from fibsem.applications.autolamella.workflows.tasks.acquire_fluorescence import (
+    AcquireFluorescenceImageConfig,
+    AcquireFluorescenceImageTask,
+)
+from fibsem.applications.autolamella.workflows.tasks.mill_coincident import (
+    MillCoincidentTask,
+    MillCoincidentTaskConfig,
+)
+from fibsem.microscope import FibsemMicroscope
+from fibsem.structures import FibsemStagePosition, MicroscopeState
+
+SIM_ARCTIS_CONFIG_PATH = os.path.join(
+    fconfig.CONFIG_PATH, "sim-arctis-configuration.yaml"
+)
+
+CONFIGURED_OBJECTIVE = 0.006  # 6 mm — the user's configured focus position
+CLIP_LIMIT = 0.004            # 4 mm — forces the live objective to diverge on move
+
+
+@pytest.fixture
+def fm_microscope() -> FibsemMicroscope:
+    """A simulated microscope with a fluorescence module attached."""
+    microscope, _ = utils.setup_session(
+        config_path=SIM_ARCTIS_CONFIG_PATH, setup_logging=False
+    )
+    if microscope.fm is None:
+        pytest.skip("Fluorescence microscope not available in simulator")
+    microscope.fm._allow_unknown_orientations = True
+    return microscope
+
+
+def _make_lamella(tmp_path: Path, objective_position, with_fluorescence_pose: bool = True) -> Lamella:
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+    stage = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0, coordinate_system="RAW")
+    lamella.milling_pose = MicroscopeState(stage_position=stage)  # provides lamella.stage_position
+    if with_fluorescence_pose:
+        fp = MicroscopeState(stage_position=stage)
+        fp.objective_position = objective_position
+        lamella.fluorescence_pose = fp
+    return lamella
+
+
+def _acquire_task(microscope: FibsemMicroscope, lamella: Lamella) -> AcquireFluorescenceImageTask:
+    return AcquireFluorescenceImageTask(
+        microscope=microscope, config=AcquireFluorescenceImageConfig(), lamella=lamella
+    )
+
+
+def test_update_fluorescence_pose_preserves_configured_objective(
+    fm_microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """Refreshing the pose keeps the configured objective position, even when the
+    live objective is at a different position."""
+    # clip limit below the configured value so moving the objective diverges from it
+    fm_microscope.fm.objective._limit_position = CLIP_LIMIT
+    lamella = _make_lamella(tmp_path, CONFIGURED_OBJECTIVE)
+    task = _acquire_task(fm_microscope, lamella)
+
+    # move the live objective to a position that differs from the configured one
+    fm_microscope.fm.objective.move_absolute(CONFIGURED_OBJECTIVE)  # clips to CLIP_LIMIT
+    assert fm_microscope.fm.objective.position != pytest.approx(CONFIGURED_OBJECTIVE)
+
+    task._update_fluorescence_pose()
+
+    assert lamella.fluorescence_pose is not None
+    assert lamella.fluorescence_pose.objective_position == pytest.approx(CONFIGURED_OBJECTIVE)
+
+
+def test_update_fluorescence_pose_refreshes_stage_position(
+    fm_microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """The pose's stage position is refreshed from the current microscope state."""
+    lamella = _make_lamella(tmp_path, CONFIGURED_OBJECTIVE)
+    task = _acquire_task(fm_microscope, lamella)
+
+    task._update_fluorescence_pose()
+
+    assert lamella.fluorescence_pose.stage_position is not None
+    assert lamella.fluorescence_pose.objective_position == pytest.approx(CONFIGURED_OBJECTIVE)
+
+
+def test_update_fluorescence_pose_without_existing_pose_does_not_crash(
+    fm_microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """When no fluorescence pose exists yet, the helper sets one with a None objective
+    (rather than raising)."""
+    lamella = _make_lamella(tmp_path, None, with_fluorescence_pose=False)
+    assert lamella.fluorescence_pose is None
+    task = _acquire_task(fm_microscope, lamella)
+
+    task._update_fluorescence_pose()
+
+    assert lamella.fluorescence_pose is not None
+    assert lamella.fluorescence_pose.objective_position is None
+
+
+def test_mill_coincident_requires_objective_position(
+    fm_microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """MillCoincidentTask raises a clear ValueError (not AttributeError) when the
+    lamella has no configured objective position."""
+    lamella = _make_lamella(tmp_path, None, with_fluorescence_pose=False)
+    task = MillCoincidentTask(
+        microscope=fm_microscope, config=MillCoincidentTaskConfig(), lamella=lamella
+    )
+    with pytest.raises(ValueError, match="objective position"):
+        task._run()


### PR DESCRIPTION
## Summary

Two related pieces of work on the AutoLamella experiment tab's **Selected Lamella** panel:

1. **Refactor** — extract the panel out of the monolithic `AutoLamellaUI` into self-contained, embeddable widgets, with a table-style pose list.
2. **Bug fix** — stop the lamella's objective (focus) position from being lost, which made the objective spinbox disappear from the Selected Lamella panel with no way to restore it.

## Refactor

- **`LamellaPoseListWidget`** (new) — a table-style list of a lamella's poses: name column, pretty position column, and per-row **Update Position** / **Move to Position** icon buttons (matching the lamella list's `mdi:map-marker-check` / `mdi:crosshairs-gps` icons). Rows are selectable, pose names are formatted (`MILLING` → `Milling`), and the list is ordered **Milling → Fluorescence → rest**. A single-row in-place refresh (`refresh_pose`) updates a pose's position after saving without rebuilding the list or losing selection.

- **`SelectedLamellaWidget`** (new) — wraps the objective-position controls and the pose list inside the `Selected Lamella` `TitledPanel`. It is **view-only**: exposes `set_lamella()` / `refresh_pose()` / objective getters-setters and emits semantic signals; the handlers that touch the microscope/experiment stay in `AutoLamellaUI`.

- **`AutoLamellaUI`** — wires the widget's signals to the existing handlers. Pose handlers now take the pose name as an argument instead of reading a combobox. Removes ~158 lines of inline construction and the now-unused imports.

- **`test-selected-lamella.py`** (new) — interactive smoke harness matching the existing `test-lamella-list.py` style.

## Bug fix: objective focus position lost

The objective focus lives in `lamella.fluorescence_pose.objective_position`. Several paths quietly reset it to `None` or overwrote it, and the panel hid the objective controls whenever it was `None` — so the value disappeared and there was no UI to bring it back.

- **Fluorescence workflow tasks** re-saved the pose at the end via `get_microscope_state()` (which does not capture the objective position) and re-read the *live* objective position, overwriting the user's configured focus (the "changed to 8.00 mm" symptom). Extracted the refresh into `AutoLamellaTask._update_fluorescence_pose()`, which **preserves the configured objective position**, and used it in `acquire_fluorescence` and `select_fluorescence_position`.
- **`mill_coincident`** referenced `self.lamella.objective_position`, which does not exist on `Lamella` (it lives on `fluorescence_pose`) and raised `AttributeError` on the MILLING→FLUORESCENCE path. Now uses `fluorescence_pose.objective_position` with a proper `None` guard.
- **`_set_current_position_as_pose`** (the pose row's **Update Position** button) now preserves an existing pose's objective position, so updating the fluorescence pose's stage position no longer wipes the focus.
- **`SelectedLamellaWidget`** shows the objective controls whenever a fluorescence pose exists (not only when the position is set), so a wiped/`None` objective can still be restored via **Use Current Objective Position**.

## Testing

- All modules import cleanly and compile in the `fibsem-os` env.
- Refactor (headless): objective controls show/hide correctly, poses populate and stay sorted, the objective spinbox round-trips without spurious change signals, signals carry the right pose names, in-place pose refresh preserves row selection, and `set_lamella(None)` clears the panel.
- Bug fix — objective visibility (headless): with a fluorescence pose and objective set → controls visible; objective `None` but pose present → controls **stay** visible (recovery reachable); no lamella → hidden.
- Bug fix — workflow round-trip (sim ARCTIS): ran the real `AcquireFluorescenceImageTask` and `SelectFluorescencePositionTask` end-to-end with the objective deliberately clipped to a different live value than the configured focus. Before the fix the saved value was clobbered with the live position; after the fix the configured focus is preserved through both workflows.

## Notes

- `get_microscope_state()` was intentionally left unchanged: making it populate `objective_position` globally would cause `set_microscope_state()` to move the objective when restoring **milling** poses. The fix targets the specific wipe sites instead.
- Not yet exercised against a live microscope/experiment in the GUI; verified in widget isolation and against the simulator.