### PR TITLE
[feat] Let scripts drive the microscope (FIB-340)

### DIFF
--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -223,11 +223,54 @@ def run(ctx):
 | Flag | What it does |
 |---|---|
 | `writes = True` | asks you to confirm before running, then calls `ctx.save()` afterwards |
+| `uses_microscope = True` | asks you to confirm, then runs the script on a background thread with `ctx.microscope` available |
 | `background = True` | **not implemented** — parsed, but the script still runs inline |
-| `uses_microscope = True` | **not implemented** — the script is refused rather than run |
 | `on_workflow_completed = True` | **not implemented** — nothing runs it automatically |
 
 Without `writes`, nothing your script changed is persisted — a read-only script cannot rewrite `experiment.yaml` by accident.
+
+## Microscope scripts
+
+`uses_microscope = True` gives you `ctx.microscope` and lets the script drive the hardware.
+
+**Nothing validates what you do.** There are no limits, no interlocks and no checks that the state you left the microscope in is sane. A script that drives the stage into the pole piece will do exactly that. This is the same access the application's own code has, with none of its guard rails — treat it accordingly, and test on a dummy or a sacrificial grid first.
+
+```python
+"""Acquire an ion image at every lamella position."""
+uses_microscope = True
+
+from fibsem.structures import BeamType, ImageSettings
+
+
+def run(ctx):
+    settings = ImageSettings(hfw=80e-6, beam_type=BeamType.ION, save=True)
+
+    for lamella in ctx.experiment.positions:
+        ctx.raise_if_cancelled()          # let Stop actually stop it
+        ctx.log(f"moving to {lamella.name}")
+        ctx.microscope.safe_absolute_stage_movement(lamella.state.stage_position)
+        settings.path, settings.filename = lamella.path, "script-survey"
+        ctx.microscope.acquire_image(settings)
+
+    return f"imaged {len(ctx.experiment.positions)} positions"
+```
+
+### How these differ from data scripts
+
+**They run on a background thread.** Hardware operations take seconds to minutes, and running one inline would freeze the window for the whole time, which is indistinguishable from a crash. The dialog's Run button becomes **Stop** while the script runs.
+
+**So do not touch `ctx.experiment` from one.** It holds evented containers whose change handlers write straight into widgets, and those must only be touched from the GUI thread. Reading is generally fine; mutating is not. Nothing stops you — this is a convention you have to keep.
+
+**Stop is cooperative, and it is your job.** A Python thread cannot be killed. Pressing Stop sets a flag; nothing happens until your script looks at it:
+
+```python
+ctx.raise_if_cancelled()   # raises, unwinding the script
+if ctx.cancelled: ...      # or check it yourself and return
+```
+
+A script that never checks runs to completion no matter how many times Stop is pressed. Call it between steps — after each move, between images.
+
+**One at a time, and never alongside a workflow.** A second script is refused while one is running, and starting a workflow is refused while a microscope script is running — otherwise two things end up commanding the stage at once.
 
 ### Editing and re-running
 
@@ -241,7 +284,7 @@ Scripts are re-read from disk on every run. Edit the file, click Run, and the ne
 
 **Scripts are unavailable with no experiment loaded, and while a workflow is running.** The menu says which. A workflow mutates lamella state from a worker thread, so a script reading mid-run would see a torn snapshot.
 
-**`ctx.microscope` exists, and you should not use it.** Scripts that declare `uses_microscope` are refused, because the guarantees they need — hardware exclusion, cancellation, restoring state afterwards — do not exist yet. Touching the microscope without declaring the flag gets you past the check, not past the missing guarantees.
+**`ctx.microscope` is there whether or not you declared the flag.** Reaching for it from a script that did not declare `uses_microscope` skips the confirmation, runs the hardware call on the GUI thread, and lets a workflow start underneath you. Declare the flag.
 
 ## Gotchas
 

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -159,7 +159,9 @@ To clear a mark again, use `lamella.defect.clear()`.
 
 ## Running scripts from the GUI
 
-Everything above assumes you loaded the experiment yourself. AutoLamella can instead run a script against the experiment it already has open, from **Tools → Scripts**.
+Everything above assumes you loaded the experiment yourself. AutoLamella can instead run a script against the experiment it already has open, from **Tools → Scripts → Manage scripts…**.
+
+Everything happens in that dialog. The menu itself only opens it and the scripts folder — it deliberately does not run anything, because a menu item has no way to show you a script that is still going, and no way to stop it.
 
 Drop a `.py` file in:
 
@@ -240,6 +242,7 @@ Without `writes`, nothing your script changed is persisted — a read-only scrip
 """Acquire an ion image at every lamella position."""
 uses_microscope = True
 
+from fibsem import acquire
 from fibsem.structures import BeamType, ImageSettings
 
 
@@ -249,12 +252,14 @@ def run(ctx):
     for lamella in ctx.experiment.positions:
         ctx.raise_if_cancelled()          # let Stop actually stop it
         ctx.log(f"moving to {lamella.name}")
-        ctx.microscope.safe_absolute_stage_movement(lamella.state.stage_position)
+        ctx.microscope.safe_absolute_stage_movement(lamella.stage_position)
         settings.path, settings.filename = lamella.path, "script-survey"
-        ctx.microscope.acquire_image(settings)
+        acquire.acquire_image(ctx.microscope, settings)
 
     return f"imaged {len(ctx.experiment.positions)} positions"
 ```
+
+Use `fibsem.acquire.acquire_image(microscope, settings)`, not `microscope.acquire_image(settings)`. The method on the microscope is the raw grab and **ignores `save=True`** — the module-level function is the one that applies autocontrast, auto-gamma and writes the file.
 
 ### How these differ from data scripts
 
@@ -277,13 +282,13 @@ A script that never checks runs to completion no matter how many times Stop is p
 
 Scripts are re-read from disk on every run. Edit the file, click Run, and the new code runs; there is no reload button because there is nothing to reload.
 
-**Manage scripts…** also lists the files that failed to import, with the reason. A file with `def main(ctx)` instead of `def run(ctx)` shows up as an error row rather than quietly disappearing from the menu.
+The dialog also lists the files that failed to import, with the reason. A file with `def main(ctx)` instead of `def run(ctx)` shows up as an error row rather than quietly disappearing from the list.
 
 ### What to expect
 
 **The window freezes while a script runs.** Scripts run on the GUI thread, so a slow loop over thousands of images locks the interface until it finishes. Keep GUI scripts short and do the heavy work headlessly.
 
-**Scripts are unavailable with no experiment loaded, and while a workflow is running.** The menu says which. A workflow mutates lamella state from a worker thread, so a script reading mid-run would see a torn snapshot.
+**Scripts are unavailable with no experiment loaded, and while a workflow is running.** Run is greyed out and the dialog says which. A workflow mutates lamella state from a worker thread, so a script reading mid-run would see a torn snapshot.
 
 **`ctx.microscope` is `None` unless you declared `uses_microscope`.** If you reach for it without the flag you get `AttributeError: 'NoneType' object has no attribute …` — add the flag rather than working around it. This is a guard against forgetting, not a sandbox: a script is arbitrary Python and can import its way to a microscope handle. Doing that skips the confirmation, runs the hardware call on the GUI thread, and lets a workflow start underneath you.
 

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -192,6 +192,7 @@ That is all of it — no registration step, nothing to install, no restart. File
 | `ctx.path` | its directory — the default place to write output |
 | `ctx.log(message)` | writes to the log, tagged with your script's name |
 | `ctx.save()` | called for you; see `writes` below |
+| `ctx.microscope` | the microscope, or `None` unless you declared `uses_microscope` |
 
 ### Showing your results
 
@@ -284,7 +285,7 @@ Scripts are re-read from disk on every run. Edit the file, click Run, and the ne
 
 **Scripts are unavailable with no experiment loaded, and while a workflow is running.** The menu says which. A workflow mutates lamella state from a worker thread, so a script reading mid-run would see a torn snapshot.
 
-**`ctx.microscope` is there whether or not you declared the flag.** Reaching for it from a script that did not declare `uses_microscope` skips the confirmation, runs the hardware call on the GUI thread, and lets a workflow start underneath you. Declare the flag.
+**`ctx.microscope` is `None` unless you declared `uses_microscope`.** If you reach for it without the flag you get `AttributeError: 'NoneType' object has no attribute …` — add the flag rather than working around it. This is a guard against forgetting, not a sandbox: a script is arbitrary Python and can import its way to a microscope handle. Doing that skips the confirmation, runs the hardware call on the GUI thread, and lets a workflow start underneath you.
 
 ## Gotchas
 

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -171,6 +171,18 @@ Drop a `.py` file in:
 
 Set `AUTOLAMELLA_SCRIPTS_DIR` to use a different folder. **Tools → Scripts → Manage scripts…** shows which folder it resolved to; **Open folder** there creates it if it does not exist yet, and **New script…** writes a working stub into it.
 
+### Working examples
+
+Three complete scripts live in [`examples/scripts/`](examples/scripts), one per tier. Copy any of them into your scripts folder and it will run as-is.
+
+| File | Flags | What it shows |
+| -- | -- | -- |
+| [`export_summary.py`](examples/scripts/export_summary.py) | none | reading the experiment, and how the return value becomes output |
+| [`describe_lamellae.py`](examples/scripts/describe_lamellae.py) | `writes` | changing lamellae and letting the runner save |
+| [`survey_positions.py`](examples/scripts/survey_positions.py) | `uses_microscope` | moving the stage, acquiring, and honouring Stop |
+
+These are executed by the test suite (`tests/autolamella/test_example_scripts.py`) against a real experiment and a simulated microscope, so they cannot quietly rot. That is deliberate: earlier versions of the snippets below shipped with two bugs that only running them would have caught — one addressed a `lamella.state` attribute that does not exist, and one used `microscope.acquire_image`, which ignores `save=True` and writes nothing.
+
 ### The contract
 
 One rule: a module-level `run(ctx)`.

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -184,7 +184,9 @@ def run(ctx):
     return out
 ```
 
-That is all of it — no registration step, nothing to install, no restart. Files whose names start with `_` are skipped, so you can keep shared helpers in the same folder.
+That is all of it — no registration step, nothing to install, no restart. Files whose names start with `_` are hidden from the list.
+
+You can import anything installed — the standard library, `numpy`, `pandas`, and all of `fibsem` itself. You **cannot** import another file from the scripts folder: the folder is not on `sys.path`, so `import _helpers` fails even with the file sitting right beside your script. To share code between scripts, put it in a small package of your own and `pip install -e` it.
 
 `ctx` carries:
 

--- a/examples/scripts/describe_lamellae.py
+++ b/examples/scripts/describe_lamellae.py
@@ -1,0 +1,28 @@
+"""Note the last completed task on every lamella."""
+
+# The runner calls ctx.save() for you after this returns, and asks the user to
+# confirm before it starts. Without this flag the loop below would still run and
+# still change things in memory, but nothing would be written to disk -- so a
+# script that means to persist has to say so.
+writes = True
+
+
+def run(ctx):
+    lamellae = ctx.experiment.positions
+
+    changed = 0
+    for lamella in lamellae:
+        task = lamella.last_completed_task
+        note = f"last task: {task.name}" if task else "no tasks completed yet"
+
+        if lamella.description == note:
+            continue  # nothing to do, and no point dirtying the save
+
+        # `description` is one of the fields the lamella list and card widgets
+        # subscribe to (lamella.events.description), so the GUI updates as this
+        # loop runs -- no refresh call and no signal needed.
+        lamella.description = note
+        changed += 1
+
+    ctx.log(f"updated {changed} of {len(lamellae)}")
+    return f"described {changed} of {len(lamellae)} lamellae"

--- a/examples/scripts/export_summary.py
+++ b/examples/scripts/export_summary.py
@@ -1,0 +1,30 @@
+"""Export a summary of every lamella to CSV."""
+
+# No flags. This script only reads, so the runner withholds ctx.microscope and
+# never saves the experiment -- there is nothing here that can damage anything.
+# Read-only is the default; the other two examples opt out of it explicitly.
+
+
+def run(ctx):
+    experiment = ctx.experiment
+
+    # Needs a protocol loaded: this dataframe asks the protocol whether each
+    # lamella is complete, so it raises AttributeError on an experiment saved
+    # without one. experiment.task_history_dataframe() has no such requirement.
+    df = experiment.experiment_summary_dataframe()
+
+    # ctx.path is the experiment directory. Writing there by default keeps
+    # exports next to the data they came from.
+    out = ctx.path / "lamella-summary.csv"
+    df.to_csv(out, index=False)
+
+    # ctx.log goes to the application log, tagged with this script's name.
+    ctx.log(f"wrote {len(df)} rows to {out.name}")
+
+    # What you return decides what the user sees:
+    #   Path      -> a toast, with an offer to open the containing folder
+    #   str       -> a toast with that message
+    #   DataFrame -> a table dialog
+    # Returning None is legal but looks like the script did nothing, because
+    # there is no log console in the application to fall back on.
+    return out

--- a/examples/scripts/survey_positions.py
+++ b/examples/scripts/survey_positions.py
@@ -1,0 +1,41 @@
+"""Acquire an ion image at every lamella position."""
+
+# Declaring this hands the script ctx.microscope and moves it onto a worker
+# thread, so the window stays responsive and the Run button becomes Stop. Nothing
+# validates what the script then does -- no limits, no interlocks. Without the
+# flag ctx.microscope is None, on purpose.
+uses_microscope = True
+
+from fibsem import acquire
+from fibsem.structures import BeamType, ImageSettings
+
+
+def run(ctx):
+    # acquire.acquire_image, NOT ctx.microscope.acquire_image. Only this one
+    # applies autocontrast and auto-gamma and honours save=True; the microscope
+    # method silently ignores it and writes nothing to disk.
+    settings = ImageSettings(hfw=80e-6, beam_type=BeamType.ION, save=True)
+
+    lamellae = ctx.experiment.positions
+    imaged = 0
+
+    for lamella in lamellae:
+        # Stopping is cooperative. A Python thread cannot be killed, so Stop only
+        # sets a flag -- if the script never asks, the button does nothing and the
+        # run continues to the end. Ask once per iteration, before the slow part.
+        ctx.raise_if_cancelled()
+
+        ctx.log(f"moving to {lamella.name}")
+        ctx.microscope.safe_absolute_stage_movement(lamella.stage_position)
+
+        # Each lamella has its own directory, so images land beside that lamella.
+        settings.path = lamella.path
+        settings.filename = "survey"
+        acquire.acquire_image(ctx.microscope, settings)
+        imaged += 1
+
+    # Reading ctx.experiment from a microscope script is fine. *Writing* to it is
+    # not: this runs off the GUI thread, and the experiment is psygnal-evented, so
+    # assigning to it here would drive widget updates from the wrong thread. Do
+    # the hardware work here and the bookkeeping in a separate `writes` script.
+    return f"imaged {imaged} of {len(lamellae)} positions"

