### PR TITLE
Correlation: FM surface point + pre-correlation refractive-index correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ fibsem/correlation/scaling_factor_lookup_table.csv
 fibsem/correlation/slice_scaling_factor_LUT.ipynb
 sashimi/*
 fibsem/applications/sashimi/log/*
+# Refractive-index LUT (downloaded on demand from the data release)
+fibsem/correlation/data/

--- a/docs/design/correlation-fm-surface-pre-correction.md
+++ b/docs/design/correlation-fm-surface-pre-correction.md
@@ -297,6 +297,36 @@ Finding 10 (PointType→list registry refactor) deferred to a follow-up PR.
   plus a stochastic re-fit per factor tweak — pre-existing Run cost, but the
   deterministic reprojection path added for ghosts shows the cheap alternative.
 
+## Follow-up: registry refactor (review finding 10) + PR #111 canvas convergence
+
+Agreed plan (2026-07-15): after PR #139 merges, a separate PR replaces the
+per-point-type plumbing in `correlation_tab_widget.py` with a
+`_PointTypeSpec` registry (point_type → list widget, canvas side, max_one,
+exclusive_group, fm_fit_role, on_cleared) + generic handlers; surface
+exclusivity and the pre-correction-factor lifecycle move into that single
+chokepoint; unknown types fail loudly (KeyError) instead of misfiling into the
+POI list; tests updated to the generic entry points + a parametrized per-type
+behaviour sweep. Includes the formula dedup (`scale_about_surface()` helper
+for the five copies of `surface + (v−surface)·factor`).
+
+**PR #111 consideration:** #111 introduces a shared canvas stack
+(`fibsem/ui/widgets/canvas/`: `FibsemImageCanvas`, `CanvasOverlay`,
+interactive `PointOverlay` with index-based signals and per-overlay legend,
+FM canvas/compositor, CanvasState reducer). It does not touch
+`fibsem/correlation/` (no conflicts), but `ImagePointCanvas` duplicates its
+concepts (and vice versa: legend/marker/datum-line features here vs
+PointOverlay's own legend). Therefore:
+- the registry's generic handlers must NOT talk to canvases directly — each
+  spec carries a thin canvas adapter (refresh/set_selected/set_points), so the
+  later swap from ImagePointCanvas (identity-based Coordinates) to per-type
+  PointOverlay (index-based) is localized to the adapter;
+- the canvas migration itself is a THIRD PR, after #111 merges and
+  stabilizes: one PointOverlay per point type, right-click type menu moves to
+  canvas level, aggregated legend / ghost / datum line ported (possibly
+  upstreamed into the canvas package), FM z-stack display onto fm_canvas.
+#111's minimap-correlation doc already defers to `CorrelationResult` as the
+canonical alignment product, so the data-model boundary stays as-is.
+
 ## Remaining / follow-ups
 
 - Full validation on real METEOR data (initial live test done 2026-07-15:

--- a/docs/design/correlation-fm-surface-pre-correction.md
+++ b/docs/design/correlation-fm-surface-pre-correction.md
@@ -221,6 +221,18 @@ the (unchanged) fiducial fit.
   Z-column table in pre mode, post double-apply guard), `_menu_load_result`
   reordered so the RI tab sees loaded surfaces, `_logger` NameError fixed.
 - Canvas/list color+marker entries (yellow "+" / "yellow").
+- Canvas legend (proxy `Line2D` handles, upper right, dark-themed): shows the
+  point types currently on screen plus labeled overlay groups (FM reprojected,
+  POI, POI uncorrected); View → Show Legend toggle (default on); replicated in
+  `render_to_axes` exports. Unfilled markers ("+") keep their own colour as the
+  legend edge so they don't render white.
+- Marker styling unified in `_marker_style()`: filled circles show selection as
+  a white rim; unfilled "+" crosshairs keep their type colour always (white
+  edge would swallow it, "none" erased it) and show selection via size/stroke.
+- FIB surface datum line: dashed orange `axhline` across the canvas at the
+  surface y (the only coordinate the post correction uses), tracks drags/edits
+  live, emphasized while selected, exported by `render_to_axes`. FM surfaces
+  are z-planes — no in-plane line.
 - Visibility of the applied correction:
   - status line reads "Done — RI pre-correction ×N applied." after a corrected run;
   - **ghost marker (both modes)**: `CorrelationResult.poi_uncorrected` holds the

--- a/docs/design/correlation-fm-surface-pre-correction.md
+++ b/docs/design/correlation-fm-surface-pre-correction.md
@@ -243,6 +243,48 @@ raise-based contract. End-to-end verified against the real `Rigid3D` fit with
 synthetic ground truth (corrected POI lands on the projection of the z-corrected
 3D point to <0.01 px; rms ≈ 0).
 
+## Code-review findings — FIXED (2026-07-15, uncommitted follow-up)
+
+Findings 1–9 of the multi-agent review are fixed with regression tests:
+1. `from_dict` now restores `stored_fib_image_shape`/`stored_fib_image_pixel_size`
+   (the properties fall back to them), so post-correcting a JSON-loaded result
+   updates px/px_m; the skip branch warns instead of staying silent.
+2. `_clear_pre_correction_factor()` runs on every FM-surface removal path
+   (canvas remove, list remove, FIB-surface replacement); `set_data` refuses to
+   arm a factor when the file has no FM surface.
+3. `_apply_post` guards `result.input_data is None` with a warning.
+4. Factor spinbox mirrors only on stored-value *change* (`_last_mirrored_factor`),
+   armed input factor outranks the older result factor, and the label shows
+   "stored — applied on next run" when they differ.
+5. `set_tilt_locked` changes tilt with signals blocked and recomputes zeta
+   quietly (`_recompute(update_factor=False)`) — mode switches never overwrite
+   a manually entered factor.
+6. `apply_refractive_index_correction` raises on double-apply;
+   `run_correlation_from_data` raises when both surfaces are set.
+7. `render_to_axes` copies `markerfacecolor` + `alpha` (hollow ghost survives
+   Save Plot).
+8. `_menu_load_result` logic extracted to `_load_result`; redundant trailing
+   `_update_run_button()` removed (status no longer clobbered on load).
+9. `_RITab._set_warning(text, level)` pairs text+color at every site.
+
+Finding 10 (PointType→list registry refactor) deferred to a follow-up PR.
+
+## Code-review follow-ups (verified, below the report cutoff)
+
+- `_RITab._populate_pre_table` inlines the correction formula instead of calling
+  `apply_z_surface_correction`; variants of `surface + (v−surface)·factor` now
+  exist in 5 places (util.py:770, structures.py ×2, tab widget ×2) — extract one
+  scalar helper used everywhere so preview and engine can't drift.
+- `_reproject_poi_via_transform` re-derives the image-px→centred-px→metres
+  conversion (3rd copy in correlation_v2.py); its `R.shape != (3,3)` guard is
+  unreachable at the only call site and silently degrades (returns no ghost).
+- `_RITab.set_result` explodes `input_data` into 5 parallel cached fields —
+  holding the object would remove the sync burden; it also rebuilds the pre
+  table + copies the POI list on every `data_changed` (minor churn).
+- Apply-and-re-run pays a full `copy.deepcopy(self.data)` (entire FM volume)
+  plus a stochastic re-fit per factor tweak — pre-existing Run cost, but the
+  deterministic reprojection path added for ghosts shows the cheap alternative.
+
 ## Remaining / follow-ups
 
 - Full validation on real METEOR data (initial live test done 2026-07-15:

--- a/docs/design/correlation-fm-surface-pre-correction.md
+++ b/docs/design/correlation-fm-surface-pre-correction.md
@@ -1,0 +1,253 @@
+# Correlation widget: FM surface point + pre-correlation refractive-index correction
+
+**Status:** implemented (pending live GUI test on real data)
+**Branch:** `claude/correlation-widget-surface-point-2904d2`
+
+## Decisions (resolved 2026-07-15)
+
+1. **LUT tilt in pre mode:** locked to 0° (FM optical axis ⊥ sample surface);
+   the tilt spinbox is disabled with an explanatory tooltip and restored on
+   returning to post mode.
+2. **POI scope in pre mode:** all POIs are corrected (each has its own depth);
+   post mode remains POI 1 only.
+3. **Apply UX:** Apply in pre mode stores the factor and re-runs the correlation;
+   a "Re-run on apply" checkbox (default on) can defer application to the next
+   manual run.
+4. **Surface exclusivity:** only one surface point may exist at a time — adding a
+   FIB surface removes the FM surface and vice versa (`set_data` prefers the FM
+   surface if a hand-edited file contains both). Consequently the RI-tab mode
+   needs no selector: it is implied by which surface exists.
+5. **Enum value:** `PointType.SURFACE_FM = "FM-SURFACE"` (JSON token, menu label
+   "Add FM-SURFACE", row names "FM-SURFACE 1").
+
+## Feature request
+
+The correlation widget currently lets the user pick a **surface point on the FIB image**
+and apply a refractive-index (RI) depth correction to the **correlated POI result**
+(post-correlation, in FIB image space). Users want to additionally be able to pick a
+**surface point in the FM image** and apply the correction to the **pre-correlation POI**
+(in FM volume space, before the 3D→2D transform is fit/applied).
+
+## Current implementation
+
+### Data model — `fibsem/correlation/structures.py`
+
+- `PointType`: `FIB | FM | POI | SURFACE`. `SURFACE` is implicitly FIB-image space.
+- `CorrelationInputData.surface_coordinate: Optional[Coordinate]` — single FIB-space
+  surface point (x, y in FIB pixels).
+- `CorrelationResult.apply_refractive_index_correction(factor)` — post-correlation,
+  in-place on `poi[0]` only, FIB image space:
+  `corrected_y = surface_y + (poi.image_px.y - surface_y) * factor`,
+  then recomputes `px` / `px_m` from `image_px`. Stores
+  `refractive_index_correction_factor` on the result.
+
+### Engine — `fibsem/correlation/correlation_v2.py`
+
+- `run_correlation_from_data(data)` → builds arrays from coordinates,
+  fits `Rigid3D.find_32` from **fiducials only** (FM 3D ↔ FIB 2D), then reprojects the
+  POI array through the fitted transform. POI does not influence the transform.
+- The fit uses random restarts (`ninit=10`) → run-to-run results vary slightly.
+- FM coordinates are passed in **voxel units** and assumed isotropic
+  (`io.py`: "assume isotropic").
+
+### Widget — `fibsem/correlation/ui/widgets/correlation_tab_widget.py`
+
+- FIB canvas: `allowed_point_types=[FIB, SURFACE]` → right-click "Add SURFACE".
+- FM display: `allowed_point_types=[FM, POI]`; added points get `z = current_z` slider value.
+- `_CoordinatesTab` has four `CoordinateListWidget` panels (FIB / FM / POI / Surface);
+  surface is max-1 (replace on add).
+- `_RITab` (tab index 3, disabled until first result):
+  - embeds `RefractiveIndexWidget` (5 optical params → ζ via 5D LUT,
+    `fibsem/correlation/refractive_index.py`; factor spinbox, default 1.47),
+  - shows surface→POI y-distance (px), Apply button populates a table of
+    original/corrected Y and calls `result.apply_refractive_index_correction(factor)`,
+    re-emits `result_changed`, re-draws FIB overlay.
+- Consumer: `fibsem/ui/widgets/autolamella_lamella_protocol_editor.py` opens
+  `CorrelationTabDialog` and reads `result.poi[0].px_m` on accept.
+- `correlation_point_picker_widget.py` is an orphaned parallel prototype (referenced
+  only by its own test script) — out of scope, do not touch.
+
+### Correction math (FM space, requested mode)
+
+RI mismatch stretches apparent depth along the FM optical axis (z). Pre-correlation
+correction is a pure z-scaling of the POI about the surface z:
+
+```
+corrected_z = surface_z + (poi_z - surface_z) * factor
+```
+
+- Signed arithmetic → works regardless of stack z direction.
+- Valid in voxel units when the z-step is uniform (scaling is unit-free); the engine
+  already assumes isotropic voxels for the transform fit itself.
+- x, y are unchanged (distortion is axial only).
+
+## Proposed design
+
+**Principle: pre-correction is part of the run pipeline, recorded in the input data.**
+The correction is applied transiently inside `run_correlation_from_data` (the stored
+`poi_coordinates` keep the user-picked z), so re-running never double-applies, headless
+use gets the same behaviour, and the auto-saved `correlation_data.json` carries full
+provenance (surface point + factor).
+
+### 1. `structures.py`
+
+- Add `PointType.SURFACE_FM` (value string TBD, e.g. `"FM-SURFACE"` — the enum value is
+  both the JSON token and the display label used in canvas menus/row names).
+- `CorrelationInputData`:
+  - `fm_surface_coordinate: Optional[Coordinate] = None`
+  - `ri_pre_correction_factor: Optional[float] = None` (None = off)
+  - serialize both; `from_dict` must use `.get(...)` for the new keys (old JSON loads).
+  - `to_input_dataframe()` / CSV export: add the FM-surface row.
+- Pure helper (unit-testable, no Qt), e.g. in `structures.py` or `util.py`:
+  `apply_z_correction(poi_coords, surface_z, factor)` → corrected copy.
+- `CorrelationResult`: add `refractive_index_correction_mode: Optional[str]`
+  (`"post" | "pre"`), `.get(...)` in `from_dict`. Set `"post"` in
+  `apply_refractive_index_correction()`.
+
+### 2. `correlation_v2.py`
+
+In `run_correlation_from_data`: if `data.fm_surface_coordinate` and
+`data.ri_pre_correction_factor` are set, scale the z of the POI array (all POIs — each
+has its own depth) before `correlate()`; log original→corrected z; set
+`result.refractive_index_correction_factor = factor` and mode `"pre"`.
+
+### 3. `correlation_tab_widget.py`
+
+- FM display: `allowed_point_types=[FM, POI, SURFACE_FM]`; `_on_fm_add_requested`
+  routes SURFACE_FM to a new max-1 list (replace semantics like the FIB surface),
+  `z = current_z`.
+- `_CoordinatesTab`: new "FM Surface" panel + `fm_surface_list`
+  (`CoordinateListWidget(point_type=SURFACE_FM)`), count label in `update_headers`.
+- Wire the 5 list signals; add the new list to every selection-clearing cascade
+  (`_on_*_selected` handlers, canvas add/move/remove routing on the FM side).
+- `data` property / `set_data` / `load_data` / `_refresh_fm_canvas` /
+  `set_fm_image` (axis maxima incl. z) include the FM surface.
+- Refit: route SURFACE_FM through the FM path (reflection/hole via the FM-fiducial
+  method+channel combos — the surface is typically picked in the reflection channel).
+- `_RITab`:
+  - mode selector (e.g. radio: "FIB surface → correct result (post)" /
+    "FM surface → correct input POI & re-run (pre)"), enabled per surface availability;
+    default to FM/pre when an FM surface exists.
+  - pre mode Apply: emit `pre_correction_requested(factor)`; main widget stores the
+    factor (widget state → included in `data`) and calls `_run()` (background worker,
+    same as Run button). Button label "Apply && Re-run" in pre mode.
+  - post mode: unchanged behaviour.
+  - guard double correction: if the result already has a factor applied in one mode,
+    block the other mode with a clear message.
+  - distance label in pre mode: slices and µm (`|Δz| * pixel_size_z`);
+    table shows Z original / Z corrected (FM voxels) instead of Y columns;
+    drop the "POI 1 only" caveat in pre mode (all POIs corrected).
+  - optional enhancement: auto-fill the ζ-LUT `depth_um` spinbox from
+    `|z_poi − z_surf| × pixel_size_z` (µm).
+- Colors/markers: add SURFACE_FM entries to `_POINT_COLORS`/`_POINT_MARKERS`
+  (image_point_canvas.py) and `_POINT_TYPE_COLORS` (coordinate_list_widget.py) —
+  lookups already `.get(...)` with fallbacks, so missing entries degrade, not crash.
+
+### Alternative considered (not recommended)
+
+Deterministic re-projection through the *stored* transform (rebuild `Rigid3D` from
+saved q/s/d and `transform()` the corrected POI, no re-fit). Instant and jitter-free,
+but duplicates projection math outside `correlate()`, needs verification of the stored
+`q` semantics, and complicates provenance. The re-run approach reuses the existing
+worker path; run-to-run transform jitter already exists and only affects the POI via
+the (unchanged) fiducial fit.
+
+## Testing plan
+
+### Unit (pytest, no Qt) — extend `tests/correlation/`
+
+1. z-correction helper: basic scaling, surface above/below POI (signed), factor=1
+   no-op, multiple POIs, z=surface (zero depth).
+2. `run_correlation_from_data` with FM surface + factor (synthetic 4-marker dataset
+   with a known transform): corrected z used for reprojection; `data.poi_coordinates`
+   NOT mutated; re-run gives same corrected input (idempotent); result records
+   factor + mode `"pre"`.
+3. Serialization: round-trip `CorrelationInputData` with new fields; loading legacy
+   dicts *without* the new keys; `CorrelationResult` mode field round-trip;
+   `PointType.SURFACE_FM` round-trip; CSV/`to_input_dataframe` row.
+4. **Fix pre-existing broken tests**: `fibsem/correlation/tests/test_structures.py`
+   calls `apply_refractive_index_correction(factor, surface_y=..., fib_shape=...,
+   pixel_size=...)` with graceful no-op semantics — the current implementation takes
+   only `factor` and raises. These fail today (verified). Update them to the current
+   contract (and consider consolidating into `tests/correlation/`).
+
+### Widget (pytest-qt, pattern exists in `tests/fm/test_autofocus_widget.py`)
+
+- Add FM surface via `_on_fm_add_requested` → appears in list (max-1 replace),
+  included in `widget.data`, survives `set_data` round-trip.
+- RI tab mode enable/disable vs. which surfaces exist; double-apply guard.
+- Pre-mode apply triggers a run with factor set (mock `run_correlation_from_data`).
+
+### Manual / on-instrument checklist
+
+1. Load FIB + FM, pick ≥4 pairs + POI; right-click FM canvas on the surface slice
+   (reflection channel) → Add FM surface; run; apply pre-correction; POI overlay on
+   FIB moves deeper along the projected axis.
+2. Compare pre vs post mode on the same dataset — directions must agree, magnitudes
+   similar (science sanity check).
+3. Save/Load coordinates JSON (new fields), Load old JSON (no fields → no crash),
+   Load Correlation Result round-trip, CSV export, auto-save files.
+4. Refit on the FM surface point; move/delete/reorder interactions; selection
+   highlighting across all five lists/canvases.
+5. Full protocol-editor flow: Continue → POI lands in lamella editor.
+
+## Impact / risks
+
+- **Downstream consumers**: protocol editor reads `result.poi[0].px_m` — no interface
+  change; the value simply reflects the corrected input when pre mode is used.
+- **File compat**: old JSON loads fine (`.get` defaults). New JSON in *old* app
+  versions: the unknown `fm_surface_coordinate` key is ignored by the old `from_dict`
+  (silent drop of the FM surface, no crash).
+- **Double correction** is the main correctness risk → explicit mode + guard.
+- **Stochastic re-run**: pre-mode Apply re-fits the transform (random restarts), so
+  the POI also shifts by ordinary run-to-run jitter. Accepted; alternative noted.
+- **Anisotropic stacks**: correction itself is valid per-axis, but the transform fit
+  already assumes isotropic voxels — unchanged, pre-existing assumption.
+- Stale test file noted above fails today regardless of this feature.
+
+## Implementation summary
+
+- `structures.py`: `PointType.SURFACE_FM`; `CorrelationInputData.fm_surface_coordinate`
+  + `ri_pre_correction_factor` (serialized, `.get()`-compatible with legacy JSON);
+  `apply_z_surface_correction()` helper; `CorrelationResult.refractive_index_correction_mode`
+  ("pre"/"post"); FM-surface row in `to_input_dataframe()`.
+- `correlation_v2.py`: `run_correlation_from_data` applies the z-correction
+  transiently to the POI array (all POIs) before `correlate()` and records
+  factor + mode on the result. Stored coordinates keep the user-picked z.
+- `refractive_index_widget.py`: `set_tilt_locked()` (0° in pre mode, restores on unlock).
+- `correlation_tab_widget.py`: SURFACE_FM on the FM canvas (z = current slice,
+  max-1 replace), "Surface (FM)" list panel + full signal wiring, surface
+  exclusivity, dual-mode `_RITab` (mode banner, tilt lock, re-run checkbox,
+  Z-column table in pre mode, post double-apply guard), `_menu_load_result`
+  reordered so the RI tab sees loaded surfaces, `_logger` NameError fixed.
+- Canvas/list color+marker entries (yellow "+" / "yellow").
+- Visibility of the applied correction:
+  - status line reads "Done — RI pre-correction ×N applied." after a corrected run;
+  - **ghost marker (both modes)**: `CorrelationResult.poi_uncorrected` holds the
+    POI position(s) *without* the correction. Pre mode: all POIs, reprojected
+    deterministically through the same fitted transform
+    (`_reproject_poi_via_transform`; note the parsed `rotation_quaternion` field
+    actually stores `Rigid3D.q`, the 3×3 rotation matrix). Post mode: POI 1
+    snapshotted inside `apply_refractive_index_correction` before the in-place
+    mutation. Drawn as a hollow magenta ring (larger than the solid marker, so
+    it stays visible under partial overlap; `add_overlay_points` gained
+    `alpha`/`show_labels`/`hollow`). The status line reports the shift in px
+    for both modes — a 0.0 px shift is the tell that surface z == POI z
+    (e.g. points placed in MIP mode without moving the z slider).
+
+Tests: `tests/correlation/test_pre_correction.py` (math + engine seam via
+monkeypatched `run_correlation` + serialization), offscreen widget tests in
+`tests/correlation/test_correlation_tab_widget.py`, and the stale
+`fibsem/correlation/tests/test_structures.py` rewritten to the current
+raise-based contract. End-to-end verified against the real `Rigid3D` fit with
+synthetic ground truth (corrected POI lands on the projection of the z-corrected
+3D point to <0.01 px; rms ≈ 0).
+
+## Remaining / follow-ups
+
+- Full validation on real METEOR data (initial live test done 2026-07-15:
+  "looks pretty good"), incl. pre vs post comparison on the same dataset.
+- Optional: auto-fill the ζ-LUT `depth_um` spinbox from `|Δz| × pixel_size_z`.
+- Pre-existing, untouched: `run_correlation` crashes when `image_props is None`
+  (no images loaded — GUI always has them); `correlation_point_picker_widget.py`
+  remains an orphaned prototype and was not updated.

--- a/fibsem/correlation/correlation_v2.py
+++ b/fibsem/correlation/correlation_v2.py
@@ -10,7 +10,14 @@ import yaml
 
 from fibsem.constants import DATETIME_FILE
 from fibsem.correlation.pyto.rigid_3d import Rigid3D # NOTE: this is still a 3DCT dependency, migrate
-from fibsem.correlation.structures import Coordinate, CorrelationInputData, CorrelationPointOfInterest, CorrelationResult, PointXYZ
+from fibsem.correlation.structures import (
+    Coordinate,
+    CorrelationInputData,
+    CorrelationPointOfInterest,
+    CorrelationResult,
+    PointXYZ,
+    apply_z_surface_correction,
+)
 from fibsem.structures import Point
 
 DEFAULT_OPTIMIZATION_PARAMETERS = {
@@ -359,6 +366,44 @@ def _coords_to_array(coords: list[Coordinate]) -> np.ndarray:
     return np.array([[c.point.x, c.point.y, c.point.z] for c in coords], dtype=np.float32)
 
 
+def _reproject_poi_via_transform(
+    transformation: dict,
+    poi_coords: np.ndarray,
+    fib_shape: Optional[Tuple[int, ...]],
+    pixel_size: Optional[float],
+) -> List[CorrelationPointOfInterest]:
+    """Project (N, 3) FM-space POIs into the FIB image using a fitted transform.
+
+    Reconstructs ``y = s * R @ x + d`` from the parsed transformation data.
+    The ``rotation_quaternion`` field stores ``Rigid3D.q``, which is the 3x3
+    rotation matrix (see ``Rigid3D.transform``); ``d`` is the translation
+    around rotation center zero — the same parameters ``correlate()`` uses to
+    reproject the POI.
+    """
+    R = np.asarray(transformation["rotation_quaternion"], dtype=float)
+    if R.shape != (3, 3):
+        logging.warning(
+            f"Cannot reproject POI: unexpected rotation shape {R.shape}"
+        )
+        return []
+    s = float(transformation["scale"])
+    d = np.asarray(
+        transformation["translation_around_rotation_center_zero"], dtype=float
+    )
+    projected = s * (R @ poi_coords.T.astype(float)) + d[:, None]  # (3, N)
+
+    pois: List[CorrelationPointOfInterest] = []
+    for i in range(projected.shape[1]):
+        x, y = float(projected[0, i]), float(projected[1, i])
+        poi = CorrelationPointOfInterest(image_px=Point(x, y))
+        if fib_shape is not None and pixel_size is not None:
+            cx, cy = fib_shape[1] / 2.0, fib_shape[0] / 2.0
+            poi.px = Point(x - cx, cy - y)
+            poi.px_m = Point(poi.px.x * pixel_size, poi.px.y * pixel_size)
+        pois.append(poi)
+    return pois
+
+
 def run_correlation_from_data(
     data: CorrelationInputData,
     path: Optional[str] = None,
@@ -372,6 +417,26 @@ def run_correlation_from_data(
         if data.poi_coordinates
         else np.zeros((0, 3), dtype=np.float32)
     )
+
+    # Pre-correlation refractive-index correction: scale POI z about the FM
+    # surface z. Applied transiently — data.poi_coordinates keeps the picked z,
+    # so re-running never double-applies.
+    pre_correction_applied = False
+    poi_coords_original = poi_coords
+    if (
+        data.fm_surface_coordinate is not None
+        and data.ri_pre_correction_factor is not None
+        and len(poi_coords)
+    ):
+        surface_z = data.fm_surface_coordinate.point.z
+        factor = data.ri_pre_correction_factor
+        poi_coords = apply_z_surface_correction(poi_coords, surface_z, factor)
+        pre_correction_applied = True
+        logging.info(
+            f"Pre-correlation RI correction: factor={factor:.4f}, "
+            f"surface_z={surface_z:.2f}, "
+            f"poi_z {poi_coords_original[:, 2].tolist()} -> {poi_coords[:, 2].tolist()}"
+        )
 
     # image_props: (fib_shape, pixel_size_um, fm_shape_3d)
     fib_shape = data.fib_image_shape
@@ -408,6 +473,14 @@ def run_correlation_from_data(
     r3d = err["reprojected_3d"] # [[x1,...], [y1,...], [z1,...]]
     n_markers = len(d2d[0])
 
+    # Ghost markers: where the POIs would land without the pre-correction,
+    # reprojected through the same fitted transform (no re-fit).
+    poi_uncorrected: List[CorrelationPointOfInterest] = []
+    if pre_correction_applied:
+        poi_uncorrected = _reproject_poi_via_transform(
+            transf, poi_coords_original, fib_shape, pixel_size
+        )
+
     return CorrelationResult(
         poi=[
             CorrelationPointOfInterest(
@@ -417,6 +490,7 @@ def run_correlation_from_data(
             )
             for p in out["poi"]
         ],
+        poi_uncorrected=poi_uncorrected,
         scale=transf["scale"],
         rotation_eulers=transf["rotation_eulers"],
         rotation_quaternion=transf["rotation_quaternion"],
@@ -427,4 +501,8 @@ def run_correlation_from_data(
         delta_2d=[Point(d2d[0][i], d2d[1][i]) for i in range(n_markers)],
         reprojected_3d=[PointXYZ(r3d[0][i], r3d[1][i], r3d[2][i]) for i in range(len(r3d[0]))],
         input_data=data,
+        refractive_index_correction_factor=(
+            data.ri_pre_correction_factor if pre_correction_applied else None
+        ),
+        refractive_index_correction_mode="pre" if pre_correction_applied else None,
     )

--- a/fibsem/correlation/correlation_v2.py
+++ b/fibsem/correlation/correlation_v2.py
@@ -410,6 +410,12 @@ def run_correlation_from_data(
 ) -> CorrelationResult:
     """Run correlation from a CorrelationInputData struct, returning a CorrelationResult."""
 
+    if data.surface_coordinate is not None and data.fm_surface_coordinate is not None:
+        raise ValueError(
+            "Both surface_coordinate (FIB) and fm_surface_coordinate (FM) are set — "
+            "only one surface point is supported (applying both would double-correct)."
+        )
+
     fib_coords = _coords_to_array(data.fib_coordinates)
     fm_coords = _coords_to_array(data.fm_coordinates)
     poi_coords = (

--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from enum import auto, Enum
 from typing import Optional
 import json
+import logging
 import time
 
 import numpy as np
@@ -86,6 +87,10 @@ class CorrelationInputData:
     fm_surface_coordinate: Optional[Coordinate] = None
     ri_pre_correction_factor: Optional[float] = None
     method: str = "multi-point"
+    # Fallbacks restored from serialized files, so a result loaded from JSON
+    # (images absent) can still convert corrected pixels to px / px_m
+    stored_fib_image_shape: Optional[tuple] = None
+    stored_fib_image_pixel_size: Optional[float] = None
 
     def to_dict(self):
         return {
@@ -110,13 +115,13 @@ class CorrelationInputData:
     @property
     def fib_image_pixel_size(self) -> Optional[float]:
         if self.fib_image is None:
-            return None
+            return self.stored_fib_image_pixel_size
         return self.fib_image.metadata.pixel_size.x  # type: ignore[union-attr]
 
     @property
     def fib_image_shape(self) -> Optional[tuple[int, int]]:
         if self.fib_image is None or self.fib_image.data is None:
-            return None
+            return self.stored_fib_image_shape
         return self.fib_image.data.shape
 
     @property
@@ -156,6 +161,7 @@ class CorrelationInputData:
             if data.get("fm_surface_coordinate")
             else None
         )
+        stored_shape = data.get("fib_image_shape")
         return CorrelationInputData(
             fib_coordinates=fib_coordinates,
             fm_coordinates=fm_coordinates,
@@ -164,6 +170,8 @@ class CorrelationInputData:
             fm_surface_coordinate=fm_surface_coordinate,
             ri_pre_correction_factor=data.get("ri_pre_correction_factor"),
             method=data["method"],
+            stored_fib_image_shape=tuple(stored_shape) if stored_shape else None,
+            stored_fib_image_pixel_size=data.get("fib_image_pixel_size"),
         )
 
     def save(self, filename: str):
@@ -298,7 +306,17 @@ class CorrelationResult:
         Reads surface_y / fib_shape / pixel_size from self.input_data. The
         uncorrected position of POI 1 is snapshotted into ``poi_uncorrected``
         (ghost overlay) before the correction is applied.
+
+        Raises ValueError if a correction (pre or post) has already been
+        applied — re-applying would compound the depth scaling.
         """
+        if self.refractive_index_correction_factor is not None:
+            raise ValueError(
+                "A refractive-index correction has already been applied to this "
+                f"result ({self.refractive_index_correction_mode or 'post'}, factor "
+                f"{self.refractive_index_correction_factor}); re-applying would "
+                "compound it. Run the correlation again first."
+            )
         if self.input_data is None:
             raise ValueError(
                 "input_data is required to apply refractive index correction"
@@ -334,6 +352,11 @@ class CorrelationResult:
             cy = fib_shape[0] / 2.0
             poi0.px.y = -(corrected_y - cy)
             poi0.px_m.y = poi0.px.y * pixel_size
+        else:
+            logging.warning(
+                "RI correction: fib image shape/pixel size unavailable — "
+                "poi.px / poi.px_m were NOT updated (only image_px)."
+            )
         self.refractive_index_correction_factor = correction_factor
         self.refractive_index_correction_mode = "post"
         self.updated_at = time.time()

--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -15,7 +15,8 @@ class PointType(Enum):
     FIB = "FIB"
     FM = "FM"
     POI = "POI"
-    SURFACE = "SURFACE"
+    SURFACE = "SURFACE"          # sample surface in the FIB image (post-correlation RI correction)
+    SURFACE_FM = "FM-SURFACE"    # sample surface in the FM volume (pre-correlation RI correction)
 
 
 @dataclass
@@ -47,6 +48,30 @@ class Coordinate:
         return Coordinate(point=point, point_type=point_type)
 
 
+def apply_z_surface_correction(
+    poi_coords: np.ndarray, surface_z: float, correction_factor: float
+) -> np.ndarray:
+    """Scale POI z about the FM surface z (pre-correlation RI correction).
+
+    corrected_z = surface_z + (z - surface_z) * correction_factor
+
+    The scaling is signed, so it is independent of the stack z direction, and
+    unit-free, so it is valid in voxel indices for a uniform z-step.
+
+    Args:
+        poi_coords: (N, 3) array of POI coordinates (x, y, z) in FM voxels.
+        surface_z: z of the surface point in the FM volume (voxels).
+        correction_factor: depth scaling factor (zeta).
+
+    Returns:
+        A corrected copy; the input array is not modified.
+    """
+    corrected = np.array(poi_coords, dtype=np.float32, copy=True)
+    if corrected.size:
+        corrected[:, 2] = surface_z + (corrected[:, 2] - surface_z) * correction_factor
+    return corrected
+
+
 @dataclass
 class CorrelationInputData:
     fib_image: Optional[FibsemImage] = None
@@ -55,6 +80,11 @@ class CorrelationInputData:
     fm_coordinates: list[Coordinate] = field(default_factory=list)
     poi_coordinates: list[Coordinate] = field(default_factory=list)
     surface_coordinate: Optional[Coordinate] = None
+    # Surface point in the FM volume; mutually exclusive with surface_coordinate.
+    # When set together with ri_pre_correction_factor, the POI z is corrected
+    # before the correlation transform is applied (see run_correlation_from_data).
+    fm_surface_coordinate: Optional[Coordinate] = None
+    ri_pre_correction_factor: Optional[float] = None
     method: str = "multi-point"
 
     def to_dict(self):
@@ -65,6 +95,10 @@ class CorrelationInputData:
             "surface_coordinate": self.surface_coordinate.to_dict()
             if self.surface_coordinate
             else None,
+            "fm_surface_coordinate": self.fm_surface_coordinate.to_dict()
+            if self.fm_surface_coordinate
+            else None,
+            "ri_pre_correction_factor": self.ri_pre_correction_factor,
             "fm_image_shape": self.fm_image_shape,
             "fib_image_shape": self.fib_image_shape,
             "fib_image_pixel_size": self.fib_image_pixel_size,
@@ -114,7 +148,12 @@ class CorrelationInputData:
         ]
         surface_coordinate = (
             Coordinate.from_dict(data["surface_coordinate"])
-            if data["surface_coordinate"]
+            if data.get("surface_coordinate")
+            else None
+        )
+        fm_surface_coordinate = (
+            Coordinate.from_dict(data["fm_surface_coordinate"])
+            if data.get("fm_surface_coordinate")
             else None
         )
         return CorrelationInputData(
@@ -122,6 +161,8 @@ class CorrelationInputData:
             fm_coordinates=fm_coordinates,
             poi_coordinates=poi_coordinates,
             surface_coordinate=surface_coordinate,
+            fm_surface_coordinate=fm_surface_coordinate,
+            ri_pre_correction_factor=data.get("ri_pre_correction_factor"),
             method=data["method"],
         )
 
@@ -166,6 +207,10 @@ class CorrelationPointOfInterest:
 @dataclass
 class CorrelationResult:
     poi: list[CorrelationPointOfInterest] = field(default_factory=list)
+    # Where the POIs would land WITHOUT the pre-correlation RI correction,
+    # reprojected through the same fitted transform. Only populated when the
+    # pre-correction was applied; used as a "ghost" overlay for comparison.
+    poi_uncorrected: list[CorrelationPointOfInterest] = field(default_factory=list)
 
     # Transformation
     scale: float = 0.0
@@ -189,11 +234,15 @@ class CorrelationResult:
     # Provenance
     input_data: Optional[CorrelationInputData] = None
     refractive_index_correction_factor: Optional[float] = None
+    # "post": factor applied to the correlated POI in FIB image space
+    # "pre":  factor applied to the input POI z (FM space) before correlation
+    refractive_index_correction_mode: Optional[str] = None
     updated_at: float = field(default_factory=time.time)
 
     def to_dict(self) -> dict:
         return {
             "poi": [p.to_dict() for p in self.poi],
+            "poi_uncorrected": [p.to_dict() for p in self.poi_uncorrected],
             "scale": self.scale,
             "rotation_eulers": self.rotation_eulers,
             "rotation_quaternion": self.rotation_quaternion,
@@ -205,6 +254,7 @@ class CorrelationResult:
             "reprojected_3d": [p.to_dict() for p in self.reprojected_3d],
             "input_data": self.input_data.to_dict() if self.input_data else None,
             "refractive_index_correction_factor": self.refractive_index_correction_factor,
+            "refractive_index_correction_mode": self.refractive_index_correction_mode,
             "updated_at": self.updated_at,
         }
 
@@ -212,6 +262,10 @@ class CorrelationResult:
     def from_dict(data: dict) -> CorrelationResult:
         return CorrelationResult(
             poi=[CorrelationPointOfInterest.from_dict(p) for p in data.get("poi", [])],
+            poi_uncorrected=[
+                CorrelationPointOfInterest.from_dict(p)
+                for p in data.get("poi_uncorrected", [])
+            ],
             scale=data.get("scale", 0.0),
             rotation_eulers=data.get("rotation_eulers", []),
             rotation_quaternion=data.get("rotation_quaternion", []),
@@ -229,6 +283,9 @@ class CorrelationResult:
             refractive_index_correction_factor=data.get(
                 "refractive_index_correction_factor"
             ),
+            refractive_index_correction_mode=data.get(
+                "refractive_index_correction_mode"
+            ),
             updated_at=data.get("updated_at", time.time()),
         )
 
@@ -238,8 +295,9 @@ class CorrelationResult:
     ) -> None:
         """Apply depth correction to the first POI (index 0) in-place.
 
-        Falls back to self.input_data for surface_y / fib_shape / pixel_size
-        when not provided explicitly.
+        Reads surface_y / fib_shape / pixel_size from self.input_data. The
+        uncorrected position of POI 1 is snapshotted into ``poi_uncorrected``
+        (ghost overlay) before the correction is applied.
         """
         if self.input_data is None:
             raise ValueError(
@@ -262,6 +320,14 @@ class CorrelationResult:
         fib_shape = self.input_data.fib_image_shape
         pixel_size = self.input_data.fib_image_pixel_size
         poi0 = self.poi[0]
+        # Snapshot the uncorrected position for the ghost overlay
+        self.poi_uncorrected = [
+            CorrelationPointOfInterest(
+                image_px=Point(poi0.image_px.x, poi0.image_px.y),
+                px=Point(poi0.px.x, poi0.px.y),
+                px_m=Point(poi0.px_m.x, poi0.px_m.y),
+            )
+        ]
         corrected_y = surface_y + (poi0.image_px.y - surface_y) * correction_factor
         poi0.image_px.y = corrected_y
         if fib_shape is not None and pixel_size is not None:
@@ -269,6 +335,7 @@ class CorrelationResult:
             poi0.px.y = -(corrected_y - cy)
             poi0.px_m.y = poi0.px.y * pixel_size
         self.refractive_index_correction_factor = correction_factor
+        self.refractive_index_correction_mode = "post"
         self.updated_at = time.time()
 
     def to_input_dataframe(self):
@@ -298,6 +365,17 @@ class CorrelationResult:
             rows.append(
                 {
                     "type": "SURFACE",
+                    "idx": 0,
+                    "x_px": sc.point.x,
+                    "y_px": sc.point.y,
+                    "z_px": sc.point.z,
+                }
+            )
+        if self.input_data.fm_surface_coordinate is not None:
+            sc = self.input_data.fm_surface_coordinate
+            rows.append(
+                {
+                    "type": PointType.SURFACE_FM.value,
                     "idx": 0,
                     "x_px": sc.point.x,
                     "y_px": sc.point.y,

--- a/fibsem/correlation/tests/test_structures.py
+++ b/fibsem/correlation/tests/test_structures.py
@@ -1,7 +1,9 @@
 """Unit tests for CorrelationResult and CorrelationInputData."""
 import math
 import time
+from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from fibsem.correlation.structures import (
@@ -32,6 +34,17 @@ def _make_coord(x: float = 0.0, y: float = 0.0, z: float = 0.0,
     return Coordinate(point=PointXYZ(x=x, y=y, z=z), point_type=pt)
 
 
+def _make_fake_fib_image(shape=(512, 512), pixel_size: float = 1e-8):
+    """Duck-typed stand-in for FibsemImage (data + metadata.pixel_size.x)."""
+    return SimpleNamespace(
+        data=np.zeros(shape, dtype=np.uint8),
+        metadata=SimpleNamespace(
+            pixel_size=SimpleNamespace(x=pixel_size),
+            image_settings=SimpleNamespace(filename="fake.tif"),
+        ),
+    )
+
+
 def _make_result() -> CorrelationResult:
     return CorrelationResult(
         poi=[_make_poi(100.0, 200.0)],
@@ -44,81 +57,89 @@ def _make_result() -> CorrelationResult:
         delta_2d=[Point(x=0.1, y=0.2)],
         reprojected_3d=[PointXYZ(x=1.0, y=2.0, z=3.0)],
         refractive_index_correction_factor=1.47,
+        refractive_index_correction_mode="post",
+    )
+
+
+def _make_corrected_result(
+    poi_list=None, fib_image=None
+) -> CorrelationResult:
+    """Result with input_data carrying a FIB surface at y=200."""
+    surface = _make_coord(y=200.0, pt=PointType.SURFACE)
+    data = CorrelationInputData(surface_coordinate=surface, fib_image=fib_image)
+    return CorrelationResult(
+        poi=poi_list if poi_list is not None else [_make_poi(image_px_y=300.0)],
+        input_data=data,
     )
 
 
 # ---------------------------------------------------------------------------
-# apply_refractive_index_correction
+# apply_refractive_index_correction (post mode: FIB image space)
 # ---------------------------------------------------------------------------
 
 class TestApplyRefractiveIndexCorrection:
 
     def test_basic_correction(self):
         """Depth below surface is scaled by the correction factor."""
-        poi = _make_poi(image_px_y=300.0)
-        result = CorrelationResult(poi=[poi])
-        result.apply_refractive_index_correction(1.5, surface_y=200.0)
+        result = _make_corrected_result()
+        result.apply_refractive_index_correction(1.5)
         # expected: 200 + (300 - 200) * 1.5 = 350
         assert math.isclose(result.poi[0].image_px.y, 350.0)
 
     def test_px_m_updated(self):
         """px and px_m coordinates are recalculated from image_px after correction."""
-        fib_shape = (512, 512)
         pixel_size = 1e-8
-        poi = _make_poi(image_px_y=300.0)
-        result = CorrelationResult(poi=[poi])
-        result.apply_refractive_index_correction(
-            1.5, surface_y=200.0, fib_shape=fib_shape, pixel_size=pixel_size
-        )
-        cy = fib_shape[0] / 2.0  # 256
+        fib_image = _make_fake_fib_image(shape=(512, 512), pixel_size=pixel_size)
+        result = _make_corrected_result(fib_image=fib_image)
+        result.apply_refractive_index_correction(1.5)
+        cy = 512 / 2.0  # 256
         corrected_y = 350.0
         assert math.isclose(result.poi[0].px.y, -(corrected_y - cy))
         assert math.isclose(result.poi[0].px_m.y, -(corrected_y - cy) * pixel_size)
 
-    def test_reads_surface_from_input_data(self):
-        """surface_y is read from input_data.surface_coordinate when not provided."""
-        surface_coord = _make_coord(y=200.0, pt=PointType.SURFACE)
-        data = CorrelationInputData(surface_coordinate=surface_coord)
-        poi = _make_poi(image_px_y=300.0)
-        result = CorrelationResult(poi=[poi], input_data=data)
-        result.apply_refractive_index_correction(2.0)  # no surface_y arg
-        # expected: 200 + (300 - 200) * 2.0 = 400
-        assert math.isclose(result.poi[0].image_px.y, 400.0)
+    def test_no_input_data_raises(self):
+        result = CorrelationResult(poi=[_make_poi()])
+        with pytest.raises(ValueError, match="input_data"):
+            result.apply_refractive_index_correction(1.5)
 
-    def test_no_poi_returns_self(self):
-        result = CorrelationResult(poi=[])
-        ret = result.apply_refractive_index_correction(1.5, surface_y=100.0)
-        assert ret is result
+    def test_no_poi_raises(self):
+        result = _make_corrected_result(poi_list=[])
+        with pytest.raises(ValueError, match="POI"):
+            result.apply_refractive_index_correction(1.5)
 
-    def test_no_surface_returns_self(self):
-        """Without surface_y and without input_data, correction is a no-op."""
-        poi = _make_poi()
-        result = CorrelationResult(poi=[poi])
-        original_y = result.poi[0].image_px.y
-        ret = result.apply_refractive_index_correction(1.5)
-        assert ret is result
-        assert result.poi[0].image_px.y == original_y
+    def test_no_surface_raises(self):
+        data = CorrelationInputData()
+        result = CorrelationResult(poi=[_make_poi()], input_data=data)
+        with pytest.raises(ValueError, match="surface_coordinate"):
+            result.apply_refractive_index_correction(1.5)
 
-    def test_factor_stored(self):
-        poi = _make_poi(image_px_y=300.0)
-        result = CorrelationResult(poi=[poi])
-        result.apply_refractive_index_correction(1.47, surface_y=200.0)
+    def test_factor_and_mode_stored(self):
+        result = _make_corrected_result()
+        result.apply_refractive_index_correction(1.47)
         assert result.refractive_index_correction_factor == 1.47
+        assert result.refractive_index_correction_mode == "post"
+
+    def test_ghost_snapshot_stored(self):
+        """The uncorrected POI 1 position is kept for the ghost overlay."""
+        result = _make_corrected_result()
+        result.apply_refractive_index_correction(1.5)
+        assert len(result.poi_uncorrected) == 1
+        assert math.isclose(result.poi_uncorrected[0].image_px.y, 300.0)
+        assert math.isclose(result.poi[0].image_px.y, 350.0)
 
     def test_updated_at_advances(self):
-        poi = _make_poi(image_px_y=300.0)
-        result = CorrelationResult(poi=[poi])
+        result = _make_corrected_result()
         before = result.updated_at
         time.sleep(0.01)
-        result.apply_refractive_index_correction(1.47, surface_y=200.0)
+        result.apply_refractive_index_correction(1.47)
         assert result.updated_at > before
 
     def test_only_first_poi_modified(self):
         """Only poi[0] is corrected; other POIs are unchanged."""
         poi0 = _make_poi(image_px_y=300.0)
         poi1 = _make_poi(image_px_y=400.0)
-        result = CorrelationResult(poi=[poi0, poi1])
-        result.apply_refractive_index_correction(2.0, surface_y=200.0)
+        result = _make_corrected_result(poi_list=[poi0, poi1])
+        result.apply_refractive_index_correction(2.0)
         assert math.isclose(result.poi[0].image_px.y, 400.0)   # corrected
         assert math.isclose(result.poi[1].image_px.y, 400.0)   # unchanged
 
@@ -136,6 +157,7 @@ class TestCorrelationResultSerialization:
         assert r2.rms_error == r.rms_error
         assert r2.rotation_eulers == r.rotation_eulers
         assert r2.refractive_index_correction_factor == r.refractive_index_correction_factor
+        assert r2.refractive_index_correction_mode == r.refractive_index_correction_mode
         assert len(r2.poi) == 1
         assert math.isclose(r2.poi[0].image_px.x, 100.0)
         assert math.isclose(r2.poi[0].image_px.y, 200.0)
@@ -177,6 +199,7 @@ class TestCorrelationResultSerialization:
         assert r2.rms_error == 0.0
         assert r2.input_data is None
         assert r2.refractive_index_correction_factor is None
+        assert r2.refractive_index_correction_mode is None
 
     def test_updated_at_preserved(self):
         r = _make_result()

--- a/fibsem/correlation/tests/test_structures.py
+++ b/fibsem/correlation/tests/test_structures.py
@@ -127,6 +127,40 @@ class TestApplyRefractiveIndexCorrection:
         assert math.isclose(result.poi_uncorrected[0].image_px.y, 300.0)
         assert math.isclose(result.poi[0].image_px.y, 350.0)
 
+    def test_double_apply_raises(self):
+        """Re-applying (post-on-post or post-on-pre) must not compound."""
+        result = _make_corrected_result()
+        result.apply_refractive_index_correction(1.5)
+        y_after_first = result.poi[0].image_px.y
+        with pytest.raises(ValueError, match="already been applied"):
+            result.apply_refractive_index_correction(1.5)
+        assert math.isclose(result.poi[0].image_px.y, y_after_first)
+        # the ghost still marks the truly uncorrected position
+        assert math.isclose(result.poi_uncorrected[0].image_px.y, 300.0)
+
+    def test_px_m_updated_after_json_roundtrip(self):
+        """Results loaded from JSON (images absent) must still update px/px_m.
+
+        from_dict restores the fib image shape/pixel size from the serialized
+        fields, so the metre-space POI handed to downstream consumers is the
+        corrected one.
+        """
+        pixel_size = 1e-8
+        fib_image = _make_fake_fib_image(shape=(512, 512), pixel_size=pixel_size)
+        surface = _make_coord(y=200.0, pt=PointType.SURFACE)
+        data = CorrelationInputData(surface_coordinate=surface, fib_image=fib_image)
+
+        data2 = CorrelationInputData.from_dict(data.to_dict())  # images dropped
+        assert data2.fib_image is None
+        assert tuple(data2.fib_image_shape) == (512, 512)
+        assert data2.fib_image_pixel_size == pytest.approx(pixel_size)
+
+        result = CorrelationResult(poi=[_make_poi(image_px_y=300.0)], input_data=data2)
+        result.apply_refractive_index_correction(1.5)
+        cy = 512 / 2.0
+        assert math.isclose(result.poi[0].px.y, -(350.0 - cy))
+        assert math.isclose(result.poi[0].px_m.y, -(350.0 - cy) * pixel_size)
+
     def test_updated_at_advances(self):
         result = _make_corrected_result()
         before = result.updated_at

--- a/fibsem/correlation/ui/widgets/coordinate_list_widget.py
+++ b/fibsem/correlation/ui/widgets/coordinate_list_widget.py
@@ -42,10 +42,11 @@ _ROW_HEIGHT = 40
 _ROW_RIGHT_WIDTH = 10
 
 _POINT_TYPE_COLORS: Dict[PointType, str] = {
-    PointType.FIB:     "lime",
-    PointType.FM:      "cyan",
-    PointType.POI:     "magenta",
-    PointType.SURFACE: "red",
+    PointType.FIB:        "lime",
+    PointType.FM:         "cyan",
+    PointType.POI:        "magenta",
+    PointType.SURFACE:    "red",
+    PointType.SURFACE_FM: "yellow",
 }
 
 

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -995,8 +995,12 @@ class CorrelationTabWidget(QWidget):
         self._action_show_scalebar = QAction("Show ScaleBar", self)
         self._action_show_scalebar.setCheckable(True)
         self._action_show_scalebar.setChecked(True)
+        self._action_show_legend = QAction("Show Legend", self)
+        self._action_show_legend.setCheckable(True)
+        self._action_show_legend.setChecked(True)
         view_menu.addAction(self._action_reset_views)
         view_menu.addAction(self._action_show_scalebar)
+        view_menu.addAction(self._action_show_legend)
 
         test_menu = menubar.addMenu("Test")
         self._action_test_save_plot = QAction("Test Save Plot", self)
@@ -1148,6 +1152,7 @@ class CorrelationTabWidget(QWidget):
         self._action_reset_views.triggered.connect(lambda _: self._reset_views())
         self._action_show_scalebar.toggled.connect(self._on_scalebar_toggled)
         self._on_scalebar_toggled(True)
+        self._action_show_legend.toggled.connect(self._on_legend_toggled)
         self._action_test_save_plot.triggered.connect(lambda _: self.save_plot())
 
         # Bottom bar run button
@@ -1456,6 +1461,7 @@ class CorrelationTabWidget(QWidget):
                 label_prefix="E",
                 size=7,
                 marker="o",
+                legend_label="FM reprojected (E)",
             )
 
         # Ghost: where the POI would land without the RI pre-correction —
@@ -1471,6 +1477,7 @@ class CorrelationTabWidget(QWidget):
                 alpha=0.7,
                 show_labels=False,
                 hollow=True,
+                legend_label="POI uncorrected",
             )
 
         # Reprojected POI — magenta circle, labeled P1/P2/...
@@ -1482,6 +1489,7 @@ class CorrelationTabWidget(QWidget):
                 label_prefix="P",
                 size=9,
                 marker="o",
+                legend_label="POI (P)",
             )
 
     # ------------------------------------------------------------------
@@ -1748,6 +1756,10 @@ class CorrelationTabWidget(QWidget):
     def _on_scalebar_toggled(self, visible: bool) -> None:
         self._fib_canvas.set_scalebar_visible(visible)
         self._fm_display.canvas.set_scalebar_visible(visible)
+
+    def _on_legend_toggled(self, visible: bool) -> None:
+        self._fib_canvas.set_legend_visible(visible)
+        self._fm_display.canvas.set_legend_visible(visible)
 
     def save_plot(self, path: Optional[str] = None) -> None:
         """Save FIB + FM canvases as a side-by-side matplotlib figure."""

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -10,15 +10,18 @@ Layout
 │    Add FIB          │  right-click →      │  │                         ││
 │    Add Surface      │    Add FM           │  │                         ││
 │                     │    Add POI          │  │                         ││
-│                     │                     │  └─────────────────────────┘│
+│                     │    Add FM-Surface   │  └─────────────────────────┘│
 └─────────────────────┴─────────────────────┴────────────────────────────┘
 
 Tabs
 ----
   Images      — browse / load FIB and FM images
-  Coordinates — coordinate lists (FIB, FM, POI, Surface) + fit settings + load/save
+  Coordinates — coordinate lists (FIB, FM, POI, Surface FIB/FM) + fit settings + load/save
   Results     — run correlation + CorrelationResultWidget overlay
-  RI          — refractive-index depth correction table
+  RI          — refractive-index depth correction; mode follows the surface point:
+                FIB surface → post-correlation (corrects the correlated POI 1),
+                FM surface  → pre-correlation (corrects every input POI z, applied
+                during the run). Only one surface point can exist at a time.
 
 Signals
 -------
@@ -361,6 +364,7 @@ class _CoordinatesTab(QWidget):
     fm_list: CoordinateListWidget
     poi_list: CoordinateListWidget
     surface_list: CoordinateListWidget
+    fm_surface_list: CoordinateListWidget
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
@@ -405,14 +409,23 @@ class _CoordinatesTab(QWidget):
         self._poi_panel.add_header_widget(self._poi_count_label)
         layout.addWidget(self._poi_panel)
 
-        # Surface (max 1)
+        # Surface (max 1, FIB image; mutually exclusive with FM Surface)
         self.surface_list = CoordinateListWidget(point_type=PointType.SURFACE)
-        self._surface_panel = TitledPanel("Surface", collapsible=True)
+        self._surface_panel = TitledPanel("Surface (FIB)", collapsible=True)
         self._surface_panel.set_content(self.surface_list)
         self._surface_count_label = QLabel("(0)")
         self._surface_count_label.setStyleSheet("color: #aaa; font-size: 11px;")
         self._surface_panel.add_header_widget(self._surface_count_label)
         layout.addWidget(self._surface_panel)
+
+        # FM Surface (max 1, FM volume; mutually exclusive with Surface)
+        self.fm_surface_list = CoordinateListWidget(point_type=PointType.SURFACE_FM)
+        self._fm_surface_panel = TitledPanel("Surface (FM)", collapsible=True)
+        self._fm_surface_panel.set_content(self.fm_surface_list)
+        self._fm_surface_count_label = QLabel("(0)")
+        self._fm_surface_count_label.setStyleSheet("color: #aaa; font-size: 11px;")
+        self._fm_surface_panel.add_header_widget(self._fm_surface_count_label)
+        layout.addWidget(self._fm_surface_panel)
 
         # Fit Settings
         fit_body = QWidget()
@@ -461,6 +474,9 @@ class _CoordinatesTab(QWidget):
         self._fm_count_label.setText(f"({len(self.fm_list.coordinates)})")
         self._poi_count_label.setText(f"({len(self.poi_list.coordinates)})")
         self._surface_count_label.setText(f"({len(self.surface_list.coordinates)})")
+        self._fm_surface_count_label.setText(
+            f"({len(self.fm_surface_list.coordinates)})"
+        )
 
     def rebuild_channel_combos(self, fm_image: Optional[FluorescenceImage]) -> None:
         for cb in (self._fm_fid_ch_combo, self._fm_poi_ch_combo):
@@ -579,15 +595,32 @@ class _ResultsTab(QWidget):
 
 
 class _RITab(QWidget):
-    """Refractive-index depth correction table."""
+    """Refractive-index depth correction.
 
-    correction_applied = pyqtSignal(object)  # CorrelationResult
+    Two modes, implied by which surface point exists (mutually exclusive):
+
+    post — FIB surface: corrects the correlated POI 1 in FIB image space,
+           in-place on the existing result.
+    pre  — FM surface: corrects the z of every input POI (FM space). The
+           correction is applied inside ``run_correlation_from_data``, so
+           applying it triggers (or requires) a correlation run.
+    """
+
+    correction_applied = pyqtSignal(object)             # CorrelationResult (post)
+    pre_correction_requested = pyqtSignal(float, bool)  # factor, rerun (pre)
+
+    _POST_HEADERS = ["POI", "X (px)", "Y original (px)", "Y corrected (px)"]
+    _PRE_HEADERS = ["POI", "X (px)", "Z original (px)", "Z corrected (px)"]
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self._poi: List[CorrelationPointOfInterest] = []
         self._surface_coordinate: Optional[Coordinate] = None
         self._surface_y: Optional[float] = None
+        self._fm_surface_coordinate: Optional[Coordinate] = None
+        self._input_poi: List[Coordinate] = []
+        self._input_pre_factor: Optional[float] = None
+        self._fm_pixel_size_z: Optional[float] = None
         self._result: Optional[CorrelationResult] = None
         self._setup_ui()
 
@@ -595,6 +628,12 @@ class _RITab(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 16, 16, 16)
         layout.setSpacing(8)
+
+        self._lbl_mode = QLabel("")
+        self._lbl_mode.setStyleSheet("color: #a0c8ff; font-size: 11px;")
+        self._lbl_mode.setWordWrap(True)
+        self._lbl_mode.setVisible(False)
+        layout.addWidget(self._lbl_mode)
 
         self._ri_widget = RefractiveIndexWidget()
         layout.addWidget(self._ri_widget)
@@ -609,6 +648,15 @@ class _RITab(QWidget):
         self._btn_apply.clicked.connect(self._apply)
         apply_layout.addWidget(self._btn_apply)
 
+        self._chk_rerun = QCheckBox("Re-run on apply")
+        self._chk_rerun.setChecked(True)
+        self._chk_rerun.setToolTip(
+            "Re-run the correlation immediately when applying the correction. "
+            "If unchecked, the factor is stored and applied on the next run."
+        )
+        self._chk_rerun.setVisible(False)
+        apply_layout.addWidget(self._chk_rerun)
+
         self._lbl_warning = QLabel("")
         self._lbl_warning.setStyleSheet("color: #e07b39; font-size: 11px;")
         apply_layout.addWidget(self._lbl_warning)
@@ -621,9 +669,7 @@ class _RITab(QWidget):
         layout.addWidget(self._lbl_distance)
 
         self._table = QTableWidget(0, 4)
-        self._table.setHorizontalHeaderLabels(
-            ["POI", "X (px)", "Y original (px)", "Y corrected (px)"]
-        )
+        self._table.setHorizontalHeaderLabels(self._POST_HEADERS)
         self._table.horizontalHeader().setSectionResizeMode(
             QHeaderView.ResizeMode.Stretch
         )
@@ -643,38 +689,91 @@ class _RITab(QWidget):
         layout.addWidget(self._lbl_multi_poi)
         layout.addStretch(1)
 
+    @property
+    def mode(self) -> Optional[str]:
+        """'pre' when an FM surface exists, 'post' for a FIB surface, else None."""
+        if self._fm_surface_coordinate is not None:
+            return "pre"
+        if self._surface_coordinate is not None:
+            return "post"
+        return None
+
     def set_result(
         self,
         result: Optional[CorrelationResult],
-        surface_coordinate: Optional[Coordinate] = None,
+        input_data: Optional[CorrelationInputData] = None,
+        fm_pixel_size_z: Optional[float] = None,
     ) -> None:
         self._result = result
         self._poi = result.poi if result else []
-        self._surface_coordinate = surface_coordinate
-        self._surface_y = surface_coordinate.point.y if surface_coordinate else None
+        surface = input_data.surface_coordinate if input_data else None
+        self._surface_coordinate = surface
+        self._surface_y = surface.point.y if surface else None
+        self._fm_surface_coordinate = (
+            input_data.fm_surface_coordinate if input_data else None
+        )
+        self._input_poi = list(input_data.poi_coordinates) if input_data else []
+        self._input_pre_factor = (
+            input_data.ri_pre_correction_factor if input_data else None
+        )
+        self._fm_pixel_size_z = fm_pixel_size_z
 
+        mode = self.mode
         logging.debug(
-            f"[RITab.set_result] result={result is not None}, "
-            f"surface_coordinate={surface_coordinate}, "
+            f"[RITab.set_result] result={result is not None}, mode={mode}, "
             f"surface_y={self._surface_y}, "
+            f"fm_surface={self._fm_surface_coordinate}, "
             f"n_poi={len(self._poi)}"
         )
 
+        # Mode banner + pre-mode controls
+        if mode == "pre":
+            self._lbl_mode.setText(
+                "FM surface mode: corrects the z of every input POI before "
+                "correlation (applied during the run)."
+            )
+        elif mode == "post":
+            self._lbl_mode.setText(
+                "FIB surface mode: corrects the correlated POI 1 in the FIB image."
+            )
+        self._lbl_mode.setVisible(mode is not None)
+        self._chk_rerun.setVisible(mode == "pre")
+        self._ri_widget.set_tilt_locked(mode == "pre")
+
+        self._table.setHorizontalHeaderLabels(
+            self._PRE_HEADERS if mode == "pre" else self._POST_HEADERS
+        )
         self._table.setRowCount(0)
-        self._lbl_multi_poi.setVisible(len(self._poi) > 1)
+        self._lbl_multi_poi.setVisible(mode == "post" and len(self._poi) > 1)
         self._update_distance_label()
 
-        factor = result.refractive_index_correction_factor if result else None
-        if factor is not None:
-            self._ri_widget.set_factor(factor)
+        result_factor = result.refractive_index_correction_factor if result else None
+        result_mode = result.refractive_index_correction_mode if result else None
+
+        # Factor spinbox mirrors the authoritative stored factor, if any
+        if result_factor is not None:
+            self._ri_widget.set_factor(result_factor)
+        elif mode == "pre" and self._input_pre_factor is not None:
+            self._ri_widget.set_factor(self._input_pre_factor)
+
+        # Pre-mode preview table (stored factor, applied or armed)
+        if mode == "pre" and self._input_pre_factor is not None:
+            self._populate_pre_table(self._input_pre_factor)
+
+        if result_factor is not None:
             self._lbl_warning.setStyleSheet("color: #6dbf6d; font-size: 11px;")
             self._lbl_warning.setText(
-                f"Correction already applied (factor: {factor:.3f})."
+                f"Correction applied ({result_mode or 'post'}, factor: {result_factor:.3f})."
+            )
+        elif mode == "pre" and self._input_pre_factor is not None:
+            self._lbl_warning.setStyleSheet("color: #e0c060; font-size: 11px;")
+            self._lbl_warning.setText(
+                f"Factor {self._input_pre_factor:.3f} stored — applied on the next run."
             )
         elif not self._poi:
             self._lbl_warning.setStyleSheet("color: #e07b39; font-size: 11px;")
             self._lbl_warning.setText("No POI in result.")
-        elif self._surface_y is None:
+        elif mode is None:
             self._lbl_warning.setStyleSheet("color: #e07b39; font-size: 11px;")
             self._lbl_warning.setText("No surface coordinate — correction unavailable.")
         else:
@@ -682,6 +781,18 @@ class _RITab(QWidget):
             self._lbl_warning.setText("")
 
     def _update_distance_label(self) -> None:
+        mode = self.mode
+        if mode == "pre":
+            if self._fm_surface_coordinate is None or not self._input_poi:
+                self._lbl_distance.setVisible(False)
+                return
+            dz = abs(self._input_poi[0].point.z - self._fm_surface_coordinate.point.z)
+            text = f"Surface → POI 1 depth: {dz:.1f} slices"
+            if self._fm_pixel_size_z:
+                text += f" ({dz * self._fm_pixel_size_z * 1e6:.2f} µm)"
+            self._lbl_distance.setText(text)
+            self._lbl_distance.setVisible(True)
+            return
         if self._surface_y is None or not self._poi:
             self._lbl_distance.setVisible(False)
             return
@@ -689,7 +800,45 @@ class _RITab(QWidget):
         self._lbl_distance.setText(f"Surface → POI depth: {dist_px:.1f} px")
         self._lbl_distance.setVisible(True)
 
+    def _populate_pre_table(self, factor: float) -> None:
+        if self._fm_surface_coordinate is None:
+            return
+        surface_z = self._fm_surface_coordinate.point.z
+        self._table.setRowCount(len(self._input_poi))
+        for i, coord in enumerate(self._input_poi):
+            z = coord.point.z
+            corrected_z = surface_z + (z - surface_z) * factor
+            self._table.setItem(i, 0, _ro_item(f"POI {i + 1}"))
+            self._table.setItem(i, 1, _ro_item(f"{coord.point.x:.2f}"))
+            self._table.setItem(i, 2, _ro_item(f"{z:.2f}"))
+            self._table.setItem(i, 3, _ro_item(f"{corrected_z:.2f}"))
+
     def _apply(self) -> None:
+        if self.mode == "pre":
+            self._apply_pre()
+        else:
+            self._apply_post()
+
+    def _apply_pre(self) -> None:
+        if self._fm_surface_coordinate is None:
+            self._lbl_warning.setText("No FM surface coordinate — cannot apply correction.")
+            return
+        if not self._input_poi:
+            self._lbl_warning.setText("No POI coordinates to correct.")
+            return
+        self._lbl_warning.setText("")
+        factor = self._ri_widget.get_factor()
+        rerun = self._chk_rerun.isChecked()
+        logging.info(
+            f"[RITab._apply_pre] factor={factor:.4f}, "
+            f"surface_z={self._fm_surface_coordinate.point.z:.2f}, "
+            f"n_poi={len(self._input_poi)}, rerun={rerun}"
+        )
+        # The parent stores the factor and emits data_changed, which refreshes
+        # this tab (preview table included) via set_result.
+        self.pre_correction_requested.emit(factor, rerun)
+
+    def _apply_post(self) -> None:
         if not self._poi:
             self._lbl_warning.setText("No POI available.")
             return
@@ -698,12 +847,21 @@ class _RITab(QWidget):
                 "No surface coordinate — cannot apply correction."
             )
             return
+        if (
+            self._result is not None
+            and self._result.refractive_index_correction_factor is not None
+        ):
+            # Guard against double-correcting (post-on-post or post-on-pre)
+            self._lbl_warning.setText(
+                "Correction already applied to this result — run correlation again first."
+            )
+            return
         self._lbl_warning.setText("")
         factor = self._ri_widget.get_factor()
         surface_y = self._surface_y
 
         logging.info(
-            f"[RITab._apply] factor={factor:.4f}, surface_y={surface_y:.2f}, n_poi={len(self._poi)}"
+            f"[RITab._apply_post] factor={factor:.4f}, surface_y={surface_y:.2f}, n_poi={len(self._poi)}"
         )
 
         # Populate table (all POIs shown for reference)
@@ -712,7 +870,7 @@ class _RITab(QWidget):
             depth = poi.image_px.y - surface_y
             corrected_y = surface_y + depth * factor
             logging.info(
-                f"[RITab._apply] POI {i + 1}: original_y={poi.image_px.y:.2f}, "
+                f"[RITab._apply_post] POI {i + 1}: original_y={poi.image_px.y:.2f}, "
                 f"depth={depth:.2f}, corrected_y={corrected_y:.2f}"
             )
             self._table.setItem(i, 0, _ro_item(f"POI {i + 1}"))
@@ -721,7 +879,7 @@ class _RITab(QWidget):
             self._table.setItem(i, 3, _ro_item(f"{corrected_y:.2f}"))
 
         if self._result is None:
-            logging.warning("[RITab._apply] No result to update with correction.")
+            logging.warning("[RITab._apply_post] No result to update with correction.")
             return
 
         # apply surface_y to the result for internal consistency (in case it wasn't set before)
@@ -729,7 +887,7 @@ class _RITab(QWidget):
 
         # Update POI 0 in the result and propagate (reads input_data internally)
         self._result.apply_refractive_index_correction(factor)
-        logging.info("[RITab._apply] correction applied, emitting correction_applied")
+        logging.info("[RITab._apply_post] correction applied, emitting correction_applied")
         self.correction_applied.emit(self._result)
 
 
@@ -764,6 +922,8 @@ class CorrelationTabWidget(QWidget):
         self._result: Optional[CorrelationResult] = None
         self._worker: Optional[_CorrelationWorker] = None
         self._project_dir: Optional[str] = None
+        # Pre-correlation RI factor (FM surface mode); set via the RI tab Apply
+        self._ri_pre_correction_factor: Optional[float] = None
 
         self._setup_ui()
         self._connect_signals()
@@ -829,7 +989,7 @@ class CorrelationTabWidget(QWidget):
 
         # Middle: FM image display
         self._fm_display = FMImageDisplayWidget(
-            allowed_point_types=[PointType.FM, PointType.POI],
+            allowed_point_types=[PointType.FM, PointType.POI, PointType.SURFACE_FM],
         )
         splitter.addWidget(self._fm_display)
 
@@ -897,6 +1057,7 @@ class CorrelationTabWidget(QWidget):
 
         # RI correction
         self._ri_tab.correction_applied.connect(self._on_correction_applied)
+        self._ri_tab.pre_correction_requested.connect(self._on_pre_correction_requested)
 
         # Canvas → list
         self._fib_canvas.point_selected.connect(self._on_fib_canvas_selected)
@@ -943,6 +1104,14 @@ class CorrelationTabWidget(QWidget):
         )
         cl.surface_list.refit_requested.connect(self._on_refit_requested)
 
+        cl.fm_surface_list.coordinate_selected.connect(self._on_fm_surface_list_selected)
+        cl.fm_surface_list.coordinate_changed.connect(self._on_fm_surface_list_changed)
+        cl.fm_surface_list.coordinate_removed.connect(self._on_fm_surface_list_removed)
+        cl.fm_surface_list.order_changed.connect(
+            lambda _: (self._refresh_fm_canvas(), self.data_changed.emit(self.data))
+        )
+        cl.fm_surface_list.refit_requested.connect(self._on_refit_requested)
+
         # File menu
         self._action_load_fib.triggered.connect(self._menu_load_fib)
         self._action_load_fm.triggered.connect(self._menu_load_fm)
@@ -963,8 +1132,15 @@ class CorrelationTabWidget(QWidget):
 
     def _on_data_changed(self, data: CorrelationInputData) -> None:
         self._ri_tab.set_result(
-            self._result, surface_coordinate=data.surface_coordinate
+            self._result,
+            input_data=data,
+            fm_pixel_size_z=self._fm_pixel_size_z(),
         )
+
+    def _fm_pixel_size_z(self) -> Optional[float]:
+        if self._fm_image is None:
+            return None
+        return getattr(self._fm_image.metadata, "pixel_size_z", None)
 
     # ------------------------------------------------------------------
     # Public API
@@ -998,6 +1174,9 @@ class CorrelationTabWidget(QWidget):
         self._coords_tab.poi_list.set_axis_maxima(
             x_max=w - 1, y_max=h - 1, z_max=n_z - 1
         )
+        self._coords_tab.fm_surface_list.set_axis_maxima(
+            x_max=w - 1, y_max=h - 1, z_max=n_z - 1
+        )
         self._coords_tab.rebuild_channel_combos(fm_image)
         self._images_tab.set_fm_image(fm_image)
 
@@ -1014,16 +1193,30 @@ class CorrelationTabWidget(QWidget):
         surf_coords = (
             [data.surface_coordinate] if data.surface_coordinate is not None else []
         )
+        fm_surf_coords = (
+            [data.fm_surface_coordinate]
+            if data.fm_surface_coordinate is not None
+            else []
+        )
+        if surf_coords and fm_surf_coords:
+            # Only one surface point is allowed — prefer the FM surface
+            logging.warning(
+                "Both FIB and FM surface coordinates present — keeping the FM surface."
+            )
+            surf_coords = []
 
         self._fib_canvas.set_coordinates(fib_coords + surf_coords)
-        self._fm_display.set_coordinates(fm_coords + poi_coords)
+        self._fm_display.set_coordinates(fm_coords + poi_coords + fm_surf_coords)
 
         cl = self._coords_tab
         cl.fib_list.coordinates = fib_coords
         cl.fm_list.coordinates = fm_coords
         cl.poi_list.coordinates = poi_coords
         cl.surface_list.coordinates = surf_coords
+        cl.fm_surface_list.coordinates = fm_surf_coords
         cl.update_headers()
+
+        self._ri_pre_correction_factor = data.ri_pre_correction_factor
 
     def load_data(self, path: str) -> None:
         """Load coordinates from JSON, preserving current images."""
@@ -1041,6 +1234,7 @@ class CorrelationTabWidget(QWidget):
     def data(self) -> CorrelationInputData:
         cl = self._coords_tab
         surf = cl.surface_list.coordinates
+        fm_surf = cl.fm_surface_list.coordinates
         return CorrelationInputData(
             fib_image=self._fib_image,
             fm_image=self._fm_image,
@@ -1048,6 +1242,8 @@ class CorrelationTabWidget(QWidget):
             fm_coordinates=cl.fm_list.coordinates,
             poi_coordinates=cl.poi_list.coordinates,
             surface_coordinate=surf[0] if surf else None,
+            fm_surface_coordinate=fm_surf[0] if fm_surf else None,
+            ri_pre_correction_factor=self._ri_pre_correction_factor,
         )
 
     @property
@@ -1067,7 +1263,9 @@ class CorrelationTabWidget(QWidget):
     def _refresh_fm_canvas(self) -> None:
         cl = self._coords_tab
         self._fm_display.set_coordinates(
-            cl.fm_list.coordinates + cl.poi_list.coordinates
+            cl.fm_list.coordinates
+            + cl.poi_list.coordinates
+            + cl.fm_surface_list.coordinates
         )
 
     # ------------------------------------------------------------------
@@ -1090,7 +1288,7 @@ class CorrelationTabWidget(QWidget):
         try:
             data.save(os.path.join(self._project_dir, "correlation_data.json"))
         except Exception:
-            _logger.exception("Auto-save of correlation data failed")
+            logging.exception("Auto-save of correlation data failed")
 
     def _auto_save_result(self, result: CorrelationResult) -> None:
         if not self._project_dir:
@@ -1098,7 +1296,7 @@ class CorrelationTabWidget(QWidget):
         try:
             result.save(os.path.join(self._project_dir, "correlation_result.json"))
         except Exception:
-            _logger.exception("Auto-save of correlation result failed")
+            logging.exception("Auto-save of correlation result failed")
 
     # ------------------------------------------------------------------
     # Run correlation
@@ -1147,18 +1345,62 @@ class CorrelationTabWidget(QWidget):
     def _on_result_ready(self, result: CorrelationResult) -> None:
         self._result = result
         self._results_tab.set_result(result)
-        self._ri_tab.set_result(result, surface_coordinate=self.data.surface_coordinate)
+        self._ri_tab.set_result(
+            result, input_data=self.data, fm_pixel_size_z=self._fm_pixel_size_z()
+        )
         self._tabs.setTabEnabled(3, True)
         self._overlay_result_on_fib(result)
-        self._lbl_status.setText("Done.")
         self._btn_continue.setEnabled(True)
+        # after _update_run_button, which would otherwise overwrite it with "Ready."
         self._update_run_button()
+        if (
+            result.refractive_index_correction_mode == "pre"
+            and result.refractive_index_correction_factor is not None
+        ):
+            msg = (
+                f"Done — RI pre-correction ×{result.refractive_index_correction_factor:.3f} applied"
+            )
+            shift = self._poi_shift_px(result)
+            if shift is not None:
+                msg += f", POI 1 shifted {shift:.1f} px"
+            self._lbl_status.setText(msg + ".")
+        else:
+            self._lbl_status.setText("Done.")
         self.result_changed.emit(result)
+
+    @staticmethod
+    def _poi_shift_px(result: CorrelationResult) -> Optional[float]:
+        """Distance (px) between POI 1 and its uncorrected ghost, if present."""
+        if not (result.poi and result.poi_uncorrected):
+            return None
+        return float(
+            np.hypot(
+                result.poi[0].image_px.x - result.poi_uncorrected[0].image_px.x,
+                result.poi[0].image_px.y - result.poi_uncorrected[0].image_px.y,
+            )
+        )
 
     def _on_correction_applied(self, result: CorrelationResult) -> None:
         self._result = result
         self._overlay_result_on_fib(result)
+        factor = result.refractive_index_correction_factor
+        shift = self._poi_shift_px(result)
+        if factor is not None and shift is not None:
+            self._lbl_status.setText(
+                f"RI post-correction ×{factor:.3f} applied, POI 1 shifted {shift:.1f} px."
+            )
         self.result_changed.emit(result)
+
+    def _on_pre_correction_requested(self, factor: float, rerun: bool) -> None:
+        """Store the pre-correlation RI factor and optionally re-run."""
+        self._ri_pre_correction_factor = factor
+        self.data_changed.emit(self.data)  # auto-save + RI tab refresh
+        if rerun:
+            self._run()
+        else:
+            self._lbl_status.setText(
+                "Pre-correction factor stored — run correlation to apply."
+            )
 
     def _on_run_error(self, msg: str) -> None:
         self._lbl_status.setText(f"Error: {msg}")
@@ -1177,6 +1419,21 @@ class CorrelationTabWidget(QWidget):
                 label_prefix="E",
                 size=7,
                 marker="o",
+            )
+
+        # Ghost: where the POI would land without the RI pre-correction —
+        # hollow magenta ring, unlabeled, larger than the corrected marker so it
+        # stays visible even when the shift is small and the markers overlap
+        ghost_pts = [(p.image_px.x, p.image_px.y) for p in result.poi_uncorrected]
+        if ghost_pts:
+            self._fib_canvas.add_overlay_points(
+                ghost_pts,
+                color="#ff00ff",
+                size=13,
+                marker="o",
+                alpha=0.7,
+                show_labels=False,
+                hollow=True,
             )
 
         # Reprojected POI — magenta circle, labeled P1/P2/...
@@ -1204,6 +1461,7 @@ class CorrelationTabWidget(QWidget):
             cl.surface_list.select_coordinate_silent(None)
         cl.fm_list.select_coordinate_silent(None)
         cl.poi_list.select_coordinate_silent(None)
+        cl.fm_surface_list.select_coordinate_silent(None)
         self._fm_display.set_selected(None)
 
     def _on_fm_canvas_selected(self, coord: Coordinate) -> None:
@@ -1211,11 +1469,14 @@ class CorrelationTabWidget(QWidget):
         self._fib_canvas.set_selected(None)
         cl.fib_list.select_coordinate_silent(None)
         cl.surface_list.select_coordinate_silent(None)
+        cl.fm_list.select_coordinate_silent(None)
+        cl.poi_list.select_coordinate_silent(None)
+        cl.fm_surface_list.select_coordinate_silent(None)
         if coord.point_type == PointType.FM:
             cl.fm_list.select_coordinate_silent(coord)
-            cl.poi_list.select_coordinate_silent(None)
+        elif coord.point_type == PointType.SURFACE_FM:
+            cl.fm_surface_list.select_coordinate_silent(coord)
         else:
-            cl.fm_list.select_coordinate_silent(None)
             cl.poi_list.select_coordinate_silent(coord)
 
     def _on_fib_canvas_moved(self, coord: Coordinate) -> None:
@@ -1230,6 +1491,8 @@ class CorrelationTabWidget(QWidget):
         cl = self._coords_tab
         if coord.point_type == PointType.FM:
             cl.fm_list.refresh_coordinate(coord)
+        elif coord.point_type == PointType.SURFACE_FM:
+            cl.fm_surface_list.refresh_coordinate(coord)
         else:
             cl.poi_list.refresh_coordinate(coord)
         self.data_changed.emit(self.data)
@@ -1254,6 +1517,10 @@ class CorrelationTabWidget(QWidget):
             cl.fm_list.coordinates = [
                 c for c in cl.fm_list.coordinates if c is not coord
             ]
+        elif coord.point_type == PointType.SURFACE_FM:
+            cl.fm_surface_list.coordinates = [
+                c for c in cl.fm_surface_list.coordinates if c is not coord
+            ]
         else:
             cl.poi_list.coordinates = [
                 c for c in cl.poi_list.coordinates if c is not coord
@@ -1267,6 +1534,10 @@ class CorrelationTabWidget(QWidget):
         coord = Coordinate(PointXYZ(x, y, 0.0), pt)
         if pt == PointType.SURFACE:
             cl.surface_list.coordinates = [coord]
+            # Only one surface point at a time — replace any FM surface
+            if cl.fm_surface_list.coordinates:
+                cl.fm_surface_list.coordinates = []
+                self._refresh_fm_canvas()
         else:
             cl.fib_list.add_coordinate(coord)
         self._refresh_fib_canvas()
@@ -1278,6 +1549,12 @@ class CorrelationTabWidget(QWidget):
         coord = Coordinate(PointXYZ(x, y, float(self._fm_display.current_z)), pt)
         if pt == PointType.FM:
             cl.fm_list.add_coordinate(coord)
+        elif pt == PointType.SURFACE_FM:
+            cl.fm_surface_list.coordinates = [coord]
+            # Only one surface point at a time — replace any FIB surface
+            if cl.surface_list.coordinates:
+                cl.surface_list.coordinates = []
+                self._refresh_fib_canvas()
         else:
             cl.poi_list.add_coordinate(coord)
         self._refresh_fm_canvas()
@@ -1295,6 +1572,7 @@ class CorrelationTabWidget(QWidget):
         cl.fm_list.select_coordinate_silent(None)
         cl.poi_list.select_coordinate_silent(None)
         cl.surface_list.select_coordinate_silent(None)
+        cl.fm_surface_list.select_coordinate_silent(None)
 
     def _on_fm_list_selected(self, coord: Coordinate) -> None:
         cl = self._coords_tab
@@ -1303,6 +1581,7 @@ class CorrelationTabWidget(QWidget):
         cl.fib_list.select_coordinate_silent(None)
         cl.poi_list.select_coordinate_silent(None)
         cl.surface_list.select_coordinate_silent(None)
+        cl.fm_surface_list.select_coordinate_silent(None)
 
     def _on_poi_list_selected(self, coord: Coordinate) -> None:
         cl = self._coords_tab
@@ -1311,6 +1590,7 @@ class CorrelationTabWidget(QWidget):
         cl.fib_list.select_coordinate_silent(None)
         cl.fm_list.select_coordinate_silent(None)
         cl.surface_list.select_coordinate_silent(None)
+        cl.fm_surface_list.select_coordinate_silent(None)
 
     def _on_surface_list_selected(self, coord: Coordinate) -> None:
         cl = self._coords_tab
@@ -1319,6 +1599,16 @@ class CorrelationTabWidget(QWidget):
         cl.fib_list.select_coordinate_silent(None)
         cl.fm_list.select_coordinate_silent(None)
         cl.poi_list.select_coordinate_silent(None)
+        cl.fm_surface_list.select_coordinate_silent(None)
+
+    def _on_fm_surface_list_selected(self, coord: Coordinate) -> None:
+        cl = self._coords_tab
+        self._fm_display.set_selected(coord)
+        self._fib_canvas.set_selected(None)
+        cl.fib_list.select_coordinate_silent(None)
+        cl.fm_list.select_coordinate_silent(None)
+        cl.poi_list.select_coordinate_silent(None)
+        cl.surface_list.select_coordinate_silent(None)
 
     def _on_fib_list_changed(self, coord: Coordinate, _f: str, _v: float) -> None:
         self._fib_canvas.refresh_coordinate(coord)
@@ -1334,6 +1624,10 @@ class CorrelationTabWidget(QWidget):
 
     def _on_surface_list_changed(self, coord: Coordinate, _f: str, _v: float) -> None:
         self._fib_canvas.refresh_coordinate(coord)
+        self.data_changed.emit(self.data)
+
+    def _on_fm_surface_list_changed(self, coord: Coordinate, _f: str, _v: float) -> None:
+        self._fm_display.refresh_coordinate(coord)
         self.data_changed.emit(self.data)
 
     def _on_fib_list_removed(self, _coord: Coordinate) -> None:
@@ -1353,6 +1647,11 @@ class CorrelationTabWidget(QWidget):
 
     def _on_surface_list_removed(self, _coord: Coordinate) -> None:
         self._refresh_fib_canvas()
+        self._coords_tab.update_headers()
+        self.data_changed.emit(self.data)
+
+    def _on_fm_surface_list_removed(self, _coord: Coordinate) -> None:
+        self._refresh_fm_canvas()
         self._coords_tab.update_headers()
         self.data_changed.emit(self.data)
 
@@ -1450,9 +1749,11 @@ class CorrelationTabWidget(QWidget):
         except Exception as exc:
             QMessageBox.warning(self, "Load Error", f"Could not load result:\n{exc}")
             return
-        self._on_result_ready(result)
+        # Populate the lists first so the RI tab sees the loaded surface points
         if result.input_data:
             self.set_data(result.input_data)
+        self._on_result_ready(result)
+        if result.input_data:
             self._update_run_button()
 
     def _on_load(self) -> None:
@@ -1496,8 +1797,10 @@ class CorrelationTabWidget(QWidget):
                     )
                     coord.point.x, coord.point.y = float(xr), float(yr)
 
-            elif coord.point_type in (PointType.FM, PointType.POI):
-                is_fid = coord.point_type == PointType.FM
+            elif coord.point_type in (PointType.FM, PointType.POI, PointType.SURFACE_FM):
+                # The FM surface is typically picked in the reflection channel,
+                # so it shares the fiducial method/channel settings.
+                is_fid = coord.point_type in (PointType.FM, PointType.SURFACE_FM)
                 method = (
                     cl._fm_fid_method_combo if is_fid else cl._fm_poi_method_combo
                 ).currentText()
@@ -1529,7 +1832,12 @@ class CorrelationTabWidget(QWidget):
             list_w.refresh_coordinate(coord)
             self._fib_canvas.refresh_coordinate(coord)
         else:
-            list_w = cl.fm_list if coord.point_type == PointType.FM else cl.poi_list
+            if coord.point_type == PointType.FM:
+                list_w = cl.fm_list
+            elif coord.point_type == PointType.SURFACE_FM:
+                list_w = cl.fm_surface_list
+            else:
+                list_w = cl.poi_list
             list_w.refresh_coordinate(coord)
             self._fm_display.refresh_coordinate(coord)
 

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -612,6 +612,12 @@ class _RITab(QWidget):
     _POST_HEADERS = ["POI", "X (px)", "Y original (px)", "Y corrected (px)"]
     _PRE_HEADERS = ["POI", "X (px)", "Z original (px)", "Z corrected (px)"]
 
+    _WARNING_STYLES = {
+        "error":   "color: #e07b39; font-size: 11px;",
+        "success": "color: #6dbf6d; font-size: 11px;",
+        "armed":   "color: #e0c060; font-size: 11px;",
+    }
+
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self._poi: List[CorrelationPointOfInterest] = []
@@ -622,7 +628,15 @@ class _RITab(QWidget):
         self._input_pre_factor: Optional[float] = None
         self._fm_pixel_size_z: Optional[float] = None
         self._result: Optional[CorrelationResult] = None
+        # Last factor mirrored into the spinbox; mirroring only on change keeps
+        # in-progress manual edits from being reverted by unrelated refreshes.
+        self._last_mirrored_factor: Optional[float] = None
         self._setup_ui()
+
+    def _set_warning(self, text: str, level: str = "error") -> None:
+        """Set the warning label text and its matching severity color together."""
+        self._lbl_warning.setStyleSheet(self._WARNING_STYLES[level])
+        self._lbl_warning.setText(text)
 
     def _setup_ui(self) -> None:
         layout = QVBoxLayout(self)
@@ -750,35 +764,43 @@ class _RITab(QWidget):
         result_factor = result.refractive_index_correction_factor if result else None
         result_mode = result.refractive_index_correction_mode if result else None
 
-        # Factor spinbox mirrors the authoritative stored factor, if any
-        if result_factor is not None:
-            self._ri_widget.set_factor(result_factor)
-        elif mode == "pre" and self._input_pre_factor is not None:
-            self._ri_widget.set_factor(self._input_pre_factor)
+        # Factor spinbox mirrors the authoritative stored factor. In pre mode a
+        # newly armed input factor is the latest user intent and outranks the
+        # (older) result factor. Mirror only when the stored value changes so
+        # a factor the user is typing survives unrelated data_changed refreshes.
+        if mode == "pre" and self._input_pre_factor is not None:
+            stored_factor = self._input_pre_factor
+        else:
+            stored_factor = result_factor
+        if stored_factor is not None and stored_factor != self._last_mirrored_factor:
+            self._ri_widget.set_factor(stored_factor)
+        self._last_mirrored_factor = stored_factor
 
         # Pre-mode preview table (stored factor, applied or armed)
         if mode == "pre" and self._input_pre_factor is not None:
             self._populate_pre_table(self._input_pre_factor)
 
-        if result_factor is not None:
-            self._lbl_warning.setStyleSheet("color: #6dbf6d; font-size: 11px;")
-            self._lbl_warning.setText(
-                f"Correction applied ({result_mode or 'post'}, factor: {result_factor:.3f})."
+        armed = (
+            mode == "pre"
+            and self._input_pre_factor is not None
+            and self._input_pre_factor != result_factor
+        )
+        if armed:
+            self._set_warning(
+                f"Factor {self._input_pre_factor:.3f} stored — applied on the next run.",
+                level="armed",
             )
-        elif mode == "pre" and self._input_pre_factor is not None:
-            self._lbl_warning.setStyleSheet("color: #e0c060; font-size: 11px;")
-            self._lbl_warning.setText(
-                f"Factor {self._input_pre_factor:.3f} stored — applied on the next run."
+        elif result_factor is not None:
+            self._set_warning(
+                f"Correction applied ({result_mode or 'post'}, factor: {result_factor:.3f}).",
+                level="success",
             )
         elif not self._poi:
-            self._lbl_warning.setStyleSheet("color: #e07b39; font-size: 11px;")
-            self._lbl_warning.setText("No POI in result.")
+            self._set_warning("No POI in result.")
         elif mode is None:
-            self._lbl_warning.setStyleSheet("color: #e07b39; font-size: 11px;")
-            self._lbl_warning.setText("No surface coordinate — correction unavailable.")
+            self._set_warning("No surface coordinate — correction unavailable.")
         else:
-            self._lbl_warning.setStyleSheet("color: #e07b39; font-size: 11px;")
-            self._lbl_warning.setText("")
+            self._set_warning("")
 
     def _update_distance_label(self) -> None:
         mode = self.mode
@@ -821,12 +843,12 @@ class _RITab(QWidget):
 
     def _apply_pre(self) -> None:
         if self._fm_surface_coordinate is None:
-            self._lbl_warning.setText("No FM surface coordinate — cannot apply correction.")
+            self._set_warning("No FM surface coordinate — cannot apply correction.")
             return
         if not self._input_poi:
-            self._lbl_warning.setText("No POI coordinates to correct.")
+            self._set_warning("No POI coordinates to correct.")
             return
-        self._lbl_warning.setText("")
+        self._set_warning("")
         factor = self._ri_widget.get_factor()
         rerun = self._chk_rerun.isChecked()
         logging.info(
@@ -840,23 +862,27 @@ class _RITab(QWidget):
 
     def _apply_post(self) -> None:
         if not self._poi:
-            self._lbl_warning.setText("No POI available.")
+            self._set_warning("No POI available.")
             return
         if self._surface_y is None or self._surface_coordinate is None:
-            self._lbl_warning.setText(
-                "No surface coordinate — cannot apply correction."
-            )
+            self._set_warning("No surface coordinate — cannot apply correction.")
             return
         if (
             self._result is not None
             and self._result.refractive_index_correction_factor is not None
         ):
             # Guard against double-correcting (post-on-post or post-on-pre)
-            self._lbl_warning.setText(
+            self._set_warning(
                 "Correction already applied to this result — run correlation again first."
             )
             return
-        self._lbl_warning.setText("")
+        if self._result is not None and self._result.input_data is None:
+            # e.g. a result JSON saved with input_data: null
+            self._set_warning(
+                "Loaded result has no input data — cannot apply correction."
+            )
+            return
+        self._set_warning("")
         factor = self._ri_widget.get_factor()
         surface_y = self._surface_y
 
@@ -1216,7 +1242,12 @@ class CorrelationTabWidget(QWidget):
         cl.fm_surface_list.coordinates = fm_surf_coords
         cl.update_headers()
 
-        self._ri_pre_correction_factor = data.ri_pre_correction_factor
+        # A factor without an FM surface is meaningless — don't arm it
+        self._ri_pre_correction_factor = (
+            data.ri_pre_correction_factor
+            if data.fm_surface_coordinate is not None
+            else None
+        )
 
     def load_data(self, path: str) -> None:
         """Load coordinates from JSON, preserving current images."""
@@ -1402,6 +1433,12 @@ class CorrelationTabWidget(QWidget):
                 "Pre-correction factor stored — run correlation to apply."
             )
 
+    def _clear_pre_correction_factor(self) -> None:
+        """The pre-correction factor's lifecycle is tied to the FM surface point:
+        removing the surface disarms the factor so it cannot silently re-apply
+        on a later run."""
+        self._ri_pre_correction_factor = None
+
     def _on_run_error(self, msg: str) -> None:
         self._lbl_status.setText(f"Error: {msg}")
         self._update_run_button()
@@ -1521,6 +1558,7 @@ class CorrelationTabWidget(QWidget):
             cl.fm_surface_list.coordinates = [
                 c for c in cl.fm_surface_list.coordinates if c is not coord
             ]
+            self._clear_pre_correction_factor()
         else:
             cl.poi_list.coordinates = [
                 c for c in cl.poi_list.coordinates if c is not coord
@@ -1538,6 +1576,7 @@ class CorrelationTabWidget(QWidget):
             if cl.fm_surface_list.coordinates:
                 cl.fm_surface_list.coordinates = []
                 self._refresh_fm_canvas()
+            self._clear_pre_correction_factor()
         else:
             cl.fib_list.add_coordinate(coord)
         self._refresh_fib_canvas()
@@ -1651,6 +1690,7 @@ class CorrelationTabWidget(QWidget):
         self.data_changed.emit(self.data)
 
     def _on_fm_surface_list_removed(self, _coord: Coordinate) -> None:
+        self._clear_pre_correction_factor()
         self._refresh_fm_canvas()
         self._coords_tab.update_headers()
         self.data_changed.emit(self.data)
@@ -1749,12 +1789,16 @@ class CorrelationTabWidget(QWidget):
         except Exception as exc:
             QMessageBox.warning(self, "Load Error", f"Could not load result:\n{exc}")
             return
-        # Populate the lists first so the RI tab sees the loaded surface points
+        self._load_result(result)
+
+    def _load_result(self, result: CorrelationResult) -> None:
+        """Adopt a loaded correlation result (and its input data, if any)."""
+        # Populate the lists first so the RI tab sees the loaded surface points.
+        # _on_result_ready refreshes the run button and sets the final status
+        # text itself — no trailing update here, it would overwrite the status.
         if result.input_data:
             self.set_data(result.input_data)
         self._on_result_ready(result)
-        if result.input_data:
-            self._update_run_button()
 
     def _on_load(self) -> None:
         start = self._project_dir or ""

--- a/fibsem/correlation/ui/widgets/image_point_canvas.py
+++ b/fibsem/correlation/ui/widgets/image_point_canvas.py
@@ -48,16 +48,18 @@ from fibsem.correlation.structures import Coordinate, PointType
 _logger = logging.getLogger(__name__)
 
 _POINT_COLORS: Dict[PointType, str] = {
-    PointType.FIB:     "#00ff00",
-    PointType.FM:      "#00e5ff",
-    PointType.POI:     "#ff00ff",
-    PointType.SURFACE: "#ff9800",
+    PointType.FIB:        "#00ff00",
+    PointType.FM:         "#00e5ff",
+    PointType.POI:        "#ff00ff",
+    PointType.SURFACE:    "#ff9800",
+    PointType.SURFACE_FM: "#ffea00",
 }
 _POINT_MARKERS: Dict[PointType, str] = {
-    PointType.FIB:     "o",
-    PointType.FM:      "o",
-    PointType.POI:     "o",
-    PointType.SURFACE: "+",
+    PointType.FIB:        "o",
+    PointType.FM:         "o",
+    PointType.POI:        "o",
+    PointType.SURFACE:    "+",
+    PointType.SURFACE_FM: "+",
 }
 _MARKER_SIZE     = 10
 _SELECTED_SIZE   = 14
@@ -335,11 +337,16 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         label_prefix: str = "",
         size: int = 7,
         marker: str = "o",
+        alpha: float = 1.0,
+        show_labels: bool = True,
+        hollow: bool = False,
     ) -> None:
         """Append a group of non-interactive overlay markers (e.g. correlation result).
 
         Call clear_overlay() before the first add_overlay_points() when replacing
         a previous result set.  Multiple add_overlay_points() calls accumulate.
+        ``hollow`` draws an unfilled ring (edge in ``color``), so the marker stays
+        visible when another marker sits on top of it.
         """
         for i, (x, y) in enumerate(points, start=1):
             (line,) = self._ax.plot(
@@ -347,14 +354,18 @@ class ImagePointCanvas(FigureCanvasQTAgg):
                 marker=marker,
                 markersize=size,
                 color=color,
-                markeredgecolor="white",
-                markeredgewidth=0.8,
+                markerfacecolor="none" if hollow else color,
+                markeredgecolor=color if hollow else "white",
+                markeredgewidth=1.5 if hollow else 0.8,
                 linestyle="none",
+                alpha=alpha,
                 zorder=8,
                 animated=True,
             )
             self._overlay_point_artists.append(line)
 
+            if not show_labels:
+                continue
             label = f"{label_prefix}{i}" if label_prefix else str(i)
             ann = self._ax.annotate(
                 label,
@@ -363,6 +374,7 @@ class ImagePointCanvas(FigureCanvasQTAgg):
                 textcoords="offset points",
                 color=color,
                 fontsize=8,
+                alpha=alpha,
                 animated=True,
                 zorder=9,
             )

--- a/fibsem/correlation/ui/widgets/image_point_canvas.py
+++ b/fibsem/correlation/ui/widgets/image_point_canvas.py
@@ -296,8 +296,10 @@ class ImagePointCanvas(FigureCanvasQTAgg):
                 marker=line.get_marker(),
                 markersize=line.get_markersize(),
                 color=line.get_color(),
+                markerfacecolor=line.get_markerfacecolor(),
                 markeredgecolor=line.get_markeredgecolor(),
                 markeredgewidth=line.get_markeredgewidth(),
+                alpha=line.get_alpha(),
                 linestyle="none",
                 zorder=line.get_zorder(),
             )

--- a/fibsem/correlation/ui/widgets/image_point_canvas.py
+++ b/fibsem/correlation/ui/widgets/image_point_canvas.py
@@ -40,6 +40,7 @@ from typing import Dict, List, Optional, Tuple
 import numpy as np
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
+from matplotlib.lines import Line2D
 from PyQt5.QtCore import Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import QCursor
 from PyQt5.QtWidgets import QAction, QMenu, QSizePolicy, QWidget
@@ -88,6 +89,66 @@ def _generate_names(coordinates: List[Coordinate]) -> List[str]:
     return names
 
 
+def _marker_style(point_type: PointType, is_selected: bool) -> dict:
+    """Marker style for a coordinate point, shared by rebuild and restyle paths.
+
+    Filled markers (circles) show selection as a white rim. Unfilled markers
+    ("+" crosshairs) are drawn entirely by their edge — a white edge would
+    replace the type colour and "none" would erase the marker — so they keep
+    their own colour and show selection via size and stroke weight instead.
+    """
+    color = _POINT_COLORS.get(point_type, "white")
+    marker = _POINT_MARKERS.get(point_type, "o")
+    unfilled = marker not in Line2D.filled_markers
+    if unfilled:
+        edge_color = color
+        edge_width = 3.0 if is_selected else 2.0
+    else:
+        edge_color = "white" if is_selected else "none"
+        edge_width = 2.0
+    return dict(
+        marker=marker,
+        markersize=_SELECTED_SIZE if is_selected else _MARKER_SIZE,
+        color=color,
+        markeredgecolor=edge_color,
+        markeredgewidth=edge_width,
+    )
+
+
+# Shared by the live canvas legend and the render_to_axes export
+_LEGEND_KWARGS = dict(
+    loc="upper right",
+    fontsize=8,
+    framealpha=0.75,
+    facecolor="#1e2124",
+    edgecolor="#3a3d42",
+    labelcolor="#e0e0e0",
+    handletextpad=0.4,
+    borderpad=0.5,
+    labelspacing=0.35,
+)
+
+
+def _legend_handle(
+    color: str, marker: str = "o", hollow: bool = False, alpha: float = 1.0
+) -> Line2D:
+    """Proxy artist for a legend entry, matching the on-canvas marker style."""
+    # For unfilled markers (e.g. "+") the edge IS the marker — a white edge
+    # would swallow the colour, so those keep their own colour as the edge.
+    unfilled = marker not in Line2D.filled_markers
+    return Line2D(
+        [], [],
+        marker=marker,
+        markersize=7,
+        color=color,
+        markerfacecolor="none" if hollow else color,
+        markeredgecolor=color if (hollow or unfilled) else "white",
+        markeredgewidth=1.5 if (hollow or unfilled) else 0.8,
+        alpha=alpha,
+        linestyle="none",
+    )
+
+
 class ImagePointCanvas(FigureCanvasQTAgg):
     """Matplotlib canvas: image + draggable Coordinate markers."""
 
@@ -133,6 +194,14 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         self._pixel_size: Optional[float] = None   # metres
         self._show_scalebar: bool = False
         self._scalebar_artist = None
+
+        # Legend (point types present + labeled overlay groups)
+        self._legend_visible: bool = True
+        self._overlay_legend: List[Tuple[str, dict]] = []  # (label, handle style)
+
+        # Dashed datum line across the canvas at the FIB surface y
+        self._surface_line = None
+        self._surface_line_coord: Optional[Coordinate] = None
 
         self._redraw_timer = QTimer(self)
         self._redraw_timer.setSingleShot(True)
@@ -260,6 +329,42 @@ class ImagePointCanvas(FigureCanvasQTAgg):
             except Exception:
                 pass
 
+    def set_legend_visible(self, visible: bool) -> None:
+        """Show or hide the point-type legend."""
+        self._legend_visible = visible
+        self._update_legend()
+        self._background = None
+        self.draw()
+
+    def _build_legend_entries(self) -> Tuple[List[Line2D], List[str]]:
+        """Proxy handles + labels for the point types on screen and labeled overlays."""
+        handles: List[Line2D] = []
+        labels: List[str] = []
+        for pt in PointType:
+            if any(c.point_type is pt for c in self._coordinates):
+                handles.append(
+                    _legend_handle(
+                        _POINT_COLORS.get(pt, "white"), _POINT_MARKERS.get(pt, "o")
+                    )
+                )
+                labels.append(pt.value)
+        for label, style in self._overlay_legend:
+            handles.append(_legend_handle(**style))
+            labels.append(label)
+        return handles, labels
+
+    def _update_legend(self) -> None:
+        """Rebuild the legend from current contents (removed when empty/hidden)."""
+        legend = self._ax.get_legend()
+        if legend is not None:
+            legend.remove()
+        if not self._legend_visible:
+            return
+        handles, labels = self._build_legend_entries()
+        if not handles:
+            return
+        self._ax.legend(handles, labels, **_LEGEND_KWARGS)
+
     def reset_view(self) -> None:
         """Fit the view to the full image extent."""
         images = self._ax.get_images()
@@ -290,6 +395,16 @@ class ImagePointCanvas(FigureCanvasQTAgg):
             ax.set_xlim(self._ax.get_xlim())
             ax.set_ylim(self._ax.get_ylim())
 
+        if self._surface_line is not None and self._surface_line_coord is not None:
+            ax.axhline(
+                self._surface_line_coord.point.y,
+                color=_POINT_COLORS[PointType.SURFACE],
+                linestyle="--",
+                linewidth=1.0,
+                alpha=0.6,
+                zorder=4,
+            )
+
         for line in self._point_artists + self._overlay_point_artists:
             ax.plot(
                 line.get_xdata(), line.get_ydata(),
@@ -303,6 +418,11 @@ class ImagePointCanvas(FigureCanvasQTAgg):
                 linestyle="none",
                 zorder=line.get_zorder(),
             )
+
+        if self._legend_visible:
+            handles, labels = self._build_legend_entries()
+            if handles:
+                ax.legend(handles, labels, **_LEGEND_KWARGS)
 
         for ann in self._label_artists + self._overlay_label_artists:
             ax.annotate(
@@ -342,14 +462,21 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         alpha: float = 1.0,
         show_labels: bool = True,
         hollow: bool = False,
+        legend_label: Optional[str] = None,
     ) -> None:
         """Append a group of non-interactive overlay markers (e.g. correlation result).
 
         Call clear_overlay() before the first add_overlay_points() when replacing
         a previous result set.  Multiple add_overlay_points() calls accumulate.
         ``hollow`` draws an unfilled ring (edge in ``color``), so the marker stays
-        visible when another marker sits on top of it.
+        visible when another marker sits on top of it. ``legend_label`` adds a
+        matching entry to the canvas legend for this group.
         """
+        if legend_label:
+            self._overlay_legend.append(
+                (legend_label, dict(color=color, marker=marker, hollow=hollow, alpha=alpha))
+            )
+            self._update_legend()
         for i, (x, y) in enumerate(points, start=1):
             (line,) = self._ax.plot(
                 x, y,
@@ -391,6 +518,8 @@ class ImagePointCanvas(FigureCanvasQTAgg):
             a.remove()
         self._overlay_point_artists.clear()
         self._overlay_label_artists.clear()
+        self._overlay_legend.clear()
+        self._update_legend()
         self._background = None
         self.draw_idle()
 
@@ -398,10 +527,18 @@ class ImagePointCanvas(FigureCanvasQTAgg):
     # Blitting
     # ------------------------------------------------------------------
 
+    def _animated_artists(self) -> list:
+        """All animated artists in draw order (surface line at the bottom)."""
+        artists: list = []
+        if self._surface_line is not None:
+            artists.append(self._surface_line)
+        artists += (self._point_artists + self._label_artists
+                    + self._overlay_point_artists + self._overlay_label_artists)
+        return artists
+
     def _on_draw_event(self, _) -> None:
         self._background = self.copy_from_bbox(self._ax.bbox)
-        for a in (self._point_artists + self._label_artists
-                  + self._overlay_point_artists + self._overlay_label_artists):
+        for a in self._animated_artists():
             self._ax.draw_artist(a)
         self.update()
 
@@ -410,8 +547,7 @@ class ImagePointCanvas(FigureCanvasQTAgg):
             self.draw_idle()
             return
         self.restore_region(self._background)
-        for a in (self._point_artists + self._label_artists
-                  + self._overlay_point_artists + self._overlay_label_artists):
+        for a in self._animated_artists():
             self._ax.draw_artist(a)
         self.blit(self._ax.bbox)
 
@@ -437,6 +573,32 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         self._point_artists.clear()
         self._label_artists.clear()
 
+        if self._surface_line is not None:
+            try:
+                self._surface_line.remove()
+            except ValueError:
+                pass
+            self._surface_line = None
+        self._surface_line_coord = None
+
+        # The FIB surface is a datum row: anchor it with a dashed line across
+        # the full canvas width at the surface y (FM surfaces are z-planes —
+        # no in-plane line applies)
+        surf = next(
+            (c for c in self._coordinates if c.point_type is PointType.SURFACE), None
+        )
+        if surf is not None:
+            self._surface_line = self._ax.axhline(
+                surf.point.y,
+                color=_POINT_COLORS[PointType.SURFACE],
+                linestyle="--",
+                linewidth=1.0,
+                alpha=0.6,
+                zorder=4,
+                animated=True,
+            )
+            self._surface_line_coord = surf
+
         names = _generate_names(self._coordinates)
         for coord, name in zip(self._coordinates, names):
             color = _POINT_COLORS.get(coord.point_type, "white")
@@ -444,14 +606,10 @@ class ImagePointCanvas(FigureCanvasQTAgg):
 
             (line,) = self._ax.plot(
                 coord.point.x, coord.point.y,
-                marker=_POINT_MARKERS.get(coord.point_type, "o"),
-                markersize=_SELECTED_SIZE if is_sel else _MARKER_SIZE,
-                color=color,
-                markeredgecolor="white" if is_sel else "none",
-                markeredgewidth=2.0,
                 linestyle="none",
                 zorder=10 if is_sel else 5,
                 animated=True,
+                **_marker_style(coord.point_type, is_sel),
             )
             self._point_artists.append(line)
 
@@ -468,6 +626,7 @@ class ImagePointCanvas(FigureCanvasQTAgg):
             )
             self._label_artists.append(ann)
 
+        self._update_legend()
         self.draw_idle()
 
     def _apply_styles(self) -> None:
@@ -475,17 +634,26 @@ class ImagePointCanvas(FigureCanvasQTAgg):
             self._coordinates, self._point_artists, self._label_artists
         ):
             is_sel = coord is self._selected
-            marker.set_markersize(_SELECTED_SIZE if is_sel else _MARKER_SIZE)
-            marker.set_markeredgecolor("white" if is_sel else "none")
+            style = _marker_style(coord.point_type, is_sel)
+            marker.set_markersize(style["markersize"])
+            marker.set_markeredgecolor(style["markeredgecolor"])
+            marker.set_markeredgewidth(style["markeredgewidth"])
             marker.set_zorder(10 if is_sel else 5)
             label.set_fontweight("bold" if is_sel else "normal")
             label.set_zorder(11 if is_sel else 6)
+
+        if self._surface_line is not None:
+            sel = self._surface_line_coord is self._selected
+            self._surface_line.set_linewidth(1.5 if sel else 1.0)
+            self._surface_line.set_alpha(0.9 if sel else 0.6)
 
     def _sync_artist_position(self, idx: int) -> None:
         coord = self._coordinates[idx]
         self._point_artists[idx].set_xdata([coord.point.x])
         self._point_artists[idx].set_ydata([coord.point.y])
         self._label_artists[idx].xy = (coord.point.x, coord.point.y)
+        if coord is self._surface_line_coord and self._surface_line is not None:
+            self._surface_line.set_ydata([coord.point.y, coord.point.y])
 
     # ------------------------------------------------------------------
     # Cursor

--- a/fibsem/correlation/ui/widgets/refractive_index_widget.py
+++ b/fibsem/correlation/ui/widgets/refractive_index_widget.py
@@ -39,6 +39,12 @@ _DEFAULTS = ZetaParams(
 
 _DEFAULT_FACTOR = 1.47
 
+_TILT_TOOLTIP = "The angle between the FIB column and the sample surface"
+_TILT_LOCKED_TOOLTIP = (
+    "Locked to 0°: the FM-surface correction acts along the optical axis, "
+    "which is normal to the sample surface."
+)
+
 
 class RefractiveIndexWidget(QWidget):
     """Form widget that computes the depth scaling factor zeta from optical parameters.
@@ -57,6 +63,8 @@ class RefractiveIndexWidget(QWidget):
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self._zeta: Optional[float] = None
+        self._tilt_locked = False
+        self._tilt_before_lock: Optional[float] = None
         try:
             _ensure_lut()
         except Exception as e:
@@ -83,7 +91,7 @@ class RefractiveIndexWidget(QWidget):
 
         self._spin_tilt = ValueSpinBox(
             suffix="°", minimum=0.0, maximum=30.0, step=1.0, decimals=0,
-            tooltip="The angle between the FIB column and the sample surface",
+            tooltip=_TILT_TOOLTIP,
         )
         self._spin_depth = ValueSpinBox(
             suffix="µm", minimum=0.5, maximum=14.5, step=0.5, decimals=1,
@@ -123,6 +131,7 @@ class RefractiveIndexWidget(QWidget):
         self._btn_reset_factor.clicked.connect(lambda: self._spin_factor.setValue(_DEFAULT_FACTOR))
 
         lut_available = _LUT_PATH.exists()
+        self._lut_available = lut_available
         if not lut_available:
             self._lut_warning = QLabel("LUT not found — calculator disabled. Edit correction factor manually.")
             self._lut_warning.setStyleSheet("color: #f0a500; font-style: italic; padding: 4px 8px;")
@@ -172,6 +181,27 @@ class RefractiveIndexWidget(QWidget):
         self._spin_factor.blockSignals(True)
         self._spin_factor.setValue(v)
         self._spin_factor.blockSignals(False)
+
+    def set_tilt_locked(self, locked: bool) -> None:
+        """Lock the tilt spinbox to 0° (FM-space correction acts along the optical axis).
+
+        The previous tilt value is restored on unlock. Idempotent.
+        """
+        if locked == self._tilt_locked:
+            return
+        self._tilt_locked = locked
+        if locked:
+            self._tilt_before_lock = self._spin_tilt.value()
+            self._spin_tilt.setValue(0.0)  # triggers recompute if it changes
+            self._spin_tilt.setEnabled(False)
+            self._spin_tilt.setToolTip(_TILT_LOCKED_TOOLTIP)
+        else:
+            self._spin_tilt.setEnabled(self._lut_available)
+            self._spin_tilt.setToolTip(
+                _TILT_TOOLTIP if self._lut_available else _LUT_MISSING_MSG
+            )
+            if self._tilt_before_lock is not None:
+                self._spin_tilt.setValue(self._tilt_before_lock)
 
     def set_params(self, params: ZetaParams) -> None:
         """Populate all spinboxes from *params* without triggering recompute."""

--- a/fibsem/correlation/ui/widgets/refractive_index_widget.py
+++ b/fibsem/correlation/ui/widgets/refractive_index_widget.py
@@ -186,13 +186,19 @@ class RefractiveIndexWidget(QWidget):
         """Lock the tilt spinbox to 0° (FM-space correction acts along the optical axis).
 
         The previous tilt value is restored on unlock. Idempotent.
+
+        The programmatic tilt change recomputes zeta quietly (the correction
+        factor spinbox is NOT overwritten): a mode switch must not clobber a
+        manually entered factor. User edits to the optical parameters still
+        update the factor as usual.
         """
         if locked == self._tilt_locked:
             return
         self._tilt_locked = locked
+        self._spin_tilt.blockSignals(True)
         if locked:
             self._tilt_before_lock = self._spin_tilt.value()
-            self._spin_tilt.setValue(0.0)  # triggers recompute if it changes
+            self._spin_tilt.setValue(0.0)
             self._spin_tilt.setEnabled(False)
             self._spin_tilt.setToolTip(_TILT_LOCKED_TOOLTIP)
         else:
@@ -202,6 +208,8 @@ class RefractiveIndexWidget(QWidget):
             )
             if self._tilt_before_lock is not None:
                 self._spin_tilt.setValue(self._tilt_before_lock)
+        self._spin_tilt.blockSignals(False)
+        self._recompute(update_factor=False)
 
     def set_params(self, params: ZetaParams) -> None:
         """Populate all spinboxes from *params* without triggering recompute."""
@@ -243,7 +251,8 @@ class RefractiveIndexWidget(QWidget):
     # Internal
     # ------------------------------------------------------------------
 
-    def _recompute(self) -> None:
+    def _recompute(self, _value: object = None, *, update_factor: bool = True) -> None:
+        # _value swallows the float from QDoubleSpinBox.valueChanged connections.
         if not _LUT_PATH.exists():
             return
         params = self.get_params()
@@ -256,6 +265,7 @@ class RefractiveIndexWidget(QWidget):
                 params.wavelength_um,
             )
             self._zeta = zeta
-            self.zeta_computed.emit(zeta)
+            if update_factor:
+                self.zeta_computed.emit(zeta)
         except Exception:
             self._zeta = None

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -1,0 +1,276 @@
+"""Headless tests for CorrelationTabWidget FM-surface / RI-correction behaviour.
+
+Uses PyQt5 directly with the offscreen platform (no pytest-qt dependency),
+matching tests/fm/test_autofocus_widget.py.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.correlation.structures import (
+    Coordinate,
+    CorrelationInputData,
+    CorrelationPointOfInterest,
+    CorrelationResult,
+    PointType,
+    PointXYZ,
+)
+from fibsem.structures import Point
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture(autouse=True)
+def _no_lut_download(monkeypatch):
+    """Never hit the network for the zeta LUT during widget construction."""
+    import fibsem.correlation.ui.widgets.refractive_index_widget as riw
+
+    monkeypatch.setattr(riw, "_ensure_lut", lambda: None)
+
+
+def _coord(x=0.0, y=0.0, z=0.0, pt=PointType.FIB) -> Coordinate:
+    return Coordinate(point=PointXYZ(x=x, y=y, z=z), point_type=pt)
+
+
+def _widget(qapp):
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        CorrelationTabWidget,
+    )
+
+    return CorrelationTabWidget()
+
+
+# ---------------------------------------------------------------------------
+# Surface exclusivity
+# ---------------------------------------------------------------------------
+
+
+def test_fm_surface_add_replaces_fib_surface(qapp):
+    w = _widget(qapp)
+    cl = w._coords_tab
+
+    w._on_fib_add_requested(1.0, 2.0, PointType.SURFACE)
+    assert len(cl.surface_list.coordinates) == 1
+
+    w._on_fm_add_requested(3.0, 4.0, PointType.SURFACE_FM)
+    assert cl.surface_list.coordinates == []
+    assert len(cl.fm_surface_list.coordinates) == 1
+
+    w._on_fib_add_requested(5.0, 6.0, PointType.SURFACE)
+    assert cl.fm_surface_list.coordinates == []
+    assert len(cl.surface_list.coordinates) == 1
+
+
+def test_fm_surface_add_is_max_one(qapp):
+    w = _widget(qapp)
+    cl = w._coords_tab
+    w._on_fm_add_requested(1.0, 1.0, PointType.SURFACE_FM)
+    w._on_fm_add_requested(2.0, 2.0, PointType.SURFACE_FM)
+    assert len(cl.fm_surface_list.coordinates) == 1
+    assert cl.fm_surface_list.coordinates[0].point.x == pytest.approx(2.0)
+
+
+def test_set_data_prefers_fm_surface_when_both_present(qapp):
+    w = _widget(qapp)
+    cl = w._coords_tab
+    data = CorrelationInputData(
+        surface_coordinate=_coord(y=100.0, pt=PointType.SURFACE),
+        fm_surface_coordinate=_coord(z=10.0, pt=PointType.SURFACE_FM),
+    )
+    w.set_data(data)
+    assert cl.surface_list.coordinates == []
+    assert len(cl.fm_surface_list.coordinates) == 1
+
+
+# ---------------------------------------------------------------------------
+# data property / set_data round trip
+# ---------------------------------------------------------------------------
+
+
+def test_data_includes_fm_surface_and_factor(qapp):
+    w = _widget(qapp)
+    w._on_fm_add_requested(3.0, 4.0, PointType.SURFACE_FM)
+    w._ri_pre_correction_factor = 1.33
+    d = w.data
+    assert d.fm_surface_coordinate is not None
+    assert d.fm_surface_coordinate.point_type is PointType.SURFACE_FM
+    assert d.ri_pre_correction_factor == pytest.approx(1.33)
+
+
+def test_set_data_restores_factor(qapp):
+    w = _widget(qapp)
+    data = CorrelationInputData(
+        fm_surface_coordinate=_coord(z=10.0, pt=PointType.SURFACE_FM),
+        ri_pre_correction_factor=1.47,
+    )
+    w.set_data(data)
+    assert w._ri_pre_correction_factor == pytest.approx(1.47)
+    assert w.data.ri_pre_correction_factor == pytest.approx(1.47)
+
+
+# ---------------------------------------------------------------------------
+# RI tab mode
+# ---------------------------------------------------------------------------
+
+
+def test_ri_tab_mode_follows_surface_type(qapp):
+    w = _widget(qapp)
+    tab = w._ri_tab
+    assert tab.mode is None
+
+    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+    assert tab.mode == "post"
+    assert not tab._chk_rerun.isVisible()
+
+    w._on_fm_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    assert tab.mode == "pre"
+
+
+def test_tilt_locked_to_zero_in_pre_mode(qapp):
+    w = _widget(qapp)
+    spin_tilt = w._ri_tab._ri_widget._spin_tilt
+    default_tilt = spin_tilt.value()
+    assert default_tilt == pytest.approx(15.0)
+
+    w._on_fm_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    assert spin_tilt.value() == pytest.approx(0.0)
+    assert not spin_tilt.isEnabled()
+
+    # removing the FM surface (via replacing with a FIB surface) unlocks tilt
+    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+    assert spin_tilt.value() == pytest.approx(default_tilt)
+
+
+# ---------------------------------------------------------------------------
+# Pre-mode apply
+# ---------------------------------------------------------------------------
+
+
+def _setup_pre_mode(w):
+    w._on_fm_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    w._coords_tab.fm_surface_list.coordinates[0].point.z = 10.0
+    w._on_fm_add_requested(5.0, 6.0, PointType.POI)
+    w._coords_tab.poi_list.coordinates[0].point.z = 30.0
+    w.data_changed.emit(w.data)  # refresh RI tab with the edited z values
+
+
+def test_apply_pre_stores_factor_and_reruns(qapp):
+    w = _widget(qapp)
+    _setup_pre_mode(w)
+
+    runs = []
+    w._run = lambda: runs.append(True)
+
+    w._ri_tab._ri_widget.set_factor(1.5)
+    w._ri_tab._chk_rerun.setChecked(True)
+    w._ri_tab._apply()
+
+    assert w._ri_pre_correction_factor == pytest.approx(1.5)
+    assert w.data.ri_pre_correction_factor == pytest.approx(1.5)
+    assert runs == [True]
+
+
+def test_apply_pre_without_rerun_only_stores(qapp):
+    w = _widget(qapp)
+    _setup_pre_mode(w)
+
+    runs = []
+    w._run = lambda: runs.append(True)
+
+    w._ri_tab._ri_widget.set_factor(1.4)
+    w._ri_tab._chk_rerun.setChecked(False)
+    w._ri_tab._apply()
+
+    assert w._ri_pre_correction_factor == pytest.approx(1.4)
+    assert runs == []
+    # preview table shows the armed correction for the POI
+    assert w._ri_tab._table.rowCount() == 1
+    # 10 + (30 - 10) * 1.4 = 38
+    assert w._ri_tab._table.item(0, 3).text() == "38.00"
+
+
+# ---------------------------------------------------------------------------
+# Post-mode double-apply guard
+# ---------------------------------------------------------------------------
+
+
+def test_status_line_shows_pre_correction_after_run(qapp):
+    """The Done message must survive _update_run_button (it used to be
+    overwritten by 'Ready.' immediately)."""
+    w = _widget(qapp)
+    result = CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+        refractive_index_correction_factor=1.5,
+        refractive_index_correction_mode="pre",
+    )
+    w._on_result_ready(result)
+    assert w._lbl_status.text() == "Done — RI pre-correction ×1.500 applied."
+
+    with_ghost = CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=60.0))],
+        poi_uncorrected=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+        refractive_index_correction_factor=1.5,
+        refractive_index_correction_mode="pre",
+    )
+    w._on_result_ready(with_ghost)
+    assert (
+        w._lbl_status.text()
+        == "Done — RI pre-correction ×1.500 applied, POI 1 shifted 40.0 px."
+    )
+
+    plain = CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+    )
+    w._on_result_ready(plain)
+    assert w._lbl_status.text() == "Done."
+
+
+def test_apply_post_creates_ghost_and_status(qapp):
+    w = _widget(qapp)
+    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+
+    result = CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=100.0, y=300.0))],
+        input_data=w.data,
+    )
+    w._ri_tab.set_result(result, input_data=w.data)
+    w._ri_tab._ri_widget.set_factor(1.5)
+    w._ri_tab._apply()
+
+    # 200 + (300 - 200) * 1.5 = 350
+    assert result.poi[0].image_px.y == pytest.approx(350.0)
+    assert len(result.poi_uncorrected) == 1
+    assert result.poi_uncorrected[0].image_px.y == pytest.approx(300.0)
+    assert (
+        w._lbl_status.text()
+        == "RI post-correction ×1.500 applied, POI 1 shifted 50.0 px."
+    )
+
+
+def test_apply_post_blocked_when_already_corrected(qapp):
+    w = _widget(qapp)
+    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+
+    result = CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=100.0, y=300.0))],
+        input_data=w.data,
+        refractive_index_correction_factor=1.4,
+        refractive_index_correction_mode="post",
+    )
+    w._ri_tab.set_result(result, input_data=w.data)
+
+    w._ri_tab._apply()
+    # guard: no double correction applied
+    assert result.poi[0].image_px.y == pytest.approx(300.0)
+    assert result.refractive_index_correction_factor == pytest.approx(1.4)
+    assert "already applied" in w._ri_tab._lbl_warning.text()

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -375,6 +375,141 @@ def test_load_result_keeps_status_message(qapp):
     assert w._lbl_status.text() == "Done — RI pre-correction ×1.500 applied."
 
 
+def _legend_labels(ax):
+    legend = ax.get_legend()
+    return [t.get_text() for t in legend.get_texts()] if legend else []
+
+
+def test_canvas_legend_lists_present_point_types(qapp):
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.set_coordinates(
+        [
+            _coord(pt=PointType.FIB),
+            _coord(pt=PointType.FIB),
+            _coord(pt=PointType.SURFACE),
+        ]
+    )
+    assert _legend_labels(canvas._ax) == ["FIB", "SURFACE"]
+
+    # legend follows content
+    canvas.set_coordinates([_coord(pt=PointType.FM), _coord(pt=PointType.SURFACE_FM)])
+    assert _legend_labels(canvas._ax) == ["FM", "FM-SURFACE"]
+
+    # empty canvas → no legend
+    canvas.set_coordinates([])
+    assert canvas._ax.get_legend() is None
+
+
+def test_canvas_legend_overlay_groups_and_toggle(qapp):
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.set_coordinates([_coord(pt=PointType.FIB)])
+    canvas.add_overlay_points(
+        [(1.0, 2.0)], color="#ff00ff", hollow=True, legend_label="POI uncorrected"
+    )
+    assert _legend_labels(canvas._ax) == ["FIB", "POI uncorrected"]
+
+    canvas.clear_overlay()
+    assert _legend_labels(canvas._ax) == ["FIB"]
+
+    canvas.set_legend_visible(False)
+    assert canvas._ax.get_legend() is None
+    canvas.set_legend_visible(True)
+    assert _legend_labels(canvas._ax) == ["FIB"]
+
+
+def test_surface_crosshair_keeps_color(qapp):
+    """Unfilled '+' markers are drawn by their edge — selection must not turn
+    them white, and deselection must not erase them."""
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    fib = _coord(x=1.0, y=1.0, pt=PointType.FIB)
+    surface = _coord(x=5.0, y=5.0, pt=PointType.SURFACE)
+    canvas.set_coordinates([fib, surface])
+    fib_artist, surf_artist = canvas._point_artists
+
+    # unselected: crosshair keeps the type colour (was "none" → near-invisible)
+    assert surf_artist.get_markeredgecolor() == "#ff9800"
+
+    # selected: still the type colour, shown bolder (was white → colour lost)
+    canvas.set_selected(surface)
+    assert surf_artist.get_markeredgecolor() == "#ff9800"
+    assert surf_artist.get_markeredgewidth() == pytest.approx(3.0)
+
+    # filled circles keep the white-rim selection style
+    canvas.set_selected(fib)
+    assert fib_artist.get_markeredgecolor() == "white"
+    assert surf_artist.get_markeredgecolor() == "#ff9800"
+    assert surf_artist.get_markeredgewidth() == pytest.approx(2.0)
+
+
+def test_fib_surface_line_follows_surface_point(qapp):
+    """A dashed datum line spans the canvas at the FIB surface y."""
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.set_coordinates([_coord(x=1.0, y=1.0, pt=PointType.FIB)])
+    assert canvas._surface_line is None
+
+    surf = _coord(x=5.0, y=40.0, pt=PointType.SURFACE)
+    canvas.set_coordinates([surf])
+    assert canvas._surface_line is not None
+    assert canvas._surface_line.get_ydata()[0] == pytest.approx(40.0)
+
+    # follows coordinate edits
+    surf.point.y = 55.0
+    canvas.refresh_coordinate(surf)
+    assert canvas._surface_line.get_ydata()[0] == pytest.approx(55.0)
+
+    # removed with the point
+    canvas.set_coordinates([])
+    assert canvas._surface_line is None
+
+
+def test_fm_surface_point_gets_no_line(qapp):
+    """FM surfaces are z-planes — no in-plane datum line."""
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.set_coordinates([_coord(z=10.0, pt=PointType.SURFACE_FM)])
+    assert canvas._surface_line is None
+
+
+def test_surface_line_exported_by_render_to_axes(qapp):
+    from matplotlib.figure import Figure
+
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.set_coordinates([_coord(x=5.0, y=40.0, pt=PointType.SURFACE)])
+    fig = Figure()
+    ax = fig.add_subplot(111)
+    canvas.render_to_axes(ax)
+    dashed = [l for l in ax.get_lines() if l.get_linestyle() == "--"]
+    assert len(dashed) == 1
+    assert dashed[0].get_ydata()[0] == pytest.approx(40.0)
+
+
+def test_render_to_axes_replicates_legend(qapp):
+    from matplotlib.figure import Figure
+
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.set_coordinates([_coord(pt=PointType.FIB)])
+    canvas.add_overlay_points(
+        [(1.0, 2.0)], color="#ff00ff", legend_label="POI (P)"
+    )
+    fig = Figure()
+    ax = fig.add_subplot(111)
+    canvas.render_to_axes(ax)
+    assert _legend_labels(ax) == ["FIB", "POI (P)"]
+
+
 def test_ghost_export_preserves_hollow_style(qapp):
     from matplotlib.figure import Figure
 

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -274,3 +274,125 @@ def test_apply_post_blocked_when_already_corrected(qapp):
     assert result.poi[0].image_px.y == pytest.approx(300.0)
     assert result.refractive_index_correction_factor == pytest.approx(1.4)
     assert "already applied" in w._ri_tab._lbl_warning.text()
+    # guard message renders in the error style, not the leftover green
+    assert "#e07b39" in w._ri_tab._lbl_warning.styleSheet()
+
+
+def test_apply_post_without_input_data_shows_warning(qapp):
+    """A result JSON with input_data: null must warn, not crash."""
+    w = _widget(qapp)
+    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+
+    result = CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=100.0, y=300.0))],
+        input_data=None,
+    )
+    w._ri_tab.set_result(result, input_data=w.data)
+    w._ri_tab._apply()  # must not raise
+    assert result.poi[0].image_px.y == pytest.approx(300.0)
+    assert "no input data" in w._ri_tab._lbl_warning.text()
+
+
+def test_factor_cleared_when_fm_surface_removed(qapp):
+    """The pre-correction factor's lifecycle is tied to the FM surface."""
+    w = _widget(qapp)
+    _setup_pre_mode(w)
+    w._ri_pre_correction_factor = 1.5
+
+    # canvas removal
+    coord = w._coords_tab.fm_surface_list.coordinates[0]
+    w._on_fm_canvas_removed(coord)
+    assert w._ri_pre_correction_factor is None
+    assert w.data.ri_pre_correction_factor is None
+
+    # replacement by a FIB surface
+    w._on_fm_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    w._ri_pre_correction_factor = 1.5
+    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+    assert w._ri_pre_correction_factor is None
+
+    # list-row removal
+    w._on_fm_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    w._ri_pre_correction_factor = 1.5
+    coord = w._coords_tab.fm_surface_list.coordinates[0]
+    w._coords_tab.fm_surface_list.coordinates = []
+    w._on_fm_surface_list_removed(coord)
+    assert w._ri_pre_correction_factor is None
+
+
+def test_set_data_does_not_arm_factor_without_fm_surface(qapp):
+    w = _widget(qapp)
+    data = CorrelationInputData(ri_pre_correction_factor=1.5)
+    w.set_data(data)
+    assert w._ri_pre_correction_factor is None
+
+
+def test_typed_factor_survives_refresh_and_armed_priority(qapp):
+    w = _widget(qapp)
+    _setup_pre_mode(w)
+    tab = w._ri_tab
+
+    # armed input factor (1.6) outranks an older result factor (1.5)
+    w._ri_pre_correction_factor = 1.6
+    result = CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=1.0, y=2.0))],
+        refractive_index_correction_factor=1.5,
+        refractive_index_correction_mode="pre",
+    )
+    tab.set_result(result, input_data=w.data)
+    assert tab._ri_widget.get_factor() == pytest.approx(1.6)
+    assert "stored — applied on the next run" in tab._lbl_warning.text()
+
+    # a factor being typed survives an unrelated refresh (same stored value)
+    tab._ri_widget._spin_factor.setValue(1.8)
+    tab.set_result(result, input_data=w.data)
+    assert tab._ri_widget.get_factor() == pytest.approx(1.8)
+
+
+def test_tilt_lock_preserves_manual_factor(qapp):
+    from fibsem.correlation.ui.widgets.refractive_index_widget import (
+        RefractiveIndexWidget,
+    )
+
+    rw = RefractiveIndexWidget()
+    rw._spin_factor.setValue(1.6)
+    rw.set_tilt_locked(True)
+    assert rw._spin_tilt.value() == pytest.approx(0.0)
+    assert rw.get_factor() == pytest.approx(1.6)
+    rw.set_tilt_locked(False)
+    assert rw.get_factor() == pytest.approx(1.6)
+
+
+def test_load_result_keeps_status_message(qapp):
+    w = _widget(qapp)
+    result = CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+        input_data=CorrelationInputData(),
+        refractive_index_correction_factor=1.5,
+        refractive_index_correction_mode="pre",
+    )
+    w._load_result(result)
+    assert w._lbl_status.text() == "Done — RI pre-correction ×1.500 applied."
+
+
+def test_ghost_export_preserves_hollow_style(qapp):
+    from matplotlib.figure import Figure
+
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.add_overlay_points(
+        [(10.0, 20.0)],
+        color="#ff00ff",
+        size=13,
+        alpha=0.7,
+        show_labels=False,
+        hollow=True,
+    )
+    fig = Figure()
+    ax = fig.add_subplot(111)
+    canvas.render_to_axes(ax)
+    lines = ax.get_lines()
+    assert len(lines) == 1
+    assert lines[0].get_markerfacecolor() == "none"
+    assert lines[0].get_alpha() == pytest.approx(0.7)

--- a/tests/correlation/test_pre_correction.py
+++ b/tests/correlation/test_pre_correction.py
@@ -1,0 +1,305 @@
+"""Tests for the pre-correlation refractive-index correction (FM surface mode).
+
+Covers:
+- apply_z_surface_correction (pure math)
+- run_correlation_from_data applying the correction transiently
+- CorrelationInputData serialization of the new fields (incl. legacy files)
+"""
+import math
+
+import numpy as np
+import pytest
+
+import fibsem.correlation.correlation_v2 as correlation_v2
+from fibsem.correlation.correlation_v2 import run_correlation_from_data
+from fibsem.correlation.structures import (
+    Coordinate,
+    CorrelationInputData,
+    CorrelationResult,
+    PointType,
+    PointXYZ,
+    apply_z_surface_correction,
+)
+
+
+def _coord(x=0.0, y=0.0, z=0.0, pt=PointType.FIB) -> Coordinate:
+    return Coordinate(point=PointXYZ(x=x, y=y, z=z), point_type=pt)
+
+
+# ---------------------------------------------------------------------------
+# apply_z_surface_correction
+# ---------------------------------------------------------------------------
+
+
+class TestApplyZSurfaceCorrection:
+
+    def test_basic_scaling(self):
+        poi = np.array([[10.0, 20.0, 30.0]], dtype=np.float32)
+        out = apply_z_surface_correction(poi, surface_z=10.0, correction_factor=1.5)
+        # 10 + (30 - 10) * 1.5 = 40
+        assert out[0, 2] == pytest.approx(40.0)
+        # x, y untouched
+        assert out[0, 0] == pytest.approx(10.0)
+        assert out[0, 1] == pytest.approx(20.0)
+
+    def test_signed_poi_above_surface(self):
+        """Scaling is signed — works regardless of stack z direction."""
+        poi = np.array([[0.0, 0.0, 30.0]], dtype=np.float32)
+        out = apply_z_surface_correction(poi, surface_z=50.0, correction_factor=1.5)
+        # 50 + (30 - 50) * 1.5 = 20
+        assert out[0, 2] == pytest.approx(20.0)
+
+    def test_factor_one_is_noop(self):
+        poi = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+        out = apply_z_surface_correction(poi, surface_z=10.0, correction_factor=1.0)
+        assert np.allclose(out, poi)
+
+    def test_poi_at_surface_unchanged(self):
+        poi = np.array([[1.0, 2.0, 10.0]], dtype=np.float32)
+        out = apply_z_surface_correction(poi, surface_z=10.0, correction_factor=2.0)
+        assert out[0, 2] == pytest.approx(10.0)
+
+    def test_all_pois_corrected(self):
+        poi = np.array(
+            [[0.0, 0.0, 20.0], [0.0, 0.0, 30.0], [0.0, 0.0, 5.0]], dtype=np.float32
+        )
+        out = apply_z_surface_correction(poi, surface_z=10.0, correction_factor=2.0)
+        assert out[:, 2] == pytest.approx([30.0, 50.0, 0.0])
+
+    def test_input_not_mutated(self):
+        poi = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+        original = poi.copy()
+        apply_z_surface_correction(poi, surface_z=0.0, correction_factor=2.0)
+        assert np.array_equal(poi, original)
+
+    def test_empty_array(self):
+        poi = np.zeros((0, 3), dtype=np.float32)
+        out = apply_z_surface_correction(poi, surface_z=0.0, correction_factor=2.0)
+        assert out.shape == (0, 3)
+
+
+# ---------------------------------------------------------------------------
+# run_correlation_from_data — transient application at the correlate() seam
+# ---------------------------------------------------------------------------
+
+
+def _fake_run_correlation(captured):
+    """Stub for correlation_v2.run_correlation that records its POI input."""
+
+    def fake(
+        fib_coords,
+        fm_coords,
+        poi_coords,
+        image_props,
+        rotation_center,
+        path=None,
+        fib_image_filename="",
+        fm_image_filename="",
+    ):
+        captured["poi_coords"] = np.array(poi_coords, copy=True)
+        n_poi = len(poi_coords)
+        n_markers = len(fib_coords)
+        return {
+            "input": {},
+            "output": {
+                "transformation": {
+                    "scale": 1.0,
+                    "rotation_eulers": [0.0, 0.0, 0.0],
+                    # NOTE: despite the name, this field stores Rigid3D.q,
+                    # the 3x3 rotation matrix (identity here)
+                    "rotation_quaternion": np.eye(3).tolist(),
+                    "translation_around_rotation_center_zero": [0.0, 0.0, 0.0],
+                    "translation_around_rotation_center_custom": [0.0, 0.0, 0.0],
+                },
+                "error": {
+                    "rms_error": 0.0,
+                    "mean_absolute_error": [0.0, 0.0],
+                    "delta_2d": [[0.0] * n_markers, [0.0] * n_markers],
+                    "reprojected_3d": [
+                        [0.0] * n_markers,
+                        [0.0] * n_markers,
+                        [0.0] * n_markers,
+                    ],
+                },
+                "poi": [
+                    {"image_px": [0.0, 0.0], "px": [0.0, 0.0], "px_m": [0.0, 0.0]}
+                    for _ in range(n_poi)
+                ],
+            },
+        }
+
+    return fake
+
+
+def _make_input_data(**kwargs) -> CorrelationInputData:
+    return CorrelationInputData(
+        fib_coordinates=[_coord(x=i, y=i, pt=PointType.FIB) for i in range(4)],
+        fm_coordinates=[_coord(x=i, y=i, z=5.0, pt=PointType.FM) for i in range(4)],
+        poi_coordinates=[
+            _coord(x=1.0, y=2.0, z=30.0, pt=PointType.POI),
+            _coord(x=3.0, y=4.0, z=5.0, pt=PointType.POI),
+        ],
+        **kwargs,
+    )
+
+
+class TestRunCorrelationPreCorrection:
+
+    @pytest.fixture
+    def captured(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            correlation_v2, "run_correlation", _fake_run_correlation(captured)
+        )
+        return captured
+
+    def test_correction_applied_to_all_pois(self, captured):
+        data = _make_input_data(
+            fm_surface_coordinate=_coord(z=10.0, pt=PointType.SURFACE_FM),
+            ri_pre_correction_factor=1.5,
+        )
+        result = run_correlation_from_data(data)
+        # POI 1: 10 + (30 - 10) * 1.5 = 40; POI 2: 10 + (5 - 10) * 1.5 = 2.5
+        assert captured["poi_coords"][:, 2] == pytest.approx([40.0, 2.5])
+        assert result.refractive_index_correction_factor == 1.5
+        assert result.refractive_index_correction_mode == "pre"
+
+    def test_ghost_poi_uncorrected(self, captured):
+        """Ghost markers reproject the ORIGINAL poi through the same transform."""
+        data = _make_input_data(
+            fm_surface_coordinate=_coord(z=10.0, pt=PointType.SURFACE_FM),
+            ri_pre_correction_factor=1.5,
+        )
+        result = run_correlation_from_data(data)
+        # stub transform is identity → image_px equals the original (x, y)
+        assert len(result.poi_uncorrected) == 2
+        assert result.poi_uncorrected[0].image_px.x == pytest.approx(1.0)
+        assert result.poi_uncorrected[0].image_px.y == pytest.approx(2.0)
+        assert result.poi_uncorrected[1].image_px.x == pytest.approx(3.0)
+        assert result.poi_uncorrected[1].image_px.y == pytest.approx(4.0)
+
+    def test_no_ghost_without_correction(self, captured):
+        data = _make_input_data(
+            fm_surface_coordinate=_coord(z=10.0, pt=PointType.SURFACE_FM),
+        )
+        result = run_correlation_from_data(data)
+        assert result.poi_uncorrected == []
+
+    def test_input_poi_not_mutated(self, captured):
+        data = _make_input_data(
+            fm_surface_coordinate=_coord(z=10.0, pt=PointType.SURFACE_FM),
+            ri_pre_correction_factor=1.5,
+        )
+        run_correlation_from_data(data)
+        # stored coordinates keep the user-picked z (correction is transient)
+        assert data.poi_coordinates[0].point.z == pytest.approx(30.0)
+        assert data.poi_coordinates[1].point.z == pytest.approx(5.0)
+
+    def test_rerun_is_idempotent(self, captured):
+        data = _make_input_data(
+            fm_surface_coordinate=_coord(z=10.0, pt=PointType.SURFACE_FM),
+            ri_pre_correction_factor=1.5,
+        )
+        run_correlation_from_data(data)
+        first = captured["poi_coords"].copy()
+        run_correlation_from_data(data)
+        assert np.allclose(captured["poi_coords"], first)
+
+    def test_no_factor_no_correction(self, captured):
+        data = _make_input_data(
+            fm_surface_coordinate=_coord(z=10.0, pt=PointType.SURFACE_FM),
+        )
+        result = run_correlation_from_data(data)
+        assert captured["poi_coords"][:, 2] == pytest.approx([30.0, 5.0])
+        assert result.refractive_index_correction_factor is None
+        assert result.refractive_index_correction_mode is None
+
+    def test_no_fm_surface_no_correction(self, captured):
+        data = _make_input_data(ri_pre_correction_factor=1.5)
+        result = run_correlation_from_data(data)
+        assert captured["poi_coords"][:, 2] == pytest.approx([30.0, 5.0])
+        assert result.refractive_index_correction_mode is None
+
+    def test_fib_surface_does_not_trigger_pre_correction(self, captured):
+        data = _make_input_data(
+            surface_coordinate=_coord(y=100.0, pt=PointType.SURFACE),
+            ri_pre_correction_factor=1.5,
+        )
+        result = run_correlation_from_data(data)
+        assert captured["poi_coords"][:, 2] == pytest.approx([30.0, 5.0])
+        assert result.refractive_index_correction_mode is None
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+
+    def test_input_data_roundtrip(self):
+        data = _make_input_data(
+            fm_surface_coordinate=_coord(x=1.0, y=2.0, z=10.0, pt=PointType.SURFACE_FM),
+            ri_pre_correction_factor=1.47,
+        )
+        data2 = CorrelationInputData.from_dict(data.to_dict())
+        assert data2.fm_surface_coordinate is not None
+        assert data2.fm_surface_coordinate.point.z == pytest.approx(10.0)
+        assert data2.fm_surface_coordinate.point_type is PointType.SURFACE_FM
+        assert data2.ri_pre_correction_factor == pytest.approx(1.47)
+
+    def test_legacy_dict_without_new_keys(self):
+        """Files written before the FM-surface feature still load."""
+        legacy = {
+            "fib_coordinates": [],
+            "fm_coordinates": [],
+            "poi_coordinates": [],
+            "surface_coordinate": None,
+            "method": "multi-point",
+        }
+        data = CorrelationInputData.from_dict(legacy)
+        assert data.fm_surface_coordinate is None
+        assert data.ri_pre_correction_factor is None
+
+    def test_point_type_roundtrip(self):
+        c = _coord(pt=PointType.SURFACE_FM)
+        c2 = Coordinate.from_dict(c.to_dict())
+        assert c2.point_type is PointType.SURFACE_FM
+
+    def test_result_mode_roundtrip(self):
+        r = CorrelationResult(
+            refractive_index_correction_factor=1.5,
+            refractive_index_correction_mode="pre",
+        )
+        r2 = CorrelationResult.from_dict(r.to_dict())
+        assert r2.refractive_index_correction_mode == "pre"
+
+    def test_poi_uncorrected_roundtrip(self):
+        from fibsem.correlation.structures import CorrelationPointOfInterest
+        from fibsem.structures import Point
+
+        r = CorrelationResult(
+            poi_uncorrected=[
+                CorrelationPointOfInterest(image_px=Point(x=11.0, y=22.0))
+            ],
+        )
+        r2 = CorrelationResult.from_dict(r.to_dict())
+        assert len(r2.poi_uncorrected) == 1
+        assert r2.poi_uncorrected[0].image_px.x == pytest.approx(11.0)
+
+    def test_legacy_result_without_poi_uncorrected(self):
+        r = CorrelationResult()
+        d = r.to_dict()
+        d.pop("poi_uncorrected")
+        r2 = CorrelationResult.from_dict(d)
+        assert r2.poi_uncorrected == []
+
+    def test_input_dataframe_contains_fm_surface(self):
+        data = _make_input_data(
+            fm_surface_coordinate=_coord(x=1.0, y=2.0, z=10.0, pt=PointType.SURFACE_FM),
+        )
+        r = CorrelationResult(input_data=data)
+        df = r.to_input_dataframe()
+        rows = df[df["type"] == PointType.SURFACE_FM.value]
+        assert len(rows) == 1
+        assert rows.iloc[0]["z_px"] == pytest.approx(10.0)

--- a/tests/correlation/test_pre_correction.py
+++ b/tests/correlation/test_pre_correction.py
@@ -229,6 +229,15 @@ class TestRunCorrelationPreCorrection:
         assert captured["poi_coords"][:, 2] == pytest.approx([30.0, 5.0])
         assert result.refractive_index_correction_mode is None
 
+    def test_both_surfaces_raise(self):
+        """FIB and FM surface points are mutually exclusive at the engine too."""
+        data = _make_input_data(
+            surface_coordinate=_coord(y=100.0, pt=PointType.SURFACE),
+            fm_surface_coordinate=_coord(z=10.0, pt=PointType.SURFACE_FM),
+        )
+        with pytest.raises(ValueError, match="only one surface point"):
+            run_correlation_from_data(data)
+
 
 # ---------------------------------------------------------------------------
 # Serialization


### PR DESCRIPTION
## Summary

Adds an FM-volume surface point as an alternative to the FIB-image surface point for refractive-index depth correction. Only one surface point can exist at a time, and the RI tab's mode follows it:

- **FIB surface → post-correlation** (as before): corrects the correlated POI 1 in FIB image space.
- **FM surface → pre-correlation** (new): corrects the z of **every** input POI in FM volume space, applied inside `run_correlation_from_data` before the transform fit — `z' = z_surf + (z − z_surf)·ζ`.

Key properties:
- The correction is applied **transiently**: picked coordinates never mutate, so re-runs are idempotent and the saved JSON records what was measured plus the factor separately.
- ζ LUT tilt is locked to 0° in FM mode (the correction acts along the optical axis).
- Apply re-runs the correlation (a "Re-run on apply" checkbox defers to the next manual run); the status line reports the applied factor and the resulting POI shift in px.
- **Ghost overlay** (hollow magenta ring) marks where each POI would land *without* the correction — in pre mode via deterministic reprojection through the same fitted transform, in post mode via a snapshot before the in-place correction.
- Canvas polish: per-canvas legend (View → Show Legend), surface crosshairs keep their type colour in all selection states, and a dashed datum line spans the FIB canvas at the surface row.

## Review

A multi-agent critical review of the diff produced 10 confirmed findings; 9 are fixed in this PR (JSON-loaded results getting stale px_m, stale factor re-arming after surface removal, input_data=null crash, two ways a typed factor could be silently clobbered, model-level double-apply guard, ghost export style, status-line clobber, warning-label colour drift). The 10th (collapsing the per-point-type widget plumbing into a registry) is deferred to a follow-up PR. Full design + decisions + findings: `docs/design/correlation-fm-surface-pre-correction.md`.

Also fixes pre-existing bugs found along the way: undefined `_logger` in auto-save error paths, the "Done." status being instantly overwritten by "Ready.", Load Correlation Result populating lists after the RI tab read them, and the stale `fibsem/correlation/tests/test_structures.py` (tested a removed signature).

## Testing

- 73 pytest tests: correction math, engine seam, serialization round-trips incl. legacy files, offscreen widget tests (surface exclusivity, mode switching, apply paths, factor lifecycle, legend, datum line, ghost export).
- End-to-end verified against a synthetic dataset with a known rigid transform: corrected POI and ghost land on the ground-truth projections to <0.01 px.
- Live-tested in the GUI (METEOR-style workflow: pick pairs + POI, add FM surface on the reflection-channel surface slice, apply, verify shift + ghost + status).