### PR TITLE
[fm] Rework the FM overview status row, and stop a click re-posing the stage (FIB-469, FIB-470, FIB-471, FIB-491)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -14,12 +14,14 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 from PyQt5.QtCore import QPoint, Qt, pyqtSignal
+from PyQt5.QtGui import QFontMetrics
 from PyQt5.QtWidgets import (
     QDialog,
     QHBoxLayout,
     QLabel,
     QPushButton,
     QScrollArea,
+    QSizePolicy,
     QSplitter,
     QVBoxLayout,
     QWidget,
@@ -60,30 +62,69 @@ from fibsem.ui.widgets.canvas.fm_canvas import FMRealSpaceCanvasWidget
 from fibsem.ui.widgets.canvas.stage_frame import FMStageProjection, StageFrame
 
 TEXT_MUTED = "#868e93"
-PROGRESS_WIDTH = 260
-PROGRESS_HEIGHT = 22
 PROGRESS_FONT_PX = 10
+# Inset for chrome drawn over the canvas, matching the toolbar buttons' own margin so
+# the cursor readout in the top left lines up with the buttons in the top right.
+CANVAS_CHROME_MARGIN = 4
 
 
-def progress_slot(progress: FibsemProgressWidget) -> QWidget:
-    """A fixed-size holder that keeps its space whether the bar is showing or not.
+def shrink_progress_text(progress: FibsemProgressWidget) -> FibsemProgressWidget:
+    """Fit a progress bar to a narrow column: smaller text, and no say in the width.
 
-    `FibsemProgressWidget.reset()` hides itself, which in a plain layout collapses the
-    row and shifts everything beside it -- so a bar going away at the end of a run
-    would drag the buttons across. Reserving the space decouples them.
+    The font goes on via a stylesheet rather than `setFont`, which does not reach the
+    bar, and rather than touching the widget's private `_bar`. The bar's own sheet sets
+    no font-size, so this applies without disturbing the chunk colouring it relies on to
+    tell finished from failed.
+
+    The size policy is the same trap as :class:`ElidedLabel`, one level down: a bar
+    reports its *message* width as its hint, so a long failure ran off the end of the
+    column and out of the window. Ignored horizontally, it takes the width it is given.
     """
-    # Via a stylesheet on the holder rather than `setFont`, which does not reach the
-    # bar, and rather than touching the widget's private `_bar`. The bar's own sheet
-    # sets no font-size, so this applies without disturbing the chunk colouring it
-    # relies on to tell finished from failed.
     progress.setStyleSheet(f"QProgressBar {{ font-size: {PROGRESS_FONT_PX}px; }}")
+    progress.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
+    return progress
 
-    slot = QWidget()
-    slot.setFixedSize(PROGRESS_WIDTH, PROGRESS_HEIGHT)
-    layout = QHBoxLayout(slot)
-    layout.setContentsMargins(0, 0, 0, 0)
-    layout.addWidget(progress)
-    return slot
+
+class ElidedLabel(QLabel):
+    """A label that shortens its text to fit, instead of forcing its parent wider.
+
+    A plain `QLabel` reports the full width of its text as its size hint, and in a
+    layout that hint becomes a minimum: a 132-character acquisition failure dragged this
+    widget's minimum width from 1030 px to 1728 px, so a message pushed the window
+    around. Here the text gives way instead.
+
+    `text()` still returns what was set, not what is drawn -- callers compare against it
+    to decide whether the line is theirs to overwrite, and eliding is presentation.
+    """
+
+    def __init__(self, text: str = "", parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._full_text = ""
+        # Ignored horizontally: the label neither asks for room nor refuses to shrink,
+        # which is the whole point -- its content must not set anyone's minimum.
+        self.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
+        self.setText(text)
+
+    def setText(self, text: Optional[str]) -> None:
+        self._full_text = text or ""
+        # The full message, for anything too long to show. Set before the caller gets a
+        # chance to override it: `_finish` follows its own `setText` with a tooltip of
+        # its own, and that one should win.
+        self.setToolTip(self._full_text)
+        self._elide()
+
+    def text(self) -> str:
+        return self._full_text
+
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        self._elide()
+
+    def _elide(self) -> None:
+        metrics = QFontMetrics(self.font())
+        super().setText(
+            metrics.elidedText(self._full_text, Qt.ElideRight, max(0, self.width() - 2))
+        )
 
 
 # Key the in-progress mosaic is drawn under. Distinct from a finished overview's
@@ -282,32 +323,40 @@ class FMOverviewWidget(QWidget):
         # and scrolling sideways to reach a spinbox is worse than a cramped one.
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
+        # Where a double-click would take the stage, read off continuously rather than
+        # on demand: the canvas is a map, and a map you have to click to get a
+        # coordinate out of cannot be used to decide whether to click.
+        #
+        # Drawn over the canvas rather than beside it, in the one free corner -- the
+        # toolbar owns the top right, the scalebar the bottom right, and the stage info
+        # bar the bottom left. A Qt label rather than the canvas's own text chrome
+        # because this updates on every mouse motion, and `set_info_text` costs ~4.9 ms
+        # against a label's 0.08 ms; at motion-event rates that is the difference
+        # between a readout and a stutter.
+        self.cursor_readout = QLabel(self.canvas.canvas)
+        self.cursor_readout.setAttribute(Qt.WA_TransparentForMouseEvents)
+        # Monospaced so the digits sit still while the cursor moves. A proportional
+        # font makes the whole readout shuffle on every pixel of travel.
+        self.cursor_readout.setStyleSheet(
+            "color: #e8e8e8; font-size: 10px; font-family: monospace;"
+            "background: rgba(26, 26, 26, 160); border-radius: 3px; padding: 2px 5px;"
+        )
+        self.cursor_readout.move(CANVAS_CHROME_MARGIN, CANVAS_CHROME_MARGIN)
+        self.cursor_readout.hide()  # nothing to say until the pointer is over the canvas
+
         splitter = QSplitter(Qt.Horizontal)
         splitter.addWidget(self.canvas)
-        splitter.addWidget(scroll)
-        splitter.setStretchFactor(0, 1)
-        splitter.setStretchFactor(1, 0)
 
         # Two bars: across the grid, and within the tile being acquired. Both are
         # `FibsemProgressWidget`, which distinguishes finished from failed -- a failed
         # run used to paint the same full green bar as a successful one.
-        self.progress_tiles = FibsemProgressWidget()
-        self.progress_tile_detail = FibsemProgressWidget()
+        # Hidden until a run starts: they are empty most of the time, and stacked in a
+        # column there is nothing beside them to shift when they come and go.
+        self.progress_tiles = shrink_progress_text(FibsemProgressWidget())
+        self.progress_tile_detail = shrink_progress_text(FibsemProgressWidget())
 
-        self.status = QLabel("")
+        self.status = ElidedLabel("")
         self.status.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px;")
-
-        # Where a double-click would take the stage, read off continuously rather than
-        # on demand: the canvas is a map, and a map you have to click to get a
-        # coordinate out of cannot be used to decide whether to click.
-        self.cursor_readout = QLabel("")
-        self.cursor_readout.setFixedWidth(CURSOR_READOUT_WIDTH)
-        self.cursor_readout.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
-        # Monospaced so the digits sit still while the cursor moves. A proportional
-        # font makes the whole readout shuffle on every pixel of travel.
-        self.cursor_readout.setStyleSheet(
-            f"color: {TEXT_MUTED}; font-size: 11px; font-family: monospace;"
-        )
 
         self.button_acquire = QPushButton("Acquire Overview")
         self.button_acquire.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
@@ -320,32 +369,45 @@ class FMOverviewWidget(QWidget):
         self.button_cancel.clicked.connect(self.cancel)
         self.button_cancel.setEnabled(False)
 
-        # One row: status, both bars, then the actions. The bars sit in fixed slots, so
-        # the buttons hold their position whatever the bars are doing.
-        # The two bars are one readout and sit tight together; the gap that matters is
-        # the one separating them from the buttons.
-        bars = QWidget()
-        bars_layout = QHBoxLayout(bars)
-        bars_layout.setContentsMargins(0, 0, 0, 0)
-        bars_layout.setSpacing(3)
-        bars_layout.addWidget(progress_slot(self.progress_tiles))
-        bars_layout.addWidget(progress_slot(self.progress_tile_detail))
+        buttons = QWidget()
+        buttons_layout = QHBoxLayout(buttons)
+        buttons_layout.setContentsMargins(0, 0, 0, 0)
+        buttons_layout.setSpacing(6)
+        buttons_layout.addWidget(self.button_cancel)
+        buttons_layout.addWidget(self.button_acquire, stretch=1)
 
+        # The actions live at the foot of the settings column, not in a row spanning the
+        # whole widget. Spanning cost 1030 px of minimum width -- all of it, the canvas
+        # asked for 10 -- because a horizontal row cannot give anything up. Stacked in
+        # the column the floor is the column's own, and the canvas can be as narrow as
+        # the window allows. Same shape as `FibsemMinimapWidget`, which stacks its run
+        # controls under its settings for the same reason.
         self.status_row = QWidget()
-        status_layout = QHBoxLayout(self.status_row)
-        status_layout.setContentsMargins(8, 4, 8, 8)
-        status_layout.setSpacing(10)
-        status_layout.addWidget(self.status, stretch=1)
-        status_layout.addWidget(self.cursor_readout)
-        status_layout.addWidget(bars)
-        status_layout.addWidget(self.button_cancel)
-        status_layout.addWidget(self.button_acquire)
+        actions_layout = QVBoxLayout(self.status_row)
+        actions_layout.setContentsMargins(8, 4, 8, 8)
+        actions_layout.setSpacing(5)
+        actions_layout.addWidget(self.status)
+        actions_layout.addWidget(self.progress_tiles)
+        actions_layout.addWidget(self.progress_tile_detail)
+        actions_layout.addWidget(buttons)
+
+        side = QWidget()
+        side_layout = QVBoxLayout(side)
+        side_layout.setContentsMargins(0, 0, 0, 0)
+        side_layout.setSpacing(0)
+        side_layout.addWidget(scroll, stretch=1)
+        side_layout.addWidget(self.status_row)
+
+        splitter.addWidget(side)
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 0)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(6)
+        layout.setSpacing(0)
         layout.addWidget(splitter, stretch=1)
-        layout.addWidget(self.status_row)
+
+        self._set_progress_visible(False)
 
         self.channel_widget.settings_changed.connect(self._on_channels_changed)
         self.channel_widget.enabled_changed.connect(self._on_enabled_changed)
@@ -743,7 +805,31 @@ class FMOverviewWidget(QWidget):
             return None
         self._origin = origin  # fix it now, so later drawing shares this frame
 
-        return StageFrame(self.canvas.canvas, origin, projection)
+        return StageFrame(self.canvas.canvas, self._posed(origin), projection)
+
+    def _posed(self, origin: FibsemStagePosition) -> FibsemStagePosition:
+        """The origin, re-stated in the pose the stage is actually in.
+
+        Canvas zero is a *place* -- x, y, z -- and stays fixed, which is what lets
+        images accumulate against a common frame. The rotation and tilt are not part of
+        that anchor: they are how stage space maps onto the canvas at all, and they
+        change when the stage re-poses.
+
+        Carrying the pose the origin happened to be captured in was a real bug, and a
+        dangerous one. The tab is built when a microscope connects, so the origin
+        recorded whatever pose the stage was in then -- usually t = 0. Moving to the FM
+        position afterwards left every click resolved through the old pose: the y
+        component came out with the wrong sign, so the stage went to the wrong place,
+        and the target inherited t = 0, so it also flipped 180 degrees getting there.
+        """
+        current = self._current_stage_position()
+        if current is None:
+            return origin
+        return FibsemStagePosition(
+            x=origin.x, y=origin.y, z=origin.z,
+            r=current.r, t=current.t,
+            coordinate_system=origin.coordinate_system,
+        )
 
     def _refresh_stage_metadata(self) -> None:
         """Draw where the sample and the stage can physically go.
@@ -814,7 +900,44 @@ class FMOverviewWidget(QWidget):
             logging.debug(f"Could not mark the current stage position: {e}")
             self.current_position_overlay.set_points([])
             return
+        # Unlabelled on purpose: the crosshair sits on top of the data, and a caption
+        # riding along with it obscures the sample it is pointing at. What it is gets
+        # said in the info bar below instead, which costs the image nothing.
         self.current_position_overlay.set_points([point], labels=[""])
+        self._refresh_stage_info()
+
+    def _refresh_stage_info(self) -> None:
+        """Say where the stage is, in the canvas's bottom-left info bar.
+
+        The marker shows *where*; this says the numbers, which is what you need to
+        write one down or check you are where you meant to be. On the canvas rather
+        than in the settings column because it describes what is being looked at.
+
+        The objective position rides along because on a fluorescence system it is part
+        of the pose -- focus depends on it, and it is not visible anywhere else on this
+        tab. The milling angle deliberately does not: it is a beam-side quantity,
+        meaningless while looking through the camera, and it belongs on the FIB/SEM
+        overview if anywhere.
+
+        The objective may be unavailable -- a microscope with none, or one that will not
+        answer -- and is dropped on its own rather than losing the stage position with it.
+        """
+        position = self._current_stage_position()
+        if position is None:
+            self.canvas.canvas.set_info_text(None)
+            return
+
+        parts = [position.pretty]
+
+        try:
+            parts.append(
+                f"objective {self.fm.objective.position * constants.SI_TO_MILLI:.3f} mm"
+                f" ({self.fm.objective.state.lower()})"
+            )
+        except Exception as e:
+            logging.debug(f"No objective position for the info bar: {e}")
+
+        self.canvas.canvas.set_info_text("   |   ".join(parts))
 
     def _current_stage_position(self) -> Optional[FibsemStagePosition]:
         """Where the stage is, polling the microscope only when nothing has said yet.
@@ -995,19 +1118,33 @@ class FMOverviewWidget(QWidget):
         self._update_grid_summary()
 
     def _on_cursor_moved(self, x: Optional[float], y: Optional[float]) -> None:
-        """Report the stage position under the cursor, or blank once it leaves."""
+        """Report the stage position under the cursor, or hide once it leaves."""
         if x is None or y is None:
-            self.cursor_readout.setText("")
+            self._set_cursor_readout("")
             return
         frame = self._frame()
         if frame is None:
-            self.cursor_readout.setText("")
+            self._set_cursor_readout("")
             return
         try:
-            self.cursor_readout.setText(self._describe(frame.to_stage(x, y)))
+            self._set_cursor_readout(self._describe(frame.to_stage(x, y)))
         except Exception as e:
             logging.debug(f"Could not resolve the cursor position: {e}")
-            self.cursor_readout.setText("")
+            self._set_cursor_readout("")
+
+    def _set_cursor_readout(self, text: str) -> None:
+        """Show the readout over the canvas, sized to its text, or hide it when empty.
+
+        Hidden rather than blanked: it sits on top of the image, and an empty plaque
+        floating over the data is worse than nothing there. `adjustSize` because the
+        label is positioned rather than laid out, so nothing else will size it.
+        """
+        self.cursor_readout.setText(text)
+        if not text:
+            self.cursor_readout.hide()
+            return
+        self.cursor_readout.adjustSize()
+        self.cursor_readout.show()
 
     @staticmethod
     def _describe(position: FibsemStagePosition) -> str:
@@ -1200,6 +1337,17 @@ class FMOverviewWidget(QWidget):
         self._apply_enabled_state()
         self.status.setText("Cancelling…")
 
+    def _set_progress_visible(self, visible: bool) -> None:
+        """Show the progress bars only while there is progress to show.
+
+        They spend most of their life empty. Stacked in the settings column nothing sits
+        beside them, so they can come and go without moving anything -- which is what
+        made this possible: they used to be inline with the buttons, where hiding one
+        slid the actions sideways, and a fixed-size holder existed purely to stop that.
+        """
+        self.progress_tiles.setVisible(visible)
+        self.progress_tile_detail.setVisible(visible)
+
     def _set_running(self, running: bool) -> None:
         self._running = running
         self._apply_enabled_state()
@@ -1212,6 +1360,11 @@ class FMOverviewWidget(QWidget):
             self.progress_tiles.reset()
             self.progress_tile_detail.reset()
             self.status.setText("Starting…")
+
+        # After the resets above, not before: `FibsemProgressWidget.reset()` hides
+        # itself, so showing the bars first and resetting them second leaves them
+        # hidden for the whole run.
+        self._set_progress_visible(running)
 
     # ── progress ─────────────────────────────────────────────────────────
 
@@ -1365,6 +1518,10 @@ class FMOverviewWidget(QWidget):
         return "", ""
 
     def _finish(self, state: str, error: Optional[str]) -> None:
+        # Hides both bars. The per-tile one stays hidden -- there is no tile in progress
+        # to describe -- but the overall bar is shown again below whenever it has a
+        # terminal state worth reading: `FibsemProgressWidget` paints finished and
+        # failed differently, and that colour is the at-a-glance answer.
         self._set_running(False)
         self._worker = None
         self.progress_tile_detail.reset()
@@ -1380,16 +1537,22 @@ class FMOverviewWidget(QWidget):
             self.status.setText(f"Overview acquired — {shape[-1]} × {shape[-2]} px{suffix}")
             self.status.setToolTip(tooltip)
             self.progress_tiles.update_progress(ProgressUpdate.done())
+            self.progress_tiles.show()
         elif state == "overview-cancelled":
             self.status.setText("Cancelled. Tiles acquired so far are still shown.")
+            # Nothing to show: a cancel has no terminal state of its own, and the status
+            # line already says what happened.
             self.progress_tiles.reset()
         else:
             self.status.setText(f"Failed: {error}" if error else "Failed.")
             # Failed, not done: the widget paints these differently, and a failure
             # showing a full green bar reads as success in everything but the text.
-            self.progress_tiles.update_progress(
-                ProgressUpdate.failed(error or "Acquisition failed")
-            )
+            # The bar carries the *fact*, not the reason -- a stage-limits rejection
+            # names every offending tile, and a bar is a worse place to read that than
+            # the status line above it, which elides and keeps the whole thing in its
+            # tooltip.
+            self.progress_tiles.update_progress(ProgressUpdate.failed("Failed"))
+            self.progress_tiles.show()
 
     # ── lifecycle ────────────────────────────────────────────────────────
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -686,7 +686,12 @@ class FMOverviewWidget(QWidget):
         if self._origin is None or position is None or projection is None:
             return (0.0, 0.0)
         try:
-            return projection.to_plane(position, self._origin)
+            # The image's own *geometry*, but the shared *pose* -- the same base
+            # `_frame` places everything else against. Two different bases put the
+            # image and the grid describing it in different places: a stale t = 0
+            # origin against a stage at t = -180 landed them 300 um apart, mirrored
+            # in y, which is a mosaic that disagrees with the grid that planned it.
+            return projection.to_plane(position, self._posed(self._origin))
         except Exception as e:
             logging.debug(f"Could not place the image in stage space: {e}")
             return (0.0, 0.0)

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -28,7 +28,11 @@ from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     format_duration,
 )
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
-from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget, progress_slot
+from fibsem.ui.fm.widgets.fm_overview_widget import (
+    ElidedLabel,
+    FMOverviewWidget,
+    shrink_progress_text,
+)
 from fibsem.ui.fm.widgets.tile_mask_widget import TileMaskWidget
 from fibsem.ui.widgets.custom_widgets import ValueComboBox
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
@@ -415,41 +419,13 @@ def test_a_stage_move_does_not_fill_the_bar(qapp):
 # ── layout stability ─────────────────────────────────────────────────────
 
 
-def test_a_reset_bar_keeps_its_space(qapp):
-    """The bars must not jitter each other.
-
-    `FibsemProgressWidget.reset()` hides itself, so in a plain row the neighbouring
-    bar would shift every time a tile finished. Each sits in a fixed slot instead.
-    """
-    from PyQt5.QtWidgets import QHBoxLayout, QWidget
-
-    left, right = FibsemProgressWidget(), FibsemProgressWidget()
-    row = QWidget()
-    layout = QHBoxLayout(row)
-    layout.addWidget(progress_slot(left))
-    layout.addWidget(progress_slot(right))
-    row.resize(600, 40)
-    row.show()
-    qapp.processEvents()
-
-    left.update_progress(ProgressUpdate.numeric(1, 2, "working"))
-    right.update_progress(ProgressUpdate.numeric(1, 2, "working"))
-    qapp.processEvents()
-    before = left.parentWidget().geometry()
-
-    right.reset()
-    qapp.processEvents()
-
-    assert left.parentWidget().geometry() == before
-
-
 def test_the_bar_text_is_smaller_than_the_default(qapp):
     """Pinned because `setFont` on the holder silently does not reach the bar, so the
     obvious way to do this looks right and changes nothing."""
     from PyQt5.QtGui import QFontMetrics
 
     plain, shrunk = FibsemProgressWidget(), FibsemProgressWidget()
-    slot = progress_slot(shrunk)  # noqa: F841 - keeps the holder alive
+    shrink_progress_text(shrunk)
 
     sample = "Tiles — 4/9 · 74s remaining"
     assert (QFontMetrics(shrunk._bar.font()).width(sample)
@@ -459,7 +435,7 @@ def test_the_bar_text_is_smaller_than_the_default(qapp):
 def test_shrinking_the_text_keeps_the_failed_colouring(qapp):
     """The chunk stylesheet is what distinguishes a failed run from a finished one."""
     progress = FibsemProgressWidget()
-    slot = progress_slot(progress)  # noqa: F841
+    shrink_progress_text(progress)
 
     progress.update_progress(ProgressUpdate.failed("nope"))
 
@@ -2077,3 +2053,288 @@ def test_the_preference_survives_a_round_trip_through_yaml():
     restored = fibsem_cfg.UserPreferences.from_dict(prefs.to_dict())
 
     assert restored.features.fm_overview_tab is True
+
+
+# ── layout: the actions live in the column, not across the widget ────────
+
+
+def test_a_long_message_does_not_widen_the_widget(qapp):
+    """A `QLabel` reports the full width of its text as its size hint, and in a layout
+    that hint is a minimum — so a 132-character acquisition failure used to drag the
+    widget's minimum width from 1030 px to 1728 px and shove the window around."""
+    widget = _fresh_widget(qapp)
+    widget.resize(1200, 800)
+    widget.show()
+    qapp.processEvents()
+    idle = widget.minimumSizeHint().width()
+
+    widget.status.setText(
+        "Failed: Acquisition grid extends beyond stage limits. 9 tile(s) out of "
+        "bounds: (0,0), (0,1), (0,2), (1,0), (1,1), (1,2), (2,0), (2,1), (2,2)"
+    )
+    qapp.processEvents()
+
+    assert widget.minimumSizeHint().width() == idle
+
+    widget.close()
+
+
+def test_the_full_message_is_still_reachable(qapp):
+    """Eliding is presentation. `text()` returns what was set — the widget compares
+    against it to decide whether the status line is its to overwrite — and the tooltip
+    carries the whole thing for anything too long to show."""
+    widget = _fresh_widget(qapp)
+    message = "Failed: " + "a very long explanation " * 8
+
+    widget.status.setText(message)
+
+    assert widget.status.text() == message
+    assert widget.status.toolTip() == message
+
+    widget.close()
+
+
+def test_the_actions_sit_in_the_column_not_across_the_widget(qapp):
+    """The floor was 1030 px, all of it this row — the canvas asked for 10. A row
+    spanning the widget cannot give anything up; stacked in the settings column the
+    floor is the column's own."""
+    widget = _fresh_widget(qapp)
+    widget.resize(1200, 800)
+    widget.show()
+    qapp.processEvents()
+
+    assert widget.minimumSizeHint().width() < 600
+
+    # ...and the actions are inside the right-hand pane, not siblings of the splitter
+    assert widget.status_row.parentWidget() is not widget
+
+    widget.close()
+
+
+def test_the_progress_bars_appear_only_while_there_is_progress(qapp):
+    """They are empty most of the time. Stacked in a column nothing sits beside them,
+    so they can come and go without moving anything — which is what made this possible.
+    """
+    widget = _fresh_widget(qapp)
+    widget.resize(1200, 800)
+    widget.show()
+    qapp.processEvents()
+
+    assert not widget.progress_tiles.isVisible()
+    assert not widget.progress_tile_detail.isVisible()
+
+    widget._set_running(True)
+    qapp.processEvents()
+
+    assert widget.progress_tiles.isVisible()
+    assert widget.progress_tile_detail.isVisible()
+
+    widget._set_running(False)
+    widget.close()
+
+
+def test_a_finished_run_keeps_its_outcome_on_screen(qapp):
+    """`FibsemProgressWidget` paints finished and failed differently, and that colour is
+    the at-a-glance answer — hiding the bar the moment a run ends would throw it away.
+    The per-tile bar does go, since no tile is in progress to describe."""
+    widget = _fresh_widget(qapp)
+    widget.resize(1200, 800)
+    widget.show()
+    qapp.processEvents()
+    widget._set_running(True)
+
+    widget._finish("overview-failed", "nope")
+    qapp.processEvents()
+
+    assert widget.progress_tiles.isVisible()
+    assert not widget.progress_tile_detail.isVisible()
+
+    widget.close()
+
+
+def test_showing_the_bars_survives_their_own_reset(qapp):
+    """`FibsemProgressWidget.reset()` hides itself, so a start sequence that shows the
+    bars and then resets them leaves them hidden for the whole run."""
+    widget = _fresh_widget(qapp)
+    widget.resize(1200, 800)
+    widget.show()
+    qapp.processEvents()
+
+    widget._set_running(True)  # resets both bars internally
+    qapp.processEvents()
+
+    assert widget.progress_tiles.isVisible()
+
+    widget._set_running(False)
+    widget.close()
+
+
+# ── the canvas says where things are ─────────────────────────────────────
+
+
+def test_the_cursor_readout_is_drawn_over_the_canvas(qapp, interactive_widget):
+    """Not beside it. The only free corner is the top left — the toolbar owns the top
+    right, the scalebar the bottom right, the stage info bar the bottom left."""
+    widget = interactive_widget
+
+    assert widget.cursor_readout.parent() is widget.canvas.canvas
+
+
+def test_the_cursor_readout_hides_when_the_pointer_leaves(qapp, interactive_widget):
+    """It sits on top of the image, so an empty plaque floating over the data is worse
+    than nothing there."""
+    widget = interactive_widget
+
+    widget._on_cursor_moved(100.0, 100.0)
+    qapp.processEvents()
+    assert widget.cursor_readout.isVisible()
+    assert widget.cursor_readout.text()
+
+    widget._on_cursor_moved(None, None)
+    qapp.processEvents()
+    assert not widget.cursor_readout.isVisible()
+
+
+def test_the_info_bar_states_the_stage_pose(qapp, interactive_widget):
+    """The marker shows *where*; this says the numbers, which is what you need to write
+    one down. The objective rides along because focus depends on it and it appears
+    nowhere else on this tab."""
+    widget = interactive_widget
+
+    widget._refresh_current_position()
+    qapp.processEvents()
+
+    info = widget.canvas.canvas._info_text
+    assert info
+    assert "X:" in info and "Y:" in info
+    assert "objective" in info
+
+
+def test_the_info_bar_leaves_out_the_milling_angle(qapp, interactive_widget):
+    """A beam-side quantity, meaningless while looking through the camera. It belongs
+    on the FIB/SEM overview if anywhere."""
+    widget = interactive_widget
+
+    widget._refresh_current_position()
+
+    assert "milling" not in (widget.canvas.canvas._info_text or "")
+
+
+def test_an_unreadable_objective_does_not_cost_the_stage_position(qapp, interactive_widget):
+    """A microscope with no objective, or one that will not answer, should lose that
+    field and not the whole line."""
+    widget = interactive_widget
+
+    class _Broken:
+        @property
+        def position(self):
+            raise RuntimeError("no objective here")
+
+    original = widget.fm.objective
+    widget.fm.objective = _Broken()
+    try:
+        widget._refresh_stage_info()
+        info = widget.canvas.canvas._info_text
+    finally:
+        widget.fm.objective = original
+
+    assert info and "X:" in info
+    assert "objective" not in info
+
+
+def test_the_stage_marker_carries_no_caption(qapp, interactive_widget):
+    """It sits on top of the data, and a caption riding along with the crosshair
+    obscures the sample it is pointing at. The info bar says what it is instead."""
+    widget = interactive_widget
+
+    widget._refresh_current_position()
+
+    assert widget.current_position_overlay._labels == [""]
+
+
+# ── the canvas frame follows the stage's pose ────────────────────────────
+
+
+def _microscope_at(tilt_deg: float):
+    """A compustage microscope posed at a given tilt, with fluorescence attached."""
+    import numpy as np
+
+    from fibsem import utils
+    from fibsem.fm.microscope import FluorescenceMicroscope
+    from fibsem.structures import FibsemStagePosition
+
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.stage_is_compustage = True
+    microscope.system.stage.shuttle_pre_tilt = 0
+    microscope._update_orientations()
+    if microscope.fm is None:
+        microscope.fm = FluorescenceMicroscope(parent=microscope)
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(tilt_deg))
+    )
+    return microscope
+
+
+def test_a_click_never_changes_the_stage_orientation(qapp):
+    """The tab is built when a microscope connects, so the origin records whatever pose
+    the stage was in then — usually t = 0. Moving to the FM position afterwards left
+    every click carrying the old tilt, and the stage flipped 180 degrees to reach it.
+    """
+    import numpy as np
+
+    microscope = _microscope_at(0.0)
+    widget = FMOverviewWidget(microscope)
+    widget._refresh_tile_grid()  # fixes the origin, at t = 0
+    qapp.processEvents()
+    assert np.rad2deg(widget.origin.t) == pytest.approx(0.0)
+
+    microscope.move_to_microscope("FM")
+    widget._on_stage_moved(microscope.get_stage_position())
+    qapp.processEvents()
+
+    target = widget._frame().to_stage(300.0, 200.0)
+
+    assert np.rad2deg(target.t) == pytest.approx(-180.0)
+    widget.close()
+
+
+def test_a_stale_origin_resolves_a_click_to_the_same_place_as_a_fresh_one(qapp):
+    """The tilt was the visible half. The projection's y/z split is computed from the
+    pose too, so a click through a stale one also landed in the wrong *place* — with y
+    inverted, which on a 180 degree flip is as wrong as it gets."""
+    stale_microscope = _microscope_at(0.0)
+    stale = FMOverviewWidget(stale_microscope)
+    stale._refresh_tile_grid()
+    stale_microscope.move_to_microscope("FM")
+    stale._on_stage_moved(stale_microscope.get_stage_position())
+    qapp.processEvents()
+
+    fresh = FMOverviewWidget(_microscope_at(-180.0))
+    fresh._refresh_tile_grid()
+    qapp.processEvents()
+
+    a = stale._frame().to_stage(300.0, 200.0)
+    b = fresh._frame().to_stage(300.0, 200.0)
+
+    assert (a.x, a.y, a.z) == pytest.approx((b.x, b.y, b.z), abs=1e-12)
+    assert a.t == pytest.approx(b.t)
+
+    stale.close()
+    fresh.close()
+
+
+def test_the_anchor_itself_does_not_move_with_the_pose(qapp):
+    """Only the pose follows. Canvas zero stays where it was fixed, which is what lets
+    images acquired at different times accumulate against one frame."""
+    microscope = _microscope_at(0.0)
+    widget = FMOverviewWidget(microscope)
+    widget._refresh_tile_grid()
+    qapp.processEvents()
+    anchor = (widget.origin.x, widget.origin.y, widget.origin.z)
+
+    microscope.move_to_microscope("FM")
+    widget._on_stage_moved(microscope.get_stage_position())
+    qapp.processEvents()
+
+    assert (widget.origin.x, widget.origin.y, widget.origin.z) == pytest.approx(anchor)
+    widget.close()

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -2338,3 +2338,69 @@ def test_the_anchor_itself_does_not_move_with_the_pose(qapp):
 
     assert (widget.origin.x, widget.origin.y, widget.origin.z) == pytest.approx(anchor)
     widget.close()
