### PR TITLE
[fix] keep Python GC on the Qt main thread (Windows vispy/gloo crash)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -40,6 +40,7 @@ from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus, La
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI, INSTRUCTIONS
 from fibsem.applications.autolamella.workflows.tasks.tasks import get_task_supervision
 from fibsem.ui import FibsemMinimapWidget
+from fibsem.ui.qt.gc import install_main_thread_gc
 from fibsem.ui.stylesheets import (
     MILLING_PROGRESS_BAR_STYLESHEET,
     NAPARI_STYLE,
@@ -1734,6 +1735,10 @@ def run_ui():
     init_sentry()  # inert unless crash reporting is enabled in preferences
     app = QApplication.instance() or QApplication(sys.argv)
     app.setStyle("Fusion")
+    # Cyclic garbage must only ever be collected on this thread: worker-thread GC
+    # finalizes Qt/vispy objects off the GUI thread and hard-crashes Windows GL
+    # drivers (access violation in glDrawArrays). See fibsem/ui/qt/gc.py.
+    gc_collector = install_main_thread_gc(parent=app)  # noqa: F841 — kept alive for app lifetime
     window = AutoLamellaSingleWindowUI()
     window.show()
     sys.exit(app.exec_())

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -139,6 +139,11 @@ if TYPE_CHECKING:
 
 class FibsemMicroscope(ABC):
     """Abstract class containing all the core microscope functionalities"""
+    # THREADING CONTRACT: these are psygnal Signals — subscribers run synchronously
+    # on whatever thread emits (workflow/movement/acquisition workers, not the GUI
+    # thread). Any handler that touches Qt or a canvas MUST marshal, e.g. with
+    # @superqt.ensure_main_thread; a bare .connect() of a GUI handler is a
+    # crash-on-hardware bug that won't reproduce on a dev machine.
     milling_progress_signal = Signal(dict)
     tiled_acquisition_signal = Signal(dict)
     spot_burn_progress_signal = Signal(dict)

--- a/fibsem/ui/qt/gc.py
+++ b/fibsem/ui/qt/gc.py
@@ -1,0 +1,111 @@
+"""Keep Python's cyclic garbage collector on the Qt main thread.
+
+CPython's automatic GC runs in whichever thread happens to allocate when a
+generation threshold is crossed — during workflows that is usually a background
+thread. Any cyclic garbage that holds Qt or vispy objects then has its
+finalizers run *off* the GUI thread:
+
+* QObject destructors from the wrong thread — the log signature is
+  ``QObject::~QObject: Timers cannot be stopped from another thread``;
+* vispy ``GLObject.__del__``, which appends a GLIR ``DELETE`` command to a
+  plain (unlocked) Python list that the GUI thread's ``paintGL`` is
+  concurrently flushing. On Windows GL drivers this intermittently ends in a
+  native access violation inside ``glDrawArrays`` and takes the whole process
+  down (observed repeatedly on a Tescan support PC, 2026-07-22).
+
+The fix — as shipped by ilastik and other large PyQt apps — is to disable
+automatic collection and run the collector from a QTimer on the main thread,
+mirroring CPython's own generation thresholds so collection stays incremental
+rather than a periodic stop-the-world full sweep.
+
+Scope: this moves *cyclic* garbage finalization to the main thread. Plain
+refcount-zero deallocation still runs on whichever thread drops the last
+reference; cycles (signal connections, parent links, closures) are the
+dominant path for Qt/napari/vispy objects and the one observed in the crash
+logs.
+"""
+from __future__ import annotations
+
+import gc
+import logging
+from typing import Optional
+
+from PyQt5.QtCore import QCoreApplication, QObject, QThread, QTimer
+
+__all__ = ["MainThreadGarbageCollector", "install_main_thread_gc"]
+
+
+class MainThreadGarbageCollector(QObject):
+    """Runs generational garbage collection from a timer on the main thread.
+
+    ``start()`` disables automatic GC and starts the timer; ``stop()`` restores
+    automatic GC. Each tick re-implements CPython's escalation rule using the
+    interpreter's own thresholds: collect gen 0 when its allocation count is
+    exceeded, escalating to gen 1 / gen 2 only when their counters are also
+    over threshold — so most ticks are no-ops or cheap young-generation passes.
+    """
+
+    DEFAULT_INTERVAL_MS = 1000
+
+    def __init__(
+        self,
+        parent: Optional[QObject] = None,
+        interval_ms: int = DEFAULT_INTERVAL_MS,
+    ):
+        super().__init__(parent)
+        self._threshold = gc.get_threshold()
+        self._timer = QTimer(self)
+        self._timer.setInterval(interval_ms)
+        self._timer.timeout.connect(self.check)
+
+    def start(self) -> None:
+        gc.disable()
+        self._timer.start()
+
+    def stop(self) -> None:
+        self._timer.stop()
+        gc.enable()
+
+    def check(self) -> None:
+        """One timer tick: collect whichever generations are over threshold."""
+        count0, count1, count2 = gc.get_count()
+        if count0 <= self._threshold[0]:
+            return
+        if count1 <= self._threshold[1]:
+            gc.collect(0)
+        elif count2 <= self._threshold[2]:
+            gc.collect(1)
+        else:
+            gc.collect(2)
+
+    def collect_now(self) -> int:
+        """Force an immediate full collection (for tests and shutdown paths)."""
+        return gc.collect()
+
+
+def install_main_thread_gc(
+    parent: Optional[QObject] = None,
+    interval_ms: int = MainThreadGarbageCollector.DEFAULT_INTERVAL_MS,
+) -> MainThreadGarbageCollector:
+    """Create and start a :class:`MainThreadGarbageCollector`.
+
+    Must be called from the Qt main thread after the ``QApplication`` exists —
+    the timer needs the main event loop, and creating it elsewhere would make
+    collections run on the wrong thread, which is the exact bug this prevents.
+    """
+    app = QCoreApplication.instance()
+    if app is None:
+        raise RuntimeError(
+            "install_main_thread_gc requires a QApplication to exist"
+        )
+    if QThread.currentThread() is not app.thread():
+        raise RuntimeError(
+            "install_main_thread_gc must be called from the Qt main thread"
+        )
+    collector = MainThreadGarbageCollector(parent=parent, interval_ms=interval_ms)
+    collector.start()
+    logging.debug(
+        "Main-thread GC installed (interval=%d ms); automatic GC disabled",
+        interval_ms,
+    )
+    return collector

--- a/test_glir_gc_repro.py
+++ b/test_glir_gc_repro.py
@@ -1,0 +1,179 @@
+"""Manual harness: reproduce / verify the Windows vispy-gloo GC crash.
+
+Recreates the conditions of the 2026-07-22 Tescan session crashes
+(``OSError: access violation reading 0x1C`` in ``glDrawArrays``): a napari
+viewer whose Image/Shapes layers are churned from the main thread (as
+``update_lamella_ui`` / ``_update_lamella_display`` do) while background
+threads allocate heavily (as workflow/movement/acquisition threads do).
+
+The crash mechanism is Python's GC running in a worker thread and finalizing
+vispy ``GLObject``s there — each finalizer appends a GLIR ``DELETE`` command
+to an unlocked list raced by the GUI thread's ``paintGL``. Rather than waiting
+for a (driver-dependent) hard crash, this harness instruments
+``_GlirQueueShare.command`` and counts every GLIR command queued from a
+non-main thread — the crash *precondition* — making the result deterministic
+and platform-independent.
+
+Usage (manual, opens a real window)::
+
+    python test_glir_gc_repro.py                 # stock GC: expect detections
+    python test_glir_gc_repro.py --fixed         # main-thread GC: expect zero
+    python test_glir_gc_repro.py --duration 60   # run longer (default 20 s)
+
+Exit code 0 = no cross-thread GLIR commands observed, 1 = at least one.
+On a Windows machine without ``--fixed`` this may also genuinely hard-crash —
+that is the bug reproducing.
+"""
+from __future__ import annotations
+
+import argparse
+import threading
+import time
+import traceback
+
+import napari
+import numpy as np
+from PyQt5.QtCore import QTimer
+from PyQt5.QtWidgets import QApplication
+
+import vispy.gloo.glir as glir
+
+# ---------------------------------------------------------------- detector
+
+_DETECTIONS: list = []  # (command-name, thread-name, stack-summary)
+_MAX_STACKS = 5
+
+
+def install_glir_thread_detector() -> None:
+    """Record every GLIR command queued from a non-main thread."""
+    original = glir._GlirQueueShare.command
+
+    def command(self, *args):
+        if threading.current_thread() is not threading.main_thread():
+            stack = (
+                "".join(traceback.format_stack(limit=8))
+                if len(_DETECTIONS) < _MAX_STACKS
+                else ""
+            )
+            _DETECTIONS.append((args[0], threading.current_thread().name, stack))
+        return original(self, *args)
+
+    glir._GlirQueueShare.command = command
+
+
+# ---------------------------------------------------------------- churn
+
+RESOLUTIONS = [(1024, 1536), (512, 768)]  # alternate → texture realloc + garbage
+
+
+class LayerChurner:
+    """Main-thread layer churn mimicking update_lamella_ui / acquisitions."""
+
+    def __init__(self, viewer: napari.Viewer):
+        self.viewer = viewer
+        self.tick = 0
+        self.image_layer = viewer.add_image(
+            np.zeros(RESOLUTIONS[0], dtype=np.uint8), name="live-image"
+        )
+
+    def churn(self) -> None:
+        self.tick += 1
+        shape = RESOLUTIONS[self.tick % len(RESOLUTIONS)]
+        self.image_layer.data = np.random.randint(
+            0, 255, shape, dtype=np.uint8
+        )
+        # remove/re-add an overlay layer, as _update_lamella_display does
+        if "overlay" in self.viewer.layers:
+            self.viewer.layers.remove("overlay")
+        lines = np.random.rand(6, 2, 2) * shape[0]
+        self.viewer.add_shapes(
+            lines, shape_type="line", edge_color="lime", name="overlay"
+        )
+
+
+def allocation_storm(stop: threading.Event) -> None:
+    """Background allocation pressure, as workflow threads produce.
+
+    With stock automatic GC, generation thresholds are crossed *in this
+    thread*, so cyclic garbage from the layer churn (old vispy visuals,
+    textures, buffers) gets finalized here — off the GUI thread. The sleep
+    yields the GIL so the GUI thread keeps churning (real workflow threads
+    block on hardware I/O the same way); without it the storms starve the
+    main loop and nothing renders.
+    """
+    while not stop.is_set():
+        sink = []
+        for i in range(20_000):
+            sink.append([i])
+        del sink
+        time.sleep(0.002)
+
+
+# ---------------------------------------------------------------- main
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--fixed",
+        action="store_true",
+        help="install the main-thread GC fix before running",
+    )
+    parser.add_argument(
+        "--duration", type=float, default=20.0, help="run time in seconds"
+    )
+    parser.add_argument(
+        "--workers", type=int, default=3, help="background allocation threads"
+    )
+    args = parser.parse_args()
+
+    install_glir_thread_detector()
+
+    viewer = napari.Viewer(title="GLIR GC repro")
+    app = QApplication.instance()
+
+    if args.fixed:
+        from fibsem.ui.qt.gc import install_main_thread_gc
+
+        collector = install_main_thread_gc(parent=app)  # noqa: F841
+
+    churner = LayerChurner(viewer)
+    churn_timer = QTimer()
+    churn_timer.setInterval(50)
+    churn_timer.timeout.connect(churner.churn)
+    churn_timer.start()
+
+    stop = threading.Event()
+    workers = [
+        threading.Thread(target=allocation_storm, args=(stop,), daemon=True)
+        for _ in range(args.workers)
+    ]
+    for w in workers:
+        w.start()
+
+    QTimer.singleShot(int(args.duration * 1000), app.quit)
+    app.exec_()
+    stop.set()
+
+    print(
+        f"\n{'=' * 70}\n"
+        f"mode: {'FIXED (main-thread GC)' if args.fixed else 'STOCK (automatic GC)'} | "
+        f"duration: {args.duration:.0f}s | churn ticks: {churner.tick}\n"
+        f"GLIR commands queued from non-main threads: {len(_DETECTIONS)}"
+    )
+    if _DETECTIONS:
+        names = sorted({f"{cmd} ({thread})" for cmd, thread, _ in _DETECTIONS})
+        print("detected:", ", ".join(names))
+        for cmd, thread, stack in _DETECTIONS[:_MAX_STACKS]:
+            if stack:
+                print(f"\n--- first stacks: {cmd} on {thread} ---\n{stack}")
+        print(
+            "\nRESULT: FAIL — off-main-thread GLIR traffic observed "
+            "(crash precondition present)"
+        )
+        return 1
+    print("RESULT: PASS — all GLIR traffic stayed on the main thread")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ui/test_main_thread_gc.py
+++ b/tests/ui/test_main_thread_gc.py
@@ -1,0 +1,144 @@
+"""Headless tests for the main-thread garbage collector.
+
+Guards the contract behind the Windows vispy/gloo crash fix: cyclic garbage
+that is *created and dropped in a worker thread* must never be finalized on
+that worker thread while the collector is installed — finalizers (QObject
+destructors, vispy ``GLObject.__del__``) must run on the Qt main thread.
+
+Two sides are tested:
+
+1. **The hazard is real** — with automatic GC enabled (stock CPython), an
+   allocation storm in a worker thread collects the cycle *in that thread*.
+   This keeps the fix honest: if this test ever fails, CPython's GC behaviour
+   changed and the fix may be obsolete.
+2. **The fix works** — with :class:`MainThreadGarbageCollector` started,
+   the same storm finalizes nothing off-thread; the cycle is collected on the
+   main thread by the timer-driven ``check()``.
+
+Uses PyQt5 directly with the offscreen platform (no pytest-qt dependency).
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import gc
+import threading
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.qt.gc import MainThreadGarbageCollector, install_main_thread_gc
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture(autouse=True)
+def _restore_gc_state():
+    """Every test leaves the interpreter's GC exactly as it found it."""
+    was_enabled = gc.isenabled()
+    try:
+        yield
+    finally:
+        gc.collect()
+        if was_enabled:
+            gc.enable()
+        else:
+            gc.disable()
+
+
+class _Finalizable:
+    """Self-referential (cyclic) object that records which thread ran __del__."""
+
+    def __init__(self, record: list):
+        self._record = record
+        self._cycle = self  # guarantees the GC, not refcounting, frees it
+
+    def __del__(self):
+        self._record.append(threading.current_thread())
+
+
+def _worker_drop_and_storm(record: list, n_allocations: int = 30_000):
+    """Create + drop a cyclic finalizable, then allocate heavily.
+
+    The storm keeps its allocations alive so the gen-0 counter (a net
+    live-allocation count) crosses the threshold many times inside this
+    thread. With automatic GC enabled the collector therefore runs here and
+    the cycle's finalizer executes on this (worker) thread — the exact
+    off-main-thread finalization that corrupts vispy's GLIR queue in the
+    real app.
+    """
+    obj = _Finalizable(record)
+    del obj
+    sink = []
+    for i in range(n_allocations):
+        sink.append([i])  # net container allocations feed the gen-0 counter
+
+
+def test_hazard_worker_thread_gc_finalizes_off_main_thread(qapp):
+    """Control: stock CPython runs the finalizer on the worker thread."""
+    gc.enable()
+    gc.collect()  # start from empty generations
+
+    record: list = []
+    worker = threading.Thread(target=_worker_drop_and_storm, args=(record,))
+    worker.start()
+    worker.join()
+
+    assert record, "allocation storm never triggered a collection — increase n_allocations"
+    assert record[0] is not threading.main_thread(), (
+        "expected the control finalizer to run on the worker thread; if CPython's "
+        "GC threading behaviour changed, the main-thread GC fix may be obsolete"
+    )
+
+
+def test_fix_finalizers_run_only_on_main_thread(qapp):
+    """With the collector started, the worker storm finalizes nothing;
+    the main-thread check() collects the cycle on the main thread."""
+    collector = MainThreadGarbageCollector(interval_ms=50)
+    collector.start()
+    try:
+        gc.collect()  # start from empty generations
+
+        record: list = []
+        worker = threading.Thread(target=_worker_drop_and_storm, args=(record,))
+        worker.start()
+        worker.join()
+
+        assert record == [], "automatic GC ran in the worker thread despite gc.disable()"
+
+        # simulate timer ticks on the main thread until the cycle is collected
+        for _ in range(10):
+            collector.check()
+            if record:
+                break
+        if not record:
+            collector.collect_now()
+
+        assert record, "cycle was never collected by the main-thread collector"
+        assert all(t is threading.main_thread() for t in record)
+    finally:
+        collector.stop()
+
+
+def test_install_requires_qapp_and_disables_automatic_gc(qapp):
+    collector = install_main_thread_gc(interval_ms=1000)
+    try:
+        assert not gc.isenabled()
+    finally:
+        collector.stop()
+    assert gc.isenabled()
+
+
+def test_stop_restores_automatic_gc(qapp):
+    collector = MainThreadGarbageCollector(interval_ms=1000)
+    collector.start()
+    assert not gc.isenabled()
+    collector.stop()
+    assert gc.isenabled()


