### PR TITLE
Correlation widget: point-type registry for canvas/list plumbing

### DIFF
--- a/docs/design/correlation-fm-surface-pre-correction.md
+++ b/docs/design/correlation-fm-surface-pre-correction.md
@@ -299,6 +299,14 @@ Finding 10 (PointType→list registry refactor) deferred to a follow-up PR.
 
 ## Follow-up: registry refactor (review finding 10) + PR #111 canvas convergence
 
+**Status: implemented on branch `claude/correlation-point-registry`
+(stacked on the #139 branch at Patrick's request; rebase onto main once #139
+merges).** Widget net −97 lines; 79 tests pass incl. a parametrized per-type
+behaviour sweep and a loud-failure (KeyError) routing test. Formula dedup
+included: `scale_about_surface()` in structures.py is now the only
+implementation of the depth-scaling formula (engine, model, util tuple
+helper, and both RI-tab previews call it).
+
 Agreed plan (2026-07-15): after PR #139 merges, a separate PR replaces the
 per-point-type plumbing in `correlation_tab_widget.py` with a
 `_PointTypeSpec` registry (point_type → list widget, canvas side, max_one,

--- a/docs/design/correlation-fm-surface-pre-correction.md
+++ b/docs/design/correlation-fm-surface-pre-correction.md
@@ -299,13 +299,26 @@ Finding 10 (PointType→list registry refactor) deferred to a follow-up PR.
 
 ## Follow-up: registry refactor (review finding 10) + PR #111 canvas convergence
 
-**Status: implemented on branch `claude/correlation-point-registry`
-(stacked on the #139 branch at Patrick's request; rebase onto main once #139
-merges).** Widget net −97 lines; 79 tests pass incl. a parametrized per-type
-behaviour sweep and a loud-failure (KeyError) routing test. Formula dedup
-included: `scale_about_surface()` in structures.py is now the only
-implementation of the depth-scaling formula (engine, model, util tuple
-helper, and both RI-tab previews call it).
+**Status: implemented — PR #140 (rebased onto main after #139 merged; CI
+green on py3.8–3.13).** 82 tests pass incl. a parametrized per-type behaviour
+sweep and a loud-failure (KeyError) routing test. Formula dedup included:
+`scale_about_surface()` in structures.py is now the only implementation of
+the depth-scaling formula (engine, model, util tuple helper, and both RI-tab
+previews call it).
+
+A medium-effort multi-agent review of the PR found zero correctness
+regressions (line-scan, removed-behaviour audit, cross-file trace, efficiency
+all clean) and six confirmed polish items, fixed in a follow-up commit:
+`_POINT_TYPE_SIDES` is now the single source for canvas allow-lists and
+adapter binding (a spec-only point type appears in the right-click menu);
+the adapter set, axis-maxima updates, and refit routing all derive from the
+registry; `_PointTypeSpec.__post_init__` rejects inconsistent side/fit-role
+combinations and the build asserts registry↔map completeness; `on_cleared`
+now fires only when the spec's LAST point is removed; the `_CanvasAdapter`
+docstring states honestly that the seam is outbound-only (inbound signal
+translation is part of the future #111 migration). A seventh candidate
+(remove the adapter as pass-through indirection) was refuted against the
+recorded design intent above.
 
 Agreed plan (2026-07-15): after PR #139 merges, a separate PR replaces the
 per-point-type plumbing in `correlation_tab_widget.py` with a

--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -49,6 +49,16 @@ class Coordinate:
         return Coordinate(point=point, point_type=point_type)
 
 
+def scale_about_surface(value, surface, correction_factor):
+    """Scale a depth-like value about a surface reference.
+
+    ``surface + (value - surface) * correction_factor`` — the single source of
+    the refractive-index depth-scaling formula. Signed (works regardless of
+    axis direction) and unit-free; accepts scalars or numpy arrays.
+    """
+    return surface + (value - surface) * correction_factor
+
+
 def apply_z_surface_correction(
     poi_coords: np.ndarray, surface_z: float, correction_factor: float
 ) -> np.ndarray:
@@ -69,7 +79,9 @@ def apply_z_surface_correction(
     """
     corrected = np.array(poi_coords, dtype=np.float32, copy=True)
     if corrected.size:
-        corrected[:, 2] = surface_z + (corrected[:, 2] - surface_z) * correction_factor
+        corrected[:, 2] = scale_about_surface(
+            corrected[:, 2], surface_z, correction_factor
+        )
     return corrected
 
 
@@ -346,7 +358,7 @@ class CorrelationResult:
                 px_m=Point(poi0.px_m.x, poi0.px_m.y),
             )
         ]
-        corrected_y = surface_y + (poi0.image_px.y - surface_y) * correction_factor
+        corrected_y = scale_about_surface(poi0.image_px.y, surface_y, correction_factor)
         poi0.image_px.y = corrected_y
         if fib_shape is not None and pixel_size is not None:
             cy = fib_shape[0] / 2.0

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -925,19 +925,38 @@ class _RITab(QWidget):
 # ---------------------------------------------------------------------------
 
 
+# Which canvas each point type lives on. Single source of truth: the canvas
+# right-click allow-lists and the registry's adapter binding both derive from
+# this map (declaration order = add-menu order).
+_POINT_TYPE_SIDES: Dict[PointType, str] = {
+    PointType.FIB: "fib",
+    PointType.SURFACE: "fib",
+    PointType.FM: "fm",
+    PointType.POI: "fm",
+    PointType.SURFACE_FM: "fm",
+}
+
+
 class _CanvasAdapter:
     """Thin seam over a point-display surface (canvas or display widget).
 
-    The registry-driven handlers talk to canvases exclusively through this
-    adapter, so migrating the correlation canvases onto the shared canvas
-    stack (fibsem.ui.widgets.canvas, PR #111) only requires new adapters —
-    the handlers, exclusivity, and lifecycle logic stay untouched.
+    Outbound canvas calls from the registry-driven handlers all go through
+    this adapter. NOTE: inbound signals (point_selected/moved/removed/
+    add_requested) still connect to the canvases directly and carry
+    identity-based Coordinate payloads — migrating onto the shared canvas
+    stack (fibsem.ui.widgets.canvas, PR #111, index-based PointOverlay
+    signals) therefore means new adapters PLUS an inbound translation layer;
+    what stays untouched is the registry, exclusivity, and lifecycle logic.
     """
 
     def __init__(
-        self, surface, z_provider: Optional[Callable[[], float]] = None
+        self,
+        surface,
+        side: str,
+        z_provider: Optional[Callable[[], float]] = None,
     ) -> None:
         self._surface = surface
+        self.side = side  # "fib" | "fm"
         self._z_provider = z_provider
 
     def set_coordinates(self, coords: List[Coordinate]) -> None:
@@ -958,20 +977,34 @@ class _CanvasAdapter:
 class _PointTypeSpec:
     """Registry entry driving all per-point-type canvas/list plumbing.
 
-    Adding a point type = adding one spec (plus its list panel); the generic
-    handlers, selection clearing, exclusivity, and refit routing follow from
-    the registry. Unregistered point types fail loudly (KeyError) instead of
-    being silently misrouted.
+    Adding a point type = one _POINT_TYPE_SIDES entry + one spec (plus its
+    list panel); the canvas add-menus, generic handlers, selection clearing,
+    exclusivity, axis maxima, and refit routing all follow from the registry.
+    Unregistered point types fail loudly (KeyError) instead of being silently
+    misrouted, and inconsistent specs are rejected at construction.
     """
 
     point_type: PointType
     list_widget: CoordinateListWidget
     adapter: _CanvasAdapter
-    side: str                                        # "fib" | "fm" (refit routing)
     max_one: bool = False                            # replace-on-add (surfaces)
     exclusive_group: Optional[str] = None            # mutually exclusive specs
     fm_fit_role: Optional[str] = None                # "fid" | "poi" → refit combos
-    on_cleared: Optional[Callable[[], None]] = None  # fired when points removed
+    on_cleared: Optional[Callable[[], None]] = None  # fired when the spec's
+                                                     # last point is removed
+
+    def __post_init__(self) -> None:
+        expected_side = _POINT_TYPE_SIDES.get(self.point_type)
+        if self.adapter.side != expected_side:
+            raise ValueError(
+                f"{self.point_type}: adapter side {self.adapter.side!r} does not "
+                f"match _POINT_TYPE_SIDES ({expected_side!r})"
+            )
+        if (self.adapter.side == "fm") != (self.fm_fit_role is not None):
+            raise ValueError(
+                f"{self.point_type}: fm_fit_role must be set for FM-side specs "
+                f"and None for FIB-side specs (got {self.fm_fit_role!r})"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -1068,15 +1101,15 @@ class CorrelationTabWidget(QWidget):
         splitter = QSplitter(Qt.Orientation.Horizontal)
         layout.addWidget(splitter, stretch=1)
 
-        # Left: FIB image canvas
+        # Left: FIB image canvas (add-menu types derived from the registry map)
         self._fib_canvas = ImagePointCanvas(
-            allowed_point_types=[PointType.FIB, PointType.SURFACE],
+            allowed_point_types=self._point_types_for_side("fib"),
         )
         splitter.addWidget(self._fib_canvas)
 
         # Middle: FM image display
         self._fm_display = FMImageDisplayWidget(
-            allowed_point_types=[PointType.FM, PointType.POI, PointType.SURFACE_FM],
+            allowed_point_types=self._point_types_for_side("fm"),
         )
         splitter.addWidget(self._fm_display)
 
@@ -1134,27 +1167,41 @@ class CorrelationTabWidget(QWidget):
 
         self._build_point_registry()
 
+    @staticmethod
+    def _point_types_for_side(side: str) -> List[PointType]:
+        return [pt for pt, s in _POINT_TYPE_SIDES.items() if s == side]
+
     def _build_point_registry(self) -> None:
         """One _PointTypeSpec per point type drives all canvas/list plumbing."""
-        self._fib_adapter = _CanvasAdapter(self._fib_canvas)
+        self._fib_adapter = _CanvasAdapter(self._fib_canvas, side="fib")
         self._fm_adapter = _CanvasAdapter(
-            self._fm_display, z_provider=lambda: self._fm_display.current_z
+            self._fm_display,
+            side="fm",
+            z_provider=lambda: self._fm_display.current_z,
         )
+        self._adapters: Dict[str, _CanvasAdapter] = {
+            "fib": self._fib_adapter,
+            "fm": self._fm_adapter,
+        }
+        adapter_for = lambda pt: self._adapters[_POINT_TYPE_SIDES[pt]]  # noqa: E731
+
         cl = self._coords_tab
         specs = (
-            _PointTypeSpec(PointType.FIB, cl.fib_list, self._fib_adapter, "fib"),
+            _PointTypeSpec(PointType.FIB, cl.fib_list, adapter_for(PointType.FIB)),
             _PointTypeSpec(
-                PointType.SURFACE, cl.surface_list, self._fib_adapter, "fib",
+                PointType.SURFACE, cl.surface_list, adapter_for(PointType.SURFACE),
                 max_one=True, exclusive_group="surface",
             ),
             _PointTypeSpec(
-                PointType.FM, cl.fm_list, self._fm_adapter, "fm", fm_fit_role="fid"
+                PointType.FM, cl.fm_list, adapter_for(PointType.FM), fm_fit_role="fid"
             ),
             _PointTypeSpec(
-                PointType.POI, cl.poi_list, self._fm_adapter, "fm", fm_fit_role="poi"
+                PointType.POI, cl.poi_list, adapter_for(PointType.POI),
+                fm_fit_role="poi",
             ),
             _PointTypeSpec(
-                PointType.SURFACE_FM, cl.fm_surface_list, self._fm_adapter, "fm",
+                PointType.SURFACE_FM, cl.fm_surface_list,
+                adapter_for(PointType.SURFACE_FM),
                 max_one=True, exclusive_group="surface", fm_fit_role="fid",
                 on_cleared=self._clear_pre_correction_factor,
             ),
@@ -1162,6 +1209,11 @@ class CorrelationTabWidget(QWidget):
         self._point_specs: Dict[PointType, _PointTypeSpec] = {
             spec.point_type: spec for spec in specs
         }
+        if set(self._point_specs) != set(_POINT_TYPE_SIDES):
+            missing = set(_POINT_TYPE_SIDES) ^ set(self._point_specs)
+            raise ValueError(
+                f"Point-type registry and _POINT_TYPE_SIDES disagree on: {missing}"
+            )
 
     def _connect_signals(self) -> None:
         # Images tab → push to canvases
@@ -1238,8 +1290,9 @@ class CorrelationTabWidget(QWidget):
         if fib_image.metadata and fib_image.metadata.pixel_size:
             self._fib_canvas.set_pixel_size(fib_image.metadata.pixel_size.x)
         h, w = fib_image.data.shape[:2]
-        self._coords_tab.fib_list.set_axis_maxima(x_max=w - 1, y_max=h - 1)
-        self._coords_tab.surface_list.set_axis_maxima(x_max=w - 1, y_max=h - 1)
+        for spec in self._point_specs.values():
+            if spec.adapter is self._fib_adapter:
+                spec.list_widget.set_axis_maxima(x_max=w - 1, y_max=h - 1)
         self._images_tab.set_fib_image(fib_image)
 
     def set_fm_image(self, fm_image: FluorescenceImage) -> None:
@@ -1250,15 +1303,11 @@ class CorrelationTabWidget(QWidget):
         if px:
             self._fm_display.canvas.set_pixel_size(px)
         _, n_z, h, w = fm_image.data.shape
-        self._coords_tab.fm_list.set_axis_maxima(
-            x_max=w - 1, y_max=h - 1, z_max=n_z - 1
-        )
-        self._coords_tab.poi_list.set_axis_maxima(
-            x_max=w - 1, y_max=h - 1, z_max=n_z - 1
-        )
-        self._coords_tab.fm_surface_list.set_axis_maxima(
-            x_max=w - 1, y_max=h - 1, z_max=n_z - 1
-        )
+        for spec in self._point_specs.values():
+            if spec.adapter is self._fm_adapter:
+                spec.list_widget.set_axis_maxima(
+                    x_max=w - 1, y_max=h - 1, z_max=n_z - 1
+                )
         self._coords_tab.rebuild_channel_combos(fm_image)
         self._images_tab.set_fm_image(fm_image)
 
@@ -1293,8 +1342,8 @@ class CorrelationTabWidget(QWidget):
         cl.poi_list.coordinates = poi_coords
         cl.surface_list.coordinates = surf_coords
         cl.fm_surface_list.coordinates = fm_surf_coords
-        self._refresh_canvas(self._fib_adapter)
-        self._refresh_canvas(self._fm_adapter)
+        for adapter in self._adapters.values():
+            self._refresh_canvas(adapter)
         cl.update_headers()
 
         # A factor without an FM surface is meaningless — don't arm it
@@ -1353,7 +1402,7 @@ class CorrelationTabWidget(QWidget):
         for other in self._point_specs.values():
             if other is not spec:
                 other.list_widget.select_coordinate_silent(None)
-        for adapter in (self._fib_adapter, self._fm_adapter):
+        for adapter in self._adapters.values():
             adapter.set_selected(coord if adapter is spec.adapter else None)
 
     # ------------------------------------------------------------------
@@ -1563,7 +1612,7 @@ class CorrelationTabWidget(QWidget):
         spec.list_widget.coordinates = [
             c for c in spec.list_widget.coordinates if c is not coord
         ]
-        if spec.on_cleared is not None:
+        if spec.on_cleared is not None and not spec.list_widget.coordinates:
             spec.on_cleared()
         self._refresh_canvas(spec.adapter)
         self._coords_tab.update_headers()
@@ -1610,7 +1659,9 @@ class CorrelationTabWidget(QWidget):
         self.data_changed.emit(self.data)
 
     def _on_list_removed(self, spec: _PointTypeSpec, _coord: Coordinate) -> None:
-        if spec.on_cleared is not None:
+        # on_cleared = "the spec's LAST point is gone" (the list widget removes
+        # the row before emitting, so the check sees the post-removal state)
+        if spec.on_cleared is not None and not spec.list_widget.coordinates:
             spec.on_cleared()
         self._refresh_canvas(spec.adapter)
         self._coords_tab.update_headers()
@@ -1763,7 +1814,7 @@ class CorrelationTabWidget(QWidget):
         fig = None
 
         try:
-            if spec.side == "fib":
+            if spec.adapter.side == "fib":
                 method = cl._fib_method_combo.currentText()
                 if method == "Hole" and self._fib_image is not None:
                     xr, yr, fig = hole_fitting_FIB(

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -35,7 +35,9 @@ import copy
 import logging
 import os
 import time
-from typing import List, Optional
+from dataclasses import dataclass
+from functools import partial
+from typing import Callable, Dict, List, Optional
 
 logging.basicConfig(level=logging.INFO)
 
@@ -72,6 +74,7 @@ from fibsem.correlation.structures import (
     CorrelationResult,
     PointType,
     PointXYZ,
+    scale_about_surface,
 )
 from fibsem.correlation.ui.widgets.coordinate_list_widget import CoordinateListWidget
 from fibsem.ui import stylesheets
@@ -829,7 +832,7 @@ class _RITab(QWidget):
         self._table.setRowCount(len(self._input_poi))
         for i, coord in enumerate(self._input_poi):
             z = coord.point.z
-            corrected_z = surface_z + (z - surface_z) * factor
+            corrected_z = scale_about_surface(z, surface_z, factor)
             self._table.setItem(i, 0, _ro_item(f"POI {i + 1}"))
             self._table.setItem(i, 1, _ro_item(f"{coord.point.x:.2f}"))
             self._table.setItem(i, 2, _ro_item(f"{z:.2f}"))
@@ -894,7 +897,7 @@ class _RITab(QWidget):
         self._table.setRowCount(len(self._poi))
         for i, poi in enumerate(self._poi):
             depth = poi.image_px.y - surface_y
-            corrected_y = surface_y + depth * factor
+            corrected_y = scale_about_surface(poi.image_px.y, surface_y, factor)
             logging.info(
                 f"[RITab._apply_post] POI {i + 1}: original_y={poi.image_px.y:.2f}, "
                 f"depth={depth:.2f}, corrected_y={corrected_y:.2f}"
@@ -915,6 +918,60 @@ class _RITab(QWidget):
         self._result.apply_refractive_index_correction(factor)
         logging.info("[RITab._apply_post] correction applied, emitting correction_applied")
         self.correction_applied.emit(self._result)
+
+
+# ---------------------------------------------------------------------------
+# Point-type registry
+# ---------------------------------------------------------------------------
+
+
+class _CanvasAdapter:
+    """Thin seam over a point-display surface (canvas or display widget).
+
+    The registry-driven handlers talk to canvases exclusively through this
+    adapter, so migrating the correlation canvases onto the shared canvas
+    stack (fibsem.ui.widgets.canvas, PR #111) only requires new adapters —
+    the handlers, exclusivity, and lifecycle logic stay untouched.
+    """
+
+    def __init__(
+        self, surface, z_provider: Optional[Callable[[], float]] = None
+    ) -> None:
+        self._surface = surface
+        self._z_provider = z_provider
+
+    def set_coordinates(self, coords: List[Coordinate]) -> None:
+        self._surface.set_coordinates(coords)
+
+    def set_selected(self, coord: Optional[Coordinate]) -> None:
+        self._surface.set_selected(coord)
+
+    def refresh_coordinate(self, coord: Coordinate) -> None:
+        self._surface.refresh_coordinate(coord)
+
+    def current_z(self) -> float:
+        """z for newly added points (FM: current slice; FIB: 0)."""
+        return float(self._z_provider()) if self._z_provider is not None else 0.0
+
+
+@dataclass(frozen=True, eq=False)
+class _PointTypeSpec:
+    """Registry entry driving all per-point-type canvas/list plumbing.
+
+    Adding a point type = adding one spec (plus its list panel); the generic
+    handlers, selection clearing, exclusivity, and refit routing follow from
+    the registry. Unregistered point types fail loudly (KeyError) instead of
+    being silently misrouted.
+    """
+
+    point_type: PointType
+    list_widget: CoordinateListWidget
+    adapter: _CanvasAdapter
+    side: str                                        # "fib" | "fm" (refit routing)
+    max_one: bool = False                            # replace-on-add (surfaces)
+    exclusive_group: Optional[str] = None            # mutually exclusive specs
+    fm_fit_role: Optional[str] = None                # "fid" | "poi" → refit combos
+    on_cleared: Optional[Callable[[], None]] = None  # fired when points removed
 
 
 # ---------------------------------------------------------------------------
@@ -1075,6 +1132,37 @@ class CorrelationTabWidget(QWidget):
         splitter.addWidget(right_pane)
         splitter.setSizes([500, 500, 350])
 
+        self._build_point_registry()
+
+    def _build_point_registry(self) -> None:
+        """One _PointTypeSpec per point type drives all canvas/list plumbing."""
+        self._fib_adapter = _CanvasAdapter(self._fib_canvas)
+        self._fm_adapter = _CanvasAdapter(
+            self._fm_display, z_provider=lambda: self._fm_display.current_z
+        )
+        cl = self._coords_tab
+        specs = (
+            _PointTypeSpec(PointType.FIB, cl.fib_list, self._fib_adapter, "fib"),
+            _PointTypeSpec(
+                PointType.SURFACE, cl.surface_list, self._fib_adapter, "fib",
+                max_one=True, exclusive_group="surface",
+            ),
+            _PointTypeSpec(
+                PointType.FM, cl.fm_list, self._fm_adapter, "fm", fm_fit_role="fid"
+            ),
+            _PointTypeSpec(
+                PointType.POI, cl.poi_list, self._fm_adapter, "fm", fm_fit_role="poi"
+            ),
+            _PointTypeSpec(
+                PointType.SURFACE_FM, cl.fm_surface_list, self._fm_adapter, "fm",
+                max_one=True, exclusive_group="surface", fm_fit_role="fid",
+                on_cleared=self._clear_pre_correction_factor,
+            ),
+        )
+        self._point_specs: Dict[PointType, _PointTypeSpec] = {
+            spec.point_type: spec for spec in specs
+        }
+
     def _connect_signals(self) -> None:
         # Images tab → push to canvases
         self._images_tab.fib_image_changed.connect(self._on_fib_image_changed)
@@ -1089,58 +1177,21 @@ class CorrelationTabWidget(QWidget):
         self._ri_tab.correction_applied.connect(self._on_correction_applied)
         self._ri_tab.pre_correction_requested.connect(self._on_pre_correction_requested)
 
-        # Canvas → list
-        self._fib_canvas.point_selected.connect(self._on_fib_canvas_selected)
-        self._fib_canvas.point_moved.connect(self._on_fib_canvas_moved)
-        self._fib_canvas.point_removed.connect(self._on_fib_canvas_removed)
-        self._fib_canvas.point_add_requested.connect(self._on_fib_add_requested)
+        # Canvas → list (registry-driven; handlers resolve the spec by type)
+        for canvas in (self._fib_canvas, self._fm_display):
+            canvas.point_selected.connect(self._on_canvas_selected)
+            canvas.point_moved.connect(self._on_canvas_moved)
+            canvas.point_removed.connect(self._on_canvas_removed)
+            canvas.point_add_requested.connect(self._on_canvas_add_requested)
 
-        self._fm_display.point_selected.connect(self._on_fm_canvas_selected)
-        self._fm_display.point_moved.connect(self._on_fm_canvas_moved)
-        self._fm_display.point_removed.connect(self._on_fm_canvas_removed)
-        self._fm_display.point_add_requested.connect(self._on_fm_add_requested)
-
-        # List → canvas
-        cl = self._coords_tab
-        cl.fib_list.coordinate_selected.connect(self._on_fib_list_selected)
-        cl.fib_list.coordinate_changed.connect(self._on_fib_list_changed)
-        cl.fib_list.coordinate_removed.connect(self._on_fib_list_removed)
-        cl.fib_list.order_changed.connect(
-            lambda _: (self._refresh_fib_canvas(), self.data_changed.emit(self.data))
-        )
-        cl.fib_list.refit_requested.connect(self._on_refit_requested)
-
-        cl.fm_list.coordinate_selected.connect(self._on_fm_list_selected)
-        cl.fm_list.coordinate_changed.connect(self._on_fm_list_changed)
-        cl.fm_list.coordinate_removed.connect(self._on_fm_list_removed)
-        cl.fm_list.order_changed.connect(
-            lambda _: (self._refresh_fm_canvas(), self.data_changed.emit(self.data))
-        )
-        cl.fm_list.refit_requested.connect(self._on_refit_requested)
-
-        cl.poi_list.coordinate_selected.connect(self._on_poi_list_selected)
-        cl.poi_list.coordinate_changed.connect(self._on_poi_list_changed)
-        cl.poi_list.coordinate_removed.connect(self._on_poi_list_removed)
-        cl.poi_list.order_changed.connect(
-            lambda _: (self._refresh_fm_canvas(), self.data_changed.emit(self.data))
-        )
-        cl.poi_list.refit_requested.connect(self._on_refit_requested)
-
-        cl.surface_list.coordinate_selected.connect(self._on_surface_list_selected)
-        cl.surface_list.coordinate_changed.connect(self._on_surface_list_changed)
-        cl.surface_list.coordinate_removed.connect(self._on_surface_list_removed)
-        cl.surface_list.order_changed.connect(
-            lambda _: (self._refresh_fib_canvas(), self.data_changed.emit(self.data))
-        )
-        cl.surface_list.refit_requested.connect(self._on_refit_requested)
-
-        cl.fm_surface_list.coordinate_selected.connect(self._on_fm_surface_list_selected)
-        cl.fm_surface_list.coordinate_changed.connect(self._on_fm_surface_list_changed)
-        cl.fm_surface_list.coordinate_removed.connect(self._on_fm_surface_list_removed)
-        cl.fm_surface_list.order_changed.connect(
-            lambda _: (self._refresh_fm_canvas(), self.data_changed.emit(self.data))
-        )
-        cl.fm_surface_list.refit_requested.connect(self._on_refit_requested)
+        # List → canvas (one identical wiring block per spec)
+        for spec in self._point_specs.values():
+            lw = spec.list_widget
+            lw.coordinate_selected.connect(partial(self._on_list_selected, spec))
+            lw.coordinate_changed.connect(partial(self._on_list_changed, spec))
+            lw.coordinate_removed.connect(partial(self._on_list_removed, spec))
+            lw.order_changed.connect(partial(self._on_list_reordered, spec))
+            lw.refit_requested.connect(self._on_refit_requested)
 
         # File menu
         self._action_load_fib.triggered.connect(self._menu_load_fib)
@@ -1236,15 +1287,14 @@ class CorrelationTabWidget(QWidget):
             )
             surf_coords = []
 
-        self._fib_canvas.set_coordinates(fib_coords + surf_coords)
-        self._fm_display.set_coordinates(fm_coords + poi_coords + fm_surf_coords)
-
         cl = self._coords_tab
         cl.fib_list.coordinates = fib_coords
         cl.fm_list.coordinates = fm_coords
         cl.poi_list.coordinates = poi_coords
         cl.surface_list.coordinates = surf_coords
         cl.fm_surface_list.coordinates = fm_surf_coords
+        self._refresh_canvas(self._fib_adapter)
+        self._refresh_canvas(self._fm_adapter)
         cl.update_headers()
 
         # A factor without an FM surface is meaningless — don't arm it
@@ -1290,19 +1340,21 @@ class CorrelationTabWidget(QWidget):
     # Canvas refresh helpers
     # ------------------------------------------------------------------
 
-    def _refresh_fib_canvas(self) -> None:
-        cl = self._coords_tab
-        self._fib_canvas.set_coordinates(
-            cl.fib_list.coordinates + cl.surface_list.coordinates
-        )
+    def _refresh_canvas(self, adapter: _CanvasAdapter) -> None:
+        """Push the full coordinate set of every spec shown on this canvas."""
+        coords: List[Coordinate] = []
+        for spec in self._point_specs.values():
+            if spec.adapter is adapter:
+                coords += spec.list_widget.coordinates
+        adapter.set_coordinates(coords)
 
-    def _refresh_fm_canvas(self) -> None:
-        cl = self._coords_tab
-        self._fm_display.set_coordinates(
-            cl.fm_list.coordinates
-            + cl.poi_list.coordinates
-            + cl.fm_surface_list.coordinates
-        )
+    def _select_only(self, spec: _PointTypeSpec, coord: Optional[Coordinate]) -> None:
+        """Make coord the sole selection: clear every other list and canvas."""
+        for other in self._point_specs.values():
+            if other is not spec:
+                other.list_widget.select_coordinate_silent(None)
+        for adapter in (self._fib_adapter, self._fm_adapter):
+            adapter.set_selected(coord if adapter is spec.adapter else None)
 
     # ------------------------------------------------------------------
     # Image loaded slots
@@ -1496,211 +1548,76 @@ class CorrelationTabWidget(QWidget):
     # Canvas → list slots
     # ------------------------------------------------------------------
 
-    def _on_fib_canvas_selected(self, coord: Coordinate) -> None:
-        cl = self._coords_tab
-        if coord.point_type == PointType.SURFACE:
-            cl.surface_list.select_coordinate_silent(coord)
-            cl.fib_list.select_coordinate_silent(None)
-        else:
-            cl.fib_list.select_coordinate_silent(coord)
-            cl.surface_list.select_coordinate_silent(None)
-        cl.fm_list.select_coordinate_silent(None)
-        cl.poi_list.select_coordinate_silent(None)
-        cl.fm_surface_list.select_coordinate_silent(None)
-        self._fm_display.set_selected(None)
+    def _on_canvas_selected(self, coord: Coordinate) -> None:
+        spec = self._point_specs[coord.point_type]
+        spec.list_widget.select_coordinate_silent(coord)
+        self._select_only(spec, coord)
 
-    def _on_fm_canvas_selected(self, coord: Coordinate) -> None:
-        cl = self._coords_tab
-        self._fib_canvas.set_selected(None)
-        cl.fib_list.select_coordinate_silent(None)
-        cl.surface_list.select_coordinate_silent(None)
-        cl.fm_list.select_coordinate_silent(None)
-        cl.poi_list.select_coordinate_silent(None)
-        cl.fm_surface_list.select_coordinate_silent(None)
-        if coord.point_type == PointType.FM:
-            cl.fm_list.select_coordinate_silent(coord)
-        elif coord.point_type == PointType.SURFACE_FM:
-            cl.fm_surface_list.select_coordinate_silent(coord)
-        else:
-            cl.poi_list.select_coordinate_silent(coord)
-
-    def _on_fib_canvas_moved(self, coord: Coordinate) -> None:
-        cl = self._coords_tab
-        if coord.point_type == PointType.SURFACE:
-            cl.surface_list.refresh_coordinate(coord)
-        else:
-            cl.fib_list.refresh_coordinate(coord)
+    def _on_canvas_moved(self, coord: Coordinate) -> None:
+        spec = self._point_specs[coord.point_type]
+        spec.list_widget.refresh_coordinate(coord)
         self.data_changed.emit(self.data)
 
-    def _on_fm_canvas_moved(self, coord: Coordinate) -> None:
-        cl = self._coords_tab
-        if coord.point_type == PointType.FM:
-            cl.fm_list.refresh_coordinate(coord)
-        elif coord.point_type == PointType.SURFACE_FM:
-            cl.fm_surface_list.refresh_coordinate(coord)
-        else:
-            cl.poi_list.refresh_coordinate(coord)
+    def _on_canvas_removed(self, coord: Coordinate) -> None:
+        spec = self._point_specs[coord.point_type]
+        spec.list_widget.coordinates = [
+            c for c in spec.list_widget.coordinates if c is not coord
+        ]
+        if spec.on_cleared is not None:
+            spec.on_cleared()
+        self._refresh_canvas(spec.adapter)
+        self._coords_tab.update_headers()
         self.data_changed.emit(self.data)
 
-    def _on_fib_canvas_removed(self, coord: Coordinate) -> None:
-        cl = self._coords_tab
-        if coord.point_type == PointType.SURFACE:
-            cl.surface_list.coordinates = [
-                c for c in cl.surface_list.coordinates if c is not coord
-            ]
+    def _on_canvas_add_requested(self, x: float, y: float, pt: PointType) -> None:
+        spec = self._point_specs[pt]
+        coord = Coordinate(PointXYZ(x, y, spec.adapter.current_z()), pt)
+        if spec.max_one:
+            spec.list_widget.coordinates = [coord]
+            self._clear_exclusive_siblings(spec)
         else:
-            cl.fib_list.coordinates = [
-                c for c in cl.fib_list.coordinates if c is not coord
-            ]
-        self._refresh_fib_canvas()
-        cl.update_headers()
+            spec.list_widget.add_coordinate(coord)
+        self._refresh_canvas(spec.adapter)
+        self._coords_tab.update_headers()
         self.data_changed.emit(self.data)
 
-    def _on_fm_canvas_removed(self, coord: Coordinate) -> None:
-        cl = self._coords_tab
-        if coord.point_type == PointType.FM:
-            cl.fm_list.coordinates = [
-                c for c in cl.fm_list.coordinates if c is not coord
-            ]
-        elif coord.point_type == PointType.SURFACE_FM:
-            cl.fm_surface_list.coordinates = [
-                c for c in cl.fm_surface_list.coordinates if c is not coord
-            ]
-            self._clear_pre_correction_factor()
-        else:
-            cl.poi_list.coordinates = [
-                c for c in cl.poi_list.coordinates if c is not coord
-            ]
-        self._refresh_fm_canvas()
-        cl.update_headers()
-        self.data_changed.emit(self.data)
-
-    def _on_fib_add_requested(self, x: float, y: float, pt: PointType) -> None:
-        cl = self._coords_tab
-        coord = Coordinate(PointXYZ(x, y, 0.0), pt)
-        if pt == PointType.SURFACE:
-            cl.surface_list.coordinates = [coord]
-            # Only one surface point at a time — replace any FM surface
-            if cl.fm_surface_list.coordinates:
-                cl.fm_surface_list.coordinates = []
-                self._refresh_fm_canvas()
-            self._clear_pre_correction_factor()
-        else:
-            cl.fib_list.add_coordinate(coord)
-        self._refresh_fib_canvas()
-        cl.update_headers()
-        self.data_changed.emit(self.data)
-
-    def _on_fm_add_requested(self, x: float, y: float, pt: PointType) -> None:
-        cl = self._coords_tab
-        coord = Coordinate(PointXYZ(x, y, float(self._fm_display.current_z)), pt)
-        if pt == PointType.FM:
-            cl.fm_list.add_coordinate(coord)
-        elif pt == PointType.SURFACE_FM:
-            cl.fm_surface_list.coordinates = [coord]
-            # Only one surface point at a time — replace any FIB surface
-            if cl.surface_list.coordinates:
-                cl.surface_list.coordinates = []
-                self._refresh_fib_canvas()
-        else:
-            cl.poi_list.add_coordinate(coord)
-        self._refresh_fm_canvas()
-        cl.update_headers()
-        self.data_changed.emit(self.data)
+    def _clear_exclusive_siblings(self, spec: _PointTypeSpec) -> None:
+        """Enforce mutual exclusivity (one surface point at a time): clear the
+        other members of the spec's exclusive group and fire their lifecycle
+        hooks (e.g. disarming the pre-correction factor)."""
+        if spec.exclusive_group is None:
+            return
+        for other in self._point_specs.values():
+            if other is spec or other.exclusive_group != spec.exclusive_group:
+                continue
+            if other.list_widget.coordinates:
+                other.list_widget.coordinates = []
+                self._refresh_canvas(other.adapter)
+            if other.on_cleared is not None:
+                other.on_cleared()
 
     # ------------------------------------------------------------------
     # List → canvas slots
     # ------------------------------------------------------------------
 
-    def _on_fib_list_selected(self, coord: Coordinate) -> None:
-        cl = self._coords_tab
-        self._fib_canvas.set_selected(coord)
-        self._fm_display.set_selected(None)
-        cl.fm_list.select_coordinate_silent(None)
-        cl.poi_list.select_coordinate_silent(None)
-        cl.surface_list.select_coordinate_silent(None)
-        cl.fm_surface_list.select_coordinate_silent(None)
+    def _on_list_selected(self, spec: _PointTypeSpec, coord: Coordinate) -> None:
+        self._select_only(spec, coord)
 
-    def _on_fm_list_selected(self, coord: Coordinate) -> None:
-        cl = self._coords_tab
-        self._fm_display.set_selected(coord)
-        self._fib_canvas.set_selected(None)
-        cl.fib_list.select_coordinate_silent(None)
-        cl.poi_list.select_coordinate_silent(None)
-        cl.surface_list.select_coordinate_silent(None)
-        cl.fm_surface_list.select_coordinate_silent(None)
-
-    def _on_poi_list_selected(self, coord: Coordinate) -> None:
-        cl = self._coords_tab
-        self._fm_display.set_selected(coord)
-        self._fib_canvas.set_selected(None)
-        cl.fib_list.select_coordinate_silent(None)
-        cl.fm_list.select_coordinate_silent(None)
-        cl.surface_list.select_coordinate_silent(None)
-        cl.fm_surface_list.select_coordinate_silent(None)
-
-    def _on_surface_list_selected(self, coord: Coordinate) -> None:
-        cl = self._coords_tab
-        self._fib_canvas.set_selected(coord)
-        self._fm_display.set_selected(None)
-        cl.fib_list.select_coordinate_silent(None)
-        cl.fm_list.select_coordinate_silent(None)
-        cl.poi_list.select_coordinate_silent(None)
-        cl.fm_surface_list.select_coordinate_silent(None)
-
-    def _on_fm_surface_list_selected(self, coord: Coordinate) -> None:
-        cl = self._coords_tab
-        self._fm_display.set_selected(coord)
-        self._fib_canvas.set_selected(None)
-        cl.fib_list.select_coordinate_silent(None)
-        cl.fm_list.select_coordinate_silent(None)
-        cl.poi_list.select_coordinate_silent(None)
-        cl.surface_list.select_coordinate_silent(None)
-
-    def _on_fib_list_changed(self, coord: Coordinate, _f: str, _v: float) -> None:
-        self._fib_canvas.refresh_coordinate(coord)
+    def _on_list_changed(
+        self, spec: _PointTypeSpec, coord: Coordinate, _f: str, _v: float
+    ) -> None:
+        spec.adapter.refresh_coordinate(coord)
         self.data_changed.emit(self.data)
 
-    def _on_fm_list_changed(self, coord: Coordinate, _f: str, _v: float) -> None:
-        self._fm_display.refresh_coordinate(coord)
-        self.data_changed.emit(self.data)
-
-    def _on_poi_list_changed(self, coord: Coordinate, _f: str, _v: float) -> None:
-        self._fm_display.refresh_coordinate(coord)
-        self.data_changed.emit(self.data)
-
-    def _on_surface_list_changed(self, coord: Coordinate, _f: str, _v: float) -> None:
-        self._fib_canvas.refresh_coordinate(coord)
-        self.data_changed.emit(self.data)
-
-    def _on_fm_surface_list_changed(self, coord: Coordinate, _f: str, _v: float) -> None:
-        self._fm_display.refresh_coordinate(coord)
-        self.data_changed.emit(self.data)
-
-    def _on_fib_list_removed(self, _coord: Coordinate) -> None:
-        self._refresh_fib_canvas()
+    def _on_list_removed(self, spec: _PointTypeSpec, _coord: Coordinate) -> None:
+        if spec.on_cleared is not None:
+            spec.on_cleared()
+        self._refresh_canvas(spec.adapter)
         self._coords_tab.update_headers()
         self.data_changed.emit(self.data)
 
-    def _on_fm_list_removed(self, _coord: Coordinate) -> None:
-        self._refresh_fm_canvas()
-        self._coords_tab.update_headers()
-        self.data_changed.emit(self.data)
-
-    def _on_poi_list_removed(self, _coord: Coordinate) -> None:
-        self._refresh_fm_canvas()
-        self._coords_tab.update_headers()
-        self.data_changed.emit(self.data)
-
-    def _on_surface_list_removed(self, _coord: Coordinate) -> None:
-        self._refresh_fib_canvas()
-        self._coords_tab.update_headers()
-        self.data_changed.emit(self.data)
-
-    def _on_fm_surface_list_removed(self, _coord: Coordinate) -> None:
-        self._clear_pre_correction_factor()
-        self._refresh_fm_canvas()
-        self._coords_tab.update_headers()
+    def _on_list_reordered(self, spec: _PointTypeSpec, _coords: list) -> None:
+        self._refresh_canvas(spec.adapter)
         self.data_changed.emit(self.data)
 
     # ------------------------------------------------------------------
@@ -1841,22 +1758,22 @@ class CorrelationTabWidget(QWidget):
         )
 
         cl = self._coords_tab
+        spec = self._point_specs[coord.point_type]
         x, y, z = coord.point.x, coord.point.y, coord.point.z
         fig = None
 
         try:
-            if coord.point_type in (PointType.FIB, PointType.SURFACE):
+            if spec.side == "fib":
                 method = cl._fib_method_combo.currentText()
                 if method == "Hole" and self._fib_image is not None:
                     xr, yr, fig = hole_fitting_FIB(
                         self._fib_image.filtered_data, int(x), int(y)
                     )
                     coord.point.x, coord.point.y = float(xr), float(yr)
-
-            elif coord.point_type in (PointType.FM, PointType.POI, PointType.SURFACE_FM):
+            else:
                 # The FM surface is typically picked in the reflection channel,
                 # so it shares the fiducial method/channel settings.
-                is_fid = coord.point_type in (PointType.FM, PointType.SURFACE_FM)
+                is_fid = spec.fm_fit_role == "fid"
                 method = (
                     cl._fm_fid_method_combo if is_fid else cl._fm_poi_method_combo
                 ).currentText()
@@ -1881,22 +1798,8 @@ class CorrelationTabWidget(QWidget):
             QMessageBox.warning(self, "Refit failed", str(exc))
             return
 
-        if coord.point_type in (PointType.FIB, PointType.SURFACE):
-            list_w = (
-                cl.fib_list if coord.point_type == PointType.FIB else cl.surface_list
-            )
-            list_w.refresh_coordinate(coord)
-            self._fib_canvas.refresh_coordinate(coord)
-        else:
-            if coord.point_type == PointType.FM:
-                list_w = cl.fm_list
-            elif coord.point_type == PointType.SURFACE_FM:
-                list_w = cl.fm_surface_list
-            else:
-                list_w = cl.poi_list
-            list_w.refresh_coordinate(coord)
-            self._fm_display.refresh_coordinate(coord)
-
+        spec.list_widget.refresh_coordinate(coord)
+        spec.adapter.refresh_coordinate(coord)
         self.data_changed.emit(self.data)
 
         if fig is not None and cl._show_diag_check.isChecked():

--- a/fibsem/correlation/util.py
+++ b/fibsem/correlation/util.py
@@ -781,17 +781,15 @@ def apply_refractive_index_correction(
     Returns:
         corrected_poi: corrected point of interest coordinates (x, y)"""
 
-    # apply correction factor to poi
-    depth = initial_poi[1] - surface_coord[1]  # assume poi always below surface, y-axis
+    from fibsem.correlation.structures import scale_about_surface
 
-    corrected_depth = depth * correction_factor
+    corrected_y = scale_about_surface(initial_poi[1], surface_coord[1], correction_factor)
     logging.info(
-        f"Correction Factor: {correction_factor}, Depth: {depth}, Corrected Depth: {corrected_depth}"
+        f"Correction Factor: {correction_factor}, "
+        f"Depth: {initial_poi[1] - surface_coord[1]}, "
+        f"Corrected Depth: {corrected_y - surface_coord[1]}"
     )
-
-    # update the poi coordinate in poi
-    corrected_poi = (initial_poi[0], surface_coord[1] + corrected_depth)
-    return corrected_poi
+    return (initial_poi[0], corrected_y)
 
 
 

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -352,6 +352,65 @@ def test_registry_add_select_remove_for_every_type(qapp, point_type):
     assert spec.list_widget.coordinates == []
 
 
+def test_canvas_allow_lists_derive_from_registry_map(qapp):
+    """The right-click add menus and the registry share one source of truth."""
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        _POINT_TYPE_SIDES,
+    )
+
+    w = _widget(qapp)
+    fib_expected = [pt for pt, s in _POINT_TYPE_SIDES.items() if s == "fib"]
+    fm_expected = [pt for pt, s in _POINT_TYPE_SIDES.items() if s == "fm"]
+    assert w._fib_canvas._allowed_types == fib_expected
+    assert w._fm_display.canvas._allowed_types == fm_expected
+    # every mapped type has a spec (checked at build time too)
+    assert set(w._point_specs) == set(_POINT_TYPE_SIDES)
+
+
+def test_inconsistent_spec_rejected(qapp):
+    """Specs with mismatched side/adapter/fm_fit_role fail at construction."""
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        _PointTypeSpec,
+    )
+
+    w = _widget(qapp)
+    fib_list = w._coords_tab.fib_list
+
+    # FIB-side type bound to the FM adapter
+    with pytest.raises(ValueError, match="does not match"):
+        _PointTypeSpec(PointType.FIB, fib_list, w._fm_adapter)
+
+    # FIB-side spec with an FM fit role
+    with pytest.raises(ValueError, match="fm_fit_role"):
+        _PointTypeSpec(PointType.FIB, fib_list, w._fib_adapter, fm_fit_role="fid")
+
+    # FM-side spec without a fit role
+    with pytest.raises(ValueError, match="fm_fit_role"):
+        _PointTypeSpec(PointType.POI, w._coords_tab.poi_list, w._fm_adapter)
+
+
+def test_on_cleared_fires_only_when_last_point_removed(qapp):
+    """The lifecycle hook means 'the spec's last point is gone', not
+    'any point was removed' — pinned with a multi-point spec."""
+    from dataclasses import replace
+
+    w = _widget(qapp)
+    fired = []
+    poi_spec = w._point_specs[PointType.POI]
+    w._point_specs[PointType.POI] = replace(
+        poi_spec, on_cleared=lambda: fired.append(True)
+    )
+
+    w._on_canvas_add_requested(1.0, 1.0, PointType.POI)
+    w._on_canvas_add_requested(2.0, 2.0, PointType.POI)
+    first, second = w._point_specs[PointType.POI].list_widget.coordinates
+
+    w._on_canvas_removed(first)
+    assert fired == []  # one point remains
+    w._on_canvas_removed(second)
+    assert fired == [True]  # last point gone
+
+
 def test_unregistered_point_type_fails_loudly(qapp):
     """Routing must never silently misfile a coordinate (old behaviour sent
     unknown types to the POI list)."""

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -59,14 +59,14 @@ def test_fm_surface_add_replaces_fib_surface(qapp):
     w = _widget(qapp)
     cl = w._coords_tab
 
-    w._on_fib_add_requested(1.0, 2.0, PointType.SURFACE)
+    w._on_canvas_add_requested(1.0, 2.0, PointType.SURFACE)
     assert len(cl.surface_list.coordinates) == 1
 
-    w._on_fm_add_requested(3.0, 4.0, PointType.SURFACE_FM)
+    w._on_canvas_add_requested(3.0, 4.0, PointType.SURFACE_FM)
     assert cl.surface_list.coordinates == []
     assert len(cl.fm_surface_list.coordinates) == 1
 
-    w._on_fib_add_requested(5.0, 6.0, PointType.SURFACE)
+    w._on_canvas_add_requested(5.0, 6.0, PointType.SURFACE)
     assert cl.fm_surface_list.coordinates == []
     assert len(cl.surface_list.coordinates) == 1
 
@@ -74,8 +74,8 @@ def test_fm_surface_add_replaces_fib_surface(qapp):
 def test_fm_surface_add_is_max_one(qapp):
     w = _widget(qapp)
     cl = w._coords_tab
-    w._on_fm_add_requested(1.0, 1.0, PointType.SURFACE_FM)
-    w._on_fm_add_requested(2.0, 2.0, PointType.SURFACE_FM)
+    w._on_canvas_add_requested(1.0, 1.0, PointType.SURFACE_FM)
+    w._on_canvas_add_requested(2.0, 2.0, PointType.SURFACE_FM)
     assert len(cl.fm_surface_list.coordinates) == 1
     assert cl.fm_surface_list.coordinates[0].point.x == pytest.approx(2.0)
 
@@ -99,7 +99,7 @@ def test_set_data_prefers_fm_surface_when_both_present(qapp):
 
 def test_data_includes_fm_surface_and_factor(qapp):
     w = _widget(qapp)
-    w._on_fm_add_requested(3.0, 4.0, PointType.SURFACE_FM)
+    w._on_canvas_add_requested(3.0, 4.0, PointType.SURFACE_FM)
     w._ri_pre_correction_factor = 1.33
     d = w.data
     assert d.fm_surface_coordinate is not None
@@ -128,11 +128,11 @@ def test_ri_tab_mode_follows_surface_type(qapp):
     tab = w._ri_tab
     assert tab.mode is None
 
-    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+    w._on_canvas_add_requested(1.0, 200.0, PointType.SURFACE)
     assert tab.mode == "post"
     assert not tab._chk_rerun.isVisible()
 
-    w._on_fm_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    w._on_canvas_add_requested(1.0, 2.0, PointType.SURFACE_FM)
     assert tab.mode == "pre"
 
 
@@ -142,12 +142,12 @@ def test_tilt_locked_to_zero_in_pre_mode(qapp):
     default_tilt = spin_tilt.value()
     assert default_tilt == pytest.approx(15.0)
 
-    w._on_fm_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    w._on_canvas_add_requested(1.0, 2.0, PointType.SURFACE_FM)
     assert spin_tilt.value() == pytest.approx(0.0)
     assert not spin_tilt.isEnabled()
 
     # removing the FM surface (via replacing with a FIB surface) unlocks tilt
-    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+    w._on_canvas_add_requested(1.0, 200.0, PointType.SURFACE)
     assert spin_tilt.value() == pytest.approx(default_tilt)
 
 
@@ -157,9 +157,9 @@ def test_tilt_locked_to_zero_in_pre_mode(qapp):
 
 
 def _setup_pre_mode(w):
-    w._on_fm_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    w._on_canvas_add_requested(1.0, 2.0, PointType.SURFACE_FM)
     w._coords_tab.fm_surface_list.coordinates[0].point.z = 10.0
-    w._on_fm_add_requested(5.0, 6.0, PointType.POI)
+    w._on_canvas_add_requested(5.0, 6.0, PointType.POI)
     w._coords_tab.poi_list.coordinates[0].point.z = 30.0
     w.data_changed.emit(w.data)  # refresh RI tab with the edited z values
 
@@ -237,7 +237,7 @@ def test_status_line_shows_pre_correction_after_run(qapp):
 
 def test_apply_post_creates_ghost_and_status(qapp):
     w = _widget(qapp)
-    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+    w._on_canvas_add_requested(1.0, 200.0, PointType.SURFACE)
 
     result = CorrelationResult(
         poi=[CorrelationPointOfInterest(image_px=Point(x=100.0, y=300.0))],
@@ -259,7 +259,7 @@ def test_apply_post_creates_ghost_and_status(qapp):
 
 def test_apply_post_blocked_when_already_corrected(qapp):
     w = _widget(qapp)
-    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+    w._on_canvas_add_requested(1.0, 200.0, PointType.SURFACE)
 
     result = CorrelationResult(
         poi=[CorrelationPointOfInterest(image_px=Point(x=100.0, y=300.0))],
@@ -281,7 +281,7 @@ def test_apply_post_blocked_when_already_corrected(qapp):
 def test_apply_post_without_input_data_shows_warning(qapp):
     """A result JSON with input_data: null must warn, not crash."""
     w = _widget(qapp)
-    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+    w._on_canvas_add_requested(1.0, 200.0, PointType.SURFACE)
 
     result = CorrelationResult(
         poi=[CorrelationPointOfInterest(image_px=Point(x=100.0, y=300.0))],
@@ -301,23 +301,66 @@ def test_factor_cleared_when_fm_surface_removed(qapp):
 
     # canvas removal
     coord = w._coords_tab.fm_surface_list.coordinates[0]
-    w._on_fm_canvas_removed(coord)
+    w._on_canvas_removed(coord)
     assert w._ri_pre_correction_factor is None
     assert w.data.ri_pre_correction_factor is None
 
     # replacement by a FIB surface
-    w._on_fm_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    w._on_canvas_add_requested(1.0, 2.0, PointType.SURFACE_FM)
     w._ri_pre_correction_factor = 1.5
-    w._on_fib_add_requested(1.0, 200.0, PointType.SURFACE)
+    w._on_canvas_add_requested(1.0, 200.0, PointType.SURFACE)
     assert w._ri_pre_correction_factor is None
 
-    # list-row removal
-    w._on_fm_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    # list-row removal (generic handler bound to the SURFACE_FM spec)
+    w._on_canvas_add_requested(1.0, 2.0, PointType.SURFACE_FM)
     w._ri_pre_correction_factor = 1.5
     coord = w._coords_tab.fm_surface_list.coordinates[0]
     w._coords_tab.fm_surface_list.coordinates = []
-    w._on_fm_surface_list_removed(coord)
+    w._on_list_removed(w._point_specs[PointType.SURFACE_FM], coord)
     assert w._ri_pre_correction_factor is None
+
+
+# ---------------------------------------------------------------------------
+# Point-type registry — generic behaviour for every registered type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("point_type", list(PointType))
+def test_registry_add_select_remove_for_every_type(qapp, point_type):
+    """Every registered point type gets identical add/select/remove plumbing —
+    a new point type only needs a registry entry to inherit all of this."""
+    w = _widget(qapp)
+    spec = w._point_specs[point_type]
+
+    w._on_canvas_add_requested(3.0, 4.0, point_type)
+    assert len(spec.list_widget.coordinates) == 1
+    coord = spec.list_widget.coordinates[0]
+    assert coord.point_type is point_type
+
+    # selecting via the canvas clears every other list's selection
+    w._on_canvas_selected(coord)
+    for other in w._point_specs.values():
+        if other is not spec:
+            assert other.list_widget.selected_coordinate is None
+
+    # moving routes to the owning list without error
+    coord.point.x = 7.0
+    w._on_canvas_moved(coord)
+
+    # removal empties the owning list
+    w._on_canvas_removed(coord)
+    assert spec.list_widget.coordinates == []
+
+
+def test_unregistered_point_type_fails_loudly(qapp):
+    """Routing must never silently misfile a coordinate (old behaviour sent
+    unknown types to the POI list)."""
+    w = _widget(qapp)
+    w._point_specs.pop(PointType.POI)  # simulate an unregistered type
+    with pytest.raises(KeyError):
+        w._on_canvas_add_requested(1.0, 2.0, PointType.POI)
+    with pytest.raises(KeyError):
+        w._on_canvas_moved(_coord(pt=PointType.POI))
 
 
 def test_set_data_does_not_arm_factor_without_fm_surface(qapp):


### PR DESCRIPTION
Follow-up to #139 (review finding 10). **Stacked on the #139 branch** — based there so the diff shows only the registry work; retargets to main automatically when #139 merges. Draft until then.

## Summary

Replaces the five hand-copied per-point-type plumbing stacks in `CorrelationTabWidget` with a declarative registry. Behaviour-preserving; widget net −97 lines.

- **`_PointTypeSpec` registry**: each point type declares its list widget, canvas adapter, side, replace-on-add semantics, exclusive group, refit role, and an `on_cleared` lifecycle hook. Adding a point type = one spec entry (it previously took ~10 scattered edits).
- **Generic handlers**: 4 canvas + 4 list handlers replace the 23 per-type ones; the five signal-wiring blocks become one loop; selection clearing and canvas refresh iterate the registry.
- **Single exclusivity chokepoint** (`_clear_exclusive_siblings`); the pre-correction-factor disarm rides the SURFACE_FM spec's `on_cleared` hook instead of three remembered call sites. Semantics unchanged (FIB-surface add disarms; FM-surface replace keeps the factor).
- **Loud failure**: unregistered point types raise `KeyError` instead of being silently misrouted into the POI list.
- **`_CanvasAdapter` seam (PR #111 prep)**: handlers never touch the canvases directly, so the planned migration onto the shared canvas stack (`fibsem/ui/widgets/canvas`) only replaces the two adapters — handlers, exclusivity, and lifecycle logic survive untouched.
- **Formula dedup**: `scale_about_surface()` in structures.py is now the single implementation of the RI depth-scaling formula (engine array correction, post-correction model method, util tuple helper, both RI-tab preview tables).

## Testing

- 79 pytest tests pass; existing widget tests updated to the generic entry points, plus a new parametrized per-type behaviour sweep (add/select/move/remove for every registered type) and a loud-failure routing test.
- End-to-end ground-truth check and offscreen visual render are identical pre/post refactor.
- Live-tested in the GUI (add/select/drag/delete/reorder/refit across all five types, surface exclusivity both directions, factor lifecycle, save/load).