### PR TITLE
Correlation: input marker tracks the sub-pixel click in fit diagnostics (FIB-282)

### DIFF
--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -2197,8 +2197,10 @@ class CorrelationTabWidget(QWidget):
                 method = cl._fib_method_combo.currentText()
                 if method == "Hole" and self._fib_image is not None:
                     attempted = True
+                    # pass the sub-pixel click (not int) so the diagnostic's
+                    # input marker lands where the user clicked — FIB-282.
                     xr, yr, fig = hole_fitting_FIB(
-                        self._fib_image.filtered_data, int(x), int(y)
+                        self._fib_image.filtered_data, x, y
                     )
                     fitted = PointXYZ(float(xr), float(yr), z)
             else:
@@ -2216,13 +2218,13 @@ class CorrelationTabWidget(QWidget):
                     if method == "Hole":
                         attempted = True
                         xr, yr, zr, fig = hole_fitting_reflection(
-                            img, int(x), int(y), z=int(z), cutout=2
+                            img, x, y, z=int(z), cutout=2  # sub-pixel x/y (FIB-282)
                         )
                         fitted = PointXYZ(float(xr), float(yr), float(zr))
                     elif method == "Gaussian":
                         attempted = True
                         xr, yr, zr, fig = target_fitting_fluorescence(
-                            img, int(x), int(y), int(z), cutout=5
+                            img, x, y, int(z), cutout=5  # sub-pixel x/y (FIB-282)
                         )
                         fitted = PointXYZ(float(xr), float(yr), float(zr))
         except Exception as exc:

