### PR TITLE
[autolamella] Record every task outcome, and register metadata outside the GUI

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -1369,6 +1369,32 @@ class Experiment:
         """
         return _configure_logging(path=self.path, log_filename="logfile")
 
+    def register_metadata(self, microscope: "FibsemMicroscope") -> None:
+        """Stamp this experiment's identity onto the images ``microscope`` acquires.
+
+        Which experiment produced an image is a property of the run, not of the GUI.
+        This previously happened only in AutoLamellaUI, so images acquired from a
+        script, a headless run, or the standalone FibsemUI carried the microscope's
+        default ``FibsemExperiment()`` -- id ``None`` -- and could not be associated
+        with an experiment afterwards. See FIB-449.
+
+        Mirrors ``configure_logging``: ``load`` and ``create`` deliberately do not
+        call it, because reading an experiment must not reach into the caller's
+        microscope. Callers that own the run say so. The app calls it when it adopts
+        an experiment, TaskManager calls it when it takes one to run, and a script
+        driving the microscope directly calls it itself.
+        """
+        import fibsem
+        from fibsem.utils import _register_metadata
+
+        _register_metadata(
+            microscope=microscope,
+            application_software="autolamella",
+            application_software_version=fibsem.__version__,
+            experiment_name=self.name,
+            experiment_method="null",
+        )
+
     def save_protocol(self) -> None:
         """Save the task protocol to disk in the experiment directory."""
         self.task_protocol.save(os.path.join(self.path, "protocol.yaml"))

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -320,9 +320,18 @@ class AutoLamellaWorkflowConfig:
         return []
 
     def get_completed_tasks(self, lamella: 'Lamella', with_timestamps: bool = False) -> List[str]:
-        """Get the list of completed tasks for a given lamella."""
+        """Get the list of completed tasks for a given lamella.
+
+        Filtered on status for the same reason as Lamella.completed_tasks:
+        task_history holds every terminal outcome since FIB-490. Unfiltered, a
+        failed required task would make is_completed() true, which drives the
+        ITEM_COMPLETED / EXPERIMENT_COMPLETED events and the is_completed column
+        in the experiment summary.
+        """
         completed_tasks = []
         for task in lamella.task_history:
+            if task.status is not AutoLamellaTaskStatus.Completed:
+                continue
             if task.name in self.workflow:
                 txt = task.name
                 if with_timestamps:
@@ -790,14 +799,30 @@ class Lamella:
 
     @property
     def completed_tasks(self) -> List[str]:
-        """Return a list of completed task names."""
-        return [task.name for task in self.task_history]
+        """Return a list of completed task names.
+
+        Filtered on status: task_history records every terminal outcome, not just
+        successes (FIB-490), so an unfiltered read would count a failed task as
+        done. That matters most in TaskManager._should_skip, where this gates
+        prerequisites -- a failed trench would otherwise license an undercut.
+        """
+        return [
+            task.name
+            for task in self.task_history
+            if task.status is AutoLamellaTaskStatus.Completed
+        ]
 
     @property
     def last_completed_task(self) -> Optional['AutoLamellaTaskState']:
-        """Return the last completed task state."""
-        if self.task_history:
-            return self.task_history[-1]
+        """Return the last completed task state.
+
+        The last *completed* one, not the last recorded: a failure landing last
+        would otherwise be reported as the lamella's latest progress in the
+        experiment summary.
+        """
+        for task in reversed(self.task_history):
+            if task.status is AutoLamellaTaskStatus.Completed:
+                return task
         return None
 
     @property

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -783,6 +783,19 @@ class Lamella:
 
     @property
     def is_failure(self) -> bool:
+        """Whether a human has judged this lamella defective.
+
+        Deliberately not set by a failing task, and it should stay that way. A
+        task failing is a fact about one attempt; a defect is a judgement about
+        the lamella. TaskManager._should_skip skips a lamella marked failed for
+        *every* remaining task, so auto-setting this on a stage timeout or a
+        momentary comms drop would permanently abandon a lamella that only
+        needed retrying.
+
+        Whether a failed task blocks dependent work is a separate question,
+        answered by completed_tasks -- which filters on task status, so a failed
+        prerequisite does not license the task that requires it. See FIB-490.
+        """
         return self.defect.state is DefectType.FAILURE
 
     @property

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -15,8 +15,7 @@ from copy import deepcopy
 from typing import List, Optional, TYPE_CHECKING
 import numpy as np
 import napari
-import fibsem
-from fibsem import conversions, utils
+from fibsem import conversions
 from fibsem.constants import METRE_TO_MICRON, MICRON_TO_METRE
 from fibsem.ui import notification_service
 from fibsem.microscope import FibsemMicroscope
@@ -567,13 +566,7 @@ class AutoLamellaUI(QMainWindow):
 
         # Register metadata
         if self.microscope is not None:
-            utils._register_metadata(
-                microscope=self.microscope,
-                application_software="autolamella",
-                application_software_version=fibsem.__version__,
-                experiment_name=self.experiment.name,
-                experiment_method="null",
-            )
+            self.experiment.register_metadata(self.microscope)
 
         # Update UI
         self.update_lamella_combobox()

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -142,11 +142,39 @@ class AutoLamellaTask(ABC):
         except Exception as e:
             # A user Stop is a cancellation, not a failure — fire the distinct hook so it
             # notifies as "cancelled" (warning) rather than "FAILED" (error).
-            self._fire_hook("task_cancelled" if self._is_cancellation(e) else "task_failed",
-                            error=str(e))
+            cancelled = self._is_cancellation(e)
+            # Record before announcing. The hook payload carries task_state, which
+            # still reads InProgress from pre_task until this runs.
+            #
+            # Guarded: anything raising in here would replace the task's own
+            # exception with this one, losing what actually went wrong.
+            try:
+                self.lamella.task_state.status = (
+                    AutoLamellaTaskStatus.Cancelled if cancelled else AutoLamellaTaskStatus.Failed
+                )
+                self.lamella.task_state.status_message = (
+                    "Cancelled by user." if cancelled else str(e)
+                )
+                self._record_outcome()
+            except Exception:
+                logging.exception(f"Could not record the outcome of {self.task_name}")
+            self._fire_hook("task_cancelled" if cancelled else "task_failed", error=str(e))
             raise
         self.post_task()
         self._fire_hook("task_completed")
+
+    def _record_outcome(self) -> None:
+        """Freeze the finished task_state into task_history.
+
+        Runs on every terminal path, not just success. task_state is a single object
+        that the next task's pre_task overwrites, so an outcome that isn't frozen here
+        is gone from the experiment as soon as that lamella starts its next task --
+        leaving the logfile as the only record that the task ever failed. See FIB-490.
+        """
+        if self.lamella.task_state is None:
+            raise ValueError("Task state is not set. Did you run pre_task()?")
+        self.lamella.task_state.end_timestamp = datetime.timestamp(datetime.now())
+        self.lamella.task_history.append(deepcopy(self.lamella.task_state))
 
     def _is_cancellation(self, exc: Exception) -> bool:
         """Whether ``exc`` is a user Stop rather than a genuine failure: it surfaces as
