### PR TITLE
[fix] milling: restore the imaging voltage the task captured, not the config default (FIB-307)

### DIFF
--- a/fibsem/milling/tasks.py
+++ b/fibsem/milling/tasks.py
@@ -208,6 +208,21 @@ class FibsemMillingTask:
         """Handle progress updates from the microscope."""
         self.microscope.milling_progress_signal.emit(ddict)
 
+    def _imaging_conditions(self) -> Tuple[float, float]:
+        """The (current, voltage) the user was imaging at before milling started.
+
+        Falls back to the system defaults only if the task failed before it could
+        capture them. Every restore path must go through here: reading
+        ``system.ion.beam.*`` directly picks up the *config* default, which bounces
+        the column back to 30 kV whenever a stage mills at some other voltage.
+        """
+        current = self.initial_imaging_current
+        voltage = self.initial_imaging_voltage
+        return (
+            current if current is not None else self.microscope.system.ion.beam.beam_current,
+            voltage if voltage is not None else self.microscope.system.ion.beam.voltage,
+        )
+
     def _configure_path(self) -> None:
         """Configure the acquisition path for the milling task."""
         path = self.config.acquisition.imaging.path
@@ -250,15 +265,11 @@ class FibsemMillingTask:
                 "msg": f"Finished Milling Task: {self.name}. Restoring Imaging Conditions...",
                 "progress": {"state": "finished", "task_id": self.task_id, "task_name": self.name}
             })
-            # restore the captured pre-milling imaging current/voltage (falling back to the
-            # system defaults if we never got to capture them, e.g. an early failure).
+            # restore the captured pre-milling imaging current/voltage
+            imaging_current, imaging_voltage = self._imaging_conditions()
             self.microscope.finish_milling(
-                imaging_current=(self.initial_imaging_current
-                                 if self.initial_imaging_current is not None
-                                 else self.microscope.system.ion.beam.beam_current),
-                imaging_voltage=(self.initial_imaging_voltage
-                                 if self.initial_imaging_voltage is not None
-                                 else self.microscope.system.ion.beam.voltage),
+                imaging_current=imaging_current,
+                imaging_voltage=imaging_voltage,
             )
             # restore initial beam shift
             if self.initial_beam_shift is not None:
@@ -373,8 +384,9 @@ class FibsemMillingTask:
             stage_name (str): Name of the milling stage
             tag (str): Tag to append to the filename
         """
-        self.microscope.finish_milling(imaging_current=self.microscope.system.ion.beam.beam_current,    # type: ignore 
-                                       imaging_voltage=self.microscope.system.ion.beam.voltage)         # type: ignore
+        imaging_current, imaging_voltage = self._imaging_conditions()
+        self.microscope.finish_milling(imaging_current=imaging_current,
+                                       imaging_voltage=imaging_voltage)
 
         acq_date = current_timestamp_v3(timeonly=True)
         self.config.acquisition.imaging.filename = f"{stage_name}_{tag}_{acq_date}".replace(' ', '-')

--- a/tests/milling/test_tasks.py
+++ b/tests/milling/test_tasks.py
@@ -8,7 +8,7 @@ from fibsem.milling.tasks import (
     FibsemMillingTaskConfig,
     MillingTaskAcquisitionSettings,
 )
-from fibsem.structures import FibsemMillingSettings, ImageSettings
+from fibsem.structures import BeamType, FibsemMillingSettings, ImageSettings
 
 
 # ── MillingTaskAcquisitionSettings.estimated_time ────────────────────────────
@@ -90,9 +90,10 @@ def _spy(obj, name):
     return calls
 
 
-def _task(tmp_path, **acquisition):
+def _task(tmp_path, stages=None, **acquisition):
     microscope, _ = utils.setup_session(manufacturer="Demo")
-    cfg = FibsemMillingTaskConfig.from_stages(stages=[FibsemMillingStage(name="s")], name="t")
+    stages = stages if stages is not None else [FibsemMillingStage(name="s")]
+    cfg = FibsemMillingTaskConfig.from_stages(stages=stages, name="t")
     cfg.acquisition.imaging.path = str(tmp_path)
     # drift correction acquires its own images; switch it off so the assertions below
     # are about the post-task refresh and nothing else
@@ -129,3 +130,44 @@ def test_final_image_flag_round_trips():
     settings = MillingTaskAcquisitionSettings(acquire_final_image=False)
     restored = MillingTaskAcquisitionSettings.from_dict(settings.to_dict())
     assert restored.acquire_final_image is False
+
+
+# ── restores go back to what the user was imaging at ─────────────────────────
+#
+# Nothing shipped has ever milled at a voltage other than 30 kV, so the restore
+# paths have never been exercised at a second voltage. Low-kV polishing steps
+# 30 -> 8 -> 2 kV across stages, which is where the two paths disagreeing matters.
+
+def test_every_restore_uses_the_captured_voltage(tmp_path):
+    """Regression: _acquire_milling_task_images restored system.ion.beam.voltage — the
+    config default — while run()'s finally correctly used the captured value. A task
+    milling at 8 kV therefore bounced the column to 30 kV between stages."""
+    polish_stage = FibsemMillingStage(
+        name="polish", milling=FibsemMillingSettings(milling_voltage=8e3)
+    )
+    microscope, task = _task(tmp_path, stages=[polish_stage], acquire_fib=True)
+
+    # image at a voltage that is neither the config default nor the milling voltage,
+    # so a wrong restore is unambiguous
+    microscope.set_beam_voltage(voltage=2e3, beam_type=BeamType.ION)
+    assert microscope.system.ion.beam.voltage != 2e3, "guard: config default must differ"
+
+    restored = _spy(microscope, "finish_milling")
+    task.run()
+
+    assert restored, "finish_milling should have run"
+    voltages = [call[1]["imaging_voltage"] for call in restored]
+    assert all(v == 2e3 for v in voltages), f"expected every restore at 2 kV, got {voltages}"
+    assert microscope.get_beam_voltage(BeamType.ION) == 2e3
+
+
+def test_imaging_conditions_falls_back_before_capture(tmp_path):
+    """If the task failed before it could capture the live conditions, fall back to the
+    system defaults rather than passing None to the column."""
+    microscope, task = _task(tmp_path)
+    assert task.initial_imaging_current is None and task.initial_imaging_voltage is None
+
+    current, voltage = task._imaging_conditions()
+
+    assert current == microscope.system.ion.beam.beam_current
+    assert voltage == microscope.system.ion.beam.voltage


### PR DESCRIPTION
Part of FIB-307 (milling voltage safety fixes), split into one PR per fix.

> **Stacked on #184.** Base is `claude/fib-307-acquire-final-image`, so the diff
> here is just this change. GitHub will retarget it to `main` automatically once
> #184 merges. Stacked rather than branched off main because both PRs touch
> `tasks.py` and `test_tasks.py` in the same regions, and this one's tests build on
> the `_task`/`_spy` helpers #184 adds.

## What

`FibsemMillingTask` captures the live imaging current/voltage before milling starts,
and `run()`'s `finally` restores exactly those:

```python
self.initial_imaging_current = self.microscope.get_beam_current(self.config.channel)
self.initial_imaging_voltage = self.microscope.get_beam_voltage(self.config.channel)
```

`_acquire_milling_task_images` did not. It read `system.ion.beam.*` instead — the
*config* default from the microscope YAML:

```python
self.microscope.finish_milling(imaging_current=self.microscope.system.ion.beam.beam_current,
                               imaging_voltage=self.microscope.system.ion.beam.voltage)
```

With every shipped protocol milling at 30 kV the two agree, which is why this has
never surfaced. A task that mills at any other voltage bounces the column back to
30 kV between stages.

Both sites now go through one `_imaging_conditions()` helper, so they cannot drift
apart again.

## Tests

Two in `tests/milling/test_tasks.py`.

The regression test images at 2 kV, mills at 8 kV, and asserts every `finish_milling`
call restores 2 kV — deliberately a value that is neither the milling voltage nor the
config default, so a wrong restore cannot pass by coincidence. Confirmed to fail with
the old inter-stage line back in place.

The second covers the fallback: if the task failed before it could capture the live
conditions, the helper returns the system defaults rather than passing `None` to the
column.

Full suite on this branch: 862 passed, 15 skipped.