### PR TITLE
[fix] vertical move: maintain SEM WD, only reset FIB to eucentric for large moves (FIB-274)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -294,7 +294,7 @@ class FibsemMicroscope(ABC):
         pass
 
     @abstractmethod
-    def vertical_move(self, dy: float, dx: float = 0, static_wd: bool = True) -> FibsemStagePosition:
+    def vertical_move(self, dy: float, dx: float = 0) -> FibsemStagePosition:
         pass
 
     @abstractmethod
@@ -1459,7 +1459,7 @@ class ThermoMicroscope(FibsemMicroscope):
         stable_move(self, dx: float, dy: float, beam_type: BeamType,) -> None:
             Calculate the corrected stage movements based on the beam_type, and then move the stage relatively.
 
-        vertical_move(self,  dy: float, dx: float = 0, static_wd: bool = True) -> None:
+        vertical_move(self,  dy: float, dx: float = 0) -> None:
             Move the stage vertically to correct eucentric point
         
         get_manipulator_position(self) -> FibsemManipulatorPosition:
@@ -2183,14 +2183,12 @@ class ThermoMicroscope(FibsemMicroscope):
         self,
         dy: float,
         dx: float = 0.0,
-        static_wd: bool = True,
     ) -> FibsemStagePosition:
         """ Move the stage vertically to correct coincidence point
 
         Args:
             dy (float): distance along the y-axis (image coordinates)
             dx (float, optional): distance along the x-axis (image coordinates). Defaults to 0.0.
-            static_wd (bool, optional): whether to fix the working distance. Defaults to True.
         """
 
         # get current working distance, to be restored later
@@ -2223,17 +2221,20 @@ class ThermoMicroscope(FibsemMicroscope):
         logging.info(f"Vertical movement: {stage_position}")
         self.move_stage_relative(stage_position) # NOTE: this seems to be a bit less than previous... -> perspective correction?
 
-        # restore working distance to adjust for microscope compenstation
-        if static_wd and not self.stage_is_compustage:
-            self.set_working_distance(wd=self.system.electron.eucentric_height, beam_type=BeamType.ELECTRON)
+        # Vertical moves re-establish the coincidence plane. Always restore the
+        # pre-move SEM (electron) working distance so fine corrections keep their
+        # focus. For a large correction, snap the FIB (ion) WD to eucentric (the
+        # best estimate at the new coincidence plane); small corrections keep the
+        # current FIB focus.
+        EUCENTRIC_RESET_THRESHOLD = 100e-6  # m (stage-z travel)
+        self.set_working_distance(wd=wd, beam_type=BeamType.ELECTRON)
+        if abs(dz) > EUCENTRIC_RESET_THRESHOLD:
             self.set_working_distance(wd=self.system.ion.eucentric_height, beam_type=BeamType.ION)
-        else:
-            self.set_working_distance(wd=wd, beam_type=BeamType.ELECTRON)
 
         # logging
-        logging.debug({"msg": "vertical_move", "dy": dy, "dx": dx, 
-                "static_wd": static_wd, "wd": wd, 
-                "scan_rotation": scan_rotation, 
+        logging.debug({"msg": "vertical_move", "dy": dy, "dx": dx,
+                "wd": wd,
+                "scan_rotation": scan_rotation,
                 "position": stage_position.to_dict()})
 
         return self.get_stage_position()

--- a/fibsem/microscopes/odemis_microscope.py
+++ b/fibsem/microscopes/odemis_microscope.py
@@ -814,10 +814,10 @@ class OdemisThermoMicroscope(FibsemMicroscope):
         return ThermoMicroscope.stable_move(self, dx=dx, dy=dy, beam_type=beam_type, static_wd=static_wd)
 
     def vertical_move(
-        self, dy: float, dx: float = 0.0, static_wd: bool = True
+        self, dy: float, dx: float = 0.0
     ) -> FibsemStagePosition:
         """Move the stage vertically by the specified amount."""
-        return ThermoMicroscope.vertical_move(self, dy=dy, dx=dx, static_wd=static_wd)
+        return ThermoMicroscope.vertical_move(self, dy=dy, dx=dx)
 
     def move_coincident_from_sem(self, dx: float, dy: float) -> FibsemStagePosition:
         """Correct coincident point from SEM to FIB stage position."""

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -638,9 +638,9 @@ class DemoMicroscope(FibsemMicroscope):
     def stable_move(self, dx: float, dy:float, beam_type: BeamType, static_wd: bool=False) -> FibsemStagePosition:
         return ThermoMicroscope.stable_move(self, dx, dy, beam_type, static_wd)
 
-    def vertical_move(self, dy: float, dx:float = 0.0, static_wd: bool=True) -> FibsemStagePosition:
+    def vertical_move(self, dy: float, dx:float = 0.0) -> FibsemStagePosition:
         """Move the stage vertically by the specified amount."""
-        return ThermoMicroscope.vertical_move(self, dy, dx, static_wd)
+        return ThermoMicroscope.vertical_move(self, dy, dx)
 
     def _y_corrected_stage_movement(self, expected_y: float, beam_type: BeamType) -> FibsemStagePosition:
         """

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -645,7 +645,6 @@ class TescanMicroscope(FibsemMicroscope):
         self,
         dy: float,
         dx: float = 0.0,
-        static_wd: bool = True,
     ) -> None:
         """
         Move the stage vertically to correct coincidence point

--- a/fibsem/server/client.py
+++ b/fibsem/server/client.py
@@ -119,8 +119,8 @@ class FibsemClient:
         })
         return FibsemStagePosition.from_dict(result["position"])
 
