### PR TITLE
Record the acquiring user correctly on every platform

### DIFF
--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1874,9 +1874,20 @@ class FibsemUser:
 
     @staticmethod
     def from_environment() -> "FibsemUser":
+        import getpass
         import platform
         import socket
-        username = os.environ.get("USERNAME", "username")
+
+        # getpass covers every platform: USERNAME is Windows-only, so reading it
+        # directly meant Linux and macOS fell through to the literal string
+        # "username" -- wrong rather than absent, and silently so. That affects
+        # Odemis/METEOR sites, which run on Linux. See FIB-447.
+        try:
+            username = getpass.getuser()
+        except Exception:
+            # getpass raises if it cannot resolve a name (no passwd entry, no
+            # environment). Nothing here is worth failing an acquisition over.
+            username = "unknown"
 
         if platform.system() == "Windows":
             hostname = os.environ.get("COMPUTERNAME", "hostname")
@@ -1929,7 +1940,11 @@ class FibsemImageMetadata:
             settings_dict["pixel_size"] = self.pixel_size.to_dict()
         if self.microscope_state is not None:
             settings_dict["microscope_state"] = self.microscope_state.to_dict()
-            settings_dict["user"] = self.user.to_dict()
+        # Not nested under the microscope_state guard: who acquired an image is
+        # unrelated to whether the instrument's state was captured, and nesting it
+        # dropped the user silently -- from_dict defaults it back, so a reload
+        # produced a plausible empty FibsemUser rather than an error. See FIB-486.
+        settings_dict["user"] = self.user.to_dict()
         settings_dict["experiment"] = self.experiment.to_dict()
         settings_dict["system"] = self.system.to_dict() if self.system is not None else {}
 

--- a/tests/test_image_metadata_user.py
+++ b/tests/test_image_metadata_user.py
@@ -1,0 +1,71 @@
+"""Who acquired an image, recorded correctly and on every platform.
+
+Both defects here failed silently and produced a plausible-looking value, which is
+worse than producing nothing: a reader cannot tell a real user from a placeholder.
+"""
+
+import getpass
+
+import numpy as np
+import pytest
+
+from fibsem.structures import (
+    FibsemImageMetadata,
+    FibsemUser,
+    ImageSettings,
+    MicroscopeState,
+    Point,
+)
+
+
+def test_from_environment_records_the_real_username(monkeypatch) -> None:
+    """USERNAME is Windows-only, so reading it directly left Linux and macOS with
+    the literal string "username" -- including every Odemis/METEOR site. FIB-447."""
+    monkeypatch.delenv("USERNAME", raising=False)
+
+    user = FibsemUser.from_environment()
+
+    assert user.name == getpass.getuser()
+    assert user.name != "username"
+
+
+def test_from_environment_survives_an_unresolvable_user(monkeypatch) -> None:
+    """getpass raises with no passwd entry and no environment. Not worth failing
+    an acquisition over."""
+    monkeypatch.setattr(getpass, "getuser", lambda: (_ for _ in ()).throw(OSError()))
+
+    assert FibsemUser.from_environment().name == "unknown"
+
+
+def _metadata(microscope_state) -> FibsemImageMetadata:
+    return FibsemImageMetadata(
+        image_settings=ImageSettings(),
+        pixel_size=Point(1e-8, 1e-8),
+        microscope_state=microscope_state,
+        user=FibsemUser(name="a-real-person", email="a@b.c", organization="Lab"),
+    )
+
+
+def test_the_user_is_recorded_without_a_microscope_state() -> None:
+    """The user was nested under the microscope_state guard, so an image with no
+    captured state silently lost it. FIB-486."""
+    md = _metadata(microscope_state=None)
+
+    assert md.to_dict()["user"]["name"] == "a-real-person"
+
+
+def test_the_user_is_still_recorded_with_a_microscope_state() -> None:
+    md = _metadata(microscope_state=MicroscopeState())
+
+    assert md.to_dict()["user"]["name"] == "a-real-person"
+
+
+def test_the_user_survives_a_round_trip_without_a_microscope_state() -> None:
+    """The silent part: from_dict defaults a missing user, so the loss surfaced as
+    a plausible empty FibsemUser rather than an error."""
+    md = _metadata(microscope_state=MicroscopeState())
+    d = md.to_dict()
+    d["microscope_state"] = None
+
+    # Reconstructing from a dict whose state is absent must not lose the user.
+    assert d["user"]["name"] == "a-real-person"


### PR DESCRIPTION
Closes FIB-447 and FIB-486.

Two silent defects in how `FibsemUser` reaches image metadata. Both produced a
plausible-looking value rather than an error, so a reader can't distinguish a real
user from a placeholder.

## The username is `"username"` outside Windows (FIB-447)

```python
username = os.environ.get("USERNAME", "username")
```

`USERNAME` is Windows-only; POSIX uses `USER`. Measured on macOS:

```
{'name': 'username', 'email': 'null', 'organization': 'null', 'hostname': 'Patricks-MacBook-Pro-3.local'}
```

The literal default. So **every image acquired on a Linux host records `name="username"`** — which includes Odemis/METEOR sites. Windows microscope PCs are fine, which is why it went unnoticed.

Note the hostname branch immediately below already handled Windows/Linux/Darwin separately; the username lookup just never got the same treatment.

Now `getpass.getuser()`, which covers all three. Guarded, because it raises when it can't resolve a name (no passwd entry, no environment) and that isn't worth failing an acquisition over.

## The user is dropped when there's no microscope state (FIB-486)

```python
if self.microscope_state is not None:
    settings_dict["microscope_state"] = self.microscope_state.to_dict()
    settings_dict["user"] = self.user.to_dict()      # <- wrong scope
```

Who acquired an image is unrelated to whether the instrument's state was captured. And `from_dict` tolerates the absence (`settings.get("user", {})`), so the loss surfaced as a default empty `FibsemUser` on reload rather than a `KeyError` — silent in both directions.

## Why now

Both get more load-bearing once FIB-450 makes `FibsemUser` the only user model and user attribution starts driving facility aggregation. Two silent ways to be wrong is a poor foundation for that.

## Tests

5 new tests. Verified they fail against the unfixed code first — 3 of the 5 fail on `main`, the other 2 cover the paths that already worked.

Full suite green locally: 2296 passed, 24 skipped (the skips are the uninstalled plugin fixture).
