### PR TITLE
[feat] Show what plugins resolved, in the GUI and the CLI (FIB-347, FIB-348)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -385,6 +385,17 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             parent=self,
         )
 
+        # Below the separator because it is the one entry here that acts on the
+        # install rather than on the experiment: read-only, and the thing you open
+        # when a Scripts entry above did not appear.
+        tools_menu.addSeparator()
+        self.action_show_plugins = QAction("Plugins...", self)
+        self.action_show_plugins.setToolTip(
+            "Show every registered pattern, strategy and task, and where it came from"
+        )
+        self.action_show_plugins.triggered.connect(self._on_show_plugins)
+        tools_menu.addAction(self.action_show_plugins)
+
         # add help menu
         help_menu = menu_bar.addMenu("Help")
         if help_menu is None:
@@ -688,6 +699,12 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         open_bug_report_dialog(
             experiment=experiment, microscope=microscope, parent=self
         )
+
+    def _on_show_plugins(self):
+        """Open the read-only listing of registered extensions."""
+        from fibsem.ui.widgets.plugins_dialog import PluginsDialog
+
+        PluginsDialog(parent=self).exec_()
 
     def _on_toggle_minimap_widget(self, checked: bool):
         """Toggle the minimap plot dock widget visibility."""

--- a/fibsem/applications/autolamella/workflows/tasks/__init__.py
+++ b/fibsem/applications/autolamella/workflows/tasks/__init__.py
@@ -7,11 +7,9 @@ similar to the BasePattern plugin system in fibsem.milling.patterning.
 
 import logging
 import typing
-try:
-    from functools import cache
-except ImportError:  # Python < 3.9 fallback
-    from functools import lru_cache as cache
-from typing import TYPE_CHECKING, Any, Dict, Type
+from typing import TYPE_CHECKING, Any, Dict, Tuple, Type
+
+from fibsem.plugins.loader import PluginRecord, load_entry_point_group, plugin_classes
 
 if TYPE_CHECKING:
     from psygnal.containers import EventedDict
@@ -112,48 +110,33 @@ def register_task(task_cls: Type[AutoLamellaTask]) -> None:
     logging.info("Registered task '%s'", task_type)
 
 
-@cache
-def _get_plugin_tasks() -> Dict[str, Type[AutoLamellaTask]]:
-    """
-    Discover and import task plugins via entry points.
+TASK_ENTRY_POINT_GROUP = "fibsem.tasks"
 
-    The plugin logic is based on:
-    https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata
+
+def get_task_plugin_records() -> Tuple[PluginRecord, ...]:
+    """Every ``fibsem.tasks`` entry point and what became of it.
+
+    Loading happens once per process, on the first call. Includes the plugins
+    that failed and the ones a built-in later shadows, neither of which
+    survives into :func:`get_tasks` -- see ``fibsem.plugins.report``.
 
     To add a plugin task, add to your package's pyproject.toml:
 
     [project.entry-points.'fibsem.tasks']
     my_task = "my_package.tasks:MyCustomTask"
     """
-    import sys
+    return load_entry_point_group(
+        group=TASK_ENTRY_POINT_GROUP,
+        base_cls=AutoLamellaTask,
+        # A task registers under its config's task_type, not its own name.
+        name_of=lambda cls: cls.config_cls.task_type,
+        kind="task",
+    )
 
-    if sys.version_info < (3, 10):
-        from importlib_metadata import entry_points
-    else:
-        from importlib.metadata import entry_points
 
-    tasks: Dict[str, Type[AutoLamellaTask]] = {}
-
-    for task_entry_point in entry_points(group="fibsem.tasks"):
-        try:
-            task = task_entry_point.load()
-            if not issubclass(task, AutoLamellaTask):
-                raise TypeError(
-                    f"'{task_entry_point.value}' is not a subclass of AutoLamellaTask"
-                )
-            task_type = task.config_cls.task_type
-            logging.info("Loaded task plugin '%s'", task_type)
-            tasks[task_type] = task
-        except TypeError as e:
-            logging.warning("Invalid task plugin found: %s", str(e))
-        except Exception:
-            logging.error(
-                "Unexpected error raised while attempting to import task from '%s'",
-                task_entry_point.value,
-                exc_info=True,
-            )
-
-    return tasks
+def _get_plugin_tasks() -> Dict[str, Type[AutoLamellaTask]]:
+    """Plugin tasks that loaded, as ``{task_type: class}``."""
+    return plugin_classes(get_task_plugin_records())
 
 
 def get_tasks() -> Dict[str, Type[AutoLamellaTask]]:

--- a/fibsem/cli.py
+++ b/fibsem/cli.py
@@ -541,6 +541,21 @@ def _add_plugins_parser(sub) -> None:
         dest="show_builtins",
         help="Include built-in extensions, which are counted but hidden by default",
     )
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        # Declared here even though the root parser already inherits --debug from
+        # the connection parent, because taking no connection arguments means
+        # `plugins --debug` -- the position a user reaches for, and the one every
+        # other subcommand accepts -- would otherwise be an unrecognized
+        # argument. SUPPRESS rather than default=False so that *both* positions
+        # work: argparse copies every attribute of the subparser's namespace over
+        # the root's, so a plain default would silently reset a --debug given
+        # before the subcommand. Suppressed, the attribute is simply absent when
+        # the flag is not passed and whatever root parsed survives.
+        default=argparse.SUPPRESS,
+        help="Show the full traceback for each plugin that failed to load",
+    )
     p.set_defaults(func=cmd_plugins, needs_microscope=False)
 
 

--- a/fibsem/cli.py
+++ b/fibsem/cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import math
 import sys
 from datetime import datetime
@@ -301,6 +302,37 @@ def cmd_info(microscope, _settings, _args) -> int:
     return 0
 
 
+def cmd_plugins(args) -> int:
+    """Print what resolved under each entry point group.
+
+    A plugin registered under a mistyped group name fails completely silently:
+    nothing iterates unknown groups, so there is no error to log and the user
+    sees only that their plugin never appeared. Printing the literal group
+    strings is the whole diagnostic -- they can diff them against their own
+    pyproject in the same terminal.
+
+    Takes no microscope: see _add_plugins_parser.
+    """
+    from fibsem.plugins.report import collect_extensions, render_report
+
+    # Loading the registries logs a full traceback per broken plugin. Those are
+    # the very failures this command reports in one readable line each, and
+    # dumping them above the report would bury it. Nothing is lost: --debug
+    # brings the tracebacks back for when the one-line reason is not enough.
+    #
+    # Safe to do here only because importing fibsem.cli does not pull in any of
+    # the three registries, so nothing has loaded yet at this point.
+    if not args.debug:
+        logging.disable(logging.CRITICAL)
+    try:
+        groups = collect_extensions()
+    finally:
+        logging.disable(logging.NOTSET)
+
+    print(render_report(groups, show_builtins=args.show_builtins))
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # Parser construction
 # ---------------------------------------------------------------------------
@@ -491,6 +523,27 @@ def _add_mill_angle_parser(sub, conn) -> None:
     p.set_defaults(func=cmd_mill_angle)
 
 
+def _add_plugins_parser(sub) -> None:
+    """List what resolved under each entry point group.
+
+    Deliberately takes no connection arguments: diagnosing a plugin is usually
+    done away from the instrument, and requiring a microscope to answer "did my
+    plugin load?" would make the command useless in exactly the situation it
+    exists for. ``main()`` dispatches it before connecting.
+    """
+    p = sub.add_parser(
+        "plugins",
+        help="List registered patterns, strategies and tasks, and where they came from",
+    )
+    p.add_argument(
+        "--all",
+        action="store_true",
+        dest="show_builtins",
+        help="Include built-in extensions, which are counted but hidden by default",
+    )
+    p.set_defaults(func=cmd_plugins, needs_microscope=False)
+
+
 def _add_set_beam_parser(sub, conn) -> None:
     p = sub.add_parser("set-beam", parents=[conn], help="Set beam voltage, current, or HFW")
     p.add_argument(
@@ -547,6 +600,7 @@ def _build_parser() -> argparse.ArgumentParser:
         action=_VersionAction,
         help="Print the fibsemOS version and exit",
     )
+    root.set_defaults(needs_microscope=True)
     sub = root.add_subparsers(dest="subcommand", metavar="SUBCOMMAND")
     sub.required = True
     _add_acquire_parser(sub, conn)
@@ -558,6 +612,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_info_parser(sub, conn)
     _add_mill_angle_parser(sub, conn)
     _add_set_beam_parser(sub, conn)
+    _add_plugins_parser(sub)
     return root
 
 
@@ -575,6 +630,17 @@ def main() -> None:
     if args.subcommand == "move":
         if all(v is None for v in [args.x, args.y, args.z, args.rotation, args.tilt]):
             parser.error("move: at least one of --x, --y, --z, --rotation, --tilt must be specified")
+
+    # Subcommands that answer a question about this install rather than about a
+    # microscope run before the connection attempt. `plugins` in particular has
+    # to work with nothing plugged in -- it exists to explain why something is
+    # missing, and demanding hardware first would make it useless.
+    if not args.needs_microscope:
+        try:
+            sys.exit(args.func(args))
+        except Exception as e:
+            print(f"error: {e}", file=sys.stderr)
+            sys.exit(1)
 
     try:
         microscope, settings = utils.setup_session(

--- a/fibsem/cli.py
+++ b/fibsem/cli.py
@@ -544,15 +544,12 @@ def _add_plugins_parser(sub) -> None:
     p.add_argument(
         "--debug",
         action="store_true",
-        # Declared here even though the root parser already inherits --debug from
-        # the connection parent, because taking no connection arguments means
-        # `plugins --debug` -- the position a user reaches for, and the one every
-        # other subcommand accepts -- would otherwise be an unrecognized
-        # argument. SUPPRESS rather than default=False so that *both* positions
-        # work: argparse copies every attribute of the subparser's namespace over
-        # the root's, so a plain default would silently reset a --debug given
-        # before the subcommand. Suppressed, the attribute is simply absent when
-        # the flag is not passed and whatever root parsed survives.
+        # Declared here because taking no connection arguments means `plugins
+        # --debug` -- the position every other subcommand accepts, and the one a
+        # user reaches for -- would otherwise be an unrecognized argument. The
+        # root parser still supplies the default, hence SUPPRESS: same reason as
+        # the subparsers' copy of the connection arguments, see
+        # _build_connection_parser.
         default=argparse.SUPPRESS,
         help="Show the full traceback for each plugin that failed to load",
     )

--- a/fibsem/milling/patterning/__init__.py
+++ b/fibsem/milling/patterning/__init__.py
@@ -7,13 +7,10 @@ similar to the MillingStrategy plugin system.
 
 import logging
 import typing
-try:
-    from functools import cache
-except ImportError:  # Python < 3.9 fallback
-    from functools import lru_cache as cache
-from typing import Dict, Type, Any, Optional
+from typing import Any, Dict, Optional, Tuple, Type
 
 from fibsem.milling.patterning.patterns2 import BasePattern
+from fibsem.plugins.loader import PluginRecord, load_entry_point_group, plugin_classes
 
 # Built-in patterns (imported from patterns2.py)
 from fibsem.milling.patterning.patterns2 import (
@@ -80,47 +77,32 @@ def register_pattern(pattern_cls: Type[BasePattern]) -> None:
     logging.info("Registered pattern '%s'", pattern_cls.name)
 
 
-@cache
-def _get_plugin_patterns() -> Dict[str, Type[BasePattern]]:
-    """
-    Discover and import pattern plugins via entry points.
-    
-    The plugin logic is based on:
-    https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata
-    
+PATTERN_ENTRY_POINT_GROUP = "fibsem.patterns"
+
+
+def get_pattern_plugin_records() -> Tuple[PluginRecord, ...]:
+    """Every ``fibsem.patterns`` entry point and what became of it.
+
+    Loading happens once per process, on the first call. Includes the plugins
+    that failed and the ones a built-in later shadows, neither of which
+    survives into :func:`get_patterns` -- see ``fibsem.plugins.report``.
+
     To add a plugin pattern, add to your package's pyproject.toml:
-    
+
     [project.entry-points.'fibsem.patterns']
     my_pattern = "my_package.patterns:MyCustomPattern"
     """
-    import sys
+    return load_entry_point_group(
+        group=PATTERN_ENTRY_POINT_GROUP,
+        base_cls=BasePattern,
+        name_of=lambda cls: cls.name,
+        kind="pattern",
+    )
 
-    if sys.version_info < (3, 10):
-        from importlib_metadata import entry_points
-    else:
-        from importlib.metadata import entry_points
 
-    patterns: Dict[str, Type[BasePattern]] = {}
-    
-    for pattern_entry_point in entry_points(group="fibsem.patterns"):
-        try:
-            pattern = pattern_entry_point.load()
-            if not issubclass(pattern, BasePattern):
-                raise TypeError(
-                    f"'{pattern_entry_point.value}' is not a subclass of BasePattern"
-                )
-            logging.info("Loaded pattern plugin '%s'", pattern.name)
-            patterns[pattern.name] = pattern
-        except TypeError as e:
-            logging.warning("Invalid pattern plugin found: %s", str(e))
-        except Exception:
-            logging.error(
-                "Unexpected error raised while attempting to import pattern from '%s'",
-                pattern_entry_point.value,
-                exc_info=True,
-            )
-    
-    return patterns
+def _get_plugin_patterns() -> Dict[str, Type[BasePattern]]:
+    """Plugin patterns that loaded, as ``{name: class}``."""
+    return plugin_classes(get_pattern_plugin_records())
 
 
 def get_patterns() -> Dict[str, Type[BasePattern]]:

--- a/fibsem/milling/strategy/__init__.py
+++ b/fibsem/milling/strategy/__init__.py
@@ -1,8 +1,7 @@
-import logging
 import typing
-from functools import lru_cache as cache
 
 from fibsem.milling.base import MillingStrategy
+from fibsem.plugins.loader import PluginRecord, load_entry_point_group, plugin_classes
 from fibsem.milling.strategy.standard import StandardMillingStrategy
 from fibsem.milling.strategy.overtilt import OvertiltTrenchMillingStrategy
 from fibsem.milling.strategy.coincidence import CoincidenceMillingStrategy # noqa: F401
@@ -15,6 +14,7 @@ BUILTIN_STRATEGIES: typing.Dict[str, typing.Type[MillingStrategy[typing.Any]]] =
     CoincidenceMillingStrategy.name: CoincidenceMillingStrategy,
 }
 REGISTERED_STRATEGIES: typing.Dict[str, typing.Type[MillingStrategy[typing.Any]]] = {}
+STRATEGY_ENTRY_POINT_GROUP = "fibsem.strategies"
 
 
 def get_strategies() -> typing.Dict[str, typing.Type[MillingStrategy[typing.Any]]]:
@@ -31,37 +31,26 @@ def register_strategy(strategy_cls: typing.Type[MillingStrategy[typing.Any]]) ->
     REGISTERED_STRATEGIES[strategy_cls.name] = strategy_cls
 
 
-@cache
+def get_strategy_plugin_records() -> typing.Tuple[PluginRecord, ...]:
+    """Every ``fibsem.strategies`` entry point and what became of it.
+
+    Loading happens once per process, on the first call. Includes the plugins
+    that failed and the ones a built-in later shadows, neither of which
+    survives into :func:`get_strategies` -- see ``fibsem.plugins.report``.
+
+    To add a plugin strategy, add to your package's pyproject.toml:
+
+    [project.entry-points.'fibsem.strategies']
+    my_strategy = "my_package.strategies:MyCustomStrategy"
+    """
+    return load_entry_point_group(
+        group=STRATEGY_ENTRY_POINT_GROUP,
+        base_cls=MillingStrategy,
+        name_of=lambda cls: cls.name,
+        kind="strategy",
+    )
+
+
 def _get_plugin_strategies() -> typing.Dict[str, typing.Type[MillingStrategy[typing.Any]]]:
-    """
-    Import new strategies and append them to the list here
-
-    The plugin logic is based on:
-    https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata
-    """
-    import sys
-
-    if sys.version_info < (3, 10):
-        from importlib_metadata import entry_points
-    else:
-        from importlib.metadata import entry_points
-
-    strategies: typing.Dict[str, typing.Type[MillingStrategy[typing.Any]]] = {}
-    for strategy_entry_point in entry_points(group="fibsem.strategies"):
-        try:
-            strategy = strategy_entry_point.load()
-            if not issubclass(strategy, MillingStrategy):
-                raise TypeError(
-                    f"'{strategy_entry_point.value}' is not a subclass of MillingStrategy"
-                )
-            logging.info("Loaded strategy '%s'", strategy.name)
-            strategies[strategy.name] = strategy
-        except TypeError as e:
-            logging.warning("Invalid strategy found: %s", str(e))
-        except Exception:
-            logging.error(
-                "Unexpected error raised while attempting to import strategy from '%s'",
-                strategy_entry_point.value,
-                exc_info=True,
-            )
-    return strategies
+    """Plugin strategies that loaded, as ``{name: class}``."""
+    return plugin_classes(get_strategy_plugin_records())

