### PR TITLE
[fix] overview stitch: correct resolution order + don't mutate caller settings

### DIFF
--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -490,13 +490,17 @@ class TiledAcquisitionRunner:
         signal = self.microscope.tiled_acquisition_signal
         total_tiles = self.settings.nrows * self.settings.ncols
         signal.emit({"msg": "Stitching Tiles", "counter": total_tiles, "total": total_tiles})
-        image = FibsemImage(data=self._canvas, metadata=self._first_image.metadata)
+        # deepcopy so the stitched image gets its OWN metadata snapshot — the edits below
+        # (hfw → total FOV, stitched resolution) must not mutate the caller's shared
+        # settings object or the first tile's metadata.
+        image = FibsemImage(data=self._canvas, metadata=deepcopy(self._first_image.metadata))
         if image.metadata is None:
             raise ValueError("Image metadata is not set. Cannot update metadata for stitched image.")
         image.metadata.microscope_state = deepcopy(self._start_state)
-        image.metadata.image_settings = self._image_settings
-        image.metadata.image_settings.hfw = deepcopy(float(self.settings.total_fov_x))
-        image.metadata.image_settings.resolution = deepcopy((self._canvas.shape[0], self._canvas.shape[1]))
+        image.metadata.image_settings = deepcopy(self._image_settings)
+        image.metadata.image_settings.hfw = float(self.settings.total_fov_x)
+        # resolution is (width, height); numpy canvas.shape is (height, width).
+        image.metadata.image_settings.resolution = (self._canvas.shape[1], self._canvas.shape[0])
 
         filename = os.path.join(image.metadata.image_settings.path, self._prev_label)  # type: ignore
         image.save(filename)


### PR DESCRIPTION
## Overview stitch metadata fixes

Two small, independent bugs in `TiledAcquisitionRunner._stitch` (`fibsem/imaging/tiled.py`),
both in the **stitched overview image's metadata**:

1. **Resolution transposed.** It stored `resolution = (canvas.shape[0], canvas.shape[1])` —
   numpy `(height, width)` — but the `ImageSettings.resolution` convention everywhere else is
   `(width, height)` (cf. `generate_blank_image`, and `total_fov_y`'s `w, h = resolution`).
   Harmless for square overviews, but wrong for any non-square montage: it breaks
   `FibsemImage.resize()`, aspect / `vfw` math, and the saved metadata.

2. **Caller settings mutated.** `image.metadata.image_settings` was assigned the caller's
   settings object *by reference*, then `hfw` / `resolution` were set on it — mutating the
   caller's (e.g. the overview-acquisition UI's) settings. After a montage acquisition the
   caller's tile `hfw` had been overwritten with the montage total FOV.

### Fix
Deepcopy the first tile's metadata + the `image_settings` into the stitched image so the edits
stay local to the stitched image, and store `resolution` as `(width, height)`. Also removes the
no-op `deepcopy(float(...))` / `deepcopy((...))` wrappers on immutable values.

The mutation fix matches the one in #103; this pulls both stitch fixes into one small, focused
PR that can merge independently.

### Verification
Non-square (2×3, 768×512 tiles) stitch on the sim:
- `resolution` → `(2304, 1024)` = `(width, height)` ✓
- caller's `image_settings` unchanged (`hfw`, `resolution`) after the call ✓
- stitched image internally consistent (`pixel_size × width == hfw == 600 µm`) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
