### PR TITLE
Move the stage from a fluorescence image with fm_stable_move (FIB-133)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -390,7 +390,9 @@ def acquire_tileset(
         channel_settings: Single channel or list of channels to acquire
         overview_parameters: Overview parameters containing grid size, overlap, autofocus mode
         zparams: Optional Z parameters for z-stack acquisition (overrides overview_parameters.use_zstack)
-        beam_type: Beam type to use for stage movements (default: ELECTRON)
+        beam_type: Unused for stage movement. Tiles are stepped with fm_stable_move,
+            which projects through the camera's own axis tilt; kept for signature
+            compatibility with callers that still pass it.
         autofocus_settings: Optional AutoFocusSettings for autofocus configuration
         save_directory: Optional directory path to save individual tile images (default: None)
         stop_event: Threading event to signal cancellation (optional)
@@ -500,12 +502,11 @@ def acquire_tileset(
         "task": "tileset",
     })
 
-    # QUERY: How we need to change direction of movements if in SEM orientation?
-    # if orientation == "SEM":
-        # start_offset_y *= -1  # invert y offset in SEM orientation
-        # step_y *= -1  # invert y step in SEM orientation
-
-    microscope.stable_move(dx=start_offset_x, dy=start_offset_y, beam_type=beam_type)
+    # Steps are expressed in the fluorescence image, so they are projected through the
+    # camera's own axis tilt rather than a beam's. Stepping with beam_type=ELECTRON
+    # used the SEM projection, which foreshortens differently from the camera on an
+    # offset mount and so mis-scaled the y pitch between tiles.
+    microscope.fm_stable_move(dx=start_offset_x, dy=start_offset_y)
 
     # Initialize results array
     tileset = []
@@ -532,6 +533,10 @@ def acquire_tileset(
     })
 
     # TODO: migrate to generate_grid_positions
+    # NOTE: when migrating, the position conversion must use the same projection the
+    # movement does. convert_grid_positions_to_stage_positions still goes through
+    # project_stable_move(beam_type=...), which would disagree with fm_stable_move on
+    # an offset mount. It has no callers today, so the two cannot drift apart yet.
     try:
         for row in range(rows):
             # Check for cancellation before each row
@@ -636,7 +641,7 @@ def acquire_tileset(
                     "state": "moving",
                     "task": "tileset",
                     })
-                    microscope.stable_move(dx=step_x, dy=0, beam_type=beam_type)
+                    microscope.fm_stable_move(dx=step_x, dy=0)
 
             tileset.append(row_images)
 
@@ -647,9 +652,7 @@ def acquire_tileset(
                     "task": "tileset",
                 })
                 # Return to first column of next row
-                microscope.stable_move(
-                    dx=-(cols - 1) * step_x, dy=step_y, beam_type=beam_type
-                )
+                microscope.fm_stable_move(dx=-(cols - 1) * step_x, dy=step_y)
 
         # save the parameters in a metadata json file if save_directory is provided
         if save_directory is not None:
@@ -881,7 +884,9 @@ def acquire_and_stitch_tileset(
         channel_settings: Single channel or list of channels to acquire
         overview_parameters: Overview parameters containing grid size, overlap, autofocus mode
         zparams: Optional Z parameters for z-stack acquisition (overrides overview_parameters.use_zstack)
-        beam_type: Beam type to use for stage movements (default: ELECTRON)
+        beam_type: Unused for stage movement. Tiles are stepped with fm_stable_move,
+            which projects through the camera's own axis tilt; kept for signature
+            compatibility with callers that still pass it.
         autofocus_settings: Optional AutoFocusSettings for autofocus configuration
         save_directory: Optional directory path to save individual tile images (default: None)
         stop_event: Optional threading event to signal cancellation
@@ -966,7 +971,9 @@ def acquire_multiple_overviews(
         channel_settings: Single channel or list of channels to acquire
         overview_parameters: Overview parameters containing grid size, overlap, autofocus mode
         zparams: Optional Z parameters for z-stack acquisition (overrides overview_parameters.use_zstack)
-        beam_type: Beam type to use for stage movements (default: ELECTRON)
+        beam_type: Unused for stage movement. Tiles are stepped with fm_stable_move,
+            which projects through the camera's own axis tilt; kept for signature
+            compatibility with callers that still pass it.
         autofocus_settings: Optional AutoFocusSettings for autofocus configuration
         save_directory: Optional directory path to save overview images. Creates subdirectories
                        for each position (default: None)

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -766,7 +766,6 @@ class FluorescenceMicroscope(ABC):
                 - CameraImageTransform.FLIP_X: Horizontal flip
                 - CameraImageTransform.FLIP_Y: Vertical flip
                 - CameraImageTransform.FLIP_XY: Both flips (equivalent to a 180° rotation)
-                - CameraImageTransform.ROTATE_180: Same as FLIP_XY
 
             Rotations are not offered here: a fixed rotation between the sensor and
             the stage describes the mount, and is corrected by `mount_transform`
@@ -831,10 +830,7 @@ class FluorescenceMicroscope(ABC):
             return np.fliplr(data)
         elif transform is CameraImageTransform.FLIP_Y:
             return np.flipud(data)
-        elif transform in (
-            CameraImageTransform.FLIP_XY,
-            CameraImageTransform.ROTATE_180,
-        ):
+        elif transform is CameraImageTransform.FLIP_XY:
             return np.fliplr(np.flipud(data))  # a half turn is both flips
         else:
             return data

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -765,10 +765,12 @@ class FluorescenceMicroscope(ABC):
                 - CameraImageTransform.NONE or None: No transformation
                 - CameraImageTransform.FLIP_X: Horizontal flip
                 - CameraImageTransform.FLIP_Y: Vertical flip
-                - CameraImageTransform.FLIP_XY: Both horizontal and vertical flip (equivalent to 180° rotation)
-                - CameraImageTransform.ROTATE_90_CW: Rotate 90° clockwise
-                - CameraImageTransform.ROTATE_90_CCW: Rotate 90° counter-clockwise
-                - CameraImageTransform.ROTATE_180: Rotate 180°
+                - CameraImageTransform.FLIP_XY: Both flips (equivalent to a 180° rotation)
+                - CameraImageTransform.ROTATE_180: Same as FLIP_XY
+
+            Rotations are not offered here: a fixed rotation between the sensor and
+            the stage describes the mount, and is corrected by `mount_transform`
+            inside the driver before this preference is applied.
 
         Raises:
             ValueError: If transform is not a valid CameraImageTransform enum value
@@ -796,7 +798,8 @@ class FluorescenceMicroscope(ABC):
         - **Offset mounts (METEOR, iFLM)** sit parallel to the FIB column, displaced
           along x, so they share the ion column's tilt.
 
-        Drivers override if a system disagrees.
+        Drivers override if a system disagrees. This needs to become configurable for
+        systems whose mount is neither of the two known cases -- see FIB-335.
         """
         if self.parent is None:
             return 0.0  # simulator without a parent microscope
@@ -828,14 +831,11 @@ class FluorescenceMicroscope(ABC):
             return np.fliplr(data)
         elif transform is CameraImageTransform.FLIP_Y:
             return np.flipud(data)
-        elif transform is CameraImageTransform.FLIP_XY:
-            return np.fliplr(np.flipud(data))
-        elif transform is CameraImageTransform.ROTATE_90_CW:
-            return np.rot90(data, k=-1)  # k=-1 for clockwise
-        elif transform is CameraImageTransform.ROTATE_90_CCW:
-            return np.rot90(data, k=1)  # k=1 for counter-clockwise
-        elif transform is CameraImageTransform.ROTATE_180:
-            return np.rot90(data, k=2)  # k=2 for 180 degrees
+        elif transform in (
+            CameraImageTransform.FLIP_XY,
+            CameraImageTransform.ROTATE_180,
+        ):
+            return np.fliplr(np.flipud(data))  # a half turn is both flips
         else:
             return data
 

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -60,15 +60,62 @@ from fibsem.autofunctions.autofocus import (  # noqa: E402,F401
 
 
 class CameraImageTransform(Enum):
-    """Image transformations for aligning fluorescence images with SEM/FIB coordinate systems."""
+    """Image transformations for aligning fluorescence images with SEM/FIB coordinate systems.
+
+    Flips only. Any fixed rotation between the sensor and the stage belongs to the
+    mount, not to user preference, and is corrected inside the driver
+    (``FluorescenceMicroscope.mount_transform``) before this is applied.
+
+    Restricting the set to flips makes it the Klein four-group: every member is its
+    own inverse and composition is order-independent, so mapping a displacement
+    between the displayed image and the stage is two sign flips with no axis swap
+    and no inverse to get backwards. Flips also preserve the array shape, so the
+    image and its geometry metadata always describe the same frame.
+    """
 
     NONE = None
     FLIP_X = "flip-x"
     FLIP_Y = "flip-y"
     FLIP_XY = "flip-xy"
-    ROTATE_90_CW = "rotate-90-cw"
-    ROTATE_90_CCW = "rotate-90-ccw"
-    ROTATE_180 = "rotate-180"
+    ROTATE_180 = "rotate-180"  # identical to FLIP_XY; retained for stored configs
+
+    def apply_to_delta(self, dx: float, dy: float) -> Tuple[float, float]:
+        """Map a displacement between the raw and displayed frames.
+
+        Every member is its own inverse, so this maps in both directions: use it to
+        take a delta measured in the displayed image back to the underlying frame,
+        and vice versa.
+        """
+        flip_x = self in (
+            CameraImageTransform.FLIP_X,
+            CameraImageTransform.FLIP_XY,
+            CameraImageTransform.ROTATE_180,
+        )
+        flip_y = self in (
+            CameraImageTransform.FLIP_Y,
+            CameraImageTransform.FLIP_XY,
+            CameraImageTransform.ROTATE_180,
+        )
+        return (-dx if flip_x else dx, -dy if flip_y else dy)
+
+
+def _parse_image_transform(value: Any) -> CameraImageTransform:
+    """Read a stored transform, tolerating values that are no longer supported.
+
+    The 90-degree rotations were removed once mount rotation moved into the driver.
+    A configuration written before that must still load, so an unrecognised value
+    falls back to no transform with a warning rather than raising.
+    """
+    if value is None:
+        return CameraImageTransform.NONE
+    try:
+        return CameraImageTransform(value)
+    except ValueError:
+        logging.warning(
+            f"Unsupported camera image transform {value!r}; falling back to none. "
+            "Rotations are now applied as a fixed mount correction inside the driver."
+        )
+        return CameraImageTransform.NONE
 
 
 class ZStackOrder(Enum):
@@ -1540,7 +1587,7 @@ class CameraSettings:
             gain=ddict.get("gain", 1.0),
             offset=ddict.get("offset", 0.0),
             binning=ddict.get("binning", 1),
-            transform=CameraImageTransform(ddict.get("transform", CameraImageTransform.NONE.value)),
+            transform=_parse_image_transform(ddict.get("transform")),
         )
 
 

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -77,7 +77,6 @@ class CameraImageTransform(Enum):
     FLIP_X = "flip-x"
     FLIP_Y = "flip-y"
     FLIP_XY = "flip-xy"
-    ROTATE_180 = "rotate-180"  # identical to FLIP_XY; retained for stored configs
 
     def apply_to_delta(self, dx: float, dy: float) -> Tuple[float, float]:
         """Map a displacement between the raw and displayed frames.
@@ -86,36 +85,44 @@ class CameraImageTransform(Enum):
         take a delta measured in the displayed image back to the underlying frame,
         and vice versa.
         """
-        flip_x = self in (
-            CameraImageTransform.FLIP_X,
-            CameraImageTransform.FLIP_XY,
-            CameraImageTransform.ROTATE_180,
-        )
-        flip_y = self in (
-            CameraImageTransform.FLIP_Y,
-            CameraImageTransform.FLIP_XY,
-            CameraImageTransform.ROTATE_180,
-        )
+        flip_x = self in (CameraImageTransform.FLIP_X, CameraImageTransform.FLIP_XY)
+        flip_y = self in (CameraImageTransform.FLIP_Y, CameraImageTransform.FLIP_XY)
         return (-dx if flip_x else dx, -dy if flip_y else dy)
 
 
-def _parse_image_transform(value: Any) -> CameraImageTransform:
-    """Read a stored transform, tolerating values that are no longer supported.
+# Transforms that stored configurations may still hold. A half turn is the same
+# element as flipping both axes, so it maps across without losing the setting; the
+# quarter turns describe a mount, which the driver now corrects, and have no
+# equivalent here.
+_LEGACY_IMAGE_TRANSFORMS = {"rotate-180": CameraImageTransform.FLIP_XY}
 
-    The 90-degree rotations were removed once mount rotation moved into the driver.
-    A configuration written before that must still load, so an unrecognised value
-    falls back to no transform with a warning rather than raising.
+
+def _parse_image_transform(value: Any) -> CameraImageTransform:
+    """Read a stored transform, tolerating values that are no longer members.
+
+    Rotations were removed once mount rotation moved into the driver. A half turn is
+    migrated to the equivalent flip so the setting survives; anything else falls back
+    to no transform with a warning rather than raising.
     """
     if value is None:
         return CameraImageTransform.NONE
     try:
         return CameraImageTransform(value)
     except ValueError:
-        logging.warning(
-            f"Unsupported camera image transform {value!r}; falling back to none. "
-            "Rotations are now applied as a fixed mount correction inside the driver."
+        pass
+
+    migrated = _LEGACY_IMAGE_TRANSFORMS.get(value)
+    if migrated is not None:
+        logging.info(
+            f"Camera image transform {value!r} is now {migrated.value!r}; migrated."
         )
-        return CameraImageTransform.NONE
+        return migrated
+
+    logging.warning(
+        f"Unsupported camera image transform {value!r}; falling back to none. "
+        "Rotations are now applied as a fixed mount correction inside the driver."
+    )
+    return CameraImageTransform.NONE
 
 
 class ZStackOrder(Enum):

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1491,6 +1491,69 @@ class FibsemMicroscope(ABC):
 
         return expected_y
 
+    def _fm_image_to_stage_delta(self, dx: float, dy: float) -> Tuple[float, float]:
+        """Map a displacement in the displayed FM image onto stage axes.
+
+        The driver hands out stage-aligned images -- any fixed rotation or flip of the
+        mount is corrected by `FluorescenceMicroscope.mount_transform` before the
+        user's display preference is applied -- so undoing that preference is all
+        that is needed here. It is read live rather than from configuration, since
+        the user can change it mid-session, and every remaining transform is its own
+        inverse, so applying it maps in both directions.
+        """
+        if self.fm is None:
+            return dx, dy
+        return self.fm._transform.apply_to_delta(dx, dy)
+
+    def fm_stable_move(self, dx: float, dy: float) -> FibsemStagePosition:
+        """Move the stage by a displacement seen in the fluorescence image.
+
+        The fluorescence counterpart of :meth:`stable_move`: click a point in the FM
+        view and the stage goes there, holding the focal plane. The projection is the
+        same one the beams use, with the camera's own axis tilt
+        (`FluorescenceMicroscope.camera_tilt`) in place of a column tilt, so the
+        foreshortening of a tilted sample is accounted for and the movement stays in
+        the sample plane -- which is what keeps the objective in focus.
+
+        Args:
+            dx: distance along the x-axis (image coordinates), as for stable_move.
+            dy: distance along the y-axis (image coordinates), as for stable_move.
+
+        Returns:
+            FibsemStagePosition: the stage position after the move.
+
+        Raises:
+            ValueError: if no fluorescence microscope is available.
+        """
+        if self.fm is None:
+            raise ValueError("Fluorescence microscope is not available. Cannot move.")
+
+        if self.fm.objective.state != "Inserted":
+            logging.warning(
+                "Moving via the fluorescence image while the objective is not inserted "
+                f"(state: {self.fm.objective.state}); the view may not match the sample."
+            )
+
+        dx, dy = self._fm_image_to_stage_delta(dx, dy)
+
+        yz_move = self._view_corrected_stage_movement(
+            expected_y=dy,
+            view_tilt=np.deg2rad(self.fm.camera_tilt),
+        )
+        stage_position = FibsemStagePosition(
+            x=dx, y=yz_move.y, z=yz_move.z, r=0, t=0, coordinate_system="RAW"
+        )
+
+        # NOTE: no working-distance restore. That is beam bookkeeping; the objective
+        # keeps focus because the move stays in the sample plane.
+        self.move_stage_relative(stage_position)
+
+        logging.debug({"msg": "fm_stable_move", "dx": dx, "dy": dy,
+                       "camera_tilt": self.fm.camera_tilt,
+                       "position": stage_position.to_dict()})
+
+        return self.get_stage_position()
+
     def move_to_device(self, device: str) -> None:
         """Move the stage to the predefined device position."""
         logging.warning(f"move_to_device is not implemented for {self.__class__.__name__}.")

--- a/fibsem/ui/fm/widgets/camera_widget.py
+++ b/fibsem/ui/fm/widgets/camera_widget.py
@@ -36,15 +36,14 @@ CAMERA_CONFIG = {
     },
 }
 
-# Mapping for transform display names
+# Mapping for transform display names.
+# Rotations are not offered: a fixed rotation between sensor and stage is a property
+# of how the camera is mounted, and is corrected inside the driver before this runs.
 TRANSFORM_DISPLAY_NAMES = {
     CameraImageTransform.NONE: "None",
     CameraImageTransform.FLIP_X: "Flip X",
     CameraImageTransform.FLIP_Y: "Flip Y",
     CameraImageTransform.FLIP_XY: "Flip X+Y",
-    CameraImageTransform.ROTATE_90_CW: "Rotate 90° CW",
-    CameraImageTransform.ROTATE_90_CCW: "Rotate 90° CCW",
-    CameraImageTransform.ROTATE_180: "Rotate 180°"
 }
 
 

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -62,7 +62,7 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem import conversions
 from fibsem.autofunctions.gamma import apply_gamma
 from fibsem.constants import METRE_TO_MICRON, MICRON_TO_METRE
-from fibsem.fm.structures import CameraImageTransform, FluorescenceImage
+from fibsem.fm.structures import FluorescenceImage
 from fibsem.milling.strategy.coincidence import CoincidenceMillingStrategy
 from fibsem.structures import BeamType, FibsemImage, Point
 from fibsem.ui import notification_service, stylesheets
@@ -2613,23 +2613,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             pixelsize=pixelsize,
         )
         px, py = point[0], -point[1]  # Y-inversion (mirrors FMControlWidget)
-        transform = self.microscope.fm._transform
-        if transform is CameraImageTransform.FLIP_X:
-            px = -px
-        elif transform is CameraImageTransform.FLIP_Y:
-            py = -py
-        elif transform is CameraImageTransform.FLIP_XY:
-            px, py = -px, -py
-        elif transform is CameraImageTransform.ROTATE_90_CW:
-            px, py = py, -px
-        elif transform is CameraImageTransform.ROTATE_90_CCW:
-            px, py = -py, px
-        elif transform is CameraImageTransform.ROTATE_180:
-            px, py = -px, -py
+        # fm_stable_move undoes the display transform and projects through the
+        # camera's own axis tilt, so the sample is not foreshortened by the wrong beam.
         threading.Thread(
-            target=lambda: self.microscope.stable_move(
-                dx=px, dy=py, beam_type=BeamType.ELECTRON
-            ),
+            target=lambda: self.microscope.fm_stable_move(dx=px, dy=py),
             daemon=True,
         ).start()
 

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -27,7 +27,6 @@ from fibsem.fm.calibration import run_autofocus
 from fibsem.fm.config import record_recent_channels
 from fibsem.fm.structures import (
     AutoFocusSettings,
-    CameraImageTransform,
     ChannelSettings,
     FluorescenceImage,
     FluorescenceConfiguration,
@@ -409,23 +408,11 @@ class FMControlWidget(QWidget):
                 point_clicked[0],
                 -point_clicked[1],
             )  # Y-inverse when t=0, need to make this more robust
-            # Apply inverse transform to account for image transformation
-            if self.fm._transform is CameraImageTransform.FLIP_X:
-                point_clicked = (-point_clicked[0], point_clicked[1])
-            elif self.fm._transform is CameraImageTransform.FLIP_Y:
-                point_clicked = (point_clicked[0], -point_clicked[1])
-            elif self.fm._transform is CameraImageTransform.FLIP_XY:
-                point_clicked = (-point_clicked[0], -point_clicked[1])
-            elif self.fm._transform is CameraImageTransform.ROTATE_90_CW:
-                point_clicked = (point_clicked[1], -point_clicked[0])
-            elif self.fm._transform is CameraImageTransform.ROTATE_90_CCW:
-                point_clicked = (-point_clicked[1], point_clicked[0])
-            elif self.fm._transform is CameraImageTransform.ROTATE_180:
-                point_clicked = (-point_clicked[0], -point_clicked[1])
 
-            self.microscope.move_stage_relative(
-                FibsemStagePosition(x=point_clicked[0], y=point_clicked[1])
-            )
+            # fm_stable_move undoes the display transform and projects onto the tilted
+            # sample plane, so the move is foreshortening-correct and holds focus.
+            # Previously this was a raw relative move with neither correction.
+            self.microscope.fm_stable_move(dx=point_clicked[0], dy=point_clicked[1])
         logging.info(f"-" * 50)
 
     def _on_channel_field_changed(self, channel, field: str, value) -> None:

--- a/tests/fm/test_config.py
+++ b/tests/fm/test_config.py
@@ -17,7 +17,7 @@ def _make_config() -> FluorescenceConfiguration:
         channel_settings=[ChannelSettings(name="GFP", exposure_time=0.05)],
         z_parameters=ZParameters(),
         overview_parameters=OverviewParameters(),
-        camera_settings=CameraSettings(transform=CameraImageTransform.ROTATE_90_CW),
+        camera_settings=CameraSettings(transform=CameraImageTransform.FLIP_XY),
         focus_position=1.1e-3,
         limit_position=3.3e-3,
     )
