### PR TITLE
[ui] Give the canvas a public pixel_size and set_title (FIB-351)

### DIFF
--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -291,9 +291,7 @@ class FMCanvasWidget(QWidget):
     def set_pixel_size(self, pixel_size: Optional[float]) -> None:
         self._pixel_size = pixel_size
         if pixel_size and self._canvas_shape is not None:
-            self.canvas._pixel_size = pixel_size
-            self.canvas._refresh_scalebar()
-            self.canvas.draw_idle()
+            self.canvas.pixel_size = pixel_size  # rescales the scalebar + redraws
 
     def clear(self) -> None:
         self._layers = []

--- a/fibsem/ui/widgets/canvas/image_canvas.py
+++ b/fibsem/ui/widgets/canvas/image_canvas.py
@@ -161,6 +161,8 @@ class FibsemImageCanvas(FigureCanvasQTAgg):
         self._crosshair_artists: list = []
         self._hint_artist = None  # transient top-left instruction hint
         self._hint_text: Optional[str] = None  # remembered so it survives set_image
+        self._title_artist = None  # top-centre image caption (e.g. FM z-slice)
+        self._title_text: Optional[str] = None  # remembered so it survives set_image
         self._info_artist = None  # bottom-left microscope-state info bar
         self._info_text: Optional[str] = None  # remembered so it survives set_image
         self._live_artist = None  # top-right "LIVE" badge during live acquisition
@@ -244,6 +246,30 @@ class FibsemImageCanvas(FigureCanvasQTAgg):
     def img_height(self) -> Optional[int]:
         return self._img_h
 
+    @property
+    def pixel_size(self) -> Optional[float]:
+        """Metres per pixel of the displayed image, or None if not known.
+
+        Companion to :attr:`img_width` / :attr:`img_height` — together they let a
+        caller convert canvas pixel coordinates to physical units. Normally set from
+        the *pixel_size* argument to :meth:`set_array` / :meth:`update_display`.
+        """
+        return self._pixel_size
+
+    @pixel_size.setter
+    def pixel_size(self, value: Optional[float]) -> None:
+        """Rescale the scalebar to a new metres/px, for a caller that owns the scale
+        independently of the pixel data (e.g. the FM canvas, which composites layers
+        and sets the scale separately from the RGB frame).
+
+        Note the None semantics differ from the *pixel_size* argument of
+        :meth:`set_array` / :meth:`update_display`, where None means "leave unchanged":
+        assigning None here is an explicit "no longer known" and drops the scalebar.
+        """
+        self._pixel_size = value
+        self._refresh_scalebar()
+        self.draw_idle()
+
     # ── public API ────────────────────────────────────────────────────────
 
     def set_image(self, image: FibsemImage, cmap: str = "gray") -> None:
@@ -312,6 +338,7 @@ class FibsemImageCanvas(FigureCanvasQTAgg):
         self._refresh_scalebar()
         self._refresh_crosshair()
         self._refresh_hint()  # axes was cleared above; restore the remembered hint
+        self._refresh_title()  # ditto: restore the remembered title
         self._refresh_info_bar()  # ditto: restore the remembered info bar
         self._refresh_live_badge()  # ditto: keep the LIVE badge across streamed frames
         self._refresh_flash()  # ditto: keep a live flash (e.g. WD scroll) visible across frames
@@ -387,6 +414,42 @@ class FibsemImageCanvas(FigureCanvasQTAgg):
                 fontsize=8, color="#1a1a1a", zorder=11,
                 bbox=dict(boxstyle="round,pad=0.3", facecolor="#e6e6e6",
                           edgecolor="none", alpha=0.85),
+            )
+
+    def set_title(self, text: Optional[str]) -> None:
+        """Show a caption centred at the top of the image, or hide with None/''.
+
+        For labelling what the frame *is* (e.g. an FM z-slice index), as opposed to
+        the instruction hint (top-left) or the microscope-state info bar (bottom-left).
+        Remembered + re-applied after each image change, like the hint.
+
+        Deliberately drawn inside the axes rather than via ``Axes.set_title``: the
+        figure is laid out edge-to-edge (``subplots_adjust(top=1)``), so a real axes
+        title lands above the figure and is clipped whenever the pane is wider in
+        aspect than the image — e.g. any square frame in a wide pane.
+
+        Shares the top-centre slot with :meth:`flash_message`, which is drawn above it
+        for the second or so it is on screen.
+        """
+        self._title_text = text or None
+        self._refresh_title()
+        self.draw_idle()
+
+    def _refresh_title(self) -> None:
+        """(Re)create the title artist from the cached text, or remove it."""
+        if self._title_artist is not None:
+            try:
+                self._title_artist.remove()
+            except Exception:
+                pass
+            self._title_artist = None
+        if self._title_text:
+            self._title_artist = self._ax.text(
+                0.5, 0.985, self._title_text,
+                transform=self._ax.transAxes, ha="center", va="top",
+                fontsize=10, color="#ffffff", zorder=11,
+                bbox=dict(boxstyle="round,pad=0.3", facecolor=_BG,
+                          edgecolor="none", alpha=0.55),
             )
 
     def set_info_text(self, text: Optional[str]) -> None:
