### PR TITLE
[autolamella] Fix the experiment completion predicate, and move the artifact to the lamella (FIB-461)

### DIFF
--- a/fibsem/applications/autolamella/tools/artifacts.py
+++ b/fibsem/applications/autolamella/tools/artifacts.py
@@ -1,4 +1,4 @@
-"""Artifacts written automatically when a run finishes.
+"""Artifacts written automatically when work finishes.
 
 The downstream recipient -- the TEM operator, the collaborator -- never installs
 fibsemOS, so what lands in the experiment directory is their only interface. Today
@@ -15,8 +15,14 @@ import os
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.structures import Experiment
+    from fibsem.applications.autolamella.structures import (
+        AutoLamellaTaskState,
+        Experiment,
+        Lamella,
+    )
     from fibsem.hooks import HookContext
 
 COMPLETION_SUMMARY_FILENAME = "completion-summary.json"
@@ -25,33 +31,101 @@ COMPLETION_SUMMARY_FILENAME = "completion-summary.json"
 def write_completion_summary(
     experiment: "Experiment", context: "HookContext"
 ) -> Optional[str]:
-    """Write a small json recording that this experiment finished, and when.
+    """Write a small json into a finished lamella's directory recording that it is done.
 
     A placeholder for the real artifacts (the PDF and the overview PNG) while the
     trigger is proven end to end -- the point being that it is written by whatever
-    finishes the run, not by a person clicking a dialog.
+    finishes the work, not by a person clicking a dialog.
 
-    Self-describing on purpose, even at four keys: the file is meant to be forwarded,
-    and an artifact that cannot say which experiment it came from is a stack of bytes
-    three months later. The id is the stable key; the name can change.
+    Hung off ITEM_COMPLETED rather than the end of the experiment, because a lamella is
+    the unit that gets delivered to a TEM, and because most experiments never complete:
+    a lamella or two gets abandoned, and everything else is still worth reporting.
 
-    Timestamped from the event, not from now(): the file records when the run
+    Self-describing on purpose, even at a handful of keys: the file is meant to be
+    forwarded, and an artifact that cannot say what it came from is a stack of bytes
+    three months later. The ids are the stable keys; the names can change.
+
+    Timestamped from the event, not from now(): the file records when the work
     finished, which is not necessarily when someone got round to writing it.
     """
+    lamella = _find_item(experiment, context)
+    if lamella is None:
+        logging.warning(
+            f"No lamella matching {context.item_name!r} in experiment "
+            f"{experiment.name}; no completion summary written."
+        )
+        return None
+
     summary = {
         "experiment_id": context.experiment_id or experiment.id,
         "experiment_name": context.experiment_name or experiment.name,
+        "item_id": lamella.id,
+        "item_name": lamella.name,
         "completed_at": datetime.fromtimestamp(context.timestamp).isoformat(
             timespec="seconds"
         ),
-        # Which event produced this. There will be more triggers -- per-item artifacts,
-        # and arguably cancelled runs, which is when someone most wants to look.
+        # Which event produced this. There will be more triggers -- an end-of-run
+        # summary covering the lamellae that did not finish, which is when someone most
+        # wants to look.
         "event": context.event,
+        # Filtered on status, so a task that failed and was not retried does not appear
+        # here as work delivered.
+        "tasks_completed": [
+            _task_record(task)
+            for task in lamella.task_history
+            if task.status is AutoLamellaTaskStatus.Completed
+        ],
     }
 
-    path = os.path.join(experiment.path, COMPLETION_SUMMARY_FILENAME)
+    os.makedirs(lamella.path, exist_ok=True)
+    path = os.path.join(lamella.path, COMPLETION_SUMMARY_FILENAME)
     with open(path, "w") as f:
         json.dump(summary, f, indent=2)
 
-    logging.info(f"Wrote completion summary for {experiment.name} to {path}")
+    logging.info(f"Wrote completion summary for {lamella.name} to {path}")
     return path
+
+
+def _task_record(task: "AutoLamellaTaskState") -> dict:
+    """What one completed task contributed, and what it left behind.
+
+    ``outputs`` is the point of this: paths are stored relative to lamella.path, and
+    the artifact is written into that same directory, so they resolve as-is for
+    whoever receives the folder. Reported per task rather than merged into one map,
+    which would lose provenance and collide on shared role names (two tasks both
+    writing final_sem).
+
+    Named to match AutoLamellaTaskState.outputs -- the artifact and the record it
+    describes should not need a glossary between them.
+    """
+    return {
+        "name": task.name,
+        # Identifies this execution, so a retried task is distinguishable from its
+        # earlier attempt, and this joins to the hook event that announced it.
+        "task_id": task.task_id,
+        "completed_at": (
+            datetime.fromtimestamp(task.end_timestamp).isoformat(timespec="seconds")
+            if task.end_timestamp is not None
+            else None
+        ),
+        "duration_s": round(task.duration, 1),
+        "outputs": task.outputs,
+    }
+
+
+def _find_item(
+    experiment: "Experiment", context: "HookContext"
+) -> Optional["Lamella"]:
+    """Resolve the item a context names back to the lamella it refers to.
+
+    By id first: the name is a petname a user can edit, the id is the stable key. The
+    context carries both precisely so a consumer does not have to trust the name.
+    """
+    if context.item_id:
+        for lamella in experiment.positions:
+            if lamella.id == context.item_id:
+                return lamella
+    for lamella in experiment.positions:
+        if lamella.name == context.item_name:
+            return lamella
+    return None

--- a/fibsem/applications/autolamella/tools/artifacts.py
+++ b/fibsem/applications/autolamella/tools/artifacts.py
@@ -1,0 +1,57 @@
+"""Artifacts written automatically when a run finishes.
+
+The downstream recipient -- the TEM operator, the collaborator -- never installs
+fibsemOS, so what lands in the experiment directory is their only interface. Today
+that artifact exists only if someone remembers to open a Qt dialog before going home.
+See FIB-461.
+
+Deliberately light on imports: these run from a hook, on the workflow's thread, so
+this module must not pull in matplotlib or reportlab the way tools/reporting.py does.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from fibsem.applications.autolamella.structures import Experiment
+    from fibsem.hooks import HookContext
+
+COMPLETION_SUMMARY_FILENAME = "completion-summary.json"
+
+
+def write_completion_summary(
+    experiment: "Experiment", context: "HookContext"
+) -> Optional[str]:
+    """Write a small json recording that this experiment finished, and when.
+
+    A placeholder for the real artifacts (the PDF and the overview PNG) while the
+    trigger is proven end to end -- the point being that it is written by whatever
+    finishes the run, not by a person clicking a dialog.
+
+    Self-describing on purpose, even at four keys: the file is meant to be forwarded,
+    and an artifact that cannot say which experiment it came from is a stack of bytes
+    three months later. The id is the stable key; the name can change.
+
+    Timestamped from the event, not from now(): the file records when the run
+    finished, which is not necessarily when someone got round to writing it.
+    """
+    summary = {
+        "experiment_id": context.experiment_id or experiment.id,
+        "experiment_name": context.experiment_name or experiment.name,
+        "completed_at": datetime.fromtimestamp(context.timestamp).isoformat(
+            timespec="seconds"
+        ),
+        # Which event produced this. There will be more triggers -- per-item artifacts,
+        # and arguably cancelled runs, which is when someone most wants to look.
+        "event": context.event,
+    }
+
+    path = os.path.join(experiment.path, COMPLETION_SUMMARY_FILENAME)
+    with open(path, "w") as f:
+        json.dump(summary, f, indent=2)
+
+    logging.info(f"Wrote completion summary for {experiment.name} to {path}")
+    return path

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -82,9 +82,10 @@ from fibsem.applications.autolamella.structures import (
     Experiment,
     Lamella,
 )
