### PR TITLE
Correlation: seed a new correlation from the lamella's previous run (FIB-299)

### DIFF
--- a/fibsem/correlation/history.py
+++ b/fibsem/correlation/history.py
@@ -1,0 +1,75 @@
+"""A lamella's correlation history — a read-only view over the on-disk run folders.
+
+Each open of the correlation dialog writes a run to
+``<lamella>/Correlation/<timestamp>/correlation.json`` (FIB-264); the app has
+always created these folders and thrown away the pointer. This reconstructs the
+history from them so a new correlation can seed from the previous one (FIB-299).
+Nothing new is persisted — the history *is* the folders.
+"""
+from __future__ import annotations
+
+import glob
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from fibsem.correlation.structures import CorrelationState, load_correlation_file
+
+# Preference order within a run folder: the consolidated file, then either legacy.
+_RUN_FILES = ("correlation.json", "correlation_result.json", "correlation_data.json")
+
+
+def _run_file(folder: str) -> Optional[str]:
+    for name in _RUN_FILES:
+        path = os.path.join(folder, name)
+        if os.path.exists(path):
+            return path
+    return None
+
+
+@dataclass
+class CorrelationRun:
+    """One saved correlation, loaded from its timestamped folder."""
+
+    path: str          # the run folder
+    name: str          # folder basename (the timestamp)
+    state: CorrelationState
+
+
+@dataclass
+class LamellaCorrelation:
+    """The runs found under a lamella's ``Correlation`` directory, oldest first."""
+
+    runs: List[CorrelationRun] = field(default_factory=list)
+
+    @staticmethod
+    def discover(correlation_dir: str) -> "LamellaCorrelation":
+        """Load every run folder under ``correlation_dir`` (``<lamella>/Correlation``).
+
+        Folders are ordered by name — the timestamp format is lexicographically
+        chronological. Unreadable folders are logged and skipped so one bad run
+        doesn't hide the rest.
+        """
+        runs: List[CorrelationRun] = []
+        if not os.path.isdir(correlation_dir):
+            return LamellaCorrelation()
+        for folder in sorted(glob.glob(os.path.join(correlation_dir, "*"))):
+            if not os.path.isdir(folder):
+                continue
+            path = _run_file(folder)
+            if path is None:
+                continue
+            try:
+                state = load_correlation_file(path)
+            except Exception:
+                logging.warning("Skipping unreadable correlation run: %s", path)
+                continue
+            runs.append(
+                CorrelationRun(path=folder, name=os.path.basename(folder), state=state)
+            )
+        return LamellaCorrelation(runs=runs)
+
+    def latest(self) -> Optional[CorrelationRun]:
+        """The most recent run, or None if there are none."""
+        return self.runs[-1] if self.runs else None

--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -110,6 +110,9 @@ class CorrelationInputData:
     # (images absent) can still convert corrected pixels to px / px_m
     stored_fib_image_shape: Optional[tuple] = None
     stored_fib_image_pixel_size: Optional[float] = None
+    # FM z-step, likewise restored from JSON: lets a seed's FM z be rescaled to a
+    # re-acquired volume with a different z-sampling (FIB-299).
+    stored_fm_pixel_size_z: Optional[float] = None
 
     def to_dict(self):
         return {
@@ -126,6 +129,7 @@ class CorrelationInputData:
             "fm_image_shape": self.fm_image_shape,
             "fib_image_shape": self.fib_image_shape,
             "fib_image_pixel_size": self.fib_image_pixel_size,
+            "fm_pixel_size_z": self.fm_pixel_size_z,
             "fib_image_filename": self.fib_image_filename,
             "fm_image_filename": self.fm_image_filename,
             "method": self.method,
@@ -148,6 +152,12 @@ class CorrelationInputData:
         if self.fm_image is None or self.fm_image.data is None:
             return None
         return self.fm_image.data.shape
+
+    @property
+    def fm_pixel_size_z(self) -> Optional[float]:
+        if self.fm_image is None:
+            return self.stored_fm_pixel_size_z
+        return getattr(self.fm_image.metadata, "pixel_size_z", None)
 
     @property
     def fib_image_filename(self) -> Optional[str]:
@@ -210,6 +220,7 @@ class CorrelationInputData:
             method=data.get("method", "multi-point"),
             stored_fib_image_shape=tuple(stored_shape) if stored_shape else None,
             stored_fib_image_pixel_size=data.get("fib_image_pixel_size"),
+            stored_fm_pixel_size_z=data.get("fm_pixel_size_z"),
         )
 
     def save(self, filename: str):

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -1643,6 +1643,23 @@ class CorrelationTabWidget(QWidget):
         if state.result is not None:
             self._load_result(state.result, adopt_inputs=False)
 
