### PR TITLE
[tests] Cover the plugin entry point contract with an installed fixture (FIB-383)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,5 +31,12 @@ jobs:
         # UI deps (the [ui] extra) are intentionally not installed: the
         # napari/PyQt5 tests importorskip and are skipped on CI.
         python -m pip install ".[test]"
+    - name: Install the plugin entry point fixture
+      # A packaged plugin is the only way into two of the three extension
+      # points, so the entry point contract needs a plugin installed the way a
+      # user installs one. Without this step tests/test_plugin_entry_points.py
+      # skips, and a refactor could break every third-party plugin with no test
+      # failure. --no-deps because fibsem is already installed above.
+      run: python -m pip install --no-deps tests/fixtures/plugin
     - name: Test with pytest
       run: pytest tests/ -n auto --dist worksteal --timeout=300

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,4 +39,9 @@ jobs:
       # failure. --no-deps because fibsem is already installed above.
       run: python -m pip install --no-deps tests/fixtures/plugin
     - name: Test with pytest
+      env:
+        # Turns the fixture-missing skip into a hard error. Without this, losing
+        # the install step above would silently skip the entry point tests and
+        # leave the build green -- the exact silent breakage they exist to catch.
+        FIBSEM_REQUIRE_PLUGIN_FIXTURE: "1"
       run: pytest tests/ -n auto --dist worksteal --timeout=300

--- a/tests/fixtures/plugin/.gitignore
+++ b/tests/fixtures/plugin/.gitignore
@@ -1,0 +1,6 @@
+# Installing this fixture (see tests/test_plugin_entry_points.py) writes build
+# artefacts here. The repo-root .gitignore does not cover them: its `build/*`
+# and `*.egg-info/*` patterns contain a non-trailing slash, so git anchors them
+# to the root and they never match this directory.
+build/
+*.egg-info/

--- a/tests/fixtures/plugin/fibsem_test_plugin/__init__.py
+++ b/tests/fixtures/plugin/fibsem_test_plugin/__init__.py
@@ -14,3 +14,7 @@ Class names avoid a ``Test`` prefix so pytest does not try to collect them.
 PATTERN_NAME = "Fixture Pattern"
 STRATEGY_NAME = "Fixture Strategy"
 TASK_TYPE = "FIXTURE_TASK"
+
+# Deliberately collides with a built-in pattern, so the documented precedence
+# (builtins > registered > plugins) has something to actually assert against.
+CLASHING_PATTERN_NAME = "Rectangle"

--- a/tests/fixtures/plugin/fibsem_test_plugin/__init__.py
+++ b/tests/fixtures/plugin/fibsem_test_plugin/__init__.py
@@ -1,0 +1,16 @@
+"""A minimal third-party plugin, used to test the entry point contract.
+
+This is not documentation -- see the fibsem-plugin-example repository for that.
+It exists so ``tests/test_plugin_entry_points.py`` can assert that a plugin
+installed the way a user installs one actually resolves through every registry.
+
+Deliberately empty. Each entry point points at its own submodule, because the
+three groups are loaded at different points in fibsem's own import sequence and
+cannot share a module -- see the note in ``patterns.py``.
+
+Class names avoid a ``Test`` prefix so pytest does not try to collect them.
+"""
+
+PATTERN_NAME = "Fixture Pattern"
+STRATEGY_NAME = "Fixture Strategy"
+TASK_TYPE = "FIXTURE_TASK"

--- a/tests/fixtures/plugin/fibsem_test_plugin/patterns.py
+++ b/tests/fixtures/plugin/fibsem_test_plugin/patterns.py
@@ -23,7 +23,7 @@ from typing import ClassVar, List
 from fibsem.milling.patterning.patterns2 import BasePattern
 from fibsem.structures import FibsemRectangleSettings
 
-from fibsem_test_plugin import PATTERN_NAME
+from fibsem_test_plugin import CLASHING_PATTERN_NAME, PATTERN_NAME
 
 
 @dataclass
@@ -44,3 +44,15 @@ class FixturePattern(BasePattern[FibsemRectangleSettings]):
             )
         ]
         return self.shapes
+
+
+@dataclass
+class ClashingPattern(FixturePattern):
+    """Takes the name of a built-in pattern on purpose.
+
+    Registering this must not displace the built-in: get_patterns() merges
+    plugins first and built-ins last, so built-ins win. Without a plugin that
+    actually collides, a test of that precedence asserts nothing.
+    """
+
+    name: ClassVar[str] = CLASHING_PATTERN_NAME

