### PR TITLE
Wheel guard: migrate all remaining spinboxes/comboboxes (47)

### DIFF
--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -82,7 +82,10 @@ from fibsem.correlation.ui.widgets.fm_image_display_widget import FMImageDisplay
 from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
 from fibsem.fm.structures import FluorescenceImage
 from fibsem.structures import FibsemImage
-from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.ui.widgets.custom_widgets import (
+    TitledPanel,
+    ValueComboBox,
+)
 from fibsem.correlation.ui.widgets.refractive_index_widget import RefractiveIndexWidget
 
 _FIT_METHODS = ["None", "Hole", "Gaussian"]
@@ -436,25 +439,25 @@ class _CoordinatesTab(QWidget):
         fit_form.setContentsMargins(8, 4, 8, 4)
         fit_form.setSpacing(4)
 
-        self._fib_method_combo = QComboBox()
+        self._fib_method_combo = ValueComboBox()
         self._fib_method_combo.addItems(_FIT_METHODS)
         self._fib_method_combo.setCurrentText("Hole")
         fit_form.addRow("FIB method:", self._fib_method_combo)
 
-        self._fm_fid_method_combo = QComboBox()
+        self._fm_fid_method_combo = ValueComboBox()
         self._fm_fid_method_combo.addItems(_FIT_METHODS)
         self._fm_fid_method_combo.setCurrentText("None")
         fit_form.addRow("FM Fid. method:", self._fm_fid_method_combo)
 
-        self._fm_poi_method_combo = QComboBox()
+        self._fm_poi_method_combo = ValueComboBox()
         self._fm_poi_method_combo.addItems(_FIT_METHODS)
         self._fm_poi_method_combo.setCurrentText("Gaussian")
         fit_form.addRow("FM POI method:", self._fm_poi_method_combo)
 
-        self._fm_fid_ch_combo = QComboBox()
+        self._fm_fid_ch_combo = ValueComboBox()
         fit_form.addRow("FM Fid. channel:", self._fm_fid_ch_combo)
 
-        self._fm_poi_ch_combo = QComboBox()
+        self._fm_poi_ch_combo = ValueComboBox()
         fit_form.addRow("FM POI channel:", self._fm_poi_ch_combo)
 
         self._show_diag_check = QCheckBox()

--- a/fibsem/ui/FibsemManipulatorWidget.py
+++ b/fibsem/ui/FibsemManipulatorWidget.py
@@ -18,7 +18,7 @@ from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
 from fibsem.ui.qtdesigner_files import (
     FibsemManipulatorWidget as FibsemManipulatorWidgetUI,
 )
-from fibsem.ui.utils import message_box_ui
+from fibsem.ui.utils import install_wheel_blocker_recursive, message_box_ui
 
 
 class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidget):
@@ -32,6 +32,8 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
     ):
         super().__init__(parent=parent)
         self.setupUi(self)
+        # generated form: guard its spinboxes/comboboxes against scroll-to-change
+        install_wheel_blocker_recursive(self)
 
         self.microscope = microscope
         self.settings = settings

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -74,7 +74,14 @@ from fibsem.ui.napari.utilities import (
     is_inside_image_bounds,
     update_text_overlay,
 )
-from fibsem.ui.widgets.custom_widgets import ContextMenu, ContextMenuConfig, LamellaNameListWidget, TitledPanel
+from fibsem.ui.widgets.custom_widgets import (
+    ContextMenu,
+    ContextMenuConfig,
+    LamellaNameListWidget,
+    TitledPanel,
+    ValueComboBox,
+    ValueSpinBox,
+)
 from fibsem.ui.widgets.overview_acquisition_settings_widget import (
     OverviewAcquisitionSettingsWidget,
 )
@@ -271,7 +278,7 @@ class FibsemMinimapWidget(QWidget):
         self.gridLayout_2.addWidget(self.label_pattern_overlay, 4, 0)
 
         self.checkBox_pattern_overlay = QCheckBox("Display Pattern")
-        self.comboBox_pattern_overlay = QComboBox()
+        self.comboBox_pattern_overlay = ValueComboBox()
         self.gridLayout_2.addWidget(self.checkBox_pattern_overlay, 5, 0)
         self.gridLayout_2.addWidget(self.comboBox_pattern_overlay, 5, 1)
 
@@ -285,7 +292,7 @@ class FibsemMinimapWidget(QWidget):
         self.gridLayout_4.setContentsMargins(4, 4, 4, 4)
 
         self.label_correlation_selected_layer = QLabel("Selected Layer")
-        self.comboBox_correlation_selected_layer = QComboBox()
+        self.comboBox_correlation_selected_layer = ValueComboBox()
         self.gridLayout_4.addWidget(self.label_correlation_selected_layer, 0, 0)
         self.gridLayout_4.addWidget(self.comboBox_correlation_selected_layer, 0, 1, 1, 2)
 
@@ -297,9 +304,9 @@ class FibsemMinimapWidget(QWidget):
         self.gridLayout_4.addWidget(self.label_gb_width, 2, 1)
         self.gridLayout_4.addWidget(self.label_gb_spacing, 2, 2)
 