--- a/fibsem/plugins/__init__.py
+++ b/fibsem/plugins/__init__.py
@@ -1,0 +1,15 @@
+"""Entry point plugin loading and introspection.
+
+Deliberately empty.
+
+``loader`` is imported by ``fibsem.milling.patterning`` while
+``fibsem.milling.base`` is only partially initialised (see the note in
+``loader.py``), so anything this package's ``__init__`` imported would be
+dragged into that window. ``report`` in particular imports all three
+registries and would deadlock the import graph outright.
+
+Import the submodules directly::
+
+    from fibsem.plugins.loader import load_entry_point_group   # early, safe
+    from fibsem.plugins.report import collect_extensions       # late, needs the registries
+"""

--- a/fibsem/plugins/loader.py
+++ b/fibsem/plugins/loader.py
@@ -1,0 +1,236 @@
+"""Load fibsem's entry point groups, and remember what happened.
+
+fibsem exposes three plugin groups -- ``fibsem.patterns``,
+``fibsem.strategies`` and ``fibsem.tasks`` -- each loaded by what used to be
+three near-identical private functions. They returned ``{name: class}`` and
+wrote every failure to a log line, which meant the two questions a user
+actually asks could not be answered:
+
+* *"my plugin isn't in the list"* -- a plugin that failed to import leaves no
+  trace in the returned dict at all.
+* *"why is my plugin being ignored?"* -- a plugin whose name collides with a
+  built-in loads fine, registers fine, and is then overwritten when
+  ``get_patterns()`` merges built-ins last. Nothing downstream can tell it ever
+  existed.
+
+So loading records what it did. ``load_entry_point_group`` returns one
+:class:`PluginRecord` per declared entry point -- successes, failures and
+shadowed-later-on alike -- and the registries derive their dict from those.
+Recording at load time rather than re-walking the entry points separately is
+the point: a second walk can disagree with what actually registered, and a
+disagreement is precisely the fault this data exists to diagnose.
+
+``fibsem.plugins.report`` turns these records into the plugin listing shown by
+``fibsem-cli plugins`` and the Plugins panel.
+
+**This module must not import anything from fibsem.** ``milling/base.py``
+imports ``fibsem.milling.patterning``, whose ``__init__`` ends with a
+module-level ``MILLING_PATTERNS = get_patterns()`` -- so this code runs while
+``fibsem.milling.base`` is only half initialised, and any import reaching back
+into it raises. The base class and the name-extraction callable are therefore
+passed in as arguments rather than imported here.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Type
+
+__all__ = [
+    "PluginRecord",
+    "load_entry_point_group",
+    "plugin_classes",
+    "clear_cache",
+]
+
+
+@dataclass(frozen=True)
+class PluginRecord:
+    """One declared entry point, and what became of it.
+
+    A record exists whether or not the plugin loaded, so a failure is
+    reportable rather than only loggable. ``cls`` and ``name`` are ``None``
+    exactly when ``error`` is set.
+    """
+
+    group: str
+    """The entry point group, e.g. ``"fibsem.patterns"``."""
+
+    entry_point: str
+    """The entry point's own name, as written in the plugin's pyproject."""
+
+    value: str
+    """The declared target, e.g. ``"lab_patterns.trench:WaffleTrenchPattern"``.
+
+    Kept even when loading failed -- a user needs to see what they *asked* for
+    to work out why it is missing.
+    """
+
+    distribution: Optional[str] = None
+    """The providing distribution's name, if it could be determined."""
+
+    version: Optional[str] = None
+    """The providing distribution's version, if it could be determined."""
+
+    cls: Optional[type] = None
+    """The loaded class, or ``None`` if it failed."""
+
+    name: Optional[str] = None
+    """The name it registered under, or ``None`` if it failed."""
+
+    error: Optional[str] = None
+    """Why it failed, phrased for a user, or ``None`` on success."""
+
+    @property
+    def loaded(self) -> bool:
+        return self.error is None
+
+
+# One load per group per process, mirroring the @cache the registries used to
+# carry. Keyed on the group alone: a group has exactly one base class, and
+# loading it twice under different rules would be a bug, not a feature.
+_CACHE: Dict[str, Tuple[PluginRecord, ...]] = {}
+
+
+def _entry_points(group: str) -> Iterator[Any]:
+    """Iterate the entry points in ``group``.
+
+    Guard on the version, not on ImportError: ``importlib.metadata`` exists
+    from 3.8, so a try/except import succeeds on 3.8/3.9 and then fails at the
+    call -- the ``group=`` filter only arrived in 3.10.
+
+    Note that the objects returned are not necessarily
+    ``importlib.metadata.EntryPoint``. The ``importlib_metadata`` backport
+    installs its own finder on ``sys.meta_path``, so on a Python where the
+    backport is also present the stdlib call hands back *backport* entry points
+    and distributions. Both expose the attributes used here, but nothing should
+    assume the concrete class.
+    """
+    import sys
+
+    if sys.version_info < (3, 10):
+        from importlib_metadata import entry_points
+    else:
+        from importlib.metadata import entry_points
+
+    return iter(entry_points(group=group))
+
+
+def _distribution_of(entry_point: Any) -> Tuple[Optional[str], Optional[str]]:
+    """Best-effort ``(name, version)`` of the package providing an entry point.
+
+    Which install a plugin came from is the question that matters on a
+    microscope PC with several environments, but it is metadata, not the
+    plugin: never let reading it break loading.
+    """
+    try:
+        dist = entry_point.dist
+        if dist is None:
+            return None, None
+        return dist.name, dist.version
+    except Exception:  # pragma: no cover - defensive, varies by metadata impl
+        return None, None
+
+
+def load_entry_point_group(
+    group: str,
+    base_cls: type,
+    name_of: Callable[[type], str],
+    kind: str,
+) -> Tuple[PluginRecord, ...]:
+    """Load every entry point in ``group``, returning a record for each.
+
+    Args:
+        group: The entry point group, e.g. ``"fibsem.patterns"``.
+        base_cls: The class every plugin in this group must subclass.
+        name_of: Extracts the name a loaded class registers under. Patterns and
+            strategies use ``cls.name``; tasks use ``cls.config_cls.task_type``.
+        kind: Singular noun for log messages, e.g. ``"pattern"``.
+
+    Returns:
+        One record per declared entry point, in discovery order. Never raises:
+        a plugin that fails to load is reported, not propagated, because a
+        third-party package must not be able to stop fibsem from starting.
+    """
+    cached = _CACHE.get(group)
+    if cached is not None:
+        return cached
+
+    records = []
+    for entry_point in _entry_points(group):
+        distribution, version = _distribution_of(entry_point)
+        record = PluginRecord(
+            group=group,
+            entry_point=entry_point.name,
+            value=entry_point.value,
+            distribution=distribution,
+            version=version,
+        )
+
+        try:
+            obj = entry_point.load()
+        except Exception as exc:
+            logging.error(
+                "Unexpected error raised while attempting to import %s from '%s'",
+                kind,
+                entry_point.value,
+                exc_info=True,
+            )
+            records.append(replace(record, error=f"{type(exc).__name__}: {exc}"))
+            continue
+
+        # issubclass() raises rather than returning False when handed a
+        # non-class, which an entry point pointing at a function or a constant
+        # does. Check first, so the reason names the real problem.
+        if not isinstance(obj, type):
+            reason = f"{type(obj).__name__} is not a class"
+            logging.warning("Invalid %s plugin found: '%s' %s", kind, entry_point.value, reason)
+            records.append(replace(record, error=reason))
+            continue
+
+        if not issubclass(obj, base_cls):
+            reason = f"not a subclass of {base_cls.__name__}"
+            logging.warning("Invalid %s plugin found: '%s' is %s", kind, entry_point.value, reason)
+            records.append(replace(record, error=reason))
+            continue
+
+        try:
+            name = name_of(obj)
+        except Exception as exc:
+            logging.warning(
+                "Invalid %s plugin found: could not read the name of '%s': %s",
+                kind,
+                entry_point.value,
+                exc,
+            )
+            records.append(replace(record, error=f"could not read its name: {exc}"))
+            continue
+
+        logging.info("Loaded %s plugin '%s'", kind, name)
+        records.append(replace(record, cls=obj, name=name))
+
+    loaded = tuple(records)
+    _CACHE[group] = loaded
+    return loaded
+
+
+def plugin_classes(records: Tuple[PluginRecord, ...]) -> Dict[str, Type[Any]]:
+    """The ``{name: class}`` mapping the registries merge.
+
+    Built in record order, so when two entry points claim the same name the
+    last one wins -- the behaviour these registries have always had. The
+    displaced record is still in ``records``, which is how the listing can
+    report a collision the mapping cannot express.
+    """
+    return {r.name: r.cls for r in records if r.loaded}  # type: ignore[misc]
+
+
+def clear_cache() -> None:
+    """Forget every loaded group, so the next call re-walks the entry points.
+
+    For tests. Calling this in a running application will make the registries
+    disagree with the module-level snapshots taken at import time
+    (``MILLING_PATTERNS``, ``TASK_REGISTRY``), which is worse than a stale list.
+    """
+    _CACHE.clear()