--- a/fibsem/correlation/util.py
+++ b/fibsem/correlation/util.py
@@ -490,15 +490,15 @@ def hole_fitting_RL(img: np.ndarray,
     return xr, yr, zr, fig
 
 def hole_fitting_FIB(img: np.ndarray,
-    x: int,
-    y: int,
+    x: float,
+    y: float,
     cutout: int = 15,
     show: bool = False,
 ):
     """Refine selection of hole in FIB image.
     Args:
         img: 2D numpy array (Y,X)
-        x,y initial coordinates from the user click
+        x,y initial coordinates from the user click (may be sub-pixel)
         cutout: size of the cutout around the point in x,y
         show: show the diagnostic figure
     Returns:
@@ -507,8 +507,12 @@ def hole_fitting_FIB(img: np.ndarray,
     """
     import matplotlib.pyplot as plt
 
+    # The click may be sub-pixel; round for integer slicing but keep the
+    # fraction so the input marker is drawn exactly where the user clicked
+    # (otherwise a no-change fit shows the markers up to ~1px apart).
+    xi, yi = int(round(x)), int(round(y))
     # cut out a box around the point
-    roi = img[y-cutout:y+cutout, x-cutout:x+cutout]
+    roi = img[yi-cutout:yi+cutout, xi-cutout:xi+cutout]
     # fit a 2D gaussian to estimate the hole position
     err = None
     try:
@@ -524,8 +528,8 @@ def hole_fitting_FIB(img: np.ndarray,
         xopt, yopt = cutout, cutout
 
     # get the refined positions in the coordinates of the original image
-    xr = xopt + x - cutout
-    yr = yopt + y - cutout
+    xr = xopt + xi - cutout
+    yr = yopt + yi - cutout
 
     # clip the coordinates to the image bounds
     xr = np.clip(xr, cutout, img.shape[1] - cutout)
@@ -537,7 +541,8 @@ def hole_fitting_FIB(img: np.ndarray,
     fig, ax = plt.subplots(1, 1, figsize=(5, 5))
     fig.suptitle("FIB hole fit")
     ax.imshow(roi, cmap="gray")
-    ax.plot(cutout, cutout, "+", color=C_IN, ms=16, mew=2, label="input")
+    ax.plot(cutout + (x - xi), cutout + (y - yi), "+", color=C_IN, ms=16, mew=2,
+            label="input")
     if err is None:
         ax.plot(xopt, yopt, "+", color=C_FIT, ms=16, mew=2, label="fitted")
     else:
@@ -555,15 +560,15 @@ def hole_fitting_FIB(img: np.ndarray,
 
     return xr, yr, fig
 
-def target_fitting_fluorescence(img: np.ndarray, 
-                                x: int, y: int, z: int, 
-                                cutout: int = 5, 
-                                show: bool=False, 
+def target_fitting_fluorescence(img: np.ndarray,
+                                x: float, y: float, z: int,
+                                cutout: int = 5,
+                                show: bool=False,
                                 use_xy_fitting: bool = False) -> tuple[int, int, int, 'plt.Figure']:
     """Refine selection of target in fluorescence image.
     Args:
         img: 3D numpy array (Z,Y,X), interpolated to isotropic pixel size
-        x,y,z initial coordinates from the user click
+        x,y,z initial coordinates from the user click (x, y may be sub-pixel)
         cutout: size of the cutout around the point in x,y. z uses 3x this value
         show: show the diagnostic figure
         use_xy_fitting: whether to use xy fitting or just return the input x, y
@@ -576,12 +581,15 @@ def target_fitting_fluorescence(img: np.ndarray,
     # input (red) / fitted (green) are the only saturated colours; rest greyscale
     C_IN, C_FIT = "#e53935", "#43a047"
 
-    roi = img[:, y - cutout:y + cutout, x - cutout:x + cutout]
+    # round the (possibly sub-pixel) click for slicing; keep the fraction for
+    # the input marker so it lands exactly where the user clicked (FIB-282).
+    xc, yc = int(round(x)), int(round(y))
+    roi = img[:, yc - cutout:yc + cutout, xc - cutout:xc + cutout]
     intensity = np.mean(roi, axis=(1, 2))
     popt_z, _ = fit_guass1d(intensity)
     zi = popt_z[1]
 
-    slc_init = img[int(zi), y - cutout:y + cutout, x - cutout:x + cutout]
+    slc_init = img[int(zi), yc - cutout:yc + cutout, xc - cutout:xc + cutout]
     n = slc_init.shape[0]
     err = None
     if use_xy_fitting:
@@ -597,8 +605,8 @@ def target_fitting_fluorescence(img: np.ndarray,
             logging.warning(f"XY fit out of bounds, returning original x, y. xopt: {xopt}, yopt: {yopt}, cutout: {cutout}")
             xopt, yopt = cutout, cutout
 
-        xi = xopt + x - cutout
-        yi = yopt + y - cutout
+        xi = xopt + xc - cutout
+        yi = yopt + yc - cutout
     else:
         xi, yi = x, y
         xopt, yopt = cutout, cutout  # fit result is the cutout centre for plotting
@@ -622,7 +630,8 @@ def target_fitting_fluorescence(img: np.ndarray,
     ax_z.legend(fontsize=7, framealpha=0.6)
 
     ax_xy.imshow(slc_init, cmap="gray")
-    ax_xy.plot(cutout, cutout, "+", color=C_IN, ms=16, mew=2, label="input")
+    ax_xy.plot(cutout + (x - xc), cutout + (y - yc), "+", color=C_IN, ms=16,
+               mew=2, label="input")
     if err is not None:
         ax_xy.text(0.5, 0.08, "XY fit failed", transform=ax_xy.transAxes,
                    ha="center", va="center", color=C_IN, fontsize=10,
@@ -936,12 +945,15 @@ def hole_fitting_reflection(da, x, y, z, cutout) -> Tuple[float, float, float, '
     import matplotlib.pyplot as plt
     from scipy.ndimage import gaussian_filter
 
+    # round the (possibly sub-pixel) click for slicing; keep the fraction for
+    # the input marker so a no-change fit shows the markers coincident.
+    xi, yi = int(round(x)), int(round(y))
     zmin = 10
     zmax = 5
     zmin1 = int(z) - zmin
     zmax1 = int(z) + zmax
 
-    roi = da[zmin1:zmax1, y - cutout:y + cutout + 1, x - cutout:x + cutout + 1]
+    roi = da[zmin1:zmax1, yi - cutout:yi + cutout + 1, xi - cutout:xi + cutout + 1]
     intensity = np.mean(roi, axis=(1, 2))
     intensity = intensity.max() - intensity  # invert: the hole is dark
 
@@ -951,12 +963,12 @@ def hole_fitting_reflection(da, x, y, z, cutout) -> Tuple[float, float, float, '
 
     # xy fitting on the fitted z-slice
     xy_cutout = 15
-    roi_fitted = da[round(zreal), y - xy_cutout:y + xy_cutout + 1,
-                    x - xy_cutout:x + xy_cutout + 1]
+    roi_fitted = da[round(zreal), yi - xy_cutout:yi + xy_cutout + 1,
+                    xi - xy_cutout:xi + xy_cutout + 1]
     popt_xy, _ = fit_gauss_2d_mod(roi_fitted)
     xopt, yopt = popt_xy[1], popt_xy[2]
-    xopt_real = xopt + x - xy_cutout
-    yopt_real = yopt + y - xy_cutout
+    xopt_real = xopt + xi - xy_cutout
+    yopt_real = yopt + yi - xy_cutout
 
     # --- confirmation-friendly diagnostic ---
     # Lead with the "did it land on the feature?" view (ROI + input/fitted
@@ -992,7 +1004,8 @@ def hole_fitting_reflection(da, x, y, z, cutout) -> Tuple[float, float, float, '
 
     # XY: the hero — did it land on the feature?
     ax_xy.imshow(gaussian_filter(roi_fitted, sigma=1), cmap="gray")
-    ax_xy.plot(xy_cutout, xy_cutout, "+", color=C_IN, ms=16, mew=2, label="input")
+    ax_xy.plot(xy_cutout + (x - xi), xy_cutout + (y - yi), "+", color=C_IN, ms=16,
+               mew=2, label="input")
     if fit_in_roi:
         ax_xy.plot(xopt, yopt, "+", color=C_FIT, ms=16, mew=2, label="fitted")
     else:

--- a/tests/correlation/test_fit_diagnostics.py
+++ b/tests/correlation/test_fit_diagnostics.py
@@ -13,6 +13,7 @@ import matplotlib
 matplotlib.use("Agg")
 
 import numpy as np
+import pytest
 from matplotlib.figure import Figure
 
 from fibsem.correlation.util import (
@@ -22,9 +23,17 @@ from fibsem.correlation.util import (
 )
 
 
-def _blob_2d(size: int, cx: int, cy: int, sigma: float = 3.0) -> np.ndarray:
+def _blob_2d(size: int, cx: float, cy: float, sigma: float = 3.0) -> np.ndarray:
     yy, xx = np.mgrid[0:size, 0:size]
     return np.exp(-((xx - cx) ** 2 + (yy - cy) ** 2) / (2 * sigma**2))
+
+
+def _marker(ax, label: str):
+    """(x, y) of the diagnostic marker with the given legend label."""
+    for line in ax.lines:
+        if line.get_label() == label:
+            return float(line.get_xdata()[0]), float(line.get_ydata()[0])
+    raise AssertionError(f"no marker labelled {label!r}")
 
 
 def test_fib_hole_fit_single_panel():
@@ -63,3 +72,76 @@ def test_fluorescence_target_fit_z_and_xy_panels():
     assert np.isfinite(zr)
     assert 8 <= zr <= 12
     assert len(fig.axes) == 2
+
+
+def test_fib_input_marker_tracks_subpixel_click():
+    # FIB-282: the input marker must sit at the sub-pixel click, not the integer
+    # ROI centre — otherwise a no-change fit draws input vs fitted ~1px apart.
+    cx = 20.6
+    img = (200.0 - 160.0 * _blob_2d(40, cx, cx)).astype(np.float32)
+    xr, yr, fig = hole_fitting_FIB(img, cx, cx, cutout=15)
+
+    ix, iy = _marker(fig.axes[0], "input")
+    expected = 15 + (cx - round(cx))  # cutout + fractional click, not the centre
+    assert ix == pytest.approx(expected, abs=1e-6)
+    assert iy == pytest.approx(expected, abs=1e-6)
+
+    # the hole sits exactly on the click, so the fit shouldn't move it and the
+    # input/fitted markers should land on top of each other.
+    assert xr == pytest.approx(cx, abs=0.3)
+    fx, fy = _marker(fig.axes[0], "fitted")
+    assert abs(ix - fx) < 0.25 and abs(iy - fy) < 0.25
+
+
+def test_reflection_input_marker_tracks_subpixel_click():
+    cx = 30.6
+    nz = 21
+    vol = np.full((nz, 60, 60), 200.0, dtype=np.float32)
+    for zi in range(nz):
+        depth = np.exp(-((zi - 10) ** 2) / (2 * 2.0**2))
+        vol[zi] -= 160.0 * depth * _blob_2d(60, cx, cx)
+
+    _, _, _, fig = hole_fitting_reflection(vol, cx, cx, z=10, cutout=2)
+
+    ax_xy = fig.axes[1]  # z panel is axes[0]; the XY hero is axes[1]
+    ix, iy = _marker(ax_xy, "input")
+    expected = 15 + (cx - round(cx))  # xy_cutout is 15
+    assert ix == pytest.approx(expected, abs=1e-6)
+    assert iy == pytest.approx(expected, abs=1e-6)
+
+    fx, fy = _marker(ax_xy, "fitted")
+    assert abs(ix - fx) < 0.5 and abs(iy - fy) < 0.5
+
+
+def _fluorescence_vol(cx, nz=21, size=40):
+    vol = np.zeros((nz, size, size), dtype=np.float32)
+    for zi in range(nz):
+        bright = np.exp(-((zi - 10) ** 2) / (2 * 2.0**2))
+        vol[zi] += 200.0 * bright * _blob_2d(size, cx, cx)
+    return vol
+
+
+def test_fluorescence_input_marker_tracks_subpixel_click():
+    # Default path (no XY fitting): only the input marker is drawn, and it must
+    # still sit at the sub-pixel click rather than the integer ROI centre.
+    cx = 20.6
+    _, _, _, fig = target_fitting_fluorescence(
+        _fluorescence_vol(cx), cx, cx, z=10, cutout=5
+    )
+    ix, iy = _marker(fig.axes[1], "input")  # XY hero is axes[1]
+    expected = 5 + (cx - round(cx))  # cutout is 5
+    assert ix == pytest.approx(expected, abs=1e-6)
+    assert iy == pytest.approx(expected, abs=1e-6)
+
+
+def test_fluorescence_xy_fit_markers_coincide_at_subpixel_click():
+    # With XY fitting on, the fitted marker should land on the input marker when
+    # the target sits exactly on the (sub-pixel) click.
+    cx = 20.6
+    _, _, _, fig = target_fitting_fluorescence(
+        _fluorescence_vol(cx), cx, cx, z=10, cutout=5, use_xy_fitting=True
+    )
+    ax_xy = fig.axes[1]
+    ix, iy = _marker(ax_xy, "input")
+    fx, fy = _marker(ax_xy, "fitted")
+    assert abs(ix - fx) < 0.5 and abs(iy - fy) < 0.5


### PR DESCRIPTION
## Summary

Fixes [FIB-282](https://linear.app/fibsemos/issue/FIB-282): in the fit-confirm diagnostic, the **input marker** was drawn at the integer ROI centre while the click is a sub-pixel float that the call site truncated (`int(x)`). So a *no-change* fit showed the input and fitted markers up to ~1px apart — "you said no change, but they don't line up."

## Fix

`hole_fitting_FIB`, `hole_fitting_reflection`, and `target_fitting_fluorescence` now take the float click, **round only for slicing**, draw the input marker at the true sub-pixel position, and back-transform the fitted coordinate with the rounded index. `_run_point_fit` passes the float click (`x, y`) instead of `int(x), int(y)`.

Cosmetic / diagnostic-only — the fit maths and returned coordinates are unchanged; only the input marker's on-figure position moves.

## Verification

For a hole / target sitting exactly on a sub-pixel click, the input and fitted markers now coincide (gap ~0 px), with net Δ ≈ 0:

```
click x=100.6 : net Δx = 0.000 , marker gap = 0.000 px   (was 0.600 px)
```

## Testing

+4 regression tests pinning the input marker to the sub-pixel position (fit-quality-independent) and checking input/fitted coincidence — FIB, reflection, and fluorescence (default + `use_xy_fitting`). Mutation-verified: reverting the marker to the integer centre fails the test. 134 correlation tests pass headless (`QT_QPA_PLATFORM=offscreen`).
