### PR TITLE
Declare package discovery explicitly rather than relying on setuptools_scm (FIB-373)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,20 @@ fm-image-viewer-ui = "fibsem.ui.fm.widgets.fm_image_viewer_widget:main"
 fibsem-correlation-ui = "fibsem.correlation.ui.widgets.correlation_tab_widget:main"
 fibsem-cli = "fibsem.cli:main"
 
-[tool.setuptools]
-packages = ["fibsem"]
+# Recursive by design. A bare `packages = ["fibsem"]` is NOT recursive: it ships
+# only the top-level fibsem/*.py and none of fibsem/ui, fibsem/milling, etc. That
+# it worked at all was an accident of setuptools_scm (in build-requires above)
+# registering a file finder that swept in every git-tracked file — so package
+# discovery silently depended on a build tool with no config section of its own.
+# See FIB-373.
+[tool.setuptools.packages.find]
+include = ["fibsem*"]
+# Stated explicitly because it is load-bearing, not a preference: a dozen
+# directories are PEP 420 namespace packages with no __init__.py, including
+# fibsem/ui/widgets (68 modules), fibsem/microscopes and fibsem/ui/napari.
+# This defaults to true for pyproject config, but setting it false — or reaching
+# for find_packages semantics — would silently drop all of them from the wheel.
+namespaces = true
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]


### PR DESCRIPTION
Refs FIB-373 — deliberately does **not** close it. That issue proposes three things; this PR does one. Removing `setuptools_scm` from `build-requires` and adding a publish-workflow smoke check are both still open, and the issue is re-scoped to them rather than auto-closing with two-thirds undone.

Two config lines. **Releases are byte-for-byte unaffected** — verified below — so the risk here is close to zero, but the thing it prevents is not.

## The problem

```toml
[build-system]
requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]

[tool.setuptools]
packages = ["fibsem"]
```

`packages = ["fibsem"]` is **not recursive**. Read literally it ships the 20 top-level `fibsem/*.py` files and none of `fibsem/ui`, `fibsem/milling`, `fibsem/applications` or the rest.

That released wheels contain the whole tree is an accident: `setuptools_scm` — sitting in `build-requires` with no `[tool.setuptools_scm]` section of its own — registers a `setuptools.file_finders` entry point that sweeps in every git-tracked file. So what ships is decided by a build tool nothing appears to be using, while the line that looks like it governs contents does not.

## Why now

FIB-350 (adopting setuptools-scm for versioning) was cancelled this week, which makes that `build-requires` entry read as leftover and an obvious cleanup target. Deleting it builds and installs perfectly happily; the first symptom is a user's `ModuleNotFoundError: No module named 'fibsem.ui'`.

Nothing in CI would catch it — `publish.yml` builds and uploads the artifact without ever importing it.

## Measured

Building with and without `setuptools_scm` available:

| config | setuptools_scm | size | `.py` | under `fibsem/ui/` |
| -- | -- | -- | -- | -- |
| `packages = ["fibsem"]` | absent | 100 KB | 20 | **0** |
| `packages = ["fibsem"]` | present (isolated) | 10 MB | 374 | 187 |
| **`packages.find`** | **absent** | **10 MB** | **374** | **187** |
| `packages.find` | present (isolated) | 10 MB | 374 | 187 |

Row 3 is the point: the explicit form produces the correct wheel on its own. This removes the hidden dependency rather than masking it.

## No change to what ships

Diffing the full file lists of **both** published artifact types, before and after:

- wheel — 374 `.py` files, **identical**
- sdist — 470 `.py` files, **identical**

Not one file added or removed in either. Both built with isolation, the way `publish.yml` builds them.

## Deliberately not included

`setuptools_scm` stays in `build-requires`. The wheel is now provably independent of it (row 3), but the sdist path is untested — `build --no-isolation` refuses to run without the declared build-requires, so verifying that needs its own change. Removing it remains a separate decision.

FIB-373 also proposes a publish-workflow smoke check — install the built wheel into a clean environment and `import fibsem.ui` — which would catch this whole class of packaging error rather than just this instance. Left out to keep this reviewable, and because it cannot be verified without cutting a release.
