### PR TITLE
Tasks record the files they produced (FIB-324)

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -132,6 +132,13 @@ class AutoLamellaTaskState:
     end_timestamp: Optional[float] = None
     status: AutoLamellaTaskStatus = AutoLamellaTaskStatus.NotStarted
     status_message: str = ""
+    # files this run produced, keyed by role, as paths relative to lamella.path.
+    # roles mirror the naming convention the files already carry: phase x modality,
+    # i.e. final_sem / final_fib / start_sem / start_fib, plus fluorescence.
+    # paths only -- the experiment is written with yaml.safe_dump, which refuses
+    # numpy scalars and enums and would fail the whole save. measured values belong
+    # in a separate field, not here.
+    outputs: Dict[str, List[str]] = field(default_factory=dict)
 
     @property
     def completed(self) -> str:
@@ -170,7 +177,10 @@ class AutoLamellaTaskState:
             return cls()
         data = data.copy()
         data["status"] = AutoLamellaTaskStatus[data.get("status", "NotStarted")]
-        return cls(**data)
+        # drop keys this build doesn't know about: an experiment written by a newer
+        # version must still load in an older one rather than raising TypeError.
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
 
 
 @evented

--- a/fibsem/applications/autolamella/task_outputs.py
+++ b/fibsem/applications/autolamella/task_outputs.py
@@ -1,0 +1,39 @@
+"""Reading back the files a task run produced.
+
+Runs record what they wrote on their history entry (`AutoLamellaTaskState.outputs`).
+This module is the read side of that: it answers "which files does this run's images
+consist of", so consumers don't each re-encode the filename convention.
+
+Deliberately free of UI imports — the policy is about paths, not widgets, and keeping
+it here lets it be tested without Qt and reused outside the review panel.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from typing import List
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskState, Lamella
+
+
+def final_reference_images(lamella: Lamella, task: AutoLamellaTaskState) -> List[str]:
+    """Absolute paths to the final reference images a task run produced.
+
+    Prefers what the run recorded. Falls back to the filename convention, which
+    remains the only route for experiments written before outputs existed, and for
+    runs that failed before reaching post_task and so have no history entry at all.
+
+    Sorted so both routes yield the same order: alphabetical puts the highest-res
+    pair last, which is what callers slice off.
+    """
+    recorded = [
+        os.path.join(lamella.path, relpath)
+        for role in ("final_sem", "final_fib")
+        for relpath in task.outputs.get(role, [])
+    ]
+    if recorded:
+        return sorted(recorded)
+    return sorted(
+        glob.glob(os.path.join(lamella.path, f"ref_{task.name}*_final_*res*.tif*"))
+    )

--- a/fibsem/applications/autolamella/task_outputs.py
+++ b/fibsem/applications/autolamella/task_outputs.py
@@ -32,8 +32,13 @@ def final_reference_images(lamella: Lamella, task: AutoLamellaTaskState) -> List
         for role in ("final_sem", "final_fib")
         for relpath in task.outputs.get(role, [])
     ]
+    # deduplicate: a path recorded twice is still one file, and duplicates would
+    # crowd out real images when callers slice the last N off the result.
+    # require the file to still exist, so a record whose images have been deleted
+    # falls through to the convention rather than yielding permanent blanks.
+    recorded = sorted({path for path in recorded if os.path.isfile(path)})
     if recorded:
-        return sorted(recorded)
+        return recorded
     return sorted(
         glob.glob(os.path.join(lamella.path, f"ref_{task.name}*_final_*res*.tif*"))
     )

--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -105,6 +105,12 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
                                 stop_event=self._stop_event,
                                 filename=filename)
 
+        # acquire_image swallows save failures (it logs and carries on), so the
+        # requested filename is not proof the file was written. FluorescenceImage.save
+        # sets filepath only after a successful write, so an unwritten image has none
+        # and _record_output skips it.
+        self._record_output("fluorescence", image)
+
         # refresh the recorded fluorescence pose (preserving the configured objective position)
         self._update_fluorescence_pose()
 

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -450,7 +450,13 @@ class AutoLamellaTask(ABC):
         if image is None or image.filepath is None:
             return
         path = os.path.relpath(image.filepath, self.lamella.path)
-        self.lamella.task_state.outputs.setdefault(role, []).append(path)
+        paths = self.lamella.task_state.outputs.setdefault(role, [])
+        # a run can acquire the same set more than once -- MillCoincidentTask does,
+        # before and after milling -- and the default filename means the second write
+        # overwrites the first. The record describes files, not writes, so the same
+        # path recorded twice is still one file.
+        if path not in paths:
+            paths.append(path)
 
     def _record_channel_outputs(self, phase: str, images: List[Tuple[Optional[FibsemImage], Optional[FibsemImage]]]) -> None:
         """Record a set of (sem, fib) pairs under `{phase}_sem` / `{phase}_fib`."""

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -82,6 +82,7 @@ from fibsem.structures import (
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.ui import AutoLamellaUI
     from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+    from fibsem.fm.structures import FluorescenceImage
 
 TAutoLamellaTaskConfig = TypeVar(
     "TAutoLamellaTaskConfig", bound="AutoLamellaTaskConfig"
@@ -177,12 +178,20 @@ class AutoLamellaTask(ABC):
         logging.info(f"Running {self.task_name}, {self.task_type} ({self.task_id}) for {self.lamella.name} ({self.lamella._id})")
 
         # pre-task
+        # task_state is a single object reused across every run, so each per-run field
+        # has to be cleared here or the next run inherits the previous one's value.
+        # NOTE: do not "fix" this by assigning a fresh AutoLamellaTaskState. The lamella
+        # list and card widgets connect psygnal handlers to this instance and use them as
+        # their only refresh trigger; replacing the object orphans those connections and
+        # they silently stop updating mid-workflow. See FIB-325 for the real fix.
         self.lamella.task_state.name = self.task_name
         self.lamella.task_state.start_timestamp = datetime.timestamp(datetime.now())
+        self.lamella.task_state.end_timestamp = None
         self.lamella.task_state.task_id = self.task_id
         self.lamella.task_state.task_type = self.task_type
         self.lamella.task_state.status = AutoLamellaTaskStatus.InProgress
         self.lamella.task_state.status_message = ""
+        self.lamella.task_state.outputs = {}
         self.log_status_message(message="STARTED",
                                 display_message="Started",
                                 workflow_display_message=f"{self.lamella.name} [{self.display_name}]")
@@ -431,6 +440,24 @@ class AutoLamellaTask(ABC):
                                                 acquire_sem=acquire_sem,
                                                 acquire_fib=acquire_fib)
 
+    def _record_output(self, role: str, image: Optional[Union[FibsemImage, "FluorescenceImage"]]) -> None:
+        """Record where an acquired image was written, under the given role.
+
+        Stored relative to the lamella directory so the record survives the
+        experiment being copied off the microscope. Images that were never
+        written to disk carry no filepath and are skipped.
+        """
+        if image is None or image.filepath is None:
+            return
+        path = os.path.relpath(image.filepath, self.lamella.path)
+        self.lamella.task_state.outputs.setdefault(role, []).append(path)
+
+    def _record_channel_outputs(self, phase: str, images: List[Tuple[Optional[FibsemImage], Optional[FibsemImage]]]) -> None:
+        """Record a set of (sem, fib) pairs under `{phase}_sem` / `{phase}_fib`."""
+        for sem_image, fib_image in images:
+            self._record_output(f"{phase}_sem", sem_image)
+            self._record_output(f"{phase}_fib", fib_image)
+
     def _acquire_channels(self,
                           image_settings: ImageSettings,
                           filename: Optional[str] = None,
@@ -438,6 +465,10 @@ class AutoLamellaTask(ABC):
                           acquire_sem: bool = True,
                           acquire_fib: bool = True) -> None:
         """Acquire images for sem/fib channels at given field of view."""
+        # only the default filename is the conventional start-of-task reference set.
+        # tasks that pass their own name are recorded separately, so consumers asking
+        # for the conventional sets don't silently pick up one-off acquisitions.
+        phase = "start" if filename is None else "other"
         if filename is None:
             filename = f"ref_{self.task_name}_start"
 
@@ -449,6 +480,7 @@ class AutoLamellaTask(ABC):
                                                         image_settings,
                                                         acquire_sem=acquire_sem,
                                                         acquire_fib=acquire_fib)
+        self._record_channel_outputs(phase, [(sem_image, fib_image)])
         if fib_image is not None:
             self._last_fib_image = fib_image
         set_images_ui(self.parent_ui, sem_image, fib_image)
@@ -462,6 +494,9 @@ class AutoLamellaTask(ABC):
 
         if field_of_views is None:
             field_of_views = (fcfg.REFERENCE_HFW_HIGH, fcfg.REFERENCE_HFW_SUPER)
+        # only the default filename is the conventional final reference set; see
+        # _acquire_channels for why one-off acquisitions are recorded separately.
+        phase = "final" if filename is None else "other"
         if filename is None:
             filename = f"ref_{self.task_name}_final"
 
@@ -474,6 +509,7 @@ class AutoLamellaTask(ABC):
             acquire_sem=acquire_sem,
             acquire_fib=acquire_fib,
         )
+        self._record_channel_outputs(phase, images)
 
         sem_image, fib_image = images[-1] # last acquired image
         if fib_image is not None:

--- a/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
+++ b/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
@@ -256,6 +256,10 @@ class MillCoincidentTask(AutoLamellaTask):
                 stop_event=self._stop_event,
                 filename=filename,
             )
+            # acquire_image swallows save failures, so the requested filename is not
+            # proof the file was written; an unwritten image has no filepath and is
+            # skipped. See AcquireFluorescenceImageTask for the same pattern.
+            self._record_output("fluorescence", image)
 
         # acquire reference images
         self._acquire_set_of_reference_images(image_settings)

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -2392,11 +2392,16 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
     def _record_coincidence_result(self) -> None:
         """Record the latest coincidence run against the selected lamella.
 
