### PR TITLE
[ui] add recent experiments quick-select to load dialog

### DIFF
--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -258,11 +258,16 @@ class MovementPreferences:
     acquire_sem_after_stage_movement: bool = True
     acquire_fib_after_stage_movement: bool = True
 
+# Maximum number of recent experiments to remember for quick-select
+MAX_RECENT_EXPERIMENTS = 10
+
+
 @dataclass
 class ExperimentPreferences:
     default_experiment_directory: str = ""
     default_protocol_path: str = ""
     last_experiment_path: str = ""
+    recent_experiments: list = field(default_factory=list)
     user: str = ""
     project: str = ""
     organisation: str = ""
@@ -334,6 +339,77 @@ def save_user_preferences(preferences) -> None:
             yaml.safe_dump(data, f)
     except Exception as e:
         logging.warning(f"Failed to save user preferences to {USER_PREFERENCES_PATH}: {e}")
+
+
+@dataclass
+class RecentExperimentInfo:
+    """Display information for a recently used experiment."""
+    path: str  # path to the experiment.yaml file
+    name: str
+    created_at: float = 0.0
+    num_lamella: int = 0
+    exists: bool = True
+
+
+def _peek_experiment_yaml(experiment_yaml_path: str) -> RecentExperimentInfo:
+    """Read minimal display info from an experiment.yaml without fully loading it.
+
+    Falls back to the parent directory name if the file is missing or unreadable.
+    """
+    fallback_name = os.path.basename(os.path.dirname(experiment_yaml_path)) or experiment_yaml_path
+    if not os.path.exists(experiment_yaml_path):
+        return RecentExperimentInfo(path=experiment_yaml_path, name=fallback_name, exists=False)
+
+    try:
+        with open(experiment_yaml_path, "r") as f:
+            ddict = yaml.safe_load(f) or {}
+        return RecentExperimentInfo(
+            path=experiment_yaml_path,
+            name=ddict.get("name") or fallback_name,
+            created_at=ddict.get("created_at") or 0.0,
+            num_lamella=len(ddict.get("positions") or []),
+            exists=True,
+        )
+    except Exception as e:
+        logging.warning(f"Failed to read experiment info from {experiment_yaml_path}: {e}")
+        return RecentExperimentInfo(path=experiment_yaml_path, name=fallback_name, exists=True)
+
+
+def record_recent_experiment(experiment_yaml_path: str) -> None:
+    """Record an experiment as recently used, moving it to the front of the list.
+
+    Args:
+        experiment_yaml_path: Path to the experiment.yaml file.
+    """
+    if not experiment_yaml_path:
+        return
+
+    path = os.path.normpath(str(experiment_yaml_path))
+    prefs = load_user_preferences()
+    recent = [p for p in prefs.experiment.recent_experiments if os.path.normpath(str(p)) != path]
+    recent.insert(0, path)
+    prefs.experiment.recent_experiments = recent[:MAX_RECENT_EXPERIMENTS]
+    save_user_preferences(prefs)
+
+
+def get_recent_experiments(prune_missing: bool = True) -> "list[RecentExperimentInfo]":
+    """Return display info for recent experiments, most-recent-first.
+
+    Args:
+        prune_missing: If True, drop paths that no longer exist on disk and
+            persist the pruned list back to preferences.
+    """
+    prefs = load_user_preferences()
+    infos = [_peek_experiment_yaml(str(p)) for p in prefs.experiment.recent_experiments]
+
+    if prune_missing:
+        kept = [info for info in infos if info.exists]
+        if len(kept) != len(infos):
+            prefs.experiment.recent_experiments = [info.path for info in kept]
+            save_user_preferences(prefs)
+        return kept
+
+    return infos
 
 
 def apply_feature_flags(prefs: UserPreferences) -> None:

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -3,6 +3,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import List
 
 import yaml
 
@@ -267,7 +268,7 @@ class ExperimentPreferences:
     default_experiment_directory: str = ""
     default_protocol_path: str = ""
     last_experiment_path: str = ""
-    recent_experiments: list = field(default_factory=list)
+    recent_experiments: List[str] = field(default_factory=list)
     user: str = ""
     project: str = ""
     organisation: str = ""
@@ -349,16 +350,21 @@ class RecentExperimentInfo:
     created_at: float = 0.0
     num_lamella: int = 0
     exists: bool = True
+    available: bool = True  # False if the file is missing or could not be read
 
 
 def _peek_experiment_yaml(experiment_yaml_path: str) -> RecentExperimentInfo:
     """Read minimal display info from an experiment.yaml without fully loading it.
 
     Falls back to the parent directory name if the file is missing or unreadable.
+    A file that exists but cannot be parsed is kept (exists=True) but flagged
+    as unavailable so the UI can show it as such rather than silently pruning it.
     """
     fallback_name = os.path.basename(os.path.dirname(experiment_yaml_path)) or experiment_yaml_path
     if not os.path.exists(experiment_yaml_path):
