### PR TITLE
Fix the spot burn progress bar lifecycle and retract the FM objective (FIB-374/375/376)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -38,6 +38,9 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
     orientation: Optional[str] = field(default=None,
                                        metadata={"help": "Orientation for acquisition. 'FM' or 'SEM'. None = use fluorescence_pose as-is.",
                                                  "label": "Orientation"})
+    retract_objective: bool = field(default=True,
+                                    metadata={"help": "Retract the objective when the task finishes, so it is clear of the stage for subsequent moves. Disable for back-to-back fluorescence tasks.",
+                                              "label": "Retract Objective"})
 
     def to_dict(self) -> dict:
         ddict = {}
@@ -46,6 +49,7 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
         ddict["autofocus_settings"] = self.autofocus_settings.to_dict()
         ddict["zparams"] = self.zparams.to_dict()
         ddict["orientation"] = self.orientation
+        ddict["retract_objective"] = self.retract_objective
         return ddict
 
     @classmethod
@@ -60,6 +64,7 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
             autofocus_settings=autofocus_settings,
             zparams=zparams,
             orientation=data.get("orientation", None),
+            retract_objective=data.get("retract_objective", True),
         )
 
 # TODO: implement time estimates...
@@ -113,6 +118,10 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
 
         # refresh the recorded fluorescence pose (preserving the configured objective position)
         self._update_fluorescence_pose()
+
+        # retract the objective so it is clear of the stage for subsequent moves
+        if self.config.retract_objective:
+            self._retract_objective()
 
 
     def _run_autofocus(self) -> Optional[AutoFocusResult]:

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -522,6 +522,28 @@ class AutoLamellaTask(ABC):
             self._last_fib_image = fib_image
         set_images_ui(self.parent_ui, sem_image, fib_image)  # show the last acquired image
 
+    def _retract_objective(self) -> None:
+        """Retract the FM objective if it is inserted.
+
+        Called at the end of tasks that insert the objective, so it is clear of the
+        stage before any subsequent move or tilt. The task manager also retracts at
+        the end of a run, but that is once for the whole queue -- without this the
+        objective stays inserted across every task in between.
+
+        Failures are logged, not raised: a task that has otherwise completed should
+        not be reported as failed because the retract did not take.
+        """
+        if self.microscope.fm is None:
+            return
+        try:
+            if self.microscope.fm.objective.state != "Inserted":
+                return
+            self.log_status_message("RETRACT_OBJECTIVE", "Retracting Objective...")
+            self.microscope.fm.objective.retract()
+        except Exception as e:
+            logging.warning(f"Failed to retract the objective after {self.task_name}: {e}",
+                            exc_info=True)
+
     def _move_to_milling_pose(self) -> None:
         """Move to the lamella milling pose."""
         self.log_status_message("MOVE_TO_POSITION", "Moving to Position...")

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -19,7 +19,7 @@ from PyQt5.QtWidgets import (
     QSpacerItem,
     QWidget,
 )
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import Qt, QTimer, pyqtSignal
 from superqt import ensure_main_thread
 
 from fibsem.imaging.spot import run_spot_burn
@@ -32,6 +32,7 @@ from fibsem.utils import format_value
 
 SPOT_BURN_POINTS_LAYER_NAME = "spot-burn-points"
 DEFAULT_BEAM_CURRENT = 60e-12  # 60 pA
+HIDE_PROGRESS_DELAY_MS = 2000  # how long the "Done" bar stays up before hiding
 
 
 def build_spot_burn_progress_update(ddict: dict) -> ProgressUpdate:
@@ -374,7 +375,25 @@ class FibsemSpotBurnWidget(QWidget):
         microscope.fib_acquisition_signal.emit(image)
 
     def spot_burn_finished(self, result):
-        """Called when the spot burn is finished."""
+        """Called when the spot burn completes successfully."""
+        self._restore_idle_state()
+        # hide the "Done" bar after a moment, so it doesn't linger for the rest of the
+        # session (mirrors the status bar). reset_if_finished leaves the widget alone if
+        # another burn has already started rendering progress in the meantime.
+        QTimer.singleShot(HIDE_PROGRESS_DELAY_MS, self.progress_widget.reset_if_finished)
+
+    def spot_burn_errored(self, error):
+        """Called when the spot burn fails.
+
+        The failed bar is deliberately left on screen (no auto-hide) so the failure is
+        still visible if the user was not watching when it happened.
+        """
+        logging.error(f"Spot burn failed: {error}")
+        self.microscope.spot_burn_progress_signal.emit({"finished": True, "error": True})
+        self._restore_idle_state()
+
+    def _restore_idle_state(self):
+        """Return the run button to its idle state after a burn ends (either way)."""
         self._is_burning = False
         self.pushButton_run_spot_burn.clicked.disconnect()
         self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)
