### PR TITLE
Import FibsemMicroscope for type-checking only in imaging/spot.py

### DIFF
--- a/fibsem/imaging/spot.py
+++ b/fibsem/imaging/spot.py
@@ -4,10 +4,17 @@ import threading
 import time
 from dataclasses import dataclass, field
 
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
-from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, Point
+
+if TYPE_CHECKING:
+    # Type-checking only. `fibsem/imaging/__init__.py` star-imports this module, so a
+    # runtime import here makes every `fibsem.imaging.*` import pull in the microscope
+    # -- and `fibsem.microscope` imports `fibsem.fm.microscope`, which reaches back
+    # into `fibsem.imaging`. `from __future__ import annotations` is already on, so the
+    # annotation below needs no runtime object.
+    from fibsem.microscope import FibsemMicroscope
 
 SLEEP_TIME = 1
 

--- a/tests/test_import_cycles.py
+++ b/tests/test_import_cycles.py
@@ -1,0 +1,102 @@
+"""Import-order regressions.
+
+`fibsem.microscope` imports `fibsem.fm.microscope` at module level, which runs
+`fibsem/fm/__init__.py` and lands in `fibsem.fm.acquisition`. So anything
+`fm.acquisition` imports at module scope is imported while `fibsem.microscope` is
+only half-built, whenever the chain *started* somewhere that pulls in
+`fibsem.microscope`.
+
+That became a real failure when `fm.acquisition` began importing
+`fibsem.imaging.tiling.geometry`: importing any `fibsem.imaging` submodule runs
+`fibsem/imaging/__init__.py`, which star-imports `fibsem.imaging.spot`, which
+imported `FibsemMicroscope` -- a name defined *after* the line that started the
+chain. The AutoLamella UI stopped importing at all.
+
+The fix was to make `spot.py` import it for type-checking only, which it always
+was: one annotation, in a module that already has `from __future__ import
+annotations`. That makes the whole `fibsem.imaging` package microscope-free.
+
+Both properties are pinned below: the entry points, and the package boundary that
+keeps them working.
+
+Run in subprocesses -- import order cannot be tested in-process, because whatever a
+previous test imported has already populated sys.modules.
+"""
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import fibsem
+
+# Entry points that reach fibsem.microscope on the way in. The AutoLamella UI is the
+# one users actually hit, but it needs the `ui` extra, so it is not what CI relies on.
+#
+# `fibsem.fm.acquisition` is in this list precisely because it passes even when the
+# cycle is present: it imports `fibsem.microscope` fully first, so it cannot observe
+# the half-initialised state. A check written against it reports success while the
+# application is broken, which is how this shipped.
+ENTRY_POINTS = [
+    "fibsem.milling.tasks",
+    "fibsem.milling",
+    "fibsem.microscope",
+    "fibsem.fm.acquisition",
+]
+
+
+def _run(code: str):
+    return subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+
+
+@pytest.mark.parametrize("module", ENTRY_POINTS)
+def test_entry_point_imports_without_a_circular_import(module):
+    result = _run(f"import {module}")
+    assert "circular import" not in result.stderr, (
+        f"importing {module} hit a circular import:\n{result.stderr[-1500:]}"
+    )
+    assert result.returncode == 0, f"importing {module} failed:\n{result.stderr[-1500:]}"
+
+
+def test_imaging_does_not_pull_in_the_microscope():
+    """The property that keeps the cycle closed.
+
+    `fibsem/imaging/__init__.py` star-imports its submodules, so one runtime
+    `fibsem.microscope` import anywhere under `fibsem.imaging` makes every
+    `fibsem.imaging.*` import drag the microscope in -- and the microscope imports
+    `fibsem.fm.microscope`, which reaches back into `fibsem.imaging`.
+    """
+    result = _run(
+        "import sys, warnings; warnings.filterwarnings('ignore')\n"
+        "import fibsem.imaging\n"
+        "print('fibsem.microscope' in sys.modules)"
+    )
+    assert result.returncode == 0, result.stderr[-1500:]
+    assert result.stdout.strip().splitlines()[-1] == "False", (
+        "importing fibsem.imaging now pulls in fibsem.microscope again. Something "
+        "under fibsem/imaging/ imports it at runtime; if it is only needed for an "
+        "annotation, put it under TYPE_CHECKING as fibsem/imaging/spot.py does."
+    )
+
+
+def test_spot_imports_the_microscope_for_typing_only():
+    """Stated statically, so the reason survives even if the runtime check moves.
+
+    `FibsemMicroscope` appears once in spot.py, as a parameter annotation, and the
+    module has `from __future__ import annotations` -- so it never needs the real
+    object at runtime.
+    """
+    source = (Path(fibsem.__file__).parent / "imaging" / "spot.py").read_text()
+    tree = ast.parse(source)
+
+    module_level = {
+        node.module
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert "fibsem.microscope" not in module_level, (
+        "spot.py imports fibsem.microscope at runtime. It is used only in an "
+        "annotation; keep it under TYPE_CHECKING."
+    )


### PR DESCRIPTION
**Breakage on `main`.** #232 broke the AutoLamella UI at startup — mine.

```
ImportError: cannot import name 'FibsemMicroscope' from partially initialized
module 'fibsem.microscope' (most likely due to a circular import)
```

## The loop

```
fibsem.microscope (line 125)
  -> fibsem.fm.microscope -> fibsem/fm/__init__.py -> fm.acquisition
  -> fibsem.imaging.tiling.geometry        <-- added by #232
  -> fibsem/imaging/__init__.py -> fibsem.imaging.spot
  -> from fibsem.microscope import FibsemMicroscope     BOOM
```

`FibsemMicroscope` is defined *after* the line that starts the chain, so it does not exist yet when `spot.py` asks for it.

## Fix: nine lines in `spot.py`

`spot.py` never needed that import at runtime. `FibsemMicroscope` appears **once**, as a parameter annotation, in a module that already has `from __future__ import annotations`. Under `TYPE_CHECKING` it goes away at runtime and the loop closes at its source.

`fm/acquisition.py` is untouched — identical to `main`. My first attempt deferred the import there instead, which worked but treated the symptom in the wrong module.

**It also makes the whole `fibsem.imaging` package microscope-free:**

| | modules loaded by `import fibsem.imaging` | pulls in microscope |
| -- | -- | -- |
| before | 1316 | yes |
| after | **520** | **no** |

That is the benefit #231 was reaching for and which I measured as absent. Removing the `tiled` star-import gained nothing *because `spot` was still pulling the microscope in through the same `__init__`*. `spot` was the single source; `masks` and `utils` never imported it at all.

## Why it shipped

The failure is **entry-point dependent**:

| entry point | before this fix |
| -- | -- |
| `fibsem.milling.tasks` | **breaks** |
| `fibsem.milling` | **breaks** |
| `fibsem.microscope` | **breaks** |
| AutoLamella UI | **breaks** |
| `fibsem.fm.acquisition` | works |

That last row is what I tested when I claimed in #229, FIB-390 and the project description that this cycle did not exist. Importing `fm.acquisition` directly initialises `fibsem.microscope` fully first, so it cannot observe the half-built state — the check doesn't merely miss the bug, it reports success. **That claim is wrong and is being retracted in Linear.**

## Tests

`tests/test_import_cycles.py`, run in subprocesses since import order cannot be tested in-process:

- four entry points import cleanly — `fibsem.milling.tasks` and `fibsem.microscope` reproduce the failure and need no `ui` extra, so CI covers it without the UI stack
- `fibsem.fm.acquisition` is **deliberately kept** in that list because it passes either way: the counterexample, preserved so the next person doesn't repeat it
- `fibsem.imaging` does not pull in the microscope
- `spot.py` keeps the import under `TYPE_CHECKING`

Verified 5 of 6 fail if `spot.py` regresses.

## Testing

Full suite including `fibsem/imaging/tests/`: **1632 passed, 24 skipped**.