-        return RecentExperimentInfo(path=experiment_yaml_path, name=fallback_name, exists=False)
+        return RecentExperimentInfo(
+            path=experiment_yaml_path, name=fallback_name, exists=False, available=False
+        )
 
     try:
         with open(experiment_yaml_path, "r") as f:
@@ -369,10 +375,33 @@ def _peek_experiment_yaml(experiment_yaml_path: str) -> RecentExperimentInfo:
             created_at=ddict.get("created_at") or 0.0,
             num_lamella=len(ddict.get("positions") or []),
             exists=True,
+            available=True,
         )
     except Exception as e:
         logging.warning(f"Failed to read experiment info from {experiment_yaml_path}: {e}")
-        return RecentExperimentInfo(path=experiment_yaml_path, name=fallback_name, exists=True)
+        return RecentExperimentInfo(
+            path=experiment_yaml_path, name=fallback_name, exists=True, available=False
+        )
+
+
+def add_recent_experiment(prefs: UserPreferences, experiment_yaml_path: str) -> None:
+    """Update ``prefs.experiment.recent_experiments`` in place (does not save).
+
+    Moves the path to the front, de-duplicates, and truncates to
+    ``MAX_RECENT_EXPERIMENTS``. Use this when the caller already holds a prefs
+    object it intends to save, to avoid a redundant load/save cycle.
+
+    Args:
+        prefs: The preferences object to mutate.
+        experiment_yaml_path: Path to the experiment.yaml file.
+    """
+    if not experiment_yaml_path:
+        return
+
+    path = os.path.normpath(str(experiment_yaml_path))
+    recent = [p for p in prefs.experiment.recent_experiments if os.path.normpath(str(p)) != path]
+    recent.insert(0, path)
+    prefs.experiment.recent_experiments = recent[:MAX_RECENT_EXPERIMENTS]
 
 
 def record_recent_experiment(experiment_yaml_path: str) -> None:
@@ -384,15 +413,12 @@ def record_recent_experiment(experiment_yaml_path: str) -> None:
     if not experiment_yaml_path:
         return
 
-    path = os.path.normpath(str(experiment_yaml_path))
     prefs = load_user_preferences()
-    recent = [p for p in prefs.experiment.recent_experiments if os.path.normpath(str(p)) != path]
-    recent.insert(0, path)
-    prefs.experiment.recent_experiments = recent[:MAX_RECENT_EXPERIMENTS]
+    add_recent_experiment(prefs, experiment_yaml_path)
     save_user_preferences(prefs)
 
 
