### PR TITLE
Correlation: fix seven UI states that misrepresent the data (FIB-321)

### DIFF
--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -445,6 +445,20 @@ class CorrelationResult:
         surface_y = self.input_data.surface_coordinate.point.y
         fib_shape = self.input_data.fib_image_shape
         pixel_size = self.input_data.fib_image_pixel_size
+        # Refuse rather than half-apply. px_m is exactly what Continue commits to
+        # the experiment, so correcting only image_px moved the marker on screen
+        # and recorded factor + mode while the committed number stayed
+        # uncorrected — a wrong result presented as a corrected one, flagged only
+        # by a log warning (FIB-321). Both properties fall back to the values
+        # restored from JSON, so this is reachable only for a result that was
+        # never associated with an image at all.
+        if fib_shape is None or pixel_size is None:
+            raise ValueError(
+                "fib image shape and pixel size are required to apply refractive "
+                "index correction: without them poi.px_m cannot be corrected, and "
+                "px_m is the value committed to the experiment"
+            )
+
         poi0 = self.poi[0]
         # Snapshot the uncorrected position for the ghost overlay
         self.poi_uncorrected = [
@@ -456,15 +470,9 @@ class CorrelationResult:
         ]
         corrected_y = scale_about_surface(poi0.image_px.y, surface_y, correction_factor)
         poi0.image_px.y = corrected_y
-        if fib_shape is not None and pixel_size is not None:
-            cy = fib_shape[0] / 2.0
-            poi0.px.y = -(corrected_y - cy)
-            poi0.px_m.y = poi0.px.y * pixel_size
-        else:
-            logging.warning(
-                "RI correction: fib image shape/pixel size unavailable — "
-                "poi.px / poi.px_m were NOT updated (only image_px)."
-            )
+        cy = fib_shape[0] / 2.0
+        poi0.px.y = -(corrected_y - cy)
+        poi0.px_m.y = poi0.px.y * pixel_size
         self.refractive_index_correction_factor = correction_factor
         self.refractive_index_correction_mode = "post"
         self.updated_at = time.time()

--- a/fibsem/correlation/ui/widgets/correlation_setup_section.py
+++ b/fibsem/correlation/ui/widgets/correlation_setup_section.py
@@ -97,7 +97,7 @@ class CorrelationSetupSection(QWidget):
         ``payload`` is a ``CorrelationInputData`` (previous run), a
         ``list[Point]`` (spot burns, normalised 0-1), or ``None``.
 
-    ``can_reseed(source) -> bool``
+    ``can_reseed(source, payload) -> bool``
         Optional veto the widget installs: consulted *before* emitting, because
         only the widget knows whether the coordinates are worth protecting or
         whether a source can be applied at all. Refusing restores the controls.
@@ -115,7 +115,7 @@ class CorrelationSetupSection(QWidget):
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
-        self.can_reseed: Optional[Callable[[str], bool]] = None
+        self.can_reseed: Optional[Callable[[str, object], bool]] = None
         self._applied = (SEED_NONE, -1)
         self._burns_available = spot_burns_available
         self._config = config or CorrelationConfig()
@@ -311,7 +311,9 @@ class CorrelationSetupSection(QWidget):
 
     def _request_apply(self) -> None:
         """Apply the current selection, unless the widget vetoes it."""
-        if self.can_reseed is not None and not self.can_reseed(self.seed_source()):
+        if self.can_reseed is not None and not self.can_reseed(
+            self.seed_source(), self.seed_payload()
+        ):
             self._restore_applied()
             return
         self.emit_current_seed()

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -343,6 +343,25 @@ class _ImagePicker(QWidget):
         self.combo.blockSignals(False)
         self.combo.setToolTip(path)
 
+    def reject_path(self, bad_path: str, restore: str) -> None:
+        """Drop a path that failed to load, and go back to ``restore``.
+
+        A browsed file joins the list before anything tries to open it, so one
+        that fails has to be taken back out — otherwise it stays selectable for
+        the rest of the session. ``restore`` is empty when nothing has loaded
+        yet, and that case is why this exists: ``show_path("")`` returns
+        immediately, leaving the failed file on display as though it were the
+        current image while there was in fact no image at all (FIB-321).
+        """
+        index = self.combo.findData(bad_path)
+        if index >= 0:
+            self.combo.removeItem(index)  # programmatic: `activated` doesn't fire
+        if restore:
+            self.show_path(restore)
+        else:
+            self.combo.setCurrentIndex(-1)
+            self.combo.setToolTip("")
+
     def _on_activated(self, index: int) -> None:
         path = self.combo.itemData(index)
         if path:
@@ -542,7 +561,7 @@ class _ImagesTab(QWidget):
             image = FibsemImage.load(path)
         except Exception as exc:
             QMessageBox.warning(self, "Load error", str(exc))
-            self._fib_picker.show_path(self._fib_loaded_path)  # revert to last good
+            self._fib_picker.reject_path(path, self._fib_loaded_path)
             return
         self._fib_image = image
         self._fib_loaded_path = path
@@ -563,7 +582,7 @@ class _ImagesTab(QWidget):
             image = FluorescenceImage.load(path)
         except Exception as exc:
             QMessageBox.warning(self, "Load error", str(exc))
-            self._fm_picker.show_path(self._fm_loaded_path)  # revert to last good
+            self._fm_picker.reject_path(path, self._fm_loaded_path)
             return
         self._fm_image = image
         self._fm_loaded_path = path
@@ -1122,10 +1141,16 @@ class _RITab(QWidget):
         if mode == "pre" and self._input_pre_factor is not None:
             self._populate_pre_table(self._input_pre_factor)
 
