### PR TITLE
Correlation: interpolate the FM z-stack from the GUI (FIB-253)

### DIFF
--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -42,7 +42,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 logging.basicConfig(level=logging.INFO)
 
 import numpy as np
-from PyQt5.QtCore import Qt, QThread, pyqtSignal
+from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal
 from PyQt5.QtWidgets import (
     QAbstractSpinBox,
     QApplication,
@@ -57,6 +57,7 @@ from PyQt5.QtWidgets import (
     QLineEdit,
     QMenuBar,
     QMessageBox,
+    QProgressBar,
     QPushButton,
     QScrollArea,
     QShortcut,
@@ -86,7 +87,8 @@ from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
     PointFitResult,
     humanize_fit_error,
 )
-from fibsem.ui import stylesheets
+from fibsem.ui import notification_service, stylesheets
+from fibsem.ui.icon import fibsem_icon
 from fibsem.correlation.ui.widgets.fm_image_display_widget import (
     IMAGE_HEADER_STYLE,
     FMImageDisplayWidget,
@@ -210,6 +212,20 @@ class _CorrelationWorker(QThread):
             self.errored.emit(str(exc))
 
 
+class _ProgressRelay(QObject):
+    """Bounces a worker-thread progress callback onto the GUI thread.
+
+    ``interpolate_fm_volume`` calls ``emit_progress(done, total)`` from the worker
+    thread; because this object is created on the GUI thread, emitting its signal
+    there delivers it through the GUI event loop, so slots may touch widgets.
+    """
+
+    progress = pyqtSignal(int, int)  # (channels_done, channels_total)
+
+    def emit_progress(self, done: int, total: int) -> None:
+        self.progress.emit(done, total)
+
+
 # ---------------------------------------------------------------------------
 # Tab 0 — Images
 # ---------------------------------------------------------------------------
@@ -221,6 +237,7 @@ class _ImagesTab(QWidget):
     fib_image_changed = pyqtSignal(object)  # FibsemImage
     fm_image_changed = pyqtSignal(object)  # FluorescenceImage
     project_dir_changed = pyqtSignal(str)  # directory path
+    interpolate_requested = pyqtSignal()  # interpolate the loaded FM z-stack
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
@@ -297,8 +314,35 @@ class _ImagesTab(QWidget):
         self._lbl_fm_z.setStyleSheet("color: #e0e0e0; font-size: 11px;")
         fm_form.addRow("Shape (C×Z×Y×X):", self._lbl_fm_shape)
         fm_form.addRow("Channels:", self._lbl_fm_ch)
-        fm_form.addRow("Z-slices:", self._lbl_fm_z)
+
+        # The interpolate action rides the Z-slices row — it acts on the z axis,
+        # so it reads as the action on that number rather than a stray button.
+        # (Data transform, deliberately not on the canvas toolbar.)
+        z_row = QWidget()
+        z_row_layout = QHBoxLayout(z_row)
+        z_row_layout.setContentsMargins(0, 0, 0, 0)
+        z_row_layout.setSpacing(6)
+        z_row_layout.addWidget(self._lbl_fm_z)
+        z_row_layout.addStretch(1)
+        self._btn_interpolate = QPushButton(" Interpolate…")
+        self._btn_interpolate.setIcon(fibsem_icon("mdi:arrow-expand-vertical"))
+        self._btn_interpolate.setToolTip(
+            "Interpolate the z-stack toward an isotropic voxel size"
+        )
+        self._btn_interpolate.setEnabled(False)  # enabled once a z-stack is loaded
+        self._btn_interpolate.clicked.connect(
+            lambda: self.interpolate_requested.emit()
+        )
+        z_row_layout.addWidget(self._btn_interpolate)
+        fm_form.addRow("Z-slices:", z_row)
+
         fm_layout.addLayout(fm_form)
+
+        # Embedded, non-modal progress — shown only while interpolating.
+        self._interp_progress = QProgressBar()
+        self._interp_progress.setTextVisible(True)
+        self._interp_progress.setVisible(False)
+        fm_layout.addWidget(self._interp_progress)
 
         layout.addWidget(TitledPanel("FM Image", content=fm_body, collapsible=False))
         layout.addStretch(1)
@@ -402,6 +446,24 @@ class _ImagesTab(QWidget):
         ) or str(c)
         self._lbl_fm_ch.setText(ch_names)
         self._lbl_fm_z.setText(str(z))
+        # interpolation needs a multi-slice stack with a known z step
+        self._btn_interpolate.setEnabled(
+            z > 1 and bool(getattr(image.metadata, "pixel_size_z", None))
+        )
+
+    def set_interpolating(self, running: bool, n_channels: int = 0) -> None:
+        """Reflect an in-flight interpolation: the button locks and an embedded
+        progress bar appears. Non-modal — the rest of the GUI stays live."""
+        self._btn_interpolate.setEnabled(not running and self._fm_image is not None)
+        if running:
+            self._interp_progress.setRange(0, max(n_channels, 1))
+            self._interp_progress.setValue(0)
+            self._interp_progress.setFormat("Interpolating z-stack… %v/%m")
+        self._interp_progress.setVisible(running)
+
+    def set_interpolation_progress(self, done: int, total: int) -> None:
+        self._interp_progress.setRange(0, max(total, 1))
+        self._interp_progress.setValue(done)
 
     @property
     def fib_image(self) -> Optional[FibsemImage]:
@@ -1117,6 +1179,9 @@ class CorrelationTabWidget(QWidget):
         self._fm_image: Optional[FluorescenceImage] = None
         self._result: Optional[CorrelationResult] = None
         self._worker: Optional[_CorrelationWorker] = None
+        # FM z-stack interpolation (background) — held for the op's lifetime
+        self._interp_worker = None
+        self._interp_relay: Optional[_ProgressRelay] = None
         self._project_dir: Optional[str] = None
         # Pre-correlation RI factor (FM surface mode); set via the RI tab Apply
         self._ri_pre_correction_factor: Optional[float] = None
@@ -1339,6 +1404,9 @@ class CorrelationTabWidget(QWidget):
             canvas.point_moved.connect(self._on_canvas_moved)
             canvas.point_removed.connect(self._on_canvas_removed)
             canvas.point_add_requested.connect(self._on_canvas_add_requested)
+
+        # FM z-stack interpolation (entry point lives in the Images tab)
+        self._images_tab.interpolate_requested.connect(self._on_interpolate_fm)
 
         # List → canvas (one identical wiring block per spec)
         for spec in self._point_specs.values():
@@ -2086,6 +2154,102 @@ class CorrelationTabWidget(QWidget):
         )
         if path:
             self.save_data(path)
