### PR TITLE
Correlation setup: fix the Setup-tab regressions and stop every open becoming a run

### DIFF
--- a/fibsem/correlation/config.py
+++ b/fibsem/correlation/config.py
@@ -1,8 +1,8 @@
 """Experiment-global correlation configuration (Tier-1 of the persistence design).
 
 ``CorrelationConfig`` is the reusable home for how a correlation is set up: fit
-settings, RI-correction parameters, an interpolation preference, and the
-spot-burn seeding toggle. It is held as a peer field on
+settings, RI-correction parameters, and the spot-burn seeding toggle. It is held
+as a peer field on
 ``AutoLamellaTaskProtocol`` — not an ``AutoLamellaTaskConfig``, since correlation
 is a user step, not an automated microscope task. Defined here so the autolamella
 model only holds an instance; imports no UI.
@@ -14,7 +14,6 @@ from typing import Any, Dict, Optional
 
 # Mirror the UI constants as plain strings so this module never imports the UI.
 FIT_METHODS = ("None", "Hole", "Gaussian")
-INTERPOLATION_METHODS = ("linear", "cubic")
 
 
 @dataclass
@@ -95,49 +94,24 @@ class RISettings:
 
 
 @dataclass
-class InterpolationSettings:
-    """FM z-interpolation preference. ``isotropic`` targets XY pixel size, else
-    ``target_z_nm``."""
-
-    enabled: bool = False
-    isotropic: bool = True
-    target_z_nm: Optional[float] = None
-    method: str = "linear"
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "enabled": self.enabled,
-            "isotropic": self.isotropic,
-            "target_z_nm": self.target_z_nm,
-            "method": self.method,
-        }
-
-    @staticmethod
-    def from_dict(data: Optional[Dict[str, Any]]) -> "InterpolationSettings":
-        d = data or {}
-        default = InterpolationSettings()
-        return InterpolationSettings(
-            enabled=d.get("enabled", default.enabled),
-            isotropic=d.get("isotropic", default.isotropic),
-            target_z_nm=d.get("target_z_nm"),
-            method=d.get("method", default.method),
-        )
-
-
-@dataclass
 class CorrelationConfig:
-    """Experiment-global correlation config; inherited by every lamella in the run."""
+    """Experiment-global correlation config; inherited by every lamella in the run.
+
+    Interpolation is deliberately absent. It was persisted here for the setup
+    pre-dialog, which FIB-302 replaced with the in-window Interpolate action, and
+    a stored preference nothing reads is how ``load_spot_burns`` came to be inert
+    (FIB-319). ``from_dict`` reads named keys only, so the leftover
+    ``"interpolation"`` in an existing protocol is ignored rather than fatal.
+    """
 
     fit: FitSettings = field(default_factory=FitSettings)
     ri: RISettings = field(default_factory=RISettings)
-    interpolation: InterpolationSettings = field(default_factory=InterpolationSettings)
     load_spot_burns: bool = True
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "fit": self.fit.to_dict(),
             "ri": self.ri.to_dict(),
-            "interpolation": self.interpolation.to_dict(),
             "load_spot_burns": self.load_spot_burns,
         }
 
@@ -147,6 +121,5 @@ class CorrelationConfig:
         return CorrelationConfig(
             fit=FitSettings.from_dict(d.get("fit")),
             ri=RISettings.from_dict(d.get("ri")),
-            interpolation=InterpolationSettings.from_dict(d.get("interpolation")),
             load_spot_burns=d.get("load_spot_burns", True),
         )

--- a/fibsem/correlation/ui/widgets/correlation_setup_section.py
+++ b/fibsem/correlation/ui/widgets/correlation_setup_section.py
@@ -21,7 +21,7 @@ Deliberately not here, because the widget already provides it:
 from __future__ import annotations
 
 import datetime
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
@@ -81,6 +81,11 @@ class CorrelationSetupSection(QWidget):
     ``seed_requested(source, payload)``
         ``payload`` is a ``CorrelationInputData`` (previous run), a
         ``list[Point]`` (spot burns, normalised 0-1), or ``None``.
+
+    ``can_reseed(source) -> bool``
+        Optional veto the widget installs: consulted *before* emitting, because
+        only the widget knows whether the coordinates are worth protecting or
+        whether a source can be applied at all. Refusing restores the controls.
     """
 
     seed_requested = pyqtSignal(str, object)
@@ -91,9 +96,13 @@ class CorrelationSetupSection(QWidget):
         spot_burns: Optional[List[Point]] = None,
         history: Optional[LamellaCorrelation] = None,
         config: Optional[CorrelationConfig] = None,
+        spot_burns_available: bool = True,
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
+        self.can_reseed: Optional[Callable[[str], bool]] = None
+        self._applied = (SEED_NONE, -1)
+        self._burns_available = spot_burns_available
         self._config = config or CorrelationConfig()
         self._spot_burns: List[Point] = list(spot_burns or [])
         # Newest first, so index i in the dropdown is self._prev_runs[i].
@@ -118,13 +127,16 @@ class CorrelationSetupSection(QWidget):
             )
         )
 
-        self.rb_burns.setEnabled(bool(self._spot_burns))
+        self._apply_burn_availability()
         self.rb_prev.setEnabled(bool(self._prev_runs))
         # Default: previous run if one exists, else spot burns, else nothing —
         # the same precedence the editor applied implicitly before this section.
+        # load_spot_burns gates the *default*, not the choice: before this section
+        # the flag meant "don't seed burns automatically", and an explicit click
+        # here is not automatic (FIB-319).
         if self._prev_runs:
             self.rb_prev.setChecked(True)
-        elif self._spot_burns:
+        elif self.rb_burns.isEnabled() and self._config.load_spot_burns:
             self.rb_burns.setChecked(True)
         else:
             self.rb_none.setChecked(True)
@@ -136,6 +148,7 @@ class CorrelationSetupSection(QWidget):
             rb.toggled.connect(self._on_source_toggled)
         self.run_combo.currentIndexChanged.connect(self._on_run_changed)
         self._apply_enabled_state()
+        self._record_applied()
 
     # ---- construction -------------------------------------------------------
 
@@ -147,10 +160,7 @@ class CorrelationSetupSection(QWidget):
 
         self._group = QButtonGroup(self)
         self.rb_none = QRadioButton("None — pick everything fresh")
-        burn_label = f"Spot-burn fiducials · {len(self._spot_burns)} found"
-        if not self._prev_runs:
-            burn_label += "  (first)"
-        self.rb_burns = QRadioButton(burn_label)
+        self.rb_burns = QRadioButton()  # text set by _apply_burn_availability
         self.rb_prev = QRadioButton("Previous correlation")
         for rb in (self.rb_none, self.rb_burns, self.rb_prev):
             rb.setStyleSheet(_CONTROL_STYLE)
@@ -221,7 +231,12 @@ class CorrelationSetupSection(QWidget):
         return None
 
     def emit_current_seed(self) -> None:
-        """Apply the current selection — also the initial seed on open."""
+        """Apply the current selection — also the initial seed on open.
+
+        Unguarded by design: the caller asked for this selection outright, and on
+        open there is nothing on the canvas to protect.
+        """
+        self._record_applied()
         self.seed_requested.emit(self.seed_source(), self.seed_payload())
 
     # ---- interaction --------------------------------------------------------
@@ -231,11 +246,66 @@ class CorrelationSetupSection(QWidget):
         self.run_combo.setEnabled(is_prev)
         self._prev_caption.setVisible(is_prev)
 