+
+
+def test_an_acquired_image_lands_where_the_grid_that_planned_it_is_drawn(qapp):
+    """The invariant that ties the two halves together.
+
+    Images are placed through their own recorded geometry and the grid through the live
+    one, which is right — an image may have been taken under a configuration the
+    instrument has since left. But both must measure from the *same* base. Placing
+    images against the raw origin while the grid used the current pose put a mosaic
+    300 µm from the grid that planned it, mirrored in y.
+    """
+    import numpy as np
+
+    from fibsem.fm.structures import ChannelSettings
+    from fibsem.structures import FibsemStagePosition
+
+    microscope = _microscope_at(0.0)
+    widget = FMOverviewWidget(microscope)
+    widget._refresh_tile_grid()  # origin fixed at t = 0
+    qapp.processEvents()
+
+    microscope.move_to_microscope("FM")
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=200e-6, y=150e-6, z=0.0, r=0.0, t=np.deg2rad(-180))
+    )
+    widget._on_stage_moved(microscope.get_stage_position())
+    qapp.processEvents()
+
+    image = microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    image.metadata.stage_position = microscope.get_stage_position()
+
+    assert widget._offset_of(image) == pytest.approx(widget._grid_offset(), abs=1e-12)
+
+    widget.close()
+
+
+def test_the_placement_of_an_image_matches_a_widget_that_never_moved(qapp):
+    """Same equivalence as the click test, for placement: whatever the tab's history,
+    an image belongs in one place."""
+    import numpy as np
+
+    from fibsem.fm.structures import ChannelSettings
+    from fibsem.structures import FibsemStagePosition
+
+    somewhere = FibsemStagePosition(
+        x=200e-6, y=150e-6, z=0.0, r=0.0, t=np.deg2rad(-180)
+    )
+
+    stale_microscope = _microscope_at(0.0)
+    stale = FMOverviewWidget(stale_microscope)
+    stale._refresh_tile_grid()
+    stale_microscope.move_to_microscope("FM")
+    stale._on_stage_moved(stale_microscope.get_stage_position())
+
+    fresh_microscope = _microscope_at(-180.0)
+    fresh = FMOverviewWidget(fresh_microscope)
+    fresh._refresh_tile_grid()
+    qapp.processEvents()
+
+    image = fresh_microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    image.metadata.stage_position = somewhere
+
+    assert stale._offset_of(image) == pytest.approx(fresh._offset_of(image), abs=1e-12)
+
+    stale.close()
+    fresh.close()


