### PR TITLE
[fix] test_spot_burn: keep cyclic GC off Qt paint (intermittent segfault)

### DIFF
--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -7,6 +7,7 @@ These cover the failure modes that crashed the unsupervised (automatic) path:
 - the widget factory rendering float/int fields as a text box instead of a spinbox.
 """
 
+import gc
 import os
 from unittest.mock import MagicMock
 
@@ -363,7 +364,33 @@ def qapp():
         from PyQt5.QtWidgets import QApplication
     except Exception as exc:  # pragma: no cover - environment without Qt
         pytest.skip(f"PyQt5 not available: {exc}")
-    return QApplication.instance() or QApplication([])
+    app = QApplication.instance() or QApplication([])
+
+    # Keep CPython's cyclic garbage collector from running while these tests build
+    # and paint real Qt widgets. Constructing the parameter form ends in
+    # widget.show() (AutoLamellaTaskParametersConfigWidget._update_from_config), and
+    # Qt's C++ paint of the qtawesome toolbutton icon re-enters Python; an automatic
+    # gen-0 collection landing in that window finalises objects mid-paint and
+    # segfaults the interpreter — an intermittent EXC_BAD_ACCESS inside
+    # QCommonStyle::drawControl that takes the whole `pytest` process down (~11/12
+    # runs of this file) rather than failing one test. It only bites when a prior
+    # test has left cyclic garbage for that collection to reclaim, which is why a
+    # single test in isolation always passes.
+    #
+    # This is the single-threaded, re-entrant cousin of the Windows vispy/gloo crash
+    # (PR #168): the application never lets automatic GC run for this reason and
+    # collects on the Qt main thread instead (fibsem/ui/qt/gc.py). The tests build
+    # widgets without that machinery, so adopt the same contract here — disable
+    # automatic collection while the widgets are alive and drain it once at a safe
+    # point (no Qt paint on the stack) on teardown.
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        yield app
+    finally:
+        gc.collect()
+        if gc_was_enabled:
+            gc.enable()
 
 
 @requires_ui


### PR DESCRIPTION
## Problem

`tests/autolamella/test_spot_burn.py` intermittently **segfaults the whole `pytest` process** (~11/12 runs of the file), so a green suite isn't trustworthy — one bad run takes the entire ~800-test suite down. The faulthandler dump always points at the same place:

```
fibsem/ui/widgets/autolamella_task_config_widget.py:575 in _update_from_config
fibsem/ui/widgets/autolamella_task_config_widget.py:506 in __init__   (AutoLamellaTaskParametersConfigWidget)
tests/autolamella/test_spot_burn.py in a UI widget test
```

Running a single test from the file in isolation always passes — it's a test-interaction / object-lifetime problem, not a bad assertion.

## Root cause

An **automatic cyclic-GC pass firing re-entrantly during Qt's paint** — not QApplication reuse (that's already a shared singleton).

`AutoLamellaTaskParametersConfigWidget.__init__` ends `_update_from_config` with `self.show()`. In the test the widget has no parent, so `show()` creates a real offscreen top-level window and paints it synchronously. Painting the `TitledPanel` collapse `QToolButton` re-enters Python through qtawesome's `CharIconEngine` (a Python `QIconEngine` subclass). If CPython's automatic gen-0 collector crosses its threshold in that window, it finalizes cyclic garbage **mid-paint**, and the process dies with `EXC_BAD_ACCESS` inside `QCommonStyle::drawControl` (confirmed via the macOS crash report's native stack). It only triggers when a *prior* test has left cyclic garbage for that pass to reclaim — hence "crashes in-suite, passes in isolation".

This is the single-threaded, re-entrant cousin of the Windows vispy/gloo crash fixed in #168. The **application** already avoids the whole class by never letting automatic GC run — it collects on the Qt main thread via `fibsem/ui/qt/gc.py`. The **tests** build widgets without that machinery.

## Fix

Both crashing tests depend on the module-scoped `qapp` fixture, and only widget-building tests do — so the fix is confined by giving that fixture the app's GC contract: disable automatic cyclic collection while the widgets are alive, drain once at a safe point (no Qt paint on the stack) on teardown, and restore prior GC state. No product code changes; no blanket/session GC disable, so the GC-behavior tests in `tests/ui/test_main_thread_gc.py` are unaffected.

## Verification

The crash is timing-sensitive, but reproduces **reliably under cold bytecode** (`python -B` / `PYTHONDONTWRITEBYTECODE=1`), which raises import-time GC pressure so a collection reliably lands in the paint window (cached `.pyc` hides it — the source of the heisenbug):

| condition (`-B`, N=20) | result |
| --- | --- |
| **unfixed** | **20/20 crash** |
| **fixed** | **0/20 crash, 17 passed** |

- `test_spot_burn.py` + `tests/ui/test_main_thread_gc.py` together, **both orders** → 21 passed (no GC-state leakage, GC-contract tests intact).
- UI + autolamella suites → 98 passed. Full `tests/` under `-B` → 737 passed, 15 skipped, **no segfault**.

## Follow-up (not in this PR)

The other UI test files (`test_wheel_blocker.py`, `test_autofocus_widget.py`, `test_interpolation.py`, `test_settings_widgets_integer.py`, `test_correlation_tab_widget.py`) duplicate the same bare `qapp` fixture and are the same latent hazard class (none reproduce individually today). A tidy follow-up is to lift a single GC-disciplined, session-shared `qapp` into `tests/conftest.py` and have those files inherit it — keeping `test_main_thread_gc.py` on its own stock-GC fixture.