--- a/tests/fixtures/plugin/fibsem_test_plugin/patterns.py
+++ b/tests/fixtures/plugin/fibsem_test_plugin/patterns.py
@@ -1,0 +1,46 @@
+"""Fixture pattern.
+
+This module's imports are load-bearing, and narrower than they look like they
+need to be.
+
+``fibsem/milling/base.py:11`` does ``from fibsem.milling.patterning import
+get_pattern, DEFAULT_MILLING_PATTERN``, and ``patterning/__init__.py`` ends with
+a module-level ``MILLING_PATTERNS = get_patterns()``. So every pattern plugin is
+imported *while ``fibsem.milling.base`` is only partially initialised*.
+
+Anything this module imports that reaches ``fibsem.milling.base`` -- including
+``fibsem.milling.tasks`` and everything under ``fibsem.applications`` -- raises
+ImportError, the plugin loader catches it, and the pattern never registers.
+
+So: patterns import from ``patterns2`` and ``fibsem.structures``, and nothing
+else. That is also why a plugin's pattern, strategy and task have to live in
+separate modules rather than one.
+"""
+
+from dataclasses import dataclass, field
+from typing import ClassVar, List
+
+from fibsem.milling.patterning.patterns2 import BasePattern
+from fibsem.structures import FibsemRectangleSettings
+
+from fibsem_test_plugin import PATTERN_NAME
+
+
+@dataclass
+class FixturePattern(BasePattern[FibsemRectangleSettings]):
+    name: ClassVar[str] = PATTERN_NAME
+
+    width: float = field(default=10.0e-6, metadata={"label": "Width", "unit": "m"})
+    depth: float = field(default=1.0e-6, metadata={"label": "Depth", "unit": "m"})
+
+    def define(self) -> List[FibsemRectangleSettings]:
+        self.shapes = [
+            FibsemRectangleSettings(
+                width=self.width,
+                height=self.width,
+                depth=self.depth,
+                centre_x=self.point.x,
+                centre_y=self.point.y,
+            )
+        ]
+        return self.shapes

--- a/tests/fixtures/plugin/fibsem_test_plugin/strategies.py
+++ b/tests/fixtures/plugin/fibsem_test_plugin/strategies.py
@@ -1,0 +1,39 @@
+"""Fixture milling strategy."""
+
+import threading
+from dataclasses import dataclass, field
+from typing import Optional
+
+from fibsem.microscope import FibsemMicroscope
+from fibsem.milling.base import (
+    FibsemMillingStage,
+    MillingStrategy,
+    MillingStrategyConfig,
+)
+
+from fibsem_test_plugin import STRATEGY_NAME
+
+
+@dataclass
+class FixtureMillingStrategyConfig(MillingStrategyConfig):
+    passes: int = field(default=1, metadata={"label": "Passes"})
+
+
+class FixtureMillingStrategy(MillingStrategy[FixtureMillingStrategyConfig]):
+    name: str = STRATEGY_NAME
+    fullname: str = "Fixture Milling Strategy"
+    config_class = FixtureMillingStrategyConfig
+
+    # Keeps the fixture out of the strategy dropdown if a developer happens to
+    # have it installed in the environment they run the app from.
+    selectable: bool = False
+
+    def run(
+        self,
+        microscope: FibsemMicroscope,
+        stage: FibsemMillingStage,
+        asynch: bool = False,
+        parent_ui=None,
+        stop_event: Optional[threading.Event] = None,
+    ) -> None:
+        raise NotImplementedError("fixture strategy is never executed")

--- a/tests/fixtures/plugin/fibsem_test_plugin/tasks.py
+++ b/tests/fixtures/plugin/fibsem_test_plugin/tasks.py
@@ -1,0 +1,25 @@
+"""Fixture AutoLamella task."""
+
+from dataclasses import dataclass, field
+from typing import ClassVar, Type
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+
+from fibsem_test_plugin import TASK_TYPE
+
+
+@dataclass
+class FixtureTaskConfig(AutoLamellaTaskConfig):
+    task_type: ClassVar[str] = TASK_TYPE
+    display_name: ClassVar[str] = "Fixture Task"
+
+    number: int = field(default=7, metadata={"help": "A round-trippable parameter"})
+
+
+class FixtureTask(AutoLamellaTask):
+    config: FixtureTaskConfig
+    config_cls: ClassVar[Type[FixtureTaskConfig]] = FixtureTaskConfig
+
+    def _run(self) -> None:
+        raise NotImplementedError("fixture task is never executed")

