### PR TITLE
Write down what image metadata is for, and rename FibsemExperiment

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -1413,7 +1413,7 @@ class Experiment:
         Which experiment produced an image is a property of the run, not of the GUI.
         This previously happened only in AutoLamellaUI, so images acquired from a
         script, a headless run, or the standalone FibsemUI carried the microscope's
-        default ``FibsemExperiment()`` -- id ``None`` -- and could not be associated
+        default ``FibsemExperimentRef()`` -- id ``None`` -- and could not be associated
         with an experiment afterwards. See FIB-449.
 
         Mirrors ``configure_logging``: ``load`` and ``create`` deliberately do not

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -11,7 +11,7 @@ import fibsem
 
 # Documentation for a human reading a file, not a parsing switch -- from_dict does not
 # branch on it, and additive changes are detected from field presence instead (FIB-445
-# D3). Bumped to v4 when FibsemExperiment gained `name` and `id` became the UUID.
+# D3). Bumped to v4 when FibsemExperimentRef gained `name` and `id` became the UUID.
 METADATA_VERSION = "v4"
 # What an unversioned file is. Absent means written before versioning existed, i.e.
 # older than v1 -- not "current", which is what defaulting to METADATA_VERSION claimed.

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -101,7 +101,7 @@ from fibsem.structures import (
     FibsemBitmapSettings,
     FibsemCircleSettings,
     FibsemDetectorSettings,
-    FibsemExperiment,
+    FibsemExperimentRef,
     FibsemGasInjectionSettings,
     FibsemImage,
     FibsemImageMetadata,
@@ -1877,7 +1877,7 @@ class ThermoMicroscope(FibsemMicroscope):
         # user, experiment metadata
         # TODO: remove once db integrated
         self.user = FibsemUser.from_environment()
-        self.experiment = FibsemExperiment()
+        self.experiment = FibsemExperimentRef()
         self._default_application_file = "Si"
         self._current_application_file = self._default_application_file
 

--- a/fibsem/microscopes/odemis_microscope.py
+++ b/fibsem/microscopes/odemis_microscope.py
@@ -15,7 +15,7 @@ from fibsem.structures import (
     FibsemBitmapSettings,
     FibsemCircleSettings,
     FibsemDetectorSettings,
-    FibsemExperiment,
+    FibsemExperimentRef,
     FibsemImage,
     FibsemImageMetadata,
     FibsemLineSettings,
@@ -266,7 +266,7 @@ class OdemisThermoMicroscope(FibsemMicroscope):
         self._last_imaging_settings: ImageSettings = ImageSettings()
 
         self.user = FibsemUser.from_environment()
-        self.experiment = FibsemExperiment()
+        self.experiment = FibsemExperimentRef()
 
         self.fm = None
         try:

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -27,7 +27,7 @@ from fibsem.structures import (
     FibsemBitmapSettings,
     FibsemCircleSettings,
     FibsemDetectorSettings,
-    FibsemExperiment,
+    FibsemExperimentRef,
     FibsemGasInjectionSettings,
     FibsemImage,
     FibsemImageMetadata,
@@ -261,7 +261,7 @@ class DemoMicroscope(FibsemMicroscope):
         # user, experiment metadata
         # TODO: remove once db integrated
         self.user = FibsemUser.from_environment()
-        self.experiment = FibsemExperiment()
+        self.experiment = FibsemExperimentRef()
 
         self._last_imaging_settings: ImageSettings = ImageSettings()
         self.milling_channel: BeamType = BeamType.ION

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -44,7 +44,7 @@ from fibsem.structures import ( #noqa
     FibsemBitmapSettings,
     FibsemCircleSettings,
     FibsemDetectorSettings,
-    FibsemExperiment,
+    FibsemExperimentRef,
     FibsemGasInjectionSettings,
     FibsemImage,
     FibsemImageMetadata,
@@ -271,7 +271,7 @@ class TescanMicroscope(FibsemMicroscope):
         # user, experiment metadata
         # TODO: remove once db integrated
         self.user = FibsemUser.from_environment()
-        self.experiment = FibsemExperiment()
+        self.experiment = FibsemExperimentRef()
 
         # initialise last images
         self.last_image_eb: Optional[FibsemImage] = None

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1640,6 +1640,23 @@ class GISSystemSettings:
 
 @dataclass
 class SystemInfo:
+    """Which instrument, and what software is running on it. Provenance.
+
+    Owns both facts, and is the only place either belongs (FIB-445 D1).
+    ``serial_number`` is the instrument identity -- the key any per-instrument
+    aggregation joins on, and the only field that distinguishes two of the same
+    model in one facility.
+
+    The version fields are duplicated on ``FibsemExperimentRef`` today; FIB-448
+    removes them from there. Software version is a property of the running system,
+    not of an experiment.
+
+    An experiment spanning a software upgrade will therefore disagree with its own
+    images -- the experiment record captured v0.5.1 at creation, day-2 images say
+    v0.5.2 here. That is two true facts, not a duplication bug: it says the run
+    spanned an upgrade, which is worth knowing.
+    """
+
     name: str
     ip_address: str
     manufacturer: str
@@ -1788,13 +1805,22 @@ class MicroscopeSettings:
 
 
 @dataclass
-class FibsemExperiment:
-    """Identity snapshot of the experiment an image was acquired for.
+class FibsemExperimentRef:
+    """A reference to the experiment an image was acquired for. Provenance.
 
-    A snapshot, not an authority: authoritative only in the absence of the experiment
-    record, which wins on conflict (FIB-445 D2). That rule needs a stable key -- with
+    Not an experiment. The experiment itself is the application's own record --
+    AutoLamella's ``Experiment``, with positions, protocol and history -- and this
+    is a denormalised pointer to it, embedded in every image so the file can say
+    what produced it without the surrounding directory. Named ``...Ref`` because
+    the two types are otherwise a single import apart and easily confused.
+
+    **Defers to the record.** Authoritative only in the absence of the experiment
+    record, which wins on conflict (FIB-445 D2). That rule needs a stable key: with
     only a name, a renamed experiment is indistinguishable from a different one, so
     there is no conflict to detect, just two strings that disagree.
+
+    The deference rule applies here because a richer record exists to defer to. It
+    does not apply to every embedded copy -- see ``FibsemUser``.
     """
 
     # Experiment._id, a UUID -- stable, the join key. Held the experiment *name* up to
@@ -1828,9 +1854,9 @@ class FibsemExperiment:
         }
 
     @staticmethod
-    def from_dict(settings: dict) -> "FibsemExperiment":
+    def from_dict(settings: dict) -> "FibsemExperimentRef":
         """Converts from a dictionary."""
-        return FibsemExperiment(
+        return FibsemExperimentRef(
             id=settings.get("id", "Unknown"),
             # Absent in files written before v0.5.3, where `id` holds the name. Left
             # as None rather than backfilled from `id`, so a reader can tell the two
@@ -1847,9 +1873,26 @@ class FibsemExperiment:
 
 @dataclass
 class FibsemUser:
+    """Who acquired an image. Provenance, and the only user model there is.
+
+    Unlike ``FibsemExperimentRef``, this is not a reference to anything: there is
+    no richer user record for it to defer to, so the "the record wins on conflict"
+    rule (FIB-445 D2) does not apply -- this *is* the record, and it happens to be
+    stored embedded in every image.
+
+    That would change if a user table ever lands (the DB work models one), at which
+    point this becomes a snapshot of it and the deference rule starts to apply.
+    Worth knowing before treating the two structures as the same kind of thing.
+
+    Practical consequence of being embedded: it cannot be corrected retroactively.
+    A wrong name here is wrong in every file already written.
+    """
+
     name: Optional[str] = None
     email: Optional[str] = None
     organization: Optional[str] = None
+    # Which machine, not which person -- host identity sitting on the user record.
+    # Left here rather than moved, because moving it changes the serialised shape.
     hostname: Optional[str] = None
     # TODO: add host_ip_address
 
@@ -1903,7 +1946,31 @@ class FibsemUser:
 
 @dataclass
 class FibsemImageMetadata:
-    """Metadata for a FibsemImage."""
+    """Metadata for a FibsemImage.
+
+    Three kinds of claim live here, and they are easy to mistake for each other
+    (FIB-445 D1). Anything added should be placed deliberately in one of them:
+
+    **Provenance** -- what produced this image. ``system`` (which instrument),
+    ``user`` (who), ``experiment`` (which run). Constant for a run. The same
+    question at a finer grain -- which lamella, which task -- is not recorded yet;
+    see FIB-466. It varies *within* a run, which changes the mechanism that writes
+    it, but not the kind of fact it is.
+
+    **Observation** -- what the instrument was doing. ``microscope_state``,
+    ``pixel_size``. Measured at acquisition.
+
+    **Request** -- what was asked for. ``image_settings``. Note this is *intent*,
+    not outcome: if autocontrast ran, or the requested hfw was clamped, nothing
+    here records that the request was not honoured. See FIB-482.
+
+    The rule for provenance is one writer per fact, denormalised deliberately at
+    this boundary: an image is embedded in a file that may be copied, emailed or
+    read years later, so it carries enough to identify its source without the
+    surrounding directory. Whether an embedded copy *defers* to a richer record is
+    a separate question, answered per-structure -- see ``FibsemExperimentRef``
+    (defers) and ``FibsemUser`` (does not, because there is nothing to defer to).
+    """
 
     image_settings: ImageSettings
     pixel_size: Point
@@ -1911,7 +1978,7 @@ class FibsemImageMetadata:
     system: Optional[SystemSettings] = None
     version: str = METADATA_VERSION
     user: FibsemUser = field(default_factory=lambda: FibsemUser())
-    experiment: FibsemExperiment = field(default_factory=lambda: FibsemExperiment())
+    experiment: FibsemExperimentRef = field(default_factory=lambda: FibsemExperimentRef())
 
     @property
     def beam_type(self) -> BeamType:
@@ -1975,7 +2042,7 @@ class FibsemImageMetadata:
             pixel_size=pixel_size,
             microscope_state=microscope_state,
             user=FibsemUser.from_dict(settings.get("user", {})),
-            experiment=FibsemExperiment.from_dict(settings.get("experiment", {})),
+            experiment=FibsemExperimentRef.from_dict(settings.get("experiment", {})),
             system=system_settings
         )
         return metadata

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -509,11 +509,11 @@ def _register_metadata(microscope: 'FibsemMicroscope',
     broke the link from every image written before it. See FIB-446.
     """
     import fibsem
-    from fibsem.structures import FibsemExperiment, FibsemUser
+    from fibsem.structures import FibsemExperimentRef, FibsemUser
 
     user = FibsemUser.from_environment()
 
-    experiment = FibsemExperiment(
+    experiment = FibsemExperimentRef(
         id=experiment_id,
         name=experiment_name,
         method=experiment_method,

--- a/fibsem/versioning.py
+++ b/fibsem/versioning.py
@@ -124,7 +124,7 @@ def _describe() -> Optional[str]:
     # Not --broken: that needs git >= 2.13, and on older git the whole command
     # fails, losing the revision entirely.
     #
-    # Cached because FibsemImageMetadata builds a FibsemExperiment for every
+    # Cached because FibsemImageMetadata builds a FibsemExperimentRef for every
     # acquired image — without this that would be one git fork per image.
     return _run_git("describe", "--tags", "--always", "--dirty")
 

--- a/tests/autolamella/test_experiment_metadata_registration.py
+++ b/tests/autolamella/test_experiment_metadata_registration.py
@@ -1,7 +1,7 @@
 """Which experiment produced an image is a property of the run, not of the GUI.
 
 Registration used to happen only in AutoLamellaUI, so images acquired from a script
-or a headless run carried the microscope's default ``FibsemExperiment()`` -- id
+or a headless run carried the microscope's default ``FibsemExperimentRef()`` -- id
 ``None`` -- and could not be associated with an experiment afterwards. See FIB-449.
 """
 

--- a/tests/test_experiment_metadata_identity.py
+++ b/tests/test_experiment_metadata_identity.py
@@ -7,11 +7,11 @@ from a different one. Up to v0.5.2 the `id` field held the name. See FIB-446.
 """
 
 from fibsem.config import METADATA_VERSION, UNVERSIONED_METADATA
-from fibsem.structures import FibsemExperiment
+from fibsem.structures import FibsemExperimentRef
 
 
 def test_the_id_and_the_name_are_separate_fields():
-    experiment = FibsemExperiment(id="7c1e...uuid", name="my-experiment")
+    experiment = FibsemExperimentRef(id="7c1e...uuid", name="my-experiment")
 
     d = experiment.to_dict()
     assert d["id"] == "7c1e...uuid"
@@ -19,9 +19,9 @@ def test_the_id_and_the_name_are_separate_fields():
 
 
 def test_round_trip_keeps_both():
-    original = FibsemExperiment(id="7c1e...uuid", name="my-experiment")
+    original = FibsemExperimentRef(id="7c1e...uuid", name="my-experiment")
 
-    restored = FibsemExperiment.from_dict(original.to_dict())
+    restored = FibsemExperimentRef.from_dict(original.to_dict())
 
     assert restored.id == original.id
     assert restored.name == original.name
@@ -32,7 +32,7 @@ def test_a_pre_rename_file_is_recognisable_by_its_missing_name():
     holds one. Not backfilled, so a reader is never handed a name claiming to be an ID."""
     old_file = {"id": "my-experiment", "method": "null"}
 
-    restored = FibsemExperiment.from_dict(old_file)
+    restored = FibsemExperimentRef.from_dict(old_file)
 
     assert restored.name is None
     assert restored.id == "my-experiment"

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -478,15 +478,15 @@ def test_fibsem_image_load_sets_filepath(tmp_path):
 
 
 def test_experiment_and_system_info_carry_fibsem_revision():
-    from fibsem.structures import FibsemExperiment, SystemInfo
+    from fibsem.structures import FibsemExperimentRef, SystemInfo
 
-    assert "fibsem_revision" in FibsemExperiment().to_dict()
+    assert "fibsem_revision" in FibsemExperimentRef().to_dict()
     assert "fibsem_revision" in SystemInfo.from_dict({}).to_dict()
 
 
 def test_metadata_from_dict_accepts_pre_change_files():
     """Saved data written before fibsem_revision existed must still load."""
-    from fibsem.structures import FibsemExperiment, SystemInfo
+    from fibsem.structures import FibsemExperimentRef, SystemInfo
 
     legacy_experiment = {
         "id": "exp-1",
@@ -496,7 +496,7 @@ def test_metadata_from_dict_accepts_pre_change_files():
         "fibsem_version": "0.5.1",
         "application_version": "0.5.1",
     }
-    experiment = FibsemExperiment.from_dict(legacy_experiment)
+    experiment = FibsemExperimentRef.from_dict(legacy_experiment)
     assert experiment.id == "exp-1"
     assert experiment.fibsem_version == "0.5.1"
 
@@ -507,14 +507,14 @@ def test_metadata_from_dict_accepts_pre_change_files():
 
 
 def test_metadata_round_trips_fibsem_revision():
-    from fibsem.structures import FibsemExperiment, SystemInfo
+    from fibsem.structures import FibsemExperimentRef, SystemInfo
 
-    experiment = FibsemExperiment.from_dict(
+    experiment = FibsemExperimentRef.from_dict(
         {"id": "exp-1", "fibsem_revision": "v0.5.1-48-g4cd11d9c"}
     )
     assert experiment.fibsem_revision == "v0.5.1-48-g4cd11d9c"
     assert (
-        FibsemExperiment.from_dict(experiment.to_dict()).fibsem_revision
+        FibsemExperimentRef.from_dict(experiment.to_dict()).fibsem_revision
         == "v0.5.1-48-g4cd11d9c"
     )
 
@@ -526,11 +526,11 @@ def test_experiment_date_is_creation_time_not_import_time():
     """A plain dataclass default would freeze this at module-import time."""
     import time
 
-    from fibsem.structures import FibsemExperiment
+    from fibsem.structures import FibsemExperimentRef
 
     before = datetime.datetime.timestamp(datetime.datetime.now())
     time.sleep(0.01)
-    experiment = FibsemExperiment()
+    experiment = FibsemExperimentRef()
     time.sleep(0.01)
     after = datetime.datetime.timestamp(datetime.datetime.now())
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -296,12 +296,12 @@ def test_repeated_calls_fork_once(monkeypatch):
 
 
 def test_metadata_construction_forks_once(monkeypatch):
-    """FibsemImageMetadata builds a FibsemExperiment per acquired image.
+    """FibsemImageMetadata builds a FibsemExperimentRef per acquired image.
 
     Without the cache on _describe that would be one git fork per image, which is
     the regression this test exists to prevent.
     """
-    from fibsem.structures import FibsemExperiment
+    from fibsem.structures import FibsemExperimentRef
 
     calls = []
 
@@ -311,7 +311,7 @@ def test_metadata_construction_forks_once(monkeypatch):
 
     monkeypatch.setattr(versioning, "_run_git", _count)
 
-    experiments = [FibsemExperiment() for _ in range(50)]
+    experiments = [FibsemExperimentRef() for _ in range(50)]
 
     assert len(calls) == 1
     assert all(e.fibsem_revision == "v0.5.1-48-g4cd11d9c" for e in experiments)


### PR DESCRIPTION
Closes FIB-445. Gates FIB-448, FIB-450, FIB-481, FIB-482 — each of those implies an answer to this, so settling it once avoids answering it four times inconsistently.

Mostly docstrings, plus one rename.

## Three kinds of claim

Metadata drifted between the layers partly because nothing said which layer owned what, so each fix answered the question again — sometimes differently. `FibsemImageMetadata` now names the three:

| | | |
|---|---|---|
| **provenance** | what produced this image | `system`, `user`, `experiment` |
| **observation** | what the instrument was doing | `microscope_state`, `pixel_size` |
| **request** | what was asked for | `image_settings` |

The load-bearing split is provenance vs the rest. Provenance answers **one question at different rates** — instrument and experiment are constant for a run, lamella and task change within it. That's one category with two mechanisms, not two categories.

Getting this wrong is what made "registration" and "acquisition context" look like different *kinds* of fact in earlier issue text, when they're the same fact written at different times. FIB-449 and FIB-466 are described in those terms; the code now uses the corrected framing.

## Embedded ≠ deferring

I'd previously called both `FibsemUser` and `FibsemExperiment` "snapshots", which merged two separate properties:

- **Embedded copy** — *storage*. Written into thousands of files, never retroactively correctable. True of everything here.
- **Defers to a richer record** — *authority*. Only applies where such a record exists.

Today that's `FibsemExperimentRef` only. `FibsemUser`, once FIB-450 lands, is **the only user model there is** — there's nothing to defer to, so "the record wins on conflict" is vacuous for it.

Stated as a test rather than a list, so it survives contact with the future: if the DB's user table ever lands, `FibsemUser` joins the deferring category, and *that transition is when the rule starts mattering*.

## `FibsemExperiment` → `FibsemExperimentRef`

It isn't an experiment. It's a pointer to one — id, name, date, versions — and it sat a single import away from AutoLamella's `Experiment`, which has positions, protocol and history. Two near-identical names, different roles, imported in the same modules.

**The serialised key stays `"experiment"`**, so no file format change. Code-readability only.

**No back-compat alias**, deliberately: the name isn't exported or documented, and an alias would leave two names for the one thing this rename exists to disambiguate. A script importing the old name gets an `ImportError` — a good failure mode. Say the word if you'd rather have the alias.

## Also documented

- `SystemInfo` owns instrument identity *and* the software versions (FIB-448 removes the duplicates from the ref). Includes why an experiment spanning an upgrade disagreeing with its own images is two true facts, not a bug.
- `FibsemUser.hostname` noted as machine identity sitting on the user record — left in place, since moving it changes the serialised shape.

Full suite green: 2304 passed, 24 skipped.