-def get_recent_experiments(prune_missing: bool = True) -> "list[RecentExperimentInfo]":
+def get_recent_experiments(prune_missing: bool = True) -> List[RecentExperimentInfo]:
     """Return display info for recent experiments, most-recent-first.
 
     Args:

--- a/fibsem/ui/widgets/autolamella_create_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_create_experiment_widget.py
@@ -15,8 +15,8 @@ from fibsem.applications.autolamella.structures import (
     Experiment,
 )
 from fibsem.config import (
+    add_recent_experiment,
     load_user_preferences,
-    record_recent_experiment,
     save_user_preferences,
 )
 from fibsem.ui import utils as fui
@@ -413,13 +413,12 @@ class AutoLamellaCreateExperimentWidget(QtWidgets.QDialog):
             logging.info(f"Experiment '{experiment_name}' created successfully at {self.experiment.path}")
             logging.info(f"Protocol saved to {protocol_save_path}")
 
-            # Save last used experiment path
+            # Save last used experiment path + record in the recent quick-select
+            # list (single load/save cycle).
             prefs = load_user_preferences()
             prefs.experiment.last_experiment_path = str(self.experiment.path)
+            add_recent_experiment(prefs, os.path.join(self.experiment.path, "experiment.yaml"))
             save_user_preferences(prefs)
-
-            # Record in the recent experiments quick-select list
-            record_recent_experiment(os.path.join(self.experiment.path, "experiment.yaml"))
 
             # Accept the dialog
             self.accept()

--- a/fibsem/ui/widgets/autolamella_create_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_create_experiment_widget.py
@@ -14,7 +14,11 @@ from fibsem.applications.autolamella.structures import (
     AutoLamellaTaskProtocol,
     Experiment,
 )
-from fibsem.config import load_user_preferences, save_user_preferences
+from fibsem.config import (
+    load_user_preferences,
+    record_recent_experiment,
+    save_user_preferences,
+)
 from fibsem.ui import utils as fui
 from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
@@ -413,6 +417,9 @@ class AutoLamellaCreateExperimentWidget(QtWidgets.QDialog):
             prefs = load_user_preferences()
             prefs.experiment.last_experiment_path = str(self.experiment.path)
             save_user_preferences(prefs)
+
+            # Record in the recent experiments quick-select list
+            record_recent_experiment(os.path.join(self.experiment.path, "experiment.yaml"))
 
             # Accept the dialog
             self.accept()

--- a/fibsem/ui/widgets/autolamella_load_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_load_experiment_widget.py
@@ -2,17 +2,24 @@
 
 import logging
 import os
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from PyQt5 import QtWidgets
+from PyQt5 import QtCore, QtGui, QtWidgets
+from superqt import QIconifyIcon
 
 from fibsem.applications.autolamella import config as cfg
 from fibsem.applications.autolamella.structures import (
     AutoLamellaTaskProtocol,
     Experiment,
 )
-from fibsem.config import load_user_preferences, save_user_preferences
+from fibsem.config import (
+    get_recent_experiments,
+    load_user_preferences,
+    record_recent_experiment,
+    save_user_preferences,
+)
 from fibsem.ui import utils as fui
 from fibsem.ui.stylesheets import PRIMARY_BUTTON_STYLESHEET, SECONDARY_BUTTON_STYLESHEET
 from fibsem.ui.widgets.custom_widgets import TitledPanel
@@ -51,6 +58,69 @@ ERROR_INVALID_LEGACY_PROTOCOL_MSG = (
     "Please select a valid legacy protocol file (*.yaml)."
 )
 
+# Width of the recent-experiments quick-select column
+RECENT_COLUMN_WIDTH = 260
+
+# Recent-experiment row icons (superqt / material design icons) and colours
+RECENT_FOLDER_ICON = "mdi:folder-outline"
+RECENT_LAMELLA_ICON = "mdi:layers-triple-outline"
+RECENT_ICON_COLOR = "#9aa0ab"
+RECENT_PILL_TEXT_COLOR = "#b7bcc6"
+RECENT_NAME_COLOR = "#d6d6d6"
+
+
+class _ElidedLabel(QtWidgets.QLabel):
+    """A QLabel that elides (…) its text on the right when too narrow.
+
+    Reports a zero minimum width so it can shrink inside a layout instead of
+    forcing the row wider than the list viewport.
+    """
+
+    def __init__(self, text: str, color: str, parent=None):
+        super().__init__(text, parent)
+        self._full_text = text
+        self._color = QtGui.QColor(color)
+        self.setSizePolicy(
+            QtWidgets.QSizePolicy.Ignored, QtWidgets.QSizePolicy.Preferred
+        )
+
+    def minimumSizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(0, QtGui.QFontMetrics(self.font()).height())
+
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(0, QtGui.QFontMetrics(self.font()).height())
+
+    def paintEvent(self, event):
+        painter = QtGui.QPainter(self)
+        painter.setPen(self._color)
+        painter.setFont(self.font())
+        metrics = QtGui.QFontMetrics(self.font())
+        elided = metrics.elidedText(self._full_text, QtCore.Qt.ElideMiddle, self.width())
+        painter.drawText(
+            self.rect(), QtCore.Qt.AlignVCenter | QtCore.Qt.AlignLeft, elided
+        )
+
+RECENT_LIST_STYLESHEET = """
+QListWidget {
+    background-color: #1e2027;
+    border: 1px solid #3d4251;
+    border-radius: 4px;
+    outline: none;
+    padding: 2px;
+}
+QListWidget::item {
+    border: none;
+    border-radius: 4px;
+    margin: 1px 0px;
+}
+QListWidget::item:selected {
+    background-color: #2d72c4;
+}
+QListWidget::item:hover:!selected {
+    background-color: #2a2e39;
+}
+"""
+
 
 class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
     """Dialog for loading an existing AutoLamella experiment.
@@ -72,10 +142,11 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         self.protocol_path: Optional[str] = None
 
         self.setWindowTitle("Load Existing Experiment")
-        self.setMinimumWidth(600)
+        self.setMinimumWidth(860)
 
         self._setup_ui()
         self._connect_signals()
+        self._populate_recent_experiments()
 
     def _setup_ui(self):
         """Set up the user interface."""
@@ -86,8 +157,8 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         exp_layout = QtWidgets.QVBoxLayout(exp_content)
         exp_layout.setContentsMargins(0, 0, 0, 0)
 
-        # Select Experiment button (added to header below)
-        self.btn_select_experiment = QtWidgets.QPushButton("Select")
+        # Browse for an experiment file (placed beneath the recent list)
+        self.btn_select_experiment = QtWidgets.QPushButton("Browse…")
         self.btn_select_experiment.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
 
         # Experiment form fields (all read-only)
@@ -140,8 +211,6 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         exp_layout.addLayout(exp_form_layout)
 
         exp_group = TitledPanel("Experiment Information", content=exp_content, collapsible=False)
-        exp_group.add_header_widget(self.btn_select_experiment)
-        main_layout.addWidget(exp_group)
 
         # Protocol Information
         protocol_content = QtWidgets.QWidget()
@@ -198,7 +267,36 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         protocol_layout.addWidget(protocol_info_label)
 
         protocol_group = TitledPanel("Protocol Information", content=protocol_content, collapsible=False)
