### PR TITLE
Correlation: separate fit-diagnostic compute from render (FIB-281)

### DIFF
--- a/fibsem/correlation/fit_diagnostics.py
+++ b/fibsem/correlation/fit_diagnostics.py
@@ -1,0 +1,166 @@
+"""Fit-diagnostic data + rendering, split from the fit compute (FIB-281).
+
+The correlation fit functions (:mod:`fibsem.correlation.util`) compute a refined
+coordinate and return a :class:`FitDiagnostic` — the *data* needed to draw the
+diagnostic figure — without touching matplotlib. :func:`plot_fit_diagnostic`
+renders it, in a light palette by default or the napari-dark palette
+(``dark=True``) used by the confirm dialog.
+
+This keeps the compute path matplotlib-free, builds a figure only when one is
+actually shown (no build-then-discard), makes the diagnostics testable on data
+rather than on figure internals, and turns the confirm dialog's dark theme into
+a render parameter (it no longer re-themes a figure after the fact).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+
+# input (red) / fitted (green) are the only saturated colours in every panel;
+# everything else is greyscale so the eye goes to the two markers.
+_C_IN = "#e53935"
+_C_FIT = "#43a047"
+
+
+@dataclass
+class FitDiagnostic:
+    """Everything needed to render a fit's diagnostic figure — no matplotlib.
+
+    The XY panel is always present; the z panel is present only when
+    :attr:`z_signal` is set (the FIB hole fit is XY-only). Marker positions are
+    in ROI pixel coordinates; :attr:`input_xy` carries the sub-pixel click so the
+    input marker lands exactly where the user clicked (FIB-282).
+    """
+
+    title: str
+    roi_xy: np.ndarray                                 # image shown in the XY panel
+    input_xy: Tuple[float, float]                      # red input marker (ROI coords)
+    fitted_xy: Optional[Tuple[float, float]] = None    # green marker, or None → not drawn
+    xy_title: str = "XY"
+    xy_message: Optional[str] = None                   # shown when there is no fitted marker
+    # z panel — left None for an XY-only (FIB) fit
+    z_axis: Optional[np.ndarray] = None
+    z_signal: Optional[np.ndarray] = None
+    z_fit: Optional[np.ndarray] = None
+    z_input: Optional[float] = None
+    z_fitted: Optional[float] = None
+    z_inverted: bool = False                           # reflection: signal is inverted
+
+    @property
+    def has_z(self) -> bool:
+        """True for the FM fits (z + XY); False for the XY-only FIB fit."""
+        return self.z_signal is not None
+
+
+def plot_fit_diagnostic(d: FitDiagnostic, *, dark: bool = False):
+    """Render a :class:`FitDiagnostic` to a matplotlib ``Figure``.
+
+    Uses the object-oriented ``Figure`` API (no pyplot), so the figure isn't
+    held in pyplot's global registry — it's freed with its canvas and needs no
+    ``plt.close``. Pass ``dark=True`` for the napari-dark confirm-dialog palette.
+    """
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+    from matplotlib.figure import Figure
+
+    if d.has_z:
+        fig = Figure(figsize=(9, 4.5))
+        FigureCanvasAgg(fig)  # gives tight_layout a renderer; replaced by the Qt canvas on embed
+        ax_z, ax_xy = fig.subplots(1, 2, gridspec_kw={"width_ratios": [1, 1.4]})
+        _draw_z_panel(ax_z, d)
+    else:
+        fig = Figure(figsize=(5, 5))
+        FigureCanvasAgg(fig)
+        ax_xy = fig.subplots(1, 1)
+
+    _draw_xy_panel(ax_xy, d)
+    fig.suptitle(d.title)
+
+    if dark:
+        _apply_dark_theme(fig)
+    fig.tight_layout()
+    return fig
+
+
+def _draw_z_panel(ax, d: FitDiagnostic) -> None:
+    ax.plot(d.z_axis, d.z_signal, color="0.55", lw=1.3)
+    if d.z_fit is not None:
+        ax.plot(d.z_axis, d.z_fit, color="0.15", ls="--", lw=1.2)
+    ax.axvline(d.z_input, color=_C_IN, ls="--", lw=1.6, label=f"input {d.z_input:.1f}")
+    ax.axvline(d.z_fitted, color=_C_FIT, ls="--", lw=1.6, label=f"fitted {d.z_fitted:.1f}")
+    ax.set_title("z", fontsize=10)
+    ax.set_xlabel("z slice", fontsize=8)
+    if d.z_inverted:
+        # the hole is dark, so the signal is inverted — the peak is the hole
+        ax.set_ylabel("signal (inverted)", fontsize=8)
+    ax.set_yticks([])
+    ax.tick_params(labelsize=8)
+    ax.legend(fontsize=7, framealpha=0.6)
+
+
+def _draw_xy_panel(ax, d: FitDiagnostic) -> None:
+    ax.imshow(d.roi_xy, cmap="gray")
+    ax.plot(d.input_xy[0], d.input_xy[1], "+", color=_C_IN, ms=16, mew=2, label="input")
+    if d.fitted_xy is not None:
+        ax.plot(d.fitted_xy[0], d.fitted_xy[1], "+", color=_C_FIT, ms=16, mew=2,
+                label="fitted")
+    elif d.xy_message:
+        # A failed / out-of-region fit has no marker to show; say so instead of
+        # letting matplotlib silently chase a marker off-axes.
+        ax.text(0.5, 0.5, d.xy_message, transform=ax.transAxes, ha="center",
+                va="center", color=_C_IN, fontsize=11,
+                bbox=dict(boxstyle="round", fc="black", ec=_C_IN, alpha=0.65))
+    n = d.roi_xy.shape[0]
+    ax.set_xlim(-0.5, n - 0.5)
+    ax.set_ylim(n - 0.5, -0.5)
+    ax.set_title(d.xy_title)
+    ax.legend(loc="upper right", fontsize=8, framealpha=0.6)
+    ax.axis("off")
+
+
+# --- dark theme -----------------------------------------------------------
+# The napari-dark palette for the confirm dialog. This is the exact re-theming
+# that shipped in #144 (formerly _apply_dark_theme in fit_confirmation_dialog);
+# it now lives here so the dialog just passes dark=True. Only theme-agnostic
+# chrome is touched — the saturated input/fitted markers and the grayscale image
+# are left as authored (they read correctly on dark).
+_FIG_BG = "#1e2124"    # == the dialog background: figure margins blend in
+_AXES_BG = "#262930"   # a subtle lift so the z line-plot reads as a panel
+_FG = "#d0d0d0"        # labels, ticks, legend text
+_FG_TITLE = "#e0e0e0"  # titles / suptitle, a touch brighter
+_SPINE = "#4a4d53"
+# A line darker than this is invisible on the dark panel; the only such artist
+# is the gaussian-fit overlay (drawn at 0.15 grey). Lift it to a light grey.
+_DARK_LINE_LUM = 0.25
+_DARK_LINE_TARGET = "0.8"
+
+
+def _luminance(color) -> float:
+    from matplotlib.colors import to_rgb
+
+    r, g, b = to_rgb(color)
+    return 0.299 * r + 0.587 * g + 0.114 * b
+
+
+def _apply_dark_theme(fig) -> None:
+    fig.set_facecolor(_FIG_BG)
+    for txt in fig.texts:  # figure-level text == the suptitle
+        txt.set_color(_FG_TITLE)
+    for ax in fig.axes:
+        ax.set_facecolor(_AXES_BG)
+        ax.title.set_color(_FG_TITLE)
+        ax.xaxis.label.set_color(_FG)
+        ax.yaxis.label.set_color(_FG)
+        ax.tick_params(colors=_FG)
+        for spine in ax.spines.values():
+            spine.set_color(_SPINE)
+        for line in ax.get_lines():
+            if _luminance(line.get_color()) < _DARK_LINE_LUM:
+                line.set_color(_DARK_LINE_TARGET)
+        legend = ax.get_legend()
+        if legend is not None:
+            legend.get_frame().set_facecolor(_AXES_BG)
+            legend.get_frame().set_edgecolor(_SPINE)
+            for text in legend.get_texts():
+                text.set_color(_FG)

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -2131,14 +2131,9 @@ class CorrelationTabWidget(QWidget):
 
         show_fig = self._coords_tab._show_diag_check.isChecked()
         dialog = FitConfirmationDialog(result, show_figure=show_fig, parent=self)
-        try:
-            accepted = dialog.exec_() == QDialog.Accepted
-        finally:
-            if result.figure is not None:
-                import matplotlib.pyplot as plt
-
-                plt.close(result.figure)
-        if accepted:
+        # The dialog renders its own figure (OO API, no pyplot) and frees it with
+        # its canvas, so there's nothing to plt.close here anymore.
+        if dialog.exec_() == QDialog.Accepted:
             self._apply_fit_result(result)
 
     def _should_auto_accept(self, result: PointFitResult) -> bool:
@@ -2161,10 +2156,8 @@ class CorrelationTabWidget(QWidget):
     def _auto_accept_fit(self, result: PointFitResult) -> None:
         """Apply a fit without the confirm dialog, with a status-bar note."""
         self._apply_fit_result(result)
-        if result.figure is not None:
-            import matplotlib.pyplot as plt
-
-            plt.close(result.figure)
+        # No figure is built on the auto-accept path (the diagnostic is just
+        # data), so there's nothing to close.
         # Set the note AFTER applying (apply emits data_changed, which may
         # refresh the status line) so this is the message that sticks.
         name = result.coordinate.point_type.value
@@ -2190,7 +2183,7 @@ class CorrelationTabWidget(QWidget):
         x, y, z = coord.point.x, coord.point.y, coord.point.z
         initial = PointXYZ(x, y, z)
         method, channel, channel_name = "", None, None
-        fitted, fig, error, error_detail, attempted = None, None, None, None, False
+        fitted, diag, error, error_detail, attempted = None, None, None, None, False
 
         try:
             if spec.adapter.side == "fib":
@@ -2199,7 +2192,7 @@ class CorrelationTabWidget(QWidget):
                     attempted = True
                     # pass the sub-pixel click (not int) so the diagnostic's
                     # input marker lands where the user clicked — FIB-282.
-                    xr, yr, fig = hole_fitting_FIB(
+                    xr, yr, diag = hole_fitting_FIB(
                         self._fib_image.filtered_data, x, y
                     )
                     fitted = PointXYZ(float(xr), float(yr), z)
@@ -2217,13 +2210,13 @@ class CorrelationTabWidget(QWidget):
                     img = self._fm_image.data[channel]
                     if method == "Hole":
                         attempted = True
-                        xr, yr, zr, fig = hole_fitting_reflection(
+                        xr, yr, zr, diag = hole_fitting_reflection(
                             img, x, y, z=int(z), cutout=2  # sub-pixel x/y (FIB-282)
                         )
                         fitted = PointXYZ(float(xr), float(yr), float(zr))
                     elif method == "Gaussian":
                         attempted = True
-                        xr, yr, zr, fig = target_fitting_fluorescence(
+                        xr, yr, zr, diag = target_fitting_fluorescence(
                             img, x, y, int(z), cutout=5  # sub-pixel x/y (FIB-282)
                         )
                         fitted = PointXYZ(float(xr), float(yr), float(zr))
@@ -2247,7 +2240,7 @@ class CorrelationTabWidget(QWidget):
             status=status,
             message=error,
             detail=error_detail,
-            figure=fig,
+            diagnostic=diag,
         )
 
     def _apply_fit_result(self, result: PointFitResult) -> None:

--- a/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
+++ b/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
@@ -41,7 +41,7 @@ class FitStatus(Enum):
 
 @dataclass
 class PointFitResult:
-    """Outcome of auto-fitting one coordinate (runtime only — holds a live fig)."""
+    """Outcome of auto-fitting one coordinate (runtime only)."""
 
     coordinate: Coordinate
     method: str
@@ -52,7 +52,7 @@ class PointFitResult:
     message: Optional[str] = None
     channel_name: Optional[str] = None  # display label for `channel` (FM only)
     detail: Optional[str] = None        # raw error, surfaced as a tooltip
-    figure: object = None  # matplotlib Figure; not serialised
+    diagnostic: object = None  # FitDiagnostic; rendered on demand, not serialised
 
     @property
     def delta_px(self) -> float:
@@ -166,61 +166,6 @@ def _kv(key: str, value: str, value_color: str = "#d0d0d0") -> QWidget:
     return w
 
 
-# --- dark theming for the embedded diagnostic figure ---------------------
-# The fit figures (fibsem.correlation.util) are authored light — black text,
-# a near-black gaussian-fit line — for standalone/saved use. This dialog is
-# napari-dark, so a white figure glares against it. Re-theme the figure to the
-# dialog palette at embed time; done here (not in util.py, which lives on main)
-# so the change stays wholly within this dialog.
-_FIG_BG = "#1e2124"    # == the dialog background: figure margins blend in
-_AXES_BG = "#262930"   # a subtle lift so the z line-plot reads as a panel
-_FG = "#d0d0d0"        # dialog foreground (labels, ticks, legend text)
-_FG_TITLE = "#e0e0e0"  # titles / suptitle, a touch brighter
-_SPINE = "#4a4d53"
-# A line darker than this is invisible on the dark panel; the only such artist
-# is the gaussian-fit overlay (authored at 0.15 grey). Lift it to a light grey
-# that still sits below the 0.55 signal line, preserving the fit-vs-signal read.
-_DARK_LINE_LUM = 0.25
-_DARK_LINE_TARGET = "0.8"
-
-
-def _luminance(color) -> float:
-    from matplotlib.colors import to_rgb
-
-    r, g, b = to_rgb(color)
-    return 0.299 * r + 0.587 * g + 0.114 * b
-
-
-def _apply_dark_theme(fig) -> None:
-    """Re-theme a light-authored fit figure onto the napari-dark palette.
-
-    Only theme-agnostic chrome is touched — figure/axes background, text,
-    ticks, spines, legend frame, and any near-black line. The saturated
-    input(red)/fitted(green) markers and the grayscale image data are left
-    exactly as authored (they already read correctly on dark).
-    """
-    fig.set_facecolor(_FIG_BG)
-    for txt in fig.texts:  # figure-level text == the suptitle
-        txt.set_color(_FG_TITLE)
-    for ax in fig.axes:
-        ax.set_facecolor(_AXES_BG)
-        ax.title.set_color(_FG_TITLE)
-        ax.xaxis.label.set_color(_FG)
-        ax.yaxis.label.set_color(_FG)
-        ax.tick_params(colors=_FG)
-        for spine in ax.spines.values():
-            spine.set_color(_SPINE)
-        for line in ax.get_lines():
-            if _luminance(line.get_color()) < _DARK_LINE_LUM:
-                line.set_color(_DARK_LINE_TARGET)
-        legend = ax.get_legend()
-        if legend is not None:
-            legend.get_frame().set_facecolor(_AXES_BG)
-            legend.get_frame().set_edgecolor(_SPINE)
-            for text in legend.get_texts():
-                text.set_color(_FG)
-
-
 class FitConfirmationDialog(QDialog):
     """Modal accept/reject for a single :class:`PointFitResult`.
 