-from fibsem.applications.autolamella.tools.artifacts import write_completion_summary
+# Paired with the disabled completion_summary hook in setup_hooks; FunctionHook comes
+# back from fibsem.hooks below at the same time.
+# from fibsem.applications.autolamella.tools.artifacts import write_completion_summary
 from fibsem.hooks import (
-    FunctionHook,
     HookEvent,
     HookManager,
     LoggingHook,
@@ -1133,21 +1134,34 @@ class AutoLamellaUI(QMainWindow):
                 message_template="Task {task_name} cancelled for {item_name}",
             )
         )
-        manager.register(
-            FunctionHook(
-                name="completion_summary",
-                events=[HookEvent.EXPERIMENT_COMPLETED],
-                # A FunctionHook rather than a template-driven one because this needs
-                # the experiment itself, which the context deliberately does not carry
-                # -- the path is derivable from the record, and in-process hooks can
-                # reach the record. A webhook could not, which is the distinction.
-                #
-                # HookManager.fire contains what this raises, so a summary that cannot
-                # be written is logged and the run carries on. FIB-461 asks for exactly
-                # that, and it comes for free rather than needing a second guard here.
-                callback=lambda ctx: write_completion_summary(self.experiment, ctx),
-            )
-        )
+        # Deliberately not registered yet. The trigger is proven end to end and the
+        # writer is tested, but completion-summary.json is a placeholder for the real
+        # artifacts (the PDF and the overview PNG), and turning it on here would start
+        # writing a throwaway file into every user's lamella directories. Re-enable when
+        # the artifact is the one people actually want -- see FIB-461. Two imports at the
+        # top of this file come back with it: write_completion_summary and FunctionHook.
+        #
+        # Per lamella, not per experiment: a lamella is what gets delivered, and an
+        # experiment with one abandoned lamella never reaches completion at all, so
+        # hanging the artifact off the experiment would mean it was almost never
+        # written.
+        #
+        # A FunctionHook rather than a template-driven one because this needs the
+        # experiment itself, which the context deliberately does not carry -- the path
+        # is derivable from the record, and in-process hooks can reach the record. A
+        # webhook could not, which is the distinction.
+        #
+        # HookManager.fire contains what this raises, so a summary that cannot be
+        # written is logged and the run carries on. FIB-461 asks for exactly that, and
+        # it comes for free rather than needing a second guard here.
+        #
+        # manager.register(
+        #     FunctionHook(
+        #         name="completion_summary",
+        #         events=[HookEvent.ITEM_COMPLETED],
+        #         callback=lambda ctx: write_completion_summary(self.experiment, ctx),
+        #     )
+        # )
         # Signals are thread-safe to emit; hooks fire on the task worker thread.
         manager.set_notifier(self._hook_toast_signal.emit)
         return manager

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -82,7 +82,9 @@ from fibsem.applications.autolamella.structures import (
     Experiment,
     Lamella,
 )
