### PR TITLE
[ui] Rework the coincidence milling confirmation dialog (FIB-430)

### DIFF
--- a/fibsem/ui/widgets/coincidence_milling_confirmation_dialog.py
+++ b/fibsem/ui/widgets/coincidence_milling_confirmation_dialog.py
@@ -1,0 +1,259 @@
+"""Pre-flight summary for a coincidence mill.
+
+Replaces the stock `QMessageBox` in `FluorescenceCoincidenceViewerWidget._run_milling`,
+which put the only per-stage detail behind "Show Details" as a `pformat` of the raw
+config dict — developer output in the one place an operator checks depth and current
+before committing.
+
+Same house style as :class:`FMOverviewConfirmationDialog`: a meta line, count chips, a
+detail block, and a primary action in the footer — with the visual constants, chip and
+duration format imported from it so the two cannot drift. If a third of these appears,
+lift the shared parts into their own module.
+
+Milling is irreversible, so the primary action is never the default button: starting
+takes a deliberate click.
+"""
+
+from typing import List, Optional, Tuple
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem import constants
+from fibsem.milling.base import FibsemMillingStage
+from fibsem.milling.tasks import FibsemMillingTaskConfig
+from fibsem.ui import stylesheets
+from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
+    BORDER,
+    PANEL,
+    TEXT,
+    TEXT_MUTED,
+    TEXT_STRONG,
+    _chip,
+    format_duration,
+)
+
+BACKGROUND = "#262930"
+
+# The dimensions that determine the milled volume, in the order they read. Driven off
+# the pattern's own to_dict() rather than isinstance checks, so a new pattern type
+# degrades to whichever of these it happens to have instead of showing nothing.
+#
+# Deliberately not every field: trench spacing and the upper/lower heights are visible
+# as the pattern's shape on the canvas, and listing them here pushed the stage line to
+# two wrapped rows where the separator read as a bullet. Full detail stays in the task
+# config editor; this is the pre-flight check.
+_DIMENSION_KEYS: List[Tuple[str, str]] = [
+    ("width", "wide"),
+    ("height", "tall"),
+    ("depth", "deep"),
+]
+
+
+def _format_current(amps: float) -> str:
+    """`1.0 nA` / `60 pA` — milling currents span three orders of magnitude, and
+    everything-in-pA turns the common nA case into a four-digit number."""
+    if amps >= 1e-9:
+        return f"{amps * constants.SI_TO_NANO:.1f} nA"
+    return f"{amps * constants.SI_TO_PICO:.0f} pA"
+
+
+def _pattern_summary(stage: FibsemMillingStage) -> str:
+    """`Rectangle 12.0 wide, 1.5 tall, 0.5 deep µm`, minus whatever it lacks."""
+    pattern = stage.pattern
+    try:
+        values = pattern.to_dict()
+    except Exception:
+        return getattr(pattern, "name", "pattern")
+
+    bits = [
+        f"{values[key] * constants.SI_TO_MICRO:.1f} {label}"
+        for key, label in _DIMENSION_KEYS
+        if isinstance(values.get(key), (int, float)) and values.get(key)
+    ]
+    name = getattr(pattern, "name", "Pattern")
+    return f"{name} {', '.join(bits)} µm" if bits else name
+
+
+class CoincidenceMillingConfirmationDialog(QDialog):
+    """Confirm a coincidence mill before it runs, with what it will do."""
+
+    def __init__(
+        self,
+        task_config: FibsemMillingTaskConfig,
+        lamella_name: str,
+        channel_name: Optional[str] = None,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(parent)
+        self.task_config = task_config
+        self.lamella_name = lamella_name
+        self.channel_name = channel_name
+
+        self.setWindowTitle("Start Coincidence Milling")
+        # Wide enough that a three-dimension pattern plus current and duration fits on
+        # one line; the stage rows are the longest thing here and wrapping them splits
+        # a stage across two lines for no gain.
+        self.setMinimumWidth(540)
+        self.setStyleSheet(f"QDialog {{ background: {BACKGROUND}; }}")
+        self._init_ui()
+
+    # ── content ──────────────────────────────────────────────────────────
+
+    def _strategy_config(self):
+        """The coincidence strategy config off the first enabled stage.
+
+        The viewer seeds its status-bar controls from these as a single source of truth
+        (`_seed_controls_from_strategy`), so reading the first is consistent with how
+        the rest of the UI already treats them.
+        """
+        for stage in self.task_config.enabled_stages:
+            config = getattr(getattr(stage, "strategy", None), "config", None)
+            if config is not None and hasattr(config, "intensity_drop_fraction"):
+                return config
+        return None
+
+    def _meta_line(self) -> str:
+        stages = self.task_config.enabled_stages
+        bits = [self.lamella_name, f"{len(stages)} stage{'s' if len(stages) != 1 else ''}"]
+        fov = getattr(self.task_config, "field_of_view", None)
+        if fov:
+            bits.append(f"{fov * constants.SI_TO_MICRO:.0f} µm field of view")
+        return " · ".join(bits)
+
+    def _stage_rows(self) -> List[tuple]:
+        """One detail row per stage, keyed by its name.
+
+        Not one multi-line "Stages" value: with the name inline each stage overran the
+        value column and wrapped, and a wrapped separator reads as a bullet. Putting the
+        name in the label column shortens the line and aligns the stages down the page.
+        """
+        stages = self.task_config.enabled_stages
+        if not stages:
+            return [("Stages", "— none enabled")]
+        return [
+            (
+                stage.name,
+                f"{_format_current(stage.milling.milling_current)}"
+                f" · {_pattern_summary(stage)}"
+                f" · {format_duration(stage.estimated_time)}",
+            )
+            for stage in stages
+        ]
+
+    def _rows(self) -> List[tuple]:
+        config = self._strategy_config()
+        detail: List[tuple] = [("FM channel", self.channel_name or "— none selected")]
+        detail.extend(self._stage_rows())
+
+        if config is not None:
+            # The trigger is three settings that only mean anything together, so they
+            # read as one sentence rather than three rows the user has to assemble.
+            detail.append((
+                "Drop trigger",
+                f"{config.intensity_drop_fraction:.0%} drop"
+                f" · {config.rolling_window}-frame window"
+                f" · {config.consecutive_triggers} consecutive",
+            ))
+            detail.append((
+                "Monitoring",
+                f"starts after {format_duration(config.warmup_duration)} warmup"
+                f" · times out at {format_duration(config.timeout)}",
+            ))
+            detail.append((
+                "Mode",
+                "supervised — pauses for confirmation"
+                if config.supervised
+                else "unattended — runs to completion",
+            ))
+            saved = (
+                f"saved (every {config.save_rate_limit} frames)"
+                if config.save_fm_images
+                else "not saved"
+            )
+            if config.acquire_fib_image:
+                saved += " · FIB image acquired"
+            detail.append(("FM images", saved))
+
+        detail.append(("Estimated time", format_duration(self.task_config.estimated_time)))
+        return detail
+
+    # ── layout ───────────────────────────────────────────────────────────
+
+    def _init_ui(self) -> None:
+        enabled = len(self.task_config.enabled_stages)
+        total = len(self.task_config.stages)
+
+        meta = QLabel(self._meta_line())
+        meta.setStyleSheet(f"color: {TEXT_STRONG}; font-size: 12px;")
+        meta.setWordWrap(True)
+
+        chips = QHBoxLayout()
+        chips.setSpacing(6)
+        chips.addWidget(_chip(f"{enabled} to mill"))
+        if enabled != total:
+            chips.addWidget(_chip(f"{total - enabled} disabled"))
+        chips.addStretch()
+
+        detail = QFrame()
+        detail.setStyleSheet(
+            f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER};"
+            f" border-radius: 4px; }}"
+        )
+        detail_layout = QVBoxLayout(detail)
+        detail_layout.setContentsMargins(12, 10, 12, 10)
+        detail_layout.setSpacing(6)
+        for label_text, value_text in self._rows():
+            row = QHBoxLayout()
+            row.setSpacing(12)
+            label = QLabel(label_text)
+            label.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px; border: none;")
+            label.setFixedWidth(104)
+            # Stage names go in this column and are user-supplied, so wrap rather than
+            # clip — a truncated stage name in a pre-flight check is worse than two lines.
+            label.setWordWrap(True)
+            value = QLabel(value_text)
+            value.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
+            value.setWordWrap(True)
+            row.addWidget(label, alignment=Qt.AlignTop)
+            row.addWidget(value, stretch=1)
+            detail_layout.addLayout(row)
+
+        self.button_start = QPushButton("Start Milling")
+        self.button_start.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.button_start.setMinimumHeight(30)
+        self.button_start.clicked.connect(self.accept)
+
+        button_cancel = QPushButton("Cancel")
+        button_cancel.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        button_cancel.setMinimumHeight(30)
+        button_cancel.clicked.connect(self.reject)
+        # Milling is irreversible and this dialog opens on the click that would start
+        # it, so Enter must not fire it — Cancel takes the default.
+        button_cancel.setDefault(True)
+        self.button_start.setAutoDefault(False)
+
+        footer = QHBoxLayout()
+        footer.addStretch()
+        footer.addWidget(button_cancel)
+        footer.addWidget(self.button_start)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 14, 16, 14)
+        layout.setSpacing(10)
+        layout.addWidget(meta)
+        layout.addLayout(chips)
+        layout.addWidget(detail)
+        layout.addLayout(footer)
+
+        if enabled == 0:
+            self.button_start.setEnabled(False)
+            self.button_start.setToolTip("No milling stages are enabled.")

