### PR TITLE
Spot burn: status-bar progress, unified UI, and milling-style workflow hook (FIB-249)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -11,7 +11,7 @@ except Exception:
 import warnings
 
 import napari
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import (
     QAction,
     QApplication,
@@ -53,6 +53,7 @@ from fibsem.ui.stylesheets import (
     WORKFLOW_BORDER_STYLESHEET,
 )
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
+from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
 from fibsem.ui import notification_service
 from fibsem.ui.widgets.autolamella_lamella_protocol_editor import (
     AutoLamellaProtocolEditorWidget,
@@ -881,6 +882,15 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.autolamella_ui.microscope.tiled_acquisition_signal.connect(
                 self._on_tile_acquisition_progress
             )
+            try:
+                self.autolamella_ui.microscope.spot_burn_progress_signal.disconnect(
+                    self._on_spot_burn_progress
+                )
+            except Exception:
+                pass
+            self.autolamella_ui.microscope.spot_burn_progress_signal.connect(
+                self._on_spot_burn_progress
+            )
         self.btn_create_experiment.setEnabled(True)
         self.btn_load_experiment.setEnabled(True)
         self._update_instructions()
@@ -923,6 +933,13 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         elif state == "finished":
             self.milling_progress_bar.setVisible(False)
+
+    @ensure_main_thread
+    def _on_spot_burn_progress(self, ddict: dict) -> None:
+        """Handle spot burn progress updates from the microscope (supervised + unsupervised)."""
+        self.progress_widget.update_progress(build_spot_burn_progress_update(ddict))
+        if ddict.get("finished"):
+            QTimer.singleShot(2000, self.progress_widget.reset)
 
     @ensure_main_thread
     def _on_tile_acquisition_progress(self, ddict: dict) -> None:

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -939,7 +939,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """Handle spot burn progress updates from the microscope (supervised + unsupervised)."""
         self.progress_widget.update_progress(build_spot_burn_progress_update(ddict))
         if ddict.get("finished"):
-            QTimer.singleShot(2000, self.progress_widget.reset)
+            # hide the Done/Failed state after a moment; reset_if_finished leaves the
+            # widget alone if another operation has started rendering progress since
+            QTimer.singleShot(2000, self.progress_widget.reset_if_finished)
 
     @ensure_main_thread
     def _on_tile_acquisition_progress(self, ddict: dict) -> None:

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1784,6 +1784,13 @@ class AutoLamellaUI(QMainWindow):
                 True
             )
 
+        # restore the spot burn widget: an aborted workflow skips the clear_spot_burn
+        # message that normally resets it, which would leave the Burn button hidden
+        # (no-op after a normal completion, where clear_spot_burn already ran)
+        if self.spot_burn_widget is not None:
+            self.spot_burn_widget.set_workflow_mode(False)
+            self.spot_burn_widget.clear_points_layer()
+
         # clear detection layers
         if self.det_widget is not None:
             self.det_widget.clear_layers()

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1718,7 +1718,7 @@ class AutoLamellaUI(QMainWindow):
         self.pushButton_no.setEnabled(neg is not None)
         self.pushButton_no.setVisible(neg is not None)
 
-        if pos == "Run Milling":
+        if pos in ("Run Milling", "Run Spot Burn"):
             self.pushButton_yes.setStyleSheet(
                 stylesheets.SUPERVISION_STATUS_AUTOMATED_STYLESHEET
             )
@@ -1759,6 +1759,8 @@ class AutoLamellaUI(QMainWindow):
             self._workflow_stop_event.set()
         if self.milling_task_config_widget is not None:
             self.milling_task_config_widget.milling_widget.stop_milling()
+        if self.spot_burn_widget is not None:
+            self.spot_burn_widget.cancel_spot_burn()
 
     def _workflow_finished(self):
         """Handle the completion of the workflow."""
@@ -1884,11 +1886,15 @@ class AutoLamellaUI(QMainWindow):
         spot_burn = info.get("spot_burn", None)
         if spot_burn:
             self.set_spot_burn_widget_active(True)
+            if self.spot_burn_widget is not None:
+                # hide the widget's own Burn button; the burn is run from the workflow control
+                self.spot_burn_widget.set_workflow_mode(True)
         spot_burn_parameters = info.get("spot_burn_parameters", None)
         if spot_burn_parameters is not None and self.spot_burn_widget is not None:
             self.spot_burn_widget.update_parameters(spot_burn_parameters)
         if info.get("clear_spot_burn", False) and self.spot_burn_widget is not None:
             self.spot_burn_widget.clear_points_layer()
+            self.spot_burn_widget.set_workflow_mode(False)
 
         milling_config = info.get("milling_config", None)
         if milling_config is not None:

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -723,6 +723,7 @@ class AutoLamellaUI(QMainWindow):
                 self.det_widget.deleteLater()
                 self.det_widget = None
             if self.spot_burn_widget is not None:
+                self.spot_burn_widget.disconnect_signals()
                 self.tabWidget.removeTab(self.tabWidget.indexOf(self.spot_burn_widget))
                 self.spot_burn_widget.deleteLater()
                 self.spot_burn_widget = None

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import ClassVar, Literal, Optional, Type
@@ -136,7 +137,9 @@ class SpotBurnFiducialTask(AutoLamellaTask):
                           stop_event=self._stop_event)
             return
 