@@ -537,6 +600,8 @@ class FibsemImageCanvas(FigureCanvasQTAgg):
         self._crosshair_artists = []
         self._hint_artist = None  # removed by cla(); drop the cached text too
         self._hint_text = None
+        self._title_artist = None
+        self._title_text = None
         self._info_artist = None
         self._info_text = None
         self._live_artist = None

--- a/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
@@ -99,7 +99,7 @@ class RulerOverlay(CanvasOverlay):
     def on_image_changed(self, width: int, height: int) -> None:
         self._img_w, self._img_h = width, height
         if self._canvas is not None:
-            self._pixel_size = self._canvas._pixel_size
+            self._pixel_size = self._canvas.pixel_size
         if self._ax is None or width == 0 or height == 0 or not self._visible:
             self._remove_artists()  # inert while hidden / between images
             return

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -273,7 +273,7 @@ class _FmImageCanvas(QWidget):
                 self.canvas.set_array(frame, pixel_size=px)
             else:
                 self.canvas.update_display(frame, pixel_size=px)
-            self.canvas._ax.set_title(f"FM  z={z}/{nz - 1}", color="white", fontsize=10)
+            self.canvas.set_title(f"FM  z={z}/{nz - 1}")
             self.canvas.draw_idle()
         except Exception:
             logging.exception("Error plotting FM z-slice")
@@ -2163,7 +2163,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         stage = self._get_selected_stage()
         if stage is None:
             return
-        pixel_size = self.fib_canvas.canvas._pixel_size
+        pixel_size = self.fib_canvas.canvas.pixel_size
         img_w = self.fib_canvas.canvas.img_width
         img_h = self.fib_canvas.canvas.img_height
         if not pixel_size or not img_w or not img_h:
@@ -2191,7 +2191,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         """Translate a FIB rect drag into a pattern position update via _move_patterns."""
         if self.milling_viewer_widget is None:
             return
-        pixel_size = self.fib_canvas.canvas._pixel_size
+        pixel_size = self.fib_canvas.canvas.pixel_size
         img_w = self.fib_canvas.canvas.img_width
         img_h = self.fib_canvas.canvas.img_height
         if not pixel_size or not img_w or not img_h:
@@ -2279,7 +2279,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         """Stable-move the stage to the double-clicked position on the FIB canvas."""
         if self._is_milling_active:
             return
-        pixel_size = self.fib_canvas.canvas._pixel_size
+        pixel_size = self.fib_canvas.canvas.pixel_size
         img_w = self.fib_canvas.canvas.img_width
         img_h = self.fib_canvas.canvas.img_height
         if not pixel_size or not img_w or not img_h:

--- a/fibsem/ui/widgets/tests/test_canvas_pixel_size.py
+++ b/fibsem/ui/widgets/tests/test_canvas_pixel_size.py
@@ -1,0 +1,93 @@
+"""Headless smoke: FibsemImageCanvas.pixel_size — the public metres/px accessor.
+
+The scale used to be reachable only as the private ``_pixel_size``, so callers that own
+the scale independently of the pixel data poked the attribute and then called the private
+``_refresh_scalebar()`` by hand. The property is the supported route for both directions;
+these tests pin the parts that would break silently — that assigning it actually rebuilds
+the scalebar, and that its None semantics differ from set_array's argument.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_canvas_pixel_size.py
+"""
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _canvas(pixel_size=1.0e-7):
+    c = FibsemImageCanvas()
+    c.set_array(np.zeros((64, 64)), pixel_size=pixel_size)
+    return c
+
+
+def test_reads_back_what_set_array_was_given():
+    assert _canvas(2.5e-8).pixel_size == 2.5e-8
+
+
+def test_assigning_rebuilds_the_scalebar():
+    """The old hand-rolled sequence was `_pixel_size = x; _refresh_scalebar()`. A setter
+    that skipped the refresh would leave a scalebar drawn at the previous scale."""
+    c = _canvas()
+    before = c._scalebar_artist
+    assert before is not None, "no scalebar to begin with"
+
+    c.pixel_size = 5.0e-7
+    assert c.pixel_size == 5.0e-7
+    assert c._scalebar_artist is not None
+    assert c._scalebar_artist is not before, "scalebar not rebuilt at the new scale"
+    assert c._scalebar_artist.dx == 5.0e-7
+
+
+def test_assigning_none_drops_the_scalebar():
+    """Unlike the *pixel_size* argument of set_array / update_display, where None means
+    "leave unchanged", assigning None is an explicit "no longer known"."""
+    c = _canvas()
+    c.pixel_size = None
+    assert c.pixel_size is None
+    assert c._scalebar_artist is None
+
+    c.set_array(np.zeros((64, 64)), pixel_size=None)  # argument form: leaves it alone
+    assert c.pixel_size is None
+
+
+def test_set_array_none_argument_keeps_the_existing_scale():
+    c = _canvas(3.0e-8)
+    c.set_array(np.zeros((32, 32)), pixel_size=None)
+    assert c.pixel_size == 3.0e-8
+
+
+def test_fm_canvas_widget_pushes_its_scale_through_the_property():
+    """FMCanvasWidget composites its own RGB and owns the scale separately from the
+    frame, so it sets the canvas scale directly rather than via set_array."""
+    fm = FMCanvasWidget()
+    fm.set_channel("DAPI", np.zeros((64, 64), dtype=np.uint16), "blue")
+    fm.set_pixel_size(1.0e-7)
+    assert fm.canvas.pixel_size == 1.0e-7
+    assert fm.canvas._scalebar_artist is not None
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fibsem/ui/widgets/tests/test_coincidence_viewer_canvas.py
+++ b/fibsem/ui/widgets/tests/test_coincidence_viewer_canvas.py
@@ -8,8 +8,9 @@ with *two* ``mdi:contrast-box`` buttons.
 
 These tests pin the parts that would break silently: exactly one contrast button per
 canvas, the rect/arrow overlays, the raw-frame display path (the canvas normalises
-internally now, so the widget must not pre-process), and the private canvas members
-the widget still reaches into.
+internally now, so the widget must not pre-process), and the public canvas API the
+widget drives in place of the private members it used to reach into
+(``pixel_size`` and ``set_title``).
 
 Run directly (no display needed):
     QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_coincidence_viewer_canvas.py
@@ -152,8 +153,46 @@ def test_fm_set_image_renders_and_sets_the_scalebar():
     assert widget.canvas._ax.get_images(), "FM canvas rendered nothing"
     assert widget.canvas._img_w == 768 and widget.canvas._img_h == 512
     # pixel_size comes from metadata.pixel_size_x, which the FibsemImage path can't source
-    assert widget.canvas._pixel_size == 1.0e-7
-    assert "FM  z=0/2" in widget.canvas._ax.get_title()
+    assert widget.canvas.pixel_size == 1.0e-7
+    assert widget.canvas._title_artist in widget.canvas._ax.texts, "z-slice title not drawn"
+    assert "FM  z=0/2" in widget.canvas._title_artist.get_text()
+
+
+def test_fm_title_is_drawn_inside_the_axes_not_as_a_clipped_axes_title():
+    """The canvas lays the figure out edge-to-edge (subplots_adjust(top=1)), so a real
+    ``Axes.set_title`` renders *above* the figure and is invisible whenever the pane is
+    wider in aspect than the image. The title must be an in-axes artist instead."""
+    widget = _FmImageCanvas()
+    widget.canvas._fig.set_size_inches(10, 2)  # pane far wider than the 768x512 frame
+    widget.set_image(_fm_stack())
+    widget.canvas.draw()
+
+    assert widget.canvas._ax.get_title() == "", "still using the clipped axes title"
+    _, fig_h = widget.canvas.get_width_height()
+    bbox = widget.canvas._title_artist.get_window_extent(widget.canvas.get_renderer())
+    assert 0 <= bbox.y0 and bbox.y1 <= fig_h, f"title outside the figure: {bbox}"
+
+
+def test_canvas_title_survives_an_image_change():
+    """set_array clears the axes, so the title has to be remembered and re-applied the
+    way the hint / info bar / legend are — otherwise it vanishes on the next frame.
+
+    Driven against the bare canvas on purpose: the FM widget re-sets the title after
+    every set_array, so going through _FmImageCanvas would pass either way.
+    """
+    canvas = FibsemImageCanvas()
+    canvas.set_array(np.zeros((512, 768)), pixel_size=1.0e-7)
+    canvas.set_title("FM  z=0/2")
+    assert canvas._title_artist is not None
+
+    canvas.set_array(np.zeros((256, 256)), pixel_size=1.0e-7)  # resolution change
+    assert canvas._title_text == "FM  z=0/2", "title text must survive an image change"
+    # Membership in _ax.texts, not `is not None`: cla() detaches the artist but leaves
+    # the attribute pointing at it, so an identity check passes on a vanished title.
+    assert canvas._title_artist in canvas._ax.texts, "title not re-attached after reset"
+
+    canvas.set_title(None)  # explicit clear
+    assert canvas._title_artist is None and canvas._title_text is None
 
 
 def test_fm_same_shape_update_is_a_data_swap_not_an_axes_reset():