+    def seed_coordinates(self, source: CorrelationInputData) -> None:
+        """Load a previous run's coordinates as starting points (FIB-299).
+
+        Coordinates only — the previous result is from different images, so it is
+        not carried in. FM z is rescaled to the current volume's z-sampling when it
+        differs, so a seed picked in a differently-interpolated volume lands at the
+        right depth. Points are placed as-is; the user refines them on demand.
+        """
+        src_z = source.stored_fm_pixel_size_z   # read before we attach the current image
+        cur_z = self._fm_pixel_size_z()
+        source.fib_image = self._fib_image
+        source.fm_image = self._fm_image
+        self.set_data(source)
+        if src_z and cur_z and abs(src_z - cur_z) > 1e-15:
+            self._rescale_fm_z(src_z / cur_z)
+        self.data_changed.emit(self.data)
+
     def load_data(self, path: str) -> None:
         """Load a legacy coordinates file, preserving current images.
 
@@ -2620,6 +2637,9 @@ class CorrelationTabDialog(QDialog):
 
     def set_correlation_config(self, config: "CorrelationConfig") -> None:
         self.widget.set_correlation_config(config)
+
+    def seed_coordinates(self, source: "CorrelationInputData") -> None:
+        self.widget.seed_coordinates(source)
 
     @property
     def correlation_config(self) -> "CorrelationConfig":

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -985,13 +985,18 @@ class AutoLamellaProtocolEditorWidget(QWidget):
             logging.error("No lamella selected, cannot open correlation dialog.")
             return
 
+        from fibsem.correlation.history import LamellaCorrelation
         from fibsem.correlation.ui.widgets.correlation_tab_widget import (
             CorrelationTabDialog,
         )
 
+        correlation_root = os.path.join(selected_lamella.path, "Correlation")
+        # Discover the newest previous run to seed from, BEFORE minting this run's
+        # folder (so this open isn't its own "previous"). FIB-299.
+        previous = LamellaCorrelation.discover(correlation_root).latest()
+
         project_path = os.path.join(
-            selected_lamella.path,
-            "Correlation",
+            correlation_root,
             datetime.datetime.now().strftime(constants.DATETIME_FILE),
         )
         os.makedirs(project_path, exist_ok=True)
@@ -1012,6 +1017,11 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         fm_image = self.fm_image
         if fm_image is not None:
             dialog.set_fm_image(fm_image)
+
+        # Seed the coordinates from the previous run (after the current images are
+        # set, so FM z can be rescaled to this volume's z-sampling). FIB-299.
+        if previous is not None and previous.state.input_data is not None:
+            dialog.seed_coordinates(previous.state.input_data)
 
         if dialog.exec_() != QDialog.Accepted:
             return

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -2325,3 +2325,71 @@ def test_ri_seed_skips_when_metadata_absent(qapp):
     before = w._ri_tab._ri_widget.get_params()
     w._seed_ri_from_fm_metadata(_fake_fm(n_c=2))  # plain channels, no λ/NA
     assert w._ri_tab._ri_widget.get_params() == before
+
+
+# ---------------------------------------------------------------------------
+# FIB-299 — seed a new correlation from the previous run
+# ---------------------------------------------------------------------------
+
+
+def _fm_at_zstep(z_step_m, n_z=21):
+    from types import SimpleNamespace
+
+    import numpy as np
+
+    return SimpleNamespace(
+        data=np.zeros((1, n_z, 8, 8), dtype=np.float32),
+        metadata=SimpleNamespace(
+            pixel_size_z=z_step_m, pixel_size_x=100e-9, channels=[], filename=""
+        ),
+    )
+
+
+def test_stored_fm_pixel_size_z_round_trips():
+    d = CorrelationInputData(
+        fib_coordinates=[_coord(1.0, 2.0, pt=PointType.FIB)],
+        stored_fm_pixel_size_z=500e-9,
+    )
+    assert d.to_dict()["fm_pixel_size_z"] == 500e-9
+    assert CorrelationInputData.from_dict(d.to_dict()).stored_fm_pixel_size_z == 500e-9
+    legacy = d.to_dict()
+    del legacy["fm_pixel_size_z"]  # a file written before FIB-299
+    assert CorrelationInputData.from_dict(legacy).stored_fm_pixel_size_z is None
+
+
+def test_seed_rescales_fm_z_across_a_different_zstep(qapp):
+    """A seed picked at 500 nm/slice, reloaded into a 100 nm/slice (interpolated)
+    volume, must land at the same physical depth — index 10 -> 50."""
+    w = _widget(qapp)
+    w._fm_image = _fm_at_zstep(100e-9, n_z=105)   # current volume, interpolated
+    source = CorrelationInputData(
+        fm_coordinates=[_coord(2.0, 2.0, z=10.0, pt=PointType.FM)],
+        stored_fm_pixel_size_z=500e-9,            # source volume z-step
+    )
+    w.seed_coordinates(source)
+
+    assert w._coords_tab.fm_list.coordinates[0].point.z == pytest.approx(50.0)
+    assert w._result is None                      # previous result not carried in
+
+
+def test_seed_is_a_noop_when_the_zstep_matches(qapp):
+    w = _widget(qapp)
+    w._fm_image = _fm_at_zstep(500e-9)
+    source = CorrelationInputData(
+        fm_coordinates=[_coord(2.0, 2.0, z=10.0, pt=PointType.FM)],
+        stored_fm_pixel_size_z=500e-9,
+    )
+    w.seed_coordinates(source)
+    assert w._coords_tab.fm_list.coordinates[0].point.z == pytest.approx(10.0)
+
+
+def test_seed_without_a_stored_zstep_does_not_rescale(qapp):
+    """A legacy seed with no stored z-step is loaded as-is (can't reconcile)."""
+    w = _widget(qapp)
+    w._fm_image = _fm_at_zstep(100e-9, n_z=105)
+    source = CorrelationInputData(
+        fm_coordinates=[_coord(2.0, 2.0, z=10.0, pt=PointType.FM)],
+        stored_fm_pixel_size_z=None,
+    )
+    w.seed_coordinates(source)
+    assert w._coords_tab.fm_list.coordinates[0].point.z == pytest.approx(10.0)

--- a/tests/correlation/test_history.py
+++ b/tests/correlation/test_history.py
@@ -1,0 +1,70 @@
+"""Tests for the on-disk correlation history view (FIB-299).
+
+``LamellaCorrelation.discover`` reconstructs a lamella's runs from the timestamped
+``Correlation/<ts>/correlation.json`` folders the app already writes; ``latest``
+returns the newest. No Qt.
+"""
+import os
+
+from fibsem.correlation.history import LamellaCorrelation
+from fibsem.correlation.structures import (
+    Coordinate,
+    CorrelationInputData,
+    CorrelationState,
+    PointType,
+    PointXYZ,
+)
+
+
+def _write_run(root, name, x):
+    folder = os.path.join(root, name)
+    os.makedirs(folder)
+    inp = CorrelationInputData(
+        fib_coordinates=[Coordinate(point=PointXYZ(x=x), point_type=PointType.FIB)]
+    )
+    CorrelationState(input_data=inp).save(os.path.join(folder, "correlation.json"))
+    return folder
+
+
+def test_discover_orders_runs_and_latest_is_newest(tmp_path):
+    _write_run(str(tmp_path), "2026-07-20-09-00-00", x=1.0)
+    _write_run(str(tmp_path), "2026-07-24-14-00-00", x=9.0)
+
+    hist = LamellaCorrelation.discover(str(tmp_path))
+    assert [r.name for r in hist.runs] == [
+        "2026-07-20-09-00-00",
+        "2026-07-24-14-00-00",
+    ]
+    latest = hist.latest()
+    assert latest.name == "2026-07-24-14-00-00"
+    assert latest.state.input_data.fib_coordinates[0].point.x == 9.0
+
+
+def test_discover_missing_or_empty_dir_has_no_runs(tmp_path):
+    assert LamellaCorrelation.discover(str(tmp_path / "nope")).latest() is None
+    assert LamellaCorrelation.discover(str(tmp_path)).runs == []
+
+
+def test_discover_skips_unreadable_and_non_run_folders(tmp_path):
+    _write_run(str(tmp_path), "2026-07-24-14-00-00", x=5.0)
+    os.makedirs(str(tmp_path / "empty-folder"))              # no correlation file
+    bad = tmp_path / "2026-07-25-08-00-00"
+    bad.mkdir()
+    (bad / "correlation.json").write_text("{ not json")      # unreadable
+
+    hist = LamellaCorrelation.discover(str(tmp_path))
+    assert [r.name for r in hist.runs] == ["2026-07-24-14-00-00"]  # the good one only
+
+
+def test_discover_reads_a_legacy_run_folder(tmp_path):
+    """A run folder from before FIB-264 holds correlation_data.json, not
+    correlation.json — still discoverable."""
+    folder = tmp_path / "2026-07-19-10-00-00"
+    folder.mkdir()
+    CorrelationInputData(
+        fib_coordinates=[Coordinate(point=PointXYZ(x=3.0), point_type=PointType.FIB)]
+    ).save(str(folder / "correlation_data.json"))
+
+    latest = LamellaCorrelation.discover(str(tmp_path)).latest()
+    assert latest is not None
+    assert latest.state.input_data.fib_coordinates[0].point.x == 3.0


### PR DESCRIPTION
Closes [FIB-299](https://linear.app/fibsemos/issue/FIB-299). Phase 2 of the [correlation-persistence design](https://linear.app/fibsemos/document/correlation-persistence-and-the-lamella-correlation-workflow-e3221e1a64bc); builds on [FIB-298](https://linear.app/fibsemos/issue/FIB-298) (phase 1). Reframes [FIB-257](https://linear.app/fibsemos/issue/FIB-257)'s "auto-reload most recent" as **seeding**.

## Why

Each lamella is correlated more than once (before / after rough mill). Re-acquisition drifts the coordinates, so a re-correlation should **seed from the previous run and refine**, not start blank. This pre-populates the previous run's coordinates as starting points when the dialog opens.

## What

- **`stored_fm_pixel_size_z`** on `CorrelationInputData` — mirrors the existing `stored_fib_image_pixel_size` fallback; round-trips, back-compat (legacy files → `None`). Lets a seed's FM z be reconciled to a re-acquired volume with a different z-sampling.
- **`fibsem/correlation/history.py`** — `LamellaCorrelation.discover()` reconstructs a lamella's runs from the `Correlation/<timestamp>/` folders the app already writes (`latest()` = newest). Reads legacy run folders too; skips unreadable ones. **Nothing new persisted — the history *is* the folders.**
- **`widget.seed_coordinates()`** — loads a previous run's coordinates and rescales FM z by the stored-vs-current `pixel_size_z` ratio (reusing `_rescale_fm_z`), so a seed picked in a differently-interpolated volume lands at the right depth. **Coordinates only.**
- **Protocol editor** — discovers the newest previous run *before* minting this open's folder (so it isn't its own "previous"), then seeds after the current images are set (so z can be reconciled).

## Design notes

- **z stays a slice index** — only the seed is rescaled, at the stored z-step ratio (design doc, "carry the z-step, don't change the point"). No-op when the z-step is unchanged.
- **The previous *result* is not carried into the new run** — it was fitted to different images; replaying it would mislead. On a re-correlation you re-solve. Coords-only is deliberate.
- **Points load as-is; refinement is on demand** (decision 1) — no auto-refit.

## Out of scope (later phases)

On-demand refinement tools (FIB-265 shift, FIB-256 multi-refit), the history *view*, the setup pre-dialog.

## Testing

9 new tests — history discover / latest / empty / skip-unreadable / legacy-folder; `stored_fm_pixel_size_z` round-trip + back-compat; seed rescales across a different z-step, no-ops when it matches, and doesn't rescale without a stored z-step. Two mutation-verified (rescale direction; `latest()` ordering). 234 correlation + autolamella-structures pass.
