### PR TITLE
[hooks] Don't report an aborted workflow as completed (FIB-465)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -170,7 +170,7 @@ class TaskManager:
             update_status_ui(self.parent_ui, "", workflow_info="Workflow cancelled.")
         else:
             self._fire_workflow_hook(HookEvent.WORKFLOW_COMPLETED)
-            update_status_ui(self.parent_ui, "", workflow_info="All tasks completed.")
+            update_status_ui(self.parent_ui, "", workflow_info=self._completion_message())
         print(self.experiment.task_history_dataframe())
 
     def build_run_summary_dataframe(self) -> pd.DataFrame:
@@ -212,6 +212,25 @@ class TaskManager:
 
     def _fire_workflow_hook(self, event: HookEvent) -> None:
         fire_event(self.hook_manager, event)
+
+    def _completion_message(self) -> str:
+        """Closing status line for a run that was not cancelled.
+
+        A run where everything was skipped did no work, so it must not report as a
+        completed workflow — that is the same misreport as an abort claiming
+        completion, only quieter. Warns as well as returning, because update_status_ui
+        does not log workflow_info, so a headless run would see nothing.
+        """
+        items = self.queue.items
+        if not items:
+            return "No tasks to run."
+        skipped = sum(1 for i in items if i.status is AutoLamellaTaskStatus.Skipped)
+        if skipped == len(items):
+            logging.warning(f"No tasks ran: all {skipped} were skipped.")
+            return f"No tasks ran: all {skipped} skipped."
+        if skipped:
+            return f"All tasks completed ({skipped} skipped)."
+        return "All tasks completed."
 
     def _fire_skipped_hook(self, task_name: str, item_name: str,
                            skip_reason: str, task_type: str = "") -> None:

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -87,7 +87,13 @@ class TaskManager:
 
             lamella = self.experiment.get_lamella_by_name(item.lamella_name)
             if lamella is None:
+                # No lamella to build a status dict from, so this used to leave no trace
+                # anywhere — not in the log, the UI, or a hook.
+                logging.warning(
+                    f"Skipping {item.task_name}: no lamella named {item.lamella_name} in the experiment."
+                )
                 self.queue.mark_done(item, AutoLamellaTaskStatus.Skipped)
+                self._fire_skipped_hook(item.task_name, item.lamella_name, "lamella_not_found")
                 continue
 
             task_names = self.queue.task_names
@@ -105,6 +111,11 @@ class TaskManager:
                     status=AutoLamellaTaskStatus.Skipped,
                     msg=msg,
                     skip_reason=skip_reason,
+                )
+                task_config = lamella.task_config.get(item.task_name)
+                self._fire_skipped_hook(
+                    item.task_name, lamella.name, skip_reason,
+                    task_type=task_config.task_type if task_config else "",
                 )
                 continue
 
@@ -152,8 +163,14 @@ class TaskManager:
         if self.microscope.fm is not None and self.microscope.fm.objective.state == "Inserted":
             self.microscope.fm.objective.retract()
 
-        self._fire_workflow_hook(HookEvent.WORKFLOW_COMPLETED)
-        update_status_ui(self.parent_ui, "", workflow_info="All tasks completed.")
+        # The loop exits when the queue drains *or* when the user presses Stop. Reporting
+        # completion for both is what made an abort look like a finished workflow.
+        if self.is_stopped:
+            self._fire_workflow_hook(HookEvent.WORKFLOW_CANCELLED)
+            update_status_ui(self.parent_ui, "", workflow_info="Workflow cancelled.")
+        else:
+            self._fire_workflow_hook(HookEvent.WORKFLOW_COMPLETED)
+            update_status_ui(self.parent_ui, "", workflow_info="All tasks completed.")
         print(self.experiment.task_history_dataframe())
 
     def build_run_summary_dataframe(self) -> pd.DataFrame:
@@ -195,6 +212,20 @@ class TaskManager:
 
     def _fire_workflow_hook(self, event: HookEvent) -> None:
         fire_event(self.hook_manager, event)
