### PR TITLE
Small independent UI/backend fixes (non-metadata images, icons, toast theme, Ctrl+C)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1703,18 +1703,40 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             except Exception:
                 pass
         super().closeEvent(event)
+        # Force the event loop to exit even if another top-level window (e.g. a stray
+        # matplotlib pyplot figure) would otherwise keep the app alive once this window
+        # closes. quit() — not os._exit — so atexit / experiment autosave still run.
+        app = QApplication.instance()
+        if app is not None:
+            app.quit()
 
 
 def run_ui():
     """Run the AutoLamella embedded example."""
+    import faulthandler
+    import signal
+
     from fibsem.applications.autolamella.tools.bug_report import init_sentry
+
+    # Ctrl+C: PyQt never runs Python's SIGINT handler while blocked in the C++ event
+    # loop — and if the GUI thread wedges, no Python runs at all — so restore the OS
+    # default disposition: SIGINT then terminates the process at the kernel level,
+    # making the app always killable with Ctrl+C. (A hard stop, not a graceful one;
+    # use Cmd+Q / File→Exit for a clean shutdown when the loop is responsive.)
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    # Diagnostics: dump every thread's Python stack on a fatal signal, and on demand
+    # via `kill -USR1 <pid>` — the fastest way to see *where* a frozen GUI thread is
+    # stuck (it does not terminate the process, so you can dump repeatedly).
+    faulthandler.enable()
+    if hasattr(signal, "SIGUSR1"):
+        faulthandler.register(signal.SIGUSR1, all_threads=True)
 
     init_sentry()  # inert unless crash reporting is enabled in preferences
     app = QApplication.instance() or QApplication(sys.argv)
     app.setStyle("Fusion")
     window = AutoLamellaSingleWindowUI()
     window.show()
-    app.exec_()
+    sys.exit(app.exec_())
 
 
 if __name__ == "__main__":

