### PR TITLE
Record where a stitched mosaic actually is (FIB-392)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -440,9 +440,20 @@ class FMTiledAcquisitionRunner:
         return self.tileset
 
     def run_and_stitch(self) -> FluorescenceImage:
-        """Acquire every tile and return the stitched mosaic."""
+        """Acquire every tile and return the stitched mosaic.
+
+        The mosaic is an ordinary fluorescence image that happens to be large, and it
+        reports where it is from what the run captured rather than from what the
+        stitcher can infer: the grid is centred on the starting stage position, and
+        every tile is taken at the starting objective position.
+        """
         self.run()
-        return stitch_tileset(self.tileset, self.overview_parameters.overlap)  # type: ignore
+        return stitch_tileset(
+            self.tileset,
+            self.overview_parameters.overlap,
+            centre_position=self._initial_position,
+            objective_position=self._initial_objective_position,
+        )
 
     # ── phases ───────────────────────────────────────────────────────────
 
@@ -815,8 +826,10 @@ def acquire_tileset(
 
 
 def stitch_tileset(
-    tileset: List[List[FluorescenceImage]],
-    tile_overlap: float = 0.1
+    tileset: List[List[Optional[FluorescenceImage]]],
+    tile_overlap: float,
+    centre_position: FibsemStagePosition,
+    objective_position: Optional[float] = None,
 ) -> FluorescenceImage:
     """Stitch a tileset of fluorescence images into a single mosaic image.
 
@@ -825,9 +838,25 @@ def stitch_tileset(
     dimensions (nc_channel, 1, ny, nx). Overlapping regions are handled by taking
     pixels from the rightmost/bottommost tile.
 
+    The result is an ordinary fluorescence image that happens to be large: the same
+    metadata a single acquisition carries, describing the whole mosaic. Nothing about
+    it is tileset-specific, so anything that consumes an FM image consumes this.
+
     Args:
-        tileset: List of lists containing FluorescenceImage objects [row][col]
+        tileset: List of lists containing FluorescenceImage objects [row][col].
+            `None` entries are tiles that were not acquired; they are left as canvas
+            zeros.
         tile_overlap: Fraction of overlap between adjacent tiles (0.0 to 1.0)
+        centre_position: Stage position of the mosaic centre. Required: where the
+            mosaic sits is what places it on the canvas, so it has to be known rather
+            than inferred. The grid is laid out centred on wherever the stage was when
+            the run started, so the runner passes that position through and it is exact
+            by construction. Deriving it instead -- by averaging the acquired tiles --
+            is only right when they are symmetric about the centre: true of a full
+            grid, false of a masked or cancelled one, and out by up to a whole tile.
+        objective_position: Objective z for the mosaic, recorded on every channel.
+            Every tile is acquired at the run's initial objective position, so that is
+            the mosaic's. Without it the first acquired tile's value is kept.
 
     Returns:
         Single FluorescenceImage containing the stitched mosaic
@@ -954,50 +983,17 @@ def stitch_tileset(
     # Update resolution to reflect new mosaic size
     stitched_metadata.resolution = (mosaic_width, mosaic_height)
 
-    # Calculate the center position as average of all tile positions
-    if any(
-        getattr(tile.metadata, "stage_position", None) is not None
-        for tile in acquired
-    ):
-        # Collect all stage positions from tiles
-        x_positions = []
-        y_positions = []
-        z_positions = []
-        r_positions = []
-        t_positions = []
-        coordinate_systems = []
+    # Where the mosaic is. The grid is laid out centred on wherever the stage was when
+    # the run started, so that position *is* the mosaic centre -- exact, and independent
+    # of which tiles were acquired.
+    stitched_metadata.stage_position = deepcopy(centre_position)
+    stitched_metadata.stage_position.name = f"stitched_mosaic_{rows}x{cols}"
 
-        for tile in acquired:
-            pos = getattr(tile.metadata, "stage_position", None)
-            if pos is not None:
-                x_positions.append(pos.x)
-                y_positions.append(pos.y)
-                z_positions.append(pos.z)
-                r_positions.append(pos.r)
-                t_positions.append(pos.t)
-                coordinate_systems.append(pos.coordinate_system)
-
-        if x_positions:  # If we found any positions
-            # Calculate average position (center of mosaic)
-            avg_x = sum(x_positions) / len(x_positions)
-            avg_y = sum(y_positions) / len(y_positions)
-            avg_z = sum(z_positions) / len(z_positions)
-            avg_r = sum(r_positions) / len(r_positions)
-            avg_t = sum(t_positions) / len(t_positions)
-
-            # Use coordinate system from first tile
-            coord_system = coordinate_systems[0] if coordinate_systems else "Unknown"
-
-            # Update stage position to mosaic center
-            stitched_metadata.stage_position = FibsemStagePosition(
-                x=avg_x,
-                y=avg_y,
-                z=avg_z,
-                r=avg_r,
-                t=avg_t,
-                coordinate_system=coord_system,
-                name=f"stitched_mosaic_{rows}x{cols}",
-            )
+    # Every tile is acquired at the run's initial objective position, so it is the
+    # mosaic's too. Recorded per channel, as it is on a single acquisition.
+    if objective_position is not None:
+        for channel in stitched_metadata.channels:
+            channel.objective_position = objective_position
 
     # Create stitched FluorescenceImage
     stitched_image = FluorescenceImage(data=mosaic_data, metadata=stitched_metadata)
@@ -1057,22 +1053,21 @@ def acquire_and_stitch_tileset(
     # previous check -- empty tileset, or any tile None -- could not tell a user
     # cancel from a tile that genuinely failed, and reported both the same way.
     try:
-        tileset = acquire_tileset(
+        # Driven through the runner rather than the `acquire_tileset` wrapper, so the
+        # stitched mosaic can be given the position and objective the run captured
+        # instead of values inferred from whichever tiles came back.
+        overview_image = FMTiledAcquisitionRunner(
             microscope=microscope,
             channel_settings=channel_settings,
             overview_parameters=overview_parameters,
             zparams=zparams,
-            beam_type=beam_type,
             autofocus_settings=autofocus_settings,
             save_directory=tiles_directory,
             stop_event=stop_event,
-        )
+        ).run_and_stitch()
     except OperationCancelledError:
         logging.info("Tileset acquisition was cancelled, cannot stitch")
         return None
-
-    # Stitch the tileset into a single overview image
-    overview_image = stitch_tileset(tileset, overview_parameters.overlap)  # type: ignore
 
     # Save overview to experiment directory
     if save_directory is not None:

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -1475,4 +1475,91 @@ def test_stitching_leaves_skipped_tiles_as_zeros_at_full_canvas_size(fm_microsco
 
 def test_a_tileset_of_nothing_but_gaps_is_rejected(fm_microscope):
     with pytest.raises(ValueError, match="no acquired tiles"):
-        stitch_tileset([[None, None], [None, None]], 0.1)
+        stitch_tileset([[None, None], [None, None]], 0.1, FibsemStagePosition())
+
+
+# ── the mosaic is just a large image ─────────────────────────────────────
+#
+# A stitched overview is an ordinary fluorescence image that happens to be big. It
+# carries the metadata a single acquisition carries, describing the whole mosaic --
+# nothing tileset-specific. What that demands is that the metadata be *true*: the
+# centre it reports has to be where the mosaic actually is, whatever was acquired.
+
+
+@pytest.mark.parametrize(
+    ("name", "predicate"),
+    [
+        ("dense", None),
+        ("symmetric-plus", lambda i, j: i == 1 or j == 1),
+        ("off-centre-block", lambda i, j: i < 2 and j < 2),
+        ("single-corner-tile", lambda i, j: (i, j) == (0, 0)),
+    ],
+)
+def test_the_mosaic_centre_is_the_run_centre_whatever_was_acquired(
+    fm_microscope, name, predicate
+):
+    """Averaging the acquired tiles only finds the centre when they are symmetric.
+
+    A single corner tile of a 3x3 averages to that tile -- a full tile away from the
+    mosaic centre, on a canvas that is still the whole 3x3. The grid is laid out
+    centred on the starting stage position, so that position is the answer, exactly,
+    and independently of the mask.
+    """
+    mask = (None if predicate is None
+            else [[predicate(i, j) for j in range(3)] for i in range(3)])
+    centre = fm_microscope.get_stage_position()
+
+    mosaic = acquire_and_stitch_tileset(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=3, cols=3, overlap=0.1, tile_mask=mask),
+    )
+
+    assert mosaic.metadata.stage_position.x == pytest.approx(centre.x, abs=1e-12)
+    assert mosaic.metadata.stage_position.y == pytest.approx(centre.y, abs=1e-12)
+    assert mosaic.metadata.stage_position.z == pytest.approx(centre.z, abs=1e-12)
+
+
+def test_the_mosaic_records_the_objective_the_run_used(fm_microscope):
+    """Every tile is taken at the run's initial objective position, so it is the
+    mosaic's -- not whatever the first acquired tile happened to carry."""
+    objective = fm_microscope.fm.objective.position
+
+    mosaic = acquire_and_stitch_tileset(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
+    )
+
+    assert all(ch.objective_position == pytest.approx(objective)
+               for ch in mosaic.metadata.channels)
+
+
+def test_the_mosaic_carries_the_same_metadata_as_a_single_image(fm_microscope):
+    """Only the resolution differs. It is a large image, not a different kind of thing."""
+    channel = ChannelSettings(name="DAPI", excitation_wavelength=358, exposure_time=0.001)
+    single = acquire_image(fm_microscope.fm, channel)
+
+    mosaic = acquire_and_stitch_tileset(
+        microscope=fm_microscope,
+        channel_settings=channel,
+        overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
+    )
+
+    assert [ch.name for ch in mosaic.metadata.channels] == \
+           [ch.name for ch in single.metadata.channels]
+    assert mosaic.metadata.pixel_size_x == single.metadata.pixel_size_x
+    assert mosaic.metadata.pixel_size_y == single.metadata.pixel_size_y
+    assert mosaic.metadata.resolution[0] > single.metadata.resolution[0]
+    assert mosaic.metadata.resolution == (mosaic.data.shape[-1], mosaic.data.shape[-2])
+
+
+def test_stitching_demands_to_be_told_where_the_mosaic_is():
+    """Not an optional refinement: it is what places the mosaic on the canvas.
+
+    Deriving it from the tiles is available and wrong, so the parameter is required
+    rather than defaulted -- a caller that does not know the centre cannot produce a
+    correctly-placed mosaic, and should fail rather than guess.
+    """
+    with pytest.raises(TypeError, match="centre_position"):
+        stitch_tileset([[Mock(spec=FluorescenceImage)]], 0.1)


### PR DESCRIPTION
A stitched overview is an **ordinary fluorescence image that happens to be large** — the same metadata a single acquisition carries, describing the whole mosaic, with nothing tileset-specific about it. That only works if the metadata is true.

## The bug

`stitch_tileset` derived the mosaic's stage position by **averaging the acquired tile positions**. That's the centre only when they're symmetric about it — true of a full grid, false the moment a mask or a cancellation makes them asymmetric.

Measured on a 3×3 at 10% overlap, against a stage that started at the origin:

| acquired | centre reported |
|---|---|
| dense 3×3 | (0.0, 0.0) µm ✓ |
| symmetric plus | (0.0, 0.0) µm ✓ |
| top-left 2×2 block | **(−46.1, +46.1) µm** |
| single corner tile | **(−92.2, +92.2) µm** |

A whole tile out, on a canvas that is still the full 3×3. For correlation that's a registration error with nothing to show it — the image looks fine.

## The fix

The run already knows the answer. The grid is laid out centred on the stage position captured at the start, so **that position *is* the mosaic centre** — exact by construction, independent of which tiles came back. Likewise every tile is acquired at the initial objective position, so that's the mosaic's objective, rather than whichever tile happened to be stitched first.

All four cases above now report (0.0, 0.0).

`centre_position` is **required**, not defaulted. Where the mosaic sits is what places it on the canvas, so a caller that doesn't know it cannot produce a correctly placed mosaic and should fail rather than guess. The averaging fallback is deleted so there's no path back to a fabricated position. Only two direct callers existed outside the runner, both in tests.

`acquire_and_stitch_tileset` now drives the runner directly instead of going through the `acquire_tileset` wrapper — that's what lets the captured position and objective reach the stitcher. The GUI call site is unaffected.

## Audited alongside, correct as they stand

- `resolution` matches the data shape with `(width, height)` ordering — checked on a non-square 2×5 grid, where a transposition would show
- pixel size carried through from the tiles unchanged
- channels survive multi-channel stitching
- a z-stack tileset stitches to a `(C, 1, Y, X)` projection with `z_positions` and `pixel_size_z` left `None`, so the metadata agrees with the data being one plane

## Found while auditing, NOT fixed here

The canvas places tile *j* at `j × round(tile_px × (1 − overlap))` while the stage steps by the **exact** value. The rounding is applied once per column, so it **accumulates**: ±1.6 px across a 5×5, ±7.6 px across a 20×20. It's exactly zero whenever the overlap divides the tile width evenly (0% and 25% at 1024 px, every overlap at 1200 px), which is why it hasn't surfaced. The mosaic is slightly stretched relative to the stage positions its tiles were taken at.

The fix is to place tile *j* at `round(j × exact_step)`, bounding the total error at ±0.5 px for any grid size. Left out of this PR because it changes canvas coordinates for the **beam** tiler too, so it wants its own tests and its own blast radius.

`1703 passed, 24 skipped`.
