### PR TITLE
[ui] Make the supervision toggle reach the run (FIB-443)

### DIFF
--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -1049,6 +1049,11 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
                 self._apply_fm_configuration(fm_config)
             if milling_config is not None and self.milling_viewer_widget is not None:
                 self.milling_viewer_widget.set_config(milling_config)
+                # Config → controls, the load direction. Without this the status bar
+                # keeps the previous supervision mode and drop threshold while the
+                # loaded config holds different ones, and the toggle would then push
+                # the stale values back over what was just loaded.
+                self._seed_controls_from_strategy()
         except Exception as e:
             logging.error(f"Failed to apply coincidence configuration: {e}")
             QMessageBox.warning(self, "Load Configuration", f"Failed to apply:\n{e}")
@@ -1779,14 +1784,17 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             strategy.intensity_stats_signal.connect(self._on_intensity_stats)
 
     def _seed_controls_from_strategy(self) -> None:
-        """Mirror the first active strategy's config into the status-bar controls.
+        """Mirror the first strategy's config into the status-bar controls.
 
-        Keeps ``strategy.config`` authoritative: the status bar reflects the value
-        set in the strategy section rather than overwriting it with its own default.
+        Config → controls happens on load; controls → config happens on edit
+        (:meth:`_coincidence_strategies`). Those are the only two directions, so this no
+        longer fights the operator: by the time a mill starts the config already holds
+        whatever the buttons show, and seeding is a no-op rather than a revert.
         """
-        if not self._active_strategies:
+        strategies = self._coincidence_strategies() or self._active_strategies
+        if not strategies:
             return
-        config = self._active_strategies[0].config
+        config = strategies[0].config
         self._supervised = bool(config.supervised)
         self._update_supervised_button()
         self.spin_drop_threshold.blockSignals(True)
@@ -1834,15 +1842,45 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         if self._is_milling_active:
             self._set_border_state("supervised" if supervised else "automated")
 
+    def _coincidence_strategies(self) -> list:
+        """Every coincidence strategy on the stages a run would actually use.
+
+        Not ``self._active_strategies``: that is only populated by
+        ``_connect_coincidence_strategies``, which runs *inside* ``_run_milling``. Before
+        the first mill of a session it is empty, so every write through it was silently
+        discarded — and then ``_seed_controls_from_strategy`` seeded the button back from
+        the untouched config, reverting the operator's choice without a word (FIB-443).
+
+        The stage list widget holds the live ``FibsemMillingStage`` objects (``get_stages``
+        returns the rows' own stages, not copies), so writing to their strategies is what
+        makes a status-bar control stick.
+        """
+        from fibsem.milling.strategy.coincidence import CoincidenceMillingStrategy
+
+        if self.milling_viewer_widget is None:
+            return []
+        try:
+            stages = (
+                self.milling_viewer_widget.config_widget.milling_stages_widget.get_stages()
+            )
+        except Exception:
+            logging.exception("Could not read milling stages for strategy update")
+            return []
+        return [
+            stage.strategy
+            for stage in stages
+            if isinstance(stage.strategy, CoincidenceMillingStrategy)
+        ]
+
     def _on_supervised_toggled(self, supervised: bool) -> None:
-        """Apply the supervision preference to any active strategies (live)."""
-        for strategy in self._active_strategies:
+        """Apply the supervision preference to the strategies a run will use."""
+        for strategy in self._coincidence_strategies():
             strategy.config.supervised = supervised
 
     def _on_drop_threshold_changed(self, pct: int) -> None:
-        """Apply the drop-fraction threshold to any active strategies (live)."""
+        """Apply the drop-fraction threshold to the strategies a run will use."""
         drop_fraction = pct / 100.0
-        for strategy in self._active_strategies:
+        for strategy in self._coincidence_strategies():
             strategy.config.intensity_drop_fraction = drop_fraction
 
     def _toggle_fm_acquisition(self):

--- a/fibsem/ui/widgets/tests/test_coincidence_milling_confirmation_dialog.py
+++ b/fibsem/ui/widgets/tests/test_coincidence_milling_confirmation_dialog.py
@@ -218,6 +218,104 @@ def test_run_milling_uses_this_dialog():
     assert "pformat" not in source, "raw config dump is back"
 
 
+# --- FIB-443: the toggle must survive to the run ------------------------------
+
+
+class _FakeStageList:
+    """Stands in for MillingStageListWidget: holds the live stage objects that
+    `get_stages()` hands out by reference, which is what makes a write stick."""
+
+    def __init__(self, stages):
+        self._stages = stages
+
+    def get_stages(self):
+        return self._stages
+
+
+class _FakeConfigWidget:
+    def __init__(self, stages):
+        self.milling_stages_widget = _FakeStageList(stages)
+
+
+class _FakeMillingWidget:
+    def __init__(self, stages):
+        self.config_widget = _FakeConfigWidget(stages)
+
+
+def _viewer_with(stages):
+    """A bare viewer instance with just the attributes these methods touch —
+    constructing the real widget needs a microscope and an experiment."""
+    from fibsem.ui.widgets.fluorescence_coincidence_viewer_widget import (
+        FluorescenceCoincidenceViewerWidget as Viewer,
+    )
+
+    viewer = Viewer.__new__(Viewer)
+    viewer.milling_viewer_widget = _FakeMillingWidget(stages)
+    viewer._active_strategies = []  # as it is before the first mill of a session
+    return viewer
+
+
+def test_supervision_toggle_reaches_the_run_before_the_first_mill():
+    """The operator sequence from FIB-443: toggle to automated, then start milling.
+
+    _active_strategies is empty until _connect_coincidence_strategies runs inside
+    _run_milling, so a toggle that only wrote through it was discarded — and the
+    failure was in the unsafe direction, since supervised is the mode where the drop
+    trigger stops nothing.
+    """
+    from fibsem.ui.widgets.fluorescence_coincidence_viewer_widget import (
+        FluorescenceCoincidenceViewerWidget as Viewer,
+    )
+
+    stages = [_stage("Rough", 1e-9, supervised=True), _stage("Polish", 60e-12, supervised=True)]
+    viewer = _viewer_with(stages)
+
+    Viewer._on_supervised_toggled(viewer, False)
+
+    assert [s.strategy.config.supervised for s in stages] == [False, False], (
+        "toggle did not reach the strategies a run would use"
+    )
+
+
+def test_drop_threshold_reaches_the_run_before_the_first_mill():
+    """Same root cause, same fix — the sibling control was equally inert."""
+    from fibsem.ui.widgets.fluorescence_coincidence_viewer_widget import (
+        FluorescenceCoincidenceViewerWidget as Viewer,
+    )
+
+    stages = [_stage("Polish", 60e-12, intensity_drop_fraction=0.20)]
+    viewer = _viewer_with(stages)
+
+    Viewer._on_drop_threshold_changed(viewer, 35)
+
+    assert stages[0].strategy.config.intensity_drop_fraction == 0.35
+
+
+def test_seeding_no_longer_reverts_a_toggle():
+    """_seed_controls_from_strategy runs when a mill starts. It must now read back what
+    the button already wrote, not the stale config value that used to overwrite it."""
+    from fibsem.ui.widgets.fluorescence_coincidence_viewer_widget import (
+        FluorescenceCoincidenceViewerWidget as Viewer,
+    )
+
+    stages = [_stage("Polish", 60e-12, supervised=True)]
+    viewer = _viewer_with(stages)
+    Viewer._on_supervised_toggled(viewer, False)
+
+    # stand in for the button/spinbox the real seed would drive
+    viewer._supervised = False
+    viewer._update_supervised_button = lambda: None
+
+    class _Spin:
+        def blockSignals(self, _): pass
+        def setValue(self, _): pass
+
+    viewer.spin_drop_threshold = _Spin()
+    Viewer._seed_controls_from_strategy(viewer)
+
+    assert viewer._supervised is False, "seeding reverted the operator's toggle"
+
+
 def _main() -> int:
     failures = 0
     for name, fn in sorted(globals().items()):


### PR DESCRIPTION
Follow-up to #258. Found while wiring that dialog, but written after #258 had already merged, so it lands separately.

## The bug

The status-bar controls applied their value by writing through `_active_strategies`:

```python
def _on_supervised_toggled(self, supervised: bool) -> None:
    for strategy in self._active_strategies:
        strategy.config.supervised = supervised
```

`_connect_coincidence_strategies` only populates that list **inside** `_run_milling`. Before the first mill of a session it is empty, so the write went nowhere — and then `_seed_controls_from_strategy` seeded the button back from the untouched config, reverting the operator's choice without a word.

## Why it matters

The failure is in the **unsafe direction**. Supervised is precisely the mode where the drop trigger stops nothing:

```python
if not self.config.supervised and self._drop_detected:
    self.microscope.stop_milling()
```

So the sequence is: switch to **Automated** → button confirms it → start milling → button flips back to **Supervised**, and the run never auto-stops on the intensity drop. The operator asked for automatic stopping, was shown it was set, and doesn't get it.

It works on the *second* run of a session, because `_active_strategies` is populated by then — which would make it read as a mis-click rather than a bug.

## The fix

One owner per direction: **config → controls on load, controls → config on edit.**

The write now targets the strategies on the **live** stages. `MillingStageListWidget.get_stages()` hands out the rows' own `FibsemMillingStage` objects, so those are what a run actually uses; `get_config()` deep-copies, which is why the original code had to go via `_active_strategies` and inherited its lifetime.

Two things came along with it:

- **Seeding now runs after a config load**, which it didn't before. Without it the status bar kept the previous mode while the loaded config held a different one, and the next toggle would push the stale value back over what was just loaded. Making the toggle authoritative is what turns that into a real problem.
- **The drop-threshold control had the identical bug** — same root cause, same one-line change. Leaving one of two siblings broken would be worse than either.

## Tests

Three, reproducing the operator sequence from the issue rather than the internals. Mutation-checked by reverting each writer back to `_active_strategies`; each fails its corresponding test.

139 widget tests and 2,136 in `tests/` pass.

Closes FIB-443.