### PR TITLE
Correlation: fix four paths that let wrong data reach the experiment or disk

### DIFF
--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -277,34 +277,6 @@ def _transform_inputs(data: CorrelationInputData) -> dict:
     }
 
 
-def _image_inputs_match(a: CorrelationInputData, b: CorrelationInputData) -> bool:
-    """Whether the FIB image parameters agree, where both sides know them.
-
-    The FIB image is an input to the answer: its shape sets the centre and its
-    pixel size the metres scaling of the reprojected POI, so swapping to an image
-    at a different magnification changes ``px_m`` (FIB-317) — a result fitted
-    against the old one is stale.
-
-    Compared pairwise, skipping any value that is ``None`` on either side: a file
-    written without these fields tells us nothing about the image it was fitted
-    to, and *absence of information is not evidence of change*. Judging it would
-    report every such reloaded result as stale, which is the failure mode the
-    staleness signal exists to avoid.
-    """
-    pairs = (
-        (a.fib_image_shape, b.fib_image_shape),
-        (a.fib_image_pixel_size, b.fib_image_pixel_size),
-    )
-    for lhs, rhs in pairs:
-        if lhs is None or rhs is None:
-            continue
-        left = tuple(lhs) if isinstance(lhs, (tuple, list)) else lhs
-        right = tuple(rhs) if isinstance(rhs, (tuple, list)) else rhs
-        if left != right:
-            return False
-    return True
-
-
 @dataclass
 class CorrelationPointOfInterest:
     """A single POI reprojected into the FIB image, in multiple coordinate systems."""
@@ -580,20 +552,18 @@ class CorrelationResult:
         :func:`_transform_inputs`); notably **excluded**:
 
           * ``fitted`` — provenance on a Coordinate, not a position;
-          * ``method`` — not read by ``run_correlation_from_data``.
+          * ``method`` — not read by ``run_correlation_from_data``;
+          * anything image-derived — see below.
 