--- a/fibsem/applications/autolamella/scripting.py
+++ b/fibsem/applications/autolamella/scripting.py
@@ -9,9 +9,12 @@ See SCRIPTING.md for the headless equivalent, and FIB-338 for the design.
 
 import logging
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, Optional
+
+from fibsem.cancellation import raise_if_cancelled
 
 from fibsem.scripting import (  # noqa: F401 - re-exported for callers
     DiscoveredScript,
@@ -63,6 +66,10 @@ class ScriptContext:
     experiment: "Experiment"
     log: Callable[[str], None] = logging.info
     microscope: Optional["FibsemMicroscope"] = None
+    # Set by the runner for scripts that run off the GUI thread. A script cannot be
+    # killed -- Python threads have no such thing -- so stopping one is cooperative:
+    # the runner sets this, and the script has to look at it.
+    stop_event: Optional[threading.Event] = None
 
     @property
     def path(self) -> Path:
@@ -72,3 +79,17 @@ class ScriptContext:
     def save(self) -> None:
         """Persist the experiment. Called by the runner only for ``writes`` scripts."""
         self.experiment.save()
+
+    @property
+    def cancelled(self) -> bool:
+        """Whether the user has asked this script to stop."""
+        return self.stop_event is not None and self.stop_event.is_set()
+
+    def raise_if_cancelled(self, msg: str = "Script cancelled by user.") -> None:
+        """Abort the script if the user pressed Stop.
+
+        Call between steps of a long run — after each move, between images. A
+        script that never calls it (or never checks :attr:`cancelled`) simply
+        runs to completion, and Stop does nothing.
+        """
+        raise_if_cancelled(self.stop_event, msg)

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -299,6 +299,16 @@ class AutoLamellaUI(QMainWindow):
             self._task_worker_thread is not None and self._task_worker_thread.is_alive()
         )
 
+    def _script_runner_is_busy(self) -> bool:
+        """Whether a user script is currently driving the microscope (FIB-340).
+
+        Reached through the parent window, which owns the Scripts menu. Absent in
+        the tests and in any host that never built one, so this stays optional
+        rather than asserting the attribute exists.
+        """
+        controller = getattr(self.parent_widget, "script_menu_controller", None)
+        return bool(controller is not None and controller.runner.is_running)
+
     def setup_connections(self):
 
         # lamella controls
@@ -1007,6 +1017,15 @@ class AutoLamellaUI(QMainWindow):
         self, selected_tasks: List[str], selected_lamella: List[str]
     ) -> None:
         """Start the workflow thread with the selected tasks and lamella, and update the UI accordingly."""
+
+        # A user script may be driving the microscope right now. Scripts are already
+        # blocked while a workflow runs; this is the other direction, so the two
+        # cannot end up moving the stage at the same time (FIB-340).
+        if self._script_runner_is_busy():
+            msg = "A microscope script is running. Stop it before starting a workflow."
+            logging.warning(msg)
+            notification_service.show_toast(msg, "warning")
+            return
 
         # clear milling task config
         self.milling_task_config_widget.clear()  # type: ignore

--- a/fibsem/scripting.py
+++ b/fibsem/scripting.py
@@ -125,8 +125,9 @@ def discover_scripts(directory: Path) -> List[DiscoveredScript]:
     """Load every ``.py`` in ``directory``, sorted by filename.
 
     Returns failures alongside successes. A missing directory is not an error —
-    it just means no scripts yet. Files starting with ``_`` are skipped so users
-    can keep shared helpers beside their scripts.
+    it just means no scripts yet. Files starting with ``_`` are hidden from the
+    listing; note that they are *not* importable from a script, since the folder
+    is never on ``sys.path`` (FIB-386).
 
     Not cached: scripts are loaded fresh on every call, so editing a file and
     running it again picks up the change. A data script runs in milliseconds, so

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -34,8 +34,12 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from fibsem.scripting import DiscoveredScript
-from fibsem.ui.stylesheets import PRIMARY_BUTTON_STYLESHEET
+from fibsem.cancellation import OperationCancelledError
+from fibsem.scripting import DiscoveredScript, ScriptResult
+from fibsem.ui.stylesheets import (
+    PRIMARY_BUTTON_STYLESHEET,
+    STOP_WORKFLOW_BUTTON_STYLESHEET,
+)
 from fibsem.ui.utils import open_path_in_file_explorer
 from fibsem.ui.widgets.script_runner import ScriptRunner
 
@@ -450,8 +454,10 @@ class ScriptManagerDialog(QDialog):
             consequence, colour, explain = "● Cannot load", _ERROR, script.error
         elif script.uses_microscope:
             consequence, colour, explain = (
-                "● Needs the microscope", _WARN,
-                "Microscope scripts are not supported yet (FIB-340).",
+                "● Drives the microscope", _ERROR,
+                "This script controls the hardware directly. Nothing checks what it "
+                "does — no limits, no interlocks. It runs in the background, and Stop "
+                "only works if the script itself checks for it.",
             )
         elif script.writes:
             consequence, colour, explain = (
@@ -475,13 +481,9 @@ class ScriptManagerDialog(QDialog):
         consequence = f'<span style="color:{colour};">{consequence}</span>'
         self.consequence_label.setText(consequence)
 
-        # uses_microscope is disabled rather than offered-then-refused: the runner
-        # would reject it anyway (FIB-340), and a button that does nothing but
-        # complain is worse than one that is visibly unavailable.
-        self.run_button.setEnabled(
-            script.is_runnable and host_ready and not script.uses_microscope
-        )
+        self.run_button.setEnabled(script.is_runnable and host_ready)
         self.hint_label.setText(reason)
+        self._sync_run_button()
 
     def change_folder(self) -> None:
         """Point the dialog at a different folder for this session."""
@@ -519,14 +521,48 @@ class ScriptManagerDialog(QDialog):
         open_path_in_file_explorer(str(directory))
 
     def run_selected(self) -> None:
+        # while a script is running this button is Stop -- see _sync_run_button
+        if self.runner.is_running:
+            self.runner.stop()
+            return
+
         script = self.selected_script()
         if script is None or not script.is_runnable:
             return
-        # the runner owns the wait cursor -- it has to be set after its write
+
+        # the runner owns the wait cursor -- it has to be set after its
         # confirmation, not before
-        result = self.runner.run(script)
-        if result is not None:
-            outcome = "ok" if result.ok else "failed"
-            stamp = datetime.now().strftime(TIME_DISPLAY_AMPM_SHORT).lstrip('0').lower()
-            self.last_run[script.name] = f"{stamp} {outcome}"
+        self.runner.run(script, on_finished=lambda r, s=script: self._record_run(s, r))
+        # a microscope script is still running at this point -- the stamp and the
+        # refresh happen in _record_run, which the worker delivers on the GUI thread
+        self._sync_run_button()
+
+    def _record_run(self, script: DiscoveredScript, result: ScriptResult) -> None:
+        """Stamp the outcome once the script has actually finished."""
+        outcome = "cancelled" if isinstance(result.error, OperationCancelledError) else (
+            "ok" if result.ok else "failed"
+        )
+        stamp = datetime.now().strftime(TIME_DISPLAY_AMPM_SHORT).lstrip('0').lower()
+        self.last_run[script.name] = f"{stamp} {outcome}"
+        self._sync_run_button()
         self.refresh()
+
+    def _sync_run_button(self) -> None:
+        """Run, or Stop while a script is running.
+
+        One button rather than two: a Stop that is greyed out almost always is
+        noise, and the state it reports is the same state Run is reporting.
+        """
+        running = self.runner.is_running
+        self.run_button.setText("Stop script" if running else "Run script")
+        self.run_button.setStyleSheet(
+            STOP_WORKFLOW_BUTTON_STYLESHEET if running else PRIMARY_BUTTON_STYLESHEET
+        )
+        if running:
+            self.run_button.setEnabled(True)  # Stop must never be the disabled one
+        # everything that would start a second run, or move the ground under the
+        # one already going
+        for button in (self.new_script_button, self.change_folder_button,
+                       self.rescan_button):
+            button.setEnabled(not running)
+        self.table.setEnabled(not running)

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -28,6 +28,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QPushButton,
     QSizePolicy,
+    QStackedWidget,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
@@ -160,8 +161,8 @@ def _script_type(script: DiscoveredScript) -> "tuple[str, Optional[str]]":
 
     A ``None`` colour means the type earns no chip. Only Data does: it is the
     default, so it appeared on nearly every row and distinguished nothing, while
-    costing width in a column that has to fit three chips. The label is still
-    returned, because the tooltip can say "Type: Data" for free.
+    costing width in a column that also has to fit the Writes chip. The label is
+    still returned, because the tooltip can say "Type: Data" for free.
     """
     if not script.is_runnable:
         return "Error", _ERROR
@@ -232,10 +233,17 @@ class ScriptManagerDialog(QDialog):
         header.addWidget(self.rescan_button)
         layout.addLayout(header)
 
+        # The table and its empty state swap places rather than the table sitting
+        # there empty: a headed grid with nothing under it is ~450px of void, and
+        # the one sentence that helps was stranded in the detail panel at the very
+        # bottom. An empty folder is the *first* thing a new user sees here.
         self.table = self._build_table()
-        layout.addWidget(self.table)
+        self.stack = QStackedWidget()
+        self.stack.addWidget(self.table)
+        self.stack.addWidget(self._build_empty_state())
+        layout.addWidget(self.stack)
 
-        detail_panel = QWidget()
+        self.detail_panel = detail_panel = QWidget()
         detail_panel.setStyleSheet(
             f"background-color: {_PANEL}; border: 1px solid {_BORDER}; border-radius: 6px;"
         )
@@ -270,6 +278,38 @@ class ScriptManagerDialog(QDialog):
         footer.addWidget(close_button)
         footer.addWidget(self.run_button)
         layout.addLayout(footer)
+
+    def _build_empty_state(self) -> QWidget:
+        """Shown instead of the table when the folder holds no scripts.
+
+        Same border and radius as the table so swapping between them does not move
+        anything else in the dialog.
+        """
+        panel = QWidget()
+        panel.setStyleSheet(
+            f"background-color: {_PANEL}; border: 1px solid {_BORDER};"
+            f"border-radius: 6px;"
+        )
+        layout = QVBoxLayout(panel)
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setSpacing(6)
+
+        headline = QLabel("No scripts in this folder")
+        headline.setAlignment(Qt.AlignCenter)
+        headline.setStyleSheet(
+            f"border: none; font-size: {_FS_NAME}px; color: {_TEXT};"
+        )
+        hint = QLabel(
+            "Use New script… to start one from a template, "
+            "or Change folder… to look somewhere else."
+        )
+        hint.setAlignment(Qt.AlignCenter)
+        hint.setStyleSheet(
+            f"border: none; font-size: {_FS_BODY}px; color: {_TEXT_MUTED};"
+        )
+        layout.addWidget(headline)
+        layout.addWidget(hint)
+        return panel
 
     def _build_table(self) -> QTableWidget:
         table = QTableWidget()
@@ -407,6 +447,7 @@ class ScriptManagerDialog(QDialog):
                 self.table.setItem(row, col, QTableWidgetItem())
 
         self._fit_type_column()
+        self.stack.setCurrentIndex(0 if self.scripts else 1)
 
         if self.scripts:
             names = [s.name for s in self.scripts]