@@ -198,15 +226,14 @@ class AutoLamellaTask(ABC):
         # post-task
         if self.lamella.task_state is None:
             raise ValueError("Task state is not set. Did you run pre_task()?")
-        self.lamella.task_state.end_timestamp = datetime.timestamp(datetime.now())
         self.lamella.task_state.status = AutoLamellaTaskStatus.Completed
         self.lamella.task_state.status_message = ""
         self.log_status_message(message="FINISHED", display_message="Finished")
         self.log_task_config()
         self.lamella.task_config[self.task_name] = deepcopy(self.config)
-        self.lamella.task_history.append(deepcopy(self.lamella.task_state))
+        self._record_outcome()
         if self._last_fib_image is not None:
-            self.lamella.save_thumbnail(self._last_fib_image) # TODO: append to the history if task fails?
+            self.lamella.save_thumbnail(self._last_fib_image)
 
     def log_task_config(self) -> None:
         """Log the task configuration to the log file. This can be used for debugging or reporting."""

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -61,6 +61,12 @@ class TaskManager:
         self.hook_manager = hook_manager
         self._stop_event = threading.Event()
         self.queue = TaskQueue()
+
+        # Stamp the experiment onto the images this run acquires. Done here rather
+        # than only in the UI so a headless run through run_tasks() records it too;
+        # the app also calls it when it adopts an experiment, and repeating it just
+        # re-sets the same two attributes. See FIB-449.
+        self.experiment.register_metadata(self.microscope)
         # Lamellae already finished when the run started, so re-running a task on
         # finished work does not re-announce it. Seeded in _run_queue.
         self._completed_lamella: Set[str] = set()