-        The FIB image's shape and pixel size *are* compared, but only where both
-        sides know them — see :func:`_image_inputs_match`. They change the
-        answer, yet a result deserialized from a file that omits them says
-        nothing about the image it was fitted to.
+        Image parameters are *not* compared: changing the image now clears the
+        coordinates outright (see ``_confirm_image_change``), so a result can no
+        longer outlive the image it was fitted to by this route.
 
         A result with no snapshot can't be shown to match, so it reports False.
         """
         if self.input_data is None:
             return False
-        if _transform_inputs(self.input_data) != _transform_inputs(current):
-            return False
-        return _image_inputs_match(self.input_data, current)
+        return _transform_inputs(self.input_data) == _transform_inputs(current)
 
     def save(self, filename: str) -> None:
         with open(filename, "w") as f:

--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field
 from enum import auto, Enum
 from typing import Optional
@@ -137,15 +138,26 @@ class CorrelationInputData:
 
     @property
     def fib_image_pixel_size(self) -> Optional[float]:
+        """Pixel size in metres, falling back to the value restored from JSON.
+
+        A plain (non-OME) TIFF loads with ``metadata = None``, and this property is
+        read by ``to_dict`` — i.e. by every auto-save. Dereferencing it blindly
+        turned "the user browsed to a bare TIFF" into "nothing is ever saved this
+        session", because the auto-save swallows exceptions (FIB-316).
+        """
         if self.fib_image is None:
             return self.stored_fib_image_pixel_size
-        return self.fib_image.metadata.pixel_size.x  # type: ignore[union-attr]
+        pixel_size = getattr(getattr(self.fib_image, "metadata", None), "pixel_size", None)
+        if pixel_size is None:
+            return self.stored_fib_image_pixel_size
+        return getattr(pixel_size, "x", None)
 
     @property
     def fib_image_shape(self) -> Optional[tuple[int, int]]:
-        if self.fib_image is None or self.fib_image.data is None:
+        data = getattr(self.fib_image, "data", None)
+        if data is None:
             return self.stored_fib_image_shape
-        return self.fib_image.data.shape
+        return data.shape
 
     @property
     def fm_image_shape(self) -> Optional[tuple[int, int, int, int]]:
@@ -161,13 +173,16 @@ class CorrelationInputData:
 
     @property
     def fib_image_filename(self) -> Optional[str]:
-        return (
-            self.fib_image.metadata.image_settings.filename if self.fib_image else None
+        # Also read by to_dict, so it must tolerate an image without metadata
+        # rather than take the auto-save down with it (FIB-316).
+        settings = getattr(
+            getattr(self.fib_image, "metadata", None), "image_settings", None
         )
+        return getattr(settings, "filename", None)
 
     @property
     def fm_image_filename(self) -> Optional[str]:
-        return self.fm_image.metadata.filename if self.fm_image else None
+        return getattr(getattr(self.fm_image, "metadata", None), "filename", None)
 
     @staticmethod
     def from_dict(data: dict) -> CorrelationInputData:
@@ -260,6 +275,34 @@ def _transform_inputs(data: CorrelationInputData) -> dict:
         # genuinely changes the answer (see run_correlation_from_data).
         "ri_pre_correction_factor": data.ri_pre_correction_factor,
     }
+
+
+def _image_inputs_match(a: CorrelationInputData, b: CorrelationInputData) -> bool:
+    """Whether the FIB image parameters agree, where both sides know them.
+
+    The FIB image is an input to the answer: its shape sets the centre and its
+    pixel size the metres scaling of the reprojected POI, so swapping to an image
+    at a different magnification changes ``px_m`` (FIB-317) — a result fitted
+    against the old one is stale.
+
+    Compared pairwise, skipping any value that is ``None`` on either side: a file
+    written without these fields tells us nothing about the image it was fitted
+    to, and *absence of information is not evidence of change*. Judging it would
+    report every such reloaded result as stale, which is the failure mode the
+    staleness signal exists to avoid.
+    """
+    pairs = (
+        (a.fib_image_shape, b.fib_image_shape),
+        (a.fib_image_pixel_size, b.fib_image_pixel_size),
+    )
+    for lhs, rhs in pairs:
+        if lhs is None or rhs is None:
+            continue
+        left = tuple(lhs) if isinstance(lhs, (tuple, list)) else lhs
+        right = tuple(rhs) if isinstance(rhs, (tuple, list)) else rhs
+        if left != right:
+            return False
+    return True
 
 
 @dataclass
@@ -537,16 +580,20 @@ class CorrelationResult:
         :func:`_transform_inputs`); notably **excluded**:
 
           * ``fitted`` — provenance on a Coordinate, not a position;
-          * ``method`` — not read by ``run_correlation_from_data``;
-          * anything image-derived — a deserialized result carries no images, so
-            e.g. ``fm_image_shape`` is None on this side and populated on the
-            live side, which would report every reloaded result as stale.
+          * ``method`` — not read by ``run_correlation_from_data``.
+
+        The FIB image's shape and pixel size *are* compared, but only where both
+        sides know them — see :func:`_image_inputs_match`. They change the
+        answer, yet a result deserialized from a file that omits them says
+        nothing about the image it was fitted to.
 
         A result with no snapshot can't be shown to match, so it reports False.
         """
         if self.input_data is None:
             return False
-        return _transform_inputs(self.input_data) == _transform_inputs(current)
+        if _transform_inputs(self.input_data) != _transform_inputs(current):
+            return False
+        return _image_inputs_match(self.input_data, current)
 
     def save(self, filename: str) -> None:
         with open(filename, "w") as f:
@@ -635,7 +682,15 @@ def load_correlation_file(filename: str) -> CorrelationState:
 
     if "poi" in data or "computed_from" in data or "input_data" in data:
         result = CorrelationResult.from_dict(data)
