### PR TITLE
Report the running git revision in the version string (FIB-349)

### DIFF
--- a/fibsem/applications/autolamella/__init__.py
+++ b/fibsem/applications/autolamella/__init__.py
@@ -1,5 +1,7 @@
-# try:
-#     import importlib.metadata
-#     __version__ = importlib.metadata.version('autolamella')
-# except ModuleNotFoundError:
-#     __version__ = "unknown"
+import fibsem
+
+# AutoLamella is not packaged separately — it ships inside the `fibsem`
+# distribution, so importlib.metadata.version('autolamella') raises
+# PackageNotFoundError. Its version is therefore fibsem's, which is what the
+# About dialog (fibsem/ui/utils.py) has always reported for it.
+__version__ = fibsem.__version__

--- a/fibsem/applications/autolamella/tools/bug_report.py
+++ b/fibsem/applications/autolamella/tools/bug_report.py
@@ -30,6 +30,7 @@ from urllib.parse import quote, urlencode
 
 import fibsem
 import fibsem.config as fibsem_cfg
+from fibsem.versioning import get_revision, get_version_string
 
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.structures import Experiment
@@ -80,6 +81,11 @@ def collect_system_context(
     """
     ctx: Dict[str, str] = {
         "fibsem_version": getattr(fibsem, "__version__", "unknown"),
+        # The commit, for source installs. Deliberately not the branch: branch
+        # names routinely embed usernames, which this function promises to omit
+        # and scrub_text cannot catch (it only strips the *local* user).
+        # Empty for a wheel install, and dropped by the filter below.
+        "fibsem_revision": get_revision() or "",
         "platform": platform.platform(),
         "python_version": platform.python_version(),
     }
@@ -348,7 +354,9 @@ def init_sentry() -> bool:
 
     sentry_sdk.init(
         dsn=dsn,
-        release=getattr(fibsem, "__version__", "unknown"),
+        # Version plus commit, so a crash group identifies the exact code. Never
+        # the branch: Sentry disallows forward slashes in release names.
+        release=get_version_string(),
         send_default_pii=False,
         before_send=_before_send,
     )

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -35,6 +35,7 @@ from superqt import ensure_main_thread
 from fibsem.ui.icon import fibsem_icon
 
 import fibsem
+from fibsem.versioning import get_version_string
 import fibsem.config as fibsem_cfg
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus, Lamella
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI, INSTRUCTIONS
@@ -141,7 +142,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def __init__(self):
         super().__init__()
-        self.setWindowTitle(f"AutoLamella v{fibsem.__version__} ")
+        self.setWindowTitle(f"AutoLamella v{get_version_string()} ")
         self.resize(1600, 1000)
 
         # Apply napari-style dark theme. Border state rules live here (on the parent)

--- a/fibsem/cli.py
+++ b/fibsem/cli.py
@@ -490,12 +490,38 @@ def _add_set_beam_parser(sub, conn) -> None:
     p.set_defaults(func=cmd_set_beam)
 
 
+class _VersionAction(argparse.Action):
+    """Print the version, revision and branch, then exit.
+
+    A custom action rather than ``action="version"`` so the git lookup happens
+    only when --version is actually passed, instead of on every CLI invocation.
+    It exits during parsing, before the required-subcommand check.
+    """
+
+    def __init__(self, option_strings, dest, **kwargs):
+        super().__init__(option_strings, dest, nargs=0, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        from fibsem.versioning import get_branch, get_version_string
+
+        print(f"fibsemOS {get_version_string()}")
+        branch = get_branch()
+        if branch:
+            print(f"branch: {branch}")
+        parser.exit()
+
+
 def _build_parser() -> argparse.ArgumentParser:
     conn = _build_connection_parser()
     root = argparse.ArgumentParser(
         prog="fibsem-cli",
         description="fibsemOS command-line interface for FIB/SEM microscope control",
         parents=[conn],
+    )
+    root.add_argument(
+        "--version",
+        action=_VersionAction,
+        help="Print the fibsemOS version and exit",
     )
     sub = root.add_subparsers(dest="subcommand", metavar="SUBCOMMAND")
     sub.required = True

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -17,6 +17,7 @@ from numpy.typing import NDArray
 from scipy.ndimage import median_filter, gaussian_filter
 
 import fibsem
+from fibsem.versioning import get_revision
 from fibsem.config import METADATA_VERSION, SUPPORTED_COORDINATE_SYSTEMS
 
 
@@ -1610,6 +1611,10 @@ class SystemInfo:
     fibsem_version: str = fibsem.__version__
     application: Optional[str] = None
     application_version: Optional[str] = None
+    # The commit actually running, when installed from a source checkout. None
+    # for a wheel install. default_factory, not a plain default, so the lookup
+    # happens on first use rather than at import of this module.
+    fibsem_revision: Optional[str] = field(default_factory=get_revision)
 
     def to_dict(self):
         return {
@@ -1623,6 +1628,7 @@ class SystemInfo:
             "fibsem_version": self.fibsem_version,
             "application": self.application,
             "application_version": self.application_version,
+            "fibsem_revision": self.fibsem_revision,
         }
 
     @staticmethod
@@ -1638,6 +1644,9 @@ class SystemInfo:
             fibsem_version=settings.get("fibsem_version", fibsem.__version__),
             application=settings.get("application", None),
             application_version=settings.get("application_version", None),
+            # `or`, not a .get() default: settings.get(k, get_revision()) would
+            # evaluate the lookup eagerly on every call.
+            fibsem_revision=settings.get("fibsem_revision") or get_revision(),
         )
 
 @dataclass
@@ -1743,10 +1752,16 @@ class MicroscopeSettings:
 class FibsemExperiment:
     id: Optional[str] = None
     method: Optional[str] = None
-    date: float = datetime.timestamp(datetime.now())
+    # default_factory, not a plain default: a plain default is evaluated once at
+    # class definition, so every experiment recorded the interpreter's import
+    # time rather than its own creation time.
+    date: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
     application: str = "fibsemOS"
     fibsem_version: str = fibsem.__version__
     application_version: Optional[str] = None
+    # The commit actually running, when installed from a source checkout. None
+    # for a wheel install.
+    fibsem_revision: Optional[str] = field(default_factory=get_revision)
 
     def to_dict(self) -> dict:
         """Converts to a dictionary."""
@@ -1757,6 +1772,7 @@ class FibsemExperiment:
             "application": self.application,
             "fibsem_version": self.fibsem_version,
             "application_version": self.application_version,
+            "fibsem_revision": self.fibsem_revision,
         }
 
     @staticmethod
@@ -1769,6 +1785,7 @@ class FibsemExperiment:
             application=settings.get("application", "fibsemOS"),
             fibsem_version=settings.get("fibsem_version", fibsem.__version__),
             application_version=settings.get("application_version", None),
+            fibsem_revision=settings.get("fibsem_revision") or get_revision(),
         )
 
 

--- a/fibsem/ui/FibsemEmbeddedDetectionWidget.py
+++ b/fibsem/ui/FibsemEmbeddedDetectionWidget.py
@@ -16,6 +16,7 @@ from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import QGridLayout, QLabel, QSizePolicy, QSpacerItem
 
 import fibsem
+from fibsem.versioning import get_version_string
 from fibsem.detection import detection
 from fibsem.detection import utils as det_utils
 from fibsem.detection.detection import DetectedFeatures
@@ -330,7 +331,7 @@ def main():
     viewer.window.add_dock_widget(
         det_widget_ui, area="right", 
         add_vertical_stretch=False, 
-        name=f"OpenFIBSEMv{fibsem.__version__} Feature Detection"
+        name=f"OpenFIBSEMv{get_version_string()} Feature Detection"
     )
     napari.run()
 

--- a/fibsem/ui/FibsemLabellingUI.py
+++ b/fibsem/ui/FibsemLabellingUI.py
@@ -17,6 +17,7 @@ from PyQt5 import QtWidgets
 from PyQt5.QtGui import QFont
 
 import fibsem
+from fibsem.versioning import get_version_string
 from fibsem.segmentation import utils as seg_utils
 from fibsem.segmentation.config import (
     CLASS_COLORS,
@@ -757,7 +758,7 @@ def main():
         fibsem_labelling_ui,
         area="right",
         add_vertical_stretch=True,
-        name=f"OpenFIBSEM v{fibsem.__version__} - Image Labelling",
+        name=f"OpenFIBSEM v{get_version_string()} - Image Labelling",
 
     )
     napari.run()

--- a/fibsem/ui/FibsemUI.py
+++ b/fibsem/ui/FibsemUI.py
@@ -3,6 +3,7 @@ from PyQt5 import QtWidgets
 from PyQt5.QtCore import pyqtSignal
 import napari.utils.notifications
 import fibsem
+from fibsem.versioning import get_version_string
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, MicroscopeSettings
 from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
@@ -20,10 +21,10 @@ class FibsemUI(FibsemUIMainWindow.Ui_MainWindow, QtWidgets.QMainWindow):
         super().__init__()
         self.setupUi(self)
 
-        self.label_title.setText(f"fibsemOS v{fibsem.__version__}")
+        self.label_title.setText(f"fibsemOS v{get_version_string()}")
 
         self.viewer = viewer
-        self.viewer.title = f"fibsemOS v{fibsem.__version__}"
+        self.viewer.title = f"fibsemOS v{get_version_string()}"
 
         self.microscope: FibsemMicroscope = None
         self.settings: MicroscopeSettings = None
@@ -157,7 +158,7 @@ def main():
     viewer.window.add_dock_widget(fibsem_ui, 
                                   area="right", 
                                   add_vertical_stretch=False, 
-                                  name=f"fibsemOS v{fibsem.__version__}")
+                                  name=f"fibsemOS v{get_version_string()}")
     napari.run()
 
 

--- a/fibsem/versioning.py
+++ b/fibsem/versioning.py
@@ -1,0 +1,182 @@
+"""Which version, and which commit, is actually running.
+
+``fibsem.__version__`` comes from installed package metadata, which for a source
+install is whatever ``pyproject.toml`` said at install time — or ``"unknown"``
+when the package was never pip-installed. Neither identifies the commit actually
+running, which is the common case for users who install from a clone and then
+``git pull``. This module adds that, by asking git about the checkout the
+package was imported from:
+
+* :func:`get_revision` — ``git describe`` of the running checkout, or ``None``
+* :func:`get_branch` — the checked-out branch, or ``None``
+* :func:`get_version_string` — packaged version plus revision, for display
+
+Never raises, never runs at import, never depends on the process cwd, and never
+writes to the user's repository. Results are cached for the lifetime of the
+process, so ``-dirty`` reflects the working tree as it was at the *first* call,
+i.e. what the session started with.
+"""
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+try:
+    from functools import cache
+except ImportError:  # Python < 3.9 fallback
+    from functools import lru_cache as cache
+
+_logger = logging.getLogger(__name__)
+
+# Small enough that a wedged git cannot visibly stall window construction, large
+# enough to survive a cold spawn behind on-access antivirus.
+_GIT_TIMEOUT_SECONDS = 2.0
+
+# These redirect git at a *different* repository and take precedence over the
+# cwd we pass, so a process launched from a git hook or pre-commit would report
+# the wrong revision. GIT_CEILING_DIRECTORIES is deliberately not scrubbed: it
+# only restricts git's upward search, which is harmless here (we have already
+# confirmed .git is in cwd) and lets the tests stay hermetic.
+_GIT_ENV_OVERRIDES = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+)
+
+# Windows-only: stops a console window flashing up when a GUI running under
+# pythonw.exe shells out. The constant is absent on other platforms, and
+# subprocess accepts creationflags=0 everywhere, so no platform branch is needed.
+_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+
+def _source_checkout_root() -> Optional[Path]:
+    """Return the repository root when running from a source checkout, else None.
+
+    Everything is inside the try: Path.exists() propagates PermissionError (it
+    only swallows ENOENT/ENOTDIR/EBADF/ELOOP), and __file__ and resolve() can
+    both fail under frozen or embedded interpreters.
+    """
+    try:
+        root = Path(__file__).resolve().parent.parent
+        # .git is a file in a git worktree and a directory in a normal clone, so
+        # test existence rather than is_dir(). pyproject.toml distinguishes our
+        # own checkout from an unrelated repo a wheel happens to be installed in.
+        if (root / ".git").exists() and (root / "pyproject.toml").exists():
+            return root
+    except Exception:
+        pass
+    return None
+
+
+def _run_git(*args: str) -> Optional[str]:
+    """Run ``git <args>`` in the source checkout, returning None on any failure."""
+    root = _source_checkout_root()
+    if root is None:
+        return None
+
+    try:
+        env = {k: v for k, v in os.environ.items() if k not in _GIT_ENV_OVERRIDES}
+        # --dirty refreshes the index, which normally takes .git/index.lock and
+        # writes the index back: a read-only version lookup would mutate the
+        # user's repository and collide with any git they run concurrently.
+        env["GIT_OPTIONAL_LOCKS"] = "0"
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(root),
+            capture_output=True,
+            # Not text=True: that decodes with the locale's preferred encoding,
+            # which raises UnicodeDecodeError on a legacy Windows code page when
+            # a branch name is non-ASCII.
+            encoding="utf-8",
+            errors="replace",
+            timeout=_GIT_TIMEOUT_SECONDS,
+            env=env,
+            creationflags=_NO_WINDOW,
+        )
+    except Exception as exc:
+        # git missing, spawn blocked, timeout, cwd vanished, ... Debug rather
+        # than warning: for a normal wheel install this path is the expected one,
+        # and a startup warning on every launch trains operators to ignore logs.
+        _logger.debug("git %s failed: %s", " ".join(args), exc)
+        return None
+
+    if result.returncode != 0:
+        _logger.debug(
+            "git %s exited %s: %s",
+            " ".join(args),
+            result.returncode,
+            result.stderr.strip(),
+        )
+        return None
+
+    return result.stdout.strip() or None
+
+
+@cache
+def _describe() -> Optional[str]:
+    # --always falls back to a bare short sha in a shallow or tagless clone,
+    # which is what CI produces (actions/checkout defaults to fetch-depth 1).
+    # Not --broken: that needs git >= 2.13, and on older git the whole command
+    # fails, losing the revision entirely.
+    #
+    # Cached because FibsemImageMetadata builds a FibsemExperiment for every
+    # acquired image — without this that would be one git fork per image.
+    return _run_git("describe", "--tags", "--always", "--dirty")
+
+
+@cache
+def _branch() -> Optional[str]:
+    # symbolic-ref rather than `rev-parse --abbrev-ref HEAD`: on a detached HEAD
+    # this exits non-zero with empty output, which _run_git already handles,
+    # instead of printing the literal string "HEAD".
+    return _run_git("symbolic-ref", "--quiet", "--short", "HEAD")
+
+
+def get_revision() -> Optional[str]:
+    """Return ``git describe`` of the running checkout, or None.
+
+    For example ``"v0.5.1-48-g4cd11d9c"``, ``"v0.5.1-48-g4cd11d9c-dirty"``, or a
+    bare ``"4cd11d9c"`` in a clone with no tags. None for a wheel install, or on
+    any failure. Cached: the first call forks git, later calls are free.
+    """
+    return _describe()
+
+
+def get_branch() -> Optional[str]:
+    """Return the checked-out branch, or None (detached HEAD, or not a checkout).
+
+    Deliberately not part of :func:`get_version_string`: it costs a second fork,
+    adds nothing to the identity of the running code, and branch names routinely
+    embed usernames — so it must not reach the bug report or Sentry.
+    """
+    return _branch()
+
+
+def get_version_string() -> str:
+    """Return the version for display. Never raises, never returns None.
+
+    ``"0.5.2.dev0 (v0.5.1-48-g4cd11d9c)"`` from a source checkout, plain
+    ``"0.5.2.dev0"`` otherwise. The parenthesised form is deliberately not
+    PEP 440 — a reader should not be tempted to hand it to
+    ``packaging.version.parse``.
+    """
+    try:
+        import fibsem
+
+        version = getattr(fibsem, "__version__", None) or "unknown"
+    except Exception:
+        version = "unknown"
+
+    # Independent guard: a failure in the git half must never cost the caller the
+    # package version it would otherwise have got.
+    try:
+        revision = _describe()
+    except Exception:
+        revision = None
+
+    return "{} ({})".format(version, revision) if revision else version

--- a/scripts/test_installation.py
+++ b/scripts/test_installation.py
@@ -11,7 +11,12 @@ def main():
     except ImportError:
         FIBSEM_AVAILABLE = False
     if FIBSEM_AVAILABLE:
-        print(f"OpenFIBSEM v{fibsem.__version__}")
+        from fibsem.versioning import get_branch, get_version_string
+
+        print(f"OpenFIBSEM v{get_version_string()}")
+        branch = get_branch()
+        if branch:
+            print(f"Branch: {branch}")
         print(f"Installed at: {fibsem.__path__}")
     
     print(f"-" * 80)
@@ -23,8 +28,10 @@ def main():
     except ImportError: 
         AUTOLAMELLA_AVAILABLE = False
     if AUTOLAMELLA_AVAILABLE:
-        print(f"AutoLamella v{autolamella.__version__}")
-        print(f"Installed at: {autolamella.__path__}")   
+        # getattr rather than direct access: this script exists to report what is
+        # installed, so a package that omits __version__ must not abort the report.
+        print(f"AutoLamella v{getattr(autolamella, '__version__', 'unknown')}")
+        print(f"Installed at: {autolamella.__path__}")
     
     try: 
         import salami
@@ -32,7 +39,7 @@ def main():
     except ImportError:
         SALAMI_AVAILABLE = False
     if SALAMI_AVAILABLE:
-        print(f"SALAMI v{salami.__version__}")
+        print(f"SALAMI v{getattr(salami, '__version__', 'unknown')}")
         print(f"Installed at: {salami.__path__}")
     print(f"-" * 80)
     

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -472,3 +472,66 @@ def test_fibsem_image_load_sets_filepath(tmp_path):
     loaded = FibsemImage.load(written)
 
     assert loaded.filepath == written
+
+
+# fibsem_revision — the running commit, recorded alongside fibsem_version
+
+
+def test_experiment_and_system_info_carry_fibsem_revision():
+    from fibsem.structures import FibsemExperiment, SystemInfo
+
+    assert "fibsem_revision" in FibsemExperiment().to_dict()
+    assert "fibsem_revision" in SystemInfo.from_dict({}).to_dict()
+
+
+def test_metadata_from_dict_accepts_pre_change_files():
+    """Saved data written before fibsem_revision existed must still load."""
+    from fibsem.structures import FibsemExperiment, SystemInfo
+
+    legacy_experiment = {
+        "id": "exp-1",
+        "method": "autolamella",
+        "date": 1700000000.0,
+        "application": "fibsemOS",
+        "fibsem_version": "0.5.1",
+        "application_version": "0.5.1",
+    }
+    experiment = FibsemExperiment.from_dict(legacy_experiment)
+    assert experiment.id == "exp-1"
+    assert experiment.fibsem_version == "0.5.1"
+
+    legacy_info = {"name": "Test", "manufacturer": "Demo", "fibsem_version": "0.5.1"}
+    info = SystemInfo.from_dict(legacy_info)
+    assert info.name == "Test"
+    assert info.fibsem_version == "0.5.1"
+
+
+def test_metadata_round_trips_fibsem_revision():
+    from fibsem.structures import FibsemExperiment, SystemInfo
+
+    experiment = FibsemExperiment.from_dict(
+        {"id": "exp-1", "fibsem_revision": "v0.5.1-48-g4cd11d9c"}
+    )
+    assert experiment.fibsem_revision == "v0.5.1-48-g4cd11d9c"
+    assert (
+        FibsemExperiment.from_dict(experiment.to_dict()).fibsem_revision
+        == "v0.5.1-48-g4cd11d9c"
+    )
+
+    info = SystemInfo.from_dict({"fibsem_revision": "v0.5.1-48-g4cd11d9c"})
+    assert info.fibsem_revision == "v0.5.1-48-g4cd11d9c"
+
+
+def test_experiment_date_is_creation_time_not_import_time():
+    """A plain dataclass default would freeze this at module-import time."""
+    import time
+
+    from fibsem.structures import FibsemExperiment
+
+    before = datetime.datetime.timestamp(datetime.datetime.now())
+    time.sleep(0.01)
+    experiment = FibsemExperiment()
+    time.sleep(0.01)
+    after = datetime.datetime.timestamp(datetime.datetime.now())
+
+    assert before < experiment.date < after

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,366 @@
+"""Tests for the git revision lookup.
+
+The overriding requirement for fibsem.versioning is that it can never raise:
+it runs inside a desktop application driving microscope hardware, where a
+version-string lookup taking down the app is unacceptable. Most of what follows
+is therefore failure-mode coverage rather than happy-path coverage.
+"""
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from fibsem import versioning
+from fibsem.versioning import get_branch, get_revision, get_version_string
+
+# The repository root as seen from *this file*, not from fibsem.__file__: in CI
+# the package is pip-installed into site-packages, so the real lookup correctly
+# returns None there while the checkout is still on disk at the workspace root.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Either `v0.5.1-48-g4cd11d9c` from a tagged clone, or a bare short sha from a
+# shallow/tagless one (which is what actions/checkout produces by default),
+# each optionally suffixed `-dirty`.
+DESCRIBE_RE = re.compile(r"^(.+-g)?[0-9a-f]{7,40}(-dirty)?$")
+
+
+def _clear_caches():
+    # Tests that monkeypatch _describe/_branch wholesale replace them with plain
+    # functions, and monkeypatch may not have restored them by the time this runs
+    # on teardown — so clear only if there is a cache to clear. The setup-side
+    # call is the load-bearing one; a replaced function never populated the real
+    # cache in the first place.
+    for name in ("_describe", "_branch"):
+        clear = getattr(getattr(versioning, name), "cache_clear", None)
+        if clear is not None:
+            clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_revision_caches():
+    """Drop the process-global caches around every test.
+
+    _describe and _branch are cached for the lifetime of the interpreter, and
+    `pytest -n auto --dist worksteal` reuses worker processes across tests, so
+    without this a stubbed result leaks into whichever test runs next.
+    """
+    _clear_caches()
+    yield
+    _clear_caches()
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["git"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+# --- happy path ------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not (REPO_ROOT / ".git").exists(),
+    reason="not running from a source checkout",
+)
+def test_revision_and_branch_from_real_checkout(monkeypatch):
+    """Read a real repository, from a working directory outside it.
+
+    tests/conftest.py chdirs every test into its own tmp_path, so this only
+    passes if the lookup honours the explicit cwd= it derives from __file__
+    rather than the process cwd.
+    """
+    monkeypatch.setattr(versioning, "_source_checkout_root", lambda: REPO_ROOT)
+
+    revision = get_revision()
+    assert revision is not None
+    assert DESCRIBE_RE.match(revision), revision
+
+    # Cross-check against git itself rather than hardcoding a sha.
+    head = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    ).stdout.strip()
+    assert head in revision
+
+    # Branch is None on a detached HEAD, which is legitimate; when present it
+    # must not be the literal "HEAD" that `rev-parse --abbrev-ref` would give.
+    branch = get_branch()
+    assert branch != "HEAD"
+
+
+def test_version_string_includes_revision_in_checkout(monkeypatch):
+    monkeypatch.setattr(versioning, "_describe", lambda: "v0.5.1-48-g4cd11d9c")
+
+    import fibsem
+
+    assert get_version_string() == f"{fibsem.__version__} (v0.5.1-48-g4cd11d9c)"
+
+
+# --- not a checkout --------------------------------------------------------
+
+
+def test_no_checkout_does_not_fork(monkeypatch):
+    """A wheel install must take the zero-fork fast path."""
+    calls = []
+
+    def _record_and_boom(*args, **kwargs):
+        calls.append(args)
+        raise AssertionError("subprocess.run must not be reached")
+
+    monkeypatch.setattr(versioning, "_source_checkout_root", lambda: None)
+    monkeypatch.setattr(versioning.subprocess, "run", _record_and_boom)
+
+    assert get_revision() is None
+    assert get_branch() is None
+    assert calls == []
+
+
+def test_directory_that_is_not_a_repo(monkeypatch, tmp_path):
+    """git exits non-zero; we return None rather than propagating."""
+    # Keep git from walking up out of tmp_path and finding a real repo, which
+    # would otherwise make this depend on where TMPDIR happens to live. This is
+    # why GIT_CEILING_DIRECTORIES is excluded from the scrubbed variables.
+    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(tmp_path.parent))
+    monkeypatch.setattr(versioning, "_source_checkout_root", lambda: tmp_path)
+
+    assert get_revision() is None
+    assert get_branch() is None
+
+
+def test_source_checkout_root_requires_both_markers(monkeypatch, tmp_path):
+    """.git alone is not enough — an unrelated enclosing repo must not match."""
+    # Pretend the package lives at <tmp_path>/fibsem/versioning.py, so the root
+    # the module derives from __file__ is tmp_path.
+    monkeypatch.setattr(
+        versioning, "__file__", str(tmp_path / "fibsem" / "versioning.py")
+    )
+
+    assert versioning._source_checkout_root() is None  # neither marker
+
+    (tmp_path / ".git").mkdir()
+    assert versioning._source_checkout_root() is None  # .git but no pyproject
+
+    (tmp_path / "pyproject.toml").touch()
+    assert versioning._source_checkout_root() == tmp_path  # both
+
+
+def test_source_checkout_root_accepts_worktree_git_file(monkeypatch, tmp_path):
+    """.git is a *file* in a git worktree, so the guard cannot use is_dir()."""
+    monkeypatch.setattr(
+        versioning, "__file__", str(tmp_path / "fibsem" / "versioning.py")
+    )
+    (tmp_path / ".git").write_text("gitdir: /elsewhere/.git/worktrees/wt\n")
+    (tmp_path / "pyproject.toml").touch()
+
+    assert versioning._source_checkout_root() == tmp_path
+
+
+# --- failure modes ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        FileNotFoundError(2, "No such file or directory: 'git'"),
+        subprocess.TimeoutExpired(cmd=["git"], timeout=2.0),
+        PermissionError(13, "Permission denied"),
+        RuntimeError("kaboom"),
+    ],
+    ids=["git-missing", "timeout", "spawn-blocked", "arbitrary"],
+)
+def test_subprocess_failures_return_none(monkeypatch, exc):
+    def _boom(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr(versioning, "_source_checkout_root", lambda: REPO_ROOT)
+    monkeypatch.setattr(versioning.subprocess, "run", _boom)
+
+    assert get_revision() is None
+    assert get_branch() is None
+
+
+@pytest.mark.parametrize(
+    "completed",
+    [
+        _completed(returncode=128, stderr="fatal: not a git repository"),
+        _completed(returncode=1, stdout=""),
+        _completed(returncode=0, stdout="   \n"),
+    ],
+    ids=["rc-128", "rc-1-empty", "rc-0-whitespace"],
+)
+def test_unusable_git_output_returns_none(monkeypatch, completed):
+    monkeypatch.setattr(versioning, "_source_checkout_root", lambda: REPO_ROOT)
+    monkeypatch.setattr(versioning.subprocess, "run", lambda *a, **k: completed)
+
+    assert get_revision() is None
+    assert get_branch() is None
+
+
+def test_root_lookup_survives_permission_error(monkeypatch):
+    """Path.exists() propagates EACCES — the guard must be inside the try."""
+
+    def _boom(self):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(versioning.Path, "exists", _boom)
+
+    assert versioning._source_checkout_root() is None
+    assert get_revision() is None
+
+
+# --- command construction --------------------------------------------------
+
+
+def test_branch_uses_symbolic_ref(monkeypatch):
+    """Pins the detached-HEAD decision.
+
+    `rev-parse --abbrev-ref HEAD` prints the literal string "HEAD" when detached;
+    `symbolic-ref --quiet` exits 1 with no output, which _run_git already maps to
+    None. Assert the argv so nobody silently swaps it back.
+    """
+    seen = {}
+
+    def _capture(argv, **kwargs):
+        seen["argv"] = argv
+        return _completed(returncode=1, stdout="")
+
+    monkeypatch.setattr(versioning, "_source_checkout_root", lambda: REPO_ROOT)
+    monkeypatch.setattr(versioning.subprocess, "run", _capture)
+
+    assert get_branch() is None
+    assert seen["argv"] == ["git", "symbolic-ref", "--quiet", "--short", "HEAD"]
+
+
+def test_describe_argv(monkeypatch):
+    seen = {}
+
+    def _capture(argv, **kwargs):
+        seen["argv"] = argv
+        return _completed(returncode=0, stdout="v0.5.1-48-g4cd11d9c\n")
+
+    monkeypatch.setattr(versioning, "_source_checkout_root", lambda: REPO_ROOT)
+    monkeypatch.setattr(versioning.subprocess, "run", _capture)
+
+    assert get_revision() == "v0.5.1-48-g4cd11d9c"
+    assert seen["argv"] == ["git", "describe", "--tags", "--always", "--dirty"]
+
+
+def test_environment_is_scrubbed(monkeypatch):
+    """GIT_DIR and friends override cwd=, so they must not reach the child."""
+    seen = {}
+
+    def _capture(argv, **kwargs):
+        seen.update(kwargs)
+        return _completed(returncode=0, stdout="abc1234\n")
+
+    monkeypatch.setenv("GIT_DIR", "/nope/.git")
+    monkeypatch.setenv("GIT_WORK_TREE", "/nope")
+    monkeypatch.setattr(versioning, "_source_checkout_root", lambda: REPO_ROOT)
+    monkeypatch.setattr(versioning.subprocess, "run", _capture)
+
+    assert get_revision() == "abc1234"
+
+    env = seen["env"]
+    assert "GIT_DIR" not in env
+    assert "GIT_WORK_TREE" not in env
+    # Read-only lookup must not take .git/index.lock, which --dirty otherwise does.
+    assert env["GIT_OPTIONAL_LOCKS"] == "0"
+    # Guards against anyone "simplifying" to a minimal env, which breaks git on
+    # Windows (no SystemRoot) and anywhere git is not on the default PATH.
+    assert "PATH" in env
+    assert seen["timeout"] == versioning._GIT_TIMEOUT_SECONDS
+    assert seen["cwd"] == str(REPO_ROOT)
+
+
+# --- caching ---------------------------------------------------------------
+
+
+def test_repeated_calls_fork_once(monkeypatch):
+    calls = []
+
+    def _count(*args):
+        calls.append(args)
+        return "v0.5.1-48-g4cd11d9c"
+
+    monkeypatch.setattr(versioning, "_run_git", _count)
+
+    for _ in range(5):
+        assert get_revision() == "v0.5.1-48-g4cd11d9c"
+    assert len(calls) == 1
+
+
+def test_metadata_construction_forks_once(monkeypatch):
+    """FibsemImageMetadata builds a FibsemExperiment per acquired image.
+
+    Without the cache on _describe that would be one git fork per image, which is
+    the regression this test exists to prevent.
+    """
+    from fibsem.structures import FibsemExperiment
+
+    calls = []
+
+    def _count(*args):
+        calls.append(args)
+        return "v0.5.1-48-g4cd11d9c"
+
+    monkeypatch.setattr(versioning, "_run_git", _count)
+
+    experiments = [FibsemExperiment() for _ in range(50)]
+
+    assert len(calls) == 1
+    assert all(e.fibsem_revision == "v0.5.1-48-g4cd11d9c" for e in experiments)
+
+
+# --- logging ---------------------------------------------------------------
+
+
+def test_failure_is_logged_quietly(monkeypatch, caplog):
+    """For a wheel install "no git" is the normal case, so it must not warn."""
+
+    def _boom(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory: 'git'")
+
+    monkeypatch.setattr(versioning, "_source_checkout_root", lambda: REPO_ROOT)
+    monkeypatch.setattr(versioning.subprocess, "run", _boom)
+
+    with caplog.at_level(logging.WARNING, logger="fibsem.versioning"):
+        assert get_revision() is None
+    assert caplog.records == []
+
+    caplog.clear()
+    _clear_caches()
+
+    # ... but the diagnostics must not be silently discarded either.
+    with caplog.at_level(logging.DEBUG, logger="fibsem.versioning"):
+        assert get_revision() is None
+    assert any("git describe" in r.getMessage() for r in caplog.records)
+
+
+# --- the hard requirement --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "describe",
+    [
+        pytest.param(lambda: (_ for _ in ()).throw(RuntimeError("kaboom")), id="raises"),
+        pytest.param(lambda: None, id="none"),
+        pytest.param(lambda: "v0.5.1-48-g4cd11d9c", id="value"),
+    ],
+)
+def test_version_string_never_raises_and_never_returns_none(monkeypatch, describe):
+    import fibsem
+
+    monkeypatch.setattr(versioning, "_describe", describe)
+
+    result = get_version_string()
+
+    assert isinstance(result, str)
+    assert result
+    # A failure in the git half must never cost the caller the package version.
+    assert result.startswith(fibsem.__version__)


### PR DESCRIPTION
Closes FIB-349.

`fibsem.__version__` comes from installed package metadata, which for a source install is whatever `pyproject.toml` said at install time (`0.5.2.dev0`) — or literally `"unknown"` when the package was never pip-installed. For the many users who `pip install -e .` from a clone and then `git pull`, every install reported the same string regardless of which commit was running. Bug reports and saved metadata could not be traced back to code, and we could not tell whether someone was on the v0.5.1 release or 48 commits past it.

## What this adds

`fibsem/versioning.py` asks git about the checkout the package was imported from:

| function | returns |
|---|---|
| `get_revision()` | `git describe --tags --always --dirty`, e.g. `v0.5.1-48-g4cd11d9c-dirty` |
| `get_branch()` | the checked-out branch, or `None` when detached |
| `get_version_string()` | `0.5.2.dev0 (v0.5.1-48-g4cd11d9c)` for display |

Surfaced in the six window titles, the bug report (`fibsem_revision`), the Sentry release tag, a new `fibsem-cli --version`, `scripts/test_installation.py`, and a new `fibsem_revision` field on `SystemInfo` and `FibsemExperiment`.

## Why runtime and not setuptools-scm

Deliberate, and tracked separately as FIB-350. A build-time version is baked at install time, so it goes stale the moment an editable install is pulled — which is precisely the case this addresses. setuptools-scm also answers "what commit was this *built* from", not "what commit is *running*". It has been attempted twice in this repo (`64663d7b`, `d9ec523f`) and abandoned at a release commit (`f832c655`), because it fails the *build* rather than degrading: `pip install .` dies outright with no git binary, no `.git`, or a `safe.directory` mismatch.

## It cannot raise

That is the hard requirement — this runs in a desktop app driving microscope hardware. Every entry point returns a sentinel on failure, and `get_version_string()` is typed `-> str` with no path that returns `None`. Covered: git missing, not a checkout, not a repo, detached HEAD, shallow/tagless clone, empty repo, `safe.directory` refusal, timeout, non-UTF8 branch name, spawn blocked, corrupt `.git`, unreadable root.

Three details are load-bearing and worth a reviewer's eye:

- The `.git` guard tests `.exists()`, **not** `.is_dir()` — `.git` is a *file* in a git worktree, so `is_dir()` would silently disable this for anyone using one.
- That guard lives *inside* the `try`, because `Path.exists()` propagates `PermissionError` (it only swallows ENOENT/ENOTDIR/EBADF/ELOOP).
- `cwd` is derived from `__file__`, never the process cwd. Users launch the app from arbitrary directories, and `tests/conftest.py` chdirs every test into a tmp dir.

Also: `GIT_DIR` and friends are scrubbed from the child environment (they override `cwd=` and would report a different repo when launched from a git hook), and `GIT_OPTIONAL_LOCKS=0` stops a read-only lookup from taking `.git/index.lock` — `--dirty` otherwise refreshes and rewrites the index, which would both mutate the user's repository and collide with a concurrent `git`.

`symbolic-ref` rather than `rev-parse --abbrev-ref HEAD`, since the latter prints the literal string `"HEAD"` on a detached checkout instead of failing cleanly.

## Cost

Lazy and cached. `import fibsem` stays fork-free at ~25 ms; `import fibsem.structures` likewise. `FibsemImageMetadata` builds a `FibsemExperiment` per acquired image, so the cache is what keeps that at **one** git call per process rather than one per image — pinned by a test. Both new dataclass fields use `field(default_factory=...)` for the same reason.

`fibsem/__init__.py` is untouched: `__version__` stays PEP 440-valid, so `check_for_updates()` keeps parsing it, and the display string uses parentheses precisely so nobody is tempted to feed it to `packaging.version.parse`.

## Metadata compatibility

`fibsem_revision` is additive and both `from_dict` methods already use `.get()` with defaults, so pre-change saved YAML and TIFF metadata load unchanged (there is a test). `METADATA_VERSION` does not need a bump.

## Two adjacent bugs fixed

- `FibsemExperiment.date` was a plain dataclass default, evaluated once at class definition, so every experiment recorded the interpreter's *import* time rather than its own creation time.
- `fibsem.applications.autolamella` had its `__version__` block commented out, so `scripts/test_installation.py` crashed partway through with `AttributeError`. AutoLamella is not packaged separately — it ships inside the `fibsem` distribution — so its version is fibsem's.

## Testing

`tests/test_versioning.py` covers the happy path against a real repo, not-a-repo, the zero-fork fast path for wheel installs, git missing / timeout / arbitrary exception, non-zero returncode and whitespace-only stdout, exact argv for both commands, environment scrubbing, caching (including 50 `FibsemExperiment` constructions producing one fork), quiet logging, and that `get_version_string()` never raises and never returns `None`.

Full suite: 1350 passed, 15 skipped.