### PR TITLE
Correlation: per-point fit confirmation + fitting UX polish (FIB-252)

### DIFF
--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -38,15 +38,22 @@ class PointXYZ:
 class Coordinate:
     point: PointXYZ = field(default_factory=PointXYZ)
     point_type: PointType = field(default=PointType.FIB)
+    fitted: bool = False  # True when this position came from an accepted auto-fit
 
     def to_dict(self):
-        return {"point": self.point.to_dict(), "point_type": self.point_type.value}
+        return {
+            "point": self.point.to_dict(),
+            "point_type": self.point_type.value,
+            "fitted": self.fitted,
+        }
 
     @staticmethod
     def from_dict(data: dict) -> Coordinate:
         point = PointXYZ.from_dict(data["point"])
         point_type = PointType(data["point_type"])
-        return Coordinate(point=point, point_type=point_type)
+        return Coordinate(
+            point=point, point_type=point_type, fitted=data.get("fitted", False)
+        )
 
 
 def scale_about_surface(value, surface, correction_factor):

--- a/fibsem/correlation/ui/widgets/coordinate_list_widget.py
+++ b/fibsem/correlation/ui/widgets/coordinate_list_widget.py
@@ -13,9 +13,10 @@ import os
 from typing import Dict, List, Optional
 
 from PyQt5.QtCore import QEvent, QSize, Qt, pyqtSignal
