### PR TITLE
[feat] Add separate width per trench component

### DIFF
--- a/fibsem/milling/patterning/patterns2.py
+++ b/fibsem/milling/patterning/patterns2.py
@@ -597,6 +597,24 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
             "tooltip": "Height of the lower trench.",
         },
     )
+    upper_trench_width: Optional[float] = field(
+        default=None,
+        metadata={
+            "label": "Upper Trench Width",
+            **DEFAULT_DISTANCE_METADATA,
+            "advanced": True,
+            "tooltip": "Width of the upper trench. If None, uses Width.",
+        },
+    )
+    lower_trench_width: Optional[float] = field(
+        default=None,
+        metadata={
+            "label": "Lower Trench Width",
+            **DEFAULT_DISTANCE_METADATA,
+            "advanced": True,
+            "tooltip": "Width of the lower trench. If None, uses Width.",
+        },
+    )
     cross_section: CrossSectionPattern = field(
         default=CrossSectionPattern.Rectangle, metadata=DEFAULT_CROSS_SECTION_METADATA
     )
@@ -627,29 +645,23 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
         ])
 
     def define(self) -> List[Union[FibsemRectangleSettings, FibsemCircleSettings]]:
-
         point = self.point
-        width = self.width
         spacing = self.spacing
         upper_trench_height = self.upper_trench_height
         lower_trench_height = self.lower_trench_height
         depth = self.depth
         cross_section = self.cross_section
         time = self.time
-        fillet = self.fillet
+        upper_trench_width = self.width if self.upper_trench_width is None else self.upper_trench_width
+        lower_trench_width = self.width if self.lower_trench_width is None else self.lower_trench_width
 
         # calculate the centre of the upper and lower trench
         centre_lower_y = point.y - (spacing / 2 + lower_trench_height / 2)
         centre_upper_y = point.y + (spacing / 2 + upper_trench_height / 2)
 
