### PR TITLE
Strategy and pattern GUI control fixes

### DIFF
--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -14,6 +14,7 @@ from PyQt5.QtWidgets import (
     QAction,
     QComboBox,
     QDoubleSpinBox,
+    QSpinBox,
     QFileDialog,
     QHBoxLayout,
     QLabel,
@@ -234,6 +235,35 @@ class ValueComboBox(QComboBox):
     def value(self):
         """Return the raw value stored as item data for the current selection."""
         return self.currentData()
+
+
+class IntegerValueSpinBox(QSpinBox):
+    """QSpinBox with sensible defaults, WheelBlocker, and None-safe configuration."""
+
+    def __init__(
+        self,
+        suffix: Optional[str] = None,
+        minimum: Optional[int] = None,
+        maximum: Optional[int] = None,
+        step: Optional[int] = None,
+        tooltip: Optional[str] = None,
+        no_buttons: bool = False,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        if suffix:
+            self.setSuffix(f" {suffix}")
+        self.setRange(
+            minimum if minimum is not None else 0,
+            maximum if maximum is not None else 1000000,
+        )
+        self.setSingleStep(step if step is not None else 1)
+        if tooltip:
+            self.setToolTip(tooltip)
+        if no_buttons:
+            self.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.setKeyboardTracking(False)
+        self.installEventFilter(WheelBlocker(parent=self))
 
 
 class ValueSpinBox(QDoubleSpinBox):

--- a/fibsem/ui/widgets/pattern_settings_widget.py
+++ b/fibsem/ui/widgets/pattern_settings_widget.py
@@ -27,6 +27,7 @@ from fibsem.ui.widgets.custom_widgets import (
     QFilePathLineEdit,
     ValueComboBox,
     ValueSpinBox,
+    IntegerValueSpinBox,
 )
 
 _HIDDEN_FIELDS = {"shapes"}
@@ -161,6 +162,9 @@ class FibsemPatternSettingsWidget(QWidget):
             dims = m.get("dimensions")
             effective_scale = (base_scale ** dims) if (base_scale and dims) else base_scale
 
+            if effective_scale is None:
+                effective_scale = 1
+
             if items == "dynamic":
                 cached = self.microscope.get_available_values_cached(
                     m["microscope_parameter"], BeamType.ION
@@ -179,22 +183,21 @@ class FibsemPatternSettingsWidget(QWidget):
                 control = QCheckBox()
                 control.setChecked(bool(value))
             elif type_ is int:
+                effective_scale = int(round(effective_scale))
                 suffix = (
                     utils._get_display_unit(base_scale, m.get("unit"))
                     if base_scale
                     else (m.get("unit") or "")
                 )
-                # Ensure integer types don't have a step size under 1 and have 0 decimals
-                control = ValueSpinBox(
+                # Ensure integer types don't have a step size under the effective scale or 1
+                step = max(m.get("step", 1), effective_scale)
+                control = IntegerValueSpinBox(
                     suffix,
                     m.get("minimum"),
                     m.get("maximum"),
-                    max(m.get("step", 1), 1),
-                    0,
+                    step,
                 )
-                control.setValue(
-                    int(round(value * effective_scale if effective_scale else value))
-                )
+                control.setValue(int(round(value * effective_scale)))
             elif isinstance(value, (float, int)) or type_ is float:
                 suffix = (
                     utils._get_display_unit(base_scale, m.get("unit"))
@@ -208,7 +211,7 @@ class FibsemPatternSettingsWidget(QWidget):
                     m.get("step"),
                     m.get("decimals"),
                 )
-                control.setValue(value * effective_scale if effective_scale else value)
+                control.setValue(value * effective_scale)
             else:
                 logging.warning("Control for '%s' is unsupported", field_name)
                 continue  # unsupported type
@@ -222,7 +225,7 @@ class FibsemPatternSettingsWidget(QWidget):
             # Connect signal
             if isinstance(control, ValueComboBox):
                 control.currentIndexChanged.connect(self._on_changed)
-            elif isinstance(control, ValueSpinBox):
+            elif isinstance(control, (ValueSpinBox, IntegerValueSpinBox)):
                 control.valueChanged.connect(self._on_changed)
             elif isinstance(control, QCheckBox):
                 control.toggled.connect(self._on_changed)
@@ -292,6 +295,13 @@ class FibsemPatternSettingsWidget(QWidget):
             elif isinstance(row.control, ValueSpinBox):
                 val = row.control.value()
                 setattr(pattern, row.field, val / row.scale if row.scale else val)
+            elif isinstance(row.control, IntegerValueSpinBox):
+                val = row.control.value()
+                setattr(
+                    pattern,
+                    row.field,
+                    int(round(val / row.scale if row.scale else val)),
+                )
             elif isinstance(row.control, QCheckBox):
                 setattr(pattern, row.field, row.control.isChecked())
             elif isinstance(row.control, QFilePathLineEdit):
@@ -328,6 +338,10 @@ class FibsemPatternSettingsWidget(QWidget):
                 row.control.set_value(value)
             elif isinstance(row.control, ValueSpinBox):
                 row.control.setValue(value * row.scale if row.scale else value)
+            elif isinstance(row.control, IntegerValueSpinBox):
+                row.control.setValue(
+                    int(round(value * row.scale if row.scale else value))
+                )
             elif isinstance(row.control, QCheckBox):
                 row.control.setChecked(bool(value))
             elif isinstance(row.control, QFilePathLineEdit):

--- a/fibsem/ui/widgets/pattern_settings_widget.py
+++ b/fibsem/ui/widgets/pattern_settings_widget.py
@@ -178,17 +178,37 @@ class FibsemPatternSettingsWidget(QWidget):
             elif type_ is bool or isinstance(value, bool):
                 control = QCheckBox()
                 control.setChecked(bool(value))
-            elif isinstance(value, (float, int)):
+            elif type_ is int:
+                suffix = (
+                    utils._get_display_unit(base_scale, m.get("unit"))
+                    if base_scale
+                    else (m.get("unit") or "")
+                )
+                # Ensure integer types don't have a step size under 1 and have 0 decimals
+                control = ValueSpinBox(
+                    suffix,
+                    m.get("minimum"),
+                    m.get("maximum"),
+                    max(m.get("step", 1), 1),
+                    0,
+                )
+                control.setValue(
+                    int(round(value * effective_scale if effective_scale else value))
+                )
+            elif isinstance(value, (float, int)) or type_ is float:
                 suffix = (
                     utils._get_display_unit(base_scale, m.get("unit"))
                     if base_scale
                     else (m.get("unit") or "")
                 )
                 control = ValueSpinBox(
-                    suffix, m.get("minimum"), m.get("maximum"), m.get("step"), m.get("decimals")
+                    suffix,
+                    m.get("minimum"),
+                    m.get("maximum"),
+                    m.get("step"),
+                    m.get("decimals"),
                 )
-                display_val = value * effective_scale if effective_scale else value
-                control.setValue(display_val)
+                control.setValue(value * effective_scale if effective_scale else value)
             else:
                 logging.warning("Control for '%s' is unsupported", field_name)
                 continue  # unsupported type

--- a/fibsem/ui/widgets/pattern_settings_widget.py
+++ b/fibsem/ui/widgets/pattern_settings_widget.py
@@ -231,7 +231,10 @@ class FibsemPatternSettingsWidget(QWidget):
                 control.toggled.connect(self._on_changed)
             elif isinstance(control, QFilePathLineEdit):
                 control.editingFinished.connect(self._on_changed)
-
+            else:
+                raise TypeError(
+                    f"Unsupported control type '{type(control)}' in FibsemPatternSettingsWidget"
+                )
             self._rows.append(FormRow(
                 label=label,
                 control=control,

--- a/fibsem/ui/widgets/pattern_settings_widget.py
+++ b/fibsem/ui/widgets/pattern_settings_widget.py
@@ -306,6 +306,10 @@ class FibsemPatternSettingsWidget(QWidget):
                 setattr(pattern, row.field, row.control.isChecked())
             elif isinstance(row.control, QFilePathLineEdit):
                 setattr(pattern, row.field, row.control.text())
+            else:
+                raise TypeError(
+                    f"Unsupported control type '{type(row.control)}' in FibsemPatternSettingsWidget"
+                )
         return pattern
 
     def set_pattern(self, pattern: BasePattern) -> None:
@@ -346,6 +350,10 @@ class FibsemPatternSettingsWidget(QWidget):
                 row.control.setChecked(bool(value))
             elif isinstance(row.control, QFilePathLineEdit):
                 row.control.setText(str(value) if value else "")
+            else:
+                raise TypeError(
+                    f"Unsupported control type '{type(row.control)}' in FibsemPatternSettingsWidget"
+                )
         for row in self._rows:
             if not isinstance(row, _PointRow):
                 row.control.blockSignals(False)

--- a/fibsem/ui/widgets/strategy_settings_widget.py
+++ b/fibsem/ui/widgets/strategy_settings_widget.py
@@ -61,7 +61,9 @@ class FibsemStrategySettingsWidget(QWidget):
         # Strategy type selector — fixed, not rebuilt
         type_form = QFormLayout()
         type_form.setContentsMargins(0, 0, 0, 0)
-        self._type_combo = ValueComboBox(get_strategy_names(), value=self._strategy.name)
+        self._type_combo = ValueComboBox(
+            get_strategy_names(), value=self._strategy.name
+        )
         type_form.addRow("Strategy:", self._type_combo)
         outer.addLayout(type_form)
 
@@ -246,6 +248,10 @@ class FibsemStrategySettingsWidget(QWidget):
                 setattr(strategy.config, row.field, row.control.isChecked())
             elif isinstance(row.control, QFilePathLineEdit):
                 setattr(strategy.config, row.field, row.control.text())
+            else:
+                raise TypeError(
+                    f"Unsupported control type '{type(row.control)}' in FibsemStrategySettingsWidget"
+                )
         return strategy
 
     def set_strategy(self, strategy: MillingStrategy[Any]) -> None:
@@ -275,5 +281,9 @@ class FibsemStrategySettingsWidget(QWidget):
                 row.control.setChecked(bool(value))
             elif isinstance(row.control, QFilePathLineEdit):
                 row.control.setText(str(value) if value else "")
+            else:
+                raise TypeError(
+                    f"Unsupported control type '{type(row.control)}' in FibsemStrategySettingsWidget"
+                )
         for row in self._rows:
             row.control.blockSignals(False)

--- a/fibsem/ui/widgets/strategy_settings_widget.py
+++ b/fibsem/ui/widgets/strategy_settings_widget.py
@@ -118,14 +118,35 @@ class FibsemStrategySettingsWidget(QWidget):
             elif type_ is bool or isinstance(value, bool):
                 control = QCheckBox()
                 control.setChecked(bool(value))
-            elif isinstance(value, (float, int)):
+            elif type_ is int:
+                suffix = (
+                    utils._get_display_unit(base_scale, m.get("unit"))
+                    if base_scale
+                    else (m.get("unit") or "")
+                )
+                # Ensure integer types don't have a step size under 1 and have 0 decimals
+                control = ValueSpinBox(
+                    suffix,
+                    m.get("minimum"),
+                    m.get("maximum"),
+                    max(m.get("step", 1), 1),
+                    0,
+                )
+                control.setValue(
+                    int(round(value * effective_scale if effective_scale else value))
+                )
+            elif isinstance(value, (float, int)) or type_ is float:
                 suffix = (
                     utils._get_display_unit(base_scale, m.get("unit"))
                     if base_scale
                     else (m.get("unit") or "")
                 )
                 control = ValueSpinBox(
-                    suffix, m.get("minimum"), m.get("maximum"), m.get("step"), m.get("decimals")
+                    suffix,
+                    m.get("minimum"),
+                    m.get("maximum"),
+                    m.get("step"),
+                    m.get("decimals"),
                 )
                 control.setValue(value * effective_scale if effective_scale else value)
             else:

--- a/fibsem/ui/widgets/strategy_settings_widget.py
+++ b/fibsem/ui/widgets/strategy_settings_widget.py
@@ -22,6 +22,7 @@ from fibsem.ui.widgets.custom_widgets import (
     QFilePathLineEdit,
     ValueComboBox,
     ValueSpinBox,
+    IntegerValueSpinBox,
 )
 
 
@@ -103,7 +104,12 @@ class FibsemStrategySettingsWidget(QWidget):
             type_ = m.get("type")
             base_scale = m.get("scale")
             dims = m.get("dimensions")
-            effective_scale = (base_scale ** dims) if (base_scale and dims) else base_scale
+            effective_scale = (
+                (base_scale**dims) if (base_scale and dims) else base_scale
+            )
+
+            if effective_scale is None:
+                effective_scale = 1
 
             if items:
                 control = ValueComboBox(
@@ -119,22 +125,21 @@ class FibsemStrategySettingsWidget(QWidget):
                 control = QCheckBox()
                 control.setChecked(bool(value))
             elif type_ is int:
+                effective_scale = int(round(effective_scale))
                 suffix = (
                     utils._get_display_unit(base_scale, m.get("unit"))
                     if base_scale
                     else (m.get("unit") or "")
                 )
-                # Ensure integer types don't have a step size under 1 and have 0 decimals
-                control = ValueSpinBox(
+                # Ensure integer types don't have a step size under the effective scale or 1
+                step = max(m.get("step", 1), effective_scale)
+                control = IntegerValueSpinBox(
                     suffix,
                     m.get("minimum"),
                     m.get("maximum"),
-                    max(m.get("step", 1), 1),
-                    0,
+                    step,
                 )
-                control.setValue(
-                    int(round(value * effective_scale if effective_scale else value))
-                )
+                control.setValue(int(round(value * effective_scale)))
             elif isinstance(value, (float, int)) or type_ is float:
                 suffix = (
                     utils._get_display_unit(base_scale, m.get("unit"))
@@ -148,7 +153,7 @@ class FibsemStrategySettingsWidget(QWidget):
                     m.get("step"),
                     m.get("decimals"),
                 )
-                control.setValue(value * effective_scale if effective_scale else value)
+                control.setValue(value * effective_scale)
             else:
                 logging.warning("Control for '%s' is unsupported", field_name)
                 continue  # unsupported type
@@ -164,18 +169,20 @@ class FibsemStrategySettingsWidget(QWidget):
 
             if isinstance(control, ValueComboBox):
                 control.currentIndexChanged.connect(self._on_changed)
-            elif isinstance(control, ValueSpinBox):
+            elif isinstance(control, (ValueSpinBox, IntegerValueSpinBox)):
                 control.valueChanged.connect(self._on_changed)
             elif isinstance(control, QCheckBox):
                 control.toggled.connect(self._on_changed)
 
-            self._rows.append(FormRow(
-                label=label,
-                control=control,
-                field=field_name,
-                advanced=advanced,
-                scale=effective_scale,
-            ))
+            self._rows.append(
+                FormRow(
+                    label=label,
+                    control=control,
+                    field=field_name,
+                    advanced=advanced,
+                    scale=effective_scale,
+                )
+            )
 
         self._empty_label.setVisible(len(self._rows) == 0)
         self._update_visibility()
@@ -223,7 +230,16 @@ class FibsemStrategySettingsWidget(QWidget):
                     setattr(strategy.config, row.field, data)
             elif isinstance(row.control, ValueSpinBox):
                 val = row.control.value()
-                setattr(strategy.config, row.field, val / row.scale if row.scale else val)
+                setattr(
+                    strategy.config, row.field, val / row.scale if row.scale else val
+                )
+            elif isinstance(row.control, IntegerValueSpinBox):
+                val = row.control.value()
+                setattr(
+                    strategy.config,
+                    row.field,
+                    int(round(val / row.scale if row.scale else val)),
+                )
             elif isinstance(row.control, QCheckBox):
                 setattr(strategy.config, row.field, row.control.isChecked())
         return strategy
@@ -247,6 +263,10 @@ class FibsemStrategySettingsWidget(QWidget):
                 row.control.set_value(value)
             elif isinstance(row.control, ValueSpinBox):
                 row.control.setValue(value * row.scale if row.scale else value)
+            elif isinstance(row.control, IntegerValueSpinBox):
+                row.control.setValue(
+                    int(round(value * row.scale if row.scale else value))
+                )
             elif isinstance(row.control, QCheckBox):
                 row.control.setChecked(bool(value))
         for row in self._rows:

--- a/fibsem/ui/widgets/strategy_settings_widget.py
+++ b/fibsem/ui/widgets/strategy_settings_widget.py
@@ -177,6 +177,10 @@ class FibsemStrategySettingsWidget(QWidget):
                 control.toggled.connect(self._on_changed)
             elif isinstance(control, QFilePathLineEdit):
                 control.editingFinished.connect(self._on_changed)
+            else:
+                raise TypeError(
+                    f"Unsupported control type '{type(control)}' in FibsemStrategySettingsWidget"
+                )
 
             self._rows.append(
                 FormRow(

--- a/fibsem/ui/widgets/strategy_settings_widget.py
+++ b/fibsem/ui/widgets/strategy_settings_widget.py
@@ -173,6 +173,8 @@ class FibsemStrategySettingsWidget(QWidget):
                 control.valueChanged.connect(self._on_changed)
             elif isinstance(control, QCheckBox):
                 control.toggled.connect(self._on_changed)
+            elif isinstance(control, QFilePathLineEdit):
+                control.editingFinished.connect(self._on_changed)
 
             self._rows.append(
                 FormRow(
@@ -242,6 +244,8 @@ class FibsemStrategySettingsWidget(QWidget):
                 )
             elif isinstance(row.control, QCheckBox):
                 setattr(strategy.config, row.field, row.control.isChecked())
+            elif isinstance(row.control, QFilePathLineEdit):
+                setattr(strategy.config, row.field, row.control.text())
         return strategy
 
     def set_strategy(self, strategy: MillingStrategy[Any]) -> None:
@@ -269,5 +273,7 @@ class FibsemStrategySettingsWidget(QWidget):
                 )
             elif isinstance(row.control, QCheckBox):
                 row.control.setChecked(bool(value))
+            elif isinstance(row.control, QFilePathLineEdit):
+                row.control.setText(str(value) if value else "")
         for row in self._rows:
             row.control.blockSignals(False)

--- a/tests/ui/test_settings_widgets_integer.py
+++ b/tests/ui/test_settings_widgets_integer.py
@@ -1,0 +1,85 @@
+"""Headless tests for integer handling in the pattern/strategy settings widgets.
+
+Guards the contract that a metadata-declared ``int`` field round-trips through
+the GUI as a Python ``int`` (not a ``float``). Regression coverage for the class
+of bug where ``get_pattern`` / ``get_strategy`` leaked floats into strategies
+that expect integers.
+
+Uses PyQt5 directly with the offscreen platform (no pytest-qt dependency).
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem import utils
+from fibsem.milling.patterning import get_pattern
+from fibsem.ui.widgets.custom_widgets import IntegerValueSpinBox
+from fibsem.ui.widgets.pattern_settings_widget import FibsemPatternSettingsWidget
+
+# ArrayPattern exposes several integer fields (n_columns, n_rows, passes) with
+# no scale, which is exactly the path that regressed.
+_INT_FIELDS = {"n_columns": 7, "n_rows": 3, "passes": 4}
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    return microscope
+
+
+def _array_pattern(**overrides):
+    pattern = get_pattern("ArrayPattern")
+    for field, value in overrides.items():
+        setattr(pattern, field, value)
+    return pattern
+
+
+def _row(widget, field):
+    return next(row for row in widget._rows if getattr(row, "field", None) == field)
+
+
+def test_integer_fields_use_integer_spinbox(qapp, microscope):
+    widget = FibsemPatternSettingsWidget(microscope=microscope, pattern=_array_pattern())
+    for field in _INT_FIELDS:
+        assert isinstance(_row(widget, field).control, IntegerValueSpinBox), field
+
+
+def test_get_pattern_returns_int_not_float(qapp, microscope):
+    """The core regression: integer fields must come back as ``int``."""
+    widget = FibsemPatternSettingsWidget(
+        microscope=microscope, pattern=_array_pattern(**_INT_FIELDS)
+    )
+    result = widget.get_pattern()
+    for field, expected in _INT_FIELDS.items():
+        value = getattr(result, field)
+        assert type(value) is int, f"{field} came back as {type(value).__name__}"
+        assert value == expected
+
+
+def test_set_pattern_roundtrip_preserves_int(qapp, microscope):
+    widget = FibsemPatternSettingsWidget(microscope=microscope, pattern=_array_pattern())
+    widget.set_pattern(_array_pattern(n_columns=9, n_rows=2, passes=6))
+    result = widget.get_pattern()
+    assert (type(result.n_columns), result.n_columns) == (int, 9)
+    assert (type(result.n_rows), result.n_rows) == (int, 2)
+    assert (type(result.passes), result.passes) == (int, 6)
+
+
+def test_float_fields_remain_float(qapp, microscope):
+    """Guard against over-correcting float controls into ints."""
+    widget = FibsemPatternSettingsWidget(microscope=microscope, pattern=_array_pattern())
+    result = widget.get_pattern()
+    assert isinstance(result.width, float)
+    assert isinstance(result.height, float)


### PR DESCRIPTION
Hi @patrickcleeve2 

Some bits of AutoLamella currently don't handle integers properly, which means that a strategy can receive a `float` when it's expecting an `int`, for example (this caused some issues for a session recently). I've made a separate `IntegerValueSpinBox` and split up some of the GUI logic to handle this.

I also noticed that strategies with `QFilePathLineEdit` weren't having the values updated from the GUI, so I've added that too. To prevent stuff like that going unnoticed, I've also added some errors that will come up if there are controls that aren't being read, which should make it easier to catch such issues going forward.

I also noticed that passes aren't being shown as an option in the GUI, so I've created issue #127 for that.