### PR TITLE
[ui] Resolve the fibsem.ui widget exports lazily (FIB-352)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -40,7 +40,7 @@ import fibsem.config as fibsem_cfg
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus, Lamella
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI, INSTRUCTIONS
 from fibsem.applications.autolamella.workflows.tasks.tasks import get_task_supervision
-from fibsem.ui import FibsemMinimapWidget
+from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
 from fibsem.ui.qt.gc import install_main_thread_gc
 from fibsem.ui.stylesheets import (
     MILLING_PROGRESS_BAR_STYLESHEET,

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -28,17 +28,14 @@ from fibsem.structures import (
     MicroscopeSettings,
     Point,
 )
-from fibsem.ui import (
-    DETECTION_AVAILABLE,
-    FibsemCryoDepositionWidget,
-    FibsemImageSettingsWidget,
-    FibsemMinimapWidget,
-    FibsemMovementWidget,
-    FibsemSystemSetupWidget,
-    FibsemSpotBurnWidget,
-    MillingTaskViewerWidget,
-    stylesheets,
-)
+from fibsem.ui import DETECTION_AVAILABLE, stylesheets
+from fibsem.ui.FibsemCryoDepositionWidget import FibsemCryoDepositionWidget
+from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
+from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
+from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
+from fibsem.ui.FibsemSpotBurnWidget import FibsemSpotBurnWidget
+from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
+from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 from fibsem.ui.FMAcquisitionWidget import open_fm_acquisition_dialog
 from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.fm.widgets import FMImageViewerWidget

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -54,7 +54,8 @@ from fibsem.structures import (
     OverviewAcquisitionSettings,
     Point,
 )
-from fibsem.ui import FibsemMovementWidget, stylesheets
+from fibsem.ui import stylesheets
+from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
 from fibsem.ui import utils as ui_utils
 from fibsem.ui.napari.patterns import COLOURS as MILLING_PATTERN_COLOURS
 from fibsem.ui.qt.threading import FunctionWorker

--- a/fibsem/ui/__init__.py
+++ b/fibsem/ui/__init__.py
@@ -1,17 +1,127 @@
-from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
-from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
-from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
-from fibsem.ui.FibsemCryoDepositionWidget import FibsemCryoDepositionWidget
-from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
-from fibsem.ui.FibsemManipulatorWidget import FibsemManipulatorWidget
-from fibsem.ui.FibsemSpotBurnWidget import FibsemSpotBurnWidget
-from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
+"""Lazy re-exports for the fibsem UI widgets.
 
-try:
+Importing these eagerly meant that reaching *any* module under ``fibsem.ui`` — including
+leaves with no display code, such as ``fibsem.ui.qt.threading`` — executed this file and so
+imported every widget, one of which imports napari. Resolving the names on first access
+(PEP 562) lets Qt-free and napari-free modules be imported on their own.
+
+**Prefer importing from the concrete module** (``from fibsem.ui.FibsemMovementWidget import
+FibsemMovementWidget``), which is what code in this repo now does.
+
+The re-exports are kept, and keep returning the *class*. That needs one piece of machinery:
+each widget class shares its name with the module defining it, and Python binds an imported
+submodule as an attribute of its package — so once ``fibsem.ui.FibsemMovementWidget`` (the
+module) has been imported by anything, that name would resolve to the module, and PEP 562's
+``__getattr__`` would never run because the attribute is no longer missing. The eager version
+papered over this by overwriting the attribute with the class at import time. ``_LazyExports``
+below restores that guarantee by unwrapping the shadowing module on access.
+"""
+import importlib
+import sys
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # keep static analysis and IDEs resolving the names
+    from fibsem.ui.FibsemCryoDepositionWidget import FibsemCryoDepositionWidget
     from fibsem.ui.FibsemEmbeddedDetectionWidget import FibsemEmbeddedDetectionUI
-    DETECTION_AVAILABLE = True
-except ImportError:
-    DETECTION_AVAILABLE = False
-    import logging
-    logging.debug("Could not import FibsemEmbeddedDetectionWidget")
+    from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
+    from fibsem.ui.FibsemManipulatorWidget import FibsemManipulatorWidget
+    from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
+    from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
+    from fibsem.ui.FibsemSpotBurnWidget import FibsemSpotBurnWidget
+    from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
+    from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 
+# exported name -> module that defines it
+_WIDGETS = {
+    "FibsemImageSettingsWidget": "fibsem.ui.FibsemImageSettingsWidget",
+    "FibsemMovementWidget": "fibsem.ui.FibsemMovementWidget",
+    "FibsemSystemSetupWidget": "fibsem.ui.FibsemSystemSetupWidget",
+    "FibsemCryoDepositionWidget": "fibsem.ui.FibsemCryoDepositionWidget",
+    "FibsemMinimapWidget": "fibsem.ui.FibsemMinimapWidget",
+    "FibsemManipulatorWidget": "fibsem.ui.FibsemManipulatorWidget",
+    "FibsemSpotBurnWidget": "fibsem.ui.FibsemSpotBurnWidget",
+    "MillingTaskViewerWidget": "fibsem.ui.widgets.milling_task_viewer_widget",
+    # Optional — needs the segmentation stack; see _OPTIONAL and DETECTION_AVAILABLE.
+    "FibsemEmbeddedDetectionUI": "fibsem.ui.FibsemEmbeddedDetectionWidget",
+}
+
+# Requires optional dependencies (torch et al). The eager __init__ imported it under
+# try/except ImportError, so the name simply did not exist when the stack was missing.
+# It is therefore kept out of __all__: advertising it unconditionally would make
+# ``from fibsem.ui import *`` and ``inspect.getmembers`` force the import and raise.
+_OPTIONAL = "FibsemEmbeddedDetectionUI"
+
+__all__ = [n for n in _WIDGETS if n != _OPTIONAL] + ["DETECTION_AVAILABLE"]
+
+_detection: "bool | None" = None  # memoised; the probe import is not cheap
+
+
+def _resolve(name: str):
+    """Import the module that defines *name* and return the attribute itself."""
+    return getattr(importlib.import_module(_WIDGETS[name]), name)
+
+
+def _detection_available() -> bool:
+    global _detection
+    if _detection is None:
+        try:
+            _resolve(_OPTIONAL)
+        except ImportError:
+            import logging
+
+            logging.debug("Could not import FibsemEmbeddedDetectionWidget")
+            _detection = False
+        else:
+            _detection = True
+    return _detection
+
+
+def __getattr__(name: str):
+    """Resolve an export on first access, then cache it in the module namespace."""
+    if name == "DETECTION_AVAILABLE":
+        value = _detection_available()
+    elif name in _WIDGETS:
+        try:
+            value = _resolve(name)
+        except ImportError:
+            if name != _OPTIONAL:
+                raise
+            # Mirror the eager behaviour: the name is absent, not broken. AttributeError
+            # (not ImportError) keeps hasattr/getmembers/dir degrading gracefully.
+            raise AttributeError(
+                f"{name!r} is unavailable: the optional segmentation dependencies are "
+                f"not installed (see fibsem.ui.DETECTION_AVAILABLE)"
+            ) from None
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    globals()[name] = value  # cache — __getattr__ runs once per name
+    return value
+
+
+def __dir__():
+    names = {*globals(), *__all__}
+    if _detection_available():  # memoised, so dir() stays cheap after the first call
+        names.add(_OPTIONAL)
+    return sorted(names)
+
+
+class _LazyExports(ModuleType):
+    """Module type that unwraps a submodule shadowing an exported class name.
+
+    ``ModuleType.__getattribute__`` already falls back to the module-level ``__getattr__``
+    above when a name is missing, so PEP 562 still does the lazy loading. This only fixes
+    the case where the name is *present* but bound to the submodule.
+    """
+
+    def __getattribute__(self, name):
+        value = ModuleType.__getattribute__(self, name)
+        if name in _WIDGETS and isinstance(value, ModuleType):
+            value = _resolve(name)  # the class, not the module that defines it
+            ModuleType.__setattr__(self, name, value)
+        return value
+
+
+# _WIDGETS / _resolve are read from this module's globals inside __getattribute__ (not via
+# self), so there is no recursion.
+sys.modules[__name__].__class__ = _LazyExports

--- a/fibsem/ui/widgets/milling_task_viewer_widget.py
+++ b/fibsem/ui/widgets/milling_task_viewer_widget.py
@@ -29,7 +29,7 @@ from fibsem.ui.widgets.milling_task_config_widget2 import MillingTaskConfigWidge
 from fibsem.ui.widgets.milling_widget import FibsemMillingWidget2
 
 if TYPE_CHECKING:
-    from fibsem.ui import FibsemImageSettingsWidget
+    from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
 
 
 def _apply_diff_to_pattern(pattern, diff: Point) -> None:

--- a/tests/ui/test_lazy_ui_exports.py
+++ b/tests/ui/test_lazy_ui_exports.py
@@ -1,0 +1,115 @@
+"""The ``fibsem.ui`` package must not drag napari in just to be imported.
+
+Its ``__init__`` used to import all eight widgets eagerly, one of which imports napari, so
+reaching *any* module under ``fibsem.ui`` — including Qt-free leaves — pulled napari into the
+graph. The exports are resolved lazily now (PEP 562).
+
+The first four tests import nothing but ``fibsem.ui`` itself and so **run on CI**, which
+installs neither PyQt5 nor napari — that is the regression worth guarding. The two that need a
+real widget class are skipped there, like every other UI test. The skip is a decorator rather
+than a module-level ``importorskip`` precisely so the CI-relevant tests still run.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+try:  # only the last two tests need Qt
+    import PyQt5  # noqa: F401
+
+    HAS_QT = True
+except ImportError:
+    HAS_QT = False
+
+needs_qt = pytest.mark.skipif(not HAS_QT, reason="needs PyQt5 (not installed on CI)")
+
+
+def _probe(body: str) -> str:
+    """Run *body* in a fresh interpreter and return its last stdout line.
+
+    Runs from the repo root so ``fibsem`` resolves to *this* checkout — an editable install
+    otherwise maps it to the main working copy, and the probe would silently test that tree
+    instead. Only the last line is returned because importing ``fibsem`` prints a
+    configuration banner.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", body],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT), "QT_QPA_PLATFORM": "offscreen"},
+    )
+    assert result.returncode == 0, f"probe failed:\n{result.stdout}\n{result.stderr}"
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert lines, f"probe produced no output:\n{result.stderr}"
+    return lines[-1].strip()
+
+
+def test_importing_the_package_needs_neither_napari_nor_qt():
+    """`import fibsem.ui` must be free of both — the CI-relevant guarantee."""
+    out = _probe(
+        "import sys, fibsem.ui;"
+        "print('napari' in sys.modules, 'PyQt5' in sys.modules)"
+    )
+    assert out == "False False", f"expected no napari and no Qt, got {out!r}"
+
+
+def test_unknown_attribute_raises_attribute_error():
+    """A typo must not surface as an ImportError from some unrelated widget."""
+    out = _probe(
+        "import fibsem.ui\n"
+        "try:\n"
+        "    fibsem.ui.NoSuchWidget\n"
+        "except AttributeError:\n"
+        "    print('AttributeError')\n"
+    )
+    assert out == "AttributeError"
+
+
+def test_dir_still_advertises_the_exports():
+    out = _probe(
+        "import fibsem.ui;"
+        "d = dir(fibsem.ui);"
+        "print(all(n in d for n in ('FibsemMinimapWidget', 'MillingTaskViewerWidget', 'DETECTION_AVAILABLE')))"
+    )
+    assert out == "True"
+
+
+def test_detection_available_is_a_plain_bool():
+    """Computed on first access now; it must still be a bool, not a lazy proxy."""
+    out = _probe("from fibsem.ui import DETECTION_AVAILABLE as d; print(type(d).__name__)")
+    assert out == "bool"
+
+
+@needs_qt
+def test_reexport_resolves_to_the_class():
+    out = _probe(
+        "import inspect;"
+        "from fibsem.ui import FibsemMovementWidget as W;"
+        "print(inspect.isclass(W))"
+    )
+    assert out == "True"
+
+
+@needs_qt
+def test_reexport_is_the_class_even_when_the_submodule_shadows_it():
+    """Each widget class shares its name with the module that defines it.
+
+    Importing ``fibsem.ui.FibsemMovementWidget`` binds that *module* onto the package under
+    the same name, which bypasses PEP 562's ``__getattr__`` entirely — the attribute is no
+    longer missing. The eager ``__init__`` used to overwrite it with the class; the lazy one
+    restores that guarantee by unwrapping the module on access. Without it, callers get a
+    module and ``FibsemMovementWidget(...)`` fails with "module is not callable".
+    """
+    out = _probe(
+        "import inspect\n"
+        "import fibsem.ui.FibsemMovementWidget  # binds the MODULE onto the package\n"
+        "from fibsem.ui import FibsemMovementWidget as W\n"
+        "print(inspect.isclass(W))\n"
+    )
+    assert out == "True", "a shadowing submodule leaked through the re-export"