--- a/fibsem/plugins/report.py
+++ b/fibsem/plugins/report.py
@@ -1,0 +1,458 @@
+"""What is registered, where it came from, and why something is missing.
+
+Assembles the three plugin groups into one listing and renders it as text.
+Both surfaces read from here -- ``fibsem-cli plugins`` and the Plugins panel --
+so a report a user pastes into a bug tracker says the same thing as the dialog
+support is looking at.
+
+The interesting rows are the ones :func:`~fibsem.milling.patterning.get_patterns`
+and friends cannot return:
+
+* **failed** -- an entry point that did not load. It is absent from every
+  registry, so without the load records from ``fibsem.plugins.loader`` there is
+  nothing to list and the user's only evidence is a log line that scrolled past
+  at startup.
+* **shadowed** -- a plugin whose name a built-in already claims. It loads, it
+  registers, and then ``{**plugins, **registered, **builtins}`` overwrites it.
+  The merged dict cannot express that it was ever there.
+
+Unlike ``loader``, this module imports all three registries, so it must only be
+imported well after startup -- from the CLI or the UI, never from a registry.
+
+Script-loaded tasks (FIB-339) are modelled here but not yet produced: nothing
+loads a scripts folder today. When that lands it only has to emit
+:class:`Extension` rows with ``source=ExtensionSource.SCRIPT`` and a ``path``;
+the renderers and the panel already handle them.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Iterable, List, Optional, Tuple, Type
+
+from fibsem.plugins.loader import PluginRecord
+
+__all__ = [
+    "ExtensionSource",
+    "Extension",
+    "ExtensionGroup",
+    "collect_extensions",
+    "render_report",
+    "group_counts_phrase",
+    "environment_line",
+    "summarise",
+]
+
+
+class ExtensionSource(Enum):
+    """Where a registered extension came from."""
+
+    BUILTIN = "built-in"
+    REGISTERED = "registered"
+    PLUGIN = "plugin"
+    SCRIPT = "script"
+    FAILED = "failed"
+
+
+# Successes before failures, and built-ins last since they are hidden by
+# default. Also the order rows appear in, so the listing is stable between runs
+# -- entry_points() iterates in filesystem order, which differs by machine, and
+# an unstable listing is useless for comparing two pasted reports.
+_SOURCE_ORDER = {
+    ExtensionSource.PLUGIN: 0,
+    ExtensionSource.SCRIPT: 1,
+    ExtensionSource.REGISTERED: 2,
+    ExtensionSource.FAILED: 3,
+    ExtensionSource.BUILTIN: 4,
+}
+
+
+@dataclass(frozen=True)
+class Extension:
+    """One row of the listing."""
+
+    group: str
+    """Entry point group, e.g. ``"fibsem.patterns"``."""
+
+    name: Optional[str]
+    """The name it registered under. ``None`` when nothing registered."""
+
+    source: ExtensionSource
+
+    target: str
+    """What the row points at.
+
+    For anything that loaded, the resolved ``module.QualName``. For a failure,
+    the *declared* ``module:Attr`` exactly as written in the plugin's
+    pyproject -- a listing that only shows what resolved cannot answer "why
+    isn't mine here?", so a failed row has to show what was asked for.
+    """
+
+    distribution: Optional[str] = None
+    version: Optional[str] = None
+
+    path: Optional[str] = None
+    """Home-relative path to the source file, for script-loaded extensions."""
+
+    problem: Optional[str] = None
+    """Why this row is inactive: a load failure, or what shadowed it."""
+
+    @property
+    def is_problem(self) -> bool:
+        return self.problem is not None
+
+    @property
+    def shadowed(self) -> bool:
+        """Loaded and registered, but another registration won the name."""
+        return self.problem is not None and self.source is not ExtensionSource.FAILED
+
+    @property
+    def origin(self) -> str:
+        """``"lab-patterns 0.3.1"``, a script path, or ``""``."""
+        if self.path is not None:
+            return self.path
+        if self.distribution is None:
+            return ""
+        if self.version is None:
+            return self.distribution
+        return f"{self.distribution} {self.version}"
+
+
+@dataclass(frozen=True)
+class ExtensionGroup:
+    """One entry point group and everything registered under it."""
+
+    group: str
+    """The literal entry point group string, e.g. ``"fibsem.patterns"``.
+
+    Shown verbatim rather than only the friendly label: a group name mistyped
+    in a plugin's pyproject registers nothing and produces no error anywhere,
+    so the exact string is the whole diagnostic. The user diffs it against
+    their own file.
+    """
+
+    label: str
+    """Human name, e.g. ``"Milling patterns"``."""
+
+    extensions: Tuple[Extension, ...]
+
+    def counts(self) -> "Dict[ExtensionSource, int]":
+        counts: Dict[ExtensionSource, int] = {}
+        for extension in self.extensions:
+            counts[extension.source] = counts.get(extension.source, 0) + 1
+        return counts
+
+    def visible(self, show_builtins: bool) -> Tuple[Extension, ...]:
+        if show_builtins:
+            return self.extensions
+        return tuple(e for e in self.extensions if e.source is not ExtensionSource.BUILTIN)
+
+
+def home_relative(path: str) -> str:
+    """``/Users/someone/.autolamella/x`` -> ``~/.autolamella/x``.
+
+    This listing is meant to be pasted into a bug report, so the paths in it
+    should not carry the user's name. Purely cosmetic -- nothing parses these
+    back.
+    """
+    try:
+        home = os.path.expanduser("~")
+    except Exception:  # pragma: no cover - expanduser is not supposed to fail
+        return path
+    if home and path.startswith(home):
+        return "~" + path[len(home):]
+    return path
+
+
+def _qualified(cls: type) -> str:
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _shadow_reason(name: str, builtins: Dict[str, type], registered: Dict[str, type]) -> str:
+    if name in builtins:
+        return "name taken by a built-in - the built-in is used, this is inactive"
+    if name in registered:
+        return "name taken by a runtime registration - this is inactive"
+    return "name taken by another plugin - this is inactive"
+
+
+def _build_group(
+    group: str,
+    label: str,
+    records: Iterable[PluginRecord],
+    builtins: Dict[str, Type],
+    registered: Dict[str, Type],
+    active: Dict[str, Type],
+) -> ExtensionGroup:
+    """Assemble one group's rows from its load records and its registries.
+
+    ``active`` is what the registry actually hands out, and it is the arbiter:
+    a plugin is shadowed precisely when the name it claimed now maps to a
+    different class.
+    """
+    extensions: List[Extension] = []
+
+    for record in records:
+        if not record.loaded:
+            extensions.append(
+                Extension(
+                    group=group,
+                    name=None,
+                    source=ExtensionSource.FAILED,
+                    target=record.value,
+                    distribution=record.distribution,
+                    version=record.version,
+                    # Spell out the consequence. "ModuleNotFoundError" on its
+                    # own does not tell a user whether their plugin is
+                    # half-loaded or absent.
+                    problem=f"{record.error} - nothing was registered",
+                )
+            )
+            continue
+
+        assert record.name is not None and record.cls is not None
+        won = active.get(record.name) is record.cls
+        extensions.append(
+            Extension(
+                group=group,
+                name=record.name,
+                source=ExtensionSource.PLUGIN,
+                target=_qualified(record.cls),
+                distribution=record.distribution,
+                version=record.version,
+                problem=None if won else _shadow_reason(record.name, builtins, registered),
+            )
+        )
+
+    for name, cls in registered.items():
+        if name in builtins:
+            # Registered at runtime, then shadowed by the built-in of the same
+            # name. Same story as a shadowed plugin.
+            problem = "name taken by a built-in - the built-in is used, this is inactive"
+        else:
+            problem = None
+        extensions.append(
+            Extension(
+                group=group,
+                name=name,
+                source=ExtensionSource.REGISTERED,
+                target=_qualified(cls),
+                problem=problem,
+            )
+        )
+
+    for name, cls in builtins.items():
+        extensions.append(
+            Extension(
+                group=group,
+                name=name,
+                source=ExtensionSource.BUILTIN,
+                target=_qualified(cls),
+            )
+        )
+
+    extensions.sort(key=lambda e: (_SOURCE_ORDER[e.source], e.name or e.target))
+    return ExtensionGroup(group=group, label=label, extensions=tuple(extensions))
+
+
+def collect_extensions() -> Tuple[ExtensionGroup, ...]:
+    """Every registered extension across all three groups, with provenance."""
+    from fibsem.applications.autolamella.workflows.tasks import (
+        BUILTIN_TASKS,
+        REGISTERED_TASKS,
+        TASK_ENTRY_POINT_GROUP,
+        get_task_plugin_records,
+        get_tasks,
+    )
+    from fibsem.milling.patterning import (
+        BUILTIN_PATTERNS,
+        PATTERN_ENTRY_POINT_GROUP,
+        REGISTERED_PATTERNS,
+        get_pattern_plugin_records,
+        get_patterns,
+    )
+    from fibsem.milling.strategy import (
+        BUILTIN_STRATEGIES,
+        REGISTERED_STRATEGIES,
+        STRATEGY_ENTRY_POINT_GROUP,
+        get_strategies,
+        get_strategy_plugin_records,
+    )
+
+    return (
+        _build_group(
+            group=PATTERN_ENTRY_POINT_GROUP,
+            label="Milling patterns",
+            records=get_pattern_plugin_records(),
+            builtins=BUILTIN_PATTERNS,
+            registered=REGISTERED_PATTERNS,
+            active=get_patterns(),
+        ),
+        _build_group(
+            group=STRATEGY_ENTRY_POINT_GROUP,
+            label="Milling strategies",
+            records=get_strategy_plugin_records(),
+            builtins=BUILTIN_STRATEGIES,
+            registered=REGISTERED_STRATEGIES,
+            active=get_strategies(),
+        ),
+        _build_group(
+            group=TASK_ENTRY_POINT_GROUP,
+            label="AutoLamella tasks",
+            records=get_task_plugin_records(),
+            builtins=BUILTIN_TASKS,
+            registered=REGISTERED_TASKS,
+            active=get_tasks(),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Text rendering
+# ---------------------------------------------------------------------------
+
+def _plural(count: int, noun: str) -> str:
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
+def group_counts_phrase(group: ExtensionGroup) -> str:
+    """``"1 plugin, 1 failed, 11 built-in"`` for a group header.
+
+    Shared with the Plugins panel rather than reimplemented there: two headers
+    disagreeing about how many plugins are installed would undermine the point
+    of both.
+    """
+    counts = group.counts()
+    parts = []
+    for source in (ExtensionSource.PLUGIN, ExtensionSource.SCRIPT, ExtensionSource.REGISTERED):
+        if counts.get(source):
+            parts.append(_plural(counts[source], source.value))
+    if counts.get(ExtensionSource.FAILED):
+        parts.append(f"{counts[ExtensionSource.FAILED]} failed")
+    if counts.get(ExtensionSource.BUILTIN):
+        parts.append(f"{counts[ExtensionSource.BUILTIN]} built-in")
+    return ", ".join(parts) if parts else "nothing registered"
+
+
+def summarise(groups: Iterable[ExtensionGroup]) -> Tuple[str, int]:
+    """``("2 plugins, 1 script, 1 failed to load", 20)``.
+
+    The count is of built-ins, which are hidden by default in both surfaces.
+    """
+    totals: Dict[ExtensionSource, int] = {}
+    for group in groups:
+        for source, count in group.counts().items():
+            totals[source] = totals.get(source, 0) + count
+
+    parts = []
+    for source in (ExtensionSource.PLUGIN, ExtensionSource.SCRIPT, ExtensionSource.REGISTERED):
+        if totals.get(source):
+            parts.append(_plural(totals[source], source.value))
+    if totals.get(ExtensionSource.FAILED):
+        parts.append(f"{totals[ExtensionSource.FAILED]} failed to load")
+
+    summary = ", ".join(parts) if parts else "no plugins installed"
+    return summary, totals.get(ExtensionSource.BUILTIN, 0)
+
+
+def environment_line() -> str:
+    """``"fibsem 0.5.2 - Python 3.11.9 - ~/miniconda3/envs/fibsem"``.
+
+    Pasted into a bug report, "which install is this?" is otherwise always the
+    next question -- a microscope PC routinely has several environments and the
+    plugin is only installed into one of them.
+    """
+    try:
+        import fibsem
+
+        version = getattr(fibsem, "__version__", "unknown")
+    except Exception:  # pragma: no cover - fibsem is obviously importable here
+        version = "unknown"
+    return (
+        f"fibsem {version} - Python {platform.python_version()} - "
+        f"{home_relative(sys.prefix)}"
+    )
+
+
+_MIN_NAME_WIDTH = 17
+_MIN_ORIGIN_WIDTH = 20
+_INDENT = "  "
+
+
+def render_report(groups: Iterable[ExtensionGroup], show_builtins: bool = False) -> str:
+    """The plugin listing as text.
+
+    This is what ``fibsem-cli plugins`` prints and what the panel's Copy report
+    button puts on the clipboard -- one renderer, so a pasted report and the
+    dialog never disagree.
+
+    Problems get a ``!`` continuation line indented under their entry: greppable
+    (``| grep '!'``), and it keeps the happy path at one line per plugin so a
+    long list stays scannable.
+
+    ASCII only. This gets pasted into terminals, issue trackers and Windows
+    consoles, where an em dash is a mojibake risk for no benefit.
+    """
+    groups = list(groups)
+    rows_by_group = [(g, g.visible(show_builtins)) for g in groups]
+    visible = [e for _, rows in rows_by_group for e in rows]
+
+    # Size the columns to the content rather than fixing them: task types run to
+    # nearly 30 characters while pattern names are short, and a name that
+    # overflows a fixed column runs into the one after it. Every width is
+    # derived purely from the rows being printed, so the same input always
+    # renders identically -- two pasted reports stay diffable. The +1 is the
+    # gutter, and the reason a value exactly as wide as its column does not
+    # collide with the next.
+    name_width = max([_MIN_NAME_WIDTH] + [len(e.name or "-") for e in visible]) + 1
+    source_width = max([len(e.source.value) for e in visible] or [0]) + 1
+    origins = [len(e.origin) for e in visible if e.path is None and e.origin]
+    # With no plugins installed at all, every row is a built-in with no
+    # distribution to show. Collapse the column rather than indenting the whole
+    # listing past an empty one.
+    origin_width = max([_MIN_ORIGIN_WIDTH] + origins) + 1 if origins else 0
+
+    lines: List[str] = []
+    for group, rows in rows_by_group:
+        lines.append(f"{group.group}  ({group_counts_phrase(group)})")
+        if not rows:
+            lines.append(f"{_INDENT}-")
+        for extension in rows:
+            # A failed entry point registered nothing, so it has no name to
+            # show; "-" holds the column while the declared target carries the
+            # information.
+            name = extension.name or "-"
+            lines.append(
+                _INDENT
+                + name.ljust(name_width)
+                + extension.source.value.ljust(source_width)
+                + _origin_and_target(extension, origin_width)
+            )
+            if extension.path is not None:
+                # The path took the origin column, so the class goes below it
+                # rather than being dropped.
+                lines.append(_INDENT + " " * (name_width + source_width) + extension.target)
+            if extension.problem:
+                lines.append(_INDENT + " " * name_width + "! " + extension.problem)
+        lines.append("")
+
+    summary, hidden = summarise(groups)
+    if hidden and not show_builtins:
+        summary += f". {hidden} built-in hidden (use --all)."
+    else:
+        summary += "."
+    lines.append(summary)
+    lines.append(environment_line())
+    return "\n".join(lines)
+
+
+def _origin_and_target(extension: Extension, origin_width: int) -> str:
+    if extension.path is not None:
+        return extension.path
+    # Built-ins have no distribution, but still pad the column so their targets
+    # line up with the plugins above them.
+    return extension.origin.ljust(origin_width) + extension.target

--- a/fibsem/plugins/report.py
+++ b/fibsem/plugins/report.py
@@ -27,12 +27,13 @@ the renderers and the panel already handle them.
 
 from __future__ import annotations
 
+import logging
 import os
 import platform
 import sys
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Iterable, List, Optional, Tuple, Type
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Type
 
 from fibsem.plugins.loader import PluginRecord
 
@@ -259,15 +260,7 @@ def _build_group(
     return ExtensionGroup(group=group, label=label, extensions=tuple(extensions))
 
 
-def collect_extensions() -> Tuple[ExtensionGroup, ...]:
-    """Every registered extension across all three groups, with provenance."""
-    from fibsem.applications.autolamella.workflows.tasks import (
-        BUILTIN_TASKS,
-        REGISTERED_TASKS,
-        TASK_ENTRY_POINT_GROUP,
-        get_task_plugin_records,
-        get_tasks,
-    )
+def _pattern_group() -> ExtensionGroup:
     from fibsem.milling.patterning import (
         BUILTIN_PATTERNS,
         PATTERN_ENTRY_POINT_GROUP,
@@ -275,6 +268,18 @@ def collect_extensions() -> Tuple[ExtensionGroup, ...]:
         get_pattern_plugin_records,
         get_patterns,
     )
+
+    return _build_group(
+        group=PATTERN_ENTRY_POINT_GROUP,
+        label="Milling patterns",
+        records=get_pattern_plugin_records(),
+        builtins=BUILTIN_PATTERNS,
+        registered=REGISTERED_PATTERNS,
+        active=get_patterns(),
+    )
+
+
+def _strategy_group() -> ExtensionGroup:
     from fibsem.milling.strategy import (
         BUILTIN_STRATEGIES,
         REGISTERED_STRATEGIES,
@@ -283,32 +288,104 @@ def collect_extensions() -> Tuple[ExtensionGroup, ...]:
         get_strategy_plugin_records,
     )
 
-    return (
-        _build_group(
-            group=PATTERN_ENTRY_POINT_GROUP,
-            label="Milling patterns",
-            records=get_pattern_plugin_records(),
-            builtins=BUILTIN_PATTERNS,
-            registered=REGISTERED_PATTERNS,
-            active=get_patterns(),
-        ),
-        _build_group(
-            group=STRATEGY_ENTRY_POINT_GROUP,
-            label="Milling strategies",
-            records=get_strategy_plugin_records(),
-            builtins=BUILTIN_STRATEGIES,
-            registered=REGISTERED_STRATEGIES,
-            active=get_strategies(),
-        ),
-        _build_group(
-            group=TASK_ENTRY_POINT_GROUP,
-            label="AutoLamella tasks",
-            records=get_task_plugin_records(),
-            builtins=BUILTIN_TASKS,
-            registered=REGISTERED_TASKS,
-            active=get_tasks(),
-        ),
+    return _build_group(
+        group=STRATEGY_ENTRY_POINT_GROUP,
+        label="Milling strategies",
+        records=get_strategy_plugin_records(),
+        builtins=BUILTIN_STRATEGIES,
+        registered=REGISTERED_STRATEGIES,
+        active=get_strategies(),
     )
+
+
+def _task_group() -> ExtensionGroup:
+    from fibsem.applications.autolamella.workflows.tasks import (
+        BUILTIN_TASKS,
+        REGISTERED_TASKS,
+        TASK_ENTRY_POINT_GROUP,
+        get_task_plugin_records,
+        get_tasks,
+    )
+
+    return _build_group(
+        group=TASK_ENTRY_POINT_GROUP,
+        label="AutoLamella tasks",
+        records=get_task_plugin_records(),
+        builtins=BUILTIN_TASKS,
+        registered=REGISTERED_TASKS,
+        active=get_tasks(),
+    )
+
+
+# group string, label, providing module, collector.
+#
+# The first three repeat what the registry modules already declare, instead of
+# importing it. That is the point: they are needed precisely when importing the
+# registry is what failed, and a group that cannot be inspected still has to be
+# named in the listing. Pinned against the real constants by
+# test_the_group_table_matches_the_registries.
+_GROUPS: Tuple[Tuple[str, str, str, Callable[[], ExtensionGroup]], ...] = (
+    ("fibsem.patterns", "Milling patterns", "fibsem.milling.patterning", _pattern_group),
+    ("fibsem.strategies", "Milling strategies", "fibsem.milling.strategy", _strategy_group),
+    (
+        "fibsem.tasks",
+        "AutoLamella tasks",
+        "fibsem.applications.autolamella.workflows.tasks",
+        _task_group,
+    ),
+)
+
+
+def _collect_group(
+    group: str,
+    label: str,
+    module: str,
+    collect: Callable[[], ExtensionGroup],
+) -> ExtensionGroup:
+    """One group, or one row explaining why it could not be read.
+
+    The header count will say "1 failed", which is a slight overstatement of what
+    is known -- nothing was inspected, so nothing is known to have failed. The row
+    underneath says so in words, and the alternative (a group-level problem field)
+    would have to be threaded through both renderers and the panel to say the same
+    thing.
+    """
+    try:
+        return collect()
+    except Exception as exc:
+        logging.error("Could not inspect the '%s' extension group", group, exc_info=True)
+        return ExtensionGroup(
+            group=group,
+            label=label,
+            extensions=(
+                Extension(
+                    group=group,
+                    name=None,
+                    source=ExtensionSource.FAILED,
+                    # The module that could not be read goes in the column that
+                    # normally carries a plugin's declared target: same question
+                    # ("what was being loaded?"), same shape of answer.
+                    target=module,
+                    problem=(
+                        f"{type(exc).__name__}: {exc} "
+                        f"- this whole group could not be inspected"
+                    ),
+                ),
+            ),
+        )
+
+
+def collect_extensions() -> Tuple[ExtensionGroup, ...]:
+    """Every registered extension across all three groups, with provenance.
+
+    Each group is collected independently. A group whose registry will not import
+    becomes a single row saying so rather than taking the listing down with it:
+    this is the surface that exists to explain a broken install, so needing an
+    intact one would defeat it. The AutoLamella task registry is the realistic
+    case -- by far the heaviest import of the three -- and the two milling groups
+    are worth showing without it.
+    """
+    return tuple(_collect_group(*spec) for spec in _GROUPS)
 
 
 # ---------------------------------------------------------------------------

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -688,6 +688,7 @@ TEXT_STRONG_COLOR = "#f0f1f2"   # titles, emphasis
 TEXT_MUTED_COLOR = "#868e93"    # secondary text, disabled
 ACCENT_COLOR = "#50a6ff"        # links, selected state, informational chips
 OK_COLOR = "#4caf50"            # success
+WARN_COLOR = "#e0a030"          # loaded but inactive, degraded, needs attention
 ERROR_COLOR = "#d04040"         # failure
 
 # The tooltip rule, for restating alongside a selector-less widget stylesheet.

--- a/fibsem/ui/widgets/plugins_dialog.py
+++ b/fibsem/ui/widgets/plugins_dialog.py
@@ -21,7 +21,6 @@ from PyQt5.QtWidgets import (
     QDialog,
     QHBoxLayout,
     QLabel,
-    QSizePolicy,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
@@ -39,22 +38,41 @@ from fibsem.plugins.report import (
     summarise,
 )
 from fibsem.ui.icon import fibsem_icon
-from fibsem.ui.stylesheets import GRAY_ICON_COLOR
+from fibsem.ui.stylesheets import (
+    ACCENT_COLOR,
+    BORDER_COLOR,
+    ERROR_COLOR,
+    GRAY_ICON_COLOR,
+    OK_COLOR,
+    PANEL_COLOR,
+    ROW_ALT_COLOR,
+    SURFACE_COLOR,
+    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
+    TEXT_STRONG_COLOR,
+    WARN_COLOR,
+)
 from fibsem.ui.utils import open_path_in_file_explorer
-from fibsem.ui.widgets.custom_widgets import IconToolButton
+from fibsem.ui.widgets.custom_widgets import (
+    ElidedLabel,
+    IconToolButton,
+    chip,
+    style_with_tooltip,
+)
 
-# Palette (matching fibsem.ui.stylesheets napari theme)
-_BG = "#262930"
-_PANEL = "#1e2027"
-_ROW_ALT = "#2b2f38"
-_BORDER = "#3d4251"
-_TEXT = "#d6d6d6"
-_TEXT_STRONG = "#f0f1f2"
-_TEXT_MUTED = "#868e93"
-_ACCENT = "#50a6ff"
-_OK = "#4caf50"
-_WARN = "#e0a030"
-_ERROR = "#d04040"
+# Short local names for the shared palette. These appear inside dozens of
+# f-strings below, where the full names would wrap every one of them.
+_BG = SURFACE_COLOR
+_PANEL = PANEL_COLOR
+_ROW_ALT = ROW_ALT_COLOR
+_BORDER = BORDER_COLOR
+_TEXT = TEXT_COLOR
+_TEXT_STRONG = TEXT_STRONG_COLOR
+_TEXT_MUTED = TEXT_MUTED_COLOR
+_ACCENT = ACCENT_COLOR
+_OK = OK_COLOR
+_WARN = WARN_COLOR
+_ERROR = ERROR_COLOR
 
 _COLUMNS = ["Extension", "Source", "Entry point group"]
 
@@ -109,55 +127,7 @@ QTableWidget::item:selected {{ background-color: #2d3947; color: {_TEXT_STRONG};
 
 _CHECKBOX_STYLE = f"font-size: 12px; color: {_TEXT};"
 
-# Restates the application stylesheet's own QToolTip rule. A selector-less
-# stylesheet set on a widget also styles the tooltip shown over that widget, and
-# it sits nearer than the application sheet, so it wins: `background:
-# transparent` on a table cell leaves its tooltip as floating text with no panel
-# behind it, and a muted `color` makes the tooltip text unreadable. Anything
-# applied through _style() carries this so that cannot happen.
-_TOOLTIP_STYLE = f"""
-QToolTip {{
-    background-color: {_PANEL};
-    color: {_TEXT};
-    border: 1px solid {_BORDER};
-    padding: 4px 8px;
-    border-radius: 3px;
-}}
-"""
-
-
-def _style(widget: QWidget, css: str) -> None:
-    """Apply a selector-less stylesheet without swallowing the widget's tooltip.
-
-    Use this rather than setStyleSheet for any rule written without a selector.
-    A rule with one (``QDialog {...}``, ``QTableWidget {...}``) cannot match
-    QToolTip and needs no such care.
-    """
-    widget.setStyleSheet(css + _TOOLTIP_STYLE)
-
 _COPY_ICON = "mdi:content-copy"
-
-
-class _ElidedLabel(QLabel):
-    """A QLabel that elides rather than clipping mid-glyph.
-
-    The Extension column stretches, so the width is not known when the row is
-    built and any one-off elide would be wrong at the next size. The size policy
-    is Ignored so a 60-character dotted class path cannot drive the column
-    wider, which would defeat the point.
-    """
-
-    def __init__(self, text: str, parent: Optional[QWidget] = None) -> None:
-        super().__init__(text, parent)
-        self._full_text = text
-        self.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
-
-    def paintEvent(self, event) -> None:  # noqa: N802 - Qt naming
-        metrics = QFontMetrics(self.font())
-        elided = metrics.elidedText(self._full_text, Qt.ElideRight, self.width())
-        if elided != self.text():
-            self.setText(elided)
-        super().paintEvent(event)
 
 
 class PluginsDialog(QDialog):
@@ -201,20 +171,20 @@ class PluginsDialog(QDialog):
         titles = QVBoxLayout()
         titles.setSpacing(2)
         self.title_label = QLabel("Registered extensions")
-        _style(
+        style_with_tooltip(
             self.title_label,
             f"font-size: 15px; font-weight: 500; color: {_TEXT_STRONG};",
         )
         # counts are meta, not the heading -- the heading says what this dialog
         # is, the line under it says what is currently in it.
         self.meta_label = QLabel()
-        _style(self.meta_label, f"font-size: 12px; color: {_TEXT_MUTED};")
+        style_with_tooltip(self.meta_label, f"font-size: 12px; color: {_TEXT_MUTED};")
         titles.addWidget(self.title_label)
         titles.addWidget(self.meta_label)
         header.addLayout(titles, 1)
 
         self.builtins_checkbox = QCheckBox("Show built-ins")
-        _style(self.builtins_checkbox, _CHECKBOX_STYLE)
+        style_with_tooltip(self.builtins_checkbox, _CHECKBOX_STYLE)
         self.builtins_checkbox.setToolTip(
             "Built-in extensions ship with fibsem and are always present; they "
             "are counted but hidden so installed ones stand out."
@@ -272,27 +242,10 @@ class PluginsDialog(QDialog):
         table.setColumnWidth(2, _group_column_width())
         return table
 
-    @staticmethod
-    def _chip(text: str, colour: str) -> QLabel:
-        """A pill label: coloured dot + text, on a tint of the same colour."""
-        rgb = QColor(colour)
-        tint = f"rgba({rgb.red()}, {rgb.green()}, {rgb.blue()}, 0.15)"
-        chip = QLabel(f'<span style="color:{colour};">&#9679;</span> {text}')
-        _style(
-            chip,
-            f"background-color: {tint}; color: {colour};"
-            f"padding: 2px 9px; border-radius: 10px; font-size: 11px;",
-        )
-        # A rich-text QLabel under-reports sizeHint against the stylesheet
-        # padding, so the last character clips. Measure and pin the width.
-        metrics = QFontMetrics(chip.font())
-        chip.setMinimumWidth(metrics.horizontalAdvance(f"* {text}") + 26)
-        return chip
-
     def _name_cell(self, extension: Extension) -> QWidget:
         """Two lines: what it registered as, and what it resolved to."""
         widget = QWidget()
-        _style(widget, "background: transparent;")
+        style_with_tooltip(widget, "background: transparent;")
         layout = QVBoxLayout(widget)
         layout.setContentsMargins(12, 8, 10, 8)
         layout.setSpacing(2)
@@ -301,14 +254,14 @@ class PluginsDialog(QDialog):
         # declared target takes the line instead. A listing that only shows what
         # resolved cannot answer "why isn't mine here?".
         inactive = extension.is_problem
-        name = _ElidedLabel(extension.name or extension.target)
-        _style(
+        name = ElidedLabel(extension.name or extension.target)
+        style_with_tooltip(
             name,
             f"{_MONOSPACE} font-size: 13px; background: transparent;"
             f"color: {_TEXT_MUTED if inactive else _TEXT_STRONG};",
         )
-        detail = _ElidedLabel(_detail_line(extension))
-        _style(
+        detail = ElidedLabel(_detail_line(extension))
+        style_with_tooltip(
             detail,
             f"font-size: 11px; background: transparent;"
             f"color: {_reason_colour(extension)};",
@@ -321,7 +274,7 @@ class PluginsDialog(QDialog):
     def _source_cell(self, extension: Extension) -> QWidget:
         """The source chip, plus a shadowed chip where the name was taken."""
         widget = QWidget()
-        _style(widget, "background: transparent;")
+        style_with_tooltip(widget, "background: transparent;")
         layout = QHBoxLayout(widget)
         layout.setContentsMargins(8, 6, 8, 6)
         layout.setSpacing(4)
@@ -333,9 +286,9 @@ class PluginsDialog(QDialog):
             # use, so it does not get the in-use colour. The state chip beside
             # it carries the emphasis instead.
             colour = _TEXT_MUTED
-        layout.addWidget(self._chip(label, colour))
+        layout.addWidget(chip(label, colour))
         if extension.shadowed:
-            layout.addWidget(self._chip(_UNAVAILABLE_LABEL, _WARN))
+            layout.addWidget(chip(_UNAVAILABLE_LABEL, _WARN))
         layout.addStretch()
         widget.setToolTip(extension.problem or f"Source: {label}")
         return widget

--- a/fibsem/ui/widgets/plugins_dialog.py
+++ b/fibsem/ui/widgets/plugins_dialog.py
@@ -1,0 +1,542 @@
+"""The Plugins dialog.
+
+Answers the question a user has after installing a plugin -- "did it work?" --
+without making them hunt for it in the Add Task combo and guess when it is
+missing. Deliberately not a place to run anything: that is the Scripts dialog.
+This one only ever reports.
+
+Everything shown comes from ``fibsem.plugins.report``, the same function behind
+``fibsem-cli plugins``, so a report a user pastes into a bug tracker says the
+same thing as the dialog support is reading over their shoulder.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtGui import QColor, QFontMetrics
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QApplication,
+    QCheckBox,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QSizePolicy,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.plugins.report import (
+    Extension,
+    ExtensionGroup,
+    ExtensionSource,
+    collect_extensions,
+    environment_line,
+    group_counts_phrase,
+    render_report,
+    summarise,
+)
+from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.stylesheets import GRAY_ICON_COLOR
+from fibsem.ui.utils import open_path_in_file_explorer
+from fibsem.ui.widgets.custom_widgets import IconToolButton
+
+# Palette (matching fibsem.ui.stylesheets napari theme)
+_BG = "#262930"
+_PANEL = "#1e2027"
+_ROW_ALT = "#2b2f38"
+_BORDER = "#3d4251"
+_TEXT = "#d6d6d6"
+_TEXT_STRONG = "#f0f1f2"
+_TEXT_MUTED = "#868e93"
+_ACCENT = "#50a6ff"
+_OK = "#4caf50"
+_WARN = "#e0a030"
+_ERROR = "#d04040"
+
+_COLUMNS = ["Extension", "Source", "Entry point group"]
+
+_MONOSPACE = "font-family: Menlo, Consolas, monospace;"
+
+# Colour carries state, never provenance. A plugin and a script are both
+# installed and both in use -- they differ only in where they came from, which
+# the chip's own label already says, so separate colours would imply a
+# distinction that does not exist.
+#
+#   blue   in use
+#   amber  installed, but not the copy being used -- look at this
+#   grey   unremarkable: a built-in, or something in use that nobody came for
+#   red    broken
+#
+# Amber rather than grey for an unavailable plugin, even though nothing is
+# technically wrong: a user installed it expecting it to work, and grey is what
+# built-ins wear. Painting one of the two rows this dialog exists to surface in
+# the colour of background noise buries it.
+_SOURCE_STYLE: Dict[ExtensionSource, Tuple[str, str]] = {
+    ExtensionSource.PLUGIN: ("Plugin", _ACCENT),
+    ExtensionSource.SCRIPT: ("Script", _ACCENT),
+    ExtensionSource.FAILED: ("Failed", _ERROR),
+    ExtensionSource.REGISTERED: ("Registered", _TEXT_MUTED),
+    ExtensionSource.BUILTIN: ("Built-in", _TEXT_MUTED),
+}
+
+# What a shadowed row is, in terms of the consequence rather than the mechanism:
+# "shadowed" describes fibsem's merge order, which is not the user's problem.
+_UNAVAILABLE_LABEL = "Unavailable"
+
+_TABLE_STYLE = f"""
+QTableWidget {{
+    background-color: {_BG};
+    alternate-background-color: {_ROW_ALT};
+    border: 1px solid {_BORDER};
+    border-radius: 6px;
+    color: {_TEXT};
+    gridline-color: transparent;
+    outline: none;
+}}
+QHeaderView::section {{
+    background-color: {_PANEL};
+    color: {_TEXT_MUTED};
+    border: none;
+    padding: 6px 8px;
+    font-size: 11px;
+}}
+QTableWidget::item {{ padding: 6px 8px; border-bottom: 1px solid #31353f; }}
+QTableWidget::item:selected {{ background-color: #2d3947; color: {_TEXT_STRONG}; }}
+"""
+
+_CHECKBOX_STYLE = f"font-size: 12px; color: {_TEXT};"
+
+# Restates the application stylesheet's own QToolTip rule. A selector-less
+# stylesheet set on a widget also styles the tooltip shown over that widget, and
+# it sits nearer than the application sheet, so it wins: `background:
+# transparent` on a table cell leaves its tooltip as floating text with no panel
+# behind it, and a muted `color` makes the tooltip text unreadable. Anything
+# applied through _style() carries this so that cannot happen.
+_TOOLTIP_STYLE = f"""
+QToolTip {{
+    background-color: {_PANEL};
+    color: {_TEXT};
+    border: 1px solid {_BORDER};
+    padding: 4px 8px;
+    border-radius: 3px;
+}}
+"""
+
+
+def _style(widget: QWidget, css: str) -> None:
+    """Apply a selector-less stylesheet without swallowing the widget's tooltip.
+
+    Use this rather than setStyleSheet for any rule written without a selector.
+    A rule with one (``QDialog {...}``, ``QTableWidget {...}``) cannot match
+    QToolTip and needs no such care.
+    """
+    widget.setStyleSheet(css + _TOOLTIP_STYLE)
+
+_COPY_ICON = "mdi:content-copy"
+
+
+class _ElidedLabel(QLabel):
+    """A QLabel that elides rather than clipping mid-glyph.
+
+    The Extension column stretches, so the width is not known when the row is
+    built and any one-off elide would be wrong at the next size. The size policy
+    is Ignored so a 60-character dotted class path cannot drive the column
+    wider, which would defeat the point.
+    """
+
+    def __init__(self, text: str, parent: Optional[QWidget] = None) -> None:
+        super().__init__(text, parent)
+        self._full_text = text
+        self.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
+
+    def paintEvent(self, event) -> None:  # noqa: N802 - Qt naming
+        metrics = QFontMetrics(self.font())
+        elided = metrics.elidedText(self._full_text, Qt.ElideRight, self.width())
+        if elided != self.text():
+            self.setText(elided)
+        super().paintEvent(event)
+
+
+class PluginsDialog(QDialog):
+    """Every registered pattern, strategy and task, and where each came from."""
+
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        groups: Optional[Tuple[ExtensionGroup, ...]] = None,
+    ) -> None:
+        super().__init__(parent)
+
+        # Snapshotted once. The registries load their entry points on first use
+        # and cache the result for the process, so this dialog can only ever
+        # show the state as of startup -- a Refresh button would either lie or,
+        # if it really re-loaded, leave the registries disagreeing with the
+        # module-level snapshots taken at import time.
+        #
+        # `groups` is for tests, which need rows this environment does not have
+        # installed (a failure, a shadowed plugin, a script).
+        self.groups: Tuple[ExtensionGroup, ...] = (
+            collect_extensions() if groups is None else tuple(groups)
+        )
+        self.rows: List[Extension] = []
+
+        self.setWindowTitle("Plugins")
+        self.setStyleSheet(f"QDialog {{ background-color: {_BG}; }}")
+        self.resize(880, 620)
+        self.setMinimumWidth(760)
+        self._build()
+        self.refresh()
+
+    # --- construction ---
+
+    def _build(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 12, 14, 12)
+        layout.setSpacing(10)
+
+        header = QHBoxLayout()
+        titles = QVBoxLayout()
+        titles.setSpacing(2)
+        self.title_label = QLabel("Registered extensions")
+        _style(
+            self.title_label,
+            f"font-size: 15px; font-weight: 500; color: {_TEXT_STRONG};",
+        )
+        # counts are meta, not the heading -- the heading says what this dialog
+        # is, the line under it says what is currently in it.
+        self.meta_label = QLabel()
+        _style(self.meta_label, f"font-size: 12px; color: {_TEXT_MUTED};")
+        titles.addWidget(self.title_label)
+        titles.addWidget(self.meta_label)
+        header.addLayout(titles, 1)
+
+        self.builtins_checkbox = QCheckBox("Show built-ins")
+        _style(self.builtins_checkbox, _CHECKBOX_STYLE)
+        self.builtins_checkbox.setToolTip(
+            "Built-in extensions ship with fibsem and are always present; they "
+            "are counted but hidden so installed ones stand out."
+        )
+        self.builtins_checkbox.toggled.connect(self.refresh)
+        header.addWidget(self.builtins_checkbox)
+
+        # Icons, not labelled buttons: neither is the reason anyone opens this
+        # dialog -- the table is -- and a row of word-buttons competes with the
+        # heading for a glance that should land on the counts.
+        self.open_folder_button = IconToolButton(
+            icon="mdi:folder-open-outline",
+            tooltip="Reveal the selected script in the file manager",
+            size=28,
+        )
+        self.open_folder_button.clicked.connect(self.open_selected_folder)
+        header.addWidget(self.open_folder_button)
+
+        self.copy_button = IconToolButton(
+            icon=_COPY_ICON,
+            tooltip="Copy this listing as text, exactly as `fibsem-cli plugins` prints it",
+            size=28,
+        )
+        self.copy_button.clicked.connect(self.copy_report)
+        header.addWidget(self.copy_button)
+        layout.addLayout(header)
+
+        # No detail strip and no footer. Every row now explains itself in place
+        # -- including why an inactive one is inactive -- so a panel repeating
+        # the selection was spending a whole widget on it. There is nothing to
+        # confirm or cancel either, which leaves Esc and the title bar to
+        # dismiss it, the same as any other read-only panel.
+        self.table = self._build_table()
+        layout.addWidget(self.table)
+
+    def _build_table(self) -> QTableWidget:
+        table = QTableWidget()
+        table.setStyleSheet(_TABLE_STYLE)
+        table.setColumnCount(len(_COLUMNS))
+        table.setHorizontalHeaderLabels(_COLUMNS)
+        table.verticalHeader().setVisible(False)
+        # rows carry a stacked name + class path, so they need room to breathe
+        table.verticalHeader().setDefaultSectionSize(56)
+        table.setShowGrid(False)
+        table.setAlternatingRowColors(True)
+        table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        table.setSelectionMode(QAbstractItemView.SingleSelection)
+        table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        table.itemSelectionChanged.connect(self._on_selection_changed)
+
+        header = table.horizontalHeader()
+        header.setDefaultAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        header.setStretchLastSection(False)
+        header.setSectionResizeMode(0, header.Stretch)
+        table.setColumnWidth(2, _group_column_width())
+        return table
+
+    @staticmethod
+    def _chip(text: str, colour: str) -> QLabel:
+        """A pill label: coloured dot + text, on a tint of the same colour."""
+        rgb = QColor(colour)
+        tint = f"rgba({rgb.red()}, {rgb.green()}, {rgb.blue()}, 0.15)"
+        chip = QLabel(f'<span style="color:{colour};">&#9679;</span> {text}')
+        _style(
+            chip,
+            f"background-color: {tint}; color: {colour};"
+            f"padding: 2px 9px; border-radius: 10px; font-size: 11px;",
+        )
+        # A rich-text QLabel under-reports sizeHint against the stylesheet
+        # padding, so the last character clips. Measure and pin the width.
+        metrics = QFontMetrics(chip.font())
+        chip.setMinimumWidth(metrics.horizontalAdvance(f"* {text}") + 26)
+        return chip
+
+    def _name_cell(self, extension: Extension) -> QWidget:
+        """Two lines: what it registered as, and what it resolved to."""
+        widget = QWidget()
+        _style(widget, "background: transparent;")
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(12, 8, 10, 8)
+        layout.setSpacing(2)
+
+        # A failed entry point registered nothing, so it has no name -- the
+        # declared target takes the line instead. A listing that only shows what
+        # resolved cannot answer "why isn't mine here?".
+        inactive = extension.is_problem
+        name = _ElidedLabel(extension.name or extension.target)
+        _style(
+            name,
+            f"{_MONOSPACE} font-size: 13px; background: transparent;"
+            f"color: {_TEXT_MUTED if inactive else _TEXT_STRONG};",
+        )
+        detail = _ElidedLabel(_detail_line(extension))
+        _style(
+            detail,
+            f"font-size: 11px; background: transparent;"
+            f"color: {_reason_colour(extension)};",
+        )
+        layout.addWidget(name)
+        layout.addWidget(detail)
+        widget.setToolTip(_tooltip(extension))
+        return widget
+
+    def _source_cell(self, extension: Extension) -> QWidget:
+        """The source chip, plus a shadowed chip where the name was taken."""
+        widget = QWidget()
+        _style(widget, "background: transparent;")
+        layout = QHBoxLayout(widget)
+        layout.setContentsMargins(8, 6, 8, 6)
+        layout.setSpacing(4)
+
+        label, colour = _SOURCE_STYLE[extension.source]
+        if extension.shadowed:
+            # Where it came from is still worth saying -- the fix for a shadowed
+            # plugin is not the fix for a shadowed script -- but it is not in
+            # use, so it does not get the in-use colour. The state chip beside
+            # it carries the emphasis instead.
+            colour = _TEXT_MUTED
+        layout.addWidget(self._chip(label, colour))
+        if extension.shadowed:
+            layout.addWidget(self._chip(_UNAVAILABLE_LABEL, _WARN))
+        layout.addStretch()
+        widget.setToolTip(extension.problem or f"Source: {label}")
+        return widget
+
+    # --- data ---
+
+    def refresh(self) -> None:
+        """Rebuild the table for the current Show built-ins state."""
+        show_builtins = self.builtins_checkbox.isChecked()
+        previous = self.selected_extension()
+
+        self.rows = [e for g in self.groups for e in g.visible(show_builtins)]
+        self._update_meta(show_builtins)
+
+        # Only a script-loaded extension has a file to reveal, and nothing
+        # produces those until FIB-339 lands -- so in every environment today
+        # this button would sit permanently greyed out, which reads as broken
+        # rather than as inapplicable. Hidden until there is something to open.
+        self.open_folder_button.setVisible(any(e.path is not None for e in self.rows))
+
+        self.table.clearContents()
+        self.table.setRowCount(0)  # destroys the previous rows' cell widgets
+        self.table.setRowCount(len(self.rows))
+        for row, extension in enumerate(self.rows):
+            # cell widgets, not items: a QTableWidgetItem cannot carry a pill
+            # background, and the name cell needs two lines.
+            self.table.setCellWidget(row, 0, self._name_cell(extension))
+            self.table.setCellWidget(row, 1, self._source_cell(extension))
+
+            group_item = QTableWidgetItem(extension.group)
+            group_item.setForeground(QColor(_TEXT_MUTED))
+            group_item.setFont(_group_font())
+            # The literal group string, not the friendly label: a group mistyped
+            # in a plugin's pyproject registers nothing and logs nothing, so
+            # comparing the real string against their own file is the only way a
+            # user can find that mistake.
+            self.table.setItem(row, 2, group_item)
+            # an empty item under each widget keeps row selection working
+            for col in (0, 1):
+                self.table.setItem(row, col, QTableWidgetItem())
+
+        self._fit_source_column()
+
+        if self.rows:
+            keys = [_key(e) for e in self.rows]
+            row = keys.index(_key(previous)) if previous and _key(previous) in keys else 0
+            self.table.selectRow(row)
+        self._on_selection_changed()
+
+        # Toggling built-ins changes what a copy would produce, so the button
+        # has to come back out of its confirmation state.
+        self._reset_copy_button()
+
+    def _fit_source_column(self) -> None:
+        """Widen the source column to the widest row of chips.
+
+        ResizeToContents is no use here: it measures the item's size hint, and
+        these cells hold widgets over empty items.
+        """
+        widths = [
+            self.table.cellWidget(row, 1).sizeHint().width()
+            for row in range(self.table.rowCount())
+            if self.table.cellWidget(row, 1) is not None
+        ]
+        self.table.setColumnWidth(1, max(widths, default=120) + 12)
+
+    def _update_meta(self, show_builtins: bool) -> None:
+        summary, hidden = summarise(self.groups)
+        if hidden and not show_builtins:
+            summary += f" · {hidden} built-in hidden"
+        self.meta_label.setText(summary)
+        self.meta_label.setToolTip(
+            "\n".join(
+                [f"{g.group}: {group_counts_phrase(g)}" for g in self.groups]
+                # Which install this is, for a machine with several environments.
+                # Went with the footer it used to hang off; it is the first thing
+                # anyone asks about a pasted report, so it stays reachable.
+                + ["", environment_line()]
+            )
+        )
+
+    # --- selection ---
+
+    def selected_extension(self) -> Optional[Extension]:
+        row = self.table.currentRow() if hasattr(self, "table") else -1
+        if 0 <= row < len(self.rows):
+            return self.rows[row]
+        return None
+
+    def _on_selection_changed(self) -> None:
+        extension = self.selected_extension()
+        self.open_folder_button.setEnabled(
+            extension is not None and extension.path is not None
+        )
+
+    # --- actions ---
+
+    def open_selected_folder(self) -> None:
+        import os
+
+        extension = self.selected_extension()
+        if extension is None or extension.path is None:
+            return
+        # The stored path is home-relative for the report; expand it back before
+        # handing it to the file manager.
+        open_path_in_file_explorer(os.path.dirname(os.path.expanduser(extension.path)))
+
+    def copy_report(self) -> None:
+        clipboard = QApplication.clipboard()
+        if clipboard is None:  # pragma: no cover - no clipboard on some displays
+            return
+        clipboard.setText(self.report_text())
+        # An icon button gives no other sign it did anything, and a clipboard is
+        # invisible until pasted somewhere else.
+        self.copy_button.setIcon(fibsem_icon("mdi:check", color=_OK))
+        self.copy_button.setToolTip("Copied")
+        # Confirmation, not a one-shot: the report is often copied twice, once
+        # per Show built-ins state.
+        QTimer.singleShot(1500, self._reset_copy_button)
+
+    def _reset_copy_button(self) -> None:
+        self.copy_button.setIcon(fibsem_icon(_COPY_ICON, color=GRAY_ICON_COLOR))
+        self.copy_button.setToolTip(
+            "Copy this listing as text, exactly as `fibsem-cli plugins` prints it"
+        )
+
+    def report_text(self) -> str:
+        """The listing as text -- byte for byte what ``fibsem-cli plugins`` prints."""
+        return render_report(
+            self.groups, show_builtins=self.builtins_checkbox.isChecked()
+        )
+
+
+def _key(extension: Extension) -> Tuple[str, str, str]:
+    """Identity for restoring the selection across a rebuild."""
+    return (extension.group, extension.name or "", extension.target)
+
+
+def _detail_line(extension: Extension) -> str:
+    """The line under the name: what it resolved to, or why it is not in use.
+
+    A row with a problem spends this line on the reason. For anything inactive
+    -- a failure, or a plugin whose name a built-in took -- that is the only
+    thing the reader wants, and a class path they cannot use is worth less than
+    the sentence explaining why. The path, the package and the group all stay in
+    the tooltip.
+    """
+    if extension.problem:
+        return _sentence(extension.problem)
+    parts = [extension.target]
+    if extension.origin:
+        parts.append(extension.origin)
+    return "   ·   ".join(parts)
+
+
+def _reason_colour(extension: Extension) -> str:
+    """The reason wears the same colour as the chip that raised it.
+
+    Red for broken, amber for installed-but-unused, muted for a row with nothing
+    wrong (where this line is a class path, not a reason).
+    """
+    if extension.source is ExtensionSource.FAILED:
+        return _ERROR
+    if extension.problem:
+        return _WARN
+    return _TEXT_MUTED
+
+
+def _group_column_width() -> int:
+    """Wide enough for the longest group string, and no wider.
+
+    There are exactly three of them and they never change at runtime, so this is
+    a measurement rather than a guess -- a fixed width elides `fibsem.strategies`
+    on some platforms and wastes a column on others.
+    """
+    metrics = QFontMetrics(_group_font())
+    longest = max(
+        metrics.horizontalAdvance(g)
+        for g in ("fibsem.patterns", "fibsem.strategies", "fibsem.tasks")
+    )
+    return longest + 24
+
+
+def _group_font():
+    from PyQt5.QtGui import QFont
+
+    font = QFont("Menlo")
+    font.setStyleHint(QFont.Monospace)
+    font.setPointSize(11)
+    return font
+
+
+def _tooltip(extension: Extension) -> str:
+    lines = [extension.name or extension.target, extension.target]
+    if extension.origin:
+        lines.append(f"Declared by {extension.origin}")
+    lines.append(extension.group)
+    if extension.problem:
+        lines.append(_sentence(extension.problem))
+    return "\n".join(dict.fromkeys(lines))
+
+
+def _sentence(text: str) -> str:
+    return text[:1].upper() + text[1:] if text else text