-        # supervised path: let the user run the burn interactively in the widget
+        # supervised path: task-orchestrated run/wait/re-prompt loop (mirrors milling).
+        # The user runs the burn via the workflow "Run Spot Burn" button; the task waits
+        # for each burn to finish before continuing so the workflow can't advance mid-burn.
         if self.parent_ui.spot_burn_widget is None:
             logging.warning("Spot burn widget not available in UI.")
             return
@@ -146,12 +149,21 @@ class SpotBurnFiducialTask(AutoLamellaTask):
                     "coordinates": self.config.coordinates})
         update_spot_burn_parameters(parent_ui=self.parent_ui, parameters=parameters)
 
-        # ask the user to select the position/parameters for spot burns
-        msg = f"Run the spot burn workflow for {self.lamella.name}. Press continue when finished."
-        ask_user(self.parent_ui, msg=msg, pos="Continue", spot_burn=True)
+        spot_burn_widget = self.parent_ui.spot_burn_widget
+        msg = f"Place points and run the spot burn for {self.lamella.name}. Press Continue when finished."
+        response = ask_user(self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True)
+        while response:
+            self.update_status_ui("Running Spot Burn...")
+            spot_burn_widget.start_spot_burn_signal.emit()
+            # wait for the burn to finish (BlockingQueuedConnection guarantees is_burning
+            # is already True on return from emit)
+            while spot_burn_widget.is_burning:
+                self._check_for_abort()
+                time.sleep(1)
+            response = ask_user(self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True)
 
         # store the coordinates from the UI back to the config
-        self.config.coordinates = self.parent_ui.spot_burn_widget.get_coordinates()
+        self.config.coordinates = spot_burn_widget.get_coordinates()
 
         # clear the spot burn parameters from the UI
         clear_spot_burn_ui(self.parent_ui)

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -115,20 +115,29 @@ class SpotBurnFiducialTask(AutoLamellaTask):
         self._acquire_set_of_reference_images(image_settings)
 
     def update_spot_burn_parameters_ui(self):
-        """Update the spot burn parameters in the UI, or run automatically if unsupervised."""
-        if (not self.validate and self.config.coordinates) or self.parent_ui is None:
-            # run spot burn automatically with stored coordinates
+        """Run the spot burn automatically (unsupervised/headless), or hand off to the UI.
+
+        Supervised runs let the user place/adjust points and run the burn in the spot
+        burn widget; unsupervised/headless runs burn the stored coordinates directly.
+        """
+        # automatic path: no user in the loop (unsupervised or headless)
+        if not self.validate or self.parent_ui is None:
+            if not self.config.coordinates:
+                logging.warning(
+                    f"No spot burn coordinates set for {self.lamella.name}; skipping spot burn."
+                )
+                return
             from fibsem.imaging.spot import run_spot_burn
             run_spot_burn(microscope=self.microscope,
                           coordinates=self.config.coordinates,
                           exposure_time=self.config.exposure_time,
                           milling_current=self.config.milling_current,
                           beam_type=BeamType.ION,
-                        #   parent_ui=self.parent_ui, # needs spot burn widget for progress
                           stop_event=self._stop_event)
             return
 
-        if self.parent_ui is None or self.parent_ui.spot_burn_widget is None:
+        # supervised path: let the user run the burn interactively in the widget
+        if self.parent_ui.spot_burn_widget is None:
             logging.warning("Spot burn widget not available in UI.")
             return
 

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -155,11 +155,20 @@ class SpotBurnFiducialTask(AutoLamellaTask):
         while response:
             self.update_status_ui("Running Spot Burn...")
             spot_burn_widget.start_spot_burn_signal.emit()
-            # wait for the burn to finish (BlockingQueuedConnection guarantees is_burning
-            # is already True on return from emit)
-            while spot_burn_widget.is_burning:
-                self._check_for_abort()
-                time.sleep(1)
+            # BlockingQueuedConnection: on return from emit the burn is either running
+            # (is_burning=True) or was refused (no in-bounds points), in which case the
+            # wait loop exits immediately and the user is re-prompted.
+            try:
+                while spot_burn_widget.is_burning:
+                    self._check_for_abort()
+                    time.sleep(1)
+            except InterruptedError:
+                # workflow stopped: take the burn down with the task. Covers the race
+                # where the burn starts after the Stop click already ran cancel (the
+                # worker clears its stop_event on start). cancel_spot_burn only sets
+                # a threading.Event, so it is safe to call from the task thread.
+                spot_burn_widget.cancel_spot_burn()
+                raise
             response = ask_user(self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True)
 
         # store the coordinates from the UI back to the config

--- a/fibsem/imaging/spot.py
+++ b/fibsem/imaging/spot.py
@@ -3,13 +3,10 @@ import logging
 import threading
 import time
 
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional
 
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, Point
-
-if TYPE_CHECKING:
-    from fibsem.ui.FibsemSpotBurnWidget import FibsemSpotBurnWidget
 
 SLEEP_TIME = 1
 
