### PR TITLE
[fix] qtawesome complaint at scios startup about spinner object

### DIFF
--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -643,7 +643,8 @@ class _SpinnerLabel(QLabel):
 
     def stop(self):
         self._active = False
-        self._spin.stop()
+        if self._spin is not None and self._spin.parent_widget in self._spin.info:
+            self._spin.stop()
         self.update()        # repaint blank
 
     def clear(self):


### PR DESCRIPTION
Starting fibsem-os on a TFS Scios leads to a qtawesome error where a spinner animation is calling stop before it was started. This prevents any startup of the application. A check before trying to stop the spinner animation resolves the issue.

<img width="1956" height="904" alt="20260724_155346" src="https://github.com/user-attachments/assets/50222d53-824d-428d-9145-4f1974fc3858" />