+    def _apply_burn_availability(self) -> None:
+        """Burns are normalised to the FIB image they were placed on, so with no
+        image loaded there is nothing to multiply them by. Say that on the
+        control, rather than accepting the choice and quietly doing nothing
+        (FIB-319)."""
+        self.rb_burns.setEnabled(bool(self._spot_burns) and self._burns_available)
+        label = f"Spot-burn fiducials · {len(self._spot_burns)} found"
+        if self._spot_burns and not self._burns_available:
+            label += "  (needs the FIB image)"
+        elif not self._prev_runs:
+            label += "  (first)"
+        self.rb_burns.setText(label)
+
+    def set_spot_burns_available(self, available: bool) -> None:
+        """Track whether a FIB image is loaded: opening without one and browsing
+        to it is a supported route, and the choice should appear when it lands."""
+        if available == self._burns_available:
+            return
+        self._burns_available = available
+        self._apply_burn_availability()
+
+    def _record_applied(self) -> None:
+        """Remember the selection that is actually on the canvas."""
+        self._applied = (self.seed_source(), self.run_combo.currentIndex())
+
+    def _restore_applied(self) -> None:
+        """Put the controls back to the last applied selection, silently.
+
+        Qt flips a radio's checked state *before* emitting ``toggled``, so a
+        request the widget refuses would otherwise leave the control claiming a
+        source that was never applied — and unrecoverable by the obvious action,
+        since re-clicking the same radio emits nothing (FIB-319).
+        """
+        source, run_index = self._applied
+        widgets = (self.rb_none, self.rb_burns, self.rb_prev, self.run_combo)
+        for w in widgets:
+            w.blockSignals(True)
+        try:
+            {
+                SEED_SPOT_BURNS: self.rb_burns,
+                SEED_PREVIOUS: self.rb_prev,
+            }.get(source, self.rb_none).setChecked(True)
+            self.run_combo.setCurrentIndex(run_index)
+        finally:
+            for w in widgets:
+                w.blockSignals(False)
+        self._apply_enabled_state()
+
+    def _request_apply(self) -> None:
+        """Apply the current selection, unless the widget vetoes it."""
+        if self.can_reseed is not None and not self.can_reseed(self.seed_source()):
+            self._restore_applied()
+            return
+        self.emit_current_seed()
+
     def _on_source_toggled(self, checked: bool) -> None:
         self._apply_enabled_state()
         if checked:  # only the newly-selected radio, not the one being cleared
-            self.emit_current_seed()
+            self._request_apply()
 
     def _on_run_changed(self, _index: int) -> None:
         if self.rb_prev.isChecked():
-            self.emit_current_seed()
+            self._request_apply()

--- a/fibsem/correlation/ui/widgets/correlation_setup_section.py
+++ b/fibsem/correlation/ui/widgets/correlation_setup_section.py
@@ -63,6 +63,21 @@ def format_run_timestamp(name: str) -> str:
     return dt.strftime("%Y-%m-%d %H:%M:%S")
 
 
+def format_run_label(run: CorrelationRun) -> str:
+    """Dropdown label for one previous run: its timestamp, and whether it has a
+    result.
+
+    A run folder is not proof a correlation ran — ``File > Save Correlation``
+    writes one deliberately, and a run whose result was discarded keeps its
+    folder. Without the suffix those are indistinguishable from a completed
+    correlation at the moment you pick what to seed from (FIB-320).
+    """
+    label = format_run_timestamp(run.name)
+    if run.state.result is None:
+        label += "  ·  no result"
+    return label
+
+
 def _caption(text: str, indent: int = 0) -> QLabel:
     lbl = QLabel(text)
     style = f"color:{_MUTED};font-size:11px;"
@@ -171,7 +186,7 @@ class CorrelationSetupSection(QWidget):
         run_layout = QHBoxLayout(run_row)
         run_layout.setContentsMargins(20, 0, 0, 0)
         self.run_combo = ValueComboBox(
-            [format_run_timestamp(r.name) for r in self._prev_runs]
+            [format_run_label(r) for r in self._prev_runs]
         )
         self.run_combo.setStyleSheet(_CONTROL_STYLE)
         run_layout.addWidget(self.run_combo, 1)

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -2731,8 +2731,13 @@ class CorrelationTabWidget(QWidget):
         path, _ = QFileDialog.getSaveFileName(
             self, "Save Correlation Plot", default, "PNG (*.png);;All files (*)"
         )
-        if path:
+        if not path:
+            return
+        try:
             self.save_plot(path)
+        except Exception as exc:
+            logging.exception("Failed to save correlation plot to %s", path)
+            QMessageBox.warning(self, "Save Error", f"Could not save plot:\n{exc}")
 
     def save_plot(self, path: Optional[str] = None) -> None:
         """Save FIB + FM canvases as a side-by-side matplotlib figure."""
@@ -2814,8 +2819,16 @@ class CorrelationTabWidget(QWidget):
         path, _ = QFileDialog.getSaveFileName(
             self, "Save Correlation", start, "JSON (*.json);;All files (*)"
         )
-        if path:
+        if not path:
+            return
+        # Mirrors the load handler: a save that fails has to say so. Without this
+        # the exception went to the event loop, so the user was told nothing and
+        # walked away believing the file had been written.
+        try:
             self.save_correlation(path)
+        except Exception as exc:
+            logging.exception("Failed to save correlation to %s", path)
+            QMessageBox.warning(self, "Save Error", f"Could not save correlation:\n{exc}")
 
     # ------------------------------------------------------------------
     # FM z-stack interpolation (FIB-253)

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -1779,9 +1779,24 @@ class CorrelationTabWidget(QWidget):
         return px
 
     def set_project_dir(self, path: str) -> None:
-        """Set the project directory used for auto-save and export."""
+        """Set where this correlation would be saved.
+
+        A destination, not a promise: the directory is created on the first write
+        worth making, not here. See :meth:`_ensure_project_dir` (FIB-320).
+        """
         self._project_dir = path
         self._images_tab._proj_path.setText(path)
+
+    def _ensure_project_dir(self) -> Optional[str]:
+        """The project directory, created on demand. None if none is set.
+
+        Only ever called from a path that is about to write a file, so an
+        abandoned session leaves nothing behind.
+        """
+        if not self._project_dir:
+            return None
+        os.makedirs(self._project_dir, exist_ok=True)
+        return self._project_dir
 
     def set_data(self, data: CorrelationInputData) -> None:
         """Populate all coordinate lists and refresh canvases."""
@@ -2257,12 +2272,21 @@ class CorrelationTabWidget(QWidget):
         design. The result carries its own ``computed_from`` snapshot, so
         staleness stays derivable on load (``matches_inputs``) and the result
         remains available to inspect; it is not silently discarded here.
+
+        Nothing is written until there is a result to write, because a run folder
+        is no longer inert bookkeeping — the setup section seeds from it. Saving
+        from the first data change made every *open* a run: history counted opens
+        rather than correlations, and a session the user cancelled came back as
+        the next open's starting coordinates (FIB-320). Once the folder exists it
+        keeps its contents current, result or not.
         """
         if not self._project_dir:
             return
+        if self._result is None and not os.path.isdir(self._project_dir):
+            return
         try:
             CorrelationState(input_data=self.data, result=self._result).save(
-                os.path.join(self._project_dir, CORRELATION_FILENAME)
+                os.path.join(self._ensure_project_dir(), CORRELATION_FILENAME)
             )
         except Exception as exc:
             # Never let this pass unseen: it is the only persistence path, so a
@@ -2705,7 +2729,9 @@ class CorrelationTabWidget(QWidget):
                 QMessageBox.warning(self, "Save Plot", "No project directory set.")
                 return
             ts = time.strftime(DATETIME_FILE)
-            path = os.path.join(self._project_dir, f"correlation_plot_{ts}.png")
+            # Writing a file into the run folder, so this is a moment it should
+            # exist — the auto-save may not have minted it yet (FIB-320).
+            path = os.path.join(self._ensure_project_dir(), f"correlation_plot_{ts}.png")
 
         self._fib_canvas.reset_view()
         self._fm_display.canvas.reset_view()

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -1782,21 +1782,25 @@ class CorrelationTabWidget(QWidget):
         """Set where this correlation would be saved.
 
         A destination, not a promise: the directory is created on the first write
-        worth making, not here. See :meth:`_ensure_project_dir` (FIB-320).
+        worth making, not here. See :meth:`_ensure_dir_for` (FIB-320).
         """
         self._project_dir = path
         self._images_tab._proj_path.setText(path)
 
-    def _ensure_project_dir(self) -> Optional[str]:
-        """The project directory, created on demand. None if none is set.
+    @staticmethod
+    def _ensure_dir_for(path: str) -> str:
+        """Create the directory ``path`` is about to be written into; return path.
 
-        Only ever called from a path that is about to write a file, so an
-        abandoned session leaves nothing behind.
+        Every write site needs this now the run folder is created on demand: the
+        auto-save mints it on the first result, and both save dialogs offer a
+        default *inside* it — so an explicitly-passed path can be just as absent
+        as a derived one (FIB-320). Called immediately before writing, so an
+        abandoned session still leaves nothing behind.
         """
