### PR TITLE
Move FM tiles to absolute positions from the shared grid (FIB-391)

### DIFF
--- a/fibsem/conversions.py
+++ b/fibsem/conversions.py
@@ -223,9 +223,10 @@ def is_inside_image_bounds(coords: Tuple[float, float], shape: Tuple[int, int]) 
         bool: True if inside image bounds, False otherwise.
 
     NOTE: the lower bound is exclusive, so row/column 0 reports as outside even
-    though it is a real pixel. Preserved verbatim from the original in
-    `fibsem.ui.napari.utilities`; callers may rely on it, so it is pinned by test
-    rather than corrected here.
+    though it is a real pixel. This is intentional -- callers use it to decide
+    whether to draw a marker, and widening the region would change what they
+    render. It reads like an off-by-one, so it is pinned by test to stop it being
+    tidied away.
     """
     ycoord, xcoord = coords
 

--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -11,6 +11,7 @@ import matplotlib.patches as patches
 
 from fibsem import utils
 from fibsem.fm.calibration import run_autofocus
+from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.structures import (
     AutoFocusMode,
@@ -492,28 +493,46 @@ def acquire_tileset(
             logging.info("Initial autofocus cancelled")
             return []  # Return empty list if cancelled
 
-    # Calculate starting position (top-left corner of grid).
+    # Lay the grid out once, with the shared tiling geometry, and project every tile
+    # to an absolute stage position before moving anywhere.
     #
-    # Row 0 is the top of the mosaic, so it sits at the most *positive* y offset and
-    # later rows step down -- the same convention `imaging/tiled.py` uses for beam
-    # tilesets ("negate: stage y axis is inverted"). Both express their steps in image
-    # coordinates and hand them to the same projection, so the two tilers have to agree
-    # on the row direction or their mosaics disagree. `stitch_tileset` places row 0 at
-    # canvas y=0 regardless, so getting this backwards reverses the row order.
-    start_offset_x = -(cols - 1) * step_x / 2
-    start_offset_y = (rows - 1) * step_y / 2
+    # Previously this walked the grid with relative steps. That accumulated error over
+    # the traversal, and on an offset mount each step carries a real z component -- so
+    # the drift was in the focal plane, not just the position. Compustage hides it,
+    # having no pre-tilt and therefore z == 0 throughout.
+    #
+    # Using the shared layout also means the row direction lives in one place rather
+    # than in this loop's step signs. Row 0 is the top of the mosaic and later rows
+    # step down; `stitch_tileset` paints row 0 at canvas y=0 regardless, so the two
+    # have to agree. They disagreed once already (#226).
+    tiles = compute_tile_grid_from_fov(
+        nrows=rows,
+        ncols=cols,
+        fov_x=fov_x,
+        fov_y=fov_y,
+        image_width=image_width,
+        image_height=image_height,
+        overlap=tile_overlap,
+    )
 
-    # Move to starting position
+    # compute_tile_grid_from_fov measures from the top-left tile; shift so the grid is
+    # centred on where the stage is now. Same convention as TiledAcquisitionRunner.
+    grid_offset_x = (cols - 1) * step_x / 2
+    grid_offset_y = (rows - 1) * step_y / 2
+
+    tile_stage_positions = {
+        (tile.row, tile.col): microscope.project_fm_stable_move(
+            dx=tile.dx - grid_offset_x,
+            dy=tile.dy + grid_offset_y,
+            base_position=initial_position,
+        )
+        for tile in tiles
+    }
+
     microscope.fm.acquisition_progress_signal.emit({
         "state": "moving",
         "task": "tileset",
     })
-
-    # Steps are expressed in the fluorescence image, so they are projected through the
-    # camera's own axis tilt rather than a beam's. Stepping with beam_type=ELECTRON
-    # used the SEM projection, which foreshortens differently from the camera on an
-    # offset mount and so mis-scaled the y pitch between tiles.
-    microscope.fm_stable_move(dx=start_offset_x, dy=start_offset_y)
 
     # Initialize results array
     tileset = []
@@ -567,10 +586,13 @@ def acquire_tileset(
                     return tileset
 
             for col in range(cols):
-                # Check for cancellation before each tile
+                # Check for cancellation before moving, so a cancel skips the travel
                 if stop_event and stop_event.is_set():
                     logging.info("Tileset acquisition cancelled during tile acquisition")
                     return tileset
+
+                # Absolute, from the grid computed up front -- no accumulation.
+                microscope.safe_absolute_stage_movement(tile_stage_positions[(row, col)])
 
                 microscope.fm.objective.move_absolute(initial_objective_position)
 
@@ -642,13 +664,13 @@ def acquire_tileset(
 
                 row_images.append(tile_image)
 
-                # Move to next column position (except for last column)
+                # Movement to the next tile happens at the top of its own iteration,
+                # from the precomputed absolute positions.
                 if col < cols - 1:
                     microscope.fm.acquisition_progress_signal.emit({
                     "state": "moving",
                     "task": "tileset",
                     })
-                    microscope.fm_stable_move(dx=step_x, dy=0)
 
             tileset.append(row_images)
 
@@ -658,9 +680,6 @@ def acquire_tileset(
                     "state": "moving",
                     "task": "tileset",
                 })
-                # Return to first column of next row, and step *down* one row (see the
-                # row-direction note where start_offset_y is computed).
-                microscope.fm_stable_move(dx=-(cols - 1) * step_x, dy=-step_y)
 
         # save the parameters in a metadata json file if save_directory is provided
         if save_directory is not None:

--- a/fibsem/imaging/tiling/geometry.py
+++ b/fibsem/imaging/tiling/geometry.py
@@ -52,17 +52,60 @@ def compute_tile_grid(settings: OverviewAcquisitionSettings) -> list[TilePositio
     image_width, image_height = settings.image_settings.resolution
     tile_fov_x = settings.image_settings.hfw
     tile_fov_y = tile_fov_x * (image_height / image_width)
-    overlap = settings.overlap
 
-    dx_step = tile_fov_x * (1 - overlap)
-    dy_step = tile_fov_y * (1 - overlap)
+    return compute_tile_grid_from_fov(
+        nrows=settings.nrows,
+        ncols=settings.ncols,
+        fov_x=tile_fov_x,
+        fov_y=tile_fov_y,
+        image_width=image_width,
+        image_height=image_height,
+        overlap=settings.overlap,
+    )
+
+
+def compute_tile_grid_from_fov(
+    nrows: int,
+    ncols: int,
+    fov_x: float,
+    fov_y: float,
+    image_width: int,
+    image_height: int,
+    overlap: float,
+) -> list[TilePosition]:
+    """Compute the tile grid from a field of view given directly.
+
+    The same layout as :func:`compute_tile_grid`, for callers that do not have an
+    `OverviewAcquisitionSettings`. A fluorescence camera has a real field of view in
+    both axes -- pixel size times resolution -- rather than a horizontal field width
+    with the vertical inferred from the aspect ratio, so it cannot go through the
+    beam-shaped settings object without inventing an `hfw`.
+
+    Keeping one implementation matters more than the convenience: the beam tiler and
+    the fluorescence tiler stepping rows in opposite directions is what produced a
+    reversed mosaic (#226), and separate layout code is how that happened.
+
+    Args:
+        nrows: Number of tile rows.
+        ncols: Number of tile columns.
+        fov_x: Width of one tile, in metres.
+        fov_y: Height of one tile, in metres.
+        image_width: Tile width in pixels.
+        image_height: Tile height in pixels.
+        overlap: Fractional overlap between adjacent tiles.
+
+    Returns:
+        Flat list of TilePosition objects in row-major order (top-left first).
+    """
+    dx_step = fov_x * (1 - overlap)
+    dy_step = fov_y * (1 - overlap)
 
     eff_w = max(1, int(round(image_width  * (1 - overlap))))
     eff_h = max(1, int(round(image_height * (1 - overlap))))
 
     tiles = []
-    for i in range(settings.nrows):
-        for j in range(settings.ncols):
+    for i in range(nrows):
+        for j in range(ncols):
             tiles.append(TilePosition(
                 row=i, col=j,
                 dx=j * dx_step,

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -1006,49 +1006,28 @@ def test_acquire_multiple_overviews(fm_microscope):
 # ---------------------------------------------------------------------------
 
 
-def _record_tile_moves(microscope, monkeypatch):
-    """Run a tileset with the stage and camera stubbed, returning the moves made.
+def _record_tile_positions(microscope, monkeypatch):
+    """Run a tileset with the stage and camera stubbed, returning where tiles land.
 
-    Returns a list of (dx, dy) passed to fm_stable_move, in call order.
+    Records the absolute stage positions the acquisition visits, in acquisition order,
+    rather than the movement calls it makes to get there. An earlier version of these
+    tests recorded `fm_stable_move` calls, which pinned the stepping *mechanism*: they
+    broke the moment stepping moved to precomputed absolute positions, even though
+    every tile still landed in exactly the same place. Where the tiles end up is the
+    thing worth asserting, and it survives the implementation changing underneath.
     """
-    moves = []
+    positions = []
 
-    def fake_move(dx, dy):
-        moves.append((dx, dy))
-        return microscope.get_stage_position()
+    def fake_move(position):
+        positions.append(position)
 
     stub = Mock(spec=FluorescenceImage)
-    monkeypatch.setattr(microscope, "fm_stable_move", fake_move)
+    monkeypatch.setattr(microscope, "safe_absolute_stage_movement", fake_move)
     monkeypatch.setattr("fibsem.fm.acquisition.acquire_image", lambda *a, **k: stub)
-    return moves
+    return positions
 
 
-def _cumulative_tile_offsets(moves, rows, cols):
-    """Replay the recorded moves into a per-tile (dx, dy) offset from the origin."""
-    x = y = 0.0
-    offsets = {}
-    index = 0  # moves[0] is the move to the start of the grid
-    x, y = moves[0]
-    for row in range(rows):
-        for col in range(cols):
-            offsets[(row, col)] = (x, y)
-            if col < cols - 1:
-                index += 1
-                x += moves[index][0]
-                y += moves[index][1]
-        if row < rows - 1:
-            index += 1
-            x += moves[index][0]
-            y += moves[index][1]
-    return offsets
-
-
-@pytest.mark.parametrize("rows,cols", [(2, 2), (3, 2), (1, 4), (4, 1)])
-def test_acquire_tileset_steps_rows_downward(fm_microscope, monkeypatch, rows, cols):
-    """Row 0 starts at the top of the grid and later rows step down."""
-    microscope = fm_microscope
-    moves = _record_tile_moves(microscope, monkeypatch)
-
+def _run_tileset(microscope, rows, cols, overlap=0.1):
     acquisition.acquire_tileset(
         microscope=microscope,
         channel_settings=ChannelSettings(
@@ -1056,24 +1035,62 @@ def test_acquire_tileset_steps_rows_downward(fm_microscope, monkeypatch, rows, c
             power=0.1, exposure_time=0.1,
         ),
         overview_parameters=OverviewParameters(
-            rows=rows, cols=cols, overlap=0.1,
+            rows=rows, cols=cols, overlap=overlap,
             use_zstack=False, autofocus_mode=AutoFocusMode.NONE,
         ),
     )
 
-    offsets = _cumulative_tile_offsets(moves, rows, cols)
 
-    # Row 0 is the top of the mosaic, so it sits at the most positive y.
-    ys = [offsets[(row, 0)][1] for row in range(rows)]
-    assert ys == sorted(ys, reverse=True), f"rows must step downward, got {ys}"
+def _by_tile(positions, rows, cols):
+    """Tiles are visited row-major, so index k is (k // cols, k % cols).
+
+    The acquisition also returns to its starting position when it finishes, which
+    lands in the same recording; the tile moves are the leading `rows * cols`.
+    """
+    assert len(positions) == rows * cols + 1, (
+        f"expected one move per tile plus the restore, got {len(positions)} "
+        f"for a {rows}x{cols} grid"
+    )
+    return {(k // cols, k % cols): p for k, p in enumerate(positions[:rows * cols])}
+
+
+@pytest.mark.parametrize("rows,cols", [(2, 2), (3, 2), (1, 4), (4, 1)])
+def test_acquire_tileset_visits_rows_top_to_bottom(fm_microscope, monkeypatch, rows, cols):
+    """Row 0 is the top of the mosaic, so it sits at the highest stage y."""
+    microscope = fm_microscope
+    positions = _record_tile_positions(microscope, monkeypatch)
+    _run_tileset(microscope, rows, cols)
+    tiles = _by_tile(positions, rows, cols)
+
+    ys = [tiles[(row, 0)].y for row in range(rows)]
+    assert ys == sorted(ys, reverse=True), f"rows must descend in y, got {ys}"
     if rows > 1:
-        assert ys[0] > ys[-1]
         # ... and the grid stays centred on the starting position.
         assert ys[0] == pytest.approx(-ys[-1])
 
-    # Columns are unchanged: col 0 is the left edge, x increases to the right.
-    xs = [offsets[(0, col)][0] for col in range(cols)]
-    assert xs == sorted(xs), f"columns must step rightward, got {xs}"
+    xs = [tiles[(0, col)].x for col in range(cols)]
+    assert xs == sorted(xs), f"columns must ascend in x, got {xs}"
+
+
+def test_acquire_tileset_uses_absolute_positions_not_accumulated_steps(
+    fm_microscope, monkeypatch
+):
+    """Every tile is projected from the same base, so error cannot accumulate.
+
+    With relative stepping the y pitch between rows is a sum of separately-projected
+    steps; with absolute positions it is a difference of two projections from one
+    origin. This asserts the pitch is uniform, which is what the difference buys.
+    """
+    rows, cols = 4, 1
+    microscope = fm_microscope
+    positions = _record_tile_positions(microscope, monkeypatch)
+    _run_tileset(microscope, rows, cols)
+    tiles = _by_tile(positions, rows, cols)
+
+    pitches = [tiles[(r + 1, 0)].y - tiles[(r, 0)].y for r in range(rows - 1)]
+    assert all(p == pytest.approx(pitches[0]) for p in pitches), (
+        f"row pitch must be uniform, got {pitches}"
+    )
 
 
 def test_acquire_tileset_row_direction_matches_the_beam_tiler(fm_microscope, monkeypatch):
@@ -1087,20 +1104,9 @@ def test_acquire_tileset_row_direction_matches_the_beam_tiler(fm_microscope, mon
 
     rows, cols = 3, 3
     microscope = fm_microscope
-    moves = _record_tile_moves(microscope, monkeypatch)
-
-    acquisition.acquire_tileset(
-        microscope=microscope,
-        channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
-        ),
-        overview_parameters=OverviewParameters(
-            rows=rows, cols=cols, overlap=0.1,
-            use_zstack=False, autofocus_mode=AutoFocusMode.NONE,
-        ),
-    )
-    fm_offsets = _cumulative_tile_offsets(moves, rows, cols)
+    positions = _record_tile_positions(microscope, monkeypatch)
+    _run_tileset(microscope, rows, cols)
+    tiles = _by_tile(positions, rows, cols)
 
     beam_tiles = compute_tile_grid(
         OverviewAcquisitionSettings(
@@ -1109,12 +1115,12 @@ def test_acquire_tileset_row_direction_matches_the_beam_tiler(fm_microscope, mon
         )
     )
 
-    # compute_tile_grid measures from the top-left tile, acquire_tileset from the
+    # compute_tile_grid measures from the top-left tile, the acquisition from the
     # centre, so compare directions between tiles rather than absolute offsets.
-    origin = fm_offsets[(0, 0)]
+    origin = tiles[(0, 0)]
     for tile in beam_tiles:
-        fm_dx, fm_dy = fm_offsets[(tile.row, tile.col)]
-        fm_dx, fm_dy = fm_dx - origin[0], fm_dy - origin[1]
+        pos = tiles[(tile.row, tile.col)]
+        fm_dx, fm_dy = pos.x - origin.x, pos.y - origin.y
         assert np.sign(fm_dx) == np.sign(tile.dx), (
             f"x direction disagrees at row {tile.row} col {tile.col}: "
             f"FM {fm_dx:+.3e} vs beam {tile.dx:+.3e}"
@@ -1125,25 +1131,15 @@ def test_acquire_tileset_row_direction_matches_the_beam_tiler(fm_microscope, mon
         )
 
 
-def test_generate_grid_positions_orders_rows_top_to_bottom():
-    """Row 0 is the top of the mosaic, so its y is the most positive.
+def test_acquire_tileset_returns_to_the_starting_position(fm_microscope, monkeypatch):
+    """The grid is centred on wherever the stage was, and it is left there."""
+    rows, cols = 2, 2
+    microscope = fm_microscope
+    start = microscope.get_stage_position()
+    positions = _record_tile_positions(microscope, monkeypatch)
+    _run_tileset(microscope, rows, cols)
 
-    The other generate_grid_positions tests assert on *sets* of coordinates, and the
-    grid is symmetric about zero -- so every one of them passes with the row order
-    inverted. This pins the ordering itself.
-    """
-    ncols, nrows, fov = 2, 3, 10.0
-    positions = generate_grid_positions(
-        ncols=ncols, nrows=nrows, fov_x=fov, fov_y=fov, overlap=0.0
-    )
-
-    # Positions come out column-major, so each run of `nrows` is one column.
-    for col in range(ncols):
-        column = positions[col * nrows:(col + 1) * nrows]
-        ys = [y for _, y in column]
-        assert ys == sorted(ys, reverse=True), (
-            f"column {col} must run top to bottom, got {ys}"
-        )
-
-    assert max(y for _, y in positions) == pytest.approx(fov)
-    assert min(y for _, y in positions) == pytest.approx(-fov)
+    final = positions[-1]
+    assert final.x == pytest.approx(start.x)
+    assert final.y == pytest.approx(start.y)
+    assert final.z == pytest.approx(start.z)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -47,11 +47,11 @@ def test_outside(coords):
 def test_zero_reports_as_outside(coords):
     """The lower bound is exclusive, so row/column 0 is 'outside' despite being real.
 
-    Almost certainly an off-by-one -- the upper bound is exclusive, as it should be,
-    but the lower one is too. Pinned rather than fixed: four call sites in
-    `imaging/tiled.py` and several in the minimap widgets use this to decide whether
-    to draw a marker, and silently widening the accepted region during a file move is
-    how a move stops being inert. Worth correcting deliberately, separately.
+    Intentional, and confirmed as wanted -- not an off-by-one to be tidied up. It
+    reads like one, since the upper bound is exclusive as it should be and the lower
+    one is too, which is exactly why it is pinned here. Several call sites in
+    `imaging/tiled.py` and the minimap widgets use this to decide whether to draw a
+    marker; widening the accepted region would change what they render.
     """
     assert is_inside_image_bounds(coords, SHAPE) is False
 


### PR DESCRIPTION
First of four slices of FIB-391. This one is the correctness core; the class-based runner, settings convergence and mosaic metadata follow separately, so each stays reviewable.

## What it does

`acquire_tileset` walked its grid with relative steps — move to the top-left corner, then step one tile at a time, each step separately projected. Now the grid is laid out **once** and every tile is projected to an absolute stage position before anything moves, which is what `TiledAcquisitionRunner` already does.

```python
tiles = compute_tile_grid_from_fov(...)          # shared layout
tile_stage_positions = {
    (t.row, t.col): microscope.project_fm_stable_move(
        dx=t.dx - grid_offset_x, dy=t.dy + grid_offset_y, base_position=initial_position,
    ) for t in tiles
}
...
microscope.safe_absolute_stage_movement(tile_stage_positions[(row, col)])
```

**Correction to an earlier version of this description.** It claimed relative stepping accumulated numerical error that absolute positioning fixes. That is wrong, and measured: the two are bit-identical on both mounts, because `_view_corrected_stage_movement` is linear in `expected_y` and tilt/rotation do not change during a tileset, so sum-of-projections equals projection-of-sum exactly.

```
compustage  relative-sum y=-3.600000e-04 z=+0.000000e+00
            absolute     y=-3.600000e-04 z=-0.000000e+00   identical? True
offset      relative-sum y=-3.083690e-04 z=-2.159223e-04
            absolute     y=-3.083690e-04 z=-2.159223e-04   identical? True
```

**Every tile is computed to land in exactly where it did before**, which is the useful thing to know for review: this is not a behavioural change to tile placement.

What it does buy:

* **Hardware move accumulation.** Nine `move_stage_relative` calls accumulate nine encoder/repeatability errors; nine absolute moves each land within one tolerance of the true target. Real, but a hardware property that cannot be demonstrated in the simulator.
* **A failed or corrected single move no longer offsets every subsequent tile.**
* The structural fix below, which is the one that matters most.

**The row direction stops living in the loop's step signs.** It is now a property of the shared layout — the same one the beam tiler uses. `stitch_tileset` paints row 0 at canvas y=0 regardless of who computed the grid, so the two must agree; they disagreed once already (#226), and separate layout code is how that happened.

## `compute_tile_grid_from_fov`

Added to `tiling/geometry.py`, with `compute_tile_grid` delegating to it.

A fluorescence camera has a real field of view in **both** axes — pixel size × resolution — rather than a horizontal field width with the vertical inferred from the aspect ratio. So it cannot go through the beam-shaped `OverviewAcquisitionSettings` without inventing an `hfw`. One layout implementation matters more than the convenience of one signature.

The 26 existing grid tests pass unchanged, so the factoring is inert.

## The #226 tests had to be rewritten — worth reading

The five row-direction tests I added in #226 **failed** against this change. They recorded `fm_stable_move` calls, so they pinned the *stepping mechanism* rather than *where tiles land*. Every tile still ends up in exactly the same place; the tests broke anyway.

They now record the absolute positions the acquisition visits. That is the thing worth asserting and it survives the implementation changing underneath. Two more tests came out of the rewrite:

- **uniform row pitch** — what absolute positioning buys over accumulation
- **returns to the starting position** — surfaced by the recorder catching one more move than the grid has tiles

The beam-tiler cross-check is unchanged in spirit: it still pins FM and beam against each other on the sign of every per-tile offset, so the convention can only be changed in both places at once.

## Also

Corrects the comments on `is_inside_image_bounds` in `conversions.py` and its test. They described the exclusive lower bound as an off-by-one "worth correcting deliberately, separately" — it is intended behaviour, and callers rely on it to decide whether to draw a marker. Now recorded as intentional so it is not tidied away.

## Testing

Full suite including `fibsem/imaging/tests/`: **1516 passed, 24 skipped** (pre-existing plugin-fixture skips).

Not verified on hardware. The behaviour that changes is where tiles land on an offset mount, which is exactly what no local fixture can confirm — tracked on FIB-334.