### PR TITLE
[ui] Rebuild the about dialog in the napari style (FIB-365)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -806,13 +806,10 @@ class AutoLamellaUI(QMainWindow):
     #### PROTOCOL EDITOR
 
     def open_information_dialog(self) -> None:
-        if self.microscope is None:
-            notification_service.show_toast(
-                "Please connect to a microscope first... [No Microscope Connected]",
-                "warning",
-            )
-            return
-        fui.open_information_dialog(self.microscope, self)
+        # No connection guard: checking which version you are running is exactly
+        # what you want to do *before* connecting. The dialog drops the
+        # microscope section when there is nothing to report.
+        fui.open_information_dialog(self.microscope, self, application="AutoLamella")
 
     def _open_experiment_directory(self) -> None:
         """Open the experiment directory in the system file explorer."""

--- a/fibsem/ui/utils.py
+++ b/fibsem/ui/utils.py
@@ -317,42 +317,15 @@ def open_text_input_dialog(
     )
     return text, okPressed
 
-def open_information_dialog(microscope: FibsemMicroscope, parent: Optional[QWidget] = None):
-    import fibsem
-    
-    fibsem_version = fibsem.__version__
-    from fibsem.structures import SystemInfo
-    if microscope is None:
-        msg = QMessageBox(parent)
-        msg.setWindowTitle("fibsemOS Information")
-        msg.setText(f"fibsemOS: {fibsem_version}\n\nNo microscope connected.")
-        msg.exec()
-        return
-    info: SystemInfo = microscope.system.info
+def open_information_dialog(
+    microscope: Optional[FibsemMicroscope] = None,
+    parent: Optional[QWidget] = None,
+    application: str = "fibsemOS",
+):
+    """Show the about dialog. Works with or without a connected microscope."""
+    from fibsem.ui.widgets.about_dialog import open_about_dialog
 
-    text = f"""
-    fibsemOS Information:
-    fibsemOS: {fibsem_version}
-    AutoLamella: {fibsem_version}
-
-    Microscope Information:
-    Name: {info.name}
-    Manufacturer: {info.manufacturer}
-    Model: {info.model}
-    Serial Number: {info.serial_number}
-    Firmware Version: {info.hardware_version}
-    Software Version: {info.software_version}
-    """
-
-    # create a qdialog box with information
-    msg = QtWidgets.QMessageBox(parent=parent)
-    msg.setIcon(QtWidgets.QMessageBox.Information)
-    msg.setWindowTitle("Information")
-    msg.setText(text)
-    msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
-
-    # exec
-    msg.exec_()
+    open_about_dialog(microscope=microscope, application=application, parent=parent)
 
 
 

