### PR TITLE
[ui] Steer the stage from the FM overview canvas: click to move, drag to aim (FIB-408, FIB-418)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -443,6 +443,7 @@ class FMTiledAcquisitionRunner:
         autofocus_settings: Optional[AutoFocusSettings] = None,
         save_directory: Optional[str] = None,
         stop_event: Optional[threading.Event] = None,
+        centre_position: Optional[FibsemStagePosition] = None,
     ):
         self.microscope = microscope
         self.channel_settings = channel_settings
@@ -451,6 +452,12 @@ class FMTiledAcquisitionRunner:
         self.autofocus_settings = autofocus_settings
         self.save_directory = save_directory
         self.stop_event = stop_event
+        # Where the grid is centred. Distinct from where the run started: those were
+        # one value until an overview could be planned somewhere other than under the
+        # stage, and conflating them meant the stage was also restored to the target.
+        # Resolved to the starting position in `_setup` when not given, so it always
+        # names the actual centre once a run has begun.
+        self.centre_position = centre_position
 
         # Sized in _setup once the grid is known, and written by index. Every cell that
         # was not reached -- skipped by the mask, or not yet visited when a cancel came
@@ -492,14 +499,14 @@ class FMTiledAcquisitionRunner:
 
         The mosaic is an ordinary fluorescence image that happens to be large, and it
         reports where it is from what the run captured rather than from what the
-        stitcher can infer: the grid is centred on the starting stage position, and
-        every tile is taken at the starting objective position.
+        stitcher can infer: the grid is centred on `centre_position`, and every tile is
+        taken at the starting objective position.
         """
         self.run()
         return stitch_tileset(
             self.tileset,
             self.overview_parameters.overlap,
-            centre_position=self._initial_position,
+            centre_position=self.centre_position,
             objective_position=self._initial_objective_position,
         )
 
@@ -554,9 +561,13 @@ class FMTiledAcquisitionRunner:
             f"{n_enabled}/{self._rows * self._cols} tiles enabled"
         )
 
-        # Captured for the restore in _restore(), and as the grid's centre.
+        # Captured for the restore in _restore(). The grid's centre defaults to it --
+        # an overview is normally taken of what you are looking at -- but a caller can
+        # name somewhere else, and then the stage still comes back here afterwards.
         self._initial_position = microscope.get_stage_position()
         self._initial_objective_position = microscope.fm.objective.position
+        if self.centre_position is None:
+            self.centre_position = self._initial_position
 
         pixel_size_x, pixel_size_y = microscope.fm.camera.pixel_size
         self._image_width, self._image_height = microscope.fm.camera.resolution
@@ -656,8 +667,8 @@ class FMTiledAcquisitionRunner:
         if not self._ordered:
             raise ValueError("Tile mask disables every tile; nothing to acquire.")
 
-        # The grid measures from its top-left tile; shift so it is centred on where
-        # the stage already is. Same convention as TiledAcquisitionRunner.
+        # The grid measures from its top-left tile; shift so it straddles the centre.
+        # Same convention as TiledAcquisitionRunner.
         grid_offset_x = (self._cols - 1) * self._step_x / 2
         grid_offset_y = (self._rows - 1) * self._step_y / 2
 
@@ -665,7 +676,7 @@ class FMTiledAcquisitionRunner:
             (tile.row, tile.col): self.microscope.project_fm_stable_move(
                 dx=tile.dx - grid_offset_x,
                 dy=tile.dy + grid_offset_y,
-                base_position=self._initial_position,
+                base_position=self.centre_position,
             )
             for tile in self._grid
         }

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import re
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime
 from enum import Enum
 from typing import Any, List, Optional, Tuple, Union
@@ -823,20 +823,11 @@ class FluorescenceImage:
         first_metadata = ch_images[0].metadata
         z_positions = [img.metadata.channels[0].objective_position for img in ch_images]
 
-        # Create new metadata with z-positions
-        md = FluorescenceImageMetadata(
-            acquisition_date=first_metadata.acquisition_date,
-            pixel_size_x=first_metadata.pixel_size_x,
-            pixel_size_y=first_metadata.pixel_size_y,
-            pixel_size_z=first_metadata.pixel_size_z,
-            resolution=first_metadata.resolution,
-            channels=first_metadata.channels,
-            z_positions=z_positions,
-            stage_position=first_metadata.stage_position,
-            filename=first_metadata.filename,
-            description=first_metadata.description,
-            system_info=first_metadata.system_info,
-        )
+        # Carry the first plane's metadata over and change only what stacking changes.
+        # Listing the fields to copy instead means every field added to the dataclass
+        # later has to be remembered here too -- which is how `geometry` came to be
+        # silently dropped from every z-stacked and multi-channel acquisition.
+        md = replace(first_metadata, z_positions=z_positions)
 
         return FluorescenceImage(data=arrs, metadata=md)
 
@@ -875,19 +866,8 @@ class FluorescenceImage:
         for img in images:
             channels.extend(img.metadata.channels)
 
-        mds = FluorescenceImageMetadata(
-            acquisition_date=first_img.metadata.acquisition_date,
-            pixel_size_x=first_img.metadata.pixel_size_x,
-            pixel_size_y=first_img.metadata.pixel_size_y,
-            pixel_size_z=first_img.metadata.pixel_size_z,
-            resolution=first_img.metadata.resolution,
-            channels=channels,
-            z_positions=first_img.metadata.z_positions,
-            stage_position=first_img.metadata.stage_position,
-            filename=first_img.metadata.filename,
-            description=first_img.metadata.description,
-            system_info=first_img.metadata.system_info,
-        )
+        # As above: copy and override, so a new metadata field cannot go missing here.
+        mds = replace(first_img.metadata, channels=channels)
 
         return FluorescenceImage(data=stacked_data, metadata=mds)
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -469,7 +469,10 @@ class FMOverviewWidget(QWidget):
         # the stage itself -- not on whatever happens to be displayed. It used to be
         # pinned to the canvas origin, which is where the stage was the *first* time
         # anything was drawn: correct until the stage moved, and then quietly not.
-        self.tile_grid_overlay.set_anchor(self._grid_anchor())
+        offset = self._grid_offset()
+        self.tile_grid_overlay.set_anchor(
+            self.canvas.canvas.metres_to_canvas(*offset)
+        )
 
         # No `display_pixel_size`: the overlay reads it from the canvas at draw time.
         # Pinning it here would freeze the scale at whatever was displayed when the
@@ -494,14 +497,39 @@ class FMOverviewWidget(QWidget):
         footprint = (parameters.rows, parameters.cols, parameters.overlap)
         changed = footprint != self._grid_footprint
         self._grid_footprint = footprint
-        if changed and not self.tile_grid_overlay.is_resizing:
+        if (changed or self._grid_has_left_the_working_area(offset, span_x, span_y)) \
+                and not self.tile_grid_overlay.is_resizing:
             # Frame the planned area, so an empty canvas shows where the run will go
             # rather than nothing at all, and so clicks land in a meaningful frame.
             # Behind the same guard as the refit below, and for the same reason: a tile
             # toggle comes through here too, and re-framing on one threw away the
             # user's zoom -- which is what made clicking a tile look like zooming.
-            self.canvas.set_world_extent(span_x, span_y)
+            self.canvas.set_world_extent(span_x, span_y, offset)
             self.tile_grid_overlay.fit_view()
+
+    def _grid_has_left_the_working_area(
+        self, offset: Tuple[float, float], span_x: float, span_y: float
+    ) -> bool:
+        """Whether the declared working area has stopped describing where the grid is.
+
+        The working area is centred on the grid rather than on the canvas origin. The
+        two coincide until the stage travels far from wherever the frame was anchored
+        -- moving to an offset FM mount steps 48 mm -- and an area left behind at the
+        origin then frames empty space *and* stretches the content extent across the
+        gap, which is what caps how far the view can zoom in: the limiter is relative
+        to the content, so it read the span as 48 mm when what mattered was 0.1 mm.
+
+        Re-declaring it re-frames the view, though, so it cannot simply follow every
+        move -- a double-click to somewhere 100 µm away would throw the zoom away, the
+        same failure a tile toggle used to cause. It follows only once the grid has
+        left the area outright, at which point what is framed and what is planned no
+        longer overlap at all.
+        """
+        declared = self.canvas.canvas.world_extent
+        if declared is None:
+            return True  # nothing declared yet, so nothing describes the grid
+        width, height, cx, cy = declared
+        return abs(offset[0] - cx) > width / 2 or abs(offset[1] - cy) > height / 2
 
     def _toggle_tile_grid_panel(self) -> None:
         if not self.btn_tile_grid.isChecked():
@@ -725,20 +753,29 @@ class FMOverviewWidget(QWidget):
         """
         return self._target or self._current_stage_position()
 
-    def _grid_anchor(self) -> Tuple[float, float]:
-        """Where on the canvas the planned grid is centred.
+    def _grid_offset(self) -> Tuple[float, float]:
+        """Where the planned grid's centre sits relative to the canvas origin, in metres.
 
-        Falls back to the canvas origin when the centre cannot be projected, which
-        draws the grid in the middle of the frame rather than not at all.
+        Falls back to the origin when the centre cannot be projected, which draws the
+        grid in the middle of the frame rather than not at all.
         """
         frame = self._frame()
         centre = self._grid_centre()
         if frame is not None and centre is not None:
             try:
-                return frame.to_canvas(centre)
+                return frame.offset(centre)
             except Exception as e:
                 logging.debug(f"Could not place the planned grid: {e}")
-        return self.canvas.canvas.metres_to_canvas(0.0, 0.0)
+        return (0.0, 0.0)
+
+    def _grid_anchor(self) -> Tuple[float, float]:
+        """Where on the canvas the planned grid is centred.
+
+        The same place :meth:`_grid_offset` names, in canvas pixels rather than metres
+        -- derived from it rather than projected again, so the drawn grid and the
+        declared working area cannot end up centred on different points.
+        """
+        return self.canvas.canvas.metres_to_canvas(*self._grid_offset())
 
     def _refresh_positions(self) -> None:
         """Mark the stage positions in the canvas frame."""

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -92,6 +92,15 @@ PREVIEW_KEY = "fm-preview"
 # Radius of the specimen grid, for the boundary circle. Matches the minimap's.
 GRID_RADIUS_M = 1000e-6
 
+# Yellow for "you are here", against the red grid origin and the amber of saved
+# positions -- three markers that must not be mistaken for each other.
+CURRENT_POSITION_COLOUR = "#ffee58"
+# Cyan for positions a user saved, against the yellow of where the stage is.
+SAVED_POSITION_COLOUR = "#26c6da"
+# Muted, because the holder slots are structural context like the limits rather
+# than something anyone marked -- and they would otherwise read as saved positions.
+SLOT_COLOUR = "#90a4ae"
+
 
 class FMOverviewWidget(QWidget):
     """Configure, run and view a fluorescence overview acquisition."""
@@ -105,6 +114,9 @@ class FMOverviewWidget(QWidget):
     # different thread"). Re-emitting as a Qt signal gets it queued onto the GUI
     # thread, because this widget lives there.
     _progress_received = pyqtSignal(dict)
+    # Same hop for stage moves: `stage_position_changed` is a psygnal, so it fires
+    # on whichever thread moved the stage -- a worker, during an acquisition.
+    _stage_moved = pyqtSignal(object)
 
     def __init__(
         self,
@@ -138,6 +150,9 @@ class FMOverviewWidget(QWidget):
 
         self._progress_received.connect(self._apply_progress)
         self.fm.acquisition_progress_signal.connect(self._on_progress)
+        self._stage_moved.connect(lambda _: self._refresh_current_position())
+        self.microscope.stage_position_changed.connect(self._stage_moved.emit)
+        self._refresh_current_position()
 
     def _default_channels(self) -> List[ChannelSettings]:
         """The saved FM configuration if there is one, otherwise a single channel."""
@@ -187,7 +202,17 @@ class FMOverviewWidget(QWidget):
         self.stage_overlay = MinimapShapesOverlay(zorder=4.0, crosshair_half_px=24)
         self.canvas.canvas.add_overlay(self.stage_overlay)
 
-        self.position_overlay = PointsOverlay(color="#ffb300", marker="o", size=7)
+        # Where the stage is now. Distinct from the red origin marker the canvas
+        # draws: the origin explains why everything sits where it does, this is what
+        # you steer by. They coincide until the stage moves, then diverge.
+        self.current_position_overlay = PointsOverlay(
+            color=CURRENT_POSITION_COLOUR, marker="+", size=13
+        )
+        self.canvas.canvas.add_overlay(self.current_position_overlay)
+
+        self.position_overlay = PointsOverlay(
+            color=SAVED_POSITION_COLOUR, marker="o", size=7
+        )
         self.canvas.canvas.add_overlay(self.position_overlay)
 
         # The list alone shows only name/excitation/emission, with no way to set the
@@ -600,11 +625,26 @@ class FMOverviewWidget(QWidget):
                 logging.debug(f"Cannot place slot {position.name!r}: {e}")
                 continue
             specs.append(ShapeSpec(
-                kind="crosshair", cx=point[0], cy=point[1], color="cyan",
+                kind="crosshair", cx=point[0], cy=point[1], color=SLOT_COLOUR,
                 label=position.name or "",
             ))
 
         self.stage_overlay.set_shapes(specs)
+
+    def _refresh_current_position(self) -> None:
+        """Mark where the stage is now."""
+        project = self._stage_to_canvas()
+        position = self._current_stage_position()
+        if project is None or position is None:
+            self.current_position_overlay.set_points([])
+            return
+        try:
+            point = project(position)
+        except Exception as e:
+            logging.debug(f"Could not mark the current stage position: {e}")
+            self.current_position_overlay.set_points([])
+            return
+        self.current_position_overlay.set_points([point], labels=[""])
 
     def _live_geometry(self):
         """(geometry, pixel_size, shape) from the microscope.

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -962,7 +962,12 @@ class FMOverviewWidget(QWidget):
             stride = payload.get("preview_stride", 1) or 1
             self.canvas.set_pixel_size(self.fm.camera.pixel_size[0] * stride)
 
-            for channel, plane in zip(self.channels, planes):
+            # This run's channels, and only these. `set_channel` upserts, so a channel
+            # switched off since the last run would otherwise keep its layer -- still
+            # holding the previous overview's pixels -- and be blended into this one.
+            channels = self.channels
+            self.canvas.retain_channels([channel.name for channel in channels])
+            for channel, plane in zip(channels, planes):
                 self.canvas.set_channel(channel.name, plane, channel.color)
         except Exception as e:
             logging.debug(f"Could not display the overview preview: {e}")

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -45,6 +45,10 @@ from fibsem.ui.fm.widgets.tile_grid_options_panel import TileGridOptionsPanel
 from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.fm.reprojection import project_stage_position
 from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
+from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
+    MinimapShapesOverlay,
+    ShapeSpec,
+)
 from fibsem.ui.widgets.canvas.overlays.point_overlay import PointsOverlay
 from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import TileGridOverlay
 from fibsem.ui.widgets.custom_widgets import TitledPanel
@@ -84,6 +88,9 @@ def progress_slot(progress: FibsemProgressWidget) -> QWidget:
 # Key the in-progress mosaic is drawn under. Distinct from a finished overview's
 # position-derived key, so the preview can be dropped when the real stitch lands.
 PREVIEW_KEY = "fm-preview"
+
+# Radius of the specimen grid, for the boundary circle. Matches the minimap's.
+GRID_RADIUS_M = 1000e-6
 
 
 class FMOverviewWidget(QWidget):
@@ -175,6 +182,11 @@ class FMOverviewWidget(QWidget):
         # Stage positions -- the current pose, lamellae, anything a host hands over --
         # projected onto whatever image is displayed. Non-interactive: this shows where
         # things are, it does not move them.
+        # Where the sample and the stage can physically go -- the context an overview
+        # is read against. Added before the position markers so it sits beneath them.
+        self.stage_overlay = MinimapShapesOverlay(zorder=4.0, crosshair_half_px=24)
+        self.canvas.canvas.add_overlay(self.stage_overlay)
+
         self.position_overlay = PointsOverlay(color="#ffb300", marker="o", size=7)
         self.canvas.canvas.add_overlay(self.position_overlay)
 
@@ -375,6 +387,9 @@ class FMOverviewWidget(QWidget):
         self.tile_grid_overlay.set_grid(
             tiles, (height, width), pixel_size, overlap=parameters.overlap
         )
+        # Same camera geometry, so it can be drawn at the same time rather than
+        # waiting for an image the tile grid does not wait for either.
+        self._refresh_stage_metadata()
 
         span_x = parameters.cols * fov[0] * (1 - parameters.overlap) + fov[0]
         span_y = parameters.rows * fov[1] * (1 - parameters.overlap) + fov[1]
@@ -426,6 +441,7 @@ class FMOverviewWidget(QWidget):
         self.canvas.set_placement(self._offset_of(image))
         self.canvas.set_fm_image(image)
         self._refresh_positions()
+        self._refresh_stage_metadata()
         self._refresh_tile_grid()
 
     @staticmethod
@@ -484,47 +500,161 @@ class FMOverviewWidget(QWidget):
         self._positions = list(positions)
         self._refresh_positions()
 
-    def _refresh_positions(self) -> None:
-        """Mark the stage positions in the canvas frame.
+    def _stage_to_canvas(self):
+        """A function mapping a stage position to canvas coordinates, or None.
+
+        The one place stage space meets the canvas frame. Everything drawn from a stage
+        position goes through it -- marked positions, the stage and grid limits, the
+        current pose -- so they are all in the same frame by construction rather than by
+        four callers agreeing to do the same arithmetic.
 
         Projected against the canvas origin rather than onto whichever image happens to
         be displayed, so a marker names the same piece of sample no matter what is on