-from PyQt5.QtGui import QColor, QIcon, QPixmap
+from PyQt5.QtGui import QColor, QFontMetrics, QIcon, QPixmap
 from PyQt5.QtWidgets import (
     QAbstractItemView,
+    QApplication,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -27,6 +28,7 @@ from PyQt5.QtWidgets import (
 
 from fibsem.correlation.structures import Coordinate, PointType
 from fibsem.ui import stylesheets
+from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueSpinBox
 
 _DRAG_HANDLE_PATH = os.path.join(
@@ -40,6 +42,12 @@ _BTN_SIZE = QSize(24, 24)
 _ROW_HEIGHT = 28
 # Spacer in header aligning with drag handle in rows (layout spacing handles the 4px gap)
 _ROW_RIGHT_WIDTH = 10
+
+# Fit-state indicator colours. A fitted point (unmodified auto-fit result) is
+# white so it reads as "lit up"; otherwise a muted grey — dimmer than the light
+# trash/edit icons — so it recedes to a placeholder.
+_FITTED_ICON_COLOR = "#ffffff"
+_UNFITTED_ICON_COLOR = "#6b6f76"
 
 _POINT_TYPE_COLORS: Dict[PointType, str] = {
     PointType.FIB:        "lime",
@@ -64,6 +72,22 @@ def _generate_names(coordinates: List[Coordinate]) -> List[str]:
         counters[c.point_type] = counters.get(c.point_type, 0) + 1
         names.append(f"{c.point_type.value} {counters[c.point_type]}")
     return names
+
+
+def _name_col_width(point_type: Optional[PointType]) -> int:
+    """Width of the Name column, sized to the longest name this list can show.
+
+    Names are ``"{point_type} {n}"`` and each list holds a single point type, so
+    a fiducial list ("FM 8") needs far less room than a surface ("FM-SURFACE 1").
+    Sizing per list removes the wide empty gap that a fixed 100px left after the
+    short FIB/FM/POI names. Capped at that former width so surface lists — the
+    only ones that filled it — are unchanged.
+    """
+    label = f"{point_type.value if point_type else 'POINT'} 99"
+    font = QApplication.font()  # the app-default family the label inherits...
+    font.setPixelSize(11)       # ...at the row/name label font-size
+    text_w = QFontMetrics(font).horizontalAdvance(label)
+    return max(48, min(text_w + 14, _NAME_FIXED_WIDTH))  # +padding, clamped
 
 
 # ---------------------------------------------------------------------------
@@ -103,7 +127,12 @@ class _CoordinateListHeader(QWidget):
     """Sticky dark header with column labels, a color indicator for the
     selected coordinate's point type, and a shared refit button."""
 
-    def __init__(self, parent=None, default_color: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        parent=None,
+        default_color: Optional[str] = None,
+        name_width: int = _NAME_FIXED_WIDTH,
+    ) -> None:
         self._default_color = default_color
         super().__init__(parent)
         self.setStyleSheet("background: #1e2124;")
@@ -120,7 +149,7 @@ class _CoordinateListHeader(QWidget):
                 lbl.setFixedWidth(width)
             return lbl
 
-        layout.addWidget(_lbl("Name", _NAME_FIXED_WIDTH))
+        layout.addWidget(_lbl("Name", name_width))
         layout.addWidget(_lbl("X", _SPIN_FIXED_WIDTH))
         layout.addWidget(_lbl("Y", _SPIN_FIXED_WIDTH))
         layout.addWidget(_lbl("Z", _SPIN_FIXED_WIDTH))
@@ -186,6 +215,7 @@ class CoordinateRowWidget(QWidget):
         coord: Coordinate,
         name: str,
         parent: Optional[QWidget] = None,
+        name_width: int = _NAME_FIXED_WIDTH,
     ) -> None:
         super().__init__(parent)
         self.coord = coord
@@ -197,10 +227,10 @@ class CoordinateRowWidget(QWidget):
 
         # Name label (read-only)
         self.name_label = QLabel(name)
-        self.name_label.setFixedWidth(_NAME_FIXED_WIDTH)
-        self.name_label.setStyleSheet(
-            "color: #F0F1F2; background: transparent; font-size: 11px;"
-        )
+        self.name_label.setFixedWidth(name_width)
+        # Omit `background: transparent` — it's the QLabel default, and an
+        # unscoped rule bleeds into this label's QToolTip background.
+        self.name_label.setStyleSheet("color: #F0F1F2; font-size: 11px;")
         self.name_label.setToolTip("Auto-generated coordinate name")
         layout.addWidget(self.name_label)
 
@@ -225,6 +255,23 @@ class CoordinateRowWidget(QWidget):
             _spin.setStyleSheet("font-size: 11px; padding: 1px 6px;")
 
         layout.addStretch(1)
+
+        # Fit-state indicator — always visible so every row keeps an aligned
+        # status column; the colour encodes the state (white = auto-fit and
+        # confirmed, grey = manually placed). coord.fitted clears on a manual
+        # edit. Pixmaps are pre-rendered once and swapped on refresh.
+        self._icon_fitted = fibsem_icon(
+            "mdi:target", color=_FITTED_ICON_COLOR
+        ).pixmap(QSize(14, 14))
+        self._icon_unfitted = fibsem_icon(
+            "mdi:target", color=_UNFITTED_ICON_COLOR
+        ).pixmap(QSize(14, 14))
+        self.fitted_icon = QLabel()
+        self.fitted_icon.setFixedSize(16, 16)
+        # No `background: transparent` stylesheet: a QLabel is already
+        # background-less, and an unscoped rule here would bleed into this
+        # widget's QToolTip (making the tooltip background transparent too).
+        layout.addWidget(self.fitted_icon)
 
         # Remove button
         self.btn_remove = IconToolButton(
@@ -304,6 +351,17 @@ class CoordinateRowWidget(QWidget):
         self.z_spin.setValue(self.coord.point.z)
         for w in (self.x_spin, self.y_spin, self.z_spin):
             w.blockSignals(False)
+        self._update_fitted_icon()
+
+    def _update_fitted_icon(self) -> None:
+        """Colour the always-visible indicator by fit state (green vs grey)."""
+        fitted = bool(getattr(self.coord, "fitted", False))
+        self.fitted_icon.setPixmap(
+            self._icon_fitted if fitted else self._icon_unfitted
+        )
+        self.fitted_icon.setToolTip(
+            "Auto-fit and confirmed" if fitted else "Manually placed (not auto-fit)"
+        )
 
     # ------------------------------------------------------------------
     # Mutation handlers
@@ -369,6 +427,7 @@ class CoordinateListWidget(QWidget):
         self._y_max: Optional[float] = None
         self._z_max: Optional[float] = None
         self._default_header_color = _POINT_TYPE_COLORS.get(point_type) if point_type else None
+        self._name_width = _name_col_width(point_type)
 
         self._setup_ui()
         self._connect_signals()
@@ -381,7 +440,9 @@ class CoordinateListWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        self._header = _CoordinateListHeader(default_color=self._default_header_color)
+        self._header = _CoordinateListHeader(
+            default_color=self._default_header_color, name_width=self._name_width
+        )
         layout.addWidget(self._header)
 
         sep = QFrame()
@@ -455,7 +516,9 @@ class CoordinateListWidget(QWidget):
         self._empty_label.setVisible(len(self._coordinates) == 0)
 
     def _add_row(self, coord: Coordinate, name: str) -> None:
-        row_widget = CoordinateRowWidget(coord=coord, name=name)
+        row_widget = CoordinateRowWidget(
+            coord=coord, name=name, name_width=self._name_width
+        )
         if any(v is not None for v in (self._x_max, self._y_max, self._z_max)):
             row_widget.set_axis_maxima(self._x_max, self._y_max, self._z_max)
         self._connect_row(row_widget)

--- a/fibsem/correlation/ui/widgets/coordinate_list_widget.py
+++ b/fibsem/correlation/ui/widgets/coordinate_list_widget.py
@@ -165,7 +165,7 @@ class _CoordinateListHeader(QWidget):
         # Refit button — acts on selected coordinate; disabled when nothing selected
         self.btn_refit = IconToolButton(
             icon="mdi:refresh",
-            tooltip="Refit selected coordinate",
+            tooltip="Refit selected coordinate (F)",
             size=_BTN_SIZE.width(),
         )
         self.btn_refit.setEnabled(False)

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -77,6 +77,10 @@ from fibsem.correlation.structures import (
     scale_about_surface,
 )
 from fibsem.correlation.ui.widgets.coordinate_list_widget import CoordinateListWidget
+from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+    FitConfirmationDialog,
+    PointFitResult,
+)
 from fibsem.ui import stylesheets
 from fibsem.correlation.ui.widgets.fm_image_display_widget import (
     IMAGE_HEADER_STYLE,
@@ -169,19 +173,6 @@ def _ro_item(text: str) -> QTableWidgetItem:
     item.setFlags(Qt.ItemFlag.ItemIsEnabled)
     item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
     return item
-
-
-def _show_figure_dialog(fig, title: str = "Diagnostic", parent=None) -> None:
-    """Show a matplotlib figure in a non-modal QDialog."""
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
-
-    dlg = QDialog(parent)
-    dlg.setWindowTitle(title)
-    dlg.resize(600, 400)
-    layout = QVBoxLayout(dlg)
-    canvas = FigureCanvasQTAgg(fig)
-    layout.addWidget(canvas)
-    dlg.show()
 
 
 # ---------------------------------------------------------------------------
@@ -1832,6 +1823,7 @@ class CorrelationTabWidget(QWidget):
         self._select_only(spec, coord)
 
     def _on_canvas_moved(self, coord: Coordinate) -> None:
+        coord.fitted = False  # a manual drag supersedes any accepted fit
         spec = self._point_specs[coord.point_type]
         spec.list_widget.refresh_coordinate(coord)
         self.data_changed.emit(self.data)
@@ -1884,6 +1876,7 @@ class CorrelationTabWidget(QWidget):
     def _on_list_changed(
         self, spec: _PointTypeSpec, coord: Coordinate, _f: str, _v: float
     ) -> None:
+        coord.fitted = False  # a manual edit supersedes any accepted fit
         spec.adapter.refresh_coordinate(coord)
         self.data_changed.emit(self.data)
 
@@ -2066,7 +2059,30 @@ class CorrelationTabWidget(QWidget):
     # ------------------------------------------------------------------
 
     def _on_refit_requested(self, coord: Coordinate) -> None:
-        """Run auto-centroid fitting on the selected coordinate."""
+        """Auto-fit the coordinate, then confirm the result before applying it."""
+        result = self._run_point_fit(coord)
+        if result is None:
+            return  # no applicable method / image — nothing to fit
+
+        show_fig = self._coords_tab._show_diag_check.isChecked()
+        dialog = FitConfirmationDialog(result, show_figure=show_fig, parent=self)
+        try:
+            accepted = dialog.exec_() == QDialog.Accepted
+        finally:
+            if result.figure is not None:
+                import matplotlib.pyplot as plt
+
+                plt.close(result.figure)
+        if accepted:
+            self._apply_fit_result(result)
+
+    def _run_point_fit(self, coord: Coordinate) -> Optional[PointFitResult]:
+        """Compute an auto-fit for ``coord`` WITHOUT mutating it.
+
+        Returns None when no fit is applicable (method "None" / image missing);
+        otherwise a PointFitResult carrying the proposed position, coarse status,
+        and the diagnostic figure.
+        """
         from fibsem.correlation.util import (
             hole_fitting_FIB,
             hole_fitting_reflection,
@@ -2076,16 +2092,19 @@ class CorrelationTabWidget(QWidget):
         cl = self._coords_tab
         spec = self._point_specs[coord.point_type]
         x, y, z = coord.point.x, coord.point.y, coord.point.z
-        fig = None
+        initial = PointXYZ(x, y, z)
+        method, channel = "", None
+        fitted, fig, error, attempted = None, None, None, False
 
         try:
             if spec.adapter.side == "fib":
                 method = cl._fib_method_combo.currentText()
                 if method == "Hole" and self._fib_image is not None:
+                    attempted = True
                     xr, yr, fig = hole_fitting_FIB(
                         self._fib_image.filtered_data, int(x), int(y)
                     )
-                    coord.point.x, coord.point.y = float(xr), float(yr)
+                    fitted = PointXYZ(float(xr), float(yr), z)
             else:
                 # The FM surface is typically picked in the reflection channel,
                 # so it shares the fiducial method/channel settings.
@@ -2093,33 +2112,55 @@ class CorrelationTabWidget(QWidget):
                 method = (
                     cl._fm_fid_method_combo if is_fid else cl._fm_poi_method_combo
                 ).currentText()
-                ch = (
+                channel = (
                     cl._fm_fid_ch_combo if is_fid else cl._fm_poi_ch_combo
                 ).currentIndex()
-                if method != "None" and self._fm_image is not None and ch >= 0:
-                    img = self._fm_image.data[ch]
+                if method != "None" and self._fm_image is not None and channel >= 0:
+                    img = self._fm_image.data[channel]
                     if method == "Hole":
+                        attempted = True
                         xr, yr, zr, fig = hole_fitting_reflection(
                             img, int(x), int(y), z=int(z), cutout=2
                         )
+                        fitted = PointXYZ(float(xr), float(yr), float(zr))
                     elif method == "Gaussian":
+                        attempted = True
                         xr, yr, zr, fig = target_fitting_fluorescence(
                             img, int(x), int(y), int(z), cutout=5
                         )
-                    coord.point.x = float(xr)
-                    coord.point.y = float(yr)
-                    coord.point.z = float(zr)
-
+                        fitted = PointXYZ(float(xr), float(yr), float(zr))
         except Exception as exc:
-            QMessageBox.warning(self, "Refit failed", str(exc))
-            return
+            logging.exception("Point fit failed")
+            error, attempted = str(exc), True
 
+        if not attempted:
+            return None
+
+        status = PointFitResult.classify(initial, fitted, error=error)
+        return PointFitResult(
+            coordinate=coord,
+            method=method,
+            channel=channel,
+            initial=initial,
+            fitted=fitted,
+            status=status,
+            message=error,
+            figure=fig,
+        )
+
+    def _apply_fit_result(self, result: PointFitResult) -> None:
+        """Commit an accepted fit: move the coordinate and flag it as fitted."""
+        if result.fitted is None:
+            return
+        coord = result.coordinate
+        coord.point.x = result.fitted.x
+        coord.point.y = result.fitted.y
+        coord.point.z = result.fitted.z
+        coord.fitted = True
+        spec = self._point_specs[coord.point_type]
         spec.list_widget.refresh_coordinate(coord)
         spec.adapter.refresh_coordinate(coord)
         self.data_changed.emit(self.data)
-
-        if fig is not None and cl._show_diag_check.isChecked():
-            _show_figure_dialog(fig, title="Refit Diagnostic", parent=self)
 
 
 # ---------------------------------------------------------------------------

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -44,6 +44,8 @@ logging.basicConfig(level=logging.INFO)
 import numpy as np
 from PyQt5.QtCore import Qt, QThread, pyqtSignal
 from PyQt5.QtWidgets import (
+    QAbstractSpinBox,
+    QApplication,
     QCheckBox,
     QAction,
     QDialog,
@@ -52,6 +54,7 @@ from PyQt5.QtWidgets import (
     QHBoxLayout,
     QHeaderView,
     QLabel,
+    QLineEdit,
     QMenuBar,
     QMessageBox,
     QPushButton,
@@ -79,6 +82,7 @@ from fibsem.correlation.structures import (
 from fibsem.correlation.ui.widgets.coordinate_list_widget import CoordinateListWidget
 from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
     FitConfirmationDialog,
+    FitStatus,
     PointFitResult,
     humanize_fit_error,
 )
@@ -99,6 +103,13 @@ from fibsem.ui.widgets.custom_widgets import (
 from fibsem.correlation.ui.widgets.refractive_index_widget import RefractiveIndexWidget
 
 _FIT_METHODS = ["None", "Hole", "Gaussian"]
+
+# Auto-accept outlier fallback: a fit is a refinement of the user's click, so a
+# large jump usually means it locked onto the wrong feature. Beyond these, the
+# confirm dialog is shown even in auto-accept mode. Generous — the goal is to
+# catch gross mis-locks, not sub-pixel disagreement.
+_AUTO_ACCEPT_MAX_XY_PX = 25.0  # XY displacement (pixels)
+_AUTO_ACCEPT_MAX_Z = 5.0       # Z displacement (slices)
 
 # Run-bar RMS cue. The badge FLAGS problems; it never certifies quality. The RMS
 # is a fit residual over the fiducials, so a low value cannot promise the POI —
@@ -504,6 +515,25 @@ class _CoordinatesTab(QWidget):
 
         self._show_diag_check = QCheckBox()
         fit_form.addRow("Show diagnostic:", self._show_diag_check)
+
+        # Opt-in: apply fits without the confirm dialog. Off by default (the
+        # confirm-first behaviour of FIB-252). Errors and far-off "surprising"
+        # fits still surface the dialog — see _on_refit_requested.
+        self._auto_accept_check = QCheckBox()
+        self._auto_accept_check.setToolTip(
+            "Apply fits immediately without the confirm dialog.\n"
+            "Failed or far-off fits still ask for confirmation."
+        )
+        fit_form.addRow("Auto-accept fits:", self._auto_accept_check)
+
+        fit_help = QLabel(
+            "Select a point and press <b>F</b> to fit it. Each fit opens a "
+            "confirmation to accept or reject — unless <b>Auto-accept</b> is on "
+            "(failed or far-off fits still ask)."
+        )
+        fit_help.setWordWrap(True)
+        fit_help.setStyleSheet("color: #8a8d93; font-size: 11px; padding-top: 4px;")
+        fit_form.addRow(fit_help)
 
         self._fit_panel = TitledPanel("Fit Settings", collapsible=True)
         self._fit_panel.set_content(fit_body)
@@ -1093,6 +1123,7 @@ class CorrelationTabWidget(QWidget):
 
         self._setup_ui()
         self._connect_signals()
+        self._setup_shortcuts()
         self._set_result_live(False)
 
         if fib_image is not None:
@@ -2060,11 +2091,43 @@ class CorrelationTabWidget(QWidget):
     # Refit
     # ------------------------------------------------------------------
 
+    def _setup_shortcuts(self) -> None:
+        """`F` fits the selected coordinate — same as the header refit button,
+        without hunting for it. Scoped to this widget and its children so it
+        only fires while the correlation UI has focus."""
+        self._fit_shortcut = QShortcut(QKeySequence("F"), self)
+        self._fit_shortcut.setContext(
+            Qt.ShortcutContext.WidgetWithChildrenShortcut
+        )
+        self._fit_shortcut.activated.connect(self._fit_selected_coordinate)
+
+    def _selected_coordinate(self) -> Optional[Coordinate]:
+        """The single selected coordinate across the lists (``_select_only``
+        guarantees at most one), or None."""
+        for spec in self._point_specs.values():
+            coord = spec.list_widget.selected_coordinate
+            if coord is not None:
+                return coord
+        return None
+
+    def _fit_selected_coordinate(self) -> None:
+        """`F` hotkey: fit the currently-selected coordinate."""
+        # Don't hijack the key while a value is being edited in a field.
+        if isinstance(QApplication.focusWidget(), (QLineEdit, QAbstractSpinBox)):
+            return
+        coord = self._selected_coordinate()
+        if coord is not None:
+            self._on_refit_requested(coord)
+
     def _on_refit_requested(self, coord: Coordinate) -> None:
         """Auto-fit the coordinate, then confirm the result before applying it."""
         result = self._run_point_fit(coord)
         if result is None:
             return  # no applicable method / image — nothing to fit
+
+        if self._should_auto_accept(result):
+            self._auto_accept_fit(result)
+            return
 
         show_fig = self._coords_tab._show_diag_check.isChecked()
         dialog = FitConfirmationDialog(result, show_figure=show_fig, parent=self)
@@ -2077,6 +2140,37 @@ class CorrelationTabWidget(QWidget):
                 plt.close(result.figure)
         if accepted:
             self._apply_fit_result(result)
+
+    def _should_auto_accept(self, result: PointFitResult) -> bool:
+        """Auto-accept only when opted in, the fit succeeded, and it isn't a
+        far-off outlier — failures and surprising jumps still get the dialog."""
+        if not self._coords_tab._auto_accept_check.isChecked():
+            return False
+        if result.status is FitStatus.ERROR:
+            return False
+        return not self._is_surprising_fit(result)
+
+    @staticmethod
+    def _is_surprising_fit(result: PointFitResult) -> bool:
+        """A jump larger than a refinement should be — likely the wrong feature."""
+        return (
+            result.delta_px > _AUTO_ACCEPT_MAX_XY_PX
+            or abs(result.delta_z) > _AUTO_ACCEPT_MAX_Z
+        )
+
+    def _auto_accept_fit(self, result: PointFitResult) -> None:
+        """Apply a fit without the confirm dialog, with a status-bar note."""
+        self._apply_fit_result(result)
+        if result.figure is not None:
+            import matplotlib.pyplot as plt
+
+            plt.close(result.figure)
+        # Set the note AFTER applying (apply emits data_changed, which may
+        # refresh the status line) so this is the message that sticks.
+        name = result.coordinate.point_type.value
+        self._lbl_status.setText(
+            f"Auto-fit {name}: Δ {result.delta_px:.1f} px, {result.delta_z:+.1f} z"
+        )
 
     def _run_point_fit(self, coord: Coordinate) -> Optional[PointFitResult]:
         """Compute an auto-fit for ``coord`` WITHOUT mutating it.

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -80,6 +80,7 @@ from fibsem.correlation.ui.widgets.coordinate_list_widget import CoordinateListW
 from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
     FitConfirmationDialog,
     PointFitResult,
+    humanize_fit_error,
 )
 from fibsem.ui import stylesheets
 from fibsem.correlation.ui.widgets.fm_image_display_widget import (
@@ -1878,6 +1879,7 @@ class CorrelationTabWidget(QWidget):
     ) -> None:
         coord.fitted = False  # a manual edit supersedes any accepted fit
         spec.adapter.refresh_coordinate(coord)
+        spec.list_widget.refresh_coordinate(coord)  # drop the fitted indicator
         self.data_changed.emit(self.data)
 
     def _on_list_removed(self, spec: _PointTypeSpec, _coord: Coordinate) -> None:
@@ -2093,8 +2095,8 @@ class CorrelationTabWidget(QWidget):
         spec = self._point_specs[coord.point_type]
         x, y, z = coord.point.x, coord.point.y, coord.point.z
         initial = PointXYZ(x, y, z)
-        method, channel = "", None
-        fitted, fig, error, attempted = None, None, None, False
+        method, channel, channel_name = "", None, None
+        fitted, fig, error, error_detail, attempted = None, None, None, None, False
 
         try:
             if spec.adapter.side == "fib":
@@ -2112,9 +2114,9 @@ class CorrelationTabWidget(QWidget):
                 method = (
                     cl._fm_fid_method_combo if is_fid else cl._fm_poi_method_combo
                 ).currentText()
-                channel = (
-                    cl._fm_fid_ch_combo if is_fid else cl._fm_poi_ch_combo
-                ).currentIndex()
+                ch_combo = cl._fm_fid_ch_combo if is_fid else cl._fm_poi_ch_combo
+                channel = ch_combo.currentIndex()
+                channel_name = ch_combo.currentText()
                 if method != "None" and self._fm_image is not None and channel >= 0:
                     img = self._fm_image.data[channel]
                     if method == "Hole":
@@ -2131,7 +2133,9 @@ class CorrelationTabWidget(QWidget):
                         fitted = PointXYZ(float(xr), float(yr), float(zr))
         except Exception as exc:
             logging.exception("Point fit failed")
-            error, attempted = str(exc), True
+            error_detail = str(exc)          # raw text -> log + tooltip
+            error = humanize_fit_error(exc)  # user-facing, actionable
+            attempted = True
 
         if not attempted:
             return None
@@ -2141,10 +2145,12 @@ class CorrelationTabWidget(QWidget):
             coordinate=coord,
             method=method,
             channel=channel,
+            channel_name=channel_name,
             initial=initial,
             fitted=fitted,
             status=status,
             message=error,
+            detail=error_detail,
             figure=fig,
         )
 

--- a/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
+++ b/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
@@ -18,6 +18,7 @@ from PyQt5.QtWidgets import (
     QDialog,
     QHBoxLayout,
     QLabel,
+    QLayout,
     QPushButton,
     QVBoxLayout,
     QWidget,
@@ -49,6 +50,8 @@ class PointFitResult:
     fitted: Optional[PointXYZ]
     status: FitStatus
     message: Optional[str] = None
+    channel_name: Optional[str] = None  # display label for `channel` (FM only)
+    detail: Optional[str] = None        # raw error, surfaced as a tooltip
     figure: object = None  # matplotlib Figure; not serialised
 
     @property
@@ -109,7 +112,31 @@ def _status_text(result: "PointFitResult") -> str:
         return "Fit ok"
     if result.status is FitStatus.UNCHANGED:
         return "No change — fit ≈ original"
-    return f"Fit failed: {result.message or 'no result'}"
+    return "Fit failed"  # the (long) reason goes in a separate wrapped line
+
+
+def humanize_fit_error(exc: Exception) -> str:
+    """Turn a raw fit exception into an actionable, non-jargon message.
+
+    scipy surfaces failures like *"Optimal parameters not found: Number of calls
+    to function has reached maxfev = 800"* — meaningless to a user. Map the known
+    modes to plain guidance; the raw text is still logged (and shown as a tooltip
+    via :attr:`PointFitResult.detail`) so debugging isn't lost.
+    """
+    msg = str(exc)
+    if "maxfev" in msg or "Optimal parameters not found" in msg:
+        return (
+            "The fit didn't converge — the feature may be too faint, or not "
+            "centred in the search region. Try re-centring your click, or a "
+            "different channel / method."
+        )
+    if isinstance(exc, IndexError) or "out of bounds" in msg or "too close" in msg:
+        return "The point is too close to the image edge to fit a region around it."
+    if isinstance(exc, (ValueError, ZeroDivisionError)) and (
+        "empty" in msg or "zero-size" in msg or "float division" in msg
+    ):
+        return "The search region is empty or featureless — nothing to fit."
+    return "The fit failed unexpectedly (see log for details)."
 
 
 def _fmt_xyz(p: PointXYZ) -> str:
@@ -223,12 +250,31 @@ class FitConfirmationDialog(QDialog):
             f"background: {bg}; color: {fg}; border-radius: 10px; "
             f"padding: 4px 12px; font-size: 12px;"
         )
+        if result.detail:  # raw error kept reachable without cluttering the chip
+            status.setToolTip(result.detail)
         layout.addWidget(status, alignment=Qt.AlignmentFlag.AlignLeft)
+
+        # The humanized failure reason can be a couple of sentences — keep it out
+        # of the chip (which would force the whole dialog absurdly wide) and show
+        # it as a wrapped detail line, capped so it wraps instead of stretching.
+        if result.status is FitStatus.ERROR and result.message:
+            reason = QLabel(result.message)
+            reason.setWordWrap(True)
+            reason.setMaximumWidth(440)
+            reason.setStyleSheet("color: #d9b3b3; font-size: 12px;")
+            if result.detail:
+                reason.setToolTip(result.detail)
+            layout.addWidget(reason)
 
         body = QHBoxLayout()
         body.setSpacing(14)
 
-        if show_figure and result.figure is not None:
+        # The diagnostic figure is always built by the fit, so always embed it
+        # and toggle its visibility at runtime (see the "diagnostic" button).
+        # `show_figure` is only the INITIAL state — the pre-fit checkbox default.
+        self._canvas = None
+        self._diag_shown = False
+        if result.figure is not None:
             from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 
             _apply_dark_theme(result.figure)
@@ -243,12 +289,19 @@ class FitConfirmationDialog(QDialog):
             disp_h = 340
             disp_w = int(min(disp_h * (w_in / h_in), 900)) if h_in else disp_h
             canvas.setMinimumSize(max(disp_w, 300), disp_h)
+            canvas.setVisible(show_figure)
+            self._canvas = canvas
+            self._diag_shown = show_figure
             body.addWidget(canvas, stretch=1)
 
         details = QVBoxLayout()
         details.setSpacing(4)
         details.addWidget(_kv("point", result.coordinate.point_type.value))
         details.addWidget(_kv("method", result.method or "—"))
+        if result.channel is not None:  # FM fits run on a specific channel
+            details.addWidget(
+                _kv("channel", result.channel_name or f"channel {result.channel}")
+            )
         details.addWidget(_kv("before", _fmt_xyz(result.initial)))
         if result.fitted is not None:
             details.addWidget(
@@ -266,6 +319,12 @@ class FitConfirmationDialog(QDialog):
         layout.addLayout(body)
 
         btn_row = QHBoxLayout()
+        # Diagnostic toggle sits on the left, apart from the accept/reject cluster.
+        if self._canvas is not None:
+            self._toggle_btn = QPushButton(self._diag_btn_text(self._diag_shown))
+            self._toggle_btn.setToolTip("Show or hide the fit diagnostic plot")
+            self._toggle_btn.clicked.connect(self._on_toggle_diagnostic)
+            btn_row.addWidget(self._toggle_btn)
         btn_row.addStretch(1)
         if result.status is FitStatus.ERROR:
             close_btn = QPushButton("Close")
@@ -280,3 +339,20 @@ class FitConfirmationDialog(QDialog):
             accept_btn.clicked.connect(self.accept)
             btn_row.addWidget(accept_btn)
         layout.addLayout(btn_row)
+
+        # Fit the dialog to its contents so toggling the diagnostic grows and
+        # shrinks it cleanly. Only when a figure is present — the error layout
+        # (a word-wrapped reason label) sizes better without a fixed constraint.
+        if self._canvas is not None:
+            layout.setSizeConstraint(QLayout.SizeConstraint.SetFixedSize)
+
+    @staticmethod
+    def _diag_btn_text(shown: bool) -> str:
+        return "Hide diagnostic" if shown else "Show diagnostic"
+
+    def _on_toggle_diagnostic(self) -> None:
+        """Reveal/collapse the embedded diagnostic figure and re-fit the dialog."""
+        self._diag_shown = not self._diag_shown
+        self._canvas.setVisible(self._diag_shown)
+        self._toggle_btn.setText(self._diag_btn_text(self._diag_shown))
+        self.adjustSize()  # immediate re-fit (SetFixedSize also keeps it snug)

--- a/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
+++ b/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
@@ -139,6 +139,61 @@ def _kv(key: str, value: str, value_color: str = "#d0d0d0") -> QWidget:
     return w
 
 
+# --- dark theming for the embedded diagnostic figure ---------------------
+# The fit figures (fibsem.correlation.util) are authored light — black text,
+# a near-black gaussian-fit line — for standalone/saved use. This dialog is
+# napari-dark, so a white figure glares against it. Re-theme the figure to the
+# dialog palette at embed time; done here (not in util.py, which lives on main)
+# so the change stays wholly within this dialog.
+_FIG_BG = "#1e2124"    # == the dialog background: figure margins blend in
+_AXES_BG = "#262930"   # a subtle lift so the z line-plot reads as a panel
+_FG = "#d0d0d0"        # dialog foreground (labels, ticks, legend text)
+_FG_TITLE = "#e0e0e0"  # titles / suptitle, a touch brighter
+_SPINE = "#4a4d53"
+# A line darker than this is invisible on the dark panel; the only such artist
+# is the gaussian-fit overlay (authored at 0.15 grey). Lift it to a light grey
+# that still sits below the 0.55 signal line, preserving the fit-vs-signal read.
+_DARK_LINE_LUM = 0.25
+_DARK_LINE_TARGET = "0.8"
+
+
+def _luminance(color) -> float:
+    from matplotlib.colors import to_rgb
+
+    r, g, b = to_rgb(color)
+    return 0.299 * r + 0.587 * g + 0.114 * b
+
+
+def _apply_dark_theme(fig) -> None:
+    """Re-theme a light-authored fit figure onto the napari-dark palette.
+
+    Only theme-agnostic chrome is touched — figure/axes background, text,
+    ticks, spines, legend frame, and any near-black line. The saturated
+    input(red)/fitted(green) markers and the grayscale image data are left
+    exactly as authored (they already read correctly on dark).
+    """
+    fig.set_facecolor(_FIG_BG)
+    for txt in fig.texts:  # figure-level text == the suptitle
+        txt.set_color(_FG_TITLE)
+    for ax in fig.axes:
+        ax.set_facecolor(_AXES_BG)
+        ax.title.set_color(_FG_TITLE)
+        ax.xaxis.label.set_color(_FG)
+        ax.yaxis.label.set_color(_FG)
+        ax.tick_params(colors=_FG)
+        for spine in ax.spines.values():
+            spine.set_color(_SPINE)
+        for line in ax.get_lines():
+            if _luminance(line.get_color()) < _DARK_LINE_LUM:
+                line.set_color(_DARK_LINE_TARGET)
+        legend = ax.get_legend()
+        if legend is not None:
+            legend.get_frame().set_facecolor(_AXES_BG)
+            legend.get_frame().set_edgecolor(_SPINE)
+            for text in legend.get_texts():
+                text.set_color(_FG)
+
+
 class FitConfirmationDialog(QDialog):
     """Modal accept/reject for a single :class:`PointFitResult`.
 
@@ -176,13 +231,14 @@ class FitConfirmationDialog(QDialog):
         if show_figure and result.figure is not None:
             from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 
+            _apply_dark_theme(result.figure)
             try:
                 result.figure.tight_layout()
             except Exception:
                 pass
             canvas = FigureCanvasQTAgg(result.figure)
-            # Size to the figure's aspect so wide multi-subplot FM figs
-            # (hole_fitting_reflection is 1x3 at 20x5) aren't squished square.
+            # Size to the figure's aspect so the wide FM figs (z + XY panels
+            # at 9x4.5) aren't squished square.
             w_in, h_in = result.figure.get_size_inches()
             disp_h = 340
             disp_w = int(min(disp_h * (w_in / h_in), 900)) if h_in else disp_h

--- a/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
+++ b/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
@@ -1,0 +1,226 @@
+"""FitConfirmationDialog — accept/reject a per-point auto-fit result.
+
+A point fit (auto-centroid / gaussian) proposes a refined position for a
+coordinate. Rather than mutating the coordinate silently, the fit is captured
+as a :class:`PointFitResult` and shown here for the user to accept or reject.
+
+The result type is list-ready: a batch fit (multiple selected points) produces
+a list of ``PointFitResult``, which a future summary dialog can present together.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.correlation.structures import Coordinate, PointXYZ
+from fibsem.ui import stylesheets
+
+# Per-axis displacement below which a fit is treated as "no change" (the fit
+# fell back to the input). Well under the 3-decimal coordinate precision, so
+# genuine sub-pixel refinements read as real moves, not "no change".
+_UNCHANGED_EPS = 0.001
+
+
+class FitStatus(Enum):
+    OK = "ok"                # fit moved the point
+    UNCHANGED = "unchanged"  # fit landed on (≈) the input position
+    ERROR = "error"          # fit raised / produced no position
+
+
+@dataclass
+class PointFitResult:
+    """Outcome of auto-fitting one coordinate (runtime only — holds a live fig)."""
+
+    coordinate: Coordinate
+    method: str
+    channel: Optional[int]
+    initial: PointXYZ
+    fitted: Optional[PointXYZ]
+    status: FitStatus
+    message: Optional[str] = None
+    figure: object = None  # matplotlib Figure; not serialised
+
+    @property
+    def delta_px(self) -> float:
+        """XY displacement between the initial and fitted position (pixels)."""
+        if self.fitted is None:
+            return 0.0
+        dx = self.fitted.x - self.initial.x
+        dy = self.fitted.y - self.initial.y
+        return (dx * dx + dy * dy) ** 0.5
+
+    @property
+    def delta_z(self) -> float:
+        if self.fitted is None:
+            return 0.0
+        return self.fitted.z - self.initial.z
+
+    @property
+    def delta(self) -> Optional[tuple]:
+        """Per-axis (dx, dy, dz) displacement, or None when there's no fit."""
+        if self.fitted is None:
+            return None
+        return (
+            self.fitted.x - self.initial.x,
+            self.fitted.y - self.initial.y,
+            self.fitted.z - self.initial.z,
+        )
+
+    @staticmethod
+    def classify(
+        initial: PointXYZ,
+        fitted: Optional[PointXYZ],
+        *,
+        error: Optional[str] = None,
+    ) -> FitStatus:
+        """Coarse status from the initial/fitted positions (no fit-fn changes)."""
+        if error is not None or fitted is None:
+            return FitStatus.ERROR
+        deltas = (
+            fitted.x - initial.x,
+            fitted.y - initial.y,
+            fitted.z - initial.z,
+        )
+        moved = any(abs(d) >= _UNCHANGED_EPS for d in deltas)
+        return FitStatus.OK if moved else FitStatus.UNCHANGED
+
+
+# (background, foreground) per status — napari-dark chips
+_STATUS_STYLE = {
+    FitStatus.OK:        ("#1b5e20", "#a5d6a7"),
+    FitStatus.UNCHANGED: ("#5d4037", "#ffcc80"),
+    FitStatus.ERROR:     ("#5a1f1f", "#ef9a9a"),
+}
+
+
+def _status_text(result: "PointFitResult") -> str:
+    if result.status is FitStatus.OK:
+        return "Fit ok"
+    if result.status is FitStatus.UNCHANGED:
+        return "No change — fit ≈ original"
+    return f"Fit failed: {result.message or 'no result'}"
+
+
+def _fmt_xyz(p: PointXYZ) -> str:
+    return f"{p.x:.3f}, {p.y:.3f}, {p.z:.3f}"
+
+
+def _fmt_delta(initial: PointXYZ, fitted: PointXYZ) -> str:
+    return (
+        f"{fitted.x - initial.x:+.3f}, "
+        f"{fitted.y - initial.y:+.3f}, "
+        f"{fitted.z - initial.z:+.3f}"
+    )
+
+
+def _kv(key: str, value: str, value_color: str = "#d0d0d0") -> QWidget:
+    w = QWidget()
+    row = QHBoxLayout(w)
+    row.setContentsMargins(0, 0, 0, 0)
+    k = QLabel(key)
+    k.setStyleSheet("color: #8a8d93; font-size: 12px;")
+    v = QLabel(value)
+    v.setStyleSheet(f"color: {value_color}; font-size: 12px;")
+    v.setTextFormat(Qt.TextFormat.PlainText)
+    row.addWidget(k)
+    row.addStretch(1)
+    row.addWidget(v)
+    return w
+
+
+class FitConfirmationDialog(QDialog):
+    """Modal accept/reject for a single :class:`PointFitResult`.
+
+    ``exec_()`` returns ``QDialog.Accepted`` when the user accepts the fitted
+    position. An ERROR result has nothing to apply — only a Close button.
+    """
+
+    def __init__(
+        self,
+        result: PointFitResult,
+        show_figure: bool = True,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._result = result
+        self.setWindowTitle("Confirm fit")
+        self.setModal(True)
+        self.setStyleSheet("background: #1e2124; color: #d0d0d0;")
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 14, 14, 12)
+        layout.setSpacing(10)
+
+        bg, fg = _STATUS_STYLE[result.status]
+        status = QLabel(_status_text(result))
+        status.setStyleSheet(
+            f"background: {bg}; color: {fg}; border-radius: 10px; "
+            f"padding: 4px 12px; font-size: 12px;"
+        )
+        layout.addWidget(status, alignment=Qt.AlignmentFlag.AlignLeft)
+
+        body = QHBoxLayout()
+        body.setSpacing(14)
+
+        if show_figure and result.figure is not None:
+            from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+
+            try:
+                result.figure.tight_layout()
+            except Exception:
+                pass
+            canvas = FigureCanvasQTAgg(result.figure)
+            # Size to the figure's aspect so wide multi-subplot FM figs
+            # (hole_fitting_reflection is 1x3 at 20x5) aren't squished square.
+            w_in, h_in = result.figure.get_size_inches()
+            disp_h = 340
+            disp_w = int(min(disp_h * (w_in / h_in), 900)) if h_in else disp_h
+            canvas.setMinimumSize(max(disp_w, 300), disp_h)
+            body.addWidget(canvas, stretch=1)
+
+        details = QVBoxLayout()
+        details.setSpacing(4)
+        details.addWidget(_kv("point", result.coordinate.point_type.value))
+        details.addWidget(_kv("method", result.method or "—"))
+        details.addWidget(_kv("before", _fmt_xyz(result.initial)))
+        if result.fitted is not None:
+            details.addWidget(
+                _kv("after", _fmt_xyz(result.fitted), value_color="#7fd4ff")
+            )
+            details.addWidget(
+                _kv("Δ x, y, z", _fmt_delta(result.initial, result.fitted))
+            )
+        details.addStretch()
+        details_w = QWidget()
+        details_w.setLayout(details)
+        details_w.setMinimumWidth(180)
+        body.addWidget(details_w)
+
+        layout.addLayout(body)
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch(1)
+        if result.status is FitStatus.ERROR:
+            close_btn = QPushButton("Close")
+            close_btn.clicked.connect(self.reject)
+            btn_row.addWidget(close_btn)
+        else:
+            reject_btn = QPushButton("Reject")
+            reject_btn.clicked.connect(self.reject)
+            btn_row.addWidget(reject_btn)
+            accept_btn = QPushButton("Accept")
+            accept_btn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+            accept_btn.clicked.connect(self.accept)
+            btn_row.addWidget(accept_btn)
+        layout.addLayout(btn_row)

--- a/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
+++ b/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
@@ -320,24 +320,33 @@ class FitConfirmationDialog(QDialog):
 
         btn_row = QHBoxLayout()
         # Diagnostic toggle sits on the left, apart from the accept/reject cluster.
+        # It's added first, so opt it out of autoDefault or it would become the
+        # dialog's default button (Enter would toggle it instead of accepting).
         if self._canvas is not None:
             self._toggle_btn = QPushButton(self._diag_btn_text(self._diag_shown))
             self._toggle_btn.setToolTip("Show or hide the fit diagnostic plot")
+            self._toggle_btn.setAutoDefault(False)
+            self._toggle_btn.setDefault(False)
             self._toggle_btn.clicked.connect(self._on_toggle_diagnostic)
             btn_row.addWidget(self._toggle_btn)
         btn_row.addStretch(1)
         if result.status is FitStatus.ERROR:
             close_btn = QPushButton("Close")
+            close_btn.setDefault(True)
             close_btn.clicked.connect(self.reject)
             btn_row.addWidget(close_btn)
         else:
             reject_btn = QPushButton("Reject")
+            reject_btn.setAutoDefault(False)
             reject_btn.clicked.connect(self.reject)
             btn_row.addWidget(reject_btn)
             accept_btn = QPushButton("Accept")
             accept_btn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+            accept_btn.setAutoDefault(True)
+            accept_btn.setDefault(True)  # Enter accepts the fit
             accept_btn.clicked.connect(self.accept)
             btn_row.addWidget(accept_btn)
+            accept_btn.setFocus()
         layout.addLayout(btn_row)
 
         # Fit the dialog to its contents so toggling the diagnostic grows and

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -1300,3 +1300,271 @@ def test_load_coordinates_shows_a_warning_instead_of_crashing(qapp, tmp_path, mo
 
     w._on_load()  # must not raise
     assert shown, "expected a warning dialog rather than an exception"
+
+
+# ---------------------------------------------------------------------------
+# FIB-252: per-point fit confirmation
+# ---------------------------------------------------------------------------
+
+
+def test_coordinate_fitted_roundtrip():
+    c = Coordinate(PointXYZ(1.0, 2.0, 3.0), PointType.FIB, fitted=True)
+    d = c.to_dict()
+    assert d["fitted"] is True
+    assert Coordinate.from_dict(d).fitted is True
+    # back-compat: a legacy dict without "fitted" defaults to False
+    legacy = {"point": {"x": 1.0, "y": 2.0, "z": 3.0}, "point_type": "FIB"}
+    assert Coordinate.from_dict(legacy).fitted is False
+
+
+def test_point_fit_result_classify_and_delta():
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        FitStatus,
+        PointFitResult,
+    )
+
+    i = PointXYZ(100.0, 100.0, 5.0)
+    assert PointFitResult.classify(i, PointXYZ(103.0, 104.0, 5.0)) is FitStatus.OK
+    # exact fallback (fit returned the input) → no change
+    assert PointFitResult.classify(i, PointXYZ(100.0, 100.0, 5.0)) is FitStatus.UNCHANGED
+    # a 0.1 px refinement is a real move, not "no change"
+    assert PointFitResult.classify(i, PointXYZ(100.1, 100.0, 5.0)) is FitStatus.OK
+    assert PointFitResult.classify(i, PointXYZ(100.0, 100.0, 7.0)) is FitStatus.OK  # z move
+    assert PointFitResult.classify(i, None, error="boom") is FitStatus.ERROR
+    assert PointFitResult.classify(i, None) is FitStatus.ERROR
+
+    r = PointFitResult(
+        coordinate=_coord(), method="Hole", channel=None,
+        initial=i, fitted=PointXYZ(103.0, 104.0, 5.0), status=FitStatus.OK,
+    )
+    assert round(r.delta_px, 1) == 5.0  # 3-4-5 triangle
+    assert r.delta == (3.0, 4.0, 0.0)   # per-axis (dx, dy, dz)
+
+
+def test_subpixel_change_is_visible_and_flagged():
+    """A sub-pixel refinement must read as a real move at 3-decimal precision."""
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        FitStatus,
+        PointFitResult,
+        _fmt_delta,
+        _fmt_xyz,
+    )
+
+    initial = PointXYZ(803.300, 1111.900, 10.500)
+    fitted = PointXYZ(803.340, 1111.940, 10.530)
+    assert PointFitResult.classify(initial, fitted) is FitStatus.OK
+    assert _fmt_xyz(fitted) == "803.340, 1111.940, 10.530"
+    assert _fmt_delta(initial, fitted) == "+0.040, +0.040, +0.030"
+
+
+def test_run_point_fit_returns_none_without_image(qapp):
+    w = _widget(qapp)  # no FIB image loaded
+    assert w._run_point_fit(_coord(10.0, 10.0, 0.0, PointType.FIB)) is None
+
+
+def test_apply_fit_result_moves_and_flags(qapp):
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        FitStatus,
+        PointFitResult,
+    )
+
+    w = _widget(qapp)
+    coord = _coord(10.0, 20.0, 0.0, PointType.FIB)
+    w._coords_tab.fib_list.add_coordinate(coord)
+    result = PointFitResult(
+        coordinate=coord, method="Hole", channel=None,
+        initial=PointXYZ(10.0, 20.0, 0.0), fitted=PointXYZ(13.0, 24.0, 0.0),
+        status=FitStatus.OK,
+    )
+    emitted = []
+    w.data_changed.connect(lambda d: emitted.append(d))
+    w._apply_fit_result(result)
+
+    assert (coord.point.x, coord.point.y) == (13.0, 24.0)
+    assert coord.fitted is True
+    assert emitted  # data_changed fired
+
+
+def test_manual_move_clears_fitted_flag(qapp):
+    w = _widget(qapp)
+    coord = _coord(5.0, 5.0, 0.0, PointType.FIB)
+    coord.fitted = True
+    w._coords_tab.fib_list.add_coordinate(coord)
+
+    w._on_canvas_moved(coord)              # drag
+    assert coord.fitted is False
+
+    coord.fitted = True
+    w._on_list_changed(w._point_specs[PointType.FIB], coord, "x", 6.0)  # spinbox
+    assert coord.fitted is False
+
+
+def test_fit_confirmation_dialog_constructs(qapp):
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        FitConfirmationDialog,
+        FitStatus,
+        PointFitResult,
+    )
+
+    ok = PointFitResult(
+        coordinate=_coord(pt=PointType.FIB), method="Hole", channel=None,
+        initial=PointXYZ(0.0, 0.0, 0.0), fitted=PointXYZ(2.0, 2.0, 0.0),
+        status=FitStatus.OK,
+    )
+    assert FitConfirmationDialog(ok, show_figure=False) is not None
+
+    err = PointFitResult(
+        coordinate=_coord(pt=PointType.FIB), method="Hole", channel=None,
+        initial=PointXYZ(0.0, 0.0, 0.0), fitted=None,
+        status=FitStatus.ERROR, message="boom",
+    )
+    assert FitConfirmationDialog(err, show_figure=False) is not None
+
+
+def test_fit_dialog_sizes_wide_figure_to_aspect(qapp):
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+    from matplotlib.figure import Figure
+
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        FitConfirmationDialog,
+        FitStatus,
+        PointFitResult,
+    )
+
+    fig = Figure(figsize=(20, 5))  # like hole_fitting_reflection's 1x3 strip
+    for i in range(3):
+        fig.add_subplot(1, 3, i + 1)
+    r = PointFitResult(
+        coordinate=_coord(pt=PointType.FM), method="Hole", channel=0,
+        initial=PointXYZ(0.0, 0.0, 0.0), fitted=PointXYZ(2.0, 2.0, 3.0),
+        status=FitStatus.OK, figure=fig,
+    )
+    dialog = FitConfirmationDialog(r, show_figure=True)
+    canvases = dialog.findChildren(FigureCanvasQTAgg)
+    assert canvases, "diagnostic figure should be embedded"
+    canvas = canvases[0]
+    assert canvas.minimumWidth() > canvas.minimumHeight()  # wide, not squished
+    assert canvas.minimumWidth() <= 900                     # capped
+
+
+def test_run_point_fit_does_not_mutate_coordinate(qapp, monkeypatch):
+    from types import SimpleNamespace
+
+    import numpy as np
+
+    import fibsem.correlation.util as util
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import FitStatus
+
+    w = _widget(qapp)
+    w._fib_image = SimpleNamespace(filtered_data=np.zeros((64, 64), dtype=np.float32))
+    fig = object()
+    monkeypatch.setattr(
+        util, "hole_fitting_FIB", lambda img, x, y: (x + 3.0, y + 4.0, fig)
+    )
+
+    coord = _coord(20.0, 20.0, 0.0, PointType.FIB)  # FIB method defaults to "Hole"
+    result = w._run_point_fit(coord)
+
+    # The fit is only a proposal — the coordinate is untouched until accepted.
+    assert (coord.point.x, coord.point.y) == (20.0, 20.0)
+    assert coord.fitted is False
+    assert result.status is FitStatus.OK
+    assert (result.fitted.x, result.fitted.y) == (23.0, 24.0)
+    assert round(result.delta_px, 1) == 5.0
+    assert result.figure is fig
+
+
+def test_refit_applies_on_accept_not_on_reject(qapp, monkeypatch):
+    from types import SimpleNamespace
+
+    import numpy as np
+    from PyQt5.QtWidgets import QDialog
+
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+    import fibsem.correlation.util as util
+
+    w = _widget(qapp)
+    w._fib_image = SimpleNamespace(filtered_data=np.zeros((64, 64), dtype=np.float32))
+    monkeypatch.setattr(
+        util, "hole_fitting_FIB", lambda img, x, y: (x + 3.0, y + 4.0, None)
+    )
+    coord = _coord(20.0, 20.0, 0.0, PointType.FIB)
+    w._coords_tab.fib_list.add_coordinate(coord)
+
+    # Reject → coordinate unchanged.
+    monkeypatch.setattr(ctw.FitConfirmationDialog, "exec_", lambda self: QDialog.Rejected)
+    w._on_refit_requested(coord)
+    assert (coord.point.x, coord.point.y) == (20.0, 20.0)
+    assert coord.fitted is False
+
+    # Accept → coordinate moved and flagged.
+    monkeypatch.setattr(ctw.FitConfirmationDialog, "exec_", lambda self: QDialog.Accepted)
+    w._on_refit_requested(coord)
+    assert (coord.point.x, coord.point.y) == (23.0, 24.0)
+    assert coord.fitted is True
+
+
+# ---------------------------------------------------------------------------
+# Seam between the fit confirmation (FIB-252) and the result-live state (#143)
+# ---------------------------------------------------------------------------
+
+
+def test_accepting_a_fit_invalidates_the_live_result(qapp):
+    """Applying a fit moves a fiducial, so the displayed result no longer
+    describes the current points and Continue must not stay armed."""
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        FitStatus,
+        PointFitResult,
+    )
+
+    w = _widget(qapp)
+    coord = _coord(10.0, 10.0, 0.0, PointType.FIB)
+    w._on_canvas_add_requested(10.0, 10.0, PointType.FIB)
+    coord = w._coords_tab.fib_list.coordinates[0]
+
+    w._on_result_ready(
+        CorrelationResult(
+            poi=[CorrelationPointOfInterest(image_px=Point(x=1.0, y=2.0))],
+            rms_error=1.5,
+        )
+    )
+    assert w._btn_continue.isEnabled() is True
+
+    w._apply_fit_result(
+        PointFitResult(
+            coordinate=coord,
+            method="Hole",
+            channel=None,
+            initial=PointXYZ(10.0, 10.0, 0.0),
+            fitted=PointXYZ(13.0, 14.0, 0.0),
+            status=FitStatus.OK,
+        )
+    )
+
+    assert coord.fitted is True
+    assert w._btn_continue.isEnabled() is False  # result is stale now
+    assert w._lbl_result.isHidden() is True
+
+
+def test_selecting_a_fitted_point_keeps_its_fitted_flag(qapp):
+    """_on_canvas_moved clears `fitted`, and before the phantom-move fix a plain
+    select-click reached it — so merely clicking a fitted point unflagged it."""
+    import numpy as np
+
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.set_image(np.zeros((100, 100)))
+    coord = _coord(50.0, 50.0, pt=PointType.FIB)
+    coord.fitted = True
+    canvas.set_coordinates([coord])
+
+    moved = []
+    canvas.point_moved.connect(moved.append)
+
+    _press_release(canvas, coord)  # click to select, no drag
+    assert moved == []
+    assert coord.fitted is True  # selection is not an edit
+
+    _press_release(canvas, coord, drag_to=(60.0, 70.0))  # a real drag
+    assert moved == [coord]

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -1478,6 +1478,175 @@ def test_apply_dark_theme_darkens_chrome_keeps_data():
     assert marker.get_color() == "#e53935"                      # marker untouched
 
 
+def test_humanize_fit_error_maps_known_modes():
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        humanize_fit_error,
+    )
+
+    conv = humanize_fit_error(RuntimeError(
+        "Optimal parameters not found: Number of calls to function has reached "
+        "maxfev = 800."
+    ))
+    assert "converge" in conv and "maxfev" not in conv  # jargon dropped
+
+    edge = humanize_fit_error(IndexError("index 70 is out of bounds"))
+    assert "edge" in edge
+
+    generic = humanize_fit_error(TypeError("something odd"))
+    assert "unexpectedly" in generic
+
+
+def test_fit_dialog_shows_channel_for_fm_only(qapp):
+    from PyQt5.QtWidgets import QLabel
+
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        FitConfirmationDialog,
+        FitStatus,
+        PointFitResult,
+    )
+
+    def _labels(dialog):
+        return {lbl.text() for lbl in dialog.findChildren(QLabel)}
+
+    fm = PointFitResult(
+        coordinate=_coord(pt=PointType.FM), method="Hole", channel=1,
+        channel_name="reflection",
+        initial=PointXYZ(0.0, 0.0, 0.0), fitted=PointXYZ(2.0, 2.0, 3.0),
+        status=FitStatus.OK,
+    )
+    fm_labels = _labels(FitConfirmationDialog(fm, show_figure=False))
+    assert "channel" in fm_labels and "reflection" in fm_labels
+
+    fib = PointFitResult(
+        coordinate=_coord(pt=PointType.FIB), method="Hole", channel=None,
+        initial=PointXYZ(0.0, 0.0, 0.0), fitted=PointXYZ(2.0, 2.0, 0.0),
+        status=FitStatus.OK,
+    )
+    assert "channel" not in _labels(FitConfirmationDialog(fib, show_figure=False))
+
+
+def test_error_dialog_splits_title_and_wrapped_reason(qapp):
+    from PyQt5.QtWidgets import QLabel
+
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        FitConfirmationDialog,
+        FitStatus,
+        PointFitResult,
+    )
+
+    reason = (
+        "The fit didn't converge — the feature may be too faint, or not centred "
+        "in the search region. Try re-centring your click, or a different "
+        "channel / method."
+    )
+    r = PointFitResult(
+        coordinate=_coord(pt=PointType.FM), method="Hole", channel=2,
+        channel_name="Feature-2-Active-Reflection",
+        initial=PointXYZ(0.0, 0.0, 0.0), fitted=None,
+        status=FitStatus.ERROR, message=reason, detail="maxfev = 800",
+    )
+    dlg = FitConfirmationDialog(r, show_figure=False)
+    labels = dlg.findChildren(QLabel)
+    texts = [lbl.text() for lbl in labels]
+
+    # The chip is a short title — NOT the long message concatenated in.
+    assert "Fit failed" in texts
+    assert not any(t.startswith("Fit failed:") for t in texts)
+    # The reason lives on its own word-wrapped label (so it wraps, not stretches).
+    reason_lbls = [lbl for lbl in labels if lbl.text() == reason]
+    assert reason_lbls and reason_lbls[0].wordWrap()
+
+
+def test_diagnostic_toggle_reveals_and_hides_figure(qapp):
+    from matplotlib.figure import Figure
+
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        FitConfirmationDialog,
+        FitStatus,
+        PointFitResult,
+    )
+
+    def _result():
+        fig = Figure(figsize=(9, 4.5))
+        fig.add_subplot(1, 1, 1)
+        return PointFitResult(
+            coordinate=_coord(pt=PointType.FM), method="Hole", channel=0,
+            initial=PointXYZ(0.0, 0.0, 0.0), fitted=PointXYZ(1.0, 1.0, 1.0),
+            status=FitStatus.OK, figure=fig,
+        )
+
+    # Checkbox unchecked -> figure is still embedded, just hidden; the button
+    # offers to reveal it (we always have the diagnostic).
+    dlg = FitConfirmationDialog(_result(), show_figure=False)
+    assert dlg._canvas is not None
+    assert dlg._canvas.isHidden()
+    assert dlg._toggle_btn.text() == "Show diagnostic"
+
+    dlg._on_toggle_diagnostic()
+    assert not dlg._canvas.isHidden()
+    assert dlg._toggle_btn.text() == "Hide diagnostic"
+
+    dlg._on_toggle_diagnostic()
+    assert dlg._canvas.isHidden()
+    assert dlg._toggle_btn.text() == "Show diagnostic"
+
+    # Checkbox checked -> shown by default.
+    shown = FitConfirmationDialog(_result(), show_figure=True)
+    assert not shown._canvas.isHidden()
+    assert shown._toggle_btn.text() == "Hide diagnostic"
+
+
+def test_fitted_icon_reflects_state(qapp):
+    from fibsem.correlation.ui.widgets.coordinate_list_widget import (
+        CoordinateRowWidget,
+    )
+
+    coord = _coord(pt=PointType.FIB)
+    coord.fitted = True
+    row = CoordinateRowWidget(coord, "FIB-0")
+    # Always visible (an aligned status column); state is encoded by colour.
+    assert not row.fitted_icon.isHidden()
+    assert "confirmed" in row.fitted_icon.toolTip()
+    fitted_key = row.fitted_icon.pixmap().cacheKey()
+
+    coord.fitted = False  # a manual edit supersedes the fit
+    row.refresh()
+    assert not row.fitted_icon.isHidden()          # still shown...
+    assert "Manually" in row.fitted_icon.toolTip()  # ...but recoloured
+    assert row.fitted_icon.pixmap().cacheKey() != fitted_key
+
+
+def test_tooltip_labels_have_no_unscoped_background(qapp):
+    # An unscoped `background: transparent` on a widget bleeds into its QToolTip
+    # (a QLabel), making the tooltip background transparent. The tooltip-bearing
+    # labels in a row must not carry a background rule in their own stylesheet.
+    from fibsem.correlation.ui.widgets.coordinate_list_widget import (
+        CoordinateRowWidget,
+    )
+
+    row = CoordinateRowWidget(_coord(pt=PointType.FIB), "FIB-0")
+    assert row.fitted_icon.toolTip()               # it does have a tooltip
+    assert "background" not in row.fitted_icon.styleSheet()
+    assert "background" not in row.name_label.styleSheet()
+
+
+def test_name_col_width_is_compact_for_short_types(qapp):
+    from fibsem.correlation.ui.widgets.coordinate_list_widget import (
+        _NAME_FIXED_WIDTH,
+        _name_col_width,
+    )
+
+    fm = _name_col_width(PointType.FM)
+    poi = _name_col_width(PointType.POI)
+    surface = _name_col_width(PointType.SURFACE_FM)
+
+    # Short-name lists (FM 8, POI 1) collapse well under the old fixed 100px,
+    # killing the empty gap; a surface name needs more room but is still capped
+    # at the former width, so surface lists don't regress.
+    assert fm < 70 and poi < 70
+    assert fm < surface <= _NAME_FIXED_WIDTH
+
+
 def test_run_point_fit_does_not_mutate_coordinate(qapp, monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -1596,6 +1596,31 @@ def test_diagnostic_toggle_reveals_and_hides_figure(qapp):
     assert shown._toggle_btn.text() == "Hide diagnostic"
 
 
+def test_accept_is_default_button_not_the_toggle(qapp):
+    from matplotlib.figure import Figure
+    from PyQt5.QtWidgets import QPushButton
+
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        FitConfirmationDialog,
+        FitStatus,
+        PointFitResult,
+    )
+
+    fig = Figure(figsize=(9, 4.5))
+    fig.add_subplot(1, 1, 1)
+    result = PointFitResult(
+        coordinate=_coord(pt=PointType.FM), method="Hole", channel=0,
+        initial=PointXYZ(0.0, 0.0, 0.0), fitted=PointXYZ(1.0, 1.0, 1.0),
+        status=FitStatus.OK, figure=fig,
+    )
+    dlg = FitConfirmationDialog(result, show_figure=True)
+    buttons = {b.text(): b for b in dlg.findChildren(QPushButton)}
+
+    assert buttons["Accept"].isDefault()          # Enter accepts the fit...
+    assert not dlg._toggle_btn.isDefault()         # ...not toggles the diagnostic
+    assert not dlg._toggle_btn.autoDefault()
+
+
 def test_fitted_icon_reflects_state(qapp):
     from fibsem.correlation.ui.widgets.coordinate_list_widget import (
         CoordinateRowWidget,
@@ -1645,6 +1670,126 @@ def test_name_col_width_is_compact_for_short_types(qapp):
     # at the former width, so surface lists don't regress.
     assert fm < 70 and poi < 70
     assert fm < surface <= _NAME_FIXED_WIDTH
+
+
+def test_f_hotkey_fits_selected_coordinate(qapp, monkeypatch):
+    w = _widget(qapp)
+    fitted = []
+    monkeypatch.setattr(w, "_on_refit_requested", lambda c: fitted.append(c))
+
+    coord = _coord(10.0, 10.0, 0.0, PointType.FIB)
+    lw = w._point_specs[PointType.FIB].list_widget
+    lw.coordinates = [coord]
+    lw.select_coordinate_silent(coord)
+
+    w._fit_selected_coordinate()
+    assert fitted == [coord]
+
+
+def test_f_hotkey_noop_without_selection(qapp, monkeypatch):
+    w = _widget(qapp)
+    fitted = []
+    monkeypatch.setattr(w, "_on_refit_requested", lambda c: fitted.append(c))
+
+    w._fit_selected_coordinate()  # nothing selected
+    assert fitted == []
+
+
+def test_f_hotkey_skips_while_editing_a_field(qapp, monkeypatch):
+    from PyQt5.QtWidgets import QApplication, QLineEdit
+
+    w = _widget(qapp)
+    fitted = []
+    monkeypatch.setattr(w, "_on_refit_requested", lambda c: fitted.append(c))
+
+    coord = _coord(10.0, 10.0, 0.0, PointType.FIB)
+    lw = w._point_specs[PointType.FIB].list_widget
+    lw.coordinates = [coord]
+    lw.select_coordinate_silent(coord)
+
+    editing = QLineEdit()
+    monkeypatch.setattr(QApplication, "focusWidget", lambda: editing)
+    w._fit_selected_coordinate()
+    assert fitted == []  # don't hijack the key mid-edit
+
+
+def _fit_result(status, dx=0.0, dy=0.0, dz=0.0, figure=None):
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import PointFitResult
+
+    initial = PointXYZ(100.0, 100.0, 10.0)
+    fitted = (
+        None
+        if status.name == "ERROR"
+        else PointXYZ(100.0 + dx, 100.0 + dy, 10.0 + dz)
+    )
+    return PointFitResult(
+        coordinate=_coord(100.0, 100.0, 10.0, PointType.FM),
+        method="Hole", channel=0, initial=initial, fitted=fitted,
+        status=status, figure=figure,
+    )
+
+
+def test_auto_accept_gating(qapp):
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import FitStatus
+
+    w = _widget(qapp)
+    ok = _fit_result(FitStatus.OK, dx=2.0)
+    err = _fit_result(FitStatus.ERROR)
+    far = _fit_result(FitStatus.OK, dx=100.0)  # surprising jump
+
+    w._coords_tab._auto_accept_check.setChecked(False)
+    assert not w._should_auto_accept(ok)   # off -> always confirm
+
+    w._coords_tab._auto_accept_check.setChecked(True)
+    assert w._should_auto_accept(ok)        # good, small fit -> apply
+    assert not w._should_auto_accept(err)   # failures always surface
+    assert not w._should_auto_accept(far)   # outliers fall back to the dialog
+
+
+def test_auto_accept_applies_without_dialog(qapp, monkeypatch):
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as mod
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import FitStatus
+
+    w = _widget(qapp)
+    w._coords_tab._auto_accept_check.setChecked(True)
+
+    result = _fit_result(FitStatus.OK, dx=2.0)
+    monkeypatch.setattr(w, "_run_point_fit", lambda c: result)
+    applied = []
+    monkeypatch.setattr(w, "_apply_fit_result", lambda r: applied.append(r))
+
+    def _boom(*a, **k):
+        raise AssertionError("confirm dialog must not open in auto-accept")
+
+    monkeypatch.setattr(mod, "FitConfirmationDialog", _boom)
+
+    w._on_refit_requested(_coord(pt=PointType.FM))
+    assert applied == [result]
+
+
+def test_auto_accept_error_still_shows_dialog(qapp, monkeypatch):
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as mod
+    from PyQt5.QtWidgets import QDialog
+
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import FitStatus
+
+    w = _widget(qapp)
+    w._coords_tab._auto_accept_check.setChecked(True)
+
+    monkeypatch.setattr(w, "_run_point_fit", lambda c: _fit_result(FitStatus.ERROR))
+    constructed = []
+
+    class _FakeDialog:
+        def __init__(self, *a, **k):
+            constructed.append(True)
+
+        def exec_(self):
+            return QDialog.Rejected
+
+    monkeypatch.setattr(mod, "FitConfirmationDialog", _FakeDialog)
+
+    w._on_refit_requested(_coord(pt=PointType.FM))
+    assert constructed == [True]  # error surfaced despite auto-accept
 
 
 def test_run_point_fit_does_not_mutate_coordinate(qapp, monkeypatch):

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -1447,6 +1447,37 @@ def test_fit_dialog_sizes_wide_figure_to_aspect(qapp):
     assert canvas.minimumWidth() <= 900                     # capped
 
 
+def test_apply_dark_theme_darkens_chrome_keeps_data():
+    # The fit figures are authored light; the dialog re-themes them to the dark
+    # palette at embed time. Lock the contract: chrome (figure/axes bg) goes
+    # dark, the near-black gaussian-fit line is lifted so it stays visible, and
+    # the saturated markers / mid-grey signal are left untouched (they read on
+    # dark already, and the marker colours carry meaning).
+    from matplotlib.colors import to_hex
+    from matplotlib.figure import Figure
+
+    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
+        _AXES_BG,
+        _FIG_BG,
+        _apply_dark_theme,
+        _luminance,
+    )
+
+    fig = Figure()
+    ax = fig.add_subplot(1, 1, 1)
+    (signal,) = ax.plot([0, 1], [0, 1], color="0.55")           # mid-grey
+    (fit,) = ax.plot([0, 1], [1, 0], color="0.15", ls="--")     # near-black
+    (marker,) = ax.plot([0.5], [0.5], "+", color="#e53935")     # input red
+
+    _apply_dark_theme(fig)
+
+    assert to_hex(fig.get_facecolor()) == _FIG_BG
+    assert to_hex(ax.get_facecolor()) == _AXES_BG
+    assert _luminance(fit.get_color()) > _luminance("0.15")     # lifted off black
+    assert signal.get_color() == "0.55"                         # signal untouched
+    assert marker.get_color() == "#e53935"                      # marker untouched
+
+
 def test_run_point_fit_does_not_mutate_coordinate(qapp, monkeypatch):
     from types import SimpleNamespace
 