--- a/fibsem/ui/widgets/about_dialog.py
+++ b/fibsem/ui/widgets/about_dialog.py
@@ -1,0 +1,297 @@
+"""
+About dialog: what version, what commit, what microscope, what environment.
+
+Its job is to answer "what am I actually running" well enough to paste into a
+bug report, so every value is selectable and the copy button in the header puts
+the whole thing on the clipboard as plain text.
+"""
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.versioning import get_branch, get_revision
+from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.stylesheets import SECONDARY_BUTTON_STYLESHEET
+
+if TYPE_CHECKING:
+    from fibsem.microscope import FibsemMicroscope
+
+# Palette (matching fibsem.ui.stylesheets napari theme)
+_BG = "#262930"
+_PANEL = "#1e2027"
+_BORDER = "#3d4251"
+_TEXT = "#d6d6d6"
+_TEXT_STRONG = "#f0f1f2"
+_TEXT_MUTED = "#868e93"
+_MONO = "Menlo, Consolas, 'DejaVu Sans Mono', monospace"
+
+# Characters of the serial number left visible; the rest is masked so a
+# screenshot or clipboard paste does not disclose the full number.
+_SERIAL_VISIBLE_CHARS = 4
+
+_UNKNOWN = "Unknown"
+
+
+def mask_serial_number(serial: Optional[str]) -> str:
+    """Mask all but the leading characters of a serial number.
+
+    Enough of the prefix survives to tell two machines apart in a support
+    thread, without publishing the whole number. Separators are preserved so the
+    result keeps the shape of the original (``8372-1194`` -> ``8372-****``).
+    """
+    if not serial:
+        return _UNKNOWN
+    serial = str(serial).strip()
+    if not serial:
+        return _UNKNOWN
+    if len(serial) <= _SERIAL_VISIBLE_CHARS:
+        return "*" * len(serial)
+    masked = [
+        char if char.isalnum() is False else "*"
+        for char in serial[_SERIAL_VISIBLE_CHARS:]
+    ]
+    return serial[:_SERIAL_VISIBLE_CHARS] + "".join(masked)
+
+
+def _environment_rows() -> List[Tuple[str, str]]:
+    """Python / Qt / napari / platform, reusing the bug report's collector.
+
+    Imported lazily and defensively: this dialog must still open if the
+    autolamella application package is unavailable for any reason.
+    """
+    try:
+        from fibsem.applications.autolamella.tools.bug_report import (
+            collect_system_context,
+        )
+
+        ctx = collect_system_context()
+    except Exception:
+        import platform
+
+        ctx = {
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+        }
+
+    rows = [
+        ("Python", ctx.get("python_version", _UNKNOWN)),
+        ("Qt", ctx.get("PyQt5", _UNKNOWN)),
+        ("napari", ctx.get("napari", _UNKNOWN)),
+        ("Platform", ctx.get("platform", _UNKNOWN)),
+    ]
+    return [(k, v) for k, v in rows if v != _UNKNOWN] or rows
+
+
+class AboutDialog(QDialog):
+    """Modal 'about' dialog for fibsemOS and the application hosting it."""
+
+    def __init__(
+        self,
+        microscope: Optional["FibsemMicroscope"] = None,
+        application: str = "fibsemOS",
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(parent)
+        self.setWindowTitle("About fibsemOS")
+        self.setStyleSheet(f"QDialog {{ background-color: {_BG}; }}")
+        self.setMinimumWidth(470)
+
+        self._sections: List[Tuple[str, List[Tuple[str, str]]]] = []
+
+        import fibsem
+
+        version = getattr(fibsem, "__version__", None) or _UNKNOWN
+        revision = get_revision()
+        branch = get_branch()
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(18, 16, 18, 14)
+        layout.setSpacing(12)
+
+        layout.addLayout(self._build_header())
+
+        meta = QLabel(f"{version}   ·   {revision}" if revision else version)
+        meta.setStyleSheet(
+            f"color: {_TEXT_MUTED}; font-size: 12px; font-family: {_MONO};"
+        )
+        meta.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        layout.addWidget(meta)
+
+        software = [("Application", application)]
+        # Only meaningful for a source install; a wheel install has neither.
+        if revision:
+            software.append(("Revision", revision))
+        if branch:
+            software.append(("Branch", branch))
+        layout.addWidget(
+            self._build_section(
+                "Software", software, mono_keys={"Revision", "Branch"}
+            )
+        )
+
+        microscope_rows = self._microscope_rows(microscope)
+        if microscope_rows:
+            layout.addWidget(
+                self._build_section(
+                    "Microscope",
+                    microscope_rows,
+                    mono_keys={"Serial number", "Firmware", "Software"},
+                )
+            )
+
+        layout.addWidget(
+            self._build_section(
+                "Environment",
+                _environment_rows(),
+                mono_keys={"Python", "Qt", "napari", "Platform"},
+            )
+        )
+
+        layout.addSpacing(2)
+        footer = QHBoxLayout()
+        footer.addStretch()
+        close_button = QPushButton("Close")
+        close_button.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
+        close_button.clicked.connect(self.accept)
+        footer.addWidget(close_button)
+        layout.addLayout(footer)
+
+    # -- construction helpers ------------------------------------------------
+
+    def _build_header(self) -> QHBoxLayout:
+        header = QHBoxLayout()
+        header.setContentsMargins(0, 0, 0, 0)
+
+        title = QLabel("fibsemOS")
+        title.setStyleSheet(
+            f"font-size: 18px; font-weight: 600; color: {_TEXT_STRONG};"
+        )
+        header.addWidget(title)
+        header.addStretch()
+
+        self.copy_button = QToolButton()
+        self.copy_button.setIcon(fibsem_icon("mdi:content-copy", color=_TEXT_MUTED))
+        self.copy_button.setToolTip("Copy details to clipboard")
+        self.copy_button.setCursor(Qt.PointingHandCursor)
+        self.copy_button.setAutoRaise(True)
+        self.copy_button.setStyleSheet(
+            "QToolButton { border: none; padding: 4px; border-radius: 3px; }"
+            f"QToolButton:hover {{ background-color: {_PANEL}; }}"
+        )
+        self.copy_button.clicked.connect(self._copy_to_clipboard)
+        header.addWidget(self.copy_button, 0, Qt.AlignTop)
+        return header
+
+    @staticmethod
+    def _microscope_rows(
+        microscope: Optional["FibsemMicroscope"],
+    ) -> List[Tuple[str, str]]:
+        """Rows for the connected microscope, or empty when there is none.
+
+        Never raises: an About dialog that cannot open because the microscope is
+        in a bad state is worse than one missing a section.
+        """
+        if microscope is None:
+            return []
+        try:
+            info = microscope.system.info
+        except Exception:
+            return []
+        return [
+            ("Name", str(getattr(info, "name", _UNKNOWN))),
+            ("Manufacturer", str(getattr(info, "manufacturer", _UNKNOWN))),
+            ("Model", str(getattr(info, "model", _UNKNOWN))),
+            ("Serial number", mask_serial_number(getattr(info, "serial_number", None))),
+            ("Firmware", str(getattr(info, "hardware_version", _UNKNOWN))),
+            ("Software", str(getattr(info, "software_version", _UNKNOWN))),
+        ]
+
+    def _build_section(
+        self, title: str, rows: List[Tuple[str, str]], mono_keys=frozenset()
+    ) -> QWidget:
+        self._sections.append((title, rows))
+
+        box = QWidget()
+        column = QVBoxLayout(box)
+        column.setContentsMargins(0, 0, 0, 0)
+        column.setSpacing(6)
+
+        heading = QLabel(title.upper())
+        heading.setStyleSheet(
+            f"color: {_TEXT_MUTED}; font-size: 10px; font-weight: 600;"
+            " letter-spacing: 1px;"
+        )
+        column.addWidget(heading)
+
+        rule = QFrame()
+        rule.setFrameShape(QFrame.HLine)
+        rule.setStyleSheet(
+            f"color: {_BORDER}; background-color: {_BORDER}; max-height: 1px;"
+        )
+        column.addWidget(rule)
+
+        grid = QGridLayout()
+        grid.setContentsMargins(0, 2, 0, 0)
+        grid.setHorizontalSpacing(16)
+        grid.setVerticalSpacing(4)
+        grid.setColumnStretch(1, 1)
+        for row, (key, value) in enumerate(rows):
+            key_label = QLabel(key)
+            key_label.setStyleSheet(f"color: {_TEXT_MUTED}; font-size: 12px;")
+            value_label = QLabel(value)
+            font = (
+                f"font-family: {_MONO}; font-size: 11px;"
+                if key in mono_keys
+                else "font-size: 12px;"
+            )
+            value_label.setStyleSheet(f"color: {_TEXT}; {font}")
+            value_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+            grid.addWidget(key_label, row, 0, Qt.AlignTop)
+            grid.addWidget(value_label, row, 1, Qt.AlignTop)
+        column.addLayout(grid)
+        return box
+
+    # -- copy ----------------------------------------------------------------
+
+    def as_text(self) -> str:
+        """Everything on screen, as plain text.
+
+        Exactly what is displayed, so the masked serial number stays masked.
+        """
+        lines: List[str] = []
+        for title, rows in self._sections:
+            if lines:
+                lines.append("")
+            lines.append(f"{title}:")
+            width = max((len(key) for key, _ in rows), default=0)
+            for key, value in rows:
+                lines.append(f"  {key.ljust(width)}  {value}")
+        return "\n".join(lines)
+
+    def _copy_to_clipboard(self) -> None:
+        clipboard = QApplication.clipboard()
+        if clipboard is None:  # pragma: no cover - no display
+            return
+        clipboard.setText(self.as_text())
+        self.copy_button.setToolTip("Copied")
+
+
+def open_about_dialog(
+    microscope: Optional["FibsemMicroscope"] = None,
+    application: str = "fibsemOS",
+    parent: Optional[QWidget] = None,
+) -> None:
+    """Show the about dialog modally."""
+    AboutDialog(microscope=microscope, application=application, parent=parent).exec_()

--- a/tests/ui/test_about_dialog.py
+++ b/tests/ui/test_about_dialog.py
@@ -1,0 +1,91 @@
+"""Tests for the About dialog."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from fibsem.ui.widgets.about_dialog import AboutDialog, mask_serial_number
+
+
+def _fake_microscope(serial="8372-1194"):
+    info = SimpleNamespace(
+        name="METEOR",
+        manufacturer="Thermo Fisher",
+        model="Helios 5 UX",
+        serial_number=serial,
+        hardware_version="1.7.2",
+        software_version="4.13.0",
+    )
+    return SimpleNamespace(system=SimpleNamespace(info=info))
+
+
+@pytest.mark.parametrize(
+    "serial, expected",
+    [
+        ("8372-1194", "8372-****"),
+        ("ABCD1234567", "ABCD*******"),
+        ("SN/2024/0091", "SN/2***/****"),  # separators survive
+        ("12", "**"),  # shorter than the visible prefix
+        ("", "Unknown"),
+        (None, "Unknown"),
+        ("   ", "Unknown"),
+    ],
+)
+def test_mask_serial_number(serial, expected):
+    assert mask_serial_number(serial) == expected
+
+
+def _rows(dialog):
+    """Every displayed key/value, flattened across sections."""
+    return {key: value for _, section in dialog._sections for key, value in section}
+
+
+def test_disconnected_dialog_has_no_microscope_section(qapp):
+    dialog = AboutDialog(application="fibsemOS")
+
+    titles = [title for title, _ in dialog._sections]
+    assert "Microscope" not in titles
+    assert titles[0] == "Software"
+    assert _rows(dialog)["Application"] == "fibsemOS"
+
+
+def test_connected_dialog_shows_masked_serial(qapp):
+    dialog = AboutDialog(microscope=_fake_microscope(), application="AutoLamella")
+
+    rows = _rows(dialog)
+    assert rows["Name"] == "METEOR"
+    assert rows["Serial number"] == "8372-****"
+    assert rows["Application"] == "AutoLamella"
+
+
+def test_copied_text_never_contains_the_full_serial(qapp):
+    dialog = AboutDialog(microscope=_fake_microscope(), application="AutoLamella")
+
+    text = dialog.as_text()
+
+    assert "8372-1194" not in text
+    assert "8372-****" in text
+    # what you see is what you copy
+    assert "METEOR" in text and "AutoLamella" in text
+
+
+def test_microscope_section_skipped_when_info_unavailable(qapp):
+    """A microscope in a bad state must not stop the dialog from opening."""
+
+    class _Boom:
+        @property
+        def system(self):
+            raise RuntimeError("disconnected mid-call")
+
+    dialog = AboutDialog(microscope=_Boom(), application="AutoLamella")
+
+    assert "Microscope" not in [title for title, _ in dialog._sections]
+
+
+def test_environment_section_is_present(qapp):
+    dialog = AboutDialog(application="fibsemOS")
+
+    titles = [title for title, _ in dialog._sections]
+    assert "Environment" in titles
+    env = dict(dict(dialog._sections)["Environment"])
+    assert "Python" in env


### PR DESCRIPTION
Closes FIB-365.

> **Stacked on #202.** Based on `patrick/fib-349-git-revision-in-version-string`, because `about_dialog.py` imports `fibsem.versioning`. Review #202 first; I will retarget this to `main` once it merges. The diff shown here is the 4 files below.

## Before

`open_information_dialog` was a raw `QMessageBox` wrapping a triple-quoted f-string:

- The f-string starts with a newline and carries four spaces of *source* indentation into every rendered line, so the dialog opened with a blank line and everything shifted right.
- It printed the same version twice under two names — `fibsemOS:` and `AutoLamella:` both rendered the same value, which reads as a bug even though the values genuinely match.
- No Python / Qt / napari versions, despite the dialog existing to answer "what am I running" — while `collect_system_context()` in the bug report tooling already collected exactly those.
- Connected and disconnected duplicated the whole structure across two branches, with different window titles (`"fibsemOS Information"` vs `"Information"`) and `exec()` vs `exec_()`.
- It did not follow the house style set by `WorkflowSummaryDialog`, so it read as a default-Qt bolt-on next to the rest of the app.

## After

An `AboutDialog` widget using the napari palette from `fibsem/ui/stylesheets.py`: title with a copy-to-clipboard icon in the header, muted version + revision meta line, and `Software` / `Microscope` / `Environment` sections.

Sections are **omitted rather than emptied**, from a single code path — the disconnected dialog is 470x334 against 470x485 connected. Every value is individually selectable.

Environment rows reuse `collect_system_context()`, so the About dialog and the bug report cannot drift apart. That import is lazy and guarded: the dialog still opens if the autolamella package is unavailable, falling back to stdlib `platform`.

## Serial number

Masked to its first four characters, with separators preserved (`8372-1194` -> `8372-****`). Copy emits exactly what is displayed, so the masked form is what reaches the clipboard and, from there, a public issue. `collect_system_context` already deliberately omits the serial; this keeps the two consistent.

## Application identifier

The `Application` row names which app is running, passed in by the caller — `AutoLamellaUI` passes `"AutoLamella"`, the default is `"fibsemOS"`. This keeps the title as the platform name rather than having it shift depending on entry point.

## Behaviour change worth flagging

`AutoLamellaUI.open_information_dialog` previously refused to open when no microscope was connected and showed a warning toast instead. That guard is gone — checking which version you are running is exactly what you want to do *before* connecting, and the dialog now handles the disconnected case by design.

## Robustness

Reading `microscope.system.info` is wrapped: a microscope in a bad state drops the section rather than stopping the dialog from opening. There is a test using a property that raises mid-call.

## What is deliberately absent

The branch name. It is surfaced in this dialog and in `scripts/test_installation.py`, but never in the bug report or the Sentry release tag: branch names routinely embed usernames (which `collect_system_context` promises to exclude, and `scrub_text` cannot catch since it only strips the *local* user), and Sentry disallows forward slashes in release names.

## Testing

`tests/ui/test_about_dialog.py` covers serial masking (separators, over-long, too-short, empty, `None`, whitespace-only), both dialog states, the masked serial reaching `as_text()` while the raw one never does, and the microscope section being skipped when info is unavailable.

Full suite on this branch: 1362 passed, 15 skipped. Rendered offscreen with live data to confirm layout.