### PR DESCRIPTION
Follow-up to #242, which took the coincidence viewer's reach-ins into `FibsemImageCanvas` from 19 to 4 and removed every write. The four left were three reads of `_pixel_size` that convert rectangle dimensions to physical units, and an `_ax.set_title` for the FM z-slice label. Production reach-ins into the canvas' pixel size are now zero.

## `pixel_size` property

Sits next to `img_width` / `img_height`, which all three call sites already read on the adjacent lines:

```python
pixel_size = self.fib_canvas.canvas._pixel_size   →   .pixel_size
img_w = self.fib_canvas.canvas.img_width
img_h = self.fib_canvas.canvas.img_height
```

It has a setter too, which lets `FMCanvasWidget` drop a hand-rolled three-liner — it composites its own RGB and owns the scale separately from the frame, so it can't carry the scale through `set_array`:

```python
self.canvas._pixel_size = pixel_size
self.canvas._refresh_scalebar()      →    self.canvas.pixel_size = pixel_size
self.canvas.draw_idle()
```

That was the actual value: the old site wasn't just poking an attribute, it was also calling a private refresh and hand-driving the redraw, so a caller who forgot either got a scalebar stuck at the previous scale.

**One asymmetry to check when reviewing.** `None` means different things on the setter and on the `set_array` argument. `set_array(pixel_size=None)` means "leave unchanged" (existing behaviour — the guard is `if pixel_size and pixel_size > 0`), while `canvas.pixel_size = None` is an explicit "no longer known" and drops the scalebar. Mirroring the argument would leave no way to clear the scale at all, so they're deliberately distinct, documented on both, and pinned against each other by two tests.

## `set_title`

A fifth text affordance rather than a wrapper over `Axes.set_title`, because **the axes title was mostly not rendering.** `set_array` lays the figure out edge-to-edge (`subplots_adjust(top=1)`), so with `aspect="equal"` the axes only leaves room above itself when it letterboxes — that is, when the pane is narrower in aspect than the image. Any square FM frame in a wider-than-tall pane drew nothing at all. Confirmed by pixel-diffing rendered output, which came back byte-identical with and without the title.

So it's drawn in axes-fraction coords at top-centre with a bbox (the old title sat on figure background and needed none; in-axes over bright data it does), and is remembered and re-applied through `_refresh_title` after each image change the way the hint / info bar / legend are, since `set_array` clears the axes.

Kept the signature as `set_title(text)` rather than exposing `color=` / `fontsize=`: the other four affordances all take content only and own their styling, and the sole caller just wanted white/10.

**Unchanged behaviour worth recording:** the FM label always reads `z=0/N`. `_show_slice` is only ever called with `z=0` — the widget has no z-slider, only a timelapse scrubber.

## Also

The ruler overlay's read moves to the property. `FMCanvasWidget`'s two `_reposition_overlay_buttons()` calls stay as they are — in-package sibling access rather than a cross-widget reach-in.

## Tests

105 pass in `fibsem/ui/widgets/tests/` (was 100). `test_canvas_pixel_size.py` is new because `set_pixel_size` had no headless coverage at all — `test_fm_canvas.py` is a GUI harness with a `main()` window, so pytest collects nothing from it.

Every new test was checked by mutating the source and re-running. Two were blind on the first pass:

- Asserting `_title_artist is not None` passes even when the title has vanished, because `cla()` detaches the artist but leaves the attribute pointing at it. The check has to be membership in `_ax.texts`.
- Driving the re-apply test through `_FmImageCanvas` passes either way, since `_show_slice` re-sets the title immediately after `set_array`. It has to run against a bare canvas to exercise the contract.

With those fixed: removing `_refresh_title()` from `set_array` fails the survival test, reverting the call site to `_ax.set_title` fails the clipping test, stripping `_refresh_scalebar()` from the setter fails three, and neutering the `fm_canvas` call site fails the FM one.

Pre-existing and unrelated: `test_saved_position_widget.py` and `test_toast.py` fail collection (`TestWindow` classes with `__init__`), identically on `main`.
