### PR TITLE
[feat] Add "Report an Issue" bug reporter to AutoLamella

### DIFF
--- a/fibsem/applications/autolamella/tools/bug_report.py
+++ b/fibsem/applications/autolamella/tools/bug_report.py
@@ -1,0 +1,353 @@
+"""Tools for reporting issues and submitting bug reports (optionally with data).
+
+Two paths are supported:
+
+* **Public report** — open a pre-filled GitHub issue in the browser. No data
+  leaves the machine beyond what the user types + basic environment info.
+* **Private data bundle** — build a scrubbed ``.zip`` of the selected experiment
+  artifacts (log file, experiment/protocol yaml, optionally screenshots/images)
+  and open a pre-filled email to the support address so the user can attach it.
+
+An inert :func:`init_sentry` hook is included so automatic crash reporting can be
+enabled later (by installing ``sentry-sdk`` and setting a DSN in preferences)
+without any UI changes.
+"""
+
+from __future__ import annotations
+
+import getpass
+import json
+import logging
+import os
+import platform
+import re
+import webbrowser
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING, Dict, List, Optional
+from urllib.parse import quote, urlencode
+
+import fibsem
+import fibsem.config as fibsem_cfg
+
+if TYPE_CHECKING:
+    from fibsem.applications.autolamella.structures import Experiment
+    from fibsem.microscope import FibsemMicroscope
+
+# Support / issue destinations
+SUPPORT_EMAIL = "contact@fibsemos.org"
+GITHUB_REPO_URL = "https://github.com/fibsem-os/fibsem-os"
+GITHUB_NEW_ISSUE_URL = f"{GITHUB_REPO_URL}/issues/new"
+
+# Text file extensions whose contents are scrubbed before being added to a bundle.
+_SCRUBBED_EXTENSIONS = {".log", ".yaml", ".yml", ".txt", ".md", ".json", ".csv"}
+
+# Rough per-file globs used to locate optional artifacts within an experiment.
+# The generic .tif/.tiff patterns also cover .ome.tif/.ome.tiff.
+_SCREENSHOT_GLOB = "**/*.png"
+_IMAGE_GLOBS = ("**/*.tif", "**/*.tiff")
+
+# Matches a home-directory prefix (group 1) followed by the username segment.
+_HOME_PATH_RE = re.compile(r"([/\\](?:Users|home)[/\\])[^/\\\s]+")
+
+
+@dataclass
+class BugReportContent:
+    """User-entered content and data-inclusion choices for a bug report."""
+
+    title: str = ""
+    description: str = ""
+    steps: str = ""
+    severity: str = "Normal"
+    contact_email: str = ""
+
+    include_logfile: bool = True
+    include_experiment_yaml: bool = True
+    include_protocol: bool = True
+    include_screenshots: bool = False
+    include_images: bool = False
+
+    system_context: Dict[str, str] = field(default_factory=dict)
+
+
+def collect_system_context(
+    microscope: Optional["FibsemMicroscope"] = None,
+) -> Dict[str, str]:
+    """Gather non-identifying environment information for a bug report.
+
+    Deliberately excludes usernames, paths and IP addresses.
+    """
+    ctx: Dict[str, str] = {
+        "fibsem_version": getattr(fibsem, "__version__", "unknown"),
+        "platform": platform.platform(),
+        "python_version": platform.python_version(),
+    }
+
+    for mod in ("napari", "PyQt5.QtCore"):
+        try:
+            imported = __import__(mod, fromlist=["__version__"])
+            version = getattr(
+                imported, "__version__", getattr(imported, "QT_VERSION_STR", None)
+            )
+            if version:
+                ctx[mod.split(".")[0]] = str(version)
+        except Exception:
+            pass
+
+    if microscope is not None:
+        try:
+            info = microscope.system.info
+            ctx["microscope_manufacturer"] = str(getattr(info, "manufacturer", ""))
+            ctx["microscope_model"] = str(getattr(info, "model", ""))
+            ctx["microscope_software_version"] = str(
+                getattr(info, "software_version", "")
+            )
+        except Exception:
+            logging.debug("Could not read microscope system info for bug report.")
+
+    return {k: v for k, v in ctx.items() if v}
+
+
+def scrub_text(text: str) -> str:
+    """Best-effort removal of the user's home directory / username from text."""
+    if not text:
+        return text
+
+    replacements: List[str] = []
+    try:
+        replacements.append(os.path.expanduser("~"))
+    except Exception:
+        pass
+    try:
+        replacements.append(getpass.getuser())
+    except Exception:
+        pass
+
+    scrubbed = text
+    for value in replacements:
+        if value and len(value) > 2:
+            scrubbed = scrubbed.replace(value, "<redacted>")
+
+    # Generic home-directory prefixes for the common platforms. The username is
+    # the path segment following the prefix, up to the next separator or
+    # whitespace (so trailing usernames without a separator are still redacted).
+    scrubbed = _HOME_PATH_RE.sub(lambda m: m.group(1) + "<user>", scrubbed)
+
+    return scrubbed
+
+
+def _collect_files(
+    experiment: "Experiment", content: BugReportContent
+) -> List[str]:
+    """Resolve the absolute paths of the artifacts selected for inclusion."""
+    from glob import glob
+
+    exp_path = str(experiment.path)
+    files: List[str] = []
+
+    def _add(path: str) -> None:
+        if path and os.path.isfile(path) and path not in files:
+            files.append(path)
+
+    if content.include_logfile:
+        _add(os.path.join(exp_path, "logfile.log"))
+    if content.include_experiment_yaml:
+        _add(os.path.join(exp_path, "experiment.yaml"))
+    if content.include_protocol:
+        _add(os.path.join(exp_path, "protocol.yaml"))
+    if content.include_screenshots:
+        for path in glob(os.path.join(exp_path, _SCREENSHOT_GLOB), recursive=True):
+            _add(path)
+    if content.include_images:
+        for pattern in _IMAGE_GLOBS:
+            for path in glob(os.path.join(exp_path, pattern), recursive=True):
+                _add(path)
+
+    return files
+
+
+def estimate_bundle_size(
+    experiment: Optional["Experiment"], content: BugReportContent
+) -> int:
+    """Estimate the on-disk size (bytes) of the selected artifacts."""
+    if experiment is None:
+        return 0
+    total = 0
+    for path in _collect_files(experiment, content):
+        try:
+            total += os.path.getsize(path)
+        except OSError:
+            pass
+    return total
+
+
+def _render_report_text(content: BugReportContent) -> str:
+    """Render the human-readable report body shared by the bundle and email."""
+    lines = [
+        f"# AutoLamella Bug Report: {content.title or '(no title)'}",
+        "",
+        f"Severity: {content.severity}",
+        f"Contact: {content.contact_email or '(not provided)'}",
+        f"Created: {datetime.now().isoformat(timespec='seconds')}",
+        "",
+        "## Description",
+        content.description or "(none)",
+        "",
+        "## Steps to reproduce",
+        content.steps or "(none)",
+        "",
+        "## Environment",
+    ]
+    for key, value in content.system_context.items():
+        lines.append(f"- {key}: {value}")
+    return "\n".join(lines)
+
+
+def build_bug_report_bundle(
+    content: BugReportContent,
+    experiment: Optional["Experiment"],
+    output_dir: Optional[str] = None,
+) -> str:
+    """Build a scrubbed ``.zip`` bundle for the bug report and return its path.
+
+    Text artifacts (logs, yaml, json, ...) are scrubbed of the user's home
+    directory / username before being written. Binary artifacts (images) are
+    included verbatim only when explicitly selected.
+    """
+    timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    zip_name = f"bug-report-autolamella-{timestamp}.zip"
+
+    if output_dir is None:
+        # Prefer alongside the experiment; fall back to the log directory.
+        if experiment is not None and os.path.isdir(str(experiment.path)):
+            output_dir = str(experiment.path)
+        else:
+            output_dir = fibsem_cfg.LOG_PATH
+    os.makedirs(output_dir, exist_ok=True)
+    zip_path = os.path.join(output_dir, zip_name)
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("report.md", scrub_text(_render_report_text(content)))
+        zf.writestr(
+            "system_info.json",
+            scrub_text(json.dumps(content.system_context, indent=2)),
+        )
+
+        if experiment is not None:
+            exp_path = str(experiment.path)
+            for path in _collect_files(experiment, content):
+                arcname = os.path.relpath(path, os.path.dirname(exp_path))
+                ext = os.path.splitext(path)[1].lower()
+                try:
+                    if ext in _SCRUBBED_EXTENSIONS:
+                        with open(path, "r", encoding="utf-8", errors="replace") as f:
+                            zf.writestr(arcname, scrub_text(f.read()))
+                    else:
+                        zf.write(path, arcname)
+                except OSError as e:
+                    logging.warning("Skipping %s in bug report bundle: %s", path, e)
+
+    logging.info("Created bug report bundle at %s", zip_path)
+    return zip_path
+
+
+def _github_issue_body(content: BugReportContent) -> str:
+    """Markdown body for a GitHub issue (no private data)."""
+    lines = [
+        "### Description",
+        content.description or "_(describe the issue)_",
+        "",
+        "### Steps to reproduce",
+        content.steps or "_(steps)_",
+        "",
+        "### Environment",
+    ]
+    for key, value in content.system_context.items():
+        lines.append(f"- **{key}**: {value}")
+    lines += [
+        "",
+        "---",
+        "_Filed from the AutoLamella Report an Issue dialog. "
+        "Do not paste private/experiment data into this public issue — "
+        "use the email option to submit data privately._",
+    ]
+    return "\n".join(lines)
+
+
+def open_github_issue(content: BugReportContent) -> None:
+    """Open a pre-filled GitHub issue in the default browser."""
+    params = {
+        "title": content.title or "AutoLamella issue",
+        "body": _github_issue_body(content),
+    }
+    url = f"{GITHUB_NEW_ISSUE_URL}?{urlencode(params)}"
+    logging.info("Opening GitHub issue in browser.")
+    webbrowser.open(url)
+
+
+def compose_support_email(
+    content: BugReportContent, attachment_path: Optional[str]
+) -> None:
+    """Open a pre-filled email to the support address.
+
+    ``mailto:`` cannot attach files, so the bundle path is included in the body
+    with an instruction for the user to attach it manually.
+    """
+    subject = f"[AutoLamella Bug Report] {content.title or 'Untitled'}"
+    body_lines = [_render_report_text(content)]
+    if attachment_path:
+        body_lines += [
+            "",
+            "---",
+            f"A data bundle was created at:\n{attachment_path}",
+            "",
+            "Please attach this file to this email before sending.",
+        ]
+    body = "\n".join(body_lines)
+
+    url = f"mailto:{SUPPORT_EMAIL}?" + urlencode(
+        {"subject": subject, "body": body}, quote_via=quote
+    )
+    logging.info("Opening support email to %s", SUPPORT_EMAIL)
+    webbrowser.open(url)
+
+
+def init_sentry() -> bool:
+    """Initialise automatic crash reporting, if enabled and available.
+
+    Inert by default: returns ``False`` unless the user has opted in
+    (``reporting.crash_reporting_enabled``), provided a DSN, and installed
+    ``sentry-sdk``. Safe to call unconditionally at startup.
+    """
+    try:
+        prefs = fibsem_cfg.load_user_preferences()
+        reporting = getattr(prefs, "reporting", None)
+        if reporting is None or not getattr(reporting, "crash_reporting_enabled", False):
+            return False
+        dsn = getattr(reporting, "sentry_dsn", "")
+        if not dsn:
+            return False
+
+        import sentry_sdk  # noqa: F401 - optional dependency
+    except ImportError:
+        logging.info("Crash reporting enabled but sentry-sdk is not installed.")
+        return False
+    except Exception as e:
+        logging.warning("Could not initialise crash reporting: %s", e)
+        return False
+
+    def _before_send(event, hint):
+        try:
+            return json.loads(scrub_text(json.dumps(event)))
+        except Exception:
+            return event
+
+    sentry_sdk.init(
+        dsn=dsn,
+        release=getattr(fibsem, "__version__", "unknown"),
+        send_default_pii=False,
+        before_send=_before_send,
+    )
+    logging.info("Crash reporting initialised.")
+    return True