+from fibsem.applications.autolamella.tools.artifacts import write_completion_summary
 from fibsem.hooks import (
+    FunctionHook,
     HookEvent,
     HookManager,
     LoggingHook,
@@ -1129,6 +1131,21 @@ class AutoLamellaUI(QMainWindow):
                 events=[HookEvent.TASK_CANCELLED],
                 notification_type="warning",
                 message_template="Task {task_name} cancelled for {item_name}",
+            )
+        )
+        manager.register(
+            FunctionHook(
+                name="completion_summary",
+                events=[HookEvent.EXPERIMENT_COMPLETED],
+                # A FunctionHook rather than a template-driven one because this needs
+                # the experiment itself, which the context deliberately does not carry
+                # -- the path is derivable from the record, and in-process hooks can
+                # reach the record. A webhook could not, which is the distinction.
+                #
+                # HookManager.fire contains what this raises, so a summary that cannot
+                # be written is logged and the run carries on. FIB-461 asks for exactly
+                # that, and it comes for free rather than needing a second guard here.
+                callback=lambda ctx: write_completion_summary(self.experiment, ctx),
             )
         )
         # Signals are thread-safe to emit; hooks fire on the task worker thread.

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -275,10 +275,19 @@ class TaskManager:
         self._experiment_was_complete = self._all_lamella_complete()
 
     def _all_lamella_complete(self) -> bool:
-        positions = self.experiment.positions
-        # An experiment with no lamellae has not been completed, it is empty. all([])
-        # would say otherwise.
-        return bool(positions) and all(self._is_complete(p) for p in positions)
+        """Whether every lamella still in scope has finished.
+
+        Lamellae a human has marked defective are out of scope: _should_skip skips them
+        for every remaining task, so they can never satisfy the completion predicate.
+        Counting them meant a single abandoned lamella permanently prevented its
+        experiment from ever reporting complete — and in a real session most experiments
+        have one. The completion predicate and the skip predicate have to agree on which
+        lamellae they are talking about.
+        """
+        active = [p for p in self.experiment.positions if not p.is_failure]
+        # An experiment with nothing left in scope — empty, or every lamella abandoned —
+        # produced nothing, and must not announce success. all([]) would say otherwise.
+        return bool(active) and all(self._is_complete(p) for p in active)
 
     def _maybe_fire_lamella_completed(self, lamella: 'Lamella', task_name: str) -> None:
         """Fire ITEM_COMPLETED the first time a lamella satisfies the workflow's

--- a/tests/autolamella/test_completion_artifacts.py
+++ b/tests/autolamella/test_completion_artifacts.py
@@ -1,0 +1,201 @@
+"""An artifact is written by whatever finishes the run, not by a person clicking.
+
+A placeholder for the PDF and overview PNG while the trigger is proven end to end.
+See FIB-461.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaTaskProtocol,
+    AutoLamellaTaskState,
+    AutoLamellaTaskStatus,
+    AutoLamellaWorkflowConfig,
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.tools.artifacts import (
+    COMPLETION_SUMMARY_FILENAME,
+    write_completion_summary,
+)
+from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+from fibsem.hooks import FunctionHook, HookContext, HookEvent, HookManager
+
+REQUIRED_TASKS = ["MillTrench", "MillUndercut"]
+
+
+@pytest.fixture
+def experiment(tmp_path: Path) -> Experiment:
+    exp = Experiment(path=tmp_path, name="test-exp")
+    exp.task_protocol = AutoLamellaTaskProtocol(
+        workflow_config=AutoLamellaWorkflowConfig(
+            tasks=[
+                AutoLamellaTaskDescription(name=name, supervise=False, required=True)
+                for name in REQUIRED_TASKS
+            ]
+        )
+    )
+    # Constructing an Experiment deliberately does not create its directory (FIB-420).
+    os.makedirs(exp.path, exist_ok=True)
+    return exp
+
+
+def _summary(experiment: Experiment) -> dict:
+    with open(os.path.join(experiment.path, COMPLETION_SUMMARY_FILENAME)) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# the writer
+# ---------------------------------------------------------------------------
+
+def test_the_summary_says_which_experiment_and_when(experiment):
+    from datetime import datetime
+
+    fired_at = 1_754_000_000.0
+    context = HookContext(
+        event=HookEvent.EXPERIMENT_COMPLETED,
+        experiment_id=experiment.id,
+        experiment_name=experiment.name,
+        timestamp=fired_at,
+    )
+
+    write_completion_summary(experiment, context)
+
+    summary = _summary(experiment)
+    assert summary["experiment_id"] == experiment.id
+    assert summary["experiment_name"] == "test-exp"
+    assert summary["event"] == "experiment_completed"
+    # ISO 8601 to the second, and it round-trips to the event's timestamp. Asserted as
+    # a property rather than a literal, which would encode the runner's timezone.
+    assert datetime.fromisoformat(summary["completed_at"]).timestamp() == fired_at
+
+
+def test_it_records_when_the_run_finished_not_when_the_file_was_written(experiment):
+    """The event's timestamp, not now(): the two differ if a hook defers work."""
+    import time
+
+    fired_at = time.time() - 3600
+    write_completion_summary(
+        experiment,
+        HookContext(event=HookEvent.EXPERIMENT_COMPLETED, timestamp=fired_at),
+    )
+
+    from datetime import datetime
+
+    expected = datetime.fromtimestamp(fired_at).isoformat(timespec="seconds")
+    assert _summary(experiment)["completed_at"] == expected
+
+
+def test_it_falls_back_to_the_experiment_when_the_context_is_bare(experiment):
+    """A context fired without the run fields still produces an identified artifact."""
+    write_completion_summary(
+        experiment, HookContext(event=HookEvent.EXPERIMENT_COMPLETED)
+    )
+
+    summary = _summary(experiment)
+    assert summary["experiment_id"] == experiment.id
+    assert summary["experiment_name"] == "test-exp"
+
+
+# ---------------------------------------------------------------------------
+# through the hook, as the UI wires it
+# ---------------------------------------------------------------------------
+
+def _manager_with_summary_hook(experiment: Experiment) -> TaskManager:
+    """Mirrors what AutoLamellaUI.setup_hooks registers."""
+    class _NoMicroscope:
+        fm = None
+
+    hooks = HookManager()
+    hooks.register(
+        FunctionHook(
+            name="completion_summary",
+            events=[HookEvent.EXPERIMENT_COMPLETED],
+            callback=lambda ctx: write_completion_summary(experiment, ctx),
+        )
+    )
+    return TaskManager(
+        microscope=_NoMicroscope(),
+        experiment=experiment,
+        parent_ui=None,
+        hook_manager=hooks,
+    )
+
+
+def _complete_lamella(experiment: Experiment, name: str) -> Lamella:
+    lamella = Lamella(path=experiment.path, number=1, petname=name)
+    for task_name in REQUIRED_TASKS:
+        lamella.task_history.append(
+            AutoLamellaTaskState(name=task_name, status=AutoLamellaTaskStatus.Completed)
+        )
+    experiment.positions.append(lamella)
+    return lamella
+
+
+def test_finishing_the_experiment_writes_the_artifact(experiment):
+    manager = _manager_with_summary_hook(experiment)
+    _complete_lamella(experiment, "lam-1")
+    manager._completed_lamella = set()  # pretend it finished during this run
+
+    manager._maybe_fire_experiment_completed()
+
+    summary = _summary(experiment)
+    assert summary["experiment_name"] == "test-exp"
+    assert summary["event"] == "experiment_completed"
+
+
+def test_an_unfinished_experiment_writes_nothing(experiment):
+    manager = _manager_with_summary_hook(experiment)
+    lamella = Lamella(path=experiment.path, number=1, petname="lam-1")
+    lamella.task_history.append(
+        AutoLamellaTaskState(name="MillTrench", status=AutoLamellaTaskStatus.Completed)
+    )
+    experiment.positions.append(lamella)
+    manager._snapshot_completion()
+
+    manager._maybe_fire_experiment_completed()
+
+    assert not os.path.exists(
+        os.path.join(experiment.path, COMPLETION_SUMMARY_FILENAME)
+    )
+
+
+def test_a_failing_artifact_does_not_break_the_run(experiment, caplog):
+    """FIB-461: a report that cannot be generated is a warning, never an exception
+    propagating into workflow teardown. HookManager.fire already contains it."""
+    import logging
+
+    class _NoMicroscope:
+        fm = None
+
+    hooks = HookManager()
+    hooks.register(
+        FunctionHook(
+            name="completion_summary",
+            events=[HookEvent.EXPERIMENT_COMPLETED],
+            callback=lambda ctx: (_ for _ in ()).throw(OSError("disk full")),
+        )
+    )
+    manager = TaskManager(
+        microscope=_NoMicroscope(), experiment=experiment,
+        parent_ui=None, hook_manager=hooks,
+    )
+    _complete_lamella(experiment, "lam-1")
+    manager._completed_lamella = set()
+
+    with caplog.at_level(logging.ERROR):
+        manager._maybe_fire_experiment_completed()  # must not raise
+
+    assert any("completion_summary" in r.message for r in caplog.records)
+
+
+def test_the_event_the_ui_subscribes_to_exists():
+    """Guards the wiring in setup_hooks, which tests/ui cannot construct headlessly."""
+    assert HookEvent.EXPERIMENT_COMPLETED in list(HookEvent)