-        self.doubleSpinBox_gb_width = QDoubleSpinBox()
+        self.doubleSpinBox_gb_width = ValueSpinBox()
         self.doubleSpinBox_gb_width.setMaximum(10000.0)
-        self.doubleSpinBox_gb_spacing = QDoubleSpinBox()
+        self.doubleSpinBox_gb_spacing = ValueSpinBox()
         self.doubleSpinBox_gb_spacing.setMaximum(10000.0)
         self.gridLayout_4.addWidget(self.doubleSpinBox_gb_width, 3, 1)
         self.gridLayout_4.addWidget(self.doubleSpinBox_gb_spacing, 3, 2)

--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -15,6 +15,9 @@ from fibsem.structures import MicroscopeSettings, SystemSettings
 from fibsem.ui import stylesheets
 from fibsem.ui import notification_service
 from fibsem.ui.utils import message_box_ui, open_existing_file_dialog
+from fibsem.ui.widgets.custom_widgets import (
+    ValueComboBox,
+)
 
 
 class FibsemSystemSetupWidget(QtWidgets.QWidget):
@@ -31,7 +34,7 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
         self.gridLayout = QtWidgets.QGridLayout(self)
         self.pushButton_connect_to_microscope = QtWidgets.QPushButton("Connect To Microscope")
         self.pushButton_apply_configuration = QtWidgets.QPushButton("Apply Microscope Configuration")
-        self.comboBox_configuration = QtWidgets.QComboBox()
+        self.comboBox_configuration = ValueComboBox()
         self.toolButton_import_configuration = QtWidgets.QToolButton()
         self.label_connection_status = QtWidgets.QLabel("No Connected")
         self.label_connection_information = QtWidgets.QLabel("No Connected")