-        screen -- and markers survive the image being swapped, or there being none yet.
-
-        The projection uses the recorded geometry rather than the live microscope: after
-        an overview is acquired the stage has moved on, and following it would drift
-        every marker off the feature it names.
+        screen. The projection uses the *recorded* geometry rather than the live
+        microscope: after an overview is acquired the stage has moved on, and following
+        it would drift everything off the features it names. That geometry is also what
+        puts the drawing in the current stage orientation -- t = -180 for FM -- since the
+        tilt, rotation and camera flip are all folded into it.
         """
-        if not self._positions or self._origin is None:
-            self.position_overlay.set_points([])
+        # Live, always -- the displayed image contributes nothing here.
+        #
+        # `FMImageGeometry` is system configuration (camera tilt, shuttle pre-tilt, the
+        # camera flip, compustage or not), not pose: the pose enters through the origin
+        # below, as its rotation and tilt. So an image's recorded geometry and the
+        # microscope's live one agree by construction.
+        #
+        # `pixel_size` and `shape` cancel outright. `project_stage_position` answers in
+        # pixels of a hypothetical image, and the very next thing done here is convert
+        # back to metres -- verified identical across a 27,000x range of pixel sizes.
+        # They are arguments to a function that measures in pixels, not inputs to the
+        # geometry.
+        #
+        # Taking it from the displayed image instead made everything drawn from a stage
+        # position vanish the moment an overview was acquired, because acquired tiles
+        # currently lose their geometry (see the note in _live_geometry).
+        geometry, pixel_size, shape = self._live_geometry()
+        if geometry is None or not pixel_size:
+            return None
+
+        origin = self._origin or self._current_stage_position()
+        if origin is None:
+            return None
+        self._origin = origin  # fix it now, so later drawing shares this frame
+
+        def project(position: FibsemStagePosition) -> Tuple[float, float]:
+            point = project_stage_position(
+                position, origin, pixel_size, shape, geometry
+            )
+            return self.canvas.canvas.metres_to_canvas(
+                (point.x - shape[1] / 2) * pixel_size,
+                (point.y - shape[0] / 2) * pixel_size,
+            )
+
+        return project
+
+    def _refresh_stage_metadata(self) -> None:
+        """Draw where the sample and the stage can physically go.
+
+        The context an overview is read against: which grid you are on, how far from its
+        centre, and how much travel is left. Same shapes the minimap draws, but placed
+        straight into the canvas frame -- on a real-space canvas there is no stitched
+        image to reproject onto, so the indirection disappears.
+        """
+        project = self._stage_to_canvas()
+        if project is None:
+            self.stage_overlay.set_shapes([])
             return
 
-        geometry = None
-        pixel_size = None
-        if self._displayed_image is not None:
-            geometry = getattr(self._displayed_image.metadata, "geometry", None)
-            pixel_size = getattr(self._displayed_image.metadata, "pixel_size_x", None)
-        if geometry is None or not pixel_size:
-            # Nothing to project through -- an image acquired before the geometry was
-            # recorded, or none displayed yet.
+        specs = []
+        try:
+            centre = project(FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0))
+        except Exception as e:
+            logging.debug(f"Cannot place the grid centre: {e}")
+            self.stage_overlay.set_shapes([])
+            return
+
+        limits = getattr(self.microscope._stage, "limits", None)
+        if limits and self.microscope.stage_is_compustage:
+            # The travel envelope, as a box around the grid centre. Sized from the
+            # limits rather than projected corner-by-corner: the projection is flips
+            # and a tilt, which keep an axis-aligned box axis-aligned.
+            specs.append(ShapeSpec(
+                kind="rect", cx=centre[0], cy=centre[1], color="yellow",
+                width=self._canvas_length(limits["x"].max - limits["x"].min),
+                height=self._canvas_length(limits["y"].max - limits["y"].min),
+                label="Stage limits",
+            ))
+            specs.append(ShapeSpec(
+                kind="circle", cx=centre[0], cy=centre[1], color="red",
+                radius=self._canvas_length(GRID_RADIUS_M), label="Grid boundary",
+            ))
+
+        holder = getattr(self.microscope._stage, "holder", None)
+        for slot in getattr(holder, "slots", {}).values():
+            position = getattr(slot, "position", None)
+            if position is None:
+                continue
+            try:
+                point = project(position)
+            except Exception as e:
+                logging.debug(f"Cannot place slot {position.name!r}: {e}")
+                continue
+            specs.append(ShapeSpec(
+                kind="crosshair", cx=point[0], cy=point[1], color="cyan",
+                label=position.name or "",
+            ))
+
+        self.stage_overlay.set_shapes(specs)
+
+    def _live_geometry(self):
+        """(geometry, pixel_size, shape) from the microscope.
+
+        The single source for projecting stage positions. Not read from the displayed
+        image, both because it need not be -- the geometry is configuration and the other
+        two cancel -- and because it currently *cannot* be: tiles acquired through the
+        tiled runner come back without a geometry, since the metadata constructors that
+        combine channels and z-planes rebuild it field by field and do not carry it over.
+        A stitched mosaic inherits that gap, so anything projected against the mosaic
+        disappeared. Worth fixing upstream regardless, for consumers that have no live
+        microscope to fall back on.
+        """
+        try:
+            width, height = self.fm.camera.resolution
+            return (
+                self.microscope.fm_image_geometry(),
+                self.fm.camera.pixel_size[0],
+                (height, width),
+            )
+        except Exception as e:
+            logging.debug(f"Could not read the live FM geometry: {e}")
+            return None, None, None
+
+    def _current_stage_position(self) -> Optional[FibsemStagePosition]:
+        try:
+            return self.microscope.get_stage_position()
+        except Exception as e:
+            logging.debug(f"Could not read the stage position: {e}")
+            return None
+
+    def _canvas_length(self, metres: float) -> float:
+        """A length in metres as a length in canvas pixels."""
+        reference = self.canvas.canvas.reference_pixel_size
+        return metres / reference if reference else 0.0
+
+    def _refresh_positions(self) -> None:
+        """Mark the stage positions in the canvas frame."""
+        project = self._stage_to_canvas()
+        if not self._positions or project is None:
             self.position_overlay.set_points([])
             return
 
         points, labels = [], []
-        shape = np.asarray(self._displayed_image.data).shape[-2:]
         for position in self._positions:
             try:
-                point = project_stage_position(
-                    position, self._origin, pixel_size, shape, geometry
-                )
+                points.append(project(position))
             except Exception as e:
                 logging.debug(f"Cannot mark {position.name!r}: {e}")
                 continue
-            metres = (
-                (point.x - shape[1] / 2) * pixel_size,
-                (point.y - shape[0] / 2) * pixel_size,
-            )
-            points.append(self.canvas.canvas.metres_to_canvas(*metres))
             labels.append(position.name or "")
 
         self.position_overlay.set_points(points, labels=labels)

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -35,7 +35,7 @@ from fibsem.fm.structures import (
     OverviewParameters,
 )
 from fibsem.microscope import FibsemMicroscope
-from fibsem.structures import FibsemStagePosition, Point
+from fibsem.structures import FibsemStagePosition
 from fibsem.ui import notification_service, stylesheets
 from fibsem.ui.fm.widgets.fm_multi_channel_widget import FluorescenceMultiChannelWidget
 from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
@@ -44,7 +44,6 @@ from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
 from fibsem.ui.fm.widgets.tile_grid_options_panel import TileGridOptionsPanel
 from fibsem.ui.qt.threading import FunctionWorker
-from fibsem.fm.reprojection import project_image_point, project_stage_position
 from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
 from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
     MinimapShapesOverlay,
@@ -58,6 +57,7 @@ from fibsem.ui.widgets.progress_widget import (
     ProgressUpdate,
 )
 from fibsem.ui.widgets.canvas.fm_canvas import FMRealSpaceCanvasWidget
+from fibsem.ui.widgets.canvas.stage_frame import FMStageProjection, StageFrame
 
 TEXT_MUTED = "#868e93"
 PROGRESS_WIDTH = 260
@@ -542,27 +542,21 @@ class FMOverviewWidget(QWidget):
     def _offset_of(self, image: FluorescenceImage) -> Tuple[float, float]:
         """Where *image*'s centre sits relative to the canvas origin, in metres.
 
-        The stage-to-plane projection the canvas deliberately knows nothing about. Falls
-        back to the origin when the image cannot be projected -- acquired before the
+        Projected through the image's *own* geometry rather than the live one, which is
+        the whole reason this is not :meth:`_offset_from_origin`: an image may have been
+        acquired under a configuration the instrument is no longer in, and it has to be
+        placed as it was taken.
+
+        Falls back to the origin when it cannot be projected -- acquired before the
         geometry was recorded, or with no pose at all -- which puts it in the middle of
         the view rather than refusing to show it.
         """
         position = self._position_of(image)
-        geometry = getattr(image.metadata, "geometry", None)
-        if self._origin is None or position is None or geometry is None:
+        projection = FMStageProjection.from_image(image)
+        if self._origin is None or position is None or projection is None:
             return (0.0, 0.0)
         try:
-            pixel_size = image.metadata.pixel_size_x
-            shape = np.asarray(image.data).shape[-2:]
-            point = project_stage_position(
-                position, self._origin, pixel_size, shape, geometry
-            )
-            # project_stage_position answers in pixels of an image acquired at the
-            # origin; the canvas wants metres from it, so measure from the centre out.
-            return (
-                (point.x - shape[1] / 2) * pixel_size,
-                (point.y - shape[0] / 2) * pixel_size,
-            )
+            return projection.to_plane(position, self._origin)
         except Exception as e:
             logging.debug(f"Could not place the image in stage space: {e}")
             return (0.0, 0.0)
@@ -576,11 +570,11 @@ class FMOverviewWidget(QWidget):
         question for an image out of its own metadata -- and has to, since an image may
         have been acquired under a configuration the instrument is no longer in.
         """
-        project = self._stage_to_canvas()
-        if project is None:
+        frame = self._frame()
+        if frame is None:
             return (0.0, 0.0)
         try:
-            return self.canvas.canvas.canvas_to_metres(*project(position))
+            return frame.offset(position)
         except Exception as e:
             logging.debug(f"Could not place {position} in the canvas frame: {e}")
             return (0.0, 0.0)
@@ -594,40 +588,21 @@ class FMOverviewWidget(QWidget):
         self._positions = list(positions)
         self._refresh_positions()
 
-    def _stage_to_canvas(self):
-        """A function mapping a stage position to canvas coordinates, or None.
+    def _frame(self) -> Optional[StageFrame]:
+        """The mapping between stage space and the canvas, or None if it cannot be had.
 
-        The one place stage space meets the canvas frame. Everything drawn from a stage
-        position goes through it -- marked positions, the stage and grid limits, the
-        current pose -- so they are all in the same frame by construction rather than by
-        four callers agreeing to do the same arithmetic.
+        The one place the two meet. Everything drawn from a stage position goes through
+        it -- marked positions, the stage and grid limits, the current pose, the planned
+        grid -- and so does every click, so they share a frame by construction rather
+        than by six callers agreeing to do the same arithmetic.
 
-        Projected against the canvas origin rather than onto whichever image happens to
-        be displayed, so a marker names the same piece of sample no matter what is on
-        screen. The projection uses the *recorded* geometry rather than the live
-        microscope: after an overview is acquired the stage has moved on, and following
-        it would drift everything off the features it names. That geometry is also what
-        puts the drawing in the current stage orientation -- t = -180 for FM -- since the
-        tilt, rotation and camera flip are all folded into it.
+        Anchored on the canvas origin rather than on whichever image happens to be
+        displayed, so a marker names the same piece of sample no matter what is on
+        screen. The origin's rotation and tilt are what put the drawing in the current
+        stage orientation -- t = -180 for FM.
         """
-        # Live, always -- the displayed image contributes nothing here.
-        #
-        # `FMImageGeometry` is system configuration (camera tilt, shuttle pre-tilt, the
-        # camera flip, compustage or not), not pose: the pose enters through the origin
-        # below, as its rotation and tilt. So an image's recorded geometry and the
-        # microscope's live one agree by construction.
-        #
-        # `pixel_size` and `shape` cancel outright. `project_stage_position` answers in
-        # pixels of a hypothetical image, and the very next thing done here is convert
-        # back to metres -- verified identical across a 27,000x range of pixel sizes.
-        # They are arguments to a function that measures in pixels, not inputs to the
-        # geometry.
-        #
-        # Taking it from the displayed image instead made everything drawn from a stage
-        # position vanish the moment an overview was acquired, because acquired tiles
-        # currently lose their geometry (see the note in _live_geometry).
-        geometry, pixel_size, shape = self._live_geometry()
-        if geometry is None or not pixel_size:
+        projection = FMStageProjection.from_microscope(self.microscope)
+        if projection is None:
             return None
 
         origin = self._origin or self._current_stage_position()
@@ -635,46 +610,7 @@ class FMOverviewWidget(QWidget):
             return None
         self._origin = origin  # fix it now, so later drawing shares this frame
 
-        def project(position: FibsemStagePosition) -> Tuple[float, float]:
-            point = project_stage_position(
-                position, origin, pixel_size, shape, geometry
-            )
-            return self.canvas.canvas.metres_to_canvas(
-                (point.x - shape[1] / 2) * pixel_size,
-                (point.y - shape[0] / 2) * pixel_size,
-            )
-
-        return project
-
-    def _canvas_to_stage(self):
-        """A function mapping canvas coordinates to a stage position, or None.
-
-        The inverse of :meth:`_stage_to_canvas`, and deliberately its mirror image:
-        same origin, same live geometry, same scale. `project_image_point` is the exact
-        inverse of the `project_stage_position` used to draw, sharing its sign terms,
-        so a click on a marker resolves to the position that marker was drawn from
-        rather than to somewhere plausibly near it.
-        """
-        geometry, pixel_size, shape = self._live_geometry()
-        if geometry is None or not pixel_size:
-            return None
-
-        origin = self._origin or self._current_stage_position()
-        if origin is None:
-            return None
-        self._origin = origin
-
-        def unproject(x: float, y: float) -> FibsemStagePosition:
-            # Canvas -> metres from the origin -> pixels of a hypothetical image
-            # acquired there, which is the frame `project_image_point` inverts from.
-            offset_x, offset_y = self.canvas.canvas.canvas_to_metres(x, y)
-            point = Point(
-                x=shape[1] / 2 + offset_x / pixel_size,
-                y=shape[0] / 2 + offset_y / pixel_size,
-            )
-            return project_image_point(point, origin, pixel_size, shape, geometry)
-
-        return unproject
+        return StageFrame(self.canvas.canvas, origin, projection)
 
     def _refresh_stage_metadata(self) -> None:
         """Draw where the sample and the stage can physically go.
@@ -684,14 +620,16 @@ class FMOverviewWidget(QWidget):
         straight into the canvas frame -- on a real-space canvas there is no stitched
         image to reproject onto, so the indirection disappears.
         """
-        project = self._stage_to_canvas()
-        if project is None:
+        frame = self._frame()
+        if frame is None:
             self.stage_overlay.set_shapes([])
             return
 
         specs = []
         try:
-            centre = project(FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0))
+            centre = frame.to_canvas(
+                FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0)
+            )
         except Exception as e:
             logging.debug(f"Cannot place the grid centre: {e}")
             self.stage_overlay.set_shapes([])
@@ -704,13 +642,13 @@ class FMOverviewWidget(QWidget):
             # and a tilt, which keep an axis-aligned box axis-aligned.
             specs.append(ShapeSpec(
                 kind="rect", cx=centre[0], cy=centre[1], color="yellow",
-                width=self._canvas_length(limits["x"].max - limits["x"].min),
-                height=self._canvas_length(limits["y"].max - limits["y"].min),
+                width=frame.length(limits["x"].max - limits["x"].min),
+                height=frame.length(limits["y"].max - limits["y"].min),
                 label="Stage limits",
             ))
             specs.append(ShapeSpec(
                 kind="circle", cx=centre[0], cy=centre[1], color="red",
-                radius=self._canvas_length(GRID_RADIUS_M), label="Grid boundary",
+                radius=frame.length(GRID_RADIUS_M), label="Grid boundary",
             ))
 
         holder = getattr(self.microscope._stage, "holder", None)
@@ -719,7 +657,7 @@ class FMOverviewWidget(QWidget):
             if position is None:
                 continue
             try:
-                point = project(position)
+                point = frame.to_canvas(position)
             except Exception as e:
                 logging.debug(f"Cannot place slot {position.name!r}: {e}")
                 continue
@@ -732,41 +670,18 @@ class FMOverviewWidget(QWidget):
 
     def _refresh_current_position(self) -> None:
         """Mark where the stage is now."""
-        project = self._stage_to_canvas()
+        frame = self._frame()
         position = self._current_stage_position()
-        if project is None or position is None:
+        if frame is None or position is None:
             self.current_position_overlay.set_points([])
             return
         try:
-            point = project(position)
+            point = frame.to_canvas(position)
         except Exception as e:
             logging.debug(f"Could not mark the current stage position: {e}")
             self.current_position_overlay.set_points([])
             return
         self.current_position_overlay.set_points([point], labels=[""])
-
-    def _live_geometry(self):
-        """(geometry, pixel_size, shape) from the microscope.
-
-        The single source for projecting stage positions. Not read from the displayed
-        image, both because it need not be -- the geometry is configuration and the other
-        two cancel -- and because it currently *cannot* be: tiles acquired through the
-        tiled runner come back without a geometry, since the metadata constructors that
-        combine channels and z-planes rebuild it field by field and do not carry it over.
-        A stitched mosaic inherits that gap, so anything projected against the mosaic
-        disappeared. Worth fixing upstream regardless, for consumers that have no live
-        microscope to fall back on.
-        """
-        try:
-            width, height = self.fm.camera.resolution
-            return (
-                self.microscope.fm_image_geometry(),
-                self.fm.camera.pixel_size[0],
-                (height, width),
-            )
-        except Exception as e:
-            logging.debug(f"Could not read the live FM geometry: {e}")
-            return None, None, None
 
     def _current_stage_position(self) -> Optional[FibsemStagePosition]:
         """Where the stage is, polling the microscope only when nothing has said yet.
@@ -801,31 +716,26 @@ class FMOverviewWidget(QWidget):
         Falls back to the canvas origin when the centre cannot be projected, which
         draws the grid in the middle of the frame rather than not at all.
         """
-        project = self._stage_to_canvas()
+        frame = self._frame()
         centre = self._grid_centre()
-        if project is not None and centre is not None:
+        if frame is not None and centre is not None:
             try:
-                return project(centre)
+                return frame.to_canvas(centre)
             except Exception as e:
                 logging.debug(f"Could not place the planned grid: {e}")
         return self.canvas.canvas.metres_to_canvas(0.0, 0.0)
 
-    def _canvas_length(self, metres: float) -> float:
-        """A length in metres as a length in canvas pixels."""
-        reference = self.canvas.canvas.reference_pixel_size
-        return metres / reference if reference else 0.0
-
     def _refresh_positions(self) -> None:
         """Mark the stage positions in the canvas frame."""
-        project = self._stage_to_canvas()
-        if not self._positions or project is None:
+        frame = self._frame()
+        if not self._positions or frame is None:
             self.position_overlay.set_points([])
             return
 
         points, labels = [], []
         for position in self._positions:
             try:
-                points.append(project(position))
+                points.append(frame.to_canvas(position))
             except Exception as e:
                 logging.debug(f"Cannot mark {position.name!r}: {e}")
                 continue
@@ -870,11 +780,11 @@ class FMOverviewWidget(QWidget):
             )
             return
 
-        unproject = self._canvas_to_stage()
-        if unproject is None:
+        frame = self._frame()
+        if frame is None:
             return
         try:
-            target = unproject(x, y)
+            target = frame.to_stage(x, y)
         except Exception as e:
             logging.debug(f"Could not resolve the clicked position: {e}")
             return
@@ -912,11 +822,11 @@ class FMOverviewWidget(QWidget):
         around to see what it would cover. The stage goes there when the acquisition
         does.
         """
-        unproject = self._canvas_to_stage()
-        if unproject is None:
+        frame = self._frame()
+        if frame is None:
             return
         try:
-            self._target = unproject(x, y)
+            self._target = frame.to_stage(x, y)
         except Exception as e:
             logging.debug(f"Could not resolve the dragged grid position: {e}")
             return
@@ -938,12 +848,12 @@ class FMOverviewWidget(QWidget):
         if x is None or y is None:
             self.cursor_readout.setText("")
             return
-        unproject = self._canvas_to_stage()
-        if unproject is None:
+        frame = self._frame()
+        if frame is None:
             self.cursor_readout.setText("")
             return
         try:
-            self.cursor_readout.setText(self._describe(unproject(x, y)))
+            self.cursor_readout.setText(self._describe(frame.to_stage(x, y)))
         except Exception as e:
             logging.debug(f"Could not resolve the cursor position: {e}")
             self.cursor_readout.setText("")

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -165,7 +165,13 @@ class FMOverviewWidget(QWidget):
         self._progress_received.connect(self._apply_progress)
         self.fm.acquisition_progress_signal.connect(self._on_progress)
         self._stage_moved.connect(self._on_stage_moved)
-        self.microscope.stage_position_changed.connect(self._stage_moved.emit)
+        # A plain bound method, not `self._stage_moved.emit`, matching how the progress
+        # signal is subscribed just above. psygnal holds bound methods weakly and drops
+        # them when the owner is collected, which a Qt signal's `emit` does not get: PyQt
+        # builds a new wrapper on every access, so psygnal cannot weakref it, cannot
+        # match it at disconnect time -- and says nothing when the disconnect therefore
+        # removes nothing. Emitting into a widget Qt had already torn down was a segfault.
+        self.microscope.stage_position_changed.connect(self._on_stage_signal)
         self._refresh_current_position()
 
     def _default_channels(self) -> List[ChannelSettings]:
@@ -797,6 +803,15 @@ class FMOverviewWidget(QWidget):
 
     # ── canvas interaction ───────────────────────────────────────────────
 
+    def _on_stage_signal(self, position: FibsemStagePosition) -> None:
+        """Called by psygnal, on whichever thread polled. Touches no widgets.
+
+        The counterpart of :meth:`_on_progress`, and a real method rather than the Qt
+        signal's `emit` for a reason beyond symmetry -- see the note where it is
+        connected.
+        """
+        self._stage_moved.emit(position)
+
     def _on_stage_moved(self, position: FibsemStagePosition) -> None:
         """A poll found the stage somewhere new.
 
@@ -1236,8 +1251,17 @@ class FMOverviewWidget(QWidget):
     def closeEvent(self, event) -> None:
         if self.is_acquiring:
             self._stop_event.set()
-        try:
-            self.fm.acquisition_progress_signal.disconnect(self._on_progress)
-        except (TypeError, RuntimeError):
-            pass
+        # Every psygnal this widget subscribed to, without exception. They outlive the
+        # widget -- they belong to the microscope -- and they hold bound methods of Qt
+        # objects that `close` has already torn down on the C++ side, so the next emit
+        # writes into freed memory. Closing the tab and then moving the stage from
+        # anywhere else in the application was a hard segfault, not an exception.
+        for signal, slot in (
+            (self.fm.acquisition_progress_signal, self._on_progress),
+            (self.microscope.stage_position_changed, self._on_stage_signal),
+        ):
+            try:
+                signal.disconnect(slot)
+            except (TypeError, RuntimeError, ValueError, KeyError):
+                pass
         super().closeEvent(event)

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -406,13 +406,28 @@ class FMOverviewWidget(QWidget):
         self.tile_grid_panel.set_summary(summary)
 
     def _target_offset(self) -> Optional[Tuple[float, float]]:
-        """How far the target sits from the stage, in metres, or None if not set."""
+        """How far the target sits from the stage, in metres, or None if not set.
+
+        Measured in the displayed plane, not by subtracting stage axes. Everything on
+        this canvas is drawn in that plane, so a readout in stage coordinates describes
+        the same gap in a frame the user cannot see: on a compustage at t = -180 it
+        reports the y offset with the sign reversed, and on a pre-tilted mount it hides
+        the z entirely -- a 100 µm step down the screen carried 70 µm of z and the
+        readout said nothing.
+        """
         if self._target is None:
             return None
+        frame = self._frame()
         position = self._current_stage_position()
-        if position is None:
+        if frame is None or position is None:
             return None
-        return (self._target.x - position.x, self._target.y - position.y)
+        try:
+            here = frame.offset(position)
+            there = frame.offset(self._target)
+        except Exception as e:
+            logging.debug(f"Could not measure the target offset: {e}")
+            return None
+        return (there[0] - here[0], there[1] - here[1])
 
     def _refresh_tile_grid(self) -> None:
         """Redraw the planned grid on the canvas.

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -25,6 +25,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from fibsem import constants
 from fibsem.fm.acquisition import FMTiledAcquisitionRunner, stitch_tileset
 from fibsem.fm.structures import (
     AutoFocusMode,
@@ -34,8 +35,8 @@ from fibsem.fm.structures import (
     OverviewParameters,
 )
 from fibsem.microscope import FibsemMicroscope
-from fibsem.structures import FibsemStagePosition
-from fibsem.ui import stylesheets
+from fibsem.structures import FibsemStagePosition, Point
+from fibsem.ui import notification_service, stylesheets
 from fibsem.ui.fm.widgets.fm_multi_channel_widget import FluorescenceMultiChannelWidget
 from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     FMOverviewConfirmationDialog,
@@ -43,7 +44,7 @@ from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
 from fibsem.ui.fm.widgets.tile_grid_options_panel import TileGridOptionsPanel
 from fibsem.ui.qt.threading import FunctionWorker
-from fibsem.fm.reprojection import project_stage_position
+from fibsem.fm.reprojection import project_image_point, project_stage_position
 from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
 from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
     MinimapShapesOverlay,
@@ -101,6 +102,10 @@ SAVED_POSITION_COLOUR = "#26c6da"
 # than something anyone marked -- and they would otherwise read as saved positions.
 SLOT_COLOUR = "#90a4ae"
 
+# Wide enough for millimetre-scale coordinates without the row re-laying out as the
+# cursor moves -- a readout that shoves the buttons sideways is worse than none.
+CURSOR_READOUT_WIDTH = 210
+
 
 class FMOverviewWidget(QWidget):
     """Configure, run and view a fluorescence overview acquisition."""
@@ -143,6 +148,15 @@ class FMOverviewWidget(QWidget):
         self._positions: List[FibsemStagePosition] = []
         self._grid_footprint: Optional[tuple] = None
         self._enabled_channels: Optional[List[ChannelSettings]] = None
+        # Where the stage is, as far as anyone has told us. Cached rather than polled
+        # per use so that everything drawn from it -- the marker, the planned grid --
+        # agrees by construction instead of because two callers happened to poll
+        # together. See `_current_stage_position` for why polling is the odd one out.
+        self._stage_position: Optional[FibsemStagePosition] = None
+        # Where the next overview will be centred, once a user has dragged the grid
+        # somewhere. None means "wherever the stage is", which is what the runner does
+        # by default -- so an untouched grid describes exactly what would be acquired.
+        self._target: Optional[FibsemStagePosition] = None
 
         self._init_ui(channel_settings or self._default_channels())
         self._sync_tile_fov()
@@ -150,7 +164,7 @@ class FMOverviewWidget(QWidget):
 
         self._progress_received.connect(self._apply_progress)
         self.fm.acquisition_progress_signal.connect(self._on_progress)
-        self._stage_moved.connect(lambda _: self._refresh_current_position())
+        self._stage_moved.connect(self._on_stage_moved)
         self.microscope.stage_position_changed.connect(self._stage_moved.emit)
         self._refresh_current_position()
 
@@ -193,6 +207,7 @@ class FMOverviewWidget(QWidget):
         self.tile_grid_panel.fill_alpha_changed.connect(
             self.tile_grid_overlay.set_fill_alpha
         )
+        self.tile_grid_panel.centre_requested.connect(self.clear_target)
 
         # Stage positions -- the current pose, lamellae, anything a host hands over --
         # projected onto whatever image is displayed. Non-interactive: this shows where
@@ -262,6 +277,18 @@ class FMOverviewWidget(QWidget):
         self.status = QLabel("")
         self.status.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px;")
 
+        # Where a double-click would take the stage, read off continuously rather than
+        # on demand: the canvas is a map, and a map you have to click to get a
+        # coordinate out of cannot be used to decide whether to click.
+        self.cursor_readout = QLabel("")
+        self.cursor_readout.setFixedWidth(CURSOR_READOUT_WIDTH)
+        self.cursor_readout.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        # Monospaced so the digits sit still while the cursor moves. A proportional
+        # font makes the whole readout shuffle on every pixel of travel.
+        self.cursor_readout.setStyleSheet(
+            f"color: {TEXT_MUTED}; font-size: 11px; font-family: monospace;"
+        )
+
         self.button_acquire = QPushButton("Acquire Overview")
         self.button_acquire.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
         self.button_acquire.setMinimumHeight(30)
@@ -289,6 +316,7 @@ class FMOverviewWidget(QWidget):
         status_layout.setContentsMargins(8, 4, 8, 8)
         status_layout.setSpacing(10)
         status_layout.addWidget(self.status, stretch=1)
+        status_layout.addWidget(self.cursor_readout)
         status_layout.addWidget(bars)
         status_layout.addWidget(self.button_cancel)
         status_layout.addWidget(self.button_acquire)
@@ -304,6 +332,9 @@ class FMOverviewWidget(QWidget):
         self.settings_widget.changed.connect(self._on_settings_changed)
         self.tile_grid_overlay.tile_toggled.connect(self._on_tile_toggled)
         self.tile_grid_overlay.grid_resize_requested.connect(self._on_grid_resize)
+        self.tile_grid_overlay.grid_move_requested.connect(self._on_grid_move)
+        self.canvas.canvas.canvas_double_clicked.connect(self._on_canvas_double_clicked)
+        self.canvas.canvas.cursor_moved.connect(self._on_cursor_moved)
 
     def _section(self, title: str, widget: QWidget) -> QWidget:
         return TitledPanel(title, content=widget)
@@ -363,7 +394,25 @@ class FMOverviewWidget(QWidget):
         fov = self.settings_widget.label_total_fov.text()
         if fov and fov != "—":
             summary = f"{summary}\n{fov}"
+        # Said in words as well as drawn, because a grid sitting away from the stage
+        # marker is only obvious while both are on screen -- zoom into the grid and
+        # the one thing that would tell you it is offset scrolls out of view.
+        offset = self._target_offset()
+        if offset is not None:
+            summary = (
+                f"{summary}\nOffset {offset[0] * constants.SI_TO_MICRO:+.0f}, "
+                f"{offset[1] * constants.SI_TO_MICRO:+.0f} µm from the stage"
+            )
         self.tile_grid_panel.set_summary(summary)
+
+    def _target_offset(self) -> Optional[Tuple[float, float]]:
+        """How far the target sits from the stage, in metres, or None if not set."""
+        if self._target is None:
+            return None
+        position = self._current_stage_position()
+        if position is None:
+            return None
+        return (self._target.x - position.x, self._target.y - position.y)
 
     def _refresh_tile_grid(self) -> None:
         """Redraw the planned grid on the canvas.
@@ -401,9 +450,11 @@ class FMOverviewWidget(QWidget):
         # to be drawn in rather than arbitrary units. No-op once an image has landed --
         # by then the image has set it, and changing it would move what is already drawn.
         self.canvas.canvas.set_reference_pixel_size(pixel_size)
-        # Centred on the origin: the tileset is planned around a stage position, not
-        # around whatever happens to be displayed.
-        self.tile_grid_overlay.set_anchor(self.canvas.canvas.metres_to_canvas(0.0, 0.0))
+        # Centred on the position the run will be centred on -- a dragged target, or
+        # the stage itself -- not on whatever happens to be displayed. It used to be
+        # pinned to the canvas origin, which is where the stage was the *first* time
+        # anything was drawn: correct until the stage moved, and then quietly not.
+        self.tile_grid_overlay.set_anchor(self._grid_anchor())
 
         # No `display_pixel_size`: the overlay reads it from the canvas at draw time.
         # Pinning it here would freeze the scale at whatever was displayed when the
@@ -516,6 +567,24 @@ class FMOverviewWidget(QWidget):
             logging.debug(f"Could not place the image in stage space: {e}")
             return (0.0, 0.0)
 
+    def _offset_from_origin(
+        self, position: FibsemStagePosition
+    ) -> Tuple[float, float]:
+        """Where a stage position sits relative to the canvas origin, in metres.
+
+        The live-position counterpart of :meth:`_offset_of`, which answers the same
+        question for an image out of its own metadata -- and has to, since an image may
+        have been acquired under a configuration the instrument is no longer in.
+        """
+        project = self._stage_to_canvas()
+        if project is None:
+            return (0.0, 0.0)
+        try:
+            return self.canvas.canvas.canvas_to_metres(*project(position))
+        except Exception as e:
+            logging.debug(f"Could not place {position} in the canvas frame: {e}")
+            return (0.0, 0.0)
+
     def set_positions(self, positions: List[FibsemStagePosition]) -> None:
         """Stage positions to mark on the overview, e.g. saved lamella positions.
 
@@ -576,6 +645,36 @@ class FMOverviewWidget(QWidget):
             )
 
         return project
+
+    def _canvas_to_stage(self):
+        """A function mapping canvas coordinates to a stage position, or None.
+
+        The inverse of :meth:`_stage_to_canvas`, and deliberately its mirror image:
+        same origin, same live geometry, same scale. `project_image_point` is the exact
+        inverse of the `project_stage_position` used to draw, sharing its sign terms,
+        so a click on a marker resolves to the position that marker was drawn from
+        rather than to somewhere plausibly near it.
+        """
+        geometry, pixel_size, shape = self._live_geometry()
+        if geometry is None or not pixel_size:
+            return None
+
+        origin = self._origin or self._current_stage_position()
+        if origin is None:
+            return None
+        self._origin = origin
+
+        def unproject(x: float, y: float) -> FibsemStagePosition:
+            # Canvas -> metres from the origin -> pixels of a hypothetical image
+            # acquired there, which is the frame `project_image_point` inverts from.
+            offset_x, offset_y = self.canvas.canvas.canvas_to_metres(x, y)
+            point = Point(
+                x=shape[1] / 2 + offset_x / pixel_size,
+                y=shape[0] / 2 + offset_y / pixel_size,
+            )
+            return project_image_point(point, origin, pixel_size, shape, geometry)
+
+        return unproject
 
     def _refresh_stage_metadata(self) -> None:
         """Draw where the sample and the stage can physically go.
@@ -670,11 +769,46 @@ class FMOverviewWidget(QWidget):
             return None, None, None
 
     def _current_stage_position(self) -> Optional[FibsemStagePosition]:
-        try:
-            return self.microscope.get_stage_position()
-        except Exception as e:
-            logging.debug(f"Could not read the stage position: {e}")
-            return None
+        """Where the stage is, polling the microscope only when nothing has said yet.
+
+        `stage_position_changed` fires from *inside* `get_stage_position`, so it means
+        "a poll found it had moved" rather than "the stage moved". Polling here on
+        every use would therefore add a round trip per keystroke on a spin box without
+        making the answer any fresher than the last poll anyone did -- so this reads
+        what the signal delivered, and everything drawn from the stage position stays
+        in agreement instead of drifting between callers who polled at different
+        moments.
+        """
+        if self._stage_position is None:
+            try:
+                self._stage_position = self.microscope.get_stage_position()
+            except Exception as e:
+                logging.debug(f"Could not read the stage position: {e}")
+        return self._stage_position
+
+    def _grid_centre(self) -> Optional[FibsemStagePosition]:
+        """The stage position the next overview will be centred on.
+
+        A target if one has been set by dragging the grid, otherwise wherever the
+        stage is -- which is what the runner falls back to, so the drawn grid and the
+        acquisition agree without either having to be told about the other.
+        """
+        return self._target or self._current_stage_position()
+
+    def _grid_anchor(self) -> Tuple[float, float]:
+        """Where on the canvas the planned grid is centred.
+
+        Falls back to the canvas origin when the centre cannot be projected, which
+        draws the grid in the middle of the frame rather than not at all.
+        """
+        project = self._stage_to_canvas()
+        centre = self._grid_centre()
+        if project is not None and centre is not None:
+            try:
+                return project(centre)
+            except Exception as e:
+                logging.debug(f"Could not place the planned grid: {e}")
+        return self.canvas.canvas.metres_to_canvas(0.0, 0.0)
 
     def _canvas_length(self, metres: float) -> float:
         """A length in metres as a length in canvas pixels."""
@@ -698,6 +832,135 @@ class FMOverviewWidget(QWidget):
             labels.append(position.name or "")
 
         self.position_overlay.set_points(points, labels=labels)
+
+    # ── canvas interaction ───────────────────────────────────────────────
+
+    def _on_stage_moved(self, position: FibsemStagePosition) -> None:
+        """A poll found the stage somewhere new.
+
+        The position comes from the signal rather than a fresh read: it is the value
+        the poll that raised the signal saw, so taking it costs nothing and cannot
+        disagree with what prompted the update.
+        """
+        self._stage_position = position
+        self._refresh_current_position()
+        # The grid follows the stage only when it is not pinned to a target and not
+        # mid-run. During a run the stage visits every tile in turn, and a grid that
+        # followed would crawl across the canvas describing nothing.
+        if self._target is None and not self.is_acquiring:
+            self._refresh_tile_grid()
+
+    def _on_canvas_double_clicked(self, x: float, y: float, modifiers=None) -> None:
+        """Move the stage to the double-clicked point.
+
+        Double-click rather than a single click, matching the minimap and the
+        coincidence viewer: a single click is how the canvas is explored, and a stage
+        that moved on every stray click would be unusable.
+        """
+        if self.is_acquiring:
+            notification_service.show_toast(
+                "Cannot move the stage during an acquisition.", "warning"
+            )
+            return
+        if not self.fm.has_valid_orientation():
+            notification_service.show_toast(
+                f"Stage must be in a valid FM orientation to move via the overview "
+                f"(currently {self.microscope.get_stage_orientation()}).",
+                "warning",
+            )
+            return
+
+        unproject = self._canvas_to_stage()
+        if unproject is None:
+            return
+        try:
+            target = unproject(x, y)
+        except Exception as e:
+            logging.debug(f"Could not resolve the clicked position: {e}")
+            return
+
+        limits = getattr(self.microscope._stage, "limits", None)
+        if limits and not target.is_within_limits(limits, axes=["x", "y"]):
+            notification_service.show_toast(
+                "That position is outside the stage limits.", "warning"
+            )
+            return
+
+        self.status.setText(f"Moving to {self._describe(target)}…")
+        worker = FunctionWorker(self._move_worker, target)
+        worker.start()
+
+    def _move_worker(self, target: FibsemStagePosition) -> None:
+        """Runs off the GUI thread. Only signals may cross back."""
+        try:
+            self.microscope.safe_absolute_stage_movement(target)
+        except Exception as e:
+            logging.error(f"Could not move the stage: {e}", exc_info=True)
+        # Publishes the new position through `stage_position_changed`, which is what
+        # re-marks it -- rather than assuming the stage arrived exactly where it was
+        # asked to, which on a real instrument it does not.
+        try:
+            self.microscope.get_stage_position()
+        except Exception as e:
+            logging.debug(f"Could not confirm the stage position after moving: {e}")
+
+    def _on_grid_move(self, x: float, y: float) -> None:
+        """The grid was dragged: plan the next overview around the point it landed on.
+
+        Deliberately does *not* move the stage. Setting up a run and driving the
+        instrument are separate acts, and a drag is exploratory -- you push the grid
+        around to see what it would cover. The stage goes there when the acquisition
+        does.
+        """
+        unproject = self._canvas_to_stage()
+        if unproject is None:
+            return
+        try:
+            self._target = unproject(x, y)
+        except Exception as e:
+            logging.debug(f"Could not resolve the dragged grid position: {e}")
+            return
+        self.tile_grid_panel.set_centre_enabled(True)
+        self._refresh_tile_grid()
+        self._update_grid_summary()
+
+    def clear_target(self) -> None:
+        """Plan the next overview around the stage position again."""
+        if self._target is None:
+            return
+        self._target = None
+        self.tile_grid_panel.set_centre_enabled(False)
+        self._refresh_tile_grid()
+        self._update_grid_summary()
+
+    def _on_cursor_moved(self, x: Optional[float], y: Optional[float]) -> None:
+        """Report the stage position under the cursor, or blank once it leaves."""
+        if x is None or y is None:
+            self.cursor_readout.setText("")
+            return
+        unproject = self._canvas_to_stage()
+        if unproject is None:
+            self.cursor_readout.setText("")
+            return
+        try:
+            self.cursor_readout.setText(self._describe(unproject(x, y)))
+        except Exception as e:
+            logging.debug(f"Could not resolve the cursor position: {e}")
+            self.cursor_readout.setText("")
+
+    @staticmethod
+    def _describe(position: FibsemStagePosition) -> str:
+        """A stage position as microns, for a readout.
+
+        z included because it is not decoration: on an offset mount a sideways move in
+        the image carries a real z component, and a readout that hid it would make the
+        focal-plane change invisible.
+        """
+        return (
+            f"x {position.x * constants.SI_TO_MICRO:.1f}  "
+            f"y {position.y * constants.SI_TO_MICRO:.1f}  "
+            f"z {position.z * constants.SI_TO_MICRO:.1f} µm"
+        )
 
     def _on_grid_resize(self, rows: int, cols: int) -> None:
         """An edge of the grid was dragged.
