### PR TITLE
Wheel guard: forward scroll to the panel, and allow dynamic ValueComboBox

### DIFF
--- a/fibsem/ui/FibsemCryoDepositionWidget.py
+++ b/fibsem/ui/FibsemCryoDepositionWidget.py
@@ -10,7 +10,7 @@ from fibsem import config as cfg
 from fibsem import gis, utils
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import FibsemGasInjectionSettings
-from fibsem.ui.utils import WheelBlocker
+from fibsem.ui.utils import install_wheel_blocker
 
 
 class FibsemCryoDepositionWidget(QtWidgets.QDialog):
@@ -29,7 +29,6 @@ class FibsemCryoDepositionWidget(QtWidgets.QDialog):
 
     def _setup_ui(self):
         """Hand-built replacement for the former Qt Designer form."""
-        self.wheel_blocker = WheelBlocker()
         layout = QtWidgets.QGridLayout(self)
 
         self.label_title = QtWidgets.QLabel("Cryo Deposition")
@@ -72,7 +71,7 @@ class FibsemCryoDepositionWidget(QtWidgets.QDialog):
 
         # block accidental scroll-to-change on the input widgets
         for w in (self.comboBox_stage_position, self.comboBox_port, self.doubleSpinBox_duration):
-            w.installEventFilter(self.wheel_blocker)
+            install_wheel_blocker(w)
 
     def setup_connections(self):
 

--- a/fibsem/ui/FibsemLabellingUI.py
+++ b/fibsem/ui/FibsemLabellingUI.py
@@ -27,7 +27,7 @@ from fibsem.segmentation.config import (
 from fibsem.ui import stylesheets
 from fibsem.ui.FibsemSegmentationModelWidget import FibsemSegmentationModelWidget
 from fibsem.ui.utils import (
-    WheelBlocker,
+    install_wheel_blocker,
     open_existing_directory_dialog,
     open_existing_file_dialog,
 )
@@ -190,7 +190,6 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         and the labelling logic work unchanged. The ``Model`` tab is added at runtime in
         ``setup_connections`` (the segmentation model widget); this builds the ``Data`` tab.
         """
-        self.wheel_blocker = WheelBlocker()
         layout = QtWidgets.QGridLayout(self)
 
         self.label_title = QtWidgets.QLabel("OpenFIBSEM Labelling")
@@ -289,7 +288,7 @@ class FibsemLabellingUI(QtWidgets.QDialog):
 
         # block accidental scroll-to-change on the comboboxes
         for w in (self.comboBox_data_file_ext, self.comboBox_model_class_index):
-            w.installEventFilter(self.wheel_blocker)
+            install_wheel_blocker(w)
 
     def setup_connections(self):
         self.pushButton_load_data.clicked.connect(self.load_data)

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -25,7 +25,7 @@ from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
 )
-from fibsem.ui.utils import WheelBlocker
+from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel
 
 INSTRUCTIONS_TEXT = """Instructions: Double Click to Move. Alt + Double Click to Move Vertically"""
@@ -247,13 +247,12 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.doubleSpinBox_movement_stage_tilt.setSuffix(constants.DEGREE_SYMBOL)
 
         # Install wheel blocker on all double spin boxes
-        self.wheel_blocker = WheelBlocker()
-        self.doubleSpinBox_movement_stage_x.installEventFilter(self.wheel_blocker)
-        self.doubleSpinBox_movement_stage_y.installEventFilter(self.wheel_blocker)
-        self.doubleSpinBox_movement_stage_z.installEventFilter(self.wheel_blocker)
-        self.doubleSpinBox_movement_stage_rotation.installEventFilter(self.wheel_blocker)
-        self.doubleSpinBox_movement_stage_tilt.installEventFilter(self.wheel_blocker)
-        self.doubleSpinBox_milling_angle.installEventFilter(self.wheel_blocker)
+        install_wheel_blocker(self.doubleSpinBox_movement_stage_x)
+        install_wheel_blocker(self.doubleSpinBox_movement_stage_y)
+        install_wheel_blocker(self.doubleSpinBox_movement_stage_z)
+        install_wheel_blocker(self.doubleSpinBox_movement_stage_rotation)
+        install_wheel_blocker(self.doubleSpinBox_movement_stage_tilt)
+        install_wheel_blocker(self.doubleSpinBox_milling_angle)
 
         if cfg.FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED:
             from fibsem.ui.widgets.sample_holder_widget import SampleHolderWidget

--- a/fibsem/ui/FibsemSegmentationModelWidget.py
+++ b/fibsem/ui/FibsemSegmentationModelWidget.py
@@ -9,7 +9,7 @@ from PyQt5.QtGui import QFont
 from fibsem.detection.detection import DetectedFeatures
 from fibsem.segmentation.model import SegmentationModel, load_model
 from fibsem.ui import stylesheets
-from fibsem.ui.utils import WheelBlocker
+from fibsem.ui.utils import install_wheel_blocker
 
 CHECKPOINT_PATH = "autolamella-mega-20240107.pt"
 SEGMENT_ANYTHING_AVAIABLE = False
@@ -44,7 +44,6 @@ class FibsemSegmentationModelWidget(QtWidgets.QDialog):
 
     def _setup_ui(self):
         """Hand-built replacement for the former Qt Designer form."""
-        self.wheel_blocker = WheelBlocker()
         layout = QtWidgets.QGridLayout(self)
 
         self.label_header_model = QtWidgets.QLabel("Segmentation Model")
@@ -76,7 +75,7 @@ class FibsemSegmentationModelWidget(QtWidgets.QDialog):
         layout.addItem(spacer, 4, 0, 1, 2)
 
         # block accidental scroll-to-change on the combobox
-        self.comboBox_model_type.installEventFilter(self.wheel_blocker)
+        install_wheel_blocker(self.comboBox_model_type)
 
     def setup_connections(self):
 

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -26,7 +26,7 @@ from fibsem.imaging.spot import run_spot_burn
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, Point
 from fibsem.ui import stylesheets
-from fibsem.ui.utils import WheelBlocker
+from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
 from fibsem.utils import format_value
 
@@ -81,7 +81,6 @@ class FibsemSpotBurnWidget(QWidget):
         drops ``label_workflow_hint`` into the run button's cell, so the grid, the
         ``progressBar`` placeholder, and the widget object names are reproduced here.
         """
-        self.wheel_blocker = WheelBlocker()
         self.gridLayout_2 = QGridLayout(self)
 
         self.label_title = QLabel("Spot Burn")
@@ -111,7 +110,7 @@ class FibsemSpotBurnWidget(QWidget):
 
         # block accidental scroll-to-change on the input widgets
         for w in (self.comboBox_beam_current, self.doubleSpinBox_exposure_time):
-            w.installEventFilter(self.wheel_blocker)
+            install_wheel_blocker(w)
 
     def setup_connections(self):
         self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)

