### PR TITLE
[spot-burn] Run an optional FIB autofocus before the burn (FIB-378)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -388,8 +388,19 @@ class AutoLamellaTask(ABC):
                                         stop_event=self._stop_event,
                                         run_name=f"{self.lamella.name} - {self.task_name}")
 
-    def _run_autofocus(self, beam_type, hfw: float = None) -> None:
-        """Run the image-based autofocus sweep, saving diagnostics to the lamella path."""
+    def _run_autofocus(self, beam_type: BeamType, hfw: Optional[float] = None) -> None:
+        """Run the image-based autofocus sweep, saving diagnostics to the lamella path.
+
+        Args:
+            beam_type: which beam to focus.
+            hfw: field width for the probe images. Defaults to the task's configured
+                imaging hfw. Pass the field of view the task actually images at, so the
+                sweep is scored on the same view the task goes on to use.
+
+        A user Stop raises OperationCancelledError out of run_auto_focus (which restores
+        the starting working distance first); _is_cancellation treats that as a
+        cancellation rather than a task failure, so it is deliberately not caught here.
+        """
         from fibsem.autofunctions.autofocus import run_auto_focus, AutoFocusSettings, FocusSweepPass
         settings = AutoFocusSettings(
             method="tenengrad",
@@ -399,12 +410,18 @@ class AutoLamellaTask(ABC):
             ],
             reduced_area=FibsemRectangle(0.25, 0.25, 0.5, 0.5),
             use_autocontrast=True)
+        # NOTE: config.imaging, not self.image_settings -- only two subclasses define
+        # that attribute, and only partway through their own _run().
+        # `is None` rather than `or`, so an explicit hfw=0 is not silently replaced.
+        if hfw is None:
+            hfw = self.config.imaging.hfw
         self.log_status_message("AUTOFOCUS", f"Running autofocus ({beam_type.name})...")
         result = run_auto_focus(
             self.microscope,
             beam_type=beam_type,
-            hfw=hfw or self.image_settings.hfw,
+            hfw=hfw,
             settings=settings,
+            stop_event=self._stop_event,
         )
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         result.save(path=os.path.join(self.lamella.path, "autofunctions"), name=f"{self.task_name}_autofocus_{ts}")

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -44,6 +44,14 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
             'scale': 1
         }
     )
+    autofocus: bool = field(
+        default=False,
+        metadata={
+            "help": "Run a FIB autofocus before acquiring the reference image, so the "
+                    "points are placed on (and burned into) a focused image",
+            "label": "Autofocus",
+        },
+    )
     coordinates: list[Point] = field(
         default_factory=list,
         metadata={"help": "Spot burn positions in normalised image coordinates (0-1)"},
@@ -59,6 +67,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
         ddict["parameters"] = {
             "milling_current": self.milling_current,
             "exposure_time": self.exposure_time,
+            "autofocus": self.autofocus,
         }
         ddict["milling"] = {k: v.to_dict() for k, v in self.milling.items()}
         if self.reference_imaging is not None:
@@ -78,6 +87,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
             # coerce numeric params: older protocols may have stored these as strings
             milling_current=float(params.get("milling_current", 60.0e-12)),
             exposure_time=int(float(params.get("exposure_time", 10))),
+            autofocus=bool(params.get("autofocus", False)),
             coordinates=coordinates,
         )
 
@@ -114,8 +124,15 @@ class SpotBurnFiducialTask(AutoLamellaTask):
 
         self.config.exposure_time = float(self.config.exposure_time)
 
+        # focus before the reference image, not after: the points are placed on that
+        # image, and the burn lands where they were placed. Same field of view, so the
+        # sweep is scored on the view the user actually works in.
+        field_of_view = self.config.reference_imaging.field_of_view1
+        if self.config.autofocus:
+            self._run_autofocus(BeamType.ION, hfw=field_of_view)
+
         # acquire images, set ui
-        self._acquire_reference_image(image_settings, field_of_view=self.config.reference_imaging.field_of_view1)
+        self._acquire_reference_image(image_settings, field_of_view=field_of_view)
 
         self.log_status_message("SPOT_BURN_FIDUCIAL", "Running Spot Burn...")
 

