### PR TITLE
[ui] Put the FM overview widget on the real-space canvas (FIB-412)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -376,11 +376,8 @@ class FMOverviewWidget(QWidget):
             tiles, (height, width), pixel_size, overlap=parameters.overlap
         )
 
-        # Frame the planned area, so an empty canvas shows where the run will go rather
-        # than nothing at all, and so clicks land in a meaningful coordinate frame.
         span_x = parameters.cols * fov[0] * (1 - parameters.overlap) + fov[0]
         span_y = parameters.rows * fov[1] * (1 - parameters.overlap) + fov[1]
-        self.canvas.set_world_extent(span_x, span_y)
 
         # Refit only when the grid's footprint actually changes. Toggling a tile also
         # comes through here, and refitting on that threw away whatever zoom and pan
@@ -392,6 +389,12 @@ class FMOverviewWidget(QWidget):
         changed = footprint != self._grid_footprint
         self._grid_footprint = footprint
         if changed and not self.tile_grid_overlay.is_resizing:
+            # Frame the planned area, so an empty canvas shows where the run will go
+            # rather than nothing at all, and so clicks land in a meaningful frame.
+            # Behind the same guard as the refit below, and for the same reason: a tile
+            # toggle comes through here too, and re-framing on one threw away the
+            # user's zoom -- which is what made clicking a tile look like zooming.
+            self.canvas.set_world_extent(span_x, span_y)
             self.tile_grid_overlay.fit_view()
 
     def _toggle_tile_grid_panel(self) -> None:

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -10,7 +10,7 @@ actions along the bottom.
 
 import logging
 import threading
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 from PyQt5.QtCore import QPoint, Qt, pyqtSignal
@@ -43,7 +43,7 @@ from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
 from fibsem.ui.fm.widgets.tile_grid_options_panel import TileGridOptionsPanel
 from fibsem.ui.qt.threading import FunctionWorker
-from fibsem.fm.reprojection import reproject_stage_positions_onto_fm_image
+from fibsem.fm.reprojection import project_stage_position
 from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
 from fibsem.ui.widgets.canvas.overlays.point_overlay import PointsOverlay
 from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import TileGridOverlay
@@ -52,7 +52,7 @@ from fibsem.ui.widgets.progress_widget import (
     FibsemProgressWidget,
     ProgressUpdate,
 )
-from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
+from fibsem.ui.widgets.canvas.fm_canvas import FMRealSpaceCanvasWidget
 
 TEXT_MUTED = "#868e93"
 PROGRESS_WIDTH = 260
@@ -111,6 +111,11 @@ class FMOverviewWidget(QWidget):
         self._runner: Optional[FMTiledAcquisitionRunner] = None
         self._mosaic: Optional[FluorescenceImage] = None
         self._displayed_image: Optional[FluorescenceImage] = None
+        # Stage position the canvas frame is built around. Everything shown -- images,
+        # the planned grid, position markers -- is placed relative to it, so it has to
+        # be fixed once and kept: re-deriving it from the newest image would shift the
+        # whole scene each time one arrived. Taken from the first image displayed.
+        self._origin: Optional[FibsemStagePosition] = None
         self._positions: List[FibsemStagePosition] = []
         self._grid_footprint: Optional[tuple] = None
         self._enabled_channels: Optional[List[ChannelSettings]] = None
@@ -137,7 +142,7 @@ class FMOverviewWidget(QWidget):
     # ── layout ───────────────────────────────────────────────────────────
 
     def _init_ui(self, channels: List[ChannelSettings]) -> None:
-        self.canvas = FMCanvasWidget()
+        self.canvas = FMRealSpaceCanvasWidget()
 
         # The planned grid, drawn on the canvas and clickable. A second view of the
         # mask `TileMaskWidget` owns, not a second copy: clicks are routed through the
@@ -321,9 +326,10 @@ class FMOverviewWidget(QWidget):
     def _refresh_tile_grid(self) -> None:
         """Redraw the planned grid on the canvas.
 
-        Needs a tile field of view (from the camera) and an image on the canvas to
-        anchor and scale against. With no image there is nothing to draw the grid
-        relative to, so it is cleared rather than guessed at.
+        Needs a tile field of view and the camera geometry. It does *not* need an image:
+        the grid is anchored to the canvas origin -- the stage position the tileset is
+        planned around -- so it can be drawn before anything is acquired, which is when
+        a planned grid is worth the most.
         """
         fov = self.settings_widget._tile_fov
         if fov is None:
@@ -349,6 +355,14 @@ class FMOverviewWidget(QWidget):
             overlap=parameters.overlap,
             mask=parameters.tile_mask,
         )
+        # Give the canvas a scale before the first image, so the grid has a real frame
+        # to be drawn in rather than arbitrary units. No-op once an image has landed --
+        # by then the image has set it, and changing it would move what is already drawn.
+        self.canvas.canvas.set_reference_pixel_size(pixel_size)
+        # Centred on the origin: the tileset is planned around a stage position, not
+        # around whatever happens to be displayed.
+        self.tile_grid_overlay.set_anchor(self.canvas.canvas.metres_to_canvas(0.0, 0.0))
+
         # No `display_pixel_size`: the overlay reads it from the canvas at draw time.
         # Pinning it here would freeze the scale at whatever was displayed when the
         # settings last changed, and the image underneath changes without them -- the
@@ -356,6 +370,12 @@ class FMOverviewWidget(QWidget):
         self.tile_grid_overlay.set_grid(
             tiles, (height, width), pixel_size, overlap=parameters.overlap
         )
+
+        # Frame the planned area, so an empty canvas shows where the run will go rather
+        # than nothing at all, and so clicks land in a meaningful coordinate frame.
+        span_x = parameters.cols * fov[0] * (1 - parameters.overlap) + fov[0]
+        span_y = parameters.rows * fov[1] * (1 - parameters.overlap) + fov[1]
+        self.canvas.set_world_extent(span_x, span_y)
 
         # Refit only when the grid's footprint actually changes. Toggling a tile also
         # comes through here, and refitting on that threw away whatever zoom and pan
@@ -384,16 +404,52 @@ class FMOverviewWidget(QWidget):
         self.tile_grid_panel.raise_()
 
     def set_image(self, image: FluorescenceImage) -> None:
-        """Show an image on the canvas and refresh anything drawn on top of it.
+        """Show an image at the stage position it was acquired at.
 
-        Overlays are positioned against the displayed image, so the image has to be
-        recorded when it is set rather than fetched from the canvas later -- the canvas
-        keeps channel stacks, not the `FluorescenceImage` and its metadata, and the
-        metadata is what carries the pose a position is projected against.
+        Overlays are positioned against the canvas frame, not against whatever is
+        currently displayed, so the image has to be recorded when it is set rather than
+        fetched from the canvas later -- the canvas keeps channel stacks, not the
+        `FluorescenceImage` and its metadata, and the metadata is what carries the pose.
         """
         self._displayed_image = image
+        if self._origin is None:
+            self._origin = self._position_of(image)
+        self.canvas.set_placement(self._offset_of(image))
         self.canvas.set_fm_image(image)
         self._refresh_positions()
+        self._refresh_tile_grid()
+
+    @staticmethod
+    def _position_of(image: FluorescenceImage) -> Optional[FibsemStagePosition]:
+        return getattr(image.metadata, "stage_position", None)
+
+    def _offset_of(self, image: FluorescenceImage) -> Tuple[float, float]:
+        """Where *image*'s centre sits relative to the canvas origin, in metres.
+
+        The stage-to-plane projection the canvas deliberately knows nothing about. Falls
+        back to the origin when the image cannot be projected -- acquired before the
+        geometry was recorded, or with no pose at all -- which puts it in the middle of
+        the view rather than refusing to show it.
+        """
+        position = self._position_of(image)
+        geometry = getattr(image.metadata, "geometry", None)
+        if self._origin is None or position is None or geometry is None:
+            return (0.0, 0.0)
+        try:
+            pixel_size = image.metadata.pixel_size_x
+            shape = np.asarray(image.data).shape[-2:]
+            point = project_stage_position(
+                position, self._origin, pixel_size, shape, geometry
+            )
+            # project_stage_position answers in pixels of an image acquired at the
+            # origin; the canvas wants metres from it, so measure from the centre out.
+            return (
+                (point.x - shape[1] / 2) * pixel_size,
+                (point.y - shape[0] / 2) * pixel_size,
+            )
+        except Exception as e:
+            logging.debug(f"Could not place the image in stage space: {e}")
+            return (0.0, 0.0)
 
     def set_positions(self, positions: List[FibsemStagePosition]) -> None:
         """Stage positions to mark on the overview, e.g. saved lamella positions.
@@ -405,30 +461,49 @@ class FMOverviewWidget(QWidget):
         self._refresh_positions()
 
     def _refresh_positions(self) -> None:
-        """Reproject the marked positions onto the displayed image.
+        """Mark the stage positions in the canvas frame.
 
