### PR TITLE
Speed up the test suite (~7 min → ~30s) and parallelize CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,9 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-      - run: pip install .
-      - run: pytest tests/
+      - run: pip install ".[test]"
+      - name: Test with pytest
+        run: pytest tests/ -n auto --dist worksteal --timeout=300
 
   publish:
     needs: test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .
+        # UI deps (the [ui] extra) are intentionally not installed: the
+        # napari/PyQt5 tests importorskip and are skipped on CI.
+        python -m pip install ".[test]"
     - name: Test with pytest
-      run: |
-        pytest tests/
+      run: pytest tests/ -n auto --dist worksteal --timeout=300

--- a/fibsem/_timing.py
+++ b/fibsem/_timing.py
@@ -1,0 +1,26 @@
+"""Simulated-hardware timing.
+
+The Demo microscope (``fibsem.microscopes.simulator``) and the simulated
+fluorescence-microscope base classes (``fibsem.fm.microscope``) sleep to emulate
+real acquisition, stage, objective and milling timing. Those sleeps dominate the
+test suite's wall-clock — most of it is spent asleep rather than computing — so
+the tests disable them via the ``FIBSEM_SIM_NO_DELAY`` environment variable (set
+in ``tests/conftest.py``).
+
+Real drivers (e.g. the odemis fluorescence microscope) override these methods and
+never call :func:`sim_sleep`, so the flag only affects simulated timing.
+"""
+
+import os
+import time
+
+
+def sim_sleep(seconds: float) -> None:
+    """Sleep to emulate simulated-hardware timing.
+
+    A no-op when ``FIBSEM_SIM_NO_DELAY=1`` (or when ``seconds`` is non-positive),
+    which is how the test suite skips the simulator's artificial delays. Reads the
+    environment on every call so it can be toggled per run without re-importing.
+    """
+    if seconds > 0 and os.environ.get("FIBSEM_SIM_NO_DELAY") != "1":
+        time.sleep(seconds)

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import threading
-import time
 from abc import ABC
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Optional, Tuple, Union, Literal
@@ -10,6 +9,7 @@ from typing import TYPE_CHECKING, Optional, Tuple, Union, Literal
 import numpy as np
 from psygnal import Signal
 
