### PR TITLE
Objective control: crash-guard, threaded insert/retract, move-to-position

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -346,6 +346,9 @@ class AutoLamellaUI(QMainWindow):
         self.selected_lamella_widget.apply_objective_to_all_requested.connect(
             self._apply_objective_position_to_all
         )
+        self.selected_lamella_widget.move_objective_requested.connect(
+            self._move_objective_to_lamella_position
+        )
         self.selected_lamella_widget.pose_update_requested.connect(
             self._set_current_position_as_pose
         )
@@ -1524,6 +1527,57 @@ class AutoLamellaUI(QMainWindow):
         notification_service.show_toast(
             f"Set objective position to {value_m * METRE_TO_MICRON:.1f} µm for {lamella.name}.", "info"
         )
+
+    def _move_objective_to_lamella_position(self):
+        """Move the FM objective to the selected lamella's stored objective position.
+
+        Independent of the stage move-to: this only drives the objective.
+        """
+        if self.microscope is None or self.microscope.fm is None:
+            notification_service.show_toast("No microscope connected.", "warning")
+            return
+        lamella = self.get_selected_lamella()
+        if lamella is None or lamella.fluorescence_pose is None:
+            notification_service.show_toast("No lamella selected.", "warning")
+            return
+        objective_position = lamella.fluorescence_pose.objective_position
+        if objective_position is None:
+            notification_service.show_toast(
+                f"{lamella.name} has no stored objective position.", "warning"
+            )
+            return
+        obj = self.microscope.fm.objective
+        if obj.state != "Inserted":
+            notification_service.show_toast(
+                "Insert the objective before moving to a stored position.", "warning"
+            )
+            return
+
+        # confirmation dialog
+        ret = QMessageBox.question(
+            self,
+            "Move Objective",
+            f"Move objective to {objective_position * METRE_TO_MICRON:.1f} µm "
+            f"for {lamella.name}?",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if ret != QMessageBox.Yes:
+            return
+
+        try:
+            logging.info(
+                f"Moving objective to {objective_position * METRE_TO_MICRON:.1f} µm "
+                f"for {lamella.name}."
+            )
+            obj.move_absolute(objective_position)
+            notification_service.show_toast(
+                f"Moved objective to {objective_position * METRE_TO_MICRON:.1f} µm "
+                f"for {lamella.name}.",
+                "info",
+            )
+        except Exception as e:
+            logging.error(f"Failed to move objective: {e}", exc_info=e)
+            notification_service.show_toast(f"Failed to move objective: {e}", "warning")
 
     def update_lamella_objective_position(self, value: float):
         """Update the objective position of the current lamella."""

--- a/fibsem/ui/fm/widgets/objective_control_widget.py
+++ b/fibsem/ui/fm/widgets/objective_control_widget.py
@@ -90,11 +90,16 @@ class _InsertObjectiveDialog(QDialog):
         self.accept()
 
 
-class ObjectiveControlWidget(QWidget):    
-    def __init__(self, fm: FluorescenceMicroscope, parent: Optional['FMAcquisitionWidget'] = None):
+class ObjectiveControlWidget(QWidget):
+    def __init__(self, fm: FluorescenceMicroscope, parent: Optional['FMAcquisitionWidget'] = None, microscope=None):
         super().__init__(parent)
         self.fm = fm
         self.parent_widget = parent
+        # microscope is required for insert (stage tilt read/move); fall back to
+        # the parent widget's microscope when embedded in a full acquisition UI.
+        self.microscope = microscope
+        if self.microscope is None and parent is not None:
+            self.microscope = getattr(parent, "microscope", None)
         self.initUI()
 
     def initUI(self):
@@ -241,12 +246,16 @@ class ObjectiveControlWidget(QWidget):
             )
             return
 
-        if self.parent_widget is None:
-            return
-        if self.parent_widget.microscope is None:
+        if self.microscope is None:
+            message_box_ui(
+                title="Objective Error",
+                text="Cannot insert objective: no microscope connection available.",
+                buttons=QMessageBox.Ok,
+                parent=self,
+            )
             return
 
-        stage_pos = self.parent_widget.microscope.get_stage_position()
+        stage_pos = self.microscope.get_stage_position()
         tilt_deg = np.degrees(stage_pos.t)
 
         dlg = _InsertObjectiveDialog(tilt_deg=tilt_deg, parent=self)
@@ -274,7 +283,7 @@ class ObjectiveControlWidget(QWidget):
                 f"Moving stage to {np.degrees(target_stage_pos.t):.0f}° tilt "
                 "before inserting objective."
             )
-            self.parent_widget.microscope.move_stage_absolute(target_stage_pos)
+            self.microscope.move_stage_absolute(target_stage_pos)
         logging.info("Inserting objective...")
         self.fm.objective.insert()
         logging.info("Objective inserted.")