--- a/tests/fixtures/plugin/fibsem_test_plugin/__init__.py
+++ b/tests/fixtures/plugin/fibsem_test_plugin/__init__.py
@@ -18,3 +18,7 @@ TASK_TYPE = "FIXTURE_TASK"
 # Deliberately collides with a built-in pattern, so the documented precedence
 # (builtins > registered > plugins) has something to actually assert against.
 CLASHING_PATTERN_NAME = "Rectangle"
+
+# Entry points that fail on purpose, one per failure shape: a class that is not
+# a task, and a module that does not exist. See the pyproject.
+FAILING_ENTRY_POINTS = ("wrong_base_class", "missing_module")

--- a/tests/fixtures/plugin/fibsem_test_plugin/tasks.py
+++ b/tests/fixtures/plugin/fibsem_test_plugin/tasks.py
@@ -23,3 +23,14 @@ class FixtureTask(AutoLamellaTask):
 
     def _run(self) -> None:
         raise NotImplementedError("fixture task is never executed")
+
+
+class NotATask:
+    """Declared under fibsem.tasks on purpose, without being a task.
+
+    The wrong-base-class failure is distinct from an import failure: this one
+    loads perfectly and only fails the issubclass check afterwards, so the
+    loader has to report it as a failure rather than let it through. Nothing
+    registers it -- that is the point.
+    """
+