--- a/fibsem/applications/autolamella/tools/bug_report.py
+++ b/fibsem/applications/autolamella/tools/bug_report.py
@@ -316,12 +316,15 @@ def compose_support_email(
 def init_sentry() -> bool:
     """Initialise automatic crash reporting, if enabled and available.
 
-    Inert by default: returns ``False`` unless the user has opted in
+    Inert by default: returns ``False`` unless the bug reporter feature is
+    enabled (``features.bug_report_enabled``), the user has opted in
     (``reporting.crash_reporting_enabled``), provided a DSN, and installed
     ``sentry-sdk``. Safe to call unconditionally at startup.
     """
     try:
         prefs = fibsem_cfg.load_user_preferences()
+        if not getattr(prefs.features, "bug_report_enabled", False):
+            return False
         reporting = getattr(prefs, "reporting", None)
         if reporting is None or not getattr(reporting, "crash_reporting_enabled", False):
             return False

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -481,6 +481,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         coincidence_enabled = self._preferences.features.coincidence_milling_enabled
         self.action_open_coincidence_viewer.setVisible(coincidence_enabled)
         self._action_coincidence_separator.setVisible(coincidence_enabled)
+        # Toggle the "Report an Issue..." Help menu action
+        self.action_report_issue.setVisible(
+            self._preferences.features.bug_report_enabled
+        )
         # Toggle the per-task schedule button in the workflow tab live, so a
         # scheduled-tasks flag change applies without restarting.
         if hasattr(self, "lamella_workflow_widget"):

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -295,6 +295,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         help_menu = menu_bar.addMenu("Help")
         if help_menu is None:
             raise RuntimeError("Failed to create Help menu in AutoLamella UI.")
+        self.action_report_issue = QAction("Report an Issue...", self)
+        self.action_report_issue.triggered.connect(self._on_report_issue)
+        help_menu.addAction(self.action_report_issue)
         self.action_about = QAction("About", self)
         self.action_about.triggered.connect(self._show_about_dialog)
         help_menu.addAction(self.action_about)
@@ -532,6 +535,16 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """Show the About dialog."""
         if self.autolamella_ui is not None:
             self.autolamella_ui.open_information_dialog()
+
+    def _on_report_issue(self):
+        """Open the Report an Issue dialog."""
+        from fibsem.ui.widgets.bug_report_widget import open_bug_report_dialog
+
+        experiment = getattr(self.autolamella_ui, "experiment", None)
+        microscope = getattr(self.autolamella_ui, "microscope", None)
+        open_bug_report_dialog(
+            experiment=experiment, microscope=microscope, parent=self
+        )
 
     def _on_toggle_minimap_widget(self, checked: bool):
         """Toggle the minimap plot dock widget visibility."""
@@ -1664,6 +1677,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
 def run_ui():
     """Run the AutoLamella embedded example."""
+    from fibsem.applications.autolamella.tools.bug_report import init_sentry
+
+    init_sentry()  # inert unless crash reporting is enabled in preferences
     app = QApplication.instance() or QApplication(sys.argv)
     app.setStyle("Fusion")
     window = AutoLamellaSingleWindowUI()

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -10,7 +10,6 @@ except Exception:
     pass
 import logging
 import os
-import subprocess
 import threading
 from copy import deepcopy
 from typing import List, Optional, TYPE_CHECKING
@@ -826,15 +825,7 @@ class AutoLamellaUI(QMainWindow):
             )
             return
 
