### PR TITLE
Project stage positions onto FM images, from the image alone (FIB-393)

### DIFF
--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -938,6 +938,13 @@ class FluorescenceMicroscope(ABC):
             objective_numerical_aperture=self.objective.numerical_aperture,
         )
 
+        # Stamp the geometry the image is being captured under, so a stage position can
+        # be projected onto it later without assuming the microscope still matches --
+        # by then the stage has usually moved, and the display transform may have been
+        # flipped. Needs the parent for the stage and system settings, so an FM with no
+        # parent records nothing rather than recording a default that looks valid.
+        geometry = self.parent.fm_image_geometry() if self.parent else None
+
         # Create complete image metadata
         return FluorescenceImageMetadata(
             acquisition_date=datetime.now().isoformat(),
@@ -945,6 +952,7 @@ class FluorescenceMicroscope(ABC):
             pixel_size_y=self.camera.pixel_size[1],
             resolution=(self.camera.resolution[0], self.camera.resolution[1]),
             stage_position=stage_position,
+            geometry=geometry,
             channels=[channel_metadata],
         )
 

--- a/fibsem/fm/reprojection.py
+++ b/fibsem/fm/reprojection.py
@@ -1,0 +1,356 @@
+"""Projecting stage positions onto fluorescence images.
+
+The fluorescence counterpart of :mod:`fibsem.imaging.tiling.reprojection`, and the
+inverse of :meth:`FibsemMicroscope.project_fm_stable_move`: that one asks where a click
+would send the stage, these ask where the stage already is on screen. Both run the same
+projection, so a marker drawn here lands where clicking there would take you.
+
+Microscope-free by design. Everything the projection reads comes from the image's own
+:class:`FMImageGeometry` and stage position, so a saved overview reprojects correctly
+even when the stage has since moved or the display transform has since been flipped --
+which is precisely when someone is looking at a saved overview. Reading any of it from
+a live microscope would make the result depend on state the image does not describe.
+
+Images written before the geometry was recorded carry ``geometry=None``. Those raise
+rather than falling back to live state or to a default pose: a marker drawn in the wrong
+place is indistinguishable on screen from one drawn in the right place, so guessing is
+worse than refusing.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING, List, Tuple
+
+import numpy as np
+
+from fibsem.fm.structures import FMImageGeometry
+from fibsem.movement import rotation_angle_is_smaller
+from fibsem.structures import FibsemStagePosition, Point
+
+if TYPE_CHECKING:  # pragma: no cover - annotation only
+    from fibsem.fm.structures import FluorescenceImage
+
+
+def _projection_terms(
+    geometry: FMImageGeometry,
+    stage_rotation: float,
+    stage_tilt: float,
+) -> Tuple[float, float, float]:
+    """The sign and angle terms both directions of the projection share.
+
+    Factored out rather than written twice: the forward and the inverse differ only in
+    the arithmetic that follows, and a sign convention that drifts between them would
+    make a click land somewhere other than where the marker was drawn -- while each
+    direction on its own still looked self-consistent.
+
+    Returns:
+        (compustage_sign, corrected_pretilt_angle, stage_tilt), where `stage_tilt` has
+        the compustage half-turn already folded in.
+    """
+    sem_column_tilt = np.deg2rad(geometry.column_tilt)
+    stage_pretilt = np.deg2rad(geometry.shuttle_pre_tilt)
+    rotation_flat_to_eb = np.deg2rad(geometry.rotation_reference) % (2 * np.pi)
+    rotation_flat_to_ion = np.deg2rad(geometry.rotation_180) % (2 * np.pi)
+
+    stage_rotation = stage_rotation % (2 * np.pi)
+
+    # The forward flips expected_y once for a compustage and a second time at the FIB
+    # orientation, so the two cancel there. The orientation is derived from the pose
+    # rather than from a live microscope's `get_stage_orientation`.
+    #
+    # The rotation test is not redundant with the tilt test: a compustage cannot
+    # rotate, so `get_stage_orientation` reports FIB only at the reference rotation.
+    # Keying on tilt alone would call an unreachable pose FIB and flip the sign
+    # against the live path -- which is a disagreement no physical run can surface,
+    # and so exactly the kind that survives.
+    compustage_sign = 1.0
+    is_fib_orientation = False
+    if geometry.is_compustage:
+        fib_orientation_tilt = np.deg2rad(
+            geometry.fib_column_tilt - geometry.shuttle_pre_tilt - 180
+        )
+        is_fib_orientation = bool(
+            np.isclose(stage_tilt, fib_orientation_tilt, atol=0.1)
+            and rotation_angle_is_smaller(stage_rotation, rotation_flat_to_eb, atol=5)
+        )
+        compustage_sign = 1.0 if is_fib_orientation else -1.0
+        stage_tilt = stage_tilt + np.pi
+
+    pretilt_sign = 1.0
+    if rotation_angle_is_smaller(stage_rotation, rotation_flat_to_eb, atol=5):
+        pretilt_sign = 1.0
+    if rotation_angle_is_smaller(stage_rotation, rotation_flat_to_ion, atol=5):
+        pretilt_sign = -1.0
+    if is_fib_orientation:
+        pretilt_sign = -1.0
+
+    corrected_pretilt_angle = pretilt_sign * (stage_pretilt + sem_column_tilt)
+
+    return compustage_sign, corrected_pretilt_angle, stage_tilt
+
+
+def view_corrected_stage_movement(
+    expected_y: float,
+    geometry: FMImageGeometry,
+    stage_rotation: float,
+    stage_tilt: float,
+) -> Tuple[float, float]:
+    """Split an in-image y-displacement across the stage y- and z-axes.
+
+    The microscope-free form of
+    :meth:`FibsemMicroscope._view_corrected_stage_movement` at the camera's view tilt.
+
+    Args:
+        expected_y: displacement along the image y-axis, in metres.
+        geometry: the geometry the image was captured under.
+        stage_rotation: stage rotation at acquisition, in radians.
+        stage_tilt: stage tilt at acquisition, in radians.
+
+    Returns:
+        (dy, dz) stage movement, in metres.
+    """
+    compustage_sign, corrected_pretilt_angle, stage_tilt = _projection_terms(
+        geometry, stage_rotation, stage_tilt
+    )
+
+    if geometry.is_compustage:
+        expected_y = expected_y * compustage_sign
+
+    perspective_tilt_adjustment = (
+        -corrected_pretilt_angle - np.deg2rad(geometry.camera_tilt)
+    )
+    y_sample_move = expected_y / np.cos(stage_tilt + perspective_tilt_adjustment)
+
+    return (
+        float(y_sample_move * np.cos(corrected_pretilt_angle)),
+        float(-y_sample_move * np.sin(corrected_pretilt_angle)),
+    )
+
+
+def inverse_view_corrected_dy(
+    dy: float,
+    dz: float,
+    geometry: FMImageGeometry,
+    stage_rotation: float,
+    stage_tilt: float,
+) -> float:
+    """Recover an in-image y-displacement from a y/z stage movement.
+
+    The microscope-free form of
+    :meth:`FibsemMicroscope._inverse_view_corrected_stage_movement`, parameterised by
+    the geometry rather than reading it off a live instrument. The two are held
+    together by a parity test across the full pose matrix, because a projection that
+    silently disagrees with the one used to move the stage puts every overlay in the
+    wrong place.
+
+    Args:
+        dy: stage y movement, in metres.
+        dz: stage z movement, in metres.
+        geometry: the geometry the image was captured under.
+        stage_rotation: stage rotation at acquisition, in radians.
+        stage_tilt: stage tilt at acquisition, in radians.
+
+    Returns:
+        The in-image y-displacement that would produce that stage movement, in metres.
+    """
+    compustage_sign, corrected_pretilt_angle, stage_tilt = _projection_terms(
+        geometry, stage_rotation, stage_tilt
+    )
+
+    perspective_tilt_adjustment = (
+        -corrected_pretilt_angle - np.deg2rad(geometry.camera_tilt)
+    )
+
+    # Undo y_move = y_sample_move * cos(a) and z_move = -y_sample_move * sin(a),
+    # taking whichever component is larger so the division stays conditioned.
+    cos_pretilt = np.cos(corrected_pretilt_angle)
+    sin_pretilt = np.sin(corrected_pretilt_angle)
+    if abs(cos_pretilt) > abs(sin_pretilt):
+        y_sample_move = dy / cos_pretilt
+    else:
+        y_sample_move = -dz / sin_pretilt
+
+    expected_y = y_sample_move * np.cos(stage_tilt + perspective_tilt_adjustment)
+
+    if geometry.is_compustage:
+        expected_y *= compustage_sign
+
+    return float(expected_y)
+
+
+def project_stage_position(
+    position: FibsemStagePosition,
+    base_position: FibsemStagePosition,
+    pixel_size: float,
+    image_shape: Tuple[int, int],
+    geometry: FMImageGeometry,
+) -> Point:
+    """Where a stage position falls in a displayed FM image, in pixels.
+
+    Args:
+        position: the stage position to locate.
+        base_position: the stage position the image was acquired at.
+        pixel_size: image pixel size, in metres.
+        image_shape: image shape as (height, width), in pixels.
+        geometry: the geometry the image was captured under.
+
+    Returns:
+        Point: pixel coordinates in the displayed image. Deliberately not clamped --
+        a position outside the field of view returns coordinates outside the image
+        bounds, which is what lets a caller draw a tile grid larger than the image.
+    """
+    delta = position - base_position
+
+    dy = inverse_view_corrected_dy(
+        dy=delta.y,
+        dz=delta.z,
+        geometry=geometry,
+        stage_rotation=base_position.r or 0.0,
+        stage_tilt=base_position.t or 0.0,
+    )
+    # The transform is restricted to flips, making it its own inverse, so the one
+    # mapping serves both directions -- see `CameraImageTransform`.
+    dx, dy = geometry.transform.apply_to_delta(delta.x, dy)
+
+    # Image y grows downward while the projected displacement grows upward.
+    return Point(
+        x=image_shape[1] / 2 + dx / pixel_size,
+        y=image_shape[0] / 2 - dy / pixel_size,
+    )
+
+
+def project_image_point(
+    point: Point,
+    base_position: FibsemStagePosition,
+    pixel_size: float,
+    image_shape: Tuple[int, int],
+    geometry: FMImageGeometry,
+) -> FibsemStagePosition:
+    """The stage position under a pixel in a displayed FM image.
+
+    The exact inverse of :func:`project_stage_position`, sharing its sign terms, so a
+    click resolves to the position the marker was drawn from.
+
+    Args:
+        point: pixel coordinates in the displayed image.
+        base_position: the stage position the image was acquired at.
+        pixel_size: image pixel size, in metres.
+        image_shape: image shape as (height, width), in pixels.
+        geometry: the geometry the image was captured under.
+
+    Returns:
+        FibsemStagePosition: the absolute position under that pixel.
+    """
+    dx = (point.x - image_shape[1] / 2) * pixel_size
+    dy = -(point.y - image_shape[0] / 2) * pixel_size
+
+    dx, dy = geometry.transform.apply_to_delta(dx, dy)
+    y_move, z_move = view_corrected_stage_movement(
+        expected_y=dy,
+        geometry=geometry,
+        stage_rotation=base_position.r or 0.0,
+        stage_tilt=base_position.t or 0.0,
+    )
+
+    position = deepcopy(base_position)
+    position.x += dx
+    position.y += y_move
+    position.z += z_move
+    return position
+
+
+def stage_position_from_fm_image(
+    image: "FluorescenceImage",
+    point: Point,
+) -> FibsemStagePosition:
+    """The stage position under a pixel of a fluorescence image.
+
+    The inverse of :func:`reproject_stage_positions_onto_fm_image`, and the projection
+    behind clicking a loaded overview. Reads the pose and transform the image records
+    rather than the live instrument's: click a saved overview after the stage has moved
+    and the answer must still describe that image, not the current view.
+
+    Args:
+        image: the image that was clicked.
+        point: pixel coordinates within it.
+
+    Returns:
+        FibsemStagePosition: the absolute position under that pixel.
+
+    Raises:
+        ValueError: if the image does not record the geometry it was captured under,
+            or has no stage position.
+    """
+    metadata = _require_projectable(image)
+    height, width = image.data.shape[-2:]
+
+    return project_image_point(
+        point=point,
+        base_position=metadata.stage_position,
+        pixel_size=metadata.pixel_size_x,
+        image_shape=(height, width),
+        geometry=metadata.geometry,
+    )
+
+
+def _require_projectable(image: "FluorescenceImage"):
+    """The metadata a projection needs, or a ValueError naming what is missing."""
+    metadata = image.metadata
+    if metadata is None:
+        raise ValueError("Image has no metadata. Cannot project stage positions.")
+    if metadata.geometry is None:
+        raise ValueError(
+            "Image metadata does not record the geometry it was captured under "
+            "(acquired before this was recorded). Cannot project stage positions."
+        )
+    if metadata.stage_position is None:
+        raise ValueError(
+            "Image metadata does not contain a stage position. "
+            "Cannot project stage positions."
+        )
+    return metadata
+
+
+def reproject_stage_positions_onto_fm_image(
+    image: "FluorescenceImage",
+    positions: List[FibsemStagePosition],
+    bound: bool = False,
+) -> List[Point]:
+    """Reproject stage positions onto a fluorescence image.
+
+    The FM counterpart of
+    :func:`fibsem.imaging.tiling.reprojection.reproject_stage_positions_onto_image2`.
+
+    Args:
+        image: the image to project onto.
+        positions: the stage positions.
+        bound: drop points that fall outside the image bounds.
+
+    Returns:
+        The positions in image pixel coordinates, carrying their names across.
+
+    Raises:
+        ValueError: if the image does not record the geometry it was captured under,
+            or has no stage position. Both are absent on images written before this
+            was recorded, and neither can be guessed without risking a marker that
+            looks correct and is not.
+    """
+    metadata = _require_projectable(image)
+    height, width = image.data.shape[-2:]
+
+    points = []
+    for position in positions:
+        point = project_stage_position(
+            position=position,
+            base_position=metadata.stage_position,
+            pixel_size=metadata.pixel_size_x,
+            image_shape=(height, width),
+            geometry=metadata.geometry,
+        )
+        point.name = position.name
+        if bound and not (0 <= point.x < width and 0 <= point.y < height):
+            continue
+        points.append(point)
+
+    return points

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -124,6 +124,64 @@ def _parse_image_transform(value: Any) -> CameraImageTransform:
     return CameraImageTransform.NONE
 
 
+@dataclass
+class FMImageGeometry:
+    """The geometry an FM image was captured under.
+
+    Recorded on the image so a stage position can be projected onto it without a live
+    microscope, and — more importantly — without *assuming* the live microscope still
+    matches. Reprojecting a saved overview against the current pose is silently wrong
+    the moment the stage has moved or the user has flipped the display, which is
+    exactly when someone is looking at a saved overview.
+
+    These are the fields the projection actually reads, rather than a whole
+    `SystemSettings`: an FM image serialises to OME-TIFF, where the rest of a system
+    configuration is both irrelevant and liable to go stale on disk. Keeping the list
+    short also keeps the reprojection contract legible — what is here is what the
+    projection depends on.
+
+    `is_compustage` is explicit for the same reason. The beam's metadata-driven
+    reprojection has to infer it by sniffing the model name for "Arctis", with a TODO
+    against it; there is no reason to repeat that here.
+
+    Angles are in degrees, matching `SystemSettings`.
+    """
+
+    transform: CameraImageTransform = CameraImageTransform.NONE
+    camera_tilt: float = 0.0            # viewing axis, from the electron column
+    column_tilt: float = 0.0            # electron column
+    fib_column_tilt: float = 52.0       # ion column; fixes the compustage FIB pose
+    shuttle_pre_tilt: float = 0.0
+    rotation_reference: float = 0.0
+    rotation_180: float = 180.0
+    is_compustage: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "transform": self.transform.value,
+            "camera_tilt": self.camera_tilt,
+            "column_tilt": self.column_tilt,
+            "fib_column_tilt": self.fib_column_tilt,
+            "shuttle_pre_tilt": self.shuttle_pre_tilt,
+            "rotation_reference": self.rotation_reference,
+            "rotation_180": self.rotation_180,
+            "is_compustage": self.is_compustage,
+        }
+
+    @classmethod
+    def from_dict(cls, ddict: dict) -> "FMImageGeometry":
+        return cls(
+            transform=_parse_image_transform(ddict.get("transform")),
+            camera_tilt=ddict.get("camera_tilt", 0.0),
+            column_tilt=ddict.get("column_tilt", 0.0),
+            fib_column_tilt=ddict.get("fib_column_tilt", 52.0),
+            shuttle_pre_tilt=ddict.get("shuttle_pre_tilt", 0.0),
+            rotation_reference=ddict.get("rotation_reference", 0.0),
+            rotation_180=ddict.get("rotation_180", 180.0),
+            is_compustage=ddict.get("is_compustage", False),
+        )
+
+
 class ZStackOrder(Enum):
     """Acquisition order for z-stack."""
     CHANNEL = "channel"   # default: for each channel, acquire all z-planes
@@ -1277,6 +1335,12 @@ class FluorescenceImageMetadata:
     # Stage position (optional, for correlative imaging)
     stage_position: Optional[FibsemStagePosition] = None
 
+    # Geometry the image was captured under, for reprojecting stage positions onto it.
+    # None on images written before this was recorded; reprojection raises rather than
+    # guessing, since a marker drawn in the wrong place looks exactly like one drawn in
+    # the right place.
+    geometry: Optional[FMImageGeometry] = None
+
     # File information
     filename: Optional[str] = None  # original filename
     description: Optional[str] = None  # image description/notes
@@ -1335,6 +1399,7 @@ class FluorescenceImageMetadata:
             "filename": self.filename,
             "description": self.description,
             "system_info": self.system_info,
+            "geometry": self.geometry.to_dict() if self.geometry else None,
             "channels": [
                 {
                     "name": ch.name,
@@ -1403,6 +1468,11 @@ class FluorescenceImageMetadata:
             filename=metadata_dict.get("filename"),
             description=metadata_dict.get("description"),
             system_info=metadata_dict.get("system_info"),
+            geometry=(
+                FMImageGeometry.from_dict(metadata_dict["geometry"])
+                if metadata_dict.get("geometry")
+                else None
+            ),
         )
     
     @classmethod

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1585,6 +1585,32 @@ class FibsemMicroscope(ABC):
 
         return new_position
 
+    def fm_image_geometry(self) -> "FMImageGeometry":
+        """The geometry the FM is currently imaging under.
+
+        Stamped onto acquired images so they can be reprojected later without a live
+        microscope, and used for the live view here so that both paths run the same
+        projection rather than two that merely agree today.
+
+        Raises:
+            ValueError: if no fluorescence microscope is available.
+        """
+        from fibsem.fm.structures import CameraImageTransform, FMImageGeometry
+
+        if self.fm is None:
+            raise ValueError("Fluorescence microscope is not available.")
+
+        return FMImageGeometry(
+            transform=self.fm._transform or CameraImageTransform.NONE,
+            camera_tilt=self.fm.camera_tilt,
+            column_tilt=self.system.electron.column_tilt,
+            fib_column_tilt=self.system.ion.column_tilt,
+            shuttle_pre_tilt=self.system.stage.shuttle_pre_tilt,
+            rotation_reference=self.system.stage.rotation_reference,
+            rotation_180=self.system.stage.rotation_180,
+            is_compustage=self.stage_is_compustage,
+        )
+
     def fm_stable_move(self, dx: float, dy: float) -> FibsemStagePosition:
         """Move the stage by a displacement seen in the fluorescence image.
 

