### PR TITLE
[feature] add free-text description to lamella (FIB-276)

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -707,6 +707,7 @@ class Lamella:
     defect: DefectState = field(default_factory=DefectState)
     milling_angle: Optional[float] = None
     poi: Point = field(default_factory=lambda: Point(0,0))  # point of interest within lamella area (milling coordinate system)
+    description: str = ""  # free-text note about the lamella
 
     def __post_init__(self):
         # only make the dir, if the base path is actually set, 
@@ -830,6 +831,7 @@ class Lamella:
             "defect": self.defect.to_dict(),
             "milling_angle": self.milling_angle,
             "poi": self.poi.to_dict(),
+            "description": self.description,
         }
 
     @property
@@ -875,6 +877,7 @@ class Lamella:
             defect=DefectState.from_dict(data.get("defect", {})),
             milling_angle=data.get("milling_angle", None),
             poi=Point.from_dict(data.get("poi", {"x":0,"y":0})),
+            description=data.get("description", ""),
         )
 
     def load_reference_image(self, fname) -> FibsemImage:

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import (
     QGridLayout,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QMessageBox,
     QScrollArea,
     QVBoxLayout,
@@ -245,6 +246,13 @@ class AutoLamellaProtocolEditorWidget(QWidget):
             "font-size: 14px; font-weight: bold; color: #e0e0e0; background: transparent;"
         )
 
+        # free-text lamella description (this editor is the source of truth for it)
+        self.label_description = QLabel("Description")
+        self.line_edit_description = QLineEdit()
+        self.line_edit_description.setPlaceholderText("Add a description…")
+        self.line_edit_description.setToolTip("Free-text note about this lamella")
+        self.line_edit_description.editingFinished.connect(self._on_description_edited)
+
         self.button_layout = QHBoxLayout()
         self.button_layout.addWidget(self.label_lamella_name)
         self.button_layout.addStretch()
@@ -293,6 +301,8 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         self.grid_layout.addWidget(self.label_lamella_warning, 5, 0, 1, 2)
         self.grid_layout.addWidget(self.label_status, 6, 0, 1, 2)
         self.grid_layout.addWidget(self.label_warning, 7, 0, 1, 2)
+        self.grid_layout.addWidget(self.label_description, 8, 0, 1, 1)
+        self.grid_layout.addWidget(self.line_edit_description, 8, 1, 1, 1)
 
         # main layout
         self.main_layout = QVBoxLayout(self)
@@ -378,6 +388,11 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         if selected_lamella is None:
             return
         self.label_lamella_name.setText(selected_lamella.name)
