### PR TITLE
Fix spot burn crash in unsupervised mode (string params + out-of-bounds coords)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -76,8 +76,9 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
             task_name=cfg.task_name,
             milling=cfg.milling,
             reference_imaging=cfg.reference_imaging,
-            milling_current=params.get("milling_current", 60.0e-12),
-            exposure_time=params.get("exposure_time", 10),
+            # coerce numeric params: older protocols may have stored these as strings
+            milling_current=float(params.get("milling_current", 60.0e-12)),
+            exposure_time=int(float(params.get("exposure_time", 10))),
             orientation=params.get("orientation", "MILLING"),
             coordinates=coordinates,
         )
@@ -105,7 +106,7 @@ class SpotBurnFiducialTask(AutoLamellaTask):
         # acquire images, set ui
         self._acquire_reference_image(image_settings, field_of_view=self.config.reference_imaging.field_of_view1)
 
-        self.log_status_message("SPOT_BURN_FIDUCIAL")
+        self.log_status_message("SPOT_BURN_FIDUCIAL", "Running Spot Burn...")
 
         # update the spot burn parameters in the UI
         self.update_spot_burn_parameters_ui()

--- a/fibsem/imaging/spot.py
+++ b/fibsem/imaging/spot.py
@@ -35,6 +35,23 @@ def run_spot_burn(microscope: FibsemMicroscope,
     """
     # - QUERY: do we need to set the full frame scanning mode each time, or only at the end?
 
+    # coerce numeric parameters: protocol-editor fields can arrive as strings
+    # (e.g. "3e-11"), which would break beam-current/timing arithmetic on hardware.
+    exposure_time = float(exposure_time)
+    milling_current = float(milling_current)
+
+    # drop points outside the image bounds (0-1 normalised); set_spot rejects out-of-range
+    # coordinates on hardware. The supervised widget filters these, so filter here too for
+    # the unsupervised/automatic path (coordinates come straight from the stored config).
+    in_bounds, dropped = [], []
+    for pt in coordinates:
+        (in_bounds if 0 <= pt.x <= 1 and 0 <= pt.y <= 1 else dropped).append(pt)
+    if dropped:
+        logging.warning(
+            f"Skipping {len(dropped)} spot burn coordinate(s) outside image bounds (0-1): {dropped}"
+        )
+    coordinates = in_bounds
+
     total_estimated_time = len(coordinates) * exposure_time
     total_remaining_time = total_estimated_time
 

--- a/fibsem/ui/widgets/autolamella_task_config_widget.py
+++ b/fibsem/ui/widgets/autolamella_task_config_widget.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 from dataclasses import fields
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, get_type_hints
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
@@ -22,6 +22,26 @@ from fibsem import utils
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 from fibsem.ui.widgets.custom_widgets import TitledPanel, WheelBlocker
+
+def resolve_field_types(config: Any) -> Dict[str, Any]:
+    """Resolve a dataclass's field annotations to concrete types.
+
+    Task configs that use ``from __future__ import annotations`` store their field
+    annotations as strings (e.g. ``'float'``), so ``dataclasses.fields(...).type`` is a
+    string, not a type. The identity-based dispatch in ``_create_parameter_widget``
+    (``annotation is float`` etc.) then never matches and silently falls back to a
+    string ``QLineEdit`` — which stores numeric values (e.g. a milling current) as raw
+    strings. Resolving the real types up front keeps numeric fields on spinboxes.
+    """
+    try:
+        return get_type_hints(type(config))
+    except Exception as exc:
+        logging.warning(
+            f"Could not resolve type hints for {type(config).__name__}: {exc}. "
+            "Falling back to raw field annotations."
+        )
+        return {}
+
 
 class ParameterWidget:
     """Base class for parameter editing widgets."""
@@ -61,21 +81,32 @@ class BoolParameterWidget(ParameterWidget):
 
 
 class IntParameterWidget(ParameterWidget):
-    """Widget for integer parameters."""
-    
+    """Widget for integer parameters with optional units suffix."""
+
+    def __init__(self, name: str, value: Any, annotation: type, metadata: Optional[dict] = None):
+        super().__init__(name, value, annotation)
+        self.metadata = metadata or {}
+        self.scale = self.metadata.get('scale', 1.0)
+        self.units = self.metadata.get('units', '')
+
     def create_widget(self) -> QWidget:
         self.widget = QSpinBox()
         self.widget.setRange(-2147483648, 2147483647)  # 32-bit int range
-        self.widget.setValue(int(self.value))
+        self.widget.setValue(int(round(self.value * self.scale)))
         self.widget.setKeyboardTracking(False)
         self.widget.installEventFilter(WheelBlocker(parent=self.widget))
+
+        # Add units suffix if available (e.g. " s" for exposure time)
+        suffix = get_si_prefix_suffix(self.scale, self.units)
+        if suffix:
+            self.widget.setSuffix(suffix)
         return self.widget
 
     def get_value(self) -> int:
-        return self.widget.value()
+        return int(round(self.widget.value() / self.scale))
 
     def set_value(self, value: int) -> None:
-        self.widget.setValue(int(value))
+        self.widget.setValue(int(round(value * self.scale)))
 
 
 def get_si_prefix_suffix(scale: float, units: str) -> str:
@@ -325,14 +356,19 @@ class AutoLamellaTaskConfigWidget(QWidget):
         
         # Show/hide task parameters section
         if self.task_config.parameters:
+            # Resolve annotations to concrete types (see resolve_field_types) so that
+            # `from __future__ import annotations` configs don't fall back to QLineEdit.
+            type_hints = resolve_field_types(self.task_config)
+
             # Get all configurable parameters using the parameters property
             for param_name in self.task_config.parameters:
                 # Get field info and current value
                 field = next(f for f in fields(self.task_config) if f.name == param_name)
                 value = getattr(self.task_config, param_name)
-                
+                annotation = type_hints.get(param_name, field.type)
+
                 # Create parameter widget
-                param_widget = self._create_parameter_widget(param_name, value, field.type, field.metadata)
+                param_widget = self._create_parameter_widget(param_name, value, annotation, field.metadata)
                 if param_widget:
                     self.parameter_widgets[param_name] = param_widget
                     
@@ -387,7 +423,7 @@ class AutoLamellaTaskConfigWidget(QWidget):
         if annotation is bool:
             return BoolParameterWidget(name, value, annotation)
         elif annotation is int:
-            return IntParameterWidget(name, value, annotation)
+            return IntParameterWidget(name, value, annotation, metadata)
         elif annotation is float:
             return FloatParameterWidget(name, value, annotation, metadata)
         elif annotation is str:
@@ -501,16 +537,21 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
             self.hide()
             return
 
+        # Resolve annotations to concrete types (see resolve_field_types) so that
+        # `from __future__ import annotations` configs don't fall back to QLineEdit.
+        type_hints = resolve_field_types(self.task_config)
+
         # Get all configurable parameters using the parameters property
         for param_name in self.task_config.parameters:
             # Get field info and current value
             field = next(f for f in fields(self.task_config) if f.name == param_name)
             value = getattr(self.task_config, param_name)
+            annotation = type_hints.get(param_name, field.type)
 
             # Create parameter widget
-            param_widget = self._create_parameter_widget(name = param_name, 
-                                                         value = value, 
-                                                         annotation = field.type, 
+            param_widget = self._create_parameter_widget(name = param_name,
+                                                         value = value,
+                                                         annotation = annotation,
                                                          metadata = field.metadata)
             if param_widget:
                 self.parameter_widgets[param_name] = param_widget
@@ -558,7 +599,7 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
         if annotation == bool:
             return BoolParameterWidget(name, value, annotation)
         elif annotation == int:
-            return IntParameterWidget(name, value, annotation)
+            return IntParameterWidget(name, value, annotation, metadata)
         elif annotation == float:
             return FloatParameterWidget(name, value, annotation, metadata)
         elif annotation == str:

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -1,0 +1,204 @@
+"""Tests for the spot burn fiducial task: run_spot_burn hardening, config
+numeric coercion, and the protocol-editor parameter-widget dispatch.
+
+These cover the failure modes that crashed the unsupervised (automatic) path:
+- numeric parameters arriving as strings (from a plain QLineEdit in the editor),
+- spot-burn coordinates outside the 0-1 image bounds reaching set_spot on hardware,
+- the widget factory rendering float/int fields as a text box instead of a spinbox.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from fibsem.imaging.spot import run_spot_burn
+from fibsem.structures import BeamType, Point
+from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
+    SpotBurnFiducialTaskConfig,
+)
+
+IMAGING_CURRENT = 20e-12
+
+
+@pytest.fixture
+def mock_microscope():
+    """A microscope stub that records the calls run_spot_burn makes."""
+    mic = MagicMock()
+    mic.get_beam_current.return_value = IMAGING_CURRENT
+    return mic
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Skip the real exposure countdown so tests run instantly."""
+    import fibsem.imaging.spot as spot
+    monkeypatch.setattr(spot.time, "sleep", lambda *_: None)
+
+
+def _burned_points(mic: MagicMock) -> list:
+    """The points passed to set_spot_scanning_mode, in order."""
+    return [c.kwargs["point"] for c in mic.set_spot_scanning_mode.call_args_list]
+
+
+# --- run_spot_burn: coordinate bounds filtering ---------------------------------
+
+
+def test_run_spot_burn_filters_out_of_bounds_coordinates(mock_microscope):
+    """Coordinates outside the 0-1 image bounds are skipped, not sent to set_spot."""
+    coords = [
+        Point(0.5, 0.5),   # valid
+        Point(0.9, 0.2),   # valid
+        Point(1.02, 0.5),  # x > 1
+        Point(-0.1, 0.3),  # x < 0
+        Point(0.5, 1.5),   # y > 1
+    ]
+    run_spot_burn(
+        microscope=mock_microscope,
+        coordinates=coords,
+        exposure_time=1.0,
+        milling_current=30e-12,
+        beam_type=BeamType.ION,
+    )
+    assert _burned_points(mock_microscope) == [Point(0.5, 0.5), Point(0.9, 0.2)]
+
+
+def test_run_spot_burn_keeps_boundary_coordinates(mock_microscope):
+    """Exact 0 and 1 boundaries are inclusive."""
+    coords = [Point(0.0, 0.0), Point(1.0, 1.0)]
+    run_spot_burn(
+        microscope=mock_microscope,
+        coordinates=coords,
+        exposure_time=1.0,
+        milling_current=30e-12,
+    )
+    assert _burned_points(mock_microscope) == coords
+
+
+def test_run_spot_burn_empty_coordinates_does_not_burn(mock_microscope):
+    """No coordinates -> no spot exposures, but the beam state is still restored."""
+    run_spot_burn(
+        microscope=mock_microscope,
+        coordinates=[],
+        exposure_time=1.0,
+        milling_current=30e-12,
+    )
+    mock_microscope.set_spot_scanning_mode.assert_not_called()
+    mock_microscope.set_full_frame_scanning_mode.assert_called_once()
+
+
+# --- run_spot_burn: string parameter coercion -----------------------------------
+
+
+def test_run_spot_burn_coerces_string_parameters(mock_microscope):
+    """String milling_current/exposure_time (from the editor QLineEdit bug) don't crash."""
+    run_spot_burn(
+        microscope=mock_microscope,
+        coordinates=[Point(0.5, 0.5)],
+        exposure_time="2",
+        milling_current="3e-11",
+        beam_type=BeamType.ION,
+    )
+    # the milling current is applied as a real float, not the string "3e-11"
+    first_current = mock_microscope.set_beam_current.call_args_list[0].kwargs["current"]
+    assert isinstance(first_current, float)
+    assert first_current == pytest.approx(3e-11)
+
+
+# --- run_spot_burn: beam state restoration --------------------------------------
+
+
+def test_run_spot_burn_restores_full_frame_and_imaging_current(mock_microscope):
+    """After burning, scanning returns to full frame and the imaging current is restored."""
+    run_spot_burn(
+        microscope=mock_microscope,
+        coordinates=[Point(0.5, 0.5)],
+        exposure_time=1.0,
+        milling_current=30e-12,
+    )
+    mock_microscope.set_full_frame_scanning_mode.assert_called_once()
+    last_current = mock_microscope.set_beam_current.call_args_list[-1].kwargs["current"]
+    assert last_current == IMAGING_CURRENT
+
+
+# --- SpotBurnFiducialTaskConfig serialization -----------------------------------
+
+
+def test_from_dict_coerces_string_numeric_params():
+    """Protocols saved with string-typed params (pre-fix) are repaired on load."""
+    cfg = SpotBurnFiducialTaskConfig(task_name="Spot Burn Fiducial")
+    d = cfg.to_dict()
+    d["parameters"]["milling_current"] = "3e-11"
+    d["parameters"]["exposure_time"] = "10"
+
+    loaded = SpotBurnFiducialTaskConfig.from_dict(d)
+
+    assert isinstance(loaded.milling_current, float)
+    assert loaded.milling_current == pytest.approx(3e-11)
+    assert isinstance(loaded.exposure_time, int)
+    assert loaded.exposure_time == 10
+
+
+def test_to_from_dict_preserves_coordinates_as_points():
+    """Coordinates round-trip as Point objects (types stay consistent across save/load)."""
+    cfg = SpotBurnFiducialTaskConfig(
+        task_name="Spot Burn Fiducial",
+        coordinates=[Point(0.5, 0.5), Point(0.9, 0.2)],
+    )
+    loaded = SpotBurnFiducialTaskConfig.from_dict(cfg.to_dict())
+
+    assert all(isinstance(c, Point) for c in loaded.coordinates)
+    assert loaded.coordinates[0].x == pytest.approx(0.5)
+    assert loaded.coordinates[1].y == pytest.approx(0.2)
+
+
+# --- widget factory: annotation resolution --------------------------------------
+
+
+def test_resolve_field_types_resolves_future_annotations():
+    """`from __future__ import annotations` string types resolve to concrete types."""
+    from fibsem.ui.widgets.autolamella_task_config_widget import resolve_field_types
+
+    cfg = SpotBurnFiducialTaskConfig(task_name="Spot Burn Fiducial")
+    hints = resolve_field_types(cfg)
+
+    assert hints["milling_current"] is float
+    assert hints["exposure_time"] is int
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    try:
+        from PyQt5.QtWidgets import QApplication
+    except Exception as exc:  # pragma: no cover - environment without Qt
+        pytest.skip(f"PyQt5 not available: {exc}")
+    return QApplication.instance() or QApplication([])
+
+
+def test_spot_burn_params_render_as_spinboxes(qapp):
+    """Regression: milling_current/exposure_time render as spinboxes, not QLineEdits."""
+    from fibsem.ui.widgets.autolamella_task_config_widget import (
+        AutoLamellaTaskParametersConfigWidget,
+        FloatParameterWidget,
+        IntParameterWidget,
+    )
+
+    cfg = SpotBurnFiducialTaskConfig(task_name="Spot Burn Fiducial")
+    widget = AutoLamellaTaskParametersConfigWidget(cfg)
+
+    assert isinstance(widget.parameter_widgets["milling_current"], FloatParameterWidget)
+    assert isinstance(widget.parameter_widgets["exposure_time"], IntParameterWidget)
+
+
+def test_exposure_time_spinbox_has_seconds_suffix(qapp):
+    """exposure_time's units metadata ('s') is shown as a spinbox suffix."""
+    from fibsem.ui.widgets.autolamella_task_config_widget import (
+        AutoLamellaTaskParametersConfigWidget,
+    )
+
+    cfg = SpotBurnFiducialTaskConfig(task_name="Spot Burn Fiducial")
+    widget = AutoLamellaTaskParametersConfigWidget(cfg)
+
+    exposure_widget = widget.parameter_widgets["exposure_time"]
+    assert exposure_widget.widget.suffix() == " s"

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -18,6 +18,24 @@ from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
     SpotBurnFiducialTaskConfig,
 )
 