### PR DESCRIPTION
Two threads: a layout rework that makes the widget usable at a sensible width, and a stage-safety bug found while testing it.

Verified in the running application, which matters here — both bugs need the connect-then-move ordering that only the tab has, and neither the standalone app nor any test fixture would have produced it.

## The layout, measured

The widget could not be made narrower than 1030 px, and a long message made it worse. All of that floor was the status row; the canvas asked for **10 px**.

| status text | before | after |
| -- | -- | -- |
| idle | 1030 px | **524** |
| a result | 1279 px | **524** |
| the out-of-bounds rejection | 1728 px | **524** |

Flat now, because nothing in the column reports its text as a minimum.

**FIB-471** — status text, progress bars and the actions stack at the foot of the settings column, the shape `FibsemMinimapWidget` already uses. The bars show only while a run is going.

`progress_slot` is gone, along with `PROGRESS_WIDTH`/`PROGRESS_HEIGHT`. It existed *only* to stop the bars dragging the buttons sideways when `reset()` hid them — with nothing beside them, show/hide came free as a consequence of the move rather than as extra work. The overall bar is shown again on a terminal state, since `FibsemProgressWidget` paints finished and failed differently and that colour is the at-a-glance answer.

The cursor readout moves onto the canvas, in the one free corner — toolbar top right, scalebar bottom right, info bar bottom left. It stays a **Qt label** rather than canvas text chrome because it updates on every motion event, and `set_info_text` costs 4.93 ms against a label's 0.08 ms.