--- a/tests/fixtures/plugin/pyproject.toml
+++ b/tests/fixtures/plugin/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fibsem-test-plugin"
+version = "0.0.0"
+description = "Test fixture: a package declaring all three fibsem entry point groups"
+requires-python = ">=3.8"
+
+# The point of the fixture. These three group names are the plugin contract;
+# nothing in fibsem scans for near-misses, so a typo here would produce a
+# plugin that loads nowhere and reports nothing.
+#
+# One module per group, not one shared module: the three registries are built
+# at different points in fibsem's own import sequence, and a pattern module in
+# particular cannot reach fibsem.milling.base. See patterns.py.
+[project.entry-points."fibsem.patterns"]
+fixture_pattern = "fibsem_test_plugin.patterns:FixturePattern"
+
+[project.entry-points."fibsem.strategies"]
+fixture_strategy = "fibsem_test_plugin.strategies:FixtureMillingStrategy"
+
+[project.entry-points."fibsem.tasks"]
+fixture_task = "fibsem_test_plugin.tasks:FixtureTask"
+
+[tool.setuptools]
+packages = ["fibsem_test_plugin"]

--- a/tests/fixtures/plugin/pyproject.toml
+++ b/tests/fixtures/plugin/pyproject.toml
@@ -17,6 +17,8 @@ requires-python = ">=3.8"
 # particular cannot reach fibsem.milling.base. See patterns.py.
 [project.entry-points."fibsem.patterns"]
 fixture_pattern = "fibsem_test_plugin.patterns:FixturePattern"
+# Claims a built-in's name on purpose; built-ins must still win.
+clashing_pattern = "fibsem_test_plugin.patterns:ClashingPattern"
 
 [project.entry-points."fibsem.strategies"]
 fixture_strategy = "fibsem_test_plugin.strategies:FixtureMillingStrategy"

--- a/tests/test_plugin_entry_points.py
+++ b/tests/test_plugin_entry_points.py
@@ -17,15 +17,23 @@ rather than failing. To run them:
 
     pip install --no-deps tests/fixtures/plugin
 
+In CI the workflow sets ``FIBSEM_REQUIRE_PLUGIN_FIXTURE=1``, which turns that
+skip into a hard failure. Without it these tests could be disabled by deleting
+the install step and CI would stay green -- which is precisely the shape of
+silent breakage this file exists to catch, so it must not be possible here.
+
 The counterpart to this file lives in the fibsem-plugin-example repository,
 which checks the same contract from the outside, against fibsem main.
 """
+
+import os
 
 import pytest
 
 PATTERN_NAME = "Fixture Pattern"
 STRATEGY_NAME = "Fixture Strategy"
 TASK_TYPE = "FIXTURE_TASK"
+CLASHING_PATTERN_NAME = "Rectangle"  # a built-in name the fixture claims on purpose
 
 def _fixture_installed() -> bool:
     """Detect the fixture without importing it.
@@ -52,10 +60,20 @@ def _fixture_installed() -> bool:
     return any(ep.name == "fixture_pattern" for ep in entry_points(group="fibsem.patterns"))
 
 
+_INSTALLED = _fixture_installed()
+
+if not _INSTALLED and os.environ.get("FIBSEM_REQUIRE_PLUGIN_FIXTURE") == "1":
+    raise RuntimeError(
+        "FIBSEM_REQUIRE_PLUGIN_FIXTURE=1 but the plugin fixture is not installed. "
+        "The CI step that runs `pip install --no-deps tests/fixtures/plugin` is "
+        "missing or failed. Skipping here would leave the entry point contract "
+        "untested with a green build."
+    )
+
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.skipif(
-        not _fixture_installed(),
+        not _INSTALLED,
         reason="plugin fixture not installed: pip install --no-deps tests/fixtures/plugin",
     ),
 ]
@@ -156,10 +174,33 @@ def test_milling_stage_built_from_yaml_uses_both_plugin_classes():
 
 
 def test_builtins_win_name_clashes():
-    """Documented precedence: builtins > runtime-registered > plugins. A plugin
-    cannot silently replace a built-in pattern."""
+    """Documented precedence: builtins > runtime-registered > plugins.
+
+    The fixture registers a pattern under a built-in's name on purpose. Without
+    a plugin that actually collides this test asserts nothing -- every built-in
+    trivially maps to itself when no plugin competes for the name.
+    """
     from fibsem.milling.patterning import BUILTIN_PATTERNS, get_patterns
 
     patterns = get_patterns()
