### PR TITLE
[fix] overtilt: always restore the stage pose, even on cancel (FIB-307)

### DIFF
--- a/fibsem/milling/strategy/overtilt.py
+++ b/fibsem/milling/strategy/overtilt.py
@@ -118,6 +118,39 @@ class OvertiltTrenchMillingStrategy(MillingStrategy[OvertiltTrenchMillingConfig]
         ref_image = acquire.acquire_image(microscope, image_settings)
 
         # TODO: support rr
+        try:
+            self._mill_overtilted_patterns(
+                microscope=microscope,
+                stage=stage,
+                ref_image=ref_image,
+                overtilt_in_radians=overtilt_in_radians,
+                initial_position=initial_position,
+                stop_event=stop_event,
+            )
+        finally:
+            # Always leave the stage where we found it. A cancel or a failure part-way
+            # through the loop used to exit with the stage still overtilted, patterns
+            # loaded and the beam at milling current.
+            try:
+                microscope.finish_milling(
+                    imaging_current=microscope.system.ion.beam.beam_current,
+                    imaging_voltage=microscope.system.ion.beam.voltage,
+                )
+            except Exception as e:
+                logging.error(f"Failed to restore imaging conditions after {self.fullname}: {e}",
+                              exc_info=True)
+            microscope.move_stage_absolute(initial_position)
+
+    def _mill_overtilted_patterns(
+        self,
+        microscope: FibsemMicroscope,
+        stage: "FibsemMillingStage",
+        ref_image,
+        overtilt_in_radians: float,
+        initial_position: FibsemStagePosition,
+        stop_event: Optional[threading.Event],
+    ) -> None:
+        """Mill each pattern at an alternating over/under-tilt, realigning at each tilt."""
         for i, pattern in enumerate(stage.define_patterns()):
             # TODO: validate which direction to tilt, including when combined with scan rotation
             scan_rotation = microscope.get(

--- a/tests/milling/test_stop_event.py
+++ b/tests/milling/test_stop_event.py
@@ -109,6 +109,65 @@ def test_overtilt_threads_stop_event_into_alignment(monkeypatch):
     assert milled == []                  # aborted after alignment, before the beam
 
 
+# ── overtilt leaves the stage where it found it ──────────────────────────────
+
+def _stub_alignment(monkeypatch, on_call=None):
+    """Replace overtilt's alignment with a no-op (optionally firing a side effect).
+
+    Keeps these tests about stage handling, and off the ~2s cross-correlation the
+    real alignment runs against the simulator's noise images.
+    """
+    def fake_alignment(*args, **kwargs):
+        if on_call is not None:
+            on_call()
+
+    monkeypatch.setattr(
+        "fibsem.milling.strategy.overtilt.alignment.multi_step_alignment_v2",
+        fake_alignment,
+    )
+
+
+def test_overtilt_restores_stage_pose_after_a_normal_run(monkeypatch):
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    stage = _trench_stage("ot")
+    _stub_alignment(monkeypatch)
+
+    # capture the scalar: the simulator hands back its live position object, and
+    # move_stage_relative rebinds it while move_stage_absolute mutates in place
+    t0 = microscope.get_stage_position().t
+
+    stage.strategy.run(microscope, stage)
+
+    assert microscope.get_stage_position().t == pytest.approx(t0)
+
+
+def test_overtilt_restores_stage_pose_when_cancelled_mid_tilt(monkeypatch):
+    """Regression: the pose restore sat inside the per-pattern loop with no try/finally,
+    so a Stop after the tilt left the stage overtilted — at ±10 deg over a 50 nm lamella
+    that is not cosmetic."""
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    stage = _trench_stage("ot")
+    stage.strategy.config.overtilt = 10.0
+
+    ev = threading.Event()
+    tilted_at = {}
+
+    def stop_after_the_tilt():
+        # alignment runs after move_stage_relative, so the stage is tilted right now
+        tilted_at["t"] = microscope.get_stage_position().t
+        ev.set()
+
+    _stub_alignment(monkeypatch, on_call=stop_after_the_tilt)
+
+    t0 = microscope.get_stage_position().t
+
+    with pytest.raises(OperationCancelledError):
+        stage.strategy.run(microscope, stage, stop_event=ev)
+
+    assert tilted_at["t"] != pytest.approx(t0), "test is vacuous unless the stage really tilted"
+    assert microscope.get_stage_position().t == pytest.approx(t0)
+
+
 # ── task-level: aborts and still cleans up ───────────────────────────────────
 
 def test_task_aborts_and_restores_conditions(tmp_path):


### PR DESCRIPTION
Part of FIB-307 (milling voltage safety fixes), split into one PR per fix.
Independent of the others — touches only the overtilt strategy.

## What

`OvertiltTrenchMillingStrategy.run` restored the stage pose at the end of its
per-pattern loop, with no `try`/`finally` around it:

```python
for i, pattern in enumerate(stage.define_patterns()):
    ...
    microscope.move_stage_absolute(initial_position)   # only on the happy path
```

A user Stop — `raise_if_cancelled` fires just before the beam starts — or any
exception mid-loop therefore exited with the stage **still overtilted**, patterns
loaded and the beam left at milling current.

Moves the loop body into `_mill_overtilted_patterns` and wraps the call, so the
pose restore and `finish_milling` run on every path out.

## Why it matters now

Harmless at the strategy's current default of 1 degree. Not harmless at the ±10
degrees the low-kV polish in FIB-306 needs, over a lamella thinned to 50 nm.

## Tests

Two in `tests/milling/test_stop_event.py`, reusing that file's existing
monkeypatch-the-alignment pattern — alignment runs *after* `move_stage_relative`,
so firing the stop from inside it reproduces a cancel with the stage already tilted.

The cancel test was confirmed to fail against the unfixed strategy. The second test
asserts the pose is also restored on a normal run, which guards the refactor itself.

Full suite on this branch: 858 passed, 15 skipped.

## Note for review

The `finish_milling` inside the new `finally` is itself unguarded, so a failure
there would mask the original exception. Guarding it is a later PR in this series —
same latent issue exists today in `FibsemMillingTask.run`'s `finally`.