--- a/tests/fm/test_reprojection.py
+++ b/tests/fm/test_reprojection.py
@@ -1,0 +1,354 @@
+"""Projecting stage positions onto fluorescence images.
+
+The property that matters is agreement: an overlay drawn with the reprojection has to
+land where clicking there would send the stage. Two things can break that quietly --
+the microscope-free path drifting from the live one, and a saved image being projected
+against the wrong pose -- so both are pinned here rather than left to inspection.
+"""
+
+import numpy as np
+import pytest
+
+from fibsem import utils
+from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.fm.reprojection import (
+    inverse_view_corrected_dy,
+    project_image_point,
+    project_stage_position,
+    reproject_stage_positions_onto_fm_image,
+    stage_position_from_fm_image,
+    view_corrected_stage_movement,
+)
+from fibsem.fm.structures import (
+    CameraImageTransform,
+    ChannelSettings,
+    FMImageGeometry,
+)
+from fibsem.structures import FibsemStagePosition, Point
+
+TRANSFORMS = list(CameraImageTransform)
+SHAPE = (1024, 1024)
+PIXEL_SIZE = 1e-7  # 102.4 um across
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    scope, _ = utils.setup_session(manufacturer="Demo")
+    if scope.fm is None:
+        scope.fm = FluorescenceMicroscope(parent=scope)
+    return scope
+
+
+def _pose(microscope, *, compustage, pretilt_deg, rotation_deg, tilt_deg):
+    """Pin the microscope into a known geometry without moving the stage."""
+    microscope.stage_is_compustage = compustage
+    microscope.system.stage.shuttle_pre_tilt = pretilt_deg
+    microscope._update_orientations()
+    position = FibsemStagePosition(
+        x=0.0, y=0.0, z=0.0,
+        r=np.deg2rad(rotation_deg),
+        t=np.deg2rad(tilt_deg),
+    )
+    microscope.get_stage_position = lambda: position  # type: ignore[method-assign]
+    return position
+
+
+# A compustage cannot rotate (see FibsemMicroscope._view_corrected_stage_movement), so
+# only the reference rotation is a reachable pose for it.
+POSES = [
+    pytest.param(True, 0, 0, tilt, id=f"compustage-t{tilt}")
+    for tilt in (0, -30, -128, -180)
+] + [
+    pytest.param(False, pretilt, rot, tilt, id=f"offset-p{pretilt}-r{rot}-t{tilt}")
+    for pretilt in (0, 35)
+    for rot in (0, 180)
+    for tilt in (0, 25, -30)
+]
+
+
+class TestParityWithTheLiveMicroscope:
+    """The microscope-free projection must reproduce the live one exactly.
+
+    They are separate implementations of one formula: the live path decides where the
+    stage goes, the pure path decides where the overlay is drawn. Any disagreement puts
+    a marker somewhere the stage will not go, and nothing on screen says so.
+    """
+
+    @pytest.mark.parametrize("compustage, pretilt, rot, tilt", POSES)
+    @pytest.mark.parametrize("camera_tilt", [0.0, 90.0, 180.0])
+    def test_inverse_matches(
+        self, microscope, compustage, pretilt, rot, tilt, camera_tilt, monkeypatch
+    ):
+        position = _pose(
+            microscope, compustage=compustage, pretilt_deg=pretilt,
+            rotation_deg=rot, tilt_deg=tilt,
+        )
+        monkeypatch.setattr(
+            type(microscope.fm), "camera_tilt", property(lambda self: camera_tilt)
+        )
+
+        live = microscope._inverse_view_corrected_stage_movement(
+            dy=12e-6, dz=-3e-6, view_tilt=np.deg2rad(camera_tilt)
+        )
+        pure = inverse_view_corrected_dy(
+            dy=12e-6, dz=-3e-6,
+            geometry=microscope.fm_image_geometry(),
+            stage_rotation=position.r,
+            stage_tilt=position.t,
+        )
+
+        assert pure == pytest.approx(live, abs=1e-15)
+
+    @pytest.mark.parametrize("compustage, pretilt, rot, tilt", POSES)
+    @pytest.mark.parametrize("camera_tilt", [0.0, 90.0, 180.0])
+    def test_forward_matches(
+        self, microscope, compustage, pretilt, rot, tilt, camera_tilt, monkeypatch
+    ):
+        """The forward direction is what actually moves the stage, so a click resolved
+        by the pure path has to agree with it exactly -- not merely closely."""
+        position = _pose(
+            microscope, compustage=compustage, pretilt_deg=pretilt,
+            rotation_deg=rot, tilt_deg=tilt,
+        )
+        monkeypatch.setattr(
+            type(microscope.fm), "camera_tilt", property(lambda self: camera_tilt)
+        )
+
+        live = microscope._view_corrected_stage_movement(
+            expected_y=17e-6, view_tilt=np.deg2rad(camera_tilt)
+        )
+        dy, dz = view_corrected_stage_movement(
+            17e-6,
+            geometry=microscope.fm_image_geometry(),
+            stage_rotation=position.r,
+            stage_tilt=position.t,
+        )
+
+        assert dy == pytest.approx(live.y, abs=1e-18)
+        assert dz == pytest.approx(live.z, abs=1e-18)
+
+    def test_an_unreachable_compustage_rotation_does_not_flip_the_sign(self, microscope):
+        """Regression: keying the FIB orientation on tilt alone disagreed with the live
+        path at a rotated compustage. No physical run can reach that pose, which is
+        exactly why the disagreement would have survived."""
+        position = _pose(
+            microscope, compustage=True, pretilt_deg=0,
+            rotation_deg=180, tilt_deg=-128,
+        )
+        assert microscope.get_stage_orientation() != "FIB", "pose assumption drifted"
+
+        live = microscope._inverse_view_corrected_stage_movement(
+            dy=12e-6, dz=-3e-6, view_tilt=np.deg2rad(microscope.fm.camera_tilt)
+        )
+        pure = inverse_view_corrected_dy(
+            dy=12e-6, dz=-3e-6,
+            geometry=microscope.fm_image_geometry(),
+            stage_rotation=position.r,
+            stage_tilt=position.t,
+        )
+
+        assert pure == pytest.approx(live, abs=1e-15)
+
+
+class TestRoundTrip:
+    """Clicking a pixel and drawing that pixel must agree."""
+
+    @pytest.mark.parametrize("compustage, pretilt, rot, tilt", POSES)
+    @pytest.mark.parametrize("transform", TRANSFORMS)
+    def test_pixel_to_stage_and_back(
+        self, microscope, compustage, pretilt, rot, tilt, transform
+    ):
+        base = _pose(
+            microscope, compustage=compustage, pretilt_deg=pretilt,
+            rotation_deg=rot, tilt_deg=tilt,
+        )
+        microscope.fm.set_image_transform(transform)
+
+        for pixel in [(512, 512), (0, 0), (1023, 40), (300, 900)]:
+            point = Point(x=float(pixel[0]), y=float(pixel[1]))
+            position = project_image_point(
+                point, base, PIXEL_SIZE, SHAPE,
+                microscope.fm_image_geometry(),
+            )
+            back = project_stage_position(
+                position, base, PIXEL_SIZE, SHAPE,
+                microscope.fm_image_geometry(),
+            )
+
+            assert back.x == pytest.approx(point.x, abs=1e-6)
+            assert back.y == pytest.approx(point.y, abs=1e-6)
+
+    def test_the_base_position_lands_on_the_image_centre(self, microscope):
+        base = _pose(
+            microscope, compustage=True, pretilt_deg=0, rotation_deg=0, tilt_deg=-180
+        )
+        point = project_stage_position(
+            base, base, PIXEL_SIZE, SHAPE, microscope.fm_image_geometry()
+        )
+
+        assert (point.x, point.y) == (SHAPE[1] / 2, SHAPE[0] / 2)
+
+    def test_positions_outside_the_field_of_view_are_not_clamped(self, microscope):
+        """The tile grid is drawn larger than the image it sits on, so a position off
+        the edge has to return coordinates off the edge rather than being pulled to
+        the border -- which would silently stack every outer tile on the boundary."""
+        base = _pose(
+            microscope, compustage=True, pretilt_deg=0, rotation_deg=0, tilt_deg=-180
+        )
+        far = project_image_point(
+            Point(x=-4000.0, y=-4000.0), base, PIXEL_SIZE, SHAPE,
+            microscope.fm_image_geometry(),
+        )
+        point = project_stage_position(
+            far, base, PIXEL_SIZE, SHAPE, microscope.fm_image_geometry()
+        )
+
+        assert point.x == pytest.approx(-4000.0, abs=1e-6)
+        assert point.y == pytest.approx(-4000.0, abs=1e-6)
+
+
+class TestGeometryIsRecorded:
+    def test_an_acquired_image_carries_the_geometry(self, microscope):
+        _pose(
+            microscope, compustage=True, pretilt_deg=0, rotation_deg=0, tilt_deg=-180
+        )
+        microscope.fm.set_image_transform(CameraImageTransform.FLIP_XY)
+
+        image = microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+
+        geometry = image.metadata.geometry
+        assert geometry is not None
+        assert geometry.transform is CameraImageTransform.FLIP_XY
+        assert geometry.is_compustage is True
+        assert geometry.camera_tilt == microscope.fm.camera_tilt
+
+    @pytest.mark.parametrize("transform", TRANSFORMS)
+    def test_geometry_round_trips_through_a_dict(self, transform):
+        geometry = FMImageGeometry(
+            transform=transform, camera_tilt=90.0, column_tilt=0.0,
+            fib_column_tilt=52.0, shuttle_pre_tilt=35.0,
+            rotation_reference=10.0, rotation_180=190.0, is_compustage=True,
+        )
+
+        assert FMImageGeometry.from_dict(geometry.to_dict()) == geometry
+
+
+class TestReprojectionOntoAnImage:
+    @pytest.fixture()
+    def image(self, microscope):
+        _pose(
+            microscope, compustage=True, pretilt_deg=0, rotation_deg=0, tilt_deg=-180
+        )
+        microscope.fm.set_image_transform(CameraImageTransform.NONE)
+        return microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+
+    def test_it_uses_the_images_own_pose_not_the_live_one(self, microscope, image):
+        """The point of recording the geometry: the stage has usually moved on by the
+        time anyone looks at a saved overview, and the answer must not follow it."""
+        base = image.metadata.stage_position
+        expected = reproject_stage_positions_onto_fm_image(image, [base])
+
+        _pose(
+            microscope, compustage=False, pretilt_deg=35,
+            rotation_deg=180, tilt_deg=25,
+        )
+        microscope.fm.set_image_transform(CameraImageTransform.FLIP_XY)
+        after = reproject_stage_positions_onto_fm_image(image, [base])
+
+        assert (after[0].x, after[0].y) == (expected[0].x, expected[0].y)
+
+    def test_names_are_carried_across(self, image):
+        base = image.metadata.stage_position
+        named = FibsemStagePosition(
+            x=base.x, y=base.y, z=base.z, r=base.r, t=base.t, name="Lamella-01"
+        )
+
+        points = reproject_stage_positions_onto_fm_image(image, [named])
+
+        assert points[0].name == "Lamella-01"
+
+    def test_bound_drops_positions_outside_the_image(self, microscope, image):
+        base = image.metadata.stage_position
+        height, width = image.data.shape[-2:]
+        outside = stage_position_from_fm_image(
+            image, Point(x=float(width * 4), y=float(height * 4))
+        )
+
+        assert len(reproject_stage_positions_onto_fm_image(image, [base, outside])) == 2
+        assert len(
+            reproject_stage_positions_onto_fm_image(image, [base, outside], bound=True)
+        ) == 1
+
+    def test_an_image_without_geometry_raises_rather_than_guessing(self, image):
+        """Images written before the geometry was recorded. A marker in the wrong place
+        is indistinguishable on screen from one in the right place, so falling back to
+        live state or to a default pose would be worse than refusing."""
+        base = image.metadata.stage_position
+        image.metadata.geometry = None
+
+        with pytest.raises(ValueError, match="geometry"):
+            reproject_stage_positions_onto_fm_image(image, [base])
+
+    def test_an_image_without_a_stage_position_raises(self, image):
+        image.metadata.stage_position = None
+
+        with pytest.raises(ValueError, match="stage position"):
+            reproject_stage_positions_onto_fm_image(image, [FibsemStagePosition()])
+
+
+def test_the_pure_projection_needs_no_microscope():
+    """The whole point of the split: reprojection must work on a loaded file with no
+    instrument attached, which is how it will usually be used."""
+    geometry = FMImageGeometry(
+        transform=CameraImageTransform.NONE, camera_tilt=180.0,
+        is_compustage=True, shuttle_pre_tilt=0.0,
+    )
+    base = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(-180))
+
+    point = project_stage_position(base, base, PIXEL_SIZE, SHAPE, geometry)
+
+    assert (point.x, point.y) == (SHAPE[1] / 2, SHAPE[0] / 2)
+
+
+class TestBothDirectionsFromAnImageAlone:
+    """The pair has to close on the image's own record, with no instrument attached --
+    which is the situation whenever someone opens a saved overview."""
+
+    @pytest.fixture()
+    def image(self, microscope):
+        _pose(
+            microscope, compustage=True, pretilt_deg=0, rotation_deg=0, tilt_deg=-180
+        )
+        microscope.fm.set_image_transform(CameraImageTransform.FLIP_XY)
+        return microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+
+    @pytest.mark.parametrize(
+        "pixel", [(512, 512), (0, 0), (900, 120), (-300, 1500)]
+    )
+    def test_pixel_to_stage_and_back(self, image, pixel):
+        point = Point(x=float(pixel[0]), y=float(pixel[1]))
+
+        position = stage_position_from_fm_image(image, point)
+        back = reproject_stage_positions_onto_fm_image(image, [position])[0]
+
+        assert back.x == pytest.approx(point.x, abs=1e-6)
+        assert back.y == pytest.approx(point.y, abs=1e-6)
+
+    def test_it_does_not_follow_the_live_microscope(self, microscope, image):
+        point = Point(x=300.0, y=800.0)
+        expected = stage_position_from_fm_image(image, point)
+
+        _pose(
+            microscope, compustage=False, pretilt_deg=35,
+            rotation_deg=180, tilt_deg=25,
+        )
+        microscope.fm.set_image_transform(CameraImageTransform.NONE)
+        after = stage_position_from_fm_image(image, point)
+
+        assert (after.x, after.y, after.z) == (expected.x, expected.y, expected.z)
+
+    def test_an_image_without_geometry_raises(self, image):
+        image.metadata.geometry = None
+
+        with pytest.raises(ValueError, match="geometry"):
+            stage_position_from_fm_image(image, Point(x=0.0, y=0.0))


