### PR TITLE
[fibsem] Move the software versions out of the experiment reference

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -1368,16 +1368,16 @@ class Experiment:
         an experiment, TaskManager calls it when it takes one to run, and a script
         driving the microscope directly calls it itself.
         """
-        import fibsem
         from fibsem.utils import _register_metadata
 
         _register_metadata(
             microscope=microscope,
             application_software="autolamella",
-            application_software_version=fibsem.__version__,
             experiment_id=self.id,
             experiment_name=self.name,
-            experiment_method="null",
+            # No application_software_version: AutoLamella ships inside fibsem and has
+            # no version of its own. Passing fibsem.__version__ only made the two
+            # fields tautologically equal. See FIB-448.
         )
 
     def save_protocol(self) -> None:

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -1375,9 +1375,6 @@ class Experiment:
             application_software="autolamella",
             experiment_id=self.id,
             experiment_name=self.name,
-            # No application_software_version: AutoLamella ships inside fibsem and has
-            # no version of its own. Passing fibsem.__version__ only made the two
-            # fields tautologically equal. See FIB-448.
         )
 
     def save_protocol(self) -> None:

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -11,8 +11,10 @@ import fibsem
 
 # Documentation for a human reading a file, not a parsing switch -- from_dict does not
 # branch on it, and additive changes are detected from field presence instead (FIB-445
-# D3). Bumped to v4 when FibsemExperimentRef gained `name` and `id` became the UUID.
-METADATA_VERSION = "v4"
+# D3). Bumped to v4 when FibsemExperimentRef gained `name` and `id` became the UUID;
+# to v5 when it dropped its duplicates of the application/version fields, which
+# SystemInfo owns (FIB-448). Those keys are still present in v4-and-earlier files.
+METADATA_VERSION = "v5"
 # What an unversioned file is. Absent means written before versioning existed, i.e.
 # older than v1 -- not "current", which is what defaulting to METADATA_VERSION claimed.
 UNVERSIONED_METADATA = "v0"

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -13,7 +13,8 @@ import fibsem
 # branch on it, and additive changes are detected from field presence instead (FIB-445
 # D3). Bumped to v4 when FibsemExperimentRef gained `name` and `id` became the UUID;
 # to v5 when it dropped its duplicates of the application/version fields, which
-# SystemInfo owns (FIB-448). Those keys are still present in v4-and-earlier files.
+# SystemInfo owns, and when `application_version` went entirely -- it was null in every
+# file ever written (FIB-448). Those keys are still present in v4-and-earlier files.
 METADATA_VERSION = "v5"
 # What an unversioned file is. Absent means written before versioning existed, i.e.
 # older than v1 -- not "current", which is what defaulting to METADATA_VERSION claimed.

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1821,53 +1821,51 @@ class FibsemExperimentRef:
 
     The deference rule applies here because a richer record exists to defer to. It
     does not apply to every embedded copy -- see ``FibsemUser``.
+
+    **Identity only.** Which experiment, and when. What software was running is a
+    property of the running system, not of an experiment, so it lives on
+    ``SystemInfo`` and only there (FIB-445 D1, FIB-448). This carried duplicates of
+    it until v5.
     """
 
     # Experiment.id, a UUID -- stable, the join key. Held the experiment *name* up to
     # and including v0.5.2; a file whose `name` is absent is from that era and its `id`
     # is a name. See FIB-446.
+    # Experiment.id, a UUID -- stable, the join key. Held the experiment *name* up to
+    # and including v0.5.2; a file whose `name` is absent is from that era and its `id`
+    # is a name. See FIB-446.
     id: Optional[str] = None
     name: Optional[str] = None
-    method: Optional[str] = None
     # default_factory, not a plain default: a plain default is evaluated once at
     # class definition, so every experiment recorded the interpreter's import
     # time rather than its own creation time.
     date: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
-    application: str = "fibsemOS"
-    fibsem_version: str = fibsem.__version__
-    application_version: Optional[str] = None
-    # The commit actually running, when installed from a source checkout. None
-    # for a wheel install.
-    fibsem_revision: Optional[str] = field(default_factory=get_revision)
 
     def to_dict(self) -> dict:
         """Converts to a dictionary."""
         return {
             "id": self.id,
             "name": self.name,
-            "method": self.method,
             "date": self.date,
-            "application": self.application,
-            "fibsem_version": self.fibsem_version,
-            "application_version": self.application_version,
-            "fibsem_revision": self.fibsem_revision,
         }
 
     @staticmethod
     def from_dict(settings: dict) -> "FibsemExperimentRef":
