### PR TITLE
Odemis FM driver: correctness, robustness, and live acquisition (FIB-285/286/287)

### DIFF
--- a/docs/design/odemis-fm-driver.md
+++ b/docs/design/odemis-fm-driver.md
@@ -1,0 +1,254 @@
+# Odemis FM Driver — Findings, Update Plan & Testing
+
+**Status:** analysis complete, implementation not started
+**Date:** 2026-07-21
+**Scope:** `fibsem/fm/odemis.py` (unchanged since PR #90), compared against `fibsem/fm/autoscript.py`, `fibsem/fm/microscope.py` (base ABCs), and the FM UI/workflow consumers.
+**Verified against:** [delmic/odemis](https://github.com/delmic/odemis) master @ `b83df59` (2026-07-20). Source references below are paths within that repo (`src/odemis/...`). Target scopes run the latest odemis (≥ 3.8, per D6), so master is the correct reference.
+
+## Context
+
+`OdemisFluorescenceMicroscope` was written alongside the original Arctis FM support and predates the workflow layer (coincident milling tasks, movement guards), the objective-control UI, and the polish applied to the ThermoFisher driver. The architecture is sound — component ABCs, live reads from hardware VAs, `MD_FAV_POS_ACTIVE/DEACTIVE` for insert/retract (the same convention odemis's own METEOR posture manager uses, `acq/move.py:1319`) — but four findings break core functionality outright and several more are safety or parity gaps.
+
+## Findings
+
+### P0 — broken functionality (confirmed)
+
+**F1. Wavelength setters always select the lowest available wavelength (unit mismatch).**
+`available_excitation_wavelengths` converts choices to nm (`odemis.py:474`), but the setter converts the incoming nm value to metres before comparing against those nm values (`odemis.py:526-528`): `abs(365 − 5.5e-7)` < `abs(635 − 5.5e-7)`, so the smallest wavelength always wins. Identical bug in the emission setter (`odemis.py:589-593`). Every `set_channel()` therefore configures the wrong filter band.
+*Verified:* stream `excitation`/`emission` VAs are `unit="m"` (`acq/stream/_live.py:1106,1112`); spectra are 5-tuples in metres, centre at index 2 (`driver/simulated.py:45-55`).
+*Fix:* build a `{nm: choice}` mapping in one pass and select by nm distance — no double conversion, and it removes the fragile two-separate-iterations-of-a-set index mapping (`exc_choices = set(...)`, `_live.py:1099`).
+
+**F2. `objective.state` is a method returning non-standard values.**
+Base + TFS define `state` as a property returning `Literal["Inserted", "Retracted", "Busy", "Error", "Other"]`; Odemis defines a *method* returning `"INSERTED"/"RETRACTED"/"UNKNOWN"` (`odemis.py:217`). Every consumer compares `fm.objective.state == "Inserted"`: workflow tasks (`mill_coincident.py:156`, `acquire_fluorescence.py:190`, `select_fluorescence_position.py:58`, `manager.py:152`), the movement guard (`fibsem/microscope.py:2101`), `FMAcquisitionWidget.py:790`, `FibsemMovementWidget.py:316`, `objective_control_widget.py:243`. On Odemis this compares a bound method to a string → always `False`: the system permanently believes the objective is retracted; coincident-milling tasks refuse to run.
+*Fix:* convert to `@property`, return the base Literal values, keep the FAV-position comparison with a ±100 µm tolerance (use `"Other"` for in-between, matching the base Literal).
+
+**F3. Camera geometry double-counts binning.**
+`_pixel_size`/`_resolution` are cached once at init (`odemis.py:272-273`) and the base properties then scale by current binning. The odemis backend already does that: `MD_PIXEL_SIZE = sensor_px × binning / magnification`, re-published live on every binning or magnification change (`odemisd/mdupdater.py:204-235` — "we compute PIXEL_SIZE every time the LENS_MAG *or* binning change"), and camera drivers rescale the `resolution` VA when binning changes (`driver/simcam.py:_setBinning` — "adapt resolution so that the AOI stays the same"). Correct only if binning happened to be 1 at init; a leftover binning from a previous session corrupts pixel size, FOV, and the stage-movement math in `acquisition.py:443`.
+*Fix:* override `pixel_size` to read `getMetadata()[MD_PIXEL_SIZE]` live and `resolution` to read `resolution.value` live, with **no** binning arithmetic. (Each read is a Pyro round-trip; if profiling ever cares, cache with invalidation via `binning.subscribe` — start with the simple correct version.)
+
+**F4. Power units: fraction vs watts.**
+`ChannelSettings.power` is a 0–1 fraction (UI shows %, `channel_settings_widget.py:104`); TFS maps it to brightness 0–1. Odemis `stream.power` is in **watts** (`FluoStream.power` inherits `unit=emitter.power.unit`; Light emitters declare `unit="W"`, `driver/simulated.py:50`). `power=0.01` means 0.01 W — wrong illumination, and because `power.clip_on_range = True` (`_live.py:1120`) out-of-range values **clip silently** rather than raise, so there's no error to notice.
+*Fix:* normalise fraction ↔ watts through `stream.power.range` in the driver (setter: `frac × range[1]`; getter returns fraction so metadata stays cross-driver comparable). See decision D1.
+
+### P1 — robustness & safety
+
+**F5. `move_absolute` ignores the user safety limit.**
+Base and TFS clip to `limit_position` (`microscope.py:170`, `autoscript.py:169-176`); Odemis calls `moveAbs` directly (`odemis.py:180-193`). The objective-limit spinbox (`objective_control_widget.py:383`) — the anti-crash-into-sample protection — has no effect on Odemis hardware. Also no pre-clip to the axis range: odemis raises `ValueError` on out-of-range moves (`model/_components.py:939-956`), surfacing as unhandled exceptions from UI values.
+
+**F6. `limits` not overridden.**
+Inherits sim constants (−12 mm, +10 mm); the objective widget uses them for spinbox ranges (`objective_control_widget.py:120`). Should be `self._focuser.axes["z"].range`.
+
+**F7. Init fragility → whole FM silently disabled.**
+`self._focus_position = self.active_position["z"]` (`odemis.py:50`) raises `TypeError` when `MD_FAV_POS_ACTIVE` is absent; `camera_md[MD_PIXEL_SIZE]` / `[MD_BASELINE]` (`odemis.py:273-274`) raise `KeyError` — **MD_BASELINE is only published by three camera drivers** (tucsen, andorcam3, simcam). Any failure is swallowed by `odemis_microscope.py:266` into `fm = None` with a log line. Use `.get()` fallbacks; only hard-fail on components that are genuinely required.
+
+**F7b. `add_odemis_path()` reads `/etc/odemis.conf` unguarded** (`odemis_microscope.py:38-58`) at import time — `FileNotFoundError` on any machine without it (dev boxes, Windows support machines), which also blocks unit-testing the driver module. Wrap in try/except and skip silently when absent. *Prerequisite for the unit-test plan.*
+
+**F8. `acquire_image` returns `None` on failure** (`odemis.py:299-301`) despite `-> np.ndarray`; the base then builds `FluorescenceImage(data=None)` and crashes far from the cause. Re-raise instead (TFS lets exceptions propagate).
+
+**F9. Emission setter crashes on `"Fluorescence"`.**
+`ChannelSettings.emission_wavelength: Optional[Union[str, float]]` — TFS-side channel files legitimately contain `"Fluorescence"`. The Odemis emission setter has no type guard, so a str hits `value *= 1e-9` → `TypeError`.
+*Fix (D3 resolved):* map str values to the emission band matching the current excitation via `odemis.util.fluo.get_one_band_em(bands, ex_band)` (`util/fluo.py:53`) — the same helper family FluoStream uses internally for its excitation↔emission guessing. Follow-up (out of scope here): expose explicit per-band emission selection to the user instead of closest-match magic.
+
+### P2 — parity gaps vs the TFS driver
+
+**F10. No live/fast acquisition path.** The base worker runs a full `acqmng.acquire()` per frame: per-frame future creation, stream activate (filter setup + light **on**), one frame, deactivate (light **off**). Seconds per frame plus LED toggling. Design below (§ Live acquisition).
+
+**F11. Camera `gain` is a silent no-op.** No override → writes land on the inherited sim `_gain`; `camera_widget.py:73` displays it and `get_metadata` records it, but hardware never changes. Wire to the camera's `gain` VA when present (`model.hasVA`), else warn-once no-op (see decision D4).
+
+**F12. Binning validation hardcoded** to `[1, 2, 4, 8]` instead of the camera's `binning.range` (simcam supports up to 16). Add `available_binnings` (powers of two within range) for TFS parity.
+
+**F13. No `exposure_time_limits`.** Available via `exposureTime.range` (FloatContinuous, `simcam.py:128`).
+
+**F14. `power_limits` is a method on Odemis (`odemis.py:414`) but a property on TFS (`autoscript.py:450`)** — the base ABC defines neither, which is why they diverged. Promote into the ABC (see decision D5).
+
+### P3 — typing & cleanup
+
+- **F15.** `parent: "Client"` forward refs on `OdemisObjectiveLens`/`OdemisCamera` (`odemis.py:32,257`) — no `Client` class exists; should be `"OdemisFluorescenceMicroscope"`.
+- **F16.** `focuser: model.Actuator = None`, `light_source: model.Emitter = None` → `Optional[...]`; `OdemisFilterSet.__init__(parent=None)` untyped; `deactive_position` missing return annotation.
+- **F17.** `available_*_wavelengths` annotated `Tuple[float, ...]` but return lists; emission list contains `None` → `List[Optional[float]]` in practice.
+- **F18.** `OdemisCamera.offset` overrides the property without a setter, killing the inherited setter (latent — nothing assigns it today).
+- **F19.** Dead code: `closest_* is None` checks after `min()` can never fire; `_excitation_wavelength = None` shadows a base attribute typed `float`.
+- **F20.** `acquire_image` actually returns `model.DataArray` (ndarray subclass carrying `.metadata`) — fine at runtime; worth using that metadata (see Phase 3).
+
+## Verified odemis behaviour (reference)
+
+| Fact | Source (delmic/odemis) |
+|---|---|
+| `excitation`/`emission` VAs in metres; excitation choices = `set(emitter.spectra.value)` of 5-tuples (centre = index 2); emission choices from filter `band` axis; `BAND_PASS_THROUGH = "pass-through"` | `acq/stream/_live.py:1096-1113`, `driver/simulated.py:45-55`, `model/_metadata.py:135` |
+| `stream.power` = per-channel `FloatContinuous`, `unit="W"`, `clip_on_range=True` (silent clip, no raise); `.range` re-slices per selected excitation channel | `acq/stream/_live.py:1116-1121, 1140-1145`; `driver/simulated.py:50` |
+| VAs only push to hardware while the stream is **active**; `_onActive(True)` runs `_setup_emission()` then `_setup_excitation()`; deactivate calls `_stop_light()` — so set-VAs-then-acquire is valid, settings land at acquisition time | `_live.py:1126-1155` |
+| `MD_PIXEL_SIZE = sensor_px × binning / mag`, live-updated on binning/mag changes; `MD_BINNING`, `MD_LENS_MAG` alongside | `odemisd/mdupdater.py:204-235` |
+| Camera `resolution` VA rescales when binning changes (AOI preserved) | `driver/simcam.py:_setBinning`; same in andorcam3 etc. |
+| `MD_BASELINE` published only by tucsen / andorcam3 / simcam | grep `driver/` |
+| `acqmng.acquire(streams)` → future → `(list[DataArray], Exception | None)` | `acq/acqmng.py:56-72` |
+| `moveAbs` raises `ValueError` outside `axes[*].range` | `model/_components.py:939-956` |
+| `MD_FAV_POS_ACTIVE/DEACTIVE` = engage/park convention, read unguarded by odemis's own METEOR posture manager (guaranteed by a correct microscope file) | `model/_metadata.py:220-221`, `acq/move.py:1319` |
+| `is_active` drives acquisition (dataflow subscribe); `should_update` is a GUI-only flag ("no direct effect") | `_base.py:180-185`, `_live.py:110-130` |
+| `LiveStream.single_frame_acquisition` VA: activate → one frame via `getSingleFrame()` → auto-deactivate | `_live.py:57,122,224` |
+| `DataFlow.get(asap=False)` returns a frame guaranteed acquired after the call | `model/_dataflow.py:340` |
+| Stream image projection throttled to ~10 Hz in a background thread (histogram + RGB compute per frame while active) | `_base.py:1064-1100` |
+
+## Live acquisition design (F10)
+
+The base worker already exposes the seam: `_acquisition_worker` checks `hasattr(self.camera, "_start_fast_acquisition")` (`fibsem/fm/microscope.py:921`) — the same hook the TFS driver uses. Implement it odemis-natively: activate the stream once, subscribe a raw-frame listener to the camera dataflow (dataflows are multi-listener), and let frames push at the exposure-limited rate.
+
+```python
+def _start_fast_acquisition(self):
+    stream = self._stream
+
+    def on_frame(dataflow, data):
+        self.parent._construct_image(data)   # emits acquisition_signal, rate-limited by base
+
+    try:
+        stream.is_active.value = True        # light on, filters set once, continuous mode
+        self._camera.data.subscribe(on_frame)
+        self.parent._stop_acquisition_event.wait()
+    finally:
+        self._camera.data.unsubscribe(on_frame)
+        stream.is_active.value = False       # light off, camera stops
+```
+
+Notes:
+- Frame pacing handled by the existing `_rate_limit` in `_construct_image`.
+- Exposure/binning VAs are writable during live; drivers apply next frame. Binning changes frame shape mid-stream — display must tolerate.
+- Frames arrive on an odemis driver thread → psygnal, same threading shape as the TFS fast path.
+- Light stays on for the whole session (fast, no LED churn; photobleaching is user-controlled via start/stop, same tradeoff as the odemis GUI).
+- **Snapshot during live:** with the stream active, `camera.data.get(asap=False)` returns a fresh frame without stopping the live stream — removes the stop/acquire/restart dance for workflows that grab stills while streaming.
+- Single-shot workflow acquisitions stay on `acqmng.acquire` (correct ordering, metadata observer, cancellable future). `single_frame_acquisition` exists but is clunkier (no future) — not worth adopting.
+- Accepted inefficiency: the active stream computes histogram + RGB projections (~10 Hz throttle) that fibsem never reads. If profiling cares, subclass `FluoStream` with a no-op `_updateImage`.
+
+## Implementation plan
+
+Ordered so each phase is a small, independently reviewable PR; P0s first. F7b lands first because the unit tests depend on it.
+
+**Phase 1 — correctness (P0): F7b, F1, F2, F3, F4**
+1. Guard `add_odemis_path()` (F7b) — unblocks unit testing.
+2. Wavelength setters: one-pass `{nm: choice}` mapping for excitation and emission; keep closest-match semantics; drop dead `is None` checks (F19 partial).
+3. `state` → property, base Literal values, ±100 µm tolerance, `"Other"` between positions.
+4. `pixel_size`/`resolution` live-read overrides (no binning arithmetic).
+5. Power fraction↔watts normalisation via `stream.power.range` (per D1).
+- *Acceptance:* unit suite below passes; a saved multi-channel `ChannelSettings` list round-trips through `set_channel` selecting the correct bands on a stubbed stream.
+
+**Phase 2 — robustness (P1): F5, F6, F7, F8, F9**
+1. `limits` from `focuser.axes["z"].range`; `move_absolute` clips to user `limit_position` **and** axis range (warn on clip, matching base behaviour).
+2. Init `.get()` fallbacks: `MD_BASELINE → 0`; missing `MD_FAV_POS_ACTIVE` → fall back to current position with a clear warning (don't kill the driver).
+3. `acquire_image` raises on failure.
+4. Emission setter: map str values via `fluo.get_one_band_em` (D3).
+
+**Phase 3 — live acquisition (P2): F10 (+ F20 metadata)**
+1. `_start_fast_acquisition` as designed above.
+2. Optional: `_construct_image` consumes `DataArray.metadata` (authoritative per-frame `MD_PIXEL_SIZE`, `MD_ACQ_DATE`, `MD_EXP_TIME`) when present.
+3. Optional: snapshot-during-live helper using `data.get(asap=False)`.
+- *Acceptance:* live view on the sim backend streams at exposure-limited rate (not seconds/frame); start/stop leaves light off and stream inactive, including on exceptions.
+
+**Phase 4 — parity & typing (P2/P3): F11–F19**
+1. Gain wiring via `model.hasVA(camera, "gain")` (per D4).
+2. `available_binnings` + `exposure_time_limits` from VA ranges; binning validation against `binning.range`.
+3. Promote `power_limits` / `exposure_time_limits` / `available_binnings` / `state` into the base ABCs with sim defaults; align TFS + Odemis (per D5).
+4. Annotation sweep (F15–F18), remove dead attributes (F19).
+
+## Testing
+
+### Unit tests (no hardware, run everywhere) — `tests/fm/test_odemis_driver.py`
+
+`fibsem.fm.odemis` imports odemis at module level, so tests inject stub modules into `sys.modules` **before** first import (fixture in `tests/fm/conftest.py`, alongside the existing sim-arctis session fixture): `odemis`, `odemis.model`, `odemis.acq`, `odemis.acq.acqmng`, `odemis.acq.stream`, `odemis.util.dataio`. Stubs needed: `FakeVA` (value/choices/range/subscribe), `model.getComponent(role=...)` returning stub focuser/ccd/light/filter, a stub `FluoStream` carrying `excitation`/`emission`/`power` VAs, `acqmng.acquire` returning a fake future. Requires F7b so importing `fibsem.microscopes.odemis_microscope` doesn't open `/etc/odemis.conf`.
+
+Cases (regression tests for each P0/P1):
+- **F1:** choices = four 5-tuples in metres → `excitation_wavelength = 635` selects the 635 nm tuple (not 365); same for emission bands; `emission_wavelength = None` → `BAND_PASS_THROUGH`; round-trip getter returns nm.
+- **F2:** position vs FAV metadata → `"Inserted"` / `"Retracted"` / `"Other"`, values ∈ base Literal; `state == "Inserted"` comparison works (property, not method).
+- **F3:** stub `MD_PIXEL_SIZE` and `resolution.value`; change binning on the stub (updating both, as the backend does) → `pixel_size`/`resolution`/`field_of_view` correct, no double count; init at binning 2 also correct.
+- **F4:** `power.range = (0, 0.4)` → `set_power(0.5)` sets 0.2 W; getter returns 0.5; metadata records the fraction.
+- **F5/F6:** `limits` == stub axis range; `move_absolute` beyond `limit_position` clips + warns; beyond axis range never reaches `moveAbs`.
+- **F7:** missing `MD_BASELINE` / `MD_FAV_POS_ACTIVE` → driver constructs, sensible fallbacks, warning logged.
+- **F8:** stub acquire failure → raises (no `None` return).
+- **F9:** `emission_wavelength = "Fluorescence"` → selects the band matching the current excitation (stub `get_one_band_em`), no `TypeError`.
+- **F10:** `_start_fast_acquisition` subscribes + activates; pushed frames emit `acquisition_signal`; setting the stop event unsubscribes + deactivates; teardown also runs when the callback raises.
+- **F11–F13:** gain maps to VA when present / warns when absent; `available_binnings` ⊆ range; `exposure_time_limits` == VA range.
+
+### Integration tests (odemis sim backend, Linux only, opt-in marker)
+
+odemis ships METEOR sim configs (`install/linux/usr/share/odemis/sim/meteor-sim.odm.yaml`, `meteor-tfs3-sim.odm.yaml`, ...). With a backend running (`odemis-start .../meteor-sim.odm.yaml`), mark tests `@pytest.mark.odemis` (skipped unless backend reachable). These exercise the *real* VA semantics and the backend-side MetadataUpdater — the things stubs can't prove:
+- set binning → `pixel_size` and `resolution` track correctly (validates F3 against the real updater);
+- excitation/emission setters land the requested band on the stream;
+- `acquire_image` returns a uint16 frame with plausible metadata;
+- insert/retract transitions `state` through the Literal values;
+- live acquisition: ≥ N frames in T seconds at a given exposure (catches any per-frame re-setup regression); light off after stop.
+
+### On-hardware checklist (METEOR)
+
+1. `odemis --version` → check out matching tag in the clone, re-verify F1/F3/F4 semantics (all long-stable core API, expected no drift).
+2. Camera model → confirms `MD_BASELINE` presence (Zyla/andorcam3 publishes it; others need the F7 fallback).
+3. Light `power.range` per channel → sanity-check the fraction→W mapping against what users expect from the odemis GUI (which displays watts — see D1).
+4. `MD_FAV_POS_ACTIVE/DEACTIVE` present in the microscope file; insert/retract from the fibsem objective widget; state chip correct at both ends and mid-travel.
+5. Objective limit spinbox actually clamps a commanded overshoot (F5).
+6. Restart-persistence: leave binning 4, restart fibsem → pixel size/FOV still correct (F3).
+7. Channel correctness: acquire each configured channel on a fluorescent test sample; confirm the expected filter wheel/LED behaviour per channel (F1).
+8. Live view: frame rate ≈ 1/exposure; exposure change applies within a frame or two; stop turns the light off; filter-wheel setup happens once at start, not per frame.
+9. FOV cross-check against a feature of known size (grid bar) — validates the full F3 pixel-size chain.
+10. Workflow smoke: coincident-milling task precondition (`state == "Inserted"`) passes with the objective inserted (F2).
+
+Per repo convention (manual GUI harnesses live outside `tests/`), add a small on-scope smoke script covering 4–8 (insert → per-channel acquire → 10 s live → snapshot-during-live → retract, printing timings) rather than pytest.
+
+## Decisions
+
+Resolved with Patrick, 2026-07-21 (D5 still open):
+
+- **D1 — power semantics. RESOLVED: fraction 0–1.** `ChannelSettings.power` stays a 0–1 fraction everywhere (UI %); the odemis driver maps fraction↔watts via `power.range`. Note the fraction re-scales if `power.range` changes per excitation channel — acceptable, since range is re-sliced per channel (`_live.py:1140-1145`).
+- **D2 — metadata honesty. RESOLVED: record the fraction.** `FluorescenceChannelMetadata.power`/`gain` record the driver-normalised fraction, not raw hardware units, for cross-driver comparability. Raw watts remain available via the odemis `DataArray.metadata` if Phase 3 adopts it.
+- **D3 — `"Fluorescence"` emission on odemis. RESOLVED: map it.** Map str values to the emission band matching the current excitation via `fluo.get_one_band_em(bands, ex_band)` (`util/fluo.py:53`). **Follow-up:** users should eventually get explicit control over emission-band selection (per-band choice in the channel UI rather than closest-match inference) — tracked as future work, not part of this update.
+- **D4 — gain without a hardware VA. RESOLVED: warn-once no-op.** Report the hardware value only when a `gain` VA exists (else omit/None in metadata) — never echo back a value that didn't reach hardware.
+- **D5 — ABC promotion timing. RESOLVED: Phase 4.** "Promotion" = adding the members the drivers invented ad-hoc (`power_limits`, `exposure_time_limits`, `available_binnings`) to the base ABCs in `fibsem/fm/microscope.py` with simulator defaults, and re-declaring `state` there so its property-ness and Literal values are enforced by the contract rather than by convention — the absence of these from the ABC is why TFS (property) and Odemis (method) drifted apart (F14). Doing it in Phase 4 keeps Phases 1–3 pure-odemis diffs. Note: the ABC also becomes the wire contract for remote control (§ below), which raises its importance.
+- **D6 — odemis version. RESOLVED: latest (≥ 3.8).** Scopes track the latest odemis, so master @ `b83df59` is the verification reference; everything cited (VA units, MetadataUpdater, FAV_POS, `clip_on_range`, `single_frame_acquisition`) is long-stable core API.
+
+## Remote control from the support PC (Phase 5, future)
+
+**Goal:** the METEOR (odemis) runs on its own Linux PC; the FIB/SEM `FibsemMicroscope` (Autoscript) runs on the Windows support PC. Support controlling the METEOR from the support PC as well as locally.
+
+### Constraints (verified)
+
+- **The odemis backend is unreachable over the network.** Its Pyro4 daemons bind to Unix domain sockets under `/var/run/odemisd` (`model/_core.py:311` — `Pyro4.Daemon.__init__(self, unixsocket=...)`). No TCP option; and odemis isn't installable on Windows anyway. → `OdemisFluorescenceMicroscope` **must** run on the Linux box; remote control means a bridge service there plus a client on Windows.
+- **The site already runs this kind of bridge — in the opposite direction.** Delmic's xtadapter runs on the Windows PC and odemis connects to it via `Pyro5.api.Proxy(f"PYRO:Microscope@{address}:{port}")` (default port 4243) with msgpack_numpy for arrays (`driver/autoscript_client.py:109,132`). We'd add the mirror-image bridge for the FM hardware. Same trust model (unauthenticated service on the private instrument LAN).
+- **odemis has no HTTP/REST layer** to piggyback on (no fastapi/flask anywhere in the tree).
+
+### Architecture: boundary at the fibsem ABC
+
+Put the network boundary at the `FluorescenceMicroscope` ABC, not at the odemis layer:
+
+- **Server (Linux):** a thin service wrapping the (fixed) `OdemisFluorescenceMicroscope`, exposing the ABC surface. Runs as a systemd unit next to odemisd (`After=odemisd`), binds to the instrument-LAN interface only.
+- **Client (Windows):** `RemoteFluorescenceMicroscope(FluorescenceMicroscope)` — a proxy implementing the same ABC by forwarding calls. Everything above the ABC (FM widgets, `acquisition.py`, autofocus, workflow tasks) works unchanged.
+- **The stage stays local.** On the support PC the stage/beams are driven by local Autoscript; only the FM components (objective, camera, light, filter) cross the network. That's exactly the ABC boundary — no split-brain stage control. (`RemoteFluorescenceMicroscope.parent` is the local Autoscript `FibsemMicroscope`, so `get_metadata()` stage positions and orientation checks are local and authoritative.)
+- This is why D5 (ABC promotion) matters beyond tidiness: **the ABC is the wire contract.**
+
+### Transport: FastAPI + one websocket (recommended)
+
+| Option | Pros | Cons |
+|---|---|---|
+| **FastAPI REST + WS** (recommended) | Self-documenting (OpenAPI), curl-debuggable, clean streaming/eventing via one WS channel, Windows client needs only `httpx` + `websockets`, team-familiar | More code than Pyro |
+| Pyro5 + msgpack_numpy (match xtadapter) | Least code; transparent object proxying; precedent on site | Push events/live frames need client-side Pyro daemon (callbacks) — clunky; version lock-step both ends |
+| gRPC | Typed contract, first-class streaming | protoc toolchain ceremony; overkill for an internal lab tool unless non-Python clients are coming |
+
+Design points:
+
+1. **Control plane vs data plane.** REST for get/set/insert/retract/`set_channel`/single acquire; one WS for live frames, acquisition-progress events, and state-change pushes. Image frames as **binary** (raw uint16 + small JSON header: dtype, shape, channel metadata) — never JSON/base64 arrays. 4512² × uint16 ≈ 40 MB/frame; with typical binning 2–4 and the existing `_rate_limit` throttle, a few fps ≈ tens of MB/s — fine on the instrument GigE LAN (comparable to the Autoscript traffic odemis already puts on the same wire).
+2. **Signals over the wire.** Server subscribes `acquisition_signal`/`acquisition_progress_signal` → WS messages; the client re-emits into local psygnal signals so widgets connect exactly as they do today.
+3. **Live mode mapping.** `start_acquisition`/`stop_acquisition` map to explicit server endpoints driving the server-side `_start_fast_acquisition` (Phase 3). Client-side loops (z-stack, autofocus in `acquisition.py`/`calibration`) run unchanged through the proxy — per-step round-trip (~2–5 ms LAN) is negligible against 50–500 ms exposures.
+4. **Chattiness.** Add a bulk `/state` endpoint (objective position + state, camera settings, filter, power) for UI polling instead of N property GETs.
+5. **Concurrency/ownership.** The odemis backend is multi-client by design (odemis GUI + CLI + our server already coexist; VAs are last-writer-wins). Start with last-writer-wins plus a visible "connected clients" indicator; add an optional soft lease only if concurrent frontends bite in practice.
+6. **Failure & safety.** Server-side watchdog: if the live-view consumer disconnects, stop acquisition (light **off**) after a short grace period — illumination must never stay on because a client vanished. Reconnect logic client-side; idempotent state reads; jobs (if any) carry IDs. No retract-on-disconnect (objective position isn't a hazard by itself; stage is local).
+7. **Serialization.** `ChannelSettings`/`ZParameters`/metadata already have `to_dict`/`from_dict` — reuse as the JSON schema. `FluorescenceImage` = binary + metadata dict.
+8. **Config & versioning.** `microscope-configuration.yaml`: `fm: {type: odemis-remote, host: ..., port: ...}` alongside the unchanged local `type: odemis`. A handshake endpoint reports fibsem + odemis versions to catch skew.
+9. **Local use goes through the same server (recommended).** The Linux PC's own fibsem-os connects to `host: localhost` — the FM server becomes the single owner of the FM session (stream activation, live-acquisition state, light state), mirroring odemis's own daemon model (odemisd owns hardware; GUI/CLI are clients). Benefits: one state machine instead of two uncoordinated stacks (an in-process driver and a remote server activating independent `FluoStream`s would fight over light/filters with no visibility); the remote path gets exercised daily on the Linux box rather than rotting until a support-PC session; and live frames **fan out** — one acquisition, N websocket subscribers, so the Linux PC and support PC can watch the same live stream simultaneously. Loopback overhead is negligible (µs round-trips; frame serialization ≈ a memcpy at a few fps). The in-process `type: odemis` path remains for development/debugging, and the server itself consumes the driver in-process.
+10. **Watchdog with multiple subscribers:** reference-count live-view subscribers; stop acquisition (light off) when the count reaches zero or the initiating client disconnects without handover — not merely when *a* client drops.
+11. **Non-goal noted:** remote desktop to the Linux box is the zero-code alternative but doesn't give single-UI operation with the FIB on the support PC — which is the point.
+
+### Extensibility to other devices
+
+The server is **driver-agnostic by construction**: it wraps the `FluorescenceMicroscope` ABC, not the odemis driver. Any concrete implementation — a future non-odemis FM, a pymmcore/Micro-Manager-backed system, the simulator — can sit behind the identical server on whatever PC hosts its control software; the client proxy and config (`fm: {type: fm-remote, host, port}`) don't change, and the handshake reports what's behind the server. Extending to a new FM = write the driver (needed anyway) + define its safe-state action for the watchdog. A simulated FM behind the server doubles as a network-testable fake device.
+
+For a different *kind* of device (non-FM), the same pattern applies but needs its own ABC written to the "remotable contract" rules the FM ABC (post-Phase 4) demonstrates: serializable arguments/returns (`to_dict` dataclasses, arrays, primitives — no live object handles over the wire); coarse-grained operations over property-twiddling; signals declared at the ABC level so the proxy can re-emit; explicit start/stop lifecycle for long-running work; and cross-device references resolved locally (the `parent`/stage pattern), never remoted. The transport/framing/watchdog/handshake infrastructure should be kept separable from the FM-specific surface so it can be reused — but don't build a generic device-server framework up front; extract the shared core when a second device type actually arrives.
+
+### Testing (remote tier)
+
+- Loopback: server + `RemoteFluorescenceMicroscope` on one machine over the stubbed driver — proxy fidelity per ABC member (the Phase 4 ABC contract doubles as the conformance checklist; run the same unit suite against the remote proxy).
+- Sim-backend over a real network hop: live view fps, frame integrity (dtype/shape/metadata round-trip).
+- Disconnect drills: kill the client mid-live → light off within the grace period; kill the server mid-workflow → client raises cleanly, UI recovers on reconnect.

--- a/fibsem/fm/odemis.py
+++ b/fibsem/fm/odemis.py
@@ -2,7 +2,7 @@ import numpy as np
 import logging
 import time
 
-from typing import List, Optional, Tuple
+from typing import Dict, List, Literal, Optional, Tuple, Union
 from fibsem.fm.microscope import (
     Camera,
     FilterSet,
@@ -19,6 +19,9 @@ from odemis.acq.acqmng import acquire
 from odemis.acq.stream import FluoStream
 
 # NOTES: needed to install shapely, pylibtiff, and odemis
+
+# position tolerance for deciding the objective is at the active/deactive position
+OBJECTIVE_POSITION_ATOL = 100e-6  # m
 
 
 class OdemisObjectiveLens(ObjectiveLens):
@@ -214,36 +217,36 @@ class OdemisObjectiveLens(ObjectiveLens):
             f = self._focuser.moveAbs(deactive_position)
             f.result()
 
-    def state(self) -> str:
+    @property
+    def state(self) -> Literal["Inserted", "Retracted", "Busy", "Error", "Other"]:
         """Get the current state of the objective lens.
 
-        Determines the lens state by comparing the current position with
-        the cached active and deactive positions.
+        Determines the lens state by comparing the current position with the
+        favourite active/deactive positions (within OBJECTIVE_POSITION_ATOL).
 
         Returns:
-            The lens state: 'INSERTED', 'RETRACTED', or 'UNKNOWN'
-
-        Note:
-            Returns 'UNKNOWN' if position data is unavailable or if the
-            lens is between the active and deactive positions.
+            'Inserted' or 'Retracted' when at the corresponding favourite
+            position, 'Other' when in between or if the favourite positions
+            are unavailable, and 'Error' if the state cannot be read.
+            Values match the FluorescenceMicroscope base contract
+            (consumers compare against 'Inserted'/'Retracted').
         """
         try:
-            position = self._focuser.position.value
+            position = self._focuser.position.value["z"]
             active_position = self.active_position
             deactive_position = self.deactive_position
 
             if active_position is None or deactive_position is None:
-                return "UNKNOWN"
+                return "Other"
 
-            if position["z"] > active_position["z"] - 100e-6:
-                return "INSERTED"
-            elif position["z"] < deactive_position["z"]:
-                return "RETRACTED"
-            else:
-                return "UNKNOWN"
+            if position > active_position["z"] - OBJECTIVE_POSITION_ATOL:
+                return "Inserted"
+            if position < deactive_position["z"] + OBJECTIVE_POSITION_ATOL:
+                return "Retracted"
+            return "Other"
         except Exception as e:
             logging.error(f"Failed to get objective lens state: {e}")
-            return "UNKNOWN"
+            return "Error"
 
 
 class OdemisCamera(Camera):
@@ -269,8 +272,9 @@ class OdemisCamera(Camera):
             camera: model.DigitalCamera = model.getComponent(role="ccd")
         self._camera = camera
         camera_md = self._camera.getMetadata()
-        self._resolution = self._camera.resolution.value  # (width, height)
-        self._pixel_size = camera_md[model.MD_PIXEL_SIZE]  # (x, y) sensor pixel size
+        # fallback values only: pixel_size/resolution are read live (see properties)
+        self._resolution = tuple(self._camera.resolution.value)  # (width, height)
+        self._pixel_size = tuple(camera_md[model.MD_PIXEL_SIZE])  # (x, y) sample-plane
         self._offset = camera_md[model.MD_BASELINE]  # offset for the camera
 
     # other attributes: depthOfField, readoutRate, pointSpreadFunctionSize
@@ -354,6 +358,31 @@ class OdemisCamera(Camera):
         self._camera.binning.value = (value, value)
 
     @property
+    def pixel_size(self) -> Tuple[float, float]:
+        """Get the sample-plane pixel size in metres, read live from camera metadata.
+
+        The odemis backend computes MD_PIXEL_SIZE = sensor pixel size x binning
+        / magnification and republishes it whenever binning or magnification
+        change, so no binning scaling is applied here (unlike the base class).
+        """
+        try:
+            return tuple(self._camera.getMetadata()[model.MD_PIXEL_SIZE])
+        except Exception as e:
+            logging.warning(
+                f"Failed to read pixel size from camera metadata, using cached value: {e}"
+            )
+            return tuple(self._pixel_size)
+
+    @property
+    def resolution(self) -> Tuple[int, int]:
+        """Get the current readout resolution in pixels, read live from the camera.
+
+        The odemis resolution VA already accounts for binning, so no binning
+        scaling is applied here (unlike the base class).
+        """
+        return tuple(self._camera.resolution.value)
+
+    @property
     def offset(self) -> float:
         """Get the baseline offset of the camera.
 
@@ -390,26 +419,38 @@ class OdemisLightSource(LightSource):
 
     @property
     def power(self) -> float:
-        """Get the current power of the light source.
+        """Get the current power of the light source as a fraction (0-1) of maximum.
+
+        The odemis stream power is in watts; it is normalised against the
+        stream power range so ChannelSettings.power keeps identical semantics
+        across drivers (fraction of maximum power, displayed as % in the UI).
 
         Returns:
-            The power level as a float (units depend on light source configuration)
+            The power level as a fraction of maximum power (0.0-1.0)
         """
-        return self._stream.power.value
+        max_power = self._stream.power.range[1]
+        if max_power <= 0:
+            return 0.0
+        return self._stream.power.value / max_power
 
     @power.setter
     def power(self, value: float):
-        """Set the power of the light source.
+        """Set the power of the light source as a fraction (0-1) of maximum.
 
         Args:
-            value: The power level to set (must be numeric)
+            value: The power level as a fraction of maximum power (0.0-1.0).
+                   Values outside [0, 1] are clipped with a warning.
 
         Raises:
             TypeError: If the value is not a number
         """
         if not isinstance(value, (int, float)):
             raise TypeError("Power must be an integer or float.")
-        self._stream.power.value = value
+        if not 0.0 <= value <= 1.0:
+            logging.warning(f"Power fraction {value} outside [0, 1], clipping.")
+            value = min(max(value, 0.0), 1.0)
+        max_power = self._stream.power.range[1]
+        self._stream.power.value = value * max_power
 
     def power_limits(self) -> Tuple[float, float]:
         """Get the valid power range for the light source.
@@ -463,19 +504,42 @@ class OdemisFilterSet(FilterSet):
     # None -> reflection
 
     @property
+    def _excitation_choices_by_nm(self) -> Dict[float, tuple]:
+        """Map centre wavelength (nm) -> excitation choice (5-tuple, in metres).
+
+        Built in a single pass over the stream choices so selection and
+        assignment always refer to the same choice object (the underlying
+        VA choices are an unordered set).
+        """
+        return {c[2] * 1e9: c for c in self._stream.excitation.choices}
+
+    @property
+    def _emission_choices_by_nm(self) -> Dict[Optional[float], Union[tuple, str]]:
+        """Map bottom wavelength (nm) -> emission choice (2-tuple, in metres).
+
+        The pass-through (reflection) choice is keyed as None.
+        """
+        mapping: Dict[Optional[float], Union[tuple, str]] = {}
+        for c in self._stream.emission.choices:
+            # special case for pass-through (reflection -> None)
+            if isinstance(c, str) and c == model.BAND_PASS_THROUGH:
+                mapping[None] = c
+                continue
+            mapping[c[0] * 1e9] = c  # convert from m to nm
+        return mapping
+
+    @property
     def available_excitation_wavelengths(self) -> Tuple[float, ...]:
         """Get the available excitation wavelengths for the filter set.
 
         Returns:
-            A tuple of available excitation wavelengths in nanometers
-            (converted from Odemis internal meter units)
+            A tuple of available centre excitation wavelengths in nanometers
+            (converted from Odemis internal metre units)
         """
-        return [
-            c[2] * 1e9 for c in self._stream.excitation.choices
-        ]  # centre wavelengths
+        return tuple(self._excitation_choices_by_nm.keys())
 
     @property
-    def available_emission_wavelengths(self) -> Tuple[float, ...]:
+    def available_emission_wavelengths(self) -> Tuple[Optional[float], ...]:
         """Get the available emission wavelengths for the filter set.
 
         Returns:
@@ -485,15 +549,7 @@ class OdemisFilterSet(FilterSet):
         Note:
             Returns the bottom wavelength of each emission filter range.
         """
-        choices = []
-        # return the bottom wavelength of each emission choice
-        for c in self._stream.emission.choices:
-            # special case for pass-through (reflection -> None)
-            if isinstance(c, str) and c == model.BAND_PASS_THROUGH:
-                choices.append(None)
-                continue
-            choices.append(c[0] * 1e9)  # convert from m to nm
-        return choices
+        return tuple(self._emission_choices_by_nm.keys())
 
     @property
     def excitation_wavelength(self) -> float:
@@ -514,7 +570,7 @@ class OdemisFilterSet(FilterSet):
 
         Raises:
             TypeError: If the value is not a number
-            ValueError: If no suitable wavelength is available
+            ValueError: If no excitation wavelengths are available
 
         Note:
             Automatically selects the closest available wavelength if an
@@ -523,23 +579,17 @@ class OdemisFilterSet(FilterSet):
         if not isinstance(value, (int, float)):
             raise TypeError("Excitation wavelength must be an integer or float.")
 
-        value *= 1e-9
-        closest_excitation = min(
-            self.available_excitation_wavelengths, key=lambda x: abs(x - value)
-        )
-        if closest_excitation is None:
-            raise ValueError(
-                f"Excitation wavelength {value} is not available. Available wavelengths: {self.available_excitation_wavelengths}"
-            )
+        choices_by_nm = self._excitation_choices_by_nm
+        if not choices_by_nm:
+            raise ValueError("No excitation wavelengths available.")
 
-        # find the index of the closest excitation wavelength
-        idx = self.available_excitation_wavelengths.index(closest_excitation)
-        choices = tuple(self._stream.excitation.choices)
-
+        closest_nm = min(choices_by_nm, key=lambda nm: abs(nm - value))
+        choice = choices_by_nm[closest_nm]
         logging.info(
-            f"Setting excitation wavelength to index: {idx}, value: {choices[idx]}, requested: {value}"
+            f"Setting excitation wavelength to {closest_nm:.0f} nm "
+            f"(requested: {value} nm, band: {choice})"
         )
-        self._stream.excitation.value = choices[idx]
+        self._stream.excitation.value = choice
 
     @property
     def emission_wavelength(self) -> Optional[float]:
@@ -566,6 +616,7 @@ class OdemisFilterSet(FilterSet):
                   for reflection/pass-through mode
 
         Raises:
+            TypeError: If the value is not a number or None
             ValueError: If the requested wavelength or pass-through mode
                        is not available
 
@@ -574,37 +625,36 @@ class OdemisFilterSet(FilterSet):
             Automatically selects the closest available wavelength.
             Performance note: Setting emission wavelength can be slow.
         """
+        choices_by_nm = self._emission_choices_by_nm
 
         # None means reflection, so we set the emission to pass-through (reflection)
         if value is None:
-            choices = tuple(self._stream.emission.choices)
-            if model.BAND_PASS_THROUGH not in choices:
+            if None not in choices_by_nm:
                 raise ValueError(
-                    f"Pass-through (reflection) is not available in the current filter set. Available choices: {choices}"
+                    f"Pass-through (reflection) is not available in the current "
+                    f"filter set. Available: {tuple(choices_by_nm.keys())}"
                 )
-            self._stream.emission.value = model.BAND_PASS_THROUGH
+            self._stream.emission.value = choices_by_nm[None]
             return
 
-        # filter out None values from available wavelengths
-        value *= 1e-9  # convert from nm to m
-        available_wavelengths = [
-            wl for wl in self.available_emission_wavelengths if wl is not None
-        ]
-        closest_emission = min(available_wavelengths, key=lambda x: abs(x - value))
-        if closest_emission is None:
-            raise ValueError(
-                f"Emission wavelength {value} is not available. Available wavelengths: {self.available_emission_wavelengths}"
-            )
+        if not isinstance(value, (int, float)):
+            # str values (e.g. 'Fluorescence' from TFS channel files) are not
+            # supported yet -- see FIB-286 (map via fluo.get_one_band_em)
+            raise TypeError("Emission wavelength must be a number or None.")
 
-        # TODO: only set the emission wavelength if it is different from the current value, it's slow to set it
+        numeric = {nm: c for nm, c in choices_by_nm.items() if nm is not None}
+        if not numeric:
+            raise ValueError("No emission wavelengths available.")
 
-        # find the index of the closest emission wavelength
-        idx = self.available_emission_wavelengths.index(closest_emission)
-        choices = tuple(self._stream.emission.choices)
+        closest_nm = min(numeric, key=lambda nm: abs(nm - value))
+        choice = numeric[closest_nm]
+        if self._stream.emission.value == choice:
+            return  # setting the emission filter is slow, skip if unchanged
         logging.info(
-            f"Setting emission wavelength to index: {idx}, value: {choices[idx]}, requested: {value}"
+            f"Setting emission wavelength to {closest_nm:.0f} nm "
+            f"(requested: {value} nm, band: {choice})"
         )
-        self._stream.emission.value = choices[idx]
+        self._stream.emission.value = choice
 
 
 class OdemisFluorescenceMicroscope(FluorescenceMicroscope):

--- a/fibsem/fm/odemis.py
+++ b/fibsem/fm/odemis.py
@@ -17,6 +17,7 @@ add_odemis_path()
 from odemis import model
 from odemis.acq.acqmng import acquire
 from odemis.acq.stream import FluoStream
+from odemis.util import fluo
 
 # NOTES: needed to install shapely, pylibtiff, and odemis
 
@@ -50,7 +51,18 @@ class OdemisObjectiveLens(ObjectiveLens):
         # Cache metadata on initialization
         self._metadata_cache = {}
         self._cache_metadata()
-        self._focus_position = self.active_position["z"]
+
+        active_position = self.active_position
+        if active_position is not None:
+            self._focus_position = active_position["z"]
+        else:
+            self._focus_position = self.position
+            logging.warning(
+                "Focuser has no active-position metadata; using the current "
+                f"position ({self._focus_position * 1e3:.3f} mm) as the focus position."
+            )
+        # default user limit: no restriction beyond the hardware range
+        self._limit_position = self.limits[1]
 
     def _cache_metadata(self):
         """Cache frequently accessed metadata for improved performance.
@@ -180,17 +192,44 @@ class OdemisObjectiveLens(ObjectiveLens):
         f = self._focuser.moveRel({"z": delta})
         f.result()
 
+    @property
+    def limits(self) -> Tuple[float, float]:
+        """Get the z-axis position limits of the objective lens.
+
+        Returns:
+            A tuple of (minimum, maximum) positions in metres, from the
+            focuser axis range.
+        """
+        rng = self._focuser.axes["z"].range
+        return (rng[0], rng[1])
+
     def move_absolute(self, position: float):
         """Move the objective lens to an absolute focus position.
+
+        The position is clipped to the user-defined safety limit and
+        validated against the focuser axis range before moving (odemis
+        raises ValueError for out-of-range moves).
 
         Args:
             position: The target z-axis position in meters
 
         Raises:
             TypeError: If position is not a number
+            ValueError: If the position is outside the focuser axis range
         """
         if not isinstance(position, (int, float)):
             raise TypeError("Position must be an integer or float.")
+
+        # clip to the user-defined safety limit
+        if position > self._limit_position:
+            logging.warning(
+                f"Clipping position {position} to user-defined limit {self._limit_position}"
+            )
+            position = self._limit_position
+
+        limits = self.limits
+        if not limits[0] <= position <= limits[1]:
+            raise ValueError(f"Position {position} outside focuser range {limits}")
 
         f = self._focuser.moveAbs({"z": position})
         f.result()
@@ -199,23 +238,31 @@ class OdemisObjectiveLens(ObjectiveLens):
         """Move the objective lens to the active (inserted) position.
 
         Moves the objective lens to the predefined active position for imaging.
-        Uses cached position data when available for improved performance.
+        The favourite active position is calibrated (Delmic), so the user
+        safety limit is not applied here.
         """
         active_position = self.active_position
-        if active_position is not None:
-            f = self._focuser.moveAbs(active_position)
-            f.result()
+        if active_position is None:
+            logging.warning(
+                "Cannot insert objective: no active-position metadata available."
+            )
+            return
+        f = self._focuser.moveAbs(active_position)
+        f.result()
 
     def retract(self):
         """Move the objective lens to the deactive (retracted) position.
 
         Moves the objective lens to the predefined deactive position for safety.
-        Uses cached position data when available for improved performance.
         """
         deactive_position = self.deactive_position
-        if deactive_position is not None:
-            f = self._focuser.moveAbs(deactive_position)
-            f.result()
+        if deactive_position is None:
+            logging.warning(
+                "Cannot retract objective: no deactive-position metadata available."
+            )
+            return
+        f = self._focuser.moveAbs(deactive_position)
+        f.result()
 
     @property
     def state(self) -> Literal["Inserted", "Retracted", "Busy", "Error", "Other"]:
@@ -274,8 +321,20 @@ class OdemisCamera(Camera):
         camera_md = self._camera.getMetadata()
         # fallback values only: pixel_size/resolution are read live (see properties)
         self._resolution = tuple(self._camera.resolution.value)  # (width, height)
-        self._pixel_size = tuple(camera_md[model.MD_PIXEL_SIZE])  # (x, y) sample-plane
-        self._offset = camera_md[model.MD_BASELINE]  # offset for the camera
+
+        pixel_size = camera_md.get(model.MD_PIXEL_SIZE)  # (x, y) sample-plane
+        if pixel_size is None:
+            # no lens/magnification wiring in the microscope file
+            pixel_size = self._camera.pixelSize.value  # sensor pixel size
+            logging.warning(
+                "Camera metadata has no MD_PIXEL_SIZE; falling back to the "
+                f"sensor pixel size {pixel_size} - image scale will not "
+                "account for magnification."
+            )
+        self._pixel_size = tuple(pixel_size)
+
+        # not all cameras publish a baseline (only some drivers set MD_BASELINE)
+        self._offset = camera_md.get(model.MD_BASELINE, 0)
 
     # other attributes: depthOfField, readoutRate, pointSpreadFunctionSize
 
@@ -286,23 +345,24 @@ class OdemisCamera(Camera):
         the configured fluorescence stream with current camera settings.
 
         Returns:
-            A numpy array containing the image data, or None if acquisition fails
+            A numpy array containing the image data
+
+        Raises:
+            RuntimeError: If the acquisition fails or returns no data
 
         Note:
             May show timing warnings if rapid successive acquisitions are attempted.
             Consider checking if acquisition is already in progress before calling.
         """
         da: List[model.DataArray]
-        try:
-            # May show timing warnings for rapid successive acquisitions
-            # TODO: Check if acquisition is already in progress
-            f = acquire([self._stream])
-            da, err = f.result()
-            if err:
-                raise RuntimeError(f"Error acquiring image: {err}")
-        except Exception as e:
-            logging.warning(f"Error acquiring image: {e}")
-            return None
+        # May show timing warnings for rapid successive acquisitions
+        # TODO: Check if acquisition is already in progress
+        f = acquire([self._stream])
+        da, err = f.result()
+        if err:
+            raise RuntimeError(f"Error acquiring image: {err}")
+        if not da:
+            raise RuntimeError("Acquisition returned no data.")
         return da[0]  # model.DataArray -> np.ndarray
 
     # QUERY: migrate to using the camera dataflow interface?
@@ -366,12 +426,15 @@ class OdemisCamera(Camera):
         change, so no binning scaling is applied here (unlike the base class).
         """
         try:
-            return tuple(self._camera.getMetadata()[model.MD_PIXEL_SIZE])
+            pixel_size = self._camera.getMetadata().get(model.MD_PIXEL_SIZE)
         except Exception as e:
             logging.warning(
-                f"Failed to read pixel size from camera metadata, using cached value: {e}"
+                f"Failed to read camera metadata, using cached pixel size: {e}"
             )
             return tuple(self._pixel_size)
+        if pixel_size is None:
+            return tuple(self._pixel_size)  # missing key already warned at init
+        return tuple(pixel_size)
 
     @property
     def resolution(self) -> Tuple[int, int]:
@@ -637,10 +700,23 @@ class OdemisFilterSet(FilterSet):
             self._stream.emission.value = choices_by_nm[None]
             return
 
+        if isinstance(value, str):
+            # TFS-style channel settings use 'Fluorescence' for multi-band
+            # emission; pick the band matching the current excitation
+            bands = {c for nm, c in choices_by_nm.items() if nm is not None}
+            if not bands:
+                raise ValueError("No emission bands available for fluorescence mode.")
+            choice = fluo.get_one_band_em(bands, self._stream.excitation.value)
+            if self._stream.emission.value != choice:
+                logging.info(
+                    f"Mapping emission '{value}' to band {choice} for the "
+                    f"current excitation"
+                )
+                self._stream.emission.value = choice
+            return
+
         if not isinstance(value, (int, float)):
-            # str values (e.g. 'Fluorescence' from TFS channel files) are not
-            # supported yet -- see FIB-286 (map via fluo.get_one_band_em)
-            raise TypeError("Emission wavelength must be a number or None.")
+            raise TypeError("Emission wavelength must be a number, str, or None.")
 
         numeric = {nm: c for nm, c in choices_by_nm.items() if nm is not None}
         if not numeric:

--- a/fibsem/fm/odemis.py
+++ b/fibsem/fm/odemis.py
@@ -341,22 +341,22 @@ class OdemisCamera(Camera):
     def acquire_image(self) -> np.ndarray:
         """Acquire a single image from the camera.
 
-        Uses the Odemis acquisition manager to capture an image through
-        the configured fluorescence stream with current camera settings.
+        While live acquisition is running (the stream is active), a fresh
+        frame is taken from the camera dataflow without stopping the stream
+        (the light stays on). Otherwise a full acquisition is run through
+        the Odemis acquisition manager.
 
         Returns:
             A numpy array containing the image data
 
         Raises:
             RuntimeError: If the acquisition fails or returns no data
-
-        Note:
-            May show timing warnings if rapid successive acquisitions are attempted.
-            Consider checking if acquisition is already in progress before calling.
         """
+        if self._stream.is_active.value:
+            # asap=False guarantees the frame is acquired after this call
+            return self._camera.data.get(asap=False)
+
         da: List[model.DataArray]
-        # May show timing warnings for rapid successive acquisitions
-        # TODO: Check if acquisition is already in progress
         f = acquire([self._stream])
         da, err = f.result()
         if err:
@@ -365,8 +365,41 @@ class OdemisCamera(Camera):
             raise RuntimeError("Acquisition returned no data.")
         return da[0]  # model.DataArray -> np.ndarray
 
-    # QUERY: migrate to using the camera dataflow interface?
-    # .camera._camera.data.get()
+    def _start_fast_acquisition(self):
+        """Continuous live acquisition via the odemis camera dataflow.
+
+        Activates the fluorescence stream once (light on, filters set,
+        camera in continuous mode) and subscribes a listener to the camera
+        dataflow, so frames are pushed at the exposure-limited rate instead
+        of paying a full acquisition round-trip (with light toggling) per
+        frame. Blocks until stop_acquisition() sets the stop event; called
+        by the base _acquisition_worker from the acquisition thread.
+
+        The stream is always deactivated (light off) on exit, even if the
+        frame handler or unsubscribe fails.
+        """
+
+        def on_frame(dataflow, data):
+            try:
+                # emits acquisition_signal, rate-limited by the base class
+                self.parent._construct_image(data)
+            except Exception as e:
+                logging.error(f"Error handling live frame: {e}")
+
+        stream = self._stream
+        try:
+            stream.is_active.value = True  # light on, filters set, streaming
+            self._camera.data.subscribe(on_frame)
+            self.parent._stop_acquisition_event.wait()
+        finally:
+            try:
+                self._camera.data.unsubscribe(on_frame)
+            except Exception as e:
+                logging.warning(f"Failed to unsubscribe live-view listener: {e}")
+            try:
+                stream.is_active.value = False  # light off, camera stopped
+            except Exception as e:
+                logging.error(f"Failed to deactivate stream after live view: {e}")
 
     @property
     def exposure_time(self) -> float:

--- a/fibsem/microscopes/odemis_microscope.py
+++ b/fibsem/microscopes/odemis_microscope.py
@@ -35,8 +35,13 @@ from fibsem.structures import (
 )
 
 
-def add_odemis_path():
-    """Add the odemis path to the python path"""
+def add_odemis_path(config_path: str = "/etc/odemis.conf"):
+    """Add the odemis path to the python path.
+
+    Safe to call on machines without an odemis installation (no config file,
+    or a config without DEVPATH): it simply leaves sys.path unchanged so the
+    subsequent `import odemis` fails with a regular ImportError.
+    """
 
     def parse_config(path) -> dict:
         """Parse the odemis config file and return a dict with the config values"""
@@ -51,9 +56,15 @@ def add_odemis_path():
         }
         return config
 
-    odemis_path = "/etc/odemis.conf"
-    config = parse_config(odemis_path)
-    sys.path.append(f"{config['DEVPATH']}/odemis/src")  # dev version
+    try:
+        config = parse_config(config_path)
+    except Exception as e:
+        logging.debug(f"Odemis config not available at {config_path}: {e}")
+        return
+
+    devpath = config.get("DEVPATH")
+    if devpath:
+        sys.path.append(f"{devpath}/odemis/src")  # dev version
     sys.path.append("/usr/lib/python3/dist-packages")  # release version + pyro4
 
 

--- a/tests/fm/_odemis_stubs.py
+++ b/tests/fm/_odemis_stubs.py
@@ -35,6 +35,7 @@ ODEMIS_MODULE_NAMES = (
     "odemis.acq.stream",
     "odemis.util",
     "odemis.util.dataio",
+    "odemis.util.fluo",
 )
 
 # fibsem modules bound to the odemis import; must be re-imported against stubs
@@ -156,12 +157,14 @@ class FakeCamera:
         resolution: tuple = (2048, 2048),
         pixel_size: tuple = (1e-7, 1e-7),
         baseline: int = 100,
+        sensor_pixel_size: tuple = (6.5e-6, 6.5e-6),
     ):
         self.resolution = FakeVA(tuple(resolution))
         self.exposureTime = FakeVA(0.1, range=(1e-3, 10.0), unit="s")
         self.binning = FakeVA(
             (1, 1), range=((1, 1), (16, 16)), setter=self._on_binning
         )
+        self.pixelSize = FakeVA(tuple(sensor_pixel_size), unit="m")  # sensor
         self._metadata = {
             MD_PIXEL_SIZE: tuple(pixel_size),
             MD_BASELINE: baseline,
@@ -238,6 +241,29 @@ def fake_acquire(streams, settings_obs=None):
     return FakeFuture(([data], None))
 
 
+def _band_center(band) -> float:
+    """Centre of a 2-tuple (mean) or 5-tuple (index 2) band, like odemis fluo.get_center."""
+    if len(band) == 5:
+        return band[2]
+    return sum(band) / len(band)
+
+
+def fake_get_one_band_em(bands, ex_band):
+    """odemis.util.fluo.get_one_band_em stand-in.
+
+    Faithful to the real logic: pick the band whose centre is closest above
+    the excitation centre; fall back to the highest band if none is above.
+    """
+    if isinstance(bands, str):
+        return bands
+    ex_center = 1e9 if isinstance(ex_band, str) else _band_center(ex_band)
+    centers = {tuple(b): _band_center(b) for b in bands}
+    above = [b for b, c in centers.items() if c > ex_center]
+    if above:
+        return min(above, key=centers.get)
+    return max(centers, key=centers.get)
+
+
 def default_components() -> Dict[str, object]:
     """Fresh set of stub hardware components keyed by odemis role."""
     return {
@@ -300,12 +326,17 @@ def install_odemis_stubs() -> None:
     dataio_mod = types.ModuleType("odemis.util.dataio")
     dataio_mod.open_acquisition = lambda path: []
 
+    fluo_mod = types.ModuleType("odemis.util.fluo")
+    fluo_mod.get_one_band_em = fake_get_one_band_em
+    fluo_mod.get_center = _band_center
+
     odemis_pkg.model = model_mod
     odemis_pkg.acq = acq_pkg
     odemis_pkg.util = util_pkg
     acq_pkg.acqmng = acqmng_mod
     acq_pkg.stream = stream_mod
     util_pkg.dataio = dataio_mod
+    util_pkg.fluo = fluo_mod
 
     modules = {
         "odemis": odemis_pkg,
@@ -315,6 +346,7 @@ def install_odemis_stubs() -> None:
         "odemis.acq.stream": stream_mod,
         "odemis.util": util_pkg,
         "odemis.util.dataio": dataio_mod,
+        "odemis.util.fluo": fluo_mod,
     }
     sys.modules.update(modules)
 

--- a/tests/fm/_odemis_stubs.py
+++ b/tests/fm/_odemis_stubs.py
@@ -1,0 +1,325 @@
+"""Stub odemis modules so fibsem.fm.odemis can be imported and unit-tested
+without an odemis installation or a running backend.
+
+Install with install_odemis_stubs() BEFORE importing fibsem.fm.odemis (or
+fibsem.microscopes.odemis_microscope). The stubs mimic the odemis conventions
+that matter to the driver:
+
+- excitation/emission/power stream VAs in SI units (bands in metres, power in
+  watts), choices as unordered sets
+- MD_PIXEL_SIZE includes binning (the backend recomputes it on binning change)
+- the camera resolution VA rescales when binning changes (AOI preserved)
+- focuser favourite positions via MD_FAV_POS_ACTIVE/DEACTIVE
+
+See docs/design/odemis-fm-driver.md for the verified behaviour these model.
+"""
+
+import sys
+import types
+from typing import Dict, Optional
+
+import numpy as np
+
+# metadata keys: only identity/equality matters, values mirror odemis for clarity
+MD_PIXEL_SIZE = "Pixel size"
+MD_BASELINE = "Baseline value"
+MD_FAV_POS_ACTIVE = "Favourite position active"
+MD_FAV_POS_DEACTIVE = "Favourite position deactive"
+BAND_PASS_THROUGH = "pass-through"
+
+ODEMIS_MODULE_NAMES = (
+    "odemis",
+    "odemis.model",
+    "odemis.acq",
+    "odemis.acq.acqmng",
+    "odemis.acq.stream",
+    "odemis.util",
+    "odemis.util.dataio",
+)
+
+# fibsem modules bound to the odemis import; must be re-imported against stubs
+FIBSEM_ODEMIS_MODULE_NAMES = (
+    "fibsem.fm.odemis",
+    "fibsem.microscopes.odemis_microscope",
+)
+
+
+def band_ex(centre_nm: float) -> tuple:
+    """Excitation band 5-tuple in metres (99%low, 25%low, centre, 25%high, 99%high)."""
+    c = centre_nm * 1e-9
+    return (c - 10e-9, c - 5e-9, c, c + 5e-9, c + 10e-9)
+
+
+def band_em(bottom_nm: float, width_nm: float = 50.0) -> tuple:
+    """Emission band 2-tuple in metres (bottom, top)."""
+    b = bottom_nm * 1e-9
+    return (b, b + width_nm * 1e-9)
+
+
+class FakeVA:
+    """Minimal odemis VigilantAttribute stand-in with an optional setter hook."""
+
+    def __init__(self, value, choices=None, range=None, unit=None, setter=None):
+        self.choices = choices
+        self.range = range
+        self.unit = unit
+        self._setter = setter
+        self._value = value
+        self.set_count = 0  # number of assignments, for skip-if-unchanged tests
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, new_value):
+        self.set_count += 1
+        if self._setter is not None:
+            result = self._setter(new_value)
+            if result is not None:
+                new_value = result
+        self._value = new_value
+
+    def subscribe(self, listener, init=False):
+        pass
+
+    def unsubscribe(self, listener):
+        pass
+
+
+class FakeFuture:
+    def __init__(self, result=None):
+        self._result = result
+
+    def result(self, timeout=None):
+        return self._result
+
+
+class FakeDataflow:
+    def __init__(self, camera):
+        self._camera = camera
+        self.listeners = []
+
+    def subscribe(self, listener):
+        self.listeners.append(listener)
+
+    def unsubscribe(self, listener):
+        if listener in self.listeners:
+            self.listeners.remove(listener)
+
+    def get(self, asap=True):
+        res = self._camera.resolution.value
+        return np.zeros(res[::-1], dtype=np.uint16)
+
+
+class FakeFocuser:
+    """Focus actuator with favourite positions and a z axis."""
+
+    def __init__(
+        self,
+        active_z: float = 8.0e-3,
+        deactive_z: float = -1.0e-3,
+        position_z: Optional[float] = None,
+        axis_range: tuple = (-2.0e-3, 10.0e-3),
+    ):
+        self._metadata = {
+            MD_FAV_POS_ACTIVE: {"z": active_z},
+            MD_FAV_POS_DEACTIVE: {"z": deactive_z},
+        }
+        z = deactive_z if position_z is None else position_z
+        self.position = FakeVA({"z": z})
+        self.axes = {"z": types.SimpleNamespace(range=axis_range)}
+
+    def getMetadata(self):
+        return self._metadata
+
+    def moveAbs(self, pos: Dict[str, float]):
+        self.position.value = dict(self.position.value, **pos)
+        return FakeFuture()
+
+    def moveRel(self, shift: Dict[str, float]):
+        new = {k: self.position.value[k] + v for k, v in shift.items()}
+        self.position.value = dict(self.position.value, **new)
+        return FakeFuture()
+
+
+class FakeCamera:
+    """Digital camera whose binning couples resolution + MD_PIXEL_SIZE.
+
+    Mirrors the real behaviour: the resolution VA rescales to preserve the AOI
+    (driver-side) and the backend MetadataUpdater recomputes MD_PIXEL_SIZE
+    whenever binning changes.
+    """
+
+    def __init__(
+        self,
+        resolution: tuple = (2048, 2048),
+        pixel_size: tuple = (1e-7, 1e-7),
+        baseline: int = 100,
+    ):
+        self.resolution = FakeVA(tuple(resolution))
+        self.exposureTime = FakeVA(0.1, range=(1e-3, 10.0), unit="s")
+        self.binning = FakeVA(
+            (1, 1), range=((1, 1), (16, 16)), setter=self._on_binning
+        )
+        self._metadata = {
+            MD_PIXEL_SIZE: tuple(pixel_size),
+            MD_BASELINE: baseline,
+        }
+        self.data = FakeDataflow(self)
+
+    def getMetadata(self):
+        return self._metadata
+
+    def _on_binning(self, new_binning):
+        old_binning = self.binning.value
+        factor = (new_binning[0] / old_binning[0], new_binning[1] / old_binning[1])
+        self.resolution.value = tuple(
+            int(round(r / f)) for r, f in zip(self.resolution.value, factor)
+        )
+        px = self._metadata[MD_PIXEL_SIZE]
+        self._metadata[MD_PIXEL_SIZE] = tuple(p * f for p, f in zip(px, factor))
+        return new_binning
+
+
+class FakeLens:
+    def __init__(self, magnification: float = 84.0, numerical_aperture: float = 0.85):
+        self.magnification = FakeVA(magnification)
+        self.numericalAperture = FakeVA(numerical_aperture)
+
+
+class FakeLight:
+    def __init__(self, max_power: float = 0.4):
+        # one power entry per source; the stream slices out the selected channel
+        self.power = FakeVA([0.0], range=((0.0,), (max_power,)), unit="W")
+        self.spectra = FakeVA(
+            [band_ex(365), band_ex(450), band_ex(550), band_ex(635)], unit="m"
+        )
+
+
+class FakeFilter:
+    def __init__(self):
+        self.axes = {"band": types.SimpleNamespace(choices={})}
+
+
+class FakeFluoStream:
+    """FluoStream stand-in: excitation/emission/power VAs in SI units."""
+
+    def __init__(self, name, detector, dataflow, emitter, em_filter, focuser=None, **kwargs):
+        self.name = name
+        self._detector = detector
+        self._emitter = emitter
+        self._em_filter = em_filter
+        self._focuser = focuser
+
+        excitations = [band_ex(365), band_ex(450), band_ex(550), band_ex(635)]
+        self.excitation = FakeVA(
+            excitations[2], choices=frozenset(excitations), unit="m"
+        )
+        emissions = [
+            BAND_PASS_THROUGH,
+            band_em(420),
+            band_em(500),
+            band_em(590),
+            band_em(680),
+        ]
+        self.emission = FakeVA(emissions[2], choices=frozenset(emissions), unit="m")
+
+        max_power = emitter.power.range[1][0] if emitter is not None else 0.4
+        self.power = FakeVA(0.0, range=(0.0, max_power), unit="W")
+        self.is_active = FakeVA(False)
+
+
+def fake_acquire(streams, settings_obs=None):
+    """acqmng.acquire stand-in: future resolving to ([DataArray], None)."""
+    detector = streams[0]._detector
+    res = detector.resolution.value
+    data = np.zeros(res[::-1], dtype=np.uint16)
+    return FakeFuture(([data], None))
+
+
+def default_components() -> Dict[str, object]:
+    """Fresh set of stub hardware components keyed by odemis role."""
+    return {
+        "focus": FakeFocuser(),
+        "ccd": FakeCamera(),
+        "light": FakeLight(),
+        "filter": FakeFilter(),
+        "lens": FakeLens(),
+    }
+
+
+# registry read by the stub model.getComponent; swap per-test via use_components()
+_COMPONENTS: Dict[str, object] = {}
+
+
+def use_components(components: Dict[str, object]) -> Dict[str, object]:
+    """Set the components returned by the stub model.getComponent."""
+    _COMPONENTS.clear()
+    _COMPONENTS.update(components)
+    return components
+
+
+def _get_component(role: str):
+    try:
+        return _COMPONENTS[role]
+    except KeyError:
+        raise LookupError(f"No stub component with role '{role}'")
+
+
+def install_odemis_stubs() -> None:
+    """Insert stub odemis modules into sys.modules (idempotent)."""
+    odemis_pkg = types.ModuleType("odemis")
+    odemis_pkg.__path__ = []  # mark as package
+
+    model_mod = types.ModuleType("odemis.model")
+    model_mod.MD_PIXEL_SIZE = MD_PIXEL_SIZE
+    model_mod.MD_BASELINE = MD_BASELINE
+    model_mod.MD_FAV_POS_ACTIVE = MD_FAV_POS_ACTIVE
+    model_mod.MD_FAV_POS_DEACTIVE = MD_FAV_POS_DEACTIVE
+    model_mod.BAND_PASS_THROUGH = BAND_PASS_THROUGH
+    model_mod.Actuator = FakeFocuser
+    model_mod.DigitalCamera = FakeCamera
+    model_mod.Emitter = FakeLight
+    model_mod.DataArray = np.ndarray
+    model_mod.getComponent = lambda role: _get_component(role)
+    model_mod.hasVA = lambda comp, name: isinstance(getattr(comp, name, None), FakeVA)
+
+    acq_pkg = types.ModuleType("odemis.acq")
+    acq_pkg.__path__ = []
+
+    acqmng_mod = types.ModuleType("odemis.acq.acqmng")
+    acqmng_mod.acquire = fake_acquire
+
+    stream_mod = types.ModuleType("odemis.acq.stream")
+    stream_mod.FluoStream = FakeFluoStream
+
+    util_pkg = types.ModuleType("odemis.util")
+    util_pkg.__path__ = []
+
+    dataio_mod = types.ModuleType("odemis.util.dataio")
+    dataio_mod.open_acquisition = lambda path: []
+
+    odemis_pkg.model = model_mod
+    odemis_pkg.acq = acq_pkg
+    odemis_pkg.util = util_pkg
+    acq_pkg.acqmng = acqmng_mod
+    acq_pkg.stream = stream_mod
+    util_pkg.dataio = dataio_mod
+
+    modules = {
+        "odemis": odemis_pkg,
+        "odemis.model": model_mod,
+        "odemis.acq": acq_pkg,
+        "odemis.acq.acqmng": acqmng_mod,
+        "odemis.acq.stream": stream_mod,
+        "odemis.util": util_pkg,
+        "odemis.util.dataio": dataio_mod,
+    }
+    sys.modules.update(modules)
+
+
+def remove_odemis_stubs() -> None:
+    """Remove stub odemis modules and the fibsem modules bound to them."""
+    for name in ODEMIS_MODULE_NAMES + FIBSEM_ODEMIS_MODULE_NAMES:
+        sys.modules.pop(name, None)

--- a/tests/fm/_odemis_stubs.py
+++ b/tests/fm/_odemis_stubs.py
@@ -112,6 +112,11 @@ class FakeDataflow:
         res = self._camera.resolution.value
         return np.zeros(res[::-1], dtype=np.uint16)
 
+    def push(self, data):
+        """Deliver a frame to all subscribers, like the camera driver would."""
+        for listener in list(self.listeners):
+            listener(self, data)
+
 
 class FakeFocuser:
     """Focus actuator with favourite positions and a z axis."""

--- a/tests/fm/test_odemis_driver.py
+++ b/tests/fm/test_odemis_driver.py
@@ -1,0 +1,264 @@
+"""Unit tests for the Odemis fluorescence microscope driver (fibsem.fm.odemis).
+
+Runs everywhere: odemis is replaced by the stub modules in _odemis_stubs.py,
+which mimic the verified odemis behaviour (SI units, binning-coupled camera
+geometry, favourite positions). See docs/design/odemis-fm-driver.md.
+
+Each test class covers a Phase 1 finding (FIB-285):
+- F1  wavelength setters select the requested band (metres-vs-nm regression)
+- F2  objective.state is a property with the base Literal values
+- F3  camera geometry reads live, no binning double-count
+- F4  power is a fraction (0-1) of maximum, normalised to watts
+- F7b add_odemis_path is safe without /etc/odemis.conf
+"""
+
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from fibsem.fm.structures import ChannelSettings, FluorescenceImage
+from tests.fm import _odemis_stubs as stubs
+
+
+@pytest.fixture(scope="module")
+def odemis_env():
+    """Install stub odemis modules and import the driver against them."""
+    saved = {}
+    for name in stubs.ODEMIS_MODULE_NAMES + stubs.FIBSEM_ODEMIS_MODULE_NAMES:
+        if name in sys.modules:
+            saved[name] = sys.modules.pop(name)
+
+    stubs.install_odemis_stubs()
+    import fibsem.fm.odemis as fm_odemis  # noqa: F401 (imported against stubs)
+
+    yield types.SimpleNamespace(module=fm_odemis, stubs=stubs)
+
+    stubs.remove_odemis_stubs()
+    sys.modules.update(saved)
+
+
+@pytest.fixture()
+def fm(odemis_env):
+    """Fresh stub components + OdemisFluorescenceMicroscope per test."""
+    components = stubs.use_components(stubs.default_components())
+    microscope = odemis_env.module.OdemisFluorescenceMicroscope(parent=None)
+    microscope.components = components  # convenience handle for tests
+    return microscope
+
+
+class TestAddOdemisPath:
+    """F7b: add_odemis_path must be safe without an odemis config."""
+
+    def test_missing_config_is_noop(self, odemis_env, tmp_path):
+        from fibsem.microscopes.odemis_microscope import add_odemis_path
+
+        before = list(sys.path)
+        add_odemis_path(config_path=str(tmp_path / "missing.conf"))
+        assert sys.path == before
+
+    def test_valid_config_appends_devpath(self, odemis_env, tmp_path):
+        from fibsem.microscopes.odemis_microscope import add_odemis_path
+
+        conf = tmp_path / "odemis.conf"
+        conf.write_text('DEVPATH="/home/dev"\nMODEL="/usr/share/odemis/meteor.yaml"\n')
+        before = list(sys.path)
+        try:
+            add_odemis_path(config_path=str(conf))
+            assert "/home/dev/odemis/src" in sys.path
+        finally:
+            sys.path[:] = before
+
+
+class TestFilterSetWavelengths:
+    """F1: setters must select the requested band, not the lowest one."""
+
+    def test_available_excitation_wavelengths_in_nm(self, fm):
+        available = sorted(fm.filter_set.available_excitation_wavelengths)
+        assert available == pytest.approx([365, 450, 550, 635])
+
+    def test_available_emission_wavelengths_in_nm(self, fm):
+        available = fm.filter_set.available_emission_wavelengths
+        assert None in available
+        numeric = sorted(wl for wl in available if wl is not None)
+        assert numeric == pytest.approx([420, 500, 590, 680])
+
+    def test_excitation_setter_selects_requested_band(self, fm):
+        # regression: the old implementation always picked the lowest band
+        for requested in (635, 550, 450, 365):
+            fm.filter_set.excitation_wavelength = requested
+            assert fm.filter_set.excitation_wavelength == pytest.approx(requested)
+            band = fm.filter_set._stream.excitation.value
+            assert band[2] == pytest.approx(requested * 1e-9)
+
+    def test_excitation_setter_closest_match(self, fm):
+        fm.filter_set.excitation_wavelength = 640  # closest available: 635
+        assert fm.filter_set.excitation_wavelength == pytest.approx(635)
+
+    def test_excitation_setter_rejects_non_numeric(self, fm):
+        with pytest.raises(TypeError):
+            fm.filter_set.excitation_wavelength = "red"
+
+    def test_emission_setter_selects_requested_band(self, fm):
+        for requested in (680, 500, 590, 420):
+            fm.filter_set.emission_wavelength = requested
+            assert fm.filter_set.emission_wavelength == pytest.approx(requested)
+            band = fm.filter_set._stream.emission.value
+            assert band[0] == pytest.approx(requested * 1e-9)
+
+    def test_emission_none_sets_pass_through(self, fm):
+        fm.filter_set.emission_wavelength = None
+        assert fm.filter_set._stream.emission.value == stubs.BAND_PASS_THROUGH
+        assert fm.filter_set.emission_wavelength is None
+
+    def test_emission_setter_rejects_str(self, fm):
+        # explicit TypeError until FIB-286 maps 'Fluorescence' to a band
+        with pytest.raises(TypeError):
+            fm.filter_set.emission_wavelength = "Fluorescence"
+
+    def test_emission_setter_skips_when_unchanged(self, fm):
+        fm.filter_set.emission_wavelength = 590
+        emission_va = fm.filter_set._stream.emission
+        sets_before = emission_va.set_count
+        fm.filter_set.emission_wavelength = 590  # unchanged: filter wheel is slow
+        assert emission_va.set_count == sets_before
+
+
+class TestObjectiveState:
+    """F2: state is a property returning the base contract's Literal values."""
+
+    def test_state_is_a_property_not_a_method(self, fm):
+        assert isinstance(fm.objective.state, str)
+
+    def test_state_retracted_at_deactive_position(self, fm):
+        assert fm.objective.state == "Retracted"  # stub starts at deactive
+
+    def test_insert_updates_state(self, fm):
+        fm.objective.insert()
+        assert fm.objective.state == "Inserted"
+
+    def test_retract_updates_state(self, fm):
+        fm.objective.insert()
+        fm.objective.retract()
+        assert fm.objective.state == "Retracted"
+
+    def test_state_other_between_positions(self, fm):
+        focuser = fm.components["focus"]
+        midpoint = (
+            focuser.getMetadata()[stubs.MD_FAV_POS_ACTIVE]["z"]
+            + focuser.getMetadata()[stubs.MD_FAV_POS_DEACTIVE]["z"]
+        ) / 2
+        fm.objective.move_absolute(midpoint)
+        assert fm.objective.state == "Other"
+
+    def test_state_error_when_unreadable(self, fm):
+        fm.components["focus"].position = None
+        assert fm.objective.state == "Error"
+
+    def test_workflow_precondition_comparison(self, fm):
+        # the exact comparison used by workflow tasks / movement guards
+        fm.objective.insert()
+        assert (fm.objective.state == "Inserted") is True
+
+
+class TestCameraGeometry:
+    """F3: pixel_size/resolution read live, no binning double-count."""
+
+    def test_pixel_size_reads_live_metadata(self, fm):
+        assert fm.camera.pixel_size == pytest.approx((1e-7, 1e-7))
+
+    def test_no_double_count_after_binning_change(self, fm):
+        fm.set_binning(2)
+        # stub backend couples binning -> resolution + MD_PIXEL_SIZE like odemis
+        assert fm.camera.pixel_size == pytest.approx((2e-7, 2e-7))
+        assert fm.camera.resolution == (1024, 1024)
+
+    def test_init_at_non_unit_binning(self, odemis_env):
+        # a leftover binning from a previous session must not corrupt geometry
+        components = stubs.default_components()
+        components["ccd"].binning.value = (2, 2)  # couples res + pixel size
+        stubs.use_components(components)
+        microscope = odemis_env.module.OdemisFluorescenceMicroscope(parent=None)
+        assert microscope.camera.pixel_size == pytest.approx((2e-7, 2e-7))
+        assert microscope.camera.resolution == (1024, 1024)
+
+    def test_field_of_view_invariant_under_binning(self, fm):
+        fov_before = fm.camera.field_of_view
+        fm.set_binning(4)
+        assert fm.camera.field_of_view == pytest.approx(fov_before)
+
+
+class TestLightSourcePower:
+    """F4: power is a fraction of maximum, mapped to watts on the stream."""
+
+    def test_set_power_fraction_maps_to_watts(self, fm):
+        fm.set_power(0.5)  # stream range is (0, 0.4) W
+        assert fm.light_source._stream.power.value == pytest.approx(0.2)
+
+    def test_get_power_returns_fraction(self, fm):
+        fm.light_source._stream.power.value = 0.1
+        assert fm.light_source.power == pytest.approx(0.25)
+
+    def test_power_round_trip(self, fm):
+        fm.set_power(0.25)
+        assert fm.light_source.power == pytest.approx(0.25)
+
+    def test_power_clips_out_of_range_fraction(self, fm):
+        fm.set_power(1.5)
+        assert fm.light_source.power == pytest.approx(1.0)
+        assert fm.light_source._stream.power.value == pytest.approx(0.4)
+
+    def test_power_rejects_non_numeric(self, fm):
+        with pytest.raises(TypeError):
+            fm.set_power("high")
+
+
+class TestChannelAndMetadata:
+    """set_channel end-to-end + metadata records driver-normalised values."""
+
+    def test_set_channel_configures_stream(self, fm):
+        channel = ChannelSettings(
+            name="ch-635",
+            excitation_wavelength=635,
+            emission_wavelength=680,
+            power=0.25,
+            exposure_time=0.05,
+            color="red",
+            gain=0.0,
+        )
+        fm.set_channel(channel)
+        stream = fm.filter_set._stream
+        assert stream.excitation.value[2] == pytest.approx(635e-9)
+        assert stream.emission.value[0] == pytest.approx(680e-9)
+        assert stream.power.value == pytest.approx(0.1)  # 0.25 * 0.4 W
+        assert fm.camera.exposure_time == pytest.approx(0.05)
+        assert fm.channel_name == "ch-635"
+
+    def test_set_channel_reflection_mode(self, fm):
+        channel = ChannelSettings(
+            name="reflection",
+            excitation_wavelength=550,
+            emission_wavelength=None,
+            power=0.1,
+            exposure_time=0.01,
+        )
+        fm.set_channel(channel)
+        assert fm.filter_set._stream.emission.value == stubs.BAND_PASS_THROUGH
+
+    def test_metadata_records_power_fraction(self, fm):
+        fm.set_power(0.25)
+        metadata = fm.get_metadata()
+        assert metadata.channels[0].power == pytest.approx(0.25)
+
+    def test_metadata_geometry_tracks_binning(self, fm):
+        fm.set_binning(2)
+        metadata = fm.get_metadata()
+        assert metadata.pixel_size_x == pytest.approx(2e-7)
+        assert metadata.resolution == (1024, 1024)
+
+    def test_acquire_image_returns_fluorescence_image(self, fm):
+        image = fm.acquire_image()
+        assert isinstance(image, FluorescenceImage)
+        assert image.data.shape == fm.camera.resolution[::-1]
+        assert image.metadata is not None

--- a/tests/fm/test_odemis_driver.py
+++ b/tests/fm/test_odemis_driver.py
@@ -4,12 +4,16 @@ Runs everywhere: odemis is replaced by the stub modules in _odemis_stubs.py,
 which mimic the verified odemis behaviour (SI units, binning-coupled camera
 geometry, favourite positions). See docs/design/odemis-fm-driver.md.
 
-Each test class covers a Phase 1 finding (FIB-285):
+Each test class covers a finding from Phase 1 (FIB-285) or Phase 2 (FIB-286):
 - F1  wavelength setters select the requested band (metres-vs-nm regression)
 - F2  objective.state is a property with the base Literal values
 - F3  camera geometry reads live, no binning double-count
 - F4  power is a fraction (0-1) of maximum, normalised to watts
+- F5/F6 objective limits from the focuser axis range + move clipping
+- F7  init tolerates missing metadata keys (baseline, FAV positions, pixel size)
 - F7b add_odemis_path is safe without /etc/odemis.conf
+- F8  acquire_image raises on failure instead of returning None
+- F9  'Fluorescence' emission maps to the band matching the excitation
 """
 
 import sys
@@ -112,10 +116,9 @@ class TestFilterSetWavelengths:
         assert fm.filter_set._stream.emission.value == stubs.BAND_PASS_THROUGH
         assert fm.filter_set.emission_wavelength is None
 
-    def test_emission_setter_rejects_str(self, fm):
-        # explicit TypeError until FIB-286 maps 'Fluorescence' to a band
+    def test_emission_setter_rejects_non_numeric_non_str(self, fm):
         with pytest.raises(TypeError):
-            fm.filter_set.emission_wavelength = "Fluorescence"
+            fm.filter_set.emission_wavelength = [500]
 
     def test_emission_setter_skips_when_unchanged(self, fm):
         fm.filter_set.emission_wavelength = 590
@@ -262,3 +265,128 @@ class TestChannelAndMetadata:
         assert isinstance(image, FluorescenceImage)
         assert image.data.shape == fm.camera.resolution[::-1]
         assert image.metadata is not None
+
+
+class TestObjectiveLimitsAndClipping:
+    """F5/F6: limits from the focuser axis range; move_absolute clips/validates."""
+
+    def test_limits_from_focuser_axis_range(self, fm):
+        assert fm.objective.limits == pytest.approx((-2.0e-3, 10.0e-3))
+
+    def test_default_user_limit_is_hardware_max(self, fm):
+        assert fm.objective.limit_position == pytest.approx(10.0e-3)
+
+    def test_move_absolute_clips_to_user_limit(self, fm):
+        fm.objective.limit_position = 5.0e-3
+        fm.objective.move_absolute(8.0e-3)
+        assert fm.objective.position == pytest.approx(5.0e-3)
+
+    def test_move_absolute_within_limit_is_unclipped(self, fm):
+        fm.objective.limit_position = 5.0e-3
+        fm.objective.move_absolute(3.0e-3)
+        assert fm.objective.position == pytest.approx(3.0e-3)
+
+    def test_move_absolute_raises_outside_axis_range(self, fm):
+        with pytest.raises(ValueError):
+            fm.objective.move_absolute(-5.0e-3)  # below focuser range minimum
+
+    def test_insert_uses_calibrated_position_despite_user_limit(self, fm):
+        # the favourite active position is calibrated, so insert() is not
+        # subject to the user focusing limit
+        fm.objective.limit_position = 5.0e-3
+        fm.objective.insert()
+        assert fm.objective.position == pytest.approx(8.0e-3)
+
+
+class TestInitFallbacks:
+    """F7: missing metadata keys must not disable the FM subsystem."""
+
+    def test_missing_baseline_defaults_to_zero(self, odemis_env):
+        components = stubs.default_components()
+        del components["ccd"]._metadata[stubs.MD_BASELINE]
+        stubs.use_components(components)
+        microscope = odemis_env.module.OdemisFluorescenceMicroscope(parent=None)
+        assert microscope.camera.offset == 0
+
+    def test_missing_pixel_size_falls_back_to_sensor(self, odemis_env):
+        components = stubs.default_components()
+        del components["ccd"]._metadata[stubs.MD_PIXEL_SIZE]
+        stubs.use_components(components)
+        microscope = odemis_env.module.OdemisFluorescenceMicroscope(parent=None)
+        assert microscope.camera.pixel_size == pytest.approx((6.5e-6, 6.5e-6))
+
+    def test_missing_fav_active_uses_current_position(self, odemis_env):
+        components = stubs.default_components()
+        del components["focus"]._metadata[stubs.MD_FAV_POS_ACTIVE]
+        stubs.use_components(components)
+        microscope = odemis_env.module.OdemisFluorescenceMicroscope(parent=None)
+        # falls back to the current (deactive) position instead of crashing
+        assert microscope.objective.focus_position == pytest.approx(-1.0e-3)
+        assert microscope.objective.state == "Other"
+
+    def test_insert_without_fav_active_warns_and_stays(self, odemis_env):
+        components = stubs.default_components()
+        del components["focus"]._metadata[stubs.MD_FAV_POS_ACTIVE]
+        stubs.use_components(components)
+        microscope = odemis_env.module.OdemisFluorescenceMicroscope(parent=None)
+        position_before = microscope.objective.position
+        microscope.objective.insert()  # must not raise
+        assert microscope.objective.position == pytest.approx(position_before)
+
+
+class TestAcquireImageErrors:
+    """F8: acquisition failures raise instead of returning None."""
+
+    def test_acquisition_error_raises(self, fm, odemis_env, monkeypatch):
+        monkeypatch.setattr(
+            odemis_env.module,
+            "acquire",
+            lambda streams: stubs.FakeFuture(([], Exception("camera timeout"))),
+        )
+        with pytest.raises(RuntimeError, match="camera timeout"):
+            fm.camera.acquire_image()
+
+    def test_empty_acquisition_raises(self, fm, odemis_env, monkeypatch):
+        monkeypatch.setattr(
+            odemis_env.module,
+            "acquire",
+            lambda streams: stubs.FakeFuture(([], None)),
+        )
+        with pytest.raises(RuntimeError, match="no data"):
+            fm.camera.acquire_image()
+
+
+class TestEmissionFluorescenceMapping:
+    """F9: TFS-style 'Fluorescence' maps to the band matching the excitation."""
+
+    @pytest.mark.parametrize(
+        "excitation_nm,expected_emission_nm",
+        [(365, 420), (450, 500), (550, 590), (635, 680)],
+    )
+    def test_fluorescence_follows_excitation(
+        self, fm, excitation_nm, expected_emission_nm
+    ):
+        fm.filter_set.excitation_wavelength = excitation_nm
+        fm.filter_set.emission_wavelength = "Fluorescence"
+        assert fm.filter_set.emission_wavelength == pytest.approx(
+            expected_emission_nm
+        )
+
+    def test_set_channel_with_tfs_style_settings(self, fm):
+        channel = ChannelSettings(
+            name="tfs-style",
+            excitation_wavelength=635,
+            emission_wavelength="Fluorescence",
+            power=0.1,
+            exposure_time=0.01,
+        )
+        fm.set_channel(channel)
+        assert fm.filter_set.emission_wavelength == pytest.approx(680)
+
+    def test_fluorescence_skips_write_when_unchanged(self, fm):
+        fm.filter_set.excitation_wavelength = 550
+        fm.filter_set.emission_wavelength = "Fluorescence"
+        emission_va = fm.filter_set._stream.emission
+        sets_before = emission_va.set_count
+        fm.filter_set.emission_wavelength = "Fluorescence"
+        assert emission_va.set_count == sets_before

--- a/tests/fm/test_odemis_driver.py
+++ b/tests/fm/test_odemis_driver.py
@@ -14,9 +14,12 @@ Each test class covers a finding from Phase 1 (FIB-285) or Phase 2 (FIB-286):
 - F7b add_odemis_path is safe without /etc/odemis.conf
 - F8  acquire_image raises on failure instead of returning None
 - F9  'Fluorescence' emission maps to the band matching the excitation
+- F10 live acquisition via dataflow subscription (stream active once,
+      frames pushed, light off on stop in all paths)
 """
 
 import sys
+import time
 import types
 
 import numpy as np
@@ -24,6 +27,16 @@ import pytest
 
 from fibsem.fm.structures import ChannelSettings, FluorescenceImage
 from tests.fm import _odemis_stubs as stubs
+
+
+def wait_until(condition, timeout: float = 2.0, interval: float = 0.01) -> bool:
+    """Poll condition until true or timeout; returns whether it became true."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if condition():
+            return True
+        time.sleep(interval)
+    return condition()
 
 
 @pytest.fixture(scope="module")
@@ -390,3 +403,91 @@ class TestEmissionFluorescenceMapping:
         sets_before = emission_va.set_count
         fm.filter_set.emission_wavelength = "Fluorescence"
         assert emission_va.set_count == sets_before
+
+
+class TestFastAcquisition:
+    """F10: live acquisition activates the stream once and subscribes to
+    the dataflow; the stream is deactivated (light off) in all stop paths."""
+
+    def _start_live(self, fm):
+        """Start live acquisition and wait until the stream owns the hardware."""
+        fm.set_rate_limit(0)  # emit every frame in tests
+        fm.start_acquisition()
+        stream = fm.camera._stream
+        dataflow = fm.components["ccd"].data
+        assert wait_until(lambda: stream.is_active.value), "stream never activated"
+        assert wait_until(lambda: dataflow.listeners), "listener never subscribed"
+        return stream, dataflow
+
+    def test_frames_are_pushed_and_emitted(self, fm):
+        received = []
+        fm.acquisition_signal.connect(received.append)
+        try:
+            stream, dataflow = self._start_live(fm)
+            frame = np.full((2048, 2048), 42, dtype=np.uint16)
+            dataflow.push(frame)
+            assert wait_until(lambda: len(received) >= 1), "no frame emitted"
+            assert received[0].data[0, 0] == 42
+        finally:
+            fm.stop_acquisition()
+            fm.acquisition_signal.disconnect(received.append)
+
+    def test_stop_deactivates_stream_and_unsubscribes(self, fm):
+        try:
+            stream, dataflow = self._start_live(fm)
+        finally:
+            fm.stop_acquisition()
+        assert wait_until(lambda: not fm.is_acquiring), "worker did not stop"
+        assert stream.is_active.value is False
+        assert dataflow.listeners == []
+
+    def test_frame_handler_error_does_not_kill_live_view(self, fm, monkeypatch):
+        try:
+            stream, dataflow = self._start_live(fm)
+            monkeypatch.setattr(
+                fm, "_construct_image", lambda data: (_ for _ in ()).throw(RuntimeError("boom"))
+            )
+            dataflow.push(np.zeros((8, 8), dtype=np.uint16))  # handled, not raised
+            assert stream.is_active.value is True
+            assert dataflow.listeners  # still subscribed
+        finally:
+            fm.stop_acquisition()
+        assert stream.is_active.value is False
+
+    def test_light_off_even_if_unsubscribe_fails(self, fm, monkeypatch):
+        try:
+            stream, dataflow = self._start_live(fm)
+            monkeypatch.setattr(
+                dataflow,
+                "unsubscribe",
+                lambda listener: (_ for _ in ()).throw(RuntimeError("ipc lost")),
+            )
+        finally:
+            fm.stop_acquisition()
+        assert wait_until(lambda: not fm.is_acquiring)
+        assert stream.is_active.value is False  # deactivation must still happen
+
+    def test_acquire_image_during_live_uses_dataflow(self, fm, odemis_env, monkeypatch):
+        # snapshot during live must not run a full acqmng acquisition
+        def _fail(streams, settings_obs=None):
+            raise AssertionError("acqmng.acquire must not be called during live view")
+
+        try:
+            self._start_live(fm)
+            monkeypatch.setattr(odemis_env.module, "acquire", _fail)
+            image = fm.acquire_image()
+            assert isinstance(image, FluorescenceImage)
+            assert image.data.shape == fm.camera.resolution[::-1]
+        finally:
+            fm.stop_acquisition()
+
+    def test_acquire_image_when_idle_uses_acqmng(self, fm, monkeypatch):
+        # the dataflow snapshot path must only be used while the stream is active
+        dataflow = fm.components["ccd"].data
+        monkeypatch.setattr(
+            dataflow,
+            "get",
+            lambda asap=True: (_ for _ in ()).throw(AssertionError("dataflow.get in idle mode")),
+        )
+        image = fm.acquire_image()
+        assert isinstance(image, FluorescenceImage)


### PR DESCRIPTION
Fixes and modernises the Odemis (METEOR) fluorescence microscope driver, which was unchanged since the original Arctis FM PR (#90) and had several bugs that made it unusable with the current workflow layer. Full analysis — with hardware behaviour verified against the delmic/odemis source (master @ b83df59) — plus the phased plan and testing strategy are in `docs/design/odemis-fm-driver.md` (added here).

## Phase 1 — correctness (FIB-285)

- **Wavelength selection**: the excitation/emission setters compared metres against nanometres, so every request selected the *lowest* available band. Rebuilt on one-pass nm→choice mappings; the emission setter also skips the slow filter write when the band is unchanged.
- **Objective state**: `state` was a method returning `"INSERTED"`, while every consumer (workflow tasks, movement guard, UI) compares `state == "Inserted"` — the objective permanently appeared retracted and coincident milling refused to run. Now a property returning `Inserted/Retracted/Other/Error` with a ±100 µm tolerance against the favourite positions.
- **Camera geometry**: `pixel_size`/`resolution` were cached at init and re-scaled by binning, but odemis already applies binning (the backend recomputes `MD_PIXEL_SIZE` and drivers rescale the resolution VA on binning change) — a double count whenever binning ≠ 1 at init. Both now read live with no binning arithmetic.
- **Power units**: `ChannelSettings.power` is a 0–1 fraction, but the odemis stream power is in watts (and clips silently). Now normalised through `stream.power.range` in both directions, matching TFS semantics.
- `add_odemis_path()` no longer crashes on machines without `/etc/odemis.conf`.

## Phase 2 — robustness (FIB-286)

- **Objective safety**: `limits` comes from the focuser axis range (previously simulation constants); `move_absolute` clips to the user safety limit and validates the axis range; the default user limit is the hardware maximum. The objective-limit spinbox in the UI now actually protects the hardware on Odemis.
- **Init fallbacks**: missing `MD_FAV_POS_ACTIVE` / `MD_PIXEL_SIZE` / `MD_BASELINE` no longer silently disable the whole FM subsystem — clear warnings and sensible fallbacks instead (`MD_BASELINE` is only published by a few camera drivers).
- **Error handling**: `acquire_image` raises `RuntimeError` on failure instead of returning `None` (which crashed far downstream); `insert`/`retract` warn instead of silently no-oping.
- **Channel compatibility**: `emission_wavelength` accepts TFS-style `"Fluorescence"` and maps it to the band matching the current excitation via `odemis.util.fluo.get_one_band_em`.

## Phase 3 — live acquisition (FIB-287)

- **Dataflow-based live view**: previously each live frame ran a full `acqmng.acquire()` round-trip — stream activate, light on, one frame, light off, deactivate — seconds per frame plus LED toggling. `_start_fast_acquisition` (the same base-worker hook the TFS driver uses) now activates the stream once and subscribes to the camera dataflow, so frames push at the exposure-limited rate. The stream is always deactivated (light off) on exit, even if the frame handler or unsubscribe fails.
- **Snapshot during live**: `acquire_image()` while streaming grabs a fresh frame from the dataflow (`get(asap=False)`) without stopping the stream — workflows no longer need the stop/acquire/restart dance for stills.
- F20 (per-frame `DataArray.metadata` consumption) deferred to FIB-288, which also picks up a base-class item found while writing the threading tests (`_stop_acquisition_event` is a shared class attribute).

## Testing

- New `tests/fm/test_odemis_driver.py`: 56 unit tests against stubbed odemis modules that replicate the verified backend behaviour (SI-unit band sets, watts power with range, binning-coupled resolution + `MD_PIXEL_SIZE`, favourite positions, dataflow push) — the live-acquisition tests exercise the real worker-thread path including light-off-on-failure.
- Full `tests/fm` suite: **192 passed**.
- Remaining validation is on-hardware: see the 10-item METEOR checklist in `docs/design/odemis-fm-driver.md` (§ Testing).

Next phase (tracked): FIB-288 ABC contract promotion + typing cleanup.