### PR TITLE
[feat] FM recent-channels quick-select menu with per-entry removal (FIB-258, FIB-290)

### DIFF
--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -82,6 +82,7 @@ MICROSCOPE_CONFIGURATION_PATH = os.path.join(
 )
 # fluorescence settings persistence
 FM_CONFIGURATION_PATH = os.path.join(CONFIG_PATH, "fm-configuration.yaml")  # working state
+FM_RECENT_CHANNELS_PATH = os.path.join(CONFIG_PATH, "fm-recent-channels.yaml")  # recently-used channels
 COINCIDENCE_MILLING_CONFIG_PATH = os.path.join(CONFIG_PATH, "coincidence-milling-config.yaml")  # milling default
 SAMPLE_HOLDER_CONFIGURATION_PATH = os.path.join(
     CONFIG_PATH, "sample-holder.yaml"

--- a/fibsem/fm/config.py
+++ b/fibsem/fm/config.py
@@ -3,14 +3,22 @@
 A single ``fm-configuration.yaml`` holds the live FM config. It is auto-saved on
 change + on close and auto-loaded + applied on startup, so FM settings survive
 restarts.
+
+``fm-recent-channels.yaml`` holds the recently-used channel settings, recorded
+whenever the user starts an acquisition, and offered as quick-select entries
+when adding a channel.
 """
 
 import logging
 import os
-from typing import Optional
+from typing import List, Optional, Union
+
+import yaml
 
 from fibsem import config as cfg
-from fibsem.fm.structures import FluorescenceConfiguration
+from fibsem.fm.structures import ChannelSettings, FluorescenceConfiguration
+
+MAX_RECENT_CHANNELS = 10
 
 
 def save_fm_configuration(config: FluorescenceConfiguration) -> str:
@@ -28,3 +36,60 @@ def load_fm_configuration() -> Optional[FluorescenceConfiguration]:
     except Exception as e:
         logging.warning(f"Failed to load FM working state: {e}")
         return None
+
+
+def _recent_channel_key(channel: ChannelSettings) -> str:
+    """Dedup key: entries matching on it are the same logical channel.
+
+    Keyed on name alone — the quick-select menu identifies entries by name, so
+    re-using a name overwrites its stored settings rather than accumulating
+    visually-identical duplicates that differ only in the tooltip.
+    """
+    return channel.name
+
+
+def load_recent_channels() -> List[ChannelSettings]:
+    """Load the recently-used channel settings, most recent first."""
+    if not os.path.exists(cfg.FM_RECENT_CHANNELS_PATH):
+        return []
+    try:
+        with open(cfg.FM_RECENT_CHANNELS_PATH, "r") as f:
+            data = yaml.safe_load(f)
+    except Exception as e:
+        logging.warning(f"Failed to load recent FM channels: {e}")
+        return []
+    if not isinstance(data, list):
+        return []
+    channels = []
+    for entry in data:
+        try:
+            channels.append(ChannelSettings.from_dict(entry))
+        except Exception as e:
+            logging.warning(f"Skipping malformed recent FM channel entry {entry}: {e}")
+    return channels
+
+
+def record_recent_channels(
+    channels: Union[ChannelSettings, List[ChannelSettings]],
+) -> None:
+    """Record channel settings as recently used (deduped, most recent first)."""
+    if isinstance(channels, ChannelSettings):
+        channels = [channels]
+    try:
+        recents = load_recent_channels()
+        previous = [ch.to_dict() for ch in recents]
+        # later entries in `channels` end up further down the list, matching
+        # the on-screen channel order
+        for channel in reversed(channels):
+            key = _recent_channel_key(channel)
+            recents = [ch for ch in recents if _recent_channel_key(ch) != key]
+            recents.insert(0, channel)
+        recents = recents[:MAX_RECENT_CHANNELS]
+        updated = [ch.to_dict() for ch in recents]
+        if updated == previous:
+            return
+        os.makedirs(cfg.CONFIG_PATH, exist_ok=True)
+        with open(cfg.FM_RECENT_CHANNELS_PATH, "w") as f:
+            yaml.safe_dump(updated, f, sort_keys=False)
+    except Exception as e:
+        logging.warning(f"Failed to record recent FM channels: {e}")

--- a/fibsem/fm/config.py
+++ b/fibsem/fm/config.py
@@ -93,3 +93,18 @@ def record_recent_channels(
             yaml.safe_dump(updated, f, sort_keys=False)
     except Exception as e:
         logging.warning(f"Failed to record recent FM channels: {e}")
+
+
+def remove_recent_channel(channel: ChannelSettings) -> None:
+    """Remove a channel from the recently-used list by its dedup key."""
+    try:
+        recents = load_recent_channels()
+        key = _recent_channel_key(channel)
+        remaining = [ch for ch in recents if _recent_channel_key(ch) != key]
+        if len(remaining) == len(recents):
+            return
+        os.makedirs(cfg.CONFIG_PATH, exist_ok=True)
+        with open(cfg.FM_RECENT_CHANNELS_PATH, "w") as f:
+            yaml.safe_dump([ch.to_dict() for ch in remaining], f, sort_keys=False)
+    except Exception as e:
+        logging.warning(f"Failed to remove recent FM channel: {e}")

--- a/fibsem/ui/fm/widgets/channel_list_widget.py
+++ b/fibsem/ui/fm/widgets/channel_list_widget.py
@@ -28,9 +28,10 @@ from PyQt5.QtWidgets import (
     QToolButton,
     QVBoxLayout,
     QWidget,
+    QWidgetAction,
 )
 
-from fibsem.fm.config import load_recent_channels
+from fibsem.fm.config import load_recent_channels, remove_recent_channel
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.structures import ChannelSettings
 from fibsem.ui import stylesheets
@@ -407,6 +408,108 @@ class ChannelRowWidget(QWidget):
 
 
 # ---------------------------------------------------------------------------
+# Recent-channels quick-select menu rows
+# ---------------------------------------------------------------------------
+
+# QWidgetAction rows don't get the menu's native hover highlight, so paint it
+# ourselves (#3d4251 matches QMenu::item:selected in stylesheets.py). Child
+# labels must stay transparent so the row's hover background shows through.
+_MENU_ROW_STYLE = (
+    "#menuRow { background: transparent; }"
+    "#menuRow:hover { background: #3d4251; }"
+    "#menuRow QLabel { background: transparent; }"
+)
+
+
+class _MenuRow(QWidget):
+    """Base row for the add-channel menu: fixed swatch slot + label, hover
+    highlight, and a left-click that emits ``selected``."""
+
+    selected = pyqtSignal(object)
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("menuRow")
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self.setStyleSheet(_MENU_ROW_STYLE)
+
+        self._layout = QHBoxLayout(self)
+        self._layout.setContentsMargins(10, 4, 6, 4)
+        self._layout.setSpacing(6)
+
+    def _emit_selected(self):
+        raise NotImplementedError
+
+    def mousePressEvent(self, event) -> None:
+        if event.button() == Qt.LeftButton:
+            self._emit_selected()
+        super().mousePressEvent(event)
+
+
+class _NewChannelRow(_MenuRow):
+    """First menu row — adds a fresh default channel."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setToolTip("Add a new channel")
+
+        # transparent placeholder aligns the label with the swatch column below
+        placeholder = QLabel()
+        placeholder.setFixedSize(14, 14)
+        self._layout.addWidget(placeholder)
+
+        self._layout.addWidget(QLabel("New channel"), 1)
+
+    def _emit_selected(self):
+        self.selected.emit(None)
+
+
+class _RecentChannelRow(_MenuRow):
+    """Recent-channel row: color + name + remove (x).
+
+    Clicking the row body selects the channel; the x removes it from the
+    recents store. Unavailable channels (wavelengths not on the current filter
+    set) are greyed out and cannot be selected, but can still be removed.
+    """
+
+    removed = pyqtSignal(object)   # ChannelSettings
+
+    def __init__(
+        self,
+        channel: ChannelSettings,
+        available: bool = True,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.channel = channel
+        self._available = available
+
+        tooltip = channel.pretty_name
+        if not available:
+            tooltip += "\nWavelength not available on current filter set"
+        self.setToolTip(tooltip)
+
+        swatch = QLabel()
+        swatch.setPixmap(_make_color_icon(channel.color, 14).pixmap(14, 14))
+        self._layout.addWidget(swatch)
+
+        name = QLabel(channel.name)
+        if not available:
+            name.setStyleSheet("color: #808080;")
+        self._layout.addWidget(name, 1)
+
+        self.btn_remove = IconToolButton(
+            icon="mdi:close", tooltip="Remove from recents", size=20
+        )
+        self.btn_remove.clicked.connect(lambda: self.removed.emit(self.channel))
+        self._layout.addWidget(self.btn_remove)
+
+    def _emit_selected(self):
+        if self._available:
+            self.selected.emit(self.channel)
+
+
+# ---------------------------------------------------------------------------
 # Header
 # ---------------------------------------------------------------------------
 
@@ -772,29 +875,53 @@ class ChannelListWidget(QWidget):
 
         menu = QMenu(self)
         menu.setToolTipsVisible(True)
-        act_new = menu.addAction("New channel")
+
+        new_action = QWidgetAction(menu)
+        new_row = _NewChannelRow()
+        new_action.setDefaultWidget(new_row)
+        new_row.selected.connect(lambda _, m=menu: self._on_new_channel_selected(m))
+        menu.addAction(new_action)
+
         menu.addSeparator()
         for recent in recents:
-            action = QAction(_make_color_icon(recent.color), recent.name, menu)
-            action.setData(recent)
-            tooltip = recent.pretty_name
-            if not self._channel_available(recent):
-                action.setEnabled(False)
-                tooltip += "\nWavelength not available on current filter set"
-            action.setToolTip(tooltip)
-            menu.addAction(action)
+            self._add_recent_menu_row(menu, recent)
 
         btn = self._header.btn_add
-        chosen = menu.exec_(btn.mapToGlobal(btn.rect().bottomLeft()))
-        if chosen is None:
-            return
-        if chosen is act_new:
-            self.add_channel()
-            return
-        channel = deepcopy(chosen.data())
+        menu.exec_(btn.mapToGlobal(btn.rect().bottomLeft()))
+
+    def _on_new_channel_selected(self, menu: QMenu) -> None:
+        menu.close()
+        self.add_channel()
+
+    def _add_recent_menu_row(self, menu: QMenu, recent: ChannelSettings) -> None:
+        action = QWidgetAction(menu)
+        row = _RecentChannelRow(recent, available=self._channel_available(recent))
+        action.setDefaultWidget(row)
+        row.selected.connect(lambda ch, m=menu: self._on_recent_selected(m, ch))
+        row.removed.connect(
+            lambda ch, m=menu, a=action: self._on_recent_removed(m, a, ch)
+        )
+        menu.addAction(action)
+
+    def _on_recent_selected(self, menu: QMenu, channel: ChannelSettings) -> None:
+        menu.close()
+        channel = deepcopy(channel)
         existing = {self._row(i).channel.name for i in range(self._list.count())}
         channel.name = _unique_name(channel.name, existing)
         self.add_channel(channel)
+
+    def _on_recent_removed(
+        self, menu: QMenu, action: QWidgetAction, channel: ChannelSettings
+    ) -> None:
+        remove_recent_channel(channel)
+        menu.removeAction(action)
+        has_recents = any(
+            isinstance(a, QWidgetAction)
+            and isinstance(a.defaultWidget(), _RecentChannelRow)
+            for a in menu.actions()
+        )
+        if not has_recents:
+            menu.close()
 
     def _channel_available(self, channel: ChannelSettings) -> bool:
         """Whether the channel's wavelengths exist on the current filter set."""

--- a/fibsem/ui/fm/widgets/channel_list_widget.py
+++ b/fibsem/ui/fm/widgets/channel_list_widget.py
@@ -30,6 +30,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from fibsem.fm.config import load_recent_channels
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.structures import ChannelSettings
 from fibsem.ui import stylesheets
@@ -764,7 +765,48 @@ class ChannelListWidget(QWidget):
     # ------------------------------------------------------------------
 
     def _on_add_channel(self) -> None:
-        self.add_channel()
+        recents = load_recent_channels()
+        if not recents:
+            self.add_channel()
+            return
+
+        menu = QMenu(self)
+        menu.setToolTipsVisible(True)
+        act_new = menu.addAction("New channel")
+        menu.addSeparator()
+        for recent in recents:
+            action = QAction(_make_color_icon(recent.color), recent.name, menu)
+            action.setData(recent)
+            tooltip = recent.pretty_name
+            if not self._channel_available(recent):
+                action.setEnabled(False)
+                tooltip += "\nWavelength not available on current filter set"
+            action.setToolTip(tooltip)
+            menu.addAction(action)
+
+        btn = self._header.btn_add
+        chosen = menu.exec_(btn.mapToGlobal(btn.rect().bottomLeft()))
+        if chosen is None:
+            return
+        if chosen is act_new:
+            self.add_channel()
+            return
+        channel = deepcopy(chosen.data())
+        existing = {self._row(i).channel.name for i in range(self._list.count())}
+        channel.name = _unique_name(channel.name, existing)
+        self.add_channel(channel)
+
+    def _channel_available(self, channel: ChannelSettings) -> bool:
+        """Whether the channel's wavelengths exist on the current filter set."""
+        if self._excitation_items and channel.excitation_wavelength not in self._excitation_items:
+            return False
+        if (
+            channel.emission_wavelength is not None
+            and self._emission_items
+            and channel.emission_wavelength not in self._emission_items
+        ):
+            return False
+        return True
 
     def _on_remove_clicked(self, channel: ChannelSettings) -> None:
         if self.fm is not None and self.fm.is_acquiring and channel is self._selected_channel:

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -24,6 +24,7 @@ from fibsem import conversions, utils
 from fibsem import config as fcfg
 from fibsem.fm.acquisition import acquire_image
 from fibsem.fm.calibration import run_autofocus
+from fibsem.fm.config import record_recent_channels
 from fibsem.fm.structures import (
     AutoFocusSettings,
     CameraImageTransform,
@@ -603,6 +604,7 @@ class FMControlWidget(QWidget):
         logging.info(
             f"Starting acquisition with channel settings: {selected_channel_settings}"
         )
+        record_recent_channels(selected_channel_settings)
         self.fm.start_acquisition(channel_settings=selected_channel_settings)
         self._update_acquisition_button_states()
 
@@ -803,6 +805,8 @@ class FMControlWidget(QWidget):
             self._current_acquisition_type = None
             self._update_acquisition_button_states()
             return
+
+        record_recent_channels(channel_settings)
 
         # Start acquisition thread
         self._acquisition_thread = threading.Thread(

--- a/tests/test_recent_channels.py
+++ b/tests/test_recent_channels.py
@@ -1,0 +1,132 @@
+"""Tests for the recently-used FM channel settings config helpers."""
+
+import os
+
+import pytest
+import yaml
+
+from fibsem import config as cfg
+from fibsem.fm import config as fm_config
+from fibsem.fm.structures import ChannelSettings
+
+
+@pytest.fixture
+def recents_env(tmp_path, monkeypatch):
+    """Point the recent-channels helpers at an isolated temp file."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_dir))
+    monkeypatch.setattr(
+        cfg, "FM_RECENT_CHANNELS_PATH", str(config_dir / "fm-recent-channels.yaml")
+    )
+    return tmp_path
+
+
+def _channel(name="DAPI", excitation=405.0, emission=450.0, **kwargs) -> ChannelSettings:
+    return ChannelSettings(
+        name=name, excitation_wavelength=excitation, emission_wavelength=emission, **kwargs
+    )
+
+
+def test_load_missing_file_returns_empty(recents_env):
+    assert fm_config.load_recent_channels() == []
+
+
+def test_record_inserts_most_recent_first(recents_env):
+    fm_config.record_recent_channels(_channel("DAPI", 405.0))
+    fm_config.record_recent_channels(_channel("GFP", 488.0, 520.0))
+
+    recents = fm_config.load_recent_channels()
+    assert [ch.name for ch in recents] == ["GFP", "DAPI"]
+
+
+def test_record_list_preserves_channel_order(recents_env):
+    fm_config.record_recent_channels(_channel("Old", 550.0))
+    fm_config.record_recent_channels(
+        [_channel("DAPI", 405.0), _channel("GFP", 488.0, 520.0)]
+    )
+
+    recents = fm_config.load_recent_channels()
+    assert [ch.name for ch in recents] == ["DAPI", "GFP", "Old"]
+
+
+def test_reuse_replaces_entry_and_moves_to_front(recents_env):
+    fm_config.record_recent_channels(_channel("DAPI", 405.0, power=0.01))
+    fm_config.record_recent_channels(_channel("GFP", 488.0, 520.0))
+    # same name with tweaked power -> replace, move to front
+    fm_config.record_recent_channels(_channel("DAPI", 405.0, power=0.05))
+
+    recents = fm_config.load_recent_channels()
+    assert [ch.name for ch in recents] == ["DAPI", "GFP"]
+    assert recents[0].power == 0.05
+
+
+def test_same_name_different_wavelength_replaces(recents_env):
+    # keyed on name only: re-using a name overwrites its stored settings
+    fm_config.record_recent_channels(_channel("DAPI", 405.0))
+    fm_config.record_recent_channels(_channel("DAPI", 488.0))
+
+    recents = fm_config.load_recent_channels()
+    assert len(recents) == 1
+    assert recents[0].excitation_wavelength == 488.0
+
+
+def test_different_name_is_separate_entry(recents_env):
+    fm_config.record_recent_channels(_channel("DAPI", 405.0))
+    fm_config.record_recent_channels(_channel("Hoechst", 405.0))
+
+    assert len(fm_config.load_recent_channels()) == 2
+
+
+def test_record_truncates_to_max(recents_env):
+    for i in range(fm_config.MAX_RECENT_CHANNELS + 5):
+        fm_config.record_recent_channels(_channel(f"Channel-{i}", 400.0 + i))
+
+    recents = fm_config.load_recent_channels()
+    assert len(recents) == fm_config.MAX_RECENT_CHANNELS
+    assert recents[0].name == f"Channel-{fm_config.MAX_RECENT_CHANNELS + 4}"
+
+
+def test_identical_record_skips_rewrite(recents_env):
+    channel = _channel("DAPI", 405.0)
+    fm_config.record_recent_channels(channel)
+    mtime = os.path.getmtime(cfg.FM_RECENT_CHANNELS_PATH)
+    os.utime(cfg.FM_RECENT_CHANNELS_PATH, (mtime - 100, mtime - 100))
+
+    fm_config.record_recent_channels(channel)
+    assert os.path.getmtime(cfg.FM_RECENT_CHANNELS_PATH) == mtime - 100
+
+
+def test_corrupted_file_returns_empty(recents_env):
+    with open(cfg.FM_RECENT_CHANNELS_PATH, "w") as f:
+        f.write("{not: valid: yaml: [")
+
+    assert fm_config.load_recent_channels() == []
+
+
+def test_malformed_entry_is_skipped(recents_env):
+    with open(cfg.FM_RECENT_CHANNELS_PATH, "w") as f:
+        yaml.safe_dump(
+            [
+                _channel("DAPI", 405.0).to_dict(),
+                {"bogus_field": 1},
+                "not-a-dict",
+            ],
+            f,
+        )
+
+    recents = fm_config.load_recent_channels()
+    assert [ch.name for ch in recents] == ["DAPI"]
+
+
+def test_round_trip_preserves_emission_types(recents_env):
+    fm_config.record_recent_channels(
+        [
+            _channel("Reflection", 550.0, emission=None),
+            _channel("Filter", 488.0, emission="LP510"),
+        ]
+    )
+
+    recents = fm_config.load_recent_channels()
+    assert recents[0].emission_wavelength is None
+    assert recents[1].emission_wavelength == "LP510"

--- a/tests/test_recent_channels.py
+++ b/tests/test_recent_channels.py
@@ -119,6 +119,31 @@ def test_malformed_entry_is_skipped(recents_env):
     assert [ch.name for ch in recents] == ["DAPI"]
 
 
+def test_remove_recent_channel(recents_env):
+    fm_config.record_recent_channels(
+        [_channel("DAPI", 405.0), _channel("GFP", 488.0, 520.0)]
+    )
+    fm_config.remove_recent_channel(_channel("DAPI", 405.0))
+
+    recents = fm_config.load_recent_channels()
+    assert [ch.name for ch in recents] == ["GFP"]
+
+
+def test_remove_recent_channel_matches_by_name(recents_env):
+    # keyed on name: wavelength need not match to remove
+    fm_config.record_recent_channels(_channel("DAPI", 405.0))
+    fm_config.remove_recent_channel(_channel("DAPI", 999.0))
+
+    assert fm_config.load_recent_channels() == []
+
+
+def test_remove_missing_channel_is_noop(recents_env):
+    fm_config.record_recent_channels(_channel("DAPI", 405.0))
+    fm_config.remove_recent_channel(_channel("Nonexistent"))
+
+    assert [ch.name for ch in fm_config.load_recent_channels()] == ["DAPI"]
+
+
 def test_round_trip_preserves_emission_types(recents_env):
     fm_config.record_recent_channels(
         [

--- a/tests/ui/test_channel_list_recent_menu.py
+++ b/tests/ui/test_channel_list_recent_menu.py
@@ -1,0 +1,194 @@
+"""Headless tests for the recent-channels quick-select menu in ChannelListWidget.
+
+Uses PyQt5 directly with the offscreen platform (no pytest-qt dependency).
+The real ``_on_add_channel`` opens a modal ``QMenu.exec_()``; tests stub that
+to capture the menu, and exercise the row/selection/removal helpers directly.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication, QMenu, QWidgetAction
+
+from fibsem import config as cfg
+from fibsem.fm import config as fm_config
+from fibsem.fm.structures import ChannelSettings
+from fibsem.ui.fm.widgets import channel_list_widget as clw
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def recents_env(tmp_path, monkeypatch):
+    """Point the recent-channels store at an isolated temp file."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_dir))
+    monkeypatch.setattr(
+        cfg, "FM_RECENT_CHANNELS_PATH", str(config_dir / "fm-recent-channels.yaml")
+    )
+    return tmp_path
+
+
+class _FakeFilterSet:
+    available_excitation_wavelengths = [405.0, 488.0, 550.0]
+    available_emission_wavelengths = [450.0, 520.0]
+
+
+class _FakeFM:
+    filter_set = _FakeFilterSet()
+    is_acquiring = False
+
+
+def _widget(qapp):
+    channel = ChannelSettings(
+        name="Channel-01", excitation_wavelength=405.0, emission_wavelength=450.0
+    )
+    return clw.ChannelListWidget(fm=_FakeFM(), channel_settings=[channel])
+
+
+def _recent_rows(menu: QMenu):
+    return [
+        a
+        for a in menu.actions()
+        if isinstance(a, QWidgetAction)
+        and isinstance(a.defaultWidget(), clw._RecentChannelRow)
+    ]
+
+
+# --- availability --------------------------------------------------------
+
+
+def test_channel_available_matches_filter_set(qapp):
+    w = _widget(qapp)
+    assert w._channel_available(
+        ChannelSettings(name="GFP", excitation_wavelength=488.0, emission_wavelength=520.0)
+    )
+    # emission None (reflection) is always allowed
+    assert w._channel_available(
+        ChannelSettings(name="Refl", excitation_wavelength=405.0, emission_wavelength=None)
+    )
+    # excitation not on the filter set
+    assert not w._channel_available(
+        ChannelSettings(name="Bad", excitation_wavelength=999.0, emission_wavelength=520.0)
+    )
+    # emission not on the filter set
+    assert not w._channel_available(
+        ChannelSettings(name="Bad", excitation_wavelength=405.0, emission_wavelength=999.0)
+    )
+
+
+# --- menu construction ---------------------------------------------------
+
+
+def test_no_recents_adds_directly_without_menu(qapp, monkeypatch):
+    w = _widget(qapp)
+    monkeypatch.setattr(clw, "load_recent_channels", lambda: [])
+    monkeypatch.setattr(
+        QMenu, "exec_", lambda *a, **k: pytest.fail("menu must not open with no recents")
+    )
+    before = w._list.count()
+    w._on_add_channel()
+    assert w._list.count() == before + 1
+
+
+def test_menu_lists_new_channel_then_recents(qapp, monkeypatch):
+    w = _widget(qapp)
+    recents = [
+        ChannelSettings(name="GFP", excitation_wavelength=488.0, emission_wavelength=520.0),
+        ChannelSettings(name="Bad", excitation_wavelength=999.0, emission_wavelength=520.0),
+    ]
+    monkeypatch.setattr(clw, "load_recent_channels", lambda: recents)
+
+    captured = {}
+
+    def fake_exec(self, *a, **k):
+        captured["menu"] = self
+        return None
+
+    monkeypatch.setattr(QMenu, "exec_", fake_exec)
+    w._on_add_channel()
+
+    menu = captured["menu"]
+    widget_actions = [a for a in menu.actions() if isinstance(a, QWidgetAction)]
+    rows = [a.defaultWidget() for a in widget_actions]
+    # first row is New channel, then one row per recent
+    assert isinstance(rows[0], clw._NewChannelRow)
+    recent_rows = [r for r in rows if isinstance(r, clw._RecentChannelRow)]
+    assert [r.channel.name for r in recent_rows] == ["GFP", "Bad"]
+    # the unavailable recent is greyed out / not selectable
+    assert recent_rows[0]._available is True
+    assert recent_rows[1]._available is False
+
+
+# --- selection -----------------------------------------------------------
+
+
+def test_new_channel_selected_adds_default(qapp):
+    w = _widget(qapp)
+    before = w._list.count()
+    w._on_new_channel_selected(QMenu())
+    assert w._list.count() == before + 1
+
+
+def test_recent_selected_adds_copy_and_uniquifies_name(qapp):
+    w = _widget(qapp)  # already contains "Channel-01"
+    recent = ChannelSettings(
+        name="Channel-01", excitation_wavelength=405.0, emission_wavelength=450.0
+    )
+    before = w._list.count()
+    w._on_recent_selected(QMenu(), recent)
+
+    assert w._list.count() == before + 1
+    names = [w._row(i).channel.name for i in range(w._list.count())]
+    assert "Channel-01 (2)" in names
+    # a copy was added, not the passed-in object
+    added = w._row(w._list.count() - 1).channel
+    assert added is not recent
+
+
+# --- removal -------------------------------------------------------------
+
+
+def test_recent_removed_updates_store(qapp, recents_env):
+    w = _widget(qapp)
+    fm_config.record_recent_channels(
+        [
+            ChannelSettings(name="GFP", excitation_wavelength=488.0, emission_wavelength=520.0),
+            ChannelSettings(name="DAPI", excitation_wavelength=405.0, emission_wavelength=450.0),
+        ]
+    )
+    menu = QMenu()
+    for recent in fm_config.load_recent_channels():
+        w._add_recent_menu_row(menu, recent)
+    assert len(_recent_rows(menu)) == 2
+
+    # click the x on the first recent row
+    _recent_rows(menu)[0].defaultWidget().btn_remove.click()
+
+    remaining = [c.name for c in fm_config.load_recent_channels()]
+    assert len(remaining) == 1
+    assert len(_recent_rows(menu)) == 1
+
+
+def test_removing_last_recent_empties_store(qapp, recents_env):
+    w = _widget(qapp)
+    fm_config.record_recent_channels(
+        ChannelSettings(name="GFP", excitation_wavelength=488.0, emission_wavelength=520.0)
+    )
+    menu = QMenu()
+    for recent in fm_config.load_recent_channels():
+        w._add_recent_menu_row(menu, recent)
+
+    _recent_rows(menu)[0].defaultWidget().btn_remove.click()
+
+    assert fm_config.load_recent_channels() == []
+    assert _recent_rows(menu) == []


### PR DESCRIPTION
## Summary

Adds a recently-used channel-settings memory to the fluorescence microscope control widget, surfaced as a quick-select menu on the channel list's **+** button.

- **Record on acquisition** ([FIB-258](https://linear.app/fibsemos/issue/FIB-258)): channel settings are saved to `fm-recent-channels.yaml` when the user starts an acquisition (live / snap / z-stack), deduped **by channel name** with the latest use replacing the stored entry, capped at 10. Recording is hooked at the acquisition button handlers in `fluorescence_control_widget.py` — not the core acquisition functions — so scripted/headless runs don't pollute the list.
- **Quick-select menu**: clicking **+** opens a menu with "New channel" first, then recents shown as a color swatch + name, with the full settings (`pretty_name`) on the tooltip. Entries whose wavelengths aren't on the current filter set are greyed out and non-selectable. Selecting a recent deep-copies it and uniquifies the name against existing rows. With no recents recorded, **+** adds a channel directly, as before.
- **Per-entry removal** ([FIB-290](https://linear.app/fibsemos/issue/FIB-290)): each recent row has an **✕** to remove that entry from the store; the menu stays open so several can be pruned and closes once the last recent is gone. ✕ (not a trash icon) signals non-destructive "dismiss from list" and avoids collision with the trash-can that deletes an actual channel in the adjacent list.

Because the menu lives in the shared `ChannelListWidget`, it appears in every consumer (FM control, FMAcquisitionWidget, and the protocol editor) with no extra wiring.

## Files

- `fibsem/config.py` — `FM_RECENT_CHANNELS_PATH` constant.
- `fibsem/fm/config.py` — `load_recent_channels` / `record_recent_channels` / `remove_recent_channel` helpers, `MAX_RECENT_CHANNELS = 10`.
- `fibsem/ui/fm/widgets/channel_list_widget.py` — quick-select menu, `_NewChannelRow` / `_RecentChannelRow` (hover-highlighted `QWidgetAction` rows).
- `fibsem/ui/widgets/fluorescence_control_widget.py` — record on acquisition button press.
- `tests/test_recent_channels.py` — 14 unit tests (ordering, name-keyed dedup/replace, truncation, skip-rewrite, corrupted/malformed files, removal, emission-type round-trips).

## Testing

- `pytest tests/test_recent_channels.py` — 14 passing.
- Manually verified in the running app: recording across live/snap/z-stack, menu labelling + tooltips, greyed unavailable entries, per-entry ✕ removal (menu stays open), name-keyed replace-on-reuse, and persistence across restarts.

## Follow-up

[FIB-291](https://linear.app/fibsemos/issue/FIB-291) tracks recording channel edits from the protocol editor (debounced), deliberately out of scope here.