### PR TITLE
[fix] overtilt: route alignment output to configured path, not CWD

### DIFF
--- a/fibsem/alignment/__init__.py
+++ b/fibsem/alignment/__init__.py
@@ -452,8 +452,10 @@ def multi_step_alignment_v2(
     """Runs the beam shift alignment multiple times."""
 
     alignment_results = []
+    aborted = False
     for i in range(steps):
         if stop_event is not None and stop_event.is_set():
+            aborted = True
             break
         # only use autocontrast on first step
         use_autocontrast = use_autocontrast if i == 0 else False
@@ -467,6 +469,20 @@ def multi_step_alignment_v2(
             method=method,
         )
         alignment_results.append(result)
+
+    # Cancelled before any step completed: there is nothing meaningful to
+    # persist. Skip the final-image acquisition (which would touch the
+    # microscope after a stop request) and the save (which would otherwise
+    # dump an empty AlignmentResult directory, into the CWD when no path is
+    # set), and return an empty result.
+    if aborted and not alignment_results:
+        return AlignmentResult(
+            name=run_name,
+            reference_image=ref_image,
+            subsystem=subsystem,
+            method=method,
+            results=[],
+        )
 
     if validate:
         acquire_final_image = True

--- a/fibsem/milling/strategy/overtilt.py
+++ b/fibsem/milling/strategy/overtilt.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import logging
-import os
 import threading
 from dataclasses import dataclass, field
 from typing import Optional
 
 import numpy as np
 
-from fibsem import acquire, alignment
+from fibsem import acquire, alignment, config as fcfg
 from fibsem.cancellation import raise_if_cancelled
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling import setup_milling
@@ -97,6 +96,13 @@ class OvertiltTrenchMillingStrategy(MillingStrategy[OvertiltTrenchMillingConfig]
         initial_position = microscope.get_stage_position()
         overtilt_in_radians = np.deg2rad(self.config.overtilt)
 
+        # route the reference image + alignment output to the stage's configured
+        # imaging path (falling back to DATA_CC_PATH), mirroring
+        # milling.core.get_stage_reference_image — never the current working dir.
+        alignment_path = stage.imaging.path
+        if alignment_path is None:
+            alignment_path = fcfg.DATA_CC_PATH
+
         # TODO: pass in image settings
         # TODO: attach image_settings to microscope? or get current settings?
         # TODO: use drift correction structure to re-align? once added to milling stage
@@ -107,7 +113,7 @@ class OvertiltTrenchMillingStrategy(MillingStrategy[OvertiltTrenchMillingConfig]
             beam_type=stage.milling.milling_channel,
         )
         image_settings.reduced_area = stage.alignment.rect
-        image_settings.path = os.getcwd()
+        image_settings.path = alignment_path
         image_settings.filename = f"ref_{stage.name}_overtilt_alignment"
         ref_image = acquire.acquire_image(microscope, image_settings)
 
@@ -128,10 +134,14 @@ class OvertiltTrenchMillingStrategy(MillingStrategy[OvertiltTrenchMillingConfig]
             image_settings = ImageSettings.fromFibsemImage(ref_image)
             image_settings.filename = f"{stage.name}_overtilt_alignment_target_{i}"
 
+            # ref_image carries alignment_path, so multi_step_alignment_v2's
+            # default save path resolves under <alignment_path>/Alignment/,
+            # mirroring setup_milling's drift-correction alignment.
             alignment.multi_step_alignment_v2(
                 microscope=microscope,
                 ref_image=ref_image,
                 steps=3,
+                run_name=f"{stage.name}_overtilt_alignment_{i}",
                 stop_event=stop_event,  # abort between alignment steps
             )
 


### PR DESCRIPTION
## Problem

`OvertiltTrenchMillingStrategy.run()` hardcoded its reference image's path to `os.getcwd()` and called `alignment.multi_step_alignment_v2(...)` with no `run_name`. Since `multi_step_alignment_v2` falls back to the ref image's path when `path` is `None` and defaults `run_name` to `"AlignmentResult"`, a production overtilt milling dumped an `Alignment/AlignmentResult-<HH-MM-SS>/` directory into whatever directory the app was launched from.

The test-level symptom (`Alignment/` leaking into the repo root) had previously been worked around at the test layer, but the underlying library behaviour of writing to CWD remained.

## Changes

**`fibsem/milling/strategy/overtilt.py`**
- Resolve the reference-image + alignment save path from `stage.imaging.path`, falling back to `fcfg.DATA_CC_PATH` when unset — mirroring `milling.core.get_stage_reference_image` (which falls back to `DATA_CC_PATH`, not CWD).
- Add a descriptive `run_name=f"{stage.name}_overtilt_alignment_{i}"` so the run directory is named per-stage instead of the generic `AlignmentResult`.
- Output now nests under `<path>/Alignment/…` via the ref-image fallback, identical to `setup_milling`'s drift-correction alignment. Removed the now-unused `import os`.

**`fibsem/alignment/__init__.py`**
- `multi_step_alignment_v2`: when `stop_event` aborts the steps loop before any step completes, return an empty `AlignmentResult` early — skipping both the post-cancel final-image acquisition (which would touch the microscope after a stop request) and the save (which would otherwise write an empty run directory, into CWD when no path is set). Partial cancellations still save.

## Testing
- All 83 `tests/milling/` tests and 36 `tests/test_alignment.py` tests pass.
- Verified a full overtilt run writes all alignment runs under `<imaging.path>/Alignment/…` and nothing into CWD.
- Verified a cancelled (0-step) alignment returns an empty result, performs no further acquisition, and creates no directory.