### PR TITLE
test+fix: integer field round-trip in pattern settings widget

### DIFF
--- a/fibsem/ui/widgets/pattern_settings_widget.py
+++ b/fibsem/ui/widgets/pattern_settings_widget.py
@@ -295,9 +295,16 @@ class FibsemPatternSettingsWidget(QWidget):
                 data = row.control.value()
                 if data is not None:
                     setattr(pattern, row.field, data)
-            elif isinstance(row.control, (ValueSpinBox, IntegerValueSpinBox)):
+            elif isinstance(row.control, ValueSpinBox):
                 val = row.control.value()
                 setattr(pattern, row.field, val / row.scale if row.scale else val)
+            elif isinstance(row.control, IntegerValueSpinBox):
+                val = row.control.value()
+                setattr(
+                    pattern,
+                    row.field,
+                    int(round(val / row.scale if row.scale else val)),
+                )
             elif isinstance(row.control, QCheckBox):
                 setattr(pattern, row.field, row.control.isChecked())
             elif isinstance(row.control, QFilePathLineEdit):

--- a/tests/ui/test_settings_widgets_integer.py
+++ b/tests/ui/test_settings_widgets_integer.py
@@ -1,0 +1,85 @@
+"""Headless tests for integer handling in the pattern/strategy settings widgets.
+
+Guards the contract that a metadata-declared ``int`` field round-trips through
+the GUI as a Python ``int`` (not a ``float``). Regression coverage for the class
+of bug where ``get_pattern`` / ``get_strategy`` leaked floats into strategies
+that expect integers.
+
+Uses PyQt5 directly with the offscreen platform (no pytest-qt dependency).
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem import utils
+from fibsem.milling.patterning import get_pattern
+from fibsem.ui.widgets.custom_widgets import IntegerValueSpinBox
+from fibsem.ui.widgets.pattern_settings_widget import FibsemPatternSettingsWidget
+
+# ArrayPattern exposes several integer fields (n_columns, n_rows, passes) with
+# no scale, which is exactly the path that regressed.
+_INT_FIELDS = {"n_columns": 7, "n_rows": 3, "passes": 4}
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    return microscope
+
+
+def _array_pattern(**overrides):
+    pattern = get_pattern("ArrayPattern")
+    for field, value in overrides.items():
+        setattr(pattern, field, value)
+    return pattern
+
+
+def _row(widget, field):
+    return next(row for row in widget._rows if getattr(row, "field", None) == field)
+
+
+def test_integer_fields_use_integer_spinbox(qapp, microscope):
+    widget = FibsemPatternSettingsWidget(microscope=microscope, pattern=_array_pattern())
+    for field in _INT_FIELDS:
+        assert isinstance(_row(widget, field).control, IntegerValueSpinBox), field
+
+
+def test_get_pattern_returns_int_not_float(qapp, microscope):
+    """The core regression: integer fields must come back as ``int``."""
+    widget = FibsemPatternSettingsWidget(
+        microscope=microscope, pattern=_array_pattern(**_INT_FIELDS)
+    )
+    result = widget.get_pattern()
+    for field, expected in _INT_FIELDS.items():
+        value = getattr(result, field)
+        assert type(value) is int, f"{field} came back as {type(value).__name__}"
+        assert value == expected
+
+
+def test_set_pattern_roundtrip_preserves_int(qapp, microscope):
+    widget = FibsemPatternSettingsWidget(microscope=microscope, pattern=_array_pattern())
+    widget.set_pattern(_array_pattern(n_columns=9, n_rows=2, passes=6))
+    result = widget.get_pattern()
+    assert (type(result.n_columns), result.n_columns) == (int, 9)
+    assert (type(result.n_rows), result.n_rows) == (int, 2)
+    assert (type(result.passes), result.passes) == (int, 6)
+
+
+def test_float_fields_remain_float(qapp, microscope):
+    """Guard against over-correcting float controls into ints."""
+    widget = FibsemPatternSettingsWidget(microscope=microscope, pattern=_array_pattern())
+    result = widget.get_pattern()
+    assert isinstance(result.width, float)
+    assert isinstance(result.height, float)


### PR DESCRIPTION
Stacked on **#128** (`fix-integer-controls`). Base branch `pr128-integer-controls-base` is a snapshot of #128's head so this PR shows only the delta — retarget to `main` once #128 merges, then delete the base branch.

## What this adds

**Regression test** — `tests/ui/test_settings_widgets_integer.py`

Guards that metadata-declared `int` fields round-trip through the settings widgets as Python `int`, not `float` — the exact class of bug #128 exists to fix. Builds `FibsemPatternSettingsWidget` for an `ArrayPattern` (`n_columns` / `n_rows` / `passes`) and asserts:

- int fields get an `IntegerValueSpinBox` control
- `get_pattern()` returns them as `int`
- a `set_pattern()` → `get_pattern()` round-trip preserves `int`
- float fields (`width` / `height`) stay `float` (no over-correction)

Headless, offscreen Qt, no `pytest-qt` dependency — mirrors `tests/fm/test_autofocus_widget.py`.

**Fix** — `get_pattern()` in the pattern settings widget

On #128's head, `get_pattern` groups `IntegerValueSpinBox` with `ValueSpinBox`:

```python
setattr(pattern, row.field, val / row.scale if row.scale else val)
```

`val` is an `int`, but `/` is true division, so `5 / 1 == 5.0` — integer fields leak back as floats (even at scale 1), re-introducing the bug. Split into its own branch with `int(round(...))`, mirroring `get_strategy` in the strategy widget.

The two are separate commits, so the fix can be dropped if you'd rather it land directly in #128 (see the inline review comment there).

## Verification

Run with the project env + offscreen Qt:

```
QT_QPA_PLATFORM=offscreen pytest tests/ui/test_settings_widgets_integer.py
```

- Test commit alone (on #128 head): 2 fail — `n_columns` comes back as `7.0`
- With the fix commit: 4 pass