### PR DESCRIPTION
Groundwork for showing stage and lamella positions on the FM overview, and for the tile-grid overlay that comes next.

## The problem

The FM coordinate pair that existed — `stage_position_to_napari_image_coordinate` and `napari_image_coordinate_to_stage_position` in `FMAcquisitionWidget` — only round-trips at `t = -180`:

| tilt | in y | out y | |
|---|---|---|---|
| -180° | +30 µm | +30 µm | round-trips |
| 0° | +30 µm | **-30 µm** | wrong |
| 25° | +30 µm | **-30 µm** | wrong |

The forward applies a y sign flip conditionally on tilt; the inverse applies it unconditionally. Arctis FM sits at -180, so this has never surfaced there — on an offset mount (METEOR) at any other tilt, the inverse returns the wrong y.

## The approach

Record what the projection needs *on the image*, and make the projection microscope-free.

`FluorescenceImageMetadata` gains an `FMImageGeometry` — display transform, camera tilt, stage geometry — stamped at acquisition. The projection then reads **the pose the image was captured at** rather than the live stage. That is the substantive fix beyond the sign bug: reprojecting a saved overview used to follow wherever the stage had since moved, and changed answer when the display transform was flipped. There is a test that moves the stage and flips the transform after acquisition and asserts the answer does not move.

