### PR TITLE
Show fluorescence images in the lamella review panel (FIB-169)

### DIFF
--- a/fibsem/applications/autolamella/task_outputs.py
+++ b/fibsem/applications/autolamella/task_outputs.py
@@ -12,34 +12,45 @@ from __future__ import annotations
 
 import glob
 import os
-from typing import List
+from typing import List, Sequence
 
 from fibsem.applications.autolamella.structures import AutoLamellaTaskState, Lamella
 
 
-def _recorded(lamella: Lamella, task: AutoLamellaTaskState, *roles: str) -> List[str]:
-    """Absolute, existing, de-duplicated paths recorded under the given roles.
+def _recorded(
+    lamella: Lamella, tasks: Sequence[AutoLamellaTaskState], *roles: str
+) -> List[str]:
+    """Absolute, existing, de-duplicated paths recorded across the given runs.
 
-    A record can hold things a directory listing never could, so both guards are
-    load-bearing rather than defensive habit:
+    Every function here accepts any number of runs of the same task and returns the
+    union of what they produced. That single rule covers both shapes without
+    branching on task or file type: reference images are written to the same
+    filename each run, so repeated runs contribute the same paths and the set
+    collapses; fluorescence stacks are uniquely named, so each run contributes its
+    own. The panel therefore shows one reference set and every FM acquisition.
 
-    * **Deduplicate** — a run can acquire the same set twice (MillCoincidentTask
-      does, before and after milling) and overwrite the same files, recording each
-      path twice. Duplicates crowd out real images when callers slice off the last N.
+    Both guards are load-bearing, because a record can hold things a directory
+    listing never could:
+
+    * **Deduplicate** — the same path recorded twice is still one file, whether
+      that came from one run acquiring a set twice (MillCoincidentTask does, before
+      and after milling) or from two runs overwriting each other. Duplicates crowd
+      out real images when callers slice off the last N.
     * **Require existence** — a record can name a file that has since been deleted.
       Returning it produces a row of placeholders that never fill, where the file
       simply being absent used to mean no row at all.
     """
     paths = (
         os.path.join(lamella.path, relpath)
+        for task in tasks
         for role in roles
         for relpath in task.outputs.get(role, [])
     )
     return sorted({path for path in paths if os.path.isfile(path)})
 
 
-def fluorescence_images(lamella: Lamella, task: AutoLamellaTaskState) -> List[str]:
-    """Absolute paths to the fluorescence z-stacks a task run produced.
+def fluorescence_images(lamella: Lamella, *tasks: AutoLamellaTaskState) -> List[str]:
+    """Absolute paths to the fluorescence z-stacks the given runs produced.
 
     No filename fallback, unlike the reference images: fluorescence output never
     followed a discoverable convention — it is named for the lamella and a
@@ -47,22 +58,28 @@ def fluorescence_images(lamella: Lamella, task: AutoLamellaTaskState) -> List[st
     recorded their outputs simply has none to find. Guessing a pattern would
     attribute files to the wrong run.
     """
-    return _recorded(lamella, task, "fluorescence")
+    return _recorded(lamella, tasks, "fluorescence")
 
 
-def final_reference_images(lamella: Lamella, task: AutoLamellaTaskState) -> List[str]:
-    """Absolute paths to the final reference images a task run produced.
+def final_reference_images(lamella: Lamella, *tasks: AutoLamellaTaskState) -> List[str]:
+    """Absolute paths to the final reference images the given runs produced.
 
-    Prefers what the run recorded. Falls back to the filename convention, which
+    Prefers what the runs recorded. Falls back to the filename convention, which
     remains the only route for experiments written before outputs existed, and for
     runs that failed before reaching post_task and so have no history entry at all.
 
     Sorted so both routes yield the same order: alphabetical puts the highest-res
     pair last, which is what callers slice off.
     """
-    recorded = _recorded(lamella, task, "final_sem", "final_fib")
+    recorded = _recorded(lamella, tasks, "final_sem", "final_fib")
     if recorded:
         return recorded
     return sorted(
-        glob.glob(os.path.join(lamella.path, f"ref_{task.name}*_final_*res*.tif*"))
+        {
+            path
+            for name in {task.name for task in tasks}
+            for path in glob.glob(
+                os.path.join(lamella.path, f"ref_{name}*_final_*res*.tif*")
+            )
+        }
     )

--- a/fibsem/applications/autolamella/task_outputs.py
+++ b/fibsem/applications/autolamella/task_outputs.py
@@ -17,6 +17,39 @@ from typing import List
 from fibsem.applications.autolamella.structures import AutoLamellaTaskState, Lamella
 
 
+def _recorded(lamella: Lamella, task: AutoLamellaTaskState, *roles: str) -> List[str]:
+    """Absolute, existing, de-duplicated paths recorded under the given roles.
+
+    A record can hold things a directory listing never could, so both guards are
+    load-bearing rather than defensive habit:
+
+    * **Deduplicate** — a run can acquire the same set twice (MillCoincidentTask
+      does, before and after milling) and overwrite the same files, recording each
+      path twice. Duplicates crowd out real images when callers slice off the last N.
+    * **Require existence** — a record can name a file that has since been deleted.
+      Returning it produces a row of placeholders that never fill, where the file
+      simply being absent used to mean no row at all.
+    """
+    paths = (
+        os.path.join(lamella.path, relpath)
+        for role in roles
+        for relpath in task.outputs.get(role, [])
+    )
+    return sorted({path for path in paths if os.path.isfile(path)})
+
+
+def fluorescence_images(lamella: Lamella, task: AutoLamellaTaskState) -> List[str]:
+    """Absolute paths to the fluorescence z-stacks a task run produced.
+
+    No filename fallback, unlike the reference images: fluorescence output never
+    followed a discoverable convention — it is named for the lamella and a
+    time-of-day stamp, with no task name — so an experiment written before runs
+    recorded their outputs simply has none to find. Guessing a pattern would
+    attribute files to the wrong run.
+    """
+    return _recorded(lamella, task, "fluorescence")
+
+
 def final_reference_images(lamella: Lamella, task: AutoLamellaTaskState) -> List[str]:
     """Absolute paths to the final reference images a task run produced.
 
