### PR TITLE
[fm] Delete the grid helpers nothing calls, and the scripts tests replaced (FIB-391)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -1372,53 +1372,6 @@ def acquire_multiple_overviews(
     return overview_images
 
 
-def generate_grid_positions(
-    ncols: int, nrows: int, fov_x: float, fov_y: float, overlap: float = 0.1
-) -> List[Tuple[float, float]]:
-    """Generate a grid of positions, centered around the origin, for acquiring tiles.
-
-    Creates a regular grid of (x, y) positions that are properly centered around the origin
-    (0, 0) for both odd and even numbers of columns and rows. The spacing between positions
-    accounts for the specified field of view and tile overlap.
-
-    Args:
-        ncols: Number of columns in the grid (must be positive)
-        nrows: Number of rows in the grid (must be positive)
-        fov_x: Horizontal field of view size in meters (physical dimension of each tile)
-        fov_y: Vertical field of view size in meters (physical dimension of each tile)
-        overlap: Fraction of overlap between adjacent tiles (0.0 to 1.0)
-
-    Returns:
-        List of (x, y) tuples representing grid positions in meters, centered around origin
-
-    Example:
-        >>> # 3x3 grid with 10μm x 8μm FOV and 10% overlap
-        >>> positions = generate_grid_positions(3, 3, 10e-6, 8e-6, 0.1)
-        >>> len(positions)
-        9
-        >>> positions[4]  # Center position
-        (0.0, 0.0)
-
-        >>> # 4x4 grid is also properly centered
-        >>> positions = generate_grid_positions(4, 4, 10e-6, 10e-6, 0.0)
-        >>> import numpy as np
-        >>> np.mean([pos[0] for pos in positions])  # Mean x should be ~0
-        0.0
-    """
-    positions = []
-    for i in range(ncols):
-        for j in range(nrows):
-            x = (i - (ncols - 1) / 2) * (fov_x * (1 - overlap))
-            # Negated so that row 0 is the top of the mosaic, matching
-            # `acquire_tileset`'s stepping and `TilePosition` in imaging/tiled.py.
-            # The grid is symmetric about zero, so this changes the row ordering
-            # without changing the set of positions visited.
-            y = -(j - (nrows - 1) / 2) * (fov_y * (1 - overlap))
-            positions.append((x, y))
-
-    return positions
-
-
 def convert_grid_positions_to_stage_positions(
     microscope: 'FibsemMicroscope',
     positions: List[Tuple[float, float]],
@@ -1442,7 +1395,7 @@ def convert_grid_positions_to_stage_positions(
 
     Example:
         >>> # Generate grid positions
-        >>> positions = generate_grid_positions(3, 3, 10e-6, 0.1)
+        >>> positions = [(0.0, 0.0), (9e-6, 0.0), (0.0, 9e-6)]
         >>> # Convert to stage positions
         >>> stage_positions = convert_grid_positions_to_stage_positions(
         ...     microscope, positions, BeamType.ELECTRON
@@ -1461,75 +1414,6 @@ def convert_grid_positions_to_stage_positions(
         )
         stage_positions.append(stage_position)
     return stage_positions
-
-
-def calculate_grid_size_for_area(
-    area_width: float,
-    area_height: float,
-    fov_x: float,
-    fov_y: float,
-    overlap: float = 0.1,
-) -> Tuple[int, int]:
-    """Calculate the number of rows and columns needed to cover a given area.
-
-    Determines the minimum grid dimensions required to fully cover a rectangular area
-    with the specified field of view and overlap between adjacent tiles.
-
-    Args:
-        area_width: Width of the area to cover in meters
-        area_height: Height of the area to cover in meters
-        fov_x: Horizontal field of view size in meters
-        fov_y: Vertical field of view size in meters
-        overlap: Fraction of overlap between adjacent tiles (0.0 to 1.0)
-
-    Returns:
-        Tuple of (ncols, nrows) representing the minimum grid dimensions needed
-
-    Raises:
-        ValueError: If area dimensions, FOV, or overlap are invalid
-
-    Example:
-        >>> # Cover a 100x80 μm area with 10x8 μm FOV and 10% overlap
-        >>> ncols, nrows = calculate_grid_size_for_area(100e-6, 80e-6, 10e-6, 8e-6, 0.1)
-        >>> print(f"Need {ncols}x{nrows} grid")
-        Need 12x11 grid
-
-        >>> # Cover a 50x50 μm area with 20x20 μm FOV and no overlap
-        >>> ncols, nrows = calculate_grid_size_for_area(50e-6, 50e-6, 20e-6, 20e-6, 0.0)
-        >>> print(f"Need {ncols}x{nrows} grid")
-        Need 3x3 grid
-    """
-    # Validate inputs
-    if area_width <= 0 or area_height <= 0:
-        raise ValueError("Area dimensions must be positive")
-    if fov_x <= 0 or fov_y <= 0:
-        raise ValueError("FOV dimensions must be positive")
-    if not 0.0 <= overlap < 1.0:
-        raise ValueError("Overlap must be between 0.0 and 1.0 (exclusive)")
-
-    # Calculate effective step size (distance between tile centers)
-    step_x = fov_x * (1.0 - overlap)
-    step_y = fov_y * (1.0 - overlap)
-
-    # Calculate number of tiles needed
-    # For n tiles, we need: (n-1) * step + fov >= area
-    # Solving for n: n >= (area - fov) / step + 1
-
-    if area_width <= fov_x:
-        # Area fits in single tile horizontally
-        ncols = 1
-    else:
-        # Need multiple tiles
-        ncols = int(np.ceil((area_width - fov_x) / step_x)) + 1
-
-    if area_height <= fov_y:
-        # Area fits in single tile vertically
-        nrows = 1
-    else:
-        # Need multiple tiles
-        nrows = int(np.ceil((area_height - fov_y) / step_y)) + 1
-
-    return ncols, nrows
 
 
 def calculate_grid_coverage_area(
@@ -1606,7 +1490,7 @@ def calculate_grid_dimensions(positions: List[Tuple[float, float]]) -> Tuple[int
         Returns (0, 0) if positions is empty
 
     Example:
-        >>> positions = generate_grid_positions(3, 4, 10e-6, 8e-6, 0.1)
+        >>> positions = [(x * 9e-6, y * 7.2e-6) for y in range(3) for x in range(4)]
         >>> ncols, nrows = calculate_grid_dimensions(positions)
         >>> print(f"Grid: {ncols}x{nrows}")
         Grid: 3x4
@@ -1657,7 +1541,7 @@ def calculate_grid_overlap(
         Returns (0.0, 0.0) if overlap cannot be determined
 
     Example:
-        >>> positions = generate_grid_positions(3, 3, 10e-6, 8e-6, 0.1)
+        >>> positions = [(x * 9e-6, y * 7.2e-6) for y in range(3) for x in range(3)]
         >>> overlap_x, overlap_y = calculate_grid_overlap(positions, 10e-6, 8e-6)
         >>> print(f"Horizontal overlap: {overlap_x:.1%}, Vertical overlap: {overlap_y:.1%}")
         Horizontal overlap: 10.0%, Vertical overlap: 10.0%
@@ -1702,158 +1586,3 @@ def calculate_grid_overlap(
         overlap_y = max(0.0, min(1.0, (fov_y - min_y_step) / fov_y))
 
     return overlap_x, overlap_y
-
-
-def plot_grid_positions(
-    positions: List[Tuple[float, float]],
-    fov_x: float,
-    fov_y: float,
-    title: str = "Grid Positions with FOV",
-    figsize: Tuple[float, float] = (8, 8),
-    show_fov_boxes: bool = True,
-    show_grid_lines: bool = True,
-    show_center_lines: bool = True,
-    show_overlap_info: bool = True,
-) -> None:
-    """Plot grid positions with field of view bounding boxes.
-
-    Creates a visualization of the grid positions showing:
-    - Grid positions as red circles
-    - FOV bounding boxes as dashed rectangles around each position
-    - Center lines (optional)
-    - Grid lines (optional)
-    - Calculated overlap information (optional)
-
-    Args:
-        positions: List of (x, y) tuples representing grid positions in meters
-        fov_x: Horizontal field of view size in meters
-        fov_y: Vertical field of view size in meters
-        title: Plot title
-        figsize: Figure size tuple (width, height)
-        show_fov_boxes: Whether to show FOV bounding boxes around each position
-        show_grid_lines: Whether to show grid lines
-        show_center_lines: Whether to show center axis lines
-        show_overlap_info: Whether to calculate and display overlap information
-
-    Example:
-        >>> positions = generate_grid_positions(3, 3, 10e-6, 8e-6, 0.1)
-        >>> plot_grid_positions(positions, 10e-6, 8e-6)
-    """
-    _, ax = plt.subplots(figsize=figsize)
-
-    # Plot grid positions as red circles
-    for pos in positions:
-        x, y = pos
-        ax.plot(
-            x,
-            y,
-            "ro",
-            markersize=8,
-            label="Grid Position" if pos == positions[0] else "",
-        )
-
-        # Draw FOV bounding box around each position
-        if show_fov_boxes:
-            # Create rectangle centered at position
-            rect = patches.Rectangle(
-                (x - fov_x / 2, y - fov_y / 2),  # Bottom-left corner
-                fov_x,
-                fov_y,  # Width and height
-                linewidth=1,
-                edgecolor="blue",
-                facecolor="none",
-                linestyle="--",
-                alpha=0.7,
-                label="FOV Boundary" if pos == positions[0] else "",
-            )
-            ax.add_patch(rect)
-
-    # Calculate plot limits from positions and FOV dimensions
-    if positions:
-        x_coords = [pos[0] for pos in positions]
-        y_coords = [pos[1] for pos in positions]
-
-        # Find the extent of positions
-        x_min, x_max = min(x_coords), max(x_coords)
-        y_min, y_max = min(y_coords), max(y_coords)
-
-        # Add FOV/2 to account for the bounding boxes around each position
-        # Plus some padding for better visualization
-        padding_x = fov_x * 0.25
-        padding_y = fov_y * 0.25
-
-        x_extent_min = x_min - fov_x / 2 - padding_x
-        x_extent_max = x_max + fov_x / 2 + padding_x
-        y_extent_min = y_min - fov_y / 2 - padding_y
-        y_extent_max = y_max + fov_y / 2 + padding_y
-
-        ax.set_xlim(x_extent_min, x_extent_max)
-        ax.set_ylim(y_extent_min, y_extent_max)
-    else:
-        # Fallback for empty positions
-        ax.set_xlim(-fov_x, fov_x)
-        ax.set_ylim(-fov_y, fov_y)
-
-    # Add center lines
-    if show_center_lines:
-        ax.axhline(0, color="black", linewidth=0.5, linestyle="--", alpha=0.5)
-        ax.axvline(0, color="black", linewidth=0.5, linestyle="--", alpha=0.5)
-
-    # Add grid lines
-    if show_grid_lines:
-        ax.grid(True, alpha=0.3)
-
-    # Labels and title
-    ax.set_xlabel("X Position (m)")
-    ax.set_ylabel("Y Position (m)")
-    ax.set_title(title)
-
-    # Add legend
-    ax.legend(loc="upper right")
-
-    # Equal aspect ratio for proper visualization
-    ax.set_aspect("equal", adjustable="box")
-
-    # Add text annotation with grid info
-    ncols, nrows = calculate_grid_dimensions(positions)
-    if ncols > 0 and nrows > 0:
-        info_text = (
-            f"Grid: {ncols}x{nrows}\nFOV: {fov_x * 1e6:.1f}x{fov_y * 1e6:.1f} μm"
-        )
-
-        # Calculate and add total grid area
-        overlap_x, overlap_y = (
-            calculate_grid_overlap(positions, fov_x, fov_y)
-            if show_overlap_info and len(positions) > 1
-            else (0.0, 0.0)
-        )
-        overlap = max(overlap_x, overlap_y)
-        total_width, total_height = calculate_grid_coverage_area(
-            ncols, nrows, fov_x, fov_y, overlap
-        )
-        info_text += f"\nArea: {total_width * 1e6:.1f}x{total_height * 1e6:.1f} μm"
-    else:
-        info_text = (
-            f"Positions: {len(positions)}\nFOV: {fov_x * 1e6:.1f}x{fov_y * 1e6:.1f} μm"
-        )
-
-    # Optionally add overlap information
-    if show_overlap_info and len(positions) > 1:
-        overlap_x, overlap_y = calculate_grid_overlap(positions, fov_x, fov_y)
-        if overlap_x > 0 or overlap_y > 0:
-            # Use the maximum overlap value (they should be the same for regular grids)
-            overlap = max(overlap_x, overlap_y)
-            info_text += f"\nOverlap: {overlap:.1%}"
-
-    ax.text(
-        0.02,
-        0.98,
-        info_text,
-        transform=ax.transAxes,
-        fontsize=10,
-        verticalalignment="top",
-        bbox=dict(boxstyle="round", facecolor="wheat", alpha=0.8),
-    )
-
-    plt.tight_layout()
-    plt.show()

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -18,9 +18,6 @@ from fibsem.fm.acquisition import (
     calculate_grid_coverage_area,
     calculate_grid_dimensions,
     calculate_grid_overlap,
-    calculate_grid_size_for_area,
-    generate_grid_positions,
-    plot_grid_positions,
     stitch_tileset,
 )
 from fibsem.fm.structures import (
@@ -50,270 +47,23 @@ def fm_microscope(demo_microscope):
     microscope.move_to_microscope("FM")
     return microscope
 
-def test_generate_grid_positions_odd_dimensions():
-    """Test grid position generation with odd numbers of columns and rows."""
-    # Test 3x3 grid
-    positions = generate_grid_positions(ncols=3, nrows=3, fov_x=10.0, fov_y=10.0, overlap=0.0)
+def _lattice(ncols, nrows, fov_x, fov_y, overlap):
+    """A grid of (x, y) positions, the shape the `calculate_grid_*` helpers consume.
 
-    # Should have 9 positions
-    assert len(positions) == 9
+    Built here rather than by a generator in `acquisition`: the generator that used to
+    do it had no production callers and was removed with the rest of the dead grid
+    helpers. These tests are about the *consumers*, which only read the spacing between
+    positions, so an explicit lattice says what they depend on rather than hiding it
+    behind a second function under test.
+    """
+    step_x, step_y = fov_x * (1 - overlap), fov_y * (1 - overlap)
+    return [(c * step_x, r * step_y) for r in range(nrows) for c in range(ncols)]
 
-    # Extract x and y coordinates
-    x_coords = [pos[0] for pos in positions]
-    y_coords = [pos[1] for pos in positions]
-
-    # For 3x3 grid with no overlap, step = 10.0
-    # Positions should be at offsets: -1, 0, 1 (centered around 0)
-    expected_coords = [-10.0, 0.0, 10.0]
-
-    # Check that we have the expected coordinate values
-    assert sorted(set(x_coords)) == expected_coords
-    assert sorted(set(y_coords)) == expected_coords
-
-    # Check specific positions. Row 0 is the top of the mosaic, so the top-left
-    # corner is at positive y -- these were labelled the other way round while the
-    # row direction was inverted, and the labels were the only thing that noticed.
-    assert (-10.0, 10.0) in positions   # Top-left
-    assert (0.0, 0.0) in positions      # Center
-    assert (10.0, -10.0) in positions   # Bottom-right
-
-def test_generate_grid_positions_even_dimensions():
-    """Test grid position generation with even numbers of columns and rows."""
-    # Test 4x4 grid
-    positions = generate_grid_positions(ncols=4, nrows=4, fov_x=10.0, fov_y=10.0, overlap=0.0)
-
-    # Should have 16 positions
-    assert len(positions) == 16
-
-    # Extract x and y coordinates
-    x_coords = [pos[0] for pos in positions]
-    y_coords = [pos[1] for pos in positions]
-
-    # For 4x4 grid with no overlap, step = 10.0
-    # Positions should be at offsets: -1.5, -0.5, 0.5, 1.5 (centered around 0)
-    expected_coords = [-15.0, -5.0, 5.0, 15.0]
-
-    # Check that we have the expected coordinate values
-    assert sorted(set(x_coords)) == expected_coords
-    assert sorted(set(y_coords)) == expected_coords
-
-    # Check that the grid is centered (mean should be close to 0)
-    assert abs(np.mean(x_coords)) < 1e-10
-    assert abs(np.mean(y_coords)) < 1e-10
-
-def test_generate_grid_positions_with_overlap():
-    """Test grid position generation with tile overlap."""
-    # Test 3x3 grid with 20% overlap
-    positions = generate_grid_positions(ncols=3, nrows=3, fov_x=10.0, fov_y=10.0, overlap=0.2)
-
-    # Should have 9 positions
-    assert len(positions) == 9
-
-    # Extract x and y coordinates
-    x_coords = [pos[0] for pos in positions]
-    y_coords = [pos[1] for pos in positions]
-
-    # With 20% overlap, step = 10.0 * (1 - 0.2) = 8.0
-    # Positions should be at offsets: -1, 0, 1 → -8.0, 0.0, 8.0
-    expected_coords = [-8.0, 0.0, 8.0]
-
-    # Check that we have the expected coordinate values
-    assert sorted(set(x_coords)) == expected_coords
-    assert sorted(set(y_coords)) == expected_coords
-
-    # Check that the grid is centered
-    assert abs(np.mean(x_coords)) < 1e-10
-    assert abs(np.mean(y_coords)) < 1e-10
-
-def test_generate_grid_positions_centering():
-    """Test that grid positions are properly centered for various dimensions."""
-    test_cases = [
-        (1, 1),   # Single position
-        (2, 2),   # Even x even
-        (3, 3),   # Odd x odd
-        (2, 3),   # Even x odd
-        (3, 2),   # Odd x even
-        (4, 6),   # Even x even (different sizes)
-        (5, 7),   # Odd x odd (different sizes)
-    ]
-
-    for ncols, nrows in test_cases:
-        positions = generate_grid_positions(ncols=ncols, nrows=nrows, fov_x=10.0, fov_y=10.0, overlap=0.0)
-
-        # Should have correct number of positions
-        assert len(positions) == ncols * nrows
-
-        # Extract coordinates
-        x_coords = [pos[0] for pos in positions]
-        y_coords = [pos[1] for pos in positions]
-
-        # Grid should be centered (mean should be 0)
-        assert abs(np.mean(x_coords)) < 1e-10, f"Failed for {ncols}x{nrows}: x_mean = {np.mean(x_coords)}"
-        assert abs(np.mean(y_coords)) < 1e-10, f"Failed for {ncols}x{nrows}: y_mean = {np.mean(y_coords)}"
-
-def test_generate_grid_positions_single_dimension():
-    """Test grid position generation with single row or column."""
-    # Test 1x3 grid (single row)
-    positions = generate_grid_positions(ncols=1, nrows=3, fov_x=10.0, fov_y=10.0, overlap=0.0)
-
-    assert len(positions) == 3
-    x_coords = [pos[0] for pos in positions]
-    y_coords = [pos[1] for pos in positions]
-
-    # Only one column, so all x should be 0
-    assert all(x == 0.0 for x in x_coords)
-    # Y coordinates should be -10, 0, 10
-    assert sorted(y_coords) == [-10.0, 0.0, 10.0]
-
-    # Test 3x1 grid (single column)
-    positions = generate_grid_positions(ncols=3, nrows=1, fov_x=10.0, fov_y=10.0, overlap=0.0)
-
-    assert len(positions) == 3
-    x_coords = [pos[0] for pos in positions]
-    y_coords = [pos[1] for pos in positions]
-
-    # Only one row, so all y should be 0
-    assert all(y == 0.0 for y in y_coords)
-    # X coordinates should be -10, 0, 10
-    assert sorted(x_coords) == [-10.0, 0.0, 10.0]
-
-def test_generate_grid_positions_return_type():
-    """Test that function returns the correct data types."""
-    positions = generate_grid_positions(ncols=2, nrows=2, fov_x=10.0, fov_y=10.0, overlap=0.1)
-
-    # Should return list of tuples
-    assert isinstance(positions, list)
-    assert len(positions) == 4
-
-    for pos in positions:
-        assert isinstance(pos, tuple)
-        assert len(pos) == 2
-        assert isinstance(pos[0], float)
-        assert isinstance(pos[1], float)
-
-def test_generate_grid_positions_different_fov():
-    """Test grid position generation with different horizontal and vertical FOV values."""
-    # Test 2x2 grid with wider horizontal FOV
-    positions = generate_grid_positions(ncols=2, nrows=2, fov_x=20.0, fov_y=10.0, overlap=0.0)
-
-    # Should have 4 positions
-    assert len(positions) == 4
-
-    # Extract x and y coordinates
-    x_coords = [pos[0] for pos in positions]
-    y_coords = [pos[1] for pos in positions]
-
-    # For 2x2 grid with no overlap:
-    # X step = 20.0, positions at offsets: -0.5, 0.5 → -10.0, 10.0
-    # Y step = 10.0, positions at offsets: -0.5, 0.5 → -5.0, 5.0
-    expected_x_coords = [-10.0, 10.0]
-    expected_y_coords = [-5.0, 5.0]
-
-    assert sorted(set(x_coords)) == expected_x_coords
-    assert sorted(set(y_coords)) == expected_y_coords
-
-    # Check that grid is centered
-    assert abs(np.mean(x_coords)) < 1e-10
-    assert abs(np.mean(y_coords)) < 1e-10
-
-    # Check specific positions
-    assert (-10.0, -5.0) in positions
-    assert (10.0, -5.0) in positions
-    assert (-10.0, 5.0) in positions
-    assert (10.0, 5.0) in positions
-
-def test_generate_grid_positions_rectangular_fov():
-    """Test grid position generation with rectangular FOV (taller than wide)."""
-    # Test 3x3 grid with taller vertical FOV
-    positions = generate_grid_positions(ncols=3, nrows=3, fov_x=8.0, fov_y=12.0, overlap=0.0)
-
-    # Should have 9 positions
-    assert len(positions) == 9
-
-    # Extract x and y coordinates
-    x_coords = [pos[0] for pos in positions]
-    y_coords = [pos[1] for pos in positions]
-
-    # For 3x3 grid with no overlap:
-    # X step = 8.0, positions at offsets: -1, 0, 1 → -8.0, 0.0, 8.0
-    # Y step = 12.0, positions at offsets: -1, 0, 1 → -12.0, 0.0, 12.0
-    expected_x_coords = [-8.0, 0.0, 8.0]
-    expected_y_coords = [-12.0, 0.0, 12.0]
-
-    assert sorted(set(x_coords)) == expected_x_coords
-    assert sorted(set(y_coords)) == expected_y_coords
-
-    # Check that grid is centered
-    assert abs(np.mean(x_coords)) < 1e-10
-    assert abs(np.mean(y_coords)) < 1e-10
-
-    # Check corner positions
-    assert (-8.0, -12.0) in positions  # Top-left
-    assert (0.0, 0.0) in positions     # Center
-    assert (8.0, 12.0) in positions    # Bottom-right
-
-def test_generate_grid_positions_asymmetric_fov_with_overlap():
-    """Test grid position generation with asymmetric FOV and tile overlap."""
-    # Test 2x3 grid with different FOV values and overlap
-    positions = generate_grid_positions(ncols=2, nrows=3, fov_x=15.0, fov_y=9.0, overlap=0.2)
-
-    # Should have 6 positions
-    assert len(positions) == 6
-
-    # Extract x and y coordinates
-    x_coords = [pos[0] for pos in positions]
-    y_coords = [pos[1] for pos in positions]
-
-    # With 20% overlap:
-    # X step = 15.0 * (1 - 0.2) = 12.0, positions at offsets: -0.5, 0.5 → -6.0, 6.0
-    # Y step = 9.0 * (1 - 0.2) = 7.2, positions at offsets: -1, 0, 1 → -7.2, 0.0, 7.2
-    expected_x_coords = [-6.0, 6.0]
-    expected_y_coords = [-7.2, 0.0, 7.2]
-
-    assert sorted(set(x_coords)) == expected_x_coords
-    assert sorted(set(y_coords)) == expected_y_coords
-
-    # Check that grid is centered
-    assert abs(np.mean(x_coords)) < 1e-10
-    assert abs(np.mean(y_coords)) < 1e-10
-
-    # Check some specific positions
-    assert (-6.0, -7.2) in positions
-    assert (6.0, 0.0) in positions
-    assert (-6.0, 7.2) in positions
-
-def test_generate_grid_positions_extreme_aspect_ratio():
-    """Test grid position generation with extreme aspect ratio FOV."""
-    # Test 4x1 grid with very wide horizontal FOV
-    positions = generate_grid_positions(ncols=4, nrows=1, fov_x=40.0, fov_y=5.0, overlap=0.0)
-
-    # Should have 4 positions
-    assert len(positions) == 4
-
-    # Extract x and y coordinates
-    x_coords = [pos[0] for pos in positions]
-    y_coords = [pos[1] for pos in positions]
-
-    # For 4x1 grid with no overlap:
-    # X step = 40.0, positions at offsets: -1.5, -0.5, 0.5, 1.5 → -60.0, -20.0, 20.0, 60.0
-    # Y step = 5.0, only one row so all y = 0.0
-    expected_x_coords = [-60.0, -20.0, 20.0, 60.0]
-    expected_y_coords = [0.0]
-
-    assert sorted(set(x_coords)) == expected_x_coords
-    assert sorted(set(y_coords)) == expected_y_coords
-
-    # Check that all y coordinates are 0 (single row)
-    assert all(y == 0.0 for y in y_coords)
-
-    # Check that grid is centered
-    assert abs(np.mean(x_coords)) < 1e-10
-    assert abs(np.mean(y_coords)) < 1e-10
 
 def test_calculate_grid_overlap():
     """Test overlap calculation from grid positions."""
     # Test with known overlap
-    positions = generate_grid_positions(ncols=3, nrows=3, fov_x=10.0, fov_y=8.0, overlap=0.2)
+    positions = _lattice(ncols=3, nrows=3, fov_x=10.0, fov_y=8.0, overlap=0.2)
     overlap_x, overlap_y = calculate_grid_overlap(positions, 10.0, 8.0)
 
     # Should recover the original overlap (within small tolerance)
@@ -321,14 +71,14 @@ def test_calculate_grid_overlap():
     assert abs(overlap_y - 0.2) < 1e-10
 
     # Test with no overlap
-    positions_no_overlap = generate_grid_positions(ncols=2, nrows=2, fov_x=5.0, fov_y=5.0, overlap=0.0)
+    positions_no_overlap = _lattice(ncols=2, nrows=2, fov_x=5.0, fov_y=5.0, overlap=0.0)
     overlap_x, overlap_y = calculate_grid_overlap(positions_no_overlap, 5.0, 5.0)
 
     assert abs(overlap_x - 0.0) < 1e-10
     assert abs(overlap_y - 0.0) < 1e-10
 
     # Test with different horizontal and vertical overlaps
-    positions_asym = generate_grid_positions(ncols=2, nrows=3, fov_x=10.0, fov_y=6.0, overlap=0.15)
+    positions_asym = _lattice(ncols=2, nrows=3, fov_x=10.0, fov_y=6.0, overlap=0.15)
     overlap_x, overlap_y = calculate_grid_overlap(positions_asym, 10.0, 6.0)
 
     assert abs(overlap_x - 0.15) < 1e-10
@@ -344,28 +94,28 @@ def test_calculate_grid_overlap():
 def test_calculate_grid_dimensions():
     """Test grid dimension calculation from positions."""
     # Test 3x4 grid
-    positions = generate_grid_positions(ncols=3, nrows=4, fov_x=10.0, fov_y=8.0, overlap=0.1)
+    positions = _lattice(ncols=3, nrows=4, fov_x=10.0, fov_y=8.0, overlap=0.1)
     ncols, nrows = calculate_grid_dimensions(positions)
 
     assert ncols == 3
     assert nrows == 4
 
     # Test 2x2 grid
-    positions_2x2 = generate_grid_positions(ncols=2, nrows=2, fov_x=5.0, fov_y=5.0, overlap=0.0)
+    positions_2x2 = _lattice(ncols=2, nrows=2, fov_x=5.0, fov_y=5.0, overlap=0.0)
     ncols, nrows = calculate_grid_dimensions(positions_2x2)
 
     assert ncols == 2
     assert nrows == 2
 
     # Test 1x5 grid (single row)
-    positions_1x5 = generate_grid_positions(ncols=1, nrows=5, fov_x=10.0, fov_y=10.0, overlap=0.0)
+    positions_1x5 = _lattice(ncols=1, nrows=5, fov_x=10.0, fov_y=10.0, overlap=0.0)
     ncols, nrows = calculate_grid_dimensions(positions_1x5)
 
     assert ncols == 1
     assert nrows == 5
 
     # Test 7x1 grid (single column)
-    positions_7x1 = generate_grid_positions(ncols=7, nrows=1, fov_x=10.0, fov_y=10.0, overlap=0.0)
+    positions_7x1 = _lattice(ncols=7, nrows=1, fov_x=10.0, fov_y=10.0, overlap=0.0)
     ncols, nrows = calculate_grid_dimensions(positions_7x1)
 
     assert ncols == 7
@@ -386,66 +136,11 @@ def test_calculate_grid_dimensions():
     assert nrows == 1
 
     # Test with different overlaps (should still give same dimensions)
-    positions_overlap = generate_grid_positions(ncols=4, nrows=3, fov_x=10.0, fov_y=10.0, overlap=0.25)
+    positions_overlap = _lattice(ncols=4, nrows=3, fov_x=10.0, fov_y=10.0, overlap=0.25)
     ncols, nrows = calculate_grid_dimensions(positions_overlap)
 
     assert ncols == 4
     assert nrows == 3
-
-def test_calculate_grid_size_for_area():
-    """Test calculation of grid size needed to cover an area."""
-    # Test exact fit (no overlap)
-    ncols, nrows = calculate_grid_size_for_area(30.0, 20.0, 10.0, 10.0, 0.0)
-    assert ncols == 3
-    assert nrows == 2
-
-    # Test with overlap
-    ncols, nrows = calculate_grid_size_for_area(30.0, 20.0, 10.0, 10.0, 0.1)
-    # With 10% overlap, step = 9.0, so we need more tiles
-    assert ncols == 4  # (30 - 10) / 9 + 1 = 3.22... -> 4
-    assert nrows == 3  # (20 - 10) / 9 + 1 = 2.11... -> 3
-
-    # Test area smaller than FOV
-    ncols, nrows = calculate_grid_size_for_area(5.0, 8.0, 10.0, 10.0, 0.0)
-    assert ncols == 1
-    assert nrows == 1
-
-    # Test area exactly equal to FOV
-    ncols, nrows = calculate_grid_size_for_area(10.0, 10.0, 10.0, 10.0, 0.0)
-    assert ncols == 1
-    assert nrows == 1
-
-    # Test with different FOV dimensions
-    ncols, nrows = calculate_grid_size_for_area(100.0, 60.0, 15.0, 12.0, 0.2)
-    # step_x = 15 * 0.8 = 12, step_y = 12 * 0.8 = 9.6
-    # ncols = ceil((100 - 15) / 12) + 1 = ceil(85/12) + 1 = 8 + 1 = 9
-    # nrows = ceil((60 - 12) / 9.6) + 1 = ceil(48/9.6) + 1 = 5 + 1 = 6
-    assert ncols == 9
-    assert nrows == 6
-
-    # Test error conditions
-    import pytest
-
-    # Negative area dimensions
-    with pytest.raises(ValueError, match="Area dimensions must be positive"):
-        calculate_grid_size_for_area(-10.0, 20.0, 10.0, 10.0, 0.1)
-
-    # Zero FOV
-    with pytest.raises(ValueError, match="FOV dimensions must be positive"):
-        calculate_grid_size_for_area(30.0, 20.0, 0.0, 10.0, 0.1)
-
-    # Invalid overlap
-    with pytest.raises(ValueError, match="Overlap must be between 0.0 and 1.0"):
-        calculate_grid_size_for_area(30.0, 20.0, 10.0, 10.0, 1.0)
-
-    # Test single row/column scenarios
-    ncols, nrows = calculate_grid_size_for_area(50.0, 8.0, 10.0, 10.0, 0.0)
-    assert ncols == 5
-    assert nrows == 1
-
-    ncols, nrows = calculate_grid_size_for_area(8.0, 50.0, 10.0, 10.0, 0.0)
-    assert ncols == 1
-    assert nrows == 5
 
 def test_calculate_grid_coverage_area():
     """Test calculation of total area covered by a grid."""
@@ -485,26 +180,6 @@ def test_calculate_grid_coverage_area():
     # width = (3-1) * 12 + 15 = 39, height = (4-1) * 9.6 + 12 = 40.8
     assert np.isclose(width, 39.0)
     assert np.isclose(height, 40.8)
-
-    # Test reciprocal relationship with calculate_grid_size_for_area
-    # Generate a grid size for an area, then calculate the area it covers
-    target_width, target_height = 100.0, 80.0
-    fov_x, fov_y = 10.0, 8.0
-    overlap = 0.15
-
-    # Calculate required grid size
-    ncols, nrows = calculate_grid_size_for_area(target_width, target_height, fov_x, fov_y, overlap)
-
-    # Calculate area covered by that grid
-    actual_width, actual_height = calculate_grid_coverage_area(ncols, nrows, fov_x, fov_y, overlap)
-
-    # Should cover at least the target area
-    assert actual_width >= target_width
-    assert actual_height >= target_height
-
-    # Should not be too much larger (within one tile's worth)
-    assert actual_width <= target_width + fov_x
-    assert actual_height <= target_height + fov_y
 
     # Test error conditions
     import pytest


### PR DESCRIPTION
Clears the two remaining items on FIB-391. Both are removal.

## Dead grid helpers

`generate_grid_positions`, `calculate_grid_size_for_area` and `plot_grid_positions` have had no production callers since FM tileset acquisition moved onto the shared geometry core. Every reference outside their own definitions was a docstring `>>>` or a test — ~270 lines of module held up by ~40 test references, for three functions the application never reaches.

Eleven tests exercised nothing else and go with them.

Three tests that check *surviving* helpers (`calculate_grid_overlap`, `calculate_grid_dimensions`, `calculate_grid_coverage_area`) were using the removed generator to build their inputs. They now build the lattice explicitly via a local `_lattice()`, which is better regardless: a fixture that calls a second function under test hides what the assertion actually depends on. The reciprocal check between coverage-area and size-for-area goes too, since one side of the reciprocity no longer exists.

Docstring examples on `convert_grid_positions_to_stage_positions`, `calculate_grid_dimensions` and `calculate_grid_overlap` referenced the removed generator and now show literal positions.

## Diagnostic scripts

`scripts/fm_tileset_record.py`, `fm_tileset_plot.py` and `fm_reprojection_plot.py` were untracked local tools, listed on FIB-391 as still-to-land. They are superseded rather than pending, so they are gone rather than committed:

- `test_acquire_tileset_row_direction_matches_the_beam_tiler` does what the record/plot pair did — `_record_tile_positions` captures where tiles *actually* land during a run, then pins the FM tiler against the beam tiler directionally. That is the #226 property, asserted rather than eyeballed.
- `tests/ui/test_stage_frame.py` covers the reprojection plot: round-trip exactness, camera flips, both mount geometries.

No diff for these — they were never tracked.

## Testing

2139 passed, 16 skipped. That is 2150 minus the 11 deleted tests; the skips are the pre-existing plugin-fixture ones.

## Follow-up

FIB-391's other two unticked boxes are not work: progress-vocabulary convergence was a decision not to do it (FIB-400/401 own that area now), and hardware verification is delegated to FIB-334. The issue is closeable once this lands.
