### PR TITLE
Correlation widget: UX polish + result-state correctness fixes

### DIFF
--- a/fibsem/correlation/ui/widgets/coordinate_list_widget.py
+++ b/fibsem/correlation/ui/widgets/coordinate_list_widget.py
@@ -36,8 +36,8 @@ _DRAG_HANDLE_PATH = os.path.join(
 
 _NAME_FIXED_WIDTH = 100
 _SPIN_FIXED_WIDTH = 75
-_BTN_SIZE = QSize(32, 32)
-_ROW_HEIGHT = 40
+_BTN_SIZE = QSize(24, 24)
+_ROW_HEIGHT = 28
 # Spacer in header aligning with drag handle in rows (layout spacing handles the 4px gap)
 _ROW_RIGHT_WIDTH = 10
 
@@ -115,7 +115,7 @@ class _CoordinateListHeader(QWidget):
 
         def _lbl(text: str, width: Optional[int] = None) -> QLabel:
             lbl = QLabel(text)
-            lbl.setStyleSheet("color: #aaa; font-size: 11px; background: transparent;")
+            lbl.setStyleSheet("color: #aaa; font-size: 10px; background: transparent;")
             if width is not None:
                 lbl.setFixedWidth(width)
             return lbl
@@ -192,14 +192,14 @@ class CoordinateRowWidget(QWidget):
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
 
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(6, 3, 6, 3)
+        layout.setContentsMargins(6, 1, 6, 1)
         layout.setSpacing(4)
 
         # Name label (read-only)
         self.name_label = QLabel(name)
         self.name_label.setFixedWidth(_NAME_FIXED_WIDTH)
         self.name_label.setStyleSheet(
-            "color: #F0F1F2; background: transparent; font-size: 12px;"
+            "color: #F0F1F2; background: transparent; font-size: 11px;"
         )
         self.name_label.setToolTip("Auto-generated coordinate name")
         layout.addWidget(self.name_label)
@@ -219,6 +219,10 @@ class CoordinateRowWidget(QWidget):
         self.z_spin.setFixedWidth(_SPIN_FIXED_WIDTH)
         self.z_spin.setToolTip("Z coordinate")
         layout.addWidget(self.z_spin)
+
+        # Compact number font + padding so the rows stay short
+        for _spin in (self.x_spin, self.y_spin, self.z_spin):
+            _spin.setStyleSheet("font-size: 11px; padding: 1px 6px;")
 
         layout.addStretch(1)
 

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -53,7 +53,6 @@ from PyQt5.QtWidgets import (
     QHBoxLayout,
     QHeaderView,
     QLabel,
-    QLineEdit,
     QMenuBar,
     QMessageBox,
     QPushButton,
@@ -82,7 +81,11 @@ from fibsem.correlation.ui.widgets.fm_image_display_widget import FMImageDisplay
 from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
 from fibsem.fm.structures import FluorescenceImage
 from fibsem.structures import FibsemImage
-from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.ui.widgets.custom_widgets import (
+    QDirectoryLineEdit,
+    QFileLineEdit,
+    TitledPanel,
+)
 from fibsem.correlation.ui.widgets.refractive_index_widget import RefractiveIndexWidget
 
 _FIT_METHODS = ["None", "Hole", "Gaussian"]
@@ -152,6 +155,10 @@ class _ImagesTab(QWidget):
         super().__init__(parent)
         self._fib_image: Optional[FibsemImage] = None
         self._fm_image: Optional[FluorescenceImage] = None
+        # Last path successfully loaded / shown per field — suppresses reloads
+        # when the editable path widget re-emits editingFinished (focus-out).
+        self._fib_loaded_path: str = ""
+        self._fm_loaded_path: str = ""
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -164,13 +171,9 @@ class _ImagesTab(QWidget):
         proj_layout = QHBoxLayout(proj_body)
         proj_layout.setContentsMargins(8, 4, 8, 4)
         proj_layout.setSpacing(4)
-        self._btn_proj = QPushButton("Browse…")
-        self._btn_proj.setFixedWidth(80)
-        self._btn_proj.clicked.connect(self._browse_project_dir)
-        self._proj_path = QLineEdit()
-        self._proj_path.setReadOnly(True)
-        self._proj_path.setPlaceholderText("No project directory set")
-        proj_layout.addWidget(self._btn_proj)
+        self._proj_path = QDirectoryLineEdit()
+        self._proj_path.lineEdit.setPlaceholderText("No project directory set")
+        self._proj_path.editingFinished.connect(self._on_project_dir_edited)
         proj_layout.addWidget(self._proj_path, stretch=1)
         layout.addWidget(TitledPanel("Project", content=proj_body, collapsible=False))
 
@@ -180,19 +183,10 @@ class _ImagesTab(QWidget):
         fib_layout.setContentsMargins(8, 4, 8, 4)
         fib_layout.setSpacing(4)
 
-        fib_browse_row = QWidget()
-        fib_browse_layout = QHBoxLayout(fib_browse_row)
-        fib_browse_layout.setContentsMargins(0, 0, 0, 0)
-        fib_browse_layout.setSpacing(4)
-        self._btn_fib = QPushButton("Browse…")
-        self._btn_fib.setFixedWidth(80)
-        self._btn_fib.clicked.connect(self._browse_fib)
-        self._fib_path = QLineEdit()
-        self._fib_path.setReadOnly(True)
-        self._fib_path.setPlaceholderText("No file loaded")
-        fib_browse_layout.addWidget(self._btn_fib)
-        fib_browse_layout.addWidget(self._fib_path, stretch=1)
-        fib_layout.addWidget(fib_browse_row)
+        self._fib_path = QFileLineEdit(filter="TIFF (*.tif *.tiff);;All Files (*)")
+        self._fib_path.lineEdit.setPlaceholderText("No file loaded")
+        self._fib_path.editingFinished.connect(self._on_fib_path_edited)
+        fib_layout.addWidget(self._fib_path)
 
         fib_form = QFormLayout()
         fib_form.setContentsMargins(0, 0, 0, 0)
@@ -213,19 +207,12 @@ class _ImagesTab(QWidget):
         fm_layout.setContentsMargins(8, 4, 8, 4)
         fm_layout.setSpacing(4)
 
-        fm_browse_row = QWidget()
-        fm_browse_layout = QHBoxLayout(fm_browse_row)
-        fm_browse_layout.setContentsMargins(0, 0, 0, 0)
-        fm_browse_layout.setSpacing(4)
-        self._btn_fm = QPushButton("Browse…")
-        self._btn_fm.setFixedWidth(80)
-        self._btn_fm.clicked.connect(self._browse_fm)
-        self._fm_path = QLineEdit()
-        self._fm_path.setReadOnly(True)
-        self._fm_path.setPlaceholderText("No file loaded")
-        fm_browse_layout.addWidget(self._btn_fm)
-        fm_browse_layout.addWidget(self._fm_path, stretch=1)
-        fm_layout.addWidget(fm_browse_row)
+        self._fm_path = QFileLineEdit(
+            filter="OME-TIFF (*.ome.tiff *.ome.tif);;TIFF (*.tif *.tiff);;All Files (*)"
+        )
+        self._fm_path.lineEdit.setPlaceholderText("No file loaded")
+        self._fm_path.editingFinished.connect(self._on_fm_path_edited)
+        fm_layout.addWidget(self._fm_path)
 
         fm_form = QFormLayout()
         fm_form.setContentsMargins(0, 0, 0, 0)
@@ -234,6 +221,7 @@ class _ImagesTab(QWidget):
         self._lbl_fm_shape.setStyleSheet("color: #e0e0e0; font-size: 11px;")
         self._lbl_fm_ch = QLabel("—")
         self._lbl_fm_ch.setStyleSheet("color: #e0e0e0; font-size: 11px;")
+        self._lbl_fm_ch.setWordWrap(True)
         self._lbl_fm_z = QLabel("—")
         self._lbl_fm_z.setStyleSheet("color: #e0e0e0; font-size: 11px;")
         fm_form.addRow("Shape (C×Z×Y×X):", self._lbl_fm_shape)
@@ -248,10 +236,9 @@ class _ImagesTab(QWidget):
     # Browse / load
     # ------------------------------------------------------------------
 
-    def _browse_project_dir(self) -> None:
-        path = QFileDialog.getExistingDirectory(self, "Select Project Directory", "")
+    def _on_project_dir_edited(self) -> None:
+        path = self._proj_path.text().strip()
         if path:
-            self._proj_path.setText(path)
             self.project_dir_changed.emit(path)
 
     @property
@@ -259,11 +246,10 @@ class _ImagesTab(QWidget):
         p = self._proj_path.text().strip()
         return p if p else None
 
-    def _browse_fib(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Open FIB Image", "", "TIFF (*.tif *.tiff);;All Files (*)"
-        )
-        if path:
+    def _on_fib_path_edited(self) -> None:
+        # Fires on browse-pick and manual entry; skip programmatic/no-op sets
+        path = self._fib_path.text().strip()
+        if path and path != self._fib_loaded_path:
             self._load_fib(path)
 
     def _load_fib(self, path: str) -> None:
@@ -273,7 +259,8 @@ class _ImagesTab(QWidget):
             QMessageBox.warning(self, "Load error", str(exc))
             return
         self._fib_image = image
-        self._fib_path.setText(path)
+        self._fib_loaded_path = path
+        self._fib_path.setText(path)  # setText → textChanged only, no reload
         h, w = image.data.shape[:2]
         self._lbl_fib_shape.setText(f"{h} × {w}")
         px = getattr(
@@ -282,14 +269,9 @@ class _ImagesTab(QWidget):
         self._lbl_fib_px.setText(f"{px * 1e9:.2f} nm" if px else "—")
         self.fib_image_changed.emit(image)
 
-    def _browse_fm(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(
-            self,
-            "Open FM Image",
-            "",
-            "OME-TIFF (*.ome.tiff *.ome.tif);;TIFF (*.tif *.tiff);;All Files (*)",
-        )
-        if path:
+    def _on_fm_path_edited(self) -> None:
+        path = self._fm_path.text().strip()
+        if path and path != self._fm_loaded_path:
             self._load_fm(path)
 
     def _load_fm(self, path: str) -> None:
@@ -299,6 +281,7 @@ class _ImagesTab(QWidget):
             QMessageBox.warning(self, "Load error", str(exc))
             return
         self._fm_image = image
+        self._fm_loaded_path = path
         self._fm_path.setText(path)
         c, z, h, w = image.data.shape
         self._lbl_fm_shape.setText(f"{c} × {z} × {h} × {w}")
@@ -324,6 +307,7 @@ class _ImagesTab(QWidget):
             )
             or ""
         )
+        self._fib_loaded_path = filename
         self._fib_path.setText(filename)
         h, w = image.data.shape[:2]
         self._lbl_fib_shape.setText(f"{h} × {w}")
@@ -335,6 +319,7 @@ class _ImagesTab(QWidget):
     def set_fm_image(self, image: FluorescenceImage) -> None:
         self._fm_image = image
         filename = getattr(image.metadata, "filename", "") or ""
+        self._fm_loaded_path = filename
         self._fm_path.setText(filename)
         c, z, h, w = image.data.shape
         self._lbl_fm_shape.setText(f"{c} × {z} × {h} × {w}")
@@ -1299,7 +1284,7 @@ class CorrelationTabWidget(QWidget):
         """Load FM image into canvas and update images tab."""
         self._fm_image = fm_image
         self._fm_display.set_fm_image(fm_image)
-        px = getattr(fm_image.metadata, "pixel_size_x", None)
+        px = self._effective_fm_pixel_size(fm_image)
         if px:
             self._fm_display.canvas.set_pixel_size(px)
         _, n_z, h, w = fm_image.data.shape
@@ -1310,6 +1295,34 @@ class CorrelationTabWidget(QWidget):
                 )
         self._coords_tab.rebuild_channel_combos(fm_image)
         self._images_tab.set_fm_image(fm_image)
+
+    @staticmethod
+    def _effective_fm_pixel_size(fm_image: FluorescenceImage) -> Optional[float]:
+        """Pixel size (m) for the FM scalebar, corrected for any display resize.
+
+        ``metadata.pixel_size_x`` describes one pixel at the acquisition
+        resolution (``metadata.resolution``). If the displayed data array was
+        resized (e.g. binned/downscaled) without rewriting the metadata, the
+        two disagree and the raw value over/under-scales the scalebar by the
+        resize ratio — so scale it to the displayed width. A no-op when the
+        metadata matches the data (the correctly-authored case).
+        """
+        meta = getattr(fm_image, "metadata", None)
+        px = getattr(meta, "pixel_size_x", None)
+        if not px:
+            return None
+        data_w = fm_image.data.shape[3]
+        res = getattr(meta, "resolution", None)
+        acq_w = res[0] if res else None
+        if acq_w and data_w and acq_w != data_w:
+            corrected = px * acq_w / data_w
+            logging.warning(
+                "FM scalebar: data width %d ≠ metadata resolution %d — pixel "
+                "size corrected %.1f→%.1f nm/px for the display resize.",
+                data_w, acq_w, px * 1e9, corrected * 1e9,
+            )
+            return corrected
+        return px
 
     def set_project_dir(self, path: str) -> None:
         """Set the project directory used for auto-save and export."""

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -1053,7 +1053,7 @@ class CorrelationTabWidget(QWidget):
 
         self._setup_ui()
         self._connect_signals()
-        self._btn_continue.setEnabled(False)
+        self._set_result_live(False)
 
         if fib_image is not None:
             self.set_fib_image(fib_image)
@@ -1298,7 +1298,32 @@ class CorrelationTabWidget(QWidget):
         self.data_changed.connect(self._update_run_button)
         self.data_changed.connect(self._on_data_changed)
 
+    def _set_result_live(self, live: bool) -> None:
+        """Reflect whether the displayed result still describes the current points.
+
+        Continue commits ``result.poi[0].px_m`` to the protocol editor, so it must
+        not stay armed once an edit has invalidated the fit. The RMS badge and the
+        Run/Continue emphasis answer that same question, so they move together
+        here rather than drifting apart across handlers.
+        """
+        self._btn_continue.setEnabled(live)
+        self._btn_continue.setStyleSheet(
+            stylesheets.PRIMARY_BUTTON_STYLESHEET
+            if live
+            else stylesheets.SECONDARY_BUTTON_STYLESHEET
+        )
+        self._btn_run.setStyleSheet(
+            stylesheets.SECONDARY_BUTTON_STYLESHEET
+            if live
+            else stylesheets.PRIMARY_BUTTON_STYLESHEET
+        )
+        if not live:
+            self._lbl_result.setVisible(False)  # text is set again by a fresh run
+
     def _on_data_changed(self, data: CorrelationInputData) -> None:
+        # Any coordinate edit invalidates the last run: the transform no longer
+        # fits the points it is displayed against.
+        self._set_result_live(False)
         self._ri_tab.set_result(
             self._result,
             input_data=data,
@@ -1546,7 +1571,8 @@ class CorrelationTabWidget(QWidget):
             self._worker = None
         self._btn_run.setEnabled(False)
         self._lbl_status.setText("Running…")
-        self._lbl_result.setVisible(False)
+        # a run in flight has no live result yet; a failed run leaves it that way
+        self._set_result_live(False)
         self._worker = _CorrelationWorker(copy.deepcopy(self.data))
         self._worker.result_ready.connect(self._on_result_ready)
         self._worker.errored.connect(self._on_run_error)
@@ -1560,7 +1586,7 @@ class CorrelationTabWidget(QWidget):
         )
         self._tabs.setTabEnabled(3, True)
         self._overlay_result_on_fib(result)
-        self._btn_continue.setEnabled(True)
+        self._set_result_live(True)
         # after _update_run_button, which would otherwise overwrite it with "Ready."
         self._update_run_button()
         # RMS beside Continue (quality-coloured); compact RI / POI note on status.

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -46,7 +46,6 @@ from PyQt5.QtCore import Qt, QThread, pyqtSignal
 from PyQt5.QtWidgets import (
     QCheckBox,
     QAction,
-    QComboBox,
     QDialog,
     QFileDialog,
     QFormLayout,
@@ -90,6 +89,7 @@ from fibsem.ui.widgets.custom_widgets import (
     QDirectoryLineEdit,
     QFileLineEdit,
     TitledPanel,
+    ValueComboBox,
 )
 from fibsem.correlation.ui.widgets.refractive_index_widget import RefractiveIndexWidget
 
@@ -441,25 +441,23 @@ class _CoordinatesTab(QWidget):
         fit_form.setContentsMargins(8, 4, 8, 4)
         fit_form.setSpacing(4)
 
-        self._fib_method_combo = QComboBox()
-        self._fib_method_combo.addItems(_FIT_METHODS)
-        self._fib_method_combo.setCurrentText("Hole")
+        # ValueComboBox installs a WheelBlocker, so scrolling this panel can't
+        # silently change a fit setting on the way past. The channel combos start
+        # empty and are refilled by rebuild_channel_combos — the blocker lives on
+        # the widget, so it survives clear()/addItem().
+        self._fib_method_combo = ValueComboBox(_FIT_METHODS, value="Hole")
         fit_form.addRow("FIB method:", self._fib_method_combo)
 
-        self._fm_fid_method_combo = QComboBox()
-        self._fm_fid_method_combo.addItems(_FIT_METHODS)
-        self._fm_fid_method_combo.setCurrentText("None")
+        self._fm_fid_method_combo = ValueComboBox(_FIT_METHODS, value="None")
         fit_form.addRow("FM Fid. method:", self._fm_fid_method_combo)
 
-        self._fm_poi_method_combo = QComboBox()
-        self._fm_poi_method_combo.addItems(_FIT_METHODS)
-        self._fm_poi_method_combo.setCurrentText("Gaussian")
+        self._fm_poi_method_combo = ValueComboBox(_FIT_METHODS, value="Gaussian")
         fit_form.addRow("FM POI method:", self._fm_poi_method_combo)
 
-        self._fm_fid_ch_combo = QComboBox()
+        self._fm_fid_ch_combo = ValueComboBox([])
         fit_form.addRow("FM Fid. channel:", self._fm_fid_ch_combo)
 
-        self._fm_poi_ch_combo = QComboBox()
+        self._fm_poi_ch_combo = ValueComboBox([])
         fit_form.addRow("FM POI channel:", self._fm_poi_ch_combo)
 
         self._show_diag_check = QCheckBox()

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -262,6 +262,7 @@ class _ImagesTab(QWidget):
             image = FibsemImage.load(path)
         except Exception as exc:
             QMessageBox.warning(self, "Load error", str(exc))
+            self._fib_path.setText(self._fib_loaded_path)  # revert to last-good path
             return
         self._fib_image = image
         self._fib_loaded_path = path
@@ -284,6 +285,7 @@ class _ImagesTab(QWidget):
             image = FluorescenceImage.load(path)
         except Exception as exc:
             QMessageBox.warning(self, "Load error", str(exc))
+            self._fm_path.setText(self._fm_loaded_path)  # revert to last-good path
             return
         self._fm_image = image
         self._fm_loaded_path = path
@@ -1818,6 +1820,10 @@ class CorrelationTabWidget(QWidget):
         fig.savefig(path, dpi=150, bbox_inches="tight", facecolor=fig.get_facecolor())
         plt.close(fig)
 
+    def load_result(self, path: str) -> None:
+        """Load a correlation result from JSON and adopt it (mirrors load_data)."""
+        self._load_result(CorrelationResult.load(path))
+
     def _menu_load_result(self) -> None:
         start = self._project_dir or ""
         path, _ = QFileDialog.getOpenFileName(
@@ -2039,7 +2045,7 @@ def load_project(widget: "CorrelationTabWidget", directory: str) -> None:
 
     if found["result"]:
         try:
-            widget._load_result(CorrelationResult.load(found["result"]))
+            widget.load_result(found["result"])
             logging.info("  result: %s", os.path.basename(found["result"]))
         except Exception:
             logging.exception("  failed to load result %s", found["result"])

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -1080,9 +1080,12 @@ class CorrelationTabWidget(QWidget):
         self._action_show_legend = QAction("Show Legend", self)
         self._action_show_legend.setCheckable(True)
         self._action_show_legend.setChecked(True)
+        self._action_save_plot = QAction("Save Plot", self)
         view_menu.addAction(self._action_reset_views)
         view_menu.addAction(self._action_show_scalebar)
         view_menu.addAction(self._action_show_legend)
+        view_menu.addSeparator()
+        view_menu.addAction(self._action_save_plot)
 
         layout.addWidget(menubar)
 
@@ -1158,11 +1161,6 @@ class CorrelationTabWidget(QWidget):
         self._btn_continue.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         btn_layout.addWidget(self._btn_continue)
         btn_layout.addStretch(1)
-
-        self._btn_save_plot = QPushButton("Save Plot")
-        self._btn_save_plot.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        self._btn_save_plot.setToolTip("Save the FIB + FM canvases as a PNG")
-        btn_layout.addWidget(self._btn_save_plot)
 
         run_layout.addWidget(btn_row)
         right_layout.addWidget(run_bar)
@@ -1261,11 +1259,11 @@ class CorrelationTabWidget(QWidget):
         self._action_show_scalebar.toggled.connect(self._on_scalebar_toggled)
         self._on_scalebar_toggled(True)
         self._action_show_legend.toggled.connect(self._on_legend_toggled)
+        self._action_save_plot.triggered.connect(lambda _: self._on_save_plot_clicked())
 
         # Bottom bar run button
         self._btn_run.clicked.connect(self._run)
         self._btn_continue.clicked.connect(self._on_continue_pressed)
-        self._btn_save_plot.clicked.connect(self._on_save_plot_clicked)
         self.data_changed.connect(self._update_run_button)
         self.data_changed.connect(self._on_data_changed)
 

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -37,7 +37,7 @@ import os
 import time
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Tuple
 
 logging.basicConfig(level=logging.INFO)
 
@@ -95,18 +95,68 @@ from fibsem.correlation.ui.widgets.refractive_index_widget import RefractiveInde
 
 _FIT_METHODS = ["None", "Hole", "Gaussian"]
 
-# Run-bar RMS quality cue (px). Placeholder thresholds — tune to the workflow.
-_RMS_GOOD_PX = 2.0
-_RMS_OK_PX = 5.0
+# Run-bar RMS cue. The badge FLAGS problems; it never certifies quality. The RMS
+# is a fit residual over the fiducials, so a low value cannot promise the POI —
+# which is extrapolated from that fit — lands where you want it. A green light
+# would read as exactly that promise, so there is no green: neutral means "no
+# detected problem", not "good".
+#
+# The two relative triggers need no calibration and hold at any HFW. Only the
+# absolute limits carry numbers, and they are set far enough out to be statements
+# of breakage rather than judgements of quality (500 nm is ~7.7 px at 100 µm HFW
+# on a 1536 px-wide image; 1 µm is ~15 px).
+_RMS_LARGE_NM = 500.0
+_RMS_BROKEN_NM = 1000.0
+_RMS_OUTLIER_RATIO = 2.0
+# Fewest fiducial pairs the run button accepts. The rigid 3D->2D transform has
+# ~7 degrees of freedom, so a fit on this many is barely over-determined and its
+# residual is small by construction rather than by agreement.
+_RMS_MIN_FIDUCIALS = 4
+
+_RMS_NEUTRAL = "#9aa0a6"
+_RMS_WARN = "#ffb300"
+_RMS_BAD = "#e53935"
 
 
-def _rms_color(rms: float) -> str:
-    """Colour for the run-bar RMS badge: green (good) / amber (ok) / red (poor)."""
-    if rms <= _RMS_GOOD_PX:
-        return "#4caf50"
-    if rms <= _RMS_OK_PX:
-        return "#ffb300"
-    return "#e53935"
+def _rms_concern(
+    rms_nm: Optional[float],
+    n_fiducials: Optional[int] = None,
+    worst_ratio: Optional[float] = None,
+) -> Tuple[str, Optional[str]]:
+    """Flag detectable problems with a fit. Returns (colour, reason or None).
+
+    A residual can demonstrate that a correlation is wrong; it can never
+    demonstrate that one is right. So this only ever reports suspicion — the
+    neutral case carries no verdict at all.
+
+    The relative checks still apply when ``rms_nm`` is None (a result loaded from
+    JSON has no pixel size): they are ratios and counts, not distances.
+    """
+    if rms_nm is not None and rms_nm > _RMS_BROKEN_NM:
+        return _RMS_BAD, (
+            f"RMS exceeds {_format_distance_nm(_RMS_BROKEN_NM)} — the fit has not "
+            "converged on anything usable."
+        )
+
+    reasons: List[str] = []
+    if rms_nm is not None and rms_nm > _RMS_LARGE_NM:
+        reasons.append(f"RMS is above {_format_distance_nm(_RMS_LARGE_NM)}.")
+    if n_fiducials and n_fiducials <= _RMS_MIN_FIDUCIALS:
+        reasons.append(
+            f"Only {n_fiducials} fiducial pairs — the fit has almost no redundancy, "
+            "so this residual understates the true error."
+        )
+    if worst_ratio is not None and worst_ratio > _RMS_OUTLIER_RATIO:
+        reasons.append(
+            f"One fiducial is {worst_ratio:.1f}× the RMS — more likely a misplaced "
+            "correspondence than general noise."
+        )
+    return (_RMS_WARN, " ".join(reasons)) if reasons else (_RMS_NEUTRAL, None)
+
+
+def _format_distance_nm(nm: float) -> str:
+    """Render a nanometre distance, switching to µm once it stops being readable."""
+    return f"{nm / 1000:.2f} µm" if nm >= 1000 else f"{nm:.0f} nm"
 
 
 # ---------------------------------------------------------------------------
@@ -1587,13 +1637,23 @@ class CorrelationTabWidget(QWidget):
         self._set_result_live(True)
         # after _update_run_button, which would otherwise overwrite it with "Ready."
         self._update_run_button()
-        # RMS beside Continue (quality-coloured); compact RI / POI note on status.
+        # RMS beside Continue (coloured only if something looks wrong); compact
+        # RI / POI note on status.
         rms = result.rms_error
         if rms is not None:
-            self._lbl_result.setText(
-                f'<span style="color:{_rms_color(rms)}">RMS {rms:.2f} px</span>'
+            px_m = self._fib_pixel_size_m()
+            rms_nm = rms * px_m * 1e9 if px_m else None
+            shown = _format_distance_nm(rms_nm) if rms_nm is not None else f"{rms:.2f} px"
+            worst = self._worst_fiducial_px(result)
+            color, concern = _rms_concern(
+                rms_nm,
+                len(result.reprojected_3d),
+                worst / rms if worst is not None and rms > 0 else None,
             )
-            self._lbl_result.setToolTip("Registration RMS error — lower is better")
+            self._lbl_result.setText(
+                f'<span style="color:{color}">RMS {shown}</span>'
+            )
+            self._lbl_result.setToolTip(self._rms_tooltip(result, rms, px_m, concern))
             self._lbl_result.setVisible(True)
         if (
             result.refractive_index_correction_mode == "pre"
@@ -1607,6 +1667,71 @@ class CorrelationTabWidget(QWidget):
         else:
             self._lbl_status.setText("Done.")
         self.result_changed.emit(result)
+
+    def _fib_pixel_size_m(self) -> Optional[float]:
+        """FIB pixel size in metres, or None. A result loaded from JSON has no
+        images restored, so this is legitimately absent rather than an error."""
+        return getattr(
+            getattr(getattr(self._fib_image, "metadata", None), "pixel_size", None),
+            "x",
+            None,
+        )
+
+    @staticmethod
+    def _worst_fiducial_px(result: CorrelationResult) -> Optional[float]:
+        """Largest single-fiducial reprojection error, which the RMS averages away.
+
+        One badly-placed correspondence among several good ones barely moves the
+        RMS but can still ruin the fit, so it is worth reporting separately.
+        """
+        if not result.delta_2d:
+            return None
+        return max(float(np.hypot(d.x, d.y)) for d in result.delta_2d)
+
+    def _rms_tooltip(
+        self,
+        result: CorrelationResult,
+        rms_px: float,
+        px_m: Optional[float],
+        concern: Optional[str] = None,
+    ) -> str:
+        """Explain what the RMS badge is measuring, and what it is not."""
+        n = len(result.reprojected_3d)
+        lines = []
+
+        if px_m:
+            lines.append(
+                f"Registration RMS error — {_format_distance_nm(rms_px * px_m * 1e9)}"
+            )
+            lines.append(f"{rms_px:.2f} px × {px_m * 1e9:.1f} nm/px")
+        else:
+            lines.append(f"Registration RMS error — {rms_px:.2f} px")
+            lines.append("FIB pixel size unknown — load the FIB image to see this in nm.")
+
+        detail = (
+            "Root-mean-square residual of the rigid 3D→2D fit"
+            f"{f' across {n} fiducial pairs' if n else ''}."
+        )
+        worst = self._worst_fiducial_px(result)
+        if worst is not None:
+            shown = f"{worst:.2f} px"
+            if px_m:
+                shown += f" ({_format_distance_nm(worst * px_m * 1e9)})"
+            detail += f" Worst single fiducial: {shown}."
+        lines += ["", detail]
+
+        if concern:
+            lines += ["", f"⚠  {concern}"]
+
+        lines += [
+            "",
+            "Measures how well the FM fiducials land on their FIB counterparts — "
+            "not POI accuracy. The POI is extrapolated from this fit, so one "
+            "outside the fiducial spread can be worse than this suggests. A low "
+            "residual cannot confirm the correlation is right; only a high one "
+            "can show it is wrong.",
+        ]
+        return "\n".join(lines)
 
     @staticmethod
     def _poi_shift_px(result: CorrelationResult) -> Optional[float]:

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -95,6 +95,19 @@ from fibsem.correlation.ui.widgets.refractive_index_widget import RefractiveInde
 
 _FIT_METHODS = ["None", "Hole", "Gaussian"]
 
+# Run-bar RMS quality cue (px). Placeholder thresholds — tune to the workflow.
+_RMS_GOOD_PX = 2.0
+_RMS_OK_PX = 5.0
+
+
+def _rms_color(rms: float) -> str:
+    """Colour for the run-bar RMS badge: green (good) / amber (ok) / red (poor)."""
+    if rms <= _RMS_GOOD_PX:
+        return "#4caf50"
+    if rms <= _RMS_OK_PX:
+        return "#ffb300"
+    return "#e53935"
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -455,6 +468,11 @@ class _CoordinatesTab(QWidget):
         self._fit_panel = TitledPanel("Fit Settings", collapsible=True)
         self._fit_panel.set_content(fit_body)
         layout.addWidget(self._fit_panel)
+
+        # Advanced / set-once panels start collapsed to keep the tab compact.
+        self._surface_panel.collapse()
+        self._fm_surface_panel.collapse()
+        self._fit_panel.collapse()
 
         layout.addStretch(1)
         scroll.setWidget(container)
@@ -1160,6 +1178,14 @@ class CorrelationTabWidget(QWidget):
         self._btn_continue = QPushButton("Continue")
         self._btn_continue.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         btn_layout.addWidget(self._btn_continue)
+
+        # Compact result summary beside Continue (RMS quality-coloured + RI/POI),
+        # shown after a run — keeps the status line free for state only.
+        self._lbl_result = QLabel("")
+        self._lbl_result.setTextFormat(Qt.TextFormat.RichText)
+        self._lbl_result.setStyleSheet("color: #9aa0a6; font-size: 12px;")
+        self._lbl_result.setVisible(False)
+        btn_layout.addWidget(self._lbl_result)
         btn_layout.addStretch(1)
 
         run_layout.addWidget(btn_row)
@@ -1515,6 +1541,7 @@ class CorrelationTabWidget(QWidget):
             self._worker = None
         self._btn_run.setEnabled(False)
         self._lbl_status.setText("Running…")
+        self._lbl_result.setVisible(False)
         self._worker = _CorrelationWorker(copy.deepcopy(self.data))
         self._worker.result_ready.connect(self._on_result_ready)
         self._worker.errored.connect(self._on_run_error)
@@ -1531,17 +1558,23 @@ class CorrelationTabWidget(QWidget):
         self._btn_continue.setEnabled(True)
         # after _update_run_button, which would otherwise overwrite it with "Ready."
         self._update_run_button()
+        # RMS beside Continue (quality-coloured); compact RI / POI note on status.
+        rms = result.rms_error
+        if rms is not None:
+            self._lbl_result.setText(
+                f'<span style="color:{_rms_color(rms)}">RMS {rms:.2f} px</span>'
+            )
+            self._lbl_result.setToolTip("Registration RMS error — lower is better")
+            self._lbl_result.setVisible(True)
         if (
             result.refractive_index_correction_mode == "pre"
             and result.refractive_index_correction_factor is not None
         ):
-            msg = (
-                f"Done — RI pre-correction ×{result.refractive_index_correction_factor:.3f} applied"
-            )
+            msg = f"Done — RI ×{result.refractive_index_correction_factor:.3f}"
             shift = self._poi_shift_px(result)
             if shift is not None:
-                msg += f", POI 1 shifted {shift:.1f} px"
-            self._lbl_status.setText(msg + ".")
+                msg += f", POI Δ{shift:.1f} px"
+            self._lbl_status.setText(msg)
         else:
             self._lbl_status.setText("Done.")
         self.result_changed.emit(result)

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -1098,10 +1098,14 @@ class CorrelationTabWidget(QWidget):
         self._action_show_legend = QAction("Show Legend", self)
         self._action_show_legend.setCheckable(True)
         self._action_show_legend.setChecked(True)
+        self._action_show_labels = QAction("Show Labels", self)
+        self._action_show_labels.setCheckable(True)
+        self._action_show_labels.setChecked(True)
         self._action_save_plot = QAction("Save Plot", self)
         view_menu.addAction(self._action_reset_views)
         view_menu.addAction(self._action_show_scalebar)
         view_menu.addAction(self._action_show_legend)
+        view_menu.addAction(self._action_show_labels)
         view_menu.addSeparator()
         view_menu.addAction(self._action_save_plot)
 
@@ -1285,6 +1289,7 @@ class CorrelationTabWidget(QWidget):
         self._action_show_scalebar.toggled.connect(self._on_scalebar_toggled)
         self._on_scalebar_toggled(True)
         self._action_show_legend.toggled.connect(self._on_legend_toggled)
+        self._action_show_labels.toggled.connect(self._on_labels_toggled)
         self._action_save_plot.triggered.connect(lambda _: self._on_save_plot_clicked())
 
         # Bottom bar run button
@@ -1634,7 +1639,7 @@ class CorrelationTabWidget(QWidget):
                 error_pts,
                 color="#ff4444",
                 label_prefix="E",
-                size=7,
+                size=4,
                 marker="o",
                 legend_label="FM reprojected (E)",
             )
@@ -1647,7 +1652,7 @@ class CorrelationTabWidget(QWidget):
             self._fib_canvas.add_overlay_points(
                 ghost_pts,
                 color="#ff00ff",
-                size=13,
+                size=7,
                 marker="o",
                 alpha=0.7,
                 show_labels=False,
@@ -1662,7 +1667,7 @@ class CorrelationTabWidget(QWidget):
                 poi_pts,
                 color="#ff00ff",
                 label_prefix="P",
-                size=9,
+                size=5,
                 marker="o",
                 legend_label="POI (P)",
             )
@@ -1808,6 +1813,10 @@ class CorrelationTabWidget(QWidget):
     def _on_legend_toggled(self, visible: bool) -> None:
         self._fib_canvas.set_legend_visible(visible)
         self._fm_display.canvas.set_legend_visible(visible)
+
+    def _on_labels_toggled(self, visible: bool) -> None:
+        self._fib_canvas.set_labels_visible(visible)
+        self._fm_display.canvas.set_labels_visible(visible)
 
     def _on_save_plot_clicked(self) -> None:
         """Prompt for a path and save the side-by-side FIB + FM plot."""

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -57,6 +57,7 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QPushButton,
     QScrollArea,
+    QShortcut,
     QSplitter,
     QTabWidget,
     QTableWidget,
@@ -64,6 +65,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from PyQt5.QtGui import QKeySequence
 from fibsem.constants import DATETIME_FILE
 from fibsem.correlation.correlation_v2 import run_correlation_from_data
 from fibsem.correlation.structures import (
@@ -77,7 +79,10 @@ from fibsem.correlation.structures import (
 )
 from fibsem.correlation.ui.widgets.coordinate_list_widget import CoordinateListWidget
 from fibsem.ui import stylesheets
-from fibsem.correlation.ui.widgets.fm_image_display_widget import FMImageDisplayWidget
+from fibsem.correlation.ui.widgets.fm_image_display_widget import (
+    IMAGE_HEADER_STYLE,
+    FMImageDisplayWidget,
+)
 from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
 from fibsem.fm.structures import FluorescenceImage
 from fibsem.structures import FibsemImage
@@ -1077,20 +1082,28 @@ class CorrelationTabWidget(QWidget):
         view_menu.addAction(self._action_show_scalebar)
         view_menu.addAction(self._action_show_legend)
 
-        test_menu = menubar.addMenu("Test")
-        self._action_test_save_plot = QAction("Test Save Plot", self)
-        test_menu.addAction(self._action_test_save_plot)
-
         layout.addWidget(menubar)
 
         splitter = QSplitter(Qt.Orientation.Horizontal)
         layout.addWidget(splitter, stretch=1)
 
-        # Left: FIB image canvas (add-menu types derived from the registry map)
+        # Left: FIB image canvas with a filename header (mirrors the FM display)
+        fib_pane = QWidget()
+        fib_layout = QVBoxLayout(fib_pane)
+        fib_layout.setContentsMargins(0, 0, 0, 0)
+        fib_layout.setSpacing(0)
+
+        self._fib_name_label = QLabel("")
+        self._fib_name_label.setStyleSheet(IMAGE_HEADER_STYLE)
+        self._fib_name_label.setTextFormat(Qt.TextFormat.PlainText)
+        self._fib_name_label.setVisible(False)
+        fib_layout.addWidget(self._fib_name_label)
+
         self._fib_canvas = ImagePointCanvas(
             allowed_point_types=self._point_types_for_side("fib"),
         )
-        splitter.addWidget(self._fib_canvas)
+        fib_layout.addWidget(self._fib_canvas, stretch=1)
+        splitter.addWidget(fib_pane)
 
         # Middle: FM image display
         self._fm_display = FMImageDisplayWidget(
@@ -1143,6 +1156,11 @@ class CorrelationTabWidget(QWidget):
         self._btn_continue.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         btn_layout.addWidget(self._btn_continue)
         btn_layout.addStretch(1)
+
+        self._btn_save_plot = QPushButton("Save Plot")
+        self._btn_save_plot.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self._btn_save_plot.setToolTip("Save the FIB + FM canvases as a PNG")
+        btn_layout.addWidget(self._btn_save_plot)
 
         run_layout.addWidget(btn_row)
         right_layout.addWidget(run_bar)
@@ -1241,11 +1259,11 @@ class CorrelationTabWidget(QWidget):
         self._action_show_scalebar.toggled.connect(self._on_scalebar_toggled)
         self._on_scalebar_toggled(True)
         self._action_show_legend.toggled.connect(self._on_legend_toggled)
-        self._action_test_save_plot.triggered.connect(lambda _: self.save_plot())
 
         # Bottom bar run button
         self._btn_run.clicked.connect(self._run)
         self._btn_continue.clicked.connect(self._on_continue_pressed)
+        self._btn_save_plot.clicked.connect(self._on_save_plot_clicked)
         self.data_changed.connect(self._update_run_button)
         self.data_changed.connect(self._on_data_changed)
 
@@ -1279,6 +1297,16 @@ class CorrelationTabWidget(QWidget):
             if spec.adapter is self._fib_adapter:
                 spec.list_widget.set_axis_maxima(x_max=w - 1, y_max=h - 1)
         self._images_tab.set_fib_image(fib_image)
+        self._update_fib_name_label(fib_image)
+
+    def _update_fib_name_label(self, image: FibsemImage) -> None:
+        """Show the loaded FIB image's filename in the header (mirrors FM)."""
+        iset = getattr(getattr(image, "metadata", None), "image_settings", None)
+        filename = getattr(iset, "filename", "") or ""
+        base = os.path.basename(filename) if filename else ""
+        self._fib_name_label.setText(base)
+        self._fib_name_label.setToolTip(filename)
+        self._fib_name_label.setVisible(bool(base))
 
     def set_fm_image(self, fm_image: FluorescenceImage) -> None:
         """Load FM image into canvas and update images tab."""
@@ -1716,6 +1744,12 @@ class CorrelationTabWidget(QWidget):
             QMessageBox.StandardButton.No,
         )
         if reply == QMessageBox.StandardButton.Yes:
+            # Auto-save the result plot alongside the auto-saved JSON.
+            if self._project_dir:
+                try:
+                    self.save_plot()
+                except Exception:
+                    logging.exception("Auto-save of correlation plot failed")
             self.continue_pressed_signal.emit(self._result)
             self.window().close()
 
@@ -1741,6 +1775,20 @@ class CorrelationTabWidget(QWidget):
     def _on_legend_toggled(self, visible: bool) -> None:
         self._fib_canvas.set_legend_visible(visible)
         self._fm_display.canvas.set_legend_visible(visible)
+
+    def _on_save_plot_clicked(self) -> None:
+        """Prompt for a path and save the side-by-side FIB + FM plot."""
+        start = self._project_dir or ""
+        default = (
+            os.path.join(start, f"correlation_plot_{time.strftime(DATETIME_FILE)}.png")
+            if start
+            else ""
+        )
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save Correlation Plot", default, "PNG (*.png);;All files (*)"
+        )
+        if path:
+            self.save_plot(path)
 
     def save_plot(self, path: Optional[str] = None) -> None:
         """Save FIB + FM canvases as a side-by-side matplotlib figure."""
@@ -1890,6 +1938,15 @@ class CorrelationTabDialog(QDialog):
         self.setModal(True)
         self.resize(1500, 900)
 
+        # Allow the whole correlation window to be minimised / maximised.
+        self.setWindowFlags(
+            self.windowFlags()
+            | Qt.WindowMinimizeButtonHint
+            | Qt.WindowMaximizeButtonHint
+        )
+        self._min_shortcut = QShortcut(QKeySequence("Ctrl+M"), self)
+        self._min_shortcut.activated.connect(self.showMinimized)
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         self.widget = CorrelationTabWidget()
@@ -1911,15 +1968,112 @@ class CorrelationTabDialog(QDialog):
         return self.widget.result
 
 
+def _discover_correlation_files(directory: str) -> Dict[str, Optional[str]]:
+    """Locate FIB/FM images and saved data/result in a correlation project dir.
+
+    Conventions (matching the widget's auto-save + typical exports):
+      - FM image : ``*.ome.tif`` / ``*.ome.tiff``
+      - FIB image: ``*_ib.tif`` / ``*_ib.tiff`` (else the first non-OME TIFF)
+      - data     : ``correlation_data.json``
+      - result   : ``correlation_result.json``
+    """
+    import glob
+
+    def _first(patterns: List[str]) -> Optional[str]:
+        for pat in patterns:
+            hits = sorted(glob.glob(os.path.join(directory, pat)))
+            if hits:
+                return hits[0]
+        return None
+
+    fib = _first(["*_ib.tif", "*_ib.tiff"])
+    if fib is None:
+        tifs = sorted(
+            glob.glob(os.path.join(directory, "*.tif"))
+            + glob.glob(os.path.join(directory, "*.tiff"))
+        )
+        fib = next(
+            (t for t in tifs if not t.endswith((".ome.tif", ".ome.tiff"))), None
+        )
+
+    def _existing(name: str) -> Optional[str]:
+        p = os.path.join(directory, name)
+        return p if os.path.exists(p) else None
+
+    return {
+        "fib": fib,
+        "fm": _first(["*.ome.tif", "*.ome.tiff"]),
+        "data": _existing("correlation_data.json"),
+        "result": _existing("correlation_result.json"),
+    }
+
+
+def load_project(widget: "CorrelationTabWidget", directory: str) -> None:
+    """Quickstart-load a correlation project directory into ``widget``.
+
+    Sets the project dir, then loads the FIB + FM images and, if present, the
+    saved correlation result (preferred) or coordinate data. Missing or
+    unreadable pieces are logged and skipped so a partial project still opens.
+    """
+    found = _discover_correlation_files(directory)
+    logging.info("Quickstart loading correlation project: %s", directory)
+    widget.set_project_dir(directory)
+
+    if found["fib"]:
+        try:
+            widget.set_fib_image(FibsemImage.load(found["fib"]))
+            logging.info("  FIB image: %s", os.path.basename(found["fib"]))
+        except Exception:
+            logging.exception("  failed to load FIB image %s", found["fib"])
+    else:
+        logging.warning("  no FIB image (*_ib.tif) found in %s", directory)
+
+    if found["fm"]:
+        try:
+            widget.set_fm_image(FluorescenceImage.load(found["fm"]))
+            logging.info("  FM image: %s", os.path.basename(found["fm"]))
+        except Exception:
+            logging.exception("  failed to load FM image %s", found["fm"])
+    else:
+        logging.warning("  no FM image (*.ome.tiff) found in %s", directory)
+
+    if found["result"]:
+        try:
+            widget._load_result(CorrelationResult.load(found["result"]))
+            logging.info("  result: %s", os.path.basename(found["result"]))
+        except Exception:
+            logging.exception("  failed to load result %s", found["result"])
+    elif found["data"]:
+        try:
+            widget.load_data(found["data"])
+            logging.info("  data: %s", os.path.basename(found["data"]))
+        except Exception:
+            logging.exception("  failed to load data %s", found["data"])
+
+
 def main() -> None:
-    from PyQt5.QtWidgets import QApplication
+    import argparse
     import sys
 
-    app = QApplication(sys.argv)
+    from PyQt5.QtWidgets import QApplication
+
+    parser = argparse.ArgumentParser(description="FIB-FM correlation widget")
+    parser.add_argument(
+        "project",
+        nargs="?",
+        default=None,
+        help="Optional correlation project directory to quickstart-load "
+        "(FIB/FM images + correlation_data.json / correlation_result.json).",
+    )
+    args = parser.parse_args()
+
+    app = QApplication(sys.argv[:1])
     app.setStyle("Fusion")
     app.setStyleSheet(stylesheets.NAPARI_STYLE)
 
     widget = CorrelationTabWidget()
+    if args.project:
+        load_project(widget, args.project)
     widget.show()
 
     sys.exit(app.exec_())

--- a/fibsem/correlation/ui/widgets/fm_image_display_widget.py
+++ b/fibsem/correlation/ui/widgets/fm_image_display_widget.py
@@ -16,6 +16,7 @@ Usage
 """
 from __future__ import annotations
 
+import os
 from typing import List, Optional
 
 import matplotlib.colors
@@ -51,9 +52,24 @@ _DEFAULT_COLORS = ["cyan", "magenta", "yellow", "green", "red", "blue", "gray"]
 _SWATCH_SIZE   = 14   # px
 _CTRL_HEIGHT   = 28   # compact control row height
 _CH_ROW_HEIGHT = 24   # one channel row (measured sizeHint)
+_CH_NAME_WIDTH = 150  # channel-name label width (keeps sliders aligned)
 # Channel-controls pane floor: 3 rows + container/spacing/frame margin
 _CH_MIN_HEIGHT = 3 * _CH_ROW_HEIGHT + 16
 _CH_INIT_HEIGHT = _CH_MIN_HEIGHT + 48  # a bit taller by default; user-resizable
+
+# Compact step buttons flanking the Z slider
+_Z_BTN_STYLE = (
+    "QToolButton { color: #d0d0d0; background: #2b2d31; border: 1px solid #3a3d42; "
+    "border-radius: 3px; font-size: 13px; }"
+    "QToolButton:hover { background: #3a3d42; }"
+    "QToolButton:disabled { color: #5a5d62; }"
+)
+
+# Filename header shown above the FM (and FIB) image canvas
+IMAGE_HEADER_STYLE = (
+    "color: #d0d0d0; font-size: 11px; padding: 3px 8px; "
+    "background: #1e2124; border-bottom: 1px solid #3a3d42;"
+)
 
 
 def _normalize_clipped(arr: np.ndarray, lo_pct: float, hi_pct: float) -> np.ndarray:
@@ -164,21 +180,19 @@ class _ChannelRow(QWidget):
         # Channel name
         lbl = QLabel(name)
         lbl.setStyleSheet("color: #d0d0d0; font-size: 11px;")
-        lbl.setFixedWidth(180)
+        lbl.setFixedWidth(_CH_NAME_WIDTH)
         lbl.setToolTip(name)
         lbl.setTextFormat(Qt.TextFormat.PlainText)
         lbl.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
         layout.addWidget(lbl)
 
-        # Per-channel clip range slider
+        # Per-channel clip range slider — fills the remaining row width
         self._clip_slider = _ClipSlider(Qt.Orientation.Horizontal)
         self._clip_slider.setRange(0, 100)
         self._clip_slider.setValue((0, 100))
-        self._clip_slider.setMinimumWidth(40)
-        self._clip_slider.setMaximumWidth(150)
+        self._clip_slider.setMinimumWidth(80)
         self._clip_slider.valueChanged.connect(lambda _: self.clip_changed.emit())
-        layout.addWidget(self._clip_slider)
-        layout.addStretch()
+        layout.addWidget(self._clip_slider, stretch=1)
 
     @property
     def is_visible(self) -> bool:
@@ -252,6 +266,13 @@ class FMImageDisplayWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
+        # Header: FM image filename (hidden until an image is loaded)
+        self._name_label = QLabel("")
+        self._name_label.setStyleSheet(IMAGE_HEADER_STYLE)
+        self._name_label.setTextFormat(Qt.TextFormat.PlainText)
+        self._name_label.setVisible(False)
+        layout.addWidget(self._name_label)
+
         # Vertical splitter: canvas (+Z row) on top, channel controls below,
         # so the channel/contrast area can be dragged taller/shorter.
         splitter = QSplitter(Qt.Orientation.Vertical)
@@ -269,6 +290,8 @@ class FMImageDisplayWidget(QWidget):
         top_layout.setSpacing(0)
 
         self.canvas = ImagePointCanvas(allowed_point_types=self._allowed_point_types)
+        self.canvas.set_shift_z_scroll_enabled(True)
+        self.canvas.z_scroll_requested.connect(self._step_z)
         top_layout.addWidget(self.canvas, stretch=1)
 
         sep1 = QFrame()
@@ -292,12 +315,28 @@ class FMImageDisplayWidget(QWidget):
 
         z_layout.addWidget(QLabel("Z:"))
 
+        self._z_prev = QToolButton()
+        self._z_prev.setText("‹")
+        self._z_prev.setFixedSize(20, 20)
+        self._z_prev.setToolTip("Previous Z-slice")
+        self._z_prev.setStyleSheet(_Z_BTN_STYLE)
+        self._z_prev.clicked.connect(lambda: self._step_z(-1))
+        z_layout.addWidget(self._z_prev)
+
         self._z_slider = QSlider(Qt.Orientation.Horizontal)
         self._z_slider.setMinimum(0)
         self._z_slider.setMaximum(0)
         self._z_slider.setSingleStep(1)
         self._z_slider.setPageStep(1)
         z_layout.addWidget(self._z_slider, stretch=1)
+
+        self._z_next = QToolButton()
+        self._z_next.setText("›")
+        self._z_next.setFixedSize(20, 20)
+        self._z_next.setToolTip("Next Z-slice")
+        self._z_next.setStyleSheet(_Z_BTN_STYLE)
+        self._z_next.clicked.connect(lambda: self._step_z(1))
+        z_layout.addWidget(self._z_next)
 
         self._z_label = QLabel("1 / 1")
         self._z_label.setStyleSheet("color: #aaa; font-size: 11px;")
@@ -348,6 +387,7 @@ class FMImageDisplayWidget(QWidget):
         """Load an FM image, rebuild channel rows, render initial composite."""
         self._fm_image = fm_image
         self._first_render = True
+        self._update_name_label()
         self._build_channel_rows()
         self._update_z_controls()
         self._render()
@@ -368,6 +408,16 @@ class FMImageDisplayWidget(QWidget):
     def current_z(self) -> int:
         """Current z-slice index (0-based)."""
         return self._z_slider.value()
+
+    def _update_name_label(self) -> None:
+        """Show the loaded FM image's filename in the header."""
+        filename = ""
+        if self._fm_image is not None:
+            filename = getattr(self._fm_image.metadata, "filename", "") or ""
+        base = os.path.basename(filename) if filename else ""
+        self._name_label.setText(base)
+        self._name_label.setToolTip(filename)
+        self._name_label.setVisible(bool(base))
 
     # ------------------------------------------------------------------
     # Channel row management
@@ -477,6 +527,12 @@ class FMImageDisplayWidget(QWidget):
     # Slots
     # ------------------------------------------------------------------
 
+    def _step_z(self, delta: int) -> None:
+        """Advance the Z slider by ``delta`` slices (no-op while MIP is active)."""
+        if self._fm_image is None or self._mip_check.isChecked():
+            return
+        self._z_slider.setValue(self._z_slider.value() + int(delta))
+
     def _on_z_changed(self) -> None:
         self._update_z_label()
         if not self._mip_check.isChecked():
@@ -485,6 +541,8 @@ class FMImageDisplayWidget(QWidget):
     def _on_mip_changed(self) -> None:
         enabled = not self._mip_check.isChecked()
         self._z_slider.setEnabled(enabled)
+        self._z_prev.setEnabled(enabled)
+        self._z_next.setEnabled(enabled)
         self._render()
 
     def _on_visibility_changed(self, _index: int, _visible: bool) -> None:

--- a/fibsem/correlation/ui/widgets/fm_image_display_widget.py
+++ b/fibsem/correlation/ui/widgets/fm_image_display_widget.py
@@ -32,6 +32,7 @@ from PyQt5.QtWidgets import (
     QScrollArea,
     QSizePolicy,
     QSlider,
+    QSplitter,
     QToolButton,
     QVBoxLayout,
     QWidget,
@@ -49,6 +50,10 @@ _DEFAULT_COLORS = ["cyan", "magenta", "yellow", "green", "red", "blue", "gray"]
 
 _SWATCH_SIZE   = 14   # px
 _CTRL_HEIGHT   = 28   # compact control row height
+_CH_ROW_HEIGHT = 24   # one channel row (measured sizeHint)
+# Channel-controls pane floor: 3 rows + container/spacing/frame margin
+_CH_MIN_HEIGHT = 3 * _CH_ROW_HEIGHT + 16
+_CH_INIT_HEIGHT = _CH_MIN_HEIGHT + 48  # a bit taller by default; user-resizable
 
 
 def _normalize_clipped(arr: np.ndarray, lo_pct: float, hi_pct: float) -> np.ndarray:
@@ -247,14 +252,29 @@ class FMImageDisplayWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        # Canvas
+        # Vertical splitter: canvas (+Z row) on top, channel controls below,
+        # so the channel/contrast area can be dragged taller/shorter.
+        splitter = QSplitter(Qt.Orientation.Vertical)
+        splitter.setChildrenCollapsible(False)
+        splitter.setHandleWidth(6)
+        splitter.setStyleSheet(
+            "QSplitter::handle { background: #3a3d42; }"
+            "QSplitter::handle:hover { background: #4a4d52; }"
+        )
+
+        # --- top pane: canvas + Z/MIP row ---
+        top = QWidget()
+        top_layout = QVBoxLayout(top)
+        top_layout.setContentsMargins(0, 0, 0, 0)
+        top_layout.setSpacing(0)
+
         self.canvas = ImagePointCanvas(allowed_point_types=self._allowed_point_types)
-        layout.addWidget(self.canvas, stretch=1)
+        top_layout.addWidget(self.canvas, stretch=1)
 
         sep1 = QFrame()
         sep1.setFrameShape(QFrame.Shape.HLine)
         sep1.setStyleSheet("color: #3a3d42;")
-        layout.addWidget(sep1)
+        top_layout.addWidget(sep1)
 
         # Z / MIP row
         self._z_row = QWidget()
@@ -284,19 +304,15 @@ class FMImageDisplayWidget(QWidget):
         self._z_label.setFixedWidth(48)
         z_layout.addWidget(self._z_label)
 
-        layout.addWidget(self._z_row)
+        top_layout.addWidget(self._z_row)
+        splitter.addWidget(top)
 
-        sep2 = QFrame()
-        sep2.setFrameShape(QFrame.Shape.HLine)
-        sep2.setStyleSheet("color: #3a3d42;")
-        layout.addWidget(sep2)
-
-        # Channel rows (scrollable, vertical stack)
+        # --- bottom pane: channel rows (scrollable, resizable) ---
         self._ch_scroll = QScrollArea()
         self._ch_scroll.setWidgetResizable(True)
         self._ch_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self._ch_scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        self._ch_scroll.setMaximumHeight(120)
+        self._ch_scroll.setMinimumHeight(_CH_MIN_HEIGHT)  # ≥ 3 channel rows + margin
         self._ch_scroll.setStyleSheet("background: #1e2124; border: none;")
 
         self._ch_container = QWidget()
@@ -305,7 +321,13 @@ class FMImageDisplayWidget(QWidget):
         self._ch_layout.setContentsMargins(4, 2, 4, 2)
         self._ch_layout.setSpacing(2)
         self._ch_scroll.setWidget(self._ch_container)
-        layout.addWidget(self._ch_scroll)
+        splitter.addWidget(self._ch_scroll)
+
+        # Canvas absorbs extra space; channel pane keeps its size on resize.
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 0)
+        splitter.setSizes([600, _CH_INIT_HEIGHT])
+        layout.addWidget(splitter, stretch=1)
 
         # Connect controls
         self._z_slider.valueChanged.connect(self._on_z_changed)

--- a/fibsem/correlation/ui/widgets/fm_image_display_widget.py
+++ b/fibsem/correlation/ui/widgets/fm_image_display_widget.py
@@ -328,6 +328,8 @@ class FMImageDisplayWidget(QWidget):
         self._z_slider.setMaximum(0)
         self._z_slider.setSingleStep(1)
         self._z_slider.setPageStep(1)
+        # Shift+scroll has no visible affordance — advertise it here
+        self._z_slider.setToolTip("Drag to change Z-slice, or Shift+scroll on the image")
         z_layout.addWidget(self._z_slider, stretch=1)
 
         self._z_next = QToolButton()

--- a/fibsem/correlation/ui/widgets/image_point_canvas.py
+++ b/fibsem/correlation/ui/widgets/image_point_canvas.py
@@ -41,11 +41,12 @@ import numpy as np
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
-from PyQt5.QtCore import Qt, QTimer, pyqtSignal
+from PyQt5.QtCore import QSize, Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import QCursor
-from PyQt5.QtWidgets import QAction, QMenu, QSizePolicy, QWidget
+from PyQt5.QtWidgets import QAction, QMenu, QPushButton, QSizePolicy, QWidget
 
 from fibsem.correlation.structures import Coordinate, PointType
+from fibsem.ui.icon import fibsem_icon
 _logger = logging.getLogger(__name__)
 
 _POINT_COLORS: Dict[PointType, str] = {
@@ -115,9 +116,27 @@ def _marker_style(point_type: PointType, is_selected: bool) -> dict:
     )
 
 
-# Shared by the live canvas legend and the render_to_axes export
+# Overlay toolbar (top-right icon buttons, matching the shared-canvas look
+# from the PR #111 stack; the mechanism is replaced by that canvas's native
+# toolbar when the correlation canvases migrate onto it)
+_OVERLAY_BTN_SIZE = 26
+_OVERLAY_ICON_SIZE = QSize(18, 18)
+_OVERLAY_MARGIN = 6
+_OVERLAY_GAP = 4
+_OVERLAY_BTN_STYLE = (
+    "QPushButton { background: rgba(30, 33, 36, 180);"
+    " border: 1px solid #3a3d42; border-radius: 4px; }"
+    "QPushButton:hover { background: rgba(45, 63, 92, 220); }"
+    "QPushButton:checked { background: rgba(45, 63, 92, 220);"
+    " border: 1px solid #6aa1e0; }"
+)
+
+
+# Shared by the live canvas legend and the render_to_axes export.
+# Upper LEFT: the top-right corner belongs to the overlay toolbar buttons
+# (same convention as the PR #111 shared canvas).
 _LEGEND_KWARGS = dict(
-    loc="upper right",
+    loc="upper left",
     fontsize=8,
     framealpha=0.75,
     facecolor="#1e2124",
@@ -202,6 +221,12 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         # Dashed datum line across the canvas at the FIB surface y
         self._surface_line = None
         self._surface_line_coord: Optional[Coordinate] = None
+
+        # Overlay toolbar (top-right)
+        self._overlay_buttons: List[QPushButton] = []
+        self._btn_scalebar: Optional[QPushButton] = None
+        self._btn_legend: Optional[QPushButton] = None
+        self._create_toolbar_buttons()
 
         self._redraw_timer = QTimer(self)
         self._redraw_timer.setSingleShot(True)
@@ -300,9 +325,71 @@ class ImagePointCanvas(FigureCanvasQTAgg):
             self._background = None
             self.draw()
 
+    # ------------------------------------------------------------------
+    # Overlay toolbar (top-right icon buttons)
+    # ------------------------------------------------------------------
+
+    def _create_toolbar_buttons(self) -> None:
+        """Standard buttons; first added stacks rightmost."""
+        self._add_overlay_button(
+            "mdi:fit-to-screen-outline", "Reset view", lambda _=False: self.reset_view()
+        )
+        self._btn_scalebar = self._add_overlay_button(
+            "mdi:arrow-expand-horizontal",
+            "Toggle scalebar",
+            self.set_scalebar_visible,
+            checkable=True,
+        )
+        self._btn_scalebar.setChecked(self._show_scalebar)
+        self._btn_legend = self._add_overlay_button(
+            "mdi:format-list-bulleted",
+            "Toggle legend",
+            self.set_legend_visible,
+            checkable=True,
+        )
+        self._btn_legend.setChecked(self._legend_visible)
+
+    def _add_overlay_button(
+        self,
+        icon_name: str,
+        tooltip: str,
+        callback,
+        checkable: bool = False,
+    ) -> QPushButton:
+        """Create a button parented to the canvas, stacked top-right.
+
+        Repositioned automatically on resize. ``clicked(bool)`` is connected to
+        ``callback`` (checkable buttons receive the new checked state).
+        """
+        btn = QPushButton(self)
+        btn.setIcon(fibsem_icon(icon_name, color="#aaaaaa"))
+        btn.setIconSize(_OVERLAY_ICON_SIZE)
+        btn.setFixedSize(_OVERLAY_BTN_SIZE, _OVERLAY_BTN_SIZE)
+        btn.setToolTip(tooltip)
+        btn.setCheckable(checkable)
+        btn.setStyleSheet(_OVERLAY_BTN_STYLE)
+        btn.clicked.connect(callback)
+        btn.raise_()
+        self._overlay_buttons.append(btn)
+        self._reposition_overlay_buttons()
+        return btn
+
+    def _reposition_overlay_buttons(self) -> None:
+        x = self.width() - _OVERLAY_MARGIN
+        for btn in self._overlay_buttons:
+            x -= btn.width()
+            btn.move(x, _OVERLAY_MARGIN)
+            x -= _OVERLAY_GAP
+
+    def resizeEvent(self, event) -> None:  # noqa: N802 (Qt override)
+        super().resizeEvent(event)
+        self._reposition_overlay_buttons()
+
     def set_scalebar_visible(self, visible: bool) -> None:
         """Show or hide the scale bar."""
         self._show_scalebar = visible
+        if self._btn_scalebar is not None:
+            self._btn_scalebar.setChecked(visible)
         self._refresh_scalebar()
         self._background = None
         self.draw()
@@ -332,6 +419,8 @@ class ImagePointCanvas(FigureCanvasQTAgg):
     def set_legend_visible(self, visible: bool) -> None:
         """Show or hide the point-type legend."""
         self._legend_visible = visible
+        if self._btn_legend is not None:
+            self._btn_legend.setChecked(visible)
         self._update_legend()
         self._background = None
         self.draw()

--- a/fibsem/correlation/ui/widgets/image_point_canvas.py
+++ b/fibsem/correlation/ui/widgets/image_point_canvas.py
@@ -38,6 +38,7 @@ import math
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
+import matplotlib.patheffects as pe
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
@@ -70,12 +71,15 @@ _POINT_MARKERS: Dict[PointType, str] = {
     PointType.SURFACE:    "+",
     PointType.SURFACE_FM: "+",
 }
-_MARKER_SIZE     = 10
-_SELECTED_SIZE   = 14
+_MARKER_SIZE     = 5
+_SELECTED_SIZE   = 7
 _PICK_RADIUS_PX  = 15
 _ZOOM_FACTOR     = 1.15
 _MAX_DISPLAY_PX  = 2048
 _REDRAW_INTERVAL = 32     # ms (~60 fps cap for pan/zoom)
+_LABEL_FONTSIZE  = 9
+# Dark outline so coloured point labels stay legible on any image background.
+_LABEL_OUTLINE   = [pe.withStroke(linewidth=0.5, foreground="black")]
 
 
 def _downsample(image: np.ndarray, max_px: int) -> np.ndarray:
@@ -247,6 +251,9 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         self._legend_visible: bool = True
         self._overlay_legend: List[Tuple[str, dict]] = []  # (label, handle style)
 
+        # Point-name labels next to each marker — toggleable to declutter
+        self._labels_visible: bool = True
+
         # Dashed datum line across the canvas at the FIB surface y
         self._surface_line = None
         self._surface_line_coord: Optional[Coordinate] = None
@@ -258,6 +265,7 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         self._overlay_buttons: List[QPushButton] = []
         self._btn_scalebar: Optional[QPushButton] = None
         self._btn_legend: Optional[QPushButton] = None
+        self._btn_labels: Optional[QPushButton] = None
         self._create_toolbar_buttons()
 
         self._redraw_timer = QTimer(self)
@@ -380,6 +388,13 @@ class ImagePointCanvas(FigureCanvasQTAgg):
             checkable=True,
         )
         self._btn_legend.setChecked(self._legend_visible)
+        self._btn_labels = self._add_overlay_button(
+            "mdi:label-outline",
+            "Toggle point labels",
+            self.set_labels_visible,
+            checkable=True,
+        )
+        self._btn_labels.setChecked(self._labels_visible)
 
     def _add_overlay_button(
         self,
@@ -454,6 +469,16 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         if self._btn_legend is not None:
             self._btn_legend.setChecked(visible)
         self._update_legend()
+        self._background = None
+        self.draw()
+
+    def set_labels_visible(self, visible: bool) -> None:
+        """Show or hide the point-name labels next to each marker."""
+        self._labels_visible = visible
+        if self._btn_labels is not None:
+            self._btn_labels.setChecked(visible)
+        for ann in self._label_artists + self._overlay_label_artists:
+            ann.set_visible(visible)
         self._background = None
         self.draw()
 
@@ -555,6 +580,7 @@ class ImagePointCanvas(FigureCanvasQTAgg):
                 fontsize=ann.get_fontsize(),
                 fontweight=ann.get_fontweight(),
                 zorder=ann.get_zorder(),
+                path_effects=_LABEL_OUTLINE,
             )
 
         if self._show_scalebar and self._pixel_size is not None:
@@ -623,11 +649,13 @@ class ImagePointCanvas(FigureCanvasQTAgg):
                 xytext=(7, 5),
                 textcoords="offset points",
                 color=color,
-                fontsize=8,
+                fontsize=_LABEL_FONTSIZE,
                 alpha=alpha,
                 animated=True,
                 zorder=9,
+                path_effects=_LABEL_OUTLINE,
             )
+            ann.set_visible(self._labels_visible)
             self._overlay_label_artists.append(ann)
 
         self._background = None
@@ -740,11 +768,13 @@ class ImagePointCanvas(FigureCanvasQTAgg):
                 xytext=(7, 5),
                 textcoords="offset points",
                 color=color,
-                fontsize=8,
+                fontsize=_LABEL_FONTSIZE,
                 fontweight="bold" if is_sel else "normal",
                 animated=True,
                 zorder=11 if is_sel else 6,
+                path_effects=_LABEL_OUTLINE,
             )
+            ann.set_visible(self._labels_visible)
             self._label_artists.append(ann)
 
         self._update_legend()

--- a/fibsem/correlation/ui/widgets/image_point_canvas.py
+++ b/fibsem/correlation/ui/widgets/image_point_canvas.py
@@ -230,6 +230,8 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         self._coordinates: List[Coordinate] = []
         self._selected: Optional[Coordinate] = None
         self._dragging: Optional[Coordinate] = None
+        # Position at press, so release can tell a select-click from a real drag
+        self._drag_origin: Optional[Tuple[float, float]] = None
         self._pan_start: Optional[Tuple] = None
 
         # Image bounds for drag clamping (set in set_image)
@@ -850,6 +852,7 @@ class ImagePointCanvas(FigureCanvasQTAgg):
                 changed = nearest is not self._selected
                 self._selected = nearest
                 self._dragging = nearest
+                self._drag_origin = (nearest.point.x, nearest.point.y)
                 self._apply_styles()
                 self._blit_points()
                 self.setCursor(Qt.CursorShape.ClosedHandCursor)
@@ -897,8 +900,17 @@ class ImagePointCanvas(FigureCanvasQTAgg):
     def _on_release(self, event) -> None:
         if event.button == 1:
             if self._dragging is not None:
-                self.point_moved.emit(self._dragging)
+                # A click to select leaves the position untouched — only report a
+                # move if one actually happened, or every selection invalidates
+                # the correlation result downstream.
+                moved = (
+                    self._dragging.point.x,
+                    self._dragging.point.y,
+                ) != self._drag_origin
+                if moved:
+                    self.point_moved.emit(self._dragging)
                 self._dragging = None
+                self._drag_origin = None
             elif self._pan_start is not None:
                 sx0, sy0, *_ = self._pan_start
                 if ((event.x - sx0) ** 2 + (event.y - sy0) ** 2) ** 0.5 < 3:

--- a/fibsem/correlation/ui/widgets/image_point_canvas.py
+++ b/fibsem/correlation/ui/widgets/image_point_canvas.py
@@ -43,7 +43,14 @@ from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
 from PyQt5.QtCore import QSize, Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import QCursor
-from PyQt5.QtWidgets import QAction, QMenu, QPushButton, QSizePolicy, QWidget
+from PyQt5.QtWidgets import (
+    QAction,
+    QApplication,
+    QMenu,
+    QPushButton,
+    QSizePolicy,
+    QWidget,
+)
 
 from fibsem.correlation.structures import Coordinate, PointType
 from fibsem.ui.icon import fibsem_icon
@@ -168,6 +175,27 @@ def _legend_handle(
     )
 
 
+_QT_MODIFIER_MAP = (
+    (Qt.AltModifier, "Alt"),
+    (Qt.ShiftModifier, "Shift"),
+    (Qt.ControlModifier, "Control"),
+    (Qt.MetaModifier, "Meta"),
+)
+
+
+def _modifiers_from_event(event) -> Tuple[str, ...]:
+    """Active keyboard modifiers for a matplotlib event, e.g. ``("Shift",)``.
+
+    Reads the underlying Qt event (``event.guiEvent``) — the Qt modifier state is
+    the reliable source in an embedded canvas, whereas matplotlib's
+    ``MouseEvent.key`` depends on canvas keyboard focus. Falls back to the
+    application-wide modifier state when no Qt event is attached.
+    """
+    gui = getattr(event, "guiEvent", None)
+    mods = gui.modifiers() if gui is not None else QApplication.keyboardModifiers()
+    return tuple(name for flag, name in _QT_MODIFIER_MAP if mods & flag)
+
+
 class ImagePointCanvas(FigureCanvasQTAgg):
     """Matplotlib canvas: image + draggable Coordinate markers."""
 
@@ -176,6 +204,7 @@ class ImagePointCanvas(FigureCanvasQTAgg):
     point_removed       = pyqtSignal(object)               # Coordinate
     canvas_clicked      = pyqtSignal(float, float)         # x, y data coords
     point_add_requested = pyqtSignal(float, float, object) # x, y, PointType
+    z_scroll_requested  = pyqtSignal(int)                  # +1 / -1 (Shift+wheel)
 
     def __init__(
         self,
@@ -221,6 +250,9 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         # Dashed datum line across the canvas at the FIB surface y
         self._surface_line = None
         self._surface_line_coord: Optional[Coordinate] = None
+
+        # Shift+wheel steps Z instead of zooming (enabled by the FM display)
+        self._shift_z_enabled: bool = False
 
         # Overlay toolbar (top-right)
         self._overlay_buttons: List[QPushButton] = []
@@ -849,8 +881,15 @@ class ImagePointCanvas(FigureCanvasQTAgg):
             else:
                 self.setCursor(Qt.CursorShape.ArrowCursor)
 
+    def set_shift_z_scroll_enabled(self, enabled: bool) -> None:
+        """When enabled, Shift+wheel emits z_scroll_requested instead of zooming."""
+        self._shift_z_enabled = bool(enabled)
+
     def _on_scroll(self, event) -> None:
         if event.inaxes is not self._ax or event.xdata is None:
+            return
+        if self._shift_z_enabled and "Shift" in _modifiers_from_event(event):
+            self.z_scroll_requested.emit(1 if event.button == "up" else -1)
             return
         factor = 1.0 / _ZOOM_FACTOR if event.button == "up" else _ZOOM_FACTOR
         cx, cy = event.xdata, event.ydata

--- a/fibsem/correlation/ui/widgets/test_correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/test_correlation_tab_widget.py
@@ -1,63 +1,57 @@
-"""Test script for CorrelationTabWidget.
+"""Manual launcher for CorrelationTabWidget, pre-loaded from a project directory.
+
+Quickstart: loads the FIB + FM images and the saved correlation result (or
+coordinate data) from a project directory — defaults to the worktree's ``tmp/``.
 
 Usage
 -----
-    python fibsem/correlation/ui/widgets/test_correlation_tab_widget.py
-"""
-import os
-from pprint import pprint
-import sys
+    # quickstart from tmp/ (FIB + FM images + correlation_result.json)
+    python -m fibsem.correlation.ui.widgets.test_correlation_tab_widget
 
-from PyQt5.QtGui import QColor, QPalette
+    # or point at any correlation project directory
+    python -m fibsem.correlation.ui.widgets.test_correlation_tab_widget /path/to/project
+"""
+import sys
+from pprint import pprint
+
 from PyQt5.QtWidgets import QApplication, QMainWindow
 
-from fibsem.correlation.ui.widgets.correlation_tab_widget import CorrelationTabWidget
-from fibsem.fm.structures import FluorescenceImage
-from fibsem.structures import FibsemImage
+from fibsem.correlation.structures import CorrelationResult
+from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+    CorrelationTabWidget,
+    load_project,
+)
 from fibsem.ui.stylesheets import NAPARI_STYLE
-from fibsem.correlation.structures import CorrelationResult, CorrelationInputData
 
-_DEV_PATH = "/home/patrick/github/fibsem/fibsem/applications/test-data"
-_FIB_IMAGE = "ref_ReferenceImage-Spot-Burn-Fiducial-10-36-30_res_02_ib.tif"
-_FM_IMAGE  = "zstack-Feature-1-Active-002.ome.tiff"
+_DEFAULT_PROJECT = "tmp"
 
 
-class TestWindow(QMainWindow):
-    def __init__(self) -> None:
+class _LauncherWindow(QMainWindow):
+    def __init__(self, directory: str) -> None:
         super().__init__()
         self.setWindowTitle("CorrelationTabWidget — test")
         self.resize(1400, 900)
 
-        fib_image = fm_image = None
-        try:
-            fib_image = FibsemImage.load(os.path.join(_DEV_PATH, _FIB_IMAGE))
-            print("FIB image loaded.")
-        except Exception as exc:
-            print(f"Could not load FIB image: {exc}")
-        try:
-            fm_image = FluorescenceImage.load(os.path.join(_DEV_PATH, _FM_IMAGE))
-            print("FM image loaded.")
-        except Exception as exc:
-            print(f"Could not load FM image: {exc}")
-
-        self._widget = CorrelationTabWidget(fib_image=fib_image, fm_image=fm_image)
+        self._widget = CorrelationTabWidget()
+        load_project(self._widget, directory)
         self.setCentralWidget(self._widget)
-
 
         self._widget.continue_pressed_signal.connect(self._print_continue)
 
-    def _print_continue(self, result: CorrelationResult):
-        # print("Continue pressed! Result:", result)
-
+    def _print_continue(self, result: CorrelationResult) -> None:
         print(f"POI: {len(result.poi)}")
-        pprint(result.poi[0])
+        if result.poi:
+            pprint(result.poi[0])
+
 
 def main() -> None:
-    app = QApplication(sys.argv)
+    directory = sys.argv[1] if len(sys.argv) > 1 else _DEFAULT_PROJECT
+
+    app = QApplication(sys.argv[:1])
     app.setStyle("Fusion")
     app.setStyleSheet(NAPARI_STYLE)
 
-    win = TestWindow()
+    win = _LauncherWindow(directory)
     win.show()
     sys.exit(app.exec_())
 

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -703,3 +703,175 @@ def test_ghost_export_preserves_hollow_style(qapp):
     assert len(lines) == 1
     assert lines[0].get_markerfacecolor() == "none"
     assert lines[0].get_alpha() == pytest.approx(0.7)
+
+
+# ---------------------------------------------------------------------------
+# Polish round 2: Z navigation, FM header, save-plot, minimise
+# ---------------------------------------------------------------------------
+
+
+def _fake_fm(n_c=2, n_z=5, filename="/data/BeforeMilling_G1.ome.tiff"):
+    from types import SimpleNamespace
+
+    import numpy as np
+
+    chans = [SimpleNamespace(name=f"CH{i}", color=None) for i in range(n_c)]
+    return SimpleNamespace(
+        data=np.zeros((n_c, n_z, 8, 8), dtype=np.float32),
+        metadata=SimpleNamespace(filename=filename, channels=chans),
+    )
+
+
+def _scroll_event(canvas, *, button, shift):
+    """A matplotlib-style scroll event carrying a Qt guiEvent with modifiers.
+
+    Mirrors real usage: modifier state is read from ``event.guiEvent.modifiers()``
+    (matplotlib's own ``event.key`` is unreliable in an embedded canvas).
+    """
+    from types import SimpleNamespace
+
+    from PyQt5.QtCore import Qt
+
+    mods = Qt.ShiftModifier if shift else Qt.NoModifier
+    gui = SimpleNamespace(modifiers=lambda: mods)
+    return SimpleNamespace(
+        inaxes=canvas._ax, xdata=1.0, ydata=1.0, button=button, guiEvent=gui
+    )
+
+
+def test_canvas_shift_scroll_emits_z_when_enabled(qapp):
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    got = []
+    canvas.z_scroll_requested.connect(got.append)
+
+    # Disabled by default: Shift+wheel zooms, never emits.
+    canvas._on_scroll(_scroll_event(canvas, button="up", shift=True))
+    assert got == []
+
+    # Enabled: Shift+wheel emits +1 (up) / -1 (down), no zoom.
+    canvas.set_shift_z_scroll_enabled(True)
+    canvas._on_scroll(_scroll_event(canvas, button="up", shift=True))
+    canvas._on_scroll(_scroll_event(canvas, button="down", shift=True))
+    assert got == [1, -1]
+
+    # Enabled but no Shift held: still zooms, no emit.
+    canvas._on_scroll(_scroll_event(canvas, button="up", shift=False))
+    assert got == [1, -1]
+
+
+def test_fm_display_shows_image_name(qapp):
+    from fibsem.correlation.ui.widgets.fm_image_display_widget import (
+        FMImageDisplayWidget,
+    )
+
+    w = FMImageDisplayWidget()
+    assert w._name_label.isHidden() is True  # nothing loaded yet
+
+    w.set_fm_image(_fake_fm(filename="/some/dir/BeforeMilling_G1.ome.tiff"))
+    assert w._name_label.text() == "BeforeMilling_G1.ome.tiff"
+    assert w._name_label.isHidden() is False
+
+
+def test_fib_header_shows_image_name(qapp):
+    from types import SimpleNamespace
+
+    w = _widget(qapp)
+    assert w._fib_name_label.isHidden() is True  # nothing loaded yet
+
+    img = SimpleNamespace(
+        metadata=SimpleNamespace(
+            image_settings=SimpleNamespace(filename="/x/ref_Mill_res_02")
+        )
+    )
+    w._update_fib_name_label(img)
+    assert w._fib_name_label.text() == "ref_Mill_res_02"
+    assert w._fib_name_label.isHidden() is False
+
+
+def test_fm_display_z_step_clamps_and_mip_disables(qapp):
+    from fibsem.correlation.ui.widgets.fm_image_display_widget import (
+        FMImageDisplayWidget,
+    )
+
+    w = FMImageDisplayWidget()
+    w.set_fm_image(_fake_fm(n_z=5))
+    assert w.current_z == 2  # starts mid-stack (n_z // 2)
+
+    w._step_z(1)
+    assert w.current_z == 3
+    for _ in range(10):
+        w._step_z(-1)
+    assert w.current_z == 0  # clamped at floor
+    for _ in range(10):
+        w._step_z(1)
+    assert w.current_z == 4  # clamped at n_z - 1
+
+    # MIP disables the slider + step buttons and freezes _step_z.
+    w._mip_check.setChecked(True)
+    assert not w._z_prev.isEnabled()
+    assert not w._z_next.isEnabled()
+    assert not w._z_slider.isEnabled()
+    frozen = w.current_z
+    w._step_z(-1)
+    assert w.current_z == frozen
+
+
+def test_run_bar_has_save_plot_and_test_menu_removed(qapp):
+    w = _widget(qapp)
+    assert w._btn_save_plot.text() == "Save Plot"
+    assert not hasattr(w, "_action_test_save_plot")
+    # The FM display opts its canvas into Shift+scroll Z stepping.
+    assert w._fm_display.canvas._shift_z_enabled is True
+
+
+def test_dialog_allows_window_minimise(qapp):
+    from PyQt5.QtCore import Qt
+
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        CorrelationTabDialog,
+    )
+
+    d = CorrelationTabDialog()
+    assert bool(d.windowFlags() & Qt.WindowMinimizeButtonHint)
+    assert hasattr(d, "_min_shortcut")
+
+
+def test_discover_correlation_files(tmp_path):
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        _discover_correlation_files,
+    )
+
+    # Empty directory → everything None.
+    assert _discover_correlation_files(str(tmp_path)) == {
+        "fib": None,
+        "fm": None,
+        "data": None,
+        "result": None,
+    }
+
+    (tmp_path / "BeforeMilling_G1.ome.tiff").write_bytes(b"")
+    (tmp_path / "ref_Mill_ib.tif").write_bytes(b"")
+    (tmp_path / "correlation_data.json").write_text("{}")
+    (tmp_path / "correlation_result.json").write_text("{}")
+
+    found = _discover_correlation_files(str(tmp_path))
+    assert os.path.basename(found["fm"]) == "BeforeMilling_G1.ome.tiff"
+    assert os.path.basename(found["fib"]) == "ref_Mill_ib.tif"
+    assert os.path.basename(found["data"]) == "correlation_data.json"
+    assert os.path.basename(found["result"]) == "correlation_result.json"
+
+
+def test_discover_fib_falls_back_to_non_ome_tif(tmp_path):
+    """With no *_ib.tif, the FIB is the first TIFF that isn't the OME-TIFF."""
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        _discover_correlation_files,
+    )
+
+    (tmp_path / "scene.ome.tif").write_bytes(b"")  # FM — must not be taken as FIB
+    (tmp_path / "fib_image.tif").write_bytes(b"")  # plain TIFF → FIB fallback
+
+    found = _discover_correlation_files(str(tmp_path))
+    assert os.path.basename(found["fm"]) == "scene.ome.tif"
+    assert os.path.basename(found["fib"]) == "fib_image.tif"

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -620,7 +620,7 @@ def test_canvas_toolbar_buttons_toggle_state(qapp):
     only their own canvas and stay in sync with the View-menu master toggle."""
     w = _widget(qapp)
     canvas = w._fib_canvas
-    assert len(canvas._overlay_buttons) == 3
+    assert len(canvas._overlay_buttons) == 4
 
     # startup: the menu handler enabled the scalebar on both canvases
     assert canvas._btn_scalebar.isChecked()
@@ -930,3 +930,29 @@ def test_advanced_panels_start_collapsed(qapp):
     assert cl._fib_panel._btn_collapse.isChecked() is True
     assert cl._fm_panel._btn_collapse.isChecked() is True
     assert cl._poi_panel._btn_collapse.isChecked() is True
+
+
+def test_point_labels_have_outline(qapp):
+    """Coloured labels get a dark outline (path effect) so they stay legible on
+    any image background."""
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.set_coordinates([_coord(5.0, 5.0, 0.0, PointType.FIB)])
+    label = canvas._label_artists[0]
+    assert label.get_path_effects()  # dark outline applied
+    assert label.get_fontsize() == 9
+
+
+def test_labels_toggle_hides_labels(qapp):
+    w = _widget(qapp)
+    w._on_canvas_add_requested(5.0, 5.0, PointType.FIB)
+    fib = w._fib_canvas
+    assert fib._label_artists[0].get_visible() is True  # shown by default
+
+    w._on_labels_toggled(False)  # View → Show Labels off
+    assert fib._label_artists[0].get_visible() is False
+    assert fib._btn_labels.isChecked() is False
+
+    w._on_labels_toggled(True)
+    assert fib._label_artists[0].get_visible() is True

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -920,6 +920,111 @@ def test_result_summary_hidden_until_run(qapp):
     assert "RMS 1.50 px" in w._lbl_result.text()
 
 
+def test_result_summary_clears_on_edit(qapp):
+    """Editing a coordinate invalidates the reported RMS, so the badge must not
+    linger beside a status line that has already reset to "Ready."."""
+    w = _widget(qapp)
+    w._on_result_ready(
+        CorrelationResult(
+            poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+            rms_error=1.5,
+        )
+    )
+    assert w._lbl_result.isHidden() is False
+
+    # go through the real signal chain rather than calling the handler directly
+    w._on_canvas_moved(_coord())
+    assert w._lbl_result.isHidden() is True
+
+
+def _result(rms=1.5) -> CorrelationResult:
+    return CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+        rms_error=rms,
+    )
+
+
+def test_continue_gated_on_live_result(qapp):
+    """Continue commits result.poi[0].px_m to the protocol editor, so it must only
+    be armed while the result still describes the current points — otherwise an
+    edit after a run hands the editor a position from the old point set."""
+    w = _widget(qapp)
+    assert w._btn_continue.isEnabled() is False  # nothing to continue with yet
+
+    w._on_result_ready(_result())
+    assert w._btn_continue.isEnabled() is True
+
+    w._on_canvas_moved(_coord())
+    assert w._btn_continue.isEnabled() is False
+
+
+def test_run_continue_emphasis_follows_result(qapp):
+    """A successful run makes Continue the primary action; an edit that invalidates
+    the result hands primacy back to Run."""
+    from fibsem.ui import stylesheets
+
+    w = _widget(qapp)
+    assert w._btn_run.styleSheet() == stylesheets.PRIMARY_BUTTON_STYLESHEET
+    assert w._btn_continue.styleSheet() == stylesheets.SECONDARY_BUTTON_STYLESHEET
+
+    w._on_result_ready(_result())
+    assert w._btn_continue.styleSheet() == stylesheets.PRIMARY_BUTTON_STYLESHEET
+    assert w._btn_run.styleSheet() == stylesheets.SECONDARY_BUTTON_STYLESHEET
+
+    w._on_canvas_moved(_coord())
+    assert w._btn_run.styleSheet() == stylesheets.PRIMARY_BUTTON_STYLESHEET
+    assert w._btn_continue.styleSheet() == stylesheets.SECONDARY_BUTTON_STYLESHEET
+
+
+def _press_release(canvas, coord, *, drag_to=None):
+    """Drive a real press → (optional motion) → release cycle on the canvas."""
+    from types import SimpleNamespace
+
+    def _ev(x, y):
+        sx, sy = canvas._ax.transData.transform((x, y))
+        return SimpleNamespace(
+            inaxes=canvas._ax, button=1, x=sx, y=sy, xdata=x, ydata=y
+        )
+
+    canvas._on_press(_ev(coord.point.x, coord.point.y))
+    if drag_to is not None:
+        canvas._on_motion(_ev(*drag_to))
+    canvas._on_release(_ev(coord.point.x, coord.point.y))
+
+
+def test_canvas_click_selects_without_reporting_a_move(qapp):
+    """Clicking a point to select it must not emit point_moved — downstream that
+    counts as an edit and invalidates the correlation result."""
+    import numpy as np
+
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.set_image(np.zeros((100, 100)))
+    coord = _coord(x=50.0, y=50.0, pt=PointType.FIB)
+    canvas.set_coordinates([coord])
+
+    moved, selected = [], []
+    canvas.point_moved.connect(moved.append)
+    canvas.point_selected.connect(selected.append)
+
+    _press_release(canvas, coord)
+    assert selected == [coord]  # selection still reported...
+    assert moved == []  # ...but no phantom move
+
+    # an actual drag still reports, and the position follows the cursor
+    _press_release(canvas, coord, drag_to=(60.0, 70.0))
+    assert moved == [coord]
+    assert (coord.point.x, coord.point.y) == (60.0, 70.0)
+
+
+def test_z_slider_advertises_shift_scroll(qapp):
+    """Shift+scroll-through-Z has no visible affordance, so the slider tooltip is
+    the only place a user can discover it."""
+    tip = _widget(qapp)._fm_display._z_slider.toolTip()
+    assert "Shift" in tip and "scroll" in tip.lower()
+
+
 def test_advanced_panels_start_collapsed(qapp):
     cl = _widget(qapp)._coords_tab
     # Advanced / set-once panels collapse by default...

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -1018,6 +1018,54 @@ def test_canvas_click_selects_without_reporting_a_move(qapp):
     assert (coord.point.x, coord.point.y) == (60.0, 70.0)
 
 
+def _fit_combos(w):
+    cl = w._coords_tab
+    return [
+        cl._fib_method_combo,
+        cl._fm_fid_method_combo,
+        cl._fm_poi_method_combo,
+        cl._fm_fid_ch_combo,
+        cl._fm_poi_ch_combo,
+    ]
+
+
+def test_fit_combos_ignore_the_wheel(qapp):
+    """Scrolling past the Fit Settings panel must not silently change a fit
+    method or channel — the selection has to survive a wheel event."""
+    from PyQt5.QtCore import QPoint, Qt
+    from PyQt5.QtGui import QWheelEvent
+
+    w = _widget(qapp)
+    for combo in _fit_combos(w):
+        if combo.count() < 2:
+            combo.addItems(["a", "b"])  # channel combos start empty
+        combo.setCurrentIndex(0)
+        before = combo.currentIndex()
+        for _ in range(3):
+            qapp.sendEvent(
+                combo,
+                QWheelEvent(
+                    QPoint(5, 5),
+                    combo.mapToGlobal(QPoint(5, 5)),
+                    QPoint(0, -120),
+                    QPoint(0, -120),
+                    Qt.NoButton,
+                    Qt.NoModifier,
+                    Qt.ScrollUpdate,
+                    False,
+                ),
+            )
+        assert combo.currentIndex() == before, f"{combo} changed on scroll"
+
+
+def test_fit_method_combos_keep_their_defaults(qapp):
+    """The ValueComboBox swap must not disturb the defaults the fits rely on."""
+    cl = _widget(qapp)._coords_tab
+    assert cl._fib_method_combo.currentText() == "Hole"
+    assert cl._fm_fid_method_combo.currentText() == "None"
+    assert cl._fm_poi_method_combo.currentText() == "Gaussian"
+
+
 def test_z_slider_advertises_shift_scroll(qapp):
     """Shift+scroll-through-Z has no visible affordance, so the slider tooltip is
     the only place a user can discover it."""

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -818,9 +818,10 @@ def test_fm_display_z_step_clamps_and_mip_disables(qapp):
     assert w.current_z == frozen
 
 
-def test_run_bar_has_save_plot_and_test_menu_removed(qapp):
+def test_save_plot_in_view_menu_and_test_menu_removed(qapp):
     w = _widget(qapp)
-    assert w._btn_save_plot.text() == "Save Plot"
+    assert w._action_save_plot.text() == "Save Plot"  # View menu, not the run bar
+    assert not hasattr(w, "_btn_save_plot")
     assert not hasattr(w, "_action_test_save_plot")
     # The FM display opts its canvas into Shift+scroll Z stepping.
     assert w._fm_display.canvas._shift_z_enabled is True

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -612,6 +612,76 @@ def test_render_to_axes_replicates_legend(qapp):
     assert _legend_labels(ax) == ["FIB", "POI (P)"]
 
 
+def test_canvas_toolbar_buttons_toggle_state(qapp):
+    """Each canvas gets reset/scalebar/legend buttons; checkable buttons drive
+    only their own canvas and stay in sync with the View-menu master toggle."""
+    w = _widget(qapp)
+    canvas = w._fib_canvas
+    assert len(canvas._overlay_buttons) == 3
+
+    # startup: the menu handler enabled the scalebar on both canvases
+    assert canvas._btn_scalebar.isChecked()
+    assert w._fm_display.canvas._btn_scalebar.isChecked()
+    assert canvas._btn_legend.isChecked()
+
+    # a button toggles only its own canvas
+    canvas._btn_scalebar.click()
+    assert canvas._show_scalebar is False
+    assert w._fm_display.canvas._show_scalebar is True
+
+    canvas._btn_legend.click()
+    assert canvas._legend_visible is False
+    canvas._btn_legend.click()
+    assert canvas._legend_visible is True
+
+    # the View menu still drives both canvases and re-syncs button state
+    w._on_scalebar_toggled(True)
+    assert canvas._show_scalebar is True
+    assert canvas._btn_scalebar.isChecked()
+
+
+def test_fm_scalebar_pixel_size_corrects_for_resize(qapp):
+    """pixel_size_x describes the acquisition resolution; when the displayed
+    data was resized without rewriting metadata, the scalebar pixel size must
+    scale to the displayed width (no-op when metadata matches the data)."""
+    from types import SimpleNamespace
+
+    import numpy as np
+
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        CorrelationTabWidget,
+    )
+
+    def _fm(data_w, res_w, px):
+        return SimpleNamespace(
+            data=np.zeros((1, 3, data_w, data_w), dtype=np.uint8),
+            metadata=SimpleNamespace(pixel_size_x=px, resolution=(res_w, res_w)),
+        )
+
+    eff = CorrelationTabWidget._effective_fm_pixel_size
+    # matched: unchanged
+    assert eff(_fm(512, 512, 150e-9)) == pytest.approx(150e-9)
+    # displayed 512 from a 2048 acquisition → 4× larger pixel
+    assert eff(_fm(512, 2048, 150e-9)) == pytest.approx(600e-9)
+    # missing/zero pixel size → None (no scalebar rather than a wrong one)
+    assert eff(_fm(512, 512, None)) is None
+    # no resolution metadata → fall back to the raw value
+    raw = SimpleNamespace(
+        data=np.zeros((1, 1, 512, 512), dtype=np.uint8),
+        metadata=SimpleNamespace(pixel_size_x=150e-9, resolution=None),
+    )
+    assert eff(raw) == pytest.approx(150e-9)
+
+
+def test_canvas_toolbar_reset_button(qapp):
+    w = _widget(qapp)
+    canvas = w._fib_canvas
+    calls = []
+    canvas.reset_view = lambda: calls.append(True)
+    canvas._overlay_buttons[0].click()  # reset is the first-added (rightmost)
+    assert calls == [True]
+
+
 def test_ghost_export_preserves_hollow_style(qapp):
     from matplotlib.figure import Figure
 

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -204,35 +204,38 @@ def test_apply_pre_without_rerun_only_stores(qapp):
 # ---------------------------------------------------------------------------
 
 
-def test_status_line_shows_pre_correction_after_run(qapp):
-    """The Done message must survive _update_run_button (it used to be
-    overwritten by 'Ready.' immediately)."""
+def test_status_short_and_result_summary_after_run(qapp):
+    """After a run: RMS shows beside Continue; the status line carries a compact
+    RI / POI note (or 'Done.') instead of the old verbose sentence — and it
+    survives _update_run_button."""
     w = _widget(qapp)
     result = CorrelationResult(
         poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+        rms_error=1.5,
         refractive_index_correction_factor=1.5,
         refractive_index_correction_mode="pre",
     )
     w._on_result_ready(result)
-    assert w._lbl_status.text() == "Done — RI pre-correction ×1.500 applied."
+    assert w._lbl_status.text() == "Done — RI ×1.500"
+    assert "RMS 1.50 px" in w._lbl_result.text()
 
     with_ghost = CorrelationResult(
         poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=60.0))],
         poi_uncorrected=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+        rms_error=1.5,
         refractive_index_correction_factor=1.5,
         refractive_index_correction_mode="pre",
     )
     w._on_result_ready(with_ghost)
-    assert (
-        w._lbl_status.text()
-        == "Done — RI pre-correction ×1.500 applied, POI 1 shifted 40.0 px."
-    )
+    assert w._lbl_status.text() == "Done — RI ×1.500, POI Δ40.0 px"
 
     plain = CorrelationResult(
         poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+        rms_error=0.8,
     )
     w._on_result_ready(plain)
     assert w._lbl_status.text() == "Done."
+    assert "RMS 0.80 px" in w._lbl_result.text()
 
 
 def test_apply_post_creates_ghost_and_status(qapp):
@@ -474,7 +477,7 @@ def test_load_result_keeps_status_message(qapp):
         refractive_index_correction_mode="pre",
     )
     w._load_result(result)
-    assert w._lbl_status.text() == "Done — RI pre-correction ×1.500 applied."
+    assert w._lbl_status.text() == "Done — RI ×1.500"
 
 
 def _legend_labels(ax):
@@ -894,3 +897,36 @@ def test_load_error_reverts_path_field(qapp, monkeypatch):
 
     assert tab._fib_path.text() == "/good/prev_ib.tif"
     assert tab._fib_loaded_path == "/good/prev_ib.tif"
+
+
+def test_rms_color_thresholds():
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import _rms_color
+
+    assert _rms_color(1.0) == "#4caf50"  # good → green
+    assert _rms_color(3.0) == "#ffb300"  # ok → amber
+    assert _rms_color(8.0) == "#e53935"  # poor → red
+
+
+def test_result_summary_hidden_until_run(qapp):
+    w = _widget(qapp)
+    assert w._lbl_result.isHidden() is True  # hidden until a run completes
+
+    result = CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+        rms_error=1.5,
+    )
+    w._on_result_ready(result)
+    assert w._lbl_result.isHidden() is False
+    assert "RMS 1.50 px" in w._lbl_result.text()
+
+
+def test_advanced_panels_start_collapsed(qapp):
+    cl = _widget(qapp)._coords_tab
+    # Advanced / set-once panels collapse by default...
+    assert cl._surface_panel._btn_collapse.isChecked() is False
+    assert cl._fm_surface_panel._btn_collapse.isChecked() is False
+    assert cl._fit_panel._btn_collapse.isChecked() is False
+    # ...while the everyday fiducial/POI panels stay expanded.
+    assert cl._fib_panel._btn_collapse.isChecked() is True
+    assert cl._fm_panel._btn_collapse.isChecked() is True
+    assert cl._poi_panel._btn_collapse.isChecked() is True

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -899,12 +899,111 @@ def test_load_error_reverts_path_field(qapp, monkeypatch):
     assert tab._fib_loaded_path == "/good/prev_ib.tif"
 
 
-def test_rms_color_thresholds():
-    from fibsem.correlation.ui.widgets.correlation_tab_widget import _rms_color
+def _fake_fib(pixel_size_m=52.1e-9):
+    """FIB image stub carrying just the pixel size the RMS badge needs."""
+    from types import SimpleNamespace
 
-    assert _rms_color(1.0) == "#4caf50"  # good → green
-    assert _rms_color(3.0) == "#ffb300"  # ok → amber
-    assert _rms_color(8.0) == "#e53935"  # poor → red
+    return SimpleNamespace(
+        metadata=SimpleNamespace(pixel_size=SimpleNamespace(x=pixel_size_m))
+    )
+
+
+def _result_fit(rms=1.82, n=6, worst=(3.0, 1.0)):
+    """A result with n fiducials, one of which is the worst by some margin."""
+    deltas = [Point(x=0.1, y=0.1) for _ in range(max(n - 1, 0))]
+    if n:
+        deltas.append(Point(x=worst[0], y=worst[1]))
+    return CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+        rms_error=rms,
+        reprojected_3d=[PointXYZ(x=0.0, y=0.0, z=0.0) for _ in range(n)],
+        delta_2d=deltas,
+    )
+
+
+def test_rms_never_certifies_a_good_fit():
+    """There is deliberately no "good" colour. A residual can show a fit is
+    wrong; it cannot show one is right, and green would read as that promise."""
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import _rms_concern
+
+    color, reason = _rms_concern(20.0, 8, 1.1)  # about as clean as it gets
+    assert color == "#9aa0a6" and reason is None  # neutral, no verdict either way
+
+
+def test_rms_flags_detectable_problems():
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import _rms_concern
+
+    # A minimum-pair fit: residual is small by construction, not by agreement.
+    color, reason = _rms_concern(20.0, 4, 1.1)
+    assert color == "#ffb300" and "no redundancy" in reason
+
+    # One correspondence dominating the error — the case an average hides.
+    color, reason = _rms_concern(20.0, 8, 3.4)
+    assert color == "#ffb300" and "3.4× the RMS" in reason
+
+    # Far enough out to be breakage rather than a judgement call.
+    color, reason = _rms_concern(1500.0, 8, 1.1)
+    assert color == "#e53935" and "not converged" in reason
+
+
+def test_rms_relative_checks_survive_a_missing_pixel_size():
+    """A result loaded from JSON restores no images, so nm is unavailable — but
+    pair counts and error ratios are unitless and still apply."""
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import _rms_concern
+
+    color, reason = _rms_concern(None, 4, 3.4)
+    assert color == "#ffb300"
+    assert "no redundancy" in reason and "3.4× the RMS" in reason
+
+    assert _rms_concern(None, 8, 1.1) == ("#9aa0a6", None)
+
+
+def test_rms_badge_reports_physical_distance(qapp):
+    """With a FIB pixel size the badge shows nm, so the number means something
+    independent of the HFW the image was taken at."""
+    w = _widget(qapp)
+    w._fib_image = _fake_fib(pixel_size_m=52.1e-9)
+    w._on_result_ready(_result_fit(rms=1.82))
+
+    # 1.82 px x 52.1 nm/px = 95 nm
+    assert "95 nm" in w._lbl_result.text()
+    assert "#9aa0a6" in w._lbl_result.text()  # nothing wrong detected → no verdict
+
+
+def test_rms_badge_falls_back_to_px_without_pixel_size(qapp):
+    """A result loaded from JSON restores no images, so nm is unavailable — show
+    px and stay neutral rather than colouring a figure we cannot interpret."""
+    w = _widget(qapp)  # no FIB image
+    w._on_result_ready(_result_fit(rms=1.82))
+
+    assert "1.82 px" in w._lbl_result.text()
+    assert "#9aa0a6" in w._lbl_result.text()
+    assert "pixel size unknown" in w._lbl_result.toolTip().lower()
+
+
+def test_rms_tooltip_explains_what_is_measured(qapp):
+    w = _widget(qapp)
+    w._fib_image = _fake_fib(pixel_size_m=52.1e-9)
+    w._on_result_ready(_result_fit(rms=1.82, n=6, worst=(3.0, 1.0)))
+    tip = w._lbl_result.toolTip()
+
+    assert "1.82 px" in tip and "52.1 nm/px" in tip  # the conversion is shown
+    assert "6 fiducial pairs" in tip
+    assert "3.16 px" in tip  # worst single fiducial, hypot(3, 1)
+    assert "not POI accuracy" in tip
+
+
+def test_rms_tooltip_flags_a_minimum_fiducial_fit(qapp):
+    """At 4 pairs the rigid fit has almost no redundancy, so a small residual is
+    structural rather than evidence of a good correlation."""
+    w = _widget(qapp)
+    w._fib_image = _fake_fib()
+
+    w._on_result_ready(_result_fit(n=4))
+    assert "no redundancy" in w._lbl_result.toolTip()
+
+    w._on_result_ready(_result_fit(n=8))
+    assert "no redundancy" not in w._lbl_result.toolTip()
 
 
 def test_result_summary_hidden_until_run(qapp):

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -875,3 +875,21 @@ def test_discover_fib_falls_back_to_non_ome_tif(tmp_path):
     found = _discover_correlation_files(str(tmp_path))
     assert os.path.basename(found["fm"]) == "scene.ome.tif"
     assert os.path.basename(found["fib"]) == "fib_image.tif"
+
+
+def test_load_error_reverts_path_field(qapp, monkeypatch):
+    """A failed load reverts the path field to the last-good value, so re-focusing
+    the field doesn't re-attempt (and re-warn about) the bad path."""
+    from PyQt5.QtWidgets import QMessageBox
+
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+
+    tab = _widget(qapp)._images_tab
+    tab._fib_loaded_path = "/good/prev_ib.tif"
+    tab._fib_path.setText("/good/prev_ib.tif")
+
+    tab._fib_path.setText("/nope/does_not_exist_ib.tif")
+    tab._load_fib("/nope/does_not_exist_ib.tif")  # FibsemImage.load raises
+
+    assert tab._fib_path.text() == "/good/prev_ib.tif"
+    assert tab._fib_loaded_path == "/good/prev_ib.tif"