@@ -27,16 +60,7 @@ def final_reference_images(lamella: Lamella, task: AutoLamellaTaskState) -> List
     Sorted so both routes yield the same order: alphabetical puts the highest-res
     pair last, which is what callers slice off.
     """
-    recorded = [
-        os.path.join(lamella.path, relpath)
-        for role in ("final_sem", "final_fib")
-        for relpath in task.outputs.get(role, [])
-    ]
-    # deduplicate: a path recorded twice is still one file, and duplicates would
-    # crowd out real images when callers slice the last N off the result.
-    # require the file to still exist, so a record whose images have been deleted
-    # falls through to the convention rather than yielding permanent blanks.
-    recorded = sorted({path for path in recorded if os.path.isfile(path)})
+    recorded = _recorded(lamella, task, "final_sem", "final_fib")
     if recorded:
         return recorded
     return sorted(

--- a/fibsem/fm/composite.py
+++ b/fibsem/fm/composite.py
@@ -1,0 +1,132 @@
+"""Multi-channel fluorescence compositing.
+
+Blends per-channel grayscale frames into one RGB image the way napari does — each
+channel tinted by its colour and **additively** summed — so any surface can show
+the colocalised multi-channel result.
+
+Qt-free by design, so it can be imported and tested without the UI extras (CI has
+no napari or PyQt5, and anything reaching through `fibsem.ui` is skipped there).
+
+Originally written for the quad-view FM canvas on PR #111 and lifted here
+unchanged so the review panel can use it too. When #111 lands, its copy at
+`fibsem/ui/widgets/canvas/fm_composite.py` should become a re-export of this
+module rather than a second implementation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+import numpy as np
+from matplotlib.colors import to_rgb
+
+# Canonical channel colours (mirrors channel_list_widget.AVAILABLE_COLORS).
+AVAILABLE_COLORS = ["violet", "blue", "cyan", "green", "yellow", "red", "gray"]
+
+_WHITE = (1.0, 1.0, 1.0)
+
+
+@dataclass
+class FMLayer:
+    """One fluorescence channel's display state (separate from acquisition
+    ``ChannelSettings``, which only carries ``name`` + ``color``)."""
+
+    name: str
+    data: Optional[np.ndarray] = None        # 2D (H, W)
+    color: str = "gray"
+    opacity: float = 1.0                      # 0..1
+    clim: Optional[Tuple[float, float]] = None  # manual limits (used when not auto)
+    visible: bool = True
+    autocontrast: bool = True                 # recompute clim from data each composite
+    # The user explicitly chose manual contrast (turned Auto off). Distinct from
+    # ``autocontrast``, which the z-scrub display path also toggles internally: the
+    # single-plane / MIP display path keeps a manual channel's clim across live frames /
+    # MIP toggles, but still restores auto for a channel the user left on Auto.
+    manual: bool = False
+    gamma: float = 1.0                        # display = norm ** gamma (1 = linear)
+    # cached auto clim, keyed on the data array identity so it's recomputed only
+    # when the channel's data actually changes (not on every unrelated recomposite,
+    # e.g. an opacity-slider drag). Not part of the layer's value.
+    _clim_cache: Optional[Tuple] = field(default=None, repr=False, compare=False)
+
+
+# Canonical channel-colour tints = napari's colormap endpoints (the colour each
+# colormap ramps to at full intensity), so the composite matches the napari main
+# tab. These mostly agree with matplotlib's named colours; the notable difference
+# is "green" (mpl (0, 0.5, 0) vs napari (0, 1, 0)). "gray" ramps to white.
+_CANONICAL_TINTS = {
+    "violet": (0.933, 0.510, 0.933),
+    "blue": (0.0, 0.0, 1.0),
+    "cyan": (0.0, 1.0, 1.0),
+    "green": (0.0, 1.0, 0.0),
+    "yellow": (1.0, 1.0, 0.0),
+    "red": (1.0, 0.0, 0.0),
+    "magenta": (1.0, 0.0, 1.0),
+    "gray": _WHITE,
+}
+
+
+def tint_rgb(color: str) -> Tuple[float, float, float]:
+    """RGB tint for a channel colour. Canonical channel colours use napari's
+    colormap endpoint (so the composite matches the napari main tab); unknown
+    names fall back to matplotlib, and anything unrecognised to white."""
+    if color in _CANONICAL_TINTS:
+        return _CANONICAL_TINTS[color]
+    try:
+        return to_rgb(color)
+    except (ValueError, TypeError):
+        return _WHITE
+
+
+def auto_clim(data: np.ndarray, max_samples: int = 250_000) -> Tuple[float, float]:
+    """Robust auto contrast limits (1st/99th percentile, min/max fallback).
+
+    The full-resolution percentile is the dominant per-frame cost on live FM, so
+    for large frames the data is strided down to ~*max_samples* points first — the
+    1st/99th percentiles are visually identical on the subsample.
+    """
+    if data.ndim == 2 and data.size > max_samples:
+        step = int(np.ceil(np.sqrt(data.size / max_samples)))
+        data = data[::step, ::step]
+    lo = float(np.percentile(data, 1.0))
+    hi = float(np.percentile(data, 99.0))
+    if hi <= lo:
+        lo, hi = float(np.min(data)), float(np.max(data))
+        if hi <= lo:
+            hi = lo + 1.0
+    return lo, hi
+
+
+def composite_fm_layers(
+    layers: List[FMLayer], shape: Optional[Tuple[int, int]] = None
+) -> Optional[np.ndarray]:
+    """Blend the visible *layers* into an ``(H, W, 3)`` uint8 RGB image.
+
+    Each visible layer is contrast-normalised by its ``clim`` (or auto), tinted by
+    ``color`` scaled by ``opacity``, and additively summed; the result is clipped.
+    Returns ``None`` if there is nothing to show and *shape* is unknown.
+    """
+    visible = [l for l in layers if l.visible and l.data is not None]
+    if not visible:
+        return np.zeros((*shape, 3), dtype=np.uint8) if shape is not None else None
+    H, W = shape if shape is not None else visible[0].data.shape[:2]
+    rgb = np.zeros((H, W, 3), dtype=np.float32)
+    for layer in visible:
+        d = np.asarray(layer.data, dtype=np.float32)
+        if d.shape[:2] != (H, W):
+            continue  # ignore mismatched-shape channels
+        if layer.autocontrast or layer.clim is None:
+            cache = layer._clim_cache
+            if cache is not None and cache[0] is layer.data:
+                lo, hi = cache[1]  # data unchanged → reuse (skip the percentile)
+            else:
+                lo, hi = auto_clim(d)
+                layer._clim_cache = (layer.data, (lo, hi))
+        else:
+            lo, hi = layer.clim
+        norm = np.clip((d - lo) / (hi - lo), 0.0, 1.0) if hi > lo else np.zeros_like(d)
+        if layer.gamma != 1.0:
+            norm = np.power(norm, layer.gamma)
+        tint = np.asarray(tint_rgb(layer.color), dtype=np.float32) * float(layer.opacity)
+        rgb += norm[..., None] * tint
+    return (np.clip(rgb, 0.0, 1.0) * 255.0).astype(np.uint8)