--- a/tests/autolamella/test_completion_artifacts.py
+++ b/tests/autolamella/test_completion_artifacts.py
@@ -1,13 +1,19 @@
-"""An artifact is written by whatever finishes the run, not by a person clicking.
+"""An artifact is written by whatever finishes the work, not by a person clicking.
 
-A placeholder for the PDF and overview PNG while the trigger is proven end to end.
-See FIB-461.
+Per lamella, because a lamella is what gets delivered to a TEM and because an
+experiment with one abandoned lamella never completes at all. A placeholder for the
+PDF and overview PNG while the trigger is proven end to end. See FIB-461.
+
+The hook is commented out in AutoLamellaUI.setup_hooks rather than shipped, so nothing
+writes these files during a real run yet. These tests are what keeps the writer honest
+in the meantime: they register the same hook themselves, so the wiring is exercised
+even while it is dormant.
 """
 
 import json
 import os
+from datetime import datetime
 from pathlib import Path
-from typing import List
 
 import pytest
 
@@ -46,62 +52,228 @@ def experiment(tmp_path: Path) -> Experiment:
     return exp
 
 
-def _summary(experiment: Experiment) -> dict:
-    with open(os.path.join(experiment.path, COMPLETION_SUMMARY_FILENAME)) as f:
+def _new_lamella(experiment: Experiment, name: str) -> Lamella:
+    """As Experiment._create_lamella builds one: its path is its own directory under
+    the experiment, which is what the artifact is written into."""
+    return Lamella(
+        path=Path(os.path.join(experiment.path, name)),
+        number=len(experiment.positions) + 1,
+        petname=name,
+    )
+
+
+def _complete_lamella(experiment: Experiment, name: str) -> Lamella:
+    lamella = _new_lamella(experiment, name)
+    for task_name in REQUIRED_TASKS:
+        lamella.task_history.append(
+            AutoLamellaTaskState(name=task_name, status=AutoLamellaTaskStatus.Completed)
+        )
+    experiment.positions.append(lamella)
+    return lamella
+
+
+def _summary(lamella: Lamella) -> dict:
+    with open(os.path.join(lamella.path, COMPLETION_SUMMARY_FILENAME)) as f:
         return json.load(f)
+
+
+def _context(lamella: Lamella, experiment: Experiment, **overrides) -> HookContext:
+    fields = dict(
+        event=HookEvent.ITEM_COMPLETED,
+        item_name=lamella.name,
+        item_id=lamella.id,
+        experiment_id=experiment.id,
+        experiment_name=experiment.name,
+    )
+    fields.update(overrides)
+    return HookContext(**fields)
 
 
 # ---------------------------------------------------------------------------
 # the writer
 # ---------------------------------------------------------------------------
 
-def test_the_summary_says_which_experiment_and_when(experiment):
-    from datetime import datetime
-
+def test_the_summary_says_which_lamella_which_experiment_and_when(experiment):
+    lamella = _complete_lamella(experiment, "lam-1")
     fired_at = 1_754_000_000.0
-    context = HookContext(
-        event=HookEvent.EXPERIMENT_COMPLETED,
-        experiment_id=experiment.id,
-        experiment_name=experiment.name,
-        timestamp=fired_at,
+
+    write_completion_summary(
+        experiment, _context(lamella, experiment, timestamp=fired_at)
     )
 
-    write_completion_summary(experiment, context)
-
-    summary = _summary(experiment)
+    summary = _summary(lamella)
+    assert summary["item_id"] == lamella.id
+    assert summary["item_name"] == lamella.name
     assert summary["experiment_id"] == experiment.id
     assert summary["experiment_name"] == "test-exp"
-    assert summary["event"] == "experiment_completed"
+    assert summary["event"] == "item_completed"
     # ISO 8601 to the second, and it round-trips to the event's timestamp. Asserted as
     # a property rather than a literal, which would encode the runner's timezone.
     assert datetime.fromisoformat(summary["completed_at"]).timestamp() == fired_at
 
 
-def test_it_records_when_the_run_finished_not_when_the_file_was_written(experiment):
+def test_it_records_the_work_that_was_delivered(experiment):
+    lamella = _complete_lamella(experiment, "lam-1")
+
+    write_completion_summary(experiment, _context(lamella, experiment))
+
+    tasks = _summary(lamella)["tasks_completed"]
+    assert [t["name"] for t in tasks] == REQUIRED_TASKS
+    assert [t["task_id"] for t in tasks] == [t.task_id for t in lamella.task_history]
+
+
+def test_it_records_the_files_each_task_left_behind(experiment):
+    """The point of the artifact: the recipient gets the folder and needs to know
+    which files in it are the result."""
+    lamella = _complete_lamella(experiment, "lam-1")
+    lamella.task_history[0].outputs = {
+        "final_sem": ["MillTrench-final-sem.tif"],
+        "final_fib": ["MillTrench-final-fib.tif"],
+    }
+
+    write_completion_summary(experiment, _context(lamella, experiment))
+
+    tasks = _summary(lamella)["tasks_completed"]
+    assert tasks[0]["outputs"] == {
+        "final_sem": ["MillTrench-final-sem.tif"],
+        "final_fib": ["MillTrench-final-fib.tif"],
+    }
+    # relative to the lamella directory, which is where the artifact itself lives, so
+    # they resolve as-is for whoever receives the folder
+    assert os.path.isabs(tasks[0]["outputs"]["final_sem"][0]) is False
+    assert tasks[1]["outputs"] == {}
+
+
+def test_it_records_how_long_each_task_took(experiment):
+    lamella = _complete_lamella(experiment, "lam-1")
+    task = lamella.task_history[0]
+    task.end_timestamp = task.start_timestamp + 412.34
+
+    write_completion_summary(experiment, _context(lamella, experiment))
+
+    record = _summary(lamella)["tasks_completed"][0]
+    assert record["duration_s"] == 412.3
+    assert (
+        datetime.fromisoformat(record["completed_at"]).timestamp()
+        == pytest.approx(task.end_timestamp, abs=1)
+    )
+
+
+def test_a_task_still_running_has_no_completion_time(experiment):
+    """end_timestamp is None until post_task lands; null rather than a crash."""
+    lamella = _complete_lamella(experiment, "lam-1")
+    lamella.task_history[0].end_timestamp = None
+
+    write_completion_summary(experiment, _context(lamella, experiment))
+
+    record = _summary(lamella)["tasks_completed"][0]
+    assert record["completed_at"] is None
+    assert record["duration_s"] == 0
+
+
+def test_a_task_that_failed_is_not_reported_as_delivered(experiment):
+    """task_history holds every terminal outcome (FIB-490), so this filters on status
+    -- a failed task's outputs are not results anyone should be handed."""
+    lamella = _complete_lamella(experiment, "lam-1")
+    lamella.task_history.append(
+        AutoLamellaTaskState(
+            name="MillPolish",
+            status=AutoLamellaTaskStatus.Failed,
+            outputs={"final_sem": ["MillPolish-final-sem.tif"]},
+        )
+    )
+
+    write_completion_summary(experiment, _context(lamella, experiment))
+
+    tasks = _summary(lamella)["tasks_completed"]
+    assert "MillPolish" not in [t["name"] for t in tasks]
+
+
+def test_a_retried_task_appears_as_both_attempts(experiment):
+    """Two completions of the same task are two entries, distinguished by task_id --
+    the history is reported as it happened rather than collapsed by name."""
+    lamella = _complete_lamella(experiment, "lam-1")
+    retry = AutoLamellaTaskState(
+        name="MillTrench", status=AutoLamellaTaskStatus.Completed
+    )
+    lamella.task_history.append(retry)
+
+    write_completion_summary(experiment, _context(lamella, experiment))
+
+    tasks = _summary(lamella)["tasks_completed"]
+    trench = [t for t in tasks if t["name"] == "MillTrench"]
+    assert len(trench) == 2
+    assert trench[0]["task_id"] != trench[1]["task_id"]
+
+
+def test_it_lands_beside_the_lamella_not_in_the_experiment_root(experiment):
+    """Two finished lamellae must not overwrite each other's artifact."""
+    lam1 = _complete_lamella(experiment, "lam-1")
+    lam2 = _complete_lamella(experiment, "lam-2")
+
+    write_completion_summary(experiment, _context(lam1, experiment))
+    write_completion_summary(experiment, _context(lam2, experiment))
+
+    assert _summary(lam1)["item_name"] == lam1.name
+    assert _summary(lam2)["item_name"] == lam2.name
+    assert not os.path.exists(
+        os.path.join(experiment.path, COMPLETION_SUMMARY_FILENAME)
+    )
+
+
+def test_it_records_when_the_work_finished_not_when_the_file_was_written(experiment):
     """The event's timestamp, not now(): the two differ if a hook defers work."""
     import time
 
