### PR TITLE
[ui] Unify GUI background threading onto FunctionWorker

### DIFF
--- a/docs/design/thread-worker-removal.md
+++ b/docs/design/thread-worker-removal.md
@@ -1,0 +1,129 @@
+# Unifying GUI background threading
+
+The PyQt5 GUI runs microscope operations off the GUI thread with **two competing patterns**,
+and this change unifies them onto one small wrapper — `fibsem/ui/qt/threading.py`
+`FunctionWorker`. A third pattern (a hand-rolled `QThread` subclass) already does the right
+thing and is left alone.
+
+1. **napari `@thread_worker`** — `napari.qt.threading.thread_worker` is one of the last hard
+   napari dependencies in the quad-view control widgets.
+2. **manual `threading.Thread`** — raw threads, some fire-and-forget, some stored on the widget
+   for lifecycle (`self._acquisition_thread`, polled via `.is_alive()` / `.join()`).
+
+Both reduce to the same need: *run a function on a background thread, then deliver its outcome
+back on the GUI thread* — plus, for the stored ones, *let the widget observe and join it*. That
+is a small thing to reproduce without napari.
+
+## The wrapper — `fibsem/ui/qt/threading.py`
+
+A `FunctionWorker(QObject)` plus a drop-in `@thread_worker` decorator.
+
+```python
+class FunctionWorker(QObject):
+    started  = pyqtSignal()
+    returned = pyqtSignal(object)   # result, on success only
+    errored  = pyqtSignal(object)   # exception, on failure only (also logged)
+    finished = pyqtSignal()         # always, after returned/errored
+
+    def start(self): ...            # daemon thread; self-registers in _ACTIVE_WORKERS
+    def is_alive(self) -> bool: ... # threading.Thread parity, for stored-thread sites
+    def join(self, timeout=None): ...
+```
+
+Because the worker is a `QObject` built on the calling (GUI) thread, emitting its completion
+signals *from the worker thread* makes Qt deliver them through the GUI event loop — exactly how
+napari's `WorkerBase` behaves, so **signal-delivery threading is unchanged at every call site**.
+
+### Why it's a faithful drop-in for both patterns
+
+- **napari sites** — `.started/.returned/.errored/.finished` mirror the napari names, delivered
+  on the GUI thread. `finished` always fires after `returned`/`errored`. Migration is a one-line
+  import swap; call sites are untouched:
+  ```python
+  # from napari.qt.threading import thread_worker
+  from fibsem.ui.qt.threading import thread_worker
+  ```
+- **stored-thread sites** — `FunctionWorker` also exposes the slice of the `threading.Thread`
+  API those widgets use (`start` / `is_alive` / `join`), so `self._acquisition_thread` can hold a
+  `FunctionWorker` with **no change** to the `is_acquiring` property, the `cancel_*` join, or the
+  `closeEvent` join. Cancellation stays **widget-owned**: the widget keeps its own
+  `threading.Event`, sets it, then `join(timeout=)`s the body out. The worker only needs to be
+  *observable*, not to own the stop signal.
+- **Liveness** — call sites keep only a local `worker = self.x_worker(...)`, GC'd the moment the
+  method returns. `_ACTIVE_WORKERS` holds a strong reference until `finished` (napari keeps its
+  own registry for the same reason).
+- **Errors never swallowed** — the body's exception is `logging.exception`-logged before
+  `.errored`, so sites that don't connect `.errored` still surface failures.
+
+Intentionally *not* implemented: generators / `.yielded` / pause / abort /
+`@thread_worker(connect=...)`. None are used; a generator body or `connect=` kwarg fails loudly.
+
+## The map — what changes, what doesn't
+
+### A1 — napari `thread_worker`, napari-free win (import swap)
+
+| File | Workers | Signals |
+|---|---|---|
+| `FibsemImageSettingsWidget.py` | autocontrast, autofocus, acquisition | `.finished` |
+| `FibsemMovementWidget.py` | absolute move, double-click, orientation | `.finished` |
+| `FibsemSpotBurnWidget.py` | spot burn | `.returned` / `.errored` |
+
+All plain (non-generator) bodies; progress reported through each widget's own `pyqtSignal`s.
+`FibsemSpotBurnWidget` already imports **both** `FunctionWorker` and `thread_worker` from napari
+and is already in returned/errored shape — so it too is a plain import swap (the wrapper exports
+both names).
+
+### B1 — manual `threading.Thread`, fire-and-forget
+
+`fluorescence_coincidence_viewer_widget.py` (×7): move-to-lamella, FIB/FM acquire, FIB
+autocontrast/autofocus, two double-click stage moves. Each becomes `FunctionWorker(body)` with
+its slots connected to `returned`/`finished`. **Fix in passing:** the autocontrast and autofocus
+bodies mutate a button (`btn.setText(...)`) from the worker thread in a `finally` block — that
+moves into a slot on `finished`, where it belongs.
+
+### B2 — manual `threading.Thread`, stored + cancel/lifecycle
+
+These store the thread and poll `.is_alive()` / `.join(timeout=5)` on cancel and close. Swapping
+the stored `threading.Thread` for a `FunctionWorker` leaves those call sites unchanged.
+
+| File | Sites | Lifecycle surface |
+|---|---|---|
+| `FMAcquisitionWidget.py` | stage move, image, overview, autofocus (shared `_acquisition_thread`) | `is_acquiring` (`is_alive`), `cancel_acquisition` (`join`), `closeEvent` (`join`); `_acquisition_stop_event` propagated into the blocking call |
+| `fluorescence_control_widget.py` | image, autofocus | `is_acquiring`, `cancel_acquisition` |
+| `FibsemMinimapWidget.py` | tile collection | returns a result dict → natural `.returned`; `tile_collection_finished(result)` |
+| `milling_widget.py` | milling | `is_milling`, `_milling_stop_event`; `finally` → `finished` slot |
+| `AutoLamellaUI.py` | task worker | `is_workflow_running`, `_workflow_stop_event`, `_workflow_finished_signal(bool)` |
+
+### Out of scope
+
+- **Deferred napari trio** — `FibsemSegmentationModelWidget`, `FibsemModelTrainingWidget`,
+  `correlation/ui/fm_import_wizard`. They still import `napari.qt.threading`, but their bodies use
+  `self.viewer` / `napari.utils.notifications`, so removing `thread_worker` there buys no
+  napari-free win. Same one-line swap when those widgets are otherwise de-napari'd.
+- **Backend / non-GUI threads** — `microscope.py`, `fm/microscope.py` (emit `psygnal.Signal`, not
+  `pyqtSignal`; driver-level), `tools/_streamlit.py` (subprocess launcher), `workflows/tasks/
+  hooks.py` (fire-and-forget webhook). These belong to the non-GUI orchestration layer, not the
+  GUI-responsiveness concern this wrapper addresses.
+- **`lamella_task_image_widget._ImageLoaderWorker(QThread)`** — a third pattern, already correct
+  (`pyqtSignal` + `cancel()`/`quit()`/`wait()`). Could fold onto `FunctionWorker` later; no need.
+
+## Slices
+
+- **T0 — wrapper + unit test.** `fibsem/ui/qt/threading.py` + `test_qt_threading.py` (success
+  delivers on the main thread while the body runs off it; error emits `errored` + `finished` but
+  not `returned`; a worker with no surviving local ref is not GC'd mid-run; `is_alive`/`join`
+  mirror `threading.Thread` for the stored-thread cancel path).
+- **T1 — A1.** Import swap in `FibsemImageSettingsWidget`, `FibsemMovementWidget`,
+  `FibsemSpotBurnWidget` + a migration test driving a real worker against a Demo microscope.
+- **T2 — B1.** `fluorescence_coincidence_viewer_widget` ×7, incl. the `setText`-in-`finally` fix.
+- **T3 — B2.** The stored-thread sites, one file per commit.
+- **T5 — verify.** Full `fibsem/ui/widgets/tests` suite green.
+
+## Risks / watch-items
+
+- **Lambda-slot threading** — relies on Qt delivering even lambda `.finished` slots on the GUI
+  thread when the sender lives there; the same assumption napari already makes at those sites.
+- **Toasts from worker threads** (a couple of pre-existing spots) — unchanged; the body already
+  ran off-thread under napari / the raw thread.
+- **Double-log on error** for sites that also log in their `.errored` handler — acceptable,
+  strictly more information.

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -56,6 +56,7 @@ from PyQt5.QtWidgets import (
     QTabWidget,
     QWidget,
 )
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.widgets.custom_widgets import LamellaNameListWidget
 from fibsem.ui.widgets.selected_lamella_widget import SelectedLamellaWidget
 
