### PR TITLE
AutoLamella: user-Cancelled task status + cancel notifications

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -54,6 +54,7 @@ class AutoLamellaTaskStatus(Enum):
     Completed = auto()
     Failed = auto()
     Skipped = auto()
+    Cancelled = auto()  # aborted by the user (Stop), distinct from a genuine Failure
 
 
 @dataclass

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1043,6 +1043,7 @@ class AutoLamellaUI(QMainWindow):
                     HookEvent.TASK_STARTED,
                     HookEvent.TASK_COMPLETED,
                     HookEvent.TASK_FAILED,
+                    HookEvent.TASK_CANCELLED,
                 ],
             )
         )
@@ -1060,6 +1061,14 @@ class AutoLamellaUI(QMainWindow):
                 events=[HookEvent.TASK_FAILED],
                 notification_type="error",
                 message_template="Task {task_name} FAILED: {error}",
+            )
+        )
+        manager.register(
+            NotificationHook(
+                name="cancellation_toast",
+                events=[HookEvent.TASK_CANCELLED],
+                notification_type="warning",
+                message_template="Task {task_name} cancelled for {lamella_name}",
             )
         )
         manager.wire(self)

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -28,6 +28,7 @@ import numpy as np
 
 from fibsem import acquire, alignment, calibration, constants, utils
 from fibsem import config as fcfg
