### PR TITLE
[fm] Add the FM Overview tab, and make its overviews land on disk (FIB-431, FIB-432, FIB-444)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import sys
 import time
+from typing import Optional
 
 try:
     sys.modules.pop("PySide6.QtCore")
@@ -41,6 +42,7 @@ from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus, La
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI, INSTRUCTIONS
 from fibsem.applications.autolamella.workflows.tasks.tasks import get_task_supervision
 from fibsem.ui import FibsemMinimapWidget
+from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
 from fibsem.ui.qt.gc import install_main_thread_gc
 from fibsem.ui.stylesheets import (
     MILLING_PROGRESS_BAR_STYLESHEET,
@@ -517,6 +519,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.action_report_issue.setVisible(
             self._preferences.features.bug_report_enabled
         )
+        # Show or hide the FM Overview tab, building or dropping its widget to match
+        self._apply_fm_overview_visibility()
         # Toggle Tools -> Scripts. Hiding the menu hides the whole feature: it is the
         # only route to the manager dialog, and the dialog is the only thing that runs
         # a script. If a script is mid-run, leave it visible -- taking away the only
@@ -841,11 +845,18 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self._set_minimap_workflow_enabled(True)
 
     def _set_minimap_workflow_enabled(self, enabled: bool):
-        """Enable/disable minimap acquisition and load-image buttons during workflow."""
-        if not hasattr(self, "minimap_widget"):
-            return
-        self.minimap_widget.pushButton_run_tile_collection.setEnabled(enabled)
-        self.minimap_widget.pushButton_load_image.setEnabled(enabled)
+        """Enable/disable overview acquisition in both overview tabs during a workflow.
+
+        A running workflow owns the instrument, so neither tab should be able to start
+        competing for it. The FM tab keeps its Cancel button live regardless -- see
+        `FMOverviewWidget.set_interactive` -- so a lock arriving mid-run cannot strand an
+        acquisition with no way to stop it.
+        """
+        if hasattr(self, "minimap_widget"):
+            self.minimap_widget.pushButton_run_tile_collection.setEnabled(enabled)
+            self.minimap_widget.pushButton_load_image.setEnabled(enabled)
+        if getattr(self, "fm_overview_widget", None) is not None:
+            self.fm_overview_widget.set_interactive(enabled)
 
     def _set_border_state(self, state: str):
         """Update the tab widget border to reflect current workflow state.
@@ -935,6 +946,11 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def _on_microscope_connected(self):
         """Handle microscope connection and connect milling progress signal."""
+        # Before the signal wiring below, which returns early on a disconnect: the FM
+        # overview tab has to hear about that case too, to let go of the old microscope.
+        # Through the visibility path rather than straight to the builder, because
+        # whether this system has a fluorescence detector at all is only known now.
+        self._apply_fm_overview_visibility()
         if (
             self.autolamella_ui is not None
             and self.autolamella_ui.microscope is not None
@@ -1123,6 +1139,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """Create the tabs for the AutoLamella UI."""
         self._create_main_tab()
         self.add_minimap_tab()
+        self.add_fm_overview_tab()
         self.add_protocol_editor_tab()
         self.add_lamella_editor_tab()
         self.add_workflow_tab()
@@ -1139,6 +1156,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             return
 
         self.minimap_widget.set_experiment()
+        self._update_fm_overview_experiment()
         self.task_widget.set_experiment(self.autolamella_ui.experiment)
         self.lamella_widget.set_experiment()
         experiment = self.autolamella_ui.experiment
@@ -1171,8 +1189,17 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             if hasattr(self, "_lamella_tab_container")
             else -1
         )
+        # The FM overview tab is enabled by the presence of a fluorescence detector, not
+        # by an experiment, so loading one must not switch it on for a system that has
+        # no FM -- it would open onto an empty container.
+        fm_overview_tab_index = (
+            self.tab_widget.indexOf(self._fm_overview_container)
+            if getattr(self, "fm_overview_widget", None) is None
+            and hasattr(self, "_fm_overview_container")
+            else -1
+        )
         for i in range(self.tab_widget.count()):
-            if i == lamella_tab_index:
+            if i in (lamella_tab_index, fm_overview_tab_index):
                 continue
             self.tab_widget.setTabEnabled(i, True)
 
@@ -1745,6 +1772,158 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         # disable the tab by default
         self.tab_widget.setTabEnabled(self.tab_widget.indexOf(container), False)
+
+    def add_fm_overview_tab(self):
+        """Reserve the FM Overview tab, beside the beam one.
+
+        Behind `features.fm_overview_tab` in user preferences, off by default: the
+        rebuilt fluorescence overview UI is still being finished, and it sits beside the
+        existing Overview tab while driving the same instrument.
+
+        The tab is always created and hidden when off, rather than skipped: that makes
+        the preference take effect the moment it is changed instead of at the next
+        launch. The widget inside is still built and destroyed with the flag -- see
+        :meth:`_apply_fm_overview_visibility` -- so a hidden tab costs nothing but the
+        container.
+
+        Separate from "Overview" deliberately, not as a step toward merging them: the
+        two show different stage poses -- milling pose on the beam side, FM pose here --
+        and relating them is what the correlation workflow is for.
+
+        Only the container is made here. `FMOverviewWidget` requires a microscope with a
+        fluorescence detector at construction -- it has no meaningful empty state, since
+        every scale on its canvas comes from the camera -- and at this point there may
+        be no microscope at all. The widget is built on connection instead, by
+        :meth:`_build_fm_overview_widget`, and the tab stays disabled until then.
+        """
+        self._fm_overview_container = QWidget()
+        layout = QVBoxLayout(self._fm_overview_container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.fm_overview_widget: Optional[FMOverviewWidget] = None
+        # The microscope the current widget was built for. A reconnection hands out a
+        # new object, and the old widget would go on reading geometry from an instrument
+        # nobody is driving (FIB-433), so the identity is worth keeping.
+        self._fm_overview_microscope = None
+
+        self.tab_widget.insertTab(
+            2, self._fm_overview_container,
+            fibsem_icon("mdi:microscope", color=GRAY_ICON_COLOR), "FM Overview",
+        )
+        self.tab_widget.setTabEnabled(
+            self.tab_widget.indexOf(self._fm_overview_container), False
+        )
+        self._apply_fm_overview_visibility()
+
+    def _apply_fm_overview_visibility(self):
+        """Show or hide the FM Overview tab to match the preference, immediately.
+
+        The widget inside is built and destroyed along with the tab rather than left
+        behind hidden. It subscribes to the microscope's stage signal for its lifetime,
+        so a hidden one would go on doing work on every poll for a feature that has been
+        switched off — and would still be holding a psygnal reference to tear down later.
+
+        Two different absences, deliberately handled differently:
+
+        * **A connected microscope with no fluorescence detector** will never drive this
+          tab, so it is hidden. Leaving it visible means a permanently greyed-out tab
+          with nothing to say why, on every system without an FM.
+        * **No microscope yet** is temporary, so the tab stays visible and disabled,
+          which is what every other tab does while waiting for a connection.
+        """
+        if not hasattr(self, "_fm_overview_container"):
+            return
+        index = self.tab_widget.indexOf(self._fm_overview_container)
+        microscope = (
+            self.autolamella_ui.microscope if self.autolamella_ui is not None else None
+        )
+        has_no_fm = microscope is not None and microscope.fm is None
+        self.tab_widget.setTabVisible(
+            index, fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED and not has_no_fm
+        )
+        # Builds when the flag is on and there is an FM, tears down otherwise.
+        self._build_fm_overview_widget()
+
+    def _build_fm_overview_widget(self):
+        """Put a widget in the FM Overview tab, once there is something to drive.
+
+        Called on every connection. Rebuilds when the microscope object has changed,
+        because the widget holds its microscope for life and would otherwise be talking
+        to the previous one -- destructive of anything on the canvas, and the reason
+        FIB-433 exists to do this without throwing the view away.
+        """
+        # `connected_signal` is subscribed in `_create_main_tab`, which runs before this
+        # tab is reserved. Nothing can fire in between synchronously, but the ordering is
+        # not this method's to rely on.
+        if not hasattr(self, "_fm_overview_container"):
+            return
+
+        microscope = (
+            self.autolamella_ui.microscope if self.autolamella_ui is not None else None
+        )
+        index = self.tab_widget.indexOf(self._fm_overview_container)
+
+        if (
+            not fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED
+            or microscope is None
+            or microscope.fm is None
+        ):
+            # Switched off, or no fluorescence detector. The tab stays in place but dead
+            # rather than being removed, so the tab bar does not change shape between
+            # systems; hiding it is `_apply_fm_overview_visibility`'s job.
+            self._teardown_fm_overview_widget()
+            self.tab_widget.setTabEnabled(index, False)
+            return
+
+        if self.fm_overview_widget is not None:
+            if self._fm_overview_microscope is microscope:
+                return
+            self._teardown_fm_overview_widget()
+
+        try:
+            self.fm_overview_widget = FMOverviewWidget(microscope)
+        except Exception as e:
+            logging.error(f"Could not create the FM overview tab: {e}")
+            self.tab_widget.setTabEnabled(index, False)
+            return
+
+        self._fm_overview_microscope = microscope
+        self._fm_overview_container.layout().addWidget(self.fm_overview_widget)
+        self.tab_widget.setTabEnabled(index, True)
+        self._update_fm_overview_experiment()
+
+    def _teardown_fm_overview_widget(self):
+        """Drop the current FM overview widget, if there is one.
+
+        `close()` rather than `deleteLater()` alone: the widget's `closeEvent` is what
+        releases its psygnal subscriptions on the microscope, and those outlive the
+        widget -- a stale one left connected emits into a torn-down Qt object.
+        """
+        if self.fm_overview_widget is None:
+            return
+        try:
+            self.fm_overview_widget.close()
+        except Exception as e:
+            logging.debug(f"Error closing the FM overview widget: {e}")
+        self._fm_overview_container.layout().removeWidget(self.fm_overview_widget)
+        self.fm_overview_widget.deleteLater()
+        self.fm_overview_widget = None
+        self._fm_overview_microscope = None
+
+    def _update_fm_overview_experiment(self):
+        """Tell the FM overview tab where to save.
+
+        Told rather than handed the experiment: the widget knows nothing about
+        experiments, and keeping it that way is what lets it open standalone against a
+        simulator and be constructed in a test from a microscope alone.
+        """
+        if getattr(self, "fm_overview_widget", None) is None:
+            return
+        experiment = (
+            self.autolamella_ui.experiment if self.autolamella_ui is not None else None
+        )
+        self.fm_overview_widget.set_save_directory(
+            str(experiment.path) if experiment is not None else None
+        )
 
     def _on_notification_service(
         self, message: str, notification_type: str, temporary: bool

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -263,6 +263,10 @@ class FeatureFlags:
     # microscope and none of its guard rails, so the menu is not offered to anyone
     # who has not asked for it (FIB-338).
     scripts_enabled: bool = False
+    # The FM Overview tab. Off while the rebuilt fluorescence overview UI is still
+    # being finished -- it sits beside the existing Overview tab and drives the same
+    # instrument, so it is offered only to people who have asked for it (FIB-432).
+    fm_overview_tab: bool = False
 
 @dataclass
 class MovementPreferences:
@@ -471,12 +475,14 @@ def apply_feature_flags(prefs: UserPreferences) -> None:
     global FEATURE_COINCIDENCE_MILLING_ENABLED
     global FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED
     global FEATURE_SCHEDULED_TASKS_ENABLED
+    global FEATURE_FM_OVERVIEW_TAB_ENABLED
     f = prefs.features
     FEATURE_LAMELLA_POSITION_ON_LIVE_VIEW_ENABLED = f.lamella_position_on_live_view
     FEATURE_VIEWER_MOVEMENT_EVENTS = f.viewer_movement_events
     FEATURE_COINCIDENCE_MILLING_ENABLED = f.coincidence_milling_enabled
     FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED = f.sample_holder_widget
     FEATURE_SCHEDULED_TASKS_ENABLED = f.scheduled_tasks
+    FEATURE_FM_OVERVIEW_TAB_ENABLED = f.fm_overview_tab
 
     # Also update the autolamella config module which re-exports these
     try:
@@ -504,3 +510,4 @@ FEATURE_VIEWER_MOVEMENT_EVENTS = False
 FEATURE_COINCIDENCE_MILLING_ENABLED = False
 FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED = False
 FEATURE_SCHEDULED_TASKS_ENABLED = False
+FEATURE_FM_OVERVIEW_TAB_ENABLED = False

--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import threading
-from dataclasses import replace
+from dataclasses import dataclass, replace
 import time
 from copy import deepcopy
 from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING, Literal
@@ -17,6 +17,7 @@ from fibsem.imaging.tiling.geometry import (
     TilePosition,
     compute_tile_grid_from_fov,
     order_tiles,
+    raise_if_outside_stage_limits,
 )
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.structures import (
@@ -418,6 +419,90 @@ def _to_channel_planes(data: np.ndarray, n_channels: int) -> np.ndarray:
     raise ValueError(f"Unsupported tile data dimensions: {data.ndim}")
 
 
+@dataclass(frozen=True)
+class OverviewDestination:
+    """Where one overview run's files go.
+
+    A run produces three things -- the tiles, the parameters describing them, and the
+    stitched mosaic -- and they have to land somewhere a later reader can put back
+    together. The tiles and their parameters get a directory of their own; the mosaic
+    sits beside that directory under the same name, because it is the thing anyone
+    opening the folder is actually looking for and burying it among a hundred tiles
+    would hide it.
+
+    Held as a value rather than recomputed at each call site: the tile directory is
+    chosen before the run and the mosaic path after it, so the two are minutes apart,
+    and a timestamp regenerated in between would name them differently.
+    """
+
+    basename: str
+    tiles_directory: str
+    mosaic_path: str
+
+    # Enough to step past any plausible pile-up inside one second, and low enough that a
+    # genuinely stuck loop gives up instead of spinning.
+    MAX_NAME_ATTEMPTS = 1000
+
+    @classmethod
+    def create(cls, root: str, basename: Optional[str] = None) -> "OverviewDestination":
+        """Claim a destination under *root*, making the tile directory.
+
+        The directory is made now rather than at the first tile so that a run which
+        fails immediately still leaves evidence it was attempted, and so a caller finds
+        out about an unwritable path before it moves the stage rather than after.
+
+        Raises:
+            OSError: if the directory cannot be made, or no free name was found.
+        """
+        stem = basename or f"overview-{utils.current_timestamp_v3(timeonly=True)}"
+        # The timestamp is only good to the second, and two runs can start inside one --
+        # a single-tile overview at a short exposure takes far less. Reusing the name
+        # would let the second run overwrite the first tile for tile, silently, which is
+        # the exact failure this class exists to prevent. So a taken name is stepped
+        # past: `makedirs` without `exist_ok` is what makes the check and the claim one
+        # atomic operation rather than a look-then-leap.
+        for attempt in range(1, cls.MAX_NAME_ATTEMPTS + 1):
+            candidate = stem if attempt == 1 else f"{stem}-{attempt}"
+            mosaic_path = os.path.join(root, f"{candidate}.ome.tiff")
+            tiles_directory = os.path.join(root, candidate)
+            # Both, because a run can leave a mosaic behind whose tile directory was
+            # cleaned up, and reusing that name would overwrite the mosaic instead.
+            if os.path.exists(mosaic_path):
+                continue
+            try:
+                os.makedirs(tiles_directory)
+            except FileExistsError:
+                continue
+            return cls(
+                basename=candidate,
+                tiles_directory=tiles_directory,
+                mosaic_path=mosaic_path,
+            )
+        raise OSError(
+            f"Could not find a free name for an overview under {root} after "
+            f"{cls.MAX_NAME_ATTEMPTS} attempts."
+        )
+
+    def save_mosaic(self, mosaic: FluorescenceImage) -> Optional[str]:
+        """Write the stitched mosaic, returning where it went, or None if it could not.
+
+        Failing to save is logged rather than raised: by the time this is called the
+        acquisition is over and the mosaic is in hand, so throwing would discard a
+        completed result over a filesystem problem the caller can do nothing about
+        mid-run. The return value is what tells a caller whether it landed.
+        """
+        # Stamped so a mosaic reloaded from disk still knows which run it came from --
+        # the tiles are in a directory of this name next to it.
+        mosaic.metadata.description = self.basename
+        try:
+            mosaic.save(self.mosaic_path)
+        except Exception as e:
+            logging.error(f"Failed to save the overview to {self.mosaic_path}: {e}")
+            return None
+        logging.info(f"Overview saved to: {self.mosaic_path}")
+        return self.mosaic_path
+
+
 class FMTiledAcquisitionRunner:
     """Orchestrates a fluorescence tileset acquisition as a series of discrete phases.
 
@@ -476,10 +561,13 @@ class FMTiledAcquisitionRunner:
         """
         self._setup()
         self._compute_grid()
+        # Before the loop, not after it. The parameters describe what was *requested*,
+        # so they are already known -- and writing them at the end meant a cancelled run
+        # left its tiles on disk with nothing saying what grid they belonged to.
+        self._save_parameters()
         try:
             self._autofocus_if_mode(AutoFocusMode.ONCE)
             self._run_tile_loop()
-            self._save_parameters()
         except OperationCancelledError:
             logging.info("Tileset acquisition cancelled")
             raise
@@ -680,6 +768,19 @@ class FMTiledAcquisitionRunner:
             )
             for tile in self._grid
         }
+
+        # Refuse a grid the stage cannot reach, before anything moves. The same check
+        # the beam tiler makes, through the same helper, so the two cannot come to
+        # different conclusions about the same limits. Only the tiles that will be
+        # visited: `_ordered` has the masked-off ones dropped already, so excluding a
+        # corner is a legitimate way to bring a grid back into range.
+        limits = getattr(self.microscope._stage, "limits", None)
+        if limits:
+            raise_if_outside_stage_limits(
+                self._ordered,
+                [self._tile_stage_positions[(t.row, t.col)] for t in self._ordered],
+                limits,
+            )
 
         self._init_preview_canvas()
 
@@ -1186,15 +1287,12 @@ def acquire_and_stitch_tileset(
     if not isinstance(channel_settings, list):
         channel_settings = [channel_settings]
 
-    # Create timestamp and subdirectory for tiles
-    if save_directory is not None:
-        timestamp = utils.current_timestamp_v3(timeonly=True)
-        basename = f"overview-{timestamp}"
-        tiles_directory = os.path.join(save_directory, basename)
-        os.makedirs(tiles_directory, exist_ok=True)
-    else:
-        tiles_directory = None
-    
+    destination = (
+        OverviewDestination.create(save_directory) if save_directory is not None else None
+    )
+    tiles_directory = destination.tiles_directory if destination is not None else None
+
+
     # Check if zparams is provided when z-stack is requested
     if zparams is None and overview_parameters.use_zstack:
         raise ValueError("Z-stack requested in overview parameters but no zparams provided")
@@ -1221,15 +1319,8 @@ def acquire_and_stitch_tileset(
         return None
 
     # Save overview to experiment directory
-    if save_directory is not None:
-        filepath = os.path.join(save_directory, f"{basename}.ome.tiff")
-        overview_image.metadata.description = basename
-
-        try:
-            overview_image.save(filepath)
-            logging.info(f"Overview saved to: {filepath}")
-        except Exception as e:
-            logging.error(f"Failed to save overview to {filepath}: {e}")
+    if destination is not None:
+        destination.save_mosaic(overview_image)
 
     return overview_image
 

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -21,6 +21,7 @@ from fibsem.imaging.tiling.geometry import (  # noqa: E402,F401
     TilePosition,
     compute_tile_grid,
     order_tiles,
+    raise_if_outside_stage_limits,
     validate_tile_stage_positions,
 )
 from fibsem.imaging.tiling.geometry import _spiral_order  # noqa: E402,F401
@@ -250,15 +251,9 @@ class TiledAcquisitionRunner:
         for tile, sp in zip(self._ordered, self._tile_stage_positions):
             logging.info(f"Tile ({tile.row}, {tile.col}) projected: {sp.pretty}")
 
-        out_of_bounds = validate_tile_stage_positions(
+        raise_if_outside_stage_limits(
             self._ordered, self._tile_stage_positions, self.microscope._stage.limits
         )
-        if out_of_bounds:
-            details = ", ".join(f"({r},{c})" for r, c in out_of_bounds)
-            raise ValueError(
-                f"Overview acquisition grid extends beyond stage limits. "
-                f"{len(out_of_bounds)} tile(s) out of bounds: {details}"
-            )
 
         # EACH_ROW is not well-defined for SPIRAL (rows are revisited non-sequentially),
         # so promote it to EACH_TILE so focus is always fresh.

--- a/fibsem/imaging/tiling/__init__.py
+++ b/fibsem/imaging/tiling/__init__.py
@@ -8,6 +8,7 @@ from fibsem.imaging.tiling.geometry import (
     TilePosition,
     compute_tile_grid,
     order_tiles,
+    raise_if_outside_stage_limits,
     validate_tile_stage_positions,
 )
 from fibsem.imaging.tiling.plotting import (
@@ -33,6 +34,7 @@ __all__ = [
     "plot_stage_positions_on_image",
     "plot_tile_grid",
     "plot_tile_positions",
+    "raise_if_outside_stage_limits",
     "reproject_stage_positions_onto_image",
     "reproject_stage_positions_onto_image2",
     "validate_tile_stage_positions",

--- a/fibsem/imaging/tiling/geometry.py
+++ b/fibsem/imaging/tiling/geometry.py
@@ -245,3 +245,36 @@ def validate_tile_stage_positions(
         for tile, sp in zip(ordered, tile_stage_positions)
         if not sp.is_within_limits(limits, axes=["x", "y"])
     ]
+
+
+def raise_if_outside_stage_limits(
+    ordered: list[TilePosition],
+    tile_stage_positions: list[FibsemStagePosition],
+    limits: dict,
+) -> None:
+    """Refuse a grid the stage cannot reach, naming the tiles that put it there.
+
+    Rejected rather than trimmed. A tileset silently missing the tiles the stage ran out
+    of travel for is a mosaic that misrepresents the sample: the gaps stitch as zeros,
+    indistinguishable from dark sample, and anything downstream consuming it -- targeting,
+    correlation -- takes them for data. Better to say so before the run starts, while the
+    grid can still be moved.
+
+    Only the tiles that will actually be visited are checked: `ordered` has already had
+    the disabled ones dropped, so masking off a corner that falls outside the limits is a
+    legitimate way to make a grid acquirable.
+
+    Shared by both tilers so they refuse the same grids for the same reason -- the FM
+    runner did not check at all, which is the shape of bug this core exists to prevent.
+
+    Raises:
+        ValueError: if any tile is outside *limits*.
+    """
+    out_of_bounds = validate_tile_stage_positions(ordered, tile_stage_positions, limits)
+    if not out_of_bounds:
+        return
+    details = ", ".join(f"({r},{c})" for r, c in out_of_bounds)
+    raise ValueError(
+        f"Acquisition grid extends beyond stage limits. "
+        f"{len(out_of_bounds)} tile(s) out of bounds: {details}"
+    )

--- a/fibsem/ui/fm/overview_app.py
+++ b/fibsem/ui/fm/overview_app.py
@@ -5,6 +5,7 @@ overview UI can be exercised without launching AutoLamella.
 
     python -m fibsem.ui.fm.overview_app                 # Demo, compustage at t = -180
     python -m fibsem.ui.fm.overview_app --manufacturer Thermo --ip 10.0.0.1
+    python -m fibsem.ui.fm.overview_app --output ~/fm-overviews    # and save them
 
 The default puts the simulator in the Arctis fluorescence pose -- compustage, no
 pre-tilt, stage tilted to -180 degrees -- because that is the geometry the tile
@@ -13,6 +14,7 @@ projection is built around and the one worth exercising.
 
 import argparse
 import logging
+import os
 import sys
 from typing import Optional
 
@@ -66,6 +68,10 @@ def main(argv: Optional[list] = None) -> int:
                         help="Stage tilt in degrees for the Demo pose (default: -180)")
     parser.add_argument("--no-compustage", action="store_false", dest="compustage",
                         help="Pose the Demo microscope as an offset FM mount instead")
+    parser.add_argument("--output", default=None, metavar="DIR",
+                        help="Write acquired overviews under DIR. Each run gets its own "
+                             "subdirectory of tiles, with the stitched mosaic beside it. "
+                             "Omitted, overviews are shown but not saved.")
     args = parser.parse_args(argv)
 
     from PyQt5.QtWidgets import QApplication, QMainWindow
@@ -93,7 +99,15 @@ def main(argv: Optional[list] = None) -> int:
         f"{' · compustage' if microscope.stage_is_compustage else ''}"
         f" · t = {np.rad2deg(microscope.get_stage_position().t):.0f}°"
     )
-    window.setCentralWidget(FMOverviewWidget(microscope))
+    widget = FMOverviewWidget(microscope)
+    # Opt-in rather than defaulted to the working directory: this app is mostly run
+    # against a simulator to exercise the UI, and those runs should not leave tiles
+    # behind wherever it happened to be launched from.
+    if args.output:
+        os.makedirs(args.output, exist_ok=True)
+        widget.set_save_directory(args.output)
+        logging.info(f"Overviews will be saved under {args.output}")
+    window.setCentralWidget(widget)
     window.resize(1500, 900)
     window.show()
     return app.exec_()

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -26,7 +26,7 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem import constants
-from fibsem.fm.acquisition import FMTiledAcquisitionRunner, stitch_tileset
+from fibsem.fm.acquisition import FMTiledAcquisitionRunner, OverviewDestination
 from fibsem.fm.structures import (
     AutoFocusMode,
     AutoFocusSettings,
@@ -157,6 +157,20 @@ class FMOverviewWidget(QWidget):
         # somewhere. None means "wherever the stage is", which is what the runner does
         # by default -- so an untouched grid describes exactly what would be acquired.
         self._target: Optional[FibsemStagePosition] = None
+        # Where acquired overviews are written. None means nowhere: the widget opens
+        # standalone against a simulator as often as it runs inside an experiment, and
+        # inventing a directory for those runs would scatter files through whatever
+        # working directory it happened to be launched from. A host that has somewhere
+        # to put them says so -- see `set_save_directory`.
+        self._save_directory: Optional[str] = None
+        self._destination: Optional[OverviewDestination] = None
+        self._saved_path: Optional[str] = None
+        # Whether a run is under way, and whether a host is allowing one to be started.
+        # Two independent facts kept apart on purpose: a workflow ending must not
+        # re-enable a tab whose acquisition is still going, nor the reverse. See
+        # `_apply_enabled_state`, which is the only thing that reads them.
+        self._running = False
+        self._interactive = True
 
         self._init_ui(channel_settings or self._default_channels())
         self._sync_tile_fov()
@@ -494,23 +508,28 @@ class FMOverviewWidget(QWidget):
         span_x = parameters.cols * fov[0] * (1 - parameters.overlap) + fov[0]
         span_y = parameters.rows * fov[1] * (1 - parameters.overlap) + fov[1]
 
-        # Refit only when the grid's footprint actually changes. Toggling a tile also
-        # comes through here, and refitting on that threw away whatever zoom and pan
-        # the user had set -- so clicking a tile appeared to zoom the view.
-        # Recorded whether or not the view is refitted, so that a drag -- which
-        # suppresses the refit on every step -- does not leave the footprint looking
+        # Measured against the area as it stands, before the line below moves it.
+        left_area = self._grid_has_left_the_working_area(offset, span_x, span_y)
+
+        # Keep the declared working area on the grid, always and silently. It is what
+        # the zoom limiter measures against, so an area left behind stretches the
+        # content across the gap and caps how far the view can zoom in. `refit=False`
+        # is what makes doing this continuously safe: re-declaring used to re-frame,
+        # so dragging the grid snapped the view onto it on every motion event.
+        self.canvas.set_world_extent(span_x, span_y, offset, refit=False)
+
+        # Re-frame only for a reason the user would expect to move the view: the grid's
+        # footprint changed, or it has ended up outside what was framed (a stage move to
+        # an offset FM mount travels 48 mm). Never mid-gesture -- a drag emits on every
+        # motion event, and re-framing each time zooms the canvas out from under the
+        # cursor. Toggling a tile comes through here too, and re-framing on one threw
+        # away the user's zoom, which is what made clicking a tile look like zooming.
+        # The footprint is recorded either way, so a suppressed refit does not leave it
         # stale and jump the view on the next unrelated settings change.
         footprint = (parameters.rows, parameters.cols, parameters.overlap)
         changed = footprint != self._grid_footprint
         self._grid_footprint = footprint
-        if (changed or self._grid_has_left_the_working_area(offset, span_x, span_y)) \
-                and not self.tile_grid_overlay.is_resizing:
-            # Frame the planned area, so an empty canvas shows where the run will go
-            # rather than nothing at all, and so clicks land in a meaningful frame.
-            # Behind the same guard as the refit below, and for the same reason: a tile
-            # toggle comes through here too, and re-framing on one threw away the
-            # user's zoom -- which is what made clicking a tile look like zooming.
-            self.canvas.set_world_extent(span_x, span_y, offset)
+        if (changed or left_area) and not self.tile_grid_overlay.is_dragging:
             self.tile_grid_overlay.fit_view()
 
     def _grid_has_left_the_working_area(
@@ -636,6 +655,38 @@ class FMOverviewWidget(QWidget):
         """
         self._positions = list(positions)
         self._refresh_positions()
+
+    def set_save_directory(self, path: Optional[str]) -> None:
+        """Write acquired overviews under *path*, or None to keep them in memory only.
+
+        Each run claims its own subdirectory under this one, named for when it started,
+        so consecutive runs accumulate instead of overwriting each other -- pointing
+        straight at an experiment directory and letting the runner write `tile-00-00`
+        into it would mean every overview replaced the last.
+
+        Told rather than discovered, because this widget knows nothing about
+        experiments: it is handed a microscope, and its tests construct it that way.
+        """
+        self._save_directory = path
+
+    @property
+    def saved_path(self) -> Optional[str]:
+        """Where the last acquired overview was written, if it was."""
+        return self._saved_path
+
+    def set_interactive(self, enabled: bool) -> None:
+        """Allow or forbid starting work, without touching a run already in progress.
+
+        For a host that owns the instrument for a while -- an AutoLamella workflow --
+        and needs the tab to stop competing for it. Cancel stays live regardless, so a
+        lock arriving mid-run cannot strand an acquisition with no way to stop it.
+
+        Deliberately not `setEnabled(False)` on the whole widget: greying out the canvas
+        would also stop you *reading* the overview you just acquired, and looking at it
+        costs the workflow nothing.
+        """
+        self._interactive = enabled
+        self._apply_enabled_state()
 
     def set_origin(self, position: Optional[FibsemStagePosition]) -> None:
         """Anchor the canvas frame at *position*, or None to go back to automatic.
@@ -1006,16 +1057,35 @@ class FMOverviewWidget(QWidget):
             return
         self._refresh_tile_grid()
         self._update_grid_summary()
-        parameters = self.settings_widget.parameters
-        enabled = parameters.n_enabled_tiles > 0
-        self.button_acquire.setEnabled(enabled)
+        self._apply_enabled_state()
         # Only own the status line while it has something of its own to say. Re-enabling
         # the controls at the end of a run makes children emit `changed`, which landed
         # here and wiped the result message the moment it was set.
-        if not enabled:
+        if self.settings_widget.parameters.n_enabled_tiles == 0:
             self.status.setText("No tiles selected.")
         elif self.status.text() == "No tiles selected.":
             self.status.setText("")
+
+    def _apply_enabled_state(self) -> None:
+        """One place decides what is clickable, from three independent facts.
+
+        A run in progress, a host that has locked the tab, and a grid with nothing
+        selected each disable different things, and they overlap: a workflow finishing
+        while an overview runs must not re-enable Acquire, and a run finishing inside a
+        locked tab must not either. Two places each setting the buttons from their own
+        half of the truth is how a control gets stuck; deriving all of it from all three
+        every time is the version that cannot.
+        """
+        idle = self._interactive and not self._running
+        has_tiles = self.settings_widget.parameters.n_enabled_tiles > 0
+        self.button_acquire.setEnabled(idle and has_tiles)
+        # Cancel is deliberately not gated on `_interactive`: a host locking the tab
+        # mid-run must not take away the only way to stop the stage. Once a cancel has
+        # been asked for, the button goes and stays away -- the stop event is the record
+        # of that, so asking it beats a second flag that could disagree.
+        self.button_cancel.setEnabled(self._running and not self._stop_event.is_set())
+        self.settings_widget.setEnabled(idle)
+        self.channel_widget.setEnabled(idle)
 
     # ── acquisition ──────────────────────────────────────────────────────
 
@@ -1052,6 +1122,10 @@ class FMOverviewWidget(QWidget):
             logging.info("Overview acquisition cancelled before starting")
             return
 
+        # Claimed on the GUI thread, before the worker starts: it makes a directory, so
+        # an unwritable path is reported now rather than after the stage has moved.
+        self._destination = self._claim_destination()
+
         self._stop_event.clear()
         self._set_running(True)
         self._runner = FMTiledAcquisitionRunner(
@@ -1065,9 +1139,31 @@ class FMOverviewWidget(QWidget):
             # stage still returns to where it started afterwards -- the target is the
             # grid's centre, not a new home.
             centre_position=self._target,
+            # None when no save directory has been set -- the standalone default. The
+            # runner writes each tile as it lands, so a cancelled run keeps what it got.
+            save_directory=self._destination.tiles_directory if self._destination else None,
         )
         self._worker = FunctionWorker(self._acquire_worker)
         self._worker.start()
+
+    def _claim_destination(self) -> Optional["OverviewDestination"]:
+        """Where this run's files go, or None if nowhere.
+
+        Failing to claim one is not fatal: an overview you can see is worth more than
+        no overview at all, so the run goes ahead unsaved and says so.
+        """
+        if self._save_directory is None:
+            return None
+        try:
+            return OverviewDestination.create(self._save_directory)
+        except OSError as e:
+            logging.error(f"Cannot save into {self._save_directory}: {e}")
+            notification_service.show_toast(
+                f"Could not prepare a save directory; this overview will not be "
+                f"saved.\n{e}",
+                "warning",
+            )
+            return None
 
     def _acquire_worker(self) -> None:
         """Runs off the GUI thread. Only signals may cross back."""
@@ -1075,14 +1171,12 @@ class FMOverviewWidget(QWidget):
 
         try:
             runner = self._runner
-            runner.run()
-            mosaic = stitch_tileset(
-                runner.tileset,
-                runner.overview_parameters.overlap,
-                centre_position=runner.centre_position,
-                objective_position=runner._initial_objective_position,
-            )
+            mosaic = runner.run_and_stitch()
             self._mosaic = mosaic
+            # Saved here rather than after the signal: a consumer of `overview_acquired`
+            # may want the file, and the mosaic carries the run's name once written.
+            if self._destination is not None:
+                self._saved_path = self._destination.save_mosaic(mosaic)
             self.overview_acquired.emit(mosaic)
             self.fm.acquisition_progress_signal.emit(
                 {"state": "overview-finished", "task": "tileset"}
@@ -1103,15 +1197,16 @@ class FMOverviewWidget(QWidget):
             return
         logging.info("Cancelling overview acquisition")
         self._stop_event.set()
-        self.button_cancel.setEnabled(False)
+        self._apply_enabled_state()
         self.status.setText("Cancelling…")
 
     def _set_running(self, running: bool) -> None:
-        self.button_acquire.setEnabled(not running)
-        self.button_cancel.setEnabled(running)
-        self.settings_widget.setEnabled(not running)
-        self.channel_widget.setEnabled(not running)
+        self._running = running
+        self._apply_enabled_state()
         if running:
+            # Cleared at the start, so a run that fails to save cannot inherit the
+            # previous run's path and report itself saved.
+            self._saved_path = None
             # Left empty rather than shown as indeterminate, which would paint a full
             # bar before a single tile had been acquired.
             self.progress_tiles.reset()
@@ -1254,6 +1349,21 @@ class FMOverviewWidget(QWidget):
         except Exception as e:
             logging.debug(f"Could not display the overview preview: {e}")
 
+    def _describe_save(self) -> Tuple[str, str]:
+        """Status suffix and tooltip for whether the overview reached disk.
+
+        Silent when nothing was meant to be saved, so the standalone app does not report
+        a failure every run. When a destination *was* claimed and the mosaic did not
+        land, that is worth saying: otherwise a failed save reads exactly like a
+        successful one, and the difference only turns up when someone goes looking for
+        the file.
+        """
+        if self._saved_path:
+            return "  ·  saved", self._saved_path
+        if self._destination is not None:
+            return "  ·  not saved", "Could not be written to disk — see the log."
+        return "", ""
+
     def _finish(self, state: str, error: Optional[str]) -> None:
         self._set_running(False)
         self._worker = None
@@ -1266,7 +1376,9 @@ class FMOverviewWidget(QWidget):
             self.set_image(self._mosaic)
             self.canvas.canvas.remove_image(PREVIEW_KEY)
             shape = self._mosaic.data.shape
-            self.status.setText(f"Overview acquired — {shape[-1]} × {shape[-2]} px")
+            suffix, tooltip = self._describe_save()
+            self.status.setText(f"Overview acquired — {shape[-1]} × {shape[-2]} px{suffix}")
+            self.status.setToolTip(tooltip)
             self.progress_tiles.update_progress(ProgressUpdate.done())
         elif state == "overview-cancelled":
             self.status.setText("Cancelled. Tiles acquired so far are still shown.")

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -701,7 +701,21 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         return self._content_extent()
 
     def _fit_view(self) -> None:
-        """Set the view to the fit extent expanded by ``_view_margin`` on each side."""
+        """Set the view to the fit extent expanded by ``_view_margin`` on each side.
+
+        Never while an overlay owns the gesture. Dragging something on the canvas is the
+        user manipulating a thing in the scene, not asking for the scene to be re-framed
+        — and a refit mid-drag moves the whole view out from under the pointer, which
+        reads as the view snapping onto whatever is being dragged.
+
+        Guarded here rather than only at the callers because a drag reaches the view
+        through several of them — the overlay's own margin, a re-declared working area,
+        any content change the drag provokes — and each one is a separate chance to get
+        it wrong. The flag is the canvas's own record of who owns the gesture, cleared
+        on release along with the pan it already suppresses.
+        """
+        if self._overlay_consuming_event:
+            return
         extent = self._fit_extent()
         if extent is None:
             return

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -578,9 +578,10 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         self._placement = (float(centre[0]), float(centre[1]))
 
     def set_world_extent(self, width: Optional[float], height: Optional[float] = None,
-                         centre: Tuple[float, float] = (0.0, 0.0)) -> None:
+                         centre: Tuple[float, float] = (0.0, 0.0),
+                         refit: bool = True) -> None:
         """Declare the working area the canvas represents — see the canvas method."""
-        self.canvas.set_world_extent(width, height, centre)
+        self.canvas.set_world_extent(width, height, centre, refit)
 
     # ── display ───────────────────────────────────────────────────────────
 

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -224,6 +224,17 @@ class TileGridOverlay(QObject, CanvasOverlay):
         """
         return self._resize_axes is not None
 
+    @property
+    def is_dragging(self) -> bool:
+        """True while any grid gesture is in flight — a resize *or* a move.
+
+        Both emit on every motion event, so anything the host does in response has to
+        be cheap and must not move the camera. Moving was missed when this was only
+        :attr:`is_resizing`: dragging the grid re-declared the canvas's working area on
+        each step, and re-declaring refits, so the view snapped onto the grid.
+        """
+        return self._resize_axes is not None or self._move_active
+
     def fit_view(self, padding: float = 0.05) -> None:
         """Zoom out so the whole grid is visible, not just the tile at the centre.
 

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -278,6 +278,7 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         width: Optional[float],
         height: Optional[float] = None,
         centre: Tuple[float, float] = (0.0, 0.0),
+        refit: bool = True,
     ) -> None:
         """Always frame at least *width* x *height* metres, centred on *centre*.
 
@@ -290,6 +291,13 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
 
         A minimum, not a clip: images outside it still draw, and the view still grows to
         include them. Pass None to go back to fitting the content alone.
+
+        `refit=False` declares the area without moving the camera. The working area is
+        also what the zoom limiter measures against, so a caller may need it to keep up
+        with something that moves continuously — a planned grid being dragged — where
+        re-framing on every step would drag the view along with it. The framing is
+        recorded as already-fitted in that case, so the *next* content change does not
+        refit on account of this one either.
         """
         if width is None:
             updated = None
@@ -306,7 +314,14 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
             return
 
         self._world_extent_m = updated
-        self._fitted_extent = None  # force a refit against the new framing
+        if refit:
+            self._fitted_extent = None  # force a refit against the new framing
+        else:
+            # Adopt the new framing as though it had already been fitted. Needed even
+            # with images on screen: `_fit_extent` falls back to the working area when
+            # nothing is placed, so a bare `_after_content_change` would refit onto the
+            # new area on an empty canvas.
+            self._fitted_extent = self._fit_extent()
         self._after_content_change()
 
     @property

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -53,6 +53,12 @@ _TIP_BUG_REPORT    = (
     "Show the 'Report an Issue...' option in the Help menu, for reporting bugs and "
     "optionally submitting experiment data privately to the maintainers."
 )
+_LBL_FM_OVERVIEW   = "Enable FM Overview Tab"
+_TIP_FM_OVERVIEW   = (
+    "Add an FM Overview tab for acquiring fluorescence overviews on the real-space "
+    "canvas, beside the existing Overview tab. Still being finished, and it drives the "
+    "same microscope as the Fluorescence controls."
+)
 _LBL_SCRIPTS       = "Enable User Scripts"
 _TIP_SCRIPTS       = (
     "Show Tools > Scripts, for running your own .py files against the open "
@@ -144,12 +150,15 @@ class PreferencesDialog(QDialog):
         self._chk_bug_report.setToolTip(_TIP_BUG_REPORT)
         self._chk_scripts = QCheckBox()
         self._chk_scripts.setToolTip(_TIP_SCRIPTS)
+        self._chk_fm_overview = QCheckBox()
+        self._chk_fm_overview.setToolTip(_TIP_FM_OVERVIEW)
         features_form.addRow(_LBL_LAMELLA_LIVE, self._chk_lamella_live)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
         features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
         features_form.addRow(_LBL_SCHEDULED, self._chk_scheduled_tasks)
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
         features_form.addRow(_LBL_SCRIPTS, self._chk_scripts)
+        features_form.addRow(_LBL_FM_OVERVIEW, self._chk_fm_overview)
         self._stack.addWidget(features_page)
 
         # --- Experiment Defaults ---
@@ -212,6 +221,7 @@ class PreferencesDialog(QDialog):
         self._chk_scheduled_tasks.setChecked(f.scheduled_tasks)
         self._chk_bug_report.setChecked(f.bug_report_enabled)
         self._chk_scripts.setChecked(f.scripts_enabled)
+        self._chk_fm_overview.setChecked(f.fm_overview_tab)
 
         e = prefs.experiment
         self._dir_experiment.setText(e.default_experiment_directory)
@@ -283,6 +293,7 @@ class PreferencesDialog(QDialog):
                 scheduled_tasks=self._chk_scheduled_tasks.isChecked(),
                 bug_report_enabled=self._chk_bug_report.isChecked(),
                 scripts_enabled=self._chk_scripts.isChecked(),
+                fm_overview_tab=self._chk_fm_overview.isChecked(),
             ),
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -1,3 +1,4 @@
+import os
 import threading
 from unittest.mock import Mock, call, patch
 
@@ -583,21 +584,24 @@ def test_acquire_multiple_overviews(fm_microscope):
     """Test acquire_multiple_overviews function with multiple FM positions."""
     microscope = fm_microscope
 
-    # Create test positions
+    # Create test positions. Kept well inside the simulated stage limits (x +/-1 mm,
+    # y +/-0.378 mm) with room for the 2x2 grid around each: these were at y = 2, 5 and
+    # 8 mm, which no stage in the fixture can reach. That went unnoticed until the FM
+    # runner started checking, since nothing on this path looked at the limits before.
     positions = [
         FMStagePosition(
             name="Region1",
-            stage_position=FibsemStagePosition(x=0.001, y=0.002, z=0.003),
+            stage_position=FibsemStagePosition(x=0.0001, y=0.0002, z=0.003),
             objective_position=0.012,
         ),
         FMStagePosition(
             name="Region2",
-            stage_position=FibsemStagePosition(x=0.004, y=0.005, z=0.006),
+            stage_position=FibsemStagePosition(x=0.0004, y=-0.0001, z=0.006),
             objective_position=0.015,
         ),
         FMStagePosition(
             name="Region3",
-            stage_position=FibsemStagePosition(x=0.007, y=0.008, z=0.009),
+            stage_position=FibsemStagePosition(x=-0.0003, y=0.0001, z=0.009),
             objective_position=0.018,
         ),
     ]
@@ -1511,3 +1515,215 @@ def test_without_a_centre_the_run_uses_the_stage(fm_microscope):
 
     assert runner.centre_position.x == pytest.approx(start.x, abs=1e-12)
     assert runner.centre_position.y == pytest.approx(start.y, abs=1e-12)
+
+
+# ── where a run's files go ───────────────────────────────────────────────
+
+
+def test_a_destination_puts_the_mosaic_beside_its_tile_directory(tmp_path):
+    """The destination anyone opening the folder has to be able to read: one directory of
+    tiles per run, and the stitched result next to it under the same name rather than
+    buried among a hundred tiles."""
+    destination = acquisition.OverviewDestination.create(str(tmp_path))
+
+    assert os.path.isdir(destination.tiles_directory)
+    assert os.path.dirname(destination.tiles_directory) == str(tmp_path)
+    assert os.path.dirname(destination.mosaic_path) == str(tmp_path)
+    assert destination.mosaic_path == f"{destination.tiles_directory}.ome.tiff"
+    assert destination.basename in destination.mosaic_path
+
+
+def test_two_runs_do_not_overwrite_each_other(tmp_path):
+    """The reason a run gets a subdirectory instead of writing straight into the
+    experiment: tiles are named by row and column, so a second overview into the same
+    directory would replace the first tile for tile."""
+    first = acquisition.OverviewDestination.create(str(tmp_path), basename="run-a")
+    second = acquisition.OverviewDestination.create(str(tmp_path), basename="run-b")
+
+    assert first.tiles_directory != second.tiles_directory
+    assert first.mosaic_path != second.mosaic_path
+
+
+def test_the_tile_directory_is_made_before_the_run(tmp_path):
+    """Made on the way in rather than at the first tile, so an unwritable path is
+    reported before the stage moves rather than after."""
+    root = tmp_path / "not" / "there" / "yet"
+
+    destination = acquisition.OverviewDestination.create(str(root))
+
+    assert os.path.isdir(destination.tiles_directory)
+
+
+def test_a_mosaic_that_cannot_be_written_is_reported_not_raised(tmp_path):
+    """By the time this is called the acquisition is over and the mosaic is in hand.
+    Raising would discard a completed result over a filesystem problem, so the return
+    value is what says whether it landed."""
+    destination = acquisition.OverviewDestination.create(str(tmp_path))
+    mosaic = Mock()
+    mosaic.save.side_effect = OSError("read-only file system")
+
+    assert destination.save_mosaic(mosaic) is None
+
+
+def test_a_saved_mosaic_is_stamped_with_the_run_it_came_from(fm_microscope, tmp_path):
+    """So a mosaic reloaded from disk can still be tied to its tiles, which sit in a
+    directory of that name beside it."""
+    destination = acquisition.OverviewDestination.create(str(tmp_path))
+    mosaic = FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=1, cols=1, overlap=0.1),
+    ).run_and_stitch()
+
+    path = destination.save_mosaic(mosaic)
+
+    assert path == destination.mosaic_path
+    assert os.path.exists(path)
+    assert mosaic.metadata.description == destination.basename
+    assert FluorescenceImage.load(path).metadata.description == destination.basename
+
+
+def test_a_cancelled_run_still_records_what_it_was_trying_to_do(fm_microscope, tmp_path):
+    """The parameters describe what was *requested*, so they are known before the first
+    tile. Written at the end instead, a cancelled run left its tiles on disk with
+    nothing saying what grid they belonged to."""
+    stop_event = threading.Event()
+    runner = FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
+        save_directory=str(tmp_path),
+        stop_event=stop_event,
+    )
+    stop_event.set()
+
+    with pytest.raises(OperationCancelledError):
+        runner.run()
+
+    assert os.path.exists(os.path.join(str(tmp_path), "overview-parameters.json"))
+
+
+def test_two_runs_in_the_same_second_do_not_collide(tmp_path):
+    """The timestamp only resolves to the second, and a single-tile overview at a short
+    exposure takes far less. Sharing the name would let the second run overwrite the
+    first tile for tile, silently."""
+    first = acquisition.OverviewDestination.create(str(tmp_path), basename="overview-12-00-00")
+    second = acquisition.OverviewDestination.create(str(tmp_path), basename="overview-12-00-00")
+
+    assert first.tiles_directory != second.tiles_directory
+    assert first.mosaic_path != second.mosaic_path
+    assert os.path.isdir(first.tiles_directory)
+    assert os.path.isdir(second.tiles_directory)
+
+
+def test_a_name_whose_mosaic_survived_its_tiles_is_not_reused(tmp_path):
+    """Tile directories get cleaned up and mosaics get kept, so the directory being
+    free does not mean the name is."""
+    taken = tmp_path / "overview-12-00-00.ome.tiff"
+    taken.write_text("")
+
+    destination = acquisition.OverviewDestination.create(
+        str(tmp_path), basename="overview-12-00-00"
+    )
+
+    assert destination.mosaic_path != str(taken)
+    assert not os.path.exists(destination.mosaic_path)
+
+
+# ── stage limits ─────────────────────────────────────────────────────────
+
+
+def _narrow_limits(microscope, half_width: float):
+    """Shrink the stage limits to a box of +/- half_width about the origin."""
+    from fibsem.structures import RangeLimit
+
+    microscope._stage.limits = {
+        "x": RangeLimit(min=-half_width, max=half_width),
+        "y": RangeLimit(min=-half_width, max=half_width),
+    }
+
+
+def test_a_grid_reaching_past_the_stage_limits_is_refused(fm_microscope):
+    """The same answer the beam tiler gives, through the same helper. Rejected rather
+    than trimmed: a mosaic quietly missing the tiles the stage could not reach stitches
+    those gaps as zeros, which nothing downstream can tell from dark sample."""
+    _narrow_limits(fm_microscope, 10e-6)  # far smaller than one tile step
+
+    runner = FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=3, cols=3, overlap=0.1),
+    )
+
+    with pytest.raises(ValueError, match="beyond stage limits"):
+        runner.run()
+
+
+def test_the_refusal_names_the_tiles_that_caused_it(fm_microscope):
+    """So the grid can be fixed rather than guessed at."""
+    _narrow_limits(fm_microscope, 10e-6)
+
+    runner = FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=1, cols=3, overlap=0.1),
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        runner.run()
+
+    # The centre tile is reachable; the two either side are not.
+    assert "(0,0)" in str(excinfo.value)
+    assert "(0,2)" in str(excinfo.value)
+
+
+def test_nothing_moves_when_a_grid_is_refused(fm_microscope):
+    """The check runs before the tile loop, so a refused grid costs no stage time."""
+    _narrow_limits(fm_microscope, 10e-6)
+    start = fm_microscope.get_stage_position()
+
+    runner = FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=3, cols=3, overlap=0.1),
+    )
+    with pytest.raises(ValueError):
+        runner.run()
+
+    after = fm_microscope.get_stage_position()
+    assert (after.x, after.y) == pytest.approx((start.x, start.y), abs=1e-12)
+    assert runner.tileset == [] or all(t is None for row in runner.tileset for t in row)
+
+
+def test_masking_off_the_unreachable_tiles_makes_a_grid_acquirable(fm_microscope):
+    """Only the tiles that will actually be visited are checked, so excluding a corner
+    that falls outside the limits is a legitimate way to bring a grid back into range."""
+    _narrow_limits(fm_microscope, 10e-6)
+
+    parameters = OverviewParameters(
+        rows=1, cols=3, overlap=0.1,
+        tile_mask=[[False, True, False]],   # keep only the reachable centre tile
+    )
+    runner = FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=parameters,
+    )
+
+    runner.run()  # must not raise
+
+    assert runner.tileset[0][1] is not None
+    assert runner.tileset[0][0] is None and runner.tileset[0][2] is None
+
+
+def test_a_grid_within_the_limits_is_untouched(fm_microscope):
+    """The check must not reject grids that were always fine."""
+    runner = FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
+        overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
+    )
+
+    runner.run()
+
+    assert sum(t is not None for row in runner.tileset for t in row) == 4

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -34,6 +34,21 @@ from fibsem.ui.widgets.custom_widgets import ValueComboBox
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
 
 
+@pytest.fixture(autouse=True)
+def _restore_fm_overview_flag():
+    """`FEATURE_FM_OVERVIEW_TAB_ENABLED` is a module global that several tests here set.
+
+    Restored around every test rather than by whoever set it: the flag has to stay on
+    for the whole of a test that uses the tab, not just while the tab is built, so the
+    setter cannot also be the restorer.
+    """
+    import fibsem.config as fibsem_cfg
+
+    previous = fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED
+    yield
+    fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED = previous
+
+
 @pytest.fixture(scope="module")
 def qapp():
     app = QApplication.instance() or QApplication([])
@@ -550,10 +565,24 @@ def _mouse(overlay, x, y, px=0.0, py=0.0, button=1):
     )
 
 
+def _end_gesture(overlay, event):
+    """Release the overlay *and* the canvas, as a real release does.
+
+    Both are connected to the same matplotlib event in the app, and it is the canvas's
+    handler that clears `_overlay_consuming_event` — the flag that suppresses panning,
+    and now refitting, for as long as an overlay owns the gesture. Releasing only the
+    overlay leaves the canvas believing a drag is still in flight, which then silently
+    disables refitting for every later test sharing the fixture.
+    """
+    overlay._on_release(event)
+    if overlay._canvas is not None:
+        overlay._canvas._on_release(event)
+
+
 def _click(overlay, x, y):
     """Press and release at one point -- the gesture that toggles a tile."""
     overlay._on_press(_mouse(overlay, x, y))
-    overlay._on_release(_mouse(overlay, x, y))
+    _end_gesture(overlay, _mouse(overlay, x, y))
 
 
 @pytest.fixture(scope="module")
@@ -860,6 +889,93 @@ def test_resizing_the_grid_does_reframe(qapp, overview_widget):
     zoomed = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
 
     widget.settings_widget.set_grid_size(5, 5)
+    qapp.processEvents()
+
+    assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) != zoomed
+
+
+def test_dragging_the_grid_leaves_the_view_alone(qapp, overview_widget):
+    """The same class of bug as a tile toggle, through a different door.
+
+    A move drag emits on every motion event, and the refresh it triggers re-declared the
+    canvas's working area — which forces a refit. Zoomed out, the very first step of a
+    drag collapsed the view onto the grid (measured: a span of 41677 down to 4168) and
+    then towed it along. The guard only knew about resize drags.
+    """
+    widget = overview_widget
+    widget.settings_widget.parameters = OverviewParameters(rows=3, cols=3, overlap=0.1)
+    qapp.processEvents()
+
+    ax = widget.canvas.canvas._ax
+    ax.set_xlim(-5000, 5000)
+    ax.set_ylim(5000, -5000)
+    zoomed = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+
+    overlay = widget.tile_grid_overlay
+    anchor = overlay._anchor() or (0.0, 0.0)
+    # Far enough to leave the declared working area, which is what zooming out makes
+    # easy: a drag that stays inside it never tripped the old refit either, so a short
+    # one would pass against the bug it is meant to catch.
+    declared_width = widget.canvas.canvas.world_extent[0] / widget.canvas.canvas.reference_pixel_size
+    reach = declared_width  # twice the half-width that bounds the area
+
+    overlay._on_press(_mouse(overlay, anchor[0], anchor[1], px=0.0, py=0.0))
+    for step in range(1, 4):
+        # `px` has to move too: the overlay measures the drag threshold in screen
+        # pixels, so a gesture that only moves in data coordinates never starts.
+        overlay._on_drag(
+            _mouse(overlay, anchor[0] + step * reach, anchor[1], px=step * 20.0, py=0.0)
+        )
+        qapp.processEvents()
+        assert overlay.is_dragging
+        assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == zoomed
+    _end_gesture(overlay, _mouse(overlay, anchor[0] + 3 * reach, anchor[1], px=60.0, py=0.0))
+    qapp.processEvents()
+
+    assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == zoomed
+
+
+def test_the_working_area_still_follows_a_dragged_grid(qapp, overview_widget):
+    """Not moving the view is not the same as not tracking the grid. The working area is
+    what the zoom limiter measures against, so leaving it behind would stretch the
+    content extent across the gap and cap how far the view could zoom in — the reason it
+    was being re-declared in the first place."""
+    widget = overview_widget
+    widget.settings_widget.parameters = OverviewParameters(rows=3, cols=3, overlap=0.1)
+    qapp.processEvents()
+
+    overlay = widget.tile_grid_overlay
+    anchor = overlay._anchor() or (0.0, 0.0)
+    before = widget.canvas.canvas.world_extent
+
+    overlay._on_press(_mouse(overlay, anchor[0], anchor[1], px=0.0, py=0.0))
+    overlay._on_drag(_mouse(overlay, anchor[0] + 1200, anchor[1], px=60.0, py=0.0))
+    _end_gesture(overlay, _mouse(overlay, anchor[0] + 1200, anchor[1], px=60.0, py=0.0))
+    qapp.processEvents()
+
+    after = widget.canvas.canvas.world_extent
+    assert after is not None and before is not None
+    assert after[2] != before[2]  # centre followed the grid
+    assert (after[0], after[1]) == (before[0], before[1])  # same size, it only moved
+
+
+def test_declaring_a_working_area_without_a_refit_does_not_move_the_view(qapp, overview_widget):
+    """The canvas-level half of the fix, stated on its own: `refit=False` has to hold
+    even on an empty canvas, where `_fit_extent` falls back to the working area and so
+    *does* change when it is re-declared."""
+    widget = overview_widget
+    canvas = widget.canvas.canvas
+    ax = canvas._ax
+    ax.set_xlim(-5000, 5000)
+    ax.set_ylim(5000, -5000)
+    zoomed = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+
+    canvas.set_world_extent(1e-3, 1e-3, (5e-4, 5e-4), refit=False)
+    qapp.processEvents()
+
+    assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == zoomed
+
+    canvas.set_world_extent(2e-3, 2e-3, (0.0, 0.0), refit=True)
     qapp.processEvents()
 
     assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) != zoomed
@@ -1291,34 +1407,72 @@ def test_the_working_area_follows_the_grid_not_the_canvas_origin(qapp, interacti
 
 
 def test_a_move_inside_the_working_area_leaves_the_framing_alone(qapp, interactive_widget):
-    """Re-declaring the working area re-frames the view, so it must not follow every
-    move -- a double-click to somewhere 100 µm away would throw the zoom away, the same
-    failure a tile toggle used to cause."""
+    """A move must not throw away the user's zoom -- a double-click to somewhere 100 µm
+    away did, the same failure a tile toggle used to cause.
+
+    It is the *framing* that has to hold still, not the declared working area. This test
+    used to assert the latter, because re-declaring the area re-framed the view and the
+    only way to hold the view was to leave the area behind. The area now follows the
+    grid on every move -- it is what the zoom limiter measures against, so leaving it
+    behind was its own bug -- and `refit=False` is what makes that safe.
+    """
     widget = interactive_widget
-    before = widget.canvas.canvas.world_extent
-    span_px = before[0] / widget.canvas.canvas.reference_pixel_size
+    canvas = widget.canvas.canvas
+    span_px = canvas.world_extent[0] / canvas.reference_pixel_size
+    anchor = widget.tile_grid_overlay._anchor()
+    ax = canvas._ax
+    framing = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+
+    widget._on_grid_move(anchor[0] + span_px / 4, anchor[1])
+    qapp.processEvents()
+
+    assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == framing
+    # ...and the grid still moved, which is the point of not re-framing for it
+    assert widget.tile_grid_overlay._anchor()[0] == pytest.approx(anchor[0] + span_px / 4)
+
+
+def test_the_working_area_follows_the_grid_on_every_move(qapp, interactive_widget):
+    """Even a small one. The area is what caps how far the view can zoom in, and one
+    left behind stretches the content extent across the gap between it and the grid."""
+    widget = interactive_widget
+    canvas = widget.canvas.canvas
+    span_px = canvas.world_extent[0] / canvas.reference_pixel_size
     anchor = widget.tile_grid_overlay._anchor()
 
     widget._on_grid_move(anchor[0] + span_px / 4, anchor[1])
     qapp.processEvents()
 
-    assert widget.canvas.canvas.world_extent == before
-    # ...and the grid still moved, which is the point of not re-framing for it
-    assert widget.tile_grid_overlay._anchor()[0] == pytest.approx(anchor[0] + span_px / 4)
+    after = canvas.world_extent
+    assert (after[2], after[3]) == pytest.approx(widget._grid_offset())
 
 
-def test_a_move_clear_of_the_working_area_re_declares_it(qapp, interactive_widget):
-    widget = interactive_widget
-    before = widget.canvas.canvas.world_extent
-    span_px = before[0] / widget.canvas.canvas.reference_pixel_size
+def test_a_grid_that_jumps_clear_of_an_empty_canvas_re_frames(qapp):
+    """The one case where the view *should* follow a move: nothing has been acquired, so
+    the grid is all there is to look at, and a grid off-screen leaves the canvas blank.
+    Moving to an offset FM mount travels 48 mm and does exactly this.
+
+    Only on an empty canvas -- once an image is placed the framing is fitted to the
+    image, which a grid move does not change. Suppressed mid-drag either way, which is
+    what `test_dragging_the_grid_leaves_the_view_alone` covers.
+    """
+    widget = _fresh_widget(qapp)
+    widget._refresh_tile_grid()
+    qapp.processEvents()
+
+    canvas = widget.canvas.canvas
+    ax = canvas._ax
+    framing = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+    span_px = canvas.world_extent[0] / canvas.reference_pixel_size
     anchor = widget.tile_grid_overlay._anchor()
 
     widget._on_grid_move(anchor[0] + 4 * span_px, anchor[1])
     qapp.processEvents()
 
-    after = widget.canvas.canvas.world_extent
-    assert after != before
+    assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) != framing
+    after = canvas.world_extent
     assert (after[2], after[3]) == pytest.approx(widget._grid_offset())
+
+    widget.close()
 
 
 # ── anchoring the frame (FIB-418) ────────────────────────────────────────
@@ -1431,3 +1585,495 @@ def test_a_dropped_widget_lets_go_of_the_stage_signal_too(qapp):
     gc.collect()
 
     assert len(microscope.stage_position_changed) == before
+
+
+# ── the host contract: saving, and being locked ──────────────────────────
+
+
+def _fresh_widget(qapp):
+    """A widget of its own, for tests that change state the module fixture shares."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    widget = FMOverviewWidget(build_microscope())
+    qapp.processEvents()
+    return widget
+
+
+def test_nothing_is_saved_until_a_host_says_where(qapp):
+    """The standalone default. This app is mostly run against a simulator to exercise
+    the UI, and those runs must not leave tiles wherever it was launched from."""
+    widget = _fresh_widget(qapp)
+
+    assert widget._save_directory is None
+    assert widget._claim_destination() is None
+
+    widget.close()
+
+
+def test_a_save_directory_gives_every_run_its_own_place(qapp, tmp_path):
+    """Not the experiment directory itself: tiles are named by row and column, so two
+    overviews written straight into one directory would replace each other tile by
+    tile."""
+    widget = _fresh_widget(qapp)
+    widget.set_save_directory(str(tmp_path))
+
+    first = widget._claim_destination()
+    second = widget._claim_destination()
+
+    assert first.tiles_directory != second.tiles_directory
+    assert os.path.dirname(first.tiles_directory) == str(tmp_path)
+
+    widget.close()
+
+
+def test_an_unwritable_directory_does_not_stop_the_run(qapp, tmp_path):
+    """An overview you can see is worth more than no overview at all, so a save
+    directory that cannot be prepared degrades to not saving rather than refusing."""
+    blocked = tmp_path / "file-not-a-directory"
+    blocked.write_text("")
+    widget = _fresh_widget(qapp)
+    widget.set_save_directory(str(blocked))
+
+    assert widget._claim_destination() is None
+
+    widget.close()
+
+
+def test_a_failed_save_is_not_reported_as_a_successful_one(qapp, tmp_path):
+    """Otherwise the difference only turns up later, when someone goes looking for the
+    file and it is not there."""
+    widget = _fresh_widget(qapp)
+
+    # Nothing was meant to be saved: silent.
+    widget._destination, widget._saved_path = None, None
+    assert widget._describe_save() == ("", "")
+
+    # A destination was claimed and the mosaic did not land: say so.
+    widget.set_save_directory(str(tmp_path))
+    widget._destination = widget._claim_destination()
+    widget._saved_path = None
+    assert "not saved" in widget._describe_save()[0]
+
+    # It landed, and the tooltip says where.
+    widget._saved_path = widget._destination.mosaic_path
+    suffix, tooltip = widget._describe_save()
+    assert suffix == "  ·  saved"
+    assert tooltip == widget._destination.mosaic_path
+
+    widget.close()
+
+
+def test_a_host_can_forbid_starting_work_without_touching_a_run(qapp):
+    """For a workflow that owns the instrument for a while. The canvas stays live --
+    greying out the whole widget would also stop you reading the overview you just
+    acquired, which costs the workflow nothing."""
+    widget = _fresh_widget(qapp)
+
+    widget.set_interactive(False)
+    assert not widget.button_acquire.isEnabled()
+    assert not widget.settings_widget.isEnabled()
+    assert not widget.channel_widget.isEnabled()
+    assert widget.canvas.isEnabled()
+
+    widget.set_interactive(True)
+    assert widget.button_acquire.isEnabled()
+    assert widget.settings_widget.isEnabled()
+
+    widget.close()
+
+
+def test_a_lock_arriving_mid_run_leaves_cancel_available(qapp):
+    """Otherwise a workflow starting while an overview is in flight would strand it:
+    the stage keeps moving and the only button that stops it is greyed out."""
+    widget = _fresh_widget(qapp)
+    widget._set_running(True)
+
+    widget.set_interactive(False)
+
+    assert widget.button_cancel.isEnabled()
+    assert not widget.button_acquire.isEnabled()
+
+    widget._set_running(False)
+    widget.close()
+
+
+def test_a_workflow_ending_does_not_re_enable_a_tab_that_is_still_acquiring(qapp):
+    """The two facts are independent and both have to be false before Acquire comes
+    back. Deriving the button from only one of them is how it gets stuck -- or worse,
+    lets a second acquisition start on top of the first."""
+    widget = _fresh_widget(qapp)
+    widget.set_interactive(False)
+    widget._set_running(True)
+
+    widget.set_interactive(True)
+
+    assert not widget.button_acquire.isEnabled()
+
+    widget._set_running(False)
+    assert widget.button_acquire.isEnabled()
+
+    widget.close()
+
+
+def test_an_empty_grid_still_forbids_acquiring_after_a_lock_is_lifted(qapp):
+    """The third fact. A tab unlocked with no tiles selected has nothing to acquire,
+    and the button that starts it should say so."""
+    widget = _fresh_widget(qapp)
+    widget.settings_widget.tile_mask.mask = [[False, False], [False, False]]
+    widget.settings_widget.set_grid_size(2, 2)
+    widget.settings_widget.tile_mask.mask = [[False, False], [False, False]]
+    widget._on_settings_changed()
+    assert not widget.button_acquire.isEnabled()
+
+    widget.set_interactive(False)
+    widget.set_interactive(True)
+
+    assert not widget.button_acquire.isEnabled()
+
+    widget.close()
+
+
+# ── the host side: building and retiring the tab ─────────────────────────
+
+
+class _StubHost:
+    """The tab wiring, without the AutoLamella main window.
+
+    Constructing the real window needs napari viewers, which segfault under the
+    offscreen platform -- on an unmodified `main` as well as here, so this stands in for
+    a window that cannot be built in this environment rather than papering over
+    something introduced with the tab. The methods borrowed below touch only the tab
+    widget and the two attributes set in `__init__`.
+    """
+
+    from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+        AutoLamellaSingleWindowUI as _Real,
+    )
+
+    add_fm_overview_tab = _Real.add_fm_overview_tab
+    _apply_fm_overview_visibility = _Real._apply_fm_overview_visibility
+    _build_fm_overview_widget = _Real._build_fm_overview_widget
+    _teardown_fm_overview_widget = _Real._teardown_fm_overview_widget
+    _update_fm_overview_experiment = _Real._update_fm_overview_experiment
+    _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
+
+    def __init__(self, microscope=None, experiment=None, tab_enabled=True):
+        import fibsem.config as fibsem_cfg
+        from PyQt5.QtWidgets import QTabWidget
+
+        self.tab_widget = QTabWidget()
+        self.autolamella_ui = type(
+            "_UI", (), {"microscope": microscope, "experiment": experiment}
+        )()
+        # The tab is behind a preference that is off by default, so these tests turn it
+        # on and leave it on -- `_restore_fm_overview_flag` puts it back afterwards.
+        fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED = tab_enabled
+        self.add_fm_overview_tab()
+
+    def set_flag(self, enabled: bool):
+        """Toggle the preference and re-apply it, as the dialog does on accept."""
+        import fibsem.config as fibsem_cfg
+
+        fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED = enabled
+        self._apply_fm_overview_visibility()
+
+    @property
+    def tab_enabled(self):
+        return self.tab_widget.isTabEnabled(
+            self.tab_widget.indexOf(self._fm_overview_container)
+        )
+
+
+def _plain_microscope():
+    """A Demo microscope with no fluorescence detector attached."""
+    from fibsem import utils
+
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.fm = None
+    return microscope
+
+
+def test_the_fm_overview_tab_is_reserved_but_dead_without_a_microscope(qapp):
+    """The widget needs a camera at construction -- every scale on its canvas comes from
+    one -- so the tab exists from startup and fills in on connection."""
+    host = _StubHost()
+
+    assert "FM Overview" in [
+        host.tab_widget.tabText(i) for i in range(host.tab_widget.count())
+    ]
+    assert not host.tab_enabled
+    assert host.fm_overview_widget is None
+
+
+def test_the_tab_comes_alive_when_fluorescence_connects(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost()
+    host.autolamella_ui.microscope = build_microscope()
+
+    host._build_fm_overview_widget()
+
+    assert host.tab_enabled
+    assert isinstance(host.fm_overview_widget, FMOverviewWidget)
+
+    host._teardown_fm_overview_widget()
+
+
+def test_a_microscope_without_fluorescence_hides_the_tab(qapp):
+    """A system with no FM will never drive this tab, so showing it means a permanently
+    greyed-out tab with nothing to say why. Distinct from *not connected yet*, which is
+    temporary and covered below."""
+    host = _StubHost(microscope=_plain_microscope())
+
+    host._apply_fm_overview_visibility()
+
+    index = host.tab_widget.indexOf(host._fm_overview_container)
+    assert not host.tab_widget.isTabVisible(index)
+    assert host.fm_overview_widget is None
+
+
+def test_no_microscope_yet_leaves_the_tab_visible_but_disabled(qapp):
+    """The other absence. Waiting for a connection is what every other tab does, and a
+    tab that vanishes until you connect is harder to find than a dim one."""
+    host = _StubHost(microscope=None)
+
+    host._apply_fm_overview_visibility()
+
+    index = host.tab_widget.indexOf(host._fm_overview_container)
+    assert host.tab_widget.isTabVisible(index)
+    assert not host.tab_widget.isTabEnabled(index)
+    assert host.fm_overview_widget is None
+
+
+def test_connecting_a_microscope_without_fluorescence_takes_the_tab_away(qapp):
+    """Whether the system has an FM is only known once something is connected, so the
+    tab starts visible and has to be withdrawn rather than never shown."""
+    host = _StubHost(microscope=None)
+    index = host.tab_widget.indexOf(host._fm_overview_container)
+    assert host.tab_widget.isTabVisible(index)
+
+    host.autolamella_ui.microscope = _plain_microscope()
+    host._apply_fm_overview_visibility()
+
+    assert not host.tab_widget.isTabVisible(index)
+
+
+def test_a_microscope_with_fluorescence_brings_the_tab_back(qapp):
+    """And the reverse, so swapping between systems in one session settles correctly."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=_plain_microscope())
+    host._apply_fm_overview_visibility()
+    index = host.tab_widget.indexOf(host._fm_overview_container)
+    assert not host.tab_widget.isTabVisible(index)
+
+    host.autolamella_ui.microscope = build_microscope()
+    host._apply_fm_overview_visibility()
+
+    assert host.tab_widget.isTabVisible(index)
+    assert host.tab_widget.isTabEnabled(index)
+    assert isinstance(host.fm_overview_widget, FMOverviewWidget)
+
+    host._teardown_fm_overview_widget()
+
+
+def test_the_same_microscope_connecting_again_keeps_the_widget(qapp):
+    """Rebuilding would throw away whatever is on the canvas, and a connection signal
+    can arrive more than once for one instrument."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope())
+    host._build_fm_overview_widget()
+    first = host.fm_overview_widget
+
+    host._build_fm_overview_widget()
+
+    assert host.fm_overview_widget is first
+
+    host._teardown_fm_overview_widget()
+
+
+def test_a_different_microscope_replaces_the_widget(qapp):
+    """The widget holds its microscope for life. Left alone across a reconnect it would
+    read geometry from an instrument nobody is driving -- FIB-433 is about doing this
+    without discarding the view."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope())
+    host._build_fm_overview_widget()
+    first = host.fm_overview_widget
+
+    host.autolamella_ui.microscope = build_microscope()
+    host._build_fm_overview_widget()
+
+    assert host.fm_overview_widget is not first
+    assert host._fm_overview_microscope is host.autolamella_ui.microscope
+
+    host._teardown_fm_overview_widget()
+
+
+def test_retiring_the_widget_releases_the_stage_signal(qapp):
+    """The subscription belongs to the microscope and outlives the widget. A stale one
+    emits into a Qt object already torn down on the C++ side, which is a segfault rather
+    than an exception -- so a reconnect that dropped the widget without closing it would
+    take the application down on the next stage move."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    microscope = build_microscope()
+    before = len(microscope.stage_position_changed)
+    host = _StubHost(microscope=microscope)
+    host._build_fm_overview_widget()
+    assert len(microscope.stage_position_changed) == before + 1
+
+    host._teardown_fm_overview_widget()
+
+    assert len(microscope.stage_position_changed) == before
+    assert host.fm_overview_widget is None
+
+
+def test_disconnecting_the_microscope_retires_the_tab(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope())
+    host._build_fm_overview_widget()
+
+    host.autolamella_ui.microscope = None
+    host._build_fm_overview_widget()
+
+    assert host.fm_overview_widget is None
+    assert not host.tab_enabled
+
+
+def test_the_experiment_directory_reaches_the_widget(qapp, tmp_path):
+    """By setter, not by handing over the experiment: the widget knows nothing about
+    experiments, which is what lets it open standalone and be built in a test."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope())
+    host._build_fm_overview_widget()
+    assert host.fm_overview_widget._save_directory is None
+
+    host.autolamella_ui.experiment = type("_Exp", (), {"path": str(tmp_path)})()
+    host._update_fm_overview_experiment()
+
+    assert host.fm_overview_widget._save_directory == str(tmp_path)
+
+    host._teardown_fm_overview_widget()
+
+
+def test_a_workflow_lock_reaches_the_fm_tab(qapp):
+    """A running workflow owns the instrument; neither overview tab should be able to
+    start competing for it."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope())
+    host._build_fm_overview_widget()
+
+    host._set_minimap_workflow_enabled(False)
+    assert not host.fm_overview_widget.button_acquire.isEnabled()
+
+    host._set_minimap_workflow_enabled(True)
+    assert host.fm_overview_widget.button_acquire.isEnabled()
+
+    host._teardown_fm_overview_widget()
+
+
+def test_the_workflow_lock_survives_there_being_no_fm_tab(qapp):
+    """A system with no fluorescence detector still runs workflows."""
+    host = _StubHost(microscope=_plain_microscope())
+    host._build_fm_overview_widget()
+
+    host._set_minimap_workflow_enabled(False)  # must not raise
+
+
+def test_the_fm_overview_tab_is_behind_a_preference(qapp):
+    """Off by default, and hidden rather than absent -- which is what lets the
+    preference take effect immediately instead of at the next launch."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope(), tab_enabled=False)
+    index = host.tab_widget.indexOf(host._fm_overview_container)
+
+    assert not host.tab_widget.isTabVisible(index)
+    assert host.fm_overview_widget is None
+
+
+def test_switching_the_preference_on_shows_the_tab_without_a_restart(qapp):
+    """The reason the tab is hidden rather than skipped."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope(), tab_enabled=False)
+    index = host.tab_widget.indexOf(host._fm_overview_container)
+
+    host.set_flag(True)
+
+    assert host.tab_widget.isTabVisible(index)
+    assert host.tab_widget.isTabEnabled(index)
+    assert isinstance(host.fm_overview_widget, FMOverviewWidget)
+
+    host._teardown_fm_overview_widget()
+
+
+def test_switching_it_off_again_releases_the_widget(qapp):
+    """Hidden is not enough on its own: the widget subscribes to the microscope's stage
+    signal for its lifetime, so one left behind keeps working for a feature that has
+    been switched off."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    microscope = build_microscope()
+    before = len(microscope.stage_position_changed)
+    host = _StubHost(microscope=microscope, tab_enabled=True)
+    index = host.tab_widget.indexOf(host._fm_overview_container)
+    assert len(microscope.stage_position_changed) == before + 1
+
+    host.set_flag(False)
+
+    assert not host.tab_widget.isTabVisible(index)
+    assert host.fm_overview_widget is None
+    assert len(microscope.stage_position_changed) == before
+
+
+def test_everything_tolerates_the_tab_being_switched_off(qapp):
+    """The host calls into the tab from several places -- connection, experiment update,
+    workflow lock -- and none of them should have to know whether it exists."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope(), tab_enabled=False)
+
+    host._build_fm_overview_widget()           # must not raise
+    host._update_fm_overview_experiment()      # must not raise
+    host._set_minimap_workflow_enabled(False)  # must not raise
+    host._apply_fm_overview_visibility()       # must not raise
+
+    assert getattr(host, "fm_overview_widget", None) is None
+
+
+def test_the_preference_reaches_the_config_flag():
+    """`apply_feature_flags` is what turns the stored preference into the module
+    global the UI reads, and a flag added to one without the other is silently dead."""
+    import fibsem.config as fibsem_cfg
+
+    prefs = fibsem_cfg.UserPreferences()
+    prefs.features.fm_overview_tab = True
+    previous = fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED
+    try:
+        fibsem_cfg.apply_feature_flags(prefs)
+        assert fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED is True
+
+        prefs.features.fm_overview_tab = False
+        fibsem_cfg.apply_feature_flags(prefs)
+        assert fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED is False
+    finally:
+        fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED = previous
+
+
+def test_the_preference_survives_a_round_trip_through_yaml():
+    """It is stored in user-preferences.yaml, so it has to serialise."""
+    import fibsem.config as fibsem_cfg
+
+    prefs = fibsem_cfg.UserPreferences()
+    prefs.features.fm_overview_tab = True
+
+    restored = fibsem_cfg.UserPreferences.from_dict(prefs.to_dict())
+
+    assert restored.features.fm_overview_tab is True

--- a/tests/ui/test_preferences_dialog.py
+++ b/tests/ui/test_preferences_dialog.py
@@ -1,0 +1,104 @@
+"""The preferences dialog, checked against the dataclass it edits.
+
+A preference has to survive four separate places to work: the `FeatureFlags` field, the
+checkbox, `_load_from_preferences`, and `get_preferences`. Miss the last two and the
+control is inert; miss the dialog entirely and the preference exists but nobody can
+reach it. None of that fails loudly — it just quietly does nothing, which is how the FM
+Overview flag shipped without a checkbox.
+
+So these tests drive the dialog's own load/save round trip rather than looking for
+attributes by name: what matters is that a value put in comes back out, not that some
+particular widget exists.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import dataclasses
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.config import FeatureFlags, UserPreferences
+from fibsem.ui.widgets.preferences_dialog import PreferencesDialog
+
+# Flags deliberately not offered in the dialog. Anything here is a decision, not an
+# oversight — which is the point of listing them rather than skipping the check.
+#
+# `viewer_movement_events` has no consumer beyond the config global it sets, so there is
+# nothing for a checkbox to switch on. It predates this test.
+NOT_IN_DIALOG = {"viewer_movement_events"}
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _round_trip(prefs: UserPreferences) -> UserPreferences:
+    """Load preferences into a dialog and read them straight back out."""
+    dialog = PreferencesDialog(prefs)
+    try:
+        return dialog.get_preferences()
+    finally:
+        dialog.deleteLater()
+
+
+@pytest.mark.parametrize(
+    "field",
+    [f.name for f in dataclasses.fields(FeatureFlags) if f.name not in NOT_IN_DIALOG],
+)
+def test_every_feature_flag_survives_the_dialog(qapp, field):
+    """A flag the dialog cannot carry is a flag nobody can turn on.
+
+    Parameterised over the dataclass rather than written out one flag at a time, so a
+    field added later is covered the day it is added — either it round-trips, or its
+    author has to say in `NOT_IN_DIALOG` that leaving it out was deliberate.
+    """
+    prefs = UserPreferences()
+    setattr(prefs.features, field, True)
+
+    restored = _round_trip(prefs)
+
+    assert getattr(restored.features, field) is True, (
+        f"features.{field} did not survive the preferences dialog — it probably has no "
+        f"checkbox, or is missing from _load_from_preferences or get_preferences."
+    )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [f.name for f in dataclasses.fields(FeatureFlags) if f.name not in NOT_IN_DIALOG],
+)
+def test_every_feature_flag_can_be_turned_off_again(qapp, field):
+    """The other direction. A checkbox wired only into the save path reads back as
+    whatever it defaulted to, which looks like it works until someone unticks it."""
+    prefs = UserPreferences()
+    setattr(prefs.features, field, False)
+
+    restored = _round_trip(prefs)
+
+    assert getattr(restored.features, field) is False
+
+
+def test_the_fm_overview_tab_can_be_switched_on_from_the_dialog(qapp):
+    """The flag this file was written for. Kept as its own test rather than left to the
+    parameterised pair, so the failure names the feature rather than a field."""
+    prefs = UserPreferences()
+    assert prefs.features.fm_overview_tab is False  # off by default
+
+    prefs.features.fm_overview_tab = True
+
+    assert _round_trip(prefs).features.fm_overview_tab is True
+
+
+def test_the_exemption_list_only_names_flags_that_exist(qapp):
+    """A flag removed or renamed would otherwise leave a stale exemption behind,
+    silently excusing nothing and hiding the next real gap."""
+    known = {f.name for f in dataclasses.fields(FeatureFlags)}
+
+    assert NOT_IN_DIALOG <= known, f"stale exemptions: {NOT_IN_DIALOG - known}"


### PR DESCRIPTION
Makes `FMOverviewWidget` reachable from AutoLamella, gives it somewhere to save, and closes two ways it could mislead. Behind a preference, off by default.

## FIB-431 — overviews are written again

`acquire()` built the runner with **no `save_directory`**, and `stitch_tileset` saves nothing, so a twenty-minute tileset left nothing behind. A regression against `FMAcquisitionWidget`, which passes the experiment path.

`OverviewDestination` now owns the layout for a run, and `acquire_and_stitch_tileset` uses it too so the two cannot drift:

```
overview-13-54-23.ome.tiff        ← stitched mosaic
overview-13-54-23/
  overview-parameters.json
  tile-00-00.ome.tiff … tile-01-01.ome.tiff
```

Two things found while testing it:

- **Two runs inside the same second reused the name** and overwrote each other tile for tile — the timestamp only resolves to seconds. Names are stepped past now, via `makedirs` without `exist_ok` so the check and the claim are one atomic operation.
- **Parameters are written before the tile loop**, not after. Written at the end, a cancelled run left tiles on disk with nothing saying what grid they belonged to.

Standalone gets `--output`; with no directory set, nothing is written and the status line says so.

## FIB-432 — the tab

`add_fm_overview_tab` in `AutoLamellaMainUI`, behind `features.fm_overview_tab` — off by default, toggled live through `setTabVisible` from the preferences dialog, no restart.

The widget is built on connection and destroyed with the tab rather than hidden alive: it holds a `stage_position_changed` subscription for its lifetime, and a hidden one keeps working for a feature you switched off. Two absences handled differently — a connected microscope **with no FM hides the tab**, while **not connected yet** leaves it visible and disabled, as every other tab does.

The host binds by setter (`set_save_directory`, `set_interactive`) rather than through a parent pointer. `FibsemMinimapWidget` takes `parent: AutoLamellaUI` and reaches through it, which is why it cannot be opened standalone or built in a test; `FMOverviewWidget` still can be, and its tests rely on that.

Enablement now derives from all three of *running* / *host-locked* / *no tiles selected* in one place — two places each setting the buttons from half the truth is how a control gets stuck. **Cancel deliberately survives a host lock**, so a workflow starting mid-run cannot strand an acquisition with no way to stop the stage.

## FIB-444 — grids past the stage limits are refused

`validate_tile_stage_positions` was already in the shared geometry core and the beam tiler already used it; the FM runner never looked at limits. Same shape as the row-direction bug this project started from.

Rejected rather than trimmed, per review: gaps stitch as zeros, which nothing downstream can distinguish from dark sample. Only *visited* tiles are checked, so masking off an unreachable corner is a legitimate way to make a grid acquirable.

It immediately caught a bad test — `test_acquire_multiple_overviews` asked for positions at y = 2, 5 and 8 mm against a simulated stage that reaches 0.378 mm. Never reachable; nothing had checked.

## Also: dragging the grid no longer snaps the view

The refresh re-declared the canvas working area on every motion event, and re-declaring forces a refit. Zoomed out, the first drag step collapsed the view onto the grid and towed it along — measured on the old code:

```
zoomed out    span=41676.8   centre=(0.0, 0.0)
  drag step 1  span= 4167.7   centre=(3334.1, 0.0)   ← 10× snap
  drag step 5  span= 4167.7   centre=(16670.7, 0.0)
```

The area now follows the grid silently (`set_world_extent(refit=False)`), re-framing only when the footprint changes or the grid leaves the frame. `_fit_view` also refuses outright while an overlay owns the gesture — a drag reaches the view through several call sites and guarding each one is a chance to miss one.

## Testing

2204 passed, 16 skipped. ~50 new tests.

Both halves of the drag fix are mutation-checked, as are the save-parameters ordering and the teardown-on-hide. One thing worth flagging: my first drag regression test **passed against the unfixed code** — the drag was too short to leave the declared area. The distance is now derived from `world_extent` rather than hardcoded.

`tests/ui/test_preferences_dialog.py` is new — there were no preferences-dialog tests. It parameterises over `FeatureFlags` so every field must survive a load/save round-trip through the dialog, in both directions. I shipped the FM flag without a checkbox earlier in this branch and nothing caught it; now a flag added later is covered the day it is added, or its author has to say in `NOT_IN_DIALOG` that leaving it out was deliberate.

## Notes for review

- **No `set_experiment()`**, which FIB-432 named. The widget gets `set_save_directory` + `set_interactive` and the host adapts, because the argument in that issue was that this widget knows nothing about experiments. Easy to add later if the minimap adopts the contract.
- Constructing `AutoLamellaSingleWindowUI` segfaults under the offscreen platform (napari) — on unmodified `main` too, not introduced here. The host-side tests therefore borrow the tab methods onto a stub host; the docstring says so and why.
- Reconnecting a different microscope rebuilds the widget, which discards the canvas. FIB-433 is about doing that without throwing the view away.