### PR TITLE
Parameterise the stage projection by view tilt (FIB-133)

### DIFF
--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -782,8 +782,68 @@ class FluorescenceMicroscope(ABC):
         )
         logging.info(f"Image transform set to: {transform}")
 
+    @property
+    def camera_tilt(self) -> float:
+        """Tilt of the FM optical axis from the SEM column, in degrees.
+
+        The camera's analogue of a beam column's ``column_tilt``; used to project
+        in-image displacements onto the tilted sample plane.
+
+        Derived from the mount geometry rather than configured:
+
+        - **Under-grid mounts (Arctis / compustage)** look up at the grid from the
+          opposite side to the SEM: a half turn, 180 degrees.
+        - **Offset mounts (METEOR, iFLM)** sit parallel to the FIB column, displaced
+          along x, so they share the ion column's tilt.
+
+        Drivers override if a system disagrees.
+        """
+        if self.parent is None:
+            return 0.0  # simulator without a parent microscope
+        if self.parent.stage_is_compustage:
+            return 180.0
+        return self.parent.system.ion.column_tilt
+
+    @property
+    def mount_transform(self) -> CameraImageTransform:
+        """Fixed correction from raw sensor axes to stage-aligned axes.
+
+        Hardware truth about how the camera is mounted, not a user preference: it
+        is applied before the user's ``CameraImageTransform`` so that every
+        consumer (display, correlation, saved data, movement) sees one consistently
+        oriented image, and so that movement needs only the user transform.
+
+        Defaults to no correction; drivers override per system. The value is
+        determined by observing which stage axis a feature travels along in the
+        FM view (see docs/design/fm-stable-move.md).
+        """
+        return CameraImageTransform.NONE
+
+    @staticmethod
+    def _transform_array(
+        data: np.ndarray, transform: Optional[CameraImageTransform]
+    ) -> np.ndarray:
+        """Apply a single CameraImageTransform to an array."""
+        if transform is CameraImageTransform.FLIP_X:
+            return np.fliplr(data)
+        elif transform is CameraImageTransform.FLIP_Y:
+            return np.flipud(data)
+        elif transform is CameraImageTransform.FLIP_XY:
+            return np.fliplr(np.flipud(data))
+        elif transform is CameraImageTransform.ROTATE_90_CW:
+            return np.rot90(data, k=-1)  # k=-1 for clockwise
+        elif transform is CameraImageTransform.ROTATE_90_CCW:
+            return np.rot90(data, k=1)  # k=1 for counter-clockwise
+        elif transform is CameraImageTransform.ROTATE_180:
+            return np.rot90(data, k=2)  # k=2 for 180 degrees
+        else:
+            return data
+
     def _apply_image_transform(self, data: np.ndarray) -> np.ndarray:
         """Apply the configured image transformation to align with SEM/FIB coordinate system.
+
+        Two stages: the fixed mount correction puts the raw sensor into stage-aligned
+        axes, then the user's transform applies their display preference on top.
 
         Args:
             data: The image data to transform
@@ -791,20 +851,8 @@ class FluorescenceMicroscope(ABC):
         Returns:
             The transformed image data
         """