+from fibsem.cancellation import OperationCancelledError
 from fibsem.applications.autolamella.protocol.constants import (
     FIDUCIAL_KEY,
     MILL_POLISHING_KEY,
@@ -138,10 +139,21 @@ class AutoLamellaTask(ABC):
         try:
             self._run()
         except Exception as e:
-            self._fire_hook("task_failed", error=str(e))
+            # A user Stop is a cancellation, not a failure — fire the distinct hook so it
+            # notifies as "cancelled" (warning) rather than "FAILED" (error).
+            self._fire_hook("task_cancelled" if self._is_cancellation(e) else "task_failed",
+                            error=str(e))
             raise
         self.post_task()
         self._fire_hook("task_completed")
+
+    def _is_cancellation(self, exc: Exception) -> bool:
+        """Whether ``exc`` is a user Stop rather than a genuine failure: it surfaces as
+        OperationCancelledError (milling / autofocus) or InterruptedError (_check_for_abort),
+        or the task manager's stop event is set."""
+        if isinstance(exc, (OperationCancelledError, InterruptedError)):
+            return True
+        return bool(getattr(getattr(self, "task_manager", None), "is_stopped", False))
 
     def _fire_hook(self, event: str, error: Optional[str] = None) -> None:
         hook_manager = getattr(self.task_manager, "hook_manager", None)

--- a/fibsem/applications/autolamella/workflows/tasks/hooks.py
+++ b/fibsem/applications/autolamella/workflows/tasks/hooks.py
@@ -18,6 +18,7 @@ class HookEvent(str, Enum):
     TASK_STARTED = "task_started"
     TASK_COMPLETED = "task_completed"
     TASK_FAILED = "task_failed"
+    TASK_CANCELLED = "task_cancelled"
     WORKFLOW_STARTED = "workflow_started"
     WORKFLOW_COMPLETED = "workflow_completed"
 

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -11,6 +11,7 @@ from fibsem.constants import DATETIME_DISPLAY_AMPM
 import pandas as pd
 
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+from fibsem.cancellation import OperationCancelledError
 from fibsem.applications.autolamella.workflows.tasks.hooks import HookContext, HookEvent, HookManager
 from fibsem.applications.autolamella.workflows.tasks.queue import TaskQueue
 from fibsem.applications.autolamella.workflows.ui import update_status_ui
@@ -290,9 +291,17 @@ class TaskManager:
             self.experiment.save()
             return None
         except Exception as e:
-            logging.warning(f"Error running task {task_name} for lamella {lamella.name}: {e}")
-            lamella.task_state.status = AutoLamellaTaskStatus.Failed
-            lamella.task_state.status_message = str(e)
+            # A user Stop surfaces as OperationCancelledError (milling) or InterruptedError
+            # (_check_for_abort); either way self.is_stopped is set by TaskManager.stop().
+            # Mark it Cancelled, not Failed — it isn't an error.
+            if self.is_stopped or isinstance(e, OperationCancelledError):
+                logging.info(f"Task {task_name} for lamella {lamella.name} cancelled by user.")
+                lamella.task_state.status = AutoLamellaTaskStatus.Cancelled
+                lamella.task_state.status_message = "Cancelled by user."
+            else:
+                logging.warning(f"Error running task {task_name} for lamella {lamella.name}: {e}")
+                lamella.task_state.status = AutoLamellaTaskStatus.Failed
+                lamella.task_state.status_message = str(e)
             self.experiment.save()
             return e
 

--- a/fibsem/applications/autolamella/workflows/tasks/test_hooks.py
+++ b/fibsem/applications/autolamella/workflows/tasks/test_hooks.py
@@ -86,6 +86,41 @@ def test_notification_hook_formats_error():
     assert "Stage timeout" in received[0][0]
 
 
+def test_notification_hook_cancelled_is_warning():
+    """A user cancel notifies as a 'warning' (amber), not an 'error' failure."""
+    received = []
+    hook = NotificationHook(
+        name="cancel",
+        events=[HookEvent.TASK_CANCELLED],
+        notification_type="warning",
+        message_template="Task {task_name} cancelled for {lamella_name}",
+        _notify=lambda msg, typ: received.append((msg, typ)),
+    )
+    # only fires for the cancelled event, not for a failure
+    manager = HookManager()
+    manager.register(hook)
+    manager.fire(_ctx(event=HookEvent.TASK_FAILED, error="boom"))
+    assert received == []
+    manager.fire(_ctx(event=HookEvent.TASK_CANCELLED, task_name="Mill", lamella_name="01-elk"))
+    assert received == [("Task Mill cancelled for 01-elk", "warning")]
+
+
+def test_task_is_cancellation_classifies_stop_vs_failure():
+    """AutoLamellaTask._is_cancellation: user Stop (cancel exc / stop event) vs real failure."""
+    import types
+    from fibsem.cancellation import OperationCancelledError
+    from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+
+    def _isc(exc, stopped=False):
+        s = types.SimpleNamespace(task_manager=types.SimpleNamespace(is_stopped=stopped))
+        return AutoLamellaTask._is_cancellation(s, exc)
+
+    assert _isc(OperationCancelledError("x")) is True
+    assert _isc(InterruptedError("Workflow aborted by user.")) is True
+    assert _isc(ValueError("real bug")) is False
+    assert _isc(ValueError("real bug"), stopped=True) is True  # stop event set → cancelled
+
+
 def test_notification_hook_falls_back_to_logging_without_notify(caplog):
     import logging
     hook = NotificationHook(

--- a/fibsem/ui/widgets/task_summary_formatting.py
+++ b/fibsem/ui/widgets/task_summary_formatting.py
@@ -33,6 +33,7 @@ STATUS_COLORS = {
     "Completed": "white",
     "Skipped": "gray",
     "InProgress": "cyan",
+    "Cancelled": "orange",
 }
 
 # Semantic badge colours (matching the fibsem.ui.stylesheets palette) used by
@@ -42,6 +43,7 @@ STATUS_BADGE_COLORS = {
     "Failed": ("#d04040", "#e08585"),
     "Skipped": ("#868e93", "#aeb4b9"),
     "InProgress": ("#50a6ff", "#9cc7f5"),
+    "Cancelled": ("#e0a030", "#e8c37f"),  # amber: user-aborted, not an error
 }
 
 # Status order for count chips (these three are always shown, even at zero)

--- a/fibsem/ui/widgets/workflow_timeline_widget.py
+++ b/fibsem/ui/widgets/workflow_timeline_widget.py
@@ -27,6 +27,7 @@ _DOT_ACTIVE     = "#ff9800"
 _DOT_PENDING    = "#606060"
 _DOT_FAILED     = "#99121F"
 _DOT_SKIPPED    = "#9e9e9e"
+_DOT_CANCELLED  = "#e0a030"  # amber: user-aborted, not an error
 
 _LINE_COLOR     = "#3a3d42"
 
@@ -56,7 +57,8 @@ def _queue_status_to_step_status(s) -> "StepStatus":
         AutoLamellaTaskStatus.Completed:  StepStatus.COMPLETED,
         AutoLamellaTaskStatus.Failed:     StepStatus.FAILED,
         AutoLamellaTaskStatus.Skipped:    StepStatus.SKIPPED,
-    }[s]
+        AutoLamellaTaskStatus.Cancelled:  StepStatus.CANCELLED,
+    }.get(s, StepStatus.PENDING)  # unknown status must never crash the timeline
 
 
 # ── Data model ────────────────────────────────────────────────────────────────
