### PR TITLE
Correlation: reject the wrong JSON in Load Coordinates instead of crashing (FIB-263)

### DIFF
--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -154,14 +154,31 @@ class CorrelationInputData:
 
     @staticmethod
     def from_dict(data: dict) -> CorrelationInputData:
+        # Reject rather than default. to_dict always writes "fib_coordinates",
+        # even when empty, so its absence means this is not a coordinates file —
+        # and defaulting to [] would quietly return an empty CorrelationInputData
+        # that the caller then applies, wiping the coordinates it replaced.
+        if "fib_coordinates" not in data:
+            hint = (
+                " This looks like a correlation result — load it with"
+                " Load Correlation Result instead."
+                if ("poi" in data or "input_data" in data)
+                else ""
+            )
+            raise ValueError(
+                "Not a correlation coordinates file: no 'fib_coordinates' key." + hint
+            )
+
         fib_coordinates = [
             Coordinate.from_dict(coord) for coord in data["fib_coordinates"]
         ]
+        # Sibling keys are written by the same writer, so tolerate their absence
+        # in a hand-edited file now that the file type itself is established.
         fm_coordinates = [
-            Coordinate.from_dict(coord) for coord in data["fm_coordinates"]
+            Coordinate.from_dict(coord) for coord in data.get("fm_coordinates", [])
         ]
         poi_coordinates = [
-            Coordinate.from_dict(coord) for coord in data["poi_coordinates"]
+            Coordinate.from_dict(coord) for coord in data.get("poi_coordinates", [])
         ]
         surface_coordinate = (
             Coordinate.from_dict(data["surface_coordinate"])
@@ -181,7 +198,9 @@ class CorrelationInputData:
             surface_coordinate=surface_coordinate,
             fm_surface_coordinate=fm_surface_coordinate,
             ri_pre_correction_factor=data.get("ri_pre_correction_factor"),
-            method=data["method"],
+            # Has a dataclass default and sits between two .get() calls; the hard
+            # subscript was the second key that could throw out of this function.
+            method=data.get("method", "multi-point"),
             stored_fib_image_shape=tuple(stored_shape) if stored_shape else None,
             stored_fib_image_pixel_size=data.get("fib_image_pixel_size"),
         )
@@ -280,6 +299,15 @@ class CorrelationResult:
 
     @staticmethod
     def from_dict(data: dict) -> CorrelationResult:
