### PR TITLE
FM driver parity: promote ABC contract + typing cleanup (FIB-288)

### DIFF
--- a/docs/design/odemis-fm-driver.md
+++ b/docs/design/odemis-fm-driver.md
@@ -141,11 +141,13 @@ Ordered so each phase is a small, independently reviewable PR; P0s first. F7b la
 3. Optional: snapshot-during-live helper using `data.get(asap=False)`.
 - *Acceptance:* live view on the sim backend streams at exposure-limited rate (not seconds/frame); start/stop leaves light off and stream inactive, including on exceptions.
 
-**Phase 4 — parity & typing (P2/P3): F11–F19**
-1. Gain wiring via `model.hasVA(camera, "gain")` (per D4).
-2. `available_binnings` + `exposure_time_limits` from VA ranges; binning validation against `binning.range`.
-3. Promote `power_limits` / `exposure_time_limits` / `available_binnings` / `state` into the base ABCs with sim defaults; align TFS + Odemis (per D5).
-4. Annotation sweep (F15–F18), remove dead attributes (F19).
+**Phase 4 — parity & typing (P2/P3): F11–F19 (+ carried items)**
+1. Gain wiring via `model.hasVA(camera, "gain")` (per D4): getter returns None without a hardware VA (metadata stays honest — `FluorescenceChannelMetadata.gain` becomes `Optional[float]`, camera widget disables the spinbox); setter is a warn-once no-op.
+2. `available_binnings` + `exposure_time_limits` from the camera VAs (choices when enumerated, powers of two within range otherwise); binning validation against them.
+3. Promote `power_limits` / `exposure_time_limits` / `available_binnings` into the base ABCs with sim defaults; the base binning setter validates against `available_binnings` (replacing the old `raise Warning`); TFS already conforms (no autoscript changes needed — the promotion formalizes its existing surface).
+4. Annotation sweep (F15–F18), remove dead attributes (F19); `offset` stays a read-only property by intent (documented).
+5. Per-instance acquisition state: `_stop_acquisition_event` / `_acquisition_thread` move from shared class attributes into `__init__`. (The same pattern exists on `FibsemMicroscope` in `fibsem/microscope.py:154` — out of FM scope, tracked separately.)
+6. F20 (carried from Phase 3): `_construct_image(data, frame_metadata=None)` — per-frame values (`pixel_size`, `acquisition_date`, `exposure_time`) override the state snapshot; the odemis microscope overrides `_construct_image` to auto-extract them from `DataArray.metadata`, so both single-shot and live paths stay correctly stamped even when settings change mid-stream.
 
 ## Testing
 

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -35,6 +35,7 @@ SIM_OBJECTIVE_USER_POSITION_LIMIT = 8.6e-3  # user-defined limits for the object
 SIM_OBJECTIVE_FOCUS_POSITION = 8.0e-3
 
 SIM_CAMERA_EXPOSURE_TIME = 0.1  # seconds
+SIM_CAMERA_EXPOSURE_LIMITS = (1e-6, 60.0)  # seconds
 SIM_CAMERA_BINNING = 4
 SIM_CAMERA_GAIN = 0.01  # 1%
 SIM_CAMERA_OFFSET = 0.0
@@ -320,18 +321,34 @@ class Camera(ABC):
         """Set the binning of the camera.
 
         Args:
-            value: The binning factor (must be >= 1)
+            value: The binning factor (must be in available_binnings)
 
         Raises:
-            ValueError: If binning is less than 1
+            ValueError: If the binning value is not supported
         """