-        """Converts from a dictionary."""
+        """Converts from a dictionary.
+
+        Files written before v5 also carry `application`, `application_version`,
+        `fibsem_version`, `fibsem_revision` and `method` here. They are not read:
+        the first four now live on ``SystemInfo``, which is where a reader should
+        look, and `method` never held anything but the string "null". The values
+        are still in those files if anyone needs to dig them out by hand.
+        """
         return FibsemExperimentRef(
             id=settings.get("id", "Unknown"),
             # Absent in files written before v0.5.3, where `id` holds the name. Left
             # as None rather than backfilled from `id`, so a reader can tell the two
             # eras apart instead of being handed a name that claims to be an ID.
             name=settings.get("name"),
-            method=settings.get("method", "Unknown"),
             date=settings.get("date", "Unknown"),
-            application=settings.get("application", "fibsemOS"),
-            fibsem_version=settings.get("fibsem_version", fibsem.__version__),
-            application_version=settings.get("application_version", None),
-            fibsem_revision=settings.get("fibsem_revision") or get_revision(),
         )
 
 

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1647,14 +1647,20 @@ class SystemInfo:
     aggregation joins on, and the only field that distinguishes two of the same
     model in one facility.
 
-    The version fields are duplicated on ``FibsemExperimentRef`` today; FIB-448
-    removes them from there. Software version is a property of the running system,
-    not of an experiment.
+    The version fields were duplicated on ``FibsemExperimentRef`` until v5, which
+    removed them from there (FIB-448). What software is running is a property of
+    the running system, not of an experiment.
 
     An experiment spanning a software upgrade will therefore disagree with its own
     images -- the experiment record captured v0.5.1 at creation, day-2 images say
     v0.5.2 here. That is two true facts, not a duplication bug: it says the run
     spanned an upgrade, which is worth knowing.
+
+    There is deliberately no ``application_version``. It existed up to v4 and was
+    never once populated: an application shipped inside fibsem has no version of its
+    own, and ``fibsem_revision`` already pins the exact commit doing the work. An
+    out-of-tree application wanting to stamp its own version needs a public
+    registration API first -- the field can come back alongside one.
     """
 
     name: str
@@ -1666,7 +1672,6 @@ class SystemInfo:
     software_version: str
     fibsem_version: str = fibsem.__version__
     application: Optional[str] = None
-    application_version: Optional[str] = None
     # The commit actually running, when installed from a source checkout. None
     # for a wheel install. default_factory, not a plain default, so the lookup
     # happens on first use rather than at import of this module.
@@ -1683,7 +1688,6 @@ class SystemInfo:
             "software_version": self.software_version,
             "fibsem_version": self.fibsem_version,
             "application": self.application,
-            "application_version": self.application_version,
             "fibsem_revision": self.fibsem_revision,
         }
 
@@ -1699,7 +1703,7 @@ class SystemInfo:
             software_version=settings.get("software_version", "Unknown"),
             fibsem_version=settings.get("fibsem_version", fibsem.__version__),
             application=settings.get("application", None),
-            application_version=settings.get("application_version", None),
+            # `application_version` is not read: files up to v4 carry it, always null.
             # `or`, not a .get() default: settings.get(k, get_revision()) would
             # evaluate the lookup eagerly on every call.
             fibsem_revision=settings.get("fibsem_revision") or get_revision(),
@@ -1831,9 +1835,6 @@ class FibsemExperimentRef:
     # Experiment.id, a UUID -- stable, the join key. Held the experiment *name* up to
     # and including v0.5.2; a file whose `name` is absent is from that era and its `id`
     # is a name. See FIB-446.
-    # Experiment.id, a UUID -- stable, the join key. Held the experiment *name* up to
-    # and including v0.5.2; a file whose `name` is absent is from that era and its `id`
-    # is a name. See FIB-446.
     id: Optional[str] = None
     name: Optional[str] = None
     # default_factory, not a plain default: a plain default is evaluated once at
@@ -1854,10 +1855,11 @@ class FibsemExperimentRef:
         """Converts from a dictionary.
 
         Files written before v5 also carry `application`, `application_version`,