-        main_layout.addWidget(protocol_group)
+
+        # Recent Experiments quick-select (left column)
+        recent_content = QtWidgets.QWidget()
+        recent_layout = QtWidgets.QVBoxLayout(recent_content)
+        recent_layout.setContentsMargins(0, 0, 0, 0)
+
+        self.list_recent_experiments = QtWidgets.QListWidget()
+        self.list_recent_experiments.setStyleSheet(RECENT_LIST_STYLESHEET)
+        self.list_recent_experiments.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.list_recent_experiments.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        recent_layout.addWidget(self.list_recent_experiments)
+
+        # Manual browse button sits beneath the recent list
+        recent_layout.addWidget(self.btn_select_experiment)
+
+        recent_group = TitledPanel("Recent Experiments", content=recent_content, collapsible=False)
+        recent_group.setFixedWidth(RECENT_COLUMN_WIDTH)
+
+        # Right column: experiment + protocol information
+        right_column = QtWidgets.QWidget()
+        right_layout = QtWidgets.QVBoxLayout(right_column)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.addWidget(exp_group)
+        right_layout.addWidget(protocol_group)
+
+        # Assemble the two columns side by side
+        columns_layout = QtWidgets.QHBoxLayout()
+        columns_layout.addWidget(recent_group)
+        columns_layout.addWidget(right_column, stretch=1)
+        main_layout.addLayout(columns_layout)
 
         # Dialog buttons (OK/Cancel)
         button_box = QtWidgets.QDialogButtonBox()
@@ -226,6 +324,10 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         self.btn_cancel.clicked.connect(self.reject)
         self.btn_select_protocol.clicked.connect(self._select_protocol)
         self.btn_select_legacy_protocol.clicked.connect(self._select_legacy_protocol)
+        self.list_recent_experiments.itemClicked.connect(self._on_recent_experiment_clicked)
+        self.list_recent_experiments.itemDoubleClicked.connect(
+            self._on_recent_experiment_double_clicked
+        )
 
     def _select_experiment(self):
         """Open dialog to select an experiment file."""
@@ -245,7 +347,17 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         if not experiment_path or experiment_path == "":
             return
 
-        # Validate the experiment file
+        self._load_experiment_from_path(experiment_path)
+
+    def _load_experiment_from_path(self, experiment_path: str) -> bool:
+        """Load and validate an experiment from a path, updating the display.
+
+        Shared by the manual file dialog and the recent-experiments quick-select.
+
+        Returns:
+            True if the experiment was loaded (with or without a protocol),
+            False if loading failed.
+        """
         try:
             # Load the experiment
             self.experiment = Experiment.load(Path(experiment_path))
@@ -286,6 +398,8 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
             if self.experiment.task_protocol is not None:
                 self._set_protocol_buttons_visible(False)
 
+            return True
+
         except Exception as e:
             logging.error(f"Failed to load experiment: {e}")
             QtWidgets.QMessageBox.critical(
@@ -294,6 +408,7 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
                 ERROR_INVALID_EXPERIMENT_MSG.format(error=e)
             )
             self._clear_display()
+            return False
 
     def _update_experiment_display(self):
         """Update the experiment information display."""
@@ -388,8 +503,123 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         prefs.experiment.last_experiment_path = str(self.experiment.path)
         save_user_preferences(prefs)
 
+        # Record in the recent experiments quick-select list
+        record_recent_experiment(os.path.join(self.experiment.path, "experiment.yaml"))
+
         # Accept the dialog
         self.accept()