--- a/fibsem/fm/preview.py
+++ b/fibsem/fm/preview.py
@@ -1,0 +1,56 @@
+"""Turning a fluorescence z-stack on disk into one displayable RGB image.
+
+Separate from the widgets that show it, and Qt-free, so it can be tested in CI —
+anything reaching through `fibsem.ui` is skipped there for lack of napari/PyQt5.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Tuple
+
+import numpy as np
+
+from fibsem.fm.composite import AVAILABLE_COLORS, FMLayer, composite_fm_layers
+from fibsem.fm.structures import FluorescenceImage
+
+
+def is_fluorescence_image(filepath: str) -> bool:
+    """Whether a recorded output is a fluorescence z-stack rather than a .tif."""
+    return os.fspath(filepath).lower().endswith((".ome.tiff", ".ome.tif"))
+
+
+def load_projection(filepath: str) -> Tuple[np.ndarray, float]:
+    """Composite a fluorescence z-stack into one RGB image.
+
+    Max-projects each channel over z, tints it by the channel's colour and blends
+    additively — the same composite the FM canvas shows, so a stack looks the same
+    in the review panel as it did live.
+
+    The volume is released before compositing: a real METEOR stack is ~530 MB in
+    memory where its projection is ~25 MB, and callers may load several in a row.
+
+    Returns:
+        (H, W, 3) uint8 RGB, and the pixel size in metres.
+    """
+    image = FluorescenceImage.load(filepath)
+    projected = image.data.max(axis=1)        # (C, Z, Y, X) -> (C, Y, X), a new array
+    channels = list(image.metadata.channels)
+    pixel_size_x = image.metadata.pixel_size_x
+    del image                                  # drop the volume, keep the projection
+
+    layers = []
+    for index, plane in enumerate(projected):
+        # metadata should describe every channel, but never drop a plane when it
+        # doesn't — an unnamed channel is better than a silently missing one.
+        if index < len(channels):
+            name, color = channels[index].name, channels[index].color
+        else:
+            name = f"Channel-{index + 1:02d}"
+            color = AVAILABLE_COLORS[index % len(AVAILABLE_COLORS)]
+        layers.append(FMLayer(name=name, data=plane, color=color))
+
+    rgb = composite_fm_layers(layers)
+    if rgb is None:
+        raise ValueError(f"fluorescence image has no displayable channels: {filepath}")
+    return rgb, pixel_size_x

--- a/fibsem/ui/widgets/lamella_task_image_widget.py
+++ b/fibsem/ui/widgets/lamella_task_image_widget.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import (
     QFrame,
     QGraphicsScene,
     QGraphicsView,
+    QGridLayout,
     QHBoxLayout,
     QLabel,
     QScrollArea,
@@ -25,13 +26,18 @@ from PyQt5.QtWidgets import (
 from skimage.transform import resize
 
 from fibsem.applications.autolamella.structures import Lamella
-from fibsem.applications.autolamella.task_outputs import final_reference_images
+from fibsem.applications.autolamella.task_outputs import (
+    final_reference_images,
+    fluorescence_images,
+)
+from fibsem.fm.preview import is_fluorescence_image, load_projection
 from fibsem.imaging.drawing import draw_image_overlays
 from fibsem.structures import FibsemImage
 
 _TARGET_WIDTH = 1024//2
 _PLACEHOLDER_HEIGHT = 768//2  # estimated height for placeholder labels
 _MAX_IMAGES_PER_TASK = 2  # last 2 files = highest-res SEM + FIB
+_IMAGES_PER_LINE = 2      # tiles per line before wrapping; matches the SEM/FIB pair
 
 
 def _arr_to_pixmap(arr: np.ndarray, w: int, h: int) -> QPixmap:
@@ -49,21 +55,33 @@ def _arr_to_pixmap(arr: np.ndarray, w: int, h: int) -> QPixmap:
 
 
 def _load_and_resize(filepath: str, target_width: int = _TARGET_WIDTH) -> Tuple[np.ndarray, float]:
-    """Load a .tif image and resize to target width, preserving aspect ratio.
+    """Load an image and resize to target width, preserving aspect ratio.
+
+    Handles both a plain .tif and a fluorescence z-stack, which becomes an RGB
+    channel composite. resize() preserves a trailing channel axis on its own, so
+    both shapes go through the same path below.
 
     Returns:
         Tuple of (resized array, pixel_size_x in metres adjusted for resize).
     """
-    img = FibsemImage.load(filepath)
-    data = img.data
-    if data.ndim == 3 and data.shape[2] in (3, 4):
-        data = data[..., :3].mean(axis=2).astype(data.dtype)
+    if is_fluorescence_image(filepath):
+        data, pixel_size_x = load_projection(filepath)
+    else:
+        img = FibsemImage.load(filepath)
+        data = img.data
+        if data.ndim == 3 and data.shape[2] in (3, 4):
+            data = data[..., :3].mean(axis=2).astype(data.dtype)
+        pixel_size_x = img.metadata.pixel_size.x
     h, w = data.shape[:2]
-    scale = target_width / w
-    new_h = int(h * scale)
-    resized = resize(data, (new_h, target_width), preserve_range=True).astype(np.uint8)
-    pixel_size_x = img.metadata.pixel_size.x / scale
-    return resized, pixel_size_x
+    # Fit inside the tile box rather than filling its width. Beam images are 3:2 and
+    # are width-limited, but a fluorescence stack is square: scaling it to the full
+    # width makes it half again as tall as its neighbours, and taller than the
+    # placeholder it replaces, so the row jumps when it finishes loading.
+    max_height = target_width * _PLACEHOLDER_HEIGHT / _TARGET_WIDTH
+    scale = min(target_width / w, max_height / h)
+    new_w, new_h = int(w * scale), int(h * scale)
+    resized = resize(data, (new_h, new_w), preserve_range=True).astype(np.uint8)
+    return resized, pixel_size_x / scale
 
 
 class ClickableLabel(QLabel):
@@ -313,10 +331,14 @@ class LamellaTaskImageWidget(QWidget):
         # Collect all filepaths to load and build placeholder rows
         all_filepaths: List[str] = []
         for task in completed_tasks:
-            filenames = final_reference_images(lamella, task)
-            if not filenames:
-                continue
-            filenames = filenames[-_MAX_IMAGES_PER_TASK:]
+            # cap the reference images *before* appending fluorescence: the cap picks
+            # the highest-magnification SEM/FIB pair out of a multi-FOV set, and
+            # applying it to a merged list would let a z-stack displace the FIB image.
+            filenames = final_reference_images(lamella, task)[-_MAX_IMAGES_PER_TASK:]
+            filenames += fluorescence_images(lamella, task)
+            # a task that produced nothing still gets a row saying so: silently
+            # omitting it is indistinguishable from the task never having run,
+            # which is the confusion this whole feature exists to remove.
             row = self._build_task_row_with_placeholders(task.name, filenames)
             self._content_layout.addWidget(row)
             all_filepaths.extend(filenames)
@@ -362,23 +384,37 @@ class LamellaTaskImageWidget(QWidget):
         )
         layout.addWidget(task_label)
 
