### PR TITLE
Drop the tiled star-import from fibsem.imaging

### DIFF
--- a/fibsem/imaging/__init__.py
+++ b/fibsem/imaging/__init__.py
@@ -1,5 +1,4 @@
 from fibsem.imaging.spot import *
 from fibsem.autofunctions.gamma import auto_gamma, apply_gamma, apply_clahe
 from fibsem.imaging.masks import *
-from fibsem.imaging.tiled import *
 from fibsem.imaging.utils import *


### PR DESCRIPTION
One-line deletion in `fibsem/imaging/__init__.py`. **Surface cleanup only — read the scope note before assuming it does more.**

## What it removes

`from fibsem.imaging.tiled import *` put **42 public names** onto `fibsem.imaging`. `tiled.py` has no `__all__`, so the star took its own imports along with the intended API:

```
FibsemMicroscope, BeamType, Dict, List, Optional, Tuple, acquire, conversions,
Figure, np, annotations, DATETIME_FILE, ...
```

`fibsem.imaging.annotations` is currently a valid attribute access. None of that was ever intended to be public.

## Nothing consumes it

Every `.py` in the repo was scanned for `from fibsem.imaging import <name>` and `fibsem.imaging.<name>` across all 42 names, plus `from fibsem.imaging import *`. **Zero hits.**

`fibsem.imaging.tiled` is untouched and remains how everything already imports this code — 15 modules do, every one of them naming the module (`from fibsem.imaging import tiled`) or the symbol directly.

## Scope note — this does not make imports cheaper

Worth stating plainly, because that was the original reason for raising it and it does not hold:

| | modules loaded | `fibsem.microscope` imported |
| -- | -- | -- |
| before | 1323 | yes |
| after | 1316 | **still yes** |

`spot`, `masks` and `utils` each pull in `fibsem.microscope` independently, so removing tiled's star-import changes essentially nothing about the cost of `import fibsem.imaging`. It also does not make a runtime import-independence check possible for the tiling package, which is why that check stayed static in #229.

Making `fibsem.imaging` genuinely cheap to import means handling all four star-imports, each needing the same zero-consumer analysis. That is a real API change and separate work.

So: worth doing for the accidental surface, not for performance.

## Testing

Full suite including `fibsem/imaging/tests/`: **1515 passed, 24 skipped** (pre-existing plugin-fixture skips).