### PR TITLE
Emit a terminal progress state from the tiled acquisition runner

### DIFF
--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -12,7 +12,7 @@ import numpy as np
 from matplotlib.figure import Figure
 
 from fibsem import acquire, conversions
-from fibsem.cancellation import raise_if_cancelled
+from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
 from fibsem.conversions import is_inside_image_bounds
 
 # Moved to the `tiling` package (FIB-390); re-exported so existing importers and the
@@ -103,13 +103,25 @@ class TiledAcquisitionRunner:
     # ── public entry point ───────────────────────────────────────────────
 
     def run(self) -> None:
-        """Acquire all tiles."""
+        """Acquire all tiles.
+
+        Always emits a terminal progress update, whatever the outcome. Previously the
+        only one came from `_stitch`, so a caller using `run()` on its own, or any run
+        that was cancelled or failed, left consumers with no way to tell "done" from
+        "still going" -- the progress bar simply stopped moving.
+        """
         self._setup()
         self._compute_grid()
+        outcome, message = "finished", "Acquisition Complete"
         try:
             self._autofocus_if_mode(AutoFocusMode.ONCE)
             self._run_tile_loop()
+        except OperationCancelledError:
+            outcome, message = "cancelled", "Acquisition Cancelled"
+            logging.info("Tiled acquisition cancelled")
+            raise
         except Exception as e:
+            outcome, message = "failed", "Acquisition Failed"
             logging.error(f"Tiled acquisition failed: {e}")
             raise
         finally:
@@ -118,7 +130,30 @@ class TiledAcquisitionRunner:
                 f"{self._start_state.stage_position.pretty}"
             )
             self.microscope.set_microscope_state(self._start_state)
+            self._emit_terminal(outcome, message)
         self._image_settings.path = self._prev_path
+
+    def _emit_terminal(self, outcome: str, message: str) -> None:
+        """Emit the final progress update for the acquisition.
+
+        Carries `counter`/`total`/`msg` because consumers read those unconditionally --
+        `FibsemMinimapWidget.handle_tile_acquisition_progress` indexes them directly
+        and would raise on a payload without them. `finished` is what
+        `AutoLamellaMainUI._on_tile_acquisition_progress` already branches on; it was
+        previously only ever set by `_stitch`. `outcome` is the addition, so a consumer can distinguish a
+        cancel from a failure rather than seeing both as "stopped". Deliberately not
+        called `state`: the fluorescence progress signal already uses that key for the
+        current *phase* (moving / acquiring / finished), and reusing it here for a
+        terminal *outcome* would collide on "finished" while meaning something else.
+        """
+        total_tiles = self.settings.nrows * self.settings.ncols
+        self.microscope.tiled_acquisition_signal.emit({
+            "msg": message,
+            "counter": getattr(self, "_n_tiles_acquired", 0),
+            "total": total_tiles,
+            "finished": True,
+            "outcome": outcome,
+        })
 
     def run_and_stitch(self) -> FibsemImage:
         """Acquire all tiles and return the stitched FibsemImage."""

--- a/tests/test_tiled.py
+++ b/tests/test_tiled.py
@@ -264,3 +264,92 @@ def test_validate_positions_all_out_of_bounds():
 
 def test_validate_positions_empty():
     assert validate_tile_stage_positions([], [], _make_limits()) == []