-        current = result.input_data or CorrelationInputData()
+        # Deep-copy rather than share: the result's input_data is the *snapshot*
+        # the transform was fitted to, while the state's is the live, editable
+        # set. Aliasing them makes every later edit mutate the snapshot too, so
+        # matches_inputs can never report stale — FIB-295 defeated by identity.
+        current = (
+            copy.deepcopy(result.input_data)
+            if result.input_data is not None
+            else CorrelationInputData()
+        )
         return CorrelationState(input_data=current, result=result)
 
     if "fib_coordinates" in data:

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -96,6 +96,7 @@ from fibsem.correlation.ui.widgets.fit_confirmation_dialog import (
 )
 from fibsem.ui import notification_service, stylesheets
 from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.utils import install_wheel_blocker
 from fibsem.correlation.ui.widgets.fm_image_display_widget import (
     IMAGE_HEADER_STYLE,
     FMImageDisplayWidget,
@@ -302,6 +303,9 @@ class _ImagePicker(QWidget):
         self.combo = QComboBox()
         # Match the 11-12px panels around it; the default app font reads oversized.
         self.combo.setStyleSheet("font-size: 12px;")
+        install_wheel_blocker(self.combo)
+        # Changing the image discards the coordinates, so a wheel scroll passing
+        # over this combo must never be able to trigger it.
         self.combo.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
         self.combo.setMinimumContentsLength(12)
         self.combo.activated.connect(self._on_activated)
@@ -369,6 +373,9 @@ class _ImagesTab(QWidget):
         # when the editable path widget re-emits editingFinished (focus-out).
         self._fib_loaded_path: str = ""
         self._fm_loaded_path: str = ""
+        # Asked before a *user-driven* image load, so the owner can confirm
+        # discarding the coordinates. None = no guard (standalone use).
+        self.confirm_image_change: Optional[Callable[[], bool]] = None
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -518,7 +525,19 @@ class _ImagesTab(QWidget):
         p = self._proj_path.text().strip()
         return p if p else None
 
+    def _allow_image_change(self) -> bool:
+        """Whether a user-driven image load may proceed (FIB-317).
+
+        Only the picker paths ask. Programmatic ``set_fib_image`` /
+        ``set_fm_image`` — how the lamella's images arrive on open — must never
+        prompt.
+        """
+        return self.confirm_image_change() if self.confirm_image_change else True
+
     def _load_fib(self, path: str) -> None:
+        if not self._allow_image_change():
+            self._fib_picker.show_path(self._fib_loaded_path)  # undo the selection
+            return
         try:
             image = FibsemImage.load(path)
         except Exception as exc:
@@ -537,6 +556,9 @@ class _ImagesTab(QWidget):
         self.fib_image_changed.emit(image)
 
     def _load_fm(self, path: str) -> None:
+        if not self._allow_image_change():
+            self._fm_picker.show_path(self._fm_loaded_path)  # undo the selection
+            return
         try:
             image = FluorescenceImage.load(path)
         except Exception as exc:
@@ -1465,6 +1487,7 @@ class CorrelationTabWidget(QWidget):
         # Right: tab widget stacked above run button
         self._tabs = QTabWidget()
         self._images_tab = _ImagesTab()
+        self._images_tab.confirm_image_change = self._confirm_image_change
         self._coords_tab = _CoordinatesTab()
         self._results_tab = _ResultsTab()
         self._ri_tab = _RITab()
@@ -1816,6 +1839,44 @@ class CorrelationTabWidget(QWidget):
         self.data_changed.emit(self.data)
         if state.result is not None:
             self._load_result(state.result, adopt_inputs=False)
+
+    def _confirm_image_change(self) -> bool:
+        """Confirm discarding the coordinates before loading a different image.
+
+        Coordinates are pixel positions in a *specific* image. A different file is
+        a different scene — even at identical shape and pixel size the sample has
+        drifted or been milled — so the existing points no longer mark anything.
+        Keeping them produced off-image points, a coordinate list that displayed
+        clamped values while the data said otherwise, and a result that looked
+        current at the wrong scale (FIB-317).
+
+        Rescaling is deliberately not offered: scaling by the shape ratio is only
+        correct if the field of view is unchanged, and nothing in the files says
+        so. Interpolation rescales because there we *know* it is the same volume
+        resampled; here we know nothing, so we clear.
+
+        Returns True to proceed — clearing as a side effect — or False to leave
+        both the image and the coordinates untouched.
+        """
+        if not self._current_positions():
+            return True  # nothing to lose
+        reply = QMessageBox.question(
+            self,
+            "Change image?",
+            "Loading a different image will clear the current coordinates — they "
+            "mark positions in the image they were placed on.\n\n"
+            "Any correlation result is discarded with them.",
+            QMessageBox.Ok | QMessageBox.Cancel,
+            QMessageBox.Cancel,
+        )
+        if reply != QMessageBox.Ok:
+            return False
+        self.set_data(
+            CorrelationInputData(fib_image=self._fib_image, fm_image=self._fm_image)
+        )
+        self._discard_result()
+        self._seeded_positions = None
+        return True
 
     def _discard_result(self) -> None:
         """Drop the current result and everything that displays it.

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -1228,8 +1228,13 @@ class _RITab(QWidget):
             logging.warning("[RITab._apply_post] No result to update with correction.")
             return
 
-        # apply surface_y to the result for internal consistency (in case it wasn't set before)
-        self._result.input_data.surface_coordinate = self._surface_coordinate # type: ignore
+        # Record the surface this correction is about, as a *copy*: input_data is
+        # the snapshot the transform was fitted to. Storing the live coordinate
+        # would let a later drag of the surface line rewrite history — and, worse,
+        # launder an already-stale result back to "current" (FIB-315).
+        self._result.input_data.surface_coordinate = copy.deepcopy(  # type: ignore
+            self._surface_coordinate
+        )
 
         # Update POI 0 in the result and propagate (reads input_data internally)
         self._result.apply_refractive_index_correction(factor)
@@ -1361,6 +1366,9 @@ class CorrelationTabWidget(QWidget):
         # Positions as last seeded by the setup section, to detect manual edits
         # before replacing them (None = nothing seeded yet). FIB-302.
         self._seeded_positions: Optional[list] = None
+        # Last auto-save failure, held so the status line keeps reporting it
+        # instead of claiming "Ready." while nothing is saved (FIB-316).
+        self._autosave_error: Optional[str] = None
         # Pre-correlation RI factor (FM surface mode); set via the RI tab Apply
         self._ri_pre_correction_factor: Optional[float] = None
         # Experiment-global config; passed in on open, read back on close (FIB-298).
@@ -1672,6 +1680,11 @@ class CorrelationTabWidget(QWidget):
                 spec.list_widget.set_axis_maxima(x_max=w - 1, y_max=h - 1)
         self._images_tab.set_fib_image(fib_image)
         self._update_fib_name_label(fib_image)
+        # The image is an input to the fit, so swapping it invalidates the result
+        # and re-opens the readiness question. data_changed drives both (via
+        # _on_data_changed and _update_run_button) — without it, Continue stayed
+        # armed and committed a POI scaled by the *previous* image (FIB-317).
+        self.data_changed.emit(self.data)
 
     def _update_fib_name_label(self, image: FibsemImage) -> None:
         """Show the loaded FIB image's filename in the header (mirrors FM)."""
@@ -1700,6 +1713,9 @@ class CorrelationTabWidget(QWidget):
         self._apply_fit_config()
         self._seed_ri_from_fm_metadata(fm_image)
         self._images_tab.set_fm_image(fm_image)
+        # As for the FIB image: a new volume invalidates the result and changes
+        # what "ready to run" means (FIB-317).
+        self.data_changed.emit(self.data)
 
     @staticmethod
     def _effective_fm_pixel_size(fm_image: FluorescenceImage) -> Optional[float]:
@@ -1792,9 +1808,34 @@ class CorrelationTabWidget(QWidget):
         data.fib_image = self._fib_image
         data.fm_image = self._fm_image
         self.set_data(data)
+        # Discard *before* the emit: data_changed drives the auto-save, so
+        # clearing afterwards still writes the new inputs paired with the old
+        # result — the very thing FIB-318 is about.
+        if state.result is None:
+            self._discard_result()
         self.data_changed.emit(self.data)
         if state.result is not None:
             self._load_result(state.result, adopt_inputs=False)
+
+    def _discard_result(self) -> None:
+        """Drop the current result and everything that displays it.
+
+        Whenever the coordinates are replaced wholesale by a new source, any
+        result belongs to the *previous* points. Without this the old result
+        survives: its markers stay drawn over the new points, the Results tab
+        keeps its numbers, CSV export writes it, and — because the auto-save
+        pairs current inputs with ``self._result`` — it gets re-saved against
+        coordinates it was never computed from (FIB-318).
+        """
+        if self._result is None:
+            return
+        self._result = None
+        self._set_result_live(False)
+        self._results_tab.clear()
+        self._fib_canvas.clear_overlay()
+        self._ri_tab.set_result(
+            None, input_data=self.data, fm_pixel_size_z=self._fm_pixel_size_z()
+        )
 
     def seed_coordinates(self, source: CorrelationInputData) -> None:
         """Load a previous run's coordinates as starting points (FIB-299).
@@ -1811,6 +1852,7 @@ class CorrelationTabWidget(QWidget):
         self.set_data(source)
         if src_z and cur_z and abs(src_z - cur_z) > 1e-15:
             self._rescale_fm_z(src_z / cur_z)
+        self._discard_result()  # the seeded points are not what it was fitted to
         self.data_changed.emit(self.data)
 
     def seed_fib_fiducials_from_spot_burns(self, coordinates: List[Point]) -> None:
@@ -1839,6 +1881,7 @@ class CorrelationTabWidget(QWidget):
                 fm_image=self._fm_image,
             )
         )
+        self._discard_result()
         self.data_changed.emit(self.data)
 
     def add_lamella_setup(
@@ -1900,6 +1943,7 @@ class CorrelationTabWidget(QWidget):
                     fib_image=self._fib_image, fm_image=self._fm_image
                 )
             )
+            self._discard_result()
             self.data_changed.emit(self.data)
         self._seeded_positions = self._current_positions()
 
@@ -1937,6 +1981,7 @@ class CorrelationTabWidget(QWidget):
         loaded.fib_image = self._fib_image
         loaded.fm_image = self._fm_image
         self.set_data(loaded)
+        self._discard_result()
         self.data_changed.emit(self.data)
 
     def save_correlation(self, path: str) -> None:
@@ -2095,8 +2140,18 @@ class CorrelationTabWidget(QWidget):
             CorrelationState(input_data=self.data, result=self._result).save(
                 os.path.join(self._project_dir, CORRELATION_FILENAME)
             )
-        except Exception:
+        except Exception as exc:
+            # Never let this pass unseen: it is the only persistence path, so a
+            # swallowed failure silently discards the whole session's work
+            # (FIB-316). Sticky, because the status line is rewritten on every
+            # data change — a one-shot message would be gone before it was read.
             logging.exception("Auto-save of correlation project failed")
+            self._autosave_error = str(exc)
+            self._update_run_button()
+        else:
+            if self._autosave_error is not None:
+                self._autosave_error = None
+                self._update_run_button()
 
     # ------------------------------------------------------------------
     # Run correlation
@@ -2115,7 +2170,13 @@ class CorrelationTabWidget(QWidget):
             and len(d.fib_coordinates) == len(d.fm_coordinates)
         )
         self._btn_run.setEnabled(ok)
-        if running:
+        if self._autosave_error is not None:
+            # Outranks the readiness text: "Ready." while nothing is being saved
+            # is the most misleading thing this label could say (FIB-316).
+            self._lbl_status.setText(
+                f"Auto-save is failing — work is NOT being saved ({self._autosave_error})"
+            )
+        elif running:
             self._lbl_status.setText("Running…")
         elif self._fib_image is None or self._fm_image is None:
             self._lbl_status.setText("Load FIB and FM images to continue.")
@@ -2558,7 +2619,10 @@ class CorrelationTabWidget(QWidget):
         # _on_result_ready refreshes the run button and sets the final status
         # text itself — no trailing update here, it would overwrite the status.
         if adopt_inputs and result.input_data:
-            self.set_data(result.input_data)
+            # Deep-copy: the lists become editable, and sharing the Coordinate
+            # objects with the result's snapshot would make every edit mutate it
+            # too, permanently defeating matches_inputs (FIB-315).
+            self.set_data(copy.deepcopy(result.input_data))
         # Continue commits result.poi[0].px_m to the protocol editor, so a result
         # that predates the current points must not arm it.
         self._on_result_ready(result, live=result.matches_inputs(self.data))

--- a/tests/correlation/test_correlation_data_integrity.py
+++ b/tests/correlation/test_correlation_data_integrity.py
@@ -131,32 +131,90 @@ def test_autosave_failure_is_reported_not_swallowed(qapp, tmp_path, monkeypatch)
 
 
 # ---------------------------------------------------------------------------
-# FIB-317 — the image is an input; swapping it invalidates the result
+# FIB-317 — a different image means different coordinates
 # ---------------------------------------------------------------------------
 
 
-def test_swapping_the_fib_image_makes_a_result_stale(qapp):
+def _load_via_picker(w, monkeypatch, answer):
+    """Drive a user-initiated image load, answering the confirm with `answer`."""
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+    from PyQt5.QtWidgets import QMessageBox
+
+    monkeypatch.setattr(
+        ctw.FibsemImage,
+        "load",
+        staticmethod(
+            lambda p: FibsemImage.generate_blank_image(resolution=(768, 512), hfw=20e-6)
+        ),
+    )
+    monkeypatch.setattr(
+        ctw.QMessageBox, "question", staticmethod(lambda *a, **k: answer)
+    )
+    w._images_tab._load_fib("/lam/other_ib.tif")
+    return QMessageBox
+
+
+def test_changing_the_image_clears_coordinates_and_result(qapp, monkeypatch):
+    from PyQt5.QtWidgets import QMessageBox
+
     w = _widget()
     w.set_fib_image(FibsemImage.generate_blank_image(resolution=(1536, 1024), hfw=80e-6))
-    result = _result(w.data)
-    w._load_result(result, adopt_inputs=False)
-    assert w._btn_continue.isEnabled() is True
+    w.set_data(_inputs(x=1382.0))
+    w._load_result(_result(w.data), adopt_inputs=False)
 
-    # a different magnification changes the metres scaling of the POI
-    w.set_fib_image(FibsemImage.generate_blank_image(resolution=(1536, 1024), hfw=20e-6))
-    assert result.matches_inputs(w.data) is False
-    assert w._btn_continue.isEnabled() is False
+    _load_via_picker(w, monkeypatch, QMessageBox.Ok)
+
+    assert w.data.fib_coordinates == []  # points belonged to the previous image
+    assert w._result is None
 
 
-def test_unknown_image_params_are_not_treated_as_a_change():
-    """A file written without the image fields says nothing about the image it
-    was fitted to — absence of information is not evidence of change."""
-    saved = _inputs()  # no image, no stored_* values
-    live = _inputs()
-    live.fib_image = FibsemImage.generate_blank_image(
-        resolution=(300, 200), hfw=100e-6
+def test_declining_the_change_keeps_both_image_and_points(qapp, monkeypatch):
+    from PyQt5.QtWidgets import QMessageBox
+
+    w = _widget()
+    original = FibsemImage.generate_blank_image(resolution=(1536, 1024), hfw=80e-6)
+    w.set_fib_image(original)
+    w.set_data(_inputs(x=1382.0))
+
+    _load_via_picker(w, monkeypatch, QMessageBox.Cancel)
+
+    assert w.data.fib_coordinates[0].point.x == 1382.0
+    assert w._fib_image is original
+    # the picker must not be left showing a file that was never loaded
+    assert w._images_tab._fib_picker.current_path() == w._images_tab._fib_loaded_path
+
+
+def test_programmatic_image_load_does_not_prompt(qapp, monkeypatch):
+    """The lamella's images arrive this way on open — prompting there would be
+    a dialog nobody asked for."""
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+
+    asked = []
+    monkeypatch.setattr(
+        ctw.QMessageBox, "question", staticmethod(lambda *a, **k: asked.append(1))
     )
-    assert _result(saved).matches_inputs(live) is True
+    w = _widget()
+    w.set_data(_inputs(x=1.0))
+    w.set_fib_image(FibsemImage.generate_blank_image(resolution=(300, 200), hfw=100e-6))
+
+    assert asked == []
+    assert w.data.fib_coordinates  # and it left them alone
+
+
+def test_image_combo_is_guarded_against_the_mouse_wheel(qapp):
+    """Changing the image discards the coordinates, so a scroll passing over the
+    combo must not be able to trigger it.
+
+    Asserts the guard is installed rather than delivering a synthetic wheel
+    event: without the guard an event-based check *hangs* offscreen instead of
+    failing, which is a useless diagnostic in CI.
+    """
+    from fibsem.ui.utils import _WHEEL_GUARD_PROPERTY
+    from PyQt5.QtCore import Qt
+
+    combo = _widget()._images_tab._fib_picker.combo
+    assert combo.property(_WHEEL_GUARD_PROPERTY) is True
+    assert combo.focusPolicy() == Qt.StrongFocus  # no wheel-focus either
 
 
 # ---------------------------------------------------------------------------

--- a/tests/correlation/test_correlation_data_integrity.py
+++ b/tests/correlation/test_correlation_data_integrity.py
@@ -1,0 +1,184 @@
+"""Data-integrity regressions in the correlation flow (FIB-315..318).
+
+Each of these let wrong data reach the experiment or the disk silently:
+
+* FIB-315 — the result's provenance snapshot aliased the live coordinates, so
+  ``matches_inputs`` could never report stale;
+* FIB-316 — an image without metadata took the auto-save down for the whole
+  session, silently;
+* FIB-317 — swapping the image left the result armed, committing a POI scaled by
+  the previous image;
+* FIB-318 — adopting new coordinates kept (and re-saved) the previous result.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import json
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.correlation.structures import (
+    Coordinate,
+    CorrelationInputData,
+    CorrelationPointOfInterest,
+    CorrelationResult,
+    CorrelationState,
+    PointType,
+    PointXYZ,
+    load_correlation_file,
+)
+from fibsem.structures import FibsemImage
+
+
+@pytest.fixture(autouse=True)
+def _no_lut_download(monkeypatch):
+    import fibsem.correlation.ui.widgets.refractive_index_widget as riw
+
+    monkeypatch.setattr(riw, "_ensure_lut", lambda: None)
+
+
+def _fib(x=1.0, y=2.0):
+    return Coordinate(point=PointXYZ(x=x, y=y, z=0.0), point_type=PointType.FIB)
+
+
+def _inputs(x=1.0):
+    return CorrelationInputData(fib_coordinates=[_fib(x=x)])
+
+
+def _result(inp):
+    return CorrelationResult(
+        poi=[CorrelationPointOfInterest()], rms_error=1.0, input_data=inp
+    )
+
+
+def _widget():
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        CorrelationTabWidget,
+    )
+
+    return CorrelationTabWidget()
+
+
+# ---------------------------------------------------------------------------
+# FIB-315 — the snapshot must not alias the live coordinates
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_result_load_copies_the_snapshot(tmp_path):
+    """Loading a legacy result file must not hand the live set the same objects
+    the transform's snapshot holds, or every later edit mutates history."""
+    path = tmp_path / "correlation_result.json"
+    _result(_inputs(x=1.0)).save(str(path))
+
+    state = load_correlation_file(str(path))
+    assert state.input_data is not state.result.input_data
+    assert state.input_data.fib_coordinates[0] is not (
+        state.result.input_data.fib_coordinates[0]
+    )
+
+    # editing the live point must make the result stale
+    state.input_data.fib_coordinates[0].point.x = 9999.0
+    assert state.result.matches_inputs(state.input_data) is False
+
+
+def test_adopting_a_results_inputs_copies_them(qapp):
+    w = _widget()
+    result = _result(_inputs(x=1.0))
+    w._load_result(result, adopt_inputs=True)
+
+    w.data.fib_coordinates[0].point.x = 9999.0
+    assert result.matches_inputs(w.data) is False
+
+
+# ---------------------------------------------------------------------------
+# FIB-316 — an image without metadata must not kill the auto-save
+# ---------------------------------------------------------------------------
+
+
+def test_serialisation_survives_an_image_without_metadata():
+    """A plain (non-OME) TIFF loads with metadata=None; to_dict is on the only
+    persistence path, so it must not raise."""
+    img = FibsemImage.generate_blank_image(resolution=(300, 200), hfw=100e-6)
+    img.metadata = None
+    data = CorrelationInputData(fib_image=img, fib_coordinates=[_fib()])
+
+    payload = data.to_dict()  # must not raise
+    assert payload["fib_image_pixel_size"] is None
+    assert payload["fib_image_filename"] is None
+    assert tuple(payload["fib_image_shape"]) == (200, 300)
+
+
+def test_autosave_failure_is_reported_not_swallowed(qapp, tmp_path, monkeypatch):
+    w = _widget()
+    w.set_project_dir(str(tmp_path))
+
+    def _boom(self, filename):
+        raise OSError("disk on fire")
+
+    monkeypatch.setattr(CorrelationState, "save", _boom)
+    w.data_changed.emit(w.data)
+
+    assert "NOT being saved" in w._lbl_status.text()
+    assert "disk on fire" in w._lbl_status.text()
+
+    # and it clears once saving works again
+    monkeypatch.undo()
+    w.data_changed.emit(w.data)
+    assert "NOT being saved" not in w._lbl_status.text()
+
+
+# ---------------------------------------------------------------------------
+# FIB-317 — the image is an input; swapping it invalidates the result
+# ---------------------------------------------------------------------------
+
+
+def test_swapping_the_fib_image_makes_a_result_stale(qapp):
+    w = _widget()
+    w.set_fib_image(FibsemImage.generate_blank_image(resolution=(1536, 1024), hfw=80e-6))
+    result = _result(w.data)
+    w._load_result(result, adopt_inputs=False)
+    assert w._btn_continue.isEnabled() is True
+
+    # a different magnification changes the metres scaling of the POI
+    w.set_fib_image(FibsemImage.generate_blank_image(resolution=(1536, 1024), hfw=20e-6))
+    assert result.matches_inputs(w.data) is False
+    assert w._btn_continue.isEnabled() is False
+
+
+def test_unknown_image_params_are_not_treated_as_a_change():
+    """A file written without the image fields says nothing about the image it
+    was fitted to — absence of information is not evidence of change."""
+    saved = _inputs()  # no image, no stored_* values
+    live = _inputs()
+    live.fib_image = FibsemImage.generate_blank_image(
+        resolution=(300, 200), hfw=100e-6
+    )
+    assert _result(saved).matches_inputs(live) is True
+
+
+# ---------------------------------------------------------------------------
+# FIB-318 — new coordinates must not keep the old result
+# ---------------------------------------------------------------------------
+
+
+def test_adopting_a_state_without_a_result_discards_the_old_one(qapp, tmp_path):
+    w = _widget()
+    w.set_project_dir(str(tmp_path))
+    w._load_result(_result(_inputs(x=1.0)), adopt_inputs=False)
+    assert w._result is not None
+
+    w._adopt_state(CorrelationState(input_data=_inputs(x=5.0), result=None))
+    assert w._result is None
+
+    saved = json.loads((tmp_path / "correlation.json").read_text())
+    assert saved["result"] is None  # not re-saved against the new coordinates
+
+
+def test_seeding_discards_a_previous_result(qapp):
+    w = _widget()
+    w._load_result(_result(_inputs(x=1.0)), adopt_inputs=False)
+    w.seed_coordinates(_inputs(x=7.0))
+    assert w._result is None