-        # Image row with placeholders
+        # Say so explicitly rather than rendering an empty row: a task with a bare
+        # heading reads as "still loading", not "produced nothing".
+        if not filenames:
+            note = QLabel("No images recorded for this task.")
+            note.setStyleSheet(
+                "font-size: 11px; color: #808080; background: transparent;"
+            )
+            layout.addWidget(note)
+            return container
+
+        # Images wrap onto further lines rather than running off the edge: a task can
+        # now produce more than the SEM/FIB pair (a fluorescence stack as well), and
+        # the panel scrolls vertically only, so anything past the width is unreachable.
         img_row = QWidget()
         img_row.setStyleSheet("background: transparent;")
-        img_layout = QHBoxLayout(img_row)
+        img_layout = QGridLayout(img_row)
         img_layout.setContentsMargins(0, 0, 0, 0)
         img_layout.setSpacing(8)
 
-        for fpath in filenames:
+        for index, fpath in enumerate(filenames):
             img_label = ClickableLabel(fpath)
             img_label.setFixedSize(_TARGET_WIDTH, _PLACEHOLDER_HEIGHT)
             img_label.setStyleSheet("background: #1a1b1e; border-radius: 4px;")
             img_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             img_label.setText("Loading...")
-            img_layout.addWidget(img_label)
+            row, column = divmod(index, _IMAGES_PER_LINE)
+            img_layout.addWidget(img_label, row, column)
             self._placeholder_labels[fpath] = img_label
 
-        img_layout.addStretch(1)
+        # trailing stretch column, so tiles stay left-aligned as before
+        img_layout.setColumnStretch(_IMAGES_PER_LINE, 1)
         layout.addWidget(img_row)
 
         return container

--- a/fibsem/ui/widgets/lamella_task_image_widget.py
+++ b/fibsem/ui/widgets/lamella_task_image_widget.py
@@ -25,7 +25,7 @@ from PyQt5.QtWidgets import (
 )
 from skimage.transform import resize
 
-from fibsem.applications.autolamella.structures import Lamella
+from fibsem.applications.autolamella.structures import AutoLamellaTaskState, Lamella
 from fibsem.applications.autolamella.task_outputs import (
     final_reference_images,
     fluorescence_images,
@@ -316,12 +316,15 @@ class LamellaTaskImageWidget(QWidget):
         )
         self._content_layout.addWidget(subtitle_label)
 
-        # Task rows — deduplicate, keep last occurrence of each task name
-        seen = {}
+        # One row per task, accumulating every run of it. Discovery returns the union
+        # of what those runs produced, which needs no special-casing: reference images
+        # are written to the same filename each run so repeated runs collapse to one
+        # set, while fluorescence stacks are uniquely named so every acquisition is
+        # kept. Showing only the last run would silently hide earlier FM images.
+        runs: Dict[str, List[AutoLamellaTaskState]] = {}
         for t in lamella.task_history:
-            seen[t.name] = t
-        completed_tasks = list(seen.values())
-        if not completed_tasks:
+            runs.setdefault(t.name, []).append(t)
+        if not runs:
             no_images = QLabel("No task images available.")
             no_images.setStyleSheet("color: #909090; font-size: 11px;")
             self._content_layout.addWidget(no_images)
@@ -330,16 +333,16 @@ class LamellaTaskImageWidget(QWidget):
 
         # Collect all filepaths to load and build placeholder rows
         all_filepaths: List[str] = []
-        for task in completed_tasks:
+        for task_name, task_runs in runs.items():
             # cap the reference images *before* appending fluorescence: the cap picks
             # the highest-magnification SEM/FIB pair out of a multi-FOV set, and
             # applying it to a merged list would let a z-stack displace the FIB image.
-            filenames = final_reference_images(lamella, task)[-_MAX_IMAGES_PER_TASK:]
-            filenames += fluorescence_images(lamella, task)
+            filenames = final_reference_images(lamella, *task_runs)[-_MAX_IMAGES_PER_TASK:]
+            filenames += fluorescence_images(lamella, *task_runs)
             # a task that produced nothing still gets a row saying so: silently
             # omitting it is indistinguishable from the task never having run,
             # which is the confusion this whole feature exists to remove.
-            row = self._build_task_row_with_placeholders(task.name, filenames)
+            row = self._build_task_row_with_placeholders(task_name, filenames)
             self._content_layout.addWidget(row)
             all_filepaths.extend(filenames)
 

--- a/fibsem/ui/widgets/tests/test_lamella_task_image_widget.py
+++ b/fibsem/ui/widgets/tests/test_lamella_task_image_widget.py
@@ -22,10 +22,11 @@ from PyQt5.QtWidgets import QApplication, QVBoxLayout, QWidget
 
 from fibsem.applications.autolamella.structures import Experiment, Lamella
 from fibsem.ui.stylesheets import NAPARI_STYLE