@@ -66,6 +68,7 @@ class StepStatus(Enum):
     COMPLETED = auto()
     FAILED    = auto()
     SKIPPED   = auto()
+    CANCELLED = auto()
 
 
 @dataclass
@@ -83,7 +86,8 @@ def _status_color(status: StepStatus) -> str:
         StepStatus.PENDING:   _DOT_PENDING,
         StepStatus.FAILED:    _DOT_FAILED,
         StepStatus.SKIPPED:   _DOT_SKIPPED,
-    }[status]
+        StepStatus.CANCELLED: _DOT_CANCELLED,
+    }.get(status, _DOT_PENDING)
 
 
 # ── _DotWidget ────────────────────────────────────────────────────────────────
@@ -441,8 +445,9 @@ class WorkflowProgressWidget(QWidget):
                     self._outer._rows[active_idx]
                 )
 
-        # Completion/failure — set subtitle, hide inner, resolve last inner step
-        if task_status in (AutoLamellaTaskStatus.Completed, AutoLamellaTaskStatus.Failed):
+        # Completion/failure/cancel — set subtitle, hide inner, resolve last inner step
+        if task_status in (AutoLamellaTaskStatus.Completed, AutoLamellaTaskStatus.Failed,
+                           AutoLamellaTaskStatus.Cancelled):
             self._elapsed_timer.stop()
             self._active_start_time = None
             idx = self._outer_index


### PR DESCRIPTION
Split out of #111 so it can land independently of the napari-removal/UX work.

> **Stacked on #148** — based on `claude/milling-cancellation` (it needs the `OperationCancelledError` primitive). GitHub will retarget this to `main` automatically once #148 merges. Review only the top commit.

## Problem
A user Stop was reported as a **failure**: the task manager marked every exception `Failed`, and the UI showed a red "FAILED" toast — so an intentional cancel looked identical to a crash.

## Changes
- `AutoLamellaTaskStatus` gains **`Cancelled`**. `TaskManager` marks Cancelled (not Failed) when the workflow was stopped or the exception is a cancel (`OperationCancelledError` / `InterruptedError`).
- `AutoLamellaTask.run` fires a distinct **`task_cancelled`** hook (new `HookEvent.TASK_CANCELLED`); a cancellation `NotificationHook` surfaces an amber **"warning"** toast ("… cancelled") instead of the red FAILED toast.
- Amber badge / table colours for the new status.

## Crash fix included
Adding an enum value would otherwise **hard-abort the app**: the workflow timeline's status→step mapping did an unguarded dict lookup (`KeyError` → `Fatal Python error: Aborted`). This adds a `CANCELLED` step status and makes both lookups `.get()`-with-default, so no future status value can crash the timeline.

## Testing
Hook tests (incl. cancelled→warning and the cancel-vs-failure classification) plus a timeline smoke for the mapping + unknown-status guard. **98 passed.**