+    lamella = _complete_lamella(experiment, "lam-1")
     fired_at = time.time() - 3600
+
     write_completion_summary(
-        experiment,
-        HookContext(event=HookEvent.EXPERIMENT_COMPLETED, timestamp=fired_at),
+        experiment, _context(lamella, experiment, timestamp=fired_at)
     )
 
-    from datetime import datetime
-
     expected = datetime.fromtimestamp(fired_at).isoformat(timespec="seconds")
-    assert _summary(experiment)["completed_at"] == expected
+    assert _summary(lamella)["completed_at"] == expected
 
 
 def test_it_falls_back_to_the_experiment_when_the_context_is_bare(experiment):
     """A context fired without the run fields still produces an identified artifact."""
+    lamella = _complete_lamella(experiment, "lam-1")
+
     write_completion_summary(
-        experiment, HookContext(event=HookEvent.EXPERIMENT_COMPLETED)
+        experiment,
+        HookContext(event=HookEvent.ITEM_COMPLETED, item_name=lamella.name),
     )
 
-    summary = _summary(experiment)
+    summary = _summary(lamella)
     assert summary["experiment_id"] == experiment.id
     assert summary["experiment_name"] == "test-exp"
+
+
+def test_the_lamella_is_found_by_id_when_it_has_been_renamed(experiment):
+    """The id is the stable key; the petname is editable. A context in flight while
+    someone renames the lamella still resolves."""
+    lamella = _complete_lamella(experiment, "lam-1")
+    context = _context(lamella, experiment)
+    lamella.name = "renamed-by-a-user"
+
+    write_completion_summary(experiment, context)
+
+    assert _summary(lamella)["item_name"] == "renamed-by-a-user"
+
+
+def test_an_unresolvable_item_writes_nothing(experiment, caplog):
+    import logging
+
+    _complete_lamella(experiment, "lam-1")
+
+    with caplog.at_level(logging.WARNING):
+        result = write_completion_summary(
+            experiment, HookContext(event=HookEvent.ITEM_COMPLETED, item_name="ghost")
+        )
+
+    assert result is None
+    assert any("ghost" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------
@@ -109,7 +281,8 @@ def test_it_falls_back_to_the_experiment_when_the_context_is_bare(experiment):
 # ---------------------------------------------------------------------------
 
 def _manager_with_summary_hook(experiment: Experiment) -> TaskManager:
-    """Mirrors what AutoLamellaUI.setup_hooks registers."""
+    """Mirrors the registration commented out in AutoLamellaUI.setup_hooks, so the two
+    have to be changed together when it is turned back on."""
     class _NoMicroscope:
         fm = None
 
@@ -117,7 +290,7 @@ def _manager_with_summary_hook(experiment: Experiment) -> TaskManager:
     hooks.register(
         FunctionHook(
             name="completion_summary",
-            events=[HookEvent.EXPERIMENT_COMPLETED],
+            events=[HookEvent.ITEM_COMPLETED],
             callback=lambda ctx: write_completion_summary(experiment, ctx),
         )
     )
@@ -129,41 +302,48 @@ def _manager_with_summary_hook(experiment: Experiment) -> TaskManager:
     )
 
 