-from fibsem.ui.widgets.lamella_task_image_widget import (
-    LamellaTaskImageWidget,
+from fibsem.applications.autolamella.task_outputs import (
     final_reference_images,
+    fluorescence_images,
 )
+from fibsem.ui.widgets.lamella_task_image_widget import LamellaTaskImageWidget
 
 LOG_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
@@ -78,11 +79,19 @@ def _report(lamella: Lamella) -> None:
     seen = {t.name: t for t in lamella.task_history}
     for task in seen.values():
         recorded = any(task.outputs.get(role) for role in ("final_sem", "final_fib"))
-        found = final_reference_images(lamella, task)
+        reference = final_reference_images(lamella, task)
+        fluorescence = fluorescence_images(lamella, task)
         route = "recorded" if recorded else "convention"
-        print(f"  {task.name:<28} {route:<11} {len(found)} image(s)")
-        for path in found:
+        print(
+            f"  {task.name:<28} {route:<11} "
+            f"{len(reference)} reference, {len(fluorescence)} fluorescence"
+        )
+        for path in reference:
             print(f"      {os.path.basename(path)}")
+        for path in fluorescence:
+            print(f"      {os.path.basename(path)}  [z-stack]")
+        if not reference and not fluorescence:
+            print("      (nothing recorded — the panel shows an empty-state row)")
     if not seen:
         print("  no completed tasks")
 

--- a/tests/autolamella/test_task_outputs.py
+++ b/tests/autolamella/test_task_outputs.py
@@ -10,7 +10,10 @@ from pathlib import Path
 from typing import List
 
 from fibsem.applications.autolamella.structures import AutoLamellaTaskState, Lamella
-from fibsem.applications.autolamella.task_outputs import final_reference_images
+from fibsem.applications.autolamella.task_outputs import (
+    final_reference_images,
+    fluorescence_images,
+)
 
 CONVENTIONAL = [
     "ref_MillRough_final_res_01_eb.tif",
@@ -169,3 +172,60 @@ def test_a_record_of_only_deleted_images_with_nothing_on_disk_finds_nothing(tmp_
     )
 
     assert final_reference_images(lamella, task) == []
+
+
+# fluorescence_images
+
+
+def test_fluorescence_images_returns_recorded_stacks(tmp_path):
+    lamella = _lamella(tmp_path)
+    _write(lamella, ["01-lam-zstack-14-26-25.ome.tiff"])
+    task = AutoLamellaTaskState(
+        name="Acquire Fluorescence Image",
+        outputs={"fluorescence": ["01-lam-zstack-14-26-25.ome.tiff"]},
+    )
+
+    found = fluorescence_images(lamella, task)
+
+    assert found == [str(Path(lamella.path, "01-lam-zstack-14-26-25.ome.tiff"))]
+
+
+def test_fluorescence_has_no_filename_fallback(tmp_path):
+    """FM output never followed a discoverable convention — it carries the lamella
+    name and a time-of-day stamp, but no task name. An experiment written before
+    runs recorded their outputs has none to find, and guessing a pattern would
+    attribute files to the wrong run.
+    """
+    lamella = _lamella(tmp_path)
+    _write(lamella, ["01-lam-zstack-14-26-25.ome.tiff"])  # on disk, but unrecorded
+
+    assert fluorescence_images(lamella, AutoLamellaTaskState(name="Acquire")) == []
+
+
+def test_fluorescence_applies_the_same_guards_as_reference_images(tmp_path):
+    """MillCoincidentTask records under `fluorescence` too, so duplicates and
+    deleted files are live cases here, not hypothetical."""
+    lamella = _lamella(tmp_path)
+    _write(lamella, ["stack.ome.tiff"])
+    task = AutoLamellaTaskState(
+        name="Mill Coincident",
+        outputs={"fluorescence": ["stack.ome.tiff", "stack.ome.tiff", "gone.ome.tiff"]},
+    )
+
+    assert fluorescence_images(lamella, task) == [str(Path(lamella.path, "stack.ome.tiff"))]
+
+
+def test_reference_and_fluorescence_are_separate(tmp_path):
+    """Each reads only its own roles — a task with both must not cross-contaminate."""
+    lamella = _lamella(tmp_path)
+    _write(lamella, CONVENTIONAL + ["stack.ome.tiff"])
+    task = AutoLamellaTaskState(
+        name="MillRough",
+        outputs={
+            "final_sem": [CONVENTIONAL[0]],
+            "fluorescence": ["stack.ome.tiff"],
+        },
+    )
+
+    assert final_reference_images(lamella, task) == [str(Path(lamella.path, CONVENTIONAL[0]))]
+    assert fluorescence_images(lamella, task) == [str(Path(lamella.path, "stack.ome.tiff"))]

--- a/tests/autolamella/test_task_outputs.py
+++ b/tests/autolamella/test_task_outputs.py
@@ -229,3 +229,59 @@ def test_reference_and_fluorescence_are_separate(tmp_path):
 
     assert final_reference_images(lamella, task) == [str(Path(lamella.path, CONVENTIONAL[0]))]
     assert fluorescence_images(lamella, task) == [str(Path(lamella.path, "stack.ome.tiff"))]
+
+
+# accumulation across repeated runs of the same task
+
+
+def test_repeated_runs_accumulate_distinct_fluorescence_stacks(tmp_path):
+    """Each FM acquisition writes its own timestamped file, so re-running a task
+    adds an image rather than replacing one. Showing only the last run would
+    silently hide every earlier acquisition."""
+    lamella = _lamella(tmp_path)
+    _write(lamella, ["lam-zstack-10-00-00.ome.tiff", "lam-zstack-11-00-00.ome.tiff"])
+    first = AutoLamellaTaskState(name="Acquire", outputs={"fluorescence": ["lam-zstack-10-00-00.ome.tiff"]})
+    second = AutoLamellaTaskState(name="Acquire", outputs={"fluorescence": ["lam-zstack-11-00-00.ome.tiff"]})
+
+    found = fluorescence_images(lamella, first, second)
+
+    assert [os.path.basename(p) for p in found] == [
+        "lam-zstack-10-00-00.ome.tiff",
+        "lam-zstack-11-00-00.ome.tiff",
+    ]
+
+
+def test_repeated_runs_collapse_when_the_files_are_overwritten(tmp_path):
+    """Reference images are written to the same filename every run, so repeated runs
+    contribute the same paths and the union is one set — no branching on task type
+    needed to get that.
+
+    This pins the assumption the accumulation rests on. If reference filenames ever
+    become unique per run, this test fails and the review panel would start showing
+    every run's beam images: that should be an explicit decision, not a silent
+    consequence of a naming change elsewhere.
+    """
+    lamella = _lamella(tmp_path)
+    _write(lamella, CONVENTIONAL)
+    outputs = {"final_sem": CONVENTIONAL[:1], "final_fib": CONVENTIONAL[1:2]}
+    first = AutoLamellaTaskState(name="MillRough", outputs=dict(outputs))
+    second = AutoLamellaTaskState(name="MillRough", outputs=dict(outputs))
+
+    assert final_reference_images(lamella, first, second) == final_reference_images(lamella, first)
+
+
+def test_the_glob_fallback_yields_one_set_however_many_runs(tmp_path):
+    """Old experiments have no records, so the fallback globs the same files for
+    every run of a task. The result must be one set, not the same files repeated
+    per run — repeats would crowd out real images when callers slice off the last N.
+
+    (Globbing each *distinct* name once is an efficiency detail on top of this; the
+    deduplication is what makes the result correct.)
+    """
+    lamella = _lamella(tmp_path)
+    _write(lamella, CONVENTIONAL)
+    runs = [AutoLamellaTaskState(name="MillRough") for _ in range(3)]
+
+    found = final_reference_images(lamella, *runs)
+
+    assert [os.path.basename(p) for p in found] == CONVENTIONAL

--- a/tests/fm/test_composite.py
+++ b/tests/fm/test_composite.py
@@ -1,0 +1,136 @@
+"""Multi-channel fluorescence compositing.
+
+The module was written for the quad-view canvas on PR #111 and lifted to
+`fibsem/fm/` so it can be shared. It had no unit tests there — it lived under
+`fibsem/ui/`, which CI skips for lack of napari/PyQt5 — so these are new.
+"""
+
+import numpy as np
+import pytest
+
+from fibsem.fm.composite import FMLayer, auto_clim, composite_fm_layers, tint_rgb
+
+
+def _layer(color: str, shape=(4, 4), **kwargs) -> FMLayer:
+    """A channel with a real intensity ramp.
+
+    Constant data has no contrast for auto_clim to find, so it composites to
+    black — see test_a_flat_channel_renders_black. A ramp makes the brightest
+    pixel normalise to 1.0, which is what the tint assertions read.
+    """
+    data = np.linspace(0, 4095, num=int(np.prod(shape)), dtype=np.uint16).reshape(shape)
+    return FMLayer(name=color, data=data, color=color, **kwargs)
+
+
+# tint_rgb
+
+
+def test_canonical_colours_use_napari_endpoints_not_matplotlib():
+    """The composite has to match what the napari main tab shows.
+
+    'green' is the case that actually differs: matplotlib's named green is
+    (0, 0.5, 0), while napari's green colormap ramps to full (0, 1, 0).
+    """
+    assert tint_rgb("green") == (0.0, 1.0, 0.0)
+    assert tint_rgb("red") == (1.0, 0.0, 0.0)
+
+
+def test_gray_ramps_to_white():
+    """A 'gray' channel is full-intensity white, not mid-grey — fibsemOS-acquired
+    stacks label a channel 'gray' and it must not render at half brightness."""
+    assert tint_rgb("gray") == (1.0, 1.0, 1.0)
+
+
+def test_hex_colours_fall_through_to_matplotlib():
+    """METEOR-acquired stacks carry hex channel colours rather than names."""
+    assert tint_rgb("#FF0000") == pytest.approx((1.0, 0.0, 0.0))
+    assert tint_rgb("#04FF00") == pytest.approx((4 / 255, 1.0, 0.0), abs=1e-6)
+
+
+def test_an_unrecognised_colour_falls_back_to_white():
+    """A channel with a junk colour must still be visible, not invisible."""
+    assert tint_rgb("not-a-colour") == (1.0, 1.0, 1.0)
+    assert tint_rgb(None) == (1.0, 1.0, 1.0)
+
+
+# auto_clim
+
+
+def test_auto_clim_brackets_the_data():
+    data = np.arange(10_000, dtype=np.uint16).reshape(100, 100)
+    lo, hi = auto_clim(data)
+    assert lo < hi
+    assert 0 <= lo and hi <= 9_999
+
+
+def test_auto_clim_never_returns_a_degenerate_range():
+    """A flat channel would otherwise divide by zero when normalising."""
+    lo, hi = auto_clim(np.full((8, 8), 42, dtype=np.uint16))
+    assert hi > lo
+
+
+# composite_fm_layers
+
+
+def test_returns_uint8_rgb():
+    out = composite_fm_layers([_layer("red")])
+    assert out.dtype == np.uint8
+    assert out.shape == (4, 4, 3)
+
+
+def test_a_single_channel_is_tinted_by_its_colour():
+    out = composite_fm_layers([_layer("red")])
+    assert out[..., 0].max() == 255
+    assert out[..., 1].max() == 0
+    assert out[..., 2].max() == 0
+
+
+def test_channels_blend_additively():
+    """Red plus green reads yellow — the point of compositing rather than
+    showing one channel at a time."""
+    out = composite_fm_layers([_layer("red"), _layer("green")])
+    brightest = np.unravel_index(out.sum(axis=2).argmax(), out.shape[:2])
+    assert out[brightest][0] == 255
+    assert out[brightest][1] == 255
+    assert out[brightest][2] == 0
+
+
+def test_a_flat_channel_renders_black():
+    """Documented, not a bug: auto-contrast has no range to stretch in constant
+    data, so a uniformly-bright channel composites to black. Worth knowing before
+    someone reports a blank image on a saturated acquisition.
+    """
+    flat = FMLayer(
+        name="flat", data=np.full((4, 4), 500, dtype=np.uint16), color="red"
+    )
+    assert composite_fm_layers([flat]).max() == 0
+
+
+def test_an_invisible_channel_contributes_nothing():
+    both = composite_fm_layers([_layer("red"), _layer("green", visible=False)])
+    red_only = composite_fm_layers([_layer("red")])
+    np.testing.assert_array_equal(both, red_only)
+
+
+def test_a_mismatched_channel_is_ignored_rather_than_raising():
+    """Channels of differing size would otherwise break the whole composite."""
+    out = composite_fm_layers([_layer("red"), _layer("green", shape=(8, 8))])
+    assert out.shape == (4, 4, 3)
+    assert out[..., 1].max() == 0
+
+
+def test_opacity_scales_a_channels_contribution():
+    full = composite_fm_layers([_layer("red")])
+    half = composite_fm_layers([_layer("red", opacity=0.5)])
+    assert half[..., 0].max() < full[..., 0].max()
+
+
+def test_nothing_visible_returns_zeros_for_a_known_shape():
+    out = composite_fm_layers([_layer("red", visible=False)], shape=(4, 4))
+    assert out.shape == (4, 4, 3)
+    assert out.max() == 0
+
+
+def test_nothing_visible_and_no_shape_returns_none():
+    """There is no sensible image to show, and guessing a size would be worse."""
+    assert composite_fm_layers([]) is None

--- a/tests/fm/test_preview.py
+++ b/tests/fm/test_preview.py
@@ -1,0 +1,133 @@
+"""Projecting a fluorescence z-stack to one displayable RGB image."""
+
+import numpy as np
+import pytest
+
+from fibsem.fm.preview import is_fluorescence_image, load_projection
+from fibsem.fm.structures import (
+    FluorescenceChannelMetadata,
+    FluorescenceImage,
+    FluorescenceImageMetadata,
+)
+
+
+def _channel(name: str, color: str) -> FluorescenceChannelMetadata:
+    return FluorescenceChannelMetadata(
+        name=name,
+        excitation_wavelength=488.0,
+        power=0.5,
+        exposure_time=0.1,
+        gain=1.0,
+        offset=0.0,
+        color=color,
+    )
+
+
+def _stack(data: np.ndarray, colors, pixel_size: float = 1e-7) -> FluorescenceImage:
+    """A (C, Z, Y, X) stack with one metadata channel per given colour."""
+    metadata = FluorescenceImageMetadata(
+        acquisition_date="2026-01-01T00:00:00",
+        pixel_size_x=pixel_size,
+        pixel_size_y=pixel_size,
+        resolution=(data.shape[3], data.shape[2]),
+        channels=[_channel(f"Channel-{i:02d}", c) for i, c in enumerate(colors)],
+    )
+    return FluorescenceImage(data=data, metadata=metadata)
+
+
+@pytest.fixture
+def stack_on_disk(monkeypatch):
+    """Hand a prepared FluorescenceImage to load_projection as if read from disk.
+
+    Deliberately does not go through save()/load(). Those transpose C and Z for
+    most real shapes (FIB-279), so a fixture built that way would test the
+    serialiser's bug rather than this module's contract, which is: given what load
+    returns, project over z and composite.
+    """
+
+    def _install(image: FluorescenceImage) -> str:
+        monkeypatch.setattr(
+            "fibsem.fm.preview.FluorescenceImage.load",
+            staticmethod(lambda _path: image),
+        )
+        return "stack.ome.tiff"
+
+    return _install
+
+
+# is_fluorescence_image
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("a.ome.tiff", True),
+        ("a.ome.tif", True),
+        ("A.OME.TIFF", True),
+        ("ref_MillRough_final_res_01_eb.tif", False),
+        ("a.png", False),
+    ],
+)
+def test_recognises_fluorescence_by_extension(name, expected):
+    assert is_fluorescence_image(name) is expected
+
+
+# load_projection
+
+
+def test_projects_over_z_not_over_channels(stack_on_disk):
+    """The single most consequential axis choice here.
+
+    Projecting axis 0 instead of axis 1 would collapse the *channels* and leave the
+    z-slices to be treated as channels — the image would still render, plausibly,
+    and be completely wrong. Channel 0 is bright in one z-slice only; channel 1 is
+    dark everywhere. A correct z-projection is red; collapsing channels is not.
+    """
+    data = np.zeros((2, 3, 8, 8), dtype=np.uint16)
+    data[0, 1] = np.linspace(0, 4095, 64, dtype=np.uint16).reshape(8, 8)
+    path = stack_on_disk(_stack(data, ["red", "green"]))
+
+    rgb, _ = load_projection(path)
+
+    assert rgb.shape == (8, 8, 3)
+    assert rgb[..., 0].max() == 255  # red channel survived the projection
+    assert rgb[..., 1].max() == 0    # the dark channel contributes nothing
+
+
+def test_returns_uint8_rgb_and_the_pixel_size(stack_on_disk):
+    data = np.zeros((1, 2, 8, 8), dtype=np.uint16)
+    data[0, 0] = np.linspace(0, 4095, 64, dtype=np.uint16).reshape(8, 8)
+    path = stack_on_disk(_stack(data, ["red"], pixel_size=1.3e-7))
+
+    rgb, pixel_size = load_projection(path)
+
+    assert rgb.dtype == np.uint8
+    assert rgb.ndim == 3 and rgb.shape[2] == 3
+    assert pixel_size == pytest.approx(1.3e-7)
+
+
+def test_a_channel_missing_from_metadata_is_still_shown(stack_on_disk):
+    """Metadata should describe every plane, but a plane must never vanish because
+    it doesn't — an unnamed channel is better than a silently missing one."""
+    ramp = np.linspace(0, 4095, 64, dtype=np.uint16).reshape(8, 8)
+    data = np.zeros((2, 2, 8, 8), dtype=np.uint16)
+    data[0, 0] = ramp
+    data[1, 0] = ramp
+
+    image = _stack(data, ["red"])           # metadata describes one of two planes
+    rgb, _ = load_projection(stack_on_disk(image))
+
+    assert rgb[..., 0].max() == 255          # the described channel is red
+    assert rgb.sum(axis=2).max() > 255       # the undescribed one still contributes
+
+
+def test_a_stack_with_no_channels_raises(stack_on_disk):
+    """Better a clear error the loader logs than a blank tile with no explanation.
+
+    Built with data that has no planes rather than metadata with no channels —
+    FluorescenceImageMetadata rejects the latter outright.
+    """
+    image = _stack(np.zeros((0, 1, 8, 8), dtype=np.uint16), ["red"])
+
+    with pytest.raises(ValueError, match="no displayable channels"):
+        load_projection(stack_on_disk(image))