@@ -418,9 +459,8 @@ class ScriptManagerDialog(QDialog):
         """Widen the type column to the widest row of chips.
 
         ResizeToContents is no use here: it measures the item's size hint, and
-        these cells hold widgets over empty items. A row carries at most one type
-        chip plus a chip per flag, so any fixed width clips as soon as a script
-        declares more than one.
+        these cells hold widgets over empty items. A row can carry a type chip and
+        a Writes chip, so any fixed width clips on a script that declares both.
 
         Floored at the header's own width: a folder of plain data scripts now has
         no chips at all, which collapsed this to 28px and clipped the word "Type".
@@ -471,11 +511,12 @@ class ScriptManagerDialog(QDialog):
         script = self.selected_script()
         host_ready, reason = self.runner.availability()
 
+        # nothing selected and nothing to select: the empty state above already says
+        # so, and an empty bordered strip down here just looks like a rendering fault
+        self.detail_panel.setVisible(bool(self.scripts))
+
         if script is None:
-            empty = (
-                "No scripts in this folder yet — use New script… to create one."
-                if not self.scripts else "No script selected."
-            )
+            empty = "" if not self.scripts else "No script selected."
             self.detail_label.setText(f'<span style="color:{_TEXT_MUTED};">{empty}</span>')
             self.consequence_label.setText("")
             self.run_button.setEnabled(False)
@@ -495,12 +536,19 @@ class ScriptManagerDialog(QDialog):
         elif script.uses_microscope:
             # matches the Microscope chip: the words carry the weight here, and the
             # confirmation dialog is what actually stops you
-            consequence, colour, explain = (
-                "● Controls the microscope", _MICROSCOPE,
+            consequence, colour = "● Controls the microscope", _MICROSCOPE
+            explain = (
                 "This script controls the hardware directly. Nothing checks what it "
                 "does — no limits, no interlocks. It runs in the background, and Stop "
-                "only works if the script itself checks for it.",
+                "only works if the script itself checks for it."
             )
+            if script.writes:
+                # Only the worse of the two fits on screen, so this is the only place
+                # a microscope script that *also* writes admits to the second half.
+                # The row still shows both chips.
+                explain += (
+                    " It also modifies the experiment and saves it when it finishes."
+                )
         elif script.writes:
             consequence, colour, explain = (
                 "● Modifies and saves the experiment", _WRITES,
@@ -511,13 +559,14 @@ class ScriptManagerDialog(QDialog):
                 "● Read-only", _TEXT_MUTED, "This script does not change anything.",
             )
         if script.on_workflow_completed:
-            # already a chip on the row -- repeating it on screen is what pushed
-            # this line past the panel edge on a narrow dialog, so tooltip only
+            # no chip for this any more, and the screen line has no room for it, so
+            # the tooltip is the only place the flag is acknowledged at all
             explain += f" {AUTO_NOT_CONNECTED}."
         self.consequence_label.setToolTip(explain)
-        # Same trap as the chips: a rich-text QLabel under-reports sizeHint
-        # against its rendered width, so the tail clips. Pin it from the metrics
-        # of the plain text before wrapping it in the colour span.
+        # sizeHint does not cover the stylesheet's own font-size, so the tail clips.
+        # Pin from the plain text before it is wrapped in the colour span. Unlike
+        # _chip, this label was styled back in _build(), so by now font() has the
+        # stylesheet size and needs no explicit setPixelSize.
         metrics = QFontMetrics(self.consequence_label.font())
         self.consequence_label.setMinimumWidth(metrics.horizontalAdvance(consequence) + 10)
         consequence = f'<span style="color:{colour};">{consequence}</span>'

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -52,15 +52,34 @@ _TEXT = "#d6d6d6"
 _TEXT_STRONG = "#f0f1f2"
 _TEXT_MUTED = "#868e93"
 _ACCENT = "#50a6ff"
-_WARN = "#e0a030"
 _ERROR = "#d04040"
+
+# Colour here says *what a script is*, not how frightened to be. Amber for
+# Microscope and Writes meant the two most common rows were permanently lit as
+# warnings, which is alarm fatigue in a list you browse rather than act on -- and
+# it left red meaning two different things. The real gate is the confirmation
+# dialog: modal, worded, defaulting to Cancel, and shown at the moment of action.
+# So these are categorical, and _ERROR now means exactly one thing in this
+# dialog: the file is broken.
+_MICROSCOPE = "#4caf72"
+_WRITES = "#4d9de0"
+
+# One type scale for the whole dialog, in px to match the rest of the app's
+# stylesheets. Ten literals were scattered across the file, so "make it smaller"
+# meant finding all of them and keeping the steps between them consistent by hand.
+_FS_TITLE = 14
+_FS_NAME = 12
+_FS_BODY = 11
+_FS_SMALL = 10
 
 _COLUMNS = ["Script", "Type", "Last run"]
 
-# on_workflow_completed is parsed and shown, but nothing fires it: the workflow
-# hook runs on a worker thread, and these scripts touch evented experiment state
-# that must only be mutated from the GUI thread. Said plainly rather than left
-# implied -- an author who declared the flag has no other way to find out.
+# on_workflow_completed is parsed, but nothing fires it: the workflow hook runs on
+# a worker thread, and these scripts touch evented experiment state that must only
+# be mutated from the GUI thread. It gets no chip -- a row badge for a feature that
+# does nothing is a distraction on every row that declares it, and it read as a
+# promise besides. Kept in the tooltips, which is where it costs nothing: an author
+# who declared the flag still has somewhere to find out it is inert.
 AUTO_NOT_CONNECTED = "auto: declared, but scripts do not run automatically yet"
 
 _TEMPLATE = '''"""Describe what this script does — this line becomes its tooltip."""
@@ -89,7 +108,7 @@ QHeaderView::section {{
     color: {_TEXT_MUTED};
     border: none;
     padding: 6px 8px;
-    font-size: 11px;
+    font-size: {_FS_SMALL}px;
 }}
 QTableWidget::item {{ padding: 6px 8px; border-bottom: 1px solid #31353f; }}
 QTableWidget::item:selected {{ background-color: #2d3947; color: {_TEXT_STRONG}; }}
@@ -102,7 +121,7 @@ QPushButton {{
     color: {_TEXT};
     border-radius: 6px;
     padding: 5px 12px;
-    font-size: 12px;
+    font-size: {_FS_BODY}px;
 }}
 QPushButton:hover {{ background-color: {_ROW_ALT}; }}
 QPushButton:disabled {{ color: {_TEXT_MUTED}; }}
@@ -136,13 +155,19 @@ class _ElidedLabel(QLabel):
         super().paintEvent(event)
 
 
-def _script_type(script: DiscoveredScript) -> "tuple[str, str]":
-    """(label, colour) describing what a script is allowed to touch."""
+def _script_type(script: DiscoveredScript) -> "tuple[str, Optional[str]]":
+    """(label, chip colour) describing what a script is allowed to touch.
+
+    A ``None`` colour means the type earns no chip. Only Data does: it is the
+    default, so it appeared on nearly every row and distinguished nothing, while
+    costing width in a column that has to fit three chips. The label is still
+    returned, because the tooltip can say "Type: Data" for free.
+    """
     if not script.is_runnable:
         return "Error", _ERROR
     if script.uses_microscope:
-        return "Microscope", _WARN
-    return "Data", _TEXT_MUTED
+        return "Microscope", _MICROSCOPE
+    return "Data", None
 
 
 class ScriptManagerDialog(QDialog):
@@ -175,12 +200,12 @@ class ScriptManagerDialog(QDialog):
         titles.setSpacing(2)
         self.title_label = QLabel("User scripts")
         self.title_label.setStyleSheet(
-            f"font-size: 15px; font-weight: 500; color: {_TEXT_STRONG};"
+            f"font-size: {_FS_TITLE}px; font-weight: 500; color: {_TEXT_STRONG};"
         )
         # counts and location are meta, not the heading -- the heading says what
         # this dialog is, the line under it says what is currently in it.
         self.meta_label = QLabel()
-        self.meta_label.setStyleSheet(f"font-size: 12px; color: {_TEXT_MUTED};")
+        self.meta_label.setStyleSheet(f"font-size: {_FS_BODY}px; color: {_TEXT_MUTED};")
         self.meta_label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
         self.meta_label.setMinimumWidth(160)
         titles.addWidget(self.title_label)
@@ -219,21 +244,21 @@ class ScriptManagerDialog(QDialog):
         self.detail_label = QLabel()
         self.detail_label.setTextFormat(Qt.RichText)
         self.detail_label.setStyleSheet(
-            f"border: none; font-size: 12px; color: {_TEXT};"
+            f"border: none; font-size: {_FS_BODY}px; color: {_TEXT};"
         )
         # the consequence of running this sits opposite the facts about it, so it
         # reads as a warning rather than another line of metadata
         self.consequence_label = QLabel()
         self.consequence_label.setTextFormat(Qt.RichText)
         self.consequence_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
-        self.consequence_label.setStyleSheet("border: none; font-size: 12px;")
+        self.consequence_label.setStyleSheet(f"border: none; font-size: {_FS_BODY}px;")
         detail_layout.addWidget(self.detail_label, 1)
         detail_layout.addWidget(self.consequence_label, 0)
         layout.addWidget(detail_panel)
 
         footer = QHBoxLayout()
         self.hint_label = QLabel()
-        self.hint_label.setStyleSheet(f"font-size: 12px; color: {_TEXT_MUTED};")
+        self.hint_label.setStyleSheet(f"font-size: {_FS_BODY}px; color: {_TEXT_MUTED};")
         footer.addWidget(self.hint_label)
         footer.addStretch()
         close_button = QPushButton("Close")
@@ -271,18 +296,25 @@ class ScriptManagerDialog(QDialog):
 
     @staticmethod
     def _chip(text: str, colour: str) -> QLabel:
-        """A pill label: coloured dot + text, on a tint of the same colour."""
+        """A pill label: text on a tint of its own colour.
+
+        No dot. Once every chip had one it separated nothing, and it cost real
+        width in a 130px column that has to fit three chips on one row.
+        """
         rgb = QColor(colour)
         tint = f"rgba({rgb.red()}, {rgb.green()}, {rgb.blue()}, 0.15)"
-        chip = QLabel(f'<span style="color:{colour};">&#9679;</span> {text}')
+        chip = QLabel(text)
         chip.setStyleSheet(
             f"background-color: {tint}; color: {colour};"
-            f"padding: 2px 9px; border-radius: 10px; font-size: 11px;"
+            f"padding: 2px 9px; border-radius: 10px; font-size: {_FS_SMALL}px;"
         )
-        # A rich-text QLabel under-reports sizeHint against the stylesheet padding,
-        # so the last character clips. Measure the visible text and pin the width.
-        metrics = QFontMetrics(chip.font())
-        chip.setMinimumWidth(metrics.horizontalAdvance(f"* {text}") + 26)
+        # sizeHint does not account for the stylesheet padding, so the last character
+        # clips. Measure the text and pin the width -- at the size it actually
+        # renders at, or the default font's metrics pad every chip by the difference.
+        font = chip.font()
+        font.setPixelSize(_FS_SMALL)
+        metrics = QFontMetrics(font)
+        chip.setMinimumWidth(metrics.horizontalAdvance(text) + 26)
         return chip
 
     def _name_cell(self, script: DiscoveredScript) -> QWidget:
@@ -296,12 +328,13 @@ class ScriptManagerDialog(QDialog):
         summary = script.description if script.is_runnable else script.error
         name = _ElidedLabel(script.name)
         name.setStyleSheet(
-            f"font-family: Menlo, monospace; font-size: 13px; background: transparent;"
+            f"font-family: Menlo, monospace; font-size: {_FS_NAME}px;"
+            f"background: transparent;"
             f"color: {_TEXT_STRONG if script.is_runnable else _TEXT_MUTED};"
         )
         detail = _ElidedLabel(summary)
         detail.setStyleSheet(
-            f"font-size: 12px; background: transparent;"
+            f"font-size: {_FS_BODY}px; background: transparent;"
             f"color: {_TEXT if script.is_runnable else _ERROR};"
         )
         layout.addWidget(name)
@@ -311,7 +344,12 @@ class ScriptManagerDialog(QDialog):
         return widget
 
     def _type_cell(self, script: DiscoveredScript) -> QWidget:
-        """The type chip, plus a chip per declared flag."""
+        """Chips for anything out of the ordinary; the tooltip carries the rest.
+
+        Only Microscope, Error and Writes get a chip. Data is the default and
+        on_workflow_completed does nothing yet, so both would be badges that appear
+        constantly and tell you no more than their absence would.
+        """
         widget = QWidget()
         widget.setStyleSheet("background: transparent;")
         layout = QHBoxLayout(widget)
@@ -319,13 +357,10 @@ class ScriptManagerDialog(QDialog):
         layout.setSpacing(4)
 
         label, colour = _script_type(script)
-        layout.addWidget(self._chip(label, colour))
+        if colour is not None:
+            layout.addWidget(self._chip(label, colour))
         if script.writes:
-            layout.addWidget(self._chip("writes", _WARN))
-        if script.on_workflow_completed:
-            # muted, and labelled off: the flag is recognised but nothing fires it
-            # yet, and a live-looking chip would promise a run that never happens
-            layout.addWidget(self._chip("auto (off)", _TEXT_MUTED))
+            layout.addWidget(self._chip("Writes", _WRITES))
         layout.addStretch()
         notes = [f"Type: {label}"]
         if script.writes:
@@ -383,16 +418,21 @@ class ScriptManagerDialog(QDialog):
         """Widen the type column to the widest row of chips.
 
         ResizeToContents is no use here: it measures the item's size hint, and
-        these cells hold widgets over empty items. A row carries one type chip
-        plus a chip per flag, so any fixed width clips as soon as a script
+        these cells hold widgets over empty items. A row carries at most one type
+        chip plus a chip per flag, so any fixed width clips as soon as a script
         declares more than one.
+
+        Floored at the header's own width: a folder of plain data scripts now has
+        no chips at all, which collapsed this to 28px and clipped the word "Type".
         """
         widths = [
             self.table.cellWidget(row, 1).sizeHint().width()
             for row in range(self.table.rowCount())
             if self.table.cellWidget(row, 1) is not None
         ]
-        self.table.setColumnWidth(1, max(widths, default=140) + 12)
+        header = self.table.horizontalHeader()
+        floor = header.fontMetrics().horizontalAdvance(_COLUMNS[1]) + 24
+        self.table.setColumnWidth(1, max(max(widths, default=0) + 12, floor))
 
     def _update_meta(self) -> None:
         """Counts plus the folder, elided to whatever width the dialog has.
@@ -453,15 +493,17 @@ class ScriptManagerDialog(QDialog):
         if not script.is_runnable:
             consequence, colour, explain = "● Cannot load", _ERROR, script.error
         elif script.uses_microscope:
+            # matches the Microscope chip: the words carry the weight here, and the
+            # confirmation dialog is what actually stops you
             consequence, colour, explain = (
-                "● Drives the microscope", _ERROR,
+                "● Controls the microscope", _MICROSCOPE,
                 "This script controls the hardware directly. Nothing checks what it "
                 "does — no limits, no interlocks. It runs in the background, and Stop "
                 "only works if the script itself checks for it.",
             )
         elif script.writes:
             consequence, colour, explain = (
-                "● Modifies and saves the experiment", _WARN,
+                "● Modifies and saves the experiment", _WRITES,
                 "This script changes the experiment and saves it when it finishes.",
             )
         else:

--- a/fibsem/ui/widgets/script_menu.py
+++ b/fibsem/ui/widgets/script_menu.py
@@ -1,12 +1,15 @@
-"""A reusable "Scripts" menu for running user scripts from a Qt application.
+"""A reusable "Scripts" menu for a Qt application.
 
-The menu is for running a known-good script in one click. Everything a menu
-cannot express — the folder path, per-script load errors, the ``writes`` warning,
-source and hash — lives in the manager dialog it opens. A failed script would
-otherwise simply be absent from the menu, which is the silent-omission failure
-this is meant to avoid.
+The menu is a way *in*, not a way to run. Running happens in the manager dialog
+only, because a script can now drive the microscope on a worker thread and the
+dialog is the only surface with a Stop button — a menu item that starts a
+ten-minute stage survey with no way to interrupt it is a trap.
 
-Knows nothing about experiments, microscopes or AutoLamella. See FIB-338.
+That also settles what the menu should list: nothing. Names alone cannot express
+the folder, a load error, or that a script writes or needs hardware, and the
+dialog shows all of it beside the button that starts it.
+
+Knows nothing about experiments, microscopes or AutoLamella. See FIB-338, FIB-340.
 """
 
 from pathlib import Path
@@ -14,7 +17,6 @@ from typing import Callable, Optional
 
 from PyQt5.QtWidgets import QAction, QMenu, QWidget
 
-from fibsem.scripting import DiscoveredScript
 from fibsem.ui.widgets.script_runner import (
     Confirmer,
     ContextFactory,
@@ -23,13 +25,14 @@ from fibsem.ui.widgets.script_runner import (
 )
 
 MANAGE_LABEL = "Manage scripts…"
+OPEN_FOLDER_LABEL = "Open scripts folder"
 
 
 class ScriptMenuController:
-    """Populates a QMenu with the scripts in a directory, and runs them.
+    """Puts the way into user scripts on an existing QMenu.
 
-    Attached to an existing menu rather than subclassing QMenu so a host can place
-    it wherever it likes in its own menu tree.
+    Attached to a menu rather than subclassing QMenu so a host can place it
+    wherever it likes in its own menu tree.
     """
 
     def __init__(
@@ -50,63 +53,26 @@ class ScriptMenuController:
             parent=parent,
             confirm=confirm,
         )
-
-        self.menu.setToolTipsVisible(True)
-        # Rebuilt on every open: scripts are not cached, so editing a file and
-        # running it again picks up the change with no reload step.
-        self.menu.aboutToShow.connect(self.rebuild)
+        self.build()
 
     # --- menu ---
 
-    def rebuild(self) -> None:
+    def build(self) -> None:
+        """Two fixed entries.
+
+        Built once, not on ``aboutToShow``: nothing here depends on what is in
+        the folder any more, so there is nothing to rebuild and no reason to
+        import every script each time the user opens the Tools menu.
+        """
         self.menu.clear()
-        scripts = self.runner.discover()
-        host_ready, reason = self.runner.availability()
-
-        runnable = [s for s in scripts if s.is_runnable]
-        failed = len(scripts) - len(runnable)
-
-        if not runnable:
-            self._add_disabled("No scripts found" if not scripts else "No runnable scripts")
-
-        for script in runnable:
-            self.menu.addAction(self._build_action(script, host_ready))
-
-        self.menu.addSeparator()
-        if reason:
-            self._add_disabled(reason)
-        if failed:
-            # named here, detail in the dialog -- a menu has nowhere to put a reason
-            self._add_disabled(f"{failed} script(s) failed to load — see {MANAGE_LABEL}")
 
         manage = QAction(MANAGE_LABEL, self.menu)
         manage.triggered.connect(self.open_manager)
         self.menu.addAction(manage)
 
-        open_folder = QAction("Open scripts folder", self.menu)
+        open_folder = QAction(OPEN_FOLDER_LABEL, self.menu)
         open_folder.triggered.connect(self.runner.open_folder)
         self.menu.addAction(open_folder)
-
-    def _add_disabled(self, text: str) -> None:
-        action = QAction(text, self.menu)
-        action.setEnabled(False)
-        self.menu.addAction(action)
-
-    def _build_action(self, script: DiscoveredScript, host_ready: bool) -> QAction:
-        label = script.name
-        # on_workflow_completed is deliberately absent: it is not connected to
-        # anything yet, and a menu has nowhere to say so, so an "auto" label here
-        # would read as a promise. The dialog carries the flag and the caveat.
-        flags = [name for name, on in (("microscope", script.uses_microscope),
-                                       ("writes", script.writes)) if on]
-        if flags:
-            label += f"  ({', '.join(flags)})"
-
-        action = QAction(label, self.menu)
-        action.setToolTip(script.description)
-        action.setEnabled(host_ready)
-        action.triggered.connect(lambda _checked=False, s=script: self.runner.run(s))
-        return action
 
     # --- manager ---
 

