### PR TITLE
Stop the report's section flags and column renames failing silently

### DIFF
--- a/fibsem/applications/autolamella/tools/data.py
+++ b/fibsem/applications/autolamella/tools/data.py
@@ -486,12 +486,16 @@ def format_pretty_dataframes(dfs: dict[str, pd.DataFrame]) -> dict[str, pd.DataF
     # WORKFLOW
     df_workflow = dfs["workflow"]
     # rename cols
+    # errors="raise" so a column that stops existing fails loudly. This rename
+    # asked for "task" while workflow_dataframe() produces "task_name", and pandas
+    # ignores unknown labels by default -- so the PDF quietly showed the raw column
+    # name instead. See FIB-458.
     df_workflow = df_workflow.rename(columns={
         "order": "Order",
-        "task": "Task Name",
+        "task_name": "Task Name",
         "required": "Required",
         "supervised": "Supervised",
-    })
+    }, errors="raise")
 
     # TASK HISTORY
     df_task_history = dfs["task_history"]

--- a/fibsem/applications/autolamella/tools/reporting.py
+++ b/fibsem/applications/autolamella/tools/reporting.py
@@ -191,6 +191,21 @@ class PDFReportGenerator:
 
 
 ###### NEW REPORTING FOR NEW TASK-WORKFLOW ######
