### PR TITLE
Remove the hard-coded y-inversion from the FM click paths (FIB-334)

### DIFF
--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -2619,9 +2619,12 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             image_shape=image_shape,
             pixelsize=pixelsize,
         )
-        px, py = point[0], -point[1]  # Y-inversion (mirrors FMControlWidget)
+        px, py = point[0], point[1]
         # fm_stable_move undoes the display transform and projects through the
         # camera's own axis tilt, so the sample is not foreshortened by the wrong beam.
+        # No hand-applied y-inversion: the projection owns the tilt-dependent sign (it
+        # reverses between t=0 and t=-180 on a compustage) and fm_stable_move undoes
+        # the display transform. Mirrors FMControlWidget.
         worker = FunctionWorker(self.microscope.fm_stable_move, dx=px, dy=py)
         worker.start()
 

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -405,14 +405,15 @@ class FMControlWidget(QWidget):
             f"Coordinates: {coords} - {point_clicked} - Movement Type {movement_type} - Alt Modifier {ALT_MODIFIER}"
         )
         if movement_type == "FM":
-            point_clicked = (
-                point_clicked[0],
-                -point_clicked[1],
-            )  # Y-inverse when t=0, need to make this more robust
-
             # fm_stable_move undoes the display transform and projects onto the tilted
             # sample plane, so the move is foreshortening-correct and holds focus.
             # Previously this was a raw relative move with neither correction.
+            #
+            # The click keeps the sign convention the beam paths use (y up-positive,
+            # straight out of image_to_microscope_image_coordinates2). There used to be
+            # a `-point_clicked[1]` here, calibrated at t=0; on a compustage the
+            # projection already reverses y between t=0 and t=-180, so a constant
+            # negation can only ever be right at one of them.
             self.microscope.fm_stable_move(dx=point_clicked[0], dy=point_clicked[1])
         logging.info(f"-" * 50)
 


### PR DESCRIPTION
Clicking in the FM view at the FM pose (`t = -180`) sends the stage the wrong way in y. x is correct.

## Cause

Both FM click paths negated the y component before handing it to `fm_stable_move`. The comment on one of them recorded the scope of its own correctness:

```python
point_clicked = (
    point_clicked[0],
    -point_clicked[1],
)  # Y-inverse when t=0, need to make this more robust
```

The negation is a constant. The sign it compensates for is not.

`_view_corrected_stage_movement` adds `pi` to the stage tilt on a compustage, so the `cos(stage_tilt + adj)` term that carries the sign goes from about -1 to about +1 between the SEM and FM poses. Measured, same input, nothing else varied (and independent of `camera_tilt`):

| stage tilt | orientation | `expected_y` | resulting `y_move` |
| --- | --- | --- | --- |
| 0 | SEM | +1 um | **+1.0000 um** |
| -180 | FM | +1 um | **-1.0000 um** |

So a constant negation at the call site can only ever be right at one of the two poses. It was right at `t = 0`; the FM click path runs at `t = -180`.

Only y is affected, which matches the symptom — `CameraImageTransform.apply_to_delta` leaves `dx` alone under `FLIP_Y`.

## Change

Drop the negation from both click paths. The click now goes through with the same convention the beam paths use — y up-positive, straight out of `image_to_microscope_image_coordinates2` into the projection — which leaves the tilt-dependent sign to the projection that knows the tilt, and the display transform to `fm_stable_move`, which already undoes it.

This is the direction FIB-334 asks for:

> If a click in the FM view sends the stage the wrong way, **do not negate at a call site** — five paths now share `fm_stable_move` (two click paths, three tileset steps) plus reprojection, so a local `-1` fixes one and leaves the rest wrong.

Both call sites are removals, so the two click paths stay consistent with each other and with the three tileset paths.

## What this does not settle

Whether the mirror belongs in `mount_transform` (hardware) or in the user's display transform is still open — that is the FIB-334 on-hardware diagnostic. It matters for tile stitching, which reads the driver's frame directly instead of going through this path, so an overview may still come out mirrored in y even with the click correct. Nothing here changes the stitching path.

## Testing

`tests/test_view_corrected_movement.py` — 286 passed. The projection itself is untouched; this only changes what the two widgets feed it.

The wrong-direction symptom was observed on the scope at the FM pose. The fix has not yet been confirmed there -- there are only two possible directions and one negation was removed, so it should be correct, but it wants a click to confirm.