+
+        # populate description without re-emitting editingFinished
+        self.line_edit_description.blockSignals(True)
+        self.line_edit_description.setText(selected_lamella.description)
+        self.line_edit_description.blockSignals(False)
 
         task_names = self._sort_task_names_by_workflow(
             list(selected_lamella.task_config.keys())
@@ -1065,6 +1080,17 @@ class AutoLamellaProtocolEditorWidget(QWidget):
             msg += "\nBase protocol was also updated."
         QMessageBox.information(self, "Apply Complete", msg)
         logging.info(msg)
+
+    def _on_description_edited(self):
+        """Persist the free-text description for the selected lamella."""
+        lamella = self._selected_lamella
+        if lamella is None:
+            return
+        text = self.line_edit_description.text()
+        if lamella.description == text:
+            return
+        lamella.description = text  # fires events.description -> updates read-only mirrors
+        self._save_experiment()
 
     def _save_experiment(self):
         """Save the experiment."""

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -904,6 +904,10 @@ class _LamellaRow(QWidget):
         self.btn_remove.setVisible(False)
         layout.addWidget(self.btn_remove)
 
+        # live-update the description tooltip when it changes (e.g. edited in the
+        # Selected Lamella panel). type: ignore because @evented adds .events dynamically.
+        self.lamella.events.description.connect(self.refresh)  # type: ignore[union-attr]
+
         self.refresh()
 
     def _on_defect_clicked(self) -> None:
@@ -943,6 +947,7 @@ class _LamellaRow(QWidget):
 
     def refresh(self) -> None:
         self.name_label.setText(self.lamella.name)
+        self.setToolTip(self.lamella.description or "")
         text, style = _lamella_status_text(self.lamella)
         self.status_label.setText(text)
         self.status_label.setStyleSheet(style)

--- a/fibsem/ui/widgets/lamella_card_widget.py
+++ b/fibsem/ui/widgets/lamella_card_widget.py
@@ -171,6 +171,7 @@ class LamellaCardWidget(QWidget):
         lamella.task_state.events.name.connect(self.refresh)    # type: ignore[union-attr]
         lamella.task_state.events.status.connect(self.refresh)  # type: ignore[union-attr]
         lamella.events.defect.connect(self.refresh)             # type: ignore[union-attr]
+        lamella.events.description.connect(self.refresh)        # type: ignore[union-attr]
 
         self.refresh()
 
@@ -179,6 +180,7 @@ class LamellaCardWidget(QWidget):
     def refresh(self) -> None:
         """Re-read all display fields from the stored Lamella."""
         self._name_label.setText(self.lamella.name)
+        self._card.setToolTip(self.lamella.description or "")
 
         icon_name, icon_color, tooltip = _defect_icon(self.lamella)
         self._btn_defect.setIcon(fibsem_icon(icon_name, color=icon_color))

--- a/fibsem/ui/widgets/lamella_list_widget.py
+++ b/fibsem/ui/widgets/lamella_list_widget.py
@@ -166,6 +166,7 @@ class LamellaRowWidget(QWidget):
         lamella.task_state.events.name.connect(self.refresh)    # type: ignore[union-attr]
         lamella.task_state.events.status.connect(self.refresh)  # type: ignore[union-attr]
         lamella.events.defect.connect(self.refresh)             # type: ignore[union-attr]
+        lamella.events.description.connect(self.refresh)        # type: ignore[union-attr]
 
         self.refresh()
 
@@ -227,6 +228,7 @@ class LamellaRowWidget(QWidget):
     def refresh(self) -> None:
         """Re-read all display fields from the stored Lamella."""
         self.name_label.setText(self.lamella.name)
+        self.setToolTip(self.lamella.description or "")
 
         icon_name, icon_color, tooltip = _defect_icon(self.lamella)
         self.btn_defect.setIcon(fibsem_icon(icon_name, color=icon_color))

--- a/fibsem/ui/widgets/selected_lamella_widget.py
+++ b/fibsem/ui/widgets/selected_lamella_widget.py
@@ -41,6 +41,15 @@ class SelectedLamellaWidget(QWidget):
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
 
+        # --- description row (read-only mirror; edited in the Lamella editor) ---
+        self._lamella: Optional[Lamella] = None
+        self.description_label = QLabel()
+        self.description_label.setWordWrap(True)
+        self.description_label.setStyleSheet(
+            "color: #909090; font-style: italic; background: transparent;"
+        )
+        self.description_label.setToolTip("Free-text note (edit in the Lamella editor)")
+
         # --- objective position row ---
         self.label_objective_position = QLabel("Objective Position")
         self.spinbox_objective_position = ValueSpinBox(
@@ -77,9 +86,10 @@ class SelectedLamellaWidget(QWidget):
         obj_row_layout.setSpacing(2)
         obj_row_layout.addWidget(self.spinbox_objective_position)
         obj_row_layout.addWidget(self.btn_objective_actions)
-        content_layout.addWidget(self.label_objective_position, 0, 0)
-        content_layout.addWidget(obj_row, 0, 1)
-        content_layout.addWidget(self.pose_list, 1, 0, 1, 2)
+        content_layout.addWidget(self.description_label, 0, 0, 1, 2)
+        content_layout.addWidget(self.label_objective_position, 1, 0)
+        content_layout.addWidget(obj_row, 1, 1)
+        content_layout.addWidget(self.pose_list, 2, 0, 1, 2)
 
         self._panel = TitledPanel(
             "Selected Lamella", content=content, collapsible=False
@@ -111,13 +121,31 @@ class SelectedLamellaWidget(QWidget):
 
     def set_lamella(self, lamella: Optional[Lamella]) -> None:
         """Refresh the panel display from *lamella* (or clear it if None)."""
+        # re-point the live description mirror at the newly selected lamella
+        if self._lamella is not None:
+            try:
+                self._lamella.events.description.disconnect(self._refresh_description)  # type: ignore[union-attr]
+            except (TypeError, ValueError, RuntimeError):
+                pass
+        self._lamella = lamella
+
         if lamella is None:
+            self._panel.set_title("Selected Lamella")
+            self.description_label.setVisible(False)
             self.label_objective_position.setVisible(False)
             self.spinbox_objective_position.setVisible(False)
             self.btn_objective_actions.setVisible(False)
             self.pose_list.set_lamella(None)
             self.pose_list.setVisible(False)
             return
+
+        # show which lamella is selected in the panel title
+        self._panel.set_title(f"Selected Lamella — {lamella.name}")
+
+        # read-only description mirror; live-updates when edited in the Lamella editor
+        self.description_label.setVisible(True)
+        self._refresh_description()
+        lamella.events.description.connect(self._refresh_description)  # type: ignore[union-attr]
 
         # objective position (shown in µm). The controls are shown whenever the
         # lamella has a fluorescence pose, so the objective can still be set/restored
@@ -142,6 +170,14 @@ class SelectedLamellaWidget(QWidget):
         # poses
         self.pose_list.set_lamella(lamella)
         self.pose_list.setVisible(bool(lamella.poses))
+
+    def _refresh_description(self) -> None:
+        """Mirror the current lamella's description into the read-only label."""
+        if self._lamella is None:
+            return
+        text = self._lamella.description
+        self.description_label.setText(text or "No description")
+        self.description_label.setToolTip(text or "Free-text note (edit in the Lamella editor)")
 
     def refresh_pose(self, pose_name: str, pretty: str) -> None:
         """Update one pose row's position in place, without rebuilding the list."""


### PR DESCRIPTION
Resolves [FIB-276](https://linear.app/fibsemos/issue/FIB-276).

Adds a free-text `description` to each lamella — a place to note what a lamella is / why it was picked — that persists with the experiment and is visible wherever lamellae are listed.

### Data model
- New `description: str = ""` field on `Lamella` + `to_dict`/`from_dict`. Round-trips through `experiment.yaml`; old experiments without the key load fine (`data.get("description", "")`). No DB / no migration. `Lamella` is a psygnal `@evented` dataclass, so assigning `description` auto-fires `events.description`.

### Editing (single source of truth)
- Editable field in the **Lamella protocol editor** (`AutoLamellaProtocolEditorWidget`); edits persist via `_save_experiment()`.

### Read-only display (live-updates via `events.description`)
- **Selected Lamella panel**: read-only label; the lamella name now shows in the panel title (`Selected Lamella — {name}`).
- **Lamella card**: tooltip.
- **Workflow lamella list** and **Experiment-tab lamella list**: row tooltip.

Every read-only surface subscribes to `events.description` (the same pattern the row/card widgets already use for name/status/defect), so editing in the editor updates them all live without cross-widget plumbing.

### Testing
Verified offscreen (Qt): round-trip + back-compat + `events.description` fires; editor handler mutates + saves; the Selected Lamella label is read-only, mirrors live, and re-points its subscription cleanly on reselect; card/list tooltips reflect the description and update live. All changed files compile.

Out of scope (follow-ups): overview-plot overlay of the description; multi-line editing; surfacing it in the running-workflow info banner.