-        Uses the image's own recorded geometry rather than the live microscope: after
+        Projected against the canvas origin rather than onto whichever image happens to
+        be displayed, so a marker names the same piece of sample no matter what is on
+        screen -- and markers survive the image being swapped, or there being none yet.
+
+        The projection uses the recorded geometry rather than the live microscope: after
         an overview is acquired the stage has moved on, and following it would drift
         every marker off the feature it names.
         """
-        if self._displayed_image is None or not self._positions:
+        if not self._positions or self._origin is None:
             self.position_overlay.set_points([])
             return
 
-        try:
-            points = reproject_stage_positions_onto_fm_image(
-                self._displayed_image, self._positions
+        geometry = None
+        pixel_size = None
+        if self._displayed_image is not None:
+            geometry = getattr(self._displayed_image.metadata, "geometry", None)
+            pixel_size = getattr(self._displayed_image.metadata, "pixel_size_x", None)
+        if geometry is None or not pixel_size:
+            # Nothing to project through -- an image acquired before the geometry was
+            # recorded, or none displayed yet.
+            self.position_overlay.set_points([])
+            return
+
+        points, labels = [], []
+        shape = np.asarray(self._displayed_image.data).shape[-2:]
+        for position in self._positions:
+            try:
+                point = project_stage_position(
+                    position, self._origin, pixel_size, shape, geometry
+                )
+            except Exception as e:
+                logging.debug(f"Cannot mark {position.name!r}: {e}")
+                continue
+            metres = (
+                (point.x - shape[1] / 2) * pixel_size,
+                (point.y - shape[0] / 2) * pixel_size,
             )
-        except ValueError as e:
-            # Images acquired before the geometry was recorded cannot be projected onto.
-            logging.debug(f"Cannot mark positions on this image: {e}")
-            self.position_overlay.set_points([])
-            return
+            points.append(self.canvas.canvas.metres_to_canvas(*metres))
+            labels.append(position.name or "")
 
-        self.position_overlay.set_points(
-            [(p.x, p.y) for p in points],
-            labels=[p.name or "" for p in points],
-        )
+        self.position_overlay.set_points(points, labels=labels)
 
     def _on_grid_resize(self, rows: int, cols: int) -> None:
         """An edge of the grid was dragged.
@@ -676,11 +751,14 @@ class FMOverviewWidget(QWidget):
             for channel, plane in zip(self.channels, planes):
                 self.canvas.set_channel(channel.name, plane, channel.color)
 
+            # The preview mosaic spans the whole planned grid, which is centred on the
+            # position the run started from -- the canvas origin.
+            self.canvas.set_placement((0.0, 0.0))
+
             # The preview is decimated to keep it a sane size, so its pixels are
-            # `preview_stride` times coarser than a tile's. `set_channel` takes raw
-            # planes and cannot know that, and anything drawn on top -- the tile grid,
-            # position markers -- scales against the canvas pixel size, so leaving it
-            # at the tile's would draw them all stride times too large.
+            # `preview_stride` times coarser than a tile's. Placement is by pixel size,
+            # so saying so is all that is needed: coarser pixels over the same count
+            # cover the same ground, and the mosaic lands at the size it represents.
             stride = payload.get("preview_stride", 1) or 1
             self.canvas.set_pixel_size(self.fm.camera.pixel_size[0] * stride)
         except Exception as e:

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -81,6 +81,11 @@ def progress_slot(progress: FibsemProgressWidget) -> QWidget:
     return slot
 
 
+# Key the in-progress mosaic is drawn under. Distinct from a finished overview's
+# position-derived key, so the preview can be dropped when the real stitch lands.
+PREVIEW_KEY = "fm-preview"
+
+
 class FMOverviewWidget(QWidget):
     """Configure, run and view a fluorescence overview acquisition."""
 
@@ -414,6 +419,7 @@ class FMOverviewWidget(QWidget):
         self._displayed_image = image
         if self._origin is None:
             self._origin = self._position_of(image)
+        self.canvas.set_composite_key(self._key_for(image))
         self.canvas.set_placement(self._offset_of(image))
         self.canvas.set_fm_image(image)
         self._refresh_positions()
@@ -422,6 +428,21 @@ class FMOverviewWidget(QWidget):
     @staticmethod
     def _position_of(image: FluorescenceImage) -> Optional[FibsemStagePosition]:
         return getattr(image.metadata, "stage_position", None)