@@ -788,6 +1051,10 @@ class FMOverviewWidget(QWidget):
             zparams=zparams,
             autofocus_settings=autofocus_settings,
             stop_event=self._stop_event,
+            # None means "where the stage is", which the runner resolves itself. The
+            # stage still returns to where it started afterwards -- the target is the
+            # grid's centre, not a new home.
+            centre_position=self._target,
         )
         self._worker = FunctionWorker(self._acquire_worker)
         self._worker.start()
@@ -802,7 +1069,7 @@ class FMOverviewWidget(QWidget):
             mosaic = stitch_tileset(
                 runner.tileset,
                 runner.overview_parameters.overlap,
-                centre_position=runner._initial_position,
+                centre_position=runner.centre_position,
                 objective_position=runner._initial_objective_position,
             )
             self._mosaic = mosaic
@@ -952,9 +1219,14 @@ class FMOverviewWidget(QWidget):
             # Its own key, so the in-progress preview neither replaces a finished
             # overview nor survives as one: it is swapped for the real stitch at the end.
             self.canvas.set_composite_key(PREVIEW_KEY)
-            # The preview mosaic spans the whole planned grid, which is centred on the
-            # position the run started from -- the canvas origin.
-            self.canvas.set_placement((0.0, 0.0))
+            # The preview mosaic spans the whole planned grid, so it goes wherever the
+            # grid's centre is. Read off the runner rather than recomputed: the runner
+            # resolved "wherever the stage is" to a concrete position when it started,
+            # and the stage has been moving from tile to tile ever since.
+            centre = getattr(self._runner, "centre_position", None)
+            self.canvas.set_placement(
+                self._offset_from_origin(centre) if centre is not None else (0.0, 0.0)
+            )
             # The preview is decimated to keep it a sane size, so its pixels are
             # `preview_stride` times coarser than a tile's. Placement is by pixel size,
             # so saying so is all that is needed: coarser pixels over the same count

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -637,6 +637,39 @@ class FMOverviewWidget(QWidget):
         self._positions = list(positions)
         self._refresh_positions()
 
+    def set_origin(self, position: Optional[FibsemStagePosition]) -> None:
+        """Anchor the canvas frame at *position*, or None to go back to automatic.
+
+        The origin decides only where canvas zero sits -- everything is drawn relative
+        to it, so any stage position serves. Left alone it is fixed to wherever the
+        stage was the first time anything was drawn, which is right for a widget opened
+        where the work is and wrong for one that should always describe the same place:
+        an FM canvas anchored at the offset mount while a FIB/SEM canvas is anchored at
+        the column, 48 mm away, each correctly framed (FIB-418).
+
+        Raises:
+            ValueError: if anything has been placed. Images are positioned relative to
+                the origin as it stood when they were added, so re-anchoring afterwards
+                would leave every one of them describing a position it was never
+                acquired at. Clear them first if that is really what you want --
+                silently reprojecting them would be a different feature.
+        """
+        placed = self.canvas.placed_overviews()
+        if placed:
+            raise ValueError(
+                f"Cannot re-anchor the canvas: {len(placed)} image(s) are already "
+                f"placed against the current origin. Call clear_overviews() first."
+            )
+        self._origin = position
+        self._refresh_current_position()
+        self._refresh_positions()
+        self._refresh_tile_grid()
+
+    @property
+    def origin(self) -> Optional[FibsemStagePosition]:
+        """The stage position canvas zero corresponds to, once one has been fixed."""
+        return self._origin
+
     def _frame(self) -> Optional[StageFrame]:
         """The mapping between stage space and the canvas, or None if it cannot be had.
 

--- a/fibsem/ui/fm/widgets/tile_grid_options_panel.py
+++ b/fibsem/ui/fm/widgets/tile_grid_options_panel.py
@@ -5,9 +5,11 @@ positioned under it. A separate top-level window rather than a child widget, for
 same reason -- native controls parented into the matplotlib canvas are forced to
 repaint on every canvas redraw.
 
-The settings here are all about *seeing* the grid, not about what will be acquired.
-Nothing in this panel changes the acquisition; the tile selection lives in
-`TileMaskWidget` and on the canvas itself.
+The settings here are about *seeing* the grid -- what is acquired is decided in the
+settings column and on the canvas itself, where the tile selection lives. The one
+exception is "Centre on stage", which undoes a drag of the grid: it is here because
+this is where you come to ask what the grid currently describes, and the summary
+directly above it is what tells you the grid is off-centre in the first place.
 """
 
 from __future__ import annotations
@@ -22,6 +24,7 @@ from PyQt5.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QLabel,
+    QPushButton,
     QSlider,
     QVBoxLayout,
     QWidget,