--- a/fibsem/ui/widgets/coincidence_milling_confirmation_dialog.py
+++ b/fibsem/ui/widgets/coincidence_milling_confirmation_dialog.py
@@ -121,6 +121,22 @@ class CoincidenceMillingConfirmationDialog(QDialog):
                 return config
         return None
 
+    def _current_chip_text(self) -> Optional[str]:
+        """`1.0 nA`, or `60 pA – 1.0 nA` when the stages differ.
+
+        A range rather than a single figure: a task that steps down from rough to
+        polish is the normal case, and showing only the first stage's current would
+        misreport the one number an operator is most likely to be checking for.
+        """
+        currents = sorted(
+            {stage.milling.milling_current for stage in self.task_config.enabled_stages}
+        )
+        if not currents:
+            return None
+        if len(currents) == 1:
+            return _format_current(currents[0])
+        return f"{_format_current(currents[0])} – {_format_current(currents[-1])}"
+
     def _meta_line(self) -> str:
         stages = self.task_config.enabled_stages
         bits = [self.lamella_name, f"{len(stages)} stage{'s' if len(stages) != 1 else ''}"]
@@ -157,12 +173,18 @@ class CoincidenceMillingConfirmationDialog(QDialog):
         if config is not None:
             # The trigger is three settings that only mean anything together, so they
             # read as one sentence rather than three rows the user has to assemble.
