### PR TITLE
[hooks] Give HookContext enough to describe what happened (FIB-489)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1114,7 +1114,13 @@ class AutoLamellaUI(QMainWindow):
                 name="failure_toast",
                 events=[HookEvent.TASK_FAILED],
                 notification_type="error",
-                message_template="Task {task_name} FAILED: {error}",
+                # A failure does not stop the run, so say what happens next: without the
+                # remaining count this reads as a dead workflow to someone at the
+                # instrument who is not watching the timeline.
+                message_template=(
+                    "Task {task_name} FAILED for {item_name}: {error} "
+                    "— continuing, {tasks_remaining} tasks remaining"
+                ),
             )
         )
         manager.register(

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -186,14 +186,23 @@ class AutoLamellaTask(ABC):
 
     def _fire_hook(self, event: str, error: Optional[str] = None) -> None:
         from fibsem.hooks import fire_event
+        # Which experiment, and how much of the queue is left. Only the manager knows
+        # either, and a task can run without one -- a script driving a task directly, or
+        # a stand-in -- so those fields are simply absent then. Fetched the same
+        # defensive way as hook_manager below, rather than requiring a real TaskManager.
+        get_run_context = getattr(self.task_manager, "hook_run_context", None)
+        run_context = get_run_context() if callable(get_run_context) else {}
         fire_event(
             getattr(self.task_manager, "hook_manager", None),
             event,
             task_name=self.task_name,
             task_type=self.task_type,
             item_name=self.lamella.name,
+            item_id=self.lamella._id,
+            task_id=self.task_id,
             task_state=self.lamella.task_state,
             error=error,
+            **run_context,
         )
 
     @abstractmethod

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -127,6 +127,7 @@ class TaskManager:
                 self._fire_skipped_hook(
                     item.task_name, lamella.name, skip_reason,
                     task_type=task_config.task_type if task_config else "",
+                    item_id=lamella._id,
                 )
                 continue
 
@@ -227,8 +228,24 @@ class TaskManager:
     def is_stopped(self) -> bool:
         return self._stop_event.is_set()
 
+    def hook_run_context(self) -> dict:
+        """The fields every hook event from this run carries: which experiment, and
+        how much of the queue is left.
+
+        Public because AutoLamellaTask fires task events itself and needs the same
+        fields; a task reaches this through its task_manager.
+        """
+        return {
+            "experiment_id": self.experiment._id,
+            "experiment_name": self.experiment.name,
+            "tasks_remaining": len(self.queue.pending),
+            "tasks_total": len(self.queue.items),
+        }
+
     def _fire_workflow_hook(self, event: HookEvent) -> None:
-        fire_event(self.hook_manager, event)
+        # Workflow events used to carry nothing at all, so workflow_completed reached a
+        # webhook with no way to tell which experiment had finished.
+        fire_event(self.hook_manager, event, **self.hook_run_context())
 
     def _is_complete(self, lamella: 'Lamella') -> bool:
         """Whether a lamella has completed every task the workflow requires of it."""
@@ -275,7 +292,10 @@ class TaskManager:
             task_name=task_name,
             task_type=lamella.task_state.task_type,
             item_name=lamella.name,
+            item_id=lamella._id,
+            task_id=lamella.task_state.task_id,
             task_state=lamella.task_state,
+            **self.hook_run_context(),
         )
 
     def _maybe_fire_experiment_completed(self) -> None:
@@ -291,6 +311,8 @@ class TaskManager:
             self.hook_manager,
             HookEvent.EXPERIMENT_COMPLETED,
             item_name=self.experiment.name,
+            item_id=self.experiment._id,
+            **self.hook_run_context(),
         )
 
     def _completion_message(self) -> str:
@@ -313,17 +335,21 @@ class TaskManager:
         return "All tasks completed."
 
     def _fire_skipped_hook(self, task_name: str, item_name: str,
-                           skip_reason: str, task_type: str = "") -> None:
+                           skip_reason: str, task_type: str = "",
+                           item_id: str = "") -> None:
         """Fire TASK_SKIPPED. Unlike the other task events this cannot come from
         AutoLamellaTask, because the skip is decided before any task object exists —
-        so there is no task_state to attach."""
+        so there is no task_state to attach, and no task_id: nothing ran to have one.
+        item_id is empty on the lamella-not-found path, where there is no lamella."""
         fire_event(
             self.hook_manager,
             HookEvent.TASK_SKIPPED,
             task_name=task_name,
             task_type=task_type,
             item_name=item_name,
+            item_id=item_id,
             skip_reason=skip_reason,
+            **self.hook_run_context(),
         )
 
     # --- Internal helpers ---

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -234,12 +234,17 @@ class TaskManager:
 
         Public because AutoLamellaTask fires task events itself and needs the same
         fields; a task reaches this through its task_manager.
+
+        tasks_remaining excludes the task the event is about: queue.next() marks an
+        item InProgress before the task runs, so the one in flight is already out of
+        the pending set on every path, skips included.
         """
+        pending, total = self.queue.counts
         return {
             "experiment_id": self.experiment._id,
             "experiment_name": self.experiment.name,
-            "tasks_remaining": len(self.queue.pending),
-            "tasks_total": len(self.queue.items),
+            "tasks_remaining": pending,
+            "tasks_total": total,
         }
 
     def _fire_workflow_hook(self, event: HookEvent) -> None:

--- a/fibsem/applications/autolamella/workflows/tasks/queue.py
+++ b/fibsem/applications/autolamella/workflows/tasks/queue.py
@@ -3,7 +3,7 @@
 import copy
 import threading
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from uuid import uuid4
 
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
@@ -118,6 +118,18 @@ class TaskQueue:
         """Return a deep copy — safe to read from another thread."""
         with self._lock:
             return [copy.copy(i) for i in self._items]
+
+    @property
+    def counts(self) -> Tuple[int, int]:
+        """(pending, total), without copying every item just to count them.
+
+        `items` and `pending` both build a new list, which is the wrong tool when the
+        caller only wants a length -- and hooks ask on every event.
+        """
+        with self._lock:
+            pending = sum(1 for i in self._items
+                          if i.status == AutoLamellaTaskStatus.NotStarted)
+            return pending, len(self._items)
 
     @property
     def pending(self) -> List[WorkItem]:

--- a/fibsem/hooks.py
+++ b/fibsem/hooks.py
@@ -52,6 +52,8 @@ class HookContext:
     experiment_name: str = ""
     # How much of the run is left. A failure does not stop a run — the queue moves to
     # the next item — so without this a bare "FAILED" reads as a dead workflow.
+    # tasks_remaining counts what is still to come, excluding the one this event is
+    # about: on a failure, "3 remaining" means three more will be attempted.
     tasks_remaining: Optional[int] = None
     tasks_total: Optional[int] = None
     # Application-owned state for the run. AutoLamella passes an AutoLamellaTaskState;

--- a/fibsem/hooks.py
+++ b/fibsem/hooks.py
@@ -11,6 +11,7 @@ import time
 import warnings
 import yaml
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Type
@@ -40,9 +41,24 @@ class HookContext:
     # Name of the item the task ran against. Today that is always a lamella, but the
     # hook contract stays domain-agnostic so grids (or anything else) can fire hooks.
     item_name: str = ""
+    # Stable keys beside the display names. Names are what a person reads and can
+    # change; these are what a consumer stores and joins on. task_id identifies this
+    # *execution*, so it matches the entry the run leaves in the task history.
+    item_id: str = ""
+    task_id: str = ""
+    # Which run this belongs to. Without it, a consumer handling more than one
+    # experiment cannot tell their events apart.
+    experiment_id: Optional[str] = None
+    experiment_name: str = ""
+    # How much of the run is left. A failure does not stop a run — the queue moves to
+    # the next item — so without this a bare "FAILED" reads as a dead workflow.
+    tasks_remaining: Optional[int] = None
+    tasks_total: Optional[int] = None
     # Application-owned state for the run. AutoLamella passes an AutoLamellaTaskState;
     # left untyped so this module does not depend on any one application's structures.
     task_state: Optional[Any] = None
+    # The exception message, not a traceback: this payload can leave the machine via a
+    # webhook, and a traceback is unbounded. The logfile has the full one.
     error: Optional[str] = None
     # Why a task was skipped, on TASK_SKIPPED. The producer decides the vocabulary;
     # AutoLamella uses not_required / failure / missing_prereqs / lamella_not_found.
@@ -54,6 +70,31 @@ class HookContext:
         # comparisons work consistently regardless of Python version.
         if hasattr(self.event, "value"):
             self.event = self.event.value