@@ -40,7 +40,7 @@ def test_configuration_roundtrip(tmp_path, monkeypatch):
 
     assert loaded is not None
     # camera transform + objective limit are the fields the earlier save path dropped
-    assert loaded.camera_settings.transform == CameraImageTransform.ROTATE_90_CW
+    assert loaded.camera_settings.transform == CameraImageTransform.FLIP_XY
     assert loaded.limit_position == 3.3e-3
     assert loaded.focus_position == 1.1e-3
     assert loaded.channel_settings[0].name == "GFP"

--- a/tests/test_view_corrected_movement.py
+++ b/tests/test_view_corrected_movement.py
@@ -485,6 +485,20 @@ class TestCameraImageTransformIsFlipOnly:
             assert dy == 0.0
             assert abs(dx) == 5.0
 
+    def test_one_spelling_per_transform(self):
+        """No two members may describe the same operation.
+
+        A half turn used to exist as both FLIP_XY and ROTATE_180, which made
+        `transform is FLIP_XY` silently false for a value that behaved identically.
+        """
+        seen = {}
+        for transform in CameraImageTransform:
+            signature = transform.apply_to_delta(1.0, 1.0)
+            assert signature not in seen, (
+                f"{transform.name} and {seen[signature].name} are the same operation"
+            )
+            seen[signature] = transform
+
     def test_removed_values_load_as_none_with_a_warning(self, caplog):
         """A configuration written before the rotations were removed must still load."""
         from fibsem.fm.structures import CameraSettings