### PR DESCRIPTION
## Summary

UI polish for the correlation widget, working through the feedback batch from a user correlation session (FIB-251) plus a follow-up round. Nine commits, no change to the correlation maths.

## Canvas

- **Per-canvas overlay toolbar** (top-right icon buttons): reset view, toggle scalebar, toggle legend, toggle labels. Checkable buttons stay in sync with the View menu; the legend moves to upper-left to clear the toolbar.
- **Smaller markers** — point markers halved (`_MARKER_SIZE` 10→5, `_SELECTED_SIZE` 14→7) along with the result-overlay markers. matplotlib sizes markers in typographic points, so they don't shrink with zoom and were dominating the image when zoomed out.
- **Legible labels** — point names get a dark outline (path effect) at 9pt so they stay readable over any image background, plus a **show/hide toggle** (toolbar button + View → Show Labels) for when they crowd a dense field.

## FM / FIB display

- **Filename headers** on both canvases via a shared `IMAGE_HEADER_STYLE` — previously the FM name appeared only in the Images-tab path field, and the FIB name nowhere.
- **Z navigation** — `‹`/`›` step buttons beside the Z slider, and **Shift+scroll** to step through Z on the FM canvas, advertised in the slider tooltip since the gesture has no visible affordance. Modifier state is read from `event.guiEvent.modifiers()` rather than matplotlib's `event.key`, which is only populated when the canvas holds keyboard focus (same approach as #111).
- **Resizable FM channel controls** — the channel/contrast rows become the bottom pane of a vertical `QSplitter`, draggable taller/shorter and floored at 3 channel rows so it can't collapse.

