### PR TITLE
Replace napari's thread_worker with a napari-free FunctionWorker

### DIFF
--- a/fibsem/ui/FibsemImageSettingsWidget.py
+++ b/fibsem/ui/FibsemImageSettingsWidget.py
@@ -6,7 +6,7 @@ import numpy as np
 from napari.layers import Image as NapariImageLayer
 from napari.layers import Points as NapariPointLayer
 from napari.layers import Shapes as NapariShapesLayer
-from napari.qt.threading import thread_worker
+from fibsem.ui.qt.threading import thread_worker
 from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtCore import QEvent, pyqtSignal
 from superqt import ensure_main_thread

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import napari
 import numpy as np
-from napari.qt.threading import thread_worker
+from fibsem.ui.qt.threading import thread_worker
 from PyQt5 import QtCore, QtWidgets
 from superqt import ensure_main_thread
 

--- a/fibsem/ui/FibsemSegmentationModelWidget.py
+++ b/fibsem/ui/FibsemSegmentationModelWidget.py
@@ -1,7 +1,7 @@
 
 import napari
 import napari.utils.notifications
-from napari.qt.threading import thread_worker
+from fibsem.ui.qt.threading import thread_worker
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtGui import QFont

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -7,7 +7,7 @@ import napari
 import napari.utils.notifications
 from napari.layers import Image as NapariImageLayer
 from napari.layers import Points as NapariPointsLayer