-        `fibsem_version`, `fibsem_revision` and `method` here. They are not read:
-        the first four now live on ``SystemInfo``, which is where a reader should
-        look, and `method` never held anything but the string "null". The values
-        are still in those files if anyone needs to dig them out by hand.
+        `fibsem_version`, `fibsem_revision` and `method` here. None are read.
+        `application`, `fibsem_version` and `fibsem_revision` live on ``SystemInfo``,
+        which is where a reader should look; `application_version` was never
+        populated anywhere; `method` never held anything but the string "null". The
+        values are still in those files if anyone needs to dig them out by hand.
         """
         return FibsemExperimentRef(
             id=settings.get("id", "Unknown"),

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -497,29 +497,38 @@ def save_positions(positions: list, path: str = None, overwrite: bool = False) -
 # TODO: re-think this, dont like the pop ups
 def _register_metadata(microscope: 'FibsemMicroscope',
                        application_software: str,
-                       application_software_version: str,
                        experiment_name: str,
-                       experiment_method: str,
-                       experiment_id: Optional[str] = None) -> None:
-    """Stamp user and experiment identity onto everything ``microscope`` acquires.
+                       experiment_id: Optional[str] = None,
+                       application_software_version: Optional[str] = None) -> None:
+    """Stamp user, experiment and application identity onto what ``microscope`` acquires.
 
     ``experiment_id`` is the stable join key and should always be supplied; it is
     optional only so a caller that has no ID yet still registers something. It used
     to be omitted entirely and ``id`` carried the name, which meant a rename silently
     broke the link from every image written before it. See FIB-446.
+
+    Which application is running goes on ``SystemInfo``, not on the experiment
+    reference. It is a property of the running system, and putting it in one place
+    is what lets the reference carry identity only (FIB-445 D1, FIB-448).
+
+    ``application_software_version`` is genuinely optional: an application shipped
+    inside fibsem has no version of its own, and passing ``fibsem.__version__`` for
+    it only made the two fields tautologically equal. Out-of-tree applications built
+    on fibsem do have one, which is why the field stays.
     """
-    import fibsem
     from fibsem.structures import FibsemExperimentRef, FibsemUser
 
-    user = FibsemUser.from_environment()
-
-    experiment = FibsemExperimentRef(
+    microscope.user = FibsemUser.from_environment()
+    microscope.experiment = FibsemExperimentRef(
         id=experiment_id,
         name=experiment_name,
-        method=experiment_method,
-        application=application_software, 
-        fibsem_version=fibsem.__version__,
-        application_version=application_software_version,
     )
-    microscope.user = user
-    microscope.experiment = experiment
+
+    # info carries fibsem_version and fibsem_revision already, set when it is built.
+    # Reached defensively at both levels: a stand-in microscope (a test double, or a
+    # caller wiring up a run without hardware) may have neither attribute, and
+    # failing to record the application is not worth an AttributeError.
+    info = getattr(getattr(microscope, "system", None), "info", None)
+    if info is not None:
+        info.application = application_software
+        info.application_version = application_software_version

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -498,8 +498,7 @@ def save_positions(positions: list, path: str = None, overwrite: bool = False) -
 def _register_metadata(microscope: 'FibsemMicroscope',
                        application_software: str,
                        experiment_name: str,
-                       experiment_id: Optional[str] = None,
-                       application_software_version: Optional[str] = None) -> None:
+                       experiment_id: Optional[str] = None) -> None:
     """Stamp user, experiment and application identity onto what ``microscope`` acquires.
 
     ``experiment_id`` is the stable join key and should always be supplied; it is
@@ -511,10 +510,10 @@ def _register_metadata(microscope: 'FibsemMicroscope',
     reference. It is a property of the running system, and putting it in one place
     is what lets the reference carry identity only (FIB-445 D1, FIB-448).
 
-    ``application_software_version`` is genuinely optional: an application shipped
-    inside fibsem has no version of its own, and passing ``fibsem.__version__`` for
-    it only made the two fields tautologically equal. Out-of-tree applications built
-    on fibsem do have one, which is why the field stays.
+    There is no application *version* to record. An application shipped inside
+    fibsem has no version of its own -- passing ``fibsem.__version__`` for it only
+    made two fields tautologically equal -- and ``info.fibsem_revision`` already
+    pins the exact commit doing the work. See FIB-448.
     """
     from fibsem.structures import FibsemExperimentRef, FibsemUser
 