-        Saves the post-milling FIB with the review-panel naming (overwriting, so
-        the panel shows the latest) and appends a 'Coincidence Milling' entry to
-        the lamella's task history so the Review tab picks it up. Every run is
+        Saves the post-milling FIB and appends a 'Coincidence Milling' entry to the
+        lamella's task history, recording the image under `final_fib` so the Review
+        tab finds it the same way it finds any other task's output. Every run is
         recorded (the panel dedups by name); per-run images stay archived in the
         strategy's own coincidence-images folders.
+
+        The file keeps the review-panel naming, and is overwritten each run, purely
+        so experiments opened by a build predating task outputs still resolve it
+        through the filename convention. Once that fallback is no longer needed the
+        name is free to become per-run, and runs will stop overwriting each other.
         """
         lamella = self._selected_lamella
         image = self._latest_fib_image
@@ -2412,7 +2417,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
                 lamella.path,
                 f"ref_{COINCIDENCE_REVIEW_TASK_NAME}_final_res_01_ib.tif",
             )
-            image.save(filename)
+            written = image.save(filename)
 
             now = datetime.datetime.now().timestamp()
             lamella.task_history.append(
@@ -2423,6 +2428,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
                     end_timestamp=now,
                     status=AutoLamellaTaskStatus.Completed,
                     status_message="Coincidence milling (recorded from viewer)",
+                    outputs={"final_fib": [os.path.relpath(written, lamella.path)]},
                 )
             )
             self.experiment.save()

--- a/fibsem/ui/widgets/lamella_task_image_widget.py
+++ b/fibsem/ui/widgets/lamella_task_image_widget.py
@@ -25,13 +25,35 @@ from PyQt5.QtWidgets import (
 )
 from skimage.transform import resize
 
-from fibsem.applications.autolamella.structures import Lamella
+from fibsem.applications.autolamella.structures import AutoLamellaTaskState, Lamella
 from fibsem.imaging.drawing import draw_image_overlays
 from fibsem.structures import FibsemImage
 
 _TARGET_WIDTH = 1024//2
 _PLACEHOLDER_HEIGHT = 768//2  # estimated height for placeholder labels
 _MAX_IMAGES_PER_TASK = 2  # last 2 files = highest-res SEM + FIB
+
+
+def final_reference_images(lamella: Lamella, task: AutoLamellaTaskState) -> List[str]:
+    """Absolute paths to the final reference images a task run produced.
+
+    Prefers what the run recorded. Falls back to the filename convention, which
+    remains the only route for experiments written before outputs existed, and for
+    runs that failed before reaching post_task and so have no history entry at all.
+
+    Sorted so both routes yield the same order: alphabetical puts the highest-res
+    pair last, which is what callers slice off.
+    """
+    recorded = [
+        os.path.join(lamella.path, relpath)
+        for role in ("final_sem", "final_fib")
+        for relpath in task.outputs.get(role, [])
+    ]
+    if recorded:
+        return sorted(recorded)
+    return sorted(
+        glob.glob(os.path.join(lamella.path, f"ref_{task.name}*_final_*res*.tif*"))
+    )
 
 
 def _arr_to_pixmap(arr: np.ndarray, w: int, h: int) -> QPixmap:
@@ -301,7 +323,7 @@ class LamellaTaskImageWidget(QWidget):
         # Task rows — deduplicate, keep last occurrence of each task name
         seen = {}
         for t in lamella.task_history:
-            seen[t.name] = t.name
+            seen[t.name] = t
         completed_tasks = list(seen.values())
         if not completed_tasks:
             no_images = QLabel("No task images available.")
@@ -312,14 +334,12 @@ class LamellaTaskImageWidget(QWidget):
 
         # Collect all filepaths to load and build placeholder rows
         all_filepaths: List[str] = []
-        for task_name in completed_tasks:
-            filenames = sorted(
-                glob.glob(os.path.join(lamella.path, f"ref_{task_name}*_final_*res*.tif*"))
-            )
+        for task in completed_tasks:
+            filenames = final_reference_images(lamella, task)
             if not filenames:
                 continue
             filenames = filenames[-_MAX_IMAGES_PER_TASK:]
-            row = self._build_task_row_with_placeholders(task_name, filenames)
+            row = self._build_task_row_with_placeholders(task.name, filenames)
             self._content_layout.addWidget(row)
             all_filepaths.extend(filenames)
 

--- a/fibsem/ui/widgets/lamella_task_image_widget.py
+++ b/fibsem/ui/widgets/lamella_task_image_widget.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import glob
 import logging
 import os
 import threading
@@ -25,35 +24,14 @@ from PyQt5.QtWidgets import (
 )
 from skimage.transform import resize
 
-from fibsem.applications.autolamella.structures import AutoLamellaTaskState, Lamella
+from fibsem.applications.autolamella.structures import Lamella
+from fibsem.applications.autolamella.task_outputs import final_reference_images
 from fibsem.imaging.drawing import draw_image_overlays
 from fibsem.structures import FibsemImage
 
 _TARGET_WIDTH = 1024//2
 _PLACEHOLDER_HEIGHT = 768//2  # estimated height for placeholder labels
 _MAX_IMAGES_PER_TASK = 2  # last 2 files = highest-res SEM + FIB
-
-
-def final_reference_images(lamella: Lamella, task: AutoLamellaTaskState) -> List[str]:
-    """Absolute paths to the final reference images a task run produced.
-
-    Prefers what the run recorded. Falls back to the filename convention, which
-    remains the only route for experiments written before outputs existed, and for
-    runs that failed before reaching post_task and so have no history entry at all.
-
-    Sorted so both routes yield the same order: alphabetical puts the highest-res
-    pair last, which is what callers slice off.
-    """
-    recorded = [
-        os.path.join(lamella.path, relpath)
-        for role in ("final_sem", "final_fib")
-        for relpath in task.outputs.get(role, [])
-    ]
-    if recorded:
-        return sorted(recorded)
-    return sorted(
-        glob.glob(os.path.join(lamella.path, f"ref_{task.name}*_final_*res*.tif*"))
-    )
 
 
 def _arr_to_pixmap(arr: np.ndarray, w: int, h: int) -> QPixmap:

--- a/fibsem/ui/widgets/tests/test_lamella_task_image_widget.py
+++ b/fibsem/ui/widgets/tests/test_lamella_task_image_widget.py
@@ -1,42 +1,115 @@
-"""Standalone test for LamellaTaskImageWidget."""
+"""Standalone viewer for LamellaTaskImageWidget.
 