+from fibsem._timing import sim_sleep
 from fibsem.fm.structures import (
     CameraImageTransform,
     ChannelSettings,
@@ -104,7 +104,7 @@ class ObjectiveLens(ABC):
         Returns:
             The current position in meters (negative values = retracted)
         """
-        time.sleep(0.1)
+        sim_sleep(0.1)
         # logging.info(f"Objective position read: {self._position * 1e3:.3f} mm")
         return self._position
 
@@ -174,7 +174,7 @@ class ObjectiveLens(ABC):
             )
             position = np.clip(position, 0, self._limit_position)
 
-        time.sleep(0.5)  # Simulate time taken to move the objective
+        sim_sleep(0.5)  # Simulate time taken to move the objective
         self._position = position
         logging.info(
             f"Objective moved to absolute position: {self._position * 1e3:.3f} mm"
@@ -261,7 +261,7 @@ class Camera(ABC):
         Returns:
             A 16-bit numpy array representing the acquired image
         """
-        time.sleep(self.exposure_time)  # Simulate exposure time in seconds
+        sim_sleep(self.exposure_time)  # Simulate exposure time in seconds
 
         # get min and max values for the image
         noise = np.random.randint(

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import numpy as np
 from skimage.transform import resize
 
+from fibsem._timing import sim_sleep
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.microscope import (
     FibsemMicroscope,
@@ -363,7 +364,7 @@ class DemoMicroscope(FibsemMicroscope):
             hfw=effective_image_settings.hfw,
             random=True
         )
-        time.sleep(effective_image_settings.dwell_time * effective_image_settings.resolution[0] * effective_image_settings.resolution[1])  # simulate acquisition time
+        sim_sleep(effective_image_settings.dwell_time * effective_image_settings.resolution[0] * effective_image_settings.resolution[1])  # simulate acquisition time
 
         # generate the next image from the sequence iterator
         if self.use_image_sequence:
@@ -543,7 +544,7 @@ class DemoMicroscope(FibsemMicroscope):
                 dwell_time = image.metadata.image_settings.dwell_time
                 resolution = image.metadata.image_settings.resolution
                 estimated_time = dwell_time * resolution[0] * resolution[1]
-                time.sleep(estimated_time)
+                sim_sleep(estimated_time)
 
                 # emit the acquired image
                 if beam_type is BeamType.ELECTRON:
@@ -559,7 +560,7 @@ class DemoMicroscope(FibsemMicroscope):
             self.set_reduced_area_scanning_mode(reduced_area, beam_type)
         # TODO: implement auto-contrast
         logging.info(f"Autocontrasting {beam_type.name} beam.")
-        time.sleep(random.uniform(0.5, 1.0))  # simulate time taken to calculate auto-contrast
+        sim_sleep(random.uniform(0.5, 1.0))  # simulate time taken to calculate auto-contrast
         self.set_detector_brightness(random.uniform(0.4, 0.6), beam_type)
         self.set_detector_contrast(random.uniform(0.4, 0.6), beam_type)
 
@@ -573,7 +574,7 @@ class DemoMicroscope(FibsemMicroscope):
         # TODO: implement auto-focus
         logging.info(f"Auto-focusing {beam_type.name} beam.")
         wd: float = self.get("eucentric_height", beam_type=beam_type) # type: ignore
-        time.sleep(random.uniform(0.5, 1.0))  # simulate time taken to calculate auto-focus
+        sim_sleep(random.uniform(0.5, 1.0))  # simulate time taken to calculate auto-focus
         focus_adjustment = random.uniform(-100e-6, 100e-6)
         new_wd = wd + focus_adjustment
         self.set_working_distance(new_wd, beam_type)
@@ -741,12 +742,12 @@ class DemoMicroscope(FibsemMicroscope):
             logging.debug(f"Running milling: {remaining_time} s remaining.")
             if self.get_milling_state() == MillingState.PAUSED:
                 logging.info("Milling paused.")
-                time.sleep(MILLING_SLEEP_TIME)
+                sim_sleep(MILLING_SLEEP_TIME)
                 continue
             if self.get_milling_state() == MillingState.IDLE:
                 logging.info("Milling stopped.")
                 break
-            time.sleep(MILLING_SLEEP_TIME)
+            sim_sleep(MILLING_SLEEP_TIME)
             remaining_time -= MILLING_SLEEP_TIME
 
             # update milling progress via signal
@@ -862,13 +863,13 @@ class DemoMicroscope(FibsemMicroscope):
         logging.info(f"Turning on heater for {gas}")
         # turn on heater
         gis.turn_heater_on()
-        time.sleep(3) # wait for the heat
+        sim_sleep(3) # wait for the heat
         # TODO: get state feedback, wait for heater to be at temp
 
         # run deposition
         logging.info(f"Running deposition for {duration} seconds")
         # gis.open()
-        time.sleep(duration) 
+        sim_sleep(duration) 
         gis.close()
 
         # turn off heater
@@ -999,7 +1000,7 @@ class DemoMicroscope(FibsemMicroscope):
     
         # stage 
         if key == "stage_position":
-            time.sleep(0.1)
+            sim_sleep(0.1)
             return self.stage_system.position
         if key == "stage_homed":
             return self.stage_system.is_homed
@@ -1270,5 +1271,5 @@ class DemoMicroscope(FibsemMicroscope):
             NotImplementedError: If the system is not an Arctis system.
         """
         logging.info(f"Running sputter coater for {time_seconds} seconds...")
-        time.sleep(time_seconds)
+        sim_sleep(time_seconds)
         logging.info("Sputter coating complete.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,13 @@ reporting = [
 
 server = ["fastapi>=0.100.0", "uvicorn[standard]>=0.20.0", "requests>=2.28.0"]
 
+# Test tooling. `pytest` itself is still listed under [project.dependencies] so
+# CI's `pip install .` keeps working; move it here once CI installs `.[test]`.
+test = [
+    "pytest-xdist>=3.0",   # parallel execution (-n auto)
+    "pytest-timeout>=2.1", # fail a hung test instead of blocking the whole run
+]
+
 [project.scripts]
 fibsem_ui = "fibsem.ui.FibsemUI:main"
 fibsem_label = "fibsem.ui.FibsemLabellingUI:main"
@@ -85,3 +92,13 @@ packages = ["fibsem"]
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra --strict-markers --strict-config"
+markers = [
+    "slow: tests dominated by simulated-hardware timing (deselect with -m 'not slow')",
+    "hardware_sim: drives the Demo microscope simulator end-to-end",
+    "ui: requires the [ui] extra (napari/pyqt5); auto-skipped when absent",
+    "integration: exercises multiple components together",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "scikit-image>=0.19.3",
     "matplotlib>=3.7.0",
     "tqdm>=4.65.0",
-    "pytest>=7.2.2",
     "petname>=2.6",
     "pandas>=2.0.0",
     "pyyaml>=6.0",
@@ -69,10 +68,10 @@ reporting = [
 
 server = ["fastapi>=0.100.0", "uvicorn[standard]>=0.20.0", "requests>=2.28.0"]
 
-# Test tooling. `pytest` itself is still listed under [project.dependencies] so
-# CI's `pip install .` keeps working; move it here once CI installs `.[test]`.
+# Test tooling. Install with `pip install .[test]` (CI does this).
 test = [
-    "pytest-xdist>=3.0",   # parallel execution (-n auto)
+    "pytest>=7.2.2",
+    "pytest-xdist>=3.0",   # parallel execution (-n auto --dist worksteal)
     "pytest-timeout>=2.1", # fail a hung test instead of blocking the whole run
 ]
 

--- a/tests/autolamella/test_milling_angle.py
+++ b/tests/autolamella/test_milling_angle.py
@@ -11,7 +11,14 @@ from fibsem.structures import FibsemStagePosition, MicroscopeState
 
 @pytest.fixture(scope="module")
 def microscope() -> DemoMicroscope:
-    return DemoMicroscope(utils.load_microscope_configuration().system)
+    microscope = DemoMicroscope(utils.load_microscope_configuration().system)
+    # Pin the milling geometry so the expected angle is independent of the
+    # machine's default configuration: the bundled configs disagree on the
+    # shuttle pre-tilt (0 in sim-arctis, 35 in microscope-configuration), which
+    # changes the computed milling angle.
+    microscope.system.stage.shuttle_pre_tilt = 35.0
+    microscope.system.ion.column_tilt = 52.0
+    return microscope
 
 
 def _make_lamella(tmp_path, tilt_rad) -> Lamella:
@@ -30,7 +37,7 @@ def test_update_milling_angle_from_pose(microscope, tmp_path):
 
     lamella.update_milling_angle(microscope)
 
-    # milling angle = stage tilt + pretilt (see get_current_milling_angle)
+    # milling_angle = 90 - column_tilt + stage_tilt - pretilt = 90 - 52 + 20 - 35 = 23
     expected = microscope.get_current_milling_angle(
         stage_position=lamella.stage_position
     )

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -7,8 +7,6 @@ These cover the failure modes that crashed the unsupervised (automatic) path:
 - the widget factory rendering float/int fields as a text box instead of a spinbox.
 """
 
-import gc
-import os
 from unittest.mock import MagicMock
 
 import pytest
@@ -355,42 +353,6 @@ def test_resolve_field_types_resolves_future_annotations():
 
     assert hints["milling_current"] is float
     assert hints["exposure_time"] is int
-
-
-@pytest.fixture(scope="module")
-def qapp():
-    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-    try:
-        from PyQt5.QtWidgets import QApplication
-    except Exception as exc:  # pragma: no cover - environment without Qt
-        pytest.skip(f"PyQt5 not available: {exc}")
-    app = QApplication.instance() or QApplication([])
-
-    # Keep CPython's cyclic garbage collector from running while these tests build
-    # and paint real Qt widgets. Constructing the parameter form ends in
-    # widget.show() (AutoLamellaTaskParametersConfigWidget._update_from_config), and
-    # Qt's C++ paint of the qtawesome toolbutton icon re-enters Python; an automatic
-    # gen-0 collection landing in that window finalises objects mid-paint and
-    # segfaults the interpreter — an intermittent EXC_BAD_ACCESS inside
-    # QCommonStyle::drawControl that takes the whole `pytest` process down (~11/12
-    # runs of this file) rather than failing one test. It only bites when a prior
-    # test has left cyclic garbage for that collection to reclaim, which is why a
-    # single test in isolation always passes.
-    #
-    # This is the single-threaded, re-entrant cousin of the Windows vispy/gloo crash
-    # (PR #168): the application never lets automatic GC run for this reason and
-    # collects on the Qt main thread instead (fibsem/ui/qt/gc.py). The tests build
-    # widgets without that machinery, so adopt the same contract here — disable
-    # automatic collection while the widgets are alive and drain it once at a safe
-    # point (no Qt paint on the stack) on teardown.
-    gc_was_enabled = gc.isenabled()
-    gc.disable()
-    try:
-        yield app
-    finally:
-        gc.collect()
-        if gc_was_enabled:
-            gc.enable()
 
 
 @requires_ui

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,20 @@ import pytest
 os.environ.setdefault("FIBSEM_SIM_NO_DELAY", "1")
 
 
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path, monkeypatch):
+    """Run every test from its own tmp dir.
+
+    Some code paths write next to the current working directory — e.g. alignment
+    plotting creates an ``Alignment/`` directory under the reference image's path
+    and falls back to the cwd when it is unset (as it is for the demo images used
+    across the alignment and milling tests). Chdir into the test's tmp_path so
+    those artifacts land there (auto-cleaned) instead of the repo root, and never
+    collide between workers under ``pytest -n``.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.fixture(scope="module")
 def qapp():
     """Shared offscreen QApplication for widget tests.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+import gc
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Shared offscreen QApplication for widget tests.
+
+    Keep CPython's cyclic garbage collector from running while these tests build
+    and paint real Qt widgets. Constructing a parameter form ends in widget.show()
+    (e.g. AutoLamellaTaskParametersConfigWidget._update_from_config), and Qt's C++
+    paint of the qtawesome toolbutton icon re-enters Python; an automatic gen-0
+    collection landing in that window finalises objects mid-paint and segfaults the
+    interpreter — an intermittent EXC_BAD_ACCESS inside QCommonStyle::drawControl
+    that takes the whole `pytest` process down rather than failing one test. It only
+    bites when a prior test has left cyclic garbage for that collection to reclaim,
+    which is why a single test in isolation always passes.
+
+    This is the single-threaded, re-entrant cousin of the Windows vispy/gloo crash
+    (PR #168): the application never lets automatic GC run for this reason and
+    collects on the Qt main thread instead (fibsem/ui/qt/gc.py). The tests build
+    widgets without that machinery, so adopt the same contract here — disable
+    automatic collection while the widgets are alive and drain it once at a safe
+    point (no Qt paint on the stack) on teardown. Module scope keeps the disable
+    confined to each UI module and restores it in between.
+
+    test_main_thread_gc.py deliberately keeps its own qapp fixture (which shadows
+    this one by name) so it can exercise stock GC behaviour.
+    """
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    try:
+        from PyQt5.QtWidgets import QApplication
+    except Exception as exc:  # pragma: no cover - environment without Qt
+        pytest.skip(f"PyQt5 not available: {exc}")
+    app = QApplication.instance() or QApplication([])
+
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        yield app
+    finally:
+        gc.collect()
+        if gc_was_enabled:
+            gc.enable()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,13 @@ import os
 
 import pytest
 
+# The Demo microscope and the simulated fluorescence microscope sleep to emulate
+# real hardware timing, which otherwise makes the suite spend most of its
+# wall-clock asleep. Skip those simulated delays for the whole test run; real
+# drivers override the methods and are unaffected (see fibsem._timing.sim_sleep).
+# Use FIBSEM_SIM_NO_DELAY=0 to run with the delays enabled.
+os.environ.setdefault("FIBSEM_SIM_NO_DELAY", "1")
+
 
 @pytest.fixture(scope="module")
 def qapp():

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -24,12 +24,6 @@ from fibsem.correlation.structures import (
 from fibsem.structures import Point
 
 
-@pytest.fixture(scope="module")
-def qapp():
-    app = QApplication.instance() or QApplication([])
-    yield app
-
-
 @pytest.fixture(autouse=True)
 def _no_lut_download(monkeypatch):
     """Never hit the network for the zeta LUT during widget construction."""

--- a/tests/correlation/test_interpolation.py
+++ b/tests/correlation/test_interpolation.py
@@ -154,13 +154,6 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 pytest.importorskip("PyQt5")
 
-from PyQt5.QtWidgets import QApplication  # noqa: E402
-
-
-@pytest.fixture(scope="module")
-def qapp():
-    return QApplication.instance() or QApplication([])
-
 
 def _real_fm(crop=64):
     """A concrete FluorescenceImage the dialog/widget can consume, or skip.

--- a/tests/fm/test_autofocus_widget.py
+++ b/tests/fm/test_autofocus_widget.py
@@ -10,15 +10,7 @@ import pytest
 
 pytest.importorskip("PyQt5")
 
-from PyQt5.QtWidgets import QApplication
-
 from fibsem.fm.structures import AutoFocusSettings, ChannelSettings, FocusMethod
-
-
-@pytest.fixture(scope="module")
-def qapp():
-    app = QApplication.instance() or QApplication([])
-    yield app
 
 
 @pytest.fixture

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -335,18 +335,6 @@ def test_alignment_differential_to_dict_structure():
 # multi_step_alignment_v2 with validate=True
 # ---------------------------------------------------------------------------
 
-@pytest.fixture(autouse=True)
-def _isolate_cwd(tmp_path, monkeypatch):
-    """Run each test from its own tmp dir.
-
-    Alignment plotting writes an ``Alignment/`` directory under the reference
-    image's path, falling back to the cwd when that path is unset (as it is for
-    the demo images used here). Chdir into the test's tmp_path so those artifacts
-    land there instead of the repo root, and don't collide under ``pytest -n``.
-    """
-    monkeypatch.chdir(tmp_path)
-
-
 @pytest.fixture(scope="module")
 def demo_session():
     """Single Demo session shared across all multi_step tests in this module."""

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -335,6 +335,18 @@ def test_alignment_differential_to_dict_structure():
 # multi_step_alignment_v2 with validate=True
 # ---------------------------------------------------------------------------
 
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path, monkeypatch):
+    """Run each test from its own tmp dir.
+
+    Alignment plotting writes an ``Alignment/`` directory under the reference
+    image's path, falling back to the cwd when that path is unset (as it is for
+    the demo images used here). Chdir into the test's tmp_path so those artifacts
+    land there instead of the repo root, and don't collide under ``pytest -n``.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.fixture(scope="module")
 def demo_session():
     """Single Demo session shared across all multi_step tests in this module."""

--- a/tests/ui/test_settings_widgets_integer.py
+++ b/tests/ui/test_settings_widgets_integer.py
@@ -15,8 +15,6 @@ import pytest
 
 pytest.importorskip("PyQt5")
 
-from PyQt5.QtWidgets import QApplication
-
 from fibsem import utils
 from fibsem.milling.patterning import get_pattern
 from fibsem.ui.widgets.custom_widgets import IntegerValueSpinBox
@@ -25,12 +23,6 @@ from fibsem.ui.widgets.pattern_settings_widget import FibsemPatternSettingsWidge
 # ArrayPattern exposes several integer fields (n_columns, n_rows, passes) with
 # no scale, which is exactly the path that regressed.
 _INT_FIELDS = {"n_columns": 7, "n_rows": 3, "passes": 4}
-
-
-@pytest.fixture(scope="module")
-def qapp():
-    app = QApplication.instance() or QApplication([])
-    yield app
 
 
 @pytest.fixture(scope="module")

--- a/tests/ui/test_wheel_blocker.py
+++ b/tests/ui/test_wheel_blocker.py
@@ -36,12 +36,6 @@ from fibsem.ui.widgets.custom_widgets import (
 )
 
 
-@pytest.fixture(scope="module")
-def qapp():
-    app = QApplication.instance() or QApplication([])
-    yield app
-
-
 def _scroll_area(factory, count=40):
     """A scroll area tall enough to scroll, filled with widgets from *factory*."""
     area = QScrollArea()


### PR DESCRIPTION
## Summary

`pytest tests/` took ~7 min but did only ~90s of real work — the rest was the Demo microscope simulator's `time.sleep()` calls emulating hardware timing. This branch removes that artificial wait, parallelizes the run, and cleans up the test configuration. Full suite: **~7 min → ~30s** (`pytest tests/ -n auto --dist worksteal`), 756 passed / 7 skipped / 0 failed.

## Changes (one per commit)

- **Shared GC-disciplined `qapp` fixture** → `tests/conftest.py`, dedupe 6 UI test files; prevents the intermittent mid-paint GC segfault (builds on #172).
- **pytest config + `[test]` extra** — add `[tool.pytest.ini_options]` (testpaths, markers, strict flags) so a bare `pytest` works (was 805 items + 4 collection errors → 763, 0 errors).
- **Gate simulated delays behind `FIBSEM_SIM_NO_DELAY`** — route the simulator / FM-sim sleeps through `fibsem._timing.sim_sleep`; the test suite sets the flag. **435s → 93s.** Real drivers override these methods and are unaffected.
- **Isolate each test's cwd** — alignment plotting wrote an `Alignment/` dir into the repo root; chdir every test into its own tmp dir (also required for `-n` parallelism).
- **Fix a config-fragile test** — `test_update_milling_angle_from_pose` hard-coded a value that only held for one default configuration; pin the geometry so it's deterministic.
- **CI** — install `.[test]` and run `-n auto --dist worksteal --timeout=300`; move `pytest` out of core deps into the `[test]` extra. UI tests stay skipped in CI (the `[ui]` extra is not installed).

## Test plan

- `pytest tests/ -n auto --dist worksteal` → 756 passed, 7 skipped, 0 failed (~30s), repo root clean.
- `test_spot_burn.py` ×20 with cold bytecode → 0 crashes; GC-contract tests pass in both orders.

## Notes

- Fixes one pre-existing failure (`test_update_milling_angle_from_pose`) as part of the work.
- UI/correlation tests still run only locally (napari/PyQt5), by design.