--- a/fibsem/ui/fm/widgets/objective_control_widget.py
+++ b/fibsem/ui/fm/widgets/objective_control_widget.py
@@ -14,8 +14,10 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 import numpy as np
+from napari.qt.threading import thread_worker
 from fibsem.constants import METRE_TO_MICRON, MICRON_TO_METRE
 from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.ui import notification_service
 from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
@@ -206,8 +208,30 @@ class ObjectiveControlWidget(QWidget):
         if self.parent_widget is not None and hasattr(self.parent_widget, "viewer"):
             self.parent_widget.viewer.mouse_wheel_callbacks.append(self._on_mouse_wheel)
 
+    def _set_objective_actions_enabled(self, enabled: bool) -> None:
+        """Enable/disable insert & retract buttons while a threaded move runs."""
+        self.pushButton_insert_objective.setEnabled(enabled)
+        self.pushButton_retract_objective.setEnabled(enabled)
+
+    def _on_objective_action_finished(self, *_) -> None:
+        """Re-enable controls and refresh labels after a threaded objective move."""
+        self._set_objective_actions_enabled(True)
+        self.update_objective_position_labels()
+
+    def _on_objective_action_error(self, exc: Exception) -> None:
+        """Report a failed objective operation without crashing the app."""
+        logging.error(f"Objective operation failed: {exc}", exc_info=exc)
+        self._set_objective_actions_enabled(True)
+        self.update_objective_position_labels()
+        message_box_ui(
+            title="Objective Error",
+            text=f"The objective operation failed:\n\n{exc}",
+            buttons=QMessageBox.Ok,
+            parent=self,
+        )
+
     def insert_objective(self):