--- a/tests/fixtures/plugin/pyproject.toml
+++ b/tests/fixtures/plugin/pyproject.toml
@@ -25,6 +25,11 @@ fixture_strategy = "fibsem_test_plugin.strategies:FixtureMillingStrategy"
 
 [project.entry-points."fibsem.tasks"]
 fixture_task = "fibsem_test_plugin.tasks:FixtureTask"
+# Two failure shapes, declared on purpose. Neither registers anything, and
+# neither used to leave a trace anywhere the user could reach -- the plugin
+# listing exists to report exactly these, so they have to be exercised.
+wrong_base_class = "fibsem_test_plugin.tasks:NotATask"
+missing_module = "fibsem_test_plugin.nonexistent:Whatever"
 
 [tool.setuptools]
 packages = ["fibsem_test_plugin"]

--- a/tests/test_cli_plugins.py
+++ b/tests/test_cli_plugins.py
@@ -22,7 +22,12 @@ def test_plugins_does_not_require_a_microscope():
 
 
 def test_plugins_takes_no_connection_arguments():
-    """Connection flags on the subcommand would imply it connects. It must not."""
+    """Connection flags on the subcommand would imply it connects. It must not.
+
+    ``--debug`` is the exception, declared on the subparser directly: it selects
+    how much this command prints, not what it connects to. See
+    test_debug_is_accepted_on_either_side_of_the_subcommand.
+    """
     with pytest.raises(SystemExit):
         _parse("plugins", "--manufacturer", "Thermo")
 
@@ -81,6 +86,25 @@ def test_broken_plugins_do_not_bury_the_report(monkeypatch, capsys):
     assert logging.getLogger().manager.disable == 0
 
 
+@pytest.mark.parametrize("argv", [("plugins", "--debug"), ("--debug", "plugins")])
+def test_debug_is_accepted_on_either_side_of_the_subcommand(argv):
+    """The position a user types must not be the broken one.
+
+    ``--debug`` reaches the root parser through the connection parent, which this
+    subcommand deliberately does not inherit -- so until it declared its own,
+    ``plugins --debug`` was an unrecognized argument while every other subcommand
+    accepted it there. It is also the flag ``cmd_plugins`` advertises for getting
+    tracebacks back, i.e. the one flag a user diagnosing a plugin will reach for.
+
+    Both positions are pinned because the obvious fix only half works: argparse
+    copies every attribute of the subparser's namespace over the root's, so
+    declaring ``--debug`` with ``default=False`` would fix ``plugins --debug`` and
+    silently reset ``--debug plugins`` to False. ``default=SUPPRESS`` leaves the
+    attribute absent unless the flag is passed, so whatever root parsed survives.
+    """
+    assert _parse(*argv).debug is True
+
+
 def test_debug_keeps_the_tracebacks(monkeypatch):
     """--debug is the escape hatch when the one-line reason is not enough."""
     import logging
@@ -98,7 +122,7 @@ def test_debug_keeps_the_tracebacks(monkeypatch):
         )[1],
     )
 
-    args = _parse("--debug", "plugins")
+    args = _parse("plugins", "--debug")
     assert args.debug is True
     cli.cmd_plugins(args)
     assert observed["disabled"] == 0