### PR DESCRIPTION
Closes FIB-315, FIB-316, FIB-317, FIB-318 — the data-integrity tier from the post-FIB-302 review of the correlation flow. Every one of these failed **silently**.

## FIB-315 — staleness detection defeated by object aliasing

`CorrelationResult.input_data` is the *snapshot* the transform was fitted to; comparing it to the live points is what makes staleness derivable (FIB-295). Two seams aliased it to the live `Coordinate` objects, so every later edit mutated the snapshot too:

- `load_correlation_file`'s legacy-result branch (`current = result.input_data`)
- `_apply_post` storing the live surface coordinate into the snapshot

Reproduced: load a legacy result, drag a fiducial to x=9999 → `matches_inputs` still `True`. The second seam is worse — run, drag the surface (result correctly greys out), then Apply, and it **launders the stale result back to "current"**. Fixed by deep-copying at both.

## FIB-316 — an odd image silently disabled saving for the whole session

`fib_image_pixel_size` / `fib_image_filename` dereferenced `metadata` unguarded, and a plain (non-OME) TIFF loads with `metadata = None`. `to_dict` is on the only persistence path and the auto-save swallows exceptions, so this turned one image into *nothing is ever written*, with no indication.

Guarded the properties, and made an auto-save failure **sticky in the status line** — it previously only reached the log, and the label would go on claiming "Ready." while nothing was being saved.