+
+    def _fire_skipped_hook(self, task_name: str, item_name: str,
+                           skip_reason: str, task_type: str = "") -> None:
+        """Fire TASK_SKIPPED. Unlike the other task events this cannot come from
+        AutoLamellaTask, because the skip is decided before any task object exists —
+        so there is no task_state to attach."""
+        fire_event(
+            self.hook_manager,
+            HookEvent.TASK_SKIPPED,
+            task_name=task_name,
+            task_type=task_type,
+            item_name=item_name,
+            skip_reason=skip_reason,
+        )
 
     # --- Internal helpers ---
 

--- a/fibsem/hooks.py
+++ b/fibsem/hooks.py
@@ -21,8 +21,10 @@ class HookEvent(str, Enum):
     TASK_COMPLETED = "task_completed"
     TASK_FAILED = "task_failed"
     TASK_CANCELLED = "task_cancelled"
+    TASK_SKIPPED = "task_skipped"
     WORKFLOW_STARTED = "workflow_started"
     WORKFLOW_COMPLETED = "workflow_completed"
+    WORKFLOW_CANCELLED = "workflow_cancelled"
 
 
 @dataclass
@@ -37,6 +39,9 @@ class HookContext:
     # left untyped so this module does not depend on any one application's structures.
     task_state: Optional[Any] = None
     error: Optional[str] = None
+    # Why a task was skipped, on TASK_SKIPPED. The producer decides the vocabulary;
+    # AutoLamella uses not_required / failure / missing_prereqs / lamella_not_found.
+    skip_reason: Optional[str] = None
     timestamp: float = field(default_factory=time.time)
 
     def __post_init__(self):
@@ -69,6 +74,7 @@ def _template_fields(context: HookContext) -> Dict[str, str]:
         "item_name": context.item_name,
         "lamella_name": context.item_name,  # deprecated alias, renders pre-rename templates
         "error": context.error or "",
+        "skip_reason": context.skip_reason or "",
     }
 
 
@@ -219,6 +225,7 @@ class WebhookHook(Hook):
                 # this key, so endpoints reading it keep working. Drop after v0.6.
                 "lamella_name": context.item_name,
                 "error": context.error,
+                "skip_reason": context.skip_reason,
                 "timestamp": context.timestamp,
             }
             requests.request(self.method, self.url, json=payload, timeout=self.timeout)

--- a/tests/autolamella/test_task_manager_hooks.py
+++ b/tests/autolamella/test_task_manager_hooks.py
@@ -1,4 +1,4 @@
-"""Which lifecycle hooks TaskManager fires, and when.
+"""Which lifecycle hooks TaskManager fires, and how it reports the outcome.
 
 These exercise `_run_queue` without running a real task: the queue either drains
 immediately, is stopped before it starts, or contains only items that get skipped.
@@ -9,7 +9,12 @@ from typing import List
 
 import pytest
 
-from fibsem.applications.autolamella.structures import DefectType, Experiment, Lamella
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskStatus,
+    DefectType,
+    Experiment,
+    Lamella,
+)
 from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
 from fibsem.hooks import FunctionHook, HookContext, HookEvent, HookManager
 
@@ -141,3 +146,70 @@ def test_skip_fires_no_task_started_or_completed(experiment, recorder):
 
     assert "task_started" not in _events(fired)
     assert "task_completed" not in _events(fired)
