### PR TITLE
Correlation: don't resurrect a stale result on reload (FIB-295)

### DIFF
--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -224,6 +224,33 @@ class CorrelationInputData:
             return CorrelationInputData.from_dict(data)
 
 
+def _transform_inputs(data: CorrelationInputData) -> dict:
+    """The subset of the inputs that can change the fitted transform.
+
+    Used to decide whether a result still describes the current points. Scoping
+    matters both ways: too narrow and a real change slips through; too broad and
+    an edit that cannot move the answer marks a good result stale, at which point
+    the signal stops meaning anything and users learn to ignore it.
+    """
+
+    def positions(coords: list[Coordinate]) -> list:
+        return [c.point.to_dict() for c in coords]
+
+    def position(coord: Optional[Coordinate]) -> Optional[dict]:
+        return coord.point.to_dict() if coord is not None else None
+
+    return {
+        "fib": positions(data.fib_coordinates),
+        "fm": positions(data.fm_coordinates),
+        "poi": positions(data.poi_coordinates),
+        "surface": position(data.surface_coordinate),
+        "fm_surface": position(data.fm_surface_coordinate),
+        # scales POI z about the FM surface *before* the fit, so a change here
+        # genuinely changes the answer (see run_correlation_from_data).
+        "ri_pre_correction_factor": data.ri_pre_correction_factor,
+    }
+
+
 @dataclass
 class CorrelationPointOfInterest:
     """A single POI reprojected into the FIB image, in multiple coordinate systems."""
@@ -481,6 +508,26 @@ class CorrelationResult:
             df_input.to_csv(f, index=False)
             f.write("\n# Marker Reprojection Error\n")
             df_result.to_csv(f, index=False)
+
+    def matches_inputs(self, current: CorrelationInputData) -> bool:
+        """Whether this result was computed from ``current``'s coordinates.
+
+        ``input_data`` is a snapshot of the points the transform was fitted to,
+        which makes staleness *derivable* — no flag anyone has to remember to
+        set. Compares only what the transform consumes (see
+        :func:`_transform_inputs`); notably **excluded**:
+
+          * ``fitted`` — provenance on a Coordinate, not a position;
+          * ``method`` — not read by ``run_correlation_from_data``;
+          * anything image-derived — a deserialized result carries no images, so
+            e.g. ``fm_image_shape`` is None on this side and populated on the
+            live side, which would report every reloaded result as stale.
+
+        A result with no snapshot can't be shown to match, so it reports False.
+        """
+        if self.input_data is None:
+            return False
+        return _transform_inputs(self.input_data) == _transform_inputs(current)
 
     def save(self, filename: str) -> None:
         with open(filename, "w") as f:

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -1733,7 +1733,9 @@ class CorrelationTabWidget(QWidget):
         self._worker.errored.connect(self._on_run_error)
         self._worker.start()
 
-    def _on_result_ready(self, result: CorrelationResult) -> None:
+    def _on_result_ready(self, result: CorrelationResult, live: bool = True) -> None:
+        """Adopt a result. ``live`` is False for a *loaded* result that no longer
+        describes the current points (FIB-295) — a fresh run is always live."""
         self._result = result
         self._results_tab.set_result(result)
         self._ri_tab.set_result(
@@ -1741,13 +1743,14 @@ class CorrelationTabWidget(QWidget):
         )
         self._tabs.setTabEnabled(3, True)
         self._overlay_result_on_fib(result)
-        self._set_result_live(True)
+        self._set_result_live(live)
         # after _update_run_button, which would otherwise overwrite it with "Ready."
         self._update_run_button()
         # RMS beside Continue (coloured only if something looks wrong); compact
-        # RI / POI note on status.
+        # RI / POI note on status. Suppressed for a stale result — an RMS is a
+        # statement about points these no longer are.
         rms = result.rms_error
-        if rms is not None:
+        if rms is not None and live:
             px_m = self._fib_pixel_size_m()
             rms_nm = rms * px_m * 1e9 if px_m else None
             shown = _format_distance_nm(rms_nm) if rms_nm is not None else f"{rms:.2f} px"
@@ -1771,6 +1774,10 @@ class CorrelationTabWidget(QWidget):
             if shift is not None:
                 msg += f", POI Δ{shift:.1f} px"
             self._lbl_status.setText(msg)
+        elif not live:
+            self._lbl_status.setText(
+                "Loaded result — the points have changed since this run. Re-run to update."
+            )
         else:
             self._lbl_status.setText("Done.")
         self.result_changed.emit(result)
@@ -2119,10 +2126,10 @@ class CorrelationTabWidget(QWidget):
         fig.savefig(path, dpi=150, bbox_inches="tight", facecolor=fig.get_facecolor())
         plt.close(fig)
 