--- a/fibsem/ui/utils.py
+++ b/fibsem/ui/utils.py
@@ -8,9 +8,13 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 from PyQt5 import QtGui, QtWidgets
-from PyQt5.QtCore import QEvent, QObject
-from PyQt5.QtGui import QImage, QPixmap
+from PyQt5.QtCore import QEvent, QObject, Qt
+from PyQt5.QtGui import QImage, QPixmap, QWheelEvent
 from PyQt5.QtWidgets import (
+    QAbstractScrollArea,
+    QAbstractSpinBox,
+    QApplication,
+    QComboBox,
     QLabel,
     QMessageBox,
     QPushButton,
@@ -43,13 +47,97 @@ def open_path_in_file_explorer(path: str) -> bool:
         return False
 
 
+_WHEEL_GUARD_PROPERTY = "_fibsem_wheel_guarded"
+
+
 class WheelBlocker(QObject):
-    """Event filter that blocks wheel events"""
+    """Event filter that stops the mouse wheel from changing a widget's value.
+
+    Scrolling over a spinbox/combobox no longer changes it. The wheel event is
+    forwarded to the enclosing scroll area instead, so the panel keeps scrolling
+    rather than dead-zoning over every input.
+
+    Blocking is unconditional, deliberately. An earlier design allowed a *focused*
+    widget to still adjust, but Qt gives focus to the first focusable widget in a
+    form automatically — so the first field in every panel stayed vulnerable to
+    exactly the accidental-change bug this exists to prevent. Use the keyboard
+    (arrow keys, or type a value) to adjust a focused widget.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._forwarding = False
 
     def eventFilter(self, watched, event):
-        if event.type() == QEvent.Wheel:
-            return True  # Block the wheel event
-        return super().eventFilter(watched, event)
+        if event.type() != QEvent.Wheel:
+            return super().eventFilter(watched, event)
+        self._forward_to_scroll_area(watched, event)
+        return True
+
+    def _forward_to_scroll_area(self, watched, event) -> None:
+        """Re-send the wheel event to the nearest scrolling ancestor, if any."""
+        if self._forwarding:  # guard against re-entrancy
+            return
+
+        target = watched.parentWidget()
+        while target is not None and not isinstance(target, QAbstractScrollArea):
+            target = target.parentWidget()
+        if target is None:
+            return  # not inside a scroll area; simply swallow the event
+
+        self._forwarding = True
+        try:
+            QApplication.sendEvent(target.viewport(), _clone_wheel_event(event))
+        except Exception:
+            logging.debug("Failed to forward wheel event", exc_info=True)
+        finally:
+            self._forwarding = False
+
+
+def _clone_wheel_event(event: QWheelEvent) -> QWheelEvent:
+    """Copy a wheel event, preserving both scroll axes and modifiers.
+
+    The position stays in the source widget's coordinates; scroll areas key off the
+    delta, not the position, so this is fine for scrolling purposes.
+    """
+    return QWheelEvent(
+        event.pos(),
+        event.globalPos(),
+        event.pixelDelta(),
+        event.angleDelta(),
+        event.angleDelta().y(),
+        Qt.Vertical,
+        event.buttons(),
+        event.modifiers(),
+        event.phase(),
+        event.source(),
+        event.inverted(),
+    )
+
+
+def install_wheel_blocker(widget: QWidget) -> None:
+    """Guard *widget* against accidental scroll-to-change. Idempotent.
+
+    Also sets ``Qt.StrongFocus``: spinboxes and comboboxes default to
+    ``Qt.WheelFocus``, so a passing scroll would otherwise move keyboard focus into
+    the widget as well.
+    """
+    if widget.property(_WHEEL_GUARD_PROPERTY):
+        return  # already guarded; a second filter would double-forward the event
+    widget.setFocusPolicy(Qt.StrongFocus)
+    widget.installEventFilter(WheelBlocker(parent=widget))
+    widget.setProperty(_WHEEL_GUARD_PROPERTY, True)
+
+
+def install_wheel_blocker_recursive(root: QWidget) -> None:
+    """Guard every spinbox/combobox under *root*. Safe to call more than once.
+
+    Useful for forms whose inputs are built elsewhere (e.g. generated UI code).
+    Widgets added *after* this call are not covered — call it again if a form
+    populates itself dynamically.
+    """
+    for child in root.findChildren((QAbstractSpinBox, QComboBox)):
+        install_wheel_blocker(child)
 
 
 def set_arr_as_qlabel(

--- a/fibsem/ui/widgets/autolamella_task_config_widget.py
+++ b/fibsem/ui/widgets/autolamella_task_config_widget.py
@@ -21,7 +21,8 @@ from superqt import QCollapsible
 from fibsem import utils
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
-from fibsem.ui.widgets.custom_widgets import TitledPanel, WheelBlocker
+from fibsem.ui.utils import install_wheel_blocker
+from fibsem.ui.widgets.custom_widgets import TitledPanel
 
 def resolve_field_types(config: Any) -> Dict[str, Any]:
     """Resolve a dataclass's field annotations to concrete types.
@@ -94,7 +95,7 @@ class IntParameterWidget(ParameterWidget):
         self.widget.setRange(-2147483648, 2147483647)  # 32-bit int range
         self.widget.setValue(int(round(self.value * self.scale)))
         self.widget.setKeyboardTracking(False)
-        self.widget.installEventFilter(WheelBlocker(parent=self.widget))
+        install_wheel_blocker(self.widget)
 
         # Add units suffix if available (e.g. " s" for exposure time)
         suffix = get_si_prefix_suffix(self.scale, self.units)
@@ -141,7 +142,7 @@ class FloatParameterWidget(ParameterWidget):
         self.widget.setRange(-1e10, 1e10)
         self.widget.setDecimals(2)
         self.widget.setKeyboardTracking(False)
-        self.widget.installEventFilter(WheelBlocker(parent=self.widget))
+        install_wheel_blocker(self.widget)
         
         # Apply scaling for display (multiply by scale to show user-friendly values)
         display_value = float(self.value) * self.scale
@@ -197,7 +198,7 @@ class EnumParameterWidget(ParameterWidget):
                 current_index = i
                 break
         self.widget.setCurrentIndex(current_index)
-        self.widget.installEventFilter(WheelBlocker(parent=self.widget))
+        install_wheel_blocker(self.widget)
         
         return self.widget
         
@@ -226,7 +227,7 @@ class ComboParameterWidget(ParameterWidget):
             if self.widget.itemData(i) == self.value:
                 self.widget.setCurrentIndex(i)
                 break
-        self.widget.installEventFilter(WheelBlocker(parent=self.widget))
+        install_wheel_blocker(self.widget)
         return self.widget
 
     def get_value(self) -> Any:

--- a/fibsem/ui/widgets/beam_settings_widget.py
+++ b/fibsem/ui/widgets/beam_settings_widget.py
@@ -15,7 +15,8 @@ from fibsem import constants, utils
 from fibsem import config as cfg
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamSettings, BeamType, Point
-from fibsem.ui.widgets.custom_widgets import WheelBlocker, _create_combobox_control
+from fibsem.ui.utils import install_wheel_blocker
+from fibsem.ui.widgets.custom_widgets import _create_combobox_control
 
 # GUI Configuration Constants
 WIDGET_CONFIG = {
@@ -103,7 +104,7 @@ class FibsemBeamSettingsWidget(QWidget):
             if c["suffix"] is not None:
                 sb.setSuffix(c["suffix"])
             sb.setKeyboardTracking(False)
-            sb.installEventFilter(WheelBlocker(parent=sb))
+            install_wheel_blocker(sb)
             return sb
 
         # --- Field of View ---
@@ -121,25 +122,25 @@ class FibsemBeamSettingsWidget(QWidget):
         for res_str, res_data in cfg.STANDARD_RESOLUTIONS_ZIP:
             self.resolution_combo.addItem(res_str, tuple(res_data))
         self.resolution_combo.setCurrentText(cfg.DEFAULT_STANDARD_RESOLUTION)
-        self.resolution_combo.installEventFilter(WheelBlocker(parent=self.resolution_combo))
+        install_wheel_blocker(self.resolution_combo)
         self.resolution_label = QLabel(WIDGET_CONFIG["resolution"]["label"])
         layout.addRow(self.resolution_label, self.resolution_combo)
 
         # --- Beam Current ---
         self.beam_current_combo = QComboBox()
-        self.beam_current_combo.installEventFilter(WheelBlocker(parent=self.beam_current_combo))
+        install_wheel_blocker(self.beam_current_combo)
         self.beam_current_label = QLabel(WIDGET_CONFIG["beam_current"]["label"])
         layout.addRow(self.beam_current_label, self.beam_current_combo)
 
         # --- Beam Voltage ---
         self.beam_voltage_combo = QComboBox()
-        self.beam_voltage_combo.installEventFilter(WheelBlocker(parent=self.beam_voltage_combo))
+        install_wheel_blocker(self.beam_voltage_combo)
         self.beam_voltage_label = QLabel(WIDGET_CONFIG["beam_voltage"]["label"])
         layout.addRow(self.beam_voltage_label, self.beam_voltage_combo)
 
         # --- Preset ---
         self.preset_combo = QComboBox()
-        self.preset_combo.installEventFilter(WheelBlocker(parent=self.preset_combo))
+        install_wheel_blocker(self.preset_combo)
         self.preset_label = QLabel(WIDGET_CONFIG["preset"]["label"])
         layout.addRow(self.preset_label, self.preset_combo)
 

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -30,7 +30,7 @@ from PyQt5.QtWidgets import (
 from fibsem.ui.icon import fibsem_icon, qta
 
 from fibsem.ui import stylesheets as stylesheets
-from fibsem.ui.utils import WheelBlocker
+from fibsem.ui.utils import install_wheel_blocker
 from fibsem.utils import format_value
 
 
@@ -189,7 +189,7 @@ def _create_combobox_control(value: Union[str, int, float, Enum],
 
     if idx >= 0:
         control.setCurrentIndex(idx)
-    control.installEventFilter(WheelBlocker(parent=control))
+    install_wheel_blocker(control)
 
     return control
 
@@ -199,7 +199,7 @@ class ValueComboBox(QComboBox):
 
     def __init__(
         self,
-        items: list,
+        items: Optional[list] = None,
         value=None,
         unit: Optional[str] = None,
         format_fn: Optional[Callable] = None,
@@ -207,19 +207,53 @@ class ValueComboBox(QComboBox):
         parent=None,
     ) -> None:
         super().__init__(parent)
-        for item in items:
-            if isinstance(item, (float, int)):
-                item_str = format_value(val=item, unit=unit, precision=decimals)
-            elif isinstance(item, Enum):
-                item_str = item.name
-            elif format_fn is not None:
-                item_str = format_fn(item)
-            else:
-                item_str = str(item)
-            self.addItem(item_str, item)
-        self.installEventFilter(WheelBlocker(parent=self))
+        self._unit = unit
+        self._format_fn = format_fn
+        self._decimals = decimals
+        if items:
+            self.add_values(items)
+        install_wheel_blocker(self)
         if value is not None:
             self.set_value(value)
+
+    def _format_item(self, item) -> str:
+        """Render an item for display, using the unit/format_fn given at construction."""
+        if isinstance(item, (float, int)):
+            return format_value(val=item, unit=self._unit, precision=self._decimals)
+        if isinstance(item, Enum):
+            return item.name
+        if self._format_fn is not None:
+            return self._format_fn(item)
+        return str(item)
+
+    def add_value(self, item) -> None:
+        """Append a single item, storing the raw value as item data."""
+        self.addItem(self._format_item(item), item)
+
+    def add_values(self, items) -> None:
+        """Append several items."""
+        for item in items:
+            self.add_value(item)
+
+    def set_values(self, items, value=None, keep_selection: bool = True) -> None:
+        """Replace all items.
+
+        By default the current selection is preserved if it survives the swap —
+        repopulating a combobox should not silently change what is selected.
+        Falls back to *value*, else leaves the default (first) item. Signals are
+        suppressed during the swap so listeners see one change at most.
+        """
+        previous = self.value() if keep_selection else None
+        blocked = self.blockSignals(True)
+        try:
+            self.clear()
+            self.add_values(items)
+        finally:
+            self.blockSignals(blocked)
+
+        target = value if value is not None else previous
+        if target is not None:
+            self.set_value(target)
 
     def set_value(self, value) -> None:
         """Select the item matching value; falls back to closest numeric match."""
@@ -263,7 +297,7 @@ class IntegerValueSpinBox(QSpinBox):
         if no_buttons:
             self.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
         self.setKeyboardTracking(False)
-        self.installEventFilter(WheelBlocker(parent=self))
+        install_wheel_blocker(self)
 
 
 class ValueSpinBox(QDoubleSpinBox):
@@ -291,7 +325,7 @@ class ValueSpinBox(QDoubleSpinBox):
         if no_buttons:
             self.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
         self.setKeyboardTracking(False)
-        self.installEventFilter(WheelBlocker(parent=self))
+        install_wheel_blocker(self)
 
 
 @dataclass

--- a/fibsem/ui/widgets/detector_settings_widget.py
+++ b/fibsem/ui/widgets/detector_settings_widget.py
@@ -12,7 +12,7 @@ from superqt import QDoubleSlider
 
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, FibsemDetectorSettings
-from fibsem.ui.widgets.custom_widgets import WheelBlocker
+from fibsem.ui.utils import install_wheel_blocker
 
 WIDGET_CONFIG = {
     "brightness": {
@@ -50,7 +50,7 @@ class _LabeledSlider(QWidget):
 
         self._slider = QDoubleSlider(Qt.Orientation.Horizontal, parent=self)  # type: ignore[attr-defined]
         self._slider.setRange(min_val, max_val)
-        self._slider.installEventFilter(WheelBlocker(parent=self._slider))
+        install_wheel_blocker(self._slider)
 
         self._value_label = QLabel(self._format(min_val), self)
         self._value_label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)  # type: ignore[attr-defined]
@@ -114,13 +114,13 @@ class FibsemDetectorSettingsWidget(QWidget):
 
         # --- Detector Type ---
         self.type_combo = QComboBox()
-        self.type_combo.installEventFilter(WheelBlocker(parent=self.type_combo))
+        install_wheel_blocker(self.type_combo)
         self.type_label = QLabel(WIDGET_CONFIG["type"]["label"])
         layout.addRow(self.type_label, self.type_combo)
 
         # --- Detector Mode ---
         self.mode_combo = QComboBox()
-        self.mode_combo.installEventFilter(WheelBlocker(parent=self.mode_combo))
+        install_wheel_blocker(self.mode_combo)
         self.mode_label = QLabel(WIDGET_CONFIG["mode"]["label"])
         layout.addRow(self.mode_label, self.mode_combo)
 

--- a/fibsem/ui/widgets/image_settings_widget.py
+++ b/fibsem/ui/widgets/image_settings_widget.py
@@ -18,7 +18,8 @@ from typing import Optional
 from fibsem.config import STANDARD_RESOLUTIONS_ZIP
 from fibsem.constants import MICRO_TO_SI, SI_TO_MICRO
 from fibsem.structures import ImageSettings
-from fibsem.ui.widgets.custom_widgets import IconToolButton, QDirectoryLineEdit, WheelBlocker
+from fibsem.ui.utils import install_wheel_blocker
+from fibsem.ui.widgets.custom_widgets import IconToolButton, QDirectoryLineEdit
 from fibsem.ui import stylesheets
 
 # GUI Configuration Constants
@@ -115,14 +116,14 @@ class ImageSettingsWidget(QWidget):
         default_index = self.resolution_combo.findData(default_resolution)
         if default_index >= 0:
             self.resolution_combo.setCurrentIndex(default_index)
-        self.resolution_combo.installEventFilter(WheelBlocker(parent=self.resolution_combo))
+        install_wheel_blocker(self.resolution_combo)
         layout.addWidget(self.resolution_label, 0, 0)
         layout.addWidget(self.resolution_combo, 0, 1)
 
         # Dwell time
         self.dwell_label = QLabel("Dwell Time")
         self.dwell_time_spinbox = QDoubleSpinBox()
-        self.dwell_time_spinbox.installEventFilter(WheelBlocker(parent=self.dwell_time_spinbox))
+        install_wheel_blocker(self.dwell_time_spinbox)
         dwell_config = WIDGET_CONFIG["dwell_time"]
         self.dwell_time_spinbox.setRange(*dwell_config["range"])
         self.dwell_time_spinbox.setDecimals(dwell_config["decimals"])
@@ -135,7 +136,7 @@ class ImageSettingsWidget(QWidget):
         # Field of View
         self.hfw_label = QLabel("Field of View")
         self.hfw_spinbox = QDoubleSpinBox()
-        self.hfw_spinbox.installEventFilter(WheelBlocker(parent=self.hfw_spinbox))
+        install_wheel_blocker(self.hfw_spinbox)
         hfw_config = WIDGET_CONFIG["hfw"]
         self.hfw_spinbox.setRange(*hfw_config["range"])
         self.hfw_spinbox.setDecimals(hfw_config["decimals"])
@@ -148,7 +149,7 @@ class ImageSettingsWidget(QWidget):
         # Line Integration
         self.line_integration_label = QLabel("Line Integration")
         self.line_integration_spinbox = QSpinBox()
-        self.line_integration_spinbox.installEventFilter(WheelBlocker(parent=self.line_integration_spinbox))
+        install_wheel_blocker(self.line_integration_spinbox)
         line_config = WIDGET_CONFIG["line_integration"]
         self.line_integration_spinbox.setRange(*line_config["range"])
         self.line_integration_spinbox.setValue(line_config["default"])
@@ -158,7 +159,7 @@ class ImageSettingsWidget(QWidget):
         # Scan Interlacing
         self.scan_interlacing_label = QLabel("Scan Interlacing")
         self.scan_interlacing_spinbox = QSpinBox()
-        self.scan_interlacing_spinbox.installEventFilter(WheelBlocker(parent=self.scan_interlacing_spinbox))
+        install_wheel_blocker(self.scan_interlacing_spinbox)
         scan_config = WIDGET_CONFIG["scan_interlacing"]
         self.scan_interlacing_spinbox.setRange(*scan_config["range"])
         self.scan_interlacing_spinbox.setValue(scan_config["default"])
@@ -168,7 +169,7 @@ class ImageSettingsWidget(QWidget):
         # Frame Integration
         self.frame_integration_label = QLabel("Frame Integration")
         self.frame_integration_spinbox = QSpinBox()
-        self.frame_integration_spinbox.installEventFilter(WheelBlocker(parent=self.frame_integration_spinbox))
+        install_wheel_blocker(self.frame_integration_spinbox)
         frame_config = WIDGET_CONFIG["frame_integration"]
         self.frame_integration_spinbox.setRange(*frame_config["range"])
         self.frame_integration_spinbox.setValue(frame_config["default"])

--- a/tests/ui/test_wheel_blocker.py
+++ b/tests/ui/test_wheel_blocker.py
@@ -1,0 +1,214 @@
+"""Headless tests for the mouse-wheel guard on spinboxes and comboboxes.
+
+Guards two contracts:
+
+1. Scrolling over a guarded input never changes its value, and the wheel is
+   forwarded to the enclosing scroll area so the panel still scrolls (no
+   "dead zone" over every input).
+2. Guarding is idempotent — installing twice must not forward the event twice,
+   which would scroll at double speed.
+
+Uses PyQt5 directly with the offscreen platform (no pytest-qt dependency).
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtCore import QPoint, Qt
+from PyQt5.QtGui import QWheelEvent
+from PyQt5.QtWidgets import (
+    QApplication,
+    QDoubleSpinBox,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.ui.utils import install_wheel_blocker, install_wheel_blocker_recursive
+from fibsem.ui.widgets.custom_widgets import (
+    IntegerValueSpinBox,
+    ValueComboBox,
+    ValueSpinBox,
+)
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _scroll_area(factory, count=40):
+    """A scroll area tall enough to scroll, filled with widgets from *factory*."""
+    area = QScrollArea()
+    inner = QWidget()
+    layout = QVBoxLayout(inner)
+    widgets = []
+    for _ in range(count):
+        w = factory()
+        layout.addWidget(w)
+        widgets.append(w)
+    area.setWidget(inner)
+    area.setWidgetResizable(True)
+    area.resize(300, 200)
+    area.show()
+    QApplication.processEvents()
+    return area, widgets
+
+
+def _wheel(widget):
+    return QWheelEvent(
+        QPoint(10, 10),
+        widget.mapToGlobal(QPoint(10, 10)),
+        QPoint(0, -120),
+        QPoint(0, -120),
+        -120,
+        Qt.Vertical,
+        Qt.NoButton,
+        Qt.NoModifier,
+    )
+
+
+def _spin(**kwargs):
+    w = ValueSpinBox(minimum=0, maximum=1000, **kwargs)
+    w.setValue(50)
+    return w
+
+
+def test_unguarded_spinbox_reproduces_the_bug(qapp):
+    """Baseline: a plain QDoubleSpinBox eats the scroll AND changes its value."""
+    area, widgets = _scroll_area(
+        lambda: (lambda w: (w.setRange(0, 1000), w.setValue(50), w)[-1])(QDoubleSpinBox())
+    )
+    w = widgets[0]
+    before = w.value()
+    QApplication.sendEvent(w, _wheel(w))
+    QApplication.processEvents()
+
+    assert w.value() != before, "expected the unguarded bug: value changes on scroll"
+    assert area.verticalScrollBar().value() == 0, "unguarded widget also swallows the scroll"
+    area.close()
+
+
+@pytest.mark.parametrize("index", [0, 3], ids=["auto-focused-first", "unfocused"])
+def test_guarded_spinbox_scrolls_without_changing_value(qapp, index):
+    """Holds for the auto-focused first widget too.
+
+    Qt focuses the first focusable widget in a form automatically, so a
+    focus-conditional guard would leave that one widget still vulnerable.
+    """
+    area, widgets = _scroll_area(_spin)
+    w = widgets[index]
+    value_before = w.value()
+    scroll_before = area.verticalScrollBar().value()
+
+    QApplication.sendEvent(w, _wheel(w))
+    QApplication.processEvents()
+
+    assert w.value() == value_before, "scrolling must not change the value"
+    assert area.verticalScrollBar().value() > scroll_before, "panel must still scroll"
+    area.close()
+
+
+def test_guarding_is_idempotent(qapp):
+    """Installing repeatedly must not forward the wheel event more than once."""
+    area, widgets = _scroll_area(_spin)
+    once = widgets[3]
+    thrice = widgets[5]
+
+    baseline = area.verticalScrollBar().value()
+    QApplication.sendEvent(once, _wheel(once))
+    QApplication.processEvents()
+    single_step = area.verticalScrollBar().value() - baseline
+    assert single_step > 0
+
+    install_wheel_blocker(thrice)  # already guarded by ValueSpinBox
+    install_wheel_blocker_recursive(area)  # ...and again, via the tree walker
+
+    baseline = area.verticalScrollBar().value()
+    QApplication.sendEvent(thrice, _wheel(thrice))
+    QApplication.processEvents()
+    repeat_step = area.verticalScrollBar().value() - baseline
+
+    assert repeat_step == single_step, "re-installing the guard double-scrolled"
+    area.close()
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: (lambda w: (w.setValue(50), w)[-1])(IntegerValueSpinBox(minimum=0, maximum=1000)),
+        lambda: ValueComboBox(items=[1, 2, 3, 4, 5], value=3),
+    ],
+    ids=["IntegerValueSpinBox", "ValueComboBox"],
+)
+def test_all_value_widgets_are_guarded(qapp, factory):
+    area, widgets = _scroll_area(factory)
+    w = widgets[0]
+    value_before = w.value()
+    scroll_before = area.verticalScrollBar().value()
+
+    QApplication.sendEvent(w, _wheel(w))
+    QApplication.processEvents()
+
+    assert w.value() == value_before
+    assert area.verticalScrollBar().value() > scroll_before
+    area.close()
+
+
+def test_guard_outside_scroll_area_still_blocks(qapp):
+    """With no scrolling ancestor there is nothing to forward to; still must not change."""
+    w = _spin()
+    w.show()
+    QApplication.processEvents()
+    before = w.value()
+
+    QApplication.sendEvent(w, _wheel(w))
+    QApplication.processEvents()
+
+    assert w.value() == before
+    w.close()
+
+
+class TestValueComboBoxPopulation:
+    """Dynamic population, so combos filled after construction can still use the class."""
+
+    def test_constructs_empty_and_adds(self, qapp):
+        combo = ValueComboBox(unit="A", decimals=1)
+        assert combo.count() == 0
+
+        combo.add_values([1e-12, 60e-12, 1e-9])
+        assert combo.count() == 3
+        assert combo.itemText(1) == "60.0 pA"
+
+        combo.add_value(5e-9)
+        assert combo.count() == 4
+
+    def test_set_values_keeps_selection(self, qapp):
+        combo = ValueComboBox(items=[1e-12, 60e-12, 1e-9], value=60e-12)
+        assert combo.value() == 60e-12
+
+        combo.set_values([1e-12, 60e-12, 1e-9, 5e-9])
+        assert combo.value() == 60e-12, "repopulating must not silently change selection"
+        assert combo.count() == 4
+
+    def test_set_values_falls_back_when_selection_gone(self, qapp):
+        combo = ValueComboBox(items=[1e-12, 60e-12], value=60e-12)
+        combo.set_values([7e-9, 8e-9])
+        assert combo.value() == 7e-9, "closest-match fallback expected"
+
+    def test_set_values_explicit_value_wins(self, qapp):
+        combo = ValueComboBox(items=[1, 2, 3], value=2)
+        combo.set_values([1, 2, 3], value=3)
+        assert combo.value() == 3
+
+    def test_text_api_still_works(self, qapp):
+        """ValueComboBox subclasses QComboBox, so text-based call sites keep working."""
+        combo = ValueComboBox()
+        combo.addItems(["a", "b"])
+        combo.setCurrentIndex(1)
+        assert combo.currentText() == "b"


### PR DESCRIPTION
Foundation for fixing the reported bug: *"scrolling to change values sometimes annoying (because you accidentally change values when scrolling to scroll down in the page)"*.

This PR only changes the shared machinery. Migrating the remaining raw widgets follows in per-subsystem batches.

## 1. `WheelBlocker` now forwards the scroll instead of eating it

Measured on a scroll area of spinboxes:

| | value | scrollbar |
|---|---|---|
| unguarded (the bug) | 50 → **49** ✗ | 0 → 0 ✗ |
| old `WheelBlocker` | 50 → 50 ✓ | 0 → 0 ✗ **dead zone** |
| this PR | 50 → 50 ✓ | 0 → **60** ✓ |

The old filter stopped the value changing but consumed the event, so hovering an input meant the panel would not scroll — in a dense form that is most of the surface.

**Blocking is unconditional, deliberately.** A focus-conditional version was tried first (a focused widget could still adjust). It was rejected because Qt focuses the first focusable widget in a form automatically, so the first field in every panel stayed vulnerable to exactly the bug this exists to prevent. There is a test pinning this. Use the keyboard to adjust a focused widget.

## 2. `install_wheel_blocker()` — idempotent, sets `StrongFocus`

Spinboxes and comboboxes default to `Qt.WheelFocus`, so a passing scroll would otherwise move keyboard focus into them too.

Idempotency is load-bearing: two filters on one widget would **both** forward, scrolling at double speed. Every existing `installEventFilter(WheelBlocker(...))` site now routes through the helper, so widgets can be migrated to the `Value*` classes incrementally without any risk of double-guarding a partially-migrated form.

`install_wheel_blocker_recursive(root)` is available for forms whose inputs are built elsewhere.

## 3. `ValueComboBox` can be populated dynamically

`add_value` / `add_values` / `set_values`, plus an optional `items` argument. `set_values` preserves the current selection if it survives the swap, since repopulating a combobox should not silently change what is selected.

This was the main reason 26 raw `QComboBox`es exist instead of adopting the class — it previously demanded all items at construction, which does not fit combos filled from microscope values or file listings.

## Testing

`tests/ui/test_wheel_blocker.py` — 12 tests, headless/offscreen, no pytest-qt dependency:

- baseline reproduction of the unguarded bug
- guarded behaviour for both the auto-focused first widget and an unfocused one
- idempotency (triple-install must not double-scroll)
- all three `Value*` classes are guarded
- guard outside a scroll area still blocks
- the `ValueComboBox` population API, including selection preservation and closest-match fallback

Full suite: **16 passed** (4 existing + 12 new). All affected widgets and the AutoLamella app still import.

## Follow-up

47 raw spinboxes/comboboxes reachable from AutoLamella remain unguarded, to be migrated to `ValueSpinBox` / `IntegerValueSpinBox` / `ValueComboBox` in batches: FM/fluorescence (24), AutoLamella-specific (8), correlation (5), minimap (4), shared/misc (6).