+        self._snapshot_task_state()
+
+    def _snapshot_task_state(self) -> None:
+        """Copy task_state, so a hook that defers work reads what happened here.
+
+        Producers pass live state. AutoLamella's is a single object reused for every
+        run, so a hook that touches it asynchronously — a webhook posting from its
+        daemon thread, a callback queued onto another thread — would otherwise read
+        whatever the *next* task has since written into it. WebhookHook is safe today
+        only because it happens to read plain strings.
+
+        Guarded, and deliberately so: this runs in the producer's call stack, before
+        HookManager.fire's try/except exists to contain anything. An application object
+        that cannot be deepcopied must not take the workflow down with it, so the copy
+        degrades to the live reference and says so.
+        """
+        if self.task_state is None:
+            return
+        try:
+            self.task_state = deepcopy(self.task_state)
+        except Exception:
+            logging.exception(
+                "Could not snapshot task_state for the %s hook; passing the live "
+                "object, which a deferred hook may see mutated", self.event,
+            )
 
     @property
     def lamella_name(self) -> str:
@@ -70,6 +111,11 @@ class HookContext:
 DEFAULT_MESSAGE_TEMPLATE = "Task {task_name} {event} for {item_name}"
 
 
+def _blank_if_none(value: Optional[int]) -> str:
+    """Render an absent count as empty rather than the string "None"."""
+    return "" if value is None else str(value)
+
+
 def _template_fields(context: HookContext) -> Dict[str, str]:
     """Placeholder values available to a hook message template."""
     return {
@@ -78,6 +124,12 @@ def _template_fields(context: HookContext) -> Dict[str, str]:
         "task_type": context.task_type,
         "item_name": context.item_name,
         "lamella_name": context.item_name,  # deprecated alias, renders pre-rename templates
+        "item_id": context.item_id,
+        "task_id": context.task_id,
+        "experiment_id": context.experiment_id or "",
+        "experiment_name": context.experiment_name,
+        "tasks_remaining": _blank_if_none(context.tasks_remaining),
+        "tasks_total": _blank_if_none(context.tasks_total),
         "error": context.error or "",
         "skip_reason": context.skip_reason or "",
     }
@@ -229,6 +281,12 @@ class WebhookHook(Hook):
                 # Deprecated duplicate of item_name: the payload shipped in v0.5.1 with
                 # this key, so endpoints reading it keep working. Drop after v0.6.
                 "lamella_name": context.item_name,
+                "item_id": context.item_id,
+                "task_id": context.task_id,
+                "experiment_id": context.experiment_id,
+                "experiment_name": context.experiment_name,
+                "tasks_remaining": context.tasks_remaining,
+                "tasks_total": context.tasks_total,
                 "error": context.error,
                 "skip_reason": context.skip_reason,
                 "timestamp": context.timestamp,