-        # fillet radius on the corners
-        fillet = np.clip(fillet, 0, upper_trench_height / 2)
-        if fillet > 0:
-            width = max(0, width - 2 * fillet) # ensure width is not negative
-
         # mill settings
         lower_trench_settings = FibsemRectangleSettings(
-            width=width,
+            width=lower_trench_width,
             height=lower_trench_height,
             depth=depth,
             centre_x=point.x,
@@ -660,7 +672,7 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
         )
 
         upper_trench_settings = FibsemRectangleSettings(
-            width=width,
+            width=upper_trench_width,
             height=upper_trench_height,
             depth=depth,
             centre_x=point.x,
@@ -672,85 +684,107 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
 
         self.shapes = [upper_trench_settings, lower_trench_settings]
 
+        # fillet radius must fit both trench height and width
+        max_fillet = min(
+            upper_trench_height / 2,
+            lower_trench_height / 2,
+            upper_trench_width / 2,
+            lower_trench_width / 2,
+        )
+        fillet = float(np.clip(self.fillet, 0.0, max_fillet))
+        if fillet <= 0:
+            return self.shapes
+
+        lower_inner_width = max(0.0, lower_trench_width - 2 * fillet)
+        upper_inner_width = max(0.0, upper_trench_width - 2 * fillet)
+
+        lower_left_x = point.x - lower_inner_width / 2
+        lower_right_x = point.x + lower_inner_width / 2
+        upper_left_x = point.x - upper_inner_width / 2
+        upper_right_x = point.x + upper_inner_width / 2
+
         # add fillet to the corners
-        if fillet > 0:            
-            left_x_pos = point.x - width / 2
-            right_x_pos = point.x + width / 2
+        fillet_offset = 1.5
+        lower_y_pos = centre_lower_y + lower_trench_height / 2 - fillet * fillet_offset
+        top_y_pos = centre_upper_y - upper_trench_height / 2 + fillet * fillet_offset
 
-            fillet_offset = 1.5
-            lower_y_pos = centre_lower_y + lower_trench_height / 2 - fillet * fillet_offset
-            top_y_pos = centre_upper_y - upper_trench_height / 2 + fillet * fillet_offset
+        lower_left_fillet = FibsemCircleSettings(
+            radius=fillet,
+            depth=depth / 2,
+            centre_x=lower_left_x,
+            centre_y=lower_y_pos,
+        )
+        lower_right_fillet = FibsemCircleSettings(
+            radius=fillet,
+            depth=depth / 2,
+            centre_x=lower_right_x,
+            centre_y=lower_y_pos,
+        )
 
-            lower_left_fillet = FibsemCircleSettings(
-                radius=fillet,
-                depth=depth/2,
-                centre_x=point.x - width / 2,
-                centre_y=lower_y_pos,
-            )
-            lower_right_fillet = FibsemCircleSettings(
-                radius=fillet,
-                depth=depth/2,
-                centre_x=point.x + width / 2,
-                centre_y=lower_y_pos,
-            )
+        # fill the remaining space with rectangles
+        lower_left_fill = FibsemRectangleSettings(
+            width=fillet,
+            height=lower_trench_height - fillet,
+            depth=depth,
+            centre_x=lower_left_x - fillet / 2,
+            centre_y=centre_lower_y - fillet / 2,
+            cross_section=cross_section,
+            scan_direction="BottomToTop",
+        )
+        lower_right_fill = FibsemRectangleSettings(
+            width=fillet,
+            height=lower_trench_height - fillet,
+            depth=depth,
+            centre_x=lower_right_x + fillet / 2,
+            centre_y=centre_lower_y - fillet / 2,
+            cross_section=cross_section,
+            scan_direction="BottomToTop",
+        )
 
-            # fill the remaining space with rectangles
-            lower_left_fill = FibsemRectangleSettings(
-                width=fillet,
-                height=lower_trench_height - fillet,
-                depth=depth,
-                centre_x=left_x_pos - fillet / 2,
-                centre_y=centre_lower_y - fillet / 2,
-                cross_section = cross_section,
-                scan_direction="BottomToTop",
+        top_left_fillet = FibsemCircleSettings(
+            radius=fillet,
+            depth=depth,
+            centre_x=upper_left_x,
+            centre_y=top_y_pos,
+        )
+        top_right_fillet = FibsemCircleSettings(
+            radius=fillet,
+            depth=depth,
+            centre_x=upper_right_x,
+            centre_y=top_y_pos,
+        )
 
-            )
-            lower_right_fill = FibsemRectangleSettings(
-                width=fillet,
-                height=lower_trench_height - fillet,
-                depth=depth,
-                centre_x=right_x_pos + fillet / 2,
-                centre_y=centre_lower_y - fillet / 2,
-                cross_section = cross_section,
-                scan_direction="BottomToTop",
-            )
+        top_left_fill = FibsemRectangleSettings(
+            width=fillet,
+            height=upper_trench_height - fillet,
+            depth=depth,
+            centre_x=upper_left_x - fillet / 2,
+            centre_y=centre_upper_y + fillet / 2,
+            cross_section=cross_section,
+            scan_direction="TopToBottom",
+        )
+        top_right_fill = FibsemRectangleSettings(
+            width=fillet,
+            height=upper_trench_height - fillet,
+            depth=depth,
+            centre_x=upper_right_x + fillet / 2,
+            centre_y=centre_upper_y + fillet / 2,
+            cross_section=cross_section,
+            scan_direction="TopToBottom",
+        )
 
-            top_left_fillet = FibsemCircleSettings(
-                radius=fillet,
-                depth=depth,
-                centre_x=point.x - width / 2,
-                centre_y=top_y_pos,
-            )
-            top_right_fillet = FibsemCircleSettings(
-                radius=fillet,
-                depth=depth,
-                centre_x=point.x + width / 2,
-                centre_y=top_y_pos,
-            )
-
-            top_left_fill = FibsemRectangleSettings(
-                width=fillet,
-                height=upper_trench_height - fillet,
-                depth=depth,
-                centre_x=left_x_pos - fillet / 2,
-                centre_y=centre_upper_y + fillet / 2,
-                cross_section = cross_section,
-                scan_direction="TopToBottom",
-            )
-            top_right_fill = FibsemRectangleSettings(
-                width=fillet,
-                height=upper_trench_height - fillet,
-                depth=depth,
-                centre_x=right_x_pos + fillet / 2,
-                centre_y=centre_upper_y + fillet / 2,
-                cross_section = cross_section,
-                scan_direction="TopToBottom",
-            )
-
-            self.shapes.extend([lower_left_fill, lower_right_fill, 
-                                top_left_fill, top_right_fill, 
-                                lower_left_fillet, lower_right_fillet, 
-                                top_left_fillet, top_right_fillet])
+        self.shapes.extend(
+            [
+                lower_left_fill,
+                lower_right_fill,
+                top_left_fill,
+                top_right_fill,
+                lower_left_fillet,
+                lower_right_fillet,
+                top_left_fillet,
+                top_right_fillet,
+            ]
+        )
 
         return self.shapes
 

--- a/tests/milling/test_patterns.py
+++ b/tests/milling/test_patterns.py
@@ -315,6 +315,8 @@ class TestTrenchPattern:
         assert trench.spacing == 20.0
         assert trench.upper_trench_height == 30.0
         assert trench.lower_trench_height == 25.0
+        assert trench.upper_trench_width is None
+        assert trench.lower_trench_width is None
         assert trench.cross_section == CrossSectionPattern.Rectangle
         assert trench.time == 0.0
         assert trench.fillet == 0.0
@@ -322,6 +324,10 @@ class TestTrenchPattern:
         assert trench.point.y == 0.0
         assert trench.name == "Trench"
         assert trench.shapes is None
+
+        field_map = {f.name: f for f in fields(TrenchPattern)}
+        assert field_map["upper_trench_width"].metadata["label"] == "Upper Trench Width"
+        assert field_map["lower_trench_width"].metadata["label"] == "Lower Trench Width"
 
     def test_define_without_fillet(self):
         trench = TrenchPattern(
@@ -381,9 +387,9 @@ class TestTrenchPattern:
         assert isinstance(shapes[0], FibsemRectangleSettings)
         assert isinstance(shapes[1], FibsemRectangleSettings)
 
-        # Check width reduction due to fillet
-        assert shapes[0].width == 90.0  # 100 - 2*5
-        assert shapes[1].width == 90.0  # 100 - 2*5
+        # Main trench widths are unchanged by fillet
+        assert shapes[0].width == 100.0
+        assert shapes[1].width == 100.0
 
         # Check fillet shapes
         fillet_shapes = shapes[2:]
@@ -398,7 +404,7 @@ class TestTrenchPattern:
             assert circle.radius == 5.0
 
     def test_fillet_clipping(self):
-        # Test when fillet is too large (more than half the upper trench height)
+        # Test when fillet is too large (clipped by min(height/2, width/2))
         trench = TrenchPattern(
             width=100.0,
             depth=50.0,
@@ -411,13 +417,38 @@ class TestTrenchPattern:
 
         shapes = trench.define()
 
-        # Check that fillet was clipped to upper_trench_height/2 = 15.0
+        # Check that fillet was clipped to min(15.0, 12.5, 50.0, 50.0) = 12.5
         circle_shapes = [s for s in shapes if isinstance(s, FibsemCircleSettings)]
         for circle in circle_shapes:
-            assert circle.radius == 15.0
+            assert circle.radius == 12.5
 
-        # Width should be reduced by 2*15.0
-        assert shapes[0].width == 70.0  # 100 - 2*15
+        # Main trench widths remain unchanged
+        assert shapes[0].width == 100.0
+        assert shapes[1].width == 100.0
+
+    def test_fillet_clipping_with_custom_trench_widths(self):
+        trench = TrenchPattern(
+            width=100.0,
+            upper_trench_width=12.0,
+            lower_trench_width=20.0,
+            depth=50.0,
+            spacing=20.0,
+            upper_trench_height=30.0,
+            lower_trench_height=25.0,
+            point=Point(10.0, 20.0),
+            fillet=10.0,
+        )
+
+        shapes = trench.define()
+
+        # Clipped by upper_trench_width / 2 => 6.0
+        circle_shapes = [s for s in shapes if isinstance(s, FibsemCircleSettings)]
+        for circle in circle_shapes:
+            assert circle.radius == 6.0
+
+        # Main trenches keep configured widths
+        assert shapes[0].width == 12.0
+        assert shapes[1].width == 20.0
 
     def test_to_dict(self):
         trench = TrenchPattern(


### PR DESCRIPTION
This pull request enhances the flexibility of the trench pattern generation in `fibsem/milling/patterning/patterns2.py`.
This is required for waffle milling since the trench components can have not only different height but also different width.

The main improvements are the addition of independent upper and lower trench width parameters, and a more robust calculation of fillet geometry to ensure proper fitting within trench dimensions.

**Pattern parameter enhancements:**

* Added `upper_trench_width` and `lower_trench_width` as optional parameters to `TrenchPattern`, allowing the upper and lower trenches to have different widths. If not specified, these default to the main `width` value.

**Trench and fillet geometry improvements:**

* Updated the `define` method so that `upper_trench_width` and `lower_trench_width` are used for their respective trenches, improving control over trench shape.
* Improved the calculation of fillet size: the fillet radius is now constrained by both trench height and width, preventing geometry errors. The code now computes separate inner widths for upper and lower trenches to position fillets and fills accurately.
* Adjusted the placement of fillet and fill shapes to use the correct inner widths and positions, ensuring that all shapes fit within the specified trench dimensions.