### PR TITLE
[ui] Make the lamella default-config preview a live editable canvas

### DIFF
--- a/fibsem/ui/widgets/lamella_default_config_widget.py
+++ b/fibsem/ui/widgets/lamella_default_config_widget.py
@@ -1,25 +1,23 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QImage, QPixmap
+from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
     QCheckBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
-    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
 
-from PIL import Image, ImageDraw
-
 from fibsem.applications.autolamella.structures import LamellaDefaultConfig
 from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel, ValueSpinBox
-from fibsem.imaging.drawing import _get_font, draw_crosshair_at, draw_rectangle_reduced, draw_scalebar
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.overlays.alignment_overlay import AlignmentAreaOverlay
+from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
 from fibsem.structures import DEFAULT_ALIGNMENT_AREA, FibsemRectangle, Point
 from fibsem.ui.stylesheets import NAPARI_STYLE
 
@@ -39,11 +37,13 @@ _EXAMPLE_PETNAME = "brave-tiger"
 _PREVIEW_HFW = 100e-6               # 100 µm horizontal field width
 _PREVIEW_W, _PREVIEW_H = 384, 288
 _PIXEL_SIZE = _PREVIEW_HFW / _PREVIEW_W
+_PREVIEW_VFW = _PREVIEW_HFW * _PREVIEW_H / _PREVIEW_W  # vertical field width (metres)
 
-_COLOR_CENTRE = (255, 255, 0)       # yellow  — image centre crosshair
-_COLOR_AA     = (0, 255, 0)         # lime    — alignment area rectangle
-_COLOR_POI    = (255, 0, 255)       # magenta — point of interest crosshair
+_COLOR_AA = "limegreen"            # alignment area rectangle
+_COLOR_POI = "magenta"             # point of interest marker
 
+# Black background the overlays are drawn over (the canvas adds its own scalebar +
+# centre crosshair from the pixel size, so only the AA rect + POI need overlays).
 _PREVIEW_BG: np.ndarray = np.zeros((_PREVIEW_H, _PREVIEW_W), dtype=np.uint8)
 
 
@@ -59,59 +59,50 @@ def _row(label_text: str, *widgets) -> QHBoxLayout:
     return row
 
 
-def _render_template_preview(template: LamellaDefaultConfig) -> QPixmap:
-    """Render a 100 µm FIB preview image with template overlays as a QPixmap."""
-    arr = _PREVIEW_BG.copy()
-
-    # Scale bar
-    arr = draw_scalebar(arr, _PIXEL_SIZE)
-
-    # Name text at top of image
+def _template_name(template: LamellaDefaultConfig) -> str:
+    """The example lamella name a template would produce (for the preview hint)."""
     prefix = template.name_prefix or ""
     sep = "-" if prefix else ""
-    name = (f"{prefix}{sep}01-{_EXAMPLE_PETNAME}" if template.use_petname
-            else f"{prefix}{sep}Lamella-01")
-    pil_img = Image.fromarray(arr).convert("RGBA")
-    overlay = Image.new("RGBA", pil_img.size, (0, 0, 0, 0))
-    ImageDraw.Draw(overlay).text((4, 4), name, font=_get_font(16, bold=True), fill=(255, 255, 255, 220))
-    arr = np.array(Image.alpha_composite(pil_img, overlay).convert("RGB"))
+    if template.use_petname:
+        return f"{prefix}{sep}01-{_EXAMPLE_PETNAME}"
+    return f"{prefix}{sep}Lamella-01"
 
-    # Yellow crosshair at image centre (always visible)
-    arr = draw_crosshair_at(arr, 0.5, 0.5, color=_COLOR_CENTRE, alpha=0.9, size_ratio=0.06)
 
-    # Lime green rectangle for alignment area
-    aa = template.alignment_area if template.alignment_area is not None else _DEFAULT_AA
-    arr = draw_rectangle_reduced(
-        arr, aa.left, aa.top, aa.width, aa.height,
-        color=_COLOR_AA, alpha=0.9, thickness=2,
-    )
+def _poi_to_pixel(poi: Point) -> Tuple[float, float]:
+    """Microscope-coord POI offset (metres, +x right / +y up) → image pixel (top-left, y-down)."""
+    px = (0.5 + poi.x / _PREVIEW_HFW) * _PREVIEW_W
+    py = (0.5 - poi.y / _PREVIEW_VFW) * _PREVIEW_H
+    px = max(0.0, min(px, _PREVIEW_W - 1))
+    py = max(0.0, min(py, _PREVIEW_H - 1))
+    return px, py
 
-    # Magenta crosshair for POI (offset from image centre in microscope coords)
-    poi = template.poi if template.poi is not None else _DEFAULT_POI
-    vfw = _PREVIEW_HFW * _PREVIEW_H / _PREVIEW_W
-    cx_frac = max(0.02, min(0.98, 0.5 + poi.x / _PREVIEW_HFW))
-    cy_frac = max(0.02, min(0.98, 0.5 - poi.y / vfw))
-    arr = draw_crosshair_at(arr, cx_frac, cy_frac, color=_COLOR_POI, alpha=0.9, size_ratio=0.05)
 
-    arr_c = np.ascontiguousarray(arr)
-    h, w = arr_c.shape[:2]
-    qimg = QImage(arr_c.data, w, h, 3 * w, QImage.Format.Format_RGB888)
-    return QPixmap.fromImage(qimg)
+def _pixel_to_poi(px: float, py: float) -> Point:
+    """Inverse of :func:`_poi_to_pixel` — image pixel → POI offset in metres."""
+    x = (px / _PREVIEW_W - 0.5) * _PREVIEW_HFW
+    y = (0.5 - py / _PREVIEW_H) * _PREVIEW_VFW
+    return Point(x=x, y=y)
 
 
 class LamellaDefaultConfigWidget(QWidget):
