### PR TITLE
[fix] Guard the stage-frame tests like every other module in tests/ui

### DIFF
--- a/tests/ui/test_stage_frame.py
+++ b/tests/ui/test_stage_frame.py
@@ -15,6 +15,13 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 import numpy as np
 import pytest
 
+# `stage_frame` itself needs neither Qt nor napari -- it is geometry -- but importing it
+# runs `fibsem.ui.widgets.canvas.__init__`, which eagerly imports the whole canvas
+# package and so pulls both in. Both live in the `ui` extra, and CI installs only
+# `.[test]`, so the guard every other module in this directory carries is what keeps
+# collection from failing there rather than skipping.
+pytest.importorskip("PyQt5")
+
 from fibsem.fm.structures import CameraImageTransform, FMImageGeometry
 from fibsem.structures import FibsemStagePosition
 from fibsem.ui.widgets.canvas.stage_frame import FMStageProjection, StageFrame


### PR DESCRIPTION
Fixes the collection error that turned main red at b46d3e89.

`tests/ui/test_stage_frame.py` (added in #252) was the only module in `tests/ui/` without `pytest.importorskip("PyQt5")`, so collection failed on all six Python versions with `ModuleNotFoundError: No module named 'napari'`.

The module under test needs neither Qt nor napari — it is geometry — but importing it runs `fibsem/ui/widgets/canvas/__init__.py`, which eagerly imports the whole canvas package and pulls both in transitively. Both are in the `ui` extra; CI installs only `.[test]`.

Verified locally: 16 passed with the ui extra present, and the module skips rather than errors when PyQt5 is unimportable.