### PR TITLE
Add project_fm_stable_move, the FM counterpart to project_stable_move (FIB-389)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1506,19 +1506,26 @@ class FibsemMicroscope(ABC):
         return self.fm._transform.apply_to_delta(dx, dy)
 
     def _fm_stage_delta(self, dx: float, dy: float) -> FibsemStagePosition:
-        """Relative stage movement for a displacement in the stage-aligned FM image.
+        """Relative stage movement for a displacement seen in the displayed FM image.
 
         The projection shared by :meth:`fm_stable_move` and
         :meth:`project_fm_stable_move`, so the two cannot disagree about where a
         given displacement lands.
 
-        Takes **stage-aligned** image coordinates: the display transform, if any,
-        must already have been undone by the caller. See
-        :meth:`project_fm_stable_move` for why that split exists.
+        Input is in the frame the user is looking at, so the display transform is
+        undone here -- the direct counterpart of `project_stable_move` undoing the
+        beam's scan rotation before projecting. Doing it in the shared helper rather
+        than at one entry point means neither path can skip it.
+
+        That applies to synthesised displacements as much as to clicks. A tile step is
+        expressed in the same frame as the tile it positions, and the mosaic canvas is
+        in display space, because `stitch_tileset` pastes image data that already
+        carries the transform. If the arrangement did not carry it while the content
+        did, the two would disagree and every seam would break.
 
         Args:
-            dx: distance along the x-axis, in stage-aligned image coordinates.
-            dy: distance along the y-axis, in stage-aligned image coordinates.
+            dx: distance along the x-axis, in displayed image coordinates.
+            dy: distance along the y-axis, in displayed image coordinates.
 
         Returns:
             FibsemStagePosition: relative movement, with the y-displacement split