@@ -496,6 +510,22 @@ class TestCameraImageTransformIsFlipOnly:
 
         assert settings.transform is CameraImageTransform.NONE
         assert "rotate-90-cw" in caplog.text
+
+    def test_a_stored_half_turn_migrates_rather_than_being_dropped(self):
+        """`rotate-180` is the same operation as a double flip, so the setting survives.
+
+        Falling back to NONE here would silently change the image orientation for
+        anyone who had it configured.
+        """
+        from fibsem.fm.structures import CameraSettings
+
+        settings = CameraSettings.from_dict(
+            {"gain": 0.1, "offset": 0.0, "binning": 1, "transform": "rotate-180"}
+        )
+
+        assert settings.transform is CameraImageTransform.FLIP_XY
+        # and it re-saves under the canonical spelling
+        assert settings.to_dict()["transform"] == "flip-xy"
 
     def test_supported_values_still_round_trip(self):
         from fibsem.fm.structures import CameraSettings
@@ -665,7 +695,7 @@ class TestMountTransform:
             (CameraImageTransform.NONE, lambda d: d),
             (CameraImageTransform.FLIP_X, np.fliplr),
             (CameraImageTransform.FLIP_Y, np.flipud),
-            (CameraImageTransform.ROTATE_180, lambda d: np.rot90(d, k=2)),
+            (CameraImageTransform.FLIP_XY, lambda d: np.rot90(d, k=2)),
         ],
     )
     def test_user_transform_still_applies(self, transform, expected):