+        # The mirror of CorrelationInputData.from_dict: the two auto-saved files
+        # sit side by side with near-identical names, so guard both directions.
+        # Loading coordinates here would otherwise yield a result with no POI and
+        # rms 0 — not a crash, but a convincing-looking empty one.
+        if "poi" not in data and "fib_coordinates" in data:
+            raise ValueError(
+                "Not a correlation result file: no 'poi' key. This looks like a"
+                " coordinates file — load it with Load Coordinates instead."
+            )
         return CorrelationResult(
             poi=[CorrelationPointOfInterest.from_dict(p) for p in data.get("poi", [])],
             poi_uncorrected=[

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -1500,6 +1500,7 @@ class CorrelationTabWidget(QWidget):
 
     def load_data(self, path: str) -> None:
         """Load coordinates from JSON, preserving current images."""
+        logging.info("Loading correlation coordinates from %s", path)
         loaded = CorrelationInputData.load(path)
         loaded.fib_image = self._fib_image
         loaded.fm_image = self._fm_image
@@ -2011,6 +2012,7 @@ class CorrelationTabWidget(QWidget):
 
     def load_result(self, path: str) -> None:
         """Load a correlation result from JSON and adopt it (mirrors load_data)."""
+        logging.info("Loading correlation result from %s", path)
         self._load_result(CorrelationResult.load(path))
 
     def _menu_load_result(self) -> None:
@@ -2041,8 +2043,15 @@ class CorrelationTabWidget(QWidget):
         path, _ = QFileDialog.getOpenFileName(
             self, "Load Coordinates", start, "JSON (*.json);;All files (*)"
         )
-        if path:
+        if not path:
+            return
+        # Guarded like _menu_load_result: this dialog opens on the project dir,
+        # which holds both auto-saved JSONs, so picking the wrong one is easy.
+        try:
             self.load_data(path)
+        except Exception as exc:
+            logging.exception("Failed to load coordinates from %s", path)
+            QMessageBox.warning(self, "Load Error", f"Could not load coordinates:\n{exc}")
 
     def _on_save(self) -> None:
         start = self._project_dir or ""

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -1208,3 +1208,95 @@ def test_labels_toggle_hides_labels(qapp):
 
     w._on_labels_toggled(True)
     assert fib._label_artists[0].get_visible() is True
+
+
+# ---------------------------------------------------------------------------
+# FIB-263: Load Coordinates on a result file
+# ---------------------------------------------------------------------------
+
+
+def _project(tmp_path, w):
+    """A project dir with both auto-saved JSONs, as a real session leaves it."""
+    import json
+
+    w.set_project_dir(str(tmp_path))
+    data = CorrelationInputData(
+        fib_coordinates=[_coord(1.0, 2.0, pt=PointType.FIB)],
+        fm_coordinates=[_coord(3.0, 4.0, pt=PointType.FM)],
+        poi_coordinates=[_coord(5.0, 6.0, pt=PointType.POI)],
+    )
+    data_path = tmp_path / "correlation_data.json"
+    data_path.write_text(json.dumps(data.to_dict()))
+
+    result_path = tmp_path / "correlation_result.json"
+    result_path.write_text(
+        json.dumps(
+            CorrelationResult(
+                poi=[CorrelationPointOfInterest(image_px=Point(x=1.0, y=2.0))],
+                rms_error=1.5,
+            ).to_dict()
+        )
+    )
+    return str(data_path), str(result_path)
+
+
+def test_load_coordinates_rejects_a_result_file(qapp, tmp_path):
+    """The reported crash: both JSONs sit in the project dir with near-identical
+    names, and Load Coordinates on the result one took the app down."""
+    w = _widget(qapp)
+    _, result_path = _project(tmp_path, w)
+
+    with pytest.raises(ValueError) as exc:
+        w.load_data(result_path)
+    assert "Load Correlation Result" in str(exc.value)  # says what to do instead
+
+
+def test_load_coordinates_does_not_wipe_points_on_a_result_file(qapp, tmp_path):
+    """Defaulting the missing key to [] instead of rejecting would turn the crash
+    into silent data loss: an empty input data is applied, and the auto-save then
+    overwrites correlation_data.json with the emptied set."""
+    import json
+
+    w = _widget(qapp)
+    data_path, result_path = _project(tmp_path, w)
+    w.load_data(data_path)
+    assert len(w.data.fib_coordinates) == 1
+
+    try:
+        w.load_data(result_path)
+    except ValueError:
+        pass  # rejected, as it should be
+
+    assert len(w.data.fib_coordinates) == 1  # still there, not cleared
+    on_disk = json.loads(open(data_path).read())
+    assert len(on_disk["fib_coordinates"]) == 1  # and not overwritten on disk
+
+
+def test_load_result_rejects_a_coordinates_file(qapp, tmp_path):
+    """The mirror mistake, which produced a plausible-looking empty result."""
+    w = _widget(qapp)
+    data_path, _ = _project(tmp_path, w)
+
+    with pytest.raises(ValueError) as exc:
+        w.load_result(data_path)
+    assert "Load Coordinates" in str(exc.value)
+
+
+def test_load_coordinates_shows_a_warning_instead_of_crashing(qapp, tmp_path, monkeypatch):
+    """_on_load had no try/except while _menu_load_result did — the same mistake
+    was a friendly warning in one direction and an unhandled KeyError in the other."""
+    from PyQt5.QtWidgets import QFileDialog, QMessageBox
+
+    w = _widget(qapp)
+    _, result_path = _project(tmp_path, w)
+
+    monkeypatch.setattr(
+        QFileDialog, "getOpenFileName", staticmethod(lambda *a, **k: (result_path, ""))
+    )
+    shown = []
+    monkeypatch.setattr(
+        QMessageBox, "warning", staticmethod(lambda *a, **k: shown.append(a))
+    )
+
+    w._on_load()  # must not raise
+    assert shown, "expected a warning dialog rather than an exception"


### PR DESCRIPTION
Fixes [FIB-263](https://linear.app/fibsemos/issue/FIB-263).

## The crash

Selecting `correlation_result.json` in **Load Coordinates** raised an unhandled `KeyError: 'fib_coordinates'` and took the application down. Reported by a user as *"software crashed twice upon reloading of coordinates in the correlation tab"*.

It was hard to avoid. Both JSONs are auto-saved side by side into the project directory, both dialogs open there with the same `*.json` filter, and the names differ by one word:

```python
self.data_changed.connect(self._auto_save_data)      # -> correlation_data.json
self.result_changed.connect(self._auto_save_result)  # -> correlation_result.json
```

Two defects sat twenty lines apart in the same file — the same mis-click was a friendly warning in one direction and a hard crash in the other:

| | `_menu_load_result` | `_on_load` |
|---|---|---|
| Error handling | `try/except` → warning | **none — propagates** |
| Parser | `data.get("poi", [])` | **`data["fib_coordinates"]`** |

## Why this rejects rather than defaults

The issue proposed switching the coordinate lists to `.get(key, [])`. That would be worse than the crash.

`to_dict` writes `"fib_coordinates"` **unconditionally, even for an empty list**. So its absence doesn't mean "no coordinates" — it means *this is not a coordinates file*. Defaulting to `[]` returns an empty `CorrelationInputData`, and then:

```
load_data → set_data (clears every list) → data_changed
          → _auto_save_data → overwrites correlation_data.json with the emptied set
```

The user's saved points are destroyed, on disk, with no error. `from_dict` now raises instead, with a message naming the menu item that *does* load the file it was handed.

`test_load_coordinates_does_not_wipe_points_on_a_result_file` pins this — it asserts the points survive both in memory and on disk.

## A second key the issue missed

Applying the proposed fix exactly still crashes, on `KeyError: 'method'`. There were **four** hard subscripts in `from_dict`, not three. `method` has a dataclass default (`"multi-point"`) and sits between two `.get()` calls, so it's softened here too — fixing only the coordinate lists would have moved the crash rather than removed it.

It has been written since #90, so this is not a back-compat fix; it was simply the next landmine.

## Changes

- **`CorrelationInputData.from_dict`** — reject a non-coordinates payload with a message pointing at *Load Correlation Result*; `.get()` for the sibling keys once the file type is established
- **`CorrelationResult.from_dict`** — guard the mirror mistake. Loading coordinates as a result didn't crash, but produced a convincing empty result with `rms 0` and no POI
- **`_on_load`** — the `try/except` → `QMessageBox.warning` that `_menu_load_result` already had
- **`load_data` / `load_result`** — log the path. Neither did, and no `.json` filename appeared anywhere in the reported 21 MB log, so the offending file had to be inferred rather than read

## Testing

116 correlation tests pass. New coverage for both rejection directions, the no-data-loss guarantee, and `_on_load` warning rather than raising. Verified against the real session files in `tmp/`: both still round-trip, and both wrong-file directions are rejected with the correct hint.

## Not included

Payload **sniff-and-redirect** — offering to load a result file as a result — is left to [FIB-264](https://linear.app/fibsemos/issue/FIB-264), which removes the mis-click entirely by consolidating the two files into one. The error message here already tells the user which menu item to use.