+# The widget-dispatch tests need the UI stack (napari/PyQt5), which isn't installed
+# in the core CI env (`pip install .`). Guard the import so they skip there instead
+# of erroring; the run_spot_burn and config tests below have no UI dependency.
+try:
+    from fibsem.ui.widgets.autolamella_task_config_widget import (
+        AutoLamellaTaskParametersConfigWidget,
+        FloatParameterWidget,
+        IntParameterWidget,
+        resolve_field_types,
+    )
+    _HAS_UI_DEPS = True
+except Exception:  # pragma: no cover - exercised only in the no-UI CI env
+    _HAS_UI_DEPS = False
+
+requires_ui = pytest.mark.skipif(
+    not _HAS_UI_DEPS, reason="UI dependencies (napari/PyQt5) not installed"
+)
+
 IMAGING_CURRENT = 20e-12
 
 
@@ -155,10 +173,9 @@ def test_to_from_dict_preserves_coordinates_as_points():
 # --- widget factory: annotation resolution --------------------------------------
 
 
+@requires_ui
 def test_resolve_field_types_resolves_future_annotations():
     """`from __future__ import annotations` string types resolve to concrete types."""
-    from fibsem.ui.widgets.autolamella_task_config_widget import resolve_field_types
-
     cfg = SpotBurnFiducialTaskConfig(task_name="Spot Burn Fiducial")
     hints = resolve_field_types(cfg)
 
