### PR TITLE
Rebuild the FM overview acquisition UI (FIB-393)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import threading
+from dataclasses import replace
 import time
 from copy import deepcopy
 from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING, Literal
@@ -11,7 +12,7 @@ import matplotlib.patches as patches
 
 from fibsem import utils
 from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
-from fibsem.fm.calibration import run_autofocus
+from fibsem.fm.calibration import run_autofocus, run_coarse_fine_autofocus
 from fibsem.imaging.tiling.geometry import (
     TilePosition,
     compute_tile_grid_from_fov,
@@ -347,17 +348,21 @@ def acquire_at_positions(
 def run_tileset_autofocus(
     microscope: 'FibsemMicroscope',
     channel_settings: Optional[ChannelSettings],
-    z_parameters: Optional[ZParameters],
-    method: str = "tenengrad",
+    autofocus_settings: AutoFocusSettings,
     stop_event: Optional[threading.Event] = None,
 ) -> bool:
     """Run autofocus during tileset acquisition with error handling and logging.
 
+    A thin wrapper over `run_coarse_fine_autofocus` -- the same sweep the live
+    auto-focus button runs -- so a tileset focuses exactly the way focusing by hand
+    does. It used to iterate passes itself, which made it a second implementation of
+    a loop that already existed and could drift from it.
+
     Args:
         microscope: The FIBSEM microscope instance
         channel_settings: Channel settings for autofocus
-        z_parameters: Z parameters for autofocus range
-        method: Autofocus method to use (default: 'tenengrad')
+        autofocus_settings: Sweep passes, method and channel. Every enabled pass runs,
+            each centred on where the previous one left the objective.
         stop_event: Threading event to check for cancellation (optional)
 
     Returns:
@@ -369,11 +374,10 @@ def run_tileset_autofocus(
         )
         return False
     try:
-        result = run_autofocus(
+        result = run_coarse_fine_autofocus(
             microscope=microscope.fm,
+            autofocus_settings=autofocus_settings,
             channel_settings=channel_settings,
-            z_parameters=z_parameters,
-            method=method,
             stop_event=stop_event,
         )
         if result is None:
@@ -608,10 +612,18 @@ class FMTiledAcquisitionRunner:
             f"{len(enabled_passes)} enabled pass(es)"
         )
 
-        self._autofocus_method = self.autofocus_settings.method.value
-        # Per-tile / per-row autofocus uses the final (narrowest) enabled pass.
-        # NOTE: a wider initial pass should only be used once, before acquisition.
-        self._autofocus_zparams = ZParameters.from_focus_pass(enabled_passes[-1])
+        # The once-before-acquisition focus runs every enabled pass, coarse to fine:
+        # each sweep centres on where the previous one left the objective, which is
+        # the entire point of configuring more than one. Per-row and per-tile focus
+        # runs only the narrowest -- they refine an already-good position, and paying
+        # for a wide sweep at every tile would dominate the acquisition.
+        #
+        # Previously *all* modes used the narrowest pass alone, so a configured coarse
+        # pass was silently ignored even for the case it exists for.
+        self._autofocus_full = replace(self.autofocus_settings, passes=enabled_passes)
+        self._autofocus_fine = replace(
+            self.autofocus_settings, passes=[enabled_passes[-1]]
+        )
 
     def _compute_grid(self) -> None:
         """Lay the grid out once and project every tile to an absolute position.
@@ -735,11 +747,13 @@ class FMTiledAcquisitionRunner:
         if self._autofocus_mode != mode:
             return
 
+        settings = (
+            self._autofocus_full if mode is AutoFocusMode.ONCE else self._autofocus_fine
+        )
         if not run_tileset_autofocus(
             self.microscope,
             self._autofocus_channel,
-            self._autofocus_zparams,
-            method=self._autofocus_method,
+            settings,
             stop_event=self.stop_event,
         ):
             raise OperationCancelledError(

--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -44,7 +44,18 @@ def acquire_channels(
         channel_settings = [channel_settings]  # Ensure settings is a list
 
     images: List[FluorescenceImage] = []
-    for channel in channel_settings:
+    for i, channel in enumerate(channel_settings):
+        # Same payload shape `acquire_z_stack` emits, minus the z fields. Without it a
+        # multi-channel acquisition was silent, so anything watching progress within a
+        # tile had nothing to show unless a z-stack happened to be enabled.
+        microscope.acquisition_progress_signal.emit({
+            "state": "acquiring",
+            "task": "channels",
+            "channel": channel.name,
+            "channel_index": i + 1,
+            "total_channels": len(channel_settings),
+        })
+
         # Check for cancellation before each channel
         if stop_event and stop_event.is_set():
             logging.info("Multi-channel acquisition cancelled")

--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -12,7 +12,11 @@ import matplotlib.patches as patches
 from fibsem import utils
 from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
 from fibsem.fm.calibration import run_autofocus
-from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov, order_tiles
+from fibsem.imaging.tiling.geometry import (
+    TilePosition,
+    compute_tile_grid_from_fov,
+    order_tiles,
+)
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.structures import (
     AutoFocusMode,
@@ -370,6 +374,35 @@ def run_tileset_autofocus(
         return False
 
 
+PREVIEW_MAX_DIMENSION = 2048
+"""Long-edge size of the live mosaic preview, in pixels.
+
+A full-resolution fluorescence mosaic is multi-channel 16-bit -- a 5x5 of 1024px tiles
+is ~88 MB -- and the whole canvas is pushed through a Qt signal on every tile. The
+preview is decimated to this so watching a run stays cheap; the final stitch is
+untouched and full resolution.
+"""
+
+
+def _to_channel_planes(data: np.ndarray, n_channels: int) -> np.ndarray:
+    """Normalise tile data to (C, Y, X), projecting z the way the final stitch does.
+
+    Tiles arrive as 2D (Y, X), 3D (either (C, Y, X) or (Z, Y, X)) or 4D (C, Z, Y, X).
+    The 3D case is genuinely ambiguous from the shape alone, so it is resolved against
+    the channel count -- a single channel with a z-stack is (Z, Y, X) and gets
+    projected, several channels without one is (C, Y, X) and does not.
+    """
+    if data.ndim == 2:
+        return data[np.newaxis]
+    if data.ndim == 4:
+        return np.max(data, axis=1)
+    if data.ndim == 3:
+        if n_channels > 1 and data.shape[0] == n_channels:
+            return data
+        return np.max(data, axis=0)[np.newaxis]
+    raise ValueError(f"Unsupported tile data dimensions: {data.ndim}")
+
+
 class FMTiledAcquisitionRunner:
     """Orchestrates a fluorescence tileset acquisition as a series of discrete phases.
 
@@ -521,7 +554,7 @@ class FMTiledAcquisitionRunner:
 
         time_estimates = estimate_tileset_acquisition_time(
             self.channel_settings, (self._rows, self._cols), self.zparams,
-            self._autofocus_mode,
+            self._autofocus_mode, tile_mask=self._tile_mask,
         )
         self._total_estimated_time = time_estimates["total_time"]
         self._acquisition_start_time = time.time()
@@ -614,6 +647,8 @@ class FMTiledAcquisitionRunner:
             for tile in self._grid
         }
 
+        self._init_preview_canvas()
+
         first = self._ordered[0]
         self._emit({"state": "moving", "task": "tileset"})
         self._emit({
@@ -627,6 +662,58 @@ class FMTiledAcquisitionRunner:
             "estimated_total_time": self._total_estimated_time,
             "estimated_remaining_time": self._total_estimated_time,
         })
+
+    def _init_preview_canvas(self) -> None:
+        """Allocate the live mosaic that tiles are painted into as they arrive.
+
+        The beam tiler does the same thing (`TiledAcquisitionRunner._canvas`) and emits
+        the whole canvas with each tile, leaving the widget to simply redisplay it. The
+        difference here is size: a full-resolution fluorescence mosaic is multi-channel
+        and 16-bit, so a 5x5 would be ~88 MB pushed through a Qt signal per tile. The
+        preview is therefore decimated to `PREVIEW_MAX_DIMENSION` on its long edge --
+        enough to watch the mosaic fill in, and the real stitch still happens at full
+        resolution when the run finishes.
+        """
+        # Taken from the grid rather than recomputed, so the preview cannot drift from
+        # where `stitch_tileset` will actually paint these tiles.
+        full_w = max(t.canvas_x for t in self._grid) + self._image_width
+        full_h = max(t.canvas_y for t in self._grid) + self._image_height
+
+        self._preview_stride = max(
+            1, int(np.ceil(max(full_w, full_h) / PREVIEW_MAX_DIMENSION))
+        )
+        self._preview_canvas = np.zeros(
+            (len(self.channel_settings),
+             int(np.ceil(full_h / self._preview_stride)),
+             int(np.ceil(full_w / self._preview_stride))),
+            dtype=np.uint16,
+        )
+        logging.debug(
+            f"Live preview canvas: {self._preview_canvas.shape} "
+            f"(stride {self._preview_stride}, full {full_h}x{full_w})"
+        )
+
+    def _paint_preview(self, tile: TilePosition, image: FluorescenceImage) -> None:
+        """Paint one acquired tile into the live preview mosaic.
+
+        Best effort: a preview that cannot be built is not a reason to fail an
+        acquisition that is otherwise fine, so this never raises into the tile loop.
+        """
+        try:
+            stride = self._preview_stride
+            data = _to_channel_planes(image.data, len(self.channel_settings))
+            if data.shape[0] != self._preview_canvas.shape[0]:
+                data = data[: self._preview_canvas.shape[0]]
+
+            thumb = data[:, ::stride, ::stride]
+            y0 = tile.canvas_y // stride
+            x0 = tile.canvas_x // stride
+            h = min(thumb.shape[1], self._preview_canvas.shape[1] - y0)
+            w = min(thumb.shape[2], self._preview_canvas.shape[2] - x0)
+            if h > 0 and w > 0:
+                self._preview_canvas[:, y0:y0 + h, x0:x0 + w] = thumb[:, :h, :w]
+        except Exception as e:  # pragma: no cover - preview is never load-bearing
+            logging.debug(f"Could not paint tile ({tile.row}, {tile.col}) into preview: {e}")
 
     def _autofocus_if_mode(self, mode: AutoFocusMode) -> None:
         """Run autofocus when the configured mode matches.
@@ -666,8 +753,11 @@ class FMTiledAcquisitionRunner:
                 prev_row = tile.row
                 self._autofocus_if_mode(AutoFocusMode.EACH_ROW)
 
-            self.tileset[tile.row][tile.col] = self._acquire_tile(tile.row, tile.col)
+            image = self._acquire_tile(tile.row, tile.col)
+            self.tileset[tile.row][tile.col] = image
             self._n_acquired += 1
+            self._paint_preview(tile, image)
+            self._emit_preview(tile)
 
             if tile is not self._ordered[-1]:
                 self._emit({"state": "moving", "task": "tileset"})
@@ -747,6 +837,31 @@ class FMTiledAcquisitionRunner:
 
     def _emit(self, payload: dict) -> None:
         self.microscope.fm.acquisition_progress_signal.emit(payload)
+
+    def _emit_preview(self, tile: TilePosition) -> None:
+        """Publish the mosaic-so-far, so a viewer can watch it fill in.
+
+        Keyed `image`, matching what `TiledAcquisitionRunner` emits and what
+        `FibsemMinimapWidget.handle_tile_acquisition_progress` already reads, so a
+        consumer of one reads the other. The whole canvas goes out rather than the
+        single tile: the receiver then needs no state of its own and simply redisplays
+        what it is given, which is also what makes a late subscriber correct.
+
+        A *copy* goes out, unlike the beam tiler, which emits its live canvas directly.
+        The acquisition runs on a worker thread, so the signal is queued and the slot
+        runs later on the GUI thread -- by which time the shared array has been painted
+        into again. Sending the buffer itself is a read/write race for the sake of the
+        one thing that does not need to be fast: at ~10 MB against a tile exposure, the
+        copy does not show.
+        """
+        self._emit({
+            "state": "tile", "task": "tileset",
+            "row": tile.row, "col": tile.col,
+            "total_rows": self._rows, "total_cols": self._cols,
+            "current": self._n_acquired, "total": len(self._ordered),
+            "image": self._preview_canvas.copy(),
+            "preview_stride": self._preview_stride,
+        })
 
     def _emit_tile_progress(self, row: int, col: int) -> None:
         # Counted by visits, not by grid index. `row * cols + col` assumed a full

--- a/fibsem/fm/calibration/__init__.py
+++ b/fibsem/fm/calibration/__init__.py
@@ -70,6 +70,8 @@ def run_autofocus(
     stop_event: Optional[threading.Event] = None,
     roi: Optional[FibsemRectangle] = None,
     save_plot: bool = False,
+    pass_index: int = 1,
+    total_passes: int = 1,
 ) -> Optional[AutoFocusResult]:
     """Run autofocus by acquiring images at different z positions and finding the best focus.
 
@@ -85,6 +87,10 @@ def run_autofocus(
         roi: Optional region of interest (0-1 relative coordinates) to measure focus on.
             If provided, only the cropped region is used for focus evaluation.
         save_plot: Whether to save a diagnostic plot of the autofocus results (default: False).
+        pass_index: Which pass of a multi-pass sweep this is, 1-based. Reported in the
+            progress payload so a viewer can say "pass 1/2" rather than restarting an
+            apparently identical bar.
+        total_passes: How many passes the caller is running in total.
 
     Returns:
         AutoFocusResult with all acquired data, or None if cancelled
@@ -134,6 +140,19 @@ def run_autofocus(
             logging.info("Autofocus cancelled")
             microscope.objective.move_absolute(initial_z)
             return None
+
+        # Same payload shape the z-stack and channel loops emit, so a viewer that
+        # renders within-tile progress renders this too. Without it the bars froze for
+        # the whole sweep -- which on per-tile autofocus is most of the run.
+        microscope.acquisition_progress_signal.emit({
+            "state": "acquiring",
+            "task": "autofocus",
+            "channel": channel_settings.name if channel_settings is not None else "",
+            "zlevel": i + 1,
+            "total_zlevels": len(z_positions),
+            "pass_index": pass_index,
+            "total_passes": total_passes,
+        })
 
         microscope.objective.move_absolute(z_pos)
         image = microscope.acquire_image()
@@ -216,6 +235,8 @@ def run_coarse_fine_autofocus(
             method=autofocus_settings.method.value,
             roi=roi,
             stop_event=stop_event,
+            pass_index=pass_index + 1,
+            total_passes=len(active_passes),
         )
         if result is None:
             if last_result is None:

--- a/fibsem/fm/timing.py
+++ b/fibsem/fm/timing.py
@@ -145,6 +145,7 @@ def estimate_tileset_acquisition_time(
     grid_size: Tuple[int, int],
     zparams: Optional[ZParameters] = None,
     autofocus_mode: AutoFocusMode = AutoFocusMode.NONE,
+    tile_mask: Optional[List[List[bool]]] = None,
 ) -> dict:
     """Estimate the total time required for tileset acquisition.
 
@@ -197,7 +198,15 @@ def estimate_tileset_acquisition_time(
             f"Grid dimensions must be positive integers, got rows={rows}, cols={cols}"
         )
 
-    total_tiles = rows * cols
+    # A masked run visits only the enabled tiles, and only the rows that contain one.
+    # Estimating the full grid instead reports roughly three times the real duration
+    # for a typical sparse selection -- and the estimate is what the confirmation
+    # dialog and the remaining-time readout are built on.
+    if tile_mask is not None:
+        total_tiles = sum(bool(v) for row in tile_mask for v in row)
+        rows = sum(1 for row in tile_mask if any(row))
+    else:
+        total_tiles = rows * cols
 
     # Calculate image acquisition time per tile
     tile_acquisition_time = estimate_acquisition_time(channel_settings, zparams)
@@ -206,17 +215,11 @@ def estimate_tileset_acquisition_time(
     # Calculate total images
     total_images = calculate_total_images_count(channel_settings, zparams) * total_tiles
 
-    # Calculate stage movement time
-    # For a grid pattern: (cols-1) horizontal moves per row + (rows-1) vertical moves + row resets
-    if total_tiles <= 1:
-        # No movement needed for 0 or 1 tiles
-        total_stage_moves = 0
-    else:
-        horizontal_moves = (cols - 1) * rows  # Moves within each row
-        vertical_moves = rows - 1  # Moves to next row
-        # Row resets only needed when there are multiple columns
-        row_resets = (rows - 1) if cols > 1 else 0  # Return to first column of next row
-        total_stage_moves = horizontal_moves + vertical_moves + row_resets
+    # Calculate stage movement time. One absolute move per tile: the runner projects
+    # every tile position up front and drives straight to each one, so there are no
+    # separate row-advance or row-reset moves to count. (The previous model counted
+    # those, and also assumed a full rectangular sweep, which a mask breaks.)
+    total_stage_moves = max(0, total_tiles - 1)
 
     total_stage_movement_time = total_stage_moves * DEFAULT_STAGE_MOVE_TIME
 

--- a/fibsem/ui/FMAcquisitionWidget.py
+++ b/fibsem/ui/FMAcquisitionWidget.py
@@ -1568,6 +1568,7 @@ class FMAcquisitionWidget(QWidget):
         progress_total = progress.get("total", None)
         channel_name = progress.get("channel", None)
         progress_state = progress.get("state", None)
+        progress_task = progress.get("task", None)
 
         if progress_state == "moving":
             self.progressText.setText("Moving stage...")
@@ -1580,7 +1581,14 @@ class FMAcquisitionWidget(QWidget):
             self.progressBar_current_acquisition.setFormat("")
 
         # set progress message
-        if channel_name is not None:
+        if progress_task == "autofocus":
+            # Handled before the channel branch, not inside it: a sweep with no channel
+            # reports an empty name, which used to render "Acquiring  (1/1)..." and now
+            # would leave the previous message sitting there instead.
+            self.progressText.setText(
+                f"Focusing on {channel_name}..." if channel_name else "Focusing..."
+            )
+        elif channel_name:
             channel_index = progress.get("channel_index", 1)
             total_channels = progress.get("total_channels", 1)
             msg = f"Acquiring {channel_name} ({channel_index}/{total_channels})..."
@@ -1594,9 +1602,18 @@ class FMAcquisitionWidget(QWidget):
                 else 0
             )
             self.progressBar_current_acquisition.setValue(percentage_zlevel)
-            self.progressBar_current_acquisition.setFormat(
-                f"Z-level {progress_zlevels}/{progress_total_zlevels}"
-            )
+            if progress_task == "autofocus":
+                # A focus sweep steps the objective through a search range. Calling
+                # those positions "Z-level" names the z-stack, which is not running --
+                # and says which pass, so a coarse sweep followed by a fine one does
+                # not look like the same bar inexplicably starting over.
+                total_passes = progress.get("total_passes", 1)
+                which = (f" · pass {progress.get('pass_index', 1)}/{total_passes}"
+                         if total_passes > 1 else "")
+                label = f"Focus {progress_zlevels}/{progress_total_zlevels}{which}"
+            else:
+                label = f"Z-level {progress_zlevels}/{progress_total_zlevels}"
+            self.progressBar_current_acquisition.setFormat(label)
 
         # set total acquisition task progress
         if progress_current is not None and progress_total is not None:

--- a/fibsem/ui/fm/overview_app.py
+++ b/fibsem/ui/fm/overview_app.py
@@ -1,0 +1,103 @@
+"""Standalone FM overview acquisition app.
+
+Opens :class:`FMOverviewWidget` against a real or simulated microscope, so the
+overview UI can be exercised without launching AutoLamella.
+
+    python -m fibsem.ui.fm.overview_app                 # Demo, compustage at t = -180
+    python -m fibsem.ui.fm.overview_app --manufacturer Thermo --ip 10.0.0.1
+
+The default puts the simulator in the Arctis fluorescence pose -- compustage, no
+pre-tilt, stage tilted to -180 degrees -- because that is the geometry the tile
+projection is built around and the one worth exercising.
+"""
+
+import argparse
+import logging
+import sys
+from typing import Optional
+
+import numpy as np
+
+from fibsem import utils
+from fibsem.microscope import FibsemMicroscope
+from fibsem.structures import FibsemStagePosition
+
+
+def build_microscope(
+    manufacturer: str = "Demo",
+    ip_address: str = "localhost",
+    compustage: bool = True,
+    tilt_deg: float = -180.0,
+) -> FibsemMicroscope:
+    """Connect, attach a fluorescence detector, and pose the stage for FM."""
+    microscope, _ = utils.setup_session(
+        manufacturer=manufacturer, ip_address=ip_address
+    )
+
+    if manufacturer == "Demo":
+        # Pose the simulator rather than assuming the ambient configuration: the tile
+        # projection depends on the compustage flag and the pre-tilt, so a run started
+        # from the wrong pose would exercise different geometry than intended.
+        microscope.stage_is_compustage = compustage
+        microscope.system.stage.shuttle_pre_tilt = 0
+        microscope._update_orientations()
+        microscope.move_stage_absolute(
+            FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(tilt_deg))
+        )
+
+    if microscope.fm is None:
+        from fibsem.fm.microscope import FluorescenceMicroscope
+
+        microscope.fm = FluorescenceMicroscope(parent=microscope)
+
+    logging.info(
+        f"FM overview app: {manufacturer}, compustage={microscope.stage_is_compustage}, "
+        f"stage={microscope.get_stage_position().pretty}"
+    )
+    return microscope
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manufacturer", default="Demo",
+                        help="Demo, Thermo, Tescan (default: Demo)")
+    parser.add_argument("--ip", default="localhost", dest="ip_address")
+    parser.add_argument("--tilt", type=float, default=-180.0,
+                        help="Stage tilt in degrees for the Demo pose (default: -180)")
+    parser.add_argument("--no-compustage", action="store_false", dest="compustage",
+                        help="Pose the Demo microscope as an offset FM mount instead")
+    args = parser.parse_args(argv)
+
+    from PyQt5.QtWidgets import QApplication, QMainWindow
+
+    from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+
+    app = QApplication(sys.argv)
+    try:
+        from fibsem.ui import stylesheets
+
+        app.setStyleSheet(stylesheets.NAPARI_STYLE)
+    except Exception as e:  # pragma: no cover - styling is cosmetic
+        logging.debug(f"Could not apply the napari stylesheet: {e}")
+
+    microscope = build_microscope(
+        manufacturer=args.manufacturer,
+        ip_address=args.ip_address,
+        compustage=args.compustage,
+        tilt_deg=args.tilt,
+    )
+
+    window = QMainWindow()
+    window.setWindowTitle(
+        f"FM Overview — {args.manufacturer}"
+        f"{' · compustage' if microscope.stage_is_compustage else ''}"
+        f" · t = {np.rad2deg(microscope.get_stage_position().t):.0f}°"
+    )
+    window.setCentralWidget(FMOverviewWidget(microscope))
+    window.resize(1500, 900)
+    window.show()
+    return app.exec_()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fibsem/ui/fm/widgets/__init__.py
+++ b/fibsem/ui/fm/widgets/__init__.py
@@ -25,6 +25,10 @@ from .load_image_dialog import LoadImageDialog
 from .fm_image_viewer_widget import FMImageViewerWidget
 from .channel_list_widget import ChannelListWidget
 from .fm_multi_channel_widget import FluorescenceMultiChannelWidget
+from .tile_mask_widget import TileMaskWidget
+from .fm_overview_settings_widget import FMOverviewSettingsWidget
+from .fm_overview_confirmation_dialog import FMOverviewConfirmationDialog
+from .fm_overview_widget import FMOverviewWidget
 
 __all__ = [
     'ZParametersWidget',
@@ -47,4 +51,8 @@ __all__ = [
     'FMImageViewerWidget',
     'ChannelListWidget',
     'FluorescenceMultiChannelWidget',
+    'TileMaskWidget',
+    'FMOverviewSettingsWidget',
+    'FMOverviewConfirmationDialog',
+    'FMOverviewWidget',
 ]

--- a/fibsem/ui/fm/widgets/channel_list_widget.py
+++ b/fibsem/ui/fm/widgets/channel_list_widget.py
@@ -95,6 +95,19 @@ class _DraggableChannelList(QListWidget):
         super().__init__(parent)
         self._fm = fm
 
+    def resizeEvent(self, event) -> None:
+        """Keep row widths pinned to the viewport as it changes.
+
+        Belongs here rather than on the parent: the parent's own resizeEvent runs
+        before its children are laid out, so it would read the previous width.
+        """
+        super().resizeEvent(event)
+        width = self.viewport().width()
+        for i in range(self.count()):
+            item = self.item(i)
+            if item.sizeHint().width() != width:
+                item.setSizeHint(QSize(width, item.sizeHint().height()))
+
     def mousePressEvent(self, event) -> None:
         if self._fm is not None and self._fm.is_acquiring:
             return  # swallow — prevent highlight change during live acquisition
@@ -788,6 +801,17 @@ class ChannelListWidget(QWidget):
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _row_item_size(self) -> QSize:
+        """Row size for a list item, with the width pinned to the viewport.
+
+        A zero width makes Qt fall back to the row widget's own preferred width, which
+        is ~190px wider than the row needs (QLineEdit hints generously) and does not
+        shrink to fit a narrow host. In a side panel the surplus hangs past the right
+        edge, taking the excitation and emission controls with it -- and hosts turn the
+        horizontal scrollbar off, so those controls become unreachable, not just tight.
+        """
+        return QSize(max(0, self._list.viewport().width()), _ROW_HEIGHT)
+
     def _add_row(self, channel: ChannelSettings, enabled: bool = True) -> ChannelRowWidget:
         row = ChannelRowWidget(
             channel=channel,
@@ -797,7 +821,7 @@ class ChannelListWidget(QWidget):
         )
         item = QListWidgetItem()
         item.setData(Qt.ItemDataRole.UserRole, channel)
-        item.setSizeHint(QSize(0, _ROW_HEIGHT))
+        item.setSizeHint(self._row_item_size())
         self._list.addItem(item)
         self._list.setItemWidget(item, row)
         self._connect_row(row)
@@ -1012,7 +1036,7 @@ class ChannelListWidget(QWidget):
                 excitation_items=self._excitation_items,
                 enabled=enabled,
             )
-            item.setSizeHint(QSize(0, _ROW_HEIGHT))
+            item.setSizeHint(self._row_item_size())
             self._list.setItemWidget(item, row)
             self._connect_row(row)
         self._sync_select_all()

--- a/fibsem/ui/fm/widgets/channel_settings_widget.py
+++ b/fibsem/ui/fm/widgets/channel_settings_widget.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QFormLayout,
     QVBoxLayout,
@@ -67,7 +67,14 @@ class ChannelSettingsWidget(QWidget):
         form = QFormLayout(form_widget)
         form.setContentsMargins(8, 6, 8, 6)
         form.setSpacing(6)
-        form.setLabelAlignment(form.labelAlignment())
+        # macOS styles forms its own way -- fields frozen at their size hint, labels
+        # right-aligned, the whole block centred. That leaves ragged field widths and
+        # dead space on the right, so pin all three to the house style.
+        # AllNonFixedFieldsGrow, not ExpandingFieldsGrow: the latter only grows fields
+        # that already carry an Expanding policy, which none of these do.
+        form.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        form.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        form.setFormAlignment(Qt.AlignLeft | Qt.AlignTop)
 
         self.excitation_combo = ValueComboBox(
             items=self._excitation_items,

--- a/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
@@ -21,6 +21,7 @@ from PyQt5.QtWidgets import (
 from fibsem import constants
 from fibsem.fm.structures import (
     AutoFocusMode,
+    AutoFocusSettings,
     ChannelSettings,
     OverviewParameters,
     ZParameters,
@@ -81,6 +82,7 @@ class FMOverviewConfirmationDialog(QDialog):
         channel_settings: List[ChannelSettings],
         zparams: Optional[ZParameters] = None,
         tile_fov: Optional[tuple] = None,
+        autofocus_settings: Optional[AutoFocusSettings] = None,
         parent: Optional[QWidget] = None,
     ):
         super().__init__(parent)
@@ -88,6 +90,7 @@ class FMOverviewConfirmationDialog(QDialog):
         self.channel_settings = channel_settings
         self.zparams = zparams if parameters.use_zstack else None
         self.tile_fov = tile_fov
+        self.autofocus_settings = autofocus_settings
 
         self.setWindowTitle("Start Overview Acquisition")
         self.setMinimumWidth(430)
@@ -119,6 +122,37 @@ class FMOverviewConfirmationDialog(QDialog):
             bits.append("sparse")
         return " · ".join(bits)
 
+    def _sweep_rows(self) -> List[tuple]:
+        """How the sweep is configured, now that it is configurable.
+
+        Reports only the enabled passes, and says so plainly when there are none --
+        that combination schedules focusing that then does nothing, and it looks
+        correct from either control alone.
+        """
+        if self.autofocus_settings is None:
+            return []
+
+        rows = [("Focus method", self.autofocus_settings.method.value.title())]
+        if self.autofocus_settings.channel_name:
+            rows.append(("Focus channel", self.autofocus_settings.channel_name))
+
+        enabled = [p for p in self.autofocus_settings.passes if p.enabled]
+        if not enabled:
+            rows.append(("Sweep", "no passes enabled — nothing will be focused"))
+        else:
+            # `search_range` is the total span, not a half-width -- positions cover
+            # +/- range/2 -- so it is reported as a span rather than as +/-.
+            rows.append((
+                "Sweep",
+                "  ·  ".join(
+                    f"{p.search_range * constants.SI_TO_MICRO:.0f} µm span, "
+                    f"{p.step_size * constants.SI_TO_MICRO:.1f} µm steps "
+                    f"({p.n_steps} images)"
+                    for p in enabled
+                ),
+            ))
+        return rows
+
     def _rows(self) -> List[tuple]:
         """Label/value pairs for the detail block."""
         p = self.parameters
@@ -143,6 +177,7 @@ class FMOverviewConfirmationDialog(QDialog):
                 # leaving the user to find it in the log afterwards.
                 note = "  → per tile, for a spiral"
             detail.append(("Auto-focus", f"{mode}{note}"))
+            detail.extend(self._sweep_rows())
 
         detail.append(("Images", f"{estimate['total_images']:,}"))
         detail.append((

--- a/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
@@ -1,0 +1,233 @@
+"""Pre-flight summary for an FM overview acquisition.
+
+Replaces `OverviewConfirmationDialog`. Same job, house style: one title, a muted meta
+line, count chips, a duration broken down by where it goes, and a primary action in
+the footer.
+"""
+
+from typing import List, Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem import constants
+from fibsem.fm.structures import (
+    AutoFocusMode,
+    ChannelSettings,
+    OverviewParameters,
+    ZParameters,
+)
+from fibsem.fm.timing import estimate_tileset_acquisition_time
+from fibsem.structures import TileOrderStrategy
+from fibsem.ui import stylesheets
+
+BACKGROUND = "#262930"
+PANEL = "#1e2027"
+BORDER = "#3d4251"
+TEXT = "#d6d6d6"
+TEXT_STRONG = "#f0f1f2"
+TEXT_MUTED = "#868e93"
+ACCENT = "#50a6ff"
+
+CHIP_ACQUIRE = "#4caf50"
+CHIP_SKIP = "#868e93"
+CHIP_CHANNEL = "#50a6ff"
+
+
+def format_duration(seconds: float) -> str:
+    """`2m 14s`, `1h 03m`, `45s` — whichever reads best at that magnitude."""
+    seconds = int(round(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m {seconds % 60:02d}s"
+    return f"{seconds // 3600}h {(seconds % 3600) // 60:02d}m"
+
+
+def _chip(text: str, color: str) -> QWidget:
+    """Pill label with a coloured dot, matching the app's other summaries."""
+    chip = QFrame()
+    chip.setStyleSheet(
+        f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER};"
+        f" border-radius: 10px; }}"
+    )
+    layout = QHBoxLayout(chip)
+    layout.setContentsMargins(9, 3, 10, 3)
+    layout.setSpacing(6)
+
+    dot = QLabel("●")
+    dot.setStyleSheet(f"color: {color}; font-size: 10px; border: none;")
+    label = QLabel(text)
+    label.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
+    layout.addWidget(dot)
+    layout.addWidget(label)
+    return chip
+
+
+class FMOverviewConfirmationDialog(QDialog):
+    """Confirm an overview before it runs, with what it will cost."""
+
+    def __init__(
+        self,
+        parameters: OverviewParameters,
+        channel_settings: List[ChannelSettings],
+        zparams: Optional[ZParameters] = None,
+        tile_fov: Optional[tuple] = None,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(parent)
+        self.parameters = parameters
+        self.channel_settings = channel_settings
+        self.zparams = zparams if parameters.use_zstack else None
+        self.tile_fov = tile_fov
+
+        self.setWindowTitle("Start Overview Acquisition")
+        self.setMinimumWidth(430)
+        self.setStyleSheet(f"QDialog {{ background: {BACKGROUND}; }}")
+        self._init_ui()
+
+    # ── content ──────────────────────────────────────────────────────────
+
+    def _estimate(self) -> dict:
+        return estimate_tileset_acquisition_time(
+            self.channel_settings,
+            (self.parameters.rows, self.parameters.cols),
+            self.zparams,
+            self.parameters.autofocus_mode,
+            tile_mask=self.parameters.tile_mask,
+        )
+
+    def _meta_line(self) -> str:
+        p = self.parameters
+        total = p.rows * p.cols
+        bits = [f"{p.rows} × {p.cols} grid", f"{p.overlap:.0%} overlap"]
+        if self.tile_fov is not None:
+            fov_x, fov_y = self.tile_fov
+            width = ((p.cols - 1) * (1 - p.overlap) + 1) * fov_x * constants.SI_TO_MICRO
+            height = ((p.rows - 1) * (1 - p.overlap) + 1) * fov_y * constants.SI_TO_MICRO
+            bits.append(f"{width:.0f} × {height:.0f} µm")
+        bits.append(f"{p.tile_order.value} order")
+        if p.n_enabled_tiles != total:
+            bits.append("sparse")
+        return " · ".join(bits)
+
+    def _rows(self) -> List[tuple]:
+        """Label/value pairs for the detail block."""
+        p = self.parameters
+        estimate = self._estimate()
+
+        detail = [
+            ("Channels", ", ".join(ch.name for ch in self.channel_settings) or "—"),
+        ]
+        if p.use_zstack and self.zparams is not None:
+            detail.append(("Z-stack", f"{self.zparams.num_planes} planes per tile"))
+        else:
+            detail.append(("Z-stack", "off"))
+
+        if p.autofocus_mode is AutoFocusMode.NONE:
+            detail.append(("Auto-focus", "off"))
+        else:
+            mode = p.autofocus_mode.name.replace("_", " ").lower()
+            note = ""
+            if (p.autofocus_mode is AutoFocusMode.EACH_ROW
+                    and p.tile_order is TileOrderStrategy.SPIRAL):
+                # The runner promotes this; say so before it happens rather than
+                # leaving the user to find it in the log afterwards.
+                note = "  → per tile, for a spiral"
+            detail.append(("Auto-focus", f"{mode}{note}"))
+
+        detail.append(("Images", f"{estimate['total_images']:,}"))
+        detail.append((
+            "Estimated time",
+            f"{format_duration(estimate['total_time'])}"
+            f"   ({format_duration(estimate['image_acquisition_time'])} imaging"
+            f" · {format_duration(estimate['stage_movement_time'])} moving"
+            + (f" · {format_duration(estimate['autofocus_time'])} focusing"
+               if estimate["autofocus_time"] else "")
+            + ")",
+        ))
+        return detail
+
+    # ── layout ───────────────────────────────────────────────────────────
+
+    def _init_ui(self) -> None:
+        p = self.parameters
+        total = p.rows * p.cols
+        acquired = p.n_enabled_tiles
+
+        title = QLabel("Start overview acquisition")
+        title.setStyleSheet(
+            f"color: {TEXT_STRONG}; font-size: 15px; font-weight: 600;"
+        )
+        meta = QLabel(self._meta_line())
+        meta.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px;")
+        meta.setWordWrap(True)
+
+        chips = QHBoxLayout()
+        chips.setSpacing(6)
+        chips.addWidget(_chip(f"{acquired} to acquire", CHIP_ACQUIRE))
+        if acquired != total:
+            chips.addWidget(_chip(f"{total - acquired} skipped", CHIP_SKIP))
+        chips.addWidget(_chip(
+            f"{len(self.channel_settings)} channel"
+            f"{'s' if len(self.channel_settings) != 1 else ''}", CHIP_CHANNEL))
+        chips.addStretch()
+
+        detail = QFrame()
+        detail.setStyleSheet(
+            f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER};"
+            f" border-radius: 4px; }}"
+        )
+        detail_layout = QVBoxLayout(detail)
+        detail_layout.setContentsMargins(12, 10, 12, 10)
+        detail_layout.setSpacing(6)
+        for label_text, value_text in self._rows():
+            row = QHBoxLayout()
+            row.setSpacing(12)
+            label = QLabel(label_text)
+            label.setStyleSheet(
+                f"color: {TEXT_MUTED}; font-size: 11px; border: none;")
+            label.setFixedWidth(96)
+            value = QLabel(value_text)
+            value.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
+            value.setWordWrap(True)
+            row.addWidget(label, alignment=Qt.AlignTop)
+            row.addWidget(value, stretch=1)
+            detail_layout.addLayout(row)
+
+        self.button_start = QPushButton("Start Acquisition")
+        self.button_start.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.button_start.setMinimumHeight(30)
+        self.button_start.clicked.connect(self.accept)
+        button_cancel = QPushButton("Cancel")
+        button_cancel.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        button_cancel.setMinimumHeight(30)
+        button_cancel.clicked.connect(self.reject)
+
+        footer = QHBoxLayout()
+        footer.addStretch()
+        footer.addWidget(button_cancel)
+        footer.addWidget(self.button_start)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 14, 16, 14)
+        layout.setSpacing(10)
+        layout.addWidget(title)
+        layout.addWidget(meta)
+        layout.addLayout(chips)
+        layout.addWidget(detail)
+        layout.addLayout(footer)
+
+        if acquired == 0:
+            # Nothing to do: the runner would reject this anyway, so say why here
+            # rather than letting it fail after the dialog is dismissed.
+            self.button_start.setEnabled(False)
+            self.button_start.setToolTip("No tiles are selected.")

--- a/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
@@ -1,8 +1,9 @@
 """Pre-flight summary for an FM overview acquisition.
 
-Replaces `OverviewConfirmationDialog`. Same job, house style: one title, a muted meta
-line, count chips, a duration broken down by where it goes, and a primary action in
-the footer.
+Replaces `OverviewConfirmationDialog`. Same job, house style: a meta line, count chips,
+a detail block, a duration broken down by where it goes, and a primary action in the
+footer. Each fact appears once — the window title is the heading, the Channels row is
+the channel count, and the skipped chip is what "sparse" would have said.
 """
 
 from typing import List, Optional
@@ -36,12 +37,6 @@ BORDER = "#3d4251"
 TEXT = "#d6d6d6"
 TEXT_STRONG = "#f0f1f2"
 TEXT_MUTED = "#868e93"
-ACCENT = "#50a6ff"
-
-CHIP_ACQUIRE = "#4caf50"
-CHIP_SKIP = "#868e93"
-CHIP_CHANNEL = "#50a6ff"
-
 
 def format_duration(seconds: float) -> str:
     """`2m 14s`, `1h 03m`, `45s` — whichever reads best at that magnitude."""
@@ -53,22 +48,20 @@ def format_duration(seconds: float) -> str:
     return f"{seconds // 3600}h {(seconds % 3600) // 60:02d}m"
 
 
-def _chip(text: str, color: str) -> QWidget:
-    """Pill label with a coloured dot, matching the app's other summaries."""
+def _chip(text: str) -> QWidget:
+    """Plain pill label. No status dot: these are counts, not states, and a colour
+    that does not encode anything reads as though it does."""
     chip = QFrame()
     chip.setStyleSheet(
         f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER};"
         f" border-radius: 10px; }}"
     )
     layout = QHBoxLayout(chip)
-    layout.setContentsMargins(9, 3, 10, 3)
-    layout.setSpacing(6)
+    layout.setContentsMargins(10, 3, 10, 3)
+    layout.setSpacing(0)
 
-    dot = QLabel("●")
-    dot.setStyleSheet(f"color: {color}; font-size: 10px; border: none;")
     label = QLabel(text)
     label.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
-    layout.addWidget(dot)
     layout.addWidget(label)
     return chip
 
@@ -110,7 +103,6 @@ class FMOverviewConfirmationDialog(QDialog):
 
     def _meta_line(self) -> str:
         p = self.parameters
-        total = p.rows * p.cols
         bits = [f"{p.rows} × {p.cols} grid", f"{p.overlap:.0%} overlap"]
         if self.tile_fov is not None:
             fov_x, fov_y = self.tile_fov
@@ -118,8 +110,7 @@ class FMOverviewConfirmationDialog(QDialog):
             height = ((p.rows - 1) * (1 - p.overlap) + 1) * fov_y * constants.SI_TO_MICRO
             bits.append(f"{width:.0f} × {height:.0f} µm")
         bits.append(f"{p.tile_order.value} order")
-        if p.n_enabled_tiles != total:
-            bits.append("sparse")
+        # No "sparse" tag: the skipped chip states the same thing as a number.
         return " · ".join(bits)
 
     def _sweep_rows(self) -> List[tuple]:
@@ -142,9 +133,11 @@ class FMOverviewConfirmationDialog(QDialog):
         else:
             # `search_range` is the total span, not a half-width -- positions cover
             # +/- range/2 -- so it is reported as a span rather than as +/-.
+            # One pass per line: joined with a separator they wrap mid-pass, and the
+            # separator can land at a line end where it reads as a bullet.
             rows.append((
                 "Sweep",
-                "  ·  ".join(
+                "\n".join(
                     f"{p.search_range * constants.SI_TO_MICRO:.0f} µm span, "
                     f"{p.step_size * constants.SI_TO_MICRO:.1f} µm steps "
                     f"({p.n_steps} images)"
@@ -198,22 +191,20 @@ class FMOverviewConfirmationDialog(QDialog):
         total = p.rows * p.cols
         acquired = p.n_enabled_tiles
 
-        title = QLabel("Start overview acquisition")
-        title.setStyleSheet(
-            f"color: {TEXT_STRONG}; font-size: 15px; font-weight: 600;"
-        )
+        # No in-dialog heading: the window title already says "Start Overview
+        # Acquisition", and repeating it 8px below costs a line and says nothing. The
+        # meta line leads instead, so it carries normal text weight rather than muted.
         meta = QLabel(self._meta_line())
-        meta.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px;")
+        meta.setStyleSheet(f"color: {TEXT_STRONG}; font-size: 12px;")
         meta.setWordWrap(True)
 
+        # Tile counts only. The channel count was a third chip, but the Channels row
+        # below lists them by name -- the chip added a number, not information.
         chips = QHBoxLayout()
         chips.setSpacing(6)
-        chips.addWidget(_chip(f"{acquired} to acquire", CHIP_ACQUIRE))
+        chips.addWidget(_chip(f"{acquired} to acquire"))
         if acquired != total:
-            chips.addWidget(_chip(f"{total - acquired} skipped", CHIP_SKIP))
-        chips.addWidget(_chip(
-            f"{len(self.channel_settings)} channel"
-            f"{'s' if len(self.channel_settings) != 1 else ''}", CHIP_CHANNEL))
+            chips.addWidget(_chip(f"{total - acquired} skipped"))
         chips.addStretch()
 
         detail = QFrame()
@@ -255,7 +246,6 @@ class FMOverviewConfirmationDialog(QDialog):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 14, 16, 14)
         layout.setSpacing(10)
-        layout.addWidget(title)
         layout.addWidget(meta)
         layout.addLayout(chips)
         layout.addWidget(detail)

--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -12,22 +12,25 @@ matter:
 
 from typing import List, Optional
 
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QCheckBox,
     QDoubleSpinBox,
     QFormLayout,
     QGroupBox,
+    QHBoxLayout,
     QLabel,
+    QSizePolicy,
     QSpinBox,
     QVBoxLayout,
     QWidget,
 )
 
 from fibsem import constants
-from fibsem.fm.structures import AutoFocusMode, OverviewParameters
+from fibsem.fm.structures import AutoFocusMode, OverviewParameters, ZParameters
 from fibsem.structures import TileOrderStrategy
 from fibsem.ui.fm.widgets.tile_mask_widget import TileMaskWidget
+from fibsem.ui.fm.widgets.z_parameters_widget import ZParametersWidget
 from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import ValueComboBox
 
@@ -41,10 +44,20 @@ AUTOFOCUS_LABELS = {
 }
 
 TILE_ORDER_LABELS = {
-    TileOrderStrategy.TYPEWRITER: "Typewriter (rows left to right)",
-    TileOrderStrategy.SERPENTINE: "Serpentine (alternating rows)",
-    TileOrderStrategy.SPIRAL: "Spiral (outward from centre)",
+    TileOrderStrategy.TYPEWRITER: "Typewriter",
+    TileOrderStrategy.SERPENTINE: "Serpentine",
+    TileOrderStrategy.SPIRAL: "Spiral",
 }
+
+TILE_ORDER_TOOLTIPS = {
+    TileOrderStrategy.TYPEWRITER: "Every row runs left to right.",
+    TileOrderStrategy.SERPENTINE: "Rows alternate direction, so the stage does not "
+                                  "travel back across the grid between them.",
+    TileOrderStrategy.SPIRAL: "Outward from the centre tile, so the tiles nearest "
+                              "the starting position are acquired first.",
+}
+
+SPINBOX_MIN_WIDTH = 92
 
 
 class FMOverviewSettingsWidget(QWidget):
@@ -56,10 +69,14 @@ class FMOverviewSettingsWidget(QWidget):
         self,
         parameters: Optional[OverviewParameters] = None,
         channel_names: Optional[List[str]] = None,
+        z_parameters: Optional[ZParameters] = None,
         parent: Optional[QWidget] = None,
     ):
         super().__init__(parent)
         self._tile_fov: Optional[tuple] = None   # (fov_x, fov_y) metres, set externally
+        # Owned here rather than by the parent, so every overview setting sits in one
+        # widget and their order is this widget's to decide.
+        self.z_widget = ZParametersWidget(z_parameters or ZParameters())
         self._init_ui()
         self.set_channel_names(channel_names or [])
         if parameters is not None:
@@ -87,6 +104,17 @@ class FMOverviewSettingsWidget(QWidget):
             items=list(TileOrderStrategy),
             format_fn=lambda s: TILE_ORDER_LABELS.get(s, s.value.title()),
         )
+        # What each strategy does belongs in a tooltip, not in the label -- the label
+        # is read on every glance and the explanation once.
+        for index in range(self.combo_tile_order.count()):
+            strategy = self.combo_tile_order.itemData(index)
+            self.combo_tile_order.setItemData(
+                index, TILE_ORDER_TOOLTIPS.get(strategy, ""), Qt.ToolTipRole
+            )
+        self.combo_tile_order.setToolTip(
+            "\n".join(f"{TILE_ORDER_LABELS[s]} — {TILE_ORDER_TOOLTIPS[s]}"
+                      for s in TileOrderStrategy)
+        )
 
         self.check_zstack = QCheckBox("Acquire a z-stack at each tile")
 
@@ -96,12 +124,31 @@ class FMOverviewSettingsWidget(QWidget):
         )
         self.combo_autofocus_channel = ValueComboBox()
 
+        # The app's spinboxes carry -/+ buttons, which eat most of a narrow field and
+        # leave the value clipped ("0" for an overlap of 0.10). Give them a floor.
+        for widget in (self.spin_rows, self.spin_cols, self.spin_overlap,
+                       self.combo_tile_order, self.combo_autofocus_mode,
+                       self.combo_autofocus_channel):
+            widget.setMinimumWidth(SPINBOX_MIN_WIDTH)
+            widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         for widget in (self.spin_rows, self.spin_cols, self.spin_overlap):
             install_wheel_blocker(widget)
 
+        # Rows and columns read as one setting and are always adjusted together, so
+        # they share a line -- which is also what gives each of them room.
+        size_row = QHBoxLayout()
+        size_row.setSpacing(6)
+        size_row.addWidget(self.spin_rows)
+        times = QLabel("×")
+        times.setStyleSheet(MUTED)
+        size_row.addWidget(times)
+        size_row.addWidget(self.spin_cols)
+
         grid_form = QFormLayout()
-        grid_form.addRow("Rows", self.spin_rows)
-        grid_form.addRow("Columns", self.spin_cols)
+        grid_form.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+        grid_form.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        grid_form.setFormAlignment(Qt.AlignLeft | Qt.AlignTop)
+        grid_form.addRow("Rows × Columns", size_row)
         grid_form.addRow("Overlap", self.spin_overlap)
         grid_form.addRow("Tile order", self.combo_tile_order)
         grid_box = QGroupBox("Grid")
@@ -114,11 +161,23 @@ class FMOverviewSettingsWidget(QWidget):
         mask_box.setLayout(mask_layout)
 
         focus_form = QFormLayout()
-        focus_form.addRow(self.check_zstack)
+        focus_form.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+        focus_form.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         focus_form.addRow("Auto-focus", self.combo_autofocus_mode)
         focus_form.addRow("Focus channel", self.combo_autofocus_channel)
         focus_box = QGroupBox("Focus")
         focus_box.setLayout(focus_form)
+
+        # The checkbox is the z-stack's enable, so it lives with what it enables --
+        # and the parameters grey out when it is off, instead of staying live and
+        # implying they apply.
+        zstack_layout = QVBoxLayout()
+        zstack_layout.setContentsMargins(6, 6, 6, 6)
+        zstack_layout.setSpacing(4)
+        zstack_layout.addWidget(self.check_zstack)
+        zstack_layout.addWidget(self.z_widget)
+        self.zstack_box = QGroupBox("Z-Stack")
+        self.zstack_box.setLayout(zstack_layout)
 
         self.label_summary = QLabel()
         self.label_summary.setStyleSheet(MUTED)
@@ -126,23 +185,29 @@ class FMOverviewSettingsWidget(QWidget):
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(focus_box)
+        layout.addWidget(self.zstack_box)
         layout.addWidget(grid_box)
         layout.addWidget(mask_box, stretch=1)
-        layout.addWidget(focus_box)
         layout.addWidget(self.label_summary)
 
         self.spin_rows.valueChanged.connect(self._on_grid_size_changed)
         self.spin_cols.valueChanged.connect(self._on_grid_size_changed)
         self.spin_overlap.valueChanged.connect(self._on_any_change)
         self.combo_tile_order.currentIndexChanged.connect(self._on_tile_order_changed)
-        self.check_zstack.stateChanged.connect(self._on_any_change)
+        self.check_zstack.stateChanged.connect(self._on_zstack_toggled)
         self.combo_autofocus_mode.currentIndexChanged.connect(self._on_autofocus_changed)
         self.combo_autofocus_channel.currentIndexChanged.connect(self._on_any_change)
         self.tile_mask.changed.connect(self._on_any_change)
 
         self._on_autofocus_changed()
+        self._on_zstack_toggled()
 
     # ── reactions ────────────────────────────────────────────────────────
+
+    def _on_zstack_toggled(self) -> None:
+        self.z_widget.setEnabled(self.check_zstack.isChecked())
+        self._on_any_change()
 
     def _on_grid_size_changed(self) -> None:
         self.tile_mask.set_grid_size(self.spin_rows.value(), self.spin_cols.value())
@@ -210,6 +275,18 @@ class FMOverviewSettingsWidget(QWidget):
         return self.combo_autofocus_channel.value()
 
     @property
+    def z_parameters(self) -> Optional[ZParameters]:
+        """The z-stack settings, or None when z-stacking is off.
+
+        None rather than the values behind a disabled checkbox: the acquisition takes
+        `zparams=None` to mean "no z-stack", so this hands back exactly what it wants
+        and there is no second place deciding whether the setting applies.
+        """
+        if not self.check_zstack.isChecked():
+            return None
+        return self.z_widget.z_parameters
+
+    @property
     def parameters(self) -> OverviewParameters:
         return OverviewParameters(
             rows=self.spin_rows.value(),
@@ -241,4 +318,8 @@ class FMOverviewSettingsWidget(QWidget):
                            self.combo_tile_order, self.check_zstack,
                            self.combo_autofocus_mode, self.tile_mask):
                 widget.blockSignals(False)
+        # Both, because the setter blocked the signals that normally trigger them --
+        # otherwise loading a z-stacked configuration leaves the z-parameters greyed
+        # out while the checkbox says they apply.
         self._on_autofocus_changed()
+        self._on_zstack_toggled()

--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -1,0 +1,244 @@
+"""Every setting an FM overview acquisition takes, in one self-contained widget.
+
+Replaces `OverviewParametersWidget` for the rebuilt overview UI. Two differences that
+matter:
+
+* **No parent coupling.** The old widget type-hinted its parent as
+  `FMAcquisitionWidget` and reached into it for channel names, so it could not be used
+  anywhere else. This one is told what it needs.
+* **Complete.** It covers `tile_order` and `tile_mask`, which the acquisition gained
+  with sparse tilesets and tile ordering and which nothing could set from the UI.
+"""
+
+from typing import List, Optional
+
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import (
+    QCheckBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QLabel,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem import constants
+from fibsem.fm.structures import AutoFocusMode, OverviewParameters
+from fibsem.structures import TileOrderStrategy
+from fibsem.ui.fm.widgets.tile_mask_widget import TileMaskWidget
+from fibsem.ui.utils import install_wheel_blocker
+from fibsem.ui.widgets.custom_widgets import ValueComboBox
+
+MUTED = "color: #868e93; font-size: 11px;"
+
+AUTOFOCUS_LABELS = {
+    AutoFocusMode.NONE: "Don't auto-focus",
+    AutoFocusMode.ONCE: "Once, at the start",
+    AutoFocusMode.EACH_ROW: "On each new row",
+    AutoFocusMode.EACH_TILE: "On every tile",
+}
+
+TILE_ORDER_LABELS = {
+    TileOrderStrategy.TYPEWRITER: "Typewriter (rows left to right)",
+    TileOrderStrategy.SERPENTINE: "Serpentine (alternating rows)",
+    TileOrderStrategy.SPIRAL: "Spiral (outward from centre)",
+}
+
+
+class FMOverviewSettingsWidget(QWidget):
+    """Grid, sampling and autofocus settings for a tileset acquisition."""
+
+    changed = pyqtSignal()
+
+    def __init__(
+        self,
+        parameters: Optional[OverviewParameters] = None,
+        channel_names: Optional[List[str]] = None,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(parent)
+        self._tile_fov: Optional[tuple] = None   # (fov_x, fov_y) metres, set externally
+        self._init_ui()
+        self.set_channel_names(channel_names or [])
+        if parameters is not None:
+            self.parameters = parameters
+        self._refresh_derived()
+
+    # ── construction ─────────────────────────────────────────────────────
+
+    def _init_ui(self) -> None:
+        self.spin_rows = QSpinBox()
+        self.spin_rows.setRange(1, 100)
+        self.spin_rows.setValue(3)
+
+        self.spin_cols = QSpinBox()
+        self.spin_cols.setRange(1, 100)
+        self.spin_cols.setValue(3)
+
+        self.spin_overlap = QDoubleSpinBox()
+        self.spin_overlap.setRange(0.0, 0.9)
+        self.spin_overlap.setSingleStep(0.05)
+        self.spin_overlap.setDecimals(2)
+        self.spin_overlap.setValue(0.1)
+
+        self.combo_tile_order = ValueComboBox(
+            items=list(TileOrderStrategy),
+            format_fn=lambda s: TILE_ORDER_LABELS.get(s, s.value.title()),
+        )
+
+        self.check_zstack = QCheckBox("Acquire a z-stack at each tile")
+
+        self.combo_autofocus_mode = ValueComboBox(
+            items=list(AutoFocusMode),
+            format_fn=lambda m: AUTOFOCUS_LABELS.get(m, m.name),
+        )
+        self.combo_autofocus_channel = ValueComboBox()
+
+        for widget in (self.spin_rows, self.spin_cols, self.spin_overlap):
+            install_wheel_blocker(widget)
+
+        grid_form = QFormLayout()
+        grid_form.addRow("Rows", self.spin_rows)
+        grid_form.addRow("Columns", self.spin_cols)
+        grid_form.addRow("Overlap", self.spin_overlap)
+        grid_form.addRow("Tile order", self.combo_tile_order)
+        grid_box = QGroupBox("Grid")
+        grid_box.setLayout(grid_form)
+
+        self.tile_mask = TileMaskWidget(rows=3, cols=3)
+        mask_layout = QVBoxLayout()
+        mask_layout.addWidget(self.tile_mask)
+        mask_box = QGroupBox("Tiles to acquire")
+        mask_box.setLayout(mask_layout)
+
+        focus_form = QFormLayout()
+        focus_form.addRow(self.check_zstack)
+        focus_form.addRow("Auto-focus", self.combo_autofocus_mode)
+        focus_form.addRow("Focus channel", self.combo_autofocus_channel)
+        focus_box = QGroupBox("Focus")
+        focus_box.setLayout(focus_form)
+
+        self.label_summary = QLabel()
+        self.label_summary.setStyleSheet(MUTED)
+        self.label_summary.setWordWrap(True)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(grid_box)
+        layout.addWidget(mask_box, stretch=1)
+        layout.addWidget(focus_box)
+        layout.addWidget(self.label_summary)
+
+        self.spin_rows.valueChanged.connect(self._on_grid_size_changed)
+        self.spin_cols.valueChanged.connect(self._on_grid_size_changed)
+        self.spin_overlap.valueChanged.connect(self._on_any_change)
+        self.combo_tile_order.currentIndexChanged.connect(self._on_tile_order_changed)
+        self.check_zstack.stateChanged.connect(self._on_any_change)
+        self.combo_autofocus_mode.currentIndexChanged.connect(self._on_autofocus_changed)
+        self.combo_autofocus_channel.currentIndexChanged.connect(self._on_any_change)
+        self.tile_mask.changed.connect(self._on_any_change)
+
+        self._on_autofocus_changed()
+
+    # ── reactions ────────────────────────────────────────────────────────
+
+    def _on_grid_size_changed(self) -> None:
+        self.tile_mask.set_grid_size(self.spin_rows.value(), self.spin_cols.value())
+        self._on_any_change()
+
+    def _on_tile_order_changed(self) -> None:
+        self._warn_if_spiral_conflicts()
+        self._on_any_change()
+
+    def _on_autofocus_changed(self) -> None:
+        mode = self.combo_autofocus_mode.value()
+        self.combo_autofocus_channel.setEnabled(mode is not AutoFocusMode.NONE)
+        self._warn_if_spiral_conflicts()
+        self._on_any_change()
+
+    def _warn_if_spiral_conflicts(self) -> None:
+        """A spiral revisits rows out of order, so the runner promotes EACH_ROW.
+
+        Surfaced here rather than left as a log line, so the setting the user chose and
+        the setting that will run are not quietly different things.
+        """
+        spiral = self.combo_tile_order.value() is TileOrderStrategy.SPIRAL
+        each_row = self.combo_autofocus_mode.value() is AutoFocusMode.EACH_ROW
+        self._spiral_conflict = spiral and each_row
+
+    def _on_any_change(self) -> None:
+        self._refresh_derived()
+        self.changed.emit()
+
+    # ── derived display ──────────────────────────────────────────────────
+
+    def set_tile_fov(self, fov_x: float, fov_y: float) -> None:
+        """Tell the widget one tile's field of view, so it can report total area."""
+        self._tile_fov = (fov_x, fov_y)
+        self._refresh_derived()
+
+    def _refresh_derived(self) -> None:
+        rows, cols = self.spin_rows.value(), self.spin_cols.value()
+        overlap = self.spin_overlap.value()
+        n_enabled = self.tile_mask.n_enabled
+
+        parts = [f"{n_enabled} of {rows * cols} tiles"]
+        if self._tile_fov is not None:
+            fov_x, fov_y = self._tile_fov
+            width = ((cols - 1) * (1 - overlap) + 1) * fov_x * constants.SI_TO_MICRO
+            height = ((rows - 1) * (1 - overlap) + 1) * fov_y * constants.SI_TO_MICRO
+            parts.append(f"{width:.0f} × {height:.0f} µm")
+        if getattr(self, "_spiral_conflict", False):
+            parts.append("per-row focus becomes per-tile for a spiral")
+        self.label_summary.setText(" · ".join(parts))
+
+    # ── value ────────────────────────────────────────────────────────────
+
+    def set_channel_names(self, names: List[str]) -> None:
+        current = self.combo_autofocus_channel.value()
+        self.combo_autofocus_channel.blockSignals(True)
+        self.combo_autofocus_channel.clear()
+        self.combo_autofocus_channel.add_values(list(names))
+        if current in names:
+            self.combo_autofocus_channel.set_value(current)
+        self.combo_autofocus_channel.blockSignals(False)
+
+    @property
+    def autofocus_channel_name(self) -> Optional[str]:
+        return self.combo_autofocus_channel.value()
+
+    @property
+    def parameters(self) -> OverviewParameters:
+        return OverviewParameters(
+            rows=self.spin_rows.value(),
+            cols=self.spin_cols.value(),
+            overlap=self.spin_overlap.value(),
+            use_zstack=self.check_zstack.isChecked(),
+            autofocus_mode=self.combo_autofocus_mode.value(),
+            tile_order=self.combo_tile_order.value(),
+            tile_mask=self.tile_mask.mask,
+        )
+
+    @parameters.setter
+    def parameters(self, value: OverviewParameters) -> None:
+        for widget in (self.spin_rows, self.spin_cols, self.spin_overlap,
+                       self.combo_tile_order, self.check_zstack,
+                       self.combo_autofocus_mode, self.tile_mask):
+            widget.blockSignals(True)
+        try:
+            self.spin_rows.setValue(value.rows)
+            self.spin_cols.setValue(value.cols)
+            self.spin_overlap.setValue(value.overlap)
+            self.combo_tile_order.set_value(value.tile_order)
+            self.check_zstack.setChecked(value.use_zstack)
+            self.combo_autofocus_mode.set_value(value.autofocus_mode)
+            self.tile_mask.set_grid_size(value.rows, value.cols)
+            self.tile_mask.mask = value.tile_mask
+        finally:
+            for widget in (self.spin_rows, self.spin_cols, self.spin_overlap,
+                           self.combo_tile_order, self.check_zstack,
+                           self.combo_autofocus_mode, self.tile_mask):
+                widget.blockSignals(False)
+        self._on_autofocus_changed()

--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -17,7 +17,6 @@ from PyQt5.QtWidgets import (
     QCheckBox,
     QDoubleSpinBox,
     QFormLayout,
-    QGroupBox,
     QHBoxLayout,
     QLabel,
     QSizePolicy,
@@ -39,7 +38,7 @@ from fibsem.ui.fm.widgets.autofocus_widget import AutofocusWidget
 from fibsem.ui.fm.widgets.tile_mask_widget import TileMaskWidget
 from fibsem.ui.fm.widgets.z_parameters_widget import ZParametersWidget
 from fibsem.ui.utils import install_wheel_blocker
-from fibsem.ui.widgets.custom_widgets import ValueComboBox
+from fibsem.ui.widgets.custom_widgets import TitledPanel, ValueComboBox
 
 MUTED = "color: #868e93; font-size: 11px;"
 
@@ -127,7 +126,9 @@ class FMOverviewSettingsWidget(QWidget):
                       for s in TileOrderStrategy)
         )
 
-        self.check_zstack = QCheckBox("Acquire a z-stack at each tile")
+        # No label: this sits in the Z-Stack panel header, which already names it.
+        self.check_zstack = QCheckBox()
+        self.check_zstack.setToolTip("Acquire a z-stack at each tile")
 
         self.combo_autofocus_mode = ValueComboBox(
             items=list(AutoFocusMode),
@@ -164,14 +165,12 @@ class FMOverviewSettingsWidget(QWidget):
         grid_form.addRow("Overlap", self.spin_overlap)
         grid_form.addRow("Tile order", self.combo_tile_order)
         grid_form.addRow("Total FOV", self.label_total_fov)
-        grid_box = QGroupBox("Grid")
-        grid_box.setLayout(grid_form)
+        grid_content = QWidget()
+        grid_content.setLayout(grid_form)
+        self.grid_panel = TitledPanel("Grid", content=grid_content)
 
         self.tile_mask = TileMaskWidget(rows=3, cols=3)
-        mask_layout = QVBoxLayout()
-        mask_layout.addWidget(self.tile_mask)
-        mask_box = QGroupBox("Tiles to acquire")
-        mask_box.setLayout(mask_layout)
+        self.mask_panel = TitledPanel("Tiles to acquire", content=self.tile_mask)
 
         # "When to focus" is the overview's own setting; everything below it -- method,
         # channel, and the sweep passes -- belongs to the sweep and is delegated.
@@ -185,19 +184,22 @@ class FMOverviewSettingsWidget(QWidget):
         focus_layout.setSpacing(6)
         focus_layout.addLayout(focus_form)
         focus_layout.addWidget(self.autofocus_widget)
-        focus_box = QGroupBox("Focus")
-        focus_box.setLayout(focus_layout)
+        focus_content = QWidget()
+        focus_content.setLayout(focus_layout)
+        self.focus_panel = TitledPanel("Focus", content=focus_content)
 
-        # The checkbox is the z-stack's enable, so it lives with what it enables --
-        # and the parameters grey out when it is off, instead of staying live and
+        # The enable checkbox goes in the panel header, not the body: it is the one
+        # piece of z-stack state worth seeing when the panel is folded away, and the
+        # parameters below it grey out when it is off rather than staying live and
         # implying they apply.
         zstack_layout = QVBoxLayout()
         zstack_layout.setContentsMargins(6, 6, 6, 6)
         zstack_layout.setSpacing(4)
-        zstack_layout.addWidget(self.check_zstack)
         zstack_layout.addWidget(self.z_widget)
-        self.zstack_box = QGroupBox("Z-Stack")
-        self.zstack_box.setLayout(zstack_layout)
+        zstack_content = QWidget()
+        zstack_content.setLayout(zstack_layout)
+        self.zstack_panel = TitledPanel("Z-Stack", content=zstack_content)
+        self.zstack_panel.add_header_widget(self.check_zstack)
 
         self.label_summary = QLabel()
         self.label_summary.setStyleSheet(MUTED)
@@ -205,11 +207,21 @@ class FMOverviewSettingsWidget(QWidget):
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(focus_box)
-        layout.addWidget(self.zstack_box)
-        layout.addWidget(grid_box)
-        layout.addWidget(mask_box, stretch=1)
+        layout.addWidget(self.focus_panel)
+        layout.addWidget(self.zstack_panel)
+        layout.addWidget(self.grid_panel)
+        # No stretch on any panel: a stretched panel keeps claiming vertical space when
+        # it is collapsed, so folding it leaves a tall empty box with the title floating
+        # in the middle of it. The trailing stretch below takes the slack instead -- kept
+        # here rather than left to the host, so the panels stay put in any container.
+        layout.addWidget(self.mask_panel)
         layout.addWidget(self.label_summary)
+        layout.addStretch()
+
+        # Grid and the tile mask are what you touch every run; focus and the z-stack are
+        # set once and then left alone, so they start folded to keep the column short.
+        self.focus_panel.collapse()
+        self.zstack_panel.collapse()
 
         self.spin_rows.valueChanged.connect(self._on_grid_size_changed)
         self.spin_cols.valueChanged.connect(self._on_grid_size_changed)
@@ -281,9 +293,6 @@ class FMOverviewSettingsWidget(QWidget):
         )
 
     def _refresh_derived(self) -> None:
-        rows, cols = self.spin_rows.value(), self.spin_cols.value()
-        n_enabled = self.tile_mask.n_enabled
-
         total = self.total_fov()
         self.label_total_fov.setText(
             "—" if total is None
@@ -291,7 +300,9 @@ class FMOverviewSettingsWidget(QWidget):
                  f"{total[1] * constants.SI_TO_MICRO:.0f} µm"
         )
 
-        parts = [f"{n_enabled} of {rows * cols} tiles"]
+        # Warnings only -- the tile count is already on the mask panel, and saying it
+        # twice just makes the second one look like a different number.
+        parts = []
         if getattr(self, "_spiral_conflict", False):
             parts.append("per-row focus becomes per-tile for a spiral")
         if self._focus_without_passes():

--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -27,8 +27,15 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem import constants
-from fibsem.fm.structures import AutoFocusMode, OverviewParameters, ZParameters
+from fibsem.fm.structures import (
+    AutoFocusMode,
+    AutoFocusSettings,
+    ChannelSettings,
+    OverviewParameters,
+    ZParameters,
+)
 from fibsem.structures import TileOrderStrategy
+from fibsem.ui.fm.widgets.autofocus_widget import AutofocusWidget
 from fibsem.ui.fm.widgets.tile_mask_widget import TileMaskWidget
 from fibsem.ui.fm.widgets.z_parameters_widget import ZParametersWidget
 from fibsem.ui.utils import install_wheel_blocker
@@ -68,7 +75,7 @@ class FMOverviewSettingsWidget(QWidget):
     def __init__(
         self,
         parameters: Optional[OverviewParameters] = None,
-        channel_names: Optional[List[str]] = None,
+        channel_settings: Optional[List[ChannelSettings]] = None,
         z_parameters: Optional[ZParameters] = None,
         parent: Optional[QWidget] = None,
     ):
@@ -77,8 +84,12 @@ class FMOverviewSettingsWidget(QWidget):
         # Owned here rather than by the parent, so every overview setting sits in one
         # widget and their order is this widget's to decide.
         self.z_widget = ZParametersWidget(z_parameters or ZParameters())
+        # The sweep itself -- method, channel, and the coarse/fine passes -- is already
+        # a solved widget backed by `AutoFocusSettings`. Only *when* to run it is an
+        # overview concern, so that is all this widget adds.
+        self.autofocus_widget = AutofocusWidget(list(channel_settings or []))
+        self.autofocus_widget.set_pass_editing_enabled(True)
         self._init_ui()
-        self.set_channel_names(channel_names or [])
         if parameters is not None:
             self.parameters = parameters
         self._refresh_derived()
@@ -122,13 +133,11 @@ class FMOverviewSettingsWidget(QWidget):
             items=list(AutoFocusMode),
             format_fn=lambda m: AUTOFOCUS_LABELS.get(m, m.name),
         )
-        self.combo_autofocus_channel = ValueComboBox()
 
         # The app's spinboxes carry -/+ buttons, which eat most of a narrow field and
         # leave the value clipped ("0" for an overlap of 0.10). Give them a floor.
         for widget in (self.spin_rows, self.spin_cols, self.spin_overlap,
-                       self.combo_tile_order, self.combo_autofocus_mode,
-                       self.combo_autofocus_channel):
+                       self.combo_tile_order, self.combo_autofocus_mode):
             widget.setMinimumWidth(SPINBOX_MIN_WIDTH)
             widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         for widget in (self.spin_rows, self.spin_cols, self.spin_overlap):
@@ -148,9 +157,13 @@ class FMOverviewSettingsWidget(QWidget):
         grid_form.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
         grid_form.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         grid_form.setFormAlignment(Qt.AlignLeft | Qt.AlignTop)
+        self.label_total_fov = QLabel("—")
+        self.label_total_fov.setStyleSheet(MUTED)
+
         grid_form.addRow("Rows × Columns", size_row)
         grid_form.addRow("Overlap", self.spin_overlap)
         grid_form.addRow("Tile order", self.combo_tile_order)
+        grid_form.addRow("Total FOV", self.label_total_fov)
         grid_box = QGroupBox("Grid")
         grid_box.setLayout(grid_form)
 
@@ -160,13 +173,20 @@ class FMOverviewSettingsWidget(QWidget):
         mask_box = QGroupBox("Tiles to acquire")
         mask_box.setLayout(mask_layout)
 
+        # "When to focus" is the overview's own setting; everything below it -- method,
+        # channel, and the sweep passes -- belongs to the sweep and is delegated.
         focus_form = QFormLayout()
         focus_form.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
         focus_form.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         focus_form.addRow("Auto-focus", self.combo_autofocus_mode)
-        focus_form.addRow("Focus channel", self.combo_autofocus_channel)
+
+        focus_layout = QVBoxLayout()
+        focus_layout.setContentsMargins(6, 6, 6, 6)
+        focus_layout.setSpacing(6)
+        focus_layout.addLayout(focus_form)
+        focus_layout.addWidget(self.autofocus_widget)
         focus_box = QGroupBox("Focus")
-        focus_box.setLayout(focus_form)
+        focus_box.setLayout(focus_layout)
 
         # The checkbox is the z-stack's enable, so it lives with what it enables --
         # and the parameters grey out when it is off, instead of staying live and
@@ -197,7 +217,7 @@ class FMOverviewSettingsWidget(QWidget):
         self.combo_tile_order.currentIndexChanged.connect(self._on_tile_order_changed)
         self.check_zstack.stateChanged.connect(self._on_zstack_toggled)
         self.combo_autofocus_mode.currentIndexChanged.connect(self._on_autofocus_changed)
-        self.combo_autofocus_channel.currentIndexChanged.connect(self._on_any_change)
+        self.autofocus_widget.settings_changed.connect(self._on_any_change)
         self.tile_mask.changed.connect(self._on_any_change)
 
         self._on_autofocus_changed()
@@ -219,7 +239,7 @@ class FMOverviewSettingsWidget(QWidget):
 
     def _on_autofocus_changed(self) -> None:
         mode = self.combo_autofocus_mode.value()
-        self.combo_autofocus_channel.setEnabled(mode is not AutoFocusMode.NONE)
+        self.autofocus_widget.setEnabled(mode is not AutoFocusMode.NONE)
         self._warn_if_spiral_conflicts()
         self._on_any_change()
 
@@ -244,20 +264,49 @@ class FMOverviewSettingsWidget(QWidget):
         self._tile_fov = (fov_x, fov_y)
         self._refresh_derived()
 
+    def total_fov(self) -> Optional[tuple]:
+        """Width and height of the whole mosaic in metres, or None if the tile FOV
+        has not been supplied.
+
+        The grid always spans the full rectangle regardless of the mask: skipped tiles
+        keep their place, so the area covered is a property of rows/cols/overlap alone.
+        """
+        if self._tile_fov is None:
+            return None
+        fov_x, fov_y = self._tile_fov
+        overlap = self.spin_overlap.value()
+        return (
+            ((self.spin_cols.value() - 1) * (1 - overlap) + 1) * fov_x,
+            ((self.spin_rows.value() - 1) * (1 - overlap) + 1) * fov_y,
+        )
+
     def _refresh_derived(self) -> None:
         rows, cols = self.spin_rows.value(), self.spin_cols.value()
-        overlap = self.spin_overlap.value()
         n_enabled = self.tile_mask.n_enabled
 
+        total = self.total_fov()
+        self.label_total_fov.setText(
+            "—" if total is None
+            else f"{total[0] * constants.SI_TO_MICRO:.0f} × "
+                 f"{total[1] * constants.SI_TO_MICRO:.0f} µm"
+        )
+
         parts = [f"{n_enabled} of {rows * cols} tiles"]
-        if self._tile_fov is not None:
-            fov_x, fov_y = self._tile_fov
-            width = ((cols - 1) * (1 - overlap) + 1) * fov_x * constants.SI_TO_MICRO
-            height = ((rows - 1) * (1 - overlap) + 1) * fov_y * constants.SI_TO_MICRO
-            parts.append(f"{width:.0f} × {height:.0f} µm")
         if getattr(self, "_spiral_conflict", False):
             parts.append("per-row focus becomes per-tile for a spiral")
+        if self._focus_without_passes():
+            parts.append("auto-focus is on but every sweep pass is disabled")
         self.label_summary.setText(" · ".join(parts))
+
+    def _focus_without_passes(self) -> bool:
+        """Focusing scheduled, but nothing for it to sweep.
+
+        `AutoFocusSettings.enabled` is False when every pass is unticked, so the run
+        would schedule focusing and then do nothing -- two controls that each look set
+        correctly, contradicting each other.
+        """
+        settings = self.autofocus_settings
+        return settings is not None and not settings.enabled
 
     # ── value ────────────────────────────────────────────────────────────
 
@@ -270,9 +319,26 @@ class FMOverviewSettingsWidget(QWidget):
             self.combo_autofocus_channel.set_value(current)
         self.combo_autofocus_channel.blockSignals(False)
 
+    def set_channel_settings(self, channels: List[ChannelSettings]) -> None:
+        """Keep the focus-channel choices in step with the channels being acquired."""
+        self.autofocus_widget.update_channels(list(channels))
+
     @property
     def autofocus_channel_name(self) -> Optional[str]:
-        return self.combo_autofocus_channel.value()
+        channel = self.autofocus_widget.get_selected_channel()
+        return channel.name if channel is not None else None
+
+    @property
+    def autofocus_settings(self) -> Optional[AutoFocusSettings]:
+        """The sweep to run, or None when autofocus is off.
+
+        None rather than settings-behind-a-disabled-control, matching how the
+        acquisition already reads `autofocus_settings=None`: one place decides whether
+        focusing happens, and it is the mode.
+        """
+        if self.combo_autofocus_mode.value() is AutoFocusMode.NONE:
+            return None
+        return self.autofocus_widget.get_autofocus_settings()
 
     @property
     def z_parameters(self) -> Optional[ZParameters]:

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -107,7 +107,7 @@ class FMOverviewWidget(QWidget):
         # Every overview setting lives in one widget, z-stack included, so their order
         # is decided in one place rather than split across two.
         self.settings_widget = FMOverviewSettingsWidget(
-            channel_names=[ch.name for ch in channels]
+            channel_settings=channels
         )
 
         controls = QWidget()
@@ -207,7 +207,7 @@ class FMOverviewWidget(QWidget):
             logging.debug(f"Could not read the camera field of view: {e}")
 
     def _on_channels_changed(self, channels: List[ChannelSettings]) -> None:
-        self.settings_widget.set_channel_names([ch.name for ch in channels])
+        self.settings_widget.set_channel_settings(channels)
         self._on_settings_changed()
 
     def _on_enabled_changed(self, channels: List[ChannelSettings]) -> None:
@@ -246,23 +246,22 @@ class FMOverviewWidget(QWidget):
             return
 
         zparams = self.settings_widget.z_parameters
+        # Method, channel and sweep passes all come from the settings panel now,
+        # rather than being defaulted with only the channel filled in. Resolved before
+        # the dialog, because the dialog reports what will run.
+        autofocus_settings = self.settings_widget.autofocus_settings
 
         dialog = FMOverviewConfirmationDialog(
             parameters=parameters,
             channel_settings=channels,
             zparams=zparams,
             tile_fov=self.settings_widget._tile_fov,
+            autofocus_settings=autofocus_settings,
             parent=self,
         )
         if dialog.exec_() != QDialog.Accepted:
             logging.info("Overview acquisition cancelled before starting")
             return
-
-        autofocus_settings = None
-        if parameters.autofocus_mode is not AutoFocusMode.NONE:
-            autofocus_settings = AutoFocusSettings(
-                channel_name=self.settings_widget.autofocus_channel_name
-            )
 
         self._stop_event.clear()
         self._set_running(True)

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -18,7 +18,6 @@ from PyQt5.QtWidgets import (
     QDialog,
     QHBoxLayout,
     QLabel,
-    QProgressBar,
     QPushButton,
     QScrollArea,
     QSplitter,
@@ -39,13 +38,40 @@ from fibsem.ui import stylesheets
 from fibsem.ui.fm.widgets.fm_multi_channel_widget import FluorescenceMultiChannelWidget
 from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     FMOverviewConfirmationDialog,
-    format_duration,
 )
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
 from fibsem.ui.qt.threading import FunctionWorker
+from fibsem.ui.widgets.progress_widget import (
+    FibsemProgressWidget,
+    ProgressUpdate,
+)
 from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
 
 TEXT_MUTED = "#868e93"
+PROGRESS_WIDTH = 260
+PROGRESS_HEIGHT = 22
+PROGRESS_FONT_PX = 10
+
+
+def progress_slot(progress: FibsemProgressWidget) -> QWidget:
+    """A fixed-size holder that keeps its space whether the bar is showing or not.
+
+    `FibsemProgressWidget.reset()` hides itself, which in a plain layout collapses the
+    row and shifts everything beside it -- so a bar going away at the end of a run
+    would drag the buttons across. Reserving the space decouples them.
+    """
+    # Via a stylesheet on the holder rather than `setFont`, which does not reach the
+    # bar, and rather than touching the widget's private `_bar`. The bar's own sheet
+    # sets no font-size, so this applies without disturbing the chunk colouring it
+    # relies on to tell finished from failed.
+    progress.setStyleSheet(f"QProgressBar {{ font-size: {PROGRESS_FONT_PX}px; }}")
+
+    slot = QWidget()
+    slot.setFixedSize(PROGRESS_WIDTH, PROGRESS_HEIGHT)
+    layout = QHBoxLayout(slot)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.addWidget(progress)
+    return slot
 
 
 class FMOverviewWidget(QWidget):
@@ -136,12 +162,11 @@ class FMOverviewWidget(QWidget):
         splitter.setStretchFactor(0, 1)
         splitter.setStretchFactor(1, 0)
 
-        self.progress = QProgressBar()
-        self.progress.setRange(0, 100)
-        self.progress.setTextVisible(True)
-        self.progress.setFormat("")
-        self.progress.setFixedHeight(18)
-        self.progress.hide()
+        # Two bars: across the grid, and within the tile being acquired. Both are
+        # `FibsemProgressWidget`, which distinguishes finished from failed -- a failed
+        # run used to paint the same full green bar as a successful one.
+        self.progress_tiles = FibsemProgressWidget()
+        self.progress_tile_detail = FibsemProgressWidget()
 
         self.status = QLabel("")
         self.status.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px;")
@@ -157,18 +182,31 @@ class FMOverviewWidget(QWidget):
         self.button_cancel.clicked.connect(self.cancel)
         self.button_cancel.setEnabled(False)
 
-        actions = QHBoxLayout()
-        actions.setContentsMargins(8, 0, 8, 8)
-        actions.addWidget(self.status, stretch=1)
-        actions.addWidget(self.button_cancel)
-        actions.addWidget(self.button_acquire)
+        # One row: status, both bars, then the actions. The bars sit in fixed slots, so
+        # the buttons hold their position whatever the bars are doing.
+        # The two bars are one readout and sit tight together; the gap that matters is
+        # the one separating them from the buttons.
+        bars = QWidget()
+        bars_layout = QHBoxLayout(bars)
+        bars_layout.setContentsMargins(0, 0, 0, 0)
+        bars_layout.setSpacing(3)
+        bars_layout.addWidget(progress_slot(self.progress_tiles))
+        bars_layout.addWidget(progress_slot(self.progress_tile_detail))
+
+        self.status_row = QWidget()
+        status_layout = QHBoxLayout(self.status_row)
+        status_layout.setContentsMargins(8, 4, 8, 8)
+        status_layout.setSpacing(10)
+        status_layout.addWidget(self.status, stretch=1)
+        status_layout.addWidget(bars)
+        status_layout.addWidget(self.button_cancel)
+        status_layout.addWidget(self.button_acquire)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(6)
         layout.addWidget(splitter, stretch=1)
-        layout.addWidget(self.progress)
-        layout.addLayout(actions)
+        layout.addWidget(self.status_row)
 
         self.channel_widget.settings_changed.connect(self._on_channels_changed)
         self.channel_widget.enabled_changed.connect(self._on_enabled_changed)
@@ -321,10 +359,12 @@ class FMOverviewWidget(QWidget):
         self.button_cancel.setEnabled(running)
         self.settings_widget.setEnabled(not running)
         self.channel_widget.setEnabled(not running)
-        self.progress.setVisible(running)
         if running:
-            self.progress.setValue(0)
-            self.progress.setFormat("Starting…")
+            # Left empty rather than shown as indeterminate, which would paint a full
+            # bar before a single tile had been acquired.
+            self.progress_tiles.reset()
+            self.progress_tile_detail.reset()
+            self.status.setText("Starting…")
 
     # ── progress ─────────────────────────────────────────────────────────
 
@@ -333,20 +373,76 @@ class FMOverviewWidget(QWidget):
         self._progress_received.emit(payload)
 
     def _apply_progress(self, payload: dict) -> None:
-        """Runs on the GUI thread, queued via `_progress_received`."""
+        """Runs on the GUI thread, queued via `_progress_received`.
+
+        One signal carries both scales -- the tileset runner's and, from inside each
+        tile, `acquire_z_stack`/`acquire_channels` -- so `task` decides which bar a
+        payload belongs to. Anything else is ignored rather than shown twice.
+        """
         state = payload.get("state")
 
-        if state == "tile":
-            self._show_preview(payload)
-            current, total = payload.get("current", 0), payload.get("total", 1)
-            self.progress.setValue(int(current / max(1, total) * 100))
-            remaining = payload.get("estimated_remaining_time")
-            suffix = f" · {format_duration(remaining)} left" if remaining else ""
-            self.progress.setFormat(f"Tile {current}/{total}{suffix}")
-        elif state == "moving":
-            self.progress.setFormat("Moving stage…")
-        elif state in ("overview-finished", "overview-cancelled", "overview-failed"):
+        if state in ("overview-finished", "overview-cancelled", "overview-failed"):
             self._finish(state, payload.get("error"))
+            return
+
+        task = payload.get("task")
+        if task == "tileset":
+            self._apply_tile_progress(payload, state)
+        elif task in ("z-stack", "channels"):
+            self.progress_tile_detail.update_progress(self._tile_detail_update(payload))
+
+    def _apply_tile_progress(self, payload: dict, state: Optional[str]) -> None:
+        if state == "moving":
+            # Deliberately not `indeterminate`: that paints a *full* bar with a
+            # spinner, so every stage move looked like the run had just completed.
+            # The bar keeps the last tile count -- which is still true between tiles --
+            # and the transient state goes to the status label instead.
+            self.status.setText("Moving stage…")
+            return
+
+        self.status.setText("")
+
+        if state == "tile":
+            # Deliberately does *not* clear the within-tile bar. It used to, which made
+            # it vanish and reappear at every tile boundary -- a flicker for the whole
+            # run. The next tile's first payload overwrites it a moment later anyway.
+            self._show_preview(payload)
+
+        current, total = payload.get("current", 0), payload.get("total", 1)
+        remaining = payload.get("estimated_remaining_time")
+        # The widget renders the count itself, so the message says what is being
+        # counted and nothing more -- otherwise it reads "Tile 4/9 — 4/9".
+        message = "Tiles"
+        if remaining:
+            self.progress_tiles.update_progress(ProgressUpdate.combined(
+                current=current, total=total,
+                remaining_seconds=remaining,
+                total_seconds=payload.get("estimated_total_time", 0.0),
+                message=message,
+            ))
+        else:
+            self.progress_tiles.update_progress(
+                ProgressUpdate.numeric(current=current, total=total, message=message)
+            )
+
+    def _tile_detail_update(self, payload: dict) -> ProgressUpdate:
+        """Progress within the tile currently being acquired.
+
+        A z-stack counts planes and a plain multi-channel acquisition counts channels,
+        so the same bar reads sensibly either way rather than sitting empty whenever
+        z-stacking happens to be off.
+        """
+        channel = payload.get("channel", "")
+        zlevel, total_z = payload.get("zlevel"), payload.get("total_zlevels")
+        if zlevel and total_z:
+            return ProgressUpdate.numeric(
+                current=zlevel, total=total_z, message=f"{channel} z-stack"
+            )
+        index = payload.get("channel_index", 1)
+        total = payload.get("total_channels", 1)
+        return ProgressUpdate.numeric(
+            current=index, total=total, message=f"{channel} channels"
+        )
 
     def _show_preview(self, payload: dict) -> None:
         """Paint the mosaic-so-far onto the canvas.
@@ -370,16 +466,24 @@ class FMOverviewWidget(QWidget):
     def _finish(self, state: str, error: Optional[str]) -> None:
         self._set_running(False)
         self._worker = None
+        self.progress_tile_detail.reset()
 
         if state == "overview-finished" and self._mosaic is not None:
             # Swap the decimated preview for the real thing.
             self.canvas.set_fm_image(self._mosaic)
             shape = self._mosaic.data.shape
             self.status.setText(f"Overview acquired — {shape[-1]} × {shape[-2]} px")
+            self.progress_tiles.update_progress(ProgressUpdate.done())
         elif state == "overview-cancelled":
             self.status.setText("Cancelled. Tiles acquired so far are still shown.")
+            self.progress_tiles.reset()
         else:
             self.status.setText(f"Failed: {error}" if error else "Failed.")
+            # Failed, not done: the widget paints these differently, and a failure
+            # showing a full green bar reads as success in everything but the text.
+            self.progress_tiles.update_progress(
+                ProgressUpdate.failed(error or "Acquisition failed")
+            )
 
     # ── lifecycle ────────────────────────────────────────────────────────
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -33,7 +33,6 @@ from fibsem.fm.structures import (
     ChannelSettings,
     FluorescenceImage,
     OverviewParameters,
-    ZParameters,
 )
 from fibsem.microscope import FibsemMicroscope
 from fibsem.ui import stylesheets
@@ -43,7 +42,6 @@ from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     format_duration,
 )
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
-from fibsem.ui.fm.widgets.z_parameters_widget import ZParametersWidget
 from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
 
@@ -106,7 +104,8 @@ class FMOverviewWidget(QWidget):
         self.canvas = FMCanvasWidget()
 
         self.channel_widget = ChannelListWidget(self.fm, channels)
-        self.z_widget = ZParametersWidget(ZParameters())
+        # Every overview setting lives in one widget, z-stack included, so their order
+        # is decided in one place rather than split across two.
         self.settings_widget = FMOverviewSettingsWidget(
             channel_names=[ch.name for ch in channels]
         )
@@ -116,7 +115,6 @@ class FMOverviewWidget(QWidget):
         controls_layout.setContentsMargins(8, 8, 8, 8)
         controls_layout.setSpacing(10)
         controls_layout.addWidget(self._section("Channels", self.channel_widget))
-        controls_layout.addWidget(self._section("Z-Stack", self.z_widget))
         controls_layout.addWidget(self.settings_widget)
         controls_layout.addStretch()
 
@@ -247,7 +245,7 @@ class FMOverviewWidget(QWidget):
             self.status.setText("No channels enabled.")
             return
 
-        zparams = self.z_widget._z_parameters if parameters.use_zstack else None
+        zparams = self.settings_widget.z_parameters
 
         dialog = FMOverviewConfirmationDialog(
             parameters=parameters,
@@ -321,7 +319,6 @@ class FMOverviewWidget(QWidget):
         self.button_cancel.setEnabled(running)
         self.settings_widget.setEnabled(not running)
         self.channel_widget.setEnabled(not running)
-        self.z_widget.setEnabled(not running)
         self.progress.setVisible(running)
         if running:
             self.progress.setValue(0)

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -388,7 +388,7 @@ class FMOverviewWidget(QWidget):
         task = payload.get("task")
         if task == "tileset":
             self._apply_tile_progress(payload, state)
-        elif task in ("z-stack", "channels"):
+        elif task in ("z-stack", "channels", "autofocus"):
             self.progress_tile_detail.update_progress(self._tile_detail_update(payload))
 
     def _apply_tile_progress(self, payload: dict, state: Optional[str]) -> None:
@@ -435,6 +435,15 @@ class FMOverviewWidget(QWidget):
         channel = payload.get("channel", "")
         zlevel, total_z = payload.get("zlevel"), payload.get("total_zlevels")
         if zlevel and total_z:
+            if payload.get("task") == "autofocus":
+                # Say which pass, so a coarse sweep followed by a fine one does not
+                # look like the same bar inexplicably starting over.
+                total_passes = payload.get("total_passes", 1)
+                which = (f" {payload.get('pass_index', 1)}/{total_passes}"
+                         if total_passes > 1 else "")
+                return ProgressUpdate.numeric(
+                    current=zlevel, total=total_z, message=f"{channel} focus{which}"
+                )
             return ProgressUpdate.numeric(
                 current=zlevel, total=total_z, message=f"{channel} z-stack"
             )

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -41,6 +41,7 @@ from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
 )
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
 from fibsem.ui.qt.threading import FunctionWorker
+from fibsem.ui.widgets.custom_widgets import TitledPanel
 from fibsem.ui.widgets.progress_widget import (
     FibsemProgressWidget,
     ProgressUpdate,
@@ -150,8 +151,13 @@ class FMOverviewWidget(QWidget):
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setWidget(controls)
-        scroll.setMinimumWidth(360)
-        scroll.setMaximumWidth(480)
+        # A channel row needs 446px before its name field hits its own minimum and the
+        # excitation combo falls off the right edge; group-box margins and the vertical
+        # scrollbar eat ~50px on the way in, so the column itself needs ~500. 510 leaves
+        # a little room for wider fonts. The horizontal bar is off below, so anything
+        # that overflows here is unreachable rather than merely cramped.
+        scroll.setMinimumWidth(510)
+        scroll.setMaximumWidth(560)
         # Vertical only: a horizontal bar here means a control is refusing to shrink,
         # and scrolling sideways to reach a spinbox is worse than a cramped one.
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
@@ -213,12 +219,7 @@ class FMOverviewWidget(QWidget):
         self.settings_widget.changed.connect(self._on_settings_changed)
 
     def _section(self, title: str, widget: QWidget) -> QWidget:
-        from PyQt5.QtWidgets import QGroupBox
-        box = QGroupBox(title)
-        inner = QVBoxLayout(box)
-        inner.setContentsMargins(6, 6, 6, 6)
-        inner.addWidget(widget)
-        return box
+        return TitledPanel(title, content=widget)
 
     # ── state ────────────────────────────────────────────────────────────
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -1,0 +1,394 @@
+"""Acquire a fluorescence overview: settings, run control, and live result.
+
+Standalone, and embeddable as a tab. It owns nothing the acquisition needs -- it is
+handed a microscope and drives `FMTiledAcquisitionRunner` -- so it can be dropped into
+the AutoLamella UI or opened on its own against a simulator.
+
+Layout follows the house convention: canvas on the left, controls on the right,
+actions along the bottom.
+"""
+
+import logging
+import threading
+from typing import List, Optional
+
+import numpy as np
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QProgressBar,
+    QPushButton,
+    QScrollArea,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.fm.acquisition import FMTiledAcquisitionRunner, stitch_tileset
+from fibsem.fm.structures import (
+    AutoFocusMode,
+    AutoFocusSettings,
+    ChannelSettings,
+    FluorescenceImage,
+    OverviewParameters,
+    ZParameters,
+)
+from fibsem.microscope import FibsemMicroscope
+from fibsem.ui import stylesheets
+from fibsem.ui.fm.widgets.channel_list_widget import ChannelListWidget
+from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
+    FMOverviewConfirmationDialog,
+    format_duration,
+)
+from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
+from fibsem.ui.fm.widgets.z_parameters_widget import ZParametersWidget
+from fibsem.ui.qt.threading import FunctionWorker
+from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
+
+TEXT_MUTED = "#868e93"
+
+
+class FMOverviewWidget(QWidget):
+    """Configure, run and view a fluorescence overview acquisition."""
+
+    overview_acquired = pyqtSignal(FluorescenceImage)
+
+    # Internal hop from the acquisition thread to the GUI thread. The microscope's
+    # progress signal is a psygnal, which calls its callbacks synchronously on
+    # whichever thread emitted -- here, the worker. Touching widgets from there is a
+    # cross-thread GUI access (Qt says so: "Cannot set parent, new parent is in a
+    # different thread"). Re-emitting as a Qt signal gets it queued onto the GUI
+    # thread, because this widget lives there.
+    _progress_received = pyqtSignal(dict)
+
+    def __init__(
+        self,
+        microscope: FibsemMicroscope,
+        channel_settings: Optional[List[ChannelSettings]] = None,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(parent)
+        if microscope.fm is None:
+            raise ValueError("This microscope has no fluorescence detector.")
+        self.microscope = microscope
+        self.fm = microscope.fm
+
+        self._stop_event = threading.Event()
+        self._worker: Optional[FunctionWorker] = None
+        self._runner: Optional[FMTiledAcquisitionRunner] = None
+        self._mosaic: Optional[FluorescenceImage] = None
+        self._enabled_channels: Optional[List[ChannelSettings]] = None
+
+        self._init_ui(channel_settings or self._default_channels())
+        self._sync_tile_fov()
+        self._on_settings_changed()
+
+        self._progress_received.connect(self._apply_progress)
+        self.fm.acquisition_progress_signal.connect(self._on_progress)
+
+    def _default_channels(self) -> List[ChannelSettings]:
+        """The saved FM configuration if there is one, otherwise a single channel."""
+        try:
+            from fibsem.fm.config import load_fm_configuration
+
+            config = load_fm_configuration()
+            if config is not None and config.channel_settings:
+                return list(config.channel_settings)
+        except Exception as e:
+            logging.debug(f"Could not load the saved FM configuration: {e}")
+        return [ChannelSettings(name="Channel-01")]
+
+    # ── layout ───────────────────────────────────────────────────────────
+
+    def _init_ui(self, channels: List[ChannelSettings]) -> None:
+        self.canvas = FMCanvasWidget()
+
+        self.channel_widget = ChannelListWidget(self.fm, channels)
+        self.z_widget = ZParametersWidget(ZParameters())
+        self.settings_widget = FMOverviewSettingsWidget(
+            channel_names=[ch.name for ch in channels]
+        )
+
+        controls = QWidget()
+        controls_layout = QVBoxLayout(controls)
+        controls_layout.setContentsMargins(8, 8, 8, 8)
+        controls_layout.setSpacing(10)
+        controls_layout.addWidget(self._section("Channels", self.channel_widget))
+        controls_layout.addWidget(self._section("Z-Stack", self.z_widget))
+        controls_layout.addWidget(self.settings_widget)
+        controls_layout.addStretch()
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(controls)
+        scroll.setMinimumWidth(360)
+        scroll.setMaximumWidth(480)
+        # Vertical only: a horizontal bar here means a control is refusing to shrink,
+        # and scrolling sideways to reach a spinbox is worse than a cramped one.
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
+        splitter = QSplitter(Qt.Horizontal)
+        splitter.addWidget(self.canvas)
+        splitter.addWidget(scroll)
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 0)
+
+        self.progress = QProgressBar()
+        self.progress.setRange(0, 100)
+        self.progress.setTextVisible(True)
+        self.progress.setFormat("")
+        self.progress.setFixedHeight(18)
+        self.progress.hide()
+
+        self.status = QLabel("")
+        self.status.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px;")
+
+        self.button_acquire = QPushButton("Acquire Overview")
+        self.button_acquire.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.button_acquire.setMinimumHeight(30)
+        self.button_acquire.clicked.connect(self.acquire)
+
+        self.button_cancel = QPushButton("Cancel")
+        self.button_cancel.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.button_cancel.setMinimumHeight(30)
+        self.button_cancel.clicked.connect(self.cancel)
+        self.button_cancel.setEnabled(False)
+
+        actions = QHBoxLayout()
+        actions.setContentsMargins(8, 0, 8, 8)
+        actions.addWidget(self.status, stretch=1)
+        actions.addWidget(self.button_cancel)
+        actions.addWidget(self.button_acquire)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        layout.addWidget(splitter, stretch=1)
+        layout.addWidget(self.progress)
+        layout.addLayout(actions)
+
+        self.channel_widget.settings_changed.connect(self._on_channels_changed)
+        self.channel_widget.enabled_changed.connect(self._on_enabled_changed)
+        self.settings_widget.changed.connect(self._on_settings_changed)
+
+    def _section(self, title: str, widget: QWidget) -> QWidget:
+        from PyQt5.QtWidgets import QGroupBox
+        box = QGroupBox(title)
+        inner = QVBoxLayout(box)
+        inner.setContentsMargins(6, 6, 6, 6)
+        inner.addWidget(widget)
+        return box
+
+    # ── state ────────────────────────────────────────────────────────────
+
+    @property
+    def is_acquiring(self) -> bool:
+        return self._worker is not None and self._worker.is_alive()
+
+    @property
+    def channels(self) -> List[ChannelSettings]:
+        """The channels that will be acquired: those ticked, or all of them.
+
+        `ChannelListWidget` reports ticks through `enabled_changed` rather than
+        exposing them, so they are tracked here. Before any tick has been touched the
+        list is every channel, which is what the widget shows.
+        """
+        if self._enabled_channels is None:
+            return list(self.channel_widget.channel_settings)
+        return list(self._enabled_channels)
+
+    def _sync_tile_fov(self) -> None:
+        """Tell the settings widget one tile's field of view, for the area readout."""
+        try:
+            pixel_size_x, pixel_size_y = self.fm.camera.pixel_size
+            width, height = self.fm.camera.resolution
+            self.settings_widget.set_tile_fov(width * pixel_size_x, height * pixel_size_y)
+        except Exception as e:
+            logging.debug(f"Could not read the camera field of view: {e}")
+
+    def _on_channels_changed(self, channels: List[ChannelSettings]) -> None:
+        self.settings_widget.set_channel_names([ch.name for ch in channels])
+        self._on_settings_changed()
+
+    def _on_enabled_changed(self, channels: List[ChannelSettings]) -> None:
+        self._enabled_channels = list(channels)
+        self._on_settings_changed()
+
+    def _on_settings_changed(self) -> None:
+        if self.is_acquiring:
+            return
+        parameters = self.settings_widget.parameters
+        enabled = parameters.n_enabled_tiles > 0
+        self.button_acquire.setEnabled(enabled)
+        # Only own the status line while it has something of its own to say. Re-enabling
+        # the controls at the end of a run makes children emit `changed`, which landed
+        # here and wiped the result message the moment it was set.
+        if not enabled:
+            self.status.setText("No tiles selected.")
+        elif self.status.text() == "No tiles selected.":
+            self.status.setText("")
+
+    # ── acquisition ──────────────────────────────────────────────────────
+
+    def acquire(self) -> None:
+        """Confirm, then run the overview on a worker thread."""
+        if self.is_acquiring:
+            logging.warning("An overview acquisition is already running.")
+            return
+        if self.fm.is_acquiring:
+            logging.warning("Stop live acquisition before acquiring an overview.")
+            return
+
+        parameters = self.settings_widget.parameters
+        channels = self.channels
+        if not channels:
+            self.status.setText("No channels enabled.")
+            return
+
+        zparams = self.z_widget._z_parameters if parameters.use_zstack else None
+
+        dialog = FMOverviewConfirmationDialog(
+            parameters=parameters,
+            channel_settings=channels,
+            zparams=zparams,
+            tile_fov=self.settings_widget._tile_fov,
+            parent=self,
+        )
+        if dialog.exec_() != QDialog.Accepted:
+            logging.info("Overview acquisition cancelled before starting")
+            return
+
+        autofocus_settings = None
+        if parameters.autofocus_mode is not AutoFocusMode.NONE:
+            autofocus_settings = AutoFocusSettings(
+                channel_name=self.settings_widget.autofocus_channel_name
+            )
+
+        self._stop_event.clear()
+        self._set_running(True)
+        self._runner = FMTiledAcquisitionRunner(
+            microscope=self.microscope,
+            channel_settings=channels,
+            overview_parameters=parameters,
+            zparams=zparams,
+            autofocus_settings=autofocus_settings,
+            stop_event=self._stop_event,
+        )
+        self._worker = FunctionWorker(self._acquire_worker)
+        self._worker.start()
+
+    def _acquire_worker(self) -> None:
+        """Runs off the GUI thread. Only signals may cross back."""
+        from fibsem.cancellation import OperationCancelledError
+
+        try:
+            runner = self._runner
+            runner.run()
+            mosaic = stitch_tileset(
+                runner.tileset,
+                runner.overview_parameters.overlap,
+                centre_position=runner._initial_position,
+                objective_position=runner._initial_objective_position,
+            )
+            self._mosaic = mosaic
+            self.overview_acquired.emit(mosaic)
+            self.fm.acquisition_progress_signal.emit(
+                {"state": "overview-finished", "task": "tileset"}
+            )
+        except OperationCancelledError:
+            logging.info("Overview acquisition cancelled")
+            self.fm.acquisition_progress_signal.emit(
+                {"state": "overview-cancelled", "task": "tileset"}
+            )
+        except Exception as e:
+            logging.error(f"Overview acquisition failed: {e}", exc_info=True)
+            self.fm.acquisition_progress_signal.emit(
+                {"state": "overview-failed", "task": "tileset", "error": str(e)}
+            )
+
+    def cancel(self) -> None:
+        if not self.is_acquiring:
+            return
+        logging.info("Cancelling overview acquisition")
+        self._stop_event.set()
+        self.button_cancel.setEnabled(False)
+        self.status.setText("Cancelling…")
+
+    def _set_running(self, running: bool) -> None:
+        self.button_acquire.setEnabled(not running)
+        self.button_cancel.setEnabled(running)
+        self.settings_widget.setEnabled(not running)
+        self.channel_widget.setEnabled(not running)
+        self.z_widget.setEnabled(not running)
+        self.progress.setVisible(running)
+        if running:
+            self.progress.setValue(0)
+            self.progress.setFormat("Starting…")
+
+    # ── progress ─────────────────────────────────────────────────────────
+
+    def _on_progress(self, payload: dict) -> None:
+        """Called by psygnal, on whichever thread emitted. Touches no widgets."""
+        self._progress_received.emit(payload)
+
+    def _apply_progress(self, payload: dict) -> None:
+        """Runs on the GUI thread, queued via `_progress_received`."""
+        state = payload.get("state")
+
+        if state == "tile":
+            self._show_preview(payload)
+            current, total = payload.get("current", 0), payload.get("total", 1)
+            self.progress.setValue(int(current / max(1, total) * 100))
+            remaining = payload.get("estimated_remaining_time")
+            suffix = f" · {format_duration(remaining)} left" if remaining else ""
+            self.progress.setFormat(f"Tile {current}/{total}{suffix}")
+        elif state == "moving":
+            self.progress.setFormat("Moving stage…")
+        elif state in ("overview-finished", "overview-cancelled", "overview-failed"):
+            self._finish(state, payload.get("error"))
+
+    def _show_preview(self, payload: dict) -> None:
+        """Paint the mosaic-so-far onto the canvas.
+
+        The runner publishes the whole preview canvas each tile, so this stays
+        stateless -- it redisplays what it is given rather than accumulating tiles of
+        its own, which is also what makes it correct if a frame is dropped.
+        """
+        image = payload.get("image")
+        if image is None:
+            return
+        try:
+            planes = np.asarray(image)
+            if planes.ndim == 2:
+                planes = planes[np.newaxis]
+            for channel, plane in zip(self.channels, planes):
+                self.canvas.set_channel(channel.name, plane, channel.color)
+        except Exception as e:
+            logging.debug(f"Could not display the overview preview: {e}")
+
+    def _finish(self, state: str, error: Optional[str]) -> None:
+        self._set_running(False)
+        self._worker = None
+
+        if state == "overview-finished" and self._mosaic is not None:
+            # Swap the decimated preview for the real thing.
+            self.canvas.set_fm_image(self._mosaic)
+            shape = self._mosaic.data.shape
+            self.status.setText(f"Overview acquired — {shape[-1]} × {shape[-2]} px")
+        elif state == "overview-cancelled":
+            self.status.setText("Cancelled. Tiles acquired so far are still shown.")
+        else:
+            self.status.setText(f"Failed: {error}" if error else "Failed.")
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+
+    def closeEvent(self, event) -> None:
+        if self.is_acquiring:
+            self._stop_event.set()
+        try:
+            self.fm.acquisition_progress_signal.disconnect(self._on_progress)
+        except (TypeError, RuntimeError):
+            pass
+        super().closeEvent(event)

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -36,7 +36,7 @@ from fibsem.fm.structures import (
 )
 from fibsem.microscope import FibsemMicroscope
 from fibsem.ui import stylesheets
-from fibsem.ui.fm.widgets.channel_list_widget import ChannelListWidget
+from fibsem.ui.fm.widgets.fm_multi_channel_widget import FluorescenceMultiChannelWidget
 from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     FMOverviewConfirmationDialog,
     format_duration,
@@ -103,7 +103,10 @@ class FMOverviewWidget(QWidget):
     def _init_ui(self, channels: List[ChannelSettings]) -> None:
         self.canvas = FMCanvasWidget()
 
-        self.channel_widget = ChannelListWidget(self.fm, channels)
+        # The list alone shows only name/excitation/emission, with no way to set the
+        # exposure, power or gain a tile is actually acquired at. This composes the
+        # list with the detail panel for the selected channel, and is a drop-in for it.
+        self.channel_widget = FluorescenceMultiChannelWidget(self.fm, channels)
         # Every overview setting lives in one widget, z-stack included, so their order
         # is decided in one place rather than split across two.
         self.settings_widget = FMOverviewSettingsWidget(

--- a/fibsem/ui/fm/widgets/tile_mask_widget.py
+++ b/fibsem/ui/fm/widgets/tile_mask_widget.py
@@ -1,0 +1,270 @@
+"""Interactive per-tile enable mask for a sparse overview.
+
+The acquisition data model is a per-tile boolean mask, deliberately: rectangular
+region selection is then an affordance over it rather than a second concept in the
+engine. This widget is that affordance -- click a tile to toggle it, drag to sweep a
+rectangle, or use the presets.
+"""
+
+from typing import List, Optional
+
+from PyQt5.QtCore import QRect, Qt, pyqtSignal
+from PyQt5.QtGui import QColor, QMouseEvent, QPainter, QPen
+from PyQt5.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+# napari-dark palette, matching the rest of the app's chrome
+BACKGROUND = QColor("#262930")
+PANEL = QColor("#1e2027")
+BORDER = QColor("#3d4251")
+ENABLED_FILL = QColor("#50a6ff")
+ENABLED_EDGE = QColor("#7cc0ff")
+DISABLED_EDGE = QColor("#4a4f5c")
+TEXT_MUTED = QColor("#868e93")
+
+MIN_CELL_PX = 10
+MAX_CELL_PX = 44
+GAP_PX = 2
+
+
+class TileMaskGrid(QWidget):
+    """The grid itself: rows x cols of togglable cells."""
+
+    changed = pyqtSignal()
+
+    def __init__(self, rows: int = 3, cols: int = 3, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self._rows = rows
+        self._cols = cols
+        self._mask = [[True] * cols for _ in range(rows)]
+        self._drag_value: Optional[bool] = None
+        self._hover: Optional[tuple] = None
+        self.setMouseTracking(True)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setMinimumSize(120, 120)
+
+    # ── state ────────────────────────────────────────────────────────────
+
+    @property
+    def mask(self) -> List[List[bool]]:
+        """A copy, so callers cannot mutate the widget's state behind its back."""
+        return [row[:] for row in self._mask]
+
+    @mask.setter
+    def mask(self, value: Optional[List[List[bool]]]) -> None:
+        if value is None:
+            self._mask = [[True] * self._cols for _ in range(self._rows)]
+        else:
+            self._mask = [
+                [bool(value[r][c]) if r < len(value) and c < len(value[r]) else True
+                 for c in range(self._cols)]
+                for r in range(self._rows)
+            ]
+        self.update()
+        self.changed.emit()
+
+    def set_grid_size(self, rows: int, cols: int) -> None:
+        """Resize the grid, keeping the state of tiles that still exist.
+
+        Nudging the row count should not silently discard a selection the user built
+        by hand; tiles that come into existence start enabled.
+        """
+        if (rows, cols) == (self._rows, self._cols):
+            return
+        old = self._mask
+        self._mask = [
+            [old[r][c] if r < len(old) and c < len(old[r]) else True
+             for c in range(cols)]
+            for r in range(rows)
+        ]
+        self._rows, self._cols = rows, cols
+        self.update()
+        self.changed.emit()
+
+    @property
+    def n_enabled(self) -> int:
+        return sum(v for row in self._mask for v in row)
+
+    def set_all(self, value: bool) -> None:
+        self._mask = [[value] * self._cols for _ in range(self._rows)]
+        self.update()
+        self.changed.emit()
+
+    def invert(self) -> None:
+        self._mask = [[not v for v in row] for row in self._mask]
+        self.update()
+        self.changed.emit()
+
+    # ── geometry ─────────────────────────────────────────────────────────
+
+    def _cell_size(self) -> int:
+        avail_w = (self.width() - GAP_PX * (self._cols + 1)) / max(1, self._cols)
+        avail_h = (self.height() - GAP_PX * (self._rows + 1)) / max(1, self._rows)
+        return int(max(MIN_CELL_PX, min(MAX_CELL_PX, min(avail_w, avail_h))))
+
+    def _origin(self, cell: int) -> tuple:
+        grid_w = self._cols * cell + GAP_PX * (self._cols + 1)
+        grid_h = self._rows * cell + GAP_PX * (self._rows + 1)
+        return (self.width() - grid_w) // 2, (self.height() - grid_h) // 2
+
+    def _cell_rect(self, row: int, col: int) -> QRect:
+        cell = self._cell_size()
+        ox, oy = self._origin(cell)
+        return QRect(
+            ox + GAP_PX + col * (cell + GAP_PX),
+            oy + GAP_PX + row * (cell + GAP_PX),
+            cell, cell,
+        )
+
+    def _cell_at(self, x: int, y: int) -> Optional[tuple]:
+        for r in range(self._rows):
+            for c in range(self._cols):
+                if self._cell_rect(r, c).contains(x, y):
+                    return r, c
+        return None
+
+    # ── painting ─────────────────────────────────────────────────────────
+
+    def paintEvent(self, event) -> None:
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing, False)
+        painter.fillRect(self.rect(), PANEL)
+
+        for r in range(self._rows):
+            for c in range(self._cols):
+                rect = self._cell_rect(r, c)
+                enabled = self._mask[r][c]
+                hovered = self._hover == (r, c)
+
+                if enabled:
+                    fill = ENABLED_FILL.lighter(115) if hovered else ENABLED_FILL
+                    painter.fillRect(rect, fill)
+                    painter.setPen(QPen(ENABLED_EDGE, 1))
+                else:
+                    if hovered:
+                        painter.fillRect(rect, BORDER)
+                    painter.setPen(QPen(DISABLED_EDGE, 1, Qt.DashLine))
+                painter.drawRect(rect)
+
+        painter.end()
+
+    # ── interaction ──────────────────────────────────────────────────────
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        cell = self._cell_at(event.x(), event.y())
+        if cell is None:
+            return
+        r, c = cell
+        # A drag paints whatever the first cell became, so a sweep sets a rectangle
+        # to one value instead of toggling each cell it crosses.
+        self._drag_value = not self._mask[r][c]
+        self._mask[r][c] = self._drag_value
+        self.update()
+        self.changed.emit()
+
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:
+        cell = self._cell_at(event.x(), event.y())
+        if cell != self._hover:
+            self._hover = cell
+            self.update()
+        if self._drag_value is None or cell is None:
+            return
+        r, c = cell
+        if self._mask[r][c] != self._drag_value:
+            self._mask[r][c] = self._drag_value
+            self.update()
+            self.changed.emit()
+
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
+        self._drag_value = None
+
+    def leaveEvent(self, event) -> None:
+        self._hover = None
+        self.update()
+
+
+class TileMaskWidget(QWidget):
+    """The grid plus its presets and a live count."""
+
+    changed = pyqtSignal()
+
+    def __init__(self, rows: int = 3, cols: int = 3, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.grid = TileMaskGrid(rows, cols)
+        self.grid.changed.connect(self._on_changed)
+        self.grid.setMinimumHeight(130)
+
+        # Row 0 is the top of the mosaic. Stated, because the whole reason the row
+        # direction is worth stating is that it was inverted once and nothing noticed.
+        hint = QLabel("Row 0 is the top of the mosaic · click or drag to toggle")
+        hint.setStyleSheet(f"color: {TEXT_MUTED.name()}; font-size: 10px;")
+        hint.setWordWrap(True)
+
+        self.label_count = QLabel()
+        self.label_count.setStyleSheet(f"color: {TEXT_MUTED.name()}; font-size: 11px;")
+
+        buttons = QHBoxLayout()
+        buttons.setContentsMargins(0, 0, 0, 0)
+        for text, slot in (
+            ("All", lambda: self.grid.set_all(True)),
+            ("None", lambda: self.grid.set_all(False)),
+            ("Invert", self.grid.invert),
+        ):
+            button = QPushButton(text)
+            button.setFixedHeight(22)
+            button.clicked.connect(slot)
+            buttons.addWidget(button)
+        buttons.addStretch()
+        buttons.addWidget(self.label_count)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+        layout.addWidget(hint)
+        layout.addWidget(self.grid, stretch=1)
+        layout.addLayout(buttons)
+
+        self._refresh_count()
+
+    def _on_changed(self) -> None:
+        self._refresh_count()
+        self.changed.emit()
+
+    def _refresh_count(self) -> None:
+        total = self.grid._rows * self.grid._cols
+        n = self.grid.n_enabled
+        self.label_count.setText(f"{n}/{total} tiles")
+
+    # ── public API ───────────────────────────────────────────────────────
+
+    def set_grid_size(self, rows: int, cols: int) -> None:
+        self.grid.set_grid_size(rows, cols)
+        self._refresh_count()
+
+    @property
+    def n_enabled(self) -> int:
+        return self.grid.n_enabled
+
+    @property
+    def mask(self) -> Optional[List[List[bool]]]:
+        """The mask, or None when every tile is enabled.
+
+        None rather than an all-True mask, because that is what
+        `OverviewParameters.tile_mask` means by "acquire everything" -- keeping the
+        two spellings distinct would leave two ways to say the same thing in saved
+        configurations.
+        """
+        mask = self.grid.mask
+        if all(all(row) for row in mask):
+            return None
+        return mask
+
+    @mask.setter
+    def mask(self, value: Optional[List[List[bool]]]) -> None:
+        self.grid.mask = value

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -217,13 +217,21 @@ class ValueComboBox(QComboBox):
             self.set_value(value)
 
     def _format_item(self, item) -> str:
-        """Render an item for display, using the unit/format_fn given at construction."""
+        """Render an item for display, using the unit/format_fn given at construction.
+
+        An explicit `format_fn` wins over every built-in rule. It used to be consulted
+        last, so a caller that supplied one still got the default rendering for numbers
+        and enums -- silently, since nothing errors when a label is merely wrong. Three
+        call sites were affected: two mode combo boxes showed `EACH_ROW` in place of
+        the label they asked for, and emission wavelengths rendered as `550.0` rather
+        than the `550 nm` their formatter produces.
+        """
+        if self._format_fn is not None:
+            return self._format_fn(item)
         if isinstance(item, (float, int)):
             return format_value(val=item, unit=self._unit, precision=self._decimals)
         if isinstance(item, Enum):
             return item.name
-        if self._format_fn is not None:
-            return self._format_fn(item)
         return str(item)
 
     def add_value(self, item) -> None:

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -474,6 +474,7 @@ class FMControlWidget(QWidget):
         progress_total = progress.get("total", None)
         channel_name = progress.get("channel", None)
         progress_state = progress.get("state", None)
+        progress_task = progress.get("task", None)
 
         if progress_state == "moving":
             self.progressText.setText("Moving stage...")
@@ -493,7 +494,14 @@ class FMControlWidget(QWidget):
             return
 
         # set progress message
-        if channel_name is not None:
+        if progress_task == "autofocus":
+            # Handled before the channel branch, not inside it: a sweep with no channel
+            # reports an empty name, which used to render "Acquiring  (1/1)..." and now
+            # would leave the previous message sitting there instead.
+            self.progressText.setText(
+                f"Focusing on {channel_name}..." if channel_name else "Focusing..."
+            )
+        elif channel_name:
             channel_index = progress.get("channel_index", 1)
             total_channels = progress.get("total_channels", 1)
             msg = f"Acquiring {channel_name} ({channel_index}/{total_channels})..."
@@ -507,9 +515,18 @@ class FMControlWidget(QWidget):
                 else 0
             )
             self.progressBar_current_acquisition.setValue(percentage_zlevel)
-            self.progressBar_current_acquisition.setFormat(
-                f"Z-level {progress_zlevels}/{progress_total_zlevels}"
-            )
+            if progress_task == "autofocus":
+                # A focus sweep steps the objective through a search range. Calling
+                # those positions "Z-level" names the z-stack, which is not running --
+                # and says which pass, so a coarse sweep followed by a fine one does
+                # not look like the same bar inexplicably starting over.
+                total_passes = progress.get("total_passes", 1)
+                which = (f" · pass {progress.get('pass_index', 1)}/{total_passes}"
+                         if total_passes > 1 else "")
+                label = f"Focus {progress_zlevels}/{progress_total_zlevels}{which}"
+            else:
+                label = f"Z-level {progress_zlevels}/{progress_total_zlevels}"
+            self.progressBar_current_acquisition.setFormat(label)
 
         # set total acquisition task progress
         if progress_current is not None and progress_total is not None:

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -1563,3 +1563,105 @@ def test_stitching_demands_to_be_told_where_the_mosaic_is():
     """
     with pytest.raises(TypeError, match="centre_position"):
         stitch_tileset([[Mock(spec=FluorescenceImage)]], 0.1)
+
+
+# ── live mosaic preview ──────────────────────────────────────────────────
+#
+# The runner owns the mosaic-so-far and publishes it with every tile, the way
+# `TiledAcquisitionRunner` does for the beam side, so a viewer stays stateless and
+# simply redisplays what it is handed. It is decimated because a full-resolution
+# multi-channel 16-bit mosaic is tens of megabytes per emission.
+
+
+def _preview_frames(microscope, rows, cols, mask=None, channels=1):
+    frames = []
+    microscope.fm.acquisition_progress_signal.connect(
+        lambda d: frames.append(d) if d.get("state") == "tile" else None
+    )
+    channel_settings = [
+        ChannelSettings(name=f"CH{i}", exposure_time=0.001) for i in range(channels)
+    ]
+    acquisition.FMTiledAcquisitionRunner(
+        microscope=microscope,
+        channel_settings=channel_settings,
+        overview_parameters=OverviewParameters(
+            rows=rows, cols=cols, overlap=0.1, tile_mask=mask
+        ),
+    ).run()
+    return frames
+
+
+def test_a_preview_frame_is_published_for_every_acquired_tile(fm_microscope):
+    mask = [[(i == 1 or j == 1) for j in range(3)] for i in range(3)]
+
+    frames = _preview_frames(fm_microscope, 3, 3, mask=mask)
+
+    assert len(frames) == 5  # the plus, not the grid
+    assert [f["current"] for f in frames] == [1, 2, 3, 4, 5]
+    assert {f["total"] for f in frames} == {5}
+
+
+def test_the_preview_fills_in_as_tiles_land(fm_microscope):
+    """The point of the preview: it has to actually change between tiles."""
+    frames = _preview_frames(fm_microscope, 2, 2)
+
+    coverage = [int((f["image"] > 0).sum()) for f in frames]
+    assert all(b > a for a, b in zip(coverage, coverage[1:])), coverage
+
+
+def test_each_preview_frame_is_its_own_array(fm_microscope):
+    """Emitting the live buffer would be a read/write race across threads.
+
+    The acquisition runs on a worker thread and the signal is queued, so the slot runs
+    on the GUI thread after the buffer has been painted into again. The beam tiler
+    emits its canvas directly; this one copies.
+    """
+    frames = _preview_frames(fm_microscope, 2, 2)
+
+    first = frames[0]["image"]
+    assert not any(first is f["image"] for f in frames[1:])
+    # and the first frame still shows one tile, not the finished mosaic
+    assert (first > 0).sum() < (frames[-1]["image"] > 0).sum()
+
+
+def test_the_preview_is_decimated(fm_microscope):
+    frames = _preview_frames(fm_microscope, 5, 5)
+
+    image = frames[-1]["image"]
+    assert max(image.shape[-2:]) <= acquisition.PREVIEW_MAX_DIMENSION
+    assert frames[-1]["preview_stride"] > 1
+
+
+def test_the_preview_leaves_skipped_tiles_blank(fm_microscope):
+    """Placement follows the same grid the stitch uses, holes included."""
+    mask = [[(i == 1 and j == 1) for j in range(3)] for i in range(3)]
+
+    frames = _preview_frames(fm_microscope, 3, 3, mask=mask)
+
+    image = frames[-1]["image"][0]
+    h, w = image.shape
+    assert not image[: h // 4, : w // 4].any(), "top-left corner was never acquired"
+    assert image[h // 3: 2 * h // 3, w // 3: 2 * w // 3].any(), "the centre tile was"
+
+
+def test_the_preview_has_one_plane_per_channel(fm_microscope):
+    frames = _preview_frames(fm_microscope, 2, 2, channels=2)
+
+    assert frames[-1]["image"].shape[0] == 2
+
+
+@pytest.mark.parametrize(
+    ("shape", "n_channels", "expected"),
+    [
+        ((8, 8), 1, (1, 8, 8)),            # plain 2D
+        ((3, 8, 8), 1, (1, 8, 8)),         # single channel z-stack -> projected
+        ((3, 8, 8), 3, (3, 8, 8)),         # three channels, no z -> kept
+        ((2, 4, 8, 8), 2, (2, 8, 8)),      # channels + z -> projected
+    ],
+    ids=["2d", "single-channel-zstack", "multi-channel", "channels-and-z"],
+)
+def test_tile_data_is_normalised_to_channel_planes(shape, n_channels, expected):
+    """The 3D case is ambiguous from the shape alone and is resolved by channel count."""
+    data = np.arange(np.prod(shape), dtype=np.uint16).reshape(shape)
+
+    assert acquisition._to_channel_planes(data, n_channels).shape == expected

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -1665,3 +1665,89 @@ def test_tile_data_is_normalised_to_channel_planes(shape, n_channels, expected):
     data = np.arange(np.prod(shape), dtype=np.uint16).reshape(shape)
 
     assert acquisition._to_channel_planes(data, n_channels).shape == expected
+
+
+# ── autofocus passes and progress ────────────────────────────────────────
+
+
+def _sweep_settings():
+    from fibsem.autofunctions.autofocus import FocusSweepPass
+
+    return AutoFocusSettings(passes=[
+        FocusSweepPass(search_range=20e-6, step_size=5e-6),   # coarse: 5 positions
+        FocusSweepPass(search_range=6e-6, step_size=1e-6),    # fine:   7 positions
+    ])
+
+
+def _autofocus_payloads(microscope, monkeypatch, mode):
+    _record_tile_positions(microscope, monkeypatch)
+    seen = []
+    microscope.fm.acquisition_progress_signal.connect(
+        lambda d: seen.append(d) if d.get("task") == "autofocus" else None
+    )
+    acquisition.FMTiledAcquisitionRunner(
+        microscope=microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1,
+                                               autofocus_mode=mode),
+        autofocus_settings=_sweep_settings(),
+    ).run()
+    return seen
+
+
+def test_focusing_once_runs_every_enabled_pass(fm_microscope, monkeypatch):
+    """Coarse then fine, which is the whole reason to configure more than one pass.
+
+    Every mode used to take the narrowest pass alone, so a configured coarse sweep was
+    silently ignored -- including in the one case it exists for.
+    """
+    seen = _autofocus_payloads(fm_microscope, monkeypatch, AutoFocusMode.ONCE)
+
+    passes = sorted({(d["pass_index"], d["total_passes"], d["total_zlevels"])
+                     for d in seen})
+    assert passes == [(1, 2, 5), (2, 2, 7)]
+
+
+def test_per_tile_focusing_runs_only_the_narrowest_pass(fm_microscope, monkeypatch):
+    """It refines an already-good position; a wide sweep at every tile would dominate."""
+    seen = _autofocus_payloads(fm_microscope, monkeypatch, AutoFocusMode.EACH_TILE)
+
+    assert sorted({(d["pass_index"], d["total_passes"]) for d in seen}) == [(1, 1)]
+    assert {d["total_zlevels"] for d in seen} == {7}          # the fine pass
+    assert len([d for d in seen if d["zlevel"] == 1]) == 4    # once per tile
+
+
+def test_the_sweep_reports_progress_per_position(fm_microscope, monkeypatch):
+    """Otherwise the bars freeze for the length of the sweep, which on per-tile
+    focusing is most of the run."""
+    seen = _autofocus_payloads(fm_microscope, monkeypatch, AutoFocusMode.ONCE)
+
+    assert [d["zlevel"] for d in seen if d["pass_index"] == 1] == [1, 2, 3, 4, 5]
+    assert all(d["channel"] == "DAPI" for d in seen)
+
+
+def test_a_cancelled_sweep_does_not_start_the_next_pass(fm_microscope, monkeypatch):
+    _record_tile_positions(fm_microscope, monkeypatch)
+    stop_event = threading.Event()
+    seen = []
+    fm_microscope.fm.acquisition_progress_signal.connect(
+        lambda d: seen.append(d) if d.get("task") == "autofocus" else None
+    )
+
+    def cancel_during_the_first_pass(*args, **kwargs):
+        stop_event.set()
+        return Mock(spec=FluorescenceImage)
+
+    monkeypatch.setattr(fm_microscope.fm, "acquire_image", cancel_during_the_first_pass)
+
+    with pytest.raises(OperationCancelledError):
+        acquisition.FMTiledAcquisitionRunner(
+            microscope=fm_microscope,
+            channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+            overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1,
+                                                   autofocus_mode=AutoFocusMode.ONCE),
+            autofocus_settings=_sweep_settings(),
+            stop_event=stop_event,
+        ).run()
+
+    assert {d["pass_index"] for d in seen} == {1}, "the second pass must not start"

--- a/tests/fm/test_structures.py
+++ b/tests/fm/test_structures.py
@@ -2013,21 +2013,42 @@ def test_estimate_tileset_acquisition_time_stage_movement_calculation():
         exposure_time=0.2,
     )
 
-    # 3x3 grid should have specific movement pattern
+    # One absolute move per tile after the first. The runner projects every tile
+    # position up front and drives straight to each one, so the separate row-advance
+    # and row-reset moves this used to count (6 + 2 + 2 = 10 for a 3x3) no longer
+    # happen -- the estimate described a sweep the acquisition stopped doing when
+    # tiles moved to absolute positions.
     result = estimate_tileset_acquisition_time(channel, grid_size=(3, 3))
 
-    # For 3x3 grid:
-    # - 2 horizontal moves per row × 3 rows = 6 horizontal moves
-    # - 2 vertical moves (to next row) = 2 moves
-    # - 2 row resets (return to first column) = 2 moves
-    # Total: 6 + 2 + 2 = 10 moves
-    expected_moves = 10
-    expected_stage_time = expected_moves * DEFAULT_STAGE_MOVE_TIME  # Using DEFAULT_STAGE_MOVE_TIME
-
+    expected_moves = 8  # 9 tiles, already at the first
     assert result["breakdown"]["stage_movement"]["total_moves"] == expected_moves
-    assert result["stage_movement_time"] == expected_stage_time
+    assert result["stage_movement_time"] == expected_moves * DEFAULT_STAGE_MOVE_TIME
 
-    # Note: Stage move time is now a constant in the timing module
+
+def test_estimate_tileset_acquisition_time_counts_only_enabled_tiles():
+    """A masked run visits its enabled tiles, and only the rows containing one.
+
+    Estimating the full grid reports roughly three times the real duration for a
+    typical sparse selection, and the estimate is what the confirmation dialog and
+    the remaining-time readout are built on.
+    """
+    channel = ChannelSettings(name="Cy5", exposure_time=0.2)
+    plus = [[(i == 2 or j == 2) for j in range(5)] for i in range(5)]
+
+    full = estimate_tileset_acquisition_time(channel, grid_size=(5, 5))
+    sparse = estimate_tileset_acquisition_time(channel, grid_size=(5, 5), tile_mask=plus)
+
+    assert full["tiles"] == 25
+    assert sparse["tiles"] == 9
+    assert sparse["total_time"] < full["total_time"]
+
+    # per-row autofocus fires once per row that actually gets visited
+    masked_rows = [[(i == 0) for j in range(4)] for i in range(4)]
+    one_row = estimate_tileset_acquisition_time(
+        channel, grid_size=(4, 4), autofocus_mode=AutoFocusMode.EACH_ROW,
+        tile_mask=masked_rows,
+    )
+    assert one_row["breakdown"]["autofocus"]["operations"] == 1
 
 
 def test_estimate_tileset_acquisition_time_comprehensive():

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1,0 +1,228 @@
+"""Headless tests for the FM overview acquisition UI.
+
+Covers the parts where being wrong is silent: what the tile mask means, whether the
+settings round-trip into the object the acquisition actually consumes, and whether a
+combo box shows the label it was given.
+
+Uses PyQt5 directly with the offscreen platform (no pytest-qt dependency).
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication, QLabel
+
+from fibsem.fm.structures import (
+    AutoFocusMode,
+    ChannelSettings,
+    OverviewParameters,
+    ZParameters,
+)
+from fibsem.structures import TileOrderStrategy
+from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
+    FMOverviewConfirmationDialog,
+    format_duration,
+)
+from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
+from fibsem.ui.fm.widgets.tile_mask_widget import TileMaskWidget
+from fibsem.ui.widgets.custom_widgets import ValueComboBox
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def plus_mask(n):
+    mid = n // 2
+    return [[(i == mid or j == mid) for j in range(n)] for i in range(n)]
+
+
+# ── tile mask ────────────────────────────────────────────────────────────
+
+
+def test_a_full_selection_is_reported_as_no_mask(qapp):
+    """None, not an all-True mask.
+
+    `OverviewParameters.tile_mask` already spells "acquire everything" as None, and
+    two spellings for one state means saved configurations disagree about which is
+    canonical.
+    """
+    widget = TileMaskWidget(rows=3, cols=3)
+
+    assert widget.mask is None
+    assert widget.n_enabled == 9
+
+
+def test_disabling_a_tile_produces_a_mask(qapp):
+    widget = TileMaskWidget(rows=3, cols=3)
+    widget.mask = plus_mask(3)
+
+    assert widget.mask == plus_mask(3)
+    assert widget.n_enabled == 5
+
+
+def test_resizing_the_grid_keeps_the_tiles_that_still_exist(qapp):
+    """Nudging the row count must not silently discard a hand-built selection."""
+    widget = TileMaskWidget(rows=3, cols=3)
+    widget.mask = plus_mask(3)
+
+    widget.set_grid_size(4, 4)
+
+    mask = widget.mask
+    assert mask[0][1] is True and mask[0][0] is False    # carried over
+    assert all(mask[3])                                   # new row starts enabled
+
+
+def test_all_none_and_invert(qapp):
+    widget = TileMaskWidget(rows=2, cols=2)
+
+    widget.grid.set_all(False)
+    assert widget.n_enabled == 0
+    widget.grid.invert()
+    assert widget.n_enabled == 4
+    widget.grid.set_all(True)
+    assert widget.mask is None
+
+
+def test_the_mask_property_hands_back_a_copy(qapp):
+    """Otherwise a caller can mutate the widget's state without it noticing."""
+    widget = TileMaskWidget(rows=2, cols=2)
+    widget.mask = [[True, False], [False, True]]
+
+    snapshot = widget.mask
+    snapshot[0][0] = False
+
+    assert widget.mask[0][0] is True
+
+
+# ── settings ─────────────────────────────────────────────────────────────
+
+
+def test_settings_round_trip_every_field(qapp):
+    """The widget's output is what the acquisition consumes, verbatim."""
+    widget = FMOverviewSettingsWidget(channel_names=["GFP", "RFP"])
+    parameters = OverviewParameters(
+        rows=5, cols=5, overlap=0.15, use_zstack=True,
+        autofocus_mode=AutoFocusMode.EACH_TILE,
+        tile_order=TileOrderStrategy.SERPENTINE,
+        tile_mask=plus_mask(5),
+    )
+
+    widget.parameters = parameters
+
+    assert widget.parameters == parameters
+
+
+def test_changing_the_grid_size_resizes_the_mask(qapp):
+    widget = FMOverviewSettingsWidget()
+    widget.spin_rows.setValue(4)
+    widget.spin_cols.setValue(6)
+
+    assert widget.parameters.rows == 4
+    assert widget.parameters.cols == 6
+    assert widget.tile_mask.grid._rows == 4
+    assert widget.tile_mask.grid._cols == 6
+
+
+def test_the_focus_channel_is_only_offered_when_focusing(qapp):
+    widget = FMOverviewSettingsWidget(channel_names=["GFP"])
+
+    widget.combo_autofocus_mode.set_value(AutoFocusMode.NONE)
+    assert not widget.combo_autofocus_channel.isEnabled()
+
+    widget.combo_autofocus_mode.set_value(AutoFocusMode.ONCE)
+    assert widget.combo_autofocus_channel.isEnabled()
+
+
+def test_a_spiral_with_per_row_focus_says_what_will_actually_happen(qapp):
+    """The runner promotes EACH_ROW to EACH_TILE for a spiral; don't make that a surprise."""
+    widget = FMOverviewSettingsWidget()
+    widget.combo_autofocus_mode.set_value(AutoFocusMode.EACH_ROW)
+    widget.combo_tile_order.set_value(TileOrderStrategy.SPIRAL)
+
+    assert "per-tile" in widget.label_summary.text()
+
+    widget.combo_tile_order.set_value(TileOrderStrategy.TYPEWRITER)
+    assert "per-tile" not in widget.label_summary.text()
+
+
+def test_the_summary_reports_the_selection_and_the_area(qapp):
+    widget = FMOverviewSettingsWidget()
+    widget.set_tile_fov(100e-6, 100e-6)
+    widget.parameters = OverviewParameters(rows=3, cols=3, overlap=0.0,
+                                           tile_mask=plus_mask(3))
+
+    text = widget.label_summary.text()
+    assert "5 of 9 tiles" in text
+    assert "300 × 300 µm" in text
+
+
+# ── confirmation dialog ──────────────────────────────────────────────────
+
+
+def _dialog(parameters, channels=None, zparams=None):
+    return FMOverviewConfirmationDialog(
+        parameters=parameters,
+        channel_settings=channels or [ChannelSettings(name="GFP", exposure_time=0.05)],
+        zparams=zparams,
+        tile_fov=(100e-6, 100e-6),
+    )
+
+
+def test_the_dialog_counts_acquired_and_skipped(qapp):
+    dialog = _dialog(OverviewParameters(rows=5, cols=5, tile_mask=plus_mask(5)))
+
+    shown = " ".join(label.text() for label in dialog.findChildren(QLabel))
+    assert "9 to acquire" in shown
+    assert "16 skipped" in shown
+
+
+def test_the_dialog_refuses_an_empty_selection(qapp):
+    """The runner rejects this too; saying so here beats failing after the dismiss."""
+    empty = [[False] * 3 for _ in range(3)]
+    dialog = _dialog(OverviewParameters(rows=3, cols=3, tile_mask=empty))
+
+    assert not dialog.button_start.isEnabled()
+
+
+def test_the_dialog_estimate_reflects_the_mask(qapp):
+    """A sparse run must not be quoted the duration of the full grid."""
+    full = _dialog(OverviewParameters(rows=5, cols=5))
+    sparse = _dialog(OverviewParameters(rows=5, cols=5, tile_mask=plus_mask(5)))
+
+    assert sparse._estimate()["total_time"] < full._estimate()["total_time"]
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [(0, "0s"), (45, "45s"), (60, "1m 00s"), (134, "2m 14s"), (3660, "1h 01m")],
+)
+def test_duration_formatting(seconds, expected):
+    assert format_duration(seconds) == expected
+
+
+# ── shared widget fix ────────────────────────────────────────────────────
+
+
+def test_an_explicit_format_fn_beats_the_built_in_rendering(qapp):
+    """It used to be consulted last, so enums and numbers ignored it silently.
+
+    Three call sites were affected: two mode combo boxes rendered `EACH_ROW` instead
+    of the label they asked for, and emission wavelengths rendered as a bare number
+    rather than the `550 nm` their formatter produces.
+    """
+    enums = ValueComboBox(items=list(AutoFocusMode), format_fn=lambda m: f"<{m.value}>")
+    assert enums.itemText(0) == "<none>"
+
+    numbers = ValueComboBox(items=[550.0, 600.0], format_fn=lambda w: f"{int(w)} nm")
+    assert numbers.itemText(0) == "550 nm"
+
+
+def test_without_a_format_fn_the_built_in_rendering_still_applies(qapp):
+    assert ValueComboBox(items=list(AutoFocusMode)).itemText(0) == "NONE"

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -106,7 +106,7 @@ def test_the_mask_property_hands_back_a_copy(qapp):
 
 def test_settings_round_trip_every_field(qapp):
     """The widget's output is what the acquisition consumes, verbatim."""
-    widget = FMOverviewSettingsWidget(channel_names=["GFP", "RFP"])
+    widget = FMOverviewSettingsWidget(channel_settings=[ChannelSettings(name="GFP"), ChannelSettings(name="RFP")])
     parameters = OverviewParameters(
         rows=5, cols=5, overlap=0.15, use_zstack=True,
         autofocus_mode=AutoFocusMode.EACH_TILE,
@@ -130,14 +130,17 @@ def test_changing_the_grid_size_resizes_the_mask(qapp):
     assert widget.tile_mask.grid._cols == 6
 
 
-def test_the_focus_channel_is_only_offered_when_focusing(qapp):
-    widget = FMOverviewSettingsWidget(channel_names=["GFP"])
+def test_the_sweep_controls_are_only_live_when_focusing(qapp):
+    """Mode is the single switch: it greys the sweep out *and* decides what is returned."""
+    widget = FMOverviewSettingsWidget(channel_settings=[ChannelSettings(name="GFP")])
 
     widget.combo_autofocus_mode.set_value(AutoFocusMode.NONE)
-    assert not widget.combo_autofocus_channel.isEnabled()
+    assert not widget.autofocus_widget.isEnabled()
+    assert widget.autofocus_settings is None
 
     widget.combo_autofocus_mode.set_value(AutoFocusMode.ONCE)
-    assert widget.combo_autofocus_channel.isEnabled()
+    assert widget.autofocus_widget.isEnabled()
+    assert widget.autofocus_settings is not None
 
 
 def test_a_spiral_with_per_row_focus_says_what_will_actually_happen(qapp):
@@ -152,15 +155,50 @@ def test_a_spiral_with_per_row_focus_says_what_will_actually_happen(qapp):
     assert "per-tile" not in widget.label_summary.text()
 
 
-def test_the_summary_reports_the_selection_and_the_area(qapp):
+def test_the_summary_reports_the_selection(qapp):
+    widget = FMOverviewSettingsWidget()
+    widget.parameters = OverviewParameters(rows=3, cols=3, tile_mask=plus_mask(3))
+
+    assert "5 of 9 tiles" in widget.label_summary.text()
+
+
+@pytest.mark.parametrize(
+    ("rows", "cols", "overlap", "expected"),
+    [
+        (3, 3, 0.0, "300 × 300 µm"),
+        (3, 3, 0.1, "280 × 280 µm"),   # (n-1) steps of 90 µm, plus one whole tile
+        (2, 5, 0.0, "500 × 200 µm"),   # width from columns, height from rows
+        (1, 1, 0.5, "100 × 100 µm"),   # a single tile is its own field of view
+    ],
+)
+def test_the_grid_reports_the_total_field_of_view(qapp, rows, cols, overlap, expected):
+    """Area covered comes from rows/cols/overlap alone -- a mask does not shrink it,
+    because skipped tiles keep their place in the grid."""
     widget = FMOverviewSettingsWidget()
     widget.set_tile_fov(100e-6, 100e-6)
-    widget.parameters = OverviewParameters(rows=3, cols=3, overlap=0.0,
-                                           tile_mask=plus_mask(3))
 
-    text = widget.label_summary.text()
-    assert "5 of 9 tiles" in text
-    assert "300 × 300 µm" in text
+    widget.parameters = OverviewParameters(rows=rows, cols=cols, overlap=overlap)
+    assert widget.label_total_fov.text() == expected
+
+    widget.tile_mask.grid.set_all(False)
+    assert widget.label_total_fov.text() == expected
+
+
+def test_the_total_field_of_view_is_unknown_until_the_camera_is_known(qapp):
+    assert FMOverviewSettingsWidget().label_total_fov.text() == "—"
+
+
+def test_focusing_with_every_pass_disabled_is_called_out(qapp):
+    """Two controls that each look right, contradicting each other: the run would
+    schedule focusing and then sweep nothing."""
+    widget = FMOverviewSettingsWidget(channel_settings=[ChannelSettings(name="GFP")])
+    widget.combo_autofocus_mode.set_value(AutoFocusMode.ONCE)
+
+    for sweep_pass in widget.autofocus_widget.autofocus_settings.passes:
+        sweep_pass.enabled = False
+    widget._refresh_derived()
+
+    assert "every sweep pass is disabled" in widget.label_summary.text()
 
 
 # ── confirmation dialog ──────────────────────────────────────────────────

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -28,8 +28,10 @@ from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     format_duration,
 )
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
+from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget, progress_slot
 from fibsem.ui.fm.widgets.tile_mask_widget import TileMaskWidget
 from fibsem.ui.widgets.custom_widgets import ValueComboBox
+from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
 
 
 @pytest.fixture(scope="module")
@@ -264,3 +266,183 @@ def test_an_explicit_format_fn_beats_the_built_in_rendering(qapp):
 
 def test_without_a_format_fn_the_built_in_rendering_still_applies(qapp):
     assert ValueComboBox(items=list(AutoFocusMode)).itemText(0) == "NONE"
+
+
+# ── progress bars ────────────────────────────────────────────────────────
+#
+# One signal carries both scales: the tileset runner's tile counter, and -- from
+# inside each tile -- `acquire_z_stack` / `acquire_channels`. `task` decides which
+# bar a payload drives, so a payload must never move both.
+
+
+class _Router:
+    """The routing half of FMOverviewWidget, without needing a microscope."""
+
+    def __init__(self):
+        self.progress_tiles = FibsemProgressWidget()
+        self.progress_tile_detail = FibsemProgressWidget()
+        self.status = QLabel()
+
+    _apply_progress = FMOverviewWidget._apply_progress
+    _apply_tile_progress = FMOverviewWidget._apply_tile_progress
+    _tile_detail_update = FMOverviewWidget._tile_detail_update
+
+    def _show_preview(self, payload):
+        pass
+
+    def _finish(self, state, error):
+        self.finished = (state, error)
+
+
+def _bar(widget):
+    return widget._bar
+
+
+def test_a_tileset_payload_moves_only_the_tile_bar(qapp):
+    router = _Router()
+
+    router._apply_progress({
+        "state": "acquiring", "task": "tileset", "current": 4, "total": 9,
+    })
+
+    # value/maximum directly, not a percentage -- the widget counts items.
+    assert (_bar(router.progress_tiles).value(),
+            _bar(router.progress_tiles).maximum()) == (4, 9)
+    assert not router.progress_tile_detail.isVisible()
+
+
+def test_a_zstack_payload_moves_only_the_detail_bar(qapp):
+    router = _Router()
+
+    router._apply_progress({
+        "state": "acquiring", "task": "z-stack", "channel": "GFP",
+        "zlevel": 7, "total_zlevels": 21,
+    })
+
+    assert "z-stack" in _bar(router.progress_tile_detail).format()
+    assert (_bar(router.progress_tile_detail).value(),
+            _bar(router.progress_tile_detail).maximum()) == (7, 21)
+    assert not router.progress_tiles.isVisible()
+
+
+def test_a_channels_payload_drives_the_detail_bar_too(qapp):
+    """Without this the second bar is dead on every run that is not z-stacked."""
+    router = _Router()
+
+    router._apply_progress({
+        "state": "acquiring", "task": "channels", "channel": "RFP",
+        "channel_index": 2, "total_channels": 3,
+    })
+
+    assert "RFP" in _bar(router.progress_tile_detail).format()
+    assert (_bar(router.progress_tile_detail).value(),
+            _bar(router.progress_tile_detail).maximum()) == (2, 3)
+
+
+def test_a_completed_tile_leaves_the_detail_bar_alone(qapp):
+    """It used to reset here, so the bar vanished and returned at every tile boundary
+    -- a flicker for the length of the run. The next tile overwrites it a moment later
+    anyway, so the stale count is never seen."""
+    router = _Router()
+    router._apply_progress({
+        "state": "acquiring", "task": "z-stack", "channel": "GFP",
+        "zlevel": 21, "total_zlevels": 21,
+    })
+
+    router._apply_progress({
+        "state": "tile", "task": "tileset", "current": 1, "total": 9,
+    })
+
+    assert router.progress_tile_detail.isVisible()
+
+
+def test_an_unknown_task_moves_nothing(qapp):
+    router = _Router()
+
+    router._apply_progress({"state": "acquiring", "task": "something-else"})
+
+    assert not router.progress_tiles.isVisible()
+    assert not router.progress_tile_detail.isVisible()
+
+
+def test_the_estimate_is_shown_when_the_payload_carries_one(qapp):
+    router = _Router()
+
+    router._apply_progress({
+        "state": "acquiring", "task": "tileset", "current": 2, "total": 9,
+        "estimated_remaining_time": 134.0, "estimated_total_time": 180.0,
+    })
+
+    assert "remaining" in _bar(router.progress_tiles).format()
+
+
+def test_a_stage_move_does_not_fill_the_bar(qapp):
+    """`indeterminate` paints a *full* bar, so every move read as "finished".
+
+    The count stays put -- it is still true between tiles -- and the transient state
+    goes to the status label.
+    """
+    router = _Router()
+    router._apply_progress({
+        "state": "acquiring", "task": "tileset", "current": 3, "total": 9,
+    })
+
+    router._apply_progress({"state": "moving", "task": "tileset"})
+
+    assert (_bar(router.progress_tiles).value(),
+            _bar(router.progress_tiles).maximum()) == (3, 9)
+    assert router.status.text() == "Moving stage…"
+
+
+# ── layout stability ─────────────────────────────────────────────────────
+
+
+def test_a_reset_bar_keeps_its_space(qapp):
+    """The bars must not jitter each other.
+
+    `FibsemProgressWidget.reset()` hides itself, so in a plain row the neighbouring
+    bar would shift every time a tile finished. Each sits in a fixed slot instead.
+    """
+    from PyQt5.QtWidgets import QHBoxLayout, QWidget
+
+    left, right = FibsemProgressWidget(), FibsemProgressWidget()
+    row = QWidget()
+    layout = QHBoxLayout(row)
+    layout.addWidget(progress_slot(left))
+    layout.addWidget(progress_slot(right))
+    row.resize(600, 40)
+    row.show()
+    qapp.processEvents()
+
+    left.update_progress(ProgressUpdate.numeric(1, 2, "working"))
+    right.update_progress(ProgressUpdate.numeric(1, 2, "working"))
+    qapp.processEvents()
+    before = left.parentWidget().geometry()
+
+    right.reset()
+    qapp.processEvents()
+
+    assert left.parentWidget().geometry() == before
+
+
+def test_the_bar_text_is_smaller_than_the_default(qapp):
+    """Pinned because `setFont` on the holder silently does not reach the bar, so the
+    obvious way to do this looks right and changes nothing."""
+    from PyQt5.QtGui import QFontMetrics
+
+    plain, shrunk = FibsemProgressWidget(), FibsemProgressWidget()
+    slot = progress_slot(shrunk)  # noqa: F841 - keeps the holder alive
+
+    sample = "Tiles — 4/9 · 74s remaining"
+    assert (QFontMetrics(shrunk._bar.font()).width(sample)
+            < QFontMetrics(plain._bar.font()).width(sample))
+
+
+def test_shrinking_the_text_keeps_the_failed_colouring(qapp):
+    """The chunk stylesheet is what distinguishes a failed run from a finished one."""
+    progress = FibsemProgressWidget()
+    slot = progress_slot(progress)  # noqa: F841
+
+    progress.update_progress(ProgressUpdate.failed("nope"))
+
+    assert "#99121F" in progress._bar.styleSheet()

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -157,11 +157,14 @@ def test_a_spiral_with_per_row_focus_says_what_will_actually_happen(qapp):
     assert "per-tile" not in widget.label_summary.text()
 
 
-def test_the_summary_reports_the_selection(qapp):
+def test_the_selection_is_counted_once(qapp):
+    """The count belongs to the mask panel. It used to be repeated in the summary line
+    below, where a stale second copy would read as a different number."""
     widget = FMOverviewSettingsWidget()
     widget.parameters = OverviewParameters(rows=3, cols=3, tile_mask=plus_mask(3))
 
-    assert "5 of 9 tiles" in widget.label_summary.text()
+    assert "5/9 tiles" in widget.tile_mask.label_count.text()
+    assert "tiles" not in widget.label_summary.text()
 
 
 @pytest.mark.parametrize(
@@ -446,3 +449,86 @@ def test_shrinking_the_text_keeps_the_failed_colouring(qapp):
     progress.update_progress(ProgressUpdate.failed("nope"))
 
     assert "#99121F" in progress._bar.styleSheet()
+
+
+# ── channel detail form ──────────────────────────────────────────────────
+
+
+def test_channel_detail_fields_fill_the_panel(qapp):
+    """macOS styles QFormLayout its own way -- fields frozen at their size hint, so
+    each row ends up a different width and the block floats in the middle of the
+    panel. Pinned behaviourally because the properties that fix it are easy to set
+    and easy to set uselessly: this form previously called `setLabelAlignment` with
+    its own current value, and `ExpandingFieldsGrow` does nothing here because none
+    of these controls carry an Expanding policy."""
+    from PyQt5.QtCore import Qt
+
+    from fibsem.fm.microscope import FluorescenceMicroscope
+    from fibsem.ui.fm.widgets.channel_settings_widget import ChannelSettingsWidget
+
+    widget = ChannelSettingsWidget(fm=FluorescenceMicroscope())
+    widget.set_channel(ChannelSettings(name="Channel-01"))
+    widget.resize(440, widget.sizeHint().height())
+    widget.show()
+    qapp.processEvents()
+
+    fields = (widget.excitation_combo, widget.emission_combo,
+              widget.exposure_spin, widget.power_spin, widget.gain_spin)
+    widths = {f.width() for f in fields}
+
+    assert len(widths) == 1, f"ragged field widths: {[f.width() for f in fields]}"
+    assert all(f.width() > f.sizeHint().width() for f in fields)
+
+    form = widget.excitation_combo.parent().layout()
+    assert form.labelAlignment() & Qt.AlignLeft
+    assert form.formAlignment() & Qt.AlignLeft
+
+
+def test_channel_rows_do_not_overflow_a_narrow_panel(qapp):
+    """A list item with a zero-width size hint takes the row widget's preferred width,
+    which QLineEdit inflates ~190px beyond what the row needs and which does not track
+    the host. In the overview's controls column that pushed the excitation and emission
+    combos past the right edge -- and the column keeps its horizontal scrollbar off, so
+    they were unreachable rather than merely cramped."""
+    from fibsem.fm.microscope import FluorescenceMicroscope
+    from fibsem.ui.fm.widgets.fm_multi_channel_widget import (
+        FluorescenceMultiChannelWidget,
+    )
+
+    widget = FluorescenceMultiChannelWidget(
+        fm=FluorescenceMicroscope(),
+        channel_settings=[ChannelSettings(name="Channel-01")],
+    )
+    widget.show()
+
+    for width in (460, 900):
+        widget.resize(width, 300)
+        qapp.processEvents()
+        qapp.processEvents()
+
+        inner = widget._list._list
+        row = inner.itemWidget(inner.item(0))
+
+        assert row.width() <= inner.viewport().width(), (
+            f"row overflows at host width {width}: "
+            f"{row.width()} > {inner.viewport().width()}"
+        )
+
+
+def test_collapsed_panels_do_not_stretch(qapp):
+    """A panel added with a stretch factor keeps claiming vertical space after it is
+    collapsed, so folding it leaves a tall empty box with the title floating in the
+    middle. Every panel must fold to the same header-only height."""
+    widget = FMOverviewSettingsWidget()
+    widget.show()
+    widget.resize(500, 1200)  # far taller than the folded panels need
+
+    panels = (widget.focus_panel, widget.zstack_panel,
+              widget.grid_panel, widget.mask_panel)
+    for panel in panels:
+        panel.collapse()
+    qapp.processEvents()
+    qapp.processEvents()
+
+    heights = {p.height() for p in panels}
+    assert len(heights) == 1, f"collapsed panels differ in height: {heights}"


### PR DESCRIPTION
A standalone widget that configures, runs and displays a fluorescence overview, embeddable as a tab. **Canvas on the left, controls on the right, actions along the bottom.**

## Try it

```bash
python -m fibsem.ui.fm.overview_app
```

Opens against the simulator posed as a **compustage at t = −180°** — the geometry the tile projection is built around, rather than whatever the ambient configuration happens to be. `--no-compustage` poses it as an offset mount instead; `--manufacturer`/`--ip` connect to real hardware.

## Live preview

The runner now owns a mosaic-so-far and publishes it with every tile, keyed `image` — which is what `TiledAcquisitionRunner` already does for the beam side and what `FibsemMinimapWidget` already reads. The viewer stays stateless: it redisplays what it's handed rather than accumulating tiles itself, which is also what makes it correct if a frame is dropped.

Two deliberate departures from the beam version:

- **Decimated to a 2048px long edge.** A full-resolution multi-channel 16-bit mosaic is ~88 MB pushed through a signal *per tile*; the preview is ~10 MB. The final stitch is untouched and full resolution.
- **A copy is emitted, not the live buffer.** The acquisition runs on a worker thread, so the slot runs later on the GUI thread, by which time the shared array has been painted into again.

## Settings

`FMOverviewSettingsWidget` replaces `OverviewParametersWidget` for this UI. The old one type-hinted its parent as `FMAcquisitionWidget` and reached into it for channel names, so it couldn't be used anywhere else — and it predated sparse tilesets and tile ordering, so **`tile_order` and `tile_mask` could not be set from the UI at all**.

`TileMaskWidget` is the mask affordance: click or drag over a grid of tiles. Drag paints whatever the first cell became, so a sweep sets a region to one value rather than toggling each cell it crosses. Resizing the grid keeps the tiles that still exist, so nudging the row count doesn't discard a hand-built selection. A full selection reports `None` rather than an all-True mask, matching what `OverviewParameters.tile_mask` already means.

## Confirmation dialog

New, in house style: title, muted meta line, count chips, and a duration broken down into imaging / moving / focusing. It says up front when a spiral will promote per-row focus to per-tile, rather than leaving that to be found in the log afterwards, and refuses an empty selection instead of failing after the dialog is dismissed.

## Fixes found while building this

**The time estimate counted `rows × cols`**, so a sparse run was quoted roughly three times its real duration — and the estimate is what the dialog and the remaining-time readout are built on. It now takes the mask, counting enabled tiles and only the rows that contain one.

**Its stage-movement model was stale**: it counted row advances and row resets for a rectangular sweep, which stopped happening when tiles moved to absolute positions. Now one move per tile.

**`ValueComboBox` ignored an explicit `format_fn`** for enums and numbers, consulting it only after its built-in rules — silently, since nothing errors when a label is merely wrong. Three existing call sites were affected: two mode combo boxes showed `EACH_ROW` instead of the label they asked for, and emission wavelengths rendered as `550.0` rather than the `550 nm` their formatter produces.

**A cross-thread GUI access.** `acquisition_progress_signal` is a psygnal, which calls its callbacks synchronously on whichever thread emitted — the worker. Touching widgets from there produced `QObject::setParent: Cannot set parent, new parent is in a different thread`. Progress is now re-emitted as a Qt signal so it's queued onto the GUI thread.

## Verified

Driven through a full acquisition offscreen: a plus-shaped mask over a 5×5, serpentine, two channels. 9 preview frames rendered as tiles landed, `(2, 1, 4712, 4712)` mosaic at the end, both channels composited on the canvas with the scalebar wired, skipped regions black, controls re-enabled.

`1714 passed, 24 skipped`, plus 20 new headless UI tests covering mask semantics, settings round-trip, dialog counts, and the combo-box formatting fix.