-    def load_result(self, path: str) -> None:
+    def load_result(self, path: str, *, adopt_inputs: bool = True) -> None:
         """Load a correlation result from JSON and adopt it (mirrors load_data)."""
         logging.info("Loading correlation result from %s", path)
-        self._load_result(CorrelationResult.load(path))
+        self._load_result(CorrelationResult.load(path), adopt_inputs=adopt_inputs)
 
     def _menu_load_result(self) -> None:
         start = self._project_dir or ""
@@ -2138,14 +2145,24 @@ class CorrelationTabWidget(QWidget):
             return
         self._load_result(result)
 
-    def _load_result(self, result: CorrelationResult) -> None:
-        """Adopt a loaded correlation result (and its input data, if any)."""
+    def _load_result(
+        self, result: CorrelationResult, *, adopt_inputs: bool = True
+    ) -> None:
+        """Adopt a loaded correlation result (and its input data, if any).
+
+        ``adopt_inputs=False`` when the caller has already loaded fresher
+        coordinates: ``result.input_data`` is a record of what the transform was
+        fitted to, not the current truth, so applying it would silently discard
+        every edit made after that run (FIB-295).
+        """
         # Populate the lists first so the RI tab sees the loaded surface points.
         # _on_result_ready refreshes the run button and sets the final status
         # text itself — no trailing update here, it would overwrite the status.
-        if result.input_data:
+        if adopt_inputs and result.input_data:
             self.set_data(result.input_data)
-        self._on_result_ready(result)
+        # Continue commits result.poi[0].px_m to the protocol editor, so a result
+        # that predates the current points must not arm it.
+        self._on_result_ready(result, live=result.matches_inputs(self.data))
 
     def _on_load(self) -> None:
         start = self._project_dir or ""
@@ -2556,18 +2573,28 @@ def load_project(widget: "CorrelationTabWidget", directory: str) -> None:
     else:
         logging.warning("  no FM image (*.ome.tiff) found in %s", directory)
 
-    if found["result"]:
-        try:
-            widget.load_result(found["result"])
-            logging.info("  result: %s", os.path.basename(found["result"]))
-        except Exception:
-            logging.exception("  failed to load result %s", found["result"])
-    elif found["data"]:
+    # Coordinates first. correlation_data.json is rewritten on every edit, so it
+    # is the freshest record of the points; correlation_result.json is only
+    # rewritten by a run, and the input_data embedded in it is a snapshot from
+    # that run. Loading the result first (as this did) let that snapshot
+    # overwrite edits made afterwards — FIB-295.
+    loaded_data = False
+    if found["data"]:
         try:
             widget.load_data(found["data"])
+            loaded_data = True
             logging.info("  data: %s", os.path.basename(found["data"]))
         except Exception:
             logging.exception("  failed to load data %s", found["data"])
+
+    if found["result"]:
+        try:
+            # With no data file the result's snapshot is the only record of the
+            # points, so adopt it; otherwise keep the coordinates just loaded.
+            widget.load_result(found["result"], adopt_inputs=not loaded_data)
+            logging.info("  result: %s", os.path.basename(found["result"]))
+        except Exception:
+            logging.exception("  failed to load result %s", found["result"])
 
 
 def main() -> None:

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -1765,7 +1765,13 @@ class CorrelationTabWidget(QWidget):
             )
             self._lbl_result.setToolTip(self._rms_tooltip(result, rms, px_m, concern))
             self._lbl_result.setVisible(True)