-        if not self._project_dir:
-            return None
-        os.makedirs(self._project_dir, exist_ok=True)
-        return self._project_dir
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        return path
 
     def set_data(self, data: CorrelationInputData) -> None:
         """Populate all coordinate lists and refresh canvases."""
@@ -2125,8 +2129,16 @@ class CorrelationTabWidget(QWidget):
         self.data_changed.emit(self.data)
 
     def save_correlation(self, path: str) -> None:
-        """Save the whole correlation state (points + result) to one JSON."""
-        CorrelationState(input_data=self.data, result=self._result).save(path)
+        """Save the whole correlation state (points + result) to one JSON.
+
+        Creates the containing directory first. ``File > Save Correlation`` seeds
+        its dialog with the run folder, which since FIB-320 is created on demand
+        and may not exist yet — accepting that default would otherwise fail on
+        ``open()``. An explicit save names where it goes; make that place.
+        """
+        CorrelationState(input_data=self.data, result=self._result).save(
+            self._ensure_dir_for(path)
+        )
 
     @property
     def data(self) -> CorrelationInputData:
@@ -2286,7 +2298,9 @@ class CorrelationTabWidget(QWidget):
             return
         try:
             CorrelationState(input_data=self.data, result=self._result).save(
-                os.path.join(self._ensure_project_dir(), CORRELATION_FILENAME)
+                self._ensure_dir_for(
+                    os.path.join(self._project_dir, CORRELATION_FILENAME)
+                )
             )
         except Exception as exc:
             # Never let this pass unseen: it is the only persistence path, so a
@@ -2729,9 +2743,11 @@ class CorrelationTabWidget(QWidget):
                 QMessageBox.warning(self, "Save Plot", "No project directory set.")
                 return
             ts = time.strftime(DATETIME_FILE)
-            # Writing a file into the run folder, so this is a moment it should
-            # exist — the auto-save may not have minted it yet (FIB-320).
-            path = os.path.join(self._ensure_project_dir(), f"correlation_plot_{ts}.png")
+            path = os.path.join(self._project_dir, f"correlation_plot_{ts}.png")
+        # Whichever branch supplied it: the Save Plot dialog offers a default
+        # inside the run folder, so an explicit path lands in the same
+        # not-yet-created directory the derived one would (FIB-320).
+        path = self._ensure_dir_for(path)
 
         self._fib_canvas.reset_view()
         self._fm_display.canvas.reset_view()

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -1280,6 +1280,12 @@ _POINT_TYPE_SIDES: Dict[PointType, str] = {
     PointType.SURFACE_FM: "fm",
 }
 
+# The point types whose z is a slice index into the FM volume, and so move when
+# that volume is resampled. Derived from the map above so the two can't drift.
+_FM_SIDE_POINT_TYPES = frozenset(
+    pt.value for pt, side in _POINT_TYPE_SIDES.items() if side == "fm"
+)
+
 
 class _CanvasAdapter:
     """Thin seam over a point-display surface (canvas or display widget).
@@ -1388,6 +1394,8 @@ class CorrelationTabWidget(QWidget):
         # Positions as last seeded by the setup section, to detect manual edits
         # before replacing them (None = nothing seeded yet). FIB-302.
         self._seeded_positions: Optional[list] = None
+        # Installed only when a lamella opens this window (add_lamella_setup).
+        self._setup_section = None
         # Last auto-save failure, held so the status line keeps reporting it
         # instead of claiming "Ready." while nothing is saved (FIB-316).
         self._autosave_error: Optional[str] = None
@@ -1703,6 +1711,8 @@ class CorrelationTabWidget(QWidget):
                 spec.list_widget.set_axis_maxima(x_max=w - 1, y_max=h - 1)
         self._images_tab.set_fib_image(fib_image)
         self._update_fib_name_label(fib_image)
+        if self._setup_section is not None:
+            self._setup_section.set_spot_burns_available(True)
         # The image is an input to the fit, so swapping it invalidates the result
         # and re-opens the readiness question. data_changed drives both (via
         # _on_data_changed and _update_run_button) — without it, Continue stayed
@@ -1969,8 +1979,13 @@ class CorrelationTabWidget(QWidget):
         )
 
         section = CorrelationSetupSection(
-            spot_burns=spot_burns, history=history, config=config, parent=self
+            spot_burns=spot_burns,
+            history=history,
+            config=config,
+            spot_burns_available=self._fib_image is not None,
+            parent=self,
         )
+        section.can_reseed = self._allow_reseed
         section.seed_requested.connect(self._on_setup_seed_requested)
         self._images_tab.add_setup_section(section)
         self._images_tab.set_image_options("fib", fib_options or [], fib_current)
@@ -1980,19 +1995,45 @@ class CorrelationTabWidget(QWidget):
         self._setup_section = section
         return section
 
+    def _allow_reseed(self, source: str) -> bool:
+        """Veto for the setup section, consulted before it emits (FIB-319).
+
+        Two reasons to refuse, in order — an impossible source is settled first,
+        so the user is never asked to sacrifice their points for a seed that was
+        never going to be applied:
+
+        1. Spot burns without a FIB image. The burns are normalised to *that*
+           image; with no image there is nothing to multiply by, and the seeding
+           call would return early leaving the radio reading as applied.
+        2. Points that differ from what was last seeded.
+
+        The section restores its controls when this returns False, so the choice
+        on screen keeps matching the canvas.
+        """
+        from fibsem.correlation.ui.widgets.correlation_setup_section import (
+            SEED_SPOT_BURNS,
+        )
+
+        if source == SEED_SPOT_BURNS and self._fib_image is None:
+            QMessageBox.information(
+                self,
+                "No FIB image",
+                "Spot-burn positions are stored relative to the FIB image they "
+                "were placed on.\n\nLoad that image first, then choose them again.",
+            )
+            return False
+        return not self._has_manual_edits() or self._confirm_reseed()
+
     def _on_setup_seed_requested(self, source: str, payload) -> None:
         """Apply a starting-coordinates choice from the setup section.
 
-        Guards edits: once points have been moved by hand, silently replacing
-        them would throw that work away, so confirm first.
+        Whether it *may* be applied was settled by :meth:`_allow_reseed` before
+        the section emitted; this only applies it.
         """
         from fibsem.correlation.ui.widgets.correlation_setup_section import (
             SEED_PREVIOUS,
             SEED_SPOT_BURNS,
         )
-
-        if self._has_manual_edits() and not self._confirm_reseed():
-            return
 
         if source == SEED_PREVIOUS and payload is not None:
             self.seed_coordinates(copy.deepcopy(payload))
@@ -2009,10 +2050,31 @@ class CorrelationTabWidget(QWidget):
         self._seeded_positions = self._current_positions()
 
     def _current_positions(self) -> list:
+        """Every point on the canvas, as comparable ``(type, x, y, z)`` tuples.
+
+        The surface points are in here too: they are single points held in their
+        own fields rather than lists, and leaving them out meant a re-seed wiped
+        a placed surface point — silently disarming any stored RI pre-correction
+        with it — without so much as a confirmation (FIB-319).
+        """
         d = self.data
-        return [
-            c.point.to_dict()
-            for c in (d.fib_coordinates + d.fm_coordinates + d.poi_coordinates)
+        coords = d.fib_coordinates + d.fm_coordinates + d.poi_coordinates
+        coords += [c for c in (d.surface_coordinate, d.fm_surface_coordinate) if c]
+        return [(c.point_type.value, c.point.x, c.point.y, c.point.z) for c in coords]
+
+    def _rescale_baseline_z(self, scale: float) -> None:
+        """Apply an FM z-rescale to the seeded baseline as well as the points.
+
+        Interpolation moves every FM-side z by the slice ratio. Rescaling only
+        the points would leave the baseline describing the old sampling, so the
+        next re-seed would announce that the coordinates "have been edited" when
+        the user edited nothing (FIB-319).
+        """
+        if self._seeded_positions is None:
+            return
+        self._seeded_positions = [
+            (t, x, y, z * scale if t in _FM_SIDE_POINT_TYPES else z)
+            for (t, x, y, z) in self._seeded_positions
         ]
 
     def _has_manual_edits(self) -> bool:
@@ -2022,10 +2084,12 @@ class CorrelationTabWidget(QWidget):
         return self._current_positions() != self._seeded_positions
 
     def _confirm_reseed(self) -> bool:
+        # Deliberately doesn't claim the points were *edited*: they may equally
+        # have arrived from File > Load Correlation, which this never sees.
         reply = QMessageBox.question(
             self,
             "Replace coordinates?",
-            "The current coordinates have been edited. Seeding will replace them.",
+            "Seeding will replace the coordinates currently on the canvas.",
             QMessageBox.Ok | QMessageBox.Cancel,
             QMessageBox.Cancel,
         )
@@ -2119,7 +2183,7 @@ class CorrelationTabWidget(QWidget):
     @property
     def correlation_config(self) -> CorrelationConfig:
         """Current config: fit/RI read from the widgets; UI-less fields (cutout,
-        interpolation, spot burns) carried through from what was set."""
+        spot burns) carried through from what was set."""
         cl = self._coords_tab
         stored = self._correlation_config
         params = self._ri_tab._ri_widget.get_params()
