### PR TITLE
[autofocus] Make run_auto_focus cancellable (extracted from #111)

### DIFF
--- a/fibsem/autofunctions/autofocus.py
+++ b/fibsem/autofunctions/autofocus.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
+import threading
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional
 
+from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
 from fibsem.structures import BeamType
 
 import numpy as np
@@ -284,6 +286,7 @@ def _run_sweep(
     sweep_pass: FocusSweepPass,
     pass_index: int,
     beam_type: BeamType,
+    stop_event: Optional[threading.Event] = None,
 ) -> "tuple[list[AutoFocusIteration], float]":
     """Acquire images across a WD range and return iterations + best WD."""
     half_range = sweep_pass.search_range / 2
@@ -291,6 +294,7 @@ def _run_sweep(
 
     iterations = []
     for i, wd in enumerate(wds):
+        raise_if_cancelled(stop_event, "AutoFocus cancelled by user.")  # abort between WD steps
         microscope.set_working_distance(wd, beam_type)
         probe = microscope.acquire_image(image_settings=probe_settings)
         score = float(np.mean(focus_fn(probe.filtered_data.astype(np.float32))))
@@ -315,6 +319,7 @@ def run_auto_focus(
     beam_type: BeamType = BeamType.ELECTRON,
     hfw: float = 150e-6,
     settings: AutoFocusSettings = None,
+    stop_event: Optional[threading.Event] = None,
 ) -> AutoFocusResult:
     """Multi-pass image-based auto-focus sweep.
 
@@ -378,11 +383,17 @@ def run_auto_focus(
 
     try:
         for pass_index, sweep_pass in enumerate(active_passes):
+            raise_if_cancelled(stop_event, "AutoFocus cancelled by user.")  # abort between passes
             pass_iters, centre_wd = _run_sweep(
                 microscope, probe_settings, focus_fn,
                 centre_wd, sweep_pass, pass_index, beam_type,
+                stop_event=stop_event,
             )
             iterations.extend(pass_iters)
+    except OperationCancelledError:
+        logger.info("AutoFocus cancelled — restoring initial WD %.4e", initial_wd)
+        microscope.set_working_distance(initial_wd, beam_type)
+        raise
     except Exception:
         logger.exception("AutoFocus failed — restoring initial WD %.4e", initial_wd)
         microscope.set_working_distance(initial_wd, beam_type)

--- a/tests/test_autofunctions.py
+++ b/tests/test_autofunctions.py
@@ -327,6 +327,44 @@ def test_run_auto_focus_restores_wd_on_error():
     assert last_set == pytest.approx(initial_wd)
 
 
+def test_run_auto_focus_cancelled_at_entry_restores_wd():
+    """A stop event set before autofocus starts aborts before any sweep and restores the WD."""
+    from fibsem.cancellation import OperationCancelledError
+    initial_wd = 7.0e-3
+    m = mock_microscope(initial_wd=initial_wd)
+    ev = threading.Event(); ev.set()
+    settings = AutoFocusSettings(passes=[FocusSweepPass(2.5e-3, 0.5e-3)])
+    with patch("fibsem.autofunctions.metrics.get_focus_measure_function", return_value=_mean_focus_fn):
+        with pytest.raises(OperationCancelledError):
+            run_auto_focus(m, settings=settings, stop_event=ev)
+    m.acquire_image.assert_not_called()  # aborted before any sweep image
+    assert m.set_working_distance.call_args[0][0] == pytest.approx(initial_wd)  # WD restored
+
+
+def test_run_auto_focus_cancelled_mid_sweep_restores_wd():
+    """A stop event set *during* the sweep aborts partway (not all steps) and restores the WD."""
+    from fibsem.cancellation import OperationCancelledError
+    initial_wd = 7.0e-3
+    m = mock_microscope(initial_wd=initial_wd)
+    ev = threading.Event()
+    calls = {"n": 0}
+    orig = m.acquire_image.side_effect
+
+    def acquire_then_cancel(image_settings=None):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            ev.set()  # user clicks Cancel after a couple of steps
+        return orig(image_settings)
+
+    m.acquire_image.side_effect = acquire_then_cancel
+    settings = AutoFocusSettings(passes=[FocusSweepPass(2.5e-3, 0.1e-3)])  # ~26 steps
+    with patch("fibsem.autofunctions.metrics.get_focus_measure_function", return_value=_mean_focus_fn):
+        with pytest.raises(OperationCancelledError):
+            run_auto_focus(m, settings=settings, stop_event=ev)
+    assert calls["n"] < settings.passes[0].n_steps + 1  # stopped before completing the sweep
+    assert m.set_working_distance.call_args[0][0] == pytest.approx(initial_wd)  # WD restored
+
+
 # ── AutoFocusResult serialisation ─────────────────────────────────────────────
 
 def test_autofocus_result_save_load(tmp_path):


### PR DESCRIPTION
Autofocus sweeps a working-distance range one step at a time and can run for a while; until now a user Stop had no effect until the whole thing finished.

Adds an optional `stop_event` to `run_auto_focus` and `_run_sweep`, polled via `raise_if_cancelled` at the two natural checkpoints — between passes, and between WD steps within a sweep. On cancel the initial working distance is restored and `OperationCancelledError` propagates, so callers can surface a neutral "cancelled" rather than a failure.

That branch sits ahead of the existing `except Exception` handler, which would otherwise log a user cancel as an error with a full traceback.

### Why it's safe

Purely additive. `stop_event` defaults to `None` and `raise_if_cancelled(None, ...)` is a no-op, so both existing call sites — the autofocus task (`workflows/tasks/base.py`) and the image settings widget — behave exactly as before. `fibsem.cancellation` is already on main via #148.

### Tests

Two new cases: cancel-at-entry (aborts before any image is acquired, WD restored) and cancel-mid-sweep (stops before completing the sweep, WD restored).

Both are Qt-free, so unlike most of the UI work they actually **run** on CI rather than skipping — verified by re-running with `napari`/`PyQt5`/`qtpy`/`superqt` blocked via a `sys.meta_path` finder: 1101 passed vs main's 1099 baseline, i.e. the two new tests execute.

Full suite: 1399 passed, 15 skipped.

### Context

Extracted from #111 (the napari→matplotlib canvas migration), which is being broken into independently mergeable pieces. The UI half of the autofocus work — the cancel button wiring — stays in #111 because it lives in `FibsemImageSettingsWidget.py`, which the cutover rewrites.