### PR TITLE
Stop an unset milling path writing to a directory named "None"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ sashimi/*
 fibsem/applications/sashimi/log/*
 # Refractive-index LUT (downloaded on demand from the data release)
 fibsem/correlation/data/
+# Belt-and-braces: a path built from an unset (None) save path lands here
+None/

--- a/fibsem/milling/tasks.py
+++ b/fibsem/milling/tasks.py
@@ -224,10 +224,21 @@ class FibsemMillingTask:
         )
 
     def _configure_path(self) -> None:
-        """Configure the acquisition path for the milling task."""
+        """Configure the acquisition path for the milling task.
+
+        Everything the task saves hangs off this path: the alignment reference image,
+        the drift-correction run, and the per-stage images. The path is unset by
+        default — a config built from stages, or loaded from a protocol that doesn't
+        name one, carries ``None`` — so fall back to the cross-correlation data
+        directory, as every other acquisition in this path already does. Stringifying
+        the ``None`` instead put the whole task under a directory literally named
+        "None", beside the current working directory.
+        """
         path = self.config.acquisition.imaging.path
+        if path is None:
+            path = fcfg.DATA_CC_PATH
         self.config.acquisition.imaging.path = os.path.join(str(path), "Milling",
-                                                            self.name.replace(" ", "-"), 
+                                                            self.name.replace(" ", "-"),
                                                             )
 
     def run(self) -> None:

--- a/tests/milling/test_tasks.py
+++ b/tests/milling/test_tasks.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from fibsem import utils
@@ -159,6 +161,39 @@ def test_every_restore_uses_the_captured_voltage(tmp_path):
     voltages = [call[1]["imaging_voltage"] for call in restored]
     assert all(v == 2e3 for v in voltages), f"expected every restore at 2 kV, got {voltages}"
     assert microscope.get_beam_voltage(BeamType.ION) == 2e3
+
+
+# ── an unset save path is not a directory called "None" ──────────────────────
+
+def test_unset_path_does_not_resolve_under_a_none_directory(tmp_path, monkeypatch):
+    """Regression: _configure_path stringified the imaging path before joining it, so a
+    task with no path configured (the default, and what the milling widget hands over
+    when its Path field is left empty) wrote its reference image and its whole
+    drift-correction run to ./None/Milling/<task>/ beside the cwd."""
+    monkeypatch.chdir(tmp_path)
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    cfg = FibsemMillingTaskConfig.from_stages(stages=[FibsemMillingStage(name="s")])
+    assert cfg.acquisition.imaging.path is None, "guard: the path starts out unset"
+
+    task = FibsemMillingTask(microscope, cfg)
+    task._configure_path()
+
+    configured = str(task.config.acquisition.imaging.path)
+    assert Path(configured).is_absolute(), f"unset path resolved to a relative {configured!r}"
+    assert "None" not in Path(configured).parts, configured
+    assert Path(configured).parts[-2:] == ("Milling", "Milling-Task")
+
+
+def test_configured_path_is_preserved(tmp_path):
+    """The fallback only applies when nothing is configured."""
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    cfg = FibsemMillingTaskConfig.from_stages(stages=[FibsemMillingStage(name="s")], name="t")
+    cfg.acquisition.imaging.path = str(tmp_path)
+
+    task = FibsemMillingTask(microscope, cfg)
+    task._configure_path()
+
+    assert task.config.acquisition.imaging.path == str(tmp_path / "Milling" / "t")
 
 
 def test_imaging_conditions_falls_back_before_capture(tmp_path):


### PR DESCRIPTION
## The bug

`FibsemMillingTask._configure_path` stringified the acquisition path before joining it:

```python
path = self.config.acquisition.imaging.path   # may be None
self.config.acquisition.imaging.path = os.path.join(str(path), "Milling", ...)
```

`str(None)` → `"None"`, so a task with no path configured resolved to `./None/Milling/<task-name>/`, relative to the current working directory. Everything the task saves hangs off that path, so the alignment reference image landed there directly, and `_mill_stage` copied the settings onto the stage — `multi_step_alignment_v2` then read the path back off the reference image's metadata and appended `Alignment/<stage>-<ts>/`, dumping the full drift-correction run (`data.json`, `figure.png`, reference/new/final images, ~1.6 MB) into the same tree.

## Why the path is unset

By default. A config built via `from_stages` carries `None`, and `MillingTaskAcquisitionSettings.from_dict` explicitly forces `imaging["path"] = None` for protocols that don't name one.

It reaches production through the standalone milling widget: `ImageSettingsWidget.get_settings` maps an empty Path field to `None`, and `FibsemMillingWidget2._milling_worker` passes the config straight to `run_milling_task` without setting one. Leaving Path blank writes the reference image and the whole alignment run beside wherever the app was launched from. AutoLamella is unaffected — its workflow tasks assign `imaging.path = self.lamella.path` first.

Baking the `None` into a string also silently killed three existing `if path is None:` guards downstream (`_acquire_reference_image`, `_acquire_milling_task_images`, `milling/core.get_stage_reference_image`) — by the time they ran, they saw a non-`None` string.

## The fix

Fall back to `fcfg.DATA_CC_PATH` when nothing is configured, matching those three sibling guards rather than inventing a new policy. That directory is already covered by `fibsem/log/*` in `.gitignore`, so the fallback can't reintroduce untracked repo pollution. `None/` is ignored too, so a future path bug of this shape can't be swept into a commit.

## Verification

Reproduced standalone with an unset path and got a byte-for-byte match of the reported file list; after the fix the same script resolves to `<repo>/fibsem/log/data/crosscorrelation/Milling/Milling-Task` and creates nothing in the cwd. Full suite from the repo root: **1399 passed, 15 skipped**, no `None/` created. Two regression tests added.

Worth noting: this is **not** reproducible from `pytest tests/` on current `main`. All three milling tests already set `imaging.path = tmp_path`, and `tests/conftest.py` chdirs every test into its own `tmp_path` (#174). I instrumented the whole suite with a probe flagging any test that leaves a literal `None` directory — zero hits. The reported `None/` in the repo root was a stale leftover from an older revision. The bug itself is live regardless, just no longer reachable from the tests.