--- a/tests/test_cli_plugins.py
+++ b/tests/test_cli_plugins.py
@@ -1,0 +1,110 @@
+"""``fibsem-cli plugins``.
+
+The failure mode this command exists for is "my plugin does not show up", so it
+has to answer without a microscope: diagnosing a plugin is usually done away
+from the instrument, and every other subcommand connects before it dispatches.
+"""
+
+import pytest
+
+from fibsem import cli
+
+
+def _parse(*argv):
+    return cli._build_parser().parse_args(argv)
+
+
+def test_plugins_does_not_require_a_microscope():
+    """The whole reason it is dispatched before setup_session()."""
+    assert _parse("plugins").needs_microscope is False
+    # ...while everything else still does.
+    assert _parse("position").needs_microscope is True
+
+
+def test_plugins_takes_no_connection_arguments():
+    """Connection flags on the subcommand would imply it connects. It must not."""
+    with pytest.raises(SystemExit):
+        _parse("plugins", "--manufacturer", "Thermo")
+
+
+def test_plugins_prints_the_report(capsys):
+    exit_code = cli.cmd_plugins(_parse("plugins"))
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    for group in ("fibsem.patterns", "fibsem.strategies", "fibsem.tasks"):
+        assert group in out
+    assert out.rstrip().endswith(cli_environment_line())
+
+
+def test_all_shows_built_ins_that_are_otherwise_only_counted(capsys):
+    cli.cmd_plugins(_parse("plugins"))
+    default = capsys.readouterr().out
+    cli.cmd_plugins(_parse("plugins", "--all"))
+    everything = capsys.readouterr().out
+
+    assert "fibsem.milling.patterning.patterns2.RectanglePattern" not in default
+    assert "fibsem.milling.patterning.patterns2.RectanglePattern" in everything
+    assert "built-in hidden (use --all)." in default
+    assert "built-in hidden" not in everything
+
+
+def test_broken_plugins_do_not_bury_the_report(monkeypatch, capsys):
+    """Loading logs a traceback per broken plugin; the report reports them again.
+
+    Dumping both would push the readable listing off the top of the terminal,
+    which defeats the point of a command whose output is meant to be pasted.
+
+    Asserted at the moment of loading rather than by checking stderr afterwards:
+    the registries load once per process and cache the result, so by the time
+    this test runs there is nothing left to log and an "is stderr clean?" check
+    would pass no matter what the command did.
+    """
+    import logging
+
+    from fibsem.plugins import report
+
+    observed = {}
+    real = report.collect_extensions
+
+    def spy():
+        observed["disabled_while_loading"] = logging.getLogger().manager.disable
+        return real()
+
+    monkeypatch.setattr(report, "collect_extensions", spy)
+
+    cli.cmd_plugins(_parse("plugins"))
+    capsys.readouterr()
+
+    assert observed["disabled_while_loading"] >= logging.CRITICAL
+    # ...and restored, so this does not silence the rest of the process.
+    assert logging.getLogger().manager.disable == 0
+
+
+def test_debug_keeps_the_tracebacks(monkeypatch):
+    """--debug is the escape hatch when the one-line reason is not enough."""
+    import logging
+
+    from fibsem.plugins import report
+
+    observed = {}
+    real = report.collect_extensions
+    monkeypatch.setattr(
+        report,
+        "collect_extensions",
+        lambda: (
+            observed.setdefault("disabled", logging.getLogger().manager.disable),
+            real(),
+        )[1],
+    )
+
+    args = _parse("--debug", "plugins")
+    assert args.debug is True
+    cli.cmd_plugins(args)
+    assert observed["disabled"] == 0
+
+
+def cli_environment_line() -> str:
+    from fibsem.plugins.report import environment_line
+
+    return environment_line()

--- a/tests/test_plugin_entry_points.py
+++ b/tests/test_plugin_entry_points.py
@@ -34,6 +34,7 @@ PATTERN_NAME = "Fixture Pattern"
 STRATEGY_NAME = "Fixture Strategy"
 TASK_TYPE = "FIXTURE_TASK"
 CLASHING_PATTERN_NAME = "Rectangle"  # a built-in name the fixture claims on purpose
+FAILING_ENTRY_POINTS = ("wrong_base_class", "missing_module")  # declared to fail
 
 def _fixture_installed() -> bool:
     """Detect the fixture without importing it.
@@ -204,3 +205,118 @@ def test_shadowed_plugin_is_not_silently_reported_as_the_builtin():
     from fibsem.milling.patterning.patterns2 import RectanglePattern
 
     assert isinstance(get_pattern(CLASHING_PATTERN_NAME), RectanglePattern)
+
+
+# ---------------------------------------------------------------------------
+# Introspection: what the registries cannot tell you
+#
+# get_patterns() and friends return {name: class}, which by construction cannot
+# express a plugin that failed to load or one a built-in shadowed. Those are the
+# two questions the plugin listing exists to answer, so they are asserted
+# against the same installed fixture rather than against synthetic records --
+# a mock cannot catch a change to the real entry point loading path.
+# ---------------------------------------------------------------------------
+
+
+def test_load_records_report_the_failures_the_registry_drops():
+    """Both failure shapes are reported, with the declared target intact."""
+    from fibsem.applications.autolamella.workflows.tasks import (
+        get_task_plugin_records,
+        get_tasks,
+    )
+
+    failures = {r.entry_point: r for r in get_task_plugin_records() if not r.loaded}
+    assert set(failures) == set(FAILING_ENTRY_POINTS), sorted(failures)
+
+    wrong_base = failures["wrong_base_class"]
+    assert "not a subclass of AutoLamellaTask" in wrong_base.error
+    # The declared target survives even though nothing resolved: a listing that
+    # only shows what worked cannot answer "why isn't mine here?".
+    assert wrong_base.value == "fibsem_test_plugin.tasks:NotATask"
+    assert wrong_base.cls is None and wrong_base.name is None
+
+    assert "ModuleNotFoundError" in failures["missing_module"].error
+
+    # ...and none of them leaked into the registry.
+    assert all(cls.__name__ != "NotATask" for cls in get_tasks().values())
+
+
+def test_load_records_carry_the_providing_distribution():
+    """Which install a plugin came from, for a machine with several envs."""
+    from fibsem.applications.autolamella.workflows.tasks import get_task_plugin_records
+
+    record = next(r for r in get_task_plugin_records() if r.entry_point == "fixture_task")
+    assert record.distribution == "fibsem-test-plugin"
+    assert record.version == "0.0.0"
+
+
+def test_shadowed_plugin_is_reported_rather_than_vanishing():
+    """The clashing pattern loaded, lost the name, and is still accounted for.
+
+    ``get_patterns()`` merges built-ins last, so the shadowed class is simply
+    absent from the result -- nothing downstream can tell it was ever installed.
+    """
+    from fibsem.plugins.report import ExtensionSource, collect_extensions
+
+    patterns = next(g for g in collect_extensions() if g.group == "fibsem.patterns")
+    shadowed = [e for e in patterns.extensions if e.shadowed]
+
+    assert [e.name for e in shadowed] == [CLASHING_PATTERN_NAME]
+    assert shadowed[0].source is ExtensionSource.PLUGIN
+    assert "built-in" in shadowed[0].problem
+    assert shadowed[0].target.endswith("ClashingPattern")
+
+    # The winning entry under that name is the built-in, listed separately.
+    winners = [
+        e
+        for e in patterns.extensions
+        if e.name == CLASHING_PATTERN_NAME and not e.shadowed
+    ]
+    assert [e.source for e in winners] == [ExtensionSource.BUILTIN]
+
+
+def test_failed_entry_point_becomes_a_row_that_spells_out_the_consequence():
+    """A bare "ModuleNotFoundError" does not tell a user what state they are in.
+
+    The reason has to say that nothing registered, or a reader cannot tell
+    whether their plugin is half-loaded or simply absent.
+    """
+    from fibsem.plugins.report import ExtensionSource, collect_extensions
+
+    tasks = next(g for g in collect_extensions() if g.group == "fibsem.tasks")
+    failed = [e for e in tasks.extensions if e.source is ExtensionSource.FAILED]
+
+    assert len(failed) == len(FAILING_ENTRY_POINTS), [e.target for e in failed]
+    for extension in failed:
+        assert extension.name is None
+        assert extension.problem.endswith("- nothing was registered")
+        # The declared target, not a resolved one -- nothing resolved.
+        assert ":" in extension.target
+        assert extension.distribution == "fibsem-test-plugin"
+
+
+def test_report_lists_the_fixture_across_all_three_groups():
+    from fibsem.plugins.report import ExtensionSource, collect_extensions, render_report
+
+    groups = collect_extensions()
+    assert [g.group for g in groups] == [
+        "fibsem.patterns",
+        "fibsem.strategies",
+        "fibsem.tasks",
+    ]
+
+    text = render_report(groups)
+    for name in (PATTERN_NAME, STRATEGY_NAME, TASK_TYPE):
+        assert name in text
+
+    # Failures are in the text too, which is the difference between this and
+    # simply listing the registries.
+    assert "fibsem_test_plugin.tasks:NotATask" in text
+    assert text.count("failed") >= 1
+
+    # Built-ins are counted but not listed unless asked for.
+    assert "fibsem.milling.patterning.patterns2.RectanglePattern" not in text
+    assert "fibsem.milling.patterning.patterns2.RectanglePattern" in render_report(
+        groups, show_builtins=True
+    )
+    assert any(e.source is ExtensionSource.BUILTIN for e in groups[0].extensions)

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,191 @@
+"""The shared entry point loader.
+
+Covers the paths an installed fixture cannot reach without a package built to
+order for each one: an entry point pointing at something that is not a class,
+a class whose name cannot be read, and the load-once caching the registries
+depend on.
+
+The counterpart against a real installed plugin is in
+tests/test_plugin_entry_points.py -- these fakes prove the branching, that one
+proves it is wired to real entry point metadata.
+"""
+
+import pytest
+
+from fibsem.plugins import loader
+from fibsem.plugins.loader import load_entry_point_group, plugin_classes
+
+
+class Base:
+    name = "base"
+
+
+class Good(Base):
+    name = "Good"
+
+
+class Unrelated:
+    name = "Unrelated"
+
+
+class NoConfig(Base):
+    """Shaped like a task class that forgot its ``config_cls``.
+
+    The real name extraction for tasks is ``cls.config_cls.task_type``, two
+    attribute hops that a plugin author can get wrong while still subclassing
+    the right base -- so reading the name is its own failure mode.
+    """
+
+
+class FakeEntryPoint:
+    """Stands in for an importlib EntryPoint.
+
+    Deliberately duck-typed rather than a real one: the loader must not depend
+    on the concrete class, since importlib_metadata's finder makes even a stdlib
+    ``entry_points()`` call hand back backport objects.
+    """
+
+    def __init__(self, name, value, target, dist="lab-thing", version="1.2.3"):
+        self.name = name
+        self.value = value
+        self._target = target
+        self.dist = type("Dist", (), {"name": dist, "version": version})()
+
+    def load(self):
+        if isinstance(self._target, Exception):
+            raise self._target
+        return self._target
+
+
+@pytest.fixture
+def fake_group(monkeypatch):
+    """Install a set of entry points under a group, with a clean cache."""
+
+    def install(*entry_points, group="test.group", name_of=lambda cls: cls.name):
+        loader.clear_cache()
+        monkeypatch.setattr(loader, "_entry_points", lambda g: iter(entry_points))
+        return load_entry_point_group(
+            group=group, base_cls=Base, name_of=name_of, kind="thing"
+        )
+
+    yield install
+    loader.clear_cache()
+
+
+def test_a_loaded_plugin_records_its_class_name_and_provenance(fake_group):
+    (record,) = fake_group(FakeEntryPoint("good", "pkg.mod:Good", Good))
+
+    assert record.loaded
+    assert record.cls is Good
+    assert record.name == "Good"
+    assert (record.distribution, record.version) == ("lab-thing", "1.2.3")
+    assert record.error is None
+    assert plugin_classes((record,)) == {"Good": Good}
+
+
+def test_an_entry_point_that_is_not_a_class_names_the_real_problem(fake_group):
+    """issubclass() raises rather than returning False when handed a non-class.
+
+    Left to the generic handler that surfaces as "issubclass() arg 1 must be a
+    class", which describes fibsem's internals rather than the user's mistake.
+    """
+    (record,) = fake_group(FakeEntryPoint("fn", "pkg.mod:helper", lambda: None))
+
+    assert not record.loaded
+    assert "is not a class" in record.error
+    assert record.cls is None
+
+
+def test_a_class_with_the_wrong_base_is_rejected_by_name(fake_group):
+    (record,) = fake_group(FakeEntryPoint("nope", "pkg.mod:Unrelated", Unrelated))
+
+    assert record.error == "not a subclass of Base"
+    assert record.cls is None
+    # It loaded fine; only the type check rejected it. The declared target has
+    # to survive so the listing can show what was asked for.
+    assert record.value == "pkg.mod:Unrelated"
+
+
+def test_an_import_failure_keeps_the_exception_type(fake_group):
+    boom = ModuleNotFoundError("No module named 'pkg.nope'")
+    (record,) = fake_group(FakeEntryPoint("boom", "pkg.nope:Thing", boom))
+
+    assert record.error == "ModuleNotFoundError: No module named 'pkg.nope'"
+    assert record.name is None
+
+
+def test_a_class_whose_name_cannot_be_read_is_a_failure_not_a_crash(fake_group):
+    """A third-party package must not be able to stop fibsem from starting."""
+    (record,) = fake_group(
+        FakeEntryPoint("odd", "pkg.mod:NoConfig", NoConfig),
+        name_of=lambda cls: cls.config_cls.task_type,
+    )
+
+    assert not record.loaded
+    assert "could not read its name" in record.error
+    assert "config_cls" in record.error
+
+
+def test_one_broken_plugin_does_not_take_out_the_others(fake_group):
+    records = fake_group(
+        FakeEntryPoint("boom", "pkg.nope:Thing", ImportError("nope")),
+        FakeEntryPoint("good", "pkg.mod:Good", Good),
+    )
+
+    assert [r.loaded for r in records] == [False, True]
+    assert plugin_classes(records) == {"Good": Good}
+
+
+def test_the_last_entry_point_wins_a_name_clash_and_the_loser_is_kept(fake_group):
+    """plugin_classes() must match the merge the registries have always done.
+
+    The displaced record stays in the list, which is the only reason the listing
+    can report a collision that the mapping cannot express.
+    """
+
+    class AlsoGood(Base):
+        name = "Good"
+
+    records = fake_group(
+        FakeEntryPoint("a", "pkg.mod:Good", Good),
+        FakeEntryPoint("b", "pkg.mod:AlsoGood", AlsoGood),
+    )
+
+    assert plugin_classes(records) == {"Good": AlsoGood}
+    assert len(records) == 2
+
+
+def test_a_group_loads_once_per_process(fake_group, monkeypatch):
+    """The registries rely on this: loading is not free and must not repeat."""
+    calls = []
+
+    class Counting(FakeEntryPoint):
+        def load(self):
+            calls.append(self.name)
+            return super().load()
+
+    fake_group(Counting("good", "pkg.mod:Good", Good))
+    assert calls == ["good"]
+
+    # A second call must not touch the entry points again, even though the
+    # monkeypatched iterator would happily yield them.
+    load_entry_point_group(
+        group="test.group", base_cls=Base, name_of=lambda cls: cls.name, kind="thing"
+    )
+    assert calls == ["good"]
+
+    loader.clear_cache()
+    load_entry_point_group(
+        group="test.group", base_cls=Base, name_of=lambda cls: cls.name, kind="thing"
+    )
+    assert calls == ["good", "good"]
+
+
+def test_missing_distribution_metadata_does_not_break_loading(fake_group):
+    """Provenance is metadata about the plugin, not the plugin."""
+    entry_point = FakeEntryPoint("good", "pkg.mod:Good", Good)
+    entry_point.dist = None
+
+    (record,) = fake_group(entry_point)
+    assert record.loaded and record.cls is Good
+    assert record.distribution is None and record.version is None

--- a/tests/test_plugin_report.py
+++ b/tests/test_plugin_report.py
@@ -12,10 +12,12 @@ contract -- that real entry points actually produce these rows -- lives in
 tests/test_plugin_entry_points.py against an installed fixture.
 """
 
+import importlib
 import os
 
 import pytest
 
