### PR TITLE
[ui] Give canvas overlays a content rect instead of an image size (FIB-410)

### DIFF
--- a/fibsem/ui/widgets/canvas/__init__.py
+++ b/fibsem/ui/widgets/canvas/__init__.py
@@ -31,7 +31,7 @@ from fibsem.ui.widgets.canvas.canvas_state import (
     SceneModel,
 )
 from fibsem.ui.widgets.canvas.fm_composite import FMLayer, composite_fm_layers
-from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase
+from fibsem.ui.widgets.canvas.canvas_base import ContentRect, FibsemCanvasBase
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
 from fibsem.ui.widgets.canvas.quad_view import (
@@ -43,6 +43,7 @@ from fibsem.ui.widgets.canvas.quad_view import (
 __all__ = [
     # canvas_base
     "FibsemCanvasBase",
+    "ContentRect",
     # image_canvas
     "FibsemImageCanvas",
     # fm_canvas

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import logging
 import math
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
@@ -50,6 +51,51 @@ if TYPE_CHECKING:
     from fibsem.ui.widgets.canvas.overlays.ruler_overlay import RulerOverlay
 
 _logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ContentRect:
+    """The region overlays clamp and anchor to, in canvas coordinates.
+
+    For a canvas holding one image this is ``(0, 0, width, height)`` — the image's
+    pixel grid, so ``x0``/``y0`` are zero and the arithmetic is the same as the
+    ``(width, height)`` pair this replaced. For a canvas holding many images placed
+    in stage space it is their union, whose origin is *not* the coordinate origin.
+    Overlays should therefore anchor with :attr:`cx` / :attr:`cy` and clamp against
+    :attr:`x0` / :attr:`x1` rather than assuming content starts at (0, 0).
+
+    Distinct from the canvas's matplotlib extent (``_content_extent``), which carries
+    imshow's half-pixel offset and exists only to fit the view.
+    """
+
+    x0: float
+    y0: float
+    width: float
+    height: float
+
+    @property
+    def x1(self) -> float:
+        return self.x0 + self.width
+
+    @property
+    def y1(self) -> float:
+        return self.y0 + self.height
+
+    @property
+    def cx(self) -> float:
+        """Horizontal centre — where an overlay with no better anchor should sit."""
+        return self.x0 + self.width / 2.0
+
+    @property
+    def cy(self) -> float:
+        return self.y0 + self.height / 2.0
+
+    @property
+    def is_empty(self) -> bool:
+        return self.width <= 0 or self.height <= 0
+
+
+EMPTY_CONTENT = ContentRect(0.0, 0.0, 0.0, 0.0)
 
 _LIVE_BADGE_BG = "#2e7d32"  # dark green behind the white "● LIVE" badge
 _MAX_DISPLAY_PX = 2048
@@ -512,11 +558,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._legend_artist = None  # removed by cla(); drop the cached entries too
         self._legend_entries = None
         self._plot_empty()
-        for overlay in self._overlays:
-            try:
-                overlay.on_image_changed(0, 0)
-            except Exception:
-                pass
+        self._notify_overlays(EMPTY_CONTENT)
         self.draw_idle()
 
     # ── overlay buttons ───────────────────────────────────────────────────
@@ -595,6 +637,38 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         if contrast is not None and contrast.isVisible():
             contrast.reposition()
 
+    def _content_rect(self) -> ContentRect:
+        """The rectangle overlays clamp and anchor to.
+
+        Defaults to the content size recorded by the subclass, anchored at the origin
+        — correct for a single image. A canvas that places content away from the
+        origin (e.g. images positioned in stage space) overrides this.
+        """
+        if self._img_w is None or self._img_h is None:
+            return EMPTY_CONTENT
+        return ContentRect(0.0, 0.0, self._img_w, self._img_h)
+
+    def _notify_overlay(self, overlay, rect: ContentRect) -> None:
+        """Tell one overlay the content rectangle changed.
+
+        Prefers the rect-based ``on_content_changed``; falls back to the older
+        ``on_image_changed(width, height)`` so a duck-typed overlay written against
+        the previous protocol keeps working untouched.
+        """
+        handler = getattr(overlay, "on_content_changed", None)
+        if handler is None:
+            overlay.on_image_changed(rect.width, rect.height)
+        else:
+            handler(rect)
+
+    def _notify_overlays(self, rect: ContentRect) -> None:
+        """Broadcast a content change to every registered overlay."""
+        for overlay in self._overlays:
+            try:
+                self._notify_overlay(overlay, rect)
+            except Exception:
+                _logger.exception("Overlay content update failed: %r", overlay)
+
     def _content_extent(self) -> Optional[Tuple[float, float, float, float]]:
         """Extent of the drawn content as ``(xmin, xmax, ymax, ymin)``, or None if empty.
 
@@ -641,9 +715,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         overlay.attach(self._ax, self)
         if self._img_w is not None:
             try:
-                overlay.on_image_changed(self._img_w, self._img_h)
+                self._notify_overlay(overlay, self._content_rect())
             except Exception:
-                _logger.exception("Overlay on_image_changed failed: %r", overlay)
+                _logger.exception("Overlay content update failed: %r", overlay)
         self.draw_idle()
 
     def remove_overlay(self, overlay: CanvasOverlay) -> None:

--- a/fibsem/ui/widgets/canvas/image_canvas.py
+++ b/fibsem/ui/widgets/canvas/image_canvas.py
@@ -112,11 +112,7 @@ class FibsemImageCanvas(FibsemCanvasBase):
         self._refresh_flash()  # ditto: keep a live flash (e.g. WD scroll) visible across frames
         self._refresh_legend()  # ditto: restore the patch legend
 
-        for overlay in self._overlays:
-            try:
-                overlay.on_image_changed(w, h)
-            except Exception:
-                _logger.exception("Overlay on_image_changed failed: %r", overlay)
+        self._notify_overlays(self._content_rect())
 
         self.draw_idle()
 

--- a/fibsem/ui/widgets/canvas/overlays/__init__.py
+++ b/fibsem/ui/widgets/canvas/overlays/__init__.py
@@ -1,7 +1,7 @@
 """Canvas overlays for :class:`fibsem.ui.widgets.canvas.image_canvas.FibsemImageCanvas`.
 
 Each overlay implements the duck-typed overlay protocol (``attach`` / ``detach`` /
-``on_image_changed``); most subclass :class:`CanvasOverlay`. Import overlay classes
+``on_content_changed``); most subclass :class:`CanvasOverlay`. Import overlay classes
 from this package, e.g. ``from fibsem.ui.widgets.canvas.overlays import MillingPatternOverlay``.
 """
 

--- a/fibsem/ui/widgets/canvas/overlays/alignment_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/alignment_overlay.py
@@ -12,12 +12,15 @@ alignment logic can drop down to this overlay when it rebases.
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from PyQt5.QtCore import pyqtSignal
 
 from fibsem.structures import FibsemRectangle
 from fibsem.ui.widgets.canvas.overlays.rect_overlay import RectOverlay
+
+if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.canvas_base import ContentRect
 
 _ALIGNMENT_COLOUR = "limegreen"
 
@@ -53,38 +56,43 @@ class AlignmentAreaOverlay(RectOverlay):
 
     # ── overlay protocol ──────────────────────────────────────────────────
 
-    def on_image_changed(self, width: int, height: int) -> None:
+    def on_content_changed(self, rect: "ContentRect") -> None:
         # super() rebuilds the artists (fresh + visible); re-position then re-apply
         # the desired visibility, otherwise a new image un-hides a cleared overlay.
-        super().on_image_changed(width, height)
-        if self._norm_area is not None and self._img_w:
+        super().on_content_changed(rect)
+        if self._norm_area is not None and not rect.is_empty:
             self.set_area(self._norm_area)
         self._apply_visibility()
 
     # ── public API ────────────────────────────────────────────────────────
 
     def set_area(self, reduced_area: FibsemRectangle) -> None:
-        """Position the rectangle from a normalized ``FibsemRectangle``."""
+        """Position the rectangle from a normalized ``FibsemRectangle``.
+
+        A reduced area is defined as fractions *of an image*, so unlike the other
+        overlays this one stays image-relative: it is meaningful only on a canvas whose
+        content is a single frame, not on one showing many images in stage space.
+        """
         self._norm_area = reduced_area
-        if self._img_w is None or self._img_h is None:
+        if self._rect is None or self._rect.is_empty:
             return
         self.set_rect(
-            reduced_area.left * self._img_w,
-            reduced_area.top * self._img_h,
-            reduced_area.width * self._img_w,
-            reduced_area.height * self._img_h,
+            self._rect.x0 + reduced_area.left * self._rect.width,
+            self._rect.y0 + reduced_area.top * self._rect.height,
+            reduced_area.width * self._rect.width,
+            reduced_area.height * self._rect.height,
         )
 
     def get_area(self) -> FibsemRectangle:
         """Return the current rectangle as a normalized ``FibsemRectangle``."""
-        if self._img_w is None or self._img_h is None:
+        if self._rect is None or self._rect.is_empty:
             return FibsemRectangle()
         d = self.get_rect()
         return FibsemRectangle(
-            left=d["x0"] / self._img_w,
-            top=d["y0"] / self._img_h,
-            width=d["width"] / self._img_w,
-            height=d["height"] / self._img_h,
+            left=(d["x0"] - self._rect.x0) / self._rect.width,
+            top=(d["y0"] - self._rect.y0) / self._rect.height,
+            width=d["width"] / self._rect.width,
+            height=d["height"] / self._rect.height,
         )
 
     def set_visible(self, visible: bool) -> None:

--- a/fibsem/ui/widgets/canvas/overlays/base.py
+++ b/fibsem/ui/widgets/canvas/overlays/base.py
@@ -1,11 +1,18 @@
-"""Base class for FibsemImageCanvas overlays.
+"""Base class for canvas overlays.
 
 Overlays implement a simple duck-typed protocol::
 
     class MyOverlay:
-        def attach(self, ax, canvas: FibsemImageCanvas) -> None: ...
+        def attach(self, ax, canvas: FibsemCanvasBase) -> None: ...
         def detach(self) -> None: ...
-        def on_image_changed(self, width: int, height: int) -> None: ...
+        def on_content_changed(self, rect: ContentRect) -> None: ...
+
+``rect`` is the region the canvas is showing, as a
+:class:`~fibsem.ui.widgets.canvas.canvas_base.ContentRect`. Overlays that need bounds
+or a placement anchor should take them from it — ``rect.cx`` / ``rect.cy`` to centre,
+``rect.x0`` / ``rect.x1`` to clamp — rather than assuming content starts at (0, 0).
+That is what lets one overlay serve both a canvas holding a single image at the origin
+and one holding many images placed in stage space.
 
 Overlays that need Qt signals extend QObject directly.  An overlay that wants
 to suppress canvas pan/zoom during a drag sets ``canvas._overlay_consuming_event = True``
@@ -17,17 +24,29 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+    from fibsem.ui.widgets.canvas.canvas_base import ContentRect, FibsemCanvasBase
 
 
 class CanvasOverlay:
     """No-op base for canvas overlays.  Sub-class or use duck-typing."""
 
-    def attach(self, ax, canvas: "FibsemImageCanvas") -> None:
+    def attach(self, ax, canvas: "FibsemCanvasBase") -> None:
         """Called once when the overlay is added.  Create artists / connect events."""
 
     def detach(self) -> None:
         """Remove all artists and disconnect mpl events."""
 
+    def on_content_changed(self, rect: "ContentRect") -> None:
+        """Called after ax.cla() + new content drawn.  Re-create artists here.
+
+        Defaults to forwarding to the older :meth:`on_image_changed`, so an overlay
+        written against the previous protocol keeps working without modification.
+        """
+        self.on_image_changed(rect.width, rect.height)
+
     def on_image_changed(self, width: int, height: int) -> None:
-        """Called after ax.cla() + new image drawn.  Re-create artists here."""
+        """Deprecated — implement :meth:`on_content_changed` instead.
+
+        Retained so overlays predating the rect-based protocol still receive updates;
+        the canvas calls it only when an overlay defines no ``on_content_changed``.
+        """

--- a/fibsem/ui/widgets/canvas/overlays/mask_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/mask_overlay.py
@@ -21,6 +21,7 @@ from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.canvas_base import ContentRect
     from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 
 _logger = logging.getLogger(__name__)
@@ -52,10 +53,10 @@ class MaskOverlay(CanvasOverlay):
         self._ax = None
         self._canvas = None
 
-    def on_image_changed(self, width: int, height: int) -> None:
-        # ax was cleared + a new image drawn; re-create from the cached mask
+    def on_content_changed(self, rect: "ContentRect") -> None:
+        # ax was cleared + new content drawn; re-create from the cached mask
         self._remove_artist()
-        if self._mask is not None and width > 0:
+        if self._mask is not None and not rect.is_empty:
             self._draw()
 
     # ── public API ────────────────────────────────────────────────────────

--- a/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
@@ -45,6 +45,7 @@ from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.canvas_base import ContentRect
     from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 
 _logger = logging.getLogger(__name__)
@@ -84,10 +85,10 @@ class MillingPatternOverlay(CanvasOverlay):
         self._ax = None
         self._canvas = None
 
-    def on_image_changed(self, width: int, height: int) -> None:
-        # ax was cleared + a new image drawn; re-create artists from cached stages
+    def on_content_changed(self, rect: "ContentRect") -> None:
+        # ax was cleared + new content drawn; re-create artists from cached stages
         self._remove_artists()
-        if width > 0 and (self._stages or self._background_stages) and self._image is not None:
+        if not rect.is_empty and (self._stages or self._background_stages) and self._image is not None:
             self._draw()
 
     # ── public API ────────────────────────────────────────────────────────

--- a/fibsem/ui/widgets/canvas/overlays/minimap_overlays.py
+++ b/fibsem/ui/widgets/canvas/overlays/minimap_overlays.py
@@ -27,6 +27,7 @@ from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.canvas_base import ContentRect
     from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 
 _logger = logging.getLogger(__name__)
@@ -59,7 +60,7 @@ class MinimapShapesOverlay(CanvasOverlay):
 
     Call :meth:`set_shapes` to (re)draw, :meth:`set_visible` to toggle, :meth:`clear`
     to hide. Specs are cached so the overlay redraws itself after an image swap
-    (``on_image_changed``).
+    (``on_content_changed``).
     """
 
     def __init__(
@@ -89,10 +90,10 @@ class MinimapShapesOverlay(CanvasOverlay):
         self._ax = None
         self._canvas = None
 
-    def on_image_changed(self, width: int, height: int) -> None:
-        # ax was cleared + a new image drawn → re-create artists from cached specs
+    def on_content_changed(self, rect: "ContentRect") -> None:
+        # ax was cleared + new content drawn → re-create artists from cached specs
         self._remove_artists()
-        if width > 0 and self._specs and self._visible:
+        if not rect.is_empty and self._specs and self._visible:
             self._draw()
 
     # ── public API ────────────────────────────────────────────────────────

--- a/fibsem/ui/widgets/canvas/overlays/pattern_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/pattern_overlay.py
@@ -14,6 +14,7 @@ from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.canvas_base import ContentRect
     from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 
 _logger = logging.getLogger(__name__)
@@ -47,9 +48,9 @@ class PatternOverlay(CanvasOverlay):
         self._ax = None
         self._canvas = None
 
-    def on_image_changed(self, width: int, height: int) -> None:
+    def on_content_changed(self, rect: "ContentRect") -> None:
         self._remove_artists()
-        if width > 0:
+        if not rect.is_empty:
             self._draw()
 
     def set_patterns(self, patterns) -> None:
@@ -150,9 +151,9 @@ class ScanDirectionArrowOverlay(CanvasOverlay):
         self._ax = None
         self._canvas = None
 
-    def on_image_changed(self, width: int, _height: int) -> None:
+    def on_content_changed(self, rect: "ContentRect") -> None:
         self._remove_artist()
-        if width > 0 and self._params is not None:
+        if not rect.is_empty and self._params is not None:
             self._draw()
 
     def set_arrow(self, cx: float, cy: float, h_px: float, scan_direction: str) -> None:

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -15,6 +15,7 @@ from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.canvas_base import ContentRect
     from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 
 
@@ -48,9 +49,9 @@ class PointsOverlay(CanvasOverlay):
         self._ax = None
         self._canvas = None
 
-    def on_image_changed(self, width: int, height: int) -> None:
+    def on_content_changed(self, rect: "ContentRect") -> None:
         self._remove_artists()
-        if width > 0:
+        if not rect.is_empty:
             self._draw()
 
     def set_points(
@@ -187,8 +188,7 @@ class PointOverlay(QObject):
 
         self._ax = None
         self._canvas: Optional[FibsemImageCanvas] = None
-        self._img_w: Optional[int] = None
-        self._img_h: Optional[int] = None
+        self._rect: Optional["ContentRect"] = None  # canvas content bounds
 
         self._points: List[List[float]] = []  # [[x, y], ...]  mutable for drag
         self._artists: List = []  # Line2D per point (index-aligned)
@@ -229,11 +229,21 @@ class PointOverlay(QObject):
         self._ax = None
         self._canvas = None
 
-    def on_image_changed(self, width: int, height: int) -> None:
-        self._img_w, self._img_h = width, height
+    def on_content_changed(self, rect: "ContentRect") -> None:
+        self._rect = rect
         self._remove_all_artists()
-        if width > 0 and self._ax is not None:
+        if not rect.is_empty and self._ax is not None:
             self._draw_all()
+
+    def _clamp_to_content(self, x: float, y: float) -> Tuple[float, float]:
+        """Clamp a point to the last addressable pixel inside the content bounds."""
+        rect = self._rect
+        if rect is None or rect.is_empty:
+            return 0.0, 0.0
+        return (
+            max(rect.x0, min(x, rect.x1 - 1)),
+            max(rect.y0, min(y, rect.y1 - 1)),
+        )
 
     # ── public API ────────────────────────────────────────────────────────
 
@@ -254,7 +264,7 @@ class PointOverlay(QObject):
         self._point_labels = list(labels) if labels is not None else None
         self._selected = None
         self._remove_all_artists()
-        if self._ax is not None and self._img_w:
+        if self._ax is not None and self._rect is not None and not self._rect.is_empty:
             self._draw_all()
         if self._canvas is not None:
             self._canvas.draw_idle()
@@ -574,8 +584,7 @@ class PointOverlay(QObject):
         if event.button == 3:  # right-click → add a new point
             if not self._add_on_right_click:
                 return
-            x = max(0.0, min(event.xdata, (self._img_w or 1) - 1))
-            y = max(0.0, min(event.ydata, (self._img_h or 1) - 1))
+            x, y = self._clamp_to_content(event.xdata, event.ydata)
             idx = self.add_point(x, y)
             old_sel = self._selected
             self._selected = idx
@@ -610,10 +619,9 @@ class PointOverlay(QObject):
             return
         if event.xdata is None or event.ydata is None:
             return
-        W = self._img_w or 1
-        H = self._img_h or 1
-        x = max(0.0, min(event.xdata - self._drag_offset[0], W - 1))
-        y = max(0.0, min(event.ydata - self._drag_offset[1], H - 1))
+        x, y = self._clamp_to_content(
+            event.xdata - self._drag_offset[0], event.ydata - self._drag_offset[1]
+        )
         self._points[self._drag_idx] = [x, y]
         self._update_artist_position(self._drag_idx)
         self.point_dragging.emit(self._drag_idx, x, y)

--- a/fibsem/ui/widgets/canvas/overlays/rect_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/rect_overlay.py
@@ -12,6 +12,7 @@ from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay  # noqa: F401  
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.canvas_base import ContentRect
     from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 
 
@@ -19,10 +20,10 @@ _RECT_FRAC = 0.25
 _RECT_OFFSET = (1.0 - _RECT_FRAC) / 2.0
 
 
-def _default_extents(H: int, W: int) -> Tuple[float, float, float, float]:
-    """Return (x0, x1, y0, y1) for a centred 25 % box."""
-    rw, rh = W * _RECT_FRAC, H * _RECT_FRAC
-    x0, y0 = W * _RECT_OFFSET, H * _RECT_OFFSET
+def _default_extents(rect: "ContentRect") -> Tuple[float, float, float, float]:
+    """Return (x0, x1, y0, y1) for a centred 25 % box within *rect*."""
+    rw, rh = rect.width * _RECT_FRAC, rect.height * _RECT_FRAC
+    x0, y0 = rect.x0 + rect.width * _RECT_OFFSET, rect.y0 + rect.height * _RECT_OFFSET
     return x0, x0 + rw, y0, y0 + rh
 
 
@@ -86,8 +87,7 @@ class RectOverlay(QObject):
 
         self._ax = None
         self._canvas: Optional[FibsemImageCanvas] = None
-        self._img_w: Optional[int] = None
-        self._img_h: Optional[int] = None
+        self._rect: Optional["ContentRect"] = None  # canvas content bounds
 
         # Rect state in data coords
         self._x0 = self._y0 = self._x1 = self._y1 = 0.0
@@ -129,9 +129,9 @@ class RectOverlay(QObject):
         self._ax = None
         self._canvas = None
 
-    def on_image_changed(self, width: int, height: int) -> None:
-        self._img_w, self._img_h = width, height
-        if self._ax is None or width == 0 or height == 0:
+    def on_content_changed(self, rect: "ContentRect") -> None:
+        self._rect = rect
+        if self._ax is None or rect.is_empty:
             return
         self._rebuild()
 
@@ -172,7 +172,7 @@ class RectOverlay(QObject):
         if self._saved is not None:
             x0, y0, w, h = self._saved
         else:
-            ex = _default_extents(self._img_h, self._img_w)
+            ex = _default_extents(self._rect)
             x0, y0, w, h = ex[0], ex[2], ex[1] - ex[0], ex[3] - ex[2]
             self._saved = (x0, y0, w, h)
 
@@ -301,26 +301,31 @@ class RectOverlay(QObject):
         dx = event.xdata - self._drag_start_data[0]
         dy = event.ydata - self._drag_start_data[1]
         rx0, ry0, rx1, ry1 = self._drag_start_rect
-        W, H = self._img_w, self._img_h
+        if self._rect is None:
+            return
+        # Clamp against the content bounds, which need not start at the origin.
+        left, top, right, bottom = (
+            self._rect.x0, self._rect.y0, self._rect.x1, self._rect.y1
+        )
 
         if self._drag_mode == "move":
             w, h = rx1 - rx0, ry1 - ry0
-            self._x0 = max(0.0, min(rx0 + dx, W - w))
-            self._y0 = max(0.0, min(ry0 + dy, H - h))
+            self._x0 = max(left, min(rx0 + dx, right - w))
+            self._y0 = max(top, min(ry0 + dy, bottom - h))
             self._x1 = self._x0 + w
             self._y1 = self._y0 + h
         elif self._drag_mode == "tl":
-            self._x0 = max(0.0, min(rx0 + dx, self._x1 - 1))
-            self._y0 = max(0.0, min(ry0 + dy, self._y1 - 1))
+            self._x0 = max(left, min(rx0 + dx, self._x1 - 1))
+            self._y0 = max(top, min(ry0 + dy, self._y1 - 1))
         elif self._drag_mode == "tr":
-            self._x1 = max(self._x0 + 1, min(rx1 + dx, W))
-            self._y0 = max(0.0, min(ry0 + dy, self._y1 - 1))
+            self._x1 = max(self._x0 + 1, min(rx1 + dx, right))
+            self._y0 = max(top, min(ry0 + dy, self._y1 - 1))
         elif self._drag_mode == "bl":
-            self._x0 = max(0.0, min(rx0 + dx, self._x1 - 1))
-            self._y1 = max(self._y0 + 1, min(ry1 + dy, H))
+            self._x0 = max(left, min(rx0 + dx, self._x1 - 1))
+            self._y1 = max(self._y0 + 1, min(ry1 + dy, bottom))
         elif self._drag_mode == "br":
-            self._x1 = max(self._x0 + 1, min(rx1 + dx, W))
-            self._y1 = max(self._y0 + 1, min(ry1 + dy, H))
+            self._x1 = max(self._x0 + 1, min(rx1 + dx, right))
+            self._y1 = max(self._y0 + 1, min(ry1 + dy, bottom))
 
         self._update_artists()
         self._blit()

--- a/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
@@ -11,6 +11,7 @@ from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from fibsem.ui.widgets.canvas.canvas_base import ContentRect
     from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 
 
@@ -52,8 +53,7 @@ class RulerOverlay(CanvasOverlay):
         self._color = color
         self._ax = None
         self._canvas: Optional["FibsemImageCanvas"] = None
-        self._img_w: Optional[int] = None
-        self._img_h: Optional[int] = None
+        self._rect: Optional["ContentRect"] = None  # canvas content bounds
         self._pixel_size: Optional[float] = None
 
         # endpoints in data coords (None until seeded)
@@ -96,11 +96,11 @@ class RulerOverlay(CanvasOverlay):
         self._ax = None
         self._canvas = None
 
-    def on_image_changed(self, width: int, height: int) -> None:
-        self._img_w, self._img_h = width, height
+    def on_content_changed(self, rect: "ContentRect") -> None:
+        self._rect = rect
         if self._canvas is not None:
             self._pixel_size = self._canvas.pixel_size
-        if self._ax is None or width == 0 or height == 0 or not self._visible:
+        if self._ax is None or rect.is_empty or not self._visible:
             self._remove_artists()  # inert while hidden / between images
             return
         if self._p1 is None or self._p2 is None:
@@ -116,7 +116,7 @@ class RulerOverlay(CanvasOverlay):
         self._visible = visible
         if not visible:
             self._remove_artists()
-        elif self._img_w:
+        elif self._rect is not None and not self._rect.is_empty:
             if self._p1 is None or self._p2 is None:
                 self._seed_default()
             self._rebuild()
@@ -133,19 +133,20 @@ class RulerOverlay(CanvasOverlay):
     # ── build / teardown ──────────────────────────────────────────────────
 
     def _seed_default(self) -> None:
-        if not self._img_w or not self._img_h:
+        rect = self._rect
+        if rect is None or rect.is_empty:
             return
-        cx, cy = self._img_w / 2.0, self._img_h / 2.0
-        half = self._img_w * 0.125
-        self._p1 = [cx - half, cy]
-        self._p2 = [cx + half, cy]
+        half = rect.width * 0.125
+        self._p1 = [rect.cx - half, rect.cy]
+        self._p2 = [rect.cx + half, rect.cy]
 
     def _clamp(self) -> None:
-        if self._img_w is None:
+        rect = self._rect
+        if rect is None:
             return
         for p in (self._p1, self._p2):
-            p[0] = _clampf(p[0], 0.0, self._img_w)
-            p[1] = _clampf(p[1], 0.0, self._img_h)
+            p[0] = _clampf(p[0], rect.x0, rect.x1)
+            p[1] = _clampf(p[1], rect.y0, rect.y1)
 
     def _remove_artists(self) -> None:
         for a in (self._line, self._dots, self._label):
@@ -247,16 +248,19 @@ class RulerOverlay(CanvasOverlay):
         dx = event.xdata - self._drag_start_data[0]
         dy = event.ydata - self._drag_start_data[1]
         p1, p2 = self._drag_start_pts
-        W, H = self._img_w, self._img_h
+        rect = self._rect
+        if rect is None:
+            return
+        left, top, right, bottom = rect.x0, rect.y0, rect.x1, rect.y1
         if self._drag == "p1":
-            self._p1 = [_clampf(p1[0] + dx, 0, W), _clampf(p1[1] + dy, 0, H)]
+            self._p1 = [_clampf(p1[0] + dx, left, right), _clampf(p1[1] + dy, top, bottom)]
         elif self._drag == "p2":
-            self._p2 = [_clampf(p2[0] + dx, 0, W), _clampf(p2[1] + dy, 0, H)]
+            self._p2 = [_clampf(p2[0] + dx, left, right), _clampf(p2[1] + dy, top, bottom)]
         else:  # move the whole line, clamped so both endpoints stay in bounds
             minx, maxx = min(p1[0], p2[0]), max(p1[0], p2[0])
             miny, maxy = min(p1[1], p2[1]), max(p1[1], p2[1])
-            dx = _clampf(dx, -minx, W - maxx)
-            dy = _clampf(dy, -miny, H - maxy)
+            dx = _clampf(dx, left - minx, right - maxx)
+            dy = _clampf(dy, top - miny, bottom - maxy)
             self._p1 = [p1[0] + dx, p1[1] + dy]
             self._p2 = [p2[0] + dx, p2[1] + dy]
         self._update_artists()

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -26,6 +26,7 @@ from fibsem.imaging.tiling.geometry import TilePosition
 from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
+    from fibsem.ui.widgets.canvas.canvas_base import ContentRect
     from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 
 # Magenta rather than the app's blue: this is drawn over fluorescence data, which is
@@ -74,8 +75,7 @@ class TileGridOverlay(QObject, CanvasOverlay):
         self._ax = None
         self._canvas: Optional["FibsemImageCanvas"] = None
         self._artists: list = []
-        self._img_w: int = 0
-        self._img_h: int = 0
+        self._rect: Optional["ContentRect"] = None  # canvas content bounds
         self._previous_margin: Optional[float] = None
         self._cids: List[int] = []
         self._resize_axes: Optional[Tuple[bool, bool]] = None  # (horizontal, vertical)
@@ -112,9 +112,18 @@ class TileGridOverlay(QObject, CanvasOverlay):
         self._ax = None
         self._canvas = None
 
-    def on_image_changed(self, width: int, height: int) -> None:
-        self._img_w, self._img_h = width, height
+    def on_content_changed(self, rect: "ContentRect") -> None:
+        self._rect = rect
         self._redraw()
+
+    def _content(self) -> Optional["ContentRect"]:
+        """Content bounds, or None if the canvas has not reported usable ones yet.
+
+        The grid is centred on the content — today the displayed image, and under a
+        real-space canvas the region the tiles are planned around.
+        """
+        rect = self._rect
+        return None if rect is None or rect.is_empty else rect
 
     # ── content ──────────────────────────────────────────────────────────
 
@@ -191,17 +200,18 @@ class TileGridOverlay(QObject, CanvasOverlay):
         view the outer tiles are off-screen -- and an outer tile that cannot be seen
         cannot be clicked.
         """
-        if self._canvas is None or not self._tiles or self._img_w <= 0:
+        rect = self._content()
+        if self._canvas is None or not self._tiles or rect is None:
             return
 
         span_w, span_h = self._extent()
         if span_w <= 0 or span_h <= 0:
             return
 
-        # `set_view_margin` is a fraction of the *image* size per side.
+        # `set_view_margin` is a fraction of the *content* size per side.
         margin = max(
-            (span_w / self._img_w - 1.0) / 2.0,
-            (span_h / self._img_h - 1.0) / 2.0,
+            (span_w / rect.width - 1.0) / 2.0,
+            (span_h / rect.height - 1.0) / 2.0,
             0.0,
         )
         if self._previous_margin is None:
@@ -243,10 +253,14 @@ class TileGridOverlay(QObject, CanvasOverlay):
         scale = self._scale()
         span_w, span_h = self._extent()
 
-        # The grid is centred on the image centre, matching the runner: it measures
+        # The grid is centred on the content centre, matching the runner: it measures
         # from the top-left tile and shifts so the grid straddles the start position.
-        origin_x = self._img_w / 2 - span_w / 2
-        origin_y = self._img_h / 2 - span_h / 2
+        # Callers guard on _content(); the (0, 0) fallback keeps this total.
+        rect = self._content()
+        cx = rect.cx if rect is not None else 0.0
+        cy = rect.cy if rect is not None else 0.0
+        origin_x = cx - span_w / 2
+        origin_y = cy - span_h / 2
 
         return (
             origin_x + tile.canvas_x * scale,
@@ -257,7 +271,7 @@ class TileGridOverlay(QObject, CanvasOverlay):
 
     def _redraw(self) -> None:
         self._remove_artists()
-        if self._ax is None or not self._tiles or self._img_w <= 0 or not self._visible:
+        if self._ax is None or not self._tiles or self._content() is None or not self._visible:
             # Still repaint: removing the artists takes them out of the axes, but the
             # canvas keeps showing the last render until it is asked to redraw -- so
             # returning early here left a hidden grid on screen.
@@ -336,12 +350,13 @@ class TileGridOverlay(QObject, CanvasOverlay):
         boolean because the hover cursor has to name a *corner* -- top-left and
         top-right want opposite diagonals -- and "on both axes" cannot distinguish them.
         """
-        if not self._tiles or self._tile_shape[1] <= 0 or self._img_w <= 0:
+        rect = self._content()
+        if not self._tiles or self._tile_shape[1] <= 0 or rect is None:
             return 0, 0
 
         span_w, span_h = self._extent()
-        left = self._img_w / 2 - span_w / 2
-        top = self._img_h / 2 - span_h / 2
+        left = rect.cx - span_w / 2
+        top = rect.cy - span_h / 2
         # Proportional to a tile rather than a fixed pixel count, so the grab zone
         # stays usable at any zoom without querying the transform.
         tolerance = self._tile_shape[1] * self._scale() * EDGE_GRAB_FRACTION
@@ -454,7 +469,8 @@ class TileGridOverlay(QObject, CanvasOverlay):
             return
         if event.xdata is None or event.ydata is None:
             return
-        if not self._tiles:
+        rect = self._content()
+        if not self._tiles or rect is None:
             # The grid can be cleared mid-drag -- `_refresh_tile_grid` does exactly
             # that if the camera geometry cannot be read -- and the row/column counts
             # below are derived from the tiles, so this would raise on an empty max().
@@ -468,11 +484,11 @@ class TileGridOverlay(QObject, CanvasOverlay):
 
         if horizontal:
             cols = self._count_for(
-                abs(event.xdata - self._img_w / 2), tile_w * scale
+                abs(event.xdata - rect.cx), tile_w * scale
             )
         if vertical:
             rows = self._count_for(
-                abs(event.ydata - self._img_h / 2), tile_h * scale
+                abs(event.ydata - rect.cy), tile_h * scale
             )
 
         self.grid_resize_requested.emit(rows, cols)

--- a/fibsem/ui/widgets/tests/test_alignment_overlay.py
+++ b/fibsem/ui/widgets/tests/test_alignment_overlay.py
@@ -30,6 +30,10 @@ class AlignmentOverlayTest(QWidget):
         self.overlay = AlignmentAreaOverlay(editable=True)
         self.canvas.add_overlay(self.overlay)
         self.overlay.set_area(FibsemRectangle(0.25, 0.25, 0.5, 0.5))
+        # Visibility is opt-in: the overlay starts hidden so a consumer can attach it
+        # before it has an area to show (see LamellaDefaultConfigWidget). Without this
+        # the demo drew nothing at all.
+        self.overlay.set_visible(True)
         self.overlay.alignment_area_changed.connect(self._show_area)
 
         self.label = QLabel()

--- a/fibsem/ui/widgets/tests/test_overlay_content_rect.py
+++ b/fibsem/ui/widgets/tests/test_overlay_content_rect.py
@@ -1,0 +1,197 @@
+"""Headless smoke: the overlay content-rect protocol.
+
+Overlays used to be told ``on_image_changed(width, height)`` and assumed content
+started at (0, 0). They are now told a ContentRect, so the same overlay works whether
+the canvas holds one image at the origin or many placed away from it.
+
+Two things are easy to get wrong and are pinned here: the rect is *not* the canvas's
+matplotlib extent (that carries imshow's half-pixel offset and would shift every clamp
+and anchor by half a pixel), and an overlay written against the old protocol must keep
+receiving updates.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_overlay_content_rect.py
+"""
+import sys
+
+import numpy as np
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.canvas_base import EMPTY_CONTENT, ContentRect
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+from fibsem.ui.widgets.canvas.overlays.ruler_overlay import RulerOverlay
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _img(h, w):
+    return np.zeros((h, w), dtype=np.uint8)
+
+
+class _Recorder(CanvasOverlay):
+    """Overlay on the current protocol."""
+
+    def __init__(self):
+        self.rects = []
+
+    def on_content_changed(self, rect):
+        self.rects.append(rect)
+
+
+class _LegacyRecorder(CanvasOverlay):
+    """Overlay written against the superseded protocol — must still work."""
+
+    def __init__(self):
+        self.sizes = []
+
+    def on_image_changed(self, width, height):
+        self.sizes.append((width, height))
+
+
+class _DuckLegacy:
+    """Legacy overlay that doesn't even subclass CanvasOverlay (pure duck-typing)."""
+
+    def __init__(self):
+        self.sizes = []
+
+    def attach(self, ax, canvas):
+        pass
+
+    def detach(self):
+        pass
+
+    def on_image_changed(self, width, height):
+        self.sizes.append((width, height))
+
+
+# ── the rect itself ───────────────────────────────────────────────────────
+
+
+def test_rect_derives_edges_and_centre():
+    r = ContentRect(10.0, 20.0, 100.0, 50.0)
+    assert (r.x1, r.y1) == (110.0, 70.0)
+    assert (r.cx, r.cy) == (60.0, 45.0)
+    assert not r.is_empty
+
+
+def test_a_zero_sized_rect_is_empty():
+    assert EMPTY_CONTENT.is_empty
+    assert ContentRect(0.0, 0.0, 10.0, 0.0).is_empty
+
+
+# ── what the image canvas reports ─────────────────────────────────────────
+
+
+def test_image_content_rect_is_pixel_space_not_the_mpl_extent():
+    """The distinction that keeps this refactor behaviour-preserving.
+
+    The image's matplotlib extent is (-0.5, w-0.5, h-0.5, -0.5); handing that to
+    overlays would move every clamp and anchor by half a pixel. The rect they get is
+    the pixel grid: origin (0, 0), size (w, h).
+    """
+    c = FibsemImageCanvas()
+    c.set_array(_img(32, 64))
+    rect = c._content_rect()
+    assert (rect.x0, rect.y0, rect.width, rect.height) == (0.0, 0.0, 64, 32)
+    assert tuple(c._content_extent()) == (-0.5, 63.5, 31.5, -0.5)  # deliberately differs
+    assert (rect.cx, rect.cy) == (32.0, 16.0)  # what an overlay centres on
+
+
+def test_content_rect_is_empty_before_any_image():
+    assert FibsemImageCanvas()._content_rect().is_empty
+
+
+# ── notification ──────────────────────────────────────────────────────────
+
+
+def test_overlays_are_told_the_rect_on_a_new_image():
+    c = FibsemImageCanvas()
+    rec = _Recorder()
+    c.add_overlay(rec)
+    c.set_array(_img(32, 64))
+    assert rec.rects[-1] == ContentRect(0.0, 0.0, 64, 32)
+
+
+def test_adding_an_overlay_to_a_live_canvas_tells_it_immediately():
+    """Otherwise an overlay added after the image draws nothing until the next frame."""
+    c = FibsemImageCanvas()
+    c.set_array(_img(32, 64))
+    rec = _Recorder()
+    c.add_overlay(rec)
+    assert rec.rects == [ContentRect(0.0, 0.0, 64, 32)]
+
+
+def test_clearing_the_canvas_reports_empty_content():
+    c = FibsemImageCanvas()
+    c.set_array(_img(32, 64))
+    rec = _Recorder()
+    c.add_overlay(rec)
+    c.clear()
+    assert rec.rects[-1].is_empty
+
+
+def test_a_failing_overlay_does_not_break_the_others():
+    class _Boom(CanvasOverlay):
+        def on_content_changed(self, rect):
+            raise RuntimeError("boom")
+
+    c = FibsemImageCanvas()
+    rec = _Recorder()
+    c.add_overlay(_Boom())
+    c.add_overlay(rec)
+    c.set_array(_img(32, 64))  # must not raise
+    assert rec.rects  # the survivor still got told
+
+
+# ── back-compat ───────────────────────────────────────────────────────────
+
+
+def test_a_legacy_overlay_still_receives_updates():
+    c = FibsemImageCanvas()
+    legacy = _LegacyRecorder()
+    c.add_overlay(legacy)
+    c.set_array(_img(32, 64))
+    assert legacy.sizes[-1] == (64, 32)
+
+
+def test_a_duck_typed_legacy_overlay_still_receives_updates():
+    """It subclasses nothing, so the base-class shim can't help — the canvas falls back."""
+    c = FibsemImageCanvas()
+    legacy = _DuckLegacy()
+    c.add_overlay(legacy)
+    c.set_array(_img(32, 64))
+    assert legacy.sizes[-1] == (64, 32)
+
+
+# ── overlays honour a non-zero origin ─────────────────────────────────────
+
+
+def test_the_ruler_seeds_itself_on_the_content_centre_wherever_that_is():
+    """The payoff: an overlay anchoring to the content works off-origin, which is what
+    a canvas placing images in stage space will hand it."""
+    ruler = RulerOverlay()
+    ruler.on_content_changed(ContentRect(1000.0, 2000.0, 400.0, 200.0))
+    ruler._seed_default()
+    (x1, y1), (x2, y2) = ruler._p1, ruler._p2
+    assert (x1 + x2) / 2 == 1200.0  # centred on the rect, not on (0, 0)
+    assert y1 == y2 == 2100.0
+    assert x2 - x1 == 100.0  # a quarter of the content width, as before
+
+
+def test_the_ruler_clamps_to_the_content_bounds_not_to_zero():
+    ruler = RulerOverlay()
+    ruler.on_content_changed(ContentRect(1000.0, 2000.0, 400.0, 200.0))
+    ruler._p1 = [-50.0, -50.0]  # dragged far outside, below the origin
+    ruler._p2 = [9999.0, 9999.0]
+    ruler._clamp()
+    assert ruler._p1 == [1000.0, 2000.0]  # pinned to the rect's top-left
+    assert ruler._p2 == [1400.0, 2200.0]  # and its bottom-right
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok  {name}")
+    print("all passed")

--- a/tests/ui/test_canvas_base.py
+++ b/tests/ui/test_canvas_base.py
@@ -8,9 +8,17 @@ changed, since _fit_view previously read the image artist's extent directly.
 Run directly (no display needed):
     QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_canvas_base.py
 """
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 import sys
 
 import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
 from PyQt5.QtWidgets import QApplication
 
 from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase

--- a/tests/ui/test_overlay_content_rect.py
+++ b/tests/ui/test_overlay_content_rect.py
@@ -12,9 +12,17 @@ receiving updates.
 Run directly (no display needed):
     QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_overlay_content_rect.py
 """
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 import sys
 
 import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
 from PyQt5.QtWidgets import QApplication
 
 from fibsem.ui.widgets.canvas.canvas_base import EMPTY_CONTENT, ContentRect

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -16,6 +16,7 @@ pytest.importorskip("PyQt5")
 from PyQt5.QtWidgets import QApplication
 
 from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
+from fibsem.ui.widgets.canvas.canvas_base import ContentRect
 from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import TileGridOverlay
 
 WIDTH = HEIGHT = 1024
@@ -53,6 +54,11 @@ class _FakeCanvas:
         self._view_margin = margin
 
 
+def _seed_content(overlay, width=WIDTH, height=HEIGHT):
+    """Tell the overlay how much canvas content there is, via the real protocol."""
+    overlay.on_content_changed(ContentRect(0.0, 0.0, width, height))
+
+
 def build(rows=3, cols=3, overlap=OVERLAP, mask=None):
     from matplotlib.figure import Figure
 
@@ -65,7 +71,7 @@ def build(rows=3, cols=3, overlap=OVERLAP, mask=None):
     overlay._ax = Figure().add_subplot(111)
     overlay._canvas = _FakeCanvas()
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
-    overlay._img_w, overlay._img_h = WIDTH, HEIGHT
+    _seed_content(overlay)
     return overlay, tiles
 
 
@@ -153,7 +159,7 @@ def test_nothing_is_drawn_without_an_image(qapp):
     """There is nothing to anchor or scale against, so the grid is cleared rather than
     drawn at a guessed position."""
     overlay, _ = build(3, 3)
-    overlay._img_w = overlay._img_h = 0
+    _seed_content(overlay, 0, 0)
 
     overlay._redraw()
 
@@ -165,7 +171,7 @@ def test_a_differing_display_pixel_size_rescales_the_grid(qapp):
     the two pixel sizes would draw the grid at the wrong scale."""
     tiles = compute_tile_grid_from_fov(3, 3, FOV, FOV, WIDTH, HEIGHT, OVERLAP)
     overlay = TileGridOverlay()
-    overlay._img_w, overlay._img_h = WIDTH, HEIGHT
+    _seed_content(overlay)
 
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
     full = overlay._rect_for(tiles[0])[2]
@@ -275,8 +281,8 @@ def _event(overlay, x, y, button=1):
 def _edges(overlay):
     span_w, span_h = overlay._extent()
     return (
-        overlay._img_w / 2 + span_w / 2,   # right
-        overlay._img_h / 2 + span_h / 2,   # bottom
+        overlay._rect.cx + span_w / 2,   # right
+        overlay._rect.cy + span_h / 2,   # bottom
     )
 
 
@@ -286,10 +292,10 @@ def test_only_the_outer_edges_grab(qapp):
     overlay, _ = build(3, 3, overlap=OVERLAP)
     right, bottom = _edges(overlay)
 
-    assert overlay._edge_at(right, overlay._img_h / 2) == (True, False)
-    assert overlay._edge_at(overlay._img_w / 2, bottom) == (False, True)
+    assert overlay._edge_at(right, overlay._rect.cy) == (True, False)
+    assert overlay._edge_at(overlay._rect.cx, bottom) == (False, True)
     assert overlay._edge_at(right, bottom) == (True, True)      # corner: both axes
-    assert overlay._edge_at(overlay._img_w / 2, overlay._img_h / 2) is None
+    assert overlay._edge_at(overlay._rect.cx, overlay._rect.cy) is None
 
 
 def test_the_bounding_lines_do_not_grab_far_outside_the_grid(qapp):
@@ -298,7 +304,7 @@ def test_the_bounding_lines_do_not_grab_far_outside_the_grid(qapp):
     overlay, _ = build(3, 3)
     right, bottom = _edges(overlay)
 
-    assert overlay._edge_at(right, bottom + overlay._img_h) is None
+    assert overlay._edge_at(right, bottom + overlay._rect.height) is None
 
 
 def test_dragging_an_edge_outward_adds_tiles_symmetrically(qapp):
@@ -309,8 +315,8 @@ def test_dragging_an_edge_outward_adds_tiles_symmetrically(qapp):
     overlay.grid_resize_requested.connect(lambda r, c: requested.append((r, c)))
     right, _ = _edges(overlay)
 
-    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
-    overlay._on_drag(_event(overlay, right + WIDTH, overlay._img_h / 2))
+    overlay._on_press(_event(overlay, right, overlay._rect.cy))
+    overlay._on_drag(_event(overlay, right + WIDTH, overlay._rect.cy))
 
     rows, cols = requested[-1]
     assert rows == 3, "dragging a vertical edge must not change the row count"
@@ -323,8 +329,8 @@ def test_dragging_an_edge_inward_removes_tiles(qapp):
     overlay.grid_resize_requested.connect(lambda r, c: requested.append((r, c)))
     right, _ = _edges(overlay)
 
-    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
-    overlay._on_drag(_event(overlay, right - 2 * WIDTH, overlay._img_h / 2))
+    overlay._on_press(_event(overlay, right, overlay._rect.cy))
+    overlay._on_drag(_event(overlay, right - 2 * WIDTH, overlay._rect.cy))
 
     assert requested[-1][1] < 5
 
@@ -337,14 +343,14 @@ def test_the_dragged_edge_follows_the_cursor(qapp):
     overlay.grid_resize_requested.connect(lambda r, c: resized.append((r, c)))
     right, _ = _edges(overlay)
     step = WIDTH * (1 - OVERLAP)
-    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+    overlay._on_press(_event(overlay, right, overlay._rect.cy))
 
     for target in (right + step, right + 2 * step, right - step):
-        overlay._on_drag(_event(overlay, target, overlay._img_h / 2))
+        overlay._on_drag(_event(overlay, target, overlay._rect.cy))
         rows, cols = resized[-1]
         # rebuild at the requested size and measure where its edge landed
         grown, _ = build(rows, cols, overlap=OVERLAP)
-        landed = grown._img_w / 2 + grown._extent()[0] / 2
+        landed = grown._rect.cx + grown._extent()[0] / 2
 
         assert abs(landed - target) <= step / 2 + 1
 
@@ -354,9 +360,9 @@ def test_a_drag_never_shrinks_past_a_single_tile(qapp):
     resized = []
     overlay.grid_resize_requested.connect(lambda r, c: resized.append((r, c)))
     right, _ = _edges(overlay)
-    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+    overlay._on_press(_event(overlay, right, overlay._rect.cy))
 
-    overlay._on_drag(_event(overlay, overlay._img_w / 2, overlay._img_h / 2))
+    overlay._on_drag(_event(overlay, overlay._rect.cx, overlay._rect.cy))
 
     assert resized[-1][1] >= 1
 
@@ -364,7 +370,7 @@ def test_a_drag_never_shrinks_past_a_single_tile(qapp):
 def test_a_press_away_from_an_edge_starts_no_resize(qapp):
     overlay, _ = build(3, 3)
 
-    overlay._on_press(_event(overlay, overlay._img_w / 2, overlay._img_h / 2))
+    overlay._on_press(_event(overlay, overlay._rect.cx, overlay._rect.cy))
 
     assert overlay.is_resizing is False
 
@@ -376,12 +382,12 @@ def test_a_press_on_an_edge_claims_the_gesture_from_the_canvas(qapp):
     overlay._canvas._overlay_consuming_event = False
     right, _ = _edges(overlay)
 
-    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+    overlay._on_press(_event(overlay, right, overlay._rect.cy))
 
     assert overlay.is_resizing is True
     assert overlay._canvas._overlay_consuming_event is True
 
-    overlay._on_release(_event(overlay, right, overlay._img_h / 2))
+    overlay._on_release(_event(overlay, right, overlay._rect.cy))
     assert overlay.is_resizing is False
 
 
@@ -390,7 +396,7 @@ def test_a_hidden_grid_cannot_be_resized(qapp):
     right, _ = _edges(overlay)
     overlay.set_grid_visible(False)
 
-    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+    overlay._on_press(_event(overlay, right, overlay._rect.cy))
 
     assert overlay.is_resizing is False
 
@@ -400,7 +406,7 @@ def test_a_hidden_grid_cannot_be_resized(qapp):
 
 def _corners(overlay):
     span_w, span_h = overlay._extent()
-    cx, cy = overlay._img_w / 2, overlay._img_h / 2
+    cx, cy = overlay._rect.cx, overlay._rect.cy
     return cx - span_w / 2, cx + span_w / 2, cy - span_h / 2, cy + span_h / 2
 
 
@@ -433,7 +439,7 @@ def test_the_edges_get_axis_cursors_and_the_interior_none(qapp):
 
     overlay, _ = build(3, 3)
     left, right, top, bottom = _corners(overlay)
-    cx, cy = overlay._img_w / 2, overlay._img_h / 2
+    cx, cy = overlay._rect.cx, overlay._rect.cy
 
     assert overlay._cursor_for(*overlay._edge_sides(right, cy)) == Qt.SizeHorCursor
     assert overlay._cursor_for(*overlay._edge_sides(left, cy)) == Qt.SizeHorCursor
@@ -448,7 +454,7 @@ def test_a_hidden_grid_shows_no_resize_cursor(qapp):
     _, right, _, _ = _corners(overlay)
     overlay.set_grid_visible(False)
 
-    overlay._update_cursor(_event(overlay, right, overlay._img_h / 2))
+    overlay._update_cursor(_event(overlay, right, overlay._rect.cy))
 
     assert overlay._cursor_set is False
 
@@ -460,8 +466,8 @@ def test_a_drag_survives_the_grid_being_cleared_underneath_it(qapp):
     escaping a handler can take the app down (FIB-329)."""
     overlay, _ = build(3, 3, overlap=OVERLAP)
     right, _ = _edges(overlay)
-    overlay._on_press(_event(overlay, right, overlay._img_h / 2))
+    overlay._on_press(_event(overlay, right, overlay._rect.cy))
 
     overlay.clear()
 
-    overlay._on_drag(_event(overlay, right + WIDTH, overlay._img_h / 2))
+    overlay._on_drag(_event(overlay, right + WIDTH, overlay._rect.cy))


### PR DESCRIPTION
Step 2 of FIB-408 — showing FM overviews on a real-space canvas. Follows #247. **No behaviour change.**

## What

Overlays were told `on_image_changed(width, height)` and assumed content began at (0, 0). They are now told a `ContentRect` — origin, size, with derived edges and centre — so the same overlay serves a canvas holding one image at the origin *and* one holding many images placed away from it.

```python
@dataclass(frozen=True)
class ContentRect:
    x0: float; y0: float; width: float; height: float
    # + x1, y1, cx, cy, is_empty
```

## Why this is small

The dimensions were only ever used for two things: **clamping to bounds**, and **a default placement anchor**. Neither cares whether the rectangle is an image or a region of stage space — which is what makes this a rename plus an origin rather than a rewrite.

Of the eleven overlay modules, seven only used `width > 0` as an "is there content?" gate. Four genuinely used the dimensions and now clamp against `rect.x0`/`rect.x1` and anchor on `rect.cx`/`rect.cy`: `rect_overlay`, `point_overlay`, `ruler_overlay`, `tile_grid_overlay`.

`AlignmentAreaOverlay` stays image-relative on purpose — a reduced area is defined as fractions *of a frame*, so it is only meaningful where the content is a single image.

## The subtle bit

**The rect is deliberately not the canvas's matplotlib extent.** That extent is `(-0.5, w-0.5, h-0.5, -0.5)` — it carries imshow's half-pixel offset and exists only to fit the view. Handing it to overlays would shift every clamp and anchor by half a pixel, silently. The rect overlays receive is the pixel grid: origin `(0, 0)`, size `(w, h)` — so every overlay computes exactly the numbers it did before. There's a test pinning the two apart.

## Back-compat

`on_image_changed` survives both as a default on `CanvasOverlay` and as a fallback in the canvas's dispatch, so a duck-typed overlay written against the old protocol keeps working untouched. Covered by two tests, including one overlay that subclasses nothing.

## Verification

- **2011 passed, 16 skipped.** 12 new tests for the protocol: the rect's geometry, what the image canvas reports, notification on new-image / add-overlay / clear, one-overlay-failing isolation, both back-compat paths, and two proving the ruler seeds and clamps correctly against a rect at origin `(1000, 2000)`.
- Manually exercised via the standalone alignment-overlay demo — the overlay whose output is numeric (a normalized `FibsemRectangle` that feeds acquisition) rather than merely visual. Round-trips exactly at the extremes.
- Verified against `main` that the rewritten anchoring produces byte-identical pixel coordinates.

## Two fixes riding along

**`8e1e31a1` — tests that never ran.** `testpaths = ["tests"]` and CI runs `pytest tests/`, so nothing under `fibsem/ui/widgets/tests/` is ever collected — not in CI, not in a plain local `pytest`. The canvas tests added in #247 went there to sit beside the existing canvas tests, so they gated nothing. Both new files move to `tests/ui/` and adopt its convention (offscreen Qt platform, `importorskip`). Default collection goes 2008 → 2027. The canvas tests that already lived there are still uncollected; that's a separate job.

**`2aefeb4b` — the alignment demo drew nothing.** `AlignmentAreaOverlay` starts hidden (visibility is opt-in so a consumer can attach before it has an area to show, which is why `LamellaDefaultConfigWidget` calls `set_visible(True)`). The standalone demo never did, so it rendered an invisible rectangle and the overlay had no working manual harness. Pre-existing on main, confirmed by running the same probe there.

## Next

FIB-411 adds `FibsemRealSpaceCanvas` — all new code, no consumers. Nothing is user-visible until FIB-412.