## Layout and density

- **Compact coordinate tables** — shorter rows, smaller fonts, tighter spinboxes; they were consuming more vertical space than their content warranted.
- **Wheel-guarded fit settings** — the five Fit Settings combos become `ValueComboBox`, which installs the repo's `WheelBlocker`. A plain `QComboBox` consumes the wheel and steps its selection, so scrolling past the panel silently reassigned the fit method or channel the next refit would use. These were the last unguarded wheel-sensitive widgets in the live correlation UI; the coordinate x/y/z spinboxes and the six refractive-index spinboxes were already `ValueSpinBox`.
- **Advanced panels start collapsed** — Surface (FIB), Surface (FM) and Fit Settings default closed, so the first view is just FIB / FM / POI. All one click to expand.
- **RMS cue** — after a run, an `RMS 115 nm` badge appears beside Continue, where the "is this good enough to proceed?" decision is actually made; previously RMS lived only in the Results tab. See *Reporting the RMS* below for why it reads in nm and why there is no green.
- **Save Plot** moved out of the old *Test* menu into the View menu.
- **Dialog minimise** — Ctrl/Cmd+M on the correlation dialog.

## Result state (correctness)

`Continue` commits `result.poi[0].px_m` to the protocol editor, but it was enabled once in `_on_result_ready` and never disabled again — so editing points after a run left it armed with a position computed from the **old point set**, handing the editor a stale milling position with no warning. The RMS badge had the same flaw, staying visible beside a status line that had already reset to "Ready.".