--- a/tests/test_view_corrected_movement.py
+++ b/tests/test_view_corrected_movement.py
@@ -433,6 +433,185 @@ class TestTiledInverseMatchesMicroscope:
             assert from_image == pytest.approx(from_microscope, rel=1e-9)
 
 
+class TestCameraImageTransformIsFlipOnly:
+    """Restricting the transform to flips is what makes the mapping two sign flips.
+
+    Rotations moved into the driver's mount correction, so the remaining members form
+    the Klein four-group: shape-preserving, self-inverse, no axis swap.
+    """
+
+    def test_no_rotations_are_offered(self):
+        names = {t.name for t in CameraImageTransform}
+        assert "ROTATE_90_CW" not in names
+        assert "ROTATE_90_CCW" not in names
+
+    @pytest.mark.parametrize("transform", list(CameraImageTransform))
+    def test_every_transform_is_its_own_inverse(self, transform):
+        dx, dy = 3.0, -7.0
+        once = transform.apply_to_delta(dx, dy)
+        twice = transform.apply_to_delta(*once)
+        assert twice == (dx, dy)
+
+    @pytest.mark.parametrize("transform", list(CameraImageTransform))
+    def test_delta_mapping_matches_the_array_transform(self, transform):
+        """The coordinate mapping and the pixel mapping must agree.
+
+        Build an index grid, transform it as an image, and check that the pixel which
+        ends up at a probe offset from centre is the one the delta mapping predicts.
+        """
+        fm = FluorescenceMicroscope()
+        size = 9
+        centre = size // 2
+        ys, xs = np.mgrid[0:size, 0:size]
+        coded = (ys * 100 + xs).astype(np.int32)
+
+        fm.set_image_transform(transform)
+        moved = fm._transform_array(coded, transform)
+
+        for probe in [(2, 0), (0, 2), (2, 3), (-1, 4)]:
+            dx, dy = probe
+            value = moved[centre + dy, centre + dx]
+            src_y, src_x = divmod(int(value), 100)
+            # where the delta mapping says that displayed offset came from
+            exp_dx, exp_dy = transform.apply_to_delta(dx, dy)
+            assert (src_x - centre, src_y - centre) == (exp_dx, exp_dy), (
+                f"{transform.name}: array and delta mappings disagree at {probe}"
+            )
+
+    def test_no_axis_swapping(self):
+        """A pure x displacement stays on x for every remaining transform."""
+        for transform in CameraImageTransform:
+            dx, dy = transform.apply_to_delta(5.0, 0.0)
+            assert dy == 0.0
+            assert abs(dx) == 5.0
+
+    def test_removed_values_load_as_none_with_a_warning(self, caplog):
+        """A configuration written before the rotations were removed must still load."""
+        from fibsem.fm.structures import CameraSettings
+
+        with caplog.at_level("WARNING"):
+            settings = CameraSettings.from_dict(
+                {"gain": 0.1, "offset": 0.0, "binning": 1, "transform": "rotate-90-cw"}
+            )
+
+        assert settings.transform is CameraImageTransform.NONE
+        assert "rotate-90-cw" in caplog.text
+
+    def test_supported_values_still_round_trip(self):
+        from fibsem.fm.structures import CameraSettings
+
+        for transform in CameraImageTransform:
+            restored = CameraSettings.from_dict(CameraSettings(transform=transform).to_dict())
+            assert restored.transform is transform
+
+
+class TestFmStableMove:
+    """Click a point in the FM image, the stage goes there, focus is held."""
+
+    def test_requires_a_fluorescence_microscope(self, microscope):
+        microscope.fm = None
+        with pytest.raises(ValueError):
+            microscope.fm_stable_move(1e-6, 1e-6)
+
+    def test_uses_the_camera_tilt_projection(self, microscope):
+        """The move must match the shared projection at the camera's own axis tilt."""
+        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+        microscope.fm = FluorescenceMicroscope(parent=microscope)
+        moved = []
+        microscope.move_stage_relative = lambda p: moved.append(p)  # type: ignore[method-assign]
+
+        microscope.fm_stable_move(dx=4e-6, dy=25e-6)
+
+        expected = microscope._view_corrected_stage_movement(
+            expected_y=25e-6, view_tilt=np.deg2rad(microscope.fm.camera_tilt)
+        )
+        assert len(moved) == 1
+        assert moved[0].x == pytest.approx(4e-6)
+        assert moved[0].y == pytest.approx(expected.y)
+        assert moved[0].z == pytest.approx(expected.z)
+
+    def test_undoes_the_display_transform(self, microscope):
+        """A flipped display must not send the stage the wrong way."""
+        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+        microscope.fm = FluorescenceMicroscope(parent=microscope)
+        moved = []
+        microscope.move_stage_relative = lambda p: moved.append(p)  # type: ignore[method-assign]
+
+        microscope.fm.set_image_transform(CameraImageTransform.NONE)
+        microscope.fm_stable_move(dx=4e-6, dy=25e-6)
+        microscope.fm.set_image_transform(CameraImageTransform.FLIP_X)
+        microscope.fm_stable_move(dx=4e-6, dy=25e-6)
+
+        assert moved[1].x == pytest.approx(-moved[0].x), "flip in x should reverse the x move"
+        assert moved[1].y == pytest.approx(moved[0].y), "flip in x should leave y alone"
+
+    def test_reads_the_transform_live(self, microscope):
+        """Changing the dropdown mid-session takes effect on the next move."""
+        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+        microscope.fm = FluorescenceMicroscope(parent=microscope)
+        moved = []
+        microscope.move_stage_relative = lambda p: moved.append(p)  # type: ignore[method-assign]
+
+        for transform in (CameraImageTransform.NONE, CameraImageTransform.FLIP_Y):
+            microscope.fm.set_image_transform(transform)
+            microscope.fm_stable_move(dx=0.0, dy=25e-6)
+
+        assert moved[1].y == pytest.approx(-moved[0].y)
+
+    def test_does_not_touch_working_distance(self, microscope):
+        """Working distance is beam bookkeeping; the FM move must leave it alone."""
+        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+        microscope.fm = FluorescenceMicroscope(parent=microscope)
+        microscope.move_stage_relative = lambda p: None  # type: ignore[method-assign]
+        calls = []
+        microscope.set_working_distance = lambda *a, **k: calls.append((a, k))  # type: ignore[method-assign]
+
+        microscope.fm_stable_move(dx=0.0, dy=25e-6)
+
+        assert calls == []
+
+
+class TestFmConsumersUseTheFmProjection:
+    """Everything that moves from a fluorescence image must use the FM projection.
+
+    Stepping with a beam type used the wrong view's foreshortening: on an offset mount
+    the camera's axis parallels the ion column, so the SEM projection mis-scales the
+    y pitch by roughly 1/cos(column_tilt).
+    """
+
+    def test_tileset_no_longer_steps_with_a_beam_type(self):
+        import inspect
+
+        from fibsem.fm import acquisition
+
+        source = inspect.getsource(acquisition.acquire_tileset)
+        assert "fm_stable_move" in source
+        assert "stable_move(dx" not in source.replace("fm_stable_move(dx", "")
+
+    def test_fm_projection_differs_from_the_sem_projection_when_it_matters(self, microscope):
+        """Guard the reason for the switch: the two projections really do differ.
+
+        At the FIB-flat orientation on an offset mount, stepping via the electron
+        column foreshortens differently from the camera. If this ever became a
+        no-op the switch would be pointless -- and a regression would be invisible.
+        """
+        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=0, compustage=False)
+        microscope.system.electron.column_tilt = 0.0
+        microscope.system.ion.column_tilt = 52.0
+        fm = FluorescenceMicroscope(parent=microscope)
+
+        by_sem = microscope._view_corrected_stage_movement(25e-6, view_tilt=0.0)
+        by_fm = microscope._view_corrected_stage_movement(
+            25e-6, view_tilt=np.deg2rad(fm.camera_tilt)
+        )
+
+        assert by_fm.y != pytest.approx(by_sem.y, rel=1e-3)
+        # the FM view here parallels the ion column, so it must match that projection
+        by_ion = microscope._y_corrected_stage_movement(25e-6, beam_type=BeamType.ION)
+        assert by_fm.y == pytest.approx(by_ion.y)
+        assert by_fm.z == pytest.approx(by_ion.z)
+
+
 class TestCameraTilt:
     """The FM optical axis is derived from the mount, not configured."""
 