-        """Insert the objective."""
+        """Insert the objective. The hardware move runs on a worker thread."""
         if self.fm.objective.state == "Inserted":
             message_box_ui(
                 title="Objective Already Inserted",
@@ -231,19 +255,32 @@ class ObjectiveControlWidget(QWidget):
             return
 
         target_tilt_deg = dlg.selected_tilt
+        target_stage_pos = None
         if not np.isclose(tilt_deg, target_tilt_deg, atol=_SAFE_TILT_TOLERANCE_DEG):
             stage_pos.t = np.radians(target_tilt_deg)
-            logging.info(f"Moving stage to {target_tilt_deg:.0f}° tilt before inserting objective.")
-            self.parent_widget.microscope.move_stage_absolute(stage_pos)
+            target_stage_pos = stage_pos
 
+        self._set_objective_actions_enabled(False)
+        worker = self._insert_objective_worker(target_stage_pos)
+        worker.returned.connect(self._on_objective_action_finished)
+        worker.errored.connect(self._on_objective_action_error)
+        worker.start()
 
+    @thread_worker
+    def _insert_objective_worker(self, target_stage_pos) -> None:
+        """Worker: move stage to the insert tilt (if needed), then insert."""
+        if target_stage_pos is not None:
+            logging.info(
+                f"Moving stage to {np.degrees(target_stage_pos.t):.0f}° tilt "
+                "before inserting objective."
+            )
+            self.parent_widget.microscope.move_stage_absolute(target_stage_pos)
         logging.info("Inserting objective...")
         self.fm.objective.insert()
         logging.info("Objective inserted.")
-        self.update_objective_position_labels()
 
     def retract_objective(self):
-        """Retract the objective."""
+        """Retract the objective. The hardware move runs on a worker thread."""
         if self.fm.objective.state == "Retracted":
             message_box_ui(
                 title="Objective Already Retracted",
@@ -263,9 +300,18 @@ class ObjectiveControlWidget(QWidget):
             logging.info("Objective retraction cancelled by user.")
             return
 
+        self._set_objective_actions_enabled(False)
+        worker = self._retract_objective_worker()
+        worker.returned.connect(self._on_objective_action_finished)
+        worker.errored.connect(self._on_objective_action_error)
+        worker.start()
+
+    @thread_worker
+    def _retract_objective_worker(self) -> None:
+        """Worker: retract the objective."""
+        logging.info("Retracting objective...")
         self.fm.objective.retract()
         logging.info("Objective retracted.")
-        self.update_objective_position_labels()
 
     def update_objective_position_labels(self, objective_position: Optional[float] = None):
         """Update the objective position input and label."""
@@ -302,10 +348,19 @@ class ObjectiveControlWidget(QWidget):
                 return
 
         logging.info(f"Changing objective position to: {position:.1f} µm")
-        self.fm.objective.move_absolute(position * MICRON_TO_METRE)
-        logging.info(f"Objective moved to position: {position:.1f} µm")
+        try:
+            self.fm.objective.move_absolute(position * MICRON_TO_METRE)
+            logging.info(f"Objective moved to position: {position:.1f} µm")
+        except Exception as e:
+            logging.error(f"Failed to move objective: {e}", exc_info=e)
+            message_box_ui(
+                title="Objective Error",
+                text=f"Failed to move the objective:\n\n{e}",
+                buttons=QMessageBox.Ok,
+                parent=self,
+            )
 
-        # Update the objective position label
+        # Update the objective position label (re-syncs to the actual position)
         self.update_objective_position_labels()
 
     @pyqtSlot(float)
@@ -348,8 +403,17 @@ class ObjectiveControlWidget(QWidget):
                 return
 
         logging.info(f"Moving objective to focus position: {focus_position_um:.1f} µm")
-        self.fm.objective.move_absolute(self.fm.objective.focus_position)
-        logging.info(f"Objective moved to focus position: {focus_position_um:.1f} µm")
+        try:
+            self.fm.objective.move_absolute(self.fm.objective.focus_position)
+            logging.info(f"Objective moved to focus position: {focus_position_um:.1f} µm")
+        except Exception as e:
+            logging.error(f"Failed to move objective to focus position: {e}", exc_info=e)
+            message_box_ui(
+                title="Objective Error",
+                text=f"Failed to move the objective:\n\n{e}",
+                buttons=QMessageBox.Ok,
+                parent=self,
+            )
 
         # Update the objective position label
         self.update_objective_position_labels()
@@ -443,5 +507,10 @@ class ObjectiveControlWidget(QWidget):
         position_um = self._wheel_target_um
         position_m = position_um * MICRON_TO_METRE
         logging.info(f"Executing debounced wheel move to: {position_um:.1f} µm")
-        self.fm.objective.move_absolute(position_m)
-        self.update_objective_position_labels(objective_position=position_m)
+        try:
+            self.fm.objective.move_absolute(position_m)
+            self.update_objective_position_labels(objective_position=position_m)
+        except Exception as e:
+            logging.error(f"Objective wheel move failed: {e}", exc_info=e)
+            notification_service.show_toast(f"Objective move failed: {e}", "warning")
+            self.update_objective_position_labels()  # re-sync to actual position

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -1048,7 +1048,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         # Objective control
         from fibsem.ui.widgets.custom_widgets import IconToolButton
 
-        self.fm_objective_widget = ObjectiveControlWidget(fm=fm)
+        self.fm_objective_widget = ObjectiveControlWidget(fm=fm, microscope=self.microscope)
         btn_refresh_objective = IconToolButton(
             icon="mdi:refresh", tooltip="Refresh objective position"
         )

--- a/fibsem/ui/widgets/selected_lamella_widget.py
+++ b/fibsem/ui/widgets/selected_lamella_widget.py
@@ -34,6 +34,7 @@ class SelectedLamellaWidget(QWidget):
     objective_position_changed = pyqtSignal(float)     # value in µm
     use_current_objective_requested = pyqtSignal()
     apply_objective_to_all_requested = pyqtSignal()
+    move_objective_requested = pyqtSignal()            # move objective to stored position
     pose_update_requested = pyqtSignal(str)            # pose name
     pose_move_to_requested = pyqtSignal(str)           # pose name
 
@@ -53,6 +54,10 @@ class SelectedLamellaWidget(QWidget):
             "QToolButton::menu-indicator { image: none; }"
         )
         obj_menu = QMenu(self)
+        self._action_move_to_obj_pos = obj_menu.addAction(
+            "Move Objective to Position"
+        )
+        obj_menu.addSeparator()
         self._action_use_current_obj_pos = obj_menu.addAction(
             "Use Current Objective Position"
         )
@@ -87,6 +92,9 @@ class SelectedLamellaWidget(QWidget):
         # --- wire internal widgets to public signals ---
         self.spinbox_objective_position.valueChanged.connect(
             self.objective_position_changed
+        )
+        self._action_move_to_obj_pos.triggered.connect(
+            self.move_objective_requested
         )
         self._action_use_current_obj_pos.triggered.connect(
             self.use_current_objective_requested


### PR DESCRIPTION
Objective-control fixes from the fluorescence-workflow user-feedback triage (split out of the larger coincidence-milling batch).

_Feedback items referenced as "item N" to avoid GitHub issue autolinking._

## Objective control
- Crash-guard all `move_absolute` paths so hardware/limit errors surface instead of aborting the app (item 1)
- Thread objective insert/retract off the GUI thread — disable the buttons + show a busy state while moving, refresh labels on finish, report errors without crashing (item 22)
- Independent "Move Objective to Position" action, driven from the selected-lamella widget (item 9)
- Fix the insert button no-op when the widget is embedded without a parent: decouple the microscope reference via an optional `microscope=` argument (falls back to `parent.microscope`)

## Files
- `fibsem/ui/fm/widgets/objective_control_widget.py`
- `fibsem/ui/widgets/selected_lamella_widget.py` — `move_objective_requested` signal + menu action
- `fibsem/applications/autolamella/ui/AutoLamellaUI.py` — `_move_objective_to_lamella_position` handler
- `fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py` — pass `microscope=` to the embedded objective widget (1 line)

## Testing
Import/parse checks (offscreen Qt); objective widget constructed against a demo microscope (microscope param resolution). On-instrument insert/retract spot-check by the author.
