### PR TITLE
AutoLamella shortcut creator

### DIFF
--- a/fibsem/applications/autolamella/tools/shortcut_creator.py
+++ b/fibsem/applications/autolamella/tools/shortcut_creator.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import shutil
+
+import pyshortcuts
+
+
+def _check_create_shortcut(shortcut_type: str) -> bool:
+    msg = f"Do you wish to create a {shortcut_type} shortcut'? [Y/N]"
+    option = str(input(msg)).strip().lower()
+    if option in ("y", "yes"):
+        return True
+    elif option in ("n", "no"):
+        return False
+    print(f"Invalid option '{option}'")
+    return _check_create_shortcut(shortcut_type=shortcut_type)
+
+
+def _create_shortcut_file(
+    desktop: bool = True, start_menu: bool = True, gui: bool = True
+) -> None:
+    pyshortcuts.make_shortcut(
+        shutil.which("fibsem-autolamella-ui"),
+        name="AutoLamella",
+        desktop=desktop,
+        startmenu=start_menu,
+    )
+
+
+def create_shortcuts() -> None:
+    _create_shortcut_file(
+        desktop=_check_create_shortcut("desktop"),
+        start_menu=_check_create_shortcut("start menu"),
+    )
+
+
+if __name__ == "__main__":
+    create_shortcuts()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,12 +68,15 @@ reporting = [
 
 server = ["fastapi>=0.100.0", "uvicorn[standard]>=0.20.0", "requests>=2.28.0"]
 
+shortcuts = ["pyshortcuts"]
+
 [project.scripts]
 fibsem_ui = "fibsem.ui.FibsemUI:main"
 fibsem_label = "fibsem.ui.FibsemLabellingUI:main"
 fibsem-generate-config = "fibsem.configuration:gen_config_cli"
 fibsem-config-ui = "fibsem.ui.FibsemMicroscopeConfigurationWidget:main"
 fibsem-autolamella-ui = "fibsem.applications.autolamella.ui.AutoLamellaMainUI:run_ui"
+fibsem-automaella-shortcut = "fibsem.applications.autolamella.tools.shortcut_creator:create_shortcuts"
 fm-ui = "fibsem.ui.FMAcquisitionWidget:main"
 fm-image-viewer-ui = "fibsem.ui.fm.widgets.fm_image_viewer_widget:main"
 fibsem-correlation-ui = "fibsem.correlation.ui.widgets.correlation_tab_widget:main"


### PR DESCRIPTION
I'm currently writing docs for AM and I thought it would be nice to have a simple way to start AutoLamella, so I threw this together. A couple of things I'm not sure about:
1. Is there a logo included somewhere I can add?
2. Having it as `pyshortcuts` in a separate dependency group makes it a bit clunky to use but also it doesn't really belong anywhere else (the most relevant group would be 'ui' but that seems like a push).
3. I had some issues with running `uv sync`, which I can do in a separate PR for if you think it's relevant:
  - ~~I had to limit `requires-python = ">=3.8, <3.14"`~~ Turns out this is fixed by the other change
  - I had to add `"pyqt5-qt5 == 5.15.2 ; platform_system == 'Windows'"` to the 'ui' requirement group, since more recent versions haven't got a Windows version.

@patrickcleeve2  What do you think?