@@ -2143,7 +2207,6 @@ class CorrelationTabWidget(QWidget):
         return CorrelationConfig(
             fit=fit,
             ri=ri,
-            interpolation=stored.interpolation,
             load_spot_burns=stored.load_spot_burns,
         )
 
@@ -2748,30 +2811,6 @@ class CorrelationTabWidget(QWidget):
         target_m, method = dlg.result_params()
         self._start_fm_interpolation(target_m, method)
 
-    def start_fm_interpolation(
-        self, *, isotropic: bool, target_z_nm: Optional[float], method: str
-    ) -> None:
-        """Kick off FM interpolation from the setup pre-dialog's choice (FIB-302).
-
-        Isotropic targets the XY pixel size (the same default ``InterpolateZDialog``
-        uses); an explicit target is given in nm. No-op unless the volume is
-        interpolatable (multi-slice with a known z step) — mirrors the in-widget
-        Interpolate button's enable rule.
-        """
-        if self._fm_image is None:
-            return
-        meta = self._fm_image.metadata
-        z_step = getattr(meta, "pixel_size_z", None)
-        if self._fm_image.data.shape[1] <= 1 or not z_step:
-            return
-        if isotropic:
-            target_m = meta.pixel_size_x
-        elif target_z_nm:
-            target_m = target_z_nm * 1e-9
-        else:
-            return
-        self._start_fm_interpolation(target_m, method)
-
     def _start_fm_interpolation(self, target_m: float, method: str) -> None:
         from fibsem.correlation.util import interpolate_fm_volume
         from fibsem.ui.qt.threading import FunctionWorker
@@ -2823,6 +2862,7 @@ class CorrelationTabWidget(QWidget):
         """
         new_nz = new_image.data.shape[1]
         self._rescale_fm_z(new_nz / old_nz)
+        self._rescale_baseline_z(new_nz / old_nz)  # nothing was *edited* by this
         self.set_fm_image(new_image)
         self.set_data(self.data)  # redraw lists/canvas at the rescaled z
         self.data_changed.emit(self.data)  # auto-save + RI refresh (new z step)
@@ -3061,13 +3101,6 @@ class CorrelationTabDialog(QDialog):
 
     def add_lamella_setup(self, **kwargs):
         return self.widget.add_lamella_setup(**kwargs)
-
-    def start_fm_interpolation(
-        self, *, isotropic: bool, target_z_nm: "Optional[float]", method: str
-    ) -> None:
-        self.widget.start_fm_interpolation(
-            isotropic=isotropic, target_z_nm=target_z_nm, method=method
-        )
 
     @property
     def correlation_config(self) -> "CorrelationConfig":

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -1004,11 +1004,22 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         )
         os.makedirs(project_path, exist_ok=True)
 
+        fib_current = self._image_path(
+            selected_lamella, self.combobox_fib_filenames.currentText()
+        )
+        fm_current = self._image_path(
+            selected_lamella, self.combobox_fm_filenames.currentText()
+        )
+
         dialog = CorrelationTabDialog(parent=self)
         dialog.set_project_dir(project_path)
         if protocol is not None:
             dialog.set_correlation_config(protocol.correlation)
-        if self.image is not None:
+        # Only a real image: with no reference image on disk self.image is a blank
+        # placeholder generated for the editor's own canvas, and correlating
+        # against it would scale the spot burns and the resulting POI by
+        # placeholder dimensions (FIB-319).
+        if self.image is not None and os.path.isfile(fib_current):
             dialog.set_fib_image(self.image)
         if self.fm_image is not None:
             dialog.set_fm_image(self.fm_image)
@@ -1024,13 +1035,9 @@ class AutoLamellaProtocolEditorWidget(QWidget):
             fib_options=self._image_paths(
                 selected_lamella, self.combobox_fib_filenames
             ),
-            fib_current=self._image_path(
-                selected_lamella, self.combobox_fib_filenames.currentText()
-            ),
+            fib_current=fib_current,
             fm_options=self._image_paths(selected_lamella, self.combobox_fm_filenames),
-            fm_current=self._image_path(
-                selected_lamella, self.combobox_fm_filenames.currentText()
-            ),
+            fm_current=fm_current,
         )
         section.emit_current_seed()  # apply the default source, live on the canvas
 

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -990,19 +990,21 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         )
 
         correlation_root = os.path.join(selected_lamella.path, "Correlation")
-        # Discover previous runs BEFORE minting this run's folder (so this open
-        # isn't its own "previous"). FIB-299.
         history = LamellaCorrelation.discover(correlation_root)
 
         experiment = self.parent_widget.experiment if self.parent_widget else None
         protocol = experiment.task_protocol if experiment is not None else None
         spot_burns = self._spot_burn_coordinates(selected_lamella)
 
+        # Named now, created by the widget only if this session records a result.
+        # Creating it here made every *open* a run: cancelling still left a folder
+        # behind, which the setup section then offered as a previous correlation
+        # to seed from — so an abandoned session became the next open's starting
+        # coordinates (FIB-320).
         project_path = os.path.join(
             correlation_root,
             datetime.datetime.now().strftime(constants.DATETIME_FILE),
         )
-        os.makedirs(project_path, exist_ok=True)
 
         fib_current = self._image_path(
             selected_lamella, self.combobox_fib_filenames.currentText()

--- a/tests/correlation/test_config.py
+++ b/tests/correlation/test_config.py
@@ -4,19 +4,13 @@ Pure dataclasses, no Qt. Covers round-trip and — the load-bearing part —
 back-compat: a config dict missing keys (or a whole nested block, or the whole
 thing) must fill in defaults, so a protocol saved before this field loads clean.
 """
-from fibsem.correlation.config import (
-    CorrelationConfig,
-    FitSettings,
-    InterpolationSettings,
-    RISettings,
-)
+from fibsem.correlation.config import CorrelationConfig, FitSettings, RISettings
 
 
 def test_correlation_config_round_trips():
     cfg = CorrelationConfig(
         fit=FitSettings(fib_method="Gaussian", fm_poi_channel="GFP", reflection_cutout=3),
         ri=RISettings(na=0.9, wavelength_um=0.488, mode="post"),
-        interpolation=InterpolationSettings(enabled=True, isotropic=False, target_z_nm=120.0),
         load_spot_burns=False,
     )
     back = CorrelationConfig.from_dict(cfg.to_dict())
@@ -36,7 +30,6 @@ def test_defaults_match_the_current_hardcoded_behaviour():
         (15.0, 4.0, 0.8, 1.4, 0.515)
     assert cfg.ri.mode == "pre"
     assert cfg.load_spot_burns is True
-    assert cfg.interpolation.enabled is False
 
 
 def test_channels_default_to_none_stored_by_name():
