### PR TITLE
[fix] Re-point lamella paths when an experiment is loaded (FIB-367)

### DIFF
--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -39,7 +39,7 @@ On each lamella in `exp.positions`:
 | Attribute | Description |
 |---|---|
 | `lamella.name` | e.g. `01-deep-crane` |
-| `lamella.path` | that lamella's directory — but see [Gotchas](#gotchas) before using it |
+| `lamella.path` | that lamella's directory, where its images live |
 | `lamella.completed_tasks` | list of completed task names |
 | `lamella.last_completed_task` | the most recent task state, or `None` |
 | `lamella.task_history` | every task state, including repeats |
@@ -118,6 +118,21 @@ df = df[df["duration"].notna()]
 print(df.groupby("task_name")["duration"].agg(["count", "mean", "max"]).round(1))
 ```
 
+### Find each lamella's images
+
+```python
+from pathlib import Path
+from fibsem.applications.autolamella.structures import Experiment
+
+exp = Experiment.load("/path/to/my-experiment/experiment.yaml")
+
+for lamella in exp.positions:
+    for image in sorted(Path(lamella.path).glob("*.tif")):
+        print(lamella.name, image.name)
+```
+
+`lamella.path` is re-derived from the experiment's location when it loads, so this keeps working after you copy an experiment off the microscope PC.
+
 ## Changing an experiment
 
 The same objects are writable. Call `exp.save()` when you are done:
@@ -141,26 +156,6 @@ To clear a mark again, use `lamella.defect.clear()`.
 **Back up the experiment directory before running anything that writes.** These scripts have no undo.
 
 ## Gotchas
-
-**Don't use `lamella.path` — derive it instead.** This one bites as soon as you copy an experiment off the microscope PC, which is the usual way of working.
-
-`exp.path` is taken from the file you loaded, so it is always right. But each `lamella.path` is stored in `experiment.yaml` exactly as it was when the lamella was created, and never updated. On a copied or moved experiment it still points at the original machine's directory:
-
-```
-exp.path      : /data/analysis/my-experiment          # correct
-lamella.path  : /home/user/experiments/my-experiment/01-deep-crane   # gone
-```
-
-If the original directory happens to still exist on the same machine, this is worse than an error — you silently read the wrong experiment. Build the path yourself:
-
-```python
-from pathlib import Path
-
-for lamella in exp.positions:
-    lamella_dir = Path(exp.path) / lamella.name
-    for image in sorted(lamella_dir.glob("*.tif")):
-        print(lamella.name, image.name)
-```
 
 **Close the experiment in the GUI first, or reload it afterwards.** AutoLamella holds the experiment in memory. If it is open while your script writes, whichever saves last wins and the other's changes are gone.
 

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -727,7 +727,7 @@ class Lamella:
     description: str = ""  # free-text note about the lamella
 
     def __post_init__(self):
-        # only make the dir, if the base path is actually set, 
+        # only make the dir, if the base path is actually set,
         # prevents creating path on other computer..
         if os.path.exists(os.path.dirname(self.path)):
             os.makedirs(self.path, exist_ok=True)
@@ -736,10 +736,29 @@ class Lamella:
             self._id = str(uuid.uuid4())
         self.task_state.lamella_id = self._id
 
-        # assign the imaging path to the task config
-        for task_name, tc in self.task_config.items():
-            for name, milling_task_config in tc.milling.items():
+        self._sync_imaging_paths()
+
+    def _sync_imaging_paths(self) -> None:
+        """Point every milling task's acquisition at this lamella's directory.
+
+        Milling configs carry their own imaging path, so it has to be re-derived
+        whenever ``path`` changes or acquisitions are written to the old location.
+        """
+        for tc in self.task_config.values():
+            for milling_task_config in tc.milling.values():
                 milling_task_config.acquisition.imaging.path = self.path
+
+    def relocate(self, experiment_path: Path) -> None:
+        """Re-point this lamella at ``experiment_path``.
+
+        ``path`` is persisted in experiment.yaml as the absolute path the lamella
+        was *created* at, so a lamella loaded from a moved or copied experiment
+        still points at the original machine. Worse, when that directory happens
+        to still exist locally, reads silently succeed against the wrong data.
+        ``Experiment.load`` calls this so paths follow the experiment. See FIB-367.
+        """
+        self.path = os.path.join(experiment_path, self.name)
+        self._sync_imaging_paths()
 
     @property
     def name(self) -> str:
@@ -1120,6 +1139,12 @@ class Experiment:
         # create experiment from dict
         experiment = Experiment.from_dict(ddict)
         experiment.path = os.path.dirname(fname)
+
+        # lamella paths are stored as-created, so re-point them at wherever the
+        # experiment actually is now. otherwise a moved or copied experiment
+        # reads and writes against the original location. (FIB-367)
+        for lamella in experiment.positions:
+            lamella.relocate(experiment.path)
 
         # configure experiment logging
         configure_logging(path=experiment.path, log_filename="logfile")

--- a/tests/autolamella/test_structures.py
+++ b/tests/autolamella/test_structures.py
@@ -391,3 +391,72 @@ def test_task_state_from_dict_ignores_unknown_keys():
 
     assert state.name == "MillRough"
     assert not hasattr(state, "metrics")
+
+
+# ── Lamella paths follow a moved experiment (FIB-367) ────────────────────────
+
+def _experiment_on_disk(root: Path, with_milling: bool = False) -> Experiment:
+    """A saved experiment with one lamella, optionally carrying a milling task."""
+    exp = Experiment(path=root, name="exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    Path(exp.path).mkdir(parents=True, exist_ok=True)
+
+    task_config = EventedDict()
+    if with_milling:
+        task_config["basic"] = _make_task_config()
+    exp.add_new_lamella(MicroscopeState(), task_config)
+    exp.save(save_protocol=True)
+    return exp
+
+
+def test_lamella_path_follows_a_copied_experiment(tmp_path):
+    """`path` is persisted as the directory the lamella was *created* in, so a
+    copied experiment would otherwise point back at the machine it came from.
+
+    That is worse than an error whenever the original directory still exists
+    locally, because reads silently succeed against the wrong experiment.
+    """
+    import shutil
+
+    src = tmp_path / "src"
+    exp = _experiment_on_disk(src)
+    original = Path(exp.positions[0].path)
+
+    dst = tmp_path / "dst"
+    shutil.copytree(exp.path, dst / "exp")
+    shutil.rmtree(src)
+
+    loaded = Experiment.load(str(dst / "exp" / "experiment.yaml"))
+    lamella = loaded.positions[0]
+
+    assert Path(lamella.path) == Path(loaded.path) / lamella.name
+    assert Path(lamella.path) != original
+    assert Path(lamella.path).exists()
+
+
+def test_milling_imaging_paths_follow_a_copied_experiment(tmp_path):
+    """Milling configs carry their own acquisition imaging path, copied from the
+    lamella in __post_init__. Correcting `path` alone would leave acquisitions
+    still writing back to the original location.
+    """
+    import shutil
+
+    src = tmp_path / "src"
+    exp = _experiment_on_disk(src, with_milling=True)
+
+    dst = tmp_path / "dst"
+    shutil.copytree(exp.path, dst / "exp")
+    shutil.rmtree(src)
+
+    loaded = Experiment.load(str(dst / "exp" / "experiment.yaml"))
+    lamella = loaded.positions[0]
+
+    imaging_paths = [
+        mtc.acquisition.imaging.path
+        for tc in lamella.task_config.values()
+        for mtc in tc.milling.values()
+    ]
+    assert imaging_paths, "expected the lamella to carry a milling task config"
+    for path in imaging_paths:
+        assert Path(path) == Path(lamella.path)
+        assert str(src) not in str(path)


### PR DESCRIPTION
Fixes FIB-367.

`Lamella.path` is persisted in `experiment.yaml` as the absolute path the lamella was *created* at, and `Experiment.load` never updated it — it recomputes `experiment.path` from the file it was handed, but leaves the lamella paths underneath untouched. So on a moved or copied experiment every lamella points back at the machine it came from.

Where that original directory still exists locally — the normal case when someone copies an experiment to re-analyse it — this is worse than an error: reads silently succeed against the wrong experiment.

## What changed

`Experiment.load` now relocates each lamella onto the experiment's actual directory.

The part that is easy to miss: milling configs carry their **own** `acquisition.imaging.path`, copied from the lamella in `__post_init__`. Correcting `lamella.path` alone would leave those stale, so a resumed workflow on a moved experiment would keep *writing* acquisitions to the original location. That assignment is now factored into `_sync_imaging_paths()` and called from both `__post_init__` and `relocate()`.

## Why not a derived property

The issue proposed making `path` a property over the experiment path and lamella name. I did not, because:

- `path=` is a constructor kwarg in a dozen places, including `compat/odemis.py` and `legacy/autoliftout.py`.
- Several tests deliberately pass a directory whose name differs from the petname — `Lamella(path=tmp_path / "lam", petname="test")`. A derived property silently changes what those resolve to.
- Its only extra benefit is handling renames, which cannot currently happen: nothing calls the `name` setter, and there is no rename affordance in the UI.

The issue listed this targeted fix as the fallback for exactly that reason. If renaming ever becomes a feature, the property becomes worth revisiting.

## Verification

- Two regression tests, both of which **fail without the fix** — verified by stashing it, not assumed. One covers `lamella.path`, one covers the milling imaging paths.
- Full suite: 1372 passed, 15 skipped.
- The original end-to-end reproduction from FIB-367 — create at an absolute path, copy the directory, delete the original — now resolves to the copy.

## Docs

`SCRIPTING.md` led with a gotcha telling users **not** to use `lamella.path` and to derive it themselves. This fix makes that advice wrong, so it is removed and the attribute table entry restored. The useful part survives as a "find each lamella's images" example, which was run against a copied experiment to confirm the claim it makes.