@@ -416,7 +422,14 @@ class TaskManager:
             # A user Stop surfaces as OperationCancelledError (milling) or InterruptedError
             # (_check_for_abort); either way self.is_stopped is set by TaskManager.stop().
             # Mark it Cancelled, not Failed — it isn't an error.
-            if self.is_stopped or isinstance(e, OperationCancelledError):
+            #
+            # The task itself now records the outcome and freezes it into task_history
+            # before re-raising (FIB-490), so this repeats what it already set. It stays
+            # as the fallback for exceptions raised before the task's run() is entered --
+            # an unknown task name, or a construction failure -- where nothing else has.
+            # The predicate matches AutoLamellaTaskBase._is_cancellation so the frozen
+            # history entry and the live task_state cannot disagree.
+            if self.is_stopped or isinstance(e, (OperationCancelledError, InterruptedError)):
                 logging.info(f"Task {task_name} for lamella {lamella.name} cancelled by user.")
                 lamella.task_state.status = AutoLamellaTaskStatus.Cancelled
                 lamella.task_state.status_message = "Cancelled by user."

--- a/tests/autolamella/test_completed_task_accessors.py
+++ b/tests/autolamella/test_completed_task_accessors.py
@@ -1,0 +1,105 @@
+"""A task in the history is not necessarily a task that succeeded.
+
+FIB-490 put failed and cancelled outcomes into ``task_history``, which is what makes
+failures durable. That changes what the history *contains*, so the accessors that
+answer "what has this lamella completed?" have to filter on status -- otherwise a
+failed task silently counts as done, and the prerequisite gate opens on work that
+never succeeded.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaTaskState,
+    AutoLamellaTaskStatus,
+    AutoLamellaWorkflowConfig,
+    Lamella,
+)
+
+
+@pytest.fixture
+def lamella(tmp_path: Path) -> Lamella:
+    return Lamella(path=tmp_path / "lam", number=0, petname="test")
+
+
+@pytest.fixture
+def workflow() -> AutoLamellaWorkflowConfig:
+    """MillUndercut requires MillTrench."""
+    return AutoLamellaWorkflowConfig(
+        tasks=[
+            AutoLamellaTaskDescription(name="MillTrench", supervise=False, required=True),
+            AutoLamellaTaskDescription(name="MillUndercut", supervise=False, required=True,
+                                       requires=["MillTrench"]),
+        ]
+    )
+
+
+def _finished(name: str, status: AutoLamellaTaskStatus) -> AutoLamellaTaskState:
+    return AutoLamellaTaskState(name=name, status=status)
+
+
+def test_a_failed_task_is_not_a_completed_task(lamella: Lamella) -> None:
+    lamella.task_history.append(_finished("MillTrench", AutoLamellaTaskStatus.Failed))
+
+    assert lamella.completed_tasks == []
+    assert not lamella.has_completed_task("MillTrench")
+
+
+def test_a_cancelled_task_is_not_a_completed_task(lamella: Lamella) -> None:
+    lamella.task_history.append(_finished("MillTrench", AutoLamellaTaskStatus.Cancelled))
+
+    assert not lamella.has_completed_task("MillTrench")
+
+
+def test_a_completed_task_still_counts(lamella: Lamella) -> None:
+    lamella.task_history.append(_finished("MillTrench", AutoLamellaTaskStatus.Completed))
+
+    assert lamella.completed_tasks == ["MillTrench"]
+    assert lamella.has_completed_task("MillTrench")
+
+
+def test_a_failed_prerequisite_does_not_satisfy_the_gate(
+    lamella: Lamella, workflow: AutoLamellaWorkflowConfig
+) -> None:
+    """The blocking case: TaskManager._should_skip gates on has_completed_task, and
+    nothing else stops it -- is_failure reads defect.state, which only a human
+    clicking in the UI ever sets. A failed trench must not license an undercut."""
+    lamella.task_history.append(_finished("MillTrench", AutoLamellaTaskStatus.Failed))
+
+    requirements = workflow.requirements("MillUndercut")
+    assert requirements == ["MillTrench"]
+    assert not all(lamella.has_completed_task(req) for req in requirements)
+
+
+def test_a_failed_required_task_leaves_the_workflow_incomplete(
+    lamella: Lamella, workflow: AutoLamellaWorkflowConfig
+) -> None:
+    """Feeds ITEM_COMPLETED / EXPERIMENT_COMPLETED and the is_completed report column."""
+    lamella.task_history.append(_finished("MillTrench", AutoLamellaTaskStatus.Failed))
+    lamella.task_history.append(_finished("MillUndercut", AutoLamellaTaskStatus.Completed))
+
+    assert not workflow.is_completed(lamella)
+    assert workflow.get_completed_tasks(lamella) == ["MillUndercut"]
+    assert "MillTrench" in workflow.get_remaining_tasks(lamella)
+
+
+def test_last_completed_task_skips_a_failed_entry(lamella: Lamella) -> None:
+    """Reported as last_completed / last_completed_at in the experiment summary, so a
+    failure landing last would otherwise be presented as the lamella's latest progress."""
+    lamella.task_history.append(_finished("MillTrench", AutoLamellaTaskStatus.Completed))
+    lamella.task_history.append(_finished("MillUndercut", AutoLamellaTaskStatus.Failed))
+
+    last = lamella.last_completed_task
+    assert last is not None
+    assert last.name == "MillTrench"
+
+
+def test_the_history_still_holds_the_failure(lamella: Lamella) -> None:
+    """Filtering the accessors must not undo FIB-490 -- the record itself stays."""
+    lamella.task_history.append(_finished("MillTrench", AutoLamellaTaskStatus.Failed))
+
+    assert len(lamella.task_history) == 1
+    assert lamella.task_history[0].status is AutoLamellaTaskStatus.Failed

