### PR TITLE
Correlation: CorrelationConfig — persist fit + RI settings on the protocol (FIB-298)

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -18,6 +18,7 @@ from psygnal.containers import EventedDict, EventedList
 
 from fibsem.applications.autolamella import config as cfg
 from fibsem.constants import TIME_DISPLAY_AMPM_SHORT
+from fibsem.correlation.config import CorrelationConfig
 from fibsem.applications.autolamella.protocol.constants import (
     FIDUCIAL_KEY,
     MICROEXPANSION_KEY,
@@ -431,6 +432,9 @@ class AutoLamellaTaskProtocol:
     workflow_config: AutoLamellaWorkflowConfig = field(default_factory=AutoLamellaWorkflowConfig)
     options: AutoLamellaWorkflowOptions = field(default_factory=AutoLamellaWorkflowOptions)
     lamella_defaults: LamellaDefaultConfig = field(default_factory=LamellaDefaultConfig)
+    # Experiment-global correlation config (FIB-298): a user-step config, not an
+    # automated task, so a peer field rather than an entry in task_config.
+    correlation: CorrelationConfig = field(default_factory=CorrelationConfig)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -442,6 +446,7 @@ class AutoLamellaTaskProtocol:
             "workflow": self.workflow_config.to_dict(),
             "options": self.options.to_dict(),
             "lamella_defaults": self.lamella_defaults.to_dict(),
+            "correlation": self.correlation.to_dict(),
         }
 
     @classmethod
@@ -458,6 +463,8 @@ class AutoLamellaTaskProtocol:
             workflow_config=workflow_config,
             options=AutoLamellaWorkflowOptions.from_dict(data.get("options", {})),
             lamella_defaults=LamellaDefaultConfig.from_dict(data.get("lamella_defaults", {})),
+            # Missing on protocols saved before this field -> a default config.
+            correlation=CorrelationConfig.from_dict(data.get("correlation")),
         )
         if "_id" in data:
             protocol._id = data["_id"]