Continue's enablement, the RMS badge and the Run/Continue emphasis all answer one question — *does the displayed result still describe the current points?* — so they now move together through a single `_set_result_live()`, applied at construction, run start, result ready, and any data change. A failed run also leaves the state cleared, where previously it kept the prior result armed.

Two consequences worth calling out for review:

- **After a run, editing any point now requires a re-run before Continue is available.** That is the intent — the transform no longer fits the points — but it is stricter than the previous behaviour.
- **Clicking a point to select it no longer counts as an edit.** `_on_press` set `_dragging` on any left-click, so `_on_release` emitted `point_moved` even when the pointer never moved; release now compares against the position recorded at press, matching the click-vs-drag threshold the pan path already used. This also stops a `correlation_data.json` rewrite firing on every select-click.

## Reporting the RMS

The run-bar badge started as a green/amber/red grade against pixel thresholds. Both halves of that were wrong.

**Pixels aren't a distance.** `rms_error` is in FIB image pixels — ~33 nm at 50 µm HFW, ~117 nm at 180 µm on a 1536 px-wide image. The same figure spans a 3.6× range of real error, straddling the lamella thickness that decides whether the POI lands inside one. The badge now reports **nm** (µm past 1000), with the raw px and pixel size in the tooltip.

**A residual can't certify a correlation.** It measures agreement across the *fiducials*; the POI is extrapolated from that fit, so a tight residual over a poor fiducial spread still misses. A green light reads as "this will work" — a promise the number cannot make. So there is no green: **neutral means "no detected problem", not "good"**.