@@ -18,17 +15,18 @@ def run_spot_burn(microscope: FibsemMicroscope,
                   exposure_time: float,
                   milling_current: float,
                   beam_type: BeamType = BeamType.ION,
-                  parent_ui: Optional['FibsemSpotBurnWidget'] = None,
                   stop_event: Optional[threading.Event] = None) -> None:
     """Run a spot burner job on the microscope. Exposes the specified coordinates for a the specified
     time at the specified current.
+
+    Progress is reported via ``microscope.spot_burn_progress_signal`` (a dict), which the
+    status bar and the spot burn widget subscribe to.
     Args:
         microscope: The microscope object.
         coordinates: List of points to burn. (0 - 1 in image coordinates)
         exposure_time: Time to expose each point in seconds.
         milling_current: Current to use for the spot.
         beam_type: The type of beam to use. (Default: BeamType.ION)
-        parent_ui: The parent UI object to emit progress signals. (Default: None)
         stop_event: Threading event to signal cancellation. (Default: None)
     Returns:
         None
@@ -56,16 +54,15 @@ def run_spot_burn(microscope: FibsemMicroscope,
     total_remaining_time = total_estimated_time
 
     # emit initial progress signal
-    if parent_ui is not None:
-        parent_ui.spot_burn_progress_signal.emit(
-            {
-                "current_point": 0,
-                "total_points": len(coordinates),
-                "remaining_time": exposure_time,
-                "total_remaining_time": total_remaining_time,
-                "total_estimated_time": total_estimated_time,
-            }
-        )
+    microscope.spot_burn_progress_signal.emit(
+        {
+            "current_point": 0,
+            "total_points": len(coordinates),
+            "remaining_time": exposure_time,
+            "total_remaining_time": total_remaining_time,
+            "total_estimated_time": total_estimated_time,
+        }
+    )
 
     # set the beam current to the milling current
     imaging_current = microscope.get_beam_current(beam_type=beam_type)
@@ -93,22 +90,20 @@ def run_spot_burn(microscope: FibsemMicroscope,
             time.sleep(SLEEP_TIME)
             remaining_time -= SLEEP_TIME
             total_remaining_time -= SLEEP_TIME
-            if parent_ui is not None:
-                parent_ui.spot_burn_progress_signal.emit(
-                    {
-                        "current_point": i,
-                        "total_points": len(coordinates),
-                        "remaining_time": remaining_time,
-                        "total_remaining_time": total_remaining_time,
-                        "total_estimated_time": total_estimated_time,
-                    }
-                )
+            microscope.spot_burn_progress_signal.emit(
+                {
+                    "current_point": i,
+                    "total_points": len(coordinates),
+                    "remaining_time": remaining_time,
+                    "total_remaining_time": total_remaining_time,
+                    "total_estimated_time": total_estimated_time,
+                }
+            )
 
     # always restore full frame scanning mode and imaging current
     microscope.set_full_frame_scanning_mode(beam_type=beam_type)
 
     # emit finished signal
-    if parent_ui is not None:
-        parent_ui.spot_burn_progress_signal.emit({"finished": True})
+    microscope.spot_burn_progress_signal.emit({"finished": True})
 
     microscope.set_beam_current(current=imaging_current, beam_type=beam_type)

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -141,6 +141,7 @@ class FibsemMicroscope(ABC):
     """Abstract class containing all the core microscope functionalities"""
     milling_progress_signal = Signal(dict)
     tiled_acquisition_signal = Signal(dict)
+    spot_burn_progress_signal = Signal(dict)
     _last_imaging_settings: ImageSettings
     system: SystemSettings
     _patterns: List

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -9,20 +9,37 @@ from napari.layers import Image as NapariImageLayer
 from napari.layers import Points as NapariPointsLayer
 from napari.qt.threading import FunctionWorker, thread_worker
 from PyQt5.QtWidgets import QWidget
-from PyQt5.QtCore import pyqtSignal
+from superqt import ensure_main_thread
 
 from fibsem.imaging.spot import run_spot_burn
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, Point
 from fibsem.ui import stylesheets
 from fibsem.ui.qtdesigner_files import FibsemSpotBurnWidget as FibsemSpotBurnWidgetUI
+from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
 from fibsem.utils import format_value
 
 SPOT_BURN_POINTS_LAYER_NAME = "spot-burn-points"
 DEFAULT_BEAM_CURRENT = 60e-12  # 60 pA
 
+
+def build_spot_burn_progress_update(ddict: dict) -> ProgressUpdate:
+    """Map a spot-burn progress dict (see run_spot_burn) to a ProgressUpdate.
+
+    Shared by the spot burn widget and the main-window status bar so both render
+    progress with identical text and formatting.
+    """
+    if ddict.get("finished"):
+        return ProgressUpdate.done()
+    return ProgressUpdate.combined(
+        current=ddict.get("current_point", 0),
+        total=ddict.get("total_points", 0),
+        remaining_seconds=ddict.get("total_remaining_time", 0.0),
+        total_seconds=ddict.get("total_estimated_time", 0.0),
+        message="Burning spots",
+    )
+
 class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
-    spot_burn_progress_signal = pyqtSignal(dict)
 
     def __init__(self, parent: QWidget):
         super().__init__(parent=parent)
@@ -42,7 +59,7 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
 
     def setup_connections(self):
         self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.GREEN_PUSHBUTTON_STYLE)
+        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
 
         beam_currents = self.microscope.get_available_values("current", BeamType.ION)
         for current in beam_currents:
@@ -60,14 +77,32 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
         self.doubleSpinBox_exposure_time.setValue(10)
         self.doubleSpinBox_exposure_time.valueChanged.connect(self._on_data_changed)
 
-        # initial state
+        # initial state (PRIMARY greys out via its :disabled rule while no points are selected)
         self.label_information.setText("No points selected. Please add points to the layer.")
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.GRAY_PUSHBUTTON_STYLE)
         self.pushButton_run_spot_burn.setEnabled(False)
 
-        # progress bar
-        self.progressBar.setVisible(False)
-        self.spot_burn_progress_signal.connect(self._update_progress_bar)
+        # replace the .ui QProgressBar with the shared FibsemProgressWidget so the widget
+        # and the status bar render progress identically.
+        self.gridLayout_2.removeWidget(self.progressBar)
+        self.progressBar.deleteLater()
+        self.progress_widget = FibsemProgressWidget(self)
+        self.gridLayout_2.addWidget(self.progress_widget, 5, 1, 1, 2)
+
+        # progress is driven by the microscope's spot_burn_progress_signal (shared with the
+        # status bar). psygnal fires on the worker thread, so _update_progress_bar is
+        # marshalled to the GUI thread via @ensure_main_thread.
+        self.microscope.spot_burn_progress_signal.connect(self._update_progress_bar)
+
+    def disconnect_signals(self):
+        """Disconnect from the microscope's progress signal before the widget is destroyed.
+
+        The microscope outlives this widget; without this, the strong psygnal connection
+        would leak the widget and fire _update_progress_bar on a deleted object.
+        """
+        try:
+            self.microscope.spot_burn_progress_signal.disconnect(self._update_progress_bar)
+        except Exception:
+            pass
 
     def _add_points_layer(self):
         # check if the points layer exists, if not create it
@@ -172,10 +207,8 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
         self.pushButton_run_spot_burn.setEnabled(enabled)
         if enabled:
             self.label_information.setText(f"Selected {len(coordinates)} points. Estimated time: {len(coordinates) * self.doubleSpinBox_exposure_time.value()} seconds")
-            self.pushButton_run_spot_burn.setStyleSheet(stylesheets.GREEN_PUSHBUTTON_STYLE)
         else:
             self.label_information.setText("No points selected. Please add points to the layer.")
-            self.pushButton_run_spot_burn.setStyleSheet(stylesheets.GRAY_PUSHBUTTON_STYLE)
 
     def run_spot_burn_worker(self):
         """Run the spot burn worker."""
@@ -198,7 +231,7 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
 
         self.stop_event.clear()
         self.pushButton_run_spot_burn.setText("Cancel")
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.RED_PUSHBUTTON_STYLE)
+        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
         self.pushButton_run_spot_burn.clicked.disconnect()
         self.pushButton_run_spot_burn.clicked.connect(self.cancel_spot_burn)
 
@@ -223,7 +256,6 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
                        exposure_time=exposure_time,
                        milling_current=milling_current,
                        beam_type=BeamType.ION,
-                       parent_ui=self,
                        stop_event=self.stop_event)
 
         # acquire a post-burn fib image and update the view
@@ -236,50 +268,16 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
         self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)
         self.pushButton_run_spot_burn.setEnabled(True)
         self.pushButton_run_spot_burn.setText("Burn Spot")
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.GREEN_PUSHBUTTON_STYLE)
+        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
 
     def spot_burn_errored(self, error):
         """Called when the spot burn fails."""
         logging.error(f"Spot burn failed: {error}")
-        self.spot_burn_progress_signal.emit({"finished": True})
+        self.microscope.spot_burn_progress_signal.emit({"finished": True})
         self.spot_burn_finished(error)
 
+    @ensure_main_thread
     def _update_progress_bar(self, ddict: dict):
-        """Update the progress bar with the current progress.
-        
-        Parameters
-        ----------
-        ddict : dict
-            Dictionary with the following keys:
-            - total_points (int): Total number of points to burn
-            - current_point (int): Current point being burned
-            - remaining_time (float): Remaining time for current point in seconds
-            - total_remaining_time (float): Total remaining time in seconds
-            - total_estimated_time (float): Total estimated time in seconds
-            - finished (bool): Whether the spot burn is finished
-        """        
-        total_points = ddict.get("total_points", 0)
-        current_point = ddict.get("current_point", 0)
-        remaining_time = ddict.get("remaining_time", 0)
-        total_remaining_time = ddict.get("total_remaining_time", 0)
-        total_estimated_time = ddict.get("total_estimated_time", 0)
-        total_elapsed_time = total_estimated_time - total_remaining_time
-        finished = ddict.get("finished", False)
-
-        self.progressBar.setVisible(True)
-        self.progressBar.setStyleSheet(stylesheets.PROGRESS_BAR_GREEN_STYLE)
-        self.progressBar.setMinimum(0)
-        
-        if total_elapsed_time > 0 and total_estimated_time > 0:
-            self.progressBar.setMaximum(int(total_estimated_time))
-            self.progressBar.setValue(int(total_elapsed_time))
-            self.progressBar.setTextVisible(True)
-            self.progressBar.setFormat(f"Burning Spot {current_point}/{total_points}... {int(remaining_time)}s remaining")
-        else:
-            self.progressBar.setValue(0)
-            self.progressBar.setFormat("Preparing Spot Burn...")
-
-        if finished:
-            self.progressBar.setValue(total_estimated_time)
-            self.progressBar.setFormat("Spot Burn Finished")
+        """Render spot burn progress (identical formatting to the status bar)."""
+        self.progress_widget.update_progress(build_spot_burn_progress_update(ddict))
 

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -31,6 +31,8 @@ def build_spot_burn_progress_update(ddict: dict) -> ProgressUpdate:
     progress with identical text and formatting.
     """
     if ddict.get("finished"):
