### PR TITLE
[spot-burn] Take a SpotBurnSettings payload in run_spot_burn

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -19,6 +19,7 @@ from fibsem.applications.autolamella.workflows.ui import (
     clear_spot_burn_ui,
     update_spot_burn_parameters,
 )
+from fibsem.imaging.spot import SpotBurnSettings, run_spot_burn
 from fibsem.structures import BeamType, Point
 
 
@@ -80,6 +81,21 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
             coordinates=coordinates,
         )
 
+    def to_settings(self) -> SpotBurnSettings:
+        """The run payload (coordinates + current + exposure) for this task."""
+        return SpotBurnSettings(
+            coordinates=list(self.coordinates),
+            milling_current=self.milling_current,
+            exposure_time=float(self.exposure_time),
+        )
+
+    def apply_settings(self, settings: SpotBurnSettings) -> None:
+        """Apply a run payload back onto this task config (coordinates + current + exposure)."""
+        self.coordinates = list(settings.coordinates)
+        self.milling_current = settings.milling_current
+        self.exposure_time = settings.exposure_time
+
+
 class SpotBurnFiducialTask(AutoLamellaTask):
     """Task to mill spot fiducial markers for correlation."""
     config: SpotBurnFiducialTaskConfig
@@ -122,11 +138,9 @@ class SpotBurnFiducialTask(AutoLamellaTask):
                     f"No spot burn coordinates set for {self.lamella.name}; skipping spot burn."
                 )
                 return
-            from fibsem.imaging.spot import run_spot_burn
+            # burn the stored coordinates directly (progress via the microscope signal)
             run_spot_burn(microscope=self.microscope,
-                          coordinates=self.config.coordinates,
-                          exposure_time=self.config.exposure_time,
-                          milling_current=self.config.milling_current,
+                          settings=self.config.to_settings(),
                           beam_type=BeamType.ION,
                           stop_event=self._stop_event)
             return

--- a/fibsem/imaging/spot.py
+++ b/fibsem/imaging/spot.py
@@ -2,6 +2,7 @@ from  __future__ import annotations
 import logging
 import threading
 import time
+from dataclasses import dataclass, field
 
 from typing import List, Optional
 
@@ -10,22 +11,49 @@ from fibsem.structures import BeamType, Point
 
 SLEEP_TIME = 1
 
+
+@dataclass
+class SpotBurnSettings:
+    """The payload for a spot-burn run: where to burn, and with what.
+
+    Shared, fibsem-level currency for the coordinate editor + the live spot-burn widget
+    + :func:`run_spot_burn`. Workflow concerns such as the stage orientation live on the
+    task config, not here.
+    """
+
+    coordinates: List[Point] = field(default_factory=list)
+    milling_current: float = 60e-12  # amperes
+    exposure_time: float = 10.0      # seconds
+
+    def to_dict(self) -> dict:
+        return {
+            "coordinates": [pt.to_dict() for pt in self.coordinates],
+            "milling_current": self.milling_current,
+            "exposure_time": self.exposure_time,
+        }
+
+    @classmethod
+    def from_dict(cls, ddict: dict) -> "SpotBurnSettings":
+        return cls(
+            coordinates=[Point.from_dict(pt) for pt in ddict.get("coordinates", [])],
+            milling_current=ddict.get("milling_current", 60e-12),
+            exposure_time=ddict.get("exposure_time", 10.0),
+        )
+
+
 def run_spot_burn(microscope: FibsemMicroscope,
-                  coordinates: List[Point],
-                  exposure_time: float,
-                  milling_current: float,
+                  settings: SpotBurnSettings,
                   beam_type: BeamType = BeamType.ION,
                   stop_event: Optional[threading.Event] = None) -> None:
-    """Run a spot burner job on the microscope. Exposes the specified coordinates for a the specified
-    time at the specified current.
+    """Run a spot burner job on the microscope. Exposes the coordinates in *settings* for
+    the exposure time at the milling current it specifies.
 
     Progress is reported via ``microscope.spot_burn_progress_signal`` (a dict), which the
     status bar and the spot burn widget subscribe to.
     Args:
         microscope: The microscope object.