+
+    @staticmethod
+    def _key_for(image: FluorescenceImage) -> str:
+        """Identify an overview by when it was acquired.
+
+        Not by position: a small overview and a wider one taken over the same area at
+        different times are both worth keeping, and keying on position would silently
+        drop the first. `stitch_tileset` carries the first tile's acquisition date onto
+        the mosaic, so this is unique per run.
+
+        A property of the image rather than a counter, so showing the same image twice
+        replaces it instead of drawing a second copy on top of itself.
+        """
+        stamp = getattr(image.metadata, "acquisition_date", None)
+        return f"overview@{stamp}" if stamp else "overview"
 
     def _offset_of(self, image: FluorescenceImage) -> Tuple[float, float]:
         """Where *image*'s centre sits relative to the canvas origin, in metres.
@@ -748,19 +769,28 @@ class FMOverviewWidget(QWidget):
             planes = np.asarray(image)
             if planes.ndim == 2:
                 planes = planes[np.newaxis]
-            for channel, plane in zip(self.channels, planes):
-                self.canvas.set_channel(channel.name, plane, channel.color)
 
+            # Where, and at what scale, *before* any pixels: `set_channel` composites
+            # and places immediately, so anything established after it applies a tick
+            # late -- the first frame of a run would land under the previous run's key
+            # at the previous run's pixel size, which drew it at the wrong size on top
+            # of a finished overview.
+            #
+            # Its own key, so the in-progress preview neither replaces a finished
+            # overview nor survives as one: it is swapped for the real stitch at the end.
+            self.canvas.set_composite_key(PREVIEW_KEY)
             # The preview mosaic spans the whole planned grid, which is centred on the
             # position the run started from -- the canvas origin.
             self.canvas.set_placement((0.0, 0.0))
-
             # The preview is decimated to keep it a sane size, so its pixels are
             # `preview_stride` times coarser than a tile's. Placement is by pixel size,
             # so saying so is all that is needed: coarser pixels over the same count
             # cover the same ground, and the mosaic lands at the size it represents.
             stride = payload.get("preview_stride", 1) or 1
             self.canvas.set_pixel_size(self.fm.camera.pixel_size[0] * stride)
+
+            for channel, plane in zip(self.channels, planes):
+                self.canvas.set_channel(channel.name, plane, channel.color)
         except Exception as e:
             logging.debug(f"Could not display the overview preview: {e}")
 
@@ -770,8 +800,11 @@ class FMOverviewWidget(QWidget):
         self.progress_tile_detail.reset()
 
         if state == "overview-finished" and self._mosaic is not None:
-            # Swap the decimated preview for the real thing.
+            # Swap the decimated preview for the real thing. Dropped rather than left
+            # underneath: it covers the same ground at a coarser scale, so keeping it
+            # would only be a blurred copy hidden behind the stitch.
             self.set_image(self._mosaic)
+            self.canvas.canvas.remove_image(PREVIEW_KEY)
             shape = self._mosaic.data.shape
             self.status.setText(f"Overview acquired — {shape[-1]} × {shape[-2]} px")
             self.progress_tiles.update_progress(ProgressUpdate.done())

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -215,7 +215,6 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._scalebar_visible: bool = True
         self._crosshair_visible: bool = True
         self._crosshair_artists: list = []
-        self._empty_artist = None  # "No image" placeholder; see _plot_empty
         self._hint_artist = None  # transient top-left instruction hint
         self._hint_text: Optional[str] = None  # remembered so it survives set_image
         self._title_artist = None  # top-centre image caption (e.g. FM z-slice)
@@ -819,9 +818,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
     def _plot_empty(self):
         self._ax.set_facecolor(self._facecolor)
         self._ax.axis("off")
-        # Kept so a subclass that never calls ax.cla() (one drawing many placed images)
-        # can take the placeholder away once it has content to show.
-        self._empty_artist = self._ax.text(
+        self._ax.text(
             0.5,
             0.5,
             "No image",

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -26,7 +26,9 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.widgets.canvas.fm_composite import (
     AVAILABLE_COLORS, FMLayer, auto_clim, composite_fm_layers,
 )
+from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
 
 if TYPE_CHECKING:
     from fibsem.fm.structures import FluorescenceImage
@@ -170,11 +172,21 @@ class _ChannelRow(QFrame):
 
 
 class FMCanvasWidget(QWidget):
-    """FibsemImageCanvas + per-channel FM layer model + composite + layers popover."""
+    """FibsemImageCanvas + per-channel FM layer model + composite + layers popover.
+
+    The channel model, the layers popover and the z-scrubbing are independent of *how*
+    the blended frame is shown, so a subclass can swap the canvas (:meth:`_make_canvas`)
+    and how the composite reaches it (:meth:`_show_composite`) while keeping all of it —
+    see :class:`FMRealSpaceCanvasWidget`.
+    """
+
+    def _make_canvas(self) -> FibsemCanvasBase:
+        """The canvas this widget composites onto."""
+        return FibsemImageCanvas()
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self.canvas = FibsemImageCanvas()
+        self.canvas = self._make_canvas()
         self._layers: List[FMLayer] = []
         self._pixel_size: Optional[float] = None
         self._canvas_shape: Optional[Tuple[int, int]] = None  # drawn-axes shape
@@ -315,10 +327,21 @@ class FMCanvasWidget(QWidget):
         if rgb is None:
             return
         h, w = rgb.shape[:2]
-        if self._canvas_shape != (h, w):
+        reshaped = self._canvas_shape != (h, w)
+        self._canvas_shape = (h, w)
+        self._show_composite(rgb, reshaped)
+
+    def _show_composite(self, rgb: np.ndarray, reshaped: bool) -> None:
+        """Put the blended RGB frame on the canvas.
+
+        The only place compositing touches the canvas, and so the seam a subclass
+        overrides to display the same frame differently — placed in stage space rather
+        than filling the view. *reshaped* is True when the frame's pixel dimensions
+        changed, which is the expensive path; the steady state swaps pixels only.
+        """
+        if reshaped:
             # (re)build axes + scalebar at this shape and show the composite
             # directly — no fake single-channel FibsemImage needed
-            self._canvas_shape = (h, w)
             self.canvas.set_array(rgb, pixel_size=self._pixel_size)
         else:
             self.canvas.update_display(rgb)  # steady state: swap pixels only
@@ -418,6 +441,89 @@ class FMCanvasWidget(QWidget):
         super().resizeEvent(event)
         if self._panel.isVisible():
             self._position_panel()
+
+
+class FMRealSpaceCanvasWidget(FMCanvasWidget):
+    """FM channel model and layer controls, composited onto a real-space canvas.
+
+    Identical to :class:`FMCanvasWidget` above the display: the same channel stacks, the
+    same layers popover, the same z-scrubbing. The difference is where the blended frame
+    lands — placed at the stage position it was acquired at, on a black stage-space
+    backdrop, rather than filling the view.
+
+    That placement is what lets overlays work in stage coordinates: a planned tile grid
+    can be drawn before anything is acquired, and position markers do not depend on there
+    being an image to reproject onto.
+
+    Layers are shared across everything placed, which is right for an overview — a mosaic
+    should render uniformly, and per-image contrast would emphasise the seams rather than
+    hide them. See FIB-415 for the per-image case.
+
+    **The canvas is not FM-only.** It knows nothing about modality: ``add_image`` takes
+    any 2-D or RGB array with a position and a pixel size, so a caller can place FIB or
+    SEM images alongside the composite and they will register with it in stage space::
+
+        widget.canvas.add_image(sem_data, centre=(x, y), pixel_size=ps, zorder=-1)
+
+    This widget only manages the one key it composites into (:attr:`COMPOSITE_KEY`), so
+    anything else placed is left alone by a layer change. What is FM-specific here is the
+    *controls* — channels, blending, the layers popover — not the display.
+    """
+
+    COMPOSITE_KEY = "fm-composite"
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._placement: Tuple[float, float] = (0.0, 0.0)
+
+    def _make_canvas(self) -> FibsemCanvasBase:
+        return FibsemRealSpaceCanvas()
+
+    # ── placement ─────────────────────────────────────────────────────────
+
+    def set_placement(self, centre: Tuple[float, float]) -> None:
+        """Where the composite sits, in metres from the canvas origin.
+
+        Set before the frame it applies to. The caller projects a stage position into
+        the display plane (see :mod:`fibsem.fm.reprojection`); this widget only carries
+        the result through to the canvas.
+        """
+        self._placement = (float(centre[0]), float(centre[1]))
+
+    def set_world_extent(self, width: Optional[float], height: Optional[float] = None,
+                         centre: Tuple[float, float] = (0.0, 0.0)) -> None:
+        """Declare the working area the canvas represents — see the canvas method."""
+        self.canvas.set_world_extent(width, height, centre)
+
+    # ── display ───────────────────────────────────────────────────────────
+
+    def _show_composite(self, rgb: np.ndarray, reshaped: bool) -> None:
+        """Place the composite, rather than letting it fill the view.
+
+        A reshaped frame has to be re-placed, since its extent depends on its pixel
+        dimensions; otherwise the pixels are swapped in place, which keeps the artist and
+        so its position and draw order.
+        """
+        if not self._pixel_size:
+            return  # nothing to scale against; the caller has not said how big a pixel is
+        if reshaped or self.COMPOSITE_KEY not in self.canvas.placed_keys:
+            self.canvas.add_image(
+                rgb,
+                centre=self._placement,
+                pixel_size=self._pixel_size,
+                key=self.COMPOSITE_KEY,
+            )
+        else:
+            self.canvas.update_image(self.COMPOSITE_KEY, rgb)
+
+    def set_pixel_size(self, pixel_size: Optional[float]) -> None:
+        """Record the scale without touching the canvas's own.
+
+        The base assigns `canvas.pixel_size` to drive the scalebar, but here the canvas
+        takes its scale from the placed image instead — assigning it directly would set a
+        scalebar that disagrees with what is drawn.
+        """
+        self._pixel_size = pixel_size
 
 
 class FMLayersPanel(QFrame):

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -11,6 +11,7 @@ are Phase 6b.
 """
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -475,11 +476,34 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self._placement: Tuple[float, float] = (0.0, 0.0)
+        self._composite_key: str = self.COMPOSITE_KEY
+        # Channel planes of everything placed, so a layer change can re-render images
+        # composited long ago. Only the newest is in `_layers`; the rest are here.
+        self._held: Dict[str, Dict[str, np.ndarray]] = {}
 
     def _make_canvas(self) -> FibsemCanvasBase:
         return FibsemRealSpaceCanvas()
 
     # ── placement ─────────────────────────────────────────────────────────
+
+    def set_composite_key(self, key: str) -> None:
+        """Choose which placed image subsequent channel data composites into.
+
+        Re-using a key replaces that image; a new key adds one. So a second overview
+        acquired somewhere else joins the first on the canvas rather than replacing it,
+        which is the reason for placing things in stage space at all.
+        """
+        self._composite_key = key
+
+    def placed_overviews(self) -> List[str]:
+        """Keys of everything this widget has composited, oldest first."""
+        return list(self._held)
+
+    def clear_overviews(self) -> None:
+        """Drop every composited image, leaving overlays and the channel model alone."""
+        for key in list(self._held):
+            self.canvas.remove_image(key)
+        self._held.clear()
 
     def set_placement(self, centre: Tuple[float, float]) -> None:
         """Where the composite sits, in metres from the canvas origin.
@@ -506,15 +530,59 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         """
         if not self._pixel_size:
             return  # nothing to scale against; the caller has not said how big a pixel is
-        if reshaped or self.COMPOSITE_KEY not in self.canvas.placed_keys:
+        key = self._composite_key
+        # Keep this image's planes, so a later layer change can re-render it once its
+        # channels are no longer the ones in `_layers`.
+        self._held[key] = {
+            layer.name: layer.data for layer in self._layers if layer.data is not None
+        }
+        if reshaped or key not in self.canvas.placed_keys:
             self.canvas.add_image(
                 rgb,
                 centre=self._placement,
                 pixel_size=self._pixel_size,
-                key=self.COMPOSITE_KEY,
+                key=key,
+                zorder=self._detail_zorder(self._pixel_size),
             )
         else:
