### PR TITLE
[autolamella] Don't create lamella directories when loading an experiment (FIB-420)

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -727,11 +727,14 @@ class Lamella:
     description: str = ""  # free-text note about the lamella
 
     def __post_init__(self):
-        # only make the dir, if the base path is actually set,
-        # prevents creating path on other computer..
-        if os.path.exists(os.path.dirname(self.path)):
-            os.makedirs(self.path, exist_ok=True)
-
+        # Deliberately does not create ``path``. Constructing a Lamella is not a
+        # request to write to disk, and on the load path this runs from
+        # ``from_dict`` with the as-created path out of the yaml -- before
+        # ``Experiment.load`` calls ``relocate``. Creating the directory here
+        # therefore wrote into whatever machine the experiment came from, at a
+        # path the caller never named. Directories are created where a lamella is
+        # actually created (``Experiment.add_new_lamella``) and where files are
+        # actually written (``FibsemImage.save``, ``save_thumbnail``). See FIB-420.
         if self._id is None:
             self._id = str(uuid.uuid4())
         self.task_state.lamella_id = self._id
@@ -953,6 +956,9 @@ class Lamella:
         data = image.filtered_data
         if data.ndim == 2:
             data = np.stack([data, data, data], axis=2)
+        # writes directly rather than through FibsemImage.save, so it makes its
+        # own directory -- construction no longer does (FIB-420).
+        os.makedirs(self.path, exist_ok=True)
         Image.fromarray(data.astype(np.uint8)).save(os.path.join(self.path, "thumbnail.png"))
 
     # def get_task_config_by_type(self, task_type: Type['AutoLamellaTaskConfig']) -> Dict[str, AutoLamellaTaskConfig]:

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -463,6 +464,16 @@ class FluorescenceImage:
             tifffile_image = self.data.reshape(1, nc, nz, ny, nx)
         else:
             tifffile_image = self.data
+
+        # Mirrors FibsemImage.save: the caller names a file, so the directory it
+        # lands in is this method's to create. AcquireFluorescenceTask writes a
+        # z-stack into the lamella directory without acquiring a beam image
+        # first, so this is the only thing that creates it -- and acquire_image
+        # swallows save failures, so a missing directory would lose the stack
+        # silently. dirname is empty for a bare filename, which makedirs rejects.
+        directory = os.path.dirname(filename)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
 
         # TODO: add overwrite protection to prevent overwriting existing files
         with tff.TiffWriter(filename) as tif:

--- a/tests/autolamella/test_structures.py
+++ b/tests/autolamella/test_structures.py
@@ -460,3 +460,63 @@ def test_milling_imaging_paths_follow_a_copied_experiment(tmp_path):
     for path in imaging_paths:
         assert Path(path) == Path(lamella.path)
         assert str(src) not in str(path)
+
+
+# ── Reading an experiment does not write to disk (FIB-420) ───────────────────
+
+def test_loading_a_copy_creates_nothing_at_the_original_path(tmp_path):
+    """Loading an experiment must not write to the filesystem.
+
+    __post_init__ used to makedirs(path). On the load path it runs from
+    from_dict with the as-created path out of the yaml -- *before*
+    Experiment.load calls relocate -- so loading a copy recreated the lamella
+    directories under the original experiment, at a path the caller never named.
+
+    The two tests above rmtree the source, so between them they only cover the
+    case where the original is already gone. This is the case FIB-367's own
+    docstring calls the dangerous one: the original still exists locally.
+    """
+    import shutil
+
+    src = tmp_path / "src"
+    exp = _experiment_on_disk(src)
+    original = Path(exp.positions[0].path)
+
+    dst = tmp_path / "dst"
+    shutil.copytree(exp.path, dst / "exp")
+    shutil.rmtree(original)  # the lamella directory goes; its parent stays
+
+    Experiment.load(str(dst / "exp" / "experiment.yaml"))
+
+    assert not original.exists(), f"loading a copy recreated {original}"
+
+
+def test_constructing_a_lamella_does_not_create_its_directory(tmp_path):
+    """The same rule stated narrowly, independent of Experiment.load."""
+    path = tmp_path / "lam"
+
+    Lamella(path=path, number=1, petname="lam")
+
+    assert not path.exists()
+
+
+def test_add_new_lamella_creates_the_lamella_directory(tmp_path):
+    """Creation still makes the directory -- tasks write reference images
+    straight into it, so the creating site owns that, not __post_init__."""
+    exp = _experiment_on_disk(tmp_path / "root")
+
+    assert Path(exp.positions[0].path).is_dir()
+
+
+def test_save_thumbnail_creates_the_lamella_directory(tmp_path):
+    """save_thumbnail writes directly rather than through FibsemImage.save, so it
+    makes its own directory now that construction does not."""
+    import numpy as np
+
+    from fibsem.structures import FibsemImage
+
+    lamella = Lamella(path=tmp_path / "lam", number=1, petname="lam")
+
+    lamella.save_thumbnail(FibsemImage(data=np.zeros((8, 8), dtype=np.uint8)))
+
+    assert (Path(lamella.path) / "thumbnail.png").is_file()