+Opens the review panel for one lamella of a real experiment, without launching the
+whole application. Defaults to the most recent experiment on this machine that has
+any completed tasks.
+
+    python fibsem/ui/widgets/tests/test_lamella_task_image_widget.py
+    python fibsem/ui/widgets/tests/test_lamella_task_image_widget.py <experiment.yaml>
+    python fibsem/ui/widgets/tests/test_lamella_task_image_widget.py --lamella 02-awake-stork
+
+Also reports, per task, whether its images were found through the paths the run
+recorded or through the filename convention -- the two routes the panel supports.
+"""
+
+import argparse
+import glob
+import os
 import sys
+from typing import List, Optional
+
 from PyQt5.QtWidgets import QApplication, QVBoxLayout, QWidget
 
-from fibsem.applications.autolamella.structures import Experiment
-from fibsem.ui.widgets.lamella_task_image_widget import LamellaTaskImageWidget
+from fibsem.applications.autolamella.structures import Experiment, Lamella
+from fibsem.ui.stylesheets import NAPARI_STYLE
+from fibsem.ui.widgets.lamella_task_image_widget import (
+    LamellaTaskImageWidget,
+    final_reference_images,
+)
+
+LOG_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
+    "applications", "autolamella", "log",
+)
 
 
-def main():
+def _experiments_with_history() -> List[str]:
+    """Experiment files under the default log directory, newest first."""
+    paths = glob.glob(os.path.join(LOG_DIR, "*", "experiment.yaml"))
+    return sorted(paths, key=os.path.getmtime, reverse=True)
+
+
+def _resolve(path: Optional[str]) -> str:
+    """Resolve a directory or file argument to an experiment.yaml, or find one."""
+    if path is not None:
+        if os.path.isdir(path):
+            return os.path.join(path, "experiment.yaml")
+        return path
+
+    for candidate in _experiments_with_history():
+        experiment = Experiment.load(candidate)
+        if any(p.task_history for p in experiment.positions):
+            return candidate
+    raise SystemExit(
+        f"No experiment with completed tasks found under {LOG_DIR}.\n"
+        "Pass one explicitly: ... test_lamella_task_image_widget.py <experiment.yaml>"
+    )
+
+
+def _pick_lamella(experiment: Experiment, name: Optional[str]) -> Lamella:
+    if name is not None:
+        for position in experiment.positions:
+            if position.name == name:
+                return position
+        raise SystemExit(
+            f"No lamella named {name!r}. Available: "
+            f"{[p.name for p in experiment.positions]}"
+        )
+
+    for position in experiment.positions:
+        if position.task_history:
+            return position
+    raise SystemExit("No lamella with completed tasks in this experiment.")
+
+
+def _report(lamella: Lamella) -> None:
+    """Print what the panel will show, and which route found it."""
+    print(f"\n{lamella.name}  ({lamella.path})")
+    seen = {t.name: t for t in lamella.task_history}
+    for task in seen.values():
+        recorded = any(task.outputs.get(role) for role in ("final_sem", "final_fib"))
+        found = final_reference_images(lamella, task)
+        route = "recorded" if recorded else "convention"
+        print(f"  {task.name:<28} {route:<11} {len(found)} image(s)")
+        for path in found:
+            print(f"      {os.path.basename(path)}")
+    if not seen:
+        print("  no completed tasks")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("experiment", nargs="?", help="experiment.yaml, or its directory")
+    parser.add_argument("--lamella", help="lamella name (default: first with task history)")
+    args = parser.parse_args()
+
+    path = _resolve(args.experiment)
+    print(f"experiment: {path}")
+    experiment = Experiment.load(path)
+    lamella = _pick_lamella(experiment, args.lamella)
+    _report(lamella)
+
     app = QApplication(sys.argv)
-
-    PATH = "/home/patrick/github/fibsem/fibsem/applications/autolamella/log/AutoLamella-2026-03-11-12-33/experiment.yaml"
-
-    exp = Experiment.load(PATH)
-
-    # Find first lamella with task history
-    lamella = None
-    for p in exp.positions:
-        if len(p.task_history) > 0:
-            lamella = p
-            break
-
-    if lamella is None:
-        print("No lamella with completed tasks found.")
-        return
-
-    print(f"Showing images for: {lamella.name}")
-    print(f"  Completed tasks: {[t.name for t in lamella.task_history]}")
+    app.setStyle("Fusion")
+    app.setStyleSheet(NAPARI_STYLE)
 
     window = QWidget()
     window.setWindowTitle(f"Task Images - {lamella.name}")
     window.setMinimumSize(600, 800)
-    window.setStyleSheet("background: #2b2d31;")
 
     layout = QVBoxLayout(window)
     widget = LamellaTaskImageWidget()
     layout.addWidget(widget)
-
     widget.set_lamella(lamella)
 
     window.show()

--- a/tests/autolamella/test_structures.py
+++ b/tests/autolamella/test_structures.py
@@ -331,3 +331,63 @@ def test_task_protocol_carries_correlation_config():
     legacy = protocol.to_dict()
     del legacy["correlation"]
     assert AutoLamellaTaskProtocol.from_dict(legacy).correlation == CorrelationConfig()
+
+
+# ── AutoLamellaTaskState.outputs ──────────────────────────────────────────────
+
+
+def test_task_state_outputs_defaults_to_empty():
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskState
+
+    assert AutoLamellaTaskState().outputs == {}
+
+
+def test_task_state_outputs_survive_an_experiment_round_trip(tmp_path):
+    """The experiment is written with yaml.safe_dump, which refuses anything but
+    plain types. Recording paths as strings is what keeps the save working."""
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskState
+
+    exp = _make_experiment(tmp_path)
+    exp.add_new_lamella(MicroscopeState(), EventedDict())
+    exp.positions[0].task_history.append(
+        AutoLamellaTaskState(
+            name="MillRough",
+            outputs={
+                "final_sem": ["ref_MillRough_final_res_01_eb.tif"],
+                "final_fib": ["ref_MillRough_final_res_01_ib.tif"],
+            },
+        )
+    )
+
+    exp.save()
+    loaded = Experiment.load(os.path.join(exp.path, "experiment.yaml"))
+
+    assert loaded.positions[0].task_history[0].outputs == {
+        "final_sem": ["ref_MillRough_final_res_01_eb.tif"],
+        "final_fib": ["ref_MillRough_final_res_01_ib.tif"],
+    }
+
+
+def test_task_state_from_dict_without_outputs_defaults(tmp_path):
+    """Experiments written before outputs existed must still load."""
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskState
+
+    legacy = {"name": "MillRough", "status": "Completed"}
+
+    assert AutoLamellaTaskState.from_dict(legacy).outputs == {}
+
+
+def test_task_state_from_dict_ignores_unknown_keys():
+    """An experiment written by a newer build must load in an older one.
+
+    from_dict expands the dict into the constructor, so an unrecognised key would
+    otherwise raise TypeError and make the whole experiment unloadable.
+    """
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskState
+
+    future = {"name": "MillRough", "status": "Completed", "metrics": {"focus": 1.0}}
+
+    state = AutoLamellaTaskState.from_dict(future)
+
+    assert state.name == "MillRough"
+    assert not hasattr(state, "metrics")

--- a/tests/autolamella/test_task_outputs.py
+++ b/tests/autolamella/test_task_outputs.py
@@ -120,3 +120,52 @@ def test_only_final_outputs_are_offered(tmp_path):
     )
 
     assert final_reference_images(lamella, task) == []
+
+
+def test_a_set_acquired_twice_in_one_run_does_not_crowd_out_the_other_beam(tmp_path):
+    """MillCoincidentTask acquires the final set twice in one run, before and after
+    milling. Both calls use the default filename, so the second overwrites the same
+    files -- but both record. Left duplicated, the last-two slice callers take would
+    return the same FIB image twice and no SEM image at all.
+    """
+    lamella = _lamella(tmp_path)
+    _write(lamella, CONVENTIONAL)
+    sem = [n for n in CONVENTIONAL if n.endswith("_eb.tif")]
+    fib = [n for n in CONVENTIONAL if n.endswith("_ib.tif")]
+
+    task = AutoLamellaTaskState(
+        name="MillRough", outputs={"final_sem": sem * 2, "final_fib": fib * 2}
+    )
+    found = final_reference_images(lamella, task)
+
+    assert [os.path.basename(p) for p in found] == CONVENTIONAL
+    assert [os.path.basename(p) for p in found[-2:]] == [
+        "ref_MillRough_final_res_02_eb.tif",
+        "ref_MillRough_final_res_02_ib.tif",
+    ]
+
+
+def test_a_record_whose_images_are_gone_falls_through_to_the_convention(tmp_path):
+    """Unlike the glob, a record can name files that no longer exist. Returning them
+    would build a task row of placeholders that never fill, where the old behaviour
+    skipped the row entirely.
+    """
+    lamella = _lamella(tmp_path)
+    _write(lamella, CONVENTIONAL)
+    task = AutoLamellaTaskState(
+        name="MillRough", outputs={"final_sem": ["deleted_eb.tif"]}
+    )
+
+    found = final_reference_images(lamella, task)
+
+    assert [os.path.basename(p) for p in found] == CONVENTIONAL
+
+
+def test_a_record_of_only_deleted_images_with_nothing_on_disk_finds_nothing(tmp_path):
+    """...and with no convention-named files either, the row is skipped as before."""
+    lamella = _lamella(tmp_path)
+    task = AutoLamellaTaskState(
+        name="MillRough", outputs={"final_sem": ["deleted_eb.tif"]}
+    )
+
+    assert final_reference_images(lamella, task) == []

--- a/tests/autolamella/test_task_outputs.py
+++ b/tests/autolamella/test_task_outputs.py
@@ -1,0 +1,122 @@
+"""Discovery of the final reference images a task run produced.
+
+Recorded outputs are preferred; the filename convention stays as the fallback for
+experiments written before outputs existed, and for runs that failed before
+reaching post_task and so left no history entry at all.
+"""
+
+import os
+from pathlib import Path
+from typing import List
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskState, Lamella
+from fibsem.applications.autolamella.task_outputs import final_reference_images
+
+CONVENTIONAL = [
+    "ref_MillRough_final_res_01_eb.tif",
+    "ref_MillRough_final_res_01_ib.tif",
+    "ref_MillRough_final_res_02_eb.tif",
+    "ref_MillRough_final_res_02_ib.tif",
+]
+
+
+def _lamella(tmp_path: Path) -> Lamella:
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+    os.makedirs(lamella.path, exist_ok=True)
+    return lamella
+
+
+def _write(lamella: Lamella, names: List[str]) -> None:
+    for name in names:
+        Path(lamella.path, name).write_bytes(b"")
+
+
+def test_falls_back_to_the_filename_convention_when_nothing_recorded(tmp_path):
+    """Old experiments have no outputs; the glob is still the route to their images."""
+    lamella = _lamella(tmp_path)
+    _write(lamella, CONVENTIONAL)
+    task = AutoLamellaTaskState(name="MillRough")
+
+    found = final_reference_images(lamella, task)
+
+    assert [os.path.basename(p) for p in found] == CONVENTIONAL
+
+
+def test_prefers_recorded_outputs_over_the_glob(tmp_path):
+    """What the run recorded wins, even when convention-named files also exist.
+
+    The recorded names deliberately do not match the glob, so a result containing
+    them can only have come from the record.
+    """
+    lamella = _lamella(tmp_path)
+    _write(lamella, CONVENTIONAL + ["custom_eb.tif", "custom_ib.tif"])
+    task = AutoLamellaTaskState(
+        name="MillRough",
+        outputs={"final_sem": ["custom_eb.tif"], "final_fib": ["custom_ib.tif"]},
+    )
+
+    found = final_reference_images(lamella, task)
+
+    assert [os.path.basename(p) for p in found] == ["custom_eb.tif", "custom_ib.tif"]
+
+
+def test_both_routes_agree_on_order(tmp_path):
+    """Recorded and globbed discovery must order identically.
+
+    Callers slice the last N off the result to get the highest-resolution pair, so a
+    difference in ordering would silently change which images the review panel shows.
+    Records arrive grouped by beam; the glob arrives interleaved.
+    """
+    lamella = _lamella(tmp_path)
+    _write(lamella, CONVENTIONAL)
+
+    globbed = final_reference_images(lamella, AutoLamellaTaskState(name="MillRough"))
+    recorded = final_reference_images(
+        lamella,
+        AutoLamellaTaskState(
+            name="MillRough",
+            outputs={
+                "final_sem": [n for n in CONVENTIONAL if n.endswith("_eb.tif")],
+                "final_fib": [n for n in CONVENTIONAL if n.endswith("_ib.tif")],
+            },
+        ),
+    )
+
+    assert recorded == globbed
+
+
+def test_recorded_relative_paths_resolve_under_the_lamella_directory(tmp_path):
+    """Records are stored relative; discovery returns absolute paths."""
+    lamella = _lamella(tmp_path)
+    _write(lamella, ["ref_MillRough_final_res_01_eb.tif"])
+    task = AutoLamellaTaskState(
+        name="MillRough", outputs={"final_sem": ["ref_MillRough_final_res_01_eb.tif"]}
+    )
+
+    found = final_reference_images(lamella, task)
+
+    assert found == [str(Path(lamella.path, "ref_MillRough_final_res_01_eb.tif"))]
+    assert os.path.isfile(found[0])
+
+
+def test_a_run_that_produced_nothing_finds_nothing(tmp_path):
+    """No record and no files on disk is an empty result, not an error."""
+    lamella = _lamella(tmp_path)
+
+    assert final_reference_images(lamella, AutoLamellaTaskState(name="MillRough")) == []
+
+
+def test_only_final_outputs_are_offered(tmp_path):
+    """start_* and one-off acquisitions are recorded but deliberately not shown.
+
+    The review panel has always shown only the final reference set; recording more
+    roles must not change what it displays.
+    """
+    lamella = _lamella(tmp_path)
+    _write(lamella, ["start_eb.tif", "other_eb.tif"])
+    task = AutoLamellaTaskState(
+        name="MillRough",
+        outputs={"start_sem": ["start_eb.tif"], "other_sem": ["other_eb.tif"]},
+    )
+
+    assert final_reference_images(lamella, task) == []

--- a/tests/autolamella/test_tasks.py
+++ b/tests/autolamella/test_tasks.py
@@ -171,3 +171,19 @@ def test_a_custom_filename_is_not_recorded_as_a_final_reference_set(
     )
 
     assert set(task.lamella.task_state.outputs) == {"other_sem", "other_fib"}
+
+
+def test_record_output_does_not_record_the_same_file_twice(
+    compustage_microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """Acquiring the same set twice in one run overwrites the same files; the record
+    describes files, not writes."""
+    task = _make_trench_task(compustage_microscope, tmp_path)
+    written = Path(task.lamella.path) / "ref_MillTrench_final_res_01_eb.tif"
+
+    task._record_output("final_sem", _image_written_to(written))
+    task._record_output("final_sem", _image_written_to(written))
+
+    assert task.lamella.task_state.outputs == {
+        "final_sem": ["ref_MillTrench_final_res_01_eb.tif"]
+    }

--- a/tests/autolamella/test_tasks.py
+++ b/tests/autolamella/test_tasks.py
@@ -11,7 +11,7 @@ from fibsem.applications.autolamella.workflows.tasks.trench import (
     MillTrenchTaskConfig,
 )
 from fibsem.microscope import FibsemMicroscope
-from fibsem.structures import FibsemStagePosition
+from fibsem.structures import FibsemImage, FibsemStagePosition
 
 
 def _make_trench_task(microscope: FibsemMicroscope, tmp_path: Path) -> MillTrenchTask:
@@ -58,3 +58,116 @@ def test_mill_trench_task_config_orientation_accepts_none_and_strings(
     """MillTrenchTaskConfig accepts all valid orientation values including None."""
     config = MillTrenchTaskConfig(orientation=orientation)
     assert config.orientation == orientation
+
+
+# ── output recording ──────────────────────────────────────────────────────────
+
+
+def _image_written_to(path: Path) -> FibsemImage:
+    """A FibsemImage that reports having been written to `path`."""
+    image = FibsemImage(data=np.zeros((4, 4), dtype=np.uint8))
+    image.filepath = str(path)
+    return image
+
+
+def test_record_output_stores_paths_relative_to_the_lamella(
+    compustage_microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """Absolute paths would break the moment an experiment is copied off the
+    microscope, which they routinely are."""
+    task = _make_trench_task(compustage_microscope, tmp_path)
+    written = Path(task.lamella.path) / "ref_MillTrench_final_res_01_eb.tif"
+
+    task._record_output("final_sem", _image_written_to(written))
+
+    assert task.lamella.task_state.outputs == {
+        "final_sem": ["ref_MillTrench_final_res_01_eb.tif"]
+    }
+
+
+def test_record_output_skips_an_image_that_was_never_written(
+    compustage_microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """save() sets filepath only after a successful write, so an image with none
+    was not written. The FM task relies on this: its acquire swallows save errors."""
+    task = _make_trench_task(compustage_microscope, tmp_path)
+
+    task._record_output("fluorescence", FibsemImage(data=np.zeros((4, 4), dtype=np.uint8)))
+    task._record_output("fluorescence", None)
+
+    assert task.lamella.task_state.outputs == {}
+
+
+def test_pre_task_clears_the_previous_runs_outputs_and_end_timestamp(
+    compustage_microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """task_state is one object reused across runs. Without an explicit reset the
+    next run's history entry accumulates the previous run's paths, and reports the
+    previous run's completion time while it is still in progress."""
+    task = _make_trench_task(compustage_microscope, tmp_path)
+
+    # stand in for a completed previous run
+    task.lamella.task_state.outputs = {"final_sem": ["ref_Previous_final_res_01_eb.tif"]}
+    task.lamella.task_state.end_timestamp = 1234.0
+
+    task.pre_task()
+
+    assert task.lamella.task_state.outputs == {}
+    assert task.lamella.task_state.end_timestamp is None
+
+
+def test_pre_task_keeps_the_same_task_state_object(
+    compustage_microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """The lamella list and card widgets connect psygnal handlers to this instance
+    and use them as their only refresh trigger. Replacing the object orphans those
+    connections and they silently stop updating mid-workflow."""
+    task = _make_trench_task(compustage_microscope, tmp_path)
+    before = task.lamella.task_state
+
+    task.pre_task()
+
+    assert task.lamella.task_state is before
+
+
+def test_default_filename_is_recorded_as_the_final_reference_set(
+    monkeypatch, compustage_microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    from fibsem import acquire
+    from fibsem.structures import ImageSettings
+
+    task = _make_trench_task(compustage_microscope, tmp_path)
+    lam = Path(task.lamella.path)
+    pair = (
+        _image_written_to(lam / "ref_MillTrench_final_res_01_eb.tif"),
+        _image_written_to(lam / "ref_MillTrench_final_res_01_ib.tif"),
+    )
+    monkeypatch.setattr(acquire, "acquire_set_of_channels", lambda *a, **k: [pair])
+
+    task._acquire_set_of_channels(ImageSettings(), field_of_views=(100e-6,))
+
+    assert set(task.lamella.task_state.outputs) == {"final_sem", "final_fib"}
+
+
+def test_a_custom_filename_is_not_recorded_as_a_final_reference_set(
+    monkeypatch, compustage_microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """Undercut alignment and one-off reference acquisitions pass their own name and
+    do not match the review panel's convention today. Recording them as `final` would
+    start showing them there."""
+    from fibsem import acquire
+    from fibsem.structures import ImageSettings
+
+    task = _make_trench_task(compustage_microscope, tmp_path)
+    lam = Path(task.lamella.path)
+    pair = (
+        _image_written_to(lam / "ref_MillTrench_undercut_res_01_eb.tif"),
+        _image_written_to(lam / "ref_MillTrench_undercut_res_01_ib.tif"),
+    )
+    monkeypatch.setattr(acquire, "acquire_set_of_channels", lambda *a, **k: [pair])
+
+    task._acquire_set_of_channels(
+        ImageSettings(), field_of_views=(100e-6,), filename="ref_MillTrench_undercut"
+    )
+
+    assert set(task.lamella.task_state.outputs) == {"other_sem", "other_fib"}

--- a/tests/ui/test_task_output_discovery.py
+++ b/tests/ui/test_task_output_discovery.py
@@ -120,3 +120,38 @@ def test_only_final_outputs_are_offered(tmp_path):
     )
 
     assert final_reference_images(lamella, task) == []
+
+
+def test_the_coincidence_viewer_records_what_the_panel_will_find(tmp_path, monkeypatch):
+    """The coincidence viewer writes its FIB image itself rather than going through a
+    task, so it has to record the output on the history entry it appends. What it
+    records and what the panel discovers must line up.
+    """
+    import numpy as np
+    from types import SimpleNamespace
+
+    from fibsem.structures import FibsemImage
+    from fibsem.ui.widgets import fluorescence_coincidence_viewer_widget as viewer
+
+    monkeypatch.setattr(viewer.notification_service, "show_toast", lambda *a, **k: None)
+
+    lamella = _lamella(tmp_path)
+    widget = viewer.FluorescenceCoincidenceViewerWidget.__new__(
+        viewer.FluorescenceCoincidenceViewerWidget
+    )
+    widget._selected_lamella = lamella
+    widget.experiment = SimpleNamespace(save=lambda: None)
+    widget._latest_fib_image = FibsemImage(data=np.zeros((8, 8), dtype=np.uint8))
+
+    widget._record_coincidence_result()
+
+    assert lamella.task_history, "no history entry was appended"
+    task = lamella.task_history[-1]
+    assert task.name == viewer.COINCIDENCE_REVIEW_TASK_NAME
+
+    recorded = task.outputs["final_fib"]
+    assert recorded == [os.path.basename(recorded[0])], "path must be relative"
+
+    found = final_reference_images(lamella, task)
+    assert found == [str(Path(lamella.path, recorded[0]))]
+    assert os.path.isfile(found[0])

--- a/tests/ui/test_task_output_discovery.py
+++ b/tests/ui/test_task_output_discovery.py
@@ -1,0 +1,122 @@
+"""Discovery of the final reference images a task run produced.
+
+Recorded outputs are preferred; the filename convention stays as the fallback for
+experiments written before outputs existed, and for runs that failed before
+reaching post_task and so left no history entry at all.
+"""
+
+import os
+from pathlib import Path
+from typing import List
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskState, Lamella
+from fibsem.ui.widgets.lamella_task_image_widget import final_reference_images
+
+CONVENTIONAL = [
+    "ref_MillRough_final_res_01_eb.tif",
+    "ref_MillRough_final_res_01_ib.tif",
+    "ref_MillRough_final_res_02_eb.tif",
+    "ref_MillRough_final_res_02_ib.tif",
+]
+
+
+def _lamella(tmp_path: Path) -> Lamella:
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+    os.makedirs(lamella.path, exist_ok=True)
+    return lamella
+
+
+def _write(lamella: Lamella, names: List[str]) -> None:
+    for name in names:
+        Path(lamella.path, name).write_bytes(b"")
+
+
+def test_falls_back_to_the_filename_convention_when_nothing_recorded(tmp_path):
+    """Old experiments have no outputs; the glob is still the route to their images."""
+    lamella = _lamella(tmp_path)
+    _write(lamella, CONVENTIONAL)
+    task = AutoLamellaTaskState(name="MillRough")
+
+    found = final_reference_images(lamella, task)
+
+    assert [os.path.basename(p) for p in found] == CONVENTIONAL
+
+
+def test_prefers_recorded_outputs_over_the_glob(tmp_path):
+    """What the run recorded wins, even when convention-named files also exist.
+
+    The recorded names deliberately do not match the glob, so a result containing
+    them can only have come from the record.
+    """
+    lamella = _lamella(tmp_path)
+    _write(lamella, CONVENTIONAL + ["custom_eb.tif", "custom_ib.tif"])
+    task = AutoLamellaTaskState(
+        name="MillRough",
+        outputs={"final_sem": ["custom_eb.tif"], "final_fib": ["custom_ib.tif"]},
+    )
+
+    found = final_reference_images(lamella, task)
+
+    assert [os.path.basename(p) for p in found] == ["custom_eb.tif", "custom_ib.tif"]
+
+
+def test_both_routes_agree_on_order(tmp_path):
+    """Recorded and globbed discovery must order identically.
+
+    Callers slice the last N off the result to get the highest-resolution pair, so a
+    difference in ordering would silently change which images the review panel shows.
+    Records arrive grouped by beam; the glob arrives interleaved.
+    """
+    lamella = _lamella(tmp_path)
+    _write(lamella, CONVENTIONAL)
+
+    globbed = final_reference_images(lamella, AutoLamellaTaskState(name="MillRough"))
+    recorded = final_reference_images(
+        lamella,
+        AutoLamellaTaskState(
+            name="MillRough",
+            outputs={
+                "final_sem": [n for n in CONVENTIONAL if n.endswith("_eb.tif")],
+                "final_fib": [n for n in CONVENTIONAL if n.endswith("_ib.tif")],
+            },
+        ),
+    )
+
+    assert recorded == globbed
+
+
+def test_recorded_relative_paths_resolve_under_the_lamella_directory(tmp_path):
+    """Records are stored relative; discovery returns absolute paths."""
+    lamella = _lamella(tmp_path)
+    _write(lamella, ["ref_MillRough_final_res_01_eb.tif"])
+    task = AutoLamellaTaskState(
+        name="MillRough", outputs={"final_sem": ["ref_MillRough_final_res_01_eb.tif"]}
+    )
+
+    found = final_reference_images(lamella, task)
+
+    assert found == [str(Path(lamella.path, "ref_MillRough_final_res_01_eb.tif"))]
+    assert os.path.isfile(found[0])
+
+
+def test_a_run_that_produced_nothing_finds_nothing(tmp_path):
+    """No record and no files on disk is an empty result, not an error."""
+    lamella = _lamella(tmp_path)
+
+    assert final_reference_images(lamella, AutoLamellaTaskState(name="MillRough")) == []
+
+
+def test_only_final_outputs_are_offered(tmp_path):
+    """start_* and one-off acquisitions are recorded but deliberately not shown.
+
+    The review panel has always shown only the final reference set; recording more
+    roles must not change what it displays.
+    """
+    lamella = _lamella(tmp_path)
+    _write(lamella, ["start_eb.tif", "other_eb.tif"])
+    task = AutoLamellaTaskState(
+        name="MillRough",
+        outputs={"start_sem": ["start_eb.tif"], "other_sem": ["other_eb.tif"]},
+    )
+
+    assert final_reference_images(lamella, task) == []

--- a/tests/ui/test_task_output_discovery.py
+++ b/tests/ui/test_task_output_discovery.py
@@ -1,125 +1,29 @@
-"""Discovery of the final reference images a task run produced.
+"""The coincidence viewer records its own task output.
 
-Recorded outputs are preferred; the filename convention stays as the fallback for
-experiments written before outputs existed, and for runs that failed before
-reaching post_task and so left no history entry at all.
+It writes its FIB image directly rather than going through a task, so it appends a
+history entry by hand and has to record the output itself. Lives here rather than
+with the other discovery tests because importing the viewer pulls in the UI stack.
 """
 
 import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 from pathlib import Path
-from typing import List
 
-from fibsem.applications.autolamella.structures import AutoLamellaTaskState, Lamella
-from fibsem.ui.widgets.lamella_task_image_widget import final_reference_images
+import pytest
 
-CONVENTIONAL = [
-    "ref_MillRough_final_res_01_eb.tif",
-    "ref_MillRough_final_res_01_ib.tif",
-    "ref_MillRough_final_res_02_eb.tif",
-    "ref_MillRough_final_res_02_ib.tif",
-]
+pytest.importorskip("PyQt5")
+pytest.importorskip("napari")
+
+from fibsem.applications.autolamella.structures import Lamella
+from fibsem.applications.autolamella.task_outputs import final_reference_images
 
 
 def _lamella(tmp_path: Path) -> Lamella:
     lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
     os.makedirs(lamella.path, exist_ok=True)
     return lamella
-
-
-def _write(lamella: Lamella, names: List[str]) -> None:
-    for name in names:
-        Path(lamella.path, name).write_bytes(b"")
-
-
-def test_falls_back_to_the_filename_convention_when_nothing_recorded(tmp_path):
-    """Old experiments have no outputs; the glob is still the route to their images."""
-    lamella = _lamella(tmp_path)
-    _write(lamella, CONVENTIONAL)
-    task = AutoLamellaTaskState(name="MillRough")
-
-    found = final_reference_images(lamella, task)
-
-    assert [os.path.basename(p) for p in found] == CONVENTIONAL
-
-
-def test_prefers_recorded_outputs_over_the_glob(tmp_path):
-    """What the run recorded wins, even when convention-named files also exist.
-
-    The recorded names deliberately do not match the glob, so a result containing
-    them can only have come from the record.
-    """
-    lamella = _lamella(tmp_path)
-    _write(lamella, CONVENTIONAL + ["custom_eb.tif", "custom_ib.tif"])
-    task = AutoLamellaTaskState(
-        name="MillRough",
-        outputs={"final_sem": ["custom_eb.tif"], "final_fib": ["custom_ib.tif"]},
-    )
-
-    found = final_reference_images(lamella, task)
-
-    assert [os.path.basename(p) for p in found] == ["custom_eb.tif", "custom_ib.tif"]
-
-
-def test_both_routes_agree_on_order(tmp_path):
-    """Recorded and globbed discovery must order identically.
-
-    Callers slice the last N off the result to get the highest-resolution pair, so a
-    difference in ordering would silently change which images the review panel shows.
-    Records arrive grouped by beam; the glob arrives interleaved.
-    """
-    lamella = _lamella(tmp_path)
-    _write(lamella, CONVENTIONAL)
-
-    globbed = final_reference_images(lamella, AutoLamellaTaskState(name="MillRough"))
-    recorded = final_reference_images(
-        lamella,
-        AutoLamellaTaskState(
-            name="MillRough",
-            outputs={
-                "final_sem": [n for n in CONVENTIONAL if n.endswith("_eb.tif")],
-                "final_fib": [n for n in CONVENTIONAL if n.endswith("_ib.tif")],
-            },
-        ),
-    )
-
-    assert recorded == globbed
-
-
-def test_recorded_relative_paths_resolve_under_the_lamella_directory(tmp_path):
-    """Records are stored relative; discovery returns absolute paths."""
-    lamella = _lamella(tmp_path)
-    _write(lamella, ["ref_MillRough_final_res_01_eb.tif"])
-    task = AutoLamellaTaskState(
-        name="MillRough", outputs={"final_sem": ["ref_MillRough_final_res_01_eb.tif"]}
-    )
-
-    found = final_reference_images(lamella, task)
-
-    assert found == [str(Path(lamella.path, "ref_MillRough_final_res_01_eb.tif"))]
-    assert os.path.isfile(found[0])
-
-
-def test_a_run_that_produced_nothing_finds_nothing(tmp_path):
-    """No record and no files on disk is an empty result, not an error."""
-    lamella = _lamella(tmp_path)
-
-    assert final_reference_images(lamella, AutoLamellaTaskState(name="MillRough")) == []
-
-
-def test_only_final_outputs_are_offered(tmp_path):
-    """start_* and one-off acquisitions are recorded but deliberately not shown.
-
-    The review panel has always shown only the final reference set; recording more
-    roles must not change what it displays.
-    """
-    lamella = _lamella(tmp_path)
-    _write(lamella, ["start_eb.tif", "other_eb.tif"])
-    task = AutoLamellaTaskState(
-        name="MillRough",
-        outputs={"start_sem": ["start_eb.tif"], "other_sem": ["other_eb.tif"]},
-    )
-
-    assert final_reference_images(lamella, task) == []
 
 
 def test_the_coincidence_viewer_records_what_the_panel_will_find(tmp_path, monkeypatch):


### PR DESCRIPTION
`AutoLamellaTaskState` gains **`outputs`** — a dict of role → paths relative to the lamella directory, recorded by the task that wrote them.

Closes FIB-324. Builds on FIB-326 (#192), which made images carry their own `filepath`. Unblocks FIB-169 (fluorescence images in the review panel).

## Why

Nothing recorded what a task produced, so every consumer rediscovered files by globbing the naming convention. That convention is encoded in three separate places, and one has already drifted — `tools/review.py` still expects `high_res`, which the producer stopped emitting.

The fluorescence task can't be found that way at all. It writes `{lamella}-zstack-{HH-MM-SS}.ome.tiff` — no task name, no date — so two fluorescence tasks in one protocol are indistinguishable.

## Roles

Keys mirror the convention the filenames already carry, **phase × modality**:

| Key | Written by |
| --- | --- |
| `final_sem` / `final_fib` | `_acquire_set_of_channels` |
| `start_sem` / `start_fib` | `_acquire_channels` |
| `other_sem` / `other_fib` | either, when the caller passes its own filename |
| `fluorescence` | `AcquireFluorescenceImageTask` |

Both axes are needed. The review panel shows only the final set, so keying by beam alone would start surfacing pre-task images; keying by phase alone would discard which beam took the image, which the panel currently can't tell without parsing filenames.

`other_*` exists because undercut alignment and one-off reference acquisitions pass their own filename and don't match the panel's glob today. Recording them as `final` would have started showing them there. The distinction is made where the default is applied, so nothing has to parse a filename to work it out.

## Paths only, deliberately

The experiment is written with `yaml.safe_dump`, which raises on numpy scalars and enums — and `Experiment.save()` dumps the whole tree in one call, so a single measured value in here would make the **entire experiment unsaveable mid-run**. `AutoFocusResult.focus_score` is an image metric, so this is not hypothetical.

Named `outputs` rather than `results` so a `metrics` field can be added later without overloading one dict and teaching every reader to discriminate.

## The glob stays

Permanent fallback, not transitional. Every existing experiment has no outputs, and a task that fails *after* acquiring never reaches `post_task`, so it gets no history entry at all. `final_reference_images()` prefers the record and falls back — and sorts both routes identically, because records arrive grouped by beam while the glob arrives interleaved, and callers slice the last two off to get the highest-magnification pair.

## pre_task

Now clears `outputs` and resets `end_timestamp`. `task_state` is a single object reused across runs, so without this the next run's history entry accumulates the previous run's paths.

It must be reset **in place, not replaced**. `lamella_list_widget.py:166` and `lamella_card_widget.py:171` connect psygnal handlers to that instance and use them as their only refresh trigger — swapping the object orphans them and the lamella list silently stops updating mid-workflow. There's a comment saying so, a test asserting the object identity survives, and FIB-325 for the real fix.

Also: `from_dict` now drops unrecognised keys, so an experiment written by a newer build loads in an older one instead of raising `TypeError`.

## Testing

12 new tests. Discovery lives in `tests/autolamella/test_task_outputs.py` so it runs in CI — the runner installs without the UI extras, so anything importing `fibsem.ui` is skipped there. That is also why `final_reference_images` sits in `fibsem/applications/autolamella/task_outputs.py` rather than in the widget: it is path policy with no Qt in it, and keeping it out of the UI layer is what makes it testable.

Mutation-verified **10/10**. The four that matter guard behaviour preservation rather than the new feature: unsorted records, every role instead of `final_*`, dropping the glob fallback, and absolute instead of relative paths (which would break the moment an experiment is copied off the microscope).

Full suite: **996 passed, 7 skipped** (pre-existing).

## Reviewing it by hand

The standalone review-panel harness now defaults to the newest local experiment with completed tasks, takes an optional path and `--lamella`, applies the app stylesheet, and prints per task whether its images were found through the **record** or the **convention**:

```
python fibsem/ui/widgets/tests/test_lamella_task_image_widget.py
```

Existing experiments should all report `convention` and look exactly as they did before. Anything run after this lands should report `recorded`.

## Not in this PR

`fluorescence` is recorded but nothing renders it yet — that needs a projection and a colour composite, which is FIB-169.

## Coincidence paths

Two sites in the coincidence flow wrote images without recording them.

**The viewer** (`_record_coincidence_result`) writes its post-milling FIB itself rather than going through a task, then appends a history entry by hand. It made that entry discoverable by *naming the file to match the review panel's glob* — a fourth copy of the convention. It now records the path under `final_fib` instead.

The filename and the overwrite-per-run behaviour stay, but only so experiments opened by a build predating task outputs still resolve through the convention. That's now the sole reason for either, and it's written down: once the fallback isn't needed, the name can become per-run and runs will stop overwriting each other's images.

**`MillCoincidentTask`** acquires a fluorescence z-stack when configured to, and discarded the result. It now records it under `fluorescence`, the same as `AcquireFluorescenceImageTask` — including relying on `filepath` being unset when a swallowed save failure means nothing was written.

One test covers the viewer end to end: what it records is what the panel discovers, relative, resolving to a file that exists. Mutation-verified against recording nothing and against recording an absolute path.

The `MillCoincidentTask` line is a one-liner following the pattern `_record_output` is already tested for; like the equivalent call in `AcquireFluorescenceImageTask`, the call site itself isn't covered.

Full suite: **997 passed, 7 skipped**.



## Found reviewing the branch

Two ways a record could show the wrong images. Both only affect the recorded path, so neither is reachable on `main`.

**Duplicates crowded out the SEM image.** A run can acquire the same reference set more than once — `MillCoincidentTask._run` does exactly that, before and after milling (`:149` and `:265`). Both calls use the default filename, so the second **overwrites the same four files** while both record:

```
glob     -> ['..._final_res_02_eb.tif', '..._final_res_02_ib.tif']   SEM + FIB
recorded -> ['..._final_res_02_ib.tif', '..._final_res_02_ib.tif']   FIB twice, no SEM
```

Callers slice the last two off to get the highest-magnification pair, so the duplicates displaced the SEM image entirely. The glob was immune — it lists a directory, so it can't return a file twice. Every test used a single-acquisition task, which is why nothing caught it.

Fixed at both ends: `_record_output` won't append a path already recorded under a role, and discovery deduplicates what it reads. The record describes files, not writes.

**Rows that never filled.** Unlike a glob, a record can name a file that no longer exists. Those paths were returned anyway; the result was non-empty, so the row wasn't skipped and its placeholders never filled — where previously the row was simply absent. Discovery now requires the file to still exist, falling through to the convention when nothing recorded survives.

Four tests, mutation-verified 4/4 including the over-correction where the existence filter drops live files too.

### Checked and clear

`os.path.relpath` will happily emit `../..`, but every `ref_*` lands in the lamella directory in a real experiment, so records are bare filenames — not reachable today, though nothing enforces it. `_ImageLoaderWorker.run()` catches per file, so a bad path degrades to a warning. `task_history_dataframe` names its fields explicitly, so `outputs` doesn't leak into the generated report.

### Known and accepted

`from_dict` dropping unknown keys trades a hard `TypeError` for silent loss of that field if an older build re-saves the experiment — opening beats crashing, but it is a real cost. `outputs: null` in a hand-edited file would raise on `.get`; our writers can't produce it, so no speculative guard was added. `_rebuild` itself and the `MillCoincidentTask` FM record call site remain uncovered.
