### PR TITLE
Spot burn: acquire on finish + reliable coordinate mode switching

### DIFF
--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -226,6 +226,10 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
                        parent_ui=self,
                        stop_event=self.stop_event)
 
+        # acquire a post-burn fib image and update the view
+        image = microscope.acquire_image(beam_type=BeamType.ION)
+        microscope.fib_acquisition_signal.emit(image)
+
     def spot_burn_finished(self, result):
         """Called when the spot burn is finished."""
         self.pushButton_run_spot_burn.clicked.disconnect()

--- a/fibsem/ui/widgets/autolamella_spot_burn_coordinates_widget.py
+++ b/fibsem/ui/widgets/autolamella_spot_burn_coordinates_widget.py
@@ -19,6 +19,10 @@ from napari.layers import Points as NapariPointsLayer
 
 from fibsem.structures import Point
 from fibsem.applications.autolamella.workflows.tasks.tasks import SpotBurnFiducialTaskConfig
+from fibsem.ui.stylesheets import (
+    PRIMARY_BUTTON_STYLESHEET,
+    SECONDARY_BUTTON_STYLESHEET,
+)
 
 
 SPOT_BURN_EDITOR_POINTS_LAYER = "spot-burn-coordinates"
@@ -73,6 +77,7 @@ class AutoLamellaSpotBurnCoordinatesWidget(QWidget):
         self.btn_mode_add.setChecked(True)
         self.btn_mode_add.clicked.connect(lambda: self._set_layer_mode("add"))
         self.btn_mode_select.clicked.connect(lambda: self._set_layer_mode("select"))
+        self._update_mode_button_styles("add")
         mode_layout.addWidget(self.btn_mode_add)
         mode_layout.addWidget(self.btn_mode_select)
         layout.addLayout(mode_layout)
@@ -260,9 +265,22 @@ class AutoLamellaSpotBurnCoordinatesWidget(QWidget):
     def _set_layer_mode(self, mode: str):
         """Set the points layer mode and update button state."""
         if self.pts_layer is not None:
+            # napari only routes clicks to the active layer; reclaim it here so the
+            # mode buttons stay usable even after the user clicked another layer.
+            self.viewer.layers.selection.active = self.pts_layer
             self.pts_layer.mode = mode
         self.btn_mode_add.setChecked(mode == "add")
         self.btn_mode_select.setChecked(mode == "select")
+        self._update_mode_button_styles(mode)
+
+    def _update_mode_button_styles(self, mode: str):
+        """Highlight the active mode button with the primary style."""
+        self.btn_mode_add.setStyleSheet(
+            PRIMARY_BUTTON_STYLESHEET if mode == "add" else SECONDARY_BUTTON_STYLESHEET
+        )
+        self.btn_mode_select.setStyleSheet(
+            PRIMARY_BUTTON_STYLESHEET if mode == "select" else SECONDARY_BUTTON_STYLESHEET
+        )
 
     # --- selection sync ---
 


### PR DESCRIPTION
Spot-burn fixes from the fluorescence-workflow user-feedback triage (split out of the larger coincidence-milling batch).

_Feedback items referenced as "item N" to avoid GitHub issue autolinking._

## Spot burn
- Acquire and display a FIB image when the burn finishes: the worker acquires an ION image and emits it via `microscope.fib_acquisition_signal`, so the FIB view refreshes automatically instead of only after Continue (item 8)
- Coordinates widget (protocol editor): reliable Add/Select mode switching — the mode buttons now reclaim the active napari layer so selection/drag works without first clicking a table row; the active mode button uses the primary style, the other the secondary style (item 5; addresses part of item 21)

## Files
- `fibsem/ui/FibsemSpotBurnWidget.py`
- `fibsem/ui/widgets/autolamella_spot_burn_coordinates_widget.py`

## Testing
Import/parse checks. Note: several other spot-burn items (item 3 apply-to-all, item 20 load-coordinates discoverability) are deferred to the canvas-UI rework and tracked separately.
