### PR TITLE
[ui] more meaningful move + autofocus status messages (FIB-272)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -136,7 +136,9 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
                 pos="Continue"
                 )
 
-        self.log_status_message("AUTOFOCUS", "Running Autofocus...")
+        af_display = (f"Autofocus: {autofocus_channel.name} "
+                      f"[{af_settings.method.value}], {len(af_settings.passes)} pass(es)")
+        self.log_status_message("AUTOFOCUS", af_display)
         self.microscope.fm.acquisition_progress_signal.emit({"state": "autofocusing", "task": f"{self.task_name}"}) # type: ignore
         # Query: pass in channel settings so we are certain the channel is correct
         result = run_coarse_fine_autofocus(

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -390,6 +390,7 @@ class AutoLamellaTask(ABC):
             ],
             reduced_area=FibsemRectangle(0.25, 0.25, 0.5, 0.5),
             use_autocontrast=True)
+        self.log_status_message("AUTOFOCUS", f"Running autofocus ({beam_type.name})...")
         result = run_auto_focus(
             self.microscope,
             beam_type=beam_type,

--- a/fibsem/ui/FibsemImageSettingsWidget.py
+++ b/fibsem/ui/FibsemImageSettingsWidget.py
@@ -433,6 +433,7 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
     def run_autofocus(self) -> None:
         """Run autofocus for the selected beam type."""
         beam_type = self.dual_beam_widget.beam_type
+        notification_service.show_toast(f"Running AutoFocus on {beam_type.name} beam...")
         self._toggle_interactions(enable=False)
         worker = self._autofocus_worker(beam_type)
         worker.finished.connect(lambda: self._on_auto_function_finished("AutoFocus", beam_type=beam_type))
@@ -466,7 +467,7 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         beam_widget.sync_from_microscope()
         if name == "AutoFocus":
             wd = beam_widget.beam_settings_widget.working_distance_spinbox.value()
-            notification_service.show_toast(f"AutoFocus Complete. Best WD: {wd:.2f}mm")
+            notification_service.show_toast(f"AutoFocus Complete ({beam_type.name}). Best WD: {wd:.2f}mm")
         if name == "AutoContrast":
             notification_service.show_toast("AutoContrast Complete.")
 

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -358,7 +358,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     @thread_worker
     def absolute_movement_worker(self, stage_position: FibsemStagePosition) -> None:
         """Worker function to move the stage to the specified position"""
-        self.movement_progress_signal.emit({"msg": f"Moving to {stage_position}"})
+        self.movement_progress_signal.emit({"msg": f"Moving to {stage_position.pretty}"})
         self.microscope.safe_absolute_stage_movement(stage_position)
         self.movement_progress_signal.emit({"msg": "Move finished, taking new images"})
         self.update_ui_after_movement()


### PR DESCRIPTION
Resolves [FIB-272](https://linear.app/fibsemos/issue/FIB-272) (part of the GUI Canvas feedback batch, [FIB-271](https://linear.app/fibsemos/issue/FIB-271)).

Makes three status-message surfaces meaningful.

### Move-to-position toast
`FibsemMovementWidget.absolute_movement_worker` interpolated the whole `FibsemStagePosition` dataclass repr. Now uses the existing `.pretty` formatter:

`Moving to X:1.00mm, Y:2.00mm, Z:..mm, R:..°, T:..°` instead of `Moving to FibsemStagePosition(name=None, x=0.001, ...)`.

### Autofocus messages (all three surfaces)
The autofocus status was `"Running Autofocus..."` (or nothing) despite the useful detail already existing in a log line.

- **Fluorescence workflow** (`acquire_fluorescence.py`): status now shows `Autofocus: {channel} [{method}], N pass(es)`.
- **Standard autofocus, workflow** (`base.py::_run_autofocus`): emits a start message `Running autofocus ({beam})...` before the run (previously only a post-completion message).
- **Standard autofocus, GUI** (`FibsemImageSettingsWidget`): adds a start toast `Running AutoFocus on {beam} beam...` (previously spinner-only) and the completion toast now names the beam.

### Testing
GUI-only paths; verified by launching the AutoLamella UI against the Demo microscope (stage move toast, Run AutoFocus toasts, autofocus workflow status line). Edited files compile.