@@ -176,14 +193,9 @@ def qapp():
     return QApplication.instance() or QApplication([])
 
 
+@requires_ui
 def test_spot_burn_params_render_as_spinboxes(qapp):
     """Regression: milling_current/exposure_time render as spinboxes, not QLineEdits."""
-    from fibsem.ui.widgets.autolamella_task_config_widget import (
-        AutoLamellaTaskParametersConfigWidget,
-        FloatParameterWidget,
-        IntParameterWidget,
-    )
-
     cfg = SpotBurnFiducialTaskConfig(task_name="Spot Burn Fiducial")
     widget = AutoLamellaTaskParametersConfigWidget(cfg)
 
@@ -191,12 +203,9 @@ def test_spot_burn_params_render_as_spinboxes(qapp):
     assert isinstance(widget.parameter_widgets["exposure_time"], IntParameterWidget)
 
 
+@requires_ui
 def test_exposure_time_spinbox_has_seconds_suffix(qapp):
     """exposure_time's units metadata ('s') is shown as a spinbox suffix."""
-    from fibsem.ui.widgets.autolamella_task_config_widget import (
-        AutoLamellaTaskParametersConfigWidget,
-    )
-
     cfg = SpotBurnFiducialTaskConfig(task_name="Spot Burn Fiducial")
     widget = AutoLamellaTaskParametersConfigWidget(cfg)
 