## FIB-317 — a different image means different coordinates

Swapping the image left the result armed, so Continue committed a POI scaled by the *previous* image (measured 6.875e-06 where the new scale gives 1.719e-06).

The first cut compared image shape/pixel size in `matches_inputs`. That was the wrong tool: it only marked the result stale while leaving coordinates that are in the wrong frame sitting on the canvas — the source of off-image points, a coordinate list displaying clamped values while the data said otherwise, and a write-back that teleported a point to the image edge on first touch.

**Now: any image change clears the coordinates**, behind a confirm that can be cancelled (which also reverts the picker selection). Shape and pixel size matching says nothing about content — a re-acquisition at identical settings has still drifted or been milled — so there is no "safe" swap to special-case.

Rescaling is deliberately not offered: scaling by the shape ratio is only correct if the field of view is unchanged, and nothing in the files says so. The rule ends up being *rescale when we know the relationship, clear when we don't* — interpolation rescales z because it is provably the same volume resampled; a different file gets cleared.

Programmatic `set_fib_image` / `set_fm_image` — how the lamella's images arrive on open — never prompts. The picker combo also gets a **WheelBlocker**: now that changing the image discards work, a scroll passing over it must not be able to.

Loading an image also now emits `data_changed`, which additionally fixes the Run button staying disabled when an image is loaded *after* the coordinates exist.

## FIB-318 — adopting new coordinates kept the old result

`_adopt_state` had no `else`: nothing cleared `self._result`, so the previous result's markers stayed drawn over the new points, CSV export wrote it, and the auto-save re-paired it with coordinates it was never computed from. Added `_discard_result()` and called it wherever the points are replaced wholesale — **before** the emit, since the emit is what saves.

## Testing

- 242 correlation tests pass (10 new).
- Every fix mutation-verified: reverting each one individually fails its test.
- The wheel-guard test asserts the guard is installed rather than sending a synthetic wheel event — without the guard, an event-based check *hangs* offscreen instead of failing, which is a useless diagnostic in CI.

## Not included

The rest of the review is filed as FIB-319 (regressions from the Setup-tab move), FIB-320 (don't create a run folder until a result is recorded), FIB-321 (UI states that misrepresent the data).