+        if ddict.get("error"):
+            return ProgressUpdate.failed("Spot burn failed")
         return ProgressUpdate.done()
     return ProgressUpdate.combined(
         current=ddict.get("current_point", 0),
@@ -86,33 +88,44 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
         self.label_information.setText("No points selected. Please add points to the layer.")
         self.pushButton_run_spot_burn.setEnabled(False)
 
-        # replace the .ui QProgressBar with the shared FibsemProgressWidget so the widget
-        # and the status bar render progress identically.
+        # replace the .ui QProgressBar with the shared FibsemProgressWidget (in the same
+        # grid cell) so the widget and the status bar render progress identically.
+        bar_pos = self.gridLayout_2.getItemPosition(
+            self.gridLayout_2.indexOf(self.progressBar)
+        )
         self.gridLayout_2.removeWidget(self.progressBar)
         self.progressBar.deleteLater()
         self.progress_widget = FibsemProgressWidget(self)
-        self.gridLayout_2.addWidget(self.progress_widget, 5, 1, 1, 2)
+        self.gridLayout_2.addWidget(self.progress_widget, *bar_pos)
 
         # progress is driven by the microscope's spot_burn_progress_signal (shared with the
         # status bar). psygnal fires on the worker thread, so _update_progress_bar is
         # marshalled to the GUI thread via @ensure_main_thread.
         self.microscope.spot_burn_progress_signal.connect(self._update_progress_bar)
 
-        # the workflow task drives the burn via start_spot_burn_signal; BlockingQueuedConnection
-        # ensures emit() returns only once the burn has started (mirrors milling).
+        # the workflow task drives the burn via start_spot_burn_signal (mirrors milling).
+        # BlockingQueuedConnection: emit() returns only after run_spot_burn_worker has
+        # run, so the burn is then either in progress (is_burning=True) or was refused
+        # (no in-bounds points), in which case the task re-prompts.
         self.start_spot_burn_signal.connect(
             self.run_spot_burn_worker, Qt.BlockingQueuedConnection  # type: ignore
         )
 
         # workflow-mode hint, shown when the widget's own Burn button is hidden during a
         # supervised workflow (the burn is run from the workflow "Run Spot Burn" control).
+        # It shares the Burn button's grid cell on purpose: exactly one of the two is
+        # visible at any time (_update_run_button_visibility), so the hint appears in
+        # place of the hidden button without the layout shifting.
         self.label_workflow_hint = QLabel(
             "Use the 'Run Spot Burn' button in the workflow controls to burn the selected points."
         )
         self.label_workflow_hint.setWordWrap(True)
         self.label_workflow_hint.setStyleSheet("color: gray; font-style: italic;")
         self.label_workflow_hint.setVisible(False)
-        self.gridLayout_2.addWidget(self.label_workflow_hint, 6, 1, 1, 2)
+        btn_pos = self.gridLayout_2.getItemPosition(
+            self.gridLayout_2.indexOf(self.pushButton_run_spot_burn)
+        )
+        self.gridLayout_2.addWidget(self.label_workflow_hint, *btn_pos)
 
     @property
     def is_burning(self) -> bool:
@@ -326,7 +339,7 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
     def spot_burn_errored(self, error):
         """Called when the spot burn fails."""
         logging.error(f"Spot burn failed: {error}")
-        self.microscope.spot_burn_progress_signal.emit({"finished": True})
+        self.microscope.spot_burn_progress_signal.emit({"finished": True, "error": True})
         self.spot_burn_finished(error)
 
     @ensure_main_thread

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -8,7 +8,8 @@ import napari.utils.notifications
 from napari.layers import Image as NapariImageLayer
 from napari.layers import Points as NapariPointsLayer
 from napari.qt.threading import FunctionWorker, thread_worker
-from PyQt5.QtWidgets import QWidget
+from PyQt5.QtWidgets import QLabel, QWidget
+from PyQt5.QtCore import Qt, pyqtSignal
 from superqt import ensure_main_thread
 
 from fibsem.imaging.spot import run_spot_burn
@@ -40,6 +41,8 @@ def build_spot_burn_progress_update(ddict: dict) -> ProgressUpdate:
     )
 
 class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
