### PR TITLE
Correlation: consolidate the two JSON files into one correlation.json (FIB-264)

### DIFF
--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -169,7 +169,7 @@ class CorrelationInputData:
             hint = (
                 " This looks like a correlation result — load it with"
                 " Load Correlation Result instead."
-                if ("poi" in data or "input_data" in data)
+                if ("poi" in data or "computed_from" in data or "input_data" in data)
                 else ""
             )
             raise ValueError(
@@ -325,7 +325,13 @@ class CorrelationResult:
             "mean_absolute_error": self.mean_absolute_error,
             "delta_2d": [p.to_dict() for p in self.delta_2d],
             "reprojected_3d": [p.to_dict() for p in self.reprojected_3d],
-            "input_data": self.input_data.to_dict() if self.input_data else None,
+            # Serialized as "computed_from", not "input_data": it is a snapshot of
+            # the points this transform was FITTED to, not the current inputs.
+            # The distinction is invisible in a standalone result file but matters
+            # in the consolidated correlation.json (FIB-264), which also carries a
+            # top-level input_data for the current points. The Python attribute
+            # stays `input_data`; only the wire key differs.
+            "computed_from": self.input_data.to_dict() if self.input_data else None,
             "refractive_index_correction_factor": self.refractive_index_correction_factor,
             "refractive_index_correction_mode": self.refractive_index_correction_mode,
             "updated_at": self.updated_at,
@@ -359,8 +365,10 @@ class CorrelationResult:
             reprojected_3d=[
                 PointXYZ.from_dict(p) for p in data.get("reprojected_3d", [])
             ],
-            input_data=CorrelationInputData.from_dict(data["input_data"])
-            if data.get("input_data")
+            # "computed_from" is the current key; "input_data" is read for
+            # back-compat with result files written before FIB-264.
+            input_data=CorrelationInputData.from_dict(snapshot)
+            if (snapshot := data.get("computed_from") or data.get("input_data"))
             else None,
             refractive_index_correction_factor=data.get(
                 "refractive_index_correction_factor"
@@ -537,3 +545,92 @@ class CorrelationResult:
     def load(filename: str) -> CorrelationResult:
         with open(filename, "r") as f:
             return CorrelationResult.from_dict(json.load(f))
+
+
+# Current on-disk container version. Bump only on a breaking layout change; the
+# loader keys migration off this, and off the shape of legacy files that predate it.
+CORRELATION_FILE_VERSION = 1
+
+
+@dataclass
+class CorrelationState:
+    """The whole correlation state for a project directory, in one file (FIB-264).
+
+    Supersedes the split ``correlation_data.json`` (a bare
+    :class:`CorrelationInputData`) + ``correlation_result.json`` (a bare
+    :class:`CorrelationResult`). Those two sat side by side with near-identical
+    names and could silently disagree — see :meth:`CorrelationResult.matches_inputs`
+    and the FIB-295 fix. This carries both, with ``input_data`` as the single
+    source of truth for the current points and ``result`` optional (``None``
+    until the first run).
+    """
+
+    input_data: CorrelationInputData = field(default_factory=CorrelationInputData)
+    result: Optional[CorrelationResult] = None
+    version: int = CORRELATION_FILE_VERSION
+
+    def to_dict(self) -> dict:
+        return {
+            "version": self.version,
+            "input_data": self.input_data.to_dict(),
+            "result": self.result.to_dict() if self.result is not None else None,
+        }
+
+    @staticmethod
+    def from_dict(data: dict) -> CorrelationState:
+        """Parse a container dict.
+
+        Only the container shape (has ``version``) is accepted here; legacy files
+        are handled by :func:`load_correlation_file`, which dispatches on shape.
+        """
+        result_data = data.get("result")
+        return CorrelationState(
+            input_data=CorrelationInputData.from_dict(data["input_data"]),
+            result=CorrelationResult.from_dict(result_data) if result_data else None,
+            version=data.get("version", CORRELATION_FILE_VERSION),
+        )
+
+    def save(self, filename: str) -> None:
+        with open(filename, "w") as f:
+            json.dump(self.to_dict(), f, indent=4)
+
+    @staticmethod
+    def load(filename: str) -> CorrelationState:
+        with open(filename, "r") as f:
+            return CorrelationState.from_dict(json.load(f))
+
+
+def load_correlation_file(filename: str) -> CorrelationState:
+    """Load any correlation JSON — new container or either legacy file — as a
+    :class:`CorrelationState`.
+
+    Dispatches on the payload shape, so the caller never has to know which of the
+    three a file is. This is the one place the sniff lives; the ``from_dict``
+    guards on the two legacy classes only reject the *wrong* legacy file when a
+    caller asks for a specific type by name.
+
+      * container      → has ``version``            → parse as-is
+      * legacy result  → has ``poi``/``computed_from``/``input_data`` → wrap
+      * legacy data    → has ``fib_coordinates``    → wrap, no result
+
+    A result file carries its own ``input_data`` snapshot, which becomes the
+    project's current points — the same behaviour the old result loader had.
+    """
+    with open(filename, "r") as f:
+        data = json.load(f)
+
+    if "version" in data:
+        return CorrelationState.from_dict(data)
+
+    if "poi" in data or "computed_from" in data or "input_data" in data:
+        result = CorrelationResult.from_dict(data)
+        current = result.input_data or CorrelationInputData()
+        return CorrelationState(input_data=current, result=result)
+
+    if "fib_coordinates" in data:
+        return CorrelationState(input_data=CorrelationInputData.from_dict(data))
+
+    raise ValueError(
+        f"{filename!r} is not a correlation file: no 'version', 'poi', or "
+        "'fib_coordinates' key."
+    )

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -75,9 +75,11 @@ from fibsem.correlation.structures import (
     Coordinate,
     CorrelationInputData,
     CorrelationPointOfInterest,
+    CorrelationState,
     CorrelationResult,
     PointType,
     PointXYZ,
+    load_correlation_file,
     scale_about_surface,
 )
 from fibsem.correlation.ui.widgets.coordinate_list_widget import CoordinateListWidget
@@ -105,6 +107,12 @@ from fibsem.ui.widgets.custom_widgets import (
 from fibsem.correlation.ui.widgets.refractive_index_widget import RefractiveIndexWidget
 
 _FIT_METHODS = ["None", "Hole", "Gaussian"]
+
+# Consolidated project file (FIB-264). The two legacy names are still *read* for
+# back-compat with projects saved by earlier versions; nothing writes them now.
+CORRELATION_FILENAME = "correlation.json"
+_LEGACY_DATA_FILENAME = "correlation_data.json"
+_LEGACY_RESULT_FILENAME = "correlation_result.json"
 
 # Auto-accept outlier fallback: a fit is a refinement of the user's click, so a
 # large jump usually means it locked onto the wrong feature. Beyond these, the
@@ -1226,17 +1234,17 @@ class CorrelationTabWidget(QWidget):
 
         self._action_load_fib = QAction("Load FIB Image", self)
         self._action_load_fm = QAction("Load Fluorescence Image", self)
-        self._action_load_coords = QAction("Load Coordinates", self)
-        self._action_save_coords = QAction("Save Coordinates", self)
-        self._action_load_result = QAction("Load Correlation Result", self)
+        # One action for coordinates + result: the file dispatches on its shape
+        # (FIB-264), so there is no wrong choice to make — removing the FIB-263
+        # misclick by construction rather than guarding against it.
+        self._action_load = QAction("Load Correlation…", self)
+        self._action_save = QAction("Save Correlation…", self)
 
         file_menu.addAction(self._action_load_fib)
         file_menu.addAction(self._action_load_fm)
         file_menu.addSeparator()
-        file_menu.addAction(self._action_load_coords)
-        file_menu.addAction(self._action_save_coords)
-        file_menu.addSeparator()
-        file_menu.addAction(self._action_load_result)
+        file_menu.addAction(self._action_load)
+        file_menu.addAction(self._action_save)
         file_menu.addSeparator()
         self._action_export_csv = QAction("Export CSV", self)
         file_menu.addAction(self._action_export_csv)
@@ -1405,9 +1413,9 @@ class CorrelationTabWidget(QWidget):
         self._images_tab.fm_image_changed.connect(self._on_fm_image_changed)
         self._images_tab.project_dir_changed.connect(self._on_project_dir_changed)
 
-        # Auto-save
-        self.data_changed.connect(self._auto_save_data)
-        self.result_changed.connect(self._auto_save_result)
+        # Auto-save — one file, rewritten whole on either signal (FIB-264)
+        self.data_changed.connect(self._auto_save_state)
+        self.result_changed.connect(self._auto_save_state)
 
         # RI correction
         self._ri_tab.correction_applied.connect(self._on_correction_applied)
@@ -1435,9 +1443,8 @@ class CorrelationTabWidget(QWidget):
         # File menu
         self._action_load_fib.triggered.connect(self._menu_load_fib)
         self._action_load_fm.triggered.connect(self._menu_load_fm)
-        self._action_load_coords.triggered.connect(self._on_load)
-        self._action_save_coords.triggered.connect(self._on_save)
-        self._action_load_result.triggered.connect(self._menu_load_result)
+        self._action_load.triggered.connect(self._menu_load_correlation)
+        self._action_save.triggered.connect(self._on_save)
         self._action_export_csv.triggered.connect(lambda _: self._menu_export_csv())
         self._action_reset_views.triggered.connect(lambda _: self._reset_views())
         self._action_show_scalebar.toggled.connect(self._on_scalebar_toggled)
@@ -1604,8 +1611,37 @@ class CorrelationTabWidget(QWidget):
             else None
         )
 
+    def load_correlation(self, path: str) -> None:
+        """Load any correlation JSON — consolidated file or either legacy file.
+
+        Dispatches on the file's shape (:func:`load_correlation_file`), so the
+        caller never picks the wrong loader — the FIB-263 crash can't recur.
+        """
+        logging.info("Loading correlation from %s", path)
+        self._adopt_state(load_correlation_file(path))
+
+    def _adopt_state(self, state: CorrelationState) -> None:
+        """Apply a loaded correlation state: points first, then the result (if any).
+
+        Points are loaded before the result so that, when a result is present,
+        its staleness is judged against the freshly-loaded coordinates and its
+        own snapshot is not replayed over them — the FIB-295 ordering, now the
+        only ordering because both come from one file.
+        """
+        data = state.input_data
+        data.fib_image = self._fib_image
+        data.fm_image = self._fm_image
+        self.set_data(data)
+        self.data_changed.emit(self.data)
+        if state.result is not None:
+            self._load_result(state.result, adopt_inputs=False)
+
     def load_data(self, path: str) -> None:
-        """Load coordinates from JSON, preserving current images."""
+        """Load a legacy coordinates file, preserving current images.
+
+        Retained for the quickstart fallback and as the type-specific loader; new
+        code and the File menu use :meth:`load_correlation`.
+        """
         logging.info("Loading correlation coordinates from %s", path)
         loaded = CorrelationInputData.load(path)
         loaded.fib_image = self._fib_image
@@ -1613,9 +1649,9 @@ class CorrelationTabWidget(QWidget):
         self.set_data(loaded)
         self.data_changed.emit(self.data)
 
-    def save_data(self, path: str) -> None:
-        """Save current coordinates to JSON."""
-        self.data.save(path)
+    def save_correlation(self, path: str) -> None:
+        """Save the whole correlation state (points + result) to one JSON."""
+        CorrelationState(input_data=self.data, result=self._result).save(path)
 
     @property
     def data(self) -> CorrelationInputData:
@@ -1671,21 +1707,28 @@ class CorrelationTabWidget(QWidget):
         self._project_dir = path
         self._lbl_status.setText(f"Project: {path}")
 
-    def _auto_save_data(self, data: CorrelationInputData) -> None:
-        if not self._project_dir:
-            return
-        try:
-            data.save(os.path.join(self._project_dir, "correlation_data.json"))
-        except Exception:
-            logging.exception("Auto-save of correlation data failed")
+    def _auto_save_state(self, *_) -> None:
+        """Persist the whole correlation state to a single correlation.json.
 
-    def _auto_save_result(self, result: CorrelationResult) -> None:
+        Wired to both ``data_changed`` and ``result_changed`` — either fires,
+        the full project is rewritten from the live widget state, so the two can
+        never drift apart on disk (which the split data/result files could;
+        FIB-264, FIB-295). The emitted payload is ignored: ``self.data`` and
+        ``self._result`` are the source of truth.
+
+        A post-run edit rewrites with the (now-stale) result still attached — by
+        design. The result carries its own ``computed_from`` snapshot, so
+        staleness stays derivable on load (``matches_inputs``) and the result
+        remains available to inspect; it is not silently discarded here.
+        """
         if not self._project_dir:
             return
         try:
-            result.save(os.path.join(self._project_dir, "correlation_result.json"))
+            CorrelationState(input_data=self.data, result=self._result).save(
+                os.path.join(self._project_dir, CORRELATION_FILENAME)
+            )
         except Exception:
-            logging.exception("Auto-save of correlation result failed")
+            logging.exception("Auto-save of correlation project failed")
 
     # ------------------------------------------------------------------
     # Run correlation
@@ -2133,20 +2176,6 @@ class CorrelationTabWidget(QWidget):
         logging.info("Loading correlation result from %s", path)
         self._load_result(CorrelationResult.load(path), adopt_inputs=adopt_inputs)
 
-    def _menu_load_result(self) -> None:
-        start = self._project_dir or ""
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Load Correlation Result", start, "JSON (*.json);;All files (*)"
-        )
-        if not path:
-            return
-        try:
-            result = CorrelationResult.load(path)
-        except Exception as exc:
-            QMessageBox.warning(self, "Load Error", f"Could not load result:\n{exc}")
-            return
-        self._load_result(result)
-
     def _load_result(
         self, result: CorrelationResult, *, adopt_inputs: bool = True
     ) -> None:
@@ -2166,28 +2195,29 @@ class CorrelationTabWidget(QWidget):
         # that predates the current points must not arm it.
         self._on_result_ready(result, live=result.matches_inputs(self.data))
 
-    def _on_load(self) -> None:
+    def _menu_load_correlation(self) -> None:
         start = self._project_dir or ""
         path, _ = QFileDialog.getOpenFileName(
-            self, "Load Coordinates", start, "JSON (*.json);;All files (*)"
+            self, "Load Correlation", start, "JSON (*.json);;All files (*)"
         )
         if not path:
             return
-        # Guarded like _menu_load_result: this dialog opens on the project dir,
-        # which holds both auto-saved JSONs, so picking the wrong one is easy.
+        # One entry point for every correlation JSON; load_correlation dispatches
+        # on shape, so a wrong pick is no longer possible — only a genuinely
+        # unreadable/foreign file reaches this warning (FIB-264).
         try:
-            self.load_data(path)
+            self.load_correlation(path)
         except Exception as exc:
-            logging.exception("Failed to load coordinates from %s", path)
-            QMessageBox.warning(self, "Load Error", f"Could not load coordinates:\n{exc}")
+            logging.exception("Failed to load correlation from %s", path)
+            QMessageBox.warning(self, "Load Error", f"Could not load correlation:\n{exc}")
 
     def _on_save(self) -> None:
-        start = self._project_dir or ""
+        start = os.path.join(self._project_dir or "", CORRELATION_FILENAME)
         path, _ = QFileDialog.getSaveFileName(
-            self, "Save Coordinates", start, "JSON (*.json);;All files (*)"
+            self, "Save Correlation", start, "JSON (*.json);;All files (*)"
         )
         if path:
-            self.save_data(path)
+            self.save_correlation(path)
 
     # ------------------------------------------------------------------
     # FM z-stack interpolation (FIB-253)
@@ -2507,13 +2537,14 @@ class CorrelationTabDialog(QDialog):
 
 
 def _discover_correlation_files(directory: str) -> Dict[str, Optional[str]]:
-    """Locate FIB/FM images and saved data/result in a correlation project dir.
+    """Locate FIB/FM images and saved correlation JSON in a project dir.
 
     Conventions (matching the widget's auto-save + typical exports):
-      - FM image : ``*.ome.tif`` / ``*.ome.tiff``
-      - FIB image: ``*_ib.tif`` / ``*_ib.tiff`` (else the first non-OME TIFF)
-      - data     : ``correlation_data.json``
-      - result   : ``correlation_result.json``
+      - FM image   : ``*.ome.tif`` / ``*.ome.tiff``
+      - FIB image  : ``*_ib.tif`` / ``*_ib.tiff`` (else the first non-OME TIFF)
+      - correlation: ``correlation.json`` (FIB-264 consolidated file)
+      - data       : ``correlation_data.json``   (legacy, still read)
+      - result     : ``correlation_result.json`` (legacy, still read)
     """
     import glob
 
@@ -2541,8 +2572,9 @@ def _discover_correlation_files(directory: str) -> Dict[str, Optional[str]]:
     return {
         "fib": fib,
         "fm": _first(["*.ome.tif", "*.ome.tiff"]),
-        "data": _existing("correlation_data.json"),
-        "result": _existing("correlation_result.json"),
+        "correlation": _existing(CORRELATION_FILENAME),
+        "data": _existing(_LEGACY_DATA_FILENAME),
+        "result": _existing(_LEGACY_RESULT_FILENAME),
     }
 
 
@@ -2575,11 +2607,23 @@ def load_project(widget: "CorrelationTabWidget", directory: str) -> None:
     else:
         logging.warning("  no FM image (*.ome.tiff) found in %s", directory)
 
-    # Coordinates first. correlation_data.json is rewritten on every edit, so it
-    # is the freshest record of the points; correlation_result.json is only
-    # rewritten by a run, and the input_data embedded in it is a snapshot from
-    # that run. Loading the result first (as this did) let that snapshot
-    # overwrite edits made afterwards — FIB-295.
+    # The consolidated file is authoritative when present — it carries both the
+    # points and the result, staleness self-described (FIB-264/FIB-295).
+    if found["correlation"]:
+        try:
+            widget.load_correlation(found["correlation"])
+            logging.info("  correlation: %s", os.path.basename(found["correlation"]))
+            return
+        except Exception:
+            logging.exception(
+                "  failed to load %s; falling back to legacy files",
+                found["correlation"],
+            )
+
+    # Legacy fallback. Coordinates first: correlation_data.json is rewritten on
+    # every edit, so it is the freshest record of the points; the result's
+    # embedded snapshot is from its last run and must not overwrite later edits
+    # (FIB-295).
     loaded_data = False
     if found["data"]:
         try:
@@ -2611,7 +2655,7 @@ def main() -> None:
         nargs="?",
         default=None,
         help="Optional correlation project directory to quickstart-load "
-        "(FIB/FM images + correlation_data.json / correlation_result.json).",
+        "(FIB/FM images + correlation.json).",
     )
     args = parser.parse_args()
 

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -17,6 +17,7 @@ from fibsem.correlation.structures import (
     Coordinate,
     CorrelationInputData,
     CorrelationPointOfInterest,
+    CorrelationState,
     CorrelationResult,
     PointType,
     PointXYZ,
@@ -851,18 +852,21 @@ def test_discover_correlation_files(tmp_path):
     assert _discover_correlation_files(str(tmp_path)) == {
         "fib": None,
         "fm": None,
+        "correlation": None,
         "data": None,
         "result": None,
     }
 
     (tmp_path / "BeforeMilling_G1.ome.tiff").write_bytes(b"")
     (tmp_path / "ref_Mill_ib.tif").write_bytes(b"")
+    (tmp_path / "correlation.json").write_text("{}")
     (tmp_path / "correlation_data.json").write_text("{}")
     (tmp_path / "correlation_result.json").write_text("{}")
 
     found = _discover_correlation_files(str(tmp_path))
     assert os.path.basename(found["fm"]) == "BeforeMilling_G1.ome.tiff"
     assert os.path.basename(found["fib"]) == "ref_Mill_ib.tif"
+    assert os.path.basename(found["correlation"]) == "correlation.json"
     assert os.path.basename(found["data"]) == "correlation_data.json"
     assert os.path.basename(found["result"]) == "correlation_result.json"
 
@@ -1282,9 +1286,9 @@ def test_load_result_rejects_a_coordinates_file(qapp, tmp_path):
     assert "Load Coordinates" in str(exc.value)
 
 
-def test_load_coordinates_shows_a_warning_instead_of_crashing(qapp, tmp_path, monkeypatch):
-    """_on_load had no try/except while _menu_load_result did — the same mistake
-    was a friendly warning in one direction and an unhandled KeyError in the other."""
+def test_menu_load_correlation_accepts_a_legacy_result_file(qapp, tmp_path, monkeypatch):
+    """FIB-264: the single Load action dispatches on shape, so selecting the
+    legacy result file — the exact FIB-263 misclick — now just loads it."""
     from PyQt5.QtWidgets import QFileDialog, QMessageBox
 
     w = _widget(qapp)
@@ -1298,7 +1302,30 @@ def test_load_coordinates_shows_a_warning_instead_of_crashing(qapp, tmp_path, mo
         QMessageBox, "warning", staticmethod(lambda *a, **k: shown.append(a))
     )
 
-    w._on_load()  # must not raise
+    w._menu_load_correlation()
+    assert not shown, "a valid result file should load, not warn"
+    assert len(w.result.poi) == 1  # the result was adopted
+
+
+def test_menu_load_correlation_warns_on_a_foreign_file(qapp, tmp_path, monkeypatch):
+    """A genuinely unreadable/foreign JSON still warns rather than crashing."""
+    import json
+
+    from PyQt5.QtWidgets import QFileDialog, QMessageBox
+
+    w = _widget(qapp)
+    junk = tmp_path / "notes.json"
+    junk.write_text(json.dumps({"hello": "world"}))
+
+    monkeypatch.setattr(
+        QFileDialog, "getOpenFileName", staticmethod(lambda *a, **k: (str(junk), ""))
+    )
+    shown = []
+    monkeypatch.setattr(
+        QMessageBox, "warning", staticmethod(lambda *a, **k: shown.append(a))
+    )
+
+    w._menu_load_correlation()  # must not raise
     assert shown, "expected a warning dialog rather than an exception"
 
 
@@ -2036,3 +2063,149 @@ def test_stale_status_outranks_the_ri_note(qapp):
 
     assert "changed since this run" in w._lbl_status.text()
     assert "Done" not in w._lbl_status.text()
+
+
+# ---------------------------------------------------------------------------
+# FIB-264 — one consolidated correlation.json
+# ---------------------------------------------------------------------------
+
+
+def test_auto_save_writes_one_correlation_json(qapp, tmp_path):
+    """Both data_changed and result_changed rewrite a single correlation.json;
+    the legacy pair is never written."""
+    import json
+
+    w = _widget(qapp)
+    w.set_project_dir(str(tmp_path))
+    w.set_data(_input(fib=(3.0, 4.0)))
+    w.data_changed.emit(w.data)
+
+    single = tmp_path / "correlation.json"
+    assert single.exists()
+    assert not (tmp_path / "correlation_data.json").exists()
+    assert not (tmp_path / "correlation_result.json").exists()
+
+    raw = json.loads(single.read_text())
+    assert raw["version"] == 1
+    assert raw["result"] is None
+    assert raw["input_data"]["fib_coordinates"][0]["point"]["x"] == 3.0
+
+    # a run adds the result to the same file
+    w._on_result_ready(_result_from(_input(fib=(3.0, 4.0))))
+    raw = json.loads(single.read_text())
+    assert raw["result"] is not None
+    assert "computed_from" in raw["result"]  # the snapshot, renamed
+
+
+def test_load_correlation_round_trips_a_consolidated_file(qapp, tmp_path):
+    w = _widget(qapp)
+    w.set_project_dir(str(tmp_path))
+    w.set_data(_input(fib=(5.0, 5.0)))
+    w._on_result_ready(_result_from(_input(fib=(5.0, 5.0))))  # live, matches
+
+    fresh = _widget(qapp)
+    fresh.load_correlation(str(tmp_path / "correlation.json"))
+    assert [(c.point.x, c.point.y) for c in fresh._coords_tab.fib_list.coordinates] == [(5.0, 5.0)]
+    assert fresh._btn_continue.isEnabled() is True  # consistent -> usable
+
+
+def test_load_correlation_flags_a_stale_consolidated_file(qapp, tmp_path):
+    """A file saved after a post-run edit carries the new points plus the old
+    result; on load, matches_inputs must still flag it (FIB-295 within one file)."""
+    import json
+
+    w = _widget(qapp)
+    w.set_project_dir(str(tmp_path))
+    w.set_data(_input(fib=(1.0, 2.0)))
+    w._on_result_ready(_result_from(_input(fib=(1.0, 2.0))))  # result fitted here
+    w.set_data(_input(fib=(9.0, 9.0)))  # ...then the points move
+    w.data_changed.emit(w.data)         # rewrite: new points, stale result
+
+    raw = json.loads((tmp_path / "correlation.json").read_text())
+    assert raw["input_data"]["fib_coordinates"][0]["point"]["x"] == 9.0
+    assert raw["result"]["computed_from"]["fib_coordinates"][0]["point"]["x"] == 1.0
+
+    fresh = _widget(qapp)
+    fresh.load_correlation(str(tmp_path / "correlation.json"))
+    assert [(c.point.x, c.point.y) for c in fresh._coords_tab.fib_list.coordinates] == [(9.0, 9.0)]
+    assert fresh._btn_continue.isEnabled() is False  # stale result not armed
+
+
+def test_load_project_prefers_the_consolidated_file(qapp, tmp_path):
+    """With correlation.json present, the legacy pair is ignored even if it
+    disagrees."""
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import load_project
+
+    CorrelationState(input_data=_input(fib=(5.0, 5.0))).save(
+        str(tmp_path / "correlation.json")
+    )
+    # a stale legacy pair that must be ignored
+    _input(fib=(1.0, 1.0)).save(str(tmp_path / "correlation_data.json"))
+
+    w = _widget(qapp)
+    load_project(w, str(tmp_path))
+    assert [(c.point.x, c.point.y) for c in w._coords_tab.fib_list.coordinates] == [(5.0, 5.0)]
+
+
+def test_load_project_falls_back_to_legacy_when_no_consolidated_file(qapp, tmp_path):
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import load_project
+
+    _input(fib=(7.0, 7.0)).save(str(tmp_path / "correlation_data.json"))
+
+    w = _widget(qapp)
+    load_project(w, str(tmp_path))
+    assert [(c.point.x, c.point.y) for c in w._coords_tab.fib_list.coordinates] == [(7.0, 7.0)]
+
+
+def test_load_correlation_reads_a_legacy_data_file(qapp, tmp_path):
+    """A pre-FIB-264 correlation_data.json still loads via the unified entry."""
+    p = tmp_path / "correlation_data.json"
+    _input(fib=(7.0, 8.0)).save(str(p))
+
+    w = _widget(qapp)
+    w.load_correlation(str(p))
+    assert [(c.point.x, c.point.y) for c in w._coords_tab.fib_list.coordinates] == [(7.0, 8.0)]
+    assert w._result is None  # a bare data file carries no result
+
+
+def test_load_correlation_file_dispatches_on_every_shape(tmp_path):
+    """The one place the shape-sniff lives: container / legacy data / legacy
+    result (new + old snapshot key) / junk. This is the 'old files still load'
+    guarantee at the unit level."""
+    import json
+
+    from fibsem.correlation.structures import load_correlation_file
+
+    # new container
+    cpath = tmp_path / "c.json"
+    CorrelationState(
+        input_data=_input(fib=(1.0, 1.0)), result=_result_from(_input(fib=(1.0, 1.0)))
+    ).save(str(cpath))
+    st = load_correlation_file(str(cpath))
+    assert st.input_data.fib_coordinates[0].point.x == 1.0 and st.result is not None
+
+    # legacy data file
+    dpath = tmp_path / "correlation_data.json"
+    _input(fib=(2.0, 2.0)).save(str(dpath))
+    st = load_correlation_file(str(dpath))
+    assert st.result is None and st.input_data.fib_coordinates[0].point.x == 2.0
+
+    # legacy result file (current computed_from key)
+    rpath = tmp_path / "correlation_result.json"
+    _result_from(_input(fib=(3.0, 3.0))).save(str(rpath))
+    st = load_correlation_file(str(rpath))
+    assert st.result is not None and st.input_data.fib_coordinates[0].point.x == 3.0
+
+    # legacy result file written with the OLD "input_data" snapshot key
+    opath = tmp_path / "old_result.json"
+    old = _result_from(_input(fib=(4.0, 4.0))).to_dict()
+    old["input_data"] = old.pop("computed_from")
+    opath.write_text(json.dumps(old))
+    st = load_correlation_file(str(opath))
+    assert st.input_data.fib_coordinates[0].point.x == 4.0
+
+    # foreign / junk JSON
+    jpath = tmp_path / "junk.json"
+    jpath.write_text(json.dumps({"foo": 1}))
+    with pytest.raises(ValueError):
+        load_correlation_file(str(jpath))


### PR DESCRIPTION
Closes [FIB-264](https://linear.app/fibsemos/issue/FIB-264).

## Why

The correlation tab auto-saved two files side by side — `correlation_data.json` (a `CorrelationInputData`) and `correlation_result.json` (a `CorrelationResult`) — names differing by one word. Two files for one logical thing, and the root of the [FIB-263](https://linear.app/fibsemos/issue/FIB-263) load-the-wrong-one crash. This collapses them into a single `correlation.json`.

Builds on [FIB-295](https://linear.app/fibsemos/issue/FIB-295) (`#169`), which made result staleness derivable — that's what lets a single file stay honest.

## Format (`structures.py`)

- **`CorrelationState`** `{version, input_data, result?}` — the in-memory model of one `correlation.json`. Not `CorrelationResult`-as-container: an empty result is indistinguishable from "not run", so `result` is explicitly `Optional`.
- **`load_correlation_file()`** dispatches on payload shape — `version`→container, `poi`/`computed_from`→legacy result, `fib_coordinates`→legacy data, else a clear error. The shape-sniff now lives in exactly one place.
- **`computed_from` key rename.** `CorrelationResult` serializes its input snapshot as `computed_from`, not `input_data` — it is the points the transform was *fitted to*, not the current inputs. Invisible in a standalone result file, but the consolidated file *also* carries a top-level `input_data` for the current points, so the rename keeps the two legible. Both keys are read (back-compat); the Python attribute stays `input_data`. The class name isn't serialized, so this changes no bytes beyond the one key.

## Widget

- Both `data_changed` and `result_changed` rewrite one `correlation.json` from live state. A post-run edit rewrites with the (now-stale) result still attached — by design: `result.computed_from` ≠ top-level `input_data`, so `matches_inputs` still derives staleness on load (the FIB-295 mechanism, now within one file). The stale result is kept, labelled, inspectable; it is not dropped.
- **File menu:** `Load Coordinates` + `Load Correlation Result` → one **Load Correlation…** that dispatches on shape — removing the FIB-263 misclick *by construction* rather than guarding against it. Save likewise writes the whole state.
- **Quickstart** prefers `correlation.json`, falls back to the legacy pair with the FIB-295 coordinates-first ordering.

## Back-compat

Old projects load unchanged — `correlation_data.json` / `correlation_result.json` are still read (menu, quickstart, and the dispatcher), including result files written with the old `input_data` snapshot key. Nothing *writes* the legacy files anymore. A migrated project keeps its old files on disk; they're ignored (quickstart prefers `correlation.json`) — left in place rather than auto-deleted.

## Testing

12 new tests, mutation-verified: container round-trip, three-way dispatcher (incl. the old snapshot key + junk), single-file write, stale-on-load flagging, menu dispatch, quickstart preference + legacy fallback, and direct legacy-file loads. The FIB-263 reject-the-wrong-file guards on the type-specific loaders still pass. **Full suite: 769 passed.**