-            self.canvas.update_image(self.COMPOSITE_KEY, rgb)
+            self.canvas.update_image(key, rgb)
+        self._restyle_others(key)
+
+    @staticmethod
+    def _detail_zorder(pixel_size: float) -> float:
+        """Draw finer images over coarser ones, whatever order they arrived in.
+
+        Arrival order is the wrong answer here. A wide, coarse overview acquired *after*
+        a detailed one covers the same ground, so by default it would hide the better
+        data underneath it — and the more detail an image has, the more it deserves to
+        be on top. Ordering by pixel size instead means a coarse survey always sits
+        behind whatever was taken at higher resolution over it.
+        """
+        return -pixel_size * 1e9  # nanometres/px, negated: smaller pixels draw on top
+
+    def _restyle_others(self, current: str) -> None:
+        """Re-render everything except *current* under the present layer settings.
+
+        Layers are display state shared by everything placed; the pixels are not. So a
+        colour or contrast change has to be applied to each held image's own planes,
+        which is why they are kept. Without this, changing a channel's colour would
+        recolour the newest overview and leave the others as they were — the same data
+        drawn two different ways, side by side.
+        """
+        for key, planes in self._held.items():
+            if key == current or key not in self.canvas.placed_keys:
+                continue
+            layers = [
+                replace(layer, data=planes[layer.name], _clim_cache=None)
+                for layer in self._layers
+                if layer.name in planes
+            ]
+            if not layers:
+                continue
+            shape = layers[0].data.shape[:2]
+            rgb = composite_fm_layers(layers, shape)
+            if rgb is not None:
+                self.canvas.update_image(key, rgb)
 
     def set_pixel_size(self, pixel_size: Optional[float]) -> None:
         """Record the scale without touching the canvas's own.

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -27,7 +27,7 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.widgets.canvas.fm_composite import (
     AVAILABLE_COLORS, FMLayer, auto_clim, composite_fm_layers,
 )
-from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase
+from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase, _downsample
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
 
@@ -322,9 +322,17 @@ class FMCanvasWidget(QWidget):
 
     # ── display ───────────────────────────────────────────────────────────
 
+    def _composite_inputs(self) -> Tuple[List[FMLayer], Optional[Tuple[int, int]]]:
+        """The layers to blend and the shape to blend them at.
+
+        A subclass that shows the composite smaller than it is can substitute reduced
+        planes here, so the blend costs what is displayed rather than what was acquired.
+        """
+        return self._layers, self._shape
+
     def _recomposite(self) -> None:
-        shape = self._shape
-        rgb = composite_fm_layers(self._layers, shape)
+        layers, shape = self._composite_inputs()
+        rgb = composite_fm_layers(layers, shape)
         if rgb is None:
             return
         h, w = rgb.shape[:2]
@@ -531,6 +539,18 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         if not self._pixel_size:
             return  # nothing to scale against; the caller has not said how big a pixel is
         key = self._composite_key
+        # The composite is blended at display resolution, so it has fewer pixels than
+        # the data it represents while covering the same ground. Placement is by pixel
+        # size, so the reduction has to be spent there -- otherwise a mosaic reduced 10x
+        # is placed a tenth of its size, which is what happened when the blend first
+        # moved to display resolution and the pixel size did not follow.
+        # The composite is blended at display resolution, so it holds fewer pixels than
+        # the data it represents while covering the same ground. Say so explicitly
+        # rather than letting the canvas infer the ground from shape x pixel size --
+        # inferring placed a mosaic reduced 10x at a tenth of its size.
+        covers = None
+        if self._shape:
+            covers = (self._shape[1] * self._pixel_size, self._shape[0] * self._pixel_size)
         # Keep this image's planes, so a later layer change can re-render it once its
         # channels are no longer the ones in `_layers`.
         self._held[key] = {
@@ -542,11 +562,39 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
                 centre=self._placement,
                 pixel_size=self._pixel_size,
                 key=key,
+                covers=covers,
+                # Ordered by the *acquired* pixel size: how much detail an image holds
+                # is a property of the data, not of the blend.
                 zorder=self._detail_zorder(self._pixel_size),
             )
         else:
             self.canvas.update_image(key, rgb)
         self._restyle_others(key)
+
+    def _reduce(self, plane: np.ndarray) -> np.ndarray:
+        """A plane at the resolution the canvas will actually store.
+
+        `_downsample` strides, so this is a view rather than a copy — the reduction
+        itself costs nothing, and the blend that follows costs what is displayed.
+        """
+        return _downsample(np.asarray(plane), self.canvas._display_max_px)
+
+    def _composite_inputs(self) -> Tuple[List[FMLayer], Optional[Tuple[int, int]]]:
+        """Blend at display resolution, not acquisition resolution.
+
+        The canvas decimates whatever it is handed, so blending a full mosaic first
+        computes ~99% of a result that is then thrown away — 153 ms per layer change for
+        a 1x5 overview, against 2.6 ms reduced, and it is the layer sliders that fire it
+        continuously. Blending the reduced planes is the same picture for the cost of the
+        pixels that survive.
+        """
+        reduced = [
+            replace(layer, data=self._reduce(layer.data), _clim_cache=None)
+            if layer.data is not None else layer
+            for layer in self._layers
+        ]
+        first = next((layer.data for layer in reduced if layer.data is not None), None)
+        return reduced, (first.shape[:2] if first is not None else self._shape)
 
     @staticmethod
     def _detail_zorder(pixel_size: float) -> float:
@@ -573,7 +621,7 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
             if key == current or key not in self.canvas.placed_keys:
                 continue
             layers = [
-                replace(layer, data=planes[layer.name], _clim_cache=None)
+                replace(layer, data=self._reduce(planes[layer.name]), _clim_cache=None)
                 for layer in self._layers
                 if layer.name in planes
             ]

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -76,6 +76,7 @@ class TileGridOverlay(QObject, CanvasOverlay):
         self._canvas: Optional["FibsemImageCanvas"] = None
         self._artists: list = []
         self._rect: Optional["ContentRect"] = None  # canvas content bounds
+        self._anchor_point: Optional[Tuple[float, float]] = None  # see set_anchor
         self._previous_margin: Optional[float] = None
         self._cids: List[int] = []
         self._resize_axes: Optional[Tuple[bool, bool]] = None  # (horizontal, vertical)
@@ -117,13 +118,30 @@ class TileGridOverlay(QObject, CanvasOverlay):
         self._redraw()
 
     def _content(self) -> Optional["ContentRect"]:
-        """Content bounds, or None if the canvas has not reported usable ones yet.
-
-        The grid is centred on the content — today the displayed image, and under a
-        real-space canvas the region the tiles are planned around.
-        """
+        """Content bounds, or None if the canvas has not reported usable ones yet."""
         rect = self._rect
         return None if rect is None or rect.is_empty else rect
+
+    def set_anchor(self, centre: Optional[Tuple[float, float]]) -> None:
+        """Centre the grid on *centre* in canvas coordinates, or None to follow content.
+
+        A tileset is planned around a *stage position*, not around whatever is currently
+        displayed. On a canvas showing one image those coincide, which is why following
+        the content worked; on a real-space canvas they do not — the content centre is
+        wherever the acquired images happen to average out, and it moves as more arrive.
+
+        Anchoring explicitly also lets the grid be drawn before anything is acquired,
+        which is when a planned grid is most useful.
+        """
+        self._anchor_point = None if centre is None else (float(centre[0]), float(centre[1]))
+        self._redraw()
+
+    def _anchor(self) -> Optional[Tuple[float, float]]:
+        """Where the grid is centred, or None if there is nothing to centre it on."""
+        if self._anchor_point is not None:
+            return self._anchor_point
+        rect = self._content()
+        return None if rect is None else (rect.cx, rect.cy)
 
     # ── content ──────────────────────────────────────────────────────────
 
@@ -255,10 +273,9 @@ class TileGridOverlay(QObject, CanvasOverlay):
 
         # The grid is centred on the content centre, matching the runner: it measures
         # from the top-left tile and shifts so the grid straddles the start position.
-        # Callers guard on _content(); the (0, 0) fallback keeps this total.
-        rect = self._content()
-        cx = rect.cx if rect is not None else 0.0
-        cy = rect.cy if rect is not None else 0.0
+        # Callers guard on _anchor(); the (0, 0) fallback keeps this total.
+        anchor = self._anchor()
+        cx, cy = anchor if anchor is not None else (0.0, 0.0)
         origin_x = cx - span_w / 2
         origin_y = cy - span_h / 2
 
@@ -271,7 +288,7 @@ class TileGridOverlay(QObject, CanvasOverlay):
 
     def _redraw(self) -> None:
         self._remove_artists()
-        if self._ax is None or not self._tiles or self._content() is None or not self._visible:
+        if self._ax is None or not self._tiles or self._anchor() is None or not self._visible:
             # Still repaint: removing the artists takes them out of the axes, but the
             # canvas keeps showing the last render until it is asked to redraw -- so
             # returning early here left a hidden grid on screen.
@@ -350,13 +367,13 @@ class TileGridOverlay(QObject, CanvasOverlay):
         boolean because the hover cursor has to name a *corner* -- top-left and
         top-right want opposite diagonals -- and "on both axes" cannot distinguish them.
         """
-        rect = self._content()
-        if not self._tiles or self._tile_shape[1] <= 0 or rect is None:
+        anchor = self._anchor()
+        if not self._tiles or self._tile_shape[1] <= 0 or anchor is None:
             return 0, 0
 
         span_w, span_h = self._extent()
-        left = rect.cx - span_w / 2
-        top = rect.cy - span_h / 2
+        left = anchor[0] - span_w / 2
+        top = anchor[1] - span_h / 2
         # Proportional to a tile rather than a fixed pixel count, so the grab zone
         # stays usable at any zoom without querying the transform.
         tolerance = self._tile_shape[1] * self._scale() * EDGE_GRAB_FRACTION
@@ -469,8 +486,8 @@ class TileGridOverlay(QObject, CanvasOverlay):
             return
         if event.xdata is None or event.ydata is None:
             return
-        rect = self._content()
-        if not self._tiles or rect is None:
+        anchor = self._anchor()
+        if not self._tiles or anchor is None:
             # The grid can be cleared mid-drag -- `_refresh_tile_grid` does exactly
             # that if the camera geometry cannot be read -- and the row/column counts
             # below are derived from the tiles, so this would raise on an empty max().
@@ -484,11 +501,11 @@ class TileGridOverlay(QObject, CanvasOverlay):
 
         if horizontal:
             cols = self._count_for(
-                abs(event.xdata - rect.cx), tile_w * scale
+                abs(event.xdata - anchor[0]), tile_w * scale
             )
         if vertical:
             rows = self._count_for(
-                abs(event.ydata - rect.cy), tile_h * scale
+                abs(event.ydata - anchor[1]), tile_h * scale
             )
 
         self.grid_resize_requested.emit(rows, cols)

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -151,6 +151,7 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         key: Optional[str] = None,
         cmap: str = "gray",
         zorder: Optional[float] = None,