+
+
+# ---------------------------------------------------------------------------
+# Terminal progress state
+#
+# The only terminal emission used to come from _stitch, so run() on its own -- and
+# any cancelled or failed run -- left consumers with a progress bar that just stopped
+# moving. AutoLamellaMainUI already branched on ddict.get("finished"), which nothing
+# on those paths ever set.
+# ---------------------------------------------------------------------------
+
+import threading
+from unittest.mock import MagicMock
+
+from fibsem.cancellation import OperationCancelledError
+from fibsem.imaging.tiled import TiledAcquisitionRunner
+
+
+def _runner_with_recorded_signal(monkeypatch):
+    """A runner whose phases are stubbed, recording what it emits."""
+    emitted = []
+    microscope = MagicMock()
+    microscope.tiled_acquisition_signal.emit = emitted.append
+
+    runner = TiledAcquisitionRunner.__new__(TiledAcquisitionRunner)
+    runner.microscope = microscope
+    runner.settings = MagicMock(nrows=2, ncols=3)
+    runner.stop_event = None
+    runner._setup = lambda: None
+    runner._compute_grid = lambda: None
+    runner._autofocus_if_mode = lambda mode: None
+    runner._start_state = MagicMock()
+    runner._image_settings = MagicMock()
+    runner._prev_path = "/tmp"
+    return runner, emitted
+
+
+def test_run_emits_a_terminal_state_on_success(monkeypatch):
+    runner, emitted = _runner_with_recorded_signal(monkeypatch)
+    runner._run_tile_loop = lambda: setattr(runner, "_n_tiles_acquired", 6)
+
+    runner.run()
+
+    assert emitted[-1]["finished"] is True
+    assert emitted[-1]["outcome"] == "finished"
+    assert emitted[-1]["counter"] == 6
+    assert emitted[-1]["total"] == 6
+
+
+def test_run_emits_a_terminal_state_when_cancelled(monkeypatch):
+    runner, emitted = _runner_with_recorded_signal(monkeypatch)
+
+    def cancel():
+        runner._n_tiles_acquired = 2
+        raise OperationCancelledError("stopped")
+
+    runner._run_tile_loop = cancel
+
+    with pytest.raises(OperationCancelledError):
+        runner.run()
+
+    assert emitted[-1]["outcome"] == "cancelled"
+    assert emitted[-1]["counter"] == 2, "partial progress is reported, not reset"
+
+
+def test_run_emits_a_terminal_state_when_it_fails(monkeypatch):
+    """A failure must be distinguishable from a cancel, not just 'stopped'."""
+    runner, emitted = _runner_with_recorded_signal(monkeypatch)
+
+    def explode():
+        raise RuntimeError("stage fell over")
+
+    runner._run_tile_loop = explode
+
+    with pytest.raises(RuntimeError):
+        runner.run()
+
+    assert emitted[-1]["outcome"] == "failed"
+
+
+def test_the_terminal_payload_satisfies_existing_consumers(monkeypatch):
+    """The minimap handler indexes counter/total/msg directly and would raise."""
+    runner, emitted = _runner_with_recorded_signal(monkeypatch)
+    runner._run_tile_loop = lambda: setattr(runner, "_n_tiles_acquired", 6)
+
+    runner.run()
+
+    for key in ("msg", "counter", "total"):
+        assert key in emitted[-1], f"consumers index {key!r} without a default"


### PR DESCRIPTION
**Stacked on #233** (which is stacked on #232). Depends on #233 only for `_check_cancelled` raising `OperationCancelledError` — without that, a cancel cannot be told apart from a failure here.

## The gap

The only terminal progress emission came from `_stitch`. So:

| path | terminal emission before |
| -- | -- |
| `run_and_stitch()`, success | yes — `{"msg": "Done", "finished": True}` |
| `run()` alone, success | **none** |
| cancelled | **none** |
| failed | **none** |

On those paths the progress bar simply stopped moving, with no way to distinguish done from stalled from cancelled.

`AutoLamellaMainUI._on_tile_acquisition_progress` already branches on it:

```python
if ddict.get("finished"):
    self.progress_widget.update_progress(ProgressUpdate.done())
```

and on the cancelled and failed paths nothing ever set that key.

## The change

`run()` emits a terminal update in its `finally`, whatever the outcome, with a `state` of `finished`, `cancelled` or `failed`. The distinction matters for the same reason it did one layer down in #233 — a cancel is a user action to report neutrally, a failure is not, and a consumer seeing only "stopped" cannot tell them apart.

**Compatible with existing consumers by construction.** The payload carries `msg`, `counter` and `total` because `FibsemMinimapWidget.handle_tile_acquisition_progress` indexes them directly:

```python
count, total = ddict["counter"], ddict["total"]
...setFormat(f"{ddict['msg']} — {count}/{total} tiles (%p%)")
```

A payload without them would raise inside a Qt slot. There's a test asserting those keys are present, for exactly that reason.

`counter` reports the tiles actually acquired rather than resetting to zero, so a cancelled run still shows how far it got.

`_stitch` keeps its own `"Done"`, which now reads as *stitching* complete rather than *acquisition* complete. Both are real milestones and consumers already handle a `finished` payload.

## Scope note

This came out of asking whether the two tilers' progress signals should converge. They should **not** — `tiled_acquisition_signal` is tiling-specific, while `fm.acquisition_progress_signal` covers all FM acquisition keyed by `task` (`tileset`, `z-stack`, `multi-position`). Merging the objects would mean breaking one or rewriting the other. Converging the payload *vocabulary* is worth doing when there's a shared consumer to check it against — that's FIB-393, where the GUI is rebuilt.

The missing terminal state was the part that was a defect rather than an inconsistency, so it's here on its own.

## Testing

Four new tests: terminal state on success, on cancel (with partial count preserved), on failure, and that the payload satisfies the keys existing consumers index without a default.

Full suite including `fibsem/imaging/tests/`: **1526 passed, 24 skipped**.

⚠️ Note: stacked PRs get **no CI** in this repo — `python-package.yml` triggers on `pull_request: branches: [main]` only. This needs retargeting to `main` before merge to be verified, as #229 did.