@@ -70,5 +63,14 @@ def test_nested_blocks_independently_tolerate_absence():
     assert cfg.ri.na == 0.7
     assert cfg.ri.mode == "pre"                   # sibling default within ri
     assert cfg.fit == FitSettings()               # whole missing block
-    assert cfg.interpolation == InterpolationSettings()
     assert cfg.load_spot_burns is False
+
+
+def test_retired_interpolation_key_is_ignored():
+    """The field was dropped in FIB-319 (persisted, never read). A protocol saved
+    while it existed must still load — silently, not by raising."""
+    cfg = CorrelationConfig.from_dict(
+        {"interpolation": {"enabled": True, "target_z_nm": 120.0}, "load_spot_burns": False}
+    )
+    assert cfg.load_spot_burns is False
+    assert not hasattr(cfg, "interpolation")

--- a/tests/correlation/test_correlation_run_folder.py
+++ b/tests/correlation/test_correlation_run_folder.py
@@ -151,6 +151,20 @@ def test_discarding_the_result_does_not_stop_saving(qapp, tmp_path):
     assert _saved_fib_x(run) == 7.0
 
 
+def test_explicit_save_creates_the_folder_it_writes_into(qapp, tmp_path):
+    """File > Save Correlation seeds its dialog with <run folder>/correlation.json.
+    Deferring creation made that default a path whose directory doesn't exist, so
+    accepting it raised FileNotFoundError out of open()."""
+    run = tmp_path / "2026-07-27_09-00-00"
+    w = _widget()
+    w.set_project_dir(str(run))
+    w.set_data(_inputs(x=3.0))
+
+    w.save_correlation(str(run / CORRELATION_JSON))  # the offered default
+
+    assert _saved_fib_x(run) == 3.0
+
+
 def test_save_plot_creates_the_folder_it_writes_into(qapp, tmp_path):
     """save_plot targets the run folder directly, so it can be the first writer."""
     run = tmp_path / "2026-07-27_09-00-00"
@@ -162,6 +176,20 @@ def test_save_plot_creates_the_folder_it_writes_into(qapp, tmp_path):
 
     assert run.is_dir()
     assert list(run.glob("correlation_plot_*.png"))