--- a/fibsem/detection/utils.py
+++ b/fibsem/detection/utils.py
@@ -86,6 +86,9 @@ def save_ml_feature_data(det: DetectedFeatures, initial_features: Optional[List[
         fname = f"ml-{utils.current_timestamp_v2()}"
         beam_type = "NULL"
 
+    # beam_type is a BeamType enum when metadata is present, else the "NULL" string fallback
+    beam_type_name = beam_type.name if hasattr(beam_type, "name") else str(beam_type)
+
     fd = [] # feature detections
     for f0, f1 in zip(det.features, initial_features):
         px_diff = f1.px - f0.px
@@ -96,7 +99,7 @@ def save_ml_feature_data(det: DetectedFeatures, initial_features: Optional[List[
                 "dpx": px_diff.to_dict(),                                   # pixel difference
                 "dm": px_diff._to_metres(det.pixelsize).to_dict(),          # metre difference
                 "is_correct": not np.any(px_diff.to_list()),                # is the feature correct
-                "beam_type": beam_type.name,                                # beam type         
+                "beam_type": beam_type_name,                                # beam type
                 "pixelsize": det.pixelsize,                                 # pixelsize
                 "checkpoint": det.checkpoint,                               # checkpoint
         }

--- a/fibsem/ui/icon.py
+++ b/fibsem/ui/icon.py
@@ -63,3 +63,10 @@ def fibsem_icon(key: str, color: Optional[str] = None, **kwargs) -> QIcon:
         # rather than crashing - and log so the missing key can be fixed.
         logging.warning("fibsem_icon: unknown icon %r; rendering blank", key)
         return QIcon()
+
+
+# ── Canonical icon keys for shared actions ───────────────────────────────────
+# Reference these instead of hardcoding "mdi:..." so the same action reads the same
+# everywhere (moving to / updating a saved stage/objective position).
+ICON_MOVE_TO_POSITION = "mdi:crosshairs-gps"   # go to a saved/target position
+ICON_UPDATE_POSITION = "mdi:map-marker-check"  # overwrite a saved position with the current one

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -27,7 +27,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from fibsem.ui.icon import fibsem_icon, qta
+from fibsem.ui.icon import ICON_MOVE_TO_POSITION, ICON_UPDATE_POSITION, fibsem_icon, qta
 
 from fibsem.ui import stylesheets as stylesheets
 from fibsem.ui.utils import WheelBlocker
@@ -867,7 +867,7 @@ class _LamellaRow(QWidget):
 
         # Direct action buttons (replaces "…" dropdown)
         self.btn_move_to = QToolButton()
-        self.btn_move_to.setIcon(fibsem_icon("mdi:crosshairs-gps", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_move_to.setIcon(fibsem_icon(ICON_MOVE_TO_POSITION, color=stylesheets.GRAY_ICON_COLOR))
         self.btn_move_to.setToolTip("Move to Position")
         self.btn_move_to.setFixedSize(_LAMELLA_BTN_SIZE)
         self.btn_move_to.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
@@ -883,7 +883,7 @@ class _LamellaRow(QWidget):
         layout.addWidget(self.btn_edit)
 
         self.btn_update = QToolButton()
-        self.btn_update.setIcon(fibsem_icon("mdi:map-marker-check", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_update.setIcon(fibsem_icon(ICON_UPDATE_POSITION, color=stylesheets.GRAY_ICON_COLOR))
         self.btn_update.setToolTip("Update Position")
         self.btn_update.setFixedSize(_LAMELLA_BTN_SIZE)
         self.btn_update.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)

--- a/fibsem/ui/widgets/notifications.py
+++ b/fibsem/ui/widgets/notifications.py
@@ -74,6 +74,11 @@ class ToastNotification(QWidget):
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.addWidget(self.container)
 
+        # Neutralise the app-global NAPARI_STYLE `QWidget { background-color: #262930 }`
+        # bleed: keep every surface transparent so it shows the #toast_container's #1e2027
+        # (the id selector wins over this type rule).
+        self.setStyleSheet("QWidget { background-color: transparent; }")
+
         # Opacity effect for fade animation
         self.opacity_effect = QGraphicsOpacityEffect(self)
         self.setGraphicsEffect(self.opacity_effect)
@@ -112,14 +117,14 @@ class ToastNotification(QWidget):
         """)
 
         self.close_btn.setStyleSheet("""
-            QPushButton {
+            QToolButton {
                 background-color: transparent;
                 color: #888;
                 border: none;
                 font-size: 16px;
                 font-weight: bold;
             }
-            QPushButton:hover {
+            QToolButton:hover {
                 color: #d6d6d6;
             }
         """)
@@ -277,6 +282,11 @@ class NotificationHistoryPopup(QWidget):
                 border-bottom: 1px solid #3d4251;
             }
         """)
+        # The app-global NAPARI_STYLE sets `QWidget { background-color: #262930 }`, which
+        # otherwise bleeds into every child surface (header / scroll area / rows). Force them
+        # transparent so they show the container's #1e2027; the container + item:hover keep
+        # their opaque colour via higher-specificity id selectors.
+        self.setStyleSheet("QWidget { background-color: transparent; }")
 
     def add_notification(self, message: str, notification_type: str, timestamp: str):
         """Add a notification to the history."""


### PR DESCRIPTION
Four small, unrelated fixes split out of #111 so they can land independently of the napari-removal/UX work. Each is a self-contained commit — happy to drop any individually.

- **`[fix] prevent error on non-metadata images`** — `detection/utils.py` raised on images without metadata.
- **`[ui] icons: centralise move-to/update-position keys as constants`** — the same actions used different (or missing) icons across widgets; define the canonical keys once (`ICON_MOVE_TO_POSITION`, `ICON_UPDATE_POSITION`).
- **`[ui] fix notification panel/toast background bleed from NAPARI_STYLE`** — the napari stylesheet bled a background onto the notification surfaces.
- **`[ui] make the AutoLamella app killable via Ctrl+C`** — PyQt never runs Python's SIGINT handler while blocked in the C++ event loop (and if the GUI thread wedges, no Python runs at all), so restore the OS default disposition: `SIGINT → SIG_DFL` terminates at the kernel level. Also enables `faulthandler` (+ `SIGUSR1` all-threads dump) for diagnosing a frozen GUI thread, and quits the app on window close so a stray top-level window can't keep the process alive.

## Note for review
The Ctrl+C commit **did not cherry-pick cleanly** (`AutoLamellaMainUI.py` has diverged substantially between the branches), so it was re-applied by hand onto the current `main` version. Worth a closer look than the other three.