+        # "Armed" means the stored factor is not what produced the POI on screen.
+        # Matching factors are not enough — a result corrected in *post* mode was
+        # corrected in a different space, so its POI is not the one this pre-mode
+        # factor describes. Comparing factors alone let a post-corrected result at
+        # the same ζ read as "Correction applied (post)" while the pre factor was
+        # only armed and the displayed POI was the old post-corrected one (FIB-321).
         armed = (
             mode == "pre"
             and self._input_pre_factor is not None
-            and self._input_pre_factor != result_factor
+            and (result_mode != "pre" or self._input_pre_factor != result_factor)
         )
         if armed:
             self._set_warning(
@@ -1258,8 +1283,15 @@ class _RITab(QWidget):
             self._surface_coordinate
         )
 
-        # Update POI 0 in the result and propagate (reads input_data internally)
-        self._result.apply_refractive_index_correction(factor)
+        # Update POI 0 in the result and propagate (reads input_data internally).
+        # It refuses when it cannot correct px_m, which is the number Continue
+        # commits — report that here rather than letting it reach the event loop.
+        try:
+            self._result.apply_refractive_index_correction(factor)
+        except ValueError as exc:
+            logging.exception("[RITab._apply_post] correction refused")
+            self._set_warning(f"Correction not applied: {exc}")
+            return
         logging.info("[RITab._apply_post] correction applied, emitting correction_applied")
         self.correction_applied.emit(self._result)
 
@@ -1285,6 +1317,24 @@ _POINT_TYPE_SIDES: Dict[PointType, str] = {
 _FM_SIDE_POINT_TYPES = frozenset(
     pt.value for pt, side in _POINT_TYPE_SIDES.items() if side == "fm"
 )
+
+
+def _has_coordinates(data: Optional[CorrelationInputData]) -> bool:
+    """Whether a seed payload actually carries points to seed from.
+
+    A run folder can hold a state with no coordinates — an empty run, or a legacy
+    result file whose ``input_data`` is null. Seeding from one replaced the live
+    coordinates with nothing (FIB-321).
+    """
+    if data is None:
+        return False
+    return bool(
+        data.fib_coordinates
+        or data.fm_coordinates
+        or data.poi_coordinates
+        or data.surface_coordinate
+        or data.fm_surface_coordinate
+    )
 
 
 class _CanvasAdapter:
@@ -2014,22 +2064,25 @@ class CorrelationTabWidget(QWidget):
         self._setup_section = section
         return section
 
-    def _allow_reseed(self, source: str) -> bool:
+    def _allow_reseed(self, source: str, payload) -> bool:
         """Veto for the setup section, consulted before it emits (FIB-319).
 
-        Two reasons to refuse, in order — an impossible source is settled first,
-        so the user is never asked to sacrifice their points for a seed that was
-        never going to be applied:
+        Reasons to refuse, impossible sources first, so the user is never asked to
+        sacrifice their points for a seed that was never going to be applied:
 
         1. Spot burns without a FIB image. The burns are normalised to *that*
            image; with no image there is nothing to multiply by, and the seeding
            call would return early leaving the radio reading as applied.
-        2. Points that differ from what was last seeded.
+        2. A previous run holding no coordinates — an empty run, or a legacy file
+           with a null ``input_data``. Seeding from one replaced the live points
+           with nothing (FIB-321).
+        3. Points that differ from what was last seeded.
 
         The section restores its controls when this returns False, so the choice
         on screen keeps matching the canvas.
         """
         from fibsem.correlation.ui.widgets.correlation_setup_section import (
+            SEED_PREVIOUS,
             SEED_SPOT_BURNS,
         )
 
@@ -2039,6 +2092,14 @@ class CorrelationTabWidget(QWidget):
                 "No FIB image",
                 "Spot-burn positions are stored relative to the FIB image they "
                 "were placed on.\n\nLoad that image first, then choose them again.",
+            )
+            return False
+        if source == SEED_PREVIOUS and not _has_coordinates(payload):
+            QMessageBox.information(
+                self,
+                "Nothing to seed",
+                "That run has no saved coordinates.\n\nPick another run, or choose "
+                "None to start fresh.",
             )
             return False
         return not self._has_manual_edits() or self._confirm_reseed()
@@ -2054,10 +2115,16 @@ class CorrelationTabWidget(QWidget):
             SEED_SPOT_BURNS,
         )
 