### PR DESCRIPTION
Phases C and D of FIB-133, following #194 and #195. **This one changes behaviour on live user paths** — unlike the two before it.

Click a point in the FM view and the stage goes there, holding the focal plane: the promise `stable_move` makes for the SEM/FIB views, now made by the FM view too.

## The problem it fixes

Click-to-move from a fluorescence image already existed — **hand-rolled in two places, disagreeing with each other for the same gesture**:

| Path | What it did | What was wrong |
|---|---|---|
| Coincidence viewer | `stable_move(..., beam_type=ELECTRON)` | The SEM projection, while imaging through a camera whose axis parallels the **ion** column — so y was out by roughly `1/cos(column_tilt)` (~1.6×) on an offset mount |
| FM control widget | `move_stage_relative(...)` | **No projection at all** — no foreshortening correction, and no z compensation, so focus drifted at any non-flat pose |

Tileset stepping in `acquire_tileset` had the same `beam_type=ELECTRON` mis-scale, between every pair of tiles.

## `fm_stable_move`

```python
def fm_stable_move(self, dx: float, dy: float) -> FibsemStagePosition
```

Undoes the display transform (read live — the dropdown can change mid-session), then projects through the shared view math at the camera's own axis tilt, so the movement stays in the sample plane. That is what holds focus, so there is deliberately **no working-distance restore** — that is beam bookkeeping and does not apply to a camera.