-        if value < 1:
-            raise ValueError("Binning must be at least 1.")
-        if value not in BINNING_VALUES:
-            raise Warning(
-                "Unusual binning value set. Typical values are 1, 2, 4, or 8."
+        if value not in self.available_binnings:
+            raise ValueError(
+                f"Binning must be one of {self.available_binnings}, got {value}"
             )
         self._binning = value
+
+    @property
+    def available_binnings(self) -> Tuple[int, ...]:
+        """Get the supported binning values for the camera.
+
+        Returns:
+            A tuple of supported binning factors (e.g., (1, 2, 4, 8))
+        """
+        return tuple(BINNING_VALUES)
+
+    @property
+    def exposure_time_limits(self) -> Tuple[float, float]:
+        """Get the valid exposure time range for the camera.
+
+        Returns:
+            A tuple of (minimum, maximum) exposure times in seconds
+        """
+        return SIM_CAMERA_EXPOSURE_LIMITS
 
     @property
     def gain(self) -> float:
@@ -451,6 +468,18 @@ class LightSource(ABC):
         """
         self._power = value
 
+    @property
+    def power_limits(self) -> Tuple[float, float]:
+        """Get the valid power range for the light source.
+
+        Power is expressed as a fraction of maximum power (0-1) across all
+        drivers; hardware units are normalised inside each driver.
+
+        Returns:
+            A tuple of (minimum, maximum) power levels
+        """
+        return (0.0, 1.0)
+
 
 class FilterSet(ABC):
     """Abstract base class for filter set control in fluorescence microscopy.
@@ -553,11 +582,9 @@ class FluorescenceMicroscope(ABC):
     camera: Camera
     light_source: LightSource
 
-    # live acquisition
+    # live acquisition signals (psygnal binds these per-instance on access)
     acquisition_signal = Signal(FluorescenceImage)
     acquisition_progress_signal = Signal(dict)
-    _stop_acquisition_event = threading.Event()
-    _acquisition_thread: Optional[threading.Thread] = None
 
     def __init__(self, parent: Optional["FibsemMicroscope"] = None):
         """Initialize the fluorescence microscope with default components.
@@ -568,6 +595,10 @@ class FluorescenceMicroscope(ABC):
         super().__init__()
 
         self.parent = parent
+
+        # per-instance acquisition state (previously shared class attributes)
+        self._stop_acquisition_event = threading.Event()
+        self._acquisition_thread: Optional[threading.Thread] = None
 
         self.channel_name: str = "channel-01"
         self.channel_color: str = "gray"
@@ -793,13 +824,34 @@ class FluorescenceMicroscope(ABC):
         img = self._construct_image(data)
         return img
 
-    def _construct_image(self, data: np.ndarray) -> FluorescenceImage:
+    def _construct_image(
+        self, data: np.ndarray, frame_metadata: Optional[dict] = None
+    ) -> FluorescenceImage:
         """Construct a FluorescenceImage from raw data with associated metadata.
 
         Applies the configured image transformation to align the fluorescence image
         with the SEM/FIB coordinate system.
+
+        Args:
+            data: The raw image data.
+            frame_metadata: Optional per-frame metadata captured at exposure
+                time by the driver; where present these values override the
+                state snapshot from get_metadata(). Supported keys:
+                'pixel_size' ((x, y) in metres), 'acquisition_date'
+                (ISO string), 'exposure_time' (seconds).
         """
         md = self.get_metadata()
+
+        if frame_metadata:
+            pixel_size = frame_metadata.get("pixel_size")
+            if pixel_size is not None:
+                md.pixel_size_x, md.pixel_size_y = pixel_size[0], pixel_size[1]
+            acquisition_date = frame_metadata.get("acquisition_date")
+            if acquisition_date is not None:
+                md.acquisition_date = acquisition_date
+            exposure_time = frame_metadata.get("exposure_time")
+            if exposure_time is not None and md.channels:
+                md.channels[0].exposure_time = exposure_time
 
         # Apply image transformation to align with SEM/FIB images
         data = self._apply_image_transform(data)

--- a/fibsem/fm/odemis.py
+++ b/fibsem/fm/odemis.py
@@ -2,6 +2,7 @@ import numpy as np
 import logging
 import time
 
+from datetime import datetime
 from typing import Dict, List, Literal, Optional, Tuple, Union
 from fibsem.fm.microscope import (
     Camera,
@@ -10,6 +11,7 @@ from fibsem.fm.microscope import (
     LightSource,
     ObjectiveLens,
 )
+from fibsem.fm.structures import FluorescenceImage
 from fibsem.microscopes.odemis_microscope import add_odemis_path
 
 add_odemis_path()
@@ -25,6 +27,33 @@ from odemis.util import fluo
 OBJECTIVE_POSITION_ATOL = 100e-6  # m
 
 
+def _frame_metadata_from_data(data) -> Optional[dict]:
+    """Translate odemis DataArray metadata to the neutral frame-metadata keys
+    consumed by FluorescenceMicroscope._construct_image.
+
+    Odemis DataArrays carry metadata captured at exposure time (pixel size,
+    acquisition date, exposure time), which is authoritative over a state
+    snapshot taken when the frame is processed.
+    """
+    md = getattr(data, "metadata", None)
+    if not md:
+        return None
+
+    frame_metadata = {}
+    pixel_size = md.get(model.MD_PIXEL_SIZE)
+    if pixel_size is not None:
+        frame_metadata["pixel_size"] = tuple(pixel_size)
+    acquisition_date = md.get(model.MD_ACQ_DATE)
+    if acquisition_date is not None:
+        frame_metadata["acquisition_date"] = datetime.fromtimestamp(
+            acquisition_date
+        ).isoformat()
+    exposure_time = md.get(model.MD_EXP_TIME)
+    if exposure_time is not None:
+        frame_metadata["exposure_time"] = exposure_time
+    return frame_metadata or None
+
+
 class OdemisObjectiveLens(ObjectiveLens):
     """Odemis objective lens implementation for fluorescence microscopy.
 
@@ -33,11 +62,15 @@ class OdemisObjectiveLens(ObjectiveLens):
     for improved performance when accessing frequently used position values.
     """
 
-    def __init__(self, parent: "Client", focuser: model.Actuator = None):
+    def __init__(
+        self,
+        parent: "OdemisFluorescenceMicroscope",
+        focuser: Optional[model.Actuator] = None,
+    ):
         """Initialize the objective lens with optional focuser component.
 
         Args:
-            parent: The parent client instance
+            parent: The parent fluorescence microscope instance
             focuser: Optional focuser actuator component. If None, will be
                     automatically detected using the 'focus' role.
         """
@@ -107,7 +140,7 @@ class OdemisObjectiveLens(ObjectiveLens):
                 return None
 
     @property
-    def deactive_position(self):
+    def deactive_position(self) -> Optional[dict]:
         """Get the deactive (retracted) position of the objective lens.
 
         Uses cached metadata when available for improved performance,
@@ -304,11 +337,15 @@ class OdemisCamera(Camera):
     through the Odemis streaming interface.
     """
 
-    def __init__(self, parent: "Client", camera: Optional[model.DigitalCamera] = None):
+    def __init__(
+        self,
+        parent: "OdemisFluorescenceMicroscope",
+        camera: Optional[model.DigitalCamera] = None,
+    ):
         """Initialize the camera with optional camera component.
 
         Args:
-            parent: The parent client instance
+            parent: The parent fluorescence microscope instance
             camera: Optional camera component. If None, will be automatically
                    detected using the 'ccd' role.
         """
@@ -335,6 +372,7 @@ class OdemisCamera(Camera):
 
         # not all cameras publish a baseline (only some drivers set MD_BASELINE)
         self._offset = camera_md.get(model.MD_BASELINE, 0)
+        self._gain_warning_logged = False
 
     # other attributes: depthOfField, readoutRate, pointSpreadFunctionSize
 
@@ -446,9 +484,68 @@ class OdemisCamera(Camera):
         Note:
             Sets symmetric binning (same value for both x and y axes)
         """
-        if value not in [1, 2, 4, 8]:
-            raise ValueError(f"Binning must be one of [1, 2, 4, 8], got {value}")
+        if value not in self.available_binnings:
+            raise ValueError(
+                f"Binning must be one of {self.available_binnings}, got {value}"
+            )
         self._camera.binning.value = (value, value)
+
+    @property
+    def available_binnings(self) -> Tuple[int, ...]:
+        """Get the supported binning values from the camera binning VA.
+
+        Uses the VA choices when enumerated; otherwise powers of two within
+        the VA range.
+        """
+        binning_va = self._camera.binning
+        choices = getattr(binning_va, "choices", None)
+        if choices:
+            return tuple(sorted({int(c[0]) for c in choices}))
+        min_binning = binning_va.range[0][0]
+        max_binning = binning_va.range[1][0]
+        binnings = []
+        b = 1
+        while b <= max_binning:
+            if b >= min_binning:
+                binnings.append(b)
+            b *= 2
+        return tuple(binnings)
+
+    @property
+    def exposure_time_limits(self) -> Tuple[float, float]:
+        """Get the valid exposure time range from the camera VA.
+
+        Returns:
+            A tuple of (minimum, maximum) exposure times in seconds
+        """
+        rng = self._camera.exposureTime.range
+        return (rng[0], rng[1])
+
+    @property
+    def gain(self) -> Optional[float]:
+        """Get the camera gain, or None when the camera has no gain control.
+
+        Only reports values that reflect hardware state: if the camera
+        exposes no gain VA, None is returned (and recorded in metadata)
+        rather than echoing back a software-only value.
+        """
+        if model.hasVA(self._camera, "gain"):
+            return self._camera.gain.value
+        return None
+
+    @gain.setter
+    def gain(self, value: float) -> None:
+        """Set the camera gain when the camera supports it.
+
+        Ignored (with a one-time warning) on cameras without a gain VA, so
+        applying a saved channel with a gain value does not fail.
+        """
+        if model.hasVA(self._camera, "gain"):
+            self._camera.gain.value = value
+            return
+        if not self._gain_warning_logged:
+            logging.warning("Camera has no gain control; ignoring gain settings.")
+            self._gain_warning_logged = True
 
     @property
     def pixel_size(self) -> Tuple[float, float]:
@@ -482,6 +579,9 @@ class OdemisCamera(Camera):
     def offset(self) -> float:
         """Get the baseline offset of the camera.
 
+        Read-only: the offset comes from the camera MD_BASELINE metadata;
+        the base-class setter is intentionally not supported here.
+
         Returns:
             The camera's baseline offset value from metadata
         """
@@ -497,7 +597,9 @@ class OdemisLightSource(LightSource):
     """
 
     def __init__(
-        self, parent: "OdemisFluorescenceMicroscope", light_source: model.Emitter = None
+        self,
+        parent: "OdemisFluorescenceMicroscope",
+        light_source: Optional[model.Emitter] = None,
     ):
         """Initialize the light source with optional emitter component.
 
@@ -548,13 +650,18 @@ class OdemisLightSource(LightSource):
         max_power = self._stream.power.range[1]
         self._stream.power.value = value * max_power
 
+    @property
     def power_limits(self) -> Tuple[float, float]:
         """Get the valid power range for the light source.
 
+        Power is normalised to a fraction of maximum across all drivers;
+        the underlying watt range remains available on the stream power VA
+        for diagnostics.
+
         Returns:
-            A tuple of (minimum, maximum) power levels
+            A tuple of (minimum, maximum) power fractions (0.0, 1.0)
         """
-        return self._stream.power.range
+        return (0.0, 1.0)
 
     # spectra property?
 
@@ -576,7 +683,7 @@ class OdemisFilterSet(FilterSet):
         for user convenience. None values represent reflection/pass-through mode.
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: Optional["OdemisFluorescenceMicroscope"] = None):
         """Initialize the filter set with parent microscope.
 
         Args:
@@ -585,8 +692,6 @@ class OdemisFilterSet(FilterSet):
         super().__init__(parent)
         self.parent = parent
         self._stream: FluoStream = self.parent._stream
-        self._excitation_wavelength = None
-        self._emission_wavelength = None
 
     # NOTE on internal representation:
     # images are acquired via the public stream interface, as it contains the necessary components
@@ -820,3 +925,17 @@ class OdemisFluorescenceMicroscope(FluorescenceMicroscope):
         self.camera = OdemisCamera(self, camera=camera)
         self.light_source = OdemisLightSource(self, light_source=light_source)
         self.filter_set = OdemisFilterSet(self)
+
+    def _construct_image(
+        self, data: np.ndarray, frame_metadata: Optional[dict] = None
+    ) -> FluorescenceImage:
+        """Construct a FluorescenceImage, preferring per-frame odemis metadata.
+
+        Odemis DataArrays carry authoritative metadata captured at exposure
+        time (pixel size, acquisition date, exposure time); when present it
+        overrides the state snapshot, so frames stay correctly stamped even
+        if settings change during live view.
+        """
+        if frame_metadata is None:
+            frame_metadata = _frame_metadata_from_data(data)
+        return super()._construct_image(data, frame_metadata=frame_metadata)

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -1146,7 +1146,7 @@ class FluorescenceChannelMetadata:
 
     # Camera settings
     exposure_time: float  # seconds
-    gain: float  # camera gain
+    gain: Optional[float]  # camera gain (None when the camera has no gain control)
     offset: float  # camera offset
 
     # Fields with defaults must come after required fields

--- a/fibsem/ui/fm/widgets/camera_widget.py
+++ b/fibsem/ui/fm/widgets/camera_widget.py
@@ -70,7 +70,13 @@ class CameraWidget(QWidget):
         self.spinBox_gain.setSuffix(CAMERA_CONFIG["gain"]["suffix"])
         self.spinBox_gain.setToolTip(CAMERA_CONFIG["gain"]["tooltip"])
         self.spinBox_gain.setKeyboardTracking(False)
-        self.spinBox_gain.setValue(self.fm.camera.gain * 100)  # Convert to percentage
+        gain = self.fm.camera.gain
+        if gain is None:
+            # camera has no gain control (e.g. odemis camera without a gain VA)
+            self.spinBox_gain.setEnabled(False)
+            self.spinBox_gain.setToolTip("Camera gain is not supported on this system")
+        else:
+            self.spinBox_gain.setValue(gain * 100)  # Convert to percentage
 
         # Binning
         self.label_binning = QLabel("Binning", self)

--- a/tests/fm/_odemis_stubs.py
+++ b/tests/fm/_odemis_stubs.py
@@ -25,7 +25,22 @@ MD_PIXEL_SIZE = "Pixel size"
 MD_BASELINE = "Baseline value"
 MD_FAV_POS_ACTIVE = "Favourite position active"
 MD_FAV_POS_DEACTIVE = "Favourite position deactive"
+MD_ACQ_DATE = "Acquisition date"
+MD_EXP_TIME = "Exposure time"
 BAND_PASS_THROUGH = "pass-through"
+
+
+class FakeDataArray(np.ndarray):
+    """odemis model.DataArray stand-in: an ndarray carrying a metadata dict."""
+
+    def __new__(cls, array, metadata=None):
+        obj = np.asarray(array).view(cls)
+        obj.metadata = dict(metadata) if metadata else {}
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is not None:
+            self.metadata = getattr(obj, "metadata", {})
 
 ODEMIS_MODULE_NAMES = (
     "odemis",
@@ -239,10 +254,21 @@ class FakeFluoStream:
 
 
 def fake_acquire(streams, settings_obs=None):
-    """acqmng.acquire stand-in: future resolving to ([DataArray], None)."""
+    """acqmng.acquire stand-in: future resolving to ([DataArray], None).
+
+    The returned frame carries per-exposure metadata like a real odemis
+    DataArray (pixel size, acquisition date, exposure time).
+    """
     detector = streams[0]._detector
     res = detector.resolution.value
-    data = np.zeros(res[::-1], dtype=np.uint16)
+    data = FakeDataArray(
+        np.zeros(res[::-1], dtype=np.uint16),
+        metadata={
+            MD_PIXEL_SIZE: detector.getMetadata()[MD_PIXEL_SIZE],
+            MD_ACQ_DATE: 1_780_000_000.0,  # fixed timestamp for determinism
+            MD_EXP_TIME: detector.exposureTime.value,
+        },
+    )
     return FakeFuture(([data], None))
 
 
@@ -308,11 +334,13 @@ def install_odemis_stubs() -> None:
     model_mod.MD_BASELINE = MD_BASELINE
     model_mod.MD_FAV_POS_ACTIVE = MD_FAV_POS_ACTIVE
     model_mod.MD_FAV_POS_DEACTIVE = MD_FAV_POS_DEACTIVE
+    model_mod.MD_ACQ_DATE = MD_ACQ_DATE
+    model_mod.MD_EXP_TIME = MD_EXP_TIME
     model_mod.BAND_PASS_THROUGH = BAND_PASS_THROUGH
     model_mod.Actuator = FakeFocuser
     model_mod.DigitalCamera = FakeCamera
     model_mod.Emitter = FakeLight
-    model_mod.DataArray = np.ndarray
+    model_mod.DataArray = FakeDataArray
     model_mod.getComponent = lambda role: _get_component(role)
     model_mod.hasVA = lambda comp, name: isinstance(getattr(comp, name, None), FakeVA)
 

--- a/tests/fm/test_fm_contract.py
+++ b/tests/fm/test_fm_contract.py
@@ -1,0 +1,97 @@
+"""Contract tests for the FluorescenceMicroscope base classes (FIB-288).
+
+The base classes double as the simulator and as the contract every driver
+implements (and, later, the wire contract for remote control). These tests
+pin the members promoted into the ABCs and the per-instance acquisition
+state, using the simulated implementations directly.
+
+TFS-driver conformance can only run on machines with the autoscript SDK;
+odemis-driver conformance is covered in test_odemis_driver.py.
+"""
+
+import numpy as np
+import pytest
+
+from fibsem.fm.microscope import (
+    BINNING_VALUES,
+    SIM_CAMERA_EXPOSURE_LIMITS,
+    FluorescenceMicroscope,
+)
+
+
+@pytest.fixture()
+def fm():
+    return FluorescenceMicroscope()
+
+
+class TestPromotedContract:
+    """power_limits / exposure_time_limits / available_binnings / state."""
+
+    def test_camera_available_binnings(self, fm):
+        assert fm.camera.available_binnings == tuple(BINNING_VALUES)
+
+    def test_camera_exposure_time_limits(self, fm):
+        assert fm.camera.exposure_time_limits == SIM_CAMERA_EXPOSURE_LIMITS
+
+    def test_light_source_power_limits_fraction(self, fm):
+        assert fm.light_source.power_limits == (0.0, 1.0)
+
+    def test_binning_setter_rejects_unsupported(self, fm):
+        with pytest.raises(ValueError):
+            fm.camera.binning = 3
+
+    def test_binning_setter_accepts_supported(self, fm):
+        fm.camera.binning = 2
+        assert fm.camera.binning == 2
+
+    def test_objective_state_is_a_string_property(self, fm):
+        assert isinstance(fm.objective.state, str)
+        assert fm.objective.state in ("Inserted", "Retracted", "Busy", "Error", "Other")
+
+
+class TestPerInstanceAcquisitionState:
+    """The stop event and thread handle must not be shared between instances."""
+
+    def test_stop_events_are_independent(self):
+        fm_a = FluorescenceMicroscope()
+        fm_b = FluorescenceMicroscope()
+        assert fm_a._stop_acquisition_event is not fm_b._stop_acquisition_event
+        fm_a._stop_acquisition_event.set()
+        assert not fm_b._stop_acquisition_event.is_set()
+
+    def test_thread_handles_are_independent(self):
+        fm_a = FluorescenceMicroscope()
+        fm_b = FluorescenceMicroscope()
+        fm_a._acquisition_thread = object()
+        assert fm_b._acquisition_thread is None
+
+
+class TestConstructImageFrameMetadata:
+    """Optional per-frame metadata overrides the state snapshot (F20)."""
+
+    def test_no_frame_metadata_uses_state_snapshot(self, fm):
+        image = fm._construct_image(np.zeros((8, 8), dtype=np.uint16))
+        assert image.metadata.pixel_size_x == pytest.approx(fm.camera.pixel_size[0])
+
+    def test_frame_metadata_overrides_geometry_and_timing(self, fm):
+        frame_metadata = {
+            "pixel_size": (5e-8, 6e-8),
+            "acquisition_date": "2026-07-22T10:00:00",
+            "exposure_time": 0.42,
+        }
+        image = fm._construct_image(
+            np.zeros((8, 8), dtype=np.uint16), frame_metadata=frame_metadata
+        )
+        assert image.metadata.pixel_size_x == pytest.approx(5e-8)
+        assert image.metadata.pixel_size_y == pytest.approx(6e-8)
+        assert image.metadata.acquisition_date == "2026-07-22T10:00:00"
+        assert image.metadata.channels[0].exposure_time == pytest.approx(0.42)
+
+    def test_partial_frame_metadata_only_overrides_present_keys(self, fm):
+        image = fm._construct_image(
+            np.zeros((8, 8), dtype=np.uint16),
+            frame_metadata={"exposure_time": 0.42},
+        )
+        # exposure overridden, geometry still from the state snapshot
+        assert image.metadata.channels[0].exposure_time == pytest.approx(0.42)
+        assert image.metadata.pixel_size_x == pytest.approx(fm.camera.pixel_size[0])

--- a/tests/fm/test_odemis_driver.py
+++ b/tests/fm/test_odemis_driver.py
@@ -16,11 +16,14 @@ Each test class covers a finding from Phase 1 (FIB-285) or Phase 2 (FIB-286):
 - F9  'Fluorescence' emission maps to the band matching the excitation
 - F10 live acquisition via dataflow subscription (stream active once,
       frames pushed, light off on stop in all paths)
+- F11-F13 gain wiring via hasVA, binning/exposure limits from the VAs
+- F20 per-frame DataArray metadata overrides the state snapshot
 """
 
 import sys
 import time
 import types
