### PR TITLE
Move is_inside_image_bounds out of the napari UI module (FIB-390)

### DIFF
--- a/fibsem/conversions.py
+++ b/fibsem/conversions.py
@@ -210,3 +210,28 @@ def convert_point_from_metres_to_pixel(point: Point, pixelsize: float) -> Point:
         y=convert_metres_to_pixels(point.y, pixelsize),
     )
     return point_px
+
+
+def is_inside_image_bounds(coords: Tuple[float, float], shape: Tuple[int, int]) -> bool:
+    """Check if the coordinates are inside the image bounds.
+
+    Args:
+        coords (Tuple[float, float]): y, x coordinates
+        shape (Tuple[int, int]): image shape (y, x)
+
+    Returns:
+        bool: True if inside image bounds, False otherwise.
+
+    NOTE: the lower bound is exclusive, so row/column 0 reports as outside even
+    though it is a real pixel. Preserved verbatim from the original in
+    `fibsem.ui.napari.utilities`; callers may rely on it, so it is pinned by test
+    rather than corrected here.
+    """
+    ycoord, xcoord = coords
+
+    if (ycoord > 0 and ycoord < shape[0]) and (
+        xcoord > 0 and xcoord < shape[1]
+    ):
+        return True
+
+    return False

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -12,6 +12,7 @@ import numpy as np
 from matplotlib.figure import Figure
 
 from fibsem import acquire, conversions
+from fibsem.conversions import is_inside_image_bounds
 from fibsem.constants import DATETIME_FILE
 from fibsem.microscope import FibsemMicroscope
 from dataclasses import dataclass