-    def vertical_move(self, dy: float, dx: float = 0.0, static_wd: bool = True) -> FibsemStagePosition:
-        result = self._post("vertical_move", {"dy": dy, "dx": dx, "static_wd": static_wd})
+    def vertical_move(self, dy: float, dx: float = 0.0) -> FibsemStagePosition:
+        result = self._post("vertical_move", {"dy": dy, "dx": dx})
         return FibsemStagePosition.from_dict(result["position"])
 
     def safe_absolute_stage_movement(self, position: FibsemStagePosition) -> None:

--- a/fibsem/server/models.py
+++ b/fibsem/server/models.py
@@ -42,7 +42,6 @@ class ProjectStableMoveRequest(BaseModel):
 class VerticalMoveRequest(BaseModel):
     dy: float
     dx: float = 0.0
-    static_wd: bool = True
 
 
 class FlatToBeamRequest(BaseModel):

--- a/fibsem/server/server.py
+++ b/fibsem/server/server.py
@@ -182,7 +182,7 @@ class FibsemServer:
 
         @app.post("/vertical_move", response_model=StagePositionResponse)
         def vertical_move(body: VerticalMoveRequest):
-            result = microscope.vertical_move(dy=body.dy, dx=body.dx, static_wd=body.static_wd)
+            result = microscope.vertical_move(dy=body.dy, dx=body.dx)
             return StagePositionResponse(position=result.to_dict())
 
         @app.post("/safe_absolute_stage_movement")


### PR DESCRIPTION
Resolves [FIB-274](https://linear.app/fibsemos/issue/FIB-274).

Using FIB vertical move silently reset the working distance back to eucentric on **every** move — resetting both beams and, notably, overwriting the ion WD that was never even read. For small coincidence corrections this threw away focus you'd just dialled in.

### New behaviour (`ThermoMicroscope.vertical_move`)
A vertical move re-establishes the coincidence plane, and the eucentric WD is the best *a-priori* estimate of focus there — but that's only useful for **large** corrections. For small ones you're already near-coincident and better focused than the eucentric estimate, so we keep what we have.

- **SEM (electron):** always restore the **pre-move** WD → fine corrections keep their focus.
- **FIB (ion):** snap to eucentric **only** for corrections > **100 µm** (a local threshold); smaller moves keep the current FIB focus.
- No more silent reset of the ion beam on small moves.

### Removed `static_wd`
`static_wd` no longer had any real effect on `vertical_move` (no caller ever passed `False`; it was only reachable via the server API), and "don't manage WD" isn't a meaningful mode for a move whose whole purpose is to re-establish coincidence. Removed it from the `vertical_move` path everywhere: abstract base signature, the Thermo/Tescan impls, the `simulator`/`odemis` delegations, and the server `client`/`server`/`VerticalMoveRequest` model. **`stable_move`'s own `static_wd` is untouched.**

### Testing
Verified on a `Demo` session: `vertical_move(dy, dx)` (no `static_wd`); a small move (dz ≈ 1 µm) sets only the electron WD, a large move (dz ≈ 1 mm) sets electron + ion→eucentric, and passing `static_wd` now raises `TypeError`. All touched files compile.

**This changes hardware behaviour — the 100 µm threshold and the FIB reset should be confirmed on a real instrument** (a FIB v-move should hold the SEM WD, and only re-eucentric the FIB on a genuinely large correction).
