### PR TITLE
[fibsem] Record the experiment ID in image metadata, not the name (FIB-446)

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -1429,6 +1429,7 @@ class Experiment:
             microscope=microscope,
             application_software="autolamella",
             application_software_version=fibsem.__version__,
+            experiment_id=self._id,
             experiment_name=self.name,
             experiment_method="null",
         )

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -9,7 +9,13 @@ import yaml
 
 import fibsem
 
-METADATA_VERSION = "v3"
+# Documentation for a human reading a file, not a parsing switch -- from_dict does not
+# branch on it, and additive changes are detected from field presence instead (FIB-445
+# D3). Bumped to v4 when FibsemExperiment gained `name` and `id` became the UUID.
+METADATA_VERSION = "v4"
+# What an unversioned file is. Absent means written before versioning existed, i.e.
+# older than v1 -- not "current", which is what defaulting to METADATA_VERSION claimed.
+UNVERSIONED_METADATA = "v0"
 
 SUPPORTED_COORDINATE_SYSTEMS = [
     "RAW",

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -18,7 +18,11 @@ from scipy.ndimage import median_filter, gaussian_filter
 
 import fibsem
 from fibsem.versioning import get_revision
-from fibsem.config import METADATA_VERSION, SUPPORTED_COORDINATE_SYSTEMS
+from fibsem.config import (
+    METADATA_VERSION,
+    SUPPORTED_COORDINATE_SYSTEMS,
+    UNVERSIONED_METADATA,
+)
 
 
 TFibsemPatternSettings = TypeVar(
@@ -1785,7 +1789,19 @@ class MicroscopeSettings:
 
 @dataclass
 class FibsemExperiment:
+    """Identity snapshot of the experiment an image was acquired for.
+
+    A snapshot, not an authority: authoritative only in the absence of the experiment
+    record, which wins on conflict (FIB-445 D2). That rule needs a stable key -- with
+    only a name, a renamed experiment is indistinguishable from a different one, so
+    there is no conflict to detect, just two strings that disagree.
+    """
+
+    # Experiment._id, a UUID -- stable, the join key. Held the experiment *name* up to
+    # and including v0.5.2; a file whose `name` is absent is from that era and its `id`
+    # is a name. See FIB-446.
     id: Optional[str] = None
+    name: Optional[str] = None
     method: Optional[str] = None
     # default_factory, not a plain default: a plain default is evaluated once at
     # class definition, so every experiment recorded the interpreter's import
@@ -1802,6 +1818,7 @@ class FibsemExperiment:
         """Converts to a dictionary."""
         return {
             "id": self.id,
+            "name": self.name,
             "method": self.method,
             "date": self.date,
             "application": self.application,
@@ -1815,6 +1832,10 @@ class FibsemExperiment:
         """Converts from a dictionary."""
         return FibsemExperiment(
             id=settings.get("id", "Unknown"),
+            # Absent in files written before v0.5.3, where `id` holds the name. Left
+            # as None rather than backfilled from `id`, so a reader can tell the two
+            # eras apart instead of being handed a name that claims to be an ID.
+            name=settings.get("name"),
             method=settings.get("method", "Unknown"),
             date=settings.get("date", "Unknown"),
             application=settings.get("application", "fibsemOS"),
@@ -1919,7 +1940,7 @@ class FibsemImageMetadata:
         """Converts a dictionary to metadata."""
 
         image_settings = ImageSettings.from_dict(settings["image"])
-        version = settings.get("version", METADATA_VERSION)
+        version = settings.get("version", UNVERSIONED_METADATA)
         if settings["pixel_size"] is not None:
             pixel_size = Point.from_dict(settings["pixel_size"])
         if settings["microscope_state"] is not None:

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -499,14 +499,23 @@ def _register_metadata(microscope: 'FibsemMicroscope',
                        application_software: str,
                        application_software_version: str,
                        experiment_name: str,
-                       experiment_method: str) -> None:
+                       experiment_method: str,
+                       experiment_id: Optional[str] = None) -> None:
+    """Stamp user and experiment identity onto everything ``microscope`` acquires.
+
+    ``experiment_id`` is the stable join key and should always be supplied; it is
+    optional only so a caller that has no ID yet still registers something. It used
+    to be omitted entirely and ``id`` carried the name, which meant a rename silently
+    broke the link from every image written before it. See FIB-446.
+    """
     import fibsem
     from fibsem.structures import FibsemExperiment, FibsemUser
 
     user = FibsemUser.from_environment()
 
     experiment = FibsemExperiment(
-        id = experiment_name,
+        id=experiment_id,
+        name=experiment_name,
         method=experiment_method,
         application=application_software, 
         fibsem_version=fibsem.__version__,

--- a/tests/autolamella/test_experiment_metadata_registration.py
+++ b/tests/autolamella/test_experiment_metadata_registration.py
@@ -47,7 +47,9 @@ def test_register_metadata_stamps_the_experiment_onto_the_microscope(
 ) -> None:
     experiment.register_metadata(microscope)
 
-    assert microscope.experiment.id == "test-experiment"
+    # The UUID is the join key; the name is the display string (FIB-446).
+    assert microscope.experiment.id == experiment._id
+    assert microscope.experiment.name == "test-experiment"
     assert microscope.experiment.application == "autolamella"
 
 
@@ -57,7 +59,8 @@ def test_creating_a_task_manager_registers_without_a_gui(
     """A headless run goes through TaskManager, never through AutoLamellaUI."""
     TaskManager(microscope=microscope, experiment=experiment, parent_ui=None)
 
-    assert microscope.experiment.id == "test-experiment"
+    assert microscope.experiment.id == experiment._id
+    assert microscope.experiment.name == "test-experiment"
 
 
 def test_loading_an_experiment_does_not_touch_the_microscope(

--- a/tests/test_experiment_metadata_identity.py
+++ b/tests/test_experiment_metadata_identity.py
@@ -1,0 +1,45 @@
+"""Image metadata carries a stable experiment key, not just a display name.
+
+Metadata embedded in an image is a snapshot: authoritative only when the experiment
+record is missing, with the record winning on conflict (FIB-445 D2). That rule needs a
+key that does not change -- given only a name, a renamed experiment is indistinguishable
+from a different one. Up to v0.5.2 the `id` field held the name. See FIB-446.
+"""
+
+from fibsem.config import METADATA_VERSION, UNVERSIONED_METADATA
+from fibsem.structures import FibsemExperiment
+
+
+def test_the_id_and_the_name_are_separate_fields():
+    experiment = FibsemExperiment(id="7c1e...uuid", name="my-experiment")
+
+    d = experiment.to_dict()
+    assert d["id"] == "7c1e...uuid"
+    assert d["name"] == "my-experiment"
+
+
+def test_round_trip_keeps_both():
+    original = FibsemExperiment(id="7c1e...uuid", name="my-experiment")
+
+    restored = FibsemExperiment.from_dict(original.to_dict())
+
+    assert restored.id == original.id
+    assert restored.name == original.name
+
+
+def test_a_pre_rename_file_is_recognisable_by_its_missing_name():
+    """The era signal is field presence, not a version lookup: no `name` means `id`
+    holds one. Not backfilled, so a reader is never handed a name claiming to be an ID."""
+    old_file = {"id": "my-experiment", "method": "null"}
+
+    restored = FibsemExperiment.from_dict(old_file)
+
+    assert restored.name is None
+    assert restored.id == "my-experiment"
+
+
+def test_an_unversioned_file_reads_as_older_than_v1_not_as_current():
+    """settings.get("version", METADATA_VERSION) claimed an unversioned file was
+    current. Absent means written before versioning existed."""
+    assert UNVERSIONED_METADATA != METADATA_VERSION
+    assert UNVERSIONED_METADATA == "v0"


### PR DESCRIPTION
Closes FIB-446.

## The bug

`_register_metadata` built the TIFF snapshot from the experiment's **name**:

```python
experiment = FibsemExperiment(id=experiment_name, ...)   # utils.py
```

while `Experiment._id` — an actual UUID — never left the application. So images can only be joined back to their experiment by a human-editable display name. Rename an experiment and every image written before the rename points at a name that no longer exists: nothing errors, the link is simply wrong.

**This got wider earlier today.** #265 moved registration into `TaskManager.__init__` so headless runs record it too — which was the right change, but it meant every run, not just the GUI, was stamping name-as-ID.

## Why it isn't cosmetic

FIB-445 D2 settles that image metadata is a *snapshot*: authoritative only when the experiment record is missing, with the record winning on conflict. That rule is unimplementable without a stable key — given only a name, a renamed experiment is indistinguishable from a genuinely different one. There is no conflict to detect, just two strings that disagree for unknown reasons.

## The change

`FibsemExperiment` carries both:

```python
id:   Optional[str]   # Experiment._id, a UUID — stable, the join key
name: Optional[str]   # Experiment.name — human-readable, may change
```

## Migration: field presence, not a version branch

| File | `id` holds | `name` |
|---|---|---|
| ≤ v0.5.2 | the experiment **name** | absent |
| new | the experiment **UUID** | the name |

`from_dict` deliberately does **not** backfill `name` from `id` — a reader should be able to tell the eras apart, not be handed a name that claims to be an ID.

Nothing in this repo reads `metadata.experiment.id`, so there's no in-tree consumer to break. The only consumers are external, and they degrade correctly: a reader that finds no `name` knows `id` holds one.

## Version housekeeping (FIB-445 D3)

`METADATA_VERSION` → **v4**, for the benefit of a human reading a file. `from_dict` doesn't branch on it and this PR doesn't make it start.

The backwards default is fixed while here. This:

```python
version = settings.get("version", METADATA_VERSION)
```

treated a file with *no* version field as **current**, when an unversioned file is by definition older than v1. It now reads as `UNVERSIONED_METADATA` (`"v0"`).

## Testing

`tests/test_experiment_metadata_identity.py` — id and name are separate, both survive a round trip, a pre-rename file is recognisable by its missing `name`, and unversioned no longer reads as current.

The two registration tests added in #265 asserted `id == "test-experiment"` — the behaviour this PR fixes — and now assert the UUID and the name separately.

1838 core tests plus 457 UI tests pass.