--- a/fibsem/ui/widgets/script_menu.py
+++ b/fibsem/ui/widgets/script_menu.py
@@ -94,11 +94,13 @@ class ScriptMenuController:
 
     def _build_action(self, script: DiscoveredScript, host_ready: bool) -> QAction:
         label = script.name
-        # writes only. on_workflow_completed is not connected to anything yet, and
-        # a menu has nowhere to say so -- an "auto" label here would read as a
-        # promise. The dialog carries the flag and the caveat together.
-        if script.writes:
-            label += "  (writes)"
+        # on_workflow_completed is deliberately absent: it is not connected to
+        # anything yet, and a menu has nowhere to say so, so an "auto" label here
+        # would read as a promise. The dialog carries the flag and the caveat.
+        flags = [name for name, on in (("microscope", script.uses_microscope),
+                                       ("writes", script.writes)) if on]
+        if flags:
+            label += f"  ({', '.join(flags)})"
 
         action = QAction(label, self.menu)
         action.setToolTip(script.description)

--- a/fibsem/ui/widgets/script_runner.py
+++ b/fibsem/ui/widgets/script_runner.py
@@ -136,15 +136,24 @@ class ScriptRunner:
         return box.clickedButton() is run
 
     def _consequence(self, script: DiscoveredScript) -> str:
-        """What running this script will do, for the confirmation box. Empty = no gate."""
+        """What running this script will do, for the confirmation box. Empty = no gate.
+
+        One whole sentence per consequence, not clauses joined with "and". A script
+        declaring both flags used to read "It drives the microscope, and nothing
+        checks what it does and modifies the experiment and saves it when it
+        finishes" -- three ands, and the second one attaches to "nothing checks",
+        so it says the opposite of what it means. That is the most dangerous kind
+        of script and the only one whose warning was broken.
+        """
         parts = []
         if script.uses_microscope:
-            parts.append("drives the microscope, and nothing checks what it does")
+            parts.append("It drives the microscope, and nothing checks what it does.")
         if script.writes:
-            parts.append("modifies the experiment and saves it when it finishes")
+            parts.append("It modifies the experiment and saves it when it finishes.")
         if not parts:
             return ""
-        return "It " + " and ".join(parts) + ". There is no undo."
+        parts.append("There is no undo.")
+        return " ".join(parts)
 
     @property
     def is_running(self) -> bool:

--- a/fibsem/ui/widgets/script_runner.py
+++ b/fibsem/ui/widgets/script_runner.py
@@ -10,10 +10,13 @@ Knows nothing about experiments, microscopes or AutoLamella. A host supplies:
 * a context factory — what to hand the script, or ``None`` if it cannot run now
 * a notifier — how to tell the user something
 
-See FIB-338.
+Data scripts run inline on the GUI thread; scripts that declare ``uses_microscope``
+run on a worker thread, because hardware operations are far too slow to freeze the
+window for. See FIB-338 and FIB-340.
 """
 
 import logging
+import threading
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple
 
@@ -29,7 +32,9 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from fibsem.cancellation import OperationCancelledError
 from fibsem.scripting import DiscoveredScript, ScriptResult, discover_scripts, run_script
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.stylesheets import (
     MESSAGE_BOX_STYLESHEET,
     PRIMARY_BUTTON_STYLESHEET,
@@ -62,6 +67,8 @@ class ScriptRunner:
         self.notify = notify
         self.parent = parent
         self.confirm = confirm or self._default_confirm
+        self._worker: Optional[FunctionWorker] = None
+        self._stop_event = threading.Event()
 
     def scripts_directory(self) -> Path:
         """Where to look for scripts — the host's folder, or a chosen override."""
@@ -128,54 +135,128 @@ class ScriptRunner:
         box.exec_()
         return box.clickedButton() is run
 
-    def run(self, script: DiscoveredScript) -> Optional[ScriptResult]:
+    def _consequence(self, script: DiscoveredScript) -> str:
+        """What running this script will do, for the confirmation box. Empty = no gate."""
+        parts = []
+        if script.uses_microscope:
+            parts.append("drives the microscope, and nothing checks what it does")
+        if script.writes:
+            parts.append("modifies the experiment and saves it when it finishes")
+        if not parts:
+            return ""
+        return "It " + " and ".join(parts) + ". There is no undo."
+
+    @property
+    def is_running(self) -> bool:
+        """Whether a script is running on a worker thread right now."""
+        return self._worker is not None and self._worker.is_alive()
+
+    def stop(self) -> None:
+        """Ask the running script to stop.
+
+        Cooperative: a Python thread cannot be killed, so this only sets the event.
+        A script that never checks it runs to completion regardless.
+        """
+        if self.is_running:
+            logging.info("Stop requested for the running script.")
+            self._stop_event.set()
+
+    def run(
+        self,
+        script: DiscoveredScript,
+        on_finished: Optional[Callable[[ScriptResult], None]] = None,
+    ) -> Optional[ScriptResult]:
         """Run one script and render whatever it returned.
 
-        Returns ``None`` when the script was refused rather than run.
+        Returns the result for a script that ran inline, and ``None`` both when the
+        script was refused and when it went to a worker thread. ``on_finished`` is
+        called with the result either way, so a caller that needs the outcome does
+        not have to care which happened.
         """
+        if self.is_running:
+            self.notify("A script is already running.", "warning")
+            return None
+
         context, reason = self.context_factory()
         if context is None:
             self.notify(reason or "Cannot run scripts right now.", "warning")
             return None
 
-        if script.uses_microscope:
-            # The strict runner these need -- worker thread, hardware exclusion,
-            # cancellation, state restoration -- is FIB-340 and not built yet.
-            self.notify(
-                f"'{script.name}' declares uses_microscope, which is not supported yet.",
-                "warning",
-            )
-            return None
-        if script.background:
+        if script.background and not script.uses_microscope:
             logging.warning(
                 "Script %s declares background=True; running inline for now.", script.name
             )
 
-        # Last gate before running: a writes script saves the moment it finishes and
-        # there is no undo, so the user gets one chance to back out. Read-only
-        # scripts -- the common case -- go straight through.
-        if script.writes and not self.confirm(
-            f"Run '{script.name}'?",
-            "It modifies the experiment and saves it when it finishes. There is no undo.",
-        ):
-            logging.info("Script %s cancelled at the write confirmation.", script.name)
+        # Last gate before running. A writes script saves the moment it finishes and a
+        # microscope script has already moved the hardware by then -- neither has an
+        # undo. Read-only scripts, the common case, go straight through.
+        consequence = self._consequence(script)
+        if consequence and not self.confirm(f"Run '{script.name}'?", consequence):
+            logging.info("Script %s cancelled at the confirmation.", script.name)
             return None
 
-        # Scripts run on the GUI thread, so a slow one freezes the window. The
-        # cursor is the only sign it is working. Set after the confirmation, or
-        # the modal box above would come up under a wait cursor.
+        if script.uses_microscope:
+            self._run_threaded(script, context, on_finished)
+            return None
+
+        # Inline, on the GUI thread, so a slow one freezes the window -- the cursor is
+        # the only sign it is working. Set after the confirmation, or the modal box
+        # above would come up under a wait cursor.
         QApplication.setOverrideCursor(Qt.WaitCursor)
         try:
             result = run_script(script, context)
         finally:
             QApplication.restoreOverrideCursor()
 
+        self._report(script, result)
+        if on_finished is not None:
+            on_finished(result)
+        return result
+
+    def _run_threaded(
+        self,
+        script: DiscoveredScript,
+        context: Any,
+        on_finished: Optional[Callable[[ScriptResult], None]],
+    ) -> None:
+        """Run a microscope script on a worker thread.
+
+        Hardware operations take seconds to minutes. Inline they would freeze the
+        window for the whole run, which is indistinguishable from a hang -- so these
+        go to a thread even though data scripts do not. The consequence is that the
+        script must not touch ``ctx.experiment``: it holds evented containers whose
+        handlers fire into widgets, and those must only be touched from the GUI
+        thread. Nothing enforces that; it is documented in SCRIPTING.md.
+        """
+        self._stop_event = threading.Event()
+        if hasattr(context, "stop_event"):
+            context.stop_event = self._stop_event
+
+        worker = self._worker = FunctionWorker(run_script, script, context)
+
+        def _done(result: object) -> None:
+            # FunctionWorker delivers this on the GUI thread, so touching widgets
+            # (toasts, dialogs) from here is safe. run_script never raises, so
+            # `returned` always fires and `errored` never does.
+            self._worker = None
+            if isinstance(result, ScriptResult):
+                self._report(script, result)
+                if on_finished is not None:
+                    on_finished(result)
+
+        worker.returned.connect(_done)
+        self.notify(f"{script.name} started…", "info")
+        worker.start()
+
+    def _report(self, script: DiscoveredScript, result: ScriptResult) -> None:
+        """Surface the outcome of a finished run."""
+        if isinstance(result.error, OperationCancelledError):
+            self.notify(f"{script.name} cancelled.", "warning")
+            return
         if not result.ok:
             self.notify(f"{script.name} failed: {result.error}", "error")
-            return result
-
+            return
         self.show_result(script, result.value)
-        return result
 
     # --- rendering ---
 

--- a/fibsem/ui/widgets/script_runner.py
+++ b/fibsem/ui/widgets/script_runner.py
@@ -199,6 +199,19 @@ class ScriptRunner:
             self._run_threaded(script, context, on_finished)
             return None
 
+        # The flag is the route to the hardware: without it, `microscope` is withheld.
+        # A script that quietly drove the stage would otherwise still be listed as
+        # "Data / Read-only" -- an active falsehood, and worse than saying nothing.
+        # Restored afterwards, so a host that reuses one context object is not left
+        # with the microscope permanently removed from it.
+        #
+        # Not a boundary. Scripts are arbitrary Python and can import their way to a
+        # handle regardless; this is for the author who did not know the flag existed,
+        # and the AttributeError it produces names the line and implies the fix.
+        withheld = getattr(context, "microscope", None)
+        if withheld is not None:
+            context.microscope = None
+
         # Inline, on the GUI thread, so a slow one freezes the window -- the cursor is
         # the only sign it is working. Set after the confirmation, or the modal box
         # above would come up under a wait cursor.
@@ -207,8 +220,18 @@ class ScriptRunner:
             result = run_script(script, context)
         finally:
             QApplication.restoreOverrideCursor()
+            if withheld is not None:
+                context.microscope = withheld
 
-        self._report(script, result)
+        # The traceback in the log names the offending line, but the toast is all
+        # most users see, and "'NoneType' has no attribute acquire_image" does not
+        # say what to do about it. Phrased as a conditional so it stays harmless on
+        # an AttributeError that had nothing to do with the microscope.
+        hint = ""
+        if withheld is not None and isinstance(result.error, AttributeError):
+            hint = " — if it needs the microscope, declare uses_microscope = True."
+
+        self._report(script, result, hint)
         if on_finished is not None:
             on_finished(result)
         return result
@@ -248,13 +271,15 @@ class ScriptRunner:
         self.notify(f"{script.name} started…", "info")
         worker.start()
 
-    def _report(self, script: DiscoveredScript, result: ScriptResult) -> None:
+    def _report(
+        self, script: DiscoveredScript, result: ScriptResult, hint: str = ""
+    ) -> None:
         """Surface the outcome of a finished run."""
         if isinstance(result.error, OperationCancelledError):
             self.notify(f"{script.name} cancelled.", "warning")
             return
         if not result.ok:
-            self.notify(f"{script.name} failed: {result.error}", "error")
+            self.notify(f"{script.name} failed: {result.error}{hint}", "error")
             return
         self.show_result(script, result.value)
 

