### PR TITLE
Converge the two AutoFocusMode enums onto one (FIB-391)

### DIFF
--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -37,17 +37,11 @@ from ome_types.model import (
     Detector as OME_Detector,
 )
 
-from fibsem.structures import FibsemRectangle, FibsemStagePosition
-
-
-class AutoFocusMode(Enum):
-    """Auto-focus modes for tileset acquisition."""
-
-    NONE = "none"
-    ONCE = "once"
-    EACH_ROW = "each_row"
-    EACH_TILE = "each_tile"
-
+# AutoFocusMode is canonical in fibsem.structures -- there was a second, identical
+# enum of the same name here, so the two tilers held different objects for the same
+# concept and `is` comparisons across them silently failed. Imported (and so
+# re-exported) rather than redefined, to keep that from happening again.
+from fibsem.structures import AutoFocusMode, FibsemRectangle, FibsemStagePosition
 
 # Autofocus types are canonical in fibsem.autofunctions.autofocus; re-export here
 # so existing `from fibsem.fm.structures import ...` imports keep working.

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -260,11 +260,11 @@ class TiledAcquisitionRunner:
                 f"{len(out_of_bounds)} tile(s) out of bounds: {details}"
             )
 
-        # EVERY_ROW is not well-defined for SPIRAL (rows are revisited non-sequentially),
-        # so promote it to EVERY_TILE so focus is always fresh.
-        if self._af_mode is AutoFocusMode.EVERY_ROW and settings.tile_order is TileOrderStrategy.SPIRAL:
-            self._af_mode = AutoFocusMode.EVERY_TILE
-            logging.info("EVERY_ROW autofocus upgraded to EVERY_TILE for SPIRAL tile order")
+        # EACH_ROW is not well-defined for SPIRAL (rows are revisited non-sequentially),
+        # so promote it to EACH_TILE so focus is always fresh.
+        if self._af_mode is AutoFocusMode.EACH_ROW and settings.tile_order is TileOrderStrategy.SPIRAL:
+            self._af_mode = AutoFocusMode.EACH_TILE
+            logging.info("EACH_ROW autofocus upgraded to EACH_TILE for SPIRAL tile order")
 
     def _run_tile_loop(self) -> None:
         """Move to each tile, autofocus as configured, acquire, and stitch into the canvas."""
@@ -290,9 +290,9 @@ class TiledAcquisitionRunner:
 
             if tile.row != prev_row:
                 prev_row = tile.row
-                self._autofocus_if_mode(AutoFocusMode.EVERY_ROW)
+                self._autofocus_if_mode(AutoFocusMode.EACH_ROW)
 
-            self._autofocus_if_mode(AutoFocusMode.EVERY_TILE)
+            self._autofocus_if_mode(AutoFocusMode.EACH_TILE)
 
             # apply per-tile focus offset (no-op until focus map is implemented)
             self._apply_focus_offset(tile)

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -153,10 +153,43 @@ class ManipulatorState(Enum):
 
 
 class AutoFocusMode(Enum):