@@ -52,15 +55,22 @@ QLabel { color: #d6d6d6; font-size: 11px; background: transparent; }
 QLabel#panelTitle { color: #9aa0a6; font-size: 10px; font-weight: 600; letter-spacing: 1px; }
 QCheckBox { color: #d6d6d6; font-size: 11px; background: transparent; }
 QLabel#gridSummary { color: #868e93; font-size: 10px; background: transparent; }
+QPushButton#centreButton {
+    background: #2a2d38; color: #d6d6d6; font-size: 11px;
+    border: 1px solid #3d4251; border-radius: 4px; padding: 4px 8px;
+}
+QPushButton#centreButton:hover:enabled { background: #333744; }
+QPushButton#centreButton:disabled { color: #5c6169; border-color: #2e323d; }
 """
 
 
 class TileGridOptionsPanel(QFrame):
-    """Show/hide, colour and fill opacity for the tile grid overlay."""
+    """Show/hide, colour and fill opacity for the tile grid overlay, and re-centre it."""
 
     visibility_changed = pyqtSignal(bool)
     color_changed = pyqtSignal(str)
     fill_alpha_changed = pyqtSignal(float)
+    centre_requested = pyqtSignal()
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
@@ -93,6 +103,16 @@ class TileGridOptionsPanel(QFrame):
         self.label_summary.setWordWrap(True)
         root.addWidget(self.label_summary)
 
+        # The way back from dragging the grid. Directly under the summary, which is
+        # what reports the offset -- disabled until there is an offset to undo, so it
+        # neither invites a click that does nothing nor strands the state a drag set.
+        self.button_centre = QPushButton("Centre on stage")
+        self.button_centre.setObjectName("centreButton")
+        self.button_centre.setToolTip("Plan the overview around the stage position again")
+        self.button_centre.setEnabled(False)
+        self.button_centre.clicked.connect(self.centre_requested)
+        root.addWidget(self.button_centre)
+
         self.check_visible = QCheckBox("Show grid")
         self.check_visible.setChecked(True)
         self.check_visible.toggled.connect(self.visibility_changed)
@@ -121,6 +141,10 @@ class TileGridOptionsPanel(QFrame):
     def set_summary(self, text: str) -> None:
         """What the grid currently describes, e.g. `3 x 3 - 10% overlap - 9/9 tiles`."""
         self.label_summary.setText(text)
+
+    def set_centre_enabled(self, enabled: bool) -> None:
+        """Whether the grid is off the stage position, and so worth re-centring."""
+        self.button_centre.setEnabled(bool(enabled))
 
     def set_color(self, color: str) -> None:
         """Reflect the current colour without emitting -- for syncing from the overlay."""

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -100,6 +100,11 @@ EMPTY_CONTENT = ContentRect(0.0, 0.0, 0.0, 0.0)
 _LIVE_BADGE_BG = "#2e7d32"  # dark green behind the white "● LIVE" badge
 _MAX_DISPLAY_PX = 2048
 _ZOOM_FACTOR = 1.15
+# How far the view may travel from the content, as a multiple of its longest side.
+# Out: enough to see a mosaic in the context around it, not enough to lose it. In:
+# enough to inspect single pixels, not enough to land between them.
+MAX_ZOOM_OUT = 20.0
+MAX_ZOOM_IN = 200.0
 _REDRAW_INTERVAL = 32  # ms (~60 fps)
 
 _OVERLAY_BTN_STYLE = (
@@ -1040,6 +1045,25 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         cx, cy = event.xdata, event.ydata
         xlim = self._ax.get_xlim()
         ylim = self._ax.get_ylim()
+        if not self._zoom_allowed(abs(xlim[1] - xlim[0]) * factor):
+            return
         self._ax.set_xlim(cx + (xlim[0] - cx) * factor, cx + (xlim[1] - cx) * factor)
         self._ax.set_ylim(cy + (ylim[0] - cy) * factor, cy + (ylim[1] - cy) * factor)
         self._schedule_redraw()
+
+    def _zoom_allowed(self, span: float) -> bool:
+        """Whether the view may show *span* data units across.
+
+        Bounded relative to the content, because unbounded scrolling ends up somewhere
+        useless in one direction and degenerate in the other: far enough out and the
+        content is a speck in an empty field with no way to tell which way to go back;
+        far enough in and you are looking between two pixels. Both are easy to reach by
+        accident on a trackpad, and neither is recoverable except through "reset view".
+        """
+        extent = self._content_extent()
+        if extent is None:
+            return True  # nothing to be relative to
+        content = max(abs(extent[1] - extent[0]), abs(extent[2] - extent[3]))
+        if content <= 0:
+            return True
+        return content / MAX_ZOOM_IN <= span <= content * MAX_ZOOM_OUT

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -177,6 +177,10 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
     canvas_double_clicked = pyqtSignal(float, float, object)  # left double-click (x, y) px, mods
     canvas_right_clicked = pyqtSignal(float, float, object)  # right single-click (x, y) px, mods
     canvas_scrolled = pyqtSignal(float, float, int, object)  # (x, y) px, dir +1/-1, mods
+    # Where the cursor is, in canvas coordinates, or (None, None) once it leaves the
+    # axes -- so a readout can blank rather than freeze on the last point it saw.
+    # Typed `object` for exactly that: pyqtSignal(float, float) cannot carry None.
+    cursor_moved = pyqtSignal(object, object)
 
     def __init__(self, parent=None):
         self._fig = Figure(facecolor=_BG)
@@ -259,6 +263,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self.mpl_connect("button_release_event", self._on_release)
         self.mpl_connect("scroll_event", self._on_scroll)
         self.mpl_connect("resize_event", lambda _: self.draw_idle())
+        # A motion event with `inaxes` unset covers most exits, but a fast flick off
+        # the widget can skip one and leave a readout showing a stale point.
+        self.mpl_connect("figure_leave_event", lambda _: self.cursor_moved.emit(None, None))
 
         # Overlay buttons (parented to self; repositioned in resizeEvent)
         self._overlay_buttons: List[QPushButton] = []
@@ -999,6 +1006,12 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         )
 
     def _on_motion(self, event):
+        # Before every early return below: a readout of where the cursor is should not
+        # go quiet because a pan happens to be in progress or an overlay owns the drag.
+        if event.inaxes is self._ax and event.xdata is not None:
+            self.cursor_moved.emit(event.xdata, event.ydata)
+        else:
+            self.cursor_moved.emit(None, None)
         # Overlay in drag mode — cancel any pending pan
         if self._overlay_consuming_event:
             self._pan_start = None

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -12,7 +12,7 @@ are Phase 6b.
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 from PyQt5.QtCore import Qt, QPoint, QSize, pyqtSignal
@@ -256,6 +256,48 @@ class FMCanvasWidget(QWidget):
             self._panel.set_layers(self._layers)
         return layer
 
+    def retain_channels(self, names: Sequence[str]) -> None:
+        """Drop the layers for channels no longer being displayed.
+
+        `_upsert_layer` only ever adds, which is right for the live path: channels
+        arrive one frame at a time and each is a partial update. But a caller showing a
+        whole *image* names every channel it has, and one that is absent has to go --
+        otherwise its layer stays behind still holding the previous image's pixels, and
+        those get blended into the new one. Acquiring a two-channel overview and then a
+        one-channel overview drew the second with the first's second channel, which was
+        then recorded as the second's own, so every later contrast change faithfully
+        redrew the ghost.
+        """
+        keep = set(names)
+        if all(layer.name in keep for layer in self._layers):
+            return
+
+        survivors = []
+        for layer in self._layers:
+            if layer.name in keep:
+                survivors.append(layer)
+                continue
+            self._stacks.pop(layer.name, None)
+            self._mip_clim.pop(layer.name, None)
+            if self._channel_still_shown(layer.name):
+                # Something else on the canvas still has this channel, so its control
+                # has to stay for that image to be styled through. Only the pixels go.
+                layer.data = None
+                layer._clim_cache = None
+                survivors.append(layer)
+
+        self._layers = survivors
+        self._panel.set_layers(self._layers)
+
+    def _channel_still_shown(self, name: str) -> bool:
+        """Whether a channel absent from the current image is displayed anywhere else.
+
+        False here: this canvas shows one image at a time, so a channel it does not
+        have is a channel nothing has. Overridden where several images share the
+        controls.
+        """
+        return False
+
     def set_channel(self, name: str, data: np.ndarray, color: Optional[str] = None) -> None:
         """Upsert a channel's 2-D image (live path — no z-stack); display props preserved."""
         had_stack = self._stacks.pop(name, None) is not None
@@ -290,6 +332,8 @@ class FMCanvasWidget(QWidget):
                 stack = np.asarray(data)[None]
             self._stacks[channel.name] = stack
             self._upsert_layer(channel.name, stack.max(axis=0), channel.color)
+        # After the upserts, so the panel is rebuilt once and from the final set.
+        self.retain_channels([channel.name for channel in md.channels])
         self._refresh_z_controls()
         self._apply_z_mode()
 
@@ -491,6 +535,17 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
 
     def _make_canvas(self) -> FibsemCanvasBase:
         return FibsemRealSpaceCanvas()
+
+    def _channel_still_shown(self, name: str) -> bool:
+        """True while any placed image has this channel.
+
+        Several images share one set of controls here, so a channel dropped from the
+        newest is not dropped from the canvas -- an earlier overview may well have it.
+        Removing the control would leave that overview with a channel nothing can
+        style, and `_restyle_others` would quietly stop drawing it: acquire a
+        one-channel overview and the two-channel one beside it loses a colour.
+        """
+        return any(name in planes for planes in self._held.values())
 
     # ── placement ─────────────────────────────────────────────────────────
 

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -50,16 +50,25 @@ LINE_WIDTH = 0.8
 EDGE_GRAB_FRACTION = 0.08
 MAX_TILES_PER_AXIS = 100  # matches the row/column spin boxes
 
+# How far the pointer must travel before a press inside the grid counts as a move
+# rather than a click on a tile. In screen pixels, so the split does not shift with
+# the zoom, and the same 3 the canvas uses for its own click-versus-drag test -- one
+# threshold everywhere means a gesture cannot read as a click to one and a drag to
+# the other.
+MOVE_DRAG_THRESHOLD_PX = 3
+
 
 class TileGridOverlay(QObject, CanvasOverlay):
-    """The planned tile grid, with click-to-toggle.
+    """The planned tile grid, with click-to-toggle, edge-to-resize and drag-to-move.
 
-    Emits :attr:`tile_toggled` rather than mutating anything: the mask belongs to the
-    settings widget, and two widgets writing the same state is how they drift apart.
+    Emits rather than mutating: rows, columns, the mask and the position the grid is
+    planned around all belong to the settings widget, and two widgets writing the same
+    state is how they drift apart.
     """
 
     tile_toggled = pyqtSignal(int, int, bool)      # row, col, enabled
     grid_resize_requested = pyqtSignal(int, int)   # rows, cols
+    grid_move_requested = pyqtSignal(float, float)  # new centre, canvas coordinates
 
     def __init__(self, parent: Optional[QObject] = None) -> None:
         QObject.__init__(self, parent)
@@ -81,13 +90,21 @@ class TileGridOverlay(QObject, CanvasOverlay):
         self._cids: List[int] = []
         self._resize_axes: Optional[Tuple[bool, bool]] = None  # (horizontal, vertical)
         self._cursor_set: bool = False
+        # A press inside the grid, held until it resolves into a move or a tile click:
+        # (press_px_x, press_px_y, press_x, press_y, anchor_x, anchor_y). The screen
+        # coordinates drive the threshold, the data coordinates the displacement.
+        self._move_start: Optional[Tuple[float, float, float, float, float, float]] = None
+        self._move_active: bool = False
 
     # ── lifecycle ────────────────────────────────────────────────────────
 
     def attach(self, ax, canvas: "FibsemImageCanvas") -> None:
         self._ax = ax
         self._canvas = canvas
-        canvas.canvas_clicked.connect(self._on_canvas_clicked)
+        # Raw press/motion/release rather than the canvas's `canvas_clicked`: a press
+        # inside the grid can turn into either a tile toggle or a move of the whole
+        # grid, and only the pointer's subsequent travel says which -- a signal that
+        # has already decided it was a click arrives too late to tell them apart.
         self._cids = [
             canvas.mpl_connect("button_press_event", self._on_press),
             canvas.mpl_connect("motion_notify_event", self._on_drag),
@@ -96,10 +113,6 @@ class TileGridOverlay(QObject, CanvasOverlay):
 
     def detach(self) -> None:
         if self._canvas is not None:
-            try:
-                self._canvas.canvas_clicked.disconnect(self._on_canvas_clicked)
-            except TypeError:
-                pass
             for cid in self._cids:
                 self._canvas.mpl_disconnect(cid)
             self._cids = []
@@ -265,23 +278,27 @@ class TileGridOverlay(QObject, CanvasOverlay):
         span_h = (max(t.canvas_y for t in self._tiles) + tile_h) * scale
         return span_w, span_h
 
+    def _bounds(self) -> Tuple[float, float, float, float]:
+        """(left, top, width, height) of the whole grid, in display pixels.
+
+        The grid is centred on the anchor, matching the runner: it measures from the
+        top-left tile and shifts so the grid straddles the position it is planned
+        around. Callers guard on `_anchor()`; the (0, 0) fallback keeps this total.
+        """
+        span_w, span_h = self._extent()
+        anchor = self._anchor()
+        cx, cy = anchor if anchor is not None else (0.0, 0.0)
+        return cx - span_w / 2, cy - span_h / 2, span_w, span_h
+
     def _rect_for(self, tile: TilePosition) -> Tuple[float, float, float, float]:
         """(x, y, width, height) of one tile, in display pixels."""
         tile_h, tile_w = self._tile_shape
         scale = self._scale()
-        span_w, span_h = self._extent()
-
-        # The grid is centred on the content centre, matching the runner: it measures
-        # from the top-left tile and shifts so the grid straddles the start position.
-        # Callers guard on _anchor(); the (0, 0) fallback keeps this total.
-        anchor = self._anchor()
-        cx, cy = anchor if anchor is not None else (0.0, 0.0)
-        origin_x = cx - span_w / 2
-        origin_y = cy - span_h / 2
+        left, top, _, _ = self._bounds()
 
         return (
-            origin_x + tile.canvas_x * scale,
-            origin_y + tile.canvas_y * scale,
+            left + tile.canvas_x * scale,
+            top + tile.canvas_y * scale,
             tile_w * scale,
             tile_h * scale,
         )
@@ -335,12 +352,6 @@ class TileGridOverlay(QObject, CanvasOverlay):
 
     # ── interaction ──────────────────────────────────────────────────────
 
-    def _on_canvas_clicked(self, x: float, y: float, modifiers) -> None:
-        tile = self._tile_at(x, y)
-        if tile is None:
-            return
-        self.tile_toggled.emit(tile.row, tile.col, not tile.enabled)
-
     def _tile_at(self, x: float, y: float) -> Optional[TilePosition]:
         """The tile under a point, or None.
 
@@ -367,13 +378,10 @@ class TileGridOverlay(QObject, CanvasOverlay):
         boolean because the hover cursor has to name a *corner* -- top-left and
         top-right want opposite diagonals -- and "on both axes" cannot distinguish them.
         """
-        anchor = self._anchor()
-        if not self._tiles or self._tile_shape[1] <= 0 or anchor is None:
+        if not self._tiles or self._tile_shape[1] <= 0 or self._anchor() is None:
             return 0, 0
 
-        span_w, span_h = self._extent()
-        left = anchor[0] - span_w / 2
-        top = anchor[1] - span_h / 2
+        left, top, span_w, span_h = self._bounds()
         # Proportional to a tile rather than a fixed pixel count, so the grab zone
         # stays usable at any zoom without querying the transform.
         tolerance = self._tile_shape[1] * self._scale() * EDGE_GRAB_FRACTION
@@ -426,17 +434,41 @@ class TileGridOverlay(QObject, CanvasOverlay):
     def _on_press(self, event) -> None:
         if event.button != 1 or event.inaxes is not self._ax or event.xdata is None:
             return
-        if not self._visible:
-            return
-        edges = self._edge_at(event.xdata, event.ydata)
-        if edges is None:
+        if not self._visible or not self._tiles:
             return
 
-        self._resize_axes = edges
+        edges = self._edge_at(event.xdata, event.ydata)
+        if edges is not None:
+            self._resize_axes = edges
+            self._claim(event)
+            return
+
+        anchor = self._anchor()
+        if anchor is None or not self._within(event.xdata, event.ydata):
+            # Outside the grid, so this press belongs to the canvas -- leave it to pan.
+            return
+        # Inside: held rather than acted on, because the same press starts both a move
+        # and a tile toggle and only the pointer's next few pixels say which.
+        self._move_start = (
+            event.x, event.y, event.xdata, event.ydata, anchor[0], anchor[1]
+        )
+        self._claim(event)
+
+    def _claim(self, event) -> None:
+        """Tell the canvas this overlay owns the gesture.
+
+        It cancels the pending pan and suppresses `canvas_clicked` on release, so a
+        drag inside the grid moves the grid rather than the view. The click that
+        suppression costs is re-emitted from `_on_release` when the press turns out to
+        have been a click after all.
+        """
         if self._canvas is not None:
-            # Tells the canvas an overlay owns this gesture: it cancels the pending pan
-            # and suppresses the click that would otherwise toggle a tile on release.
             self._canvas._overlay_consuming_event = True
+
+    def _within(self, x: float, y: float) -> bool:
+        """Whether a point is inside the grid's bounding box."""
+        left, top, width, height = self._bounds()
+        return left <= x <= left + width and top <= y <= top + height
 
     def _cursor_for(self, x_side: int, y_side: int):
         """The resize cursor naming what dragging here would do, or None."""
@@ -449,6 +481,16 @@ class TileGridOverlay(QObject, CanvasOverlay):
         if y_side:
             return Qt.SizeVerCursor
         return None
+
+    def _cursor_at(self, x: float, y: float):
+        """The cursor for a point over the grid, or None if it is over nothing.
+
+        Edges win over the interior, matching which gesture a press there starts.
+        """
+        cursor = self._cursor_for(*self._edge_sides(x, y))
+        if cursor is not None:
+            return cursor
+        return Qt.SizeAllCursor if self._within(x, y) else None
 
     def _update_cursor(self, event) -> None:
         """Show a resize cursor over the grid's edges.
@@ -467,7 +509,7 @@ class TileGridOverlay(QObject, CanvasOverlay):
             and event.inaxes is self._ax
             and event.xdata is not None
         ):
-            cursor = self._cursor_for(*self._edge_sides(event.xdata, event.ydata))
+            cursor = self._cursor_at(event.xdata, event.ydata)
 
         if cursor is not None:
             self._canvas.setCursor(cursor)
@@ -479,6 +521,9 @@ class TileGridOverlay(QObject, CanvasOverlay):
             self._cursor_set = False
 
     def _on_drag(self, event) -> None:
+        if self._move_start is not None:
+            self._drag_move(event)
+            return
         if self._resize_axes is None:
             self._update_cursor(event)
             return
@@ -510,8 +555,48 @@ class TileGridOverlay(QObject, CanvasOverlay):
 
         self.grid_resize_requested.emit(rows, cols)
 
+    def _drag_move(self, event) -> None:
+        """Follow the pointer with the whole grid, once it has clearly moved.
+
+        Emits an absolute centre rather than a delta, measured from where the anchor
+        was at press: the host re-anchors on every step, so accumulating deltas would
+        compound whatever it rounds the position to -- and it *does* round, because it
+        resolves the centre to a stage position and projects it back.
+        """
+        press_x, press_y, x0, y0, anchor_x, anchor_y = self._move_start
+        if event.inaxes is not self._ax or event.xdata is None or event.ydata is None:
+            return
+        if not self._move_active:
+            travelled = (event.x - press_x) ** 2 + (event.y - press_y) ** 2
+            if travelled < MOVE_DRAG_THRESHOLD_PX ** 2:
+                return
+            self._move_active = True
+
+        self.grid_move_requested.emit(
+            anchor_x + (event.xdata - x0), anchor_y + (event.ydata - y0)
+        )
+
     def _on_release(self, event) -> None:
+        # A press inside the grid that never became a drag is a click on a tile. It has
+        # to be emitted here because claiming the gesture suppressed the canvas's own
+        # click signal -- claiming is what stops the view panning out from under a move.
+        pressed_inside = self._move_start is not None
+        was_moving = self._move_active
+        self._move_start = None
+        self._move_active = False
         self._resize_axes = None
+
+        if (
+            pressed_inside
+            and not was_moving
+            and event.button == 1
+            and event.inaxes is self._ax
+            and event.xdata is not None
+        ):
+            tile = self._tile_at(event.xdata, event.ydata)
+            if tile is not None:
+                self.tile_toggled.emit(tile.row, tile.col, not tile.enabled)
+
         self._update_cursor(event)
 
     def _restore_margin(self) -> None:

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -42,6 +42,9 @@ _logger = logging.getLogger(__name__)
 
 _DEFAULT_BACKGROUND = "#000000"  # empty space reads as "nothing acquired here"
 _ORIGIN_MARKER_SIZE = 11  # points; fixed on screen, so zoom-independent
+# Red, matching the grid boundary this marks the centre of. The current stage
+# position is the yellow one -- the pair have to stay distinguishable.
+_ORIGIN_MARKER_COLOUR = "#ff5252"
 
 # Pixels kept per placed image. Every artist is redrawn in full on each pan/zoom, so a
 # redraw costs the *total* stored pixels — 100 tiles kept at 1024 px square take ~2.7 s,
@@ -476,7 +479,7 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         (marker,) = self._ax.plot(
             [0.0], [0.0],
             marker="+", markersize=_ORIGIN_MARKER_SIZE, markeredgewidth=1.0,
-            color="yellow", alpha=0.8, linestyle="None", zorder=7,
+            color=_ORIGIN_MARKER_COLOUR, alpha=0.8, linestyle="None", zorder=7,
         )
         self._crosshair_artists = [marker]
 

--- a/fibsem/ui/widgets/canvas/stage_frame.py
+++ b/fibsem/ui/widgets/canvas/stage_frame.py
@@ -1,0 +1,198 @@
+"""Stage space on a real-space canvas.
+
+The canvas draws in pixels around an origin; the instrument works in stage coordinates.
+Everything drawn from a stage position -- a marker, the travel limits, a planned
+acquisition grid -- needs the same mapping between the two, and every click needs its
+inverse. Left to the callers, that is five places agreeing to do the same arithmetic,
+and they agree right up until one of them is changed.
+
+:class:`StageFrame` is that mapping, composed from two halves neither of which is
+enough alone:
+
+* a :class:`StageProjection`, mapping stage coordinates into the displayed plane in
+  metres. This is the half that differs by modality -- a fluorescence camera projects
+  through its own axis tilt and image transform, a beam through scan rotation and a
+  column tilt -- so it is supplied rather than assumed.
+* the canvas's own scale, in metres per canvas pixel.
+
+The frame is anchored at an *origin*: the stage position it is built around. Whoever
+owns the frame fixes that once and keeps it, because re-deriving it from whatever
+arrived last would shift the whole scene each time something did.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Protocol, Tuple
+
+import numpy as np
+
+from fibsem.fm.reprojection import project_image_point, project_stage_position
+from fibsem.structures import FibsemStagePosition, Point
+
+if TYPE_CHECKING:  # pragma: no cover - annotation only
+    from fibsem.fm.structures import FMImageGeometry
+    from fibsem.microscope import FibsemMicroscope
+    from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
+
+
+class StageProjection(Protocol):
+    """Stage coordinates to the displayed plane and back, both in metres.
+
+    Metres rather than pixels on purpose. The underlying projections answer in pixels
+    of a hypothetical image, but pixels are a property of a detector, not of the
+    geometry, and a real-space canvas has its own scale -- so a projection that spoke
+    in pixels would have to be told which pixels, and the answer would cancel out
+    immediately afterwards.
+    """
+
+    def to_plane(
+        self, position: FibsemStagePosition, base: FibsemStagePosition
+    ) -> Tuple[float, float]:
+        """Where *position* falls relative to *base*, in metres in the displayed plane."""
+        ...
+
+    def from_plane(
+        self, dx: float, dy: float, base: FibsemStagePosition
+    ) -> FibsemStagePosition:
+        """The stage position a displayed-plane offset from *base* corresponds to."""
+        ...
+
+
+@dataclass(frozen=True)
+class FMStageProjection:
+    """The fluorescence projection: camera axis tilt, image transform, sample tilt.
+
+    `pixel_size` and `shape` are arguments to functions that measure in pixels, not
+    inputs to the geometry -- they cancel between the projection and the conversion
+    back to metres, verified identical across a 27,000x range of pixel sizes. They are
+    carried here so the two directions cannot be handed different ones.
+    """
+
+    geometry: "FMImageGeometry"
+    pixel_size: float
+    shape: Tuple[int, int]  # (height, width)
+
+    @classmethod
+    def from_microscope(
+        cls, microscope: "FibsemMicroscope"
+    ) -> Optional["FMStageProjection"]:
+        """Read the projection off the live instrument, or None if it cannot be read.
+
+        Live rather than from a displayed image, for two reasons. `FMImageGeometry` is
+        system configuration -- camera tilt, shuttle pre-tilt, the camera flip,
+        compustage or not -- and not pose; the pose enters through the frame's origin,
+        as its rotation and tilt. So a recorded geometry and the live one agree by
+        construction.
+
+        And, at present, an acquired tile has no geometry to read: the metadata
+        constructors that combine channels and z-planes rebuild it field by field, and
+        a stitched mosaic inherits the gap (FIB-416). Taking it from the displayed
+        image made everything drawn from a stage position vanish the moment an overview
+        was acquired.
+        """
+        if microscope.fm is None:
+            return None
+        try:
+            width, height = microscope.fm.camera.resolution
+            pixel_size = microscope.fm.camera.pixel_size[0]
+            if not pixel_size:
+                return None
+            return cls(
+                geometry=microscope.fm_image_geometry(),
+                pixel_size=pixel_size,
+                shape=(height, width),
+            )
+        except Exception as e:
+            logging.debug(f"Could not read the live FM geometry: {e}")
+            return None
+
+    @classmethod
+    def from_image(cls, image) -> Optional["FMStageProjection"]:
+        """Read the projection off an image's own metadata, or None if it has none.
+
+        For placing an image rather than drawing on top of one, and the reason the
+        projection is not simply always taken live: an image may have been acquired
+        under a configuration the instrument is no longer in -- a different camera
+        transform, or loaded from disk entirely -- and it has to be placed as it was
+        taken, not as things stand now.
+        """
+        metadata = getattr(image, "metadata", None)
+        geometry = getattr(metadata, "geometry", None)
+        pixel_size = getattr(metadata, "pixel_size_x", None)
+        if geometry is None or not pixel_size:
+            return None
+        shape = np.asarray(image.data).shape[-2:]
+        return cls(geometry=geometry, pixel_size=pixel_size, shape=shape)
+
+    def to_plane(
+        self, position: FibsemStagePosition, base: FibsemStagePosition
+    ) -> Tuple[float, float]:
+        point = project_stage_position(
+            position, base, self.pixel_size, self.shape, self.geometry
+        )
+        # `project_stage_position` answers in pixels measured from the corner; the
+        # frame wants metres measured from the centre.
+        return (
+            (point.x - self.shape[1] / 2) * self.pixel_size,
+            (point.y - self.shape[0] / 2) * self.pixel_size,
+        )
+
+    def from_plane(
+        self, dx: float, dy: float, base: FibsemStagePosition
+    ) -> FibsemStagePosition:
+        # `project_image_point` is the exact inverse of `project_stage_position`,
+        # sharing its sign terms, so a click on a marker resolves to the position that
+        # marker was drawn from rather than to somewhere plausibly near it.
+        point = Point(
+            x=self.shape[1] / 2 + dx / self.pixel_size,
+            y=self.shape[0] / 2 + dy / self.pixel_size,
+        )
+        return project_image_point(
+            point, base, self.pixel_size, self.shape, self.geometry
+        )
+
+
+class StageFrame:
+    """Stage positions and canvas coordinates, in both directions, about an origin.
+
+    Cheap to build and holds no state of its own, so a caller can make one per use
+    rather than keeping one in sync with a microscope that moves underneath it.
+    """
+
+    def __init__(
+        self,
+        canvas: "FibsemRealSpaceCanvas",
+        origin: FibsemStagePosition,
+        projection: StageProjection,
+    ) -> None:
+        self._canvas = canvas
+        self.origin = origin
+        self.projection = projection
+
+    def to_canvas(self, position: FibsemStagePosition) -> Tuple[float, float]:
+        """Where a stage position falls on the canvas."""
+        return self._canvas.metres_to_canvas(*self.offset(position))
+
+    def to_stage(self, x: float, y: float) -> FibsemStagePosition:
+        """The stage position under a canvas point."""
+        return self.projection.from_plane(
+            *self._canvas.canvas_to_metres(x, y), self.origin
+        )
+
+    def offset(self, position: FibsemStagePosition) -> Tuple[float, float]:
+        """Where a stage position sits relative to the origin, in metres.
+
+        The placement a canvas wants for an image acquired there, as distinct from the
+        canvas coordinates :meth:`to_canvas` gives for drawing on top of one.
+        """
+        return self.projection.to_plane(position, self.origin)
+
+    def length(self, metres: float) -> float:
+        """A length in metres as a length in canvas pixels.
+
+        Through the canvas rather than divided by its pixel size directly, so a
+        measured length and a placed position cannot end up on different scales.
+        """
+        return self._canvas.metres_to_canvas(metres, 0.0)[0]

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -8,6 +8,7 @@ from fibsem import utils
 from fibsem.cancellation import OperationCancelledError
 from fibsem.fm import acquisition
 from fibsem.fm.acquisition import (
+    FMTiledAcquisitionRunner,
     acquire_and_stitch_tileset,
     acquire_at_positions,
     acquire_channels,
@@ -1751,3 +1752,87 @@ def test_a_cancelled_sweep_does_not_start_the_next_pass(fm_microscope, monkeypat
         ).run()
 
     assert {d["pass_index"] for d in seen} == {1}, "the second pass must not start"
+
+
+# ── acquiring somewhere other than under the stage ───────────────────────
+#
+# The grid's centre and the position the run returns to used to be one value. They are
+# not the same thing: an overview can be planned over a neighbouring square while the
+# stage stays where it is, and the stage still has to come home afterwards.
+
+
+def _offset_from(position, dx, dy):
+    from copy import deepcopy
+
+    moved = deepcopy(position)
+    moved.x += dx
+    moved.y += dy
+    return moved
+
+
+def test_the_grid_is_laid_out_around_the_requested_centre(fm_microscope):
+    start = fm_microscope.get_stage_position()
+    centre = _offset_from(start, 400e-6, -250e-6)
+
+    runner = FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=3, cols=3, overlap=0.1),
+        centre_position=centre,
+    )
+    runner.run()
+
+    middle = runner._tile_stage_positions[(1, 1)]
+    assert middle.x == pytest.approx(centre.x, abs=1e-12)
+    assert middle.y == pytest.approx(centre.y, abs=1e-12)
+
+
+def test_the_stage_still_returns_to_where_it_started(fm_microscope):
+    """The centre is where the grid goes, not a new home for the stage. Conflating the
+    two would leave the instrument somewhere the user never asked to be."""
+    start = fm_microscope.get_stage_position()
+
+    runner = FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
+        centre_position=_offset_from(start, 400e-6, -250e-6),
+    )
+    runner.run()
+
+    ended = fm_microscope.get_stage_position()
+    assert ended.x == pytest.approx(start.x, abs=1e-9)
+    assert ended.y == pytest.approx(start.y, abs=1e-9)
+
+
+def test_the_mosaic_reports_the_requested_centre(fm_microscope):
+    """A mosaic acquired over there has to say it is over there, or every position
+    later read off it lands back where the stage happened to be."""
+    start = fm_microscope.get_stage_position()
+    centre = _offset_from(start, 400e-6, -250e-6)
+
+    mosaic = FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
+        centre_position=centre,
+    ).run_and_stitch()
+
+    assert mosaic.metadata.stage_position.x == pytest.approx(centre.x, abs=1e-12)
+    assert mosaic.metadata.stage_position.y == pytest.approx(centre.y, abs=1e-12)
+
+
+def test_without_a_centre_the_run_uses_the_stage(fm_microscope):
+    """The default has to keep working: an overview is normally of what you are
+    looking at, and `centre_position` is resolved rather than left as None."""
+    start = fm_microscope.get_stage_position()
+
+    runner = FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=1, cols=1, overlap=0.1),
+    )
+    runner.run()
+
+    assert runner.centre_position.x == pytest.approx(start.x, abs=1e-12)
+    assert runner.centre_position.y == pytest.approx(start.y, abs=1e-12)

--- a/tests/fm/test_structures.py
+++ b/tests/fm/test_structures.py
@@ -2352,3 +2352,79 @@ def test_fluorescence_image_filepath_excluded_from_compare_and_repr():
     image = _make_image()
     image.filepath = "/somewhere/on/disk.ome.tiff"
     assert "filepath" not in repr(image)