All five call sites now go through it: both click paths and the three tileset steps. That also settles the long-standing `QUERY: How we need to change direction of movements if in SEM orientation?` at the top of the tileset loop — the projection answers it.

## `CameraImageTransform` loses its 90° rotations

A fixed rotation between sensor and stage describes the **mount**, not user preference, and is corrected by `mount_transform` inside the driver before the user's choice applies (added in #194, defaults to none). What remains is flips only.

That is not just tidying — it is the Klein four-group, and three things fall out:

1. **No axis swapping.** Mapping a displacement is two independent signs, never `dx → ±dy`.
2. **No inverse to get backwards.** Every member is its own inverse, so one method maps in both directions.
3. **Shape is preserved.** An image and its geometry metadata always describe the same frame, so the square-sensor assumption stops being load-bearing.

The mapping is now `CameraImageTransform.apply_to_delta`, replacing both hand-rolled copies. `ROTATE_180` is gone too: it was the same element as `FLIP_XY`, so having both spellings made `transform is FLIP_XY` silently false for a value that behaved identically. Stored `rotate-180` settings migrate to `FLIP_XY` on load rather than being dropped; the quarter turns have no equivalent and load as no transform with a warning rather than raising. A test asserts no two members share a delta signature, so a duplicate cannot come back.