+        covers: Optional[Tuple[float, float]] = None,
     ) -> str:
         """Place *data* centred on *centre* (metres), at *pixel_size* metres/px.
 
@@ -162,6 +163,13 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         earlier one where they overlap. Pass *zorder* when that is the wrong answer —
         a coarse overview belongs *under* the detailed tiles acquired over it,
         regardless of which arrived first.
+
+        The ground an image covers is normally its shape times *pixel_size*. Pass
+        *covers* as ``(width, height)`` in metres when the array is a *reduced*
+        representation of something larger — a decimated preview, or a composite blended
+        at display resolution — so it is placed at the size it represents rather than
+        the size it is stored at. *pixel_size* then describes the source, and still
+        decides how this image sorts against others by detail.
         """
         data = np.asarray(data)
         _require_displayable(data)
@@ -181,7 +189,7 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         if existing is not None:
             self._remove_artist(existing)
 
-        extent = self._extent_for(data.shape, centre, pixel_size)
+        extent = self._extent_for(data.shape, centre, pixel_size, covers)
         shown = _downsample(data, self._display_max_px)
         kw = {} if zorder is None else {"zorder": zorder}
         artist = self._ax.imshow(
@@ -423,9 +431,19 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         shape: Tuple[int, ...],
         centre: Tuple[float, float],
         pixel_size: float,
+        covers: Optional[Tuple[float, float]] = None,
     ) -> Tuple[float, float, float, float]:
-        """Where an image of *shape* centred on *centre* (metres) lands, in canvas px."""
+        """Where an image of *shape* centred on *centre* (metres) lands, in canvas px.
+
+        *covers* overrides the ground derived from shape x pixel size, for an array that
+        is a reduced representation of something larger.
+        """
         ref = self._reference_pixel_size or pixel_size
+        if covers is not None:
+            half_w = covers[0] / ref / 2.0
+            half_h = covers[1] / ref / 2.0
+            cx, cy = centre[0] / ref, centre[1] / ref
+            return (cx - half_w, cx + half_w, cy + half_h, cy - half_h)
         height, width = shape[0], shape[1]
         scale = pixel_size / ref  # canvas pixels per image pixel
         half_w = width * scale / 2.0

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -281,12 +281,20 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         include them. Pass None to go back to fitting the content alone.
         """
         if width is None:
-            self._world_extent_m = None
+            updated = None
         else:
             height = width if height is None else height
             if width <= 0 or height <= 0:
                 raise ValueError(f"world extent must be positive, got {width}x{height}")
-            self._world_extent_m = (width, height, centre[0], centre[1])
+            updated = (width, height, centre[0], centre[1])
+
+        if updated == self._world_extent_m:
+            # Idempotent: re-declaring the same working area is not a change, and
+            # refitting anyway would throw away the user's zoom every time a caller
+            # restated it — which one doing so on each settings change duly did.
+            return
+
+        self._world_extent_m = updated
         self._fitted_extent = None  # force a refit against the new framing
         self._after_content_change()
 

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -51,6 +51,29 @@ _ORIGIN_MARKER_SIZE = 11  # points; fixed on screen, so zoom-independent
 _DEFAULT_DISPLAY_PX = 512
 
 
+def _require_displayable(data: np.ndarray) -> None:
+    """Reject anything that is not a single displayable picture, before anything mutates.
+
+    This canvas places pictures, not stacks: z is projected and channels are composited
+    *before* an image gets here, because neither has a single answer once many images are
+    on screen at once. Scrubbing z across tiles that were acquired over different ranges,
+    or contrasting one tile independently of its neighbours, are questions the placement
+    layer cannot answer — so they belong to whatever owns the channels.
+
+    Without this check matplotlib raises from inside ``imshow`` instead, by which point
+    :meth:`FibsemRealSpaceCanvas.add_image` has already dropped the image previously held
+    under that key — so a bad call would destroy a good picture.
+    """
+    if data.ndim == 2:
+        return
+    if data.ndim == 3 and data.shape[2] in (3, 4):
+        return
+    raise ValueError(
+        f"expected a 2-D image or (H, W, 3|4) RGB(A), got shape {data.shape}. "
+        "Project z and composite channels before placing."
+    )
+
+
 @dataclass
 class PlacedImage:
     """One image on the canvas, with the extent it was drawn at (canvas pixels)."""
@@ -93,6 +116,13 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         if reference_pixel_size:
             self._pixel_size = reference_pixel_size  # drives the scalebar
 
+        # Square pixels from the outset, not just once an image happens to arrive.
+        # imshow sets this per-artist, so an empty canvas would otherwise be "auto":
+        # the axes would stretch to the widget and draw a square grid as a rectangle --
+        # a resize alone distorted it 3x. Overlays are drawn in this frame whether or
+        # not anything has been acquired, so the frame has to be honest first.
+        self._ax.set_aspect("equal", adjustable="box")
+
         self.set_background_color(_DEFAULT_BACKGROUND)
         # Contrast/gamma acts on a single frame; there is no meaning yet for "the"
         # image here, so don't offer a control that would silently do nothing.
@@ -134,8 +164,7 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         regardless of which arrived first.
         """
         data = np.asarray(data)
-        if data.ndim < 2:
-            raise ValueError(f"image data must be at least 2-D, got shape {data.shape}")
+        _require_displayable(data)
         if not pixel_size or pixel_size <= 0:
             raise ValueError(f"pixel_size must be positive, got {pixel_size!r}")
 
@@ -183,7 +212,9 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         placed = self._placed.get(key)
         if placed is None:
             return False
-        placed.artist.set_data(_downsample(np.asarray(data), self._display_max_px))
+        data = np.asarray(data)
+        _require_displayable(data)
+        placed.artist.set_data(_downsample(data, self._display_max_px))
         self.draw_idle()
         return True
 
@@ -211,6 +242,25 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         self._placed.clear()
         self._fitted_extent = None
         super().clear()