**FIB-470** — `ElidedLabel`. A `QLabel` reports its text width as its size hint and a layout treats that as a minimum. `text()` still returns what was set (the widget compares against it to decide whether the line is its to overwrite) and the tooltip carries the whole message.

The same trap applied one level down: a long failure ran the progress bar out of the window. The bars take the width they are given now, and the bar carries the *fact* while the status line carries the *reason*.

**FIB-469** — the canvas states the pose in its bottom-left info bar: stage position and objective position, each dropped on its own if unavailable. No milling angle — a beam-side quantity that means nothing through the camera; it belongs on the FIB/SEM overview. The stage crosshair stays uncaptioned, since it sits on the data and the info bar can say what it is for free.

## FIB-491 — a click re-posed the stage

Reported from the app: double-clicking at t = -180 sent the stage back to t = 0.

`project_image_point` copies the base position and adjusts only x/y/z, so rotation and tilt come from the frame's origin. The origin is fixed the first time anything is drawn — and the tab is built when a microscope *connects*, so it records whatever pose the stage was in then, normally t = 0. Move to the FM position afterwards and every click resolves through the pose the instrument left behind:

```
origin fixed at    t=   0.0
stage now at       t=-180.0
clicked target     t=   0.0   y=+20.0um
```

**The tilt was the visible half.** The projection's y/z split is computed from the pose too, so `y` came out with the sign inverted — the stage went to the wrong place *and* flipped 180° getting there.