What's left is exception-based, and two of the three triggers need no calibration:

| Trigger | Why it needs no threshold |
|---|---|
| Only 4 fiducial pairs | A ~7-DOF rigid fit on 4 pairs is barely over-determined — the small residual is structural, not evidence |
| One fiducial > 2× the RMS | The misplaced correspondence an average hides. A ratio, so it holds at any HFW |
| RMS > 500 nm / > 1 µm | Set far enough out to state breakage rather than judge quality (~7.7 px / ~15 px at 100 µm HFW) |

Both relative checks still apply to a result loaded from JSON, which restores no images and therefore has no pixel size — the badge falls back to px and stays neutral rather than colouring a figure it can't interpret.

The tooltip shows the conversion, the fiducial count, the worst single fiducial, whichever concern fired, and what the number does not mean.

> [!NOTE]
> Checked against two real sessions from `tmp/`: 8 pairs at 173 nm (worst/RMS 1.80) and 7 pairs at 115 nm (worst/RMS 1.56). Both read neutral — no false alarms to tune away.

## Loading

- **Shared path widgets** — the Images-tab Project/FIB/FM browse rows become `QDirectoryLineEdit` / `QFileLineEdit` (editable + `...` browse), with a last-loaded-path guard so focus-out doesn't trigger a reload.
- **Revert on error** — a failed image load restores the last-good path rather than leaving the rejected one in the field.
- **Quickstart** — `load_project(widget, dir)` + `_discover_correlation_files` load a project directory's FIB/FM images and any saved data/result in one call:
  ```bash
  python -m fibsem.correlation.ui.widgets.correlation_tab_widget <project_dir>
  ```