+
+    # the colliding entry point resolved, so the precedence rule is under load
+    assert CLASHING_PATTERN_NAME in BUILTIN_PATTERNS
+    assert patterns[CLASHING_PATTERN_NAME] is BUILTIN_PATTERNS[CLASHING_PATTERN_NAME]
+    assert patterns[CLASHING_PATTERN_NAME].__module__.startswith("fibsem.")
+
+    # and no other built-in was displaced either
     for name, cls in BUILTIN_PATTERNS.items():
         assert patterns[name] is cls
+
+
+def test_shadowed_plugin_is_not_silently_reported_as_the_builtin():
+    """A shadowed plugin should be absent, not masquerading.
+
+    get_pattern() must hand back the built-in class, so a protocol naming
+    "Rectangle" keeps meaning the built-in even with the plugin installed.
+    """
+    from fibsem.milling.patterning import get_pattern
+    from fibsem.milling.patterning.patterns2 import RectanglePattern
+
+    assert isinstance(get_pattern(CLASHING_PATTERN_NAME), RectanglePattern)

--- a/tests/test_plugin_entry_points.py
+++ b/tests/test_plugin_entry_points.py
@@ -1,0 +1,157 @@
+"""The plugin entry point contract.
+
+fibsem exposes three extension points -- ``fibsem.patterns``,
+``fibsem.strategies`` and ``fibsem.tasks`` -- and for patterns and strategies a
+packaged plugin is the *only* way in. Nothing in the test suite exercised that
+path, so a refactor could break every third-party plugin in existence without a
+single test failing; the breakage would surface months later on a user's
+microscope, as a class that silently fails to appear.
+
+These tests close that gap. ``tests/fixtures/plugin`` is a package that
+declares all three groups the way a real plugin does; CI installs it before
+running the suite, and the tests assert it resolves through fibsem's own
+registries -- not merely that it imports.
+
+The fixture is not installed by default, so a bare local ``pytest`` skips these
+rather than failing. To run them:
+
+    pip install --no-deps tests/fixtures/plugin
+
+The counterpart to this file lives in the fibsem-plugin-example repository,
+which checks the same contract from the outside, against fibsem main.
+"""
+
+import pytest
+
+PATTERN_NAME = "Fixture Pattern"
+STRATEGY_NAME = "Fixture Strategy"
+TASK_TYPE = "FIXTURE_TASK"
+
+def _fixture_installed() -> bool:
+    """Detect the fixture without importing it.
+
+    Deliberately not ``pytest.importorskip``: importing the plugin package
+    before fibsem's registries are built poisons them. The registry functions
+    are ``@cache``d, so the empty result is locked in for the rest of the
+    process and every assertion below fails for the wrong reason. Asking the
+    entry point metadata is both safer and a more direct test of the contract.
+    """
+    try:
+        from importlib.metadata import entry_points
+    except ImportError:  # Python < 3.10
+        from importlib_metadata import entry_points
+
+    return any(ep.name == "fixture_pattern" for ep in entry_points(group="fibsem.patterns"))
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _fixture_installed(),
+        reason="plugin fixture not installed: pip install --no-deps tests/fixtures/plugin",
+    ),
+]
+
+
+def test_pattern_plugin_resolves_through_the_registry():
+    from fibsem.milling.patterning import get_pattern, get_pattern_names, get_patterns
+
+    assert PATTERN_NAME in get_patterns(), sorted(get_patterns())
+    assert PATTERN_NAME in get_pattern_names()
+
+    pattern = get_pattern(PATTERN_NAME, {"width": 20.0e-6})
+    assert type(pattern).__name__ == "FixturePattern"
+    assert pattern.width == 20.0e-6
+    assert len(pattern.define()) == 1
+
+
+def test_pattern_plugin_round_trips_through_a_protocol_dict():
+    """A pattern that cannot survive to_dict/from_dict works in the UI and
+    vanishes when the protocol is reloaded."""
+    from fibsem.milling.patterning import get_pattern
+
+    pattern = get_pattern(PATTERN_NAME, {"width": 15.0e-6})
+    ddict = pattern.to_dict()
+
+    assert ddict["name"] == PATTERN_NAME
+    assert get_pattern(ddict["name"], ddict).width == 15.0e-6
+
+
+def test_strategy_plugin_resolves_through_the_registry():
+    from fibsem.milling.base import get_strategy
+    from fibsem.milling.strategy import get_strategies
+
+    assert STRATEGY_NAME in get_strategies(), sorted(get_strategies())
+
+    strategy = get_strategy(STRATEGY_NAME, {"config": {"passes": 3}})
+    assert type(strategy).__name__ == "FixtureMillingStrategy"
+    assert strategy.config.passes == 3
+    assert strategy.to_dict()["name"] == STRATEGY_NAME
+
+
+def test_unselectable_strategy_is_hidden_from_the_dropdown():
+    """``selectable = False`` is how a strategy stays out of the UI while
+    remaining resolvable by name from an existing protocol."""
+    from fibsem.milling.strategy import get_strategies, get_strategy_names
+
+    assert STRATEGY_NAME in get_strategies()
+    assert STRATEGY_NAME not in get_strategy_names()
+
+
+def test_task_plugin_resolves_through_the_registry():
+    from fibsem.applications.autolamella.workflows.tasks import (
+        get_task_config,
+        get_task_names,
+        get_tasks,
+    )
+
+    assert TASK_TYPE in get_tasks(), sorted(get_tasks())
+    assert TASK_TYPE in get_task_names()
+    assert get_task_config(TASK_TYPE).__name__ == "FixtureTaskConfig"
+
+
+def test_task_plugin_survives_protocol_load():
+    """load_task_config() skips task types it does not recognise with only a log
+    warning: the task disappears from the protocol and re-saving drops it from
+    the yaml. A plugin task must not be one of them."""
+    from fibsem.applications.autolamella.workflows.tasks import load_task_config
+
+    loaded = load_task_config(
+        {"Fixture": {"task_type": TASK_TYPE, "parameters": {"number": 42}}}
+    )
+
+    assert "Fixture" in loaded, dict(loaded)
+    assert loaded["Fixture"].number == 42
+    assert loaded["Fixture"].task_name == "Fixture"
+
+
+def test_milling_stage_built_from_yaml_uses_both_plugin_classes():
+    """The end-to-end shape: a protocol naming a plugin pattern and a plugin
+    strategy produces a milling stage."""
+    from fibsem.milling.base import FibsemMillingStage
+
+    stage = FibsemMillingStage.from_dict(
+        {
+            "name": "Fixture Stage",
+            "milling": {},
+            "pattern": {"name": PATTERN_NAME, "width": 12.0e-6},
+            "strategy": {"name": STRATEGY_NAME, "config": {"passes": 2}},
+        }
+    )
+
+    assert stage.pattern.name == PATTERN_NAME
+    assert stage.strategy.name == STRATEGY_NAME
+
+    ddict = stage.to_dict()
+    assert ddict["pattern"]["name"] == PATTERN_NAME
+    assert ddict["strategy"]["name"] == STRATEGY_NAME
+
+
+def test_builtins_win_name_clashes():
+    """Documented precedence: builtins > runtime-registered > plugins. A plugin
+    cannot silently replace a built-in pattern."""
+    from fibsem.milling.patterning import BUILTIN_PATTERNS, get_patterns
+
+    patterns = get_patterns()
+    for name, cls in BUILTIN_PATTERNS.items():
+        assert patterns[name] is cls