+from datetime import datetime
 
 import numpy as np
 import pytest
@@ -403,6 +406,101 @@ class TestEmissionFluorescenceMapping:
         sets_before = emission_va.set_count
         fm.filter_set.emission_wavelength = "Fluorescence"
         assert emission_va.set_count == sets_before
+
+
+class TestGainWiring:
+    """F11: gain maps to the camera gain VA when present; honest otherwise."""
+
+    def test_gain_none_without_hardware_va(self, fm):
+        assert fm.camera.gain is None
+
+    def test_set_gain_without_va_is_warn_once_noop(self, fm, caplog):
+        fm.set_gain(0.5)
+        fm.set_gain(0.7)
+        warnings = [r for r in caplog.records if "no gain control" in r.message]
+        assert len(warnings) == 1
+        assert fm.camera.gain is None  # never echoes back a software value
+
+    def test_metadata_gain_none_without_va(self, fm):
+        metadata = fm.get_metadata()
+        assert metadata.channels[0].gain is None
+
+    def test_gain_wired_when_va_present(self, odemis_env):
+        components = stubs.default_components()
+        components["ccd"].gain = stubs.FakeVA(1.0, range=(1.0, 30.0))
+        stubs.use_components(components)
+        microscope = odemis_env.module.OdemisFluorescenceMicroscope(parent=None)
+        microscope.set_gain(2.5)
+        assert components["ccd"].gain.value == pytest.approx(2.5)
+        assert microscope.camera.gain == pytest.approx(2.5)
+        assert microscope.get_metadata().channels[0].gain == pytest.approx(2.5)
+
+
+class TestCameraLimitsFromHardware:
+    """F12/F13: binning and exposure limits come from the camera VAs."""
+
+    def test_available_binnings_from_range(self, fm):
+        assert fm.camera.available_binnings == (1, 2, 4, 8, 16)
+
+    def test_binning_setter_accepts_hardware_supported_value(self, fm):
+        fm.set_binning(16)
+        assert fm.camera.binning == 16
+
+    def test_binning_setter_rejects_unsupported_value(self, fm):
+        with pytest.raises(ValueError):
+            fm.set_binning(3)
+
+    def test_available_binnings_from_choices(self, odemis_env):
+        components = stubs.default_components()
+        components["ccd"].binning.choices = {(1, 1), (2, 2), (4, 4)}
+        stubs.use_components(components)
+        microscope = odemis_env.module.OdemisFluorescenceMicroscope(parent=None)
+        assert microscope.camera.available_binnings == (1, 2, 4)
+
+    def test_exposure_time_limits_from_va(self, fm):
+        assert fm.camera.exposure_time_limits == (1e-3, 10.0)
+
+    def test_power_limits_is_a_fraction_property(self, fm):
+        assert fm.light_source.power_limits == (0.0, 1.0)
+
+
+class TestFrameMetadata:
+    """F20: per-frame DataArray metadata overrides the state snapshot."""
+
+    def test_single_shot_uses_frame_metadata(self, fm):
+        image = fm.acquire_image()
+        # fake_acquire stamps a fixed acquisition date + the VA exposure time
+        expected_date = datetime.fromtimestamp(1_780_000_000.0).isoformat()
+        assert image.metadata.acquisition_date == expected_date
+        assert image.metadata.channels[0].exposure_time == pytest.approx(
+            fm.components["ccd"].exposureTime.value
+        )
+
+    def test_live_frame_metadata_overrides_state(self, fm):
+        received = []
+        fm.acquisition_signal.connect(received.append)
+        try:
+            fm.set_rate_limit(0)
+            fm.start_acquisition()
+            stream = fm.camera._stream
+            dataflow = fm.components["ccd"].data
+            assert wait_until(lambda: stream.is_active.value)
+            assert wait_until(lambda: dataflow.listeners)
+            frame = stubs.FakeDataArray(
+                np.zeros((16, 16), dtype=np.uint16),
+                metadata={stubs.MD_PIXEL_SIZE: (9e-8, 9e-8)},
+            )
+            dataflow.push(frame)
+            assert wait_until(lambda: len(received) >= 1)
+            # the frame's own pixel size wins over the current camera state
+            assert received[0].metadata.pixel_size_x == pytest.approx(9e-8)
+        finally:
+            fm.stop_acquisition()
+            fm.acquisition_signal.disconnect(received.append)
+
+    def test_plain_ndarray_frames_fall_back_to_state(self, fm):
+        image = fm._construct_image(np.zeros((8, 8), dtype=np.uint16))
+        assert image.metadata.pixel_size_x == pytest.approx(1e-7)
 
 
 class TestFastAcquisition:


