### PR TITLE
Correlation: confirmation-friendly fit diagnostic plots (FIB-260)

### DIFF
--- a/fibsem/correlation/util.py
+++ b/fibsem/correlation/util.py
@@ -531,15 +531,24 @@ def hole_fitting_FIB(img: np.ndarray,
     xr = np.clip(xr, cutout, img.shape[1] - cutout)
     yr = np.clip(yr, cutout, img.shape[0] - cutout)
 
-    # --- Diagnostic figure ---
+    # --- Diagnostic figure (XY only — no z for the FIB image) ---
+    C_IN, C_FIT = "#e53935", "#43a047"
+    n = roi.shape[0]
     fig, ax = plt.subplots(1, 1, figsize=(5, 5))
-    title = "FIB Hole Fit (XY)" if err is None else "FIB Hole Fit Failed, using input XY"
-    ax.set_title(title)
-    im = ax.imshow(roi, cmap='gray')
-    ax.scatter(cutout, cutout, color='c', label='Input')
-    ax.scatter(xopt, yopt, color='r', label='Fit')
-    fig.colorbar(im, ax=ax, label='Intensity')
-    ax.legend()
+    fig.suptitle("FIB hole fit")
+    ax.imshow(roi, cmap="gray")
+    ax.plot(cutout, cutout, "+", color=C_IN, ms=16, mew=2, label="input")
+    if err is None:
+        ax.plot(xopt, yopt, "+", color=C_FIT, ms=16, mew=2, label="fitted")
+    else:
+        ax.text(0.5, 0.08, "fit failed — using input", transform=ax.transAxes,
+                ha="center", va="center", color=C_IN, fontsize=10,
+                bbox=dict(boxstyle="round", fc="black", ec=C_IN, alpha=0.65))
+    ax.set_xlim(-0.5, n - 0.5)
+    ax.set_ylim(n - 0.5, -0.5)
+    ax.set_title("XY")
+    ax.legend(loc="upper right", fontsize=8, framealpha=0.6)
+    ax.axis("off")
 
     if show:
         plt.show()
@@ -564,20 +573,16 @@ def target_fitting_fluorescence(img: np.ndarray,
     """
     import matplotlib.pyplot as plt
 
-    fig, axes = plt.subplots(1, 2)#, figsize=(10, 5))
-    fig.suptitle("Target Fitting Fluorescence")
+    # input (red) / fitted (green) are the only saturated colours; rest greyscale
+    C_IN, C_FIT = "#e53935", "#43a047"
 
-    roi = img[:, y-cutout:y+cutout, x-cutout:x+cutout]
+    roi = img[:, y - cutout:y + cutout, x - cutout:x + cutout]
     intensity = np.mean(roi, axis=(1, 2))
-    popt_z, _ = fit_guass1d(intensity, ax=axes[0])
-
+    popt_z, _ = fit_guass1d(intensity)
     zi = popt_z[1]
-    axes[0].set_title("Initial Z fit")
-    axes[0].axvline(zi, color='r', label='Fit')
-    axes[0].axvline(z, color='k', linestyle='--', label=f'Input Z: {z}')
-    axes[0].legend()
 
-    slc_init = img[int(zi), y-cutout:y+cutout, x-cutout:x+cutout]
+    slc_init = img[int(zi), y - cutout:y + cutout, x - cutout:x + cutout]
+    n = slc_init.shape[0]
     err = None
     if use_xy_fitting:
         try:
@@ -585,7 +590,7 @@ def target_fitting_fluorescence(img: np.ndarray,
             xopt, yopt = popt_xy[1], popt_xy[2]
         except Exception as e:
             logging.warning(f"Error in initial XY fit: {e}")
-            xopt, yopt = cutout, cutout # fallback to center of cutout if fit fails
+            xopt, yopt = cutout, cutout  # fallback to center of cutout if fit fails
             err = e
 
         if not (0 <= xopt < 2 * cutout and 0 <= yopt < 2 * cutout):
@@ -596,22 +601,41 @@ def target_fitting_fluorescence(img: np.ndarray,
         yi = yopt + y - cutout
     else:
         xi, yi = x, y
-        xopt, yopt = cutout, cutout # for plotting the fit result as the center of the cutout
+        xopt, yopt = cutout, cutout  # fit result is the cutout centre for plotting
 
-    
-    title = "Initial XY fit" if use_xy_fitting else "Input XY position"
+    # --- confirmation-friendly diagnostic: z (left) + XY hero (right) ---
+    fig, (ax_z, ax_xy) = plt.subplots(
+        1, 2, figsize=(9, 4.5), gridspec_kw={"width_ratios": [1, 1.4]}
+    )
+    fig.suptitle("Fluorescence target fit")
 
-    axes[1].set_title(f"{title} (z={zi:.2f})")
-    im = axes[1].imshow(slc_init, cmap='gray')
-    axes[1].scatter(cutout, cutout, color='yellow', label='Input')
-    if err:
-        axes[1].text(0.5, 0.5, f"XY fit failed: {err}", ha='center', va='center', transform=axes[1].transAxes, color='red')
-    else:
-        axes[1].scatter(xopt, yopt, color='r', label='Fit')
+    z_axis = np.arange(len(intensity))
+    ax_z.plot(z_axis, intensity, color="0.55", lw=1.3)
+    ax_z.plot(z_axis, gauss1d(z_axis, *popt_z) + intensity.min(),
+              color="0.15", ls="--", lw=1.2)
+    ax_z.axvline(z, color=C_IN, ls="--", lw=1.6, label=f"input {z}")
+    ax_z.axvline(zi, color=C_FIT, ls="--", lw=1.6, label=f"fitted {zi:.1f}")
+    ax_z.set_title("z", fontsize=10)
+    ax_z.set_xlabel("z slice", fontsize=8)
+    ax_z.set_yticks([])
+    ax_z.tick_params(labelsize=8)
+    ax_z.legend(fontsize=7, framealpha=0.6)
 
-    fig.colorbar(im, ax=axes[1], label='Intensity')
-    axes[1].legend()
+    ax_xy.imshow(slc_init, cmap="gray")
+    ax_xy.plot(cutout, cutout, "+", color=C_IN, ms=16, mew=2, label="input")
+    if err is not None:
+        ax_xy.text(0.5, 0.08, "XY fit failed", transform=ax_xy.transAxes,
+                   ha="center", va="center", color=C_IN, fontsize=10,
+                   bbox=dict(boxstyle="round", fc="black", ec=C_IN, alpha=0.65))
+    elif use_xy_fitting:
+        ax_xy.plot(xopt, yopt, "+", color=C_FIT, ms=16, mew=2, label="fitted")
+    ax_xy.set_xlim(-0.5, n - 0.5)
+    ax_xy.set_ylim(n - 0.5, -0.5)
+    ax_xy.set_title(f"XY  @ z = {zi:.1f}")
+    ax_xy.legend(loc="upper right", fontsize=8, framealpha=0.6)
+    ax_xy.axis("off")
 
+    fig.tight_layout()
     if show:
         plt.show()
 
@@ -912,72 +936,79 @@ def hole_fitting_reflection(da, x, y, z, cutout) -> Tuple[float, float, float, '
     import matplotlib.pyplot as plt
     from scipy.ndimage import gaussian_filter
 
-    fig, axes = plt.subplots(1, 3, figsize=(20, 5))
-
     zmin = 10
     zmax = 5
     zmin1 = int(z) - zmin
     zmax1 = int(z) + zmax
 
-    # query: use the argmin/argmax to set the z-window?
-    zmin_arg=  np.argmin(da[:, y, x])
-    zmax_arg = np.argmax(da[:, y, x])
-    # zmin1 = zmax_arg
-
-    roi = da[zmin1:zmax1, 
-                            y-cutout:y+cutout+1, 
-                            x-cutout:x+cutout+1]
+    roi = da[zmin1:zmax1, y - cutout:y + cutout + 1, x - cutout:x + cutout + 1]
     intensity = np.mean(roi, axis=(1, 2))
+    intensity = intensity.max() - intensity  # invert: the hole is dark
 
-    # invert intensity for hole fitting
-    intensity = intensity.max() - intensity
-    popt, pcov = fit_guass1d(intensity, ax=axes[1] )
+    popt, _ = fit_guass1d(intensity)
     zopt = popt[1]
-    zreal = zopt + zmin1 # convert back to original z coordinate
+    zreal = zopt + zmin1  # back to absolute z
 
-    # xy fitting
+    # xy fitting on the fitted z-slice
     xy_cutout = 15
-    roi_fitted = da[round(zreal), y-xy_cutout:y+xy_cutout+1, x-xy_cutout:x+xy_cutout+1]
-
+    roi_fitted = da[round(zreal), y - xy_cutout:y + xy_cutout + 1,
+                    x - xy_cutout:x + xy_cutout + 1]
     popt_xy, _ = fit_gauss_2d_mod(roi_fitted)
     xopt, yopt = popt_xy[1], popt_xy[2]
-
-    # transform back to original image coordinates
     xopt_real = xopt + x - xy_cutout
     yopt_real = yopt + y - xy_cutout
 
-    # # print(zmin1, zmax1)
-    # # print(xopt, yopt)
-    # print(f"Fitted Z: {zopt}, Input Z: {z}, Z Fitted (Real) {zreal:.2f}")
-    # print(f"Fitted XY: ({xopt_real:.2f}, {yopt_real:.2f}), Input XY: ({x}, {y})")
+    # --- confirmation-friendly diagnostic ---
+    # Lead with the "did it land on the feature?" view (ROI + input/fitted
+    # markers); a compact z panel answers "did z land right?". The old figure
+    # had a raw-profile panel with six reference lines and a second z panel in a
+    # different (cutout-relative) frame with the same labels — dropped.
+    n = roi_fitted.shape[0]
+    fit_in_roi = 0 <= xopt < n and 0 <= yopt < n
 
-    # fig, axes = plt.subplots(1, 3, figsize=(20, 5))
-    fig.suptitle("Hole Fitting (Reflection)")
+    # Palette kept deliberately minimal: only input (red) and fitted (green) are
+    # saturated; signal / fit are greyscale so the eye goes to the two markers.
+    C_IN, C_FIT = "#e53935", "#43a047"
 
-    axes[0].plot(da[:, y, x])
-    axes[0].set_title(f"Original Z Profile at (x={x}, y={y})")
-    axes[0].axvline(z, color='r', linestyle='--', label=f'Input Z: {z:.2f}')
-    axes[0].axvline(zreal, color='g', linestyle='--', label=f'Fitted Z: {zreal:.2f}')
-    axes[0].axvline(zmin1, color='orange', linestyle='--', label=f'Cutout Start: {zmin1}')
-    axes[0].axvline(zmax1, color='orange', linestyle='--', label=f'Cutout End: {zmax1}')
-    axes[0].set_xlabel("Z Slice")
-    axes[0].set_ylabel("Intensity")
-    axes[0].axvline(zmin_arg, color="purple", linestyle='--', label="Min Z Value")
-    axes[0].axvline(zmax_arg, color="magenta", linestyle='--', label="Max Z Value")
-    axes[0].legend()
+    fig, (ax_z, ax_xy) = plt.subplots(
+        1, 2, figsize=(9, 4.5), gridspec_kw={"width_ratios": [1, 1.4]}
+    )
+    fig.suptitle("Reflection hole fit")
 
-    axes[1].set_title(f"Mean Intensity Profile Along Z Axis (Cutout: {cutout})")
-    axes[1].set_xlabel("Z Slice")
-    axes[1].set_ylabel("Mean Intensity")
-    axes[1].axvline(zopt, color='g', linestyle='--', label=f'Fitted Z: {zopt:.2f}')
-    axes[1].axvline(zmin, color='r', linestyle='--', label=f'Input Z: {zmin}')
-    axes[1].legend()
+    # z: signal + gaussian fit (grey), with input / fitted z the only labels
+    z_axis = np.arange(zmin1, zmin1 + len(intensity))
+    gauss_curve = gauss1d(np.arange(len(intensity)), *popt) + intensity.min()
+    ax_z.plot(z_axis, intensity, color="0.55", lw=1.3)
+    ax_z.plot(z_axis, gauss_curve, color="0.15", ls="--", lw=1.2)
+    ax_z.axvline(z, color=C_IN, ls="--", lw=1.6, label=f"input {z:.1f}")
+    ax_z.axvline(zreal, color=C_FIT, ls="--", lw=1.6, label=f"fitted {zreal:.1f}")
+    ax_z.set_title("z", fontsize=10)
+    ax_z.set_xlabel("z slice", fontsize=8)
+    # the hole is dark, so the signal is inverted — the peak is the hole
+    ax_z.set_ylabel("signal (inverted)", fontsize=8)
+    ax_z.set_yticks([])
+    ax_z.tick_params(labelsize=8)
+    ax_z.legend(fontsize=7, framealpha=0.6)
 
-    im = axes[2].imshow(gaussian_filter(roi_fitted, sigma=1), cmap='gray')
-    axes[2].set_title(f"Z Projection of ROI (Cutout: {cutout}, z={zreal:.2f})")
-    axes[2].plot(15, 15, "r+", label=f'Initial Point (x={x:.2f}, y={y:.2f})')
-    axes[2].plot(xopt, yopt, "g+", label=f'Fitted Point (x={xopt_real:.2f}, y={yopt_real:.2f})')
-    fig.colorbar(im, ax=axes[2])
-    axes[2].legend()
+    # XY: the hero — did it land on the feature?
+    ax_xy.imshow(gaussian_filter(roi_fitted, sigma=1), cmap="gray")
+    ax_xy.plot(xy_cutout, xy_cutout, "+", color=C_IN, ms=16, mew=2, label="input")
+    if fit_in_roi:
+        ax_xy.plot(xopt, yopt, "+", color=C_FIT, ms=16, mew=2, label="fitted")
+    else:
+        # A failed 2D fit lands outside the ROI; make that explicit instead of
+        # letting matplotlib silently expand the axes to chase the marker.
+        ax_xy.text(
+            0.5, 0.5, "fit fell outside\nthe search region",
+            transform=ax_xy.transAxes, ha="center", va="center",
+            color=C_IN, fontsize=11,
+            bbox=dict(boxstyle="round", fc="black", ec=C_IN, alpha=0.65),
+        )
+    ax_xy.set_xlim(-0.5, n - 0.5)
+    ax_xy.set_ylim(n - 0.5, -0.5)
+    ax_xy.set_title(f"XY  @ z = {zreal:.1f}")
+    ax_xy.legend(loc="upper right", fontsize=8, framealpha=0.6)
+    ax_xy.axis("off")
 
+    fig.tight_layout()
     return xopt_real, yopt_real, zreal, fig

--- a/tests/correlation/test_fit_diagnostics.py
+++ b/tests/correlation/test_fit_diagnostics.py
@@ -1,0 +1,65 @@
+"""Smoke tests for the fit diagnostic figures (FIB-260).
+
+The change is presentational (confirmation-friendly figures), so these lock the
+figure layout — each fit runs on a clean synthetic feature, returns finite
+coordinates, and produces the expected number of panels:
+
+  * FIB hole            -> 1 panel  (XY only)
+  * reflection hole     -> 2 panels (z + XY)
+  * fluorescence target -> 2 panels (z + XY)
+"""
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+from matplotlib.figure import Figure
+
+from fibsem.correlation.util import (
+    hole_fitting_FIB,
+    hole_fitting_reflection,
+    target_fitting_fluorescence,
+)
+
+
+def _blob_2d(size: int, cx: int, cy: int, sigma: float = 3.0) -> np.ndarray:
+    yy, xx = np.mgrid[0:size, 0:size]
+    return np.exp(-((xx - cx) ** 2 + (yy - cy) ** 2) / (2 * sigma**2))
+
+
+def test_fib_hole_fit_single_panel():
+    # a dark hole on a bright background
+    img = (200.0 - 160.0 * _blob_2d(40, 20, 20)).astype(np.float32)
+    xr, yr, fig = hole_fitting_FIB(img, x=20, y=20, cutout=15)
+
+    assert np.isfinite(xr) and np.isfinite(yr)
+    assert isinstance(fig, Figure)
+    assert len(fig.axes) == 1  # XY only — no z for a FIB image
+
+
+def test_reflection_hole_fit_z_and_xy_panels():
+    nz = 21
+    vol = np.full((nz, 60, 60), 200.0, dtype=np.float32)
+    for zi in range(nz):
+        depth = np.exp(-((zi - 10) ** 2) / (2 * 2.0**2))  # hole deepest at z=10
+        vol[zi] -= 160.0 * depth * _blob_2d(60, 30, 30)
+
+    xr, yr, zr, fig = hole_fitting_reflection(vol, x=30, y=30, z=10, cutout=2)
+
+    assert np.isfinite(xr) and np.isfinite(yr) and np.isfinite(zr)
+    assert 8 <= zr <= 12  # near the true hole z
+    assert len(fig.axes) == 2  # consolidated: one z panel + XY hero
+
+
+def test_fluorescence_target_fit_z_and_xy_panels():
+    nz = 21
+    vol = np.zeros((nz, 40, 40), dtype=np.float32)
+    for zi in range(nz):
+        bright = np.exp(-((zi - 10) ** 2) / (2 * 2.0**2))  # brightest at z=10
+        vol[zi] += 200.0 * bright * _blob_2d(40, 20, 20)
+
+    xr, yr, zr, fig = target_fitting_fluorescence(vol, x=20, y=20, z=10, cutout=5)
+
+    assert np.isfinite(zr)
+    assert 8 <= zr <= 12
+    assert len(fig.axes) == 2


### PR DESCRIPTION
Closes [FIB-260](https://linear.app/fibsemos/issue/FIB-260).

## Summary

The per-point fit diagnostic figures were debug-grade — too busy for a user deciding *"did this land on the feature?"*. This redesigns all three fit functions (`hole_fitting_FIB`, `hole_fitting_reflection`, `target_fitting_fluorescence`) into one consistent, confirmation-grade language.

Presentational only — the returned fit coordinates are unchanged. Shown via the existing **"Show diagnostic"** refit dialog on main today, and by the fit confirmation dialog once [FIB-252](https://linear.app/fibsemos/issue/FIB-252) (#144) lands.

## What changed

- **Lead with the XY view** (ROI + input/fitted markers) as the hero; a single compact **z** panel (signal + gaussian fit + input/fitted z) sits beside it.
- **The reflection figure was the worst offender** — a 3-panel 20×5 strip with a raw-profile panel carrying *six* reference lines, and a second z panel drawn in a different (cutout-relative) frame with identical labels. Both dropped; consolidated to one z panel.
- **Minimal palette** — only input (red) and fitted (green) are saturated; signal and fit curves are greyscale, so the eye goes straight to the two markers. A good fit reads as the markers **overlapping** on the feature; a bad one as them **diverging**.
- **A failed fit is now explicit.** `hole_fitting_reflection` had no bounds check, so a 2D fit landing outside the ROI used to let matplotlib silently expand the axes to chase the marker. It now shows **"fit fell outside the search region"** instead.
- **The reflection signal is inverted** (the hole is dark, so its peak *is* the hole) — labelled on the axis so the peak isn't misread as "brightest".
- Colorbars dropped; clipped titles fixed.

## Good vs bad fit, at a glance

| | |
|---|---|
| **FIB hole** — input/fitted markers land on top of each other, dead-centre on the hole | reads as a *good* fit instantly |
| **Reflection** on a mis-placed point — markers diverge onto different dark spots; z fit off at the edge; "fell outside" annotation | reads as a *bad* fit instantly |

## Testing

103 correlation tests pass. New `test_fit_diagnostics.py` runs each fit on a clean synthetic feature and locks the layout — finite coordinates, the fitted z near the true feature, and the expected panel count (FIB hole → 1, reflection → 2, fluorescence → 2). Iterated live against real METEOR data via a render harness.