### PR DESCRIPTION
## Summary

The correlation widget's per-point **refit** now proposes an auto-fit and asks you to **accept or reject** it — or applies it directly in an opt-in **auto-accept** mode — instead of mutating the coordinate silently.

Scoped from [FIB-252](https://linear.app/fibsemos/issue/FIB-252): this is the per-point fit-confirmation half; the *correlated POI on FM display* half remains open on the issue.

## What changed

**Confirm-fit flow**
- **New `fit_confirmation_dialog.py`** — `FitStatus`, a list-ready `PointFitResult` (initial / fitted / status / message / channel / detail / figure, per-axis Δ), and `FitConfirmationDialog`: diagnostic figure, before/after, per-axis `Δ x, y, z` at 3 dp, and a coarse `ok` / `no change` / `error` status.
- **Refit split** — `_run_point_fit` (compute, no mutate) → confirmation → `_apply_fit_result` (apply + flag on accept). The figure is closed after the dialog, fixing a pre-existing matplotlib leak. Removed the dead `_show_figure_dialog`.
- **`Coordinate.fitted` flag** — serialised (back-compat via `.get`), set on accept, cleared on manual drag / spinbox edit.

**Dialog polish**
- **Fit channel shown** (name, not index) for FM fits.
- **Humanized fit errors** — `curve_fit` non-convergence / edge / empty-region map to a short "Fit failed" title + a wrapped reason line; the raw scipy text is kept as a tooltip (no more `maxfev = 800` stretching the dialog full-width).
- **Show/Hide diagnostic toggle** on the left of the button row — the figure is always built, so it's always embedded and toggled at runtime; the pre-fit checkbox sets the default, and the dialog re-fits to its contents.
- **Dark-themed diagnostic figure** so the plot matches the napari-dark dialog instead of glaring white.
- **Accept is the default button** (Enter accepts, not the toggle).

**Coordinate list**
- **Per-row fit-state indicator** — white target = auto-fit + confirmed, grey = manually placed; always visible for an aligned status column, cleared on manual edit.
- **Per-list Name column width** sized to the point type (FIB/FM/POI collapse to ~50px, killing the wide empty gap; surface lists unchanged).
- Dropped unscoped `background: transparent` on the name/icon labels (it was bleeding into their tooltips, making tooltip backgrounds transparent).

**Fitting workflow**
- **`F` hotkey** fits the selected coordinate (guarded so it doesn't fire while a value field is being edited; surfaced on the refit-button tooltip).
- **Opt-in "Auto-accept fits"** (off by default) — applies non-error fits without the dialog, with a status-bar note; failed and far-off "surprising" fits (> 25 px XY / > 5 slices Z) still surface the dialog.
- Help text at the bottom of the Fit Settings section explaining the hotkey + confirmation / auto-accept behaviour.

`PointFitResult` is a list-ready type, designed for the future batch multi-point summary ([FIB-256](https://linear.app/fibsemos/issue/FIB-256)).

## Rebased onto #143 — two seams worth knowing about

This branch predates [#143](https://github.com/fibsem-os/fibsem-os/pull/143) and [#154](https://github.com/fibsem-os/fibsem-os/pull/154), both since merged. It has been rebased onto current main, and the two places where this work meets #143's result-state changes are covered by tests, since neither branch could have tested the interaction alone.

**1. Accepting a fit invalidates the displayed result.** `_apply_fit_result` ends with `data_changed.emit`, which under #143 routes into `_set_result_live(False)`. Moving a fiducial means the correlation no longer fits the points it is shown against, so Continue disarms and the RMS badge clears — correct, and pinned by `test_accepting_a_fit_invalidates_the_live_result`.

**2. #143 fixed a bug in this branch.** `_on_canvas_moved` clears `coord.fitted` on the grounds that a manual drag supersedes a fit. But before #143's phantom-move fix, that handler fired on *every left-click* — so on this branch's original base, merely **selecting** a fitted point silently erased its fitted flag. `test_selecting_a_fitted_point_keeps_its_fitted_flag` pins the repaired behaviour.

## Testing

130 correlation tests pass headless (`QT_QPA_PLATFORM=offscreen`), covering serialization / back-compat, `classify` / delta, no-mutate-before-accept, apply, clear-on-edit, dialog construction (OK / ERROR), the channel row, humanized errors + title/detail wrap, the diagnostic toggle, fitted-icon state, the tooltip-background guard, per-list name width, the `F` hotkey (fires / no-op / edit-guard), auto-accept (gating / apply / error-still-shows-dialog), Accept-is-default, wide-figure sizing, and the two rebase seams above.

Exercised in the running app against real FIB + FM data (Hole and Gaussian methods) — the confirm dialog, error state, coordinate list, and hotkey / auto-accept flow were all iterated on from live app feedback.
