### PR TITLE
[autolamella] Drop an ask_user argument it never accepted (FIB-454)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
+++ b/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
@@ -224,11 +224,18 @@ class MillCoincidentTask(AutoLamellaTask):
 
         # QUERY: can we just use milling ui?
         # wait for user to complete coincidence milling
+        # NOTE: this used to pass coincidence_milling=True, which ask_user has never
+        # accepted — the task raised TypeError here, after moving the stage and objective
+        # and acquiring. Nothing consumed the flag either: its siblings `mill` and
+        # `spot_burn` both have handlers in handle_workflow_update that surface the right
+        # controls, and `coincidence_milling` had none. Dropped rather than plumbed
+        # through, so the task reaches its wait state; whether the workflow should surface
+        # the coincidence viewer here is an open question (FIB-454), and the operator
+        # opens it by hand today.
         ask_user(
             self.parent_ui,
             msg=f"Run coincidence milling for {self.lamella.name}. Press Continue when done.",
             pos="Continue",
-            coincidence_milling=True,
         )
 
         # clear the coincidence milling config from the milling widget

--- a/tests/autolamella/test_workflow_ui_call_signatures.py
+++ b/tests/autolamella/test_workflow_ui_call_signatures.py
@@ -1,0 +1,102 @@
+"""Every call into the workflow UI helpers must match its signature (FIB-454).
+
+`MillCoincidentTask` passed `coincidence_milling=True` to `ask_user`, which has never had
+that parameter. It raised `TypeError` at the hand-off to the operator — after moving the
+stage and objective, applying the milling config and acquiring — and survived because the
+workflow path is rarely exercised: in a two-day log covering ten coincidence mills, the
+task never ran once.
+
+These helpers are called from workflow tasks that need hardware and a GUI, so nothing
+imports them under test and a plain signature mismatch is invisible until an operator hits
+it mid-run. Checking the call sites statically costs nothing and catches the whole class.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+
+from fibsem.applications.autolamella.workflows import ui as workflow_ui
+
+# Helpers worth checking: module-level functions in workflows/ui.py that tasks call with
+# keywords. Resolved dynamically so a new helper is covered without touching this test.
+_HELPERS = {
+    name: obj
+    for name, obj in vars(workflow_ui).items()
+    if inspect.isfunction(obj) and not name.startswith("_")
+    and obj.__module__ == workflow_ui.__name__
+}
+
+_TASKS_DIR = Path(workflow_ui.__file__).parent / "tasks"
+
+
+def _call_sites() -> List[Tuple[Path, int, str, ast.Call]]:
+    """Every call to a workflows.ui helper made from a workflow task module."""
+    sites = []
+    for path in sorted(_TASKS_DIR.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - a broken file is another test's problem
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = _called_helper_name(node.func)
+            if name in _HELPERS:
+                sites.append((path, node.lineno, name, node))
+    return sites
+
+
+def _called_helper_name(func: ast.expr):
+    """The helper being called, or None if this is not a direct call to one.
+
+    `self.update_status_ui(...)` is a *method* that wraps the module-level function of the
+    same name with different parameter names (`message=` vs `msg=`). Matching on the
+    attribute alone reported it as a signature mismatch when it is simply a different
+    callable, so calls on self/cls are excluded.
+    """
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        value = func.value
+        if isinstance(value, ast.Name) and value.id in {"self", "cls"}:
+            return None
+        return func.attr
+    return None
+
+
+def test_the_helpers_are_discoverable():
+    """Guard against the discovery above silently finding nothing, which would make every
+    other test in this file vacuously pass."""
+    assert "ask_user" in _HELPERS, f"ask_user not discovered; found {sorted(_HELPERS)}"
+    assert _call_sites(), "no workflow-ui call sites found — discovery is broken"
+
+
+@pytest.mark.parametrize(
+    "path,lineno,name,call",
+    [pytest.param(*s, id=f"{s[0].name}:{s[1]}:{s[2]}") for s in _call_sites()],
+)
+def test_call_site_matches_signature(path, lineno, name, call):
+    """Bind each call's arguments against the real signature.
+
+    Positional args are passed as placeholders — only arity and keyword *names* matter
+    here, not types. `bind_partial` because a task may legitimately rely on defaults.
+    """
+    signature = inspect.signature(_HELPERS[name])
+    args = [object()] * len(call.args)
+    if any(isinstance(a, ast.Starred) for a in call.args):
+        pytest.skip("call uses *args; arity cannot be checked statically")
+    kwargs = {kw.arg: object() for kw in call.keywords if kw.arg is not None}
+    if any(kw.arg is None for kw in call.keywords):
+        pytest.skip("call uses **kwargs; keywords cannot be checked statically")
+
+    try:
+        signature.bind_partial(*args, **kwargs)
+    except TypeError as exc:
+        pytest.fail(
+            f"{path.name}:{lineno} calls {name}({', '.join(sorted(kwargs))}) "
+            f"but the signature is {name}{signature} — {exc}"
+        )


### PR DESCRIPTION
Found while investigating a report that coincidence milling wasn't auto-stopping. Unrelated to that report — which turned out not to be a bug — but real.

## The bug

```python
# mill_coincident.py:227
ask_user(self.parent_ui, msg=..., pos="Continue", coincidence_milling=True)

# workflows/ui.py:128
def ask_user(parent_ui, msg, pos, neg=None, mill=None, det=None, spot_burn=None) -> bool:
```

`TypeError: got an unexpected keyword argument 'coincidence_milling'`, verified on `main`. `MillCoincidentTask` raises at the hand-off to the operator — after moving the stage and objective, applying the milling config, setting the FM channel and acquiring. It fails at the point where it would wait, not before doing work.

## Why dropped rather than plumbed through

Nothing consumes the flag. Its siblings both have handlers in `handle_workflow_update`:

* `milling_enabled` → switch to the milling tab, hide the run button
* `spot_burn` → activate the spot-burn widget in workflow mode
* `coincidence_milling` → **nothing**

So adding the parameter would have added an inert flag. Whether the workflow *should* surface the coincidence viewer at that point is a separate design question — operators open it by hand today, and that is being checked with them.

## Why it survived

Not a recent regression: the mismatch was already present on 2026-07-24 (`c21c8994`), and `ui.py` has not changed since 2026-07-02. The workflow path is rarely exercised — in a 119k-line log covering ten coincidence mills over two days, `MillCoincidentTask` never ran once (no `MILL_COINCIDENT` status message, no `WAITING_FOR_USER_INTERACTION`), while sibling task keys logged freely.

## Test

Rather than pinning this one line, it binds **every** call to a `workflows/ui` helper made from a task module against the real signature — 22 call sites today, and new helpers are picked up automatically. These helpers are only called from tasks needing hardware and a GUI, so nothing imports them under test and a plain signature mismatch is invisible until an operator hits it mid-run.

Two things about its shape, both from getting them wrong first:

- it asserts the discovery actually finds call sites, because a broken AST walk would make every case vacuously pass;
- it skips calls on `self`/`cls` — `self.update_status_ui()` is a method wrapping the module-level function with different parameter names (`message=` vs `msg=`), and the first version reported it as a mismatch.

2,165 tests pass.

Closes FIB-454.