-def _complete_lamella(experiment: Experiment, name: str) -> Lamella:
-    lamella = Lamella(path=experiment.path, number=1, petname=name)
-    for task_name in REQUIRED_TASKS:
-        lamella.task_history.append(
-            AutoLamellaTaskState(name=task_name, status=AutoLamellaTaskStatus.Completed)
-        )
-    experiment.positions.append(lamella)
-    return lamella
-
-
-def test_finishing_the_experiment_writes_the_artifact(experiment):
+def test_finishing_a_lamella_writes_its_artifact(experiment):
     manager = _manager_with_summary_hook(experiment)
-    _complete_lamella(experiment, "lam-1")
+    lamella = _complete_lamella(experiment, "lam-1")
     manager._completed_lamella = set()  # pretend it finished during this run
 
-    manager._maybe_fire_experiment_completed()
+    manager._maybe_fire_lamella_completed(lamella, "MillUndercut")
 
-    summary = _summary(experiment)
-    assert summary["experiment_name"] == "test-exp"
-    assert summary["event"] == "experiment_completed"
+    summary = _summary(lamella)
+    assert summary["item_name"] == lamella.name
+    assert summary["event"] == "item_completed"
 
 
-def test_an_unfinished_experiment_writes_nothing(experiment):
+def test_an_abandoned_neighbour_does_not_stop_the_artifact(experiment):
+    """The reason this hangs off the item: one defective lamella must not suppress the
+    artifact for the ones that finished."""
+    from fibsem.applications.autolamella.structures import DefectType
+
     manager = _manager_with_summary_hook(experiment)