+
+    # ------------------------------------------------------------------
+    # FM z-stack interpolation (FIB-253)
+    # ------------------------------------------------------------------
+
+    def _fm_side_lists(self) -> List["CoordinateListWidget"]:
+        """The coordinate lists whose points live in the FM volume (carry z)."""
+        cl = self._coords_tab
+        return [cl.fm_list, cl.poi_list, cl.fm_surface_list]
+
+    def _fm_point_count(self) -> int:
+        return sum(len(lst.coordinates) for lst in self._fm_side_lists())
+
+    def _rescale_fm_z(self, scale: float) -> None:
+        """Scale every FM-side point's z index so its physical depth is preserved
+        after the z axis is resampled (depth = z_index * pixel_size_z)."""
+        for lst in self._fm_side_lists():
+            for coord in lst.coordinates:
+                coord.point.z *= scale
+
+    def _on_interpolate_fm(self) -> None:
+        if self._fm_image is None:
+            return
+        if self._interp_worker is not None and self._interp_worker.is_alive():
+            return  # one at a time
+        from fibsem.correlation.ui.widgets.fm_interpolate_dialog import (
+            InterpolateZDialog,
+        )
+
+        dlg = InterpolateZDialog(
+            self._fm_image, parent=self, fm_point_count=self._fm_point_count()
+        )
+        if dlg.exec_() != QDialog.Accepted:
+            return
+        target_m, method = dlg.result_params()
+        self._start_fm_interpolation(target_m, method)
+
+    def _start_fm_interpolation(self, target_m: float, method: str) -> None:
+        from fibsem.correlation.util import interpolate_fm_volume
+        from fibsem.ui.qt.threading import FunctionWorker
+
+        src = self._fm_image
+        old_nz = src.data.shape[1]
+        n_channels = src.data.shape[0]
+
+        # Non-modal: an embedded progress bar in the Images tab, and the FM display
+        # is disabled so a point edit can't race the image/coordinate swap — but
+        # the rest of the GUI stays live.
+        self._images_tab.set_interpolating(True, n_channels)
+        self._fm_display.setEnabled(False)
+
+        relay = self._interp_relay = _ProgressRelay()
+        relay.progress.connect(self._images_tab.set_interpolation_progress)
+
+        worker = self._interp_worker = FunctionWorker(
+            interpolate_fm_volume, src, target_m, method, relay.emit_progress
+        )
+
+        def _finish() -> None:
+            self._interp_worker = None
+            self._images_tab.set_interpolating(False)
+            self._fm_display.setEnabled(True)
+
+        def _done(new_image) -> None:
+            _finish()
+            self._adopt_interpolated_volume(new_image, old_nz)
+
+        def _fail(exc) -> None:
+            _finish()
+            logging.exception("FM z-interpolation failed")
+            notification_service.show("Z-interpolation failed.", "error")
+            QMessageBox.warning(
+                self, "Interpolation failed", f"Could not interpolate:\n{exc}"
+            )
+
+        worker.returned.connect(_done)
+        worker.errored.connect(_fail)
+        worker.start()
+
+    def _adopt_interpolated_volume(self, new_image, old_nz: int) -> None:
+        """Swap in the resampled volume and keep FM coordinates + metadata coherent.
+
+        Matched pair: rescale FM-point z by the ACTUAL slice ratio, then adopt the
+        new volume whose pixel_size_z was derived from that same ratio — so each
+        point's physical depth (z_index * pixel_size_z) is preserved.
+        """
+        new_nz = new_image.data.shape[1]
+        self._rescale_fm_z(new_nz / old_nz)
+        self.set_fm_image(new_image)
+        self.set_data(self.data)  # redraw lists/canvas at the rescaled z
+        self.data_changed.emit(self.data)  # auto-save + RI refresh (new z step)
+        notification_service.show(
+            f"Z-interpolation complete — {old_nz} → {new_nz} slices "
+            f"({new_image.metadata.pixel_size_z * 1e9:.0f} nm z step)",
+            "info",
+        )
 
     # ------------------------------------------------------------------
     # Refit

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -135,6 +135,9 @@ _RMS_NEUTRAL = "#9aa0a6"
 _RMS_WARN = "#ffb300"
 _RMS_BAD = "#e53935"
 
+# Form-row labels: muted and one step below the value they describe.
+_FORM_LABEL_COLOR = "#9aa0a6"
+
 
 def _rms_concern(
     rms_nm: Optional[float],
@@ -187,6 +190,18 @@ def _ro_item(text: str) -> QTableWidgetItem:
     item.setFlags(Qt.ItemFlag.ItemIsEnabled)
     item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
     return item
+
+
+def _form_label(text: str) -> QLabel:
+    """A form-row label: small and muted, so the value reads louder than its name.
+
+    ``QFormLayout.addRow("Name:", w)`` builds the label at the default app font
+    size, which renders *larger* than the 11-12px values in these panels — the
+    field name ends up shouting over its own data. Pass this instead.
+    """
+    lbl = QLabel(text)
+    lbl.setStyleSheet(f"color: {_FORM_LABEL_COLOR}; font-size: 11px;")
+    return lbl
 
 
 # ---------------------------------------------------------------------------
@@ -283,8 +298,8 @@ class _ImagesTab(QWidget):
         self._lbl_fib_shape.setStyleSheet("color: #e0e0e0; font-size: 11px;")
         self._lbl_fib_px = QLabel("—")
         self._lbl_fib_px.setStyleSheet("color: #e0e0e0; font-size: 11px;")
-        fib_form.addRow("Shape:", self._lbl_fib_shape)
-        fib_form.addRow("Pixel size:", self._lbl_fib_px)
+        fib_form.addRow(_form_label("Shape:"), self._lbl_fib_shape)
+        fib_form.addRow(_form_label("Pixel size:"), self._lbl_fib_px)
         fib_layout.addLayout(fib_form)
 
         layout.addWidget(TitledPanel("FIB Image", content=fib_body, collapsible=False))
@@ -312,8 +327,8 @@ class _ImagesTab(QWidget):
         self._lbl_fm_ch.setWordWrap(True)
         self._lbl_fm_z = QLabel("—")
         self._lbl_fm_z.setStyleSheet("color: #e0e0e0; font-size: 11px;")
-        fm_form.addRow("Shape (C×Z×Y×X):", self._lbl_fm_shape)
-        fm_form.addRow("Channels:", self._lbl_fm_ch)
+        fm_form.addRow(_form_label("Shape (C×Z×Y×X):"), self._lbl_fm_shape)
+        fm_form.addRow(_form_label("Channels:"), self._lbl_fm_ch)
 
         # The interpolate action rides the Z-slices row — it acts on the z axis,
         # so it reads as the action on that number rather than a stray button.
@@ -334,7 +349,7 @@ class _ImagesTab(QWidget):
             lambda: self.interpolate_requested.emit()
         )
         z_row_layout.addWidget(self._btn_interpolate)