-        coordinates: List of points to burn. (0 - 1 in image coordinates)
-        exposure_time: Time to expose each point in seconds.
-        milling_current: Current to use for the spot.
+        settings: What to burn — coordinates (0-1 image coordinates), exposure time per
+            point in seconds, and the milling current to burn at.
         beam_type: The type of beam to use. (Default: BeamType.ION)
         stop_event: Threading event to signal cancellation. (Default: None)
     Returns:
@@ -35,14 +63,15 @@ def run_spot_burn(microscope: FibsemMicroscope,
 
     # coerce numeric parameters: protocol-editor fields can arrive as strings
     # (e.g. "3e-11"), which would break beam-current/timing arithmetic on hardware.
-    exposure_time = float(exposure_time)
-    milling_current = float(milling_current)
+    # Read into locals rather than writing back — settings belongs to the caller.
+    exposure_time = float(settings.exposure_time)
+    milling_current = float(settings.milling_current)
 
     # drop points outside the image bounds (0-1 normalised); set_spot rejects out-of-range
     # coordinates on hardware. The supervised widget filters these, so filter here too for
     # the unsupervised/automatic path (coordinates come straight from the stored config).
     in_bounds, dropped = [], []
-    for pt in coordinates:
+    for pt in settings.coordinates:
         (in_bounds if 0 <= pt.x <= 1 and 0 <= pt.y <= 1 else dropped).append(pt)
     if dropped:
         logging.warning(

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from typing import List, Optional
+from typing import Optional
 import numpy as np
 
 import napari
@@ -22,7 +22,7 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtCore import Qt, pyqtSignal
 from superqt import ensure_main_thread
 
-from fibsem.imaging.spot import run_spot_burn
+from fibsem.imaging.spot import SpotBurnSettings, run_spot_burn
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, Point
 from fibsem.ui import stylesheets
@@ -346,10 +346,12 @@ class FibsemSpotBurnWidget(QWidget):
         # in workflow mode the button is hidden when idle — show it as "Cancel" while burning
         self._update_run_button_visibility()
 
-        self.worker = self._spot_burn_worker(microscope=self.microscope,
-                                             coordinates=coordinates,
-                                             exposure_time=exposure_time,
-                                             milling_current=beam_current,)
+        self.worker = self._spot_burn_worker(
+            microscope=self.microscope,
+            settings=SpotBurnSettings(coordinates=coordinates,
+                                      exposure_time=exposure_time,
+                                      milling_current=beam_current),
+        )
         self.worker.returned.connect(self.spot_burn_finished)
         self.worker.errored.connect(self.spot_burn_errored)
         self.worker.start()
@@ -360,14 +362,12 @@ class FibsemSpotBurnWidget(QWidget):
         self.stop_event.set()
 
     @thread_worker
-    def _spot_burn_worker(self, microscope: FibsemMicroscope, coordinates: List[Point], exposure_time: float, milling_current: float):
+    def _spot_burn_worker(self, microscope: FibsemMicroscope, settings: SpotBurnSettings):
         """Worker function to run the spot burn."""
         run_spot_burn(microscope=microscope,
-                       coordinates=coordinates,
-                       exposure_time=exposure_time,
-                       milling_current=milling_current,
-                       beam_type=BeamType.ION,
-                       stop_event=self.stop_event)
+                      settings=settings,
+                      beam_type=BeamType.ION,
+                      stop_event=self.stop_event)
 
         # acquire a post-burn fib image and update the view
         image = microscope.acquire_image(beam_type=BeamType.ION)

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from fibsem.imaging.spot import run_spot_burn
+from fibsem.imaging.spot import SpotBurnSettings, run_spot_burn
 from fibsem.structures import BeamType, Point
 from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
     SpotBurnFiducialTaskConfig,
@@ -72,9 +72,8 @@ def test_run_spot_burn_filters_out_of_bounds_coordinates(mock_microscope):
     ]
     run_spot_burn(
         microscope=mock_microscope,
-        coordinates=coords,
-        exposure_time=1.0,
-        milling_current=30e-12,
+        settings=SpotBurnSettings(coordinates=coords, exposure_time=1.0,
+                                  milling_current=30e-12),
         beam_type=BeamType.ION,
     )
     assert _burned_points(mock_microscope) == [Point(0.5, 0.5), Point(0.9, 0.2)]