@@ -1529,6 +1536,8 @@ class FibsemMicroscope(ABC):
         """
         if self.fm is None:
             raise ValueError("Fluorescence microscope is not available.")
+
+        dx, dy = self._fm_image_to_stage_delta(dx, dy)
 
         yz_move = self._view_corrected_stage_movement(
             expected_y=dy,
@@ -1549,16 +1558,16 @@ class FibsemMicroscope(ABC):
         `camera_tilt` and the projection itself are already concrete here, so this
         needs no per-driver override.
 
-        Unlike :meth:`fm_stable_move`, this does **not** undo the user's display
-        transform. The undo belongs at the point where a displacement enters from
-        display space -- that is, a click. Callers that synthesise a displacement
-        instead, such as tile stepping computed from the camera's field of view in
-        physical units, were never in display space and have nothing to undo; running
-        them through the undo would make a display preference alter the stage path.
+        Like its beam counterpart, it maps a displacement in the image the user is
+        looking at, so the display transform is undone before projecting -- the same
+        role scan rotation plays for a beam. Both take the displayed frame as their
+        input convention, including for synthesised displacements: `tiled.py` hands
+        `project_stable_move` raw grid offsets and relies on the scan-rotation undo
+        for exactly this reason.
 
         Args:
-            dx: distance along the x-axis, in stage-aligned image coordinates.
-            dy: distance along the y-axis, in stage-aligned image coordinates.
+            dx: distance along the x-axis, in displayed image coordinates.
+            dy: distance along the y-axis, in displayed image coordinates.
             base_position: the position the displacement is measured from.
 
         Returns:
@@ -1605,11 +1614,8 @@ class FibsemMicroscope(ABC):
                 f"(state: {self.fm.objective.state}); the view may not match the sample."
             )
 
-        # The click arrived in display space, so undo the user's transform before
-        # projecting. Displacements that were never in display space must not come
-        # through here -- see project_fm_stable_move.
-        dx, dy = self._fm_image_to_stage_delta(dx, dy)
-
+        # The display transform is undone inside _fm_stage_delta, so this and
+        # project_fm_stable_move share one input convention.
         stage_position = self._fm_stage_delta(dx, dy)
 
         # NOTE: no working-distance restore. That is beam bookkeeping; the objective

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1505,6 +1505,77 @@ class FibsemMicroscope(ABC):
             return dx, dy
         return self.fm._transform.apply_to_delta(dx, dy)
 
+    def _fm_stage_delta(self, dx: float, dy: float) -> FibsemStagePosition:
+        """Relative stage movement for a displacement in the stage-aligned FM image.
+
+        The projection shared by :meth:`fm_stable_move` and
+        :meth:`project_fm_stable_move`, so the two cannot disagree about where a
+        given displacement lands.
+
+        Takes **stage-aligned** image coordinates: the display transform, if any,
+        must already have been undone by the caller. See
+        :meth:`project_fm_stable_move` for why that split exists.
+
+        Args:
+            dx: distance along the x-axis, in stage-aligned image coordinates.
+            dy: distance along the y-axis, in stage-aligned image coordinates.
+
+        Returns:
+            FibsemStagePosition: relative movement, with the y-displacement split
+            across the stage y- and z-axes by the sample tilt.
+
+        Raises:
+            ValueError: if no fluorescence microscope is available.
+        """
+        if self.fm is None:
+            raise ValueError("Fluorescence microscope is not available.")
+
+        yz_move = self._view_corrected_stage_movement(
+            expected_y=dy,
+            view_tilt=np.deg2rad(self.fm.camera_tilt),
+        )
+        return FibsemStagePosition(
+            x=dx, y=yz_move.y, z=yz_move.z, r=0, t=0, coordinate_system="RAW"
+        )
+
+    def project_fm_stable_move(
+        self, dx: float, dy: float, base_position: FibsemStagePosition
+    ) -> FibsemStagePosition:
+        """Where the stage would end up after an FM displacement, without moving.
+
+        The fluorescence counterpart of :meth:`project_stable_move`. That one is
+        abstract and reimplemented by every driver, because it carries beam-specific
+        work -- scan rotation, `beam_type` dispatch. A camera has neither, and both
+        `camera_tilt` and the projection itself are already concrete here, so this
+        needs no per-driver override.
+
+        Unlike :meth:`fm_stable_move`, this does **not** undo the user's display
+        transform. The undo belongs at the point where a displacement enters from
+        display space -- that is, a click. Callers that synthesise a displacement
+        instead, such as tile stepping computed from the camera's field of view in
+        physical units, were never in display space and have nothing to undo; running
+        them through the undo would make a display preference alter the stage path.
+
+        Args:
+            dx: distance along the x-axis, in stage-aligned image coordinates.
+            dy: distance along the y-axis, in stage-aligned image coordinates.
+            base_position: the position the displacement is measured from.
+
+        Returns:
+            FibsemStagePosition: the absolute position the displacement lands on.
+
+        Raises:
+            ValueError: if no fluorescence microscope is available.
+        """
+        delta = self._fm_stage_delta(dx, dy)
+
+        new_position = deepcopy(base_position)
+        new_position.x += delta.x
+        new_position.y += delta.y
+        new_position.z += delta.z
+
+        return new_position
+
     def fm_stable_move(self, dx: float, dy: float) -> FibsemStagePosition:
         """Move the stage by a displacement seen in the fluorescence image.
 
@@ -1534,15 +1605,12 @@ class FibsemMicroscope(ABC):
                 f"(state: {self.fm.objective.state}); the view may not match the sample."
             )
 
+        # The click arrived in display space, so undo the user's transform before
+        # projecting. Displacements that were never in display space must not come
+        # through here -- see project_fm_stable_move.
         dx, dy = self._fm_image_to_stage_delta(dx, dy)
 