-    """Compact editor for LamellaDefaultConfig protocol defaults."""
+    """Compact editor for LamellaDefaultConfig protocol defaults.
+
+    The right-hand preview is a live :class:`FibsemImageCanvas`: the alignment area
+    (lime rectangle) and point of interest (magenta marker) are editable overlays
+    that stay in two-way sync with the spinboxes — drag them on the canvas or type
+    values, either updates the other.
+    """
 
     template_changed = pyqtSignal(object)  # LamellaDefaultConfig
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self._preview_pixmap: Optional[QPixmap] = None
         self.setStyleSheet(NAPARI_STYLE + "QCheckBox { background: transparent; }")
         self._setup_ui()
         self._connect_signals()
-        self._validate_alignment_area()
-        self._update_image_preview(LamellaDefaultConfig())
+        # Position spinboxes + overlays + name hint from the defaults (silent — the
+        # spinbox writes are blocked and the overlays don't echo programmatic sets).
+        self.set_template(LamellaDefaultConfig())
 
     # ------------------------------------------------------------------
     def _setup_ui(self) -> None:
@@ -198,18 +189,43 @@ class LamellaDefaultConfigWidget(QWidget):
         self._params_panel.add_header_widget(self._btn_reset)
         root.addWidget(self._params_panel)
 
-        # ── right column: preview image ───────────────────────────────
+        # ── right column: live preview canvas + editable overlays ─────
         preview_widget = QWidget()
         preview_layout = QVBoxLayout(preview_widget)
         preview_layout.setContentsMargins(4, 4, 4, 4)
         preview_layout.setSpacing(4)
 