-        if source == SEED_PREVIOUS and payload is not None:
-            self.seed_coordinates(copy.deepcopy(payload))
-        elif source == SEED_SPOT_BURNS and payload:
-            self.seed_fib_fiducials_from_spot_burns(payload)
+        # Only the None branch clears. A source that cannot be applied leaves the
+        # canvas alone rather than emptying it under someone else's banner —
+        # falling through to the clear is how an empty previous run wiped every
+        # coordinate while the radio read "Previous correlation" (FIB-321).
+        if source == SEED_PREVIOUS:
+            if _has_coordinates(payload):
+                self.seed_coordinates(copy.deepcopy(payload))
+        elif source == SEED_SPOT_BURNS:
+            if payload:
+                self.seed_fib_fiducials_from_spot_burns(payload)
         else:
             self.set_data(
                 CorrelationInputData(
@@ -2363,13 +2430,24 @@ class CorrelationTabWidget(QWidget):
         # a run in flight has no live result yet; a failed run leaves it that way
         self._set_result_live(False)
         self._worker = _CorrelationWorker(copy.deepcopy(self.data))
-        self._worker.result_ready.connect(self._on_result_ready)
+        self._worker.result_ready.connect(self._on_run_finished)
         self._worker.errored.connect(self._on_run_error)
         self._worker.start()
 
+    def _on_run_finished(self, result: CorrelationResult) -> None:
+        """Adopt a just-computed result, judged against the points as they are now.
+
+        A finished run is not automatically current: ``_run`` snapshots the data
+        for the worker but leaves the canvases editable, so a fiducial dragged
+        while the run was in flight makes the delivered result describe points
+        that no longer exist. Marking it live regardless armed Continue on a
+        result whose ``matches_inputs`` was already False (FIB-321).
+        """
+        self._on_result_ready(result, live=result.matches_inputs(self.data))
+
     def _on_result_ready(self, result: CorrelationResult, live: bool = True) -> None:
-        """Adopt a result. ``live`` is False for a *loaded* result that no longer
-        describes the current points (FIB-295) — a fresh run is always live."""
+        """Adopt a result. ``live`` is False for a result that no longer describes
+        the current points (FIB-295)."""
         self._result = result
         self._results_tab.set_result(result)
         self._ri_tab.set_result(

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -343,6 +343,31 @@ class _ImagePicker(QWidget):
         self.combo.blockSignals(False)
         self.combo.setToolTip(path)
 
+    def select_file(self, name: str) -> str:
+        """Select the known entry ``name`` refers to; return its full path.
+
+        Image metadata records a *basename* while entries are keyed on full
+        paths, so a direct lookup never matches and ``show_path`` would add the
+        bare name as a new entry — listing the same file twice, and leaving an
+        item that fails to load when picked, since nothing resolves a bare name
+        against a directory (FIB-321). The list holds paths; never put anything
+        else in it.
+
+        Returns "" and changes nothing when the file isn't one of the known ones.
+        """
+        if not name:
+            return ""
+        target = os.path.basename(name)
+        for i in range(self.combo.count()):
+            path = self.combo.itemData(i) or ""
+            if path == name or os.path.basename(path) == target:
+                self.combo.blockSignals(True)
+                self.combo.setCurrentIndex(i)
+                self.combo.blockSignals(False)
+                self.combo.setToolTip(path)
+                return path
+        return ""
+
     def reject_path(self, bad_path: str, restore: str) -> None:
         """Drop a path that failed to load, and go back to ``restore``.
 
@@ -524,6 +549,13 @@ class _ImagesTab(QWidget):
         """
         picker = self._fib_picker if kind == "fib" else self._fm_picker
         picker.set_options(paths, current)
+        # `current` is the file the caller has already loaded, so it is also the
+        # last-good path to fall back to when a later pick fails to load.
+        if current:
+            if kind == "fib":
+                self._fib_loaded_path = current
+            else:
+                self._fm_loaded_path = current
 
     def add_setup_section(self, section: QWidget) -> None:
         """Insert the lamella setup section before the tab's trailing stretch."""
@@ -604,8 +636,13 @@ class _ImagesTab(QWidget):
             )
             or ""
         )
-        self._fib_loaded_path = filename
-        self._fib_picker.show_path(filename)
+        # The metadata names the file; only the picker knows where it is. Resolve
+        # against what it already offers instead of taking the name as a path —
+        # and leave the display alone if this image isn't one of the known files,
+        # rather than showing a name the picker cannot load.
+        resolved = self._fib_picker.select_file(filename)
+        if resolved:
+            self._fib_loaded_path = resolved
         h, w = image.data.shape[:2]
         self._lbl_fib_shape.setText(f"{h} × {w}")
         px = getattr(
@@ -615,9 +652,11 @@ class _ImagesTab(QWidget):
 
     def set_fm_image(self, image: FluorescenceImage) -> None:
         self._fm_image = image
-        filename = getattr(image.metadata, "filename", "") or ""
-        self._fm_loaded_path = filename
-        self._fm_picker.show_path(filename)
+        resolved = self._fm_picker.select_file(
+            getattr(image.metadata, "filename", "") or ""
+        )
+        if resolved:
+            self._fm_loaded_path = resolved
         self._update_fm_labels(image)
 
     def _update_fm_labels(self, image: FluorescenceImage) -> None:

--- a/fibsem/correlation/ui/widgets/image_point_canvas.py
+++ b/fibsem/correlation/ui/widgets/image_point_canvas.py
@@ -318,6 +318,10 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         self._refresh_scalebar()
         self._overlay_point_artists.clear()
         self._overlay_label_artists.clear()
+        # ...and the legend entries that described them: cla() took the markers
+        # away, so keeping the labels left "POI (P)" / "FM reprojected (E)" in
+        # the legend of an image that has neither (FIB-321).
+        self._overlay_legend.clear()
         self._rebuild_artists()
 
     def set_coordinates(self, coords: List[Coordinate]) -> None:

--- a/fibsem/correlation/ui/widgets/test_correlation_setup_section.py
+++ b/fibsem/correlation/ui/widgets/test_correlation_setup_section.py
@@ -1,0 +1,191 @@
+"""Manual launcher for the correlation window's lamella Setup tab, on mock data.
+
+The Setup section is installed only when the autolamella protocol editor opens
+the correlation window, so seeing it normally means an experiment, a lamella and
+its images. This builds the same thing from mock data — no microscope, no
+experiment, no files needed.
+
+Usage
+-----
+    # a lamella with spot burns, two previous runs and both images loaded
+    python -m fibsem.correlation.ui.widgets.test_correlation_setup_section
+
+    # opened with no FIB image, to see the spot-burn rule
+    python -m fibsem.correlation.ui.widgets.test_correlation_setup_section --no-fib
+
+What to try
+-----------
+* Switch Starting Coordinates between Previous / Spot-burn / None and watch the
+  points change on the real canvases — the canvas *is* the preview.
+* Drag a seeded point, then switch the radio (or the run dropdown) and Cancel:
+  the control goes back to the source actually on the canvas (FIB-319). Add an FM
+  surface point first and the same confirm covers it.
+* ``--no-fib``: the burns are normalised to the FIB image they were placed on, so
+  with no image the radio is disabled and says so. The FIB entries are written to
+  real files, so picking one loads it for real and the radio comes alive;
+  switching between them raises the discard confirm (FIB-317).
+"""
+import os
+import sys
+import tempfile
+from datetime import datetime
+
+import numpy as np
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.correlation.config import CorrelationConfig
+from fibsem.correlation.history import CorrelationRun, LamellaCorrelation
+from fibsem.correlation.structures import (
+    Coordinate,
+    CorrelationInputData,
+    CorrelationState,
+    PointType,
+    PointXYZ,
+)
+from fibsem.correlation.ui.widgets.correlation_tab_widget import CorrelationTabWidget
+from fibsem.fm.structures import (
+    FluorescenceChannelMetadata,
+    FluorescenceImage,
+    FluorescenceImageMetadata,
+)
+from fibsem.structures import FibsemImage, Point
+from fibsem.ui.stylesheets import NAPARI_STYLE
+
+_BURNS = [Point(0.33, 0.51), Point(0.5, 0.51), Point(0.66, 0.51)]
+
+
+def _fib_image(burn_y: int = 205, seed: int = 1) -> FibsemImage:
+    """A lamella strip with three spot burns melted into it."""
+    img = FibsemImage.generate_blank_image(resolution=(600, 400), hfw=100e-6)
+    yy, xx = np.mgrid[0:400, 0:600]
+    g = np.full((400, 600), 60, np.float32)
+    g[burn_y - 25 : burn_y + 25, :] = 110
+    for cx in (200, 300, 400):
+        g += 150 * np.exp(-((xx - cx) ** 2 + (yy - burn_y) ** 2) / 72)
+    img.data[:] = np.clip(
+        g + np.random.default_rng(seed).normal(0, 6, (400, 600)), 0, 255
+    ).astype(img.data.dtype)
+    return img
+
+
+def _write_fib_images() -> list:
+    """Two FIB images on disk, so the picker has something real to load.
+
+    The second sits lower in frame, so swapping between them is obvious — and
+    raises the coordinate-discard confirm.
+    """
+    directory = tempfile.mkdtemp(prefix="correlation-mock-")
+    paths = []
+    for name, img in (
+        ("ref_MillRough_final_ib.tif", _fib_image()),
+        ("ref_Trench_final_ib.tif", _fib_image(burn_y=260, seed=2)),
+    ):
+        path = os.path.join(directory, name)
+        img.save(path)
+        paths.append(path)
+    return paths
+
+
+def _fm_image(nz: int = 11) -> FluorescenceImage:
+    """A single-channel stack with one blob, anisotropic in z."""
+    data = np.zeros((1, nz, 200, 200), np.uint16)
+    yy, xx = np.mgrid[0:200, 0:200]
+    for z in range(nz):
+        data[0, z] = (2000 * np.exp(-((xx - 100) ** 2 + (yy - 95) ** 2) / 648)).astype(
+            np.uint16
+        )
+    channel = FluorescenceChannelMetadata(
+        name="GFP",
+        excitation_wavelength=488.0,
+        emission_wavelength=520.0,
+        power=0.3,
+        exposure_time=0.05,
+        gain=1.5,
+        offset=50.0,
+    )
+    return FluorescenceImage(
+        data=data,
+        metadata=FluorescenceImageMetadata(
+            acquisition_date=datetime(2026, 7, 24).isoformat(),
+            pixel_size_x=40e-9,
+            pixel_size_y=40e-9,
+            pixel_size_z=200e-9,
+            resolution=(200, 200),
+            channels=[channel],
+        ),
+    )
+
+
+def _history() -> LamellaCorrelation:
+    """Two previous runs: an empty one, and one worth seeding from."""
+    previous = CorrelationInputData(
+        fib_coordinates=[
+            Coordinate(point=PointXYZ(x=x, y=205, z=0), point_type=PointType.FIB)
+            for x in (200, 300, 400)
+        ],
+        fm_coordinates=[
+            Coordinate(point=PointXYZ(x=x, y=y, z=5), point_type=PointType.FM)
+            for x, y in ((60, 60), (140, 70), (100, 150))
+        ],
+        poi_coordinates=[
+            Coordinate(point=PointXYZ(x=100, y=95, z=5), point_type=PointType.POI)
+        ],
+    )
+    return LamellaCorrelation(
+        runs=[
+            CorrelationRun(
+                path="/tmp/a",
+                name="2026-07-23_09-10-00",
+                state=CorrelationState(input_data=CorrelationInputData()),
+            ),
+            CorrelationRun(
+                path="/tmp/b",
+                name="2026-07-24_14-32-00",
+                state=CorrelationState(input_data=previous),
+            ),
+        ]
+    )
+
+
+def main() -> None:
+    no_fib = "--no-fib" in sys.argv
+
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    app.setStyle("Fusion")
+    app.setStyleSheet(NAPARI_STYLE)
+
+    # Mock session: never reach for the network to fetch the zeta LUT.
+    import fibsem.correlation.ui.widgets.refractive_index_widget as riw
+
+    riw._ensure_lut = lambda: None
+
+    config = CorrelationConfig()
+    config.fit.fm_poi_channel = "GFP"
+    fib_paths = _write_fib_images()
+
+    widget = CorrelationTabWidget()
+    widget.setWindowTitle(
+        "Correlation — Lamella 03 (mock)" + (" — no FIB image" if no_fib else "")
+    )
+    if not no_fib:
+        widget.set_fib_image(FibsemImage.load(fib_paths[0]))
+    widget.set_fm_image(_fm_image())
+
+    section = widget.add_lamella_setup(
+        spot_burns=_BURNS,
+        history=_history(),
+        config=config,
+        fib_options=fib_paths,
+        fib_current="" if no_fib else fib_paths[0],
+        fm_options=["/lam/Lamella03_FM_G1.ome.tiff"],
+        fm_current="/lam/Lamella03_FM_G1.ome.tiff",
+    )
+    section.emit_current_seed()  # what the editor does on open
+
+    widget.resize(1360, 900)
+    widget.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -440,14 +440,11 @@ class AutoLamellaProtocolEditorWidget(QWidget):
                     sorted(matching_filenames, key=os.path.getmtime)[-1]
                 )
 
-        # set default fib image filename
-        default_filename = fib_filenames[-1] if len(fib_filenames) > 0 else ""
-        if latest_task_filename in base_filenames:
-            default_filename = latest_task_filename
-        elif selected_fib_filename in base_filenames:
-            default_filename = selected_fib_filename
-
-        self.combobox_fib_filenames.setCurrentText(default_filename)
+        self.combobox_fib_filenames.setCurrentText(
+            self._default_fib_filename(
+                base_filenames, latest_task_filename, selected_fib_filename
+            )
+        )
         self.combobox_fib_filenames.blockSignals(False)
 
         # load sem reference image
@@ -1053,6 +1050,27 @@ class AutoLamellaProtocolEditorWidget(QWidget):
 
         if dialog.result is not None:
             self._handle_correlation_dialog_result(dialog.result)
+
+    @staticmethod
+    def _default_fib_filename(
+        base_filenames: List[str],
+        latest_task_filename: str,
+        previous_selection: str,
+    ) -> str:
+        """Which FIB image the combo lands on: the last completed task's reference
+        image, else whatever was selected before, else the newest.
+
+        Everything here is a *basename*, because that is what the combo holds.
+        The newest-image fallback used to be the full path from ``glob``, which
+        made ``setCurrentText`` a silent no-op — so a lamella with no task
+        reference image and no prior selection stayed on the *oldest* image, and
+        that is the image handed to the correlation window (FIB-321).
+        """
+        if latest_task_filename in base_filenames:
+            return latest_task_filename
+        if previous_selection in base_filenames:
+            return previous_selection
+        return base_filenames[-1] if base_filenames else ""
 
     @staticmethod
     def _image_path(lamella: Lamella, filename: str) -> str:

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -234,7 +234,12 @@ def test_status_short_and_result_summary_after_run(qapp):
 
 
 def test_apply_post_creates_ghost_and_status(qapp):
+    from fibsem.structures import FibsemImage
+
     w = _widget(qapp)
+    # Correcting needs the image dimensions: px_m is derived from them, and px_m
+    # is what Continue commits (FIB-321).
+    w.set_fib_image(FibsemImage.generate_blank_image(resolution=(512, 512), hfw=100e-6))
     w._on_canvas_add_requested(1.0, 200.0, PointType.SURFACE)
 
     result = CorrelationResult(

--- a/tests/correlation/test_correlation_ui_honesty.py
+++ b/tests/correlation/test_correlation_ui_honesty.py
@@ -1,0 +1,315 @@
+"""UI states that misrepresent the data (FIB-321).
+
+None of these corrupt what is stored; each shows the user something untrue, and
+two of them let a wrong number reach the experiment:
+
+* a result marked "Correction applied" when the factor is merely armed;
+* a finished run marked live even though the points moved while it ran;
+* a post-correction that updates the display but not ``px_m`` — the value
+  Continue commits;
+* an image picker still displaying a file that failed to load;
+* a previous run with no coordinates silently clearing the live ones;
+* the editor's "latest image" default never applying, so the *oldest* image is
+  the one handed to correlation;
+* legend entries surviving an image swap that removed their markers.
+
+Headless PyQt5, offscreen.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.correlation.config import CorrelationConfig
+from fibsem.correlation.history import CorrelationRun, LamellaCorrelation
+from fibsem.correlation.structures import (
+    Coordinate,
+    CorrelationInputData,
+    CorrelationPointOfInterest,
+    CorrelationResult,
+    CorrelationState,
+    PointType,
+    PointXYZ,
+)
+from fibsem.structures import FibsemImage, Point
+
+
+@pytest.fixture(autouse=True)
+def _no_lut_download(monkeypatch):
+    import fibsem.correlation.ui.widgets.refractive_index_widget as riw
+
+    monkeypatch.setattr(riw, "_ensure_lut", lambda: None)
+
+
+def _widget():
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        CorrelationTabWidget,
+    )
+
+    return CorrelationTabWidget()
+
+
+def _fib_image(resolution=(300, 200)):
+    return FibsemImage.generate_blank_image(resolution=resolution, hfw=100e-6)
+
+
+def _fib(x=1.0, y=2.0):
+    return Coordinate(point=PointXYZ(x=x, y=y, z=0.0), point_type=PointType.FIB)
+
+
+def _poi():
+    return CorrelationPointOfInterest(image_px=Point(x=100.0, y=300.0))
+
+
+# ---------------------------------------------------------------------------
+# 1 — "applied" must mean applied, in this mode
+# ---------------------------------------------------------------------------
+
+
+def test_a_pre_factor_matching_a_post_result_is_still_only_armed(qapp):
+    """Post-correct at ζ, then add an FM surface point and store the same ζ: the
+    factors match but the result was corrected in the *other* space, so the POI
+    on screen is not the one this factor describes."""
+    w = _widget()
+    data = CorrelationInputData(
+        fm_surface_coordinate=Coordinate(
+            point=PointXYZ(x=1.0, y=2.0, z=3.0), point_type=PointType.SURFACE_FM
+        ),
+        ri_pre_correction_factor=1.470,
+    )
+    result = CorrelationResult(
+        poi=[_poi()],
+        refractive_index_correction_factor=1.470,
+        refractive_index_correction_mode="post",
+    )
+
+    w._ri_tab.set_result(result, input_data=data)
+
+    assert "applied on the next run" in w._ri_tab._lbl_warning.text()
+    assert "Correction applied" not in w._ri_tab._lbl_warning.text()
+
+
+def test_a_pre_factor_matching_a_pre_result_reads_as_applied(qapp):
+    """The other side of it: same mode, same factor — that one really is applied."""
+    w = _widget()
+    data = CorrelationInputData(
+        fm_surface_coordinate=Coordinate(
+            point=PointXYZ(x=1.0, y=2.0, z=3.0), point_type=PointType.SURFACE_FM
+        ),
+        ri_pre_correction_factor=1.470,
+    )
+    result = CorrelationResult(
+        poi=[_poi()],
+        refractive_index_correction_factor=1.470,
+        refractive_index_correction_mode="pre",
+    )
+
+    w._ri_tab.set_result(result, input_data=data)
+
+    assert "Correction applied" in w._ri_tab._lbl_warning.text()
+
+
+# ---------------------------------------------------------------------------
+# 2 — a finished run is judged against the points as they are now
+# ---------------------------------------------------------------------------
+
+
+def test_a_run_finishing_after_an_edit_is_not_live(qapp):
+    """_run snapshots the data for the worker but leaves the canvases editable, so
+    a fiducial dragged mid-run makes the delivered result already stale. Continue
+    commits poi[0].px_m, so it must not stay armed."""
+    w = _widget()
+    w.set_fib_image(_fib_image())
+    w.set_data(CorrelationInputData(fib_coordinates=[_fib(x=10.0)]))
+    snapshot = CorrelationInputData(fib_coordinates=[_fib(x=10.0)])
+
+    w.data.fib_coordinates[0].point.x = 999.0  # dragged while the run was in flight
+    w._on_run_finished(CorrelationResult(poi=[_poi()], rms_error=1.0, input_data=snapshot))
+
+    assert not w._btn_continue.isEnabled()
+    assert "points have changed" in w._lbl_status.text()
+
+
+def test_an_undisturbed_run_is_live(qapp):
+    """Guards the over-correction: a normal run must still arm Continue."""
+    w = _widget()
+    w.set_fib_image(_fib_image())
+    w.set_data(CorrelationInputData(fib_coordinates=[_fib(x=10.0)]))
+
+    w._on_run_finished(
+        CorrelationResult(poi=[_poi()], rms_error=1.0, input_data=w.data)
+    )
+
+    assert w._btn_continue.isEnabled()
+
+
+# ---------------------------------------------------------------------------
+# 3 — a correction that cannot reach px_m is refused, not half-applied
+# ---------------------------------------------------------------------------
+
+
+def test_correction_without_image_dimensions_raises():
+    """px_m is what Continue commits. Correcting only image_px moved the marker
+    and recorded the factor while the committed number stayed uncorrected."""
+    result = CorrelationResult(
+        poi=[_poi()],
+        input_data=CorrelationInputData(
+            surface_coordinate=Coordinate(
+                point=PointXYZ(x=1.0, y=200.0, z=0.0), point_type=PointType.SURFACE
+            )
+        ),
+    )
+
+    with pytest.raises(ValueError, match="px_m"):
+        result.apply_refractive_index_correction(1.5)
+
+    # and it left the result alone rather than half-correcting it
+    assert result.poi[0].image_px.y == pytest.approx(300.0)
+    assert result.refractive_index_correction_factor is None
+
+
+# ---------------------------------------------------------------------------
+# 4 — the picker must not display a file that failed to load
+# ---------------------------------------------------------------------------
+
+
+def test_a_file_that_fails_to_load_is_dropped_from_the_picker(qapp, monkeypatch):
+    """A browsed file joins the list before anything opens it. With nothing loaded
+    before, the revert (`show_path("")`) returned immediately and left the bad
+    file on display as though it were the current image."""
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+
+    w = _widget()
+    tab, picker = w._images_tab, w._images_tab._fib_picker
+    picker.show_path("/lam/broken_ib.tif")  # as _browse does
+    monkeypatch.setattr(
+        ctw.FibsemImage,
+        "load",
+        staticmethod(lambda p: (_ for _ in ()).throw(OSError("not a TIFF"))),
+    )
+    monkeypatch.setattr(ctw.QMessageBox, "warning", staticmethod(lambda *a, **k: None))
+
+    tab._load_fib("/lam/broken_ib.tif")
+
+    assert picker.current_path() == ""  # not claiming to show an image
+    assert picker.combo.findData("/lam/broken_ib.tif") < 0  # nor offering it again
+
+
+def _loads_as(path):
+    """A FIB image whose metadata names the file it came from, as a saved one does."""
+    image = _fib_image()
+    image.metadata.image_settings.filename = path
+    return image
+
+
+def test_a_failed_load_falls_back_to_the_last_good_image(qapp, monkeypatch):
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+
+    w = _widget()
+    tab, picker = w._images_tab, w._images_tab._fib_picker
+    monkeypatch.setattr(ctw.FibsemImage, "load", staticmethod(_loads_as))
+    tab._load_fib("/lam/good_ib.tif")
+
+    monkeypatch.setattr(
+        ctw.FibsemImage,
+        "load",
+        staticmethod(lambda p: (_ for _ in ()).throw(OSError("not a TIFF"))),
+    )
+    monkeypatch.setattr(ctw.QMessageBox, "warning", staticmethod(lambda *a, **k: None))
+    picker.show_path("/lam/broken_ib.tif")
+    tab._load_fib("/lam/broken_ib.tif")
+
+    assert picker.current_path() == "/lam/good_ib.tif"
+    assert picker.combo.findData("/lam/broken_ib.tif") < 0
+
+
+# ---------------------------------------------------------------------------
+# 5 — a previous run with no coordinates has nothing to seed
+# ---------------------------------------------------------------------------
+
+
+def _run(name, inp):
+    return CorrelationRun(
+        path="/tmp/" + name, name=name, state=CorrelationState(input_data=inp)
+    )
+
+
+def test_an_empty_previous_run_does_not_wipe_the_coordinates(qapp, monkeypatch):
+    """An empty run — or a legacy file with a null input_data — took the
+    "Previous correlation" branch and replaced every point with nothing."""
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+
+    asked = []
+    monkeypatch.setattr(
+        ctw.QMessageBox,
+        "information",
+        staticmethod(lambda *a, **k: asked.append(a[1])),
+    )
+
+    w = _widget()
+    w.set_fib_image(_fib_image())
+    good = CorrelationInputData(fib_coordinates=[_fib(x=77.0)])
+    section = w.add_lamella_setup(
+        # reversed for display: index 0 is the newest (good), index 1 the empty one
+        history=LamellaCorrelation(
+            runs=[
+                _run("2026-07-20_09-00-00", CorrelationInputData()),
+                _run("2026-07-24_14-32-00", good),
+            ]
+        ),
+        config=CorrelationConfig(),
+    )
+    section.emit_current_seed()
+    assert w.data.fib_coordinates[0].point.x == 77.0
+
+    section.run_combo.setCurrentIndex(1)  # the empty run
+
+    assert asked == ["Nothing to seed"]
+    assert w.data.fib_coordinates[0].point.x == 77.0  # untouched
+    assert section.run_combo.currentIndex() == 0  # and the control went back
+
+
+# ---------------------------------------------------------------------------
+# 6 — the editor's default image
+# ---------------------------------------------------------------------------
+
+
+def test_editor_defaults_to_the_newest_image():
+    """The fallback was a full path from glob while the combo holds basenames, so
+    setCurrentText silently no-op'd and the combo stayed on the oldest image."""
+    from fibsem.ui.widgets.autolamella_lamella_protocol_editor import (
+        AutoLamellaProtocolEditorWidget as Editor,
+    )
+
+    names = ["01_ib.tif", "02_ib.tif", "03_ib.tif"]
+
+    assert Editor._default_fib_filename(names, "", "") == "03_ib.tif"
+    # a task reference image wins, then a previous selection
+    assert Editor._default_fib_filename(names, "02_ib.tif", "01_ib.tif") == "02_ib.tif"
+    assert Editor._default_fib_filename(names, "gone.tif", "01_ib.tif") == "01_ib.tif"
+    assert Editor._default_fib_filename([], "", "") == ""
+
+
+# ---------------------------------------------------------------------------
+# 7 — the legend describes what is on the canvas
+# ---------------------------------------------------------------------------
+
+
+def test_swapping_the_image_clears_the_overlay_legend(qapp):
+    """set_image drops the overlay artists, so their legend entries have to go
+    too — otherwise "POI (P)" keeps appearing over an image that has no POI."""
+    import numpy as np
+
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.set_image(np.zeros((64, 64), np.uint8))
+    canvas.add_overlay_points([(10.0, 10.0)], legend_label="POI (P)")
+    assert canvas._overlay_legend
+
+    canvas.set_image(np.zeros((64, 64), np.uint8))
+
+    assert canvas._overlay_legend == []

--- a/tests/correlation/test_correlation_ui_honesty.py
+++ b/tests/correlation/test_correlation_ui_honesty.py
@@ -226,6 +226,43 @@ def test_a_failed_load_falls_back_to_the_last_good_image(qapp, monkeypatch):
     assert picker.combo.findData("/lam/broken_ib.tif") < 0
 
 
+def test_loading_an_image_does_not_list_it_twice(qapp, monkeypatch):
+    """Metadata records a basename, entries are keyed on full paths — so the
+    lookup missed and the bare name was added as a second entry for the same
+    file. Picking that one calls FibsemImage.load on a bare name, which resolves
+    against the working directory and fails."""
+    import fibsem.correlation.ui.widgets.correlation_tab_widget as ctw
+
+    w = _widget()
+    tab, picker = w._images_tab, w._images_tab._fib_picker
+    path = "/lam/03_ref_MillRough_ib.tif"
+    picker.set_options([path], path)
+    monkeypatch.setattr(
+        ctw.FibsemImage, "load", staticmethod(lambda p: _loads_as("03_ref_MillRough_ib.tif"))
+    )
+
+    tab._load_fib(path)
+
+    assert [picker.combo.itemData(i) for i in range(picker.combo.count())] == [path]
+    assert picker.current_path() == path
+    assert tab._fib_loaded_path == path  # a path, not a bare name
+
+
+def test_an_unknown_image_does_not_invent_an_entry(qapp):
+    """An image whose metadata names a file the picker doesn't offer must leave
+    the list — and the display — alone, rather than showing something it can't
+    load."""
+    w = _widget()
+    tab, picker = w._images_tab, w._images_tab._fib_picker
+    known = "/lam/03_ref_MillRough_ib.tif"
+    picker.set_options([known], known)
+
+    tab.set_fib_image(_loads_as("/somewhere/else/other_ib.tif"))
+
+    assert [picker.combo.itemData(i) for i in range(picker.combo.count())] == [known]
+    assert picker.current_path() == known
+
+
 # ---------------------------------------------------------------------------
 # 5 — a previous run with no coordinates has nothing to seed
 # ---------------------------------------------------------------------------

--- a/tests/correlation/test_structures.py
+++ b/tests/correlation/test_structures.py
@@ -64,9 +64,17 @@ def _make_result() -> CorrelationResult:
 def _make_corrected_result(
     poi_list=None, fib_image=None
 ) -> CorrelationResult:
-    """Result with input_data carrying a FIB surface at y=200."""
+    """Result with input_data carrying a FIB surface at y=200.
+
+    Carries a FIB image by default: correcting needs the image shape and pixel
+    size to update ``px_m``, and every real result has them — from the image, or
+    restored from JSON via the ``stored_*`` fallbacks (FIB-321).
+    """
     surface = _make_coord(y=200.0, pt=PointType.SURFACE)
-    data = CorrelationInputData(surface_coordinate=surface, fib_image=fib_image)
+    data = CorrelationInputData(
+        surface_coordinate=surface,
+        fib_image=fib_image if fib_image is not None else _make_fake_fib_image(),
+    )
     return CorrelationResult(
         poi=poi_list if poi_list is not None else [_make_poi(image_px_y=300.0)],
         input_data=data,


### PR DESCRIPTION
Closes FIB-321 — the last tier from the post-FIB-302 review. None of these corrupt what is stored; each shows the user something untrue, and two let a wrong number reach the experiment.

## Results that claim to be current

**"Correction applied" while a factor is only armed.** `armed` compared factors and ignored the result's *mode*. Post-correct at ζ=1.470 → add an FM surface point (the tab switches to pre) → store 1.470 without re-running, and the label read a green *"Correction applied (post, factor: 1.470)"* while the factor was merely armed and the POI on screen was the old post-corrected one.

**A finished run was always marked live.** `_run` snapshots the data for the worker but leaves the canvases editable, so a fiducial dragged mid-run makes the delivered result already stale — yet Continue was armed and the RMS badge shown. It's now judged with `matches_inputs`, the same as the load path. Same failure FIB-317 was about, reached by a different route.

**A post-correction could update the display but not `px_m`.** With the image dimensions absent it corrected `image_px`, recorded factor and mode, and left `px_m` uncorrected — and `px_m` is exactly what Continue commits. It logged a warning and carried on; it now refuses. Both properties fall back to the values restored from JSON, so this is reachable only for a result never associated with an image at all.

## Sources that quietly do the wrong thing

**The picker kept displaying a file that failed to load.** A browsed file joins the list before anything tries to open it, and the revert — `show_path("")` — returns immediately. Browse to an unreadable TIFF before any image has loaded and the combo still showed it, `current_path()` still returned it while `fib_image` was `None`, and the bad path stayed selectable all session.

**A previous run with no coordinates cleared every live point.** Falling through to the "None" branch is how an empty run — or a legacy file with a null `input_data` — emptied the canvas while the radio read "Previous correlation". Only the None branch clears now, and the veto explains why the others didn't apply.

**The editor's latest-image default never applied.** The fallback was a full path from `glob` while the combo holds basenames, so `setCurrentText` silently no-op'd: a lamella with no task reference image and no prior selection stayed on the **oldest** image — which is the image handed to the correlation window. Extracted to `_default_fib_filename` so the precedence is testable.

**The picker held things that were not paths.** Metadata records a *basename* while entries are keyed on full paths, so the lookup in `set_fib_image` never matched and `show_path` added the bare name as a new entry. On an ordinary fibsemOS image with valid metadata:

```
combo before      : ['/var/.../03_ref_MillRough_ib.tif']
metadata.filename : 03_ref_MillRough_ib.tif
_fib_loaded_path  : '03_ref_MillRough_ib.tif'      <- a bare name, not a path
combo after       : ['/var/.../03_ref_MillRough_ib.tif', '03_ref_MillRough_ib.tif']
```

The dropdown listed the same file twice after every load; picking the second entry called `FibsemImage.load` on a bare name, which resolves against the working directory and fails; and `_fib_loaded_path` — the last-good path a failed load reverts to — stopped being a path. `set_fib_image`/`set_fm_image` now resolve the name against what the picker already offers, and leave list and display alone when the image isn't one of the known files.

## Cosmetic

**Stale legend entries.** `set_image` dropped the overlay artists but kept their legend entries, so "POI (P)" / "FM reprojected (E)" advertised markers the new image did not have.

## Testing

- 409 pass across correlation + autolamella + ui; 12 new.
- All 11 mutations verified, two of them guarding against over-correcting rather than under-: everything reading as armed, and no run ever being live.
- Seven existing tests exercised the no-image correction path deliberately; they now carry the FIB image every real result has.

## Also here

A manual launcher for the Setup tab (`fibsem/correlation/ui/widgets/test_correlation_setup_section.py`), following the house convention for GUI harnesses — `test_*.py` beside the widget, `main()` behind `__main__`, no test functions in it. `--no-fib` opens in the state that disables the spot-burn radio.