--- a/fibsem/autofunctions/autofocus.py
+++ b/fibsem/autofunctions/autofocus.py
@@ -333,10 +333,16 @@ def run_auto_focus(
         beam_type: Which beam to focus.
         hfw: Horizontal field width for probe images (metres).
         settings: ``AutoFocusSettings``; defaults constructed if ``None``.
+        stop_event: Cancellation event, polled between passes and between working
+            distance steps. On cancel the starting working distance is restored and
+            ``OperationCancelledError`` is raised.
 
     Returns:
         ``AutoFocusResult`` with the best probe image, winning working
         distance, focus score, and full per-pass iteration history.
+
+    Raises:
+        OperationCancelledError: if ``stop_event`` is set during the sweep.
     """
     from fibsem.autofunctions.metrics import get_focus_measure_function
     from fibsem.structures import BeamType, ImageSettings

--- a/tests/autolamella/test_spot_burn_autofocus.py
+++ b/tests/autolamella/test_spot_burn_autofocus.py
@@ -1,0 +1,204 @@
+"""Tests for the FIB autofocus step in SpotBurnFiducialTask (FIB-378).
+
+Covers the config field round-trip, the ordering (focus before the reference image
+the points are placed on), and the `_run_autofocus` helper — which until now read
+`self.image_settings`, an attribute the base class never defines.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
+    SpotBurnFiducialTaskConfig,
+)
+from fibsem.structures import BeamType, Point
+
+
+# --- config -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_autofocus_survives_a_config_round_trip(value):
+    """to_dict/from_dict are hand-written here — a new field is easy to drop."""
+    config = SpotBurnFiducialTaskConfig(task_name="Spot Burn", autofocus=value)
+    assert SpotBurnFiducialTaskConfig.from_dict(config.to_dict()).autofocus is value
+
+
+def test_autofocus_is_off_by_default():
+    """Opt-in: adds a sweep to every spot burn run, and the ranges are unvalidated."""
+    assert SpotBurnFiducialTaskConfig(task_name="Spot Burn").autofocus is False
+
+
+def test_autofocus_defaults_off_for_older_protocols():
+    config = SpotBurnFiducialTaskConfig.from_dict(
+        {"task_type": "SPOT_BURN_FIDUCIAL", "parameters": {}}
+    )
+    assert config.autofocus is False
+
+
+def test_autofocus_is_exposed_as_a_task_parameter():
+    """The parameters form is generated from this tuple, so the checkbox comes free."""
+    assert "autofocus" in SpotBurnFiducialTaskConfig(task_name="Spot Burn").parameters
+
+
+def test_autofocus_is_not_part_of_the_run_payload():
+    """SpotBurnSettings is what to burn; autofocus is a workflow concern (see #211)."""
+    settings = SpotBurnFiducialTaskConfig(task_name="Spot Burn", autofocus=True).to_settings()
+    assert not hasattr(settings, "autofocus")
+
+
+# --- task ordering ----------------------------------------------------------
+
+
+def _make_task(tmp_path, *, autofocus: bool):
+    from fibsem.applications.autolamella.structures import Lamella
+    from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
+        SpotBurnFiducialTask,
+    )
+
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+    config = SpotBurnFiducialTaskConfig(
+        task_name="Spot Burn Fiducial",
+        autofocus=autofocus,
+        coordinates=[Point(0.5, 0.5)],
+    )
+    return SpotBurnFiducialTask(
+        microscope=MagicMock(), config=config, lamella=lamella, parent_ui=None
+    )
+
+
+def _record_run(task, calls):
+    """Stub out everything _run does except the autofocus/reference-image ordering."""
+    task._move_to_milling_pose = lambda: calls.append(("move", None))
+    task._align_reference_image = lambda *a, **k: calls.append(("align", None))
+    task._run_autofocus = lambda beam_type, hfw=None: calls.append(("autofocus", (beam_type, hfw)))
+    task._acquire_reference_image = lambda *a, **k: calls.append(("reference", k.get("field_of_view")))
+    task._acquire_set_of_reference_images = lambda *a, **k: calls.append(("final", None))
+    task.update_spot_burn_parameters_ui = lambda: calls.append(("burn", None))
+    task.log_status_message = lambda *a, **k: None
+
+
+def test_autofocus_runs_before_the_reference_image(tmp_path):
+    """The points are placed on that image, so focusing after it would be too late."""
+    task = _make_task(tmp_path, autofocus=True)
+    calls = []
+    _record_run(task, calls)
+
+    task._run()
+
+    steps = [name for name, _ in calls]
+    assert steps.index("autofocus") < steps.index("reference")
+    assert steps.index("autofocus") < steps.index("burn")
+
+
+def test_autofocus_uses_the_reference_field_of_view(tmp_path):
+    """Sweep at the field of view the task images at, not some unrelated hfw."""
+    task = _make_task(tmp_path, autofocus=True)
+    calls = []
+    _record_run(task, calls)
+
+    task._run()
+
+    args = dict(calls)["autofocus"]
+    assert args == (BeamType.ION, task.config.reference_imaging.field_of_view1)
+    assert dict(calls)["reference"] == task.config.reference_imaging.field_of_view1
+
+
+def test_no_autofocus_when_disabled(tmp_path):
+    task = _make_task(tmp_path, autofocus=False)
+    calls = []
+    _record_run(task, calls)
+
+    task._run()
+
+    assert "autofocus" not in [name for name, _ in calls]
+
+
+# --- _run_autofocus helper --------------------------------------------------
+
+
+def _make_autofocus_task(tmp_path, monkeypatch):
+    """A task with run_auto_focus stubbed, returning the kwargs it was called with."""
+    import fibsem.autofunctions.autofocus as af
+
+    task = _make_task(tmp_path, autofocus=True)
+    task.log_status_message = lambda *a, **k: None
+    (tmp_path / "lam").mkdir(parents=True, exist_ok=True)
+
+    calls = []
+
+    def _fake_run_auto_focus(microscope, **kwargs):
+        calls.append(kwargs)
+        return MagicMock(working_distance=16.5e-3, focus_score=1.0)
+
+    monkeypatch.setattr(af, "run_auto_focus", _fake_run_auto_focus)
+    return task, calls
+
+
+def test_run_autofocus_defaults_hfw_from_the_task_config(tmp_path, monkeypatch):
+    """Regression: this read self.image_settings, which AutoLamellaTask never defines.
+
+    Only select_position and rough create that attribute, and only partway through
+    their own _run() — so the default-hfw path raised AttributeError everywhere else,
+    including in the spot burn task this feature targets.
+    """
+    task, calls = _make_autofocus_task(tmp_path, monkeypatch)
+
+    task._run_autofocus(BeamType.ION)  # no explicit hfw
+
+    assert calls[0]["hfw"] == task.config.imaging.hfw
+
+
+def test_config_imaging_hands_back_the_stored_object_not_a_copy():
+    """The invariant that makes swapping self.image_settings for config.imaging safe.
+
+    select_position captures `self.image_settings = self.config.imaging` and the
+    acquisition helpers then mutate `.hfw` on it. Reading config.imaging instead is
+    only behaviour-preserving because the property returns that same object — if it
+    ever starts returning a copy, the default hfw silently diverges from the field of
+    view the task is actually imaging at.
+    """
+    config = SpotBurnFiducialTaskConfig(task_name="Spot Burn")
+    assert config.imaging is config.reference_imaging.imaging
+    assert config.imaging is config.imaging
+
+    captured = config.imaging  # what select_position.py:58 does
+    captured.hfw = 1.234e-4  # what _acquire_channels does
+    assert config.imaging.hfw == 1.234e-4
+
+
+def test_run_autofocus_honours_an_explicit_zero_hfw(tmp_path, monkeypatch):
+    """`hfw or default` silently replaced 0; `hfw is None` does not."""
+    task, calls = _make_autofocus_task(tmp_path, monkeypatch)
+
+    task._run_autofocus(BeamType.ION, hfw=0)
+
+    assert calls[0]["hfw"] == 0
+
+
+def test_run_autofocus_passes_the_stop_event(tmp_path, monkeypatch):
+    """run_auto_focus became cancellable in #210; the task has to opt in."""
+    import threading
+
+    task, calls = _make_autofocus_task(tmp_path, monkeypatch)
+    task._stop_event = threading.Event()
+
+    task._run_autofocus(BeamType.ION, hfw=150e-6)
+
+    assert calls[0]["stop_event"] is task._stop_event
+
+
+def test_run_autofocus_lets_cancellation_propagate(tmp_path, monkeypatch):
+    """_is_cancellation turns this into "cancelled", not "failed" — don't swallow it."""
+    import fibsem.autofunctions.autofocus as af
+    from fibsem.cancellation import OperationCancelledError
+
+    task, _ = _make_autofocus_task(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        af, "run_auto_focus", MagicMock(side_effect=OperationCancelledError("stopped"))
+    )
+
+    with pytest.raises(OperationCancelledError):
+        task._run_autofocus(BeamType.ION, hfw=150e-6)
+
+    assert task._is_cancellation(OperationCancelledError("stopped")) is True