--- a/fibsem/correlation/config.py
+++ b/fibsem/correlation/config.py
@@ -1,0 +1,152 @@
+"""Experiment-global correlation configuration (Tier-1 of the persistence design).
+
+``CorrelationConfig`` is the reusable home for how a correlation is set up: fit
+settings, RI-correction parameters, an interpolation preference, and the
+spot-burn seeding toggle. It is held as a peer field on
+``AutoLamellaTaskProtocol`` — not an ``AutoLamellaTaskConfig``, since correlation
+is a user step, not an automated microscope task. Defined here so the autolamella
+model only holds an instance; imports no UI.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+# Mirror the UI constants as plain strings so this module never imports the UI.
+FIT_METHODS = ("None", "Hole", "Gaussian")
+INTERPOLATION_METHODS = ("linear", "cubic")
+
+
+@dataclass
+class FitSettings:
+    """Fit method per point-role, and channel *by name* (not index, so it can't
+    pin the wrong dye across images). ``cutout`` is the ROI half-size — currently
+    hardcoded per method (no UI), kept here so a future control has a home."""
+
+    fib_method: str = "Hole"
+    fm_fiducial_method: str = "None"
+    fm_poi_method: str = "Gaussian"
+    fm_fiducial_channel: Optional[str] = None
+    fm_poi_channel: Optional[str] = None
+    reflection_cutout: int = 2
+    fluorescence_cutout: int = 5
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "fib_method": self.fib_method,
+            "fm_fiducial_method": self.fm_fiducial_method,
+            "fm_poi_method": self.fm_poi_method,
+            "fm_fiducial_channel": self.fm_fiducial_channel,
+            "fm_poi_channel": self.fm_poi_channel,
+            "reflection_cutout": self.reflection_cutout,
+            "fluorescence_cutout": self.fluorescence_cutout,
+        }
+
+    @staticmethod
+    def from_dict(data: Optional[Dict[str, Any]]) -> "FitSettings":
+        d = data or {}
+        default = FitSettings()
+        return FitSettings(
+            fib_method=d.get("fib_method", default.fib_method),
+            fm_fiducial_method=d.get("fm_fiducial_method", default.fm_fiducial_method),
+            fm_poi_method=d.get("fm_poi_method", default.fm_poi_method),
+            fm_fiducial_channel=d.get("fm_fiducial_channel"),
+            fm_poi_channel=d.get("fm_poi_channel"),
+            reflection_cutout=d.get("reflection_cutout", default.reflection_cutout),
+            fluorescence_cutout=d.get("fluorescence_cutout", default.fluorescence_cutout),
+        )
+
+
+@dataclass
+class RISettings:
+    """RI depth-correction ζ inputs + mode. Mirrors ``ZetaParams`` (tilt / depth /
+    NA / n2 / wavelength); defaults match ``DEFAULT_ZETA_PARAMS``. ``wavelength_um``
+    and ``na`` may be seeded from channel metadata on FM load (FIB-277)."""
+
+    tilt_deg: float = 15.0
+    depth_um: float = 4.0
+    na: float = 0.8
+    n2: float = 1.4
+    wavelength_um: float = 0.515
+    mode: str = "pre"  # "pre" (correct POI z before correlation) | "post"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tilt_deg": self.tilt_deg,
+            "depth_um": self.depth_um,
+            "na": self.na,
+            "n2": self.n2,
+            "wavelength_um": self.wavelength_um,
+            "mode": self.mode,
+        }
+
+    @staticmethod
+    def from_dict(data: Optional[Dict[str, Any]]) -> "RISettings":
+        d = data or {}
+        default = RISettings()
+        return RISettings(
+            tilt_deg=d.get("tilt_deg", default.tilt_deg),
+            depth_um=d.get("depth_um", default.depth_um),
+            na=d.get("na", default.na),
+            n2=d.get("n2", default.n2),
+            wavelength_um=d.get("wavelength_um", default.wavelength_um),
+            mode=d.get("mode", default.mode),
+        )
+
+
+@dataclass
+class InterpolationSettings:
+    """FM z-interpolation preference. ``isotropic`` targets XY pixel size, else
+    ``target_z_nm``."""
+
+    enabled: bool = False
+    isotropic: bool = True
+    target_z_nm: Optional[float] = None
+    method: str = "linear"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "isotropic": self.isotropic,
+            "target_z_nm": self.target_z_nm,
+            "method": self.method,
+        }
+
+    @staticmethod
+    def from_dict(data: Optional[Dict[str, Any]]) -> "InterpolationSettings":
+        d = data or {}
+        default = InterpolationSettings()
+        return InterpolationSettings(
+            enabled=d.get("enabled", default.enabled),
+            isotropic=d.get("isotropic", default.isotropic),
+            target_z_nm=d.get("target_z_nm"),
+            method=d.get("method", default.method),
+        )
+
+
+@dataclass
+class CorrelationConfig:
+    """Experiment-global correlation config; inherited by every lamella in the run."""
+
+    fit: FitSettings = field(default_factory=FitSettings)
+    ri: RISettings = field(default_factory=RISettings)
+    interpolation: InterpolationSettings = field(default_factory=InterpolationSettings)
+    load_spot_burns: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "fit": self.fit.to_dict(),
+            "ri": self.ri.to_dict(),
+            "interpolation": self.interpolation.to_dict(),
+            "load_spot_burns": self.load_spot_burns,
+        }
+
+    @staticmethod
+    def from_dict(data: Optional[Dict[str, Any]]) -> "CorrelationConfig":
+        d = data or {}
+        return CorrelationConfig(
+            fit=FitSettings.from_dict(d.get("fit")),
+            ri=RISettings.from_dict(d.get("ri")),
+            interpolation=InterpolationSettings.from_dict(d.get("interpolation")),
+            load_spot_burns=d.get("load_spot_burns", True),
+        )

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -71,6 +71,8 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtGui import QKeySequence
 from fibsem.constants import DATETIME_FILE
 from fibsem.correlation.correlation_v2 import run_correlation_from_data
+from fibsem.correlation.config import CorrelationConfig, FitSettings, RISettings
+from fibsem.correlation.refractive_index import ZetaParams
 from fibsem.correlation.structures import (
     Coordinate,
     CorrelationInputData,
@@ -1208,6 +1210,8 @@ class CorrelationTabWidget(QWidget):
         self._project_dir: Optional[str] = None
         # Pre-correlation RI factor (FM surface mode); set via the RI tab Apply
         self._ri_pre_correction_factor: Optional[float] = None
+        # Experiment-global config; passed in on open, read back on close (FIB-298).
+        self._correlation_config = CorrelationConfig()
 
         self._setup_ui()
         self._connect_signals()
@@ -1539,6 +1543,9 @@ class CorrelationTabWidget(QWidget):
                     x_max=w - 1, y_max=h - 1, z_max=n_z - 1
                 )
         self._coords_tab.rebuild_channel_combos(fm_image)
+        # Channels now exist — re-apply the config's channel-by-name selection.
+        self._apply_fit_config()
+        self._seed_ri_from_fm_metadata(fm_image)
         self._images_tab.set_fm_image(fm_image)
 
     @staticmethod
@@ -1672,6 +1679,84 @@ class CorrelationTabWidget(QWidget):
     @property
     def result(self) -> Optional[CorrelationResult]:
         return self._result
+
+    # ------------------------------------------------------------------
+    # Correlation config (FIB-298) — passed in on open, read back on close
+    # ------------------------------------------------------------------
+
+    def set_correlation_config(self, config: CorrelationConfig) -> None:
+        """Apply an experiment-global config as the fit + RI defaults."""
+        self._correlation_config = config
+        self._apply_fit_config()
+        ri = config.ri
+        self._ri_tab._ri_widget.set_params(
+            ZetaParams(
+                tilt_deg=ri.tilt_deg,
+                depth_um=ri.depth_um,
+                NA=ri.na,
+                n2=ri.n2,
+                wavelength_um=ri.wavelength_um,
+            )
+        )
+
+    def _seed_ri_from_fm_metadata(self, fm_image: FluorescenceImage) -> None:
+        """Seed RI λ / NA from the POI channel's metadata (FIB-277); λ is
+        channel-specific, so read from the selected POI channel."""
+        channels = list(getattr(fm_image.metadata, "channels", None) or [])
+        if not channels:
+            return
+        poi_name = self._coords_tab._fm_poi_ch_combo.currentText()
+        channel = next((c for c in channels if (c.name or "") == poi_name), channels[0])
+        exc_nm = getattr(channel, "excitation_wavelength", None)
+        self._ri_tab._ri_widget.seed_from_metadata(
+            wavelength_um=(exc_nm / 1000.0) if exc_nm else None,
+            na=getattr(channel, "objective_numerical_aperture", None),
+        )
+
+    def _apply_fit_config(self) -> None:
+        """Push the config's fit methods + channel names into the combos.
+        setCurrentText no-ops on an absent channel, so this is safe before an FM
+        image loads and re-applied after — the selection lands once it exists."""
+        cl = self._coords_tab
+        fit = self._correlation_config.fit
+        cl._fib_method_combo.setCurrentText(fit.fib_method)
+        cl._fm_fid_method_combo.setCurrentText(fit.fm_fiducial_method)
+        cl._fm_poi_method_combo.setCurrentText(fit.fm_poi_method)
+        if fit.fm_fiducial_channel:
+            cl._fm_fid_ch_combo.setCurrentText(fit.fm_fiducial_channel)
+        if fit.fm_poi_channel:
+            cl._fm_poi_ch_combo.setCurrentText(fit.fm_poi_channel)
+
+    @property
+    def correlation_config(self) -> CorrelationConfig:
+        """Current config: fit/RI read from the widgets; UI-less fields (cutout,
+        interpolation, spot burns) carried through from what was set."""
+        cl = self._coords_tab
+        stored = self._correlation_config
+        params = self._ri_tab._ri_widget.get_params()
+        fit = FitSettings(
+            fib_method=cl._fib_method_combo.currentText(),
+            fm_fiducial_method=cl._fm_fid_method_combo.currentText(),
+            fm_poi_method=cl._fm_poi_method_combo.currentText(),
+            fm_fiducial_channel=cl._fm_fid_ch_combo.currentText() or None,
+            fm_poi_channel=cl._fm_poi_ch_combo.currentText() or None,
+            reflection_cutout=stored.fit.reflection_cutout,
+            fluorescence_cutout=stored.fit.fluorescence_cutout,
+        )
+        ri = RISettings(
+            tilt_deg=params.tilt_deg,
+            depth_um=params.depth_um,
+            na=params.NA,
+            n2=params.n2,
+            wavelength_um=params.wavelength_um,
+            mode=stored.ri.mode,
+        )
+        return CorrelationConfig(
+            fit=fit,
+            ri=ri,
+            interpolation=stored.interpolation,
+            load_spot_burns=stored.load_spot_burns,
+        )
 
     # ------------------------------------------------------------------
     # Canvas refresh helpers
@@ -2439,13 +2524,15 @@ class CorrelationTabWidget(QWidget):
                     if method == "Hole":
                         attempted = True
                         xr, yr, zr, diag = hole_fitting_reflection(
-                            img, x, y, z=int(z), cutout=2  # sub-pixel x/y (FIB-282)
+                            img, x, y, z=int(z),  # sub-pixel x/y (FIB-282)
+                            cutout=self._correlation_config.fit.reflection_cutout,
                         )
                         fitted = PointXYZ(float(xr), float(yr), float(zr))
                     elif method == "Gaussian":
                         attempted = True
                         xr, yr, zr, diag = target_fitting_fluorescence(
-                            img, x, y, int(z), cutout=5  # sub-pixel x/y (FIB-282)
+                            img, x, y, int(z),  # sub-pixel x/y (FIB-282)
+                            cutout=self._correlation_config.fit.fluorescence_cutout,
                         )
                         fitted = PointXYZ(float(xr), float(yr), float(zr))
         except Exception as exc:
@@ -2530,6 +2617,14 @@ class CorrelationTabDialog(QDialog):
 
     def set_project_dir(self, path: str) -> None:
         self.widget.set_project_dir(path)
+
+    def set_correlation_config(self, config: "CorrelationConfig") -> None:
+        self.widget.set_correlation_config(config)
+
+    @property
+    def correlation_config(self) -> "CorrelationConfig":
+        """The (possibly edited) config to write back to the protocol on close."""
+        return self.widget.correlation_config
 
     @property
     def result(self):

--- a/fibsem/correlation/ui/widgets/refractive_index_widget.py
+++ b/fibsem/correlation/ui/widgets/refractive_index_widget.py
@@ -65,6 +65,8 @@ class RefractiveIndexWidget(QWidget):
         self._zeta: Optional[float] = None
         self._tilt_locked = False
         self._tilt_before_lock: Optional[float] = None
+        # Params the user has typed by hand; metadata seeding leaves these alone.
+        self._user_edited: set = set()
         try:
             _ensure_lut()
         except Exception as e:
@@ -162,6 +164,13 @@ class RefractiveIndexWidget(QWidget):
         ):
             spin.valueChanged.connect(self._recompute)
 
+        # Track manual edits so metadata seeding never clobbers a typed value
+        # (FIB-277). editingFinished fires only on user interaction, not setValue.
+        self._spin_na.editingFinished.connect(lambda: self._user_edited.add("na"))
+        self._spin_wl.editingFinished.connect(
+            lambda: self._user_edited.add("wavelength")
+        )
+
         self.zeta_computed.connect(self._spin_factor.setValue)
 
     # ------------------------------------------------------------------
@@ -246,6 +255,18 @@ class RefractiveIndexWidget(QWidget):
             n2=self._spin_n2.value(),
             wavelength_um=self._spin_wl.value() / 1000.0,  # nm → µm
         )
+
+    def seed_from_metadata(
+        self,
+        wavelength_um: Optional[float] = None,
+        na: Optional[float] = None,
+    ) -> None:
+        """Populate λ and/or NA from FM metadata (FIB-277), leaving user-typed
+        values and absent (``None``) inputs untouched."""
+        if wavelength_um is not None and "wavelength" not in self._user_edited:
+            self._spin_wl.setValue(wavelength_um * 1000.0)  # µm → nm
+        if na is not None and "na" not in self._user_edited:
+            self._spin_na.setValue(na)
 
     # ------------------------------------------------------------------
     # Internal

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -999,6 +999,12 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         dialog = CorrelationTabDialog(parent=self)
         dialog.set_project_dir(project_path)
 
+        # Experiment-global correlation config: pass in on open (FIB-298).
+        experiment = self.parent_widget.experiment if self.parent_widget else None
+        protocol = experiment.task_protocol if experiment is not None else None
+        if protocol is not None:
+            dialog.set_correlation_config(protocol.correlation)
+
         fib_image = self.image
         if fib_image is not None:
             dialog.set_fib_image(fib_image)
@@ -1007,7 +1013,15 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         if fm_image is not None:
             dialog.set_fm_image(fm_image)
 
-        if dialog.exec_() == QDialog.Accepted and dialog.result is not None:
+        if dialog.exec_() != QDialog.Accepted:
+            return
+
+        # Persist the edited config to the protocol so every lamella inherits it.
+        if protocol is not None:
+            protocol.correlation = dialog.correlation_config
+            self._save_experiment()
+
+        if dialog.result is not None:
             self._handle_correlation_dialog_result(dialog.result)
 
     def _handle_correlation_dialog_result(self, result: "CorrelationResult") -> None:

--- a/tests/autolamella/test_structures.py
+++ b/tests/autolamella/test_structures.py
@@ -308,3 +308,26 @@ def test_task_protocol_estimated_time_per_task():
         assert isinstance(task.estimated_time, float)
         assert task.estimated_time >= 0.0
 
+
+
+def test_task_protocol_carries_correlation_config():
+    """FIB-298: the protocol holds an experiment-global CorrelationConfig as a
+    peer field, round-trips it, and a legacy protocol without the key defaults."""
+    from fibsem.correlation.config import CorrelationConfig
+
+    protocol = AutoLamellaTaskProtocol()
+    assert isinstance(protocol.correlation, CorrelationConfig)
+
+    # a customised config survives a to_dict / from_dict round-trip
+    protocol.correlation.fit.fm_poi_channel = "RFP"
+    protocol.correlation.ri.na = 0.9
+    protocol.correlation.load_spot_burns = False
+    restored = AutoLamellaTaskProtocol.from_dict(protocol.to_dict())
+    assert restored.correlation.fit.fm_poi_channel == "RFP"
+    assert restored.correlation.ri.na == 0.9
+    assert restored.correlation.load_spot_burns is False
+
+    # a protocol saved before this field existed loads with a default config
+    legacy = protocol.to_dict()
+    del legacy["correlation"]
+    assert AutoLamellaTaskProtocol.from_dict(legacy).correlation == CorrelationConfig()

--- a/tests/correlation/test_config.py
+++ b/tests/correlation/test_config.py
@@ -1,0 +1,74 @@
+"""Tests for CorrelationConfig (persistence phase 1, FIB-298).
+
+Pure dataclasses, no Qt. Covers round-trip and — the load-bearing part —
+back-compat: a config dict missing keys (or a whole nested block, or the whole
+thing) must fill in defaults, so a protocol saved before this field loads clean.
+"""
+from fibsem.correlation.config import (
+    CorrelationConfig,
+    FitSettings,
+    InterpolationSettings,
+    RISettings,
+)
+
+
+def test_correlation_config_round_trips():
+    cfg = CorrelationConfig(
+        fit=FitSettings(fib_method="Gaussian", fm_poi_channel="GFP", reflection_cutout=3),
+        ri=RISettings(na=0.9, wavelength_um=0.488, mode="post"),
+        interpolation=InterpolationSettings(enabled=True, isotropic=False, target_z_nm=120.0),
+        load_spot_burns=False,
+    )
+    back = CorrelationConfig.from_dict(cfg.to_dict())
+    assert back == cfg
+
+
+def test_defaults_match_the_current_hardcoded_behaviour():
+    """The default config must reproduce today's behaviour so nothing changes
+    for a project that never sets it."""
+    cfg = CorrelationConfig()
+    assert cfg.fit.fib_method == "Hole"
+    assert cfg.fit.fm_fiducial_method == "None"
+    assert cfg.fit.fm_poi_method == "Gaussian"
+    assert (cfg.fit.reflection_cutout, cfg.fit.fluorescence_cutout) == (2, 5)
+    # RI defaults mirror DEFAULT_ZETA_PARAMS in the RI widget
+    assert (cfg.ri.tilt_deg, cfg.ri.depth_um, cfg.ri.na, cfg.ri.n2, cfg.ri.wavelength_um) == \
+        (15.0, 4.0, 0.8, 1.4, 0.515)
+    assert cfg.ri.mode == "pre"
+    assert cfg.load_spot_burns is True
+    assert cfg.interpolation.enabled is False
+
+
+def test_channels_default_to_none_stored_by_name():
+    """Channels are stored by name (resolved against the image later), so they
+    start unset rather than pinned to an index."""
+    fit = FitSettings()
+    assert fit.fm_fiducial_channel is None
+    assert fit.fm_poi_channel is None
+    fit.fm_poi_channel = "RFP"
+    assert FitSettings.from_dict(fit.to_dict()).fm_poi_channel == "RFP"
+
+
+def test_empty_dict_yields_defaults():
+    """A missing 'correlation' block on a legacy protocol -> a default config."""
+    assert CorrelationConfig.from_dict({}) == CorrelationConfig()
+    assert CorrelationConfig.from_dict(None) == CorrelationConfig()
+
+
+def test_partial_dict_fills_missing_keys():
+    """A hand-edited or older config with only some keys keeps the rest at default,
+    rather than raising on a missing key."""
+    cfg = CorrelationConfig.from_dict({"fit": {"fib_method": "None"}})
+    assert cfg.fit.fib_method == "None"           # the provided key
+    assert cfg.fit.fm_poi_method == "Gaussian"    # a sibling default
+    assert cfg.ri == RISettings()                 # a missing nested block
+    assert cfg.load_spot_burns is True
+
+
+def test_nested_blocks_independently_tolerate_absence():
+    cfg = CorrelationConfig.from_dict({"ri": {"na": 0.7}, "load_spot_burns": False})
+    assert cfg.ri.na == 0.7
+    assert cfg.ri.mode == "pre"                   # sibling default within ri
+    assert cfg.fit == FitSettings()               # whole missing block
+    assert cfg.interpolation == InterpolationSettings()
+    assert cfg.load_spot_burns is False

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -2209,3 +2209,125 @@ def test_load_correlation_file_dispatches_on_every_shape(tmp_path):
     jpath.write_text(json.dumps({"foo": 1}))
     with pytest.raises(ValueError):
         load_correlation_file(str(jpath))
+
+
+# ---------------------------------------------------------------------------
+# FIB-298 — CorrelationConfig passed in on open, read back on close
+# ---------------------------------------------------------------------------
+
+
+def test_widget_config_round_trips(qapp):
+    """set_correlation_config -> combos + RI widget -> correlation_config back."""
+    from fibsem.correlation.config import CorrelationConfig, FitSettings, RISettings
+
+    w = _widget(qapp)
+    cfg = CorrelationConfig(
+        fit=FitSettings(fib_method="None", fm_poi_method="Hole", reflection_cutout=4),
+        ri=RISettings(na=0.9, wavelength_um=0.488, n2=1.33),
+        load_spot_burns=False,
+    )
+    w.set_correlation_config(cfg)
+
+    cl = w._coords_tab
+    assert cl._fib_method_combo.currentText() == "None"
+    assert cl._fm_poi_method_combo.currentText() == "Hole"
+    p = w._ri_tab._ri_widget.get_params()
+    assert (p.NA, p.n2) == (pytest.approx(0.9), pytest.approx(1.33))
+    assert p.wavelength_um == pytest.approx(0.488)
+
+    out = w.correlation_config
+    assert out.fit.fib_method == "None"
+    assert out.fit.reflection_cutout == 4      # UI-less field carried through
+    assert out.ri.na == pytest.approx(0.9)
+    assert out.load_spot_burns is False        # UI-less field carried through
+
+
+def test_widget_config_reflects_a_combo_edit(qapp):
+    from fibsem.correlation.config import CorrelationConfig
+
+    w = _widget(qapp)
+    w.set_correlation_config(CorrelationConfig())
+    w._coords_tab._fib_method_combo.setCurrentText("Gaussian")
+    assert w.correlation_config.fit.fib_method == "Gaussian"
+
+
+def test_config_default_matches_current_behaviour(qapp):
+    """A widget that was never given a config reports today's defaults."""
+    w = _widget(qapp)
+    fit = w.correlation_config.fit
+    assert (fit.fib_method, fit.fm_fiducial_method, fit.fm_poi_method) == \
+        ("Hole", "None", "Gaussian")
+
+
+def test_channel_by_name_lands_once_the_channel_exists(qapp):
+    """A config naming a POI channel applies after the FM image populates the
+    combos — stored by name, resolved against the image (not a pinned index)."""
+    from fibsem.correlation.config import CorrelationConfig, FitSettings
+
+    w = _widget(qapp)
+    # config set before any FM image: channel combo is still empty, no-op
+    w.set_correlation_config(
+        CorrelationConfig(fit=FitSettings(fm_poi_channel="CH1"))
+    )
+    assert w._coords_tab._fm_poi_ch_combo.currentText() == ""
+
+    # channels populate; re-apply lands the named selection (as set_fm_image does)
+    w._coords_tab.rebuild_channel_combos(_fake_fm(n_c=3))
+    w._apply_fit_config()
+    assert w._coords_tab._fm_poi_ch_combo.currentText() == "CH1"
+    assert w.correlation_config.fit.fm_poi_channel == "CH1"
+
+
+def _fake_fm_with_optics(names=("Reflection", "GFP"), wl_nm=(488, 520), na=0.85):
+    """FM whose channels carry the ζ-seedable metadata (λ, NA)."""
+    from types import SimpleNamespace
+
+    import numpy as np
+
+    chans = [
+        SimpleNamespace(name=n, color=None, excitation_wavelength=w,
+                        objective_numerical_aperture=na)
+        for n, w in zip(names, wl_nm)
+    ]
+    return SimpleNamespace(
+        data=np.zeros((len(chans), 5, 8, 8), dtype=np.float32),
+        metadata=SimpleNamespace(filename="/data/fm.ome.tiff", channels=chans),
+    )
+
+
+def test_ri_seeds_wavelength_and_na_from_poi_channel(qapp):
+    """FIB-277: λ comes from the *POI* channel's excitation wavelength, NA from
+    the objective — both read from metadata, not left at the generic default."""
+    from fibsem.correlation.config import CorrelationConfig, FitSettings
+
+    w = _widget(qapp)
+    fm = _fake_fm_with_optics(names=("Reflection", "GFP"), wl_nm=(488, 520), na=0.85)
+    w._coords_tab.rebuild_channel_combos(fm)
+    # POI channel = GFP (520 nm)
+    w.set_correlation_config(CorrelationConfig(fit=FitSettings(fm_poi_channel="GFP")))
+    w._apply_fit_config()
+
+    w._seed_ri_from_fm_metadata(fm)
+
+    p = w._ri_tab._ri_widget.get_params()
+    assert p.wavelength_um == pytest.approx(0.520)   # GFP, not Reflection
+    assert p.NA == pytest.approx(0.85)
+
+
+def test_ri_seed_respects_a_manual_edit(qapp):
+    """A wavelength the user typed is not clobbered by metadata on FM load."""
+    w = _widget(qapp)
+    ri = w._ri_tab._ri_widget
+    ri._spin_wl.setValue(600.0)
+    ri._spin_wl.editingFinished.emit()   # marks it user-edited
+
+    w._seed_ri_from_fm_metadata(_fake_fm_with_optics(wl_nm=(488, 520)))
+    assert ri.get_params().wavelength_um == pytest.approx(0.600)  # kept
+
+
+def test_ri_seed_skips_when_metadata_absent(qapp):
+    """A channel with no optics metadata leaves the RI params at their default."""
+    w = _widget(qapp)
+    before = w._ri_tab._ri_widget.get_params()
+    w._seed_ri_from_fm_metadata(_fake_fm(n_c=2))  # plain channels, no λ/NA
+    assert w._ri_tab._ri_widget.get_params() == before