+    # emitted by the workflow task to trigger a burn (mirrors milling's start_milling_signal)
+    start_spot_burn_signal = pyqtSignal()
 
     def __init__(self, parent: QWidget):
         super().__init__(parent=parent)
@@ -50,6 +53,8 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
         self.microscope: FibsemMicroscope = parent.microscope
         self.worker: FunctionWorker = None
         self.stop_event: threading.Event = threading.Event()
+        self._is_burning: bool = False
+        self._workflow_mode: bool = False
 
         # napari layers
         self.pts_layer: Optional[NapariPointsLayer] = None
@@ -92,6 +97,48 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
         # status bar). psygnal fires on the worker thread, so _update_progress_bar is
         # marshalled to the GUI thread via @ensure_main_thread.
         self.microscope.spot_burn_progress_signal.connect(self._update_progress_bar)
+
+        # the workflow task drives the burn via start_spot_burn_signal; BlockingQueuedConnection
+        # ensures emit() returns only once the burn has started (mirrors milling).
+        self.start_spot_burn_signal.connect(
+            self.run_spot_burn_worker, Qt.BlockingQueuedConnection  # type: ignore
+        )
+
+        # workflow-mode hint, shown when the widget's own Burn button is hidden during a
+        # supervised workflow (the burn is run from the workflow "Run Spot Burn" control).
+        self.label_workflow_hint = QLabel(
+            "Use the 'Run Spot Burn' button in the workflow controls to burn the selected points."
+        )
+        self.label_workflow_hint.setWordWrap(True)
+        self.label_workflow_hint.setStyleSheet("color: gray; font-style: italic;")
+        self.label_workflow_hint.setVisible(False)
+        self.gridLayout_2.addWidget(self.label_workflow_hint, 6, 1, 1, 2)
+
+    @property
+    def is_burning(self) -> bool:
+        """Whether a spot burn is currently running."""
+        return self._is_burning
+
+    def set_workflow_mode(self, active: bool):
+        """Toggle workflow mode.
+
+        During a supervised workflow the burn is task-orchestrated (like milling), so the
+        widget's own Burn button is hidden and a hint points the user to the workflow
+        "Run Spot Burn" control. The button still appears as "Cancel" while a burn is in
+        progress so the user can cancel locally. Outside the workflow it is used directly.
+        """
+        self._workflow_mode = active
+        self._update_run_button_visibility()
+
+    def _update_run_button_visibility(self):
+        """Show/hide the run button and workflow hint for the current mode + burn state."""
+        if self._workflow_mode:
+            # idle: hidden (run via the workflow control); burning: shown as "Cancel"
+            self.pushButton_run_spot_burn.setVisible(self._is_burning)
+            self.label_workflow_hint.setVisible(not self._is_burning)
+        else:
+            self.pushButton_run_spot_burn.setVisible(True)
+            self.label_workflow_hint.setVisible(False)
 
     def disconnect_signals(self):
         """Disconnect from the microscope's progress signal before the widget is destroyed.
@@ -230,10 +277,13 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
         logging.info(f"Running spot burn with {len(coordinates)} points. Beam current: {beam_current} A, exposure time: {exposure_time} s")
 
         self.stop_event.clear()
+        self._is_burning = True
         self.pushButton_run_spot_burn.setText("Cancel")
         self.pushButton_run_spot_burn.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
         self.pushButton_run_spot_burn.clicked.disconnect()
         self.pushButton_run_spot_burn.clicked.connect(self.cancel_spot_burn)
+        # in workflow mode the button is hidden when idle — show it as "Cancel" while burning
+        self._update_run_button_visibility()
 
         self.worker = self._spot_burn_worker(microscope=self.microscope,
                                              coordinates=coordinates,
@@ -264,11 +314,14 @@ class FibsemSpotBurnWidget(FibsemSpotBurnWidgetUI.Ui_Form, QWidget):
 
     def spot_burn_finished(self, result):
         """Called when the spot burn is finished."""
+        self._is_burning = False
         self.pushButton_run_spot_burn.clicked.disconnect()
         self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)
         self.pushButton_run_spot_burn.setEnabled(True)
         self.pushButton_run_spot_burn.setText("Burn Spot")
         self.pushButton_run_spot_burn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        # in workflow mode, hide the button again now the burn is done
+        self._update_run_button_visibility()
 
     def spot_burn_errored(self, error):
         """Called when the spot burn fails."""

--- a/fibsem/ui/widgets/progress_widget.py
+++ b/fibsem/ui/widgets/progress_widget.py
@@ -28,7 +28,13 @@ Done — completes the bar and shows "Done"::
 
     ProgressUpdate.done()
 
-Call :meth:`FibsemProgressWidget.reset` to return to the initial hidden state.
+Failed — completes the bar but shows an error message::
+
+    ProgressUpdate.failed("Spot burn failed")
+
+Call :meth:`FibsemProgressWidget.reset` to return to the initial hidden state, or
+:meth:`FibsemProgressWidget.reset_if_finished` from delayed hide-after-done timers
+(it leaves the widget alone if a newer operation is already rendering progress).
 """
 
 from __future__ import annotations
