### PR TITLE
[ui] Add FibsemRealSpaceCanvas — images drawn where they were acquired (FIB-411)

### DIFF
--- a/fibsem/ui/widgets/canvas/__init__.py
+++ b/fibsem/ui/widgets/canvas/__init__.py
@@ -5,6 +5,8 @@ This package groups the (napari-free) canvas widgets and their supporting state:
 - :mod:`~fibsem.ui.widgets.canvas.canvas_base` — :class:`FibsemCanvasBase`, the
   content-agnostic navigation / overlay / toolbar / chrome half of the canvas.
 - :mod:`~fibsem.ui.widgets.canvas.image_canvas` — the core :class:`FibsemImageCanvas`.
+- :mod:`~fibsem.ui.widgets.canvas.real_space_canvas` — :class:`FibsemRealSpaceCanvas`,
+  many images drawn at the positions they were acquired.
 - :mod:`~fibsem.ui.widgets.canvas.fm_canvas` — fluorescence-microscopy canvas.
 - :mod:`~fibsem.ui.widgets.canvas.fm_composite` — FM layer compositing helpers.
 - :mod:`~fibsem.ui.widgets.canvas.quad_view` — quad-view widget, lamella editor, and
@@ -33,6 +35,7 @@ from fibsem.ui.widgets.canvas.canvas_state import (
 from fibsem.ui.widgets.canvas.fm_composite import FMLayer, composite_fm_layers
 from fibsem.ui.widgets.canvas.canvas_base import ContentRect, FibsemCanvasBase
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
 from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
 from fibsem.ui.widgets.canvas.quad_view import (
     LamellaEditorView,
@@ -46,6 +49,8 @@ __all__ = [
     "ContentRect",
     # image_canvas
     "FibsemImageCanvas",
+    # real_space_canvas
+    "FibsemRealSpaceCanvas",
     # fm_canvas
     "FMCanvasWidget",
     # fm_composite

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -215,6 +215,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._scalebar_visible: bool = True
         self._crosshair_visible: bool = True
         self._crosshair_artists: list = []
+        self._empty_artist = None  # "No image" placeholder; see _plot_empty
         self._hint_artist = None  # transient top-left instruction hint
         self._hint_text: Optional[str] = None  # remembered so it survives set_image
         self._title_artist = None  # top-centre image caption (e.g. FM z-slice)
@@ -678,9 +679,19 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         """
         return None
 
+    def _fit_extent(self) -> Optional[Tuple[float, float, float, float]]:
+        """What "fit to view" frames, as ``(xmin, xmax, ymax, ymin)`` or None.
+
+        Separate from :meth:`_content_extent` because the two answer different questions:
+        that one is *the space the canvas represents* (what overlays clamp and anchor to),
+        this one is *the thing worth looking at*. They coincide unless a canvas declares
+        space it has not filled.
+        """
+        return self._content_extent()
+
     def _fit_view(self) -> None:
-        """Set the view to the content extent expanded by ``_view_margin`` on each side."""
-        extent = self._content_extent()
+        """Set the view to the fit extent expanded by ``_view_margin`` on each side."""
+        extent = self._fit_extent()
         if extent is None:
             return
         xmin, xmax, ybot, ytop = extent  # (xmin, xmax, ymax, ymin)
@@ -808,7 +819,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
     def _plot_empty(self):
         self._ax.set_facecolor(self._facecolor)
         self._ax.axis("off")
-        self._ax.text(
+        # Kept so a subclass that never calls ax.cla() (one drawing many placed images)
+        # can take the placeholder away once it has content to show.
+        self._empty_artist = self._ax.text(
             0.5,
             0.5,
             "No image",
@@ -931,12 +944,15 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             except (ValueError, NotImplementedError):
                 pass
         self._crosshair_artists = []
-        if not self._crosshair_visible or self._img_w is None:
+        rect = self._content_rect()
+        if not self._crosshair_visible or rect.is_empty:
             return
-        cx, cy = self._img_w / 2.0, self._img_h / 2.0
+        # Centre of the content, wherever that is — for a single image at the origin
+        # this is (w/2, h/2) as before; for content placed in stage space it follows.
+        cx, cy = rect.cx, rect.cy
         # Size both arms from the longest dimension so the crosshair stays square
         # (axes use aspect="equal", so equal data-unit arms are equal on screen).
-        half = max(self._img_w, self._img_h) * 0.05 / 2
+        half = max(rect.width, rect.height) * 0.05 / 2
         kw = dict(color="yellow", linewidth=1, alpha=0.8, zorder=7)
         (h_line,) = self._ax.plot([cx - half, cx + half], [cy, cy], **kw)
         (v_line,) = self._ax.plot([cx, cx], [cy - half, cy + half], **kw)
@@ -951,9 +967,10 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
     def _on_press(self, event):
         if event.inaxes is not self._ax or event.xdata is None:
             return
-        if self._img_w is None:
-            # No image: axes span the default [0,1], so xdata/ydata are not image pixels.
-            # Suppress clicks/pan so a stray double-click can't drive a stage move to (~0,0).
+        if self._content_rect().is_empty:
+            # No content: axes span the default [0,1], so xdata/ydata are not canvas
+            # coordinates. Suppress clicks/pan so a stray double-click can't drive a
+            # stage move to (~0,0).
             return
         mods = _modifiers_from_event(event)
         if event.dblclick:

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -1,0 +1,439 @@
+"""FibsemRealSpaceCanvas — many images placed where they were acquired.
+
+Where :class:`~fibsem.ui.widgets.canvas.image_canvas.FibsemImageCanvas` shows one image
+filling the view, this shows *space*: a backdrop onto which each image is drawn at its
+own position and scale. Images acquired at different stage positions line up; images
+acquired at different pixel sizes compose at their true relative sizes.
+
+Coordinates
+-----------
+Positions are supplied in **metres**, in the plane the canvas is showing, with ``+x``
+right and ``+y`` down (image convention). Converting a *stage* position into that plane
+is the caller's job — see :mod:`fibsem.fm.reprojection` — which keeps this canvas free
+of microscope geometry and usable for FM and FIB/SEM alike.
+
+Internally the axes are in **canvas pixels at a reference pixel size**: a position in
+metres divided by :attr:`reference_pixel_size`. Metres would be the more natural unit,
+but the scalebar, ruler and view margin all assume pixel-ish magnitudes, and overlays
+would need converting. Matplotlib does the placement and scaling through each artist's
+``extent``, so nothing is resampled and no backing raster is allocated — memory is just
+the sum of the images.
+
+The reference pixel size defaults to that of the first image added, so a canvas holding
+a single image has axes in that image's own pixels.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from fibsem.ui.widgets.canvas.canvas_base import (
+    EMPTY_CONTENT,
+    ContentRect,
+    FibsemCanvasBase,
+    _downsample,
+)
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_BACKGROUND = "#000000"  # empty space reads as "nothing acquired here"
+_ORIGIN_MARKER_SIZE = 11  # points; fixed on screen, so zoom-independent
+
+# Pixels kept per placed image. Every artist is redrawn in full on each pan/zoom, so a
+# redraw costs the *total* stored pixels — 100 tiles kept at 1024 px square take ~2.7 s,
+# against ~0.75 s at 512. And 512 is already more than the display can use for the case
+# this canvas exists for: tiles in a 3x3 occupy ~330 screen px each, in a 10x10 ~100 px.
+# It only costs detail when zooming deep into one image; see FIB-414 for the real fix.
+_DEFAULT_DISPLAY_PX = 512
+
+
+@dataclass
+class PlacedImage:
+    """One image on the canvas, with the extent it was drawn at (canvas pixels)."""
+
+    key: str
+    artist: object
+    extent: Tuple[float, float, float, float]  # (xmin, xmax, ymax, ymin)
+
+
+class FibsemRealSpaceCanvas(FibsemCanvasBase):
+    """Canvas holding N images, each placed at the position it was acquired.
+
+    * :meth:`add_image` places an image from its centre position and pixel size
+    * :meth:`clear_images` empties the canvas without disturbing overlays
+    * the view fits the union of everything placed
+
+    Navigation, overlays, toolbar and chrome all come from :class:`FibsemCanvasBase`.
+    """
+
+    def __init__(
+        self,
+        parent=None,
+        reference_pixel_size: Optional[float] = None,
+        display_max_px: int = _DEFAULT_DISPLAY_PX,
+    ):
+        super().__init__(parent)
+        # Raise this for a canvas holding only a handful of images, where per-image
+        # detail matters more than redraw cost. See _DEFAULT_DISPLAY_PX.
+        self._display_max_px = int(display_max_px)
+        self._placed: Dict[str, PlacedImage] = {}
+        self._reference_pixel_size: Optional[float] = reference_pixel_size
+        # Optional (width, height, cx, cy) in metres — see set_world_extent.
+        self._world_extent_m: Optional[Tuple[float, float, float, float]] = None
+        self._auto_key = 0
+        # Refit as content grows, so tiles arriving during an acquisition stay in view.
+        # Callers that would rather keep the user's zoom can turn this off.
+        self.auto_fit: bool = True
+        self._fitted_extent: Optional[Tuple[float, float, float, float]] = None
+
+        if reference_pixel_size:
+            self._pixel_size = reference_pixel_size  # drives the scalebar
+
+        self.set_background_color(_DEFAULT_BACKGROUND)
+        # Contrast/gamma acts on a single frame; there is no meaning yet for "the"
+        # image here, so don't offer a control that would silently do nothing.
+        self.btn_contrast.hide()
+        self._reposition_overlay_buttons()
+
+    # ── properties ────────────────────────────────────────────────────────
+
+    @property
+    def reference_pixel_size(self) -> Optional[float]:
+        """Metres per canvas pixel, or None until the first image sets it."""
+        return self._reference_pixel_size
+
+    @property
+    def placed_keys(self) -> List[str]:
+        """Keys of the images currently placed, in insertion order."""
+        return list(self._placed)
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    def add_image(
+        self,
+        data: np.ndarray,
+        centre: Tuple[float, float],
+        pixel_size: float,
+        key: Optional[str] = None,
+        cmap: str = "gray",
+        zorder: Optional[float] = None,
+    ) -> str:
+        """Place *data* centred on *centre* (metres), at *pixel_size* metres/px.
+
+        Re-using a *key* replaces that image in place rather than stacking a second
+        artist on top — which is what a live preview wants as frames arrive. Returns
+        the key, so callers that don't supply one can still address the image later.
+
+        Images otherwise draw in the order they were added, so a later one covers an
+        earlier one where they overlap. Pass *zorder* when that is the wrong answer —
+        a coarse overview belongs *under* the detailed tiles acquired over it,
+        regardless of which arrived first.
+        """
+        data = np.asarray(data)
+        if data.ndim < 2:
+            raise ValueError(f"image data must be at least 2-D, got shape {data.shape}")
+        if not pixel_size or pixel_size <= 0:
+            raise ValueError(f"pixel_size must be positive, got {pixel_size!r}")
+
+        if self._reference_pixel_size is None:
+            # First image defines the scale, so a lone image maps 1:1 to canvas pixels.
+            self._reference_pixel_size = float(pixel_size)
+            self._pixel_size = float(pixel_size)
+
+        if key is None:
+            key = f"image-{self._auto_key}"
+            self._auto_key += 1
+
+        existing = self._placed.pop(key, None)
+        if existing is not None:
+            self._remove_artist(existing)
+
+        extent = self._extent_for(data.shape, centre, pixel_size)
+        shown = _downsample(data, self._display_max_px)
+        kw = {} if zorder is None else {"zorder": zorder}
+        artist = self._ax.imshow(
+            shown,
+            origin="upper",
+            aspect="equal",
+            interpolation="nearest",
+            extent=extent,
+            cmap=cmap if shown.ndim == 2 else None,
+            **kw,
+        )
+        self._placed[key] = PlacedImage(key=key, artist=artist, extent=extent)
+
+        self._after_content_change()
+        return key
+
+    def update_image(self, key: str, data: np.ndarray) -> bool:
+        """Swap the pixels of a placed image, keeping its position, scale and z-order.
+
+        The counterpart to :meth:`~FibsemImageCanvas.update_display` for a canvas holding
+        many images. Re-adding under the same key also works, but it destroys and
+        recreates the artist, which moves it to the top of the draw order — so a live
+        preview refreshed that way would climb over tiles it should sit beneath.
+
+        Returns False if *key* was not placed. The shape may change; the image keeps its
+        extent, so different-shaped data is stretched over the same ground.
+        """
+        placed = self._placed.get(key)
+        if placed is None:
+            return False
+        placed.artist.set_data(_downsample(np.asarray(data), self._display_max_px))
+        self.draw_idle()
+        return True
+
+    def remove_image(self, key: str) -> bool:
+        """Remove one placed image. Returns False if *key* was not placed."""
+        placed = self._placed.pop(key, None)
+        if placed is None:
+            return False
+        self._remove_artist(placed)
+        self._after_content_change()
+        return True
+
+    def clear_images(self) -> None:
+        """Remove every placed image, leaving overlays and chrome attached."""
+        if not self._placed:
+            return
+        for placed in self._placed.values():
+            self._remove_artist(placed)
+        self._placed.clear()
+        self._fitted_extent = None
+        self._after_content_change()
+
+    def clear(self) -> None:
+        """Clear the canvas entirely (axes are wiped, so drop the placements too)."""
+        self._placed.clear()
+        self._fitted_extent = None
+        super().clear()
+
+    def set_world_extent(
+        self,
+        width: Optional[float],
+        height: Optional[float] = None,
+        centre: Tuple[float, float] = (0.0, 0.0),
+    ) -> None:
+        """Always frame at least *width* x *height* metres, centred on *centre*.
+
+        Without this the view hugs whatever has been acquired, which has two costs: the
+        framing jumps every time a tile lands, and a run that walks in one direction
+        produces a long thin footprint — at which point ``aspect="equal"`` squeezes the
+        axes into a sliver of the window, since keeping pixels square leaves nothing else
+        to give. Declaring the working area up front keeps the framing stable and gives
+        the acquired region somewhere to sit.
+
+        A minimum, not a clip: images outside it still draw, and the view still grows to
+        include them. Pass None to go back to fitting the content alone.
+        """
+        if width is None:
+            self._world_extent_m = None
+        else:
+            height = width if height is None else height
+            if width <= 0 or height <= 0:
+                raise ValueError(f"world extent must be positive, got {width}x{height}")
+            self._world_extent_m = (width, height, centre[0], centre[1])
+        self._fitted_extent = None  # force a refit against the new framing
+        self._after_content_change()
+
+    @property
+    def world_extent(self) -> Optional[Tuple[float, float, float, float]]:
+        """The declared working area as (width, height, cx, cy) in metres, or None."""
+        return self._world_extent_m
+
+    def metres_to_canvas(self, x: float, y: float) -> Tuple[float, float]:
+        """Convert a position in metres to canvas coordinates.
+
+        For placing overlay geometry — markers, a planned grid — in the same frame as
+        the images. Returns (0, 0) before a reference pixel size exists.
+        """
+        ref = self._reference_pixel_size
+        if not ref:
+            return 0.0, 0.0
+        return x / ref, y / ref
+
+    def canvas_to_metres(self, x: float, y: float) -> Tuple[float, float]:
+        """Convert canvas coordinates back to metres — e.g. for a click position."""
+        ref = self._reference_pixel_size
+        if not ref:
+            return 0.0, 0.0
+        return x * ref, y * ref
+
+    # ── the base's content hooks ──────────────────────────────────────────
+
+    def _content_extent(self) -> Optional[Tuple[float, float, float, float]]:
+        """Union of every placed image and the declared working area, or None if empty.
+
+        The world extent is included as a *minimum*, so content outside it still frames.
+        """
+        extents = [p.extent for p in self._placed.values()]
+        world = self._world_extent_canvas()
+        if world is not None:
+            extents.append(world)
+        if not extents:
+            return None
+        return (
+            min(e[0] for e in extents),  # xmin
+            max(e[1] for e in extents),  # xmax
+            max(e[2] for e in extents),  # ymax (bottom; y runs down)
+            min(e[3] for e in extents),  # ymin (top)
+        )
+
+    def _image_extent(self) -> Optional[Tuple[float, float, float, float]]:
+        """Union of the placed images alone, ignoring any declared working area."""
+        extents = [p.extent for p in self._placed.values()]
+        if not extents:
+            return None
+        return (
+            min(e[0] for e in extents),
+            max(e[1] for e in extents),
+            max(e[2] for e in extents),
+            min(e[3] for e in extents),
+        )
+
+    def _fit_extent(self) -> Optional[Tuple[float, float, float, float]]:
+        """Frame the images, not the working area, padded to the widget's shape.
+
+        The working area says how much space the canvas *represents*; fitting to it would
+        zoom out past the data whenever the declared area is larger than what has been
+        acquired — which is the normal case. Falls back to the working area only when
+        there is nothing acquired to look at.
+        """
+        extent = self._image_extent() or self._content_extent()
+        return self._pad_to_widget_aspect(extent)
+
+    def _pad_to_widget_aspect(
+        self, extent: Optional[Tuple[float, float, float, float]]
+    ) -> Optional[Tuple[float, float, float, float]]:
+        """Grow the shorter axis so the framed region has the widget's proportions.
+
+        ``aspect="equal"`` keeps pixels square, and when the framed region is a different
+        shape from the widget the only thing left to give is the axes box — which
+        collapses to a sliver for a long thin mosaic (a run walking one direction framed
+        at 39:1 left an axes 2% of the window wide, with the content squeezed into it).
+
+        Padding the *view* instead means the box always fills the widget and the spare
+        room shows as backdrop, which on a real-space canvas is exactly right: empty
+        space is a truthful statement that nothing was acquired there.
+        """
+        if extent is None:
+            return None
+        xmin, xmax, ymax, ymin = extent
+        width, height = xmax - xmin, ymax - ymin
+        widget_w, widget_h = self.width(), self.height()
+        if width <= 0 or height <= 0 or widget_w <= 0 or widget_h <= 0:
+            return extent
+
+        target = widget_w / widget_h
+        if width / height < target:  # too tall for the window -> widen
+            pad = (height * target - width) / 2.0
+            return (xmin - pad, xmax + pad, ymax, ymin)
+        pad = (width / target - height) / 2.0  # too wide -> heighten
+        return (xmin, xmax, ymax + pad, ymin - pad)
+
+    def _world_extent_canvas(self) -> Optional[Tuple[float, float, float, float]]:
+        """The declared working area in canvas pixels, or None if not usable yet.
+
+        Needs a reference pixel size, which the first image supplies unless one was
+        given up front — so a world extent set on an empty canvas takes effect as soon
+        as there is something to scale it against.
+        """
+        ref = self._reference_pixel_size
+        if self._world_extent_m is None or not ref:
+            return None
+        width, height, cx, cy = self._world_extent_m
+        half_w, half_h = width / 2.0 / ref, height / 2.0 / ref
+        cx, cy = cx / ref, cy / ref
+        return (cx - half_w, cx + half_w, cy + half_h, cy - half_h)
+
+    def _content_rect(self) -> ContentRect:
+        """The union, as the rectangle overlays clamp and anchor to."""
+        extent = self._content_extent()
+        if extent is None:
+            return EMPTY_CONTENT
+        xmin, xmax, ymax, ymin = extent
+        return ContentRect(xmin, ymin, xmax - xmin, ymax - ymin)
+
+    # ── internals ─────────────────────────────────────────────────────────
+
+    def _extent_for(
+        self,
+        shape: Tuple[int, ...],
+        centre: Tuple[float, float],
+        pixel_size: float,
+    ) -> Tuple[float, float, float, float]:
+        """Where an image of *shape* centred on *centre* (metres) lands, in canvas px."""
+        ref = self._reference_pixel_size or pixel_size
+        height, width = shape[0], shape[1]
+        scale = pixel_size / ref  # canvas pixels per image pixel
+        half_w = width * scale / 2.0
+        half_h = height * scale / 2.0
+        cx, cy = centre[0] / ref, centre[1] / ref
+        # matplotlib extent is (left, right, bottom, top); y runs down, so bottom > top.
+        return (cx - half_w, cx + half_w, cy + half_h, cy - half_h)
+
+    def _refresh_crosshair(self):
+        """Mark the origin, at a fixed size on screen.
+
+        The base draws at the centre of the content, with arms scaled to it. Neither
+        works here: the centre of a union of tiles is wherever they happen to average
+        out, and scaling the arms to a declared working area makes the crosshair
+        enormous — 5% of 2 mm is 100 um across.
+
+        The origin is the position the caller built the canvas around (the reference
+        stage position), so that is the landmark worth drawing. Drawn as a marker rather
+        than two lines so it keeps its size on screen through zoom, the way a position
+        marker should.
+        """
+        for a in self._crosshair_artists:
+            try:
+                a.remove()
+            except (ValueError, NotImplementedError):
+                pass
+        self._crosshair_artists = []
+        if not self._crosshair_visible or self._reference_pixel_size is None:
+            return
+        (marker,) = self._ax.plot(
+            [0.0], [0.0],
+            marker="+", markersize=_ORIGIN_MARKER_SIZE, markeredgewidth=1.0,
+            color="yellow", alpha=0.8, linestyle="None", zorder=7,
+        )
+        self._crosshair_artists = [marker]
+
+    def _remove_artist(self, placed: PlacedImage) -> None:
+        try:
+            placed.artist.remove()
+        except (ValueError, NotImplementedError, AttributeError):
+            pass
+
+    def _sync_placeholder(self) -> None:
+        """Show "No image" only while nothing is placed.
+
+        This canvas never calls ``ax.cla()`` — that is the whole point, since the axes
+        accumulate images — so the placeholder has to be taken away and put back by hand.
+        """
+        if self._placed and self._empty_artist is not None:
+            try:
+                self._empty_artist.remove()
+            except (ValueError, NotImplementedError):
+                pass
+            self._empty_artist = None
+        elif not self._placed and self._empty_artist is None:
+            self._plot_empty()
+
+    def _after_content_change(self) -> None:
+        """Refit if the footprint changed, refresh chrome, and tell the overlays."""
+        self._sync_placeholder()
+        extent = self._fit_extent()
+        if self.auto_fit and extent != self._fitted_extent:
+            self._fit_view()
+            self._fitted_extent = extent
+
+        self._refresh_scalebar()
+        self._refresh_crosshair()
+        self._notify_overlays(self._content_rect())
+        self.draw_idle()

--- a/fibsem/ui/widgets/tests/test_real_space_canvas_demo.py
+++ b/fibsem/ui/widgets/tests/test_real_space_canvas_demo.py
@@ -1,0 +1,231 @@
+"""Standalone demo for FibsemRealSpaceCanvas.
+
+Not a pytest module despite the name — this directory holds GUI harnesses, which pytest
+never collects (``testpaths = ["tests"]``). The automated tests live in
+``tests/ui/test_real_space_canvas.py``.
+
+Run directly:
+    python fibsem/ui/widgets/tests/test_real_space_canvas_demo.py
+
+Shows a 3x3 tileset placed at true stage offsets on a black backdrop, so overlap and
+alignment are visible. The cursor readout gives the position in canvas-frame metres.
+
+The second button adds *the same array* at 4x the pixel size, which must therefore cover
+4x the ground. That is the property a canvas can only get right by honouring pixel size
+per image: resample everything onto one raster, or ignore pixel size, and it would draw
+the same size as a grid tile. It is what a decimated live preview or a binned overview
+looks like beside a full-resolution tile.
+
+Pan/zoom, the scalebar and the ruler all work as on any canvas.
+"""
+import sys
+
+import numpy as np
+from PyQt5.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.ui.stylesheets import NAPARI_STYLE
+from fibsem.ui.widgets.canvas.overlays.point_overlay import PointsOverlay
+from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
+
+PIXEL_SIZE = 1e-7  # 100 nm/px
+TILE = 256  # px -> 25.6 um per tile
+OVERLAP = 0.1
+STEP = TILE * PIXEL_SIZE * (1 - OVERLAP)  # centre-to-centre tile spacing, metres
+WORLD_EXTENT = 2000e-6  # declared working area, so framing is stable as tiles arrive
+
+# Stage positions to mark, in metres. The second is the centre of the top-left tile, so
+# its marker should sit dead-centre on that tile — the check that overlay geometry and
+# image placement agree rather than merely looking plausible together.
+STAGE_MARKERS = [
+    (0.0, 0.0),
+    (-STEP, -STEP),
+]
+
+
+def _tile(seed: int, size: int = TILE) -> np.ndarray:
+    """A distinguishable tile: noise plus a bright border to show seams.
+
+    Brightness cycles over a narrow band rather than climbing with the seed — scaling it
+    linearly saturated every tile past seed ~11 to solid white, which drew as an opaque
+    block hiding whatever it overlapped.
+    """
+    rng = np.random.default_rng(seed)
+    data = rng.normal(loc=85 + 22 * (seed % 5), scale=20, size=(size, size))
+    data[:4, :] = data[-4:, :] = data[:, :4] = data[:, -4:] = 255
+    return np.clip(data, 0, 255).astype(np.uint8)
+
+
+class RealSpaceCanvasDemo(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Real-space canvas — demo")
+        self.resize(1000, 900)
+
+        self.canvas = FibsemRealSpaceCanvas()
+        self.label = QLabel()
+        self.label.setStyleSheet("color: #d1d2d4; padding: 6px; font-family: monospace;")
+
+        # Live cursor position, which is the readout that actually shows the canvas is
+        # in real space: hovering the same feature on two tiles should give the same
+        # metres, and the numbers should track the tile centres the demo places.
+        self.cursor_label = QLabel()
+        self.cursor_label.setStyleSheet(
+            "color: #ffd23f; padding: 0px 6px 6px 6px; font-family: monospace;"
+        )
+        self.canvas.mpl_connect("motion_notify_event", self._on_cursor_moved)
+        self._on_cursor_moved(None)
+
+        # Stage-position markers, placed through the same metres-to-canvas conversion
+        # the images use — so if the two ever disagree, the marker misses its tile.
+        self.markers = PointsOverlay(color="#00e5ff", marker="+", size=14)
+        self.canvas.add_overlay(self.markers)
+
+        self._n_coarse = 0
+        self._add_tileset()
+
+        btn_reset = QPushButton("Reload tileset")
+        btn_reset.clicked.connect(self._reload)
+        btn_coarse = QPushButton("Add same tile at 4x pixel size (covers 4x the ground)")
+        btn_coarse.clicked.connect(self._add_coarse)
+        btn_clear = QPushButton("Clear images")
+        btn_clear.clicked.connect(self._clear)
+        self.btn_world = QPushButton()
+        self.btn_world.clicked.connect(self._toggle_world)
+
+        row = QHBoxLayout()
+        for b in (btn_reset, btn_coarse, btn_clear, self.btn_world):
+            row.addWidget(b)
+
+        self._world_on = True
+        self.canvas.set_world_extent(WORLD_EXTENT)
+        self._sync_world_button()
+
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.addWidget(self.canvas)
+        lay.addWidget(self.label)
+        lay.addWidget(self.cursor_label)
+        lay.addLayout(row)
+
+    # ── actions ───────────────────────────────────────────────────────────
+
+    def _add_tileset(self) -> None:
+        """A 3x3 grid stepped by one field of view less the overlap."""
+        step = TILE * PIXEL_SIZE * (1 - OVERLAP)
+        seed = 0
+        for row in range(3):
+            for col in range(3):
+                x = (col - 1) * step
+                y = (row - 1) * step
+                self.canvas.add_image(
+                    _tile(seed), centre=(x, y), pixel_size=PIXEL_SIZE, key=f"r{row}c{col}"
+                )
+                seed += 1
+        self._refresh_markers()
+        self._describe()
+
+    def _refresh_markers(self) -> None:
+        """Place the stage markers, converting metres to canvas coordinates.
+
+        Deferred until an image exists, because the reference pixel size — and so the
+        conversion — is set by the first image added.
+        """
+        if self.canvas.reference_pixel_size is None:
+            return
+        points = [self.canvas.metres_to_canvas(x, y) for x, y in STAGE_MARKERS]
+        labels = [f"({x * 1e6:+.1f}, {y * 1e6:+.1f}) um" for x, y in STAGE_MARKERS]
+        self.markers.set_points(points, labels=labels)
+
+    def _add_coarse(self) -> None:
+        """The same-sized array at 4x the pixel size, so it must cover 4x the ground.
+
+        This is the property that matters: a canvas that resampled everything onto one
+        raster, or that ignored pixel size, would draw this the same size as a grid tile.
+        It is what a decimated live preview or a binned overview looks like next to a
+        full-resolution tile.
+
+        Only the pixel size differs from a grid tile — same array shape — so the
+        comparison reads directly as "4x the pixel size, 4x the footprint". Placed clear
+        of the grid, since images draw in the order added and an overlapping one would
+        simply hide what is beneath.
+        """
+        self._n_coarse += 1
+        grid_half = TILE * PIXEL_SIZE * (1 - OVERLAP) + TILE * PIXEL_SIZE / 2
+        coarse_half = TILE * PIXEL_SIZE * 4 / 2
+        pitch = 2 * coarse_half + 5e-6
+        # Wrap into a block rather than a single column: marching in one direction gives
+        # a long thin footprint, and with aspect="equal" that squeezes the whole scene
+        # into a sliver of the window.
+        col, row = (self._n_coarse - 1) % 4, (self._n_coarse - 1) // 4
+        x = grid_half + coarse_half + 5e-6 + col * pitch
+        y = row * pitch - coarse_half
+        self.canvas.add_image(
+            _tile(self._n_coarse),
+            centre=(x, y),
+            pixel_size=PIXEL_SIZE * 4,
+            key=f"coarse-{self._n_coarse}",
+        )
+        self._describe()
+
+    def _toggle_world(self) -> None:
+        """Compare a declared working area against framing that hugs the content."""
+        self._world_on = not self._world_on
+        self.canvas.set_world_extent(WORLD_EXTENT if self._world_on else None)
+        self._sync_world_button()
+        self._describe()
+
+    def _sync_world_button(self) -> None:
+        self.btn_world.setText(
+            f"Working area: {WORLD_EXTENT * 1e6:.0f} um" if self._world_on
+            else "Working area: off (fit to content)"
+        )
+
+    def _on_cursor_moved(self, event) -> None:
+        """Report the cursor in canvas-frame metres — the demo's real-space readout."""
+        if event is None or event.xdata is None or event.ydata is None:
+            self.cursor_label.setText("cursor:  —")
+            return
+        x, y = self.canvas.canvas_to_metres(event.xdata, event.ydata)
+        self.cursor_label.setText(f"cursor:  x={x * 1e6:+8.2f} um   y={y * 1e6:+8.2f} um")
+
+    def _reload(self) -> None:
+        self.canvas.clear_images()
+        self._n_coarse = 0
+        self._add_tileset()
+
+    def _clear(self) -> None:
+        self.canvas.clear_images()
+        self._describe()
+
+    def _describe(self) -> None:
+        rect = self.canvas._content_rect()
+        ref = self.canvas.reference_pixel_size
+        if rect.is_empty or not ref:
+            self.label.setText("no images placed")
+            return
+        self.label.setText(
+            f"{len(self.canvas.placed_keys)} images   "
+            f"reference={ref * 1e9:.0f} nm/px   "
+            f"span={rect.width * ref * 1e6:.1f} x {rect.height * ref * 1e6:.1f} um   "
+            f"centre=({rect.cx * ref * 1e6:+.1f}, {rect.cy * ref * 1e6:+.1f}) um"
+        )
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    app.setStyle("Fusion")
+    win = RealSpaceCanvasDemo()
+    win.setStyleSheet(NAPARI_STYLE + "QWidget { background: #262930; color: #d1d2d4; }")
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -1,0 +1,509 @@
+"""The real-space canvas: images drawn where they were acquired.
+
+The thing worth pinning is that placement is *truthful* — two images acquired a known
+distance apart must land that distance apart on screen, in the right direction, at the
+right relative size. A canvas that draws them plausibly but wrongly is worse than one
+that draws nothing, because it looks like evidence.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python tests/ui/test_real_space_canvas.py
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase
+from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+PIXEL_SIZE = 1e-7  # 100 nm/px
+W = H = 100  # so one image spans 10 um
+
+
+def _img(h=H, w=W):
+    return np.zeros((h, w), dtype=np.uint8)
+
+
+def _canvas(**kw):
+    return FibsemRealSpaceCanvas(**kw)
+
+
+# ── structure ─────────────────────────────────────────────────────────────
+
+
+def test_it_is_a_base_canvas():
+    assert issubclass(FibsemRealSpaceCanvas, FibsemCanvasBase)
+
+
+def test_an_empty_canvas_has_no_content_and_survives_a_fit():
+    c = _canvas()
+    assert c._content_extent() is None
+    assert c._content_rect().is_empty
+    c.reset_view()  # must not raise
+
+
+def test_the_first_image_sets_the_reference_scale():
+    """So a canvas showing one image has axes in that image's own pixels."""
+    c = _canvas()
+    assert c.reference_pixel_size is None
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    assert c.reference_pixel_size == PIXEL_SIZE
+    xmin, xmax, ymax, ymin = c._content_extent()
+    assert (xmax - xmin, ymax - ymin) == (W, H)  # one canvas pixel per image pixel
+
+
+# ── placement ─────────────────────────────────────────────────────────────
+
+
+def test_an_image_is_centred_on_its_position():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    xmin, xmax, ymax, ymin = c._content_extent()
+    assert (xmin, xmax) == (-W / 2, W / 2)
+    assert (ymin, ymax) == (-H / 2, H / 2)
+
+
+def test_two_images_land_the_right_distance_apart():
+    """The core claim: a 10 um separation is 10 um on the canvas."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="a")
+    c.add_image(_img(), centre=(10e-6, 0.0), pixel_size=PIXEL_SIZE, key="b")
+    a, b = c._placed["a"].extent, c._placed["b"].extent
+    centre_a = (a[0] + a[1]) / 2
+    centre_b = (b[0] + b[1]) / 2
+    assert centre_b - centre_a == pytest.approx(10e-6 / PIXEL_SIZE)  # 100 canvas px
+
+
+def test_positive_x_is_right_and_positive_y_is_down():
+    """Direction, not just distance — a sign error here mirrors the whole mosaic."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="origin")
+    c.add_image(_img(), centre=(5e-6, 3e-6), pixel_size=PIXEL_SIZE, key="offset")
+    o, f = c._placed["origin"].extent, c._placed["offset"].extent
+    assert (f[0] + f[1]) / 2 > (o[0] + o[1]) / 2  # +x drew further right
+    assert (f[2] + f[3]) / 2 > (o[2] + o[3]) / 2  # +y drew further down
+
+
+def test_a_coarser_image_covers_proportionally_more_ground():
+    """Different binning must compose at true relative size, not equal size."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="fine")
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE * 4, key="coarse")
+    fine = c._placed["fine"].extent
+    coarse = c._placed["coarse"].extent
+    assert (coarse[1] - coarse[0]) == pytest.approx(4 * (fine[1] - fine[0]))
+
+
+def test_a_non_square_image_keeps_its_aspect():
+    c = _canvas()
+    c.add_image(_img(h=50, w=200), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    xmin, xmax, ymax, ymin = c._content_extent()
+    assert (xmax - xmin, ymax - ymin) == (200, 50)
+
+
+def test_placement_is_absolute_not_relative_to_the_previous_image():
+    """Positions are absolute, so nothing accumulates drift as tiles arrive (FIB-399)."""
+    c = _canvas()
+    step = 9.999e-6  # deliberately not a whole number of canvas pixels
+    for i in range(10):
+        c.add_image(_img(), centre=(i * step, 0.0), pixel_size=PIXEL_SIZE, key=str(i))
+    first, last = c._placed["0"].extent, c._placed["9"].extent
+    spread = (last[0] + last[1]) / 2 - (first[0] + first[1]) / 2
+    assert spread == pytest.approx(9 * step / PIXEL_SIZE)
+
+
+# ── the union ─────────────────────────────────────────────────────────────
+
+
+def test_the_content_extent_is_the_union():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    c.add_image(_img(), centre=(10e-6, 10e-6), pixel_size=PIXEL_SIZE)
+    xmin, xmax, ymax, ymin = c._content_extent()
+    assert (xmin, ymin) == (-W / 2, -H / 2)  # top-left of the first
+    assert (xmax, ymax) == (100 + W / 2, 100 + H / 2)  # bottom-right of the second
+
+
+def test_the_content_rect_matches_the_union_and_is_offset():
+    """Overlays clamp and anchor to this — it must carry the origin, not assume (0, 0)."""
+    c = _canvas()
+    c.add_image(_img(), centre=(50e-6, 20e-6), pixel_size=PIXEL_SIZE)
+    rect = c._content_rect()
+    assert (rect.x0, rect.y0) == pytest.approx((500 - W / 2, 200 - H / 2))
+    assert (rect.width, rect.height) == pytest.approx((W, H))
+    assert (rect.cx, rect.cy) == pytest.approx((500, 200))  # what an overlay anchors on
+
+
+def test_fit_view_frames_everything_placed():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    c.add_image(_img(), centre=(50e-6, 0.0), pixel_size=PIXEL_SIZE)
+    c.reset_view()
+    x0, x1 = c._ax.get_xlim()
+    assert x0 <= -W / 2 and x1 >= 500 + W / 2
+
+
+# ── lifecycle ─────────────────────────────────────────────────────────────
+
+
+def test_reusing_a_key_replaces_rather_than_stacks():
+    """A live preview pushes a frame per tick; stacking artists would leak them."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="preview")
+    c.add_image(_img(), centre=(20e-6, 0.0), pixel_size=PIXEL_SIZE, key="preview")
+    assert c.placed_keys == ["preview"]
+    assert len(c._ax.get_images()) == 1
+    assert c._content_rect().cx == pytest.approx(200)  # moved to the new position
+
+
+def test_distinct_images_accumulate():
+    c = _canvas()
+    for i in range(3):
+        c.add_image(_img(), centre=(i * 20e-6, 0.0), pixel_size=PIXEL_SIZE)
+    assert len(c.placed_keys) == 3
+    assert len(c._ax.get_images()) == 3
+
+
+def test_removing_an_image_shrinks_the_union():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="a")
+    c.add_image(_img(), centre=(50e-6, 0.0), pixel_size=PIXEL_SIZE, key="b")
+    assert c.remove_image("b") is True
+    assert c._content_rect().cx == 0
+    assert c.remove_image("b") is False  # already gone
+
+
+def test_clear_images_empties_the_canvas_but_keeps_overlays():
+    from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+
+    class _Rec(CanvasOverlay):
+        def __init__(self):
+            self.rects = []
+
+        def on_content_changed(self, rect):
+            self.rects.append(rect)
+
+    c = _canvas()
+    rec = _Rec()
+    c.add_overlay(rec)
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    c.clear_images()
+    assert c.placed_keys == []
+    assert c._content_extent() is None
+    assert rec in c._overlays
+    assert rec.rects[-1].is_empty  # told the content went away
+
+
+def test_the_placeholder_goes_away_and_comes_back():
+    """The axes are never cleared here, so the "No image" text is managed by hand."""
+    c = _canvas()
+    assert c._empty_artist is not None
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    assert c._empty_artist is None
+    c.clear_images()
+    assert c._empty_artist is not None
+
+
+# ── validation and conversion ─────────────────────────────────────────────
+
+
+def test_a_nonsense_pixel_size_is_rejected():
+    c = _canvas()
+    for bad in (0, -1e-7, None):
+        with pytest.raises(ValueError):
+            c.add_image(_img(), centre=(0.0, 0.0), pixel_size=bad)
+
+
+def test_one_dimensional_data_is_rejected():
+    c = _canvas()
+    with pytest.raises(ValueError):
+        c.add_image(np.zeros(10), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+
+
+def test_metres_and_canvas_coordinates_round_trip():
+    c = _canvas(reference_pixel_size=PIXEL_SIZE)
+    assert c.metres_to_canvas(5e-6, -2e-6) == pytest.approx((50.0, -20.0))
+    assert c.canvas_to_metres(50.0, -20.0) == pytest.approx((5e-6, -2e-6))
+
+
+def test_conversion_is_inert_before_a_reference_exists():
+    assert _canvas().metres_to_canvas(1.0, 1.0) == (0.0, 0.0)
+
+
+# ── auto-fit ──────────────────────────────────────────────────────────────
+
+
+def test_auto_fit_can_be_turned_off_to_keep_the_users_zoom():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    c.auto_fit = False
+    c._ax.set_xlim(0, 10)
+    c.add_image(_img(), centre=(500e-6, 0.0), pixel_size=PIXEL_SIZE)
+    assert c._ax.get_xlim() == (0, 10)  # the new tile did not re-frame the view
+
+
+# ── the declared working area ─────────────────────────────────────────────
+
+
+def test_a_world_extent_frames_at_least_that_much_space():
+    """Without one the view hugs the content, so framing jumps as each tile lands."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    c.set_world_extent(200e-6)
+    rect = c._content_rect()
+    assert (rect.width, rect.height) == pytest.approx((2000, 2000))  # 200 um at 100 nm/px
+    assert (rect.cx, rect.cy) == pytest.approx((0, 0))
+
+
+def test_a_world_extent_is_a_minimum_not_a_clip():
+    """Content beyond the declared area must still be framed, not cropped away."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    c.set_world_extent(50e-6)
+    c.add_image(_img(), centre=(500e-6, 0.0), pixel_size=PIXEL_SIZE, key="far")
+    rect = c._content_rect()
+    assert rect.x1 >= 5000 + W / 2  # the distant image is still inside the frame
+
+
+def test_a_world_extent_bounds_the_overlays_not_the_view():
+    """The two extents answer different questions and must not be conflated: overlays
+    clamp and anchor to the space the canvas represents, while the view frames the data.
+    """
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    c.set_world_extent(500e-6)
+    assert c._content_rect().width == pytest.approx(5000)  # overlays see the whole area
+    assert c._image_extent() == pytest.approx((-W / 2, W / 2, H / 2, -H / 2))
+
+
+def test_fit_frames_the_images_not_the_declared_working_area():
+    """Fitting to the working area would zoom past the data whenever the declared area
+    is bigger than what has been acquired — which is the normal case."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    c.set_world_extent(500e-6)
+    xmin, xmax, _, _ = c._fit_extent()
+    assert xmax - xmin < 5000  # nowhere near the 500 um working area
+    c.clear_images()
+    assert c._fit_extent() is not None  # with nothing acquired, the area is all there is
+
+
+def test_a_rectangular_and_offset_working_area():
+    c = _canvas(reference_pixel_size=PIXEL_SIZE)
+    c.set_world_extent(100e-6, 40e-6, centre=(10e-6, -20e-6))
+    rect = c._content_rect()
+    assert (rect.width, rect.height) == pytest.approx((1000, 400))
+    assert (rect.cx, rect.cy) == pytest.approx((100, -200))
+
+
+def test_clearing_the_world_extent_returns_to_fitting_the_content():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    c.set_world_extent(500e-6)
+    assert c._content_rect().width == pytest.approx(5000)
+    c.set_world_extent(None)
+    assert c._content_rect().width == pytest.approx(W)
+    assert c.world_extent is None
+
+
+def test_a_world_extent_waits_for_a_reference_pixel_size():
+    """Set on an empty canvas there is nothing to scale against; it must apply as soon
+    as the first image supplies the scale, rather than being silently dropped."""
+    c = _canvas()
+    c.set_world_extent(200e-6)
+    assert c._content_extent() is None  # nothing to scale it against yet
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    assert c._content_rect().width == pytest.approx(2000)
+
+
+def test_a_nonsense_world_extent_is_rejected():
+    c = _canvas()
+    for bad in (0, -1e-6):
+        with pytest.raises(ValueError):
+            c.set_world_extent(bad)
+
+
+# ── framing and the crosshair ─────────────────────────────────────────────
+
+
+def test_a_long_thin_mosaic_still_fills_the_widget():
+    """aspect="equal" keeps pixels square, so a framed region shaped unlike the widget
+    collapses the axes box instead — 39:1 content left an axes 2% of the window wide.
+    The fit pads the short axis so the box stays full and the slack shows as backdrop.
+    """
+    c = _canvas()
+    c.resize(1000, 900)
+    for i in range(20):
+        c.add_image(_img(), centre=(0.0, i * 20e-6), pixel_size=PIXEL_SIZE, key=str(i))
+    images = c._image_extent()
+    assert (images[2] - images[3]) / (images[1] - images[0]) > 30  # genuinely degenerate
+
+    fit = c._fit_extent()
+    assert (fit[2] - fit[3]) / (fit[1] - fit[0]) == pytest.approx(900 / 1000, rel=0.01)
+
+
+def test_padding_the_fit_never_hides_an_image():
+    """Padding may only grow the framed region — cropping to fit would lose data."""
+    c = _canvas()
+    c.resize(1000, 900)
+    for i in range(6):
+        c.add_image(_img(), centre=(0.0, i * 20e-6), pixel_size=PIXEL_SIZE, key=str(i))
+    images, fit = c._image_extent(), c._fit_extent()
+    assert fit[0] <= images[0] and fit[1] >= images[1]
+    assert fit[3] <= images[3] and fit[2] >= images[2]
+
+
+def test_the_crosshair_marks_the_origin_not_the_middle_of_the_content():
+    """The centre of a union of tiles is wherever they happen to average out; the origin
+    is the position the caller built the canvas around."""
+    c = _canvas()
+    c.add_image(_img(), centre=(500e-6, 500e-6), pixel_size=PIXEL_SIZE)  # far off-origin
+    assert c._content_rect().cx == pytest.approx(5000)  # content is nowhere near (0, 0)
+    (marker,) = c._crosshair_artists
+    xs, ys = marker.get_data()
+    assert (xs[0], ys[0]) == (0.0, 0.0)
+
+
+def test_the_crosshair_does_not_scale_with_the_working_area():
+    """Arms scaled to the content made the crosshair 5% of a 2 mm area — 100 um across."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    small = c._crosshair_artists[0].get_markersize()
+    c.set_world_extent(2000e-6)
+    assert c._crosshair_artists[0].get_markersize() == small  # fixed on screen
+
+
+def test_the_crosshair_can_still_be_hidden():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    assert c._crosshair_artists
+    c.set_crosshair_visible(False)
+    assert c._crosshair_artists == []
+
+
+# ── draw order and in-place updates ───────────────────────────────────────
+
+
+def test_later_images_draw_over_earlier_ones_by_default():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="under")
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="over")
+    order = [im.get_zorder() for im in c._ax.get_images()]
+    assert c._ax.get_images()[-1] is c._placed["over"].artist
+    assert order == sorted(order)
+
+
+def test_zorder_puts_a_coarse_overview_beneath_later_tiles():
+    """Arrival order is the wrong answer when a low-res overview is acquired first and
+    detailed tiles land on top of it — or acquired last and would bury them."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="tile")
+    c.add_image(
+        _img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE * 4, key="overview", zorder=-1
+    )
+    assert c._placed["overview"].artist.get_zorder() < c._placed["tile"].artist.get_zorder()
+
+
+def test_update_image_keeps_position_scale_and_draw_order():
+    """A live preview refreshed by re-adding would climb over tiles it should sit under,
+    because destroying the artist and making a new one puts it on top."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="preview", zorder=-1)
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="tile")
+    before = c._placed["preview"].extent
+    artist = c._placed["preview"].artist
+
+    assert c.update_image("preview", np.full((H, W), 200, dtype=np.uint8)) is True
+    assert c._placed["preview"].artist is artist  # same artist, so same z-order
+    assert c._placed["preview"].extent == before
+    assert c._placed["preview"].artist.get_array().max() == 200  # pixels did change
+
+
+def test_update_image_reports_an_unknown_key():
+    assert _canvas().update_image("nope", _img()) is False
+
+
+def test_the_default_display_cap_favours_redraw_speed():
+    """A redraw costs the total stored pixels, so the default is tuned for the case this
+    canvas exists for — many images at once, where 512 px already exceeds what each gets
+    on screen. At 1024 px a 100-tile redraw took 2.7 s; at 512 px it takes ~0.7 s."""
+    c = _canvas()
+    c.add_image(_img(1024, 1024), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    assert max(c._ax.get_images()[0].get_array().shape) <= 512
+
+
+def test_the_display_cap_bounds_what_each_image_stores():
+    """Redraw cost is the total stored pixels across every placed image, so a canvas
+    expecting many tiles needs a lower cap than one expecting a few."""
+    c = FibsemRealSpaceCanvas(display_max_px=128)
+    c.add_image(_img(1024, 1024), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    stored = c._ax.get_images()[0].get_array()
+    assert max(stored.shape) <= 128
+    # the extent still describes the full physical footprint, not the stored pixels
+    xmin, xmax, _, _ = c._content_extent()
+    assert xmax - xmin == pytest.approx(1024)
+
+
+# ── the seam with the real projection ─────────────────────────────────────
+
+
+def test_a_projected_stage_offset_places_an_image_where_the_projection_says():
+    """This canvas deliberately knows nothing about stages — the caller projects, and
+    hands over metres in the display plane. This pins that composition, so FIB-412
+    wires the two together rather than reimplementing the geometry against it.
+    """
+    import numpy as np
+
+    from fibsem.fm.reprojection import project_stage_position
+    from fibsem.fm.structures import CameraImageTransform, FMImageGeometry
+    from fibsem.structures import FibsemStagePosition
+
+    geometry = FMImageGeometry(
+        transform=CameraImageTransform.NONE,
+        camera_tilt=180.0,
+        is_compustage=True,
+        shuttle_pre_tilt=0.0,
+    )
+    base = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(-180))
+    moved = FibsemStagePosition(x=20e-6, y=0.0, z=0.0, r=0.0, t=np.deg2rad(-180))
+    shape = (H, W)
+
+    # What the caller does: project, then express the offset from the image centre
+    # in metres, which is what add_image() takes.
+    point = project_stage_position(moved, base, PIXEL_SIZE, shape, geometry)
+    centre = ((point.x - W / 2) * PIXEL_SIZE, (point.y - H / 2) * PIXEL_SIZE)
+
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="base")
+    c.add_image(_img(), centre=centre, pixel_size=PIXEL_SIZE, key="moved")
+
+    a, b = c._placed["base"].extent, c._placed["moved"].extent
+    separation = (b[0] + b[1]) / 2 - (a[0] + a[1]) / 2
+    # The 20 um stage step is 200 canvas pixels at 100 nm/px, and lands on the axis
+    # and in the direction the projection chose -- not one this canvas invented.
+    assert separation == pytest.approx(point.x - W / 2)
+    assert abs(separation) == pytest.approx(200)
+    assert (b[2] + b[3]) / 2 == pytest.approx((a[2] + a[3]) / 2)  # no drift in y
+
+
+if __name__ == "__main__":
+    failed = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except AssertionError as e:
+                failed += 1
+                print(f"FAIL {name}: {e}")
+    print("all passed" if not failed else f"{failed} failed")