-        fm_form.addRow("Z-slices:", z_row)
+        fm_form.addRow(_form_label("Z-slices:"), z_row)
 
         fm_layout.addLayout(fm_form)
 
@@ -561,22 +576,22 @@ class _CoordinatesTab(QWidget):
         # empty and are refilled by rebuild_channel_combos — the blocker lives on
         # the widget, so it survives clear()/addItem().
         self._fib_method_combo = ValueComboBox(_FIT_METHODS, value="Hole")
-        fit_form.addRow("FIB method:", self._fib_method_combo)
+        fit_form.addRow(_form_label("FIB method:"), self._fib_method_combo)
 
         self._fm_fid_method_combo = ValueComboBox(_FIT_METHODS, value="None")
-        fit_form.addRow("FM Fid. method:", self._fm_fid_method_combo)
+        fit_form.addRow(_form_label("FM Fid. method:"), self._fm_fid_method_combo)
 
         self._fm_poi_method_combo = ValueComboBox(_FIT_METHODS, value="Gaussian")
-        fit_form.addRow("FM POI method:", self._fm_poi_method_combo)
+        fit_form.addRow(_form_label("FM POI method:"), self._fm_poi_method_combo)
 
         self._fm_fid_ch_combo = ValueComboBox([])
-        fit_form.addRow("FM Fid. channel:", self._fm_fid_ch_combo)
+        fit_form.addRow(_form_label("FM Fid. channel:"), self._fm_fid_ch_combo)
 
         self._fm_poi_ch_combo = ValueComboBox([])
-        fit_form.addRow("FM POI channel:", self._fm_poi_ch_combo)
+        fit_form.addRow(_form_label("FM POI channel:"), self._fm_poi_ch_combo)
 
         self._show_diag_check = QCheckBox()
-        fit_form.addRow("Show diagnostic:", self._show_diag_check)
+        fit_form.addRow(_form_label("Show diagnostic:"), self._show_diag_check)
 
         # Opt-in: apply fits without the confirm dialog. Off by default (the
         # confirm-first behaviour of FIB-252). Errors and far-off "surprising"
@@ -586,7 +601,7 @@ class _CoordinatesTab(QWidget):
             "Apply fits immediately without the confirm dialog.\n"
             "Failed or far-off fits still ask for confirmation."
         )