@@ -383,12 +402,6 @@ class FibsemSpotBurnWidget(QWidget):
         self.pushButton_run_spot_burn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
         # in workflow mode, hide the button again now the burn is done
         self._update_run_button_visibility()
-
-    def spot_burn_errored(self, error):
-        """Called when the spot burn fails."""
-        logging.error(f"Spot burn failed: {error}")
-        self.microscope.spot_burn_progress_signal.emit({"finished": True, "error": True})
-        self.spot_burn_finished(error)
 
     @ensure_main_thread
     def _update_progress_bar(self, ddict: dict):

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -438,6 +438,21 @@ MILLING_PROGRESS_BAR_STYLESHEET = """
             }
         """
 
+# same bar, error-coloured chunk: rendered when an operation finishes in a failed
+# state, so "Done" and "Failed" are not both a full green bar.
+FAILED_PROGRESS_BAR_STYLESHEET = """
+            QProgressBar {
+                border: 1px solid #3d4251;
+                border-radius: 3px;
+                text-align: center;
+                background-color: #1e2027;
+                color: #d6d6d6;
+            }
+            QProgressBar::chunk {
+                background-color: #99121F;
+            }
+        """
+
 USER_ATTENTION_BUTTON_STYLESHEET = """
             QPushButton {
                 background-color: #ff9800;

--- a/fibsem/ui/widgets/progress_widget.py
+++ b/fibsem/ui/widgets/progress_widget.py
@@ -28,7 +28,7 @@ Done — completes the bar and shows "Done"::
 
     ProgressUpdate.done()
 
-Failed — completes the bar but shows an error message::
+Failed — completes the bar, shows an error message, and turns the bar red::
 
     ProgressUpdate.failed("Spot burn failed")
 
@@ -66,6 +66,9 @@ class ProgressUpdate:
     total_seconds: float = 0.0
     message: str = ""
     finished: bool = False
+    # NOTE: not `failed` -- the `failed()` classmethod below would shadow the field's
+    # class attribute, and @dataclass would take the method object as the default.
+    is_failed: bool = False
 
     @classmethod
     def numeric(cls, current: int, total: int, message: str = "") -> "ProgressUpdate":
@@ -117,7 +120,7 @@ class ProgressUpdate:
     @classmethod
     def failed(cls, message: str = "Failed") -> "ProgressUpdate":
         """Signals failure — completes the bar but shows ``message`` instead of "Done"."""
-        return cls(finished=True, message=message)
+        return cls(finished=True, is_failed=True, message=message)
 
 
 # ---------------------------------------------------------------------------
@@ -150,8 +153,24 @@ class FibsemProgressWidget(QWidget):
 
         self._bar = QProgressBar()
         self._bar.setTextVisible(True)
+        self._failed_style = False
         self._bar.setStyleSheet(stylesheets.MILLING_PROGRESS_BAR_STYLESHEET)
         layout.addWidget(self._bar)
+
+    def _set_failed_style(self, failed: bool) -> None:
+        """Swap the chunk colour between the normal and error styles.
+
+        Guarded on the current state: setStyleSheet forces a restyle, and
+        update_progress runs on every frame of a countdown.
+        """
+        if failed == self._failed_style:
+            return
+        self._failed_style = failed
+        self._bar.setStyleSheet(
+            stylesheets.FAILED_PROGRESS_BAR_STYLESHEET
+            if failed
+            else stylesheets.MILLING_PROGRESS_BAR_STYLESHEET
+        )
 
     # ------------------------------------------------------------------
     # Public API
@@ -165,6 +184,7 @@ class FibsemProgressWidget(QWidget):
         prefix = f"{info.message} — " if info.message else ""
 
         self._finished = info.finished
+        self._set_failed_style(info.is_failed)
         self.setVisible(True)
 
         if info.finished:
@@ -236,6 +256,7 @@ class FibsemProgressWidget(QWidget):
     def reset(self) -> None:
         """Return to initial hidden state."""
         self._finished = False
+        self._set_failed_style(False)
         self._spinner.stop()
         self._spinner.clear()
         self._bar.setMinimum(0)

--- a/tests/autolamella/test_objective_retract.py
+++ b/tests/autolamella/test_objective_retract.py
@@ -1,0 +1,75 @@
+"""Tests for retracting the FM objective when a fluorescence task finishes (FIB-376).
+
+The objective is inserted by the fluorescence tasks and, before this, was only
+retracted once at the very end of a whole workflow run — so it stayed inserted
+across every task in between.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from fibsem.applications.autolamella.workflows.tasks.acquire_fluorescence import (
+    AcquireFluorescenceImageConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+
+
+class _StubTask(AutoLamellaTask):
+    """Concrete subclass — AutoLamellaTask is abstract on ``_run``."""
+
+    def _run(self) -> None:  # pragma: no cover - never called
+        raise NotImplementedError
+
+
+def _task_with_objective(state: str) -> AutoLamellaTask:
+    """A bare task instance wired to a mock microscope, for the retract helper."""
+    task = _StubTask.__new__(_StubTask)
+    task.microscope = MagicMock()
+    task.microscope.fm.objective.state = state
+    task.config = MagicMock(task_name="Acquire Fluorescence Image")
+    task.lamella = MagicMock()
+    task.parent_ui = None
+    task.log_status_message = MagicMock()
+    return task
+
+
+# --- task-level helper ------------------------------------------------------
+
+
+def test_retract_objective_when_inserted():
+    task = _task_with_objective("Inserted")
+    task._retract_objective()
+    assert task.microscope.fm.objective.retract.called
+
+
+def test_no_retract_when_already_retracted():
+    task = _task_with_objective("Retracted")
+    task._retract_objective()
+    assert not task.microscope.fm.objective.retract.called
+
+
+def test_no_retract_without_an_fm():
+    task = _task_with_objective("Inserted")
+    task.microscope.fm = None
+    task._retract_objective()  # must not raise
+
+
+def test_retract_failure_does_not_fail_the_task():
+    """A task that otherwise completed shouldn't be reported failed by the retract."""
+    task = _task_with_objective("Inserted")
+    task.microscope.fm.objective.retract.side_effect = RuntimeError("stuck")
+    task._retract_objective()  # swallowed and logged
+
+
+# --- config round-trip ------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_retract_objective_survives_a_config_round_trip(value):
+    """to_dict/from_dict are hand-written here — a new field is easy to drop."""
+    config = AcquireFluorescenceImageConfig(task_name="FM", retract_objective=value)
+    assert AcquireFluorescenceImageConfig.from_dict(config.to_dict()).retract_objective is value
+
+
+def test_retract_objective_defaults_true_for_older_protocols():
+    assert AcquireFluorescenceImageConfig.from_dict({"task_name": "FM"}).retract_objective is True

--- a/tests/ui/test_progress_widget_states.py
+++ b/tests/ui/test_progress_widget_states.py
@@ -1,0 +1,105 @@
+"""Headless tests for FibsemProgressWidget's finished/failed rendering.
+
+Covers the two states that previously looked identical: a completed operation and
+a failed one both painted a full green bar, so a failed spot burn read as "Done"
+in everything but the text (FIB-375).
+
+Uses the shared offscreen ``qapp`` fixture from tests/conftest.py.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.ui import stylesheets
+from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
+
+GREEN = "#4caf50"
+RED = "#99121F"
+
+
+def _chunk_colour(widget: FibsemProgressWidget) -> str:
+    """The chunk colour currently applied to the bar."""
+    sheet = widget._bar.styleSheet()
+    if RED in sheet:
+        return RED
+    if GREEN in sheet:
+        return GREEN
+    raise AssertionError(f"unrecognised progress bar stylesheet: {sheet!r}")
+
+
+@pytest.fixture
+def widget(qapp):
+    return FibsemProgressWidget()
+
+
+def test_done_is_not_failed():
+    """done() must not set the failure flag.
+
+    Regression guard for the field/classmethod name collision: a field named
+    `failed` would be shadowed by the `failed()` classmethod, and @dataclass would
+    take the method object as the default — truthy, so every done() rendered red.
+    """
+    assert ProgressUpdate.done().is_failed is False
+    assert ProgressUpdate.failed("boom").is_failed is True
+    assert ProgressUpdate.combined(1, 2, 3, 4).is_failed is False
+
+
+def test_done_stays_green(widget):
+    widget.update_progress(ProgressUpdate.combined(2, 5, 8, 10, "Burning spots"))
+    assert _chunk_colour(widget) == GREEN
+
+    widget.update_progress(ProgressUpdate.done())
+    assert _chunk_colour(widget) == GREEN
+    assert widget._bar.value() == 100
+    assert widget._bar.format() == "Done"
+
+
+def test_failed_renders_red_with_its_message(widget):
+    widget.update_progress(ProgressUpdate.failed("Spot burn failed"))
+    assert _chunk_colour(widget) == RED
+    assert widget._bar.format() == "Spot burn failed"
+
+
+def test_next_run_clears_the_failed_style(widget):
+    """A failure must not leave the bar red for the following operation."""
+    widget.update_progress(ProgressUpdate.failed("Spot burn failed"))
+    widget.update_progress(ProgressUpdate.combined(1, 3, 5, 10, "Burning spots"))
+    assert _chunk_colour(widget) == GREEN
+
+
+def test_reset_clears_the_failed_style(widget):
+    widget.update_progress(ProgressUpdate.failed("Spot burn failed"))
+    widget.reset()
+    assert _chunk_colour(widget) == GREEN
+    assert widget.isHidden()
+
+
+def test_reset_if_finished_only_resets_when_finished(widget):
+    """The delayed hide must not blank a run that has already started."""
+    widget.update_progress(ProgressUpdate.combined(1, 3, 5, 10, "Burning spots"))
+    widget.reset_if_finished()
+    assert not widget.isHidden()
+    assert widget._bar.format() == "Burning spots — 1/3 · 5s remaining"
+
+    widget.update_progress(ProgressUpdate.done())
+    widget.reset_if_finished()
+    assert widget.isHidden()
+
+
+def test_reset_if_finished_resets_after_a_failure(widget):
+    """Failed is a finished state — an explicit reset still clears it."""
+    widget.update_progress(ProgressUpdate.failed("Spot burn failed"))
+    widget.reset_if_finished()
+    assert widget.isHidden()
+    assert _chunk_colour(widget) == GREEN
+
+
+def test_failed_stylesheet_is_the_bar_with_an_error_chunk():
+    """The failed sheet should differ from the normal one only in chunk colour."""
+    normal = stylesheets.MILLING_PROGRESS_BAR_STYLESHEET
+    failed = stylesheets.FAILED_PROGRESS_BAR_STYLESHEET
+    assert failed.replace(RED, GREEN) == normal


### PR DESCRIPTION
First batch from the fluorescence workflow feedback triage — three small, independent fixes.

## FIB-374 — spot burn progress bar lingers after completion

`run_spot_burn` emits `{"finished": True}`, which paints the bar 100% / "Done" and leaves it there for the rest of the session. The main-window status bar already has the delayed hide (`QTimer.singleShot(2000, reset_if_finished)`); the spot burn widget's own `FibsemProgressWidget` never got one.

Schedules the same 2s `reset_if_finished` after a successful burn. `reset_if_finished` no-ops if another burn has started rendering in the meantime, so back-to-back burns don't blank each other.

The failure path deliberately does **not** auto-hide — a burn that failed while the user was away should still be on screen. The shared button-restore is split into `_restore_idle_state()` so both paths reuse it.

Reported as happening "in manual mode": the supervised workflow path masks it, because `clear_spot_burn_ui` runs at task end.

## FIB-375 — failed progress bar rendered green

`ProgressUpdate.failed()` took the same `finished` branch as `done()`, and the chunk colour was fixed at construction — so a failed spot burn showed a full green bar reading "Spot burn failed".

Adds an `is_failed` flag and a `FAILED_PROGRESS_BAR_STYLESHEET` (identical to the normal bar, error-coloured chunk), swapped in `update_progress` and restored on `reset()` and on the next run. The swap is guarded on current state so it isn't re-applied every countdown frame.

The field is `is_failed`, not `failed`: a field of that name is shadowed by the `failed()` classmethod defined below it in the class body, so `@dataclass` takes the method object as the default — truthy, meaning every `done()` would render red. `test_done_is_not_failed` guards against that regression.

The done state stays green, as agreed.

## FIB-376 — objective stays inserted between tasks

The objective was retracted once, at the very end of a whole workflow run, so it stayed inserted across every task in between — through subsequent stage moves and tilts.

Adds `AutoLamellaTask._retract_objective()` (guarded on `state == "Inserted"`, logs rather than raises so a completed task isn't reported failed by a retract hiccup) and calls it at the end of `AcquireFluorescenceImageTask._run`, behind a `retract_objective` config field defaulting to True. The flag lets back-to-back FM tasks opt out rather than thrashing the objective.

`retract_objective` is threaded through the hand-written `to_dict`/`from_dict`, and defaults to True for protocols saved before the field existed.

The end-of-run retract in `TaskManager` is unchanged.

## Testing

Full suite passes: 1388 passed, 15 skipped (skips pre-existing — missing correlation LUT and volume data files).

Two new test files:
- `tests/ui/test_progress_widget_states.py` — done stays green, failed goes red, the failed style clears on the next run and on reset, `reset_if_finished` doesn't blank a run in progress.
- `tests/autolamella/test_objective_retract.py` — retract when inserted / skip when already retracted / no-op without an FM / a failing retract doesn't fail the task, plus the config round-trip.

**Not hardware verified.** The retract paths are exercised against mocks only; the real objective behaviour needs a run on the instrument before this is trusted on a live system.
