### PR TITLE
[autolamella] Configure logging when the app adopts an experiment, not on load (FIB-421)

### DIFF
--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -24,6 +24,19 @@ for lamella in exp.positions:
 
 If a `protocol.yaml` sits next to `experiment.yaml`, it is loaded automatically into `exp.task_protocol`. That matters for two of the helpers below — see [Gotchas](#gotchas).
 
+### Logging
+
+Loading an experiment does not touch your script's logging, so `logging.info(...)` goes wherever your script already sends it — and if you have not set that up, Python discards anything below `WARNING`. Ask for the experiment's logfile explicitly if you want your output alongside the run:
+
+```python
+exp = Experiment.load("/path/to/my-experiment/experiment.yaml")
+exp.configure_logging()          # now logging.info(...) lands in the experiment folder
+
+logging.info("this shows up in <experiment>/logfile.log")
+```
+
+This reconfigures the root logger for the whole process, so a script that already logs somewhere will stop. Read-only scripts are usually better off leaving it alone — writing into the logfile of a run that may still be going mixes your lines into its record.
+
 ## What you get
 
 On the experiment:
@@ -229,7 +242,7 @@ What you return decides how it is shown:
 | a `Path` | toast, and the containing folder opens |
 | `None` | a "finished" toast |
 
-`ctx.log("...")` writes to the log file, tagged with the script name so the lines stay attributable afterwards. Plain `logging.info(...)` works too and goes to the same place, just untagged.
+`ctx.log("...")` writes to the log file, tagged with the script name so the lines stay attributable afterwards. Plain `logging.info(...)` works too and goes to the same place, just untagged. Both land in the open experiment's logfile because the app is already logging there — a script run standalone has to ask for that itself, see [Logging](#logging).
 
 ### Flags
 

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -41,6 +41,7 @@ from fibsem.structures import (
     Point,
     ReferenceImageParameters,
 )
+from fibsem.utils import configure_logging as _configure_logging
 from fibsem.utils import format_duration
 
 if TYPE_CHECKING:
@@ -1339,6 +1340,28 @@ class Experiment:
         logging.info(f"Created new experiment {experiment.name} at {experiment.path}")
 
         return experiment
+
+    def configure_logging(self) -> str:
+        """Send this process's log output to the experiment's logfile.
+
+        Note this reconfigures the *root* logger: it is process-global, not
+        scoped to this experiment, and it replaces whatever handlers were set up
+        before. Two consequences worth knowing before calling it:
+
+        * a process that logs elsewhere stops doing so
+        * a second call points logging at the second experiment
+
+        ``load`` and ``create`` deliberately do not call this. Reading an
+        experiment must not reach into the caller's logging -- the load dialog
+        reads one on every click to preview it -- so the callers that do want it
+        say so. The app calls this when it adopts an experiment; a headless
+        script that wants its output in the experiment folder calls it after
+        loading or creating one. See FIB-421.
+
+        Returns:
+            The path of the logfile being written to.
+        """
+        return _configure_logging(path=self.path, log_filename="logfile")
 
     def save_protocol(self) -> None:
         """Save the task protocol to disk in the experiment directory."""

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -41,7 +41,7 @@ from fibsem.structures import (
     Point,
     ReferenceImageParameters,
 )
-from fibsem.utils import configure_logging, format_duration
+from fibsem.utils import format_duration
 
 if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
@@ -1146,8 +1146,12 @@ class Experiment:
         for lamella in experiment.positions:
             lamella.relocate(experiment.path)
 
-        # configure experiment logging
-        configure_logging(path=experiment.path, log_filename="logfile")
+        # NOTE: deliberately does not configure logging. configure_logging calls
+        # basicConfig(force=True), which closes and replaces every root handler --
+        # so reading an experiment would reach into the calling process's global
+        # logging and redirect its output into this experiment's logfile. Callers
+        # that want that ask for it: the app does so when it adopts an experiment.
+        # See FIB-421.
 
         # attempt to load task protocol from the same directory
         protocol_path = os.path.join(experiment.path, "protocol.yaml")
@@ -1323,9 +1327,11 @@ class Experiment:
         # create the experiment
         experiment = Experiment(path=path, name=name, metadata=metadata)
 
-        # configure experiment logging
         os.makedirs(experiment.path, exist_ok=True)
-        configure_logging(path=experiment.path, log_filename="logfile")
+
+        # NOTE: as with load(), creating an experiment does not reconfigure the
+        # calling process's logging -- the app does that when it adopts one.
+        # See FIB-421.
 
         # save the experiment
         experiment.save()

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -597,16 +597,7 @@ class AutoLamellaUI(QMainWindow):
             notification_service.show_toast("Experiment creation cancelled.", "info")
             return
 
-        # Disconnect existing event subscribers if there's an existing experiment
-        self._disconnect_experiment_events()
-
-        # Assign the experiment
-        self.experiment = experiment
-
-        # Setup experiment connections and update UI
-        self._setup_experiment_connections()
-
-        self.experiment_update_signal.emit()
+        self._adopt_experiment(experiment)
 
     def load_experiment(self) -> None:
         """Load an existing experiment using the experiment loading dialog."""
@@ -623,11 +614,27 @@ class AutoLamellaUI(QMainWindow):
             notification_service.show_toast("Experiment loading cancelled.", "info")
             return
 
+        self._adopt_experiment(experiment)
+
+    def _adopt_experiment(self, experiment: Experiment) -> None:
+        """Make ``experiment`` the current one, and point logging at its logfile.
+
+        The single place the app takes ownership of an experiment, whether it was
+        just created or loaded from disk. Logging is configured here rather than in
+        Experiment.load/create because those are also called to *read* an
+        experiment -- the load dialog calls load() on every single click to preview
+        a recent entry, which previously repointed the app's root logger at each one
+        in turn, and closed the previous handler, even when the dialog was then
+        cancelled. See FIB-421.
+        """
         # Disconnect existing event subscribers if there's an existing experiment
         self._disconnect_experiment_events()
 
         # Assign the experiment
         self.experiment = experiment
+
+        utils.configure_logging(path=experiment.path, log_filename="logfile")
+        logging.info(f"Logging to experiment {experiment.name} at {experiment.path}")
 
         # Setup experiment connections and update UI
         self._setup_experiment_connections()

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -633,7 +633,7 @@ class AutoLamellaUI(QMainWindow):
         # Assign the experiment
         self.experiment = experiment
 
-        utils.configure_logging(path=experiment.path, log_filename="logfile")
+        experiment.configure_logging()
         logging.info(f"Logging to experiment {experiment.name} at {experiment.path}")
 
         # Setup experiment connections and update UI

--- a/tests/autolamella/test_structures.py
+++ b/tests/autolamella/test_structures.py
@@ -488,6 +488,34 @@ def test_create_does_not_touch_the_calling_process_logging(tmp_path):
         logging.basicConfig(handlers=[logging.NullHandler()], force=True)
 
 
+def test_configure_logging_sends_output_to_the_experiment_logfile(tmp_path):
+    """The explicit opt-in that replaces the old side effect.
+
+    A headless script gets no experiment logfile from load()/create() any more,
+    and with no handler configured Python discards anything below WARNING -- so
+    without this the output does not go somewhere else, it disappears.
+    """
+    import logging
+
+    exp = _experiment_on_disk(tmp_path / "src")
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    try:
+        logfile = exp.configure_logging()
+
+        logging.info("from a standalone script")
+        for handler in root.handlers:
+            handler.flush()
+
+        assert Path(logfile) == Path(exp.path) / "logfile.log"
+        assert "from a standalone script" in Path(logfile).read_text()
+    finally:
+        for handler in list(root.handlers):
+            if handler not in saved:
+                handler.close()
+        root.handlers = saved
+
+
 def test_milling_imaging_paths_follow_a_copied_experiment(tmp_path):
     """Milling configs carry their own acquisition imaging path, copied from the
     lamella in __post_init__. Correcting `path` alone would leave acquisitions

--- a/tests/autolamella/test_structures.py
+++ b/tests/autolamella/test_structures.py
@@ -434,6 +434,60 @@ def test_lamella_path_follows_a_copied_experiment(tmp_path):
     assert Path(lamella.path).exists()
 
 
+def _root_handler_files() -> List[str]:
+    """The files the root logger is currently writing to."""
+    import logging
+
+    return [
+        getattr(h, "baseFilename", "")
+        for h in logging.getLogger().handlers
+        if getattr(h, "baseFilename", None)
+    ]
+
+
+def test_load_does_not_touch_the_calling_process_logging(tmp_path):
+    """Reading an experiment must not reach into global logging.
+
+    configure_logging calls basicConfig(force=True), which closes and replaces
+    every root handler. Calling it from load() meant any process that read an
+    experiment lost its own logging configuration and had its output redirected
+    into that experiment's logfile -- including the load dialog, which calls
+    load() on every single click to preview a recent entry. See FIB-421.
+    """
+    import logging
+
+    exp = _experiment_on_disk(tmp_path / "src")
+
+    own = logging.FileHandler(tmp_path / "caller.log")
+    logging.basicConfig(handlers=[own], level=logging.INFO, force=True)
+    try:
+        before = _root_handler_files()
+
+        Experiment.load(os.path.join(exp.path, "experiment.yaml"))
+
+        assert _root_handler_files() == before
+        assert not own.stream.closed, "the caller's own handler was closed"
+    finally:
+        logging.basicConfig(handlers=[logging.NullHandler()], force=True)
+
+
+def test_create_does_not_touch_the_calling_process_logging(tmp_path):
+    """Same rule for create(): the app configures logging when it adopts an
+    experiment, not as a side effect of the object existing."""
+    import logging
+
+    own = logging.FileHandler(tmp_path / "caller.log")
+    logging.basicConfig(handlers=[own], level=logging.INFO, force=True)
+    try:
+        before = _root_handler_files()
+
+        Experiment.create(path=tmp_path / "root", name="exp")
+
+        assert _root_handler_files() == before
+    finally:
+        logging.basicConfig(handlers=[logging.NullHandler()], force=True)
+
+
 def test_milling_imaging_paths_follow_a_copied_experiment(tmp_path):
     """Milling configs carry their own acquisition imaging path, copied from the
     lamella in __post_init__. Correcting `path` alone would leave acquisitions

--- a/tests/ui/test_experiment_adoption_logging.py
+++ b/tests/ui/test_experiment_adoption_logging.py
@@ -1,0 +1,130 @@
+"""Where the app points its logging when it takes on an experiment (FIB-421).
+
+`Experiment.load` and `Experiment.create` no longer configure logging -- reading
+an experiment must not reach into the calling process's global logging, and the
+load dialog calls `load()` on every single click to preview a recent entry. The
+app therefore has to do it at the one point it takes ownership, and this pins
+that it still does. Without it the change is a silent regression: the workflow
+would run with its log going wherever the app's log went at startup, and nobody
+would notice until they went looking for an experiment's logfile.
+
+Exercised through the unbound method against a stub, so no microscope, no
+QApplication, and no widget tree are needed to check the wiring.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.structures import Experiment  # noqa: E402
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI  # noqa: E402
+
+
+class _Signal:
+    def __init__(self):
+        self.emitted = 0
+
+    def emit(self):
+        self.emitted += 1
+
+
+class _StubUI:
+    """The parts of AutoLamellaUI that _adopt_experiment touches."""
+
+    def __init__(self):
+        self.experiment = None
+        self.disconnected = 0
+        self.connected = 0
+        self.experiment_update_signal = _Signal()
+
+    def _disconnect_experiment_events(self):
+        self.disconnected += 1
+
+    def _setup_experiment_connections(self):
+        self.connected += 1
+
+
+@pytest.fixture
+def quiet_root_logger():
+    """Leave the root logger as we found it, whatever the test does to it."""
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    yield
+    for handler in list(root.handlers):
+        if handler not in saved:
+            handler.close()
+    root.handlers = saved
+
+
+def test_adopting_an_experiment_points_logging_at_its_logfile(tmp_path, quiet_root_logger):
+    experiment = Experiment.create(path=tmp_path, name="exp")
+    ui = _StubUI()
+
+    AutoLamellaUI._adopt_experiment(ui, experiment)
+
+    logfile = Path(experiment.path) / "logfile.log"
+    assert logfile.is_file()
+    assert str(logfile) in [
+        getattr(h, "baseFilename", "") for h in logging.getLogger().handlers
+    ]
+
+    logging.info("after adoption")
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+    assert "after adoption" in logfile.read_text()
+
+
+def test_adopting_an_experiment_still_does_the_rest_of_the_wiring(tmp_path, quiet_root_logger):
+    """The logging call was added to an existing sequence, not in place of it."""
+    experiment = Experiment.create(path=tmp_path, name="exp")
+    ui = _StubUI()
+
+    AutoLamellaUI._adopt_experiment(ui, experiment)
+
+    assert ui.experiment is experiment
+    assert ui.disconnected == 1
+    assert ui.connected == 1
+    assert ui.experiment_update_signal.emitted == 1
+
+
+def test_a_second_adoption_moves_logging_to_the_new_experiment(tmp_path, quiet_root_logger):
+    """Switching experiments mid-session has to follow, not accumulate."""
+    first = Experiment.create(path=tmp_path / "a", name="exp")
+    second = Experiment.create(path=tmp_path / "b", name="exp")
+    ui = _StubUI()
+
+    AutoLamellaUI._adopt_experiment(ui, first)
+    AutoLamellaUI._adopt_experiment(ui, second)
+
+    logging.info("belongs to the second experiment")
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+
+    assert "belongs to the second experiment" in (
+        Path(second.path) / "logfile.log"
+    ).read_text()
+    assert "belongs to the second experiment" not in (
+        Path(first.path) / "logfile.log"
+    ).read_text()
+
+
+def test_previewing_an_experiment_leaves_logging_alone(tmp_path, quiet_root_logger):
+    """The load dialog calls Experiment.load on every single click to preview a
+    recent entry. That must not repoint the app's logging at whatever the user
+    happens to be browsing -- the bug this issue is about."""
+    experiment = Experiment.create(path=tmp_path, name="exp")
+    ui = _StubUI()
+    AutoLamellaUI._adopt_experiment(ui, experiment)
+
+    other = Experiment.create(path=tmp_path / "elsewhere", name="other")
+    before = [getattr(h, "baseFilename", "") for h in logging.getLogger().handlers]
+
+    Experiment.load(os.path.join(other.path, "experiment.yaml"))
+
+    assert [
+        getattr(h, "baseFilename", "") for h in logging.getLogger().handlers
+    ] == before


### PR DESCRIPTION
Closes FIB-421.

## Problem

`Experiment.load` and `Experiment.create` called `configure_logging`, which calls `logging.basicConfig(..., force=True)` — and `force=True` **removes and closes every existing root handler**.

So any process that read an experiment lost its own logging configuration and had all subsequent output redirected into that experiment's `logfile.log`:

```
root handlers now : ['/tmp/sfx/B/run/logfile.log', 'StreamHandler']
my_own.log lines  : 4                        # stopped receiving records
B/run/logfile.log : ... — tool: after loading an experiment
```

The clearest case is in the app itself, not in analysis tools. `_load_experiment_from_path` is called on **every single click** in the recent-experiments list as a lightweight preview, so browsing that list repointed the app's root logger at each experiment in turn — and closed the previous handler — even when the dialog was then cancelled.

## Change

Reading or creating an `Experiment` no longer touches global logging. The app configures it at the one point it takes ownership, in a new `AutoLamellaUI._adopt_experiment`.

That method also absorbs the adoption sequence that `create_experiment` and `load_experiment` each had a verbatim copy of (disconnect events → assign → reconnect → emit), so there is one seam rather than two that can drift.

`Experiment.create` loses the call as well. The app reaches `_adopt_experiment` immediately afterwards, so a newly created experiment still logs to its own file; the only difference is that create's own "Created new experiment ..." line now goes to the app's log, which is arguably where an app event belongs.

## Callers checked

16 `Experiment.load` / `Experiment.create` call sites. Only the app's load and create dialogs want the side effect, and both now get it via `_adopt_experiment`. The rest are analysis tools (`tools/stats.py`, `tools/data.py`, `tools/ml_export.py`), standalone widget demo blocks, and tests — none of which want their logging redirected.

`compat/odemis.py` also wraps `Experiment.load`. It is unreachable: the module imports `AutoLamellaStage` and `LamellaState` from `structures`, and neither exists, so it raises `ImportError` before odemis is even considered. Nothing there to preserve.

There is precedent for this shape already — `utils.setup_session` takes a `setup_logging` flag rather than configuring logging unconditionally.

## Tests

Six added, all confirmed failing without the change:

- `load()` and `create()` each leave the root logger's handlers untouched, and do not close the caller's own handler
- adopting an experiment points logging at its logfile, and records actually land there
- adopting a second experiment moves logging rather than accumulating handlers
- adoption still does the rest of the wiring it always did
- previewing an experiment with `load()` after adoption leaves logging where it was — the reported bug

The UI tests drive the unbound `_adopt_experiment` against a stub, so no microscope, QApplication, or widget tree is needed.

Full suite: 2137 passed, 24 skipped (pre-existing environment skips).

## Context

Third of three cleanups found while scoping a read-only web view of a running experiment (FIB-422): a monitor tailing `logfile.log` for workflow steps would otherwise see foreign records interleaved by any tool that happened to read the experiment. Siblings: FIB-419 (atomic `experiment.yaml` write), FIB-420 (#254, loading creates directories).