-        try:
-            if sys.platform.startswith("darwin"):
-                subprocess.Popen(["open", experiment_path])
-            elif os.name == "nt":
-                os.startfile(experiment_path)  # type: ignore[attr-defined]
-            else:
-                subprocess.Popen(["xdg-open", experiment_path])
-        except Exception:
-            logging.exception("Failed to open experiment directory.")
+        if not fui.open_path_in_file_explorer(experiment_path):
             notification_service.show_toast(
                 "Failed to open experiment directory.", "error"
             )

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -254,6 +254,7 @@ class FeatureFlags:
     coincidence_milling_enabled: bool = False
     sample_holder_widget: bool = False
     scheduled_tasks: bool = False
+    bug_report_enabled: bool = False
 
 @dataclass
 class MovementPreferences:

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -275,11 +275,18 @@ class ExperimentPreferences:
     organisation: str = ""
 
 @dataclass
+class ReportingPreferences:
+    contact_email: str = ""
+    crash_reporting_enabled: bool = False
+    sentry_dsn: str = ""
+
+@dataclass
 class UserPreferences:
     display: DisplayPreferences = field(default_factory=DisplayPreferences)
     features: FeatureFlags = field(default_factory=FeatureFlags)
     movement: MovementPreferences = field(default_factory=MovementPreferences)
     experiment: ExperimentPreferences = field(default_factory=ExperimentPreferences)
