### PR TITLE
Correlation: fix Shift+scroll Z stepping on a discrete mouse (FIB-323)

### DIFF
--- a/fibsem/correlation/ui/widgets/image_point_canvas.py
+++ b/fibsem/correlation/ui/widgets/image_point_canvas.py
@@ -931,6 +931,40 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         """When enabled, Shift+wheel emits z_scroll_requested instead of zooming."""
         self._shift_z_enabled = bool(enabled)
 
+    def wheelEvent(self, event) -> None:
+        """Rescue Shift+wheel when the delta doesn't arrive vertically.
+
+        matplotlib's Qt backend reads only the *vertical* component and emits
+        nothing at all when it is zero::
+
+            steps = event.angleDelta().y() / 120   # or pixelDelta().y()
+            if steps and self.figure is not None:
+                MouseEvent("scroll_event", ...)._process()
+
+        macOS turns Shift+wheel from a discrete mouse into horizontal scrolling,
+        moving the delta into ``x`` — so ``scroll_event`` never fires and Z
+        stepping is silently dead, while the same gesture on a trackpad (which
+        reports ``pixelDelta``) keeps working. Hence "it worked yesterday".
+
+        Only the empty-vertical case is taken here, which is exactly the case
+        matplotlib drops. Anything it would deliver is passed straight through,
+        so platforms where this already works — Windows wheels, macOS trackpads —
+        keep going through ``_on_scroll`` with its in-axes check intact.
+        """
+        angle, pixel = event.angleDelta(), event.pixelDelta()
+        if (
+            self._shift_z_enabled
+            and event.modifiers() & Qt.ShiftModifier
+            and angle.y() == 0
+            and pixel.y() == 0
+        ):
+            step = angle.x() or pixel.x()
+            if step:
+                self.z_scroll_requested.emit(1 if step > 0 else -1)
+                event.accept()
+                return
+        super().wheelEvent(event)
+
     def _on_scroll(self, event) -> None:
         if event.inaxes is not self._ax or event.xdata is None:
             return

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -764,6 +764,78 @@ def test_canvas_shift_scroll_emits_z_when_enabled(qapp):
     assert got == [1, -1]
 
 