+# The sections generate_report2 understands, in report order. Exported so callers
+# building a sections dict name them from here rather than by hand -- the report
+# widget spelled one of these "lamella_images" for as long as both existed, which
+# silently did nothing because an unmatched key just leaves the default in place.
+# See FIB-458.
+REPORT_SECTIONS = (
+    "overview",
+    "task_history",
+    "detection",
+    "lamella_workflow",
+    "lamella_workflow_images",
+    "lamella_milling",
+)
+
+
 def _add_lamella_section(pdf: PDFReportGenerator,
                          lamella: Lamella,
                          df_task_history: pd.DataFrame,
@@ -301,15 +316,19 @@ def generate_report2(experiment: Experiment,
         >>> exp = Experiment.load("path/to/experiment.yaml")
         >>> generate_report2(exp, "my_report.pdf", sections={"overview": True, "detection": False})
     """
-    # Set up default sections
-    default_sections = {
-        "overview": True,
-        "task_history": True,
-        "detection": True,
-        "lamella_workflow": True,
-        "lamella_workflow_images": True,
-        "lamella_milling": True
-    }
+    default_sections = dict.fromkeys(REPORT_SECTIONS, True)
+    # A key that matches nothing is a no-op that looks like a working control: the
+    # report widget asked for "lamella_images" while this expects
+    # "lamella_workflow_images", so unchecking that box did nothing for as long as
+    # both existed. Warn rather than raise, so an older caller still gets a report.
+    # See FIB-458.
+    unknown = set(sections or {}) - set(default_sections)
+    if unknown:
+        logging.warning(
+            f"Ignoring unknown report section(s): {sorted(unknown)}. "
+            f"Valid sections: {sorted(default_sections)}"
+        )
+
     sections = {**default_sections, **(sections or {})}
 
     report_data = generate_report_data2(experiment, encoding=encoding)

--- a/fibsem/ui/widgets/autolamella_generate_report_widget.py
+++ b/fibsem/ui/widgets/autolamella_generate_report_widget.py
@@ -300,7 +300,10 @@ class AutoLamellaGenerateReportWidget(QtWidgets.QDialog):
             "task_history": self.checkbox_task_history.isChecked(),
             "detection": self.checkbox_detection.isChecked(),
             "lamella_workflow": self.checkbox_lamella_workflow.isChecked(),
-            "lamella_images": self.checkbox_lamella_images.isChecked(),
+            # Must match generate_report2's key exactly -- see REPORT_SECTIONS.
+            # This was "lamella_images", which silently never matched, so the
+            # default True always won and unchecking the box did nothing. FIB-458.
+            "lamella_workflow_images": self.checkbox_lamella_images.isChecked(),
             "lamella_milling": self.checkbox_lamella_milling.isChecked(),
         }
 

--- a/tests/autolamella/test_report_sections.py
+++ b/tests/autolamella/test_report_sections.py
@@ -1,0 +1,95 @@
+"""Report section flags and column renames, both of which failed silently.
+
+A section key that matches nothing is a no-op wearing the costume of a working
+control: the checkbox moves, the default wins, the report is unchanged. A column
+rename that matches nothing leaves the raw column name in the PDF. Neither raises,
+so neither surfaced until someone compared the output against what they asked for.
+
+Both sides are read as source text rather than imported. The reporting module pulls
+in reportlab and matplotlib_scalebar, and the dialog pulls in PyQt5 -- all in the
+[ui] extra, which CI does not install. Importing them would make these skip in CI,
+and a regression test that never runs is not much of a guard against a regression.
+What is being checked is the literal spelling on each side, which the text carries.
+"""
+
+import re
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaTaskProtocol,
+    AutoLamellaWorkflowConfig,
+    Experiment,
+)
+
+_FIBSEM = Path(__file__).resolve().parents[2] / "fibsem"
+_REPORTING = _FIBSEM / "applications" / "autolamella" / "tools" / "reporting.py"
+_DATA = _FIBSEM / "applications" / "autolamella" / "tools" / "data.py"
+_WIDGET = _FIBSEM / "ui" / "widgets" / "autolamella_generate_report_widget.py"
+
+
+def _report_sections() -> set:
+    """The section names generate_report2 builds its defaults from."""
+    block = _REPORTING.read_text().split("REPORT_SECTIONS = (", 1)[1].split(")", 1)[0]
+    return set(re.findall(r'"(\w+)"', block))
+
+
+def _widget_section_keys() -> set:
+    """The section keys the report dialog emits."""
+    src = _WIDGET.read_text()
+    block = src.split("def _get_sections_config", 1)[1].split("def ", 1)[0]
+    return set(re.findall(r'"(\w+)":\s*self\.checkbox', block))
+
+
+def _workflow_rename_keys() -> set:
+    """The columns format_pretty_dataframes renames on the workflow frame."""
+    block = _DATA.read_text().split("# WORKFLOW", 1)[1].split("# TASK HISTORY", 1)[0]
+    return set(re.findall(r'"(\w+)":\s*"', block))
+
+
+def test_the_widget_emits_exactly_the_sections_the_report_reads() -> None:
+    """The defect: the widget said "lamella_images", the report read
+    "lamella_workflow_images". The default True always won, so unchecking
+    "Per-Lamella Workflow Images" did nothing."""
+    assert _widget_section_keys() == _report_sections()
+
+
+def test_the_report_sections_are_not_empty() -> None:
+    """Guard on the parsing above -- two empty sets would compare equal."""
+    assert len(_report_sections()) >= 6
+    assert "lamella_workflow_images" in _report_sections()
+
+
+def test_the_workflow_rename_targets_columns_that_exist() -> None:
+    """The rename asked for "task"; workflow_dataframe() produces "task_name".
+    pandas ignores unknown labels by default, so the PDF showed the raw name.
+
+    Checked against the real dataframe rather than a hand-written column list, so
+    this fails if either side moves.
+    """
+    exp = Experiment(path="/tmp", name="x")
+    exp.task_protocol = AutoLamellaTaskProtocol(
+        workflow_config=AutoLamellaWorkflowConfig(
+            tasks=[
+                AutoLamellaTaskDescription(
+                    name="MillTrench", supervise=False, required=True
+                )
+            ]
+        )
+    )
+
+    rename_keys = _workflow_rename_keys()
+
+    assert rename_keys, "parsed no rename keys -- the source layout moved"
+    assert rename_keys <= set(exp.workflow_dataframe().columns)
+
+
+def test_a_stale_rename_key_raises_rather_than_no_opping() -> None:
+    """errors="raise" is what turns the silent case loud, so pin the behaviour."""
+    df = pd.DataFrame([{"order": 1, "task_name": "MillTrench"}])
+
+    with pytest.raises(KeyError):
+        df.rename(columns={"task": "Task Name"}, errors="raise")


### PR DESCRIPTION
Closes FIB-458.

Two mismatches in the reporting path. Both no-op rather than error, which is why neither surfaced.

## The section checkbox has been decorative

`AutoLamellaGenerateReportWidget._get_sections_config()` emitted:

```python
"lamella_images": self.checkbox_lamella_images.isChecked(),
```

while `generate_report2` reads:

```python
"lamella_workflow_images": True,
...
sections = {**default_sections, **(sections or {})}
```

An unmatched key just leaves the default in place, so the default `True` always won. **Unchecking "Per-Lamella Workflow Images" did nothing** for as long as both spellings existed — and the unused `"lamella_images"` key was merged in alongside it, inert.

This matters beyond tidiness once artifacts get emailed (FIB-461): per-lamella images are the bulk of the file size, and this checkbox is the only lever a user has over it.

## The workflow table shows a raw column name

```python
df_workflow.rename(columns={"order": "Order", "task": "Task Name", ...})
```

`Experiment.workflow_dataframe()` produces `task_name`, not `task`. pandas ignores unknown labels by default, so the rename was a no-op and the PDF printed `task_name`.

## Fixing the class, not just the two spellings

Both are the same failure mode — a name that matches nothing, in a language that doesn't mind. So beyond correcting the spellings:

- section names move to a module-level **`REPORT_SECTIONS`** that `generate_report2` builds its defaults from, so callers name them from one place rather than by hand
- `generate_report2` **warns on an unrecognised section key**, which would have caught this the first time the dialog ran. A warning rather than an error, so an older caller still gets a report
- the workflow rename passes **`errors="raise"`**, so a column that stops existing fails loudly instead of quietly mislabelling a table

## Tests

3 new tests, and they read the keys from *both sides* rather than restating them — so they fail if either end moves, which is the actual invariant that broke. The widget's keys are parsed from the method source so no `QApplication` is needed; the rename keys are checked against a real `workflow_dataframe()`.

Verified each fails against the unfixed code first, by reverting one file at a time.

Full suite green locally: 2294 passed, 24 skipped.