-        fit_form.addRow("Auto-accept fits:", self._auto_accept_check)
+        fit_form.addRow(_form_label("Auto-accept fits:"), self._auto_accept_check)
 
         fit_help = QLabel(
             "Select a point and press <b>F</b> to fit it. Each fit opens a "
@@ -664,11 +679,11 @@ class _ResultsTab(QWidget):
         self._lbl_mae = self._val("—")
         self._lbl_rotation = self._val("—")
         self._lbl_trans = self._val("—")
-        summary_form.addRow("Scale:", self._lbl_scale)
-        summary_form.addRow("RMS Error:", self._lbl_rms)
-        summary_form.addRow("Mean Abs Error:", self._lbl_mae)
-        summary_form.addRow("Rotation:", self._lbl_rotation)
-        summary_form.addRow("Translation:", self._lbl_trans)
+        summary_form.addRow(_form_label("Scale:"), self._lbl_scale)
+        summary_form.addRow(_form_label("RMS Error:"), self._lbl_rms)
+        summary_form.addRow(_form_label("Mean Abs Error:"), self._lbl_mae)
+        summary_form.addRow(_form_label("Rotation:"), self._lbl_rotation)
+        summary_form.addRow(_form_label("Translation:"), self._lbl_trans)
         layout.addWidget(TitledPanel("Summary", content=summary_body))
 
         # Per-marker error table

--- a/fibsem/correlation/ui/widgets/fm_interpolate_dialog.py
+++ b/fibsem/correlation/ui/widgets/fm_interpolate_dialog.py
@@ -1,0 +1,165 @@
+"""Dialog to configure FM z-stack interpolation (FIB-253).
+
+Collects a target z pixel size and interpolation method for
+:func:`fibsem.correlation.util.interpolate_fm_volume`. Interpolation only
+resamples z, so the natural default is the XY pixel size — an isotropic volume.
+"""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QFrame,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.correlation.util import INTERPOLATION_METHODS
+from fibsem.fm.structures import FluorescenceImage
+from fibsem.ui.widgets.custom_widgets import ValueComboBox, ValueSpinBox
+
+
+def _estimate_slices(nz: int, z_step_m: float, target_m: float) -> int:
+    """Match scipy.ndimage.zoom's output length (round-half-to-even on the scale)."""
+    if target_m <= 0:
+        return nz
+    return int(round(nz * (z_step_m / target_m)))
+
+
+class InterpolateZDialog(QDialog):
+    """Ask for a target z pixel size + method; expose them after ``exec_()``."""
+
+    def __init__(
+        self, fm_image: FluorescenceImage, parent: Optional[QWidget] = None,
+        fm_point_count: int = 0,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Interpolate z-stack")
+        self.setModal(True)
+
+        meta = fm_image.metadata
+        self._nc, self._nz, self._ny, self._nx = fm_image.data.shape
+        self._z_step = meta.pixel_size_z  # m; guaranteed non-None by the caller
+        self._xy = meta.pixel_size_x  # m
+        self._itemsize = fm_image.data.dtype.itemsize
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(16, 14, 16, 14)
+        root.setSpacing(12)
+
+        # --- current volume ---
+        info = QLabel(
+            f"{self._nc} channels · {self._nz} slices · {self._ny} × {self._nx}\n"
+            f"XY pixel size: {self._xy * 1e9:.0f} nm    "
+            f"Z step: {self._z_step * 1e9:.0f} nm "
+            f"({self._z_step / self._xy:.2f}× anisotropic)"
+        )
+        info.setStyleSheet("color: #b8b8b8; font-size: 12px;")
+        root.addWidget(info)
+
+        line = QFrame()
+        line.setFrameShape(QFrame.Shape.HLine)
+        line.setStyleSheet("color: #3a3d42;")
+        root.addWidget(line)
+
+        form = QFormLayout()
+        form.setSpacing(10)
+
+        self._chk_iso = QCheckBox("Match XY pixel size (isotropic)")
+        self._chk_iso.setChecked(True)
+        self._chk_iso.toggled.connect(self._on_iso_toggled)
+        form.addRow(self._chk_iso)
+
+        self._spin_target = ValueSpinBox(
+            suffix="nm", minimum=1.0, maximum=100000.0, step=10.0, decimals=1,
+        )
+        self._spin_target.setValue(self._xy * 1e9)
+        self._spin_target.setEnabled(False)  # isotropic on by default
+        self._spin_target.valueChanged.connect(self._update_preview)
+        form.addRow("Target z pixel size", self._spin_target)
+
+        self._combo_method = ValueComboBox(list(INTERPOLATION_METHODS), value="linear")
+        form.addRow("Method", self._combo_method)
+        root.addLayout(form)
+
+        self._preview = QLabel()
+        self._preview.setStyleSheet(
+            "color: #cfe0f2; background: #21303f; border: 0.5px solid #2f4a63;"
+            " border-radius: 6px; padding: 8px 10px; font-size: 12px;"
+        )
+        root.addWidget(self._preview)
+
+        if fm_point_count:
+            warn = QLabel(
+                f"⚠  {fm_point_count} FM point"
+                f"{'s' if fm_point_count != 1 else ''} carry a z-index — "
+                "they'll be rescaled to the new slice count."
+            )
+            warn.setWordWrap(True)
+            warn.setStyleSheet("color: #d6b57a; font-size: 12px;")
+            root.addWidget(warn)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        ok_btn = buttons.button(QDialogButtonBox.StandardButton.Ok)
+        ok_btn.setText("Interpolate")
+        # No default button: Enter while editing a field should commit that field,
+        # not fire off a tens-of-seconds interpolation. Require a real click.
+        for btn in (ok_btn, buttons.button(QDialogButtonBox.StandardButton.Cancel)):
+            btn.setAutoDefault(False)
+            btn.setDefault(False)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        root.addWidget(buttons)
+
+        self._update_preview()
+
+    def keyPressEvent(self, event) -> None:
+        # Don't let Enter auto-accept. autoDefault=False isn't enough — a shown
+        # QDialogButtonBox re-promotes its accept button to default — so swallow
+        # Return/Enter here. A focused field (e.g. the spinbox) still gets the key
+        # first and commits its edit; only the dialog-level default is blocked, so
+        # a real click on Interpolate is required. Escape still cancels.
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+    # ------------------------------------------------------------------
+
+    def _on_iso_toggled(self, checked: bool) -> None:
+        self._spin_target.setEnabled(not checked)
+        if checked:
+            self._spin_target.setValue(self._xy * 1e9)
+        self._update_preview()
+
+    def _update_preview(self) -> None:
+        target_m = self.target_z_size_m()
+        new_nz = _estimate_slices(self._nz, self._z_step, target_m)
+        gb = self._nc * new_nz * self._ny * self._nx * self._itemsize / 1e9
+        iso = " · isotropic" if abs(target_m - self._xy) < 1e-12 else ""
+        self._preview.setText(
+            f"{self._nz} → {new_nz} slices{iso} · ~{gb:.1f} GB"
+        )
+
+    # ------------------------------------------------------------------
+    # Results (valid after exec_)
+
+    def target_z_size_m(self) -> float:
+        """Chosen target z pixel size in metres."""
+        if self._chk_iso.isChecked():
+            return self._xy
+        return self._spin_target.value() * 1e-9
+
+    def method(self) -> str:
+        return self._combo_method.value()
+
+    def result_params(self) -> Tuple[float, str]:
+        return self.target_z_size_m(), self.method()

--- a/fibsem/correlation/ui/widgets/fm_interpolate_dialog.py
+++ b/fibsem/correlation/ui/widgets/fm_interpolate_dialog.py
@@ -15,6 +15,7 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox,
     QFormLayout,
     QFrame,
+    QHBoxLayout,
     QLabel,
     QVBoxLayout,
     QWidget,
@@ -22,7 +23,11 @@ from PyQt5.QtWidgets import (
 
 from fibsem.correlation.util import INTERPOLATION_METHODS
 from fibsem.fm.structures import FluorescenceImage
+from fibsem.ui import stylesheets
+from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.widgets.custom_widgets import ValueComboBox, ValueSpinBox
+
+_WARN_COLOR = "#d6b57a"
 
 
 def _estimate_slices(nz: int, z_step_m: float, target_m: float) -> int:
@@ -42,6 +47,10 @@ class InterpolateZDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("Interpolate z-stack")
         self.setModal(True)
+        # The label/chip colours below are picked for a dark surface, so don't
+        # rely on the app-level napari stylesheet being installed — state it
+        # here, as FitConfirmationDialog does.
+        self.setStyleSheet("background: #1e2124; color: #d0d0d0;")
 
         meta = fm_image.metadata
         self._nc, self._nz, self._ny, self._nx = fm_image.data.shape
@@ -96,20 +105,33 @@ class InterpolateZDialog(QDialog):
         root.addWidget(self._preview)
 
         if fm_point_count:
+            warn_row = QWidget()
+            warn_layout = QHBoxLayout(warn_row)
+            warn_layout.setContentsMargins(0, 0, 0, 0)
+            warn_layout.setSpacing(6)
+
+            warn_icon = QLabel()
+            warn_icon.setPixmap(
+                fibsem_icon("mdi:alert-circle-outline", color=_WARN_COLOR).pixmap(14, 14)
+            )
+            warn_layout.addWidget(warn_icon, 0, Qt.AlignmentFlag.AlignTop)
+
             warn = QLabel(
-                f"⚠  {fm_point_count} FM point"
+                f"{fm_point_count} FM point"
                 f"{'s' if fm_point_count != 1 else ''} carry a z-index — "
                 "they'll be rescaled to the new slice count."
             )
             warn.setWordWrap(True)
-            warn.setStyleSheet("color: #d6b57a; font-size: 12px;")
-            root.addWidget(warn)
+            warn.setStyleSheet(f"color: {_WARN_COLOR}; font-size: 12px;")
+            warn_layout.addWidget(warn, 1)
+            root.addWidget(warn_row)
 
         buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
         ok_btn = buttons.button(QDialogButtonBox.StandardButton.Ok)
         ok_btn.setText("Interpolate")
+        ok_btn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
         # No default button: Enter while editing a field should commit that field,
         # not fire off a tens-of-seconds interpolation. Require a real click.
         for btn in (ok_btn, buttons.button(QDialogButtonBox.StandardButton.Cancel)):

--- a/fibsem/correlation/util.py
+++ b/fibsem/correlation/util.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 from scipy import ndimage
@@ -312,24 +312,31 @@ def multi_channel_interpolation(
     image: np.ndarray,
     pixelsize_in: float,
     pixelsize_out: float,
-    method: str = "cubic",
-    parent_ui=None,
+    method: str = "linear",
+    progress_callback: Optional[Callable[[int, int], None]] = None,
 ) -> np.ndarray:
-    """Interpolate a multi-channel z-stack (CZYX) along the z-axis
+    """Interpolate a multi-channel z-stack (CZYX) along the z-axis.
+
     Args:
         image: 4D numpy array (CZYX)
         pixelsize_in: original pixel size in z-axis
         pixelsize_out: desired pixel size in z-axis
+        method: one of ``INTERPOLATION_METHODS``
+        progress_callback: optional ``fn(channels_done, channels_total)`` invoked
+            before the first channel and after each one. Kept UI-agnostic (a plain
+            callable, not a Qt object) so the algorithm stays testable; a worker
+            passes a callback that emits its own progress signal.
+
     Returns:
         interpolated: 4D numpy array (CZYX) with adjusted z-axis resolution
     """
-    if parent_ui:
-        parent_ui.progress_update.emit({"value": 0, "max": image.shape[0]})
+    n = image.shape[0]
+    if progress_callback is not None:
+        progress_callback(0, n)
 
-    # QUERY: how to speed up?
     ch_interpolated = []
     for i, channel in enumerate(image):
-        logging.info(f"Interpolating channel {i+1}/{image.shape[0]}")
+        logging.info(f"Interpolating channel {i + 1}/{n}")
         ch_interpolated.append(
             interpolate_z_stack(
                 image=channel,
@@ -338,9 +345,94 @@ def multi_channel_interpolation(
                 method=method,
             )
         )
-        if parent_ui:
-            parent_ui.progress_update.emit({"value": i + 1, "max": image.shape[0]})
+        if progress_callback is not None:
+            progress_callback(i + 1, n)
     return np.array(ch_interpolated)
+
+
+def interpolate_fm_volume(
+    fm_image,
+    target_z_size_m: float,
+    method: str = "linear",
+    progress_callback: Optional[Callable[[int, int], None]] = None,
+):
+    """Resample an FM volume along z, returning a NEW ``FluorescenceImage``.
+
+    Only the z-axis is resampled (XY is untouched). The returned image carries
+    metadata consistent with the resampled data: ``pixel_size_z`` and
+    ``z_positions`` are recomputed for the new slice count.
+
+    scipy's ``zoom`` rounds the output slice count to an integer, so the achieved
+    z-scale is ``new_nz / old_nz`` — not the nominal ``pixel_size_z / target``.
+    The effective z pixel size is derived from that actual ratio, keeping data,
+    metadata, and any caller-side coordinate rescale exactly consistent. Callers
+    that must move z-bearing coordinates should scale by ``new_nz / old_nz``,
+    read from the returned image's shape versus the input's.
+
+    Args:
+        fm_image: source ``FluorescenceImage`` (CZYX, with ``pixel_size_z`` set)
+        target_z_size_m: desired z pixel size in metres (e.g. ``pixel_size_x`` for
+            an isotropic volume)
+        method: one of ``INTERPOLATION_METHODS``
+        progress_callback: forwarded to :func:`multi_channel_interpolation`
+
+    Raises:
+        ValueError: for a single-plane volume (no ``pixel_size_z``), a
+            non-positive target, or a non-CZYX array.
+    """
+    import copy
+
+    from fibsem.fm.structures import FluorescenceImage  # lazy: correlation -> fm
+
+    data = fm_image.data
+    if data.ndim != 4:
+        raise ValueError(f"expected a CZYX volume, got shape {data.shape}")
+
+    meta = fm_image.metadata
+    z_in = getattr(meta, "pixel_size_z", None)
+    if not z_in:
+        raise ValueError(
+            "volume has no z step (single plane) — nothing to interpolate"
+        )
+    if not target_z_size_m or target_z_size_m <= 0:
+        raise ValueError(
+            f"target z pixel size must be positive, got {target_z_size_m}"
+        )
+
+    old_nz = data.shape[1]
+    interpolated = multi_channel_interpolation(
+        data,
+        pixelsize_in=z_in,
+        pixelsize_out=target_z_size_m,
+        method=method,
+        progress_callback=progress_callback,
+    )
+    new_nz = interpolated.shape[1]
+    if new_nz < 1:
+        raise ValueError("interpolation produced an empty volume")
+
+    # Effective z pixel size from the ACTUAL resampled slice count, not the
+    # nominal target — so physical depth (z_index * pixel_size_z) is preserved
+    # when the caller rescales coordinates by new_nz / old_nz.
+    new_meta = copy.deepcopy(meta)
+    new_meta.pixel_size_z = z_in * old_nz / new_nz
+
+    # z_positions is a per-plane objective ramp; resample it to the new count so
+    # its length scales with the volume (convention-agnostic — np.interp on the
+    # existing ramp preserves whatever ordering it had).
+    positions = getattr(meta, "z_positions", None)
+    if positions:
+        old = np.asarray(positions, dtype=float)
+        new_len = max(1, round(len(old) * new_nz / old_nz))
+        if new_len == 1 or len(old) == 1:
+            new_meta.z_positions = [float(old[0])] * new_len
+        else:
+            src = np.linspace(0.0, len(old) - 1, new_len)
+            new_meta.z_positions = np.interp(
+                src, np.arange(len(old)), old
+            ).tolist()
+
+    return FluorescenceImage(data=interpolated, metadata=new_meta)
 
 
 def multi_channel_get_z_guass(image: np.ndarray, x: int, y: int, show: bool = False) -> List[float]:

--- a/tests/correlation/test_interpolation.py
+++ b/tests/correlation/test_interpolation.py
@@ -1,0 +1,324 @@
+"""Tests for FM z-stack interpolation (FIB-253).
+
+Pure-array + FluorescenceImage-level; no Qt. Uses small synthetic volumes so it
+runs fast and deterministically, with the numbers chosen to mirror the real
+METEOR case (500 nm z step, 130 nm XY -> isotropic).
+"""
+import numpy as np
+import pytest
+
+from fibsem.correlation.util import (
+    interpolate_fm_volume,
+    interpolate_z_stack,
+    multi_channel_interpolation,
+)
+
+
+def _fake_fm(nc=2, nz=21, ny=8, nx=8, z_step=500e-9, xy=130e-9, z_positions=True):
+    """A minimal FluorescenceImage stand-in with the fields interpolation reads."""
+    from types import SimpleNamespace
+
+    # a ramp along z so interpolation has structure to preserve
+    data = np.empty((nc, nz, ny, nx), dtype=np.float32)
+    for z in range(nz):
+        data[:, z] = float(z)
+    positions = None
+    if z_positions:
+        # channel-major flat ramp, mirroring the real files (len = nc * nz)
+        positions = list(np.arange(nc * nz, dtype=float) * z_step)
+    meta = SimpleNamespace(
+        pixel_size_x=xy,
+        pixel_size_y=xy,
+        pixel_size_z=z_step,
+        z_positions=positions,
+    )
+    return SimpleNamespace(data=data, metadata=meta)
+
+
+# ---------------------------------------------------------------------------
+# Array-level
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_z_stack_only_scales_z():
+    img = np.random.rand(10, 6, 6).astype(np.float32)
+    out = interpolate_z_stack(img, pixelsize_in=500e-9, pixelsize_out=250e-9)
+    assert out.shape[1:] == img.shape[1:]  # XY untouched
+    assert out.shape[0] == 20  # z doubled (500 -> 250)
+
+
+def test_multi_channel_progress_callback_is_ui_agnostic():
+    """The algorithm reports progress through a plain callable, not a Qt object."""
+    img = np.random.rand(3, 5, 4, 4).astype(np.float32)
+    calls = []
+    multi_channel_interpolation(
+        img, 500e-9, 250e-9, progress_callback=lambda done, total: calls.append((done, total))
+    )
+    # one call before the loop, one after each of the 3 channels
+    assert calls == [(0, 3), (1, 3), (2, 3), (3, 3)]
+
+
+def test_multi_channel_runs_without_a_callback():
+    img = np.random.rand(2, 5, 4, 4).astype(np.float32)
+    out = multi_channel_interpolation(img, 500e-9, 250e-9)  # no callback
+    assert out.shape[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# Volume-level: interpolate_fm_volume
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_fm_volume_makes_it_isotropic():
+    fm = _fake_fm(nc=2, nz=21, z_step=500e-9, xy=130e-9)
+    out = interpolate_fm_volume(fm, target_z_size_m=130e-9)
+
+    assert out.data.shape[0] == 2  # channels preserved
+    assert out.data.shape[2:] == fm.data.shape[2:]  # XY preserved
+    # 21 * (500/130) = 80.8 -> scipy rounds to 81 slices
+    assert out.data.shape[1] == 81
+
+
+def test_pixel_size_z_matches_the_actual_slice_ratio_not_the_nominal():
+    """scipy rounds the slice count, so pixel_size_z must come from the achieved
+    ratio (old_nz/new_nz) — otherwise metadata and data drift apart."""
+    fm = _fake_fm(nz=21, z_step=500e-9, xy=130e-9)
+    out = interpolate_fm_volume(fm, target_z_size_m=130e-9)
+
+    new_nz = out.data.shape[1]  # 81
+    expected = 500e-9 * 21 / new_nz  # ~129.6 nm, NOT the nominal 130
+    assert out.metadata.pixel_size_z == pytest.approx(expected)
+    assert out.metadata.pixel_size_z != pytest.approx(130e-9)  # the nominal is wrong
+
+
+def test_physical_depth_is_preserved_under_the_matched_rescale():
+    """A coordinate at slice k, rescaled by new_nz/old_nz, keeps its physical
+    depth (z_index * pixel_size_z) — the property the whole feature rests on."""
+    fm = _fake_fm(nz=21, z_step=500e-9, xy=130e-9)
+    old_nz = fm.data.shape[1]
+    out = interpolate_fm_volume(fm, target_z_size_m=130e-9)
+    new_nz = out.data.shape[1]
+
+    scale = new_nz / old_nz
+    for k in (0, 7, 15, 20):
+        depth_before = k * fm.metadata.pixel_size_z
+        depth_after = (k * scale) * out.metadata.pixel_size_z
+        assert depth_after == pytest.approx(depth_before)
+
+
+def test_z_positions_length_scales_with_slice_count():
+    fm = _fake_fm(nc=3, nz=21, z_step=500e-9)  # 63 positions, like the real file
+    assert len(fm.metadata.z_positions) == 63
+    out = interpolate_fm_volume(fm, target_z_size_m=130e-9)
+    new_nz = out.data.shape[1]  # 81
+    # resampled proportionally: 63 * 81/21 = 243
+    assert len(out.metadata.z_positions) == round(63 * new_nz / 21)
+
+
+def test_does_not_mutate_the_source_image():
+    fm = _fake_fm(nz=21)
+    before_shape = fm.data.shape
+    before_z = fm.metadata.pixel_size_z
+    interpolate_fm_volume(fm, target_z_size_m=130e-9)
+    assert fm.data.shape == before_shape
+    assert fm.metadata.pixel_size_z == before_z  # metadata deep-copied, not edited
+
+
+def test_single_plane_volume_is_rejected():
+    fm = _fake_fm(nz=1, z_step=None, z_positions=False)
+    with pytest.raises(ValueError, match="single plane"):
+        interpolate_fm_volume(fm, target_z_size_m=130e-9)
+
+
+def test_non_positive_target_is_rejected():
+    fm = _fake_fm(nz=10)
+    with pytest.raises(ValueError, match="positive"):
+        interpolate_fm_volume(fm, target_z_size_m=0.0)
+
+
+def test_returns_a_fluorescence_image():
+    from fibsem.fm.structures import FluorescenceImage
+
+    fm = _fake_fm(nz=10)
+    out = interpolate_fm_volume(fm, target_z_size_m=130e-9)
+    assert isinstance(out, FluorescenceImage)
+
+
+# ---------------------------------------------------------------------------
+# Dialog (headless Qt)
+# ---------------------------------------------------------------------------
+
+import os  # noqa: E402
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def _real_fm(crop=64):
+    """A concrete FluorescenceImage the dialog/widget can consume, or skip.
+
+    Cropped in XY by default: interpolation is z-only, so a small frame keeps the
+    slice counts, pixel sizes, and the physical-depth invariant identical while
+    the 2048x2048 -> would-be 2 GB / ~36 s full run stays out of the test suite.
+    """
+    import copy
+
+    from fibsem.fm.structures import FluorescenceImage
+
+    path = os.path.join(
+        os.getcwd(), "tmp", "BeforeMilling_G1_-Feature-2-Active-001.ome.tiff"
+    )
+    if not os.path.exists(path):
+        pytest.skip("tmp/ FM volume not present")
+    fm = FluorescenceImage.load(path)
+    if crop:
+        fm = FluorescenceImage(
+            data=fm.data[:, :, :crop, :crop].copy(),
+            metadata=copy.deepcopy(fm.metadata),
+        )
+    return fm
+
+
+def test_dialog_defaults_to_isotropic(qapp):
+    from fibsem.correlation.ui.widgets.fm_interpolate_dialog import InterpolateZDialog
+
+    fm = _real_fm()
+    dlg = InterpolateZDialog(fm)
+    assert dlg._chk_iso.isChecked()  # isotropic on by default
+    assert not dlg._spin_target.isEnabled()  # driven by the checkbox
+    assert dlg.target_z_size_m() == pytest.approx(fm.metadata.pixel_size_x)
+    assert dlg.method() == "linear"
+    assert "→ 81 slices" in dlg._preview.text()
+
+
+def test_dialog_unchecking_isotropic_frees_the_spinbox(qapp):
+    from fibsem.correlation.ui.widgets.fm_interpolate_dialog import InterpolateZDialog
+
+    fm = _real_fm()
+    dlg = InterpolateZDialog(fm)
+    dlg._chk_iso.setChecked(False)
+    assert dlg._spin_target.isEnabled()
+    dlg._spin_target.setValue(250.0)
+    assert dlg.target_z_size_m() == pytest.approx(250e-9)
+
+
+def test_enter_does_not_run_the_interpolation(qapp):
+    """Pressing Enter while editing must not fire the (tens-of-seconds) run — only
+    a real click on Interpolate accepts. Escape still cancels."""
+    from PyQt5.QtCore import Qt
+    from PyQt5.QtTest import QTest
+    from PyQt5.QtWidgets import QDialog
+
+    from fibsem.correlation.ui.widgets.fm_interpolate_dialog import InterpolateZDialog
+
+    dlg = InterpolateZDialog(_real_fm())
+    dlg.show()
+    QTest.keyClick(dlg, Qt.Key_Return)
+    QTest.keyClick(dlg, Qt.Key_Enter)
+    assert dlg.result() != QDialog.Accepted  # Enter did not accept
+    assert not dlg.isHidden()  # still open
+
+    QTest.keyClick(dlg, Qt.Key_Escape)
+    assert dlg.isHidden()  # Escape still cancels
+
+    dlg2 = InterpolateZDialog(_real_fm())
+    dlg2.accept()  # the click path still accepts
+    assert dlg2.result() == QDialog.Accepted
+
+
+# ---------------------------------------------------------------------------
+# Widget wiring
+# ---------------------------------------------------------------------------
+
+
+def _widget(qapp):
+    import fibsem.correlation.ui.widgets.refractive_index_widget as riw
+
+    riw._ensure_lut = lambda: None  # never hit the network for the LUT
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        CorrelationTabWidget,
+    )
+
+    return CorrelationTabWidget()
+
+
+def test_interpolate_button_lives_in_images_tab_and_needs_a_zstack(qapp):
+    w = _widget(qapp)
+    btn = w._images_tab._btn_interpolate  # under the FM load controls, not the canvas
+    assert btn.isEnabled() is False  # no image yet
+    w.set_fm_image(_real_fm())
+    assert btn.isEnabled() is True  # 21-slice stack
+
+
+def test_interpolating_shows_embedded_progress_and_locks_the_button(qapp):
+    """Progress is a non-modal bar in the Images tab; the button locks while it
+    runs, and neither blocks the rest of the GUI."""
+    w = _widget(qapp)
+    w.set_fm_image(_real_fm())
+    tab = w._images_tab
+    # isHidden(), not isVisible(): the latter is False for any child of an unshown
+    # top-level window, so it can't distinguish our explicit hide.
+    assert tab._interp_progress.isHidden() is True  # hidden until running
+
+    tab.set_interpolating(True, n_channels=3)
+    assert tab._interp_progress.isHidden() is False
+    assert tab._btn_interpolate.isEnabled() is False  # locked during the run
+    tab.set_interpolation_progress(2, 3)
+    assert tab._interp_progress.value() == 2
+
+    tab.set_interpolating(False)
+    assert tab._interp_progress.isHidden() is True
+    assert tab._btn_interpolate.isEnabled() is True  # re-armed
+
+
+def test_adopt_interpolated_volume_preserves_physical_depth(qapp):
+    """The end-to-end widget behaviour: after adopting the resampled volume, every
+    FM point keeps its physical depth and pixel_size_z propagates to the tab."""
+    from fibsem.correlation.structures import PointType
+    from fibsem.correlation.util import interpolate_fm_volume
+
+    w = _widget(qapp)
+    fm = _real_fm()
+    w.set_fm_image(fm)
+    old_nz = fm.data.shape[1]
+    old_z_step = fm.metadata.pixel_size_z
+
+    w._on_canvas_add_requested(20.0, 20.0, PointType.FM)
+    w._coords_tab.fm_list.coordinates[0].point.z = 15.0
+    w._on_canvas_add_requested(30.0, 30.0, PointType.POI)
+    w._coords_tab.poi_list.coordinates[0].point.z = 11.0
+    assert w._fm_point_count() == 2
+
+    depth_before = 11.0 * old_z_step
+
+    new_image = interpolate_fm_volume(fm, fm.metadata.pixel_size_x, "linear")
+    w._adopt_interpolated_volume(new_image, old_nz)
+
+    new_z = w._coords_tab.poi_list.coordinates[0].point.z
+    depth_after = new_z * new_image.metadata.pixel_size_z
+    assert depth_after == pytest.approx(depth_before)  # matched pair holds
+    assert new_z != pytest.approx(11.0)  # it actually moved
+    assert w._fm_pixel_size_z() == pytest.approx(new_image.metadata.pixel_size_z)
+
+
+def test_rescale_only_touches_fm_side_points(qapp):
+    from fibsem.correlation.structures import PointType
+
+    w = _widget(qapp)
+    w.set_fm_image(_real_fm())
+    w._on_canvas_add_requested(10.0, 10.0, PointType.FIB)  # FIB side
+    w._coords_tab.fib_list.coordinates[0].point.z = 5.0
+    w._on_canvas_add_requested(20.0, 20.0, PointType.FM)  # FM side
+    w._coords_tab.fm_list.coordinates[0].point.z = 5.0
+
+    w._rescale_fm_z(2.0)
+    assert w._coords_tab.fib_list.coordinates[0].point.z == 5.0  # FIB untouched
+    assert w._coords_tab.fm_list.coordinates[0].point.z == 10.0  # FM scaled


### PR DESCRIPTION
Closes [FIB-253](https://linear.app/fibsemos/issue/FIB-253).

## Summary

Adds a GUI control to resample the FM volume along z toward an isotropic voxel size, run in the background. The interpolation algorithm already existed in `correlation/util.py` but had no callers — this wires it up, with the metadata and coordinate bookkeeping needed to make it correct.

## Algorithm (`util.py`)

- `multi_channel_interpolation` now takes a plain `progress_callback(done, total)` instead of reaching into a widget's Qt signal — the algorithm stays pure and testable.
- New `interpolate_fm_volume(fm_image, target_z, method, progress_callback) -> FluorescenceImage` runs the channel loop and rebuilds metadata (`pixel_size_z`, `z_positions`) from the **actual** resampled slice count. scipy's `zoom` rounds the count to an integer (21 × 500/130 = 80.9 → 81), so the effective z pixel size is derived from `new_nz / old_nz` — keeping data, metadata, and the caller-side coordinate rescale exactly consistent.

## UI

- An **"Interpolate z-stack…" button in the Images tab**, on the Z-slices row (it acts on the z axis), enabled only for a multi-slice stack.
- `InterpolateZDialog` — isotropic-by-default target, method, a live `21 → 81 slices · ~2.0 GB` preview, and an FM-point warning. **Enter doesn't auto-run it**: a shown `QDialogButtonBox` re-promotes its accept button to default, so Return/Enter is swallowed and a real click is required (Escape still cancels).
- Runs on a `FunctionWorker` with a **non-modal progress bar embedded in the Images tab**; the FM display is disabled during the run so a point edit can't race the swap, but the rest of the GUI stays live.

## Correctness — the matched pair

FM coordinates carry z as a **slice index**, so resampling z moves what each index means. On completion, each FM-side point's z is rescaled by the same actual slice ratio the metadata's `pixel_size_z` was derived from, so physical depth (`z_index × pixel_size_z`) is preserved.

Verified end-to-end on real METEOR data: **21 → 81 slices, z step 500 → 130 nm, a POI at z=11 holds 5500 nm depth** through the full widget path.

## Persistence — session-only

The interpolated volume is **not** written to disk (avoids a multi-GB write). The rescaled coordinates auto-save as usual. A reload pairs the original on-disk volume with new-space coordinates; re-interpolating reproduces the working state. This was a deliberate decision — see the follow-ups.

## Styling pass

- **Interpolate** uses `PRIMARY_BUTTON_STYLESHEET`, matching the confirm dialog's Accept and the run bar — the primary action stands out and Cancel recedes beside it.
- The dialog sets its own background. Its label/chip colours are picked for a dark surface, so it was unreadable if the app-level napari stylesheet wasn't installed.
- The warning's `⚠` emoji is now an `mdi:alert-circle-outline` icon, per the house convention.
- **Form labels across the correlation tab**: `QFormLayout.addRow("Name:", w)` builds the label at the default app font (12pt), which renders *larger* than the 11–12px values it describes — the field name was shouting over its own data. All 17 rows (Images, Fit Settings, Results summary) now go through a muted 11px `_form_label()`.

## Testing

153 correlation tests pass headless (`QT_QPA_PLATFORM=offscreen`), 16 new for interpolation: the isotropic conversion, the actual-vs-nominal slice ratio, the physical-depth invariant (unit + through the widget), z_positions rescaling, single-plane and non-positive-target rejection, the dialog (isotropic default, spinbox gating, Enter-doesn't-run), the Images-tab button gating, and the embedded-progress lifecycle. Widget tests crop the real volume to 64² so the suite stays fast.

## Follow-ups filed while building this

- **[FIB-278](https://linear.app/fibsemos/issue/FIB-278)** — the interpolation is ~36 s (single-threaded scipy `zoom` on a z-only op); a vectorized z-resample + thread-parallelism would cut it to a few seconds with no new deps. Findings captured on the issue.
- **[FIB-279](https://linear.app/fibsemos/issue/FIB-279)** (Bug, High) — a pre-existing `FluorescenceImage.save()` C↔Z transpose on multi-channel z-stacks, which is why this PR does **not** persist the interpolated volume. More tangled than a one-liner; deferred with full findings on the issue.