-            detail.append((
-                "Drop trigger",
+            trigger = (
                 f"{config.intensity_drop_fraction:.0%} drop"
                 f" · {config.rolling_window}-frame window"
-                f" · {config.consecutive_triggers} consecutive",
-            ))
+                f" · {config.consecutive_triggers} consecutive"
+            )
+            if config.supervised:
+                # The strategy only acts on _drop_detected when NOT supervised, so in
+                # supervised mode these thresholds still drive the readout but stop
+                # nothing. Saying so here beats letting the operator infer that the
+                # mill will halt itself when it will not.
+                trigger += "  → monitoring only; you stop the mill"
+            detail.append(("Drop trigger", trigger))
             detail.append((
                 "Monitoring",
                 f"starts after {format_duration(config.warmup_duration)} warmup"
@@ -170,9 +192,9 @@ class CoincidenceMillingConfirmationDialog(QDialog):
             ))
             detail.append((
                 "Mode",
-                "supervised — pauses for confirmation"
+                "supervised — you stop the mill manually"
                 if config.supervised
-                else "unattended — runs to completion",
+                else "automated — stops itself on the drop trigger",
             ))
             saved = (
                 f"saved (every {config.save_rate_limit} frames)"
@@ -196,11 +218,25 @@ class CoincidenceMillingConfirmationDialog(QDialog):
         meta.setStyleSheet(f"color: {TEXT_STRONG}; font-size: 12px;")
         meta.setWordWrap(True)
 
+        # Counts first, then the two facts worth reading before anything else: what
+        # current is going into the sample, and whether it will stop for you. The FM
+        # dialog uses chips only for counts; these are states, but `_chip` carries no
+        # colour, so a state here reads as a fact rather than as a status light.
         chips = QHBoxLayout()
         chips.setSpacing(6)
         chips.addWidget(_chip(f"{enabled} to mill"))
         if enabled != total:
             chips.addWidget(_chip(f"{total - enabled} disabled"))
+        current_text = self._current_chip_text()
+        if current_text:
+            chips.addWidget(_chip(current_text))
+        config = self._strategy_config()
+        if config is not None:
+            # "Automated", not "Unattended" or "Unsupervised": that is what the
+            # supervision toggle a few pixels away already says (_update_supervised_button),
+            # and what the border state is called. A third word for one mode is worse
+            # than an imperfect one.
+            chips.addWidget(_chip("Supervised" if config.supervised else "Automated"))
         chips.addStretch()
 
         detail = QFrame()

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -1991,7 +1991,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             pformat(milling_task_config.to_dict(), width=80, compact=True)
         )
         dlg.setStandardButtons(QMessageBox.Yes | QMessageBox.Cancel)