--- a/tests/ui/test_task_row_layout.py
+++ b/tests/ui/test_task_row_layout.py
@@ -1,0 +1,144 @@
+"""Task rows wrap rather than running off the edge of the review panel.
+
+Needs Qt, so it skips in CI like everything else under tests/ui — the layout
+behaviour it guards can't be observed without a real layout.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+pytest.importorskip("napari")
+
+from PyQt5.QtWidgets import QApplication, QGridLayout
+
+from fibsem.ui.widgets.lamella_task_image_widget import (
+    _IMAGES_PER_LINE,
+    LamellaTaskImageWidget,
+)
+
+
+@pytest.fixture(scope="module")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+def _lines_and_columns(widget, count):
+    row = widget._build_task_row_with_placeholders(
+        "Task", [f"/tmp/image-{i}.tif" for i in range(count)]
+    )
+    grid = row.findChildren(QGridLayout)[0]
+    occupied = [
+        grid.getItemPosition(i)[:2] for i in range(grid.count())
+    ]  # (row, column)
+    return occupied
+
+
+@pytest.mark.parametrize("count", [1, 2, 3, 4, 5])
+def test_no_line_holds_more_than_the_wrap_width(app, count):
+    """The panel scrolls vertically only, so a tile past the width is unreachable.
+
+    Before fluorescence images a task had at most the SEM/FIB pair and always fitted;
+    a task can now also carry a z-stack, which is what made this reachable.
+    """
+    widget = LamellaTaskImageWidget()
+    occupied = _lines_and_columns(widget, count)
+
+    per_line = {}
+    for row, column in occupied:
+        per_line.setdefault(row, []).append(column)
+
+    assert len(occupied) == count, "every image must get a tile"
+    assert all(len(cols) <= _IMAGES_PER_LINE for cols in per_line.values())
+    assert max(c for _, c in occupied) < _IMAGES_PER_LINE
+
+
+def test_the_common_pair_still_fits_on_one_line(app):
+    """The SEM/FIB pair is the overwhelmingly common case and must not start
+    wrapping — that would be a visible regression for every existing experiment."""
+    assert len({row for row, _ in _lines_and_columns(LamellaTaskImageWidget(), 2)}) == 1
+
+
+def test_a_task_with_three_images_wraps_onto_two_lines(app):
+    """SEM + FIB + fluorescence: the case that motivated wrapping."""
+    assert len({row for row, _ in _lines_and_columns(LamellaTaskImageWidget(), 3)}) == 2
+
+
+# tile sizing
+
+
+def _render(tmp_path, resolution):
+    """Save an image at the given resolution and return its rendered tile size.
+
+    Built with full metadata rather than via generate_blank_image: that one carries
+    no microscope_state, which from_dict requires, so its metadata does not survive
+    the tif round-trip and the loader has no pixel size to read.
+    """
+    import numpy as np
+
+    from fibsem.structures import (
+        FibsemImage,
+        FibsemImageMetadata,
+        ImageSettings,
+        MicroscopeState,
+        Point,
+    )
+    from fibsem.ui.widgets.lamella_task_image_widget import _load_and_resize
+
+    width, height = resolution
+    metadata = FibsemImageMetadata(
+        image_settings=ImageSettings(resolution=resolution),
+        pixel_size=Point(1e-7, 1e-7),
+        microscope_state=MicroscopeState(),
+    )
+    image = FibsemImage(data=np.zeros((height, width), dtype=np.uint8), metadata=metadata)
+    path = image.save(str(tmp_path / f"ref_{width}x{height}.tif"))
+
+    arr, _ = _load_and_resize(path)
+    h, w = arr.shape[:2]
+    return w, h
+
+
+@pytest.mark.parametrize("resolution", [(1536, 1024), (1024, 1024), (2048, 2048), (512, 1024)])
+def test_every_tile_fits_the_placeholder_box(app, tmp_path, resolution):
+    """A tile must never exceed the placeholder it replaces.
+
+    Beam images are 3:2 and are width-limited, so filling the width was fine. A
+    fluorescence stack is square: scaled to the full width it is half again as tall
+    as its neighbours and taller than its own placeholder, so the row jumps when it
+    loads and everything below shifts.
+    """
+    from fibsem.ui.widgets.lamella_task_image_widget import (
+        _PLACEHOLDER_HEIGHT,
+        _TARGET_WIDTH,
+    )
+
+    w, h = _render(tmp_path, resolution)
+
+    assert w <= _TARGET_WIDTH
+    assert h <= _PLACEHOLDER_HEIGHT
+
+
+def test_a_three_by_two_image_still_fills_the_width(app, tmp_path):
+    """The common beam-image case must be untouched — it was already width-limited,
+    and shrinking it would be a visible regression on every existing experiment."""
+    from fibsem.ui.widgets.lamella_task_image_widget import _TARGET_WIDTH
+
+    assert _render(tmp_path, (1536, 1024))[0] == _TARGET_WIDTH
+
+
+def test_a_square_image_is_limited_by_height_not_width(app, tmp_path):
+    """A square stack fits the box by its height, leaving it narrower than a beam
+    image rather than taller."""
+    from fibsem.ui.widgets.lamella_task_image_widget import (
+        _PLACEHOLDER_HEIGHT,
+        _TARGET_WIDTH,
+    )
+
+    w, h = _render(tmp_path, (2048, 2048))
+
+    assert h == _PLACEHOLDER_HEIGHT
+    assert w < _TARGET_WIDTH


### PR DESCRIPTION
A completed **Acquire Fluorescence Image** task rendered as *no row at all* — it looked like the task never ran. FIB-324 made those runs record their z-stack; this displays it.

Closes FIB-169.

## What it does

The panel's loader was `FibsemImage.load` plus a greyscale resize, and an FM acquisition is a multi-channel z-stack. It now dispatches on `.ome.tif*`, max-projects each channel over z, tints each by its channel colour and blends additively — the same composite the FM canvas shows, so a stack looks the same in review as it did live.

## The composite comes from PR #111

`fibsem/fm/composite.py` is #111's `fm_composite.py`, lifted **verbatim** (only the docstring differs). It's Qt-free, and its home under `fibsem/ui/` meant CI could never import it — so it had no unit tests. It has 15 now, including that `gray` ramps to white and that `green` uses napari's `(0,1,0)` rather than matplotlib's `(0,0.5,0)`.

> **When #111 lands**, its copy should become a one-line re-export of `fibsem.fm.composite` rather than a second implementation. Main has no `canvas/` package so #111 merges cleanly — which means the duplicate is silent unless someone acts. Its four importers need no change.

## Cost

Measured on a real METEOR stack, `(3, 21, 2048, 2048)` uint16, 348 MB on disk:

| | |
| --- | --- |
| `FluorescenceImage.load` | 0.76 s, 528 MB array |
| per-channel MIP | 0.03 s → 25 MB |

The volume is released before compositing — a 21× reduction — since the panel may load several in a row.

## Discovery

`fluorescence_images()` mirrors the reference-image path but has **no filename fallback**: FM output never followed a discoverable convention (lamella name + time-of-day stamp, no task name), so an experiment written before FIB-324 has none to find, and guessing a pattern would attribute files to the wrong run. It shares the dedupe and existence guards, which matter here because `MillCoincidentTask` records under this role too.

## Two problems found testing in the application

Neither came from tests — both from running the real app.

**Tiles were scaled to fill the tile width.** Beam images are 3:2 and so were width-limited, but a stack is square: it rendered 512×512 against a 384-tall placeholder — half again the height of its neighbours — and the row jumped 128 px when the image finished loading.

| | before | after |
| --- | --- | --- |
| SEM/FIB (3:2) | 512 × 341 | 512 × 341 — unchanged |
| FM (1:1) | 512 × 512 | **384 × 384** |

**Rows laid tiles out on one line** at fixed width, and the panel scrolls vertically only, so a third tile was unreachable. Rows now wrap at 2 per line. To be clear about scope: **no task in use produces three images** — only `MillCoincidentTask` could, and it isn't in use — so this is defensive layout, not a fix for something users hit.

Also, a task that produced nothing now says so rather than being omitted: an absent row is indistinguishable from a task that never ran, which is the confusion this whole feature exists to remove.

## Every run of a task, not just the last

The panel collapsed history by name and kept the last entry, so re-running an acquisition *replaced* the previous one in the display. For fluorescence — where each run writes its own timestamped file — that silently hid every earlier acquisition.

Discovery now takes any number of runs and returns the **union** of what they produced. One rule, no branching on task or file type:

| | filenames | result |
| --- | --- | --- |
| reference images | same every run (overwritten) | repeated runs contribute identical paths → collapses to one set |
| fluorescence | uniquely timestamped | each run contributes its own → all kept |

Measured on the local experiments: **37 rows before, 37 rows after** — every repeated task there (`Setup Lamella Position`, `Spot Burn Fiducial`) records byte-identical file sets, so nothing about existing experiments changes.

The row stays *the task* rather than *a run*, so labels need no timestamp to disambiguate. Only the fluorescence count is unbounded; reference images are still capped to the highest-magnification pair.

**The collapse is an assumption about naming, not intent**, so a test pins it. If reference filenames ever become unique per run, that test fails — and the panel showing every run's beam images becomes an explicit decision rather than a silent consequence of a change elsewhere.

## Testing

29 new tests. Projection, compositing and discovery live outside `fibsem/ui/` so **CI runs them**; only the Qt layout tests are skipped there.

Mutation-verified **11/11**, including the over-corrections — beam images also shrinking, every tile getting its own line, the existence filter dropping live files.

Verified visually against two real stacks: the METEOR file (3 channels, hex colours, OME-fallback metadata) and a fibsemOS-acquired one (2 channels, named colours). Both composite correctly, and the second's near-white appearance is the simulator's test pattern, not a blend fault.

Full suite: **1042 passed, 7 skipped**.

## Known, not addressed

- **FIB-279.** Where `FluorescenceImage.load` transposes C and Z, this panel will project over *channels* and show something wrong-but-plausible. That's the serialiser's defect; fixing it here would be fixing it under cover of a display change. The tests deliberately bypass `save()` with a comment saying why. I added a sharper repro to FIB-279 — a synthetic, warning-free reproduction exists, which that issue currently says it doesn't.
- **Expanding an FM tile re-reads the full stack**, because the expanded view is 2× the cached tile's width. Correct, but the slowest interaction here; caching the projection would avoid it.