-    lamella = Lamella(path=experiment.path, number=1, petname="lam-1")
+    finished = _complete_lamella(experiment, "lam-1")
+    abandoned = _new_lamella(experiment, "lam-2")
+    abandoned.defect.state = DefectType.FAILURE
+    experiment.positions.append(abandoned)
+    manager._completed_lamella = set()
+
+    manager._maybe_fire_lamella_completed(finished, "MillUndercut")
+
+    assert _summary(finished)["item_name"] == finished.name
+
+
+def test_an_unfinished_lamella_writes_nothing(experiment):
+    manager = _manager_with_summary_hook(experiment)
+    lamella = _new_lamella(experiment, "lam-1")
     lamella.task_history.append(
         AutoLamellaTaskState(name="MillTrench", status=AutoLamellaTaskStatus.Completed)
     )
     experiment.positions.append(lamella)
     manager._snapshot_completion()
 
-    manager._maybe_fire_experiment_completed()
+    manager._maybe_fire_lamella_completed(lamella, "MillTrench")
 
     assert not os.path.exists(
-        os.path.join(experiment.path, COMPLETION_SUMMARY_FILENAME)
+        os.path.join(lamella.path, COMPLETION_SUMMARY_FILENAME)
     )
 
 
@@ -179,7 +359,7 @@ def test_a_failing_artifact_does_not_break_the_run(experiment, caplog):
     hooks.register(
         FunctionHook(
             name="completion_summary",
-            events=[HookEvent.EXPERIMENT_COMPLETED],
+            events=[HookEvent.ITEM_COMPLETED],
             callback=lambda ctx: (_ for _ in ()).throw(OSError("disk full")),
         )
     )
@@ -187,15 +367,17 @@ def test_a_failing_artifact_does_not_break_the_run(experiment, caplog):
         microscope=_NoMicroscope(), experiment=experiment,
         parent_ui=None, hook_manager=hooks,
     )
-    _complete_lamella(experiment, "lam-1")
+    lamella = _complete_lamella(experiment, "lam-1")
     manager._completed_lamella = set()
 
     with caplog.at_level(logging.ERROR):
-        manager._maybe_fire_experiment_completed()  # must not raise
+        manager._maybe_fire_lamella_completed(lamella, "MillUndercut")  # must not raise
 
     assert any("completion_summary" in r.message for r in caplog.records)
 
 
-def test_the_event_the_ui_subscribes_to_exists():
-    """Guards the wiring in setup_hooks, which tests/ui cannot construct headlessly."""
-    assert HookEvent.EXPERIMENT_COMPLETED in list(HookEvent)
+def test_the_event_the_dormant_wiring_names_still_exists():
+    """The registration in setup_hooks is commented out, so nothing type-checks the
+    event it names. This does, and fails loudly if ITEM_COMPLETED is ever renamed while
+    the wiring is asleep."""
+    assert HookEvent.ITEM_COMPLETED in list(HookEvent)

--- a/tests/autolamella/test_task_manager_completion_hooks.py
+++ b/tests/autolamella/test_task_manager_completion_hooks.py
@@ -19,6 +19,7 @@ from fibsem.applications.autolamella.structures import (
     AutoLamellaTaskState,
     AutoLamellaTaskStatus,
     AutoLamellaWorkflowConfig,
+    DefectType,
     Experiment,
     Lamella,
 )
