### PR TITLE
[autolamella] Remove AutoLamellaUser, and rename _id to id

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -393,7 +393,7 @@ class AutoLamellaTaskProtocol:
     name: str = "AutoLamella Task Protocol"
     description: str = "Protocol for AutoLamella"
     version: str = "1.0"
-    _id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
     task_config: EventedDict[str, AutoLamellaTaskConfig] = field(default_factory=lambda: EventedDict())   # unique_name: AutoLamellaTaskConfig
     workflow_config: AutoLamellaWorkflowConfig = field(default_factory=AutoLamellaWorkflowConfig)
     options: AutoLamellaWorkflowOptions = field(default_factory=AutoLamellaWorkflowOptions)
@@ -404,7 +404,7 @@ class AutoLamellaTaskProtocol:
 
     def to_dict(self) -> Dict[str, Any]:
         return {
-            "_id": self._id,
+            "_id": self.id,
             "name": self.name,
             "description": self.description,
             "version": self.version,
@@ -433,7 +433,7 @@ class AutoLamellaTaskProtocol:
             correlation=CorrelationConfig.from_dict(data.get("correlation")),
         )
         if "_id" in data:
-            protocol._id = data["_id"]
+            protocol.id = data["_id"]
         return protocol
 
     @classmethod
@@ -672,7 +672,7 @@ class Lamella:
     number: int                                                             # TODO: deprecate, use petname instead
     petname: str
     alignment_area: FibsemRectangle = field(default_factory=lambda: FibsemRectangle.from_dict(DEFAULT_ALIGNMENT_AREA))
-    _id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
     task_config: EventedDict[str, 'AutoLamellaTaskConfig'] = field(default_factory=lambda: EventedDict())
     poses: Dict[str, MicroscopeState] = field(default_factory=dict)
     task_state: AutoLamellaTaskState = field(default_factory=AutoLamellaTaskState)
@@ -691,9 +691,9 @@ class Lamella:
         # path the caller never named. Directories are created where a lamella is
         # actually created (``Experiment.add_new_lamella``) and where files are
         # actually written (``FibsemImage.save``, ``save_thumbnail``). See FIB-420.
-        if self._id is None:
-            self._id = str(uuid.uuid4())
-        self.task_state.lamella_id = self._id
+        if self.id is None:
+            self.id = str(uuid.uuid4())
+        self.task_state.lamella_id = self.id
 
         self._sync_imaging_paths()
 
@@ -847,7 +847,7 @@ class Lamella:
             "path": str(self.path),
             "alignment_area": self.alignment_area.to_dict(),
             "number": self.number,
-            "id": str(self._id),
+            "id": str(self.id),
             "poses": {k: v.to_dict() for k, v in self.poses.items()},
             "task_config": {k: v.to_dict() for k, v in self.task_config.items()},
             "task_state": self.task_state.to_dict(),
@@ -893,7 +893,7 @@ class Lamella:
             path=data["path"],
             alignment_area=alignment_area,
             number=data.get("number", data.get("number", 0)),
-            _id=data.get("id", ""),
+            id=data.get("id", ""),
             poses=poses,
             task_config=load_task_config(data.get("task_config", {})),
             task_state=AutoLamellaTaskState.from_dict(data.get("task_state", {})),
@@ -984,7 +984,7 @@ class Lamella:
 @dataclass
 class Experiment:
     name: str
-    _id: str
+    id: str
     path: Path
     positions: EventedList[Lamella] = field(default_factory=EventedList)
     landing_positions: List[FibsemStagePosition] = field(default_factory=list)