### PR DESCRIPTION
## Problem

On the Tescan Windows machine, AutoLamella hard-crashed 7 times in a single 2-hour session (2026-07-22) — `OSError: exception: access violation reading 0x1C` inside `glDrawArrays` while drawing a vispy `Image` visual, typically right after selecting a lamella card, changing tabs, or a workflow acquisition. Each crash killed the process and required an app restart + experiment reload.

## Root cause

CPython's cyclic garbage collector runs in **whichever thread crosses an allocation threshold** — during workflows that is a background thread (workflow / movement / acquisition). Any cyclic garbage holding Qt or vispy objects then has its finalizers run off the GUI thread:

- vispy's `GLObject.__del__` appends a GLIR `DELETE` command to a **plain, unlocked Python list** (`_GlirQueueShare._commands`) that the GUI thread's `paintGL` is concurrently flushing → corrupted command stream → draws against freed GL state → native access violation. Windows drivers crash hard; macOS mostly tolerates it, which is why it never reproduced locally.
- The same mechanism destroys QObjects off-thread — the session log contains `QObject::~QObject: Timers cannot be stopped from another thread`, which Qt only prints when an object with active timers is destructed from the wrong thread.

Layer churn (`update_lamella_ui` → remove/re-add of overlay layers, acquisitions replacing image data) is what generates the cyclic garbage; all *visible* GUI-update paths were already correctly marshalled (`ensure_main_thread` / `pyqtSignal`) — the bug is object destruction, not updates.