@@ -274,18 +219,19 @@ class FitConfirmationDialog(QDialog):
         # `show_figure` is only the INITIAL state — the pre-fit checkbox default.
         self._canvas = None
         self._diag_shown = False
-        if result.figure is not None:
+        if result.diagnostic is not None:
             from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 
-            _apply_dark_theme(result.figure)
-            try:
-                result.figure.tight_layout()
-            except Exception:
-                pass
-            canvas = FigureCanvasQTAgg(result.figure)
+            from fibsem.correlation.fit_diagnostics import plot_fit_diagnostic
+
+            # Render on demand, dark to match this dialog. The figure is built
+            # via the OO API (no pyplot), so it's freed with the canvas — no
+            # plt.close needed.
+            fig = plot_fit_diagnostic(result.diagnostic, dark=True)
+            canvas = FigureCanvasQTAgg(fig)
             # Size to the figure's aspect so the wide FM figs (z + XY panels
             # at 9x4.5) aren't squished square.
-            w_in, h_in = result.figure.get_size_inches()
+            w_in, h_in = fig.get_size_inches()
             disp_h = 340
             disp_w = int(min(disp_h * (w_in / h_in), 900)) if h_in else disp_h
             canvas.setMinimumSize(max(disp_w, 300), disp_h)

--- a/fibsem/correlation/util.py
+++ b/fibsem/correlation/util.py
@@ -7,6 +7,8 @@ import numpy as np
 from scipy import ndimage
 from scipy.optimize import curve_fit, leastsq
 