+
+
+class TestCombiningImagesKeepsTheirMetadata:
+    """`create_z_stack` and `create_multi_channel_image` used to rebuild the metadata
+    field by field, so every field added to the dataclass afterwards had to be
+    remembered in two more places. `geometry` was not, and went missing from every
+    z-stacked and multi-channel acquisition — and so from every stitched mosaic, which
+    inherits the reference tile's metadata. Nothing consumed it there until the overview
+    canvas began projecting stage positions, at which point they all vanished on
+    acquisition.
+    """
+
+    @staticmethod
+    def _image(**overrides):
+        from fibsem.fm.structures import (
+            CameraImageTransform,
+            FluorescenceChannelMetadata,
+            FluorescenceImage,
+            FluorescenceImageMetadata,
+            FMImageGeometry,
+        )
+
+        metadata = FluorescenceImageMetadata(
+            acquisition_date="2026-07-31T12:00:00",
+            pixel_size_x=1e-7,
+            pixel_size_y=1e-7,
+            channels=[FluorescenceChannelMetadata(
+                name=overrides.pop("name", "GFP"),
+                excitation_wavelength=488.0,
+                power=0.5,
+                exposure_time=0.1,
+                gain=1.0,
+                offset=0.0,
+                objective_position=1e-3,
+            )],
+            geometry=FMImageGeometry(
+                transform=CameraImageTransform.FLIP_XY,
+                camera_tilt=180.0,
+                is_compustage=True,
+            ),
+            description="carried through",
+            **overrides,
+        )
+        return FluorescenceImage(data=np.zeros((1, 8, 8), dtype=np.uint16), metadata=metadata)
+
+    def test_a_z_stack_keeps_the_geometry(self):
+        from fibsem.fm.structures import FluorescenceImage
+
+        stack = FluorescenceImage.create_z_stack([self._image(), self._image()])
+
+        assert stack.metadata.geometry is not None
+        assert stack.metadata.geometry.camera_tilt == 180.0
+        assert stack.metadata.geometry.is_compustage is True
+        assert stack.metadata.z_positions is not None  # what stacking is *for*
+
+    def test_a_multi_channel_image_keeps_the_geometry(self):
+        from fibsem.fm.structures import FluorescenceImage
+
+        combined = FluorescenceImage.create_multi_channel_image(
+            [self._image(name="GFP"), self._image(name="RFP")]
+        )
+
+        assert combined.metadata.geometry is not None
+        assert combined.metadata.geometry.is_compustage is True
+        assert [c.name for c in combined.metadata.channels] == ["GFP", "RFP"]
+
+    def test_unrelated_fields_survive_too(self):
+        """The point is not `geometry` specifically — it is that nothing is dropped."""
+        from fibsem.fm.structures import FluorescenceImage
+
+        stack = FluorescenceImage.create_z_stack([self._image(), self._image()])
+        combined = FluorescenceImage.create_multi_channel_image([self._image()])
+
+        for metadata in (stack.metadata, combined.metadata):
+            assert metadata.description == "carried through"
+            assert metadata.pixel_size_x == 1e-7

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1321,6 +1321,76 @@ def test_a_move_clear_of_the_working_area_re_declares_it(qapp, interactive_widge
     assert (after[2], after[3]) == pytest.approx(widget._grid_offset())
 
 
+# ── anchoring the frame (FIB-418) ────────────────────────────────────────
+
+
+def test_the_frame_can_be_anchored_at_a_chosen_position(qapp, interactive_widget):
+    """So one canvas can describe the FM mount while another describes the column
+    48 mm away, each correctly framed, rather than both taking whatever the stage
+    happened to be doing when they woke up."""
+    from fibsem.structures import FibsemStagePosition
+
+    widget = interactive_widget
+    widget.canvas.clear_overviews()
+    stage = widget._current_stage_position()
+    elsewhere = FibsemStagePosition(
+        x=stage.x + 48e-3, y=stage.y, z=stage.z, r=stage.r, t=stage.t,
+        coordinate_system=stage.coordinate_system,
+    )
+    try:
+        widget.set_origin(elsewhere)
+        qapp.processEvents()
+
+        assert widget.origin is elsewhere
+        # canvas zero is now that position, and the stage is 48 mm the other way
+        assert widget._frame().to_canvas(elsewhere) == pytest.approx((0.0, 0.0))
+        assert widget.current_position_overlay._points[0][0] == pytest.approx(
+            widget._frame().to_canvas(stage)[0]
+        )
+    finally:
+        widget.set_origin(None)
+        qapp.processEvents()
+
+
+def test_anchoring_again_returns_to_following_the_stage(qapp, interactive_widget):
+    from fibsem.structures import FibsemStagePosition
+
+    widget = interactive_widget
+    widget.canvas.clear_overviews()
+    stage = widget._current_stage_position()
+    widget.set_origin(FibsemStagePosition(
+        x=stage.x + 1e-3, y=stage.y, z=stage.z, r=stage.r, t=stage.t,
+        coordinate_system=stage.coordinate_system,
+    ))
+    qapp.processEvents()
+
+    widget.set_origin(None)
+    qapp.processEvents()
+
+    # re-derived from the stage on the next use, rather than left unset
+    assert widget._frame() is not None
+    assert widget.origin.x == pytest.approx(stage.x)
+
+
+def test_the_frame_cannot_be_re_anchored_under_placed_images(qapp, interactive_widget):
+    """Images are positioned relative to the origin as it stood when they were added,
+    so moving it afterwards leaves every one describing a position it was never
+    acquired at."""
+    widget = interactive_widget
+    widget.canvas.clear_overviews()
+    widget.set_image(
+        widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    )
+    qapp.processEvents()
+    anchored = widget.origin
+
+    with pytest.raises(ValueError, match="already"):
+        widget.set_origin(widget._current_stage_position())
+
+    assert widget.origin is anchored, "the origin moved despite the refusal"
+    widget.canvas.clear_overviews()
+
+
 def test_closing_the_widget_lets_go_of_the_stage_signal(qapp):
     """`stage_position_changed` belongs to the microscope and outlives the widget. A
     connection left behind emits into a Qt object already torn down on the C++ side,

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -696,14 +696,14 @@ def test_an_image_without_geometry_can_still_be_marked(qapp, overview_widget):
 def test_positions_are_dropped_when_no_geometry_is_available_at_all(qapp, overview_widget):
     """Better an empty overlay than markers in plausible-looking wrong places."""
     widget = overview_widget
-    original = widget._live_geometry
-    widget._live_geometry = lambda: (None, None, None)
+    original = widget._frame
+    widget._frame = lambda: None
     try:
         widget.set_positions([_offset(widget._current_stage_position(), name="nowhere")])
         qapp.processEvents()
         assert widget.position_overlay._points == []
     finally:
-        widget._live_geometry = original
+        widget._frame = original
 
 
 def test_clearing_the_positions_clears_the_markers(qapp, overview_widget):
@@ -929,13 +929,13 @@ def test_stage_metadata_is_dropped_when_the_geometry_is_unknown(qapp, overview_w
     widget = overview_widget
     widget._displayed_image = None
     widget._origin = None
-    original = widget._live_geometry
-    widget._live_geometry = lambda: (None, None, None)
+    original = widget._frame
+    widget._frame = lambda: None
     try:
         widget._refresh_stage_metadata()
         assert widget.stage_overlay._specs == []
     finally:
-        widget._live_geometry = original
+        widget._frame = original
 
 
 def test_the_current_position_marker_follows_the_stage(qapp, overview_widget):
@@ -1036,8 +1036,7 @@ def test_a_canvas_point_resolves_to_the_position_it_was_drawn_from(interactive_w
     from fibsem.structures import FibsemStagePosition
 
     widget = interactive_widget
-    project = widget._stage_to_canvas()
-    unproject = widget._canvas_to_stage()
+    frame = widget._frame()
     base = widget._current_stage_position()
 
     for dx, dy in [(0.0, 0.0), (120e-6, 0.0), (0.0, -85e-6), (-250e-6, 375e-6)]:
@@ -1045,7 +1044,7 @@ def test_a_canvas_point_resolves_to_the_position_it_was_drawn_from(interactive_w
             x=base.x + dx, y=base.y + dy, z=base.z, r=base.r, t=base.t,
             coordinate_system=base.coordinate_system,
         )
-        resolved = unproject(*project(marked))
+        resolved = frame.to_stage(*frame.to_canvas(marked))
 
         assert resolved.x == pytest.approx(marked.x, abs=1e-12)
         assert resolved.y == pytest.approx(marked.y, abs=1e-12)
@@ -1056,9 +1055,9 @@ def test_double_clicking_moves_the_stage_to_that_point(qapp, interactive_widget,
 
     widget = interactive_widget
     monkeypatch.setattr(module, "FunctionWorker", _SynchronousWorker)
-    project = widget._stage_to_canvas()
+    frame = widget._frame()
     before = widget._current_stage_position()
-    point = project(before)
+    point = frame.to_canvas(before)
 
     widget._on_canvas_double_clicked(point[0] + 1200.0, point[1] - 500.0, None)
     qapp.processEvents()
@@ -1066,7 +1065,9 @@ def test_double_clicking_moves_the_stage_to_that_point(qapp, interactive_widget,
     after = widget.microscope.get_stage_position()
     assert (after.x, after.y) != (before.x, before.y), "the stage did not move"
     # and it landed under the click, which is the only claim the gesture makes
-    assert project(after) == pytest.approx((point[0] + 1200.0, point[1] - 500.0), abs=1e-6)
+    assert frame.to_canvas(after) == pytest.approx(
+        (point[0] + 1200.0, point[1] - 500.0), abs=1e-6
+    )
 
 
 def test_the_marker_follows_the_stage_after_a_double_click(qapp, interactive_widget, monkeypatch):
@@ -1241,8 +1242,7 @@ def test_the_cursor_readout_names_the_position_under_it(qapp, interactive_widget
     """A canvas you have to click to get a coordinate out of cannot be used to decide
     whether to click."""
     widget = interactive_widget
-    unproject = widget._canvas_to_stage()
-    under = unproject(1500.0, -900.0)
+    under = widget._frame().to_stage(1500.0, -900.0)
 
     widget._on_cursor_moved(1500.0, -900.0)
 

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1319,3 +1319,45 @@ def test_a_move_clear_of_the_working_area_re_declares_it(qapp, interactive_widge
     after = widget.canvas.canvas.world_extent
     assert after != before
     assert (after[2], after[3]) == pytest.approx(widget._grid_offset())
+
+
+def test_closing_the_widget_lets_go_of_the_stage_signal(qapp):
+    """`stage_position_changed` belongs to the microscope and outlives the widget. A
+    connection left behind emits into a Qt object already torn down on the C++ side,
+    which is a segfault rather than an exception: closing the tab and then moving the
+    stage from anywhere else in the application took the whole application down.
+
+    Asserted on the subscriber count rather than by provoking the crash, since a test
+    that segfaults takes the runner with it.
+    """
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    microscope = build_microscope()
+    before = len(microscope.stage_position_changed)
+    widget = FMOverviewWidget(microscope)
+    assert len(microscope.stage_position_changed) == before + 1
+
+    widget.close()
+    qapp.processEvents()
+
+    assert len(microscope.stage_position_changed) == before
+
+
+def test_a_dropped_widget_lets_go_of_the_stage_signal_too(qapp):
+    """Not everything gets closed. psygnal holds a bound method weakly and drops it
+    when the owner is collected -- but not a Qt signal's `emit`, which PyQt rebuilds on
+    every access, so psygnal can neither weakref it nor match it at disconnect time.
+    It also says nothing when the disconnect therefore removes nothing."""
+    import gc
+
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    microscope = build_microscope()
+    before = len(microscope.stage_position_changed)
+    widget = FMOverviewWidget(microscope)
+    assert len(microscope.stage_position_changed) == before + 1
+
+    del widget
+    gc.collect()
+
+    assert len(microscope.stage_position_changed) == before

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -917,3 +917,57 @@ def test_stage_metadata_is_dropped_when_the_geometry_is_unknown(qapp, overview_w
         assert widget.stage_overlay._specs == []
     finally:
         widget._live_geometry = original
+
+
+def test_the_current_position_marker_follows_the_stage(qapp, overview_widget):
+    """Drawn separately from the canvas's red origin marker: the origin explains why
+    everything sits where it does, this yellow one is what you steer by. They coincide
+    until the stage moves, then diverge."""
+    from fibsem.structures import FibsemStagePosition
+
+    widget = overview_widget
+    widget.canvas.clear_overviews()
+    widget._origin = None
+    widget._refresh_current_position()
+    qapp.processEvents()
+    at_origin = list(widget.current_position_overlay._points)
+
+    tilt = widget.microscope.get_stage_position().t
+    widget.microscope.move_stage_absolute(
+        FibsemStagePosition(x=150e-6, y=-60e-6, z=0.0, r=0.0, t=tilt)
+    )
+    qapp.processEvents()
+
+    moved = widget.current_position_overlay._points
+    assert moved != at_origin, "the marker did not follow the stage"
+
+    # the canvas's own origin marker stays put, which is the point of having both
+    origin_marker = widget.canvas.canvas._crosshair_artists[0].get_data()
+    assert (origin_marker[0][0], origin_marker[1][0]) == (0.0, 0.0)
+
+
+def test_the_marker_lands_where_an_image_acquired_there_is_placed(qapp, overview_widget):
+    """The marker and the image reach the canvas by different routes — one through
+    set_points, the other through add_image — so agreeing is worth checking. If they
+    ever diverge, the canvas is telling two stories about the same stage position."""
+    from fibsem.structures import FibsemStagePosition
+
+    widget = overview_widget
+    widget.canvas.clear_overviews()
+    widget.set_image(widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01")))
+    qapp.processEvents()
+
+    tilt = widget.microscope.get_stage_position().t
+    widget.microscope.move_stage_absolute(
+        FibsemStagePosition(x=150e-6, y=-60e-6, z=0.0, r=0.0, t=tilt)
+    )
+    qapp.processEvents()
+    marker = widget.current_position_overlay._points[0]
+
+    widget.set_image(widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01")))
+    qapp.processEvents()
+
+    placed = widget.canvas.canvas._placed[max(widget.canvas.canvas.placed_keys)]
+    xmin, xmax, ymax, ymin = placed.extent
+    assert marker[0] == pytest.approx((xmin + xmax) / 2)
+    assert marker[1] == pytest.approx((ymin + ymax) / 2)

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1273,3 +1273,49 @@ def test_the_reported_offset_is_measured_in_the_frame_it_is_drawn_in(qapp, inter
     # and the sign follows the canvas: dragging down the screen reads as +y
     assert widget._target_offset()[1] > 0
 
+
+def test_the_working_area_follows_the_grid_not_the_canvas_origin(qapp, interactive_widget):
+    """Pinned to the origin, it framed empty space once the stage travelled far from
+    wherever the frame was anchored -- moving to an offset FM mount steps 48 mm -- and
+    stretched the content extent across the gap, which capped how far the view could
+    zoom in."""
+    widget = interactive_widget
+    span = widget.canvas.canvas.world_extent[0]
+
+    widget._on_grid_move(*[v + 4 * span / widget.canvas.canvas.reference_pixel_size
+                           for v in widget.tile_grid_overlay._anchor()])
+    qapp.processEvents()
+
+    _, _, cx, cy = widget.canvas.canvas.world_extent
+    assert (cx, cy) == pytest.approx(widget._grid_offset())
+
+
+def test_a_move_inside_the_working_area_leaves_the_framing_alone(qapp, interactive_widget):
+    """Re-declaring the working area re-frames the view, so it must not follow every
+    move -- a double-click to somewhere 100 µm away would throw the zoom away, the same
+    failure a tile toggle used to cause."""
+    widget = interactive_widget
+    before = widget.canvas.canvas.world_extent
+    span_px = before[0] / widget.canvas.canvas.reference_pixel_size
+    anchor = widget.tile_grid_overlay._anchor()
+
+    widget._on_grid_move(anchor[0] + span_px / 4, anchor[1])
+    qapp.processEvents()
+
+    assert widget.canvas.canvas.world_extent == before
+    # ...and the grid still moved, which is the point of not re-framing for it
+    assert widget.tile_grid_overlay._anchor()[0] == pytest.approx(anchor[0] + span_px / 4)
+
+
+def test_a_move_clear_of_the_working_area_re_declares_it(qapp, interactive_widget):
+    widget = interactive_widget
+    before = widget.canvas.canvas.world_extent
+    span_px = before[0] / widget.canvas.canvas.reference_pixel_size
+    anchor = widget.tile_grid_overlay._anchor()
+
+    widget._on_grid_move(anchor[0] + 4 * span_px, anchor[1])
+    qapp.processEvents()
+
+    after = widget.canvas.canvas.world_extent
+    assert after != before
+    assert (after[2], after[3]) == pytest.approx(widget._grid_offset())

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1252,3 +1252,24 @@ def test_the_cursor_readout_names_the_position_under_it(qapp, interactive_widget
 
     widget._on_cursor_moved(None, None)
     assert widget.cursor_readout.text() == "", "the readout must not freeze off-canvas"
+
+
+def test_the_reported_offset_is_measured_in_the_frame_it_is_drawn_in(qapp, interactive_widget):
+    """Subtracting stage axes describes the same gap in a frame the user cannot see: on
+    a compustage at t = -180 it reports y with the sign reversed, so the panel said the
+    grid was above the stage while it was drawn below."""
+    widget = interactive_widget
+    frame = widget._frame()
+    anchor = widget.tile_grid_overlay._anchor()
+
+    widget._on_grid_move(anchor[0] + 1000.0, anchor[1] + 1000.0)
+    qapp.processEvents()
+
+    here = frame.offset(widget._current_stage_position())
+    there = frame.offset(widget._target)
+    assert widget._target_offset() == pytest.approx(
+        (there[0] - here[0], there[1] - here[1])
+    )
+    # and the sign follows the canvas: dragging down the screen reads as +y
+    assert widget._target_offset()[1] > 0
+

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -537,6 +537,25 @@ def test_collapsed_panels_do_not_stretch(qapp):
 # ── tile grid overlay wiring ─────────────────────────────────────────────
 
 
+def _mouse(overlay, x, y, px=0.0, py=0.0, button=1):
+    """A matplotlib mouse event over the overlay's axes.
+
+    `px`/`py` are screen pixels: the overlay measures drag distance in them, so a
+    click and a drag differ only in whether these change between press and release.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        button=button, inaxes=overlay._ax, xdata=x, ydata=y, x=px, y=py
+    )
+
+
+def _click(overlay, x, y):
+    """Press and release at one point -- the gesture that toggles a tile."""
+    overlay._on_press(_mouse(overlay, x, y))
+    overlay._on_release(_mouse(overlay, x, y))
+
+
 @pytest.fixture(scope="module")
 def overview_widget(qapp):
     """A real widget against the Demo microscope, for the canvas/settings wiring."""