## Fix

`fibsem/ui/qt/gc.py` — `MainThreadGarbageCollector`: `gc.disable()` + a 1 s `QTimer` on the main thread that mirrors CPython's own generation thresholds (most ticks are no-ops or cheap gen-0 passes; gen-2 only when its counter is over threshold). Installed in `AutoLamellaMainUI.run_ui`. This is the pattern shipped by ilastik and other large PyQt apps.

Also documents the threading contract on `FibsemMicroscope`'s psygnal signals: subscribers run synchronously on the emitting worker thread, so GUI handlers must marshal.

## Verification

- **`tests/ui/test_main_thread_gc.py`** (offscreen, no pytest-qt): 4 tests, including a *control* proving stock CPython finalizes worker-dropped cycles on the worker thread — if CPython's GC behaviour ever changes, that test failing flags the fix as obsolete.
- **`test_glir_gc_repro.py`** (root-level manual harness): real napari viewer + main-thread layer churn + background allocation storms, with `_GlirQueueShare.command` instrumented to count commands queued off the main thread — the crash *precondition*, detectable without waiting for a driver fault.

| 20 s run (macOS) | stock GC | with fix |
|---|---|---|
| GLIR commands from worker threads | 117 (`DELETE`, stacks through `GLObject.__del__` in storm threads) | **0** |
| Process outcome | **SIGBUS native crash** | clean exit |
| GUI churn ticks completed | 4 | 68 |

The GUI was also markedly more responsive with the fix — automatic GC pauses run with the GIL held inside worker threads, stalling rendering.

## Notes

- Relationship to #111 (napari removal): #111 eliminates the vispy/GLIR crash vector, but worker-thread GC destroying QObjects survives it — keep this fix permanently. Only `test_glir_gc_repro.py` becomes obsolete with #111 (it instruments vispy internals) and can be deleted then.
- Scope: only *cyclic* garbage finalization moves to the main thread; refcount-zero frees still run on the dropping thread (harmless for the observed failure mode). Headless/scripted use is unaffected — the install only happens in `run_ui()`.