### PR TITLE
Show an update-available indicator in the about dialog (FIB-366)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1728,6 +1728,27 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             app.quit()
 
 
+def _start_update_check() -> None:
+    """Ask PyPI about newer releases on a worker thread, once, at startup.
+
+    Startup rather than on dialog open: the about dialog reads the cached result,
+    so it stays instant and offline-safe by construction, and the latency lands
+    where nothing is waiting on it. A no-op for source installs and when the user
+    has opted out, so the common developer case makes no network call at all.
+    """
+    from fibsem import update_check
+    from fibsem.ui.qt.threading import thread_worker
+
+    if not update_check.is_enabled():
+        return
+
+    @thread_worker
+    def _check() -> None:
+        update_check.refresh()
+
+    _check().start()
+
+
 def run_ui():
     """Run the AutoLamella embedded example."""
     import faulthandler
@@ -1757,6 +1778,7 @@ def run_ui():
     gc_collector = install_main_thread_gc(parent=app)  # noqa: F841 — kept alive for app lifetime
     window = AutoLamellaSingleWindowUI()
     window.show()
+    _start_update_check()
     sys.exit(app.exec_())
 
 

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -284,6 +284,13 @@ class ReportingPreferences:
     contact_email: str = ""
     crash_reporting_enabled: bool = False
     sentry_dsn: str = ""
+    # Grouped with crash reporting because it is the same question: may the
+    # application make outbound network calls? Opt-in for the same reason —
+    # these run on instrument PCs, sometimes on institutional networks where an
+    # unannounced connection at startup is a compliance question and the
+    # operator would have no idea it was happening. Skipped entirely for source
+    # installs regardless of this setting (see fibsem.update_check.is_enabled).
+    update_check_enabled: bool = False
 
 @dataclass
 class UserPreferences:

--- a/fibsem/ui/widgets/about_dialog.py
+++ b/fibsem/ui/widgets/about_dialog.py
@@ -5,9 +5,10 @@ Its job is to answer "what am I actually running" well enough to paste into a
 bug report, so every value is selectable and the copy button in the header puts
 the whole thing on the clipboard as plain text.
 """
+import logging
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import QSize, Qt
 from PyQt5.QtWidgets import (
     QApplication,
     QDialog,
@@ -24,6 +25,9 @@ from PyQt5.QtWidgets import (
 from fibsem.versioning import get_branch, get_revision
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.stylesheets import SECONDARY_BUTTON_STYLESHEET
+from fibsem.ui.widgets.custom_widgets import IconToolButton, _SpinnerLabel
+
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
@@ -35,6 +39,8 @@ _BORDER = "#3d4251"
 _TEXT = "#d6d6d6"
 _TEXT_STRONG = "#f0f1f2"
 _TEXT_MUTED = "#868e93"
+_ACCENT = "#50a6ff"
+_OK = "#4caf50"
 _MONO = "Menlo, Consolas, 'DejaVu Sans Mono', monospace"
 
 # Characters of the serial number left visible; the rest is masked so a
@@ -109,6 +115,9 @@ class AboutDialog(QDialog):
         self.setMinimumWidth(470)
 
         self._sections: List[Tuple[str, List[Tuple[str, str]]]] = []
+        # Set once the dialog is dismissed, so a still-running update check can
+        # tell that there is nothing left to render into.
+        self._closed = False
 
         import fibsem
 
@@ -122,12 +131,18 @@ class AboutDialog(QDialog):
 
         layout.addLayout(self._build_header())
 
+        meta_row = QHBoxLayout()
+        meta_row.setContentsMargins(0, 0, 0, 0)
+        meta_row.setSpacing(7)
         meta = QLabel(f"{version}   ·   {revision}" if revision else version)
         meta.setStyleSheet(
             f"color: {_TEXT_MUTED}; font-size: 12px; font-family: {_MONO};"
         )
         meta.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        layout.addWidget(meta)
+        meta_row.addWidget(meta)
+        meta_row.addWidget(self._build_update_slot())
+        meta_row.addStretch()
+        layout.addLayout(meta_row)
 
         software = [("Application", application)]
         # Only meaningful for a source install; a wheel install has neither.
@@ -193,6 +208,142 @@ class AboutDialog(QDialog):
         self.copy_button.clicked.connect(self._copy_to_clipboard)
         header.addWidget(self.copy_button, 0, Qt.AlignTop)
         return header
+
+    # -- the update slot -----------------------------------------------------
+    #
+    # One slot beside the version does three jobs in sequence: offer a manual
+    # check, report it in flight, then show the outcome. What it starts as
+    # depends on whether the opt-in background check already ran.
+
+    def _build_update_slot(self) -> QWidget:
+        self._update_slot = QWidget()
+        row = QHBoxLayout(self._update_slot)
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(7)
+        try:
+            self._render_initial_update_state()
+        except Exception:
+            # A broken update check must never stop the dialog from opening.
+            _logger.debug("Could not build the update slot", exc_info=True)
+        return self._update_slot
+
+    def _set_update_slot(self, *widgets: QWidget) -> None:
+        row = self._update_slot.layout()
+        while row.count():
+            item = row.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.setParent(None)
+                widget.deleteLater()
+        for widget in widgets:
+            row.addWidget(widget)
+
+    def _render_initial_update_state(self) -> None:
+        from fibsem import update_check
+
+        if not update_check.is_supported():
+            return  # source install: a PyPI comparison would be meaningless
+
+        latest = update_check.get_available_update()
+        if latest:
+            # The background check already found something actionable.
+            self._render_update_available(latest)
+        else:
+            # Deliberately not "up to date" — the background check reports only
+            # the actionable case. "Up to date" is an answer to a question, and
+            # nobody has asked one yet.
+            self._render_check_button()
+
+    def _render_check_button(self) -> None:
+        button = IconToolButton(
+            icon="mdi:refresh",
+            color=_TEXT_MUTED,
+            tooltip="Check for updates",
+        )
+        button.setIconSize(QSize(14, 14))
+        button.clicked.connect(self._start_update_check)
+        self._set_update_slot(button)
+
+    def _render_update_available(self, latest: str) -> None:
+        icon = QLabel()
+        icon.setPixmap(
+            fibsem_icon("mdi:arrow-up-circle", color=_ACCENT).pixmap(13, 13)
+        )
+        note = QLabel(f"{latest} available")
+        note.setStyleSheet(f"color: {_ACCENT}; font-size: 12px;")
+        note.setToolTip(f"fibsemOS {latest} is available on PyPI")
+        self._set_update_slot(icon, note)
+
+    def _render_up_to_date(self) -> None:
+        icon = QLabel()
+        icon.setPixmap(fibsem_icon("mdi:check-circle", color=_OK).pixmap(13, 13))
+        # Muted text: the tick carries the signal, and this is a non-event.
+        note = QLabel("up to date")
+        note.setStyleSheet(f"color: {_TEXT_MUTED}; font-size: 12px;")
+        self._set_update_slot(icon, note)
+
+    def _render_check_failed(self) -> None:
+        icon = QLabel()
+        icon.setPixmap(
+            fibsem_icon("mdi:cloud-off-outline", color=_TEXT_MUTED).pixmap(13, 13)
+        )
+        note = QLabel("could not check")
+        note.setStyleSheet(f"color: {_TEXT_MUTED}; font-size: 12px;")
+        note.setToolTip("Could not reach PyPI")
+        # Keep the button: a failed check is exactly when you want to retry, and
+        # a transient network blip should not remove the affordance.
+        retry = IconToolButton(
+            icon="mdi:refresh", color=_TEXT_MUTED, tooltip="Try again"
+        )
+        retry.setIconSize(QSize(14, 14))
+        retry.clicked.connect(self._start_update_check)
+        self._set_update_slot(icon, note, retry)
+
+    def _start_update_check(self) -> None:
+        """Run a user-requested check off the GUI thread."""
+        from fibsem import update_check
+        from fibsem.ui.qt.threading import thread_worker
+
+        spinner = _SpinnerLabel(size=14, step_deg=30, color=_TEXT_MUTED)
+        note = QLabel("checking…")
+        note.setStyleSheet(f"color: {_TEXT_MUTED}; font-size: 12px;")
+        self._set_update_slot(spinner, note)
+        spinner.start()
+
+        @thread_worker
+        def _run():
+            # force: the user clicked, so the opt-in preference does not apply.
+            return update_check.refresh(force=True)
+
+        worker = _run()
+        worker.returned.connect(self._on_update_check_returned)
+        worker.errored.connect(lambda _exc: self._on_update_check_returned(None))
+        worker.start()
+
+    def _on_update_check_returned(self, status) -> None:
+        """Render the outcome, if the dialog is still around to render it into.
+
+        The dialog is modal but closable, so the worker can outlive it. PyQt5
+        calls qFatal on any exception escaping a slot (FIB-329), which makes
+        touching a deleted C++ object here an process abort rather than a
+        traceback — hence both guards.
+        """
+        if self._closed:
+            return
+        try:
+            if status is None:
+                self._render_check_failed()
+            elif status.update_available:
+                self._render_update_available(status.latest)
+            else:
+                self._render_up_to_date()
+        except RuntimeError:
+            _logger.debug("About dialog closed during the update check")
+
+    def done(self, result: int) -> None:
+        # accept(), reject() and the window's close button all funnel here.
+        self._closed = True
+        super().done(result)
 
     @staticmethod
     def _microscope_rows(

--- a/fibsem/update_check.py
+++ b/fibsem/update_check.py
@@ -1,0 +1,184 @@
+"""Whether a newer fibsemOS release is available on PyPI.
+
+Deliberately Qt-free and stdlib-only: the UI owns the threading (see
+``fibsem/ui/qt/threading.py``), and this module only knows how to ask PyPI, cache
+the answer, and decide whether asking is appropriate at all.
+
+Two rules shape everything here:
+
+* **Never block the caller for long, and never raise.** :func:`refresh` is
+  blocking and must be run on a worker thread; it has an explicit timeout, since
+  an instrument PC behind a firewall that blackholes packets would otherwise
+  stall until the OS TCP timeout.
+* **A failed check is not an error state.** Offline is the normal condition on an
+  air-gapped microscope, so it is indistinguishable from "no check has run": both
+  leave the cached status as ``None`` and the UI shows nothing.
+"""
+
+import json
+import logging
+import urllib.request
+from dataclasses import dataclass
+from typing import List, Optional
+
+from packaging import version
+
+from fibsem.versioning import get_revision
+
+logger = logging.getLogger(__name__)
+
+PYPI_URL = "https://pypi.org/pypi/{package}/json"
+
+# Long enough for a slow-but-working connection, short enough that a wedged
+# network does not keep a worker thread alive for the rest of the session.
+REQUEST_TIMEOUT_SECONDS = 5.0
+
+_PACKAGE = "fibsem"
+
+# Populated by refresh(); None means "no successful check", which covers both
+# "not run yet" and "could not reach PyPI".
+_status: Optional["UpdateStatus"] = None
+
+
+@dataclass(frozen=True)
+class UpdateStatus:
+    """The outcome of a successful PyPI lookup."""
+
+    current: str
+    latest: str
+    update_available: bool
+
+
+def is_supported() -> bool:
+    """Whether an update check could say anything meaningful.
+
+    False for source installs, and no preference or explicit request overrides
+    it: someone 48 commits past v0.5.1 being told that 0.5.1 is available is
+    noise, and once a newer release lands it becomes advice to ``pip install -U``
+    over their editable install.
+    """
+    return get_revision() is None
+
+
+def is_enabled() -> bool:
+    """Whether to check *automatically*, without the user asking.
+
+    **Opt-in.** These run on instrument PCs, sometimes on institutional networks
+    where an unannounced connection at startup is a compliance question, so the
+    user has to ask for it (``reporting.update_check_enabled``).
+
+    This governs the background check only. A user-initiated check goes through
+    ``refresh(force=True)`` — the click is the consent.
+    """
+    if not is_supported():
+        return False
+    try:
+        from fibsem.config import load_user_preferences
+
+        return bool(load_user_preferences().reporting.update_check_enabled)
+    except Exception:
+        # Fail closed. An unreadable preferences file must not produce a network
+        # call the user never opted into.
+        logger.debug("Could not read update-check preference", exc_info=True)
+        return False
+
+
+def get_status() -> Optional[UpdateStatus]:
+    """The cached result, or None if no check has succeeded this session."""
+    return _status
+
+
+def get_available_update() -> Optional[str]:
+    """The newer version available, or None.
+
+    None whenever there is nothing to act on — no check has run, the check
+    failed, updates are disabled, or the installed version is already current.
+    The UI shows an indicator if and only if this returns a version.
+    """
+    status = _status
+    if status is not None and status.update_available:
+        return status.latest
+    return None
+
+
+def fetch_stable_versions(package: str = _PACKAGE) -> List[str]:
+    """Stable versions on PyPI, newest first. Empty list on any failure.
+
+    Uses ``urllib`` rather than ``requests``: requests is not a core dependency
+    (it only appears in the ``server`` extra), so importing it would fail for a
+    normal install and this check would silently never work.
+    """
+    try:
+        request = urllib.request.Request(
+            PYPI_URL.format(package=package),
+            headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(
+            request, timeout=REQUEST_TIMEOUT_SECONDS
+        ) as response:
+            data = json.loads(response.read().decode("utf-8"))
+        releases = list(data["releases"].keys())
+    except Exception as exc:
+        # Debug, not warning: being offline is the expected state on an
+        # air-gapped instrument PC, and a warning every launch trains operators
+        # to ignore the log.
+        logger.debug("Could not fetch PyPI versions for %s: %s", package, exc)
+        return []
+
+    stable = []
+    for release in releases:
+        try:
+            parsed = version.parse(release)
+        except Exception:
+            continue
+        if not parsed.is_prerelease and not parsed.is_devrelease:
+            stable.append((parsed, release))
+    return [release for _, release in sorted(stable, reverse=True)]
+
+
+def refresh(package: str = _PACKAGE, force: bool = False) -> Optional[UpdateStatus]:
+    """Ask PyPI and cache the result. Blocking — run me on a worker thread.
+
+    Returns None (leaving any previous result cached) when the check is disabled
+    or could not complete.
+
+    Pass ``force=True`` for a user-initiated check, e.g. an explicit "check for
+    updates" click: that is not an unexpected network call, so the opt-in
+    preference does not apply to it. Source-install suppression still does,
+    since the answer would be meaningless either way.
+    """
+    global _status
+
+    if not is_supported():
+        return None
+    if not force and not is_enabled():
+        return None
+
+    versions = fetch_stable_versions(package)
+    if not versions:
+        return None
+
+    import fibsem
+
+    current_raw = getattr(fibsem, "__version__", None) or ""
+    try:
+        current = version.parse(current_raw)
+        latest = version.parse(versions[0])
+    except Exception as exc:
+        logger.debug("Could not compare versions (%r vs %r): %s",
+                     current_raw, versions[0], exc)
+        return None
+
+    _status = UpdateStatus(
+        current=current_raw,
+        latest=versions[0],
+        update_available=current < latest,
+    )
+    logger.debug("Update check: %s", _status)
+    return _status
+
+
+def reset() -> None:
+    """Drop the cached status. For tests."""
+    global _status
+    _status = None

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, List, Tuple, Optional, Union
 
 import yaml
-from packaging import version
 from PIL import Image
 
 from fibsem import config as cfg
@@ -515,76 +514,3 @@ def _register_metadata(microscope: 'FibsemMicroscope',
     )
     microscope.user = user
     microscope.experiment = experiment
-
-
-def get_pypi_versions(package_name: str = "fibsem") -> List[str]:
-    """Get all available versions from PyPI for the specified package.
-    
-    Args:
-        package_name: Name of the package to check. Defaults to "fibsem".
-        
-    Returns:
-        List of available versions sorted by version number (latest first).
-        Returns empty list if unable to fetch versions.
-    """
-    try:
-        import requests
-        url = f'https://pypi.org/pypi/{package_name}/json'
-        response = requests.get(url)
-        response.raise_for_status()
-        data = response.json()
-        versions = list(data['releases'].keys())
-        # Filter out pre-releases and dev versions for cleaner output
-        stable_versions = [v for v in versions if not any(pre in v.lower() for pre in ['a', 'b', 'rc', 'dev'])]
-        return sorted(stable_versions, key=version.parse, reverse=True)
-    except Exception as e:
-        logging.warning(f'Error fetching PyPI data for {package_name}: {e}')
-        return []
-
-
-def check_for_updates(package_name: str = "fibsem") -> dict:
-    """Check if a newer version of the package is available on PyPI.
-    
-    Args:
-        package_name: Name of the package to check. Defaults to "fibsem".
-        
-    Returns:
-        Dictionary containing:
-        - 'current_version': Currently installed version
-        - 'latest_version': Latest version on PyPI (None if unable to fetch)
-        - 'update_available': Boolean indicating if update is available
-        - 'status': Text description of the status
-    """
-    import fibsem
-    
-    result = {
-        'current_version': fibsem.__version__,
-        'latest_version': None,
-        'update_available': False,
-        'status': 'Unknown'
-    }
-    
-    # Get PyPI versions
-    pypi_versions = get_pypi_versions(package_name)
-    if pypi_versions:
-        result['latest_version'] = pypi_versions[0]
-    
-    # Compare versions
-    if result['latest_version']:
-        try:
-            current_ver = version.parse(result['current_version'])
-            latest_ver = version.parse(result['latest_version'])
-            
-            if current_ver < latest_ver:
-                result['update_available'] = True
-                result['status'] = f'Newer version available: {result["latest_version"]} (you have {result["current_version"]})'
-            elif current_ver == latest_ver:
-                result['status'] = f'You have the latest version: {result["current_version"]}'
-            else:
-                result['status'] = f'You have a newer version than PyPI: {result["current_version"]} > {result["latest_version"]}'
-        except Exception as e:
-            result['status'] = f'Error comparing versions: {e}'
-    else:
-        result['status'] = f'Could not fetch PyPI versions for {package_name}'
-    
-    return result

--- a/scripts/test_update_indicator.py
+++ b/scripts/test_update_indicator.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+"""Standalone harness for the PyPI update-available indicator.
+
+The update check is skipped entirely on source installs by design, so running
+fibsemOS from a checkout shows nothing — which is exactly what makes this
+feature awkward to try by hand. Every mode below fakes a wheel install (no git
+revision, an older version) so the feature becomes reachable.
+
+Note that ``fibsem.update_check`` binds ``get_revision`` into its own namespace
+with a from-import, so it is that name which must be patched, not
+``fibsem.versioning.get_revision``.
+
+Usage:
+    python scripts/test_update_indicator.py live        # real request to pypi.org
+    python scripts/test_update_indicator.py dialog      # about dialog, update waiting
+    python scripts/test_update_indicator.py button      # manual check button, clickable
+    python scripts/test_update_indicator.py suppressed  # about dialog as-is on a checkout
+    python scripts/test_update_indicator.py hang        # prove a wedged network cannot block
+"""
+
+import argparse
+import socket
+import sys
+import time
+from contextlib import ExitStack
+from unittest.mock import patch
+
+FAKE_INSTALLED_VERSION = "0.5.0"
+
+# Long enough to be obviously a hang rather than a slow network, short enough
+# that the harness itself does not look wedged.
+HANG_BUDGET_SECONDS = 10
+
+
+def _pretend_wheel_install(stack: ExitStack, version: str = FAKE_INSTALLED_VERSION):
+    """Look like an old pip install, by an opted-in user.
+
+    Both halves are needed: the check is skipped for source checkouts, and it is
+    opt-in even for wheel installs, so a default preferences file disables it.
+    """
+    import fibsem
+    from fibsem.config import ReportingPreferences, UserPreferences
+
+    opted_in = UserPreferences(
+        reporting=ReportingPreferences(update_check_enabled=True)
+    )
+    stack.enter_context(patch("fibsem.update_check.get_revision", lambda: None))
+    stack.enter_context(patch.object(fibsem, "__version__", version))
+    stack.enter_context(
+        patch("fibsem.config.load_user_preferences", lambda: opted_in)
+    )
+
+
+def run_live() -> int:
+    """Ask the real PyPI, pretending to be an old wheel install."""
+    from fibsem import update_check
+
+    with ExitStack() as stack:
+        _pretend_wheel_install(stack)
+
+        print(f"pretending to be fibsem {FAKE_INSTALLED_VERSION} installed from a wheel")
+        print("enabled          :", update_check.is_enabled())
+
+        started = time.perf_counter()
+        status = update_check.refresh()
+        elapsed_ms = (time.perf_counter() - started) * 1000
+
+        print(f"refresh took     : {elapsed_ms:.0f} ms "
+              f"(timeout is {update_check.REQUEST_TIMEOUT_SECONDS}s)")
+        print("status           :", status)
+        print("indicator shows  :", update_check.get_available_update() or "(nothing)")
+    return 0
+
+
+def run_dialog(mode: str) -> int:
+    """Show the real about dialog.
+
+    ``dialog``     an update is already known, so the indicator is showing
+    ``button``     nothing known yet, so the manual check button is offered —
+                   click it for a real request to PyPI
+    ``suppressed`` the dialog exactly as it is here, on a source checkout
+    """
+    from PyQt5.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication(sys.argv)  # noqa: F841
+    import fibsem.ui.widgets.about_dialog as about_dialog
+
+    with ExitStack() as stack:
+        if mode != "suppressed":
+            _pretend_wheel_install(stack)
+            # The dialog reads these directly, so they need patching here too.
+            stack.enter_context(patch.object(about_dialog, "get_revision", lambda: None))
+            stack.enter_context(patch.object(about_dialog, "get_branch", lambda: None))
+        if mode == "dialog":
+            stack.enter_context(
+                patch("fibsem.update_check.get_available_update", lambda: "0.5.3")
+            )
+        about_dialog.AboutDialog(application="AutoLamella").exec_()
+    return 0
+
+
+def run_hang() -> int:
+    """Point the check at a socket that accepts and then never replies.
+
+    This is what a firewall blackholing packets looks like, and it is the reason
+    the request carries an explicit timeout: without one it would block until
+    the OS gave up, minutes later, with a worker thread stuck the whole time.
+    """
+    from fibsem import update_check
+
+    server = socket.socket()
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+
+    try:
+        with ExitStack() as stack:
+            _pretend_wheel_install(stack)
+            stack.enter_context(
+                patch.object(
+                    update_check, "PYPI_URL", f"http://127.0.0.1:{port}/{{package}}"
+                )
+            )
+            started = time.perf_counter()
+            result = update_check.fetch_stable_versions()
+            elapsed = time.perf_counter() - started
+    finally:
+        server.close()
+
+    print(f"blackholed request returned {result!r} after {elapsed:.1f}s")
+    ok = elapsed < HANG_BUDGET_SECONDS
+    print(f"timeout is {update_check.REQUEST_TIMEOUT_SECONDS}s — "
+          f"{'PASS' if ok else 'FAIL: it hung'}")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "mode",
+        nargs="?",
+        default="live",
+        choices=["live", "dialog", "button", "suppressed", "hang"],
+    )
+    args = parser.parse_args()
+
+    if args.mode == "live":
+        return run_live()
+    if args.mode in ("dialog", "button", "suppressed"):
+        return run_dialog(args.mode)
+    return run_hang()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,264 @@
+"""Tests for the PyPI update check.
+
+Two properties matter more than the happy path: the network call must always
+carry a timeout (a wedged firewall would otherwise stall a worker thread for the
+rest of the session), and a failed check must be indistinguishable from no check
+— being offline is the normal condition on an air-gapped instrument PC.
+"""
+
+import json
+from contextlib import contextmanager
+
+import pytest
+
+from fibsem import update_check
+
+
+@pytest.fixture(autouse=True)
+def _clear_cached_status():
+    update_check.reset()
+    yield
+    update_check.reset()
+
+
+@pytest.fixture
+def wheel_install(monkeypatch):
+    """Look like a pip-installed wheel rather than a source checkout.
+
+    Not sufficient on its own to make the check run — it is opt-in.
+    """
+    monkeypatch.setattr(update_check, "get_revision", lambda: None)
+
+
+@pytest.fixture
+def update_check_active(monkeypatch, wheel_install):
+    """A wheel install whose user has opted in: the check actually runs."""
+    from fibsem.config import ReportingPreferences, UserPreferences
+
+    prefs = UserPreferences(
+        reporting=ReportingPreferences(update_check_enabled=True)
+    )
+    monkeypatch.setattr("fibsem.config.load_user_preferences", lambda: prefs)
+
+
+def _pypi_payload(*versions):
+    return json.dumps({"releases": {v: [] for v in versions}}).encode("utf-8")
+
+
+@contextmanager
+def _fake_response(payload):
+    class _Response:
+        def read(self):
+            return payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    yield _Response()
+
+
+def _stub_urlopen(monkeypatch, payload, seen=None):
+    def _urlopen(request, **kwargs):
+        if seen is not None:
+            seen.update(kwargs)
+            seen["url"] = request.full_url
+        return _fake_response(payload).__enter__()
+
+    monkeypatch.setattr(update_check.urllib.request, "urlopen", _urlopen)
+
+
+# --- when the check should run at all --------------------------------------
+
+
+def test_disabled_for_source_installs(monkeypatch):
+    """A checkout 48 commits past a tag must not be told to pip install -U."""
+    monkeypatch.setattr(update_check, "get_revision", lambda: "v0.5.1-48-g4cd11d9c")
+
+    assert update_check.is_enabled() is False
+
+
+def test_opt_in_so_disabled_by_default(wheel_install):
+    """No preferences file must mean no outbound call."""
+    assert update_check.is_enabled() is False
+
+
+def test_enabled_once_the_user_opts_in(monkeypatch, wheel_install):
+    from fibsem.config import ReportingPreferences, UserPreferences
+
+    prefs = UserPreferences(
+        reporting=ReportingPreferences(update_check_enabled=True)
+    )
+    monkeypatch.setattr("fibsem.config.load_user_preferences", lambda: prefs)
+
+    assert update_check.is_enabled() is True
+
+
+def test_opting_in_does_not_override_source_install_suppression(monkeypatch):
+    from fibsem.config import ReportingPreferences, UserPreferences
+
+    prefs = UserPreferences(
+        reporting=ReportingPreferences(update_check_enabled=True)
+    )
+    monkeypatch.setattr("fibsem.config.load_user_preferences", lambda: prefs)
+    monkeypatch.setattr(update_check, "get_revision", lambda: "v0.5.1-48-gabc")
+
+    assert update_check.is_enabled() is False
+
+
+def test_unreadable_preferences_fail_closed(monkeypatch, wheel_install):
+    """A broken preferences file must not produce an unopted-into network call."""
+
+    def _boom():
+        raise OSError("preferences on fire")
+
+    monkeypatch.setattr("fibsem.config.load_user_preferences", _boom)
+
+    assert update_check.is_enabled() is False
+
+
+def test_is_supported_is_about_the_install_not_the_preference(monkeypatch):
+    monkeypatch.setattr(update_check, "get_revision", lambda: "v0.5.1-48-gabc")
+    assert update_check.is_supported() is False
+
+    monkeypatch.setattr(update_check, "get_revision", lambda: None)
+    assert update_check.is_supported() is True
+
+
+def test_force_bypasses_the_opt_in_preference(monkeypatch, wheel_install):
+    """A user clicking 'check for updates' is consent for that one call."""
+    from fibsem.config import ReportingPreferences, UserPreferences
+
+    opted_out = UserPreferences(
+        reporting=ReportingPreferences(update_check_enabled=False)
+    )
+    monkeypatch.setattr("fibsem.config.load_user_preferences", lambda: opted_out)
+    monkeypatch.setattr("fibsem.__version__", "0.5.1", raising=False)
+    _stub_urlopen(monkeypatch, _pypi_payload("0.5.3"))
+
+    assert update_check.is_enabled() is False  # no *background* check
+    assert update_check.refresh() is None  # ... and none happens
+    assert update_check.refresh(force=True).latest == "0.5.3"  # but asking works
+
+
+def test_force_does_not_override_source_install_suppression(monkeypatch):
+    """Even an explicit click cannot make the comparison meaningful."""
+    monkeypatch.setattr(update_check, "get_revision", lambda: "v0.5.1-48-gabc")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("must not reach the network")
+
+    monkeypatch.setattr(update_check.urllib.request, "urlopen", _boom)
+
+    assert update_check.refresh(force=True) is None
+
+
+def test_disabled_check_makes_no_network_call(monkeypatch):
+    monkeypatch.setattr(update_check, "get_revision", lambda: "v0.5.1-48-gabc")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("must not reach the network")
+
+    monkeypatch.setattr(update_check.urllib.request, "urlopen", _boom)
+
+    assert update_check.refresh() is None
+    assert update_check.get_available_update() is None
+
+
+# --- fetching ---------------------------------------------------------------
+
+
+def test_timeout_is_always_passed(monkeypatch, update_check_active):
+    """The whole reason this is not the old requests-based helper."""
+    seen = {}
+    _stub_urlopen(monkeypatch, _pypi_payload("0.5.1"), seen)
+
+    update_check.fetch_stable_versions()
+
+    assert seen["timeout"] == update_check.REQUEST_TIMEOUT_SECONDS
+    assert seen["url"].startswith("https://pypi.org/pypi/fibsem/")
+
+
+def test_prereleases_and_dev_versions_are_filtered(monkeypatch, update_check_active):
+    _stub_urlopen(
+        monkeypatch,
+        _pypi_payload("0.5.0", "0.5.1", "0.5.1a0", "0.5.2.dev0", "0.6.0rc1"),
+    )
+
+    assert update_check.fetch_stable_versions() == ["0.5.1", "0.5.0"]
+
+
+def test_unparseable_versions_are_skipped(monkeypatch, update_check_active):
+    _stub_urlopen(monkeypatch, _pypi_payload("0.5.1", "not-a-version"))
+
+    assert update_check.fetch_stable_versions() == ["0.5.1"]
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [OSError("network unreachable"), TimeoutError(), ValueError("bad json")],
+    ids=["offline", "timeout", "malformed"],
+)
+def test_fetch_failures_return_empty(monkeypatch, update_check_active, exc):
+    def _boom(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr(update_check.urllib.request, "urlopen", _boom)
+
+    assert update_check.fetch_stable_versions() == []
+
+
+# --- refresh and the cached answer -----------------------------------------
+
+
+def test_update_available(monkeypatch, update_check_active):
+    monkeypatch.setattr("fibsem.__version__", "0.5.1", raising=False)
+    _stub_urlopen(monkeypatch, _pypi_payload("0.5.1", "0.5.3"))
+
+    status = update_check.refresh()
+
+    assert status.update_available is True
+    assert status.latest == "0.5.3"
+    assert update_check.get_available_update() == "0.5.3"
+
+
+def test_no_update_when_current(monkeypatch, update_check_active):
+    monkeypatch.setattr("fibsem.__version__", "0.5.3", raising=False)
+    _stub_urlopen(monkeypatch, _pypi_payload("0.5.1", "0.5.3"))
+
+    status = update_check.refresh()
+
+    assert status.update_available is False
+    # Only the actionable case is surfaced.
+    assert update_check.get_available_update() is None
+
+
+def test_no_update_when_ahead_of_pypi(monkeypatch, update_check_active):
+    monkeypatch.setattr("fibsem.__version__", "0.6.0", raising=False)
+    _stub_urlopen(monkeypatch, _pypi_payload("0.5.3"))
+
+    assert update_check.refresh().update_available is False
+    assert update_check.get_available_update() is None
+
+
+def test_failed_check_looks_like_no_check(monkeypatch, update_check_active):
+    """Offline is normal on an air-gapped instrument; it is not an error state."""
+
+    def _boom(*args, **kwargs):
+        raise OSError("network unreachable")
+
+    monkeypatch.setattr(update_check.urllib.request, "urlopen", _boom)
+
+    assert update_check.refresh() is None
+    assert update_check.get_status() is None
+    assert update_check.get_available_update() is None
+
+
+def test_unparseable_current_version_is_not_fatal(monkeypatch, update_check_active):
+    monkeypatch.setattr("fibsem.__version__", "unknown", raising=False)
+    _stub_urlopen(monkeypatch, _pypi_payload("0.5.3"))
+
+    assert update_check.refresh() is None
+    assert update_check.get_available_update() is None

--- a/tests/ui/test_about_dialog.py
+++ b/tests/ui/test_about_dialog.py
@@ -84,6 +84,96 @@ def test_microscope_section_skipped_when_info_unavailable(qapp):
     assert "Microscope" not in [title for title, _ in dialog._sections]
 
 
+def _slot_text(dialog):
+    from PyQt5.QtWidgets import QLabel
+
+    return " ".join(
+        w.text() for w in dialog._update_slot.findChildren(QLabel) if w.text()
+    )
+
+
+def _slot_buttons(dialog):
+    from PyQt5.QtWidgets import QToolButton
+
+    return dialog._update_slot.findChildren(QToolButton)
+
+
+@pytest.fixture
+def wheel_install(monkeypatch):
+    monkeypatch.setattr("fibsem.ui.widgets.about_dialog.get_revision", lambda: None)
+    monkeypatch.setattr("fibsem.update_check.get_revision", lambda: None)
+
+
+def test_source_install_gets_no_update_slot_content(qapp, monkeypatch):
+    """A PyPI comparison is meaningless from a checkout, so offer nothing."""
+    monkeypatch.setattr("fibsem.update_check.get_revision", lambda: "v0.5.1-48-gabc")
+
+    dialog = AboutDialog(application="fibsemOS")
+
+    assert dialog._update_slot.layout().count() == 0
+
+
+def test_check_button_offered_when_no_result_yet(qapp, wheel_install, monkeypatch):
+    monkeypatch.setattr("fibsem.update_check.get_available_update", lambda: None)
+
+    dialog = AboutDialog(application="fibsemOS")
+
+    assert _slot_text(dialog) == ""
+    assert len(_slot_buttons(dialog)) == 1
+
+
+def test_background_result_shown_instead_of_the_button(qapp, wheel_install, monkeypatch):
+    monkeypatch.setattr("fibsem.update_check.get_available_update", lambda: "0.5.3")
+
+    dialog = AboutDialog(application="fibsemOS")
+
+    assert "0.5.3 available" in _slot_text(dialog)
+    assert _slot_buttons(dialog) == []
+
+
+@pytest.mark.parametrize(
+    "render, expected_text, keeps_button",
+    [
+        ("_render_up_to_date", "up to date", False),
+        ("_render_check_failed", "could not check", True),
+    ],
+)
+def test_manual_check_reports_every_outcome(
+    qapp, wheel_install, render, expected_text, keeps_button
+):
+    """Unlike the passive indicator, a check the user asked for always answers."""
+    dialog = AboutDialog(application="fibsemOS")
+
+    getattr(dialog, render)()
+
+    assert expected_text in _slot_text(dialog)
+    # A failed check keeps the button so a transient blip can be retried.
+    assert bool(_slot_buttons(dialog)) is keeps_button
+
+
+def test_result_after_close_is_ignored(qapp, wheel_install):
+    """PyQt5 qFatals on an exception escaping a slot, so this must not throw."""
+    from fibsem.update_check import UpdateStatus
+
+    dialog = AboutDialog(application="fibsemOS")
+    dialog.done(0)
+
+    dialog._on_update_check_returned(
+        UpdateStatus(current="0.5.1", latest="0.5.3", update_available=True)
+    )
+
+    assert dialog._closed is True
+
+
+def test_update_slot_never_stops_the_dialog_opening(qapp, monkeypatch):
+    def _boom():
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr("fibsem.update_check.is_supported", _boom)
+
+    AboutDialog(application="fibsemOS")  # must still construct
+
+
 def test_environment_section_is_present(qapp):
     dialog = AboutDialog(application="fibsemOS")
 


### PR DESCRIPTION
Closes FIB-366. Builds on #202 / #203.

`check_for_updates()` and `get_pypi_versions()` had sat in `fibsem/utils.py` with no callers. They were also **unusable**: both went through `import requests`, which is not a core dependency — it appears only in the `server` extra — so on a normal install the import failed, the blanket `except` swallowed it, and they silently returned nothing. This replaces them with `fibsem/update_check.py` on stdlib `urllib`, and surfaces the result in the about dialog.

## Opt-in, and it fails closed

`update_check_enabled` defaults to **`False`**, next to `crash_reporting_enabled`. These run on instrument PCs, sometimes on institutional or air-gapped networks where an unannounced connection at startup is a compliance question and the operator would have no idea it was happening.

If the preference cannot be read, `is_enabled()` returns `False` — an unreadable preferences file must not produce a network call nobody opted into.

Existing preference files load unchanged; `_sub_from_dict` ignores unknown keys.

## Two ways to reach it

|  | background check | manual button |
|---|---|---|
| trigger | app startup, worker thread | user clicks |
| requires opt-in | yes | **no** — the click is the consent |
| update available | shows | shows |
| up to date | shows nothing | **shows** |
| check failed | shows nothing | **shows**, and keeps the button |

The passive path stays silent on non-actionable outcomes because nobody asked. A manual check must answer, or clicking a button and seeing nothing change reads as broken — and "could not reach PyPI" is honest when the user explicitly asked. A failed manual check keeps the button, since that is exactly when you want to retry.

This is what makes the feature reachable at all now that the default is off; without it FIB-366 would ship something almost nobody ever sees.

`is_enabled()` is therefore split: `is_supported()` (install type — absolute, no preference or click overrides it) and `is_enabled()` (opt-in, governs the background check only). The button goes through `refresh(force=True)`.

## Never blocks, never aborts

- **Explicit timeout.** The old helper had none, so on an instrument PC behind a firewall that *blackholes* packets rather than refusing them it would block until the OS TCP timeout — minutes, with a worker thread stuck. `scripts/test_update_indicator.py hang` reproduces this against a real socket that accepts and never replies; it returns in 5s.
- **Off the GUI thread**, via `fibsem/ui/qt/threading.py`.
- **Survives the dialog closing mid-check.** The dialog is modal but closable, so the worker outlives it. PyQt5 calls `qFatal` on any exception escaping a slot (FIB-329), which makes touching a deleted C++ object here a process abort rather than a traceback — hence a `_closed` flag plus a `RuntimeError` guard, with a test that closes mid-flight and then delivers the result.

## Suppressed for source installs

Before any network call, and no preference or click overrides it. Someone 48 commits past v0.5.1 being told 0.5.1 is available is noise, and once a newer release lands it becomes an implicit suggestion to `pip install -U` over an editable install.

Note the irony: source installs are the population that most opens this dialog, and the one that must never see this indicator.

## Testing

`fibsem/update_check.py` is deliberately Qt-free — the UI owns the threading — so most of it is covered by plain unit tests: the timeout always reaching `urlopen`, prerelease/dev filtering, offline and malformed responses, the opt-in default, fail-closed on unreadable preferences, `force=` bypassing the preference but not the source-install suppression, and a source install making **no** network call at all (the stub raises if reached).

Because the feature is suppressed on source installs it cannot be tried by hand from a checkout, so `scripts/test_update_indicator.py` fakes a wheel install: `live`, `dialog`, `button` (clickable, real request), `suppressed`, and `hang`. Follows the existing `scripts/test_workflow_summary_dialog.py` harness convention; not collected by pytest, since `testpaths = ["tests"]`.

Full suite: 1397 passed, 15 skipped.

## Note on #206

My original about-dialog test lacked the `pytest.importorskip` guard every other file in `tests/ui/` carries, which turned main red. #206 fixed that; this branch carries the identical line so the rebase was a no-op on it and nothing is reverted. Root cause is `fibsem/ui/__init__.py` importing a napari-dependent widget eagerly — #204 addresses that properly.