-    NONE = 0
-    ONCE = 1
-    EVERY_ROW = 2
-    EVERY_TILE = 3
+    """When to run autofocus during a tiled acquisition.
+
+    One vocabulary for both tilers. There used to be two enums of this name --
+    this one, and an identical set of concepts in `fibsem.fm.structures` -- which
+    meant `AutoFocusMode.NONE is AutoFocusMode.NONE` was False across the two
+    import paths, with no type error to catch it. `fibsem.fm.structures` now
+    re-exports this one.
+
+    Every spelling either enum was ever written in still resolves: the `EVERY_*`
+    aliases below (this side persisted by name), the lowercase values (the FM side
+    persisted by value), and the integers 0-3 that used to be this enum's values.
+    """
+
+    NONE = "none"
+    ONCE = "once"
+    EACH_ROW = "each_row"
+    EACH_TILE = "each_tile"
+
+    # Aliases, not new members: `AutoFocusMode.EVERY_ROW is AutoFocusMode.EACH_ROW`,
+    # `AutoFocusMode["EVERY_ROW"]` resolves, and `list(AutoFocusMode)` still yields
+    # exactly the four modes above -- which is what the mode combo boxes iterate.
+    EVERY_ROW = "each_row"
+    EVERY_TILE = "each_tile"
+
+    @classmethod
+    def _missing_(cls, value):
+        """Resolve the older spellings, so nothing already written stops loading."""
+        if isinstance(value, str):
+            # Member names ("EVERY_ROW", "NONE"). Values are lowercase and names are
+            # uppercase, so this cannot collide with a real value.
+            return cls.__members__.get(value.upper())
+        # The integers this enum used to be, in declaration order. bool is excluded
+        # deliberately: True == 1 would otherwise silently resolve to ONCE.
+        if isinstance(value, int) and not isinstance(value, bool):
+            order = (cls.NONE, cls.ONCE, cls.EACH_ROW, cls.EACH_TILE)
+            return order[value] if 0 <= value < len(order) else None
+        return None
 
 
 class TileOrderStrategy(Enum):
@@ -716,19 +749,21 @@ class AutoFocusSettings:
     """Settings for autofocus in tiled overview acquisition.
 
     Attributes:
-        mode: When to apply autofocus (NONE, ONCE, EVERY_ROW, EVERY_TILE).
+        mode: When to apply autofocus (NONE, ONCE, EACH_ROW, EACH_TILE).
               beam_type and reduced_area are taken from image_settings at acquisition time.
     """
 
     mode: AutoFocusMode = AutoFocusMode.NONE
 
     def to_dict(self) -> dict:
-        return {"mode": self.mode.name}
+        # By value, matching how the fluorescence side has always written this mode.
+        # Files that stored the old member name ("EVERY_ROW") still load.
+        return {"mode": self.mode.value}
 
     @staticmethod
     def from_dict(d: dict) -> "AutoFocusSettings":
         return AutoFocusSettings(
-            mode=AutoFocusMode[d.get("mode", "NONE")]
+            mode=AutoFocusMode(d.get("mode", AutoFocusMode.NONE.value))
         )
 
 