+
+    def set_reference_pixel_size(self, pixel_size: float) -> bool:
+        """Fix the canvas scale before anything is placed.
+
+        Normally the first image supplies it. Setting it up front lets a caller draw in
+        the canvas frame — a planned tile grid, stage markers — while the canvas is still
+        empty, which is exactly when a *planned* overlay is most useful.
+
+        Refuses once images are placed: their extents were computed against the current
+        scale, so changing it would move everything already drawn. Returns whether it
+        was applied.
+        """
+        if self._placed or not pixel_size or pixel_size <= 0:
+            return False
+        self._reference_pixel_size = float(pixel_size)
+        self._pixel_size = float(pixel_size)
+        self._refresh_scalebar()
+        self._after_content_change()
+        return True
 
     def set_world_extent(
         self,
@@ -410,24 +460,20 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         except (ValueError, NotImplementedError, AttributeError):
             pass
 
-    def _sync_placeholder(self) -> None:
-        """Show "No image" only while nothing is placed.
+    def _plot_empty(self) -> None:
+        """No "No image" placeholder — the empty backdrop already says it.
 
-        This canvas never calls ``ax.cla()`` — that is the whole point, since the axes
-        accumulate images — so the placeholder has to be taken away and put back by hand.
+        On a canvas that fills the view with one image, blank axes are ambiguous and the
+        text resolves it. Here the black backdrop *is* the statement: it means "nothing
+        acquired here", and it stays meaningful once images arrive, since the gaps
+        between them carry the same meaning. The text would also sit in the middle of
+        the planned tile grid, which is drawn before any acquisition.
         """
-        if self._placed and self._empty_artist is not None:
-            try:
-                self._empty_artist.remove()
-            except (ValueError, NotImplementedError):
-                pass
-            self._empty_artist = None
-        elif not self._placed and self._empty_artist is None:
-            self._plot_empty()
+        self._ax.set_facecolor(self._facecolor)
+        self._ax.axis("off")
 
     def _after_content_change(self) -> None:
         """Refit if the footprint changed, refresh chrome, and tell the overlays."""
-        self._sync_placeholder()
         extent = self._fit_extent()
         if self.auto_fit and extent != self._fitted_extent:
             self._fit_view()

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -727,3 +727,69 @@ def test_a_canvas_resize_goes_through_the_settings_widget(qapp, overview_widget)
     assert widget.settings_widget.parameters.rows == 4
     assert widget.settings_widget.parameters.cols == 6
     assert len(widget.tile_grid_overlay._tiles) == 24
+
+
+def test_overviews_are_kept_per_acquisition_not_per_position(qapp, overview_widget):
+    """A small overview and a wider one taken over the same area at different times are
+    both worth keeping. Keying on position would silently drop the first; keying on the
+    acquisition timestamp keeps both, and still replaces an image shown twice."""
+    import copy
+
+    widget = overview_widget
+    # The fixture is shared, and overviews now accumulate by design — so start clean
+    # rather than counting whatever earlier tests left behind.
+    widget.canvas.clear_overviews()
+    small = widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    widget.set_image(small)
+    qapp.processEvents()
+
+    wide = copy.deepcopy(small)
+    wide.metadata.acquisition_date = "2026-07-31T19:00:00"
+    wide.metadata.pixel_size_x = small.metadata.pixel_size_x * 3
+    wide.metadata.pixel_size_y = small.metadata.pixel_size_y * 3
+    widget.set_image(wide)
+    qapp.processEvents()
+
+    def overviews():
+        # Only what set_image placed: the fixture seeds the canvas directly, which
+        # lands under the widget's default key rather than an overview one.
+        return [k for k in widget.canvas.canvas.placed_keys if k.startswith("overview@")]
+
+    assert len(overviews()) == 2, "the wider overview replaced the detailed one"
+
+    widths = sorted(
+        widget.canvas.canvas._placed[k].extent[1]
+        - widget.canvas.canvas._placed[k].extent[0]
+        for k in overviews()
+    )
+    assert widths[1] == pytest.approx(widths[0] * 3)  # each at its own scale
+
+    widget.set_image(small)  # showing one again must not draw a second copy
+    qapp.processEvents()
+    assert len(overviews()) == 2
+
+
+def test_the_first_preview_frame_lands_at_the_right_scale(qapp, overview_widget):
+    """`set_channel` composites and places immediately, so the key, placement and pixel
+    size have to be set before it. Establishing them afterwards applied them a tick late:
+    the first frame of a run landed under the previous run's key at the previous run's
+    pixel size, drawing it at the wrong size on top of a finished overview."""
+    import numpy as np
+
+    widget = overview_widget
+    stride = 3
+    tile_ps = widget.fm.camera.pixel_size[0]
+    preview = np.zeros((1, 64, 128), dtype=np.uint8)  # (C, H, W), already decimated
+
+    widget._show_preview({"image": preview, "preview_stride": stride})
+    qapp.processEvents()
+
+    placed = widget.canvas.canvas._placed
+    assert "fm-preview" in placed, "the first preview frame was dropped"
+
+    extent = placed["fm-preview"].extent
+    reference = widget.canvas.canvas.reference_pixel_size
+    # 128 decimated pixels at `stride` times the tile pixel size cover 128 * stride
+    # tiles-worth of ground, whatever the canvas reference happens to be.
+    expected = 128 * (tile_ps * stride) / reference
+    assert extent[1] - extent[0] == pytest.approx(expected)

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -624,20 +624,22 @@ def _offset(base, dx=0.0, dy=0.0, name=""):
 
 
 def test_positions_are_marked_where_they_are(qapp, overview_widget):
+    """Markers live in the canvas frame, which is anchored on the stage position the
+    overview is built around -- so the origin is (0, 0), not the middle of some image.
+    What matters is that a known stage offset comes out as the same offset on screen."""
     widget = overview_widget
     image = widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
     widget.set_image(image)
     base = image.metadata.stage_position
     pixel_size = image.metadata.pixel_size_x
-    height, width = image.data.shape[-2:]
 
     widget.set_positions([_offset(base, name="here"),
                           _offset(base, dx=20e-6, name="right")])
     qapp.processEvents()
 
     points = widget.position_overlay._points
-    assert points[0] == pytest.approx((width / 2, height / 2))
-    assert points[1] == pytest.approx((width / 2 + 20e-6 / pixel_size, height / 2))
+    assert points[0] == pytest.approx((0.0, 0.0))  # the origin the canvas is built on
+    assert points[1] == pytest.approx((20e-6 / pixel_size, 0.0))  # 20 um to the right
     assert widget.position_overlay._labels == ["here", "right"]
 
 
@@ -653,7 +655,7 @@ def test_positions_outside_the_image_are_still_marked(qapp, overview_widget):
     widget.set_positions([_offset(base, dx=300e-6, name="far")])
     qapp.processEvents()
 
-    assert widget.position_overlay._points[0][0] > width
+    assert widget.position_overlay._points[0][0] > width / 2
 
 
 def test_an_image_without_geometry_marks_nothing_rather_than_guessing(qapp, overview_widget):

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -793,3 +793,60 @@ def test_the_first_preview_frame_lands_at_the_right_scale(qapp, overview_widget)
     # tiles-worth of ground, whatever the canvas reference happens to be.
     expected = 128 * (tile_ps * stride) / reference
     assert extent[1] - extent[0] == pytest.approx(expected)
+
+
+def test_toggling_a_tile_leaves_the_view_alone(qapp, overview_widget):
+    """A tile toggle comes through the same refresh as a grid resize. Re-framing on one
+    throws away the user's zoom, which reads on screen as clicking a tile zooming the
+    view — the bug #245 fixed, and which declaring the working area on every refresh
+    quietly reintroduced."""
+    widget = overview_widget
+    widget.settings_widget.parameters = OverviewParameters(rows=3, cols=3, overlap=0.1)
+    qapp.processEvents()
+
+    ax = widget.canvas.canvas._ax
+    ax.set_xlim(-100, 100)
+    ax.set_ylim(100, -100)
+    zoomed = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+
+    widget._on_tile_toggled(0, 0, False)
+    qapp.processEvents()
+
+    assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == zoomed
+
+
+def test_resizing_the_grid_does_reframe(qapp, overview_widget):
+    """The counterpart: a grid that no longer fits the view is worth re-framing for."""
+    widget = overview_widget
+    widget.settings_widget.parameters = OverviewParameters(rows=3, cols=3, overlap=0.1)
+    qapp.processEvents()
+
+    ax = widget.canvas.canvas._ax
+    ax.set_xlim(-100, 100)
+    ax.set_ylim(100, -100)
+    zoomed = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+
+    widget.settings_widget.set_grid_size(5, 5)
+    qapp.processEvents()
+
+    assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) != zoomed
+
+
+def test_the_grid_keeps_its_scale_under_a_decimated_preview(qapp, overview_widget):
+    """The live preview is coarser than a tile. The grid is drawn in canvas coordinates,
+    whose scale is fixed by the canvas reference — so the preview's stride must not
+    reach it. Getting this wrong drew the grid stride times too large over the very
+    image it describes."""
+    import numpy as np
+
+    widget = overview_widget
+    widget.settings_widget.parameters = OverviewParameters(rows=3, cols=3, overlap=0.1)
+    qapp.processEvents()
+    before = widget.tile_grid_overlay._rect_for(widget.tile_grid_overlay._tiles[0])
+
+    widget._show_preview({"image": np.zeros((1, 256, 256), np.uint8), "preview_stride": 4})
+    qapp.processEvents()
+
+    after = widget.tile_grid_overlay._rect_for(widget.tile_grid_overlay._tiles[0])
+    assert after[2] == pytest.approx(before[2])
+    assert after[3] == pytest.approx(before[3])

--- a/tests/ui/test_fm_real_space_canvas.py
+++ b/tests/ui/test_fm_real_space_canvas.py
@@ -1,0 +1,137 @@
+"""FM channel controls composited onto a real-space canvas.
+
+The split between FM and everything else is in the *controls*, not the display: the
+canvas takes any picture with a position, and this widget owns only the one key it
+composites its channels into. So FIB/SEM images can share the view and register with the
+FM composite in stage space — which is the point of a real-space canvas.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python tests/ui/test_fm_real_space_canvas.py
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget, FMRealSpaceCanvasWidget
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+PIXEL_SIZE = 1e-7
+
+
+def _plane(h=128, w=128):
+    return np.random.randint(0, 255, (h, w), dtype=np.uint8)
+
+
+def _widget(pixel_size=PIXEL_SIZE):
+    w = FMRealSpaceCanvasWidget()
+    w.set_pixel_size(pixel_size)
+    return w
+
+
+# ── it is the same widget above the display ───────────────────────────────
+
+
+def test_it_composites_onto_a_real_space_canvas():
+    assert isinstance(_widget().canvas, FibsemRealSpaceCanvas)
+
+
+def test_the_plain_fm_widget_is_untouched():
+    """The seam is a subclass, so the existing FM canvas must be unaffected."""
+    assert isinstance(FMCanvasWidget().canvas, FibsemImageCanvas)
+
+
+def test_the_composite_is_placed_at_its_scale():
+    w = _widget()
+    w.set_channel("GFP", _plane(128, 256), "#00ff00")
+    rect = w.canvas._content_rect()
+    assert (rect.width, rect.height) == (256, 128)
+    assert (rect.cx, rect.cy) == (0.0, 0.0)
+
+
+def test_the_composite_is_placed_where_it_was_acquired():
+    w = _widget()
+    w.set_placement((50e-6, -20e-6))
+    w.set_channel("GFP", _plane(64, 64), "#00ff00")
+    rect = w.canvas._content_rect()
+    assert (rect.cx, rect.cy) == pytest.approx((500.0, -200.0))
+
+
+def test_a_same_shaped_frame_updates_in_place():
+    """Re-placing would rebuild the artist, moving it to the top of the draw order —
+    so a live frame would climb over anything deliberately drawn above it."""
+    w = _widget()
+    w.set_channel("GFP", _plane(), "#00ff00")
+    artist = w.canvas._placed[w.COMPOSITE_KEY].artist
+    w.set_channel("GFP", _plane(), "#00ff00")
+    assert w.canvas._placed[w.COMPOSITE_KEY].artist is artist
+
+
+def test_a_reshaped_frame_is_replaced():
+    w = _widget()
+    w.set_channel("GFP", _plane(64, 64), "#00ff00")
+    w.set_channel("GFP", _plane(128, 128), "#00ff00")
+    rect = w.canvas._content_rect()
+    assert (rect.width, rect.height) == (128, 128)
+    assert len(w.canvas.placed_keys) == 1  # replaced, not stacked
+
+
+def test_nothing_is_placed_before_a_pixel_size_is_known():
+    """There is nothing to scale against, and guessing would place it at the wrong size."""
+    w = FMRealSpaceCanvasWidget()  # no set_pixel_size
+    w.set_channel("GFP", _plane(), "#00ff00")
+    assert w.canvas.placed_keys == []
+
+
+# ── the canvas is not FM-only ─────────────────────────────────────────────
+
+
+def test_greyscale_images_share_the_canvas_with_the_composite():
+    """The reason there is no FM/FIBSEM split at the display layer."""
+    w = _widget()
+    w.set_channel("GFP", _plane(), "#00ff00")
+    w.canvas.add_image(_plane(256, 256), centre=(40e-6, 0.0), pixel_size=2e-7, key="fib")
+    w.canvas.add_image(_plane(512, 512), centre=(0.0, 0.0), pixel_size=4e-7,
+                       key="sem", zorder=-5)
+
+    assert set(w.canvas.placed_keys) == {w.COMPOSITE_KEY, "fib", "sem"}
+    # each at its own scale: 256 px at 2x the reference covers 512 canvas px
+    fib = w.canvas._placed["fib"].extent
+    assert fib[1] - fib[0] == pytest.approx(512)
+    assert w.canvas._placed["sem"].artist.get_zorder() < 0
+
+
+def test_a_layer_change_leaves_other_images_alone():
+    w = _widget()
+    w.set_channel("GFP", _plane(), "#00ff00")
+    w.canvas.add_image(_plane(256, 256), centre=(40e-6, 0.0), pixel_size=2e-7, key="fib")
+    before = w.canvas._placed["fib"].artist
+
+    w.set_channel("GFP", _plane(), "#00ffff")  # recolour the FM channel
+
+    assert w.canvas._placed["fib"].artist is before
+    assert [layer.name for layer in w._layers] == ["GFP"]  # not listed as a layer
+
+
+if __name__ == "__main__":
+    failed = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except AssertionError as e:
+                failed += 1
+                print(f"FAIL {name}: {e}")
+    print("all passed" if not failed else f"{failed} failed")

--- a/tests/ui/test_fm_real_space_canvas.py
+++ b/tests/ui/test_fm_real_space_canvas.py
@@ -223,3 +223,31 @@ if __name__ == "__main__":
                 failed += 1
                 print(f"FAIL {name}: {e}")
     print("all passed" if not failed else f"{failed} failed")
+
+
+def test_the_composite_is_blended_at_display_resolution():
+    """Blending a full mosaic computes ~99% of a result the canvas then throws away —
+    153 ms per layer change for a 1x5 overview against ~3 ms reduced, and it is the
+    layer sliders that fire it continuously."""
+    w = _widget()
+    big = np.zeros((1024, 4712), dtype=np.uint8)
+    w.set_composite_key("ov")
+    w.set_channel("GFP", big, "green")
+
+    stored = w.canvas._placed["ov"].artist.get_array()
+    assert max(stored.shape[:2]) <= w.canvas._display_max_px
+
+
+def test_a_reduced_composite_is_still_placed_at_full_size():
+    """The reduction must be spent on the placement, not lost: blending smaller must not
+    draw the mosaic smaller."""
+    w = _widget()
+    big = np.zeros((1024, 4712), dtype=np.uint8)
+    w.set_composite_key("ov")
+    w.set_channel("GFP", big, "green")
+
+    extent = w.canvas._placed["ov"].extent
+    assert extent[1] - extent[0] == pytest.approx(4712)
+    assert extent[2] - extent[3] == pytest.approx(1024)
+    # and the canvas frame is still the acquired scale, which overlays measure against
+    assert w.canvas.reference_pixel_size == pytest.approx(PIXEL_SIZE)

--- a/tests/ui/test_fm_real_space_canvas.py
+++ b/tests/ui/test_fm_real_space_canvas.py
@@ -124,6 +124,94 @@ def test_a_layer_change_leaves_other_images_alone():
     assert [layer.name for layer in w._layers] == ["GFP"]  # not listed as a layer
 
 
+# ── more than one overview ────────────────────────────────────────────────
+
+
+def test_a_second_overview_joins_the_first():
+    """The reason for placing anything in stage space: acquire somewhere else and it
+    lines up with what is already shown instead of replacing it."""
+    w = _widget()
+    w.set_composite_key("a")
+    w.set_placement((0.0, 0.0))
+    w.set_channel("GFP", _plane(), "#00ff00")
+
+    w.set_composite_key("b")
+    w.set_placement((200e-6, 0.0))
+    w.set_channel("GFP", _plane(), "#00ff00")
+
+    assert set(w.canvas.placed_keys) == {"a", "b"}
+    a, b = w.canvas._placed["a"].extent, w.canvas._placed["b"].extent
+    assert (b[0] + b[1]) / 2 - (a[0] + a[1]) / 2 == pytest.approx(2000)  # 200 um
+
+
+def test_reusing_a_key_replaces_that_overview():
+    w = _widget()
+    for _ in range(3):
+        w.set_composite_key("same")
+        w.set_channel("GFP", _plane(), "#00ff00")
+    assert w.canvas.placed_keys == ["same"]
+
+
+def test_a_layer_change_restyles_every_overview_not_just_the_newest():
+    """Layers are display state shared by everything placed; the pixels are not. Without
+    re-rendering the held planes, recolouring would leave the same data drawn two
+    different ways side by side."""
+    w = _widget()
+    plane = _plane()
+    for key, centre in (("a", (0.0, 0.0)), ("b", (200e-6, 0.0))):
+        w.set_composite_key(key)
+        w.set_placement(centre)
+        w.set_channel("GFP", plane, "green")
+
+    w._layers[0].color = "red"
+    w._recomposite()
+
+    def red_mean(key):
+        return float(np.asarray(w.canvas._placed[key].artist.get_array())[..., 0].mean())
+
+    assert red_mean("a") == pytest.approx(red_mean("b"))
+    assert red_mean("a") > 0  # actually recoloured, not merely equal at zero
+
+
+def test_overviews_can_be_cleared_without_disturbing_the_channel_model():
+    w = _widget()
+    for key in ("a", "b"):
+        w.set_composite_key(key)
+        w.set_channel("GFP", _plane(), "#00ff00")
+
+    w.clear_overviews()
+
+    assert w.canvas.placed_keys == []
+    assert w.placed_overviews() == []
+    assert [layer.name for layer in w._layers] == ["GFP"]  # channels survive
+
+
+def test_a_coarse_overview_sits_behind_a_detailed_one_whenever_it_arrived():
+    """A wide survey acquired after a detailed overview covers the same ground, so by
+    arrival order it would hide the better data. Ordering by pixel size instead keeps
+    the most detailed image on top however the run happened to be sequenced."""
+    w = _widget()
+    w.set_composite_key("detailed")
+    w.set_channel("GFP", _plane(), "#00ff00")
+
+    w.set_pixel_size(PIXEL_SIZE * 4)  # a later, coarser survey on the same canvas
+    w.set_composite_key("survey")
+    w.set_channel("GFP", _plane(), "#00ff00")
+
+    detailed_z = w.canvas._placed["detailed"].artist.get_zorder()
+    survey_z = w.canvas._placed["survey"].artist.get_zorder()
+    assert survey_z < detailed_z  # coarser is behind, despite arriving later
+
+
+def test_held_planes_track_what_was_placed():
+    w = _widget()
+    w.set_composite_key("a")
+    w.set_channel("GFP", _plane(), "#00ff00")
+    w.set_composite_key("b")
+    w.set_channel("GFP", _plane(), "#00ff00")
+    assert w.placed_overviews() == ["a", "b"]
+
+
 if __name__ == "__main__":
     failed = 0
     for name, fn in sorted(globals().items()):

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -204,14 +204,15 @@ def test_clear_images_empties_the_canvas_but_keeps_overlays():
     assert rec.rects[-1].is_empty  # told the content went away
 
 
-def test_the_placeholder_goes_away_and_comes_back():
-    """The axes are never cleared here, so the "No image" text is managed by hand."""
+def test_there_is_no_placeholder_text():
+    """The black backdrop already says "nothing acquired here", and keeps saying it once
+    images arrive — the gaps between them mean the same thing. Text would also sit in the
+    middle of the tile grid, which is drawn before any acquisition."""
     c = _canvas()
-    assert c._empty_artist is not None
+    assert len(c._ax.texts) == 0
     c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
-    assert c._empty_artist is None
     c.clear_images()
-    assert c._empty_artist is not None
+    assert len(c._ax.texts) == 0
 
 
 # ── validation and conversion ─────────────────────────────────────────────
@@ -228,6 +229,44 @@ def test_one_dimensional_data_is_rejected():
     c = _canvas()
     with pytest.raises(ValueError):
         c.add_image(np.zeros(10), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+
+
+def test_rgb_and_rgba_are_placed_like_any_other_picture():
+    """The composited path: an FM overview arrives here already blended to colour."""
+    c = _canvas()
+    c.add_image(np.zeros((64, 128, 3), np.uint8), centre=(0.0, 0.0),
+                pixel_size=PIXEL_SIZE, key="rgb")
+    c.add_image(np.zeros((64, 128, 4), np.uint8), centre=(0.0, 0.0),
+                pixel_size=PIXEL_SIZE, key="rgba")
+    rect = c._content_rect()
+    assert (rect.width, rect.height) == (128, 64)  # the channel axis is not a dimension
+    assert c._placed["rgb"].artist.get_array().shape[-1] == 3
+
+
+def test_the_display_cap_keeps_the_channel_axis():
+    c = FibsemRealSpaceCanvas(display_max_px=128)
+    c.add_image(np.zeros((1024, 1024, 3), np.uint8), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    assert c._ax.get_images()[0].get_array().shape == (128, 128, 3)
+
+
+def test_stacks_are_rejected_rather_than_misplaced():
+    """z and channels have no single answer once many images share a view, so they are
+    resolved upstream. Left to matplotlib this raises from inside imshow instead."""
+    c = _canvas()
+    for bad in (np.zeros((5, 64, 64)), np.zeros((2, 5, 64, 64)), np.zeros((64, 64, 7))):
+        with pytest.raises(ValueError, match="Project z and composite channels"):
+            c.add_image(bad, centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+
+
+def test_a_rejected_image_does_not_destroy_the_one_it_would_have_replaced():
+    """add_image drops the old artist before drawing the new one, so validating late
+    would mean a bad call silently deleting a good picture."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="keep")
+    with pytest.raises(ValueError):
+        c.add_image(np.zeros((5, 64, 64)), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="keep")
+    assert c.placed_keys == ["keep"]
+    assert len(c._ax.get_images()) == 1
 
 
 def test_metres_and_canvas_coordinates_round_trip():
@@ -361,6 +400,45 @@ def test_padding_the_fit_never_hides_an_image():
     images, fit = c._image_extent(), c._fit_extent()
     assert fit[0] <= images[0] and fit[1] >= images[1]
     assert fit[3] <= images[3] and fit[2] >= images[2]
+
+
+def test_the_geometry_survives_a_resize_with_nothing_acquired():
+    """imshow sets aspect="equal" per artist, so an empty canvas would be "auto" and the
+    axes would stretch to the widget — drawing a square grid as a rectangle. Overlays are
+    drawn here before anything is acquired, so the frame has to be square from the start.
+    """
+    def _ratio(c):
+        x0, x1 = c._ax.get_xlim()
+        y0, y1 = c._ax.get_ylim()
+        box = c._ax.get_window_extent()
+        return (box.width / abs(x1 - x0)) / (box.height / abs(y1 - y0))
+
+    c = _canvas()
+    c.resize(1200, 600)
+    c.show()
+    c.set_reference_pixel_size(PIXEL_SIZE)
+    c.set_world_extent(200e-6)
+    _app.processEvents()
+    assert _ratio(c) == pytest.approx(1.0, abs=0.01)
+
+    c.resize(600, 900)  # a resize alone used to distort this 3x
+    _app.processEvents()  # Qt has to lay the resize out before the axes re-fits to it
+    assert _ratio(c) == pytest.approx(1.0, abs=0.01)
+
+
+def test_a_reference_pixel_size_can_be_fixed_before_any_image():
+    """So a planned grid or stage markers have a real frame to be drawn in."""
+    c = _canvas()
+    assert c.set_reference_pixel_size(PIXEL_SIZE) is True
+    assert c.metres_to_canvas(10e-6, 0.0) == pytest.approx((100.0, 0.0))
+
+
+def test_the_reference_pixel_size_is_not_changed_under_a_placed_image():
+    """Their extents were computed against it, so changing it would move them."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    assert c.set_reference_pixel_size(PIXEL_SIZE * 4) is False
+    assert c.reference_pixel_size == PIXEL_SIZE
 
 
 def test_the_crosshair_marks_the_origin_not_the_middle_of_the_content():

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -585,3 +585,24 @@ if __name__ == "__main__":
                 failed += 1
                 print(f"FAIL {name}: {e}")
     print("all passed" if not failed else f"{failed} failed")
+
+
+def test_covers_places_a_reduced_array_at_the_size_it_represents():
+    """An array can be a reduced stand-in for something larger — a decimated preview, or
+    a composite blended at display resolution. Inferring the ground from shape x pixel
+    size then places it at a fraction of its size."""
+    c = _canvas()
+    c.set_reference_pixel_size(PIXEL_SIZE)
+    reduced = _img(100, 100)  # stands in for a 1000x1000 acquisition
+    c.add_image(reduced, centre=(0.0, 0.0), pixel_size=PIXEL_SIZE,
+                covers=(1000 * PIXEL_SIZE, 1000 * PIXEL_SIZE))
+    xmin, xmax, ymax, ymin = c._content_extent()
+    assert xmax - xmin == pytest.approx(1000)
+    assert ymax - ymin == pytest.approx(1000)
+
+
+def test_without_covers_the_ground_still_comes_from_shape_and_pixel_size():
+    c = _canvas()
+    c.add_image(_img(100, 100), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    xmin, xmax, _, _ = c._content_extent()
+    assert xmax - xmin == pytest.approx(100)


### PR DESCRIPTION
Step 4 of FIB-408, and the first user-visible one. Follows #247, #248, #249.

The FM overview is now drawn **where it was acquired**, on a black stage-space backdrop, instead of filling the canvas — and every overview stays on it, so a second one joins the first rather than replacing it.

## The shape of it

Everything on screen is placed relative to a canvas **origin**: the stage position the overview is built around, taken from the first image and then kept. Re-deriving it per image would shift the whole scene each time one arrived.

`FMCanvasWidget` gained two seams — `_make_canvas` and `_show_composite` — and `FMRealSpaceCanvasWidget` subclasses it. Everything above the display is inherited unchanged (channel stacks, layers popover, z-scrubbing), because compositing already sat above display; only where the blended frame lands differs.

```
per-image channel planes -> FMLayer (shared display state) -> composite -> add_image / update_image
```

The canvas knows nothing about modality, so FIB/SEM images can be placed alongside the composite and register with it in stage space. What is FM-specific is the *controls*, not the display.

## The planned grid no longer needs an image

`TileGridOverlay` takes an explicit anchor, because a tileset is planned around a *stage position* rather than around whatever happens to be displayed. With a reference pixel size set before the first image and a world extent derived from the grid, the planned grid draws on an empty canvas — which also fixes the standalone app showing nothing at startup.

Position markers project against the origin rather than onto the displayed image, so a marker names the same piece of sample whatever is on screen, and survives the image being swapped or not existing yet.

## Keeping more than one

Overviews are keyed by **acquisition timestamp**, not position: a small overview and a wider one taken over the same area at different times are both worth keeping, and keying on position silently dropped the first. Using a property of the image rather than a counter keeps it idempotent — showing the same image twice replaces it instead of drawing a second copy on itself.

Channel planes are held **per placed image**, because layers are display state shared by everything on the canvas while the pixels are not. Without that, recolouring a channel would restyle the newest overview and leave the rest — the same data drawn two different ways, side by side.

Draw order comes from **pixel size**, not arrival: a wide coarse survey acquired after a detailed overview covers the same ground, so by arrival order it would hide the better data underneath it.

## Bugs found and fixed on the way

**A scale error, reported from testing:** a 1x5 acquired after a 2x1 appeared three times too large. `set_channel` composites and places immediately, so the key, placement and pixel size must be set before it — `_show_preview` set them after, applying them a tick late. The first frame of each run landed under the previous run's key at the previous run's pixel size, drawing it wrong *and* corrupting the earlier overview's extent. Latent before this work: the same ordering existed, but nothing depended on pixel size for placement, so it only ever affected the scalebar for one frame.

| run | expected | now |
| -- | -- | -- |
| 2x1 | 1024 x 1946 | 1024 x 1946 |
| 1x5 | 4712 x 1024 | 4712 x 1024 |

**A geometry bug:** `aspect="equal"` is set by `imshow`, per artist — so an empty real-space canvas was `"auto"` and a window resize drew a square grid with 3x distortion. It only looked right because the fit padding happened to compensate on each refit. Now set at construction, with a test that resizes and checks the ratio.

**The "No image" placeholder** is gone from this canvas: the black backdrop already says nothing was acquired there, keeps saying it once images arrive, and the text would sit inside the planned grid.

## Verification

Full suite **2077 passed, 16 skipped**. New coverage for placement, multi-overview keying and restyling, detail ordering, the preview-frame ordering, RGB/RGBA (which the composited path is, and which #249 had no test for), and stack rejection.

One existing test needed rewriting rather than patching: `test_positions_are_marked_where_they_are` asserted a marker at the origin lands at `(width/2, height/2)`. In the canvas frame the origin is `(0, 0)`; the invariant worth holding is that a 20 um stage offset comes out as 20 um on screen.

## Not in scope

Per-*tile* placement during a run was considered and dropped: the runner would have to emit each tile, the widget would hold accumulated state, and the benefit is largely undone by `_finish` swapping in the properly stitched mosaic anyway. The preview stays a rough guide, which is what it is for.

FIB-414 (pyramids) and FIB-415 (per-image layer selection) remain open and are unaffected by this.
