### PR TITLE
[ui] Make the manipulator widget napari-free

### DIFF
--- a/fibsem/ui/FibsemManipulatorWidget.py
+++ b/fibsem/ui/FibsemManipulatorWidget.py
@@ -1,24 +1,30 @@
 import logging
-import os
+from typing import TYPE_CHECKING, Optional
 
-import napari
-import napari.utils.notifications
-import numpy as np
 from PyQt5 import QtWidgets
 from PyQt5.QtWidgets import QMessageBox
 
 from fibsem import config as cfg
-from fibsem import constants, conversions
+from fibsem import constants
 from fibsem.microscope import FibsemMicroscope, ThermoMicroscope
 from fibsem.microscopes.tescan import TescanMicroscope
 from fibsem.microscopes.simulator import DemoMicroscope
 from fibsem.structures import BeamType, FibsemManipulatorPosition, MicroscopeSettings
-from fibsem.ui import stylesheets
-from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
+from fibsem.ui import notification_service, stylesheets
 from fibsem.ui.qtdesigner_files import (
     FibsemManipulatorWidget as FibsemManipulatorWidgetUI,
 )
 from fibsem.ui.utils import install_wheel_blocker_recursive, message_box_ui
+
+if TYPE_CHECKING:
+    # Annotation-only. `viewer` is still handed a napari Viewer by FibsemUI, so the
+    # type stays documented without importing napari here; image_widget likewise
+    # avoids a runtime dependency on a sibling widget module. (napari still reaches
+    # this module transitively via fibsem/ui/__init__.py, which eagerly imports every
+    # widget — that one belongs to the wider cutover.)
+    import napari
+
+    from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
 
 
 class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidget):
@@ -26,8 +32,8 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
         self,
         microscope: FibsemMicroscope = None,
         settings: MicroscopeSettings = None,
-        viewer: napari.Viewer = None,
-        image_widget: FibsemImageSettingsWidget = None, 
+        viewer: Optional["napari.Viewer"] = None,  # unused; retained for call-site compatibility
+        image_widget: Optional["FibsemImageSettingsWidget"] = None,
         parent=None,
     ):
         super().__init__(parent=parent)
@@ -56,7 +62,7 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
                 self.savedPosition_combobox.addItems(["PARK", "EUCENTRIC"])
              
             except Exception as e:
-                napari.utils.notifications.show_warning(f"Error loading PARK and EUCENTRIC positions, calibration of manipulator is possibly needed. {e}")
+                notification_service.show_toast(f"Error loading PARK and EUCENTRIC positions, calibration of manipulator is possibly needed. {e}", "warning")
                             
             self.move_type_comboBox.currentIndexChanged.connect(self.change_move_type)
             self.move_type_comboBox.setCurrentIndex(0)
@@ -223,7 +229,7 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
             except Exception as e:
                 error_message = f"Error moving manipulator (Relative): {str(e)}"
                 logging.error(error_message)
-                napari.utils.notifications.show_error(error_message)
+                notification_service.show_toast(error_message, "error")
             
         else:
             try:
@@ -231,7 +237,7 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
             except Exception as e:
                 error_message = f"Error moving manipulator (Corrected): {str(e)}"
                 logging.error(error_message)
-                napari.utils.notifications.show_error(error_message)
+                notification_service.show_toast(error_message, "error")
 
         self.update_ui()      
   
@@ -309,18 +315,3 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
         logging.info(f"Moving to saved position {name} at {position}")
         self.microscope.move_manipulator_absolute(position=position)
         self.update_ui()
-
-
-
-def main():
-
-    viewer = napari.Viewer(ndisplay=2)
-    manipulator_widget = FibsemManipulatorWidget()
-    viewer.window.add_dock_widget(
-        manipulator_widget, area="right", add_vertical_stretch=False
-    )
-    napari.run()
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary

Removes napari from `FibsemManipulatorWidget`'s own source — the second small stream
extracted from #111 so it can land ahead of the full napari cutover. One file, +19/-28.

- The two `napari` imports go away.
- The three `napari.utils.notifications.show_warning` / `show_error` calls become
  `notification_service.show_toast(msg, "warning"|"error")`, matching how the rest of the
  UI reports widget-level errors.
- The standalone `main()` demo is **deleted** rather than ported. It constructed the widget
  with no microscope, which has always crashed in `update_ui()` on
  `self.microscope.get_manipulator_state()` — dead code on `main` today. It is not a
  packaging entry point and nothing references it.

## Imports and typing

- `os`, `numpy as np` and `conversions` were unused (already dead on `main`) — removed.
- The annotation-only `napari.Viewer` and `FibsemImageSettingsWidget` references move into a
  `TYPE_CHECKING` block, so the types stay documented without the runtime imports. Both
  resolve correctly as forward references.

## Scope notes

- **`viewer` is kept as a parameter.** `FibsemUI.py:114` still passes a real napari viewer
  when it builds this widget, so dropping the argument belongs with the wider cutover. It is
  stored but never read (verified nothing accesses `manipulator_widget.viewer`).
- **napari still reaches this module transitively**, via `fibsem/ui/__init__.py` eagerly
  importing all eight widgets — one of which is `FibsemImageSettingsWidget`. Nothing this
  file does can change that; it is cutover work. The claim here is only that this widget's
  own source no longer touches napari.

## Testing

Verified against a live `DemoMicroscope` session, not just imports:

- constructs via the exact `FibsemUI` call shape (`viewer=` by keyword) and with no viewer at all;
- forced a hardware fault through `move_relative()` and captured the emitted toast —
  `('error', 'Error moving manipulator (Relative): simulated fault')` — so the replaced
  notification path genuinely fires;
- `FibsemUI` (the only external call site) still imports;
- AST check reports zero unused imports;
- full suite: 1323 passed, 15 skipped.