-        if self._transform is CameraImageTransform.FLIP_X:
-            return np.fliplr(data)
-        elif self._transform is CameraImageTransform.FLIP_Y:
-            return np.flipud(data)
-        elif self._transform is CameraImageTransform.FLIP_XY:
-            return np.fliplr(np.flipud(data))
-        elif self._transform is CameraImageTransform.ROTATE_90_CW:
-            return np.rot90(data, k=-1)  # k=-1 for clockwise
-        elif self._transform is CameraImageTransform.ROTATE_90_CCW:
-            return np.rot90(data, k=1)  # k=1 for counter-clockwise
-        elif self._transform is CameraImageTransform.ROTATE_180:
-            return np.rot90(data, k=2)  # k=2 for 180 degrees
-        else:
-            return data
+        data = self._transform_array(data, self.mount_transform)
+        return self._transform_array(data, self._transform)
 
     def acquire_image(
         self, channel_settings: Optional[ChannelSettings] = None

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1320,6 +1320,171 @@ class FibsemMicroscope(ABC):
 
         return self.is_close_to_milling_angle(milling_angle)
 
+    def _beam_view_tilt(self, beam_type: BeamType) -> float:
+        """Tilt of a beam column's viewing axis from the electron column, in radians."""
+        if beam_type is BeamType.ELECTRON:
+            return 0.0
+        if beam_type is BeamType.ION:
+            return np.deg2rad(self.system.ion.column_tilt)
+        # the previous inline form left the adjustment unbound here; keep failing loudly
+        raise ValueError(f"Unsupported beam type: {beam_type}")
+
+    def _view_corrected_stage_movement(
+        self,
+        expected_y: float,
+        view_tilt: float = 0.0,
+    ) -> FibsemStagePosition:
+        """Project a displacement seen in an image onto the tilted sample plane.
+
+        Every view of the sample shares this projection and differs only in how far
+        its viewing axis is tilted from the electron column: the electron column is
+        0, the ion column is its ``column_tilt``, and the fluorescence camera is its
+        ``camera_tilt``. The sample is additionally tilted by the shuttle pre-tilt,
+        so an in-image y-displacement becomes a movement along the holder, split
+        across the stage y- and z-axes.
+
+        Args:
+            expected_y: distance along the image y-axis, in metres.
+            view_tilt: tilt of the viewing axis from the electron column, in radians.
+
+        Returns:
+            FibsemStagePosition: y-corrected stage movement (relative position)
+        """
+
+        # TODO: replace with camera matrix * inverse kinematics
+
+        # all angles in radians
+        sem_column_tilt = np.deg2rad(self.system.electron.column_tilt)
+
+        stage_pretilt = np.deg2rad(self.system.stage.shuttle_pre_tilt)
+
+        stage_rotation_flat_to_eb = np.deg2rad(
+            self.system.stage.rotation_reference
+        ) % (2 * np.pi)
+        stage_rotation_flat_to_ion = np.deg2rad(
+            self.system.stage.rotation_180
+        ) % (2 * np.pi)
+
+        # current stage position
+        current_stage_position = self.get_stage_position()
+        stage_rotation = current_stage_position.r % (2 * np.pi)
+        stage_tilt = current_stage_position.t
+
+        # the compustage does not have pre-tilt, cannot rotate, but tilts 180 deg.
+        if self.stage_is_compustage:
+
+            # if stage_tilt < 0:
+            expected_y *= -1.0
+
+            stage_tilt += np.pi
+
+        PRETILT_SIGN = 1.0
+        # pretilt angle depends on rotation # TODO: migrate to orientation
+        from fibsem import movement
+        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
+            PRETILT_SIGN = 1.0
+        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
+            PRETILT_SIGN = -1.0
+
+        if self.stage_is_compustage and self.get_stage_orientation() == "FIB":
+            expected_y *= -1.0 # use this until rotation_180 is deprecated correctly...
+            PRETILT_SIGN = -1.0
+
+        corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt) # electron angle = 0, ion = 52
+
+        # perspective tilt adjustment (difference between perspective view and sample coordinate system)
+        perspective_tilt_adjustment = -corrected_pretilt_angle - view_tilt
+
+        # the amount the sample has to move in the y-axis
+        y_sample_move = expected_y  / np.cos(stage_tilt + perspective_tilt_adjustment)
+
+        # the amount the stage has to move in each axis
+        y_move = y_sample_move * np.cos(corrected_pretilt_angle)
+        z_move = -y_sample_move * np.sin(corrected_pretilt_angle) #TODO: investigate this
+
+        return FibsemStagePosition(x=0, y=y_move, z=z_move)
+
+    def _inverse_view_corrected_stage_movement(
+        self,
+        dy: float,
+        dz: float,
+        view_tilt: float = 0.0,
+    ) -> float:
+        """Recover the in-image y-displacement from a y/z stage movement.
+
+        Inverse of :meth:`_view_corrected_stage_movement`.
+
+        Args:
+            dy: actual y stage movement
+            dz: actual z stage movement
+            view_tilt: tilt of the viewing axis from the electron column, in radians.
+
+        Returns:
+            float: expected_y input that would produce the given dy, dz movements
+        """
+
+        # all angles in radians
+        sem_column_tilt = np.deg2rad(self.system.electron.column_tilt)
+
+        stage_pretilt = np.deg2rad(self.system.stage.shuttle_pre_tilt)
+
+        stage_rotation_flat_to_eb = np.deg2rad(
+            self.system.stage.rotation_reference
+        ) % (2 * np.pi)
+        stage_rotation_flat_to_ion = np.deg2rad(
+            self.system.stage.rotation_180
+        ) % (2 * np.pi)
+
+        # current stage position
+        current_stage_position = self.get_stage_position()
+        stage_rotation = current_stage_position.r % (2 * np.pi) if current_stage_position.r is not None else 0.0
+        stage_tilt = current_stage_position.t if current_stage_position.t is not None else 0.0
+
+        # Handle compustage case
+        compustage_sign = 1.0
+        if self.stage_is_compustage:
+            if stage_tilt <= 0:
+                compustage_sign = -1.0
+            stage_tilt += np.pi
+
+        PRETILT_SIGN = 1.0
+        # pretilt angle depends on rotation
+        from fibsem import movement
+        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
+            PRETILT_SIGN = 1.0
+        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
+            PRETILT_SIGN = -1.0
+
+        corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
+
+        # perspective tilt adjustment
+        perspective_tilt_adjustment = -corrected_pretilt_angle - view_tilt
+
+        # Reverse the calculations from the forward function:
+        # Forward: y_move = y_sample_move * cos(corrected_pretilt_angle)
+        # Forward: z_move = -y_sample_move * sin(corrected_pretilt_angle)
+        # Therefore: y_sample_move can be calculated from either dy or dz
+
+        # Calculate y_sample_move from dy and dz (should be consistent)
+        cos_pretilt = np.cos(corrected_pretilt_angle)
+        sin_pretilt = np.sin(corrected_pretilt_angle)
+
+        if abs(cos_pretilt) > abs(sin_pretilt):
+            # Use dy calculation when cos component is larger
+            y_sample_move = dy / cos_pretilt
+        else:
+            # Use dz calculation when sin component is larger
+            y_sample_move = -dz / sin_pretilt
+
+        # Reverse: expected_y = y_sample_move * cos(stage_tilt + perspective_tilt_adjustment)
+        expected_y = y_sample_move * np.cos(stage_tilt + perspective_tilt_adjustment)
+
+        # Apply compustage correction if needed
+        if self.stage_is_compustage:
+            expected_y *= compustage_sign
+
+        return expected_y
+
     def move_to_device(self, device: str) -> None:
         """Move the stage to the predefined device position."""
         logging.warning(f"move_to_device is not implemented for {self.__class__.__name__}.")
