### PR TITLE
Correlation: seed FIB fiducials from spot burns on a first correlation (FIB-259)

### DIFF
--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -99,7 +99,7 @@ from fibsem.correlation.ui.widgets.fm_image_display_widget import (
 )
 from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
 from fibsem.fm.structures import FluorescenceImage
-from fibsem.structures import FibsemImage
+from fibsem.structures import FibsemImage, Point
 from fibsem.ui.widgets.custom_widgets import (
     QDirectoryLineEdit,
     QFileLineEdit,
@@ -1660,6 +1660,34 @@ class CorrelationTabWidget(QWidget):
             self._rescale_fm_z(src_z / cur_z)
         self.data_changed.emit(self.data)
 
+    def seed_fib_fiducials_from_spot_burns(self, coordinates: List[Point]) -> None:
+        """Seed FIB fiducials from spot-burn coordinates for a first correlation (FIB-259).
+
+        Spot burns are stored normalised (0-1) to the FIB image they were placed
+        on — the same image this correlation opens on — so multiply by that image's
+        pixel dimensions to get the absolute-pixel fiducials the canvas and fits
+        use. Only the FIB side is seeded; the FM side stays empty for the user to
+        pick. No-op without a FIB image or coordinates.
+        """
+        if self._fib_image is None or not coordinates:
+            return
+        h, w = self._fib_image.data.shape[:2]
+        fib_coords = [
+            Coordinate(
+                point=PointXYZ(x=pt.x * w, y=pt.y * h, z=0.0),
+                point_type=PointType.FIB,
+            )
+            for pt in coordinates
+        ]
+        self.set_data(
+            CorrelationInputData(
+                fib_coordinates=fib_coords,
+                fib_image=self._fib_image,
+                fm_image=self._fm_image,
+            )
+        )
+        self.data_changed.emit(self.data)
+
     def load_data(self, path: str) -> None:
         """Load a legacy coordinates file, preserving current images.
 
@@ -2640,6 +2668,9 @@ class CorrelationTabDialog(QDialog):
 
     def seed_coordinates(self, source: "CorrelationInputData") -> None:
         self.widget.seed_coordinates(source)
+
+    def seed_fib_fiducials_from_spot_burns(self, coordinates: "List[Point]") -> None:
+        self.widget.seed_fib_fiducials_from_spot_burns(coordinates)
 
     @property
     def correlation_config(self) -> "CorrelationConfig":

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -1030,10 +1030,22 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         if fm_image is not None:
             dialog.set_fm_image(fm_image)
 
-        # Seed the coordinates from the chosen run (after the current images are
-        # set, so FM z can be rescaled to this volume's z-sampling). FIB-299.
+        # Seed the coordinates (after the current images are set, so FM z can be
+        # rescaled to this volume's z-sampling). A previous run seeds a
+        # re-correlation (FIB-299/301); with no previous run, the spot burns seed
+        # a first correlation's FIB fiducials (FIB-259). The two are exclusive: the
+        # burns are normalised to the setup FIB image, so they only map cleanly
+        # before milling — exactly the no-previous-run case.
         if seed_run is not None and seed_run.state.input_data is not None:
             dialog.seed_coordinates(seed_run.state.input_data)
+        elif (
+            not history.runs
+            and protocol is not None
+            and protocol.correlation.load_spot_burns
+        ):
+            spot_burns = self._spot_burn_coordinates(selected_lamella)
+            if spot_burns:
+                dialog.seed_fib_fiducials_from_spot_burns(spot_burns)
 
         if dialog.exec_() != QDialog.Accepted:
             return
@@ -1045,6 +1057,18 @@ class AutoLamellaProtocolEditorWidget(QWidget):
 
         if dialog.result is not None:
             self._handle_correlation_dialog_result(dialog.result)
+
+    @staticmethod
+    def _spot_burn_coordinates(lamella: Lamella) -> List[Point]:
+        """The lamella's spot-burn fiducial coordinates, or [] if it has none.
+
+        Matched by config type — there's no fixed task-name key. Coordinates are
+        normalised (0-1) to the lamella's FIB reference image (FIB-259).
+        """
+        for cfg in lamella.task_config.values():
+            if isinstance(cfg, SpotBurnFiducialTaskConfig):
+                return list(cfg.coordinates)
+        return []
 
     def _handle_correlation_dialog_result(self, result: "CorrelationResult") -> None:
         """Handle the CorrelationResult returned from CorrelationTabDialog."""

--- a/tests/correlation/test_spot_burn_seeding.py
+++ b/tests/correlation/test_spot_burn_seeding.py
@@ -1,0 +1,117 @@
+"""Seeding correlation FIB fiducials from spot-burn coordinates (FIB-259).
+
+Spot burns are stored normalised (0-1, top-left origin, no y-flip) to the FIB
+image they were placed on. The correlation widget converts them to absolute FIB
+pixels (the frame the canvas and fits use); the protocol editor picks the burns
+off the lamella and only for a first correlation. Headless PyQt5, offscreen.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import types
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.correlation.structures import PointType
+from fibsem.structures import FibsemImage, Point
+
+
+@pytest.fixture(autouse=True)
+def _no_lut_download(monkeypatch):
+    """Never hit the network for the zeta LUT during widget construction."""
+    import fibsem.correlation.ui.widgets.refractive_index_widget as riw
+
+    monkeypatch.setattr(riw, "_ensure_lut", lambda: None)
+
+
+def _widget():
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        CorrelationTabWidget,
+    )
+
+    return CorrelationTabWidget()
+
+
+def _fib_image():
+    # resolution=(W, H) -> data.shape == (H, W)
+    return FibsemImage.generate_blank_image(resolution=(300, 200), hfw=100e-6)
+
+
+# ---------------------------------------------------------------------------
+# widget: normalised -> pixel conversion
+# ---------------------------------------------------------------------------
+
+
+def test_seed_converts_normalised_to_pixels(qapp):
+    w = _widget()
+    img = _fib_image()
+    w.set_fib_image(img)
+    h, wd = img.data.shape[:2]  # (200, 300)
+
+    w.seed_fib_fiducials_from_spot_burns([Point(0.25, 0.5), Point(1.0, 0.0)])
+
+    fib = w.data.fib_coordinates
+    assert len(fib) == 2
+    assert fib[0].point.x == pytest.approx(0.25 * wd)  # 75.0
+    assert fib[0].point.y == pytest.approx(0.5 * h)    # 100.0
+    assert fib[0].point.z == 0.0
+    assert fib[0].point_type is PointType.FIB
+    assert fib[0].fitted is False                       # a seed, not an accepted fit
+    assert fib[1].point.x == pytest.approx(1.0 * wd)
+    assert fib[1].point.y == pytest.approx(0.0)
+
+
+def test_seed_only_touches_fib_side(qapp):
+    w = _widget()
+    w.set_fib_image(_fib_image())
+    w.seed_fib_fiducials_from_spot_burns([Point(0.1, 0.1), Point(0.2, 0.2)])
+    d = w.data
+    assert len(d.fib_coordinates) == 2
+    assert d.fm_coordinates == []
+    assert d.poi_coordinates == []
+
+
+def test_seed_noop_without_fib_image(qapp):
+    w = _widget()  # no set_fib_image
+    w.seed_fib_fiducials_from_spot_burns([Point(0.5, 0.5)])
+    assert w.data.fib_coordinates == []
+
+
+def test_seed_noop_with_empty_coordinates(qapp):
+    w = _widget()
+    w.set_fib_image(_fib_image())
+    w.seed_fib_fiducials_from_spot_burns([])
+    assert w.data.fib_coordinates == []
+
+
+# ---------------------------------------------------------------------------
+# protocol editor: locate the spot-burn config on a lamella
+# ---------------------------------------------------------------------------
+
+
+def test_spot_burn_coordinates_matches_by_type():
+    from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
+        SpotBurnFiducialTaskConfig,
+    )
+    from fibsem.ui.widgets.autolamella_lamella_protocol_editor import (
+        AutoLamellaProtocolEditorWidget,
+    )
+
+    burns = [Point(0.1, 0.2), Point(0.3, 0.4)]
+    spot = SpotBurnFiducialTaskConfig(task_name="spot", coordinates=burns)
+    # a non-spot config in the mix (any object that isn't the spot-burn type)
+    lamella = types.SimpleNamespace(task_config={"other": object(), "burn": spot})
+
+    assert AutoLamellaProtocolEditorWidget._spot_burn_coordinates(lamella) == burns
+
+
+def test_spot_burn_coordinates_empty_when_absent():
+    from fibsem.ui.widgets.autolamella_lamella_protocol_editor import (
+        AutoLamellaProtocolEditorWidget,
+    )
+
+    lamella = types.SimpleNamespace(task_config={"other": object()})
+    assert AutoLamellaProtocolEditorWidget._spot_burn_coordinates(lamella) == []


