### PR TITLE
[ui] Finish the GUI threading migration onto FunctionWorker

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -40,6 +40,7 @@ from fibsem.ui import (
     stylesheets,
 )
 from fibsem.ui.FMAcquisitionWidget import open_fm_acquisition_dialog
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.fm.widgets import FMImageViewerWidget
 from fibsem.ui import utils as fui
 from PyQt5.QtCore import pyqtSignal
@@ -209,7 +210,7 @@ class AutoLamellaUI(QMainWindow):
         self.SELECTED_POI: Optional[Point] = None
         self._poi_layer = None
         self._workflow_stop_event: threading.Event = threading.Event()
-        self._task_worker_thread: Optional[threading.Thread] = None
+        self._task_worker_thread: Optional[FunctionWorker] = None
         self._task_manager: Optional[TaskManager] = None
         self._last_run_summary: Optional["pd.DataFrame"] = None
 
@@ -1014,10 +1015,8 @@ class AutoLamellaUI(QMainWindow):
         self.milling_task_config_widget.clear()  # type: ignore
 
         # Start acquisition thread
-        self._task_worker_thread = threading.Thread(
-            target=self._run_tasks_worker,
-            args=(selected_tasks, selected_lamella),
-            daemon=True,
+        self._task_worker_thread = FunctionWorker(
+            self._run_tasks_worker, selected_tasks, selected_lamella
         )
         self._task_worker_thread.start()
 

--- a/fibsem/ui/FMAcquisitionWidget.py
+++ b/fibsem/ui/FMAcquisitionWidget.py
@@ -85,6 +85,7 @@ from fibsem.ui.stylesheets import (
 )
 from fibsem.ui.widgets.custom_widgets import LamellaNameListWidget, TitledPanel
 from fibsem.utils import format_duration
+from fibsem.ui.qt.threading import FunctionWorker
 
 
 # Overlay layer configuration constants
@@ -385,7 +386,7 @@ class FMAcquisitionWidget(QWidget):
         self.histogramWidget: HistogramWidget
 
         # Consolidated acquisition threading
-        self._acquisition_thread: Optional[threading.Thread] = None
+        self._acquisition_thread: Optional[FunctionWorker] = None
         self._acquisition_stop_event = threading.Event()
         self._current_acquisition_type: Optional[str] = None
 
@@ -887,10 +888,8 @@ class FMAcquisitionWidget(QWidget):
         self._update_acquisition_button_states()
         self._acquisition_stop_event.clear()
 
-        self._acquisition_thread = threading.Thread(
-            target=self._stage_movement_worker,
-            args=(stage_position, objective_position),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._stage_movement_worker, stage_position, objective_position
         )
         self._acquisition_thread.start()
 
@@ -1797,10 +1796,8 @@ class FMAcquisitionWidget(QWidget):
             z_parameters = settings["z_parameters"]
 
         # Start acquisition thread
-        self._acquisition_thread = threading.Thread(
-            target=self._image_acquistion_worker,
-            args=(channel_settings, z_parameters),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._image_acquistion_worker, channel_settings, z_parameters
         )
         self._acquisition_thread.start()
 
@@ -1939,16 +1936,13 @@ class FMAcquisitionWidget(QWidget):
         positions = None  # self.experiment.positions
 
         # Start acquisition thread
-        self._acquisition_thread = threading.Thread(
-            target=self._overview_worker,
-            args=(
-                channel_settings,
-                overview_parameters,
-                z_parameters,
-                autofocus_settings,
-                positions,
-            ),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._overview_worker,
+            channel_settings,
+            overview_parameters,
+            z_parameters,
+            autofocus_settings,
+            positions,
         )
         self._acquisition_thread.start()
 
@@ -2100,10 +2094,8 @@ class FMAcquisitionWidget(QWidget):
         z_parameters = settings["z_parameters"]
 
         # Start auto-focus thread
-        self._acquisition_thread = threading.Thread(
-            target=self._autofocus_worker,
-            args=(channel_settings, z_parameters),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._autofocus_worker, channel_settings, z_parameters
         )
         self._acquisition_thread.start()
 

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -57,6 +57,7 @@ from fibsem.structures import (
 from fibsem.ui import FibsemMovementWidget, stylesheets
 from fibsem.ui import utils as ui_utils
 from fibsem.ui.napari.patterns import COLOURS as MILLING_PATTERN_COLOURS
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.napari.patterns import (
     MILLING_PATTERN_LAYER_NAME,
     draw_milling_patterns_in_napari,
@@ -207,7 +208,7 @@ class FibsemMinimapWidget(QWidget):
         self.correlation_mode_enabled: bool = False
 
         self._thread_stop_event = threading.Event()
-        self._acquisition_worker: Optional[threading.Thread] = None
+        self._acquisition_worker: Optional[FunctionWorker] = None
 
         # display options
         self.show_current_fov: bool = True
@@ -588,10 +589,8 @@ class FibsemMinimapWidget(QWidget):
         self._hide_overlay_layers()
 
         self._thread_stop_event.clear()
-        self._acquisition_worker = threading.Thread(
-            target=self._run_tile_collection,
-            args=(self.microscope, overview_settings),
-            daemon=True,
+        self._acquisition_worker = FunctionWorker(
+            self._run_tile_collection, self.microscope, overview_settings
         )
         self._acquisition_worker.start()
 

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -27,7 +27,6 @@ import logging
 import math
 import os
 import time
-import threading
 from collections import deque
 from datetime import timedelta
 from pprint import pformat
@@ -67,6 +66,7 @@ from fibsem.milling.strategy.coincidence import CoincidenceMillingStrategy
 from fibsem.structures import BeamType, FibsemImage, Point
 from fibsem.ui import notification_service, stylesheets
 from fibsem.ui.fm.widgets import LinePlotWidget
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.widgets.custom_widgets import (
     IntegerValueSpinBox,
     LamellaNameListWidget,
@@ -1667,7 +1667,8 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             except Exception:
                 logging.exception("Error moving objective to stored position")
 
-        threading.Thread(target=_move, daemon=True).start()
+        worker = FunctionWorker(_move)
+        worker.start()
 
     def _on_slw_pose_move_to(self, pose_name: str):
         """Move the stage to the given pose of the selected lamella."""
@@ -1698,7 +1699,8 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             except Exception:
                 logging.exception("Error moving to pose position")
 
-        threading.Thread(target=_move, daemon=True).start()
+        worker = FunctionWorker(_move)
+        worker.start()
 
     def _on_slw_pose_update(self, pose_name: str):
         """Set the current stage position as the given pose of the selected lamella."""
@@ -1755,7 +1757,8 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             except Exception:
                 logging.exception("Error moving to lamella position")
 
-        threading.Thread(target=_move, daemon=True).start()
+        worker = FunctionWorker(_move)
+        worker.start()
 
     def _acquire_fib_image(self):
         """Acquire a FIB image using current microscope settings and display it."""
@@ -1771,7 +1774,8 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             finally:
                 self._fib_acquire_done.emit()
 
-        threading.Thread(target=_worker, daemon=True).start()
+        worker = FunctionWorker(_worker)
+        worker.start()
 
     def _acquire_fm_image(self):
         """Acquire a single FM image in a background thread and display it."""
@@ -1799,7 +1803,8 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             finally:
                 self._fm_acquire_done.emit()
 
-        threading.Thread(target=_worker, daemon=True).start()
+        worker = FunctionWorker(_worker)
+        worker.start()
 
     def _set_fib_buttons_enabled(self, enabled: bool) -> None:
         for btn in [
@@ -1829,9 +1834,11 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
                 logging.exception("Error running FIB autocontrast")
             finally:
                 self._fib_acquire_done.emit()
-                self.btn_autocontrast_fib.setText("AutoContrast")
 
-        threading.Thread(target=_worker, daemon=True).start()
+        worker = FunctionWorker(_worker)
+        # reset the label on the GUI thread; setText from the worker thread is unsafe
+        worker.finished.connect(lambda: self.btn_autocontrast_fib.setText("AutoContrast"))
+        worker.start()
 
     def _run_fib_autofocus(self) -> None:
         from fibsem.structures import FibsemRectangle
@@ -1853,9 +1860,11 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
                 logging.exception("Error running FIB autofocus")
             finally:
                 self._fib_acquire_done.emit()
-                self.btn_autofocus_fib.setText("AutoFocus")
 
-        threading.Thread(target=_worker, daemon=True).start()
+        worker = FunctionWorker(_worker)
+        # reset the label on the GUI thread; setText from the worker thread is unsafe
+        worker.finished.connect(lambda: self.btn_autofocus_fib.setText("AutoFocus"))
+        worker.start()
 
     def _on_fib_acquire_done(self):
         self._set_fib_buttons_enabled(True)
@@ -2580,12 +2589,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             return
         dx = (x - img_w / 2) * pixel_size
         dy = -(y - img_h / 2) * pixel_size
-        threading.Thread(
-            target=lambda: self.microscope.stable_move(
-                dx=dx, dy=dy, beam_type=BeamType.ION
-            ),
-            daemon=True,
-        ).start()
+        worker = FunctionWorker(
+            self.microscope.stable_move, dx=dx, dy=dy, beam_type=BeamType.ION
+        )
+        worker.start()
 
     def _on_fm_double_clicked(self, x: float, y: float) -> None:
         """Stable-move the stage to the double-clicked position on the FM canvas."""
@@ -2615,10 +2622,8 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         px, py = point[0], -point[1]  # Y-inversion (mirrors FMControlWidget)
         # fm_stable_move undoes the display transform and projects through the
         # camera's own axis tilt, so the sample is not foreshortened by the wrong beam.
-        threading.Thread(
-            target=lambda: self.microscope.fm_stable_move(dx=px, dy=py),
-            daemon=True,
-        ).start()
+        worker = FunctionWorker(self.microscope.fm_stable_move, dx=px, dy=py)
+        worker.start()
 
     # Public API
     # ------------------------------------------------------------------

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -51,6 +51,7 @@ from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
 )
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.widgets.custom_widgets import (
     IconToolButton,
     TitledPanel,
@@ -92,7 +93,7 @@ class FMControlWidget(QWidget):
         self.channel_settings = ChannelSettings()
 
         # Consolidated acquisition threading
-        self._acquisition_thread: Optional[threading.Thread] = None
+        self._acquisition_thread: Optional[FunctionWorker] = None
         self._acquisition_stop_event = threading.Event()
         self._current_acquisition_type: Optional[str] = None
 
@@ -796,10 +797,8 @@ class FMControlWidget(QWidget):
         record_recent_channels(channel_settings)
 
         # Start acquisition thread
-        self._acquisition_thread = threading.Thread(
-            target=self._image_acquistion_worker,
-            args=(channel_settings, z_parameters, filename),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._image_acquistion_worker, channel_settings, z_parameters, filename
         )
         self._acquisition_thread.start()
 
@@ -907,10 +906,8 @@ class FMControlWidget(QWidget):
         autofocus_settings = settings["autofocus_settings"]
 
         # Start auto-focus thread
-        self._acquisition_thread = threading.Thread(
-            target=self._autofocus_worker,
-            args=(channel_settings, autofocus_settings),
-            daemon=True,
+        self._acquisition_thread = FunctionWorker(
+            self._autofocus_worker, channel_settings, autofocus_settings
         )
         self._acquisition_thread.start()
 

--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -15,6 +15,7 @@ from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.tasks import FibsemMillingTaskConfig, run_milling_task
 from fibsem.structures import MillingState
 from fibsem.ui import stylesheets
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.utils import format_duration
 
 if TYPE_CHECKING:
@@ -37,7 +38,7 @@ class FibsemMillingWidget2(QWidget):
         self.microscope = microscope
         self.parent_widget = parent
 
-        self._milling_thread: Optional[threading.Thread] = None
+        self._milling_thread: Optional[FunctionWorker] = None
         self._milling_stop_event = threading.Event()
         self._has_stages = False
         layout = QGridLayout()
@@ -176,10 +177,8 @@ class FibsemMillingWidget2(QWidget):
             config = self.parent_widget.get_config()
 
         # Start the milling task in a separate thread
-        self._milling_thread = threading.Thread(
-            target=self._milling_worker,
-            args=(self.microscope, config),
-            daemon=True,
+        self._milling_thread = FunctionWorker(
+            self._milling_worker, self.microscope, config
         )
 
         self._milling_thread.start()

--- a/tests/ui/test_gui_thread_migration.py
+++ b/tests/ui/test_gui_thread_migration.py
@@ -1,0 +1,114 @@
+"""Guard the GUI's background-threading migration onto ``FunctionWorker``.
+
+``fibsem.ui.qt.threading`` is tested on its own in ``test_qt_threading.py``. What this file
+protects is the *migration*: every GUI background job goes through ``FunctionWorker`` rather
+than a bare ``threading.Thread``.
+
+That matters because a raw thread is invisible to Qt. It swallows exceptions into the
+interpreter's default handler instead of surfacing them, and it offers no signal that is
+marshalled back onto the GUI thread — which is how widget updates end up being made from a
+worker thread. ``FunctionWorker`` logs every failure and delivers ``returned`` / ``errored`` /
+``finished`` on the thread that created it.
+
+Deliberately *not* covered: the driver layer (``fibsem/microscope.py``, ``fibsem/fm/microscope.py``)
+and the workflow hooks (``workflows/tasks/hooks.py``). Those are Qt-free by design, and
+``FunctionWorker`` is a ``QObject`` — pulling it in there would drag Qt into non-GUI code.
+
+These checks read source rather than importing it, deliberately: CI installs neither PyQt5 nor
+napari, and ``fibsem/ui/__init__.py`` eagerly imports every widget, so *any* import under
+``fibsem.ui`` pulls in napari and would skip the whole file there. Reading the files keeps the
+guard running on CI, where it is most useful. ``FunctionWorker``'s runtime behaviour — including
+the ``start`` / ``is_alive`` / ``join`` surface these call sites rely on — is covered by
+``test_qt_threading.py``, which is import-guarded and runs locally.
+"""
+import ast
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories whose background work must be Qt-observable.
+GUI_ROOTS = [
+    REPO_ROOT / "fibsem" / "ui",
+    REPO_ROOT / "fibsem" / "correlation" / "ui",
+    REPO_ROOT / "fibsem" / "applications" / "autolamella" / "ui",
+]
+
+# The FunctionWorker implementation itself owns the one legitimate raw thread.
+ALLOWED = {REPO_ROOT / "fibsem" / "ui" / "qt" / "threading.py"}
+
+# Widgets whose background jobs were migrated off raw threads; each must still route
+# through FunctionWorker, so a half-revert is caught.
+MIGRATED_MODULES = [
+    "fibsem/ui/FMAcquisitionWidget.py",
+    "fibsem/ui/FibsemMinimapWidget.py",
+    "fibsem/ui/widgets/milling_widget.py",
+    "fibsem/ui/widgets/fluorescence_control_widget.py",
+    "fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py",
+    "fibsem/applications/autolamella/ui/AutoLamellaUI.py",
+]
+
+
+def _gui_python_files() -> List[Path]:
+    files = []
+    for root in GUI_ROOTS:
+        if root.exists():
+            files.extend(p for p in root.rglob("*.py") if p not in ALLOWED)
+    return sorted(files)
+
+
+def _raw_thread_constructions(path: Path) -> List[Tuple[int, str]]:
+    """Return (lineno, source-ish) for every ``threading.Thread(...)`` construction."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    hits = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # threading.Thread(...)
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "Thread"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "threading"
+        ):
+            hits.append((node.lineno, "threading.Thread"))
+        # from threading import Thread; Thread(...)
+        elif isinstance(func, ast.Name) and func.id == "Thread":
+            hits.append((node.lineno, "Thread"))
+    return hits
+
+
+def test_no_raw_threads_in_gui_code():
+    """No GUI module may start a bare thread — background work goes through FunctionWorker."""
+    offenders = []
+    for path in _gui_python_files():
+        for lineno, what in _raw_thread_constructions(path):
+            offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {what}(...)")
+    assert not offenders, (
+        "GUI background work must use fibsem.ui.qt.threading.FunctionWorker, which logs "
+        "failures and delivers its signals on the GUI thread:\n  " + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("relpath", MIGRATED_MODULES)
+def test_migrated_modules_use_function_worker(relpath: str):
+    """Each migrated widget still imports and uses FunctionWorker."""
+    src = (REPO_ROOT / relpath).read_text()
+    assert "from fibsem.ui.qt.threading import" in src, f"{relpath} lost its FunctionWorker import"
+    assert "FunctionWorker(" in src, f"{relpath} no longer constructs a FunctionWorker"
+
+
+def test_non_gui_layers_are_left_alone():
+    """FunctionWorker is a QObject, so Qt-free layers must keep their plain threads."""
+    for relpath in (
+        "fibsem/microscope.py",
+        "fibsem/fm/microscope.py",
+        "fibsem/applications/autolamella/workflows/tasks/hooks.py",
+    ):
+        src = (REPO_ROOT / relpath).read_text()
+        assert "FunctionWorker" not in src, (
+            f"{relpath} is Qt-free by design; importing FunctionWorker would drag Qt into it"
+        )


### PR DESCRIPTION
## Summary

#151 landed `fibsem/ui/qt/threading.py` and swapped every napari `@thread_worker` site onto
it, but the manual `threading.Thread` call sites were left behind. This finishes the job:
all background work started from the UI is now Qt-observable. Third stream extracted from
#111, ahead of the napari cutover.

A bare thread is invisible to Qt — it swallows exceptions into the interpreter's default
handler rather than surfacing them, and offers no signal marshalled back onto the GUI
thread. `FunctionWorker` logs every failure and delivers `started` / `returned` / `errored` /
`finished` on the thread that created it, while mirroring the slice of the `Thread` API these
sites already use (`start` / `is_alive` / `join`) — so the surrounding lifecycle code
(`is_acquiring`, `is_milling`, `is_workflow_running`, `join(timeout=5)`) is untouched.

| Module | Sites |
| --- | --- |
| `FMAcquisitionWidget` | 4 — stage move, single image, overview, autofocus |
| `fluorescence_coincidence_viewer_widget` | 9 — moves, FIB/FM acquires, autocontrast, autofocus |
| `fluorescence_control_widget` | 2 — image acquisition, autofocus |
| `FibsemMinimapWidget` | 1 — tile collection |
| `milling_widget` | 1 — milling task |
| `AutoLamellaUI` | 1 — task workflow |

## Bug fixed along the way

The coincidence viewer's FIB **autocontrast** and **autofocus** workers called
`btn.setText(...)` from inside the worker thread's `finally` block — a direct widget touch
off the GUI thread. Both now hang off `worker.finished`, which `FunctionWorker` delivers on
the GUI thread. This is the only behavioural change in the PR; everything else is mechanical.

## Deliberately excluded

`fibsem/microscope.py`, `fibsem/fm/microscope.py` and `workflows/tasks/hooks.py` keep their
plain threads. All three are Qt-free by design and `FunctionWorker` is a `QObject`, so
migrating them would drag Qt into non-GUI code. There is a test asserting they stay that way.

## Testing

- New `tests/ui/test_gui_thread_migration.py` — **under `tests/`, so CI actually runs it**
  (CI is `pytest tests/`, so a test under `fibsem/` would not be guarded). An AST scan asserts
  no GUI module constructs a bare `threading.Thread`, that each migrated widget still routes
  through `FunctionWorker`, and that the Qt-free layers are left alone. Mutation-tested:
  reintroducing a raw thread makes it fail with a pointed message, so it is not passing vacuously.
- `FunctionWorker`'s own semantics stay covered by the existing `tests/ui/test_qt_threading.py`.
- Verified the `setText` fix directly: worker body runs off-thread, the label reset lands on
  the GUI thread, button ends with the correct text.
- Driven in the running app (AutoLamella UI + FM acquisition UI) across the migrated surfaces.
- Full suite: 1332 passed, 15 skipped.
