### PR TITLE
Stop warning about a disconnected microscope on every launch

### DIFF
--- a/fibsem/ui/napari/utilities.py
+++ b/fibsem/ui/napari/utilities.py
@@ -404,6 +404,17 @@ def update_text_overlay(viewer: napari.Viewer, microscope: FibsemMicroscope,
         viewer: napari viewer object
         microscope: FibsemMicroscope instance
     """
+    if microscope is None:
+        # Expected before a microscope is connected, not an error. FibsemUI builds the
+        # minimap widget during setup, and that widget's `microscope` property reads
+        # through to its parent, which is None until connect. The widget already
+        # treats that as a normal state (`if self.microscope is None: return`); this
+        # was the one path that passed it through to be dereferenced, so every launch
+        # logged "Error updating text overlay: 'NoneType' object has no attribute
+        # '_stage_position'".
+        viewer.text_overlay.text = "<STAGE POSITION UNAVAILABLE>"
+        return
+
     try:
 
         if isinstance(microscope, TescanMicroscope):

--- a/tests/ui/test_text_overlay.py
+++ b/tests/ui/test_text_overlay.py
@@ -1,0 +1,66 @@
+"""No microscope is a normal state for the text overlay, not an error.
+
+`FibsemUI` builds `FibsemMinimapWidget` during setup, before any connection. That
+widget's `microscope` property reads through to its parent, so it is None at that
+point -- which the widget already handles everywhere else with
+`if self.microscope is None: return`. `update_text_overlay` was the one path that
+passed it through to be dereferenced, so every launch logged:
+
+    WARNING:root:Error updating text overlay: 'NoneType' object has no attribute
+    '_stage_position'
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+napari = pytest.importorskip("napari", reason="text overlay is a napari widget")
+
+from fibsem.ui.napari.utilities import update_text_overlay  # noqa: E402
+
+UNAVAILABLE = "<STAGE POSITION UNAVAILABLE>"
+
+
+@pytest.fixture()
+def viewer():
+    """Just enough of a napari viewer for the overlay path."""
+    return SimpleNamespace(
+        text_overlay=SimpleNamespace(text="", visible=False, position=None)
+    )
+
+
+def test_no_microscope_does_not_warn(viewer, caplog):
+    with caplog.at_level(logging.WARNING):
+        update_text_overlay(viewer, None)
+
+    assert caplog.records == [], (
+        "a disconnected microscope is an expected startup state; warning about it "
+        f"on every launch is noise. Got: {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+def test_no_microscope_shows_the_unavailable_text(viewer):
+    """Same text the failure path already produced, so the display is unchanged."""
+    update_text_overlay(viewer, None)
+
+    assert viewer.text_overlay.text == UNAVAILABLE
+
+
+def test_a_real_failure_still_warns(viewer, caplog):
+    """The guard must not become a blanket silencer.
+
+    A microscope that raises when queried is a genuine problem and should still be
+    reported, so narrowing the None case must not swallow the rest.
+    """
+
+    class Broken:
+        @property
+        def _stage_position(self):
+            raise RuntimeError("comms lost")
+
+    with caplog.at_level(logging.WARNING):
+        update_text_overlay(viewer, Broken())
+
+    assert any("Error updating text overlay" in r.getMessage() for r in caplog.records)
+    assert viewer.text_overlay.text == UNAVAILABLE


### PR DESCRIPTION
Every launch logs this, before anything has gone wrong:

```
WARNING:root:Error updating text overlay: 'NoneType' object has no attribute '_stage_position'
```

## Cause

`FibsemUI` builds `FibsemMinimapWidget` during setup — [FibsemUI.py:59](fibsem/ui/FibsemUI.py:59) — before any microscope is connected. That widget's `microscope` is a **property** reading through to its parent:

```python
@property
def microscope(self) -> FibsemMicroscope:
    return self.parent_widget.microscope
```

so it is `None` at that point.

The widget already treats that as a perfectly normal state — `draw_blank_image` and its sibling both open with `if self.microscope is None: return`. The `update_text_overlay` call at [FibsemMinimapWidget.py:784](fibsem/ui/FibsemMinimapWidget.py:784) is the one path that passes it straight through, into a function that dereferences it inside a broad `except Exception` and logs the result as a warning. An ordinary startup condition ends up reported as an error.

## Fix

Handle it as what it is: there is nothing to display yet.

The text is unchanged — `"<STAGE POSITION UNAVAILABLE>"`, exactly what the failure path already produced — so the UI looks identical. Only the spurious warning goes away.

The guard is deliberately narrow. A microscope that *raises* when queried is a genuine problem and must still be reported, so the `except` stays and there's a test asserting it still fires. The point is to stop reporting the one condition that is expected, not to quieten the handler.

## Testing

`tests/ui/test_text_overlay.py` — three tests: no warning when there's no microscope, the unavailable text is still shown, and a microscope that raises still warns.

Verified the first one fails without the fix, reproducing the reported string verbatim:

```
WARNING  root:utilities.py:435 Error updating text overlay: 'NoneType' object has no attribute '_stage_position'
```

The other two pass either way, which is correct — they pin behaviour that must *not* change.

Full suite: **1490 passed, 24 skipped** (pre-existing plugin-fixture skips).