+
+
+def test_save_plot_creates_the_folder_for_an_explicit_path_too(qapp, tmp_path):
+    """The Save Plot dialog offers a default *inside* the run folder and then
+    passes it back as an explicit path — the same absent directory, arriving by
+    the branch that doesn't derive it."""
+    run = tmp_path / "2026-07-27_09-00-00"
+    w = _widget()
+    w.set_project_dir(str(run))
+    w.set_fib_image(FibsemImage.generate_blank_image(resolution=(64, 64), hfw=100e-6))
+
+    w.save_plot(str(run / "correlation_plot_2026-07-27_09-05-00.png"))  # as offered
+
+    assert (run / "correlation_plot_2026-07-27_09-05-00.png").is_file()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/correlation/test_correlation_run_folder.py
+++ b/tests/correlation/test_correlation_run_folder.py
@@ -1,0 +1,196 @@
+"""A run folder is created when a correlation is recorded, not when one is opened
+(FIB-320).
+
+``Correlation/<timestamp>/`` used to be minted before the window appeared, and
+the initial seed auto-saved into it immediately — so cancelling still left a
+complete run on disk. That was harmless while nothing read those folders;
+FIB-299/301/302 made them *functional* (they seed the next correlation), which
+turned it into two real defects:
+
+* an abandoned session became the next open's starting coordinates — Cancel read
+  as "discard", but wasn't;
+* history counted opens rather than correlations, so a first correlation stopped
+  being treated as one.
+
+Headless PyQt5, offscreen.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import json
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.correlation.history import LamellaCorrelation
+from fibsem.correlation.structures import (
+    Coordinate,
+    CorrelationInputData,
+    CorrelationPointOfInterest,
+    CorrelationResult,
+    PointType,
+    PointXYZ,
+)
+from fibsem.structures import FibsemImage
+
+CORRELATION_JSON = "correlation.json"
+
+
+@pytest.fixture(autouse=True)
+def _no_lut_download(monkeypatch):
+    import fibsem.correlation.ui.widgets.refractive_index_widget as riw
+
+    monkeypatch.setattr(riw, "_ensure_lut", lambda: None)
+
+
+def _widget():
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        CorrelationTabWidget,
+    )
+
+    return CorrelationTabWidget()
+
+
+def _inputs(x=1.0):
+    return CorrelationInputData(
+        fib_coordinates=[
+            Coordinate(point=PointXYZ(x=x, y=2.0, z=0.0), point_type=PointType.FIB)
+        ]
+    )
+
+
+def _result(inp=None):
+    return CorrelationResult(
+        poi=[CorrelationPointOfInterest()], rms_error=1.0, input_data=inp or _inputs()
+    )
+
+
+def _saved(run_dir):
+    return json.loads((run_dir / CORRELATION_JSON).read_text())
+
+
+def _saved_fib_x(run_dir):
+    return _saved(run_dir)["input_data"]["fib_coordinates"][0]["point"]["x"]
+
+
+# ---------------------------------------------------------------------------
+# the widget: nothing on disk until there is something worth writing
+# ---------------------------------------------------------------------------
+
+
+def test_picking_points_alone_writes_nothing(qapp, tmp_path):
+    """Seeding and editing coordinates is not a correlation. Writing here is what
+    made every open a run."""
+    run = tmp_path / "2026-07-27_09-00-00"
+    w = _widget()
+    w.set_project_dir(str(run))
+
+    w.set_data(_inputs(x=42.0))
+    w.data_changed.emit(w.data)
+
+    assert not run.exists()
+
+
+def test_an_existing_project_dir_saves_from_the_first_edit(qapp, tmp_path):
+    """The standalone widget points at a directory the user picked, which already
+    exists — deferring *creation* must not become deferring *saving* there, or
+    quickstart silently stops persisting point-picking."""
+    run = tmp_path / "chosen_by_the_user"
+    run.mkdir()
+    w = _widget()
+    w.set_project_dir(str(run))
+
+    w.set_data(_inputs(x=42.0))
+    w.data_changed.emit(w.data)
+
+    assert _saved_fib_x(run) == 42.0
+
+
+def test_the_first_result_creates_the_run_folder(qapp, tmp_path):
+    run = tmp_path / "2026-07-27_09-00-00"
+    w = _widget()
+    w.set_project_dir(str(run))
+    w.set_data(_inputs(x=42.0))
+
+    w._on_result_ready(_result(w.data))
+
+    assert (run / CORRELATION_JSON).is_file()
+    assert _saved(run)["result"] is not None
+
+
+def test_edits_after_a_result_keep_the_file_current(qapp, tmp_path):
+    """Once the folder exists it tracks the session — including the FIB-295 case
+    where an edit leaves the stored result stale but still recorded."""
+    run = tmp_path / "2026-07-27_09-00-00"
+    w = _widget()
+    w.set_project_dir(str(run))
+    w.set_data(_inputs(x=42.0))
+    w._on_result_ready(_result(w.data))
+
+    w.data.fib_coordinates[0].point.x = 999.0
+    w.data_changed.emit(w.data)
+
+    assert _saved_fib_x(run) == 999.0
+    assert _saved(run)["result"] is not None  # stale, not dropped
+
+
+def test_discarding_the_result_does_not_stop_saving(qapp, tmp_path):
+    """The folder is already a run; it must not go quietly out of date."""
+    run = tmp_path / "2026-07-27_09-00-00"
+    w = _widget()
+    w.set_project_dir(str(run))
+    w._on_result_ready(_result())
+    w._discard_result()
+
+    w.set_data(_inputs(x=7.0))
+    w.data_changed.emit(w.data)
+
+    assert _saved(run)["result"] is None
+    assert _saved_fib_x(run) == 7.0
+
+
+def test_save_plot_creates_the_folder_it_writes_into(qapp, tmp_path):
+    """save_plot targets the run folder directly, so it can be the first writer."""
+    run = tmp_path / "2026-07-27_09-00-00"
+    w = _widget()
+    w.set_project_dir(str(run))
+    w.set_fib_image(FibsemImage.generate_blank_image(resolution=(64, 64), hfw=100e-6))
+
+    w.save_plot()
+
+    assert run.is_dir()
+    assert list(run.glob("correlation_plot_*.png"))
+
+
+# ---------------------------------------------------------------------------
+# end to end: the editor opens the real window and the user cancels
+# ---------------------------------------------------------------------------
+
+
+def test_a_cancelled_correlation_leaves_no_run_behind(qapp, tmp_path, monkeypatch):
+    """The reproduction from the issue: open, edit a point, cancel — and the next
+    open must not offer that abandoned session as a previous correlation."""
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+    from fibsem.ui.widgets.autolamella_lamella_protocol_editor import (
+        AutoLamellaProtocolEditorWidget as Editor,
+    )
+    from tests.correlation.test_correlation_setup_regressions import _editor_stub
+
+    opened = []
+
+    def _cancel(self):
+        opened.append(self)
+        self.widget.set_data(_inputs(x=999.0))  # the user picks, then thinks better
+        self.widget.data_changed.emit(self.widget.data)
+        return 0  # QDialog.Rejected
+
+    monkeypatch.setattr(ctw.CorrelationTabDialog, "exec_", _cancel)
+
+    lamella = tmp_path / "lamella-01"
+    lamella.mkdir()
+    Editor._open_correlation_dialog(_editor_stub(str(lamella), "", image=None))
+
+    assert opened, "the dialog never opened — the test proves nothing"
+    assert LamellaCorrelation.discover(str(lamella / "Correlation")).runs == []

--- a/tests/correlation/test_correlation_run_folder.py
+++ b/tests/correlation/test_correlation_run_folder.py
@@ -197,6 +197,74 @@ def test_save_plot_creates_the_folder_for_an_explicit_path_too(qapp, tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def test_a_run_without_a_result_says_so_in_the_dropdown(qapp):
+    """A run folder is not proof a correlation ran: File > Save Correlation
+    writes one deliberately (creating the folder is the point of an explicit
+    save), and a run whose result was discarded keeps its folder. Picking a
+    starting point means picking between those and real correlations."""
+    from fibsem.correlation.history import CorrelationRun
+    from fibsem.correlation.structures import CorrelationState
+    from fibsem.correlation.ui.widgets.correlation_setup_section import (
+        format_run_label,
+    )
+
+    def _run(result):
+        return CorrelationRun(
+            path="/tmp/r",
+            name="2026-07-24_14-32-00",
+            state=CorrelationState(input_data=CorrelationInputData(), result=result),
+        )
+
+    assert format_run_label(_run(_result())) == "2026-07-24 14:32:00"
+    assert format_run_label(_run(None)) == "2026-07-24 14:32:00  ·  no result"
+
+
+def test_a_failed_save_is_reported(qapp, tmp_path, monkeypatch):
+    """The load handler warns on failure; the save handlers didn't, so the
+    exception went to the event loop and the user was told nothing."""
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+
+    warned = []
+    monkeypatch.setattr(
+        ctw.QFileDialog,
+        "getSaveFileName",
+        staticmethod(lambda *a, **k: (str(tmp_path / "x.json"), "")),
+    )
+    monkeypatch.setattr(
+        ctw.QMessageBox, "warning", staticmethod(lambda *a, **k: warned.append(a[1]))
+    )
+
+    w = _widget()
+    monkeypatch.setattr(
+        type(w), "save_correlation", lambda self, path: (_ for _ in ()).throw(OSError("disk full"))
+    )
+    w._on_save()  # must not raise
+
+    assert warned == ["Save Error"]
+
+
+def test_a_failed_plot_save_is_reported(qapp, tmp_path, monkeypatch):
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+
+    warned = []
+    monkeypatch.setattr(
+        ctw.QFileDialog,
+        "getSaveFileName",
+        staticmethod(lambda *a, **k: (str(tmp_path / "x.png"), "")),
+    )
+    monkeypatch.setattr(
+        ctw.QMessageBox, "warning", staticmethod(lambda *a, **k: warned.append(a[1]))
+    )
+
+    w = _widget()
+    monkeypatch.setattr(
+        type(w), "save_plot", lambda self, path=None: (_ for _ in ()).throw(OSError("disk full"))
+    )
+    w._on_save_plot_clicked()  # must not raise
+
+    assert warned == ["Save Error"]
+
+
 def test_a_cancelled_correlation_leaves_no_run_behind(qapp, tmp_path, monkeypatch):
     """The reproduction from the issue: open, edit a point, cancel — and the next
     open must not offer that abandoned session as a previous correlation."""

--- a/tests/correlation/test_correlation_setup_regressions.py
+++ b/tests/correlation/test_correlation_setup_regressions.py
@@ -1,0 +1,345 @@
+"""Regressions introduced by the Setup-tab move (FIB-319).
+
+Setup moved from implicit seeding in the protocol editor, through a pre-dialog,
+into a section inside the correlation window. Things lost or invented on the way:
+
+* ``load_spot_burns`` stopped gating anything — an experiment that turned burn
+  seeding off got it anyway;
+* the manual-edit guard couldn't see surface points, so a re-seed wiped one
+  without asking, silently disarming the RI pre-correction with it;
+* the same guard announced "edited" after interpolation, which only resampled z;
+* a declined re-seed left the radio claiming a source that was never applied;
+* spot burns read as applied with no FIB image to place them in — and the editor
+  handed over a *blank generated placeholder* when the lamella had no reference
+  image, which would scale the burns and the POI by placeholder dimensions.
+
+Headless PyQt5, offscreen.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import types
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.correlation.config import CorrelationConfig
+from fibsem.correlation.history import CorrelationRun, LamellaCorrelation
+from fibsem.correlation.structures import (
+    Coordinate,
+    CorrelationInputData,
+    CorrelationState,
+    PointType,
+    PointXYZ,
+)
+from fibsem.correlation.ui.widgets.correlation_setup_section import (
+    SEED_NONE,
+    SEED_PREVIOUS,
+    SEED_SPOT_BURNS,
+    CorrelationSetupSection,
+)
+from fibsem.structures import FibsemImage, Point
+
+
+@pytest.fixture(autouse=True)
+def _no_lut_download(monkeypatch):
+    import fibsem.correlation.ui.widgets.refractive_index_widget as riw
+
+    monkeypatch.setattr(riw, "_ensure_lut", lambda: None)
+
+
+OLD = "2026-07-20_09-00-00"
+NEW = "2026-07-24_14-32-00"
+
+
+def _widget():
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        CorrelationTabWidget,
+    )
+
+    return CorrelationTabWidget()
+
+
+def _fib_image():
+    return FibsemImage.generate_blank_image(resolution=(300, 200), hfw=100e-6)
+
+
+def _run(name, inp=None):
+    return CorrelationRun(
+        path="/tmp/" + name,
+        name=name,
+        state=CorrelationState(input_data=inp or CorrelationInputData()),
+    )
+
+
+def _asked(monkeypatch, answer):
+    """Record every confirm/inform the widget raises, answering with `answer`."""
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+
+    seen = []
+    for name in ("question", "information"):
+        monkeypatch.setattr(
+            ctw.QMessageBox,
+            name,
+            staticmethod(lambda *a, **k: (seen.append(a[1]), answer)[1]),
+        )
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# 1 — load_spot_burns gates the default again
+# ---------------------------------------------------------------------------
+
+
+def test_load_spot_burns_false_does_not_preselect_burns(qapp):
+    """The flag meant "don't seed burns automatically". It kept round-tripping
+    through the protocol while nothing read it."""
+    s = CorrelationSetupSection(
+        spot_burns=[Point(0.1, 0.2)],
+        history=LamellaCorrelation(runs=[]),
+        config=CorrelationConfig(load_spot_burns=False),
+    )
+    assert s.seed_source() == SEED_NONE
+    # still offered, though: an explicit click is not automatic seeding
+    assert s.rb_burns.isEnabled()
+
+
+# ---------------------------------------------------------------------------
+# 2 — the manual-edit guard sees surface points, and isn't fooled by a rescale
+# ---------------------------------------------------------------------------
+
+
+def _seed_burns(w, **kwargs):
+    section = w.add_lamella_setup(
+        spot_burns=[Point(0.25, 0.5)], config=CorrelationConfig(), **kwargs
+    )
+    section.emit_current_seed()
+    return section
+
+
+def test_a_surface_point_is_something_to_lose(qapp, monkeypatch):
+    """Surface points live in their own single-value fields, not the three
+    coordinate lists — so the guard walked straight past them."""
+    from PyQt5.QtWidgets import QMessageBox
+
+    w = _widget()
+    w.set_fib_image(_fib_image())
+    section = _seed_burns(w)
+
+    w._coords_tab.fm_surface_list.add_coordinate(
+        Coordinate(point=PointXYZ(x=10.0, y=20.0, z=3.0), point_type=PointType.SURFACE_FM)
+    )
+    assert w._has_manual_edits()
+
+    asked = _asked(monkeypatch, QMessageBox.Cancel)
+    section.rb_none.setChecked(True)  # would wipe the surface point
+
+    assert asked, "no confirmation before discarding a surface point"
+    assert w.data.fm_surface_coordinate is not None
+
+
+def test_interpolating_does_not_look_like_an_edit(qapp, monkeypatch):
+    """Interpolation rescales every FM-side z. The baseline has to move with it,
+    or the next re-seed reports edits the user never made."""
+    from PyQt5.QtWidgets import QMessageBox
+
+    from tests.correlation.test_correlation_setup_section import _fm_image
+
+    w = _widget()
+    w.set_fib_image(_fib_image())
+    w.set_fm_image(_fm_image(nz=11))
+    seed = CorrelationInputData(
+        fm_coordinates=[
+            Coordinate(point=PointXYZ(x=5.0, y=6.0, z=4.0), point_type=PointType.FM)
+        ]
+    )
+    section = w.add_lamella_setup(
+        spot_burns=[Point(0.25, 0.5)],
+        history=LamellaCorrelation(runs=[_run(NEW, seed)]),
+        config=CorrelationConfig(),
+    )
+    section.emit_current_seed()
+    assert not w._has_manual_edits()
+
+    w._adopt_interpolated_volume(_fm_image(nz=22, pixel_size_z=100e-9), old_nz=11)
+    assert w.data.fm_coordinates[0].point.z == pytest.approx(8.0)  # z did move
+    assert not w._has_manual_edits()  # ...but the user didn't move it
+
+    asked = _asked(monkeypatch, QMessageBox.Ok)
+    section.rb_burns.setChecked(True)
+    assert not asked, "warned about edits after nothing was edited"
+
+
+# ---------------------------------------------------------------------------
+# 3 — a declined re-seed puts the controls back
+# ---------------------------------------------------------------------------
+
+
+def test_declining_restores_the_radio(qapp, monkeypatch):
+    """Qt flips the radio before emitting `toggled`, so an unapplied source stays
+    on screen — and re-clicking the same radio emits nothing, so the obvious
+    recovery does nothing either."""
+    from PyQt5.QtWidgets import QMessageBox
+
+    w = _widget()
+    w.set_fib_image(_fib_image())
+    section = _seed_burns(w)
+    w.data.fib_coordinates[0].point.x = 111.0  # hand-moved
+
+    _asked(monkeypatch, QMessageBox.Cancel)
+    section.rb_none.setChecked(True)
+
+    assert section.seed_source() == SEED_SPOT_BURNS
+    assert section.rb_burns.isChecked()
+    assert w.data.fib_coordinates[0].point.x == 111.0
+
+
+def test_declining_restores_the_run_selection(qapp, monkeypatch):
+    """Same for the run dropdown, which re-seeds on every index change."""
+    from PyQt5.QtWidgets import QMessageBox
+
+    w = _widget()
+    w.set_fib_image(_fib_image())
+    inp = CorrelationInputData(
+        fib_coordinates=[Coordinate(point=PointXYZ(x=1.0), point_type=PointType.FIB)]
+    )
+    section = w.add_lamella_setup(
+        history=LamellaCorrelation(runs=[_run(OLD, inp), _run(NEW, inp)]),
+        config=CorrelationConfig(),
+    )
+    section.emit_current_seed()
+    assert section.seed_source() == SEED_PREVIOUS
+    w.data.fib_coordinates[0].point.x = 222.0
+
+    _asked(monkeypatch, QMessageBox.Cancel)
+    section.run_combo.setCurrentIndex(1)
+
+    assert section.run_combo.currentIndex() == 0
+    assert w.data.fib_coordinates[0].point.x == 222.0
+
+
+# ---------------------------------------------------------------------------
+# 5 — spot burns need a FIB image, and a real one
+# ---------------------------------------------------------------------------
+
+
+def test_burns_are_not_offered_without_a_fib_image(qapp):
+    """Nothing to multiply the normalised burns by — so don't present the choice,
+    and above all don't make it the default the window opens on."""
+    w = _widget()  # no FIB image
+    section = w.add_lamella_setup(
+        spot_burns=[Point(0.25, 0.5)], config=CorrelationConfig()
+    )
+    assert not section.rb_burns.isEnabled()
+    assert "needs the FIB image" in section.rb_burns.text()
+    assert section.seed_source() == SEED_NONE
+
+
+def test_burns_become_available_when_the_image_arrives(qapp):
+    """Opening with no image and browsing to one is a supported route."""
+    w = _widget()
+    section = w.add_lamella_setup(
+        spot_burns=[Point(0.25, 0.5)], config=CorrelationConfig()
+    )
+    w.set_fib_image(_fib_image())
+
+    assert section.rb_burns.isEnabled()
+    assert "needs the FIB image" not in section.rb_burns.text()
+
+
+def test_spot_burns_without_a_fib_image_are_refused(qapp, monkeypatch):
+    """Belt and braces behind the disabled radio: the seeding call returns early
+    with no image, and used to leave the radio reading as applied — no points, no
+    message, no way to tell."""
+    w = _widget()  # no FIB image
+    section = w.add_lamella_setup(
+        spot_burns=[Point(0.25, 0.5)],
+        history=LamellaCorrelation(runs=[_run(NEW)]),
+        config=CorrelationConfig(),
+    )
+    section.emit_current_seed()  # defaults to the previous run
+
+    asked = _asked(monkeypatch, None)
+    section.rb_burns.setChecked(True)
+
+    assert asked == ["No FIB image"]
+    assert section.seed_source() == SEED_PREVIOUS  # not left claiming burns
+
+
+def _editor_stub(lamella_path, fib_filename, image):
+    """Enough of the protocol editor to run _open_correlation_dialog unbound —
+    constructing the real widget needs napari."""
+    from PyQt5.QtWidgets import QComboBox
+
+    from fibsem.ui.widgets.autolamella_lamella_protocol_editor import (
+        AutoLamellaProtocolEditorWidget as Editor,
+    )
+
+    fib_combo = QComboBox()
+    if fib_filename:
+        fib_combo.addItem(fib_filename)
+    return types.SimpleNamespace(
+        _selected_lamella=types.SimpleNamespace(path=lamella_path, task_config={}),
+        parent_widget=None,
+        image=image,
+        fm_image=None,
+        combobox_fib_filenames=fib_combo,
+        combobox_fm_filenames=QComboBox(),
+        _image_path=Editor._image_path,
+        _image_paths=Editor._image_paths,
+        _spot_burn_coordinates=Editor._spot_burn_coordinates,
+    )
+
+
+def _fake_dialog_class(record):
+    class _FakeDialog:
+        def __init__(self, parent=None):
+            record.append(self)
+            self.fib_image = None
+
+        def set_project_dir(self, path):
+            pass
+
+        def set_fib_image(self, image):
+            self.fib_image = image
+
+        def set_fm_image(self, image):
+            pass
+
+        def add_lamella_setup(self, **kwargs):
+            return types.SimpleNamespace(emit_current_seed=lambda: None)
+
+        def exec_(self):
+            return 0  # rejected — stop before the result handling
+
+    return _FakeDialog
+
+
+def _open_correlation(stub, monkeypatch):
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+    from fibsem.ui.widgets.autolamella_lamella_protocol_editor import (
+        AutoLamellaProtocolEditorWidget as Editor,
+    )
+
+    opened = []
+    monkeypatch.setattr(ctw, "CorrelationTabDialog", _fake_dialog_class(opened))
+    Editor._open_correlation_dialog(stub)
+    return opened[0]
+
+
+def test_editor_withholds_the_placeholder_image(qapp, tmp_path, monkeypatch):
+    """With no *_ib.tif the editor's self.image is a blank generated placeholder
+    for its own canvas. Correlating against it would scale the burns — and the
+    POI written back to the experiment — by placeholder dimensions."""
+    stub = _editor_stub(str(tmp_path), fib_filename="", image=_fib_image())
+    assert _open_correlation(stub, monkeypatch).fib_image is None
+
+
+def test_editor_passes_a_real_reference_image(qapp, tmp_path, monkeypatch):
+    real = tmp_path / "01_ref_ib.tif"
+    _fib_image().save(str(real))
+    image = _fib_image()
+    stub = _editor_stub(str(tmp_path), fib_filename=real.name, image=image)
+    assert _open_correlation(stub, monkeypatch).fib_image is image