--- a/tests/test_autofocus_mode.py
+++ b/tests/test_autofocus_mode.py
@@ -1,0 +1,121 @@
+"""One AutoFocusMode, and everything that was ever written for it still loads.
+
+There used to be two enums called `AutoFocusMode` -- `fibsem.structures` (NONE=0,
+ONCE=1, EVERY_ROW=2, EVERY_TILE=3) for the beam tiler, and `fibsem.fm.structures`
+(NONE="none" .. EACH_TILE="each_tile") for the fluorescence tiler. Same four
+concepts, different member names, different value types, identical class name.
+Two sibling widgets already imported different ones, and `is` comparisons across
+them were silently False with no type error to catch it.
+
+They are now one enum. The identity test below is the point of the exercise; the
+rest pin the back-compat that made converging them safe.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+import fibsem
+from fibsem.structures import AutoFocusMode, AutoFocusSettings
+
+
+def test_every_import_path_yields_the_same_enum():
+    """The hazard, stated directly: these used to be four different objects."""
+    import fibsem.fm
+    import fibsem.fm.acquisition
+    import fibsem.fm.structures
+    import fibsem.fm.timing
+    import fibsem.imaging.tiled
+
+    paths = {
+        "fibsem.fm.structures": fibsem.fm.structures.AutoFocusMode,
+        "fibsem.fm": fibsem.fm.AutoFocusMode,
+        "fibsem.fm.acquisition": fibsem.fm.acquisition.AutoFocusMode,
+        "fibsem.fm.timing": fibsem.fm.timing.AutoFocusMode,
+        "fibsem.imaging.tiled": fibsem.imaging.tiled.AutoFocusMode,
+    }
+    divergent = [name for name, enum in paths.items() if enum is not AutoFocusMode]
+    assert not divergent, (
+        f"{divergent} define or import a different AutoFocusMode than "
+        "fibsem.structures. Re-export the canonical one; do not redefine it."
+    )
+
+
+def test_iteration_yields_exactly_the_four_modes():
+    """Aliases must not leak into the mode combo boxes, which iterate the enum."""
+    assert [m.name for m in AutoFocusMode] == ["NONE", "ONCE", "EACH_ROW", "EACH_TILE"]
+
+
+@pytest.mark.parametrize(
+    ("alias", "canonical"),
+    [("EVERY_ROW", AutoFocusMode.EACH_ROW), ("EVERY_TILE", AutoFocusMode.EACH_TILE)],
+)
+def test_the_beam_side_spellings_are_aliases_not_new_members(alias, canonical):
+    assert getattr(AutoFocusMode, alias) is canonical
+    assert AutoFocusMode[alias] is canonical   # settings persisted by name
+    assert AutoFocusMode(alias) is canonical   # ... and read back by value
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        # canonical values, as written today
+        ("none", AutoFocusMode.NONE),
+        ("once", AutoFocusMode.ONCE),
+        ("each_row", AutoFocusMode.EACH_ROW),
+        ("each_tile", AutoFocusMode.EACH_TILE),
+        # member names -- how the beam side persisted them
+        ("NONE", AutoFocusMode.NONE),
+        ("EVERY_ROW", AutoFocusMode.EACH_ROW),
+        ("EVERY_TILE", AutoFocusMode.EACH_TILE),
+        # the integers this enum's values used to be
+        (0, AutoFocusMode.NONE),
+        (1, AutoFocusMode.ONCE),
+        (2, AutoFocusMode.EACH_ROW),
+        (3, AutoFocusMode.EACH_TILE),
+    ],
+)
+def test_older_spellings_still_resolve(stored, expected):
+    assert AutoFocusMode(stored) is expected
+
+
+@pytest.mark.parametrize("bogus", [True, False, 4, -1, "sometimes", ""])
+def test_junk_still_raises(bogus):
+    """The compatibility hatch must not turn into an accept-anything hatch.
+
+    `True` is called out specifically: `True == 1`, so a dict lookup keyed on the
+    legacy integers would have quietly resolved it to ONCE.
+    """
+    with pytest.raises(ValueError):
+        AutoFocusMode(bogus)
+
+
+@pytest.mark.parametrize("mode", list(AutoFocusMode))
+def test_autofocus_settings_round_trip(mode):
+    assert AutoFocusSettings.from_dict(AutoFocusSettings(mode=mode).to_dict()).mode is mode
+
+
+def test_autofocus_settings_reads_the_previously_persisted_name_form():
+    """Beam settings on disk say {"mode": "EVERY_ROW"}; they must keep loading."""
+    assert AutoFocusSettings.from_dict({"mode": "EVERY_ROW"}).mode is AutoFocusMode.EACH_ROW
+    assert AutoFocusSettings.from_dict({"mode": "NONE"}).mode is AutoFocusMode.NONE
+
+
+def test_overview_parameters_round_trip():
+    from fibsem.fm.structures import OverviewParameters
+
+    for mode in AutoFocusMode:
+        params = OverviewParameters(rows=2, cols=3, overlap=0.1, autofocus_mode=mode)
+        assert OverviewParameters.from_dict(params.to_dict()).autofocus_mode is mode
+
+
+def test_the_shipped_fm_configuration_still_parses():
+    """The default config has `autofocus_mode: once` in it -- pin it against the enum."""
+    from fibsem.fm.structures import OverviewParameters
+
+    path = Path(fibsem.__file__).parent / "config" / "fm" / "fm-configuration-default.yaml"
+    config = yaml.safe_load(path.read_text())
+
+    params = OverviewParameters.from_dict(config["overview_parameters"])
+    assert params.autofocus_mode is AutoFocusMode.ONCE

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -196,7 +196,7 @@ def test_autofocus_settings_round_trip():
     for mode in AutoFocusMode:
         s = AutoFocusSettings(mode=mode)
         d = s.to_dict()
-        assert d["mode"] == mode.name
+        assert d["mode"] == mode.value
         restored = AutoFocusSettings.from_dict(d)
         assert restored.mode is mode
 


### PR DESCRIPTION
## The problem

There were **two enums called `AutoFocusMode`**, holding the same four concepts:

| concept | `fibsem.structures` (beam) | `fibsem.fm.structures` (FM) |
|---|---|---|
| off | `NONE = 0` | `NONE = "none"` |
| once | `ONCE = 1` | `ONCE = "once"` |
| per row | `EVERY_ROW = 2` | `EACH_ROW = "each_row"` |
| per tile | `EVERY_TILE = 3` | `EACH_TILE = "each_tile"` |

Different member names, different value types, identical class name. `AutoFocusMode.NONE is AutoFocusMode.NONE` was **False** across the two import paths, with no type error to catch it — and two sibling widgets already imported different ones (`fibsem/ui/fm/widgets/overview_parameters_widget.py` the FM one, `fibsem/ui/widgets/overview_acquisition_settings_widget.py` the beam one).

This is the same class of divergence that produced the reversed FM mosaic in #226.

## The change

`fibsem.structures` is now canonical; `fibsem.fm.structures` re-exports it rather than redefining it.

It takes the **fluorescence side's names and string values**, because that side persists by *value* and ships a default config containing `autofocus_mode: once`. The beam side persists by *name*, so its spellings survive as **enum aliases** rather than as members:

- `AutoFocusMode.EVERY_ROW is AutoFocusMode.EACH_ROW` → `True`
- `AutoFocusMode["EVERY_ROW"]` still resolves, so beam settings on disk keep loading
- `list(AutoFocusMode)` still yields exactly four items — which is what the mode combo boxes iterate

A `_missing_` hook additionally accepts the integers `0-3` the beam values used to be. `bool` is excluded from it deliberately: `True == 1` would otherwise have quietly resolved to `ONCE`.

The beam tiler moves onto the canonical `EACH_*` names.

## Two visible consequences

- `AutoFocusSettings.to_dict` now writes the **value** (`"each_row"`) rather than the member name (`"EVERY_ROW"`), so both sides persist one spelling. Older files still load; files written from here **will not load on an older fibsem**.
- The beam mode combo formats from `.name`, so it now reads "Each Row" instead of "Every Row".

## Testing

`1658 passed, 24 skipped`.

New `tests/test_autofocus_mode.py` pins:
- the same enum object across all five import paths (`fibsem.fm`, `fibsem.fm.structures`, `fibsem.fm.acquisition`, `fibsem.fm.timing`, `fibsem.imaging.tiled`) — the point of the exercise
- aliases resolve by attribute, by name and by value, and don't leak into iteration
- all eleven legacy input forms (values, member names, legacy integers)
- junk still raises, `True`/`False` included
- round-trips for `AutoFocusSettings` and `OverviewParameters`
- the shipped `fibsem/config/fm/fm-configuration-default.yaml` still parses

## Scope note

This is the first slice of what FIB-391 called "settings convergence". Measuring it first showed the two `Overview*` settings classes are **not** worth merging — their shared surface is only rows/cols/overlap, everything else is genuinely modality-specific, and merging means one class with two optional modality payloads across 142 references for nothing user-visible. The colliding enums were the real hazard in there. Tile ordering for FM (it currently has none and never calls `order_tiles`) is blocked on the row-major tileset assembly, so it belongs with the sparse-tileset work in FIB-392 rather than here.
