### PR TITLE
[feature] show lamella descriptions on the overview export plot (FIB-280)

### DIFF
--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -5,7 +5,7 @@ import logging
 import os
 import threading
 from copy import deepcopy
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -831,6 +831,8 @@ def plot_minimap(
         color: str = "cyan",
         show_scalebar: bool = False,
         show_names: bool = True,
+        show_descriptions: bool = False,
+        descriptions: Optional[Dict[str, str]] = None,
         show_grid_radius: bool = False,
         fontsize: int = 12,
         markersize: int = 20,
@@ -892,6 +894,7 @@ def plot_minimap(
                 "point": (pt.x, pt.y),
                 "color": c,
                 "label": pt.name,
+                "description": descriptions.get(pt.name, "") if descriptions else "",
             }
         )
 
@@ -925,6 +928,19 @@ def plot_minimap(
                     alpha=0.75,
                     clip_on=True,
                 )
+                # description as a smaller subtitle just below the name
+                if show_descriptions and entry["description"]:
+                    ax.annotate(
+                        entry["description"],
+                        xy=(x + 10, y - 10),
+                        xytext=(0, -(fontsize + 2)),
+                        textcoords="offset points",
+                        fontsize=max(6, int(round(fontsize * 0.7))),
+                        color=entry["color"],
+                        alpha=0.6,
+                        va="top",
+                        annotation_clip=True,
+                    )
 
     if show_scalebar:
         try:

--- a/fibsem/ui/widgets/autolamella_overview_image_widget.py
+++ b/fibsem/ui/widgets/autolamella_overview_image_widget.py
@@ -202,6 +202,11 @@ class OverviewImageWidget(QWidget):
         self.show_names_checkbox.setStyleSheet(CHECKBOX_STYLESHEET)
         self.show_names_checkbox.setChecked(True)
 
+        # Show descriptions checkbox (drawn as a subtitle under each name)
+        self.show_descriptions_checkbox = QCheckBox("")
+        self.show_descriptions_checkbox.setStyleSheet(CHECKBOX_STYLESHEET)
+        self.show_descriptions_checkbox.setChecked(False)
+
         # Show scalebar checkbox
         self.show_scalebar_checkbox = QCheckBox("")
         self.show_scalebar_checkbox.setStyleSheet(CHECKBOX_STYLESHEET)
@@ -213,6 +218,7 @@ class OverviewImageWidget(QWidget):
         display_layout.addRow("Text Size", self.text_size_spinbox)
         display_layout.addRow("Marker Size", self.markersize_spinbox)
         display_layout.addRow("Show Names", self.show_names_checkbox)
+        display_layout.addRow("Show Descriptions", self.show_descriptions_checkbox)
         display_layout.addRow("Show Scalebar", self.show_scalebar_checkbox)
 
         display_group = TitledPanel("Display Options", content=display_content, collapsible=False)
@@ -221,6 +227,7 @@ class OverviewImageWidget(QWidget):
         self.text_size_spinbox.valueChanged.connect(self._on_preview_clicked)
         self.markersize_spinbox.valueChanged.connect(self._on_preview_clicked)
         self.show_names_checkbox.stateChanged.connect(self._on_preview_clicked)
+        self.show_descriptions_checkbox.stateChanged.connect(self._on_preview_clicked)
         self.show_scalebar_checkbox.stateChanged.connect(self._on_preview_clicked)
         self.title_textbox.editingFinished.connect(self._on_preview_clicked)
 
@@ -561,10 +568,14 @@ class OverviewImageWidget(QWidget):
 
             # Get settings
             show_names = self.show_names_checkbox.isChecked()
+            show_descriptions = self.show_descriptions_checkbox.isChecked()
             show_scalebar = self.show_scalebar_checkbox.isChecked()
             color = self.marker_color.name()
             fontsize = self.text_size_spinbox.value()
             markersize = self.markersize_spinbox.value()
+
+            # lamella name -> free-text description, for the optional subtitle
+            descriptions = {lam.name: lam.description for lam in self.experiment.positions}
 
             if not self.stage_positions:
                 self.info_label.setText("Warning: No positions found for MILLING state")
@@ -582,6 +593,8 @@ class OverviewImageWidget(QWidget):
                 markersize=markersize,
                 show_scalebar=show_scalebar,
                 show_names=show_names,
+                show_descriptions=show_descriptions,
+                descriptions=descriptions,
                 figsize=(15, 15)
             )
 


### PR DESCRIPTION
Resolves [FIB-280](https://linear.app/fibsemos/issue/FIB-280). Follow-up to FIB-276 (#159), which added the `Lamella.description` field.

Surfaces each lamella's free-text description on the **exported overview plot** (Tools → Reporting → Generate Overview Plot), drawn as a subtitle under the position name.

### Changes
- **`plot_minimap` (`tiled.py`):** new `show_descriptions: bool` and `descriptions: Optional[Dict[str, str]]` (name → text) params. When enabled, each position's description is drawn as a smaller `ax.annotate` subtitle (~0.7× the name font, offset in points so it sits just below the name regardless of image scale), and only when the description is non-empty. `pt.name` is not overloaded (marker colour keys off it).
- **`OverviewImageWidget`:** new "Show Descriptions" toggle in Display Options (off by default). Builds a `{lamella.name: description}` map from the experiment and passes it + the toggle through to `plot_minimap`; live-updates the preview like the other display options.

### Notes
- Uses a name→description map rather than threading through `get_milling_positions` / `FibsemStagePosition`, keeping the change contained and avoiding edits to the widely-used stage-position struct.
- Targets the **export** path (`OverviewImageWidget`), not the live minimap tab.

### Testing
Verified with a `Demo`-acquired image + reprojected positions: names draw next to markers; a description renders as a smaller subtitle below its name; positions without a description get no subtitle; toggling "Show Descriptions" off removes them. Rendered a PNG and eyeballed the sizing/placement. Both files compile.