+
+    def _populate_recent_experiments(self) -> None:
+        """Populate the recent-experiments list from user preferences."""
+        self.list_recent_experiments.clear()
+
+        recents = get_recent_experiments()
+
+        if not recents:
+            placeholder = QtWidgets.QListWidgetItem("No recent experiments")
+            placeholder.setFlags(QtCore.Qt.NoItemFlags)
+            placeholder.setForeground(QtCore.Qt.gray)
+            self.list_recent_experiments.addItem(placeholder)
+            return
+
+        for info in recents:
+            item = QtWidgets.QListWidgetItem(self.list_recent_experiments)
+            item.setData(QtCore.Qt.UserRole, info.path)
+            item.setToolTip(info.path)
+            row = self._make_recent_row_widget(info)
+            # Width 0 lets the row track the list viewport width instead of the
+            # row's (wide) content hint, so long names elide rather than clip.
+            item.setSizeHint(QtCore.QSize(0, row.sizeHint().height()))
+            self.list_recent_experiments.addItem(item)
+            self.list_recent_experiments.setItemWidget(item, row)
+
+    def _make_recent_row_widget(self, info) -> QtWidgets.QWidget:
+        """Build a row widget for a recent experiment.
+
+        Layout: folder icon | name + date (stacked) | lamella-count pill.
+        """
+        widget = QtWidgets.QWidget()
+        layout = QtWidgets.QHBoxLayout(widget)
+        layout.setContentsMargins(10, 11, 8, 11)
+        layout.setSpacing(9)
+
+        # Leading folder icon
+        folder_label = QtWidgets.QLabel()
+        folder_label.setPixmap(
+            QIconifyIcon(RECENT_FOLDER_ICON, color=RECENT_ICON_COLOR).pixmap(18, 18)
+        )
+        folder_label.setFixedWidth(18)
+        layout.addWidget(folder_label, alignment=QtCore.Qt.AlignVCenter)
+
+        # Name + date (stacked)
+        text_layout = QtWidgets.QVBoxLayout()
+        text_layout.setContentsMargins(0, 0, 0, 0)
+        text_layout.setSpacing(5)
+
+        name_label = _ElidedLabel(info.name, RECENT_NAME_COLOR)
+        name_font = name_label.font()
+        name_font.setPixelSize(13)
+        name_font.setWeight(QtGui.QFont.DemiBold)
+        name_label.setFont(name_font)
+        name_label.setToolTip(info.name)
+
+        if info.created_at:
+            date_str = datetime.fromtimestamp(info.created_at).strftime("%Y-%m-%d")
+        else:
+            date_str = "unknown date"
+        date_label = QtWidgets.QLabel(date_str)
+        date_label.setStyleSheet("color: #8a8f99; font-size: 11px; background: transparent;")
+
+        text_layout.addWidget(name_label)
+        text_layout.addWidget(date_label)
+        layout.addLayout(text_layout, stretch=1)
+
+        # Trailing lamella-count pill
+        layout.addWidget(
+            self._make_lamella_pill(info.num_lamella), alignment=QtCore.Qt.AlignVCenter
+        )
+        return widget
+
+    def _make_lamella_pill(self, num_lamella: int) -> QtWidgets.QWidget:
+        """Build a small rounded pill showing a layers icon and the lamella count."""
+        pill = QtWidgets.QFrame()
+        pill.setObjectName("lamellaPill")
+        pill.setStyleSheet("#lamellaPill { background: #2a2e39; border-radius: 9px; }")
+
+        pill_layout = QtWidgets.QHBoxLayout(pill)
+        pill_layout.setContentsMargins(7, 2, 8, 2)
+        pill_layout.setSpacing(3)
+
+        icon_label = QtWidgets.QLabel()
+        icon_label.setPixmap(
+            QIconifyIcon(RECENT_LAMELLA_ICON, color=RECENT_PILL_TEXT_COLOR).pixmap(12, 12)
+        )
+        count_label = QtWidgets.QLabel(str(num_lamella))
+        count_label.setStyleSheet(
+            f"color: {RECENT_PILL_TEXT_COLOR}; font-size: 11px; "
+            "font-weight: 600; background: transparent;"
+        )
+
+        pill_layout.addWidget(icon_label)
+        pill_layout.addWidget(count_label)
+        return pill
+
+    def _on_recent_experiment_clicked(self, item: QtWidgets.QListWidgetItem) -> None:
+        """Load the selected recent experiment into the form (single click)."""
+        path = item.data(QtCore.Qt.UserRole)
+        if not path:
+            return
+        self._load_experiment_from_path(path)
+
+    def _on_recent_experiment_double_clicked(self, item: QtWidgets.QListWidgetItem) -> None:
+        """Load the selected recent experiment and accept immediately (double click)."""
+        path = item.data(QtCore.Qt.UserRole)
+        if not path:
+            return
+        if self._load_experiment_from_path(path):
+            # Only accept if the experiment loaded with a valid protocol
+            if self.experiment is not None and self.experiment.task_protocol is not None:
+                self._on_ok_clicked()
 
     def get_experiment(self) -> Optional[Experiment]:
         """Return the loaded experiment, or None if cancelled."""

--- a/fibsem/ui/widgets/autolamella_load_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_load_experiment_widget.py
@@ -21,7 +21,11 @@ from fibsem.config import (
     save_user_preferences,
 )
 from fibsem.ui import utils as fui
-from fibsem.ui.stylesheets import PRIMARY_BUTTON_STYLESHEET, SECONDARY_BUTTON_STYLESHEET
+from fibsem.ui.stylesheets import (
+    PRIMARY_BUTTON_STYLESHEET,
+    PRIMARY_COLOR_PRESSED,
+    SECONDARY_BUTTON_STYLESHEET,
+)
 from fibsem.ui.widgets.custom_widgets import TitledPanel
 
 # Error message constants
@@ -64,9 +68,12 @@ RECENT_COLUMN_WIDTH = 260
 # Recent-experiment row icons (superqt / material design icons) and colours
 RECENT_FOLDER_ICON = "mdi:folder-outline"
 RECENT_LAMELLA_ICON = "mdi:layers-triple-outline"
+RECENT_ALERT_ICON = "mdi:alert-circle-outline"
 RECENT_ICON_COLOR = "#9aa0ab"
 RECENT_PILL_TEXT_COLOR = "#b7bcc6"
 RECENT_NAME_COLOR = "#d6d6d6"
+# Muted colour for rows whose experiment.yaml is missing or unreadable
+RECENT_UNAVAILABLE_COLOR = "#6b6b6b"
 
 
 class _ElidedLabel(QtWidgets.QLabel):
@@ -100,25 +107,25 @@ class _ElidedLabel(QtWidgets.QLabel):
             self.rect(), QtCore.Qt.AlignVCenter | QtCore.Qt.AlignLeft, elided
         )
 