The origin was conflating two things. Canvas zero is a **place** (x, y, z) and stays fixed, which is what lets images accumulate against one frame; rotation and tilt are **how stage space maps onto the canvas at all**, and must follow the instrument.

The second commit fixes a defect in the first. `_frame` was corrected but `_offset_of` — which places acquired images — still measured from the raw origin, so the grid moved to the correct pose and the images did not. Worse than both being wrong together:

```
grid offset  : x= 200.0 um  y= -150.0 um
image offset : x= 200.0 um  y= +150.0 um    <- 300 um apart, mirrored
```

Kept as a separate commit rather than folded in, since the intermediate state is worth being findable if anyone bisects through it.

## Testing

2257 passed, 16 skipped.

The regression test that matters asserts the invariant rather than either half: **an image acquired at a position lands where a grid centred on that position is drawn**. Plus the equivalence that actually proves the pose fix — a widget with a stale origin resolves a click, and places an image, identically to one freshly built at the same pose.

Mutation-checked: the pose fix, the placement fix, the elided label, and the show-the-bars-after-resetting-them ordering each fail their tests when reverted.

## Notes for review

- `FibsemProgressWidget.reset()` hides itself, so a start sequence that shows the bars and *then* resets them leaves them hidden for the whole run. Cost me one round trip; there is a test.
- The two placement paths deliberately differ — an image uses its own recorded geometry, the grid uses the live one — so it is not obvious they must share a base. That is what made the half-fix easy to miss.