### PR DESCRIPTION
Step 3 of FIB-408 — showing FM overviews on a real-space canvas. Follows #247 and #248. **All new code, no consumers**, so nothing in the app changes.

## What

A second `FibsemCanvasBase` subclass holding N images instead of one, each placed at its own position and scale. Images acquired at different stage positions line up; images acquired at different pixel sizes compose at true relative size.

```python
canvas.add_image(data, centre=(x_m, y_m), pixel_size=1e-7, key="r0c0", zorder=-1)
canvas.update_image("preview", frame)      # swap pixels, keep position and draw order
canvas.set_world_extent(2000e-6)           # frame at least this much space
canvas.canvas_to_metres(x, y)              # e.g. a click position
```

## Design decisions worth reviewing

**Positions are metres, not stage positions.** The caller does the stage-to-plane projection with `fibsem/fm/reprojection.py`. Keeping microscope geometry out of the canvas is what lets the FIB/SEM overview reuse it later (FIB-413), and there is a test pinning that composition so FIB-412 wires the two together rather than re-deriving the geometry against it.

**Axes are canvas pixels at a reference pixel size**, taken from the first image added — so a canvas holding a single image has axes in that image's own pixels, degrading to today's behaviour. Metres would be more natural, but the scalebar, ruler and view margin all assume pixel-ish magnitudes.