+
+
+# ---------------------------------------------------------------------------
+# closing status message
+# ---------------------------------------------------------------------------
+
+def _status_messages(monkeypatch) -> List[str]:
+    """Capture the workflow_info strings the manager closes a run with."""
+    captured: List[str] = []
+    monkeypatch.setattr(
+        "fibsem.applications.autolamella.workflows.tasks.manager.update_status_ui",
+        lambda parent_ui, msg, workflow_info=None, **kw: captured.append(workflow_info),
+    )
+    return captured
+
+
+def test_a_run_that_skipped_everything_does_not_claim_completion(
+    experiment, recorder, monkeypatch, caplog
+):
+    """Every task skipped means no work happened. Reporting "All tasks completed." is
+    the same misreport as an abort claiming completion, just quieter."""
+    import logging
+
+    messages = _status_messages(monkeypatch)
+    hook_manager, _ = recorder
+    lamella = Lamella(path=experiment.path, number=1, petname="lam-1")
+    lamella.defect.state = DefectType.FAILURE
+    experiment.positions.append(lamella)
+    manager = _manager(experiment, hook_manager)
+
+    with caplog.at_level(logging.WARNING):
+        manager.run(task_names=["MillTrench"], required_lamella=[lamella.name])
+
+    assert messages[-1] == "No tasks ran: all 1 skipped."
+    # update_status_ui does not log workflow_info, so headless needs its own warning
+    assert any("all 1 were skipped" in r.message for r in caplog.records)
+
+
+def test_completion_message_counts_partial_skips(experiment, recorder):
+    hook_manager, _ = recorder
+    manager = _manager(experiment, hook_manager)
+    items = manager.queue.build_from_matrix(["MillTrench"], ["lam-1", "lam-2"])
+    manager.queue.mark_done(items[0], AutoLamellaTaskStatus.Skipped)
+    manager.queue.mark_done(items[1], AutoLamellaTaskStatus.Completed)
+
+    assert manager._completion_message() == "All tasks completed (1 skipped)."
+
+
+def test_completion_message_unchanged_when_nothing_skipped(experiment, recorder):
+    hook_manager, _ = recorder
+    manager = _manager(experiment, hook_manager)
+    items = manager.queue.build_from_matrix(["MillTrench"], ["lam-1"])
+    manager.queue.mark_done(items[0], AutoLamellaTaskStatus.Completed)
+
+    assert manager._completion_message() == "All tasks completed."
+
+
+def test_cancelled_run_keeps_its_own_message(experiment, recorder, monkeypatch):
+    """The cancelled path must not fall through to a completion message."""
+    messages = _status_messages(monkeypatch)
+    hook_manager, _ = recorder
+    manager = _manager(experiment, hook_manager)
+    manager.stop()
+
+    manager.run(task_names=["MillTrench"], required_lamella=[])
+
+    assert messages[-1] == "Workflow cancelled."