@@ -1003,7 +1003,7 @@ class Experiment:
             metadata: Optional dictionary containing experiment metadata (e.g., description, user, project, organisation).
         """
         self.name: str = name
-        self._id = str(uuid.uuid4())
+        self.id = str(uuid.uuid4())
         self.path: Path = os.path.join(path, name)
         self.created_at: float = datetime.timestamp(datetime.now())
 
@@ -1017,7 +1017,7 @@ class Experiment:
 
         state_dict = {
             "name": self.name,
-            "_id": self._id,
+            "_id": self.id,
             "path": self.path,
             "positions": [deepcopy(lamella.to_dict()) for lamella in self.positions],
             "landing_positions": [pos.to_dict() for pos in self.landing_positions],
@@ -1037,7 +1037,7 @@ class Experiment:
         name = ddict["name"]
         experiment = Experiment(path=path, name=name)
         experiment.created_at = ddict.get("created_at", None)
-        experiment._id = ddict.get("_id", "NULL")
+        experiment.id = ddict.get("_id", "NULL")
 
         experiment.metadata = ddict.get("metadata", {})
 
@@ -1375,7 +1375,7 @@ class Experiment:
             microscope=microscope,
             application_software="autolamella",
             application_software_version=fibsem.__version__,
-            experiment_id=self._id,
+            experiment_id=self.id,
             experiment_name=self.name,
             experiment_method="null",
         )
@@ -1452,9 +1452,9 @@ class Experiment:
                 "experiment_name": self.name,
                 "experiment_path": self.path,
                 "experiment_created_at": self.created_at,
-                "experiment_id": self._id,
+                "experiment_id": self.id,
                 "lamella_name": p.name,
-                "lamella_id": p._id,
+                "lamella_id": p.id,
                 "last_completed": p.last_completed_task.completed if p.last_completed_task else None,
                 "last_completed_task": p.last_completed_task.name if p.last_completed_task else None,
                 "last_completed_at": p.last_completed_task.completed_at if p.last_completed_task else None,

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -59,66 +59,12 @@ class AutoLamellaTaskStatus(Enum):
     Cancelled = auto()  # aborted by the user (Stop), distinct from a genuine Failure
 
 
-@dataclass
-class AutoLamellaUser:
-    """Application-level user identity. Maps to the DB user table."""
-    _id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    username: str = ""          # login handle / OS username
-    name: str = ""              # display name
-    email: str = ""
-    organization: str = ""
-    role: str = "user"          # "admin" | "user" | "guest"
-    is_default: bool = False    # loaded automatically at startup
-    preferences: dict = field(default_factory=dict)
-    created_at: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
-
-    def to_fibsem_user(self) -> "FibsemUser":
-        """Convert to a FibsemUser snapshot for image TIFF metadata."""
-        from fibsem.structures import FibsemUser
-        return FibsemUser(
-            name=self.name or self.username,
-            email=self.email,
-            organization=self.organization,
-        )
-
-    def to_dict(self) -> dict:
-        return {
-            "_id": self._id,
-            "username": self.username,
-            "name": self.name,
-            "email": self.email,
-            "organization": self.organization,
-            "role": self.role,
-            "is_default": self.is_default,
-            "preferences": self.preferences,
-            "created_at": self.created_at,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "AutoLamellaUser":
-        user = cls(
-            username=data.get("username", ""),
-            name=data.get("name", ""),
-            email=data.get("email", ""),
-            organization=data.get("organization", ""),
-            role=data.get("role", "user"),
-            is_default=data.get("is_default", False),
-            preferences=data.get("preferences", {}),
-            created_at=data.get("created_at", datetime.timestamp(datetime.now())),
-        )
-        if "_id" in data:
-            user._id = data["_id"]
-        return user
-
-    @staticmethod
-    def from_environment() -> "AutoLamellaUser":
-        """Create a default user from the OS environment."""
-        import platform
-        import socket
-        username = os.environ.get("USERNAME") or os.environ.get("USER", "user")
-        hostname = socket.gethostname() if platform.system() in ("Linux", "Darwin") \
-            else os.environ.get("COMPUTERNAME", "hostname")
-        return AutoLamellaUser(username=username, name=username, is_default=True)
+# AutoLamellaUser lived here: a richer user identity (role, preferences, is_default)
+# with a to_fibsem_user() bridge into image metadata. Nothing ever constructed one --
+# not the app, not a script, not a test -- so the bridge was never called and the
+# extra fields never had a reader. Removed rather than left dormant, because half a
+# user model is worse than either answer. fibsem.structures.FibsemUser is the only
+# user model now; see FIB-450 and the ownership rule on FibsemImageMetadata.
 
 
 @evented

--- a/fibsem/applications/autolamella/tools/data.py
+++ b/fibsem/applications/autolamella/tools/data.py
@@ -277,13 +277,13 @@ def calculate_statistics_dataframe(path: Path, encoding: str = "cp1252"):
     df_milling["exp_name"] = experiment.name
 
     # add experiment id to all df
-    df_history["exp_id"] = experiment._id if experiment._id is not None else "NO_ID"
-    df_beam_shift["exp_id"] = experiment._id if experiment._id is not None else "NO_ID"
-    df_steps["exp_id"] = experiment._id if experiment._id is not None else "NO_ID"
-    df_stage["exp_id"] = experiment._id if experiment._id is not None else "NO_ID"
-    df_det["exp_id"] = experiment._id if experiment._id is not None else "NO_ID"
-    df_click["exp_id"] = experiment._id if experiment._id is not None else "NO_ID"
-    df_milling["exp_id"] = experiment._id if experiment._id is not None else "NO_ID"
+    df_history["exp_id"] = experiment.id if experiment.id is not None else "NO_ID"
+    df_beam_shift["exp_id"] = experiment.id if experiment.id is not None else "NO_ID"
+    df_steps["exp_id"] = experiment.id if experiment.id is not None else "NO_ID"
+    df_stage["exp_id"] = experiment.id if experiment.id is not None else "NO_ID"
+    df_det["exp_id"] = experiment.id if experiment.id is not None else "NO_ID"
+    df_click["exp_id"] = experiment.id if experiment.id is not None else "NO_ID"
+    df_milling["exp_id"] = experiment.id if experiment.id is not None else "NO_ID"
 
     # write dataframes to csv, overwrite
     filename = os.path.join(path, 'history.csv')

--- a/fibsem/applications/autolamella/tools/ml_export.py
+++ b/fibsem/applications/autolamella/tools/ml_export.py
@@ -214,7 +214,7 @@ def collect_sample(lamella: Lamella, stem: str) -> Optional[ExportedSample]:
         pixelsize=image.metadata.pixel_size.x,
         hfw=hfw,
         petname=lamella.name,
-        lamella_id=lamella._id,
+        lamella_id=lamella.id,
         pixel_x=float(point.x),
         pixel_y=float(point.y),
         poi=lamella.poi.to_dict(),
@@ -264,7 +264,7 @@ def _sample_to_dict(sample: ExportedSample, experiment: Experiment) -> dict:
         "image": f"{IMAGES_DIR}/{sample.stem}.tif",
         "experiment": {
             "name": experiment.name,
-            "id": experiment._id,
+            "id": experiment.id,
             "path": str(experiment.path),
             "user": experiment.user,
             "project": experiment.project,

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -198,7 +198,7 @@ class AutoLamellaTask(ABC):
             task_name=self.task_name,
             task_type=self.task_type,
             item_name=self.lamella.name,
-            item_id=self.lamella._id,
+            item_id=self.lamella.id,
             task_id=self.task_id,
             task_state=self.lamella.task_state,
             error=error,
@@ -210,7 +210,7 @@ class AutoLamellaTask(ABC):
         pass
 
     def pre_task(self) -> None:
-        logging.info(f"Running {self.task_name}, {self.task_type} ({self.task_id}) for {self.lamella.name} ({self.lamella._id})")
+        logging.info(f"Running {self.task_name}, {self.task_type} ({self.task_id}) for {self.lamella.name} ({self.lamella.id})")
 
         # pre-task
         # task_state is a single object reused across every run, so each per-run field
@@ -251,7 +251,7 @@ class AutoLamellaTask(ABC):
                 "msg": "task_config",
                 "timestamp": datetime.now().isoformat(),
                 "lamella": self.lamella.name,
-                "lamella_id": self.lamella._id,
+                "lamella_id": self.lamella.id,
                 "task_id": self.task_id,
                 "task_type": self.task_type,
                 "task_name": self.task_name,
@@ -266,7 +266,7 @@ class AutoLamellaTask(ABC):
         logging.debug({"msg": "status",
                        "timestamp": datetime.now().isoformat(),
                        "lamella": self.lamella.name,
-                       "lamella_id": self.lamella._id,
+                       "lamella_id": self.lamella.id,
                        "task_id": self.task_id,
                        "task_type": self.task_type,
                        "task_name": self.task_name,

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -127,7 +127,7 @@ class TaskManager:
                 self._fire_skipped_hook(
                     item.task_name, lamella.name, skip_reason,
                     task_type=task_config.task_type if task_config else "",
-                    item_id=lamella._id,
+                    item_id=lamella.id,
                 )
                 continue
 
@@ -241,7 +241,7 @@ class TaskManager:
         """
         pending, total = self.queue.counts
         return {
-            "experiment_id": self.experiment._id,
+            "experiment_id": self.experiment.id,
             "experiment_name": self.experiment.name,
             "tasks_remaining": pending,
             "tasks_total": total,
@@ -297,7 +297,7 @@ class TaskManager:
             task_name=task_name,
             task_type=lamella.task_state.task_type,
             item_name=lamella.name,
-            item_id=lamella._id,
+            item_id=lamella.id,
             task_id=lamella.task_state.task_id,
             task_state=lamella.task_state,
             **self.hook_run_context(),
@@ -316,7 +316,7 @@ class TaskManager:
             self.hook_manager,
             HookEvent.EXPERIMENT_COMPLETED,
             item_name=self.experiment.name,
-            item_id=self.experiment._id,
+            item_id=self.experiment.id,
             **self.hook_run_context(),
         )
 

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1823,7 +1823,7 @@ class FibsemExperimentRef:
     does not apply to every embedded copy -- see ``FibsemUser``.
     """
 
-    # Experiment._id, a UUID -- stable, the join key. Held the experiment *name* up to
+    # Experiment.id, a UUID -- stable, the join key. Held the experiment *name* up to
     # and including v0.5.2; a file whose `name` is absent is from that era and its `id`
     # is a name. See FIB-446.
     id: Optional[str] = None

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -1082,7 +1082,7 @@ class AutoLamellaProtocolEditorWidget(QWidget):
             return
 
         other_names = [
-            p.name for p in experiment.positions if p._id != source_lamella._id
+            p.name for p in experiment.positions if p.id != source_lamella.id
         ]
         task_names = self._sort_task_names_by_workflow(
             list(source_lamella.task_config.keys())

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -2132,7 +2132,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
                 AutoLamellaTaskState(
                     name=COINCIDENCE_REVIEW_TASK_NAME,
                     task_type="MILL_COINCIDENT",
-                    lamella_id=lamella._id,
+                    lamella_id=lamella.id,
                     end_timestamp=now,
                     status=AutoLamellaTaskStatus.Completed,
                     status_message="Coincidence milling (recorded from viewer)",

--- a/fibsem/ui/widgets/lamella_card_widget.py
+++ b/fibsem/ui/widgets/lamella_card_widget.py
@@ -260,7 +260,7 @@ class LamellaCardContainer(QWidget):
 
     def __init__(self, columns: int = _N_COLS, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self._cards: Dict[str, LamellaCardWidget] = {}   # lamella._id → card
+        self._cards: Dict[str, LamellaCardWidget] = {}   # lamella.id → card
         self._selected_id: Optional[str] = None
         self._n_cols: int = max(1, columns)
 
@@ -280,18 +280,18 @@ class LamellaCardContainer(QWidget):
         card.move_to_requested.connect(self.move_to_requested)
         card.update_position_requested.connect(self.update_position_requested)
         card.remove_requested.connect(self._on_card_remove_requested)
-        self._cards[lamella._id] = card
+        self._cards[lamella.id] = card
         self._rebuild_grid()
         return card
 
     def remove_lamella(self, lamella: Lamella) -> None:
-        card = self._cards.pop(lamella._id, None)
+        card = self._cards.pop(lamella.id, None)
         if card is not None:
             card.deleteLater()
             self._rebuild_grid()
 
     def refresh_lamella(self, lamella: Lamella) -> None:
-        card = self._cards.get(lamella._id)
+        card = self._cards.get(lamella.id)
         if card is not None:
             card.refresh()
 
@@ -325,7 +325,7 @@ class LamellaCardContainer(QWidget):
 
     def _on_card_clicked(self, lamella: Lamella) -> None:
         prev_id = self._selected_id
-        new_id = lamella._id
+        new_id = lamella.id
 
         if prev_id and prev_id in self._cards:
             self._cards[prev_id].set_selected(False)

--- a/fibsem/ui/widgets/lamella_task_image_widget.py
+++ b/fibsem/ui/widgets/lamella_task_image_widget.py
@@ -252,7 +252,7 @@ class LamellaTaskImageWidget(QWidget):
 
     def set_lamella(self, lamella: Optional[Lamella]) -> None:
         """Set the lamella to display. Skips reload if same lamella."""
-        new_id = lamella._id if lamella is not None else None
+        new_id = lamella.id if lamella is not None else None
         if new_id == self._lamella_id:
             return
 

--- a/tests/autolamella/test_experiment_metadata_registration.py
+++ b/tests/autolamella/test_experiment_metadata_registration.py
@@ -48,7 +48,7 @@ def test_register_metadata_stamps_the_experiment_onto_the_microscope(
     experiment.register_metadata(microscope)
 
     # The UUID is the join key; the name is the display string (FIB-446).
-    assert microscope.experiment.id == experiment._id
+    assert microscope.experiment.id == experiment.id
     assert microscope.experiment.name == "test-experiment"
     assert microscope.experiment.application == "autolamella"
 
@@ -59,7 +59,7 @@ def test_creating_a_task_manager_registers_without_a_gui(
     """A headless run goes through TaskManager, never through AutoLamellaUI."""
     TaskManager(microscope=microscope, experiment=experiment, parent_ui=None)
 
-    assert microscope.experiment.id == experiment._id
+    assert microscope.experiment.id == experiment.id
     assert microscope.experiment.name == "test-experiment"
 
 

--- a/tests/autolamella/test_hook_run_context.py
+++ b/tests/autolamella/test_hook_run_context.py
@@ -59,7 +59,7 @@ def test_workflow_events_say_which_experiment(experiment, recorder):
 
     assert [c.event for c in fired] == ["workflow_started", "workflow_completed"]
     for context in fired:
-        assert context.experiment_id == experiment._id
+        assert context.experiment_id == experiment.id
         assert context.experiment_name == "test-exp"
 
 
@@ -92,7 +92,7 @@ def test_a_skipped_event_carries_the_lamella_id(experiment, recorder):
     manager.run(task_names=["MillTrench"], required_lamella=[lamella.name])
 
     skipped = [c for c in fired if c.event == "task_skipped"]
-    assert skipped[0].item_id == lamella._id
+    assert skipped[0].item_id == lamella.id
 
 
 def test_a_missing_lamella_has_no_id_to_report(experiment, recorder):
@@ -106,7 +106,7 @@ def test_a_missing_lamella_has_no_id_to_report(experiment, recorder):
     assert skipped[0].item_name == "ghost"
     assert skipped[0].item_id == ""
     # still says which experiment, even with nothing else to go on
-    assert skipped[0].experiment_id == experiment._id
+    assert skipped[0].experiment_id == experiment.id
 
 
 def test_the_event_task_id_joins_to_the_task_history_entry(recorder, tmp_path):
@@ -136,7 +136,7 @@ def test_the_event_task_id_joins_to_the_task_history_entry(recorder, tmp_path):
 
     failed = [c for c in fired if c.event == "task_failed"][0]
     assert failed.task_id == lamella.task_history[-1].task_id
-    assert failed.item_id == lamella._id
+    assert failed.item_id == lamella.id
     # and the snapshot is of the terminal state, not the InProgress it started in
     assert failed.task_state.status is AutoLamellaTaskStatus.Failed
 

--- a/tests/autolamella/test_id_serialisation.py
+++ b/tests/autolamella/test_id_serialisation.py
@@ -1,0 +1,81 @@
+"""The `_id` -> `id` rename must not move the on-disk format.
+
+FIB-495 renamed the attribute because it is the system's most externally-facing
+identifier -- persisted, read from 26 call sites, and carried in image metadata and
+hook payloads -- while the underscore marked it internal.
+
+The serialised keys deliberately did not change, so no existing experiment.yaml
+needs migrating. That is the load-bearing claim, and it is the one worth pinning:
+a later cleanup that "tidies" the key would silently orphan the id in every
+experiment ever written, and every image whose metadata joins on it.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    Experiment,
+    Lamella,
+)
+
+
+def test_the_experiment_id_is_still_written_under_underscore_id(tmp_path: Path) -> None:
+    exp = Experiment(path=tmp_path, name="test-exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    os.makedirs(exp.path, exist_ok=True)
+    exp.save()
+
+    written = yaml.safe_load((Path(exp.path) / "experiment.yaml").read_text())
+
+    assert written["_id"] == exp.id
+    assert "id" not in written, "the key moved -- existing experiments would lose their id"
+
+
+def test_an_experiment_written_before_the_rename_still_loads(tmp_path: Path) -> None:
+    """The point of keeping the key: files on disk predate the attribute name."""
+    exp = Experiment(path=tmp_path, name="test-exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    os.makedirs(exp.path, exist_ok=True)
+    exp.save()
+
+    path = Path(exp.path) / "experiment.yaml"
+    on_disk = yaml.safe_load(path.read_text())
+    original_id = on_disk["_id"]
+
+    reloaded = Experiment.load(path)
+
+    assert reloaded.id == original_id
+
+
+def test_the_lamella_id_keeps_its_own_key(tmp_path: Path) -> None:
+    """Lamella already serialised under "id", not "_id" -- the two were inconsistent
+    before this rename and still are. Pinned so the asymmetry is deliberate rather
+    than something a future reader assumes is a typo and "fixes"."""
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+
+    assert lamella.to_dict()["id"] == lamella.id
+
+    restored = Lamella.from_dict(lamella.to_dict())
+    assert restored.id == lamella.id
+
+
+def test_the_protocol_id_round_trips() -> None:
+    protocol = AutoLamellaTaskProtocol()
+
+    written = protocol.to_dict()
+    assert written["_id"] == protocol.id
+
+    assert AutoLamellaTaskProtocol.from_dict(written).id == protocol.id
+
+
+def test_a_missing_id_does_not_raise(tmp_path: Path) -> None:
+    """Older or hand-edited files may have no id at all."""
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+    data = lamella.to_dict()
+    del data["id"]
+
+    assert Lamella.from_dict(data).id == ""

--- a/tests/autolamella/test_ml_export.py
+++ b/tests/autolamella/test_ml_export.py
@@ -287,7 +287,7 @@ def test_collect_sample_carries_provenance(tmp_path):
     sample = ml_export.collect_sample(lamella, "0001")
     assert sample.defect == "FAILURE"
     assert sample.milling_angle == pytest.approx(0.3)
-    assert sample.lamella_id == lamella._id
+    assert sample.lamella_id == lamella.id
     assert sample.petname == lamella.name
 
 


### PR DESCRIPTION
Closes FIB-450 and FIB-495. Two commits, reviewable separately.

## Remove `AutoLamellaUser` (FIB-450)

Nothing ever constructed one — `from_dict`, `from_environment` and `to_fibsem_user` were all uncalled, so its richer fields never had a reader and the bridge into image metadata was never crossed.

Removed rather than left dormant: a class a schema might one day map to, that nothing builds today, is a thing every reader has to decide about. `FibsemUser` is now the only user model, which is what the ownership rule documented on `FibsemImageMetadata` already said.

What goes with it — `role` (permissions concept nothing uses), `preferences` (belongs with FIB-336's user-state work), `is_default` and `created_at` (only meaningful with a registry to select from). `_id` is the only real loss, and email is a better natural key here anyway.

**One deferral made explicit rather than silent:** core facilities commonly run a shared login on the microscope PC, so identity being the OS username means every operator on that instrument is the same person. This doesn't cause that — it was already true — but it removes the obvious place a "who is at the console" record would live. If per-operator attribution matters later it returns as a new decision, not a dormant class.

## Rename `_id` → `id` (FIB-495)

The underscore said private. The field is persisted, read from **26 call sites across nine modules**, recorded in image metadata as the join key that lets a renamed experiment still be identified (FIB-446), and carried off the machine in every hook payload as `item_id`/`experiment_id` (FIB-489). No accessor was ever added, so every call site reached past the underscore — uniformly ignored, not partially observed.

It also left the layers spelling the same concepts differently: `FibsemExperimentRef` uses `id` + `name`, the `Experiment` it points at used `_id` + `name`, one import apart.

### The serialised keys do not move

`to_dict` still writes `"_id"` for `Experiment` and the task protocol, and `"id"` for `Lamella` — exactly what they wrote before, **including the inconsistency between them**, which predates this change. No experiment file needs migrating, and the image→experiment join keeps working.

Tests pin this, because it's the load-bearing claim: a later cleanup that "tidies" `"_id"` to `"id"` would silently orphan the identifier in every experiment ever written and every image whose metadata joins on it. One test exists purely to make the `Lamella`/`Experiment` key asymmetry look deliberate rather than like a typo someone should fix.

### One pass, not a compatibility property

A half-migrated convention is worse than a uniformly ignored one — three call sites on a new accessor while twenty-three keep `_id` is harder to reason about than either end state, and leaves two names for one field indefinitely.

## Note on the DB branch

FIB-450 said to check `feat/autolamella-database` before deleting, and that check **failed**: the branch has a `user` table mapped to `AutoLamellaUser`, adapters, CRUD, and a `SCHEMA.md` stating it *replaces* `FibsemUser.from_environment()` — the opposite direction from this change. Confirmed as deprecated and unused, so proceeding regardless. Noting it because the conflict is real if that branch is ever revived.

Full suite: 2324 passed, 24 skipped.
