### PR TITLE
[fix] Honour fibsem-cli connection arguments given before the subcommand

### DIFF
--- a/fibsem/cli.py
+++ b/fibsem/cli.py
@@ -305,23 +305,44 @@ def cmd_info(microscope, _settings, _args) -> int:
 # Parser construction
 # ---------------------------------------------------------------------------
 
-def _build_connection_parser() -> argparse.ArgumentParser:
+def _build_connection_parser(*, defaults: bool = True) -> argparse.ArgumentParser:
+    """The connection arguments, shared by the root parser and every subcommand.
+
+    Built twice, and the difference is load-bearing. argparse parses a subcommand
+    into a fresh namespace and then copies every attribute of it over the root's,
+    so an argument the subparser merely *defaulted* silently overwrites the same
+    argument the root actually *parsed*. With one copy of this parser as a parent
+    of both, every connection flag given before the subcommand reverted without a
+    word: ``fibsem-cli --manufacturer Thermo info`` connected to the Demo
+    simulator, and ``--config`` was ignored outright.
+
+    So the root parser gets the copy carrying the real defaults -- that copy is
+    what guarantees the attribute exists at all -- and the subparsers get the copy
+    whose defaults are ``SUPPRESS``, which leaves each attribute absent unless
+    the flag was actually passed. Both positions then work, and when a flag is
+    given in both the one after the subcommand wins.
+    """
     p = argparse.ArgumentParser(add_help=False)
+
+    def default(value):
+        """The declared default, or nothing at all in the subparsers' copy."""
+        return value if defaults else argparse.SUPPRESS
+
     p.add_argument(
         "--manufacturer",
-        default="Demo",
+        default=default("Demo"),
         choices=["Demo", "Thermo", "Tescan", "Odemis"],
         help="Microscope manufacturer (default: Demo)",
     )
     p.add_argument(
         "--ip-address",
-        default="localhost",
+        default=default("localhost"),
         dest="ip_address",
         help="Microscope IP address (default: localhost)",
     )
     p.add_argument(
         "--config",
-        default=None,
+        default=default(None),
         dest="config_path",
         type=Path,
         metavar="PATH",
@@ -330,7 +351,7 @@ def _build_connection_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--debug",
         action="store_true",
-        default=False,
+        default=default(False),
         help="Enable debug logging",
     )
     return p