--- a/tests/correlation/test_correlation_setup_regressions.py
+++ b/tests/correlation/test_correlation_setup_regressions.py
@@ -270,8 +270,12 @@ def test_spot_burns_without_a_fib_image_are_refused(qapp, monkeypatch):
 
 def _editor_stub(lamella_path, fib_filename, image):
     """Enough of the protocol editor to run _open_correlation_dialog unbound —
-    constructing the real widget needs napari."""
-    from PyQt5.QtWidgets import QComboBox
+    constructing the real widget needs napari.
+
+    A real QWidget, not a namespace: it is passed as the dialog's parent, so the
+    end-to-end variant of this harness needs it to survive PyQt's type check.
+    """
+    from PyQt5.QtWidgets import QComboBox, QWidget
 
     from fibsem.ui.widgets.autolamella_lamella_protocol_editor import (
         AutoLamellaProtocolEditorWidget as Editor,
@@ -280,17 +284,17 @@ def _editor_stub(lamella_path, fib_filename, image):
     fib_combo = QComboBox()
     if fib_filename:
         fib_combo.addItem(fib_filename)
-    return types.SimpleNamespace(
-        _selected_lamella=types.SimpleNamespace(path=lamella_path, task_config={}),
-        parent_widget=None,
-        image=image,
-        fm_image=None,
-        combobox_fib_filenames=fib_combo,
-        combobox_fm_filenames=QComboBox(),
-        _image_path=Editor._image_path,
-        _image_paths=Editor._image_paths,
-        _spot_burn_coordinates=Editor._spot_burn_coordinates,
-    )
+    stub = QWidget()
+    stub._selected_lamella = types.SimpleNamespace(path=lamella_path, task_config={})
+    stub.parent_widget = None
+    stub.image = image
+    stub.fm_image = None
+    stub.combobox_fib_filenames = fib_combo
+    stub.combobox_fm_filenames = QComboBox()
+    stub._image_path = Editor._image_path
+    stub._image_paths = Editor._image_paths
+    stub._spot_burn_coordinates = Editor._spot_burn_coordinates
+    return stub
 
 
 def _fake_dialog_class(record):


### PR DESCRIPTION
Closes FIB-319, FIB-320 — the second tier from the post-FIB-302 review, both about the setup surface.

## FIB-319 — regressions from the Setup-tab move

Setup moved from implicit seeding in the protocol editor, through a pre-dialog, into a section inside the window. Five things were lost or invented on the way.

**`load_spot_burns` stopped gating anything.** The editor used to check it; the section enabled *and auto-selected* the radio purely on `bool(spot_burns)`, so an experiment configured `load_spot_burns: false` got seeding anyway. It now gates the **default**, not the choice — the flag meant "don't seed automatically", and an explicit click is not automatic.

**The manual-edit guard had two holes.** It walked past the surface points, which live in single-value fields rather than the three coordinate lists — so a re-seed wiped a placed surface point with no confirmation, silently disarming any stored RI pre-correction factor with it. And interpolation's z-rescale made it report edits the user never made. Surface points are now counted, and the baseline is rescaled alongside the points. The dialog also stopped claiming the coordinates "have been edited": it can't know that, since they may equally have arrived from File → Load Correlation.

**A declined re-seed left the radio lying.** Qt flips the checked state *before* emitting `toggled`, so cancelling the confirm left a source on screen that was never applied — and unrecoverable by the obvious action, since re-clicking the same radio emits nothing. The guard moved into a `can_reseed(source)` veto the section consults before emitting; refusing restores both radio and run dropdown.

**Dead code from the pre-dialog.** `start_fm_interpolation` (widget + dialog passthrough) had no caller and no tests. `CorrelationConfig.interpolation` was a persisted setting nothing read — the same defect as `load_spot_burns` — so it goes rather than accumulating another inert field; `from_dict` reads named keys, so an existing protocol carrying it still loads (tested). Also drops a duplicate `INTERPOLATION_METHODS` shadowing the real one in `util.py`.

**Spot burns without a FIB image.** The seeding call returned early while the radio read as applied. The radio is now disabled and labelled *(needs the FIB image)*, re-enabling if one is browsed to. Relatedly the editor passed `self.image` unconditionally — a blank generated placeholder when the lamella has no `*_ib.tif`, which would have scaled the burns and the returned POI by placeholder dimensions.

Withholding that placeholder is what makes the disabled radio necessary: the open path seeds directly, with nothing to veto it. Left alone, that fix would have made the silent no-op *more* likely, not less.

## FIB-320 — a run folder means a correlation, not an open

`Correlation/<timestamp>/` was minted before the window appeared and the initial seed auto-saved into it immediately, so cancelling still left a complete run on disk. Harmless while nothing read those folders; FIB-299/301/302 made them functional, which turned it into:

- an abandoned session becoming the next open's starting coordinates — drag a point, Cancel, reopen, and you resume from the edit you discarded;
- history counting opens rather than correlations, so a first correlation stopped being treated as one.

`set_project_dir` now names a destination rather than promising a directory. The editor passes the path without `mkdir`; the widget creates it on the first write worth making.

The gate is *a result exists **or** the directory already does*, which keeps the standalone widget unchanged — there the user picks an existing directory, so point-picking still autosaves from the first edit. Deferring **creation** must not turn into deferring **saving**.

Known trade-off, from the issue: the accidental autosave did buy crash-safety for point-picking. Seeding softens the loss — a crash mid-picking reopens seeded from the last real correlation — leaving only a lamella's *first* correlation exposed. If that proves painful the mitigation is a draft *file*, not a draft folder: history discovery globs directories, so a file is invisible to it by construction.

### Follow-up: every write site creates its own directory

Deferring the folder's creation opened a hole in both save dialogs, which seed a default *inside* the run folder. `File → Save Correlation` raised `FileNotFoundError` straight out of `open()`; `Save Plot` handed its offered default back as an *explicit* path, taking the branch that skipped creation entirely. One helper, `_ensure_dir_for(path)`, now covers all three write sites, called immediately before writing so an abandoned session still leaves nothing behind.

### Follow-up: a run folder is not proof a correlation ran

`File → Save Correlation` writes one deliberately — creating the folder *is* the point of an explicit save, so this is kept as a feature rather than closed off: it's the manual checkpoint that softens FIB-320's crash-safety trade-off. What was wrong is that such a run looked identical to a completed one at the moment you pick what to seed from, since the dropdown shows only a timestamp and the Result column went away when the history modal folded into the Setup tab. Runs without a result now say so — which covers a discarded result's folder too, not just manual saves.

Also: a failed save said nothing. The load handler warns on failure; neither save handler did, so the exception went to the Qt event loop and the user walked away believing the file had been written. Both now mirror the load handler. Pre-existing, not introduced by the deferral.

## Testing

- 397 pass across correlation + autolamella + ui; 21 new.
- All 19 mutations verified. Four guard against over-correcting rather than under-: the editor withholding *every* image, availability never refreshing, the folder never being created, and saving stopping once a result is discarded.
- FIB-320 includes the issue's end-to-end reproduction, driving the real dialog through the editor's open path.

## Not included

FIB-321 — the UI-honesty batch (states that misrepresent the data) — is the remaining tier.