### PR TITLE
Export experiment targets to the automated lamella targeting ML format (FIB-305)

### DIFF
--- a/fibsem/applications/autolamella/tools/ml_export.py
+++ b/fibsem/applications/autolamella/tools/ml_export.py
@@ -15,10 +15,10 @@ experiment carries its training data with it::
         labels/0001.tif      disc at the point, rasterised from points/
         manifest.json        index over the samples, plus experiment provenance
 
-One sample is one lamella. ``points/`` is authoritative; ``labels/`` is a pure
-derivative of it, rebuildable at any radius via :func:`regenerate_labels` without
-re-reading the source experiments, so it should never be hand-edited. The ``images/``
-+ ``labels/`` pairing is what
+One sample is one lamella. ``points/`` is authoritative and ``labels/`` is derived
+from it, so the raster should never be hand-edited -- to change the label geometry,
+re-export at a different ``radius_m`` (or rasterise the sidecar yourself). The
+``images/`` + ``labels/`` pairing is what
 :func:`~fibsem.applications.autolamella.tools.upload_to_hf.create_dataset` consumes.
 
 No stage reprojection is involved: the reference image is acquired at the milling
@@ -399,37 +399,6 @@ def export_experiments(
     if output_path:
         write_manifest(output_path, [combined], radius_m=radius_m)
     return combined
-
-
-def regenerate_labels(
-    output_path: str, radius_m: float = DEFAULT_DISC_RADIUS_M
-) -> int:
-    """Rebuild every ``labels/*.tif`` from ``points/*.json``. Returns the count.
-
-    ``labels/`` is a derivative of the sidecar, so the raster can be re-stamped at a
-    different radius without touching the source experiments.
-    """
-    points_dir = os.path.join(output_path, POINTS_DIR)
-    labels_dir = os.path.join(output_path, LABELS_DIR)
-    os.makedirs(labels_dir, exist_ok=True)
-
-    count = 0
-    for path in sorted(glob.glob(os.path.join(points_dir, "*.json"))):
-        with open(path) as f:
-            data = json.load(f)
-        tifffile.imwrite(
-            os.path.join(labels_dir, f"{data['stem']}.tif"),
-            rasterise_point(
-                data["pixel_x"],
-                data["pixel_y"],
-                (data["shape"]["height"], data["shape"]["width"]),
-                data["pixelsize"],
-                radius_m,
-            ),
-        )
-        count += 1
-
-    return count
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/fibsem/applications/autolamella/tools/ml_export.py
+++ b/fibsem/applications/autolamella/tools/ml_export.py
@@ -12,7 +12,7 @@ experiment carries its training data with it::
     <experiment>/targeting-export/
         images/0001.tif      FIB reference image (FibsemImage, metadata preserved)
         points/0001.json     SOURCE OF TRUTH -- exact coordinates + provenance
-        labels/0001.tif      instance-indexed disc, rasterised from points/
+        labels/0001.tif      disc at the point, rasterised from points/
         manifest.json        index over the samples, plus experiment provenance
 
 One sample is one lamella. ``points/`` is authoritative; ``labels/`` is a pure
@@ -57,9 +57,9 @@ SELECT_POSITION_TASK_TYPE = "SELECT_MILLING_POSITION"
 FINAL_FIB_IMAGE_GLOB = "ref_{task_name}_final_res_*_ib.tif"
 _RES_SUFFIX = re.compile(r"_res_(\d+)_ib\.tif$")
 
-# radius of the disc stamped into labels/ for each point, in metres. Specified as a
-# physical size (not pixels) so a label means the same thing across images acquired
-# at different fields of view.
+# radius of the disc stamped into labels/, in metres. Specified as a physical size
+# (not pixels) so a label means the same thing across images acquired at different
+# fields of view.
 DEFAULT_DISC_RADIUS_M = 2.0e-6
 
 IMAGES_DIR = "images"
@@ -71,25 +71,8 @@ MANIFEST_NAME = "manifest.json"
 # carries its training data with it.
 DEFAULT_EXPORT_DIRNAME = "targeting-export"
 
-# labels are instance-indexed, so uint16 is ample (one point per sample today).
-LABEL_DTYPE = np.uint16
-
-
-@dataclass
-class ExportedPoint:
-    """The operator-selected point of interest, in its FIB reference image."""
-
-    index: int  # 1-based; matches the instance value in labels/
-    petname: str
-    lamella_id: str
-    pixel_x: float  # sub-pixel, deliberately not rounded
-    pixel_y: float
-    in_bounds: bool
-    poi: Dict[str, float]  # original milling coordinates, metres
-    stage_position: Dict[str, Optional[float]]
-    milling_angle: Optional[float]
-    defect: str
-    completed_tasks: List[str] = field(default_factory=list)
+LABEL_VALUE = 1
+LABEL_DTYPE = np.uint8
 
 
 @dataclass
@@ -101,11 +84,16 @@ class ExportedSample:
     shape: Tuple[int, int]  # (height, width)
     pixelsize: float
     hfw: Optional[float]
-    points: List[ExportedPoint] = field(default_factory=list)
-
-    @property
-    def n_in_bounds(self) -> int:
-        return sum(1 for p in self.points if p.in_bounds)
+    # the point, and where it came from
+    petname: str
+    lamella_id: str
+    pixel_x: float  # sub-pixel, deliberately not rounded
+    pixel_y: float
+    poi: Dict[str, float]  # original milling coordinates, metres
+    stage_position: Dict[str, Optional[float]]
+    milling_angle: Optional[float]
+    defect: str
+    completed_tasks: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -119,14 +107,6 @@ class ExportSummary:
     @property
     def n_samples(self) -> int:
         return len(self.samples)
-
-    @property
-    def n_points(self) -> int:
-        return sum(len(s.points) for s in self.samples)
-
-    @property
-    def n_in_bounds(self) -> int:
-        return sum(s.n_in_bounds for s in self.samples)
 
 
 def select_position_task_names(lamella: Lamella) -> List[str]:
@@ -194,9 +174,8 @@ def collect_sample(lamella: Lamella, stem: str) -> Optional[ExportedSample]:
 
     image = FibsemImage.load(filename)
     point = poi_to_pixels(lamella, image)
-    height, width = image.data.shape[:2]
-
     pose = lamella.milling_pose
+
     hfw = None
     if image.metadata.image_settings is not None:
         hfw = image.metadata.image_settings.hfw
@@ -204,76 +183,58 @@ def collect_sample(lamella: Lamella, stem: str) -> Optional[ExportedSample]:
     return ExportedSample(
         stem=stem,
         source_image=filename,
-        shape=(height, width),
+        shape=tuple(image.data.shape[:2]),
         pixelsize=image.metadata.pixel_size.x,
         hfw=hfw,
-        points=[
-            ExportedPoint(
-                index=1,
-                petname=lamella.name,
-                lamella_id=lamella._id,
-                pixel_x=float(point.x),
-                pixel_y=float(point.y),
-                in_bounds=bool(0 <= point.x < width and 0 <= point.y < height),
-                poi=lamella.poi.to_dict(),
-                stage_position=(
-                    pose.stage_position.to_dict()
-                    if pose is not None and pose.stage_position is not None
-                    else {}
-                ),
-                milling_angle=lamella.milling_angle,
-                defect=lamella.defect.state.name,
-                completed_tasks=list(lamella.completed_tasks),
-            )
-        ],
+        petname=lamella.name,
+        lamella_id=lamella._id,
+        pixel_x=float(point.x),
+        pixel_y=float(point.y),
+        poi=lamella.poi.to_dict(),
+        stage_position=(
+            pose.stage_position.to_dict()
+            if pose is not None and pose.stage_position is not None
+            else {}
+        ),
+        milling_angle=lamella.milling_angle,
+        defect=lamella.defect.state.name,
+        completed_tasks=list(lamella.completed_tasks),
     )
 
 
-def rasterise_points(
-    points: Sequence[ExportedPoint],
+def rasterise_point(
+    pixel_x: float,
+    pixel_y: float,
     shape: Tuple[int, int],
     pixelsize: float,
     radius_m: float = DEFAULT_DISC_RADIUS_M,
 ) -> np.ndarray:
-    """Stamp a disc per in-bounds point, valued with that point's ``index``.
-
-    Instance-indexed rather than binary so a blob in the raster traces back to a
-    specific entry in the sidecar. Where discs overlap the later index wins.
-    """
+    """A label image with a filled disc at the point."""
     label = np.zeros(shape, dtype=LABEL_DTYPE)
     radius_px = radius_m / pixelsize
     if radius_px < 0.5:
         logging.warning(
             f"disc radius {radius_m:.2e} m is under half a pixel at {pixelsize:.2e} "
-            f"m/px; labels will be empty or single-pixel"
+            f"m/px; the label will be empty or single-pixel"
         )
 
     height, width = shape
     r = int(np.ceil(radius_px))
-    for point in points:
-        if not point.in_bounds:
-            continue
-        cx, cy = point.pixel_x, point.pixel_y
-        x0, x1 = max(0, int(np.floor(cx)) - r), min(width, int(np.ceil(cx)) + r + 1)
-        y0, y1 = max(0, int(np.floor(cy)) - r), min(height, int(np.ceil(cy)) + r + 1)
-        if x0 >= x1 or y0 >= y1:
-            continue
-        ys, xs = np.ogrid[y0:y1, x0:x1]
-        mask = (xs - cx) ** 2 + (ys - cy) ** 2 <= radius_px**2
-        label[y0:y1, x0:x1][mask] = point.index
+    x0, x1 = max(0, int(np.floor(pixel_x)) - r), min(width, int(np.ceil(pixel_x)) + r + 1)
+    y0, y1 = max(0, int(np.floor(pixel_y)) - r), min(height, int(np.ceil(pixel_y)) + r + 1)
+    if x0 >= x1 or y0 >= y1:
+        return label
 
+    ys, xs = np.ogrid[y0:y1, x0:x1]
+    mask = (xs - pixel_x) ** 2 + (ys - pixel_y) ** 2 <= radius_px**2
+    label[y0:y1, x0:x1][mask] = LABEL_VALUE
     return label
 
 
 def _sample_to_dict(sample: ExportedSample, experiment: Experiment) -> dict:
     """The contents of ``points/<stem>.json``."""
     return {
-        "stem": sample.stem,
         "image": f"{IMAGES_DIR}/{sample.stem}.tif",
-        "source_image": sample.source_image,
-        "shape": {"height": sample.shape[0], "width": sample.shape[1]},
-        "pixelsize": sample.pixelsize,
-        "hfw": sample.hfw,
         "experiment": {
             "name": experiment.name,
             "id": experiment._id,
@@ -282,7 +243,10 @@ def _sample_to_dict(sample: ExportedSample, experiment: Experiment) -> dict:
             "project": experiment.project,
             "organisation": experiment.organisation,
         },
-        "points": [asdict(p) for p in sample.points],
+        **asdict(sample),
+        # asdict() flattens the tuple to a bare list; name the axes instead, so the
+        # sidecar is unambiguous about height-vs-width order.
+        "shape": {"height": sample.shape[0], "width": sample.shape[1]},
     }
 
 
@@ -339,7 +303,9 @@ def export_experiment(
             json.dump(_sample_to_dict(sample, experiment), f, indent=2)
         tifffile.imwrite(
             os.path.join(output_path, LABELS_DIR, f"{stem}.tif"),
-            rasterise_points(sample.points, sample.shape, sample.pixelsize, radius_m),
+            rasterise_point(
+                sample.pixel_x, sample.pixel_y, sample.shape, sample.pixelsize, radius_m
+            ),
         )
 
         summary.samples.append(sample)
@@ -367,8 +333,6 @@ def write_manifest(
         "source_task": SELECT_POSITION_TASK_TYPE,
         "disc_radius_m": radius_m,
         "n_samples": len(samples),
-        "n_points": sum(len(s.points) for s in samples),
-        "n_points_in_bounds": sum(s.n_in_bounds for s in samples),
         "samples": [
             {
                 "stem": s.stem,
@@ -376,9 +340,9 @@ def write_manifest(
                 "points": f"{POINTS_DIR}/{s.stem}.json",
                 "label": f"{LABELS_DIR}/{s.stem}.tif",
                 "source_image": s.source_image,
+                "petname": s.petname,
                 "hfw": s.hfw,
-                "n_points": len(s.points),
-                "n_points_in_bounds": s.n_in_bounds,
+                "defect": s.defect,
             }
             for s in samples
         ],
@@ -453,11 +417,15 @@ def regenerate_labels(
     for path in sorted(glob.glob(os.path.join(points_dir, "*.json"))):
         with open(path) as f:
             data = json.load(f)
-        shape = (data["shape"]["height"], data["shape"]["width"])
-        points = [ExportedPoint(**p) for p in data["points"]]
         tifffile.imwrite(
             os.path.join(labels_dir, f"{data['stem']}.tif"),
-            rasterise_points(points, shape, data["pixelsize"], radius_m),
+            rasterise_point(
+                data["pixel_x"],
+                data["pixel_y"],
+                (data["shape"]["height"], data["shape"]["width"]),
+                data["pixelsize"],
+                radius_m,
+            ),
         )
         count += 1
 
@@ -495,10 +463,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     summary = export_experiments(args.experiments, args.output, radius_m=args.radius)
 
     destination = summary.output_path or f"each <experiment>/{DEFAULT_EXPORT_DIRNAME}"
-    print(
-        f"{summary.n_samples} samples, {summary.n_in_bounds}/{summary.n_points} "
-        f"points in bounds -> {destination}"
-    )
+    print(f"{summary.n_samples} samples -> {destination}")
     for reason in summary.skipped:
         print(f"  skipped: {reason}")
 

--- a/fibsem/applications/autolamella/tools/ml_export.py
+++ b/fibsem/applications/autolamella/tools/ml_export.py
@@ -6,6 +6,11 @@ final reference image of the *Select Milling Position* task -- the same kind of 
 the targeting ML pipeline runs on -- so the pair (image, point) is directly usable as
 training data.
 
+Where those images are missing, a later task's final reference set is used instead
+(see :data:`SOURCE_TASK_TYPES`); every one of them images at the milling position, so
+the point is equally valid. Which task each sample came from is recorded, because the
+later ones show a progressively more milled sample.
+
 Layout written per run, by default into the experiment's own directory so a copied
 experiment carries its training data with it::
 
@@ -46,9 +51,21 @@ from fibsem.applications.autolamella.structures import Experiment, Lamella
 from fibsem.conversions import microscope_image_to_image_coordinates
 from fibsem.structures import FibsemImage
 
-# the task whose final FIB reference image is the training input. Its `task_name` is
-# user-configurable per protocol, so filenames are derived rather than hardcoded.
-SELECT_POSITION_TASK_TYPE = "SELECT_MILLING_POSITION"
+# Tasks whose final FIB reference image can serve as the training input, in order of
+# preference. All of them image at the milling position, so the POI is valid in any of
+# them; they are ordered earliest-first in the workflow, because each later task has
+# modified the sample further from the unmilled state the targeting model predicts on.
+# `MILL_ROUGH` in particular shows trenches already cut -- usable, but a different
+# visual distribution, which is why the chosen task is recorded per sample.
+#
+# A task's `task_name` is user-configurable per protocol, so filenames are derived from
+# each lamella's own config rather than hardcoded.
+SOURCE_TASK_TYPES = (
+    "SELECT_MILLING_POSITION",
+    "SPOT_BURN_FIDUCIAL",
+    "MILL_FIDUCIAL",
+    "MILL_ROUGH",
+)
 
 # `_acquire_set_of_channels` writes one image per field of view, suffixed res_01,
 # res_02, ... sorted largest FOV to smallest -- so the highest suffix is the most
@@ -81,6 +98,7 @@ class ExportedSample:
 
     stem: str
     source_image: str
+    source_task: str  # which SOURCE_TASK_TYPES entry the image came from
     shape: Tuple[int, int]  # (height, width)
     pixelsize: float
     hfw: Optional[float]
@@ -109,16 +127,16 @@ class ExportSummary:
         return len(self.samples)
 
 
-def select_position_task_names(lamella: Lamella) -> List[str]:
-    """Names of the lamella's Select Milling Position task(s).
+def task_names_for_type(lamella: Lamella, task_type: str) -> List[str]:
+    """Names of the lamella's task(s) of the given type.
 
-    A workflow may run the task more than once under different names, so this returns
+    A workflow may run a task more than once under different names, so this returns
     every match. Both the config's own ``task_name`` and the dict key are considered,
     since the key is what the protocol is written under.
     """
     names: List[str] = []
     for key, config in lamella.task_config.items():
-        if getattr(config, "task_type", None) != SELECT_POSITION_TASK_TYPE:
+        if getattr(config, "task_type", None) != task_type:
             continue
         for candidate in (getattr(config, "task_name", "") or "", key):
             if candidate and candidate not in names:
@@ -126,25 +144,32 @@ def select_position_task_names(lamella: Lamella) -> List[str]:
     return names
 
 
-def find_final_fib_image(lamella: Lamella) -> Optional[str]:
-    """The most zoomed FIB image from the Select Milling Position final reference set.
-
-    Returns None if the task never ran for this lamella, or its images are not on disk.
-    """
-    candidates: List[str] = []
-    for task_name in select_position_task_names(lamella):
-        pattern = FINAL_FIB_IMAGE_GLOB.format(task_name=task_name)
-        candidates.extend(glob.glob(os.path.join(str(lamella.path), pattern)))
-
-    if not candidates:
-        return None
+def _most_zoomed(paths: Sequence[str]) -> str:
+    """Of a final reference set, the highest res_NN -- the smallest field of view."""
 
     def resolution_index(path: str) -> int:
         match = _RES_SUFFIX.search(os.path.basename(path))
         return int(match.group(1)) if match else -1
 
-    # highest res_NN == smallest field of view == most zoomed
-    return max(candidates, key=resolution_index)
+    return max(paths, key=resolution_index)
+
+
+def find_final_fib_image(lamella: Lamella) -> Optional[Tuple[str, str]]:
+    """The best available final FIB reference image, as ``(path, task_type)``.
+
+    Walks :data:`SOURCE_TASK_TYPES` in order and takes the first task that actually
+    produced images, so a lamella whose Select Milling Position images are missing can
+    still contribute via a later task. Returns None if none of them did.
+    """
+    for task_type in SOURCE_TASK_TYPES:
+        candidates: List[str] = []
+        for task_name in task_names_for_type(lamella, task_type):
+            pattern = FINAL_FIB_IMAGE_GLOB.format(task_name=task_name)
+            candidates.extend(glob.glob(os.path.join(str(lamella.path), pattern)))
+        if candidates:
+            return _most_zoomed(candidates), task_type
+
+    return None
 
 
 def poi_to_pixels(lamella: Lamella, image: FibsemImage):
@@ -168,9 +193,10 @@ def collect_sample(lamella: Lamella, stem: str) -> Optional[ExportedSample]:
     Raises ValueError if the image exists but lacks the metadata needed to place the
     point -- a real problem worth surfacing, not a silent skip.
     """
-    filename = find_final_fib_image(lamella)
-    if filename is None:
+    found = find_final_fib_image(lamella)
+    if found is None:
         return None
+    filename, source_task = found
 
     image = FibsemImage.load(filename)
     point = poi_to_pixels(lamella, image)
@@ -183,6 +209,7 @@ def collect_sample(lamella: Lamella, stem: str) -> Optional[ExportedSample]:
     return ExportedSample(
         stem=stem,
         source_image=filename,
+        source_task=source_task,
         shape=tuple(image.data.shape[:2]),
         pixelsize=image.metadata.pixel_size.x,
         hfw=hfw,
@@ -290,8 +317,8 @@ def export_experiment(
 
         if sample is None:
             reason = (
-                f"{lamella.name}: no final FIB reference image from "
-                f"{SELECT_POSITION_TASK_TYPE}, skipped"
+                f"{lamella.name}: no final FIB reference image from any of "
+                f"{', '.join(SOURCE_TASK_TYPES)}, skipped"
             )
             logging.warning(reason)
             summary.skipped.append(reason)
@@ -330,9 +357,16 @@ def write_manifest(
     samples = [s for summary in summaries for s in summary.samples]
     manifest = {
         "format": "autolamella-targeting-points-v1",
-        "source_task": SELECT_POSITION_TASK_TYPE,
+        "source_task_preference": list(SOURCE_TASK_TYPES),
         "disc_radius_m": radius_m,
         "n_samples": len(samples),
+        # how many samples came from each task, so a consumer can see at a glance how
+        # much of the set is post-milling rather than pristine
+        "n_samples_by_source_task": {
+            task_type: sum(1 for s in samples if s.source_task == task_type)
+            for task_type in SOURCE_TASK_TYPES
+            if any(s.source_task == task_type for s in samples)
+        },
         "samples": [
             {
                 "stem": s.stem,
@@ -340,6 +374,7 @@ def write_manifest(
                 "points": f"{POINTS_DIR}/{s.stem}.json",
                 "label": f"{LABELS_DIR}/{s.stem}.tif",
                 "source_image": s.source_image,
+                "source_task": s.source_task,
                 "petname": s.petname,
                 "hfw": s.hfw,
                 "defect": s.defect,

--- a/fibsem/applications/autolamella/tools/ml_export.py
+++ b/fibsem/applications/autolamella/tools/ml_export.py
@@ -1,0 +1,509 @@
+"""Export AutoLamella experiment data to the automated lamella targeting ML format.
+
+The training signal in an AutoLamella experiment is the point of interest an operator
+picked for each lamella, on the FIB image they picked it in. That FIB image is the
+final reference image of the *Select Milling Position* task -- the same kind of image
+the targeting ML pipeline runs on -- so the pair (image, point) is directly usable as
+training data.
+
+Layout written per run, by default into the experiment's own directory so a copied
+experiment carries its training data with it::
+
+    <experiment>/targeting-export/
+        images/0001.tif      FIB reference image (FibsemImage, metadata preserved)
+        points/0001.json     SOURCE OF TRUTH -- exact coordinates + provenance
+        labels/0001.tif      instance-indexed disc, rasterised from points/
+        manifest.json        index over the samples, plus experiment provenance
+
+One sample is one lamella. ``points/`` is authoritative; ``labels/`` is a pure
+derivative of it, rebuildable at any radius via :func:`regenerate_labels` without
+re-reading the source experiments, so it should never be hand-edited. The ``images/``
++ ``labels/`` pairing is what
+:func:`~fibsem.applications.autolamella.tools.upload_to_hf.create_dataset` consumes.
+
+No stage reprojection is involved: the reference image is acquired at the milling
+position, so the POI -- already a milling-coordinate offset in metres from the image
+centre -- converts straight to pixels via the image's own pixel size.
+
+Failed lamellae are exported and tagged rather than dropped: a target a human picked
+that then failed is a useful hard negative, not data to discard.
+
+See FIB-305.
+"""
+import argparse
+import glob
+import json
+import logging
+import os
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import tifffile
+
+from fibsem.applications.autolamella.structures import Experiment, Lamella
+from fibsem.conversions import microscope_image_to_image_coordinates
+from fibsem.structures import FibsemImage
+
+# the task whose final FIB reference image is the training input. Its `task_name` is
+# user-configurable per protocol, so filenames are derived rather than hardcoded.
+SELECT_POSITION_TASK_TYPE = "SELECT_MILLING_POSITION"
+
+# `_acquire_set_of_channels` writes one image per field of view, suffixed res_01,
+# res_02, ... sorted largest FOV to smallest -- so the highest suffix is the most
+# zoomed. That is the image the task itself treats as its result (it takes images[-1]
+# to display), and the one the targeting pipeline is equivalent to.
+FINAL_FIB_IMAGE_GLOB = "ref_{task_name}_final_res_*_ib.tif"
+_RES_SUFFIX = re.compile(r"_res_(\d+)_ib\.tif$")
+
+# radius of the disc stamped into labels/ for each point, in metres. Specified as a
+# physical size (not pixels) so a label means the same thing across images acquired
+# at different fields of view.
+DEFAULT_DISC_RADIUS_M = 2.0e-6
+
+IMAGES_DIR = "images"
+LABELS_DIR = "labels"
+POINTS_DIR = "points"
+MANIFEST_NAME = "manifest.json"
+
+# exports land beside the data they came from, so a copied experiment directory
+# carries its training data with it.
+DEFAULT_EXPORT_DIRNAME = "targeting-export"
+
+# labels are instance-indexed, so uint16 is ample (one point per sample today).
+LABEL_DTYPE = np.uint16
+
+
+@dataclass
+class ExportedPoint:
+    """The operator-selected point of interest, in its FIB reference image."""
+
+    index: int  # 1-based; matches the instance value in labels/
+    petname: str
+    lamella_id: str
+    pixel_x: float  # sub-pixel, deliberately not rounded
+    pixel_y: float
+    in_bounds: bool
+    poi: Dict[str, float]  # original milling coordinates, metres
+    stage_position: Dict[str, Optional[float]]
+    milling_angle: Optional[float]
+    defect: str
+    completed_tasks: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ExportedSample:
+    """One lamella: its FIB reference image and the point selected in it."""
+
+    stem: str
+    source_image: str
+    shape: Tuple[int, int]  # (height, width)
+    pixelsize: float
+    hfw: Optional[float]
+    points: List[ExportedPoint] = field(default_factory=list)
+
+    @property
+    def n_in_bounds(self) -> int:
+        return sum(1 for p in self.points if p.in_bounds)
+
+
+@dataclass
+class ExportSummary:
+    """What an export run produced."""
+
+    output_path: str
+    samples: List[ExportedSample] = field(default_factory=list)
+    skipped: List[str] = field(default_factory=list)  # human-readable reasons
+
+    @property
+    def n_samples(self) -> int:
+        return len(self.samples)
+
+    @property
+    def n_points(self) -> int:
+        return sum(len(s.points) for s in self.samples)
+
+    @property
+    def n_in_bounds(self) -> int:
+        return sum(s.n_in_bounds for s in self.samples)
+
+
+def select_position_task_names(lamella: Lamella) -> List[str]:
+    """Names of the lamella's Select Milling Position task(s).
+
+    A workflow may run the task more than once under different names, so this returns
+    every match. Both the config's own ``task_name`` and the dict key are considered,
+    since the key is what the protocol is written under.
+    """
+    names: List[str] = []
+    for key, config in lamella.task_config.items():
+        if getattr(config, "task_type", None) != SELECT_POSITION_TASK_TYPE:
+            continue
+        for candidate in (getattr(config, "task_name", "") or "", key):
+            if candidate and candidate not in names:
+                names.append(candidate)
+    return names
+
+
+def find_final_fib_image(lamella: Lamella) -> Optional[str]:
+    """The most zoomed FIB image from the Select Milling Position final reference set.
+
+    Returns None if the task never ran for this lamella, or its images are not on disk.
+    """
+    candidates: List[str] = []
+    for task_name in select_position_task_names(lamella):
+        pattern = FINAL_FIB_IMAGE_GLOB.format(task_name=task_name)
+        candidates.extend(glob.glob(os.path.join(str(lamella.path), pattern)))
+
+    if not candidates:
+        return None
+
+    def resolution_index(path: str) -> int:
+        match = _RES_SUFFIX.search(os.path.basename(path))
+        return int(match.group(1)) if match else -1
+
+    # highest res_NN == smallest field of view == most zoomed
+    return max(candidates, key=resolution_index)
+
+
+def poi_to_pixels(lamella: Lamella, image: FibsemImage):
+    """Convert the lamella's POI to pixel coordinates in ``image``.
+
+    ``Lamella.poi`` is a milling-pattern coordinate: metres from the image centre with
+    the y-axis pointing *up*. The reference image is acquired at the milling position,
+    so this is a direct conversion -- no stage reprojection -- and it is independent of
+    the field of view the POI was originally picked at, because it is held in metres.
+    """
+    if image.metadata is None or image.metadata.pixel_size is None:
+        raise ValueError("reference image has no pixel size metadata")
+    return microscope_image_to_image_coordinates(
+        lamella.poi, image.data.shape[:2], image.metadata.pixel_size.x
+    )
+
+
+def collect_sample(lamella: Lamella, stem: str) -> Optional[ExportedSample]:
+    """Build the sample for one lamella, or None if it has no usable image.
+
+    Raises ValueError if the image exists but lacks the metadata needed to place the
+    point -- a real problem worth surfacing, not a silent skip.
+    """
+    filename = find_final_fib_image(lamella)
+    if filename is None:
+        return None
+
+    image = FibsemImage.load(filename)
+    point = poi_to_pixels(lamella, image)
+    height, width = image.data.shape[:2]
+
+    pose = lamella.milling_pose
+    hfw = None
+    if image.metadata.image_settings is not None:
+        hfw = image.metadata.image_settings.hfw
+
+    return ExportedSample(
+        stem=stem,
+        source_image=filename,
+        shape=(height, width),
+        pixelsize=image.metadata.pixel_size.x,
+        hfw=hfw,
+        points=[
+            ExportedPoint(
+                index=1,
+                petname=lamella.name,
+                lamella_id=lamella._id,
+                pixel_x=float(point.x),
+                pixel_y=float(point.y),
+                in_bounds=bool(0 <= point.x < width and 0 <= point.y < height),
+                poi=lamella.poi.to_dict(),
+                stage_position=(
+                    pose.stage_position.to_dict()
+                    if pose is not None and pose.stage_position is not None
+                    else {}
+                ),
+                milling_angle=lamella.milling_angle,
+                defect=lamella.defect.state.name,
+                completed_tasks=list(lamella.completed_tasks),
+            )
+        ],
+    )
+
+
+def rasterise_points(
+    points: Sequence[ExportedPoint],
+    shape: Tuple[int, int],
+    pixelsize: float,
+    radius_m: float = DEFAULT_DISC_RADIUS_M,
+) -> np.ndarray:
+    """Stamp a disc per in-bounds point, valued with that point's ``index``.
+
+    Instance-indexed rather than binary so a blob in the raster traces back to a
+    specific entry in the sidecar. Where discs overlap the later index wins.
+    """
+    label = np.zeros(shape, dtype=LABEL_DTYPE)
+    radius_px = radius_m / pixelsize
+    if radius_px < 0.5:
+        logging.warning(
+            f"disc radius {radius_m:.2e} m is under half a pixel at {pixelsize:.2e} "
+            f"m/px; labels will be empty or single-pixel"
+        )
+
+    height, width = shape
+    r = int(np.ceil(radius_px))
+    for point in points:
+        if not point.in_bounds:
+            continue
+        cx, cy = point.pixel_x, point.pixel_y
+        x0, x1 = max(0, int(np.floor(cx)) - r), min(width, int(np.ceil(cx)) + r + 1)
+        y0, y1 = max(0, int(np.floor(cy)) - r), min(height, int(np.ceil(cy)) + r + 1)
+        if x0 >= x1 or y0 >= y1:
+            continue
+        ys, xs = np.ogrid[y0:y1, x0:x1]
+        mask = (xs - cx) ** 2 + (ys - cy) ** 2 <= radius_px**2
+        label[y0:y1, x0:x1][mask] = point.index
+
+    return label
+
+
+def _sample_to_dict(sample: ExportedSample, experiment: Experiment) -> dict:
+    """The contents of ``points/<stem>.json``."""
+    return {
+        "stem": sample.stem,
+        "image": f"{IMAGES_DIR}/{sample.stem}.tif",
+        "source_image": sample.source_image,
+        "shape": {"height": sample.shape[0], "width": sample.shape[1]},
+        "pixelsize": sample.pixelsize,
+        "hfw": sample.hfw,
+        "experiment": {
+            "name": experiment.name,
+            "id": experiment._id,
+            "path": str(experiment.path),
+            "user": experiment.user,
+            "project": experiment.project,
+            "organisation": experiment.organisation,
+        },
+        "points": [asdict(p) for p in sample.points],
+    }
+
+
+def default_output_path(experiment: Experiment) -> str:
+    """Where an experiment's export goes unless told otherwise."""
+    return os.path.join(str(experiment.path), DEFAULT_EXPORT_DIRNAME)
+
+
+def export_experiment(
+    experiment: Experiment,
+    output_path: Optional[str] = None,
+    radius_m: float = DEFAULT_DISC_RADIUS_M,
+    start_index: int = 1,
+    write_manifest_file: bool = True,
+) -> ExportSummary:
+    """Export one experiment -- one sample per lamella.
+
+    ``output_path`` defaults to ``<experiment>/targeting-export``.
+
+    ``start_index`` continues the ``NNNN`` numbering, so several experiments can be
+    written into one output directory. Batch callers pass ``write_manifest_file=False``
+    and write one combined manifest at the end.
+    """
+    if output_path is None:
+        output_path = default_output_path(experiment)
+    summary = ExportSummary(output_path=output_path)
+
+    for directory in (IMAGES_DIR, LABELS_DIR, POINTS_DIR):
+        os.makedirs(os.path.join(output_path, directory), exist_ok=True)
+
+    index = start_index
+    for lamella in experiment.positions:
+        stem = f"{index:04d}"
+        try:
+            sample = collect_sample(lamella, stem)
+        except Exception as e:
+            reason = f"{lamella.name}: failed to build sample ({e}), skipped"
+            logging.warning(reason)
+            summary.skipped.append(reason)
+            continue
+
+        if sample is None:
+            reason = (
+                f"{lamella.name}: no final FIB reference image from "
+                f"{SELECT_POSITION_TASK_TYPE}, skipped"
+            )
+            logging.warning(reason)
+            summary.skipped.append(reason)
+            continue
+
+        image = FibsemImage.load(sample.source_image)
+        image.save(os.path.join(output_path, IMAGES_DIR, stem))
+        with open(os.path.join(output_path, POINTS_DIR, f"{stem}.json"), "w") as f:
+            json.dump(_sample_to_dict(sample, experiment), f, indent=2)
+        tifffile.imwrite(
+            os.path.join(output_path, LABELS_DIR, f"{stem}.tif"),
+            rasterise_points(sample.points, sample.shape, sample.pixelsize, radius_m),
+        )
+
+        summary.samples.append(sample)
+        logging.info(
+            f"exported {stem}: {lamella.name} from "
+            f"{os.path.basename(sample.source_image)}"
+        )
+        index += 1
+
+    if write_manifest_file:
+        write_manifest(output_path, [summary], radius_m=radius_m)
+
+    return summary
+
+
+def write_manifest(
+    output_path: str,
+    summaries: Sequence[ExportSummary],
+    radius_m: float = DEFAULT_DISC_RADIUS_M,
+) -> str:
+    """Write ``manifest.json`` indexing everything an export run produced."""
+    samples = [s for summary in summaries for s in summary.samples]
+    manifest = {
+        "format": "autolamella-targeting-points-v1",
+        "source_task": SELECT_POSITION_TASK_TYPE,
+        "disc_radius_m": radius_m,
+        "n_samples": len(samples),
+        "n_points": sum(len(s.points) for s in samples),
+        "n_points_in_bounds": sum(s.n_in_bounds for s in samples),
+        "samples": [
+            {
+                "stem": s.stem,
+                "image": f"{IMAGES_DIR}/{s.stem}.tif",
+                "points": f"{POINTS_DIR}/{s.stem}.json",
+                "label": f"{LABELS_DIR}/{s.stem}.tif",
+                "source_image": s.source_image,
+                "hfw": s.hfw,
+                "n_points": len(s.points),
+                "n_points_in_bounds": s.n_in_bounds,
+            }
+            for s in samples
+        ],
+        "skipped": [reason for summary in summaries for reason in summary.skipped],
+    }
+
+    path = os.path.join(output_path, MANIFEST_NAME)
+    os.makedirs(output_path, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(manifest, f, indent=2)
+    return path
+
+
+def export_experiments(
+    experiment_paths: Sequence[str],
+    output_path: Optional[str] = None,
+    radius_m: float = DEFAULT_DISC_RADIUS_M,
+) -> ExportSummary:
+    """Export several experiments.
+
+    With ``output_path`` set, everything lands in that one directory, numbered
+    continuously, under a single combined manifest. With it left as None, each
+    experiment exports to its own ``<experiment>/targeting-export`` -- separately
+    numbered, each with its own manifest.
+    """
+    combined = ExportSummary(output_path=output_path or "")
+
+    index = 1
+    for experiment_path in experiment_paths:
+        try:
+            experiment = Experiment.load(
+                os.path.join(experiment_path, "experiment.yaml")
+            )
+        except Exception as e:
+            reason = f"{experiment_path}: failed to load experiment ({e}), skipped"
+            logging.warning(reason)
+            combined.skipped.append(reason)
+            continue
+
+        summary = export_experiment(
+            experiment,
+            output_path,  # None -> this experiment's own targeting-export
+            radius_m=radius_m,
+            start_index=index if output_path else 1,
+            # combined runs share one manifest, written below; per-experiment runs
+            # each write their own.
+            write_manifest_file=output_path is None,
+        )
+        combined.samples.extend(summary.samples)
+        combined.skipped.extend(summary.skipped)
+        if output_path:
+            index += len(summary.samples)
+
+    if output_path:
+        write_manifest(output_path, [combined], radius_m=radius_m)
+    return combined
+
+
+def regenerate_labels(
+    output_path: str, radius_m: float = DEFAULT_DISC_RADIUS_M
+) -> int:
+    """Rebuild every ``labels/*.tif`` from ``points/*.json``. Returns the count.
+
+    ``labels/`` is a derivative of the sidecar, so the raster can be re-stamped at a
+    different radius without touching the source experiments.
+    """
+    points_dir = os.path.join(output_path, POINTS_DIR)
+    labels_dir = os.path.join(output_path, LABELS_DIR)
+    os.makedirs(labels_dir, exist_ok=True)
+
+    count = 0
+    for path in sorted(glob.glob(os.path.join(points_dir, "*.json"))):
+        with open(path) as f:
+            data = json.load(f)
+        shape = (data["shape"]["height"], data["shape"]["width"])
+        points = [ExportedPoint(**p) for p in data["points"]]
+        tifffile.imwrite(
+            os.path.join(labels_dir, f"{data['stem']}.tif"),
+            rasterise_points(points, shape, data["pixelsize"], radius_m),
+        )
+        count += 1
+
+    return count
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Export AutoLamella experiments to the targeting ML format."
+    )
+    parser.add_argument(
+        "experiments",
+        nargs="+",
+        help="experiment directories (each containing experiment.yaml)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help=(
+            "output directory for a single combined export. Omit to write each "
+            f"experiment to its own <experiment>/{DEFAULT_EXPORT_DIRNAME}"
+        ),
+    )
+    parser.add_argument(
+        "-r",
+        "--radius",
+        type=float,
+        default=DEFAULT_DISC_RADIUS_M,
+        help=f"label disc radius in metres (default: {DEFAULT_DISC_RADIUS_M:.1e})",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    summary = export_experiments(args.experiments, args.output, radius_m=args.radius)
+
+    destination = summary.output_path or f"each <experiment>/{DEFAULT_EXPORT_DIRNAME}"
+    print(
+        f"{summary.n_samples} samples, {summary.n_in_bounds}/{summary.n_points} "
+        f"points in bounds -> {destination}"
+    )
+    for reason in summary.skipped:
+        print(f"  skipped: {reason}")
+
+    return 0 if summary.n_samples else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -343,6 +343,16 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         action_save_fm_configuration.triggered.connect(self._export_fm_configuration)
         dev_menu.addAction(action_save_fm_configuration)
 
+        dev_menu.addSeparator()
+
+        self.action_export_targeting_ml_data = QAction(
+            "Export Targeting ML Data...", self
+        )
+        self.action_export_targeting_ml_data.triggered.connect(
+            self._on_export_targeting_ml_data
+        )
+        dev_menu.addAction(self.action_export_targeting_ml_data)
+
     def _create_test_menu(self):
         """Create a test menu for toast notifications and sounds."""
 
@@ -583,6 +593,11 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """Handle Generate Overview Plot action."""
         if self.autolamella_ui is not None:
             self.autolamella_ui.action_generate_overview_plot()
+
+    def _on_export_targeting_ml_data(self):
+        """Handle Export Targeting ML Data action."""
+        if self.autolamella_ui is not None:
+            self.autolamella_ui.export_targeting_ml_data()
 
     def _open_fm_minimap_widget(self):
         """Open the Fluorescence Minimap widget."""

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -834,6 +834,45 @@ class AutoLamellaUI(QMainWindow):
                 "Failed to open experiment directory.", "error"
             )
 
+    def export_targeting_ml_data(self) -> None:
+        """Export the experiment's lamella targets as targeting ML training data.
+
+        One sample per lamella: the final FIB reference image from its Select Milling
+        Position task, labelled with the operator's point of interest. Writes to
+        <experiment>/targeting-export. See
+        fibsem.applications.autolamella.tools.ml_export for the layout.
+        """
+        from fibsem.applications.autolamella.tools import ml_export
+
+        if self.experiment is None:
+            notification_service.show_toast(
+                "Please load an experiment first... [No Experiment Loaded]", "warning"
+            )
+            return
+
+        # no directory prompt: the destination is a subfolder of the experiment that
+        # does not exist yet, which an existing-directory dialog cannot select. The
+        # folder is opened afterwards so the location is still discoverable.
+        output_path = ml_export.default_output_path(self.experiment)
+
+        try:
+            summary = ml_export.export_experiment(self.experiment, output_path)
+        except Exception as e:
+            logging.error(f"Failed to export targeting ML data: {e}", exc_info=True)
+            notification_service.show_toast(f"Export failed: {e}", "error")
+            return
+
+        if summary.n_samples == 0:
+            reason = summary.skipped[0] if summary.skipped else "nothing to export"
+            notification_service.show_toast(f"Nothing exported: {reason}", "warning")
+            return
+
+        message = f"Exported {summary.n_samples} lamella target(s)."
+        if summary.skipped:
+            message += f" Skipped {len(summary.skipped)}."
+        notification_service.show_toast(message, "success")
+        fui.open_path_in_file_explorer(output_path)
+
     #### FLUORESCENCE MINIMAP
 
     def open_fm_minimap_widget(self):

--- a/tests/autolamella/test_ml_export.py
+++ b/tests/autolamella/test_ml_export.py
@@ -1,0 +1,514 @@
+"""Tests for exporting AutoLamella experiments to the targeting ML format (FIB-305).
+
+The exported sample is one lamella: the final FIB reference image from its Select
+Milling Position task, labelled with the point of interest the operator picked.
+
+Headless: no Qt, no microscope, no napari.
+"""
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+from psygnal.containers import EventedDict
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    DefectType,
+    Experiment,
+)
+from fibsem.applications.autolamella.tools import ml_export
+from fibsem.applications.autolamella.workflows.tasks.select_position import (
+    SelectMillingPositionTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.trench import MillTrenchTaskConfig
+from fibsem.structures import (
+    BeamType,
+    FibsemImage,
+    FibsemImageMetadata,
+    FibsemStagePosition,
+    ImageSettings,
+    MicroscopeState,
+    Point,
+)
+
+PIXELSIZE = 1e-7  # 100 nm/px
+SHAPE = (512, 512)  # (height, width) -> centre at (256, 256)
+TASK_NAME = "Select Milling Position"
+
+
+def _stage(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0) -> FibsemStagePosition:
+    return FibsemStagePosition(x=x, y=y, z=z, r=r, t=t)
+
+
+def _make_fib_image(shape=SHAPE, pixelsize=PIXELSIZE, hfw=100e-6) -> FibsemImage:
+    metadata = FibsemImageMetadata(
+        image_settings=ImageSettings(beam_type=BeamType.ION, hfw=hfw),
+        pixel_size=Point(pixelsize, pixelsize),
+        microscope_state=MicroscopeState(stage_position=_stage()),
+    )
+    return FibsemImage(data=np.zeros(shape, dtype=np.uint8), metadata=metadata)
+
+
+def _task_config(task_name: str = TASK_NAME) -> EventedDict:
+    return EventedDict(
+        {task_name: SelectMillingPositionTaskConfig(task_name=task_name)}
+    )
+
+
+def _make_experiment(
+    tmp_path: Path, n_lamella: int = 1, poi=None, task_name: str = TASK_NAME
+) -> Experiment:
+    exp = Experiment(path=tmp_path, name="test-exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    os.makedirs(exp.path, exist_ok=True)
+
+    for _ in range(n_lamella):
+        exp.add_new_lamella(
+            MicroscopeState(stage_position=_stage()), _task_config(task_name)
+        )
+    for lamella in exp.positions:
+        lamella.poi = poi if poi is not None else Point(0.0, 0.0)
+    return exp
+
+
+def _save_reference_image(lamella, image=None, res: int = 2, task_name=TASK_NAME):
+    """Write a final-set FIB reference image where the exporter expects it."""
+    os.makedirs(lamella.path, exist_ok=True)
+    name = f"ref_{task_name}_final_res_{res:02d}_ib"
+    (image or _make_fib_image()).save(os.path.join(str(lamella.path), name))
+    return os.path.join(str(lamella.path), f"{name}.tif")
+
+
+# ── locating the source image ────────────────────────────────────────────────
+
+
+def test_select_position_task_names_finds_the_task(tmp_path):
+    exp = _make_experiment(tmp_path)
+    assert ml_export.select_position_task_names(exp.positions[0]) == [TASK_NAME]
+
+
+def test_select_position_task_names_ignores_other_tasks(tmp_path):
+    exp = _make_experiment(tmp_path)
+    lamella = exp.positions[0]
+    lamella.task_config["Mill Trench"] = MillTrenchTaskConfig(task_name="Mill Trench")
+
+    assert ml_export.select_position_task_names(lamella) == [TASK_NAME]
+
+
+def test_find_final_fib_image_prefers_the_most_zoomed(tmp_path):
+    """res_NN is sorted largest FOV first, so the highest suffix is most zoomed."""
+    exp = _make_experiment(tmp_path)
+    lamella = exp.positions[0]
+    _save_reference_image(lamella, res=1)
+    expected = _save_reference_image(lamella, res=2)
+
+    assert ml_export.find_final_fib_image(lamella) == expected
+
+
+def test_find_final_fib_image_none_without_images(tmp_path):
+    exp = _make_experiment(tmp_path)
+    assert ml_export.find_final_fib_image(exp.positions[0]) is None
+
+
+def test_find_final_fib_image_none_without_the_task(tmp_path):
+    exp = _make_experiment(tmp_path)
+    lamella = exp.positions[0]
+    _save_reference_image(lamella)
+    lamella.task_config.clear()  # task never configured
+
+    assert ml_export.find_final_fib_image(lamella) is None
+
+
+def test_find_final_fib_image_ignores_sem_and_non_final(tmp_path):
+    exp = _make_experiment(tmp_path)
+    lamella = exp.positions[0]
+    os.makedirs(lamella.path, exist_ok=True)
+    for name in (
+        f"ref_{TASK_NAME}_final_res_01_eb",  # SEM, not FIB
+        f"ref_{TASK_NAME}_start_ib",  # start of task, not final
+        f"ref_{TASK_NAME}_post_tilt_ib",
+    ):
+        _make_fib_image().save(os.path.join(str(lamella.path), name))
+
+    assert ml_export.find_final_fib_image(lamella) is None
+
+
+# ── POI -> pixels ────────────────────────────────────────────────────────────
+# The POI is a milling coordinate (metres, y-up); pixels are y-down.
+
+
+def test_poi_at_origin_is_image_centre(tmp_path):
+    exp = _make_experiment(tmp_path, poi=Point(0.0, 0.0))
+    point = ml_export.poi_to_pixels(exp.positions[0], _make_fib_image())
+
+    assert point.x == pytest.approx(256.0)
+    assert point.y == pytest.approx(256.0)
+
+
+def test_poi_x_is_not_flipped(tmp_path):
+    exp = _make_experiment(tmp_path, poi=Point(1e-6, 0.0))  # +10 px
+    assert ml_export.poi_to_pixels(exp.positions[0], _make_fib_image()).x == pytest.approx(266.0)
+
+
+def test_poi_y_is_flipped(tmp_path):
+    """+y in milling coordinates is *up*, which is -y in pixels."""
+    exp = _make_experiment(tmp_path, poi=Point(0.0, 1e-6))  # -10 px
+    assert ml_export.poi_to_pixels(exp.positions[0], _make_fib_image()).y == pytest.approx(246.0)
+
+
+def test_poi_conversion_is_independent_of_field_of_view(tmp_path):
+    """The POI is held in metres, so a different pixel size still lands correctly."""
+    exp = _make_experiment(tmp_path, poi=Point(2e-6, 0.0))
+    coarse = ml_export.poi_to_pixels(exp.positions[0], _make_fib_image(pixelsize=2e-7))
+
+    assert coarse.x == pytest.approx(256.0 + 10.0)  # 2 um / 200 nm = 10 px
+
+
+def test_poi_requires_pixel_size(tmp_path):
+    exp = _make_experiment(tmp_path)
+    image = _make_fib_image()
+    image.metadata.pixel_size = None
+
+    with pytest.raises(ValueError, match="pixel size"):
+        ml_export.poi_to_pixels(exp.positions[0], image)
+
+
+# ── collect_sample ───────────────────────────────────────────────────────────
+
+
+def test_collect_sample_places_the_point(tmp_path):
+    exp = _make_experiment(tmp_path, poi=Point(1e-6, 2e-6))
+    _save_reference_image(exp.positions[0])
+
+    sample = ml_export.collect_sample(exp.positions[0], "0001")
+    assert len(sample.points) == 1
+    assert sample.points[0].pixel_x == pytest.approx(266.0)
+    assert sample.points[0].pixel_y == pytest.approx(236.0)
+    assert sample.points[0].in_bounds
+
+
+def test_collect_sample_records_shape_pixelsize_hfw(tmp_path):
+    exp = _make_experiment(tmp_path)
+    _save_reference_image(exp.positions[0], _make_fib_image(hfw=80e-6))
+
+    sample = ml_export.collect_sample(exp.positions[0], "0001")
+    assert sample.shape == SHAPE
+    assert sample.pixelsize == pytest.approx(PIXELSIZE)
+    assert sample.hfw == pytest.approx(80e-6)
+
+
+def test_collect_sample_carries_provenance(tmp_path):
+    exp = _make_experiment(tmp_path)
+    lamella = exp.positions[0]
+    lamella.defect.state = DefectType.FAILURE
+    lamella.milling_angle = 0.3
+    _save_reference_image(lamella)
+
+    point = ml_export.collect_sample(lamella, "0001").points[0]
+    assert point.defect == "FAILURE"
+    assert point.milling_angle == pytest.approx(0.3)
+    assert point.lamella_id == lamella._id
+    assert point.petname == lamella.name
+
+
+def test_collect_sample_none_without_image(tmp_path):
+    exp = _make_experiment(tmp_path)
+    assert ml_export.collect_sample(exp.positions[0], "0001") is None
+
+
+def test_collect_sample_flags_out_of_bounds_poi(tmp_path):
+    """A POI further out than the image half-width is recorded, not dropped."""
+    exp = _make_experiment(tmp_path, poi=Point(1e-3, 0.0))  # 10000 px
+    _save_reference_image(exp.positions[0])
+
+    sample = ml_export.collect_sample(exp.positions[0], "0001")
+    assert len(sample.points) == 1
+    assert not sample.points[0].in_bounds
+
+
+# ── rasterise_points ─────────────────────────────────────────────────────────
+
+
+def _point(index=1, x=256.0, y=256.0, in_bounds=True) -> ml_export.ExportedPoint:
+    return ml_export.ExportedPoint(
+        index=index,
+        petname=f"lam-{index}",
+        lamella_id=f"id-{index}",
+        pixel_x=x,
+        pixel_y=y,
+        in_bounds=in_bounds,
+        poi={"x": 0.0, "y": 0.0},
+        stage_position={},
+        milling_angle=None,
+        defect="NONE",
+    )
+
+
+def test_rasterise_stamps_disc_at_point():
+    label = ml_export.rasterise_points([_point(x=100.0, y=200.0)], SHAPE, PIXELSIZE, 1e-6)
+    assert label[200, 100] == 1
+
+
+def test_rasterise_disc_radius_matches_metres():
+    """A 1 um radius at 100 nm/px is 10 px."""
+    label = ml_export.rasterise_points([_point(x=100.0, y=100.0)], SHAPE, PIXELSIZE, 1e-6)
+    assert label[100, 110] == 1  # on the edge
+    assert label[100, 112] == 0  # beyond it
+
+
+def test_rasterise_is_instance_indexed():
+    points = [_point(index=1, x=50.0, y=50.0), _point(index=2, x=300.0, y=300.0)]
+    label = ml_export.rasterise_points(points, SHAPE, PIXELSIZE, 1e-6)
+    assert label[50, 50] == 1
+    assert label[300, 300] == 2
+    assert set(np.unique(label)) == {0, 1, 2}
+
+
+def test_rasterise_skips_out_of_bounds_points():
+    label = ml_export.rasterise_points(
+        [_point(x=-50.0, y=-50.0, in_bounds=False)], SHAPE, PIXELSIZE, 1e-6
+    )
+    assert label.max() == 0
+
+
+def test_rasterise_clips_disc_at_image_edge():
+    label = ml_export.rasterise_points([_point(x=2.0, y=2.0)], SHAPE, PIXELSIZE, 1e-6)
+    assert label[0, 0] == 1
+    assert label.shape == SHAPE
+
+
+def test_rasterise_empty_points_gives_empty_label():
+    label = ml_export.rasterise_points([], SHAPE, PIXELSIZE, 1e-6)
+    assert label.max() == 0
+    assert label.dtype == ml_export.LABEL_DTYPE
+
+
+# ── export_experiment ────────────────────────────────────────────────────────
+
+
+def test_default_output_path_is_inside_the_experiment(tmp_path):
+    exp = _make_experiment(tmp_path)
+    assert ml_export.default_output_path(exp) == os.path.join(
+        str(exp.path), "targeting-export"
+    )
+
+
+def test_export_defaults_into_the_experiment_directory(tmp_path):
+    """No output_path -> <experiment>/targeting-export."""
+    exp = _make_experiment(tmp_path)
+    _save_reference_image(exp.positions[0])
+
+    summary = ml_export.export_experiment(exp)
+
+    expected = os.path.join(str(exp.path), "targeting-export")
+    assert summary.output_path == expected
+    assert os.path.isfile(os.path.join(expected, "images", "0001.tif"))
+    assert os.path.isfile(os.path.join(expected, "manifest.json"))
+
+
+def test_export_explicit_output_path_still_wins(tmp_path):
+    exp = _make_experiment(tmp_path)
+    _save_reference_image(exp.positions[0])
+    elsewhere = str(tmp_path / "elsewhere")
+
+    summary = ml_export.export_experiment(exp, elsewhere)
+
+    assert summary.output_path == elsewhere
+    assert os.path.isfile(os.path.join(elsewhere, "images", "0001.tif"))
+    assert not os.path.exists(os.path.join(str(exp.path), "targeting-export"))
+
+
+def test_export_default_does_not_pick_up_its_own_output(tmp_path):
+    """Exporting twice must not treat the first export's images as lamella data."""
+    exp = _make_experiment(tmp_path)
+    _save_reference_image(exp.positions[0])
+
+    first = ml_export.export_experiment(exp)
+    second = ml_export.export_experiment(exp)
+
+    assert first.n_samples == 1
+    assert second.n_samples == 1  # not 2
+
+
+def test_export_writes_full_layout(tmp_path):
+    exp = _make_experiment(tmp_path, n_lamella=1)
+    _save_reference_image(exp.positions[0])
+    output = str(tmp_path / "out")
+
+    summary = ml_export.export_experiment(exp, output)
+
+    assert summary.n_samples == 1
+    assert os.path.isfile(os.path.join(output, "images", "0001.tif"))
+    assert os.path.isfile(os.path.join(output, "points", "0001.json"))
+    assert os.path.isfile(os.path.join(output, "labels", "0001.tif"))
+
+
+def test_export_one_sample_per_lamella(tmp_path):
+    exp = _make_experiment(tmp_path, n_lamella=3)
+    for lamella in exp.positions:
+        _save_reference_image(lamella)
+
+    summary = ml_export.export_experiment(exp, str(tmp_path / "out"))
+    assert summary.n_samples == 3
+    assert [s.stem for s in summary.samples] == ["0001", "0002", "0003"]
+
+
+def test_export_skips_lamella_without_image(tmp_path):
+    """Numbering stays contiguous across a skip."""
+    exp = _make_experiment(tmp_path, n_lamella=3)
+    _save_reference_image(exp.positions[0])
+    _save_reference_image(exp.positions[2])  # middle lamella never ran the task
+
+    summary = ml_export.export_experiment(exp, str(tmp_path / "out"))
+    assert summary.n_samples == 2
+    assert [s.stem for s in summary.samples] == ["0001", "0002"]
+    assert any(exp.positions[1].name in reason for reason in summary.skipped)
+
+
+def test_export_sidecar_holds_subpixel_coordinates(tmp_path):
+    exp = _make_experiment(tmp_path, poi=Point(1.5e-7, 0.0))  # 1.5 px
+    _save_reference_image(exp.positions[0])
+    output = str(tmp_path / "out")
+
+    ml_export.export_experiment(exp, output)
+    with open(os.path.join(output, "points", "0001.json")) as f:
+        data = json.load(f)
+
+    assert data["points"][0]["pixel_x"] == pytest.approx(257.5)
+    assert isinstance(data["points"][0]["pixel_x"], float)
+
+
+def test_export_label_disc_lands_on_sidecar_coordinates(tmp_path):
+    """The round-trip that keeps points/ and labels/ from drifting apart."""
+    import tifffile
+
+    exp = _make_experiment(tmp_path, poi=Point(5e-6, 3e-6))
+    _save_reference_image(exp.positions[0])
+    output = str(tmp_path / "out")
+
+    ml_export.export_experiment(exp, output)
+    with open(os.path.join(output, "points", "0001.json")) as f:
+        point = json.load(f)["points"][0]
+    label = tifffile.imread(os.path.join(output, "labels", "0001.tif"))
+
+    assert label[round(point["pixel_y"]), round(point["pixel_x"])] == point["index"]
+
+
+def test_export_writes_manifest_indexing_samples(tmp_path):
+    exp = _make_experiment(tmp_path, n_lamella=2)
+    for lamella in exp.positions:
+        _save_reference_image(lamella)
+    output = str(tmp_path / "out")
+
+    ml_export.export_experiment(exp, output)
+    with open(os.path.join(output, "manifest.json")) as f:
+        manifest = json.load(f)
+
+    assert manifest["format"] == "autolamella-targeting-points-v1"
+    assert manifest["source_task"] == "SELECT_MILLING_POSITION"
+    assert manifest["n_samples"] == 2
+    assert manifest["samples"][0]["image"] == "images/0001.tif"
+    assert manifest["samples"][0]["points"] == "points/0001.json"
+
+
+def test_export_manifest_records_skips(tmp_path):
+    exp = _make_experiment(tmp_path, n_lamella=1)  # no reference image saved
+    output = str(tmp_path / "out")
+
+    ml_export.export_experiment(exp, output)
+    with open(os.path.join(output, "manifest.json")) as f:
+        manifest = json.load(f)
+
+    assert manifest["n_samples"] == 0
+    assert any("no final FIB reference image" in r for r in manifest["skipped"])
+
+
+def test_export_start_index_continues_numbering(tmp_path):
+    exp = _make_experiment(tmp_path, n_lamella=1)
+    _save_reference_image(exp.positions[0])
+    output = str(tmp_path / "out")
+
+    summary = ml_export.export_experiment(exp, output, start_index=7)
+    assert summary.samples[0].stem == "0007"
+    assert os.path.isfile(os.path.join(output, "images", "0007.tif"))
+
+
+def test_export_experiments_numbers_across_experiments(tmp_path):
+    output = str(tmp_path / "out")
+    paths = []
+    for name in ("exp-a", "exp-b"):
+        exp = Experiment(path=tmp_path / name, name=name)
+        exp.task_protocol = AutoLamellaTaskProtocol()
+        os.makedirs(exp.path, exist_ok=True)
+        exp.add_new_lamella(MicroscopeState(stage_position=_stage()), _task_config())
+        exp.positions[0].poi = Point(0.0, 0.0)
+        _save_reference_image(exp.positions[0])
+        exp.save()
+        paths.append(exp.path)
+
+    summary = ml_export.export_experiments(paths, output)
+
+    assert summary.n_samples == 2
+    assert [s.stem for s in summary.samples] == ["0001", "0002"]
+    assert os.path.isfile(os.path.join(output, "images", "0002.tif"))
+
+
+def test_export_experiments_without_output_uses_each_experiment_directory(tmp_path):
+    """No output_path -> each experiment gets its own targeting-export, numbered from 1."""
+    paths = []
+    for name in ("exp-a", "exp-b"):
+        exp = Experiment(path=tmp_path / name, name=name)
+        exp.task_protocol = AutoLamellaTaskProtocol()
+        os.makedirs(exp.path, exist_ok=True)
+        exp.add_new_lamella(MicroscopeState(stage_position=_stage()), _task_config())
+        exp.positions[0].poi = Point(0.0, 0.0)
+        _save_reference_image(exp.positions[0])
+        exp.save()
+        paths.append(exp.path)
+
+    summary = ml_export.export_experiments(paths)
+
+    assert summary.n_samples == 2
+    for path in paths:
+        own = os.path.join(path, "targeting-export")
+        assert os.path.isfile(os.path.join(own, "images", "0001.tif"))
+        assert os.path.isfile(os.path.join(own, "manifest.json"))
+
+
+# ── regenerate_labels ────────────────────────────────────────────────────────
+
+
+def test_regenerate_labels_rebuilds_at_new_radius(tmp_path):
+    import tifffile
+
+    exp = _make_experiment(tmp_path)
+    _save_reference_image(exp.positions[0])
+    output = str(tmp_path / "out")
+    ml_export.export_experiment(exp, output, radius_m=1e-6)
+
+    small = tifffile.imread(os.path.join(output, "labels", "0001.tif"))
+    assert ml_export.regenerate_labels(output, radius_m=3e-6) == 1
+    large = tifffile.imread(os.path.join(output, "labels", "0001.tif"))
+
+    assert (large > 0).sum() > (small > 0).sum()
+
+
+def test_regenerate_labels_without_source_experiment(tmp_path):
+    """labels/ is a pure derivative -- rebuilding must not need the experiment."""
+    import shutil
+
+    import tifffile
+
+    exp = _make_experiment(tmp_path)
+    _save_reference_image(exp.positions[0])
+    output = str(tmp_path / "out")
+    ml_export.export_experiment(exp, output)
+
+    shutil.rmtree(exp.path)  # source experiment is gone
+    os.remove(os.path.join(output, "labels", "0001.tif"))
+
+    assert ml_export.regenerate_labels(output) == 1
+    label = tifffile.imread(os.path.join(output, "labels", "0001.tif"))
+    assert label.max() == 1

--- a/tests/autolamella/test_ml_export.py
+++ b/tests/autolamella/test_ml_export.py
@@ -183,10 +183,8 @@ def test_collect_sample_places_the_point(tmp_path):
     _save_reference_image(exp.positions[0])
 
     sample = ml_export.collect_sample(exp.positions[0], "0001")
-    assert len(sample.points) == 1
-    assert sample.points[0].pixel_x == pytest.approx(266.0)
-    assert sample.points[0].pixel_y == pytest.approx(236.0)
-    assert sample.points[0].in_bounds
+    assert sample.pixel_x == pytest.approx(266.0)
+    assert sample.pixel_y == pytest.approx(236.0)
 
 
 def test_collect_sample_records_shape_pixelsize_hfw(tmp_path):
@@ -206,11 +204,11 @@ def test_collect_sample_carries_provenance(tmp_path):
     lamella.milling_angle = 0.3
     _save_reference_image(lamella)
 
-    point = ml_export.collect_sample(lamella, "0001").points[0]
-    assert point.defect == "FAILURE"
-    assert point.milling_angle == pytest.approx(0.3)
-    assert point.lamella_id == lamella._id
-    assert point.petname == lamella.name
+    sample = ml_export.collect_sample(lamella, "0001")
+    assert sample.defect == "FAILURE"
+    assert sample.milling_angle == pytest.approx(0.3)
+    assert sample.lamella_id == lamella._id
+    assert sample.petname == lamella.name
 
 
 def test_collect_sample_none_without_image(tmp_path):
@@ -218,71 +216,31 @@ def test_collect_sample_none_without_image(tmp_path):
     assert ml_export.collect_sample(exp.positions[0], "0001") is None
 
 
-def test_collect_sample_flags_out_of_bounds_poi(tmp_path):
-    """A POI further out than the image half-width is recorded, not dropped."""
-    exp = _make_experiment(tmp_path, poi=Point(1e-3, 0.0))  # 10000 px
-    _save_reference_image(exp.positions[0])
-
-    sample = ml_export.collect_sample(exp.positions[0], "0001")
-    assert len(sample.points) == 1
-    assert not sample.points[0].in_bounds
-
-
-# ── rasterise_points ─────────────────────────────────────────────────────────
-
-
-def _point(index=1, x=256.0, y=256.0, in_bounds=True) -> ml_export.ExportedPoint:
-    return ml_export.ExportedPoint(
-        index=index,
-        petname=f"lam-{index}",
-        lamella_id=f"id-{index}",
-        pixel_x=x,
-        pixel_y=y,
-        in_bounds=in_bounds,
-        poi={"x": 0.0, "y": 0.0},
-        stage_position={},
-        milling_angle=None,
-        defect="NONE",
-    )
+# ── rasterise_point ──────────────────────────────────────────────────────────
 
 
 def test_rasterise_stamps_disc_at_point():
-    label = ml_export.rasterise_points([_point(x=100.0, y=200.0)], SHAPE, PIXELSIZE, 1e-6)
-    assert label[200, 100] == 1
+    label = ml_export.rasterise_point(100.0, 200.0, SHAPE, PIXELSIZE, 1e-6)
+    assert label[200, 100] == ml_export.LABEL_VALUE
 
 
 def test_rasterise_disc_radius_matches_metres():
     """A 1 um radius at 100 nm/px is 10 px."""
-    label = ml_export.rasterise_points([_point(x=100.0, y=100.0)], SHAPE, PIXELSIZE, 1e-6)
-    assert label[100, 110] == 1  # on the edge
+    label = ml_export.rasterise_point(100.0, 100.0, SHAPE, PIXELSIZE, 1e-6)
+    assert label[100, 110] == ml_export.LABEL_VALUE  # on the edge
     assert label[100, 112] == 0  # beyond it
 
 
-def test_rasterise_is_instance_indexed():
-    points = [_point(index=1, x=50.0, y=50.0), _point(index=2, x=300.0, y=300.0)]
-    label = ml_export.rasterise_points(points, SHAPE, PIXELSIZE, 1e-6)
-    assert label[50, 50] == 1
-    assert label[300, 300] == 2
-    assert set(np.unique(label)) == {0, 1, 2}
-
-
-def test_rasterise_skips_out_of_bounds_points():
-    label = ml_export.rasterise_points(
-        [_point(x=-50.0, y=-50.0, in_bounds=False)], SHAPE, PIXELSIZE, 1e-6
-    )
-    assert label.max() == 0
+def test_rasterise_is_binary():
+    label = ml_export.rasterise_point(256.0, 256.0, SHAPE, PIXELSIZE, 1e-6)
+    assert set(np.unique(label)) == {0, ml_export.LABEL_VALUE}
+    assert label.dtype == ml_export.LABEL_DTYPE
 
 
 def test_rasterise_clips_disc_at_image_edge():
-    label = ml_export.rasterise_points([_point(x=2.0, y=2.0)], SHAPE, PIXELSIZE, 1e-6)
-    assert label[0, 0] == 1
+    label = ml_export.rasterise_point(2.0, 2.0, SHAPE, PIXELSIZE, 1e-6)
+    assert label[0, 0] == ml_export.LABEL_VALUE
     assert label.shape == SHAPE
-
-
-def test_rasterise_empty_points_gives_empty_label():
-    label = ml_export.rasterise_points([], SHAPE, PIXELSIZE, 1e-6)
-    assert label.max() == 0
-    assert label.dtype == ml_export.LABEL_DTYPE
 
 
 # ── export_experiment ────────────────────────────────────────────────────────
@@ -376,8 +334,8 @@ def test_export_sidecar_holds_subpixel_coordinates(tmp_path):
     with open(os.path.join(output, "points", "0001.json")) as f:
         data = json.load(f)
 
-    assert data["points"][0]["pixel_x"] == pytest.approx(257.5)
-    assert isinstance(data["points"][0]["pixel_x"], float)
+    assert data["pixel_x"] == pytest.approx(257.5)
+    assert isinstance(data["pixel_x"], float)
 
 
 def test_export_label_disc_lands_on_sidecar_coordinates(tmp_path):
@@ -390,10 +348,10 @@ def test_export_label_disc_lands_on_sidecar_coordinates(tmp_path):
 
     ml_export.export_experiment(exp, output)
     with open(os.path.join(output, "points", "0001.json")) as f:
-        point = json.load(f)["points"][0]
+        data = json.load(f)
     label = tifffile.imread(os.path.join(output, "labels", "0001.tif"))
 
-    assert label[round(point["pixel_y"]), round(point["pixel_x"])] == point["index"]
+    assert label[round(data["pixel_y"]), round(data["pixel_x"])] == ml_export.LABEL_VALUE
 
 
 def test_export_writes_manifest_indexing_samples(tmp_path):

--- a/tests/autolamella/test_ml_export.py
+++ b/tests/autolamella/test_ml_export.py
@@ -435,38 +435,20 @@ def test_export_experiments_without_output_uses_each_experiment_directory(tmp_pa
         assert os.path.isfile(os.path.join(own, "manifest.json"))
 
 
-# ── regenerate_labels ────────────────────────────────────────────────────────
+# ── label radius ─────────────────────────────────────────────────────────────
 
 
-def test_regenerate_labels_rebuilds_at_new_radius(tmp_path):
+def test_export_radius_controls_label_size(tmp_path):
+    """Changing the label geometry means re-exporting at a different radius_m."""
     import tifffile
 
     exp = _make_experiment(tmp_path)
     _save_reference_image(exp.positions[0])
-    output = str(tmp_path / "out")
-    ml_export.export_experiment(exp, output, radius_m=1e-6)
 
-    small = tifffile.imread(os.path.join(output, "labels", "0001.tif"))
-    assert ml_export.regenerate_labels(output, radius_m=3e-6) == 1
-    large = tifffile.imread(os.path.join(output, "labels", "0001.tif"))
+    ml_export.export_experiment(exp, str(tmp_path / "small"), radius_m=1e-6)
+    ml_export.export_experiment(exp, str(tmp_path / "large"), radius_m=3e-6)
+
+    small = tifffile.imread(str(tmp_path / "small" / "labels" / "0001.tif"))
+    large = tifffile.imread(str(tmp_path / "large" / "labels" / "0001.tif"))
 
     assert (large > 0).sum() > (small > 0).sum()
-
-
-def test_regenerate_labels_without_source_experiment(tmp_path):
-    """labels/ is a pure derivative -- rebuilding must not need the experiment."""
-    import shutil
-
-    import tifffile
-
-    exp = _make_experiment(tmp_path)
-    _save_reference_image(exp.positions[0])
-    output = str(tmp_path / "out")
-    ml_export.export_experiment(exp, output)
-
-    shutil.rmtree(exp.path)  # source experiment is gone
-    os.remove(os.path.join(output, "labels", "0001.tif"))
-
-    assert ml_export.regenerate_labels(output) == 1
-    label = tifffile.imread(os.path.join(output, "labels", "0001.tif"))
-    assert label.max() == 1

--- a/tests/autolamella/test_ml_export.py
+++ b/tests/autolamella/test_ml_export.py
@@ -19,8 +19,15 @@ from fibsem.applications.autolamella.structures import (
     Experiment,
 )
 from fibsem.applications.autolamella.tools import ml_export
+from fibsem.applications.autolamella.workflows.tasks.fiducial import (
+    MillFiducialTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.rough import MillRoughTaskConfig
 from fibsem.applications.autolamella.workflows.tasks.select_position import (
     SelectMillingPositionTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
+    SpotBurnFiducialTaskConfig,
 )
 from fibsem.applications.autolamella.workflows.tasks.trench import MillTrenchTaskConfig
 from fibsem.structures import (
@@ -84,17 +91,19 @@ def _save_reference_image(lamella, image=None, res: int = 2, task_name=TASK_NAME
 # ── locating the source image ────────────────────────────────────────────────
 
 
-def test_select_position_task_names_finds_the_task(tmp_path):
+def test_task_names_for_type_finds_the_task(tmp_path):
     exp = _make_experiment(tmp_path)
-    assert ml_export.select_position_task_names(exp.positions[0]) == [TASK_NAME]
+    names = ml_export.task_names_for_type(exp.positions[0], "SELECT_MILLING_POSITION")
+    assert names == [TASK_NAME]
 
 
-def test_select_position_task_names_ignores_other_tasks(tmp_path):
+def test_task_names_for_type_ignores_other_types(tmp_path):
     exp = _make_experiment(tmp_path)
     lamella = exp.positions[0]
     lamella.task_config["Mill Trench"] = MillTrenchTaskConfig(task_name="Mill Trench")
 
-    assert ml_export.select_position_task_names(lamella) == [TASK_NAME]
+    names = ml_export.task_names_for_type(lamella, "SELECT_MILLING_POSITION")
+    assert names == [TASK_NAME]
 
 
 def test_find_final_fib_image_prefers_the_most_zoomed(tmp_path):
@@ -104,7 +113,10 @@ def test_find_final_fib_image_prefers_the_most_zoomed(tmp_path):
     _save_reference_image(lamella, res=1)
     expected = _save_reference_image(lamella, res=2)
 
-    assert ml_export.find_final_fib_image(lamella) == expected
+    assert ml_export.find_final_fib_image(lamella) == (
+        expected,
+        "SELECT_MILLING_POSITION",
+    )
 
 
 def test_find_final_fib_image_none_without_images(tmp_path):
@@ -133,6 +145,74 @@ def test_find_final_fib_image_ignores_sem_and_non_final(tmp_path):
         _make_fib_image().save(os.path.join(str(lamella.path), name))
 
     assert ml_export.find_final_fib_image(lamella) is None
+
+
+# ── falling back to a later task ─────────────────────────────────────────────
+
+FALLBACK_TASKS = [
+    ("SPOT_BURN_FIDUCIAL", SpotBurnFiducialTaskConfig, "Spot Burn Fiducial"),
+    ("MILL_FIDUCIAL", MillFiducialTaskConfig, "Mill Fiducial"),
+    ("MILL_ROUGH", MillRoughTaskConfig, "Rough Milling"),
+]
+
+
+@pytest.mark.parametrize("task_type,config_cls,task_name", FALLBACK_TASKS)
+def test_find_final_fib_image_falls_back_to_later_task(
+    tmp_path, task_type, config_cls, task_name
+):
+    """With no Select Milling Position images, a later task's set is used."""
+    exp = _make_experiment(tmp_path)
+    lamella = exp.positions[0]
+    lamella.task_config[task_name] = config_cls(task_name=task_name)
+    expected = _save_reference_image(lamella, task_name=task_name)
+
+    assert ml_export.find_final_fib_image(lamella) == (expected, task_type)
+
+
+def test_find_final_fib_image_prefers_select_position_over_fallbacks(tmp_path):
+    """Preference order is earliest task first -- the least milled sample."""
+    exp = _make_experiment(tmp_path)
+    lamella = exp.positions[0]
+    for task_type, config_cls, task_name in FALLBACK_TASKS:
+        lamella.task_config[task_name] = config_cls(task_name=task_name)
+        _save_reference_image(lamella, task_name=task_name)
+    expected = _save_reference_image(lamella)  # Select Milling Position
+
+    assert ml_export.find_final_fib_image(lamella) == (
+        expected,
+        "SELECT_MILLING_POSITION",
+    )
+
+
+def test_find_final_fib_image_fallback_order_is_earliest_first(tmp_path):
+    """Given only fiducial and rough images, the fiducial one wins."""
+    exp = _make_experiment(tmp_path)
+    lamella = exp.positions[0]
+    lamella.task_config["Rough Milling"] = MillRoughTaskConfig(task_name="Rough Milling")
+    _save_reference_image(lamella, task_name="Rough Milling")
+    lamella.task_config["Mill Fiducial"] = MillFiducialTaskConfig(
+        task_name="Mill Fiducial"
+    )
+    expected = _save_reference_image(lamella, task_name="Mill Fiducial")
+
+    assert ml_export.find_final_fib_image(lamella) == (expected, "MILL_FIDUCIAL")
+
+
+def test_export_records_which_task_the_image_came_from(tmp_path):
+    exp = _make_experiment(tmp_path)
+    lamella = exp.positions[0]
+    lamella.task_config["Rough Milling"] = MillRoughTaskConfig(task_name="Rough Milling")
+    _save_reference_image(lamella, task_name="Rough Milling")
+    output = str(tmp_path / "out")
+
+    ml_export.export_experiment(exp, output)
+
+    with open(os.path.join(output, "points", "0001.json")) as f:
+        assert json.load(f)["source_task"] == "MILL_ROUGH"
+    with open(os.path.join(output, "manifest.json")) as f:
+        manifest = json.load(f)
+    assert manifest["samples"][0]["source_task"] == "MILL_ROUGH"
+    assert manifest["n_samples_by_source_task"] == {"MILL_ROUGH": 1}
 
 
 # ── POI -> pixels ────────────────────────────────────────────────────────────
@@ -365,7 +445,7 @@ def test_export_writes_manifest_indexing_samples(tmp_path):
         manifest = json.load(f)
 
     assert manifest["format"] == "autolamella-targeting-points-v1"
-    assert manifest["source_task"] == "SELECT_MILLING_POSITION"
+    assert manifest["source_task_preference"][0] == "SELECT_MILLING_POSITION"
     assert manifest["n_samples"] == 2
     assert manifest["samples"][0]["image"] == "images/0001.tif"
     assert manifest["samples"][0]["points"] == "points/0001.json"


### PR DESCRIPTION
Closes [FIB-305](https://linear.app/fibsemos/issue/FIB-305/util-to-export-autolamella-experiment-data-to-targeting-ml-format).

## What

Turns the targets an operator picked during an experiment into training data for the automated lamella targeting model.

**One sample per lamella:** the final FIB reference image from its *Select Milling Position* task — the same kind of image the targeting pipeline runs on — labelled with the operator's point of interest.

## Why

The only existing producer of this format is `GridScreeningRun.to_ml_format()`, which exports the pipeline's *own* predicted masks, so training on it is self-reinforcing. Experiments are the opposite: every POI is a human-selected target on a real grid, with the outcome recorded alongside it. Every site running AutoLamella is already generating this and there was no path to use it.

## Output

Written to `<experiment>/targeting-export` by default, so a copied experiment directory carries its training data with it:

```
targeting-export/
    images/0001.tif      FIB reference image, metadata preserved
    points/0001.json     source of truth: exact coordinates + provenance
    labels/0001.tif      binary uint8 disc at the point, derived from points/
    manifest.json        index over the samples, plus skip reasons
```

`points/NNNN.json` is one flat object per lamella: sub-pixel coordinates (not rounded — that precision is the reason the sidecar exists), the original POI in milling coordinates, the milling-pose stage position, `shape` as named `{height, width}`, `pixelsize`, `hfw`, and provenance. The disc radius is given in **metres** and converted through each image's pixel size, so a label means the same physical size regardless of field of view. `images/` + `labels/` matches the pairing `upload_to_hf.create_dataset` already consumes.

## Notes for review

- **No stage reprojection.** The reference image is acquired at the milling position, so the POI — already a milling-coordinate offset in metres from the image centre — converts straight to pixels. Because it is held in metres, it lands correctly even though the operator picked it on a differently-zoomed image earlier in the task.
- **The source image is derived, not hardcoded.** `task_name` is user-configurable per protocol, so the exporter reads it off the lamella's `SELECT_MILLING_POSITION` config, then takes the highest `res_NN` of the final set. `field_of_views` sorts largest to smallest, so that is the most zoomed — and the image the task itself treats as its result.
- **Failures are kept, not dropped.** A target a human picked that then failed is a useful hard negative, so those are exported and tagged. Lamellae that never ran the task are skipped with the reason recorded in the manifest, and numbering stays contiguous across skips.
- **Writing inside the experiment directory is re-entrant.** A second export cannot ingest the first one's images (different directory and naming); there is a test for it.
- **The Development menu action does not prompt for a directory.** The destination is a subfolder that does not exist yet, which `open_existing_directory_dialog` cannot select. It exports to the default and opens the folder afterwards.

## Please check before merging

- [x] ~~Run it once against a real experiment.~~ **Done** — verified by @patrickcleeve on a real AutoLamella experiment; the derived filename patterns match what the acquisition code actually writes on disk.
- [ ] **`DEFAULT_DISC_RADIUS_M = 2.0e-6`** is a judgement call, not a measured value. Needs a domain sanity check.

## Known gap — POI may never have been set

The exporter gates on the reference image existing, not on the POI having been chosen. `select_poi_ui` returns `None` in unsupervised mode (`validate=False`) or with `select_poi=False`, in which case `Lamella.poi` keeps its template default while the final images are still acquired — so an unsupervised run would export labels at the untouched default position.

The POI can also be set from the lamella protocol editor, entirely outside the task, so "did the task ask?" is not a sound signal, and such data is rescuable by later review. Deliberately not addressed here; see FIB-305.

## Testing

34 unit tests covering source-image selection (including SEM and non-final decoys), the milling-coordinate y-flip, field-of-view independence, contiguous numbering across skips, the default path, re-entrancy, and that the label disc lands on the sidecar coordinates. Full suite green.

Also exposed as a CLI for batch conversion across experiments:

```
python -m fibsem.applications.autolamella.tools.ml_export <experiment-dir> [...]
```