@@ -512,11 +533,14 @@ class _VersionAction(argparse.Action):
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    conn = _build_connection_parser()
+    # Two copies on purpose, not an oversight: the root parser holds the real
+    # defaults, the subcommands hold suppressed ones so they cannot overwrite a
+    # flag the root already parsed. See _build_connection_parser.
+    conn = _build_connection_parser(defaults=False)
     root = argparse.ArgumentParser(
         prog="fibsem-cli",
         description="fibsemOS command-line interface for FIB/SEM microscope control",
-        parents=[conn],
+        parents=[_build_connection_parser()],
     )
     root.add_argument(
         "--version",

--- a/tests/test_cli_connection_args.py
+++ b/tests/test_cli_connection_args.py
@@ -1,0 +1,107 @@
+"""Connection arguments, on either side of the subcommand.
+
+argparse parses a subcommand into a fresh namespace and then copies every
+attribute of it over the root parser's. The connection arguments were one parser
+used as a parent of both, so a flag given *before* the subcommand was overwritten
+by the subparser that had simply defaulted it -- silently, with nothing logged
+and nothing failing. ``fibsem-cli --manufacturer Thermo info`` connected to the
+Demo simulator; ``--config`` was dropped on the floor. ``main()`` hands all four
+straight to ``setup_session()``, so the wrong value was acted on, not merely
+displayed.
+
+These pin both positions for every connection argument, and sweep every
+subcommand so the fix cannot be half-reverted for one of them. See
+``_build_connection_parser``.
+"""
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from fibsem import cli
+
+# flag argv, namespace attribute, value once given, value when absent
+CONNECTION_FLAGS = [
+    (["--manufacturer", "Thermo"], "manufacturer", "Thermo", "Demo"),
+    (["--ip-address", "10.0.0.1"], "ip_address", "10.0.0.1", "localhost"),
+    (["--config", "/tmp/scope.yaml"], "config_path", Path("/tmp/scope.yaml"), None),
+    (["--debug"], "debug", True, False),
+]
+_IDS = [dest for _, dest, _, _ in CONNECTION_FLAGS]
+
+# Subcommands with required positionals. Nothing to do with connection
+# arguments; they just have to be supplied to reach a successful parse.
+POSITIONALS = {"beam": ["on"], "mill-angle": ["18"]}
+
+
+def _parse(*argv):
+    return cli._build_parser().parse_args(argv)
+
+
+def _subcommand_names():
+    """The registered subcommands, read off the parser so this cannot go stale.
+
+    Private argparse attributes, deliberately: there is no public way to
+    enumerate subparsers, and a hardcoded list would silently stop covering
+    whatever was added next.
+    """
+    parser = cli._build_parser()
+    return sorted(
+        name
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+        for name in action.choices
+    )
+
+
+@pytest.mark.parametrize("flag,dest,given,_absent", CONNECTION_FLAGS, ids=_IDS)
+def test_a_connection_flag_is_honoured_from_either_position(flag, dest, given, _absent):
+    assert getattr(_parse(*flag, "info"), dest) == given
+    assert getattr(_parse("info", *flag), dest) == given
+
+
+@pytest.mark.parametrize("_flag,dest,_given,absent", CONNECTION_FLAGS, ids=_IDS)
+def test_the_declared_default_still_applies_when_the_flag_is_absent(_flag, dest, _given, absent):
+    """Suppressing the subparsers' defaults must not suppress them everywhere.
+
+    The root parser's copy is the one that guarantees the attribute exists at
+    all; without it every ``args.manufacturer`` in main() becomes an
+    AttributeError.
+    """
+    assert getattr(_parse("info"), dest) == absent
+
+
+def test_the_flag_after_the_subcommand_wins_when_given_in_both_positions():
+    """The more specific position, and the one that already worked."""
+    args = _parse("--manufacturer", "Thermo", "info", "--manufacturer", "Tescan")
+    assert args.manufacturer == "Tescan"
+
+
+@pytest.mark.parametrize("subcommand", _subcommand_names())
+def test_every_subcommand_honours_a_flag_given_before_it(subcommand):
+    """Swept rather than spot-checked: this broke for all of them at once.
+
+    A subcommand built with its own defaulted copy of the connection parser --
+    ``_build_connection_parser()`` instead of the shared suppressed ``conn`` --
+    would reintroduce the bug for that one subcommand only.
+    """
+    argv = ["--manufacturer", "Thermo", subcommand, *POSITIONALS.get(subcommand, [])]
+    assert _parse(*argv).manufacturer == "Thermo"
+
+
+def test_the_sweep_covers_every_subcommand():
+    """Guard the guard: a new subcommand needing positionals must be added above.
+
+    Otherwise its parse fails, the sweep cannot reach its assertion, and the
+    coverage quietly stops one subcommand short.
+    """
+    for subcommand in _subcommand_names():
+        argv = ["--manufacturer", "Thermo", subcommand, *POSITIONALS.get(subcommand, [])]
+        try:
+            _parse(*argv)
+        except SystemExit:
+            pytest.fail(
+                f"'{subcommand}' cannot be parsed as {argv!r}: add its required "
+                f"positionals to POSITIONALS so the sweep actually covers it."
+            )


### PR DESCRIPTION
## The bug

`argparse` parses a subcommand into a fresh namespace, then copies every attribute of it over the root parser's. An argument the subparser merely *defaulted* therefore overwrites the same argument the root actually *parsed*.

The connection parser was one object used as a parent of both the root parser and every subcommand, so every connection flag given **before** the subcommand silently reverted to its default:

| command | before this PR |
|---|---|
| `fibsem-cli --manufacturer Thermo info` | connected to the **Demo simulator** |
| `fibsem-cli --ip-address 10.0.0.1 info` | connected to **localhost** |
| `fibsem-cli --config scope.yaml info` | config **ignored** |
| `fibsem-cli --debug info` | debug logging **off** |

`main()` passes all four straight into `setup_session()`, so the wrong value was acted on rather than merely displayed. Nothing failed, and nothing was logged to say so.

Flags given *after* the subcommand always worked, which is why this went unnoticed.

## The fix

Build the connection parser twice. The root parser takes the copy carrying the real defaults — that copy is what guarantees the attribute exists at all — and the subparsers take the copy whose defaults are `argparse.SUPPRESS`, which leaves each attribute absent unless the flag was actually passed.

Both positions now work, and when a flag is given in both, the one after the subcommand wins.

Note the obvious one-line fix does **not** work: declaring the arguments on the subparsers with real defaults fixes nothing, and suppressing them everywhere turns every `args.manufacturer` in `main()` into an `AttributeError`. The split is the point.

## Verification

All four flags in both positions, across all nine subcommands (including `beam` and `mill-angle` with their positionals). Defaults unchanged when a flag is absent; `SUPPRESS` does not leak into any `--help` output.

New tests sweep every subcommand rather than spot-checking one, since this broke for all of them simultaneously and a single subcommand built with its own defaulted copy would reintroduce it unnoticed. The sweep enumerates subcommands off the parser, with a companion test that fails if a future subcommand's required positionals aren't registered — otherwise its parse would fail and the sweep would silently cover one fewer.

Mutation-tested both halves:

- subparsers given the defaulted copy (the original bug) → 13 failures
- root also suppressed → the `AttributeError` case

Full suite: 1452 passed, 24 skipped.

## Provenance

Split out of #222, where it was found while reviewing the `plugins` subcommand's `--debug` flag. It has nothing to do with plugins and changes hardware connection behaviour, so it belongs on its own — `--manufacturer Thermo` now actually connects to the Thermo.