-        dlg.setDefaultButton(QMessageBox.Yes)
+        # Cancel is the default: this dialog opens on the click that would start the
+        # mill, so a default of Yes means a stray Enter or Space burns the sample.
+        # Starting an irreversible action should take a deliberate click.
+        dlg.setDefaultButton(QMessageBox.Cancel)
         if dlg.exec_() != QMessageBox.Yes:
             return
 

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -29,13 +29,13 @@ import os
 import time
 from collections import deque
 from datetime import timedelta
-from pprint import pformat
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QAction,
+    QDialog,
     QFileDialog,
     QFrame,
     QHBoxLayout,
@@ -69,6 +69,9 @@ from fibsem.ui.widgets.custom_widgets import (
     IntegerValueSpinBox,
     LamellaNameListWidget,
     TitledPanel,
+)
+from fibsem.ui.widgets.coincidence_milling_confirmation_dialog import (
+    CoincidenceMillingConfirmationDialog,
 )
 from fibsem.ui.widgets.selected_lamella_widget import SelectedLamellaWidget
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
@@ -1973,30 +1976,26 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
                     )
                     return
 
-        # Build confirmation summary
-        lines = [f"Lamella: {self._selected_lamella.name}"]
-        if selected_channel_settings is not None:
-            lines.append(f"Channel: {selected_channel_settings.pretty}")
-        lines.append(f"Field of View: {milling_task_config.field_of_view * 1e6:.1f} µm")
-        stage_names = [s.pretty_name for s in milling_task_config.stages if s.enabled]
-        if stage_names:
-            lines.append("Stages: " + ", ".join(stage_names))
-
-        dlg = QMessageBox(self)
-        dlg.setWindowTitle("Confirm Coincidence Milling")
-        dlg.setIcon(QMessageBox.Question)
-        dlg.setText("Review milling parameters before starting.")
-        dlg.setInformativeText("\n".join(lines))
-        dlg.setDetailedText(
-            pformat(milling_task_config.to_dict(), width=80, compact=True)
+        # Pre-flight summary. Supervision is read off the strategy config rather than
+        # self._supervised, because the config is what governs the run:
+        # _connect_coincidence_strategies seeds the button from it a few lines below,
+        # so before the first mill a toggled button and the config can disagree and the
+        # config wins. A confirmation dialog has to describe what will happen.
+        dlg = CoincidenceMillingConfirmationDialog(
+            task_config=milling_task_config,
+            lamella_name=self._selected_lamella.name,
+            channel_name=(
+                selected_channel_settings.pretty
+                if selected_channel_settings is not None
+                else None
+            ),
+            parent=self,
         )
-        dlg.setStandardButtons(QMessageBox.Yes | QMessageBox.Cancel)
-        # Cancel is the default: this dialog opens on the click that would start the
-        # mill, so a default of Yes means a stray Enter or Space burns the sample.
-        # Starting an irreversible action should take a deliberate click.
-        dlg.setDefaultButton(QMessageBox.Cancel)
-        if dlg.exec_() != QMessageBox.Yes:
-            return
+        try:
+            if dlg.exec_() != QDialog.Accepted:
+                return
+        finally:
+            dlg.deleteLater()
 
         if selected_channel_settings is not None and self.microscope is not None:
             self.microscope.fm.set_channel(selected_channel_settings)

--- a/fibsem/ui/widgets/tests/test_coincidence_milling_confirmation_dialog.py
+++ b/fibsem/ui/widgets/tests/test_coincidence_milling_confirmation_dialog.py
@@ -1,0 +1,237 @@
+"""Headless tests for the coincidence milling confirmation dialog (FIB-430).
+
+This is the last gate before an irreversible, sample-destroying action, so the tests
+are mostly about it telling the truth: the mode it reports must be the mode that will
+actually run, and starting must never be reachable by a stray keypress.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_coincidence_milling_confirmation_dialog.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5.QtWidgets import QApplication, QPushButton
+
+from fibsem.milling.base import FibsemMillingStage
+from fibsem.milling.patterning.patterns2 import RectanglePattern, TrenchPattern
+from fibsem.milling.strategy.coincidence import (
+    CoincidenceMillingStrategy,
+    CoincidenceMillingStrategyConfig,
+)
+from fibsem.milling.tasks import FibsemMillingTaskConfig
+from fibsem.structures import FibsemMillingSettings
+from fibsem.ui.widgets.coincidence_milling_confirmation_dialog import (
+    CoincidenceMillingConfirmationDialog,
+    _format_current,
+    _pattern_summary,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _stage(name="Polish", current=60e-12, pattern=None, enabled=True, **cfg):
+    stage = FibsemMillingStage(
+        name=name,
+        enabled=enabled,
+        milling=FibsemMillingSettings(milling_current=current),
+        pattern=pattern or RectanglePattern(width=12e-6, height=1.5e-6, depth=0.5e-6),
+    )
+    base = dict(
+        intensity_drop_fraction=0.20,
+        rolling_window=10,
+        consecutive_triggers=3,
+        warmup_duration=30.0,
+        timeout=1800,
+        supervised=True,
+        save_fm_images=True,
+        save_rate_limit=2,
+        acquire_fib_image=False,
+    )
+    base.update(cfg)
+    stage.strategy = CoincidenceMillingStrategy(CoincidenceMillingStrategyConfig(**base))
+    return stage
+
+
+def _dialog(stages=None, channel_name="GFP (488 nm)", lamella_name="01-calm-muskox"):
+    config = FibsemMillingTaskConfig(stages=stages or [_stage()])
+    config.field_of_view = 80e-6
+    return CoincidenceMillingConfirmationDialog(
+        config, lamella_name=lamella_name, channel_name=channel_name
+    )
+
+
+def _text(dialog) -> str:
+    """Everything the dialog puts on screen, flattened."""
+    from PyQt5.QtWidgets import QLabel
+
+    return "\n".join(label.text() for label in dialog.findChildren(QLabel))
+
+
+# --- the safety property -------------------------------------------------------
+
+
+def test_start_is_never_the_default_button():
+    """The dialog opens on the click that would start the mill. If Start were the
+    default, Enter or Space would burn the sample."""
+    dialog = _dialog()
+    assert not dialog.button_start.isDefault(), "Start Milling is the default button"
+    assert not dialog.button_start.autoDefault(), "Start Milling would take Enter"
+    cancel = next(
+        b for b in dialog.findChildren(QPushButton) if b.text() == "Cancel"
+    )
+    assert cancel.isDefault(), "Cancel is not the default"
+
+
+def test_start_is_disabled_with_nothing_to_mill():
+    dialog = _dialog(stages=[_stage(enabled=False)])
+    assert not dialog.button_start.isEnabled()
+    assert dialog.button_start.toolTip()
+
+
+# --- it must report the mode that will actually run ----------------------------
+
+
+def _row(dialog, label: str) -> str:
+    """One row's value by label. Asserting on the flattened text instead let the Mode
+    row's wording be satisfied by the Drop trigger caveat, which happens to contain the
+    same phrase — the assertion passed while the row under test was wrong."""
+    for row_label, value in dialog._rows():
+        if row_label == label:
+            return value
+    raise AssertionError(f"no {label!r} row; rows are {[r[0] for r in dialog._rows()]}")
+
+
+def test_supervised_says_you_stop_it():
+    """Supervised is the mode where the drop trigger stops *nothing* — the strategy
+    only acts on _drop_detected when not supervised. Reporting it as auto-stopping
+    would tell the operator the mill halts itself when it will not."""
+    dialog = _dialog(stages=[_stage(supervised=True)])
+    assert "Supervised" in _text(dialog)
+    assert _row(dialog, "Mode") == "supervised — you stop the mill manually"
+    assert "monitoring only" in _row(dialog, "Drop trigger"), (
+        "drop trigger not marked inert while supervised"
+    )
+
+
+def test_automated_says_it_stops_itself():
+    dialog = _dialog(stages=[_stage(supervised=False)])
+    assert "Automated" in _text(dialog)
+    assert _row(dialog, "Mode") == "automated — stops itself on the drop trigger"
+    assert "monitoring only" not in _row(dialog, "Drop trigger")
+
+
+def test_mode_wording_matches_the_supervision_button():
+    """The toggle a few pixels away sets its label to exactly these words
+    (`_update_supervised_button`). A third synonym for one mode is worse than an
+    imperfect one, so this pins them together."""
+    import inspect
+
+    from fibsem.ui.widgets import fluorescence_coincidence_viewer_widget as viewer
+
+    source = inspect.getsource(viewer.FluorescenceCoincidenceViewerWidget._update_supervised_button)
+    assert 'setText("Supervised")' in source
+    assert 'setText("Automated")' in source
+
+
+# --- the facts the operator is checking ----------------------------------------
+
+
+def test_shows_per_stage_current_pattern_and_duration():
+    stages = [
+        _stage("Rough Mill", 1.0e-9, TrenchPattern(width=20e-6, depth=2e-6, spacing=3e-6,
+                                                   upper_trench_height=8e-6,
+                                                   lower_trench_height=6e-6)),
+        _stage("Polish", 60e-12),
+    ]
+    text = _text(_dialog(stages=stages))
+    for expected in ("Rough Mill", "Polish", "1.0 nA", "60 pA", "Trench", "Rectangle"):
+        assert expected in text, f"missing {expected!r}"
+
+
+def test_current_chip_spans_the_range_when_stages_differ():
+    """A task stepping down rough → polish is the normal case; showing only the first
+    stage's current would misreport the number most likely being checked."""
+    text = _text(_dialog(stages=[_stage("Rough", 1.0e-9), _stage("Polish", 60e-12)]))
+    assert "60 pA – 1.0 nA" in text
+
+    single = _text(_dialog(stages=[_stage("Polish", 60e-12)]))
+    assert "60 pA" in single and "–" not in single
+
+
+def test_shows_channel_and_says_so_when_there_is_none():
+    assert "GFP (488 nm)" in _text(_dialog())
+    assert "none selected" in _text(_dialog(channel_name=None))
+
+
+def test_shows_a_total_estimated_time():
+    """The number the old QMessageBox omitted entirely."""
+    config = FibsemMillingTaskConfig(stages=[_stage()])
+    config.field_of_view = 80e-6
+    dialog = CoincidenceMillingConfirmationDialog(config, lamella_name="x")
+    assert config.estimated_time > 0
+    assert "Estimated time" in _text(dialog)
+
+
+def test_disabled_stages_are_counted_but_not_listed():
+    stages = [_stage("Polish", 60e-12), _stage("Skipped", 1e-9, enabled=False)]
+    text = _text(_dialog(stages=stages))
+    assert "1 disabled" in text
+    assert "Skipped" not in text, "a disabled stage was listed as if it would run"
+
+
+# --- formatting helpers --------------------------------------------------------
+
+
+def test_current_formats_nano_above_a_nanoamp():
+    assert _format_current(1.0e-9) == "1.0 nA"
+    assert _format_current(60e-12) == "60 pA"
+    assert _format_current(2.5e-9) == "2.5 nA"
+
+
+def test_pattern_summary_omits_dimensions_a_pattern_lacks():
+    rect = _pattern_summary(_stage(pattern=RectanglePattern(width=12e-6, height=1.5e-6, depth=0.5e-6)))
+    assert "12.0 wide" in rect and "1.5 tall" in rect and "0.5 deep" in rect
+
+    trench = _pattern_summary(_stage(pattern=TrenchPattern(
+        width=20e-6, depth=2e-6, spacing=3e-6,
+        upper_trench_height=8e-6, lower_trench_height=6e-6)))
+    assert "20.0 wide" in trench and "2.0 deep" in trench
+    # secondary trench dimensions are deliberately left to the task config editor
+    assert "gap" not in trench and "upper" not in trench
+
+
+# --- the call site -------------------------------------------------------------
+
+
+def test_run_milling_uses_this_dialog():
+    import inspect
+
+    from fibsem.ui.widgets import fluorescence_coincidence_viewer_widget as viewer
+
+    source = inspect.getsource(viewer.FluorescenceCoincidenceViewerWidget._run_milling)
+    assert "CoincidenceMillingConfirmationDialog" in source
+    assert "QMessageBox(" not in source, "the old stock dialog is still built"
+    assert "pformat" not in source, "raw config dump is back"
+
+
+def _main() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        try:
+            fn()
+            print(f"PASS  {name}")
+        except Exception as exc:  # noqa: BLE001 - standalone runner
+            failures += 1
+            print(f"FAIL  {name}: {type(exc).__name__}: {exc}")
+    print(f"\n{'FAILED' if failures else 'OK'} — {failures} failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())


### PR DESCRIPTION
The last gate before an irreversible, sample-destroying action was a stock `QMessageBox` whose only per-stage detail sat behind "Show Details" as a `pformat` of the raw config dict.

Three commits, and the first is independently shippable.

## 1. `4e52178c` — the default button

```python
dlg.setDefaultButton(QMessageBox.Yes)   # before
```

The dialog opens on the same click that would start the mill, so a default of Yes meant a stray **Enter or Space burned the sample**. Now Cancel. One line, no dependency on the rest of this PR.

## 2 & 3. The dialog

Same house style as `FMOverviewConfirmationDialog` — meta line, count chips, detail block, primary action in the footer — importing its visual constants, chip and duration format rather than restating them, so the two cannot drift. (If a third appears, lift the shared parts out.)

What it shows that the old one didn't: per-stage **milling current, pattern dimensions and duration**; the **FM channel**, with an explicit "— none selected"; the **drop trigger** as one sentence rather than three settings to assemble; **supervised vs automated** spelled out as what it *does*; whether FM images are saved; and a **total estimated time**, which was missing entirely.

Chips carry the two facts worth reading first: the current (as a **range** — a task stepping rough → polish is the normal case, and the first stage's current alone would misreport the number most likely being checked) and the supervision mode.

## Two corrections found by checking rather than assuming

**"Automated", not "Unattended".** The supervision toggle a few pixels away already sets its label to exactly that (`_update_supervised_button`), and the border state is called the same. Across the tree: automated 26, unsupervised 12, unattended 2.

**The mode descriptions were backwards**, in the direction that matters:

```python
# unsupervised runs: automatically stop on intensity drop
if not self.config.supervised and self._drop_detected:
    self.microscope.stop_milling()
```

Supervised is the mode where *you* stop the mill; **automated** is the one that stops itself. The first draft said automated "runs to completion" — exactly wrong about the only mode that halts on its own.

That surfaced a third thing: **the drop trigger is inert on a supervised run**, so the row now says `→ monitoring only; you stop the mill`. Otherwise you are looking at a configured 20% trigger and reasonably concluding the mill will stop by itself.

## One wiring subtlety

Supervision is read off the **strategy config**, not `self._supervised`. `_on_supervised_toggled` writes to `_active_strategies`, which is empty until `_connect_coincidence_strategies` runs — so before the first mill a toggled button and the config can disagree, and the config wins because it seeds the button afterwards. A confirmation dialog has to describe what will happen, not what the UI intends. That divergence is a separate bug, fixed in #259.

## Tests

13, all mutation-checked: making Start the default, swapping the mode descriptions, dropping the inert-trigger caveat, reporting only the first stage's current, and listing disabled stages each fail at least one.

Two were weak on the first pass — they asserted against the flattened label text, so the Mode row's wording was satisfied by the Drop trigger caveat, which contains the same phrase: the assertion passed while the row under test was wrong. They read `_rows()` by label now.

136 widget tests and 2,136 in `tests/` pass.

The underlying divergence is tracked as FIB-443 and fixed separately in #259 — that work was written after this PR had already merged.

Closes FIB-430.