## Tests

+179 lines, 1323 passing overall. Beyond the obvious:

- **The array mapping and the coordinate mapping must agree** — an index grid is transformed as an image, and the pixel landing at a probe offset must be the one `apply_to_delta` predicts. This is the property that catches a sign error in either direction.
- **Every transform applied twice is the identity** — the self-inverse property the trimmed group buys.
- **The FM and SEM projections genuinely differ** where it matters, and the FM one matches the ION projection on an offset mount. If that ever became a no-op the switch would be pointless and a regression invisible.
- **Working distance is untouched** by an FM move.
- A removed rotation in a stored config loads as `NONE` with a warning.

## Known and deliberate

- **`camera_tilt` stays derived from the mount** (180° under-grid, ion `column_tilt` otherwise). Making it configurable for a system that is neither is FIB-335.
- **The in-plane mount correction `M` defaults to none**, which assumes the raw sensor axes are already stage-aligned. Confirming that per system is the mosaic question in FIB-334 — if a system needs a correction, it is one property on its driver, not a change here.
- `beam_type` on the tileset entry points is now unused for movement. Kept for signature compatibility and documented as such rather than removed, to keep this diff to the behaviour change.
- `convert_grid_positions_to_stage_positions` still projects via `project_stable_move(beam_type=...)`, which would disagree with `fm_stable_move` on an offset mount. It has no callers today, so the two cannot drift apart yet; noted at the migration TODO that would first make it reachable.

## Hardware

The projection is verified by construction and against the ION equivalence, but direction on a real stage is not something a test can settle. Checks are queued in FIB-334 — in particular click-to-centre convergence, and confirming the two `camera_tilt` values before this is trusted in anger.
