### PR TITLE
[feat] milling: make the post-task FIB refresh opt-out (FIB-307)

### DIFF
--- a/fibsem/milling/tasks.py
+++ b/fibsem/milling/tasks.py
@@ -32,6 +32,12 @@ class MillingTaskAcquisitionSettings:
                               metadata={
                                   "label": "Acquire FIB Image",
                                   "tooltip": "Whether to acquire FIB images between the milling task stages."})
+    acquire_final_image: bool = field(default=True,
+                                      metadata={
+                                          "label": "Acquire Final Image",
+                                          "tooltip": "Refresh the FIB view with a single image once the task finishes. "
+                                                     "Disable for low-kV polishing, where imaging the lamella with a "
+                                                     "higher-voltage beam undoes the polish."})
     imaging: ImageSettings = field(default_factory=ImageSettings)
 
     @property
@@ -49,6 +55,7 @@ class MillingTaskAcquisitionSettings:
         return {
             "acquire_sem": self.acquire_sem,
             "acquire_fib": self.acquire_fib,
+            "acquire_final_image": self.acquire_final_image,
             "imaging": self.imaging.to_dict(),
         }
 
@@ -60,6 +67,9 @@ class MillingTaskAcquisitionSettings:
         return cls(
             acquire_sem=data.get("acquire_sem", False),
             acquire_fib=data.get("acquire_fib", False),
+            # default True so protocols written before this flag existed keep the
+            # post-task FIB refresh they have always had
+            acquire_final_image=data.get("acquire_final_image", True),
             imaging=ImageSettings.from_dict(imaging),
         )
 
@@ -259,8 +269,10 @@ class FibsemMillingTask:
     def _post_task_acquisition(self) -> None:
         """Acquire an image after finishing the milling task."""
         try:
-            # acquire an image after finishing the task, if not already done
-            if not self.config.acquisition.enabled and not self.config.acquisition.acquire_fib:
+            # refresh the view with a single image if the task didn't already acquire one.
+            # NB: acquisition.enabled is (acquire_sem or acquire_fib), so it subsumes the
+            # acquire_fib check this condition used to carry.
+            if self.config.acquisition.acquire_final_image and not self.config.acquisition.enabled:
                 self.microscope.autocontrast(beam_type=self.config.channel)
                 fib_image = self.microscope.acquire_image(image_settings=None, beam_type=self.config.channel)
                 self.microscope.fib_acquisition_signal.emit(fib_image)

--- a/tests/milling/test_tasks.py
+++ b/tests/milling/test_tasks.py
@@ -1,8 +1,13 @@
 import pytest
 
+from fibsem import utils
 from fibsem.milling.base import FibsemMillingStage
 from fibsem.milling.patterning.patterns2 import RectanglePattern
-from fibsem.milling.tasks import FibsemMillingTaskConfig, MillingTaskAcquisitionSettings
+from fibsem.milling.tasks import (
+    FibsemMillingTask,
+    FibsemMillingTaskConfig,
+    MillingTaskAcquisitionSettings,
+)
 from fibsem.structures import FibsemMillingSettings, ImageSettings
 
 
@@ -63,3 +68,64 @@ def test_milling_task_config_estimated_time_multiple_stages():
     )
     cfg = FibsemMillingTaskConfig(stages=[stage1, stage2])
     assert cfg.estimated_time == pytest.approx(stage1.estimated_time + stage2.estimated_time)
+
+
+# ── the post-task image refresh is opt-out ───────────────────────────────────
+#
+# A milling task ends by acquiring one FIB image to refresh the view, when the task
+# didn't already acquire one of its own. That is the right default, but it has never
+# been switchable — and for a low-kV polish, imaging the lamella with a higher-voltage
+# beam undoes the polish.
+
+def _spy(obj, name):
+    """Replace ``obj.name`` with a wrapper that records calls, returns the recorder."""
+    calls = []
+    orig = getattr(obj, name)
+
+    def wrapper(*a, **k):
+        calls.append((a, k))
+        return orig(*a, **k)
+
+    setattr(obj, name, wrapper)
+    return calls
+
+
+def _task(tmp_path, **acquisition):
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    cfg = FibsemMillingTaskConfig.from_stages(stages=[FibsemMillingStage(name="s")], name="t")
+    cfg.acquisition.imaging.path = str(tmp_path)
+    # drift correction acquires its own images; switch it off so the assertions below
+    # are about the post-task refresh and nothing else
+    cfg.alignment.enabled = False
+    for key, value in acquisition.items():
+        setattr(cfg.acquisition, key, value)
+    return microscope, FibsemMillingTask(microscope, cfg)
+
+
+def test_final_image_is_acquired_by_default(tmp_path):
+    microscope, task = _task(tmp_path)
+    assert task.config.acquisition.acquire_final_image is True
+
+    acquired = _spy(microscope, "acquire_image")
+    task.run()
+
+    assert acquired, "the post-task FIB refresh should fire by default"
+
+
+def test_final_image_can_be_suppressed(tmp_path):
+    microscope, task = _task(tmp_path, acquire_final_image=False)
+
+    acquired = _spy(microscope, "acquire_image")
+    task.run()
+
+    assert acquired == [], "no image should be acquired when the final refresh is off"
+
+
+def test_final_image_defaults_to_true_for_protocols_predating_the_flag():
+    assert MillingTaskAcquisitionSettings.from_dict({}).acquire_final_image is True
+
+
+def test_final_image_flag_round_trips():
+    settings = MillingTaskAcquisitionSettings(acquire_final_image=False)
+    restored = MillingTaskAcquisitionSettings.from_dict(settings.to_dict())
+    assert restored.acquire_final_image is False


### PR DESCRIPTION
First of six small PRs splitting FIB-307 (milling voltage safety fixes). Each one
targets a different failure mode, so they review better separately.

## What

`FibsemMillingTask` ends by acquiring one FIB image to refresh the view, when the
task did not already acquire one of its own. That is deliberate — it has been there
since the task layer was written, and `FibsemImageSettingsWidget` consumes the
resulting `fib_acquisition_signal` to update the displayed FIB image.

It has never been switchable, though. For the low-kV polishing work in FIB-306,
imaging a freshly polished lamella with a higher-voltage beam undoes the polish, so
a task needs to be able to finish without one.

Adds `MillingTaskAcquisitionSettings.acquire_final_image`, default `True`.

## Notes for review

- **No behaviour change for anything shipping today.** The field defaults to `True`
  and `from_dict` defaults it to `True`, so protocols written before the flag exists
  keep the refresh they have always had.
- **The redundant clause is gone.** The condition was
  `not acquisition.enabled and not acquisition.acquire_fib`. `enabled` is
  `acquire_sem or acquire_fib`, so `not enabled` already implied `not acquire_fib`.
- **Not exposed in the UI.** `MillingTaskAcquisitionSettingsWidget` builds its
  checkboxes explicitly rather than from field metadata, and mutates the stored
  settings in place, so the new flag survives a UI round-trip untouched. Setting it
  is a protocol-level concern for now; surfacing it fits more naturally alongside the
  exposure policy in FIB-314.

## Tests

Four tests in `tests/milling/test_tasks.py`, which already covers
`MillingTaskAcquisitionSettings`: default acquires, `False` suppresses,
`from_dict({})` yields `True`, and the flag round-trips.

The suppression test was confirmed to fail against the unfixed condition.
Full suite: 860 passed, 15 skipped.