-        if (
+        # Staleness outranks the RI note: this is the only line explaining why
+        # Continue is greyed out, so "Done — RI ×1.500" must not mask it.
+        if not live:
+            self._lbl_status.setText(
+                "Loaded result — the points have changed since this run. Re-run to update."
+            )
+        elif (
             result.refractive_index_correction_mode == "pre"
             and result.refractive_index_correction_factor is not None
         ):
@@ -1774,10 +1780,6 @@ class CorrelationTabWidget(QWidget):
             if shift is not None:
                 msg += f", POI Δ{shift:.1f} px"
             self._lbl_status.setText(msg)
-        elif not live:
-            self._lbl_status.setText(
-                "Loaded result — the points have changed since this run. Re-run to update."
-            )
         else:
             self._lbl_status.setText("Done.")
         self.result_changed.emit(result)

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -1886,3 +1886,138 @@ def test_selecting_a_fitted_point_keeps_its_fitted_flag(qapp):
 
     _press_release(canvas, coord, drag_to=(60.0, 70.0))  # a real drag
     assert moved == [coord]
+
+
+# ---------------------------------------------------------------------------
+# FIB-295 — a result that predates the current points
+# ---------------------------------------------------------------------------
+
+
+def _input(fib=(1.0, 2.0), ri=None) -> CorrelationInputData:
+    return CorrelationInputData(
+        fib_coordinates=[_coord(*fib, pt=PointType.FIB)],
+        ri_pre_correction_factor=ri,
+    )
+
+
+def _result_from(data: CorrelationInputData) -> CorrelationResult:
+    return CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=10.0, y=20.0))],
+        rms_error=1.5,
+        input_data=data,
+    )
+
+
+def test_matches_inputs_detects_a_moved_coordinate():
+    result = _result_from(_input(fib=(1.0, 2.0)))
+    assert result.matches_inputs(_input(fib=(1.0, 2.0))) is True
+    assert result.matches_inputs(_input(fib=(1.0, 9.0))) is False
+
+
+def test_matches_inputs_tracks_the_ri_factor():
+    """The RI pre-correction scales POI z before the fit, so it does change the
+    answer — unlike the flags below, it must count as a change."""
+    result = _result_from(_input(ri=1.4))
+    assert result.matches_inputs(_input(ri=1.4)) is True
+    assert result.matches_inputs(_input(ri=1.8)) is False
+
+
+def test_matches_inputs_ignores_changes_that_cannot_move_the_answer():
+    """Scoping guard. If a change the transform never reads marks a good result
+    stale, users learn to ignore the warning and it stops carrying information."""
+    result = _result_from(_input())
+
+    refit = _input()
+    refit.fib_coordinates[0].fitted = True  # provenance, not a position
+    assert result.matches_inputs(refit) is True
+
+    other_method = _input()
+    other_method.method = "single-point"  # not read by run_correlation_from_data
+    assert result.matches_inputs(other_method) is True
+
+
+def test_matches_inputs_ignores_image_presence():
+    """A deserialized result carries no images, so image-derived properties are
+    None on one side and populated on the other. Comparing them would report
+    every reloaded result as stale."""
+    saved = _input()  # no images, as if from JSON
+    live = _input()
+    live.fib_image = _fake_fib()
+    assert _result_from(saved).matches_inputs(live) is True
+
+
+def test_result_with_no_snapshot_cannot_claim_to_match():
+    result = CorrelationResult(poi=[], input_data=None)
+    assert result.matches_inputs(_input()) is False
+
+
+def test_loading_a_stale_result_does_not_arm_continue(qapp):
+    """Continue commits result.poi[0].px_m to the protocol editor. The in-session
+    guard (_set_result_live on edit) does not survive a reload, so the staleness
+    has to be re-derived from the result's own snapshot."""
+    w = _widget(qapp)
+    w.set_data(_input(fib=(5.0, 5.0)))  # the points as they are now
+
+    stale = _result_from(_input(fib=(1.0, 2.0)))  # fitted to where they were
+    w._load_result(stale, adopt_inputs=False)
+
+    assert w._btn_continue.isEnabled() is False
+    assert w._lbl_result.isHidden() is True  # no RMS badge for a dead transform
+    assert "changed since this run" in w._lbl_status.text()
+
+
+def test_loading_a_current_result_stays_live(qapp):
+    w = _widget(qapp)
+    w.set_data(_input(fib=(5.0, 5.0)))
+
+    fresh = _result_from(_input(fib=(5.0, 5.0)))
+    w._load_result(fresh, adopt_inputs=False)
+
+    assert w._btn_continue.isEnabled() is True
+    assert w._lbl_status.text() == "Done."
+
+
+def test_load_result_can_keep_the_coordinates_already_loaded(qapp):
+    """The destructive half of FIB-295: the result's embedded snapshot used to
+    overwrite the lists unconditionally, so reopening a project silently
+    discarded every edit made after the last run."""
+    w = _widget(qapp)
+    w.set_data(_input(fib=(5.0, 5.0)))
+
+    w._load_result(_result_from(_input(fib=(1.0, 2.0))), adopt_inputs=False)
+
+    kept = w._coords_tab.fib_list.coordinates
+    assert [(c.point.x, c.point.y) for c in kept] == [(5.0, 5.0)]
+
+
+def test_load_project_prefers_the_data_file_over_the_result_snapshot(qapp, tmp_path):
+    """End-to-end of the reported path: edit after a run, reopen, keep the edit."""
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import load_project
+
+    _result_from(_input(fib=(1.0, 2.0))).save(
+        str(tmp_path / "correlation_result.json")
+    )
+    _input(fib=(5.0, 5.0)).save(str(tmp_path / "correlation_data.json"))
+
+    w = _widget(qapp)
+    load_project(w, str(tmp_path))
+
+    kept = w._coords_tab.fib_list.coordinates
+    assert [(c.point.x, c.point.y) for c in kept] == [(5.0, 5.0)]  # the edit survives
+    assert w._btn_continue.isEnabled() is False  # and the old result isn't armed
+
+
+def test_load_project_adopts_the_snapshot_when_there_is_no_data_file(qapp, tmp_path):
+    """With no data file the result's snapshot is the only record of the points."""
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import load_project
+
+    _result_from(_input(fib=(1.0, 2.0))).save(
+        str(tmp_path / "correlation_result.json")
+    )
+
+    w = _widget(qapp)
+    load_project(w, str(tmp_path))
+
+    kept = w._coords_tab.fib_list.coordinates
+    assert [(c.point.x, c.point.y) for c in kept] == [(1.0, 2.0)]
+    assert w._btn_continue.isEnabled() is True  # consistent, so still usable

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -2021,3 +2021,18 @@ def test_load_project_adopts_the_snapshot_when_there_is_no_data_file(qapp, tmp_p
     kept = w._coords_tab.fib_list.coordinates
     assert [(c.point.x, c.point.y) for c in kept] == [(1.0, 2.0)]
     assert w._btn_continue.isEnabled() is True  # consistent, so still usable
+
+
+def test_stale_status_outranks_the_ri_note(qapp):
+    """The status line is the only thing explaining why Continue is greyed out,
+    so a stale result must not report 'Done — RI ×1.500'."""
+    w = _widget(qapp)
+    w.set_data(_input(fib=(5.0, 5.0)))
+
+    stale = _result_from(_input(fib=(1.0, 2.0)))
+    stale.refractive_index_correction_mode = "pre"
+    stale.refractive_index_correction_factor = 1.5
+    w._load_result(stale, adopt_inputs=False)
+
+    assert "changed since this run" in w._lbl_status.text()
+    assert "Done" not in w._lbl_status.text()


### PR DESCRIPTION
Closes [FIB-295](https://linear.app/fibsemos/issue/FIB-295).

## The bug

A coordinate edit after a correlation run invalidates the result **in the UI** (#143), but nothing rewrites `correlation_result.json`. On reopening the project that compounded into something worse than a stale badge:

- `load_project` preferred the result file over the data file, and
- `_load_result` unconditionally applied `result.input_data`.

So the pre-edit snapshot **overwrote the user's points**, and Continue came back **armed** with a transform fitted to coordinates that no longer existed. Continue commits `result.poi[0].px_m` to the protocol editor, so this hands it a position from the old point set. The in-session guard never survived a reload.

## The fix

`result.input_data` is a snapshot of what the transform was fitted to, which makes staleness **derivable** — no flag for anyone to forget to set.

**`CorrelationResult.matches_inputs(current)`**, backed by `_transform_inputs()`, compares only what can change the answer: coordinate **positions** and `ri_pre_correction_factor`.

That factor is in the comparison on purpose. The issue originally listed it as transform-irrelevant; `run_correlation_from_data` shows it isn't — it scales POI z about the FM surface *before* the fit. There's a test pinning that.

Deliberately **excluded**, each with a test:

| field | why |
|---|---|
| `fitted` | provenance on a Coordinate, not a position |
| `method` | never read by `run_correlation_from_data` |
| anything image-derived | a deserialized result carries no images, so `fm_image_shape` is `None` on one side and populated on the other |

That last one isn't hypothetical. The unscoped `to_dict()` comparison first proposed on the issue doesn't merely report false staleness — it raises `AttributeError`. Mutation 3 below surfaced it.

**Scoping is the load-bearing part.** If a change the transform never reads marks a good result stale, users learn to ignore the warning and it stops carrying information.

**Wiring:**
- `_on_result_ready(result, live=True)` — a fresh run is always live; a loaded result that no longer matches gets `live=False`: Continue disabled, RMS badge suppressed (an RMS is a statement about points these no longer are), status reads *"the points have changed since this run. Re-run to update."* The result still loads and stays inspectable.
- `load_project` loads **coordinates first** — the data file is rewritten on every edit, so it is the freshest record — and adopts the result's snapshot only when there is no data file.

## Testing

738 pass (full suite); correlation 153 → 163. Each new test was mutation-verified against the pre-fix behaviour:

| reverted | tests that failed |
|---|---|
| staleness check on load | `stale_result_does_not_arm_continue`, `load_project_prefers_the_data_file` |
| result-first ordering in `load_project` | `load_project_prefers_the_data_file` |
| scoped → full `to_dict()` comparison | both scoping guards |

Six tests on `matches_inputs` (including the two scoping guards and the no-snapshot case) and four on the widget, ending with an end-to-end replay of the reported path: save both files, `load_project`, assert the edit survives and Continue stays disabled.

## Why this first

Groundwork for [FIB-264](https://linear.app/fibsemos/issue/FIB-264) (consolidate the two JSON files). Merging them without this produces a single file that *looks* internally self-consistent while pairing fresh inputs with a dead transform — strictly worse than two files with distinct names. It's also a real bug on its own today.