-RECENT_LIST_STYLESHEET = """
-QListWidget {
+RECENT_LIST_STYLESHEET = f"""
+QListWidget {{
     background-color: #1e2027;
     border: 1px solid #3d4251;
     border-radius: 4px;
     outline: none;
     padding: 2px;
-}
-QListWidget::item {
+}}
+QListWidget::item {{
     border: none;
     border-radius: 4px;
     margin: 1px 0px;
-}
-QListWidget::item:selected {
-    background-color: #2d72c4;
-}
-QListWidget::item:hover:!selected {
+}}
+QListWidget::item:selected {{
+    background-color: {PRIMARY_COLOR_PRESSED};
+}}
+QListWidget::item:hover:!selected {{
     background-color: #2a2e39;
-}
+}}
 """
 
 
@@ -349,10 +356,18 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
 
         self._load_experiment_from_path(experiment_path)
 
-    def _load_experiment_from_path(self, experiment_path: str) -> bool:
+    def _load_experiment_from_path(
+        self, experiment_path: str, warn_on_missing_protocol: bool = True
+    ) -> bool:
         """Load and validate an experiment from a path, updating the display.
 
         Shared by the manual file dialog and the recent-experiments quick-select.
+
+        Args:
+            experiment_path: Path to the experiment.yaml file to load.
+            warn_on_missing_protocol: If True, pop a modal warning when the
+                experiment has no task protocol. Suppressed for the lightweight
+                single-click preview so browsing the recent list stays quiet.
 
         Returns:
             True if the experiment was loaded (with or without a protocol),
@@ -378,13 +393,14 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
                 logging.info(f"Protocol loaded successfully from {protocol_path}")
             else:
                 # Protocol missing; keep experiment loaded so user can reattach one
-                QtWidgets.QMessageBox.warning(
-                    self,
-                    ERROR_PROTOCOL_NOT_FOUND_TITLE,
-                    ERROR_PROTOCOL_NOT_FOUND_MSG.format(experiment_dir=experiment_dir)
-                    + "\n\nThe experiment has been loaded without a task protocol. "
-                      "Please load a protocol before continuing."
-                )
+                if warn_on_missing_protocol:
+                    QtWidgets.QMessageBox.warning(
+                        self,
+                        ERROR_PROTOCOL_NOT_FOUND_TITLE,
+                        ERROR_PROTOCOL_NOT_FOUND_MSG.format(experiment_dir=experiment_dir)
+                        + "\n\nThe experiment has been loaded without a task protocol. "
+                          "Please load a protocol before continuing."
+                    )
                 self.protocol_path = None
                 self.btn_ok.setEnabled(False)
                 self._set_protocol_buttons_visible(True)
@@ -525,7 +541,13 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         for info in recents:
             item = QtWidgets.QListWidgetItem(self.list_recent_experiments)
             item.setData(QtCore.Qt.UserRole, info.path)
-            item.setToolTip(info.path)
+            # Unavailable rows (unreadable experiment.yaml) are shown greyed out
+            # and made non-interactive so a click can't try to load them.
+            if not info.available:
+                item.setFlags(QtCore.Qt.NoItemFlags)
+                item.setToolTip(f"{info.path}\n\nThis experiment could not be read.")
+            else:
+                item.setToolTip(info.path)
             row = self._make_recent_row_widget(info)
             # Width 0 lets the row track the list viewport width instead of the
             # row's (wide) content hint, so long names elide rather than clip.
@@ -537,16 +559,23 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         """Build a row widget for a recent experiment.
 
         Layout: folder icon | name + date (stacked) | lamella-count pill.
+        Rows whose experiment.yaml is missing or unreadable (``not
+        info.available``) are rendered muted with an alert icon and no pill.
         """
+        available = getattr(info, "available", True)
+        icon_color = RECENT_ICON_COLOR if available else RECENT_UNAVAILABLE_COLOR
+        name_color = RECENT_NAME_COLOR if available else RECENT_UNAVAILABLE_COLOR
+
         widget = QtWidgets.QWidget()
         layout = QtWidgets.QHBoxLayout(widget)
         layout.setContentsMargins(10, 11, 8, 11)
         layout.setSpacing(9)
 
-        # Leading folder icon
+        # Leading icon (folder, or an alert marker when unavailable)
+        icon_name = RECENT_FOLDER_ICON if available else RECENT_ALERT_ICON
         folder_label = QtWidgets.QLabel()
         folder_label.setPixmap(
-            QIconifyIcon(RECENT_FOLDER_ICON, color=RECENT_ICON_COLOR).pixmap(18, 18)
+            QIconifyIcon(icon_name, color=icon_color).pixmap(18, 18)
         )
         folder_label.setFixedWidth(18)
         layout.addWidget(folder_label, alignment=QtCore.Qt.AlignVCenter)
@@ -556,28 +585,34 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         text_layout.setContentsMargins(0, 0, 0, 0)
         text_layout.setSpacing(5)
 