--- a/tests/ui/test_lazy_ui_exports.py
+++ b/tests/ui/test_lazy_ui_exports.py
@@ -86,6 +86,52 @@ def test_detection_available_is_a_plain_bool():
     assert out == "bool"
 
 
+def test_optional_export_is_absent_rather_than_broken():
+    """FibsemEmbeddedDetectionUI needs optional deps (torch et al).
+
+    The eager ``__init__`` imported it under ``try/except ImportError``, so when the stack
+    was missing the name simply did not exist. Resolving it lazily must degrade the same
+    way — ``AttributeError``, not the underlying ``ModuleNotFoundError`` — or ``hasattr``,
+    ``dir`` and ``inspect.getmembers`` all blow up on an optional dependency.
+    """
+    out = _probe(
+        "import fibsem.ui\n"
+        "try:\n"
+        "    fibsem.ui.FibsemEmbeddedDetectionUI\n"
+        "    print('resolved')\n"
+        "except AttributeError:\n"
+        "    print('AttributeError')\n"
+        "except ImportError as exc:\n"
+        "    print('LEAKED ImportError:', exc)\n"
+    )
+    assert out in ("resolved", "AttributeError"), out
+
+
+@needs_qt
+def test_star_import_does_not_force_optional_dependencies():
+    """`from fibsem.ui import *` must not explode when the segmentation stack is absent.
+
+    Regression: listing the optional export in ``__all__`` made star-import resolve it and
+    raise ModuleNotFoundError, where the eager version worked fine.
+    """
+    out = _probe(
+        "ns = {}\n"
+        "exec('from fibsem.ui import *', ns)\n"
+        "print('FibsemMovementWidget' in ns)\n"
+    )
+    assert out == "True"
+
+
+@needs_qt
+def test_getmembers_does_not_force_optional_dependencies():
+    """Same regression, reached through introspection rather than star-import."""
+    out = _probe(
+        "import inspect, fibsem.ui;"
+        "print('FibsemMovementWidget' in dict(inspect.getmembers(fibsem.ui)))"
+    )
+    assert out == "True"
+
+
 @needs_qt
 def test_reexport_resolves_to_the_class():
     out = _probe(


### PR DESCRIPTION
Closes FIB-352.

## Summary

`fibsem/ui/__init__.py` imported all eight widgets at module level, and one of them
(`FibsemImageSettingsWidget`) imports napari. Because importing a submodule runs its package's
`__init__` first, reaching **any** module under `fibsem.ui` — including Qt-free leaves like
`fibsem.ui.qt.threading` — pulled in every widget, and napari with them.

| | before | after |
| --- | --- | --- |
| `import fibsem.ui` → napari / Qt loaded | True / True | **False / False** |
| `import fibsem.ui.qt.threading` → napari | True | **False** |
| `import fibsem.ui.widgets.canvas` → napari | True | **False** |

The widgets still import napari — you just stop paying for it when importing something
unrelated.

## Why this matters for the napari deprecation

A widget can be made napari-free in its own source (as #200 did for the manipulator) and, until
now, there was no way to demonstrate it: the package init dragged napari in regardless. This
makes "is this widget napari-free?" answerable by import, which is the verification story for
the rest of the cutover.

It does **not** make the UI tests run on CI — CI installs `.[test]` and the workflow says the
`[ui]` extra is omitted deliberately, so anything importing a Qt object still skips. What it
does buy is that genuinely Qt-free modules become importable there and can be tested directly.

## The one subtlety

Each widget class shares its name with the module defining it, and Python binds an imported
submodule as an attribute of its package. So once `fibsem.ui.FibsemMovementWidget` (the module)
has been imported by anything, that name is no longer *missing* — PEP 562's `__getattr__` never
runs, callers get a module, and `FibsemMovementWidget(...)` fails with "module is not callable".
The eager version papered over this by overwriting the attribute with the class at import time.

`_LazyExports` restores the guarantee by unwrapping the shadowing module on access, so the
re-exports behave exactly as they did. There is a test for precisely this ordering.

Internal callers now import from the concrete module instead — clearer, and unambiguous. Only
four sites used the re-exports.

## Side effects checked

Each in a fresh interpreter, with import order controlled:

- `DETECTION_AVAILABLE` — `False` before and after (it is computed on first access now, and is
  still a plain `bool`);
- `dir()` still advertises every export;
- an unknown attribute raises `AttributeError`, not an `ImportError` surfacing from some
  unrelated widget;
- re-exports resolve to the **class**, in both clean and shadowed import order;
- all five importable entry points still import (`FibsemUI`, `AutoLamellaMainUI`,
  `FMAcquisitionWidget`, `microscope_config_widget`, `correlation_tab_widget`);
- no star-imports of `fibsem.ui` exist anywhere to worry about.

**Not fixed, and not caused by this**: constructing the AutoLamella main window under
`QT_QPA_PLATFORM=offscreen` segfaults in vispy's GL context. Identical exit code (139) on `main`
— a pre-existing offscreen napari limitation.

## Testing

New `tests/ui/test_lazy_ui_exports.py`. Four of its six tests import nothing but `fibsem.ui`, so
they **run on CI** — the Qt skip is a decorator rather than a module-level `importorskip`, which
would skip the whole file including the part that matters there. Verified by re-running with
`napari`/`PyQt5`/`qtpy`/`superqt` blocked via a `sys.meta_path` finder: 4 passed, 2 skipped.

Full suite: 1337 passed, 15 skipped (up 6).