Both directions, each parameterised and image-based:

| | explicit geometry | from an image |
|---|---|---|
| stage → pixel | `project_stage_position` | `reproject_stage_positions_onto_fm_image` |
| pixel → stage | `project_image_point` | `stage_position_from_fm_image` |

Shared sign and angle terms live in one `_projection_terms`. That is the part that drifts — each direction stays internally consistent while disagreeing with the other, so a marker gets drawn somewhere a click will not go and neither side looks wrong alone.

A short flat field set is stored rather than a whole `SystemSettings`: these serialise to OME-TIFF, where the rest of a system config is irrelevant and goes stale on disk. It also lets `is_compustage` be recorded honestly — the beam's equivalent infers it by sniffing `"Arctis"` in the model name, with a TODO against it.

## Old files

Images written before this carry `geometry=None` and **raise**, naming the missing field, rather than falling back to live state or an assumed pose. A marker in the wrong place is indistinguishable on screen from one in the right place.

## Correctness

Parity against the live projection in **both** directions across the pose matrix (compustage/offset × pre-tilt × rotation × tilt × camera tilt), at 1e-15 and 1e-18 — plus an image-only round trip with no instrument attached.

One bug found that way: the FIB-orientation test keyed on tilt alone, flipping the sign against the live path on a rotated compustage. A compustage cannot rotate, so no physical run could surface it — which is exactly why it would have survived. Fixed, with its own regression test.

## Notes for review

- `project_fm_stage_position` / `project_fm_image_point` were added on the microscope first, then **removed**: with the image carrying its own geometry they only re-derive it from a live instrument, which is worse whenever an image is in hand — and drawing on one means it always is. `fm_image_geometry()` stays (it stamps the metadata); the move API is untouched.
- **Trap worth knowing:** clicking a *saved* overview and calling `fm_stable_move(dx, dy)` with pixel deltas resolves against *live* geometry and goes to the wrong place. Use `stage_position_from_fm_image` then an absolute move.
- The broken napari pair is left in place; retiring it is a separate change.
- Verified on the Demo simulator only. Hardware validation of the underlying geometry is still outstanding.

Tests: 180 new, 769 passing across the FM and movement suites.