### PR TITLE
FM: recover OME metadata from files with <Channel><Filter/></Channel>

### DIFF
--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -117,16 +118,17 @@ def safe_ome_from_tiff(filename: str) -> OMEMetadata:
         # Attempt to read OME metadata directly from the TIFF file
         ome = from_tiff(filename)
     except Exception as e:
-        if "Filter" in str(e):
-            # read xml description from the file
-            with tff.TiffFile(filename) as tif:
-                ome_xml = tif.pages[0].tags["ImageDescription"].value
-
-                # Filter should be FilterSetRef, drop for now
-                start = ome_xml.find("<Filter")
-                end = ome_xml.find("/>", start) + 2
-                ome_xml = ome_xml[:start] + ome_xml[end:]
-                ome = from_xml(ome_xml)
+        if "Filter" not in str(e):
+            raise
+        # Some microscopes emit <Channel><Filter .../></Channel>, which the OME
+        # schema rejects ("Unknown property Channel:Filter"). Strip every
+        # self-closing <Filter .../> element (there is one per channel — a naive
+        # single find() drops only the first and re-throws) then re-parse, so the
+        # real PhysicalSize/channel metadata is preserved instead of discarded.
+        with tff.TiffFile(filename) as tif:
+            ome_xml = tif.pages[0].tags["ImageDescription"].value
+        ome_xml = re.sub(r"<Filter\b[^>]*/>", "", ome_xml)
+        ome = from_xml(ome_xml)
     return ome
 
 @dataclass

--- a/tests/fm/test_structures.py
+++ b/tests/fm/test_structures.py
@@ -642,6 +642,47 @@ def test_fluorescence_image_load_fallback():
             os.unlink(filename)
 
 
+def test_safe_ome_from_tiff_strips_channel_filters():
+    """OME files with <Channel><Filter/></Channel> (rejected by the schema)
+    must still load their real PhysicalSize instead of falling back to the 1µm
+    default. Regression: the naive single-find strip dropped only the first of
+    multiple channels' Filter elements and re-threw, discarding all metadata.
+    """
+    import os
+
+    import tifffile
+
+    from fibsem.fm.structures import safe_ome_from_tiff
+
+    # Two channels, each with the schema-invalid nested <Filter/> (real METEOR
+    # export shape), and a real PhysicalSizeX of 0.13 µm.
+    ome_xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06">'
+        '<Image ID="Image:0"><Pixels ID="Pixels:0" DimensionOrder="XYCZT" '
+        'Type="uint8" SizeX="4" SizeY="4" SizeC="2" SizeZ="1" SizeT="1" '
+        'PhysicalSizeX="0.13" PhysicalSizeY="0.13">'  # unit defaults to µm
+        '<Channel ID="Channel:0:0" SamplesPerPixel="1">'
+        '<Filter ID="Filter:0:0" Type="pass-through" /></Channel>'
+        '<Channel ID="Channel:0:1" SamplesPerPixel="1">'
+        '<Filter ID="Filter:0:1" Type="pass-through" /></Channel>'
+        '<TiffData /></Pixels></Image></OME>'
+    )
+    data = np.zeros((2, 4, 4), dtype=np.uint8)
+
+    with tempfile.NamedTemporaryFile(suffix=".ome.tiff", delete=False) as f:
+        filename = f.name
+    try:
+        tifffile.imwrite(filename, data, description=ome_xml)
+        ome = safe_ome_from_tiff(filename)
+        px = ome.images[0].pixels
+        assert px.physical_size_x == pytest.approx(0.13)
+        assert len(px.channels) == 2  # both channels survive the strip
+    finally:
+        if os.path.exists(filename):
+            os.unlink(filename)
+
+
 def test_fluorescence_image_multi_channel_stacking():
     """Test multi-channel image creation."""
     # Create individual channel images


### PR DESCRIPTION
## Summary

Some microscopes (e.g. METEOR) write a nested `<Filter .../>` inside each `<Channel>`, which the OME schema rejects (`Unknown property Channel:Filter`). `safe_ome_from_tiff` already tried to work around this by stripping `<Filter>`, but it used a single `find()` that removed only the **first** channel's Filter — the second one re-threw, so `FluorescenceImage.load` caught the error and fell all the way back to `_create_basic_metadata`, which hardcodes **1µm/px**.

For a real 3-channel FM file whose true `PhysicalSizeX` is **0.13µm**, this made every downstream scale wrong by **~7.7×** (surfaced as a visibly wrong scalebar in the correlation FM view) and left `pixel_size_z` as `None`.

## Fix

- Strip **every** self-closing `<Filter .../>` with a regex, then re-parse — so the real `PhysicalSize`/channel metadata is preserved instead of discarded.
- Re-raise parse errors that aren't Filter-related, rather than silently returning bad metadata.

## Verification

- Against the real file: `pixel_size_x` 1e-6 → **1.3e-7 m**, `pixel_size_z` now **5e-7 m** (was `None`).
- New regression test builds a two-channel `Channel/Filter` OME-TIFF and asserts the pixel size and both channels survive.

Found while investigating a wrong FM scalebar in the correlation widget; the correlation-side UI work is a separate PR.