@@ -210,7 +211,7 @@ class AutoLamellaUI(QMainWindow):
         self.SELECTED_POI: Optional[Point] = None
         self._poi_layer = None
         self._workflow_stop_event: threading.Event = threading.Event()
-        self._task_worker_thread: Optional[threading.Thread] = None
+        self._task_worker_thread: Optional[FunctionWorker] = None
         self._task_manager: Optional[TaskManager] = None
         self._last_run_summary: Optional["pd.DataFrame"] = None
 
@@ -966,10 +967,8 @@ class AutoLamellaUI(QMainWindow):
         self.milling_task_config_widget.clear()  # type: ignore
 
         # Start acquisition thread
-        self._task_worker_thread = threading.Thread(
-            target=self._run_tasks_worker,
-            args=(selected_tasks, selected_lamella),
-            daemon=True,
+        self._task_worker_thread = FunctionWorker(
+            self._run_tasks_worker, selected_tasks, selected_lamella
         )
         self._task_worker_thread.start()
 

--- a/fibsem/ui/FMAcquisitionWidget.py
+++ b/fibsem/ui/FMAcquisitionWidget.py
@@ -85,6 +85,7 @@ from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
 )
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.widgets.custom_widgets import LamellaNameListWidget, TitledPanel
 from fibsem.utils import format_duration
 
@@ -387,7 +388,7 @@ class FMAcquisitionWidget(QWidget):
         self.histogramWidget: HistogramWidget
 
         # Consolidated acquisition threading
-        self._acquisition_thread: Optional[threading.Thread] = None
+        self._acquisition_thread: Optional[FunctionWorker] = None
         self._acquisition_stop_event = threading.Event()
         self._current_acquisition_type: Optional[str] = None
 
@@ -889,10 +890,8 @@ class FMAcquisitionWidget(QWidget):
         self._update_acquisition_button_states()
         self._acquisition_stop_event.clear()
 
-        self._acquisition_thread = threading.Thread(
-            target=self._stage_movement_worker,
-            args=(stage_position, objective_position),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._stage_movement_worker, stage_position, objective_position
         )
         self._acquisition_thread.start()
 
@@ -1869,10 +1868,8 @@ class FMAcquisitionWidget(QWidget):
             z_parameters = settings["z_parameters"]
 
         # Start acquisition thread
-        self._acquisition_thread = threading.Thread(
-            target=self._image_acquistion_worker,
-            args=(channel_settings, z_parameters),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._image_acquistion_worker, channel_settings, z_parameters
         )
         self._acquisition_thread.start()
 
@@ -2011,16 +2008,13 @@ class FMAcquisitionWidget(QWidget):
         positions = None  # self.experiment.positions
 
         # Start acquisition thread
-        self._acquisition_thread = threading.Thread(
-            target=self._overview_worker,
-            args=(
-                channel_settings,
-                overview_parameters,
-                z_parameters,
-                autofocus_settings,
-                positions,
-            ),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._overview_worker,
+            channel_settings,
+            overview_parameters,
+            z_parameters,
+            autofocus_settings,
+            positions,
         )
         self._acquisition_thread.start()
 
@@ -2172,10 +2166,8 @@ class FMAcquisitionWidget(QWidget):
         z_parameters = settings["z_parameters"]
 
         # Start auto-focus thread
-        self._acquisition_thread = threading.Thread(
-            target=self._autofocus_worker,
-            args=(channel_settings, z_parameters),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._autofocus_worker, channel_settings, z_parameters
         )
         self._acquisition_thread.start()
 