--- a/tests/autolamella/test_experiment_metadata_registration.py
+++ b/tests/autolamella/test_experiment_metadata_registration.py
@@ -1,0 +1,73 @@
+"""Which experiment produced an image is a property of the run, not of the GUI.
+
+Registration used to happen only in AutoLamellaUI, so images acquired from a script
+or a headless run carried the microscope's default ``FibsemExperiment()`` -- id
+``None`` -- and could not be associated with an experiment afterwards. See FIB-449.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from fibsem import utils
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+from fibsem.microscope import FibsemMicroscope
+
+
+@pytest.fixture
+def microscope() -> FibsemMicroscope:
+    scope, _ = utils.setup_session(manufacturer="Demo")
+    return scope
+
+
+@pytest.fixture
+def experiment(tmp_path: Path) -> Experiment:
+    exp = Experiment(path=tmp_path, name="test-experiment")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    # Constructing an Experiment deliberately does not write to disk (FIB-420);
+    # Experiment.create() is what makes the directory in the app.
+    os.makedirs(exp.path, exist_ok=True)
+    return exp
+
+
+def test_a_fresh_microscope_records_no_experiment(
+    microscope: FibsemMicroscope,
+) -> None:
+    """The gap this closes: without registration there is nothing to associate."""
+    assert microscope.experiment.id is None
+
+
+def test_register_metadata_stamps_the_experiment_onto_the_microscope(
+    microscope: FibsemMicroscope, experiment: Experiment
+) -> None:
+    experiment.register_metadata(microscope)
+
+    assert microscope.experiment.id == "test-experiment"
+    assert microscope.experiment.application == "autolamella"
+
+
+def test_creating_a_task_manager_registers_without_a_gui(
+    microscope: FibsemMicroscope, experiment: Experiment
+) -> None:
+    """A headless run goes through TaskManager, never through AutoLamellaUI."""
+    TaskManager(microscope=microscope, experiment=experiment, parent_ui=None)
+
+    assert microscope.experiment.id == "test-experiment"
+
+
+def test_loading_an_experiment_does_not_touch_the_microscope(
+    microscope: FibsemMicroscope, experiment: Experiment, tmp_path: Path
+) -> None:
+    """Mirrors configure_logging (FIB-421): reading an experiment must not reach
+    into the caller's microscope. The load dialog reads one on every click to
+    preview it, and previewing is not adopting."""
+    experiment.save()
+
+    Experiment.load(Path(experiment.path) / "experiment.yaml")
+
+    assert microscope.experiment.id is None

--- a/tests/autolamella/test_task_manager_completion_hooks.py
+++ b/tests/autolamella/test_task_manager_completion_hooks.py
@@ -17,6 +17,7 @@ from fibsem.applications.autolamella.structures import (
     AutoLamellaTaskDescription,
     AutoLamellaTaskProtocol,
     AutoLamellaTaskState,
+    AutoLamellaTaskStatus,
     AutoLamellaWorkflowConfig,
     Experiment,
     Lamella,
@@ -68,7 +69,7 @@ def _manager(experiment: Experiment, hook_manager: HookManager) -> TaskManager:
 def _add_lamella(experiment: Experiment, name: str, completed: List[str]) -> Lamella:
     lamella = Lamella(path=experiment.path, number=len(experiment.positions) + 1, petname=name)
     for task_name in completed:
-        lamella.task_history.append(AutoLamellaTaskState(name=task_name))
+        lamella.task_history.append(AutoLamellaTaskState(name=task_name, status=AutoLamellaTaskStatus.Completed))
     experiment.positions.append(lamella)
     return lamella
 
@@ -91,7 +92,7 @@ def test_fires_when_the_last_required_task_lands(experiment, recorder):
     manager._maybe_fire_lamella_completed(lamella, "MillTrench")
     assert _events(fired) == []
 
-    lamella.task_history.append(AutoLamellaTaskState(name="MillUndercut"))
+    lamella.task_history.append(AutoLamellaTaskState(name="MillUndercut", status=AutoLamellaTaskStatus.Completed))
     manager._maybe_fire_lamella_completed(lamella, "MillUndercut")
 
     assert _events(fired) == ["item_completed"]
@@ -131,7 +132,7 @@ def test_each_lamella_fires_for_itself(experiment, recorder):
     manager._snapshot_completion()
 
     for lamella in (lam1, lam2):
-        lamella.task_history.append(AutoLamellaTaskState(name="MillUndercut"))
+        lamella.task_history.append(AutoLamellaTaskState(name="MillUndercut", status=AutoLamellaTaskStatus.Completed))
         manager._maybe_fire_lamella_completed(lamella, "MillUndercut")
 
     assert [c.item_name for c in fired] == [lam1.name, lam2.name]
@@ -151,7 +152,7 @@ def test_fires_when_the_last_outstanding_lamella_finishes(experiment, recorder):
     manager._maybe_fire_experiment_completed()
     assert _events(fired) == []  # lam-2 still outstanding
 
-    lam2.task_history.append(AutoLamellaTaskState(name="MillUndercut"))
+    lam2.task_history.append(AutoLamellaTaskState(name="MillUndercut", status=AutoLamellaTaskStatus.Completed))
     manager._maybe_fire_experiment_completed()
 
     assert _events(fired) == ["experiment_completed"]

--- a/tests/autolamella/test_task_outcome_recording.py
+++ b/tests/autolamella/test_task_outcome_recording.py
@@ -1,0 +1,138 @@
+"""Every terminal outcome is recorded, not just success.
+
+``task_state`` is a single object the next task's ``pre_task`` overwrites, so an
+outcome that never reaches ``task_history`` is gone from the experiment as soon as
+that lamella starts its next task. Before FIB-490 only ``post_task`` appended, and
+``run()`` re-raises before reaching it -- so failures and cancellations were absent
+from the history entirely, leaving the logfile as the only record they happened.
+"""
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from fibsem import utils
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskStatus,
+    Lamella,
+)
+from fibsem.applications.autolamella.workflows.tasks.trench import (
+    MillTrenchTask,
+    MillTrenchTaskConfig,
+)
+from fibsem.cancellation import OperationCancelledError
+from fibsem.hooks import FunctionHook, HookContext, HookManager
+from fibsem.microscope import FibsemMicroscope
+
+
+@pytest.fixture
+def microscope() -> FibsemMicroscope:
+    scope, _ = utils.setup_session(manufacturer="Demo")
+    return scope
+
+
+def _make_task(microscope: FibsemMicroscope, tmp_path: Path) -> MillTrenchTask:
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+    return MillTrenchTask(
+        microscope=microscope, config=MillTrenchTaskConfig(), lamella=lamella
+    )
+
+
+def _run_raising(task: MillTrenchTask, exc: Exception) -> None:
+    """Drive task.run() with a _run that raises, swallowing the re-raise."""
+    task._run = lambda: (_ for _ in ()).throw(exc)  # type: ignore[method-assign]
+    with pytest.raises(type(exc)):
+        task.run()
+
+
+def test_a_failed_task_is_recorded_in_the_history(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    task = _make_task(microscope, tmp_path)
+    _run_raising(task, RuntimeError("stage timeout"))
+
+    assert len(task.lamella.task_history) == 1
+    entry = task.lamella.task_history[0]
+    assert entry.status is AutoLamellaTaskStatus.Failed
+    assert entry.status_message == "stage timeout"
+    assert entry.end_timestamp is not None
+
+
+def test_a_cancelled_task_is_recorded_as_cancelled_not_failed(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    task = _make_task(microscope, tmp_path)
+    _run_raising(task, OperationCancelledError("stopped"))
+
+    assert len(task.lamella.task_history) == 1
+    assert task.lamella.task_history[0].status is AutoLamellaTaskStatus.Cancelled
+
+
+def test_a_successful_task_still_records_exactly_one_entry(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """Regression: post_task's append moved into _record_outcome."""
+    task = _make_task(microscope, tmp_path)
+    task._run = lambda: None  # type: ignore[method-assign]
+    task.run()
+
+    assert len(task.lamella.task_history) == 1
+    entry = task.lamella.task_history[0]
+    assert entry.status is AutoLamellaTaskStatus.Completed
+    assert entry.end_timestamp is not None
+
+
+def test_the_history_entry_survives_the_next_task_on_that_lamella(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """The point of freezing a copy: pre_task resets the live task_state, so an
+    entry holding a reference rather than a copy would be silently rewritten."""
+    task = _make_task(microscope, tmp_path)
+    _run_raising(task, RuntimeError("stage timeout"))
+
+    # The same lamella starts its next task, resetting the live state.
+    next_task = MillTrenchTask(
+        microscope=microscope, config=MillTrenchTaskConfig(), lamella=task.lamella
+    )
+    next_task.pre_task()
+
+    assert task.lamella.task_state.status is AutoLamellaTaskStatus.InProgress
+    assert task.lamella.task_history[0].status is AutoLamellaTaskStatus.Failed
+    assert task.lamella.task_history[0].status_message == "stage timeout"
+
+
+def test_a_recording_failure_does_not_mask_the_task_error(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """Recording runs inside the except block, so if it raised it would replace the
+    task's own exception and hide what actually went wrong."""
+    task = _make_task(microscope, tmp_path)
+    task._record_outcome = lambda: (_ for _ in ()).throw(  # type: ignore[method-assign]
+        RuntimeError("history is broken")
+    )
+    task._run = lambda: (_ for _ in ()).throw(ValueError("the real failure"))  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError, match="the real failure"):
+        task.run()
+
+
+def test_the_failure_hook_sees_the_terminal_status(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """The hook fires after the outcome is recorded, not before.
+
+    Previously the manager set Failed only once the exception had propagated out
+    of run(), so a task_failed consumer read InProgress off task_state.
+    """
+    seen: List[HookContext] = []
+    manager = HookManager()
+    manager.register(FunctionHook(events=["task_failed"], callback=seen.append))
+
+    task = _make_task(microscope, tmp_path)
+    task.task_manager = type("_M", (), {"hook_manager": manager, "is_stopped": False})()
+    _run_raising(task, RuntimeError("stage timeout"))
+
+    assert len(seen) == 1
+    assert seen[0].task_state.status is AutoLamellaTaskStatus.Failed
+    assert seen[0].error == "stage timeout"


### PR DESCRIPTION
Closes FIB-490 and FIB-449.

## Failures were recorded durably nowhere (FIB-490)

`task_history` is appended in one place — `post_task` — and `run()` re-raises before reaching it:

```python
try:
    self._run()
except Exception as e:
    self._fire_hook(...)
    raise                      # <- post_task never runs
self.post_task()               # <- only on success
```

So **`task_history` contained successes only.**

The manager does set `Failed` and call `experiment.save()`, but it writes to `task_state` — a single object that the next task's `pre_task` overwrites, resetting status, message, end timestamp and outputs. The queue is task-outer / lamella-inner, so a failure survived only until that lamella reached its next task, then disappeared from `experiment.yaml` entirely. The logfile was the only remaining trace.

That silently emptied the report's Task History table, made per-protocol success rates uncomputable, and meant a bug-report bundle carried an experiment whose history showed no failures.

### What changed

`_record_outcome()` is shared by both paths and runs on every terminal outcome. On the failure path it runs **before** the hook fires, not after — previously a `task_failed` consumer read `InProgress` off `task_state`, because the manager set the real status only once the exception had propagated out of `run()`.

Two things beyond the literal fix:

**The recording is guarded.** Code in an `except` block that runs before `raise` must not itself raise, or it replaces the task's real exception with its own. There's a test asserting a deliberately broken recorder still lets `ValueError("the real failure")` through.

**The manager's cancellation predicate now matches the task's.** It was missing `InterruptedError`, so a bare one would have frozen `Cancelled` into history while the manager stamped `Failed` on the live state — the two disagreeing about the same task.

The manager's status-setting stays rather than being deleted as redundant: it's still the only thing that runs if `run_task` raises *before* the task's `run()` is entered — an unknown task name, or a construction failure.

## Registration only happened in the GUI (FIB-449)

`utils._register_metadata` was called from exactly one place, `AutoLamellaUI`. Images acquired from a script, a headless run, or the standalone FibsemUI carried the microscope's default `FibsemExperiment()` — `id=None` — and could not be associated with an experiment afterwards.

`Experiment.register_metadata(microscope)` mirrors `Experiment.configure_logging()` from FIB-421, including the deliberate omission from `load`/`create`: reading an experiment must not reach into the caller's microscope, since the load dialog reads one on every click to preview it. `TaskManager.__init__` calls it so headless runs through `run_tasks()` record it too.

## Scoped out on purpose

FIB-449's second half — stamping lamella and task identity into image metadata via the `pre_task`/`post_task` bracket. That needs the field decisions in FIB-466 and FIB-483, and building the mechanism now would leave it with no consumer. The exception-safety groundwork it depends on is what this PR lays.

## Tests

10 new tests across two files. The one that matters most asserts a history entry survives the next task's `pre_task` overwriting the live state — that's the actual bug, and a version holding a reference rather than a frozen copy would pass every other test here.

Full suite green locally (2265 passed, 24 skipped — the skips are the uninstalled plugin fixture).