### PR TITLE
[feat] Run user scripts from the GUI (FIB-338, FIB-340)

### DIFF
--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -223,11 +223,54 @@ def run(ctx):
 | Flag | What it does |
 |---|---|
 | `writes = True` | asks you to confirm before running, then calls `ctx.save()` afterwards |
+| `uses_microscope = True` | asks you to confirm, then runs the script on a background thread with `ctx.microscope` available |
 | `background = True` | **not implemented** — parsed, but the script still runs inline |
-| `uses_microscope = True` | **not implemented** — the script is refused rather than run |
 | `on_workflow_completed = True` | **not implemented** — nothing runs it automatically |
 
 Without `writes`, nothing your script changed is persisted — a read-only script cannot rewrite `experiment.yaml` by accident.
+
+## Microscope scripts
+
+`uses_microscope = True` gives you `ctx.microscope` and lets the script drive the hardware.
+
+**Nothing validates what you do.** There are no limits, no interlocks and no checks that the state you left the microscope in is sane. A script that drives the stage into the pole piece will do exactly that. This is the same access the application's own code has, with none of its guard rails — treat it accordingly, and test on a dummy or a sacrificial grid first.
+
+```python
+"""Acquire an ion image at every lamella position."""
+uses_microscope = True
+
+from fibsem.structures import BeamType, ImageSettings
+
+
+def run(ctx):
+    settings = ImageSettings(hfw=80e-6, beam_type=BeamType.ION, save=True)
+
+    for lamella in ctx.experiment.positions:
+        ctx.raise_if_cancelled()          # let Stop actually stop it
+        ctx.log(f"moving to {lamella.name}")
+        ctx.microscope.safe_absolute_stage_movement(lamella.state.stage_position)
+        settings.path, settings.filename = lamella.path, "script-survey"
+        ctx.microscope.acquire_image(settings)
+
+    return f"imaged {len(ctx.experiment.positions)} positions"
+```
+
+### How these differ from data scripts
+
+**They run on a background thread.** Hardware operations take seconds to minutes, and running one inline would freeze the window for the whole time, which is indistinguishable from a crash. The dialog's Run button becomes **Stop** while the script runs.
+
+**So do not touch `ctx.experiment` from one.** It holds evented containers whose change handlers write straight into widgets, and those must only be touched from the GUI thread. Reading is generally fine; mutating is not. Nothing stops you — this is a convention you have to keep.
+
+**Stop is cooperative, and it is your job.** A Python thread cannot be killed. Pressing Stop sets a flag; nothing happens until your script looks at it:
+
+```python
+ctx.raise_if_cancelled()   # raises, unwinding the script
+if ctx.cancelled: ...      # or check it yourself and return
+```
+
+A script that never checks runs to completion no matter how many times Stop is pressed. Call it between steps — after each move, between images.
+
+**One at a time, and never alongside a workflow.** A second script is refused while one is running, and starting a workflow is refused while a microscope script is running — otherwise two things end up commanding the stage at once.
 
 ### Editing and re-running
 
@@ -241,7 +284,7 @@ Scripts are re-read from disk on every run. Edit the file, click Run, and the ne
 
 **Scripts are unavailable with no experiment loaded, and while a workflow is running.** The menu says which. A workflow mutates lamella state from a worker thread, so a script reading mid-run would see a torn snapshot.
 
-**`ctx.microscope` exists, and you should not use it.** Scripts that declare `uses_microscope` are refused, because the guarantees they need — hardware exclusion, cancellation, restoring state afterwards — do not exist yet. Touching the microscope without declaring the flag gets you past the check, not past the missing guarantees.
+**`ctx.microscope` is there whether or not you declared the flag.** Reaching for it from a script that did not declare `uses_microscope` skips the confirmation, runs the hardware call on the GUI thread, and lets a workflow start underneath you. Declare the flag.
 
 ## Gotchas
 

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -161,6 +161,16 @@ To clear a mark again, use `lamella.defect.clear()`.
 
 Everything above assumes you loaded the experiment yourself. AutoLamella can instead run a script against the experiment it already has open, from **Tools → Scripts → Manage scripts…**.
 
+> **Off by default.** The Scripts menu is not built unless you opt in:
+>
+> ```
+> AUTOLAMELLA_ENABLE_SCRIPTS=1
+> ```
+>
+> A script gets the application's own access to the microscope and none of its guard rails, so it is not offered to someone who never asked for it. Anything other than `1`, `true`, `yes` or `on` — including a typo — leaves it off. Nothing else creates the menu or the dialog, so with the variable unset the feature is entirely absent rather than present-but-disabled.
+>
+> None of this affects the headless recipes above: loading an experiment yourself in a notebook or a plain `python` script needs no flag.
+
 Everything happens in that dialog. The menu itself only opens it and the scripts folder — it deliberately does not run anything, because a menu item has no way to show you a script that is still going, and no way to stop it.
 
 Drop a `.py` file in:

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -161,13 +161,9 @@ To clear a mark again, use `lamella.defect.clear()`.
 
 Everything above assumes you loaded the experiment yourself. AutoLamella can instead run a script against the experiment it already has open, from **Tools → Scripts → Manage scripts…**.
 
-> **Off by default.** The Scripts menu is not built unless you opt in:
+> **Off by default.** Turn it on in **File → Preferences… → Features → Enable User Scripts**. It takes effect immediately — no restart — and persists in `user-preferences.yaml`.
 >
-> ```
-> AUTOLAMELLA_ENABLE_SCRIPTS=1
-> ```
->
-> A script gets the application's own access to the microscope and none of its guard rails, so it is not offered to someone who never asked for it. Anything other than `1`, `true`, `yes` or `on` — including a typo — leaves it off. Nothing else creates the menu or the dialog, so with the variable unset the feature is entirely absent rather than present-but-disabled.
+> A script gets the application's own access to the microscope and none of its guard rails, so the menu is not offered to anyone who has not asked for it. Switching it on warns you once; switching it off hides the menu again. Hiding the menu hides the whole feature, since that is the only route to the dialog and the dialog is the only thing that runs a script.
 >
 > None of this affects the headless recipes above: loading an experiment yourself in a notebook or a plain `python` script needs no flag.
 

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -159,7 +159,9 @@ To clear a mark again, use `lamella.defect.clear()`.
 
 ## Running scripts from the GUI
 
-Everything above assumes you loaded the experiment yourself. AutoLamella can instead run a script against the experiment it already has open, from **Tools → Scripts**.
+Everything above assumes you loaded the experiment yourself. AutoLamella can instead run a script against the experiment it already has open, from **Tools → Scripts → Manage scripts…**.
+
+Everything happens in that dialog. The menu itself only opens it and the scripts folder — it deliberately does not run anything, because a menu item has no way to show you a script that is still going, and no way to stop it.
 
 Drop a `.py` file in:
 
@@ -240,6 +242,7 @@ Without `writes`, nothing your script changed is persisted — a read-only scrip
 """Acquire an ion image at every lamella position."""
 uses_microscope = True
 
+from fibsem import acquire
 from fibsem.structures import BeamType, ImageSettings
 
 
@@ -249,12 +252,14 @@ def run(ctx):
     for lamella in ctx.experiment.positions:
         ctx.raise_if_cancelled()          # let Stop actually stop it
         ctx.log(f"moving to {lamella.name}")
-        ctx.microscope.safe_absolute_stage_movement(lamella.state.stage_position)
+        ctx.microscope.safe_absolute_stage_movement(lamella.stage_position)
         settings.path, settings.filename = lamella.path, "script-survey"
-        ctx.microscope.acquire_image(settings)
+        acquire.acquire_image(ctx.microscope, settings)
 
     return f"imaged {len(ctx.experiment.positions)} positions"
 ```
+
+Use `fibsem.acquire.acquire_image(microscope, settings)`, not `microscope.acquire_image(settings)`. The method on the microscope is the raw grab and **ignores `save=True`** — the module-level function is the one that applies autocontrast, auto-gamma and writes the file.
 
 ### How these differ from data scripts
 
@@ -277,13 +282,13 @@ A script that never checks runs to completion no matter how many times Stop is p
 
 Scripts are re-read from disk on every run. Edit the file, click Run, and the new code runs; there is no reload button because there is nothing to reload.
 
-**Manage scripts…** also lists the files that failed to import, with the reason. A file with `def main(ctx)` instead of `def run(ctx)` shows up as an error row rather than quietly disappearing from the menu.
+The dialog also lists the files that failed to import, with the reason. A file with `def main(ctx)` instead of `def run(ctx)` shows up as an error row rather than quietly disappearing from the list.
 
 ### What to expect
 
 **The window freezes while a script runs.** Scripts run on the GUI thread, so a slow loop over thousands of images locks the interface until it finishes. Keep GUI scripts short and do the heavy work headlessly.
 
-**Scripts are unavailable with no experiment loaded, and while a workflow is running.** The menu says which. A workflow mutates lamella state from a worker thread, so a script reading mid-run would see a torn snapshot.
+**Scripts are unavailable with no experiment loaded, and while a workflow is running.** Run is greyed out and the dialog says which. A workflow mutates lamella state from a worker thread, so a script reading mid-run would see a torn snapshot.
 
 **`ctx.microscope` is `None` unless you declared `uses_microscope`.** If you reach for it without the flag you get `AttributeError: 'NoneType' object has no attribute …` — add the flag rather than working around it. This is a guard against forgetting, not a sandbox: a script is arbitrary Python and can import its way to a microscope handle. Doing that skips the confirmation, runs the hardware call on the GUI thread, and lets a workflow start underneath you.
 

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -192,6 +192,7 @@ That is all of it — no registration step, nothing to install, no restart. File
 | `ctx.path` | its directory — the default place to write output |
 | `ctx.log(message)` | writes to the log, tagged with your script's name |
 | `ctx.save()` | called for you; see `writes` below |
+| `ctx.microscope` | the microscope, or `None` unless you declared `uses_microscope` |
 
 ### Showing your results
 
@@ -284,7 +285,7 @@ Scripts are re-read from disk on every run. Edit the file, click Run, and the ne
 
 **Scripts are unavailable with no experiment loaded, and while a workflow is running.** The menu says which. A workflow mutates lamella state from a worker thread, so a script reading mid-run would see a torn snapshot.
 
-**`ctx.microscope` is there whether or not you declared the flag.** Reaching for it from a script that did not declare `uses_microscope` skips the confirmation, runs the hardware call on the GUI thread, and lets a workflow start underneath you. Declare the flag.
+**`ctx.microscope` is `None` unless you declared `uses_microscope`.** If you reach for it without the flag you get `AttributeError: 'NoneType' object has no attribute …` — add the flag rather than working around it. This is a guard against forgetting, not a sandbox: a script is arbitrary Python and can import its way to a microscope handle. Doing that skips the confirmation, runs the hardware call on the GUI thread, and lets a workflow start underneath you.
 
 ## Gotchas
 

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -4,6 +4,8 @@ You can read and modify an AutoLamella experiment from a plain Python script. No
 
 This is the quickest way to do custom things with your data: export a summary, pull out timings, find the lamellae that failed, or bulk-edit something across a whole run.
 
+AutoLamella can also run scripts itself, against the experiment you already have open — see [Running scripts from the GUI](#running-scripts-from-the-gui).
+
 ## Loading an experiment
 
 Every experiment directory contains an `experiment.yaml`. Point `Experiment.load()` at it:
@@ -154,6 +156,92 @@ To clear a mark again, use `lamella.defect.clear()`.
 `exp.save()` rewrites `experiment.yaml` only, leaving `protocol.yaml` untouched. Pass `exp.save(save_protocol=True)` if you also want the protocol written out.
 
 **Back up the experiment directory before running anything that writes.** These scripts have no undo.
+
+## Running scripts from the GUI
+
+Everything above assumes you loaded the experiment yourself. AutoLamella can instead run a script against the experiment it already has open, from **Tools → Scripts**.
+
+Drop a `.py` file in:
+
+```
+~/.autolamella/scripts
+```
+
+Set `AUTOLAMELLA_SCRIPTS_DIR` to use a different folder. **Tools → Scripts → Manage scripts…** shows which folder it resolved to; **Open folder** there creates it if it does not exist yet, and **New script…** writes a working stub into it.
+
+### The contract
+
+One rule: a module-level `run(ctx)`.
+
+```python
+"""Export the experiment summary to CSV."""   # first line becomes the tooltip
+
+def run(ctx):
+    out = ctx.path / "summary.csv"
+    ctx.experiment.experiment_summary_dataframe().to_csv(out, index=False)
+    return out
+```
+
+That is all of it — no registration step, nothing to install, no restart. Files whose names start with `_` are skipped, so you can keep shared helpers in the same folder.
+
+`ctx` carries:
+
+| Attribute | Description |
+|---|---|
+| `ctx.experiment` | the experiment currently open in the GUI |
+| `ctx.path` | its directory — the default place to write output |
+| `ctx.log(message)` | writes to the log, tagged with your script's name |
+| `ctx.save()` | called for you; see `writes` below |
+
+### Showing your results
+
+**Return the output.** There is no console in the app — `print()` goes to a terminal you may not have, and a packaged Windows build has none at all. A script that prints its answer and returns nothing looks like it did nothing.
+
+What you return decides how it is shown:
+
+| Return | What happens |
+|---|---|
+| a `str` | shown as a toast |
+| a `DataFrame` | opened in a table |
+| a `Path` | toast, and the containing folder opens |
+| `None` | a "finished" toast |
+
+`ctx.log("...")` writes to the log file, tagged with the script name so the lines stay attributable afterwards. Plain `logging.info(...)` works too and goes to the same place, just untagged.
+
+### Flags
+
+A script declares what it needs with module-level names, so the declaration cannot drift from the code it governs:
+
+```python
+"""Mark every lamella that never reached polishing."""
+writes = True
+
+def run(ctx):
+    ...
+```
+
+| Flag | What it does |
+|---|---|
+| `writes = True` | asks you to confirm before running, then calls `ctx.save()` afterwards |
+| `background = True` | **not implemented** — parsed, but the script still runs inline |
+| `uses_microscope = True` | **not implemented** — the script is refused rather than run |
+| `on_workflow_completed = True` | **not implemented** — nothing runs it automatically |
+
+Without `writes`, nothing your script changed is persisted — a read-only script cannot rewrite `experiment.yaml` by accident.
+
+### Editing and re-running
+
+Scripts are re-read from disk on every run. Edit the file, click Run, and the new code runs; there is no reload button because there is nothing to reload.
+
+**Manage scripts…** also lists the files that failed to import, with the reason. A file with `def main(ctx)` instead of `def run(ctx)` shows up as an error row rather than quietly disappearing from the menu.
+
+### What to expect
+
+**The window freezes while a script runs.** Scripts run on the GUI thread, so a slow loop over thousands of images locks the interface until it finishes. Keep GUI scripts short and do the heavy work headlessly.
+
+**Scripts are unavailable with no experiment loaded, and while a workflow is running.** The menu says which. A workflow mutates lamella state from a worker thread, so a script reading mid-run would see a torn snapshot.
+
+**`ctx.microscope` exists, and you should not use it.** Scripts that declare `uses_microscope` are refused, because the guarantees they need — hardware exclusion, cancellation, restoring state afterwards — do not exist yet. Touching the microscope without declaring the flag gets you past the check, not past the missing guarantees.
 
 ## Gotchas
 

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -171,6 +171,18 @@ Drop a `.py` file in:
 
 Set `AUTOLAMELLA_SCRIPTS_DIR` to use a different folder. **Tools → Scripts → Manage scripts…** shows which folder it resolved to; **Open folder** there creates it if it does not exist yet, and **New script…** writes a working stub into it.
 
+### Working examples
+
+Three complete scripts live in [`examples/scripts/`](examples/scripts), one per tier. Copy any of them into your scripts folder and it will run as-is.
+
+| File | Flags | What it shows |
+| -- | -- | -- |
+| [`export_summary.py`](examples/scripts/export_summary.py) | none | reading the experiment, and how the return value becomes output |
+| [`describe_lamellae.py`](examples/scripts/describe_lamellae.py) | `writes` | changing lamellae and letting the runner save |
+| [`survey_positions.py`](examples/scripts/survey_positions.py) | `uses_microscope` | moving the stage, acquiring, and honouring Stop |
+
+These are executed by the test suite (`tests/autolamella/test_example_scripts.py`) against a real experiment and a simulated microscope, so they cannot quietly rot. That is deliberate: earlier versions of the snippets below shipped with two bugs that only running them would have caught — one addressed a `lamella.state` attribute that does not exist, and one used `microscope.acquire_image`, which ignores `save=True` and writes nothing.
+
 ### The contract
 
 One rule: a module-level `run(ctx)`.

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -184,7 +184,9 @@ def run(ctx):
     return out
 ```
 
-That is all of it — no registration step, nothing to install, no restart. Files whose names start with `_` are skipped, so you can keep shared helpers in the same folder.
+That is all of it — no registration step, nothing to install, no restart. Files whose names start with `_` are hidden from the list.
+
+You can import anything installed — the standard library, `numpy`, `pandas`, and all of `fibsem` itself. You **cannot** import another file from the scripts folder: the folder is not on `sys.path`, so `import _helpers` fails even with the file sitting right beside your script. To share code between scripts, put it in a small package of your own and `pip install -e` it.
 
 `ctx` carries:
 

--- a/examples/scripts/describe_lamellae.py
+++ b/examples/scripts/describe_lamellae.py
@@ -1,0 +1,28 @@
+"""Note the last completed task on every lamella."""
+
+# The runner calls ctx.save() for you after this returns, and asks the user to
+# confirm before it starts. Without this flag the loop below would still run and
+# still change things in memory, but nothing would be written to disk -- so a
+# script that means to persist has to say so.
+writes = True
+
+
+def run(ctx):
+    lamellae = ctx.experiment.positions
+
+    changed = 0
+    for lamella in lamellae:
+        task = lamella.last_completed_task
+        note = f"last task: {task.name}" if task else "no tasks completed yet"
+
+        if lamella.description == note:
+            continue  # nothing to do, and no point dirtying the save
+
+        # `description` is one of the fields the lamella list and card widgets
+        # subscribe to (lamella.events.description), so the GUI updates as this
+        # loop runs -- no refresh call and no signal needed.
+        lamella.description = note
+        changed += 1
+
+    ctx.log(f"updated {changed} of {len(lamellae)}")
+    return f"described {changed} of {len(lamellae)} lamellae"

--- a/examples/scripts/export_summary.py
+++ b/examples/scripts/export_summary.py
@@ -1,0 +1,30 @@
+"""Export a summary of every lamella to CSV."""
+
+# No flags. This script only reads, so the runner withholds ctx.microscope and
+# never saves the experiment -- there is nothing here that can damage anything.
+# Read-only is the default; the other two examples opt out of it explicitly.
+
+
+def run(ctx):
+    experiment = ctx.experiment
+
+    # Needs a protocol loaded: this dataframe asks the protocol whether each
+    # lamella is complete, so it raises AttributeError on an experiment saved
+    # without one. experiment.task_history_dataframe() has no such requirement.
+    df = experiment.experiment_summary_dataframe()
+
+    # ctx.path is the experiment directory. Writing there by default keeps
+    # exports next to the data they came from.
+    out = ctx.path / "lamella-summary.csv"
+    df.to_csv(out, index=False)
+
+    # ctx.log goes to the application log, tagged with this script's name.
+    ctx.log(f"wrote {len(df)} rows to {out.name}")
+
+    # What you return decides what the user sees:
+    #   Path      -> a toast, with an offer to open the containing folder
+    #   str       -> a toast with that message
+    #   DataFrame -> a table dialog
+    # Returning None is legal but looks like the script did nothing, because
+    # there is no log console in the application to fall back on.
+    return out

--- a/examples/scripts/survey_positions.py
+++ b/examples/scripts/survey_positions.py
@@ -1,0 +1,41 @@
+"""Acquire an ion image at every lamella position."""
+
+# Declaring this hands the script ctx.microscope and moves it onto a worker
+# thread, so the window stays responsive and the Run button becomes Stop. Nothing
+# validates what the script then does -- no limits, no interlocks. Without the
+# flag ctx.microscope is None, on purpose.
+uses_microscope = True
+
+from fibsem import acquire
+from fibsem.structures import BeamType, ImageSettings
+
+
+def run(ctx):
+    # acquire.acquire_image, NOT ctx.microscope.acquire_image. Only this one
+    # applies autocontrast and auto-gamma and honours save=True; the microscope
+    # method silently ignores it and writes nothing to disk.
+    settings = ImageSettings(hfw=80e-6, beam_type=BeamType.ION, save=True)
+
+    lamellae = ctx.experiment.positions
+    imaged = 0
+
+    for lamella in lamellae:
+        # Stopping is cooperative. A Python thread cannot be killed, so Stop only
+        # sets a flag -- if the script never asks, the button does nothing and the
+        # run continues to the end. Ask once per iteration, before the slow part.
+        ctx.raise_if_cancelled()
+
+        ctx.log(f"moving to {lamella.name}")
+        ctx.microscope.safe_absolute_stage_movement(lamella.stage_position)
+
+        # Each lamella has its own directory, so images land beside that lamella.
+        settings.path = lamella.path
+        settings.filename = "survey"
+        acquire.acquire_image(ctx.microscope, settings)
+        imaged += 1
+
+    # Reading ctx.experiment from a microscope script is fine. *Writing* to it is
+    # not: this runs off the GUI thread, and the experiment is psygnal-evented, so
+    # assigning to it here would drive widget updates from the wrong thread. Do
+    # the hardware work here and the bookkeeping in a separate `writes` script.
+    return f"imaged {imaged} of {len(lamellae)} positions"