+from fibsem.correlation.fit_diagnostics import FitDiagnostic
+
 # migrated from tdct.beadPos and refactored
 
 ### GAUSSIAN FITTING ###
@@ -493,20 +495,16 @@ def hole_fitting_FIB(img: np.ndarray,
     x: float,
     y: float,
     cutout: int = 15,
-    show: bool = False,
 ):
     """Refine selection of hole in FIB image.
     Args:
         img: 2D numpy array (Y,X)
         x,y initial coordinates from the user click (may be sub-pixel)
         cutout: size of the cutout around the point in x,y
-        show: show the diagnostic figure
     Returns:
         xr, yr: refined x, y coordinates
-        fig: matplotlib figure with diagnostic plot (or None if show=False)
+        diagnostic: FitDiagnostic for the (XY-only) diagnostic figure
     """
-    import matplotlib.pyplot as plt
-
     # The click may be sub-pixel; round for integer slicing but keep the
     # fraction so the input marker is drawn exactly where the user clicked
     # (otherwise a no-change fit shows the markers up to ~1px apart).
@@ -535,52 +533,31 @@ def hole_fitting_FIB(img: np.ndarray,
     xr = np.clip(xr, cutout, img.shape[1] - cutout)
     yr = np.clip(yr, cutout, img.shape[0] - cutout)
 
-    # --- Diagnostic figure (XY only — no z for the FIB image) ---
-    C_IN, C_FIT = "#e53935", "#43a047"
-    n = roi.shape[0]
-    fig, ax = plt.subplots(1, 1, figsize=(5, 5))
-    fig.suptitle("FIB hole fit")
-    ax.imshow(roi, cmap="gray")
-    ax.plot(cutout + (x - xi), cutout + (y - yi), "+", color=C_IN, ms=16, mew=2,
-            label="input")
-    if err is None:
-        ax.plot(xopt, yopt, "+", color=C_FIT, ms=16, mew=2, label="fitted")
-    else:
-        ax.text(0.5, 0.08, "fit failed — using input", transform=ax.transAxes,
-                ha="center", va="center", color=C_IN, fontsize=10,
-                bbox=dict(boxstyle="round", fc="black", ec=C_IN, alpha=0.65))
-    ax.set_xlim(-0.5, n - 0.5)
-    ax.set_ylim(n - 0.5, -0.5)
-    ax.set_title("XY")
-    ax.legend(loc="upper right", fontsize=8, framealpha=0.6)
-    ax.axis("off")
-
-    if show:
-        plt.show()
-
-    return xr, yr, fig
+    # --- Diagnostic (XY only — no z for the FIB image) ---
+    diagnostic = FitDiagnostic(
+        title="FIB hole fit",
+        roi_xy=roi,
+        input_xy=(cutout + (x - xi), cutout + (y - yi)),
+        fitted_xy=None if err is not None else (xopt, yopt),
+        xy_title="XY",
+        xy_message=None if err is None else "fit failed — using input",
+    )
+    return xr, yr, diagnostic
 
 def target_fitting_fluorescence(img: np.ndarray,
                                 x: float, y: float, z: int,
                                 cutout: int = 5,
-                                show: bool=False,
-                                use_xy_fitting: bool = False) -> tuple[int, int, int, 'plt.Figure']:
+                                use_xy_fitting: bool = False) -> tuple:
     """Refine selection of target in fluorescence image.
     Args:
         img: 3D numpy array (Z,Y,X), interpolated to isotropic pixel size
         x,y,z initial coordinates from the user click (x, y may be sub-pixel)
         cutout: size of the cutout around the point in x,y. z uses 3x this value
-        show: show the diagnostic figure
         use_xy_fitting: whether to use xy fitting or just return the input x, y
     Returns:
         xr, yr, zr: refined x, y, z coordinates
-        fig: matplotlib figure with diagnostic plot (or None if show=False)
+        diagnostic: FitDiagnostic for the z + XY diagnostic figure
     """