--- a/fibsem/ui/FibsemImageSettingsWidget.py
+++ b/fibsem/ui/FibsemImageSettingsWidget.py
@@ -6,7 +6,6 @@ import numpy as np
 from napari.layers import Image as NapariImageLayer
 from napari.layers import Points as NapariPointLayer
 from napari.layers import Shapes as NapariShapesLayer
-from napari.qt.threading import thread_worker
 from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtCore import QEvent, pyqtSignal
 from superqt import QIconifyIcon, ensure_main_thread
@@ -23,6 +22,7 @@ from fibsem.structures import (
 )
 from fibsem.ui import stylesheets as stylesheets
 from fibsem.ui import notification_service
+from fibsem.ui.qt.threading import thread_worker
 from fibsem.ui.napari.patterns import (
     convert_reduced_area_to_napari_shape,
     convert_shape_to_image_area,

--- a/fibsem/ui/FibsemImageSettingsWidget.py
+++ b/fibsem/ui/FibsemImageSettingsWidget.py
@@ -79,6 +79,7 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         self.alignment_layer: Optional[NapariShapesLayer] = None
 
         self.is_acquiring: bool = False
+        self._auto_function_error: Optional[Exception] = None
         self._ruler_enabled: bool = False
 
         self._setup_ui()
@@ -425,7 +426,9 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         """Run autocontrast for the selected beam type."""
         beam_type = self.dual_beam_widget.beam_type
         self._toggle_interactions(enable=False)
+        self._auto_function_error = None
         worker = self._autocontrast_worker(beam_type)
+        worker.errored.connect(self._on_auto_function_errored)
         worker.finished.connect(lambda: self._on_auto_function_finished("AutoContrast", beam_type=beam_type))
         worker.start()
 
@@ -433,7 +436,9 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         """Run autofocus for the selected beam type."""
         beam_type = self.dual_beam_widget.beam_type
         self._toggle_interactions(enable=False)
+        self._auto_function_error = None
         worker = self._autofocus_worker(beam_type)
+        worker.errored.connect(self._on_auto_function_errored)
         worker.finished.connect(lambda: self._on_auto_function_finished("AutoFocus", beam_type=beam_type))
         worker.start()
 
@@ -445,10 +450,23 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
     def _autofocus_worker(self, beam_type: BeamType):
         self.microscope.auto_focus(beam_type, reduced_area=FibsemRectangle(left=0.25, top=0.25, width=0.5, height=0.5))
 
+    def _on_auto_function_errored(self, exc: Exception) -> None:
+        """Record a background auto-function failure.
+
+        The user-facing toast is shown in ``_on_auto_function_finished`` (which
+        runs after ``sync_from_microscope``); ``errored`` is delivered before
+        ``finished``, so the flag is set by the time it is read.
+        """
+        self._auto_function_error = exc
+
     def _on_auto_function_finished(self, name: str, beam_type: BeamType) -> None:
         self._toggle_interactions(enable=True)
         beam_widget = self.dual_beam_widget.sem_widget if beam_type is BeamType.ELECTRON else self.dual_beam_widget.fib_widget
         beam_widget.sync_from_microscope()
+        if self._auto_function_error is not None:
+            notification_service.show_toast(f"{name} failed: {self._auto_function_error}", "error")
+            self._auto_function_error = None
+            return
         if name == "AutoFocus":
             wd = beam_widget.beam_settings_widget.working_distance_spinbox.value()
             notification_service.show_toast(f"AutoFocus Complete. Best WD: {wd:.2f}mm")
@@ -581,6 +599,15 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         self._toggle_interactions(True)
         self.is_acquiring = False
 
+    def _on_acquisition_errored(self, exc: Exception) -> None:
+        """Surface a background image-acquisition failure to the user.
+
+        ``FunctionWorker`` logs the traceback but (unlike napari's old
+        ``thread_worker``) does not reraise it onto the GUI thread; interaction
+        state is still reset by ``acquisition_finished`` on ``finished``.
+        """
+        notification_service.show_toast(f"Image acquisition failed: {exc}", "error")
+
     def acquire_sem_image(self) -> None:
         """Acquire an SEM image with the current settings"""
         self.start_acquisition(both=False, beam_type=BeamType.ELECTRON)
@@ -618,6 +645,7 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         # start the acquisition worker
         worker = self.acquisition_worker(self.image_settings, both=both)
         worker.finished.connect(self.acquisition_finished)
+        worker.errored.connect(self._on_acquisition_errored)
         worker.start()
 
     @thread_worker

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -74,6 +74,7 @@ from fibsem.ui.napari.utilities import (
     is_inside_image_bounds,
     update_text_overlay,
 )
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.widgets.custom_widgets import ContextMenu, ContextMenuConfig, LamellaNameListWidget, TitledPanel
 from fibsem.ui.widgets.overview_acquisition_settings_widget import (
     OverviewAcquisitionSettingsWidget,
@@ -200,7 +201,7 @@ class FibsemMinimapWidget(QWidget):
         self.correlation_mode_enabled: bool = False
 
         self._thread_stop_event = threading.Event()
-        self._acquisition_worker: Optional[threading.Thread] = None
+        self._acquisition_worker: Optional[FunctionWorker] = None
 
         # display options
         self.show_current_fov: bool = True
@@ -581,10 +582,8 @@ class FibsemMinimapWidget(QWidget):
         self._hide_overlay_layers()
 
         self._thread_stop_event.clear()
-        self._acquisition_worker = threading.Thread(
-            target=self._run_tile_collection,
-            args=(self.microscope, overview_settings),
-            daemon=True,
+        self._acquisition_worker = FunctionWorker(
+            self._run_tile_collection, self.microscope, overview_settings
         )
         self._acquisition_worker.start()
 

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -353,6 +353,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self._toggle_interactions(enable=False)
         worker = self.absolute_movement_worker(stage_position=stage_position)
         worker.finished.connect(self.move_stage_finished)
+        worker.errored.connect(self._on_movement_error)
         worker.start()
     
     @thread_worker
@@ -369,6 +370,17 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         if self.image_widget.is_acquiring:
             return
         self._toggle_interactions(enable=True)
+
+    def _on_movement_error(self, exc: Exception) -> None:
+        """Surface a background stage-movement failure to the user.
+
+        The napari ``thread_worker`` this widget migrated off used to reraise
+        unhandled worker errors onto the GUI thread (visible notification); the
+        napari-free ``FunctionWorker`` only logs them, so surface a toast here.
+        Interaction state is still re-enabled by ``move_stage_finished`` (wired to
+        ``finished``, which fires on error too).
+        """
+        notification_service.show_toast(f"Stage movement failed: {exc}", "error")
 
     def get_position_from_ui(self):
         """Get the stage position from the UI"""
@@ -400,6 +412,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
 
         worker = self._double_click_worker(layer, event)
         worker.finished.connect(self.move_stage_finished)
+        worker.errored.connect(self._on_movement_error)
         worker.start()
 
     @thread_worker
@@ -472,6 +485,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self._toggle_interactions(False)
         worker = self.move_to_orientation_worker(orientation)
         worker.finished.connect(self.move_stage_finished)
+        worker.errored.connect(self._on_movement_error)
         worker.start()
 
     @thread_worker

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import napari
 import numpy as np
-from napari.qt.threading import thread_worker
 from PyQt5 import QtCore, QtWidgets
 from superqt import ensure_main_thread
 
@@ -19,6 +18,7 @@ from fibsem.structures import (
 )
 from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
 from fibsem.ui.napari.utilities import update_text_overlay
+from fibsem.ui.qt.threading import thread_worker
 from fibsem.ui.stylesheets import (
     DISABLED_PUSHBUTTON_STYLE,
     LABEL_INSTRUCTIONS_STYLE,

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -7,7 +7,6 @@ import napari
 import napari.utils.notifications
 from napari.layers import Image as NapariImageLayer
 from napari.layers import Points as NapariPointsLayer
-from napari.qt.threading import FunctionWorker, thread_worker
 from PyQt5.QtWidgets import QWidget
 from PyQt5.QtCore import pyqtSignal
 
@@ -15,6 +14,7 @@ from fibsem.imaging.spot import run_spot_burn
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, Point
 from fibsem.ui import stylesheets
+from fibsem.ui.qt.threading import FunctionWorker, thread_worker
 from fibsem.ui.qtdesigner_files import FibsemSpotBurnWidget as FibsemSpotBurnWidgetUI
 from fibsem.utils import format_value
 

--- a/fibsem/ui/qt/__init__.py
+++ b/fibsem/ui/qt/__init__.py
@@ -1,0 +1,1 @@
+"""Qt / GUI-thread helpers (napari-free)."""

--- a/fibsem/ui/qt/threading.py
+++ b/fibsem/ui/qt/threading.py
@@ -1,0 +1,132 @@
+"""A tiny, napari-free replacement for the subset of ``napari.qt.threading`` we use.
+
+Two threading patterns exist in the GUI, and this wrapper covers both:
+
+* **napari ``@thread_worker`` sites** — a decorated *plain function* (never a generator —
+  nothing uses ``yield``), started with ``.start()`` and observed via ``.finished`` (and, in a
+  couple of places, ``.returned`` / ``.errored``). Progress is reported through each widget's
+  own ``pyqtSignal``s, not napari's ``.yielded``; no site uses pause/resume/abort.
+* **manual ``threading.Thread`` sites** — some fire-and-forget, others stored on the widget
+  (``self._acquisition_thread``) so the widget can poll ``.is_alive()`` and ``.join(timeout=)``
+  on cancel / close. Cancellation there is widget-owned: the widget holds a ``threading.Event``
+  and passes it into the blocking call; the worker only needs to be *observable*, not to own
+  the stop signal.
+
+So :class:`FunctionWorker` both re-emits its outcome as Qt signals *and* mirrors the slice of
+the ``threading.Thread`` API those sites use (``start`` / ``is_alive`` / ``join``), making it a
+drop-in for either pattern.
+
+Because the worker is a ``QObject`` constructed on the calling (GUI) thread, emitting its
+signals from the worker thread makes Qt deliver them through the GUI event loop — exactly the
+mechanism napari uses, so signal-delivery threading is unchanged at every call site.
+
+Migration is a one-line import swap::
+
+    # from napari.qt.threading import thread_worker
+    from fibsem.ui.qt.threading import thread_worker
+
+This intentionally implements only the non-generator, bare-decorator subset. A generator body
+or ``@thread_worker(connect=...)`` will fail loudly rather than silently misbehave.
+"""
+from __future__ import annotations
+
+import functools
+import logging
+import threading
+from typing import Callable, Optional, Set
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+__all__ = ["FunctionWorker", "thread_worker"]
+
+# Call sites keep only a local ``worker = self.x_worker(...)`` reference, which would be
+# garbage-collected the moment the method returns — before the thread finishes and its
+# signals are delivered. Hold a strong reference here for the worker's lifetime (napari
+# keeps its own registry for the same reason); it is released when ``finished`` fires.
+_ACTIVE_WORKERS: Set["FunctionWorker"] = set()
+
+
+class FunctionWorker(QObject):
+    """Runs ``func(*args, **kwargs)`` on a daemon thread and re-emits the result as signals.
+
+    Signals mirror the napari names we rely on and are delivered on the thread that created
+    the worker (the GUI thread), so connected slots may safely touch widgets:
+
+    * ``started``  — emitted just before the body runs.
+    * ``returned`` — the return value, on success only.
+    * ``errored``  — the exception, on failure only (also logged with a traceback).
+    * ``finished`` — always, after ``returned``/``errored`` (matching napari).
+
+    It also exposes the slice of the :class:`threading.Thread` API the manual-thread sites
+    use — :meth:`is_alive` and :meth:`join` — so a widget that stored a raw ``Thread`` for
+    lifecycle (``is_acquiring`` / ``cancel`` / ``closeEvent``) can hold a ``FunctionWorker``
+    instead with no change to those call sites.
+    """
+
+    started = pyqtSignal()
+    returned = pyqtSignal(object)
+    errored = pyqtSignal(object)
+    finished = pyqtSignal()
+
+    def __init__(self, func: Callable, *args, **kwargs):
+        super().__init__()
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        """Launch the worker on a daemon thread."""
+        _ACTIVE_WORKERS.add(self)
+        # Released on the GUI thread once the worker is done (self lives there).
+        self.finished.connect(lambda: _ACTIVE_WORKERS.discard(self))
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def is_alive(self) -> bool:
+        """Whether the worker thread has been started and has not yet finished.
+
+        Drop-in for ``threading.Thread.is_alive`` at the stored-thread lifecycle sites
+        (``is_acquiring`` / ``is_milling`` / ``is_workflow_running``). ``False`` before
+        :meth:`start`.
+        """
+        return self._thread is not None and self._thread.is_alive()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        """Block until the worker thread finishes (or ``timeout`` elapses).
+
+        Drop-in for ``threading.Thread.join`` at the cancel / ``closeEvent`` sites. A no-op
+        if the worker was never started. Cancellation itself is widget-owned (the widget sets
+        its ``stop_event`` first, then joins to wait the body out).
+        """
+        if self._thread is not None:
+            self._thread.join(timeout)
+
+    def _run(self) -> None:
+        self.started.emit()
+        try:
+            result = self._func(*self._args, **self._kwargs)
+        except Exception as exc:  # noqa: BLE001 - report every failure, never swallow it
+            logging.exception(
+                "worker %r failed", getattr(self._func, "__name__", self._func)
+            )
+            self.errored.emit(exc)
+        else:
+            self.returned.emit(result)
+        finally:
+            self.finished.emit()
+
+
+def thread_worker(func: Callable) -> Callable:
+    """Turn ``func`` into a factory that returns a :class:`FunctionWorker`.
+
+    Drop-in for the subset of :func:`napari.qt.threading.thread_worker` this codebase uses.
+    The factory is a plain function, so it binds as a method — ``self.some_worker(...)``
+    passes ``self`` through as the first positional argument, just like the original.
+    """
+
+    @functools.wraps(func)
+    def factory(*args, **kwargs) -> FunctionWorker:
+        return FunctionWorker(func, *args, **kwargs)
+
+    return factory

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -26,7 +26,6 @@ import datetime
 import logging
 import math
 import time
-import threading
 from collections import deque
 from datetime import timedelta
 from pprint import pformat
@@ -58,6 +57,7 @@ from fibsem.milling.strategy.coincidence import CoincidenceMillingStrategy
 from fibsem.structures import BeamType, FibsemImage, Point
 from fibsem.ui import stylesheets
 from fibsem.ui.fm.widgets import LinePlotWidget
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.widgets.custom_widgets import LamellaNameListWidget, TitledPanel
 from fibsem.ui.widgets.image_canvas import (
     FibsemImageCanvas,
@@ -1277,13 +1277,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         if ret != QMessageBox.Yes:  # type: ignore[attr-defined]
             return
 
-        def _move():
-            try:
-                self.microscope.safe_absolute_stage_movement(lamella.stage_position)
-            except Exception:
-                logging.exception("Error moving to lamella position")
-
-        threading.Thread(target=_move, daemon=True).start()
+        worker = FunctionWorker(
+            self.microscope.safe_absolute_stage_movement, lamella.stage_position
+        )
+        worker.start()
 
     def _acquire_fib_image(self):
         """Acquire a FIB image using current microscope settings and display it."""
@@ -1299,7 +1296,8 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             finally:
                 self._fib_acquire_done.emit()
 
-        threading.Thread(target=_worker, daemon=True).start()
+        worker = FunctionWorker(_worker)
+        worker.start()
 
     def _acquire_fm_image(self):
         """Acquire a single FM image in a background thread and display it."""
@@ -1327,7 +1325,8 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             finally:
                 self._fm_acquire_done.emit()
 
-        threading.Thread(target=_worker, daemon=True).start()
+        worker = FunctionWorker(_worker)
+        worker.start()
 
     def _set_fib_buttons_enabled(self, enabled: bool) -> None:
         for btn in [
@@ -1357,9 +1356,11 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
                 logging.exception("Error running FIB autocontrast")
             finally:
                 self._fib_acquire_done.emit()
-                self.btn_autocontrast_fib.setText("AutoContrast")
 
-        threading.Thread(target=_worker, daemon=True).start()
+        worker = FunctionWorker(_worker)
+        # reset the button label on the GUI thread when the worker finishes (success or error)
+        worker.finished.connect(lambda: self.btn_autocontrast_fib.setText("AutoContrast"))
+        worker.start()
 
     def _run_fib_autofocus(self) -> None:
         from fibsem.structures import FibsemRectangle
@@ -1381,9 +1382,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
                 logging.exception("Error running FIB autofocus")
             finally:
                 self._fib_acquire_done.emit()
-                self.btn_autofocus_fib.setText("AutoFocus")
 
-        threading.Thread(target=_worker, daemon=True).start()
+        worker = FunctionWorker(_worker)
+        worker.finished.connect(lambda: self.btn_autofocus_fib.setText("AutoFocus"))
+        worker.start()
 
     def _on_fib_acquire_done(self):
         self._set_fib_buttons_enabled(True)
@@ -1945,12 +1947,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             return
         dx = (x - img_w / 2) * pixel_size
         dy = -(y - img_h / 2) * pixel_size
-        threading.Thread(
-            target=lambda: self.microscope.stable_move(
-                dx=dx, dy=dy, beam_type=BeamType.ION
-            ),
-            daemon=True,
-        ).start()
+        worker = FunctionWorker(
+            self.microscope.stable_move, dx=dx, dy=dy, beam_type=BeamType.ION
+        )
+        worker.start()
 
     def _on_fm_double_clicked(self, x: float, y: float) -> None:
         """Stable-move the stage to the double-clicked position on the FM canvas."""
@@ -1991,12 +1991,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             px, py = -py, px
         elif transform is CameraImageTransform.ROTATE_180:
             px, py = -px, -py
-        threading.Thread(
-            target=lambda: self.microscope.stable_move(
-                dx=px, dy=py, beam_type=BeamType.ELECTRON
-            ),
-            daemon=True,
-        ).start()
+        worker = FunctionWorker(
+            self.microscope.stable_move, dx=px, dy=py, beam_type=BeamType.ELECTRON
+        )
+        worker.start()
 
     # Public API
     # ------------------------------------------------------------------

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -47,6 +47,7 @@ from fibsem.ui.fm.widgets import (
     ZParametersWidget,
 )
 from fibsem.ui.napari.utilities import is_position_inside_layer, update_text_overlay
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
@@ -88,7 +89,7 @@ class FMControlWidget(QWidget):
         self.channel_settings = ChannelSettings()
 
         # Consolidated acquisition threading
-        self._acquisition_thread: Optional[threading.Thread] = None
+        self._acquisition_thread: Optional[FunctionWorker] = None
         self._acquisition_stop_event = threading.Event()
         self._current_acquisition_type: Optional[str] = None
 
@@ -781,10 +782,8 @@ class FMControlWidget(QWidget):
             return
 
         # Start acquisition thread
-        self._acquisition_thread = threading.Thread(
-            target=self._image_acquistion_worker,
-            args=(channel_settings, z_parameters, filename),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._image_acquistion_worker, channel_settings, z_parameters, filename
         )
         self._acquisition_thread.start()
 
@@ -892,10 +891,8 @@ class FMControlWidget(QWidget):
         autofocus_settings = settings["autofocus_settings"]
 
         # Start auto-focus thread
-        self._acquisition_thread = threading.Thread(
-            target=self._autofocus_worker,
-            args=(channel_settings, autofocus_settings),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._autofocus_worker, channel_settings, autofocus_settings
         )
         self._acquisition_thread.start()
 

--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -15,6 +15,7 @@ from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.tasks import FibsemMillingTaskConfig, run_milling_task
 from fibsem.structures import MillingState
 from fibsem.ui import stylesheets
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.utils import format_duration
 
 if TYPE_CHECKING:
@@ -36,7 +37,7 @@ class FibsemMillingWidget2(QWidget):
         self.microscope = microscope
         self.parent_widget = parent
 
-        self._milling_thread: Optional[threading.Thread] = None
+        self._milling_thread: Optional[FunctionWorker] = None
         self._milling_stop_event = threading.Event()
         self._has_stages = False
         layout = QGridLayout()
@@ -175,10 +176,8 @@ class FibsemMillingWidget2(QWidget):
             config = self.parent_widget.get_config()
 
         # Start the milling task in a separate thread
-        self._milling_thread = threading.Thread(
-            target=self._milling_worker,
-            args=(self.microscope, config),
-            daemon=True,
+        self._milling_thread = FunctionWorker(
+            self._milling_worker, self.microscope, config
         )
 
         self._milling_thread.start()

--- a/fibsem/ui/widgets/tests/test_qt_threading.py
+++ b/fibsem/ui/widgets/tests/test_qt_threading.py
@@ -1,0 +1,187 @@
+"""Unit test for the napari-free ``thread_worker`` replacement (``fibsem.ui.qt.threading``).
+
+Covers the properties the migration depends on:
+  * success   — ``returned`` carries the value and its slot runs on the *main* thread,
+                while the body itself runs off it; ``finished`` fires; method binding works.
+  * error     — a raising body emits ``errored`` (with the exception) and still ``finished``,
+                but not ``returned``.
+  * liveness  — a worker started with no surviving local reference is not garbage-collected
+                mid-run (the module keeps it alive until ``finished``).
+  * lifecycle — ``is_alive()`` / ``join(timeout)`` mirror ``threading.Thread`` for the stored
+                -thread sites (``is_acquiring`` / cancel / ``closeEvent``).
+
+Run directly (headless):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_qt_threading.py
+"""
+from __future__ import annotations
+
+import gc
+import os
+import threading
+import time
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import QEventLoop, QObject, QTimer
+
+_QAPP = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+from fibsem.ui.qt import threading as qtthreading  # aliased: stdlib ``threading`` above stays intact
+from fibsem.ui.qt.threading import FunctionWorker, thread_worker
+
+_MAIN_THREAD = threading.current_thread()
+
+
+def _spin(signal, timeout_ms: int = 5000) -> None:
+    """Run the event loop until ``signal`` fires (or the timeout elapses)."""
+    loop = QEventLoop()
+    signal.connect(loop.quit)
+    QTimer.singleShot(timeout_ms, loop.quit)
+    loop.exec_()
+    _QAPP.processEvents()
+
+
+class _Receiver(QObject):
+    """A GUI-thread QObject: bound-method slots are the guaranteed cross-thread-queued case."""
+
+    def __init__(self):
+        super().__init__()
+        self.returned_value = None
+        self.returned_on_main = None
+        self.finished_on_main = None
+        self.errored_value = "unset"
+
+    def on_returned(self, value):
+        self.returned_value = value
+        self.returned_on_main = threading.current_thread() is _MAIN_THREAD
+
+    def on_finished(self):
+        self.finished_on_main = threading.current_thread() is _MAIN_THREAD
+
+    def on_errored(self, exc):
+        self.errored_value = exc
+
+
+class _Host:
+    """The decorator must bind as a method: ``self`` is passed through as arg 0."""
+
+    @thread_worker
+    def double(self, x: int):
+        # runs on the worker thread; return the value + the thread it ran on
+        return {"result": x * 2, "thread": threading.current_thread()}
+
+
+def test_success_delivers_on_main_thread():
+    host = _Host()
+    recv = _Receiver()
+
+    worker = host.double(21)
+    assert isinstance(worker, FunctionWorker)
+    worker.returned.connect(recv.on_returned)
+    worker.finished.connect(recv.on_finished)
+    worker.start()
+    _spin(worker.finished)
+
+    assert recv.returned_value["result"] == 42          # method binding worked (self + x)
+    assert recv.returned_value["thread"] is not _MAIN_THREAD  # body ran off the main thread
+    assert recv.returned_on_main is True                # ...but the slot ran ON the main thread
+    assert recv.finished_on_main is True
+
+
+def test_error_still_finishes():
+    @thread_worker
+    def boom():
+        raise ValueError("nope")
+
+    recv = _Receiver()
+    fired = []
+    worker = boom()
+    worker.errored.connect(recv.on_errored)
+    worker.returned.connect(lambda r: fired.append(("returned", r)))  # must NOT fire
+    worker.finished.connect(lambda: fired.append(("finished", None)))
+    worker.start()
+    _spin(worker.finished)
+
+    assert isinstance(recv.errored_value, ValueError)
+    assert str(recv.errored_value) == "nope"
+    assert not any(k == "returned" for k, _ in fired)  # returned skipped on error
+    assert ("finished", None) in fired                 # finished still fired
+
+
+def test_worker_survives_dropped_local_ref():
+    done = []
+
+    @thread_worker
+    def slow():
+        time.sleep(0.05)  # still running during the gc.collect() below
+        return 7
+
+    def launch():
+        worker = slow()
+        worker.returned.connect(lambda r: done.append(r))
+        worker.start()
+        # local `worker` goes out of scope here — only _ACTIVE_WORKERS keeps it alive
+
+    launch()
+    assert len(qtthreading._ACTIVE_WORKERS) == 1
+    gc.collect()  # would collect the worker if it were not self-registered
+
+    deadline = 3.0
+    while deadline > 0 and not done:
+        _QAPP.processEvents()
+        time.sleep(0.02)
+        deadline -= 0.02
+
+    assert done == [7]
+    _QAPP.processEvents()
+    assert len(qtthreading._ACTIVE_WORKERS) == 0  # released once finished fired
+
+
+def test_is_alive_and_join_mirror_thread():
+    """The stored-thread sites poll ``is_alive()`` and ``join(timeout=)`` on a FunctionWorker
+    held in place of a raw ``threading.Thread`` — the same shape as ``is_acquiring`` + cancel.
+    A widget-owned Event stops the body; ``join`` waits it out."""
+    stop_event = threading.Event()
+
+    @thread_worker
+    def acquire():
+        # a bounded acquisition loop, cancelled by the widget-owned stop_event
+        while not stop_event.is_set():
+            time.sleep(0.01)
+
+    worker = acquire()
+    assert worker.is_alive() is False          # not started yet
+    worker.start()
+    # give the daemon thread a moment to actually enter the loop
+    for _ in range(50):
+        if worker.is_alive():
+            break
+        time.sleep(0.01)
+    assert worker.is_alive() is True           # running
+
+    # cancel: set the stop event (widget-owned), then join with a timeout (as cancel does)
+    stop_event.set()
+    worker.join(timeout=5)
+    assert worker.is_alive() is False          # joined cleanly within the timeout
+
+    _spin(worker.finished, timeout_ms=1000)    # drain the queued finished signal
+
+
+def test_join_before_start_is_noop():
+    @thread_worker
+    def noop():
+        return None
+
+    worker = noop()
+    worker.join(timeout=1)                      # must not raise when never started
+    assert worker.is_alive() is False
+
+
+if __name__ == "__main__":
+    test_success_delivers_on_main_thread()
+    test_error_still_finishes()
+    test_worker_survives_dropped_local_ref()
+    test_is_alive_and_join_mirror_thread()
+    test_join_before_start_is_noop()
+    print("PASS")

--- a/fibsem/ui/widgets/tests/test_qt_worker_migration.py
+++ b/fibsem/ui/widgets/tests/test_qt_worker_migration.py
@@ -1,0 +1,159 @@
+"""Migration smoke: the quad-view widgets' ``@thread_worker`` methods now build the napari-free
+``FunctionWorker`` and still run off the GUI thread, delivering ``finished`` / ``returned`` /
+``errored`` back on it.
+
+After swapping ``from napari.qt.threading import thread_worker`` for
+``from fibsem.ui.qt.threading import thread_worker`` in ``FibsemImageSettingsWidget``,
+``FibsemMovementWidget`` and ``FibsemSpotBurnWidget``, each decorated method must:
+
+* return a :class:`fibsem.ui.qt.threading.FunctionWorker` (the swap took effect), and
+* run its *real* body off-thread against a Demo microscope and emit ``finished``.
+
+The widgets themselves need a live napari GL canvas to construct, which aborts under the
+offscreen platform, so we drive each real decorated body against a minimal QObject stub as
+``self`` — the decorator binds ``self`` through exactly as it does on the real widget, so this
+exercises the migrated code path (decorator -> FunctionWorker -> off-thread body -> GUI-thread
+delivery) without the canvas.
+
+Run directly (headless):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_qt_worker_migration.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import Qt, QEventLoop, QObject, QTimer, pyqtSignal
+
+# QApplication before the napari/vispy-heavy fibsem imports below.
+_QAPP = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+from fibsem import acquire, utils
+from fibsem.structures import BeamType
+from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
+from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
+from fibsem.ui.FibsemSpotBurnWidget import FibsemSpotBurnWidget
+from fibsem.ui.qt.threading import FunctionWorker
+
+# ``fibsem.ui.__init__`` re-exports the class name, shadowing the submodule attribute, so grab
+# the real module object from sys.modules to monkeypatch its module-level ``run_spot_burn``.
+spot_burn_module = sys.modules[FibsemSpotBurnWidget.__module__]
+
+_MAIN_THREAD = threading.current_thread()
+
+
+def _spin(signal, timeout_ms: int = 20000) -> None:
+    loop = QEventLoop()
+    signal.connect(loop.quit)
+    QTimer.singleShot(timeout_ms, loop.quit)
+    loop.exec_()
+    _QAPP.processEvents()
+
+
+def _drive(worker: FunctionWorker):
+    """Start a worker, spin until finished, return (error_or_None, ran_off_main_thread)."""
+    assert isinstance(worker, FunctionWorker), "decorated method did not build a FunctionWorker"
+    err, fin, off_main = [], [], []
+    worker.errored.connect(lambda e: err.append(e))
+    # DirectConnection: this slot runs synchronously in the emitting thread, so it captures the
+    # thread the body runs on. ``started`` is the first line of the worker body's execution.
+    worker.started.connect(
+        lambda: off_main.append(threading.current_thread() is not _MAIN_THREAD),
+        Qt.DirectConnection,
+    )
+    worker.finished.connect(lambda: fin.append(True))
+    worker.start()
+    _spin(worker.finished)
+    assert fin == [True], "worker never emitted finished"
+    return (err[0] if err else None), (off_main[0] if off_main else None)
+
+
+class _ImageStub(QObject):
+    """Just what ``FibsemImageSettingsWidget``'s workers touch on ``self``."""
+
+    acquisition_progress_signal = pyqtSignal(dict)
+
+    def __init__(self, microscope, image_settings):
+        super().__init__()
+        self.microscope = microscope
+        self.image_settings = image_settings
+        self.eb_image = None
+        self.ib_image = None
+
+
+class _MoveStub(QObject):
+    """Just what ``FibsemMovementWidget.move_to_orientation_worker`` touches on ``self``."""
+
+    movement_progress_signal = pyqtSignal(dict)
+
+    def __init__(self, microscope):
+        super().__init__()
+        self.microscope = microscope
+
+    def update_ui_after_movement(self):
+        pass
+
+
+class _SpotStub(QObject):
+    """Just what ``FibsemSpotBurnWidget._spot_burn_worker`` touches on ``self``."""
+
+    spot_burn_progress_signal = pyqtSignal(dict)
+
+    def __init__(self):
+        super().__init__()
+        self.stop_event = threading.Event()
+
+
+def test_image_settings_workers_migrated():
+    microscope, settings = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    stub = _ImageStub(microscope, settings.image)
+
+    # autocontrast: a bare microscope call, off-thread, no error.
+    err, off_main = _drive(FibsemImageSettingsWidget._autocontrast_worker(stub, BeamType.ELECTRON))
+    assert err is None
+    assert off_main is True  # body genuinely ran on the worker thread
+
+    # acquisition (both): populates eb/ib images off-thread.
+    err, _ = _drive(FibsemImageSettingsWidget.acquisition_worker(stub, stub.image_settings, both=True))
+    assert err is None
+    assert stub.eb_image is not None and stub.ib_image is not None
+
+
+def test_movement_worker_migrated():
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    stub = _MoveStub(microscope)
+
+    err, off_main = _drive(FibsemMovementWidget.move_to_orientation_worker(stub, "SEM"))
+    assert err is None
+    assert off_main is True
+
+
+def test_spot_burn_worker_migrated():
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    stub = _SpotStub()
+
+    # stub the low-level burn to a no-op; the point is the worker plumbing, not a real burn.
+    orig = spot_burn_module.run_spot_burn
+    spot_burn_module.run_spot_burn = lambda **kw: None
+    try:
+        worker = FibsemSpotBurnWidget._spot_burn_worker(
+            stub, microscope=microscope, coordinates=[], exposure_time=1.0, milling_current=60e-12
+        )
+        returned = []
+        worker.returned.connect(lambda r: returned.append(r))
+        err, _ = _drive(worker)
+        assert err is None
+        assert returned == [None]  # .returned fires on success (spot-burn observes it)
+    finally:
+        spot_burn_module.run_spot_burn = orig
+
+
+if __name__ == "__main__":
+    test_image_settings_workers_migrated()
+    test_movement_worker_migrated()
+    test_spot_burn_worker_migrated()
+    print("PASS")


### PR DESCRIPTION
## Summary

Replaces the two competing GUI background-threading patterns — napari's `thread_worker` and hand-rolled `threading.Thread` — with a single napari-free wrapper: `fibsem/ui/qt/threading.py` `FunctionWorker` (+ a drop-in `@thread_worker` decorator). Part of the napari-deprecation effort.

`FunctionWorker` is a `QObject` that runs the body on a daemon thread and re-emits `started`/`returned`/`errored`/`finished` on the GUI thread — the **same mechanism napari used**, so signal-delivery threading is unchanged at every call site. It also mirrors the slice of the `threading.Thread` API the stored-thread sites use (`start`/`is_alive`/`join`), so those swaps are a construction-line change with lifecycle (`is_acquiring`/cancel/`closeEvent`) untouched. Cancellation stays widget-owned via each widget's existing `stop_event`.

## Scope (A1 + B)

- **A1 — napari-free win (import swap):** `FibsemImageSettingsWidget`, `FibsemMovementWidget`, `FibsemSpotBurnWidget`.
- **B1 — fire-and-forget threads:** `fluorescence_coincidence_viewer_widget` ×7. Also fixes two **thread-unsafe** `btn.setText()` calls that ran in a worker's `finally` — moved to `finished` slots (GUI thread).
- **B2 — stored-thread / cancel sites:** `FMAcquisitionWidget` ×4, `fluorescence_control_widget` ×2, `FibsemMinimapWidget`, `milling_widget`, `AutoLamellaUI`.

## Out of scope (intentionally)

- The three still-napari-native widgets (`FibsemSegmentationModelWidget`, `FibsemModelTrainingWidget`, `fm_import_wizard`) — they use `self.viewer` / `napari.utils.notifications`, so swapping `thread_worker` there buys no napari-free win. Same one-liner when those widgets are otherwise de-napari'd.
- Backend / non-GUI threads (microscope drivers use `psygnal`, the streamlit launcher, the webhook hook) — non-GUI orchestration layer.

## Testing

`QT_QPA_PLATFORM=offscreen` — all green:
- `test_qt_threading.py` — wrapper semantics (main-thread delivery, error-still-finishes, liveness-under-GC) + the `is_alive`/`join` lifecycle used by the stored-thread cancel path.
- `test_qt_worker_migration.py` — each migrated worker drives its **real** body against a Demo microscope and confirms it builds a `FunctionWorker`, runs off-thread, and delivers `finished`/`returned`.

Full-widget construction isn't exercised in tests because a headless napari `Viewer` aborts under the offscreen platform (`QOpenGLWidget not supported`); the migration test drives real decorated bodies against lightweight QObject stubs instead.

Design notes: `docs/design/thread-worker-removal.md`.