### PR TITLE
[autolamella] Align the status dict's item vocabulary with HookContext (FIB-464)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1542,7 +1542,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.workflow_timeline.update_from_status(status_msg)
 
             task_name = status_msg.get("task_name", "Unknown Task")
-            lamella_name = status_msg.get("lamella_name", "Unknown Lamella")
+            lamella_name = status_msg.get("item_name", "Unknown Lamella")
             current_lamella_index = status_msg.get("current_lamella_index", None)
             total_lamellae = status_msg.get("total_lamellas", None)
             current_task_index = status_msg.get("current_task_index", None)

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -375,12 +375,26 @@ class TaskManager:
                      error_message: Optional[str] = None,
                      task_duration: Optional[float] = None,
                      skip_reason: Optional[str] = None) -> None:
-        """Emit workflow_update_signal with standard status dict."""
+        """Emit workflow_update_signal with the standard status dict.
+
+        This stream and the hook stream describe the same lifecycle from two different
+        brackets — the manager brackets the task *call*, the task brackets its own
+        *execution* — and they are deliberately not merged. Hooks run user-configurable
+        code synchronously on the worker thread and HookManager.fire swallows what it
+        raises; the UI needs neither of those properties. See FIB-464.
+
+        What the two must agree on is vocabulary: the item is item_name here as it is in
+        HookContext. The matrix fields below have no hook counterpart and stay — they are
+        timeline positioning, not lifecycle facts.
+        """
         if self.parent_ui is None:
             return
 
         status_dict = {
             "task_name": task_name,
+            "item_name": lamella.name,
+            # Deprecated alias for item_name, kept for consumers outside this repo.
+            # Drop alongside the HookContext shims after v0.6.
             "lamella_name": lamella.name,
             "status": status,
             "timestamp": time.time(),

--- a/fibsem/ui/widgets/workflow_timeline_widget.py
+++ b/fibsem/ui/widgets/workflow_timeline_widget.py
@@ -467,10 +467,10 @@ class WorkflowProgressWidget(QWidget):
         elif task_status == AutoLamellaTaskStatus.Skipped:
             skip_reason = status.get("skip_reason", None)
             task_name = status.get("task_name", "")
-            lamella_name = status.get("lamella_name", "")
+            item_name = status.get("item_name", "")
             reason_str = _SKIP_REASON_LABELS.get(skip_reason, skip_reason or "Skipped")
             for i, item in enumerate(queue_items):
-                if item.lamella_name == lamella_name and item.task_name == task_name:
+                if item.lamella_name == item_name and item.task_name == task_name:
                     if 0 <= i < len(self._outer._rows):
                         self._outer._steps[i].subtitle = reason_str
                         self._outer._rows[i].refresh(self._outer._steps[i])

--- a/tests/autolamella/test_status_dict_vocabulary.py
+++ b/tests/autolamella/test_status_dict_vocabulary.py
@@ -1,0 +1,87 @@
+"""The status dict and HookContext name the same thing the same way.
+
+Both streams describe one task lifecycle. They stay separate on purpose — see the
+_emit_status docstring — but a subscriber reading one and then the other should not
+have to learn two words for the item. See FIB-464.
+"""
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    AutoLamellaTaskStatus,
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+from fibsem.hooks import HookContext
+
+
+class _FakeSignal:
+    def __init__(self) -> None:
+        self.payloads: List[dict] = []
+
+    def emit(self, payload: dict) -> None:
+        self.payloads.append(payload)
+
+
+class _FakeUI:
+    """Just enough parent_ui for _emit_status: it only touches this one signal."""
+
+    def __init__(self) -> None:
+        self.workflow_update_signal = _FakeSignal()
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> TaskManager:
+    class _NoMicroscope:
+        fm = None
+
+    experiment = Experiment(path=tmp_path, name="test-exp")
+    experiment.task_protocol = AutoLamellaTaskProtocol()
+    return TaskManager(
+        microscope=_NoMicroscope(),
+        experiment=experiment,
+        parent_ui=_FakeUI(),
+    )
+
+
+def _emit(manager: TaskManager, name: str = "lam-1") -> dict:
+    lamella = Lamella(path=manager.experiment.path, number=1, petname=name)
+    manager.queue.build_from_matrix(["MillTrench"], [lamella.name])
+    manager._emit_status(
+        task_name="MillTrench",
+        task_names=["MillTrench"],
+        lamella=lamella,
+        required_lamella=[lamella.name],
+        status=AutoLamellaTaskStatus.InProgress,
+    )
+    return manager.parent_ui.workflow_update_signal.payloads[-1]["status"]
+
+
+def test_the_status_dict_names_the_item_the_way_the_hook_does(manager: TaskManager):
+    status = _emit(manager)
+
+    assert status["item_name"] == "lam-1"
+    # the hook payload names it identically
+    assert "item_name" in HookContext(event="task_started").__dict__
+
+
+def test_the_old_key_is_still_emitted_for_outside_consumers(manager: TaskManager):
+    """Same deprecation shape as the HookContext shims: emit both until v0.6."""
+    status = _emit(manager, name="lam-7")
+
+    assert status["lamella_name"] == status["item_name"]
+
+
+def test_the_matrix_fields_keep_their_names(manager: TaskManager):
+    """lamella_names and the indices are timeline positioning, not lifecycle facts —
+    they have no hook counterpart to agree with, so they are left alone."""
+    status = _emit(manager)
+
+    assert "lamella_names" in status
+    assert "current_lamella_index" in status
+    assert "total_lamellas" in status


### PR DESCRIPTION
Part of FIB-464 — the vocabulary half. The other half is deliberately deferred, see below.

## The drift

Two streams describe one task lifecycle. #260 renamed the hook payload's `lamella_name` to `item_name` so the contract could describe non-lamella items; the status dict kept the old word for the same thing. One concept, two names, and nothing to catch it.

`_emit_status` now emits `item_name`, keeping `lamella_name` as a deprecated duplicate for consumers outside this repo — the same shape as the `HookContext` shims from #260, to be dropped together after v0.6.

Smaller than it sounds: only **one** of the thirteen `workflow_update_signal.emit` sites carries this dict (the other twelve emit a different, opaque payload — noted in FIB-402), and two consumers read the key.

## What is deliberately unchanged

**The two streams stay separate.** They observe different brackets — the manager brackets the task *call*, the task brackets its own *execution* — and hooks run user-configurable code synchronously on the worker thread while `HookManager.fire` swallows what it raises. Those are properties the UI must not inherit: a throwing timeline update would vanish silently, and a slow third-party hook would stall the display. This is now written into the `_emit_status` docstring so the next reader doesn't "fix" it.

**The matrix fields keep their names.** `lamella_names`, `current_lamella_index`, `total_lamellas` are timeline positioning with no hook counterpart, so there's no divergence to reconcile. Renaming them would be churn.

**The dataframe columns are out of scope.** `build_run_summary_dataframe` and `task_history_dataframe` expose `lamella_name` as a documented column in `SCRIPTING.md` — a different surface with different consumers.

## What is not here

FIB-464's other half — routing both payloads through one shared builder, so a new field can't land in one stream and not the other. It touches the same regions of `base.py`/`manager.py` as the unmerged #265, and it wants the `HookContext` shape that FIB-489 will settle. Building it now means building it twice. FIB-464 should stay open for it.

That drift is real, incidentally — `skip_reason` had to be added to both payloads by hand in #263.

## Testing

`tests/autolamella/test_status_dict_vocabulary.py` — 3 tests: the status dict names the item as the hook does, the old key is still emitted, and the matrix fields are untouched. 722 tests pass overall.