### PR DESCRIPTION
Spot burn points are placed on the reference image, and the burn lands where they were placed — so an out-of-focus reference image costs accuracy twice. Adds an `autofocus` flag to `SpotBurnFiducialTaskConfig` that runs the existing image-based sweep before that image is acquired, at the same field of view, so the sweep is scored on the view the user actually works in.

**Off by default.** It adds a sweep to every run, and the ranges have never been exercised on hardware.

The flag lives on the task config rather than `SpotBurnSettings`, matching the line #211 drew: `SpotBurnSettings` is the run payload (coordinates + current + exposure), workflow concerns stay on the config. `to_settings()`/`apply_settings()` are unchanged. `to_dict`/`from_dict` are hand-written here, so the field is threaded through both — it defaults to `False` for protocols saved before it existed.

## ⚠️ This changes behaviour outside spot burn

`_run_autofocus` did not pass a `stop_event`, so its sweeps were uncancellable even after #210 made `run_auto_focus` honour one. It now passes the task's.

**`select_position` is the only caller today**, so `SELECT_MILLING_POSITION` is what actually starts behaving differently: with `use_autofocus` set, its SEM and FIB sweeps ([:70](https://github.com/fibsem-os/fibsem-os/blob/main/fibsem/applications/autolamella/workflows/tasks/select_position.py#L70), [:71](https://github.com/fibsem-os/fibsem-os/blob/main/fibsem/applications/autolamella/workflows/tasks/select_position.py#L71), [:100](https://github.com/fibsem-os/fibsem-os/blob/main/fibsem/applications/autolamella/workflows/tasks/select_position.py#L100)) go from ignoring a Stop to aborting on one, with the starting working distance restored, reported as cancelled rather than failed.

That is the intended effect of #210 and I think it's right — a SEM + FIB sweep pair is exactly what you want to be able to interrupt — but it wants checking on hardware alongside the new path. Happy to split it out if you'd rather this PR stayed a no-op for existing tasks.

`OperationCancelledError` is deliberately **not** caught in `_run_autofocus`: `_is_cancellation` already classifies it as a user Stop rather than a task failure. Noted in the docstring so it doesn't get "fixed" later by swallowing it.

## The `self.image_settings` fix

The hfw fallback read `self.image_settings.hfw`, an attribute `AutoLamellaTask` never defines. Only `select_position` (`:58`) and `rough` (`:64`) create it, as a side effect partway through their own `_run()`; every other task uses a local. Called from anywhere else without an explicit `hfw`, it raises `AttributeError` — a latent trap that spot burn would have walked straight into.

Now reads `config.imaging`, which every task has. **This is behaviour-preserving**: `config.imaging` is a property returning the same `reference_imaging.imaging` object `select_position` binds at line 58 — not a copy — so the two names always read the same value, including after the acquisition helpers mutate `.hfw`. Verified by identity rather than inference, and `test_config_imaging_hands_back_the_stored_object_not_a_copy` guards it: if that property ever starts returning a copy, the test fails rather than the default hfw silently diverging.

The fallback also guards on `hfw is None` rather than `hfw or`, so an explicit `hfw=0` isn't silently replaced. No current caller passes one.

Plus the `stop_event` docstring gap #210 left in `run_auto_focus`.

## Testing

Full suite: 1431 passed, 15 skipped (skips pre-existing — missing correlation LUT and volume data files).

14 new tests in `tests/autolamella/test_spot_burn_autofocus.py`: config round-trip and off-by-default, autofocus ordering (before the reference image, at the matching field of view), no sweep when disabled, and the `_run_autofocus` helper itself — default hfw from config, the `hfw=0` case, the stop event being passed, cancellation propagating, and the copy-vs-reference invariant above.

**Not hardware verified.** Two things to check on the instrument before trusting this: the sweep ranges (±0.5mm coarse in 100µm steps, ±50µm fine in 10µm, inherited from the helper as written rather than measured), and that a real Stop during `SELECT_MILLING_POSITION`'s autofocus behaves.