@@ -2283,6 +2448,9 @@ class ThermoMicroscope(FibsemMicroscope):
         """
         Calculate the y corrected stage movement, corrected for the additional tilt of the sample holder (pre-tilt angle).
 
+        Thin wrapper over :meth:`_view_corrected_stage_movement`: a beam is just a
+        view whose axis is tilted from the electron column by its ``column_tilt``.
+
         Args:
             expected_y (float, optional): distance along y-axis.
             beam_type (BeamType, optional): beam_type to move in. Defaults to BeamType.ELECTRON.
@@ -2290,81 +2458,10 @@ class ThermoMicroscope(FibsemMicroscope):
         Returns:
             StagePosition: y corrected stage movement (relative position)
         """
-
-        # TODO: replace with camera matrix * inverse kinematics
-
-        # all angles in radians
-        sem_column_tilt = np.deg2rad(self.system.electron.column_tilt)
-        fib_column_tilt = np.deg2rad(self.system.ion.column_tilt)
-
-        stage_pretilt = np.deg2rad(self.system.stage.shuttle_pre_tilt)
-
-        stage_rotation_flat_to_eb = np.deg2rad(
-            self.system.stage.rotation_reference
-        ) % (2 * np.pi)
-        stage_rotation_flat_to_ion = np.deg2rad(
-            self.system.stage.rotation_180
-        ) % (2 * np.pi)
-
-        # current stage position
-        current_stage_position = self.get_stage_position()
-        stage_rotation = current_stage_position.r % (2 * np.pi)
-        stage_tilt = current_stage_position.t
-
-        # TODO: @patrick investigate if these calculations need to be adjusted for compustage...
-        # the compustage does not have pre-tilt, cannot rotate, but tilts 180 deg. 
-        # Therefore, the rotation will always be 0, pre-tilt will always be 0
-        # therefore, I think it should always be treated as a flat stage, that is oriented towards the ion beam (in rotation)?
-        # need hardware to confirm this
-        # QUESTION: is the compustage always flat to the ion beam? or is it flat to the electron beam?
-        # QUESTION: what is the tilt coordinate system (where is 0 degrees, where is 90 degrees, where is 180 degrees)?
-        # QUESTION: what does flip do? Is it 180 degrees rotation or tilt? This will affect move_flat_to_beam        
-        # ASSUMPTION: (naive) tilt=0 -> flat to electron beam, tilt=52 -> flat to ion
-
-        # new info:
-        # rotation always will be zero -> PRETILT_SIGN = 1
-        # because we want to image the back of the grid, we need to flip the stage by 180 degrees
-        # flat to electron, tilt = -180
-        # flat to ion, tilt = -128
-        # we may also need to flip the PRETILT_SIGN?
-
-        if self.stage_is_compustage:
-
-            # if stage_tilt < 0:
-            expected_y *= -1.0
-
-            stage_tilt += np.pi
-        # QUERY: for compustage, can we just return the expected y? there is no pre-tilt?
-
-        PRETILT_SIGN = 1.0
-        # pretilt angle depends on rotation # TODO: migrate to orientation
-        from fibsem import movement
-        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
-            PRETILT_SIGN = 1.0
-        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
-            PRETILT_SIGN = -1.0
-
-        if self.stage_is_compustage and self.get_stage_orientation() == "FIB":
-            expected_y *= -1.0 # use this until rotation_180 is deprecated correctly...
-            PRETILT_SIGN = -1.0
-
-        # corrected_pretilt_angle = PRETILT_SIGN * stage_tilt_flat_to_electron
-        corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt) # electron angle = 0, ion = 52
-
-        # perspective tilt adjustment (difference between perspective view and sample coordinate system)
-        if beam_type == BeamType.ELECTRON:
-            perspective_tilt_adjustment = -corrected_pretilt_angle
-        elif beam_type == BeamType.ION:
-            perspective_tilt_adjustment = (-corrected_pretilt_angle - fib_column_tilt)
-
-        # the amount the sample has to move in the y-axis
-        y_sample_move = expected_y  / np.cos(stage_tilt + perspective_tilt_adjustment)
-
-        # the amount the stage has to move in each axis
-        y_move = y_sample_move * np.cos(corrected_pretilt_angle)
-        z_move = -y_sample_move * np.sin(corrected_pretilt_angle) #TODO: investigate this
-
-        return FibsemStagePosition(x=0, y=y_move, z=z_move)
+        return self._view_corrected_stage_movement(
+            expected_y=expected_y,
+            view_tilt=self._beam_view_tilt(beam_type),
+        )
 
     def _inverse_y_corrected_stage_movement(
         self,
@@ -2376,80 +2473,21 @@ class ThermoMicroscope(FibsemMicroscope):
         Calculate the expected_y input from dy, dz stage movements and beam_type.
         This is the inverse of _y_corrected_stage_movement.
 
+        Thin wrapper over :meth:`_inverse_view_corrected_stage_movement`.
+
         Args:
             dy (float): actual y stage movement
-            dz (float): actual z stage movement  
+            dz (float): actual z stage movement
             beam_type (BeamType, optional): beam_type used. Defaults to BeamType.ELECTRON.
 
         Returns:
             float: expected_y input that would produce the given dy, dz movements
         """
-
-        # all angles in radians
-        sem_column_tilt = np.deg2rad(self.system.electron.column_tilt)
-        fib_column_tilt = np.deg2rad(self.system.ion.column_tilt)
-
-        stage_pretilt = np.deg2rad(self.system.stage.shuttle_pre_tilt)
-
-        stage_rotation_flat_to_eb = np.deg2rad(
-            self.system.stage.rotation_reference
-        ) % (2 * np.pi)
-        stage_rotation_flat_to_ion = np.deg2rad(
-            self.system.stage.rotation_180
-        ) % (2 * np.pi)
-
-        # current stage position
-        current_stage_position = self.get_stage_position()
-        stage_rotation = current_stage_position.r % (2 * np.pi) if current_stage_position.r is not None else 0.0
-        stage_tilt = current_stage_position.t if current_stage_position.t is not None else 0.0
-
-        # Handle compustage case
-        compustage_sign = 1.0
-        if self.stage_is_compustage:
-            if stage_tilt <= 0:
-                compustage_sign = -1.0
-            stage_tilt += np.pi
-
-        PRETILT_SIGN = 1.0
-        # pretilt angle depends on rotation
-        from fibsem import movement
-        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
-            PRETILT_SIGN = 1.0
-        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
-            PRETILT_SIGN = -1.0
-
-        corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
-
-        # perspective tilt adjustment
-        if beam_type == BeamType.ELECTRON:
-            perspective_tilt_adjustment = -corrected_pretilt_angle
-        elif beam_type == BeamType.ION:
-            perspective_tilt_adjustment = (-corrected_pretilt_angle - fib_column_tilt)
-
-        # Reverse the calculations from the forward function:
-        # Forward: y_move = y_sample_move * cos(corrected_pretilt_angle)
-        # Forward: z_move = -y_sample_move * sin(corrected_pretilt_angle)
-        # Therefore: y_sample_move can be calculated from either dy or dz
-
-        # Calculate y_sample_move from dy and dz (should be consistent)
-        cos_pretilt = np.cos(corrected_pretilt_angle)
-        sin_pretilt = np.sin(corrected_pretilt_angle)
-        
-        if abs(cos_pretilt) > abs(sin_pretilt):
-            # Use dy calculation when cos component is larger
-            y_sample_move = dy / cos_pretilt
-        else:
-            # Use dz calculation when sin component is larger
-            y_sample_move = -dz / sin_pretilt
-
-        # Reverse: expected_y = y_sample_move * cos(stage_tilt + perspective_tilt_adjustment)
-        expected_y = y_sample_move * np.cos(stage_tilt + perspective_tilt_adjustment)
-
-        # Apply compustage correction if needed
-        if self.stage_is_compustage:
-            expected_y *= compustage_sign
-
-        return expected_y
+        return self._inverse_view_corrected_stage_movement(
+            dy=dy,
+            dz=dz,
+            view_tilt=self._beam_view_tilt(beam_type),
+        )
 
 
 

--- a/tests/test_view_corrected_movement.py
+++ b/tests/test_view_corrected_movement.py
@@ -1,0 +1,316 @@
+"""Parity tests for the view-parameterised stage projection (FIB-133 Phase A/B).
+
+`_y_corrected_stage_movement` used to hardcode a two-branch choice between the
+electron and ion columns. It is now a thin wrapper over
+`_view_corrected_stage_movement(expected_y, view_tilt)`, where `view_tilt` is how
+far the viewing axis sits from the electron column -- 0 for the electron column,
+`column_tilt` for the ion column, and `camera_tilt` for a fluorescence camera.
+
+These tests pin that refactor as *inert*: the reference implementations below are
+the pre-refactor formulae copied verbatim, and the sweep asserts the new code
+agrees with them everywhere.
+"""
+
+import numpy as np
+import pytest
+
+from fibsem import movement, utils
+from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.fm.structures import CameraImageTransform
+from fibsem.structures import BeamType, FibsemStagePosition
+
+# sweep: stage tilt x pretilt x rotation x beam x compustage
+STAGE_TILTS_DEG = [-50, -23, 0, 15, 35, 52]
+PRETILTS_DEG = [0, 35, 45]
+ROTATIONS_DEG = [0, 180]
+BEAM_TYPES = [BeamType.ELECTRON, BeamType.ION]
+COMPUSTAGE = [False, True]
+
+
+def _reference_y_corrected(microscope, expected_y: float, beam_type: BeamType):
+    """Pre-refactor `_y_corrected_stage_movement`, copied verbatim."""
+    sem_column_tilt = np.deg2rad(microscope.system.electron.column_tilt)
+    fib_column_tilt = np.deg2rad(microscope.system.ion.column_tilt)
+
+    stage_pretilt = np.deg2rad(microscope.system.stage.shuttle_pre_tilt)
+
+    stage_rotation_flat_to_eb = np.deg2rad(
+        microscope.system.stage.rotation_reference
+    ) % (2 * np.pi)
+    stage_rotation_flat_to_ion = np.deg2rad(
+        microscope.system.stage.rotation_180
+    ) % (2 * np.pi)
+
+    current_stage_position = microscope.get_stage_position()
+    stage_rotation = current_stage_position.r % (2 * np.pi)
+    stage_tilt = current_stage_position.t
+
+    if microscope.stage_is_compustage:
+        expected_y *= -1.0
+        stage_tilt += np.pi
+
+    PRETILT_SIGN = 1.0
+    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
+        PRETILT_SIGN = 1.0
+    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
+        PRETILT_SIGN = -1.0
+
+    if microscope.stage_is_compustage and microscope.get_stage_orientation() == "FIB":
+        expected_y *= -1.0
+        PRETILT_SIGN = -1.0
+
+    corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
+
+    if beam_type == BeamType.ELECTRON:
+        perspective_tilt_adjustment = -corrected_pretilt_angle
+    elif beam_type == BeamType.ION:
+        perspective_tilt_adjustment = (-corrected_pretilt_angle - fib_column_tilt)
+
+    y_sample_move = expected_y / np.cos(stage_tilt + perspective_tilt_adjustment)
+
+    y_move = y_sample_move * np.cos(corrected_pretilt_angle)
+    z_move = -y_sample_move * np.sin(corrected_pretilt_angle)
+
+    return FibsemStagePosition(x=0, y=y_move, z=z_move)
+
+
+def _reference_inverse_y_corrected(microscope, dy: float, dz: float, beam_type: BeamType):
+    """Pre-refactor `_inverse_y_corrected_stage_movement`, copied verbatim."""
+    sem_column_tilt = np.deg2rad(microscope.system.electron.column_tilt)
+    fib_column_tilt = np.deg2rad(microscope.system.ion.column_tilt)
+
+    stage_pretilt = np.deg2rad(microscope.system.stage.shuttle_pre_tilt)
+
+    stage_rotation_flat_to_eb = np.deg2rad(
+        microscope.system.stage.rotation_reference
+    ) % (2 * np.pi)
+    stage_rotation_flat_to_ion = np.deg2rad(
+        microscope.system.stage.rotation_180
+    ) % (2 * np.pi)
+
+    current_stage_position = microscope.get_stage_position()
+    stage_rotation = current_stage_position.r % (2 * np.pi) if current_stage_position.r is not None else 0.0
+    stage_tilt = current_stage_position.t if current_stage_position.t is not None else 0.0
+
+    compustage_sign = 1.0
+    if microscope.stage_is_compustage:
+        if stage_tilt <= 0:
+            compustage_sign = -1.0
+        stage_tilt += np.pi
+
+    PRETILT_SIGN = 1.0
+    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
+        PRETILT_SIGN = 1.0
+    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
+        PRETILT_SIGN = -1.0
+
+    corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
+
+    if beam_type == BeamType.ELECTRON:
+        perspective_tilt_adjustment = -corrected_pretilt_angle
+    elif beam_type == BeamType.ION:
+        perspective_tilt_adjustment = (-corrected_pretilt_angle - fib_column_tilt)
+
+    cos_pretilt = np.cos(corrected_pretilt_angle)
+    sin_pretilt = np.sin(corrected_pretilt_angle)
+
+    if abs(cos_pretilt) > abs(sin_pretilt):
+        y_sample_move = dy / cos_pretilt
+    else:
+        y_sample_move = -dz / sin_pretilt
+
+    expected_y = y_sample_move * np.cos(stage_tilt + perspective_tilt_adjustment)
+
+    if microscope.stage_is_compustage:
+        expected_y *= compustage_sign
+
+    return expected_y
+
+
+@pytest.fixture()
+def microscope():
+    scope, _ = utils.setup_session(manufacturer="Demo")
+    return scope
+
+
+def _configure(microscope, *, pretilt_deg, rotation_deg, tilt_deg, compustage):
+    """Pin the microscope into a known geometry (pure math, no stage motion)."""
+    microscope.stage_is_compustage = compustage
+    microscope.system.stage.shuttle_pre_tilt = pretilt_deg
+    microscope._update_orientations()
+
+    position = FibsemStagePosition(
+        x=0.0, y=0.0, z=0.0,
+        r=np.deg2rad(rotation_deg),
+        t=np.deg2rad(tilt_deg),
+    )
+    microscope.get_stage_position = lambda: position  # type: ignore[method-assign]
+    return position
+
+
+class TestRefactorParity:
+    """The extracted projection must reproduce the pre-refactor formulae exactly."""
+
+    @pytest.mark.parametrize("tilt_deg", STAGE_TILTS_DEG)
+    @pytest.mark.parametrize("pretilt_deg", PRETILTS_DEG)
+    @pytest.mark.parametrize("rotation_deg", ROTATIONS_DEG)
+    @pytest.mark.parametrize("beam_type", BEAM_TYPES)
+    @pytest.mark.parametrize("compustage", COMPUSTAGE)
+    def test_forward_parity(
+        self, microscope, tilt_deg, pretilt_deg, rotation_deg, beam_type, compustage
+    ):
+        _configure(
+            microscope,
+            pretilt_deg=pretilt_deg,
+            rotation_deg=rotation_deg,
+            tilt_deg=tilt_deg,
+            compustage=compustage,
+        )
+        expected_y = 25e-6
+
+        got = microscope._y_corrected_stage_movement(expected_y, beam_type=beam_type)
+        want = _reference_y_corrected(microscope, expected_y, beam_type=beam_type)
+
+        assert got.y == pytest.approx(want.y, rel=1e-12, abs=1e-18)
+        assert got.z == pytest.approx(want.z, rel=1e-12, abs=1e-18)
+
+    @pytest.mark.parametrize("tilt_deg", STAGE_TILTS_DEG)
+    @pytest.mark.parametrize("pretilt_deg", PRETILTS_DEG)
+    @pytest.mark.parametrize("rotation_deg", ROTATIONS_DEG)
+    @pytest.mark.parametrize("beam_type", BEAM_TYPES)
+    @pytest.mark.parametrize("compustage", COMPUSTAGE)
+    def test_inverse_parity(
+        self, microscope, tilt_deg, pretilt_deg, rotation_deg, beam_type, compustage
+    ):
+        _configure(
+            microscope,
+            pretilt_deg=pretilt_deg,
+            rotation_deg=rotation_deg,
+            tilt_deg=tilt_deg,
+            compustage=compustage,
+        )
+        dy, dz = 12e-6, -3e-6
+
+        got = microscope._inverse_y_corrected_stage_movement(dy=dy, dz=dz, beam_type=beam_type)
+        want = _reference_inverse_y_corrected(microscope, dy=dy, dz=dz, beam_type=beam_type)
+
+        assert got == pytest.approx(want, rel=1e-12, abs=1e-18)
+
+
+class TestViewTiltEquivalence:
+    """A beam is just a view with a particular axis tilt."""
+
+    def test_zero_view_tilt_is_the_electron_column(self, microscope):
+        _configure(microscope, pretilt_deg=35, rotation_deg=0, tilt_deg=20, compustage=False)
+
+        by_view = microscope._view_corrected_stage_movement(25e-6, view_tilt=0.0)
+        by_beam = microscope._y_corrected_stage_movement(25e-6, beam_type=BeamType.ELECTRON)
+
+        assert by_view.y == pytest.approx(by_beam.y)
+        assert by_view.z == pytest.approx(by_beam.z)
+
+    def test_column_tilt_view_is_the_ion_column(self, microscope):
+        _configure(microscope, pretilt_deg=35, rotation_deg=0, tilt_deg=20, compustage=False)
+        view_tilt = np.deg2rad(microscope.system.ion.column_tilt)
+
+        by_view = microscope._view_corrected_stage_movement(25e-6, view_tilt=view_tilt)
+        by_beam = microscope._y_corrected_stage_movement(25e-6, beam_type=BeamType.ION)
+
+        assert by_view.y == pytest.approx(by_beam.y)
+        assert by_view.z == pytest.approx(by_beam.z)
+
+    def test_beam_view_tilt_values(self, microscope):
+        assert microscope._beam_view_tilt(BeamType.ELECTRON) == 0.0
+        assert microscope._beam_view_tilt(BeamType.ION) == pytest.approx(
+            np.deg2rad(microscope.system.ion.column_tilt)
+        )
+
+    @pytest.mark.parametrize("view_tilt_deg", [0, 38, 52, 180])
+    def test_inverse_round_trips(self, microscope, view_tilt_deg):
+        _configure(microscope, pretilt_deg=35, rotation_deg=0, tilt_deg=20, compustage=False)
+        view_tilt = np.deg2rad(view_tilt_deg)
+        expected_y = 25e-6
+
+        move = microscope._view_corrected_stage_movement(expected_y, view_tilt=view_tilt)
+        recovered = microscope._inverse_view_corrected_stage_movement(
+            dy=move.y, dz=move.z, view_tilt=view_tilt
+        )
+
+        assert recovered == pytest.approx(expected_y, rel=1e-9)
+
+
+class TestCameraTilt:
+    """The FM optical axis is derived from the mount, not configured."""
+
+    def test_offset_mount_matches_the_ion_column(self, microscope):
+        # METEOR / iFLM: optical axis parallel to the FIB column, offset along x
+        microscope.stage_is_compustage = False
+        fm = FluorescenceMicroscope(parent=microscope)
+        assert fm.camera_tilt == pytest.approx(microscope.system.ion.column_tilt)
+
+    def test_under_grid_mount_is_a_half_turn(self, microscope):
+        # Arctis: camera mounted under the grid, looking up
+        microscope.stage_is_compustage = True
+        fm = FluorescenceMicroscope(parent=microscope)
+        assert fm.camera_tilt == pytest.approx(180.0)
+
+    def test_no_parent_is_zero(self):
+        assert FluorescenceMicroscope().camera_tilt == 0.0
+
+    def test_under_grid_mount_cancels_the_stage_flip(self, microscope):
+        """Arctis images FM with the stage flipped; the half-turn camera_tilt cancels it.
+
+        compustage has no pre-tilt, so the projection should come out flat-on to the
+        camera: no foreshortening, pure y move.
+        """
+        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+        microscope.system.electron.column_tilt = 0.0
+
+        fm = FluorescenceMicroscope(parent=microscope)
+        move = microscope._view_corrected_stage_movement(
+            25e-6, view_tilt=np.deg2rad(fm.camera_tilt)
+        )
+
+        assert abs(move.y) == pytest.approx(25e-6, rel=1e-9)
+        assert move.z == pytest.approx(0.0, abs=1e-18)
+
+
+class TestMountTransform:
+    """The mount correction is applied before the user's transform."""
+
+    def test_defaults_to_no_correction(self):
+        assert FluorescenceMicroscope().mount_transform is CameraImageTransform.NONE
+
+    def test_default_pipeline_is_unchanged(self):
+        fm = FluorescenceMicroscope()
+        data = np.arange(12, dtype=np.uint16).reshape(3, 4)
+        assert np.array_equal(fm._apply_image_transform(data), data)
+
+    @pytest.mark.parametrize(
+        "transform, expected",
+        [
+            (CameraImageTransform.NONE, lambda d: d),
+            (CameraImageTransform.FLIP_X, np.fliplr),
+            (CameraImageTransform.FLIP_Y, np.flipud),
+            (CameraImageTransform.ROTATE_180, lambda d: np.rot90(d, k=2)),
+        ],
+    )
+    def test_user_transform_still_applies(self, transform, expected):
+        fm = FluorescenceMicroscope()
+        fm.set_image_transform(transform)
+        data = np.arange(12, dtype=np.uint16).reshape(3, 4)
+        assert np.array_equal(fm._apply_image_transform(data), expected(data))
+
+    def test_mount_correction_composes_before_user_transform(self, monkeypatch):
+        """A driver overriding mount_transform gets it applied first."""
+        fm = FluorescenceMicroscope()
+        monkeypatch.setattr(
+            type(fm), "mount_transform",
+            property(lambda self: CameraImageTransform.FLIP_Y),
+        )
+        fm.set_image_transform(CameraImageTransform.FLIP_X)
+
+        data = np.arange(12, dtype=np.uint16).reshape(3, 4)
+        assert np.array_equal(
+            fm._apply_image_transform(data), np.fliplr(np.flipud(data))
+        )


### PR DESCRIPTION
Phase A + B of FM stable move (FIB-133).

**This PR changes no behaviour.** It makes the stage projection view-parameterised so the fluorescence camera can become a first-class view, and describes the FM mount. The FM movement API itself is Phase C.

## Why

`_y_corrected_stage_movement` projects an in-image y-displacement onto the tilted sample plane. It distinguished the electron column from the ion column by exactly one thing — how far the viewing axis sits from the electron column:

```python
if beam_type == BeamType.ELECTRON:
    perspective_tilt_adjustment = -corrected_pretilt_angle
elif beam_type == BeamType.ION:
    perspective_tilt_adjustment = (-corrected_pretilt_angle - fib_column_tilt)
```

An FM camera is a third view of the same sample, so it wants the same projection with its own axis tilt. Today FM tiling instead borrows the electron branch (`acquire_tileset` steps with `beam_type=ELECTRON`), which at the FM imaging orientation mis-scales y-steps by ~`1/cos(52°)` on offset mounts. Making the tilt a parameter is the prerequisite for fixing that properly.

## What changed

**`FibsemMicroscope`** gains `_view_corrected_stage_movement(expected_y, view_tilt)` and `_inverse_view_corrected_stage_movement(dy, dz, view_tilt)` — the base already had everything they need (`system`, `get_stage_position`, `stage_is_compustage`, `get_stage_orientation`). The two-branch conditional collapses to:

```python
perspective_tilt_adjustment = -corrected_pretilt_angle - view_tilt
```

with the electron column now simply the `view_tilt = 0` case.

**`ThermoMicroscope`**'s two methods become thin wrappers passing `0` / `ion.column_tilt` through `_beam_view_tilt()`. Odemis and the simulator delegate to the Thermo methods, so they inherit this for free, and `project_stable_move` needed no edit. **Tescan keeps its own divergent `_y_corrected_stage_movement` (`tescan.py:669`) and is untouched** — it inherits the Thermo-shaped base method, which is inert today since Tescan has no FM, but a Tescan FM would need its own view projection.

**`FluorescenceMicroscope.camera_tilt`** derives the FM optical axis from the mount instead of configuration, because the compustage flag already distinguishes the two real cases:

- **under-grid mounts** (Arctis) look up at the grid from the opposite side to the SEM — a half turn, 180°;
- **offset mounts** (METEOR, iFLM) sit parallel to the FIB column displaced along x, so they share the ion column's tilt.

The Arctis case falls out of the shared formula rather than needing special-casing: compustage has no pre-tilt and images FM with the stage flipped, so the half-turn `camera_tilt` and the flip cancel (`cos(-360°) = 1`) and the projection comes out flat-on, no foreshortening. There is a test for that.

**`FluorescenceMicroscope.mount_transform`** adds a per-system raw-sensor-to-stage-aligned correction, applied ahead of the user's `CameraImageTransform` so display, correlation, saved data and movement all see one consistently oriented image. It defaults to `NONE`, so the image pipeline is unchanged until a driver supplies a value.

## How "no behaviour change" is established

`tests/test_view_corrected_movement.py` copies the **pre-refactor formulae verbatim** as reference implementations and asserts the refactored code agrees across the full sweep — stage tilt × pretilt × rotation × beam type × compustage, 144 combinations, forward and inverse, at `rel=1e-12`. Plus view-tilt equivalence (`view_tilt=0` ≡ ELECTRON, `view_tilt=column_tilt` ≡ ION), inverse round-trip, the `camera_tilt` derivations, and mount/user transform composition order.

306 new tests. Full suite: 1278 passed, 15 skipped, 0 failed.

## Known follow-up, deliberately not in this PR

While writing the parity sweep I found that `_inverse_y_corrected_stage_movement` is **not a faithful inverse of the forward on compustage**: the forward flips `expected_y` a second time when compustage *and* FIB orientation, but the inverse uses a stage-tilt threshold and never consults orientation. On the Arctis sim a +25 µm input returns −25 µm at t=−128°. There are also two copies that disagree — the microscope one and a microscope-free copy in `tiled.py:1066` used for offline reprojection, which has a `> -90°` clause the microscope version lacks.

This is latent rather than live: the microscope-bound inverse has no production callers today (only driver delegations), and `tiled.py`'s copy is correct for the SEM/FIB images it is actually given. It goes live in Phase C.

It is **excluded on purpose** — folding a behaviour change into this PR would force the parity tests to encode the new behaviour and destroy the "provably inert" property that makes the diff safe to review at a glance. It follows as its own small PR, with round-trip identity as its proof.

Unifying the `tiled.py` copy with the microscope one is a separate question again, and deliberately not scheduled — it must come after the inverse fix (otherwise it silently picks one compustage behaviour over the other and changes Arctis results as a side effect of a refactor), and it wants a real compustage metadata field first, since `tiled.py:1103` currently string-sniffs the model name.
