### PR TITLE
[docs] Recommend Miniforge and document uv install option

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -8,8 +8,12 @@
 
 ### Python
 Python 3.9+ is required.
-The [Anaconda distribution](https://www.anaconda.com/distribution/)
-of python is recommended.
+We recommend installing Python via [Miniforge](https://conda-forge.org/download/),
+a minimal installer that uses the community-maintained
+[conda-forge](https://conda-forge.org/) channel by default. It provides the same
+`conda` (and `mamba`) commands as Anaconda/Miniconda while staying lightweight and
+avoiding the licensing terms that can apply to Anaconda's default channels for larger
+organizations.
 
 ## Setting up your python virtual environment
 It is also highly recommended to use virtual environments for development,
@@ -17,7 +21,8 @@ see [Managing Conda Environments](https://docs.conda.io/projects/conda/en/latest
 for more information.
 (Optionally, you could use `virtualenv` if you prefer.)
 
-Create a new virutal environment from the Anaconda Prompt terminal:
+Create a new virtual environment from your conda terminal (the Miniforge Prompt on
+Windows, or any terminal on macOS/Linux):
 ```
 cd fibsem
 conda env create -n fibsem python=3.11 pip
@@ -42,6 +47,34 @@ Once activated, move to the fibsem root directory and install fibsem like so
 ```
 pip install -e .
 ```
+
+### Installation with uv
+
+[uv](https://docs.astral.sh/uv/) is a fast, drop-in replacement for `pip`.
+
+First, install uv (see the [official install guide](https://docs.astral.sh/uv/getting-started/installation/)
+for all options):
+```
+# macOS / Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+```
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+Alternatively, install it into an existing environment with `pip install uv`.
+
+uv works inside either environment above (conda or virtualenv) with nothing extra to
+set up. Once your environment is created and activated, install fibsem with:
+```
+uv pip install -e .
+```
+To include the GUI dependencies, install the `ui` extra:
+```
+uv pip install -e '.[ui]'
+```
+This resolves the same dependencies from `pyproject.toml` as `pip`, just faster.
+No lockfile or additional configuration is required.
 
 ## Installing Microscope Hardware APIs
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -27,8 +27,10 @@ Windows, or any terminal on macOS/Linux):
 cd fibsem
 conda env create -n fibsem python=3.11 pip
 conda activate fibsem
-python -m pip install -e .
+python -m pip install -e ".[ui]"
 ```
+The `[ui]` extra installs the GUI dependencies (recommended). To install without the
+GUI, use `python -m pip install -e .` instead.
 
 ### Installation through Python virtualenv
 
@@ -45,8 +47,10 @@ fibsem\Scripts\activate.bat
 ```
 Once activated, move to the fibsem root directory and install fibsem like so
 ```
-python -m pip install -e .
+python -m pip install -e ".[ui]"
 ```
+The `[ui]` extra installs the GUI dependencies (recommended). To install without the
+GUI, use `python -m pip install -e .` instead.
 
 ### Installation with uv
 
@@ -81,7 +85,7 @@ extra to set up — just activate that environment instead.
 
 Once your environment is active, install fibsem with the GUI dependencies (recommended):
 ```
-uv pip install -e '.[ui]'
+uv pip install -e ".[ui]"
 ```
 To install without the GUI dependencies:
 ```

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -45,7 +45,7 @@ fibsem\Scripts\activate.bat
 ```
 Once activated, move to the fibsem root directory and install fibsem like so
 ```
-pip install -e .
+python -m pip install -e .
 ```
 
 ### Installation with uv

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -27,7 +27,7 @@ Windows, or any terminal on macOS/Linux):
 cd fibsem
 conda env create -n fibsem python=3.11 pip
 conda activate fibsem
-pip install -e .
+python -m pip install -e .
 ```
 
 ### Installation through Python virtualenv

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -64,14 +64,28 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 ```
 Alternatively, install it into an existing environment with `pip install uv`.
 
-uv works inside either environment above (conda or virtualenv) with nothing extra to
-set up. Once your environment is created and activated, install fibsem with:
+uv can create and manage the virtual environment itself, so you don't need conda or
+`virtualenv`. From the fibsem root directory, create and activate an environment:
 ```
-uv pip install -e .
+# macOS / Linux
+uv venv
+source .venv/bin/activate
 ```
-To include the GUI dependencies, install the `ui` extra:
+```
+# Windows (PowerShell)
+uv venv
+.venv\Scripts\activate
+```
+uv also works inside a conda or `virtualenv` environment created above, with nothing
+extra to set up — just activate that environment instead.
+
+Once your environment is active, install fibsem with the GUI dependencies (recommended):
 ```
 uv pip install -e '.[ui]'
+```
+To install without the GUI dependencies:
+```
+uv pip install -e .
 ```
 This resolves the same dependencies from `pyproject.toml` as `pip`, just faster.
 No lockfile or additional configuration is required.


### PR DESCRIPTION
Closes #121.

Updates `INSTALLATION.md` per the issue:

- Recommends [Miniforge](https://conda-forge.org/download/) over the Anaconda distribution — conda-forge-based, lightweight, and avoids Anaconda's channel licensing terms that affect many academic institutions.
- Adds an **Installation with uv** section documenting `uv pip install` as a faster drop-in for pip (addresses the follow-up comment), including how to install uv and the `.[ui]` extra. No lockfile or migration to `uv sync` — pip/conda flows are unchanged.

Docs-only; no dependency or tooling changes.

Both `uv pip install -e .` and `uv pip install -e '.[ui]'` were tested locally on macOS (resolve + editable install + imports OK).