### PR TITLE
[test] Guard the about-dialog test's Qt import (main is red)

### DIFF
--- a/tests/ui/test_about_dialog.py
+++ b/tests/ui/test_about_dialog.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 
 import pytest
 
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
 from fibsem.ui.widgets.about_dialog import AboutDialog, mask_serial_number
 
 


### PR DESCRIPTION
**`main` is currently red.** One line fixes it.

`tests/ui/test_about_dialog.py` (added in #203) imports `fibsem.ui.widgets.about_dialog` at
module level with no `importorskip`, so collection fails on CI:

```
ImportError while importing test module '.../tests/ui/test_about_dialog.py'
E   ModuleNotFoundError: No module named 'PyQt5'
```

CI installs `.[test]` only, and the workflow says the omission is deliberate:

```
# UI deps (the [ui] extra) are intentionally not installed: the
# napari/PyQt5 tests importorskip and are skipped on CI.
```

This adds the same module-level `pytest.importorskip("PyQt5")` that every other UI test file
under `tests/` already uses, so the module skips on CI instead of erroring.

## Verification

- With PyQt5, napari, qtpy and superqt blocked via a `sys.meta_path` finder — simulating the CI
  environment — the whole `tests/` directory runs clean: **1079 passed, 30 skipped, no
  collection errors**. Without this change it errors out.
- Locally, where PyQt5 is present, the test still runs and passes: **12 passed**. The guard only
  affects environments that lack Qt.

Failing runs for reference: `cb120124` on `main`, and every PR branched from it since.