--- a/tests/test_plugin_entry_points.py
+++ b/tests/test_plugin_entry_points.py
@@ -35,11 +35,19 @@ def _fixture_installed() -> bool:
     are ``@cache``d, so the empty result is locked in for the rest of the
     process and every assertion below fails for the wrong reason. Asking the
     entry point metadata is both safer and a more direct test of the contract.
+
+    Guard on the version, not on ImportError: ``importlib.metadata`` exists
+    from 3.8, so a try/except import succeeds on 3.8/3.9 and then fails at the
+    call with ``entry_points() got an unexpected keyword argument 'group'`` --
+    the ``group=`` filter only arrived in 3.10. This is the same check the
+    plugin loaders themselves use.
     """
-    try:
-        from importlib.metadata import entry_points
-    except ImportError:  # Python < 3.10
+    import sys
+
+    if sys.version_info < (3, 10):
         from importlib_metadata import entry_points
+    else:
+        from importlib.metadata import entry_points
 
     return any(ep.name == "fixture_pattern" for ep in entry_points(group="fibsem.patterns"))
 


### PR DESCRIPTION
Closes FIB-383.

Nothing in the suite loaded a plugin. All three entry point groups — `fibsem.patterns`, `fibsem.strategies`, `fibsem.tasks` — were exercised only through their built-in registries, which are populated in code, so `entry_points()` was never called anywhere in the tests. A refactor could break every third-party plugin without a single failure, and it would surface months later on a user's microscope: the loaders catch and log, so nothing is reported in the app.

Patterns and strategies have no alternative to a packaged plugin, so this is not a hypothetical extension point — it is the only one those two have.

## What's here

* **`tests/fixtures/plugin/`** — a small package declaring all three groups the way a real plugin does. The strategy and task raise `NotImplementedError`; nothing is ever executed, only resolved.
* **`tests/test_plugin_entry_points.py`** — 9 tests. Beyond "it's in the dict": patterns round-trip through `to_dict`/`from_dict` (a pattern that can't works in the UI and vanishes on protocol reload), `load_task_config()` doesn't silently drop the task type, a `FibsemMillingStage` builds from yaml dicts using a plugin pattern *and* a plugin strategy together, `selectable = False` hides a strategy from the dropdown while staying resolvable by name, and built-ins win a real name clash.
* **One CI step** — `pip install --no-deps tests/fixtures/plugin`, plus `FIBSEM_REQUIRE_PLUGIN_FIXTURE=1` on the pytest step. No network beyond what CI already does, no external repo in the dependency graph, no Qt: all three registries import with napari/PyQt5 blocked.

## The constraint the fixture encodes

The fixture is three modules rather than one, and that is load-bearing:

```
fibsem.milling.base  (starts importing)
  └─ line 11: from fibsem.milling.patterning import get_pattern, DEFAULT_MILLING_PATTERN
       └─ patterning/__init__.py runs to: MILLING_PATTERNS = get_patterns()
            └─ loads the pattern plugin   ←── mid-import
                 └─ ...which imports AutoLamellaTaskConfig
                      └─ autolamella.structures → fibsem.milling.tasks
                           └─ from fibsem.milling.base import FibsemMillingStage
                                └─ ImportError: partially initialized module
```

So a pattern plugin cannot import anything reaching back into `fibsem.milling.base` — including `fibsem.milling.tasks` and all of `fibsem.applications`. Sharing a module with the task is enough to trip it. The first version of the fixture did exactly that and failed every registry assertion.

Same reason the fixture is detected via `entry_points()` rather than `pytest.importorskip`: importing a plugin package before the registries are built poisons them, since the registry functions are `@cache`d and the empty result is locked in for the process. And the version guard is on `sys.version_info`, not `try/except ImportError` — `importlib.metadata` exists from 3.8, but its `group=` keyword only arrived in 3.10.

Worth noting for later: deleting the `MILLING_PATTERNS` snapshot (and `TASK_REGISTRY`, FIB-343) would remove this hazard at the source rather than documenting around it.

## Skipping is not allowed to hide a broken contract

The tests skip when the fixture is absent, so a bare local `pytest` is unchanged. But a test that skips silently is how this whole class of bug survives, so CI sets `FIBSEM_REQUIRE_PLUGIN_FIXTURE=1` and the skip becomes a hard error. Deleting the install step now fails the build instead of quietly passing it.

## Reviewing

```
pip install --no-deps tests/fixtures/plugin
pytest tests/test_plugin_entry_points.py -v
```

Mutation-tested rather than just green. Each of these fails the suite: a typo'd entry point group, a package-level import in the pattern module, a `run()` override on the task, a merged pattern+task module, a missing fixture with the CI env var set, and reversing the merge order in `get_patterns()`.

Numbers, `-m "not slow"`:

| | collected | passed | skipped |
| -- | -- | -- | -- |
| without fixture (bare `pytest`) | 1456 | 1432 | 24 |
| with fixture (CI) | 1457 | 1442 | 15 |

The +10 is the 9 tests going skipped→passed plus one free case from `tests/milling/test_patterns.py::test_required_attributes`, which parametrizes over `MILLING_PATTERNS.values()` and so now covers plugin patterns too. No other test is affected.

The fixture is never in the fibsem wheel — verified: no `fibsem_test_plugin` files, no `tests/`, and `entry_points.txt` carries only `console_scripts`. It only becomes visible to anything if installed as its own distribution, which nothing but the CI step does.

## Related

The outside-in counterpart is [fibsem-os/fibsem-plugin-example](https://github.com/fibsem-os/fibsem-plugin-example) (FIB-346), whose CI checks the same contract against fibsem `main` weekly. This PR is what fails on the breaking PR itself.