@@ -108,6 +114,11 @@ class ProgressUpdate:
         """Signals completion — widget shows 100 % and "Done"."""
         return cls(finished=True)
 
+    @classmethod
+    def failed(cls, message: str = "Failed") -> "ProgressUpdate":
+        """Signals failure — completes the bar but shows ``message`` instead of "Done"."""
+        return cls(finished=True, message=message)
+
 
 # ---------------------------------------------------------------------------
 # Widget
@@ -153,6 +164,7 @@ class FibsemProgressWidget(QWidget):
 
         prefix = f"{info.message} — " if info.message else ""
 
+        self._finished = info.finished
         self.setVisible(True)
 
         if info.finished:
@@ -160,7 +172,7 @@ class FibsemProgressWidget(QWidget):
             self._spinner.clear()  # blank icon, fixed size keeps space reserved
             self._bar.setMaximum(100)
             self._bar.setValue(100)
-            self._bar.setFormat("Done")
+            self._bar.setFormat(info.message or "Done")
             self._bar.setVisible(True)
             return
 
@@ -212,8 +224,18 @@ class FibsemProgressWidget(QWidget):
 
         self._bar.setVisible(True)
 
+    def reset_if_finished(self) -> None:
+        """Reset only if the most recent update was a finished/failed one.
+
+        For delayed hide-after-done timers on a shared widget: if another
+        operation has started rendering progress in the meantime, leave it alone.
+        """
+        if self._finished:
+            self.reset()
+
     def reset(self) -> None:
         """Return to initial hidden state."""