--- a/fibsem/applications/autolamella/scripting.py
+++ b/fibsem/applications/autolamella/scripting.py
@@ -9,9 +9,12 @@ See SCRIPTING.md for the headless equivalent, and FIB-338 for the design.
 
 import logging
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, Optional
+
+from fibsem.cancellation import raise_if_cancelled
 
 from fibsem.scripting import (  # noqa: F401 - re-exported for callers
     DiscoveredScript,
@@ -63,6 +66,10 @@ class ScriptContext:
     experiment: "Experiment"
     log: Callable[[str], None] = logging.info
     microscope: Optional["FibsemMicroscope"] = None
+    # Set by the runner for scripts that run off the GUI thread. A script cannot be
+    # killed -- Python threads have no such thing -- so stopping one is cooperative:
+    # the runner sets this, and the script has to look at it.
+    stop_event: Optional[threading.Event] = None
 
     @property
     def path(self) -> Path:
@@ -72,3 +79,17 @@ class ScriptContext:
     def save(self) -> None:
         """Persist the experiment. Called by the runner only for ``writes`` scripts."""
         self.experiment.save()
+
+    @property
+    def cancelled(self) -> bool:
+        """Whether the user has asked this script to stop."""
+        return self.stop_event is not None and self.stop_event.is_set()
+
+    def raise_if_cancelled(self, msg: str = "Script cancelled by user.") -> None:
+        """Abort the script if the user pressed Stop.
+
+        Call between steps of a long run — after each move, between images. A
+        script that never calls it (or never checks :attr:`cancelled`) simply
+        runs to completion, and Stop does nothing.
+        """
+        raise_if_cancelled(self.stop_event, msg)

--- a/fibsem/applications/autolamella/scripting.py
+++ b/fibsem/applications/autolamella/scripting.py
@@ -36,28 +36,6 @@ if TYPE_CHECKING:
 SCRIPTS_DIR_ENV_VAR = "AUTOLAMELLA_SCRIPTS_DIR"
 DEFAULT_SCRIPTS_DIR = Path.home() / ".autolamella" / "scripts"
 
-# Off by default. A script here runs with the application's own access to the
-# hardware and none of its guard rails, so the feature should not appear to someone
-# who never asked for it. Set AUTOLAMELLA_ENABLE_SCRIPTS=1 to opt a machine in.
-# An env var rather than a settings key because that is what the rest of the
-# codebase already uses for this kind of switch (FIBSEM_SIM_NO_DELAY, and
-# SCRIPTS_DIR_ENV_VAR above), and because it needs no file on a locked-down
-# microscope PC.
-SCRIPTS_ENABLED_ENV_VAR = "AUTOLAMELLA_ENABLE_SCRIPTS"
-_TRUTHY = frozenset({"1", "true", "yes", "on"})
-
-
-def scripts_enabled() -> bool:
-    """Whether the Scripts menu is offered at all.
-
-    Gating the menu gates everything: it is the only way to reach the manager
-    dialog, and the dialog is the only thing that runs a script. Unset, empty, and
-    anything unrecognised all count as off -- a typo in the value should leave the
-    feature hidden rather than silently enabled.
-    """
-    return os.environ.get(SCRIPTS_ENABLED_ENV_VAR, "").strip().lower() in _TRUTHY
-
-
 def get_scripts_directory() -> Path:
     """Resolve the user scripts directory. Does not create it."""
     override = os.environ.get(SCRIPTS_DIR_ENV_VAR)

--- a/fibsem/applications/autolamella/scripting.py
+++ b/fibsem/applications/autolamella/scripting.py
@@ -1,0 +1,74 @@
+"""AutoLamella's binding for user scripts.
+
+The discovery and execution machinery is application-agnostic and lives in
+``fibsem.scripting``. This module supplies the two things that are specific to
+AutoLamella: where the scripts live, and what a script is handed when it runs.
+
+See SCRIPTING.md for the headless equivalent, and FIB-338 for the design.
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+from fibsem.scripting import (  # noqa: F401 - re-exported for callers
+    DiscoveredScript,
+    ScriptResult,
+    discover_scripts as _discover_scripts,
+    load_script,
+    run_script,
+)
+
+if TYPE_CHECKING:
+    from fibsem.applications.autolamella.structures import Experiment
+    from fibsem.microscope import FibsemMicroscope
+
+# Interim location: the final root is decided by FIB-336, and this should become
+# <user root>/scripts rather than being chosen separately. `%APPDATA%` was rejected
+# (hidden in Explorer, and users must browse here to drop files in); Documents was
+# rejected (OneDrive-synced on most institutional machines). A leading dot does not
+# set the hidden attribute on Windows, so this is visible there too. See FIB-341.
+SCRIPTS_DIR_ENV_VAR = "AUTOLAMELLA_SCRIPTS_DIR"
+DEFAULT_SCRIPTS_DIR = Path.home() / ".autolamella" / "scripts"
+
+
+def get_scripts_directory() -> Path:
+    """Resolve the user scripts directory. Does not create it."""
+    override = os.environ.get(SCRIPTS_DIR_ENV_VAR)
+    if override:
+        return Path(override).expanduser()
+    return DEFAULT_SCRIPTS_DIR
+
+
+def discover_scripts(directory: Optional[Path] = None) -> List[DiscoveredScript]:
+    """Load the user's scripts, defaulting to the AutoLamella scripts folder."""
+    return _discover_scripts(directory or get_scripts_directory())
+
+
+@dataclass
+class ScriptContext:
+    """What a script is handed when it runs.
+
+    Deliberately not the ``AutoLamellaUI`` object. ``AutoLamellaUI.experiment`` is
+    *rebound* on create/load rather than mutated, so a script that cached the ui
+    would silently operate on a dead experiment; and this stays a documented,
+    stable surface while the GUI internals are still moving.
+
+    ``microscope`` is optional so the same file also runs headlessly, with no
+    hardware attached.
+    """
+
+    experiment: "Experiment"
+    log: Callable[[str], None] = logging.info
+    microscope: Optional["FibsemMicroscope"] = None
+
+    @property
+    def path(self) -> Path:
+        """The experiment directory — the default place to write output."""
+        return Path(self.experiment.path)
+
+    def save(self) -> None:
+        """Persist the experiment. Called by the runner only for ``writes`` scripts."""
+        self.experiment.save()

--- a/fibsem/applications/autolamella/scripting.py
+++ b/fibsem/applications/autolamella/scripting.py
@@ -36,6 +36,27 @@ if TYPE_CHECKING:
 SCRIPTS_DIR_ENV_VAR = "AUTOLAMELLA_SCRIPTS_DIR"
 DEFAULT_SCRIPTS_DIR = Path.home() / ".autolamella" / "scripts"
 
+# Off by default. A script here runs with the application's own access to the
+# hardware and none of its guard rails, so the feature should not appear to someone
+# who never asked for it. Set AUTOLAMELLA_ENABLE_SCRIPTS=1 to opt a machine in.
+# An env var rather than a settings key because that is what the rest of the
+# codebase already uses for this kind of switch (FIBSEM_SIM_NO_DELAY, and
+# SCRIPTS_DIR_ENV_VAR above), and because it needs no file on a locked-down
+# microscope PC.
+SCRIPTS_ENABLED_ENV_VAR = "AUTOLAMELLA_ENABLE_SCRIPTS"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def scripts_enabled() -> bool:
+    """Whether the Scripts menu is offered at all.
+
+    Gating the menu gates everything: it is the only way to reach the manager
+    dialog, and the dialog is the only thing that runs a script. Unset, empty, and
+    anything unrecognised all count as off -- a typo in the value should leave the
+    feature hidden rather than silently enabled.
+    """
+    return os.environ.get(SCRIPTS_ENABLED_ENV_VAR, "").strip().lower() in _TRUTHY
+
 
 def get_scripts_directory() -> Path:
     """Resolve the user scripts directory. Does not create it."""

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -295,6 +295,22 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         reporting_menu.addAction(self.action_generate_report)
         reporting_menu.addAction(self.action_generate_overview_plot)
 
+        # user scripts (FIB-338). The menu itself is application-agnostic; this
+        # supplies only the folder, the context, and how to notify.
+        from fibsem.applications.autolamella.scripting import get_scripts_directory
+        from fibsem.ui.widgets.script_menu import ScriptMenuController
+
+        self.scripts_menu = tools_menu.addMenu("Scripts")
+        if self.scripts_menu is None:
+            raise RuntimeError("Failed to create Scripts submenu in AutoLamella UI.")
+        self.script_menu_controller = ScriptMenuController(
+            menu=self.scripts_menu,
+            scripts_directory=get_scripts_directory,
+            context_factory=self._script_context,
+            notify=self.show_toast,
+            parent=self,
+        )
+
         # add help menu
         help_menu = menu_bar.addMenu("Help")
         if help_menu is None:
@@ -505,6 +521,30 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.lamella_workflow_widget.workflow.enable_schedule_button(
                 self._preferences.features.scheduled_tasks
             )
+
+    #### USER SCRIPTS (FIB-338)
+
+    def _script_context(self):
+        """Build the context a script runs against, or explain why it cannot.
+
+        Returns (context, reason). A reason means the menu entries are disabled and
+        that string is shown instead.
+        """
+        from fibsem.applications.autolamella.scripting import ScriptContext
+
+        experiment = self.autolamella_ui.experiment
+        if experiment is None:
+            return None, "Load an experiment to run scripts"
+        if self.autolamella_ui.is_workflow_running:
+            # tasks mutate lamella state on a worker thread, so a script reading
+            # mid-workflow would get a torn snapshot.
+            return None, "Unavailable while a workflow is running"
+
+        return ScriptContext(
+            experiment=experiment,
+            log=logging.info,
+            microscope=self.autolamella_ui.microscope,
+        ), ""
 
     def show_toast(
         self,

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -297,19 +297,32 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         # user scripts (FIB-338). The menu itself is application-agnostic; this
         # supplies only the folder, the context, and how to notify.
-        from fibsem.applications.autolamella.scripting import get_scripts_directory
-        from fibsem.ui.widgets.script_menu import ScriptMenuController
-
-        self.scripts_menu = tools_menu.addMenu("Scripts")
-        if self.scripts_menu is None:
-            raise RuntimeError("Failed to create Scripts submenu in AutoLamella UI.")
-        self.script_menu_controller = ScriptMenuController(
-            menu=self.scripts_menu,
-            scripts_directory=get_scripts_directory,
-            context_factory=self._script_context,
-            notify=self.show_toast,
-            parent=self,
+        #
+        # Behind AUTOLAMELLA_ENABLE_SCRIPTS, and off by default: a script runs with
+        # the application's own hardware access and none of its guard rails. Not
+        # built at all rather than built-and-disabled -- a greyed-out Scripts menu
+        # advertises a feature the user cannot reach and cannot be told how to.
+        # Nothing else creates the menu or the dialog, so this is the whole gate.
+        from fibsem.applications.autolamella.scripting import (
+            get_scripts_directory,
+            scripts_enabled,
         )
+
+        self.scripts_menu = None
+        self.script_menu_controller = None
+        if scripts_enabled():
+            from fibsem.ui.widgets.script_menu import ScriptMenuController
+
+            self.scripts_menu = tools_menu.addMenu("Scripts")
+            if self.scripts_menu is None:
+                raise RuntimeError("Failed to create Scripts submenu in AutoLamella UI.")
+            self.script_menu_controller = ScriptMenuController(
+                menu=self.scripts_menu,
+                scripts_directory=get_scripts_directory,
+                context_factory=self._script_context,
+                notify=self.show_toast,
+                parent=self,
+            )
 
         # add help menu
         help_menu = menu_bar.addMenu("Help")

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -298,31 +298,25 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # user scripts (FIB-338). The menu itself is application-agnostic; this
         # supplies only the folder, the context, and how to notify.
         #
-        # Behind AUTOLAMELLA_ENABLE_SCRIPTS, and off by default: a script runs with
-        # the application's own hardware access and none of its guard rails. Not
-        # built at all rather than built-and-disabled -- a greyed-out Scripts menu
-        # advertises a feature the user cannot reach and cannot be told how to.
-        # Nothing else creates the menu or the dialog, so this is the whole gate.
-        from fibsem.applications.autolamella.scripting import (
-            get_scripts_directory,
-            scripts_enabled,
+        # Built unconditionally and hidden by _apply_preferences when the
+        # features.scripts_enabled flag is off, which is the default. Hidden rather
+        # than absent so toggling the preference takes effect without a restart, the
+        # same way the coincidence viewer and bug reporter do. Constructing the
+        # controller costs nothing -- it adds two fixed actions and never touches the
+        # scripts folder until the dialog is opened.
+        from fibsem.applications.autolamella.scripting import get_scripts_directory
+        from fibsem.ui.widgets.script_menu import ScriptMenuController
+
+        self.scripts_menu = tools_menu.addMenu("Scripts")
+        if self.scripts_menu is None:
+            raise RuntimeError("Failed to create Scripts submenu in AutoLamella UI.")
+        self.script_menu_controller = ScriptMenuController(
+            menu=self.scripts_menu,
+            scripts_directory=get_scripts_directory,
+            context_factory=self._script_context,
+            notify=self.show_toast,
+            parent=self,
         )
-
-        self.scripts_menu = None
-        self.script_menu_controller = None
-        if scripts_enabled():
-            from fibsem.ui.widgets.script_menu import ScriptMenuController
-
-            self.scripts_menu = tools_menu.addMenu("Scripts")
-            if self.scripts_menu is None:
-                raise RuntimeError("Failed to create Scripts submenu in AutoLamella UI.")
-            self.script_menu_controller = ScriptMenuController(
-                menu=self.scripts_menu,
-                scripts_directory=get_scripts_directory,
-                context_factory=self._script_context,
-                notify=self.show_toast,
-                parent=self,
-            )
 
         # add help menu
         help_menu = menu_bar.addMenu("Help")
@@ -527,6 +521,15 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # Toggle the "Report an Issue..." Help menu action
         self.action_report_issue.setVisible(
             self._preferences.features.bug_report_enabled
+        )
+        # Toggle Tools -> Scripts. Hiding the menu hides the whole feature: it is the
+        # only route to the manager dialog, and the dialog is the only thing that runs
+        # a script. If a script is mid-run, leave it visible -- taking away the only
+        # Stop button while the microscope is moving would be worse than the flag
+        # being briefly wrong.
+        self.scripts_menu.menuAction().setVisible(
+            self._preferences.features.scripts_enabled
+            or self.script_menu_controller.runner.is_running
         )
         # Toggle the per-task schedule button in the workflow tab live, so a
         # scheduled-tasks flag change applies without restarting.

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -299,6 +299,16 @@ class AutoLamellaUI(QMainWindow):
             self._task_worker_thread is not None and self._task_worker_thread.is_alive()
         )
 
+    def _script_runner_is_busy(self) -> bool:
+        """Whether a user script is currently driving the microscope (FIB-340).
+
+        Reached through the parent window, which owns the Scripts menu. Absent in
+        the tests and in any host that never built one, so this stays optional
+        rather than asserting the attribute exists.
+        """
+        controller = getattr(self.parent_widget, "script_menu_controller", None)
+        return bool(controller is not None and controller.runner.is_running)
+
     def setup_connections(self):
 
         # lamella controls
@@ -1007,6 +1017,15 @@ class AutoLamellaUI(QMainWindow):
         self, selected_tasks: List[str], selected_lamella: List[str]
     ) -> None:
         """Start the workflow thread with the selected tasks and lamella, and update the UI accordingly."""
+
+        # A user script may be driving the microscope right now. Scripts are already
+        # blocked while a workflow runs; this is the other direction, so the two
+        # cannot end up moving the stage at the same time (FIB-340).
+        if self._script_runner_is_busy():
+            msg = "A microscope script is running. Stop it before starting a workflow."
+            logging.warning(msg)
+            notification_service.show_toast(msg, "warning")
+            return
 
         # clear milling task config
         self.milling_task_config_widget.clear()  # type: ignore

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -259,6 +259,10 @@ class FeatureFlags:
     sample_holder_widget: bool = False
     scheduled_tasks: bool = False
     bug_report_enabled: bool = False
+    # Tools -> Scripts. A user script runs with the application's own access to the
+    # microscope and none of its guard rails, so the menu is not offered to anyone
+    # who has not asked for it (FIB-338).
+    scripts_enabled: bool = False
 
 @dataclass
 class MovementPreferences:

--- a/fibsem/scripting.py
+++ b/fibsem/scripting.py
@@ -1,0 +1,192 @@
+"""Discovery and execution of user scripts.
+
+Lets a user drop a plain ``.py`` file in a folder and run it, without packaging
+anything. Application-agnostic: this module knows nothing about experiments,
+microscopes or Qt. An application supplies the folder and the context object.
+
+A script is a module exposing ``run(ctx)``:
+
+    \"\"\"Export a summary to CSV.\"\"\"   # docstring -> menu tooltip
+
+    def run(ctx):
+        ...
+        return path_or_dataframe_or_string
+
+It declares its own contract with module-level flags, so the declaration cannot
+drift from the code it governs:
+
+    writes = True                 # the run mutates state the host should persist
+    background = True             # safe to run off the GUI thread
+    uses_microscope = True        # needs hardware, and whatever guarantees that implies
+    on_workflow_completed = True  # also runs automatically when a workflow finishes
+
+Only ``writes`` is acted on here, via the context's optional ``save()`` hook. The
+rest are parsed and exposed for the host to interpret.
+"""
+
+import hashlib
+import importlib.util
+import logging
+import traceback
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import ModuleType
+from typing import Any, List, Optional
+
+# Module-level names a script may declare. Anything else is ignored.
+FLAG_WRITES = "writes"
+FLAG_BACKGROUND = "background"
+FLAG_USES_MICROSCOPE = "uses_microscope"
+FLAG_ON_WORKFLOW_COMPLETED = "on_workflow_completed"
+
+ENTRYPOINT = "run"
+
+
+@dataclass
+class DiscoveredScript:
+    """A ``.py`` file found in the scripts folder, loaded or not."""
+
+    path: Path
+    name: str
+    description: str = ""
+    writes: bool = False
+    background: bool = False
+    uses_microscope: bool = False
+    on_workflow_completed: bool = False
+    error: Optional[str] = None  # set when the file could not be loaded
+    _module: Optional[ModuleType] = field(default=None, repr=False)
+
+    @property
+    def is_runnable(self) -> bool:
+        return self.error is None and self._module is not None
+
+    @property
+    def content_hash(self) -> str:
+        """Short hash of the file as it was loaded.
+
+        Users edit these in place, so "which version ran" is otherwise
+        unanswerable after the fact.
+        """
+        try:
+            return hashlib.sha256(self.path.read_bytes()).hexdigest()[:8]
+        except OSError:
+            return "unknown"
+
+
+def _load_module(path: Path) -> ModuleType:
+    """Import a script file under a unique synthetic name.
+
+    Deliberately **not** inserted into ``sys.modules``: two scripts sharing a
+    filename in different folders would collide, and stale modules would leak
+    across reloads.
+    """
+    module_name = f"_fibsem_script_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not create a module spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_script(path: Path) -> DiscoveredScript:
+    """Load one script file, capturing failure rather than raising.
+
+    A file that cannot be loaded still comes back with ``error`` set, so the host
+    can show it. Silently omitting it is the failure this avoids: the author sees
+    nothing and assumes the folder is wrong.
+    """
+    script = DiscoveredScript(path=path, name=path.stem)
+    try:
+        module = _load_module(path)
+    except Exception:
+        script.error = traceback.format_exc(limit=3).strip().splitlines()[-1]
+        logging.warning("Failed to load script %s: %s", path, script.error)
+        return script
+
+    entrypoint = getattr(module, ENTRYPOINT, None)
+    if not callable(entrypoint):
+        script.error = f"no {ENTRYPOINT}() function found — expected def {ENTRYPOINT}(ctx)"
+        return script
+
+    doc = (module.__doc__ or "").strip()
+    script._module = module
+    script.description = doc.splitlines()[0] if doc else path.stem
+    script.writes = bool(getattr(module, FLAG_WRITES, False))
+    script.background = bool(getattr(module, FLAG_BACKGROUND, False))
+    script.uses_microscope = bool(getattr(module, FLAG_USES_MICROSCOPE, False))
+    script.on_workflow_completed = bool(getattr(module, FLAG_ON_WORKFLOW_COMPLETED, False))
+    return script
+
+
+def discover_scripts(directory: Path) -> List[DiscoveredScript]:
+    """Load every ``.py`` in ``directory``, sorted by filename.
+
+    Returns failures alongside successes. A missing directory is not an error —
+    it just means no scripts yet. Files starting with ``_`` are skipped so users
+    can keep shared helpers beside their scripts.
+
+    Not cached: scripts are loaded fresh on every call, so editing a file and
+    running it again picks up the change. A data script runs in milliseconds, so
+    the import cost is irrelevant beside it, and "reload" stops being a feature.
+    """
+    directory = Path(directory)
+    if not directory.is_dir():
+        return []
+
+    scripts: List[DiscoveredScript] = []
+    for path in sorted(directory.glob("*.py")):
+        if path.name.startswith("_"):
+            continue
+        scripts.append(load_script(path))
+    return scripts
+
+
+@dataclass
+class ScriptResult:
+    """Outcome of one run, for the host to render and record."""
+
+    script: DiscoveredScript
+    value: Any = None
+    error: Optional[BaseException] = None
+    saved: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+def run_script(script: DiscoveredScript, ctx: Any) -> ScriptResult:
+    """Run a script and return its outcome. Never raises.
+
+    Exceptions are captured rather than propagated: hosts call this from a Qt slot,
+    and PyQt5 aborts the whole process on any exception that escapes one (FIB-329).
+    The host decides how to surface it.
+
+    If the script declared ``writes`` and ``ctx`` provides a ``save()``, it is
+    called after a successful run. A script that did not declare it cannot
+    persist anything by accident.
+    """
+    if not script.is_runnable:
+        return ScriptResult(script=script, error=RuntimeError(script.error or "not runnable"))
+
+    logging.info(
+        "Running script %s (%s) writes=%s microscope=%s",
+        script.name, script.content_hash, script.writes, script.uses_microscope,
+    )
+
+    result = ScriptResult(script=script)
+    try:
+        result.value = script._module.run(ctx)  # type: ignore[union-attr]
+    except BaseException as e:  # noqa: BLE001 - deliberately broad, see docstring
+        result.error = e
+        logging.exception("Script %s failed", script.name)
+        return result
+
+    save = getattr(ctx, "save", None)
+    if script.writes and callable(save):
+        save()
+        result.saved = True
+
+    return result

--- a/fibsem/scripting.py
+++ b/fibsem/scripting.py
@@ -177,12 +177,20 @@ def run_script(script: DiscoveredScript, ctx: Any) -> ScriptResult:
     )
 
     result = ScriptResult(script=script)
+    # Tag anything the script logs with its name, so lines in a shared logfile are
+    # attributable. Restored afterwards so a reused context is not left modified.
+    original_log = getattr(ctx, "log", None)
+    if callable(original_log):
+        ctx.log = lambda message, _name=script.name: logging.info("[%s] %s", _name, message)
     try:
         result.value = script._module.run(ctx)  # type: ignore[union-attr]
     except BaseException as e:  # noqa: BLE001 - deliberately broad, see docstring
         result.error = e
         logging.exception("Script %s failed", script.name)
         return result
+    finally:
+        if callable(original_log):
+            ctx.log = original_log
 
     save = getattr(ctx, "save", None)
     if script.writes and callable(save):

--- a/fibsem/scripting.py
+++ b/fibsem/scripting.py
@@ -125,8 +125,9 @@ def discover_scripts(directory: Path) -> List[DiscoveredScript]:
     """Load every ``.py`` in ``directory``, sorted by filename.
 
     Returns failures alongside successes. A missing directory is not an error —
-    it just means no scripts yet. Files starting with ``_`` are skipped so users
-    can keep shared helpers beside their scripts.
+    it just means no scripts yet. Files starting with ``_`` are hidden from the
+    listing; note that they are *not* importable from a script, since the folder
+    is never on ``sys.path`` (FIB-386).
 
     Not cached: scripts are loaded fresh on every call, so editing a file and
     running it again picks up the change. A data script runs in milliseconds, so

--- a/fibsem/scripting.py
+++ b/fibsem/scripting.py
@@ -18,10 +18,11 @@ drift from the code it governs:
     writes = True                 # the run mutates state the host should persist
     background = True             # safe to run off the GUI thread
     uses_microscope = True        # needs hardware, and whatever guarantees that implies
-    on_workflow_completed = True  # also runs automatically when a workflow finishes
+    on_workflow_completed = True  # host may also run it when a workflow finishes
 
 Only ``writes`` is acted on here, via the context's optional ``save()`` hook. The
-rest are parsed and exposed for the host to interpret.
+rest are parsed and exposed for the host to interpret — and no host acts on
+``on_workflow_completed`` yet, so declaring it currently does nothing.
 """
 
 import hashlib

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -582,6 +582,24 @@ SECONDARY_BUTTON_STYLESHEET = """
     }
 """
 
+MESSAGE_BOX_STYLESHEET = """
+    QMessageBox {
+        background-color: #262930;
+    }
+    QMessageBox QLabel {
+        color: #d6d6d6;
+        font-size: 12px;
+    }
+    QMessageBox QLabel#qt_msgbox_label {
+        color: #f0f1f2;
+        font-size: 13px;
+        font-weight: 500;
+    }
+"""
+# The #qt_msgbox_label id is Qt's own name for the headline label, so it is only
+# a lift on top of the rule above -- if a future Qt renames it the text stays
+# readable rather than disappearing.
+
 STATUS_BAR_STYLESHEET = """
                 QStatusBar {
                     background-color: #1e2027;

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -53,6 +53,12 @@ _TIP_BUG_REPORT    = (
     "Show the 'Report an Issue...' option in the Help menu, for reporting bugs and "
     "optionally submitting experiment data privately to the maintainers."
 )
+_LBL_SCRIPTS       = "Enable User Scripts"
+_TIP_SCRIPTS       = (
+    "Show Tools > Scripts, for running your own .py files against the open "
+    "experiment. A script has the same access to the microscope as the application "
+    "itself and none of its safety checks — nothing validates what it does."
+)
 
 # Experiment defaults
 _LBL_EXP_DIR       = "Default Experiment Directory"
@@ -83,7 +89,10 @@ class PreferencesDialog(QDialog):
         self._preferences = preferences
         self._setup_ui()
         self._load_from_preferences(preferences)
+        # Connected after loading, so opening this dialog with a flag already on does
+        # not fire its warning.
         self._chk_coincidence_milling.toggled.connect(self._on_coincidence_milling_toggled)
+        self._chk_scripts.toggled.connect(self._on_scripts_toggled)
 
     def _setup_ui(self):
         layout = QVBoxLayout(self)
@@ -133,11 +142,14 @@ class PreferencesDialog(QDialog):
         self._chk_scheduled_tasks.setToolTip(_TIP_SCHEDULED)
         self._chk_bug_report = QCheckBox()
         self._chk_bug_report.setToolTip(_TIP_BUG_REPORT)
+        self._chk_scripts = QCheckBox()
+        self._chk_scripts.setToolTip(_TIP_SCRIPTS)
         features_form.addRow(_LBL_LAMELLA_LIVE, self._chk_lamella_live)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
         features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
         features_form.addRow(_LBL_SCHEDULED, self._chk_scheduled_tasks)
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
+        features_form.addRow(_LBL_SCRIPTS, self._chk_scripts)
         self._stack.addWidget(features_page)
 
         # --- Experiment Defaults ---
@@ -199,6 +211,7 @@ class PreferencesDialog(QDialog):
         self._chk_sample_holder.setChecked(f.sample_holder_widget)
         self._chk_scheduled_tasks.setChecked(f.scheduled_tasks)
         self._chk_bug_report.setChecked(f.bug_report_enabled)
+        self._chk_scripts.setChecked(f.scripts_enabled)
 
         e = prefs.experiment
         self._dir_experiment.setText(e.default_experiment_directory)
@@ -233,6 +246,20 @@ class PreferencesDialog(QDialog):
             "running the fluorescence microscope while milling.",
         )
 
+    def _on_scripts_toggled(self, checked: bool):
+        """Same shape as the coincidence-milling warning: state the consequence once,
+        on the way in, and never on the way out."""
+        if not checked:
+            return
+        QMessageBox.warning(
+            self,
+            "User Scripts — No Safety Checks",
+            "A script you run from Tools > Scripts has the same access to the "
+            "microscope as the application itself, with none of its limits or "
+            "interlocks, and nothing validates what it does before it runs.\n\n"
+            "Scripts you did not write yourself should be read before they are run.",
+        )
+
     def get_preferences(self) -> UserPreferences:
         """Build a UserPreferences instance from current widget state."""
         from fibsem.config import (
@@ -255,6 +282,7 @@ class PreferencesDialog(QDialog):
                 sample_holder_widget=self._chk_sample_holder.isChecked(),
                 scheduled_tasks=self._chk_scheduled_tasks.isChecked(),
                 bug_report_enabled=self._chk_bug_report.isChecked(),
+                scripts_enabled=self._chk_scripts.isChecked(),
             ),
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -215,21 +215,23 @@ class ScriptManagerDialog(QDialog):
         header.setDefaultAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         header.setStretchLastSection(False)
         header.setSectionResizeMode(0, header.Stretch)
-        table.setColumnWidth(1, 210)
         table.setColumnWidth(2, 100)
         return table
 
     @staticmethod
-    def _chip(text: str, colour: str, dot: bool = True) -> QLabel:
+    def _chip(text: str, colour: str) -> QLabel:
         """A pill label: coloured dot + text, on a tint of the same colour."""
         rgb = QColor(colour)
         tint = f"rgba({rgb.red()}, {rgb.green()}, {rgb.blue()}, 0.15)"
-        marker = f'<span style="color:{colour};">&#9679;</span> ' if dot else ""
-        chip = QLabel(f"{marker}{text}")
+        chip = QLabel(f'<span style="color:{colour};">&#9679;</span> {text}')
         chip.setStyleSheet(
             f"background-color: {tint}; color: {colour};"
             f"padding: 2px 9px; border-radius: 10px; font-size: 11px;"
         )
+        # A rich-text QLabel under-reports sizeHint against the stylesheet padding,
+        # so the last character clips. Measure the visible text and pin the width.
+        metrics = QFontMetrics(chip.font())
+        chip.setMinimumWidth(metrics.horizontalAdvance(f"* {text}") + 26)
         return chip
 
     def _name_cell(self, script: DiscoveredScript) -> QWidget:
@@ -266,9 +268,9 @@ class ScriptManagerDialog(QDialog):
         label, colour = _script_type(script)
         layout.addWidget(self._chip(label, colour))
         if script.writes:
-            layout.addWidget(self._chip("writes", _WARN, dot=False))
+            layout.addWidget(self._chip("writes", _WARN))
         if script.on_workflow_completed:
-            layout.addWidget(self._chip("auto", _ACCENT, dot=False))
+            layout.addWidget(self._chip("auto", _ACCENT))
         layout.addStretch()
         notes = [f"Type: {label}"]
         if script.writes:
@@ -314,11 +316,28 @@ class ScriptManagerDialog(QDialog):
             for col in (0, 1):
                 self.table.setItem(row, col, QTableWidgetItem())
 
+        self._fit_type_column()
+
         if self.scripts:
             names = [s.name for s in self.scripts]
             row = names.index(previous) if previous in names else 0
             self.table.selectRow(row)
         self._on_selection_changed()
+
+    def _fit_type_column(self) -> None:
+        """Widen the type column to the widest row of chips.
+
+        ResizeToContents is no use here: it measures the item's size hint, and
+        these cells hold widgets over empty items. A row carries one type chip
+        plus a chip per flag, so any fixed width clips as soon as a script
+        declares more than one.
+        """
+        widths = [
+            self.table.cellWidget(row, 1).sizeHint().width()
+            for row in range(self.table.rowCount())
+            if self.table.cellWidget(row, 1) is not None
+        ]
+        self.table.setColumnWidth(1, max(widths, default=140) + 12)
 
     def _update_meta(self) -> None:
         """Counts plus the folder, elided to whatever width the dialog has.

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -34,8 +34,12 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from fibsem.scripting import DiscoveredScript
-from fibsem.ui.stylesheets import PRIMARY_BUTTON_STYLESHEET
+from fibsem.cancellation import OperationCancelledError
+from fibsem.scripting import DiscoveredScript, ScriptResult
+from fibsem.ui.stylesheets import (
+    PRIMARY_BUTTON_STYLESHEET,
+    STOP_WORKFLOW_BUTTON_STYLESHEET,
+)
 from fibsem.ui.utils import open_path_in_file_explorer
 from fibsem.ui.widgets.script_runner import ScriptRunner
 
@@ -450,8 +454,10 @@ class ScriptManagerDialog(QDialog):
             consequence, colour, explain = "● Cannot load", _ERROR, script.error
         elif script.uses_microscope:
             consequence, colour, explain = (
-                "● Needs the microscope", _WARN,
-                "Microscope scripts are not supported yet (FIB-340).",
+                "● Drives the microscope", _ERROR,
+                "This script controls the hardware directly. Nothing checks what it "
+                "does — no limits, no interlocks. It runs in the background, and Stop "
+                "only works if the script itself checks for it.",
             )
         elif script.writes:
             consequence, colour, explain = (
@@ -475,13 +481,9 @@ class ScriptManagerDialog(QDialog):
         consequence = f'<span style="color:{colour};">{consequence}</span>'
         self.consequence_label.setText(consequence)
 
-        # uses_microscope is disabled rather than offered-then-refused: the runner
-        # would reject it anyway (FIB-340), and a button that does nothing but
-        # complain is worse than one that is visibly unavailable.
-        self.run_button.setEnabled(
-            script.is_runnable and host_ready and not script.uses_microscope
-        )
+        self.run_button.setEnabled(script.is_runnable and host_ready)
         self.hint_label.setText(reason)
+        self._sync_run_button()
 
     def change_folder(self) -> None:
         """Point the dialog at a different folder for this session."""
@@ -519,14 +521,48 @@ class ScriptManagerDialog(QDialog):
         open_path_in_file_explorer(str(directory))
 
     def run_selected(self) -> None:
+        # while a script is running this button is Stop -- see _sync_run_button
+        if self.runner.is_running:
+            self.runner.stop()
+            return
+
         script = self.selected_script()
         if script is None or not script.is_runnable:
             return
-        # the runner owns the wait cursor -- it has to be set after its write
+
+        # the runner owns the wait cursor -- it has to be set after its
         # confirmation, not before
-        result = self.runner.run(script)
-        if result is not None:
-            outcome = "ok" if result.ok else "failed"
-            stamp = datetime.now().strftime(TIME_DISPLAY_AMPM_SHORT).lstrip('0').lower()
-            self.last_run[script.name] = f"{stamp} {outcome}"
+        self.runner.run(script, on_finished=lambda r, s=script: self._record_run(s, r))
+        # a microscope script is still running at this point -- the stamp and the
+        # refresh happen in _record_run, which the worker delivers on the GUI thread
+        self._sync_run_button()
+
+    def _record_run(self, script: DiscoveredScript, result: ScriptResult) -> None:
+        """Stamp the outcome once the script has actually finished."""
+        outcome = "cancelled" if isinstance(result.error, OperationCancelledError) else (
+            "ok" if result.ok else "failed"
+        )
+        stamp = datetime.now().strftime(TIME_DISPLAY_AMPM_SHORT).lstrip('0').lower()
+        self.last_run[script.name] = f"{stamp} {outcome}"
+        self._sync_run_button()
         self.refresh()
+
+    def _sync_run_button(self) -> None:
+        """Run, or Stop while a script is running.
+
+        One button rather than two: a Stop that is greyed out almost always is
+        noise, and the state it reports is the same state Run is reporting.
+        """
+        running = self.runner.is_running
+        self.run_button.setText("Stop script" if running else "Run script")
+        self.run_button.setStyleSheet(
+            STOP_WORKFLOW_BUTTON_STYLESHEET if running else PRIMARY_BUTTON_STYLESHEET
+        )
+        if running:
+            self.run_button.setEnabled(True)  # Stop must never be the disabled one
+        # everything that would start a second run, or move the ground under the
+        # one already going
+        for button in (self.new_script_button, self.change_folder_button,
+                       self.rescan_button):
+            button.setEnabled(not running)
+        self.table.setEnabled(not running)

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -83,6 +83,16 @@ _COLUMNS = ["Script", "Type", "Last run"]
 # who declared the flag still has somewhere to find out it is inert.
 AUTO_NOT_CONNECTED = "auto: declared, but scripts do not run automatically yet"
 
+# Shown in the empty state. Three worked examples exist, one per tier, but they live
+# in the repository rather than the wheel -- so someone who pip-installed has no
+# local copy and no way to know they exist.
+EXAMPLES_PATH = "examples/scripts/"
+EXAMPLES_HINT = (
+    f"Three worked examples — read-only, writes, and microscope — are in "
+    f"<span style='font-family: Menlo, monospace;'>{EXAMPLES_PATH}</span> "
+    f"in the fibsem-os repository. Copy one here to try it."
+)
+
 _TEMPLATE = '''"""Describe what this script does — this line becomes its tooltip."""
 
 # writes = True   # uncomment if the script changes state that should be saved
@@ -307,8 +317,20 @@ class ScriptManagerDialog(QDialog):
         hint.setStyleSheet(
             f"border: none; font-size: {_FS_BODY}px; color: {_TEXT_MUTED};"
         )
+        # Says "repository" on purpose: examples/ is not shipped in the wheel, so a
+        # pip-installed user will not find it on disk and would otherwise be told
+        # only to write one from scratch. FIB-341 owns seeding them properly.
+        examples = QLabel(EXAMPLES_HINT)
+        examples.setTextFormat(Qt.RichText)
+        examples.setAlignment(Qt.AlignCenter)
+        examples.setWordWrap(True)
+        examples.setStyleSheet(
+            f"border: none; font-size: {_FS_BODY}px; color: {_TEXT_MUTED};"
+        )
         layout.addWidget(headline)
         layout.addWidget(hint)
+        layout.addSpacing(4)
+        layout.addWidget(examples)
         return panel
 
     def _build_table(self) -> QTableWidget:

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -21,7 +21,6 @@ from PyQt5.QtGui import QFontMetrics
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import (
     QAbstractItemView,
-    QApplication,
     QDialog,
     QFileDialog,
     QInputDialog,
@@ -53,6 +52,12 @@ _WARN = "#e0a030"
 _ERROR = "#d04040"
 
 _COLUMNS = ["Script", "Type", "Last run"]
+
+# on_workflow_completed is parsed and shown, but nothing fires it: the workflow
+# hook runs on a worker thread, and these scripts touch evented experiment state
+# that must only be mutated from the GUI thread. Said plainly rather than left
+# implied -- an author who declared the flag has no other way to find out.
+AUTO_NOT_CONNECTED = "auto: declared, but scripts do not run automatically yet"
 
 _TEMPLATE = '''"""Describe what this script does — this line becomes its tooltip."""
 
@@ -98,6 +103,33 @@ QPushButton {{
 QPushButton:hover {{ background-color: {_ROW_ALT}; }}
 QPushButton:disabled {{ color: {_TEXT_MUTED}; }}
 """
+
+
+class _ElidedLabel(QLabel):
+    """A QLabel that elides rather than clipping mid-glyph.
+
+    The Script column stretches, so the width is not known when the row is built
+    and any one-off elide would be wrong at the next size. Re-eliding on resize
+    tracks it. The size policy is Ignored so the full text cannot drive the
+    column wider, which would defeat the point.
+    """
+
+    def __init__(self, text: str, parent: Optional[QWidget] = None) -> None:
+        super().__init__(text, parent)
+        self._full_text = text
+        self.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
+
+    def paintEvent(self, event) -> None:  # noqa: N802 - Qt naming
+        # At paint time the width is always the real one. Doing this on resize
+        # instead misses a label that is laid out at its final size and never
+        # resized, which then clips. Re-eliding from _full_text rather than from
+        # the displayed text keeps it stable: setText schedules one more paint,
+        # the second computes the same string, and it settles.
+        metrics = QFontMetrics(self.font())
+        elided = metrics.elidedText(self._full_text, Qt.ElideRight, self.width())
+        if elided != self.text():
+            self.setText(elided)  # QLabel draws it, so the stylesheet colour survives
+        super().paintEvent(event)
 
 
 def _script_type(script: DiscoveredScript) -> "tuple[str, str]":
@@ -257,19 +289,21 @@ class ScriptManagerDialog(QDialog):
         layout.setContentsMargins(12, 8, 10, 8)
         layout.setSpacing(2)
 
-        name = QLabel(script.name)
+        summary = script.description if script.is_runnable else script.error
+        name = _ElidedLabel(script.name)
         name.setStyleSheet(
             f"font-family: Menlo, monospace; font-size: 13px; background: transparent;"
             f"color: {_TEXT_STRONG if script.is_runnable else _TEXT_MUTED};"
         )
-        detail = QLabel(script.description if script.is_runnable else script.error)
+        detail = _ElidedLabel(summary)
         detail.setStyleSheet(
             f"font-size: 12px; background: transparent;"
             f"color: {_TEXT if script.is_runnable else _ERROR};"
         )
         layout.addWidget(name)
         layout.addWidget(detail)
-        widget.setToolTip(f"{script.path}\n{script.content_hash}")
+        # the summary is elided in the row, so the tooltip has to carry it in full
+        widget.setToolTip(f"{summary}\n\n{script.path}\n{script.content_hash}")
         return widget
 
     def _type_cell(self, script: DiscoveredScript) -> QWidget:
@@ -285,13 +319,15 @@ class ScriptManagerDialog(QDialog):
         if script.writes:
             layout.addWidget(self._chip("writes", _WARN))
         if script.on_workflow_completed:
-            layout.addWidget(self._chip("auto", _ACCENT))
+            # muted, and labelled off: the flag is recognised but nothing fires it
+            # yet, and a live-looking chip would promise a run that never happens
+            layout.addWidget(self._chip("auto (off)", _TEXT_MUTED))
         layout.addStretch()
         notes = [f"Type: {label}"]
         if script.writes:
             notes.append("writes: saves the experiment when finished")
         if script.on_workflow_completed:
-            notes.append("auto: also runs when a workflow finishes")
+            notes.append(AUTO_NOT_CONNECTED)
         widget.setToolTip("\n".join(notes))
         return widget
 
@@ -427,9 +463,9 @@ class ScriptManagerDialog(QDialog):
                 "● Read-only", _TEXT_MUTED, "This script does not change anything.",
             )
         if script.on_workflow_completed:
-            # already an "auto" chip on the row -- repeating it here is what
-            # pushed this line past the panel edge on a narrow dialog
-            explain += " It also runs automatically when a workflow finishes."
+            # already a chip on the row -- repeating it on screen is what pushed
+            # this line past the panel edge on a narrow dialog, so tooltip only
+            explain += f" {AUTO_NOT_CONNECTED}."
         self.consequence_label.setToolTip(explain)
         # Same trap as the chips: a rich-text QLabel under-reports sizeHint
         # against its rendered width, so the tail clips. Pin it from the metrics
@@ -486,11 +522,9 @@ class ScriptManagerDialog(QDialog):
         script = self.selected_script()
         if script is None or not script.is_runnable:
             return
-        QApplication.setOverrideCursor(Qt.WaitCursor)
-        try:
-            result = self.runner.run(script)
-        finally:
-            QApplication.restoreOverrideCursor()
+        # the runner owns the wait cursor -- it has to be set after its write
+        # confirmation, not before
+        result = self.runner.run(script)
         if result is not None:
             outcome = "ok" if result.ok else "failed"
             stamp = datetime.now().strftime(TIME_DISPLAY_AMPM_SHORT).lstrip('0').lower()

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -28,6 +28,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QPushButton,
     QSizePolicy,
+    QStackedWidget,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
@@ -160,8 +161,8 @@ def _script_type(script: DiscoveredScript) -> "tuple[str, Optional[str]]":
 
     A ``None`` colour means the type earns no chip. Only Data does: it is the
     default, so it appeared on nearly every row and distinguished nothing, while
-    costing width in a column that has to fit three chips. The label is still
-    returned, because the tooltip can say "Type: Data" for free.
+    costing width in a column that also has to fit the Writes chip. The label is
+    still returned, because the tooltip can say "Type: Data" for free.
     """
     if not script.is_runnable:
         return "Error", _ERROR
@@ -232,10 +233,17 @@ class ScriptManagerDialog(QDialog):
         header.addWidget(self.rescan_button)
         layout.addLayout(header)
 
+        # The table and its empty state swap places rather than the table sitting
+        # there empty: a headed grid with nothing under it is ~450px of void, and
+        # the one sentence that helps was stranded in the detail panel at the very
+        # bottom. An empty folder is the *first* thing a new user sees here.
         self.table = self._build_table()
-        layout.addWidget(self.table)
+        self.stack = QStackedWidget()
+        self.stack.addWidget(self.table)
+        self.stack.addWidget(self._build_empty_state())
+        layout.addWidget(self.stack)
 
-        detail_panel = QWidget()
+        self.detail_panel = detail_panel = QWidget()
         detail_panel.setStyleSheet(
             f"background-color: {_PANEL}; border: 1px solid {_BORDER}; border-radius: 6px;"
         )
@@ -270,6 +278,38 @@ class ScriptManagerDialog(QDialog):
         footer.addWidget(close_button)
         footer.addWidget(self.run_button)
         layout.addLayout(footer)
+
+    def _build_empty_state(self) -> QWidget:
+        """Shown instead of the table when the folder holds no scripts.
+
+        Same border and radius as the table so swapping between them does not move
+        anything else in the dialog.
+        """
+        panel = QWidget()
+        panel.setStyleSheet(
+            f"background-color: {_PANEL}; border: 1px solid {_BORDER};"
+            f"border-radius: 6px;"
+        )
+        layout = QVBoxLayout(panel)
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setSpacing(6)
+
+        headline = QLabel("No scripts in this folder")
+        headline.setAlignment(Qt.AlignCenter)
+        headline.setStyleSheet(
+            f"border: none; font-size: {_FS_NAME}px; color: {_TEXT};"
+        )
+        hint = QLabel(
+            "Use New script… to start one from a template, "
+            "or Change folder… to look somewhere else."
+        )
+        hint.setAlignment(Qt.AlignCenter)
+        hint.setStyleSheet(
+            f"border: none; font-size: {_FS_BODY}px; color: {_TEXT_MUTED};"
+        )
+        layout.addWidget(headline)
+        layout.addWidget(hint)
+        return panel
 
     def _build_table(self) -> QTableWidget:
         table = QTableWidget()
@@ -407,6 +447,7 @@ class ScriptManagerDialog(QDialog):
                 self.table.setItem(row, col, QTableWidgetItem())
 
         self._fit_type_column()
+        self.stack.setCurrentIndex(0 if self.scripts else 1)
 
         if self.scripts:
             names = [s.name for s in self.scripts]
@@ -418,9 +459,8 @@ class ScriptManagerDialog(QDialog):
         """Widen the type column to the widest row of chips.
 
         ResizeToContents is no use here: it measures the item's size hint, and
-        these cells hold widgets over empty items. A row carries at most one type
-        chip plus a chip per flag, so any fixed width clips as soon as a script
-        declares more than one.
+        these cells hold widgets over empty items. A row can carry a type chip and
+        a Writes chip, so any fixed width clips on a script that declares both.
 
         Floored at the header's own width: a folder of plain data scripts now has
         no chips at all, which collapsed this to 28px and clipped the word "Type".
@@ -471,11 +511,12 @@ class ScriptManagerDialog(QDialog):
         script = self.selected_script()
         host_ready, reason = self.runner.availability()
 
+        # nothing selected and nothing to select: the empty state above already says
+        # so, and an empty bordered strip down here just looks like a rendering fault
+        self.detail_panel.setVisible(bool(self.scripts))
+
         if script is None:
-            empty = (
-                "No scripts in this folder yet — use New script… to create one."
-                if not self.scripts else "No script selected."
-            )
+            empty = "" if not self.scripts else "No script selected."
             self.detail_label.setText(f'<span style="color:{_TEXT_MUTED};">{empty}</span>')
             self.consequence_label.setText("")
             self.run_button.setEnabled(False)
@@ -495,12 +536,19 @@ class ScriptManagerDialog(QDialog):
         elif script.uses_microscope:
             # matches the Microscope chip: the words carry the weight here, and the
             # confirmation dialog is what actually stops you
-            consequence, colour, explain = (
-                "● Controls the microscope", _MICROSCOPE,
+            consequence, colour = "● Controls the microscope", _MICROSCOPE
+            explain = (
                 "This script controls the hardware directly. Nothing checks what it "
                 "does — no limits, no interlocks. It runs in the background, and Stop "
-                "only works if the script itself checks for it.",
+                "only works if the script itself checks for it."
             )
+            if script.writes:
+                # Only the worse of the two fits on screen, so this is the only place
+                # a microscope script that *also* writes admits to the second half.
+                # The row still shows both chips.
+                explain += (
+                    " It also modifies the experiment and saves it when it finishes."
+                )
         elif script.writes:
             consequence, colour, explain = (
                 "● Modifies and saves the experiment", _WRITES,
@@ -511,13 +559,14 @@ class ScriptManagerDialog(QDialog):
                 "● Read-only", _TEXT_MUTED, "This script does not change anything.",
             )
         if script.on_workflow_completed:
-            # already a chip on the row -- repeating it on screen is what pushed
-            # this line past the panel edge on a narrow dialog, so tooltip only
+            # no chip for this any more, and the screen line has no room for it, so
+            # the tooltip is the only place the flag is acknowledged at all
             explain += f" {AUTO_NOT_CONNECTED}."
         self.consequence_label.setToolTip(explain)
-        # Same trap as the chips: a rich-text QLabel under-reports sizeHint
-        # against its rendered width, so the tail clips. Pin it from the metrics
-        # of the plain text before wrapping it in the colour span.
+        # sizeHint does not cover the stylesheet's own font-size, so the tail clips.
+        # Pin from the plain text before it is wrapped in the colour span. Unlike
+        # _chip, this label was styled back in _build(), so by now font() has the
+        # stylesheet size and needs no explicit setPixelSize.
         metrics = QFontMetrics(self.consequence_label.font())
         self.consequence_label.setMinimumWidth(metrics.horizontalAdvance(consequence) + 10)
         consequence = f'<span style="color:{colour};">{consequence}</span>'

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -11,6 +11,8 @@ See FIB-338.
 """
 
 from datetime import datetime
+
+from fibsem.constants import TIME_DISPLAY_AMPM_SHORT
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -19,6 +21,7 @@ from PyQt5.QtGui import QFontMetrics
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import (
     QAbstractItemView,
+    QApplication,
     QDialog,
     QFileDialog,
     QInputDialog,
@@ -119,7 +122,8 @@ class ScriptManagerDialog(QDialog):
 
         self.setWindowTitle("Scripts")
         self.setStyleSheet(f"QDialog {{ background-color: {_BG}; }}")
-        self.resize(780, 620)
+        self.resize(820, 640)
+        self.setMinimumWidth(720)
         self._build()
         self.refresh()
 
@@ -145,8 +149,7 @@ class ScriptManagerDialog(QDialog):
         self.meta_label.setMinimumWidth(160)
         titles.addWidget(self.title_label)
         titles.addWidget(self.meta_label)
-        header.addLayout(titles)
-        header.addStretch()
+        header.addLayout(titles, 1)  # take the free width so the path can elide into it
 
         self.open_folder_button = QPushButton("Open folder")
         self.open_folder_button.setStyleSheet(_SECONDARY_BUTTON_STYLE)
@@ -171,14 +174,26 @@ class ScriptManagerDialog(QDialog):
         self.table = self._build_table()
         layout.addWidget(self.table)
 
+        detail_panel = QWidget()
+        detail_panel.setStyleSheet(
+            f"background-color: {_PANEL}; border: 1px solid {_BORDER}; border-radius: 6px;"
+        )
+        detail_layout = QHBoxLayout(detail_panel)
+        detail_layout.setContentsMargins(11, 9, 11, 9)
         self.detail_label = QLabel()
         self.detail_label.setTextFormat(Qt.RichText)
-        self.detail_label.setWordWrap(True)
         self.detail_label.setStyleSheet(
-            f"background-color: {_PANEL}; border: 1px solid {_BORDER};"
-            f"border-radius: 6px; padding: 9px 11px; font-size: 12px; color: {_TEXT};"
+            f"border: none; font-size: 12px; color: {_TEXT};"
         )
-        layout.addWidget(self.detail_label)
+        # the consequence of running this sits opposite the facts about it, so it
+        # reads as a warning rather than another line of metadata
+        self.consequence_label = QLabel()
+        self.consequence_label.setTextFormat(Qt.RichText)
+        self.consequence_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self.consequence_label.setStyleSheet("border: none; font-size: 12px;")
+        detail_layout.addWidget(self.detail_label, 1)
+        detail_layout.addWidget(self.consequence_label, 0)
+        layout.addWidget(detail_panel)
 
         footer = QHBoxLayout()
         self.hint_label = QLabel()
@@ -202,7 +217,7 @@ class ScriptManagerDialog(QDialog):
         table.setHorizontalHeaderLabels(_COLUMNS)
         table.verticalHeader().setVisible(False)
         # rows carry a stacked name + description, so they need room to breathe
-        table.verticalHeader().setDefaultSectionSize(62)
+        table.verticalHeader().setDefaultSectionSize(56)
         table.setShowGrid(False)
         table.setAlternatingRowColors(True)
         table.setSelectionBehavior(QAbstractItemView.SelectRows)
@@ -215,7 +230,7 @@ class ScriptManagerDialog(QDialog):
         header.setDefaultAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         header.setStretchLastSection(False)
         header.setSectionResizeMode(0, header.Stretch)
-        table.setColumnWidth(2, 100)
+        table.setColumnWidth(2, 130)
         return table
 
     @staticmethod
@@ -239,8 +254,8 @@ class ScriptManagerDialog(QDialog):
         widget = QWidget()
         widget.setStyleSheet("background: transparent;")
         layout = QVBoxLayout(widget)
-        layout.setContentsMargins(12, 10, 10, 10)
-        layout.setSpacing(3)
+        layout.setContentsMargins(12, 8, 10, 8)
+        layout.setSpacing(2)
 
         name = QLabel(script.name)
         name.setStyleSheet(
@@ -377,38 +392,53 @@ class ScriptManagerDialog(QDialog):
         host_ready, reason = self.runner.availability()
 
         if script is None:
-            self.detail_label.setText(
-                f'<span style="color:{_TEXT_MUTED};">No script selected.</span>'
+            empty = (
+                "No scripts in this folder yet — use New script… to create one."
+                if not self.scripts else "No script selected."
             )
+            self.detail_label.setText(f'<span style="color:{_TEXT_MUTED};">{empty}</span>')
+            self.consequence_label.setText("")
             self.run_button.setEnabled(False)
             self.hint_label.setText(reason)
             return
 
-        parts = [
-            f'<span style="color:{_TEXT_MUTED};">Source</span>&nbsp; {script.path.name}',
-            f'<span style="color:{_TEXT_MUTED};">Hash</span>&nbsp; {script.content_hash}',
-        ]
-        detail = "<br>".join(parts)
+        self.detail_label.setText(
+            f'<span style="color:{_TEXT_MUTED};">Source</span>&nbsp; {script.path.name}'
+            f'<br><span style="color:{_TEXT_MUTED};">Hash</span>&nbsp; {script.content_hash}'
+        )
 
+        # short phrases, not sentences: this sits opposite the Source/Hash block and
+        # a full sentence clips against it once the dialog narrows. The tooltip
+        # carries the longer wording.
         if not script.is_runnable:
-            detail += f'<br><span style="color:{_ERROR};">● {script.error}</span>'
+            consequence, colour, explain = "● Cannot load", _ERROR, script.error
         elif script.uses_microscope:
-            detail += (
-                f'<br><span style="color:{_WARN};">● Needs the microscope — '
-                f"not supported yet.</span>"
+            consequence, colour, explain = (
+                "● Needs the microscope", _WARN,
+                "Microscope scripts are not supported yet (FIB-340).",
             )
         elif script.writes:
-            detail += (
-                f'<br><span style="color:{_WARN};">● Modifies the experiment and '
-                f"saves it when finished.</span>"
+            consequence, colour, explain = (
+                "● Modifies and saves the experiment", _WARN,
+                "This script changes the experiment and saves it when it finishes.",
+            )
+        else:
+            consequence, colour, explain = (
+                "● Read-only", _TEXT_MUTED, "This script does not change anything.",
             )
         if script.on_workflow_completed:
-            detail += (
-                f'<br><span style="color:{_ACCENT};">● Also runs automatically when '
-                f"a workflow finishes.</span>"
-            )
+            # already an "auto" chip on the row -- repeating it here is what
+            # pushed this line past the panel edge on a narrow dialog
+            explain += " It also runs automatically when a workflow finishes."
+        self.consequence_label.setToolTip(explain)
+        # Same trap as the chips: a rich-text QLabel under-reports sizeHint
+        # against its rendered width, so the tail clips. Pin it from the metrics
+        # of the plain text before wrapping it in the colour span.
+        metrics = QFontMetrics(self.consequence_label.font())
+        self.consequence_label.setMinimumWidth(metrics.horizontalAdvance(consequence) + 10)
+        consequence = f'<span style="color:{colour};">{consequence}</span>'
+        self.consequence_label.setText(consequence)
 
-        self.detail_label.setText(detail)
         # uses_microscope is disabled rather than offered-then-refused: the runner
         # would reject it anyway (FIB-340), and a button that does nothing but
         # complain is worse than one that is visibly unavailable.
@@ -456,8 +486,13 @@ class ScriptManagerDialog(QDialog):
         script = self.selected_script()
         if script is None or not script.is_runnable:
             return
-        result = self.runner.run(script)
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            result = self.runner.run(script)
+        finally:
+            QApplication.restoreOverrideCursor()
         if result is not None:
             outcome = "ok" if result.ok else "failed"
-            self.last_run[script.name] = f"{datetime.now().strftime('%H:%M')} {outcome}"
+            stamp = datetime.now().strftime(TIME_DISPLAY_AMPM_SHORT).lstrip('0').lower()
+            self.last_run[script.name] = f"{stamp} {outcome}"
         self.refresh()

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -52,15 +52,34 @@ _TEXT = "#d6d6d6"
 _TEXT_STRONG = "#f0f1f2"
 _TEXT_MUTED = "#868e93"
 _ACCENT = "#50a6ff"
-_WARN = "#e0a030"
 _ERROR = "#d04040"
+
+# Colour here says *what a script is*, not how frightened to be. Amber for
+# Microscope and Writes meant the two most common rows were permanently lit as
+# warnings, which is alarm fatigue in a list you browse rather than act on -- and
+# it left red meaning two different things. The real gate is the confirmation
+# dialog: modal, worded, defaulting to Cancel, and shown at the moment of action.
+# So these are categorical, and _ERROR now means exactly one thing in this
+# dialog: the file is broken.
+_MICROSCOPE = "#4caf72"
+_WRITES = "#4d9de0"
+
+# One type scale for the whole dialog, in px to match the rest of the app's
+# stylesheets. Ten literals were scattered across the file, so "make it smaller"
+# meant finding all of them and keeping the steps between them consistent by hand.
+_FS_TITLE = 14
+_FS_NAME = 12
+_FS_BODY = 11
+_FS_SMALL = 10
 
 _COLUMNS = ["Script", "Type", "Last run"]
 
-# on_workflow_completed is parsed and shown, but nothing fires it: the workflow
-# hook runs on a worker thread, and these scripts touch evented experiment state
-# that must only be mutated from the GUI thread. Said plainly rather than left
-# implied -- an author who declared the flag has no other way to find out.
+# on_workflow_completed is parsed, but nothing fires it: the workflow hook runs on
+# a worker thread, and these scripts touch evented experiment state that must only
+# be mutated from the GUI thread. It gets no chip -- a row badge for a feature that
+# does nothing is a distraction on every row that declares it, and it read as a
+# promise besides. Kept in the tooltips, which is where it costs nothing: an author
+# who declared the flag still has somewhere to find out it is inert.
 AUTO_NOT_CONNECTED = "auto: declared, but scripts do not run automatically yet"
 
 _TEMPLATE = '''"""Describe what this script does — this line becomes its tooltip."""
@@ -89,7 +108,7 @@ QHeaderView::section {{
     color: {_TEXT_MUTED};
     border: none;
     padding: 6px 8px;
-    font-size: 11px;
+    font-size: {_FS_SMALL}px;
 }}
 QTableWidget::item {{ padding: 6px 8px; border-bottom: 1px solid #31353f; }}
 QTableWidget::item:selected {{ background-color: #2d3947; color: {_TEXT_STRONG}; }}
@@ -102,7 +121,7 @@ QPushButton {{
     color: {_TEXT};
     border-radius: 6px;
     padding: 5px 12px;
-    font-size: 12px;
+    font-size: {_FS_BODY}px;
 }}
 QPushButton:hover {{ background-color: {_ROW_ALT}; }}
 QPushButton:disabled {{ color: {_TEXT_MUTED}; }}
@@ -136,13 +155,19 @@ class _ElidedLabel(QLabel):
         super().paintEvent(event)
 
 
-def _script_type(script: DiscoveredScript) -> "tuple[str, str]":
-    """(label, colour) describing what a script is allowed to touch."""
+def _script_type(script: DiscoveredScript) -> "tuple[str, Optional[str]]":
+    """(label, chip colour) describing what a script is allowed to touch.
+
+    A ``None`` colour means the type earns no chip. Only Data does: it is the
+    default, so it appeared on nearly every row and distinguished nothing, while
+    costing width in a column that has to fit three chips. The label is still
+    returned, because the tooltip can say "Type: Data" for free.
+    """
     if not script.is_runnable:
         return "Error", _ERROR
     if script.uses_microscope:
-        return "Microscope", _WARN
-    return "Data", _TEXT_MUTED
+        return "Microscope", _MICROSCOPE
+    return "Data", None
 
 
 class ScriptManagerDialog(QDialog):
@@ -175,12 +200,12 @@ class ScriptManagerDialog(QDialog):
         titles.setSpacing(2)
         self.title_label = QLabel("User scripts")
         self.title_label.setStyleSheet(
-            f"font-size: 15px; font-weight: 500; color: {_TEXT_STRONG};"
+            f"font-size: {_FS_TITLE}px; font-weight: 500; color: {_TEXT_STRONG};"
         )
         # counts and location are meta, not the heading -- the heading says what
         # this dialog is, the line under it says what is currently in it.
         self.meta_label = QLabel()
-        self.meta_label.setStyleSheet(f"font-size: 12px; color: {_TEXT_MUTED};")
+        self.meta_label.setStyleSheet(f"font-size: {_FS_BODY}px; color: {_TEXT_MUTED};")
         self.meta_label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
         self.meta_label.setMinimumWidth(160)
         titles.addWidget(self.title_label)
@@ -219,21 +244,21 @@ class ScriptManagerDialog(QDialog):
         self.detail_label = QLabel()
         self.detail_label.setTextFormat(Qt.RichText)
         self.detail_label.setStyleSheet(
-            f"border: none; font-size: 12px; color: {_TEXT};"
+            f"border: none; font-size: {_FS_BODY}px; color: {_TEXT};"
         )
         # the consequence of running this sits opposite the facts about it, so it
         # reads as a warning rather than another line of metadata
         self.consequence_label = QLabel()
         self.consequence_label.setTextFormat(Qt.RichText)
         self.consequence_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
-        self.consequence_label.setStyleSheet("border: none; font-size: 12px;")
+        self.consequence_label.setStyleSheet(f"border: none; font-size: {_FS_BODY}px;")
         detail_layout.addWidget(self.detail_label, 1)
         detail_layout.addWidget(self.consequence_label, 0)
         layout.addWidget(detail_panel)
 
         footer = QHBoxLayout()
         self.hint_label = QLabel()
-        self.hint_label.setStyleSheet(f"font-size: 12px; color: {_TEXT_MUTED};")
+        self.hint_label.setStyleSheet(f"font-size: {_FS_BODY}px; color: {_TEXT_MUTED};")
         footer.addWidget(self.hint_label)
         footer.addStretch()
         close_button = QPushButton("Close")
@@ -271,18 +296,25 @@ class ScriptManagerDialog(QDialog):
 
     @staticmethod
     def _chip(text: str, colour: str) -> QLabel:
-        """A pill label: coloured dot + text, on a tint of the same colour."""
+        """A pill label: text on a tint of its own colour.
+
+        No dot. Once every chip had one it separated nothing, and it cost real
+        width in a 130px column that has to fit three chips on one row.
+        """
         rgb = QColor(colour)
         tint = f"rgba({rgb.red()}, {rgb.green()}, {rgb.blue()}, 0.15)"
-        chip = QLabel(f'<span style="color:{colour};">&#9679;</span> {text}')
+        chip = QLabel(text)
         chip.setStyleSheet(
             f"background-color: {tint}; color: {colour};"
-            f"padding: 2px 9px; border-radius: 10px; font-size: 11px;"
+            f"padding: 2px 9px; border-radius: 10px; font-size: {_FS_SMALL}px;"
         )
-        # A rich-text QLabel under-reports sizeHint against the stylesheet padding,
-        # so the last character clips. Measure the visible text and pin the width.
-        metrics = QFontMetrics(chip.font())
-        chip.setMinimumWidth(metrics.horizontalAdvance(f"* {text}") + 26)
+        # sizeHint does not account for the stylesheet padding, so the last character
+        # clips. Measure the text and pin the width -- at the size it actually
+        # renders at, or the default font's metrics pad every chip by the difference.
+        font = chip.font()
+        font.setPixelSize(_FS_SMALL)
+        metrics = QFontMetrics(font)
+        chip.setMinimumWidth(metrics.horizontalAdvance(text) + 26)
         return chip
 
     def _name_cell(self, script: DiscoveredScript) -> QWidget:
@@ -296,12 +328,13 @@ class ScriptManagerDialog(QDialog):
         summary = script.description if script.is_runnable else script.error
         name = _ElidedLabel(script.name)
         name.setStyleSheet(
-            f"font-family: Menlo, monospace; font-size: 13px; background: transparent;"
+            f"font-family: Menlo, monospace; font-size: {_FS_NAME}px;"
+            f"background: transparent;"
             f"color: {_TEXT_STRONG if script.is_runnable else _TEXT_MUTED};"
         )
         detail = _ElidedLabel(summary)
         detail.setStyleSheet(
-            f"font-size: 12px; background: transparent;"
+            f"font-size: {_FS_BODY}px; background: transparent;"
             f"color: {_TEXT if script.is_runnable else _ERROR};"
         )
         layout.addWidget(name)
@@ -311,7 +344,12 @@ class ScriptManagerDialog(QDialog):
         return widget
 
     def _type_cell(self, script: DiscoveredScript) -> QWidget:
-        """The type chip, plus a chip per declared flag."""
+        """Chips for anything out of the ordinary; the tooltip carries the rest.
+
+        Only Microscope, Error and Writes get a chip. Data is the default and
+        on_workflow_completed does nothing yet, so both would be badges that appear
+        constantly and tell you no more than their absence would.
+        """
         widget = QWidget()
         widget.setStyleSheet("background: transparent;")
         layout = QHBoxLayout(widget)
@@ -319,13 +357,10 @@ class ScriptManagerDialog(QDialog):
         layout.setSpacing(4)
 
         label, colour = _script_type(script)
-        layout.addWidget(self._chip(label, colour))
+        if colour is not None:
+            layout.addWidget(self._chip(label, colour))
         if script.writes:
-            layout.addWidget(self._chip("writes", _WARN))
-        if script.on_workflow_completed:
-            # muted, and labelled off: the flag is recognised but nothing fires it
-            # yet, and a live-looking chip would promise a run that never happens
-            layout.addWidget(self._chip("auto (off)", _TEXT_MUTED))
+            layout.addWidget(self._chip("Writes", _WRITES))
         layout.addStretch()
         notes = [f"Type: {label}"]
         if script.writes:
@@ -383,16 +418,21 @@ class ScriptManagerDialog(QDialog):
         """Widen the type column to the widest row of chips.
 
         ResizeToContents is no use here: it measures the item's size hint, and
-        these cells hold widgets over empty items. A row carries one type chip
-        plus a chip per flag, so any fixed width clips as soon as a script
+        these cells hold widgets over empty items. A row carries at most one type
+        chip plus a chip per flag, so any fixed width clips as soon as a script
         declares more than one.
+
+        Floored at the header's own width: a folder of plain data scripts now has
+        no chips at all, which collapsed this to 28px and clipped the word "Type".
         """
         widths = [
             self.table.cellWidget(row, 1).sizeHint().width()
             for row in range(self.table.rowCount())
             if self.table.cellWidget(row, 1) is not None
         ]
-        self.table.setColumnWidth(1, max(widths, default=140) + 12)
+        header = self.table.horizontalHeader()
+        floor = header.fontMetrics().horizontalAdvance(_COLUMNS[1]) + 24
+        self.table.setColumnWidth(1, max(max(widths, default=0) + 12, floor))
 
     def _update_meta(self) -> None:
         """Counts plus the folder, elided to whatever width the dialog has.
@@ -453,15 +493,17 @@ class ScriptManagerDialog(QDialog):
         if not script.is_runnable:
             consequence, colour, explain = "● Cannot load", _ERROR, script.error
         elif script.uses_microscope:
+            # matches the Microscope chip: the words carry the weight here, and the
+            # confirmation dialog is what actually stops you
             consequence, colour, explain = (
-                "● Drives the microscope", _ERROR,
+                "● Controls the microscope", _MICROSCOPE,
                 "This script controls the hardware directly. Nothing checks what it "
                 "does — no limits, no interlocks. It runs in the background, and Stop "
                 "only works if the script itself checks for it.",
             )
         elif script.writes:
             consequence, colour, explain = (
-                "● Modifies and saves the experiment", _WARN,
+                "● Modifies and saves the experiment", _WRITES,
                 "This script changes the experiment and saves it when it finishes.",
             )
         else:

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -11,16 +11,21 @@ See FIB-338.
 """
 
 from datetime import datetime
+from pathlib import Path
 from typing import Dict, List, Optional
 
 from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QFontMetrics
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import (
     QAbstractItemView,
     QDialog,
+    QFileDialog,
+    QInputDialog,
     QHBoxLayout,
     QLabel,
     QPushButton,
+    QSizePolicy,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
@@ -29,6 +34,7 @@ from PyQt5.QtWidgets import (
 
 from fibsem.scripting import DiscoveredScript
 from fibsem.ui.stylesheets import PRIMARY_BUTTON_STYLESHEET
+from fibsem.ui.utils import open_path_in_file_explorer
 from fibsem.ui.widgets.script_runner import ScriptRunner
 
 # Palette (matching fibsem.ui.stylesheets napari theme)
@@ -44,6 +50,17 @@ _WARN = "#e0a030"
 _ERROR = "#d04040"
 
 _COLUMNS = ["Script", "Type", "Last run"]
+
+_TEMPLATE = '''"""Describe what this script does — this line becomes its tooltip."""
+
+# writes = True   # uncomment if the script changes state that should be saved
+
+
+def run(ctx):
+    # ctx carries whatever the application provides.
+    # Return a string, a Path or a DataFrame to show the result.
+    return "done"
+'''
 
 _TABLE_STYLE = f"""
 QTableWidget {{
@@ -102,7 +119,7 @@ class ScriptManagerDialog(QDialog):
 
         self.setWindowTitle("Scripts")
         self.setStyleSheet(f"QDialog {{ background-color: {_BG}; }}")
-        self.resize(760, 580)
+        self.resize(780, 620)
         self._build()
         self.refresh()
 
@@ -116,14 +133,18 @@ class ScriptManagerDialog(QDialog):
         header = QHBoxLayout()
         titles = QVBoxLayout()
         titles.setSpacing(2)
-        self.title_label = QLabel()
+        self.title_label = QLabel("User scripts")
         self.title_label.setStyleSheet(
-            f"font-size: 14px; font-weight: 500; color: {_TEXT_STRONG};"
+            f"font-size: 15px; font-weight: 500; color: {_TEXT_STRONG};"
         )
-        self.path_label = QLabel()
-        self.path_label.setStyleSheet(f"font-size: 12px; color: {_TEXT_MUTED};")
+        # counts and location are meta, not the heading -- the heading says what
+        # this dialog is, the line under it says what is currently in it.
+        self.meta_label = QLabel()
+        self.meta_label.setStyleSheet(f"font-size: 12px; color: {_TEXT_MUTED};")
+        self.meta_label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
+        self.meta_label.setMinimumWidth(160)
         titles.addWidget(self.title_label)
-        titles.addWidget(self.path_label)
+        titles.addWidget(self.meta_label)
         header.addLayout(titles)
         header.addStretch()
 
@@ -135,6 +156,14 @@ class ScriptManagerDialog(QDialog):
         # "Rescan", not "Reload": scripts are loaded fresh on every run anyway, so
         # this only picks up files added or deleted since the dialog opened.
         self.rescan_button.clicked.connect(self.refresh)
+        self.new_script_button = QPushButton("New script…")
+        self.new_script_button.setStyleSheet(_SECONDARY_BUTTON_STYLE)
+        self.new_script_button.clicked.connect(self.new_script)
+        self.change_folder_button = QPushButton("Change folder…")
+        self.change_folder_button.setStyleSheet(_SECONDARY_BUTTON_STYLE)
+        self.change_folder_button.clicked.connect(self.change_folder)
+        header.addWidget(self.new_script_button)
+        header.addWidget(self.change_folder_button)
         header.addWidget(self.open_folder_button)
         header.addWidget(self.rescan_button)
         layout.addLayout(header)
@@ -251,8 +280,14 @@ class ScriptManagerDialog(QDialog):
 
     # --- data ---
 
-    def refresh(self) -> None:
-        """Re-read the folder and rebuild the table."""
+    def refresh(self, keep_selection: bool = True) -> None:
+        """Re-read the folder and rebuild the table.
+
+        The selected script is restored by name, so running one does not bounce
+        the selection back to the top of the list.
+        """
+        previous = self.selected_script().name if (keep_selection and self.selected_script()) else None
+
         self.scripts = self.runner.discover()
         failed = sum(1 for s in self.scripts if not s.is_runnable)
         runnable = len(self.scripts) - failed
@@ -260,9 +295,11 @@ class ScriptManagerDialog(QDialog):
         summary = f"{runnable} script{'s' if runnable != 1 else ''}"
         if failed:
             summary += f", {failed} failed to load"
-        self.title_label.setText(summary)
-        self.path_label.setText(str(self.runner.scripts_directory()))
+        self._summary = summary
+        self._update_meta()
 
+        self.table.clearContents()
+        self.table.setRowCount(0)  # destroys the previous rows' cell widgets
         self.table.setRowCount(len(self.scripts))
         for row, script in enumerate(self.scripts):
             # cell widgets, not items: a QTableWidgetItem cannot carry a pill
@@ -278,8 +315,35 @@ class ScriptManagerDialog(QDialog):
                 self.table.setItem(row, col, QTableWidgetItem())
 
         if self.scripts:
-            self.table.selectRow(0)
+            names = [s.name for s in self.scripts]
+            row = names.index(previous) if previous in names else 0
+            self.table.selectRow(row)
         self._on_selection_changed()
+
+    def _update_meta(self) -> None:
+        """Counts plus the folder, elided to whatever width the dialog has.
+
+        The path is often far longer than anything else in the dialog and would
+        otherwise dictate its width. The full value stays in the tooltip.
+        """
+        directory = str(self.runner.scripts_directory())
+        # elide against the label's real width -- with a floor, because showEvent
+        # fires before layout and a near-zero width elides the path away entirely
+        available = max(self.meta_label.width(), 240)
+        elided = QFontMetrics(self.meta_label.font()).elidedText(
+            directory, Qt.ElideMiddle, available
+        )
+        self.meta_label.setText(f"{self._summary}  ·  {elided}")
+        self.meta_label.setToolTip(directory)
+
+    def resizeEvent(self, event) -> None:  # noqa: N802 - Qt naming
+        super().resizeEvent(event)
+        if getattr(self, "_summary", None) is not None:
+            self._update_meta()
+
+    def showEvent(self, event) -> None:  # noqa: N802 - Qt naming
+        super().showEvent(event)
+        self._update_meta()
 
     # --- selection + running ---
 
@@ -333,6 +397,41 @@ class ScriptManagerDialog(QDialog):
             script.is_runnable and host_ready and not script.uses_microscope
         )
         self.hint_label.setText(reason)
+
+    def change_folder(self) -> None:
+        """Point the dialog at a different folder for this session."""
+        chosen = QFileDialog.getExistingDirectory(
+            self, "Choose a scripts folder", str(self.runner.scripts_directory())
+        )
+        if not chosen:
+            return
+        self.runner.set_directory(Path(chosen))
+        self.refresh(keep_selection=False)
+
+    def new_script(self) -> None:
+        """Create a stub script in the current folder and reveal it."""
+        name, accepted = QInputDialog.getText(self, "New script", "File name:", text="my_script")
+        if not accepted or not name.strip():
+            return
+
+        directory = self.runner.scripts_directory()
+        path = directory / (name.strip() if name.strip().endswith(".py") else f"{name.strip()}.py")
+        if path.exists():
+            self.runner.notify(f"{path.name} already exists.", "warning")
+            return
+
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+            path.write_text(_TEMPLATE)
+        except OSError as e:
+            self.runner.notify(f"Could not create {path.name}: {e}", "error")
+            return
+
+        self.refresh(keep_selection=False)
+        names = [s.name for s in self.scripts]
+        if path.stem in names:
+            self.table.selectRow(names.index(path.stem))
+        open_path_in_file_explorer(str(directory))
 
     def run_selected(self) -> None:
         script = self.selected_script()

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -1,0 +1,345 @@
+"""The Scripts manager dialog.
+
+Everything the Scripts menu cannot express: the resolved folder, per-script load
+errors, which scripts write or run automatically, and the source path and content
+hash of what would actually run. A menu has nowhere to put any of that, so a
+failed script would simply be absent from it — the silent omission this exists to
+avoid.
+
+Application-agnostic: it drives a :class:`ScriptRunner`, which the host wires up.
+See FIB-338.
+"""
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.scripting import DiscoveredScript
+from fibsem.ui.stylesheets import PRIMARY_BUTTON_STYLESHEET
+from fibsem.ui.widgets.script_runner import ScriptRunner
+
+# Palette (matching fibsem.ui.stylesheets napari theme)
+_BG = "#262930"
+_PANEL = "#1e2027"
+_ROW_ALT = "#2b2f38"
+_BORDER = "#3d4251"
+_TEXT = "#d6d6d6"
+_TEXT_STRONG = "#f0f1f2"
+_TEXT_MUTED = "#868e93"
+_ACCENT = "#50a6ff"
+_WARN = "#e0a030"
+_ERROR = "#d04040"
+
+_COLUMNS = ["Script", "Type", "Last run"]
+
+_TABLE_STYLE = f"""
+QTableWidget {{
+    background-color: {_BG};
+    alternate-background-color: {_ROW_ALT};
+    border: 1px solid {_BORDER};
+    border-radius: 6px;
+    color: {_TEXT};
+    gridline-color: transparent;
+    outline: none;
+}}
+QHeaderView::section {{
+    background-color: {_PANEL};
+    color: {_TEXT_MUTED};
+    border: none;
+    padding: 6px 8px;
+    font-size: 11px;
+}}
+QTableWidget::item {{ padding: 6px 8px; border-bottom: 1px solid #31353f; }}
+QTableWidget::item:selected {{ background-color: #2d3947; color: {_TEXT_STRONG}; }}
+"""
+
+_SECONDARY_BUTTON_STYLE = f"""
+QPushButton {{
+    background-color: transparent;
+    border: 1px solid {_BORDER};
+    color: {_TEXT};
+    border-radius: 6px;
+    padding: 5px 12px;
+    font-size: 12px;
+}}
+QPushButton:hover {{ background-color: {_ROW_ALT}; }}
+QPushButton:disabled {{ color: {_TEXT_MUTED}; }}
+"""
+
+
+def _script_type(script: DiscoveredScript) -> "tuple[str, str]":
+    """(label, colour) describing what a script is allowed to touch."""
+    if not script.is_runnable:
+        return "Error", _ERROR
+    if script.uses_microscope:
+        return "Microscope", _WARN
+    return "Data", _TEXT_MUTED
+
+
+class ScriptManagerDialog(QDialog):
+    """Lists every script in the folder — including the ones that failed to load."""
+
+    def __init__(self, runner: ScriptRunner, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.runner = runner
+        self.scripts: List[DiscoveredScript] = []
+        # Populated as scripts are run, so the table gives immediate feedback.
+        # Deliberately not persisted -- nothing records run history yet.
+        self.last_run: Dict[str, str] = {}
+
+        self.setWindowTitle("Scripts")
+        self.setStyleSheet(f"QDialog {{ background-color: {_BG}; }}")
+        self.resize(760, 580)
+        self._build()
+        self.refresh()
+
+    # --- construction ---
+
+    def _build(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 12, 14, 12)
+        layout.setSpacing(10)
+
+        header = QHBoxLayout()
+        titles = QVBoxLayout()
+        titles.setSpacing(2)
+        self.title_label = QLabel()
+        self.title_label.setStyleSheet(
+            f"font-size: 14px; font-weight: 500; color: {_TEXT_STRONG};"
+        )
+        self.path_label = QLabel()
+        self.path_label.setStyleSheet(f"font-size: 12px; color: {_TEXT_MUTED};")
+        titles.addWidget(self.title_label)
+        titles.addWidget(self.path_label)
+        header.addLayout(titles)
+        header.addStretch()
+
+        self.open_folder_button = QPushButton("Open folder")
+        self.open_folder_button.setStyleSheet(_SECONDARY_BUTTON_STYLE)
+        self.open_folder_button.clicked.connect(self.runner.open_folder)
+        self.rescan_button = QPushButton("Rescan folder")
+        self.rescan_button.setStyleSheet(_SECONDARY_BUTTON_STYLE)
+        # "Rescan", not "Reload": scripts are loaded fresh on every run anyway, so
+        # this only picks up files added or deleted since the dialog opened.
+        self.rescan_button.clicked.connect(self.refresh)
+        header.addWidget(self.open_folder_button)
+        header.addWidget(self.rescan_button)
+        layout.addLayout(header)
+
+        self.table = self._build_table()
+        layout.addWidget(self.table)
+
+        self.detail_label = QLabel()
+        self.detail_label.setTextFormat(Qt.RichText)
+        self.detail_label.setWordWrap(True)
+        self.detail_label.setStyleSheet(
+            f"background-color: {_PANEL}; border: 1px solid {_BORDER};"
+            f"border-radius: 6px; padding: 9px 11px; font-size: 12px; color: {_TEXT};"
+        )
+        layout.addWidget(self.detail_label)
+
+        footer = QHBoxLayout()
+        self.hint_label = QLabel()
+        self.hint_label.setStyleSheet(f"font-size: 12px; color: {_TEXT_MUTED};")
+        footer.addWidget(self.hint_label)
+        footer.addStretch()
+        close_button = QPushButton("Close")
+        close_button.setStyleSheet(_SECONDARY_BUTTON_STYLE)
+        close_button.clicked.connect(self.reject)
+        self.run_button = QPushButton("Run script")
+        self.run_button.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
+        self.run_button.clicked.connect(self.run_selected)
+        footer.addWidget(close_button)
+        footer.addWidget(self.run_button)
+        layout.addLayout(footer)
+
+    def _build_table(self) -> QTableWidget:
+        table = QTableWidget()
+        table.setStyleSheet(_TABLE_STYLE)
+        table.setColumnCount(len(_COLUMNS))
+        table.setHorizontalHeaderLabels(_COLUMNS)
+        table.verticalHeader().setVisible(False)
+        # rows carry a stacked name + description, so they need room to breathe
+        table.verticalHeader().setDefaultSectionSize(62)
+        table.setShowGrid(False)
+        table.setAlternatingRowColors(True)
+        table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        table.setSelectionMode(QAbstractItemView.SingleSelection)
+        table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        table.itemSelectionChanged.connect(self._on_selection_changed)
+        table.doubleClicked.connect(self.run_selected)
+
+        header = table.horizontalHeader()
+        header.setDefaultAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        header.setStretchLastSection(False)
+        header.setSectionResizeMode(0, header.Stretch)
+        table.setColumnWidth(1, 210)
+        table.setColumnWidth(2, 100)
+        return table
+
+    @staticmethod
+    def _chip(text: str, colour: str, dot: bool = True) -> QLabel:
+        """A pill label: coloured dot + text, on a tint of the same colour."""
+        rgb = QColor(colour)
+        tint = f"rgba({rgb.red()}, {rgb.green()}, {rgb.blue()}, 0.15)"
+        marker = f'<span style="color:{colour};">&#9679;</span> ' if dot else ""
+        chip = QLabel(f"{marker}{text}")
+        chip.setStyleSheet(
+            f"background-color: {tint}; color: {colour};"
+            f"padding: 2px 9px; border-radius: 10px; font-size: 11px;"
+        )
+        return chip
+
+    def _name_cell(self, script: DiscoveredScript) -> QWidget:
+        """Two lines: the filename, and what it does (or why it will not load)."""
+        widget = QWidget()
+        widget.setStyleSheet("background: transparent;")
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(12, 10, 10, 10)
+        layout.setSpacing(3)
+
+        name = QLabel(script.name)
+        name.setStyleSheet(
+            f"font-family: Menlo, monospace; font-size: 13px; background: transparent;"
+            f"color: {_TEXT_STRONG if script.is_runnable else _TEXT_MUTED};"
+        )
+        detail = QLabel(script.description if script.is_runnable else script.error)
+        detail.setStyleSheet(
+            f"font-size: 12px; background: transparent;"
+            f"color: {_TEXT if script.is_runnable else _ERROR};"
+        )
+        layout.addWidget(name)
+        layout.addWidget(detail)
+        widget.setToolTip(f"{script.path}\n{script.content_hash}")
+        return widget
+
+    def _type_cell(self, script: DiscoveredScript) -> QWidget:
+        """The type chip, plus a chip per declared flag."""
+        widget = QWidget()
+        widget.setStyleSheet("background: transparent;")
+        layout = QHBoxLayout(widget)
+        layout.setContentsMargins(8, 6, 8, 6)
+        layout.setSpacing(4)
+
+        label, colour = _script_type(script)
+        layout.addWidget(self._chip(label, colour))
+        if script.writes:
+            layout.addWidget(self._chip("writes", _WARN, dot=False))
+        if script.on_workflow_completed:
+            layout.addWidget(self._chip("auto", _ACCENT, dot=False))
+        layout.addStretch()
+        notes = [f"Type: {label}"]
+        if script.writes:
+            notes.append("writes: saves the experiment when finished")
+        if script.on_workflow_completed:
+            notes.append("auto: also runs when a workflow finishes")
+        widget.setToolTip("\n".join(notes))
+        return widget
+
+    # --- data ---
+
+    def refresh(self) -> None:
+        """Re-read the folder and rebuild the table."""
+        self.scripts = self.runner.discover()
+        failed = sum(1 for s in self.scripts if not s.is_runnable)
+        runnable = len(self.scripts) - failed
+
+        summary = f"{runnable} script{'s' if runnable != 1 else ''}"
+        if failed:
+            summary += f", {failed} failed to load"
+        self.title_label.setText(summary)
+        self.path_label.setText(str(self.runner.scripts_directory()))
+
+        self.table.setRowCount(len(self.scripts))
+        for row, script in enumerate(self.scripts):
+            # cell widgets, not items: a QTableWidgetItem cannot carry a pill
+            # background, and the name cell needs two lines.
+            self.table.setCellWidget(row, 0, self._name_cell(script))
+            self.table.setCellWidget(row, 1, self._type_cell(script))
+
+            last_item = QTableWidgetItem(self.last_run.get(script.name, "—"))
+            last_item.setForeground(QColor(_TEXT_MUTED))
+            self.table.setItem(row, 2, last_item)
+            # an empty item under each widget keeps row selection working
+            for col in (0, 1):
+                self.table.setItem(row, col, QTableWidgetItem())
+
+        if self.scripts:
+            self.table.selectRow(0)
+        self._on_selection_changed()
+
+    # --- selection + running ---
+
+    def selected_script(self) -> Optional[DiscoveredScript]:
+        row = self.table.currentRow()
+        if 0 <= row < len(self.scripts):
+            return self.scripts[row]
+        return None
+
+    def _on_selection_changed(self) -> None:
+        script = self.selected_script()
+        host_ready, reason = self.runner.availability()
+
+        if script is None:
+            self.detail_label.setText(
+                f'<span style="color:{_TEXT_MUTED};">No script selected.</span>'
+            )
+            self.run_button.setEnabled(False)
+            self.hint_label.setText(reason)
+            return
+
+        parts = [
+            f'<span style="color:{_TEXT_MUTED};">Source</span>&nbsp; {script.path.name}',
+            f'<span style="color:{_TEXT_MUTED};">Hash</span>&nbsp; {script.content_hash}',
+        ]
+        detail = "<br>".join(parts)
+
+        if not script.is_runnable:
+            detail += f'<br><span style="color:{_ERROR};">● {script.error}</span>'
+        elif script.uses_microscope:
+            detail += (
+                f'<br><span style="color:{_WARN};">● Needs the microscope — '
+                f"not supported yet.</span>"
+            )
+        elif script.writes:
+            detail += (
+                f'<br><span style="color:{_WARN};">● Modifies the experiment and '
+                f"saves it when finished.</span>"
+            )
+        if script.on_workflow_completed:
+            detail += (
+                f'<br><span style="color:{_ACCENT};">● Also runs automatically when '
+                f"a workflow finishes.</span>"
+            )
+
+        self.detail_label.setText(detail)
+        # uses_microscope is disabled rather than offered-then-refused: the runner
+        # would reject it anyway (FIB-340), and a button that does nothing but
+        # complain is worse than one that is visibly unavailable.
+        self.run_button.setEnabled(
+            script.is_runnable and host_ready and not script.uses_microscope
+        )
+        self.hint_label.setText(reason)
+
+    def run_selected(self) -> None:
+        script = self.selected_script()
+        if script is None or not script.is_runnable:
+            return
+        result = self.runner.run(script)
+        if result is not None:
+            outcome = "ok" if result.ok else "failed"
+            self.last_run[script.name] = f"{datetime.now().strftime('%H:%M')} {outcome}"
+        self.refresh()

--- a/fibsem/ui/widgets/script_menu.py
+++ b/fibsem/ui/widgets/script_menu.py
@@ -15,7 +15,12 @@ from typing import Callable, Optional
 from PyQt5.QtWidgets import QAction, QMenu, QWidget
 
 from fibsem.scripting import DiscoveredScript
-from fibsem.ui.widgets.script_runner import ContextFactory, Notifier, ScriptRunner
+from fibsem.ui.widgets.script_runner import (
+    Confirmer,
+    ContextFactory,
+    Notifier,
+    ScriptRunner,
+)
 
 MANAGE_LABEL = "Manage scripts…"
 
@@ -34,6 +39,7 @@ class ScriptMenuController:
         context_factory: ContextFactory,
         notify: Notifier,
         parent: Optional[QWidget] = None,
+        confirm: Optional[Confirmer] = None,
     ) -> None:
         self.menu = menu
         self.parent = parent
@@ -42,6 +48,7 @@ class ScriptMenuController:
             context_factory=context_factory,
             notify=notify,
             parent=parent,
+            confirm=confirm,
         )
 
         self.menu.setToolTipsVisible(True)
@@ -87,10 +94,11 @@ class ScriptMenuController:
 
     def _build_action(self, script: DiscoveredScript, host_ready: bool) -> QAction:
         label = script.name
-        flags = [name for name, on in (("writes", script.writes),
-                                       ("auto", script.on_workflow_completed)) if on]
-        if flags:
-            label += f"  ({', '.join(flags)})"
+        # writes only. on_workflow_completed is not connected to anything yet, and
+        # a menu has nowhere to say so -- an "auto" label here would read as a
+        # promise. The dialog carries the flag and the caveat together.
+        if script.writes:
+            label += "  (writes)"
 
         action = QAction(label, self.menu)
         action.setToolTip(script.description)

--- a/fibsem/ui/widgets/script_menu.py
+++ b/fibsem/ui/widgets/script_menu.py
@@ -1,12 +1,15 @@
-"""A reusable "Scripts" menu for running user scripts from a Qt application.
+"""A reusable "Scripts" menu for a Qt application.
 
-The menu is for running a known-good script in one click. Everything a menu
-cannot express — the folder path, per-script load errors, the ``writes`` warning,
-source and hash — lives in the manager dialog it opens. A failed script would
-otherwise simply be absent from the menu, which is the silent-omission failure
-this is meant to avoid.
+The menu is a way *in*, not a way to run. Running happens in the manager dialog
+only, because a script can now drive the microscope on a worker thread and the
+dialog is the only surface with a Stop button — a menu item that starts a
+ten-minute stage survey with no way to interrupt it is a trap.
 
-Knows nothing about experiments, microscopes or AutoLamella. See FIB-338.
+That also settles what the menu should list: nothing. Names alone cannot express
+the folder, a load error, or that a script writes or needs hardware, and the
+dialog shows all of it beside the button that starts it.
+
+Knows nothing about experiments, microscopes or AutoLamella. See FIB-338, FIB-340.
 """
 
 from pathlib import Path
@@ -14,7 +17,6 @@ from typing import Callable, Optional
 
 from PyQt5.QtWidgets import QAction, QMenu, QWidget
 
-from fibsem.scripting import DiscoveredScript
 from fibsem.ui.widgets.script_runner import (
     Confirmer,
     ContextFactory,
@@ -23,13 +25,14 @@ from fibsem.ui.widgets.script_runner import (
 )
 
 MANAGE_LABEL = "Manage scripts…"
+OPEN_FOLDER_LABEL = "Open scripts folder"
 
 
 class ScriptMenuController:
-    """Populates a QMenu with the scripts in a directory, and runs them.
+    """Puts the way into user scripts on an existing QMenu.
 
-    Attached to an existing menu rather than subclassing QMenu so a host can place
-    it wherever it likes in its own menu tree.
+    Attached to a menu rather than subclassing QMenu so a host can place it
+    wherever it likes in its own menu tree.
     """
 
     def __init__(
@@ -50,63 +53,26 @@ class ScriptMenuController:
             parent=parent,
             confirm=confirm,
         )
-
-        self.menu.setToolTipsVisible(True)
-        # Rebuilt on every open: scripts are not cached, so editing a file and
-        # running it again picks up the change with no reload step.
-        self.menu.aboutToShow.connect(self.rebuild)
+        self.build()
 
     # --- menu ---
 
-    def rebuild(self) -> None:
+    def build(self) -> None:
+        """Two fixed entries.
+
+        Built once, not on ``aboutToShow``: nothing here depends on what is in
+        the folder any more, so there is nothing to rebuild and no reason to
+        import every script each time the user opens the Tools menu.
+        """
         self.menu.clear()
-        scripts = self.runner.discover()
-        host_ready, reason = self.runner.availability()
-
-        runnable = [s for s in scripts if s.is_runnable]
-        failed = len(scripts) - len(runnable)
-
-        if not runnable:
-            self._add_disabled("No scripts found" if not scripts else "No runnable scripts")
-
-        for script in runnable:
-            self.menu.addAction(self._build_action(script, host_ready))
-
-        self.menu.addSeparator()
-        if reason:
-            self._add_disabled(reason)
-        if failed:
-            # named here, detail in the dialog -- a menu has nowhere to put a reason
-            self._add_disabled(f"{failed} script(s) failed to load — see {MANAGE_LABEL}")
 
         manage = QAction(MANAGE_LABEL, self.menu)
         manage.triggered.connect(self.open_manager)
         self.menu.addAction(manage)
 
-        open_folder = QAction("Open scripts folder", self.menu)
+        open_folder = QAction(OPEN_FOLDER_LABEL, self.menu)
         open_folder.triggered.connect(self.runner.open_folder)
         self.menu.addAction(open_folder)
-
-    def _add_disabled(self, text: str) -> None:
-        action = QAction(text, self.menu)
-        action.setEnabled(False)
-        self.menu.addAction(action)
-
-    def _build_action(self, script: DiscoveredScript, host_ready: bool) -> QAction:
-        label = script.name
-        # on_workflow_completed is deliberately absent: it is not connected to
-        # anything yet, and a menu has nowhere to say so, so an "auto" label here
-        # would read as a promise. The dialog carries the flag and the caveat.
-        flags = [name for name, on in (("microscope", script.uses_microscope),
-                                       ("writes", script.writes)) if on]
-        if flags:
-            label += f"  ({', '.join(flags)})"
-
-        action = QAction(label, self.menu)
-        action.setToolTip(script.description)
-        action.setEnabled(host_ready)
-        action.triggered.connect(lambda _checked=False, s=script: self.runner.run(s))
-        return action
 
     # --- manager ---
 

--- a/fibsem/ui/widgets/script_menu.py
+++ b/fibsem/ui/widgets/script_menu.py
@@ -1,29 +1,23 @@
 """A reusable "Scripts" menu for running user scripts from a Qt application.
 
-Knows nothing about experiments, microscopes or AutoLamella. A host supplies:
+The menu is for running a known-good script in one click. Everything a menu
+cannot express — the folder path, per-script load errors, the ``writes`` warning,
+source and hash — lives in the manager dialog it opens. A failed script would
+otherwise simply be absent from the menu, which is the silent-omission failure
+this is meant to avoid.
 
-* where the scripts live
-* a context factory — what to hand the script, or ``None`` if it cannot run now
-* a notifier — how to tell the user something
-
-so the same menu can be dropped into any fibsem application, and tested without
-one. See FIB-338.
+Knows nothing about experiments, microscopes or AutoLamella. See FIB-338.
 """
 
-import logging
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Callable, Optional
 
-import pandas as pd
-from PyQt5.QtWidgets import QAction, QDialog, QMenu, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QAction, QMenu, QWidget
 
-from fibsem.scripting import DiscoveredScript, ScriptResult, discover_scripts, run_script
-from fibsem.ui.utils import open_path_in_file_explorer
+from fibsem.scripting import DiscoveredScript
+from fibsem.ui.widgets.script_runner import ContextFactory, Notifier, ScriptRunner
 
-# (context, reason). A context of None means "cannot run", and reason says why.
-ContextFactory = Callable[[], Tuple[Optional[Any], str]]
-# (message, level) where level is info/success/warning/error
-Notifier = Callable[[str, str], None]
+MANAGE_LABEL = "Manage scripts…"
 
 
 class ScriptMenuController:
@@ -42,10 +36,13 @@ class ScriptMenuController:
         parent: Optional[QWidget] = None,
     ) -> None:
         self.menu = menu
-        self.scripts_directory = scripts_directory
-        self.context_factory = context_factory
-        self.notify = notify
         self.parent = parent
+        self.runner = ScriptRunner(
+            scripts_directory=scripts_directory,
+            context_factory=context_factory,
+            notify=notify,
+            parent=parent,
+        )
 
         self.menu.setToolTipsVisible(True)
         # Rebuilt on every open: scripts are not cached, so editing a file and
@@ -56,26 +53,32 @@ class ScriptMenuController:
 
     def rebuild(self) -> None:
         self.menu.clear()
-        scripts = self.discover()
-        _context, reason = self.context_factory()
-        runnable = not reason
+        scripts = self.runner.discover()
+        host_ready, reason = self.runner.availability()
 
-        if not scripts:
-            self._add_disabled("No scripts found")
+        runnable = [s for s in scripts if s.is_runnable]
+        failed = len(scripts) - len(runnable)
 
-        for script in scripts:
-            self.menu.addAction(self._build_action(script, runnable))
+        if not runnable:
+            self._add_disabled("No scripts found" if not scripts else "No runnable scripts")
+
+        for script in runnable:
+            self.menu.addAction(self._build_action(script, host_ready))
 
         self.menu.addSeparator()
         if reason:
             self._add_disabled(reason)
+        if failed:
+            # named here, detail in the dialog -- a menu has nowhere to put a reason
+            self._add_disabled(f"{failed} script(s) failed to load — see {MANAGE_LABEL}")
+
+        manage = QAction(MANAGE_LABEL, self.menu)
+        manage.triggered.connect(self.open_manager)
+        self.menu.addAction(manage)
 
         open_folder = QAction("Open scripts folder", self.menu)
-        open_folder.triggered.connect(self.open_folder)
+        open_folder.triggered.connect(self.runner.open_folder)
         self.menu.addAction(open_folder)
-
-    def discover(self) -> List[DiscoveredScript]:
-        return discover_scripts(self.scripts_directory())
 
     def _add_disabled(self, text: str) -> None:
         action = QAction(text, self.menu)
@@ -90,89 +93,15 @@ class ScriptMenuController:
             label += f"  ({', '.join(flags)})"
 
         action = QAction(label, self.menu)
-        if not script.is_runnable:
-            # A script that failed to load is shown, not omitted. Silently hiding
-            # it leaves the author with nothing to diagnose.
-            action.setEnabled(False)
-            action.setToolTip(f"Cannot load: {script.error}")
-            return action
-
         action.setToolTip(script.description)
         action.setEnabled(host_ready)
-        action.triggered.connect(lambda _checked=False, s=script: self.run(s))
+        action.triggered.connect(lambda _checked=False, s=script: self.runner.run(s))
         return action
 
-    # --- running ---
+    # --- manager ---
 
-    def open_folder(self) -> None:
-        """Create the scripts folder if needed and reveal it."""
-        directory = self.scripts_directory()
-        try:
-            directory.mkdir(parents=True, exist_ok=True)
-        except OSError as e:
-            self.notify(f"Could not create {directory}: {e}", "error")
-            return
-        open_path_in_file_explorer(str(directory))
+    def open_manager(self) -> None:
+        from fibsem.ui.widgets.script_manager_dialog import ScriptManagerDialog
 
-    def run(self, script: DiscoveredScript) -> Optional[ScriptResult]:
-        """Run one script and render whatever it returned."""
-        context, reason = self.context_factory()
-        if context is None:
-            self.notify(reason or "Cannot run scripts right now.", "warning")
-            return None
-
-        if script.uses_microscope:
-            # The strict runner these need -- worker thread, hardware exclusion,
-            # cancellation, state restoration -- is FIB-340 and not built yet.
-            self.notify(
-                f"'{script.name}' declares uses_microscope, which is not supported yet.",
-                "warning",
-            )
-            return None
-        if script.background:
-            logging.warning(
-                "Script %s declares background=True; running inline for now.", script.name
-            )
-
-        result = run_script(script, context)
-
-        if not result.ok:
-            self.notify(f"{script.name} failed: {result.error}", "error")
-            return result
-
-        self.show_result(script, result.value)
-        return result
-
-    def show_result(self, script: DiscoveredScript, value: Any) -> None:
-        """Render a script's return value.
-
-        The return value carries the output because there is typically no log
-        console in the app -- print() goes to a terminal the user may not have,
-        and a packaged Windows build has none at all. Without this a working
-        script looks like it did nothing.
-        """
-        if value is None:
-            self.notify(f"{script.name} finished.", "success")
-            return
-
-        if isinstance(value, pd.DataFrame):
-            self.show_dataframe(script.name, value)
-            return
-
-        if isinstance(value, Path):
-            self.notify(f"{script.name} wrote {value.name}", "success")
-            if value.exists():
-                open_path_in_file_explorer(str(value.parent))
-            return
-
-        self.notify(f"{script.name}: {value}", "success")
-
-    def show_dataframe(self, title: str, dataframe: pd.DataFrame) -> None:
-        from fibsem.ui.widgets.dataframe_table_widget import DataFrameTableWidget
-
-        dialog = QDialog(self.parent)
-        dialog.setWindowTitle(title)
-        dialog.resize(720, 420)
-        layout = QVBoxLayout(dialog)
-        layout.addWidget(DataFrameTableWidget(dataframe=dataframe, parent=dialog))
+        dialog = ScriptManagerDialog(runner=self.runner, parent=self.parent)
         dialog.exec_()

--- a/fibsem/ui/widgets/script_menu.py
+++ b/fibsem/ui/widgets/script_menu.py
@@ -1,0 +1,178 @@
+"""A reusable "Scripts" menu for running user scripts from a Qt application.
+
+Knows nothing about experiments, microscopes or AutoLamella. A host supplies:
+
+* where the scripts live
+* a context factory — what to hand the script, or ``None`` if it cannot run now
+* a notifier — how to tell the user something
+
+so the same menu can be dropped into any fibsem application, and tested without
+one. See FIB-338.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Tuple
+
+import pandas as pd
+from PyQt5.QtWidgets import QAction, QDialog, QMenu, QVBoxLayout, QWidget
+
+from fibsem.scripting import DiscoveredScript, ScriptResult, discover_scripts, run_script
+from fibsem.ui.utils import open_path_in_file_explorer
+
+# (context, reason). A context of None means "cannot run", and reason says why.
+ContextFactory = Callable[[], Tuple[Optional[Any], str]]
+# (message, level) where level is info/success/warning/error
+Notifier = Callable[[str, str], None]
+
+
+class ScriptMenuController:
+    """Populates a QMenu with the scripts in a directory, and runs them.
+
+    Attached to an existing menu rather than subclassing QMenu so a host can place
+    it wherever it likes in its own menu tree.
+    """
+
+    def __init__(
+        self,
+        menu: QMenu,
+        scripts_directory: Callable[[], Path],
+        context_factory: ContextFactory,
+        notify: Notifier,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        self.menu = menu
+        self.scripts_directory = scripts_directory
+        self.context_factory = context_factory
+        self.notify = notify
+        self.parent = parent
+
+        self.menu.setToolTipsVisible(True)
+        # Rebuilt on every open: scripts are not cached, so editing a file and
+        # running it again picks up the change with no reload step.
+        self.menu.aboutToShow.connect(self.rebuild)
+
+    # --- menu ---
+
+    def rebuild(self) -> None:
+        self.menu.clear()
+        scripts = self.discover()
+        _context, reason = self.context_factory()
+        runnable = not reason
+
+        if not scripts:
+            self._add_disabled("No scripts found")
+
+        for script in scripts:
+            self.menu.addAction(self._build_action(script, runnable))
+
+        self.menu.addSeparator()
+        if reason:
+            self._add_disabled(reason)
+
+        open_folder = QAction("Open scripts folder", self.menu)
+        open_folder.triggered.connect(self.open_folder)
+        self.menu.addAction(open_folder)
+
+    def discover(self) -> List[DiscoveredScript]:
+        return discover_scripts(self.scripts_directory())
+
+    def _add_disabled(self, text: str) -> None:
+        action = QAction(text, self.menu)
+        action.setEnabled(False)
+        self.menu.addAction(action)
+
+    def _build_action(self, script: DiscoveredScript, host_ready: bool) -> QAction:
+        label = script.name
+        flags = [name for name, on in (("writes", script.writes),
+                                       ("auto", script.on_workflow_completed)) if on]
+        if flags:
+            label += f"  ({', '.join(flags)})"
+
+        action = QAction(label, self.menu)
+        if not script.is_runnable:
+            # A script that failed to load is shown, not omitted. Silently hiding
+            # it leaves the author with nothing to diagnose.
+            action.setEnabled(False)
+            action.setToolTip(f"Cannot load: {script.error}")
+            return action
+
+        action.setToolTip(script.description)
+        action.setEnabled(host_ready)
+        action.triggered.connect(lambda _checked=False, s=script: self.run(s))
+        return action
+
+    # --- running ---
+
+    def open_folder(self) -> None:
+        """Create the scripts folder if needed and reveal it."""
+        directory = self.scripts_directory()
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            self.notify(f"Could not create {directory}: {e}", "error")
+            return
+        open_path_in_file_explorer(str(directory))
+
+    def run(self, script: DiscoveredScript) -> Optional[ScriptResult]:
+        """Run one script and render whatever it returned."""
+        context, reason = self.context_factory()
+        if context is None:
+            self.notify(reason or "Cannot run scripts right now.", "warning")
+            return None
+
+        if script.uses_microscope:
+            # The strict runner these need -- worker thread, hardware exclusion,
+            # cancellation, state restoration -- is FIB-340 and not built yet.
+            self.notify(
+                f"'{script.name}' declares uses_microscope, which is not supported yet.",
+                "warning",
+            )
+            return None
+        if script.background:
+            logging.warning(
+                "Script %s declares background=True; running inline for now.", script.name
+            )
+
+        result = run_script(script, context)
+
+        if not result.ok:
+            self.notify(f"{script.name} failed: {result.error}", "error")
+            return result
+
+        self.show_result(script, result.value)
+        return result
+
+    def show_result(self, script: DiscoveredScript, value: Any) -> None:
+        """Render a script's return value.
+
+        The return value carries the output because there is typically no log
+        console in the app -- print() goes to a terminal the user may not have,
+        and a packaged Windows build has none at all. Without this a working
+        script looks like it did nothing.
+        """
+        if value is None:
+            self.notify(f"{script.name} finished.", "success")
+            return
+
+        if isinstance(value, pd.DataFrame):
+            self.show_dataframe(script.name, value)
+            return
+
+        if isinstance(value, Path):
+            self.notify(f"{script.name} wrote {value.name}", "success")
+            if value.exists():
+                open_path_in_file_explorer(str(value.parent))
+            return
+
+        self.notify(f"{script.name}: {value}", "success")
+
+    def show_dataframe(self, title: str, dataframe: pd.DataFrame) -> None:
+        from fibsem.ui.widgets.dataframe_table_widget import DataFrameTableWidget
+
+        dialog = QDialog(self.parent)
+        dialog.setWindowTitle(title)
+        dialog.resize(720, 420)
+        layout = QVBoxLayout(dialog)
+        layout.addWidget(DataFrameTableWidget(dataframe=dataframe, parent=dialog))
+        dialog.exec_()

--- a/fibsem/ui/widgets/script_menu.py
+++ b/fibsem/ui/widgets/script_menu.py
@@ -94,11 +94,13 @@ class ScriptMenuController:
 
     def _build_action(self, script: DiscoveredScript, host_ready: bool) -> QAction:
         label = script.name
-        # writes only. on_workflow_completed is not connected to anything yet, and
-        # a menu has nowhere to say so -- an "auto" label here would read as a
-        # promise. The dialog carries the flag and the caveat together.
-        if script.writes:
-            label += "  (writes)"
+        # on_workflow_completed is deliberately absent: it is not connected to
+        # anything yet, and a menu has nowhere to say so, so an "auto" label here
+        # would read as a promise. The dialog carries the flag and the caveat.
+        flags = [name for name, on in (("microscope", script.uses_microscope),
+                                       ("writes", script.writes)) if on]
+        if flags:
+            label += f"  ({', '.join(flags)})"
 
         action = QAction(label, self.menu)
         action.setToolTip(script.description)

--- a/fibsem/ui/widgets/script_runner.py
+++ b/fibsem/ui/widgets/script_runner.py
@@ -136,15 +136,24 @@ class ScriptRunner:
         return box.clickedButton() is run
 
     def _consequence(self, script: DiscoveredScript) -> str:
-        """What running this script will do, for the confirmation box. Empty = no gate."""
+        """What running this script will do, for the confirmation box. Empty = no gate.
+
+        One whole sentence per consequence, not clauses joined with "and". A script
+        declaring both flags used to read "It drives the microscope, and nothing
+        checks what it does and modifies the experiment and saves it when it
+        finishes" -- three ands, and the second one attaches to "nothing checks",
+        so it says the opposite of what it means. That is the most dangerous kind
+        of script and the only one whose warning was broken.
+        """
         parts = []
         if script.uses_microscope:
-            parts.append("drives the microscope, and nothing checks what it does")
+            parts.append("It drives the microscope, and nothing checks what it does.")
         if script.writes:
-            parts.append("modifies the experiment and saves it when it finishes")
+            parts.append("It modifies the experiment and saves it when it finishes.")
         if not parts:
             return ""
-        return "It " + " and ".join(parts) + ". There is no undo."
+        parts.append("There is no undo.")
+        return " ".join(parts)
 
     @property
     def is_running(self) -> bool:

--- a/fibsem/ui/widgets/script_runner.py
+++ b/fibsem/ui/widgets/script_runner.py
@@ -10,10 +10,13 @@ Knows nothing about experiments, microscopes or AutoLamella. A host supplies:
 * a context factory — what to hand the script, or ``None`` if it cannot run now
 * a notifier — how to tell the user something
 
-See FIB-338.
+Data scripts run inline on the GUI thread; scripts that declare ``uses_microscope``
+run on a worker thread, because hardware operations are far too slow to freeze the
+window for. See FIB-338 and FIB-340.
 """
 
 import logging
+import threading
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple
 
@@ -29,7 +32,9 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from fibsem.cancellation import OperationCancelledError
 from fibsem.scripting import DiscoveredScript, ScriptResult, discover_scripts, run_script
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.stylesheets import (
     MESSAGE_BOX_STYLESHEET,
     PRIMARY_BUTTON_STYLESHEET,
@@ -62,6 +67,8 @@ class ScriptRunner:
         self.notify = notify
         self.parent = parent
         self.confirm = confirm or self._default_confirm
+        self._worker: Optional[FunctionWorker] = None
+        self._stop_event = threading.Event()
 
     def scripts_directory(self) -> Path:
         """Where to look for scripts — the host's folder, or a chosen override."""
@@ -128,54 +135,128 @@ class ScriptRunner:
         box.exec_()
         return box.clickedButton() is run
 
-    def run(self, script: DiscoveredScript) -> Optional[ScriptResult]:
+    def _consequence(self, script: DiscoveredScript) -> str:
+        """What running this script will do, for the confirmation box. Empty = no gate."""
+        parts = []
+        if script.uses_microscope:
+            parts.append("drives the microscope, and nothing checks what it does")
+        if script.writes:
+            parts.append("modifies the experiment and saves it when it finishes")
+        if not parts:
+            return ""
+        return "It " + " and ".join(parts) + ". There is no undo."
+
+    @property
+    def is_running(self) -> bool:
+        """Whether a script is running on a worker thread right now."""
+        return self._worker is not None and self._worker.is_alive()
+
+    def stop(self) -> None:
+        """Ask the running script to stop.
+
+        Cooperative: a Python thread cannot be killed, so this only sets the event.
+        A script that never checks it runs to completion regardless.
+        """
+        if self.is_running:
+            logging.info("Stop requested for the running script.")
+            self._stop_event.set()
+
+    def run(
+        self,
+        script: DiscoveredScript,
+        on_finished: Optional[Callable[[ScriptResult], None]] = None,
+    ) -> Optional[ScriptResult]:
         """Run one script and render whatever it returned.
 
-        Returns ``None`` when the script was refused rather than run.
+        Returns the result for a script that ran inline, and ``None`` both when the
+        script was refused and when it went to a worker thread. ``on_finished`` is
+        called with the result either way, so a caller that needs the outcome does
+        not have to care which happened.
         """
+        if self.is_running:
+            self.notify("A script is already running.", "warning")
+            return None
+
         context, reason = self.context_factory()
         if context is None:
             self.notify(reason or "Cannot run scripts right now.", "warning")
             return None
 
-        if script.uses_microscope:
-            # The strict runner these need -- worker thread, hardware exclusion,
-            # cancellation, state restoration -- is FIB-340 and not built yet.
-            self.notify(
-                f"'{script.name}' declares uses_microscope, which is not supported yet.",
-                "warning",
-            )
-            return None
-        if script.background:
+        if script.background and not script.uses_microscope:
             logging.warning(
                 "Script %s declares background=True; running inline for now.", script.name
             )
 
-        # Last gate before running: a writes script saves the moment it finishes and
-        # there is no undo, so the user gets one chance to back out. Read-only
-        # scripts -- the common case -- go straight through.
-        if script.writes and not self.confirm(
-            f"Run '{script.name}'?",
-            "It modifies the experiment and saves it when it finishes. There is no undo.",
-        ):
-            logging.info("Script %s cancelled at the write confirmation.", script.name)
+        # Last gate before running. A writes script saves the moment it finishes and a
+        # microscope script has already moved the hardware by then -- neither has an
+        # undo. Read-only scripts, the common case, go straight through.
+        consequence = self._consequence(script)
+        if consequence and not self.confirm(f"Run '{script.name}'?", consequence):
+            logging.info("Script %s cancelled at the confirmation.", script.name)
             return None
 
-        # Scripts run on the GUI thread, so a slow one freezes the window. The
-        # cursor is the only sign it is working. Set after the confirmation, or
-        # the modal box above would come up under a wait cursor.
+        if script.uses_microscope:
+            self._run_threaded(script, context, on_finished)
+            return None
+
+        # Inline, on the GUI thread, so a slow one freezes the window -- the cursor is
+        # the only sign it is working. Set after the confirmation, or the modal box
+        # above would come up under a wait cursor.
         QApplication.setOverrideCursor(Qt.WaitCursor)
         try:
             result = run_script(script, context)
         finally:
             QApplication.restoreOverrideCursor()
 
+        self._report(script, result)
+        if on_finished is not None:
+            on_finished(result)
+        return result
+
+    def _run_threaded(
+        self,
+        script: DiscoveredScript,
+        context: Any,
+        on_finished: Optional[Callable[[ScriptResult], None]],
+    ) -> None:
+        """Run a microscope script on a worker thread.
+
+        Hardware operations take seconds to minutes. Inline they would freeze the
+        window for the whole run, which is indistinguishable from a hang -- so these
+        go to a thread even though data scripts do not. The consequence is that the
+        script must not touch ``ctx.experiment``: it holds evented containers whose
+        handlers fire into widgets, and those must only be touched from the GUI
+        thread. Nothing enforces that; it is documented in SCRIPTING.md.
+        """
+        self._stop_event = threading.Event()
+        if hasattr(context, "stop_event"):
+            context.stop_event = self._stop_event
+
+        worker = self._worker = FunctionWorker(run_script, script, context)
+
+        def _done(result: object) -> None:
+            # FunctionWorker delivers this on the GUI thread, so touching widgets
+            # (toasts, dialogs) from here is safe. run_script never raises, so
+            # `returned` always fires and `errored` never does.
+            self._worker = None
+            if isinstance(result, ScriptResult):
+                self._report(script, result)
+                if on_finished is not None:
+                    on_finished(result)
+
+        worker.returned.connect(_done)
+        self.notify(f"{script.name} started…", "info")
+        worker.start()
+
+    def _report(self, script: DiscoveredScript, result: ScriptResult) -> None:
+        """Surface the outcome of a finished run."""
+        if isinstance(result.error, OperationCancelledError):
+            self.notify(f"{script.name} cancelled.", "warning")
+            return
         if not result.ok:
             self.notify(f"{script.name} failed: {result.error}", "error")
-            return result
-
+            return
         self.show_result(script, result.value)
-        return result
 
     # --- rendering ---
 

--- a/fibsem/ui/widgets/script_runner.py
+++ b/fibsem/ui/widgets/script_runner.py
@@ -199,6 +199,19 @@ class ScriptRunner:
             self._run_threaded(script, context, on_finished)
             return None
 
+        # The flag is the route to the hardware: without it, `microscope` is withheld.
+        # A script that quietly drove the stage would otherwise still be listed as
+        # "Data / Read-only" -- an active falsehood, and worse than saying nothing.
+        # Restored afterwards, so a host that reuses one context object is not left
+        # with the microscope permanently removed from it.
+        #
+        # Not a boundary. Scripts are arbitrary Python and can import their way to a
+        # handle regardless; this is for the author who did not know the flag existed,
+        # and the AttributeError it produces names the line and implies the fix.
+        withheld = getattr(context, "microscope", None)
+        if withheld is not None:
+            context.microscope = None
+
         # Inline, on the GUI thread, so a slow one freezes the window -- the cursor is
         # the only sign it is working. Set after the confirmation, or the modal box
         # above would come up under a wait cursor.
@@ -207,8 +220,18 @@ class ScriptRunner:
             result = run_script(script, context)
         finally:
             QApplication.restoreOverrideCursor()
+            if withheld is not None:
+                context.microscope = withheld
 
-        self._report(script, result)
+        # The traceback in the log names the offending line, but the toast is all
+        # most users see, and "'NoneType' has no attribute acquire_image" does not
+        # say what to do about it. Phrased as a conditional so it stays harmless on
+        # an AttributeError that had nothing to do with the microscope.
+        hint = ""
+        if withheld is not None and isinstance(result.error, AttributeError):
+            hint = " — if it needs the microscope, declare uses_microscope = True."
+
+        self._report(script, result, hint)
         if on_finished is not None:
             on_finished(result)
         return result
@@ -248,13 +271,15 @@ class ScriptRunner:
         self.notify(f"{script.name} started…", "info")
         worker.start()
 
-    def _report(self, script: DiscoveredScript, result: ScriptResult) -> None:
+    def _report(
+        self, script: DiscoveredScript, result: ScriptResult, hint: str = ""
+    ) -> None:
         """Surface the outcome of a finished run."""
         if isinstance(result.error, OperationCancelledError):
             self.notify(f"{script.name} cancelled.", "warning")
             return
         if not result.ok:
-            self.notify(f"{script.name} failed: {result.error}", "error")
+            self.notify(f"{script.name} failed: {result.error}{hint}", "error")
             return
         self.show_result(script, result.value)
 

--- a/fibsem/ui/widgets/script_runner.py
+++ b/fibsem/ui/widgets/script_runner.py
@@ -19,9 +19,22 @@ from typing import Any, Callable, List, Optional, Tuple
 
 import pandas as pd
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QDialog, QMessageBox, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import (
+    QApplication,
+    QDialog,
+    QMessageBox,
+    QSizePolicy,
+    QSpacerItem,
+    QVBoxLayout,
+    QWidget,
+)
 
 from fibsem.scripting import DiscoveredScript, ScriptResult, discover_scripts, run_script
+from fibsem.ui.stylesheets import (
+    MESSAGE_BOX_STYLESHEET,
+    PRIMARY_BUTTON_STYLESHEET,
+    SECONDARY_BUTTON_STYLESHEET,
+)
 from fibsem.ui.utils import open_path_in_file_explorer
 
 # (context, reason). A context of None means "cannot run", and reason says why.
@@ -87,14 +100,31 @@ class ScriptRunner:
 
     def _default_confirm(self, question: str, detail: str) -> bool:
         """Yes/No box defaulting to Cancel, since this gates a destructive action."""
-        box = QMessageBox(self.parent)
+        # parented to whatever the user is actually looking at, so it centres over
+        # the manager dialog when the run came from there rather than over the
+        # main window behind it
+        box = QMessageBox(QApplication.activeWindow() or self.parent)
         box.setWindowTitle("Run script")
         box.setText(question)
         box.setInformativeText(detail)
         box.setIcon(QMessageBox.Warning)
+        box.setStyleSheet(MESSAGE_BOX_STYLESHEET)
         run = box.addButton("Run script", QMessageBox.AcceptRole)
         cancel = box.addButton("Cancel", QMessageBox.RejectRole)
+        # same weighting as the dialog's own footer: Run primary, Cancel secondary
+        run.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
+        cancel.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
         box.setDefaultButton(cancel)
+
+        # QMessageBox sizes itself from its own layout and ignores a stylesheet
+        # min-width, so the width has to come from the layout too. Without this it
+        # comes up at ~280px and wraps two short sentences over three lines.
+        layout = box.layout()
+        layout.addItem(
+            QSpacerItem(400, 0, QSizePolicy.Minimum, QSizePolicy.Fixed),
+            layout.rowCount(), 0, 1, layout.columnCount(),
+        )
+
         box.exec_()
         return box.clickedButton() is run
 

--- a/fibsem/ui/widgets/script_runner.py
+++ b/fibsem/ui/widgets/script_runner.py
@@ -18,7 +18,8 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple
 
 import pandas as pd
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QWidget
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication, QDialog, QMessageBox, QVBoxLayout, QWidget
 
 from fibsem.scripting import DiscoveredScript, ScriptResult, discover_scripts, run_script
 from fibsem.ui.utils import open_path_in_file_explorer
@@ -27,6 +28,8 @@ from fibsem.ui.utils import open_path_in_file_explorer
 ContextFactory = Callable[[], Tuple[Optional[Any], str]]
 # (message, level) where level is info/success/warning/error
 Notifier = Callable[[str, str], None]
+# (question, detail) -> True to go ahead. Injectable so the gate can be driven in tests.
+Confirmer = Callable[[str, str], bool]
 
 
 class ScriptRunner:
@@ -38,12 +41,14 @@ class ScriptRunner:
         context_factory: ContextFactory,
         notify: Notifier,
         parent: Optional[QWidget] = None,
+        confirm: Optional[Confirmer] = None,
     ) -> None:
         self._scripts_directory = scripts_directory
         self._directory_override: Optional[Path] = None
         self.context_factory = context_factory
         self.notify = notify
         self.parent = parent
+        self.confirm = confirm or self._default_confirm
 
     def scripts_directory(self) -> Path:
         """Where to look for scripts — the host's folder, or a chosen override."""
@@ -80,6 +85,19 @@ class ScriptRunner:
 
     # --- running ---
 
+    def _default_confirm(self, question: str, detail: str) -> bool:
+        """Yes/No box defaulting to Cancel, since this gates a destructive action."""
+        box = QMessageBox(self.parent)
+        box.setWindowTitle("Run script")
+        box.setText(question)
+        box.setInformativeText(detail)
+        box.setIcon(QMessageBox.Warning)
+        run = box.addButton("Run script", QMessageBox.AcceptRole)
+        cancel = box.addButton("Cancel", QMessageBox.RejectRole)
+        box.setDefaultButton(cancel)
+        box.exec_()
+        return box.clickedButton() is run
+
     def run(self, script: DiscoveredScript) -> Optional[ScriptResult]:
         """Run one script and render whatever it returned.
 
@@ -103,7 +121,24 @@ class ScriptRunner:
                 "Script %s declares background=True; running inline for now.", script.name
             )
 
-        result = run_script(script, context)
+        # Last gate before running: a writes script saves the moment it finishes and
+        # there is no undo, so the user gets one chance to back out. Read-only
+        # scripts -- the common case -- go straight through.
+        if script.writes and not self.confirm(
+            f"Run '{script.name}'?",
+            "It modifies the experiment and saves it when it finishes. There is no undo.",
+        ):
+            logging.info("Script %s cancelled at the write confirmation.", script.name)
+            return None
+
+        # Scripts run on the GUI thread, so a slow one freezes the window. The
+        # cursor is the only sign it is working. Set after the confirmation, or
+        # the modal box above would come up under a wait cursor.
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            result = run_script(script, context)
+        finally:
+            QApplication.restoreOverrideCursor()
 
         if not result.ok:
             self.notify(f"{script.name} failed: {result.error}", "error")

--- a/fibsem/ui/widgets/script_runner.py
+++ b/fibsem/ui/widgets/script_runner.py
@@ -1,0 +1,140 @@
+"""Shared glue between user scripts and a Qt host.
+
+Owns everything the Scripts menu and the Scripts manager dialog both need —
+finding scripts, deciding whether one may run, running it, and rendering what it
+returned — so neither surface duplicates it.
+
+Knows nothing about experiments, microscopes or AutoLamella. A host supplies:
+
+* where the scripts live
+* a context factory — what to hand the script, or ``None`` if it cannot run now
+* a notifier — how to tell the user something
+
+See FIB-338.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Tuple
+
+import pandas as pd
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QWidget
+
+from fibsem.scripting import DiscoveredScript, ScriptResult, discover_scripts, run_script
+from fibsem.ui.utils import open_path_in_file_explorer
+
+# (context, reason). A context of None means "cannot run", and reason says why.
+ContextFactory = Callable[[], Tuple[Optional[Any], str]]
+# (message, level) where level is info/success/warning/error
+Notifier = Callable[[str, str], None]
+
+
+class ScriptRunner:
+    """Finds, runs and renders user scripts on behalf of a Qt host."""
+
+    def __init__(
+        self,
+        scripts_directory: Callable[[], Path],
+        context_factory: ContextFactory,
+        notify: Notifier,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        self.scripts_directory = scripts_directory
+        self.context_factory = context_factory
+        self.notify = notify
+        self.parent = parent
+
+    # --- discovery ---
+
+    def discover(self) -> List[DiscoveredScript]:
+        """Load the scripts fresh.
+
+        Not cached anywhere: editing a file and running it again picks up the
+        change, so "reload" is not a feature that needs to exist.
+        """
+        return discover_scripts(self.scripts_directory())
+
+    def availability(self) -> Tuple[bool, str]:
+        """Whether the host can run scripts right now, and why not if it cannot."""
+        _context, reason = self.context_factory()
+        return (not reason), reason
+
+    def open_folder(self) -> None:
+        """Create the scripts folder if needed and reveal it."""
+        directory = self.scripts_directory()
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            self.notify(f"Could not create {directory}: {e}", "error")
+            return
+        open_path_in_file_explorer(str(directory))
+
+    # --- running ---
+
+    def run(self, script: DiscoveredScript) -> Optional[ScriptResult]:
+        """Run one script and render whatever it returned.
+
+        Returns ``None`` when the script was refused rather than run.
+        """
+        context, reason = self.context_factory()
+        if context is None:
+            self.notify(reason or "Cannot run scripts right now.", "warning")
+            return None
+
+        if script.uses_microscope:
+            # The strict runner these need -- worker thread, hardware exclusion,
+            # cancellation, state restoration -- is FIB-340 and not built yet.
+            self.notify(
+                f"'{script.name}' declares uses_microscope, which is not supported yet.",
+                "warning",
+            )
+            return None
+        if script.background:
+            logging.warning(
+                "Script %s declares background=True; running inline for now.", script.name
+            )
+
+        result = run_script(script, context)
+
+        if not result.ok:
+            self.notify(f"{script.name} failed: {result.error}", "error")
+            return result
+
+        self.show_result(script, result.value)
+        return result
+
+    # --- rendering ---
+
+    def show_result(self, script: DiscoveredScript, value: Any) -> None:
+        """Render a script's return value.
+
+        The return value carries the output because there is typically no log
+        console in the app -- print() goes to a terminal the user may not have,
+        and a packaged Windows build has none at all. Without this a working
+        script looks like it did nothing.
+        """
+        if value is None:
+            self.notify(f"{script.name} finished.", "success")
+            return
+
+        if isinstance(value, pd.DataFrame):
+            self.show_dataframe(script.name, value)
+            return
+
+        if isinstance(value, Path):
+            self.notify(f"{script.name} wrote {value.name}", "success")
+            if value.exists():
+                open_path_in_file_explorer(str(value.parent))
+            return
+
+        self.notify(f"{script.name}: {value}", "success")
+
+    def show_dataframe(self, title: str, dataframe: pd.DataFrame) -> None:
+        from fibsem.ui.widgets.dataframe_table_widget import DataFrameTableWidget
+
+        dialog = QDialog(self.parent)
+        dialog.setWindowTitle(title)
+        dialog.resize(720, 420)
+        layout = QVBoxLayout(dialog)
+        layout.addWidget(DataFrameTableWidget(dataframe=dataframe, parent=dialog))
+        dialog.exec_()

--- a/fibsem/ui/widgets/script_runner.py
+++ b/fibsem/ui/widgets/script_runner.py
@@ -39,10 +39,19 @@ class ScriptRunner:
         notify: Notifier,
         parent: Optional[QWidget] = None,
     ) -> None:
-        self.scripts_directory = scripts_directory
+        self._scripts_directory = scripts_directory
+        self._directory_override: Optional[Path] = None
         self.context_factory = context_factory
         self.notify = notify
         self.parent = parent
+
+    def scripts_directory(self) -> Path:
+        """Where to look for scripts — the host's folder, or a chosen override."""
+        return self._directory_override or Path(self._scripts_directory())
+
+    def set_directory(self, directory: Optional[Path]) -> None:
+        """Point at a different folder for this session. ``None`` restores the host's."""
+        self._directory_override = Path(directory) if directory is not None else None
 
     # --- discovery ---
 

--- a/tests/autolamella/test_example_scripts.py
+++ b/tests/autolamella/test_example_scripts.py
@@ -1,0 +1,176 @@
+"""The shipped example scripts, executed rather than eyeballed.
+
+Every scripting example that was never run turned out to have a bug in it: one
+addressed ``lamella.state``, which does not exist, and another relied on
+``microscope.acquire_image`` honouring ``save=True``, which it does not -- so it
+claimed to write files and wrote none. Both looked completely reasonable on the
+page.
+
+That is why ``examples/scripts/`` holds real ``.py`` files instead of markdown
+snippets: they go through the same ``load_script`` / ``run_script`` path the GUI
+uses, against a real Experiment and a simulated microscope. If an example stops
+working, this fails.
+"""
+
+from pathlib import Path
+
+import pytest
+from psygnal.containers import EventedDict
+
+import fibsem.utils as utils
+from fibsem.applications.autolamella.scripting import ScriptContext
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.microscopes.simulator import DemoMicroscope
+from fibsem.scripting import load_script, run_script
+from fibsem.structures import FibsemStagePosition, MicroscopeState
+
+EXAMPLES = Path(__file__).resolve().parents[2] / "examples" / "scripts"
+
+# Named individually rather than globbed: a typo in the folder name would make a
+# glob quietly collect nothing and the suite would pass having tested nothing.
+EXPECTED = ["describe_lamellae", "export_summary", "survey_positions"]
+
+
+@pytest.fixture
+def experiment(tmp_path) -> Experiment:
+    exp = Experiment(path=tmp_path / "exp", name="exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    Path(exp.path).mkdir(parents=True, exist_ok=True)
+    for i in range(2):
+        exp.add_new_lamella(MicroscopeState(), EventedDict())
+        # a fresh lamella's milling pose has no coordinates, and moving to None
+        # is not something the examples should have to defend against
+        exp.positions[i].stage_position = FibsemStagePosition(
+            x=i * 100e-6, y=0.0, z=0.0, r=0.0, t=0.0, coordinate_system="RAW"
+        )
+    exp.save(save_protocol=True)
+    return exp
+
+
+@pytest.fixture(scope="module")
+def microscope() -> DemoMicroscope:
+    return DemoMicroscope(utils.load_microscope_configuration().system)
+
+
+def _context(experiment, microscope=None) -> ScriptContext:
+    return ScriptContext(experiment=experiment, microscope=microscope)
+
+
+def _load(name: str):
+    script = load_script(EXAMPLES / f"{name}.py")
+    assert script.is_runnable, f"{name} failed to load: {script.error}"
+    return script
+
+
+# ── the folder itself ────────────────────────────────────────────────────────
+
+def test_the_examples_folder_holds_exactly_the_documented_scripts():
+    """SCRIPTING.md points at these by name, so an added or renamed file needs the
+    docs updated in the same commit."""
+    found = sorted(p.stem for p in EXAMPLES.glob("*.py"))
+    assert found == sorted(EXPECTED)
+
+
+@pytest.mark.parametrize("name", EXPECTED)
+def test_every_example_loads_and_declares_a_docstring(name):
+    """The first docstring line becomes the description in the manager dialog, so
+    an example without one shows its own filename twice."""
+    script = _load(name)
+    assert script.description and script.description != script.name
+
+
+# ── one test per example, asserting the effect it advertises ─────────────────
+
+def test_export_summary_writes_a_csv_with_a_row_per_lamella(experiment):
+    script = _load("export_summary")
+
+    result = run_script(script, _context(experiment))
+
+    assert result.ok, result.error
+    assert isinstance(result.value, Path) and result.value.exists()
+    assert result.value.parent == Path(experiment.path)
+    # header + one row per lamella
+    assert len(result.value.read_text().strip().splitlines()) == len(experiment.positions) + 1
+
+
+def test_export_summary_does_not_declare_itself_a_writer(experiment):
+    """It is the read-only example. If it ever grows a `writes` flag the point of
+    having three tiers is gone."""
+    script = _load("export_summary")
+    assert not script.writes
+    assert not script.uses_microscope
+
+    result = run_script(script, _context(experiment))
+
+    assert result.saved is False
+
+
+def test_describe_lamellae_sets_descriptions_and_asks_to_be_saved(experiment):
+    script = _load("describe_lamellae")
+    assert script.writes
+
+    result = run_script(script, _context(experiment))
+
+    assert result.ok, result.error
+    assert result.saved is True  # run_script called ctx.save() because of the flag
+    assert all(lamella.description for lamella in experiment.positions)
+    assert "no tasks completed yet" in experiment.positions[0].description
+
+
+def test_describe_lamellae_is_idempotent(experiment):
+    """Second run changes nothing, so re-running it is not a way to dirty the
+    experiment. The example short-circuits on an unchanged description."""
+    script = _load("describe_lamellae")
+
+    first = run_script(script, _context(experiment))
+    second = run_script(script, _context(experiment))
+
+    assert first.ok and second.ok
+    assert "described 2 of 2" in first.value
+    assert "described 0 of 2" in second.value
+
+
+def test_describe_lamellae_fires_the_events_the_ui_listens_to(experiment):
+    """The example claims in a comment that the GUI updates as it runs. That is
+    only true if `description` actually emits, so pin it here rather than trust
+    the comment."""
+    seen = []
+    for lamella in experiment.positions:
+        lamella.events.description.connect(lambda *_: seen.append(1))
+
+    run_script(_load("describe_lamellae"), _context(experiment))
+
+    assert len(seen) == len(experiment.positions)
+
+
+def test_survey_positions_acquires_an_image_per_lamella(experiment, microscope):
+    script = _load("survey_positions")
+    assert script.uses_microscope
+
+    result = run_script(script, _context(experiment, microscope))
+
+    assert result.ok, result.error
+    for lamella in experiment.positions:
+        written = list(Path(lamella.path).glob("survey*"))
+        assert written, f"no survey image written for {lamella.name}"
+
+
+def test_survey_positions_stops_when_asked(experiment, microscope):
+    """Cancellation is cooperative, so this only passes because the example calls
+    ctx.raise_if_cancelled(). Delete that line and this test is what notices."""
+    import threading
+
+    from fibsem.cancellation import OperationCancelledError
+
+    context = _context(experiment, microscope)
+    context.stop_event = threading.Event()
+    context.stop_event.set()  # already cancelled before the first iteration
+
+    result = run_script(_load("survey_positions"), context)
+
+    assert isinstance(result.error, OperationCancelledError)
+    for lamella in experiment.positions:
+        assert not list(Path(lamella.path).glob("survey*"))

--- a/tests/autolamella/test_scripting.py
+++ b/tests/autolamella/test_scripting.py
@@ -1,6 +1,5 @@
 """Tier 1 user scripts: discovery, flags, and the runner (FIB-338)."""
 
-import os
 import threading
 from pathlib import Path
 
@@ -11,12 +10,10 @@ from fibsem.cancellation import OperationCancelledError
 from fibsem.applications.autolamella.scripting import (
     DEFAULT_SCRIPTS_DIR,
     SCRIPTS_DIR_ENV_VAR,
-    SCRIPTS_ENABLED_ENV_VAR,
     ScriptContext,
     discover_scripts,
     get_scripts_directory,
     run_script,
-    scripts_enabled,
 )
 from fibsem.applications.autolamella.structures import (
     AutoLamellaTaskProtocol,
@@ -56,29 +53,6 @@ def test_scripts_directory_env_override(monkeypatch, tmp_path):
 
 def test_missing_directory_is_not_an_error(tmp_path):
     assert discover_scripts(tmp_path / "nope") == []
-
-
-# ── the feature flag ─────────────────────────────────────────────────────────
-
-def test_scripts_are_off_unless_asked_for(monkeypatch):
-    """A script runs with the application's hardware access and none of its guard
-    rails, so nobody gets the feature by simply upgrading."""
-    monkeypatch.delenv(SCRIPTS_ENABLED_ENV_VAR, raising=False)
-    assert scripts_enabled() is False
-
-
-@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " 1 "])
-def test_the_flag_accepts_the_obvious_spellings(monkeypatch, value):
-    monkeypatch.setenv(SCRIPTS_ENABLED_ENV_VAR, value)
-    assert scripts_enabled() is True
-
-
-@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "ture", "enabled"])
-def test_anything_unrecognised_leaves_the_flag_off(monkeypatch, value):
-    """Including "ture" and "enabled": a typo in the value must fail closed, not
-    quietly switch the feature on."""
-    monkeypatch.setenv(SCRIPTS_ENABLED_ENV_VAR, value)
-    assert scripts_enabled() is False
 
 
 # ── discovery ────────────────────────────────────────────────────────────────

--- a/tests/autolamella/test_scripting.py
+++ b/tests/autolamella/test_scripting.py
@@ -1,11 +1,13 @@
 """Tier 1 user scripts: discovery, flags, and the runner (FIB-338)."""
 
 import os
+import threading
 from pathlib import Path
 
 import pytest
 from psygnal.containers import EventedDict
 
+from fibsem.cancellation import OperationCancelledError
 from fibsem.applications.autolamella.scripting import (
     DEFAULT_SCRIPTS_DIR,
     SCRIPTS_DIR_ENV_VAR,
@@ -188,3 +190,20 @@ def test_an_unrunnable_script_returns_an_error_result(tmp_path):
 def test_ctx_path_is_the_experiment_directory(tmp_path):
     exp = _experiment(tmp_path)
     assert ScriptContext(experiment=exp).path == Path(exp.path)
+
+
+def test_ctx_cancellation_is_inert_without_a_stop_event(tmp_path):
+    """A headless run has no one to press Stop, so the same script must still work."""
+    ctx = ScriptContext(experiment=_experiment(tmp_path))
+
+    assert ctx.cancelled is False
+    ctx.raise_if_cancelled()  # must not raise
+
+
+def test_ctx_raise_if_cancelled_aborts_once_the_event_is_set(tmp_path):
+    ctx = ScriptContext(experiment=_experiment(tmp_path), stop_event=threading.Event())
+    ctx.stop_event.set()
+
+    assert ctx.cancelled is True
+    with pytest.raises(OperationCancelledError):
+        ctx.raise_if_cancelled()

--- a/tests/autolamella/test_scripting.py
+++ b/tests/autolamella/test_scripting.py
@@ -11,10 +11,12 @@ from fibsem.cancellation import OperationCancelledError
 from fibsem.applications.autolamella.scripting import (
     DEFAULT_SCRIPTS_DIR,
     SCRIPTS_DIR_ENV_VAR,
+    SCRIPTS_ENABLED_ENV_VAR,
     ScriptContext,
     discover_scripts,
     get_scripts_directory,
     run_script,
+    scripts_enabled,
 )
 from fibsem.applications.autolamella.structures import (
     AutoLamellaTaskProtocol,
@@ -54,6 +56,29 @@ def test_scripts_directory_env_override(monkeypatch, tmp_path):
 
 def test_missing_directory_is_not_an_error(tmp_path):
     assert discover_scripts(tmp_path / "nope") == []
+
+
+# ── the feature flag ─────────────────────────────────────────────────────────
+
+def test_scripts_are_off_unless_asked_for(monkeypatch):
+    """A script runs with the application's hardware access and none of its guard
+    rails, so nobody gets the feature by simply upgrading."""
+    monkeypatch.delenv(SCRIPTS_ENABLED_ENV_VAR, raising=False)
+    assert scripts_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " 1 "])
+def test_the_flag_accepts_the_obvious_spellings(monkeypatch, value):
+    monkeypatch.setenv(SCRIPTS_ENABLED_ENV_VAR, value)
+    assert scripts_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "ture", "enabled"])
+def test_anything_unrecognised_leaves_the_flag_off(monkeypatch, value):
+    """Including "ture" and "enabled": a typo in the value must fail closed, not
+    quietly switch the feature on."""
+    monkeypatch.setenv(SCRIPTS_ENABLED_ENV_VAR, value)
+    assert scripts_enabled() is False
 
 
 # ── discovery ────────────────────────────────────────────────────────────────

--- a/tests/autolamella/test_scripting.py
+++ b/tests/autolamella/test_scripting.py
@@ -1,0 +1,190 @@
+"""Tier 1 user scripts: discovery, flags, and the runner (FIB-338)."""
+
+import os
+from pathlib import Path
+
+import pytest
+from psygnal.containers import EventedDict
+
+from fibsem.applications.autolamella.scripting import (
+    DEFAULT_SCRIPTS_DIR,
+    SCRIPTS_DIR_ENV_VAR,
+    ScriptContext,
+    discover_scripts,
+    get_scripts_directory,
+    run_script,
+)
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.structures import MicroscopeState
+
+
+def _experiment(tmp_path: Path) -> Experiment:
+    exp = Experiment(path=tmp_path / "exp-root", name="exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    Path(exp.path).mkdir(parents=True, exist_ok=True)
+    exp.add_new_lamella(MicroscopeState(), EventedDict())
+    exp.save(save_protocol=True)
+    return exp
+
+
+def _write(directory: Path, name: str, body: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(body)
+    return path
+
+
+# ── directory resolution ─────────────────────────────────────────────────────
+
+def test_scripts_directory_defaults_under_home(monkeypatch):
+    monkeypatch.delenv(SCRIPTS_DIR_ENV_VAR, raising=False)
+    assert get_scripts_directory() == DEFAULT_SCRIPTS_DIR
+
+
+def test_scripts_directory_env_override(monkeypatch, tmp_path):
+    """Shared microscope PCs need to point this elsewhere."""
+    monkeypatch.setenv(SCRIPTS_DIR_ENV_VAR, str(tmp_path / "custom"))
+    assert get_scripts_directory() == tmp_path / "custom"
+
+
+def test_missing_directory_is_not_an_error(tmp_path):
+    assert discover_scripts(tmp_path / "nope") == []
+
+
+# ── discovery ────────────────────────────────────────────────────────────────
+
+def test_docstring_becomes_the_description(tmp_path):
+    _write(tmp_path, "export.py", '"""Export a summary."""\ndef run(ctx):\n    return "ok"\n')
+    script = discover_scripts(tmp_path)[0]
+    assert script.name == "export"
+    assert script.description == "Export a summary."
+    assert script.is_runnable
+
+
+def test_a_file_without_run_is_reported_not_hidden(tmp_path):
+    """Silently omitting it is the failure this is meant to avoid — the author
+    sees nothing and assumes the folder is wrong."""
+    _write(tmp_path, "broken.py", "def main(ctx):\n    return 1\n")
+    script = discover_scripts(tmp_path)[0]
+    assert not script.is_runnable
+    assert "run()" in script.error
+
+
+def test_a_file_that_raises_on_import_is_reported_not_hidden(tmp_path):
+    _write(tmp_path, "boom.py", "raise ValueError('bad import')\n")
+    script = discover_scripts(tmp_path)[0]
+    assert not script.is_runnable
+    assert "bad import" in script.error
+
+
+def test_flags_are_read_from_the_module(tmp_path):
+    _write(tmp_path, "flags.py",
+           "writes = True\nbackground = True\nuses_microscope = True\n"
+           "on_workflow_completed = True\ndef run(ctx):\n    pass\n")
+    script = discover_scripts(tmp_path)[0]
+    assert (script.writes, script.background) == (True, True)
+    assert (script.uses_microscope, script.on_workflow_completed) == (True, True)
+
+
+def test_flags_default_to_false(tmp_path):
+    _write(tmp_path, "plain.py", "def run(ctx):\n    pass\n")
+    script = discover_scripts(tmp_path)[0]
+    assert not any([script.writes, script.background,
+                    script.uses_microscope, script.on_workflow_completed])
+
+
+def test_same_filename_in_two_folders_does_not_collide(tmp_path):
+    """Scripts are loaded under synthetic names and kept out of sys.modules."""
+    _write(tmp_path / "a", "dup.py", 'def run(ctx):\n    return "A"\n')
+    _write(tmp_path / "b", "dup.py", 'def run(ctx):\n    return "B"\n')
+    a = discover_scripts(tmp_path / "a")[0]
+    b = discover_scripts(tmp_path / "b")[0]
+    assert a._module is not b._module
+    assert (a._module.run(None), b._module.run(None)) == ("A", "B")
+
+
+def test_underscore_files_are_skipped(tmp_path):
+    _write(tmp_path, "_helper.py", "def run(ctx):\n    pass\n")
+    _write(tmp_path, "real.py", "def run(ctx):\n    pass\n")
+    assert [s.name for s in discover_scripts(tmp_path)] == ["real"]
+
+
+def test_edits_are_picked_up_without_a_reload_step(tmp_path):
+    """Scripts are not cached, so edit-then-run just works."""
+    path = _write(tmp_path, "edit.py", 'def run(ctx):\n    return "before"\n')
+    assert discover_scripts(tmp_path)[0]._module.run(None) == "before"
+    path.write_text('def run(ctx):\n    return "after"\n')
+    assert discover_scripts(tmp_path)[0]._module.run(None) == "after"
+
+
+# ── running ──────────────────────────────────────────────────────────────────
+
+def test_run_passes_the_experiment_and_returns_the_value(tmp_path):
+    exp = _experiment(tmp_path)
+    _write(tmp_path / "s", "names.py",
+           "def run(ctx):\n    return [p.name for p in ctx.experiment.positions]\n")
+    script = discover_scripts(tmp_path / "s")[0]
+
+    result = run_script(script, ScriptContext(experiment=exp))
+
+    assert result.ok
+    assert result.value == [p.name for p in exp.positions]
+
+
+def test_a_failing_script_is_captured_not_raised(tmp_path):
+    """This runs from a Qt slot, and PyQt5 aborts the process on any exception
+    that escapes one (FIB-329)."""
+    exp = _experiment(tmp_path)
+    _write(tmp_path / "s", "bad.py", "def run(ctx):\n    raise RuntimeError('nope')\n")
+    script = discover_scripts(tmp_path / "s")[0]
+
+    result = run_script(script, ScriptContext(experiment=exp))
+
+    assert not result.ok
+    assert isinstance(result.error, RuntimeError)
+
+
+def test_writes_flag_persists_the_change(tmp_path):
+    exp = _experiment(tmp_path)
+    _write(tmp_path / "s", "mark.py",
+           "writes = True\n"
+           "def run(ctx):\n    ctx.experiment.positions[0].defect.set_defect('bad')\n")
+    script = discover_scripts(tmp_path / "s")[0]
+
+    result = run_script(script, ScriptContext(experiment=exp))
+
+    assert result.saved
+    reloaded = Experiment.load(str(Path(exp.path) / "experiment.yaml"))
+    assert reloaded.positions[0].is_failure
+
+
+def test_without_the_writes_flag_nothing_is_persisted(tmp_path):
+    """A read-only script must not rewrite the experiment yaml by accident."""
+    exp = _experiment(tmp_path)
+    _write(tmp_path / "s", "sneaky.py",
+           "def run(ctx):\n    ctx.experiment.positions[0].defect.set_defect('bad')\n")
+    script = discover_scripts(tmp_path / "s")[0]
+
+    result = run_script(script, ScriptContext(experiment=exp))
+
+    assert not result.saved
+    reloaded = Experiment.load(str(Path(exp.path) / "experiment.yaml"))
+    assert not reloaded.positions[0].is_failure
+
+
+def test_an_unrunnable_script_returns_an_error_result(tmp_path):
+    exp = _experiment(tmp_path)
+    _write(tmp_path / "s", "broken.py", "def main(ctx):\n    pass\n")
+    script = discover_scripts(tmp_path / "s")[0]
+
+    result = run_script(script, ScriptContext(experiment=exp))
+
+    assert not result.ok
+
+
+def test_ctx_path_is_the_experiment_directory(tmp_path):
+    exp = _experiment(tmp_path)
+    assert ScriptContext(experiment=exp).path == Path(exp.path)

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -68,7 +68,9 @@ def test_lists_runnable_and_failed_together(qapp, tmp_path):
     dialog = _dialog(tmp_path, context=FakeContext())
 
     assert dialog.table.rowCount() == 2
-    assert dialog.title_label.text() == "1 script, 1 failed to load"
+    # the heading says what the dialog is; the counts are meta beneath it
+    assert dialog.title_label.text() == "User scripts"
+    assert "1 script, 1 failed to load" in dialog.meta_label.text()
 
 
 def test_the_failure_reason_is_shown_in_the_row(qapp, tmp_path):
@@ -186,3 +188,86 @@ def test_the_type_tooltip_spells_out_the_flags(qapp, tmp_path):
     tooltip = dialog.table.cellWidget(0, 1).toolTip()
 
     assert "saves the experiment" in tooltip
+
+
+def test_selection_survives_running_a_script(qapp, tmp_path):
+    """Running one used to bounce the selection back to the top of the list."""
+    for name in ("a.py", "b.py", "c.py"):
+        _write(tmp_path, name, "def run(ctx):\n    return 'ok'\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(_row_of(dialog, "b"))
+
+    dialog.run_selected()
+
+    assert dialog.selected_script().name == "b"
+
+
+def test_rebuilding_does_not_stack_cell_widgets(qapp, tmp_path):
+    """setRowCount alone leaves the previous build's widgets parented to the
+    viewport, so rows drew on top of each other."""
+    from PyQt5.QtWidgets import QLabel
+
+    _write(tmp_path, "a.py", '"""One."""\ndef run(ctx):\n    pass\n')
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    for _ in range(3):
+        dialog.refresh()
+
+    # name + description, not three builds' worth
+    assert len(dialog.table.cellWidget(0, 0).findChildren(QLabel)) == 2
+
+
+def test_change_folder_switches_the_listing(qapp, tmp_path):
+    _write(tmp_path / "first", "one.py", "def run(ctx):\n    pass\n")
+    _write(tmp_path / "second", "two.py", "def run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path / "first", context=FakeContext())
+    assert [s.name for s in dialog.scripts] == ["one"]
+
+    dialog.runner.set_directory(tmp_path / "second")
+    dialog.refresh(keep_selection=False)
+
+    assert [s.name for s in dialog.scripts] == ["two"]
+
+
+def test_new_script_creates_a_runnable_stub(qapp, tmp_path, monkeypatch):
+    from PyQt5.QtWidgets import QInputDialog
+
+    monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("fresh", True))
+    monkeypatch.setattr(
+        "fibsem.ui.widgets.script_manager_dialog.open_path_in_file_explorer",
+        lambda path: None,
+    )
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    dialog.new_script()
+
+    assert (tmp_path / "fresh.py").exists()
+    assert "fresh" in [s.name for s in dialog.scripts]
+    # the stub must actually load, or the first thing a user sees is an error
+    assert dialog.scripts[_row_of(dialog, "fresh")].is_runnable
+
+
+def test_new_script_refuses_to_overwrite(qapp, tmp_path, monkeypatch):
+    from PyQt5.QtWidgets import QInputDialog
+
+    _write(tmp_path, "taken.py", "def run(ctx):\n    return 'original'\n")
+    monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("taken", True))
+    notes = []
+    dialog = _dialog(tmp_path, context=FakeContext(), notes=notes)
+
+    dialog.new_script()
+
+    assert "original" in (tmp_path / "taken.py").read_text()
+    assert notes and notes[-1][0] == "warning"
+
+
+def test_the_folder_is_elided_but_kept_whole_in_the_tooltip(qapp, tmp_path):
+    """The path is far longer than anything else and would otherwise dictate the
+    dialog's width."""
+    deep = tmp_path / ("nested/" * 12).rstrip("/")
+    _write(deep, "s.py", "def run(ctx):\n    pass\n")
+    dialog = _dialog(deep, context=FakeContext())
+    dialog.show()
+
+    assert "…" in dialog.meta_label.text()
+    assert str(deep) == dialog.meta_label.toolTip()

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -91,7 +91,34 @@ def test_a_writing_script_warns_in_the_detail_panel(qapp, tmp_path):
     _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
     dialog = _dialog(tmp_path, context=FakeContext())
     dialog.table.selectRow(0)
-    assert "saves it when finished" in dialog.detail_label.text()
+    # the consequence sits opposite the facts; the chip-length phrase is on
+    # screen and the full sentence is in the tooltip
+    assert "Modifies and saves" in dialog.consequence_label.text()
+    assert "saves it when it finishes" in dialog.consequence_label.toolTip()
+
+
+def test_a_read_only_script_says_so(qapp, tmp_path):
+    """Silence would leave the user guessing whether it writes."""
+    _write(tmp_path, "r.py", "def run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+    assert "Read-only" in dialog.consequence_label.text()
+
+
+def test_an_empty_folder_says_how_to_start(qapp, tmp_path):
+    dialog = _dialog(tmp_path, context=FakeContext())
+    assert "New script" in dialog.detail_label.text()
+
+
+def test_the_last_run_stamp_is_12_hour(qapp, tmp_path):
+    _write(tmp_path, "s.py", "def run(ctx):\n    return 'ok'\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+
+    dialog.run_selected()
+
+    stamp = _cell_text(dialog, 0, 2)
+    assert "am" in stamp or "pm" in stamp
 
 
 def test_source_and_hash_are_shown(qapp, tmp_path):

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -1,0 +1,188 @@
+"""The Scripts manager dialog, driven without an application around it (FIB-338)."""
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.ui.widgets.script_manager_dialog import ScriptManagerDialog  # noqa: E402
+from fibsem.ui.widgets.script_runner import ScriptRunner  # noqa: E402
+
+
+@pytest.fixture
+def qapp():
+    from PyQt5.QtWidgets import QApplication
+    yield QApplication.instance() or QApplication([])
+
+
+class FakeContext:
+    def __init__(self):
+        self.saved = False
+
+    def save(self):
+        self.saved = True
+
+
+def _write(directory: Path, name: str, body: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(body)
+    return path
+
+
+def _dialog(tmp_path, context=None, reason="", notes=None):
+    runner = ScriptRunner(
+        scripts_directory=lambda: tmp_path,
+        context_factory=lambda: (context, reason),
+        notify=lambda m, l: (notes if notes is not None else []).append((l, m)),
+    )
+    return ScriptManagerDialog(runner=runner)
+
+
+def _row_of(dialog, name: str) -> int:
+    return [s.name for s in dialog.scripts].index(name)
+
+
+def _cell_text(dialog, row: int, col: int) -> str:
+    """Read a cell whether it holds a plain item or a widget.
+
+    Name and type cells are widgets, because a QTableWidgetItem cannot carry a
+    two-line layout or a pill background.
+    """
+    from PyQt5.QtWidgets import QLabel
+
+    widget = dialog.table.cellWidget(row, col)
+    if widget is not None:
+        return " ".join(label.text() for label in widget.findChildren(QLabel))
+    item = dialog.table.item(row, col)
+    return item.text() if item is not None else ""
+
+
+def test_lists_runnable_and_failed_together(qapp, tmp_path):
+    """The failed one is a row, not an omission -- a menu has nowhere to put the
+    reason, which is the whole point of this dialog existing."""
+    _write(tmp_path, "good.py", '"""Fine."""\ndef run(ctx):\n    pass\n')
+    _write(tmp_path, "bad.py", "def main(ctx):\n    pass\n")
+
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    assert dialog.table.rowCount() == 2
+    assert dialog.title_label.text() == "1 script, 1 failed to load"
+
+
+def test_the_failure_reason_is_shown_in_the_row(qapp, tmp_path):
+    _write(tmp_path, "bad.py", "def main(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    assert "run()" in _cell_text(dialog, 0, 0)
+    assert "Error" in _cell_text(dialog, 0, 1)
+
+
+def test_flags_appear_in_the_type_cell(qapp, tmp_path):
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    assert "writes" in _cell_text(dialog, 0, 1)
+
+
+def test_a_writing_script_warns_in_the_detail_panel(qapp, tmp_path):
+    """The consequence has to be stated before Run is pressed."""
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+    assert "saves it when finished" in dialog.detail_label.text()
+
+
+def test_source_and_hash_are_shown(qapp, tmp_path):
+    """Users edit these in place, so 'which version ran' is otherwise unanswerable."""
+    _write(tmp_path, "s.py", "def run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+    assert "s.py" in dialog.detail_label.text()
+    assert dialog.scripts[0].content_hash in dialog.detail_label.text()
+
+
+def test_run_is_disabled_for_a_broken_script(qapp, tmp_path):
+    _write(tmp_path, "bad.py", "def main(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+    assert not dialog.run_button.isEnabled()
+
+
+def test_run_is_disabled_for_a_microscope_script(qapp, tmp_path):
+    """The runner would refuse it (FIB-340); a button that only complains is worse
+    than one that is visibly unavailable."""
+    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+    assert not dialog.run_button.isEnabled()
+
+
+def test_run_is_disabled_and_explained_when_the_host_is_not_ready(qapp, tmp_path):
+    _write(tmp_path, "s.py", "def run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=None, reason="Load an experiment")
+    dialog.table.selectRow(0)
+    assert not dialog.run_button.isEnabled()
+    assert dialog.hint_label.text() == "Load an experiment"
+
+
+def test_running_records_the_outcome_in_the_last_run_column(qapp, tmp_path):
+    _write(tmp_path, "s.py", "def run(ctx):\n    return 'done'\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+
+    dialog.run_selected()
+
+    assert "ok" in _cell_text(dialog, 0, 2)
+
+
+def test_a_failing_run_is_recorded_as_failed(qapp, tmp_path):
+    _write(tmp_path, "s.py", "def run(ctx):\n    raise RuntimeError('nope')\n")
+    notes = []
+    dialog = _dialog(tmp_path, context=FakeContext(), notes=notes)
+    dialog.table.selectRow(0)
+
+    dialog.run_selected()
+
+    assert "failed" in _cell_text(dialog, 0, 2)
+    assert notes and notes[-1][0] == "error"
+
+
+def test_rescan_picks_up_a_new_file(qapp, tmp_path):
+    _write(tmp_path, "one.py", "def run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    assert dialog.table.rowCount() == 1
+
+    _write(tmp_path, "two.py", "def run(ctx):\n    pass\n")
+    dialog.refresh()
+
+    assert dialog.table.rowCount() == 2
+
+
+def test_empty_folder_renders_without_a_selection(qapp, tmp_path):
+    dialog = _dialog(tmp_path, context=FakeContext())
+    assert dialog.table.rowCount() == 0
+    assert dialog.selected_script() is None
+    assert not dialog.run_button.isEnabled()
+
+
+def test_the_row_tooltip_carries_the_full_path(qapp, tmp_path):
+    """The header shows the folder and the detail panel the filename, so the
+    absolute path is the one thing you otherwise cannot read off the dialog --
+    and it is what you need in order to go and edit the file."""
+    path = _write(tmp_path, "s.py", "def run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    tooltip = dialog.table.cellWidget(0, 0).toolTip()
+
+    assert str(path) in tooltip
+    assert dialog.scripts[0].content_hash in tooltip
+
+
+def test_the_type_tooltip_spells_out_the_flags(qapp, tmp_path):
+    """Chips are shorthand; the tooltip says what they actually mean."""
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    tooltip = dialog.table.cellWidget(0, 1).toolTip()
+
+    assert "saves the experiment" in tooltip

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -1,5 +1,6 @@
 """The Scripts manager dialog, driven without an application around it (FIB-338)."""
 
+import time
 from pathlib import Path
 
 import pytest
@@ -19,9 +20,27 @@ def qapp():
 class FakeContext:
     def __init__(self):
         self.saved = False
+        self.stop_event = None  # the runner injects one for threaded scripts
 
     def save(self):
         self.saved = True
+
+    def raise_if_cancelled(self):
+        from fibsem.cancellation import raise_if_cancelled
+        raise_if_cancelled(self.stop_event)
+
+
+def _drain(qapp, predicate, timeout=5.0):
+    """Pump the Qt event loop until predicate() is true, or give up.
+
+    Threaded scripts report back through a queued signal, so nothing lands unless
+    the loop runs.
+    """
+    deadline = time.monotonic() + timeout
+    while not predicate() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.005)
+    return predicate()
 
 
 def _write(directory: Path, name: str, body: str) -> Path:
@@ -139,13 +158,45 @@ def test_run_is_disabled_for_a_broken_script(qapp, tmp_path):
     assert not dialog.run_button.isEnabled()
 
 
-def test_run_is_disabled_for_a_microscope_script(qapp, tmp_path):
-    """The runner would refuse it (FIB-340); a button that only complains is worse
-    than one that is visibly unavailable."""
+def test_a_microscope_script_can_be_run_and_says_what_it_will_do(qapp, tmp_path):
     _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
     dialog = _dialog(tmp_path, context=FakeContext())
     dialog.table.selectRow(0)
-    assert not dialog.run_button.isEnabled()
+
+    assert dialog.run_button.isEnabled()
+    assert "Drives the microscope" in dialog.consequence_label.text()
+    # the warning has to be specific about what is missing, not just "careful"
+    assert "no limits, no interlocks" in dialog.consequence_label.toolTip()
+
+
+def test_run_becomes_stop_while_a_script_is_running(qapp, tmp_path):
+    """A microscope script runs for minutes. Without this the dialog looks idle
+    and the only way to stop it is to kill the app."""
+    _write(tmp_path, "slow.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(3)\n"
+           "    ctx.raise_if_cancelled()\n"
+           "    return 'ran to completion'\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+
+    dialog.run_selected()
+    assert _drain(qapp, lambda: dialog.runner.is_running)
+    assert dialog.run_button.text() == "Stop script"
+    assert dialog.run_button.isEnabled()
+    # nothing that would start a second run or move the ground under this one
+    assert not dialog.table.isEnabled()
+    assert not dialog.change_folder_button.isEnabled()
+
+    dialog.run_selected()  # the same button, now Stop
+
+    # not `not is_running` -- the thread dies before its result is delivered, so
+    # that would pass while the dialog is still mid-teardown
+    assert _drain(qapp, lambda: "slow" in dialog.last_run)
+    assert dialog.run_button.text() == "Run script"
+    assert dialog.table.isEnabled()
+    assert "cancelled" in dialog.last_run["slow"]
 
 
 def test_run_is_disabled_and_explained_when_the_host_is_not_ready(qapp, tmp_path):

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -394,25 +394,6 @@ def test_the_auto_flag_says_it_is_not_connected(qapp, tmp_path):
     assert "not run automatically yet" in dialog.consequence_label.toolTip()
 
 
-def test_the_menu_does_not_label_a_script_auto(qapp, tmp_path):
-    """A menu has nowhere to explain the caveat, so it leaves the flag out."""
-    from PyQt5.QtWidgets import QMenu
-
-    from fibsem.ui.widgets.script_menu import ScriptMenuController
-
-    _write(tmp_path, "a.py", "on_workflow_completed = True\ndef run(ctx):\n    pass\n")
-    menu = QMenu()
-    controller = ScriptMenuController(
-        menu=menu,
-        scripts_directory=lambda: tmp_path,
-        context_factory=lambda: (FakeContext(), ""),
-        notify=lambda m, l: None,
-    )
-    controller.rebuild()
-
-    assert not any("auto" in a.text() for a in menu.actions())
-
-
 def test_every_chip_carries_a_dot(qapp, tmp_path):
     """Type and flag chips looked like different kinds of thing for no readable
     reason. Colour separates them; shape should not."""

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -151,6 +151,20 @@ def test_a_plain_data_script_gets_no_type_chip(qapp, tmp_path):
     assert "Type: Data" in cell.toolTip()
 
 
+def test_a_microscope_script_that_also_writes_admits_to_both(qapp, tmp_path):
+    """Only the worse of the two fits on the line, so the tooltip is the only place
+    the second half can be stated -- and it was silently dropped."""
+    _write(tmp_path, "both.py",
+           "uses_microscope = True\nwrites = True\ndef run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+
+    assert "Controls the microscope" in dialog.consequence_label.text()
+    tip = dialog.consequence_label.toolTip()
+    assert "no limits, no interlocks" in tip
+    assert "saves it when it finishes" in tip
+
+
 def test_the_consequence_line_matches_its_chip(qapp, tmp_path):
     """One script, one colour. The line under the table used to be red while the
     row's chip was amber, so the same fact arrived twice in two severities."""
@@ -181,9 +195,42 @@ def test_only_a_broken_script_is_red(qapp, tmp_path):
     assert _ERROR in dialog.consequence_label.text()
 
 
-def test_an_empty_folder_says_how_to_start(qapp, tmp_path):
+def test_an_empty_folder_says_how_to_start_where_you_are_looking(qapp, tmp_path):
+    """The message replaces the table rather than sitting under 450px of empty grid
+    with the one useful sentence stranded in the detail panel at the bottom."""
     dialog = _dialog(tmp_path, context=FakeContext())
-    assert "New script" in dialog.detail_label.text()
+
+    from PyQt5.QtWidgets import QLabel
+    shown = dialog.stack.currentWidget()
+    text = " ".join(label.text() for label in shown.findChildren(QLabel))
+
+    assert shown is not dialog.table
+    assert "No scripts in this folder" in text
+    assert "New script" in text and "Change folder" in text
+
+
+def test_the_empty_message_is_not_also_repeated_in_the_detail_panel(qapp, tmp_path):
+    """It used to be the only place it appeared; now it would be the second. The
+    panel hides rather than sitting there as an empty bordered strip."""
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.show()
+
+    assert "New script" not in dialog.detail_label.text()
+    assert not dialog.detail_panel.isVisible()
+
+    _write(tmp_path, "s.py", "def run(ctx):\n    pass\n")
+    dialog.refresh()
+    assert dialog.detail_panel.isVisible()
+
+
+def test_the_table_comes_back_once_a_script_exists(qapp, tmp_path):
+    dialog = _dialog(tmp_path, context=FakeContext())
+    assert dialog.stack.currentWidget() is not dialog.table
+
+    _write(tmp_path, "s.py", "def run(ctx):\n    pass\n")
+    dialog.refresh()
+
+    assert dialog.stack.currentWidget() is dialog.table
 
 
 def test_the_last_run_stamp_is_12_hour(qapp, tmp_path):

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -209,6 +209,23 @@ def test_an_empty_folder_says_how_to_start_where_you_are_looking(qapp, tmp_path)
     assert "New script" in text and "Change folder" in text
 
 
+def test_the_empty_state_points_at_the_worked_examples(qapp, tmp_path):
+    """examples/scripts/ is not in the wheel, so a pip-installed user has no local
+    copy and no way to know three of them exist. Saying "repository" is the point:
+    without it the only advice is to write one from scratch."""
+    from fibsem.ui.widgets.script_manager_dialog import EXAMPLES_PATH
+
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    from PyQt5.QtWidgets import QLabel
+    text = " ".join(
+        label.text() for label in dialog.stack.currentWidget().findChildren(QLabel)
+    )
+
+    assert EXAMPLES_PATH in text
+    assert "repository" in text
+
+
 def test_the_empty_message_is_not_also_repeated_in_the_detail_panel(qapp, tmp_path):
     """It used to be the only place it appeared; now it would be the second. The
     panel hides rather than sitting there as an empty bordered strip."""

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -104,7 +104,7 @@ def test_the_failure_reason_is_shown_in_the_row(qapp, tmp_path):
 def test_flags_appear_in_the_type_cell(qapp, tmp_path):
     _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
     dialog = _dialog(tmp_path, context=FakeContext())
-    assert "writes" in _cell_text(dialog, 0, 1)
+    assert "Writes" in _cell_text(dialog, 0, 1)
 
 
 def test_a_writing_script_warns_in_the_detail_panel(qapp, tmp_path):
@@ -124,6 +124,61 @@ def test_a_read_only_script_says_so(qapp, tmp_path):
     dialog = _dialog(tmp_path, context=FakeContext())
     dialog.table.selectRow(0)
     assert "Read-only" in dialog.consequence_label.text()
+
+
+def test_the_type_column_survives_a_folder_with_no_chips(qapp, tmp_path):
+    """Dropping the Data chip meant an all-plain folder had nothing to measure, so
+    the column collapsed to 28px and clipped its own header."""
+    _write(tmp_path, "a.py", "def run(ctx):\n    pass\n")
+    _write(tmp_path, "b.py", "def run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    header = dialog.table.horizontalHeader()
+    assert dialog.table.columnWidth(1) >= header.fontMetrics().horizontalAdvance("Type")
+
+
+def test_a_plain_data_script_gets_no_type_chip(qapp, tmp_path):
+    """Data is the default, so a chip for it sat on nearly every row and separated
+    nothing. An empty Type cell means "touches nothing unusual"; the word survives
+    in the tooltip, where it costs no width."""
+    _write(tmp_path, "plain.py", '"""Read some numbers."""\ndef run(ctx):\n    pass\n')
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    from PyQt5.QtWidgets import QLabel
+    cell = dialog.table.cellWidget(0, 1)
+
+    assert cell.findChildren(QLabel) == []
+    assert "Type: Data" in cell.toolTip()
+
+
+def test_the_consequence_line_matches_its_chip(qapp, tmp_path):
+    """One script, one colour. The line under the table used to be red while the
+    row's chip was amber, so the same fact arrived twice in two severities."""
+    from fibsem.ui.widgets.script_manager_dialog import _MICROSCOPE, _WRITES
+
+    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    dialog.table.selectRow(0)  # hw.py
+    assert _MICROSCOPE in dialog.consequence_label.text()
+    dialog.table.selectRow(1)  # w.py
+    assert _WRITES in dialog.consequence_label.text()
+
+
+def test_only_a_broken_script_is_red(qapp, tmp_path):
+    """Colour in the list says what a script *is*; the confirmation dialog is what
+    warns. Red left for the one thing that is actionable while browsing."""
+    from fibsem.ui.widgets.script_manager_dialog import _ERROR
+
+    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
+    _write(tmp_path, "oops.py", "def main(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    dialog.table.selectRow(0)  # hw.py -- the most dangerous, still not red
+    assert _ERROR not in dialog.consequence_label.text()
+    dialog.table.selectRow(1)  # oops.py -- cannot load
+    assert _ERROR in dialog.consequence_label.text()
 
 
 def test_an_empty_folder_says_how_to_start(qapp, tmp_path):
@@ -164,7 +219,7 @@ def test_a_microscope_script_can_be_run_and_says_what_it_will_do(qapp, tmp_path)
     dialog.table.selectRow(0)
 
     assert dialog.run_button.isEnabled()
-    assert "Drives the microscope" in dialog.consequence_label.text()
+    assert "Controls the microscope" in dialog.consequence_label.text()
     # the warning has to be specific about what is missing, not just "careful"
     assert "no limits, no interlocks" in dialog.consequence_label.toolTip()
 
@@ -368,8 +423,18 @@ def test_the_folder_is_elided_but_kept_whole_in_the_tooltip(qapp, tmp_path):
 
 def test_a_long_description_elides_instead_of_clipping(qapp, tmp_path):
     """It used to be cut off mid-glyph, which reads as a typo rather than as
-    text continuing past the edge."""
-    summary = "Archive the experiment folder and every image in it when a workflow finishes"
+    text continuing past the edge.
+
+    The description has to beat the Script column at the dialog's *minimum* width,
+    not at the width passed to resize() -- a layout minimum of ~720px wins over a
+    smaller request, so a merely long sentence stopped eliding the moment the Type
+    column got narrower.
+    """
+    summary = (
+        "Archive the experiment folder and every image in it when a workflow "
+        "finishes, then upload the archive, verify its checksum, and email a "
+        "summary to whoever started the run"
+    )
     _write(tmp_path, "a.py", f'"""{summary}"""\ndef run(ctx):\n    pass\n')
     dialog = _dialog(tmp_path, context=FakeContext())
     dialog.resize(520, 400)  # narrow enough that this description cannot fit
@@ -382,21 +447,23 @@ def test_a_long_description_elides_instead_of_clipping(qapp, tmp_path):
     assert summary in dialog.table.cellWidget(0, 0).toolTip()
 
 
-def test_the_auto_flag_says_it_is_not_connected(qapp, tmp_path):
-    """Nothing fires on_workflow_completed yet. An author who declared it has no
-    other way to find that out, and a chip alone would read as a promise."""
+def test_the_auto_flag_gets_no_chip_but_is_still_explained(qapp, tmp_path):
+    """Nothing fires on_workflow_completed yet, so a chip for it was a badge for a
+    feature that does not exist. The author who declared it still needs somewhere to
+    learn that, and a tooltip costs no width."""
     _write(tmp_path, "a.py", "on_workflow_completed = True\ndef run(ctx):\n    pass\n")
     dialog = _dialog(tmp_path, context=FakeContext())
     dialog.table.selectRow(0)
 
-    assert "off" in _cell_text(dialog, 0, 1)
+    from PyQt5.QtWidgets import QLabel
+    assert dialog.table.cellWidget(0, 1).findChildren(QLabel) == []
     assert "not run automatically yet" in dialog.table.cellWidget(0, 1).toolTip()
     assert "not run automatically yet" in dialog.consequence_label.toolTip()
 
 
-def test_every_chip_carries_a_dot(qapp, tmp_path):
-    """Type and flag chips looked like different kinds of thing for no readable
-    reason. Colour separates them; shape should not."""
+def test_chips_are_text_only(qapp, tmp_path):
+    """The dot separated nothing once every chip carried one, and it cost width in
+    a column that has to fit more than one. Colour and the pill do the work."""
     _write(tmp_path, "s.py",
            "writes = True\non_workflow_completed = True\ndef run(ctx):\n    pass\n")
     dialog = _dialog(tmp_path, context=FakeContext())
@@ -404,8 +471,7 @@ def test_every_chip_carries_a_dot(qapp, tmp_path):
     from PyQt5.QtWidgets import QLabel
     chips = dialog.table.cellWidget(0, 1).findChildren(QLabel)
 
-    assert len(chips) == 3  # Data + writes + auto (off)
-    assert all("9679" in chip.text() for chip in chips)
+    assert [chip.text() for chip in chips] == ["Writes"]
 
 
 def test_the_type_column_fits_the_widest_row_of_chips(qapp, tmp_path):

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -271,3 +271,33 @@ def test_the_folder_is_elided_but_kept_whole_in_the_tooltip(qapp, tmp_path):
 
     assert "…" in dialog.meta_label.text()
     assert str(deep) == dialog.meta_label.toolTip()
+
+
+def test_every_chip_carries_a_dot(qapp, tmp_path):
+    """Type and flag chips looked like different kinds of thing for no readable
+    reason. Colour separates them; shape should not."""
+    _write(tmp_path, "s.py",
+           "writes = True\non_workflow_completed = True\ndef run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    from PyQt5.QtWidgets import QLabel
+    chips = dialog.table.cellWidget(0, 1).findChildren(QLabel)
+
+    assert len(chips) == 3  # Data + writes + auto
+    assert all("9679" in chip.text() for chip in chips)
+
+
+def test_the_type_column_fits_the_widest_row_of_chips(qapp, tmp_path):
+    """A fixed width clips as soon as a script declares more than one flag, and
+    ResizeToContents is no help -- it measures the item, not the cell widget."""
+    _write(tmp_path, "plain.py", "def run(ctx):\n    pass\n")
+    _write(tmp_path, "loaded.py",
+           "writes = True\non_workflow_completed = True\ndef run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.show()
+
+    widest = max(
+        dialog.table.cellWidget(row, 1).sizeHint().width()
+        for row in range(dialog.table.rowCount())
+    )
+    assert dialog.table.columnWidth(1) >= widest

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -31,11 +31,13 @@ def _write(directory: Path, name: str, body: str) -> Path:
     return path
 
 
-def _dialog(tmp_path, context=None, reason="", notes=None):
+def _dialog(tmp_path, context=None, reason="", notes=None, confirm=True):
     runner = ScriptRunner(
         scripts_directory=lambda: tmp_path,
         context_factory=lambda: (context, reason),
         notify=lambda m, l: (notes if notes is not None else []).append((l, m)),
+        # the real one is a modal box; a stub keeps the tests from blocking on it
+        confirm=lambda question, detail: confirm,
     )
     return ScriptManagerDialog(runner=runner)
 
@@ -229,6 +231,19 @@ def test_selection_survives_running_a_script(qapp, tmp_path):
     assert dialog.selected_script().name == "b"
 
 
+def test_cancelling_a_writes_confirmation_leaves_no_last_run(qapp, tmp_path):
+    """A run that never happened must not read as one that did."""
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    context = FakeContext()
+    dialog = _dialog(tmp_path, context=context, confirm=False)
+
+    dialog.run_selected()
+
+    assert dialog.last_run == {}
+    assert _cell_text(dialog, 0, 2) == "—"
+    assert not context.saved
+
+
 def test_rebuilding_does_not_stack_cell_widgets(qapp, tmp_path):
     """setRowCount alone leaves the previous build's widgets parented to the
     viewport, so rows drew on top of each other."""
@@ -300,6 +315,53 @@ def test_the_folder_is_elided_but_kept_whole_in_the_tooltip(qapp, tmp_path):
     assert str(deep) == dialog.meta_label.toolTip()
 
 
+def test_a_long_description_elides_instead_of_clipping(qapp, tmp_path):
+    """It used to be cut off mid-glyph, which reads as a typo rather than as
+    text continuing past the edge."""
+    summary = "Archive the experiment folder and every image in it when a workflow finishes"
+    _write(tmp_path, "a.py", f'"""{summary}"""\ndef run(ctx):\n    pass\n')
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.resize(520, 400)  # narrow enough that this description cannot fit
+    dialog.grab()  # forces the paint pass that does the eliding
+
+    from PyQt5.QtWidgets import QLabel
+    shown = dialog.table.cellWidget(0, 0).findChildren(QLabel)[1].text()
+
+    assert shown.endswith("…") and shown != summary
+    assert summary in dialog.table.cellWidget(0, 0).toolTip()
+
+
+def test_the_auto_flag_says_it_is_not_connected(qapp, tmp_path):
+    """Nothing fires on_workflow_completed yet. An author who declared it has no
+    other way to find that out, and a chip alone would read as a promise."""
+    _write(tmp_path, "a.py", "on_workflow_completed = True\ndef run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+
+    assert "off" in _cell_text(dialog, 0, 1)
+    assert "not run automatically yet" in dialog.table.cellWidget(0, 1).toolTip()
+    assert "not run automatically yet" in dialog.consequence_label.toolTip()
+
+
+def test_the_menu_does_not_label_a_script_auto(qapp, tmp_path):
+    """A menu has nowhere to explain the caveat, so it leaves the flag out."""
+    from PyQt5.QtWidgets import QMenu
+
+    from fibsem.ui.widgets.script_menu import ScriptMenuController
+
+    _write(tmp_path, "a.py", "on_workflow_completed = True\ndef run(ctx):\n    pass\n")
+    menu = QMenu()
+    controller = ScriptMenuController(
+        menu=menu,
+        scripts_directory=lambda: tmp_path,
+        context_factory=lambda: (FakeContext(), ""),
+        notify=lambda m, l: None,
+    )
+    controller.rebuild()
+
+    assert not any("auto" in a.text() for a in menu.actions())
+
+
 def test_every_chip_carries_a_dot(qapp, tmp_path):
     """Type and flag chips looked like different kinds of thing for no readable
     reason. Colour separates them; shape should not."""
@@ -310,7 +372,7 @@ def test_every_chip_carries_a_dot(qapp, tmp_path):
     from PyQt5.QtWidgets import QLabel
     chips = dialog.table.cellWidget(0, 1).findChildren(QLabel)
 
-    assert len(chips) == 3  # Data + writes + auto
+    assert len(chips) == 3  # Data + writes + auto (off)
     assert all("9679" in chip.text() for chip in chips)
 
 

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -162,6 +162,18 @@ def test_declining_the_confirmation_does_not_run_or_save(qapp, tmp_path):
     assert not getattr(context, "ran", False)
 
 
+def test_the_real_confirmation_box_builds(qapp, tmp_path, monkeypatch):
+    """Every other test injects a stub for it, so the box itself is otherwise
+    never constructed and a mistake in it would only show up in the app."""
+    from PyQt5.QtWidgets import QMessageBox
+
+    monkeypatch.setattr(QMessageBox, "exec_", lambda self: 0)
+    controller, _ = _controller(tmp_path, context=FakeContext())
+
+    # no button clicked -> not confirmed, which is the safe direction
+    assert controller.runner._default_confirm("Run 'x'?", "It writes.") is False
+
+
 def test_a_read_only_script_is_not_confirmed(qapp, tmp_path):
     """The common case must stay one click -- a prompt on every run gets clicked
     through without reading, which is worse than not having one."""

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -12,7 +12,7 @@ pytest.importorskip("PyQt5")
 
 from PyQt5.QtWidgets import QMenu  # noqa: E402
 
-from fibsem.ui.widgets.script_menu import ScriptMenuController  # noqa: E402
+from fibsem.ui.widgets.script_menu import MANAGE_LABEL, ScriptMenuController  # noqa: E402
 
 
 @pytest.fixture
@@ -71,16 +71,24 @@ def test_a_script_that_writes_is_labelled(qapp, tmp_path):
     assert any("writes" in a.text() for a in menu.actions())
 
 
-def test_a_broken_script_is_shown_disabled_with_the_reason(qapp, tmp_path):
-    """Omitting it would leave the author with nothing to diagnose."""
+def test_a_broken_script_is_summarised_and_points_at_the_manager(qapp, tmp_path):
+    """A menu has nowhere to put a failure reason, so it reports the count and
+    sends the user to the dialog. Omitting it entirely is what we are avoiding."""
     _write(tmp_path, "broken.py", "def main(ctx):\n    pass\n")
     controller, menu = _controller(tmp_path, context=FakeContext())
 
     controller.rebuild()
 
-    action = next(a for a in menu.actions() if a.text().startswith("broken"))
-    assert not action.isEnabled()
-    assert "run()" in action.toolTip()
+    labels = [a.text() for a in menu.actions()]
+    assert not any(t.startswith("broken") for t in labels)
+    assert any("failed to load" in t for t in labels)
+    assert any(t == MANAGE_LABEL for t in labels)
+
+
+def test_the_manager_entry_is_always_offered(qapp, tmp_path):
+    controller, menu = _controller(tmp_path, context=FakeContext())
+    controller.rebuild()
+    assert any(a.text() == MANAGE_LABEL for a in menu.actions())
 
 
 def test_entries_are_disabled_and_explained_when_the_host_is_not_ready(qapp, tmp_path):
@@ -113,7 +121,7 @@ def test_running_passes_the_context_through(qapp, tmp_path):
     context = FakeContext()
     controller, _ = _controller(tmp_path, context=context)
 
-    result = controller.run(controller.discover()[0])
+    result = controller.runner.run(controller.runner.discover()[0])
 
     assert result.ok and result.value == "from-context"
 
@@ -123,7 +131,7 @@ def test_writes_flag_triggers_the_context_save_hook(qapp, tmp_path):
     context = FakeContext()
     controller, _ = _controller(tmp_path, context=context)
 
-    controller.run(controller.discover()[0])
+    controller.runner.run(controller.runner.discover()[0])
 
     assert context.saved
 
@@ -133,7 +141,7 @@ def test_without_the_flag_the_save_hook_is_not_called(qapp, tmp_path):
     context = FakeContext()
     controller, _ = _controller(tmp_path, context=context)
 
-    controller.run(controller.discover()[0])
+    controller.runner.run(controller.runner.discover()[0])
 
     assert not context.saved
 
@@ -144,7 +152,7 @@ def test_a_failing_script_notifies_instead_of_raising(qapp, tmp_path):
     notes = []
     controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
 
-    result = controller.run(controller.discover()[0])
+    result = controller.runner.run(controller.runner.discover()[0])
 
     assert not result.ok
     assert notes and notes[-1][0] == "error"
@@ -156,7 +164,7 @@ def test_a_microscope_script_is_refused_until_the_strict_runner_exists(qapp, tmp
     notes = []
     controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
 
-    assert controller.run(controller.discover()[0]) is None
+    assert controller.runner.run(controller.runner.discover()[0]) is None
     assert notes and notes[-1][0] == "warning"
 
 
@@ -165,5 +173,5 @@ def test_running_is_refused_when_the_host_has_no_context(qapp, tmp_path):
     notes = []
     controller, _ = _controller(tmp_path, context=None, reason="Load an experiment", notes=notes)
 
-    assert controller.run(controller.discover()[0]) is None
+    assert controller.runner.run(controller.runner.discover()[0]) is None
     assert notes and notes[-1] == ("warning", "Load an experiment")

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -4,6 +4,7 @@ The controller takes a folder, a context factory and a notifier, so it can be
 driven standalone -- which is the point of it not living in AutoLamellaMainUI.
 """
 
+import time
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ pytest.importorskip("PyQt5")
 
 from PyQt5.QtWidgets import QMenu  # noqa: E402
 
+from fibsem.cancellation import OperationCancelledError  # noqa: E402
 from fibsem.ui.widgets.script_menu import MANAGE_LABEL, ScriptMenuController  # noqa: E402
 
 
@@ -23,14 +25,40 @@ def qapp():
 
 
 class FakeContext:
-    """Stands in for whatever an application hands its scripts."""
+    """Stands in for whatever an application hands its scripts.
+
+    Same shape as the real ScriptContext, including the cancellation surface the
+    runner injects into for threaded scripts.
+    """
 
     def __init__(self):
         self.saved = False
         self.value = "from-context"
+        self.stop_event = None
 
     def save(self):
         self.saved = True
+
+    @property
+    def cancelled(self):
+        return self.stop_event is not None and self.stop_event.is_set()
+
+    def raise_if_cancelled(self):
+        from fibsem.cancellation import raise_if_cancelled
+        raise_if_cancelled(self.stop_event)
+
+
+def _drain(qapp, predicate, timeout=5.0):
+    """Pump the Qt event loop until predicate() is true, or give up.
+
+    Threaded scripts report back through a queued signal, so nothing is delivered
+    unless the loop runs.
+    """
+    deadline = time.monotonic() + timeout
+    while not predicate() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.005)
+    return predicate()
 
 
 def _write(directory: Path, name: str, body: str) -> Path:
@@ -206,14 +234,117 @@ def test_a_failing_script_notifies_instead_of_raising(qapp, tmp_path):
     assert notes and notes[-1][0] == "error"
 
 
-def test_a_microscope_script_is_refused_until_the_strict_runner_exists(qapp, tmp_path):
-    """FIB-340 owns the worker thread, hardware lock and state restoration."""
-    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    raise AssertionError\n")
-    notes = []
-    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
+def test_a_microscope_script_runs_off_the_gui_thread(qapp, tmp_path):
+    """Hardware operations take seconds to minutes. Inline they would freeze the
+    window for the whole run, which is indistinguishable from a crash."""
+    _write(tmp_path, "hw.py",
+           "import threading\n"
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    return threading.current_thread() is threading.main_thread()\n")
+    done = []
+    controller, _ = _controller(tmp_path, context=FakeContext())
+
+    # returns None because it has not finished yet -- the result arrives by callback
+    assert controller.runner.run(controller.runner.discover()[0],
+                                 on_finished=done.append) is None
+    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
+    assert done[0].value is False, "ran on the main thread"
+
+
+def test_a_microscope_script_is_confirmed_before_it_runs(qapp, tmp_path):
+    """It has already moved the hardware by the time it finishes."""
+    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
+    asked = []
+    controller, _ = _controller(tmp_path, context=FakeContext())
+    controller.runner.confirm = lambda q, detail: asked.append(detail) or True
+
+    controller.runner.run(controller.runner.discover()[0])
+    _drain(qapp, lambda: not controller.runner.is_running)
+
+    assert asked and "drives the microscope" in asked[0]
+
+
+def test_declining_a_microscope_confirmation_does_not_start_a_thread(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\ndef run(ctx):\n    raise AssertionError\n")
+    controller, _ = _controller(tmp_path, context=FakeContext(), confirm=False)
 
     assert controller.runner.run(controller.runner.discover()[0]) is None
-    assert notes and notes[-1][0] == "warning"
+    assert not controller.runner.is_running
+
+
+def test_a_script_that_both_writes_and_drives_says_both(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\nwrites = True\ndef run(ctx):\n    pass\n")
+    asked = []
+    controller, _ = _controller(tmp_path, context=FakeContext())
+    controller.runner.confirm = lambda q, detail: asked.append(detail) or True
+
+    controller.runner.run(controller.runner.discover()[0])
+    _drain(qapp, lambda: not controller.runner.is_running)
+
+    assert "drives the microscope" in asked[0] and "modifies the experiment" in asked[0]
+
+
+def test_only_one_script_runs_at_a_time(qapp, tmp_path):
+    """Two threads commanding one microscope is the failure this prevents."""
+    _write(tmp_path, "slow.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(3)\n"
+           "    return 'done'\n")
+    notes = []
+    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
+    script = controller.runner.discover()[0]
+
+    controller.runner.run(script)
+    assert _drain(qapp, lambda: controller.runner.is_running)
+
+    assert controller.runner.run(script) is None
+    assert notes[-1] == ("warning", "A script is already running.")
+
+    controller.runner.stop()
+    assert _drain(qapp, lambda: not controller.runner.is_running)
+
+
+def test_stop_is_cooperative_and_reports_as_cancelled(qapp, tmp_path):
+    """A Python thread cannot be killed, so Stop only sets a flag -- the script
+    has to look at it."""
+    _write(tmp_path, "slow.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(3)\n"
+           "    ctx.raise_if_cancelled()\n"
+           "    return 'ran to completion'\n")
+    done, notes = [], []
+    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
+
+    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
+    assert _drain(qapp, lambda: controller.runner.is_running)
+    controller.runner.stop()
+
+    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
+    assert isinstance(done[0].error, OperationCancelledError)
+    # a cancel is not a failure, and must not be reported as one
+    assert notes[-1] == ("warning", "slow cancelled.")
+
+
+def test_a_script_that_ignores_stop_still_finishes(qapp, tmp_path):
+    """Documented behaviour, not a bug: nothing can force it to stop."""
+    _write(tmp_path, "stubborn.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(0.05)\n"
+           "    return 'finished anyway'\n")
+    done = []
+    controller, _ = _controller(tmp_path, context=FakeContext())
+
+    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
+    controller.runner.stop()
+
+    assert _drain(qapp, lambda: bool(done))
+    assert done[0].ok and done[0].value == "finished anyway"
 
 
 def test_running_is_refused_when_the_host_has_no_context(qapp, tmp_path):

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -1,0 +1,169 @@
+"""The Scripts menu, exercised without any application around it (FIB-338).
+
+The controller takes a folder, a context factory and a notifier, so it can be
+driven standalone -- which is the point of it not living in AutoLamellaMainUI.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QMenu  # noqa: E402
+
+from fibsem.ui.widgets.script_menu import ScriptMenuController  # noqa: E402
+
+
+@pytest.fixture
+def qapp():
+    from PyQt5.QtWidgets import QApplication
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+class FakeContext:
+    """Stands in for whatever an application hands its scripts."""
+
+    def __init__(self):
+        self.saved = False
+        self.value = "from-context"
+
+    def save(self):
+        self.saved = True
+
+
+def _write(directory: Path, name: str, body: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(body)
+    return path
+
+
+def _controller(tmp_path, context=None, reason="", notes=None):
+    menu = QMenu()
+    controller = ScriptMenuController(
+        menu=menu,
+        scripts_directory=lambda: tmp_path,
+        context_factory=lambda: (context, reason),
+        notify=lambda msg, level: (notes if notes is not None else []).append((level, msg)),
+    )
+    return controller, menu
+
+
+def test_menu_lists_scripts_by_name(qapp, tmp_path):
+    _write(tmp_path, "export.py", '"""Export a summary."""\ndef run(ctx):\n    pass\n')
+    controller, menu = _controller(tmp_path, context=FakeContext())
+
+    controller.rebuild()
+
+    labels = [a.text() for a in menu.actions() if a.text()]
+    assert "export" in labels
+
+
+def test_a_script_that_writes_is_labelled(qapp, tmp_path):
+    """A script that rewrites state must not look identical to one that reads."""
+    _write(tmp_path, "mark.py", "writes = True\ndef run(ctx):\n    pass\n")
+    controller, menu = _controller(tmp_path, context=FakeContext())
+
+    controller.rebuild()
+
+    assert any("writes" in a.text() for a in menu.actions())
+
+
+def test_a_broken_script_is_shown_disabled_with_the_reason(qapp, tmp_path):
+    """Omitting it would leave the author with nothing to diagnose."""
+    _write(tmp_path, "broken.py", "def main(ctx):\n    pass\n")
+    controller, menu = _controller(tmp_path, context=FakeContext())
+
+    controller.rebuild()
+
+    action = next(a for a in menu.actions() if a.text().startswith("broken"))
+    assert not action.isEnabled()
+    assert "run()" in action.toolTip()
+
+
+def test_entries_are_disabled_and_explained_when_the_host_is_not_ready(qapp, tmp_path):
+    _write(tmp_path, "export.py", "def run(ctx):\n    pass\n")
+    controller, menu = _controller(tmp_path, context=None, reason="Load an experiment")
+
+    controller.rebuild()
+
+    export = next(a for a in menu.actions() if a.text().startswith("export"))
+    assert not export.isEnabled()
+    assert any(a.text() == "Load an experiment" for a in menu.actions())
+
+
+def test_empty_folder_says_so_rather_than_showing_nothing(qapp, tmp_path):
+    controller, menu = _controller(tmp_path, context=FakeContext())
+
+    controller.rebuild()
+
+    assert any(a.text() == "No scripts found" for a in menu.actions())
+
+
+def test_open_folder_action_is_always_offered(qapp, tmp_path):
+    controller, menu = _controller(tmp_path, context=FakeContext())
+    controller.rebuild()
+    assert any(a.text() == "Open scripts folder" for a in menu.actions())
+
+
+def test_running_passes_the_context_through(qapp, tmp_path):
+    _write(tmp_path, "read.py", "def run(ctx):\n    return ctx.value\n")
+    context = FakeContext()
+    controller, _ = _controller(tmp_path, context=context)
+
+    result = controller.run(controller.discover()[0])
+
+    assert result.ok and result.value == "from-context"
+
+
+def test_writes_flag_triggers_the_context_save_hook(qapp, tmp_path):
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    context = FakeContext()
+    controller, _ = _controller(tmp_path, context=context)
+
+    controller.run(controller.discover()[0])
+
+    assert context.saved
+
+
+def test_without_the_flag_the_save_hook_is_not_called(qapp, tmp_path):
+    _write(tmp_path, "r.py", "def run(ctx):\n    pass\n")
+    context = FakeContext()
+    controller, _ = _controller(tmp_path, context=context)
+
+    controller.run(controller.discover()[0])
+
+    assert not context.saved
+
+
+def test_a_failing_script_notifies_instead_of_raising(qapp, tmp_path):
+    """PyQt5 aborts the process on an exception escaping a slot (FIB-329)."""
+    _write(tmp_path, "bad.py", "def run(ctx):\n    raise RuntimeError('nope')\n")
+    notes = []
+    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
+
+    result = controller.run(controller.discover()[0])
+
+    assert not result.ok
+    assert notes and notes[-1][0] == "error"
+
+
+def test_a_microscope_script_is_refused_until_the_strict_runner_exists(qapp, tmp_path):
+    """FIB-340 owns the worker thread, hardware lock and state restoration."""
+    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    raise AssertionError\n")
+    notes = []
+    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
+
+    assert controller.run(controller.discover()[0]) is None
+    assert notes and notes[-1][0] == "warning"
+
+
+def test_running_is_refused_when_the_host_has_no_context(qapp, tmp_path):
+    _write(tmp_path, "export.py", "def run(ctx):\n    raise AssertionError\n")
+    notes = []
+    controller, _ = _controller(tmp_path, context=None, reason="Load an experiment", notes=notes)
+
+    assert controller.run(controller.discover()[0]) is None
+    assert notes and notes[-1] == ("warning", "Load an experiment")

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -40,13 +40,15 @@ def _write(directory: Path, name: str, body: str) -> Path:
     return path
 
 
-def _controller(tmp_path, context=None, reason="", notes=None):
+def _controller(tmp_path, context=None, reason="", notes=None, confirm=True):
     menu = QMenu()
     controller = ScriptMenuController(
         menu=menu,
         scripts_directory=lambda: tmp_path,
         context_factory=lambda: (context, reason),
         notify=lambda msg, level: (notes if notes is not None else []).append((level, msg)),
+        # the real one is a modal box; a stub keeps the tests from blocking on it
+        confirm=lambda question, detail: confirm,
     )
     return controller, menu
 
@@ -134,6 +136,40 @@ def test_writes_flag_triggers_the_context_save_hook(qapp, tmp_path):
     controller.runner.run(controller.runner.discover()[0])
 
     assert context.saved
+
+
+def test_a_writes_script_is_confirmed_before_it_runs(qapp, tmp_path):
+    """It saves the moment it finishes and there is no undo."""
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    asked = []
+    controller, _ = _controller(tmp_path, context=FakeContext())
+    controller.runner.confirm = lambda q, detail: asked.append((q, detail)) or True
+
+    controller.runner.run(controller.runner.discover()[0])
+
+    assert asked, "a writes script ran without asking"
+    question, detail = asked[0]
+    assert "w" in question and "no undo" in detail
+
+
+def test_declining_the_confirmation_does_not_run_or_save(qapp, tmp_path):
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    ctx.ran = True\n")
+    context = FakeContext()
+    controller, _ = _controller(tmp_path, context=context, confirm=False)
+
+    assert controller.runner.run(controller.runner.discover()[0]) is None
+    assert not context.saved
+    assert not getattr(context, "ran", False)
+
+
+def test_a_read_only_script_is_not_confirmed(qapp, tmp_path):
+    """The common case must stay one click -- a prompt on every run gets clicked
+    through without reading, which is worse than not having one."""
+    _write(tmp_path, "r.py", "def run(ctx):\n    pass\n")
+    controller, _ = _controller(tmp_path, context=FakeContext())
+    controller.runner.confirm = lambda q, detail: pytest.fail("asked to confirm a read")
+
+    assert controller.runner.run(controller.runner.discover()[0]).ok
 
 
 def test_without_the_flag_the_save_hook_is_not_called(qapp, tmp_path):

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -91,3 +91,24 @@ def test_the_controller_exposes_the_runner_it_built(qapp, tmp_path):
     script is running (FIB-340)."""
     controller, _ = _controller(tmp_path, context=FakeContext())
     assert controller.runner.is_running is False
+
+
+@pytest.mark.parametrize("parent_widget", [None, object()])
+def test_the_workflow_gate_holds_when_scripting_is_switched_off(parent_widget):
+    """With AUTOLAMELLA_ENABLE_SCRIPTS unset there is no menu and no controller, so
+    the gate has to read "no script running" rather than raise -- otherwise turning
+    the feature off would break starting a workflow, which is the whole app.
+
+    Called unbound on a stub: the method only reads self.parent_widget, and building
+    a real AutoLamellaUI needs a viewer and a microscope.
+    """
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+
+    class Host:
+        script_menu_controller = None
+
+    stub = type("Stub", (), {"parent_widget": parent_widget})()
+    assert AutoLamellaUI._script_runner_is_busy(stub) is False
+
+    stub_with_host = type("Stub", (), {"parent_widget": Host()})()
+    assert AutoLamellaUI._script_runner_is_busy(stub_with_host) is False

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -1,10 +1,11 @@
 """The Scripts menu, exercised without any application around it (FIB-338).
 
-The controller takes a folder, a context factory and a notifier, so it can be
-driven standalone -- which is the point of it not living in AutoLamellaMainUI.
+The menu is a way *in*, not a way to run: it offers the manager and the folder
+and nothing else. Running lives in the dialog, which is the only surface with a
+Stop button. What the runner does once something is started is pinned down in
+test_script_runner.py.
 """
 
-import time
 from pathlib import Path
 
 import pytest
@@ -13,52 +14,22 @@ pytest.importorskip("PyQt5")
 
 from PyQt5.QtWidgets import QMenu  # noqa: E402
 
-from fibsem.cancellation import OperationCancelledError  # noqa: E402
-from fibsem.ui.widgets.script_menu import MANAGE_LABEL, ScriptMenuController  # noqa: E402
+from fibsem.ui.widgets.script_menu import (  # noqa: E402
+    MANAGE_LABEL,
+    OPEN_FOLDER_LABEL,
+    ScriptMenuController,
+)
 
 
 @pytest.fixture
 def qapp():
     from PyQt5.QtWidgets import QApplication
-    app = QApplication.instance() or QApplication([])
-    yield app
+    yield QApplication.instance() or QApplication([])
 
 
 class FakeContext:
-    """Stands in for whatever an application hands its scripts.
-
-    Same shape as the real ScriptContext, including the cancellation surface the
-    runner injects into for threaded scripts.
-    """
-
-    def __init__(self):
-        self.saved = False
-        self.value = "from-context"
-        self.stop_event = None
-
     def save(self):
-        self.saved = True
-
-    @property
-    def cancelled(self):
-        return self.stop_event is not None and self.stop_event.is_set()
-
-    def raise_if_cancelled(self):
-        from fibsem.cancellation import raise_if_cancelled
-        raise_if_cancelled(self.stop_event)
-
-
-def _drain(qapp, predicate, timeout=5.0):
-    """Pump the Qt event loop until predicate() is true, or give up.
-
-    Threaded scripts report back through a queued signal, so nothing is delivered
-    unless the loop runs.
-    """
-    deadline = time.monotonic() + timeout
-    while not predicate() and time.monotonic() < deadline:
-        qapp.processEvents()
-        time.sleep(0.005)
-    return predicate()
+        pass
 
 
 def _write(directory: Path, name: str, body: str) -> Path:
@@ -68,334 +39,55 @@ def _write(directory: Path, name: str, body: str) -> Path:
     return path
 
 
-def _controller(tmp_path, context=None, reason="", notes=None, confirm=True):
+def _controller(tmp_path, context=None, reason=""):
     menu = QMenu()
     controller = ScriptMenuController(
         menu=menu,
         scripts_directory=lambda: tmp_path,
         context_factory=lambda: (context, reason),
-        notify=lambda msg, level: (notes if notes is not None else []).append((level, msg)),
-        # the real one is a modal box; a stub keeps the tests from blocking on it
-        confirm=lambda question, detail: confirm,
+        notify=lambda msg, level: None,
     )
     return controller, menu
 
 
-def test_menu_lists_scripts_by_name(qapp, tmp_path):
+def test_the_menu_offers_the_manager_and_the_folder(qapp, tmp_path):
+    _, menu = _controller(tmp_path, context=FakeContext())
+    assert [a.text() for a in menu.actions()] == [MANAGE_LABEL, OPEN_FOLDER_LABEL]
+
+
+def test_the_menu_never_offers_to_run_a_script(qapp, tmp_path):
+    """A menu item cannot be stopped. A microscope script started from one would
+    run to completion with no way to interrupt it, so nothing here starts one."""
     _write(tmp_path, "export.py", '"""Export a summary."""\ndef run(ctx):\n    pass\n')
-    controller, menu = _controller(tmp_path, context=FakeContext())
-
-    controller.rebuild()
-
-    labels = [a.text() for a in menu.actions() if a.text()]
-    assert "export" in labels
-
-
-def test_a_script_that_writes_is_labelled(qapp, tmp_path):
-    """A script that rewrites state must not look identical to one that reads."""
-    _write(tmp_path, "mark.py", "writes = True\ndef run(ctx):\n    pass\n")
-    controller, menu = _controller(tmp_path, context=FakeContext())
-
-    controller.rebuild()
-
-    assert any("writes" in a.text() for a in menu.actions())
-
-
-def test_a_broken_script_is_summarised_and_points_at_the_manager(qapp, tmp_path):
-    """A menu has nowhere to put a failure reason, so it reports the count and
-    sends the user to the dialog. Omitting it entirely is what we are avoiding."""
-    _write(tmp_path, "broken.py", "def main(ctx):\n    pass\n")
-    controller, menu = _controller(tmp_path, context=FakeContext())
-
-    controller.rebuild()
-
-    labels = [a.text() for a in menu.actions()]
-    assert not any(t.startswith("broken") for t in labels)
-    assert any("failed to load" in t for t in labels)
-    assert any(t == MANAGE_LABEL for t in labels)
-
-
-def test_the_manager_entry_is_always_offered(qapp, tmp_path):
-    controller, menu = _controller(tmp_path, context=FakeContext())
-    controller.rebuild()
-    assert any(a.text() == MANAGE_LABEL for a in menu.actions())
-
-
-def test_entries_are_disabled_and_explained_when_the_host_is_not_ready(qapp, tmp_path):
-    _write(tmp_path, "export.py", "def run(ctx):\n    pass\n")
-    controller, menu = _controller(tmp_path, context=None, reason="Load an experiment")
-
-    controller.rebuild()
-
-    export = next(a for a in menu.actions() if a.text().startswith("export"))
-    assert not export.isEnabled()
-    assert any(a.text() == "Load an experiment" for a in menu.actions())
-
-
-def test_empty_folder_says_so_rather_than_showing_nothing(qapp, tmp_path):
-    controller, menu = _controller(tmp_path, context=FakeContext())
-
-    controller.rebuild()
-
-    assert any(a.text() == "No scripts found" for a in menu.actions())
-
-
-def test_open_folder_action_is_always_offered(qapp, tmp_path):
-    controller, menu = _controller(tmp_path, context=FakeContext())
-    controller.rebuild()
-    assert any(a.text() == "Open scripts folder" for a in menu.actions())
-
-
-def test_running_passes_the_context_through(qapp, tmp_path):
-    _write(tmp_path, "read.py", "def run(ctx):\n    return ctx.value\n")
-    context = FakeContext()
-    controller, _ = _controller(tmp_path, context=context)
-
-    result = controller.runner.run(controller.runner.discover()[0])
-
-    assert result.ok and result.value == "from-context"
-
-
-def test_writes_flag_triggers_the_context_save_hook(qapp, tmp_path):
-    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
-    context = FakeContext()
-    controller, _ = _controller(tmp_path, context=context)
-
-    controller.runner.run(controller.runner.discover()[0])
-
-    assert context.saved
-
-
-def test_a_writes_script_is_confirmed_before_it_runs(qapp, tmp_path):
-    """It saves the moment it finishes and there is no undo."""
-    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
-    asked = []
-    controller, _ = _controller(tmp_path, context=FakeContext())
-    controller.runner.confirm = lambda q, detail: asked.append((q, detail)) or True
-
-    controller.runner.run(controller.runner.discover()[0])
-
-    assert asked, "a writes script ran without asking"
-    question, detail = asked[0]
-    assert "w" in question and "no undo" in detail
-
-
-def test_declining_the_confirmation_does_not_run_or_save(qapp, tmp_path):
-    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    ctx.ran = True\n")
-    context = FakeContext()
-    controller, _ = _controller(tmp_path, context=context, confirm=False)
-
-    assert controller.runner.run(controller.runner.discover()[0]) is None
-    assert not context.saved
-    assert not getattr(context, "ran", False)
-
-
-def test_the_real_confirmation_box_builds(qapp, tmp_path, monkeypatch):
-    """Every other test injects a stub for it, so the box itself is otherwise
-    never constructed and a mistake in it would only show up in the app."""
-    from PyQt5.QtWidgets import QMessageBox
-
-    monkeypatch.setattr(QMessageBox, "exec_", lambda self: 0)
-    controller, _ = _controller(tmp_path, context=FakeContext())
-
-    # no button clicked -> not confirmed, which is the safe direction
-    assert controller.runner._default_confirm("Run 'x'?", "It writes.") is False
-
-
-def test_a_read_only_script_is_not_confirmed(qapp, tmp_path):
-    """The common case must stay one click -- a prompt on every run gets clicked
-    through without reading, which is worse than not having one."""
-    _write(tmp_path, "r.py", "def run(ctx):\n    pass\n")
-    controller, _ = _controller(tmp_path, context=FakeContext())
-    controller.runner.confirm = lambda q, detail: pytest.fail("asked to confirm a read")
-
-    assert controller.runner.run(controller.runner.discover()[0]).ok
-
-
-def test_without_the_flag_the_save_hook_is_not_called(qapp, tmp_path):
-    _write(tmp_path, "r.py", "def run(ctx):\n    pass\n")
-    context = FakeContext()
-    controller, _ = _controller(tmp_path, context=context)
-
-    controller.runner.run(controller.runner.discover()[0])
-
-    assert not context.saved
-
-
-def test_a_failing_script_notifies_instead_of_raising(qapp, tmp_path):
-    """PyQt5 aborts the process on an exception escaping a slot (FIB-329)."""
-    _write(tmp_path, "bad.py", "def run(ctx):\n    raise RuntimeError('nope')\n")
-    notes = []
-    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
-
-    result = controller.runner.run(controller.runner.discover()[0])
-
-    assert not result.ok
-    assert notes and notes[-1][0] == "error"
-
-
-def test_a_microscope_script_runs_off_the_gui_thread(qapp, tmp_path):
-    """Hardware operations take seconds to minutes. Inline they would freeze the
-    window for the whole run, which is indistinguishable from a crash."""
-    _write(tmp_path, "hw.py",
-           "import threading\n"
-           "uses_microscope = True\n"
-           "def run(ctx):\n"
-           "    return threading.current_thread() is threading.main_thread()\n")
-    done = []
-    controller, _ = _controller(tmp_path, context=FakeContext())
-
-    # returns None because it has not finished yet -- the result arrives by callback
-    assert controller.runner.run(controller.runner.discover()[0],
-                                 on_finished=done.append) is None
-    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
-    assert done[0].value is False, "ran on the main thread"
-
-
-def test_the_microscope_is_withheld_without_the_flag(qapp, tmp_path):
-    """Otherwise a script could drive the stage while the dialog still labels it
-    'Data / Read-only' -- an active falsehood, worse than saying nothing."""
-    _write(tmp_path, "sneaky.py", "def run(ctx):\n    return ctx.microscope\n")
-    context = FakeContext()
-    context.microscope = object()
-    controller, _ = _controller(tmp_path, context=context)
-
-    result = controller.runner.run(controller.runner.discover()[0])
-
-    assert result.ok and result.value is None
-    # put back, so a host that reuses one context object is not left without it
-    assert context.microscope is not None
-
-
-def test_forgetting_the_flag_says_which_flag_to_add(qapp, tmp_path):
-    """The traceback names the line, but the toast is all most users see, and
-    "'NoneType' has no attribute acquire_image" does not say what to do."""
-    _write(tmp_path, "forgot.py", "def run(ctx):\n    return ctx.microscope.acquire()\n")
-    context = FakeContext()
-    context.microscope = object()
-    notes = []
-    controller, _ = _controller(tmp_path, context=context, notes=notes)
-
-    controller.runner.run(controller.runner.discover()[0])
-
-    level, message = notes[-1]
-    assert level == "error"
-    assert "uses_microscope = True" in message
-
-
-def test_a_declared_script_gets_the_real_microscope(qapp, tmp_path):
-    _write(tmp_path, "hw.py",
-           "uses_microscope = True\ndef run(ctx):\n    return ctx.microscope\n")
-    context = FakeContext()
-    context.microscope = microscope = object()
-    done = []
-    controller, _ = _controller(tmp_path, context=context)
-
-    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
-
-    assert _drain(qapp, lambda: bool(done))
-    assert done[0].value is microscope
-
-
-def test_a_microscope_script_is_confirmed_before_it_runs(qapp, tmp_path):
-    """It has already moved the hardware by the time it finishes."""
     _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
-    asked = []
+
+    _, menu = _controller(tmp_path, context=FakeContext())
+
+    assert not any("export" in a.text() or "hw" in a.text() for a in menu.actions())
+
+
+def test_the_menu_is_the_same_whatever_is_in_the_folder(qapp, tmp_path):
+    """Nothing here depends on the folder, so it is built once rather than
+    re-importing every script each time the Tools menu opens."""
+    _, empty = _controller(tmp_path, context=FakeContext())
+    before = [a.text() for a in empty.actions()]
+
+    _write(tmp_path, "broken.py", "def main(ctx):\n    pass\n")
+    _write(tmp_path, "good.py", "def run(ctx):\n    pass\n")
+    _, populated = _controller(tmp_path, context=FakeContext())
+
+    assert [a.text() for a in populated.actions()] == before
+
+
+def test_the_menu_is_usable_with_no_experiment_loaded(qapp, tmp_path):
+    """Both entries still work -- the dialog is where "why can I not run this"
+    gets explained, and you have to be able to reach it to read that."""
+    _, menu = _controller(tmp_path, context=None, reason="Load an experiment")
+    assert all(a.isEnabled() for a in menu.actions())
+
+
+def test_the_controller_exposes_the_runner_it_built(qapp, tmp_path):
+    """AutoLamellaUI reaches through it to refuse a workflow while a microscope
+    script is running (FIB-340)."""
     controller, _ = _controller(tmp_path, context=FakeContext())
-    controller.runner.confirm = lambda q, detail: asked.append(detail) or True
-
-    controller.runner.run(controller.runner.discover()[0])
-    _drain(qapp, lambda: not controller.runner.is_running)
-
-    assert asked and "drives the microscope" in asked[0]
-
-
-def test_declining_a_microscope_confirmation_does_not_start_a_thread(qapp, tmp_path):
-    _write(tmp_path, "hw.py",
-           "uses_microscope = True\ndef run(ctx):\n    raise AssertionError\n")
-    controller, _ = _controller(tmp_path, context=FakeContext(), confirm=False)
-
-    assert controller.runner.run(controller.runner.discover()[0]) is None
-    assert not controller.runner.is_running
-
-
-def test_a_script_that_both_writes_and_drives_says_both(qapp, tmp_path):
-    _write(tmp_path, "hw.py",
-           "uses_microscope = True\nwrites = True\ndef run(ctx):\n    pass\n")
-    asked = []
-    controller, _ = _controller(tmp_path, context=FakeContext())
-    controller.runner.confirm = lambda q, detail: asked.append(detail) or True
-
-    controller.runner.run(controller.runner.discover()[0])
-    _drain(qapp, lambda: not controller.runner.is_running)
-
-    assert "drives the microscope" in asked[0] and "modifies the experiment" in asked[0]
-
-
-def test_only_one_script_runs_at_a_time(qapp, tmp_path):
-    """Two threads commanding one microscope is the failure this prevents."""
-    _write(tmp_path, "slow.py",
-           "uses_microscope = True\n"
-           "def run(ctx):\n"
-           "    ctx.stop_event.wait(3)\n"
-           "    return 'done'\n")
-    notes = []
-    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
-    script = controller.runner.discover()[0]
-
-    controller.runner.run(script)
-    assert _drain(qapp, lambda: controller.runner.is_running)
-
-    assert controller.runner.run(script) is None
-    assert notes[-1] == ("warning", "A script is already running.")
-
-    controller.runner.stop()
-    assert _drain(qapp, lambda: not controller.runner.is_running)
-
-
-def test_stop_is_cooperative_and_reports_as_cancelled(qapp, tmp_path):
-    """A Python thread cannot be killed, so Stop only sets a flag -- the script
-    has to look at it."""
-    _write(tmp_path, "slow.py",
-           "uses_microscope = True\n"
-           "def run(ctx):\n"
-           "    ctx.stop_event.wait(3)\n"
-           "    ctx.raise_if_cancelled()\n"
-           "    return 'ran to completion'\n")
-    done, notes = [], []
-    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
-
-    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
-    assert _drain(qapp, lambda: controller.runner.is_running)
-    controller.runner.stop()
-
-    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
-    assert isinstance(done[0].error, OperationCancelledError)
-    # a cancel is not a failure, and must not be reported as one
-    assert notes[-1] == ("warning", "slow cancelled.")
-
-
-def test_a_script_that_ignores_stop_still_finishes(qapp, tmp_path):
-    """Documented behaviour, not a bug: nothing can force it to stop."""
-    _write(tmp_path, "stubborn.py",
-           "uses_microscope = True\n"
-           "def run(ctx):\n"
-           "    ctx.stop_event.wait(0.05)\n"
-           "    return 'finished anyway'\n")
-    done = []
-    controller, _ = _controller(tmp_path, context=FakeContext())
-
-    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
-    controller.runner.stop()
-
-    assert _drain(qapp, lambda: bool(done))
-    assert done[0].ok and done[0].value == "finished anyway"
-
-
-def test_running_is_refused_when_the_host_has_no_context(qapp, tmp_path):
-    _write(tmp_path, "export.py", "def run(ctx):\n    raise AssertionError\n")
-    notes = []
-    controller, _ = _controller(tmp_path, context=None, reason="Load an experiment", notes=notes)
-
-    assert controller.runner.run(controller.runner.discover()[0]) is None
-    assert notes and notes[-1] == ("warning", "Load an experiment")
+    assert controller.runner.is_running is False

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -252,6 +252,51 @@ def test_a_microscope_script_runs_off_the_gui_thread(qapp, tmp_path):
     assert done[0].value is False, "ran on the main thread"
 
 
+def test_the_microscope_is_withheld_without_the_flag(qapp, tmp_path):
+    """Otherwise a script could drive the stage while the dialog still labels it
+    'Data / Read-only' -- an active falsehood, worse than saying nothing."""
+    _write(tmp_path, "sneaky.py", "def run(ctx):\n    return ctx.microscope\n")
+    context = FakeContext()
+    context.microscope = object()
+    controller, _ = _controller(tmp_path, context=context)
+
+    result = controller.runner.run(controller.runner.discover()[0])
+
+    assert result.ok and result.value is None
+    # put back, so a host that reuses one context object is not left without it
+    assert context.microscope is not None
+
+
+def test_forgetting_the_flag_says_which_flag_to_add(qapp, tmp_path):
+    """The traceback names the line, but the toast is all most users see, and
+    "'NoneType' has no attribute acquire_image" does not say what to do."""
+    _write(tmp_path, "forgot.py", "def run(ctx):\n    return ctx.microscope.acquire()\n")
+    context = FakeContext()
+    context.microscope = object()
+    notes = []
+    controller, _ = _controller(tmp_path, context=context, notes=notes)
+
+    controller.runner.run(controller.runner.discover()[0])
+
+    level, message = notes[-1]
+    assert level == "error"
+    assert "uses_microscope = True" in message
+
+
+def test_a_declared_script_gets_the_real_microscope(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\ndef run(ctx):\n    return ctx.microscope\n")
+    context = FakeContext()
+    context.microscope = microscope = object()
+    done = []
+    controller, _ = _controller(tmp_path, context=context)
+
+    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
+
+    assert _drain(qapp, lambda: bool(done))
+    assert done[0].value is microscope
+
+
 def test_a_microscope_script_is_confirmed_before_it_runs(qapp, tmp_path):
     """It has already moved the hardware by the time it finishes."""
     _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -94,10 +94,11 @@ def test_the_controller_exposes_the_runner_it_built(qapp, tmp_path):
 
 
 @pytest.mark.parametrize("parent_widget", [None, object()])
-def test_the_workflow_gate_holds_when_scripting_is_switched_off(parent_widget):
-    """With AUTOLAMELLA_ENABLE_SCRIPTS unset there is no menu and no controller, so
-    the gate has to read "no script running" rather than raise -- otherwise turning
-    the feature off would break starting a workflow, which is the whole app.
+def test_the_workflow_gate_holds_with_no_controller(parent_widget):
+    """This runs on every workflow start, and any host that never built a Scripts
+    menu has no controller for it to find -- so it has to read "no script running"
+    rather than raise. A crash here would break starting a workflow, which is the
+    whole application.
 
     Called unbound on a stub: the method only reads self.parent_widget, and building
     a real AutoLamellaUI needs a viewer and a microscope.

--- a/tests/ui/test_script_runner.py
+++ b/tests/ui/test_script_runner.py
@@ -1,0 +1,312 @@
+"""ScriptRunner: what may run, how it runs, and what the user is told (FIB-338/340).
+
+Driven with no menu and no dialog around it -- the runner is the one path both
+surfaces go through, so this is where the running rules are pinned down.
+"""
+
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.cancellation import OperationCancelledError  # noqa: E402
+from fibsem.ui.widgets.script_runner import ScriptRunner  # noqa: E402
+
+
+@pytest.fixture
+def qapp():
+    from PyQt5.QtWidgets import QApplication
+    yield QApplication.instance() or QApplication([])
+
+
+class FakeContext:
+    """Stands in for whatever an application hands its scripts.
+
+    Same shape as the real ScriptContext, including the cancellation surface the
+    runner injects into for threaded scripts.
+    """
+
+    def __init__(self):
+        self.saved = False
+        self.value = "from-context"
+        self.stop_event = None
+
+    def save(self):
+        self.saved = True
+
+    @property
+    def cancelled(self):
+        return self.stop_event is not None and self.stop_event.is_set()
+
+    def raise_if_cancelled(self):
+        from fibsem.cancellation import raise_if_cancelled
+        raise_if_cancelled(self.stop_event)
+
+
+def _drain(qapp, predicate, timeout=5.0):
+    """Pump the Qt event loop until predicate() is true, or give up.
+
+    Threaded scripts report back through a queued signal, so nothing is delivered
+    unless the loop runs.
+    """
+    deadline = time.monotonic() + timeout
+    while not predicate() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.005)
+    return predicate()
+
+
+def _write(directory: Path, name: str, body: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(body)
+    return path
+
+
+def _runner(tmp_path, context=None, reason="", notes=None, confirm=True):
+    return ScriptRunner(
+        scripts_directory=lambda: tmp_path,
+        context_factory=lambda: (context, reason),
+        notify=lambda msg, level: (notes if notes is not None else []).append((level, msg)),
+        # the real one is a modal box; a stub keeps the tests from blocking on it
+        confirm=lambda question, detail: confirm,
+    )
+
+
+def test_running_passes_the_context_through(qapp, tmp_path):
+    _write(tmp_path, "read.py", "def run(ctx):\n    return ctx.value\n")
+    context = FakeContext()
+    runner = _runner(tmp_path, context=context)
+
+    result = runner.run(runner.discover()[0])
+
+    assert result.ok and result.value == "from-context"
+
+def test_writes_flag_triggers_the_context_save_hook(qapp, tmp_path):
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    context = FakeContext()
+    runner = _runner(tmp_path, context=context)
+
+    runner.run(runner.discover()[0])
+
+    assert context.saved
+
+def test_a_writes_script_is_confirmed_before_it_runs(qapp, tmp_path):
+    """It saves the moment it finishes and there is no undo."""
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    asked = []
+    runner = _runner(tmp_path, context=FakeContext())
+    runner.confirm = lambda q, detail: asked.append((q, detail)) or True
+
+    runner.run(runner.discover()[0])
+
+    assert asked, "a writes script ran without asking"
+    question, detail = asked[0]
+    assert "w" in question and "no undo" in detail
+
+def test_declining_the_confirmation_does_not_run_or_save(qapp, tmp_path):
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    ctx.ran = True\n")
+    context = FakeContext()
+    runner = _runner(tmp_path, context=context, confirm=False)
+
+    assert runner.run(runner.discover()[0]) is None
+    assert not context.saved
+    assert not getattr(context, "ran", False)
+
+def test_the_real_confirmation_box_builds(qapp, tmp_path, monkeypatch):
+    """Every other test injects a stub for it, so the box itself is otherwise
+    never constructed and a mistake in it would only show up in the app."""
+    from PyQt5.QtWidgets import QMessageBox
+
+    monkeypatch.setattr(QMessageBox, "exec_", lambda self: 0)
+    runner = _runner(tmp_path, context=FakeContext())
+
+    # no button clicked -> not confirmed, which is the safe direction
+    assert runner._default_confirm("Run 'x'?", "It writes.") is False
+
+def test_a_read_only_script_is_not_confirmed(qapp, tmp_path):
+    """The common case must stay one click -- a prompt on every run gets clicked
+    through without reading, which is worse than not having one."""
+    _write(tmp_path, "r.py", "def run(ctx):\n    pass\n")
+    runner = _runner(tmp_path, context=FakeContext())
+    runner.confirm = lambda q, detail: pytest.fail("asked to confirm a read")
+
+    assert runner.run(runner.discover()[0]).ok
+
+def test_without_the_flag_the_save_hook_is_not_called(qapp, tmp_path):
+    _write(tmp_path, "r.py", "def run(ctx):\n    pass\n")
+    context = FakeContext()
+    runner = _runner(tmp_path, context=context)
+
+    runner.run(runner.discover()[0])
+
+    assert not context.saved
+
+def test_a_failing_script_notifies_instead_of_raising(qapp, tmp_path):
+    """PyQt5 aborts the process on an exception escaping a slot (FIB-329)."""
+    _write(tmp_path, "bad.py", "def run(ctx):\n    raise RuntimeError('nope')\n")
+    notes = []
+    runner = _runner(tmp_path, context=FakeContext(), notes=notes)
+
+    result = runner.run(runner.discover()[0])
+
+    assert not result.ok
+    assert notes and notes[-1][0] == "error"
+
+def test_a_microscope_script_runs_off_the_gui_thread(qapp, tmp_path):
+    """Hardware operations take seconds to minutes. Inline they would freeze the
+    window for the whole run, which is indistinguishable from a crash."""
+    _write(tmp_path, "hw.py",
+           "import threading\n"
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    return threading.current_thread() is threading.main_thread()\n")
+    done = []
+    runner = _runner(tmp_path, context=FakeContext())
+
+    # returns None because it has not finished yet -- the result arrives by callback
+    assert runner.run(runner.discover()[0],
+                                 on_finished=done.append) is None
+    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
+    assert done[0].value is False, "ran on the main thread"
+
+def test_the_microscope_is_withheld_without_the_flag(qapp, tmp_path):
+    """Otherwise a script could drive the stage while the dialog still labels it
+    'Data / Read-only' -- an active falsehood, worse than saying nothing."""
+    _write(tmp_path, "sneaky.py", "def run(ctx):\n    return ctx.microscope\n")
+    context = FakeContext()
+    context.microscope = object()
+    runner = _runner(tmp_path, context=context)
+
+    result = runner.run(runner.discover()[0])
+
+    assert result.ok and result.value is None
+    # put back, so a host that reuses one context object is not left without it
+    assert context.microscope is not None
+
+def test_forgetting_the_flag_says_which_flag_to_add(qapp, tmp_path):
+    """The traceback names the line, but the toast is all most users see, and
+    "'NoneType' has no attribute acquire_image" does not say what to do."""
+    _write(tmp_path, "forgot.py", "def run(ctx):\n    return ctx.microscope.acquire()\n")
+    context = FakeContext()
+    context.microscope = object()
+    notes = []
+    runner = _runner(tmp_path, context=context, notes=notes)
+
+    runner.run(runner.discover()[0])
+
+    level, message = notes[-1]
+    assert level == "error"
+    assert "uses_microscope = True" in message
+
+def test_a_declared_script_gets_the_real_microscope(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\ndef run(ctx):\n    return ctx.microscope\n")
+    context = FakeContext()
+    context.microscope = microscope = object()
+    done = []
+    runner = _runner(tmp_path, context=context)
+
+    runner.run(runner.discover()[0], on_finished=done.append)
+
+    assert _drain(qapp, lambda: bool(done))
+    assert done[0].value is microscope
+
+def test_a_microscope_script_is_confirmed_before_it_runs(qapp, tmp_path):
+    """It has already moved the hardware by the time it finishes."""
+    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
+    asked = []
+    runner = _runner(tmp_path, context=FakeContext())
+    runner.confirm = lambda q, detail: asked.append(detail) or True
+
+    runner.run(runner.discover()[0])
+    _drain(qapp, lambda: not runner.is_running)
+
+    assert asked and "drives the microscope" in asked[0]
+
+def test_declining_a_microscope_confirmation_does_not_start_a_thread(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\ndef run(ctx):\n    raise AssertionError\n")
+    runner = _runner(tmp_path, context=FakeContext(), confirm=False)
+
+    assert runner.run(runner.discover()[0]) is None
+    assert not runner.is_running
+
+def test_a_script_that_both_writes_and_drives_says_both(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\nwrites = True\ndef run(ctx):\n    pass\n")
+    asked = []
+    runner = _runner(tmp_path, context=FakeContext())
+    runner.confirm = lambda q, detail: asked.append(detail) or True
+
+    runner.run(runner.discover()[0])
+    _drain(qapp, lambda: not runner.is_running)
+
+    assert "drives the microscope" in asked[0] and "modifies the experiment" in asked[0]
+
+def test_only_one_script_runs_at_a_time(qapp, tmp_path):
+    """Two threads commanding one microscope is the failure this prevents."""
+    _write(tmp_path, "slow.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(3)\n"
+           "    return 'done'\n")
+    notes = []
+    runner = _runner(tmp_path, context=FakeContext(), notes=notes)
+    script = runner.discover()[0]
+
+    runner.run(script)
+    assert _drain(qapp, lambda: runner.is_running)
+
+    assert runner.run(script) is None
+    assert notes[-1] == ("warning", "A script is already running.")
+
+    runner.stop()
+    assert _drain(qapp, lambda: not runner.is_running)
+
+def test_stop_is_cooperative_and_reports_as_cancelled(qapp, tmp_path):
+    """A Python thread cannot be killed, so Stop only sets a flag -- the script
+    has to look at it."""
+    _write(tmp_path, "slow.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(3)\n"
+           "    ctx.raise_if_cancelled()\n"
+           "    return 'ran to completion'\n")
+    done, notes = [], []
+    runner = _runner(tmp_path, context=FakeContext(), notes=notes)
+
+    runner.run(runner.discover()[0], on_finished=done.append)
+    assert _drain(qapp, lambda: runner.is_running)
+    runner.stop()
+
+    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
+    assert isinstance(done[0].error, OperationCancelledError)
+    # a cancel is not a failure, and must not be reported as one
+    assert notes[-1] == ("warning", "slow cancelled.")
+
+def test_a_script_that_ignores_stop_still_finishes(qapp, tmp_path):
+    """Documented behaviour, not a bug: nothing can force it to stop."""
+    _write(tmp_path, "stubborn.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(0.05)\n"
+           "    return 'finished anyway'\n")
+    done = []
+    runner = _runner(tmp_path, context=FakeContext())
+
+    runner.run(runner.discover()[0], on_finished=done.append)
+    runner.stop()
+
+    assert _drain(qapp, lambda: bool(done))
+    assert done[0].ok and done[0].value == "finished anyway"
+
+def test_running_is_refused_when_the_host_has_no_context(qapp, tmp_path):
+    _write(tmp_path, "export.py", "def run(ctx):\n    raise AssertionError\n")
+    notes = []
+    runner = _runner(tmp_path, context=None, reason="Load an experiment", notes=notes)
+
+    assert runner.run(runner.discover()[0]) is None
+    assert notes and notes[-1] == ("warning", "Load an experiment")

--- a/tests/ui/test_script_runner.py
+++ b/tests/ui/test_script_runner.py
@@ -246,6 +246,23 @@ def test_a_script_that_both_writes_and_drives_says_both(qapp, tmp_path):
 
     assert "drives the microscope" in asked[0] and "modifies the experiment" in asked[0]
 
+def test_two_consequences_are_two_sentences_not_a_chain_of_ands(qapp, tmp_path):
+    """Joining the clauses with "and" produced "nothing checks what it does and
+    modifies the experiment", where the second and attaches to "nothing checks" --
+    so the warning stated the opposite of what it meant, on the worst script type."""
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\nwrites = True\ndef run(ctx):\n    pass\n")
+    runner = _runner(tmp_path, context=FakeContext())
+
+    detail = runner._consequence(runner.discover()[0])
+
+    assert detail == (
+        "It drives the microscope, and nothing checks what it does. "
+        "It modifies the experiment and saves it when it finishes. "
+        "There is no undo."
+    )
+    assert "does and modifies" not in detail
+
 def test_only_one_script_runs_at_a_time(qapp, tmp_path):
     """Two threads commanding one microscope is the failure this prevents."""
     _write(tmp_path, "slow.py",

--- a/tests/ui/test_scripts_feature_flag.py
+++ b/tests/ui/test_scripts_feature_flag.py
@@ -1,0 +1,146 @@
+"""The user-scripts feature flag (FIB-338).
+
+Scripts ship off. A script gets the application's own access to the microscope and
+none of its guard rails, so nobody should acquire the capability by upgrading.
+
+The flag is a normal entry in ``features`` in user-preferences, alongside coincidence
+milling and the bug reporter, rather than a bespoke switch -- so it persists, appears
+in the Preferences dialog, and can be toggled without a restart.
+"""
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+import fibsem.config as cfg  # noqa: E402
+from fibsem.ui.widgets.preferences_dialog import PreferencesDialog  # noqa: E402
+
+
+@pytest.fixture
+def qapp():
+    from PyQt5.QtWidgets import QApplication
+    yield QApplication.instance() or QApplication([])
+
+
+@pytest.fixture(autouse=True)
+def warnings(monkeypatch):
+    """Capture QMessageBox.warning for every test in this module.
+
+    Autouse, not opt-in: setChecked() fires the toggled signal exactly as a click
+    does, so any test that flips the checkbox without this stub opens a real modal
+    and hangs the suite until it times out. Found the hard way.
+    """
+    captured = []
+    monkeypatch.setattr(
+        "fibsem.ui.widgets.preferences_dialog.QMessageBox.warning",
+        lambda *args, **kwargs: captured.append(args),
+    )
+    return captured
+
+
+@pytest.fixture
+def prefs_file(tmp_path, monkeypatch):
+    """Point the preferences file somewhere disposable, so a test never reads or
+    overwrites the developer's real one."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_dir))
+    monkeypatch.setattr(
+        cfg, "USER_PREFERENCES_PATH", str(config_dir / "user-preferences.yaml")
+    )
+    return config_dir
+
+
+# ── the default ──────────────────────────────────────────────────────────────
+
+def test_scripts_are_off_by_default():
+    assert cfg.FeatureFlags().scripts_enabled is False
+
+
+def test_scripts_are_off_with_no_preferences_file(prefs_file):
+    """First launch on a new machine must not have scripts enabled."""
+    assert cfg.load_user_preferences().features.scripts_enabled is False
+
+
+def test_scripts_stay_off_for_a_file_that_predates_the_flag(prefs_file):
+    """Upgrading must not turn it on. An older user-preferences.yaml has no
+    scripts_enabled key at all, so this is the realistic upgrade path."""
+    with open(cfg.USER_PREFERENCES_PATH, "w") as f:
+        f.write("features:\n  coincidence_milling_enabled: true\n")
+
+    prefs = cfg.load_user_preferences()
+
+    assert prefs.features.coincidence_milling_enabled is True  # the file was read
+    assert prefs.features.scripts_enabled is False
+
+
+# ── persistence ──────────────────────────────────────────────────────────────
+
+def test_the_flag_round_trips(prefs_file):
+    prefs = cfg.load_user_preferences()
+    prefs.features.scripts_enabled = True
+    cfg.save_user_preferences(prefs)
+
+    assert cfg.load_user_preferences().features.scripts_enabled is True
+
+
+def test_enabling_scripts_leaves_the_other_flags_alone(prefs_file):
+    prefs = cfg.load_user_preferences()
+    prefs.features.sample_holder_widget = True
+    prefs.features.scripts_enabled = True
+    cfg.save_user_preferences(prefs)
+
+    reloaded = cfg.load_user_preferences().features
+
+    assert (reloaded.scripts_enabled, reloaded.sample_holder_widget) == (True, True)
+    assert reloaded.coincidence_milling_enabled is False
+
+
+# ── the Preferences dialog ───────────────────────────────────────────────────
+
+def test_the_dialog_shows_the_current_value(qapp):
+    prefs = cfg.UserPreferences()
+    prefs.features.scripts_enabled = True
+
+    dialog = PreferencesDialog(prefs)
+
+    assert dialog._chk_scripts.isChecked()
+
+
+def test_the_dialog_reports_the_new_value(qapp):
+    dialog = PreferencesDialog(cfg.UserPreferences())
+    assert dialog.get_preferences().features.scripts_enabled is False
+
+    dialog._chk_scripts.setChecked(True)
+
+    assert dialog.get_preferences().features.scripts_enabled is True
+
+
+def test_opening_the_dialog_with_scripts_already_on_does_not_warn(qapp, warnings):
+    """The warning is connected after the initial load for exactly this reason: it
+    belongs to the act of switching the flag on, not to opening Preferences."""
+    prefs = cfg.UserPreferences()
+    prefs.features.scripts_enabled = True
+
+    PreferencesDialog(prefs)
+
+    assert warnings == []
+
+
+def test_switching_scripts_on_warns_that_nothing_is_checked(qapp, warnings):
+    dialog = PreferencesDialog(cfg.UserPreferences())
+
+    dialog._chk_scripts.setChecked(True)
+
+    assert len(warnings) == 1
+    assert "none of its limits or interlocks" in warnings[0][2]
+
+
+def test_switching_scripts_back_off_does_not_warn(qapp, warnings):
+    prefs = cfg.UserPreferences()
+    prefs.features.scripts_enabled = True
+    dialog = PreferencesDialog(prefs)
+
+    dialog._chk_scripts.setChecked(False)
+
+    assert warnings == []


### PR DESCRIPTION
Lets a user drop a `.py` file in a folder and run it against the currently loaded experiment, from **Tools → Scripts → Manage scripts…**. No packaging, no registration, no restart.

Covers FIB-338 (data scripts) and FIB-340 (microscope scripts) — #221 was stacked on this branch and its commits are now here, so this is the single PR for the feature.

```python
"""Export the experiment summary to CSV."""   # first line becomes the description

def run(ctx):
    out = ctx.path / "summary.csv"
    ctx.experiment.experiment_summary_dataframe().to_csv(out, index=False)
    return out
```

## Off by default

**File → Preferences… → Features → Enable User Scripts**, unchecked by default. A normal `features` flag in user-preferences alongside coincidence milling and the bug reporter — it persists, and applies live without a restart. A script gets the application's own access to the microscope and none of its guard rails, so nobody acquires the capability by upgrading; an existing `user-preferences.yaml` written before this flag has no key for it and loads as off.

The menu is built and hidden rather than not built. Hidden is not greyed out — it is absent from the menu bar — and it is what makes the preference apply live. Hiding it hides the whole feature, since it is the only route to the dialog and the dialog is the only thing that runs a script. Visibility is `scripts_enabled or runner.is_running`, so turning the flag off mid-run does not take away the only Stop button while the stage is moving.

Switching it on warns once that nothing validates what a script does. Only the Scripts submenu is gated; `Tools` and its `Reporting` submenu already ship on `main`.

## Three layers, so this is testable and reusable

| | |
|---|---|
| `fibsem/scripting.py` | discovery and execution. No Qt, no experiments, no AutoLamella. |
| `fibsem/ui/widgets/script_runner.py` | Qt glue: what may run, running it, rendering the result. Host supplies the folder, a context factory and a notifier. |
| `fibsem/applications/autolamella/scripting.py` | the AutoLamella binding: where scripts live, whether the feature is on, and `ScriptContext`. |

`AutoLamellaMainUI` is left with a menu and a context factory. The menu and dialog are driven standalone in tests, with no application around them.

## Tiers

| Flag | Behaviour |
|---|---|
| none | read-only. Runs inline, `ctx.microscope` withheld. |
| `writes` | confirms first, then `experiment.save()` after it returns. |
| `uses_microscope` | confirms, then runs on a worker thread with Run becoming **Stop**. |
| `background`, `on_workflow_completed` | parsed, inert. FIB-388 covers wiring the latter. |

## Design notes

**`ScriptContext`, never the raw `ui`.** `AutoLamellaUI.experiment` is *rebound* on create/load rather than mutated, so a script holding the ui would silently operate on a dead experiment.

**`ctx.microscope` is `None` unless the flag is declared**, and restored afterwards so a reused context is not left stripped. A guard against forgetting, not a sandbox. Kept as `None` rather than a self-explaining sentinel so `ctx.microscope is None` still works headless; the toast carries the fix instead.

**The menu does not run scripts.** It offers `Manage scripts…` and `Open scripts folder`, built once rather than on `aboutToShow`. A menu item has no Stop button, so a microscope script started from one could not be interrupted.

**Workflow and scripts are mutually exclusive, both ways.** `_script_context()` refuses while a workflow runs (tasks mutate lamella state on a worker thread, so a script would read a torn snapshot), and `_start_run_workflow_thread` refuses while a script runs. The latter has exactly one caller, so that gate is complete.

**No caching — scripts load fresh on every run.** Edit the file, click Run, new code runs. Each load gets a synthetic module name and is kept out of `sys.modules`, so two scripts sharing a filename cannot collide. Side effect: the folder is never on `sys.path`, so a script cannot import a `_helper.py` sibling — installed packages import normally. FIB-386.

**All exceptions are captured at the runner boundary.** PyQt5 aborts the process on anything escaping a slot (FIB-329), so a user's typo must not take the app down.

**The return value carries the output.** There is no console in the app; `print()` goes to a terminal the user may not have, and a packaged Windows build has none. `str` → toast, `DataFrame` → table, `Path` → toast plus the folder opens.

**Failures are rows, not omissions.** A file that fails to import is listed with its reason. Omitted silently, the author sees nothing and assumes the folder is wrong.

**No `experiment_update_signal` after a `writes` script.** All three existing emit sites fire when the experiment or protocol *object is replaced* and re-wire subscribers, so firing it for an in-place mutation forces a full re-wire for nothing. Live updates already flow through the psygnal path — `Experiment.positions` is an `EventedList`, and `Lamella` is `@evented` with the lamella list and card widgets subscribed to `events.description` and `events.defect`.

## Colour says what a script is, not how frightened to be

Amber on Microscope and Writes meant the two most common row types were permanently lit as warnings — alarm fatigue in a list you browse rather than act on, and it left red meaning two different things. Microscope is green, Writes blue, and `_ERROR` red now means exactly one thing: the file will not load. The warning lives in the confirmation dialog, which is modal, worded, and defaults to Cancel.

## Docs and examples

`SCRIPTING.md` gains a GUI section, a microscope section, and the flag.

Three complete examples in `examples/scripts/` — one per tier — are **executed by the test suite** against a real experiment and a `DemoMicroscope`. That is not decoration: the prose-only examples shipped with two bugs that only running them would have caught, one addressing a `lamella.state` attribute that does not exist and one using `microscope.acquire_image`, which ignores `save=True` and silently wrote nothing. I confirmed the tests are not vacuous by mutating the examples — deleting `ctx.raise_if_cancelled()` and swapping back in `microscope.acquire_image` each fail exactly one test and no others.

## Testing

104 tests across the core, the runner, the menu, the dialog, the examples and the feature flag. Full suite **1537 passed, 15 skipped**.

The dialog was rendered offscreen at each step and inspected, which caught what reading the code did not: `QAction`s garbage-collected before the menu drew, cell widgets stacking on rebuild, underscores clipped off script names, rich-text `QLabel`s under-reporting `sizeHint()` so chips lost their last character, an empty folder rendering 450px of void with the only useful sentence stranded at the bottom, and `_chip` measuring its width before the stylesheet resolved — sizing every chip against the default font for text that renders at 10px.

Two pre-existing bugs surfaced on the way: `_fit_type_column` collapsed to 28px and clipped its own header once no row had a chip, and `test_a_long_description_elides_instead_of_clipping` only ever passed by accident — it called `resize(520, 400)` to force eliding, but the dialog's layout minimum is ~720px so the resize never applied.

