### PR TITLE
Images record the file they were written to or read from (FIB-326)

### DIFF
--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -324,6 +324,10 @@ class ZParameters:
 class FluorescenceImage:
     data: np.ndarray  # TCZYX format (Time, Channels, Z, Y, X)
     metadata: "FluorescenceImageMetadata"
+    # the file this image is associated with on disk, set by save() and load().
+    # excluded from compare/repr: it describes where the image lives, not what it contains,
+    # so two images of the same data read from different paths are still equal.
+    filepath: Optional[str] = field(default=None, compare=False, repr=False)
 
     def save(self, filename: str) -> str:
         """
@@ -354,7 +358,9 @@ class FluorescenceImage:
             tif.write(data=tifffile_image, contiguous=True)
             tif.overwrite_description(ome_xml)
 
-        return filename
+        # set only after a successful write, so a recorded path is always a path that exists
+        self.filepath = str(filename)
+        return self.filepath
 
     def get_ome_metadata(self) -> OMEMetadata:
         """Generate OME metadata for the FluorescenceImage."""
@@ -613,7 +619,7 @@ class FluorescenceImage:
                             # Single channel, single Z: YX -> CZYX
                             data = data[np.newaxis, np.newaxis, :, :]
 
-                        return cls(data=data, metadata=metadata)
+                        return cls(data=data, metadata=metadata, filepath=str(filename))
 
         except Exception as e:
             logging.warning(f"Failed to load structured annotations: {e}")
@@ -628,7 +634,7 @@ class FluorescenceImage:
                 # Fallback to basic metadata
                 metadata = cls._create_basic_metadata(data.shape)
 
-        return cls(data=data, metadata=metadata)
+        return cls(data=data, metadata=metadata, filepath=str(filename))
 
     @classmethod
     def _create_basic_metadata(cls, data_shape: tuple) -> "FluorescenceImageMetadata":

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1945,11 +1945,18 @@ class FibsemImage:
             Returns:
                 FibsemImage: instance of FibsemImage
 
-        save(self, path: Path) -> None:
+        save(self, path: Path) -> str:
             Saves a FibsemImage to a tiff file.
 
             Inputs:
                 path (path): path to save directory and filename
+
+            Returns:
+                str: the resolved path written to
+
+    Attributes:
+        filepath (Optional[str]): the file this image is associated with on disk, set by
+            save() and load(). None for an image that has never been written or read.
     """
 
     def __init__(self, data: np.ndarray, metadata: Optional[FibsemImageMetadata] = None):
@@ -1963,6 +1970,9 @@ class FibsemImage:
             self.metadata = metadata
         else:
             self.metadata = None
+        # the file this image is associated with on disk, set by save() and load().
+        # not serialised: it describes where the image lives, not what it contains.
+        self.filepath: Optional[str] = None
 
     @property
     def shape(self) -> tuple[int, int]:
@@ -2018,15 +2028,20 @@ class FibsemImage:
                 # print(f"Error: {e}")
                 # import traceback
                 # traceback.print_exc()
-        return cls(data=data, metadata=metadata)
+        image = cls(data=data, metadata=metadata)
+        image.filepath = str(tiff_path)
+        return image
 
-    def save(self, path: Optional[Union[Path, str]] = None) -> None:
+    def save(self, path: Optional[Union[Path, str]] = None) -> str:
         """Saves a FibsemImage to a tiff file.
 
         Inputs:
             path (path): path to save directory and filename
+
+        Returns:
+            str: the resolved path the image was written to (also set on self.filepath)
         """
-        
+
         if path is None:
             if self.metadata is None:
                 raise ValueError("No metadata provided, cannot determine save path. Please provide a path.")
@@ -2049,6 +2064,9 @@ class FibsemImage:
             self.data,
             metadata=metadata_dict,
         )
+        # set only after a successful write, so a recorded path is always a path that exists
+        self.filepath = str(path)
+        return self.filepath
 
     ### EXPERIMENTAL START ####
 

--- a/tests/fm/test_structures.py
+++ b/tests/fm/test_structures.py
@@ -635,6 +635,9 @@ def test_fluorescence_image_load_fallback():
         assert loaded_image.metadata.pixel_size_x == 1e-6
         assert loaded_image.metadata.pixel_size_y == 1e-6
 
+        # the fallback path is a separate return point — it must record the file too
+        assert loaded_image.filepath == filename
+
     finally:
         import os
 
@@ -2268,3 +2271,63 @@ def test_fluorescence_configuration_yaml_roundtrip_fm():
         import os
         if os.path.exists(filename):
             os.unlink(filename)
+
+
+# FluorescenceImage.filepath — the file an image is associated with on disk
+
+
+def _make_image() -> FluorescenceImage:
+    """A minimal two-channel image that round-trips through OME-TIFF cleanly."""
+    data = np.zeros((2, 1, 16, 16), dtype=np.uint8)  # C, Z, Y, X
+    metadata = FluorescenceImageMetadata(
+        acquisition_date="2025-01-01T12:00:00",
+        pixel_size_x=100e-9,
+        pixel_size_y=100e-9,
+        resolution=(16, 16),
+        channels=[
+            FluorescenceChannelMetadata(
+                name=name,
+                excitation_wavelength=excitation,
+                power=0.5,
+                exposure_time=0.1,
+                gain=1.0,
+                offset=0.0,
+            )
+            for name, excitation in (("DAPI", 365.0), ("GFP", 488.0))
+        ],
+    )
+    return FluorescenceImage(data=data, metadata=metadata)
+
+
+def test_fluorescence_image_filepath_is_none_until_written_or_read():
+    """An image that has never been saved or loaded has no file."""
+    assert _make_image().filepath is None
+
+
+def test_fluorescence_image_save_and_load_set_filepath(tmp_path):
+    """save() records where it wrote; load() records where it read."""
+    filename = str(tmp_path / "zstack.ome.tiff")
+
+    image = _make_image()
+    returned = image.save(filename)
+    assert returned == filename
+    assert image.filepath == filename
+
+    loaded = FluorescenceImage.load(filename)
+    assert loaded.filepath == filename
+
+
+def test_fluorescence_image_filepath_excluded_from_compare_and_repr():
+    """filepath describes where the image lives, not what it contains.
+
+    Guards the compare=False/repr=False on the field: without them, adding it
+    would change dataclass equality and repr for every FluorescenceImage.
+    """
+    import dataclasses
+
+    compared = [f.name for f in dataclasses.fields(FluorescenceImage) if f.compare]
+    assert compared == ["data", "metadata"]
+
+    image = _make_image()
+    image.filepath = "/somewhere/on/disk.ome.tiff"
+    assert "filepath" not in repr(image)

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 
 import pytest
 
