### PR TITLE
Correlation: history picker — choose which previous run to seed from (FIB-301)

### DIFF
--- a/fibsem/correlation/ui/widgets/correlation_history_dialog.py
+++ b/fibsem/correlation/ui/widgets/correlation_history_dialog.py
@@ -1,0 +1,235 @@
+"""CorrelationHistoryDialog — pick which previous run a re-correlation seeds from.
+
+Each open of the correlation tool writes a run to
+``<lamella>/Correlation/<timestamp>/`` (FIB-264); :class:`LamellaCorrelation`
+reconstructs that history from disk (FIB-299). With one prior run the newest is
+seeded silently; with several, this dialog lets the user choose which to seed
+from — or start fresh — so a bad re-correlation isn't the only thing to build on
+(FIB-257).
+
+Purely a chooser: it returns the selected :class:`CorrelationRun` (or ``None``
+for "start fresh") and never mutates the runs.
+"""
+from __future__ import annotations
+
+import datetime
+from typing import List, Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem import constants
+from fibsem.correlation.history import CorrelationRun, LamellaCorrelation
+from fibsem.correlation.structures import CorrelationState
+from fibsem.ui import stylesheets
+
+_MUTED = "#8a8d93"
+_OK = "#a5d6a7"
+_STALE = "#ffcc80"
+
+_TABLE_STYLE = (
+    "QTableWidget { background: #1e2124; color: #d0d0d0; border: 1px solid #2a2d31; }"
+    "QHeaderView::section { background: #262930; color: #b0b3b8; padding: 4px 10px;"
+    " border: none; }"
+    "QTableWidget::item { padding: 5px 10px; }"
+    "QTableWidget::item:selected { background: #264f78; color: #ffffff; }"
+)
+
+
+def _format_timestamp(name: str) -> str:
+    """Reformat a run folder name (a ``DATETIME_FILE`` stamp) for display.
+
+    Falls back to the raw name for a folder that doesn't parse (e.g. a legacy or
+    hand-named directory), so an odd name still shows rather than disappearing.
+    """
+    try:
+        dt = datetime.datetime.strptime(name, constants.DATETIME_FILE)
+    except ValueError:
+        return name
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _points_summary(state: CorrelationState) -> str:
+    """Compact count of the seed coordinates a run carries."""
+    data = state.input_data
+    parts = []
+    for count, label in (
+        (len(data.fib_coordinates), "FIB"),
+        (len(data.fm_coordinates), "FM"),
+        (len(data.poi_coordinates), "POI"),
+    ):
+        if count:
+            parts.append(f"{count} {label}")
+    return " · ".join(parts) if parts else "—"
+
+
+def _result_cell(state: CorrelationState) -> tuple[str, str]:
+    """(text, hex colour) describing a run's computed result, if any.
+
+    Reuses ``matches_inputs`` — the same derived-staleness machinery FIB-295 added
+    — to flag a run whose transform no longer describes its own coordinates.
+    """
+    result = state.result
+    if result is None:
+        return "No result", _MUTED
+    text = f"{result.rms_error:.2f} px RMS"
+    if not result.matches_inputs(state.input_data):
+        return f"{text} · stale", _STALE
+    return text, _OK
+
+
+class CorrelationHistoryDialog(QDialog):
+    """Modal chooser over a lamella's previous correlation runs.
+
+    ``exec_()`` returns ``QDialog.Accepted`` for both "seed from selected" and
+    "start fresh"; :attr:`selected_run` disambiguates (a run, or ``None`` for
+    fresh). ``Rejected`` means the user cancelled opening the correlation tool.
+    """
+
+    def __init__(
+        self,
+        history: LamellaCorrelation,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        # Newest first — the run most likely to be seeded sits at the top and is
+        # pre-selected. LamellaCorrelation.runs is oldest-first.
+        self._display_runs: List[CorrelationRun] = list(reversed(history.runs))
+        self._selected_run: Optional[CorrelationRun] = None
+
+        self.setWindowTitle("Correlation history")
+        self.setModal(True)
+        self.setStyleSheet("background: #1e2124; color: #d0d0d0;")
+        self.setMinimumWidth(420)  # a floor; the table's content usually drives it wider
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 14, 14, 12)
+        layout.setSpacing(10)
+
+        title = QLabel("Seed from a previous correlation")
+        title.setStyleSheet("font-size: 13px; font-weight: bold; color: #e0e0e0;")
+        subtitle = QLabel(
+            "The newest run is selected. Choose an older one, or start fresh."
+        )
+        subtitle.setStyleSheet(f"color: {_MUTED}; font-size: 12px;")
+        layout.addWidget(title)
+        layout.addWidget(subtitle)
+
+        self.table = self._build_table()
+        layout.addWidget(self.table)
+        self._fit_dialog_width_to_table()
+
+        layout.addLayout(self._build_buttons())
+
+    def _build_table(self) -> QTableWidget:
+        table = QTableWidget(len(self._display_runs), 3)
+        table.setHorizontalHeaderLabels(["When", "Points", "Result"])
+        table.setStyleSheet(_TABLE_STYLE)
+        table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        table.setSelectionMode(QAbstractItemView.SingleSelection)
+        table.verticalHeader().setVisible(False)
+        table.setShowGrid(False)
+        table.itemDoubleClicked.connect(lambda _item: self._accept_selected())
+
+        # Size every column to its content (which counts the item padding) so no
+        # cell text elides. _fit_dialog_width_to_table then widens the dialog to
+        # fit all three and lets the last column stretch into the small remainder —
+        # done in that order because a stretch column sized before the dialog is
+        # wide enough would just clip the RMS/stale text.
+        header = table.horizontalHeader()
+        header.setStretchLastSection(False)
+        for col in range(table.columnCount()):
+            header.setSectionResizeMode(col, QHeaderView.ResizeToContents)
+        table.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
+        for row, run in enumerate(self._display_runs):
+            table.setItem(row, 0, QTableWidgetItem(_format_timestamp(run.name)))
+            table.setItem(row, 1, QTableWidgetItem(_points_summary(run.state)))
+            text, colour = _result_cell(run.state)
+            result_item = QTableWidgetItem(text)
+            result_item.setForeground(QColor(colour))
+            table.setItem(row, 2, result_item)
+
+        if self._display_runs:
+            table.selectRow(0)  # newest
+        return table
+
+    def _fit_dialog_width_to_table(self) -> None:
+        """Widen the dialog to the table's content so no cell text elides.
+
+        Offscreen (and some styles) don't propagate the table's size hint up to
+        the dialog, so set the width from the measured column widths directly —
+        font metrics need no display. The last column then stretches to absorb the
+        slack, so the guaranteed-ample width leaves no trailing gap.
+        """
+        self.table.resizeColumnsToContents()
+        cols = sum(
+            self.table.columnWidth(c) for c in range(self.table.columnCount())
+        )
+        frame = 2 * self.table.frameWidth()
+        margins = self.layout().contentsMargins()
+        needed = cols + frame + margins.left() + margins.right() + 24  # border slack
+        self.setMinimumWidth(max(self.minimumWidth(), needed))
+        self.table.horizontalHeader().setStretchLastSection(True)
+
+        # Hug the rows so the dialog doesn't carry a band of empty table below the
+        # last run. Capped so a long history scrolls instead of running off-screen.
+        self.table.resizeRowsToContents()
+        rows_h = sum(
+            self.table.rowHeight(r) for r in range(self.table.rowCount())
+        )
+        header_h = self.table.horizontalHeader().height()
+        self.table.setMaximumHeight(header_h + rows_h + frame + 2)
+
+    def _build_buttons(self) -> QHBoxLayout:
+        row = QHBoxLayout()
+        fresh_btn = QPushButton("Start fresh")
+        fresh_btn.setToolTip("Open the correlation tool with no seeded coordinates.")
+        fresh_btn.setAutoDefault(False)
+        fresh_btn.clicked.connect(self._start_fresh)
+        row.addWidget(fresh_btn)
+
+        row.addStretch(1)
+
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.setAutoDefault(False)
+        cancel_btn.clicked.connect(self.reject)
+        row.addWidget(cancel_btn)
+
+        self.seed_btn = QPushButton("Seed from selected")
+        self.seed_btn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.seed_btn.setDefault(True)
+        self.seed_btn.setAutoDefault(True)
+        self.seed_btn.setEnabled(bool(self._display_runs))
+        self.seed_btn.clicked.connect(self._accept_selected)
+        row.addWidget(self.seed_btn)
+        return row
+
+    @property
+    def selected_run(self) -> Optional[CorrelationRun]:
+        """The run chosen to seed from, or ``None`` when the user started fresh."""
+        return self._selected_run
+
+    def _accept_selected(self) -> None:
+        if not self._display_runs:
+            return
+        row = self.table.currentRow()
+        self._selected_run = self._display_runs[row if row >= 0 else 0]
+        self.accept()
+
+    def _start_fresh(self) -> None:
+        self._selected_run = None
+        self.accept()

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -986,14 +986,26 @@ class AutoLamellaProtocolEditorWidget(QWidget):
             return
 
         from fibsem.correlation.history import LamellaCorrelation
