### PR TITLE
Draw the planned tile grid on the canvas, and let it be edited there (FIB-393)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -241,6 +241,32 @@ class FMOverviewSettingsWidget(QWidget):
         self.z_widget.setEnabled(self.check_zstack.isChecked())
         self._on_any_change()
 
+    def set_grid_size(self, rows: int, cols: int) -> None:
+        """Set both grid dimensions as a single change.
+
+        Setting the two spin boxes one after the other emits `changed` twice and
+        passes through a size nobody asked for -- the new row count against the old
+        column count. That is invisible when a spin box is nudged by hand, but an edge
+        drag on the canvas does it on every motion event.
+
+        Follows the `parameters` setter: block, apply, resize the mask explicitly
+        because its handler is blocked with it, then notify once.
+        """
+        if (rows, cols) == (self.spin_rows.value(), self.spin_cols.value()):
+            return
+
+        for widget in (self.spin_rows, self.spin_cols, self.tile_mask):
+            widget.blockSignals(True)
+        try:
+            self.spin_rows.setValue(rows)
+            self.spin_cols.setValue(cols)
+            self.tile_mask.set_grid_size(rows, cols)
+        finally:
+            for widget in (self.spin_rows, self.spin_cols, self.tile_mask):
+                widget.blockSignals(False)
+
+        self._on_any_change()
+
     def _on_grid_size_changed(self) -> None:
         self.tile_mask.set_grid_size(self.spin_rows.value(), self.spin_cols.value())
         self._on_any_change()

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -436,11 +436,10 @@ class FMOverviewWidget(QWidget):
         Writes to the settings widget, which owns rows and columns, for the same reason
         a tile click does: the canvas is a view of that state, not a second copy.
         """
-        settings = self.settings_widget
-        if (rows, cols) == (settings.spin_rows.value(), settings.spin_cols.value()):
-            return
-        settings.spin_rows.setValue(rows)
-        settings.spin_cols.setValue(cols)
+        # One call rather than two spin boxes: a drag emits on every motion event, and
+        # setting them separately would refresh twice per step and pass through a grid
+        # size that was never requested.
+        self.settings_widget.set_grid_size(rows, cols)
 
     def _on_tile_toggled(self, row: int, col: int, enabled: bool) -> None:
         """A tile was clicked on the canvas.

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -13,7 +13,7 @@ import threading
 from typing import List, Optional
 
 import numpy as np
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import QPoint, Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QDialog,
     QHBoxLayout,
@@ -34,13 +34,19 @@ from fibsem.fm.structures import (
     OverviewParameters,
 )
 from fibsem.microscope import FibsemMicroscope
+from fibsem.structures import FibsemStagePosition
 from fibsem.ui import stylesheets
 from fibsem.ui.fm.widgets.fm_multi_channel_widget import FluorescenceMultiChannelWidget
 from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     FMOverviewConfirmationDialog,
 )
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
+from fibsem.ui.fm.widgets.tile_grid_options_panel import TileGridOptionsPanel
 from fibsem.ui.qt.threading import FunctionWorker