**Placement goes through each artist's `extent`**, so nothing is resampled and there is no backing raster. Positions are absolute rather than accumulated, avoiding the drift class of FIB-399.

**Two extents, deliberately distinct.** `_content_extent` is *the space the canvas represents* (images ∪ declared working area) and drives what overlays clamp and anchor to; `_fit_extent` is *the thing worth looking at* (images). Conflating them meant "fit" zoomed out past the data whenever the working area was larger than what had been acquired — the normal case.

## Things found by measuring

**A 10x10 overview took 2.7 s to redraw.** Every placed artist is redrawn in full on each pan/zoom, so cost scales with total stored pixels, not the largest image. Adding is cheap (~0.6 ms/tile); drawing was not:

| tiles | redraw @1024px | redraw @512px |
| -- | -- | -- |
| 9 | 310 ms | 139 ms |
| 25 | 688 ms | 187 ms |
| 100 | 2681 ms | 698 ms |

Hence `display_max_px`, defaulting to **512** — already more than each image gets on screen in the case this canvas exists for (tiles in a 3x3 occupy ~330 screen px, in a 10x10 ~100 px). This is explicitly only half a fix, and **FIB-414** tracks the real one: image pyramids, so a lone tile zoomed in keeps its detail.

**A long thin mosaic collapsed the axes to a 2% sliver.** `aspect="equal"` keeps pixels square, so when the framed region is shaped unlike the widget the only thing left to give is the axes box — 39:1 content left an axes 2.3% of the window wide with everything crushed into it. The fit now pads the *short axis* to the widget's proportions, so the box always fills the window and the slack shows as backdrop. Padding may only grow the framed region; there is a test for that specifically, since "pad to fit" is one sign flip from "crop to fit".

**The inherited crosshair was wrong here** on both count and size: it drew at the centre of the content (wherever tiles happen to average out) with arms at 5% of the extent — 100 um across on a 2 mm working area. It now marks the **origin**, drawn as a marker so it holds its size on screen through zoom.

## Verification

42 tests covering placement (distance, direction, differing pixel sizes, absolute-not-accumulated), the union, lifecycle, the working area, framing and the crosshair, draw order and in-place updates, and the composition with the real projection. Full suite **2053 passed, 16 skipped**.

There is also a standalone demo (`fibsem/ui/widgets/tests/test_real_space_canvas_demo.py`) — a 3x3 tileset at true stage offsets, a live cursor readout in metres, stage markers, and a working-area toggle. It is a GUI harness, so pytest does not collect it.

## Known gaps, filed not hidden

- **FIB-414** — pyramids; `display_max_px` is a fixed cap trading a visible performance problem for an invisible quality one
- **FIB-415** — contrast/gamma is hidden here, because the base drives it from a single frame. Worth resolving before FIB-412 lands, since FM overviews are exactly what people reach for contrast on

## Next

FIB-412 puts the FM overview widget on this canvas — the first user-visible change in the stack.