@@ -531,4 +530,3 @@ def _register_metadata(microscope: 'FibsemMicroscope',
     info = getattr(getattr(microscope, "system", None), "info", None)
     if info is not None:
         info.application = application_software
-        info.application_version = application_software_version

--- a/tests/autolamella/test_experiment_metadata_registration.py
+++ b/tests/autolamella/test_experiment_metadata_registration.py
@@ -50,7 +50,9 @@ def test_register_metadata_stamps_the_experiment_onto_the_microscope(
     # The UUID is the join key; the name is the display string (FIB-446).
     assert microscope.experiment.id == experiment.id
     assert microscope.experiment.name == "test-experiment"
-    assert microscope.experiment.application == "autolamella"
+    # Which application is running lives on SystemInfo, not the experiment reference:
+    # it is a property of the running system, not of an experiment. See FIB-448.
+    assert microscope.system.info.application == "autolamella"
 
 
 def test_creating_a_task_manager_registers_without_a_gui(

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -477,11 +477,20 @@ def test_fibsem_image_load_sets_filepath(tmp_path):
 # fibsem_revision — the running commit, recorded alongside fibsem_version
 
 
-def test_experiment_and_system_info_carry_fibsem_revision():
+def test_only_system_info_carries_the_software_versions():
+    """SystemInfo owns what software is running; the experiment reference carries
+    identity only. They both did until FIB-448, with no rule about which won if
+    they disagreed -- and they could, being built at different moments."""
     from fibsem.structures import FibsemExperimentRef, SystemInfo
 
-    assert "fibsem_revision" in FibsemExperimentRef().to_dict()
-    assert "fibsem_revision" in SystemInfo.from_dict({}).to_dict()
+    ref = FibsemExperimentRef().to_dict()
+    info = SystemInfo.from_dict({}).to_dict()
+
+    for key in ("fibsem_version", "fibsem_revision", "application", "application_version"):
+        assert key in info, f"SystemInfo should own {key}"
+        assert key not in ref, f"the experiment reference should not duplicate {key}"
+
+    assert set(ref) == {"id", "name", "date"}
 
 
 def test_metadata_from_dict_accepts_pre_change_files():
@@ -496,9 +505,12 @@ def test_metadata_from_dict_accepts_pre_change_files():
         "fibsem_version": "0.5.1",
         "application_version": "0.5.1",
     }
+    # Keys this build no longer reads must not stop the file loading. The versions
+    # are still in the file; a reader wanting them looks at system.info, or at the
+    # raw dict for a file old enough to lack one. See FIB-448.
     experiment = FibsemExperimentRef.from_dict(legacy_experiment)
     assert experiment.id == "exp-1"
-    assert experiment.fibsem_version == "0.5.1"
+    assert experiment.date == 1700000000.0
 
     legacy_info = {"name": "Test", "manufacturer": "Demo", "fibsem_version": "0.5.1"}
     info = SystemInfo.from_dict(legacy_info)
@@ -507,19 +519,13 @@ def test_metadata_from_dict_accepts_pre_change_files():
 
 
 def test_metadata_round_trips_fibsem_revision():
-    from fibsem.structures import FibsemExperimentRef, SystemInfo
-
-    experiment = FibsemExperimentRef.from_dict(
-        {"id": "exp-1", "fibsem_revision": "v0.5.1-48-g4cd11d9c"}
-    )
-    assert experiment.fibsem_revision == "v0.5.1-48-g4cd11d9c"
-    assert (
-        FibsemExperimentRef.from_dict(experiment.to_dict()).fibsem_revision
-        == "v0.5.1-48-g4cd11d9c"
-    )
+    from fibsem.structures import SystemInfo
 
     info = SystemInfo.from_dict({"fibsem_revision": "v0.5.1-48-g4cd11d9c"})
     assert info.fibsem_revision == "v0.5.1-48-g4cd11d9c"
+    assert (
+        SystemInfo.from_dict(info.to_dict()).fibsem_revision == "v0.5.1-48-g4cd11d9c"
+    )
 
 
 def test_experiment_date_is_creation_time_not_import_time():

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -486,11 +486,16 @@ def test_only_system_info_carries_the_software_versions():
     ref = FibsemExperimentRef().to_dict()
     info = SystemInfo.from_dict({}).to_dict()
 
-    for key in ("fibsem_version", "fibsem_revision", "application", "application_version"):
+    for key in ("fibsem_version", "fibsem_revision", "application"):
         assert key in info, f"SystemInfo should own {key}"
         assert key not in ref, f"the experiment reference should not duplicate {key}"
 
     assert set(ref) == {"id", "name", "date"}
+    # Neither, since v5: it was declared in both and populated in neither. An
+    # application inside fibsem has no version of its own, and fibsem_revision
+    # already pins the commit doing the work.
+    assert "application_version" not in info
+    assert "application_version" not in ref
 
 
 def test_metadata_from_dict_accepts_pre_change_files():
@@ -512,7 +517,15 @@ def test_metadata_from_dict_accepts_pre_change_files():
     assert experiment.id == "exp-1"
     assert experiment.date == 1700000000.0
 
-    legacy_info = {"name": "Test", "manufacturer": "Demo", "fibsem_version": "0.5.1"}
+    # `application_version` is here because SystemInfo declared it up to v4. It is
+    # constructed field by field, so a key it no longer knows is ignored rather than
+    # raising -- which is what makes dropping the field safe for existing files.
+    legacy_info = {
+        "name": "Test",
+        "manufacturer": "Demo",
+        "fibsem_version": "0.5.1",
+        "application_version": "0.5.1",
+    }
     info = SystemInfo.from_dict(legacy_info)
     assert info.name == "Test"
     assert info.fibsem_version == "0.5.1"

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -296,12 +296,18 @@ def test_repeated_calls_fork_once(monkeypatch):
 
 
 def test_metadata_construction_forks_once(monkeypatch):
-    """FibsemImageMetadata builds a FibsemExperimentRef per acquired image.
+    """Reading many images must not mean one git fork per image.
 
-    Without the cache on _describe that would be one git fork per image, which is
-    the regression this test exists to prevent.
+    SystemInfo defaults fibsem_revision from get_revision(), and from_dict falls back
+    to it for any file that predates the field -- so loading a directory of images
+    calls it once per image. Without the cache on _describe that is a subprocess each
+    time, which is the regression this test exists to prevent.
+
+    Until FIB-448 the motivating case was FibsemExperimentRef, which carried its own
+    copy of the revision and was built per acquired image. That duplicate is gone;
+    SystemInfo owns the field now, and the invariant is unchanged.
     """
-    from fibsem.structures import FibsemExperimentRef
+    from fibsem.structures import SystemInfo
 
     calls = []
 
@@ -311,10 +317,10 @@ def test_metadata_construction_forks_once(monkeypatch):
 
     monkeypatch.setattr(versioning, "_run_git", _count)
 
-    experiments = [FibsemExperimentRef() for _ in range(50)]
+    infos = [SystemInfo.from_dict({}) for _ in range(50)]
 
     assert len(calls) == 1
-    assert all(e.fibsem_revision == "v0.5.1-48-g4cd11d9c" for e in experiments)
+    assert all(i.fibsem_revision == "v0.5.1-48-g4cd11d9c" for i in infos)
 
 
 # --- logging ---------------------------------------------------------------


### PR DESCRIPTION
Closes FIB-448. Implements the ownership rule from FIB-445 D1: `SystemInfo` owns what software is running, `FibsemExperimentRef` carries identity only.

## Not the pure deletion the issue assumed

Measured what was actually in each place before removing anything:

| field | `SystemInfo` | `FibsemExperimentRef` | |
|---|---|---|---|
| `fibsem_version` | populated | same value | true duplicate |
| `fibsem_revision` | populated | same value | true duplicate |
| `application` | **`None`** | `"autolamella"` | **the only home** |
| `application_version` | `None` | tautological | useless in both |

`application` is the one that mattered. `SystemInfo` has the field but **nothing ever populated it**, so deleting it from the reference would have lost the fact entirely — one test was reading it, which is how it surfaced. `_register_metadata` now writes it where it belongs. That's the real work; the deletion on its own would have been a regression.

## `application_version` was tautological

The only caller passed `fibsem.__version__` for it, so it always equalled `fibsem_version`. It's now genuinely optional and AutoLamella passes nothing — an application shipped *inside* fibsem has no version of its own. The field stays because out-of-tree applications built on fibsem do have one.

## `method` dropped

Hardcoded to the string `"null"` at the only call site, and never held anything else. The `AutoLamellaMethod` it once mirrored survives only in the legacy protocol-conversion path; the task protocol has no method concept. If one returns it comes back deliberately.

## Compatibility

`METADATA_VERSION` → **v5**. Files written earlier still load — `from_dict` simply doesn't read the keys it no longer owns, and the values remain in those files. A reader wanting the versions looks at `system.info`.

I checked that `system` is actually populated on the acquire path before relying on it (it is, verified on the simulator), since otherwise moving the fields there would have lost them for images without it.

## One bug I introduced and caught

First version reached `microscope.system.info` with a guard on `info` but not on `system` — which broke 10 hook tests using a stub microscope that has neither. Now defensive at both levels: a stand-in microscope may have no system, and failing to record the application isn't worth an `AttributeError` mid-run.

## Tests

Four existing tests asserted the old shape and were updated rather than deleted:

- the duplication test now asserts the *opposite* invariant — `SystemInfo` has all four, the reference has none, and the reference's keys are exactly `{id, name, date}`
- the legacy-compat test keeps its point (an old file still loads) with the assertion moved off a field that's no longer surfaced
- `test_metadata_construction_forks_once` guarded against one git fork per acquired image via the reference's revision factory. That path is now structurally gone, so it guards the remaining one — `SystemInfo.from_dict` when *loading* a directory of images.

Full suite: 2324 passed, 24 skipped.