-        name_label = _ElidedLabel(info.name, RECENT_NAME_COLOR)
+        name_label = _ElidedLabel(info.name, name_color)
         name_font = name_label.font()
         name_font.setPixelSize(13)
         name_font.setWeight(QtGui.QFont.DemiBold)
         name_label.setFont(name_font)
         name_label.setToolTip(info.name)
 
-        if info.created_at:
+        if not available:
+            date_str = "unavailable"
+        elif info.created_at:
             date_str = datetime.fromtimestamp(info.created_at).strftime("%Y-%m-%d")
         else:
             date_str = "unknown date"
+        date_color = "#8a8f99" if available else RECENT_UNAVAILABLE_COLOR
         date_label = QtWidgets.QLabel(date_str)
-        date_label.setStyleSheet("color: #8a8f99; font-size: 11px; background: transparent;")
+        date_label.setStyleSheet(
+            f"color: {date_color}; font-size: 11px; background: transparent;"
+        )
 
         text_layout.addWidget(name_label)
         text_layout.addWidget(date_label)
         layout.addLayout(text_layout, stretch=1)
 
-        # Trailing lamella-count pill
-        layout.addWidget(
-            self._make_lamella_pill(info.num_lamella), alignment=QtCore.Qt.AlignVCenter
-        )
+        # Trailing lamella-count pill (omitted for unavailable rows)
+        if available:
+            layout.addWidget(
+                self._make_lamella_pill(info.num_lamella), alignment=QtCore.Qt.AlignVCenter
+            )
         return widget
 
     def _make_lamella_pill(self, num_lamella: int) -> QtWidgets.QWidget:
@@ -605,11 +640,15 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         return pill
 
     def _on_recent_experiment_clicked(self, item: QtWidgets.QListWidgetItem) -> None:
-        """Load the selected recent experiment into the form (single click)."""
+        """Load the selected recent experiment into the form (single click).
+
+        A single click is a lightweight preview, so a missing protocol does not
+        pop a modal warning here; it surfaces on the OK / double-click commit.
+        """
         path = item.data(QtCore.Qt.UserRole)
         if not path:
             return
-        self._load_experiment_from_path(path)
+        self._load_experiment_from_path(path, warn_on_missing_protocol=False)
 
     def _on_recent_experiment_double_clicked(self, item: QtWidgets.QListWidgetItem) -> None:
         """Load the selected recent experiment and accept immediately (double click)."""