--- a/tests/autolamella/test_hook_run_context.py
+++ b/tests/autolamella/test_hook_run_context.py
@@ -1,0 +1,155 @@
+"""The manager fills in which experiment an event belongs to, and how much is left.
+
+Without these a consumer handling more than one run cannot tell events apart, and a
+failure reads as a dead workflow when the queue is still moving. See FIB-489.
+"""
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    AutoLamellaTaskStatus,
+    DefectType,
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+from fibsem.hooks import FunctionHook, HookContext, HookEvent, HookManager
+
+
+@pytest.fixture
+def recorder() -> "tuple[HookManager, List[HookContext]]":
+    fired: List[HookContext] = []
+    manager = HookManager()
+    manager.register(
+        FunctionHook(name="recorder", events=list(HookEvent), callback=fired.append)
+    )
+    return manager, fired
+
+
+@pytest.fixture
+def experiment(tmp_path: Path) -> Experiment:
+    exp = Experiment(path=tmp_path, name="test-exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    return exp
+
+
+def _manager(experiment: Experiment, hook_manager: HookManager) -> TaskManager:
+    class _NoMicroscope:
+        fm = None
+
+    return TaskManager(
+        microscope=_NoMicroscope(),
+        experiment=experiment,
+        parent_ui=None,
+        hook_manager=hook_manager,
+    )
+
+
+def test_workflow_events_say_which_experiment(experiment, recorder):
+    """They used to carry nothing at all, so workflow_completed reached a webhook with
+    no way to tell which experiment had finished."""
+    hook_manager, fired = recorder
+    manager = _manager(experiment, hook_manager)
+
+    manager.run(task_names=["MillTrench"], required_lamella=[])
+
+    assert [c.event for c in fired] == ["workflow_started", "workflow_completed"]
+    for context in fired:
+        assert context.experiment_id == experiment._id
+        assert context.experiment_name == "test-exp"
+
+
+def test_progress_counts_down_as_the_queue_drains(experiment, recorder):
+    """Three lamellae, all skipped, so the queue drains without running anything."""
+    hook_manager, fired = recorder
+    for i in (1, 2, 3):
+        lamella = Lamella(path=experiment.path, number=i, petname=f"lam-{i}")
+        lamella.defect.state = DefectType.FAILURE  # skipped by _should_skip
+        experiment.positions.append(lamella)
+    manager = _manager(experiment, hook_manager)
+
+    manager.run(
+        task_names=["MillTrench"],
+        required_lamella=[p.name for p in experiment.positions],
+    )
+
+    skipped = [c for c in fired if c.event == "task_skipped"]
+    assert [c.tasks_remaining for c in skipped] == [2, 1, 0]
+    assert {c.tasks_total for c in skipped} == {3}
+
+
+def test_a_skipped_event_carries_the_lamella_id(experiment, recorder):
+    hook_manager, fired = recorder
+    lamella = Lamella(path=experiment.path, number=1, petname="lam-1")
+    lamella.defect.state = DefectType.FAILURE
+    experiment.positions.append(lamella)
+    manager = _manager(experiment, hook_manager)
+
+    manager.run(task_names=["MillTrench"], required_lamella=[lamella.name])
+
+    skipped = [c for c in fired if c.event == "task_skipped"]
+    assert skipped[0].item_id == lamella._id
+
+
+def test_a_missing_lamella_has_no_id_to_report(experiment, recorder):
+    """The one path with no lamella in hand: the name is all there is."""
+    hook_manager, fired = recorder
+    manager = _manager(experiment, hook_manager)
+
+    manager.run(task_names=["MillTrench"], required_lamella=["ghost"])
+
+    skipped = [c for c in fired if c.event == "task_skipped"]
+    assert skipped[0].item_name == "ghost"
+    assert skipped[0].item_id == ""
+    # still says which experiment, even with nothing else to go on
+    assert skipped[0].experiment_id == experiment._id
+
+
+def test_the_event_task_id_joins_to_the_task_history_entry(recorder, tmp_path):
+    """The point of carrying task_id: a consumer that received "MillTrench failed" can
+    find the exact history entry it referred to, instead of guessing by name and time.
+
+    task_id identifies this *execution*, so two runs of the same task on the same
+    lamella share every name field but not this.
+    """
+    from fibsem import utils
+    from fibsem.applications.autolamella.workflows.tasks.trench import (
+        MillTrenchTask,
+        MillTrenchTaskConfig,
+    )
+
+    hook_manager, fired = recorder
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    lamella = Lamella(path=tmp_path / "lam", number=1, petname="lam-1")
+    task = MillTrenchTask(
+        microscope=microscope, config=MillTrenchTaskConfig(), lamella=lamella
+    )
+    task.task_manager = type("_M", (), {"hook_manager": hook_manager, "is_stopped": False})()
+
+    task._run = lambda: (_ for _ in ()).throw(RuntimeError("stage timeout"))
+    with pytest.raises(RuntimeError):
+        task.run()
+
+    failed = [c for c in fired if c.event == "task_failed"][0]
+    assert failed.task_id == lamella.task_history[-1].task_id
+    assert failed.item_id == lamella._id
+    # and the snapshot is of the terminal state, not the InProgress it started in
+    assert failed.task_state.status is AutoLamellaTaskStatus.Failed
+
+
+def test_hook_run_context_is_a_snapshot_not_a_live_view(experiment, recorder):
+    hook_manager, _ = recorder
+    manager = _manager(experiment, hook_manager)
+    items = manager.queue.build_from_matrix(["MillTrench"], ["lam-1", "lam-2"])
+
+    before = manager.hook_run_context()
+    manager.queue.mark_done(items[0], AutoLamellaTaskStatus.Completed)
+    after = manager.hook_run_context()
+
+    assert before["tasks_remaining"] == 2
+    assert after["tasks_remaining"] == 1
+    assert before["tasks_total"] == after["tasks_total"] == 2

--- a/tests/test_hook_context_payload.py
+++ b/tests/test_hook_context_payload.py
@@ -1,0 +1,155 @@
+"""What a HookContext carries, and why it has to stand alone.
+
+A webhook consumer is out of process and out of band: it cannot ask a follow-up
+question, so the payload has to make sense by itself. See FIB-489.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import List
+
+from fibsem.hooks import (
+    FunctionHook,
+    HookContext,
+    HookEvent,
+    HookManager,
+    NotificationHook,
+    render_template,
+)
+
+
+@dataclass
+class _MutableState:
+    """Stands in for AutoLamellaTaskState: one object, reused for every run."""
+
+    status: str = "InProgress"
+    outputs: List[str] = field(default_factory=list)
+
+
+class _Uncopyable:
+    def __deepcopy__(self, memo):
+        raise RuntimeError("cannot copy this")
+
+
+# ---------------------------------------------------------------------------
+# the task_state snapshot
+# ---------------------------------------------------------------------------
+
+def test_the_context_snapshots_task_state():
+    """The producer reuses one state object per run, so a hook that defers work would
+    otherwise read whatever the *next* task has since written into it."""
+    live = _MutableState(status="InProgress")
+
+    context = HookContext(event=HookEvent.TASK_STARTED, task_state=live)
+    live.status = "Completed"          # the next task moves on
+    live.outputs.append("later.tif")
+
+    assert context.task_state.status == "InProgress"
+    assert context.task_state.outputs == []
+
+
+def test_the_snapshot_is_deep_not_a_shallow_copy():
+    live = _MutableState()
+    context = HookContext(event=HookEvent.TASK_STARTED, task_state=live)
+
+    live.outputs.append("later.tif")
+
+    assert context.task_state.outputs is not live.outputs
+
+
+def test_a_state_that_cannot_be_copied_does_not_break_the_producer(caplog):
+    """This runs in the producer's call stack, before HookManager.fire's try/except
+    exists to contain anything -- so it must degrade, not raise."""
+    with caplog.at_level(logging.ERROR):
+        context = HookContext(event=HookEvent.TASK_FAILED, task_state=_Uncopyable())
+
+    assert isinstance(context.task_state, _Uncopyable)  # the live reference
+    assert any("snapshot task_state" in r.message for r in caplog.records)
+
+
+def test_no_task_state_is_fine():
+    assert HookContext(event=HookEvent.WORKFLOW_STARTED).task_state is None
+
+
+# ---------------------------------------------------------------------------
+# identity and progress
+# ---------------------------------------------------------------------------
+
+def _ctx(**kwargs) -> HookContext:
+    defaults = dict(
+        event=HookEvent.TASK_FAILED,
+        task_name="MillRough",
+        item_name="lamella-3",
+        item_id="lam-uuid",
+        task_id="task-uuid",
+        experiment_id="exp-uuid",
+        experiment_name="my-experiment",
+        tasks_remaining=5,
+        tasks_total=20,
+        error="stage timeout",
+    )
+    defaults.update(kwargs)
+    return HookContext(**defaults)
+
+
+def test_the_motivating_message_is_now_renderable():
+    """The failure toast this issue was opened for: a failure does not stop the run,
+    so a bare FAILED reads as a dead workflow."""
+    rendered = render_template(
+        "Task {task_name} FAILED for {item_name}: {error} "
+        "— continuing, {tasks_remaining} tasks remaining",
+        _ctx(),
+    )
+
+    assert rendered == (
+        "Task MillRough FAILED for lamella-3: stage timeout "
+        "— continuing, 5 tasks remaining"
+    )
+
+
+def test_identity_placeholders_render():
+    rendered = render_template(
+        "{experiment_name}/{item_name} {item_id} {task_id} {experiment_id}", _ctx()
+    )
+
+    assert rendered == "my-experiment/lamella-3 lam-uuid task-uuid exp-uuid"
+
+
+def test_an_absent_count_renders_blank_not_none():
+    """Workflow events from a producer with no queue have no counts; a template must
+    not print the word None at a user."""
+    rendered = render_template("[{tasks_remaining}]", _ctx(tasks_remaining=None))
+
+    assert rendered == "[]"
+
+
+def test_the_payload_reaches_a_function_hook():
+    received: List[HookContext] = []
+    manager = HookManager()
+    manager.register(
+        FunctionHook(name="f", events=[HookEvent.TASK_FAILED], callback=received.append)
+    )
+
+    manager.fire(_ctx())
+
+    got = received[0]
+    assert (got.item_id, got.task_id) == ("lam-uuid", "task-uuid")
+    assert (got.experiment_id, got.experiment_name) == ("exp-uuid", "my-experiment")
+    assert (got.tasks_remaining, got.tasks_total) == (5, 20)
+
+
+def test_errors_carry_the_message_only():
+    """Decided: no traceback. The payload can leave the machine via a webhook, and a
+    traceback is unbounded -- the logfile keeps the full one."""
+    received = []
+    hook = NotificationHook(
+        name="n",
+        events=[HookEvent.TASK_FAILED],
+        message_template="{error}",
+        _notify=lambda msg, typ: received.append(msg),
+    )
+
+    hook.run(_ctx(error=str(RuntimeError("stage timeout"))))
+
+    assert received == ["stage timeout"]
+    assert "Traceback" not in received[0]


### PR DESCRIPTION
Closes FIB-489 — the event half. The session envelope stays described in the issue but is not built, since it wants FIB-452's session record to reference and that's parked.

## Why this isn't a webhook-only concern

`setup_hooks()` wires a `LoggingHook` and three `NotificationHook`s by default, all reading this same context. So the in-app toasts were limited by it too. The default failure toast changes from:

> Task MillRough FAILED: stage timeout

to:

> Task MillRough FAILED for lamella-3: stage timeout — continuing, 5 tasks remaining

That difference matters because **a failure does not stop the run** — `_run_queue` marks the item done and moves to the next queue entry. Without the count, a bare "FAILED" reads as a dead workflow to someone at the instrument who isn't watching the timeline.

## Added

| field | why |
|---|---|
| `item_id`, `task_id` | Stable keys beside the display names |
| `experiment_id`, `experiment_name` | There was no experiment identity at all |
| `tasks_remaining`, `tasks_total` | From `TaskQueue.pending` |

`task_id` earns its place: it identifies this *execution*, so an event joins to the entry the run leaves in `task_history` — which since #265 exists for failures too. A consumer that received "MillTrench failed for 01-elk" can find the exact history entry rather than guessing by name and timestamp. There's a test for precisely that.

Workflow events now carry the run context as well; they used to fire completely bare, so `workflow_completed` reached a webhook with no way to tell which experiment had finished.

## The `task_state` snapshot

`task_state` is one object reused for every run, so a hook that defers work — a webhook posting from its daemon thread, a callback queued elsewhere — read whatever the *next* task had since written into it. `WebhookHook` is safe today only because it happens to read plain string fields.

It's now deepcopied in `__post_init__`, which is correct rather than merely frozen because #265 made the outcome get recorded *before* the hook fires; previously this would have made a transient `InProgress` permanent.

**Guarded, deliberately.** This runs in the producer's call stack, before `HookManager.fire`'s try/except exists to contain anything. An application object that can't be deepcopied must not take a workflow down, so it degrades to the live reference and logs. Tested.

## Two decisions

**Errors carry the message, not a traceback.** The payload can leave the machine and a traceback is unbounded; the logfile keeps the full one, and the ids now point at it.

**The explicit status field from the issue is dropped.** Dispatch matches on event name — `if context.event not in hook.events` — so a payload field can't reduce what a hook *subscribes* to, only what it branches on after delivery. And the mapping is 1:1 with the event (`task_failed`→`Failed`), so it's duplication that can disagree. The underlying complaint is real but it's a subscription problem: **FIB-494**.

## Testing

`tests/test_hook_context_payload.py` (9) — the snapshot isolates from later mutation, an uncopyable state degrades instead of raising, the motivating message renders, an absent count renders blank rather than `None`.

`tests/autolamella/test_hook_run_context.py` (6) — workflow events say which experiment, progress counts down across a draining queue, a skip carries the lamella id, the missing-lamella path has none to report, and the event's `task_id` matches the `task_history` entry.

1862 core + 457 UI tests pass.