--- a/tests/autolamella/test_task_manager_hooks.py
+++ b/tests/autolamella/test_task_manager_hooks.py
@@ -1,0 +1,143 @@
+"""Which lifecycle hooks TaskManager fires, and when.
+
+These exercise `_run_queue` without running a real task: the queue either drains
+immediately, is stopped before it starts, or contains only items that get skipped.
+"""
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from fibsem.applications.autolamella.structures import DefectType, Experiment, Lamella
+from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+from fibsem.hooks import FunctionHook, HookContext, HookEvent, HookManager
+
+
+ALL_EVENTS = list(HookEvent)
+
+
+@pytest.fixture
+def recorder() -> "tuple[HookManager, List[HookContext]]":
+    """A HookManager that records every event fired, in order."""
+    fired: List[HookContext] = []
+    manager = HookManager()
+    manager.register(FunctionHook(name="recorder", events=ALL_EVENTS, callback=fired.append))
+    return manager, fired
+
+
+@pytest.fixture
+def experiment(tmp_path: Path) -> Experiment:
+    return Experiment(path=tmp_path, name="test-exp")
+
+
+def _manager(experiment: Experiment, hook_manager: HookManager) -> TaskManager:
+    # The microscope is only touched to retract the FM objective after the queue
+    # drains; None would raise, so a stand-in with fm=None is enough.
+    class _NoMicroscope:
+        fm = None
+
+    return TaskManager(
+        microscope=_NoMicroscope(),
+        experiment=experiment,
+        parent_ui=None,
+        hook_manager=hook_manager,
+    )
+
+
+def _events(fired: List[HookContext]) -> List[str]:
+    return [c.event for c in fired]
+
+
+# ---------------------------------------------------------------------------
+# workflow_completed vs workflow_cancelled
+# ---------------------------------------------------------------------------
+
+def test_draining_the_queue_fires_workflow_completed(experiment, recorder):
+    hook_manager, fired = recorder
+    manager = _manager(experiment, hook_manager)
+
+    manager.run(task_names=["MillTrench"], required_lamella=[])
+
+    assert _events(fired) == ["workflow_started", "workflow_completed"]
+
+
+def test_stopping_fires_workflow_cancelled_not_completed(experiment, recorder):
+    """Pressing Stop used to fire workflow_completed, so a subscriber could not tell an
+    aborted run from a finished one."""
+    hook_manager, fired = recorder
+    manager = _manager(experiment, hook_manager)
+    manager.stop()
+
+    manager.run(task_names=["MillTrench"], required_lamella=[])
+
+    assert _events(fired) == ["workflow_started", "workflow_cancelled"]
+    assert "workflow_completed" not in _events(fired)
+
+
+def test_stopping_midway_still_cancels(experiment, recorder):
+    """Stop set while items remain: the queue does not drain, so this is a cancel."""
+    hook_manager, fired = recorder
+    experiment.positions.append(Lamella(path=experiment.path, number=1, petname="lam-1"))
+    manager = _manager(experiment, hook_manager)
+    manager.stop()
+
+    manager.run(task_names=["MillTrench"], required_lamella=["lam-1"])
+
+    assert _events(fired)[-1] == "workflow_cancelled"
+
+
+# ---------------------------------------------------------------------------
+# task_skipped
+# ---------------------------------------------------------------------------
+
+def test_missing_lamella_fires_task_skipped(experiment, recorder, caplog):
+    """A queue item naming a lamella that is not in the experiment used to be marked
+    Skipped and dropped silently — no status, no hook, no log."""
+    import logging
+
+    hook_manager, fired = recorder
+    manager = _manager(experiment, hook_manager)
+
+    with caplog.at_level(logging.WARNING):
+        manager.run(task_names=["MillTrench"], required_lamella=["ghost-lamella"])
+
+    skipped = [c for c in fired if c.event == "task_skipped"]
+    assert len(skipped) == 1
+    assert skipped[0].item_name == "ghost-lamella"
+    assert skipped[0].task_name == "MillTrench"
+    assert skipped[0].skip_reason == "lamella_not_found"
+    assert any("ghost-lamella" in r.message for r in caplog.records)
+
+
+def test_skipped_task_carries_its_reason(experiment, recorder):
+    """A lamella marked as a failure is skipped by _should_skip, and the reason reaches
+    the hook rather than only the UI status dict."""
+    hook_manager, fired = recorder
+    lamella = Lamella(path=experiment.path, number=1, petname="lam-1")
+    lamella.defect.state = DefectType.FAILURE
+    experiment.positions.append(lamella)
+    manager = _manager(experiment, hook_manager)
+
+    manager.run(task_names=["MillTrench"], required_lamella=[lamella.name])
+
+    skipped = [c for c in fired if c.event == "task_skipped"]
+    assert len(skipped) == 1
+    assert skipped[0].item_name == lamella.name
+    assert skipped[0].skip_reason == "failure"
+    # a skip still leaves a complete workflow: nothing was aborted
+    assert _events(fired)[-1] == "workflow_completed"
+
+
+def test_skip_fires_no_task_started_or_completed(experiment, recorder):
+    """A skipped task never ran, so it must not look like one that did."""
+    hook_manager, fired = recorder
+    lamella = Lamella(path=experiment.path, number=1, petname="lam-1")
+    lamella.defect.state = DefectType.FAILURE
+    experiment.positions.append(lamella)
+    manager = _manager(experiment, hook_manager)
+
+    manager.run(task_names=["MillTrench"], required_lamella=[lamella.name])
+
+    assert "task_started" not in _events(fired)
+    assert "task_completed" not in _events(fired)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -132,6 +132,31 @@ def test_notification_hook_unknown_placeholder_does_not_drop_message():
     assert received == ["MillTrench on {itemname}"]
 
 