### PR DESCRIPTION
Closes [FIB-298](https://linear.app/fibsemos/issue/FIB-298). Phase 1 of the [correlation-persistence design](https://linear.app/fibsemos/document/correlation-persistence-and-the-lamella-correlation-workflow-e3221e1a64bc), and it delivers two existing backlog issues on the way: [FIB-284](https://linear.app/fibsemos/issue/FIB-284) (persist fit settings) and [FIB-277](https://linear.app/fibsemos/issue/FIB-277) (seed RI from FM metadata).

## Why

Correlation settings (fit method / channel / cutout, RI params) lived only in the widget's combos, so a save→reload reset them to defaults, and every lamella started from scratch. This introduces **`CorrelationConfig`** as the experiment-global home for them.

## The tiers

- **Config type** — `fibsem/correlation/config.py`: `CorrelationConfig` composing `FitSettings` / `RISettings` / `InterpolationSettings` + `load_spot_burns`, with a back-compat-tolerant `from_dict` (missing keys/blocks default cleanly). Defined in `fibsem/correlation/` so the autolamella model only holds an instance; imports no UI.
- **On the protocol** — `AutoLamellaTaskProtocol.correlation`, a **peer field** of `options` / `lamella_defaults`, **not** an entry in `task_config`. Correlation is a user-completed step, not an automated microscope task, so it carries none of the `milling` / `reference_imaging` machinery a task config does. A protocol saved before this field loads with a default config.

## Widget wiring (pass-in on open, return on close)

- `set_correlation_config` applies the fit combos + RI params; the `correlation_config` property reads them back.
- **Channels stored by name**, resolved against the loaded image and re-applied once the combos populate — a persisted "POI = channel 1" would pin the wrong dye across images.
- `cutout` now flows from the config into `_run_point_fit` (was hardcoded 2/5).
- Dialog passthrough + protocol-editor: pass `protocol.correlation` in on open; **persist the edited config back only on accept**.

## RI from metadata (FIB-277)

On FM load, λ (from the **POI channel's** excitation wavelength — it's channel-specific) and NA (from the objective) seed the RI widget, **leaving values the user has typed untouched** (tracked via `editingFinished`, so programmatic sets don't count as edits).

## Out of scope (later phases)

The setup pre-dialog, seeding coordinates from previous runs, the history view.

## Testing

15 new tests — config round-trip + back-compat (empty/partial/missing-block), protocol round-trip + legacy default, widget config in/out, channel-by-name-after-load, RI seeding + the manual-edit guard — two mutation-verified (RI edit-guard; cutout carry-through). 217 correlation + autolamella-structures pass; correlation suite 185.

_(The pre-existing `test_milling_angle` failure is unrelated — a config difference between checkouts, being fixed on another branch.)_
