### PR TITLE
Support sparse tilesets with a per-tile enable mask (FIB-392)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -12,7 +12,7 @@ import matplotlib.patches as patches
 from fibsem import utils
 from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
 from fibsem.fm.calibration import run_autofocus
-from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
+from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov, order_tiles
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.structures import (
     AutoFocusMode,
@@ -25,7 +25,7 @@ from fibsem.fm.structures import (
     AutoFocusSettings,
 )
 from fibsem.fm.timing import estimate_tileset_acquisition_time, estimate_positions_acquisition_time
-from fibsem.structures import BeamType, FibsemStagePosition
+from fibsem.structures import BeamType, FibsemStagePosition, TileOrderStrategy
 if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
 
@@ -404,7 +404,10 @@ class FMTiledAcquisitionRunner:
         self.save_directory = save_directory
         self.stop_event = stop_event
 
-        # Rows are appended whole, so on a mid-row cancel that row is discarded.
+        # Sized in _setup once the grid is known, and written by index. Every cell that
+        # was not reached -- skipped by the mask, or not yet visited when a cancel came
+        # in -- stays None, so a partial result keeps every acquired tile in its right
+        # place instead of collapsing toward the origin.
         self.tileset: List[List[Optional[FluorescenceImage]]] = []
 
     # ── public entry points ──────────────────────────────────────────────
@@ -465,6 +468,8 @@ class FMTiledAcquisitionRunner:
         self._cols = self.overview_parameters.cols
         self._overlap = self.overview_parameters.overlap
         self._autofocus_mode = self.overview_parameters.autofocus_mode
+        self._tile_order = self.overview_parameters.tile_order
+        self._tile_mask = self.overview_parameters.tile_mask
 
         if self._rows <= 0 or self._cols <= 0:
             raise ValueError("Grid size must contain positive values")
@@ -472,9 +477,22 @@ class FMTiledAcquisitionRunner:
         if not 0.0 <= self._overlap < 1.0:
             raise ValueError("Tile overlap must be between 0.0 and 1.0 (exclusive)")
 
+        # A spiral revisits rows non-sequentially, so "autofocus on each new row" would
+        # fire almost every tile and still leave stale focus in between. Promote it, as
+        # the beam runner does.
+        if (self._autofocus_mode is AutoFocusMode.EACH_ROW
+                and self._tile_order is TileOrderStrategy.SPIRAL):
+            self._autofocus_mode = AutoFocusMode.EACH_TILE
+            logging.info("EACH_ROW autofocus upgraded to EACH_TILE for SPIRAL tile order")
+
+        # Full grid, holes included: the canvas is the whole grid whatever the mask.
+        self.tileset = [[None] * self._cols for _ in range(self._rows)]
+
+        n_enabled = self.overview_parameters.n_enabled_tiles
         logging.info(
             f"Starting tileset acquisition: {self._rows}x{self._cols} grid "
-            f"with {self._overlap:.1%} overlap"
+            f"with {self._overlap:.1%} overlap, {self._tile_order.value} order, "
+            f"{n_enabled}/{self._rows * self._cols} tiles enabled"
         )
 
         # Captured for the restore in _restore(), and as the grid's centre.
@@ -553,7 +571,7 @@ class FMTiledAcquisitionRunner:
         paints row 0 at canvas y=0 regardless, so the two have to agree. They
         disagreed once already (#226).
         """
-        tiles = compute_tile_grid_from_fov(
+        self._grid = compute_tile_grid_from_fov(
             nrows=self._rows,
             ncols=self._cols,
             fov_x=self._fov_x,
@@ -561,7 +579,15 @@ class FMTiledAcquisitionRunner:
             image_width=self._image_width,
             image_height=self._image_height,
             overlap=self._overlap,
+            mask=self._tile_mask,
         )
+        # Ordered, and disabled tiles dropped. The traversal comes from the full grid
+        # extent, so a sparse run follows the dense path with stops missing rather than
+        # a pattern re-derived over the holes -- see order_tiles.
+        self._ordered = order_tiles(self._grid, self._tile_order)
+
+        if not self._ordered:
+            raise ValueError("Tile mask disables every tile; nothing to acquire.")
 
         # The grid measures from its top-left tile; shift so it is centred on where
         # the stage already is. Same convention as TiledAcquisitionRunner.
@@ -574,15 +600,19 @@ class FMTiledAcquisitionRunner:
                 dy=tile.dy + grid_offset_y,
                 base_position=self._initial_position,
             )
-            for tile in tiles
+            for tile in self._grid
         }
 
+        first = self._ordered[0]
         self._emit({"state": "moving", "task": "tileset"})
         self._emit({
             "state": "acquiring", "task": "tileset",
-            "row": 1, "col": 1,
+            "row": first.row + 1, "col": first.col + 1,
             "total_rows": self._rows, "total_cols": self._cols,
-            "current": 1, "total": self._rows * self._cols,
+            # `total` counts tiles that will actually be acquired, not grid cells --
+            # a progress bar that stops at 9/25 on a successful sparse run reads as a
+            # failure.
+            "current": 1, "total": len(self._ordered),
             "estimated_total_time": self._total_estimated_time,
             "estimated_remaining_time": self._total_estimated_time,
         })
@@ -608,25 +638,27 @@ class FMTiledAcquisitionRunner:
             )
 
     def _run_tile_loop(self) -> None:
-        """Visit every tile in row-major order."""
-        for row in range(self._rows):
+        """Visit the enabled tiles in traversal order.
+
+        Tiles are written into the pre-allocated `self.tileset` by index rather than
+        appended. Appending assumed a row-major visit and a full grid -- neither holds
+        once the order is configurable or tiles can be skipped, and the failure is
+        silent: the mosaic would still stitch, with tiles in the wrong places.
+        """
+        prev_row = -1
+        self._n_acquired = 0
+        for tile in self._ordered:
+            # Check before moving, so a cancel skips the travel entirely.
             raise_if_cancelled(self.stop_event, "Tileset acquisition cancelled by user.")
-            self._autofocus_if_mode(AutoFocusMode.EACH_ROW)
 
-            row_images: List[Optional[FluorescenceImage]] = []
-            for col in range(self._cols):
-                # Check before moving, so a cancel skips the travel entirely.
-                raise_if_cancelled(
-                    self.stop_event, "Tileset acquisition cancelled by user."
-                )
-                row_images.append(self._acquire_tile(row, col))
+            if tile.row != prev_row:
+                prev_row = tile.row
+                self._autofocus_if_mode(AutoFocusMode.EACH_ROW)
 
-                if col < self._cols - 1:
-                    self._emit({"state": "moving", "task": "tileset"})
+            self.tileset[tile.row][tile.col] = self._acquire_tile(tile.row, tile.col)
+            self._n_acquired += 1
 
-            self.tileset.append(row_images)
-
-            if row < self._rows - 1:
+            if tile is not self._ordered[-1]:
                 self._emit({"state": "moving", "task": "tileset"})
 
     def _acquire_tile(self, row: int, col: int) -> FluorescenceImage:
@@ -706,8 +738,11 @@ class FMTiledAcquisitionRunner:
         self.microscope.fm.acquisition_progress_signal.emit(payload)
 
     def _emit_tile_progress(self, row: int, col: int) -> None:
-        current_tile = row * self._cols + col + 1
-        total_tiles = self._rows * self._cols
+        # Counted by visits, not by grid index. `row * cols + col` assumed a full
+        # row-major traversal; under a spiral it jumps around, and under a mask it
+        # overcounts by every skipped tile.
+        current_tile = self._n_acquired + 1
+        total_tiles = len(self._ordered)
         elapsed_time = time.time() - self._acquisition_start_time
 
         if current_tile > 1:
@@ -816,10 +851,22 @@ def stitch_tileset(
         if len(row) != cols:
             raise ValueError("Tileset must be rectangular (all rows same length)")
 
-    logging.info(f"Stitching {rows}x{cols} tileset with {tile_overlap:.1%} overlap")
+    # Gaps are expected, not exceptional: a sparse acquisition leaves every skipped
+    # tile as None, and a cancelled one leaves everything it never reached. Both stitch
+    # into a full-size canvas with the missing tiles left as zeros, so acquired tiles
+    # keep the canvas coordinates they would have had in a dense mosaic.
+    acquired = [t for row in tileset for t in row if t is not None]
+    if not acquired:
+        raise ValueError("Tileset contains no acquired tiles")
 
-    # Get reference tile for dimensions
-    ref_tile = tileset[0][0]
+    logging.info(
+        f"Stitching {rows}x{cols} tileset with {tile_overlap:.1%} overlap "
+        f"({len(acquired)}/{rows * cols} tiles acquired)"
+    )
+
+    # Get reference tile for dimensions -- the first acquired one, which is not
+    # necessarily (0, 0).
+    ref_tile = acquired[0]
 
     # Handle both 2D and multi-dimensional data
     if ref_tile.data.ndim == 2:
@@ -860,6 +907,8 @@ def stitch_tileset(
     for row in range(rows):
         for col in range(cols):
             tile = tileset[row][col]
+            if tile is None:
+                continue  # not acquired: leave the canvas zeros
 
             # Calculate position in mosaic
             y_start = row * effective_tile_height
@@ -907,10 +956,8 @@ def stitch_tileset(
 
     # Calculate the center position as average of all tile positions
     if any(
-        hasattr(tileset[row][col].metadata, "stage_position")
-        and tileset[row][col].metadata.stage_position is not None
-        for row in range(rows)
-        for col in range(cols)
+        getattr(tile.metadata, "stage_position", None) is not None
+        for tile in acquired
     ):
         # Collect all stage positions from tiles
         x_positions = []
@@ -920,20 +967,15 @@ def stitch_tileset(
         t_positions = []
         coordinate_systems = []
 
-        for row in range(rows):
-            for col in range(cols):
-                tile_metadata = tileset[row][col].metadata
-                if (
-                    hasattr(tile_metadata, "stage_position")
-                    and tile_metadata.stage_position is not None
-                ):
-                    pos = tile_metadata.stage_position
-                    x_positions.append(pos.x)
-                    y_positions.append(pos.y)
-                    z_positions.append(pos.z)
-                    r_positions.append(pos.r)
-                    t_positions.append(pos.t)
-                    coordinate_systems.append(pos.coordinate_system)
+        for tile in acquired:
+            pos = getattr(tile.metadata, "stage_position", None)
+            if pos is not None:
+                x_positions.append(pos.x)
+                y_positions.append(pos.y)
+                z_positions.append(pos.z)
+                r_positions.append(pos.r)
+                t_positions.append(pos.t)
+                coordinate_systems.append(pos.coordinate_system)
 
         if x_positions:  # If we found any positions
             # Calculate average position (center of mosaic)

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -41,7 +41,12 @@ from ome_types.model import (
 # enum of the same name here, so the two tilers held different objects for the same
 # concept and `is` comparisons across them silently failed. Imported (and so
 # re-exported) rather than redefined, to keep that from happening again.
-from fibsem.structures import AutoFocusMode, FibsemRectangle, FibsemStagePosition
+from fibsem.structures import (
+    AutoFocusMode,
+    FibsemRectangle,
+    FibsemStagePosition,
+    TileOrderStrategy,
+)
 
 # Autofocus types are canonical in fibsem.autofunctions.autofocus; re-export here
 # so existing `from fibsem.fm.structures import ...` imports keep working.
@@ -1534,14 +1539,29 @@ class FluorescenceImageMetadata:
 
 @dataclass
 class OverviewParameters:
-    """Parameters for FM overview/tileset acquisition."""
-    
+    """Parameters for FM overview/tileset acquisition.
+
+    Attributes:
+        rows: Number of tile rows.
+        cols: Number of tile columns.
+        overlap: Fractional overlap between adjacent tiles.
+        use_zstack: Acquire a z-stack at each tile.
+        autofocus_mode: When to autofocus during the traversal.
+        tile_order: Traversal strategy over the grid.
+        tile_mask: Optional per-tile enable mask, `tile_mask[row][col]`. None acquires
+            every tile. Disabled tiles are skipped but keep their place: the mosaic is
+            still the full grid size and acquired tiles land at the same canvas
+            coordinates they would have in a dense overview.
+    """
+
     rows: int = 3
     cols: int = 3
     overlap: float = 0.1
     use_zstack: bool = False
     autofocus_mode: AutoFocusMode = AutoFocusMode.NONE
-    
+    tile_order: TileOrderStrategy = TileOrderStrategy.TYPEWRITER
+    tile_mask: Optional[List[List[bool]]] = None
+
     def to_dict(self) -> dict:
         """Convert to dictionary representation."""
         return {
@@ -1550,18 +1570,34 @@ class OverviewParameters:
             "overlap": self.overlap,
             "use_zstack": self.use_zstack,
             "autofocus_mode": self.autofocus_mode.value,
+            "tile_order": self.tile_order.value,
+            # plain bools: np.bool_ does not survive yaml.safe_dump
+            "tile_mask": None if self.tile_mask is None
+            else [[bool(v) for v in row] for row in self.tile_mask],
         }
-    
+
     @classmethod
     def from_dict(cls, ddict: dict) -> "OverviewParameters":
         """Create OverviewParameters from dictionary."""
+        mask = ddict.get("tile_mask")
         return cls(
             rows=ddict.get("rows", 3),
             cols=ddict.get("cols", 3),
             overlap=ddict.get("overlap", 0.1),
             use_zstack=ddict.get("use_zstack", False),
             autofocus_mode=AutoFocusMode(ddict.get("autofocus_mode", AutoFocusMode.NONE.value)),
+            tile_order=TileOrderStrategy(
+                ddict.get("tile_order", TileOrderStrategy.TYPEWRITER.value)
+            ),
+            tile_mask=None if mask is None else [[bool(v) for v in row] for row in mask],
         )
+
+    @property
+    def n_enabled_tiles(self) -> int:
+        """How many tiles will actually be acquired."""
+        if self.tile_mask is None:
+            return self.rows * self.cols
+        return sum(bool(v) for row in self.tile_mask for v in row)
 
 
 @dataclass

--- a/fibsem/imaging/tiling/__init__.py
+++ b/fibsem/imaging/tiling/__init__.py
@@ -13,6 +13,7 @@ from fibsem.imaging.tiling.geometry import (
 from fibsem.imaging.tiling.plotting import (
     plot_minimap,
     plot_stage_positions_on_image,
+    plot_tile_grid,
     plot_tile_positions,
 )
 from fibsem.imaging.tiling.reprojection import (
@@ -30,6 +31,7 @@ __all__ = [
     "order_tiles",
     "plot_minimap",
     "plot_stage_positions_on_image",
+    "plot_tile_grid",
     "plot_tile_positions",
     "reproject_stage_positions_onto_image",
     "reproject_stage_positions_onto_image2",

--- a/fibsem/imaging/tiling/geometry.py
+++ b/fibsem/imaging/tiling/geometry.py
@@ -12,6 +12,7 @@ not convention, because it is a single convenient import away from being broken.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional, Sequence
 
 from fibsem.structures import (
     FibsemStagePosition,
@@ -31,6 +32,9 @@ class TilePosition:
         dy: Y offset from start_position in metres; negative = down (stage y inverted).
         canvas_x: Pixel left edge in the stitched canvas array.
         canvas_y: Pixel top edge in the stitched canvas array.
+        enabled: Whether this tile is to be acquired. Disabled tiles keep their place
+            in the grid -- they still define the canvas extent and the traversal
+            pattern -- but are not visited. See :func:`order_tiles`.
     """
     row: int
     col: int
@@ -38,14 +42,38 @@ class TilePosition:
     dy: float
     canvas_x: int
     canvas_y: int
+    enabled: bool = True
 
-def compute_tile_grid(settings: OverviewAcquisitionSettings) -> list[TilePosition]:
+
+def _validate_mask(mask, nrows: int, ncols: int) -> None:
+    """Reject a mask whose shape does not match the grid.
+
+    A mask is positional: `mask[row][col]`. Silently tolerating the wrong shape
+    would skip or acquire the wrong tiles, which is invisible in the result --
+    a mosaic of zeros looks the same whether the tile was skipped by mistake or
+    the sample was dark there.
+    """
+    if len(mask) != nrows:
+        raise ValueError(
+            f"Tile mask has {len(mask)} rows, but the grid has {nrows}."
+        )
+    for i, row in enumerate(mask):
+        if len(row) != ncols:
+            raise ValueError(
+                f"Tile mask row {i} has {len(row)} columns, but the grid has {ncols}."
+            )
+
+def compute_tile_grid(
+    settings: OverviewAcquisitionSettings,
+    mask: Optional[Sequence[Sequence[bool]]] = None,
+) -> list[TilePosition]:
     """Compute physical and canvas positions for every tile in the grid.
 
     Pure function — no microscope, no side effects.
 
     Args:
         settings: Overview acquisition settings (hfw, resolution, nrows, ncols, overlap).
+        mask: Optional per-tile enable mask, `mask[row][col]`. None enables everything.
     Returns:
         Flat list of TilePosition objects in row-major order (top-left first).
     """
@@ -61,6 +89,7 @@ def compute_tile_grid(settings: OverviewAcquisitionSettings) -> list[TilePositio
         image_width=image_width,
         image_height=image_height,
         overlap=settings.overlap,
+        mask=mask,
     )
 
 
@@ -72,6 +101,7 @@ def compute_tile_grid_from_fov(
     image_width: int,
     image_height: int,
     overlap: float,
+    mask: Optional[Sequence[Sequence[bool]]] = None,
 ) -> list[TilePosition]:
     """Compute the tile grid from a field of view given directly.
 
@@ -93,10 +123,18 @@ def compute_tile_grid_from_fov(
         image_width: Tile width in pixels.
         image_height: Tile height in pixels.
         overlap: Fractional overlap between adjacent tiles.
+        mask: Optional per-tile enable mask, `mask[row][col]`. None enables everything.
+            Disabled tiles are still returned -- they hold the grid's shape, so the
+            canvas extent and the traversal pattern do not change when tiles are
+            skipped. Filtering happens in :func:`order_tiles`.
 
     Returns:
-        Flat list of TilePosition objects in row-major order (top-left first).
+        Flat list of TilePosition objects in row-major order (top-left first),
+        including disabled ones.
     """
+    if mask is not None:
+        _validate_mask(mask, nrows, ncols)
+
     dx_step = fov_x * (1 - overlap)
     dy_step = fov_y * (1 - overlap)
 
@@ -112,6 +150,9 @@ def compute_tile_grid_from_fov(
                 dy=-(i * dy_step),   # negate: stage y axis is inverted
                 canvas_x=j * eff_w,
                 canvas_y=i * eff_h,
+                # bool(): a numpy mask yields np.bool_, which does not survive
+                # yaml.safe_dump when the grid is recorded alongside the mosaic.
+                enabled=True if mask is None else bool(mask[i][j]),
             ))
     return tiles
 
@@ -149,21 +190,32 @@ def _spiral_order(nrows: int, ncols: int) -> list[tuple[int, int]]:
     return result
 
 def order_tiles(tiles: list[TilePosition], strategy: TileOrderStrategy) -> list[TilePosition]:
-    """Reorder tiles according to the movement strategy.
+    """Put tiles in traversal order, dropping the disabled ones.
 
     Pure function — no microscope, no side effects.
 
+    Order first, filter second, and in that order deliberately. The traversal is
+    derived from the **full** grid extent and disabled tiles are removed from the
+    resulting sequence, so a sparse acquisition follows the same path the dense one
+    would have and simply misses stops along it. Filtering first would re-derive the
+    pattern over the holes: a spiral would wind around the enabled tiles' bounding
+    box instead of the grid's centre, and serpentine row parity would flip if a whole
+    row were disabled -- a different, and usually longer, stage path.
+
+    This is why `compute_tile_grid*` returns disabled tiles rather than omitting them.
+
     Args:
-        tiles: Flat list of TilePosition objects (any order).
+        tiles: Flat list of TilePosition objects (any order), including disabled ones.
         strategy: TYPEWRITER, SERPENTINE, or SPIRAL.
     Returns:
-        New list with tiles in traversal order.
+        New list of the enabled tiles, in traversal order.
     """
     if strategy is TileOrderStrategy.SPIRAL:
         nrows = max(t.row for t in tiles) + 1
         ncols = max(t.col for t in tiles) + 1
         tile_map = {(t.row, t.col): t for t in tiles}
-        return [tile_map[rc] for rc in _spiral_order(nrows, ncols) if rc in tile_map]
+        ordered = [tile_map[rc] for rc in _spiral_order(nrows, ncols) if rc in tile_map]
+        return [t for t in ordered if t.enabled]
 
     rows = sorted(set(t.row for t in tiles))
     result = []
@@ -171,7 +223,7 @@ def order_tiles(tiles: list[TilePosition], strategy: TileOrderStrategy) -> list[
         row_tiles = sorted([t for t in tiles if t.row == row], key=lambda t: t.col)
         if strategy is TileOrderStrategy.SERPENTINE and row_idx % 2 == 1:
             row_tiles = list(reversed(row_tiles))
-        result.extend(row_tiles)
+        result.extend(t for t in row_tiles if t.enabled)
     return result
 
 def validate_tile_stage_positions(

--- a/fibsem/imaging/tiling/plotting.py
+++ b/fibsem/imaging/tiling/plotting.py
@@ -36,6 +36,11 @@ def plot_tile_positions(
 ) -> Figure:
     """Plot the tile grid with traversal order, for debugging and validation.
 
+    Beam-side adapter over :func:`plot_tile_grid`, which takes the field of view
+    directly -- a fluorescence camera has a real FOV in both axes rather than an
+    `hfw` with the vertical inferred, the same asymmetry `compute_tile_grid_from_fov`
+    exists for.
+
     Args:
         tiles: Ordered list of TilePosition objects (acquisition order).
         settings: Overview acquisition settings (for FOV dimensions and labels).
@@ -47,47 +52,112 @@ def plot_tile_positions(
     Returns:
         The matplotlib Figure.
     """
-    import matplotlib.patches as mpatches
-    from fibsem import constants
-
     image_width, image_height = settings.image_settings.resolution
-    tile_fov_x = settings.image_settings.hfw * constants.SI_TO_MICRO  # µm
+    tile_fov_x = settings.image_settings.hfw
     tile_fov_y = tile_fov_x * (image_height / image_width)
+
+    return plot_tile_grid(
+        tiles,
+        fov_x=tile_fov_x,
+        fov_y=tile_fov_y,
+        ax=ax,
+        stage_positions=stage_positions,
+        title=(
+            f"{settings.tile_order.value.title()} — {settings.nrows}×{settings.ncols} tiles, "
+            f"{settings.overlap*100:.0f}% overlap"
+        ),
+    )
+
+
+def plot_tile_grid(
+    grid: list[TilePosition],
+    fov_x: float,
+    fov_y: float,
+    order: Optional[list[TilePosition]] = None,
+    ax: Optional[plt.Axes] = None,
+    stage_positions: Optional[list[FibsemStagePosition]] = None,
+    title: Optional[str] = None,
+) -> Figure:
+    """Draw a tile grid: what gets acquired, in what order, and what gets skipped.
+
+    Skipped tiles are drawn hollow and unnumbered rather than omitted. A sparse
+    overview otherwise looks identical to a smaller dense one, and the difference
+    between "not acquired" and "acquired but dark" is the whole reason the mask is
+    recorded in the first place.
+
+    Args:
+        grid: Every tile in the grid, enabled or not. Defines what is drawn.
+        fov_x: Tile width in metres.
+        fov_y: Tile height in metres.
+        order: The enabled tiles in traversal order. Defaults to the enabled tiles in
+            the order `grid` gives them. Numbering and the path follow this list.
+        ax: Optional existing axes to draw on; creates a new figure if None.
+        stage_positions: Optional projected positions, same length as `order`. Overlaid
+            as white crosses and a dotted path, so the ideal grid can be compared with
+            the real stage coordinates the projection returned.
+        title: Optional axes title.
+    Returns:
+        The matplotlib Figure.
+    """
+    import matplotlib.patches as mpatches
+
+    if order is None:
+        order = [t for t in grid if t.enabled]
+
+    tile_fov_x = fov_x * constants.SI_TO_MICRO  # µm
+    tile_fov_y = fov_y * constants.SI_TO_MICRO
 
     if ax is None:
         fig, ax = plt.subplots(1, 1, figsize=(8, 6))
     else:
         fig = ax.get_figure()
 
-    # draw tiles
-    for order_idx, tile in enumerate(tiles):
-        cx = tile.dx * constants.SI_TO_MICRO  # µm
-        cy = tile.dy * constants.SI_TO_MICRO
-        x0 = cx - tile_fov_x / 2
-        y0 = cy - tile_fov_y / 2
+    def centre(tile: TilePosition) -> Tuple[float, float]:
+        return tile.dx * constants.SI_TO_MICRO, tile.dy * constants.SI_TO_MICRO
+
+    # skipped tiles first, so the acquired ones draw over them
+    for tile in grid:
+        if tile.enabled:
+            continue
+        cx, cy = centre(tile)
+        ax.add_patch(mpatches.FancyBboxPatch(
+            (cx - tile_fov_x / 2, cy - tile_fov_y / 2), tile_fov_x, tile_fov_y,
+            boxstyle="round,pad=0.01",
+            linewidth=1, edgecolor="#5a5f6e", facecolor="none", linestyle="--",
+        ))
+        ax.text(cx, cy, "—", ha="center", va="center", fontsize=8, color="#5a5f6e")
+
+    for order_idx, tile in enumerate(order):
+        cx, cy = centre(tile)
         colour = POSITION_COLOURS[tile.row % len(POSITION_COLOURS)]
-        rect = mpatches.FancyBboxPatch(
-            (x0, y0), tile_fov_x, tile_fov_y,
+        ax.add_patch(mpatches.FancyBboxPatch(
+            (cx - tile_fov_x / 2, cy - tile_fov_y / 2), tile_fov_x, tile_fov_y,
             boxstyle="round,pad=0.01",
             linewidth=1, edgecolor="white", facecolor=colour, alpha=0.4,
-        )
-        ax.add_patch(rect)
+        ))
         ax.text(cx, cy, str(order_idx), ha="center", va="center",
                 fontsize=8, color="white", fontweight="bold")
 
-    # draw traversal path
-    if len(tiles) > 1:
-        xs = [t.dx * constants.SI_TO_MICRO for t in tiles]
-        ys = [t.dy * constants.SI_TO_MICRO for t in tiles]
-        for k in range(len(tiles) - 1):
-            ax.annotate("", xy=(xs[k + 1], ys[k + 1]), xytext=(xs[k], ys[k]),
+    # traversal path -- through the acquired tiles only, so a jump over a skipped
+    # region is visible as a long arrow rather than hidden
+    if len(order) > 1:
+        pts = [centre(t) for t in order]
+        for (x0, y0), (x1, y1) in zip(pts, pts[1:]):
+            ax.annotate("", xy=(x1, y1), xytext=(x0, y0),
                         arrowprops=dict(arrowstyle="->", color="white", lw=1.0))
 
     # overlay actual projected stage positions (if provided)
-    if stage_positions is not None and len(stage_positions) > 0:
+    if stage_positions is not None and len(stage_positions) > 0 and order:
+        # Anchored on the first tile *visited*, not on the grid origin. The projection
+        # centres the grid on wherever the stage already is, so its coordinates differ
+        # from the grid's by a constant offset. Subtracting only `stage_positions[0]`
+        # leaves the overlay displaced by that offset, which looks exactly like a
+        # geometry error and hides the thing actually worth seeing: whether the *shape*
+        # of the projected path matches the grid it came from.
         ref = stage_positions[0]
-        sxs = [(sp.x - ref.x) * constants.SI_TO_MICRO for sp in stage_positions]
-        sys_ = [(sp.y - ref.y) * constants.SI_TO_MICRO for sp in stage_positions]
+        anchor_x, anchor_y = centre(order[0])
+        sxs = [anchor_x + (sp.x - ref.x) * constants.SI_TO_MICRO for sp in stage_positions]
+        sys_ = [anchor_y + (sp.y - ref.y) * constants.SI_TO_MICRO for sp in stage_positions]
         ax.plot(sxs, sys_, linestyle=":", color="white", lw=0.8, alpha=0.6)
         ax.plot(sxs, sys_, marker="x", color="white", ms=6, markeredgewidth=1.5, linestyle="none")
 
@@ -101,11 +171,8 @@ def plot_tile_positions(
     ax.xaxis.label.set_color("white")
     ax.yaxis.label.set_color("white")
     ax.title.set_color("white")
-    strategy_name = settings.tile_order.value.title()
-    ax.set_title(
-        f"{strategy_name} — {settings.nrows}×{settings.ncols} tiles, "
-        f"{settings.overlap*100:.0f}% overlap"
-    )
+    if title:
+        ax.set_title(title)
     ax.autoscale_view()
     fig.tight_layout()
     return fig

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -24,13 +24,14 @@ from fibsem.fm.acquisition import (
 )
 from fibsem.fm.structures import (
     AutoFocusMode,
+    AutoFocusSettings,
     ChannelSettings,
     FluorescenceImage,
     FMStagePosition,
     OverviewParameters,
     ZParameters,
 )
-from fibsem.structures import FibsemStagePosition
+from fibsem.structures import FibsemStagePosition, TileOrderStrategy
 
 
 @pytest.fixture
@@ -1198,11 +1199,20 @@ def test_cancel_before_the_first_tile_raises(fm_microscope, monkeypatch):
     with pytest.raises(OperationCancelledError):
         runner.run()
 
-    assert runner.tileset == [], "no tiles were acquired before the cancel"
+    # The grid is allocated up front, so the shape is the grid's whatever happened.
+    assert [[t for t in row] for row in runner.tileset] == [[None, None], [None, None]]
 
 
-def test_cancel_midway_keeps_the_completed_rows_on_the_runner(fm_microscope, monkeypatch):
-    """Rows are appended whole, so a mid-row cancel discards that row's tiles."""
+def test_cancel_midway_keeps_every_acquired_tile_in_its_grid_position(
+    fm_microscope, monkeypatch
+):
+    """A partial row survives, and each tile stays at its own (row, col).
+
+    Tiles used to be appended a whole row at a time, so a mid-row cancel threw that
+    row away. They are now written by index into a pre-allocated grid: nothing
+    acquired is lost, and nothing shifts position to fill a gap -- which matters
+    because the canvas coordinates a tile stitches to come from its indices.
+    """
     microscope = fm_microscope
     _record_tile_positions(microscope, monkeypatch)
     stub = Mock(spec=FluorescenceImage)
@@ -1215,10 +1225,15 @@ def test_cancel_midway_keeps_the_completed_rows_on_the_runner(fm_microscope, mon
     with pytest.raises(OperationCancelledError):
         runner.run()
 
-    # 3 tiles on a 2-wide grid: row 0 complete, row 1 abandoned partway.
-    assert len(runner.tileset) == 1
-    assert len(runner.tileset[0]) == 2
-    assert all(tile is not None for tile in runner.tileset[0])
+    # 3 tiles into a 3x2 typewriter traversal: row 0 complete, row 1 half done.
+    acquired = [
+        (r, c)
+        for r, row in enumerate(runner.tileset)
+        for c, tile in enumerate(row)
+        if tile is not None
+    ]
+    assert acquired == [(0, 0), (0, 1), (1, 0)]
+    assert len(runner.tileset) == 3 and all(len(row) == 2 for row in runner.tileset)
 
 
 def test_cancel_still_restores_the_starting_position(fm_microscope, monkeypatch):
@@ -1288,3 +1303,176 @@ def test_a_genuine_failure_is_not_reported_as_a_cancel(fm_microscope, monkeypatc
 
     with pytest.raises(RuntimeError, match="camera fell over"):
         _runner(microscope, 2, 2).run()
+
+
+# ── sparse tilesets (FIB-392) ────────────────────────────────────────────
+#
+# A masked run acquires a subset of the grid. What must not change is *where* the
+# acquired tiles go: same stage positions and same canvas coordinates as the dense
+# run, so a sparse overview can be compared with, or later filled in from, a full one.
+
+
+def _sparse_runner(microscope, rows, cols, mask=None, order=None, stop_event=None):
+    return acquisition.FMTiledAcquisitionRunner(
+        microscope=microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.1),
+        overview_parameters=OverviewParameters(
+            rows=rows, cols=cols, overlap=0.1, use_zstack=False,
+            autofocus_mode=AutoFocusMode.NONE,
+            tile_order=order or TileOrderStrategy.TYPEWRITER,
+            tile_mask=mask,
+        ),
+        stop_event=stop_event,
+    )
+
+
+def _plus_mask(n):
+    """Middle row and middle column enabled; corners skipped."""
+    mid = n // 2
+    return [[(i == mid or j == mid) for j in range(n)] for i in range(n)]
+
+
+def test_a_masked_run_visits_only_the_enabled_tiles(fm_microscope, monkeypatch):
+    positions = _record_tile_positions(fm_microscope, monkeypatch)
+
+    _sparse_runner(fm_microscope, 5, 5, mask=_plus_mask(5)).run()
+
+    # 9 enabled tiles of 25, plus the restore move at the end. Nothing is driven to a
+    # skipped tile -- the point of a sparse overview is the travel and the exposure it
+    # does not spend.
+    assert len(positions) == 9 + 1
+
+
+def test_skipped_tiles_stay_none_and_the_grid_keeps_its_shape(fm_microscope, monkeypatch):
+    _record_tile_positions(fm_microscope, monkeypatch)
+    mask = _plus_mask(5)
+
+    runner = _sparse_runner(fm_microscope, 5, 5, mask=mask)
+    tileset = runner.run()
+
+    assert len(tileset) == 5 and all(len(row) == 5 for row in tileset)
+    for r in range(5):
+        for c in range(5):
+            assert (tileset[r][c] is not None) is mask[r][c], f"tile ({r}, {c})"
+
+
+def test_masking_changes_which_tiles_are_acquired_never_where(fm_microscope, monkeypatch):
+    """The headline property, at runner level."""
+    dense = _record_tile_positions(fm_microscope, monkeypatch)
+    _sparse_runner(fm_microscope, 5, 5).run()
+    dense_by_tile = {
+        (k // 5, k % 5): p for k, p in enumerate(list(dense)[:25])
+    }
+
+    sparse = _record_tile_positions(fm_microscope, monkeypatch)
+    mask = _plus_mask(5)
+    _sparse_runner(fm_microscope, 5, 5, mask=mask).run()
+
+    enabled = [(r, c) for r in range(5) for c in range(5) if mask[r][c]]
+    for (row, col), position in zip(enabled, list(sparse)[:len(enabled)]):
+        expected = dense_by_tile[(row, col)]
+        assert position.x == pytest.approx(expected.x), f"tile ({row}, {col}) x"
+        assert position.y == pytest.approx(expected.y), f"tile ({row}, {col}) y"
+        assert position.z == pytest.approx(expected.z), f"tile ({row}, {col}) z"
+
+
+def test_a_fully_masked_grid_is_rejected(fm_microscope, monkeypatch):
+    """Rather than silently returning an all-zero mosaic."""
+    _record_tile_positions(fm_microscope, monkeypatch)
+    mask = [[False] * 3 for _ in range(3)]
+
+    with pytest.raises(ValueError, match="disables every tile"):
+        _sparse_runner(fm_microscope, 3, 3, mask=mask).run()
+
+
+def test_progress_totals_count_enabled_tiles_not_grid_cells(fm_microscope, monkeypatch):
+    """A bar that stops at 9/25 on a successful run reads as a failure."""
+    _record_tile_positions(fm_microscope, monkeypatch)
+    emitted = []
+    fm_microscope.fm.acquisition_progress_signal.connect(emitted.append)
+
+    _sparse_runner(fm_microscope, 5, 5, mask=_plus_mask(5)).run()
+
+    totals = {p["total"] for p in emitted if "total" in p}
+    assert totals == {9}
+    counters = [p["current"] for p in emitted if p.get("state") == "acquiring"]
+    assert counters[-1] == 9
+
+
+def test_tile_order_drives_the_visit_sequence(fm_microscope, monkeypatch):
+    """FM had no ordering at all before this; it was hard-coded row-major."""
+    typewriter = _record_tile_positions(fm_microscope, monkeypatch)
+    _sparse_runner(fm_microscope, 3, 3, order=TileOrderStrategy.TYPEWRITER).run()
+
+    serpentine = _record_tile_positions(fm_microscope, monkeypatch)
+    _sparse_runner(fm_microscope, 3, 3, order=TileOrderStrategy.SERPENTINE).run()
+
+    # Row 1 runs right-to-left under serpentine, so tiles 3..5 are reversed.
+    assert [p.x for p in list(serpentine)[3:6]] == [p.x for p in list(typewriter)[3:6]][::-1]
+    # Same set of positions either way -- only the order differs.
+    assert sorted(round(p.x, 12) for p in list(typewriter)[:9]) == \
+           sorted(round(p.x, 12) for p in list(serpentine)[:9])
+
+
+def test_each_row_autofocus_is_promoted_to_each_tile_for_a_spiral(fm_microscope, monkeypatch):
+    """A spiral revisits rows non-sequentially, so "on each new row" is meaningless."""
+    _record_tile_positions(fm_microscope, monkeypatch)
+    runner = acquisition.FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.1),
+        overview_parameters=OverviewParameters(
+            rows=3, cols=3, overlap=0.1, use_zstack=False,
+            autofocus_mode=AutoFocusMode.EACH_ROW,
+            tile_order=TileOrderStrategy.SPIRAL,
+        ),
+        # _setup resolves the autofocus configuration, and rejects a non-NONE mode
+        # without one -- so the promotion cannot be observed unless this is supplied.
+        autofocus_settings=AutoFocusSettings(),
+    )
+    runner._setup()
+
+    assert runner._autofocus_mode is AutoFocusMode.EACH_TILE
+
+
+def test_each_row_autofocus_survives_a_row_wise_order(fm_microscope, monkeypatch):
+    """The promotion is specific to SPIRAL; typewriter and serpentine keep rows."""
+    _record_tile_positions(fm_microscope, monkeypatch)
+    runner = acquisition.FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.1),
+        overview_parameters=OverviewParameters(
+            rows=3, cols=3, overlap=0.1, use_zstack=False,
+            autofocus_mode=AutoFocusMode.EACH_ROW,
+            tile_order=TileOrderStrategy.SERPENTINE,
+        ),
+        autofocus_settings=AutoFocusSettings(),
+    )
+    runner._setup()
+
+    assert runner._autofocus_mode is AutoFocusMode.EACH_ROW
+
+
+def test_stitching_leaves_skipped_tiles_as_zeros_at_full_canvas_size(fm_microscope):
+    """The mosaic is the whole grid whatever the mask, with gaps left black."""
+    mask = _plus_mask(3)
+    dense = acquire_and_stitch_tileset(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=3, cols=3, overlap=0.1),
+    )
+    sparse = acquire_and_stitch_tileset(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=3, cols=3, overlap=0.1, tile_mask=mask),
+    )
+
+    assert sparse.data.shape == dense.data.shape
+    # The corners are skipped, so the canvas there was never written.
+    tile_h, tile_w = fm_microscope.fm.camera.resolution[1], fm_microscope.fm.camera.resolution[0]
+    assert not sparse.data[0, 0, :tile_h // 2, :tile_w // 2].any(), "top-left corner"
+    assert sparse.data[0, 0].any(), "the enabled tiles were written"
+
+
+def test_a_tileset_of_nothing_but_gaps_is_rejected(fm_microscope):
+    with pytest.raises(ValueError, match="no acquired tiles"):
+        stitch_tileset([[None, None], [None, None]], 0.1)

--- a/tests/test_sparse_tiles.py
+++ b/tests/test_sparse_tiles.py
@@ -1,0 +1,185 @@
+"""Sparse tile grids: the enable mask, and the order-then-filter rule.
+
+A sparse acquisition visits a subset of the grid. Two properties have to hold or the
+result is silently wrong rather than loudly broken:
+
+* **Canvas placement is unaffected by the mask.** An acquired tile lands at exactly the
+  canvas coordinates it would have had in the dense mosaic, so a sparse overview can be
+  compared with, or later filled in from, a dense one.
+* **The traversal is the dense traversal with stops removed**, not a pattern re-derived
+  over the holes -- see `order_tiles`.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from fibsem.imaging.tiling.geometry import (
+    compute_tile_grid_from_fov,
+    order_tiles,
+)
+from fibsem.structures import TileOrderStrategy
+
+GRID_KWARGS = dict(fov_x=1.0, fov_y=1.0, image_width=100, image_height=100, overlap=0.0)
+
+
+def make_grid(n, predicate=None):
+    """An n x n grid; `predicate(row, col)` decides which tiles are enabled."""
+    mask = None if predicate is None else [[predicate(i, j) for j in range(n)] for i in range(n)]
+    return compute_tile_grid_from_fov(nrows=n, ncols=n, mask=mask, **GRID_KWARGS)
+
+
+def rc(tiles):
+    return [(t.row, t.col) for t in tiles]
+
+
+def travel(tiles):
+    """Total stage path length through the tiles, in grid units."""
+    return sum(math.dist((a.dx, a.dy), (b.dx, b.dy)) for a, b in zip(tiles, tiles[1:]))
+
+
+# ── the mask itself ──────────────────────────────────────────────────────
+
+
+def test_no_mask_enables_everything():
+    assert all(t.enabled for t in make_grid(4))
+
+
+def test_disabled_tiles_are_still_returned():
+    """They hold the grid's shape; `order_tiles` is what drops them."""
+    tiles = make_grid(4, lambda i, j: i == j)
+
+    assert len(tiles) == 16
+    assert sum(t.enabled for t in tiles) == 4
+
+
+def test_mask_is_indexed_row_then_col():
+    """A transposed mask would be a silent, symmetric-looking wrong answer."""
+    tiles = {(t.row, t.col): t for t in make_grid(3, lambda i, j: (i, j) == (0, 2))}
+
+    assert tiles[(0, 2)].enabled
+    assert not tiles[(2, 0)].enabled
+
+
+def test_a_numpy_mask_yields_plain_bools():
+    """np.bool_ does not survive yaml.safe_dump, and the mask gets recorded."""
+    mask = np.zeros((3, 3), dtype=bool)
+    mask[1, 1] = True
+
+    tiles = compute_tile_grid_from_fov(nrows=3, ncols=3, mask=mask, **GRID_KWARGS)
+
+    assert all(type(t.enabled) is bool for t in tiles)
+
+
+@pytest.mark.parametrize(
+    ("mask", "match"),
+    [
+        ([[True] * 3] * 2, "2 rows"),        # too few rows
+        ([[True] * 2] * 3, "2 columns"),     # too few columns
+        ([[True] * 3] * 4, "4 rows"),        # too many rows
+    ],
+)
+def test_a_mask_of_the_wrong_shape_is_rejected(mask, match):
+    """Loudly, because the failure mode is invisible: a skipped tile and a dark tile
+    look identical in the mosaic."""
+    with pytest.raises(ValueError, match=match):
+        compute_tile_grid_from_fov(nrows=3, ncols=3, mask=mask, **GRID_KWARGS)
+
+
+# ── canvas placement ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("overlap", [0.0, 0.1, 0.25])
+def test_sparse_tiles_land_where_the_dense_ones_would(overlap):
+    """The headline property. Masking changes which tiles are acquired, never where."""
+    kwargs = dict(GRID_KWARGS, overlap=overlap)
+    predicate = lambda i, j: (i + j) % 2 == 0  # noqa: E731
+
+    dense = {(t.row, t.col): t for t in compute_tile_grid_from_fov(nrows=4, ncols=4, **kwargs)}
+    mask = [[predicate(i, j) for j in range(4)] for i in range(4)]
+    sparse = compute_tile_grid_from_fov(nrows=4, ncols=4, mask=mask, **kwargs)
+
+    for tile in sparse:
+        reference = dense[(tile.row, tile.col)]
+        assert (tile.canvas_x, tile.canvas_y) == (reference.canvas_x, reference.canvas_y)
+        assert (tile.dx, tile.dy) == (reference.dx, reference.dy)
+
+
+# ── ordering ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("strategy", list(TileOrderStrategy))
+def test_ordering_returns_only_enabled_tiles(strategy):
+    tiles = make_grid(5, lambda i, j: i == 2)
+
+    ordered = order_tiles(tiles, strategy)
+
+    assert len(ordered) == 5
+    assert all(t.enabled for t in ordered)
+
+
+@pytest.mark.parametrize("strategy", list(TileOrderStrategy))
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        lambda i, j: (i + j) % 2 == 0,      # checkerboard
+        lambda i, j: i < 3 and j < 3,       # off-centre block
+        lambda i, j: i != 1,                # a whole row missing
+        lambda i, j: (i, j) != (2, 2),      # a single hole
+    ],
+    ids=["checkerboard", "off-centre-block", "whole-row-missing", "single-hole"],
+)
+def test_the_sparse_order_is_the_dense_order_with_stops_removed(strategy, predicate):
+    """The rule, stated as one property over several mask shapes."""
+    dense = order_tiles(make_grid(5), strategy)
+    sparse = order_tiles(make_grid(5, predicate), strategy)
+
+    assert rc(sparse) == [(r, c) for r, c in rc(dense) if predicate(r, c)]
+
+
+def test_spiral_keeps_the_grid_centre_when_the_enabled_block_is_off_centre():
+    """Re-deriving would spiral around the block's centre instead of the grid's.
+
+    Concretely: the enabled top-left 3x3 of a 5x5 starts at the grid centre (2,2) and
+    winds outward from there. A spiral computed over the block alone would start at
+    (1,1) -- a different pattern, and one that no longer means "outward from where the
+    stage already is".
+    """
+    tiles = make_grid(5, lambda i, j: i < 3 and j < 3)
+
+    ours = order_tiles(tiles, TileOrderStrategy.SPIRAL)
+    re_derived = order_tiles([t for t in tiles if t.enabled], TileOrderStrategy.SPIRAL)
+
+    assert (ours[0].row, ours[0].col) == (2, 2)
+    assert (re_derived[0].row, re_derived[0].col) == (1, 1)
+    assert rc(ours) != rc(re_derived)
+
+
+def test_serpentine_parity_follows_the_grid_row_not_the_visit_count():
+    """Known consequence of the order-then-filter rule, recorded rather than asserted good.
+
+    With row 1 absent, rows 0 and 2 are both even-parity grid rows, so both run
+    left-to-right and the stage jumps back across the grid between them. Re-deriving
+    parity over the visited rows would reverse row 2 and save that jump.
+
+    This is the one case where the rule costs travel. It is kept because the rule is
+    uniform and because the same rule is what makes SPIRAL correct; if the travel
+    matters more than the uniformity, this is the test to change.
+    """
+    tiles = make_grid(4, lambda i, j: i != 1)
+
+    ours = order_tiles(tiles, TileOrderStrategy.SERPENTINE)
+    re_derived = order_tiles([t for t in tiles if t.enabled], TileOrderStrategy.SERPENTINE)
+
+    assert rc(ours)[:5] == [(0, 0), (0, 1), (0, 2), (0, 3), (2, 0)]
+    assert rc(re_derived)[:5] == [(0, 0), (0, 1), (0, 2), (0, 3), (2, 3)]
+    assert travel(ours) > travel(re_derived)
+
+
+def test_an_empty_mask_yields_no_tiles_to_visit():
+    """The grid still exists -- the canvas keeps its size -- but nothing is acquired."""
+    tiles = make_grid(3, lambda i, j: False)
+
+    assert len(tiles) == 9
+    assert order_tiles(tiles, TileOrderStrategy.TYPEWRITER) == []