+        self._finished = False
         self._spinner.stop()
         self._spinner.clear()
         self._bar.setMinimum(0)

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -207,6 +207,71 @@ def test_update_spot_burn_ui_runs_stored_coordinates_headless(monkeypatch, tmp_p
     assert calls[0]["coordinates"] == coords
 
 
+# --- SpotBurnFiducialTask supervised loop ---------------------------------------
+
+
+def _make_supervised_spot_burn_task(monkeypatch, tmp_path, ask_user_responses):
+    """A supervised SpotBurnFiducialTask with a mock parent UI + spot burn widget.
+
+    ask_user_responses is an iterable of the booleans ask_user should return.
+    Returns (task, widget, cleared_list).
+    """
+    import fibsem.applications.autolamella.workflows.tasks.spot_burn as sb_mod
+    from fibsem.applications.autolamella.structures import Lamella
+    from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
+        SpotBurnFiducialTask,
+    )
+
+    widget = MagicMock()
+    widget.is_burning = False  # each burn "completes" immediately
+    widget.get_coordinates.return_value = [Point(0.5, 0.5)]
+    parent_ui = MagicMock()  # truthy experiment.task_protocol.get_supervision -> supervised
+    parent_ui.spot_burn_widget = widget
+
+    responses = iter(ask_user_responses)
+    monkeypatch.setattr(sb_mod, "ask_user", lambda *a, **k: next(responses))
+    monkeypatch.setattr(sb_mod, "update_spot_burn_parameters", lambda **k: None)
+    cleared = []
+    monkeypatch.setattr(sb_mod, "clear_spot_burn_ui", lambda ui: cleared.append(ui))
+
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+    config = SpotBurnFiducialTaskConfig(
+        task_name="Spot Burn Fiducial", coordinates=[Point(0.5, 0.5)]
+    )
+    task = SpotBurnFiducialTask(
+        microscope=MagicMock(), config=config, lamella=lamella, parent_ui=parent_ui
+    )
+    task.update_status_ui = lambda *a, **k: None  # isolate the loop
+    task._check_for_abort = lambda: None
+    return task, widget, cleared
+
+
+def test_supervised_spot_burn_runs_then_continues(monkeypatch, tmp_path):
+    """'Run Spot Burn' triggers the widget and waits; then Continue proceeds."""
+    task, widget, cleared = _make_supervised_spot_burn_task(
+        monkeypatch, tmp_path, ask_user_responses=[True, False]
+    )
+
+    task.update_spot_burn_parameters_ui()
+
+    widget.start_spot_burn_signal.emit.assert_called_once()
+    widget.get_coordinates.assert_called_once()
+    assert cleared  # spot burn UI was cleared afterwards
+
+
+def test_supervised_spot_burn_continue_without_running(monkeypatch, tmp_path):
+    """Pressing Continue immediately runs no burn but still reads back + clears."""
+    task, widget, cleared = _make_supervised_spot_burn_task(
+        monkeypatch, tmp_path, ask_user_responses=[False]
+    )
+
+    task.update_spot_burn_parameters_ui()
+
+    widget.start_spot_burn_signal.emit.assert_not_called()
+    widget.get_coordinates.assert_called_once()
+    assert cleared
+
+
 # --- SpotBurnFiducialTaskConfig serialization -----------------------------------
 
 

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -160,6 +160,53 @@ def test_run_spot_burn_emits_progress_via_microscope(mock_microscope):
     assert emitted[-1] == {"finished": True}
 
 
+# --- SpotBurnFiducialTask.update_spot_burn_parameters_ui ------------------------
+
+
+def _make_headless_spot_burn_task(coordinates, tmp_path):
+    """A SpotBurnFiducialTask with no parent UI (unsupervised/headless path)."""
+    from fibsem.applications.autolamella.structures import Lamella
+    from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
+        SpotBurnFiducialTask,
+    )
+
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+    config = SpotBurnFiducialTaskConfig(
+        task_name="Spot Burn Fiducial", coordinates=coordinates
+    )
+    return SpotBurnFiducialTask(
+        microscope=MagicMock(), config=config, lamella=lamella, parent_ui=None
+    )
+
+
+def test_update_spot_burn_ui_skips_when_no_coordinates(monkeypatch, tmp_path):
+    """Unsupervised/headless with no coordinates skips, rather than blocking on ask_user."""
+    import fibsem.imaging.spot as spot_mod
+
+    calls = []
+    monkeypatch.setattr(spot_mod, "run_spot_burn", lambda **kw: calls.append(kw))
+
+    task = _make_headless_spot_burn_task([], tmp_path)
+    task.update_spot_burn_parameters_ui()  # must return, not hang
+
+    assert calls == []
+
+
+def test_update_spot_burn_ui_runs_stored_coordinates_headless(monkeypatch, tmp_path):
+    """Unsupervised/headless with coordinates burns them directly."""
+    import fibsem.imaging.spot as spot_mod
+
+    calls = []
+    monkeypatch.setattr(spot_mod, "run_spot_burn", lambda **kw: calls.append(kw))
+
+    coords = [Point(0.5, 0.5), Point(0.6, 0.6)]
+    task = _make_headless_spot_burn_task(coords, tmp_path)
+    task.update_spot_burn_parameters_ui()
+
+    assert len(calls) == 1
+    assert calls[0]["coordinates"] == coords
+
+
 # --- SpotBurnFiducialTaskConfig serialization -----------------------------------
 
 

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -139,6 +139,27 @@ def test_run_spot_burn_restores_full_frame_and_imaging_current(mock_microscope):
     assert last_current == IMAGING_CURRENT
 
 