- **`load_result(path)`** is now public, mirroring `load_data`.
- **FM scalebar resize guard** — `_effective_fm_pixel_size` corrects the scalebar when the displayed data width disagrees with `metadata.resolution` (no-op when they match).

> [!IMPORTANT]
> The *actual* cause of the wrong FM scalebar on real METEOR data is an OME `<Filter>` parse bug that discards metadata and defaults to 1 µm/px — fixed separately in #142. The resize guard here is a defensive complement, not the root-cause fix.

## Testing

88 correlation-tab tests pass headless (`QT_QPA_PLATFORM=offscreen`), with new coverage for the toolbar toggles and view reset, the resize-corrected pixel size, Shift+scroll Z routing (via a synthetic `guiEvent` carrying Qt modifiers), the RMS unit conversion and concern flags, the collapsed-by-default panels, the label outlines, the fit-combo wheel guard, and the result-live state — badge lifecycle, Continue gating, Run/Continue emphasis, and click-select vs. drag driven through real press/motion/release events.

Each behavioural test was mutation-checked: removing the fix it covers makes it fail, so none of them pass vacuously. Worth noting for the wheel guard specifically — a synthetic `QWheelEvent` *does* move a plain `QComboBox` under offscreen Qt (three wheel-downs stepped it 0 → 2), so that test is measuring the real thing.

Live-tested in the app across project load, toolbar toggles, channel-pane resize, the new path fields, Z navigation, and the select/edit/re-run cycle.

## Not in scope

Two load-path issues found while reviewing this work are filed separately rather than folded in here, since they are bug/persistence work rather than polish:

- **FIB-263** — Load Coordinates crashes on a `correlation_result.json` (unguarded `_on_load` + hard `data["fib_coordinates"]` subscript).
- **FIB-264** — consolidate `correlation_data.json` and `correlation_result.json` into one file, which removes the mis-click that causes FIB-263.
