### PR TITLE
[hooks] Add item and experiment completion events (FIB-465)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -253,8 +253,8 @@ class TaskManager:
         return bool(positions) and all(self._is_complete(p) for p in positions)
 
     def _maybe_fire_lamella_completed(self, lamella: 'Lamella', task_name: str) -> None:
-        """Fire LAMELLA_COMPLETED the first time a lamella satisfies the workflow's
-        completion predicate during this run.
+        """Fire ITEM_COMPLETED the first time a lamella satisfies the workflow's
+        completion predicate during this run. The lamella is AutoLamella's item.
 
         A lamella is the unit that gets delivered to a TEM, so this is the event
         downstream work hangs off — it lets a per-lamella artifact be produced the
@@ -265,7 +265,7 @@ class TaskManager:
         self._completed_lamella.add(lamella.name)
         fire_event(
             self.hook_manager,
-            HookEvent.LAMELLA_COMPLETED,
+            HookEvent.ITEM_COMPLETED,
             task_name=task_name,
             task_type=lamella.task_state.task_type,
             item_name=lamella.name,
@@ -275,7 +275,7 @@ class TaskManager:
     def _maybe_fire_experiment_completed(self) -> None:
         """Fire EXPERIMENT_COMPLETED once, when the last outstanding lamella finishes.
 
-        The roll-up of LAMELLA_COMPLETED: same predicate, applied to every position.
+        The roll-up of ITEM_COMPLETED: same predicate, applied to every position.
         """
         if self._experiment_was_complete or not self._all_lamella_complete():
             return

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -4,7 +4,7 @@ import logging
 import threading
 import time
 from datetime import datetime
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Set
 
 import fibsem.config as fcfg
 from fibsem.constants import DATETIME_DISPLAY_AMPM
@@ -61,6 +61,10 @@ class TaskManager:
         self.hook_manager = hook_manager
         self._stop_event = threading.Event()
         self.queue = TaskQueue()
+        # Lamellae already finished when the run started, so re-running a task on
+        # finished work does not re-announce it. Seeded in _run_queue.
+        self._completed_lamella: Set[str] = set()
+        self._experiment_was_complete = False
 
     # --- Public API ---
 
@@ -79,6 +83,7 @@ class TaskManager:
 
     def _run_queue(self) -> None:
         """Process queue items until empty or stopped."""
+        self._snapshot_completion()
         self._fire_workflow_hook(HookEvent.WORKFLOW_STARTED)
         while not self.is_stopped:
             item = self.queue.next()
@@ -159,6 +164,8 @@ class TaskManager:
                 msg=msg,
             )
 
+            self._maybe_fire_lamella_completed(lamella, item.task_name)
+
         # if the objective is inserted, retract for safety
         if self.microscope.fm is not None and self.microscope.fm.objective.state == "Inserted":
             self.microscope.fm.objective.retract()
@@ -171,6 +178,10 @@ class TaskManager:
         else:
             self._fire_workflow_hook(HookEvent.WORKFLOW_COMPLETED)
             update_status_ui(self.parent_ui, "", workflow_info=self._completion_message())
+            # After the run event, since finishing the run is what makes the experiment
+            # finishable. Not fired on the cancelled path: an aborted run has not
+            # established anything about the experiment.
+            self._maybe_fire_experiment_completed()
         print(self.experiment.task_history_dataframe())
 
     def build_run_summary_dataframe(self) -> pd.DataFrame:
@@ -212,6 +223,69 @@ class TaskManager:
 
     def _fire_workflow_hook(self, event: HookEvent) -> None:
         fire_event(self.hook_manager, event)