+def _wheel(canvas, *, angle=(0, 0), pixel=(0, 0), shift=True):
+    """Deliver a real QWheelEvent, so the Qt -> matplotlib path is exercised.
+
+    The test above hand-builds a matplotlib event and calls _on_scroll directly,
+    which is why it kept passing while Z stepping was dead on a real mouse: the
+    event never reached _on_scroll at all.
+    """
+    import numpy as np
+    from PyQt5.QtCore import QPoint, QPointF, Qt
+    from PyQt5.QtGui import QWheelEvent
+    from PyQt5.QtWidgets import QApplication
+
+    if canvas._ax.images == []:
+        canvas.set_image(np.zeros((64, 64), np.uint8))
+        canvas.resize(400, 400)
+    pos = QPointF(200.0, 200.0)
+    QApplication.sendEvent(
+        canvas,
+        QWheelEvent(
+            pos, pos, QPoint(*pixel), QPoint(*angle), Qt.NoButton,
+            Qt.ShiftModifier if shift else Qt.NoModifier, Qt.NoScrollPhase, False,
+        ),
+    )
+
+
+def test_shift_wheel_steps_z_however_the_delta_arrives(qapp):
+    """matplotlib reads only the *vertical* delta and emits nothing when it is
+    zero, so a device that reports Shift+wheel horizontally (a discrete mouse on
+    macOS) got no scroll_event at all — Z stepping silently dead, while the same
+    gesture on a trackpad kept working."""
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    canvas.set_shift_z_scroll_enabled(True)
+    got = []
+    canvas.z_scroll_requested.connect(got.append)
+
+    # Windows mouse / any platform that keeps it vertical: via matplotlib.
+    _wheel(canvas, angle=(0, 120))
+    assert got == [1]
+
+    # Trackpad: pixelDelta carries it, also vertical.
+    _wheel(canvas, angle=(0, 120), pixel=(0, 30))
+    assert got == [1, 1]
+
+    # macOS discrete mouse: the delta lands in x and matplotlib drops the event.
+    _wheel(canvas, angle=(120, 0))
+    _wheel(canvas, angle=(-120, 0))
+    assert got == [1, 1, 1, -1]
+
+    # Diagonal: matplotlib owns it, because it reads y. Taking it here would let
+    # x reach the opposite conclusion — which is what the vertical guard is for.
+    got.clear()
+    _wheel(canvas, angle=(-120, 120))
+    assert got == [1]
+
+
+def test_horizontal_wheel_only_steps_z_when_it_should(qapp):
+    """Guards the over-correction: the rescue must not fire without Shift, nor
+    when the canvas hasn't opted into Z stepping."""
+    from fibsem.correlation.ui.widgets.image_point_canvas import ImagePointCanvas
+
+    canvas = ImagePointCanvas()
+    got = []
+    canvas.z_scroll_requested.connect(got.append)
+
+    _wheel(canvas, angle=(120, 0))                 # not enabled yet
+    canvas.set_shift_z_scroll_enabled(True)
+    _wheel(canvas, angle=(120, 0), shift=False)    # enabled, but no Shift
+    assert got == []
+
+
 def test_fm_display_shows_image_name(qapp):
     from fibsem.correlation.ui.widgets.fm_image_display_widget import (
         FMImageDisplayWidget,


### PR DESCRIPTION
Closes FIB-323.

Shift+scroll over the FM canvas steps through Z slices. It works with a trackpad and does **nothing at all** with a conventional mouse on macOS — no Z step, no zoom, no error.

## Cause

matplotlib's Qt backend reads only the *vertical* component of the wheel delta, and emits no event at all when it is zero:

```python
if event.pixelDelta().isNull() or platformName() == "xcb":
    steps = event.angleDelta().y() / 120     # discrete mouse
else:
    steps = event.pixelDelta().y()           # trackpad / Magic Mouse
if steps and self.figure is not None:
    MouseEvent("scroll_event", ...)._process()
```

macOS turns Shift+wheel from a discrete mouse into *horizontal* scrolling, moving the delta into `angleDelta().x()`. `steps` is then 0, `scroll_event` never fires, and `_on_scroll` — where the Shift branch lives — is never reached. A trackpad reports `pixelDelta`, whose `y` survives, which is why the same gesture works there.

Reproduced by sending real QWheelEvents to the canvas:

```
vertical   + shift  ->  z emits: [1]
horizontal + shift  ->  z emits: []      # nothing, not even a zoom
```

## Fix

A `wheelEvent` override that takes Shift+wheel only when the vertical delta is empty — exactly the case matplotlib drops — and reads whichever axis carries it.

| | `angleDelta.y` | before | after |
|---|---|---|---|
| Windows mouse | ±120 | matplotlib → works | unchanged |
| macOS trackpad | via `pixelDelta.y` | matplotlib → works | unchanged |
| macOS mouse | 0, delta in `x` | **nothing** | intercepted → Z step |

Purely additive: it can only fire where the current behaviour is "nothing happens at all", so it cannot regress a platform where the feature works. Everything matplotlib would deliver still goes through `_on_scroll` with its in-axes check.

The vertical guard is load-bearing rather than belt-and-braces: for a diagonal delta, `angleDelta = (-120, 120)` must step **+1** from `y`, not **−1** from `x`. My first mutation run missed that, because no test input had both axes populated — there's a case for it now.

## Testing

- 451 pass across correlation + autolamella + ui; 3 new.
- Tests send **real `QWheelEvent`s** through the Qt → matplotlib path. The existing test hand-builds a matplotlib event and calls `_on_scroll` directly, which is why it kept passing while the feature was dead on a mouse.
- All 5 mutations verified, three of them over-corrections: intercepting what matplotlib would deliver, firing without Shift, ignoring the opt-in.
- Confirmed working on hardware by Patrick before this was committed.

## Noticed, not fixed

`FMImageDisplayWidget._step_z` silently no-ops while Max Projection is ticked. Defensible — there's no single slice to step through in a projection — but it's the same silence that made this bug hard to spot.