### PR TITLE
[ui] Add the reusable matplotlib canvas subsystem (extracted from #111)

### DIFF
--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -616,6 +616,10 @@ ORANGE_COLOR = " #ff9800"
 DEFECT_ORANGE_COLOR = "#e8a020"
 DEFECT_RED_COLOR = "#d04040"
 
+# Shared canvas colours (image canvas / overlays / quad-view selection border)
+CANVAS_BG = "#1e2124"
+PRIMARY_ACCENT = "#3a6ea5"  # matches the quad-view selection border
+
 WORKFLOW_BORDER_STYLESHEET = """
     QFrame#workflow_border_frame[borderState="idle"]       { border: 4px solid #262930; }
     QFrame#workflow_border_frame[borderState="automated"]  { border: 4px solid #4caf50; }

--- a/fibsem/ui/widgets/canvas/__init__.py
+++ b/fibsem/ui/widgets/canvas/__init__.py
@@ -1,0 +1,60 @@
+"""Canvas subsystem: matplotlib-based image/FM canvases, overlays, and view controllers.
+
+This package groups the (napari-free) canvas widgets and their supporting state:
+
+- :mod:`~fibsem.ui.widgets.canvas.image_canvas` — the core :class:`FibsemImageCanvas`.
+- :mod:`~fibsem.ui.widgets.canvas.fm_canvas` — fluorescence-microscopy canvas.
+- :mod:`~fibsem.ui.widgets.canvas.fm_composite` — FM layer compositing helpers.
+- :mod:`~fibsem.ui.widgets.canvas.quad_view` — quad-view widget, lamella editor, and
+  :class:`MicroscopeViewController`.
+- :mod:`~fibsem.ui.widgets.canvas.canvas_state` — declarative scene/overlay specs.
+- :mod:`~fibsem.ui.widgets.canvas.overlays` — the overlay classes drawn on the canvases.
+
+The public API is re-exported here so callers can write, e.g.::
+
+    from fibsem.ui.widgets.canvas import FibsemImageCanvas, MicroscopeViewController
+
+Imports are ordered leaf-first to avoid partial-initialisation issues.
+"""
+
+# Leaf modules first (canvas_state, fm_composite, contrast_gamma_control have no
+# intra-cluster deps), then overlays, then image_canvas, fm_canvas, quad_view.
+from fibsem.ui.widgets.canvas.canvas_state import (
+    AlignmentSpec,
+    CanvasState,
+    MaskSpec,
+    MillingSpec,
+    OverlaySpec,
+    PointsSpec,
+    SceneModel,
+)
+from fibsem.ui.widgets.canvas.fm_composite import FMLayer, composite_fm_layers
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
+from fibsem.ui.widgets.canvas.quad_view import (
+    LamellaEditorView,
+    MicroscopeViewController,
+    QuadViewWidget,
+)
+
+__all__ = [
+    # image_canvas
+    "FibsemImageCanvas",
+    # fm_canvas
+    "FMCanvasWidget",
+    # fm_composite
+    "FMLayer",
+    "composite_fm_layers",
+    # quad_view
+    "QuadViewWidget",
+    "LamellaEditorView",
+    "MicroscopeViewController",
+    # canvas_state
+    "SceneModel",
+    "CanvasState",
+    "OverlaySpec",
+    "MillingSpec",
+    "PointsSpec",
+    "MaskSpec",
+    "AlignmentSpec",
+]

--- a/fibsem/ui/widgets/canvas/canvas_state.py
+++ b/fibsem/ui/widgets/canvas/canvas_state.py
@@ -1,0 +1,117 @@
+"""Declarative canvas-state model for the quad-view microscope display.
+
+Pure data: one :class:`CanvasState` per canvas (image + overlays + info + the
+armed overlay), aggregated by :class:`SceneModel`. Producers mutate this model
+*only* through ``MicroscopeViewController`` (the reducer), which renders it onto
+the matplotlib canvases in a single debounced pass.
+
+Overlay specs (:class:`OverlaySpec` subclasses) are data records the reducer maps
+onto the existing ``CanvasOverlay`` objects — they hold no Qt / matplotlib state,
+so they stay trivially testable and thread-safe to construct.
+
+Each spec is keyed on a canvas by its ``id``, so re-setting a spec with the same id
+updates that overlay in place rather than stacking a second one.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from fibsem.structures import FibsemImage, FibsemRectangle
+
+
+@dataclass
+class OverlaySpec:
+    """Base for declarative overlay descriptions; ``id`` keys the overlay on a canvas."""
+
+    id: str
+
+
+@dataclass
+class MillingSpec(OverlaySpec):
+    """Milling stage patterns for a canvas (rendered by ``MillingPatternOverlay``).
+
+    Carries no image: the reducer injects the canvas's current image when driving
+    the overlay (``set_stages`` needs pixel-size + shape).
+    """
+
+    id: str = "milling"
+    stages: Sequence = ()
+    background_stages: Sequence = ()
+    selected_index: Optional[int] = None
+    visible: bool = True
+
+
+@dataclass
+class AlignmentSpec(OverlaySpec):
+    """Image-alignment reduced area — one overlay, two producers.
+
+    ``rect`` is a normalized ``FibsemRectangle``. ``display`` = the milling viewer
+    wants it shown read-only; ``editing`` = the image widget is editing it (wins).
+    The reducer resolves: editable = editing, visible = editing or display.
+    """
+
+    id: str = "alignment"
+    rect: Optional["FibsemRectangle"] = None
+    display: bool = False
+    editing: bool = False
+
+
+@dataclass
+class PointsSpec(OverlaySpec):
+    """Interactive points (rendered by ``PointOverlay``) — POI / spot burn / detection
+    features. ``points`` are (x, y) pixel coords; the rest configure the overlay at
+    creation. ``colors`` / ``labels`` are optional index-aligned per-point overrides.
+    """
+
+    id: str = "points"
+    points: Sequence = ()
+    visible: bool = True
+    color: str = "cyan"
+    selected_color: str = "yellow"
+    marker: str = "o"
+    size: float = 10.0
+    label_prefix: str = ""
+    add_on_right_click: bool = False
+    removable: bool = False
+    modal: bool = False
+    edge_width: Optional[float] = None
+    legend_label: Optional[str] = None
+    numbered: bool = False
+    colors: Optional[Sequence] = None
+    labels: Optional[Sequence] = None
+    selected: Optional[int] = None  # selected point index (table-driven), preserved across re-renders
+
+
+@dataclass
+class MaskSpec(OverlaySpec):
+    """A segmentation mask (rendered by ``MaskOverlay``, display-only) — HxW integer
+    class indices; ``colors`` is an optional index→(r,g,b) override."""
+
+    id: str = "mask"
+    mask: Optional["np.ndarray"] = None
+    colors: Optional[Sequence] = None
+
+
+@dataclass
+class CanvasState:
+    """Everything shown on one canvas; the reducer renders from this."""
+
+    image: Optional["FibsemImage"] = None
+    overlays: Dict[str, OverlaySpec] = field(default_factory=dict)
+    info: List[Tuple[str, str]] = field(default_factory=list)
+    armed_overlay: Optional[str] = None  # id that owns edit input (None = view/move)
+    armed_label: str = ""                # toolbar-mode label for the armed overlay
+    armed_icon: str = ""                 # toolbar-mode icon for the armed overlay
+
+
+@dataclass
+class SceneModel:
+    """Per-canvas states for the quad view (SEM / FIB / FM)."""
+
+    sem: CanvasState = field(default_factory=CanvasState)
+    fib: CanvasState = field(default_factory=CanvasState)
+    fm: CanvasState = field(default_factory=CanvasState)

--- a/fibsem/ui/widgets/canvas/contrast_gamma_control.py
+++ b/fibsem/ui/widgets/canvas/contrast_gamma_control.py
@@ -31,7 +31,7 @@ from PyQt5.QtWidgets import (
 )
 from superqt import QDoubleSlider
 
-from fibsem.imaging.autogamma import apply_gamma
+from fibsem.autofunctions.gamma import apply_gamma
 
 _PANEL_STYLE = (
     "QFrame { background: rgba(30,33,36,230); border: 1px solid #555;"

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -1,0 +1,679 @@
+"""Dedicated multi-channel fluorescence canvas for the quad-view FM panel.
+
+``FMCanvasWidget`` wraps a generic :class:`FibsemImageCanvas` and adds the
+FM-specific bits the bare canvas should not carry: a per-channel layer model, the
+additive colour composite (:mod:`fm_composite`), and a toolbar **layers** popover
+(:class:`FMLayersPanel`) for per-channel visibility / colormap / opacity / gamma /
+contrast — the napari layer-controls equivalent, on matplotlib.
+
+Display only (Phase 6a); FM canvas interactions (position select, relative move)
+are Phase 6b.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+import numpy as np
+from PyQt5.QtCore import Qt, QPoint, QSize, pyqtSignal
+from PyQt5.QtGui import QColor, QIcon, QPainter, QPixmap
+from PyQt5.QtWidgets import (
+    QComboBox, QFrame, QHBoxLayout, QLabel, QPushButton, QSlider, QToolButton,
+    QVBoxLayout, QWidget,
+)
+from superqt import QRangeSlider
+
+from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.widgets.canvas.fm_composite import (
+    AVAILABLE_COLORS, FMLayer, auto_clim, composite_fm_layers,
+)
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+if TYPE_CHECKING:
+    from fibsem.fm.structures import FluorescenceImage
+
+_PANEL_BG = "#2c3036"
+_ACCENT = "#5b9bd5"
+
+# napari-style dark theme for the floating layers panel
+_PANEL_QSS = """
+QFrame#fmPanel { background: #2c3036; border: 1px solid #3f444b; border-radius: 10px; }
+QLabel { color: #e4e6e9; background: transparent; }
+#panelTitle { color: #9aa0a6; font-size: 12px; font-weight: 500; letter-spacing: 1px; }
+QFrame#divider { background: #3a3f46; border: none; }
+#selName { color: #e4e6e9; font-size: 13px; font-weight: 500; }
+#selTag { color: #80858b; font-size: 11px; }
+#ctrlLbl { color: #9aa0a6; font-size: 12px; }
+#valLbl { color: #d2d5d9; font-size: 12px; }
+#valSm { color: #70757b; font-size: 11px; }
+QFrame#channelRow { border-radius: 7px; background: transparent; }
+QFrame#channelRow:hover { background: #32373e; }
+QFrame#channelRow[selected="true"] { background: #363d46; }
+QToolButton#eyeBtn { border: none; background: transparent; padding: 0; }
+#chName { color: #e4e6e9; font-size: 13px; }
+QComboBox { background: #23262b; color: #e4e6e9; border: 1px solid #3f444b;
+            border-radius: 6px; padding: 4px 8px; font-size: 12px; }
+QComboBox::drop-down { border: none; width: 18px; }
+QComboBox QAbstractItemView { background: #23262b; color: #e4e6e9;
+            border: 1px solid #3f444b; selection-background-color: #363d46; outline: none; }
+QPushButton#autoPill { color: #9bcdf6; background: #243140; border: 1px solid #2e4a61;
+            border-radius: 11px; padding: 3px 11px; font-size: 11px; }
+QPushButton#autoPill:!checked { color: #9aa0a6; background: transparent; border: 1px solid #3f444b; }
+QPushButton#resetBtn { background: transparent; color: #cdd0d4; border: 1px solid #3f444b;
+            border-radius: 6px; padding: 8px; font-size: 12px; }
+QPushButton#resetBtn:hover { background: #363d46; }
+QSlider { background: transparent; }
+QSlider::groove:horizontal { height: 4px; background: #3a3f46; border-radius: 2px; }
+QSlider::sub-page:horizontal { background: #5b9bd5; border-radius: 2px; }
+QSlider::add-page:horizontal { background: #3a3f46; border-radius: 2px; }
+QSlider::handle:horizontal { width: 13px; height: 13px; margin: -5px 0; border-radius: 7px;
+            background: #eceef0; border: 1px solid #5b9bd5; }
+QSlider::handle:horizontal:disabled { background: #5a6068; border-color: #5a6068; }
+QSlider::sub-page:horizontal:disabled { background: #4a5058; }
+"""
+
+
+def _color_icon(color: str, size: int = 14) -> QIcon:
+    px = QPixmap(size, size)
+    px.fill(QColor("white" if color == "gray" else color))
+    return QIcon(px)
+
+
+def _chip_css(color: str) -> str:
+    return "background: %s; border-radius: 3px;" % ("white" if color == "gray" else color)
+
+
+class _ContrastSlider(QRangeSlider):
+    """Dual-handle range slider for per-channel contrast limits (min + max on one
+    track). Paints its own handles so they stay visible (mirrors the correlation
+    widget's ``_ClipSlider``), and dims when disabled (auto contrast)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._style.brush_active = _ACCENT
+        self._style.brush_inactive = "#3a3f46"
+
+    def _draw_handle(self, painter, opt) -> None:
+        on = self.isEnabled()
+        self._style.brush_active = _ACCENT if on else "#46505d"
+        if self._should_draw_bar:
+            self._drawBar(painter, opt)
+        painter.save()
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QColor("#eceef0" if on else "#8a8f95"))
+        for i in range(len(self.value())):
+            rect = self._handleRect(i).adjusted(1, 1, -1, -1)
+            painter.drawEllipse(rect)
+        painter.restore()
+
+
+class _ChannelRow(QFrame):
+    """One channel: eye visibility toggle + colour chip + name, click to select."""
+
+    selected = pyqtSignal(int)
+    visibility_changed = pyqtSignal(int, bool)
+
+    def __init__(self, index: int, layer: FMLayer, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._index = index
+        self.setObjectName("channelRow")
+        self.setProperty("selected", False)
+        self.setCursor(Qt.PointingHandCursor)
+        lay = QHBoxLayout(self)
+        lay.setContentsMargins(10, 7, 10, 7)
+        lay.setSpacing(11)
+
+        self.eye = QToolButton()
+        self.eye.setObjectName("eyeBtn")
+        self.eye.setCheckable(True)
+        self.eye.setChecked(layer.visible)
+        self.eye.setCursor(Qt.PointingHandCursor)
+        self.eye.setIconSize(QSize(16, 16))
+        self._refresh_eye(layer.visible)
+        self.eye.toggled.connect(self._on_eye)
+
+        self.chip = QLabel()
+        self.chip.setFixedSize(13, 13)
+        self.chip.setStyleSheet(_chip_css(layer.color))
+
+        self.name = QLabel(layer.name)
+        self.name.setObjectName("chName")
+
+        lay.addWidget(self.eye)
+        lay.addWidget(self.chip)
+        lay.addWidget(self.name, 1)
+        self._dim(not layer.visible)
+
+    def _refresh_eye(self, visible: bool) -> None:
+        icon = "mdi:eye" if visible else "mdi:eye-off-outline"
+        self.eye.setIcon(fibsem_icon(icon, color="#d2d5d9" if visible else "#70757b"))
+
+    def _dim(self, dim: bool) -> None:
+        self.name.setStyleSheet("color: #70757b;" if dim else "color: #e4e6e9;")
+
+    def _on_eye(self, checked: bool) -> None:
+        self._refresh_eye(checked)
+        self._dim(not checked)
+        self.visibility_changed.emit(self._index, checked)
+
+    def set_color(self, color: str) -> None:
+        self.chip.setStyleSheet(_chip_css(color))
+
+    def set_selected(self, sel: bool) -> None:
+        self.setProperty("selected", sel)
+        self.style().unpolish(self)
+        self.style().polish(self)
+
+    def mousePressEvent(self, event) -> None:
+        self.selected.emit(self._index)
+        super().mousePressEvent(event)
+
+
+class FMCanvasWidget(QWidget):
+    """FibsemImageCanvas + per-channel FM layer model + composite + layers popover."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.canvas = FibsemImageCanvas()
+        self._layers: List[FMLayer] = []
+        self._pixel_size: Optional[float] = None
+        self._canvas_shape: Optional[Tuple[int, int]] = None  # drawn-axes shape
+        self._shape: Optional[Tuple[int, int]] = None  # composite target shape (last upserted layer)
+        # z-stack scrubbing: keep the full ZYX stack per channel + display state
+        self._stacks: Dict[str, np.ndarray] = {}   # channel name -> ZYX stack
+        self._mip_clim: Dict[str, Tuple[float, float]] = {}  # fixed clim while scrubbing
+        self._z_index: int = 0
+        self._z_max: int = 0                        # nz - 1
+        self._max_projection: bool = True           # default: MIP (behaviour-preserving)
+
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.addWidget(self.canvas)
+
+        # z-slider (shown only for a multi-plane stack with max-projection off)
+        self._z_row = QWidget()
+        zrl = QHBoxLayout(self._z_row)
+        zrl.setContentsMargins(6, 2, 6, 4)
+        zrl.setSpacing(6)
+        zrl.addWidget(QLabel("z"))
+        self._z_slider = QSlider(Qt.Horizontal)
+        self._z_slider.setMinimum(0)
+        self._z_slider.valueChanged.connect(self._on_z_changed)
+        zrl.addWidget(self._z_slider, 1)
+        self._z_label = QLabel("1/1")
+        zrl.addWidget(self._z_label)
+        self._z_row.setVisible(False)
+        lay.addWidget(self._z_row)
+
+        self._btn_layers = self.canvas.add_toolbar_button(
+            "mdi:layers", "FM channels", self._toggle_layers_panel, checkable=True
+        )
+        # max-projection toggle (checked = MIP; uncheck to scrub the z-slider)
+        self._btn_mip = self.canvas.add_toolbar_button(
+            "mdi:arrow-collapse-vertical", "Max projection", self._on_mip_button, checkable=True
+        )
+        self._btn_mip.setChecked(True)
+        self._btn_mip.setVisible(False)  # shown only once a multi-plane z-stack is loaded
+        # FM contrast/gamma is per-channel (layers popover); the canvas's built-in
+        # grayscale contrast button does nothing on the RGB composite — hide it.
+        self.canvas.btn_contrast.hide()
+        self.canvas._reposition_overlay_buttons()
+
+        self._panel = FMLayersPanel(self)
+        self._panel.changed.connect(self._recomposite)
+        self._panel.hide()
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    def _upsert_layer(self, name: str, data: np.ndarray, color: Optional[str]) -> FMLayer:
+        """Create or update a channel's layer (2-D data + colour); display props preserved.
+
+        Rebuilds the panel list only when a channel is added — a data-only update (live
+        acquisition / z-scrub) must NOT reset the per-channel controls."""
+        layer = next((l for l in self._layers if l.name == name), None)
+        is_new = layer is None
+        if is_new:
+            layer = FMLayer(name=name, color=color or "gray")
+            self._layers.append(layer)
+        layer.data = np.asarray(data)
+        if color is not None:
+            layer.color = color
+        self._shape = layer.data.shape[:2]
+        if is_new:
+            self._panel.set_layers(self._layers)
+        return layer
+
+    def set_channel(self, name: str, data: np.ndarray, color: Optional[str] = None) -> None:
+        """Upsert a channel's 2-D image (live path — no z-stack); display props preserved."""
+        had_stack = self._stacks.pop(name, None) is not None
+        self._mip_clim.pop(name, None)
+        layer = self._upsert_layer(name, data, color)
+        if had_stack:  # leaving z-scrub for a live 2-D frame → auto-contrast again
+            layer.autocontrast = True
+            layer.clim = None
+            self._refresh_z_controls()  # a stack went away → maybe hide the z-controls
+        self._recomposite()
+
+    def set_fm_image(self, image: "FluorescenceImage") -> None:
+        """Composite every channel of an acquired ``FluorescenceImage`` (CZYX), keeping the
+        z-stacks so the z-slider / max-projection toggle can scrub them.
+
+        Pixel size and per-channel name/colour come from the image metadata; channels
+        upsert by name and blend additively (parity with the napari main tab). Defaults to
+        the max-intensity projection.
+        """
+        md = image.metadata
+        self.set_pixel_size(getattr(md, "pixel_size_x", None))
+        data = np.asarray(image.data)
+        self._stacks = {}
+        self._mip_clim = {}
+        self._z_index = 0
+        for ci, channel in enumerate(md.channels):
+            if data.ndim >= 4:        # CZYX
+                stack = np.asarray(data[ci])
+            elif data.ndim == 3:      # ZYX (single channel)
+                stack = np.asarray(data)
+            else:                      # 2-D single plane
+                stack = np.asarray(data)[None]
+            self._stacks[channel.name] = stack
+            self._upsert_layer(channel.name, stack.max(axis=0), channel.color)
+        self._refresh_z_controls()
+        self._apply_z_mode()
+
+    def set_layers(self, layers: List[FMLayer]) -> None:
+        self._layers = list(layers)
+        for l in self._layers:
+            if l.data is not None:
+                self._shape = l.data.shape[:2]
+        self._panel.set_layers(self._layers)
+        self._recomposite()
+
+    def set_pixel_size(self, pixel_size: Optional[float]) -> None:
+        self._pixel_size = pixel_size
+        if pixel_size and self._canvas_shape is not None:
+            self.canvas._pixel_size = pixel_size
+            self.canvas._refresh_scalebar()
+            self.canvas.draw_idle()
+
+    def clear(self) -> None:
+        self._layers = []
+        self._canvas_shape = None
+        self._stacks = {}
+        self._mip_clim = {}
+        self._z_index = 0
+        self._refresh_z_controls()  # hides the z-controls (no stacks)
+        self._panel.set_layers(self._layers)
+        self.canvas.clear()
+
+    @property
+    def layers(self) -> List[FMLayer]:
+        return self._layers
+
+    # ── display ───────────────────────────────────────────────────────────
+
+    def _recomposite(self) -> None:
+        shape = self._shape
+        rgb = composite_fm_layers(self._layers, shape)
+        if rgb is None:
+            return
+        h, w = rgb.shape[:2]
+        if self._canvas_shape != (h, w):
+            # (re)build axes + scalebar at this shape and show the composite
+            # directly — no fake single-channel FibsemImage needed
+            self._canvas_shape = (h, w)
+            self.canvas.set_array(rgb, pixel_size=self._pixel_size)
+        else:
+            self.canvas.update_display(rgb)  # steady state: swap pixels only
+
+    # ── z-stack scrubbing ──────────────────────────────────────────────────
+
+    def _refresh_z_controls(self) -> None:
+        """Recompute the z-range from the current stacks and show/hide the z-controls.
+
+        The Max-projection toggle + z-slider appear only when a multi-plane stack is
+        present — so a single-frame (live microscope) FM canvas shows neither."""
+        nz = max((s.shape[0] for s in self._stacks.values()), default=1)
+        self._z_max = max(0, nz - 1)
+        self._z_index = min(self._z_index, self._z_max)
+        self._z_slider.blockSignals(True)
+        self._z_slider.setMaximum(self._z_max)
+        self._z_slider.setValue(self._z_index)
+        self._z_slider.blockSignals(False)
+        self._btn_mip.setVisible(self._z_max > 0)
+        self.canvas._reposition_overlay_buttons()
+        self._update_z_visibility()
+
+    def _update_z_visibility(self) -> None:
+        """The z-slider shows only for a multi-plane stack with max-projection off."""
+        show = self._z_max > 0 and not self._max_projection
+        self._z_row.setVisible(show)
+        if show:
+            self._z_label.setText(f"{self._z_index + 1}/{self._z_max + 1}")
+
+    def _plane_for(self, stack: np.ndarray) -> np.ndarray:
+        """The 2-D plane to display for a ZYX *stack* under the current mode."""
+        if self._max_projection or stack.shape[0] <= 1:
+            return stack.max(axis=0)
+        return stack[min(self._z_index, stack.shape[0] - 1)]
+
+    def _apply_z_mode(self) -> None:
+        """Set each stacked channel's plane + contrast for the current mode, then composite.
+
+        MIP → auto-contrast per the projection; scrub → a fixed clim (computed once off the
+        MIP) held across planes, so brightness doesn't jump. Live 2-D channels (no stack)
+        are left untouched."""
+        for layer in self._layers:
+            stack = self._stacks.get(layer.name)
+            if stack is None:
+                continue
+            if self._max_projection or stack.shape[0] <= 1:
+                # single plane (incl. every live frame) or an explicit MIP: default to
+                # auto-contrast UNLESS the user chose manual. Keying off layer.manual (an
+                # explicit user choice) rather than layer.autocontrast (which the z-scrub
+                # branch below also toggles) is what lets a MIP toggle restore auto while a
+                # live feed — every frame lands here — keeps the user's manual contrast.
+                if not layer.manual:
+                    layer.autocontrast = True
+                    layer.clim = None
+            else:
+                clim = self._mip_clim.get(layer.name)
+                if clim is None:
+                    clim = auto_clim(stack.max(axis=0))
+                    self._mip_clim[layer.name] = clim
+                layer.autocontrast = False
+                layer.clim = clim
+            layer.data = self._plane_for(stack)
+        self._recomposite()
+
+    def _on_z_changed(self, value: int) -> None:
+        self._z_index = value
+        self._z_label.setText(f"{value + 1}/{self._z_max + 1}")
+        self._apply_z_mode()
+
+    def _on_max_projection_toggled(self, on: bool) -> None:
+        self._max_projection = bool(on)
+        self._update_z_visibility()
+        self._apply_z_mode()
+
+    def _on_mip_button(self) -> None:
+        """Toolbar toggle → max-projection on/off (checked = MIP)."""
+        self._on_max_projection_toggled(self._btn_mip.isChecked())
+
+    # ── layers popover ────────────────────────────────────────────────────
+
+    def _toggle_layers_panel(self) -> None:
+        if self._btn_layers.isChecked():
+            self._panel.set_layers(self._layers)
+            self._position_panel()
+            self._panel.show()
+            self._panel.raise_()
+        else:
+            self._panel.hide()
+
+    def _position_panel(self) -> None:
+        self._panel.adjustSize()
+        # top-level window → anchor near the canvas top-right in global coordinates
+        anchor = self.canvas.mapToGlobal(QPoint(self.canvas.width() - 8, 44))
+        self._panel.move(anchor.x() - self._panel.width(), anchor.y())
+
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        if self._panel.isVisible():
+            self._position_panel()
+
+
+class FMLayersPanel(QFrame):
+    """Floating per-channel controls — a dark channel list (eye toggle + colour chip
+    + name) over a detail panel (colormap / opacity / gamma / contrast) for the
+    selected channel. Emits :attr:`changed` whenever an edit needs a re-composite."""
+
+    changed = pyqtSignal()
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        # Float as a separate top-level tool window: the panel overlays the
+        # matplotlib canvas, and as a child widget its native sliders were forced
+        # to repaint (and flicker) on every canvas redraw during a slider drag.
+        self.setWindowFlags(Qt.Tool | Qt.FramelessWindowHint)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setObjectName("fmPanel")
+        self.setStyleSheet(_PANEL_QSS)
+        self.setFixedWidth(268)
+
+        self._layers: List[FMLayer] = []
+        self._rows: List[_ChannelRow] = []
+        self._selected: int = 0
+        self._updating = False  # guard so programmatic updates don't emit changed
+        self._data_lo: float = 0.0
+        self._data_span: float = 1.0
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(14, 14, 14, 16)
+        root.setSpacing(0)
+
+        # header
+        header = QHBoxLayout(); header.setSpacing(8)
+        hicon = QLabel()
+        hicon.setPixmap(fibsem_icon("mdi:layers-triple-outline", color="#9aa0a6").pixmap(QSize(16, 16)))
+        title = QLabel("FM CHANNELS"); title.setObjectName("panelTitle")
+        header.addWidget(hicon); header.addWidget(title); header.addStretch()
+        root.addLayout(header)
+        root.addSpacing(12)
+
+        # channel list
+        self._list_box = QVBoxLayout(); self._list_box.setSpacing(2)
+        root.addLayout(self._list_box)
+        root.addSpacing(12)
+
+        div = QFrame(); div.setObjectName("divider"); div.setFixedHeight(1)
+        root.addWidget(div)
+        root.addSpacing(12)
+
+        # detail header (selected channel)
+        dh = QHBoxLayout(); dh.setSpacing(8)
+        self.sel_chip = QLabel(); self.sel_chip.setFixedSize(11, 11)
+        self.sel_name = QLabel("—"); self.sel_name.setObjectName("selName")
+        sel_tag = QLabel("selected"); sel_tag.setObjectName("selTag")
+        dh.addWidget(self.sel_chip); dh.addWidget(self.sel_name); dh.addStretch(); dh.addWidget(sel_tag)
+        root.addLayout(dh)
+        root.addSpacing(14)
+
+        # colormap
+        cm_row = QHBoxLayout()
+        cm_lbl = QLabel("Colormap"); cm_lbl.setObjectName("ctrlLbl")
+        self.colormap = QComboBox(); self.colormap.setFixedWidth(132)
+        for c in AVAILABLE_COLORS:
+            self.colormap.addItem(_color_icon(c), c)
+        self.colormap.currentTextChanged.connect(self._on_colormap)
+        cm_row.addWidget(cm_lbl); cm_row.addStretch(); cm_row.addWidget(self.colormap)
+        root.addLayout(cm_row)
+        root.addSpacing(13)
+
+        # opacity + gamma sliders (label + value, then track)
+        self.opacity, self.opacity_val = self._slider_row(root, "Opacity", 0, 100, 100)
+        self.opacity.valueChanged.connect(self._on_opacity)
+        self.gamma, self.gamma_val = self._slider_row(root, "Gamma", 10, 300, 100)
+        self.gamma.valueChanged.connect(self._on_gamma)
+
+        # contrast header (label + Auto pill)
+        ch = QHBoxLayout()
+        ct_lbl = QLabel("Contrast"); ct_lbl.setObjectName("ctrlLbl")
+        self.autocontrast_cb = QPushButton("Auto"); self.autocontrast_cb.setObjectName("autoPill")
+        self.autocontrast_cb.setCheckable(True); self.autocontrast_cb.setChecked(True)
+        self.autocontrast_cb.setCursor(Qt.PointingHandCursor)
+        self.autocontrast_cb.toggled.connect(self._on_autocontrast)
+        ch.addWidget(ct_lbl); ch.addStretch(); ch.addWidget(self.autocontrast_cb)
+        root.addLayout(ch)
+        root.addSpacing(8)
+
+        self.contrast = _ContrastSlider(Qt.Horizontal)
+        self.contrast.setRange(0, 1000); self.contrast.setValue((0, 1000))
+        self.contrast.valueChanged.connect(self._on_contrast)
+        root.addWidget(self.contrast)
+        root.addSpacing(8)
+
+        cv = QHBoxLayout()
+        self.cmin_val = QLabel("0"); self.cmin_val.setObjectName("valSm")
+        self.cmax_val = QLabel("0"); self.cmax_val.setObjectName("valSm")
+        cv.addWidget(self.cmin_val); cv.addStretch(); cv.addWidget(self.cmax_val)
+        root.addLayout(cv)
+        root.addSpacing(14)
+
+        self.btn_reset = QPushButton("Reset adjustments"); self.btn_reset.setObjectName("resetBtn")
+        self.btn_reset.setCursor(Qt.PointingHandCursor)
+        self.btn_reset.clicked.connect(self._on_reset)
+        root.addWidget(self.btn_reset)
+
+    def _slider_row(self, root, label: str, lo: int, hi: int, val: int):
+        head = QHBoxLayout()
+        lbl = QLabel(label); lbl.setObjectName("ctrlLbl")
+        valw = QLabel(); valw.setObjectName("valLbl")
+        head.addWidget(lbl); head.addStretch(); head.addWidget(valw)
+        root.addLayout(head)
+        root.addSpacing(7)
+        s = QSlider(Qt.Horizontal); s.setRange(lo, hi); s.setValue(val)
+        root.addWidget(s)
+        root.addSpacing(13)
+        return s, valw
+
+    # ── populate / select ─────────────────────────────────────────────────
+
+    def set_layers(self, layers: List[FMLayer]) -> None:
+        self._layers = layers
+        self._updating = True
+        prev = self._selected
+        for row in self._rows:
+            self._list_box.removeWidget(row)
+            row.setParent(None)
+            row.deleteLater()
+        self._rows = []
+        for i, layer in enumerate(layers):
+            row = _ChannelRow(i, layer)
+            row.selected.connect(self._select_row)
+            row.visibility_changed.connect(self._on_visibility)
+            self._list_box.addWidget(row)
+            self._rows.append(row)
+        self._selected = prev if 0 <= prev < len(layers) else 0
+        self._updating = False
+        self._refresh_selection()
+        self._sync_detail()
+
+    def _select_row(self, index: int) -> None:
+        if index == self._selected or not (0 <= index < len(self._layers)):
+            return
+        self._selected = index
+        self._refresh_selection()
+        self._sync_detail()
+
+    def _refresh_selection(self) -> None:
+        for i, row in enumerate(self._rows):
+            row.set_selected(i == self._selected)
+
+    def _current(self) -> Optional[FMLayer]:
+        return self._layers[self._selected] if 0 <= self._selected < len(self._layers) else None
+
+    def _sync_detail(self) -> None:
+        layer = self._current()
+        prev_updating = self._updating  # save/restore so a caller's guard survives
+        self._updating = True
+        if layer is None:
+            self.sel_name.setText("—")
+            self.sel_chip.setStyleSheet("background: transparent;")
+        else:
+            self.sel_chip.setStyleSheet(_chip_css(layer.color))
+            self.sel_name.setText(layer.name)
+            self.colormap.setCurrentText(layer.color)
+            self.opacity.setValue(int(layer.opacity * 100))
+            self.opacity_val.setText("%d%%" % int(layer.opacity * 100))
+            self.gamma.setValue(int(layer.gamma * 100))
+            self.gamma_val.setText("%.2f" % layer.gamma)
+            self.autocontrast_cb.setChecked(layer.autocontrast)
+            self.contrast.setEnabled(not layer.autocontrast)  # manual edits only when off
+            if layer.data is not None:
+                d = np.asarray(layer.data, dtype=np.float32)
+                lo_d, hi_d = float(d.min()), float(d.max())
+                span = max(hi_d - lo_d, 1.0)
+                if layer.autocontrast or layer.clim is None:
+                    clo, chi = auto_clim(d)
+                else:
+                    clo, chi = layer.clim
+                self._data_lo, self._data_span = lo_d, span
+                self.contrast.setValue((
+                    int((clo - lo_d) / span * 1000),
+                    int((chi - lo_d) / span * 1000),
+                ))
+                self.cmin_val.setText("%d" % round(clo))
+                self.cmax_val.setText("%d" % round(chi))
+        self._updating = prev_updating
+
+    # ── edits ─────────────────────────────────────────────────────────────
+
+    def _on_visibility(self, index: int, visible: bool) -> None:
+        if self._updating or not (0 <= index < len(self._layers)):
+            return
+        self._layers[index].visible = visible
+        self.changed.emit()
+
+    def _on_colormap(self, color: str) -> None:
+        layer = self._current()
+        if self._updating or layer is None or not color:
+            return
+        layer.color = color
+        self.sel_chip.setStyleSheet(_chip_css(color))
+        if 0 <= self._selected < len(self._rows):
+            self._rows[self._selected].set_color(color)
+        self.changed.emit()
+
+    def _on_opacity(self, value: int) -> None:
+        self.opacity_val.setText("%d%%" % value)
+        layer = self._current()
+        if self._updating or layer is None:
+            return
+        layer.opacity = value / 100.0
+        self.changed.emit()
+
+    def _on_gamma(self, value: int) -> None:
+        self.gamma_val.setText("%.2f" % (value / 100.0))
+        layer = self._current()
+        if self._updating or layer is None:
+            return
+        layer.gamma = value / 100.0
+        self.changed.emit()
+
+    def _on_reset(self) -> None:
+        """Reset the selected channel's display adjustments (opacity / gamma /
+        contrast → auto); colour + visibility are kept."""
+        layer = self._current()
+        if layer is None:
+            return
+        layer.opacity = 1.0
+        layer.gamma = 1.0
+        layer.autocontrast = True
+        layer.clim = None
+        self._sync_detail()
+        self.changed.emit()
+
+    def _on_autocontrast(self, checked: bool) -> None:
+        layer = self._current()
+        if self._updating or layer is None:
+            return
+        layer.autocontrast = checked
+        layer.manual = not checked  # explicit user choice — survives live frames / MIP toggles
+        if not checked and layer.clim is None and layer.data is not None:
+            # seed manual limits from the current auto values so the image doesn't jump
+            layer.clim = auto_clim(np.asarray(layer.data, dtype=np.float32))
+        self._sync_detail()  # refresh slider value + enabled state
+        self.changed.emit()
+
+    def _on_contrast(self) -> None:
+        layer = self._current()
+        lo_n, hi_n = self.contrast.value()
+        lo = self._data_lo + lo_n / 1000.0 * self._data_span
+        hi = self._data_lo + hi_n / 1000.0 * self._data_span
+        self.cmin_val.setText("%d" % round(lo))
+        self.cmax_val.setText("%d" % round(hi))
+        if self._updating or layer is None:
+            return
+        if hi > lo:
+            layer.clim = (lo, hi)
+            self.changed.emit()

--- a/fibsem/ui/widgets/canvas/fm_composite.py
+++ b/fibsem/ui/widgets/canvas/fm_composite.py
@@ -1,0 +1,127 @@
+"""Multi-channel fluorescence compositing for the quad-view FM canvas.
+
+Blends per-channel grayscale frames into one RGB image the way napari does on the
+main tab — each channel tinted by its colour and **additively** summed — so the
+matplotlib `FibsemImageCanvas` can show the colocalised multi-channel result.
+
+Reusable + Qt-free: the coincidence viewer (which currently max-projects to
+grayscale) could converge onto this later.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+import numpy as np
+from matplotlib.colors import to_rgb
+
+# Canonical channel colours (mirrors channel_list_widget.AVAILABLE_COLORS).
+AVAILABLE_COLORS = ["violet", "blue", "cyan", "green", "yellow", "red", "gray"]
+
+_WHITE = (1.0, 1.0, 1.0)
+
+
+@dataclass
+class FMLayer:
+    """One fluorescence channel's display state (separate from acquisition
+    ``ChannelSettings``, which only carries ``name`` + ``color``)."""
+
+    name: str
+    data: Optional[np.ndarray] = None        # 2D (H, W)
+    color: str = "gray"
+    opacity: float = 1.0                      # 0..1
+    clim: Optional[Tuple[float, float]] = None  # manual limits (used when not auto)
+    visible: bool = True
+    autocontrast: bool = True                 # recompute clim from data each composite
+    # The user explicitly chose manual contrast (turned Auto off). Distinct from
+    # ``autocontrast``, which the z-scrub display path also toggles internally: the
+    # single-plane / MIP display path keeps a manual channel's clim across live frames /
+    # MIP toggles, but still restores auto for a channel the user left on Auto.
+    manual: bool = False
+    gamma: float = 1.0                        # display = norm ** gamma (1 = linear)
+    # cached auto clim, keyed on the data array identity so it's recomputed only
+    # when the channel's data actually changes (not on every unrelated recomposite,
+    # e.g. an opacity-slider drag). Not part of the layer's value.
+    _clim_cache: Optional[Tuple] = field(default=None, repr=False, compare=False)
+
+
+# Canonical channel-colour tints = napari's colormap endpoints (the colour each
+# colormap ramps to at full intensity), so the composite matches the napari main
+# tab. These mostly agree with matplotlib's named colours; the notable difference
+# is "green" (mpl (0, 0.5, 0) vs napari (0, 1, 0)). "gray" ramps to white.
+_CANONICAL_TINTS = {
+    "violet": (0.933, 0.510, 0.933),
+    "blue": (0.0, 0.0, 1.0),
+    "cyan": (0.0, 1.0, 1.0),
+    "green": (0.0, 1.0, 0.0),
+    "yellow": (1.0, 1.0, 0.0),
+    "red": (1.0, 0.0, 0.0),
+    "magenta": (1.0, 0.0, 1.0),
+    "gray": _WHITE,
+}
+
+
+def tint_rgb(color: str) -> Tuple[float, float, float]:
+    """RGB tint for a channel colour. Canonical channel colours use napari's
+    colormap endpoint (so the composite matches the napari main tab); unknown
+    names fall back to matplotlib, and anything unrecognised to white."""
+    if color in _CANONICAL_TINTS:
+        return _CANONICAL_TINTS[color]
+    try:
+        return to_rgb(color)
+    except (ValueError, TypeError):
+        return _WHITE
+
+
+def auto_clim(data: np.ndarray, max_samples: int = 250_000) -> Tuple[float, float]:
+    """Robust auto contrast limits (1st/99th percentile, min/max fallback).
+
+    The full-resolution percentile is the dominant per-frame cost on live FM, so
+    for large frames the data is strided down to ~*max_samples* points first — the
+    1st/99th percentiles are visually identical on the subsample.
+    """
+    if data.ndim == 2 and data.size > max_samples:
+        step = int(np.ceil(np.sqrt(data.size / max_samples)))
+        data = data[::step, ::step]
+    lo = float(np.percentile(data, 1.0))
+    hi = float(np.percentile(data, 99.0))
+    if hi <= lo:
+        lo, hi = float(np.min(data)), float(np.max(data))
+        if hi <= lo:
+            hi = lo + 1.0
+    return lo, hi
+
+
+def composite_fm_layers(
+    layers: List[FMLayer], shape: Optional[Tuple[int, int]] = None
+) -> Optional[np.ndarray]:
+    """Blend the visible *layers* into an ``(H, W, 3)`` uint8 RGB image.
+
+    Each visible layer is contrast-normalised by its ``clim`` (or auto), tinted by
+    ``color`` scaled by ``opacity``, and additively summed; the result is clipped.
+    Returns ``None`` if there is nothing to show and *shape* is unknown.
+    """
+    visible = [l for l in layers if l.visible and l.data is not None]
+    if not visible:
+        return np.zeros((*shape, 3), dtype=np.uint8) if shape is not None else None
+    H, W = shape if shape is not None else visible[0].data.shape[:2]
+    rgb = np.zeros((H, W, 3), dtype=np.float32)
+    for layer in visible:
+        d = np.asarray(layer.data, dtype=np.float32)
+        if d.shape[:2] != (H, W):
+            continue  # ignore mismatched-shape channels
+        if layer.autocontrast or layer.clim is None:
+            cache = layer._clim_cache
+            if cache is not None and cache[0] is layer.data:
+                lo, hi = cache[1]  # data unchanged → reuse (skip the percentile)
+            else:
+                lo, hi = auto_clim(d)
+                layer._clim_cache = (layer.data, (lo, hi))
+        else:
+            lo, hi = layer.clim
+        norm = np.clip((d - lo) / (hi - lo), 0.0, 1.0) if hi > lo else np.zeros_like(d)
+        if layer.gamma != 1.0:
+            norm = np.power(norm, layer.gamma)
+        tint = np.asarray(tint_rgb(layer.color), dtype=np.float32) * float(layer.opacity)
+        rgb += norm[..., None] * tint
+    return (np.clip(rgb, 0.0, 1.0) * 255.0).astype(np.uint8)

--- a/fibsem/ui/widgets/canvas/image_canvas.py
+++ b/fibsem/ui/widgets/canvas/image_canvas.py
@@ -1,0 +1,977 @@
+"""FibsemImageCanvas — reusable matplotlib image canvas with pluggable overlays.
+
+Zoom: scroll wheel centred on cursor.
+Pan: left-drag on empty canvas area.
+
+Overlays implement a simple duck-typed protocol::
+
+    class MyOverlay:
+        def attach(self, ax, canvas: FibsemImageCanvas) -> None: ...
+        def detach(self) -> None: ...
+        def on_image_changed(self, width: int, height: int) -> None: ...
+
+Overlays that need Qt signals extend QObject directly.  An overlay that wants
+to suppress canvas pan/zoom during a drag sets ``canvas._overlay_consuming_event = True``
+on button-press; the canvas clears the flag automatically on button-release.
+
+The overlay classes themselves live in the :mod:`fibsem.ui.widgets.canvas.overlays`
+package (``CanvasOverlay`` base + ``PointsOverlay`` / ``PointOverlay`` /
+``RectOverlay`` / ``RulerOverlay`` / ``PatternOverlay`` / ``ScanDirectionArrowOverlay``
+and the milling / mask / alignment / minimap overlays).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+import numpy as np
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+from matplotlib.figure import Figure
+from PyQt5.QtCore import QSize, QTimer, Qt, pyqtSignal
+from PyQt5.QtWidgets import QApplication, QPushButton, QSizePolicy
+
+from fibsem.structures import FibsemImage
+from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.stylesheets import CANVAS_BG as _BG, PRIMARY_ACCENT as _ACCENT
+from fibsem.ui.widgets.canvas.contrast_gamma_control import ContrastGammaControl
+
+if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+    from fibsem.ui.widgets.canvas.overlays.ruler_overlay import RulerOverlay
+
+_logger = logging.getLogger(__name__)
+
+_LIVE_BADGE_BG = "#2e7d32"  # dark green behind the white "● LIVE" badge
+_MAX_DISPLAY_PX = 2048
+_ZOOM_FACTOR = 1.15
+_REDRAW_INTERVAL = 32  # ms (~60 fps)
+
+_OVERLAY_BTN_STYLE = (
+    "QPushButton { background: rgba(40,41,48,180); border: 1px solid #555;"
+    " border-radius: 3px; padding: 0px; }"
+    "QPushButton:hover { background: rgba(74,74,74,200); }"
+    "QPushButton:pressed { background: rgba(30,30,30,220); }"
+    "QPushButton:checked { background: rgba(90,92,100,200); border-color: #FFFFFF; }"
+)
+_OVERLAY_ICON_SIZE = QSize(14, 14)
+_OVERLAY_BTN_SIZE = 22
+_OVERLAY_MARGIN = 4
+_OVERLAY_GAP = 2
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _downsample(arr: np.ndarray, max_px: int) -> np.ndarray:
+    h, w = arr.shape[:2]
+    if h <= max_px and w <= max_px:
+        return arr
+    stride = max(1, math.ceil(max(h, w) / max_px))
+    return arr[::stride, ::stride] if arr.ndim == 2 else arr[::stride, ::stride, :]
+
+
+# Keyboard modifiers mapped to napari-style strings, so handler bodies that
+# branch on ``"Alt" in modifiers`` port across from the napari callbacks verbatim.
+_QT_MODIFIER_MAP = (
+    (Qt.AltModifier, "Alt"),
+    (Qt.ShiftModifier, "Shift"),
+    (Qt.ControlModifier, "Control"),
+    (Qt.MetaModifier, "Meta"),
+)
+
+
+def _modifiers_from_event(event) -> Tuple[str, ...]:
+    """Active keyboard modifiers as napari-style strings, e.g. ``("Alt",)``.
+
+    Reads the underlying Qt event (``event.guiEvent``) — the Qt modifier state is
+    the reliable source in an embedded canvas, whereas matplotlib's
+    ``MouseEvent.key`` depends on canvas keyboard focus.  Falls back to the
+    application-wide modifier state when no Qt event is attached.
+    """
+    gui = getattr(event, "guiEvent", None)
+    mods = gui.modifiers() if gui is not None else QApplication.keyboardModifiers()
+    return tuple(name for flag, name in _QT_MODIFIER_MAP if mods & flag)
+
+
+# ---------------------------------------------------------------------------
+# FibsemImageCanvas
+# ---------------------------------------------------------------------------
+
+
+class FibsemImageCanvas(FigureCanvasQTAgg):
+    """Reusable matplotlib canvas for FibsemImage.
+
+    * Scroll-wheel zoom centred on cursor
+    * Left-drag pan on empty area
+    * Pluggable overlay objects via add_overlay() / remove_overlay()
+    * Optional scalebar (auto-populated from FibsemImage.metadata.pixel_size)
+    """
+
+    # Trailing ``object`` is a tuple of napari-style modifier strings, e.g. ("Alt",).
+    canvas_clicked = pyqtSignal(float, float, object)  # left single-click (x, y) px, mods
+    canvas_double_clicked = pyqtSignal(float, float, object)  # left double-click (x, y) px, mods
+    canvas_right_clicked = pyqtSignal(float, float, object)  # right single-click (x, y) px, mods
+    canvas_scrolled = pyqtSignal(float, float, int, object)  # (x, y) px, dir +1/-1, mods
+
+    def __init__(self, parent=None):
+        self._fig = Figure(facecolor=_BG)
+        # Axes + figure background; overridable via set_background_color (the minimap
+        # uses black). The label/hint bboxes keep their own colours.
+        self._facecolor = _BG
+        # Extra empty space around the image when fitting the view, as a fraction of the
+        # image size per side (0 = tight to the image; set via set_view_margin). Lets
+        # overlays that extend past the image (stage limits, grid boundary) stay visible.
+        self._view_margin = 0.0
+        super().__init__(self._fig)
+        self.setParent(parent)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+        self._ax = self._fig.add_subplot(111)
+        self._ax.set_facecolor(self._facecolor)
+        self._ax.axis("off")
+        self._fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
+
+        self._img_w: Optional[int] = None
+        self._img_h: Optional[int] = None
+        self._overlays: List[CanvasOverlay] = []
+        self._pan_start: Optional[Tuple] = None
+        # Modifiers captured at left-press, emitted with canvas_clicked on release
+        self._press_modifiers: Tuple[str, ...] = ()
+
+        # Overlays set this True on press to suppress canvas pan
+        self._overlay_consuming_event: bool = False
+
+        # Active-overlay input gating. None = default "Move" (full navigation +
+        # stage movement + milling menu). When set, that overlay owns input and
+        # the canvas suppresses its semantic click signals; see the design doc's
+        # active-overlay model. _mode_overlay/_mode_label back the toolbar toggle.
+        self._active_overlay = None
+        self._mode_overlay = None
+        self._mode_label: str = ""
+
+        self._pixel_size: Optional[float] = None
+        self._scalebar_artist = None
+        self._scalebar_visible: bool = True
+        self._crosshair_visible: bool = True
+        self._crosshair_artists: list = []
+        self._hint_artist = None  # transient top-left instruction hint
+        self._hint_text: Optional[str] = None  # remembered so it survives set_image
+        self._info_artist = None  # bottom-left microscope-state info bar
+        self._info_text: Optional[str] = None  # remembered so it survives set_image
+        self._live_artist = None  # top-right "LIVE" badge during live acquisition
+        self._live_on: bool = False  # remembered so it survives set_image
+
+        # Transient top-centre flash message (e.g. "WD 4.001 mm" on Shift+scroll); auto-clears
+        self._flash_artist = None
+        self._flash_text: Optional[str] = None
+        self._flash_timer = QTimer(self)
+        self._flash_timer.setSingleShot(True)
+        self._flash_timer.timeout.connect(self._clear_flash)
+
+        # Optional patch legend (list of (color, label)); re-applied across image changes.
+        self._legend_artist = None
+        self._legend_entries: Optional[List[Tuple[str, str]]] = None
+        self._legend_loc: str = "upper right"
+
+        # Drag-to-measure ruler (lazily created on first toggle; see toggle_ruler).
+        self._ruler_overlay: Optional["RulerOverlay"] = None
+
+        # Contrast / gamma (display-only; applied to the downsampled grayscale frame)
+        self._display_base: Optional[np.ndarray] = None
+        self._norm: Optional[np.ndarray] = None  # normalized base, computed lazily
+        self._is_gray: bool = True
+
+        self._redraw_timer = QTimer(self)
+        self._redraw_timer.setSingleShot(True)
+        self._redraw_timer.setInterval(_REDRAW_INTERVAL)
+        self._redraw_timer.timeout.connect(self.draw_idle)
+
+        self.mpl_connect("button_press_event", self._on_press)
+        self.mpl_connect("motion_notify_event", self._on_motion)
+        self.mpl_connect("button_release_event", self._on_release)
+        self.mpl_connect("scroll_event", self._on_scroll)
+        self.mpl_connect("resize_event", lambda _: self.draw_idle())
+
+        # Overlay buttons (parented to self; repositioned in resizeEvent)
+        self._overlay_buttons: List[QPushButton] = []
+        # Toolbar-group visibility (quad-view "only the selected view shows its toolbar").
+        # _toolbar_hidden snapshots the buttons hidden by the group toggle so they restore
+        # exactly (buttons hidden for other reasons — e.g. FM hides btn_contrast — stay hidden).
+        self._toolbar_visible: bool = True
+        self._toolbar_hidden: List[QPushButton] = []
+        self.btn_reset_view = self._add_overlay_button(
+            "mdi:fit-to-screen-outline", "Reset view", self.reset_view
+        )
+        self.btn_toggle_scalebar = self._add_overlay_button(
+            "mdi:arrow-expand-horizontal", "Hide scalebar", self.toggle_scalebar, checkable=True
+        )
+        self.btn_toggle_scalebar.setChecked(True)
+        self.btn_toggle_crosshair = self._add_overlay_button(
+            "mdi:crosshairs", "Hide crosshair", self.toggle_crosshair, checkable=True
+        )
+        self.btn_toggle_crosshair.setChecked(True)
+        self.btn_contrast = self._add_overlay_button(
+            "mdi:contrast-box", "Contrast / Gamma", self.toggle_contrast, checkable=True
+        )
+        self.btn_toggle_ruler = self._add_overlay_button(
+            "mdi:ruler", "Measure (ruler)", self.toggle_ruler, checkable=True
+        )
+        # Contextual mode toggle — shown only while an overlay owns input
+        # (enter_overlay_mode). Checked = active; unchecking returns to Move.
+        self.btn_mode = self._add_overlay_button(
+            "mdi:cursor-default-click", "", self._on_mode_button_clicked, checkable=True
+        )
+        self.btn_mode.hide()
+
+        # Floating contrast / gamma popover, anchored under btn_contrast
+        self._contrast = ContrastGammaControl(self)
+        self._contrast.changed.connect(self._apply_contrast)
+
+        self._plot_empty()
+
+    # ── properties ────────────────────────────────────────────────────────
+
+    @property
+    def img_width(self) -> Optional[int]:
+        return self._img_w
+
+    @property
+    def img_height(self) -> Optional[int]:
+        return self._img_h
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    def set_image(self, image: FibsemImage, cmap: str = "gray") -> None:
+        """Display a FibsemImage.  Notifies all registered overlays."""
+        pixel_size = None
+        try:
+            if image.metadata and image.metadata.pixel_size:
+                pixel_size = image.metadata.pixel_size.x
+        except Exception:
+            pass
+        self.set_array(image.filtered_data, pixel_size=pixel_size, cmap=cmap)
+
+    def set_array(
+        self,
+        arr: np.ndarray,
+        pixel_size: Optional[float] = None,
+        cmap: str = "gray",
+    ) -> None:
+        """Display a raw 2-D (grayscale) or HxWx3 (RGB) array.
+
+        The lower-level entry point behind :meth:`set_image`, for composites/RGB
+        that have no backing ``FibsemImage`` (e.g. the multi-channel FM canvas).
+        *pixel_size* (metres/px) drives the scalebar; ``None`` leaves the current
+        value unchanged.  Notifies all registered overlays.
+        """
+        arr = np.asarray(arr)
+        h, w = arr.shape[:2]
+        # Preserve the current zoom/pan across a same-resolution update — otherwise live
+        # acquisition re-frames on every frame. Auto-fit only on the first image or a
+        # resolution change; the toolbar "fit to view" (reset_view) still fits on demand.
+        had_image = self._img_w is not None
+        prev_wh = (self._img_w, self._img_h)
+        prev_xlim, prev_ylim = self._ax.get_xlim(), self._ax.get_ylim()
+        self._img_w, self._img_h = w, h
+
+        self._ax.cla()
+        self._ax.set_facecolor(self._facecolor)
+        self._ax.axis("off")
+        self._fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
+
+        self._display_base = _downsample(arr, _MAX_DISPLAY_PX)
+        self._is_gray = arr.ndim == 2
+        self._norm = None  # recomputed lazily when contrast is engaged
+        extent = (-0.5, w - 0.5, h - 0.5, -0.5)
+        kw = dict(
+            origin="upper", aspect="equal", interpolation="nearest", extent=extent
+        )
+        to_show, clim = self._contrast_display()
+        if self._is_gray:
+            im = self._ax.imshow(to_show, cmap=cmap, **kw)
+            if clim is not None:
+                im.set_clim(*clim)
+        else:
+            self._ax.imshow(to_show, **kw)
+
+        if had_image and prev_wh == (w, h):
+            self._ax.set_xlim(prev_xlim)  # same resolution -> keep the user's zoom/pan
+            self._ax.set_ylim(prev_ylim)
+        else:
+            self._fit_view()
+
+        # Scalebar
+        self._scalebar_artist = None
+        if pixel_size and pixel_size > 0:
+            self._pixel_size = pixel_size
+        self._refresh_scalebar()
+        self._refresh_crosshair()
+        self._refresh_hint()  # axes was cleared above; restore the remembered hint
+        self._refresh_info_bar()  # ditto: restore the remembered info bar
+        self._refresh_live_badge()  # ditto: keep the LIVE badge across streamed frames
+        self._refresh_flash()  # ditto: keep a live flash (e.g. WD scroll) visible across frames
+        self._refresh_legend()  # ditto: restore the patch legend
+
+        for overlay in self._overlays:
+            try:
+                overlay.on_image_changed(w, h)
+            except Exception:
+                _logger.exception("Overlay on_image_changed failed: %r", overlay)
+
+        self.draw_idle()
+
+    def update_display(self, arr: np.ndarray, pixel_size: Optional[float] = None) -> None:
+        """Fast pixel-data swap without resetting overlays.
+
+        Use for z-slice navigation / recomposites where image dimensions don't change.
+        *pixel_size* (metres/px) updates the scalebar if it changed — important when the
+        same-shape swap actually carries a different scale (e.g. a real overview replacing
+        a blank placeholder of matching pixel dimensions). ``None`` leaves it unchanged.
+        Falls back to a no-op if no image has been set yet.
+        """
+        imgs = self._ax.get_images()
+        if not imgs:
+            return
+        self._display_base = _downsample(arr, _MAX_DISPLAY_PX)
+        self._is_gray = arr.ndim == 2
+        self._norm = None
+        to_show, clim = self._contrast_display()
+        imgs[0].set_data(to_show)
+        if clim is not None:
+            imgs[0].set_clim(*clim)
+        if pixel_size and pixel_size > 0 and pixel_size != self._pixel_size:
+            self._pixel_size = pixel_size
+            self._refresh_scalebar()
+        self.draw_idle()
+
+    def set_crosshair_visible(self, visible: bool) -> None:
+        """Show or hide the yellow crosshair centred on the image."""
+        self._crosshair_visible = visible
+        self._refresh_crosshair()
+        self.draw_idle()
+
+    def set_hint(self, text: Optional[str]) -> None:
+        """Show a small instruction hint in the top-left corner, or hide with None.
+
+        Drawn in axes-fraction coords so it stays fixed through zoom/pan.  The text
+        is remembered and re-applied after each image change (``set_image`` clears
+        the axes), so the hint is not silently dropped by a new acquisition.
+        """
+        self._hint_text = text or None
+        self._refresh_hint()
+        self.draw_idle()
+
+    def _refresh_hint(self) -> None:
+        """(Re)create the hint artist from the cached text, or remove it."""
+        if self._hint_artist is not None:
+            try:
+                self._hint_artist.remove()
+            except Exception:
+                pass
+            self._hint_artist = None
+        if self._hint_text:
+            self._hint_artist = self._ax.text(
+                0.012, 0.985, self._hint_text,
+                transform=self._ax.transAxes, ha="left", va="top",
+                fontsize=8, color="#1a1a1a", zorder=11,
+                bbox=dict(boxstyle="round,pad=0.3", facecolor="#e6e6e6",
+                          edgecolor="none", alpha=0.85),
+            )
+
+    def set_info_text(self, text: Optional[str]) -> None:
+        """Show a small, muted info bar in the bottom-left, or hide with None/''.
+
+        Remembered + re-applied after each image change (like the hint). Driven by
+        the controller from the canvas-state model — microscope state, not image."""
+        self._info_text = text or None
+        self._refresh_info_bar()
+        self.draw_idle()
+
+    def _refresh_info_bar(self) -> None:
+        """(Re)create the info artist from the cached text, or remove it."""
+        if self._info_artist is not None:
+            try:
+                self._info_artist.remove()
+            except Exception:
+                pass
+            self._info_artist = None
+        if self._info_text:
+            self._info_artist = self._ax.text(
+                0.012, 0.015, self._info_text,
+                transform=self._ax.transAxes, ha="left", va="bottom",
+                fontsize=6.5, color="#e8e8e8", zorder=11,
+                bbox=dict(boxstyle="round,pad=0.25", facecolor=_BG,
+                          edgecolor="none", alpha=0.55),
+            )
+
+    def set_live_badge(self, on: bool) -> None:
+        """Show/hide a green "● LIVE" badge in the top-right during live acquisition.
+
+        Remembered + re-applied after each image change (like the info bar), so it stays put as
+        live frames stream in."""
+        self._live_on = bool(on)
+        self._refresh_live_badge()
+        self.draw_idle()
+
+    def _refresh_live_badge(self) -> None:
+        """(Re)create the LIVE badge artist, or remove it."""
+        if self._live_artist is not None:
+            try:
+                self._live_artist.remove()
+            except Exception:
+                pass
+            self._live_artist = None
+        if self._live_on:
+            self._live_artist = self._ax.text(
+                0.988, 0.985, "● LIVE",
+                transform=self._ax.transAxes, ha="right", va="top",
+                fontsize=7, color="#ffffff", zorder=12, fontweight="bold",
+                bbox=dict(boxstyle="round,pad=0.3", facecolor=_LIVE_BADGE_BG,
+                          edgecolor="none", alpha=0.9),
+            )
+
+    def flash_message(self, text: str, duration_ms: int = 1200) -> None:
+        """Show a brief top-centre status message that auto-clears after *duration_ms*.
+
+        Repeated calls refresh the text and restart the timer, so it stays visible during a
+        burst (e.g. Shift+scroll working-distance nudges) and fades shortly after the last
+        event. Independent of :meth:`set_hint` / :meth:`set_info_text` — transient, not
+        remembered across image changes."""
+        self._flash_text = text or None
+        self._refresh_flash()
+        self.draw_idle()
+        if self._flash_text:
+            self._flash_timer.start(duration_ms)
+
+    def _refresh_flash(self) -> None:
+        """(Re)create the flash artist from the cached text, or remove it."""
+        if self._flash_artist is not None:
+            try:
+                self._flash_artist.remove()
+            except Exception:
+                pass
+            self._flash_artist = None
+        if self._flash_text:
+            self._flash_artist = self._ax.text(
+                0.5, 0.975, self._flash_text,
+                transform=self._ax.transAxes, ha="center", va="top",
+                fontsize=9, color="#e8e8e8", zorder=12,
+                bbox=dict(boxstyle="round,pad=0.35", facecolor=_BG,
+                          edgecolor=_ACCENT, linewidth=1.0, alpha=0.85),
+            )
+
+    def _clear_flash(self) -> None:
+        self._flash_text = None
+        self._refresh_flash()
+        self.draw_idle()
+
+    def set_legend(self, entries, loc: str = "upper right") -> None:
+        """Show a small patch legend, or clear it with None / an empty list.
+
+        *entries* is a sequence of ``(color, label)`` pairs, each drawn as a filled
+        swatch. Remembered and re-applied after every image change (like the hint /
+        info bar), so a new frame doesn't silently drop it."""
+        self._legend_entries = list(entries) if entries else None
+        self._legend_loc = loc
+        self._refresh_legend()
+        self.draw_idle()
+
+    def _refresh_legend(self) -> None:
+        """(Re)create the legend artist from the cached entries, or remove it.
+
+        Each entry is ``(color, label)`` (a filled swatch) or ``(color, label, marker)``
+        (a marker glyph, e.g. ``"+"`` for a crosshair / point of interest)."""
+        if self._legend_artist is not None:
+            try:
+                self._legend_artist.remove()
+            except Exception:
+                pass
+            self._legend_artist = None
+        if not self._legend_entries:
+            return
+        import matplotlib.patches as mpatches
+        from matplotlib.legend import Legend
+        from matplotlib.lines import Line2D
+
+        labels, handles = [], []
+        for entry in self._legend_entries:
+            color, label = entry[0], entry[1]
+            marker = entry[2] if len(entry) > 2 else None
+            labels.append(label)
+            if marker:
+                handles.append(Line2D(
+                    [], [], linestyle="None", marker=marker, markersize=9,
+                    color=color, markeredgewidth=1.6, label=label,
+                ))
+            else:
+                handles.append(mpatches.Patch(facecolor=color, edgecolor="white", label=label))
+        # Build the Legend directly (not ax.legend) so it doesn't replace an overlay's
+        # own legend (e.g. milling stages); styled like the point/milling legends.
+        leg = Legend(
+            self._ax, handles, labels, loc=self._legend_loc,
+            fontsize=7, facecolor=_BG, edgecolor="#555555",
+            labelcolor="#d1d2d4", framealpha=0.85,
+        )
+        leg.set_zorder(10)
+        self._ax.add_artist(leg)
+        self._legend_artist = leg
+
+    def clear(self) -> None:
+        """Clear the image and show placeholder text."""
+        self._img_w = self._img_h = None
+        self._display_base = None
+        self._norm = None
+        self._ax.cla()
+        self._scalebar_artist = None
+        self._crosshair_artists = []
+        self._hint_artist = None  # removed by cla(); drop the cached text too
+        self._hint_text = None
+        self._info_artist = None
+        self._info_text = None
+        self._live_artist = None
+        self._live_on = False
+        self._flash_artist = None
+        self._flash_text = None
+        self._flash_timer.stop()
+        self._legend_artist = None  # removed by cla(); drop the cached entries too
+        self._legend_entries = None
+        self._plot_empty()
+        for overlay in self._overlays:
+            try:
+                overlay.on_image_changed(0, 0)
+            except Exception:
+                pass
+        self.draw_idle()
+
+    # ── overlay buttons ───────────────────────────────────────────────────
+
+    def add_toolbar_button(
+        self, icon_name: str, tooltip: str, callback, checkable: bool = False
+    ) -> QPushButton:
+        """Public: add a custom button to the canvas's top-right toolbar (e.g. an
+        FM-layers control owned by a wrapper). Returns the QPushButton."""
+        return self._add_overlay_button(icon_name, tooltip, callback, checkable)
+
+    def _add_overlay_button(
+        self,
+        icon_name: str,
+        tooltip: str,
+        callback,
+        checkable: bool = False,
+    ) -> QPushButton:
+        """Create an overlay button parented to this canvas and register it.
+
+        Buttons are stacked right-to-left in the top-right corner and
+        repositioned automatically on resize.  Returns the button.
+        """
+        btn = QPushButton(self)
+        btn.setIcon(fibsem_icon(icon_name, color="#aaaaaa"))
+        btn.setIconSize(_OVERLAY_ICON_SIZE)
+        btn.setFixedSize(_OVERLAY_BTN_SIZE, _OVERLAY_BTN_SIZE)
+        btn.setToolTip(tooltip)
+        btn.setCheckable(checkable)
+        btn.setStyleSheet(_OVERLAY_BTN_STYLE)
+        btn.clicked.connect(callback)
+        btn.raise_()
+        self._overlay_buttons.append(btn)
+        self._reposition_overlay_buttons()
+        return btn
+
+    def _reposition_overlay_buttons(self) -> None:
+        """Place overlay buttons right-to-left in the top-right corner."""
+        x = self.width() - _OVERLAY_MARGIN
+        for btn in self._overlay_buttons:
+            if btn.isHidden():  # contextual buttons (e.g. mode toggle) reserve no slot
+                continue
+            x -= btn.width()
+            btn.move(x, _OVERLAY_MARGIN)
+            x -= _OVERLAY_GAP
+
+    def set_toolbar_visible(self, visible: bool) -> None:
+        """Show or hide this canvas's top-right toolbar buttons as a group.
+
+        Used by the quad view so only the selected canvas shows its toolbar. The
+        contextual mode toggle (:attr:`btn_mode`) is exempt — it follows overlay-mode
+        state, not selection — so an in-progress edit on a non-selected canvas keeps its
+        toggle. Buttons already hidden for other reasons (e.g. the FM canvas hides
+        ``btn_contrast``) stay hidden when the group is shown again.
+        """
+        if visible == self._toolbar_visible:
+            return
+        self._toolbar_visible = visible
+        if not visible:
+            self._toolbar_hidden = [
+                b for b in self._overlay_buttons
+                if b is not self.btn_mode and not b.isHidden()
+            ]
+            for b in self._toolbar_hidden:
+                b.hide()
+        else:
+            for b in self._toolbar_hidden:
+                b.show()
+            self._toolbar_hidden = []
+        self._reposition_overlay_buttons()
+
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        self._reposition_overlay_buttons()
+        contrast = getattr(self, "_contrast", None)
+        if contrast is not None and contrast.isVisible():
+            contrast.reposition()
+
+    def _fit_view(self) -> None:
+        """Set the view to the image extent expanded by ``_view_margin`` on each side."""
+        imgs = self._ax.get_images()
+        if not imgs:
+            return
+        xmin, xmax, ybot, ytop = imgs[0].get_extent()  # (xmin, xmax, ymax, ymin)
+        mx = self._view_margin * (xmax - xmin)
+        my = self._view_margin * abs(ybot - ytop)
+        self._ax.set_xlim(xmin - mx, xmax + mx)
+        self._ax.set_ylim(ybot + my, ytop - my)  # y-axis stays inverted (origin upper)
+
+    def set_view_margin(self, frac: float) -> None:
+        """Empty space kept around the image when fitting the view, as a fraction of the
+        image size per side (0 = tight, 0.5 = 2x the image extent). Also keeps overlays
+        that extend beyond the image (e.g. stage limits) visible."""
+        self._view_margin = max(0.0, float(frac))
+        self._fit_view()
+        self._schedule_redraw()
+
+    def set_background_color(self, color: str) -> None:
+        """Set the axes + figure background colour (the area around the image)."""
+        self._facecolor = color
+        self._fig.set_facecolor(color)
+        self._ax.set_facecolor(color)
+        self._schedule_redraw()
+
+    def reset_view(self) -> None:
+        """Fit the view to the image extent (plus any view margin)."""
+        self._fit_view()
+        self._schedule_redraw()
+
+    def add_overlay(self, overlay: CanvasOverlay) -> None:
+        """Register an overlay and attach it to the current axes."""
+        self._overlays.append(overlay)
+        overlay.attach(self._ax, self)
+        if self._img_w is not None:
+            try:
+                overlay.on_image_changed(self._img_w, self._img_h)
+            except Exception:
+                _logger.exception("Overlay on_image_changed failed: %r", overlay)
+        self.draw_idle()
+
+    def remove_overlay(self, overlay: CanvasOverlay) -> None:
+        if overlay in self._overlays:
+            self.exit_overlay_mode(overlay)  # no-op unless it owns the mode
+            if overlay is self._active_overlay:  # active without a toolbar mode
+                self._active_overlay = None
+            try:
+                overlay.detach()
+            except Exception:
+                _logger.exception("Overlay detach failed: %r", overlay)
+            self._overlays.remove(overlay)
+            self.draw_idle()
+
+    def clear_overlays(self) -> None:
+        for o in list(self._overlays):
+            self.remove_overlay(o)
+
+    # ── active-overlay input gating ───────────────────────────────────────
+
+    @property
+    def active_overlay(self):
+        """The overlay currently owning input, or None (default 'Move' mode)."""
+        return self._active_overlay
+
+    def set_active_overlay(self, overlay) -> None:
+        """Make *overlay* the sole input handler on this canvas (None = Move).
+
+        While set, the canvas suppresses its semantic click signals
+        (``canvas_clicked`` / ``canvas_double_clicked`` / ``canvas_right_clicked``),
+        so stage movement and the milling menu stand down and other interactive
+        overlays stand down; pan / zoom / scroll stay live. This is the low-level
+        primitive — :meth:`enter_overlay_mode` wraps it with the toolbar toggle.
+        """
+        self._active_overlay = overlay
+        self.draw_idle()
+
+    def _overlay_input_allowed(self, overlay) -> bool:
+        """True if *overlay* may handle input now (nothing active, or it's active)."""
+        return self._active_overlay is None or self._active_overlay is overlay
+
+    def enter_overlay_mode(
+        self, overlay, label: str, icon: str = "mdi:cursor-default-click"
+    ) -> None:
+        """Activate *overlay* and show the contextual toolbar toggle (checked).
+
+        Checked = the overlay owns input; unchecking returns to Move (re-enables
+        stage movement); re-checking re-activates. Call :meth:`exit_overlay_mode`
+        when the workflow step ends.
+        """
+        self._mode_overlay = overlay
+        self._mode_label = label
+        self.btn_mode.setIcon(fibsem_icon(icon, color="#aaaaaa"))
+        self.btn_mode.setToolTip(f"{label} active — click to enable Move")
+        self.btn_mode.setChecked(True)
+        self.btn_mode.show()
+        self._reposition_overlay_buttons()
+        self.set_active_overlay(overlay)
+
+    def exit_overlay_mode(self, overlay=None) -> None:
+        """Deactivate the overlay mode and hide the toolbar toggle (idempotent).
+
+        Pass *overlay* to scope the exit — it's a no-op unless that overlay owns
+        the current mode, so one caller can't tear down another's mode (POI and
+        alignment editing share the FIB canvas). ``None`` forces an exit.
+        """
+        if overlay is not None and overlay is not self._mode_overlay:
+            return
+        self._mode_overlay = None
+        self.btn_mode.setChecked(False)
+        self.btn_mode.hide()
+        self._reposition_overlay_buttons()
+        self.set_active_overlay(None)
+
+    def _on_mode_button_clicked(self) -> None:
+        """Toolbar toggle: flip between the bound overlay and Move (no teardown)."""
+        if self._mode_overlay is None:
+            return
+        if self.btn_mode.isChecked():
+            self.btn_mode.setToolTip(f"{self._mode_label} active — click to enable Move")
+            self.set_active_overlay(self._mode_overlay)
+        else:
+            self.btn_mode.setToolTip(f"Click to resume {self._mode_label}")
+            self.set_active_overlay(None)
+
+    # ── internals ─────────────────────────────────────────────────────────
+
+    def _plot_empty(self):
+        self._ax.set_facecolor(self._facecolor)
+        self._ax.axis("off")
+        self._ax.text(
+            0.5,
+            0.5,
+            "No image",
+            ha="center",
+            va="center",
+            transform=self._ax.transAxes,
+            fontsize=11,
+            color="#bbbbbb",
+        )
+
+    def toggle_scalebar(self) -> None:
+        """Show or hide the scalebar and update the button tooltip."""
+        self._scalebar_visible = not self._scalebar_visible
+        self.btn_toggle_scalebar.setChecked(self._scalebar_visible)
+        self.btn_toggle_scalebar.setToolTip(
+            "Hide scalebar" if self._scalebar_visible else "Show scalebar"
+        )
+        self._refresh_scalebar()
+        self.draw_idle()
+
+    def toggle_crosshair(self) -> None:
+        """Show or hide the crosshair and update the button tooltip."""
+        self.set_crosshair_visible(not self._crosshair_visible)
+        self.btn_toggle_crosshair.setChecked(self._crosshair_visible)
+        self.btn_toggle_crosshair.setToolTip(
+            "Hide crosshair" if self._crosshair_visible else "Show crosshair"
+        )
+
+    def toggle_ruler(self) -> None:
+        """Toggle the drag-to-measure ruler (a generic canvas tool).
+
+        While on, the ruler owns input (so a stray double-click/right-click
+        doesn't move the stage or open the milling menu); when turned off, input
+        returns to whatever the current overlay *mode* dictates.
+        """
+        if self.btn_toggle_ruler.isChecked():
+            if self._ruler_overlay is None:
+                from fibsem.ui.widgets.canvas.overlays.ruler_overlay import RulerOverlay
+
+                self._ruler_overlay = RulerOverlay()
+                self.add_overlay(self._ruler_overlay)
+            self._ruler_overlay.set_visible(True)
+            self.set_active_overlay(self._ruler_overlay)
+            self.btn_toggle_ruler.setToolTip("Hide ruler")
+        else:
+            if self._ruler_overlay is not None:
+                self._ruler_overlay.set_visible(False)
+            # Derive the restore target from the live mode state rather than a snapshot
+            # taken when the ruler was switched on: that snapshot goes stale if an overlay
+            # is armed / exited / removed while measuring — restoring it could undo a new
+            # arm, or re-activate a now-detached overlay and suppress input permanently.
+            restore = self._mode_overlay if self.btn_mode.isChecked() else None
+            self.set_active_overlay(restore)
+            self.btn_toggle_ruler.setToolTip("Measure (ruler)")
+
+    # ── contrast / gamma ──────────────────────────────────────────────────
+
+    def toggle_contrast(self) -> None:
+        """Show or hide the floating contrast / gamma popover."""
+        self._contrast.set_open(self.btn_contrast.isChecked(), self.btn_contrast)
+
+    def _contrast_display(self) -> Tuple[Optional[np.ndarray], Optional[Tuple[float, float]]]:
+        """Return (array_to_show, clim) for the current contrast state.
+
+        When the control is at its defaults (or the image is RGB) the raw
+        downsampled frame is returned with ``clim=None`` — i.e. no change.
+        """
+        base = self._display_base
+        if base is None:
+            return None, None
+        if self._is_gray and not self._contrast.is_default():
+            if self._norm is None:
+                self._norm = ContrastGammaControl.normalize(base)
+            return self._contrast.apply(self._norm), (0.0, 1.0)
+        return base, None
+
+    def _apply_contrast(self) -> None:
+        """Re-apply contrast/gamma to the live image without a full redraw."""
+        imgs = self._ax.get_images()
+        if not imgs:
+            return
+        to_show, clim = self._contrast_display()
+        if to_show is None:
+            return
+        im = imgs[0]
+        im.set_data(to_show)
+        if clim is not None:
+            im.set_clim(*clim)
+        elif self._is_gray and self._display_base is not None:
+            # back to default → restore the raw intensity range
+            im.set_clim(float(self._display_base.min()), float(self._display_base.max()))
+        self.draw_idle()
+
+    def _refresh_scalebar(self):
+        if self._scalebar_artist is not None:
+            try:
+                self._scalebar_artist.remove()
+            except (ValueError, NotImplementedError):
+                pass
+            self._scalebar_artist = None
+        if self._pixel_size is not None and self._scalebar_visible:
+            try:
+                from matplotlib_scalebar.scalebar import ScaleBar
+
+                self._scalebar_artist = ScaleBar(
+                    dx=self._pixel_size,
+                    color="white",
+                    box_color=_BG,
+                    box_alpha=0.6,
+                    location="lower right",
+                )
+                self._ax.add_artist(self._scalebar_artist)
+            except Exception:
+                pass
+
+    def _refresh_crosshair(self):
+        for a in self._crosshair_artists:
+            try:
+                a.remove()
+            except (ValueError, NotImplementedError):
+                pass
+        self._crosshair_artists = []
+        if not self._crosshair_visible or self._img_w is None:
+            return
+        cx, cy = self._img_w / 2.0, self._img_h / 2.0
+        # Size both arms from the longest dimension so the crosshair stays square
+        # (axes use aspect="equal", so equal data-unit arms are equal on screen).
+        half = max(self._img_w, self._img_h) * 0.05 / 2
+        kw = dict(color="yellow", linewidth=1, alpha=0.8, zorder=7)
+        (h_line,) = self._ax.plot([cx - half, cx + half], [cy, cy], **kw)
+        (v_line,) = self._ax.plot([cx, cx], [cy - half, cy + half], **kw)
+        self._crosshair_artists = [h_line, v_line]
+
+    def _schedule_redraw(self):
+        if not self._redraw_timer.isActive():
+            self._redraw_timer.start()
+
+    # ── mouse events ──────────────────────────────────────────────────────
+
+    def _on_press(self, event):
+        if event.inaxes is not self._ax or event.xdata is None:
+            return
+        if self._img_w is None:
+            # No image: axes span the default [0,1], so xdata/ydata are not image pixels.
+            # Suppress clicks/pan so a stray double-click can't drive a stage move to (~0,0).
+            return
+        mods = _modifiers_from_event(event)
+        if event.dblclick:
+            # active overlay owns input → suppress stage-move double-click
+            if event.button == 1 and self._active_overlay is None:
+                self.canvas_double_clicked.emit(event.xdata, event.ydata, mods)
+            return  # don't start a pan on double-click
+        if event.button == 3:
+            # active overlay owns input → suppress the right-click (milling) menu
+            if self._active_overlay is None:
+                self.canvas_right_clicked.emit(event.xdata, event.ydata, mods)
+            return
+        if event.button != 1:
+            return
+        # Capture now; canvas_clicked fires on release (after the drag-distance test)
+        self._press_modifiers = mods
+        inv = self._ax.transData.inverted()
+        self._pan_start = (
+            event.x,
+            event.y,
+            self._ax.get_xlim(),
+            self._ax.get_ylim(),
+            inv,
+        )
+
+    def _on_motion(self, event):
+        # Overlay in drag mode — cancel any pending pan
+        if self._overlay_consuming_event:
+            self._pan_start = None
+            return
+        if self._pan_start is None:
+            return
+        if event.x is None or event.y is None:
+            return
+        sx0, sy0, xlim0, ylim0, inv0 = self._pan_start
+        x0, y0 = inv0.transform((sx0, sy0))
+        x1, y1 = inv0.transform((event.x, event.y))
+        dx, dy = x1 - x0, y1 - y0
+        self._ax.set_xlim(xlim0[0] - dx, xlim0[1] - dx)
+        self._ax.set_ylim(ylim0[0] - dy, ylim0[1] - dy)
+        self._schedule_redraw()
+
+    def _on_release(self, event):
+        was_consuming = self._overlay_consuming_event
+        self._overlay_consuming_event = False
+        if event.button == 1 and self._pan_start is not None:
+            sx0, sy0, *_ = self._pan_start
+            dist = ((event.x - sx0) ** 2 + (event.y - sy0) ** 2) ** 0.5
+            if (
+                dist < 3
+                and not was_consuming
+                and self._active_overlay is None  # active overlay owns the click
+                and event.xdata is not None
+                and event.ydata is not None
+            ):
+                self.canvas_clicked.emit(event.xdata, event.ydata, self._press_modifiers)
+        self._pan_start = None
+
+    def _on_scroll(self, event):
+        if event.inaxes is not self._ax or event.xdata is None:
+            return
+        direction = 1 if event.button == "up" else -1
+        mods = _modifiers_from_event(event)
+        self.canvas_scrolled.emit(event.xdata, event.ydata, direction, mods)
+        if mods:
+            # modified scroll (e.g. Shift+scroll → objective) is claimed by a
+            # consumer via canvas_scrolled; don't also zoom
+            return
+        factor = 1.0 / _ZOOM_FACTOR if direction == 1 else _ZOOM_FACTOR
+        cx, cy = event.xdata, event.ydata
+        xlim = self._ax.get_xlim()
+        ylim = self._ax.get_ylim()
+        self._ax.set_xlim(cx + (xlim[0] - cx) * factor, cx + (xlim[1] - cx) * factor)
+        self._ax.set_ylim(cy + (ylim[0] - cy) * factor, cy + (ylim[1] - cy) * factor)
+        self._schedule_redraw()

--- a/fibsem/ui/widgets/canvas/overlays/__init__.py
+++ b/fibsem/ui/widgets/canvas/overlays/__init__.py
@@ -1,0 +1,34 @@
+"""Canvas overlays for :class:`fibsem.ui.widgets.canvas.image_canvas.FibsemImageCanvas`.
+
+Each overlay implements the duck-typed overlay protocol (``attach`` / ``detach`` /
+``on_image_changed``); most subclass :class:`CanvasOverlay`. Import overlay classes
+from this package, e.g. ``from fibsem.ui.widgets.canvas.overlays import MillingPatternOverlay``.
+"""
+
+from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay, PointsOverlay
+from fibsem.ui.widgets.canvas.overlays.rect_overlay import RectOverlay
+from fibsem.ui.widgets.canvas.overlays.ruler_overlay import RulerOverlay
+from fibsem.ui.widgets.canvas.overlays.pattern_overlay import (
+    PatternOverlay,
+    ScanDirectionArrowOverlay,
+)
+from fibsem.ui.widgets.canvas.overlays.alignment_overlay import AlignmentAreaOverlay
+from fibsem.ui.widgets.canvas.overlays.mask_overlay import MaskOverlay
+from fibsem.ui.widgets.canvas.overlays.milling_overlay import MillingPatternOverlay
+from fibsem.ui.widgets.canvas.overlays.minimap_overlays import MinimapShapesOverlay, ShapeSpec
+
+__all__ = [
+    "CanvasOverlay",
+    "PointsOverlay",
+    "PointOverlay",
+    "RectOverlay",
+    "RulerOverlay",
+    "PatternOverlay",
+    "ScanDirectionArrowOverlay",
+    "AlignmentAreaOverlay",
+    "MaskOverlay",
+    "MillingPatternOverlay",
+    "MinimapShapesOverlay",
+    "ShapeSpec",
+]

--- a/fibsem/ui/widgets/canvas/overlays/alignment_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/alignment_overlay.py
@@ -1,0 +1,115 @@
+"""Editable alignment-area overlay for FibsemImageCanvas.
+
+A reusable ``RectOverlay`` that speaks a normalized ``FibsemRectangle``
+(``left, top, width, height`` in [0, 1], top-left origin) and emits one when the
+user drags/resizes. Used for the image-alignment / drift-correction reduced area
+(image widget — editable; milling — read-only; lamella editor later).
+
+The normalized↔pixel conversion and the ``editable`` toggle mirror the
+``feat-proj-volume-milling`` branch (``VolumeMillingImageCanvas`` /
+``VolumeSEMAcquisitionCanvas``) so the two converge — that branch's per-canvas
+alignment logic can drop down to this overlay when it rebases.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from PyQt5.QtCore import pyqtSignal
+
+from fibsem.structures import FibsemRectangle
+from fibsem.ui.widgets.canvas.overlays.rect_overlay import RectOverlay
+
+_ALIGNMENT_COLOUR = "limegreen"
+
+
+class AlignmentAreaOverlay(RectOverlay):
+    """RectOverlay that maps to/from a normalized ``FibsemRectangle``.
+
+    Emits :attr:`alignment_area_changed` (a ``FibsemRectangle``) on drag/resize.
+    Pass ``editable=False`` for a read-only display (no handles, no mouse capture).
+    """
+
+    alignment_area_changed = pyqtSignal(object)  # FibsemRectangle
+
+    def __init__(
+        self,
+        color: str = _ALIGNMENT_COLOUR,
+        editable: bool = True,
+        parent=None,
+    ) -> None:
+        super().__init__(
+            color=color,
+            facecolor=None,
+            alpha=1.0,
+            linewidth=2.5,
+            linestyle="--",
+            resizable=True,
+            parent=parent,
+        )
+        self._interactive = editable
+        self._norm_area: Optional[FibsemRectangle] = None
+        self._area_visible = False  # desired visibility, preserved across rebuilds
+        self.rect_changed.connect(self._on_rect_changed)
+
+    # ── overlay protocol ──────────────────────────────────────────────────
+
+    def on_image_changed(self, width: int, height: int) -> None:
+        # super() rebuilds the artists (fresh + visible); re-position then re-apply
+        # the desired visibility, otherwise a new image un-hides a cleared overlay.
+        super().on_image_changed(width, height)
+        if self._norm_area is not None and self._img_w:
+            self.set_area(self._norm_area)
+        self._apply_visibility()
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    def set_area(self, reduced_area: FibsemRectangle) -> None:
+        """Position the rectangle from a normalized ``FibsemRectangle``."""
+        self._norm_area = reduced_area
+        if self._img_w is None or self._img_h is None:
+            return
+        self.set_rect(
+            reduced_area.left * self._img_w,
+            reduced_area.top * self._img_h,
+            reduced_area.width * self._img_w,
+            reduced_area.height * self._img_h,
+        )
+
+    def get_area(self) -> FibsemRectangle:
+        """Return the current rectangle as a normalized ``FibsemRectangle``."""
+        if self._img_w is None or self._img_h is None:
+            return FibsemRectangle()
+        d = self.get_rect()
+        return FibsemRectangle(
+            left=d["x0"] / self._img_w,
+            top=d["y0"] / self._img_h,
+            width=d["width"] / self._img_w,
+            height=d["height"] / self._img_h,
+        )
+
+    def set_visible(self, visible: bool) -> None:
+        """Show or hide the rectangle (state preserved across image rebuilds)."""
+        self._area_visible = visible
+        self._apply_visibility()
+
+    def set_editable(self, editable: bool) -> None:
+        """Toggle drag/resize (handles hidden + mouse ignored when disabled)."""
+        self._interactive = editable
+        self._apply_visibility()
+
+    # ── private ───────────────────────────────────────────────────────────
+
+    def _apply_visibility(self) -> None:
+        """Apply current visibility: patch follows ``_area_visible``; handles also
+        require ``_interactive`` (read-only overlays show no handles)."""
+        if self._patch is not None:
+            self._patch.set_visible(self._area_visible)
+        for h in self._handles.values():
+            h.set_visible(self._area_visible and self._interactive)
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def _on_rect_changed(self, _d: dict) -> None:
+        # rect_changed only fires on user drag/resize (not on programmatic set_rect)
+        self._norm_area = self.get_area()
+        self.alignment_area_changed.emit(self._norm_area)

--- a/fibsem/ui/widgets/canvas/overlays/base.py
+++ b/fibsem/ui/widgets/canvas/overlays/base.py
@@ -1,0 +1,33 @@
+"""Base class for FibsemImageCanvas overlays.
+
+Overlays implement a simple duck-typed protocol::
+
+    class MyOverlay:
+        def attach(self, ax, canvas: FibsemImageCanvas) -> None: ...
+        def detach(self) -> None: ...
+        def on_image_changed(self, width: int, height: int) -> None: ...
+
+Overlays that need Qt signals extend QObject directly.  An overlay that wants
+to suppress canvas pan/zoom during a drag sets ``canvas._overlay_consuming_event = True``
+on button-press; the canvas clears the flag automatically on button-release.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+
+class CanvasOverlay:
+    """No-op base for canvas overlays.  Sub-class or use duck-typing."""
+
+    def attach(self, ax, canvas: "FibsemImageCanvas") -> None:
+        """Called once when the overlay is added.  Create artists / connect events."""
+
+    def detach(self) -> None:
+        """Remove all artists and disconnect mpl events."""
+
+    def on_image_changed(self, width: int, height: int) -> None:
+        """Called after ax.cla() + new image drawn.  Re-create artists here."""

--- a/fibsem/ui/widgets/canvas/overlays/mask_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/mask_overlay.py
@@ -1,0 +1,139 @@
+"""Display-only segmentation-mask overlay for FibsemImageCanvas.
+
+Alpha-blends a label array (per-pixel class indices) over the image using a
+per-class colour map (``CLASS_COLORS_RGB`` by default), with the background class
+rendered fully transparent. Display-only — captures no mouse events, so it
+coexists with pan/zoom and any interactive overlay (e.g. the detection feature
+points) on the same canvas.
+
+Lifecycle: add once via ``canvas.add_overlay(overlay)``; draws nothing until
+:meth:`set_mask` is called; :meth:`clear` (or ``set_mask(None)``) removes it.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional, Sequence
+
+import numpy as np
+
+from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+_logger = logging.getLogger(__name__)
+
+_MASK_ALPHA = 0.3
+_MASK_ZORDER = 4  # above the base image, below patterns (6) / crosshair (7) / points (8)
+_BACKGROUND_CLASS = 0  # rendered transparent
+
+
+class MaskOverlay(CanvasOverlay):
+    """Alpha-blended label-mask overlay (display-only)."""
+
+    def __init__(self) -> None:
+        self._ax = None
+        self._canvas: Optional[FibsemImageCanvas] = None
+        self._artist = None  # AxesImage
+        self._mask: Optional[np.ndarray] = None
+        self._colors: Optional[Sequence] = None
+        self._alpha: float = _MASK_ALPHA
+
+    # ── overlay protocol ──────────────────────────────────────────────────
+
+    def attach(self, ax, canvas: FibsemImageCanvas) -> None:
+        self._ax = ax
+        self._canvas = canvas
+
+    def detach(self) -> None:
+        self._remove_artist()
+        self._ax = None
+        self._canvas = None
+
+    def on_image_changed(self, width: int, height: int) -> None:
+        # ax was cleared + a new image drawn; re-create from the cached mask
+        self._remove_artist()
+        if self._mask is not None and width > 0:
+            self._draw()
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    def set_mask(
+        self,
+        mask: Optional[np.ndarray],
+        colors: Optional[Sequence] = None,
+        alpha: float = _MASK_ALPHA,
+    ) -> None:
+        """Display *mask* (HxW integer class indices).
+
+        ``colors`` is an index→(r, g, b) sequence (0-255); defaults to
+        ``CLASS_COLORS_RGB``. The background class (0) is always transparent;
+        every other class is drawn at ``alpha``. Pass ``mask=None`` to clear.
+        """
+        if mask is None:
+            self.clear()
+            return
+        self._mask = np.asarray(mask)
+        self._colors = colors
+        self._alpha = alpha
+        self._remove_artist()
+        self._draw()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def clear(self) -> None:
+        """Remove the mask (no segmentation → nothing drawn)."""
+        self._mask = None
+        self._remove_artist()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    # ── drawing ───────────────────────────────────────────────────────────
+
+    def _colours_rgb(self) -> Sequence:
+        if self._colors is not None:
+            return self._colors
+        from fibsem.segmentation.config import CLASS_COLORS_RGB
+        return CLASS_COLORS_RGB
+
+    def _mask_to_rgba(self, mask: np.ndarray) -> np.ndarray:
+        """Map an HxW label array to an HxWx4 float RGBA image via a class LUT.
+
+        Background (class 0) is transparent; other classes use ``_alpha``. Using a
+        direct RGBA image (rather than cmap + scalar alpha) keeps per-pixel alpha,
+        so the background stays clear instead of dimming the underlying image.
+        """
+        colours = self._colours_rgb()
+        lut = np.zeros((len(colours), 4), dtype=float)
+        for i, c in enumerate(colours):
+            lut[i, :3] = [v / 255.0 for v in c[:3]]
+            lut[i, 3] = 0.0 if i == _BACKGROUND_CLASS else self._alpha
+        idx = np.clip(mask.astype(int), 0, len(colours) - 1)
+        return lut[idx]
+
+    def _draw(self) -> None:
+        if self._ax is None or self._mask is None:
+            return
+        try:
+            rgba = self._mask_to_rgba(self._mask)
+        except Exception:
+            _logger.exception("MaskOverlay: failed to build RGBA from mask")
+            return
+        h, w = self._mask.shape[:2]
+        self._artist = self._ax.imshow(
+            rgba,
+            interpolation="nearest",
+            origin="upper",
+            extent=(-0.5, w - 0.5, h - 0.5, -0.5),
+            zorder=_MASK_ZORDER,
+        )
+
+    def _remove_artist(self) -> None:
+        if self._artist is not None:
+            try:
+                self._artist.remove()
+            except Exception:
+                pass
+            self._artist = None

--- a/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
@@ -1,0 +1,251 @@
+"""Milling pattern overlay for FibsemImageCanvas — display-only.
+
+Renders ``FibsemMillingStage`` patterns (rectangle / circle / line / polygon) on a
+:class:`FibsemImageCanvas`, one colour per stage, with a crosshair at each stage's
+point-of-interest. Reuses the metres→pixel converters from
+``fibsem.ui.napari.patterns`` (which already emit rotated, y-flipped pixel geometry).
+
+Display-only: the overlay captures no mouse events, so it coexists cleanly with
+the canvas pan/zoom, double-click-to-move, and right-click menu. Pattern movement
+is handled by the host widget (right-click → menu → ``_move_patterns``).
+
+Lifecycle: add it to a canvas once via ``canvas.add_overlay(overlay)``. It draws
+nothing until :meth:`set_stages` is called with non-empty stages; :meth:`clear`
+(or ``set_stages([], …)``) removes all artists, so it's invisible when there is no
+milling.
+
+Deferred (see design doc): direct drag-to-move, FOV rect, alignment area,
+selected-stage highlight, background stages, annulus / bitmap shapes.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional, Sequence
+
+import matplotlib.lines as mlines
+import matplotlib.patches as mpatches
+from matplotlib.colors import to_rgba
+
+from fibsem.structures import (
+    FibsemCircleSettings,
+    FibsemImage,
+    FibsemLineSettings,
+    FibsemPolygonSettings,
+    FibsemRectangleSettings,
+)
+from fibsem.ui.napari.patterns import (
+    COLOURS,
+    convert_pattern_to_napari_line,
+    convert_pattern_to_napari_polygon,
+    convert_pattern_to_napari_rect,
+    get_image_pixel_centre,
+)
+from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+_logger = logging.getLogger(__name__)
+
+_CROSSHAIR_HALF_PX = 20  # crosshair arm half-length, pixels
+_PATTERN_ZORDER = 6
+_FILL_ALPHA = 0.4  # semi-transparent fill; edge stays solid
+_LINEWIDTH = 1.0  # default pattern edge width
+_LINEWIDTH_SELECTED = 2.5  # selected stage edge width
+_BACKGROUND_COLOUR = "black"  # background milling stages
+
+
+class MillingPatternOverlay(CanvasOverlay):
+    """Display-only overlay rendering milling stage patterns + per-stage crosshairs.
+
+    Call :meth:`set_stages` to (re)draw, :meth:`clear` to hide.
+    """
+
+    def __init__(self) -> None:
+        self._ax = None
+        self._canvas: Optional[FibsemImageCanvas] = None
+        self._artists: list = []
+        self._stages: list = []
+        self._background_stages: list = []
+        self._selected_index: Optional[int] = None
+        self._image: Optional[FibsemImage] = None
+        self._legend = None
+
+    # ── overlay protocol ──────────────────────────────────────────────────
+
+    def attach(self, ax, canvas: FibsemImageCanvas) -> None:
+        self._ax = ax
+        self._canvas = canvas
+
+    def detach(self) -> None:
+        self._remove_artists()
+        self._ax = None
+        self._canvas = None
+
+    def on_image_changed(self, width: int, height: int) -> None:
+        # ax was cleared + a new image drawn; re-create artists from cached stages
+        self._remove_artists()
+        if width > 0 and (self._stages or self._background_stages) and self._image is not None:
+            self._draw()
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    def set_stages(
+        self,
+        stages: Sequence,
+        image: FibsemImage,
+        *,
+        background_stages: Sequence = (),
+        selected_index: Optional[int] = None,
+    ) -> None:
+        """Display *stages* against *image*.
+
+        ``background_stages`` are drawn in black behind the foreground stages;
+        ``selected_index`` (into *stages*) is drawn with a thicker edge, on top.
+        """
+        self._stages = list(stages)
+        self._background_stages = list(background_stages)
+        self._selected_index = selected_index
+        self._image = image
+        self._remove_artists()
+        self._draw()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def clear(self) -> None:
+        """Remove all pattern artists (no milling → nothing drawn)."""
+        self._stages = []
+        self._background_stages = []
+        self._selected_index = None
+        self._remove_artists()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    # ── drawing ───────────────────────────────────────────────────────────
+
+    def _remove_artists(self) -> None:
+        for a in self._artists:
+            try:
+                a.remove()
+            except Exception:
+                pass
+        self._artists.clear()
+        if self._legend is not None:
+            try:
+                self._legend.remove()
+            except Exception:
+                pass
+            self._legend = None
+
+    def _draw(self) -> None:
+        if self._ax is None or self._image is None:
+            return
+        if not self._stages and not self._background_stages:
+            return
+        if self._image.metadata is None or self._image.metadata.pixel_size is None:
+            return
+        shape = self._image.data.shape[:2]
+        pixelsize = self._image.metadata.pixel_size.x
+
+        # background stages first (black, behind the foreground)
+        for stage in self._background_stages:
+            try:
+                self._draw_stage(
+                    stage, shape, pixelsize, _BACKGROUND_COLOUR,
+                    linewidth=_LINEWIDTH, zorder=_PATTERN_ZORDER - 2,
+                )
+            except Exception:
+                _logger.exception("MillingPatternOverlay: failed to draw background stage")
+
+        # foreground stages (per-colour; selected is thicker and on top)
+        for i, stage in enumerate(self._stages):
+            colour = COLOURS[i % len(COLOURS)]
+            selected = i == self._selected_index
+            linewidth = _LINEWIDTH_SELECTED if selected else _LINEWIDTH
+            zorder = _PATTERN_ZORDER + 2 if selected else _PATTERN_ZORDER
+            try:
+                self._draw_stage(
+                    stage, shape, pixelsize, colour, linewidth=linewidth, zorder=zorder
+                )
+            except Exception:
+                _logger.exception(
+                    "MillingPatternOverlay: failed to draw stage %r",
+                    getattr(stage, "name", i),
+                )
+        self._draw_legend()
+
+    def _draw_legend(self) -> None:
+        """Colour-keyed legend of stage names, top-right."""
+        handles = [
+            mpatches.Patch(
+                facecolor=to_rgba(COLOURS[i % len(COLOURS)], _FILL_ALPHA),
+                edgecolor=COLOURS[i % len(COLOURS)],
+                label=getattr(stage, "name", f"Stage {i + 1}"),
+            )
+            for i, stage in enumerate(self._stages)
+        ]
+        if not handles:
+            return
+        self._legend = self._ax.legend(
+            handles=handles,
+            loc="upper right",
+            fontsize=8,
+            facecolor="#1e2124",
+            edgecolor="#555555",
+            labelcolor="#d1d2d4",
+            framealpha=0.85,
+        )
+        self._legend.set_zorder(10)
+
+    def _draw_stage(self, stage, shape, pixelsize: float, colour: str,
+                    *, linewidth: float, zorder: float) -> None:
+        for pattern_settings in stage.define_patterns():
+            artist = self._shape_to_artist(
+                pattern_settings, shape, pixelsize, colour, linewidth, zorder
+            )
+            if artist is not None:
+                self._ax.add_artist(artist)
+                self._artists.append(artist)
+        self._draw_crosshair(stage.pattern.point, shape, pixelsize, colour, zorder + 0.5)
+
+    def _shape_to_artist(self, ps, shape, pixelsize: float, colour: str,
+                         linewidth: float, zorder: float):
+        # Solid edge + same-colour fill at _FILL_ALPHA. Independent face/edge
+        # alphas via RGBA (a patch-level ``alpha`` would dim the edge too).
+        patch_kw = dict(
+            edgecolor=colour,
+            facecolor=to_rgba(colour, _FILL_ALPHA),
+            linewidth=linewidth,
+            zorder=zorder,
+        )
+        if isinstance(ps, FibsemRectangleSettings):
+            verts, _ = convert_pattern_to_napari_rect(ps, shape, pixelsize)
+            return mpatches.Polygon(verts[:, ::-1], closed=True, **patch_kw)  # (y,x)→(x,y)
+        if isinstance(ps, FibsemCircleSettings):
+            icy, icx = get_image_pixel_centre(shape)
+            cx = icx + ps.centre_x / pixelsize
+            cy = icy - ps.centre_y / pixelsize
+            return mpatches.Circle((cx, cy), ps.radius / pixelsize, **patch_kw)
+        if isinstance(ps, FibsemLineSettings):
+            verts, _ = convert_pattern_to_napari_line(ps, shape, pixelsize)
+            (y0, x0), (y1, x1) = verts
+            return mlines.Line2D(
+                [x0, x1], [y0, y1], color=colour, linewidth=linewidth, zorder=zorder,
+            )
+        if isinstance(ps, FibsemPolygonSettings):
+            verts, _ = convert_pattern_to_napari_polygon(ps, shape, pixelsize)
+            return mpatches.Polygon(verts[:, ::-1], closed=True, **patch_kw)
+        return None  # bitmap / annulus / unknown — deferred
+
+    def _draw_crosshair(self, point, shape, pixelsize: float, colour: str,
+                        zorder: float) -> None:
+        icy, icx = get_image_pixel_centre(shape)
+        cx = icx + point.x / pixelsize
+        cy = icy - point.y / pixelsize
+        h = _CROSSHAIR_HALF_PX
+        kw = dict(color=colour, linewidth=1, alpha=0.9, zorder=zorder)
+        (l1,) = self._ax.plot([cx - h, cx + h], [cy, cy], **kw)
+        (l2,) = self._ax.plot([cx, cx], [cy - h, cy + h], **kw)
+        self._artists.extend([l1, l2])

--- a/fibsem/ui/widgets/canvas/overlays/minimap_overlays.py
+++ b/fibsem/ui/widgets/canvas/overlays/minimap_overlays.py
@@ -1,0 +1,181 @@
+"""Generic shape overlay for the minimap (Overview tab) canvas — display-only.
+
+One :class:`MinimapShapesOverlay` renders a flat list of :class:`ShapeSpec` (rectangle
+/ circle / crosshair + optional label) on a :class:`FibsemImageCanvas`. The host widget
+groups specs **by entity** (LamellaMarkers / CurrentPosition / ReferenceFrame) into
+separate overlay instances so each redraws on its own trigger — unlike the napari
+minimap, which grouped by shape *type* (one Shapes layer per geometry kind) and had to
+rebuild everything on any change.
+
+Geometry is plain image-pixel coordinates: a spec's ``(cx, cy)`` is the shape centre in
+image pixels (col, row), matching the axes' ``extent``. Callers compute those from
+``tiled.reproject_stage_positions_onto_image2`` exactly as before — no napari vertex
+arrays.
+
+Display-only: captures no mouse events, so it coexists with the canvas pan/zoom +
+click-to-move + right-click menu.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import matplotlib.patches as mpatches
+
+from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_CROSSHAIR_HALF_PX = 40  # crosshair arm half-length, image pixels
+_LABEL_FONTSIZE = 7
+
+
+@dataclass
+class ShapeSpec:
+    """One overlay primitive in image-pixel coordinates.
+
+    ``kind`` is ``"rect"`` (uses ``width``/``height``), ``"circle"`` (uses ``radius``),
+    or ``"crosshair"`` (a ``+`` of ``crosshair_half`` arms). ``label`` is optional text
+    drawn near the shape in the shape's colour.
+    """
+
+    kind: str
+    cx: float
+    cy: float
+    color: str
+    width: float = 0.0
+    height: float = 0.0
+    radius: float = 0.0
+    label: str = ""
+
+
+class MinimapShapesOverlay(CanvasOverlay):
+    """Display-only overlay rendering a list of :class:`ShapeSpec`.
+
+    Call :meth:`set_shapes` to (re)draw, :meth:`set_visible` to toggle, :meth:`clear`
+    to hide. Specs are cached so the overlay redraws itself after an image swap
+    (``on_image_changed``).
+    """
+
+    def __init__(
+        self,
+        *,
+        zorder: float = 5.0,
+        linewidth: float = 1.2,
+        crosshair_half_px: int = _DEFAULT_CROSSHAIR_HALF_PX,
+    ) -> None:
+        self._ax = None
+        self._canvas: "FibsemImageCanvas | None" = None
+        self._artists: list = []
+        self._specs: list[ShapeSpec] = []
+        self._visible: bool = True
+        self._zorder = zorder
+        self._linewidth = linewidth
+        self._crosshair_half = crosshair_half_px
+
+    # ── overlay protocol ──────────────────────────────────────────────────
+
+    def attach(self, ax, canvas: FibsemImageCanvas) -> None:
+        self._ax = ax
+        self._canvas = canvas
+
+    def detach(self) -> None:
+        self._remove_artists()
+        self._ax = None
+        self._canvas = None
+
+    def on_image_changed(self, width: int, height: int) -> None:
+        # ax was cleared + a new image drawn → re-create artists from cached specs
+        self._remove_artists()
+        if width > 0 and self._specs and self._visible:
+            self._draw()
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    def set_shapes(self, specs) -> None:
+        """Replace the drawn shapes with *specs* and redraw."""
+        self._specs = list(specs)
+        self._remove_artists()
+        if self._visible:
+            self._draw()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def set_visible(self, visible: bool) -> None:
+        """Show or hide the whole group without discarding its specs."""
+        if visible == self._visible:
+            return
+        self._visible = visible
+        self._remove_artists()
+        if visible:
+            self._draw()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def clear(self) -> None:
+        """Remove all shapes (group draws nothing until the next set_shapes)."""
+        self.set_shapes([])
+
+    # ── drawing ───────────────────────────────────────────────────────────
+
+    def _remove_artists(self) -> None:
+        for a in self._artists:
+            try:
+                a.remove()
+            except Exception:
+                pass
+        self._artists.clear()
+
+    def _draw(self) -> None:
+        if self._ax is None:
+            return
+        for spec in self._specs:
+            try:
+                self._draw_spec(spec)
+            except Exception:
+                _logger.exception("MinimapShapesOverlay: failed to draw %r", spec)
+
+    def _draw_spec(self, spec: ShapeSpec) -> None:
+        if spec.kind == "rect":
+            patch = mpatches.Rectangle(
+                (spec.cx - spec.width / 2.0, spec.cy - spec.height / 2.0),
+                spec.width, spec.height,
+                fill=False, edgecolor=spec.color, linewidth=self._linewidth,
+                zorder=self._zorder,
+            )
+            self._ax.add_patch(patch)
+            self._artists.append(patch)
+            self._draw_label(spec, spec.cx - spec.width / 2.0,
+                              spec.cy - spec.height / 2.0, va="bottom")
+        elif spec.kind == "circle":
+            patch = mpatches.Circle(
+                (spec.cx, spec.cy), spec.radius,
+                fill=False, edgecolor=spec.color, linewidth=self._linewidth,
+                zorder=self._zorder,
+            )
+            self._ax.add_patch(patch)
+            self._artists.append(patch)
+            self._draw_label(spec, spec.cx, spec.cy - spec.radius, va="bottom")
+        elif spec.kind == "crosshair":
+            h = self._crosshair_half
+            kw = dict(color=spec.color, linewidth=self._linewidth, zorder=self._zorder)
+            (l1,) = self._ax.plot([spec.cx - h, spec.cx + h], [spec.cy, spec.cy], **kw)
+            (l2,) = self._ax.plot([spec.cx, spec.cx], [spec.cy - h, spec.cy + h], **kw)
+            self._artists.extend([l1, l2])
+            self._draw_label(spec, spec.cx + h * 0.15, spec.cy + h * 0.15,
+                             va="top", ha="left")
+
+    def _draw_label(self, spec: ShapeSpec, x: float, y: float,
+                    *, va: str = "bottom", ha: str = "left") -> None:
+        if not spec.label:
+            return
+        t = self._ax.text(
+            x, y, spec.label, color=spec.color, fontsize=_LABEL_FONTSIZE,
+            ha=ha, va=va, zorder=self._zorder + 0.5, clip_on=True,
+        )
+        self._artists.append(t)

--- a/fibsem/ui/widgets/canvas/overlays/pattern_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/pattern_overlay.py
@@ -1,0 +1,217 @@
+"""Milling-shape pattern overlays (pixel-space) for FibsemImageCanvas.
+
+``PatternOverlay`` — milling pattern shapes as matplotlib patches.
+``ScanDirectionArrowOverlay`` — arrow indicating the milling scan direction.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+_logger = logging.getLogger(__name__)
+
+
+class PatternOverlay(CanvasOverlay):
+    """Renders milling pattern shapes as matplotlib patches.
+
+    Coordinates must be in image pixel space (caller handles unit conversion).
+    Supported pattern attributes:
+      - Rectangle / Bitmap : ``centre_x, centre_y, width, height``
+      - Circle             : ``centre_x, centre_y, radius``
+      - Line               : ``start_x, start_y, end_x, end_y``
+      - Polygon            : ``vertices`` (N×2 array)
+    """
+
+    def __init__(self, patterns=(), color: str = "cyan", alpha: float = 0.4):
+        self._patterns = list(patterns)
+        self._color = color
+        self._alpha = alpha
+        self._ax = None
+        self._canvas = None
+        self._artists: list = []
+
+    def attach(self, ax, canvas: FibsemImageCanvas) -> None:
+        self._ax = ax
+        self._canvas = canvas
+
+    def detach(self) -> None:
+        self._remove_artists()
+        self._ax = None
+        self._canvas = None
+
+    def on_image_changed(self, width: int, height: int) -> None:
+        self._remove_artists()
+        if width > 0:
+            self._draw()
+
+    def set_patterns(self, patterns) -> None:
+        self._patterns = list(patterns)
+        self._remove_artists()
+        self._draw()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    # ── private ──
+
+    def _remove_artists(self):
+        for a in self._artists:
+            try:
+                a.remove()
+            except Exception:
+                pass
+        self._artists.clear()
+
+    def _draw(self):
+        if self._ax is None:
+            return
+        import matplotlib.lines as mlines
+        import matplotlib.patches as mpatches
+
+        kw = dict(
+            edgecolor=self._color,
+            facecolor=self._color,
+            alpha=self._alpha,
+            linewidth=1.5,
+            zorder=6,
+        )
+        for pat in self._patterns:
+            try:
+                artist = _pattern_to_artist(pat, kw, mpatches, mlines)
+                if artist is not None:
+                    self._ax.add_artist(artist)
+                    self._artists.append(artist)
+            except Exception:
+                _logger.exception("PatternOverlay: failed to render %r", pat)
+
+
+def _pattern_to_artist(pat, kw, mpatches, mlines):
+    name = type(pat).__name__
+    if any(k in name for k in ("Rectangle", "Bitmap")):
+        return mpatches.Rectangle(
+            (pat.centre_x - pat.width / 2, pat.centre_y - pat.height / 2),
+            pat.width,
+            pat.height,
+            **kw,
+        )
+    if "Circle" in name:
+        return mpatches.Circle(
+            (pat.centre_x, pat.centre_y),
+            pat.radius,
+            **{**kw, "facecolor": "none"},
+        )
+    if "Line" in name:
+        return mlines.Line2D(
+            [pat.start_x, pat.end_x],
+            [pat.start_y, pat.end_y],
+            color=kw["edgecolor"],
+            linewidth=2,
+            alpha=kw["alpha"],
+            zorder=kw["zorder"],
+        )
+    if "Polygon" in name and hasattr(pat, "vertices"):
+        return mpatches.Polygon(pat.vertices, closed=True, **kw)
+    return None
+
+
+class ScanDirectionArrowOverlay(CanvasOverlay):
+    """Draws a yellow arrow indicating the milling scan direction.
+
+    Only ``"TopToBottom"`` and ``"BottomToTop"`` are supported; all other
+    values result in no arrow being shown.
+
+    Call :meth:`set_arrow` with the pattern bounding box in pixel coordinates
+    to update the arrow, or :meth:`clear` to hide it.
+    """
+
+    _SUPPORTED = {"TopToBottom", "BottomToTop"}
+
+    def __init__(self, color: str = "yellow"):
+        self._color = color
+        self._ax = None
+        self._canvas = None
+        self._artist = None
+        # (x_start, y_start, x_end, y_end) in pixel coords
+        self._params: Optional[tuple] = None
+
+    def attach(self, ax, canvas: "FibsemImageCanvas") -> None:
+        self._ax = ax
+        self._canvas = canvas
+
+    def detach(self) -> None:
+        self._remove_artist()
+        self._ax = None
+        self._canvas = None
+
+    def on_image_changed(self, width: int, _height: int) -> None:
+        self._remove_artist()
+        if width > 0 and self._params is not None:
+            self._draw()
+
+    def set_arrow(self, cx: float, cy: float, h_px: float, scan_direction: str) -> None:
+        """Position the arrow based on pattern centre and height.
+
+        Args:
+            cx: pattern centre x in pixel coords
+            cy: pattern centre y in pixel coords
+            h_px: pattern height in pixels
+            scan_direction: ``"TopToBottom"`` or ``"BottomToTop"``
+        """
+        if scan_direction not in self._SUPPORTED:
+            self.clear()
+            return
+        margin = h_px * 0.15
+        if scan_direction == "TopToBottom":
+            # Arrow from near top edge → near bottom edge (↓ in image coords)
+            x_s, y_s = cx, cy - h_px / 2 + margin
+            x_e, y_e = cx, cy + h_px / 2 - margin
+        else:  # BottomToTop
+            # Arrow from near bottom edge → near top edge (↑ in image coords)
+            x_s, y_s = cx, cy + h_px / 2 - margin
+            x_e, y_e = cx, cy - h_px / 2 + margin
+        self._params = (x_s, y_s, x_e, y_e)
+        self._remove_artist()
+        self._draw()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def clear(self) -> None:
+        """Hide the arrow."""
+        self._params = None
+        self._remove_artist()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    # ── private ──
+
+    def _remove_artist(self):
+        if self._artist is not None:
+            try:
+                self._artist.remove()
+            except Exception:
+                pass
+            self._artist = None
+
+    def _draw(self):
+        if self._ax is None or self._params is None:
+            return
+        x_s, y_s, x_e, y_e = self._params
+        self._artist = self._ax.annotate(
+            "",
+            xy=(x_e, y_e),
+            xytext=(x_s, y_s),
+            arrowprops=dict(
+                arrowstyle="-|>",
+                color=self._color,
+                lw=2.0,
+                mutation_scale=18,
+            ),
+            zorder=10,
+        )

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -1,0 +1,629 @@
+"""Static + interactive scatter-point overlays for FibsemImageCanvas.
+
+``PointsOverlay`` — non-interactive scatter markers with optional labels.
+``PointOverlay`` — interactive points (select / drag / delete / add).
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+
+class PointsOverlay(CanvasOverlay):
+    """Non-interactive scatter points.  Call set_points() to update."""
+
+    def __init__(
+        self,
+        points: List[Tuple[float, float]] = (),
+        color: str = "white",
+        marker: str = "o",
+        size: int = 8,
+        label_prefix: str = "",
+    ):
+        self._points = list(points)
+        self._color = color
+        self._marker = marker
+        self._size = size
+        self._label_prefix = label_prefix
+        self._ax = None
+        self._canvas = None
+        self._artists: list = []
+
+    def attach(self, ax, canvas: FibsemImageCanvas) -> None:
+        self._ax = ax
+        self._canvas = canvas
+
+    def detach(self) -> None:
+        self._remove_artists()
+        self._ax = None
+        self._canvas = None
+
+    def on_image_changed(self, width: int, height: int) -> None:
+        self._remove_artists()
+        if width > 0:
+            self._draw()
+
+    def set_points(self, points: List[Tuple[float, float]]) -> None:
+        self._points = list(points)
+        self._remove_artists()
+        self._draw()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    # ── private ──
+
+    def _remove_artists(self):
+        for a in self._artists:
+            try:
+                a.remove()
+            except Exception:
+                pass
+        self._artists.clear()
+
+    def _draw(self):
+        if self._ax is None:
+            return
+        for i, (x, y) in enumerate(self._points, 1):
+            (line,) = self._ax.plot(
+                x,
+                y,
+                marker=self._marker,
+                markersize=self._size,
+                color=self._color,
+                markeredgecolor="white",
+                markeredgewidth=0.8,
+                linestyle="none",
+                zorder=8,
+            )
+            self._artists.append(line)
+            if self._label_prefix:
+                ann = self._ax.annotate(
+                    f"{self._label_prefix}{i}",
+                    xy=(x, y),
+                    xytext=(6, 4),
+                    textcoords="offset points",
+                    color=self._color,
+                    fontsize=8,
+                    zorder=9,
+                )
+                self._artists.append(ann)
+
+
+_PICK_RADIUS_PX = 12  # screen-space hit radius for point picking
+
+
+class PointOverlay(QObject):
+    """Interactive points overlay.
+
+    * Left-click a point → selects it (highlighted colour + larger marker)
+    * Left-click empty area → deselects
+    * Drag a selected point → moves it, clamped to image bounds (blitted)
+    * Right-click empty area → adds a new point (when ``add_on_right_click=True``)
+    * Delete / Backspace → removes the selected point
+
+    Parameters
+    ----------
+    color : str
+        Default point colour.
+    selected_color : str
+        Colour when a point is selected.
+    marker : str
+        Matplotlib marker style.
+    size : float
+        Marker size in points (selected markers are drawn at ``size * 1.4``).
+    label_prefix : str
+        If non-empty, each point gets an annotation ``label_prefix + (index+1)``.
+    add_on_right_click : bool
+        If True (default), right-clicking adds a new point.
+    removable : bool
+        If True (default), Delete/Backspace removes the selected point.
+    modal : bool
+        If True, the overlay handles input *only* while it is the canvas's active
+        overlay (e.g. spot burn — inert in Move mode). If False (default), it also
+        responds when no overlay is active (always-on, backward-compatible).
+    """
+
+    point_added = pyqtSignal(int, float, float)  # index, x, y
+    point_selected = pyqtSignal(int, float, float)  # index, x, y
+    point_dragging = pyqtSignal(int, float, float)  # index, x, y  (each motion step)
+    point_moved = pyqtSignal(int, float, float)  # index, x, y  (on release)
+    point_removed = pyqtSignal(int)  # index (before removal)
+
+    def __init__(
+        self,
+        color: str = "cyan",
+        selected_color: str = "yellow",
+        marker: str = "o",
+        size: float = 10.0,
+        label_prefix: str = "",
+        add_on_right_click: bool = True,
+        removable: bool = True,
+        modal: bool = False,
+        edge_width: Optional[float] = None,
+        legend_label: Optional[str] = None,
+        numbered: bool = False,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self._color = color
+        self._selected_color = selected_color
+        self._marker = marker
+        self._size = size
+        self._label_prefix = label_prefix
+        self._add_on_right_click = add_on_right_click
+        self._removable = removable
+        self._modal = modal
+        self._edge_width = edge_width  # override the default marker edge width if set
+        self._legend_label = legend_label  # opt-in patch legend for this overlay
+        self._legend = None
+        self._numbered = numbered  # annotate each point with its 1-based index
+        self._visible = True  # toggled by set_visible (points kept, artists hidden)
+
+        self._ax = None
+        self._canvas: Optional[FibsemImageCanvas] = None
+        self._img_w: Optional[int] = None
+        self._img_h: Optional[int] = None
+
+        self._points: List[List[float]] = []  # [[x, y], ...]  mutable for drag
+        self._artists: List = []  # Line2D per point (index-aligned)
+        self._anns: List = []  # Annotation per point (or None)
+        # Optional per-point overrides (index-aligned), else the global style is used
+        self._point_colors: Optional[List[str]] = None
+        self._point_labels: Optional[List[str]] = None
+
+        self._selected: Optional[int] = None
+        self._drag_idx: Optional[int] = None
+        self._drag_offset: Tuple[float, float] = (0.0, 0.0)
+        self._drag_start_xy: Tuple[float, float] = (0.0, 0.0)
+        self._blit_bg = None
+
+        self._cids: List[int] = []
+
+    # ── overlay protocol ──────────────────────────────────────────────────
+
+    def attach(self, ax, canvas: "FibsemImageCanvas") -> None:
+        self._ax = ax
+        self._canvas = canvas
+        self._cids = [
+            canvas.mpl_connect("button_press_event", self._on_press),
+            canvas.mpl_connect("motion_notify_event", self._on_motion),
+            canvas.mpl_connect("button_release_event", self._on_release),
+            canvas.mpl_connect("key_press_event", self._on_key),
+        ]
+
+    def detach(self) -> None:
+        if self._canvas is not None:
+            for cid in self._cids:
+                try:
+                    self._canvas.mpl_disconnect(cid)
+                except Exception:
+                    pass
+        self._cids = []
+        self._remove_all_artists()
+        self._ax = None
+        self._canvas = None
+
+    def on_image_changed(self, width: int, height: int) -> None:
+        self._img_w, self._img_h = width, height
+        self._remove_all_artists()
+        if width > 0 and self._ax is not None:
+            self._draw_all()
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    def set_points(
+        self,
+        points: List[Tuple[float, float]],
+        colors: Optional[List[str]] = None,
+        labels: Optional[List[str]] = None,
+    ) -> None:
+        """Replace all points.
+
+        ``colors`` / ``labels``, when given, are index-aligned per-point overrides
+        (e.g. one colour + name per detection feature); otherwise the global
+        ``color`` / ``label_prefix`` style is used.
+        """
+        self._points = [[float(x), float(y)] for x, y in points]
+        self._point_colors = list(colors) if colors is not None else None
+        self._point_labels = list(labels) if labels is not None else None
+        self._selected = None
+        self._remove_all_artists()
+        if self._ax is not None and self._img_w:
+            self._draw_all()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def add_point(self, x: float, y: float) -> int:
+        """Append a point and return its index."""
+        idx = len(self._points)
+        self._points.append([float(x), float(y)])
+        if self._ax is not None:
+            self._append_artist(idx)
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+        return idx
+
+    def remove_point(self, index: int) -> None:
+        """Remove the point at *index*."""
+        if index < 0 or index >= len(self._points):
+            return
+        self.point_removed.emit(index)
+        for lst in (self._artists, self._anns):
+            a = lst.pop(index)
+            if a is not None:
+                try:
+                    a.remove()
+                except Exception:
+                    pass
+        self._points.pop(index)
+        if self._selected == index:
+            self._selected = None
+        elif self._selected is not None and self._selected > index:
+            self._selected -= 1
+        if self._label_prefix or self._numbered:
+            self._refresh_ann_text()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def clear_points(self) -> None:
+        self._selected = None
+        self._remove_all_artists()
+        self._points.clear()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def get_points(self) -> List[Tuple[float, float]]:
+        return [(p[0], p[1]) for p in self._points]
+
+    def set_visible(self, visible: bool) -> None:
+        """Show or hide all markers/labels without discarding the points.
+
+        State is remembered and re-applied across image rebuilds (a hidden
+        overlay stays hidden when a new image arrives).
+        """
+        self._visible = visible
+        for a in self._artists + self._anns:
+            if a is not None:
+                a.set_visible(visible)
+        self._draw_legend()  # add/remove the legend to match visibility
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def set_selected(self, index: Optional[int]) -> None:
+        """Programmatically select a point (e.g. from a synced table).
+
+        Silent — does not emit ``point_selected`` — so it will not loop back onto a
+        producer that is driving the selection. Pass ``None`` (or an out-of-range
+        index) to clear the selection.
+        """
+        n = len(self._points)
+        idx = index if (index is not None and 0 <= index < n) else None
+        if idx == self._selected:
+            return
+        prev = self._selected
+        self._selected = idx
+        if prev is not None:
+            self._update_artist_appearance(prev)
+        if idx is not None:
+            self._update_artist_appearance(idx)
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    # ── private: artists ──────────────────────────────────────────────────
+
+    def _input_allowed(self) -> bool:
+        """Whether this overlay may handle input now (modal-aware).
+
+        Modal overlays respond only while they are the canvas's active overlay;
+        non-modal overlays also respond when nothing is active (default).
+        """
+        if self._canvas is None:
+            return True
+        if self._modal:
+            return self._canvas._active_overlay is self
+        return self._canvas._overlay_input_allowed(self)
+
+    def _remove_all_artists(self):
+        for lst in (self._artists, self._anns):
+            for a in lst:
+                if a is not None:
+                    try:
+                        a.remove()
+                    except Exception:
+                        pass
+            lst.clear()
+        self._remove_legend()
+
+    def _draw_all(self):
+        for idx in range(len(self._points)):
+            self._append_artist(idx)
+        self._draw_legend()
+
+    def _remove_legend(self) -> None:
+        if self._legend is not None:
+            try:
+                self._legend.remove()
+            except Exception:
+                pass
+            self._legend = None
+
+    def _draw_legend(self) -> None:
+        """Opt-in legend (top-left); the swatch is the overlay's own marker glyph
+        (e.g. a "+" for the POI), styled like the milling-stage legend."""
+        self._remove_legend()
+        if (
+            not self._legend_label
+            or self._ax is None
+            or not self._points
+            or not self._visible
+        ):
+            return
+        from matplotlib.legend import Legend
+        from matplotlib.lines import Line2D
+
+        handle = Line2D(
+            [], [], linestyle="None", marker=self._marker, markersize=9,
+            color=self._color,
+            markeredgewidth=(self._edge_width if self._edge_width is not None else 2.0),
+            label=self._legend_label,
+        )
+        # build the Legend directly (not ax.legend()) so it doesn't replace another
+        # overlay's primary legend (e.g. the milling stages, top-right)
+        leg = Legend(
+            self._ax,
+            [handle],
+            [self._legend_label],
+            loc="upper left",
+            fontsize=8,
+            facecolor="#1e2124",
+            edgecolor="#555555",
+            labelcolor="#d1d2d4",
+            framealpha=0.85,
+        )
+        leg.set_zorder(10)
+        self._ax.add_artist(leg)
+        self._legend = leg
+
+    def _marker_edge(self, color: str, selected: bool):
+        """Edge colour/width for the marker. Unfilled markers (+, x, ...) are drawn
+        in their edge colour, so they take the point colour and a thicker line;
+        filled markers (o, s, ...) keep a thin white outline for contrast.
+
+        ``edge_width`` (if set) overrides the normal-state width; the selected state
+        adds a fixed bump, so backward-compatible defaults are preserved when unset.
+        """
+        from matplotlib.lines import Line2D
+        if self._marker in Line2D.filled_markers:
+            base = self._edge_width if self._edge_width is not None else 0.8
+            return "white", (base + 1.2 if selected else base)
+        base = self._edge_width if self._edge_width is not None else 2.0
+        return color, (base + 0.8 if selected else base)
+
+    def _point_color(self, idx: int, selected: bool) -> str:
+        """Per-point colour override if set, else the global selected/normal colour.
+        (Per-point points keep their own colour even when selected — size + edge
+        convey the selection instead.)"""
+        if self._point_colors is not None and idx < len(self._point_colors):
+            return self._point_colors[idx]
+        return self._selected_color if selected else self._color
+
+    def _point_label(self, idx: int) -> Optional[str]:
+        """Per-point label override if set, else ``label_prefix + (idx+1)``, else the
+        bare 1-based index when ``numbered``, else None."""
+        if self._point_labels is not None and idx < len(self._point_labels):
+            return self._point_labels[idx]
+        if self._label_prefix:
+            return f"{self._label_prefix}{idx + 1}"
+        if self._numbered:
+            return str(idx + 1)
+        return None
+
+    def _append_artist(self, idx: int):
+        if self._ax is None:
+            return
+        x, y = self._points[idx]
+        selected = idx == self._selected
+        color = self._point_color(idx, selected)
+        ms = self._size * 1.4 if selected else self._size
+        edge_color, mew = self._marker_edge(color, selected)
+        (line,) = self._ax.plot(
+            x,
+            y,
+            marker=self._marker,
+            markersize=ms,
+            color=color,
+            markeredgecolor=edge_color,
+            markeredgewidth=mew,
+            linestyle="none",
+            zorder=8,
+            animated=False,
+            visible=self._visible,
+        )
+        self._artists.append(line)
+        ann = None
+        label = self._point_label(idx)
+        if label is not None:
+            ann = self._ax.annotate(
+                label,
+                xy=(x, y),
+                xytext=(6, 4),
+                textcoords="offset points",
+                color=color,
+                fontsize=8,
+                zorder=9,
+                animated=False,
+                visible=self._visible,
+            )
+        self._anns.append(ann)
+
+    def _update_artist_appearance(self, idx: int):
+        if idx >= len(self._artists):
+            return
+        selected = idx == self._selected
+        color = self._point_color(idx, selected)
+        ms = self._size * 1.4 if selected else self._size
+        edge_color, mew = self._marker_edge(color, selected)
+        line = self._artists[idx]
+        line.set_color(color)
+        line.set_markersize(ms)
+        line.set_markeredgecolor(edge_color)
+        line.set_markeredgewidth(mew)
+        ann = self._anns[idx] if idx < len(self._anns) else None
+        if ann is not None:
+            ann.set_color(color)
+
+    def _update_artist_position(self, idx: int):
+        if idx >= len(self._artists):
+            return
+        x, y = self._points[idx]
+        self._artists[idx].set_xdata([x])
+        self._artists[idx].set_ydata([y])
+        ann = self._anns[idx] if idx < len(self._anns) else None
+        if ann is not None:
+            ann.xy = (x, y)
+
+    def _refresh_ann_text(self):
+        for idx, ann in enumerate(self._anns):
+            if ann is not None:
+                label = self._point_label(idx)
+                if label is not None:
+                    ann.set_text(label)
+
+    # ── hit testing ───────────────────────────────────────────────────────
+
+    def _hit_point(self, event) -> Optional[int]:
+        if not self._points or self._ax is None:
+            return None
+        trans = self._ax.transData
+        best_idx, best_dist = None, _PICK_RADIUS_PX
+        for i, (px, py) in enumerate(self._points):
+            sx, sy = trans.transform((px, py))
+            d = ((event.x - sx) ** 2 + (event.y - sy) ** 2) ** 0.5
+            if d < best_dist:
+                best_dist, best_idx = d, i
+        return best_idx
+
+    # ── blit helpers ──────────────────────────────────────────────────────
+
+    def _start_drag(self, idx: int, event):
+        if self._canvas is None or self._ax is None:
+            return
+        self._drag_idx = idx
+        px, py = self._points[idx]
+        self._drag_offset = (event.xdata - px, event.ydata - py)
+        self._drag_start_xy = (px, py)  # so a no-move select-click skips point_moved
+        self._canvas._overlay_consuming_event = True
+        self._artists[idx].set_animated(True)
+        ann = self._anns[idx] if idx < len(self._anns) else None
+        if ann is not None:
+            ann.set_animated(True)
+        self._canvas.draw()
+        self._blit_bg = self._canvas.copy_from_bbox(self._ax.bbox)
+
+    def _blit(self):
+        if self._canvas is None or self._ax is None:
+            return
+        if self._blit_bg is None or self._drag_idx is None:
+            self._canvas.draw_idle()
+            return
+        self._canvas.restore_region(self._blit_bg)
+        self._ax.draw_artist(self._artists[self._drag_idx])
+        ann = self._anns[self._drag_idx] if self._drag_idx < len(self._anns) else None
+        if ann is not None:
+            self._ax.draw_artist(ann)
+        self._canvas.blit(self._ax.bbox)
+
+    # ── mouse / key events ────────────────────────────────────────────────
+
+    def _on_press(self, event):
+        if self._canvas is None or self._ax is None:
+            return
+        if not self._input_allowed():  # another overlay owns input (modal-aware)
+            return
+        if event.inaxes is not self._ax or event.xdata is None or event.dblclick:
+            return
+        if self._canvas._overlay_consuming_event:
+            return
+
+        if event.button == 3:  # right-click → add a new point
+            if not self._add_on_right_click:
+                return
+            x = max(0.0, min(event.xdata, (self._img_w or 1) - 1))
+            y = max(0.0, min(event.ydata, (self._img_h or 1) - 1))
+            idx = self.add_point(x, y)
+            old_sel = self._selected
+            self._selected = idx
+            if old_sel is not None:
+                self._update_artist_appearance(old_sel)
+            self._update_artist_appearance(idx)
+            self.point_added.emit(idx, x, y)
+            self._canvas.draw_idle()
+            return
+
+        if event.button != 1:
+            return
+
+        hit = self._hit_point(event)
+        if hit is not None:
+            old_sel = self._selected
+            self._selected = hit
+            if old_sel is not None and old_sel != hit:
+                self._update_artist_appearance(old_sel)
+            self._update_artist_appearance(hit)
+            self.point_selected.emit(hit, self._points[hit][0], self._points[hit][1])
+            self._start_drag(hit, event)
+        elif self._selected is not None:
+            # left-click empty → deselect
+            old_sel = self._selected
+            self._selected = None
+            self._update_artist_appearance(old_sel)
+            self._canvas.draw_idle()
+
+    def _on_motion(self, event):
+        if self._drag_idx is None:
+            return
+        if event.xdata is None or event.ydata is None:
+            return
+        W = self._img_w or 1
+        H = self._img_h or 1
+        x = max(0.0, min(event.xdata - self._drag_offset[0], W - 1))
+        y = max(0.0, min(event.ydata - self._drag_offset[1], H - 1))
+        self._points[self._drag_idx] = [x, y]
+        self._update_artist_position(self._drag_idx)
+        self.point_dragging.emit(self._drag_idx, x, y)
+        self._blit()
+
+    def _on_release(self, event):
+        if self._canvas is None:
+            return
+        self._canvas._overlay_consuming_event = False
+        if self._drag_idx is not None:
+            idx = self._drag_idx
+            self._drag_idx = None
+            self._blit_bg = None
+            self._artists[idx].set_animated(False)
+            ann = self._anns[idx] if idx < len(self._anns) else None
+            if ann is not None:
+                ann.set_animated(False)
+            # Only a real move emits point_moved (a select-click without a drag
+            # leaves the position unchanged; point_selected already covered it).
+            if tuple(self._points[idx]) != self._drag_start_xy:
+                self.point_moved.emit(idx, self._points[idx][0], self._points[idx][1])
+            self._canvas.draw_idle()
+
+    def _on_key(self, event):
+        if not self._input_allowed():  # another overlay owns input (modal-aware)
+            return
+        if not self._removable:
+            return
+        if event.key in ("delete", "backspace") and self._selected is not None:
+            self.remove_point(self._selected)

--- a/fibsem/ui/widgets/canvas/overlays/rect_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/rect_overlay.py
@@ -1,0 +1,351 @@
+"""Configurable rectangle overlay (drag-only or drag+resize) for FibsemImageCanvas."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from matplotlib.patches import Rectangle as MplRectangle
+from PyQt5.QtCore import QObject, pyqtSignal
+
+from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay  # noqa: F401  (re-exported by package)
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+
+_RECT_FRAC = 0.25
+_RECT_OFFSET = (1.0 - _RECT_FRAC) / 2.0
+
+
+def _default_extents(H: int, W: int) -> Tuple[float, float, float, float]:
+    """Return (x0, x1, y0, y1) for a centred 25 % box."""
+    rw, rh = W * _RECT_FRAC, H * _RECT_FRAC
+    x0, y0 = W * _RECT_OFFSET, H * _RECT_OFFSET
+    return x0, x0 + rw, y0, y0 + rh
+
+
+_HANDLE_RADIUS_PX = 8  # screen-space hit radius for corner handles
+# Corner handles: name -> (x_fraction, y_fraction) within the rect
+_CORNERS = {"tl": (0.0, 0.0), "tr": (1.0, 0.0), "bl": (0.0, 1.0), "br": (1.0, 1.0)}
+
+
+class RectOverlay(QObject):
+    """Rectangle overlay using ``MplRectangle`` + manual mouse handling.
+
+    Both modes share the same drag/release logic.  ``resizable=True`` additionally
+    draws four corner handles and supports resize by dragging them.
+
+    Parameters
+    ----------
+    color : str
+        Edge colour (and handle colour).
+    facecolor : str | None
+        Fill colour.  ``None`` → transparent.
+    alpha : float
+        Opacity of edge/fill.
+    linewidth : int
+        Edge linewidth in points.
+    linestyle : str
+        Matplotlib linestyle string (``"solid"``, ``"--"``, etc.)
+    resizable : bool
+        ``True`` → drag + four corner resize handles.
+        ``False`` → drag only.
+
+    Examples
+    --------
+    FIB — yellow filled, drag-only::
+
+        RectOverlay(color="yellow", facecolor="yellow", alpha=0.5, resizable=False)
+
+    FM — white dotted, drag + resize::
+
+        RectOverlay(color="white", facecolor=None, linestyle="--", resizable=True)
+    """
+
+    rect_changed = pyqtSignal(dict)  # {x0,y0,x1,y1,cx,cy,width,height} pixels
+
+    def __init__(
+        self,
+        color: str = "yellow",
+        facecolor: Optional[str] = None,
+        alpha: float = 0.5,
+        linewidth: int = 2,
+        linestyle: str = "solid",
+        resizable: bool = True,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self._color = color
+        self._facecolor = facecolor if facecolor is not None else "none"
+        self._alpha = alpha
+        self._linewidth = linewidth
+        self._linestyle = linestyle
+        self._resizable = resizable
+
+        self._ax = None
+        self._canvas: Optional[FibsemImageCanvas] = None
+        self._img_w: Optional[int] = None
+        self._img_h: Optional[int] = None
+
+        # Rect state in data coords
+        self._x0 = self._y0 = self._x1 = self._y1 = 0.0
+        self._saved: Optional[Tuple[float, float, float, float]] = None  # x0,y0,w,h
+
+        # Artists
+        self._patch: Optional[MplRectangle] = None
+        self._handles: dict = {}  # name → Line2D marker
+
+        # Drag state: None | "move" | "tl" | "tr" | "bl" | "br"
+        self._drag_mode: Optional[str] = None
+        self._drag_start_data: Optional[Tuple[float, float]] = None
+        self._drag_start_rect: Optional[Tuple[float, float, float, float]] = None
+        self._blit_bg = None  # background region captured at drag start
+
+        self._interactive: bool = True
+        self._cids: List[int] = []
+
+    # ── overlay protocol ──────────────────────────────────────────────────
+
+    def attach(self, ax, canvas: FibsemImageCanvas) -> None:
+        self._ax = ax
+        self._canvas = canvas
+        self._cids = [
+            canvas.mpl_connect("button_press_event", self._on_press),
+            canvas.mpl_connect("motion_notify_event", self._on_motion),
+            canvas.mpl_connect("button_release_event", self._on_release),
+        ]
+
+    def detach(self) -> None:
+        if self._canvas is not None:
+            for cid in self._cids:
+                try:
+                    self._canvas.mpl_disconnect(cid)
+                except Exception:
+                    pass
+        self._cids = []
+        self._remove_artists()
+        self._ax = None
+        self._canvas = None
+
+    def on_image_changed(self, width: int, height: int) -> None:
+        self._img_w, self._img_h = width, height
+        if self._ax is None or width == 0 or height == 0:
+            return
+        self._rebuild()
+
+    # ── public helpers ────────────────────────────────────────────────────
+
+    def get_rect(self) -> dict:
+        return _xywh_to_dict(
+            self._x0, self._y0, self._x1 - self._x0, self._y1 - self._y0
+        )
+
+    def set_rect(self, x0: float, y0: float, width: float, height: float) -> None:
+        self._x0, self._y0 = x0, y0
+        self._x1, self._y1 = x0 + width, y0 + height
+        self._saved = (x0, y0, width, height)
+        self._update_artists()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    # ── build / teardown ──────────────────────────────────────────────────
+
+    def _remove_artists(self):
+        if self._patch is not None:
+            try:
+                self._patch.remove()
+            except Exception:
+                pass
+            self._patch = None
+        for h in self._handles.values():
+            try:
+                h.remove()
+            except Exception:
+                pass
+        self._handles.clear()
+
+    def _rebuild(self):
+        self._remove_artists()
+
+        if self._saved is not None:
+            x0, y0, w, h = self._saved
+        else:
+            ex = _default_extents(self._img_h, self._img_w)
+            x0, y0, w, h = ex[0], ex[2], ex[1] - ex[0], ex[3] - ex[2]
+            self._saved = (x0, y0, w, h)
+
+        self._x0, self._y0 = x0, y0
+        self._x1, self._y1 = x0 + w, y0 + h
+
+        self._patch = MplRectangle(
+            (self._x0, self._y0),
+            w,
+            h,
+            linewidth=self._linewidth,
+            edgecolor=self._color,
+            facecolor=self._facecolor,
+            linestyle=self._linestyle,
+            alpha=self._alpha,
+            zorder=5,
+        )
+        self._ax.add_patch(self._patch)
+
+        if self._resizable:
+            for name in _CORNERS:
+                hx, hy = self._handle_pos(name)
+                (line,) = self._ax.plot(
+                    hx,
+                    hy,
+                    "s",
+                    markersize=7,
+                    color=self._color,
+                    markeredgecolor="white",
+                    markeredgewidth=0.8,
+                    zorder=6,
+                    visible=self._interactive,
+                )
+                self._handles[name] = line
+
+    def _update_artists(self):
+        if self._patch is not None:
+            self._patch.set_xy((self._x0, self._y0))
+            self._patch.set_width(self._x1 - self._x0)
+            self._patch.set_height(self._y1 - self._y0)
+        for name, line in self._handles.items():
+            hx, hy = self._handle_pos(name)
+            line.set_xdata([hx])
+            line.set_ydata([hy])
+
+    def _handle_pos(self, name: str) -> Tuple[float, float]:
+        fx, fy = _CORNERS[name]
+        return self._x0 + fx * (self._x1 - self._x0), self._y0 + fy * (
+            self._y1 - self._y0
+        )
+
+    # ── hit testing ───────────────────────────────────────────────────────
+
+    def _hit_handle(self, event) -> Optional[str]:
+        """Return corner name if click is within _HANDLE_RADIUS_PX of a handle."""
+        trans = self._ax.transData
+        for name, line in self._handles.items():
+            hx, hy = self._handle_pos(name)
+            sx, sy = trans.transform((hx, hy))
+            if ((event.x - sx) ** 2 + (event.y - sy) ** 2) ** 0.5 < _HANDLE_RADIUS_PX:
+                return name
+        return None
+
+    # ── mouse events ──────────────────────────────────────────────────────
+
+    def _on_press(self, event):
+        if not self._interactive:
+            return
+        # Another overlay owns input on this canvas
+        if self._canvas is not None and not self._canvas._overlay_input_allowed(self):
+            return
+        if event.inaxes is not self._ax or event.button != 1:
+            return
+        if self._patch is None or event.xdata is None:
+            return
+        # Another overlay already claimed this event
+        if self._canvas._overlay_consuming_event:
+            return
+
+        # Check corner handles first (resizable only)
+        if self._resizable:
+            hit = self._hit_handle(event)
+            if hit is not None:
+                self._start_drag(hit, event)
+                return
+
+        # Check rect body
+        contains, _ = self._patch.contains(event)
+        if contains:
+            self._start_drag("move", event)
+
+    def _set_animated(self, val: bool):
+        if self._patch is not None:
+            self._patch.set_animated(val)
+        for h in self._handles.values():
+            h.set_animated(val)
+
+    def _blit(self):
+        """Restore background and redraw only the overlay artists."""
+        if self._blit_bg is None:
+            self._canvas.draw_idle()
+            return
+        self._canvas.restore_region(self._blit_bg)
+        if self._patch is not None:
+            self._ax.draw_artist(self._patch)
+        for h in self._handles.values():
+            self._ax.draw_artist(h)
+        self._canvas.blit(self._ax.bbox)
+
+    def _start_drag(self, mode: str, event):
+        self._drag_mode = mode
+        self._drag_start_data = (event.xdata, event.ydata)
+        self._drag_start_rect = (self._x0, self._y0, self._x1, self._y1)
+        self._canvas._overlay_consuming_event = True
+        # Mark artists animated so they're excluded from the background draw
+        self._set_animated(True)
+        self._canvas.draw()
+        self._blit_bg = self._canvas.copy_from_bbox(self._ax.bbox)
+
+    def _on_motion(self, event):
+        if self._drag_mode is None:
+            return
+        if event.xdata is None or event.ydata is None:
+            return
+
+        dx = event.xdata - self._drag_start_data[0]
+        dy = event.ydata - self._drag_start_data[1]
+        rx0, ry0, rx1, ry1 = self._drag_start_rect
+        W, H = self._img_w, self._img_h
+
+        if self._drag_mode == "move":
+            w, h = rx1 - rx0, ry1 - ry0
+            self._x0 = max(0.0, min(rx0 + dx, W - w))
+            self._y0 = max(0.0, min(ry0 + dy, H - h))
+            self._x1 = self._x0 + w
+            self._y1 = self._y0 + h
+        elif self._drag_mode == "tl":
+            self._x0 = max(0.0, min(rx0 + dx, self._x1 - 1))
+            self._y0 = max(0.0, min(ry0 + dy, self._y1 - 1))
+        elif self._drag_mode == "tr":
+            self._x1 = max(self._x0 + 1, min(rx1 + dx, W))
+            self._y0 = max(0.0, min(ry0 + dy, self._y1 - 1))
+        elif self._drag_mode == "bl":
+            self._x0 = max(0.0, min(rx0 + dx, self._x1 - 1))
+            self._y1 = max(self._y0 + 1, min(ry1 + dy, H))
+        elif self._drag_mode == "br":
+            self._x1 = max(self._x0 + 1, min(rx1 + dx, W))
+            self._y1 = max(self._y0 + 1, min(ry1 + dy, H))
+
+        self._update_artists()
+        self._blit()
+
+    def _on_release(self, event):
+        if self._canvas is not None:
+            self._canvas._overlay_consuming_event = False
+        if self._drag_mode is not None:
+            self._drag_mode = None
+            self._saved = (self._x0, self._y0, self._x1 - self._x0, self._y1 - self._y0)
+            # Restore normal rendering
+            self._set_animated(False)
+            self._blit_bg = None
+            self._canvas.draw_idle()
+            self.rect_changed.emit(self.get_rect())
+
+
+def _xywh_to_dict(x: float, y: float, w: float, h: float) -> dict:
+    return {
+        "x0": round(x),
+        "y0": round(y),
+        "x1": round(x + w),
+        "y1": round(y + h),
+        "cx": round(x + w / 2),
+        "cy": round(y + h / 2),
+        "width": round(w),
+        "height": round(h),
+    }

--- a/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
@@ -1,0 +1,290 @@
+"""Drag-to-measure ruler overlay (distance in SI units) for FibsemImageCanvas."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Tuple
+
+from fibsem.ui.stylesheets import CANVAS_BG as _BG
+from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+
+_RULER_PICK_PX = 10  # screen-space hit radius for ruler endpoints / line body
+
+
+def _clampf(v: float, lo: float, hi: float) -> float:
+    return lo if v < lo else hi if v > hi else v
+
+
+def _format_distance(metres: float) -> str:
+    """Auto-scale a distance in metres to a short SI string."""
+    a = abs(metres)
+    if a == 0:
+        return "0 nm"
+    if a < 1e-6:
+        return f"{metres * 1e9:.1f} nm"
+    if a < 1e-3:
+        return f"{metres * 1e6:.2f} µm"
+    if a < 1.0:
+        return f"{metres * 1e3:.3f} mm"
+    return f"{metres:.4f} m"
+
+
+class RulerOverlay(CanvasOverlay):
+    """Two-endpoint measure line on a :class:`FibsemImageCanvas`.
+
+    Drag either endpoint — or the line body — to measure; the label shows the
+    distance using the canvas pixel size (SI-formatted), or pixels when the
+    pixel size is unknown.  Endpoints live in data (image-pixel) coordinates, so
+    the ruler survives zoom / pan and image swaps.
+
+    Inert until :meth:`set_visible(True)` (driven by the canvas ruler button):
+    it builds no artists and captures no input while hidden, so canvases that
+    never enable it are unaffected.
+    """
+
+    def __init__(self, color: str = "#ffd23f"):
+        self._color = color
+        self._ax = None
+        self._canvas: Optional["FibsemImageCanvas"] = None
+        self._img_w: Optional[int] = None
+        self._img_h: Optional[int] = None
+        self._pixel_size: Optional[float] = None
+
+        # endpoints in data coords (None until seeded)
+        self._p1: Optional[List[float]] = None
+        self._p2: Optional[List[float]] = None
+        self._visible: bool = False
+
+        # artists
+        self._line = None   # Line2D segment
+        self._dots = None   # Line2D endpoint markers
+        self._label = None  # Annotation (distance)
+
+        # drag state: None | "p1" | "p2" | "line"
+        self._drag: Optional[str] = None
+        self._drag_start_data: Optional[Tuple[float, float]] = None
+        self._drag_start_pts = None
+        self._blit_bg = None
+        self._cids: List[int] = []
+
+    # ── overlay protocol ──────────────────────────────────────────────────
+
+    def attach(self, ax, canvas: "FibsemImageCanvas") -> None:
+        self._ax = ax
+        self._canvas = canvas
+        self._cids = [
+            canvas.mpl_connect("button_press_event", self._on_press),
+            canvas.mpl_connect("motion_notify_event", self._on_motion),
+            canvas.mpl_connect("button_release_event", self._on_release),
+        ]
+
+    def detach(self) -> None:
+        if self._canvas is not None:
+            for cid in self._cids:
+                try:
+                    self._canvas.mpl_disconnect(cid)
+                except Exception:
+                    pass
+        self._cids = []
+        self._remove_artists()
+        self._ax = None
+        self._canvas = None
+
+    def on_image_changed(self, width: int, height: int) -> None:
+        self._img_w, self._img_h = width, height
+        if self._canvas is not None:
+            self._pixel_size = self._canvas._pixel_size
+        if self._ax is None or width == 0 or height == 0 or not self._visible:
+            self._remove_artists()  # inert while hidden / between images
+            return
+        if self._p1 is None or self._p2 is None:
+            self._seed_default()
+        else:
+            self._clamp()
+        self._rebuild()
+
+    # ── public ────────────────────────────────────────────────────────────
+
+    def set_visible(self, visible: bool) -> None:
+        """Show/hide the ruler.  Endpoints persist while hidden."""
+        self._visible = visible
+        if not visible:
+            self._remove_artists()
+        elif self._img_w:
+            if self._p1 is None or self._p2 is None:
+                self._seed_default()
+            self._rebuild()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def measurement(self) -> Optional[float]:
+        """Current distance in metres (or pixels when no pixel size), or None."""
+        if self._p1 is None or self._p2 is None:
+            return None
+        d = math.hypot(self._p2[0] - self._p1[0], self._p2[1] - self._p1[1])
+        return d * self._pixel_size if self._pixel_size else d
+
+    # ── build / teardown ──────────────────────────────────────────────────
+
+    def _seed_default(self) -> None:
+        if not self._img_w or not self._img_h:
+            return
+        cx, cy = self._img_w / 2.0, self._img_h / 2.0
+        half = self._img_w * 0.125
+        self._p1 = [cx - half, cy]
+        self._p2 = [cx + half, cy]
+
+    def _clamp(self) -> None:
+        if self._img_w is None:
+            return
+        for p in (self._p1, self._p2):
+            p[0] = _clampf(p[0], 0.0, self._img_w)
+            p[1] = _clampf(p[1], 0.0, self._img_h)
+
+    def _remove_artists(self) -> None:
+        for a in (self._line, self._dots, self._label):
+            if a is not None:
+                try:
+                    a.remove()
+                except Exception:
+                    pass
+        self._line = self._dots = self._label = None
+
+    def _xs_ys(self) -> Tuple[List[float], List[float]]:
+        return [self._p1[0], self._p2[0]], [self._p1[1], self._p2[1]]
+
+    def _rebuild(self) -> None:
+        self._remove_artists()
+        if self._p1 is None or self._p2 is None:
+            return
+        xs, ys = self._xs_ys()
+        (self._line,) = self._ax.plot(
+            xs, ys, color=self._color, linewidth=1.6,
+            solid_capstyle="round", zorder=8,
+        )
+        (self._dots,) = self._ax.plot(
+            xs, ys, linestyle="none", marker="o", markersize=6,
+            markerfacecolor=self._color, markeredgecolor="white",
+            markeredgewidth=0.8, zorder=9,
+        )
+        mx, my = (xs[0] + xs[1]) / 2.0, (ys[0] + ys[1]) / 2.0
+        self._label = self._ax.annotate(
+            self._text(), xy=(mx, my), xytext=(0, 9),
+            textcoords="offset points", ha="center", va="bottom",
+            fontsize=8, color="#ffffff", zorder=10,
+            bbox=dict(boxstyle="round,pad=0.3", facecolor=_BG,
+                      edgecolor=self._color, alpha=0.8, linewidth=0.8),
+        )
+
+    def _text(self) -> str:
+        d = math.hypot(self._p2[0] - self._p1[0], self._p2[1] - self._p1[1])
+        if self._pixel_size:
+            return _format_distance(d * self._pixel_size)
+        return f"{d:.0f} px"
+
+    def _update_artists(self) -> None:
+        xs, ys = self._xs_ys()
+        self._line.set_data(xs, ys)
+        self._dots.set_data(xs, ys)
+        self._label.xy = ((xs[0] + xs[1]) / 2.0, (ys[0] + ys[1]) / 2.0)
+        self._label.set_text(self._text())
+
+    # ── hit testing (screen space) ────────────────────────────────────────
+
+    def _screen(self, p: List[float]) -> Tuple[float, float]:
+        return self._ax.transData.transform((p[0], p[1]))
+
+    def _hit(self, event) -> Optional[str]:
+        for name, p in (("p1", self._p1), ("p2", self._p2)):
+            sx, sy = self._screen(p)
+            if math.hypot(event.x - sx, event.y - sy) <= _RULER_PICK_PX:
+                return name
+        x1, y1 = self._screen(self._p1)
+        x2, y2 = self._screen(self._p2)
+        if self._seg_dist(event.x, event.y, x1, y1, x2, y2) <= _RULER_PICK_PX * 0.6:
+            return "line"
+        return None
+
+    @staticmethod
+    def _seg_dist(px, py, x1, y1, x2, y2) -> float:
+        dx, dy = x2 - x1, y2 - y1
+        if dx == 0 and dy == 0:
+            return math.hypot(px - x1, py - y1)
+        t = _clampf(((px - x1) * dx + (py - y1) * dy) / (dx * dx + dy * dy), 0.0, 1.0)
+        return math.hypot(px - (x1 + t * dx), py - (y1 + t * dy))
+
+    # ── mouse events ──────────────────────────────────────────────────────
+
+    def _on_press(self, event) -> None:
+        if not self._visible or self._line is None:
+            return
+        if self._canvas is not None and not self._canvas._overlay_input_allowed(self):
+            return
+        if event.inaxes is not self._ax or event.button != 1 or event.xdata is None:
+            return
+        if self._canvas._overlay_consuming_event:
+            return
+        hit = self._hit(event)
+        if hit is None:
+            return
+        self._drag = hit
+        self._drag_start_data = (event.xdata, event.ydata)
+        self._drag_start_pts = (list(self._p1), list(self._p2))
+        self._canvas._overlay_consuming_event = True
+        self._set_animated(True)
+        self._canvas.draw()
+        self._blit_bg = self._canvas.copy_from_bbox(self._ax.bbox)
+
+    def _on_motion(self, event) -> None:
+        if self._drag is None or event.xdata is None or event.ydata is None:
+            return
+        dx = event.xdata - self._drag_start_data[0]
+        dy = event.ydata - self._drag_start_data[1]
+        p1, p2 = self._drag_start_pts
+        W, H = self._img_w, self._img_h
+        if self._drag == "p1":
+            self._p1 = [_clampf(p1[0] + dx, 0, W), _clampf(p1[1] + dy, 0, H)]
+        elif self._drag == "p2":
+            self._p2 = [_clampf(p2[0] + dx, 0, W), _clampf(p2[1] + dy, 0, H)]
+        else:  # move the whole line, clamped so both endpoints stay in bounds
+            minx, maxx = min(p1[0], p2[0]), max(p1[0], p2[0])
+            miny, maxy = min(p1[1], p2[1]), max(p1[1], p2[1])
+            dx = _clampf(dx, -minx, W - maxx)
+            dy = _clampf(dy, -miny, H - maxy)
+            self._p1 = [p1[0] + dx, p1[1] + dy]
+            self._p2 = [p2[0] + dx, p2[1] + dy]
+        self._update_artists()
+        self._blit()
+
+    def _on_release(self, event) -> None:
+        if self._canvas is not None:
+            self._canvas._overlay_consuming_event = False
+        if self._drag is not None:
+            self._drag = None
+            self._set_animated(False)
+            self._blit_bg = None
+            if self._canvas is not None:
+                self._canvas.draw_idle()
+
+    # ── blitting ──────────────────────────────────────────────────────────
+
+    def _set_animated(self, val: bool) -> None:
+        for a in (self._line, self._dots, self._label):
+            if a is not None:
+                a.set_animated(val)
+
+    def _blit(self) -> None:
+        if self._blit_bg is None:
+            self._canvas.draw_idle()
+            return
+        self._canvas.restore_region(self._blit_bg)
+        for a in (self._line, self._dots, self._label):
+            if a is not None:
+                self._ax.draw_artist(a)
+        self._canvas.blit(self._ax.bbox)

--- a/fibsem/ui/widgets/canvas/quad_view.py
+++ b/fibsem/ui/widgets/canvas/quad_view.py
@@ -1,0 +1,869 @@
+"""Quad-view microscope display — reusable 2x2 grid of FibsemImageCanvas.
+
+Replaces the single napari viewer in the main microscope tab. Four cells:
+
+    SEM (electron) | FIB (ion)
+    FM (fluorescence) | "No Data" placeholder
+
+``MicroscopeViewController`` wraps the widget and is the object handed to the
+control widgets in place of the napari ``Viewer``. Its surface is intentionally
+small in Phase 0 (image routing only) and grows in later phases (overlays,
+per-beam click signals).
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Dict, Optional, Set
+
+from PyQt5.QtCore import QEvent, QObject, Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QFrame,
+    QLabel,
+    QSplitter,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem import constants
+from fibsem.structures import BeamType, FibsemImage
+from fibsem.ui.widgets.canvas.canvas_state import (
+    AlignmentSpec,
+    CanvasState,
+    MaskSpec,
+    MillingSpec,
+    OverlaySpec,
+    PointsSpec,
+    SceneModel,
+)
+from fibsem.ui.stylesheets import CANVAS_BG as _BG, PRIMARY_ACCENT as _SELECT_ACCENT
+from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+if TYPE_CHECKING:
+    from fibsem.fm.structures import FluorescenceImage
+    from fibsem.structures import FibsemRectangle
+    from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+
+_logger = logging.getLogger(__name__)
+
+_TITLE_STYLE = (
+    "color: #888; font-size: 11px; padding: 2px 6px; background: #1e2124;"
+)
+_PLACEHOLDER_STYLE = "color: #777; font-size: 12px;"
+# Selected-view border: the primary accent (matches PRIMARY_BUTTON_STYLESHEET), kept subtle.
+# A transparent border of the same width is always present so selection causes no layout shift,
+# and it's scoped via the #viewPanel object name so it never cascades onto the title / canvas.
+_PANEL_QSS = "#viewPanel {{ background: {bg}; border: 2px solid {border}; }}"
+# Live-acquisition border: green, and it takes priority over the blue selected border so a
+# live view is obvious even when you've clicked away to another cell.
+_LIVE_ACCENT = "#4caf50"
+
+
+def _titled(title: str, inner: QWidget) -> QFrame:
+    """Wrap *inner* in a selectable panel frame with a small title label above it."""
+    frame = QFrame()
+    frame.setObjectName("viewPanel")
+    frame.setAttribute(Qt.WA_StyledBackground, True)
+    frame.setStyleSheet(_PANEL_QSS.format(bg=_BG, border="transparent"))
+    lbl = QLabel(title, alignment=Qt.AlignLeft)
+    lbl.setStyleSheet(_TITLE_STYLE)
+    lay = QVBoxLayout(frame)
+    lay.setContentsMargins(0, 0, 0, 0)
+    lay.setSpacing(0)
+    lay.addWidget(lbl)
+    lay.addWidget(inner)
+    return frame
+
+
+def _splitter(orientation, *widgets) -> QSplitter:
+    s = QSplitter(orientation)
+    s.setChildrenCollapsible(False)
+    for w in widgets:
+        s.addWidget(w)
+    s.setSizes([1000] * len(widgets))
+    return s
+
+
+class PlaceholderPanel(QFrame):
+    """Inert 'No Data' panel for the 4th quad-view cell (no canvas, no toolbar)."""
+
+    def __init__(self, text: str = "No Data") -> None:
+        super().__init__()
+        self.setStyleSheet(f"background: {_BG};")
+        lbl = QLabel(text, alignment=Qt.AlignCenter)
+        lbl.setStyleSheet(_PLACEHOLDER_STYLE)
+        lay = QVBoxLayout(self)
+        lay.addWidget(lbl)
+
+
+class QuadViewWidget(QWidget):
+    """2x2 grid: SEM | FIB over FM | placeholder, each a selectable titled panel.
+
+    The SEM/FIB cells are :class:`FibsemImageCanvas` instances (so they inherit
+    the reset / scalebar / crosshair / contrast toolbar); the FM cell is an
+    :class:`FMCanvasWidget` (multi-channel composite + per-channel controls), and
+    the 4th is an inert placeholder. ``fm_canvas`` aliases the FM widget's inner
+    canvas so overlays attach the same way they do on SEM/FIB.
+
+    The most-recently-clicked canvas is the *selected* view: its panel gets a subtle
+    primary border, only its canvas toolbar is shown, and it is the target for
+    view-scoped hotkeys. All canvases stay fully interactive regardless of selection.
+    """
+
+    # Emitted when the selected view changes; payload is the view key
+    # (BeamType.ELECTRON / BeamType.ION for SEM / FIB, or the string "fm").
+    view_selected = pyqtSignal(object)
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.sem_canvas = FibsemImageCanvas()
+        self.fib_canvas = FibsemImageCanvas()
+        self.fm_widget = FMCanvasWidget()
+        self.fm_canvas = self.fm_widget.canvas
+        self.placeholder = PlaceholderPanel("No Data")
+
+        sem_panel = _titled("SEM", self.sem_canvas)
+        fm_panel = _titled("FM", self.fm_widget)
+        fib_panel = _titled("FIB", self.fib_canvas)
+        placeholder_panel = _titled("Placeholder", self.placeholder)
+
+        left = _splitter(Qt.Vertical, sem_panel, fm_panel)
+        right = _splitter(Qt.Vertical, fib_panel, placeholder_panel)
+        root = _splitter(Qt.Horizontal, left, right)
+
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.addWidget(root)
+
+        # ── full-screen state ─────────────────────────────────────────────
+        # Full screen hides a cell's vertical-splitter sibling + the other vertical splitter,
+        # leaving one cell filling the quad. Reversible: saved sizes restore the grid.
+        self._root_splitter = root
+        self._splitters = {"left": left, "right": right}
+        self._all_panels = [sem_panel, fm_panel, fib_panel, placeholder_panel]
+        self._panel_splitter = {
+            sem_panel: left, fm_panel: left, fib_panel: right, placeholder_panel: right,
+        }
+        self._fullscreen: Optional[object] = None
+        self._saved_sizes: dict = {}
+
+        # ── selected-view state ───────────────────────────────────────────
+        self._panels: Dict[object, QFrame] = {
+            BeamType.ELECTRON: sem_panel,
+            BeamType.ION: fib_panel,
+            "fm": fm_panel,
+        }
+        self._canvas_keys: Dict[QWidget, object] = {
+            self.sem_canvas: BeamType.ELECTRON,
+            self.fib_canvas: BeamType.ION,
+            self.fm_canvas: "fm",
+        }
+        self._key_canvas: Dict[object, QWidget] = {v: k for k, v in self._canvas_keys.items()}
+        self._live: set = set()  # view keys currently live-acquiring (green border + LIVE badge)
+        self._selected: Optional[object] = None
+        for canvas in self._canvas_keys:
+            canvas.installEventFilter(self)
+        # default: SEM selected, so exactly one view always has the border + toolbar
+        self.set_selected(BeamType.ELECTRON)
+
+    @property
+    def selected(self) -> Optional[object]:
+        """The selected view key (``BeamType.ELECTRON`` / ``BeamType.ION`` / ``"fm"``)."""
+        return self._selected
+
+    def set_selected(self, key: object) -> None:
+        """Select the view *key*: highlight its panel, show only its canvas toolbar, and
+        emit :attr:`view_selected`. No-op for unknown keys or re-selecting the current view."""
+        if key not in self._panels or key == self._selected:
+            return
+        self._selected = key
+        self._refresh_borders()
+        for canvas, k in self._canvas_keys.items():
+            canvas.set_toolbar_visible(k == key)
+        self.view_selected.emit(key)
+
+    def _panel_border(self, key: object) -> str:
+        """Border colour for a panel: green while live (wins), else blue if selected, else none."""
+        if key in self._live:
+            return _LIVE_ACCENT
+        if key == self._selected:
+            return _SELECT_ACCENT
+        return "transparent"
+
+    def _refresh_borders(self) -> None:
+        for k, frame in self._panels.items():
+            frame.setStyleSheet(_PANEL_QSS.format(bg=_BG, border=self._panel_border(k)))
+
+    def set_live(self, key: object, live: bool) -> None:
+        """Mark view *key* (a ``BeamType``) as live-acquiring: green border + a "LIVE" badge on
+        its canvas, independent of which view is selected. The border wins over selection."""
+        if key not in self._panels:
+            return
+        if live:
+            self._live.add(key)
+        else:
+            self._live.discard(key)
+        self._refresh_borders()
+        canvas = self._key_canvas.get(key)
+        if canvas is not None and hasattr(canvas, "set_live_badge"):
+            canvas.set_live_badge(live)
+
+    def eventFilter(self, obj, event):
+        """Select the view whose canvas was pressed (any mouse button). The event is not
+        consumed, so clicks still pan / move the stage / open menus exactly as before."""
+        if event.type() == QEvent.MouseButtonPress:
+            key = self._canvas_keys.get(obj)
+            if key is not None:
+                self.set_selected(key)
+        return super().eventFilter(obj, event)
+
+    # ── full screen ─────────────────────────────────────────────────────────
+    @property
+    def fullscreen(self) -> Optional[object]:
+        """The full-screened view key, or ``None`` when showing the 2x2 grid."""
+        return self._fullscreen
+
+    def toggle_fullscreen(self) -> None:
+        """Toggle full screen for the selected view (no-op if nothing is selected)."""
+        if self._fullscreen is not None:
+            self.set_fullscreen(None)
+        elif self._selected is not None:
+            self.set_fullscreen(self._selected)
+
+    def set_fullscreen(self, key: Optional[object]) -> None:
+        """Full-screen the view *key* (``BeamType.ELECTRON`` / ``BeamType.ION`` / ``"fm"``),
+        hiding the other cells; pass ``None`` to restore the 2x2 grid. No-op for unknown keys
+        or re-requesting the current state.
+
+        The full-screened view is also made the selected view, so the one visible cell always
+        shows its toolbar (selection drives toolbar visibility)."""
+        if key == self._fullscreen:
+            return
+        if key is None:
+            self._restore_grid()
+            return
+        if key not in self._panels:
+            return
+        self.set_selected(key)  # invariant: the full-screened cell is the selected one
+        if self._fullscreen is None:
+            # entering from the grid: remember the grid's splitter sizes for restore
+            self._saved_sizes = {
+                "root": self._root_splitter.sizes(),
+                "left": self._splitters["left"].sizes(),
+                "right": self._splitters["right"].sizes(),
+            }
+        target = self._panels[key]
+        keep_splitter = self._panel_splitter[target]
+        for panel in self._all_panels:
+            panel.setVisible(panel is target)
+        for spl in self._splitters.values():
+            spl.setVisible(spl is keep_splitter)
+        self._fullscreen = key
+
+    def _restore_grid(self) -> None:
+        """Show all cells + both splitters and restore the saved grid sizes."""
+        for panel in self._all_panels:
+            panel.setVisible(True)
+        for spl in self._splitters.values():
+            spl.setVisible(True)
+        if self._saved_sizes:
+            self._root_splitter.setSizes(self._saved_sizes["root"])
+            self._splitters["left"].setSizes(self._saved_sizes["left"])
+            self._splitters["right"].setSizes(self._saved_sizes["right"])
+        self._fullscreen = None
+
+
+class LamellaEditorView(QWidget):
+    """Task-driven stacked view backing the lamella protocol editor.
+
+    Unlike :class:`QuadViewWidget` (a static 2x2 grid), this shows *one* page at a
+    time, chosen by the selected task type — mirroring the old editor's per-task
+    napari layer-visibility toggle:
+
+        * "beams"        — the FIB canvas, with the SEM canvas beside it (hidden
+                           unless toggled on). Milling / POI / alignment / spot-burn
+                           overlays all live on the FIB canvas.
+        * "fluorescence" — the multi-channel FM widget.
+
+    Exposes ``sem_canvas`` / ``fib_canvas`` / ``fm_widget`` / ``fm_canvas`` so a
+    :class:`MicroscopeViewController` can drive it exactly like ``QuadViewWidget``.
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.sem_canvas = FibsemImageCanvas()
+        self.fib_canvas = FibsemImageCanvas()
+        self.fm_widget = FMCanvasWidget()
+        self.fm_canvas = self.fm_widget.canvas
+
+        self._sem_panel = _titled("SEM", self.sem_canvas)
+        self._sem_panel.setVisible(False)  # shown on demand via set_sem_visible()
+        self._beams_page = _splitter(
+            Qt.Horizontal, _titled("FIB", self.fib_canvas), self._sem_panel
+        )
+
+        self._stack = QStackedWidget()
+        self._stack.addWidget(self._beams_page)  # index 0: beams
+        self._stack.addWidget(_titled("Fluorescence", self.fm_widget))  # index 1: FM
+
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.addWidget(self._stack)
+
+    def show_beams(self) -> None:
+        """Show the FIB (+ optional SEM) page."""
+        self._stack.setCurrentIndex(0)
+
+    def show_fluorescence(self) -> None:
+        """Show the multi-channel FM page."""
+        self._stack.setCurrentIndex(1)
+
+    def set_sem_visible(self, visible: bool) -> None:
+        """Show/hide the SEM canvas beside FIB on the beams page."""
+        self._sem_panel.setVisible(visible)
+
+
+class MicroscopeViewController(QObject):
+    """Seam object that replaces the napari ``Viewer`` in the main microscope tab.
+
+    Holds the :class:`QuadViewWidget`, owns a declarative :class:`SceneModel`
+    (image + overlays + info per canvas), and renders it onto the per-beam canvases
+    in a single debounced pass. Producers mutate the model *only* through the reducer
+    API (``set_image`` / ``set_overlay`` / ``remove_overlay``); they never touch the
+    canvases or overlay objects directly. Renders are coalesced: mutations mark the
+    scene dirty and a queued signal drives one ``_reconcile`` pass per canvas on the
+    GUI thread, so the reducer API is safe to call from worker threads.
+    """
+
+    # Emitted (queued) when a canvas needs re-rendering; the queued connection
+    # marshals the render onto the GUI thread, so the reducer API is safe to call
+    # from worker threads.
+    _render_requested = pyqtSignal()
+
+    # Emitted when the user commits an edit on an interactive overlay:
+    # (beam, overlay_id, value). Producers subscribe and filter by overlay_id.
+    overlay_edited = pyqtSignal(object, str, object)
+
+    # Emitted when the user selects a point on a PointsSpec overlay:
+    # (beam, overlay_id, index). Producers subscribe to mirror selection (e.g. a table).
+    overlay_point_selected = pyqtSignal(object, str, int)
+
+    # Forwarded from the view when the selected view changes (BeamType or "fm"). Only the
+    # quad view emits this; the lamella editor view has no selection concept.
+    view_selected = pyqtSignal(object)
+
+    def __init__(
+        self, parent: Optional[QObject] = None, view: Optional[QWidget] = None
+    ) -> None:
+        super().__init__(parent)
+        # The view widget must expose sem_canvas / fib_canvas / fm_widget / fm_canvas.
+        # Defaults to the 2x2 quad; the lamella editor passes a LamellaEditorView.
+        self._widget = view if view is not None else QuadViewWidget()
+        # Forward the view's selection signal when it supports selection (quad view does;
+        # the lamella editor view does not).
+        if hasattr(self._widget, "view_selected"):
+            self._widget.view_selected.connect(self.view_selected)
+        self._canvases: Dict[BeamType, FibsemImageCanvas] = {
+            BeamType.ELECTRON: self._widget.sem_canvas,
+            BeamType.ION: self._widget.fib_canvas,
+        }
+
+        # ── declarative state model (one CanvasState per canvas) ──────────
+        self._scene = SceneModel()
+        self._states: Dict[FibsemImageCanvas, CanvasState] = {
+            self._widget.sem_canvas: self._scene.sem,
+            self._widget.fib_canvas: self._scene.fib,
+            self._widget.fm_canvas: self._scene.fm,
+        }
+        # reducer-owned overlay objects (id → overlay) per canvas; their lifetime
+        # matches the canvas, so producers never attach or tear them down.
+        self._overlay_objs: Dict[FibsemImageCanvas, Dict[str, "CanvasOverlay"]] = {
+            canvas: {} for canvas in self._states
+        }
+        # reverse map (canvas → beam) for tagging edit signals; armed-mode applied
+        # state (canvas → overlay object) so arming only toggles on change.
+        self._beams: Dict[FibsemImageCanvas, BeamType] = {
+            canvas: beam for beam, canvas in self._canvases.items()
+        }
+        self._armed_applied: Dict[FibsemImageCanvas, Optional["CanvasOverlay"]] = {
+            canvas: None for canvas in self._states
+        }
+        self._dirty: Set[FibsemImageCanvas] = set()
+        self._render_scheduled = False
+        self._render_requested.connect(self._do_render, Qt.QueuedConnection)
+
+    @property
+    def widget(self) -> QWidget:
+        """The view widget (``QuadViewWidget`` or a ``LamellaEditorView``)."""
+        return self._widget
+
+    @property
+    def selected_view(self):
+        """The selected view key (``BeamType.ELECTRON`` / ``BeamType.ION`` / ``"fm"``), or
+        ``None`` for views (e.g. the lamella editor) that don't support selection."""
+        return getattr(self._widget, "selected", None)
+
+    @property
+    def fullscreen(self):
+        """The full-screened view key, or ``None`` (grid, or a view without full screen)."""
+        return getattr(self._widget, "fullscreen", None)
+
+    def set_fullscreen(self, key) -> None:
+        """Full-screen a view (``BeamType`` or ``"fm"``), or restore the grid with ``None``.
+        No-op on views that don't support it (e.g. the lamella editor)."""
+        fn = getattr(self._widget, "set_fullscreen", None)
+        if callable(fn):
+            fn(key)
+
+    def toggle_fullscreen(self) -> None:
+        """Toggle full screen for the selected view; no-op on unsupported views."""
+        fn = getattr(self._widget, "toggle_fullscreen", None)
+        if callable(fn):
+            fn()
+
+    def set_live(self, key: BeamType, live: bool) -> None:
+        """Mark a beam view as live-acquiring (green border + LIVE badge). No-op on views
+        that don't support it."""
+        fn = getattr(self._widget, "set_live", None)
+        if callable(fn):
+            fn(key, live)
+
+    @property
+    def sem_canvas(self) -> FibsemImageCanvas:
+        return self._widget.sem_canvas
+
+    @property
+    def fib_canvas(self) -> FibsemImageCanvas:
+        return self._widget.fib_canvas
+
+    @property
+    def fm_widget(self) -> FMCanvasWidget:
+        """The multi-channel FM widget (composite + per-channel controls)."""
+        return self._widget.fm_widget
+
+    @property
+    def fm_canvas(self) -> FibsemImageCanvas:
+        """The FM widget's inner canvas — for overlays / scalebar, like SEM/FIB."""
+        return self._widget.fm_canvas
+
+    def get_canvas(self, beam: BeamType) -> Optional[FibsemImageCanvas]:
+        """Return the canvas for a charged-particle beam (ELECTRON / ION)."""
+        return self._canvases.get(beam)
+
+    def set_image(self, beam: BeamType, image: FibsemImage) -> None:
+        """Display *image* on the canvas for *beam* and stash it on the canvas state
+        (no-op for unknown beams).
+
+        The stashed image is what the reducer injects into image-dependent overlays
+        (e.g. milling), so a bare image swap re-renders them against the new image.
+        """
+        canvas = self._canvases.get(beam)
+        if canvas is None:
+            return
+        canvas.set_image(image)
+        self._states[canvas].image = image
+        self._mark_dirty(canvas)
+
+    def set_fm_channel(self, name: str, data, color: Optional[str] = None) -> None:
+        """Upsert one fluorescence channel into the FM composite (by *name*)."""
+        self._widget.fm_widget.set_channel(name, data, color)
+
+    def set_fm_pixel_size(self, pixel_size: Optional[float]) -> None:
+        """Set the FM canvas pixel size (metres/px) for the scalebar."""
+        self._widget.fm_widget.set_pixel_size(pixel_size)
+
+    def set_fm_image(self, image: "FluorescenceImage") -> None:
+        """Composite an acquired ``FluorescenceImage`` (all channels) onto the FM
+        canvas. See :meth:`FMCanvasWidget.set_fm_image`."""
+        self._widget.fm_widget.set_fm_image(image)
+
+    def clear_fm(self) -> None:
+        """Drop all composited FM channels. Used on a lamella/task swap so a prior
+        selection's channels (esp. differently-named ones) don't linger."""
+        self._widget.fm_widget.clear()
+
+    # ── overlay reducer ───────────────────────────────────────────────────
+    def set_overlay(self, beam: BeamType, spec: OverlaySpec) -> None:
+        """Upsert an overlay *spec* (keyed by ``spec.id``) on the canvas for *beam*;
+        rendered on the next debounced pass. No-op for unknown beams."""
+        canvas = self._canvases.get(beam)
+        if canvas is None:
+            return
+        self._states[canvas].overlays[spec.id] = spec
+        self._mark_dirty(canvas)
+
+    def remove_overlay(self, beam: BeamType, overlay_id: str) -> None:
+        """Remove the overlay with *overlay_id* from the canvas for *beam*."""
+        canvas = self._canvases.get(beam)
+        if canvas is None:
+            return
+        if self._states[canvas].overlays.pop(overlay_id, None) is not None:
+            self._mark_dirty(canvas)
+
+    def arm_overlay(
+        self,
+        beam: BeamType,
+        overlay_id: Optional[str],
+        label: str = "",
+        icon: str = "mdi:cursor-default-click",
+    ) -> None:
+        """Arm *overlay_id* for edit input on the canvas for *beam* (single arbiter;
+        ``None`` returns to Move). The reducer drives the canvas's
+        ``enter_overlay_mode`` / ``exit_overlay_mode`` (incl. the toolbar toggle)."""
+        canvas = self._canvases.get(beam)
+        if canvas is None:
+            return
+        state = self._states[canvas]
+        state.armed_overlay = overlay_id
+        state.armed_label = label
+        state.armed_icon = icon
+        self._mark_dirty(canvas)
+
+    def set_overlay_visible(self, beam: BeamType, overlay_id: str, visible: bool) -> None:
+        """Toggle an overlay's visibility without replacing its spec (keeps points /
+        value). Applies to specs with a ``visible`` field (e.g. PointsSpec)."""
+        canvas = self._canvases.get(beam)
+        if canvas is None:
+            return
+        spec = self._states[canvas].overlays.get(overlay_id)
+        if spec is not None and hasattr(spec, "visible"):
+            spec.visible = visible
+            self._mark_dirty(canvas)
+
+    def set_points(self, beam: BeamType, overlay_id: str, points) -> None:
+        """Replace a PointsSpec overlay's points without touching its config / visibility."""
+        canvas = self._canvases.get(beam)
+        if canvas is None:
+            return
+        spec = self._states[canvas].overlays.get(overlay_id)
+        if isinstance(spec, PointsSpec):
+            spec.points = list(points)
+            self._mark_dirty(canvas)
+
+    def set_selected_point(
+        self, beam: BeamType, overlay_id: str, index: Optional[int]
+    ) -> None:
+        """Select a point on a ``PointsSpec`` overlay (e.g. mirroring a table row).
+
+        Persists the selection on the spec (so it survives the next reconcile / a live
+        frame re-render) and applies it to the live object if it exists. Silent — no
+        echo — so producers can drive it from a table without a feedback loop."""
+        canvas = self._canvases.get(beam)
+        if canvas is None:
+            return
+        spec = self._states[canvas].overlays.get(overlay_id)
+        if isinstance(spec, PointsSpec):
+            spec.selected = index
+        obj = self._overlay_objs.get(canvas, {}).get(overlay_id)
+        if obj is not None and hasattr(obj, "set_selected"):
+            obj.set_selected(index)
+
+    def set_alignment_edit(
+        self, beam: BeamType, rect: Optional["FibsemRectangle"], editing: bool
+    ) -> None:
+        """Image widget: start/stop editing the alignment area. Editing wins over the
+        milling read-only display and owns input (armed). The spec is kept when
+        editing stops (hidden if nothing else wants it) so the value survives the
+        workflow's clear-then-read."""
+        canvas = self._canvases.get(beam)
+        if canvas is None:
+            return
+        spec = self._alignment_spec(canvas)
+        spec.editing = editing
+        if rect is not None:
+            spec.rect = rect
+        self.arm_overlay(
+            beam,
+            "alignment" if editing else None,
+            label="Alignment",
+            icon="mdi:vector-rectangle",
+        )
+        self._mark_dirty(canvas)
+
+    def set_alignment_display(
+        self, beam: BeamType, rect: Optional["FibsemRectangle"], show: bool
+    ) -> None:
+        """Milling viewer: request the alignment area shown read-only. Yields to an
+        active edit and never clobbers an in-progress edit's rect."""
+        canvas = self._canvases.get(beam)
+        if canvas is None:
+            return
+        spec = self._states[canvas].overlays.get("alignment")
+        if not isinstance(spec, AlignmentSpec):
+            if not show:
+                return
+            spec = self._alignment_spec(canvas)
+        spec.display = show
+        if rect is not None and not spec.editing:
+            spec.rect = rect
+        self._mark_dirty(canvas)
+
+    def _alignment_spec(self, canvas: FibsemImageCanvas) -> AlignmentSpec:
+        spec = self._states[canvas].overlays.get("alignment")
+        if not isinstance(spec, AlignmentSpec):
+            spec = AlignmentSpec()
+            self._states[canvas].overlays["alignment"] = spec
+        return spec
+
+    def alignment_area(self, beam: BeamType) -> Optional["FibsemRectangle"]:
+        """The current alignment-area rect for *beam* — the model's authoritative
+        value (updated on every user edit) — or ``None``."""
+        canvas = self._canvases.get(beam)
+        if canvas is None:
+            return None
+        spec = self._states[canvas].overlays.get("alignment")
+        return getattr(spec, "rect", None)
+
+    def overlay_points(self, beam: BeamType, overlay_id: str) -> list:
+        """Current points (x, y) for a ``PointsSpec`` overlay — the model's
+        authoritative value (updated on every add / move / remove) — or ``[]``."""
+        canvas = self._canvases.get(beam)
+        if canvas is None:
+            return []
+        spec = self._states[canvas].overlays.get(overlay_id)
+        pts = getattr(spec, "points", None)
+        return list(pts) if pts else []
+
+    # ── info bar ──────────────────────────────────────────────────────────
+    def set_info(self, beam: BeamType, key: str, text: Optional[str]) -> None:
+        """Upsert an info-bar field on the canvas for *beam* (drop when text empty)."""
+        canvas = self._canvases.get(beam)
+        if canvas is not None:
+            self._set_info_on(canvas, key, text)
+
+    def set_fm_info(self, key: str, text: Optional[str]) -> None:
+        """Upsert an info-bar field on the FM canvas (FM isn't a BeamType)."""
+        self._set_info_on(self._widget.fm_canvas, key, text)
+
+    def _set_info_on(self, canvas: FibsemImageCanvas, key: str, text: Optional[str]) -> None:
+        info = self._states[canvas].info
+        for i, (k, _) in enumerate(info):
+            if k == key:
+                if text:
+                    info[i] = (key, text)
+                else:
+                    del info[i]
+                self._mark_dirty(canvas)
+                return
+        if text:
+            info.append((key, text))
+            self._mark_dirty(canvas)
+
+    def update_info(self, microscope, stage_position=None, objective_position=None) -> None:
+        """Refresh the info bar from microscope state (mirrors napari
+        ``update_text_overlay``): STAGE on SEM+FIB, MILLING ANGLE on FIB, OBJECTIVE on
+        FM. It goes through the model + debounced render, so it is safe to call from an
+        ``@ensure_main_thread`` ``update_ui`` — there is no synchronous draw to re-enter
+        (which is what froze the original info bar)."""
+        try:
+            if type(microscope).__name__ == "TescanMicroscope":
+                return  # no stage-position display yet
+            if stage_position is None:
+                stage_position = microscope._stage_position
+            orientation = microscope.get_stage_orientation(stage_position=stage_position)
+            grid = microscope.current_grid
+            milling_angle = microscope.get_current_milling_angle(stage_position=stage_position)
+            stage_txt = f"STAGE: {stage_position.pretty_string} [{orientation}] [{grid}]"
+            self.set_info(BeamType.ELECTRON, "stage", stage_txt)
+            self.set_info(BeamType.ION, "stage", stage_txt)
+            self.set_fm_info("stage", stage_txt)  # universal context (before objective)
+            self.set_info(BeamType.ION, "milling", f"MILLING ANGLE: {milling_angle:.1f}°")
+            if microscope.fm is not None:
+                if objective_position is None:
+                    objective_position = microscope.fm.objective.position
+                self.set_fm_info(
+                    "objective",
+                    f"OBJECTIVE: {objective_position * constants.METRE_TO_MICRON:.1f} µm",
+                )
+        except Exception:
+            _logger.warning("MicroscopeViewController.update_info failed", exc_info=True)
+
+    # ── render loop ───────────────────────────────────────────────────────
+    def _mark_dirty(self, canvas: FibsemImageCanvas) -> None:
+        self._dirty.add(canvas)
+        if not self._render_scheduled:
+            self._render_scheduled = True
+            self._render_requested.emit()  # queued → coalesced render on the GUI thread
+
+    def _do_render(self) -> None:
+        self._render_scheduled = False
+        dirty = list(self._dirty)  # snapshot (GIL-safe vs. concurrent producers)
+        self._dirty.clear()
+        for canvas in dirty:
+            try:
+                self._reconcile(canvas)
+            except Exception:
+                _logger.exception("MicroscopeViewController: reconcile failed")
+
+    def _reconcile(self, canvas: FibsemImageCanvas) -> None:
+        """Diff a canvas's specs against its owned overlay objects: create / drive /
+        remove so the rendered overlays match the model."""
+        state = self._states[canvas]
+        objs = self._overlay_objs[canvas]
+        image = state.image
+        # drop overlays whose spec is gone
+        for oid in list(objs.keys()):
+            if oid not in state.overlays:
+                canvas.remove_overlay(objs.pop(oid))
+        # create + drive overlays from their specs
+        for oid, spec in list(state.overlays.items()):
+            obj = objs.get(oid)
+            if obj is None:
+                obj = self._create_overlay(canvas, oid, spec)
+                if obj is None:
+                    continue
+                objs[oid] = obj
+                canvas.add_overlay(obj)
+            self._drive_overlay(obj, spec, image)
+        self._apply_arming(canvas, state, objs)
+        info_text = "\n".join(text for _, text in state.info if text)
+        if (canvas._info_text or "") != info_text:
+            canvas.set_info_text(info_text)
+
+    def _create_overlay(self, canvas: FibsemImageCanvas, overlay_id: str, spec: OverlaySpec):
+        """Construct the overlay object for *spec* and wire its edit signal (if any)
+        back to :attr:`overlay_edited` (one branch per migrated slice)."""
+        if isinstance(spec, MillingSpec):
+            from fibsem.ui.widgets.canvas.overlays.milling_overlay import MillingPatternOverlay
+
+            return MillingPatternOverlay()
+        if isinstance(spec, MaskSpec):
+            from fibsem.ui.widgets.canvas.overlays.mask_overlay import MaskOverlay
+
+            return MaskOverlay()
+        if isinstance(spec, AlignmentSpec):
+            from fibsem.ui.widgets.canvas.overlays.alignment_overlay import AlignmentAreaOverlay
+
+            obj = AlignmentAreaOverlay(editable=spec.editing)
+            beam = self._beams.get(canvas)
+            obj.alignment_area_changed.connect(
+                lambda value, b=beam, i=overlay_id: self._on_overlay_edited(b, i, value)
+            )
+            return obj
+        if isinstance(spec, PointsSpec):
+            from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
+
+            obj = PointOverlay(
+                color=spec.color,
+                selected_color=spec.selected_color,
+                marker=spec.marker,
+                size=spec.size,
+                label_prefix=spec.label_prefix,
+                add_on_right_click=spec.add_on_right_click,
+                removable=spec.removable,
+                modal=spec.modal,
+                edge_width=spec.edge_width,
+                legend_label=spec.legend_label,
+                numbered=spec.numbered,
+            )
+            beam = self._beams.get(canvas)
+            for sig in (obj.point_added, obj.point_moved, obj.point_removed):
+                sig.connect(
+                    lambda *a, b=beam, i=overlay_id, o=obj: self._on_overlay_edited(
+                        b, i, o.get_points()
+                    )
+                )
+            obj.point_selected.connect(
+                lambda idx, x, y, b=beam, i=overlay_id: self.overlay_point_selected.emit(
+                    b, i, idx
+                )
+            )
+            return obj
+        _logger.warning(
+            "MicroscopeViewController: no renderer for spec %r", type(spec).__name__
+        )
+        return None
+
+    def _drive_overlay(self, obj, spec: OverlaySpec, image: Optional[FibsemImage]) -> None:
+        """Push *spec* data into its overlay object, injecting the canvas image."""
+        if isinstance(spec, MillingSpec):
+            if image is None or not spec.visible:
+                obj.clear()
+                return
+            obj.set_stages(
+                spec.stages,
+                image,
+                background_stages=spec.background_stages,
+                selected_index=spec.selected_index,
+            )
+        elif isinstance(spec, AlignmentSpec):
+            if spec.rect is not None:
+                obj.set_area(spec.rect)
+            obj.set_editable(spec.editing)
+            obj.set_visible(spec.editing or spec.display)
+        elif isinstance(spec, PointsSpec):
+            # Rebuild the markers only when the point data actually changed. A reconcile
+            # runs on ANY change to this canvas (the info bar ticking on a stage move, a
+            # sibling overlay, a new frame), and set_points() is destructive — it nulls the
+            # selection and rebuilds the artists. Re-driving unchanged points would wipe a
+            # canvas-made selection (so Delete stops removing points) and snap an
+            # in-progress drag back to its pre-drag position. set_visible is cheap and
+            # non-destructive, so it always runs.
+            sig = self._points_signature(spec)
+            if getattr(obj, "_reducer_pts_sig", None) != sig:
+                obj.set_points(list(spec.points), colors=spec.colors, labels=spec.labels)
+                obj.set_selected(spec.selected)  # set_points nulls the selection; re-apply
+                obj._reducer_pts_sig = sig
+            obj.set_visible(spec.visible)
+        elif isinstance(spec, MaskSpec):
+            obj.set_mask(spec.mask, colors=spec.colors)
+
+    @staticmethod
+    def _points_signature(spec: PointsSpec) -> str:
+        """A value signature of the fields ``set_points`` / ``set_selected`` render, used to
+        skip a redundant (destructive) rebuild when a reconcile is driven by unrelated
+        state. ``repr`` so it is robust to numpy/Point element types and compares by value."""
+        pts = [(float(p[0]), float(p[1])) for p in spec.points]
+        return repr((pts, spec.colors, spec.labels, spec.selected))
+
+    def _apply_arming(self, canvas: FibsemImageCanvas, state: CanvasState, objs) -> None:
+        """Make the model's armed overlay the canvas's active input mode (single
+        arbiter). Toggles only on change; the exit is scoped to the overlay we armed,
+        so it never tears down a mode another (still-direct) consumer owns."""
+        desired_id = state.armed_overlay if state.armed_overlay in objs else None
+        desired = objs.get(desired_id) if desired_id else None
+        prev = self._armed_applied.get(canvas)
+        if prev is desired:
+            return
+        if desired is not None:
+            canvas.enter_overlay_mode(
+                desired, state.armed_label, icon=state.armed_icon or "mdi:cursor-default-click"
+            )
+        elif prev is not None:
+            canvas.exit_overlay_mode(prev)  # scoped: no-op unless prev still owns the mode
+        self._armed_applied[canvas] = desired
+
+    def _on_overlay_edited(self, beam, overlay_id: str, value) -> None:
+        """Fold a committed overlay edit back into the model and re-emit it for
+        producers. No re-render — the overlay already shows the edited value."""
+        canvas = self._canvases.get(beam)
+        if canvas is not None:
+            spec = self._states[canvas].overlays.get(overlay_id)
+            if isinstance(spec, AlignmentSpec):
+                spec.rect = value
+            elif isinstance(spec, PointsSpec):
+                spec.points = value
+                # keep the driven signature in sync so the next unrelated reconcile does
+                # not rebuild these markers (and wipe the selection) after a canvas edit
+                obj = self._overlay_objs[canvas].get(overlay_id)
+                if obj is not None:
+                    obj._reducer_pts_sig = self._points_signature(spec)
+        self.overlay_edited.emit(beam, overlay_id, value)
+
+    def clear(self) -> None:
+        """Clear all canvases (images + reducer-owned overlays) back to placeholders."""
+        for canvas, state in self._states.items():
+            for obj in list(self._overlay_objs[canvas].values()):
+                canvas.remove_overlay(obj)
+            self._overlay_objs[canvas].clear()
+            self._armed_applied[canvas] = None
+            state.image = None
+            state.overlays.clear()
+            state.info.clear()
+            state.armed_overlay = None
+            state.armed_label = ""
+            state.armed_icon = ""
+        self.sem_canvas.clear()
+        self.fib_canvas.clear()
+        self._widget.fm_widget.clear()

--- a/fibsem/ui/widgets/tests/test_active_overlay_mode.py
+++ b/fibsem/ui/widgets/tests/test_active_overlay_mode.py
@@ -1,0 +1,57 @@
+"""Standalone demo: active-overlay input model + toolbar mode toggle.
+
+Run:
+    PYTHONPATH=<worktree> python fibsem/ui/widgets/tests/test_active_overlay_mode.py
+
+A FibsemImageCanvas with a PointOverlay (right-click adds). Use the "Enter POI
+mode" button to make the overlay active — while active the contextual toolbar
+toggle (top-right) appears, the overlay owns input, and the canvas's
+double-click / right-click signals are suppressed. Click the toolbar toggle to
+drop to Move (the two signals fire again, logged below) and back.
+"""
+import sys
+
+import numpy as np
+from PyQt5.QtWidgets import (
+    QApplication, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget,
+)
+
+from fibsem.structures import FibsemImage
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    win = QWidget()
+    win.resize(820, 640)
+    canvas = FibsemImageCanvas()
+    canvas.set_image(FibsemImage(data=(np.random.rand(512, 512) * 255).astype(np.uint8)))
+
+    overlay = PointOverlay(color="magenta", selected_color="cyan", marker="o", size=9)
+    canvas.add_overlay(overlay)
+
+    log = QLabel("Move mode: double-click and right-click fire (stage move / milling menu).")
+    log.setWordWrap(True)
+    canvas.canvas_double_clicked.connect(lambda x, y, m: log.setText(f"double-click → STAGE MOVE @ ({x:.0f},{y:.0f})"))
+    canvas.canvas_right_clicked.connect(lambda x, y, m: log.setText(f"right-click → MILLING MENU @ ({x:.0f},{y:.0f})"))
+
+    btn_enter = QPushButton("Enter POI mode")
+    btn_exit = QPushButton("Exit mode")
+    btn_enter.clicked.connect(lambda: canvas.enter_overlay_mode(overlay, "POI", icon="mdi:map-marker"))
+    btn_exit.clicked.connect(lambda: canvas.exit_overlay_mode(overlay))
+
+    bar = QHBoxLayout()
+    bar.addWidget(btn_enter)
+    bar.addWidget(btn_exit)
+    bar.addStretch()
+    lay = QVBoxLayout(win)
+    lay.addWidget(canvas, 1)
+    lay.addLayout(bar)
+    lay.addWidget(log)
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/fibsem/ui/widgets/tests/test_alignment_overlay.py
+++ b/fibsem/ui/widgets/tests/test_alignment_overlay.py
@@ -1,0 +1,73 @@
+"""Standalone demo for AlignmentAreaOverlay.
+
+Run directly:
+    python fibsem/ui/widgets/tests/test_alignment_overlay.py
+
+Drag/resize the dashed lime alignment rectangle on the FIB image; the label shows
+the normalized FibsemRectangle (and whether it's valid). "Toggle editable"
+switches between editable (corner handles + drag/resize) and read-only (static).
+"""
+import sys
+
+from PyQt5.QtWidgets import QApplication, QLabel, QPushButton, QVBoxLayout, QWidget
+
+from fibsem.structures import FibsemImage, FibsemRectangle
+from fibsem.ui.stylesheets import NAPARI_STYLE
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.overlays.alignment_overlay import AlignmentAreaOverlay
+
+
+class AlignmentOverlayTest(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Alignment overlay — test")
+        self.resize(900, 800)
+
+        self.image = FibsemImage.generate_blank_image(hfw=80e-6, random=True)
+        self.canvas = FibsemImageCanvas()
+        self.canvas.set_image(self.image)
+
+        self.overlay = AlignmentAreaOverlay(editable=True)
+        self.canvas.add_overlay(self.overlay)
+        self.overlay.set_area(FibsemRectangle(0.25, 0.25, 0.5, 0.5))
+        self.overlay.alignment_area_changed.connect(self._show_area)
+
+        self.label = QLabel()
+        self.label.setStyleSheet("color: #d1d2d4; padding: 6px; font-family: monospace;")
+        self._show_area(self.overlay.get_area())
+
+        self._editable = True
+        self.btn = QPushButton("Toggle editable (now: editable)")
+        self.btn.clicked.connect(self._toggle_editable)
+
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.addWidget(self.canvas)
+        lay.addWidget(self.label)
+        lay.addWidget(self.btn)
+
+    def _show_area(self, a: FibsemRectangle) -> None:
+        self.label.setText(
+            f"alignment area:  left={a.left:.3f}  top={a.top:.3f}  "
+            f"width={a.width:.3f}  height={a.height:.3f}  valid={a.is_valid_reduced_area}"
+        )
+
+    def _toggle_editable(self) -> None:
+        self._editable = not self._editable
+        self.overlay.set_editable(self._editable)
+        self.btn.setText(
+            f"Toggle editable (now: {'editable' if self._editable else 'read-only'})"
+        )
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    app.setStyle("Fusion")
+    win = AlignmentOverlayTest()
+    win.setStyleSheet(NAPARI_STYLE + "QWidget { background: #262930; color: #d1d2d4; }")
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/fibsem/ui/widgets/tests/test_canvas_modifiers.py
+++ b/fibsem/ui/widgets/tests/test_canvas_modifiers.py
@@ -1,0 +1,135 @@
+"""Standalone test for FibsemImageCanvas modifier-aware mouse signals.
+
+Run directly:
+    python fibsem/ui/widgets/tests/test_canvas_modifiers.py
+
+Click / double-click / right-click / scroll on the image while holding
+Alt / Shift / Ctrl and watch each event — with its modifier tuple — appear in
+the log panel.  This exercises the widened signals:
+
+    canvas_clicked        (x, y, modifiers)
+    canvas_double_clicked (x, y, modifiers)
+    canvas_right_clicked  (x, y, modifiers)
+    canvas_scrolled       (x, y, direction, modifiers)
+
+The "legacy 2-arg slot" counter is connected to ``canvas_clicked`` with a
+2-argument slot; it proves the widening stays backward-compatible (PyQt5
+truncates the extra ``modifiers`` argument for slots that don't want it).
+"""
+import sys
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.structures import FibsemImage
+from fibsem.ui.stylesheets import NAPARI_STYLE
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+
+class ModifierTestWidget(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Canvas modifiers — test")
+        self.resize(1100, 700)
+
+        image = FibsemImage.generate_blank_image(hfw=80e-6, random=True)
+        self.canvas = FibsemImageCanvas()
+        self.canvas.set_image(image)
+
+        instructions = QLabel(
+            "Click · double-click · right-click · scroll on the image.\n"
+            "Hold Alt / Shift / Ctrl and watch the modifier tuple in the log.\n"
+            "Top-right buttons: reset · scalebar · crosshair · contrast/gamma "
+            "(open the last one and drag Min / Max / Gamma)."
+        )
+        instructions.setWordWrap(True)
+        instructions.setStyleSheet("color: #d1d2d4; padding: 6px;")
+
+        self.log = QPlainTextEdit()
+        self.log.setReadOnly(True)
+        self.log.setMaximumBlockCount(1000)
+        self.log.setStyleSheet(
+            "QPlainTextEdit { background: #1e2124; color: #d1d2d4;"
+            " font-family: monospace; font-size: 12px; border: 1px solid #444; }"
+        )
+
+        self.legacy_label = QLabel("legacy 2-arg slot (backward-compat): fired 0×")
+        self.legacy_label.setStyleSheet("color: #888; padding: 4px 6px;")
+        self._legacy_count = 0
+
+        clear_btn = QPushButton("Clear log")
+        clear_btn.clicked.connect(self.log.clear)
+
+        right = QVBoxLayout()
+        right.setContentsMargins(0, 0, 0, 0)
+        right.addWidget(instructions)
+        right.addWidget(self.log)
+        right.addWidget(self.legacy_label)
+        right.addWidget(clear_btn)
+        right_w = QWidget()
+        right_w.setLayout(right)
+
+        layout = QHBoxLayout(self)
+        layout.addWidget(self.canvas, stretch=3)
+        layout.addWidget(right_w, stretch=2)
+
+        # New 3-arg / 4-arg slots
+        self.canvas.canvas_clicked.connect(self._on_click)
+        self.canvas.canvas_double_clicked.connect(self._on_double)
+        self.canvas.canvas_right_clicked.connect(self._on_right)
+        self.canvas.canvas_scrolled.connect(self._on_scroll)
+        # Legacy 2-arg slot on the same (widened) signal — must still fire
+        self.canvas.canvas_clicked.connect(self._legacy_click)
+
+    @staticmethod
+    def _fmt(mods) -> str:
+        return f"({', '.join(mods)})" if mods else "(none)"
+
+    def _on_click(self, x, y, mods):
+        self.log.appendPlainText(
+            f"click          x={x:7.1f} y={y:7.1f}  mods={self._fmt(mods)}"
+        )
+
+    def _on_double(self, x, y, mods):
+        self.log.appendPlainText(
+            f"double-click   x={x:7.1f} y={y:7.1f}  mods={self._fmt(mods)}"
+        )
+
+    def _on_right(self, x, y, mods):
+        self.log.appendPlainText(
+            f"right-click    x={x:7.1f} y={y:7.1f}  mods={self._fmt(mods)}"
+        )
+
+    def _on_scroll(self, x, y, direction, mods):
+        arrow = "up" if direction == 1 else "down"
+        self.log.appendPlainText(
+            f"scroll {arrow:<4}    x={x:7.1f} y={y:7.1f}  mods={self._fmt(mods)}"
+        )
+
+    def _legacy_click(self, x, y):
+        """2-arg slot connected to the 3-arg canvas_clicked (truncation check)."""
+        self._legacy_count += 1
+        self.legacy_label.setText(
+            f"legacy 2-arg slot (backward-compat): fired {self._legacy_count}×"
+        )
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    app.setStyle("Fusion")
+    win = ModifierTestWidget()
+    win.setStyleSheet(NAPARI_STYLE + "QWidget { background: #262930; color: #d1d2d4; }")
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/fibsem/ui/widgets/tests/test_canvas_overlay_reducer.py
+++ b/fibsem/ui/widgets/tests/test_canvas_overlay_reducer.py
@@ -1,0 +1,494 @@
+"""Headless tests for the canvas-state reducer on MicroscopeViewController.
+
+Run directly (headless):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_canvas_overlay_reducer.py
+
+Or via pytest. Covers the milling slice (MillingSpec -> MillingPatternOverlay) and
+the alignment slice (one AlignmentSpec; edit > display; the input round-trip).
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.milling.base import FibsemMillingStage
+from fibsem.milling.patterning.patterns2 import RectanglePattern
+from fibsem.structures import BeamType, FibsemImage, FibsemRectangle, Point
+from fibsem.ui.widgets.canvas.canvas_state import MaskSpec, MillingSpec, PointsSpec
+from fibsem.ui.widgets.canvas.overlays.alignment_overlay import AlignmentAreaOverlay
+from fibsem.ui.widgets.canvas.overlays.milling_overlay import MillingPatternOverlay
+from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+
+
+def _app() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+def _image() -> FibsemImage:
+    return FibsemImage.generate_blank_image(hfw=80e-6, random=True)
+
+
+def _stage(name: str = "s", x_um: float = 0.0, y_um: float = 0.0) -> FibsemMillingStage:
+    pattern = RectanglePattern(width=10e-6, height=5e-6)
+    pattern.point = Point(x=x_um * 1e-6, y=y_um * 1e-6)
+    return FibsemMillingStage(name=name, pattern=pattern)
+
+
+def _rect(left=0.25, top=0.25, width=0.5, height=0.5) -> FibsemRectangle:
+    return FibsemRectangle(left=left, top=top, width=width, height=height)
+
+
+def _flush(app: QApplication) -> None:
+    for _ in range(3):
+        app.processEvents()
+
+
+# ── milling slice ───────────────────────────────────────────────────────────
+
+def test_set_overlay_creates_attaches_and_renders():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_overlay(BeamType.ION, MillingSpec(stages=[_stage()]))
+    _flush(app)
+
+    objs = ctl._overlay_objs[fib]
+    assert "milling" in objs, "milling overlay not created"
+    overlay = objs["milling"]
+    assert isinstance(overlay, MillingPatternOverlay)
+    assert overlay in fib._overlays, "overlay not attached to the canvas"
+    assert len(overlay._stages) == 1
+    assert len(overlay._artists) > 0, "patterns not rendered"
+    print("ok: set_overlay creates + attaches + renders")
+
+
+def test_remove_overlay_detaches():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_overlay(BeamType.ION, MillingSpec(stages=[_stage()]))
+    _flush(app)
+    overlay = ctl._overlay_objs[fib]["milling"]
+
+    ctl.remove_overlay(BeamType.ION, "milling")
+    _flush(app)
+
+    assert "milling" not in ctl._overlay_objs[fib]
+    assert overlay not in fib._overlays
+    assert "milling" not in ctl._scene.fib.overlays
+    print("ok: remove_overlay detaches + drops the spec")
+
+
+def test_image_injected_from_canvas():
+    """No image -> overlay attaches but draws nothing; image arriving re-renders it."""
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+
+    ctl.set_overlay(BeamType.ION, MillingSpec(stages=[_stage()]))  # before any image
+    _flush(app)
+    overlay = ctl._overlay_objs[fib]["milling"]
+    assert overlay in fib._overlays
+    assert len(overlay._artists) == 0, "should draw nothing without an image"
+
+    ctl.set_image(BeamType.ION, _image())  # image swap marks dirty -> re-render
+    _flush(app)
+    assert len(overlay._artists) > 0, "did not render after image arrived"
+    print("ok: reducer injects the canvas image (no image -> no draw -> renders on image)")
+
+
+def test_renders_coalesce_into_one_pass():
+    app = _app()
+    ctl = MicroscopeViewController()
+    emits = []
+    ctl._render_requested.connect(lambda: emits.append(1))
+
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_overlay(BeamType.ION, MillingSpec(stages=[_stage("a")]))
+    ctl.set_overlay(BeamType.ION, MillingSpec(stages=[_stage("a"), _stage("b")]))
+    assert len(emits) == 1, f"expected 1 coalesced render, got {len(emits)}"
+
+    _flush(app)
+    assert len(ctl._overlay_objs[ctl.fib_canvas]["milling"]._stages) == 2
+    print("ok: renders coalesce into one pass")
+
+
+def test_overlay_on_sem_canvas_beam_generic():
+    app = _app()
+    ctl = MicroscopeViewController()
+    ctl.set_overlay(BeamType.ELECTRON, MillingSpec(stages=[_stage()]))
+    _flush(app)
+    assert "milling" in ctl._overlay_objs[ctl.sem_canvas]
+    assert "milling" not in ctl._overlay_objs[ctl.fib_canvas]
+    print("ok: reducer is beam-generic (SEM canvas)")
+
+
+# ── alignment slice (one overlay; edit > display) ────────────────────────────
+
+def test_alignment_edit_shows_editable_and_arms():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    r = _rect()
+    ctl.set_alignment_edit(BeamType.ION, r, editing=True)
+    _flush(app)
+
+    ov = ctl._overlay_objs[fib]["alignment"]
+    assert isinstance(ov, AlignmentAreaOverlay)
+    assert ov in fib._overlays
+    assert ov._area_visible is True and ov._interactive is True
+    assert fib.active_overlay is ov, "editing should arm the overlay"
+    assert ctl.alignment_area(BeamType.ION) is r
+    print("ok: set_alignment_edit -> editable + armed + visible")
+
+
+def test_alignment_display_shows_readonly_not_armed():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    r = _rect()
+    ctl.set_alignment_display(BeamType.ION, r, show=True)
+    _flush(app)
+
+    ov = ctl._overlay_objs[fib]["alignment"]
+    assert ov._area_visible is True and ov._interactive is False
+    assert fib.active_overlay is None, "read-only display must not arm"
+    assert ctl.alignment_area(BeamType.ION) is r
+    print("ok: set_alignment_display -> read-only, not armed")
+
+
+def test_edit_overrides_display_then_falls_back():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_alignment_display(BeamType.ION, _rect(), show=True)   # milling: read-only
+    ctl.set_alignment_edit(BeamType.ION, _rect(), editing=True)   # image widget: edit wins
+    _flush(app)
+    ov = ctl._overlay_objs[fib]["alignment"]
+    assert ov._interactive is True and fib.active_overlay is ov
+
+    ctl.set_alignment_edit(BeamType.ION, None, editing=False)     # end edit; display still on
+    _flush(app)
+    assert ov._area_visible is True and ov._interactive is False, "should fall back to read-only"
+    assert fib.active_overlay is None
+
+    ctl.set_alignment_display(BeamType.ION, None, show=False)     # milling stops
+    _flush(app)
+    assert ov._area_visible is False, "nothing wants it -> hidden"
+    print("ok: edit > display, falls back to read-only, then hidden")
+
+
+def test_alignment_value_survives_end_of_edit():
+    """The clear-then-read guarantee: ending an edit hides but keeps the value."""
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    r = _rect()
+    ctl.set_alignment_edit(BeamType.ION, r, editing=True)
+    _flush(app)
+    ctl.set_alignment_edit(BeamType.ION, None, editing=False)  # no display -> hidden, value kept
+    _flush(app)
+    ov = ctl._overlay_objs[fib]["alignment"]
+    assert ov._area_visible is False
+    assert ctl.alignment_area(BeamType.ION) is r, "value must survive (workflow reads after clear)"
+    print("ok: alignment value survives the end of an edit")
+
+
+def test_alignment_edit_roundtrips_to_signal_and_model():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_alignment_edit(BeamType.ION, _rect(), editing=True)
+    _flush(app)
+    ov = ctl._overlay_objs[fib]["alignment"]
+
+    seen = []
+    ctl.overlay_edited.connect(lambda b, i, v: seen.append((b, i, v)))
+    edited = _rect(0.1, 0.1, 0.3, 0.3)
+    ov.alignment_area_changed.emit(edited)  # simulate a user drag/resize commit
+    _flush(app)
+    assert seen == [(BeamType.ION, "alignment", edited)], f"got {seen}"
+    assert ctl.alignment_area(BeamType.ION) is edited, "edit must update the model"
+    print("ok: alignment edit re-emits overlay_edited + updates the model")
+
+
+def test_true_clear_removes_alignment():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_alignment_edit(BeamType.ION, _rect(), editing=True)
+    _flush(app)
+    ov = ctl._overlay_objs[fib]["alignment"]
+
+    ctl.arm_overlay(BeamType.ION, None)
+    ctl.remove_overlay(BeamType.ION, "alignment")  # true teardown
+    _flush(app)
+    assert "alignment" not in ctl._overlay_objs[fib]
+    assert ov not in fib._overlays
+    assert ctl.alignment_area(BeamType.ION) is None
+    assert fib.active_overlay is None
+    print("ok: remove_overlay (true clear) drops the overlay + value + disarms")
+
+
+# ── points slice (POI / spot / detection share this) ─────────────────────────
+
+def test_points_create_arm_and_set():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_overlay(
+        BeamType.ION,
+        PointsSpec(id="poi", points=[(10.0, 12.0)], color="magenta", marker="+", size=18),
+    )
+    ctl.arm_overlay(BeamType.ION, "poi", label="POI")
+    _flush(app)
+
+    from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
+    ov = ctl._overlay_objs[fib]["poi"]
+    assert isinstance(ov, PointOverlay)
+    assert ov in fib._overlays
+    assert fib.active_overlay is ov, "POI should own input"
+    assert ctl.overlay_points(BeamType.ION, "poi") == [(10.0, 12.0)]
+    print("ok: points overlay creates + arms + sets points")
+
+
+def test_points_move_roundtrips_to_model():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_overlay(BeamType.ION, PointsSpec(id="poi", points=[(10.0, 10.0)]))
+    _flush(app)
+    ov = ctl._overlay_objs[fib]["poi"]
+
+    # simulate a drag: the overlay geometry changes, point_moved fires on release
+    ov.set_points([(25.0, 30.0)])
+    ov.point_moved.emit(0, 25.0, 30.0)
+    assert ctl.overlay_points(BeamType.ION, "poi") == [(25.0, 30.0)], "model not updated from drag"
+    print("ok: point move round-trips into the model (read-back authoritative)")
+
+
+def test_points_remove_disarms():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_overlay(BeamType.ION, PointsSpec(id="poi", points=[(10.0, 10.0)]))
+    ctl.arm_overlay(BeamType.ION, "poi")
+    _flush(app)
+    ov = ctl._overlay_objs[fib]["poi"]
+
+    ctl.arm_overlay(BeamType.ION, None)
+    ctl.remove_overlay(BeamType.ION, "poi")
+    _flush(app)
+    assert "poi" not in ctl._overlay_objs[fib]
+    assert ov not in fib._overlays
+    assert ctl.overlay_points(BeamType.ION, "poi") == []
+    assert fib.active_overlay is None
+    print("ok: remove points overlay drops it + disarms")
+
+
+def test_points_visible_toggle_keeps_points():
+    """Spot burn show/hide: visibility toggles without losing the points."""
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_overlay(BeamType.ION, PointsSpec(id="spot", points=[(5.0, 5.0)], visible=True))
+    _flush(app)
+    ov = ctl._overlay_objs[fib]["spot"]
+    assert ov._visible is True
+
+    ctl.set_overlay_visible(BeamType.ION, "spot", False)  # hide, keep points
+    _flush(app)
+    assert ov._visible is False
+    assert ctl.overlay_points(BeamType.ION, "spot") == [(5.0, 5.0)], "points kept on hide"
+
+    ctl.set_overlay_visible(BeamType.ION, "spot", True)
+    _flush(app)
+    assert ov._visible is True
+    print("ok: set_overlay_visible toggles visibility, keeps points")
+
+
+def test_set_points_partial_keeps_config():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_overlay(BeamType.ION, PointsSpec(id="spot", points=[(5.0, 5.0)], visible=False))
+    _flush(app)
+    ctl.set_points(BeamType.ION, "spot", [(1.0, 2.0), (3.0, 4.0)])  # points only
+    _flush(app)
+    assert ctl.overlay_points(BeamType.ION, "spot") == [(1.0, 2.0), (3.0, 4.0)]
+    ov = ctl._overlay_objs[fib]["spot"]
+    assert ov._visible is False, "visibility preserved by set_points"
+    print("ok: set_points updates points, keeps config/visibility")
+
+
+def test_canvas_selection_survives_unrelated_reconcile():
+    """Regression: a reconcile runs on ANY change to a canvas (e.g. the info bar ticking on
+    a stage move). set_points is destructive — it nulls the selection — so re-driving
+    UNCHANGED points would silently clear a canvas-made selection, breaking Delete. The
+    reducer must skip the rebuild when the point data is unchanged."""
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_overlay(BeamType.ION, PointsSpec(id="spot", points=[(5.0, 5.0), (9.0, 9.0)]))
+    _flush(app)
+    ov = ctl._overlay_objs[fib]["spot"]
+
+    ov.set_selected(1)  # user selects a point on the canvas (overlay-side; not in the spec)
+    assert ov._selected == 1
+
+    ctl._reconcile(fib)  # unrelated reconcile (same points) — must not touch the selection
+    assert ov._selected == 1, "unrelated reconcile wiped the canvas selection"
+    print("ok: canvas selection survives an unrelated reconcile")
+
+
+def test_in_progress_drag_survives_unrelated_reconcile():
+    """Regression: during a drag the overlay's live points move but the spec is not updated
+    until release (point_moved). An unrelated reconcile mid-drag must not re-drive the
+    unchanged spec — set_points would snap the point back to its pre-drag position."""
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_overlay(BeamType.ION, PointsSpec(id="spot", points=[(5.0, 5.0)]))
+    _flush(app)
+    ov = ctl._overlay_objs[fib]["spot"]
+
+    ov._points = [[25.0, 30.0]]  # mid-drag live position (spec still holds (5, 5))
+    ctl._reconcile(fib)          # unrelated reconcile while dragging
+    assert ov.get_points() == [(25.0, 30.0)], "reconcile snapped the in-progress drag back"
+    print("ok: in-progress drag survives an unrelated reconcile")
+
+
+def test_mask_overlay_displays_and_removes():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    mask = np.zeros((64, 64), dtype=np.uint8)
+    mask[10:30, 10:30] = 1
+    ctl.set_overlay(BeamType.ION, MaskSpec(id="mask", mask=mask))
+    _flush(app)
+    from fibsem.ui.widgets.canvas.overlays.mask_overlay import MaskOverlay
+    ov = ctl._overlay_objs[fib]["mask"]
+    assert isinstance(ov, MaskOverlay)
+    assert ov in fib._overlays
+    ctl.remove_overlay(BeamType.ION, "mask")
+    _flush(app)
+    assert "mask" not in ctl._overlay_objs[fib]
+    print("ok: mask overlay displays + removes")
+
+
+def test_detection_features_colors_labels_and_move():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_overlay(BeamType.ION, PointsSpec(
+        id="detection", points=[(10.0, 10.0), (20.0, 20.0)],
+        colors=["red", "lime"], labels=["A", "B"],
+        marker="+", removable=False, add_on_right_click=False, modal=True,
+    ))
+    ctl.arm_overlay(BeamType.ION, "detection", label="Detection")
+    _flush(app)
+    ov = ctl._overlay_objs[fib]["detection"]
+    assert ov in fib._overlays
+    assert fib.active_overlay is ov
+    assert ctl.overlay_points(BeamType.ION, "detection") == [(10.0, 10.0), (20.0, 20.0)]
+
+    # dragging a feature round-trips into the model (features re-read from the points)
+    ov.set_points([(15.0, 15.0), (20.0, 20.0)])
+    ov.point_moved.emit(0, 15.0, 15.0)
+    assert ctl.overlay_points(BeamType.ION, "detection") == [(15.0, 15.0), (20.0, 20.0)]
+    print("ok: detection features (colors/labels) + move round-trip")
+
+
+# ── info bar ─────────────────────────────────────────────────────────────────
+
+def test_info_bar_renders_ordered_fields_per_canvas():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_image(BeamType.ION, _image())
+    ctl.set_info(BeamType.ION, "stage", "STAGE: x")
+    ctl.set_info(BeamType.ION, "milling", "MILLING ANGLE: 30.0°")
+    ctl.set_info(BeamType.ELECTRON, "stage", "STAGE: x")  # SEM gets stage only
+    _flush(app)
+    assert fib._info_text == "STAGE: x\nMILLING ANGLE: 30.0°"
+    assert fib._info_artist is not None
+    assert ctl.sem_canvas._info_text == "STAGE: x"
+    print("ok: info bar renders ordered fields per canvas (milling FIB-only)")
+
+
+def test_set_fm_info_targets_fm_canvas():
+    app = _app()
+    ctl = MicroscopeViewController()
+    ctl.set_fm_info("objective", "OBJECTIVE: 12.3 µm")
+    _flush(app)
+    assert ctl.fm_canvas._info_text == "OBJECTIVE: 12.3 µm"
+    print("ok: set_fm_info targets the FM canvas")
+
+
+def test_info_bar_survives_image_change():
+    app = _app()
+    ctl = MicroscopeViewController()
+    fib = ctl.fib_canvas
+    ctl.set_info(BeamType.ION, "stage", "STAGE: x")
+    _flush(app)
+    assert fib._info_text == "STAGE: x"
+    ctl.set_image(BeamType.ION, _image())  # a new image clears the axes
+    _flush(app)
+    assert fib._info_text == "STAGE: x", "info must survive an image change"
+    assert fib._info_artist is not None
+    print("ok: info bar survives an image change (microscope state, not image)")
+
+
+def _run_all():
+    tests = [
+        test_set_overlay_creates_attaches_and_renders,
+        test_remove_overlay_detaches,
+        test_image_injected_from_canvas,
+        test_renders_coalesce_into_one_pass,
+        test_overlay_on_sem_canvas_beam_generic,
+        test_alignment_edit_shows_editable_and_arms,
+        test_alignment_display_shows_readonly_not_armed,
+        test_edit_overrides_display_then_falls_back,
+        test_alignment_value_survives_end_of_edit,
+        test_alignment_edit_roundtrips_to_signal_and_model,
+        test_true_clear_removes_alignment,
+        test_points_create_arm_and_set,
+        test_points_move_roundtrips_to_model,
+        test_points_remove_disarms,
+        test_points_visible_toggle_keeps_points,
+        test_set_points_partial_keeps_config,
+        test_mask_overlay_displays_and_removes,
+        test_detection_features_colors_labels_and_move,
+        test_info_bar_renders_ordered_fields_per_canvas,
+        test_set_fm_info_targets_fm_canvas,
+        test_info_bar_survives_image_change,
+    ]
+    for t in tests:
+        t()
+    print(f"\nALL {len(tests)} TESTS PASSED")
+
+
+if __name__ == "__main__":
+    _run_all()

--- a/fibsem/ui/widgets/tests/test_canvas_preserve_zoom.py
+++ b/fibsem/ui/widgets/tests/test_canvas_preserve_zoom.py
@@ -1,0 +1,88 @@
+"""Headless smoke: FibsemImageCanvas keeps zoom/pan across same-shape image updates.
+
+Live acquisition pushes a new frame every tick via set_array; re-framing each time is the
+bug this guards against. Auto-fit still fires on the first image, on a resolution change,
+and on the explicit reset_view() (fit-to-view) button.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_canvas_preserve_zoom.py
+"""
+import sys
+
+import numpy as np
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _img(h, w):
+    return np.zeros((h, w), dtype=np.uint8)
+
+
+def _zoom(c, x0, x1, y0, y1):
+    c._ax.set_xlim(x0, x1)
+    c._ax.set_ylim(y0, y1)  # y inverted (origin upper): pass (bottom, top)
+
+
+def test_same_shape_preserves_view():
+    c = FibsemImageCanvas()
+    c.set_array(_img(64, 64))
+    _zoom(c, 10, 30, 30, 10)          # user zooms in
+    c.set_array(_img(64, 64))         # next live frame, same resolution
+    assert c._ax.get_xlim() == (10, 30)
+    assert c._ax.get_ylim() == (30, 10)
+
+
+def test_first_image_fits():
+    c = FibsemImageCanvas()
+    c.set_array(_img(64, 64))
+    x0, x1 = c._ax.get_xlim()
+    assert x0 < 0 and x1 > 63          # framed to the image extent, not a stale view
+
+
+def test_resolution_change_refits():
+    c = FibsemImageCanvas()
+    c.set_array(_img(64, 64))
+    _zoom(c, 10, 30, 30, 10)
+    c.set_array(_img(128, 128))        # different resolution -> refit
+    x0, x1 = c._ax.get_xlim()
+    assert not (x0 == 10 and x1 == 30)
+    assert x1 > 100                    # framed to the larger image
+
+
+def test_reset_view_always_fits():
+    c = FibsemImageCanvas()
+    c.set_array(_img(64, 64))
+    _zoom(c, 10, 30, 30, 10)
+    c.reset_view()                     # fit-to-view button -> refit despite same shape
+    x0, x1 = c._ax.get_xlim()
+    assert x0 < 0 and x1 > 63
+
+
+def test_update_display_also_preserves():
+    # the fast same-shape swap path must not re-frame either
+    c = FibsemImageCanvas()
+    c.set_array(_img(64, 64))
+    _zoom(c, 5, 25, 25, 5)
+    c.update_display(_img(64, 64))
+    assert c._ax.get_xlim() == (5, 25)
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fibsem/ui/widgets/tests/test_detection_overlay.py
+++ b/fibsem/ui/widgets/tests/test_detection_overlay.py
@@ -1,0 +1,95 @@
+"""Standalone demo: detection display (MaskOverlay + per-feature PointOverlay).
+
+Run:
+    PYTHONPATH=<worktree> python fibsem/ui/widgets/tests/test_detection_overlay.py
+
+A FibsemImageCanvas showing a synthetic image + an alpha-blended segmentation
+mask (MaskOverlay) + draggable, per-feature-coloured, named feature points
+(PointOverlay, move-only) in an active "Detection" mode — the matplotlib
+equivalent of FibsemEmbeddedDetectionWidget's napari view (display-only mask).
+
+Drag the points to correct them (positions are logged). Toggle the mask, or drop
+to Move via the top-right toolbar toggle (the feature points go inert).
+"""
+import sys
+
+import numpy as np
+from PyQt5.QtWidgets import (
+    QApplication, QCheckBox, QHBoxLayout, QLabel, QVBoxLayout, QWidget,
+)
+
+from fibsem.structures import FibsemImage
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.overlays.mask_overlay import MaskOverlay
+from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
+
+H = W = 512
+
+
+def _synthetic_image() -> FibsemImage:
+    img = (np.random.rand(H, W) * 60 + 40)
+    img[H // 2 - 40:H // 2 + 40, W // 4:3 * W // 4] += 120  # bright lamella band
+    return FibsemImage(data=np.clip(img, 0, 255).astype(np.uint8))
+
+
+def _synthetic_mask() -> np.ndarray:
+    mask = np.zeros((H, W), dtype=np.uint8)
+    mask[H // 2 - 40:H // 2 + 40, W // 4:3 * W // 4] = 1  # class 1 = lamella
+    yy, xx = np.ogrid[:H, :W]
+    mask[(yy - 120) ** 2 + (xx - 400) ** 2 < 45 ** 2] = 2  # class 2 = manipulator blob
+    return mask
+
+
+# (name, colour, (col, row)) — mirrors detection Feature.name / .color / .px
+FEATURES = [
+    ("LamellaLeftEdge", "red", (W // 4, H // 2)),
+    ("LamellaRightEdge", "red", (3 * W // 4, H // 2)),
+    ("LamellaCentre", "yellow", (W // 2, H // 2)),
+    ("NeedleTip", "lime", (400, 120)),
+]
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    win = QWidget()
+    win.resize(820, 680)
+
+    canvas = FibsemImageCanvas()
+    canvas.set_image(_synthetic_image())
+
+    mask_overlay = MaskOverlay()
+    canvas.add_overlay(mask_overlay)
+    mask_overlay.set_mask(_synthetic_mask())
+
+    feats = PointOverlay(marker="+", size=16, removable=False, add_on_right_click=False)
+    canvas.add_overlay(feats)
+    feats.set_points(
+        [f[2] for f in FEATURES],
+        colors=[f[1] for f in FEATURES],
+        labels=[f[0] for f in FEATURES],
+    )
+    canvas.enter_overlay_mode(feats, "Detection", icon="mdi:vector-point")
+    canvas.set_hint("drag features to correct  ·  Continue when done")
+
+    log = QLabel("Drag a feature point to correct it.")
+    feats.point_moved.connect(
+        lambda i, x, y: log.setText(f"{FEATURES[i][0]} → ({x:.0f}, {y:.0f}) px")
+    )
+
+    chk = QCheckBox("Show mask")
+    chk.setChecked(True)
+    chk.toggled.connect(lambda on: mask_overlay.set_mask(_synthetic_mask() if on else None))
+
+    bar = QHBoxLayout()
+    bar.addWidget(chk)
+    bar.addStretch()
+    lay = QVBoxLayout(win)
+    lay.addWidget(canvas, 1)
+    lay.addLayout(bar)
+    lay.addWidget(log)
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/fibsem/ui/widgets/tests/test_empty_canvas_clicks.py
+++ b/fibsem/ui/widgets/tests/test_empty_canvas_clicks.py
@@ -1,0 +1,68 @@
+"""Headless smoke: an empty (no-image) canvas must not emit semantic click signals.
+
+Guards the fix for the placeholder-removal side effect — before an image is loaded the axes
+span the default [0,1], so a double-click would otherwise emit ~(0.5, 0.5) "pixels" and drive
+a stage move to the image corner. Once an image is present, clicks emit normally.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_empty_canvas_clicks.py
+"""
+import sys
+import types
+
+import numpy as np
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _event(canvas, x, y, *, dblclick=False, button=1):
+    return types.SimpleNamespace(
+        inaxes=canvas._ax, xdata=x, ydata=y, dblclick=dblclick, button=button,
+        guiEvent=None, x=10, y=10,
+    )
+
+
+def test_no_double_click_emit_on_empty_canvas():
+    c = FibsemImageCanvas()  # no image -> _img_w is None
+    seen = []
+    c.canvas_double_clicked.connect(lambda x, y, m: seen.append((x, y)))
+    c._on_press(_event(c, 0.5, 0.5, dblclick=True))
+    assert seen == [], f"empty canvas emitted a double-click: {seen}"
+
+
+def test_no_right_click_emit_on_empty_canvas():
+    c = FibsemImageCanvas()
+    seen = []
+    c.canvas_right_clicked.connect(lambda x, y, m: seen.append((x, y)))
+    c._on_press(_event(c, 0.5, 0.5, button=3))
+    assert seen == [], f"empty canvas emitted a right-click: {seen}"
+
+
+def test_double_click_emits_with_image():
+    c = FibsemImageCanvas()
+    c.set_array(np.zeros((64, 64), dtype=np.uint8))
+    seen = []
+    c.canvas_double_clicked.connect(lambda x, y, m: seen.append((x, y)))
+    c._on_press(_event(c, 10.0, 12.0, dblclick=True))
+    assert seen == [(10.0, 12.0)], f"expected one double-click, got {seen}"
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fibsem/ui/widgets/tests/test_fm_canvas.py
+++ b/fibsem/ui/widgets/tests/test_fm_canvas.py
@@ -1,0 +1,74 @@
+"""Standalone demo: multi-channel FM canvas + per-channel layer controls.
+
+Run:
+    PYTHONPATH=<worktree> python fibsem/ui/widgets/tests/test_fm_canvas.py
+
+An FMCanvasWidget showing a synthetic 3-channel fluorescence image composited
+(per-channel colour, additive blend). Click the **layers** button (top-right of
+the canvas) to open the controls and toggle visibility, change colormap, opacity,
+or per-channel contrast — the composite updates live. "Re-acquire" jitters the
+intensities to mimic a live update.
+"""
+import sys
+
+import numpy as np
+from PyQt5.QtWidgets import (
+    QApplication, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget,
+)
+
+from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
+
+H = W = 512
+_RNG_SEED = 0
+
+
+def _blobs(centres, r, peak) -> np.ndarray:
+    yy, xx = np.ogrid[:H, :W]
+    out = np.zeros((H, W), dtype=np.float32)
+    for cy, cx in centres:
+        out += np.exp(-(((yy - cy) ** 2 + (xx - cx) ** 2) / (2 * r * r))) * peak
+    return out
+
+
+def _channels(scale: float = 1.0):
+    # DAPI: scattered nuclei; GFP: a band; RFP: a cluster
+    dapi = _blobs([(120, 140), (200, 380), (340, 180), (400, 410), (260, 260)], 28, 4000 * scale)
+    gfp = _blobs([(256, 200), (256, 256), (256, 312)], 40, 3000 * scale)
+    rfp = _blobs([(360, 360), (390, 330), (330, 390)], 34, 3500 * scale)
+    return {"DAPI": ("blue", dapi), "GFP": ("green", gfp), "RFP": ("red", rfp)}
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    win = QWidget()
+    win.resize(820, 720)
+
+    fm = FMCanvasWidget()
+    fm.set_pixel_size(100e-9)
+    for name, (color, data) in _channels().items():
+        fm.set_channel(name, data, color)
+
+    info = QLabel("Click the layers button (top-right) to control channels.")
+
+    def reacquire():
+        rng = np.random.default_rng()
+        for name, (color, data) in _channels(scale=float(rng.uniform(0.6, 1.4))).items():
+            fm.set_channel(name, data)  # keep colour/display props, swap data
+        info.setText("Re-acquired (intensities jittered).")
+
+    btn = QPushButton("Re-acquire")
+    btn.clicked.connect(reacquire)
+
+    bar = QHBoxLayout()
+    bar.addWidget(btn)
+    bar.addStretch()
+    lay = QVBoxLayout(win)
+    lay.addWidget(fm, 1)
+    lay.addLayout(bar)
+    lay.addWidget(info)
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/fibsem/ui/widgets/tests/test_fm_z_slider.py
+++ b/fibsem/ui/widgets/tests/test_fm_z_slider.py
@@ -1,0 +1,137 @@
+"""FM z-slider + max-projection behaviour for ``FMCanvasWidget``.
+
+Feeds a synthetic CZYX stack (each z-plane a distinct constant) and checks the plane
+selection + contrast mode as the max-projection checkbox / z-slider are driven. The
+displayed 2-D plane is asserted on each channel's ``FMLayer.data`` (independent of the
+RGB composite).
+
+Run directly (headless):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_fm_z_slider.py
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+from PyQt5 import QtWidgets
+
+_QAPP = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
+
+
+def _fake_fm(data: np.ndarray, colors):
+    """Minimal stand-in for FluorescenceImage: CZYX data + metadata (channels, pixel size)."""
+    channels = [SimpleNamespace(name=f"ch{i}", color=colors[i]) for i in range(data.shape[0])]
+    return SimpleNamespace(data=data, metadata=SimpleNamespace(pixel_size_x=1e-7, channels=channels))
+
+
+def _layer(fmw, name):
+    return next(l for l in fmw._layers if l.name == name)
+
+
+def test_fm_z_slider_and_max_projection():
+    nc, nz, h, w = 2, 5, 6, 6
+    data = np.zeros((nc, nz, h, w), dtype=np.uint16)
+    for c in range(nc):
+        for z in range(nz):
+            data[c, z] = c * 100 + (z + 1)  # distinct constant per (channel, z)
+
+    fmw = FMCanvasWidget()
+    assert not fmw._btn_mip.isVisibleTo(fmw)  # no stack yet → no MIP toggle (live microscope canvas)
+    fmw.set_fm_image(_fake_fm(data, ["green", "red"]))
+    _QAPP.processEvents()
+
+    # default = max projection: MIP toggle shown for the stack, layers hold stack.max(0), z-slider hidden
+    assert fmw._max_projection is True
+    assert fmw._btn_mip.isVisibleTo(fmw)
+    assert not fmw._z_row.isVisibleTo(fmw)
+    assert np.array_equal(_layer(fmw, "ch0").data, data[0].max(0))
+    assert _layer(fmw, "ch0").data.flat[0] == 5  # max over z of ch0 == 5
+
+    # turn off Max projection via the canvas toolbar toggle
+    fmw._btn_mip.setChecked(False)
+    fmw._on_mip_button()
+    _QAPP.processEvents()
+    assert fmw._max_projection is False
+    assert fmw._z_row.isVisibleTo(fmw)
+    assert np.array_equal(_layer(fmw, "ch0").data, data[0][0])  # plane 0
+    assert _layer(fmw, "ch0").data.flat[0] == 1
+    # fixed clim while scrubbing (decision A)
+    assert _layer(fmw, "ch0").autocontrast is False and _layer(fmw, "ch0").clim is not None
+    clim0 = _layer(fmw, "ch0").clim
+
+    # scrub to z = 3
+    fmw._z_slider.setValue(3)
+    _QAPP.processEvents()
+    assert np.array_equal(_layer(fmw, "ch0").data, data[0][3])
+    assert _layer(fmw, "ch0").data.flat[0] == 4
+    assert _layer(fmw, "ch1").data.flat[0] == 104  # second channel scrubs in lock-step
+    assert fmw._z_label.text() == "4/5"
+    assert _layer(fmw, "ch0").clim == clim0  # clim held fixed across planes
+
+    # turn Max projection back on: MIP, z-slider hidden, auto-contrast restored
+    fmw._btn_mip.setChecked(True)
+    fmw._on_mip_button()
+    _QAPP.processEvents()
+    assert fmw._max_projection is True
+    assert not fmw._z_row.isVisibleTo(fmw)
+    assert _layer(fmw, "ch0").autocontrast is True and _layer(fmw, "ch0").clim is None
+    assert _layer(fmw, "ch0").data.flat[0] == 5
+
+    # single-plane stack: no z-slider even with max-projection off
+    fmw._btn_mip.setChecked(False)
+    fmw._on_mip_button()
+    _QAPP.processEvents()
+    single = np.full((1, 1, h, w), 7, dtype=np.uint16)
+    fmw.set_fm_image(_fake_fm(single, ["green"]))
+    _QAPP.processEvents()
+    assert fmw._z_max == 0
+    assert not fmw._z_row.isVisibleTo(fmw)
+    assert not fmw._btn_mip.isVisibleTo(fmw)  # single frame → no MIP toggle
+    assert _layer(fmw, "ch0").data.flat[0] == 7
+
+    # a live 2-D channel has no stack and is not scrubbable
+    fmw.set_channel("live", np.full((h, w), 9, dtype=np.uint16))
+    _QAPP.processEvents()
+    assert "live" not in fmw._stacks
+
+
+def test_manual_contrast_survives_live_frames():
+    """Regression: the live FM feed pushes each frame through set_fm_image as a single-plane
+    stack. _apply_z_mode must not force a channel back to auto-contrast when the user has set
+    a manual contrast, or the live feed reverts the user's clim on every frame."""
+    h = w = 16
+    fmw = FMCanvasWidget()
+    fmw.set_fm_image(_fake_fm(np.full((1, 1, h, w), 3, dtype=np.uint16), ["green"]))
+    _QAPP.processEvents()
+
+    # user turns Auto off and dials in a manual contrast (mirrors _on_autocontrast(False))
+    layer = _layer(fmw, "ch0")
+    layer.autocontrast = False
+    layer.manual = True
+    layer.clim = (100.0, 4000.0)
+
+    # the next live frame arrives (another single-plane set_fm_image)
+    fmw.set_fm_image(_fake_fm(np.full((1, 1, h, w), 7, dtype=np.uint16), ["green"]))
+    _QAPP.processEvents()
+
+    layer = _layer(fmw, "ch0")
+    assert layer.autocontrast is False, "live frame reverted the channel to auto-contrast"
+    assert layer.clim == (100.0, 4000.0), "live frame clobbered the manual clim"
+
+    # user turns Auto back on: the next frame re-derives the clim (fix doesn't over-preserve)
+    layer.autocontrast = True
+    layer.manual = False
+    fmw.set_fm_image(_fake_fm(np.full((1, 1, h, w), 9, dtype=np.uint16), ["green"]))
+    _QAPP.processEvents()
+    assert _layer(fmw, "ch0").clim is None, "auto channel should re-derive its clim"
+
+
+if __name__ == "__main__":
+    test_fm_z_slider_and_max_projection()
+    test_manual_contrast_survives_live_frames()
+    print("PASS")

--- a/fibsem/ui/widgets/tests/test_milling_overlay.py
+++ b/fibsem/ui/widgets/tests/test_milling_overlay.py
@@ -1,0 +1,102 @@
+"""Standalone demo for MillingPatternOverlay.
+
+Run directly:
+    python fibsem/ui/widgets/tests/test_milling_overlay.py
+
+Shows a few milling stages drawn on a blank FIB canvas — one colour per stage,
+each with a crosshair at its point-of-interest. "Toggle patterns" clears / re-shows
+them to demonstrate that the overlay draws nothing when there is no milling.
+"""
+import sys
+
+from PyQt5.QtWidgets import QApplication, QPushButton, QVBoxLayout, QWidget
+
+from fibsem.milling.base import FibsemMillingStage
+from fibsem.milling.patterning.patterns2 import (
+    CirclePattern,
+    LinePattern,
+    RectanglePattern,
+    TrenchPattern,
+)
+from fibsem.structures import FibsemImage, Point
+from fibsem.ui.stylesheets import NAPARI_STYLE
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.overlays.milling_overlay import MillingPatternOverlay
+
+
+def _stage(name: str, pattern, x_um: float, y_um: float) -> FibsemMillingStage:
+    pattern.point = Point(x=x_um * 1e-6, y=y_um * 1e-6)
+    return FibsemMillingStage(name=name, pattern=pattern)
+
+
+def build_stages():
+    """A spread of pattern types / positions to exercise the overlay."""
+    return [
+        _stage("Trench", TrenchPattern(), 0, 0),
+        _stage("Rect top", RectanglePattern(width=12e-6, height=5e-6), 0, 16),
+        _stage("Rotated", RectanglePattern(width=10e-6, height=3e-6, rotation=25), -22, -2),
+        _stage("Circle", CirclePattern(radius=4e-6), 20, 10),
+        _stage("Line", LinePattern(start_x=-8e-6, end_x=8e-6, start_y=-16e-6, end_y=-16e-6), 0, 0),
+    ]
+
+
+class MillingOverlayTest(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Milling overlay — test")
+        self.resize(900, 800)
+
+        self.image = FibsemImage.generate_blank_image(hfw=80e-6, random=True)
+        self.canvas = FibsemImageCanvas()
+        self.canvas.set_image(self.image)
+
+        self.overlay = MillingPatternOverlay()
+        self.canvas.add_overlay(self.overlay)
+
+        stages = build_stages()
+        self.fg = stages[:3]          # foreground (coloured); one is "selected"
+        self.bg = stages[3:]          # background (drawn black)
+        self.selected = 0
+        self._shown = True
+        self._render()
+
+        self.btn = QPushButton("Toggle patterns (clear / show)")
+        self.btn.clicked.connect(self._toggle)
+        self.btn_sel = QPushButton("Cycle selected stage")
+        self.btn_sel.clicked.connect(self._cycle_selected)
+
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.addWidget(self.canvas)
+        lay.addWidget(self.btn)
+        lay.addWidget(self.btn_sel)
+
+    def _render(self) -> None:
+        self.overlay.set_stages(
+            self.fg, self.image, background_stages=self.bg, selected_index=self.selected
+        )
+
+    def _toggle(self) -> None:
+        self._shown = not self._shown
+        if self._shown:
+            self._render()
+        else:
+            self.overlay.clear()
+
+    def _cycle_selected(self) -> None:
+        self.selected = (self.selected + 1) % len(self.fg)
+        if self._shown:
+            self._render()
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    app.setStyle("Fusion")
+    win = MillingOverlayTest()
+    win.setStyleSheet(NAPARI_STYLE + "QWidget { background: #262930; color: #d1d2d4; }")
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/fibsem/ui/widgets/tests/test_point_overlay_legend.py
+++ b/fibsem/ui/widgets/tests/test_point_overlay_legend.py
@@ -1,0 +1,64 @@
+"""Headless smoke: point-overlay + canvas legends render the actual marker glyph.
+
+The lamella-editor POI is a "+" marker with a legend; the swatch must be a "+" (Line2D),
+not a filled square (Patch). Also covers FibsemImageCanvas.set_legend's per-entry marker.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_point_overlay_legend.py
+"""
+import sys
+
+import numpy as np
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _canvas():
+    c = FibsemImageCanvas()
+    c.set_array(np.zeros((32, 32), dtype=np.uint8))
+    return c
+
+
+def test_point_overlay_legend_swatch_is_the_marker():
+    c = _canvas()
+    ov = PointOverlay(
+        color="magenta", marker="+", edge_width=1.2,
+        legend_label="Point of Interest", add_on_right_click=False, removable=False,
+    )
+    c.add_overlay(ov)
+    ov.set_points([(16, 16)])
+    assert ov._legend is not None
+    lines = ov._legend.get_lines()
+    assert len(lines) == 1 and lines[0].get_marker() == "+"
+
+
+def test_set_legend_marker_vs_patch_entries():
+    c = _canvas()
+    c.set_legend([("magenta", "POI", "+"), ("limegreen", "area")])
+    leg = c._legend_artist
+    assert leg is not None
+    lines, patches = leg.get_lines(), leg.get_patches()
+    assert len(lines) == 1 and lines[0].get_marker() == "+"
+    assert len(patches) == 1  # the 2-tuple entry stays a filled swatch
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fibsem/ui/widgets/tests/test_quad_view.py
+++ b/fibsem/ui/widgets/tests/test_quad_view.py
@@ -1,0 +1,44 @@
+"""Standalone demo for the quad-view microscope display.
+
+Run directly:
+    python fibsem/ui/widgets/tests/test_quad_view.py
+
+Shows a QuadViewWidget driven through a MicroscopeViewController: SEM / FIB / FM
+get blank images, the 4th cell is the inert "No Data" placeholder. Each image
+cell carries the full FibsemImageCanvas toolbar (reset / scalebar / crosshair /
+contrast) and supports zoom / pan.
+"""
+import sys
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.structures import BeamType, FibsemImage
+from fibsem.ui.stylesheets import NAPARI_STYLE
+from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    app.setStyle("Fusion")
+
+    controller = MicroscopeViewController()
+    controller.set_image(
+        BeamType.ELECTRON, FibsemImage.generate_blank_image(hfw=80e-6, random=True)
+    )
+    controller.set_image(
+        BeamType.ION, FibsemImage.generate_blank_image(hfw=80e-6, random=True)
+    )
+    controller.set_fm_channel(
+        "FM", FibsemImage.generate_blank_image(hfw=150e-6, random=True).data, "gray"
+    )
+
+    win = controller.widget
+    win.setWindowTitle("Quad view — test")
+    win.setStyleSheet(NAPARI_STYLE + "QWidget { background: #262930; color: #d1d2d4; }")
+    win.resize(1200, 800)
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/fibsem/ui/widgets/tests/test_ruler_overlay.py
+++ b/fibsem/ui/widgets/tests/test_ruler_overlay.py
@@ -1,0 +1,226 @@
+"""Headless tests for the canvas drag-to-measure RulerOverlay (Phase 7.1).
+
+Run directly (headless):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_ruler_overlay.py
+
+Or via pytest. Covers SI formatting, the toolbar toggle (seed + activate +
+restore), endpoint/line drag with bounds clamping, screen-space hit testing,
+and that the overlay stays fully inert (no artists, no input) while hidden.
+"""
+from __future__ import annotations
+
+import os
+import types
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.overlays.ruler_overlay import RulerOverlay, _format_distance
+
+_W, _H = 1536, 1024
+_PX = 10e-9  # 10 nm / px
+
+
+def _app() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+def _ev(**kw):
+    return types.SimpleNamespace(**kw)
+
+
+def _canvas() -> FibsemImageCanvas:
+    _app()
+    c = FibsemImageCanvas()
+    c.resize(800, 600)
+    c.set_array(np.zeros((_H, _W), dtype=np.uint8), pixel_size=_PX)
+    c.draw()  # realise transData for screen-space hit tests
+    return c
+
+
+def _ruler_on(c: FibsemImageCanvas) -> RulerOverlay:
+    c.btn_toggle_ruler.setChecked(True)
+    c.toggle_ruler()
+    return c._ruler_overlay
+
+
+def test_si_formatting():
+    assert _format_distance(5e-9) == "5.0 nm"
+    assert _format_distance(2.5e-6) == "2.50 µm"
+    assert _format_distance(3e-3) == "3.000 mm"
+    assert _format_distance(0) == "0 nm"
+
+
+def test_toggle_on_seeds_and_activates():
+    c = _canvas()
+    r = _ruler_on(c)
+    assert r is not None and r in c._overlays
+    assert r._visible is True
+    assert r._p1 is not None and r._p2 is not None
+    assert r._line is not None and r._dots is not None and r._label is not None
+    assert c.active_overlay is r
+    seed_len = abs(r._p2[0] - r._p1[0])
+    assert abs(seed_len - 0.25 * _W) < 1e-6
+    assert abs(r.measurement() - seed_len * _PX) < 1e-18
+    assert r._label.get_text() == _format_distance(seed_len * _PX)
+
+
+def test_drag_endpoint_updates_distance():
+    c = _canvas()
+    r = _ruler_on(c)
+    seed_len = abs(r._p2[0] - r._p1[0])
+    r._drag = "p2"
+    r._drag_start_data = (r._p2[0], r._p2[1])
+    r._drag_start_pts = (list(r._p1), list(r._p2))
+    r._blit_bg = None  # force the draw_idle path (skip blit)
+    r._on_motion(_ev(xdata=r._p2[0] + 200, ydata=r._p2[1] + 100))
+    expected = ((seed_len + 200) ** 2 + 100 ** 2) ** 0.5
+    assert abs(r.measurement() - expected * _PX) < 1e-15
+    r._on_release(_ev(button=1))
+    assert c._overlay_consuming_event is False
+    assert r._drag is None
+
+
+def test_drag_clamps_to_bounds():
+    c = _canvas()
+    r = _ruler_on(c)
+    r._drag = "p2"
+    r._drag_start_data = (r._p2[0], r._p2[1])
+    r._drag_start_pts = (list(r._p1), list(r._p2))
+    r._blit_bg = None
+    r._on_motion(_ev(xdata=r._p2[0] + 99999, ydata=r._p2[1] + 99999))
+    assert r._p2[0] <= _W and r._p2[1] <= _H
+    r._on_release(_ev(button=1))
+
+
+def test_move_line_preserves_length_and_clamps():
+    c = _canvas()
+    r = _ruler_on(c)
+    p1_0, p2_0 = list(r._p1), list(r._p2)
+    length0 = ((p2_0[0] - p1_0[0]) ** 2 + (p2_0[1] - p1_0[1]) ** 2) ** 0.5
+    r._drag = "line"
+    r._drag_start_data = (0.0, 0.0)
+    r._drag_start_pts = (list(r._p1), list(r._p2))
+    r._blit_bg = None
+    r._on_motion(_ev(xdata=-99999, ydata=0.0))  # shove far left
+    length1 = ((r._p2[0] - r._p1[0]) ** 2 + (r._p2[1] - r._p1[1]) ** 2) ** 0.5
+    assert abs(length1 - length0) < 1e-6
+    assert min(r._p1[0], r._p2[0]) >= -1e-9
+    r._on_release(_ev(button=1))
+
+
+def test_screen_space_hit_testing():
+    c = _canvas()
+    r = _ruler_on(c)
+    c.draw()
+    sx1, sy1 = r._screen(r._p1)
+    sx2, sy2 = r._screen(r._p2)
+    mx, my = (sx1 + sx2) / 2, (sy1 + sy2) / 2
+    assert r._hit(_ev(x=sx1, y=sy1)) == "p1"
+    assert r._hit(_ev(x=sx2, y=sy2)) == "p2"
+    assert r._hit(_ev(x=mx, y=my)) == "line"
+    assert r._hit(_ev(x=sx1, y=sy1 + 200)) is None
+
+
+def test_ruler_off_restores_active_mode():
+    """Ruler off returns input to the overlay MODE that is active, derived from the live
+    mode state (not a snapshot taken when the ruler was switched on)."""
+    c = _canvas()
+    mode_ov = RulerOverlay()  # stands in for a workflow overlay (POI / spot burn)
+    c.add_overlay(mode_ov)
+    c.enter_overlay_mode(mode_ov, "Edit")
+    assert c.active_overlay is mode_ov
+    r = _ruler_on(c)
+    assert c.active_overlay is r
+    c.btn_toggle_ruler.setChecked(False)
+    c.toggle_ruler()
+    assert r._line is None and r._visible is False
+    assert c.active_overlay is mode_ov  # mode restored, not a stale snapshot
+
+
+def test_ruler_off_after_mode_exit_returns_to_move():
+    """Regression: a mode exited while measuring must not leave a stale overlay owning input
+    (with no toolbar affordance) when the ruler is switched off — it returns to Move."""
+    c = _canvas()
+    mode_ov = RulerOverlay()
+    c.add_overlay(mode_ov)
+    c.enter_overlay_mode(mode_ov, "Edit")
+    _ruler_on(c)
+    c.exit_overlay_mode(mode_ov)  # the workflow ends the step while measuring
+    c.btn_toggle_ruler.setChecked(False)
+    c.toggle_ruler()
+    assert c.active_overlay is None  # Move, not the stale mode_ov
+
+
+def test_ruler_off_after_mode_overlay_removed_returns_to_move():
+    """Regression: if the mode overlay is removed while measuring (the reducer drops its
+    spec), switching the ruler off must not re-activate the now-detached overlay — that
+    would suppress every semantic click permanently. It returns to Move."""
+    c = _canvas()
+    mode_ov = RulerOverlay()
+    c.add_overlay(mode_ov)
+    c.enter_overlay_mode(mode_ov, "Edit")
+    _ruler_on(c)
+    c.remove_overlay(mode_ov)  # e.g. controller.remove_overlay / clear()
+    c.btn_toggle_ruler.setChecked(False)
+    c.toggle_ruler()
+    assert c.active_overlay is None
+    assert mode_ov not in c._overlays
+
+
+def test_ruler_off_with_no_mode_returns_to_move():
+    """No overlay mode active: ruler off returns to Move (None)."""
+    c = _canvas()
+    r = _ruler_on(c)
+    assert c.active_overlay is r
+    c.btn_toggle_ruler.setChecked(False)
+    c.toggle_ruler()
+    assert c.active_overlay is None
+
+
+def test_inert_while_hidden():
+    c = _canvas()
+    r = RulerOverlay()
+    c.add_overlay(r)  # never toggled visible
+    assert r._line is None
+    r._on_press(_ev(inaxes=c._ax, button=1, xdata=10, ydata=10, x=10, y=10))
+    assert r._drag is None
+    c.set_array(np.zeros((_H, _W), dtype=np.uint8), pixel_size=_PX)
+    assert r._line is None  # image change keeps it inert
+
+
+def test_pixel_size_refreshes_on_image_change():
+    c = _canvas()
+    r = _ruler_on(c)
+    # a new image with a different pixel size updates the label units
+    c.set_array(np.zeros((_H, _W), dtype=np.uint8), pixel_size=2 * _PX)
+    seed_len = abs(r._p2[0] - r._p1[0])
+    assert abs(r.measurement() - seed_len * 2 * _PX) < 1e-18
+
+
+def _run_all():
+    tests = [
+        test_si_formatting,
+        test_toggle_on_seeds_and_activates,
+        test_drag_endpoint_updates_distance,
+        test_drag_clamps_to_bounds,
+        test_move_line_preserves_length_and_clamps,
+        test_screen_space_hit_testing,
+        test_ruler_off_restores_active_mode,
+        test_ruler_off_after_mode_exit_returns_to_move,
+        test_ruler_off_after_mode_overlay_removed_returns_to_move,
+        test_ruler_off_with_no_mode_returns_to_move,
+        test_inert_while_hidden,
+        test_pixel_size_refreshes_on_image_change,
+    ]
+    for t in tests:
+        t()
+        print(f"  ok  {t.__name__}")
+    print(f"\nALL {len(tests)} TESTS PASSED")
+
+
+if __name__ == "__main__":
+    _run_all()


### PR DESCRIPTION
## Summary

Lands `fibsem/ui/widgets/canvas/` — the napari-free, reusable display stack built on
#111 — as a standalone package, **without any of that PR's cutover**. The goal is to get
the canvas reviewed and available to other widgets now, instead of waiting for the full
AutoLamella migration to be tested on every microscope.

**This PR changes no shipping code path.** Nothing on `main` imports the new package, and
the existing `fibsem/ui/widgets/image_canvas.py` is left in place, byte-identical, still
serving the fluorescence coincidence viewer. It is additive review surface only.

## What's here

| Module | What it provides |
| --- | --- |
| `canvas/image_canvas.py` | `FibsemImageCanvas` — zoom/pan, scalebar, crosshair, contrast/gamma popover, overlay toolbar, hint / info-bar / flash text, and pixel-coordinate click + scroll signals carrying keyboard modifiers |
| `canvas/overlays/` | `CanvasOverlay` base + point, rect, ruler, pattern, alignment-area, segmentation-mask, milling-pattern and minimap-shape overlays |
| `canvas/fm_canvas.py` | `FMCanvasWidget` — per-channel z-stacks, max-projection toggle, z-slider, dark layers panel (visibility / colormap / opacity / gamma / contrast) |
| `canvas/fm_composite.py` | Qt-free additive channel compositor, napari-matched tints, cached auto-contrast limits |
| `canvas/canvas_state.py` | Pure-data overlay specs + per-canvas scene model |
| `canvas/quad_view.py` | `QuadViewWidget` (SEM \| FIB / FM \| placeholder) + `MicroscopeViewController`, the reducer |

### The reducer, in one paragraph

Producers never touch canvases or overlay objects. They mutate a declarative `SceneModel`
through `MicroscopeViewController` (`set_image` / `set_overlay` / `remove_overlay`); each
mutation marks the scene dirty, and a queued signal drives one coalesced `_reconcile` pass
per canvas on the GUI thread. That makes the reducer API safe to call from worker threads
and keeps overlay specs — plain dataclasses keyed by `id` — trivially testable. Overlays
update artists in place rather than being destroyed and recreated per refresh.

## Using it in a widget

```python
controller = MicroscopeViewController()
layout.addWidget(controller.widget)

controller.set_image(BeamType.ELECTRON, image)
controller.set_overlay(BeamType.ION, MillingSpec(stages=stages, selected_index=0))
controller.set_fm_channel("GFP", data, "green")
```

`FibsemImageCanvas` is also usable on its own — that is how the coincidence viewer already
hosts the current canvas.

## Testing

- 47 headless pytest cases: reducer behaviour, ruler measurement/formatting, point-overlay
  legends, zoom/pan preserved across same-resolution updates, FM z-slider + max projection,
  and empty-canvas click gating.
- Seven standalone demos under `fibsem/ui/widgets/tests/` (`main()`-under-`__main__`, not
  pytest-collected).
- Verified `image_canvas.py`, `fluorescence_coincidence_viewer_widget.py` and their tests
  are byte-identical to `main`; both canvases import and coexist.
- Full suite still collects clean (1338 tests, no import errors).

## Notes for review

- **Temporary duplication is deliberate.** ~1400 lines of the old `image_canvas.py` sit
  alongside the new core until the coincidence viewer is repointed. Doing that repoint here
  would have meant re-testing the viewer, which is exactly the coupling this split removes.
  It is a follow-up, along with dropping the viewer's bespoke histogram panel in favour of
  the canvas's built-in contrast control.
- `contrast_gamma_control.py` moves into the package. It had **no importers on `main`**, so
  the move is free; its gamma helper import is corrected to `fibsem.autofunctions.gamma`.
- #111 will need a rebase onto this, since it currently carries these files itself. The
  content is identical, so it should be mechanical.