+        from fibsem.correlation.ui.widgets.correlation_history_dialog import (
+            CorrelationHistoryDialog,
+        )
         from fibsem.correlation.ui.widgets.correlation_tab_widget import (
             CorrelationTabDialog,
         )
 
         correlation_root = os.path.join(selected_lamella.path, "Correlation")
-        # Discover the newest previous run to seed from, BEFORE minting this run's
-        # folder (so this open isn't its own "previous"). FIB-299.
-        previous = LamellaCorrelation.discover(correlation_root).latest()
+        # Discover previous runs to seed from, BEFORE minting this run's folder
+        # (so this open isn't its own "previous"). FIB-299.
+        history = LamellaCorrelation.discover(correlation_root)
+
+        # Which run to seed from. 0/1 runs: nothing to choose, keep the silent
+        # default (newest, or none). 2+: let the user pick, or start fresh (FIB-257).
+        seed_run = history.latest()
+        if len(history.runs) >= 2:
+            picker = CorrelationHistoryDialog(history, parent=self)
+            if picker.exec_() != QDialog.Accepted:
+                return  # user cancelled opening the correlation tool
+            seed_run = picker.selected_run  # a run, or None for "start fresh"
 
         project_path = os.path.join(
             correlation_root,
@@ -1018,10 +1030,10 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         if fm_image is not None:
             dialog.set_fm_image(fm_image)
 
-        # Seed the coordinates from the previous run (after the current images are
+        # Seed the coordinates from the chosen run (after the current images are
         # set, so FM z can be rescaled to this volume's z-sampling). FIB-299.
-        if previous is not None and previous.state.input_data is not None:
-            dialog.seed_coordinates(previous.state.input_data)
+        if seed_run is not None and seed_run.state.input_data is not None:
+            dialog.seed_coordinates(seed_run.state.input_data)
 
         if dialog.exec_() != QDialog.Accepted:
             return

--- a/tests/correlation/test_correlation_history_dialog.py
+++ b/tests/correlation/test_correlation_history_dialog.py
@@ -1,0 +1,147 @@
+"""Tests for CorrelationHistoryDialog — the previous-run picker (FIB-257).
+
+Headless PyQt5 with the offscreen platform (no pytest-qt), matching
+tests/correlation/test_correlation_tab_widget.py. The dialog is a pure chooser,
+so exec_() is never entered; the button handlers (_accept_selected /
+_start_fresh) are driven directly and set the result via accept().
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QDialog
+
+from fibsem.correlation.history import CorrelationRun, LamellaCorrelation
+from fibsem.correlation.structures import (
+    Coordinate,
+    CorrelationInputData,
+    CorrelationPointOfInterest,
+    CorrelationResult,
+    CorrelationState,
+    PointType,
+    PointXYZ,
+)
+from fibsem.correlation.ui.widgets.correlation_history_dialog import (
+    CorrelationHistoryDialog,
+    _format_timestamp,
+    _points_summary,
+    _result_cell,
+)
+
+
+def _run(name, *, n_fib=0, n_fm=0, n_poi=0, result=None):
+    inp = CorrelationInputData(
+        fib_coordinates=[
+            Coordinate(point=PointXYZ(x=float(i)), point_type=PointType.FIB)
+            for i in range(n_fib)
+        ],
+        fm_coordinates=[
+            Coordinate(point=PointXYZ(x=float(i)), point_type=PointType.FM)
+            for i in range(n_fm)
+        ],
+        poi_coordinates=[
+            Coordinate(point=PointXYZ(x=float(i)), point_type=PointType.POI)
+            for i in range(n_poi)
+        ],
+    )
+    state = CorrelationState(input_data=inp, result=result)
+    return CorrelationRun(path=f"/tmp/{name}", name=name, state=state)
+
+
+def _history(*runs) -> LamellaCorrelation:
+    return LamellaCorrelation(runs=list(runs))
+
+
+# oldest-first, as LamellaCorrelation.discover returns
+OLD = "2026-07-20_09-00-00"
+NEW = "2026-07-24_14-00-00"
+
+
+def test_rows_are_newest_first_and_latest_preselected(qapp):
+    dlg = CorrelationHistoryDialog(_history(_run(OLD), _run(NEW)))
+    # display order is newest-first: row 0 is NEW, row 1 is OLD
+    assert dlg.table.item(0, 0).text() == _format_timestamp(NEW)
+    assert dlg.table.item(1, 0).text() == _format_timestamp(OLD)
+    # newest row pre-selected
+    assert dlg.table.currentRow() == 0
+
+
+def test_seed_from_selected_returns_the_selected_run(qapp):
+    dlg = CorrelationHistoryDialog(_history(_run(OLD), _run(NEW)))
+    dlg.table.selectRow(1)  # the older run
+    dlg._accept_selected()
+    assert dlg.result() == QDialog.Accepted
+    assert dlg.selected_run is not None
+    assert dlg.selected_run.name == OLD
+
+
+def test_default_selection_seeds_the_newest(qapp):
+    dlg = CorrelationHistoryDialog(_history(_run(OLD), _run(NEW)))
+    dlg._accept_selected()  # no explicit selection change -> newest (row 0)
+    assert dlg.selected_run.name == NEW
+
+
+def test_start_fresh_accepts_with_no_run(qapp):
+    dlg = CorrelationHistoryDialog(_history(_run(OLD), _run(NEW)))
+    dlg._start_fresh()
+    assert dlg.result() == QDialog.Accepted
+    assert dlg.selected_run is None
+
+
+def test_points_summary_counts_each_type(qapp):
+    dlg = CorrelationHistoryDialog(_history(_run(OLD, n_fib=4, n_fm=3, n_poi=1)))
+    assert dlg.table.item(0, 1).text() == "4 FIB · 3 FM · 1 POI"
+
+
+def test_points_summary_empty_is_dash():
+    assert _points_summary(CorrelationState(input_data=CorrelationInputData())) == "—"
+
+
+def test_result_cell_no_result_vs_rms():
+    no_result = CorrelationState(input_data=CorrelationInputData())
+    text, _ = _result_cell(no_result)
+    assert text == "No result"
+
+    inp = CorrelationInputData(
+        fib_coordinates=[Coordinate(point=PointXYZ(x=1.0), point_type=PointType.FIB)]
+    )
+    # a result whose snapshot matches the state's inputs -> current, not stale
+    result = CorrelationResult(
+        poi=[CorrelationPointOfInterest()],
+        rms_error=1.234,
+        input_data=CorrelationInputData(
+            fib_coordinates=[
+                Coordinate(point=PointXYZ(x=1.0), point_type=PointType.FIB)
+            ]
+        ),
+    )
+    text, _ = _result_cell(CorrelationState(input_data=inp, result=result))
+    assert text == "1.23 px RMS"
+
+
+def test_result_cell_flags_stale_when_inputs_diverge():
+    # state's current inputs differ from the result's fitted snapshot -> stale
+    inp = CorrelationInputData(
+        fib_coordinates=[Coordinate(point=PointXYZ(x=9.0), point_type=PointType.FIB)]
+    )
+    result = CorrelationResult(
+        poi=[CorrelationPointOfInterest()],
+        rms_error=2.0,
+        input_data=CorrelationInputData(
+            fib_coordinates=[
+                Coordinate(point=PointXYZ(x=1.0), point_type=PointType.FIB)
+            ]
+        ),
+    )
+    text, _ = _result_cell(CorrelationState(input_data=inp, result=result))
+    assert "stale" in text
+
+
+def test_format_timestamp_reformats_and_falls_back():
+    assert _format_timestamp("2026-07-24_14-30-05") == "2026-07-24 14:30:05"
+    # a non-conforming folder name is shown verbatim, not dropped
+    assert _format_timestamp("not-a-timestamp") == "not-a-timestamp"


### PR DESCRIPTION
Phase 3 of the correlation-persistence work ([design doc](https://linear.app/fibsemos/document/correlation-persistence-and-the-lamella-correlation-workflow-e3221e1a64bc)). Closes FIB-301.

## What

Phase 2 ([#178](https://github.com/fibsem-os/fibsem-os/pull/178), FIB-299) seeds a re-correlation from the lamella's **newest** run, silently. This adds a picker so the user can **see** the prior runs and **choose** which to seed from — or start fresh — instead of being locked to the newest.

On opening correlation for a lamella with **≥2** prior runs, a modal `CorrelationHistoryDialog` lists them:

| When | Points | Result |
|---|---|---|
| 2026-07-24 14:05:22 *(selected)* | 5 FIB · 5 FM · 1 POI | No result |
| 2026-07-22 15:40:51 | 5 FIB · 4 FM · 1 POI | 1.42 px RMS · **stale** |
| 2026-07-20 09:12:03 | 4 FIB · 4 FM · 1 POI | 0.83 px RMS |

- Newest is pre-selected, so the common case is still one keystroke.
- Pick an older run to seed from, or **Start fresh** (no seed).
- The **stale** flag reuses FIB-295's `matches_inputs` — it marks a run whose transform no longer matches its own coordinates, so you don't unknowingly build on a bad re-correlation.

## Scope / no behaviour change for the common path

With **0 or 1** prior runs there's nothing to choose, so the picker doesn't appear — it seeds the newest silently, exactly as phase 2 did. No friction added.

The dialog is a **pure chooser**: it returns the selected `CorrelationRun` (or `None` for "start fresh") and never mutates the on-disk history. `Cancel` aborts opening the correlation tool.

Delivers the "per-lamella indexing of past correlations + load-on-open" half of FIB-257; the "embed result/status in the protocol editor" half remains a separate follow-up.

## Changes

- **`fibsem/correlation/ui/widgets/correlation_history_dialog.py`** (new) — `CorrelationHistoryDialog`, napari-dark, over the `LamellaCorrelation` history view from FIB-299.
- **`fibsem/ui/widgets/autolamella_lamella_protocol_editor.py`** — `_open_correlation_dialog` shows the picker when `len(history.runs) >= 2` and seeds from `picker.selected_run`.
- **`tests/correlation/test_correlation_history_dialog.py`** (new) — 9 tests.

## Testing

- 9 new tests + full correlation suite green (211 passed / 7 skipped).
- Newest-first ordering and the stale flag both mutation-verified (revert the behaviour → the test fails).