### PR TITLE
Fix pyqt5-qt5 dependency on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ ui = [
     "napari>=0.4.17; python_version < '3.9'",         # Python 3.8 support stops after 0.4.19
     "napari>=0.5.1,<=0.5.6; python_version >= '3.9'", # NumPy 2 well supported from 0.5.1
     "pyqt5>=5.15.9",
+    "pyqt5-qt5 == 5.15.2 ; platform_system == 'Windows'",
     "matplotlib_scalebar>=0.8.1",
     "qtawesome>=1.3.0", # bundled Material Design Icons font (offline icon rendering); >=1.3.0 for Spin.start/stop
 ]


### PR DESCRIPTION
Only Linux and MacOS have pyqt5-qt5 releases > 5.12.2, so without updating to PyQt6 pyqt5-qt5 has to be set at 5.15.2 for Windows. This issue was highlighted to me by `uv` trying and failing to generate a lock file with consistent versions across the board.