@@ -435,3 +436,39 @@ def test_reference_image_parameters_estimated_time_no_images():
         imaging=img, acquire_sem=False, acquire_fib=False, acquire_image1=True, acquire_image2=True
     )
     assert ref.estimated_time == 0.0
+
+
+# FibsemImage.filepath — the file an image is associated with on disk
+
+
+def test_fibsem_image_filepath_is_none_until_written_or_read():
+    """An image that has never been saved or loaded has no file."""
+    import numpy as np
+    image = FibsemImage(data=np.zeros((10, 10), dtype=np.uint8))
+    assert image.filepath is None
+
+
+def test_fibsem_image_save_sets_filepath_to_the_resolved_file(tmp_path):
+    """save() records the path it actually wrote, extension included."""
+    import numpy as np
+    image = FibsemImage(data=np.zeros((10, 10), dtype=np.uint8))
+
+    # deliberately passed without a suffix: save() resolves it to .tif, and the
+    # recorded path must be the resolved one, not the argument.
+    returned = image.save(str(tmp_path / "ref_image"))
+
+    assert image.filepath == returned
+    assert image.filepath.endswith(".tif")
+    assert os.path.isfile(image.filepath)
+
+
+def test_fibsem_image_load_sets_filepath(tmp_path):
+    """load() records where the image came from."""
+    import numpy as np
+    written = FibsemImage(data=np.zeros((10, 10), dtype=np.uint8)).save(
+        str(tmp_path / "ref_image")
+    )
+
+    loaded = FibsemImage.load(written)
+
+    assert loaded.filepath == written


### PR DESCRIPTION
`FibsemImage` and `FluorescenceImage` now carry a `filepath` attribute naming the file they are associated with on disk, set by `save()` and `load()`.

Closes FIB-326. Unblocks FIB-324 (tasks recording what they produced), which was the driver — but this stands on its own.

## Why

Nothing could ask a saved image where it landed. The path is assembled across three layers, all *below* the task layer:

| Layer | Adds |
| --- | --- |
| `acquire_set_of_channels` ([acquire.py:221](https://github.com/fibsem-os/fibsem-os/blob/main/fibsem/acquire.py#L221)) | `_res_NN` |
| `new_image` ([acquire.py:35](https://github.com/fibsem-os/fibsem-os/blob/main/fibsem/acquire.py#L35)) | `_eb` / `_ib` |
| `FibsemImage.save` | `.tif` |

So any caller wanting a path had to re-encode that convention. It is already encoded in three places — `lamella_task_image_widget`, `autolamella_lamella_protocol_editor`, and `tools/review.py` — and the third still expects `high_res`, which the producer stopped emitting. Adding a fourth copy was the alternative to this change.

Making the image carry its own path means **`fibsem/acquire.py` needs no change at all**: `new_image` already returns the image, and the image now knows where it went.

## What changed

**`FibsemImage`** — a plain class, so a plain instance attribute in `__init__`.

- `save()` sets it **after** `tff.imwrite`, so a recorded path is always a path that exists, and returns it. Signature goes `-> None` to `-> str`: purely additive, since no caller could have been using the old `None`.
- `load()` sets it before returning.

**`FluorescenceImage`** — this one **is** a `@dataclass`, where a bare annotated attribute would silently become a field and join `__init__`, `__eq__` and `asdict()`. Declared explicitly instead:

```python
filepath: Optional[str] = field(default=None, compare=False, repr=False)
```

so equality and repr keep describing what the image *contains*, not where it *lives*. Its `load()` has two return points; both record.

Derived images — projections, z-stacks, the correlation interpolation — construct by keyword and get `None`. Correct: a projection is not a file on disk.

## Deliberately not done

- Writing the suffixed name back into `metadata.image_settings.filename` — that would change what gets serialised into every `.tif`.
- Changing the return types of `acquire_channels` / `acquire_set_of_channels` — six call sites across milling and alignment, for no gain once the image carries its own path.

## Testing

Six new tests, plus one assertion added to the existing `test_fluorescence_image_load_fallback` so `load()`'s **second** return point is covered rather than only the path the round-trip test happens to take.

Mutation-verified 8/8. The two worth calling out:

- recording an **unresolved** path (dropping the `.tif` that `save()` adds) — caught
- letting `filepath` join `compare`/`repr` — caught. This is the dataclass trap: it would change equality for every `FluorescenceImage` in the codebase.

Full suite: **980 passed, 7 skipped** (pre-existing `tmp/ FM volume not present`).

## Noted in passing, not fixed

`FluorescenceImage.__eq__` raises `ValueError: truth value of an array with more than one element is ambiguous` for any multi-element image — dataclass equality has never worked on it. So the `compare=False` guard is tested by asserting on `dataclasses.fields(...)` directly rather than by comparing two instances.