@@ -85,9 +84,8 @@ def test_run_spot_burn_keeps_boundary_coordinates(mock_microscope):
     coords = [Point(0.0, 0.0), Point(1.0, 1.0)]
     run_spot_burn(
         microscope=mock_microscope,
-        coordinates=coords,
-        exposure_time=1.0,
-        milling_current=30e-12,
+        settings=SpotBurnSettings(coordinates=coords, exposure_time=1.0,
+                                  milling_current=30e-12),
     )
     assert _burned_points(mock_microscope) == coords
 
@@ -96,9 +94,8 @@ def test_run_spot_burn_empty_coordinates_does_not_burn(mock_microscope):
     """No coordinates -> no spot exposures, but the beam state is still restored."""
     run_spot_burn(
         microscope=mock_microscope,
-        coordinates=[],
-        exposure_time=1.0,
-        milling_current=30e-12,
+        settings=SpotBurnSettings(coordinates=[], exposure_time=1.0,
+                                  milling_current=30e-12),
     )
     mock_microscope.set_spot_scanning_mode.assert_not_called()
     mock_microscope.set_full_frame_scanning_mode.assert_called_once()
@@ -111,9 +108,8 @@ def test_run_spot_burn_coerces_string_parameters(mock_microscope):
     """String milling_current/exposure_time (from the editor QLineEdit bug) don't crash."""
     run_spot_burn(
         microscope=mock_microscope,
-        coordinates=[Point(0.5, 0.5)],
-        exposure_time="2",
-        milling_current="3e-11",
+        settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5)], exposure_time="2",
+                                  milling_current="3e-11"),
         beam_type=BeamType.ION,
     )
     # the milling current is applied as a real float, not the string "3e-11"
@@ -129,9 +125,8 @@ def test_run_spot_burn_restores_full_frame_and_imaging_current(mock_microscope):
     """After burning, scanning returns to full frame and the imaging current is restored."""
     run_spot_burn(
         microscope=mock_microscope,
-        coordinates=[Point(0.5, 0.5)],
-        exposure_time=1.0,
-        milling_current=30e-12,
+        settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5)], exposure_time=1.0,
+                                  milling_current=30e-12),
     )
     mock_microscope.set_full_frame_scanning_mode.assert_called_once()
     last_current = mock_microscope.set_beam_current.call_args_list[-1].kwargs["current"]