+    reporting: ReportingPreferences = field(default_factory=ReportingPreferences)
 
     def to_dict(self) -> dict:
         return dataclasses.asdict(self)
@@ -287,12 +294,13 @@ class UserPreferences:
     @classmethod
     def from_dict(cls, d: dict) -> "UserPreferences":
         """Reconstruct from a dict, handling both nested and legacy flat formats."""
-        if any(k in d for k in ("display", "features", "movement", "experiment")):
+        if any(k in d for k in ("display", "features", "movement", "experiment", "reporting")):
             return cls(
                 display=_sub_from_dict(DisplayPreferences, d.get("display", {})),
                 features=_sub_from_dict(FeatureFlags, d.get("features", {})),
                 movement=_sub_from_dict(MovementPreferences, d.get("movement", {})),
                 experiment=_sub_from_dict(ExperimentPreferences, d.get("experiment", {})),
+                reporting=_sub_from_dict(ReportingPreferences, d.get("reporting", {})),
             )
         # Legacy flat format
         prefs = cls()

--- a/fibsem/ui/utils.py
+++ b/fibsem/ui/utils.py
@@ -1,4 +1,8 @@
 
+import logging
+import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -15,6 +19,28 @@ from PyQt5.QtWidgets import (
 
 from fibsem import config as cfg
 from fibsem.microscope import FibsemMicroscope
+
+
+def open_path_in_file_explorer(path: str) -> bool:
+    """Open a directory (or file's location) in the system file explorer.
+
+    Returns True on success. Cross-platform: uses ``open`` on macOS,
+    ``os.startfile`` on Windows, and ``xdg-open`` elsewhere.
+    """
+    if not path or not os.path.isdir(path):
+        logging.warning("Cannot open path in file explorer (not found): %s", path)
+        return False
+    try:
+        if sys.platform.startswith("darwin"):
+            subprocess.Popen(["open", path])
+        elif os.name == "nt":
+            os.startfile(path)  # type: ignore[attr-defined]
+        else:
+            subprocess.Popen(["xdg-open", path])
+        return True
+    except Exception:
+        logging.exception("Failed to open path in file explorer: %s", path)
+        return False
 
 
 class WheelBlocker(QObject):

--- a/fibsem/ui/widgets/bug_report_widget.py
+++ b/fibsem/ui/widgets/bug_report_widget.py
@@ -1,0 +1,284 @@
+"""Dialog for reporting issues / submitting bug reports (optionally with data)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+import fibsem.config as fibsem_cfg
+from fibsem.applications.autolamella.tools import bug_report
+from fibsem.applications.autolamella.tools.bug_report import BugReportContent
+from fibsem.ui import stylesheets
+from fibsem.ui.utils import open_path_in_file_explorer
+from fibsem.ui.widgets.custom_widgets import TitledPanel
+
+if TYPE_CHECKING:
+    from fibsem.applications.autolamella.structures import Experiment
+    from fibsem.microscope import FibsemMicroscope
+
+SEVERITY_OPTIONS = ["Low", "Normal", "High", "Crash"]
+
+
+class BugReportDialog(QDialog):
+    """Collect a bug report and submit it publicly (GitHub) or privately (email)."""
+
+    def __init__(
+        self,
+        experiment: Optional["Experiment"] = None,
+        microscope: Optional["FibsemMicroscope"] = None,
+        traceback_text: str = "",
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(parent)
+        self.experiment = experiment
+        self.microscope = microscope
+        self._system_context = bug_report.collect_system_context(microscope)
+
+        self.setWindowTitle("Report an Issue")
+        self.setModal(True)
+        self.setMinimumWidth(520)
+
+        self._create_widgets(traceback_text)
+        self._setup_layout()
+        self._update_preview()
+
+    def _create_widgets(self, traceback_text: str):
+        self.label_description = QLabel(
+            "Report a bug or issue. Use <b>Report on GitHub</b> for a public "
+            "report (no data), or <b>Create Bundle &amp; Email</b> to send "
+            "experiment data privately to the maintainers."
+        )
+        self.label_description.setWordWrap(True)
+        self.label_description.setStyleSheet("font-style: italic; margin-bottom: 8px;")
+
+        # --- Report details ---
+        details = QWidget()
+        form = QFormLayout(details)
+        form.setContentsMargins(8, 8, 8, 8)
+
+        self.lineEdit_title = QLineEdit()
+        self.lineEdit_title.setPlaceholderText("Short summary of the issue")
+
+        self.combo_severity = QComboBox()
+        self.combo_severity.addItems(SEVERITY_OPTIONS)
+        self.combo_severity.setCurrentText("Crash" if traceback_text else "Normal")
+
+        self.lineEdit_email = QLineEdit()
+        self.lineEdit_email.setPlaceholderText("you@example.com (optional)")
+        prefs = fibsem_cfg.load_user_preferences()
+        self.lineEdit_email.setText(getattr(prefs.reporting, "contact_email", ""))
+
+        self.textEdit_description = QTextEdit()
+        self.textEdit_description.setPlaceholderText("What happened?")
+        if traceback_text:
+            self.textEdit_description.setPlainText(
+                f"An unexpected error occurred:\n\n{traceback_text}"
+            )
+        self.textEdit_description.setMinimumHeight(90)
+
+        self.textEdit_steps = QTextEdit()
+        self.textEdit_steps.setPlaceholderText("1. ...\n2. ...")
+        self.textEdit_steps.setMinimumHeight(60)
+
+        form.addRow("Title", self.lineEdit_title)
+        form.addRow("Severity", self.combo_severity)
+        form.addRow("Contact email", self.lineEdit_email)
+        form.addRow("Description", self.textEdit_description)
+        form.addRow("Steps to reproduce", self.textEdit_steps)
+        self.details_panel = TitledPanel("Details", content=details, collapsible=False)
+
+        # --- Data to include (private bundle only) ---
+        data = QWidget()
+        data_layout = QVBoxLayout(data)
+        data_layout.setContentsMargins(8, 8, 8, 8)
+
+        self.checkbox_logfile = QCheckBox("Log file (logfile.log)")
+        self.checkbox_experiment = QCheckBox("Experiment file (experiment.yaml)")
+        self.checkbox_protocol = QCheckBox("Protocol file (protocol.yaml)")
+        self.checkbox_screenshots = QCheckBox("Task screenshots (.png)")
+        self.checkbox_images = QCheckBox("Image data (.tiff) — may be large")
+        self.checkbox_logfile.setChecked(True)
+        self.checkbox_experiment.setChecked(True)
+        self.checkbox_protocol.setChecked(True)
+
+        has_experiment = self.experiment is not None
+        for cb in (
+            self.checkbox_logfile,
+            self.checkbox_experiment,
+            self.checkbox_protocol,
+            self.checkbox_screenshots,
+            self.checkbox_images,
+        ):
+            cb.setEnabled(has_experiment)
+            cb.stateChanged.connect(lambda _: self._update_preview())
+            data_layout.addWidget(cb)
+
+        if not has_experiment:
+            no_exp = QLabel("No experiment loaded — only text will be sent.")
+            no_exp.setStyleSheet("color: orange; font-style: italic;")
+            data_layout.addWidget(no_exp)
+
+        self.data_panel = TitledPanel(
+            "Data to include", content=data, collapsible=False
+        )
+
+        # --- Preview + privacy note ---
+        self.label_preview = QLabel()
+        self.label_preview.setWordWrap(True)
+        self.label_preview.setStyleSheet("color: gray; font-style: italic;")
+
+        # --- Buttons ---
+        self.button_box = QDialogButtonBox(self)
+        self.pushButton_github = QPushButton("Report on GitHub")
+        self.pushButton_github.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.pushButton_github.setAutoDefault(False)
+        self.pushButton_email = QPushButton("Create Bundle && Email")
+        self.pushButton_email.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.pushButton_email.setAutoDefault(False)
+        self.pushButton_cancel = QPushButton("Cancel")
+        self.pushButton_cancel.setAutoDefault(False)
+
+        self.button_box.addButton(
+            self.pushButton_github, QDialogButtonBox.ActionRole
+        )
+        self.button_box.addButton(self.pushButton_email, QDialogButtonBox.AcceptRole)
+        self.button_box.addButton(self.pushButton_cancel, QDialogButtonBox.RejectRole)
+        self.pushButton_github.clicked.connect(self._on_report_github)
+        self.pushButton_email.clicked.connect(self._on_create_bundle)
+        self.pushButton_cancel.clicked.connect(self.reject)
+
+    def _setup_layout(self):
+        layout = QVBoxLayout()
+        layout.addWidget(self.label_description)
+        layout.addWidget(self.details_panel)
+        layout.addWidget(self.data_panel)
+        layout.addWidget(self.label_preview)
+        layout.addStretch()
+        layout.addWidget(self.button_box)
+        self.setLayout(layout)
+
+    def _content(self) -> BugReportContent:
+        return BugReportContent(
+            title=self.lineEdit_title.text().strip(),
+            description=self.textEdit_description.toPlainText().strip(),
+            steps=self.textEdit_steps.toPlainText().strip(),
+            severity=self.combo_severity.currentText(),
+            contact_email=self.lineEdit_email.text().strip(),
+            include_logfile=self.checkbox_logfile.isChecked(),
+            include_experiment_yaml=self.checkbox_experiment.isChecked(),
+            include_protocol=self.checkbox_protocol.isChecked(),
+            include_screenshots=self.checkbox_screenshots.isChecked(),
+            include_images=self.checkbox_images.isChecked(),
+            system_context=self._system_context,
+        )
+
+    def _update_preview(self):
+        content = self._content()
+        size = bug_report.estimate_bundle_size(self.experiment, content)
+        env = ", ".join(f"{k}={v}" for k, v in self._system_context.items())
+        size_str = f"{size / 1e6:.1f} MB" if size else "0 MB"
+        self.label_preview.setText(
+            f"Bundle size (approx): {size_str}. "
+            f"Text is scrubbed of your home directory / username before sending. "
+            f"Included environment info: {env}"
+        )
+
+    def _persist_email(self, content: BugReportContent):
+        """Remember the contact email for next time."""
+        try:
+            prefs = fibsem_cfg.load_user_preferences()
+            prefs.reporting.contact_email = content.contact_email
+            fibsem_cfg.save_user_preferences(prefs)
+        except Exception as e:
+            logging.debug("Could not persist contact email: %s", e)
+
+    def _validate(self, content: BugReportContent) -> bool:
+        if not content.title and not content.description:
+            QMessageBox.warning(
+                self, "Missing information", "Please add a title or description."
+            )
+            return False
+        return True
+
+    def _on_report_github(self):
+        content = self._content()
+        if not self._validate(content):
+            return
+        try:
+            bug_report.open_github_issue(content)
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Could not open GitHub issue:\n{e}")
+            return
+        self.accept()
+
+    def _on_create_bundle(self):
+        content = self._content()
+        if not self._validate(content):
+            return
+        self._persist_email(content)
+        try:
+            zip_path = bug_report.build_bug_report_bundle(content, self.experiment)
+            bug_report.compose_support_email(content, zip_path)
+        except Exception as e:
+            logging.exception("Failed to create bug report bundle.")
+            QMessageBox.critical(
+                self, "Error", f"Could not create the bug report bundle:\n{e}"
+            )
+            return
+        msg = QMessageBox(self)
+        msg.setIcon(QMessageBox.Information)
+        msg.setWindowTitle("Bug report created")
+        msg.setText("Bug report created")
+        msg.setInformativeText(
+            f"A data bundle was saved to:\n\n{zip_path}\n\n"
+            f"An email to {bug_report.SUPPORT_EMAIL} has been opened — "
+            f"please attach this file before sending."
+        )
+        open_button = msg.addButton("Open Directory", QMessageBox.ActionRole)
+        open_button.setMinimumWidth(
+            open_button.fontMetrics().boundingRect(open_button.text()).width() + 40
+        )
+        msg.addButton(QMessageBox.Ok)
+        msg.exec_()
+        if msg.clickedButton() is open_button:
+            open_path_in_file_explorer(os.path.dirname(zip_path))
+        self.accept()
+
+    def keyPressEvent(self, event):
+        if event.key() in (Qt.Key_Return, Qt.Key_Enter):  # type: ignore
+            event.ignore()
+        else:
+            super().keyPressEvent(event)
+
+
+def open_bug_report_dialog(
+    experiment: Optional["Experiment"] = None,
+    microscope: Optional["FibsemMicroscope"] = None,
+    traceback_text: str = "",
+    parent: Optional[QWidget] = None,
+) -> None:
+    """Convenience helper to construct and show the bug report dialog."""
+    dialog = BugReportDialog(
+        experiment=experiment,
+        microscope=microscope,
+        traceback_text=traceback_text,
+        parent=parent,
+    )
+    dialog.exec_()

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -48,6 +48,11 @@ _TIP_SCHEDULED     = (
     "control to the task editor; the workflow waits until the scheduled time before "
     "running that task."
 )
+_LBL_BUG_REPORT    = "Enable Bug Reporter"
+_TIP_BUG_REPORT    = (
+    "Show the 'Report an Issue...' option in the Help menu, for reporting bugs and "
+    "optionally submitting experiment data privately to the maintainers."
+)
 
 # Experiment defaults
 _LBL_EXP_DIR       = "Default Experiment Directory"
@@ -126,10 +131,13 @@ class PreferencesDialog(QDialog):
         self._chk_sample_holder.setToolTip(_TIP_SAMPLE_HOLDER)
         self._chk_scheduled_tasks = QCheckBox()
         self._chk_scheduled_tasks.setToolTip(_TIP_SCHEDULED)
+        self._chk_bug_report = QCheckBox()
+        self._chk_bug_report.setToolTip(_TIP_BUG_REPORT)
         features_form.addRow(_LBL_LAMELLA_LIVE, self._chk_lamella_live)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
         features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
         features_form.addRow(_LBL_SCHEDULED, self._chk_scheduled_tasks)
+        features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
         self._stack.addWidget(features_page)
 
         # --- Experiment Defaults ---
@@ -190,6 +198,7 @@ class PreferencesDialog(QDialog):
         self._chk_coincidence_milling.setChecked(f.coincidence_milling_enabled)
         self._chk_sample_holder.setChecked(f.sample_holder_widget)
         self._chk_scheduled_tasks.setChecked(f.scheduled_tasks)
+        self._chk_bug_report.setChecked(f.bug_report_enabled)
 
         e = prefs.experiment
         self._dir_experiment.setText(e.default_experiment_directory)
@@ -245,6 +254,7 @@ class PreferencesDialog(QDialog):
                 coincidence_milling_enabled=self._chk_coincidence_milling.isChecked(),
                 sample_holder_widget=self._chk_sample_holder.isChecked(),
                 scheduled_tasks=self._chk_scheduled_tasks.isChecked(),
+                bug_report_enabled=self._chk_bug_report.isChecked(),
             ),
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),
@@ -254,8 +264,11 @@ class PreferencesDialog(QDialog):
                 default_experiment_directory=self._dir_experiment.text(),
                 default_protocol_path=self._dir_protocol.text(),
                 last_experiment_path=self._preferences.experiment.last_experiment_path,
+                recent_experiments=self._preferences.experiment.recent_experiments,
                 user=self._edit_exp_user.text(),
                 project=self._edit_exp_project.text(),
                 organisation=self._edit_exp_organisation.text(),
             ),
+            # Preserve sections not managed by this dialog.
+            reporting=self._preferences.reporting,
         )

--- a/tests/autolamella/test_bug_report.py
+++ b/tests/autolamella/test_bug_report.py
@@ -1,0 +1,156 @@
+"""Tests for the bug report bundle builder and its helpers."""
+
+import getpass
+import os
+import zipfile
+from types import SimpleNamespace
+
+import pytest
+
+from fibsem.applications.autolamella.tools import bug_report
+from fibsem.applications.autolamella.tools.bug_report import BugReportContent
+
+
+def _make_experiment(tmp_path):
+    """Create a fake experiment directory with typical artifacts on disk."""
+    exp_dir = tmp_path / "AutoLamella-test"
+    (exp_dir / "01-lam" / "Milling").mkdir(parents=True)
+
+    home = os.path.expanduser("~")
+    (exp_dir / "logfile.log").write_text(f"path {home}/secret error boom")
+    (exp_dir / "experiment.yaml").write_text(f"path: {home}/secret\nname: exp")
+    (exp_dir / "protocol.yaml").write_text("tasks: 4")
+    (exp_dir / "01-lam" / "shot.png").write_bytes(b"PNGDATA")
+    (exp_dir / "01-lam" / "Milling" / "z.ome.tiff").write_bytes(b"TIFFDATA")
+
+    return SimpleNamespace(name="AutoLamella-test", path=str(exp_dir))
+
+
+def _names(zip_path):
+    with zipfile.ZipFile(zip_path) as zf:
+        return zf.namelist()
+
+
+def test_bundle_filename_and_base_contents(tmp_path):
+    """A bundle with no experiment still contains the report + system info."""
+    content = BugReportContent(title="t", description="d", system_context={"a": "b"})
+    zip_path = bug_report.build_bug_report_bundle(
+        content, experiment=None, output_dir=str(tmp_path)
+    )
+
+    fname = os.path.basename(zip_path)
+    assert fname.startswith("bug-report-autolamella-")
+    assert fname.endswith(".zip")
+    assert "AutoLamella-test" not in fname  # experiment name is not in filename
+
+    names = _names(zip_path)
+    assert "report.md" in names
+    assert "system_info.json" in names
+
+
+def test_bundle_includes_selected_text_files_scrubbed(tmp_path):
+    """Default selection includes the log/yaml files, scrubbed of the home dir."""
+    experiment = _make_experiment(tmp_path)
+    content = BugReportContent(title="t", description="d")  # defaults: text on
+
+    zip_path = bug_report.build_bug_report_bundle(
+        content, experiment=experiment, output_dir=str(tmp_path)
+    )
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+        log_name = next(n for n in names if n.endswith("logfile.log"))
+        log_text = zf.read(log_name).decode()
+
+    assert any(n.endswith("experiment.yaml") for n in names)
+    assert any(n.endswith("protocol.yaml") for n in names)
+    # screenshots / images are off by default
+    assert not any(n.endswith(".png") for n in names)
+    assert not any(n.endswith(".tiff") for n in names)
+    # home directory scrubbed out of text artifacts
+    assert os.path.expanduser("~") not in log_text
+    assert "<redacted>" in log_text
+
+
+def test_bundle_excludes_text_files_when_unselected(tmp_path):
+    experiment = _make_experiment(tmp_path)
+    content = BugReportContent(
+        include_logfile=False,
+        include_experiment_yaml=False,
+        include_protocol=False,
+    )
+    zip_path = bug_report.build_bug_report_bundle(
+        content, experiment=experiment, output_dir=str(tmp_path)
+    )
+    names = _names(zip_path)
+    assert not any(n.endswith(".log") for n in names)
+    assert not any(n.endswith(".yaml") for n in names)
+    # base artifacts always present
+    assert "report.md" in names
+
+
+def test_bundle_includes_images_when_opted_in(tmp_path):
+    """Binary artifacts are added verbatim only when explicitly selected."""
+    experiment = _make_experiment(tmp_path)
+    content = BugReportContent(include_screenshots=True, include_images=True)
+
+    zip_path = bug_report.build_bug_report_bundle(
+        content, experiment=experiment, output_dir=str(tmp_path)
+    )
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+        tiff_name = next(n for n in names if n.endswith(".ome.tiff"))
+        tiff_bytes = zf.read(tiff_name)
+
+    assert any(n.endswith(".png") for n in names)
+    assert tiff_bytes == b"TIFFDATA"  # binary included verbatim, not scrubbed
+
+
+def test_estimate_bundle_size(tmp_path):
+    experiment = _make_experiment(tmp_path)
+    empty = BugReportContent(
+        include_logfile=False,
+        include_experiment_yaml=False,
+        include_protocol=False,
+    )
+    assert bug_report.estimate_bundle_size(experiment, empty) == 0
+    assert bug_report.estimate_bundle_size(None, BugReportContent()) == 0
+
+    full = BugReportContent(include_screenshots=True, include_images=True)
+    assert bug_report.estimate_bundle_size(experiment, full) > 0
+
+
+@pytest.mark.parametrize(
+    "text, needle",
+    [
+        (f"{os.path.expanduser('~')}/x", os.path.expanduser("~")),
+        ("/home/someoneelse/data", "/home/someoneelse/"),
+        (f"user={getpass.getuser()}", getpass.getuser()),
+    ],
+)
+def test_scrub_text_removes_identifying_info(text, needle):
+    scrubbed = bug_report.scrub_text(text)
+    assert needle not in scrubbed
+
+
+def test_scrub_text_handles_empty():
+    assert bug_report.scrub_text("") == ""
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "done for /Users/bob",  # trailing username, no separator
+        "path /Users/bob/file.txt",  # username mid-path
+        r"see C:\Users\alice",  # windows trailing username
+        r"C:\Users\alice\project\x",  # windows mid-path
+        "home /home/carol",  # linux trailing username
+    ],
+)
+def test_scrub_text_redacts_other_user_paths(text):
+    """Usernames of *other* users are redacted, incl. trailing (no separator)."""
+    scrubbed = bug_report.scrub_text(text)
+    for name in ("bob", "alice", "carol"):
+        assert name not in scrubbed
+    assert "<user>" in scrubbed

--- a/tests/autolamella/test_bug_report.py
+++ b/tests/autolamella/test_bug_report.py
@@ -138,6 +138,20 @@ def test_scrub_text_handles_empty():
     assert bug_report.scrub_text("") == ""
 
 
+def test_bug_report_feature_flag_defaults_off_and_roundtrips():
+    """The bug_report_enabled flag defaults off and survives yaml round-trip."""
+    import fibsem.config as cfg
+
+    assert cfg.FeatureFlags().bug_report_enabled is False
+
+    prefs = cfg.UserPreferences()
+    prefs.features.bug_report_enabled = True
+    prefs.reporting.contact_email = "me@example.org"
+    restored = cfg.UserPreferences.from_dict(prefs.to_dict())
+    assert restored.features.bug_report_enabled is True
+    assert restored.reporting.contact_email == "me@example.org"
+
+
 @pytest.mark.parametrize(
     "text",
     [


### PR DESCRIPTION
## Summary

Adds a **Help → Report an Issue…** dialog to AutoLamella so users can report bugs and optionally submit experiment data privately.

Two submission paths:
- **Public** — opens a pre-filled GitHub issue in the browser (no data leaves the machine; body warns not to paste private data).
- **Private** — builds a scrubbed `.zip` bundle of selected experiment artifacts and opens a pre-filled support email (`contact@fibsemos.org`) to attach it to. Native `mailto:` (opens the OS default mail client).

## Privacy handling
- Data checkboxes: log / `experiment.yaml` / `protocol.yaml` **on** by default; screenshots and `.tiff` image data **opt-in** (with a size estimate).
- Text artifacts are scrubbed of the user's home directory / username before being bundled (handles current user, other-user paths, and Windows `C:\Users\...`, including trailing usernames with no separator). Images are included verbatim only when selected.

## Notes
- `bug-report-autolamella-<timestamp>.zip`, saved into the experiment directory; the confirmation dialog has an **Open Directory** button.
- Inert `init_sentry()` wired at startup — no-op until `sentry-sdk` is installed and a DSN + opt-in are set in preferences (`ReportingPreferences` added to user preferences).
- Extracted a shared `fibsem.ui.utils.open_path_in_file_explorer()` helper, now reused by `AutoLamellaUI.open_experiment_directory` too.

## Testing
- New unit tests (`tests/autolamella/test_bug_report.py`, 14 tests): bundle filename/contents, default vs opt-in file selection, verbatim image inclusion, size estimation, and scrubbing (incl. trailing/other-user/Windows paths). All pass.
- Reviewed with a multi-angle pass (correctness + cleanup); the surviving finding (a scrub gap for trailing usernames) and two cleanups (glob overlap, duplicated directory-open logic) are fixed in this PR.