### PR DESCRIPTION
Acquire only selected regions of an overview. Skipped tiles stay as gaps in the mosaic rather than forcing a full rectangular scan.

The data model is a **per-tile enable mask**, which is maximally general — rectangular sub-region selection becomes a GUI affordance that sets a mask, not a separate concept in the engine.

## Geometry core

`TilePosition` gains `enabled`, and both grid functions take a `mask[row][col]`. Disabled tiles are **still returned** rather than omitted: they hold the grid's shape, so the canvas extent and the traversal pattern don't change when tiles are skipped.

`order_tiles` therefore **orders over the full grid extent and filters afterwards**. Filtering first would re-derive the pattern over the holes — a spiral would wind around the enabled tiles' bounding box instead of the grid's centre, and serpentine row parity would flip if a whole row were disabled. Both are pinned by test.

There is one case where the uniform rule costs travel: with a whole row absent, the rows either side share parity, so both run left-to-right and the stage jumps back across the grid between them (31.8 vs 25.0 grid units on a 6×6 with two rows off). Measured, accepted, and recorded in `test_serpentine_parity_follows_the_grid_row_not_the_visit_count` rather than left implicit — uniformity wins, and the same rule is what makes SPIRAL correct.

## FM runner

Reads the mask and a tile order off `OverviewParameters`, iterates the ordered tiles, and **writes into a pre-allocated grid by index instead of appending rows**.