--- a/tests/test_recent_experiments.py
+++ b/tests/test_recent_experiments.py
@@ -1,0 +1,141 @@
+"""Tests for the recent-experiments quick-select config helpers."""
+
+import os
+
+import pytest
+import yaml
+
+from fibsem import config as cfg
+
+
+@pytest.fixture
+def prefs_env(tmp_path, monkeypatch):
+    """Point the preferences helpers at an isolated temp file."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_dir))
+    monkeypatch.setattr(cfg, "USER_PREFERENCES_PATH", str(config_dir / "user-preferences.yaml"))
+    return tmp_path
+
+
+def _write_experiment(dir_path, name="exp", created_at=1000.0, num_positions=0) -> str:
+    """Create an experiment.yaml on disk and return its path."""
+    os.makedirs(dir_path, exist_ok=True)
+    yaml_path = os.path.join(dir_path, "experiment.yaml")
+    with open(yaml_path, "w") as f:
+        yaml.safe_dump(
+            {
+                "name": name,
+                "created_at": created_at,
+                "positions": [{"id": i} for i in range(num_positions)],
+            },
+            f,
+        )
+    return yaml_path
+
+
+def test_record_persists_and_dedups_most_recent_first(prefs_env):
+    a = _write_experiment(prefs_env / "a")
+    b = _write_experiment(prefs_env / "b")
+
+    cfg.record_recent_experiment(a)
+    cfg.record_recent_experiment(b)
+    cfg.record_recent_experiment(a)  # re-record moves a back to front
+
+    recent = cfg.load_user_preferences().experiment.recent_experiments
+    assert recent == [os.path.normpath(a), os.path.normpath(b)]
+
+
+def test_record_truncates_to_max(prefs_env):
+    for i in range(cfg.MAX_RECENT_EXPERIMENTS + 5):
+        cfg.record_recent_experiment(_write_experiment(prefs_env / f"e{i}"))
+
+    recent = cfg.load_user_preferences().experiment.recent_experiments
+    assert len(recent) == cfg.MAX_RECENT_EXPERIMENTS
+    # Most recently recorded is first
+    assert recent[0] == os.path.normpath(str(prefs_env / f"e{cfg.MAX_RECENT_EXPERIMENTS + 4}" / "experiment.yaml"))
+
+
+def test_record_ignores_empty_path(prefs_env):
+    cfg.record_recent_experiment("")
+    assert cfg.load_user_preferences().experiment.recent_experiments == []
+
+
+def test_peek_reads_display_metadata(prefs_env):
+    path = _write_experiment(prefs_env / "meta", name="cool-experiment", created_at=1234.0, num_positions=3)
+    info = cfg._peek_experiment_yaml(path)
+    assert info.name == "cool-experiment"
+    assert info.created_at == 1234.0
+    assert info.num_lamella == 3
+    assert info.exists is True
+    assert info.available is True
+
+
+def test_peek_missing_file(prefs_env):
+    path = str(prefs_env / "gone" / "experiment.yaml")
+    info = cfg._peek_experiment_yaml(path)
+    assert info.exists is False
+    assert info.available is False
+    assert info.name == "gone"  # falls back to parent dir name
+
+
+def test_peek_corrupt_file_is_unavailable_but_exists(prefs_env):
+    dir_path = prefs_env / "corrupt"
+    os.makedirs(dir_path)
+    yaml_path = os.path.join(dir_path, "experiment.yaml")
+    with open(yaml_path, "w") as f:
+        f.write("{ this is: not: valid yaml ]")
+
+    info = cfg._peek_experiment_yaml(yaml_path)
+    assert info.exists is True       # kept, not silently pruned
+    assert info.available is False   # flagged so the UI can grey it out
+
+
+def test_get_recent_prunes_missing_and_persists(prefs_env):
+    good = _write_experiment(prefs_env / "good")
+    missing = str(prefs_env / "missing" / "experiment.yaml")
+    cfg.record_recent_experiment(good)
+    cfg.record_recent_experiment(missing)
+
+    infos = cfg.get_recent_experiments(prune_missing=True)
+
+    assert [i.path for i in infos] == [os.path.normpath(good)]
+    # Pruned list was persisted back to disk
+    assert cfg.load_user_preferences().experiment.recent_experiments == [os.path.normpath(good)]
+
+
+def test_get_recent_keeps_corrupt_entries(prefs_env):
+    dir_path = prefs_env / "corrupt"
+    os.makedirs(dir_path)
+    yaml_path = os.path.join(dir_path, "experiment.yaml")
+    with open(yaml_path, "w") as f:
+        f.write(": : :")
+    cfg.record_recent_experiment(yaml_path)
+
+    infos = cfg.get_recent_experiments(prune_missing=True)
+
+    assert len(infos) == 1
+    assert infos[0].available is False
+    # corrupt-but-present entry is not pruned from preferences
+    assert cfg.load_user_preferences().experiment.recent_experiments == [os.path.normpath(yaml_path)]
+
+
+def test_add_recent_experiment_mutates_without_saving(prefs_env):
+    prefs = cfg.load_user_preferences()
+    a = _write_experiment(prefs_env / "a")
+
+    cfg.add_recent_experiment(prefs, a)
+
+    assert prefs.experiment.recent_experiments == [os.path.normpath(a)]
+    # Nothing was written to disk (no save called)
+    assert not os.path.exists(cfg.USER_PREFERENCES_PATH)
+
+
+def test_backward_compat_missing_key(prefs_env):
+    # Legacy prefs file without the recent_experiments key
+    with open(cfg.USER_PREFERENCES_PATH, "w") as f:
+        yaml.safe_dump({"experiment": {"user": "someone"}}, f)
+
+    prefs = cfg.load_user_preferences()
+    assert prefs.experiment.user == "someone"
+    assert prefs.experiment.recent_experiments == []


### PR DESCRIPTION
Linear: [FIB-245](https://linear.app/fibsemos/issue/FIB-245/ui-recent-experiments-quick-select-in-load-dialog)

## Summary

Adds a **Recent Experiments** quick-select to the AutoLamella *Load Existing Experiment* dialog. The app now remembers the last 10 experiments created or loaded and shows them as a clickable list, so users can reopen a recent experiment in one click instead of navigating the file dialog every time.

## Changes

**`fibsem/config.py`**
- New `ExperimentPreferences.recent_experiments` field + `MAX_RECENT_EXPERIMENTS = 10`.
- `record_recent_experiment(path)` — dedups, moves-to-front, truncates to 10, persists to `user-preferences.yaml`.
- `get_recent_experiments()` — returns display info (name, created date, lamella count) by peeking each `experiment.yaml`; prunes paths that no longer exist on disk.
- Backward compatible with existing preference files (missing key → empty list).

**`fibsem/ui/widgets/autolamella_load_experiment_widget.py`**
- Two-column layout: a **Recent Experiments** list on the left, the existing Experiment/Protocol panels on the right.
- Each row: folder icon, middle-elided name (full name on hover), date, and a lamella-count pill. Icons via `superqt.QIconifyIcon` to match the rest of the app.
- Single-click loads into the form; double-click loads and accepts.
- Refactored the load logic into a shared `_load_experiment_from_path()` used by both the browse dialog and the recent list.
- Empty state shows a "No recent experiments" placeholder; the manual **Browse…** button remains.

**`fibsem/ui/widgets/autolamella_create_experiment_widget.py`**
- Records the experiment in the recent list on successful create.

## Testing

- Unit-level checks of the config helpers: dedup / most-recent-first ordering, metadata peek, truncate-to-10, prune-missing + persist, and legacy-prefs backward compatibility.
- Dialog constructed and populated offscreen (rows render, icons resolve, names elide correctly at the column width, count pill visible).
- Verified live in the running app.