@@ -145,9 +140,8 @@ def test_run_spot_burn_emits_progress_via_microscope(mock_microscope):
     """Progress is reported through microscope.spot_burn_progress_signal (both run paths)."""
     run_spot_burn(
         microscope=mock_microscope,
-        coordinates=[Point(0.5, 0.5), Point(0.6, 0.6)],
-        exposure_time=1.0,
-        milling_current=30e-12,
+        settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5), Point(0.6, 0.6)],
+                                  exposure_time=1.0, milling_current=30e-12),
     )
     emitted = [
         c.args[0] for c in mock_microscope.spot_burn_progress_signal.emit.call_args_list
@@ -200,10 +194,12 @@ def _make_headless_spot_burn_task(coordinates, tmp_path):
 
 def test_update_spot_burn_ui_skips_when_no_coordinates(monkeypatch, tmp_path):
     """Unsupervised/headless with no coordinates skips, rather than blocking on ask_user."""
-    import fibsem.imaging.spot as spot_mod
+    # patch where it is *used*: the task imports run_spot_burn at module level, so
+    # patching fibsem.imaging.spot would leave the task's own binding untouched.
+    import fibsem.applications.autolamella.workflows.tasks.spot_burn as sb_mod
 
     calls = []
-    monkeypatch.setattr(spot_mod, "run_spot_burn", lambda **kw: calls.append(kw))
+    monkeypatch.setattr(sb_mod, "run_spot_burn", lambda **kw: calls.append(kw))
 
     task = _make_headless_spot_burn_task([], tmp_path)
     task.update_spot_burn_parameters_ui()  # must return, not hang
@@ -213,17 +209,20 @@ def test_update_spot_burn_ui_skips_when_no_coordinates(monkeypatch, tmp_path):
 
 def test_update_spot_burn_ui_runs_stored_coordinates_headless(monkeypatch, tmp_path):
     """Unsupervised/headless with coordinates burns them directly."""
-    import fibsem.imaging.spot as spot_mod
+    import fibsem.applications.autolamella.workflows.tasks.spot_burn as sb_mod
 
     calls = []
-    monkeypatch.setattr(spot_mod, "run_spot_burn", lambda **kw: calls.append(kw))
+    monkeypatch.setattr(sb_mod, "run_spot_burn", lambda **kw: calls.append(kw))
 
     coords = [Point(0.5, 0.5), Point(0.6, 0.6)]
     task = _make_headless_spot_burn_task(coords, tmp_path)
     task.update_spot_burn_parameters_ui()
 
     assert len(calls) == 1
-    assert calls[0]["coordinates"] == coords
+    settings = calls[0]["settings"]
+    assert settings.coordinates == coords
+    assert settings.milling_current == task.config.milling_current
+    assert settings.exposure_time == task.config.exposure_time
 
 
 # --- SpotBurnFiducialTask supervised loop ---------------------------------------


### PR DESCRIPTION
A spot-burn run is three things that always travel together — where to burn, at what current, for how long — but they were passed around loose: as three keyword arguments into `run_spot_burn`, and as an untyped `dict` between the task and the UI. Every layer had to know the key names, and the dict had no schema to check against.

Adds `SpotBurnSettings` to `fibsem/imaging/spot.py` (coordinates + milling current + exposure time, with `to_dict`/`from_dict`) and makes it the parameter `run_spot_burn` takes:

```python
run_spot_burn(microscope, settings, beam_type=..., stop_event=...)
```

Workflow concerns such as the stage orientation stay on the task config; this is only the run payload. The numeric coercion that guards against protocol-editor strings now reads into locals rather than writing back, so the caller's settings object is left alone.

Both call sites move over. `SpotBurnFiducialTaskConfig` gains `to_settings()`/`apply_settings()` — its projection onto that payload and back — and the unsupervised/headless path uses them; the spot-burn widget's worker takes one `settings` argument in place of three.

### Migrating a caller

Mechanical — `SpotBurnSettings` takes the same keyword names the old call did, so wrap them in the constructor:

```python
# before
run_spot_burn(mic, coordinates=pts, exposure_time=t, milling_current=i)
# after
run_spot_burn(mic, SpotBurnSettings(coordinates=pts, exposure_time=t, milling_current=i))
```

### No compatibility shim, deliberately

`run_spot_burn` is not exported from any `__init__.py` and appears in no docs or scripts, so every caller is in this repo and all are updated here. #138 removed this function's `parent_ui` parameter two weeks ago on the same basis.

Beyond that: a shim would keep the loose form valid, which is the thing this change exists to replace — you'd end up with two shapes rather than one. And a stale call fails loudly with a `TypeError` at the call site, not silently, so there's no wrong-but-working failure mode to guard against.

### Two test fixes worth calling out

The headless tests patched `run_spot_burn` on its *defining* module, which only worked because the task imported it inside the function. The import is now module-level (needed so `get_type_hints` can resolve the `SpotBurnSettings` annotations), so they patch the task module instead — patch where it is used, not where it is defined.

That also repairs a blind spot: `test_update_spot_burn_ui_skips_when_no_coordinates` asserted an empty call list, which passed whether the code correctly skipped *or* the patch simply never took. Confirmed by mutation — forcing the skip guard off now fails that test, where before it passed either way.

### Verification

Full suite 1397 passed, 15 skipped. With `PyQt5`/`napari` blocked via a `sys.meta_path` finder (the CI environment installs neither): 1099 passed, 30 skipped — identical to main's baseline.

### Scope

Extracted from #111. The supervised path still speaks `dict`: moving it means changing `update_spot_burn_parameters` and teaching the widget `get_settings`, both of which sit in the napari cutover. This is the half that lands independently.

Note this does touch `FibsemSpotBurnWidget.py`, a cutover file — but only the call site plus a now-unused `List` import. #111 will need a small fixup to match, since it currently carries a `settings.run()` shape instead.