-    import matplotlib.pyplot as plt
-
-    # input (red) / fitted (green) are the only saturated colours; rest greyscale
-    C_IN, C_FIT = "#e53935", "#43a047"
-
     # round the (possibly sub-pixel) click for slicing; keep the fraction for
     # the input marker so it lands exactly where the user clicked (FIB-282).
     xc, yc = int(round(x)), int(round(y))
@@ -590,7 +567,6 @@ def target_fitting_fluorescence(img: np.ndarray,
     zi = popt_z[1]
 
     slc_init = img[int(zi), yc - cutout:yc + cutout, xc - cutout:xc + cutout]
-    n = slc_init.shape[0]
     err = None
     if use_xy_fitting:
         try:
@@ -612,43 +588,21 @@ def target_fitting_fluorescence(img: np.ndarray,
         xopt, yopt = cutout, cutout  # fit result is the cutout centre for plotting
 
     # --- confirmation-friendly diagnostic: z (left) + XY hero (right) ---
-    fig, (ax_z, ax_xy) = plt.subplots(
-        1, 2, figsize=(9, 4.5), gridspec_kw={"width_ratios": [1, 1.4]}
-    )
-    fig.suptitle("Fluorescence target fit")
-
     z_axis = np.arange(len(intensity))
-    ax_z.plot(z_axis, intensity, color="0.55", lw=1.3)
-    ax_z.plot(z_axis, gauss1d(z_axis, *popt_z) + intensity.min(),
-              color="0.15", ls="--", lw=1.2)
-    ax_z.axvline(z, color=C_IN, ls="--", lw=1.6, label=f"input {z}")
-    ax_z.axvline(zi, color=C_FIT, ls="--", lw=1.6, label=f"fitted {zi:.1f}")
-    ax_z.set_title("z", fontsize=10)
-    ax_z.set_xlabel("z slice", fontsize=8)
-    ax_z.set_yticks([])
-    ax_z.tick_params(labelsize=8)
-    ax_z.legend(fontsize=7, framealpha=0.6)
-
-    ax_xy.imshow(slc_init, cmap="gray")
-    ax_xy.plot(cutout + (x - xc), cutout + (y - yc), "+", color=C_IN, ms=16,
-               mew=2, label="input")
-    if err is not None:
-        ax_xy.text(0.5, 0.08, "XY fit failed", transform=ax_xy.transAxes,
-                   ha="center", va="center", color=C_IN, fontsize=10,
-                   bbox=dict(boxstyle="round", fc="black", ec=C_IN, alpha=0.65))
-    elif use_xy_fitting:
-        ax_xy.plot(xopt, yopt, "+", color=C_FIT, ms=16, mew=2, label="fitted")
-    ax_xy.set_xlim(-0.5, n - 0.5)
-    ax_xy.set_ylim(n - 0.5, -0.5)
-    ax_xy.set_title(f"XY  @ z = {zi:.1f}")
-    ax_xy.legend(loc="upper right", fontsize=8, framealpha=0.6)
-    ax_xy.axis("off")
-
-    fig.tight_layout()
-    if show:
-        plt.show()
-
-    return xi, yi, zi, fig
+    diagnostic = FitDiagnostic(
+        title="Fluorescence target fit",
+        roi_xy=slc_init,
+        input_xy=(cutout + (x - xc), cutout + (y - yc)),
+        fitted_xy=(xopt, yopt) if (use_xy_fitting and err is None) else None,
+        xy_title=f"XY  @ z = {zi:.1f}",
+        xy_message="XY fit failed" if err is not None else None,
+        z_axis=z_axis,
+        z_signal=intensity,
+        z_fit=gauss1d(z_axis, *popt_z) + intensity.min(),
+        z_input=z,
+        z_fitted=zi,
+    )
+    return xi, yi, zi, diagnostic
 
 
 def zyx_targeting(
@@ -940,9 +894,8 @@ def fit_gauss1d_mod_old(data: np.ndarray, show: bool = False) -> Tuple[np.ndarra
 
 
 
-def hole_fitting_reflection(da, x, y, z, cutout) -> Tuple[float, float, float, 'plt.Figure']:
+def hole_fitting_reflection(da, x, y, z, cutout) -> tuple:
 
-    import matplotlib.pyplot as plt
     from scipy.ndimage import gaussian_filter
 
     # round the (possibly sub-pixel) click for slicing; keep the fraction for
@@ -978,50 +931,24 @@ def hole_fitting_reflection(da, x, y, z, cutout) -> Tuple[float, float, float, '
     n = roi_fitted.shape[0]
     fit_in_roi = 0 <= xopt < n and 0 <= yopt < n
 
-    # Palette kept deliberately minimal: only input (red) and fitted (green) are
-    # saturated; signal / fit are greyscale so the eye goes to the two markers.
-    C_IN, C_FIT = "#e53935", "#43a047"
-
-    fig, (ax_z, ax_xy) = plt.subplots(
-        1, 2, figsize=(9, 4.5), gridspec_kw={"width_ratios": [1, 1.4]}
-    )
-    fig.suptitle("Reflection hole fit")
-
-    # z: signal + gaussian fit (grey), with input / fitted z the only labels
+    # z: signal + gaussian fit (grey). The hole is dark, so the signal is
+    # inverted (z_inverted) — the peak is the hole.
     z_axis = np.arange(zmin1, zmin1 + len(intensity))
     gauss_curve = gauss1d(np.arange(len(intensity)), *popt) + intensity.min()
-    ax_z.plot(z_axis, intensity, color="0.55", lw=1.3)
-    ax_z.plot(z_axis, gauss_curve, color="0.15", ls="--", lw=1.2)
-    ax_z.axvline(z, color=C_IN, ls="--", lw=1.6, label=f"input {z:.1f}")
-    ax_z.axvline(zreal, color=C_FIT, ls="--", lw=1.6, label=f"fitted {zreal:.1f}")
-    ax_z.set_title("z", fontsize=10)
-    ax_z.set_xlabel("z slice", fontsize=8)
-    # the hole is dark, so the signal is inverted — the peak is the hole
-    ax_z.set_ylabel("signal (inverted)", fontsize=8)
-    ax_z.set_yticks([])
-    ax_z.tick_params(labelsize=8)
-    ax_z.legend(fontsize=7, framealpha=0.6)
 
-    # XY: the hero — did it land on the feature?
-    ax_xy.imshow(gaussian_filter(roi_fitted, sigma=1), cmap="gray")
-    ax_xy.plot(xy_cutout + (x - xi), xy_cutout + (y - yi), "+", color=C_IN, ms=16,
-               mew=2, label="input")
-    if fit_in_roi:
-        ax_xy.plot(xopt, yopt, "+", color=C_FIT, ms=16, mew=2, label="fitted")
-    else:
-        # A failed 2D fit lands outside the ROI; make that explicit instead of
-        # letting matplotlib silently expand the axes to chase the marker.
-        ax_xy.text(
-            0.5, 0.5, "fit fell outside\nthe search region",
-            transform=ax_xy.transAxes, ha="center", va="center",
-            color=C_IN, fontsize=11,
-            bbox=dict(boxstyle="round", fc="black", ec=C_IN, alpha=0.65),
-        )
-    ax_xy.set_xlim(-0.5, n - 0.5)
-    ax_xy.set_ylim(n - 0.5, -0.5)
-    ax_xy.set_title(f"XY  @ z = {zreal:.1f}")
-    ax_xy.legend(loc="upper right", fontsize=8, framealpha=0.6)
-    ax_xy.axis("off")
-
-    fig.tight_layout()
-    return xopt_real, yopt_real, zreal, fig
+    diagnostic = FitDiagnostic(
+        title="Reflection hole fit",
+        roi_xy=gaussian_filter(roi_fitted, sigma=1),
+        input_xy=(xy_cutout + (x - xi), xy_cutout + (y - yi)),
+        # A failed 2D fit lands outside the ROI — say so instead of a marker.
+        fitted_xy=(xopt, yopt) if fit_in_roi else None,
+        xy_title=f"XY  @ z = {zreal:.1f}",
+        xy_message=None if fit_in_roi else "fit fell outside\nthe search region",
+        z_axis=z_axis,
+        z_signal=intensity,
+        z_fit=gauss_curve,
+        z_input=z,
+        z_fitted=zreal,
+        z_inverted=True,
+    )
+    return xopt_real, yopt_real, zreal, diagnostic

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -1422,22 +1422,26 @@ def test_fit_confirmation_dialog_constructs(qapp):
 
 
 def test_fit_dialog_sizes_wide_figure_to_aspect(qapp):
+    import numpy as np
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
-    from matplotlib.figure import Figure
 
+    from fibsem.correlation.fit_diagnostics import FitDiagnostic
     from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
         FitConfirmationDialog,
         FitStatus,
         PointFitResult,
     )
 
-    fig = Figure(figsize=(20, 5))  # like hole_fitting_reflection's 1x3 strip
-    for i in range(3):
-        fig.add_subplot(1, 3, i + 1)
+    # a z + XY diagnostic renders wide (9x4.5), like the FM fits
+    diag = FitDiagnostic(
+        title="t", roi_xy=np.zeros((10, 10)), input_xy=(5.0, 5.0),
+        z_axis=np.arange(5), z_signal=np.arange(5.0), z_fit=np.arange(5.0),
+        z_input=2.0, z_fitted=2.5,
+    )
     r = PointFitResult(
         coordinate=_coord(pt=PointType.FM), method="Hole", channel=0,
         initial=PointXYZ(0.0, 0.0, 0.0), fitted=PointXYZ(2.0, 2.0, 3.0),
-        status=FitStatus.OK, figure=fig,
+        status=FitStatus.OK, diagnostic=diag,
     )
     dialog = FitConfirmationDialog(r, show_figure=True)
     canvases = dialog.findChildren(FigureCanvasQTAgg)
@@ -1445,37 +1449,6 @@ def test_fit_dialog_sizes_wide_figure_to_aspect(qapp):
     canvas = canvases[0]
     assert canvas.minimumWidth() > canvas.minimumHeight()  # wide, not squished
     assert canvas.minimumWidth() <= 900                     # capped
-
-
-def test_apply_dark_theme_darkens_chrome_keeps_data():
-    # The fit figures are authored light; the dialog re-themes them to the dark
-    # palette at embed time. Lock the contract: chrome (figure/axes bg) goes
-    # dark, the near-black gaussian-fit line is lifted so it stays visible, and
-    # the saturated markers / mid-grey signal are left untouched (they read on
-    # dark already, and the marker colours carry meaning).
-    from matplotlib.colors import to_hex
-    from matplotlib.figure import Figure
-
-    from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
-        _AXES_BG,
-        _FIG_BG,
-        _apply_dark_theme,
-        _luminance,
-    )
-
-    fig = Figure()
-    ax = fig.add_subplot(1, 1, 1)
-    (signal,) = ax.plot([0, 1], [0, 1], color="0.55")           # mid-grey
-    (fit,) = ax.plot([0, 1], [1, 0], color="0.15", ls="--")     # near-black
-    (marker,) = ax.plot([0.5], [0.5], "+", color="#e53935")     # input red
-
-    _apply_dark_theme(fig)
-
-    assert to_hex(fig.get_facecolor()) == _FIG_BG
-    assert to_hex(ax.get_facecolor()) == _AXES_BG
-    assert _luminance(fit.get_color()) > _luminance("0.15")     # lifted off black
-    assert signal.get_color() == "0.55"                         # signal untouched
-    assert marker.get_color() == "#e53935"                      # marker untouched
 
 
 def test_humanize_fit_error_maps_known_modes():
@@ -1558,8 +1531,9 @@ def test_error_dialog_splits_title_and_wrapped_reason(qapp):
 
 
 def test_diagnostic_toggle_reveals_and_hides_figure(qapp):
-    from matplotlib.figure import Figure
+    import numpy as np
 
+    from fibsem.correlation.fit_diagnostics import FitDiagnostic
     from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
         FitConfirmationDialog,
         FitStatus,
@@ -1567,12 +1541,11 @@ def test_diagnostic_toggle_reveals_and_hides_figure(qapp):
     )
 
     def _result():
-        fig = Figure(figsize=(9, 4.5))
-        fig.add_subplot(1, 1, 1)
+        diag = FitDiagnostic(title="t", roi_xy=np.zeros((10, 10)), input_xy=(5.0, 5.0))
         return PointFitResult(
             coordinate=_coord(pt=PointType.FM), method="Hole", channel=0,
             initial=PointXYZ(0.0, 0.0, 0.0), fitted=PointXYZ(1.0, 1.0, 1.0),
-            status=FitStatus.OK, figure=fig,
+            status=FitStatus.OK, diagnostic=diag,
         )
 
     # Checkbox unchecked -> figure is still embedded, just hidden; the button
@@ -1597,21 +1570,21 @@ def test_diagnostic_toggle_reveals_and_hides_figure(qapp):
 
 
 def test_accept_is_default_button_not_the_toggle(qapp):
-    from matplotlib.figure import Figure
+    import numpy as np
     from PyQt5.QtWidgets import QPushButton
 
+    from fibsem.correlation.fit_diagnostics import FitDiagnostic
     from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
         FitConfirmationDialog,
         FitStatus,
         PointFitResult,
     )
 
-    fig = Figure(figsize=(9, 4.5))
-    fig.add_subplot(1, 1, 1)
+    diag = FitDiagnostic(title="t", roi_xy=np.zeros((10, 10)), input_xy=(5.0, 5.0))
     result = PointFitResult(
         coordinate=_coord(pt=PointType.FM), method="Hole", channel=0,
         initial=PointXYZ(0.0, 0.0, 0.0), fitted=PointXYZ(1.0, 1.0, 1.0),
-        status=FitStatus.OK, figure=fig,
+        status=FitStatus.OK, diagnostic=diag,
     )
     dlg = FitConfirmationDialog(result, show_figure=True)
     buttons = {b.text(): b for b in dlg.findChildren(QPushButton)}
@@ -1713,7 +1686,7 @@ def test_f_hotkey_skips_while_editing_a_field(qapp, monkeypatch):
     assert fitted == []  # don't hijack the key mid-edit
 
 
-def _fit_result(status, dx=0.0, dy=0.0, dz=0.0, figure=None):
+def _fit_result(status, dx=0.0, dy=0.0, dz=0.0, diagnostic=None):
     from fibsem.correlation.ui.widgets.fit_confirmation_dialog import PointFitResult
 
     initial = PointXYZ(100.0, 100.0, 10.0)
@@ -1725,7 +1698,7 @@ def _fit_result(status, dx=0.0, dy=0.0, dz=0.0, figure=None):
     return PointFitResult(
         coordinate=_coord(100.0, 100.0, 10.0, PointType.FM),
         method="Hole", channel=0, initial=initial, fitted=fitted,
-        status=status, figure=figure,
+        status=status, diagnostic=diagnostic,
     )
 
 
@@ -1802,9 +1775,9 @@ def test_run_point_fit_does_not_mutate_coordinate(qapp, monkeypatch):
 
     w = _widget(qapp)
     w._fib_image = SimpleNamespace(filtered_data=np.zeros((64, 64), dtype=np.float32))
-    fig = object()
+    diag = object()  # stand-in FitDiagnostic
     monkeypatch.setattr(
-        util, "hole_fitting_FIB", lambda img, x, y: (x + 3.0, y + 4.0, fig)
+        util, "hole_fitting_FIB", lambda img, x, y: (x + 3.0, y + 4.0, diag)
     )
 
     coord = _coord(20.0, 20.0, 0.0, PointType.FIB)  # FIB method defaults to "Hole"
@@ -1816,7 +1789,7 @@ def test_run_point_fit_does_not_mutate_coordinate(qapp, monkeypatch):
     assert result.status is FitStatus.OK
     assert (result.fitted.x, result.fitted.y) == (23.0, 24.0)
     assert round(result.delta_px, 1) == 5.0
-    assert result.figure is fig
+    assert result.diagnostic is diag
 
 
 def test_refit_applies_on_accept_not_on_reject(qapp, monkeypatch):

--- a/tests/correlation/test_fit_diagnostics.py
+++ b/tests/correlation/test_fit_diagnostics.py
@@ -1,12 +1,13 @@
-"""Smoke tests for the fit diagnostic figures (FIB-260).
+"""Tests for the fit diagnostics — the compute → data → render split (FIB-281).
 
-The change is presentational (confirmation-friendly figures), so these lock the
-figure layout — each fit runs on a clean synthetic feature, returns finite
-coordinates, and produces the expected number of panels:
+Each fit function computes a refined coordinate and returns a ``FitDiagnostic``
+(data, no matplotlib); ``plot_fit_diagnostic`` renders it. Tests assert on the
+data (panel presence, marker positions) rather than on figure internals, plus a
+couple of render checks.
 
-  * FIB hole            -> 1 panel  (XY only)
-  * reflection hole     -> 2 panels (z + XY)
-  * fluorescence target -> 2 panels (z + XY)
+  * FIB hole            -> XY only        (has_z False)
+  * reflection hole     -> z + XY, inverted signal
+  * fluorescence target -> z + XY
 """
 import matplotlib
 
@@ -14,8 +15,8 @@ matplotlib.use("Agg")
 
 import numpy as np
 import pytest
-from matplotlib.figure import Figure
 
+from fibsem.correlation.fit_diagnostics import FitDiagnostic, plot_fit_diagnostic
 from fibsem.correlation.util import (
     hole_fitting_FIB,
     hole_fitting_reflection,
@@ -28,120 +29,117 @@ def _blob_2d(size: int, cx: float, cy: float, sigma: float = 3.0) -> np.ndarray:
     return np.exp(-((xx - cx) ** 2 + (yy - cy) ** 2) / (2 * sigma**2))
 
 
-def _marker(ax, label: str):
-    """(x, y) of the diagnostic marker with the given legend label."""
-    for line in ax.lines:
-        if line.get_label() == label:
-            return float(line.get_xdata()[0]), float(line.get_ydata()[0])
-    raise AssertionError(f"no marker labelled {label!r}")
+def _refl_vol(cx: float, nz: int = 21, size: int = 60) -> np.ndarray:
+    vol = np.full((nz, size, size), 200.0, dtype=np.float32)
+    for zi in range(nz):  # a dark hole, deepest at z=10
+        vol[zi] -= 160.0 * np.exp(-((zi - 10) ** 2) / (2 * 2.0**2)) * _blob_2d(size, cx, cx)
+    return vol
 
 
-def test_fib_hole_fit_single_panel():
-    # a dark hole on a bright background
+def _fluor_vol(cx: float, nz: int = 21, size: int = 40) -> np.ndarray:
+    vol = np.zeros((nz, size, size), dtype=np.float32)
+    for zi in range(nz):  # a bright target, brightest at z=10
+        vol[zi] += 200.0 * np.exp(-((zi - 10) ** 2) / (2 * 2.0**2)) * _blob_2d(size, cx, cx)
+    return vol
+
+
+# --- the fit fns return a FitDiagnostic (data, no matplotlib) --------------
+
+
+def test_fib_hole_fit_returns_xy_only_diagnostic():
     img = (200.0 - 160.0 * _blob_2d(40, 20, 20)).astype(np.float32)
-    xr, yr, fig = hole_fitting_FIB(img, x=20, y=20, cutout=15)
+    xr, yr, d = hole_fitting_FIB(img, x=20, y=20, cutout=15)
 
+    assert isinstance(d, FitDiagnostic)
     assert np.isfinite(xr) and np.isfinite(yr)
-    assert isinstance(fig, Figure)
-    assert len(fig.axes) == 1  # XY only — no z for a FIB image
+    assert not d.has_z              # FIB has no z panel
+    assert d.fitted_xy is not None  # a clean fit has a fitted marker
 
 
-def test_reflection_hole_fit_z_and_xy_panels():
-    nz = 21
-    vol = np.full((nz, 60, 60), 200.0, dtype=np.float32)
-    for zi in range(nz):
-        depth = np.exp(-((zi - 10) ** 2) / (2 * 2.0**2))  # hole deepest at z=10
-        vol[zi] -= 160.0 * depth * _blob_2d(60, 30, 30)
+def test_reflection_fit_returns_inverted_z_and_xy_diagnostic():
+    xr, yr, zr, d = hole_fitting_reflection(_refl_vol(30), 30, 30, 10, 2)
 
-    xr, yr, zr, fig = hole_fitting_reflection(vol, x=30, y=30, z=10, cutout=2)
-
-    assert np.isfinite(xr) and np.isfinite(yr) and np.isfinite(zr)
-    assert 8 <= zr <= 12  # near the true hole z
-    assert len(fig.axes) == 2  # consolidated: one z panel + XY hero
-
-
-def test_fluorescence_target_fit_z_and_xy_panels():
-    nz = 21
-    vol = np.zeros((nz, 40, 40), dtype=np.float32)
-    for zi in range(nz):
-        bright = np.exp(-((zi - 10) ** 2) / (2 * 2.0**2))  # brightest at z=10
-        vol[zi] += 200.0 * bright * _blob_2d(40, 20, 20)
-
-    xr, yr, zr, fig = target_fitting_fluorescence(vol, x=20, y=20, z=10, cutout=5)
-
-    assert np.isfinite(zr)
+    assert isinstance(d, FitDiagnostic)
+    assert d.has_z and d.z_inverted  # reflection: z panel, signal inverted
     assert 8 <= zr <= 12
-    assert len(fig.axes) == 2
+    assert d.z_fitted == pytest.approx(zr)
+
+
+def test_fluorescence_fit_returns_z_and_xy_diagnostic():
+    xr, yr, zr, d = target_fitting_fluorescence(_fluor_vol(20), 20, 20, 10, 5)
+
+    assert isinstance(d, FitDiagnostic)
+    assert d.has_z and not d.z_inverted
+    assert 8 <= zr <= 12
+    assert d.fitted_xy is None  # default has no XY fitting -> no fitted marker
+
+
+# --- FIB-282: the input marker tracks the sub-pixel click ------------------
 
 
 def test_fib_input_marker_tracks_subpixel_click():
-    # FIB-282: the input marker must sit at the sub-pixel click, not the integer
-    # ROI centre — otherwise a no-change fit draws input vs fitted ~1px apart.
+    # The input marker must sit at the sub-pixel click, not the integer ROI
+    # centre — otherwise a no-change fit draws input vs fitted ~1px apart.
     cx = 20.6
     img = (200.0 - 160.0 * _blob_2d(40, cx, cx)).astype(np.float32)
-    xr, yr, fig = hole_fitting_FIB(img, cx, cx, cutout=15)
+    xr, yr, d = hole_fitting_FIB(img, cx, cx, cutout=15)
 
-    ix, iy = _marker(fig.axes[0], "input")
     expected = 15 + (cx - round(cx))  # cutout + fractional click, not the centre
-    assert ix == pytest.approx(expected, abs=1e-6)
-    assert iy == pytest.approx(expected, abs=1e-6)
-
-    # the hole sits exactly on the click, so the fit shouldn't move it and the
-    # input/fitted markers should land on top of each other.
+    assert d.input_xy == pytest.approx((expected, expected), abs=1e-6)
+    # the hole sits on the click, so the fit shouldn't move it and the markers
+    # should land on top of each other.
     assert xr == pytest.approx(cx, abs=0.3)
-    fx, fy = _marker(fig.axes[0], "fitted")
-    assert abs(ix - fx) < 0.25 and abs(iy - fy) < 0.25
+    assert d.fitted_xy == pytest.approx(d.input_xy, abs=0.25)
 
 
 def test_reflection_input_marker_tracks_subpixel_click():
     cx = 30.6
-    nz = 21
-    vol = np.full((nz, 60, 60), 200.0, dtype=np.float32)
-    for zi in range(nz):
-        depth = np.exp(-((zi - 10) ** 2) / (2 * 2.0**2))
-        vol[zi] -= 160.0 * depth * _blob_2d(60, cx, cx)
+    _, _, _, d = hole_fitting_reflection(_refl_vol(cx), cx, cx, 10, 2)
 
-    _, _, _, fig = hole_fitting_reflection(vol, cx, cx, z=10, cutout=2)
-
-    ax_xy = fig.axes[1]  # z panel is axes[0]; the XY hero is axes[1]
-    ix, iy = _marker(ax_xy, "input")
     expected = 15 + (cx - round(cx))  # xy_cutout is 15
-    assert ix == pytest.approx(expected, abs=1e-6)
-    assert iy == pytest.approx(expected, abs=1e-6)
-
-    fx, fy = _marker(ax_xy, "fitted")
-    assert abs(ix - fx) < 0.5 and abs(iy - fy) < 0.5
-
-
-def _fluorescence_vol(cx, nz=21, size=40):
-    vol = np.zeros((nz, size, size), dtype=np.float32)
-    for zi in range(nz):
-        bright = np.exp(-((zi - 10) ** 2) / (2 * 2.0**2))
-        vol[zi] += 200.0 * bright * _blob_2d(size, cx, cx)
-    return vol
+    assert d.input_xy == pytest.approx((expected, expected), abs=1e-6)
+    assert d.fitted_xy == pytest.approx(d.input_xy, abs=0.5)
 
 
 def test_fluorescence_input_marker_tracks_subpixel_click():
-    # Default path (no XY fitting): only the input marker is drawn, and it must
-    # still sit at the sub-pixel click rather than the integer ROI centre.
     cx = 20.6
-    _, _, _, fig = target_fitting_fluorescence(
-        _fluorescence_vol(cx), cx, cx, z=10, cutout=5
-    )
-    ix, iy = _marker(fig.axes[1], "input")  # XY hero is axes[1]
+    _, _, _, d = target_fitting_fluorescence(_fluor_vol(cx), cx, cx, z=10, cutout=5)
+
     expected = 5 + (cx - round(cx))  # cutout is 5
-    assert ix == pytest.approx(expected, abs=1e-6)
-    assert iy == pytest.approx(expected, abs=1e-6)
+    assert d.input_xy == pytest.approx((expected, expected), abs=1e-6)
 
 
-def test_fluorescence_xy_fit_markers_coincide_at_subpixel_click():
-    # With XY fitting on, the fitted marker should land on the input marker when
-    # the target sits exactly on the (sub-pixel) click.
+def test_fluorescence_xy_fit_marker_coincides_at_subpixel_click():
     cx = 20.6
-    _, _, _, fig = target_fitting_fluorescence(
-        _fluorescence_vol(cx), cx, cx, z=10, cutout=5, use_xy_fitting=True
+    _, _, _, d = target_fitting_fluorescence(
+        _fluor_vol(cx), cx, cx, z=10, cutout=5, use_xy_fitting=True
     )
-    ax_xy = fig.axes[1]
-    ix, iy = _marker(ax_xy, "input")
-    fx, fy = _marker(ax_xy, "fitted")
-    assert abs(ix - fx) < 0.5 and abs(iy - fy) < 0.5
+    assert d.fitted_xy is not None
+    assert d.fitted_xy == pytest.approx(d.input_xy, abs=0.5)
+
+
+# --- plot_fit_diagnostic renders the data ----------------------------------
+
+
+def _xy_only():
+    return FitDiagnostic(title="t", roi_xy=np.zeros((10, 10)), input_xy=(5.0, 5.0))
+
+
+def _with_z():
+    return FitDiagnostic(
+        title="t", roi_xy=np.zeros((10, 10)), input_xy=(5.0, 5.0),
+        z_axis=np.arange(5), z_signal=np.arange(5.0), z_fit=np.arange(5.0),
+        z_input=2.0, z_fitted=2.5,
+    )
+
+
+def test_plot_fit_diagnostic_panel_counts():
+    assert len(plot_fit_diagnostic(_xy_only()).axes) == 1   # XY only
+    assert len(plot_fit_diagnostic(_with_z()).axes) == 2    # z + XY
+
+
+def test_plot_fit_diagnostic_dark_vs_light_facecolor():
+    from matplotlib.colors import to_hex
+
+    assert to_hex(plot_fit_diagnostic(_with_z(), dark=True).get_facecolor()) == "#1e2124"
+    assert to_hex(plot_fit_diagnostic(_with_z(), dark=False).get_facecolor()) == "#ffffff"


### PR DESCRIPTION
## Summary

Implements [FIB-281](https://linear.app/fibsemos/issue/FIB-281): split the correlation fit **compute** from the diagnostic **render**. The three fit functions in `util.py` computed a refined coordinate *and* built a matplotlib figure inline, on every call — even when the figure was never shown. Now they return data; a separate function renders it.

**No user-visible change** — the confirm dialog and all three figures render identically (verified pixel-for-pixel, dark and in-app).

## What changed

- **New `fibsem/correlation/fit_diagnostics.py`**: a `FitDiagnostic` dataclass (everything needed to draw the diagnostic — image, marker positions, z profile) + `plot_fit_diagnostic(d, *, dark=False)`. Built via the OO `Figure` API (no pyplot), so the figure is freed with its canvas — no `plt.close`.
- **`util.py`**: `hole_fitting_FIB` / `hole_fitting_reflection` / `target_fitting_fluorescence` now **return a `FitDiagnostic`** instead of a `Figure`, and no longer import matplotlib.
- **`fit_confirmation_dialog.py`**: `PointFitResult.figure` → `.diagnostic`; the dialog renders `plot_fit_diagnostic(diag, dark=True)` **on demand**, so a figure is built only when actually shown (not on the auto-accept / diagnostic-off paths). The post-hoc `_apply_dark_theme` moves into `fit_diagnostics` as the dark render path.
- **`correlation_tab_widget.py`**: `_run_point_fit` stores the diagnostic; both `plt.close(result.figure)` calls are gone.

## Why

- Compute path is now **matplotlib-free** and builds no throwaway figures.
- The dialog's dark theme is a **render parameter**, not a re-theme-after-the-fact hack.
- Diagnostics are **testable on data** (marker positions, panel presence) rather than on figure internals.
- Sets up [FIB-283](https://linear.app/fibsemos/issue/FIB-283) (in-dialog re-fit / nudge) cleanly.

## Two small render normalisations

From unifying three render paths into one (flagged for transparency):
1. The fluorescence z legend now reads **"input 10.0"** (matching reflection's `.1f`; was "input 10").
2. A **failed** fit's message is centred at 11pt for all three (FIB/fluorescence were bottom-anchored at 10pt).

## Testing

135 correlation tests pass headless (`QT_QPA_PLATFORM=offscreen`). `test_fit_diagnostics.py` rewritten to assert on `FitDiagnostic` fields (incl. the FIB-282 sub-pixel input marker) + a couple of `plot_fit_diagnostic` render checks (panel count, dark facecolor); the dialog tests pass a `FitDiagnostic`. Verified end-to-end in the running app.