### PR DESCRIPTION
Phase 4 of the FM driver update, following #165 (phases 1–3, merged). Plan and rationale in `docs/design/odemis-fm-driver.md` (§ Phase 4, updated here).

The base ABCs in `fibsem/fm/microscope.py` never declared several members the drivers invented ad-hoc, which is why the TFS and Odemis drivers drifted apart (`power_limits` property vs method; `state` silently becoming a method — the FIB-285 bug). This PR makes the ABC the actual contract — which also matters as the future wire contract for remote METEOR control (design doc § Phase 5).

## Base contract (`fibsem/fm/microscope.py`)

- `available_binnings`, `exposure_time_limits` (Camera) and `power_limits` (LightSource) promoted with simulator defaults; power is documented as a 0–1 fraction across all drivers.
- The base binning setter validates against `available_binnings` with `ValueError` (previously `raise Warning`).
- `_stop_acquisition_event` / `_acquisition_thread` move from **shared class attributes** to per-instance state in `__init__`.
- `_construct_image(data, frame_metadata=None)`: per-frame values (`pixel_size`, `acquisition_date`, `exposure_time`) override the state snapshot when provided (F20, deferred from FIB-287).

## Odemis driver

- **Gain honesty (D4)**: gain maps to the camera's `gain` VA when present (`model.hasVA`); otherwise the getter returns `None` and the setter is a warn-once no-op — metadata never echoes back a value that didn't reach hardware. `FluorescenceChannelMetadata.gain` is now `Optional[float]` (None round-trips the dict path), and the camera widget disables the gain spinbox with a tooltip when unsupported.
- **Hardware-derived limits**: `available_binnings` from the binning VA (choices when enumerated, powers of two within range — simcam supports 16, the old hardcoded `[1,2,4,8]` didn't); `exposure_time_limits` from the exposure VA; `power_limits` converted to a property.
- **Per-frame metadata**: the odemis microscope overrides `_construct_image` to auto-extract `MD_PIXEL_SIZE` / `MD_ACQ_DATE` / `MD_EXP_TIME` from `DataArray.metadata`, so both single-shot and live frames stay correctly stamped even if settings change mid-stream.
- **Typing sweep**: stale `parent: "Client"` forward refs, missing `Optional[...]` params, dead filter-set attributes removed, `offset` documented as intentionally read-only.

## TFS driver

Zero changes — it already conformed; the promotion formalizes its existing surface.

## Testing

- New `tests/fm/test_fm_contract.py`: pins the promoted contract, per-instance stop events, and frame-metadata override semantics against the simulator.
- 13 new odemis cases (gain paths, VA-derived limits, frame metadata through single-shot and live paths) — 80 tests in the driver file.
- Full `tests/fm` suite: **216 passed**.

Noted out of scope: the same class-attribute acquisition state exists on `FibsemMicroscope` (`fibsem/microscope.py:154`) — tracked separately.