-from napari.qt.threading import FunctionWorker, thread_worker
+from fibsem.ui.qt.threading import FunctionWorker, thread_worker
 from PyQt5.QtWidgets import (
     QComboBox,
     QDoubleSpinBox,

--- a/fibsem/ui/fm/widgets/objective_control_widget.py
+++ b/fibsem/ui/fm/widgets/objective_control_widget.py
@@ -14,7 +14,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 import numpy as np
-from napari.qt.threading import thread_worker
+from fibsem.ui.qt.threading import thread_worker
 from fibsem.constants import METRE_TO_MICRON, MICRON_TO_METRE
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.ui import notification_service

--- a/fibsem/ui/qt/__init__.py
+++ b/fibsem/ui/qt/__init__.py
@@ -1,0 +1,1 @@
+"""Qt / GUI-thread helpers (napari-free)."""

--- a/fibsem/ui/qt/threading.py
+++ b/fibsem/ui/qt/threading.py
@@ -1,0 +1,132 @@
+"""A tiny, napari-free replacement for the subset of ``napari.qt.threading`` we use.
+
+Two threading patterns exist in the GUI, and this wrapper covers both:
+
+* **napari ``@thread_worker`` sites** — a decorated *plain function* (never a generator —
+  nothing uses ``yield``), started with ``.start()`` and observed via ``.finished`` (and, in a
+  couple of places, ``.returned`` / ``.errored``). Progress is reported through each widget's
+  own ``pyqtSignal``s, not napari's ``.yielded``; no site uses pause/resume/abort.
+* **manual ``threading.Thread`` sites** — some fire-and-forget, others stored on the widget
+  (``self._acquisition_thread``) so the widget can poll ``.is_alive()`` and ``.join(timeout=)``
+  on cancel / close. Cancellation there is widget-owned: the widget holds a ``threading.Event``
+  and passes it into the blocking call; the worker only needs to be *observable*, not to own
+  the stop signal.
+
+So :class:`FunctionWorker` both re-emits its outcome as Qt signals *and* mirrors the slice of
+the ``threading.Thread`` API those sites use (``start`` / ``is_alive`` / ``join``), making it a
+drop-in for either pattern.
+
+Because the worker is a ``QObject`` constructed on the calling (GUI) thread, emitting its
+signals from the worker thread makes Qt deliver them through the GUI event loop — exactly the
+mechanism napari uses, so signal-delivery threading is unchanged at every call site.
+
+Migration is a one-line import swap::
+
+    # from napari.qt.threading import thread_worker
+    from fibsem.ui.qt.threading import thread_worker
+
+This intentionally implements only the non-generator, bare-decorator subset. A generator body
+or ``@thread_worker(connect=...)`` will fail loudly rather than silently misbehave.
+"""
+from __future__ import annotations
+
+import functools
+import logging
+import threading
+from typing import Callable, Optional, Set
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+__all__ = ["FunctionWorker", "thread_worker"]
+
+# Call sites keep only a local ``worker = self.x_worker(...)`` reference, which would be
+# garbage-collected the moment the method returns — before the thread finishes and its
+# signals are delivered. Hold a strong reference here for the worker's lifetime (napari
+# keeps its own registry for the same reason); it is released when ``finished`` fires.
+_ACTIVE_WORKERS: Set["FunctionWorker"] = set()
+
+
+class FunctionWorker(QObject):
+    """Runs ``func(*args, **kwargs)`` on a daemon thread and re-emits the result as signals.
+
+    Signals mirror the napari names we rely on and are delivered on the thread that created
+    the worker (the GUI thread), so connected slots may safely touch widgets:
+
+    * ``started``  — emitted just before the body runs.
+    * ``returned`` — the return value, on success only.
+    * ``errored``  — the exception, on failure only (also logged with a traceback).
+    * ``finished`` — always, after ``returned``/``errored`` (matching napari).
+
+    It also exposes the slice of the :class:`threading.Thread` API the manual-thread sites
+    use — :meth:`is_alive` and :meth:`join` — so a widget that stored a raw ``Thread`` for
+    lifecycle (``is_acquiring`` / ``cancel`` / ``closeEvent``) can hold a ``FunctionWorker``
+    instead with no change to those call sites.
+    """
+
+    started = pyqtSignal()
+    returned = pyqtSignal(object)
+    errored = pyqtSignal(object)
+    finished = pyqtSignal()
+
+    def __init__(self, func: Callable, *args, **kwargs):
+        super().__init__()
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        """Launch the worker on a daemon thread."""
+        _ACTIVE_WORKERS.add(self)
+        # Released on the GUI thread once the worker is done (self lives there).
+        self.finished.connect(lambda: _ACTIVE_WORKERS.discard(self))
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def is_alive(self) -> bool:
+        """Whether the worker thread has been started and has not yet finished.
+
+        Drop-in for ``threading.Thread.is_alive`` at the stored-thread lifecycle sites
+        (``is_acquiring`` / ``is_milling`` / ``is_workflow_running``). ``False`` before
+        :meth:`start`.
+        """
+        return self._thread is not None and self._thread.is_alive()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        """Block until the worker thread finishes (or ``timeout`` elapses).
+
+        Drop-in for ``threading.Thread.join`` at the cancel / ``closeEvent`` sites. A no-op
+        if the worker was never started. Cancellation itself is widget-owned (the widget sets
+        its ``stop_event`` first, then joins to wait the body out).
+        """
+        if self._thread is not None:
+            self._thread.join(timeout)
+
+    def _run(self) -> None:
+        self.started.emit()
+        try:
+            result = self._func(*self._args, **self._kwargs)
+        except Exception as exc:  # noqa: BLE001 - report every failure, never swallow it
+            logging.exception(
+                "worker %r failed", getattr(self._func, "__name__", self._func)
+            )
+            self.errored.emit(exc)
+        else:
+            self.returned.emit(result)
+        finally:
+            self.finished.emit()
+
+
+def thread_worker(func: Callable) -> Callable:
+    """Turn ``func`` into a factory that returns a :class:`FunctionWorker`.
+
+    Drop-in for the subset of :func:`napari.qt.threading.thread_worker` this codebase uses.
+    The factory is a plain function, so it binds as a method — ``self.some_worker(...)``
+    passes ``self`` through as the first positional argument, just like the original.
+    """
+
+    @functools.wraps(func)
+    def factory(*args, **kwargs) -> FunctionWorker:
+        return FunctionWorker(func, *args, **kwargs)
+
+    return factory

--- a/fibsem/ui/widgets/tests/test_qt_threading.py
+++ b/fibsem/ui/widgets/tests/test_qt_threading.py
@@ -1,0 +1,187 @@
+"""Unit test for the napari-free ``thread_worker`` replacement (``fibsem.ui.qt.threading``).
+
+Covers the properties the migration depends on:
+  * success   — ``returned`` carries the value and its slot runs on the *main* thread,
+                while the body itself runs off it; ``finished`` fires; method binding works.
+  * error     — a raising body emits ``errored`` (with the exception) and still ``finished``,
+                but not ``returned``.
+  * liveness  — a worker started with no surviving local reference is not garbage-collected
+                mid-run (the module keeps it alive until ``finished``).
+  * lifecycle — ``is_alive()`` / ``join(timeout)`` mirror ``threading.Thread`` for the stored
+                -thread sites (``is_acquiring`` / cancel / ``closeEvent``).
+
+Run directly (headless):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_qt_threading.py
+"""
+from __future__ import annotations
+
+import gc
+import os
+import threading
+import time
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import QEventLoop, QObject, QTimer
+
+_QAPP = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+from fibsem.ui.qt import threading as qtthreading  # aliased: stdlib ``threading`` above stays intact
+from fibsem.ui.qt.threading import FunctionWorker, thread_worker
+
+_MAIN_THREAD = threading.current_thread()
+
+
+def _spin(signal, timeout_ms: int = 5000) -> None:
+    """Run the event loop until ``signal`` fires (or the timeout elapses)."""
+    loop = QEventLoop()
+    signal.connect(loop.quit)
+    QTimer.singleShot(timeout_ms, loop.quit)
+    loop.exec_()
+    _QAPP.processEvents()
+
+
+class _Receiver(QObject):
+    """A GUI-thread QObject: bound-method slots are the guaranteed cross-thread-queued case."""
+
+    def __init__(self):
+        super().__init__()
+        self.returned_value = None
+        self.returned_on_main = None
+        self.finished_on_main = None
+        self.errored_value = "unset"
+
+    def on_returned(self, value):
+        self.returned_value = value
+        self.returned_on_main = threading.current_thread() is _MAIN_THREAD
+
+    def on_finished(self):
+        self.finished_on_main = threading.current_thread() is _MAIN_THREAD
+
+    def on_errored(self, exc):
+        self.errored_value = exc
+
+
+class _Host:
+    """The decorator must bind as a method: ``self`` is passed through as arg 0."""
+
+    @thread_worker
+    def double(self, x: int):
+        # runs on the worker thread; return the value + the thread it ran on
+        return {"result": x * 2, "thread": threading.current_thread()}
+
+
+def test_success_delivers_on_main_thread():
+    host = _Host()
+    recv = _Receiver()
+
+    worker = host.double(21)
+    assert isinstance(worker, FunctionWorker)
+    worker.returned.connect(recv.on_returned)
+    worker.finished.connect(recv.on_finished)
+    worker.start()
+    _spin(worker.finished)
+
+    assert recv.returned_value["result"] == 42          # method binding worked (self + x)
+    assert recv.returned_value["thread"] is not _MAIN_THREAD  # body ran off the main thread
+    assert recv.returned_on_main is True                # ...but the slot ran ON the main thread
+    assert recv.finished_on_main is True
+
+
+def test_error_still_finishes():
+    @thread_worker
+    def boom():
+        raise ValueError("nope")
+
+    recv = _Receiver()
+    fired = []
+    worker = boom()
+    worker.errored.connect(recv.on_errored)
+    worker.returned.connect(lambda r: fired.append(("returned", r)))  # must NOT fire
+    worker.finished.connect(lambda: fired.append(("finished", None)))
+    worker.start()
+    _spin(worker.finished)
+
+    assert isinstance(recv.errored_value, ValueError)
+    assert str(recv.errored_value) == "nope"
+    assert not any(k == "returned" for k, _ in fired)  # returned skipped on error
+    assert ("finished", None) in fired                 # finished still fired
+
+
+def test_worker_survives_dropped_local_ref():
+    done = []
+
+    @thread_worker
+    def slow():
+        time.sleep(0.05)  # still running during the gc.collect() below
+        return 7
+
+    def launch():
+        worker = slow()
+        worker.returned.connect(lambda r: done.append(r))
+        worker.start()
+        # local `worker` goes out of scope here — only _ACTIVE_WORKERS keeps it alive
+
+    launch()
+    assert len(qtthreading._ACTIVE_WORKERS) == 1
+    gc.collect()  # would collect the worker if it were not self-registered
+
+    deadline = 3.0
+    while deadline > 0 and not done:
+        _QAPP.processEvents()
+        time.sleep(0.02)
+        deadline -= 0.02
+
+    assert done == [7]
+    _QAPP.processEvents()
+    assert len(qtthreading._ACTIVE_WORKERS) == 0  # released once finished fired
+
+
+def test_is_alive_and_join_mirror_thread():
+    """The stored-thread sites poll ``is_alive()`` and ``join(timeout=)`` on a FunctionWorker
+    held in place of a raw ``threading.Thread`` — the same shape as ``is_acquiring`` + cancel.
+    A widget-owned Event stops the body; ``join`` waits it out."""
+    stop_event = threading.Event()
+
+    @thread_worker
+    def acquire():
+        # a bounded acquisition loop, cancelled by the widget-owned stop_event
+        while not stop_event.is_set():
+            time.sleep(0.01)
+
+    worker = acquire()
+    assert worker.is_alive() is False          # not started yet
+    worker.start()
+    # give the daemon thread a moment to actually enter the loop
+    for _ in range(50):
+        if worker.is_alive():
+            break
+        time.sleep(0.01)
+    assert worker.is_alive() is True           # running
+
+    # cancel: set the stop event (widget-owned), then join with a timeout (as cancel does)
+    stop_event.set()
+    worker.join(timeout=5)
+    assert worker.is_alive() is False          # joined cleanly within the timeout
+
+    _spin(worker.finished, timeout_ms=1000)    # drain the queued finished signal
+
+
+def test_join_before_start_is_noop():
+    @thread_worker
+    def noop():
+        return None
+
+    worker = noop()
+    worker.join(timeout=1)                      # must not raise when never started
+    assert worker.is_alive() is False
+
+
+if __name__ == "__main__":
+    test_success_delivers_on_main_thread()
+    test_error_still_finishes()
+    test_worker_survives_dropped_local_ref()
+    test_is_alive_and_join_mirror_thread()
+    test_join_before_start_is_noop()
+    print("PASS")


### PR DESCRIPTION
Split out of #111 so it can land independently of the napari-removal/UX work. Supersedes the earlier #114.

## Problem
The GUI's background work ran on `napari.qt.threading.thread_worker`, tying every threaded widget to napari even where nothing else in the widget needs it.

## Changes
- **New `fibsem/ui/qt/threading.py`** — a small `QObject`-based `FunctionWorker` that runs a callable on a daemon thread and re-emits the outcome as Qt signals (`started` / `returned` / `errored` / `finished`), plus a `thread_worker` decorator mirroring napari's factory behaviour.
  Because the worker is created on the GUI thread, emitting from the worker thread delivers slots through the GUI event loop — the same mechanism napari used, so **signal-delivery threading is unchanged at every call site**. It also mirrors the slice of the `threading.Thread` API the manual-thread sites use (`start` / `is_alive` / `join`).
- **One-line import swap** at the five current importers: `FibsemSpotBurnWidget`, `FibsemImageSettingsWidget`, `FibsemMovementWidget`, `FibsemSegmentationModelWidget`, `fm/widgets/objective_control_widget`.

Intentionally implements only the non-generator, bare-decorator subset actually in use — a generator body or `@thread_worker(connect=...)` fails loudly rather than silently misbehaving.

## Testing
Adds `fibsem/ui/widgets/tests/test_qt_threading.py` (worker runs off-thread, delivers signals on the GUI thread, propagates errors). Full suite: **559 passed, 8 skipped**.

## Notes for review
- The importer set differs from #114: this swaps the files that import `napari.qt.threading` **today** — adds `FibsemSegmentationModelWidget` + `objective_control_widget`, drops widgets that no longer import it.
- `FibsemSegmentationModelWidget` could not be import-tested here — **`torch` is not installed in this environment** (pre-existing, unrelated to this change). It byte-compiles, and the change is a one-line import swap.