-        self.image_preview_lbl = QLabel()
-        self.image_preview_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.image_preview_lbl.setMinimumSize(_PREVIEW_W // 2, _PREVIEW_H // 2)
-        self.image_preview_lbl.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-        self.image_preview_lbl.setStyleSheet("background: black;")
-        preview_layout.addWidget(self.image_preview_lbl)
+        self.canvas = FibsemImageCanvas()
+        self.canvas.setMinimumSize(_PREVIEW_W // 2, _PREVIEW_H // 2)
+        # Config preview: keep only fit-to-view + scalebar + crosshair toggles;
+        # drop contrast / ruler (mode is already hidden until an overlay arms it).
+        self.canvas.btn_contrast.hide()
+        self.canvas.btn_toggle_ruler.hide()
+        # Seed the black background (gives the overlays their pixel dimensions and the
+        # canvas its scalebar); then attach overlays. POI is added *before* the
+        # alignment rect so its press handler wins when the marker sits inside the rect.
+        self.canvas.set_array(_PREVIEW_BG, pixel_size=_PIXEL_SIZE)
+        self._poi_overlay = PointOverlay(
+            color=_COLOR_POI,
+            selected_color=_COLOR_POI,
+            marker="+",       # thin cross, reads like the (yellow) centre crosshair
+            size=11.0,
+            edge_width=1.2,   # thin lines (centre crosshair is linewidth=1)
+            add_on_right_click=False,
+            removable=False,
+        )
+        self._aa_overlay = AlignmentAreaOverlay(color=_COLOR_AA, editable=True)
+        self.canvas.add_overlay(self._poi_overlay)
+        self.canvas.add_overlay(self._aa_overlay)
+        # Patch legend keying the three preview elements ("yellow" = the canvas's
+        # built-in centre crosshair; see FibsemImageCanvas._refresh_crosshair).
+        # Lower-left: name hint is upper-left, toolbar upper-right, scalebar lower-right.
+        self.canvas.set_legend([
+            ("yellow", "Image centre", "+"),      # matches the built-in crosshair glyph
+            (_COLOR_AA, "Alignment area"),        # a region -> filled swatch
+            (_COLOR_POI, "Point of interest", "+"),
+        ], loc="lower left")
+        preview_layout.addWidget(self.canvas)
 
         preview_panel = TitledPanel("Preview  (100 µm FIB)", content=preview_widget, collapsible=False)
         root.addWidget(preview_panel)
@@ -223,6 +239,10 @@ class LamellaDefaultConfigWidget(QWidget):
             sb.valueChanged.connect(self._on_alignment_changed)
         for sb in self._poi_widgets:
             sb.valueChanged.connect(self._on_changed)
+        # Overlay → spinbox (only fires on user drag/resize, never on programmatic set)
+        self._aa_overlay.alignment_area_changed.connect(self._on_overlay_alignment_changed)
+        self._poi_overlay.point_dragging.connect(self._on_overlay_poi_dragging)
+        self._poi_overlay.point_moved.connect(self._on_overlay_poi_moved)
 
     # ------------------------------------------------------------------
     # Public API
@@ -251,7 +271,7 @@ class LamellaDefaultConfigWidget(QWidget):
         self.name_prefix_edit.blockSignals(False)
 
         self._validate_alignment_area()
-        self._update_image_preview(template)
+        self._sync_overlays(template)
 
     def get_template(self) -> LamellaDefaultConfig:
         return LamellaDefaultConfig(
@@ -305,29 +325,54 @@ class LamellaDefaultConfigWidget(QWidget):
             self.aa_validation_lbl.setText("⚠ " + ";  ".join(issues))
             self.aa_validation_lbl.setVisible(True)
 
-    def _update_image_preview(self, template: LamellaDefaultConfig) -> None:
-        self._preview_pixmap = _render_template_preview(template)
-        self._scale_preview()
+    def _sync_overlays(self, template: LamellaDefaultConfig) -> None:
+        """Push a template onto the canvas overlays + name hint (no signals emitted)."""
+        aa = template.alignment_area if template.alignment_area is not None else _DEFAULT_AA
+        self._aa_overlay.set_area(aa)
+        self._aa_overlay.set_visible(True)
 
-    def _scale_preview(self) -> None:
-        if self._preview_pixmap is None:
-            return
-        scaled = self._preview_pixmap.scaled(
-            self.image_preview_lbl.size(),
-            Qt.AspectRatioMode.KeepAspectRatio,
-            Qt.TransformationMode.SmoothTransformation,
-        )
-        self.image_preview_lbl.setPixmap(scaled)
+        poi = template.poi if template.poi is not None else _DEFAULT_POI
+        self._poi_overlay.set_points([_poi_to_pixel(poi)])
 
-    def showEvent(self, event) -> None:
-        super().showEvent(event)
-        self._scale_preview()
+        self.canvas.set_hint(_template_name(template))
 
-    def resizeEvent(self, event) -> None:
-        super().resizeEvent(event)
-        self._scale_preview()
+    # ── overlay → spinbox sync ────────────────────────────────────────
+
+    def _on_overlay_alignment_changed(self, area: FibsemRectangle) -> None:
+        """User dragged/resized the alignment rectangle on the canvas."""
+        for sb in self._aa_widgets:
+            sb.blockSignals(True)
+        self.aa_left.setValue(area.left)
+        self.aa_top.setValue(area.top)
+        self.aa_width.setValue(area.width)
+        self.aa_height.setValue(area.height)
+        for sb in self._aa_widgets:
+            sb.blockSignals(False)
+        self._validate_alignment_area()
+        self._emit_changed()
+
+    def _on_overlay_poi_dragging(self, _idx: int, x: float, y: float) -> None:
+        """Live spinbox feedback while dragging the POI marker (no emit)."""
+        poi = _pixel_to_poi(x, y)
+        for sb in self._poi_widgets:
+            sb.blockSignals(True)
+        self.poi_x.setValue(poi.x * 1e6)
+        self.poi_y.setValue(poi.y * 1e6)
+        for sb in self._poi_widgets:
+            sb.blockSignals(False)
+
+    def _on_overlay_poi_moved(self, _idx: int, x: float, y: float) -> None:
+        """POI marker released — commit the value and notify listeners."""
+        self._on_overlay_poi_dragging(_idx, x, y)  # ensure spinboxes match the release point
+        self._emit_changed()
+
+    # ── outward change notification ───────────────────────────────────
+
+    def _emit_changed(self) -> None:
+        """Emit template_changed without re-touching the overlays (avoids echo)."""
+        self.template_changed.emit(self.get_template())
 
     def _on_changed(self) -> None:
         template = self.get_template()
-        self._update_image_preview(template)
+        self._sync_overlays(template)
         self.template_changed.emit(template)

--- a/fibsem/ui/widgets/lamella_default_config_widget.py
+++ b/fibsem/ui/widgets/lamella_default_config_widget.py
@@ -36,29 +36,34 @@ _HINT_STYLE = (
 )
 
 # Tells the user the preview is editable — without it the overlays look decorative
-# and the spinboxes read as the only way in.
+# and the spinboxes read as the only way in. Says what to drag, not what colour it
+# is; the canvas legend already names the colours.
 _CANVAS_HINT = (
-    "Drag on the preview to edit:\n"
-    "• green box (and its corners) — alignment area\n"
-    "• magenta marker — point of interest\n"
+    "Drag the box, or its corners, to set the alignment area.\n"
+    "Drag the marker to set the point of interest.\n"
     "The values above stay in sync, both ways."
 )
 
 _EXAMPLE_PETNAME = "brave-tiger"
 
-_POI_RANGE_UM = 5000.0  # POI spinbox limit, ± micrometres
-
 _AA_SPIN_W = 120   # holds a bare "0.20"
-# Sized for the widest legal POI value, "-4888.88 µm" — sign, four digits and the
-# suffix. Sizing for a typical "-3.00 µm" instead clips silently at the extremes,
-# which is how the suffix used to render as "µn".
-_POI_SPIN_W = 170
+# Sized for the widest legal POI value, "-50.00 µm" — sign, digits and the suffix.
+# Sizing for a typical "-3.00 µm" instead clips silently at the extremes, which is
+# how the suffix used to render as "µn".
+_POI_SPIN_W = 150
 
 # ── Preview image settings ─────────────────────────────────────────────────────
 _PREVIEW_HFW = 100e-6               # 100 µm horizontal field width
 _PREVIEW_W, _PREVIEW_H = 384, 288
 _PIXEL_SIZE = _PREVIEW_HFW / _PREVIEW_W
 _PREVIEW_VFW = _PREVIEW_HFW * _PREVIEW_H / _PREVIEW_W  # vertical field width (metres)
+
+# POI spinbox limits = half the preview frame, so every value the spinboxes accept
+# lands inside the image. Previously ±5000 µm, 100x what a 100 µm frame can show:
+# _poi_to_pixel clamps anything past the edge, so the marker parked on the border
+# and displayed a position it did not have (500 µm and 5000 µm looked identical).
+_POI_LIMIT_X_UM = _PREVIEW_HFW / 2 * 1e6   # 50.00
+_POI_LIMIT_Y_UM = _PREVIEW_VFW / 2 * 1e6   # 37.50
 
 _COLOR_AA = "limegreen"            # alignment area rectangle
 _COLOR_POI = "magenta"             # point of interest marker
@@ -190,11 +195,11 @@ class LamellaDefaultConfigWidget(QWidget):
         left.addWidget(poi_lbl)
 
         # Wider than the alignment-area boxes: those hold a bare "0.20", these hold a
-        # signed value plus the µm suffix ("-3.00 µm"), which does not fit in 120px.
-        self.poi_x = ValueSpinBox(suffix="µm", minimum=-_POI_RANGE_UM, maximum=_POI_RANGE_UM,
+        # signed value plus the µm suffix ("-50.00 µm"), which does not fit in 120px.
+        self.poi_x = ValueSpinBox(suffix="µm", minimum=-_POI_LIMIT_X_UM, maximum=_POI_LIMIT_X_UM,
                                   decimals=2, step=0.1)
         self.poi_x.setFixedWidth(_POI_SPIN_W)
-        self.poi_y = ValueSpinBox(suffix="µm", minimum=-_POI_RANGE_UM, maximum=_POI_RANGE_UM,
+        self.poi_y = ValueSpinBox(suffix="µm", minimum=-_POI_LIMIT_Y_UM, maximum=_POI_LIMIT_Y_UM,
                                   decimals=2, step=0.1)
         self.poi_y.setFixedWidth(_POI_SPIN_W)
         self._poi_widgets = [self.poi_x, self.poi_y]
@@ -202,7 +207,9 @@ class LamellaDefaultConfigWidget(QWidget):
         _poi_tip = (
             "The point of interest is the initial target position within the image for\n"
             "the lamella workflow. It is defined as an offset from the image centre.\n"
-            "Units: micrometres (µm). Positive X is right, positive Y is up."
+            "Units: micrometres (µm). Positive X is right, positive Y is up.\n"
+            f"Limited to the {_PREVIEW_HFW * 1e6:.0f} µm preview frame "
+            f"(X ±{_POI_LIMIT_X_UM:.2f}, Y ±{_POI_LIMIT_Y_UM:.2f})."
         )
         self.poi_x.setToolTip(f"Horizontal offset from image centre.\n{_poi_tip}")
         self.poi_y.setToolTip(f"Vertical offset from image centre.\n{_poi_tip}")
@@ -214,6 +221,15 @@ class LamellaDefaultConfigWidget(QWidget):
         # spinbox has the µm suffix.
         left.addLayout(_row("X", self.poi_x))
         left.addLayout(_row("Y", self.poi_y))
+
+        # A protocol saved before the limits existed can carry a POI outside the frame.
+        # setValue() clamps silently, which would rewrite the stored value the moment
+        # the dialog opened — say so instead of quietly changing it.
+        self.poi_clamped_lbl = QLabel()
+        self.poi_clamped_lbl.setStyleSheet(_INVALID_STYLE)
+        self.poi_clamped_lbl.setWordWrap(True)
+        self.poi_clamped_lbl.setVisible(False)
+        left.addWidget(self.poi_clamped_lbl)
         left.addStretch()
 
         # pinned below the stretch so it sits at the foot of the panel, clear of the controls
@@ -302,6 +318,7 @@ class LamellaDefaultConfigWidget(QWidget):
         poi = template.poi if template.poi is not None else _DEFAULT_POI
         self.poi_x.setValue(poi.x * 1e6)
         self.poi_y.setValue(poi.y * 1e6)
+        self._report_poi_clamped(poi)
 
         for w in [self.use_petname_cb, *self._aa_widgets, *self._poi_widgets]:
             w.blockSignals(False)
@@ -340,6 +357,25 @@ class LamellaDefaultConfigWidget(QWidget):
     def _on_alignment_changed(self) -> None:
         self._validate_alignment_area()
         self._on_changed()
+
+    def _report_poi_clamped(self, poi: Point) -> None:
+        """Warn if *poi* fell outside the preview frame and was clamped on load.
+
+        The spinboxes bound the POI to the frame, so anything further in is silently
+        pulled to the edge by setValue. Left unsaid, opening the dialog and pressing
+        OK would rewrite a stored value the user never touched.
+        """
+        out = []
+        if abs(poi.x * 1e6) > _POI_LIMIT_X_UM:
+            out.append(f"X {poi.x * 1e6:.2f} → {self.poi_x.value():.2f} µm")
+        if abs(poi.y * 1e6) > _POI_LIMIT_Y_UM:
+            out.append(f"Y {poi.y * 1e6:.2f} → {self.poi_y.value():.2f} µm")
+        if out:
+            self.poi_clamped_lbl.setText(
+                f"Outside the {_PREVIEW_HFW * 1e6:.0f} µm preview frame, clamped: "
+                + ", ".join(out)
+            )
+        self.poi_clamped_lbl.setVisible(bool(out))
 
     def _validate_alignment_area(self) -> None:
         aa = FibsemRectangle(

--- a/fibsem/ui/widgets/lamella_default_config_widget.py
+++ b/fibsem/ui/widgets/lamella_default_config_widget.py
@@ -46,6 +46,14 @@ _CANVAS_HINT = (
 
 _EXAMPLE_PETNAME = "brave-tiger"
 
+_POI_RANGE_UM = 5000.0  # POI spinbox limit, ± micrometres
+
+_AA_SPIN_W = 120   # holds a bare "0.20"
+# Sized for the widest legal POI value, "-4888.88 µm" — sign, four digits and the
+# suffix. Sizing for a typical "-3.00 µm" instead clips silently at the extremes,
+# which is how the suffix used to render as "µn".
+_POI_SPIN_W = 170
+
 # ── Preview image settings ─────────────────────────────────────────────────────
 _PREVIEW_HFW = 100e-6               # 100 µm horizontal field width
 _PREVIEW_W, _PREVIEW_H = 384, 288
@@ -151,13 +159,13 @@ class LamellaDefaultConfigWidget(QWidget):
         left.addWidget(aa_lbl)
 
         self.aa_left   = ValueSpinBox(minimum=0.0, maximum=1.0, decimals=2, step=0.01)
-        self.aa_left.setFixedWidth(120)
+        self.aa_left.setFixedWidth(_AA_SPIN_W)
         self.aa_top    = ValueSpinBox(minimum=0.0, maximum=1.0, decimals=2, step=0.01)
-        self.aa_top.setFixedWidth(120)
+        self.aa_top.setFixedWidth(_AA_SPIN_W)
         self.aa_width  = ValueSpinBox(minimum=0.0, maximum=1.0, decimals=2, step=0.01)
-        self.aa_width.setFixedWidth(120)
+        self.aa_width.setFixedWidth(_AA_SPIN_W)
         self.aa_height = ValueSpinBox(minimum=0.0, maximum=1.0, decimals=2, step=0.01)
-        self.aa_height.setFixedWidth(120)
+        self.aa_height.setFixedWidth(_AA_SPIN_W)
         self._aa_widgets = [self.aa_left, self.aa_top, self.aa_width, self.aa_height]
 
         _aa_tip = (
@@ -181,10 +189,14 @@ class LamellaDefaultConfigWidget(QWidget):
         poi_lbl.setStyleSheet(_SECTION_STYLE)
         left.addWidget(poi_lbl)
 
-        self.poi_x = ValueSpinBox(suffix="µm", minimum=-5000.0, maximum=5000.0, decimals=2, step=0.1)
-        self.poi_x.setFixedWidth(120)
-        self.poi_y = ValueSpinBox(suffix="µm", minimum=-5000.0, maximum=5000.0, decimals=2, step=0.1)
-        self.poi_y.setFixedWidth(120)
+        # Wider than the alignment-area boxes: those hold a bare "0.20", these hold a
+        # signed value plus the µm suffix ("-3.00 µm"), which does not fit in 120px.
+        self.poi_x = ValueSpinBox(suffix="µm", minimum=-_POI_RANGE_UM, maximum=_POI_RANGE_UM,
+                                  decimals=2, step=0.1)
+        self.poi_x.setFixedWidth(_POI_SPIN_W)
+        self.poi_y = ValueSpinBox(suffix="µm", minimum=-_POI_RANGE_UM, maximum=_POI_RANGE_UM,
+                                  decimals=2, step=0.1)
+        self.poi_y.setFixedWidth(_POI_SPIN_W)
         self._poi_widgets = [self.poi_x, self.poi_y]
 
         _poi_tip = (
@@ -195,7 +207,13 @@ class LamellaDefaultConfigWidget(QWidget):
         self.poi_x.setToolTip(f"Horizontal offset from image centre.\n{_poi_tip}")
         self.poi_y.setToolTip(f"Vertical offset from image centre.\n{_poi_tip}")
 
-        left.addLayout(_row("X (µm) / Y (µm)", self.poi_x, self.poi_y))
+        # One per row, unlike the paired alignment-area rows. Side by side, two boxes
+        # wide enough for "-4888.88 µm" would push the whole panel out and shrink the
+        # preview; stacked they fit inside the width the alignment rows already need,
+        # using vertical space the panel has spare. Labels carry no unit — each
+        # spinbox has the µm suffix.
+        left.addLayout(_row("X", self.poi_x))
+        left.addLayout(_row("Y", self.poi_y))
         left.addStretch()
 
         # pinned below the stretch so it sits at the foot of the panel, clear of the controls

--- a/fibsem/ui/widgets/lamella_default_config_widget.py
+++ b/fibsem/ui/widgets/lamella_default_config_widget.py
@@ -30,6 +30,19 @@ _SECTION_STYLE = (
 )
 _LABEL_STYLE = "color: #a0a0a0; min-width: 80px; font-size: 11px; background: transparent;"
 _INVALID_STYLE = "color: #E3B617; font-size: 10px; background: transparent;"
+_HINT_STYLE = (
+    "color: #808080; font-size: 10px; background: transparent;"
+    " border-top: 1px solid #4a4a4a; padding-top: 6px;"
+)
+
+# Tells the user the preview is editable — without it the overlays look decorative
+# and the spinboxes read as the only way in.
+_CANVAS_HINT = (
+    "Drag on the preview to edit:\n"
+    "• green box (and its corners) — alignment area\n"
+    "• magenta marker — point of interest\n"
+    "The values above stay in sync, both ways."
+)
 
 _EXAMPLE_PETNAME = "brave-tiger"
 
@@ -184,6 +197,12 @@ class LamellaDefaultConfigWidget(QWidget):
 
         left.addLayout(_row("X (µm) / Y (µm)", self.poi_x, self.poi_y))
         left.addStretch()
+
+        # pinned below the stretch so it sits at the foot of the panel, clear of the controls
+        self.canvas_hint_lbl = QLabel(_CANVAS_HINT)
+        self.canvas_hint_lbl.setStyleSheet(_HINT_STYLE)
+        self.canvas_hint_lbl.setWordWrap(True)
+        left.addWidget(self.canvas_hint_lbl)
 
         self._params_panel = TitledPanel("Default Parameters", content=controls_widget, collapsible=False)
         self._params_panel.add_header_widget(self._btn_reset)

--- a/fibsem/ui/widgets/tests/test_lamella_default_config_widget.py
+++ b/fibsem/ui/widgets/tests/test_lamella_default_config_widget.py
@@ -1,60 +1,229 @@
-"""Test script for LamellaDefaultConfigWidget."""
+"""Headless smoke for LamellaDefaultConfigWidget (canvas + editable overlays).
+
+Verifies the two-way sync between the spinboxes and the canvas overlays:
+  * set_template positions the alignment rect + POI marker (and is silent),
+  * dragging the alignment rect / POI marker (simulated via the overlay signals)
+    writes back to the spinboxes and emits template_changed,
+  * editing a spinbox repositions the overlay,
+  * get_template round-trips and is_valid still reflects the alignment area,
+  * the POI overlay is attached before the alignment overlay (press precedence).
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_lamella_default_config_widget.py
+"""
+from __future__ import annotations
+
 import sys
 
-from PyQt5.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QApplication
+
+import numpy as np
 
 from fibsem.applications.autolamella.structures import LamellaDefaultConfig
-from fibsem.structures import DEFAULT_ALIGNMENT_AREA, FibsemRectangle, Point
-from fibsem.ui.widgets.lamella_default_config_widget import LamellaDefaultConfigWidget
+from fibsem.structures import FibsemRectangle, Point
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.lamella_default_config_widget import (
+    LamellaDefaultConfigWidget,
+    _pixel_to_poi,
+    _poi_to_pixel,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
 
 
-def main():
-    app = QApplication(sys.argv)
+def _close(a, b, tol=1e-6):
+    return abs(a - b) < tol
 
-    win = QWidget()
-    win.setWindowTitle("LamellaDefaultConfigWidget test")
-    win.setStyleSheet("background: #1a1b1e;")
-    layout = QVBoxLayout(win)
-    layout.setContentsMargins(12, 12, 12, 12)
-    layout.setSpacing(8)
 
-    # status label shows emitted template on every change
-    status = QLabel("(change a value to see emitted template)")
-    status.setStyleSheet("color: #a0a0a0; font-size: 10px;")
-    status.setWordWrap(True)
+def _widget(template: LamellaDefaultConfig | None = None) -> LamellaDefaultConfigWidget:
+    w = LamellaDefaultConfigWidget()
+    if template is not None:
+        w.set_template(template)
+    return w
 
-    widget = LamellaDefaultConfigWidget()
 
-    # load a non-default template so all controls are exercised
-    template = LamellaDefaultConfig(
-        use_petname=False,
-        name_prefix="GridA",
-        alignment_area=FibsemRectangle.from_dict(DEFAULT_ALIGNMENT_AREA),
-        poi=Point(x=1.5e-6, y=-2.0e-6),
+_TPL = LamellaDefaultConfig(
+    use_petname=False,
+    name_prefix="GridA",
+    alignment_area=FibsemRectangle(left=0.2, top=0.3, width=0.4, height=0.5),
+    poi=Point(x=5e-6, y=-3e-6),
+)
+
+
+# ── transforms ─────────────────────────────────────────────────────────────
+
+def test_poi_pixel_roundtrip():
+    p = Point(x=7.5e-6, y=-4.2e-6)
+    px, py = _poi_to_pixel(p)
+    back = _pixel_to_poi(px, py)
+    assert _close(back.x, p.x, tol=1e-12) and _close(back.y, p.y, tol=1e-12)
+
+
+def test_poi_centre_maps_to_image_centre():
+    px, py = _poi_to_pixel(Point(0, 0))
+    assert _close(px, 384 / 2) and _close(py, 288 / 2)
+
+
+# ── set_template → overlays ──────────────────────────────────────────────────
+
+def test_set_template_positions_overlays():
+    w = _widget(_TPL)
+    area = w._aa_overlay.get_area()
+    # the rect snaps to integer pixels, so allow ~1px of normalised error
+    assert _close(area.left, 0.2, 0.005) and _close(area.top, 0.3, 0.005)
+    assert _close(area.width, 0.4, 0.005) and _close(area.height, 0.5, 0.005)
+    pt = w._poi_overlay.get_points()[0]
+    assert _close(pt[0], _poi_to_pixel(_TPL.poi)[0]) and _close(pt[1], _poi_to_pixel(_TPL.poi)[1])
+
+
+def test_set_template_is_silent():
+    w = _widget()
+    seen = []
+    w.template_changed.connect(seen.append)
+    w.set_template(_TPL)
+    assert seen == []  # programmatic set must not emit
+
+
+def test_name_hint_follows_petname():
+    w = _widget(_TPL)
+    assert w.canvas._hint_text == "GridA-Lamella-01"
+    w.set_template(LamellaDefaultConfig(use_petname=True, name_prefix="GridA"))
+    assert w.canvas._hint_text == "GridA-01-brave-tiger"
+
+
+# ── overlay drag → spinbox + emit ────────────────────────────────────────────
+
+def test_alignment_drag_updates_spinboxes_and_emits():
+    w = _widget(_TPL)
+    seen = []
+    w.template_changed.connect(seen.append)
+    new_area = FibsemRectangle(left=0.1, top=0.15, width=0.25, height=0.35)
+    w._aa_overlay.alignment_area_changed.emit(new_area)
+    assert _close(w.aa_left.value(), 0.1) and _close(w.aa_top.value(), 0.15)
+    assert _close(w.aa_width.value(), 0.25) and _close(w.aa_height.value(), 0.35)
+    assert len(seen) == 1
+    assert _close(seen[0].alignment_area.left, 0.1)
+
+
+def test_poi_move_updates_spinboxes_and_emits():
+    w = _widget(_TPL)
+    seen = []
+    w.template_changed.connect(seen.append)
+    px, py = 250.0, 100.0
+    w._poi_overlay.point_moved.emit(0, px, py)
+    expected = _pixel_to_poi(px, py)
+    assert _close(w.poi_x.value(), expected.x * 1e6, 0.01)  # spinbox rounds to 2 dp
+    assert _close(w.poi_y.value(), expected.y * 1e6, 0.01)
+    assert len(seen) == 1
+    assert _close(seen[0].poi.x, w.poi_x.value() * 1e-6, 1e-12)  # emit matches spinbox exactly
+
+
+def test_poi_dragging_updates_spinboxes_without_emit():
+    w = _widget(_TPL)
+    seen = []
+    w.template_changed.connect(seen.append)
+    px, py = 300.0, 80.0
+    w._poi_overlay.point_dragging.emit(0, px, py)
+    expected = _pixel_to_poi(px, py)
+    assert _close(w.poi_x.value(), expected.x * 1e6, 0.01)
+    assert seen == []  # live drag feedback is silent until release
+
+
+# ── spinbox → overlay ────────────────────────────────────────────────────────
+
+def test_spinbox_edit_repositions_alignment_overlay():
+    w = _widget(_TPL)
+    seen = []
+    w.template_changed.connect(seen.append)
+    w.aa_left.setValue(0.05)  # distinct from _TPL (0.2) → valueChanged fires
+    assert _close(w._aa_overlay.get_area().left, 0.05, 0.005)  # pixel-snapped
+    assert len(seen) == 1
+
+
+def test_spinbox_edit_repositions_poi_overlay():
+    w = _widget(_TPL)
+    w.poi_x.setValue(12.0)  # µm, distinct from _TPL (5 µm)
+    px, _ = w._poi_overlay.get_points()[0]
+    assert _close(px, _poi_to_pixel(Point(x=12e-6, y=_TPL.poi.y))[0])
+
+
+# ── round-trip + validation + invariants ─────────────────────────────────────
+
+def test_get_template_roundtrips():
+    w = _widget(_TPL)
+    t = w.get_template()
+    assert t.use_petname is False and t.name_prefix == "GridA"
+    assert _close(t.alignment_area.left, 0.2) and _close(t.alignment_area.height, 0.5)
+    assert _close(t.poi.x, 5e-6, tol=1e-12) and _close(t.poi.y, -3e-6, tol=1e-12)
+
+
+def test_is_valid_tracks_alignment_area():
+    w = _widget(_TPL)
+    assert w.is_valid() is True
+    w.set_template(
+        LamellaDefaultConfig(alignment_area=FibsemRectangle(left=0.8, top=0.0, width=0.5, height=0.5))
     )
-    widget.set_template(template)
+    assert w.is_valid() is False  # left + width = 1.3 > 1
 
-    def _on_changed(t: LamellaDefaultConfig):
-        aa = t.alignment_area
-        poi = t.poi
-        aa_str = f"FibsemRectangle({aa.left:.3f}, {aa.top:.3f}, {aa.width:.3f}, {aa.height:.3f})" if aa else "None"
-        poi_str = f"Point({poi.x*1e6:.3f} µm, {poi.y*1e6:.3f} µm)" if poi else "None"
-        status.setText(
-            f"use_petname={t.use_petname}  prefix='{t.name_prefix}'\n"
-            f"alignment_area={aa_str}\n"
-            f"poi={poi_str}"
-        )
 
-    widget.template_changed.connect(_on_changed)
+def test_poi_attached_before_alignment_for_press_precedence():
+    w = _widget()
+    overlays = w.canvas._overlays
+    assert overlays.index(w._poi_overlay) < overlays.index(w._aa_overlay)
 
-    layout.addWidget(widget)
-    layout.addWidget(status)
-    layout.addStretch()
 
-    win.resize(780, 340)
-    win.show()
-    sys.exit(app.exec_())
+# ── POI style + legend ───────────────────────────────────────────────────────
+
+def test_poi_marker_is_thin_cross():
+    w = _widget()
+    assert w._poi_overlay._marker == "+"       # thin cross, not a filled marker
+    assert w._poi_overlay._edge_width == 1.2    # thin lines
+
+
+def test_toolbar_shows_only_view_scalebar_crosshair():
+    w = _widget()
+    assert w.canvas.btn_reset_view.isHidden() is False       # fit to view
+    assert w.canvas.btn_toggle_scalebar.isHidden() is False   # scalebar toggle
+    assert w.canvas.btn_toggle_crosshair.isHidden() is False  # crosshair toggle
+    assert w.canvas.btn_contrast.isHidden() is True           # dropped
+    assert w.canvas.btn_toggle_ruler.isHidden() is True       # dropped
+
+
+def test_legend_entries_markers_and_patch():
+    w = _widget()
+    labels = [e[1] for e in w.canvas._legend_entries]
+    assert labels == ["Image centre", "Alignment area", "Point of interest"]
+    leg = w.canvas._legend_artist
+    assert leg is not None
+    # Image centre + POI render as "+" markers; Alignment area is a filled swatch.
+    assert len(leg.get_lines()) == 2 and all(ln.get_marker() == "+" for ln in leg.get_lines())
+    assert len(leg.get_patches()) == 1
+
+
+def test_legend_survives_image_change_and_clears():
+    c = FibsemImageCanvas()
+    c.set_array(np.zeros((32, 32), dtype=np.uint8))
+    c.set_legend([("yellow", "A"), ("limegreen", "B")])
+    assert c._legend_artist is not None
+    c.set_array(np.zeros((32, 32), dtype=np.uint8))  # a new frame must not drop it
+    assert c._legend_artist is not None
+    c.set_legend(None)  # explicit clear
+    assert c._legend_artist is None and c._legend_entries is None
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/fibsem/ui/widgets/tests/test_lamella_default_config_widget.py
+++ b/fibsem/ui/widgets/tests/test_lamella_default_config_widget.py
@@ -23,6 +23,10 @@ from fibsem.applications.autolamella.structures import LamellaDefaultConfig
 from fibsem.structures import FibsemRectangle, Point
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 from fibsem.ui.widgets.lamella_default_config_widget import (
+    _POI_LIMIT_X_UM,
+    _POI_LIMIT_Y_UM,
+    _PREVIEW_H,
+    _PREVIEW_W,
     LamellaDefaultConfigWidget,
     _pixel_to_poi,
     _poi_to_pixel,
@@ -209,6 +213,57 @@ def test_legend_survives_image_change_and_clears():
     assert c._legend_artist is not None
     c.set_legend(None)  # explicit clear
     assert c._legend_artist is None and c._legend_entries is None
+
+
+# ── POI limits: every accepted value must be representable on the preview ──
+
+def test_poi_limits_match_the_preview_frame():
+    """The spinbox bounds are exactly half the frame, so no accepted value is clamped."""
+    w = _widget()
+    assert (w.poi_x.minimum(), w.poi_x.maximum()) == (-_POI_LIMIT_X_UM, _POI_LIMIT_X_UM)
+    assert (w.poi_y.minimum(), w.poi_y.maximum()) == (-_POI_LIMIT_Y_UM, _POI_LIMIT_Y_UM)
+    # x and y limits differ: the frame is 4:3, not square
+    assert _POI_LIMIT_X_UM != _POI_LIMIT_Y_UM
+
+
+def test_extreme_poi_still_lands_inside_the_image():
+    """_poi_to_pixel clamps; at the limits it must not have to, or the marker lies."""
+    for sx in (-1, 1):
+        for sy in (-1, 1):
+            poi = Point(x=sx * _POI_LIMIT_X_UM * 1e-6, y=sy * _POI_LIMIT_Y_UM * 1e-6)
+            px, py = _poi_to_pixel(poi)
+            assert 0 <= px <= _PREVIEW_W - 1 and 0 <= py <= _PREVIEW_H - 1
+            # round-trips within a pixel, i.e. it was not silently pulled to the edge
+            back = _pixel_to_poi(px, py)
+            assert abs(back.x - poi.x) < _POI_LIMIT_X_UM * 1e-6 / _PREVIEW_W * 2
+            assert abs(back.y - poi.y) < _POI_LIMIT_Y_UM * 1e-6 / _PREVIEW_H * 2
+
+
+def test_out_of_frame_poi_is_clamped_but_reported():
+    """A legacy protocol POI beyond the frame is clamped — and the user is told."""
+    w = _widget()
+    w.set_template(LamellaDefaultConfig(poi=Point(x=500e-6, y=-400e-6)))
+    assert not w.poi_clamped_lbl.isHidden()  # isVisible() is False while the parent is unshown
+    msg = w.poi_clamped_lbl.text()
+    assert "500.00" in msg and "-400.00" in msg  # the original values are named
+    t = w.get_template()
+    assert _close(t.poi.x, _POI_LIMIT_X_UM * 1e-6, tol=1e-12)
+    assert _close(t.poi.y, -_POI_LIMIT_Y_UM * 1e-6, tol=1e-12)
+
+
+def test_in_frame_poi_reports_nothing():
+    w = _widget()
+    w.set_template(LamellaDefaultConfig(poi=Point(x=5e-6, y=-3e-6)))
+    assert w.poi_clamped_lbl.isHidden()
+
+
+def test_clamp_warning_clears_when_a_valid_template_is_loaded():
+    """The warning must not persist across loads."""
+    w = _widget()
+    w.set_template(LamellaDefaultConfig(poi=Point(x=500e-6, y=0)))
+    assert not w.poi_clamped_lbl.isHidden()  # isVisible() is False while the parent is unshown
+    w.set_template(LamellaDefaultConfig(poi=Point(x=1e-6, y=0)))
+    assert w.poi_clamped_lbl.isHidden()
 
 
 def main() -> int:


### PR DESCRIPTION
The Default Parameters dialog showed the alignment area and point of interest as a static picture — a 100 µm FIB frame rendered with PIL and redrawn from scratch whenever a spinbox changed. You could see roughly where things were, but the only way to move them was to type numbers.

The preview is now a real `FibsemImageCanvas` with two editable overlays: the alignment area as a lime `AlignmentAreaOverlay` with drag handles, and the point of interest as a magenta `PointOverlay`. Both stay in two-way sync with the spinboxes — drag on the canvas and the numbers follow, type a number and the overlay moves. Programmatic updates don't echo back, so loading a template doesn't emit spurious change signals.

It also drops the decoration the PIL renderer had to hand-roll. The canvas supplies the scalebar and centre crosshair from the pixel size, and a legend now names the three markers — previously the image-centre and point-of-interest crosses were both thin crosshairs sitting almost on top of each other with nothing to distinguish them.

### Before / after

| before | after |
|---|---|
| solid rect, no handles, no legend; the two crosses overlap ambiguously | dashed rect with drag handles, labelled legend, canvas scalebar |

### Why this is independently mergeable

It became extractable only once #199 put the canvas package on main. It depends on nothing else from the napari cutover:

- no `napari` import
- no `MicroscopeViewController` — it constructs the canvas directly, so it works standalone in the dialog exactly as it does inside the migrated main window

Every import resolves against current main (`FibsemImageCanvas`, `AlignmentAreaOverlay`, `PointOverlay`, `TitledPanel`, `IconToolButton`, `ValueSpinBox`, `DEFAULT_ALIGNMENT_AREA`, `NAPARI_STYLE`, `LamellaDefaultConfig`). One importer, `autolamella_task_config_editor.py`, is unaffected.

### Tests

`test_lamella_default_config_widget.py` was a manual demo harness with zero test functions; it becomes **17 real ones** — POI pixel round-trip, overlay↔spinbox sync in both directions, silent programmatic updates, template round-tripping, alignment-area validity.

17 passed when run directly. Full suite: 1418 passed, 15 skipped.

**Caveat worth stating plainly:** those 17 do **not** run on CI, and aren't picked up by a plain `pytest fibsem/ui/widgets/tests/` either — that directory mixes real tests with demo harnesses and currently fails collection on three of them. Filed as [FIB-382](https://linear.app/fibsemos/issue/FIB-382/64-real-pytest-tests-under-fibsemuiwidgetstests-are-never-run-not-by) rather than fixed here, because moving one file leaves the directory just as broken and adds churn against the open cutover branch. There are 64 such tests in that directory today.

### Context

Extracted from #111, the sixth stream to come out of it (after #199 canvas, #200 manipulator, #201 FunctionWorker, #210 autofocus, #211 spot-burn settings). This is the last independently mergeable piece — what remains in #111 is the cutover itself.

This is a visible UI change, so it wants a click-through of Protocol → Default Parameters, but no microscope.

---

## Follow-up commits on this branch

Three fixes on top of the extraction, from a design pass over the dialog.

**`fa0c77c0` — say the preview is draggable.** The overlays are editable but nothing said so, which made them read as decoration and the spinboxes as the only way in. A muted three-line hint at the foot of the panel says what to drag and that both directions stay in sync. It names the controls, not the colours — the canvas legend already covers those.

**`396f22d2` — stop the POI fields clipping their own values.** They rendered "5.00 µm" as "5.00 µn": 120px of box leaves 60px of text area, and "-3.00 µm" needs 71px, so the suffix was cut mid-glyph. The row label was clipped too ("X (µm) / Y (µm)" needs 85px in an 80px column). Both pre-date this PR.

Widening the boxes in place worked but pushed the panel out and took the width off the preview. Stacking X and Y on their own rows fits them inside the width the alignment rows already need — panel +16px instead of +60px, canvas keeps its size, using vertical space the panel had spare.

**`40bb7bd5` — bound the POI to the preview frame.** The spinboxes accepted ±5000 µm on both axes. The preview is 100 × 75 µm, so only x ±50 µm and y ±37.5 µm are representable; `_poi_to_pixel` clamps anything further to the edge, and the marker then sat on the border showing a position it did not have — 500 µm and 5000 µm rendered identically. The single ±5000 bound was also wrong on its own terms, since the frame is 4:3.

Limits now derive from the frame, so every accepted value lands inside the image. Verified at all four corners: no clamping, and the pixel round-trip returns to within a pixel.

**Behaviour change worth a look:** a protocol written before the limits can carry a larger POI, and `setValue` clamps silently — opening the dialog and pressing OK would have rewritten a stored value nobody touched. It now warns, naming both the original and clamped value, and clears on the next valid load.

Tests: 22 (5 new — limits, corner round-trip, the clamp report, and that it does not persist).