Appending assumed a row-major visit over a full grid. Neither holds once the order is configurable or tiles can be skipped, and the failure would have been silent — the mosaic would still stitch, with tiles in the wrong places. A side benefit: a cancelled run now keeps a partial row instead of discarding it.

This is also where **FM gains tile ordering, which it had none of** — `_run_tile_loop` was hard-coded row-major and never called `order_tiles`, so FM was typewriter-only while the beam side had serpentine and spiral. `EACH_ROW` autofocus promotes to `EACH_TILE` under a spiral, as the beam runner already did.

Progress totals count enabled tiles, not grid cells — a bar stopping at 9/25 on a successful sparse run reads as a failure.

`stitch_tileset` tolerates gaps in the four places it dereferenced tiles blind, including `ref_tile = tileset[0][0]`, which crashed whenever tile (0, 0) was masked out. Missing tiles are left as canvas zeros at full mosaic size.

## Diagnostic plotting

`plot_tile_grid` takes the field of view directly, so fluorescence can plot without inventing an `hfw`, and draws skipped tiles hollow rather than omitting them — a sparse overview otherwise looks identical to a smaller dense one.

Two fixes the plot found **in itself** while being used to verify this:

- The stage overlay was anchored on `stage_positions[0]` alone, leaving it displaced by the whole grid-centring offset. It showed a mismatch on a correct run.
- It compared display-space tiles against stage-space positions, which diverge by design under a flip. Anchoring on the first tile visited puts both in one frame, and a real geometry error still shows as a divergence.

## Verification

Run end to end against the Demo microscope, compustage at t = −180°, under both `NONE` and `FLIP_XY`:

- 9 of 25 tiles acquired at exactly the masked positions; **one stage move per enabled tile** — no travel spent on skipped ones
- mosaic at full grid size (4712×4712) with gaps left black
- the acquisition index the simulator stamps into each image lands in the mosaic **in traversal order**, which ties ordering, projection and canvas placement together in one observation
- under `FLIP_XY` the stage sweep is the exact negation of `NONE` (row 0 at −184.32 µm vs +184.32 µm) and the mosaic stays coherent — the hardware observation behind #226, reproduced in sim with the settled explanation

Separately measured: mapping a recorded stage delta back through the camera transform lands on the display grid **bit-exactly for all four transforms** (1e-15).

`1696 passed, 24 skipped`.

## Not in this PR

The **metadata trap** from the issue — persisting which tiles were acquired alongside the stitched mosaic — is not done. Until it is, a skipped tile and a genuinely dark one remain indistinguishable downstream, so correlation and targeting can consume the zeros as signal. That is the next PR, and the beam-side mask a third.
