### PR TITLE
[chore] move tqdm from core dependencies to the ml extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "opencv-python-headless>=4.7.0.72",
     "scikit-image>=0.19.3",
     "matplotlib>=3.7.0",
-    "tqdm>=4.65.0",
     "pytest>=7.2.2",
     "petname>=2.6",
     "pandas>=2.0.0",
@@ -43,6 +42,7 @@ Homepage = "https://github.com/fibsem-os/fibsem-os"
 
 [project.optional-dependencies]
 ml = [
+    "tqdm>=4.65.0",
     "zarr>=2.13.6",
     "dask>=2023.3.0",
     "torch>=2.0.0,<=2.3.0",


### PR DESCRIPTION
## Summary

`tqdm` was listed in the core `[project].dependencies` but is only used by ML/model code:

- `fibsem/segmentation/_nnunet.py`, `nnunet_model_v2.py`, `train.py`, `onnx_model.py`
- `fibsem/detection/evaluation.py` (pulls `segmentation.model`)
- `fibsem/detection/detection.py` — local import inside `generate_segmentation_objects` (dataset-prep helper)

Every one of these already requires the `ml` extra (torch, nnunetv2, onnxruntime, segmentation-models-pytorch). No core import path (`import fibsem`) touches tqdm, so it doesn't belong in the default install.

## Change

- Removed `tqdm>=4.65.0` from `[project].dependencies`
- Added it to the `ml` optional extra

`pip install fibsem` no longer pulls tqdm; `pip install fibsem[ml]` still does.