@@ -174,6 +175,55 @@ def test_does_not_refire_for_an_already_complete_experiment(experiment, recorder
 def test_an_empty_experiment_is_not_a_completed_one(experiment, recorder):
     """all([]) is True, which would declare an experiment with no lamellae finished."""
     hook_manager, fired = recorder
+    manager = _manager(experiment, hook_manager)
+    manager._snapshot_completion()
+
+    manager._maybe_fire_experiment_completed()
+
+    assert _events(fired) == []
+
+
+def test_an_abandoned_lamella_does_not_hold_the_experiment_open(experiment, recorder):
+    """_should_skip skips a defective lamella for every remaining task, so it can never
+    satisfy the completion predicate. Counting it meant one abandoned lamella — which
+    most real sessions have — permanently prevented its experiment from completing."""
+    hook_manager, fired = recorder
+    _add_lamella(experiment, "lam-1", completed=REQUIRED_TASKS)
+    abandoned = _add_lamella(experiment, "lam-2", completed=["MillTrench"])
+    manager = _manager(experiment, hook_manager)
+    manager._snapshot_completion()
+
+    manager._maybe_fire_experiment_completed()
+    assert _events(fired) == []  # lam-2 is still expected to finish
+
+    abandoned.defect.state = DefectType.FAILURE
+    manager._maybe_fire_experiment_completed()
+
+    assert _events(fired) == ["experiment_completed"]
+
+
+def test_a_lamella_sent_for_rework_still_holds_it_open(experiment, recorder):
+    """Rework is not abandonment: that lamella is coming back."""
+    hook_manager, fired = recorder
+    _add_lamella(experiment, "lam-1", completed=REQUIRED_TASKS)
+    rework = _add_lamella(experiment, "lam-2", completed=["MillTrench"])
+    rework.defect.state = DefectType.REWORK
+    manager = _manager(experiment, hook_manager)
+    manager._snapshot_completion()
+
+    manager._maybe_fire_experiment_completed()
+
+    assert _events(fired) == []
+
+
+def test_an_experiment_where_everything_was_abandoned_is_not_complete(
+    experiment, recorder
+):
+    """Nothing was delivered, so this must not report as success — the same misreport
+    as a workflow claiming completion when every task was skipped."""
+    hook_manager, fired = recorder
+    for name in ("lam-1", "lam-2"):
+        _add_lamella(experiment, name, completed=[]).defect.state = DefectType.FAILURE
     manager = _manager(experiment, hook_manager)
     manager._snapshot_completion()
 


### PR DESCRIPTION
Two things, both found by testing the placeholder artifact from #275 against a realistic experiment rather than a perfect one.

## The completion predicate could not be satisfied in practice

`_should_skip` skips a lamella a human has marked defective for *every* remaining task, so it can never accumulate the task history that completion requires. `_all_lamella_complete` counted every position regardless. Together that meant a single abandoned lamella permanently prevented its experiment from ever reporting complete — and abandoning one is the normal case, not the exception. `EXPERIMENT_COMPLETED` was unreachable for any experiment where that had happened, which is most of them.

The two predicates now agree on the population: completion is judged over the lamellae the workflow would still act on.

- Rework is not abandonment — `is_failure` is only `DefectType.FAILURE` — so a lamella coming back still holds its experiment open.
- An experiment where *everything* was abandoned is not complete either. Nothing was delivered, and announcing success over that is the same misreport as a workflow claiming completion when every task was skipped.

## The artifact moved to the lamella

Same reasoning one level down: if most experiments never complete, hanging the artifact off the experiment means it is almost never written. A lamella is the unit that gets delivered to a TEM, so `ITEM_COMPLETED` is both the more frequent and the more useful trigger — it fires the moment that lamella is finished, whatever happens to its neighbours.

It now writes into the lamella's own directory, since two finished lamellae would otherwise overwrite each other, and it carries the work that was actually done:

```json
{
  "experiment_id": "00bfed45-…",
  "experiment_name": "cryo-session-12",
  "item_id": "f0c5f560-…",
  "item_name": "lam-01-brave-tiger",
  "completed_at": "2026-08-04T14:57:17",
  "event": "item_completed",
  "tasks_completed": [
    {
      "name": "MillTrench",
      "task_id": "72644415-…",
      "completed_at": "2026-08-04T15:02:18",
      "duration_s": 300.5,
      "outputs": {
        "start_sem": ["MillTrench-start-sem.tif"],
        "final_fib": ["MillTrench-final-fib.tif"]
      }
    }
  ]
}
```

`outputs` is `AutoLamellaTaskState.outputs` (FIB-324), keeping the record's own vocabulary rather than inventing a synonym for it. Paths stay relative to the lamella directory — which is where the artifact itself lives, so they resolve as-is for whoever receives the folder. Reported per task rather than merged into one map, which would lose provenance and collide on shared role names when two milling tasks both write `final_sem`.

Status-filtered throughout, so a failed task's outputs are not handed over as results. A retried task appears as both attempts, distinguished by `task_id`.

## Not enabled

The registration in `setup_hooks` is commented out, with a note giving the reason. `completion-summary.json` is still a placeholder for the real artifacts (the PDF and the overview PNG), and shipping it as-is would start writing a throwaway file into every user's lamella directories. The writer and the trigger are both tested, so the wiring stays exercised while it is dormant, and turning it on is uncommenting two imports and one registration.

## Still open under FIB-461

The end-of-run artifact — the one covering the lamellae that *didn't* finish, which is when someone most wants to look. `WORKFLOW_COMPLETED` already fires on every non-cancelled run and carries experiment identity and task counts, so the trigger is there; the content is the work. Cancelled runs are the same question.

`save_final_overview_image` in `tools/reporting.py` is exactly the overview PNG and still has zero callers, but wiring it needs the headless entry point from FIB-460.

## Testing

`tests/autolamella/test_completion_artifacts.py` — 17 tests: identity and timestamp round-trip, the outputs each task left behind, durations, a still-running task's null completion time, per-lamella isolation, id-first lookup surviving a rename, an unresolvable item, a retried task as two entries, and a throwing writer leaving the run intact.

`tests/autolamella/test_task_manager_completion_hooks.py` — 3 more on the predicate: an abandoned lamella no longer holds the experiment open, a rework one still does, and an all-abandoned experiment stays silent.

2344 tests pass.

The predicate fix is the part that matters for main; the artifact is groundwork behind a comment.
