### PR TITLE
[ui] render icons offline via qtawesome instead of network Iconify

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -31,7 +31,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 from superqt import ensure_main_thread
-from superqt.iconify import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 import fibsem
 import fibsem.config as fibsem_cfg
@@ -617,7 +617,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.user_attention_btn = QPushButton("Attention Required")
         self.user_attention_btn.setStyleSheet(USER_ATTENTION_BUTTON_STYLESHEET)
         self.user_attention_btn.setIcon(
-            QIconifyIcon("mdi:alert-circle", color=GRAY_ICON_COLOR)
+            fibsem_icon("mdi:alert-circle", color=GRAY_ICON_COLOR)
         )
         self.user_attention_btn.hide()  # Hidden by default
         self.user_attention_btn.setToolTip(
@@ -639,7 +639,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.run_workflow_btn = QPushButton("Run Workflow")
         self.run_workflow_btn.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         self.run_workflow_btn.setIcon(
-            QIconifyIcon("mdi:play-circle", color=GRAY_ICON_COLOR)
+            fibsem_icon("mdi:play-circle", color=GRAY_ICON_COLOR)
         )
         self.run_workflow_btn.setEnabled(False)
         self.run_workflow_btn.setToolTip("Run the AutoLamella workflow.")
@@ -650,7 +650,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.stop_workflow_btn = QPushButton("Stop Workflow")
         self.stop_workflow_btn.setStyleSheet(STOP_WORKFLOW_BUTTON_STYLESHEET)
         self.stop_workflow_btn.setIcon(
-            QIconifyIcon("mdi:stop-circle", color=GRAY_ICON_COLOR)
+            fibsem_icon("mdi:stop-circle", color=GRAY_ICON_COLOR)
         )
         self.stop_workflow_btn.hide()  # Hidden by default
         self.stop_workflow_btn.setToolTip(
@@ -778,7 +778,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         supervised = get_task_supervision(task_name, self.autolamella_ui)
         if supervised:
             self.supervised_status_btn.setIcon(
-                QIconifyIcon("mdi:account-hard-hat", color="white")
+                fibsem_icon("mdi:account-hard-hat", color="white")
             )
             self.supervised_status_btn.setText("Supervised")
             self.supervised_status_btn.setToolTip(
@@ -789,7 +789,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             )
         else:
             self.supervised_status_btn.setIcon(
-                QIconifyIcon("mdi:lightning-bolt", color="white")
+                fibsem_icon("mdi:lightning-bolt", color="white")
             )
             self.supervised_status_btn.setText("Automated")
             self.supervised_status_btn.setToolTip(
@@ -1004,7 +1004,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         layout.addWidget(splitter)
         self.tab_widget.addTab(
             container,
-            QIconifyIcon("mdi:microscope", color=GRAY_ICON_COLOR),
+            fibsem_icon("mdi:microscope", color=GRAY_ICON_COLOR),
             "Microscope",
         )
 
@@ -1148,7 +1148,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         layout.addWidget(self.task_widget)
         self.tab_widget.addTab(
             container,
-            QIconifyIcon("mdi:file-document-edit", color=GRAY_ICON_COLOR),
+            fibsem_icon("mdi:file-document-edit", color=GRAY_ICON_COLOR),
             "Protocol",
         )
 
@@ -1232,7 +1232,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         layout.addWidget(outer_splitter)
         self.tab_widget.addTab(
-            container, QIconifyIcon("mdi:layers", color=GRAY_ICON_COLOR), "Lamella"
+            container, fibsem_icon("mdi:layers", color=GRAY_ICON_COLOR), "Lamella"
         )
         self._lamella_tab_container = container
 
@@ -1318,7 +1318,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         layout.addWidget(splitter)
         self.tab_widget.addTab(
             container,
-            QIconifyIcon("mdi:play-circle-outline", color=GRAY_ICON_COLOR),
+            fibsem_icon("mdi:play-circle-outline", color=GRAY_ICON_COLOR),
             "Workflow",
         )
 
@@ -1635,7 +1635,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         splitter.setSizes([700, 500])
         layout.addWidget(splitter)
         self.tab_widget.insertTab(
-            1, container, QIconifyIcon("mdi:map", color=GRAY_ICON_COLOR), "Overview"
+            1, container, fibsem_icon("mdi:map", color=GRAY_ICON_COLOR), "Overview"
         )
 
         # disable the tab by default

--- a/fibsem/ui/FibsemImageSettingsWidget.py
+++ b/fibsem/ui/FibsemImageSettingsWidget.py
@@ -9,7 +9,8 @@ from napari.layers import Shapes as NapariShapesLayer
 from napari.qt.threading import thread_worker
 from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtCore import QEvent, pyqtSignal
-from superqt import QIconifyIcon, ensure_main_thread
+from superqt import ensure_main_thread
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem import acquire, constants, utils
 from fibsem.microscope import FibsemMicroscope
@@ -254,8 +255,8 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         self.pushButton_run_autocontrast.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         self.pushButton_run_autofocus.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
 
-        self.pushButton_run_autocontrast.setIcon(QIconifyIcon("mdi:contrast-circle", color=stylesheets.GRAY_ICON_COLOR))
-        self.pushButton_run_autofocus.setIcon(QIconifyIcon("mdi:image-filter-center-focus", color=stylesheets.GRAY_ICON_COLOR))
+        self.pushButton_run_autocontrast.setIcon(fibsem_icon("mdi:contrast-circle", color=stylesheets.GRAY_ICON_COLOR))
+        self.pushButton_run_autofocus.setIcon(fibsem_icon("mdi:image-filter-center-focus", color=stylesheets.GRAY_ICON_COLOR))
 
         self.acquisition_buttons: List[QtWidgets.QPushButton] = [
             self.pushButton_take_all_images,

--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -6,7 +6,7 @@ from typing import Optional
 import napari
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import pyqtSignal
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem import config as cfg
 from fibsem import utils
@@ -129,7 +129,7 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
 
         self.pushButton_apply_configuration.clicked.connect(lambda: self.apply_microscope_configuration(None))
         self.pushButton_apply_configuration.setToolTip("Apply configuration can take some time. Please make sure the microscope beams are both on.")
-        self.toolButton_import_configuration.setIcon(QIconifyIcon("mdi:add", color="#a0a0a0"))
+        self.toolButton_import_configuration.setIcon(fibsem_icon("mdi:add", color="#a0a0a0"))
 
     def load_configuration(self, configuration_name: Optional[str] = None) -> Optional[str]:
         if configuration_name is None:
@@ -240,7 +240,7 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
 
             info = self.microscope.system.info
             self._label_status_icon.setPixmap(
-                QIconifyIcon("mdi:check-circle", color=stylesheets.GREEN_COLOR).pixmap(20, 20)
+                fibsem_icon("mdi:check-circle", color=stylesheets.GREEN_COLOR).pixmap(20, 20)
             )
             self._label_status_title.setText("Microscope Connected")
             self._label_status_subtitle.setText(
@@ -256,7 +256,7 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
             self.disconnected_signal.emit()
 
             self._label_status_icon.setPixmap(
-                QIconifyIcon("mdi:close-circle", color="#f44336").pixmap(20, 20)
+                fibsem_icon("mdi:close-circle", color="#f44336").pixmap(20, 20)
             )
             self._label_status_title.setText("Not Connected")
             self._label_status_subtitle.setText("No microscope connected")

--- a/fibsem/ui/fm/widgets/line_plot_widget.py
+++ b/fibsem/ui/fm/widgets/line_plot_widget.py
@@ -16,7 +16,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 _OVERLAY_BTN_STYLE = (
     "QPushButton { background: rgba(40,41,48,180); border: 1px solid #555;"
@@ -127,7 +127,7 @@ class LinePlotWidget(QWidget):
         # ── Overlay buttons (parented to canvas, stacked right-to-left) ──────
         def _obtn(icon_name: str, tooltip: str, checkable: bool = False) -> QPushButton:
             btn = QPushButton(self.canvas)
-            btn.setIcon(QIconifyIcon(icon_name, color="#aaaaaa"))
+            btn.setIcon(fibsem_icon(icon_name, color="#aaaaaa"))
             btn.setIconSize(_OVERLAY_ICON_SIZE)
             btn.setFixedSize(_OVERLAY_BTN_SIZE, _OVERLAY_BTN_SIZE)
             btn.setToolTip(tooltip)
@@ -490,10 +490,10 @@ class LinePlotWidget(QWidget):
         self.updates_paused = not self.updates_paused
 
         if self.updates_paused:
-            self.pause_button.setIcon(QIconifyIcon("mdi:play", color="#ff9800"))
+            self.pause_button.setIcon(fibsem_icon("mdi:play", color="#ff9800"))
             self.pause_button.setToolTip("Resume live updates")
         else:
-            self.pause_button.setIcon(QIconifyIcon("mdi:pause", color="#aaaaaa"))
+            self.pause_button.setIcon(fibsem_icon("mdi:pause", color="#aaaaaa"))
             self.pause_button.setToolTip("Pause live updates")
             # Trigger a plot update with the current data when resuming
             if len(self.data_buffer) > 0:
@@ -503,10 +503,10 @@ class LinePlotWidget(QWidget):
         """Toggle between datetime and sample index x-axis."""
         self.use_datetime_axis = not self.use_datetime_axis
         if self.use_datetime_axis:
-            self.xaxis_button.setIcon(QIconifyIcon("mdi:clock-outline", color="#aaaaaa"))
+            self.xaxis_button.setIcon(fibsem_icon("mdi:clock-outline", color="#aaaaaa"))
             self.xaxis_button.setToolTip("X axis: Time — click to switch to Sample index")
         else:
-            self.xaxis_button.setIcon(QIconifyIcon("mdi:numeric", color="#aaaaaa"))
+            self.xaxis_button.setIcon(fibsem_icon("mdi:numeric", color="#aaaaaa"))
             self.xaxis_button.setToolTip("X axis: Sample index — click to switch to Time")
 
         # Force axes re-setup and replot

--- a/fibsem/ui/icon.py
+++ b/fibsem/ui/icon.py
@@ -1,0 +1,58 @@
+"""Central icon factory for the fibsem UI, backed by qtawesome.
+
+Icons are referenced throughout the UI by Iconify-style keys such as
+``"mdi:check-circle"``. This module resolves them against qtawesome's *bundled*
+Material Design Icons font, so the application renders every icon **fully
+offline** - no network access, no icon assets committed to the repo.
+
+Keeping this one indirection point means:
+  * the ``"mdi:<name>"`` key convention (including dynamically-built names like
+    ``f"mdi:numeric-{n}-box-outline"``) keeps working unchanged;
+  * the handful of names that differ between Iconify's MDI and qtawesome's MDI6
+    are remapped in exactly one place (see ``_REMAP``);
+  * the icon backend can be swapped again from a single file.
+
+Usage mirrors the previous ``QIconifyIcon`` call sites::
+
+    btn.setIcon(fibsem_icon("mdi:check-circle", color="#4caf50"))
+
+Extra keyword arguments pass straight through to ``qtawesome.icon`` (e.g.
+``color_active``, ``color_disabled`` for per-state colouring).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import qtawesome as qta
+from qtpy.QtGui import QIcon
+
+# qtawesome's font prefix for Material Design Icons v6.
+_MDI = "mdi6"
+
+# Names that exist in Iconify's MDI but not under the same key in MDI6.
+_REMAP = {
+    "add": "plus",            # iconify aliases "add" -> "plus"; MDI6 has no "add"
+    "file-transfer": "file-send",  # MDI6 has no "file-transfer"
+}
+
+
+def fibsem_icon(key: str, color: Optional[str] = None, **kwargs) -> QIcon:
+    """Return a :class:`QIcon` for an ``"mdi:<name>"`` (or bare ``<name>``) key.
+
+    Rendered from qtawesome's offline MDI6 font. ``color`` is applied exactly as
+    before; any additional ``qtawesome.icon`` keyword arguments are forwarded.
+    """
+    name = key.split(":", 1)[1] if ":" in key else key
+    name = _REMAP.get(name, name)
+    if color is not None:
+        kwargs["color"] = color
+    try:
+        return qta.icon(f"{_MDI}.{name}", **kwargs)
+    except Exception:
+        # Unknown/misspelled icon name: qtawesome raises, but widget code (often
+        # a paint/refresh path) expects a QIcon. Degrade gracefully to a blank
+        # icon - matching the old superqt.QIconifyIcon, which drew a placeholder
+        # rather than crashing - and log so the missing key can be fixed.
+        logging.warning("fibsem_icon: unknown icon %r; rendering blank", key)
+        return QIcon()

--- a/fibsem/ui/icon.py
+++ b/fibsem/ui/icon.py
@@ -24,7 +24,14 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-import qtawesome as qta
+try:
+    import qtawesome as qta
+except ModuleNotFoundError as e:  # pragma: no cover - dependency guard
+    raise ModuleNotFoundError(
+        "The fibsem UI requires 'qtawesome' for offline icon rendering "
+        "(added in this version). Install it with:\n"
+        "    pip install 'fibsem[ui]'   (or: pip install qtawesome)"
+    ) from e
 from qtpy.QtGui import QIcon
 
 # qtawesome's font prefix for Material Design Icons v6.

--- a/fibsem/ui/widgets/autolamella_load_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_load_experiment_widget.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 from PyQt5 import QtCore, QtGui, QtWidgets
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem.applications.autolamella import config as cfg
 from fibsem.applications.autolamella.structures import (
@@ -65,7 +65,7 @@ ERROR_INVALID_LEGACY_PROTOCOL_MSG = (
 # Width of the recent-experiments quick-select column
 RECENT_COLUMN_WIDTH = 260
 
-# Recent-experiment row icons (superqt / material design icons) and colours
+# Recent-experiment row icons (material design icons) and colours
 RECENT_FOLDER_ICON = "mdi:folder-outline"
 RECENT_LAMELLA_ICON = "mdi:layers-triple-outline"
 RECENT_ALERT_ICON = "mdi:alert-circle-outline"
@@ -589,7 +589,7 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         icon_name = RECENT_FOLDER_ICON if available else RECENT_ALERT_ICON
         folder_label = QtWidgets.QLabel()
         folder_label.setPixmap(
-            QIconifyIcon(icon_name, color=icon_color).pixmap(18, 18)
+            fibsem_icon(icon_name, color=icon_color).pixmap(18, 18)
         )
         folder_label.setFixedWidth(18)
         layout.addWidget(folder_label, alignment=QtCore.Qt.AlignVCenter)
@@ -641,7 +641,7 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
 
         icon_label = QtWidgets.QLabel()
         icon_label.setPixmap(
-            QIconifyIcon(RECENT_LAMELLA_ICON, color=RECENT_PILL_TEXT_COLOR).pixmap(12, 12)
+            fibsem_icon(RECENT_LAMELLA_ICON, color=RECENT_PILL_TEXT_COLOR).pixmap(12, 12)
         )
         count_label = QtWidgets.QLabel(str(num_lamella))
         count_label.setStyleSheet(

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -6,8 +6,9 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, List, Optional, Union
 
-from PyQt5.QtCore import QSize, Qt, QTimer, pyqtSignal
-from PyQt5.QtGui import QCursor, QIcon, QTransform
+import qtawesome as qta
+from PyQt5.QtCore import QSize, Qt, pyqtSignal
+from PyQt5.QtGui import QCursor, QIcon, QPainter
 from PyQt5.QtWidgets import (
     QAbstractItemView,
     QAbstractSpinBox,
@@ -26,7 +27,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem.ui import stylesheets as stylesheets
 from fibsem.ui.utils import WheelBlocker
@@ -522,7 +523,7 @@ class TitledPanel(QWidget):
             expanded = True
         self._body.setVisible(expanded)
         icon = "mdi:chevron-up" if expanded else "mdi:chevron-down"
-        self._btn_collapse.setIcon(QIconifyIcon(icon, color=stylesheets.GRAY_ICON_COLOR))
+        self._btn_collapse.setIcon(fibsem_icon(icon, color=stylesheets.GRAY_ICON_COLOR))
         self._btn_collapse.setToolTip("Collapse" if expanded else "Expand")
 
     def set_title(self, title: str) -> None:
@@ -542,37 +543,50 @@ class TitledPanel(QWidget):
 
 
 class _SpinnerLabel(QLabel):
-    """Rotating icon label used as a lightweight acquisition progress indicator."""
+    """Spinning icon label used as a lightweight acquisition progress indicator.
+
+    Backed by qtawesome's native ``Spin`` animation: the icon engine rotates the
+    glyph and repaints this widget on a timer, so there is no manual rotation
+    bookkeeping. The animation timer is created lazily on first paint, so we let
+    it ``autostart`` and drive visibility via :meth:`start`/:meth:`stop`.
+    """
 
     def __init__(self, icon_name="mdi:loading", color="#4fc3f7", size=24,
                  step_deg=20, interval_ms=40, parent=None):
         super().__init__(parent)
-        self._pixmap = QIconifyIcon(icon_name, color=color).pixmap(size, size)
-        self._angle = 0
-        self._step = step_deg
-        self._timer = QTimer(self)
-        self._timer.setInterval(interval_ms)
-        self._timer.timeout.connect(self._tick)
+        self._spin = qta.Spin(self, interval=interval_ms, step=step_deg)
+        self._icon = fibsem_icon(icon_name, color=color, animation=self._spin)
+        self._active = False
         self.setFixedSize(size, size)
         self.setAlignment(Qt.AlignCenter)
-        self._render()
         self.setStyleSheet("background: transparent;")
 
-    def _tick(self):
-        self._angle = (self._angle + self._step) % 360
-        self._render()
-
-    def _render(self):
-        t = QTransform().rotate(self._angle)
-        self.setPixmap(self._pixmap.transformed(t, Qt.SmoothTransformation))
+    def paintEvent(self, event):
+        # only draw (and thereby drive the animation) while active
+        if not self._active:
+            return
+        painter = QPainter(self)
+        try:
+            self._icon.paint(painter, self.rect())
+        finally:
+            painter.end()
 
     def start(self):
-        self._timer.start()
+        self._active = True
+        # first paint registers the widget with the Spin (autostart=True) and
+        # starts its timer; _spin.start() then resumes it on a start-after-stop.
+        self.update()
+        self._spin.start()
 
     def stop(self):
-        self._timer.stop()
-        self._angle = 0
-        self._render()
+        self._active = False
+        self._spin.stop()
+        self.update()        # repaint blank
+
+    def clear(self):
+        # blanking the spinner implies stopping its animation
+        self.stop()
+        super().clear()
 
 
 class IconToolButton(QToolButton):
@@ -638,14 +652,14 @@ class IconToolButton(QToolButton):
             super().setChecked(checked)
             self._on_toggled(checked)
         else:
-            self.setIcon(QIconifyIcon(self._icon, color=self._color))
+            self.setIcon(fibsem_icon(self._icon, color=self._color))
             if tooltip:
                 self.setToolTip(tooltip)
 
     def _on_toggled(self, checked: bool) -> None:
         icon = self._checked_icon if checked else self._icon
         color = self._checked_color if checked else self._color
-        self.setIcon(QIconifyIcon(icon, color=color))
+        self.setIcon(fibsem_icon(icon, color=color))
         tip = self._checked_tooltip if checked else self._tooltip
         if tip is not None:
             self.setToolTip(tip)
@@ -824,7 +838,7 @@ class _LamellaRow(QWidget):
 
         # Direct action buttons (replaces "…" dropdown)
         self.btn_move_to = QToolButton()
-        self.btn_move_to.setIcon(QIconifyIcon("mdi:crosshairs-gps", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_move_to.setIcon(fibsem_icon("mdi:crosshairs-gps", color=stylesheets.GRAY_ICON_COLOR))
         self.btn_move_to.setToolTip("Move to Position")
         self.btn_move_to.setFixedSize(_LAMELLA_BTN_SIZE)
         self.btn_move_to.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
@@ -832,7 +846,7 @@ class _LamellaRow(QWidget):
         layout.addWidget(self.btn_move_to)
 
         self.btn_edit = QToolButton()
-        self.btn_edit.setIcon(QIconifyIcon("mdi:pencil", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_edit.setIcon(fibsem_icon("mdi:pencil", color=stylesheets.GRAY_ICON_COLOR))
         self.btn_edit.setToolTip("Edit Lamella")
         self.btn_edit.setFixedSize(_LAMELLA_BTN_SIZE)
         self.btn_edit.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
@@ -840,7 +854,7 @@ class _LamellaRow(QWidget):
         layout.addWidget(self.btn_edit)
 
         self.btn_update = QToolButton()
-        self.btn_update.setIcon(QIconifyIcon("mdi:map-marker-check", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_update.setIcon(fibsem_icon("mdi:map-marker-check", color=stylesheets.GRAY_ICON_COLOR))
         self.btn_update.setToolTip("Update Position")
         self.btn_update.setFixedSize(_LAMELLA_BTN_SIZE)
         self.btn_update.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
@@ -853,7 +867,7 @@ class _LamellaRow(QWidget):
 
         # Remove button
         self.btn_remove = QToolButton()
-        self.btn_remove.setIcon(QIconifyIcon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_remove.setIcon(fibsem_icon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR))
         self.btn_remove.setToolTip("Remove")
         self.btn_remove.setFixedSize(_LAMELLA_BTN_SIZE)
         self.btn_remove.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
@@ -870,13 +884,13 @@ class _LamellaRow(QWidget):
             return
         menu = QMenu(self)
         action_none = menu.addAction(
-            QIconifyIcon("mdi:check-circle", color=stylesheets.GREEN_COLOR), "No defect"
+            fibsem_icon("mdi:check-circle", color=stylesheets.GREEN_COLOR), "No defect"
         )
         action_rework = menu.addAction(
-            QIconifyIcon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR), "Rework required"
+            fibsem_icon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR), "Rework required"
         )
         action_failure = menu.addAction(
-            QIconifyIcon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR), "Failure"
+            fibsem_icon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR), "Failure"
         )
         chosen = menu.exec_(self.btn_defect.mapToGlobal(self.btn_defect.rect().bottomLeft()))
         if chosen == action_none:
@@ -906,7 +920,7 @@ class _LamellaRow(QWidget):
         # Update defect icon if visible
         if self.btn_defect.isVisible():
             icon_name, icon_color, tooltip = _lamella_defect_icon(self.lamella)
-            self.btn_defect.setIcon(QIconifyIcon(icon_name, color=icon_color))
+            self.btn_defect.setIcon(fibsem_icon(icon_name, color=icon_color))
             self.btn_defect.setToolTip(tooltip)
 
 
@@ -1078,7 +1092,7 @@ class LamellaNameListWidget(QWidget):
             # Set icon directly — row.refresh() won't work here because
             # isVisible() returns False before the row is parented via setItemWidget
             icon_name, icon_color, tooltip = _lamella_defect_icon(row.lamella)
-            row.btn_defect.setIcon(QIconifyIcon(icon_name, color=icon_color))
+            row.btn_defect.setIcon(fibsem_icon(icon_name, color=icon_color))
             row.btn_defect.setToolTip(tooltip)
 
     # ------------------------------------------------------------------

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, List, Optional, Union
 
-import qtawesome as qta
 from PyQt5.QtCore import QSize, Qt, pyqtSignal
 from PyQt5.QtGui import QCursor, QIcon, QPainter
 from PyQt5.QtWidgets import (
@@ -27,7 +26,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.icon import fibsem_icon, qta
 
 from fibsem.ui import stylesheets as stylesheets
 from fibsem.ui.utils import WheelBlocker

--- a/fibsem/ui/widgets/dual_beam_widget.py
+++ b/fibsem/ui/widgets/dual_beam_widget.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamSettings, BeamType, FibsemDetectorSettings
@@ -78,11 +78,11 @@ class FibsemDualBeamWidget(QWidget):
 
         # --- Beam on / blanked buttons ---
         self.btn_beam_on = QToolButton()
-        self.btn_beam_on.setIcon(QIconifyIcon("mdi:power", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_beam_on.setIcon(fibsem_icon("mdi:power", color=stylesheets.GRAY_ICON_COLOR))
         self.btn_beam_on.setToolTip("Toggle beam on/off")
 
         self.btn_beam_blanked = QToolButton()
-        self.btn_beam_blanked.setIcon(QIconifyIcon("mdi:eye", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_beam_blanked.setIcon(fibsem_icon("mdi:eye", color=stylesheets.GRAY_ICON_COLOR))
         self.btn_beam_blanked.setToolTip("Toggle beam blank/unblank")
 
         # --- Refresh button ---
@@ -220,12 +220,12 @@ class FibsemDualBeamWidget(QWidget):
         is_blanked = self.microscope.is_blanked(bt)
 
         power_color = stylesheets.GREEN_COLOR if is_on else stylesheets.ORANGE_COLOR
-        self.btn_beam_on.setIcon(QIconifyIcon("mdi:power", color=power_color))
+        self.btn_beam_on.setIcon(fibsem_icon("mdi:power", color=power_color))
         self.btn_beam_on.setToolTip("Beam ON — click to turn off" if is_on else "Beam OFF — click to turn on")
 
         eye_icon = "mdi:eye-off" if is_blanked else "mdi:eye"
         eye_color = stylesheets.ORANGE_COLOR if is_blanked else stylesheets.GRAY_ICON_COLOR
-        self.btn_beam_blanked.setIcon(QIconifyIcon(eye_icon, color=eye_color))
+        self.btn_beam_blanked.setIcon(fibsem_icon(eye_icon, color=eye_color))
         self.btn_beam_blanked.setToolTip("Blanked — click to unblank" if is_blanked else "Unblanked — click to blank")
 
     def sync_from_microscope(self):

--- a/fibsem/ui/widgets/fibsem_image_flow_widget.py
+++ b/fibsem/ui/widgets/fibsem_image_flow_widget.py
@@ -17,7 +17,8 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QFlowLayout, QIconifyIcon
+from superqt import QFlowLayout
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem.structures import FibsemImage
 
@@ -96,7 +97,7 @@ class FibsemImageCard(QWidget):
 
         # Zoom button — top-right of the image container
         self._zoom_btn = QPushButton(img_container)
-        self._zoom_btn.setIcon(QIconifyIcon("mdi:magnify", color="#cccccc"))
+        self._zoom_btn.setIcon(fibsem_icon("mdi:magnify", color="#cccccc"))
         self._zoom_btn.setFixedSize(28, 28)
         self._zoom_btn.setStyleSheet(
             "QPushButton {"

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -49,7 +49,8 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import ensure_main_thread, QDoubleSlider, QIconifyIcon
+from superqt import ensure_main_thread, QDoubleSlider
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem import conversions
 from fibsem.imaging.autogamma import apply_gamma
@@ -979,12 +980,12 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         auto_row.setSpacing(4)
         self.btn_autocontrast_fib = QPushButton("AutoContrast")
         self.btn_autocontrast_fib.setIcon(
-            QIconifyIcon("mdi:contrast-circle", color=stylesheets.GRAY_ICON_COLOR)
+            fibsem_icon("mdi:contrast-circle", color=stylesheets.GRAY_ICON_COLOR)
         )
         self.btn_autocontrast_fib.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         self.btn_autofocus_fib = QPushButton("AutoFocus")
         self.btn_autofocus_fib.setIcon(
-            QIconifyIcon(
+            fibsem_icon(
                 "mdi:image-filter-center-focus", color=stylesheets.GRAY_ICON_COLOR
             )
         )
@@ -1138,7 +1139,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
 
         self.btn_milling = QPushButton("Start Milling")
         self.btn_milling.setIcon(
-            QIconifyIcon("mdi:play-circle", color=stylesheets.GRAY_ICON_COLOR)
+            fibsem_icon("mdi:play-circle", color=stylesheets.GRAY_ICON_COLOR)
         )
         self.btn_milling.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
 
@@ -1148,7 +1149,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
 
         self.label_threshold_chip = QPushButton("Threshold Reached")
         self.label_threshold_chip.setIcon(
-            QIconifyIcon("mdi:alert-circle", color=stylesheets.GRAY_ICON_COLOR)
+            fibsem_icon("mdi:alert-circle", color=stylesheets.GRAY_ICON_COLOR)
         )
         self.label_threshold_chip.setStyleSheet(
             stylesheets.USER_ATTENTION_BUTTON_STYLESHEET
@@ -1765,7 +1766,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             self.progressBar_stages.setVisible(True)
             self.btn_milling.setText("Stop Milling")
             self.btn_milling.setIcon(
-                QIconifyIcon("mdi:stop-circle", color=stylesheets.GRAY_ICON_COLOR)
+                fibsem_icon("mdi:stop-circle", color=stylesheets.GRAY_ICON_COLOR)
             )
             self.btn_milling.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
             self.btn_pause_milling.setVisible(True)
@@ -1789,7 +1790,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             self.progressBar_stages.setVisible(False)
             self.btn_milling.setText("Start Milling")
             self.btn_milling.setIcon(
-                QIconifyIcon("mdi:play-circle", color=stylesheets.GRAY_ICON_COLOR)
+                fibsem_icon("mdi:play-circle", color=stylesheets.GRAY_ICON_COLOR)
             )
             self.btn_milling.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
             self.btn_pause_milling.setVisible(False)

--- a/fibsem/ui/widgets/hook_config_widget.py
+++ b/fibsem/ui/widgets/hook_config_widget.py
@@ -22,7 +22,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt.iconify import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem.applications.autolamella.workflows.tasks.hooks import (
     FunctionHook,

--- a/fibsem/ui/widgets/image_canvas.py
+++ b/fibsem/ui/widgets/image_canvas.py
@@ -35,7 +35,7 @@ from matplotlib.figure import Figure
 from matplotlib.patches import Rectangle as MplRectangle
 from PyQt5.QtCore import QObject, QSize, QTimer, Qt, pyqtSignal
 from PyQt5.QtWidgets import QPushButton, QSizePolicy
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem.structures import FibsemImage
 
@@ -274,7 +274,7 @@ class FibsemImageCanvas(FigureCanvasQTAgg):
         repositioned automatically on resize.  Returns the button.
         """
         btn = QPushButton(self)
-        btn.setIcon(QIconifyIcon(icon_name, color="#aaaaaa"))
+        btn.setIcon(fibsem_icon(icon_name, color="#aaaaaa"))
         btn.setIconSize(_OVERLAY_ICON_SIZE)
         btn.setFixedSize(_OVERLAY_BTN_SIZE, _OVERLAY_BTN_SIZE)
         btn.setToolTip(tooltip)

--- a/fibsem/ui/widgets/lamella_card_widget.py
+++ b/fibsem/ui/widgets/lamella_card_widget.py
@@ -16,7 +16,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem.applications.autolamella.structures import DefectState, DefectType, Lamella
 from fibsem.ui.widgets.lamella_list_widget import _defect_icon, _status_text
@@ -130,18 +130,18 @@ class LamellaCardWidget(QWidget):
         self._btn_actions = QToolButton()
         self._btn_actions.setFixedSize(_BTN_SIZE, _BTN_SIZE)
         self._btn_actions.setStyleSheet(_BTN_STYLE + " QToolButton::menu-indicator { image: none; }")
-        self._btn_actions.setIcon(QIconifyIcon("mdi:dots-horizontal", color=stylesheets.GRAY_ICON_COLOR))
+        self._btn_actions.setIcon(fibsem_icon("mdi:dots-horizontal", color=stylesheets.GRAY_ICON_COLOR))
         self._btn_actions.setToolTip("Actions")
         self._btn_actions.setPopupMode(QToolButton.InstantPopup)
         _actions_menu = QMenu(self)
         self._action_move = _actions_menu.addAction(
-            QIconifyIcon("mdi:crosshairs-gps", color=stylesheets.GRAY_ICON_COLOR), "Move to Position"
+            fibsem_icon("mdi:crosshairs-gps", color=stylesheets.GRAY_ICON_COLOR), "Move to Position"
         )
         self._action_update = _actions_menu.addAction(
-            QIconifyIcon("mdi:map-marker-check", color=stylesheets.GRAY_ICON_COLOR), "Update Position"
+            fibsem_icon("mdi:map-marker-check", color=stylesheets.GRAY_ICON_COLOR), "Update Position"
         )
         self._action_remove = _actions_menu.addAction(
-            QIconifyIcon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR), "Remove"
+            fibsem_icon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR), "Remove"
         )
         self._btn_actions.setMenu(_actions_menu)
         self._action_move.triggered.connect(lambda: self.move_to_requested.emit(self.lamella))
@@ -181,7 +181,7 @@ class LamellaCardWidget(QWidget):
         self._name_label.setText(self.lamella.name)
 
         icon_name, icon_color, tooltip = _defect_icon(self.lamella)
-        self._btn_defect.setIcon(QIconifyIcon(icon_name, color=icon_color))
+        self._btn_defect.setIcon(fibsem_icon(icon_name, color=icon_color))
         self._btn_defect.setToolTip(tooltip)
 
         status_text, status_style = _status_text(self.lamella)
@@ -218,13 +218,13 @@ class LamellaCardWidget(QWidget):
     def _on_defect_clicked(self) -> None:
         menu = QMenu(self)
         action_none = menu.addAction(
-            QIconifyIcon("mdi:check-circle", color=stylesheets.GREEN_COLOR), "No defect"
+            fibsem_icon("mdi:check-circle", color=stylesheets.GREEN_COLOR), "No defect"
         )
         action_rework = menu.addAction(
-            QIconifyIcon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR), "Rework required"
+            fibsem_icon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR), "Rework required"
         )
         action_failure = menu.addAction(
-            QIconifyIcon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR), "Failure"
+            fibsem_icon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR), "Failure"
         )
 
         chosen = menu.exec_(self._btn_defect.mapToGlobal(

--- a/fibsem/ui/widgets/lamella_list_widget.py
+++ b/fibsem/ui/widgets/lamella_list_widget.py
@@ -19,7 +19,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem.applications.autolamella.structures import (
     AutoLamellaTaskStatus,
@@ -140,7 +140,7 @@ class LamellaRowWidget(QWidget):
         layout.addWidget(self.status_label, 1)
 
         self.btn_defect = QToolButton()
-        self.btn_defect.setIcon(QIconifyIcon("mdi:circle", color=stylesheets.GREEN_COLOR))
+        self.btn_defect.setIcon(fibsem_icon("mdi:circle", color=stylesheets.GREEN_COLOR))
         self.btn_defect.setFixedSize(_BTN_SIZE)
         self.btn_defect.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
         layout.addWidget(self.btn_defect)
@@ -172,13 +172,13 @@ class LamellaRowWidget(QWidget):
     def _on_defect_clicked(self) -> None:
         menu = QMenu(self)
         action_none = menu.addAction(
-            QIconifyIcon("mdi:check-circle", color=stylesheets.GREEN_COLOR), "No defect"
+            fibsem_icon("mdi:check-circle", color=stylesheets.GREEN_COLOR), "No defect"
         )
         action_rework = menu.addAction(
-            QIconifyIcon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR), "Rework required"
+            fibsem_icon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR), "Rework required"
         )
         action_failure = menu.addAction(
-            QIconifyIcon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR), "Failure"
+            fibsem_icon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR), "Failure"
         )
 
         chosen = menu.exec_(self.btn_defect.mapToGlobal(
@@ -229,7 +229,7 @@ class LamellaRowWidget(QWidget):
         self.name_label.setText(self.lamella.name)
 
         icon_name, icon_color, tooltip = _defect_icon(self.lamella)
-        self.btn_defect.setIcon(QIconifyIcon(icon_name, color=icon_color))
+        self.btn_defect.setIcon(fibsem_icon(icon_name, color=icon_color))
         self.btn_defect.setToolTip(tooltip)
 
         status_text, status_style = _status_text(self.lamella)

--- a/fibsem/ui/widgets/milling_task_config_widget2.py
+++ b/fibsem/ui/widgets/milling_task_config_widget2.py
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem import constants
 from fibsem.microscope import FibsemMicroscope
@@ -218,7 +218,7 @@ class MillingTaskConfigWidget2(QWidget):
 
     def _update_stage_count_icon(self, n: int) -> None:
         icon_name = "mdi:numeric-9-plus-box-outline" if n > 9 else f"mdi:numeric-{n}-box-outline"
-        self._btn_stage_count.setIcon(QIconifyIcon(icon_name, color=stylesheets.GRAY_ICON_COLOR))
+        self._btn_stage_count.setIcon(fibsem_icon(icon_name, color=stylesheets.GRAY_ICON_COLOR))
         self._btn_stage_count.setToolTip(f"{n} stage{'s' if n != 1 else ''}")
 
     def _emit_settings_changed(self) -> None:

--- a/fibsem/ui/widgets/notifications.py
+++ b/fibsem/ui/widgets/notifications.py
@@ -18,7 +18,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt.iconify import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 from fibsem.constants import TIME_DISPLAY
 from fibsem.ui import stylesheets
 
@@ -63,7 +63,7 @@ class ToastNotification(QWidget):
 
         # Close button
         self.close_btn = QToolButton()
-        self.close_btn.setIcon(QIconifyIcon("mdi:close", color="#888"))
+        self.close_btn.setIcon(fibsem_icon("mdi:close", color="#888"))
         self.close_btn.setFixedSize(20, 20)
         self.close_btn.clicked.connect(self.hide_toast)
         self.close_btn.setCursor(Qt.PointingHandCursor)
@@ -344,9 +344,9 @@ class NotificationBell(QWidget):
         self.setFixedSize(28, 28)
         self.setCursor(Qt.PointingHandCursor)
 
-        # Bell icon button using QToolButton with QIconifyIcon
+        # Bell icon button using QToolButton with a Material Design icon
         self.bell_btn = QToolButton()
-        self.bell_btn.setIcon(QIconifyIcon("mdi:bell", color="#d6d6d6"))
+        self.bell_btn.setIcon(fibsem_icon("mdi:bell", color="#d6d6d6"))
         self.bell_btn.setFixedSize(24, 24)
         self.bell_btn.setIconSize(self.bell_btn.size() * 0.7)
         self.bell_btn.clicked.connect(self._on_clicked)

--- a/fibsem/ui/widgets/sample_holder_widget.py
+++ b/fibsem/ui/widgets/sample_holder_widget.py
@@ -15,7 +15,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 from fibsem.microscopes._stage import GridSlot, SampleGrid, SampleHolder
 from fibsem.ui import stylesheets
@@ -76,7 +76,7 @@ class _GridSlotRowWidget(QWidget):
         self.btn_capture = QToolButton()
         self.btn_capture.setFixedSize(_ACTIONS_BTN_SIZE, _ACTIONS_BTN_SIZE)
         self.btn_capture.setStyleSheet(_BTN_STYLE)
-        self.btn_capture.setIcon(QIconifyIcon("mdi:map-marker-plus", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_capture.setIcon(fibsem_icon("mdi:map-marker-plus", color=stylesheets.GRAY_ICON_COLOR))
         self.btn_capture.setToolTip("Update Position")
         self.btn_capture.setVisible(_show_move)
         self.btn_capture.clicked.connect(lambda: self.capture_clicked.emit(self.slot))
@@ -86,7 +86,7 @@ class _GridSlotRowWidget(QWidget):
         self.btn_move = QToolButton()
         self.btn_move.setFixedSize(_ACTIONS_BTN_SIZE, _ACTIONS_BTN_SIZE)
         self.btn_move.setStyleSheet(_BTN_STYLE)
-        self.btn_move.setIcon(QIconifyIcon("mdi:crosshairs-gps", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_move.setIcon(fibsem_icon("mdi:crosshairs-gps", color=stylesheets.GRAY_ICON_COLOR))
         self.btn_move.setToolTip("Move to Position")
         self.btn_move.setVisible(_show_move)
         self.btn_move.clicked.connect(lambda: self.move_clicked.emit(self.slot))
@@ -98,7 +98,7 @@ class _GridSlotRowWidget(QWidget):
         self.btn_clear.setFixedSize(_ACTIONS_BTN_SIZE, _ACTIONS_BTN_SIZE)
         self.btn_clear.setStyleSheet(_BTN_STYLE)
         self.btn_clear.setIcon(
-            QIconifyIcon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR)
+            fibsem_icon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR)
         )
         self.btn_clear.setToolTip("Remove grid from this slot")
         self.btn_clear.setVisible(show_grid_edit)

--- a/fibsem/ui/widgets/tests/test-spinner-icon.py
+++ b/fibsem/ui/widgets/tests/test-spinner-icon.py
@@ -1,4 +1,4 @@
-"""Test script for SVG spinner icons using superqt's QIconifyIcon + QTimer rotation."""
+"""Test script for spinner icons using fibsem_icon (qtawesome) + QTimer rotation."""
 from __future__ import annotations
 
 import sys
@@ -8,16 +8,16 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtGui import QTransform
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 
 class SpinnerLabel(QLabel):
-    """A QLabel that spins a QIconifyIcon at a given speed."""
+    """A QLabel that spins an icon at a given speed."""
 
     def __init__(self, icon_name: str, color: str = "#d6d6d6", size: int = 32,
                  step_deg: int = 15, interval_ms: int = 50, parent=None):
         super().__init__(parent)
-        self._pixmap = QIconifyIcon(icon_name, color=color).pixmap(size, size)
+        self._pixmap = fibsem_icon(icon_name, color=color).pixmap(size, size)
         self._angle = 0
         self._step = step_deg
         self._timer = QTimer(self)

--- a/fibsem/ui/widgets/workflow_config_widget.py
+++ b/fibsem/ui/widgets/workflow_config_widget.py
@@ -18,7 +18,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 import fibsem.config as fcfg
 from fibsem.constants import DATETIME_DISPLAY_AMPM
@@ -159,15 +159,15 @@ class WorkflowTaskRowWidget(QWidget):
         requires_text = ", ".join(self.task.requires) if self.task.requires else "No requirements"
         self.requires_label.setText(requires_text)
         icon_name, icon_color, tooltip = _supervise_icon(self.task)
-        self.btn_supervise.setIcon(QIconifyIcon(icon_name, color=icon_color))
+        self.btn_supervise.setIcon(fibsem_icon(icon_name, color=icon_color))
         self.btn_supervise.setToolTip(tooltip)
         if self.task.scheduled_at is not None:
-            self.btn_schedule.setIcon(QIconifyIcon("mdi:clock", color=stylesheets.WHITE_ICON_COLOR))
+            self.btn_schedule.setIcon(fibsem_icon("mdi:clock", color=stylesheets.WHITE_ICON_COLOR))
             self.btn_schedule.setToolTip(
                 f"Scheduled: {self.task.scheduled_at.strftime(DATETIME_DISPLAY_AMPM)}"
             )
         else:
-            self.btn_schedule.setIcon(QIconifyIcon("mdi:clock-outline", color="#606060"))
+            self.btn_schedule.setIcon(fibsem_icon("mdi:clock-outline", color="#606060"))
             self.btn_schedule.setToolTip("Not scheduled — click to set")
 
 

--- a/fibsem/ui/widgets/workflow_task_editor_widget.py
+++ b/fibsem/ui/widgets/workflow_task_editor_widget.py
@@ -16,7 +16,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QIconifyIcon
+from fibsem.ui.icon import fibsem_icon
 
 import fibsem.config as fcfg
 from fibsem.applications.autolamella.structures import AutoLamellaTaskDescription
@@ -107,7 +107,7 @@ class WorkflowTaskEditorWidget(QWidget):
         header_row = QHBoxLayout()
         header_row.setSpacing(8)
         icon_lbl = QLabel()
-        icon_lbl.setPixmap(QIconifyIcon("mdi:pencil", color="#a0a0a0").pixmap(18, 18))
+        icon_lbl.setPixmap(fibsem_icon("mdi:pencil", color="#a0a0a0").pixmap(18, 18))
         icon_lbl.setStyleSheet("background: transparent;")
         header_row.addWidget(icon_lbl)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ ui = [
     "napari>=0.5.1,<=0.5.6; python_version >= '3.9'", # NumPy 2 well supported from 0.5.1
     "pyqt5>=5.15.9",
     "matplotlib_scalebar>=0.8.1",
+    "qtawesome>=1.3.0", # bundled Material Design Icons font (offline icon rendering); >=1.3.0 for Spin.start/stop
 ]
 odemis = ["pylibtiff", "shapely"]
 


### PR DESCRIPTION
## Summary

The AutoLamella / fibsem UI fetched Material Design icons from `api.iconify.design` at widget-build time (`superqt.QIconifyIcon`), so it **required an internet connection** and showed placeholder `?` icons when offline — a problem for air-gapped microscope PCs. This replaces that with **qtawesome**, which bundles the MDI font, so icons render **fully offline with no committed icon assets**.

This was chosen over committing a curated SVG bundle because it makes offline correctness *unconditional* (the whole MDI set is always present, so a new icon can never silently break offline) while adding no new transitive dependencies (`qtawesome` only needs `qtpy`, already present) and net-removing bespoke code. It renders identically to the previous icons at UI sizes.

## Changes

- **New `fibsem/ui/icon.py` shim** — `fibsem_icon("mdi:<name>", color=…)` maps Iconify-style keys to qtawesome's `mdi6` font. It centralizes the two names MDI6 renames (`add`→`plus`, `file-transfer`→`file-send`) and **degrades to a blank icon on an unknown key** (matching the old `superqt` placeholder behaviour instead of crashing).
- **Migrated 18 widget modules** from `superqt.QIconifyIcon` to `fibsem_icon` (mechanical import + call-site rename; the `"mdi:…"` key convention and dynamic `f"mdi:numeric-{n}-box-outline"` names are unchanged).
- **`_SpinnerLabel` reworked** onto qtawesome's native `Spin` animation (no more manual `QTimer`/`QTransform` rotation).
- **`pyproject.toml`** — added `qtawesome>=1.3.0` to the `ui` extra (`>=1.3.0` because `Spin.start`/`Spin.stop` were introduced there; py38-compatible).

## Verification

- All 19 migrated modules import cleanly; every static + dynamic icon name resolves in the bundled MDI6 font.
- Spinner lifecycle tested headless: spins, `stop()`/`clear()` blank + halt the timer, restart-after-stop works.
- The real AutoLamella UI launched against this branch with no icon/import errors.

## Review

Self-reviewed with a multi-angle pass; fixed 5 issues before opening: the `qtawesome` version floor (would `AttributeError` on <1.3.0), the unknown-icon crash regression (now graceful), `QPainter` lifecycle, `clear()` semantics, and a stale comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)