### PR TITLE
[ui] Fix missing unit suffix on coincidence strategy config fields

### DIFF
--- a/fibsem/milling/strategy/coincidence.py
+++ b/fibsem/milling/strategy/coincidence.py
@@ -38,7 +38,7 @@ class CoincidenceMillingStrategyConfig(MillingStrategyConfig):
         default=1800,
         metadata={
             "label": "Timeout",
-            "units": "s",
+            "unit": "s",
             "minimum": 30,
             "maximum": 9000,
             "tooltip": "Milling will timeout after this duration in seconds, without user intervention",
@@ -86,7 +86,7 @@ class CoincidenceMillingStrategyConfig(MillingStrategyConfig):
         default=30.0,
         metadata={
             "label": "Warmup Duration",
-            "units": "s",
+            "unit": "s",
             "tooltip": "Seconds to ignore at start before tracking the peak",
         },
     )


### PR DESCRIPTION
## Problem

Two fields of `CoincidenceMillingStrategyConfig` (`timeout` and `warmup_duration`) declared their display unit with the metadata key `"units"` (plural). The strategy form builder — `FibsemStrategySettingsWidget` — reads `"unit"` (singular):

```python
suffix = utils._get_display_unit(base_scale, m.get("unit")) if base_scale else (m.get("unit") or "")
```

So both fields fell through to the `or ""` branch and rendered with no unit suffix at all.

## Note on the two key names

The plural `"units"` is **correct** for AutoLamella *task* config fields — `autolamella_task_config_widget.py` reads `self.metadata.get('units', '')`. The two form builders genuinely use different key names, and only the strategy one was wrong here. The other `"units"` users in the tree are all task configs (`undercut.py`, `fiducial.py`, `select_position.py`, `spot_burn.py`) and are untouched. No pattern config uses the plural key.

## Verification

Rendered the widget headlessly (registered strategy name is `CoincidenceMilling`):

```
timeout                    ValueSpinBox   suffix=' s'
save_fm_images             QCheckBox      suffix=None
save_rate_limit            ValueSpinBox   suffix=''
acquire_fib_image          QCheckBox      suffix=None
intensity_drop_fraction    ValueSpinBox   suffix=''
rolling_window             ValueSpinBox   suffix=''
warmup_duration            ValueSpinBox   suffix=' s'
consecutive_triggers       ValueSpinBox   suffix=''
supervised                 QCheckBox      suffix=None
```

The `''` on the remaining spinboxes is the same `(m.get("unit") or "")` fallback the two fixed fields were hitting before — those fields are genuinely unitless (counts, fractions).

123 strategy/milling/coincidence tests pass.

## Knock-on effect

`MillingStrategy.summary()` also reads `"unit"`, so the fix propagates there too:

```
Warmup Duration: 30.0 s      # was: 30.0
```

`Timeout` stays bare in the summary because `summary()` only calls `format_value` on floats and it's an `int` — pre-existing behaviour, unrelated to this change.