+def test_notification_hook_renders_skip_reason():
+    received = []
+    hook = NotificationHook(
+        name="skip",
+        events=[HookEvent.TASK_SKIPPED],
+        message_template="Skipped {task_name} on {item_name}: {skip_reason}",
+        _notify=lambda msg, typ: received.append(msg),
+    )
+    hook.run(_ctx(event=HookEvent.TASK_SKIPPED, skip_reason="missing_prereqs"))
+    assert received == ["Skipped MillTrench on Lamella-1: missing_prereqs"]
+
+
+def test_skip_reason_renders_empty_when_absent():
+    """Every other event leaves skip_reason unset; the placeholder must not print None."""
+    received = []
+    hook = NotificationHook(
+        name="skip",
+        events=[HookEvent.TASK_COMPLETED],
+        message_template="{task_name}[{skip_reason}]",
+        _notify=lambda msg, typ: received.append(msg),
+    )
+    hook.run(_ctx())
+    assert received == ["MillTrench[]"]
+
+
 def test_hook_context_lamella_name_alias_is_deprecated():
     ctx = _ctx(item_name="Lamella-7")
     with pytest.deprecated_call():


### PR DESCRIPTION
Part 1 of FIB-465 — the defects only. The completion events (`EXPERIMENT_COMPLETED`, `LAMELLA_COMPLETED`) follow in a separate PR.

## The bug

`TaskManager._run_queue()`'s loop exits when the queue drains **or** when the user presses Stop, and it fired `WORKFLOW_COMPLETED` unconditionally after it:

```python
while not self.is_stopped:
    ...
self._fire_workflow_hook(HookEvent.WORKFLOW_COMPLETED)   # both ways out
update_status_ui(self.parent_ui, "", workflow_info="All tasks completed.")
```

So pressing Stop fired a completion event and put "All tasks completed." in the status bar. There was a `TASK_CANCELLED` but no workflow equivalent, so nothing downstream could tell an abort from a finished run. FIB-461 proposes generating the shareable PDF and overview PNG off `WORKFLOW_COMPLETED`, which would have regenerated them after every abort and labelled the result complete.

## Changes

**`WORKFLOW_CANCELLED`** — fired when the loop exits with the stop event set, with the status message corrected on that path.

**`TASK_SKIPPED`** — a skip was already reported to the UI with a `skip_reason`, but fired no hook, so a run that skipped every task was indistinguishable from one where every task succeeded. It fires from the manager rather than `AutoLamellaTask`, because `_should_skip` decides before any task object exists — which is also why there is no `task_state` on this event. `task_type` is looked up from the lamella's config so `Hook.task_types` filtering still works.

**`HookContext.skip_reason`** — needed to carry the reason. Rendered in message templates (`{skip_reason}`, empty string when unset) and included in the webhook payload. Growing the context rather than widening the gap with the status dict, per FIB-464.

**The silent skip path** — when `get_lamella_by_name` returned `None` the item was marked `Skipped` and dropped with no status, no hook and no log entry. It now warns and fires `TASK_SKIPPED` with reason `lamella_not_found`.

## Compatibility

Both events are additive. `HookEvent` is a `str, Enum` whose values are what `Hook.to_dict` persists, so saved configurations keep loading and firing unchanged. `hook_config_widget` derives its event list from the enum, so both are selectable in the UI without a second edit:

```
task_started, task_completed, task_failed, task_cancelled, task_skipped,
workflow_started, workflow_completed, workflow_cancelled
```

## Testing

`TaskManager` had no test coverage at all, so this adds `tests/autolamella/test_task_manager_hooks.py` — 6 tests driving `_run_queue` without running a real task (the queue drains, is stopped, or contains only items that get skipped).

Checked against the pre-fix manager: 4 of the 6 fail, and the 2 that pass are the controls (`workflow_completed` on a clean drain; a skip firing no `task_started`). 659 tests pass overall.