@@ -566,7 +585,7 @@ def test_clicking_a_tile_updates_the_mask_the_settings_widget_owns(qapp, overvie
     overlay = widget.tile_grid_overlay
     tile = next(t for t in overlay._tiles if (t.row, t.col) == (0, 0))
     x, y, tw, th = overlay._rect_for(tile)
-    overlay._on_canvas_clicked(x + tw / 2, y + th / 2, None)
+    _click(overlay, x + tw / 2, y + th / 2)
     qapp.processEvents()
 
     assert widget.settings_widget.tile_mask.mask[0][0] is False
@@ -587,7 +606,7 @@ def test_clicking_the_same_tile_twice_returns_it(qapp, overview_widget):
     x, y, tw, th = overlay._rect_for(tile)
 
     for _ in range(2):
-        overlay._on_canvas_clicked(x + tw / 2, y + th / 2, None)
+        _click(overlay, x + tw / 2, y + th / 2)
         qapp.processEvents()
 
     assert widget.settings_widget.tile_mask.n_enabled == 9
@@ -971,3 +990,265 @@ def test_the_marker_lands_where_an_image_acquired_there_is_placed(qapp, overview
     xmin, xmax, ymax, ymin = placed.extent
     assert marker[0] == pytest.approx((xmin + xmax) / 2)
     assert marker[1] == pytest.approx((ymin + ymax) / 2)
+
+
+# ── canvas interaction ───────────────────────────────────────────────────
+
+
+class _SynchronousWorker:
+    """Stands in for FunctionWorker so a test can see the outcome, not a thread."""
+
+    def __init__(self, fn, *args, **kwargs):
+        self.fn, self.args, self.kwargs = fn, args, kwargs
+
+    def start(self):
+        self.fn(*self.args, **self.kwargs)
+
+    def is_alive(self):
+        return False
+
+
+@pytest.fixture
+def interactive_widget(qapp, overview_widget):
+    """`overview_widget` with the interaction state reset, and restored afterwards.
+
+    The widget is module-scoped, so a target left behind by one test would silently
+    re-centre every grid the next one drew.
+    """
+    from fibsem.structures import FibsemStagePosition
+
+    widget = overview_widget
+    start = widget.microscope.get_stage_position()
+    widget.clear_target()
+    qapp.processEvents()
+    yield widget
+    widget.clear_target()
+    widget.microscope.move_stage_absolute(
+        FibsemStagePosition(x=start.x, y=start.y, z=start.z, r=start.r, t=start.t)
+    )
+    qapp.processEvents()
+
+
+def test_a_canvas_point_resolves_to_the_position_it_was_drawn_from(interactive_widget):
+    """The two projections have to be exact inverses, not merely close. Everything on
+    this canvas is placed by the forward one and clicked through the backward one, so
+    any gap between them is the distance between what you point at and what you get."""
+    from fibsem.structures import FibsemStagePosition
+
+    widget = interactive_widget
+    project = widget._stage_to_canvas()
+    unproject = widget._canvas_to_stage()
+    base = widget._current_stage_position()
+
+    for dx, dy in [(0.0, 0.0), (120e-6, 0.0), (0.0, -85e-6), (-250e-6, 375e-6)]:
+        marked = FibsemStagePosition(
+            x=base.x + dx, y=base.y + dy, z=base.z, r=base.r, t=base.t,
+            coordinate_system=base.coordinate_system,
+        )
+        resolved = unproject(*project(marked))
+
+        assert resolved.x == pytest.approx(marked.x, abs=1e-12)
+        assert resolved.y == pytest.approx(marked.y, abs=1e-12)
+
+
+def test_double_clicking_moves_the_stage_to_that_point(qapp, interactive_widget, monkeypatch):
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    widget = interactive_widget
+    monkeypatch.setattr(module, "FunctionWorker", _SynchronousWorker)
+    project = widget._stage_to_canvas()
+    before = widget._current_stage_position()
+    point = project(before)
+
+    widget._on_canvas_double_clicked(point[0] + 1200.0, point[1] - 500.0, None)
+    qapp.processEvents()
+
+    after = widget.microscope.get_stage_position()
+    assert (after.x, after.y) != (before.x, before.y), "the stage did not move"
+    # and it landed under the click, which is the only claim the gesture makes
+    assert project(after) == pytest.approx((point[0] + 1200.0, point[1] - 500.0), abs=1e-6)
+
+
+def test_the_marker_follows_the_stage_after_a_double_click(qapp, interactive_widget, monkeypatch):
+    """The move is confirmed by re-reading the stage rather than assumed, so the marker
+    shows where the instrument went rather than where it was asked to go."""
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    widget = interactive_widget
+    monkeypatch.setattr(module, "FunctionWorker", _SynchronousWorker)
+    before = list(widget.current_position_overlay._points)
+
+    widget._on_canvas_double_clicked(1500.0, 900.0, None)
+    qapp.processEvents()
+
+    assert widget.current_position_overlay._points != before
+
+
+def test_the_stage_cannot_be_driven_during_an_acquisition(qapp, interactive_widget, monkeypatch):
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    widget = interactive_widget
+    monkeypatch.setattr(module, "FunctionWorker", _SynchronousWorker)
+    before = widget.microscope.get_stage_position()
+
+    class _Running:
+        def is_alive(self):
+            return True
+
+    widget._worker = _Running()
+    try:
+        widget._on_canvas_double_clicked(1500.0, 900.0, None)
+        qapp.processEvents()
+    finally:
+        widget._worker = None
+
+    after = widget.microscope.get_stage_position()
+    assert (after.x, after.y) == (before.x, before.y)
+
+
+def test_a_point_outside_the_stage_limits_is_refused(qapp, interactive_widget, monkeypatch):
+    """A click can land anywhere on a real-space canvas, including well past where the
+    stage can physically go. Asking for it is how a stage ends up against its stop."""
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    widget = interactive_widget
+    monkeypatch.setattr(module, "FunctionWorker", _SynchronousWorker)
+    before = widget.microscope.get_stage_position()
+    limits = getattr(widget.microscope._stage, "limits", None)
+    if not limits:
+        pytest.skip("this stage declares no limits")
+
+    # far outside any plausible envelope: 1 m of travel at 100 nm/px
+    widget._on_canvas_double_clicked(1e7, 1e7, None)
+    qapp.processEvents()
+
+    after = widget.microscope.get_stage_position()
+    assert (after.x, after.y) == (before.x, before.y)
+
+
+def test_dragging_the_grid_sets_a_target_without_moving_the_stage(qapp, interactive_widget):
+    """Planning a run and driving the instrument are separate acts. A drag is
+    exploratory -- you push the grid around to see what it would cover."""
+    widget = interactive_widget
+    before = widget.microscope.get_stage_position()
+    anchor = widget.tile_grid_overlay._anchor()
+
+    widget._on_grid_move(anchor[0] + 800.0, anchor[1] - 300.0)
+    qapp.processEvents()
+
+    after = widget.microscope.get_stage_position()
+    assert (after.x, after.y) == (before.x, before.y)
+    assert widget._target is not None
+    assert widget.tile_grid_overlay._anchor() == pytest.approx(
+        (anchor[0] + 800.0, anchor[1] - 300.0)
+    )
+
+
+def test_the_planned_grid_is_centred_where_the_run_will_be(qapp, interactive_widget):
+    """The grid is a preview of an acquisition, so it has to sit where the acquisition
+    would: on the target once one is set, and on the stage until then."""
+    widget = interactive_widget
+    anchor = widget.tile_grid_overlay._anchor()
+    widget._on_grid_move(anchor[0] + 800.0, anchor[1])
+    qapp.processEvents()
+
+    assert widget._grid_centre() is widget._target
+
+    widget.clear_target()
+    qapp.processEvents()
+
+    centre = widget._grid_centre()
+    stage = widget.microscope.get_stage_position()
+    assert (centre.x, centre.y) == (stage.x, stage.y)
+
+
+def test_an_untargeted_grid_follows_the_stage(qapp, interactive_widget, monkeypatch):
+    """It used to be pinned to the canvas origin -- where the stage was the first time
+    anything was drawn. Correct until the stage moved, and then quietly not."""
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    widget = interactive_widget
+    monkeypatch.setattr(module, "FunctionWorker", _SynchronousWorker)
+    before = widget.tile_grid_overlay._anchor()
+
+    widget._on_canvas_double_clicked(before[0] + 1500.0, before[1], None)
+    qapp.processEvents()
+
+    assert widget.tile_grid_overlay._anchor()[0] == pytest.approx(before[0] + 1500.0, abs=1.0)
+
+
+def test_a_targeted_grid_stays_put_when_the_stage_moves(qapp, interactive_widget, monkeypatch):
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    widget = interactive_widget
+    monkeypatch.setattr(module, "FunctionWorker", _SynchronousWorker)
+    anchor = widget.tile_grid_overlay._anchor()
+    widget._on_grid_move(anchor[0] + 800.0, anchor[1])
+    qapp.processEvents()
+    targeted = widget.tile_grid_overlay._anchor()
+
+    widget._on_canvas_double_clicked(anchor[0] - 1500.0, anchor[1], None)
+    qapp.processEvents()
+
+    assert widget.tile_grid_overlay._anchor() == pytest.approx(targeted)
+
+
+def test_centring_the_grid_is_only_offered_once_it_is_off_centre(qapp, interactive_widget):
+    """The way back from a drag. A control that is always live invites a click that
+    does nothing, and one that is never live strands the state it set."""
+    widget = interactive_widget
+    assert widget.tile_grid_panel.button_centre.isEnabled() is False
+
+    anchor = widget.tile_grid_overlay._anchor()
+    widget._on_grid_move(anchor[0] + 800.0, anchor[1])
+    qapp.processEvents()
+    assert widget.tile_grid_panel.button_centre.isEnabled() is True
+
+    widget.tile_grid_panel.button_centre.click()
+    qapp.processEvents()
+    assert widget.tile_grid_panel.button_centre.isEnabled() is False
+    assert widget.tile_grid_overlay._anchor() == pytest.approx(anchor)
+
+
+def test_the_target_reaches_the_acquisition(qapp, interactive_widget, monkeypatch):
+    """The drag is only worth anything if the run is actually centred there."""
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    widget = interactive_widget
+    recorded = {}
+
+    class _RecordingRunner:
+        def __init__(self, **kwargs):
+            recorded.update(kwargs)
+
+    monkeypatch.setattr(module, "FMTiledAcquisitionRunner", _RecordingRunner)
+    monkeypatch.setattr(module, "FunctionWorker", lambda *a, **k: _SynchronousWorker(lambda: None))
+    monkeypatch.setattr(
+        module.FMOverviewConfirmationDialog, "exec_", lambda self: module.QDialog.Accepted
+    )
+    anchor = widget.tile_grid_overlay._anchor()
+    widget._on_grid_move(anchor[0] + 800.0, anchor[1])
+    qapp.processEvents()
+
+    widget.acquire()
+    qapp.processEvents()
+    widget._set_running(False)
+
+    assert recorded["centre_position"] is widget._target
+
+
+def test_the_cursor_readout_names_the_position_under_it(qapp, interactive_widget):
+    """A canvas you have to click to get a coordinate out of cannot be used to decide
+    whether to click."""
+    widget = interactive_widget
+    unproject = widget._canvas_to_stage()
+    under = unproject(1500.0, -900.0)
+
+    widget._on_cursor_moved(1500.0, -900.0)
+
+    text = widget.cursor_readout.text()
+    assert f"{under.x * 1e6:.1f}" in text
+    assert f"{under.y * 1e6:.1f}" in text
+
+    widget._on_cursor_moved(None, None)
+    assert widget.cursor_readout.text() == "", "the readout must not freeze off-canvas"

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -658,19 +658,33 @@ def test_positions_outside_the_image_are_still_marked(qapp, overview_widget):
     assert widget.position_overlay._points[0][0] > width / 2
 
 
-def test_an_image_without_geometry_marks_nothing_rather_than_guessing(qapp, overview_widget):
-    """Older images cannot be projected onto. Better an empty overlay than markers in
-    plausible-looking wrong places."""
+def test_an_image_without_geometry_can_still_be_marked(qapp, overview_widget):
+    """Markers live in the canvas frame, which comes from the microscope, so nothing is
+    projected *onto* the image — an image with no recorded geometry no longer blocks it.
+    That matters in practice: tiles from the tiled runner come back without one."""
     widget = overview_widget
     image = widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
     base = image.metadata.stage_position
     image.metadata.geometry = None
     widget.set_image(image)
 
-    widget.set_positions([_offset(base, name="unknowable")])
+    widget.set_positions([_offset(base, dx=20e-6, name="markable")])
     qapp.processEvents()
 
-    assert widget.position_overlay._points == []
+    assert widget.position_overlay._points, "the image's missing geometry blocked marking"
+
+
+def test_positions_are_dropped_when_no_geometry_is_available_at_all(qapp, overview_widget):
+    """Better an empty overlay than markers in plausible-looking wrong places."""
+    widget = overview_widget
+    original = widget._live_geometry
+    widget._live_geometry = lambda: (None, None, None)
+    try:
+        widget.set_positions([_offset(widget._current_stage_position(), name="nowhere")])
+        qapp.processEvents()
+        assert widget.position_overlay._points == []
+    finally:
+        widget._live_geometry = original
 
 
 def test_clearing_the_positions_clears_the_markers(qapp, overview_widget):
@@ -850,3 +864,56 @@ def test_the_grid_keeps_its_scale_under_a_decimated_preview(qapp, overview_widge
     after = widget.tile_grid_overlay._rect_for(widget.tile_grid_overlay._tiles[0])
     assert after[2] == pytest.approx(before[2])
     assert after[3] == pytest.approx(before[3])
+
+
+def test_the_stage_and_grid_limits_are_drawn_in_the_canvas_frame(qapp, overview_widget):
+    """Same context the minimap gives, without its indirection: on a real-space canvas
+    stage coordinates map straight to canvas coordinates, so there is no stitched image
+    to reproject onto. Sizes must match what the microscope reports."""
+    widget = overview_widget
+    image = widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    widget.set_image(image)
+    qapp.processEvents()
+
+    by_label = {s.label: s for s in widget.stage_overlay._specs}
+    reference = widget.canvas.canvas.reference_pixel_size
+    limits = widget.microscope._stage.limits
+
+    stage = by_label["Stage limits"]
+    assert stage.width == pytest.approx((limits["x"].max - limits["x"].min) / reference)
+    assert stage.height == pytest.approx((limits["y"].max - limits["y"].min) / reference)
+
+    from fibsem.ui.fm.widgets.fm_overview_widget import GRID_RADIUS_M
+    assert by_label["Grid boundary"].radius == pytest.approx(GRID_RADIUS_M / reference)
+
+    assert widget.stage_overlay._artists, "specs were built but nothing was drawn"
+
+
+def test_stage_metadata_does_not_wait_for_an_image(qapp, overview_widget):
+    """The camera and stage can say where things are before anything is acquired, and the
+    planned tile grid is already drawn from exactly that. Requiring an image would show
+    two halves of the same picture at different times."""
+    widget = overview_widget
+    widget._displayed_image = None
+    widget._origin = None
+
+    widget._refresh_stage_metadata()
+
+    labels = [spec.label for spec in widget.stage_overlay._specs]
+    assert "Stage limits" in labels
+    assert "Grid boundary" in labels
+
+
+def test_stage_metadata_is_dropped_when_the_geometry_is_unknown(qapp, overview_widget):
+    """Without a geometry there is no frame, and drawing at a guessed scale would put
+    plausible-looking shapes in the wrong places."""
+    widget = overview_widget
+    widget._displayed_image = None
+    widget._origin = None
+    original = widget._live_geometry
+    widget._live_geometry = lambda: (None, None, None)
+    try:
+        widget._refresh_stage_metadata()
+        assert widget.stage_overlay._specs == []
+    finally:
+        widget._live_geometry = original

--- a/tests/ui/test_fm_real_space_canvas.py
+++ b/tests/ui/test_fm_real_space_canvas.py
@@ -251,3 +251,72 @@ def test_a_reduced_composite_is_still_placed_at_full_size():
     assert extent[2] - extent[3] == pytest.approx(1024)
     # and the canvas frame is still the acquired scale, which overlays measure against
     assert w.canvas.reference_pixel_size == pytest.approx(PIXEL_SIZE)
+
+
+# ── a channel that goes away ──────────────────────────────────────────────
+#
+# `_upsert_layer` only ever adds, which is right for the live path -- channels arrive a
+# frame at a time. It is wrong the moment a *set* of channels shrinks: the layer left
+# behind still holds the previous image's pixels, and those get blended into the next
+# one and then recorded as its own.
+
+
+def _place(widget, key, names, centre=(0.0, 0.0)):
+    """Composite one overview from a named set of channels."""
+    widget.set_composite_key(key)
+    widget.set_placement(centre)
+    widget.retain_channels(names)
+    for name in names:
+        widget.set_channel(name, _plane(), "green")
+
+
+def test_a_dropped_channel_does_not_bleed_into_the_next_overview():
+    """The bug this exists for: a two-channel overview followed by a one-channel one
+    drew the second with the first's second channel."""
+    widget = _widget()
+    _place(widget, "first", ["Channel-01", "Channel-02"])
+    stale = next(l for l in widget.layers if l.name == "Channel-02").data
+
+    _place(widget, "second", ["Channel-01"], centre=(300e-6, 0.0))
+
+    assert "Channel-02" not in widget._held["second"]
+    assert not any(
+        plane is stale for plane in widget._held["second"].values()
+    ), "the second overview was composited from the first's pixels"
+
+
+def test_the_earlier_overview_keeps_the_channel_it_was_acquired_with():
+    """Dropping the control outright would be the opposite error: `_restyle_others`
+    only draws channels that still have one, so the first overview would silently lose
+    a colour the moment a narrower overview was acquired beside it."""
+    widget = _widget()
+    _place(widget, "first", ["Channel-01", "Channel-02"])
+
+    _place(widget, "second", ["Channel-01"], centre=(300e-6, 0.0))
+
+    assert sorted(widget._held["first"]) == ["Channel-01", "Channel-02"]
+    assert [layer.name for layer in widget.layers] == ["Channel-01", "Channel-02"]
+    dropped = next(l for l in widget.layers if l.name == "Channel-02")
+    assert dropped.data is None, "the control stays; the stale pixels do not"
+
+
+def test_a_channel_nothing_displays_is_dropped_entirely():
+    widget = _widget()
+    _place(widget, "first", ["Channel-01", "Channel-02"])
+    widget.clear_overviews()
+
+    _place(widget, "second", ["Channel-01"])
+
+    assert [layer.name for layer in widget.layers] == ["Channel-01"]
+
+
+def test_the_single_image_canvas_drops_a_channel_outright():
+    """One image at a time, so a channel it does not have is a channel nothing has."""
+    widget = FMCanvasWidget()
+    widget.set_pixel_size(PIXEL_SIZE)
+    widget.set_channel("Channel-01", _plane(), "green")
+    widget.set_channel("Channel-02", _plane(), "red")
+
+    widget.retain_channels(["Channel-01"])
+
+    assert [layer.name for layer in widget.layers] == ["Channel-01"]

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -606,3 +606,48 @@ def test_without_covers_the_ground_still_comes_from_shape_and_pixel_size():
     c.add_image(_img(100, 100), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
     xmin, xmax, _, _ = c._content_extent()
     assert xmax - xmin == pytest.approx(100)
+
+
+# ── zoom bounds ───────────────────────────────────────────────────────────
+
+
+def _scroll(canvas, direction, n=1):
+    from types import SimpleNamespace
+    for _ in range(n):
+        canvas._on_scroll(SimpleNamespace(
+            inaxes=canvas._ax, xdata=0.0, ydata=0.0,
+            button="up" if direction > 0 else "down", guiEvent=None,
+        ))
+
+
+def _span(canvas):
+    x0, x1 = canvas._ax.get_xlim()
+    return abs(x1 - x0)
+
+
+def test_zooming_out_stops_before_the_content_is_lost():
+    """Unbounded scroll-out leaves the content a speck in an empty field, with no way to
+    tell which direction to come back — easy to reach by accident on a trackpad."""
+    from fibsem.ui.widgets.canvas.canvas_base import MAX_ZOOM_OUT
+
+    c = _canvas()
+    c.add_image(_img(512, 512), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    c.reset_view()
+    _scroll(c, -1, 100)
+    assert _span(c) <= 512 * MAX_ZOOM_OUT
+
+
+def test_zooming_in_stops_before_falling_between_pixels():
+    from fibsem.ui.widgets.canvas.canvas_base import MAX_ZOOM_IN
+
+    c = _canvas()
+    c.add_image(_img(512, 512), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    c.reset_view()
+    _scroll(c, 1, 100)
+    assert _span(c) >= 512 / MAX_ZOOM_IN
+
+
+def test_zoom_is_unbounded_with_nothing_to_be_relative_to():
+    """The bounds are a multiple of the content, so an empty canvas has none."""
+    c = _canvas()
+    assert c._zoom_allowed(1e9) is True

--- a/tests/ui/test_stage_frame.py
+++ b/tests/ui/test_stage_frame.py
@@ -1,0 +1,203 @@
+"""The mapping between stage space and a real-space canvas.
+
+Tested without a widget, and mostly without a microscope: the frame is the piece a
+second modality has to be able to reuse, so anything it needs from a canvas or an
+instrument is worth seeing spelled out here.
+
+The property that matters is that the two directions are exact inverses. Everything on
+the canvas is placed by one and clicked through the other, so a gap between them is the
+distance between what you point at and what you get.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+import pytest
+
+from fibsem.fm.structures import CameraImageTransform, FMImageGeometry
+from fibsem.structures import FibsemStagePosition
+from fibsem.ui.widgets.canvas.stage_frame import FMStageProjection, StageFrame
+
+PIXEL_SIZE = 1e-7
+SHAPE = (1024, 1024)
+
+
+class _FakeCanvas:
+    """Only what a frame asks of a canvas: the scale, in both directions."""
+
+    def __init__(self, reference_pixel_size=PIXEL_SIZE):
+        self.reference_pixel_size = reference_pixel_size
+
+    def metres_to_canvas(self, x, y):
+        return x / self.reference_pixel_size, y / self.reference_pixel_size
+
+    def canvas_to_metres(self, x, y):
+        return x * self.reference_pixel_size, y * self.reference_pixel_size
+
+
+def _geometry(**overrides):
+    fields = dict(
+        transform=CameraImageTransform.NONE,
+        camera_tilt=180.0,
+        column_tilt=0.0,
+        fib_column_tilt=52.0,
+        shuttle_pre_tilt=0.0,
+        rotation_reference=0.0,
+        rotation_180=180.0,
+        is_compustage=True,
+    )
+    fields.update(overrides)
+    return FMImageGeometry(**fields)
+
+
+def _frame(canvas=None, origin=None, **geometry):
+    return StageFrame(
+        canvas or _FakeCanvas(),
+        origin or FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(-180)),
+        FMStageProjection(_geometry(**geometry), PIXEL_SIZE, SHAPE),
+    )
+
+
+def _offset(base, dx=0.0, dy=0.0):
+    return FibsemStagePosition(
+        x=base.x + dx, y=base.y + dy, z=base.z, r=base.r, t=base.t,
+        coordinate_system=base.coordinate_system,
+    )
+
+
+# ── the round trip ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("point", [(0.0, 0.0), (2500.0, 0.0), (0.0, -1750.0), (-3200.0, 4100.0)])
+def test_a_canvas_point_round_trips_through_stage_space(point):
+    frame = _frame()
+
+    assert frame.to_canvas(frame.to_stage(*point)) == pytest.approx(point, abs=1e-6)
+
+
+@pytest.mark.parametrize("pretilt", [0.0, 35.0])
+def test_the_round_trip_holds_on_a_pre_tilted_mount(pretilt):
+    """A pre-tilt puts a real z on every sideways move, which is the case a compustage
+    hides -- z stays 0 there, so an error in the y/z split cannot show up."""
+    frame = _frame(shuttle_pre_tilt=pretilt, is_compustage=False)
+
+    resolved = frame.to_stage(2500.0, 4000.0)
+
+    assert frame.to_canvas(resolved) == pytest.approx((2500.0, 4000.0), abs=1e-6)
+
+
+def test_a_sideways_click_carries_z_on_a_tilted_mount():
+    """What keeps the sample in focus when you click across it. Zero here would mean
+    the focal plane was being ignored, which a compustage would never reveal."""
+    flat = _frame().to_stage(0.0, 2500.0)
+    tilted = _frame(shuttle_pre_tilt=35.0, is_compustage=False).to_stage(0.0, 2500.0)
+
+    assert flat.z == pytest.approx(0.0, abs=1e-15)
+    assert abs(tilted.z) > 1e-9
+
+
+def test_the_origin_maps_to_the_canvas_origin():
+    origin = FibsemStagePosition(x=1e-3, y=-2e-3, z=0.0, r=0.0, t=np.deg2rad(-180))
+    frame = _frame(origin=origin)
+
+    assert frame.to_canvas(origin) == pytest.approx((0.0, 0.0))
+    assert frame.offset(origin) == pytest.approx((0.0, 0.0))
+
+
+# ── the scale ────────────────────────────────────────────────────────────
+
+
+def test_a_length_is_measured_on_the_canvas_scale():
+    frame = _frame(canvas=_FakeCanvas(reference_pixel_size=2e-7))
+
+    assert frame.length(1e-3) == pytest.approx(5000.0)
+
+
+def test_the_scale_cancels_out_of_the_round_trip():
+    """`pixel_size` and `shape` on the projection are arguments to functions that
+    measure in pixels, not inputs to the geometry -- so a canvas at a wildly different
+    scale must resolve a click to the same stage position."""
+    origin = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(-180))
+    fine = StageFrame(_FakeCanvas(1e-9), origin, FMStageProjection(_geometry(), 1e-9, SHAPE))
+    coarse = StageFrame(_FakeCanvas(1e-9), origin, FMStageProjection(_geometry(), 27e-6, SHAPE))
+
+    a, b = fine.to_stage(1500.0, -900.0), coarse.to_stage(1500.0, -900.0)
+
+    assert (a.x, a.y, a.z) == pytest.approx((b.x, b.y, b.z), abs=1e-15)
+
+
+def test_offset_is_metres_and_to_canvas_is_pixels():
+    """The two answer the same question in different units, and confusing them places
+    an image a factor of the pixel size away from where it belongs."""
+    frame = _frame()
+    position = _offset(frame.origin, dx=100e-6)
+
+    assert frame.offset(position) == pytest.approx((100e-6, 0.0))
+    assert frame.to_canvas(position) == pytest.approx((1000.0, 0.0))
+
+
+# ── reading a projection off its source ──────────────────────────────────
+
+
+def test_a_projection_can_be_read_off_the_live_microscope():
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    projection = FMStageProjection.from_microscope(build_microscope())
+
+    assert projection is not None
+    assert projection.pixel_size > 0
+    assert len(projection.shape) == 2
+
+
+def test_a_microscope_without_fluorescence_yields_no_projection():
+    class _NoFM:
+        fm = None
+
+    assert FMStageProjection.from_microscope(_NoFM()) is None
+
+
+def test_an_image_without_a_recorded_geometry_yields_no_projection():
+    """Acquired tiles currently lose their geometry (FIB-416), so this is the live
+    case, not a hypothetical one -- and a caller has to be able to tell."""
+
+    class _Metadata:
+        geometry = None
+        pixel_size_x = PIXEL_SIZE
+
+    class _Image:
+        metadata = _Metadata()
+        data = np.zeros(SHAPE)
+
+    assert FMStageProjection.from_image(_Image()) is None
+
+
+def test_a_projection_read_off_an_image_uses_the_image_geometry():
+    """The reason this is not simply always read live: an image may have been acquired
+    under a configuration the instrument is no longer in, and has to be placed as it
+    was taken."""
+
+    class _Metadata:
+        geometry = _geometry(transform=CameraImageTransform.FLIP_X)
+        pixel_size_x = 5e-7
+
+    class _Image:
+        metadata = _Metadata()
+        data = np.zeros((512, 256))
+
+    projection = FMStageProjection.from_image(_Image())
+
+    assert projection.geometry.transform is CameraImageTransform.FLIP_X
+    assert projection.pixel_size == 5e-7
+    assert tuple(projection.shape) == (512, 256)
+
+
+def test_a_camera_flip_reverses_the_axis_it_names():
+    origin = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(-180))
+    plain = _frame(origin=origin).to_canvas(_offset(origin, dx=100e-6))
+    flipped = _frame(
+        origin=origin, transform=CameraImageTransform.FLIP_X
+    ).to_canvas(_offset(origin, dx=100e-6))
+
+    assert flipped[0] == pytest.approx(-plain[0])
+    assert flipped[1] == pytest.approx(plain[1])

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -17,7 +17,10 @@ from PyQt5.QtWidgets import QApplication
 
 from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
 from fibsem.ui.widgets.canvas.canvas_base import ContentRect
-from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import TileGridOverlay
+from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import (
+    MOVE_DRAG_THRESHOLD_PX,
+    TileGridOverlay,
+)
 
 WIDTH = HEIGHT = 1024
 PIXEL_SIZE = 1e-7
@@ -73,6 +76,33 @@ def build(rows=3, cols=3, overlap=OVERLAP, mask=None):
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
     _seed_content(overlay)
     return overlay, tiles
+
+
+def _event(overlay, x, y, button=1, px=0.0, py=0.0):
+    """A matplotlib mouse event over the overlay's axes.
+
+    `px`/`py` are screen pixels. They matter for the move gesture, which decides
+    between a click and a drag by how far the pointer travelled on screen -- in data
+    coordinates that distance would change with the zoom.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        button=button, inaxes=overlay._ax, xdata=x, ydata=y, x=px, y=py
+    )
+
+
+def _click(overlay, x, y):
+    """Press and release at one point, without moving between the two."""
+    overlay._on_press(_event(overlay, x, y))
+    overlay._on_release(_event(overlay, x, y))
+
+
+def _drag(overlay, start, end, px_travel=50.0):
+    """Press at *start*, move to *end*, release. Screen travel defaults to a real drag."""
+    overlay._on_press(_event(overlay, *start))
+    overlay._on_drag(_event(overlay, *end, px=px_travel, py=px_travel))
+    overlay._on_release(_event(overlay, *end, px=px_travel, py=px_travel))
 
 
 def test_the_centre_tile_coincides_with_the_displayed_image(qapp):
@@ -150,7 +180,7 @@ def test_toggling_reports_the_new_state_not_the_old(qapp):
 
     disabled = next(t for t in tiles if (t.row, t.col) == (0, 0))
     x, y, width, height = overlay._rect_for(disabled)
-    overlay._on_canvas_clicked(x + width / 2, y + height / 2, None)
+    _click(overlay, x + width / 2, y + height / 2)
 
     assert received == [(0, 0, True)]
 
@@ -268,14 +298,6 @@ def test_skipped_tiles_are_grey_regardless_of_the_grid_colour(qapp):
 
 
 # ── resize by dragging an edge ───────────────────────────────────────────
-
-
-def _event(overlay, x, y, button=1):
-    from types import SimpleNamespace
-
-    return SimpleNamespace(
-        button=button, inaxes=overlay._ax, xdata=x, ydata=y, x=0, y=0
-    )
 
 
 def _edges(overlay):
@@ -471,3 +493,127 @@ def test_a_drag_survives_the_grid_being_cleared_underneath_it(qapp):
     overlay.clear()
 
     overlay._on_drag(_event(overlay, right + WIDTH, overlay._rect.cy))
+
+
+# ── move by dragging the interior ────────────────────────────────────────
+
+
+def _centre(overlay):
+    return overlay._rect.cx, overlay._rect.cy
+
+
+def test_dragging_the_interior_moves_the_grid_by_the_drag(qapp):
+    """The grid has to land where it was let go, not merely somewhere in that
+    direction -- it is a plan of where tiles will be acquired, and a drag that
+    approximated the position would plan an acquisition of somewhere else."""
+    overlay, _ = build(3, 3)
+    moved = []
+    overlay.grid_move_requested.connect(lambda x, y: moved.append((x, y)))
+    cx, cy = _centre(overlay)
+
+    _drag(overlay, (cx, cy), (cx + 300.0, cy - 125.0))
+
+    assert moved[-1] == pytest.approx((cx + 300.0, cy - 125.0))
+
+
+def test_a_press_that_barely_moves_is_a_click_not_a_drag(qapp):
+    """The same press starts both gestures, so the split has to fall somewhere. Below
+    the threshold it must toggle the tile: a hand is never perfectly still, and a click
+    that nudged the whole grid by a pixel would be worse than one that did nothing."""
+    overlay, tiles = build(3, 3)
+    moved, toggled = [], []
+    overlay.grid_move_requested.connect(lambda x, y: moved.append((x, y)))
+    overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+    centre = next(t for t in tiles if (t.row, t.col) == (1, 1))
+    x, y, width, height = overlay._rect_for(centre)
+    point = (x + width / 2, y + height / 2)
+
+    _drag(overlay, point, point, px_travel=MOVE_DRAG_THRESHOLD_PX - 1)
+
+    assert moved == [], "a press that did not travel must not move the grid"
+    assert toggled == [(1, 1, False)]
+
+
+def test_a_real_drag_does_not_also_toggle_the_tile_it_started_on(qapp):
+    overlay, _ = build(3, 3)
+    toggled = []
+    overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+    cx, cy = _centre(overlay)
+
+    _drag(overlay, (cx, cy), (cx + 400.0, cy))
+
+    assert toggled == []
+
+
+def test_a_press_inside_the_grid_claims_the_gesture(qapp):
+    """Otherwise the canvas pans underneath the move, and the grid and the view slide
+    apart by the same drag."""
+    overlay, _ = build(3, 3)
+    overlay._canvas._overlay_consuming_event = False
+
+    overlay._on_press(_event(overlay, *_centre(overlay)))
+
+    assert overlay._canvas._overlay_consuming_event is True
+
+
+def test_a_press_outside_the_grid_is_left_to_the_canvas(qapp):
+    """The canvas still has to be pannable. Claiming everything would take that away
+    for the sake of a gesture the pointer was nowhere near."""
+    overlay, _ = build(3, 3)
+    overlay._canvas._overlay_consuming_event = False
+    _, right, _, _ = _corners(overlay)
+
+    overlay._on_press(_event(overlay, right + 5 * WIDTH, overlay._rect.cy))
+
+    assert overlay._canvas._overlay_consuming_event is False
+
+
+def test_an_edge_press_still_resizes_rather_than_moving(qapp):
+    """Edges are inside the bounding box too, so the two gestures overlap. Resize wins,
+    matching the cursor shown there."""
+    overlay, _ = build(3, 3, overlap=OVERLAP)
+    moved = []
+    overlay.grid_move_requested.connect(lambda x, y: moved.append((x, y)))
+    right, _ = _edges(overlay)
+
+    _drag(overlay, (right, overlay._rect.cy), (right + WIDTH, overlay._rect.cy))
+
+    assert moved == []
+    assert overlay.is_resizing is False  # released
+
+
+def test_a_hidden_grid_cannot_be_moved(qapp):
+    overlay, _ = build(3, 3)
+    moved = []
+    overlay.grid_move_requested.connect(lambda x, y: moved.append((x, y)))
+    overlay.set_grid_visible(False)
+    cx, cy = _centre(overlay)
+
+    _drag(overlay, (cx, cy), (cx + 400.0, cy))
+
+    assert moved == []
+
+
+def test_the_interior_offers_a_move_cursor(qapp):
+    """The drag is undiscoverable without it -- nothing about a grid of rectangles
+    suggests the whole thing can be pushed around."""
+    from PyQt5.QtCore import Qt
+
+    overlay, _ = build(3, 3)
+
+    overlay._update_cursor(_event(overlay, *_centre(overlay)))
+
+    assert overlay._canvas.cursor == Qt.SizeAllCursor
+
+
+def test_a_move_drag_survives_the_grid_being_cleared_underneath_it(qapp):
+    """Same hazard as the resize drag: `_refresh_tile_grid` can clear the grid between
+    two motion events, and an exception escaping a handler can take the app down."""
+    overlay, _ = build(3, 3)
+    cx, cy = _centre(overlay)
+    overlay._on_press(_event(overlay, cx, cy))
+
+    overlay.clear()
+
+    overlay._on_drag(_event(overlay, cx + 400.0, cy, px=50.0, py=50.0))
+    overlay._on_release(_event(overlay, cx + 400.0, cy, px=50.0, py=50.0))


### PR DESCRIPTION
Stacked on #251 (FIB-412) — review that first; this PR's diff is only the 13 commits above it.

Makes the FM overview canvas something you steer by rather than only look at: double-click to move the stage, drag the planned grid to aim the next acquisition, and read the stage context you need to interpret what you are seeing.

## What it does

**Interaction**
- **Double-click to move the stage**, matching the minimap and the coincidence viewer. Guarded on an acquisition in progress, on the FM orientation, and on the stage limits, and confirmed by re-reading the stage rather than assuming it arrived.
- **Drag the tile grid to aim the next overview.** Sets a target and deliberately moves nothing — planning a run and driving the instrument are separate acts. The stage still returns to where it started when the run ends. "Centre on stage" in the grid options panel is the way back.
- **Hover reports the stage position under the cursor.** A canvas you have to click to get a coordinate out of cannot be used to decide whether to click.

**Context**
- Bounded zoom, the stage travel limits, the grid boundary, holder slots, and a marker for the current stage position — all drawn in the current stage orientation, since the origin's rotation and tilt are folded into the projection.

**Structure**
- `StageFrame` + `StageProjection` (`fibsem/ui/widgets/canvas/stage_frame.py`) extract the stage↔canvas mapping out of the widget: five helpers collapse into one `_frame()`, and the widget loses 159 lines. FIB-413 will supply a beam projection against the same protocol.
- `set_origin` lets a canvas be anchored at a chosen stage position (FIB-418), so an FM canvas at the offset mount and a FIB/SEM canvas at the column 48 mm away can coexist.

## Bugs fixed along the way

- **A closed widget crashed the application.** `stage_position_changed` is a psygnal that outlives the widget; the subscription was never removed, so closing the tab and moving the stage segfaulted (`exit 139`, reproducible). Two defects: psygnal cannot weakref a Qt signal's `emit`, *and* disconnecting one silently removes nothing without raising. Filed FIB-428 — the same pattern is in the coincidence viewer.
- **A dropped channel bled into the next overview.** `_upsert_layer` only ever adds, so a two-channel overview followed by a one-channel one drew the second with the first's second channel, then recorded it as the second's own. Measured: `_held['B']['Channel-02'] is _held['A']['Channel-02']`.
- **The planned grid was pinned to the canvas origin** — where the stage was the *first* time anything was drawn. Correct until the stage moved, and then quietly not.
- **The declared working area was pinned there too**, which stretched the content extent across the whole gap after a 48 mm shuttle move and capped the zoom: the limiter read the span as 482,406 px when what mattered was 1,126, and scroll-to-zoom-in was rejected outright.
- **The reported grid offset was measured in stage axes**, not in the frame it was drawn in — reversing the y sign on a compustage and hiding 70 µm of z on a pre-tilted mount.
- **Combined FM metadata dropped fields, geometry included** (FIB-416), which had made everything projected from a stage position vanish the moment an overview was acquired.

## Notes for review

- The runner's `centre_position` is split from `_initial_position`: one is where the grid goes, the other is where the stage comes home to. They were one value, which is why an offset overview was not possible before.
- The stage position is cached and refreshed from `stage_position_changed` rather than polled per use. `stage_position_changed` fires from *inside* `get_stage_position`, so it reports "a poll found it moved" — polling per use would add a round trip per spin-box keystroke without making the answer fresher, and would let the marker and the grid disagree.
- No beam projection yet. The beam side is not symmetric with the FM side (`calculate_reprojected_stage_position2` takes a whole `FibsemImage`, and its inverse needs a live microscope), so writing one now would be a signature invented with nothing to check it against.

## Testing

2150 passed, 16 skipped (the skips are the pre-existing plugin-fixture ones).

New: `tests/ui/test_stage_frame.py` (16, no widget and mostly no microscope), plus tile-grid drag, canvas interaction, channel retention, lifecycle, and runner `centre_position` coverage.

The `stage_frame` tests were mutation-checked rather than trusted green — dropping the centre offset fails nine of them, swapping dx/dy in the inverse fails six.

## Follow-ups filed

- FIB-417 — choose the objective position an overview starts from
- FIB-428 — psygnal subscriptions outliving their widgets (sweep)
- FIB-415 — per-image layer controls; changing a channel's colour currently restyles every overview that has it