-        yz_move = self._view_corrected_stage_movement(
-            expected_y=dy,
-            view_tilt=np.deg2rad(self.fm.camera_tilt),
-        )
-        stage_position = FibsemStagePosition(
-            x=dx, y=yz_move.y, z=yz_move.z, r=0, t=0, coordinate_system="RAW"
-        )
+        stage_position = self._fm_stage_delta(dx, dy)
 
         # NOTE: no working-distance restore. That is beam bookkeeping; the objective
         # keeps focus because the move stays in the sample plane.

--- a/tests/test_view_corrected_movement.py
+++ b/tests/test_view_corrected_movement.py
@@ -601,6 +601,141 @@ class TestFmStableMove:
         assert calls == []
 
 
+# NOTE: these build their own sessions rather than taking the shared `microscope`
+# fixture. A test that contrasts the two mounts needs two distinct microscopes -- with a
+# common parent fixture they alias to one object, the second _configure silently wins,
+# and the contrast the test is written to check quietly stops existing.
+
+
+@pytest.fixture()
+def compustage_fm():
+    """The Arctis geometry: under-grid camera, no pre-tilt, FM pose at t = -180."""
+    scope, _ = utils.setup_session(manufacturer="Demo")
+    _configure(scope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+    scope.fm = FluorescenceMicroscope(parent=scope)
+    return scope
+
+
+@pytest.fixture()
+def offset_fm():
+    """A non-compustage FM mount: optical axis parallel to the FIB column, real pre-tilt.
+
+    The suite otherwise only exercises the compustage geometry, where the absence of a
+    pre-tilt pins z at zero and so hides a whole class of error -- see
+    `test_z_is_only_exercised_by_the_offset_mount`.
+    """
+    scope, _ = utils.setup_session(manufacturer="Demo")
+    _configure(scope, pretilt_deg=35, rotation_deg=0, tilt_deg=0, compustage=False)
+    scope.fm = FluorescenceMicroscope(parent=scope)
+    return scope
+
+
+class TestProjectFmStableMove:
+    """Where an FM displacement lands, without moving the stage."""
+
+    def test_requires_a_fluorescence_microscope(self, microscope):
+        microscope.fm = None
+        with pytest.raises(ValueError):
+            microscope.project_fm_stable_move(1e-6, 1e-6, FibsemStagePosition())
+
+    def test_does_not_move_the_stage(self, compustage_fm):
+        """It is a projection. Nothing may reach the stage."""
+        moved = []
+        compustage_fm.move_stage_relative = lambda p: moved.append(p)  # type: ignore[method-assign]
+        compustage_fm.move_stage_absolute = lambda p: moved.append(p)  # type: ignore[method-assign]
+
+        compustage_fm.project_fm_stable_move(4e-6, 25e-6, FibsemStagePosition(x=0, y=0, z=0))
+
+        assert moved == []
+
+    @pytest.mark.parametrize("mount", ["compustage_fm", "offset_fm"])
+    def test_agrees_with_fm_stable_move(self, request, mount):
+        """The projection and the real move must land in the same place.
+
+        Both go through `_fm_stage_delta`, so this pins them together rather than
+        merely checking each against a hand-computed number.
+        """
+        scope = request.getfixturevalue(mount)
+        scope.fm.set_image_transform(CameraImageTransform.NONE)
+        base = FibsemStagePosition(x=1e-3, y=-2e-3, z=5e-4, r=0, t=0, coordinate_system="RAW")
+
+        moved = []
+        scope.move_stage_relative = lambda p: moved.append(p)  # type: ignore[method-assign]
+        scope.fm_stable_move(dx=4e-6, dy=25e-6)
+
+        projected = scope.project_fm_stable_move(4e-6, 25e-6, base)
+
+        assert projected.x == pytest.approx(base.x + moved[0].x)
+        assert projected.y == pytest.approx(base.y + moved[0].y)
+        assert projected.z == pytest.approx(base.z + moved[0].z)
+
+    def test_is_absolute_not_relative(self, compustage_fm):
+        """The result is measured from the base position, not from zero."""
+        origin = FibsemStagePosition(x=0.0, y=0.0, z=0.0)
+        offset = FibsemStagePosition(x=1e-3, y=2e-3, z=3e-3)
+
+        a = compustage_fm.project_fm_stable_move(4e-6, 25e-6, origin)
+        b = compustage_fm.project_fm_stable_move(4e-6, 25e-6, offset)
+
+        assert b.x - a.x == pytest.approx(offset.x)
+        assert b.y - a.y == pytest.approx(offset.y)
+        assert b.z - a.z == pytest.approx(offset.z)
+
+    def test_leaves_the_base_position_untouched(self, compustage_fm):
+        """It returns a new position rather than mutating the caller's."""
+        base = FibsemStagePosition(x=1e-3, y=2e-3, z=3e-3)
+
+        compustage_fm.project_fm_stable_move(4e-6, 25e-6, base)
+
+        assert (base.x, base.y, base.z) == (1e-3, 2e-3, 3e-3)
+
+    def test_does_not_undo_the_display_transform(self, compustage_fm):
+        """Deliberately unlike fm_stable_move -- and the whole point of the split.
+
+        Input is stage-aligned, so a display preference must not reach it. Callers that
+        synthesise a displacement (tile steps, computed from the camera field of view in
+        physical units) were never in display space; routing them through the undo is
+        what lets a dropdown alter the stage path.
+        """
+        base = FibsemStagePosition(x=0.0, y=0.0, z=0.0)
+        results = []
+        for transform in CameraImageTransform:
+            compustage_fm.fm.set_image_transform(transform)
+            results.append(compustage_fm.project_fm_stable_move(4e-6, 25e-6, base))
+
+        assert all(r.x == pytest.approx(results[0].x) for r in results)
+        assert all(r.y == pytest.approx(results[0].y) for r in results)
+        assert all(r.z == pytest.approx(results[0].z) for r in results)
+
+    def test_z_is_only_exercised_by_the_offset_mount(self, compustage_fm, offset_fm):
+        """Why the offset fixture exists.
+
+        Compustage has no pre-tilt, so z stays 0 and relative-step accumulation only
+        drifts in y. An offset mount puts a real z on every step, which is what makes
+        accumulating them a focus problem rather than a positioning one.
+        """
+        base = FibsemStagePosition(x=0.0, y=0.0, z=0.0)
+
+        flat = compustage_fm.project_fm_stable_move(0.0, 25e-6, base)
+        tilted = offset_fm.project_fm_stable_move(0.0, 25e-6, base)
+
+        assert flat.z == pytest.approx(0.0, abs=1e-18)
+        assert abs(tilted.z) > 1e-9
+
+    def test_offset_mount_uses_the_ion_column_tilt(self, offset_fm):
+        """The offset optical axis is parallel to the FIB column, so it must project like one."""
+        assert offset_fm.fm.camera_tilt == pytest.approx(offset_fm.system.ion.column_tilt)
+
+        base = FibsemStagePosition(x=0.0, y=0.0, z=0.0)
+        projected = offset_fm.project_fm_stable_move(0.0, 25e-6, base)
+        expected = offset_fm._view_corrected_stage_movement(
+            expected_y=25e-6, view_tilt=np.deg2rad(offset_fm.system.ion.column_tilt)
+        )
+
+        assert projected.y == pytest.approx(expected.y)
+        assert projected.z == pytest.approx(expected.z)
+
+
 class TestFmConsumersUseTheFmProjection:
     """Everything that moves from a fluorescence image must use the FM projection.
 

--- a/tests/test_view_corrected_movement.py
+++ b/tests/test_view_corrected_movement.py
@@ -649,14 +649,18 @@ class TestProjectFmStableMove:
         assert moved == []
 
     @pytest.mark.parametrize("mount", ["compustage_fm", "offset_fm"])
-    def test_agrees_with_fm_stable_move(self, request, mount):
+    @pytest.mark.parametrize("transform", list(CameraImageTransform))
+    def test_agrees_with_fm_stable_move(self, request, mount, transform):
         """The projection and the real move must land in the same place.
 
         Both go through `_fm_stage_delta`, so this pins them together rather than
-        merely checking each against a hand-computed number.
+        merely checking each against a hand-computed number. Swept over the display
+        transform as well as the mount because the two now share one input convention:
+        if either stopped undoing the transform, or started undoing it twice, this
+        breaks.
         """
         scope = request.getfixturevalue(mount)
-        scope.fm.set_image_transform(CameraImageTransform.NONE)
+        scope.fm.set_image_transform(transform)
         base = FibsemStagePosition(x=1e-3, y=-2e-3, z=5e-4, r=0, t=0, coordinate_system="RAW")
 
         moved = []
@@ -689,23 +693,30 @@ class TestProjectFmStableMove:
 
         assert (base.x, base.y, base.z) == (1e-3, 2e-3, 3e-3)
 
-    def test_does_not_undo_the_display_transform(self, compustage_fm):
-        """Deliberately unlike fm_stable_move -- and the whole point of the split.
+    def test_undoes_the_display_transform(self, compustage_fm):
+        """Same input convention as fm_stable_move: the frame the user is looking at.
 
-        Input is stage-aligned, so a display preference must not reach it. Callers that
-        synthesise a displacement (tile steps, computed from the camera field of view in
-        physical units) were never in display space; routing them through the undo is
-        what lets a dropdown alter the stage path.
+        The counterpart of project_stable_move undoing the beam's scan rotation, and it
+        applies to synthesised displacements just as much as to clicks -- `tiled.py`
+        hands project_stable_move raw grid offsets and relies on that undo. A tile step
+        is in the same frame as the tile it positions, and the mosaic canvas is in
+        display space because stitch_tileset pastes content that already carries the
+        transform. Arrangement and content have to agree or every seam breaks.
         """
         base = FibsemStagePosition(x=0.0, y=0.0, z=0.0)
-        results = []
-        for transform in CameraImageTransform:
-            compustage_fm.fm.set_image_transform(transform)
-            results.append(compustage_fm.project_fm_stable_move(4e-6, 25e-6, base))
 
-        assert all(r.x == pytest.approx(results[0].x) for r in results)
-        assert all(r.y == pytest.approx(results[0].y) for r in results)
-        assert all(r.z == pytest.approx(results[0].z) for r in results)
+        def project(transform):
+            compustage_fm.fm.set_image_transform(transform)
+            return compustage_fm.project_fm_stable_move(4e-6, 25e-6, base)
+
+        none = project(CameraImageTransform.NONE)
+        flip_x = project(CameraImageTransform.FLIP_X)
+        flip_y = project(CameraImageTransform.FLIP_Y)
+
+        assert flip_x.x == pytest.approx(-none.x), "flip in x must reverse the x move"
+        assert flip_x.y == pytest.approx(none.y), "flip in x must leave y alone"
+        assert flip_y.y == pytest.approx(-none.y), "flip in y must reverse the y move"
+        assert flip_y.x == pytest.approx(none.x), "flip in y must leave x alone"
 
     def test_z_is_only_exercised_by_the_offset_mount(self, compustage_fm, offset_fm):
         """Why the offset fixture exists.


### PR DESCRIPTION
There was no way to ask where an FM displacement would land without actually moving the stage to find out. First of five in the [FM Overview Acquisition](https://linear.app/fibsemos/project/fm-overview-acquisition-d020be881661) project.

Two commits: the method, then a correction to its input convention (see the last section — worth reading before reviewing, since the first commit's docstrings argue the opposite of the final behaviour).

## Why it needs no per-driver implementations

`project_stable_move` is abstract on `FibsemMicroscope` and reimplemented in every driver — Thermo, Tescan, odemis, simulator, `_stage`, plus server/client — because it carries beam-specific work: scan rotation, `beam_type` dispatch.

The FM version carries no `beam_type`, and `camera_tilt` and `_view_corrected_stage_movement` are already concrete on the base class. One method, one place, both mounts.

The projection itself is not new. PR #194 parameterised `_view_corrected_stage_movement` by view tilt precisely so a camera is just another view: electron = 0, ion = its `column_tilt`, camera = its `camera_tilt`.

## Structure

`_fm_stage_delta` holds what both entry points share, so the moving and non-moving paths cannot drift apart:

```
_fm_stage_delta(dx, dy)                    undo display transform -> project
├── fm_stable_move                         ... -> move relative
└── project_fm_stable_move(.., base)       ... -> add to a base position
```

`fm_stable_move` is behaviour-unchanged — its existing tests pass untouched.

## Input convention

Both entry points take a displacement measured in **the image the user is looking at**, matching `project_stable_move`:

| | undone before projecting |
| -- | -- |
| `project_stable_move` | scan rotation — the coils rotate the raster |
| `project_fm_stable_move` | `CameraImageTransform` — the user's display flip |

`mount_transform` is undone by neither. It is applied inside the driver to *define* the stage-aligned frame, so reversing it would return to raw sensor coordinates.

## An offset-FM fixture, which the suite lacked entirely

Everything previously ran against the compustage geometry, where the absence of a pre-tilt holds `z` at zero and hides a whole class of error. An offset mount puts a real `z` on every step — which is what makes accumulating relative steps a *focus* problem rather than a positioning one, and why this projection is a correctness fix there rather than plumbing.

`test_z_is_only_exercised_by_the_offset_mount` asserts `z == 0` on compustage and `|z| > 0` on offset, so the distinction can't quietly stop being true.

Both fixtures build their own sessions rather than sharing one. With a common parent fixture they alias to a single object, the second `_configure` silently wins, and a test written to contrast the two mounts ends up comparing one microscope with itself. That is commented in place, since FIB-391 reuses both.

## The correction in the second commit

The first commit had `project_fm_stable_move` take *stage-aligned* deltas and deliberately **not** undo the display transform, reasoning that only clicks arrive in display space while synthesised displacements like tile steps do not. That was wrong on both counts, and reviewers will find its docstrings arguing for the opposite of the final behaviour.

**`tiled.py` already hands `project_stable_move` raw grid offsets** straight out of `compute_tile_grid` — synthesised, never clicked — and the scan-rotation undo applies to them. There is no "synthesised deltas skip the undo" rule to mirror.

**The mosaic canvas is in display space.** `stitch_tileset` pastes image content that already carries the transform, baked in by `_apply_image_transform` at acquisition, so tile content and tile arrangement must be in the same frame. If the arrangement did not carry it while the content did, every seam would break.

Hardware agrees: a 2×2 at `FLIP_XY` and one at `None` come out a **coherent** 180° rotation of each other with identical seam structure. The only break in either was the row direction fixed in #226, which was transform-independent. A spurious coupling would have scrambled the `FLIP_XY` mosaic at every seam rather than merely rotating it.

`test_does_not_undo_the_display_transform` asserted the wrong invariant and is replaced by `test_undoes_the_display_transform`. The round-trip test now sweeps all four transform values as well as both mounts, so it fails if either path stops undoing the transform or starts undoing it twice.

This also strikes one item from FIB-391's scope: what that issue called a "`CameraImageTransform` leak into the scan pattern" is required coupling, not a defect. What remains real there is that a mosaic's canvas-to-stage mapping depends on the transform in force when it was captured, so that has to be recorded in its metadata.

## Testing

Full suite: **1473 passed, 24 skipped** (pre-existing plugin-fixture skips).

Not verified on hardware. Offset FM is code-correct-by-construction for now; when scope time comes, the FM ≡ ION equivalence is directly testable there in a way it is not on Arctis, because the non-zero pre-tilt makes a `camera_tilt` error separable from a mount flip. Tracked on FIB-334.