+from fibsem.plugins import report
 from fibsem.plugins.report import (
     Extension,
     ExtensionGroup,
@@ -219,6 +221,87 @@ def test_script_row_shows_its_path_and_keeps_the_class():
 def test_empty_group_says_so_rather_than_rendering_nothing():
     text = render_report([_group()])
     assert "fibsem.tasks  (nothing registered)" in text
+
+
+# ---------------------------------------------------------------------------
+# A registry that will not import
+# ---------------------------------------------------------------------------
+
+
+def _boom():
+    raise ImportError("No module named 'psygnal'")
+
+
+def test_a_group_that_cannot_be_inspected_becomes_one_row_saying_so():
+    group = report._collect_group(
+        "fibsem.tasks", "AutoLamella tasks", "fibsem.applications.autolamella.workflows.tasks", _boom
+    )
+
+    (row,) = group.extensions
+    assert row.source is ExtensionSource.FAILED
+    # The module that could not be read, so the reader knows what to try importing.
+    assert row.target == "fibsem.applications.autolamella.workflows.tasks"
+    assert "No module named 'psygnal'" in row.problem
+    # ...and that this is not one plugin failing but the whole group being unknown.
+    assert "whole group could not be inspected" in row.problem
+
+
+def test_one_unreadable_group_does_not_take_the_others_down(monkeypatch):
+    """The point of the isolation: a broken task registry still leaves a report.
+
+    This listing is what a user is asked for when their install misbehaves. If it
+    needs all three registries intact to print anything, it cannot do the one job
+    it exists for.
+    """
+    monkeypatch.setattr(
+        report,
+        "_GROUPS",
+        tuple(
+            (group, label, module, _boom if group == "fibsem.tasks" else collect)
+            for group, label, module, collect in report._GROUPS
+        ),
+    )
+
+    groups = {g.group: g for g in report.collect_extensions()}
+
+    assert set(groups) == {"fibsem.patterns", "fibsem.strategies", "fibsem.tasks"}
+    assert [e.source for e in groups["fibsem.tasks"].extensions] == [ExtensionSource.FAILED]
+    # The milling groups are not merely present, they are populated: every
+    # install has built-in patterns and strategies.
+    for intact in ("fibsem.patterns", "fibsem.strategies"):
+        assert any(e.source is ExtensionSource.BUILTIN for e in groups[intact].extensions)
+
+
+def test_an_unreadable_group_still_renders(monkeypatch):
+    """Rendering must not assume a row has a name or a distribution."""
+    group = report._collect_group("fibsem.tasks", "AutoLamella tasks", "some.module", _boom)
+
+    text = render_report([group])
+
+    assert "fibsem.tasks" in text
+    assert "some.module" in text
+    assert "! ImportError: No module named 'psygnal'" in text
+
+
+def test_the_group_table_matches_the_registries():
+    """_GROUPS repeats the group strings, because it is used when the import fails.
+
+    Repeating them is the only option -- the constant lives in the module that may
+    not be importable -- so the duplication gets pinned here instead.
+    """
+    from fibsem.applications.autolamella.workflows.tasks import TASK_ENTRY_POINT_GROUP
+    from fibsem.milling.patterning import PATTERN_ENTRY_POINT_GROUP
+    from fibsem.milling.strategy import STRATEGY_ENTRY_POINT_GROUP
+
+    assert [group for group, _, _, _ in report._GROUPS] == [
+        PATTERN_ENTRY_POINT_GROUP,
+        STRATEGY_ENTRY_POINT_GROUP,
+        TASK_ENTRY_POINT_GROUP,
+    ]
+    # The module named in the fallback row has to be the one actually imported,
+    # or the row sends the reader somewhere irrelevant.
+    for _, _, module, _ in report._GROUPS:
+        importlib.import_module(module)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugin_report.py
+++ b/tests/test_plugin_report.py
@@ -1,0 +1,299 @@
+"""The plugin listing's text rendering.
+
+``fibsem-cli plugins`` output and the Plugins panel's Copy report button are the
+same string, and it gets pasted into bug reports -- so it has to stay readable
+and stable rather than merely non-empty.
+
+These build :class:`Extension` rows directly instead of installing plugins.
+That is deliberate: it covers the rows this environment cannot produce (a
+script-loaded task, which nothing loads until FIB-339 lands) and the pathological
+widths that would otherwise need a package named to order. The other half of the
+contract -- that real entry points actually produce these rows -- lives in
+tests/test_plugin_entry_points.py against an installed fixture.
+"""
+
+import os
+
+import pytest
+
+from fibsem.plugins.report import (
+    Extension,
+    ExtensionGroup,
+    ExtensionSource,
+    environment_line,
+    group_counts_phrase,
+    home_relative,
+    render_report,
+    summarise,
+)
+
+
+def _extension(**kwargs) -> Extension:
+    defaults = dict(
+        group="fibsem.tasks",
+        name="MY_TASK",
+        source=ExtensionSource.PLUGIN,
+        target="lab_patterns.tasks.MyTask",
+        distribution="lab-patterns",
+        version="0.3.1",
+    )
+    defaults.update(kwargs)
+    return Extension(**defaults)
+
+
+def _group(*extensions: Extension, group="fibsem.tasks", label="AutoLamella tasks") -> ExtensionGroup:
+    return ExtensionGroup(group=group, label=label, extensions=tuple(extensions))
+
+
+def _row_for(text: str, name: str) -> str:
+    return next(line for line in text.splitlines() if line.strip().startswith(name))
+
+
+# ---------------------------------------------------------------------------
+# Layout
+# ---------------------------------------------------------------------------
+
+
+def test_columns_do_not_collide_when_a_value_fills_its_column():
+    """A name or distribution as wide as its column must not run into the next.
+
+    Fixed column widths are the obvious implementation and the wrong one: task
+    types run to nearly thirty characters, and "built-in" is exactly as long as
+    a naive source column, which silently produced `built-infibsem.milling...`.
+    """
+    long_name = "SELECT_FLUORESCENCE_POSITION_AND_THEN_SOME"
+    text = render_report(
+        [
+            _group(
+                _extension(name=long_name),
+                _extension(
+                    name="SHORT",
+                    source=ExtensionSource.BUILTIN,
+                    distribution=None,
+                    version=None,
+                    target="fibsem.tasks.Short",
+                ),
+            )
+        ],
+        show_builtins=True,
+    )
+
+    # Every row splits into exactly the columns it should: nothing has been
+    # glued to its neighbour by a value that filled its column exactly.
+    assert _row_for(text, long_name).split() == [
+        long_name,
+        "plugin",
+        "lab-patterns",
+        "0.3.1",
+        "lab_patterns.tasks.MyTask",
+    ]
+    assert _row_for(text, "SHORT").split() == [
+        "SHORT",
+        "built-in",
+        "fibsem.tasks.Short",
+    ]
+
+
+def test_builtin_targets_line_up_with_plugin_targets():
+    """Built-ins have no distribution, but still hold the column."""
+    text = render_report(
+        [
+            _group(
+                _extension(name="PLUGGED"),
+                _extension(
+                    name="NATIVE",
+                    source=ExtensionSource.BUILTIN,
+                    distribution=None,
+                    version=None,
+                    target="fibsem.tasks.Native",
+                ),
+            )
+        ],
+        show_builtins=True,
+    )
+    plugged, native = _row_for(text, "PLUGGED"), _row_for(text, "NATIVE")
+    assert plugged.index("lab_patterns.tasks.MyTask") == native.index("fibsem.tasks.Native")
+
+
+def test_no_distribution_column_when_nothing_is_installed():
+    """With only built-ins, do not indent every row past an empty column.
+
+    Also the one arrangement where "built-in" is the widest source value, so a
+    source column sized to anything but the content puts it flush against the
+    class path -- `built-infibsem.milling...`, which is what shipped first.
+    """
+    text = render_report(
+        [
+            _group(
+                _extension(
+                    name="NATIVE",
+                    source=ExtensionSource.BUILTIN,
+                    distribution=None,
+                    version=None,
+                    target="fibsem.tasks.Native",
+                )
+            )
+        ],
+        show_builtins=True,
+    )
+    row = _row_for(text, "NATIVE")
+    assert row.split() == ["NATIVE", "built-in", "fibsem.tasks.Native"]
+    assert row.rstrip().endswith("fibsem.tasks.Native")
+
+
+def test_rendering_is_deterministic():
+    """Two runs on one machine must be diffable; entry_points() is not ordered."""
+    groups = [_group(_extension(name="B"), _extension(name="A"))]
+    assert render_report(groups) == render_report(groups)
+
+
+# ---------------------------------------------------------------------------
+# Rows that the registries cannot express
+# ---------------------------------------------------------------------------
+
+
+def test_failed_row_shows_the_declared_target_and_the_reason():
+    """A failed entry point has no name, so the declared value carries the row."""
+    text = render_report(
+        [
+            _group(
+                _extension(
+                    name=None,
+                    source=ExtensionSource.FAILED,
+                    target="lab_patterns.tasks:BadTask",
+                    problem="not a subclass of AutoLamellaTask - nothing was registered",
+                )
+            )
+        ]
+    )
+
+    assert "lab_patterns.tasks:BadTask" in text
+    assert "-  " in text  # the empty name column
+    # Problems are indented under their entry and marked, so `| grep '!'` works.
+    problem = next(line for line in text.splitlines() if "!" in line)
+    assert problem.lstrip().startswith("! not a subclass of AutoLamellaTask")
+    assert problem.startswith("  ")
+
+
+def test_shadowed_row_is_listed_with_its_reason():
+    text = render_report(
+        [
+            _group(
+                _extension(
+                    name="Rectangle",
+                    problem="name taken by a built-in - the built-in is used, this is inactive",
+                )
+            )
+        ]
+    )
+    assert "Rectangle" in text
+    assert "! name taken by a built-in" in text
+
+
+def test_script_row_shows_its_path_and_keeps_the_class():
+    """The path takes the origin column, so the class moves to the line below.
+
+    Nothing produces script rows until the scripts folder lands (FIB-339); this
+    is what it has to emit for the listing to be complete.
+    """
+    text = render_report(
+        [
+            _group(
+                _extension(
+                    name="MY_POLISH",
+                    source=ExtensionSource.SCRIPT,
+                    target="custom_polish.MyPolishTask",
+                    distribution=None,
+                    version=None,
+                    path="~/.autolamella/scripts/custom_polish.py",
+                )
+            )
+        ]
+    )
+    lines = text.splitlines()
+    row = lines.index(_row_for(text, "MY_POLISH"))
+    assert "~/.autolamella/scripts/custom_polish.py" in lines[row]
+    assert lines[row + 1].strip() == "custom_polish.MyPolishTask"
+
+
+def test_empty_group_says_so_rather_than_rendering_nothing():
+    text = render_report([_group()])
+    assert "fibsem.tasks  (nothing registered)" in text
+
+
+# ---------------------------------------------------------------------------
+# Counts and trailer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sources, expected",
+    [
+        ([ExtensionSource.PLUGIN], "1 plugin"),
+        ([ExtensionSource.PLUGIN, ExtensionSource.PLUGIN], "2 plugins"),
+        ([ExtensionSource.PLUGIN, ExtensionSource.FAILED], "1 plugin, 1 failed"),
+        ([ExtensionSource.BUILTIN, ExtensionSource.BUILTIN], "2 built-in"),
+        ([], "nothing registered"),
+    ],
+)
+def test_group_counts_phrase(sources, expected):
+    group = _group(*[_extension(source=s, name=f"N{i}") for i, s in enumerate(sources)])
+    assert group_counts_phrase(group) == expected
+
+
+def test_summary_counts_across_groups_and_reports_hidden_builtins():
+    groups = [
+        _group(_extension(), group="fibsem.patterns"),
+        _group(
+            _extension(source=ExtensionSource.FAILED, name=None),
+            _extension(source=ExtensionSource.BUILTIN, name="X"),
+            _extension(source=ExtensionSource.BUILTIN, name="Y"),
+        ),
+    ]
+    summary, hidden = summarise(groups)
+    assert summary == "1 plugin, 1 failed to load"
+    assert hidden == 2
+
+    assert "2 built-in hidden (use --all)." in render_report(groups)
+    # ...and not once they are on screen.
+    assert "built-in hidden" not in render_report(groups, show_builtins=True)
+
+
+def test_summary_says_so_when_nothing_is_installed():
+    summary, _ = summarise([_group(_extension(source=ExtensionSource.BUILTIN))])
+    assert summary == "no plugins installed"
+
+
+def test_report_ends_with_the_environment_it_describes():
+    """Pasted into a bug report, "which install is this?" is the next question."""
+    text = render_report([_group(_extension())])
+    assert text.splitlines()[-1] == environment_line()
+    assert environment_line().startswith("fibsem ")
+    assert "Python" in environment_line()
+
+
+def test_report_is_ascii_so_it_survives_a_windows_console():
+    text = render_report(
+        [_group(_extension(problem="name taken by a built-in - this is inactive"))]
+    )
+    text.encode("ascii")  # raises if a dash or bullet crept in
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def test_home_relative_strips_the_username():
+    """Script paths and the env path both carry the user's name otherwise."""
+    home = os.path.expanduser("~")
+    inside = os.path.join(home, "scripts", "x.py")
+
+    assert home_relative(inside) == "~" + inside[len(home):]
+    assert not home_relative(inside).startswith(home)
+    # Anything outside the home directory is left exactly as it is.
+    assert home_relative("/opt/env/fibsem") == "/opt/env/fibsem"
+
+
+def test_environment_line_does_not_leak_the_home_path():
+    assert os.path.expanduser("~") not in environment_line()