### PR DESCRIPTION
Phase 4 of the correlation-persistence work ([design doc](https://linear.app/fibsemos/document/correlation-persistence-and-the-lamella-correlation-workflow-e3221e1a64bc)). Closes FIB-259.

## What

When opening a lamella's **first** correlation (no previous run) with `load_spot_burns` enabled, the FIB fiducials are now pre-seeded from the lamella's spot-burn coordinates — so you don't re-click points you already placed during spot-burn setup.

Spot burns are stored **normalised (0–1)** to the FIB reference image (top-left origin, no y-flip). The correlation tool opens on that **same** image, so they convert cleanly to the absolute FIB pixels the canvas and fits use: `x_px = x·W`, `y_px = y·H`, `z = 0`. Only the FIB side is seeded; the FM side stays empty for the user to pick.

## Exclusive with seed-from-previous

This never fights the phase-2/3 "seed from previous run" path:

- **≥1 previous run** → seed from history (FIB-299/301); spot burns are *not* used.
- **no previous run** → spot burns seed the first correlation.

The burns are normalised to the *setup* FIB image, so they only map cleanly **before milling** — exactly the no-previous-run case. After milling the burns would be re-detected, not trusted from stored coords, which is why re-correlations use history instead.

The `CorrelationConfig.load_spot_burns` flag has existed since phase 1 (FIB-298) but was inert; this wires it up.

## Changes

- **`fibsem/correlation/ui/widgets/correlation_tab_widget.py`** — `CorrelationTabWidget.seed_fib_fiducials_from_spot_burns()` (+ `CorrelationTabDialog` passthrough): normalised → pixel conversion via the FIB image shape, seeds FIB only.
- **`fibsem/ui/widgets/autolamella_lamella_protocol_editor.py`** — `_open_correlation_dialog` first-correlation gate; `_spot_burn_coordinates(lamella)` helper (locates the `SpotBurnFiducialTaskConfig` by type).
- **`tests/correlation/test_spot_burn_seeding.py`** (new) — 6 tests.

## Testing

- 6 new tests + full correlation suite green (217 passed / 7 skipped).
- The pixel conversion and the type-match helper are both mutation-verified.