+# --- run_spot_burn: progress reporting -----------------------------------------
+
+
+def test_run_spot_burn_emits_progress_via_microscope(mock_microscope):
+    """Progress is reported through microscope.spot_burn_progress_signal (both run paths)."""
+    run_spot_burn(
+        microscope=mock_microscope,
+        coordinates=[Point(0.5, 0.5), Point(0.6, 0.6)],
+        exposure_time=1.0,
+        milling_current=30e-12,
+    )
+    emitted = [
+        c.args[0] for c in mock_microscope.spot_burn_progress_signal.emit.call_args_list
+    ]
+    # initial progress reports the total number of points
+    assert emitted[0]["current_point"] == 0
+    assert emitted[0]["total_points"] == 2
+    # final emission signals completion
+    assert emitted[-1] == {"finished": True}
+
+
 # --- SpotBurnFiducialTaskConfig serialization -----------------------------------
 
 

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -160,6 +160,26 @@ def test_run_spot_burn_emits_progress_via_microscope(mock_microscope):
     assert emitted[-1] == {"finished": True}
 
 
+@requires_ui
+def test_build_spot_burn_progress_update_mapping():
+    """Progress dicts map to ProgressUpdate: running, done, and failed states."""
+    from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
+
+    running = build_spot_burn_progress_update(
+        {"current_point": 1, "total_points": 3,
+         "total_remaining_time": 20.0, "total_estimated_time": 30.0}
+    )
+    assert (running.current, running.total) == (1, 3)
+    assert running.remaining_seconds == 20.0
+    assert not running.finished
+
+    done = build_spot_burn_progress_update({"finished": True})
+    assert done.finished and not done.message
+
+    failed = build_spot_burn_progress_update({"finished": True, "error": True})
+    assert failed.finished and failed.message == "Spot burn failed"
+
+
 # --- SpotBurnFiducialTask.update_spot_burn_parameters_ui ------------------------
 
 
@@ -270,6 +290,26 @@ def test_supervised_spot_burn_continue_without_running(monkeypatch, tmp_path):
     widget.start_spot_burn_signal.emit.assert_not_called()
     widget.get_coordinates.assert_called_once()
     assert cleared
+
+
+def test_supervised_spot_burn_abort_cancels_burn(monkeypatch, tmp_path):
+    """Workflow abort during the wait loop cancels the in-progress burn.
+
+    Also covers the stop-vs-start race: a burn that starts after the workflow
+    Stop already ran cancel_spot_burn (clearing its stop_event) is still taken
+    down by the aborting task.
+    """
+    task, widget, cleared = _make_supervised_spot_burn_task(
+        monkeypatch, tmp_path, ask_user_responses=[True]
+    )
+    widget.is_burning = True  # burn in progress
+    task._check_for_abort = MagicMock(side_effect=InterruptedError("aborted"))
+
+    with pytest.raises(InterruptedError):
+        task.update_spot_burn_parameters_ui()
+
+    widget.cancel_spot_burn.assert_called_once()
+    assert not cleared  # abort propagates before the UI cleanup runs
 
 
 # --- SpotBurnFiducialTaskConfig serialization -----------------------------------


### PR DESCRIPTION
Implements [FIB-249](https://linear.app/fibsemos/issue/FIB-249). Follow-up to the spot-burn crash fix (#137). Three related commits:

## 1. Status-bar progress + unified progress/button styling

- Add `microscope.spot_burn_progress_signal`; `run_spot_burn` emits through it and no longer takes `parent_ui` (fully UI-decoupled).
- **Unsupervised** runs now show progress in the status-bar `FibsemProgressWidget`; **supervised** runs show it in both the widget and the status bar, from one signal via a shared mapping helper (`Burning spots — N/M · Xs remaining` → `Done`).
- The spot burn widget renders through the **same** `FibsemProgressWidget` as the status bar (guaranteed-consistent formatting), disconnecting on teardown.
- Run/Cancel button uses the app-standard `PRIMARY` / `STOP_WORKFLOW` stylesheets (matching the milling widget).

## 2. Task cleanup — empty-coordinates hang fix

- The unsupervised/headless path now takes the automatic branch whenever there's no user in the loop, and **skips with a warning if no coordinates are set** instead of falling through to the interactive `ask_user`, which would block forever in an unattended run.
- Removed a stale commented-out `parent_ui` argument.

## 3. Supervised runs via a milling-style workflow hook

Supervised spot burns are now task-orchestrated, matching the milling workflow:
- The user places points and clicks a **"Run Spot Burn"** button in the workflow controls; the task runs the burn and **waits for completion** before continuing (the workflow can no longer advance mid-burn), then re-prompts so the user can re-burn (preview loop) or press **Continue**.
- Widget: `start_spot_burn_signal` (BlockingQueuedConnection) + `is_burning`; `set_workflow_mode()` hides the widget's own Burn button during the workflow (a hint points to the workflow control) but shows it as **"Cancel"** while a burn is in progress so cancellation stays available locally.
- Workflow **Stop** now cancels an in-progress burn (previously the task aborted but the beam kept burning on the worker).

## Tests

`tests/autolamella/test_spot_burn.py` covers coordinate filtering, string-param coercion, config serialization, progress emission, the empty-coords skip, and the supervised run/wait/continue loop. UI-dependent tests skip gracefully where napari/PyQt aren't installed (CI).

## Verification

Unit tests + end-to-end plumbing checks, plus a full GUI pass on the running app: manual and automated runs, cancel-burn, and cancel-workflow all confirmed.