@@ -620,8 +621,6 @@ def reproject_stage_positions_onto_image(
         bound: Whether to only return points inside the image.
     Returns:
         The reprojected stage positions on the image plane."""
-    from fibsem.ui.napari.utilities import is_inside_image_bounds
-
     # reprojection of positions onto image coordinates
     points = []
     for pos in positions:
@@ -722,8 +721,6 @@ def reproject_stage_positions_onto_image2(
         bound: Whether to only return points inside the image.
     Returns:
         The reprojected stage positions on the image plane."""
-    from fibsem.ui.napari.utilities import is_inside_image_bounds
-
     # reprojection of positions onto image coordinates
     points = []
     for pos in positions:
@@ -773,7 +770,6 @@ def plot_stage_positions_on_image(
         color: The color of the points. (None -> default colour cycle)
     Returns:
         The matplotlib figure."""
-    from fibsem.ui.napari.utilities import is_inside_image_bounds
     if image.metadata is None or image.metadata.microscope_state is None:
         raise ValueError("Image metadata or microscope state is not set. Cannot reproject stage positions.")
 
@@ -853,7 +849,6 @@ def plot_minimap(
         figsize: Figure size in inches (default: (15, 15))
     Returns:
         The matplotlib figure."""
-    from fibsem.ui.napari.utilities import is_inside_image_bounds
     if image.metadata is None or image.metadata.microscope_state is None:
         raise ValueError("Image metadata or microscope state is not set. Cannot reproject stage positions.")
 

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -67,12 +67,12 @@ from fibsem.ui.napari.properties import (
     GRIDBAR_IMAGE_LAYER_PROPERTIES,
     OVERVIEW_IMAGE_LAYER_PROPERTIES,
 )
+from fibsem.conversions import is_inside_image_bounds
 from fibsem.ui.napari.utilities import (
     NapariShapeOverlay,
     create_circle_shape,
     create_crosshair_shape,
     create_rectangle_shape,
-    is_inside_image_bounds,
     update_text_overlay,
 )
 from fibsem.ui.widgets.custom_widgets import (

--- a/fibsem/ui/fm/widgets/minimap_plot_widget.py
+++ b/fibsem/ui/fm/widgets/minimap_plot_widget.py
@@ -14,9 +14,9 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 from fibsem import conversions
+from fibsem.conversions import is_inside_image_bounds
 from fibsem.structures import FibsemImage, FibsemStagePosition, Point
 from fibsem.imaging.tiled import reproject_stage_positions_onto_image2
-from fibsem.ui.napari.utilities import is_inside_image_bounds
 try:
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
     from matplotlib.figure import Figure

--- a/fibsem/ui/napari/utilities.py
+++ b/fibsem/ui/napari/utilities.py
@@ -192,23 +192,6 @@ def draw_scalebar_in_napari(
         viewer.layers[SCALEBAR_LAYER_NAME].text = scale_bar_txt
 
 
-def is_inside_image_bounds(coords: Tuple[float, float], shape: Tuple[int, int]) -> bool:
-    """Check if the coordinates are inside the image bounds.
-    Args:
-        coords (Tuple[float, float]): y, x coordinates
-        shape (Tuple[int, int]): image shape (y, x)
-    Returns:
-        bool: True if inside image bounds, False otherwise."""
-    ycoord, xcoord = coords
-
-    if (ycoord > 0 and ycoord < shape[0]) and (
-        xcoord > 0 and xcoord < shape[1]
-    ):
-        return True
-    
-    return False
-
-
 def is_position_inside_layer(position: Tuple[float, float], target_layer) -> bool:
     """Check if the position of the event is inside the bounds of the target layer.
     Args:

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,0 +1,77 @@
+"""Tests for fibsem.conversions.
+
+`is_inside_image_bounds` moved here from `fibsem.ui.napari.utilities`. It is pure
+integer geometry with no napari content, and living in a module that imports napari,
+`FibsemMicroscope` and `TescanMicroscope` at the top forced `imaging/tiled.py` to
+import it lazily inside four separate function bodies to avoid the cycle.
+
+These pin the behaviour as it was, including the off-by-one below, so the move is
+provably inert.
+"""
+
+import pytest
+
+from fibsem.conversions import is_inside_image_bounds
+
+SHAPE = (100, 200)  # (y, x)
+
+
+@pytest.mark.parametrize(
+    "coords",
+    [
+        (50, 100),   # middle
+        (1, 1),      # just inside the low corner
+        (99, 199),   # just inside the high corner
+        (50.5, 100.5),  # sub-pixel
+    ],
+)
+def test_inside(coords):
+    assert is_inside_image_bounds(coords, SHAPE) is True
+
+
+@pytest.mark.parametrize(
+    "coords",
+    [
+        (-1, 50),     # above
+        (100, 50),    # below: shape[0] is exclusive
+        (50, -1),     # left
+        (50, 200),    # right: shape[1] is exclusive
+        (1000, 1000), # far outside
+    ],
+)
+def test_outside(coords):
+    assert is_inside_image_bounds(coords, SHAPE) is False
+
+
+@pytest.mark.parametrize("coords", [(0, 50), (50, 0), (0, 0)])
+def test_zero_reports_as_outside(coords):
+    """The lower bound is exclusive, so row/column 0 is 'outside' despite being real.
+
+    Almost certainly an off-by-one -- the upper bound is exclusive, as it should be,
+    but the lower one is too. Pinned rather than fixed: four call sites in
+    `imaging/tiled.py` and several in the minimap widgets use this to decide whether
+    to draw a marker, and silently widening the accepted region during a file move is
+    how a move stops being inert. Worth correcting deliberately, separately.
+    """
+    assert is_inside_image_bounds(coords, SHAPE) is False
+
+
+def test_shape_is_y_x_not_x_y():
+    """coords and shape are both (y, x); a transposed shape changes the answer."""
+    assert is_inside_image_bounds((50, 150), (100, 200)) is True
+    assert is_inside_image_bounds((50, 150), (200, 100)) is False
+
+
+def test_is_importable_without_napari():
+    """The point of the move: this must not drag a UI stack in behind it."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-c",
+         "import sys; from fibsem.conversions import is_inside_image_bounds; "
+         "assert 'napari' not in sys.modules, 'napari was imported'; "
+         "assert 'fibsem.microscope' not in sys.modules, 'fibsem.microscope was imported'"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Groundwork for FIB-390. Landing separately because it touches a UI file and the extraction PR should stay a pure code move.

## The problem

`is_inside_image_bounds` is a six-line integer bounds check with no napari content:

```python
if (ycoord > 0 and ycoord < shape[0]) and (xcoord > 0 and xcoord < shape[1]):
```

It lived in `fibsem/ui/napari/utilities.py`, which imports `napari`, `FibsemMicroscope` and `TescanMicroscope` at module level.

`imaging/tiled.py` needs it in four functions — both `reproject_stage_positions_onto_image` variants, `plot_stage_positions_on_image`, and `plot_minimap` — and imported it **lazily inside each function body** to avoid dragging that in:

```python
def reproject_stage_positions_onto_image(...):
    """..."""
    from fibsem.ui.napari.utilities import is_inside_image_bounds
```

The workaround held, but it left those functions with a hidden runtime dependency on a UI stack they have no other use for. It also blocks FIB-390: those functions are pure and belong in a microscope-free geometry module, and they can't go there while reaching into a napari module at call time.

## The change

Moved to `fibsem.conversions`, alongside the other pure image-coordinate helpers (`image_to_microscope_image_coordinates`, `convert_metres_to_pixels`, …). That module imports neither napari nor `fibsem.microscope` — verified, not assumed.

The four lazy imports collapse to one module-level import, and the two UI callers (`FibsemMinimapWidget`, `minimap_plot_widget`) import from the new home. Nothing else changes.

After: `import fibsem.imaging.tiled` pulls in **no napari** at module load or call time.

## One thing deliberately not fixed

The upper bound is exclusive, as it should be — but so is the lower one, so **row/column 0 reports as outside** despite being a real pixel. That looks like an off-by-one and probably is.

It is pinned by `test_zero_reports_as_outside` rather than corrected. Four call sites in `tiled.py` and several in the minimap widgets use this to decide whether to draw a marker, and silently widening the accepted region during a file move is how a move stops being inert. Worth fixing deliberately, on its own, where the behaviour change is the point of the PR rather than a side effect.

## Testing

New `tests/test_conversions.py`: inside/outside cases, sub-pixel coordinates, the `(y, x)` argument order, the zero-is-outside quirk, and a subprocess check that importing the function pulls in neither napari nor `fibsem.microscope` — the property this PR exists to establish, kept as a regression guard.

Full suite including `fibsem/imaging/tests/`: **1487 passed, 24 skipped** (pre-existing plugin-fixture skips).