--- a/tests/autolamella/test_example_scripts.py
+++ b/tests/autolamella/test_example_scripts.py
@@ -1,0 +1,176 @@
+"""The shipped example scripts, executed rather than eyeballed.
+
+Every scripting example that was never run turned out to have a bug in it: one
+addressed ``lamella.state``, which does not exist, and another relied on
+``microscope.acquire_image`` honouring ``save=True``, which it does not -- so it
+claimed to write files and wrote none. Both looked completely reasonable on the
+page.
+
+That is why ``examples/scripts/`` holds real ``.py`` files instead of markdown
+snippets: they go through the same ``load_script`` / ``run_script`` path the GUI
+uses, against a real Experiment and a simulated microscope. If an example stops
+working, this fails.
+"""
+
+from pathlib import Path
+
+import pytest
+from psygnal.containers import EventedDict
+
+import fibsem.utils as utils
+from fibsem.applications.autolamella.scripting import ScriptContext
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.microscopes.simulator import DemoMicroscope
+from fibsem.scripting import load_script, run_script
+from fibsem.structures import FibsemStagePosition, MicroscopeState
+
+EXAMPLES = Path(__file__).resolve().parents[2] / "examples" / "scripts"
+
+# Named individually rather than globbed: a typo in the folder name would make a
+# glob quietly collect nothing and the suite would pass having tested nothing.
+EXPECTED = ["describe_lamellae", "export_summary", "survey_positions"]
+
+
+@pytest.fixture
+def experiment(tmp_path) -> Experiment:
+    exp = Experiment(path=tmp_path / "exp", name="exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    Path(exp.path).mkdir(parents=True, exist_ok=True)
+    for i in range(2):
+        exp.add_new_lamella(MicroscopeState(), EventedDict())
+        # a fresh lamella's milling pose has no coordinates, and moving to None
+        # is not something the examples should have to defend against
+        exp.positions[i].stage_position = FibsemStagePosition(
+            x=i * 100e-6, y=0.0, z=0.0, r=0.0, t=0.0, coordinate_system="RAW"
+        )
+    exp.save(save_protocol=True)
+    return exp
+
+
+@pytest.fixture(scope="module")
+def microscope() -> DemoMicroscope:
+    return DemoMicroscope(utils.load_microscope_configuration().system)
+
+
+def _context(experiment, microscope=None) -> ScriptContext:
+    return ScriptContext(experiment=experiment, microscope=microscope)
+
+
+def _load(name: str):
+    script = load_script(EXAMPLES / f"{name}.py")
+    assert script.is_runnable, f"{name} failed to load: {script.error}"
+    return script
+
+
+# ── the folder itself ────────────────────────────────────────────────────────
+
+def test_the_examples_folder_holds_exactly_the_documented_scripts():
+    """SCRIPTING.md points at these by name, so an added or renamed file needs the
+    docs updated in the same commit."""
+    found = sorted(p.stem for p in EXAMPLES.glob("*.py"))
+    assert found == sorted(EXPECTED)
+
+
+@pytest.mark.parametrize("name", EXPECTED)
+def test_every_example_loads_and_declares_a_docstring(name):
+    """The first docstring line becomes the description in the manager dialog, so
+    an example without one shows its own filename twice."""
+    script = _load(name)
+    assert script.description and script.description != script.name
+
+
+# ── one test per example, asserting the effect it advertises ─────────────────
+
+def test_export_summary_writes_a_csv_with_a_row_per_lamella(experiment):
+    script = _load("export_summary")
+
+    result = run_script(script, _context(experiment))
+
+    assert result.ok, result.error
+    assert isinstance(result.value, Path) and result.value.exists()
+    assert result.value.parent == Path(experiment.path)
+    # header + one row per lamella
+    assert len(result.value.read_text().strip().splitlines()) == len(experiment.positions) + 1
+
+
+def test_export_summary_does_not_declare_itself_a_writer(experiment):
+    """It is the read-only example. If it ever grows a `writes` flag the point of
+    having three tiers is gone."""
+    script = _load("export_summary")
+    assert not script.writes
+    assert not script.uses_microscope
+
+    result = run_script(script, _context(experiment))
+
+    assert result.saved is False
+
+
+def test_describe_lamellae_sets_descriptions_and_asks_to_be_saved(experiment):
+    script = _load("describe_lamellae")
+    assert script.writes
+
+    result = run_script(script, _context(experiment))
+
+    assert result.ok, result.error
+    assert result.saved is True  # run_script called ctx.save() because of the flag
+    assert all(lamella.description for lamella in experiment.positions)
+    assert "no tasks completed yet" in experiment.positions[0].description
+
+
+def test_describe_lamellae_is_idempotent(experiment):
+    """Second run changes nothing, so re-running it is not a way to dirty the
+    experiment. The example short-circuits on an unchanged description."""
+    script = _load("describe_lamellae")
+
+    first = run_script(script, _context(experiment))
+    second = run_script(script, _context(experiment))
+
+    assert first.ok and second.ok
+    assert "described 2 of 2" in first.value
+    assert "described 0 of 2" in second.value
+
+
+def test_describe_lamellae_fires_the_events_the_ui_listens_to(experiment):
+    """The example claims in a comment that the GUI updates as it runs. That is
+    only true if `description` actually emits, so pin it here rather than trust
+    the comment."""
+    seen = []
+    for lamella in experiment.positions:
+        lamella.events.description.connect(lambda *_: seen.append(1))
+
+    run_script(_load("describe_lamellae"), _context(experiment))
+
+    assert len(seen) == len(experiment.positions)
+
+
+def test_survey_positions_acquires_an_image_per_lamella(experiment, microscope):
+    script = _load("survey_positions")
+    assert script.uses_microscope
+
+    result = run_script(script, _context(experiment, microscope))
+
+    assert result.ok, result.error
+    for lamella in experiment.positions:
+        written = list(Path(lamella.path).glob("survey*"))
+        assert written, f"no survey image written for {lamella.name}"
+
+
+def test_survey_positions_stops_when_asked(experiment, microscope):
+    """Cancellation is cooperative, so this only passes because the example calls
+    ctx.raise_if_cancelled(). Delete that line and this test is what notices."""
+    import threading
+
+    from fibsem.cancellation import OperationCancelledError
+
+    context = _context(experiment, microscope)
+    context.stop_event = threading.Event()
+    context.stop_event.set()  # already cancelled before the first iteration
+
+    result = run_script(_load("survey_positions"), context)
+
+    assert isinstance(result.error, OperationCancelledError)
+    for lamella in experiment.positions:
+        assert not list(Path(lamella.path).glob("survey*"))

--- a/tests/autolamella/test_scripting.py
+++ b/tests/autolamella/test_scripting.py
@@ -1,11 +1,13 @@
 """Tier 1 user scripts: discovery, flags, and the runner (FIB-338)."""
 
 import os
+import threading
 from pathlib import Path
 
 import pytest
 from psygnal.containers import EventedDict
 
+from fibsem.cancellation import OperationCancelledError
 from fibsem.applications.autolamella.scripting import (
     DEFAULT_SCRIPTS_DIR,
     SCRIPTS_DIR_ENV_VAR,
@@ -188,3 +190,20 @@ def test_an_unrunnable_script_returns_an_error_result(tmp_path):
 def test_ctx_path_is_the_experiment_directory(tmp_path):
     exp = _experiment(tmp_path)
     assert ScriptContext(experiment=exp).path == Path(exp.path)
+
+
+def test_ctx_cancellation_is_inert_without_a_stop_event(tmp_path):
+    """A headless run has no one to press Stop, so the same script must still work."""
+    ctx = ScriptContext(experiment=_experiment(tmp_path))
+
+    assert ctx.cancelled is False
+    ctx.raise_if_cancelled()  # must not raise
+
+
+def test_ctx_raise_if_cancelled_aborts_once_the_event_is_set(tmp_path):
+    ctx = ScriptContext(experiment=_experiment(tmp_path), stop_event=threading.Event())
+    ctx.stop_event.set()
+
+    assert ctx.cancelled is True
+    with pytest.raises(OperationCancelledError):
+        ctx.raise_if_cancelled()

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -1,5 +1,6 @@
 """The Scripts manager dialog, driven without an application around it (FIB-338)."""
 
+import time
 from pathlib import Path
 
 import pytest
@@ -19,9 +20,27 @@ def qapp():
 class FakeContext:
     def __init__(self):
         self.saved = False
+        self.stop_event = None  # the runner injects one for threaded scripts
 
     def save(self):
         self.saved = True
+
+    def raise_if_cancelled(self):
+        from fibsem.cancellation import raise_if_cancelled
+        raise_if_cancelled(self.stop_event)
+
+
+def _drain(qapp, predicate, timeout=5.0):
+    """Pump the Qt event loop until predicate() is true, or give up.
+
+    Threaded scripts report back through a queued signal, so nothing lands unless
+    the loop runs.
+    """
+    deadline = time.monotonic() + timeout
+    while not predicate() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.005)
+    return predicate()
 
 
 def _write(directory: Path, name: str, body: str) -> Path:
@@ -139,13 +158,45 @@ def test_run_is_disabled_for_a_broken_script(qapp, tmp_path):
     assert not dialog.run_button.isEnabled()
 
 
-def test_run_is_disabled_for_a_microscope_script(qapp, tmp_path):
-    """The runner would refuse it (FIB-340); a button that only complains is worse
-    than one that is visibly unavailable."""
+def test_a_microscope_script_can_be_run_and_says_what_it_will_do(qapp, tmp_path):
     _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
     dialog = _dialog(tmp_path, context=FakeContext())
     dialog.table.selectRow(0)
-    assert not dialog.run_button.isEnabled()
+
+    assert dialog.run_button.isEnabled()
+    assert "Drives the microscope" in dialog.consequence_label.text()
+    # the warning has to be specific about what is missing, not just "careful"
+    assert "no limits, no interlocks" in dialog.consequence_label.toolTip()
+
+
+def test_run_becomes_stop_while_a_script_is_running(qapp, tmp_path):
+    """A microscope script runs for minutes. Without this the dialog looks idle
+    and the only way to stop it is to kill the app."""
+    _write(tmp_path, "slow.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(3)\n"
+           "    ctx.raise_if_cancelled()\n"
+           "    return 'ran to completion'\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+
+    dialog.run_selected()
+    assert _drain(qapp, lambda: dialog.runner.is_running)
+    assert dialog.run_button.text() == "Stop script"
+    assert dialog.run_button.isEnabled()
+    # nothing that would start a second run or move the ground under this one
+    assert not dialog.table.isEnabled()
+    assert not dialog.change_folder_button.isEnabled()
+
+    dialog.run_selected()  # the same button, now Stop
+
+    # not `not is_running` -- the thread dies before its result is delivered, so
+    # that would pass while the dialog is still mid-teardown
+    assert _drain(qapp, lambda: "slow" in dialog.last_run)
+    assert dialog.run_button.text() == "Run script"
+    assert dialog.table.isEnabled()
+    assert "cancelled" in dialog.last_run["slow"]
 
 
 def test_run_is_disabled_and_explained_when_the_host_is_not_ready(qapp, tmp_path):

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -394,25 +394,6 @@ def test_the_auto_flag_says_it_is_not_connected(qapp, tmp_path):
     assert "not run automatically yet" in dialog.consequence_label.toolTip()
 
 
-def test_the_menu_does_not_label_a_script_auto(qapp, tmp_path):
-    """A menu has nowhere to explain the caveat, so it leaves the flag out."""
-    from PyQt5.QtWidgets import QMenu
-
-    from fibsem.ui.widgets.script_menu import ScriptMenuController
-
-    _write(tmp_path, "a.py", "on_workflow_completed = True\ndef run(ctx):\n    pass\n")
-    menu = QMenu()
-    controller = ScriptMenuController(
-        menu=menu,
-        scripts_directory=lambda: tmp_path,
-        context_factory=lambda: (FakeContext(), ""),
-        notify=lambda m, l: None,
-    )
-    controller.rebuild()
-
-    assert not any("auto" in a.text() for a in menu.actions())
-
-
 def test_every_chip_carries_a_dot(qapp, tmp_path):
     """Type and flag chips looked like different kinds of thing for no readable
     reason. Colour separates them; shape should not."""

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -151,6 +151,20 @@ def test_a_plain_data_script_gets_no_type_chip(qapp, tmp_path):
     assert "Type: Data" in cell.toolTip()
 
 
+def test_a_microscope_script_that_also_writes_admits_to_both(qapp, tmp_path):
+    """Only the worse of the two fits on the line, so the tooltip is the only place
+    the second half can be stated -- and it was silently dropped."""
+    _write(tmp_path, "both.py",
+           "uses_microscope = True\nwrites = True\ndef run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.table.selectRow(0)
+
+    assert "Controls the microscope" in dialog.consequence_label.text()
+    tip = dialog.consequence_label.toolTip()
+    assert "no limits, no interlocks" in tip
+    assert "saves it when it finishes" in tip
+
+
 def test_the_consequence_line_matches_its_chip(qapp, tmp_path):
     """One script, one colour. The line under the table used to be red while the
     row's chip was amber, so the same fact arrived twice in two severities."""
@@ -181,9 +195,42 @@ def test_only_a_broken_script_is_red(qapp, tmp_path):
     assert _ERROR in dialog.consequence_label.text()
 
 
-def test_an_empty_folder_says_how_to_start(qapp, tmp_path):
+def test_an_empty_folder_says_how_to_start_where_you_are_looking(qapp, tmp_path):
+    """The message replaces the table rather than sitting under 450px of empty grid
+    with the one useful sentence stranded in the detail panel at the bottom."""
     dialog = _dialog(tmp_path, context=FakeContext())
-    assert "New script" in dialog.detail_label.text()
+
+    from PyQt5.QtWidgets import QLabel
+    shown = dialog.stack.currentWidget()
+    text = " ".join(label.text() for label in shown.findChildren(QLabel))
+
+    assert shown is not dialog.table
+    assert "No scripts in this folder" in text
+    assert "New script" in text and "Change folder" in text
+
+
+def test_the_empty_message_is_not_also_repeated_in_the_detail_panel(qapp, tmp_path):
+    """It used to be the only place it appeared; now it would be the second. The
+    panel hides rather than sitting there as an empty bordered strip."""
+    dialog = _dialog(tmp_path, context=FakeContext())
+    dialog.show()
+
+    assert "New script" not in dialog.detail_label.text()
+    assert not dialog.detail_panel.isVisible()
+
+    _write(tmp_path, "s.py", "def run(ctx):\n    pass\n")
+    dialog.refresh()
+    assert dialog.detail_panel.isVisible()
+
+
+def test_the_table_comes_back_once_a_script_exists(qapp, tmp_path):
+    dialog = _dialog(tmp_path, context=FakeContext())
+    assert dialog.stack.currentWidget() is not dialog.table
+
+    _write(tmp_path, "s.py", "def run(ctx):\n    pass\n")
+    dialog.refresh()
+
+    assert dialog.stack.currentWidget() is dialog.table
 
 
 def test_the_last_run_stamp_is_12_hour(qapp, tmp_path):

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -104,7 +104,7 @@ def test_the_failure_reason_is_shown_in_the_row(qapp, tmp_path):
 def test_flags_appear_in_the_type_cell(qapp, tmp_path):
     _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
     dialog = _dialog(tmp_path, context=FakeContext())
-    assert "writes" in _cell_text(dialog, 0, 1)
+    assert "Writes" in _cell_text(dialog, 0, 1)
 
 
 def test_a_writing_script_warns_in_the_detail_panel(qapp, tmp_path):
@@ -124,6 +124,61 @@ def test_a_read_only_script_says_so(qapp, tmp_path):
     dialog = _dialog(tmp_path, context=FakeContext())
     dialog.table.selectRow(0)
     assert "Read-only" in dialog.consequence_label.text()
+
+
+def test_the_type_column_survives_a_folder_with_no_chips(qapp, tmp_path):
+    """Dropping the Data chip meant an all-plain folder had nothing to measure, so
+    the column collapsed to 28px and clipped its own header."""
+    _write(tmp_path, "a.py", "def run(ctx):\n    pass\n")
+    _write(tmp_path, "b.py", "def run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    header = dialog.table.horizontalHeader()
+    assert dialog.table.columnWidth(1) >= header.fontMetrics().horizontalAdvance("Type")
+
+
+def test_a_plain_data_script_gets_no_type_chip(qapp, tmp_path):
+    """Data is the default, so a chip for it sat on nearly every row and separated
+    nothing. An empty Type cell means "touches nothing unusual"; the word survives
+    in the tooltip, where it costs no width."""
+    _write(tmp_path, "plain.py", '"""Read some numbers."""\ndef run(ctx):\n    pass\n')
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    from PyQt5.QtWidgets import QLabel
+    cell = dialog.table.cellWidget(0, 1)
+
+    assert cell.findChildren(QLabel) == []
+    assert "Type: Data" in cell.toolTip()
+
+
+def test_the_consequence_line_matches_its_chip(qapp, tmp_path):
+    """One script, one colour. The line under the table used to be red while the
+    row's chip was amber, so the same fact arrived twice in two severities."""
+    from fibsem.ui.widgets.script_manager_dialog import _MICROSCOPE, _WRITES
+
+    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    dialog.table.selectRow(0)  # hw.py
+    assert _MICROSCOPE in dialog.consequence_label.text()
+    dialog.table.selectRow(1)  # w.py
+    assert _WRITES in dialog.consequence_label.text()
+
+
+def test_only_a_broken_script_is_red(qapp, tmp_path):
+    """Colour in the list says what a script *is*; the confirmation dialog is what
+    warns. Red left for the one thing that is actionable while browsing."""
+    from fibsem.ui.widgets.script_manager_dialog import _ERROR
+
+    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
+    _write(tmp_path, "oops.py", "def main(ctx):\n    pass\n")
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    dialog.table.selectRow(0)  # hw.py -- the most dangerous, still not red
+    assert _ERROR not in dialog.consequence_label.text()
+    dialog.table.selectRow(1)  # oops.py -- cannot load
+    assert _ERROR in dialog.consequence_label.text()
 
 
 def test_an_empty_folder_says_how_to_start(qapp, tmp_path):
@@ -164,7 +219,7 @@ def test_a_microscope_script_can_be_run_and_says_what_it_will_do(qapp, tmp_path)
     dialog.table.selectRow(0)
 
     assert dialog.run_button.isEnabled()
-    assert "Drives the microscope" in dialog.consequence_label.text()
+    assert "Controls the microscope" in dialog.consequence_label.text()
     # the warning has to be specific about what is missing, not just "careful"
     assert "no limits, no interlocks" in dialog.consequence_label.toolTip()
 
@@ -368,8 +423,18 @@ def test_the_folder_is_elided_but_kept_whole_in_the_tooltip(qapp, tmp_path):
 
 def test_a_long_description_elides_instead_of_clipping(qapp, tmp_path):
     """It used to be cut off mid-glyph, which reads as a typo rather than as
-    text continuing past the edge."""
-    summary = "Archive the experiment folder and every image in it when a workflow finishes"
+    text continuing past the edge.
+
+    The description has to beat the Script column at the dialog's *minimum* width,
+    not at the width passed to resize() -- a layout minimum of ~720px wins over a
+    smaller request, so a merely long sentence stopped eliding the moment the Type
+    column got narrower.
+    """
+    summary = (
+        "Archive the experiment folder and every image in it when a workflow "
+        "finishes, then upload the archive, verify its checksum, and email a "
+        "summary to whoever started the run"
+    )
     _write(tmp_path, "a.py", f'"""{summary}"""\ndef run(ctx):\n    pass\n')
     dialog = _dialog(tmp_path, context=FakeContext())
     dialog.resize(520, 400)  # narrow enough that this description cannot fit
@@ -382,21 +447,23 @@ def test_a_long_description_elides_instead_of_clipping(qapp, tmp_path):
     assert summary in dialog.table.cellWidget(0, 0).toolTip()
 
 
-def test_the_auto_flag_says_it_is_not_connected(qapp, tmp_path):
-    """Nothing fires on_workflow_completed yet. An author who declared it has no
-    other way to find that out, and a chip alone would read as a promise."""
+def test_the_auto_flag_gets_no_chip_but_is_still_explained(qapp, tmp_path):
+    """Nothing fires on_workflow_completed yet, so a chip for it was a badge for a
+    feature that does not exist. The author who declared it still needs somewhere to
+    learn that, and a tooltip costs no width."""
     _write(tmp_path, "a.py", "on_workflow_completed = True\ndef run(ctx):\n    pass\n")
     dialog = _dialog(tmp_path, context=FakeContext())
     dialog.table.selectRow(0)
 
-    assert "off" in _cell_text(dialog, 0, 1)
+    from PyQt5.QtWidgets import QLabel
+    assert dialog.table.cellWidget(0, 1).findChildren(QLabel) == []
     assert "not run automatically yet" in dialog.table.cellWidget(0, 1).toolTip()
     assert "not run automatically yet" in dialog.consequence_label.toolTip()
 
 
-def test_every_chip_carries_a_dot(qapp, tmp_path):
-    """Type and flag chips looked like different kinds of thing for no readable
-    reason. Colour separates them; shape should not."""
+def test_chips_are_text_only(qapp, tmp_path):
+    """The dot separated nothing once every chip carried one, and it cost width in
+    a column that has to fit more than one. Colour and the pill do the work."""
     _write(tmp_path, "s.py",
            "writes = True\non_workflow_completed = True\ndef run(ctx):\n    pass\n")
     dialog = _dialog(tmp_path, context=FakeContext())
@@ -404,8 +471,7 @@ def test_every_chip_carries_a_dot(qapp, tmp_path):
     from PyQt5.QtWidgets import QLabel
     chips = dialog.table.cellWidget(0, 1).findChildren(QLabel)
 
-    assert len(chips) == 3  # Data + writes + auto (off)
-    assert all("9679" in chip.text() for chip in chips)
+    assert [chip.text() for chip in chips] == ["Writes"]
 
 
 def test_the_type_column_fits_the_widest_row_of_chips(qapp, tmp_path):

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -4,6 +4,7 @@ The controller takes a folder, a context factory and a notifier, so it can be
 driven standalone -- which is the point of it not living in AutoLamellaMainUI.
 """
 
+import time
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ pytest.importorskip("PyQt5")
 
 from PyQt5.QtWidgets import QMenu  # noqa: E402
 
+from fibsem.cancellation import OperationCancelledError  # noqa: E402
 from fibsem.ui.widgets.script_menu import MANAGE_LABEL, ScriptMenuController  # noqa: E402
 
 
@@ -23,14 +25,40 @@ def qapp():
 
 
 class FakeContext:
-    """Stands in for whatever an application hands its scripts."""
+    """Stands in for whatever an application hands its scripts.
+
+    Same shape as the real ScriptContext, including the cancellation surface the
+    runner injects into for threaded scripts.
+    """
 
     def __init__(self):
         self.saved = False
         self.value = "from-context"
+        self.stop_event = None
 
     def save(self):
         self.saved = True
+
+    @property
+    def cancelled(self):
+        return self.stop_event is not None and self.stop_event.is_set()
+
+    def raise_if_cancelled(self):
+        from fibsem.cancellation import raise_if_cancelled
+        raise_if_cancelled(self.stop_event)
+
+
+def _drain(qapp, predicate, timeout=5.0):
+    """Pump the Qt event loop until predicate() is true, or give up.
+
+    Threaded scripts report back through a queued signal, so nothing is delivered
+    unless the loop runs.
+    """
+    deadline = time.monotonic() + timeout
+    while not predicate() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.005)
+    return predicate()
 
 
 def _write(directory: Path, name: str, body: str) -> Path:
@@ -206,14 +234,117 @@ def test_a_failing_script_notifies_instead_of_raising(qapp, tmp_path):
     assert notes and notes[-1][0] == "error"
 
 
-def test_a_microscope_script_is_refused_until_the_strict_runner_exists(qapp, tmp_path):
-    """FIB-340 owns the worker thread, hardware lock and state restoration."""
-    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    raise AssertionError\n")
-    notes = []
-    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
+def test_a_microscope_script_runs_off_the_gui_thread(qapp, tmp_path):
+    """Hardware operations take seconds to minutes. Inline they would freeze the
+    window for the whole run, which is indistinguishable from a crash."""
+    _write(tmp_path, "hw.py",
+           "import threading\n"
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    return threading.current_thread() is threading.main_thread()\n")
+    done = []
+    controller, _ = _controller(tmp_path, context=FakeContext())
+
+    # returns None because it has not finished yet -- the result arrives by callback
+    assert controller.runner.run(controller.runner.discover()[0],
+                                 on_finished=done.append) is None
+    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
+    assert done[0].value is False, "ran on the main thread"
+
+
+def test_a_microscope_script_is_confirmed_before_it_runs(qapp, tmp_path):
+    """It has already moved the hardware by the time it finishes."""
+    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
+    asked = []
+    controller, _ = _controller(tmp_path, context=FakeContext())
+    controller.runner.confirm = lambda q, detail: asked.append(detail) or True
+
+    controller.runner.run(controller.runner.discover()[0])
+    _drain(qapp, lambda: not controller.runner.is_running)
+
+    assert asked and "drives the microscope" in asked[0]
+
+
+def test_declining_a_microscope_confirmation_does_not_start_a_thread(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\ndef run(ctx):\n    raise AssertionError\n")
+    controller, _ = _controller(tmp_path, context=FakeContext(), confirm=False)
 
     assert controller.runner.run(controller.runner.discover()[0]) is None
-    assert notes and notes[-1][0] == "warning"
+    assert not controller.runner.is_running
+
+
+def test_a_script_that_both_writes_and_drives_says_both(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\nwrites = True\ndef run(ctx):\n    pass\n")
+    asked = []
+    controller, _ = _controller(tmp_path, context=FakeContext())
+    controller.runner.confirm = lambda q, detail: asked.append(detail) or True
+
+    controller.runner.run(controller.runner.discover()[0])
+    _drain(qapp, lambda: not controller.runner.is_running)
+
+    assert "drives the microscope" in asked[0] and "modifies the experiment" in asked[0]
+
+
+def test_only_one_script_runs_at_a_time(qapp, tmp_path):
+    """Two threads commanding one microscope is the failure this prevents."""
+    _write(tmp_path, "slow.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(3)\n"
+           "    return 'done'\n")
+    notes = []
+    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
+    script = controller.runner.discover()[0]
+
+    controller.runner.run(script)
+    assert _drain(qapp, lambda: controller.runner.is_running)
+
+    assert controller.runner.run(script) is None
+    assert notes[-1] == ("warning", "A script is already running.")
+
+    controller.runner.stop()
+    assert _drain(qapp, lambda: not controller.runner.is_running)
+
+
+def test_stop_is_cooperative_and_reports_as_cancelled(qapp, tmp_path):
+    """A Python thread cannot be killed, so Stop only sets a flag -- the script
+    has to look at it."""
+    _write(tmp_path, "slow.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(3)\n"
+           "    ctx.raise_if_cancelled()\n"
+           "    return 'ran to completion'\n")
+    done, notes = [], []
+    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
+
+    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
+    assert _drain(qapp, lambda: controller.runner.is_running)
+    controller.runner.stop()
+
+    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
+    assert isinstance(done[0].error, OperationCancelledError)
+    # a cancel is not a failure, and must not be reported as one
+    assert notes[-1] == ("warning", "slow cancelled.")
+
+
+def test_a_script_that_ignores_stop_still_finishes(qapp, tmp_path):
+    """Documented behaviour, not a bug: nothing can force it to stop."""
+    _write(tmp_path, "stubborn.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(0.05)\n"
+           "    return 'finished anyway'\n")
+    done = []
+    controller, _ = _controller(tmp_path, context=FakeContext())
+
+    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
+    controller.runner.stop()
+
+    assert _drain(qapp, lambda: bool(done))
+    assert done[0].ok and done[0].value == "finished anyway"
 
 
 def test_running_is_refused_when_the_host_has_no_context(qapp, tmp_path):

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -1,10 +1,11 @@
 """The Scripts menu, exercised without any application around it (FIB-338).
 
-The controller takes a folder, a context factory and a notifier, so it can be
-driven standalone -- which is the point of it not living in AutoLamellaMainUI.
+The menu is a way *in*, not a way to run: it offers the manager and the folder
+and nothing else. Running lives in the dialog, which is the only surface with a
+Stop button. What the runner does once something is started is pinned down in
+test_script_runner.py.
 """
 
-import time
 from pathlib import Path
 
 import pytest
@@ -13,52 +14,22 @@ pytest.importorskip("PyQt5")
 
 from PyQt5.QtWidgets import QMenu  # noqa: E402
 
-from fibsem.cancellation import OperationCancelledError  # noqa: E402
-from fibsem.ui.widgets.script_menu import MANAGE_LABEL, ScriptMenuController  # noqa: E402
+from fibsem.ui.widgets.script_menu import (  # noqa: E402
+    MANAGE_LABEL,
+    OPEN_FOLDER_LABEL,
+    ScriptMenuController,
+)
 
 
 @pytest.fixture
 def qapp():
     from PyQt5.QtWidgets import QApplication
-    app = QApplication.instance() or QApplication([])
-    yield app
+    yield QApplication.instance() or QApplication([])
 
 
 class FakeContext:
-    """Stands in for whatever an application hands its scripts.
-
-    Same shape as the real ScriptContext, including the cancellation surface the
-    runner injects into for threaded scripts.
-    """
-
-    def __init__(self):
-        self.saved = False
-        self.value = "from-context"
-        self.stop_event = None
-
     def save(self):
-        self.saved = True
-
-    @property
-    def cancelled(self):
-        return self.stop_event is not None and self.stop_event.is_set()
-
-    def raise_if_cancelled(self):
-        from fibsem.cancellation import raise_if_cancelled
-        raise_if_cancelled(self.stop_event)
-
-
-def _drain(qapp, predicate, timeout=5.0):
-    """Pump the Qt event loop until predicate() is true, or give up.
-
-    Threaded scripts report back through a queued signal, so nothing is delivered
-    unless the loop runs.
-    """
-    deadline = time.monotonic() + timeout
-    while not predicate() and time.monotonic() < deadline:
-        qapp.processEvents()
-        time.sleep(0.005)
-    return predicate()
+        pass
 
 
 def _write(directory: Path, name: str, body: str) -> Path:
@@ -68,334 +39,55 @@ def _write(directory: Path, name: str, body: str) -> Path:
     return path
 
 
-def _controller(tmp_path, context=None, reason="", notes=None, confirm=True):
+def _controller(tmp_path, context=None, reason=""):
     menu = QMenu()
     controller = ScriptMenuController(
         menu=menu,
         scripts_directory=lambda: tmp_path,
         context_factory=lambda: (context, reason),
-        notify=lambda msg, level: (notes if notes is not None else []).append((level, msg)),
-        # the real one is a modal box; a stub keeps the tests from blocking on it
-        confirm=lambda question, detail: confirm,
+        notify=lambda msg, level: None,
     )
     return controller, menu
 
 
-def test_menu_lists_scripts_by_name(qapp, tmp_path):
+def test_the_menu_offers_the_manager_and_the_folder(qapp, tmp_path):
+    _, menu = _controller(tmp_path, context=FakeContext())
+    assert [a.text() for a in menu.actions()] == [MANAGE_LABEL, OPEN_FOLDER_LABEL]
+
+
+def test_the_menu_never_offers_to_run_a_script(qapp, tmp_path):
+    """A menu item cannot be stopped. A microscope script started from one would
+    run to completion with no way to interrupt it, so nothing here starts one."""
     _write(tmp_path, "export.py", '"""Export a summary."""\ndef run(ctx):\n    pass\n')
-    controller, menu = _controller(tmp_path, context=FakeContext())
-
-    controller.rebuild()
-
-    labels = [a.text() for a in menu.actions() if a.text()]
-    assert "export" in labels
-
-
-def test_a_script_that_writes_is_labelled(qapp, tmp_path):
-    """A script that rewrites state must not look identical to one that reads."""
-    _write(tmp_path, "mark.py", "writes = True\ndef run(ctx):\n    pass\n")
-    controller, menu = _controller(tmp_path, context=FakeContext())
-
-    controller.rebuild()
-
-    assert any("writes" in a.text() for a in menu.actions())
-
-
-def test_a_broken_script_is_summarised_and_points_at_the_manager(qapp, tmp_path):
-    """A menu has nowhere to put a failure reason, so it reports the count and
-    sends the user to the dialog. Omitting it entirely is what we are avoiding."""
-    _write(tmp_path, "broken.py", "def main(ctx):\n    pass\n")
-    controller, menu = _controller(tmp_path, context=FakeContext())
-
-    controller.rebuild()
-
-    labels = [a.text() for a in menu.actions()]
-    assert not any(t.startswith("broken") for t in labels)
-    assert any("failed to load" in t for t in labels)
-    assert any(t == MANAGE_LABEL for t in labels)
-
-
-def test_the_manager_entry_is_always_offered(qapp, tmp_path):
-    controller, menu = _controller(tmp_path, context=FakeContext())
-    controller.rebuild()
-    assert any(a.text() == MANAGE_LABEL for a in menu.actions())
-
-
-def test_entries_are_disabled_and_explained_when_the_host_is_not_ready(qapp, tmp_path):
-    _write(tmp_path, "export.py", "def run(ctx):\n    pass\n")
-    controller, menu = _controller(tmp_path, context=None, reason="Load an experiment")
-
-    controller.rebuild()
-
-    export = next(a for a in menu.actions() if a.text().startswith("export"))
-    assert not export.isEnabled()
-    assert any(a.text() == "Load an experiment" for a in menu.actions())
-
-
-def test_empty_folder_says_so_rather_than_showing_nothing(qapp, tmp_path):
-    controller, menu = _controller(tmp_path, context=FakeContext())
-
-    controller.rebuild()
-
-    assert any(a.text() == "No scripts found" for a in menu.actions())
-
-
-def test_open_folder_action_is_always_offered(qapp, tmp_path):
-    controller, menu = _controller(tmp_path, context=FakeContext())
-    controller.rebuild()
-    assert any(a.text() == "Open scripts folder" for a in menu.actions())
-
-
-def test_running_passes_the_context_through(qapp, tmp_path):
-    _write(tmp_path, "read.py", "def run(ctx):\n    return ctx.value\n")
-    context = FakeContext()
-    controller, _ = _controller(tmp_path, context=context)
-
-    result = controller.runner.run(controller.runner.discover()[0])
-
-    assert result.ok and result.value == "from-context"
-
-
-def test_writes_flag_triggers_the_context_save_hook(qapp, tmp_path):
-    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
-    context = FakeContext()
-    controller, _ = _controller(tmp_path, context=context)
-
-    controller.runner.run(controller.runner.discover()[0])
-
-    assert context.saved
-
-
-def test_a_writes_script_is_confirmed_before_it_runs(qapp, tmp_path):
-    """It saves the moment it finishes and there is no undo."""
-    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
-    asked = []
-    controller, _ = _controller(tmp_path, context=FakeContext())
-    controller.runner.confirm = lambda q, detail: asked.append((q, detail)) or True
-
-    controller.runner.run(controller.runner.discover()[0])
-
-    assert asked, "a writes script ran without asking"
-    question, detail = asked[0]
-    assert "w" in question and "no undo" in detail
-
-
-def test_declining_the_confirmation_does_not_run_or_save(qapp, tmp_path):
-    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    ctx.ran = True\n")
-    context = FakeContext()
-    controller, _ = _controller(tmp_path, context=context, confirm=False)
-
-    assert controller.runner.run(controller.runner.discover()[0]) is None
-    assert not context.saved
-    assert not getattr(context, "ran", False)
-
-
-def test_the_real_confirmation_box_builds(qapp, tmp_path, monkeypatch):
-    """Every other test injects a stub for it, so the box itself is otherwise
-    never constructed and a mistake in it would only show up in the app."""
-    from PyQt5.QtWidgets import QMessageBox
-
-    monkeypatch.setattr(QMessageBox, "exec_", lambda self: 0)
-    controller, _ = _controller(tmp_path, context=FakeContext())
-
-    # no button clicked -> not confirmed, which is the safe direction
-    assert controller.runner._default_confirm("Run 'x'?", "It writes.") is False
-
-
-def test_a_read_only_script_is_not_confirmed(qapp, tmp_path):
-    """The common case must stay one click -- a prompt on every run gets clicked
-    through without reading, which is worse than not having one."""
-    _write(tmp_path, "r.py", "def run(ctx):\n    pass\n")
-    controller, _ = _controller(tmp_path, context=FakeContext())
-    controller.runner.confirm = lambda q, detail: pytest.fail("asked to confirm a read")
-
-    assert controller.runner.run(controller.runner.discover()[0]).ok
-
-
-def test_without_the_flag_the_save_hook_is_not_called(qapp, tmp_path):
-    _write(tmp_path, "r.py", "def run(ctx):\n    pass\n")
-    context = FakeContext()
-    controller, _ = _controller(tmp_path, context=context)
-
-    controller.runner.run(controller.runner.discover()[0])
-
-    assert not context.saved
-
-
-def test_a_failing_script_notifies_instead_of_raising(qapp, tmp_path):
-    """PyQt5 aborts the process on an exception escaping a slot (FIB-329)."""
-    _write(tmp_path, "bad.py", "def run(ctx):\n    raise RuntimeError('nope')\n")
-    notes = []
-    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
-
-    result = controller.runner.run(controller.runner.discover()[0])
-
-    assert not result.ok
-    assert notes and notes[-1][0] == "error"
-
-
-def test_a_microscope_script_runs_off_the_gui_thread(qapp, tmp_path):
-    """Hardware operations take seconds to minutes. Inline they would freeze the
-    window for the whole run, which is indistinguishable from a crash."""
-    _write(tmp_path, "hw.py",
-           "import threading\n"
-           "uses_microscope = True\n"
-           "def run(ctx):\n"
-           "    return threading.current_thread() is threading.main_thread()\n")
-    done = []
-    controller, _ = _controller(tmp_path, context=FakeContext())
-
-    # returns None because it has not finished yet -- the result arrives by callback
-    assert controller.runner.run(controller.runner.discover()[0],
-                                 on_finished=done.append) is None
-    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
-    assert done[0].value is False, "ran on the main thread"
-
-
-def test_the_microscope_is_withheld_without_the_flag(qapp, tmp_path):
-    """Otherwise a script could drive the stage while the dialog still labels it
-    'Data / Read-only' -- an active falsehood, worse than saying nothing."""
-    _write(tmp_path, "sneaky.py", "def run(ctx):\n    return ctx.microscope\n")
-    context = FakeContext()
-    context.microscope = object()
-    controller, _ = _controller(tmp_path, context=context)
-
-    result = controller.runner.run(controller.runner.discover()[0])
-
-    assert result.ok and result.value is None
-    # put back, so a host that reuses one context object is not left without it
-    assert context.microscope is not None
-
-
-def test_forgetting_the_flag_says_which_flag_to_add(qapp, tmp_path):
-    """The traceback names the line, but the toast is all most users see, and
-    "'NoneType' has no attribute acquire_image" does not say what to do."""
-    _write(tmp_path, "forgot.py", "def run(ctx):\n    return ctx.microscope.acquire()\n")
-    context = FakeContext()
-    context.microscope = object()
-    notes = []
-    controller, _ = _controller(tmp_path, context=context, notes=notes)
-
-    controller.runner.run(controller.runner.discover()[0])
-
-    level, message = notes[-1]
-    assert level == "error"
-    assert "uses_microscope = True" in message
-
-
-def test_a_declared_script_gets_the_real_microscope(qapp, tmp_path):
-    _write(tmp_path, "hw.py",
-           "uses_microscope = True\ndef run(ctx):\n    return ctx.microscope\n")
-    context = FakeContext()
-    context.microscope = microscope = object()
-    done = []
-    controller, _ = _controller(tmp_path, context=context)
-
-    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
-
-    assert _drain(qapp, lambda: bool(done))
-    assert done[0].value is microscope
-
-
-def test_a_microscope_script_is_confirmed_before_it_runs(qapp, tmp_path):
-    """It has already moved the hardware by the time it finishes."""
     _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
-    asked = []
+
+    _, menu = _controller(tmp_path, context=FakeContext())
+
+    assert not any("export" in a.text() or "hw" in a.text() for a in menu.actions())
+
+
+def test_the_menu_is_the_same_whatever_is_in_the_folder(qapp, tmp_path):
+    """Nothing here depends on the folder, so it is built once rather than
+    re-importing every script each time the Tools menu opens."""
+    _, empty = _controller(tmp_path, context=FakeContext())
+    before = [a.text() for a in empty.actions()]
+
+    _write(tmp_path, "broken.py", "def main(ctx):\n    pass\n")
+    _write(tmp_path, "good.py", "def run(ctx):\n    pass\n")
+    _, populated = _controller(tmp_path, context=FakeContext())
+
+    assert [a.text() for a in populated.actions()] == before
+
+
+def test_the_menu_is_usable_with_no_experiment_loaded(qapp, tmp_path):
+    """Both entries still work -- the dialog is where "why can I not run this"
+    gets explained, and you have to be able to reach it to read that."""
+    _, menu = _controller(tmp_path, context=None, reason="Load an experiment")
+    assert all(a.isEnabled() for a in menu.actions())
+
+
+def test_the_controller_exposes_the_runner_it_built(qapp, tmp_path):
+    """AutoLamellaUI reaches through it to refuse a workflow while a microscope
+    script is running (FIB-340)."""
     controller, _ = _controller(tmp_path, context=FakeContext())
-    controller.runner.confirm = lambda q, detail: asked.append(detail) or True
-
-    controller.runner.run(controller.runner.discover()[0])
-    _drain(qapp, lambda: not controller.runner.is_running)
-
-    assert asked and "drives the microscope" in asked[0]
-
-
-def test_declining_a_microscope_confirmation_does_not_start_a_thread(qapp, tmp_path):
-    _write(tmp_path, "hw.py",
-           "uses_microscope = True\ndef run(ctx):\n    raise AssertionError\n")
-    controller, _ = _controller(tmp_path, context=FakeContext(), confirm=False)
-
-    assert controller.runner.run(controller.runner.discover()[0]) is None
-    assert not controller.runner.is_running
-
-
-def test_a_script_that_both_writes_and_drives_says_both(qapp, tmp_path):
-    _write(tmp_path, "hw.py",
-           "uses_microscope = True\nwrites = True\ndef run(ctx):\n    pass\n")
-    asked = []
-    controller, _ = _controller(tmp_path, context=FakeContext())
-    controller.runner.confirm = lambda q, detail: asked.append(detail) or True
-
-    controller.runner.run(controller.runner.discover()[0])
-    _drain(qapp, lambda: not controller.runner.is_running)
-
-    assert "drives the microscope" in asked[0] and "modifies the experiment" in asked[0]
-
-
-def test_only_one_script_runs_at_a_time(qapp, tmp_path):
-    """Two threads commanding one microscope is the failure this prevents."""
-    _write(tmp_path, "slow.py",
-           "uses_microscope = True\n"
-           "def run(ctx):\n"
-           "    ctx.stop_event.wait(3)\n"
-           "    return 'done'\n")
-    notes = []
-    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
-    script = controller.runner.discover()[0]
-
-    controller.runner.run(script)
-    assert _drain(qapp, lambda: controller.runner.is_running)
-
-    assert controller.runner.run(script) is None
-    assert notes[-1] == ("warning", "A script is already running.")
-
-    controller.runner.stop()
-    assert _drain(qapp, lambda: not controller.runner.is_running)
-
-
-def test_stop_is_cooperative_and_reports_as_cancelled(qapp, tmp_path):
-    """A Python thread cannot be killed, so Stop only sets a flag -- the script
-    has to look at it."""
-    _write(tmp_path, "slow.py",
-           "uses_microscope = True\n"
-           "def run(ctx):\n"
-           "    ctx.stop_event.wait(3)\n"
-           "    ctx.raise_if_cancelled()\n"
-           "    return 'ran to completion'\n")
-    done, notes = [], []
-    controller, _ = _controller(tmp_path, context=FakeContext(), notes=notes)
-
-    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
-    assert _drain(qapp, lambda: controller.runner.is_running)
-    controller.runner.stop()
-
-    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
-    assert isinstance(done[0].error, OperationCancelledError)
-    # a cancel is not a failure, and must not be reported as one
-    assert notes[-1] == ("warning", "slow cancelled.")
-
-
-def test_a_script_that_ignores_stop_still_finishes(qapp, tmp_path):
-    """Documented behaviour, not a bug: nothing can force it to stop."""
-    _write(tmp_path, "stubborn.py",
-           "uses_microscope = True\n"
-           "def run(ctx):\n"
-           "    ctx.stop_event.wait(0.05)\n"
-           "    return 'finished anyway'\n")
-    done = []
-    controller, _ = _controller(tmp_path, context=FakeContext())
-
-    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
-    controller.runner.stop()
-
-    assert _drain(qapp, lambda: bool(done))
-    assert done[0].ok and done[0].value == "finished anyway"
-
-
-def test_running_is_refused_when_the_host_has_no_context(qapp, tmp_path):
-    _write(tmp_path, "export.py", "def run(ctx):\n    raise AssertionError\n")
-    notes = []
-    controller, _ = _controller(tmp_path, context=None, reason="Load an experiment", notes=notes)
-
-    assert controller.runner.run(controller.runner.discover()[0]) is None
-    assert notes and notes[-1] == ("warning", "Load an experiment")
+    assert controller.runner.is_running is False

--- a/tests/ui/test_script_menu.py
+++ b/tests/ui/test_script_menu.py
@@ -252,6 +252,51 @@ def test_a_microscope_script_runs_off_the_gui_thread(qapp, tmp_path):
     assert done[0].value is False, "ran on the main thread"
 
 
+def test_the_microscope_is_withheld_without_the_flag(qapp, tmp_path):
+    """Otherwise a script could drive the stage while the dialog still labels it
+    'Data / Read-only' -- an active falsehood, worse than saying nothing."""
+    _write(tmp_path, "sneaky.py", "def run(ctx):\n    return ctx.microscope\n")
+    context = FakeContext()
+    context.microscope = object()
+    controller, _ = _controller(tmp_path, context=context)
+
+    result = controller.runner.run(controller.runner.discover()[0])
+
+    assert result.ok and result.value is None
+    # put back, so a host that reuses one context object is not left without it
+    assert context.microscope is not None
+
+
+def test_forgetting_the_flag_says_which_flag_to_add(qapp, tmp_path):
+    """The traceback names the line, but the toast is all most users see, and
+    "'NoneType' has no attribute acquire_image" does not say what to do."""
+    _write(tmp_path, "forgot.py", "def run(ctx):\n    return ctx.microscope.acquire()\n")
+    context = FakeContext()
+    context.microscope = object()
+    notes = []
+    controller, _ = _controller(tmp_path, context=context, notes=notes)
+
+    controller.runner.run(controller.runner.discover()[0])
+
+    level, message = notes[-1]
+    assert level == "error"
+    assert "uses_microscope = True" in message
+
+
+def test_a_declared_script_gets_the_real_microscope(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\ndef run(ctx):\n    return ctx.microscope\n")
+    context = FakeContext()
+    context.microscope = microscope = object()
+    done = []
+    controller, _ = _controller(tmp_path, context=context)
+
+    controller.runner.run(controller.runner.discover()[0], on_finished=done.append)
+
+    assert _drain(qapp, lambda: bool(done))
+    assert done[0].value is microscope
+
+
 def test_a_microscope_script_is_confirmed_before_it_runs(qapp, tmp_path):
     """It has already moved the hardware by the time it finishes."""
     _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")

--- a/tests/ui/test_script_runner.py
+++ b/tests/ui/test_script_runner.py
@@ -1,0 +1,312 @@
+"""ScriptRunner: what may run, how it runs, and what the user is told (FIB-338/340).
+
+Driven with no menu and no dialog around it -- the runner is the one path both
+surfaces go through, so this is where the running rules are pinned down.
+"""
+
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.cancellation import OperationCancelledError  # noqa: E402
+from fibsem.ui.widgets.script_runner import ScriptRunner  # noqa: E402
+
+
+@pytest.fixture
+def qapp():
+    from PyQt5.QtWidgets import QApplication
+    yield QApplication.instance() or QApplication([])
+
+
+class FakeContext:
+    """Stands in for whatever an application hands its scripts.
+
+    Same shape as the real ScriptContext, including the cancellation surface the
+    runner injects into for threaded scripts.
+    """
+
+    def __init__(self):
+        self.saved = False
+        self.value = "from-context"
+        self.stop_event = None
+
+    def save(self):
+        self.saved = True
+
+    @property
+    def cancelled(self):
+        return self.stop_event is not None and self.stop_event.is_set()
+
+    def raise_if_cancelled(self):
+        from fibsem.cancellation import raise_if_cancelled
+        raise_if_cancelled(self.stop_event)
+
+
+def _drain(qapp, predicate, timeout=5.0):
+    """Pump the Qt event loop until predicate() is true, or give up.
+
+    Threaded scripts report back through a queued signal, so nothing is delivered
+    unless the loop runs.
+    """
+    deadline = time.monotonic() + timeout
+    while not predicate() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.005)
+    return predicate()
+
+
+def _write(directory: Path, name: str, body: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(body)
+    return path
+
+
+def _runner(tmp_path, context=None, reason="", notes=None, confirm=True):
+    return ScriptRunner(
+        scripts_directory=lambda: tmp_path,
+        context_factory=lambda: (context, reason),
+        notify=lambda msg, level: (notes if notes is not None else []).append((level, msg)),
+        # the real one is a modal box; a stub keeps the tests from blocking on it
+        confirm=lambda question, detail: confirm,
+    )
+
+
+def test_running_passes_the_context_through(qapp, tmp_path):
+    _write(tmp_path, "read.py", "def run(ctx):\n    return ctx.value\n")
+    context = FakeContext()
+    runner = _runner(tmp_path, context=context)
+
+    result = runner.run(runner.discover()[0])
+
+    assert result.ok and result.value == "from-context"
+
+def test_writes_flag_triggers_the_context_save_hook(qapp, tmp_path):
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    context = FakeContext()
+    runner = _runner(tmp_path, context=context)
+
+    runner.run(runner.discover()[0])
+
+    assert context.saved
+
+def test_a_writes_script_is_confirmed_before_it_runs(qapp, tmp_path):
+    """It saves the moment it finishes and there is no undo."""
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    pass\n")
+    asked = []
+    runner = _runner(tmp_path, context=FakeContext())
+    runner.confirm = lambda q, detail: asked.append((q, detail)) or True
+
+    runner.run(runner.discover()[0])
+
+    assert asked, "a writes script ran without asking"
+    question, detail = asked[0]
+    assert "w" in question and "no undo" in detail
+
+def test_declining_the_confirmation_does_not_run_or_save(qapp, tmp_path):
+    _write(tmp_path, "w.py", "writes = True\ndef run(ctx):\n    ctx.ran = True\n")
+    context = FakeContext()
+    runner = _runner(tmp_path, context=context, confirm=False)
+
+    assert runner.run(runner.discover()[0]) is None
+    assert not context.saved
+    assert not getattr(context, "ran", False)
+
+def test_the_real_confirmation_box_builds(qapp, tmp_path, monkeypatch):
+    """Every other test injects a stub for it, so the box itself is otherwise
+    never constructed and a mistake in it would only show up in the app."""
+    from PyQt5.QtWidgets import QMessageBox
+
+    monkeypatch.setattr(QMessageBox, "exec_", lambda self: 0)
+    runner = _runner(tmp_path, context=FakeContext())
+
+    # no button clicked -> not confirmed, which is the safe direction
+    assert runner._default_confirm("Run 'x'?", "It writes.") is False
+
+def test_a_read_only_script_is_not_confirmed(qapp, tmp_path):
+    """The common case must stay one click -- a prompt on every run gets clicked
+    through without reading, which is worse than not having one."""
+    _write(tmp_path, "r.py", "def run(ctx):\n    pass\n")
+    runner = _runner(tmp_path, context=FakeContext())
+    runner.confirm = lambda q, detail: pytest.fail("asked to confirm a read")
+
+    assert runner.run(runner.discover()[0]).ok
+
+def test_without_the_flag_the_save_hook_is_not_called(qapp, tmp_path):
+    _write(tmp_path, "r.py", "def run(ctx):\n    pass\n")
+    context = FakeContext()
+    runner = _runner(tmp_path, context=context)
+
+    runner.run(runner.discover()[0])
+
+    assert not context.saved
+
+def test_a_failing_script_notifies_instead_of_raising(qapp, tmp_path):
+    """PyQt5 aborts the process on an exception escaping a slot (FIB-329)."""
+    _write(tmp_path, "bad.py", "def run(ctx):\n    raise RuntimeError('nope')\n")
+    notes = []
+    runner = _runner(tmp_path, context=FakeContext(), notes=notes)
+
+    result = runner.run(runner.discover()[0])
+
+    assert not result.ok
+    assert notes and notes[-1][0] == "error"
+
+def test_a_microscope_script_runs_off_the_gui_thread(qapp, tmp_path):
+    """Hardware operations take seconds to minutes. Inline they would freeze the
+    window for the whole run, which is indistinguishable from a crash."""
+    _write(tmp_path, "hw.py",
+           "import threading\n"
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    return threading.current_thread() is threading.main_thread()\n")
+    done = []
+    runner = _runner(tmp_path, context=FakeContext())
+
+    # returns None because it has not finished yet -- the result arrives by callback
+    assert runner.run(runner.discover()[0],
+                                 on_finished=done.append) is None
+    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
+    assert done[0].value is False, "ran on the main thread"
+
+def test_the_microscope_is_withheld_without_the_flag(qapp, tmp_path):
+    """Otherwise a script could drive the stage while the dialog still labels it
+    'Data / Read-only' -- an active falsehood, worse than saying nothing."""
+    _write(tmp_path, "sneaky.py", "def run(ctx):\n    return ctx.microscope\n")
+    context = FakeContext()
+    context.microscope = object()
+    runner = _runner(tmp_path, context=context)
+
+    result = runner.run(runner.discover()[0])
+
+    assert result.ok and result.value is None
+    # put back, so a host that reuses one context object is not left without it
+    assert context.microscope is not None
+
+def test_forgetting_the_flag_says_which_flag_to_add(qapp, tmp_path):
+    """The traceback names the line, but the toast is all most users see, and
+    "'NoneType' has no attribute acquire_image" does not say what to do."""
+    _write(tmp_path, "forgot.py", "def run(ctx):\n    return ctx.microscope.acquire()\n")
+    context = FakeContext()
+    context.microscope = object()
+    notes = []
+    runner = _runner(tmp_path, context=context, notes=notes)
+
+    runner.run(runner.discover()[0])
+
+    level, message = notes[-1]
+    assert level == "error"
+    assert "uses_microscope = True" in message
+
+def test_a_declared_script_gets_the_real_microscope(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\ndef run(ctx):\n    return ctx.microscope\n")
+    context = FakeContext()
+    context.microscope = microscope = object()
+    done = []
+    runner = _runner(tmp_path, context=context)
+
+    runner.run(runner.discover()[0], on_finished=done.append)
+
+    assert _drain(qapp, lambda: bool(done))
+    assert done[0].value is microscope
+
+def test_a_microscope_script_is_confirmed_before_it_runs(qapp, tmp_path):
+    """It has already moved the hardware by the time it finishes."""
+    _write(tmp_path, "hw.py", "uses_microscope = True\ndef run(ctx):\n    pass\n")
+    asked = []
+    runner = _runner(tmp_path, context=FakeContext())
+    runner.confirm = lambda q, detail: asked.append(detail) or True
+
+    runner.run(runner.discover()[0])
+    _drain(qapp, lambda: not runner.is_running)
+
+    assert asked and "drives the microscope" in asked[0]
+
+def test_declining_a_microscope_confirmation_does_not_start_a_thread(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\ndef run(ctx):\n    raise AssertionError\n")
+    runner = _runner(tmp_path, context=FakeContext(), confirm=False)
+
+    assert runner.run(runner.discover()[0]) is None
+    assert not runner.is_running
+
+def test_a_script_that_both_writes_and_drives_says_both(qapp, tmp_path):
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\nwrites = True\ndef run(ctx):\n    pass\n")
+    asked = []
+    runner = _runner(tmp_path, context=FakeContext())
+    runner.confirm = lambda q, detail: asked.append(detail) or True
+
+    runner.run(runner.discover()[0])
+    _drain(qapp, lambda: not runner.is_running)
+
+    assert "drives the microscope" in asked[0] and "modifies the experiment" in asked[0]
+
+def test_only_one_script_runs_at_a_time(qapp, tmp_path):
+    """Two threads commanding one microscope is the failure this prevents."""
+    _write(tmp_path, "slow.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(3)\n"
+           "    return 'done'\n")
+    notes = []
+    runner = _runner(tmp_path, context=FakeContext(), notes=notes)
+    script = runner.discover()[0]
+
+    runner.run(script)
+    assert _drain(qapp, lambda: runner.is_running)
+
+    assert runner.run(script) is None
+    assert notes[-1] == ("warning", "A script is already running.")
+
+    runner.stop()
+    assert _drain(qapp, lambda: not runner.is_running)
+
+def test_stop_is_cooperative_and_reports_as_cancelled(qapp, tmp_path):
+    """A Python thread cannot be killed, so Stop only sets a flag -- the script
+    has to look at it."""
+    _write(tmp_path, "slow.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(3)\n"
+           "    ctx.raise_if_cancelled()\n"
+           "    return 'ran to completion'\n")
+    done, notes = [], []
+    runner = _runner(tmp_path, context=FakeContext(), notes=notes)
+
+    runner.run(runner.discover()[0], on_finished=done.append)
+    assert _drain(qapp, lambda: runner.is_running)
+    runner.stop()
+
+    assert _drain(qapp, lambda: bool(done)), "the script never reported back"
+    assert isinstance(done[0].error, OperationCancelledError)
+    # a cancel is not a failure, and must not be reported as one
+    assert notes[-1] == ("warning", "slow cancelled.")
+
+def test_a_script_that_ignores_stop_still_finishes(qapp, tmp_path):
+    """Documented behaviour, not a bug: nothing can force it to stop."""
+    _write(tmp_path, "stubborn.py",
+           "uses_microscope = True\n"
+           "def run(ctx):\n"
+           "    ctx.stop_event.wait(0.05)\n"
+           "    return 'finished anyway'\n")
+    done = []
+    runner = _runner(tmp_path, context=FakeContext())
+
+    runner.run(runner.discover()[0], on_finished=done.append)
+    runner.stop()
+
+    assert _drain(qapp, lambda: bool(done))
+    assert done[0].ok and done[0].value == "finished anyway"
+
+def test_running_is_refused_when_the_host_has_no_context(qapp, tmp_path):
+    _write(tmp_path, "export.py", "def run(ctx):\n    raise AssertionError\n")
+    notes = []
+    runner = _runner(tmp_path, context=None, reason="Load an experiment", notes=notes)
+
+    assert runner.run(runner.discover()[0]) is None
+    assert notes and notes[-1] == ("warning", "Load an experiment")

--- a/tests/ui/test_script_runner.py
+++ b/tests/ui/test_script_runner.py
@@ -246,6 +246,23 @@ def test_a_script_that_both_writes_and_drives_says_both(qapp, tmp_path):
 
     assert "drives the microscope" in asked[0] and "modifies the experiment" in asked[0]
 
+def test_two_consequences_are_two_sentences_not_a_chain_of_ands(qapp, tmp_path):
+    """Joining the clauses with "and" produced "nothing checks what it does and
+    modifies the experiment", where the second and attaches to "nothing checks" --
+    so the warning stated the opposite of what it meant, on the worst script type."""
+    _write(tmp_path, "hw.py",
+           "uses_microscope = True\nwrites = True\ndef run(ctx):\n    pass\n")
+    runner = _runner(tmp_path, context=FakeContext())
+
+    detail = runner._consequence(runner.discover()[0])
+
+    assert detail == (
+        "It drives the microscope, and nothing checks what it does. "
+        "It modifies the experiment and saves it when it finishes. "
+        "There is no undo."
+    )
+    assert "does and modifies" not in detail
+
 def test_only_one_script_runs_at_a_time(qapp, tmp_path):
     """Two threads commanding one microscope is the failure this prevents."""
     _write(tmp_path, "slow.py",


### PR DESCRIPTION
Stacked on #219 — base is `claude/fib-338-tier1-scripts`, so the diff here is only the microscope change. Rebase onto main once #219 lands.

> **No CI has run on this PR and none will.** `python-package.yml` filters on `pull_request: branches: [main]`, and that filter is on the *base* branch — a PR targeting another branch never triggers it. Verification so far is local only: 1504 passed, 15 skipped, on Python 3.13. CI covers 3.8–3.13, and the new threading tests are the ones most likely to differ elsewhere.

`uses_microscope = True` was parsed, displayed, and then refused. It now runs.

## Safety is the script author's

That is the premise, and the UI says it in those words rather than implying otherwise — the confirmation and the detail panel both state that nothing checks what the script does, no limits and no interlocks. It is the same access the application's own code has, with none of its guard rails.

```python
"""Acquire an ion image at every lamella position."""
uses_microscope = True

from fibsem import acquire
from fibsem.structures import BeamType, ImageSettings


def run(ctx):
    settings = ImageSettings(hfw=80e-6, beam_type=BeamType.ION, save=True)

    for lamella in ctx.experiment.positions:
        ctx.raise_if_cancelled()          # let Stop actually stop it
        ctx.log(f"moving to {lamella.name}")
        ctx.microscope.safe_absolute_stage_movement(lamella.stage_position)
        settings.path, settings.filename = lamella.path, "script-survey"
        acquire.acquire_image(ctx.microscope, settings)

    return f"imaged {len(ctx.experiment.positions)} positions"
```

## What is *not* the author's problem

**Freezing the app.** Hardware operations take seconds to minutes. Run inline, that is indistinguishable from a crash, so microscope scripts go to a `FunctionWorker`. Data scripts still run inline — they take milliseconds, and they touch evented experiment state that only the GUI thread may touch.

The consequence is the reverse rule for microscope scripts: **do not touch `ctx.experiment` from one.** Documented in SCRIPTING.md, not enforced — enforcing it would mean withholding the experiment, which is worse.

**Two things commanding the stage.** A second script is refused while one runs, and starting a workflow is now refused while a microscope script runs. That is the other direction of the guard that already blocked scripts during a workflow.

**No way to stop it.** `ctx.stop_event`, `ctx.cancelled`, `ctx.raise_if_cancelled()`, and the dialog's Run button becomes a red Stop. Cooperative, because a Python thread cannot be killed — a script that never checks runs to completion, and the docs say that plainly rather than implying Stop is a kill. A cancelled run reports as *cancelled*, not *failed*.

**Starting one somewhere it cannot be stopped.** The Scripts menu used to list every script and run it on click, which was fine while scripts were inline and instant. A menu item has nowhere to show that a script is still going and no Stop button, so the menu no longer runs anything — it offers `Manage scripts…` and `Open scripts folder`, and everything happens in the dialog. It is also built once rather than on `aboutToShow`, so opening the Tools menu no longer imports every script in the folder.

## `ctx.microscope` is withheld without the flag

Otherwise the flag is advisory: a script could drive the stage without declaring it, skipping the confirmation, running the hardware call on the GUI thread and leaving the workflow gate open — while the dialog went on labelling it **Data / Read-only**. That last part is what makes it worth fixing: an active falsehood is worse than saying nothing.

Kept as `None` rather than a self-explaining sentinel, because `ctx.microscope is None` is the headless default and a script that checks it has to keep working in both places. The cost is a useless error message, so the toast carries the fix instead:

```
forgot_the_flag failed: 'NoneType' object has no attribute 'acquire_image'
  — if it needs the microscope, declare uses_microscope = True.
```

Not a boundary — scripts are arbitrary Python and can import their way to a handle. This is for the author who did not know the flag existed.

`writes` has the same hole via `ctx.save()` and is deliberately left alone: it overwrites a yaml the docs tell you to back up, where this can drive the stage into the pole piece.

## API change

`ScriptRunner.run()` grows an optional `on_finished` callback, because the result no longer always exists by the time it returns. The inline path is unchanged and still returns its result directly, so every existing caller and test still works.

## Testing

72 tests across the runner, menu, dialog and core — the runner ones moved into a new `tests/ui/test_script_runner.py`, since they were only in the menu's file because the menu used to be the thing that ran scripts.

The threaded path is exercised end to end: that the script really is off the main thread, that Stop cancels a running one, that a script *ignoring* Stop still completes, that a second run is refused, and that the dialog's button round-trips Run → Stop → Run with the outcome stamped as cancelled.

The dialog's running state was rendered offscreen and checked: red Stop button, table and folder controls disabled, `Drives the microscope` in the detail panel.

**The SCRIPTING.md microscope example is now extracted from the markdown and executed against a demo microscope.** It was wrong in two ways before anyone ran it: `lamella.state.stage_position` does not exist (it is `lamella.stage_position`), and `microscope.acquire_image()` **ignores `save=True`** — `fibsem.acquire.acquire_image()` is the one that writes the file. It now produces the images it claims to.

## Still not implemented

`background` (parsed, still inline) and `on_workflow_completed` (nothing fires it). Both say so in the UI.