--- a/fibsem/ui/fm/widgets/autofocus_widget.py
+++ b/fibsem/ui/fm/widgets/autofocus_widget.py
@@ -23,7 +23,11 @@ from PyQt5.QtWidgets import (
 
 from fibsem.autofunctions.autofocus import FocusSweepPass
 from fibsem.fm.structures import AutoFocusSettings, ChannelSettings, FocusMethod
-from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueSpinBox
+from fibsem.ui.widgets.custom_widgets import (
+    IconToolButton,
+    ValueComboBox,
+    ValueSpinBox,
+)
 
 if TYPE_CHECKING:
     from fibsem.ui.FMAcquisitionWidget import FMAcquisitionWidget
@@ -228,7 +232,7 @@ class AutofocusWidget(QWidget):
         sep.setStyleSheet("color: #3a3d42;")
         layout.addWidget(sep)
 
-        self.comboBox_method = QComboBox()
+        self.comboBox_method = ValueComboBox()
         self.comboBox_method.setToolTip("Focus measurement method to use")
         for method in FocusMethod:
             self.comboBox_method.addItem(method.value.title(), method)
@@ -236,7 +240,7 @@ class AutofocusWidget(QWidget):
         self.comboBox_method.currentIndexChanged.connect(self._on_method_changed)
         layout.addLayout(self._aligned_control_row("Focus Method", self.comboBox_method))
 
-        self.comboBox_channel = QComboBox()
+        self.comboBox_channel = ValueComboBox()
         self.comboBox_channel.setToolTip("Channel to use for autofocus")
         self._update_channel_list()
         self.comboBox_channel.currentIndexChanged.connect(self._on_channel_changed)

--- a/fibsem/ui/fm/widgets/camera_widget.py
+++ b/fibsem/ui/fm/widgets/camera_widget.py
@@ -12,6 +12,10 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem.fm.structures import CameraImageTransform, CameraSettings
+from fibsem.ui.widgets.custom_widgets import (
+    ValueComboBox,
+    ValueSpinBox,
+)
 
 if TYPE_CHECKING:
     from fibsem.fm.microscope import FluorescenceMicroscope
@@ -60,7 +64,7 @@ class CameraWidget(QWidget):
 
         # Gain
         self.label_gain = QLabel("Gain", self)
-        self.spinBox_gain = QDoubleSpinBox(self)
+        self.spinBox_gain = ValueSpinBox(parent=self)
         self.spinBox_gain.setRange(*CAMERA_CONFIG["gain"]["range"])
         self.spinBox_gain.setSingleStep(CAMERA_CONFIG["gain"]["step"])
         self.spinBox_gain.setSuffix(CAMERA_CONFIG["gain"]["suffix"])
@@ -70,7 +74,7 @@ class CameraWidget(QWidget):
 
         # Binning
         self.label_binning = QLabel("Binning", self)
-        self.combobox_binning = QComboBox(self)
+        self.combobox_binning = ValueComboBox(parent=self)
         for b in CAMERA_CONFIG["binning"]["available_values"]:
             self.combobox_binning.addItem(f"{b}x{b}", b)
         self.combobox_binning.setToolTip(CAMERA_CONFIG["binning"]["tooltip"])
@@ -84,7 +88,7 @@ class CameraWidget(QWidget):
 
         # Image Transform
         self.label_transform = QLabel("Image Transform", self)
-        self.comboBox_transform = QComboBox(self)
+        self.comboBox_transform = ValueComboBox(parent=self)
         self.comboBox_transform.setToolTip(CAMERA_CONFIG["transform"]["tooltip"])
 
         # Populate transform combobox with enum values

--- a/fibsem/ui/fm/widgets/objective_control_widget.py
+++ b/fibsem/ui/fm/widgets/objective_control_widget.py
@@ -25,6 +25,9 @@ from fibsem.ui.stylesheets import (
 from superqt.utils import qdebounced
 from fibsem.ui.utils import message_box_ui
 from fibsem.ui.napari.utilities import update_text_overlay
+from fibsem.ui.widgets.custom_widgets import (
+    ValueSpinBox,
+)
 
 if TYPE_CHECKING:
     from fibsem.ui.FMAcquisitionWidget import FMAcquisitionWidget
@@ -113,7 +116,7 @@ class ObjectiveControlWidget(QWidget):
 
         # add focus position controls
         self.label_focus_position = QLabel("Focus Position", self)
-        self.doubleSpinBox_focus_position = QDoubleSpinBox(self)
+        self.doubleSpinBox_focus_position = ValueSpinBox(parent=self)
         self.doubleSpinBox_focus_position.setRange(self.fm.objective.limits[0] * METRE_TO_MICRON,
                                                    self.fm.objective.limits[1] * METRE_TO_MICRON)
         # Set initial value from objective's focus position if available
@@ -134,7 +137,7 @@ class ObjectiveControlWidget(QWidget):
         # add double spin box for objective position
         self.label_objective_control = QLabel("Current Position", self)
         self.label_objective_step_size = QLabel("Step Size", self)
-        self.doubleSpinBox_objective_position = QDoubleSpinBox(self)
+        self.doubleSpinBox_objective_position = ValueSpinBox(parent=self)
         self.doubleSpinBox_objective_position.setRange(self.fm.objective.limits[0] * METRE_TO_MICRON,
                                                         self.fm.objective.limits[1] * METRE_TO_MICRON)
         self.doubleSpinBox_objective_position.setValue(self.fm.objective.position * METRE_TO_MICRON)  # Convert m to µm
@@ -143,7 +146,7 @@ class ObjectiveControlWidget(QWidget):
         self.doubleSpinBox_objective_position.setSuffix(OBJECTIVE_CONFIG["position"]["suffix"])
         self.doubleSpinBox_objective_position.setToolTip(OBJECTIVE_CONFIG["position"]["tooltip"])
         self.doubleSpinBox_objective_position.setKeyboardTracking(False)  # Disable keyboard tracking for immediate updates
-        self.doubleSpinBox_objective_step_size = QDoubleSpinBox(self)
+        self.doubleSpinBox_objective_step_size = ValueSpinBox(parent=self)
         self.doubleSpinBox_objective_step_size.setRange(*OBJECTIVE_CONFIG["step_size_control"]["range"])
         self.doubleSpinBox_objective_step_size.setSingleStep(OBJECTIVE_CONFIG["step_size_control"]["step"])
         self.doubleSpinBox_objective_step_size.setValue(OBJECTIVE_CONFIG["step_size_control"]["default"])
@@ -154,7 +157,7 @@ class ObjectiveControlWidget(QWidget):
 
         # add user-defined limit controls
         self.label_objective_limit = QLabel("Limit Position", self)
-        self.doubleSpinBox_objective_limit = QDoubleSpinBox(self)
+        self.doubleSpinBox_objective_limit = ValueSpinBox(parent=self)
         self.doubleSpinBox_objective_limit.setRange(0.0, self.fm.objective.limits[1] * METRE_TO_MICRON)
         self.doubleSpinBox_objective_limit.setValue(self.fm.objective.limit_position * METRE_TO_MICRON)
         self.doubleSpinBox_objective_limit.setSingleStep(OBJECTIVE_CONFIG["position"]["step_size"])

--- a/fibsem/ui/fm/widgets/overview_parameters_widget.py
+++ b/fibsem/ui/fm/widgets/overview_parameters_widget.py
@@ -16,6 +16,11 @@ from PyQt5.QtWidgets import (
 
 from fibsem.fm.acquisition import AutoFocusMode, calculate_grid_coverage_area
 from fibsem.fm.structures import OverviewParameters
+from fibsem.ui.widgets.custom_widgets import (
+    IntegerValueSpinBox,
+    ValueComboBox,
+    ValueSpinBox,
+)
 
 if TYPE_CHECKING:
     from fibsem.ui.FMAcquisitionWidget import FMAcquisitionWidget
@@ -58,7 +63,7 @@ class OverviewParametersWidget(QWidget):
 
         # Number of rows
         self.label_rows = QLabel("Rows", self)
-        self.spinBox_rows = QSpinBox(self)
+        self.spinBox_rows = IntegerValueSpinBox(parent=self)
         self.spinBox_rows.setRange(OVERVIEW_PARAMETERS_CONFIG["min_grid_size"], 
                                    OVERVIEW_PARAMETERS_CONFIG["max_grid_size"])
         self.spinBox_rows.setValue(self.rows)
@@ -66,7 +71,7 @@ class OverviewParametersWidget(QWidget):
 
         # Number of columns
         self.label_cols = QLabel("Columns", self)
-        self.spinBox_cols = QSpinBox(self)
+        self.spinBox_cols = IntegerValueSpinBox(parent=self)
         self.spinBox_cols.setRange(OVERVIEW_PARAMETERS_CONFIG["min_grid_size"], 
                                    OVERVIEW_PARAMETERS_CONFIG["max_grid_size"])
         self.spinBox_cols.setValue(self.cols)
@@ -74,7 +79,7 @@ class OverviewParametersWidget(QWidget):
 
         # Tile overlap
         self.label_overlap = QLabel("Overlap", self)
-        self.doubleSpinBox_overlap = QDoubleSpinBox(self)
+        self.doubleSpinBox_overlap = ValueSpinBox(parent=self)
         self.doubleSpinBox_overlap.setRange(*OVERVIEW_PARAMETERS_CONFIG["overlap_range"])
         self.doubleSpinBox_overlap.setValue(self.overlap)
         self.doubleSpinBox_overlap.setSingleStep(OVERVIEW_PARAMETERS_CONFIG["overlap_step"])
@@ -94,7 +99,7 @@ class OverviewParametersWidget(QWidget):
         
         # Auto-focus mode selection
         self.label_autofocus_mode = QLabel("Auto-Focus Mode", self)
-        self.comboBox_autofocus_mode = QComboBox(self)
+        self.comboBox_autofocus_mode = ValueComboBox(parent=self)
         self.comboBox_autofocus_mode.addItem("Don't Auto-Focus", AutoFocusMode.NONE)
         self.comboBox_autofocus_mode.addItem("Auto-Focus Once", AutoFocusMode.ONCE)
         self.comboBox_autofocus_mode.addItem("Auto-Focus Each Row", AutoFocusMode.EACH_ROW)
@@ -110,7 +115,7 @@ class OverviewParametersWidget(QWidget):
 
         # Auto-focus channel selection
         self.label_autofocus_channel = QLabel("Auto-Focus Channel", self)
-        self.comboBox_autofocus_channel = QComboBox(self)
+        self.comboBox_autofocus_channel = ValueComboBox(parent=self)
         self.comboBox_autofocus_channel.setToolTip(OVERVIEW_PARAMETERS_CONFIG["tooltips"]["autofocus_channel"])
         self.autofocus_channel_name = None
 

--- a/fibsem/ui/fm/widgets/saved_positions_widget.py
+++ b/fibsem/ui/fm/widgets/saved_positions_widget.py
@@ -22,6 +22,9 @@ from fibsem.ui.stylesheets import (
 )
 from fibsem.ui.utils import message_box_ui
 from fibsem.applications.autolamella.structures import Lamella
+from fibsem.ui.widgets.custom_widgets import (
+    ValueComboBox,
+)
 
 if TYPE_CHECKING:
     from fibsem.ui.FMAcquisitionWidget import FMAcquisitionWidget
@@ -37,7 +40,7 @@ class SavedPositionsWidget(QWidget):
     def initUI(self):
         # Combobox for selecting saved positions
         self.label_positions = QLabel("Select Position", self)
-        self.comboBox_positions = QComboBox(self)
+        self.comboBox_positions = ValueComboBox(parent=self)
         self.comboBox_positions.setToolTip("Select a saved position from the list")
 
         # Checkbox list for selecting multiple positions
@@ -53,7 +56,7 @@ class SavedPositionsWidget(QWidget):
         self.pushButton_delete_position.setToolTip("Delete the selected position")
 
         # Controls for updating objective position
-        self.comboBox_objective_source = QComboBox(self)
+        self.comboBox_objective_source = ValueComboBox(parent=self)
         self.comboBox_objective_source.addItem("Current Position")
         self.comboBox_objective_source.addItem("Focus Position")
         self.comboBox_objective_source.setToolTip("Select which objective position to use")

--- a/fibsem/ui/fm/widgets/sem_acquisition_widget.py
+++ b/fibsem/ui/fm/widgets/sem_acquisition_widget.py
@@ -8,6 +8,10 @@ from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import ImageSettings, BeamType
 from fibsem.config import SQUARE_RESOLUTIONS_LIST
 from fibsem.ui.stylesheets import GREEN_PUSHBUTTON_STYLE
+from fibsem.ui.widgets.custom_widgets import (
+    ValueComboBox,
+    ValueSpinBox,
+)
 
 if TYPE_CHECKING:
     from fibsem.ui.FMAcquisitionWidget import FMAcquisitionWidget
@@ -33,7 +37,7 @@ class SEMAcquisitionWidget(QWidget):
 
         # field of view, dwell time
         self.fov_label = QLabel("Field of View (FOV)")
-        self.fov_spinbox = QDoubleSpinBox()
+        self.fov_spinbox = ValueSpinBox()
         self.fov_spinbox.setRange(100.0, 2000.0)
         self.fov_spinbox.setValue(500.0)
         self.fov_spinbox.setSuffix(" μm")
@@ -41,7 +45,7 @@ class SEMAcquisitionWidget(QWidget):
         self.fov_spinbox.setDecimals(1)
 
         self.dwell_time_label = QLabel("Dwell Time")
-        self.dwell_time_spinbox = QDoubleSpinBox()
+        self.dwell_time_spinbox = ValueSpinBox()
         self.dwell_time_spinbox.setRange(0.2, 10.0)
         self.dwell_time_spinbox.setValue(1.0)
         self.dwell_time_spinbox.setSuffix(" μs")
@@ -49,7 +53,7 @@ class SEMAcquisitionWidget(QWidget):
         self.dwell_time_spinbox.setDecimals(1)
 
         self.label_resolution = QLabel("Resolution")
-        self.combobox_resolution = QComboBox()
+        self.combobox_resolution = ValueComboBox()
         for res in SQUARE_RESOLUTIONS_LIST:
             self.combobox_resolution.addItem(f"{res[0]}x{res[1]}", userData=res)
         self.combobox_resolution.setCurrentIndex(SQUARE_RESOLUTIONS_LIST.index([2048, 2048]))  # Default to 2048x2048

--- a/fibsem/ui/fm/widgets/stage_position_control_widget.py
+++ b/fibsem/ui/fm/widgets/stage_position_control_widget.py
@@ -15,6 +15,9 @@ from fibsem.ui.stylesheets import (
     BLUE_PUSHBUTTON_STYLE,
     GRAY_PUSHBUTTON_STYLE,
 )
+from fibsem.ui.widgets.custom_widgets import (
+    ValueSpinBox,
+)
 
 if TYPE_CHECKING:
     from fibsem.ui.FMAcquisitionWidget import FMAcquisitionWidget
@@ -40,7 +43,7 @@ class StagePositionControlWidget(QWidget):
         self.button_fm_orientation.clicked.connect(self.move_to_fm_orientation)
 
         # Milling angle controls    
-        self.milling_angle_spinbox = QDoubleSpinBox(self)
+        self.milling_angle_spinbox = ValueSpinBox(parent=self)
         self.milling_angle_spinbox.setRange(0, 45)
         self.milling_angle_spinbox.setValue(self.microscope.system.stage.milling_angle)
         self.milling_angle_spinbox.setSuffix("°")

--- a/fibsem/ui/fm/widgets/z_parameters_widget.py
+++ b/fibsem/ui/fm/widgets/z_parameters_widget.py
@@ -10,6 +10,10 @@ from PyQt5.QtWidgets import (
 )
 from fibsem.fm.structures import ZParameters, ZStackOrder
 from PyQt5.QtCore import pyqtSignal
+from fibsem.ui.widgets.custom_widgets import (
+    ValueComboBox,
+    ValueSpinBox,
+)
 
 Z_PARAMETERS_CONFIG = {
     "step_size": 0.1,  # µm
@@ -44,7 +48,7 @@ class ZParametersWidget(QWidget):
 
         # Z minimum
         self.label_zmin = QLabel("Z Min", self)
-        self.doubleSpinBox_zmin = QDoubleSpinBox(self)
+        self.doubleSpinBox_zmin = ValueSpinBox(parent=self)
         self.doubleSpinBox_zmin.setRange(*Z_PARAMETERS_CONFIG["range"]["zmin"])  # ±100 µm range
         self.doubleSpinBox_zmin.setValue(self.z_parameters.zmin * 1e6)  # Convert m to µm
         self.doubleSpinBox_zmin.setSingleStep(Z_PARAMETERS_CONFIG["step_size"])
@@ -55,7 +59,7 @@ class ZParametersWidget(QWidget):
 
         # Z maximum
         self.label_zmax = QLabel("Z Max", self)
-        self.doubleSpinBox_zmax = QDoubleSpinBox(self)
+        self.doubleSpinBox_zmax = ValueSpinBox(parent=self)
         self.doubleSpinBox_zmax.setRange(*Z_PARAMETERS_CONFIG["range"]["zmax"])  # ±100 µm range
         self.doubleSpinBox_zmax.setValue(self.z_parameters.zmax * 1e6)  # Convert m to µm
         self.doubleSpinBox_zmax.setSingleStep(Z_PARAMETERS_CONFIG["step_size"])
@@ -66,7 +70,7 @@ class ZParametersWidget(QWidget):
 
         # Z step
         self.label_zstep = QLabel("Z Step", self)
-        self.doubleSpinBox_zstep = QDoubleSpinBox(self)
+        self.doubleSpinBox_zstep = ValueSpinBox(parent=self)
         self.doubleSpinBox_zstep.setRange(*Z_PARAMETERS_CONFIG["range"]["zstep"])  # 0.1 to 10 µm range
         self.doubleSpinBox_zstep.setValue(self.z_parameters.zstep * 1e6)  # Convert m to µm
         self.doubleSpinBox_zstep.setSingleStep(Z_PARAMETERS_CONFIG["step_size"])
@@ -82,7 +86,7 @@ class ZParametersWidget(QWidget):
 
         # Acquisition order
         self.label_order = QLabel("Order", self)
-        self.combo_order = QComboBox(self)
+        self.combo_order = ValueComboBox(parent=self)
         self.combo_order.addItem("Channel-wise", ZStackOrder.CHANNEL)
         self.combo_order.addItem("Z-level-wise", ZStackOrder.Z_LEVEL)
         self.combo_order.setCurrentIndex(

--- a/fibsem/ui/utils.py
+++ b/fibsem/ui/utils.py
@@ -243,7 +243,10 @@ def create_combobox_message_box(text: str, title: str, options: list, parent = N
     msg.setStandardButtons(QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel)
 
     # create a combobox
+    # guarded directly rather than via ValueComboBox: custom_widgets imports from
+    # this module, so importing it back here would be circular.
     combobox = QtWidgets.QComboBox(msg)
+    install_wheel_blocker(combobox)
     combobox.addItems(options)
 
     # add combobox to message box

--- a/fibsem/ui/widgets/autolamella_global_task_editor_dialog.py
+++ b/fibsem/ui/widgets/autolamella_global_task_editor_dialog.py
@@ -24,7 +24,10 @@ from fibsem.constants import SI_TO_MICRO, MICRO_TO_SI
 from fibsem.applications.autolamella.structures import Experiment
 from fibsem.structures import ReferenceImageParameters
 from fibsem.ui.stylesheets import PRIMARY_BUTTON_STYLESHEET
-from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.ui.widgets.custom_widgets import (
+    TitledPanel,
+    ValueSpinBox,
+)
 from fibsem.ui.widgets.reference_image_parameters_widget import ReferenceImageParametersWidget
 
 
@@ -57,7 +60,7 @@ class AutoLamellaGlobalTaskEditDialog(QDialog):
         self.label_milling_fov = QLabel("Field of View")
         self.label_milling_fov.setToolTip("Field of view for all milling tasks (in microns)")
 
-        self.spinbox_milling_fov = QDoubleSpinBox()
+        self.spinbox_milling_fov = ValueSpinBox()
         self.spinbox_milling_fov.setRange(0.001, 10000)
         self.spinbox_milling_fov.setDecimals(1)
         self.spinbox_milling_fov.setSingleStep(5.0)

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -49,6 +49,7 @@ from fibsem.ui.widgets.custom_widgets import (
     ContextMenuConfig,
     IconToolButton,
     TaskNameListWidget,
+    ValueComboBox,
 )
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 from fibsem.ui.widgets.reference_image_parameters_widget import (
@@ -258,15 +259,15 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         self.listWidget_selected_task = TaskNameListWidget()
         self.listWidget_selected_task.set_buttons_visible(add=False, remove=False)
 
-        self.combobox_fm_filenames = QComboBox()
+        self.combobox_fm_filenames = ValueComboBox()
         self.combobox_fm_filenames_label = QLabel("FM Z-Stack")
         self.combobox_fm_filenames.currentIndexChanged.connect(self._on_image_selected)
 
-        self.combobox_fib_filenames = QComboBox()
+        self.combobox_fib_filenames = ValueComboBox()
         self.combobox_fib_filenames_label = QLabel("FIB Image")
         self.combobox_fib_filenames.currentIndexChanged.connect(self._on_image_selected)
 
-        self.combobox_sem_filenames = QComboBox()
+        self.combobox_sem_filenames = ValueComboBox()
         self.combobox_sem_filenames_label = QLabel("SEM Image")
         self.combobox_sem_filenames.currentIndexChanged.connect(self._on_image_selected)
         self.combobox_sem_filenames.setEnabled(self.show_sem_image)

--- a/fibsem/ui/widgets/autolamella_overview_image_widget.py
+++ b/fibsem/ui/widgets/autolamella_overview_image_widget.py
@@ -26,7 +26,10 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtGui import QColor
 
 from fibsem.applications.autolamella.structures import Experiment
-from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.ui.widgets.custom_widgets import (
+    IntegerValueSpinBox,
+    TitledPanel,
+)
 from fibsem.imaging.tiled import plot_minimap
 from fibsem.structures import FibsemImage
 import glob
@@ -181,14 +184,14 @@ class OverviewImageWidget(QWidget):
         color_layout.addStretch()
 
         # Text size
-        self.text_size_spinbox = QSpinBox()
+        self.text_size_spinbox = IntegerValueSpinBox()
         self.text_size_spinbox.setStyleSheet(SPINBOX_STYLESHEET)
         self.text_size_spinbox.setRange(6, 48)
         self.text_size_spinbox.setValue(10)
         self.text_size_spinbox.setKeyboardTracking(False)
 
         # Marker size
-        self.markersize_spinbox = QSpinBox()
+        self.markersize_spinbox = IntegerValueSpinBox()
         self.markersize_spinbox.setStyleSheet(SPINBOX_STYLESHEET)
         self.markersize_spinbox.setRange(5, 100)
         self.markersize_spinbox.setValue(20)

--- a/fibsem/ui/widgets/autolamella_task_config_editor.py
+++ b/fibsem/ui/widgets/autolamella_task_config_editor.py
@@ -34,7 +34,10 @@ from fibsem.ui.widgets.autolamella_spot_burn_coordinates_widget import (
 )
 from fibsem.ui.widgets.autolamella_global_task_editor_dialog import AutoLamellaGlobalTaskEditDialog
 from fibsem.ui.widgets.lamella_default_config_widget import LamellaDefaultConfigWidget
-from fibsem.ui.widgets.custom_widgets import TaskNameListWidget
+from fibsem.ui.widgets.custom_widgets import (
+    TaskNameListWidget,
+    ValueComboBox,
+)
 from fibsem.ui.widgets.autolamella_protocol_information_widget import ProtocolInformationWidget
 from fibsem.ui.widgets.autolamella_task_config_widget import AutoLamellaTaskParametersConfigWidget
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
@@ -57,7 +60,7 @@ class AddTaskDialog(QDialog):
 
         # Create widgets
         self.label_task_type = QLabel("Task Type:")
-        self.comboBox_task_type = QComboBox()
+        self.comboBox_task_type = ValueComboBox()
 
         # Populate task types from registry (includes plugins and runtime registrations)
         for task_type, task_cls in get_tasks().items():

--- a/fibsem/ui/widgets/bug_report_widget.py
+++ b/fibsem/ui/widgets/bug_report_widget.py
@@ -27,7 +27,10 @@ from fibsem.applications.autolamella.tools import bug_report
 from fibsem.applications.autolamella.tools.bug_report import BugReportContent
 from fibsem.ui import stylesheets
 from fibsem.ui.utils import open_path_in_file_explorer
-from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.ui.widgets.custom_widgets import (
+    TitledPanel,
+    ValueComboBox,
+)
 
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.structures import Experiment
@@ -76,7 +79,7 @@ class BugReportDialog(QDialog):
         self.lineEdit_title = QLineEdit()
         self.lineEdit_title.setPlaceholderText("Short summary of the issue")
 
-        self.combo_severity = QComboBox()
+        self.combo_severity = ValueComboBox()
         self.combo_severity.addItems(SEVERITY_OPTIONS)
         self.combo_severity.setCurrentText("Crash" if traceback_text else "Normal")
 

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -67,7 +67,11 @@ from fibsem.milling.strategy.coincidence import CoincidenceMillingStrategy
 from fibsem.structures import BeamType, FibsemImage, Point
 from fibsem.ui import notification_service, stylesheets
 from fibsem.ui.fm.widgets import LinePlotWidget
-from fibsem.ui.widgets.custom_widgets import LamellaNameListWidget, TitledPanel
+from fibsem.ui.widgets.custom_widgets import (
+    IntegerValueSpinBox,
+    LamellaNameListWidget,
+    TitledPanel,
+)
 from fibsem.ui.widgets.selected_lamella_widget import SelectedLamellaWidget
 from fibsem.ui.widgets.image_canvas import (
     FibsemImageCanvas,
@@ -1434,7 +1438,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         self.btn_supervised.setVisible(False)
         self._update_supervised_button()
 
-        self.spin_drop_threshold = QSpinBox()
+        self.spin_drop_threshold = IntegerValueSpinBox()
         self.spin_drop_threshold.setRange(5, 90)
         self.spin_drop_threshold.setValue(40)  # % drop (40% == retained fraction 0.6)
         self.spin_drop_threshold.setPrefix("Stop at ")

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -51,7 +51,11 @@ from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
 )
-from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel
+from fibsem.ui.widgets.custom_widgets import (
+    IconToolButton,
+    TitledPanel,
+    ValueComboBox,
+)
 
 
 class FMControlWidget(QWidget):
@@ -163,7 +167,7 @@ class FMControlWidget(QWidget):
 
         # Default orientation for fluorescence pose when adding a lamella
         self.label_default_orientation = QLabel("Default Orientation", self)
-        self.comboBox_default_orientation = QComboBox(self)
+        self.comboBox_default_orientation = ValueComboBox(parent=self)
         self.comboBox_default_orientation.addItems(["SEM", "FM"])
         self.comboBox_default_orientation.setCurrentText(self.fm.default_orientation)
         self.comboBox_default_orientation.setToolTip(

--- a/fibsem/ui/widgets/lamella_workflow_widget.py
+++ b/fibsem/ui/widgets/lamella_workflow_widget.py
@@ -26,6 +26,9 @@ from fibsem.ui.widgets.lamella_list_widget import LamellaListWidget
 from fibsem.ui.widgets.workflow_config_widget import WorkflowConfigWidget
 from fibsem.ui.widgets.workflow_info_widget import WorkflowInfoWidget
 from fibsem.ui.widgets.workflow_task_editor_widget import WorkflowTaskEditorWidget
+from fibsem.ui.widgets.custom_widgets import (
+    ValueComboBox,
+)
 
 _SECTION_LABEL_STYLE = (
     "font-size: 11px; font-weight: bold; color: #a0a0a0;"
@@ -58,7 +61,7 @@ class AddTaskDialog(QDialog):
         layout.addWidget(info_label)
 
         # Task selector
-        self.task_selector = QComboBox()
+        self.task_selector = ValueComboBox()
         self.task_selector.addItem("Select a task...", None)
 
         for name in sorted(available_tasks):

--- a/fibsem/ui/widgets/milling_alignment_widget.py
+++ b/fibsem/ui/widgets/milling_alignment_widget.py
@@ -3,6 +3,9 @@ from PyQt5.QtWidgets import QCheckBox, QGridLayout, QLabel, QSpinBox, QWidget
 
 from fibsem.structures import MillingAlignment
 from fibsem.ui.widgets.image_settings_widget import ImageSettingsWidget
+from fibsem.ui.widgets.custom_widgets import (
+    IntegerValueSpinBox,
+)
 
 # GUI Configuration Constants
 WIDGET_CONFIG = {
@@ -74,7 +77,7 @@ class FibsemMillingAlignmentWidget(QWidget):
         # Alignment steps
         self.steps_label = QLabel("Alignment Steps")
         layout.addWidget(self.steps_label, 2, 0)
-        self.steps_spinbox = QSpinBox()
+        self.steps_spinbox = IntegerValueSpinBox()
         steps_config = WIDGET_CONFIG["steps"]
         self.steps_spinbox.setRange(*steps_config["range"])
         self.steps_spinbox.setValue(steps_config["default"])

--- a/tests/ui/test_wheel_blocker.py
+++ b/tests/ui/test_wheel_blocker.py
@@ -160,6 +160,29 @@ def test_all_value_widgets_are_guarded(qapp, factory):
     area.close()
 
 
+def test_recursive_guard_protects_raw_widgets(qapp):
+    """Covers forms built elsewhere, e.g. generated Qt Designer code.
+
+    Those declare plain QSpinBox/QComboBox that we cannot swap for Value* classes,
+    so the consuming widget calls install_wheel_blocker_recursive() after setupUi().
+    """
+    area, widgets = _scroll_area(
+        lambda: (lambda w: (w.setRange(0, 1000), w.setValue(50), w)[-1])(QDoubleSpinBox())
+    )
+    install_wheel_blocker_recursive(area)
+
+    w = widgets[3]
+    value_before = w.value()
+    scroll_before = area.verticalScrollBar().value()
+
+    QApplication.sendEvent(w, _wheel(w))
+    QApplication.processEvents()
+
+    assert w.value() == value_before, "recursive guard must stop the value changing"
+    assert area.verticalScrollBar().value() > scroll_before, "panel must still scroll"
+    area.close()
+
+
 def test_guard_outside_scroll_area_still_blocks(qapp):
     """With no scrolling ancestor there is nothing to forward to; still must not change."""
     w = _spin()


### PR DESCRIPTION
Stacked on #152 (retarget to `main` once that merges).

Completes the fix for *"you accidentally change values when scrolling to scroll down in the page"*. #152 added the machinery; this migrates every raw spinbox/combobox reachable from AutoLamella onto the guarded `Value*` classes.

## How the widgets were found

Static transitive import closure from `AutoLamellaMainUI` (**210 modules** — catches imports inside functions, which a runtime trace misses), then an AST scan for raw `QSpinBox`/`QDoubleSpinBox`/`QComboBox` assignments minus anything already protected.

## Migrated — 47 widgets across 21 files

| Batch | Widgets |
|---|---|
| FM / fluorescence | 24 |
| AutoLamella-specific | 8 |
| Correlation | 5 |
| Minimap | 4 |
| Shared / misc | 6 |

`QSpinBox` → `IntegerValueSpinBox`, `QDoubleSpinBox` → `ValueSpinBox`, `QComboBox` → `ValueComboBox`.

**Only the constructor changes.** These widgets configure themselves with `setRange`/`setValue`/`setSuffix`/etc *after* construction, so every existing setting still applies and overrides the `Value*` defaults. That is what keeps a 47-widget change low-risk.

The one intended behaviour difference is `setKeyboardTracking(False)`, which the `Value*` classes apply: `valueChanged` now fires on commit rather than per keystroke. That is desirable here — e.g. typing `45` into the milling-angle box no longer transiently applies `4`.

## Two cases that could not use `Value*`

- **`utils.py`'s selection dialog** builds a `QComboBox`, but `custom_widgets` imports from `utils`, so importing it back is circular. Guarded directly with `install_wheel_blocker()`.
- **`FibsemManipulatorWidget`** is generated Qt Designer code, so its 7 widgets cannot be swapped. Its consumer calls `install_wheel_blocker_recursive()` after `setupUi()` — the case that helper exists for. (This one is in the `fibsem_ui` app, not AutoLamella.)

## Verification

Re-running the audit against the migrated tree reports **0 unprotected widgets** reachable from AutoLamella.

The audit still lists the *generated* `FibsemManipulatorWidget.py`, because a static scan cannot see protection applied in a different file from where the widgets are declared. A test covers that path directly instead.

`tests/ui` — **17 passed**. All apps and affected widgets still import.