+
+    def _is_complete(self, lamella: 'Lamella') -> bool:
+        """Whether a lamella has completed every task the workflow requires of it."""
+        # task_protocol is None until one is loaded ("must be set externally").
+        if self.experiment.task_protocol is None:
+            return False
+        workflow_config = self.experiment.task_protocol.workflow_config
+        # A workflow that requires nothing completes nothing. is_completed() is
+        # vacuously True against an empty required-task list, which would announce
+        # every lamella as finished the moment a protocol failed to load — and with
+        # FIB-461 that means generating artifacts for work that never happened.
+        if not workflow_config.required_tasks:
+            return False
+        return workflow_config.is_completed(lamella)
+
+    def _snapshot_completion(self) -> None:
+        """Record what was already finished before this run, so the completion events
+        fire on the transition rather than on every run that ends in a finished state."""
+        self._completed_lamella = {
+            p.name for p in self.experiment.positions if self._is_complete(p)
+        }
+        self._experiment_was_complete = self._all_lamella_complete()
+
+    def _all_lamella_complete(self) -> bool:
+        positions = self.experiment.positions
+        # An experiment with no lamellae has not been completed, it is empty. all([])
+        # would say otherwise.
+        return bool(positions) and all(self._is_complete(p) for p in positions)
+
+    def _maybe_fire_lamella_completed(self, lamella: 'Lamella', task_name: str) -> None:
+        """Fire LAMELLA_COMPLETED the first time a lamella satisfies the workflow's
+        completion predicate during this run.
+
+        A lamella is the unit that gets delivered to a TEM, so this is the event
+        downstream work hangs off — it lets a per-lamella artifact be produced the
+        moment that lamella is finished, rather than waiting for the whole run.
+        """
+        if lamella.name in self._completed_lamella or not self._is_complete(lamella):
+            return
+        self._completed_lamella.add(lamella.name)
+        fire_event(
+            self.hook_manager,
+            HookEvent.LAMELLA_COMPLETED,
+            task_name=task_name,
+            task_type=lamella.task_state.task_type,
+            item_name=lamella.name,
+            task_state=lamella.task_state,
+        )
+
+    def _maybe_fire_experiment_completed(self) -> None:
+        """Fire EXPERIMENT_COMPLETED once, when the last outstanding lamella finishes.
+
+        The roll-up of LAMELLA_COMPLETED: same predicate, applied to every position.
+        """
+        if self._experiment_was_complete or not self._all_lamella_complete():
+            return
+        self._experiment_was_complete = True
+        logging.info(f"Experiment {self.experiment.name} is complete.")
+        fire_event(
+            self.hook_manager,
+            HookEvent.EXPERIMENT_COMPLETED,
+            item_name=self.experiment.name,
+        )
 
     def _completion_message(self) -> str:
         """Closing status line for a run that was not cancelled.

--- a/fibsem/hooks.py
+++ b/fibsem/hooks.py
@@ -23,8 +23,9 @@ class HookEvent(str, Enum):
     TASK_CANCELLED = "task_cancelled"
     TASK_SKIPPED = "task_skipped"
     # Ordered by widening scope: one task, then the item all its tasks were for, then
-    # the run, then the whole experiment.
-    LAMELLA_COMPLETED = "lamella_completed"
+    # the run, then the whole experiment. "item" rather than "lamella" to match
+    # HookContext.item_name — the application decides what an item is.
+    ITEM_COMPLETED = "item_completed"
     WORKFLOW_STARTED = "workflow_started"
     WORKFLOW_COMPLETED = "workflow_completed"
     WORKFLOW_CANCELLED = "workflow_cancelled"

--- a/fibsem/hooks.py
+++ b/fibsem/hooks.py
@@ -22,9 +22,13 @@ class HookEvent(str, Enum):
     TASK_FAILED = "task_failed"
     TASK_CANCELLED = "task_cancelled"
     TASK_SKIPPED = "task_skipped"
+    # Ordered by widening scope: one task, then the item all its tasks were for, then
+    # the run, then the whole experiment.
+    LAMELLA_COMPLETED = "lamella_completed"
     WORKFLOW_STARTED = "workflow_started"
     WORKFLOW_COMPLETED = "workflow_completed"
     WORKFLOW_CANCELLED = "workflow_cancelled"
+    EXPERIMENT_COMPLETED = "experiment_completed"
 
 
 @dataclass

--- a/fibsem/ui/widgets/tests/test_hooks_manual.py
+++ b/fibsem/ui/widgets/tests/test_hooks_manual.py
@@ -54,8 +54,7 @@ class HookTestWindow(QMainWindow):
         self.manager = HookManager()
         self.manager.register(LoggingHook(
             name="task_logger",
-            events=[HookEvent.TASK_STARTED, HookEvent.TASK_COMPLETED, HookEvent.TASK_FAILED,
-                    HookEvent.WORKFLOW_STARTED, HookEvent.WORKFLOW_COMPLETED],
+            events=list(HookEvent),  # from the enum, so a new event is logged for free
         ))
         self.manager.register(NotificationHook(
             name="completion_toast",

--- a/tests/autolamella/test_task_manager_completion_hooks.py
+++ b/tests/autolamella/test_task_manager_completion_hooks.py
@@ -1,4 +1,6 @@
-"""LAMELLA_COMPLETED and EXPERIMENT_COMPLETED: when a unit of work is finished.
+"""ITEM_COMPLETED and EXPERIMENT_COMPLETED: when a unit of work is finished.
+
+AutoLamella's item is a lamella.
 
 Both fire on the *transition* into completeness, so a run that re-touches finished
 work stays quiet. Completion is driven through the real predicate — a workflow config
@@ -76,7 +78,7 @@ def _events(fired: List[HookContext]) -> List[str]:
 
 
 # ---------------------------------------------------------------------------
-# lamella_completed
+# item_completed (an item is a lamella here)
 # ---------------------------------------------------------------------------
 
 def test_fires_when_the_last_required_task_lands(experiment, recorder):
@@ -92,7 +94,7 @@ def test_fires_when_the_last_required_task_lands(experiment, recorder):
     lamella.task_history.append(AutoLamellaTaskState(name="MillUndercut"))
     manager._maybe_fire_lamella_completed(lamella, "MillUndercut")
 
-    assert _events(fired) == ["lamella_completed"]
+    assert _events(fired) == ["item_completed"]
     assert fired[0].item_name == lamella.name
     assert fired[0].task_name == "MillUndercut"
 
@@ -106,7 +108,7 @@ def test_fires_once_not_on_every_later_task(experiment, recorder):
     manager._maybe_fire_lamella_completed(lamella, "MillUndercut")
     manager._maybe_fire_lamella_completed(lamella, "SomeExtraTask")
 
-    assert _events(fired) == ["lamella_completed"]
+    assert _events(fired) == ["item_completed"]
 
 
 def test_a_lamella_already_finished_before_the_run_stays_quiet(experiment, recorder):

--- a/tests/autolamella/test_task_manager_completion_hooks.py
+++ b/tests/autolamella/test_task_manager_completion_hooks.py
@@ -1,0 +1,213 @@
+"""LAMELLA_COMPLETED and EXPERIMENT_COMPLETED: when a unit of work is finished.
+
+Both fire on the *transition* into completeness, so a run that re-touches finished
+work stays quiet. Completion is driven through the real predicate — a workflow config
+with required tasks, and lamellae whose task_history satisfies it — rather than by
+stubbing, so these break if the predicate's inputs change.
+"""
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaTaskProtocol,
+    AutoLamellaTaskState,
+    AutoLamellaWorkflowConfig,
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+from fibsem.hooks import FunctionHook, HookContext, HookEvent, HookManager
+
+REQUIRED_TASKS = ["MillTrench", "MillUndercut"]
+
+
+@pytest.fixture
+def recorder() -> "tuple[HookManager, List[HookContext]]":
+    fired: List[HookContext] = []
+    manager = HookManager()
+    manager.register(
+        FunctionHook(name="recorder", events=list(HookEvent), callback=fired.append)
+    )
+    return manager, fired
+
+
+@pytest.fixture
+def experiment(tmp_path: Path) -> Experiment:
+    """An experiment whose workflow requires two tasks of every lamella."""
+    exp = Experiment(path=tmp_path, name="test-exp")
+    # task_protocol is None until one is loaded, so build one
+    exp.task_protocol = AutoLamellaTaskProtocol(
+        workflow_config=AutoLamellaWorkflowConfig(
+            tasks=[
+                AutoLamellaTaskDescription(name=name, supervise=False, required=True)
+                for name in REQUIRED_TASKS
+            ]
+        )
+    )
+    return exp
+
+
+def _manager(experiment: Experiment, hook_manager: HookManager) -> TaskManager:
+    class _NoMicroscope:
+        fm = None
+
+    return TaskManager(
+        microscope=_NoMicroscope(),
+        experiment=experiment,
+        parent_ui=None,
+        hook_manager=hook_manager,
+    )
+
+
+def _add_lamella(experiment: Experiment, name: str, completed: List[str]) -> Lamella:
+    lamella = Lamella(path=experiment.path, number=len(experiment.positions) + 1, petname=name)
+    for task_name in completed:
+        lamella.task_history.append(AutoLamellaTaskState(name=task_name))
+    experiment.positions.append(lamella)
+    return lamella
+
+
+def _events(fired: List[HookContext]) -> List[str]:
+    return [c.event for c in fired]
+
+
+# ---------------------------------------------------------------------------
+# lamella_completed
+# ---------------------------------------------------------------------------
+
+def test_fires_when_the_last_required_task_lands(experiment, recorder):
+    hook_manager, fired = recorder
+    lamella = _add_lamella(experiment, "lam-1", completed=["MillTrench"])
+    manager = _manager(experiment, hook_manager)
+    manager._snapshot_completion()
+
+    # not finished yet: one required task outstanding
+    manager._maybe_fire_lamella_completed(lamella, "MillTrench")
+    assert _events(fired) == []
+
+    lamella.task_history.append(AutoLamellaTaskState(name="MillUndercut"))
+    manager._maybe_fire_lamella_completed(lamella, "MillUndercut")
+
+    assert _events(fired) == ["lamella_completed"]
+    assert fired[0].item_name == lamella.name
+    assert fired[0].task_name == "MillUndercut"
+
+
+def test_fires_once_not_on_every_later_task(experiment, recorder):
+    hook_manager, fired = recorder
+    lamella = _add_lamella(experiment, "lam-1", completed=REQUIRED_TASKS)
+    manager = _manager(experiment, hook_manager)
+    manager._completed_lamella = set()  # pretend it finished during this run
+
+    manager._maybe_fire_lamella_completed(lamella, "MillUndercut")
+    manager._maybe_fire_lamella_completed(lamella, "SomeExtraTask")
+
+    assert _events(fired) == ["lamella_completed"]
+
+
+def test_a_lamella_already_finished_before_the_run_stays_quiet(experiment, recorder):
+    """Re-running a task on finished work must not re-announce it."""
+    hook_manager, fired = recorder
+    lamella = _add_lamella(experiment, "lam-1", completed=REQUIRED_TASKS)
+    manager = _manager(experiment, hook_manager)
+    manager._snapshot_completion()
+
+    manager._maybe_fire_lamella_completed(lamella, "MillTrench")
+
+    assert _events(fired) == []
+
+
+def test_each_lamella_fires_for_itself(experiment, recorder):
+    hook_manager, fired = recorder
+    lam1 = _add_lamella(experiment, "lam-1", completed=["MillTrench"])
+    lam2 = _add_lamella(experiment, "lam-2", completed=["MillTrench"])
+    manager = _manager(experiment, hook_manager)
+    manager._snapshot_completion()
+
+    for lamella in (lam1, lam2):
+        lamella.task_history.append(AutoLamellaTaskState(name="MillUndercut"))
+        manager._maybe_fire_lamella_completed(lamella, "MillUndercut")
+
+    assert [c.item_name for c in fired] == [lam1.name, lam2.name]
+
+
+# ---------------------------------------------------------------------------
+# experiment_completed
+# ---------------------------------------------------------------------------
+
+def test_fires_when_the_last_outstanding_lamella_finishes(experiment, recorder):
+    hook_manager, fired = recorder
+    _add_lamella(experiment, "lam-1", completed=REQUIRED_TASKS)
+    lam2 = _add_lamella(experiment, "lam-2", completed=["MillTrench"])
+    manager = _manager(experiment, hook_manager)
+    manager._snapshot_completion()
+
+    manager._maybe_fire_experiment_completed()
+    assert _events(fired) == []  # lam-2 still outstanding
+
+    lam2.task_history.append(AutoLamellaTaskState(name="MillUndercut"))
+    manager._maybe_fire_experiment_completed()
+
+    assert _events(fired) == ["experiment_completed"]
+    assert fired[0].item_name == experiment.name
+
+
+def test_does_not_refire_for_an_already_complete_experiment(experiment, recorder):
+    hook_manager, fired = recorder
+    _add_lamella(experiment, "lam-1", completed=REQUIRED_TASKS)
+    manager = _manager(experiment, hook_manager)
+    manager._snapshot_completion()
+
+    manager._maybe_fire_experiment_completed()
+    manager._maybe_fire_experiment_completed()
+
+    assert _events(fired) == []
+
+
+def test_an_empty_experiment_is_not_a_completed_one(experiment, recorder):
+    """all([]) is True, which would declare an experiment with no lamellae finished."""
+    hook_manager, fired = recorder
+    manager = _manager(experiment, hook_manager)
+    manager._snapshot_completion()
+
+    manager._maybe_fire_experiment_completed()
+
+    assert _events(fired) == []
+
+
+def test_a_workflow_requiring_nothing_completes_nothing(tmp_path, recorder):
+    """is_completed() is vacuously True against an empty required-task list, so a
+    protocol that failed to load would otherwise announce every lamella as finished."""
+    hook_manager, fired = recorder
+    exp = Experiment(path=tmp_path, name="no-protocol")  # task_protocol is None
+    lamella = _add_lamella(exp, "lam-1", completed=[])
+    manager = _manager(exp, hook_manager)
+    manager._snapshot_completion()
+
+    manager._maybe_fire_lamella_completed(lamella, "MillTrench")
+    manager._maybe_fire_experiment_completed()
+
+    assert _events(fired) == []
+
+
+# ---------------------------------------------------------------------------
+# through a real run
+# ---------------------------------------------------------------------------
+
+def test_a_cancelled_run_does_not_complete_the_experiment(experiment, recorder):
+    """An aborted run establishes nothing about the experiment, even if the work
+    happens to be finished."""
+    hook_manager, fired = recorder
+    _add_lamella(experiment, "lam-1", completed=REQUIRED_TASKS)
+    manager = _manager(experiment, hook_manager)
+    manager._completed_lamella = set()
+    manager.stop()
+
+    manager.run(task_names=["MillTrench"], required_lamella=[])
+
+    assert "experiment_completed" not in _events(fired)
+    assert _events(fired)[-1] == "workflow_cancelled"


### PR DESCRIPTION
Part 2 of FIB-465, completing it. Part 1 (the abort defect and `TASK_SKIPPED`) shipped in #263.

Nothing could tell when a unit of work was actually *finished*. `WORKFLOW_COMPLETED` means "this run's queue drained", which is true after running one task on one lamella — so it says nothing about whether anything is done.

## Changes

**`LAMELLA_COMPLETED`** — fires the first time a lamella satisfies the workflow's completion predicate. Lead event of the two: a lamella is what gets delivered to a TEM, so the downstream recipient's unit is the lamella, and a per-lamella artifact can be produced the moment that lamella finishes rather than waiting for the whole run.

**`EXPERIMENT_COMPLETED`** — the roll-up. Same predicate over every position, fired *after* `WORKFLOW_COMPLETED` (finishing the run is what makes the experiment finishable) and **not** on the cancelled path, since an aborted run establishes nothing.

Both fire on the **transition**, not the state. The manager snapshots what was already complete when the run started, so re-running a task on finished work stays quiet.

## Three ways the predicate lies

All guarded, because FIB-461 will hang artifact generation off these events and a false positive means generating a report for work that never happened:

| case | without the guard |
|---|---|
| `required_tasks` is empty | `is_completed()` is vacuously `True`, so a protocol that failed to load announces **every** lamella as finished |
| `task_protocol` is `None` | `AttributeError` — it's `None` until a protocol is loaded ("must be set externally") |
| experiment has no lamellae | `all([])` is `True`, so an empty experiment reports as completed |

The `None` case was found by the tests, not by reading — worth noting since it's reachable from a fresh experiment.

A failed task can't trigger a false completion: `task_history` is only appended in `post_task()`, which a raising task never reaches.

## Payload

`LAMELLA_COMPLETED` carries the lamella in `item_name` plus the task that finished it. `EXPERIMENT_COMPLETED` carries the **experiment name** in `item_name` — which is what the `lamella_name` → `item_name` rename in #260 was for; the event's subject genuinely isn't a lamella.

## Compatibility

Additive, so saved hook configurations keep loading. Both events are selectable in the config UI without a second edit:

```
task_started, task_completed, task_failed, task_cancelled, task_skipped,
lamella_completed, workflow_started, workflow_completed, workflow_cancelled,
experiment_completed
```

The manual harness's LoggingHook now derives its list from `HookEvent` too, so it stops needing an edit per event.

## Testing

`tests/autolamella/test_task_manager_completion_hooks.py` — 9 tests driving completion through the *real* predicate (a workflow config with required tasks, and lamellae whose `task_history` satisfies it) rather than stubbing it, so they break if the predicate's inputs change. 719 tests pass overall.

## One naming question before merge

`LAMELLA_COMPLETED` puts AutoLamella vocabulary into `fibsem/hooks.py`, which #260 deliberately made domain-agnostic — the whole point of `item_name`. The consistent alternative is `ITEM_COMPLETED`, with `item_name` saying which lamella.

I implemented the name FIB-465 specifies rather than renaming your spec unilaterally, but **this is the moment to decide**: `HookEvent` values are persisted in hook configs, so renaming after release is a breaking change, exactly as the issue notes for its other members. Two-line change if you want `ITEM_COMPLETED`.