--- a/tests/ui/test_plugins_dialog.py
+++ b/tests/ui/test_plugins_dialog.py
@@ -1,0 +1,354 @@
+"""Tests for the Plugins dialog.
+
+Built from synthetic groups rather than whatever happens to be installed: the
+rows worth testing are the ones a normal environment does not have -- a plugin
+that failed to load, one a built-in shadowed, and a script-loaded task that
+nothing produces until FIB-339 lands.
+"""
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtWidgets import QLabel  # noqa: E402
+
+from fibsem.plugins.report import (  # noqa: E402
+    Extension,
+    ExtensionGroup,
+    ExtensionSource,
+    environment_line,
+    render_report,
+)
+from fibsem.ui.widgets.plugins_dialog import PluginsDialog  # noqa: E402
+
+PLUGIN = Extension(
+    group="fibsem.patterns",
+    name="WaffleTrench",
+    source=ExtensionSource.PLUGIN,
+    target="lab_patterns.trench.WaffleTrenchPattern",
+    distribution="lab-patterns",
+    version="0.3.1",
+)
+BUILTIN = Extension(
+    group="fibsem.patterns",
+    name="Rectangle",
+    source=ExtensionSource.BUILTIN,
+    target="fibsem.milling.patterning.patterns2.RectanglePattern",
+)
+SHADOWED = Extension(
+    group="fibsem.strategies",
+    name="Overtilt",
+    source=ExtensionSource.PLUGIN,
+    target="lab_patterns.strategy.LabOvertilt",
+    distribution="lab-patterns",
+    version="0.3.1",
+    problem="name taken by a built-in - the built-in is used, this is inactive",
+)
+SCRIPT = Extension(
+    group="fibsem.tasks",
+    name="MY_POLISH",
+    source=ExtensionSource.SCRIPT,
+    target="custom_polish.MyPolishTask",
+    path="~/.autolamella/scripts/custom_polish.py",
+)
+FAILED = Extension(
+    group="fibsem.tasks",
+    name=None,
+    source=ExtensionSource.FAILED,
+    target="lab_patterns.tasks:BadTask",
+    distribution="lab-patterns",
+    version="0.3.1",
+    problem="not a subclass of AutoLamellaTask - nothing was registered",
+)
+
+GROUPS = (
+    ExtensionGroup("fibsem.patterns", "Milling patterns", (PLUGIN, BUILTIN)),
+    ExtensionGroup("fibsem.strategies", "Milling strategies", (SHADOWED,)),
+    ExtensionGroup("fibsem.tasks", "AutoLamella tasks", (SCRIPT, FAILED)),
+)
+
+
+@pytest.fixture
+def dialog(qapp):
+    widget = PluginsDialog(groups=GROUPS)
+    yield widget
+    widget.deleteLater()
+
+
+def _cell_text(dialog, row: int, column: int) -> str:
+    """Everything a cell widget renders, joined -- the name and detail lines."""
+    widget = dialog.table.cellWidget(row, column)
+    if widget is None:
+        item = dialog.table.item(row, column)
+        return item.text() if item else ""
+    return "\n".join(label.text() for label in widget.findChildren(QLabel))
+
+
+def _row_of(dialog, extension: Extension) -> int:
+    return dialog.rows.index(extension)
+
+
+def _tooltip_of(dialog, extension: Extension) -> str:
+    return dialog.table.cellWidget(_row_of(dialog, extension), 0).toolTip()
+
+
+def _chip_colours(dialog, extension: Extension) -> list:
+    """The colour each chip in the Source cell is painted, left to right."""
+    import re
+
+    cell = dialog.table.cellWidget(_row_of(dialog, extension), 1)
+    return [
+        re.search(r"color: (#[0-9a-fA-F]{6});", label.styleSheet()).group(1)
+        for label in cell.findChildren(QLabel)
+    ]
+
+
+def test_every_extension_gets_a_row_in_group_order(dialog):
+    # The built-in is counted but hidden, so four of the five.
+    assert dialog.table.rowCount() == 4
+    assert [e.group for e in dialog.rows] == [
+        "fibsem.patterns",
+        "fibsem.strategies",
+        "fibsem.tasks",
+        "fibsem.tasks",
+    ]
+
+
+def test_the_entry_point_group_column_shows_the_literal_string(dialog):
+    """The exact string, not just "Milling patterns".
+
+    A group mistyped in a plugin's pyproject registers nothing and logs nothing,
+    so comparing the real string against their own file is the only way a user
+    can find that mistake.
+    """
+    groups = {_cell_text(dialog, row, 2) for row in range(dialog.table.rowCount())}
+    assert groups == {"fibsem.patterns", "fibsem.strategies", "fibsem.tasks"}
+
+
+def test_failed_row_leads_with_what_was_declared_and_why_it_failed(dialog):
+    """No name registered, so the declared target takes the name line."""
+    text = _cell_text(dialog, _row_of(dialog, FAILED), 0)
+
+    assert "lab_patterns.tasks:BadTask" in text
+    assert "Not a subclass of AutoLamellaTask - nothing was registered" in text
+    assert "Failed" in _cell_text(dialog, _row_of(dialog, FAILED), 1)
+    # Which package declared it is unrecoverable elsewhere when several plugins
+    # are installed, so it has to be reachable -- just not at the reason's expense.
+    assert "lab-patterns 0.3.1" in _tooltip_of(dialog, FAILED)
+
+
+def test_shadowed_row_reads_as_unavailable_rather_than_broken(dialog):
+    """The consequence, not the mechanism: it loaded, it just is not in use.
+
+    "shadowed" describes fibsem's merge order, which is not the user's problem.
+    """
+    row = _row_of(dialog, SHADOWED)
+    source = _cell_text(dialog, row, 1)
+
+    assert "Unavailable" in source
+    # Still a plugin: it is installed and it loaded, it just is not the one used.
+    assert "Plugin" in source
+    assert "built-in" in _tooltip_of(dialog, SHADOWED)
+
+
+def test_colour_marks_state_not_where_something_came_from(dialog):
+    """A plugin and a script are both in use, so they get the same colour.
+
+    Separate colours would imply a distinction that does not exist -- the chip
+    label already says which is which. Four states, four colours: in use,
+    installed-but-unused, unremarkable, broken.
+    """
+    from fibsem.ui.widgets.plugins_dialog import (
+        _SOURCE_STYLE,
+        _TEXT_MUTED,
+        _WARN,
+        _reason_colour,
+    )
+
+    _, plugin_colour = _SOURCE_STYLE[ExtensionSource.PLUGIN]
+    _, script_colour = _SOURCE_STYLE[ExtensionSource.SCRIPT]
+    _, failed_colour = _SOURCE_STYLE[ExtensionSource.FAILED]
+    _, builtin_colour = _SOURCE_STYLE[ExtensionSource.BUILTIN]
+
+    assert plugin_colour == script_colour
+    assert len({plugin_colour, _WARN, builtin_colour, failed_colour}) == 4
+    assert builtin_colour == _TEXT_MUTED
+
+    # The reason wears the same colour as the chip that raised it.
+    assert _reason_colour(FAILED) == failed_colour
+    assert _reason_colour(SHADOWED) == _WARN
+    assert _reason_colour(PLUGIN) == _TEXT_MUTED
+
+
+def test_an_unavailable_row_does_not_wear_the_in_use_colour(dialog):
+    """It is installed, but it is not the copy being used.
+
+    Leaving the Source chip blue would say "in use" next to a chip saying it is
+    not, and grey would file one of the two rows this dialog exists to surface
+    alongside the built-ins nobody came for.
+    """
+    from fibsem.ui.widgets.plugins_dialog import _SOURCE_STYLE, _TEXT_MUTED, _WARN
+
+    _, in_use = _SOURCE_STYLE[ExtensionSource.PLUGIN]
+    chips = _chip_colours(dialog, SHADOWED)
+
+    assert in_use not in chips
+    assert chips == [_TEXT_MUTED, _WARN]
+
+    # ...while an active plugin still does.
+    assert _chip_colours(dialog, PLUGIN) == [in_use]
+
+
+def test_an_inactive_row_explains_itself_without_being_selected(dialog):
+    """The reason is on the row, not behind a click or a hover.
+
+    A shadowed plugin used to explain itself only in a detail panel below the
+    table, which meant the Unavailable chip was unexplained until you selected
+    it -- the same shape of silence this dialog exists to end.
+    """
+    text = _cell_text(dialog, _row_of(dialog, SHADOWED), 0)
+    assert "Name taken by a built-in" in text
+
+    # The class path it displaced is still reachable, just not at the reason's
+    # expense.
+    assert "lab_patterns.strategy.LabOvertilt" in _tooltip_of(dialog, SHADOWED)
+
+
+def test_a_healthy_row_shows_what_it_resolved_to(dialog):
+    text = _cell_text(dialog, _row_of(dialog, PLUGIN), 0)
+    assert "lab_patterns.trench.WaffleTrenchPattern" in text
+    assert "lab-patterns 0.3.1" in text
+
+
+def test_open_folder_is_enabled_only_for_something_with_a_file(dialog):
+    """The action is meaningless for a packaged plugin -- there is no file."""
+    dialog.table.selectRow(_row_of(dialog, SCRIPT))
+    assert dialog.open_folder_button.isEnabled()
+
+    dialog.table.selectRow(_row_of(dialog, PLUGIN))
+    assert not dialog.open_folder_button.isEnabled()
+
+
+def test_open_folder_is_absent_when_nothing_has_a_file(qapp):
+    """Which is every environment until the scripts folder lands (FIB-339).
+
+    A button that can never be enabled reads as broken, not as inapplicable.
+    """
+    packaged_only = (
+        ExtensionGroup("fibsem.patterns", "Milling patterns", (PLUGIN,)),
+    )
+    widget = PluginsDialog(groups=packaged_only)
+    try:
+        assert not widget.open_folder_button.isVisible()
+    finally:
+        widget.deleteLater()
+
+    with_a_script = packaged_only + (
+        ExtensionGroup("fibsem.tasks", "AutoLamella tasks", (SCRIPT,)),
+    )
+    widget = PluginsDialog(groups=with_a_script)
+    try:
+        assert not widget.open_folder_button.isHidden()
+    finally:
+        widget.deleteLater()
+
+
+def test_show_builtins_reveals_them_and_drops_the_hidden_count(dialog):
+    assert "1 built-in hidden" in dialog.meta_label.text()
+
+    dialog.builtins_checkbox.setChecked(True)
+    assert dialog.table.rowCount() == 5
+    assert BUILTIN in dialog.rows
+    assert "built-in hidden" not in dialog.meta_label.text()
+
+    dialog.builtins_checkbox.setChecked(False)
+    assert dialog.table.rowCount() == 4
+
+
+def test_the_selection_survives_a_rebuild(dialog):
+    """Toggling built-ins must not bounce the selection back to the top."""
+    dialog.table.selectRow(_row_of(dialog, FAILED))
+    dialog.builtins_checkbox.setChecked(True)
+
+    assert dialog.selected_extension() is FAILED
+
+
+def test_copy_report_emits_exactly_what_the_cli_prints(dialog):
+    """One renderer for both surfaces.
+
+    If these drift, a report a user pastes into a bug tracker stops matching
+    what support is looking at on screen -- worse than having only one of them.
+    """
+    assert dialog.report_text() == render_report(GROUPS, show_builtins=False)
+
+    dialog.builtins_checkbox.setChecked(True)
+    assert dialog.report_text() == render_report(GROUPS, show_builtins=True)
+
+
+def test_copy_confirms_then_recovers_so_it_can_be_copied_again(dialog):
+    """An icon button gives no other sign it did anything."""
+    dialog.copy_report()
+    assert dialog.copy_button.toolTip() == "Copied"
+
+    # Toggling changes what a copy would produce, so the button has to come back.
+    dialog.builtins_checkbox.setChecked(True)
+    assert "Copy this listing" in dialog.copy_button.toolTip()
+
+
+def test_meta_line_counts_everything_installed(dialog):
+    # The shadowed plugin counts as installed: it is on disk and it loaded, it
+    # just is not the one in use. Saying "1 plugin" would contradict the row
+    # sitting in the table below.
+    assert dialog.meta_label.text().startswith("2 plugins, 1 script, 1 failed to load")
+    # Per-group counts are the tooltip, so the line stays one line.
+    assert "fibsem.strategies: 1 plugin" in dialog.meta_label.toolTip()
+    # "which install is this?" is the first question about any pasted report,
+    # and it used to live on a footer that no longer exists.
+    assert environment_line() in dialog.meta_label.toolTip()
+
+
+def test_a_group_with_nothing_registered_leaves_an_empty_table(qapp):
+    widget = PluginsDialog(groups=(ExtensionGroup("fibsem.patterns", "Milling patterns", ()),))
+    try:
+        assert widget.table.rowCount() == 0
+        assert widget.selected_extension() is None
+        assert not widget.open_folder_button.isEnabled()
+        assert "no plugins installed" in widget.meta_label.text()
+    finally:
+        widget.deleteLater()
+
+
+def test_no_widget_stylesheet_swallows_its_own_tooltip(dialog):
+    """A selector-less rule on a widget also styles the tooltip shown over it.
+
+    It sits nearer than the application stylesheet, so it wins: `background:
+    transparent` on a table cell left its tooltip as floating text with no panel
+    behind it, and a muted `color` would make tooltip text unreadable. Every rule
+    written without a selector therefore has to restate the QToolTip block.
+
+    Checked as an invariant rather than by rendering, because the offscreen
+    platform never realises a tooltip window to look at.
+    """
+    from PyQt5.QtWidgets import QWidget
+
+    offenders = []
+    for widget in [dialog] + dialog.findChildren(QWidget):
+        css = widget.styleSheet()
+        if not css:
+            continue
+        # A rule that names a type or an id cannot match QToolTip.
+        scoped = css.lstrip().startswith(("Q", "#", "*"))
+        if not scoped and "QToolTip" not in css:
+            offenders.append((type(widget).__name__, widget.toolTip(), css[:60]))
+
+    assert not offenders, offenders
+
+
+def test_the_tooltip_rule_matches_the_application_theme(dialog):
+    """Restated locally, so it has to stay in step with the real one."""
+    from fibsem.ui import stylesheets
+    from fibsem.ui.widgets.plugins_dialog import _BORDER, _PANEL, _TEXT
+
+    app_rule = stylesheets.NAPARI_STYLE.split("QToolTip {")[1].split("}")[0]
+    for value in (_PANEL, _TEXT, _BORDER):
+        assert value in app_rule, f"{value} no longer matches the app tooltip style"


### PR DESCRIPTION
Adds a listing of every registered pattern, strategy and task, and where each came from — as a dialog (**Tools → Plugins…**) and as `fibsem-cli plugins`. Closes FIB-347 and FIB-348.

## The listing cannot be derived from the registries

Measured against a real environment before writing anything:

```
patterns:  18  (17 built-in + 1)   ← 2 pattern entry points installed
tasks:     13  (12 built-in + 1)   ← 5 task entry points installed, 4 broken
```

A plugin claiming a built-in's name loads fine, registers fine, then gets overwritten when `get_patterns()` merges built-ins last. Four broken task entry points leave **zero** trace in the returned dict. Both — the two rows a user actually opens this for — are information `{name: class}` structurally cannot express, and their only evidence today is a log line that scrolled past at startup.

So the three near-identical `_get_plugin_*` functions now record what they did. `load_entry_point_group()` returns one `PluginRecord` per declared entry point — successes, failures and shadowed alike — and the registries derive their dict from those. Recording at load time rather than re-walking the entry points separately is the point: a second walk can disagree with what actually registered, and a disagreement is exactly the fault this data exists to diagnose.

## Three layers

| | |
|---|---|
| `fibsem/plugins/loader.py` | Loads the groups, records the outcome. **No fibsem imports at all.** |
| `fibsem/plugins/report.py` | Assembly + the one text renderer. Imports all three registries. |
| `fibsem/ui/widgets/plugins_dialog.py` | Qt. Reads `report`, nothing else. |

The loader/report split is load-bearing, not tidiness. `milling/base.py` imports `fibsem.milling.patterning`, whose `__init__` ends with a module-level `MILLING_PATTERNS = get_patterns()` — so pattern loading runs while `fibsem.milling.base` is half initialised, and anything reaching back into it raises. `loader` takes the base class and the name-extraction callable as *arguments* so it never needs to import them. (Same constraint that forces a plugin's pattern, strategy and task into separate modules.)

Behaviour is unchanged: same registries, same precedence, same log levels. Two failure reasons are now phrased for a user rather than for fibsem — an entry point pointing at a non-class says so, instead of surfacing `issubclass()`'s own "arg 1 must be a class".

## Design notes

**One renderer, two surfaces.** Copy report emits byte-for-byte what the CLI prints. If they drift, a report pasted into a bug tracker stops matching what support is looking at — worse than having only one of them. A test pins the equality in both `--all` states.

**The CLI takes no connection arguments** and dispatches before `setup_session()`. Diagnosing a plugin is usually done away from the instrument, and requiring hardware to answer "did my plugin load?" would make it useless in exactly the situation it exists for.

**Group headers are the literal entry point strings**, and the dialog puts them on every row. A mistyped group registers nothing and logs nothing — there is no error to find, so the only route to that mistake is diffing the real string against your own `pyproject.toml`.

**A failed row shows the declared target** with `-` in the name column. A listing of successes cannot answer "why isn't mine here?".

**Colour carries state, never provenance.** Blue in use, amber installed-but-not-used, grey unremarkable, red broken. A plugin and a script are both blue because the chip label already says which is which. "Unavailable" rather than "shadowed" — the consequence, not fibsem's merge order — and amber rather than grey even though nothing is technically wrong, because grey is what built-ins wear and that buries it.

**The listing is the state as of startup.** The registries cache their entry points for the process. A Refresh button would either lie, or really re-load and leave the registries disagreeing with the module-level snapshots taken at import time.

## Not implemented, and it does not pretend otherwise

Script-loaded rows (FIB-339) are modelled, rendered and tested, but nothing produces them — no scripts folder exists yet. When it lands it only has to emit `Extension` rows with `source=SCRIPT` and a `path`. `Open folder` is *hidden* rather than disabled until some row has a file, since a permanently greyed button reads as broken rather than inapplicable.

## Testing

66 new tests. Full suite **1506 passed / 15 skipped** with the plugin fixture installed.

The fixture in `tests/fixtures/plugin` gains two entry points that fail on purpose, one per failure shape — neither previously left anything a test could assert on.

Ten mutations run against the new guards; the first pass caught six. The four misses were all tests asserting something other than what they claimed, and are worth naming because three are reusable traps:

- a column-collision test whose fixture happened to have a wide neighbouring column, so the collision never occurred;
- a test asserting a string the test itself constructed, not the code under test;
- asserting `QLabel.text()` to detect rich-vs-plain text — `text()` returns what was set either way, so it has to assert `textFormat()`;
- asserting stderr is clean to prove log suppression, when the load-once cache means nothing logs by then anyway. Asserts at the moment of loading via a spy instead.

Second pass: 10/10.

The dialog was rendered offscreen at each step and inspected, which caught what reading the code did not: underscores clipped off names at a too-tight row height, a `QFrame` type selector putting a failure's red gutter on every label inside the row, and — the one worth repeating — **a selector-less stylesheet on a widget also styles the `QToolTip` shown over it**, beating the application sheet because it sits nearer. `background: transparent` on a table cell left its tooltip as floating text with no panel behind it. Every bare rule now goes through `_style()`, which restates the `QToolTip` block. Not verifiable by rendering (the offscreen platform never realises a tooltip window), so a test asserts no widget's stylesheet can swallow its own tooltip.

## Robustness of the listing itself

`collect_extensions()` collects each group behind its own guard, so a registry that will not import becomes one row naming the module and the reason while the other two groups print in full. This surface exists to explain a broken install, so requiring an intact one would defeat it — and the AutoLamella task registry is by far the heaviest import of the three. Verified against a genuinely hollowed-out task registry: the two milling groups still print, and the task group degrades to a single explanatory row.

## Split out of this PR

An argparse bug found while reviewing the `plugins --debug` flag — every connection flag given *before* a subcommand was silently reverted to its default, so `fibsem-cli --manufacturer Thermo info` connected to the Demo simulator — is #224. It changes hardware connection behaviour for every subcommand and has nothing to do with plugins, so it is reviewed separately. `plugins --debug` itself stays here, since that flag only exists because of `cmd_plugins`.

## Follow-ups, deliberately not in this PR

- `_ElidedLabel`, `_chip()` and the palette constants are duplicated from `script_manager_dialog.py` (#219) to keep the two PRs independent. Whichever lands second should factor them into a shared module.
- **`script_manager_dialog.py` has the same transparent-tooltip bug** — its cell widgets carry tooltips and a bare `background: transparent`. Same one-line fix.