### PR DESCRIPTION
## Problem

The spot burn fiducial task crashed when run **automatically (unsupervised)** — after a user selected spot coordinates for one lamella and applied them to others in the protocol editor. The supervised (interactive) path worked fine, which made it look coordinate-specific.

## Root cause

`spot_burn.py` uses `from __future__ import annotations`, so dataclass field types are **strings** (`'float'`) at runtime. The task-parameter widget factory dispatched with identity checks (`annotation is float`), which never matched the string, so numeric fields (`milling_current`, `exposure_time`) fell through to a plain `QLineEdit` and were stored as **raw strings** (e.g. `"3e-11"`).

- **Unsupervised path:** `run_spot_burn` passed that string straight to `microscope.set_beam_current(current="3e-11")` on the hardware → crash.
- **Supervised path:** unaffected, because `FibsemSpotBurnWidget` reads the current from a combobox (a real float), not from the config.

A secondary hole: the supervised widget filters spot coordinates to the `0–1` image bounds before burning, but the unsupervised path did not — an out-of-bounds coordinate reaching `set_spot` also throws on hardware.

## Changes

- **Widget factory** (`autolamella_task_config_widget.py`): resolve annotations to concrete types via `get_type_hints()` so `float`/`int` fields render as spinboxes instead of text boxes. This fixes the whole class of affected configs (spot burn plus the other `from __future__ import annotations` task configs), not just spot burn.
- **`IntParameterWidget`**: now applies the units suffix from metadata, so `exposure_time` shows `s`.
- **`run_spot_burn`** (`imaging/spot.py`): coerce `exposure_time`/`milling_current` to `float` and filter out-of-bounds coordinates (single pass, logs what it drops) before touching the hardware.
- **`SpotBurnFiducialTaskConfig.from_dict`**: coerce the numeric params, repairing protocols already saved with string values.
- **Status text**: the spot burn step now reports `"Running Spot Burn..."` instead of the raw `SPOT_BURN_FIDUCIAL` step code (matches every sibling task).

## Tests

Adds `tests/autolamella/test_spot_burn.py` (10 tests, passing) covering coordinate bounds filtering, string-parameter coercion, config serialization round-trips, and the widget dispatch (spinbox vs line-edit, units suffix). The two Qt tests skip gracefully if PyQt5 can't initialize a display.

## Scope / follow-ups

Kept intentionally scoped to the **fixes**. Two related UX improvements — an unsupervised progress bar and consolidating the supervised/unsupervised paths — are tracked separately in FIB-249.

## Reviewer notes

- The milling-current spinbox displays in **pA** (`scale: 1e12`), so `3e-11 A` is entered as `30`. `QDoubleSpinBox` does not accept scientific-notation typing — this is the intended, safer behavior (no more string storage, range/units enforced).
- Not yet driven through the live GUI end-to-end; verified via unit tests and a headless demo-microscope run of `run_spot_burn`.