--- a/tests/fm/test_structures.py
+++ b/tests/fm/test_structures.py
@@ -492,6 +492,42 @@ def test_fluorescence_image_creation():
     assert image.metadata.channels[0].name == "GFP"
 
 
+def test_fluorescence_image_save_creates_the_directory(tmp_path):
+    """save() names a file, so it owns the directory that file lands in.
+
+    FibsemImage.save has always done this. The FM sibling did not, and
+    AcquireFluorescenceTask writes its z-stack into the lamella directory
+    without acquiring a beam image first -- so this is the only thing that
+    creates it. acquire_image swallows save failures, so a missing directory
+    would have lost the stack silently rather than raising. See FIB-420.
+    """
+    channel = FluorescenceChannelMetadata(
+        name="GFP",
+        excitation_wavelength=488.0,
+        emission_wavelength=520.0,
+        power=0.3,
+        exposure_time=0.05,
+        gain=1.0,
+        offset=0.0,
+    )
+    metadata = FluorescenceImageMetadata(
+        acquisition_date=datetime.now().isoformat(),
+        pixel_size_x=100e-9,
+        pixel_size_y=100e-9,
+        resolution=(16, 16),
+        channels=[channel],
+    )
+    image = FluorescenceImage(
+        data=np.zeros((1, 1, 16, 16), dtype=np.uint8), metadata=metadata
+    )
+    filename = tmp_path / "does" / "not" / "exist" / "stack.ome.tiff"
+
+    written = image.save(str(filename))
+
+    assert filename.is_file()
+    assert written == str(filename)
+
+
 def test_fluorescence_image_save_load_roundtrip():
     """Test save/load roundtrip with structured annotations."""
     # Create test data


### PR DESCRIPTION
Closes FIB-420.

## Problem

`Lamella.__post_init__` called `os.makedirs(self.path, exist_ok=True)` whenever the parent directory existed.

On the load path it runs from `Lamella.from_dict` with the **as-created absolute path stored in the yaml**, and only *afterwards* does `Experiment.load` call `relocate()` to re-point it. So loading a copied experiment recreated lamella directories at the original location:

```
A/run before load : ['experiment.yaml']
A/run AFTER load  : ['01-lam', 'experiment.yaml']   <-- recreated at the ORIGINAL path
```

Loading from `B` created a directory under `A`. Merely reading an experiment wrote to the filesystem, at a path the caller never named.

## Why removal rather than a guard

The call was not load-bearing:

- `Experiment.add_new_lamella` — the only live construction site — already calls `os.makedirs(lamella.path, exist_ok=True)` explicitly right after constructing the object.
- The other two construction sites (`compat/odemis.py`, `workflows/legacy/autoliftout.py`) already raise `TypeError` against the current dataclass — FIB-372. Left alone here; adding directory creation to code that cannot run would be noise.

So it was redundant where a directory is genuinely wanted, and wrong where it fired.

`save_thumbnail` was the one real dependant — it writes directly rather than through `FibsemImage.save` (which does its own `os.makedirs`), so it now makes its own directory.

## Test gap this closes

`test_lamella_path_follows_a_copied_experiment` and `test_milling_imaging_paths_follow_a_copied_experiment` both `shutil.rmtree(src)`, so between them they only exercise the case where the original is already **gone**. The case where the original still exists locally — which the first test's own docstring calls the dangerous one — was uncovered. That is why FIB-367 fixed the path re-pointing without catching this.

## Tests

Four added:

- loading a copy creates nothing at the original path
- constructing a `Lamella` creates no directory
- `add_new_lamella` still creates one
- `save_thumbnail` creates one

The first two were confirmed failing without the fix. Full suite: 2049 passed, 24 skipped (pre-existing environment skips — correlation LUT CSV and the plugin fixture).

Verified end to end that FIB-367 relocation still resolves correctly after the change.

## Context

Found while scoping a read-only web view of a running experiment (FIB-422), which needs to read experiment directories without mutating them. Pre-existing defect that stands on its own. Sibling cleanups: FIB-419 (atomic `experiment.yaml` write) and FIB-421 (`Experiment.load` hijacks the root logger).