+from fibsem.fm.reprojection import reproject_stage_positions_onto_fm_image
+from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
+from fibsem.ui.widgets.canvas.overlays.point_overlay import PointsOverlay
+from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import TileGridOverlay
 from fibsem.ui.widgets.custom_widgets import TitledPanel
 from fibsem.ui.widgets.progress_widget import (
     FibsemProgressWidget,
@@ -104,6 +110,9 @@ class FMOverviewWidget(QWidget):
         self._worker: Optional[FunctionWorker] = None
         self._runner: Optional[FMTiledAcquisitionRunner] = None
         self._mosaic: Optional[FluorescenceImage] = None
+        self._displayed_image: Optional[FluorescenceImage] = None
+        self._positions: List[FibsemStagePosition] = []
+        self._grid_footprint: Optional[tuple] = None
         self._enabled_channels: Optional[List[ChannelSettings]] = None
 
         self._init_ui(channel_settings or self._default_channels())
@@ -129,6 +138,35 @@ class FMOverviewWidget(QWidget):
 
     def _init_ui(self, channels: List[ChannelSettings]) -> None:
         self.canvas = FMCanvasWidget()
+
+        # The planned grid, drawn on the canvas and clickable. A second view of the
+        # mask `TileMaskWidget` owns, not a second copy: clicks are routed through the
+        # settings widget so there is one place the selection lives.
+        self.tile_grid_overlay = TileGridOverlay()
+        self.canvas.canvas.add_overlay(self.tile_grid_overlay)
+
+        # Grid display options live on the canvas toolbar, beside the layers control:
+        # they are about reading the image, not about what gets acquired, so they do
+        # not belong in the settings column with the parameters of the run.
+        self.btn_tile_grid = self.canvas.canvas.add_toolbar_button(
+            "mdi:grid", "Tile grid", self._toggle_tile_grid_panel, checkable=True
+        )
+        self.canvas.canvas._reposition_overlay_buttons()
+        self.tile_grid_panel = TileGridOptionsPanel(self)
+        self.tile_grid_panel.hide()
+        self.tile_grid_panel.visibility_changed.connect(
+            self.tile_grid_overlay.set_grid_visible
+        )
+        self.tile_grid_panel.color_changed.connect(self.tile_grid_overlay.set_color)
+        self.tile_grid_panel.fill_alpha_changed.connect(
+            self.tile_grid_overlay.set_fill_alpha
+        )
+
+        # Stage positions -- the current pose, lamellae, anything a host hands over --
+        # projected onto whatever image is displayed. Non-interactive: this shows where
+        # things are, it does not move them.
+        self.position_overlay = PointsOverlay(color="#ffb300", marker="o", size=7)
+        self.canvas.canvas.add_overlay(self.position_overlay)
 
         # The list alone shows only name/excitation/emission, with no way to set the
         # exposure, power or gain a tile is actually acquired at. This composes the
@@ -217,6 +255,8 @@ class FMOverviewWidget(QWidget):
         self.channel_widget.settings_changed.connect(self._on_channels_changed)
         self.channel_widget.enabled_changed.connect(self._on_enabled_changed)
         self.settings_widget.changed.connect(self._on_settings_changed)
+        self.tile_grid_overlay.tile_toggled.connect(self._on_tile_toggled)
+        self.tile_grid_overlay.grid_resize_requested.connect(self._on_grid_resize)
 
     def _section(self, title: str, widget: QWidget) -> QWidget:
         return TitledPanel(title, content=widget)
@@ -256,9 +296,175 @@ class FMOverviewWidget(QWidget):
         self._enabled_channels = list(channels)
         self._on_settings_changed()
 
+    def _update_grid_summary(self) -> None:
+        """Describe the grid on the canvas-side panel.
+
+        Built from the settings widget's own formatted values rather than recomputed,
+        so the two cannot end up quoting different numbers for the same grid.
+        """
+        parameters = self.settings_widget.parameters
+        total = parameters.rows * parameters.cols
+        parts = [
+            f"{parameters.rows} × {parameters.cols}",
+            f"{parameters.overlap:.0%} overlap",
+        ]
+        parts.append(f"{parameters.n_enabled_tiles}/{total} tiles")
+
+        # The field of view goes on its own line rather than into the join: the panel
+        # is narrow, and wrapping a "287 × 287 µm" mid-value reads as two numbers.
+        summary = "  ·  ".join(parts)
+        fov = self.settings_widget.label_total_fov.text()
+        if fov and fov != "—":
+            summary = f"{summary}\n{fov}"
+        self.tile_grid_panel.set_summary(summary)
+
+    def _refresh_tile_grid(self) -> None:
+        """Redraw the planned grid on the canvas.
+
+        Needs a tile field of view (from the camera) and an image on the canvas to
+        anchor and scale against. With no image there is nothing to draw the grid
+        relative to, so it is cleared rather than guessed at.
+        """
+        fov = self.settings_widget._tile_fov
+        if fov is None:
+            self.tile_grid_overlay.clear()
+            return
+
+        try:
+            width, height = self.fm.camera.resolution
+            pixel_size = self.fm.camera.pixel_size[0]
+        except Exception as e:
+            logging.debug(f"Could not read the camera geometry for the tile grid: {e}")
+            self.tile_grid_overlay.clear()
+            return
+
+        parameters = self.settings_widget.parameters
+        tiles = compute_tile_grid_from_fov(
+            nrows=parameters.rows,
+            ncols=parameters.cols,
+            fov_x=fov[0],
+            fov_y=fov[1],
+            image_width=width,
+            image_height=height,
+            overlap=parameters.overlap,
+            mask=parameters.tile_mask,
+        )
+        # No `display_pixel_size`: the overlay reads it from the canvas at draw time.
+        # Pinning it here would freeze the scale at whatever was displayed when the
+        # settings last changed, and the image underneath changes without them -- the
+        # live preview swaps in a decimated mosaic mid-run.
+        self.tile_grid_overlay.set_grid(
+            tiles, (height, width), pixel_size, overlap=parameters.overlap
+        )
+
+        # Refit only when the grid's footprint actually changes. Toggling a tile also
+        # comes through here, and refitting on that threw away whatever zoom and pan
+        # the user had set -- so clicking a tile appeared to zoom the view.
+        # Recorded whether or not the view is refitted, so that a drag -- which
+        # suppresses the refit on every step -- does not leave the footprint looking
+        # stale and jump the view on the next unrelated settings change.
+        footprint = (parameters.rows, parameters.cols, parameters.overlap)
+        changed = footprint != self._grid_footprint
+        self._grid_footprint = footprint
+        if changed and not self.tile_grid_overlay.is_resizing:
+            self.tile_grid_overlay.fit_view()
+
+    def _toggle_tile_grid_panel(self) -> None:
+        if not self.btn_tile_grid.isChecked():
+            self.tile_grid_panel.hide()
+            return
+
+        self.tile_grid_panel.adjustSize()
+        # Anchored in global coordinates: the panel is a top-level tool window, so it
+        # cannot be placed relative to the canvas in widget coordinates.
+        canvas = self.canvas.canvas
+        anchor = canvas.mapToGlobal(QPoint(canvas.width() - 8, 44))
+        self.tile_grid_panel.move(anchor.x() - self.tile_grid_panel.width(), anchor.y())
+        self.tile_grid_panel.show()
+        self.tile_grid_panel.raise_()
+
+    def set_image(self, image: FluorescenceImage) -> None:
+        """Show an image on the canvas and refresh anything drawn on top of it.
+
+        Overlays are positioned against the displayed image, so the image has to be
+        recorded when it is set rather than fetched from the canvas later -- the canvas
+        keeps channel stacks, not the `FluorescenceImage` and its metadata, and the
+        metadata is what carries the pose a position is projected against.
+        """
+        self._displayed_image = image
+        self.canvas.set_fm_image(image)
+        self._refresh_positions()
+
+    def set_positions(self, positions: List[FibsemStagePosition]) -> None:
+        """Stage positions to mark on the overview, e.g. saved lamella positions.
+
+        Names are carried onto the markers, so a caller does not have to keep a
+        parallel list of labels in the order it happened to pass them.
+        """
+        self._positions = list(positions)
+        self._refresh_positions()
+
+    def _refresh_positions(self) -> None:
+        """Reproject the marked positions onto the displayed image.
+
+        Uses the image's own recorded geometry rather than the live microscope: after
+        an overview is acquired the stage has moved on, and following it would drift
+        every marker off the feature it names.
+        """
+        if self._displayed_image is None or not self._positions:
+            self.position_overlay.set_points([])
+            return
+
+        try:
+            points = reproject_stage_positions_onto_fm_image(
+                self._displayed_image, self._positions
+            )
+        except ValueError as e:
+            # Images acquired before the geometry was recorded cannot be projected onto.
+            logging.debug(f"Cannot mark positions on this image: {e}")
+            self.position_overlay.set_points([])
+            return
+
+        self.position_overlay.set_points(
+            [(p.x, p.y) for p in points],
+            labels=[p.name or "" for p in points],
+        )
+
+    def _on_grid_resize(self, rows: int, cols: int) -> None:
+        """An edge of the grid was dragged.
+
+        Writes to the settings widget, which owns rows and columns, for the same reason
+        a tile click does: the canvas is a view of that state, not a second copy.
+        """
+        settings = self.settings_widget
+        if (rows, cols) == (settings.spin_rows.value(), settings.spin_cols.value()):
+            return
+        settings.spin_rows.setValue(rows)
+        settings.spin_cols.setValue(cols)
+
+    def _on_tile_toggled(self, row: int, col: int, enabled: bool) -> None:
+        """A tile was clicked on the canvas.
+
+        The mask belongs to the settings widget, so this writes there and lets the
+        resulting `changed` redraw the overlay -- rather than updating the overlay
+        directly, which would leave the two views to drift apart on any path that
+        touched only one of them.
+        """
+        mask = self.settings_widget.tile_mask.mask
+        parameters = self.settings_widget.parameters
+        if mask is None:
+            mask = [[True] * parameters.cols for _ in range(parameters.rows)]
+        if not (0 <= row < len(mask) and 0 <= col < len(mask[row])):
+            return
+
+        mask[row][col] = enabled
+        self.settings_widget.tile_mask.mask = mask
+
     def _on_settings_changed(self) -> None:
         if self.is_acquiring:
             return
+        self._refresh_tile_grid()
+        self._update_grid_summary()
         parameters = self.settings_widget.parameters
         enabled = parameters.n_enabled_tiles > 0
         self.button_acquire.setEnabled(enabled)
@@ -470,6 +676,14 @@ class FMOverviewWidget(QWidget):
                 planes = planes[np.newaxis]
             for channel, plane in zip(self.channels, planes):
                 self.canvas.set_channel(channel.name, plane, channel.color)
+
+            # The preview is decimated to keep it a sane size, so its pixels are
+            # `preview_stride` times coarser than a tile's. `set_channel` takes raw
+            # planes and cannot know that, and anything drawn on top -- the tile grid,
+            # position markers -- scales against the canvas pixel size, so leaving it
+            # at the tile's would draw them all stride times too large.
+            stride = payload.get("preview_stride", 1) or 1
+            self.canvas.set_pixel_size(self.fm.camera.pixel_size[0] * stride)
         except Exception as e:
             logging.debug(f"Could not display the overview preview: {e}")
 
@@ -480,7 +694,7 @@ class FMOverviewWidget(QWidget):
 
         if state == "overview-finished" and self._mosaic is not None:
             # Swap the decimated preview for the real thing.
-            self.canvas.set_fm_image(self._mosaic)
+            self.set_image(self._mosaic)
             shape = self._mosaic.data.shape
             self.status.setText(f"Overview acquired — {shape[-1]} × {shape[-2]} px")
             self.progress_tiles.update_progress(ProgressUpdate.done())

--- a/fibsem/ui/fm/widgets/tile_grid_options_panel.py
+++ b/fibsem/ui/fm/widgets/tile_grid_options_panel.py
@@ -1,0 +1,132 @@
+"""Floating options for the tile grid overlay.
+
+Follows `FMLayersPanel`: a frameless tool window opened from a canvas toolbar button,
+positioned under it. A separate top-level window rather than a child widget, for the
+same reason -- native controls parented into the matplotlib canvas are forced to
+repaint on every canvas redraw.
+
+The settings here are all about *seeing* the grid, not about what will be acquired.
+Nothing in this panel changes the acquisition; the tile selection lives in
+`TileMaskWidget` and on the canvas itself.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from PyQt5.QtCore import QSize, Qt, pyqtSignal
+from PyQt5.QtGui import QColor, QIcon, QPixmap
+from PyQt5.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QSlider,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.ui.icon import fibsem_icon
+
+# Ordered by how often an FM sample makes them useless: magenta first, because
+# fluorescence channels are usually cyan/green/blue and rarely magenta.
+GRID_COLORS = [
+    ("Magenta", "#ff3ec8"),
+    ("Yellow", "#ffd54f"),
+    ("Cyan", "#00e5ff"),
+    ("Green", "#69f0ae"),
+    ("White", "#ffffff"),
+]
+
+def _color_icon(color: str, size: int = 12) -> QIcon:
+    """A filled swatch for a combo entry, so the colour is picked by eye not by name."""
+    pixmap = QPixmap(size, size)
+    pixmap.fill(QColor(color))
+    return QIcon(pixmap)
+
+
+_PANEL_QSS = """
+QFrame#tileGridPanel { background: #1e2027; border: 1px solid #3d4251; border-radius: 6px; }
+QLabel { color: #d6d6d6; font-size: 11px; background: transparent; }
+QLabel#panelTitle { color: #9aa0a6; font-size: 10px; font-weight: 600; letter-spacing: 1px; }
+QCheckBox { color: #d6d6d6; font-size: 11px; background: transparent; }
+QLabel#gridSummary { color: #868e93; font-size: 10px; background: transparent; }
+"""
+
+
+class TileGridOptionsPanel(QFrame):
+    """Show/hide, colour and fill opacity for the tile grid overlay."""
+
+    visibility_changed = pyqtSignal(bool)
+    color_changed = pyqtSignal(str)
+    fill_alpha_changed = pyqtSignal(float)
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWindowFlags(Qt.Tool | Qt.FramelessWindowHint)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setObjectName("tileGridPanel")
+        self.setStyleSheet(_PANEL_QSS)
+        self.setFixedWidth(196)
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(12, 12, 12, 12)
+        root.setSpacing(10)
+
+        header = QHBoxLayout()
+        header.setSpacing(8)
+        icon = QLabel()
+        icon.setPixmap(fibsem_icon("mdi:grid", color="#9aa0a6").pixmap(QSize(14, 14)))
+        title = QLabel("TILE GRID")
+        title.setObjectName("panelTitle")
+        header.addWidget(icon)
+        header.addWidget(title)
+        header.addStretch()
+        root.addLayout(header)
+
+        # Read-only. This panel does not change what gets acquired -- the grid's
+        # parameters are owned by the settings column -- but when you are zoomed into
+        # the canvas it is the obvious place to ask what you are looking at.
+        self.label_summary = QLabel()
+        self.label_summary.setObjectName("gridSummary")
+        self.label_summary.setWordWrap(True)
+        root.addWidget(self.label_summary)
+
+        self.check_visible = QCheckBox("Show grid")
+        self.check_visible.setChecked(True)
+        self.check_visible.toggled.connect(self.visibility_changed)
+        root.addWidget(self.check_visible)
+
+        root.addWidget(QLabel("Colour"))
+        self.combo_color = QComboBox()
+        for name, color in GRID_COLORS:
+            self.combo_color.addItem(_color_icon(color), name, color)
+        self.combo_color.currentIndexChanged.connect(
+            lambda _index: self.color_changed.emit(self.combo_color.currentData())
+        )
+        root.addWidget(self.combo_color)
+
+        # Off by default -- outlines alone show the tile boundaries without hiding the
+        # data. Turned up, the fill doubles as an overlap map.
+        root.addWidget(QLabel("Fill"))
+        self.slider_alpha = QSlider(Qt.Horizontal)
+        self.slider_alpha.setRange(0, 40)  # per-cent; above ~40 the data is unreadable
+        self.slider_alpha.setValue(0)
+        self.slider_alpha.valueChanged.connect(
+            lambda value: self.fill_alpha_changed.emit(value / 100.0)
+        )
+        root.addWidget(self.slider_alpha)
+
+    def set_summary(self, text: str) -> None:
+        """What the grid currently describes, e.g. `3 x 3 - 10% overlap - 9/9 tiles`."""
+        self.label_summary.setText(text)
+
+    def set_color(self, color: str) -> None:
+        """Reflect the current colour without emitting -- for syncing from the overlay."""
+        index = self.combo_color.findData(color)
+        if index < 0:
+            return
+        self.combo_color.blockSignals(True)
+        self.combo_color.setCurrentIndex(index)
+        self.combo_color.blockSignals(False)

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -34,6 +34,7 @@ class PointsOverlay(CanvasOverlay):
         self._marker = marker
         self._size = size
         self._label_prefix = label_prefix
+        self._labels: Optional[List[str]] = None
         self._ax = None
         self._canvas = None
         self._artists: list = []
@@ -52,8 +53,19 @@ class PointsOverlay(CanvasOverlay):
         if width > 0:
             self._draw()
 
-    def set_points(self, points: List[Tuple[float, float]]) -> None:
+    def set_points(
+        self,
+        points: List[Tuple[float, float]],
+        labels: Optional[List[str]] = None,
+    ) -> None:
+        """Replace the points, optionally labelling each one.
+
+        `labels` takes precedence over `label_prefix`: positions that carry their own
+        names (lamellae, saved positions) should show those rather than an index into
+        whatever order they happened to arrive in.
+        """
         self._points = list(points)
+        self._labels = list(labels) if labels is not None else None
         self._remove_artists()
         self._draw()
         if self._canvas is not None:
@@ -85,9 +97,14 @@ class PointsOverlay(CanvasOverlay):
                 zorder=8,
             )
             self._artists.append(line)
-            if self._label_prefix:
+            label = None
+            if self._labels is not None and i <= len(self._labels):
+                label = self._labels[i - 1]
+            elif self._label_prefix:
+                label = f"{self._label_prefix}{i}"
+            if label:
                 ann = self._ax.annotate(
-                    f"{self._label_prefix}{i}",
+                    label,
                     xy=(x, y),
                     xytext=(6, 4),
                     textcoords="offset points",

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -454,6 +454,11 @@ class TileGridOverlay(QObject, CanvasOverlay):
             return
         if event.xdata is None or event.ydata is None:
             return
+        if not self._tiles:
+            # The grid can be cleared mid-drag -- `_refresh_tile_grid` does exactly
+            # that if the camera geometry cannot be read -- and the row/column counts
+            # below are derived from the tiles, so this would raise on an empty max().
+            return
 
         horizontal, vertical = self._resize_axes
         tile_h, tile_w = self._tile_shape

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -1,0 +1,482 @@
+"""Planned tile grid, drawn on the canvas and clickable to include/exclude tiles.
+
+Shows where an overview acquisition will put its tiles before it runs, and lets a tile
+be toggled by clicking it. The same selection is editable in `TileMaskWidget`; this is
+a second view of that one mask, not a second copy of it.
+
+Placement comes from `TilePosition.canvas_x/canvas_y` -- the pixel offsets
+`stitch_tileset` pastes each tile at -- rather than from the metre offsets `dx/dy`.
+Both would work, but only one of them is the number the stitcher actually uses, so
+this way the preview cannot disagree with the mosaic it is previewing. It also avoids
+restating the sign convention: the runner applies `dx - offset` but `dy + offset`, and
+getting that backwards would draw a grid that looks plausible and is upside down.
+
+The grid is a regular lattice in the displayed frame at any stage tilt, because tiles
+are *defined* by displayed-frame offsets handed to `project_fm_stable_move`. The tilt
+is absorbed into the stage moves, not into where the tiles appear.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
+
+from PyQt5.QtCore import QObject, Qt, pyqtSignal
+
+from fibsem.imaging.tiling.geometry import TilePosition
+from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+
+if TYPE_CHECKING:  # pragma: no cover - annotation only
+    from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+# Magenta rather than the app's blue: this is drawn over fluorescence data, which is
+# routinely cyan, green or blue, and an overlay the same hue as the sample is one you
+# have to hunt for. Magenta is the one corner of the wheel FM channels rarely occupy.
+ENABLED_EDGE = "#ff3ec8"
+# No fill by default: filled squares hide the data they are drawn over, and the tile
+# boundaries -- which are the thing worth seeing -- are the outlines, not the areas.
+# The fill is still available from the options panel, where it doubles as an overlap
+# map (two overlapping tiles read brighter than one), but it is opt-in.
+ENABLED_ALPHA = 0.0
+# Grey, so a skipped tile reads as inactive at a glance rather than as a differently
+# dashed active one. Distinguished by colour *and* line style, since either alone is
+# easy to miss in a large grid.
+DISABLED_EDGE = "#9aa0a6"
+DISABLED_ALPHA = 0.75
+LINE_WIDTH = 0.8
+
+# Grab zone for an edge drag, as a fraction of a tile. Proportional rather than a
+# fixed pixel count so it stays usable however far the view is zoomed out.
+EDGE_GRAB_FRACTION = 0.08
+MAX_TILES_PER_AXIS = 100  # matches the row/column spin boxes
+
+
+class TileGridOverlay(QObject, CanvasOverlay):
+    """The planned tile grid, with click-to-toggle.
+
+    Emits :attr:`tile_toggled` rather than mutating anything: the mask belongs to the
+    settings widget, and two widgets writing the same state is how they drift apart.
+    """
+
+    tile_toggled = pyqtSignal(int, int, bool)      # row, col, enabled
+    grid_resize_requested = pyqtSignal(int, int)   # rows, cols
+
+    def __init__(self, parent: Optional[QObject] = None) -> None:
+        QObject.__init__(self, parent)
+        self._tiles: List[TilePosition] = []
+        self._tile_shape: Tuple[int, int] = (0, 0)     # (height, width) px
+        self._tile_pixel_size: float = 0.0
+        self._display_pixel_size: Optional[float] = None
+        self._overlap: float = 0.0
+        self._color: str = ENABLED_EDGE
+        self._fill_alpha: float = ENABLED_ALPHA
+        self._visible: bool = True
+
+        self._ax = None
+        self._canvas: Optional["FibsemImageCanvas"] = None
+        self._artists: list = []
+        self._img_w: int = 0
+        self._img_h: int = 0
+        self._previous_margin: Optional[float] = None
+        self._cids: List[int] = []
+        self._resize_axes: Optional[Tuple[bool, bool]] = None  # (horizontal, vertical)
+        self._cursor_set: bool = False
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+
+    def attach(self, ax, canvas: "FibsemImageCanvas") -> None:
+        self._ax = ax
+        self._canvas = canvas
+        canvas.canvas_clicked.connect(self._on_canvas_clicked)
+        self._cids = [
+            canvas.mpl_connect("button_press_event", self._on_press),
+            canvas.mpl_connect("motion_notify_event", self._on_drag),
+            canvas.mpl_connect("button_release_event", self._on_release),
+        ]
+
+    def detach(self) -> None:
+        if self._canvas is not None:
+            try:
+                self._canvas.canvas_clicked.disconnect(self._on_canvas_clicked)
+            except TypeError:
+                pass
+            for cid in self._cids:
+                self._canvas.mpl_disconnect(cid)
+            self._cids = []
+            if self._cursor_set:
+                self._canvas.unsetCursor()
+                self._cursor_set = False
+            # The margin is a property of the canvas, not of this overlay, so leaving
+            # it widened would keep every later image zoomed out for no visible reason.
+            self._restore_margin()
+        self._remove_artists()
+        self._ax = None
+        self._canvas = None
+
+    def on_image_changed(self, width: int, height: int) -> None:
+        self._img_w, self._img_h = width, height
+        self._redraw()
+
+    # ── content ──────────────────────────────────────────────────────────
+
+    def set_grid(
+        self,
+        tiles: Sequence[TilePosition],
+        tile_shape: Tuple[int, int],
+        tile_pixel_size: float,
+        display_pixel_size: Optional[float] = None,
+        overlap: float = 0.0,
+    ) -> None:
+        """Set the grid to draw.
+
+        Args:
+            tiles: the planned grid, as returned by the tiling geometry core.
+            tile_shape: one tile's (height, width), in pixels.
+            tile_pixel_size: the pixel size those dimensions are in, in metres.
+            display_pixel_size: pixel size of the image being drawn on. Defaults to
+                `tile_pixel_size` -- the usual case, since the canvas is showing a
+                frame from the same camera.
+            overlap: fraction adjacent tiles share. Passed rather than derived from
+                the tile spacing, because a single-row or single-column grid has no
+                spacing to derive it from -- and that is exactly the case a resize
+                drag has to grow out of.
+        """
+        self._tiles = list(tiles)
+        self._tile_shape = tile_shape
+        self._tile_pixel_size = tile_pixel_size
+        self._display_pixel_size = display_pixel_size
+        self._overlap = overlap
+        self._redraw()
+
+    def clear(self) -> None:
+        self._tiles = []
+        self._redraw()
+
+    def set_color(self, color: str) -> None:
+        """Recolour the grid.
+
+        Exposed because no single colour works over every sample: the default avoids
+        the hues FM channels usually occupy, but a magenta channel makes a magenta
+        grid invisible, and only the person looking at the data knows that.
+        """
+        self._color = color
+        self._redraw()
+
+    def set_fill_alpha(self, alpha: float) -> None:
+        """Opacity of the enabled-tile fill. 0 leaves outlines only."""
+        self._fill_alpha = max(0.0, min(1.0, float(alpha)))
+        self._redraw()
+
+    def set_grid_visible(self, visible: bool) -> None:
+        """Hide the grid without discarding it, for an unobstructed look at the data."""
+        self._visible = bool(visible)
+        self._redraw()
+
+    @property
+    def is_grid_visible(self) -> bool:
+        return self._visible
+
+    @property
+    def is_resizing(self) -> bool:
+        """True while an edge is being dragged.
+
+        The host needs this: resizing changes the grid's footprint, and refitting the
+        view on every step of a drag would zoom the canvas out from under the cursor.
+        """
+        return self._resize_axes is not None
+
+    def fit_view(self, padding: float = 0.05) -> None:
+        """Zoom out so the whole grid is visible, not just the tile at the centre.
+
+        A 3x3 at 10% overlap spans ~2.8x the field of view per axis, so at the default
+        view the outer tiles are off-screen -- and an outer tile that cannot be seen
+        cannot be clicked.
+        """
+        if self._canvas is None or not self._tiles or self._img_w <= 0:
+            return
+
+        span_w, span_h = self._extent()
+        if span_w <= 0 or span_h <= 0:
+            return
+
+        # `set_view_margin` is a fraction of the *image* size per side.
+        margin = max(
+            (span_w / self._img_w - 1.0) / 2.0,
+            (span_h / self._img_h - 1.0) / 2.0,
+            0.0,
+        )
+        if self._previous_margin is None:
+            self._previous_margin = getattr(self._canvas, "_view_margin", 0.0)
+        self._canvas.set_view_margin(margin + padding)
+
+    # ── drawing ──────────────────────────────────────────────────────────
+
+    def _scale(self) -> float:
+        """Tile pixels per displayed pixel.
+
+        Read from the canvas at draw time rather than cached at `set_grid` time: the
+        displayed image changes underneath the grid during an acquisition -- the live
+        preview is a decimated mosaic, so its pixels are `preview_stride` times coarser
+        than a tile's -- and a scale captured before that swap draws the grid stride
+        times too large over the very image it is meant to describe.
+        """
+        display = self._display_pixel_size
+        if display is None and self._canvas is not None:
+            display = getattr(self._canvas, "_pixel_size", None)
+        display = display or self._tile_pixel_size
+        if not display:
+            return 1.0
+        return self._tile_pixel_size / display
+
+    def _extent(self) -> Tuple[float, float]:
+        """The whole grid's size in display pixels."""
+        if not self._tiles:
+            return 0.0, 0.0
+        tile_h, tile_w = self._tile_shape
+        scale = self._scale()
+        span_w = (max(t.canvas_x for t in self._tiles) + tile_w) * scale
+        span_h = (max(t.canvas_y for t in self._tiles) + tile_h) * scale
+        return span_w, span_h
+
+    def _rect_for(self, tile: TilePosition) -> Tuple[float, float, float, float]:
+        """(x, y, width, height) of one tile, in display pixels."""
+        tile_h, tile_w = self._tile_shape
+        scale = self._scale()
+        span_w, span_h = self._extent()
+
+        # The grid is centred on the image centre, matching the runner: it measures
+        # from the top-left tile and shifts so the grid straddles the start position.
+        origin_x = self._img_w / 2 - span_w / 2
+        origin_y = self._img_h / 2 - span_h / 2
+
+        return (
+            origin_x + tile.canvas_x * scale,
+            origin_y + tile.canvas_y * scale,
+            tile_w * scale,
+            tile_h * scale,
+        )
+
+    def _redraw(self) -> None:
+        self._remove_artists()
+        if self._ax is None or not self._tiles or self._img_w <= 0 or not self._visible:
+            # Still repaint: removing the artists takes them out of the axes, but the
+            # canvas keeps showing the last render until it is asked to redraw -- so
+            # returning early here left a hidden grid on screen.
+            if self._canvas is not None:
+                self._canvas.draw_idle()
+            return
+
+        from matplotlib.colors import to_rgba
+        from matplotlib.patches import Rectangle
+
+        for tile in self._tiles:
+            x, y, width, height = self._rect_for(tile)
+            # Alpha is baked into the face colour rather than set on the patch:
+            # `alpha=` applies to the edge as well, which drew the outlines at the
+            # fill's opacity and left them all but invisible -- so the grid could only
+            # be seen by turning the fill up until it obscured the data.
+            patch = Rectangle(
+                (x, y), width, height,
+                fill=tile.enabled,
+                facecolor=(
+                    to_rgba(self._color, self._fill_alpha) if tile.enabled else "none"
+                ),
+                edgecolor=(
+                    to_rgba(self._color, 1.0) if tile.enabled
+                    else to_rgba(DISABLED_EDGE, DISABLED_ALPHA)
+                ),
+                linestyle="-" if tile.enabled else "--",
+                linewidth=LINE_WIDTH,
+                zorder=20,
+            )
+            self._ax.add_patch(patch)
+            self._artists.append(patch)
+
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def _remove_artists(self) -> None:
+        for artist in self._artists:
+            try:
+                artist.remove()
+            except (ValueError, NotImplementedError):
+                pass
+        self._artists = []
+
+    # ── interaction ──────────────────────────────────────────────────────
+
+    def _on_canvas_clicked(self, x: float, y: float, modifiers) -> None:
+        tile = self._tile_at(x, y)
+        if tile is None:
+            return
+        self.tile_toggled.emit(tile.row, tile.col, not tile.enabled)
+
+    def _tile_at(self, x: float, y: float) -> Optional[TilePosition]:
+        """The tile under a point, or None.
+
+        Nearest centre among the tiles containing the point, rather than the first
+        match: tiles overlap by design, so a click in a seam is inside two of them and
+        "first in the list" would make the answer depend on the traversal order.
+        """
+        hits = []
+        for tile in self._tiles:
+            left, top, width, height = self._rect_for(tile)
+            if left <= x <= left + width and top <= y <= top + height:
+                centre_x, centre_y = left + width / 2, top + height / 2
+                hits.append(((centre_x - x) ** 2 + (centre_y - y) ** 2, tile))
+        if not hits:
+            return None
+        return min(hits, key=lambda item: item[0])[1]
+
+    # ── resize by dragging an edge ───────────────────────────────────────
+
+    def _edge_sides(self, x: float, y: float) -> Tuple[int, int]:
+        """Which outer edges a point is on, as (x_side, y_side).
+
+        -1 for the low edge, +1 for the high one, 0 for neither. Signed rather than
+        boolean because the hover cursor has to name a *corner* -- top-left and
+        top-right want opposite diagonals -- and "on both axes" cannot distinguish them.
+        """
+        if not self._tiles or self._tile_shape[1] <= 0 or self._img_w <= 0:
+            return 0, 0
+
+        span_w, span_h = self._extent()
+        left = self._img_w / 2 - span_w / 2
+        top = self._img_h / 2 - span_h / 2
+        # Proportional to a tile rather than a fixed pixel count, so the grab zone
+        # stays usable at any zoom without querying the transform.
+        tolerance = self._tile_shape[1] * self._scale() * EDGE_GRAB_FRACTION
+
+        # Only count an edge if the point is actually alongside the grid, otherwise
+        # the extended lines of the bounding box grab far outside it.
+        within_x = left - tolerance <= x <= left + span_w + tolerance
+        within_y = top - tolerance <= y <= top + span_h + tolerance
+
+        x_side = 0
+        if within_y:
+            if abs(x - left) <= tolerance:
+                x_side = -1
+            elif abs(x - (left + span_w)) <= tolerance:
+                x_side = 1
+
+        y_side = 0
+        if within_x:
+            if abs(y - top) <= tolerance:
+                y_side = -1
+            elif abs(y - (top + span_h)) <= tolerance:
+                y_side = 1
+
+        return x_side, y_side
+
+    def _edge_at(self, x: float, y: float) -> Optional[Tuple[bool, bool]]:
+        """Which outer edges a point grabs, as (horizontal, vertical), or None.
+
+        A corner returns both, so dragging it resizes each axis at once.
+        """
+        x_side, y_side = self._edge_sides(x, y)
+        if not (x_side or y_side):
+            return None
+        return bool(x_side), bool(y_side)
+
+    def _count_for(self, distance: float, tile_extent: float) -> int:
+        """Rows or columns whose half-extent best matches a distance from the centre.
+
+        The grid is centred on the stage position, so it can only grow symmetrically:
+        `half = ((n - 1) * step + tile) / 2`. Inverting that is what makes the dragged
+        edge follow the cursor -- and why the count ticks up every *half* step, one
+        tile appearing on each side.
+        """
+        step = tile_extent * (1.0 - self._overlap)
+        if step <= 0:
+            return 1
+        count = round((2.0 * distance - tile_extent) / step) + 1
+        return max(1, min(MAX_TILES_PER_AXIS, int(count)))
+
+    def _on_press(self, event) -> None:
+        if event.button != 1 or event.inaxes is not self._ax or event.xdata is None:
+            return
+        if not self._visible:
+            return
+        edges = self._edge_at(event.xdata, event.ydata)
+        if edges is None:
+            return
+
+        self._resize_axes = edges
+        if self._canvas is not None:
+            # Tells the canvas an overlay owns this gesture: it cancels the pending pan
+            # and suppresses the click that would otherwise toggle a tile on release.
+            self._canvas._overlay_consuming_event = True
+
+    def _cursor_for(self, x_side: int, y_side: int):
+        """The resize cursor naming what dragging here would do, or None."""
+        if x_side and y_side:
+            # Opposite corners share a diagonal: top-left/bottom-right lie along "\",
+            # top-right/bottom-left along "/".
+            return Qt.SizeFDiagCursor if x_side == y_side else Qt.SizeBDiagCursor
+        if x_side:
+            return Qt.SizeHorCursor
+        if y_side:
+            return Qt.SizeVerCursor
+        return None
+
+    def _update_cursor(self, event) -> None:
+        """Show a resize cursor over the grid's edges.
+
+        Without it the drag is undiscoverable -- nothing on screen suggests the
+        boundary is draggable, and no one hunts for an affordance they have no reason
+        to believe exists.
+        """
+        if self._canvas is None:
+            return
+
+        cursor = None
+        if (
+            self._visible
+            and self._tiles
+            and event.inaxes is self._ax
+            and event.xdata is not None
+        ):
+            cursor = self._cursor_for(*self._edge_sides(event.xdata, event.ydata))
+
+        if cursor is not None:
+            self._canvas.setCursor(cursor)
+            self._cursor_set = True
+        elif self._cursor_set:
+            # Only unset a cursor this overlay set, so it cannot clobber one another
+            # overlay is showing.
+            self._canvas.unsetCursor()
+            self._cursor_set = False
+
+    def _on_drag(self, event) -> None:
+        if self._resize_axes is None:
+            self._update_cursor(event)
+            return
+        if event.inaxes is not self._ax:
+            return
+        if event.xdata is None or event.ydata is None:
+            return
+
+        horizontal, vertical = self._resize_axes
+        tile_h, tile_w = self._tile_shape
+        scale = self._scale()
+        rows = max(t.row for t in self._tiles) + 1
+        cols = max(t.col for t in self._tiles) + 1
+
+        if horizontal:
+            cols = self._count_for(
+                abs(event.xdata - self._img_w / 2), tile_w * scale
+            )
+        if vertical:
+            rows = self._count_for(
+                abs(event.ydata - self._img_h / 2), tile_h * scale
+            )
+
+        self.grid_resize_requested.emit(rows, cols)
+
+    def _on_release(self, event) -> None:
+        self._resize_axes = None
+        self._update_cursor(event)
+
+    def _restore_margin(self) -> None:
+        if self._previous_margin is not None and self._canvas is not None:
+            self._canvas.set_view_margin(self._previous_margin)
+            self._previous_margin = None

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -532,3 +532,154 @@ def test_collapsed_panels_do_not_stretch(qapp):
 
     heights = {p.height() for p in panels}
     assert len(heights) == 1, f"collapsed panels differ in height: {heights}"
+
+
+# ── tile grid overlay wiring ─────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def overview_widget(qapp):
+    """A real widget against the Demo microscope, for the canvas/settings wiring."""
+    from fibsem.ui.fm.overview_app import build_microscope
+    from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+
+    microscope = build_microscope()
+    widget = FMOverviewWidget(microscope)
+    widget.resize(1200, 800)
+    widget.show()
+    widget.canvas.set_fm_image(
+        microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    )
+    qapp.processEvents()
+    widget._refresh_tile_grid()
+    qapp.processEvents()
+    return widget
+
+
+def test_clicking_a_tile_updates_the_mask_the_settings_widget_owns(qapp, overview_widget):
+    """One mask, two views. The overlay must not keep its own copy -- a click routes
+    through the settings widget, and the redraw follows from that."""
+    widget = overview_widget
+    widget.settings_widget.tile_mask.mask = None
+    qapp.processEvents()
+
+    overlay = widget.tile_grid_overlay
+    tile = next(t for t in overlay._tiles if (t.row, t.col) == (0, 0))
+    x, y, tw, th = overlay._rect_for(tile)
+    overlay._on_canvas_clicked(x + tw / 2, y + th / 2, None)
+    qapp.processEvents()
+
+    assert widget.settings_widget.tile_mask.mask[0][0] is False
+    assert widget.settings_widget.tile_mask.n_enabled == 8
+    # and the overlay redrew from the widget's mask, rather than mutating its own
+    assert next(
+        t for t in overlay._tiles if (t.row, t.col) == (0, 0)
+    ).enabled is False
+
+
+def test_clicking_the_same_tile_twice_returns_it(qapp, overview_widget):
+    widget = overview_widget
+    widget.settings_widget.tile_mask.mask = None
+    qapp.processEvents()
+
+    overlay = widget.tile_grid_overlay
+    tile = next(t for t in overlay._tiles if (t.row, t.col) == (2, 1))
+    x, y, tw, th = overlay._rect_for(tile)
+
+    for _ in range(2):
+        overlay._on_canvas_clicked(x + tw / 2, y + th / 2, None)
+        qapp.processEvents()
+
+    assert widget.settings_widget.tile_mask.n_enabled == 9
+
+
+def test_resizing_the_grid_redraws_the_overlay(qapp, overview_widget):
+    widget = overview_widget
+    widget.settings_widget.tile_mask.mask = None
+    widget.settings_widget.spin_rows.setValue(5)
+    widget.settings_widget.spin_cols.setValue(4)
+    qapp.processEvents()
+
+    assert len(widget.tile_grid_overlay._tiles) == 20
+    assert len(widget.tile_grid_overlay._artists) == 20
+
+    widget.settings_widget.spin_rows.setValue(3)
+    widget.settings_widget.spin_cols.setValue(3)
+    qapp.processEvents()
+
+    assert len(widget.tile_grid_overlay._tiles) == 9
+
+
+# ── position overlay ─────────────────────────────────────────────────────
+
+
+def _offset(base, dx=0.0, dy=0.0, name=""):
+    from fibsem.structures import FibsemStagePosition
+
+    position = FibsemStagePosition(
+        x=base.x + dx, y=base.y + dy, z=base.z, r=base.r, t=base.t
+    )
+    position.name = name
+    return position
+
+
+def test_positions_are_marked_where_they_are(qapp, overview_widget):
+    widget = overview_widget
+    image = widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    widget.set_image(image)
+    base = image.metadata.stage_position
+    pixel_size = image.metadata.pixel_size_x
+    height, width = image.data.shape[-2:]
+
+    widget.set_positions([_offset(base, name="here"),
+                          _offset(base, dx=20e-6, name="right")])
+    qapp.processEvents()
+
+    points = widget.position_overlay._points
+    assert points[0] == pytest.approx((width / 2, height / 2))
+    assert points[1] == pytest.approx((width / 2 + 20e-6 / pixel_size, height / 2))
+    assert widget.position_overlay._labels == ["here", "right"]
+
+
+def test_positions_outside_the_image_are_still_marked(qapp, overview_widget):
+    """The canvas is zoomed out past the image for the tile grid, so a position beyond
+    the field of view is visible and must not be pulled to the border."""
+    widget = overview_widget
+    image = widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    widget.set_image(image)
+    base = image.metadata.stage_position
+    width = image.data.shape[-1]
+
+    widget.set_positions([_offset(base, dx=300e-6, name="far")])
+    qapp.processEvents()
+
+    assert widget.position_overlay._points[0][0] > width
+
+
+def test_an_image_without_geometry_marks_nothing_rather_than_guessing(qapp, overview_widget):
+    """Older images cannot be projected onto. Better an empty overlay than markers in
+    plausible-looking wrong places."""
+    widget = overview_widget
+    image = widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    base = image.metadata.stage_position
+    image.metadata.geometry = None
+    widget.set_image(image)
+
+    widget.set_positions([_offset(base, name="unknowable")])
+    qapp.processEvents()
+
+    assert widget.position_overlay._points == []
+
+
+def test_clearing_the_positions_clears_the_markers(qapp, overview_widget):
+    widget = overview_widget
+    image = widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    widget.set_image(image)
+    widget.set_positions([_offset(image.metadata.stage_position, name="one")])
+    qapp.processEvents()
+    assert widget.position_overlay._points
+
+    widget.set_positions([])
+    qapp.processEvents()
+
+    assert widget.position_overlay._points == []

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -683,3 +683,45 @@ def test_clearing_the_positions_clears_the_markers(qapp, overview_widget):
     qapp.processEvents()
 
     assert widget.position_overlay._points == []
+
+
+def test_setting_both_grid_dimensions_notifies_once(qapp):
+    """Nudging the two spin boxes emits four times -- twice each, since resizing the
+    mask emits again -- and passes through a grid size nobody asked for (new rows,
+    old columns). Invisible by hand; an edge drag on the canvas does it per motion
+    event, refreshing the overlay repeatedly against a size that was never requested."""
+    widget = FMOverviewSettingsWidget()
+    seen = []
+    widget.changed.connect(
+        lambda: seen.append((widget.spin_rows.value(), widget.spin_cols.value()))
+    )
+
+    widget.set_grid_size(2, 7)
+
+    assert seen == [(2, 7)]
+    assert (widget.tile_mask.grid._rows, widget.tile_mask.grid._cols) == (2, 7)
+
+
+def test_setting_the_same_grid_size_is_a_no_op(qapp):
+    widget = FMOverviewSettingsWidget()
+    rows, cols = widget.spin_rows.value(), widget.spin_cols.value()
+    seen = []
+    widget.changed.connect(lambda: seen.append(1))
+
+    widget.set_grid_size(rows, cols)
+
+    assert seen == []
+
+
+def test_a_canvas_resize_goes_through_the_settings_widget(qapp, overview_widget):
+    """The canvas is a view: a drag asks for a size, it does not hold one."""
+    widget = overview_widget
+    widget.settings_widget.set_grid_size(3, 3)
+    qapp.processEvents()
+
+    widget.tile_grid_overlay.grid_resize_requested.emit(4, 6)
+    qapp.processEvents()
+
+    assert widget.settings_widget.parameters.rows == 4
+    assert widget.settings_widget.parameters.cols == 6
+    assert len(widget.tile_grid_overlay._tiles) == 24

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -1,0 +1,453 @@
+"""The planned tile grid drawn on the canvas.
+
+The thing worth pinning is agreement with the acquisition: the grid is a *preview*, so
+if it disagrees with where tiles actually land it is worse than not drawing one. It is
+placed from the same `canvas_x/canvas_y` that `stitch_tileset` pastes with, and these
+tests hold it to that rather than to a second derivation of the same arithmetic.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
+from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import TileGridOverlay
+
+WIDTH = HEIGHT = 1024
+PIXEL_SIZE = 1e-7
+FOV = WIDTH * PIXEL_SIZE
+OVERLAP = 0.1
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+class _FakeCanvas:
+    """Just enough canvas for the overlay to draw against, without a real widget."""
+
+    _pixel_size = None
+    _view_margin = 0.0
+
+    def __init__(self):
+        self.redraws = 0
+        self.cursor = None
+
+    def draw_idle(self):
+        self.redraws += 1
+
+    def setCursor(self, cursor):   # noqa: N802 - mirrors the Qt API
+        self.cursor = cursor
+
+    def unsetCursor(self):         # noqa: N802 - mirrors the Qt API
+        self.cursor = None
+
+    def set_view_margin(self, margin):
+        self._view_margin = margin
+
+
+def build(rows=3, cols=3, overlap=OVERLAP, mask=None):
+    from matplotlib.figure import Figure
+
+    tiles = compute_tile_grid_from_fov(
+        rows, cols, FOV, FOV, WIDTH, HEIGHT, overlap, mask=mask
+    )
+    overlay = TileGridOverlay()
+    # A real axes, so the drawing tests exercise the patches rather than an early
+    # return -- `_redraw` is a no-op without one, which would make them pass empty.
+    overlay._ax = Figure().add_subplot(111)
+    overlay._canvas = _FakeCanvas()
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+    overlay._img_w, overlay._img_h = WIDTH, HEIGHT
+    return overlay, tiles
+
+
+def test_the_centre_tile_coincides_with_the_displayed_image(qapp):
+    """The middle tile of an odd grid *is* the current view -- the acquisition starts
+    where the stage already is. If it does not line up with the image, the whole grid
+    is offset and every tile is drawn somewhere the stage will not go."""
+    overlay, tiles = build(3, 3)
+    centre = next(t for t in tiles if (t.row, t.col) == (1, 1))
+
+    x, y, width, height = overlay._rect_for(centre)
+
+    assert (x, y) == (0.0, 0.0)
+    assert (width, height) == (WIDTH, HEIGHT)
+
+
+def test_tile_spacing_matches_the_overlap(qapp):
+    overlay, tiles = build(3, 3, overlap=0.1)
+    first = next(t for t in tiles if (t.row, t.col) == (1, 0))
+    second = next(t for t in tiles if (t.row, t.col) == (1, 1))
+
+    step = overlay._rect_for(second)[0] - overlay._rect_for(first)[0]
+
+    assert step == pytest.approx(WIDTH * (1 - 0.1), abs=1.0)
+
+
+def test_the_grid_extent_spans_the_whole_mosaic(qapp):
+    overlay, _ = build(3, 3, overlap=0.1)
+
+    span_w, span_h = overlay._extent()
+
+    expected = WIDTH * ((3 - 1) * (1 - 0.1) + 1)
+    assert span_w == pytest.approx(expected, abs=2.0)
+    assert span_h == pytest.approx(expected, abs=2.0)
+
+
+def test_a_click_at_a_tile_centre_finds_that_tile(qapp):
+    overlay, tiles = build(4, 4)
+
+    for tile in tiles:
+        x, y, width, height = overlay._rect_for(tile)
+        hit = overlay._tile_at(x + width / 2, y + height / 2)
+
+        assert hit is not None and (hit.row, hit.col) == (tile.row, tile.col)
+
+
+def test_a_click_in_an_overlap_picks_the_nearer_tile(qapp):
+    """Tiles overlap by design, so a click in a seam is inside two rectangles. Which
+    one wins has to be decided by distance, not by whichever comes first in the list --
+    otherwise the answer depends on the traversal order."""
+    overlay, tiles = build(3, 3, overlap=0.3)
+    left = next(t for t in tiles if (t.row, t.col) == (1, 0))
+    right = next(t for t in tiles if (t.row, t.col) == (1, 1))
+
+    lx, ly, lw, lh = overlay._rect_for(left)
+    rx, _, _, _ = overlay._rect_for(right)
+    seam_y = ly + lh / 2
+
+    just_left = overlay._tile_at(rx + 1, seam_y)          # inside both, nearer `left`
+    just_right = overlay._tile_at(lx + lw - 1, seam_y)    # inside both, nearer `right`
+
+    assert (just_left.row, just_left.col) == (1, 0)
+    assert (just_right.row, just_right.col) == (1, 1)
+
+
+def test_a_click_outside_every_tile_hits_nothing(qapp):
+    overlay, _ = build(3, 3)
+
+    assert overlay._tile_at(-5000.0, -5000.0) is None
+
+
+def test_toggling_reports_the_new_state_not_the_old(qapp):
+    overlay, tiles = build(3, 3, mask=[[False, True, True]] + [[True] * 3] * 2)
+    received = []
+    overlay.tile_toggled.connect(lambda r, c, e: received.append((r, c, e)))
+
+    disabled = next(t for t in tiles if (t.row, t.col) == (0, 0))
+    x, y, width, height = overlay._rect_for(disabled)
+    overlay._on_canvas_clicked(x + width / 2, y + height / 2, None)
+
+    assert received == [(0, 0, True)]
+
+
+def test_nothing_is_drawn_without_an_image(qapp):
+    """There is nothing to anchor or scale against, so the grid is cleared rather than
+    drawn at a guessed position."""
+    overlay, _ = build(3, 3)
+    overlay._img_w = overlay._img_h = 0
+
+    overlay._redraw()
+
+    assert overlay._artists == []
+
+
+def test_a_differing_display_pixel_size_rescales_the_grid(qapp):
+    """The canvas may be showing a mosaic binned differently from a tile. Conflating
+    the two pixel sizes would draw the grid at the wrong scale."""
+    tiles = compute_tile_grid_from_fov(3, 3, FOV, FOV, WIDTH, HEIGHT, OVERLAP)
+    overlay = TileGridOverlay()
+    overlay._img_w, overlay._img_h = WIDTH, HEIGHT
+
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+    full = overlay._rect_for(tiles[0])[2]
+
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, display_pixel_size=PIXEL_SIZE * 2)
+    half = overlay._rect_for(tiles[0])[2]
+
+    assert half == pytest.approx(full / 2)
+
+
+def test_disabled_tiles_keep_their_place_in_the_grid(qapp):
+    """A skipped tile still defines the extent and the layout -- it is simply not
+    acquired -- so removing it must not shift its neighbours."""
+    dense, _ = build(3, 3)
+    sparse, tiles = build(3, 3, mask=[[True, True, True],
+                                      [True, False, True],
+                                      [True, True, True]])
+
+    centre = next(t for t in tiles if (t.row, t.col) == (1, 1))
+    assert centre.enabled is False
+    assert sparse._extent() == dense._extent()
+    assert sparse._rect_for(centre) == dense._rect_for(
+        next(t for t in dense._tiles if (t.row, t.col) == (1, 1))
+    )
+
+
+# ── display options ──────────────────────────────────────────────────────
+
+
+def test_hiding_the_grid_repaints_the_canvas(qapp):
+    """Regression: dropping the artists takes them out of the axes, but the canvas goes
+    on showing its last render until asked to redraw -- so "show grid" appeared to do
+    nothing. Asserting on `_artists` alone missed this, because the list was correct
+    and the screen was not."""
+    overlay, _ = build(3, 3)
+    overlay._redraw()
+    before = overlay._canvas.redraws
+
+    overlay.set_grid_visible(False)
+
+    assert overlay._canvas.redraws > before
+
+
+def test_hiding_the_grid_removes_the_artists_but_keeps_the_tiles(qapp):
+    """Hidden, not discarded: toggling back must not need the grid rebuilt, and the
+    tile selection is unaffected either way."""
+    overlay, tiles = build(3, 3)
+    overlay._redraw()
+    assert overlay._artists
+
+    overlay.set_grid_visible(False)
+    assert overlay._artists == []
+    assert len(overlay._tiles) == len(tiles)
+    assert overlay.is_grid_visible is False
+
+    overlay.set_grid_visible(True)
+    assert len(overlay._artists) == len(tiles)
+
+
+def test_the_fill_alpha_is_clamped(qapp):
+    overlay, _ = build(2, 2)
+
+    overlay.set_fill_alpha(5.0)
+    assert overlay._fill_alpha == 1.0
+
+    overlay.set_fill_alpha(-1.0)
+    assert overlay._fill_alpha == 0.0
+
+
+def test_the_scale_follows_the_canvas_pixel_size(qapp):
+    """Regression: the live preview swaps a decimated mosaic in mid-run, so a scale
+    captured when the grid was built drew it `preview_stride` times too large over the
+    very image it describes."""
+
+    overlay, _ = build(3, 3)
+    overlay._display_pixel_size = None      # not pinned -> read from the canvas
+    overlay._canvas._pixel_size = PIXEL_SIZE * 2
+
+    assert overlay._scale() == pytest.approx(0.5)
+
+    overlay._canvas._pixel_size = PIXEL_SIZE * 4
+    assert overlay._scale() == pytest.approx(0.25)
+
+
+def test_skipped_tiles_are_grey_regardless_of_the_grid_colour(qapp):
+    """Colour is what marks a tile inactive at a glance; the chosen grid colour applies
+    to the tiles that will actually be acquired."""
+    overlay, _ = build(3, 3, mask=[[False, True, True]] + [[True] * 3] * 2)
+    overlay.set_color("#00e5ff")
+    overlay._redraw()
+
+    hues = {patch.get_edgecolor()[:3] for patch in overlay._artists}
+    assert len(hues) == 2, "skipped and acquired tiles should differ in colour"
+
+
+# ── resize by dragging an edge ───────────────────────────────────────────
+
+
+def _event(overlay, x, y, button=1):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        button=button, inaxes=overlay._ax, xdata=x, ydata=y, x=0, y=0
+    )
+
+
+def _edges(overlay):
+    span_w, span_h = overlay._extent()
+    return (
+        overlay._img_w / 2 + span_w / 2,   # right
+        overlay._img_h / 2 + span_h / 2,   # bottom
+    )
+
+
+def test_only_the_outer_edges_grab(qapp):
+    """The middle of the grid must stay clickable and pannable -- an edge grab that
+    also fired in the interior would make tile toggling impossible."""
+    overlay, _ = build(3, 3, overlap=OVERLAP)
+    right, bottom = _edges(overlay)
+
+    assert overlay._edge_at(right, overlay._img_h / 2) == (True, False)
+    assert overlay._edge_at(overlay._img_w / 2, bottom) == (False, True)
+    assert overlay._edge_at(right, bottom) == (True, True)      # corner: both axes
+    assert overlay._edge_at(overlay._img_w / 2, overlay._img_h / 2) is None
+
+
+def test_the_bounding_lines_do_not_grab_far_outside_the_grid(qapp):
+    """The edges are line segments, not infinite lines: a point level with the right
+    edge but far below the grid is not on it."""
+    overlay, _ = build(3, 3)
+    right, bottom = _edges(overlay)
+
+    assert overlay._edge_at(right, bottom + overlay._img_h) is None
+
+
+def test_dragging_an_edge_outward_adds_tiles_symmetrically(qapp):
+    """The grid is centred on the stage position, so it can only grow both ways at
+    once -- the count ticks up every half step, one tile appearing on each side."""
+    overlay, _ = build(3, 3, overlap=OVERLAP)
+    requested = []
+    overlay.grid_resize_requested.connect(lambda r, c: requested.append((r, c)))
+    right, _ = _edges(overlay)
+
+    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+    overlay._on_drag(_event(overlay, right + WIDTH, overlay._img_h / 2))
+
+    rows, cols = requested[-1]
+    assert rows == 3, "dragging a vertical edge must not change the row count"
+    assert cols > 3
+
+
+def test_dragging_an_edge_inward_removes_tiles(qapp):
+    overlay, _ = build(5, 5, overlap=OVERLAP)
+    requested = []
+    overlay.grid_resize_requested.connect(lambda r, c: requested.append((r, c)))
+    right, _ = _edges(overlay)
+
+    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+    overlay._on_drag(_event(overlay, right - 2 * WIDTH, overlay._img_h / 2))
+
+    assert requested[-1][1] < 5
+
+
+def test_the_dragged_edge_follows_the_cursor(qapp):
+    """Within half a step -- the finest the count can express, since a tile appears on
+    each side at once."""
+    overlay, _ = build(3, 3, overlap=OVERLAP)
+    resized = []
+    overlay.grid_resize_requested.connect(lambda r, c: resized.append((r, c)))
+    right, _ = _edges(overlay)
+    step = WIDTH * (1 - OVERLAP)
+    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+
+    for target in (right + step, right + 2 * step, right - step):
+        overlay._on_drag(_event(overlay, target, overlay._img_h / 2))
+        rows, cols = resized[-1]
+        # rebuild at the requested size and measure where its edge landed
+        grown, _ = build(rows, cols, overlap=OVERLAP)
+        landed = grown._img_w / 2 + grown._extent()[0] / 2
+
+        assert abs(landed - target) <= step / 2 + 1
+
+
+def test_a_drag_never_shrinks_past_a_single_tile(qapp):
+    overlay, _ = build(3, 3, overlap=OVERLAP)
+    resized = []
+    overlay.grid_resize_requested.connect(lambda r, c: resized.append((r, c)))
+    right, _ = _edges(overlay)
+    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+
+    overlay._on_drag(_event(overlay, overlay._img_w / 2, overlay._img_h / 2))
+
+    assert resized[-1][1] >= 1
+
+
+def test_a_press_away_from_an_edge_starts_no_resize(qapp):
+    overlay, _ = build(3, 3)
+
+    overlay._on_press(_event(overlay, overlay._img_w / 2, overlay._img_h / 2))
+
+    assert overlay.is_resizing is False
+
+
+def test_a_press_on_an_edge_claims_the_gesture_from_the_canvas(qapp):
+    """Otherwise the drag pans the view underneath the resize, and the release fires a
+    tile toggle on top of it."""
+    overlay, _ = build(3, 3)
+    overlay._canvas._overlay_consuming_event = False
+    right, _ = _edges(overlay)
+
+    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+
+    assert overlay.is_resizing is True
+    assert overlay._canvas._overlay_consuming_event is True
+
+    overlay._on_release(_event(overlay, right, overlay._img_h / 2))
+    assert overlay.is_resizing is False
+
+
+def test_a_hidden_grid_cannot_be_resized(qapp):
+    overlay, _ = build(3, 3)
+    right, _ = _edges(overlay)
+    overlay.set_grid_visible(False)
+
+    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+
+    assert overlay.is_resizing is False
+
+
+# ── hover affordance ─────────────────────────────────────────────────────
+
+
+def _corners(overlay):
+    span_w, span_h = overlay._extent()
+    cx, cy = overlay._img_w / 2, overlay._img_h / 2
+    return cx - span_w / 2, cx + span_w / 2, cy - span_h / 2, cy + span_h / 2
+
+
+@pytest.mark.parametrize(
+    "corner, expected",
+    [
+        ("top-left", "SizeFDiagCursor"),
+        ("bottom-right", "SizeFDiagCursor"),
+        ("top-right", "SizeBDiagCursor"),
+        ("bottom-left", "SizeBDiagCursor"),
+    ],
+)
+def test_opposite_corners_share_a_diagonal_cursor(qapp, corner, expected):
+    """Top-left and bottom-right lie along one diagonal, the other two along the other.
+    Getting this backwards points the cursor across the edge it would drag."""
+    from PyQt5.QtCore import Qt
+
+    overlay, _ = build(3, 3)
+    left, right, top, bottom = _corners(overlay)
+    x = left if "left" in corner else right
+    y = top if "top" in corner else bottom
+
+    cursor = overlay._cursor_for(*overlay._edge_sides(x, y))
+
+    assert cursor == getattr(Qt, expected)
+
+
+def test_the_edges_get_axis_cursors_and_the_interior_none(qapp):
+    from PyQt5.QtCore import Qt
+
+    overlay, _ = build(3, 3)
+    left, right, top, bottom = _corners(overlay)
+    cx, cy = overlay._img_w / 2, overlay._img_h / 2
+
+    assert overlay._cursor_for(*overlay._edge_sides(right, cy)) == Qt.SizeHorCursor
+    assert overlay._cursor_for(*overlay._edge_sides(left, cy)) == Qt.SizeHorCursor
+    assert overlay._cursor_for(*overlay._edge_sides(cx, top)) == Qt.SizeVerCursor
+    assert overlay._cursor_for(*overlay._edge_sides(cx, bottom)) == Qt.SizeVerCursor
+    assert overlay._cursor_for(*overlay._edge_sides(cx, cy)) is None
+
+
+def test_a_hidden_grid_shows_no_resize_cursor(qapp):
+    """Nothing is drawn to grab, so promising a drag would be a lie."""
+    overlay, _ = build(3, 3)
+    _, right, _, _ = _corners(overlay)
+    overlay.set_grid_visible(False)
+
+    overlay._update_cursor(_event(overlay, right, overlay._img_h / 2))
+
+    assert overlay._cursor_set is False

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -451,3 +451,17 @@ def test_a_hidden_grid_shows_no_resize_cursor(qapp):
     overlay._update_cursor(_event(overlay, right, overlay._img_h / 2))
 
     assert overlay._cursor_set is False
+
+
+def test_a_drag_survives_the_grid_being_cleared_underneath_it(qapp):
+    """`_refresh_tile_grid` clears the grid when the camera geometry cannot be read,
+    which can happen between two motion events of a drag. The row and column counts
+    are derived from the tiles, so an empty grid raised on `max()` -- and an exception
+    escaping a handler can take the app down (FIB-329)."""
+    overlay, _ = build(3, 3, overlap=OVERLAP)
+    right, _ = _edges(overlay)
+    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+
+    overlay.clear()
+
+    overlay._on_drag(_event(overlay, right + WIDTH, overlay._img_h / 2))


### PR DESCRIPTION
Shows where an overview acquisition will put its tiles *before* it runs, on the image rather than as a row of spin boxes — and lets the selection be edited in place.

Builds on #243 (FM reprojection) for the position markers.

## What it does

- **Click a tile** to include or exclude it
- **Drag an outer edge or corner** to add/remove rows and columns
- **Hover an edge** for a resize cursor, so the drag is discoverable
- Canvas toolbar button opens display options: summary, show/hide, colour, fill opacity
- `set_positions()` marks stage positions (lamellae, etc.), reprojected through the image's own geometry

## Design notes for review

**Placement comes from `TilePosition.canvas_x/canvas_y`** — the offsets `stitch_tileset` actually pastes at — not recomputed from the metre offsets `dx/dy`. Both would work, but only one is the number the stitcher uses, so the preview cannot disagree with the mosaic it previews. It also avoids restating a sign convention the runner applies asymmetrically (`dx - offset` but `dy + offset`); getting that backwards draws a plausible, upside-down grid.

**The overlay owns no state.** Clicks and drags are emitted as signals; the widget applies them to the settings widget, which already owns the mask and the row/column counts. The redraw follows from that. Two views, one model — the same reason the confirmation dialog reads its numbers rather than recomputing them.

**Growth is symmetric, unavoidably.** The grid is centred on the stage position and the runner centres it there (`grid_offset_x = (cols-1) * step / 2`), so dragging one edge moves the opposite edge too, and crossing one tile-width adds *two* columns. Asymmetric drags would need an offset field in `OverviewParameters` and runner changes — a data-model change, deliberately not attempted here.

**The grid is a regular lattice at any stage tilt.** Tiles are *defined* by displayed-frame offsets handed to `project_fm_stable_move`, so the tilt is absorbed into the stage moves, not into where tiles appear. (I initially assumed the opposite and was wrong.)

**Display options are read-only about the acquisition.** Rows/columns already have a home in the settings column; a second set of spin boxes would be a second place to edit one value. Dragging an edge is different — it is spatial, with no equivalent expression as a number.

## Two bugs found while building it

Both invisible without looking at the screen, and one had a passing test:

1. **Live preview scaling.** The preview is a mosaic decimated by `preview_stride`, but nothing told the canvas its pixels were coarser than a tile's — so anything drawn over it was scaled `stride`× too large (measured 2× and 4× at strides 2 and 4). The canvas is now told, and the overlay reads the scale at draw time rather than caching it at build time.

2. **Invisible outlines.** Matplotlib's `alpha=` applies to the *edge* as well as the face, so outlines were drawn at the fill's opacity — which is why the grid could only be seen by turning the fill up until it obscured the data. Alpha is now baked into the face colour alone; outlines-only is the default.

Separately: **"Show grid" did nothing** despite a passing test. The early return in `_redraw` dropped the artists but never called `draw_idle`, so the canvas kept showing its last render. The test asserted `_artists == []`, which was true — it checked the model where the bug lived in the repaint. Replaced with one that asserts a redraw was requested.

And **refitting the view** now happens only when the grid's footprint changes, and never mid-drag: refitting on a tile toggle discarded the user's zoom, which read as *clicking a tile zooms the canvas*.

## Verification

235 UI tests (24 for the overlay), full suite green — 1745 passed, 24 skipped.

Verified interactively on the Demo simulator: geometry against the stitched placement, drag tracking (edge follows the cursor within half a step), all eight hover cases including the corner diagonals, and click-still-works-after-drag.

## Known gaps

- The grid needs an image on the canvas to anchor and scale against; the standalone app acquires none at startup, so it stays invisible until something is displayed. Deliberate, but it makes the pre-acquisition preview awkward to preview.
- `set_positions()` has no caller yet — wiring it to a lamella list belongs to whatever embeds the widget.
- The edge grab zone is 8% of a tile, chosen by eye and verified programmatically rather than by feel.