### PR TITLE
Bump the qtawesome floor to 1.4.0 (FIB-304)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ ui = [
     "pyqt5>=5.15.9",
     "pyqt5-qt5 == 5.15.2 ; platform_system == 'Windows'",
     "matplotlib_scalebar>=0.8.1",
-    "qtawesome>=1.3.0", # bundled Material Design Icons font (offline icon rendering); >=1.3.0 for Spin.start/stop
+    "qtawesome>=1.4.0", # bundled Material Design Icons font (offline icon rendering); >=1.4.0 guards Spin.start/stop before first paint
 ]
 odemis = ["pylibtiff", "shapely"]
 


### PR DESCRIPTION
Follow-up to #183, which fixes the Scios startup crash by guarding one call site. This does it upstream instead.

## Why

`SpinnerLabel.start()`/`stop()` call `qta.Spin.start()`/`stop()`, which on qtawesome 1.3.x index `self.info[self.parent_widget]` unconditionally. The widget is only registered there by its first paint, so calling either beforehand raises `KeyError` — the traceback in #183 that blocks startup on a TFS Scios.

qtawesome 1.4.0 added the `if self.parent_widget in self.info` guard to **both** methods (spyder-ide/qtawesome#277). Verified against an installed 1.4.2: the guard is present in `start()` and `stop()`.

Bumping the floor fixes `start()` too — #183's guard only covers `stop()`, and `start()` has the identical bug on the first acquisition. With this pin, the call-site guards in #183 are redundant.

## Compatibility

qtawesome 1.4.x is `Requires-Python: >=3.7`, so it stays inside this project's `requires-python = ">=3.8"`. 1.4.0/1.4.1/1.4.2 are all on PyPI.

## Caveat

The pin only reaches a machine that actually re-resolves dependencies. A frozen or source checkout — including the Scios that hit this — may still need a one-off:

    pip install -U qtawesome

Tracked in [FIB-304](https://linear.app/fibsemos/issue/FIB-304/spinner-crash-on-qtawesome-13x-guard-startstop-before-first-paint-or).