### PR TITLE
[ui] Add a spot-burn coordinate editor to the protocol editor (FIB-380)

### DIFF
--- a/fibsem/ui/widgets/autolamella_task_config_editor.py
+++ b/fibsem/ui/widgets/autolamella_task_config_editor.py
@@ -21,6 +21,7 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem.applications.autolamella.workflows.tasks import get_tasks
+from fibsem.structures import BeamType, FibsemImage
 from fibsem.ui import stylesheets
 from fibsem.applications.autolamella.ui.autolamella_fluorescence_acquisition_task_config_widget import (
     AutoLamellaFluorescenceAcquisitionTaskConfigWidget,
@@ -29,10 +30,9 @@ from fibsem.applications.autolamella.workflows.tasks.tasks import (
     AcquireFluorescenceImageConfig,
     SpotBurnFiducialTaskConfig,
 )
-from fibsem.ui.widgets.autolamella_spot_burn_coordinates_widget import (
-    AutoLamellaSpotBurnCoordinatesWidget,
-)
 from fibsem.ui.widgets.autolamella_global_task_editor_dialog import AutoLamellaGlobalTaskEditDialog
+from fibsem.ui.widgets.canvas.quad_view import LamellaEditorView, MicroscopeViewController
+from fibsem.ui.widgets.spot_burn_coordinates_widget import SpotBurnCoordinatesWidget
 from fibsem.ui.widgets.lamella_default_config_widget import LamellaDefaultConfigWidget
 from fibsem.ui.widgets.custom_widgets import (
     TaskNameListWidget,
@@ -219,12 +219,6 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
             parent=self
         )
 
-        # self.spot_burn_coordinates_widget = AutoLamellaSpotBurnCoordinatesWidget(
-        #     viewer=self.viewer,
-        #     config=None,
-        #     parent=self
-        # )
-
         # lamella, milling controls (Column 1)
         self.task_list_widget = TaskNameListWidget()
 
@@ -241,6 +235,15 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         self.pushButton_open_lamella_defaults.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         self.pushButton_open_lamella_defaults.setToolTip("Edit the initial state applied to every new lamella created from this protocol.")
 
+        # only meaningful for a spot-burn task; shown/hidden in _on_selected_task_changed
+        self.pushButton_edit_spot_burn = QPushButton("Spot Burn Coordinates")
+        self.pushButton_edit_spot_burn.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.pushButton_edit_spot_burn.setToolTip(
+            "Place this task's default spot-burn coordinates on a reference frame, "
+            "instead of hand-editing them in the protocol file."
+        )
+        self.pushButton_edit_spot_burn.setVisible(False)
+
         self.label_warning = QLabel("")
         self.label_warning.setStyleSheet("color: orange;")
         self.label_warning.setVisible(False)
@@ -250,6 +253,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         self.button_layout.addWidget(self.pushButton_sync_to_lamella)
         self.button_layout.addWidget(self.pushButton_open_global_editor)
         self.button_layout.addWidget(self.pushButton_open_lamella_defaults)
+        self.button_layout.addWidget(self.pushButton_edit_spot_burn)
 
         self.grid_layout = QGridLayout()
         self.grid_layout.addWidget(self.task_list_widget, 0, 0, 1, 2)
@@ -275,7 +279,6 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         col2_layout.addWidget(self.task_parameters_config_widget)
         col2_layout.addWidget(self.ref_image_params_widget)
         col2_layout.addWidget(self.fluorescence_acquisition_task_config_widget)
-        # col2_layout.addWidget(self.spot_burn_coordinates_widget)
         col2_layout.addStretch()
         col2_scroll = QScrollArea()
         col2_scroll.setWidgetResizable(True)
@@ -319,7 +322,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         self.task_parameters_config_widget.parameter_changed.connect(self._on_task_parameters_config_changed)
         self.ref_image_params_widget.settings_changed.connect(self._on_ref_image_settings_changed)
         self.fluorescence_acquisition_task_config_widget.settings_changed.connect(self._on_fluorescence_acquisition_settings_changed)
-        # self.spot_burn_coordinates_widget.settings_changed.connect(self._on_spot_burn_coordinates_changed)
+        self.pushButton_edit_spot_burn.clicked.connect(self._on_spot_burn_coordinates_clicked)
         self.pushButton_sync_to_lamella.clicked.connect(self._on_sync_to_lamella_clicked)
         self.pushButton_open_global_editor.clicked.connect(self._on_global_edit_clicked)
         self.pushButton_open_lamella_defaults.clicked.connect(self._on_lamella_defaults_clicked)
@@ -364,11 +367,11 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
         self._set_protocol_dirty(False)
 
-        # special handling for spot burn fiducial task
-        # is_spot_burn_task = isinstance(task_config, SpotBurnFiducialTaskConfig)
-        # self.spot_burn_coordinates_widget.setVisible(is_spot_burn_task)
-        # if is_spot_burn_task:
-            # self.spot_burn_coordinates_widget.set_task_config(task_config)
+        # spot-burn coordinates live in their own dialog (they need a canvas to place
+        # points on, which this tab has no room for) — offer the button only for that task
+        self.pushButton_edit_spot_burn.setVisible(
+            isinstance(task_config, SpotBurnFiducialTaskConfig)
+        )
 
     def _on_milling_settings_changed(self, config: 'FibsemMillingTaskConfig'):
         """Callback when the milling task config is changed."""
@@ -415,12 +418,95 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         # # Save the experiment
         self._save_experiment()
 
-    def _on_spot_burn_coordinates_changed(self, config: 'SpotBurnFiducialTaskConfig'):
-        """Callback when the spot burn coordinates are changed."""
-        selected_task_name = self.task_list_widget.selected_task
-        self.experiment.task_protocol.task_config[selected_task_name] = config
-        logging.info(f"Updated {selected_task_name} Spot Burn Coordinates")
-        self._save_experiment()
+    def _on_spot_burn_coordinates_clicked(self):
+        """Edit this task's default spot-burn coordinates on a reference frame.
+
+        A dialog rather than a column in this tab: placing points needs a canvas, and
+        this editor's third column is the milling viewer built with ``viewer=None``.
+        The widget brings its own canvas via a standalone ``MicroscopeViewController``,
+        so no microscope and no acquired image are involved.
+        """
+        task_name = self.task_list_widget.selected_task
+        config = self.experiment.task_protocol.task_config[task_name]
+        if not isinstance(config, SpotBurnFiducialTaskConfig):
+            return
+
+        dialog = QDialog(self)
+        dialog.setWindowTitle(f"Spot Burn Coordinates — {task_name}")
+        dialog.setModal(True)
+
+        # The frame the coordinates are relative to. Coordinates are normalised 0-1 in x
+        # and y *independently*, so the aspect ratio has to match the real reference image
+        # or every point lands somewhere else — hence the task's own reference-imaging
+        # resolution rather than an arbitrary square. field_of_view1 gives the scalebar
+        # its scale. Deliberately flat, not noise: this is a coordinate frame, not a
+        # picture of anyone's sample.
+        ref = config.reference_imaging
+        resolution = tuple(ref.imaging.resolution)
+        image = FibsemImage.generate_blank_image(
+            resolution=resolution, hfw=ref.field_of_view1, random=False
+        )
+
+        # Kept on the dialog: the controller must outlive the coordinate widget, and
+        # LamellaEditorView must outlive the controller (it is the controller's widget).
+        dialog._view = LamellaEditorView()
+        dialog._controller = MicroscopeViewController(view=dialog._view)
+        dialog._controller.set_image(BeamType.ION, image)
+
+        coord_widget = SpotBurnCoordinatesWidget(
+            controller=dialog._controller,
+            beam=BeamType.ION,
+            settings=config.to_settings(),
+            parent=dialog,
+        )
+        coord_widget.set_image_shape(image.data.shape)
+
+        layout = QVBoxLayout(dialog)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(6)
+
+        body = QHBoxLayout()
+        body.setSpacing(8)
+        coord_widget.setMinimumWidth(360)
+        body.addWidget(coord_widget, 0)
+        body.addWidget(dialog._controller.widget, 1)
+        layout.addLayout(body)
+
+        hint = QLabel(
+            f"Coordinates are fractions of the reference image ({resolution[0]}×{resolution[1]} px, "
+            f"{ref.field_of_view1 * 1e6:.0f} µm wide): 0-1 across, 0-1 down, origin top-left. "
+            "Right-click the frame to add a point, drag to move, Delete to remove."
+        )
+        hint.setWordWrap(True)
+        hint.setStyleSheet("color: #8a9099; font-size: 11px;")
+        layout.addWidget(hint)
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        cancel_btn = QPushButton("Cancel")
+        ok_btn = QPushButton("OK")
+        cancel_btn.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        ok_btn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        for b in (cancel_btn, ok_btn):
+            b.setDefault(False)
+            b.setAutoDefault(False)
+        cancel_btn.clicked.connect(dialog.reject)
+        ok_btn.clicked.connect(dialog.accept)
+        btn_row.addWidget(cancel_btn)
+        btn_row.addWidget(ok_btn)
+        layout.addLayout(btn_row)
+
+        dialog.resize(1000, 560)
+        if dialog.exec_() == QDialog.Accepted:
+            # apply onto the stored config rather than replacing it, so the task's other
+            # fields (milling, reference imaging, autofocus) survive the edit
+            config.apply_settings(coord_widget.get_settings())
+            self._set_protocol_dirty(True)
+            logging.info(
+                f"Updated {task_name} spot burn coordinates "
+                f"({len(config.coordinates)} point(s))"
+            )
+            self._save_experiment()
 
     def _save_experiment(self):
         """Save the experiment if available."""

--- a/fibsem/ui/widgets/autolamella_task_config_editor.py
+++ b/fibsem/ui/widgets/autolamella_task_config_editor.py
@@ -43,6 +43,21 @@ from fibsem.ui.widgets.autolamella_task_config_widget import AutoLamellaTaskPara
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 from fibsem.ui.widgets.reference_image_parameters_widget import ReferenceImageParametersWidget
 
+# Frame used by the spot-burn coordinate dialog when the task's stored reference
+# imaging is unusable (missing/zero). Matches ImageSettings' own defaults.
+_FALLBACK_RESOLUTION = (1536, 1024)
+_FALLBACK_HFW = 150e-6
+
+
+def _valid_resolution(resolution) -> Tuple[int, int]:
+    """A usable (x, y) pixel resolution, falling back when the protocol's is not."""
+    try:
+        x, y = (int(v) for v in resolution)
+    except (TypeError, ValueError):
+        return _FALLBACK_RESOLUTION
+    return (x, y) if x > 0 and y > 0 else _FALLBACK_RESOLUTION
+
+
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.ui import AutoLamellaUI
     from fibsem.applications.autolamella.structures import Experiment
@@ -441,10 +456,14 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         # resolution rather than an arbitrary square. field_of_view1 gives the scalebar
         # its scale. Deliberately flat, not noise: this is a coordinate frame, not a
         # picture of anyone's sample.
+        # Fall back rather than crash on a malformed protocol: this feature exists
+        # because people hand-edit these files, so a null or zero resolution is a real
+        # input, and generate_blank_image would raise TypeError / ZeroDivisionError.
         ref = config.reference_imaging
-        resolution = tuple(ref.imaging.resolution)
+        resolution = _valid_resolution(getattr(ref.imaging, "resolution", None))
+        hfw = ref.field_of_view1 if (ref.field_of_view1 or 0) > 0 else _FALLBACK_HFW
         image = FibsemImage.generate_blank_image(
-            resolution=resolution, hfw=ref.field_of_view1, random=False
+            resolution=resolution, hfw=hfw, random=False
         )
 
         # Kept on the dialog: the controller must outlive the coordinate widget, and
@@ -474,7 +493,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
         hint = QLabel(
             f"Coordinates are fractions of the reference image ({resolution[0]}×{resolution[1]} px, "
-            f"{ref.field_of_view1 * 1e6:.0f} µm wide): 0-1 across, 0-1 down, origin top-left. "
+            f"{hfw * 1e6:.0f} µm wide): 0-1 across, 0-1 down, origin top-left. "
             "Right-click the frame to add a point, drag to move, Delete to remove."
         )
         hint.setWordWrap(True)
@@ -497,16 +516,22 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         layout.addLayout(btn_row)
 
         dialog.resize(1000, 560)
-        if dialog.exec_() == QDialog.Accepted:
-            # apply onto the stored config rather than replacing it, so the task's other
-            # fields (milling, reference imaging, autofocus) survive the edit
-            config.apply_settings(coord_widget.get_settings())
-            self._set_protocol_dirty(True)
-            logging.info(
-                f"Updated {task_name} spot burn coordinates "
-                f"({len(config.coordinates)} point(s))"
-            )
-            self._save_experiment()
+        try:
+            if dialog.exec_() == QDialog.Accepted:
+                # apply onto the stored config rather than replacing it, so the task's
+                # other fields (milling, reference imaging, autofocus) survive the edit
+                config.apply_settings(coord_widget.get_settings())
+                self._set_protocol_dirty(True)
+                logging.info(
+                    f"Updated {task_name} spot burn coordinates "
+                    f"({len(config.coordinates)} point(s))"
+                )
+                self._save_experiment()
+        finally:
+            # QDialog(self) parents the dialog to this editor, so Qt keeps it alive after
+            # exec_ returns and every open would strand another canvas + controller for
+            # the session. Delete after reading the settings, never before.
+            dialog.deleteLater()
 
     def _save_experiment(self):
         """Save the experiment if available."""
@@ -636,9 +661,12 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         btn_row.addWidget(ok_btn)
         layout.addLayout(btn_row)
 
-        if dialog.exec_() == QDialog.Accepted:
-            self.experiment.task_protocol.lamella_defaults = template_widget.get_template()
-            self._save_experiment()
+        try:
+            if dialog.exec_() == QDialog.Accepted:
+                self.experiment.task_protocol.lamella_defaults = template_widget.get_template()
+                self._save_experiment()
+        finally:
+            dialog.deleteLater()  # parented to this editor, so Qt keeps it otherwise
 
     def _on_protocol_field_changed(self, field: str, value: str) -> None:
         if self.experiment and self.experiment.task_protocol:

--- a/fibsem/ui/widgets/spot_burn_coordinates_widget.py
+++ b/fibsem/ui/widgets/spot_burn_coordinates_widget.py
@@ -128,18 +128,20 @@ class SpotBurnCoordinatesWidget(QWidget):
         cl.addSpacing(24)  # align with the per-row remove button
         outer.addWidget(col)
 
-        # rows
+        # rows — the only part that should absorb spare height. It used to be capped at
+        # 180px with no stretch, which scrolled a six-row window while the panel below it
+        # sat empty; a fiducial pattern is a dozen-plus points, so the cap bit immediately.
         self._list = QListWidget()
         self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        self._list.setMaximumHeight(180)
+        self._list.setMinimumHeight(120)  # still readable in a short host
         self._list.itemSelectionChanged.connect(self._on_row_selection_changed)
-        outer.addWidget(self._list)
+        outer.addWidget(self._list, 1)
 
         # footer summary + hint
         self.label_summary = QLabel()
         self.label_summary.setWordWrap(True)
         self.label_summary.setStyleSheet(f"color: {_MUTED}; padding: 4px 6px;")
-        outer.addWidget(self.label_summary)
+        outer.addWidget(self.label_summary, 0)
 
         self._rebuild_rows()
 

--- a/fibsem/ui/widgets/spot_burn_coordinates_widget.py
+++ b/fibsem/ui/widgets/spot_burn_coordinates_widget.py
@@ -209,7 +209,12 @@ class SpotBurnCoordinatesWidget(QWidget):
             color="white",
             selected_color="cyan",
             marker="o",
-            size=12,
+            # markersize, in points. Deliberately small: fiducial patterns put spots
+            # ~0.01 of the frame apart, and a larger marker merges the cluster into one
+            # blob at full-frame zoom. Picking is unaffected — PointOverlay hit-tests
+            # against a fixed screen-space radius, not the marker size — and the
+            # selected point still stands out at size * 1.4.
+            size=6,
             add_on_right_click=True,
             removable=True,
             modal=True,

--- a/fibsem/ui/widgets/spot_burn_coordinates_widget.py
+++ b/fibsem/ui/widgets/spot_burn_coordinates_widget.py
@@ -1,0 +1,332 @@
+from typing import List, Optional, Tuple
+
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.imaging.spot import SpotBurnSettings
+from fibsem.structures import BeamType, Point
+from fibsem.ui.widgets.canvas.canvas_state import PointsSpec
+from fibsem.ui.widgets.custom_widgets import IconToolButton
+
+
+_HEADER_BG = "#1e2124"
+_MUTED = "#8a9099"
+
+
+class _SpotBurnRow(QWidget):
+    """A single read-only coordinate row: index + X + Y + a remove button."""
+
+    remove_clicked = pyqtSignal(int)
+
+    def __init__(self, index: int, point: Point, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.index = index
+        self.setAttribute(Qt.WA_TranslucentBackground)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(6, 3, 6, 3)
+        layout.setSpacing(8)
+
+        idx_lbl = QLabel(str(index + 1))
+        idx_lbl.setFixedWidth(20)
+        idx_lbl.setAlignment(Qt.AlignCenter)
+        idx_lbl.setStyleSheet(f"color: {_MUTED}; background: transparent;")
+        layout.addWidget(idx_lbl)
+
+        x_lbl = QLabel(f"{point.x:.3f}")
+        x_lbl.setStyleSheet("background: transparent; font-family: monospace;")
+        layout.addWidget(x_lbl, stretch=1)
+
+        y_lbl = QLabel(f"{point.y:.3f}")
+        y_lbl.setStyleSheet("background: transparent; font-family: monospace;")
+        layout.addWidget(y_lbl, stretch=1)
+
+        btn_remove = IconToolButton(
+            "mdi:trash-can-outline", tooltip="Remove coordinate", size=24
+        )
+        btn_remove.clicked.connect(lambda: self.remove_clicked.emit(self.index))
+        layout.addWidget(btn_remove)
+
+
+class SpotBurnCoordinatesWidget(QWidget):
+    """Editor for spot-burn coordinates, backed by a canvas points overlay.
+
+    A titled list of read-only coordinate rows (index + x, y in relative 0-1 image
+    space), each with a remove button, plus an add button in the header — styled to
+    match the app's task / lamella lists. Coordinates are *placed and moved on the
+    image* (right-click to add, drag to move, Delete to remove); the list mirrors the
+    overlay and its selection both ways, and the on-image markers are numbered to match
+    the rows.
+
+    Works with a :class:`SpotBurnSettings` payload — it edits ``.coordinates`` and passes
+    current/exposure through untouched. Reusable by any host that owns a
+    ``MicroscopeViewController`` — the protocol editor and the live spot-burn widget.
+    """
+
+    settings_changed = pyqtSignal(SpotBurnSettings)
+    OVERLAY_ID = "spot_burn"
+
+    def __init__(self,
+                 controller,
+                 beam: BeamType = BeamType.ION,
+                 settings: Optional[SpotBurnSettings] = None,
+                 parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.controller = controller
+        self.beam = beam
+        self.settings = settings if settings is not None else SpotBurnSettings()
+        self._coordinates: List[Point] = list(self.settings.coordinates)
+        self._image_shape: Optional[Tuple[int, int]] = None  # (h, w) for 0-1 <-> px
+        self._updating = False  # guard against re-entrant list/overlay updates
+        self._active = False    # overlay armed + shown while the widget is visible
+        self._wired = False     # subscribed to controller signals
+
+        self._init_ui()
+
+    def _init_ui(self):
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        # header: title + add button (matches TaskNameListWidget / LamellaNameListWidget)
+        header = QWidget()
+        header.setStyleSheet(f"background: {_HEADER_BG};")
+        hl = QHBoxLayout(header)
+        hl.setContentsMargins(8, 3, 4, 3)
+        hl.setSpacing(4)
+        title = QLabel("Spot Burn Coordinates")
+        title.setStyleSheet("font-weight: bold; background: transparent;")
+        hl.addWidget(title)
+        hl.addStretch()
+        self.btn_add = IconToolButton("mdi:plus", tooltip="Add coordinate", size=24)
+        self.btn_add.clicked.connect(self._add_coordinate)
+        hl.addWidget(self.btn_add)
+        outer.addWidget(header)
+
+        # column header
+        col = QWidget()
+        cl = QHBoxLayout(col)
+        cl.setContentsMargins(6, 2, 6, 2)
+        cl.setSpacing(8)
+        lbl_idx = QLabel("#")
+        lbl_idx.setFixedWidth(20)
+        lbl_idx.setAlignment(Qt.AlignCenter)
+        lbl_x = QLabel("X (0-1)")
+        lbl_y = QLabel("Y (0-1)")
+        for lbl in (lbl_idx, lbl_x, lbl_y):
+            lbl.setStyleSheet(f"color: {_MUTED}; background: transparent; font-size: 11px;")
+        cl.addWidget(lbl_idx)
+        cl.addWidget(lbl_x, stretch=1)
+        cl.addWidget(lbl_y, stretch=1)
+        cl.addSpacing(24)  # align with the per-row remove button
+        outer.addWidget(col)
+
+        # rows
+        self._list = QListWidget()
+        self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self._list.setMaximumHeight(180)
+        self._list.itemSelectionChanged.connect(self._on_row_selection_changed)
+        outer.addWidget(self._list)
+
+        # footer summary + hint
+        self.label_summary = QLabel()
+        self.label_summary.setWordWrap(True)
+        self.label_summary.setStyleSheet(f"color: {_MUTED}; padding: 4px 6px;")
+        outer.addWidget(self.label_summary)
+
+        self._rebuild_rows()
+
+    # --- public API ---
+
+    def set_image_shape(self, shape) -> None:
+        """Set the host FIB image shape (h, w), used for 0-1 <-> pixel conversion."""
+        self._image_shape = (int(shape[0]), int(shape[1])) if shape is not None else None
+        self._sync_overlay()
+
+    def set_settings(self, settings: SpotBurnSettings):
+        """Set the settings payload and update the rows + overlay."""
+        self.settings = settings
+        self._coordinates = list(settings.coordinates)
+        self._sync_overlay()
+        self._rebuild_rows()
+
+    def get_settings(self) -> SpotBurnSettings:
+        """Read the current coordinates back into the settings payload."""
+        self.settings.coordinates = list(self._coordinates)
+        return self.settings
+
+    # --- rows ---
+
+    def _rebuild_rows(self):
+        self._updating = True
+        # QListWidget.clear() drops the items but leaves the setItemWidget row widgets
+        # parented to the viewport. This runs on every edit — including each drag-release
+        # on the canvas — so without an explicit delete they accumulate for the lifetime
+        # of the widget (measured: 24 row widgets for a single coordinate after 21 edits).
+        for i in range(self._list.count()):
+            row = self._list.itemWidget(self._list.item(i))
+            if row is not None:
+                row.setParent(None)
+                row.deleteLater()
+        self._list.clear()
+        for i, pt in enumerate(self._coordinates):
+            row = _SpotBurnRow(i, pt)
+            row.remove_clicked.connect(self._remove_coordinate)
+            item = QListWidgetItem(self._list)
+            item.setSizeHint(row.sizeHint())
+            self._list.addItem(item)
+            self._list.setItemWidget(item, row)
+        self._updating = False
+        self._update_summary()
+
+    def _add_coordinate(self):
+        """Add a coordinate at the image centre; the user then drags it into place."""
+        self._coordinates.append(Point(0.5, 0.5))
+        self._sync_overlay()
+        self._rebuild_rows()
+        self._emit_settings_changed()
+
+    def _remove_coordinate(self, index: int):
+        if 0 <= index < len(self._coordinates):
+            self._coordinates.pop(index)
+            self._sync_overlay()
+            self._rebuild_rows()
+            self._emit_settings_changed()
+
+    # --- overlay sync ---
+
+    def _points_spec(self, px_points) -> PointsSpec:
+        return PointsSpec(
+            id=self.OVERLAY_ID,
+            points=px_points,
+            color="white",
+            selected_color="cyan",
+            marker="o",
+            size=12,
+            add_on_right_click=True,
+            removable=True,
+            modal=True,
+            numbered=True,
+        )
+
+    def _sync_overlay(self):
+        """Push the coordinates onto the canvas overlay (relative -> pixels)."""
+        if not self._active or self._image_shape is None:
+            return
+        h, w = self._image_shape
+        px = [(pt.x * w, pt.y * h) for pt in self._coordinates]
+        self.controller.set_overlay(self.beam, self._points_spec(px))
+
+    def _on_overlay_edited(self, beam, overlay_id, points):
+        """A point was added / moved / removed on the canvas -> refresh the rows."""
+        if beam != self.beam or overlay_id != self.OVERLAY_ID or self._image_shape is None:
+            return
+        h, w = self._image_shape
+        # overlay already reflects the edit (incl. renumbering); just mirror it here
+        self._coordinates = [Point(float(x / w), float(y / h)) for (x, y) in points]
+        self._rebuild_rows()
+        self._emit_settings_changed()
+
+    # --- selection sync (list <-> overlay) ---
+
+    def _on_row_selection_changed(self):
+        """A row was selected -> highlight the matching point on the canvas."""
+        if self._updating or not self._active:
+            return
+        row = self._list.currentRow()
+        self.controller.set_selected_point(
+            self.beam, self.OVERLAY_ID, row if row >= 0 else None
+        )
+
+    def _on_overlay_point_selected(self, beam, overlay_id, index):
+        """A point was selected on the canvas -> select the matching row."""
+        if beam != self.beam or overlay_id != self.OVERLAY_ID:
+            return
+        if 0 <= index < self._list.count():
+            self._updating = True
+            self._list.setCurrentRow(index)
+            self._updating = False
+
+    # --- misc ---
+
+    def _emit_settings_changed(self):
+        self.settings_changed.emit(self.get_settings())
+
+    def _update_summary(self):
+        n = len(self._coordinates)
+        if n == 0:
+            self.label_summary.setText(
+                "No coordinates defined.  ·  right-click the image to add a burn point."
+            )
+        else:
+            self.label_summary.setText(
+                f"{n} coordinate{'s' if n != 1 else ''}  ·  drag to move, Delete to remove."
+            )
+
+    # --- activation (arming) driven by visibility ---
+
+    def set_active(self, active: bool) -> None:
+        """Explicitly arm/disarm the overlay — for hosts that drive activation directly
+        (e.g. the live spot-burn tab) rather than relying on show/hide. Idempotent with
+        the show/hide path."""
+        self._set_active(active)
+
+    def _set_active(self, active: bool):
+        if active == self._active:
+            if active:
+                self._sync_overlay()  # refresh on re-show
+            return
+        self._active = active
+        if active:
+            if not self._wired:
+                self.controller.overlay_edited.connect(self._on_overlay_edited)
+                self.controller.overlay_point_selected.connect(
+                    self._on_overlay_point_selected
+                )
+                self._wired = True
+            self._sync_overlay()
+            self.controller.arm_overlay(
+                self.beam,
+                self.OVERLAY_ID,
+                label="Spot Burn",
+                icon="mdi:record-circle-outline",
+            )
+        else:
+            # Deactivation runs on teardown too (hideEvent), and Qt gives no ordering
+            # guarantee between this widget and the controller. If the controller's C++
+            # object is already gone, touching it raises RuntimeError — there is nothing
+            # left to disarm, so treat it as already torn down. closeEvent guards its
+            # disconnects the same way.
+            try:
+                self.controller.arm_overlay(self.beam, None)
+                self.controller.remove_overlay(self.beam, self.OVERLAY_ID)
+            except RuntimeError:
+                pass
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self._set_active(True)
+
+    def hideEvent(self, event):
+        super().hideEvent(event)
+        self._set_active(False)
+
+    def closeEvent(self, event):
+        if self._wired:
+            for sig, slot in (
+                (self.controller.overlay_edited, self._on_overlay_edited),
+                (self.controller.overlay_point_selected, self._on_overlay_point_selected),
+            ):
+                try:
+                    sig.disconnect(slot)
+                except (TypeError, RuntimeError):
+                    pass
+            self._wired = False
+        super().closeEvent(event)

--- a/fibsem/ui/widgets/tests/test_spot_burn_coordinates_widget.py
+++ b/fibsem/ui/widgets/tests/test_spot_burn_coordinates_widget.py
@@ -207,6 +207,96 @@ def test_cramped_host_keeps_the_summary_and_a_usable_list():
     assert sibling.isVisible()              # and so did the host's own controls
 
 
+# ── the protocol-editor dialog that hosts the widget ────────────────────────
+
+def _editor_stub(config):
+    """The minimum of AutoLamellaProtocolTaskConfigEditor the dialog method touches."""
+    import types
+
+    from PyQt5.QtWidgets import QWidget
+
+    from fibsem.applications.autolamella.structures import LamellaDefaultConfig
+
+    host = QWidget()
+    host.task_list_widget = types.SimpleNamespace(selected_task="T")
+    host.experiment = types.SimpleNamespace(
+        task_protocol=types.SimpleNamespace(
+            task_config={"T": config}, lamella_defaults=LamellaDefaultConfig()
+        )
+    )
+    host.dirty, host.saved = [], []
+    host._set_protocol_dirty = lambda v: host.dirty.append(v)
+    host._save_experiment = lambda: host.saved.append(1)
+    return host
+
+
+def _open_dialog(host, on_exec=None):
+    from PyQt5.QtWidgets import QDialog
+
+    from fibsem.ui.widgets.autolamella_task_config_editor import (
+        AutoLamellaProtocolTaskConfigEditor,
+    )
+
+    original = QDialog.exec_
+    QDialog.exec_ = on_exec or (lambda self: QDialog.Rejected)
+    try:
+        AutoLamellaProtocolTaskConfigEditor._on_spot_burn_coordinates_clicked(host)
+    finally:
+        QDialog.exec_ = original
+
+
+def test_dialog_does_not_leak_a_canvas_per_open():
+    """QDialog(parent) is owned by the parent, so without an explicit delete every open
+    strands another controller + matplotlib canvas for the rest of the session."""
+    from PyQt5.QtCore import QCoreApplication, QEvent
+    from PyQt5.QtWidgets import QDialog
+
+    host = _editor_stub(SpotBurnFiducialTaskConfig(task_name="T",
+                                                   coordinates=[Point(0.2, 0.2)]))
+    for _ in range(5):
+        _open_dialog(host)
+    # deleteLater posts a DeferredDelete event; processEvents alone will not deliver it
+    QCoreApplication.sendPostedEvents(None, QEvent.DeferredDelete)
+    for _ in range(4):
+        _app.processEvents()
+    assert host.findChildren(QDialog) == []
+    assert host.findChildren(SpotBurnCoordinatesWidget) == []
+
+
+def test_cancel_leaves_the_config_untouched():
+    cfg = SpotBurnFiducialTaskConfig(task_name="T",
+                                     coordinates=[Point(0.2, 0.2), Point(0.4, 0.4)])
+    before = [(p.x, p.y) for p in cfg.coordinates]
+    host = _editor_stub(cfg)
+
+    from PyQt5.QtWidgets import QDialog
+
+    def edit_then_cancel(dialog):
+        w = dialog.findChild(SpotBurnCoordinatesWidget)
+        w._coordinates = [Point(0.9, 0.9)]
+        w._rebuild_rows()
+        return QDialog.Rejected
+
+    _open_dialog(host, on_exec=edit_then_cancel)
+    assert [(p.x, p.y) for p in cfg.coordinates] == before
+    assert host.dirty == [] and host.saved == []  # nothing marked dirty, nothing written
+
+
+def test_dialog_survives_a_malformed_protocol():
+    """This feature exists because people hand-edit these files, so a null or zero
+    reference-imaging resolution is a real input, not a hypothetical."""
+    for mutate in (
+        lambda c: setattr(c.reference_imaging.imaging, "resolution", None),
+        lambda c: setattr(c.reference_imaging.imaging, "resolution", [0, 0]),
+        lambda c: setattr(c.reference_imaging.imaging, "resolution", "abc"),
+        lambda c: setattr(c.reference_imaging, "field_of_view1", 0.0),
+        lambda c: setattr(c.reference_imaging, "field_of_view1", None),
+    ):
+        cfg = SpotBurnFiducialTaskConfig(task_name="T", coordinates=[Point(0.2, 0.2)])
+        mutate(cfg)
+        _open_dialog(_editor_stub(cfg))  # must not raise
+
+
 def main() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/fibsem/ui/widgets/tests/test_spot_burn_coordinates_widget.py
+++ b/fibsem/ui/widgets/tests/test_spot_burn_coordinates_widget.py
@@ -1,0 +1,181 @@
+"""Headless tests for the protocol-level spot-burn coordinate editor (FIB-380).
+
+Covers the widget itself (settings round-trip, list <-> overlay sync, teardown) and
+the config bridge the protocol editor's dialog relies on:
+
+    SpotBurnFiducialTaskConfig --to_settings()--> SpotBurnSettings --> widget
+    widget.get_settings() --> SpotBurnSettings --apply_settings()--> config
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_spot_burn_coordinates_widget.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
+    SpotBurnFiducialTaskConfig,
+)
+from fibsem.imaging.spot import SpotBurnSettings
+from fibsem.structures import BeamType, FibsemImage, Point
+from fibsem.ui.widgets.canvas.quad_view import LamellaEditorView, MicroscopeViewController
+from fibsem.ui.widgets.spot_burn_coordinates_widget import SpotBurnCoordinatesWidget
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+_RESOLUTION = (1536, 1024)  # (x, y) — deliberately non-square, see the aspect test
+_HFW = 150e-6
+
+
+def _close(a, b, tol=1e-6):
+    return abs(a - b) < tol
+
+
+def _host(settings=None):
+    """A widget + its own controller/canvas, as the protocol-editor dialog builds it."""
+    view = LamellaEditorView()
+    controller = MicroscopeViewController(view=view)
+    image = FibsemImage.generate_blank_image(resolution=_RESOLUTION, hfw=_HFW, random=False)
+    controller.set_image(BeamType.ION, image)
+    w = SpotBurnCoordinatesWidget(controller=controller, beam=BeamType.ION, settings=settings)
+    w.set_image_shape(image.data.shape)
+    return w, controller, view, image
+
+
+# ── the config <-> settings bridge the dialog depends on ────────────────────
+
+def test_config_round_trips_through_settings():
+    cfg = SpotBurnFiducialTaskConfig(
+        task_name="Spot Burn Fiducial",
+        milling_current=80e-12,
+        exposure_time=7,
+        coordinates=[Point(0.16, 0.45), Point(0.15, 0.45)],
+    )
+    w, _, _, _ = _host(settings=cfg.to_settings())
+    cfg.apply_settings(w.get_settings())
+    assert [(p.x, p.y) for p in cfg.coordinates] == [(0.16, 0.45), (0.15, 0.45)]
+    assert cfg.milling_current == 80e-12 and cfg.exposure_time == 7.0
+
+
+def test_apply_settings_preserves_unrelated_task_fields():
+    """The dialog applies onto the stored config; milling/reference/autofocus must survive."""
+    cfg = SpotBurnFiducialTaskConfig(task_name="Spot Burn Fiducial", autofocus=True)
+    ref_before = cfg.reference_imaging
+    cfg.apply_settings(SpotBurnSettings(coordinates=[Point(0.5, 0.5)]))
+    assert cfg.autofocus is True
+    assert cfg.reference_imaging is ref_before
+    assert cfg.task_type == "SPOT_BURN_FIDUCIAL"
+
+
+# ── coordinates are relative to the frame, and the frame is not square ──────
+
+def test_normalised_coordinates_survive_a_non_square_frame():
+    """x and y are normalised independently — a 3:2 frame must not skew them."""
+    pts = [Point(0.25, 0.75), Point(0.9, 0.1)]
+    w, _, _, image = _host(settings=SpotBurnSettings(coordinates=pts))
+    h, width = image.data.shape
+    assert (width, h) == _RESOLUTION  # generate_blank_image takes (x, y)
+    out = w.get_settings().coordinates
+    assert _close(out[0].x, 0.25) and _close(out[0].y, 0.75)
+    assert _close(out[1].x, 0.9) and _close(out[1].y, 0.1)
+
+
+def test_overlay_receives_pixel_positions_scaled_by_each_axis():
+    w, controller, _, image = _host(settings=SpotBurnSettings(coordinates=[Point(0.25, 0.75)]))
+    w.set_active(True)
+    _app.processEvents()
+    spec = controller._scene.fib.overlays[SpotBurnCoordinatesWidget.OVERLAY_ID]
+    h, width = image.data.shape
+    (px, py), = spec.points
+    assert _close(px, 0.25 * width) and _close(py, 0.75 * h)
+
+
+# ── list <-> canvas sync ────────────────────────────────────────────────────
+
+def test_canvas_edit_writes_back_to_settings_and_emits():
+    w, controller, _, image = _host(settings=SpotBurnSettings(coordinates=[Point(0.2, 0.2)]))
+    w.set_active(True)
+    seen = []
+    w.settings_changed.connect(seen.append)
+    h, width = image.data.shape
+    # simulate a drag + an add on the canvas
+    controller.overlay_edited.emit(
+        BeamType.ION, SpotBurnCoordinatesWidget.OVERLAY_ID,
+        [(0.4 * width, 0.6 * h), (0.8 * width, 0.1 * h)],
+    )
+    out = w.get_settings().coordinates
+    assert len(out) == 2
+    assert _close(out[0].x, 0.4) and _close(out[0].y, 0.6)
+    assert len(seen) == 1
+
+
+def test_rows_mirror_the_coordinates():
+    w, _, _, _ = _host(settings=SpotBurnSettings(
+        coordinates=[Point(0.16, 0.45), Point(0.15, 0.45), Point(0.17, 0.45)]))
+    assert w._list.count() == 3
+    w.set_settings(SpotBurnSettings(coordinates=[Point(0.5, 0.5)]))
+    assert w._list.count() == 1
+
+
+def test_rebuilding_rows_does_not_accumulate_widgets():
+    """_rebuild_rows runs on every edit (each canvas drag-release), so leaked row
+    widgets would grow without bound over a session."""
+    from fibsem.ui.widgets.spot_burn_coordinates_widget import _SpotBurnRow
+
+    w, _, _, _ = _host(settings=SpotBurnSettings(coordinates=[Point(0.1, 0.1)]))
+    for _ in range(20):
+        w.set_settings(SpotBurnSettings(coordinates=[Point(0.5, 0.5)]))
+    for _ in range(5):
+        _app.processEvents()
+    live = [r for r in w.findChildren(_SpotBurnRow)]
+    assert len(live) <= 2, f"{len(live)} row widgets alive for 1 coordinate"
+
+
+# ── teardown ────────────────────────────────────────────────────────────────
+
+def test_hide_after_controller_is_gone_does_not_raise():
+    """Qt gives no teardown ordering guarantee between the widget and the controller.
+
+    The dialog owns both, so on close the controller's C++ object can go first; the
+    widget's hideEvent then disarms an overlay on a dead object. Must be survivable.
+    """
+    import sip
+
+    w, controller, view, _ = _host(settings=SpotBurnSettings(coordinates=[Point(0.3, 0.3)]))
+    w.set_active(True)
+    sip.delete(controller)          # controller dies first
+    assert sip.isdeleted(controller)
+    w.set_active(False)             # what hideEvent does — must not raise
+
+
+def test_deactivate_removes_the_overlay():
+    w, controller, _, _ = _host(settings=SpotBurnSettings(coordinates=[Point(0.3, 0.3)]))
+    w.set_active(True)
+    _app.processEvents()
+    assert SpotBurnCoordinatesWidget.OVERLAY_ID in controller._scene.fib.overlays
+    w.set_active(False)
+    _app.processEvents()
+    assert SpotBurnCoordinatesWidget.OVERLAY_ID not in controller._scene.fib.overlays
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fibsem/ui/widgets/tests/test_spot_burn_coordinates_widget.py
+++ b/fibsem/ui/widgets/tests/test_spot_burn_coordinates_widget.py
@@ -297,6 +297,77 @@ def test_dialog_survives_a_malformed_protocol():
         _open_dialog(_editor_stub(cfg))  # must not raise
 
 
+def test_button_wiring_on_the_real_editor():
+    """The tests above drive the dialog against a stub, which cannot catch the button
+    being created in the wrong place or never connected. Build the real editor."""
+    import logging
+    import pathlib
+    import tempfile
+
+    from PyQt5.QtWidgets import QDialog, QWidget
+
+    from fibsem import utils
+    from fibsem.applications.autolamella.structures import (
+        AutoLamellaTaskProtocol,
+        Experiment,
+    )
+    from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTaskConfig
+    from fibsem.ui.widgets.autolamella_task_config_editor import (
+        AutoLamellaProtocolTaskConfigEditor,
+    )
+
+    logging.disable(logging.CRITICAL)
+    try:
+        microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+        exp = Experiment(path=pathlib.Path(tempfile.mkdtemp()), name="probe")
+        exp.task_protocol = AutoLamellaTaskProtocol()
+        exp.task_protocol.task_config = {
+            "Spot Burn Fiducial": SpotBurnFiducialTaskConfig(
+                task_name="Spot Burn Fiducial", coordinates=[Point(0.16, 0.45)]
+            ),
+            "Other Task": AutoLamellaTaskConfig(task_name="Other Task"),
+        }
+        parent = QWidget()
+        parent.experiment, parent.microscope = exp, microscope
+        editor = AutoLamellaProtocolTaskConfigEditor(parent=parent)
+        editor.show()
+        for _ in range(8):
+            _app.processEvents()
+
+        btn = editor.pushButton_edit_spot_burn
+        rows = editor.task_list_widget._list
+        for row, want_visible in ((0, True), (1, False), (0, True)):
+            rows.setCurrentRow(row)
+            for _ in range(3):
+                _app.processEvents()
+            assert (not btn.isHidden()) == want_visible, (
+                f"row {row} ({editor.task_list_widget.selected_task}): "
+                f"visible={not btn.isHidden()}, wanted {want_visible}"
+            )
+
+        # and the click reaches the dialog with this task's coordinates
+        seen = {}
+        original = QDialog.exec_
+
+        def fake_exec(dialog):
+            w = dialog.findChild(SpotBurnCoordinatesWidget)
+            seen["coords"] = len(w.get_settings().coordinates)
+            seen["title"] = dialog.windowTitle()
+            return QDialog.Rejected
+
+        QDialog.exec_ = fake_exec
+        try:
+            btn.click()
+            for _ in range(4):
+                _app.processEvents()
+        finally:
+            QDialog.exec_ = original
+        assert seen["coords"] == 1
+        assert "Spot Burn Fiducial" in seen["title"]
+    finally:
+        logging.disable(logging.NOTSET)
+
+
 def main() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/fibsem/ui/widgets/tests/test_spot_burn_coordinates_widget.py
+++ b/fibsem/ui/widgets/tests/test_spot_burn_coordinates_widget.py
@@ -163,6 +163,50 @@ def test_deactivate_removes_the_overlay():
     assert SpotBurnCoordinatesWidget.OVERLAY_ID not in controller._scene.fib.overlays
 
 
+# ── layout: the list absorbs spare height, and survives a cramped host ──────
+
+def test_list_takes_the_spare_height():
+    """The list used to be capped at 180px with no stretch, so a dozen-point pattern
+    scrolled a six-row window while the panel below it sat empty."""
+    from PyQt5.QtWidgets import QVBoxLayout, QWidget
+
+    w, _, _, _ = _host(settings=SpotBurnSettings(
+        coordinates=[Point(0.1 * i, 0.1 * i) for i in range(1, 12)]))
+    host = QWidget()
+    QVBoxLayout(host).addWidget(w, 1)
+    host.resize(360, 800)
+    host.show()
+    for _ in range(8):
+        _app.processEvents()
+    assert w._list.height() > 400, w._list.height()
+    # every row reachable without scrolling
+    visible = sum(
+        1 for i in range(w._list.count())
+        if w._list.visualItemRect(w._list.item(i)).bottom() <= w._list.viewport().height()
+    )
+    assert visible == w._list.count() == 11
+
+
+def test_cramped_host_keeps_the_summary_and_a_usable_list():
+    """The live spot-burn tab is short — the list must not eat the footer."""
+    from PyQt5.QtWidgets import QPushButton, QVBoxLayout, QWidget
+
+    w, _, _, _ = _host(settings=SpotBurnSettings(
+        coordinates=[Point(0.1 * i, 0.1 * i) for i in range(1, 12)]))
+    host = QWidget()
+    lay = QVBoxLayout(host)
+    lay.addWidget(w, 1)
+    sibling = QPushButton("Run Spot Burn")
+    lay.addWidget(sibling, 0)
+    host.resize(360, 260)
+    host.show()
+    for _ in range(8):
+        _app.processEvents()
+    assert w._list.height() >= 100          # did not collapse
+    assert not w.label_summary.isHidden()   # footer survived
+    assert sibling.isVisible()              # and so did the host's own controls
+
+
 def main() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0


### PR DESCRIPTION
Closes FIB-380.

Setting a protocol's **default** spot-burn coordinates meant hand-editing YAML. The reported ask was *"should add a GUI to do this easier than have to edit the file"* — and the coordinates in question are fiducial patterns:

```yaml
- {"x": 0.16, "y": 0.45} # A1 - center
- {"x": 0.15, "y": 0.45} # A2 - left-arm
- {"x": 0.17, "y": 0.45} # A3 - right-arm
```

A five-spot cross, a doublet, an L — arms 0.01 apart. That's a shape, and typing it blind is the wrong tool.

The coordinate GUI already existed but was **commented out** in the protocol-level editor at four sites, because that tab builds its milling viewer with `viewer=None` and so has no canvas to place points on.

## What this does

Ports `SpotBurnCoordinatesWidget` from the napari-cutover branch (#111): a coordinate list backed by a canvas points overlay, synced both ways, markers numbered to match the rows. The reason it works *here* is that it brings its own canvas via a standalone `MicroscopeViewController` — no microscope, no napari viewer, no acquired image.

A **"Spot Burn Coordinates"** button opens it in a dialog, mirroring the existing Lamella Template button in the same editor, and shows only for a spot-burn task.

FIB-380 suggested re-enabling the old widget in *table-only mode* with point placement hidden. That would have left the user reading a table of 0–1 numbers — barely different from the YAML, and useless for a cross whose arms are 0.01 apart.

## Nothing existing changes

The napari `AutoLamellaSpotBurnCoordinatesWidget` and its live use in the **per-lamella** editor are untouched. The two never collide — different file, different class, different currency (`SpotBurnSettings` vs `SpotBurnFiducialTaskConfig`). Only the four dead commented-out blocks and the now-unused import go.

**The config bridge needed no new code.** `SpotBurnFiducialTaskConfig.to_settings()` / `apply_settings()` landed in #211 for the unsupervised burn path and happen to be exactly this round-trip. Settings are applied *onto* the stored config rather than replacing it, so milling, reference imaging and autofocus survive an edit.

## The frame

Built from the task's own reference-imaging settings, not an arbitrary square — coordinates are normalised 0–1 in x and y **independently**, so a square preview would misplace every point on a 1536×1024 image. `field_of_view1` gives the scalebar its scale. Flat rather than noise: it's a coordinate frame, not a picture of anyone's sample.

## Two fixes to the ported widget, both found by testing it standalone

- **Teardown crash.** `hideEvent` → `_set_active(False)` touched the controller unguarded. Qt gives no teardown ordering guarantee and a dialog owns both, so the controller's C++ object can go first: `RuntimeError: wrapped C/C++ object ... has been deleted`. Now guarded the same way `closeEvent` already guards its disconnects. Latent in #111, where the controller is app-lifetime.
- **Row-widget leak.** `_rebuild_rows` leaked a widget per row per rebuild — `QListWidget.clear()` drops the items but leaves the `setItemWidget` widgets parented to the viewport. It runs on *every* edit including each drag-release, so it grew for the whole session. Measured **24 row widgets for a single coordinate after 21 edits**; now 2 for two coordinates after 50.

## Verification

9 new tests: config round-trip, unrelated task fields surviving `apply_settings`, non-square normalisation, overlay pixel scaling per-axis, list↔canvas sync, the teardown case, and the leak. Full suite **1433 passed**; **1127** with PyQt5/napari blocked (matches main).

The dialog screenshot was produced by driving the real `_on_spot_burn_coordinates_clicked`, not a replica.

## Known rough edge

The dialog opens at full-frame zoom, where a tight fiducial cluster overlaps into a blob — precisely the data that motivated this. The canvas zooms and pans, so it's workable, but the first view isn't useful. Auto-zooming to the coordinates needs a zoom-to-region API the canvas doesn't expose, and adding one would diverge the canvas package from #111 where it's currently byte-identical. Left as a follow-up.

FIB-380 also asks for load/save of a coordinate set to file so a fiducial pattern is reusable across protocols — not in this PR; the dialog makes it easy to add.

Note that saving a protocol through the GUI goes through `yaml.safe_dump`, which drops the `# A1 - center` style comments in hand-annotated protocol files. Confirmed as acceptable.