### PR TITLE
[autolamella] Rebuild the workflow timeline as the queue changes (FIB-475)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -180,7 +180,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self._toasts_enabled = self._preferences.display.toasts_enabled
         self._border_enabled = self._preferences.display.border_enabled
         self.dev_mode = self._preferences.display.dev_mode
-        self._workflow_timeline_initialized = False
 
         # create menus, status bar, and tabs
         self._create_menu_bar()
@@ -1532,13 +1531,17 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if status_bar_msg is not None and self.status_bar is not None:
             self.status_bar.showMessage(status_bar_msg)
 
+        # Queue edited between tasks (added to, reordered, item removed) — no task
+        # lifecycle to hang it off, so refresh the timeline on its own.
+        queue_changed = info.get("queue_changed", None)
+        if queue_changed is not None:
+            self.workflow_timeline.refresh_queue(queue_changed.get("queue_items", []))
+
         status_msg = info.get("status", None)
         if status_msg is not None:
-            _is_start = not self._workflow_timeline_initialized
-            queue_items = status_msg.get("queue_items", [])
-            if _is_start and queue_items:
-                self.workflow_timeline.set_workflow(queue_items)
-                self._workflow_timeline_initialized = True
+            # No build-once guard: update_from_status reconciles rows against the
+            # snapshot by WorkItem id, so first paint and every later change go
+            # through the same path.
             self.workflow_timeline.update_from_status(status_msg)
 
             task_name = status_msg.get("task_name", "Unknown Task")
@@ -1716,7 +1719,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def _on_workflow_finished(self, cancelled: bool = False):
         """Handle workflow finished signal."""
-        self._workflow_timeline_initialized = False
+        # The next run's items carry new ids, so the timeline rebuilds itself on
+        # its first status update — nothing to reset here.
         # Resolve any outer row left in ACTIVE state (e.g. if workflow was cancelled)
         self.workflow_timeline.finish_current_step(failed=cancelled)
         self.workflow_timeline.clear_steps()

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -219,6 +219,24 @@ class TaskManager:
     def is_stopped(self) -> bool:
         return self._stop_event.is_set()
 
+    def notify_queue_changed(self) -> None:
+        """Tell the UI the queue's contents changed, outside the task lifecycle.
+
+        Status updates only fire when a task starts, finishes or is skipped, so
+        an edit made between two tasks would otherwise stay invisible until the
+        next one began. Routing it through the same signal keeps the UI's view
+        of the queue single-sourced, and makes an edit from the worker thread
+        (a script, say) as safe as one from the UI thread.
+        """
+        if self.parent_ui is None:
+            return
+        self.parent_ui.workflow_update_signal.emit({
+            "queue_changed": {
+                "queue_items": self.queue.items,  # thread-safe snapshot
+                "version": self.queue.version,
+            }
+        })
+
     def hook_run_context(self) -> dict:
         """The fields every hook event from this run carries: which experiment, and
         how much of the queue is left.

--- a/fibsem/ui/widgets/workflow_timeline_widget.py
+++ b/fibsem/ui/widgets/workflow_timeline_widget.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from PyQt5.QtCore import Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import QColor, QPainter
@@ -58,8 +58,8 @@ def _queue_status_to_step_status(s) -> "StepStatus":
         AutoLamellaTaskStatus.Failed:     StepStatus.FAILED,
         AutoLamellaTaskStatus.Skipped:    StepStatus.SKIPPED,
         AutoLamellaTaskStatus.Cancelled:  StepStatus.CANCELLED,
-        # Removed reuses the skipped look (grey, struck through) for now; it gets
-        # its own treatment when the timeline becomes queue-editable.
+        # Removed items are filtered out before they reach the timeline; mapped
+        # anyway so any other caller gets the struck-through look, not a crash.
         AutoLamellaTaskStatus.Removed:    StepStatus.SKIPPED,
     }.get(s, StepStatus.PENDING)  # unknown status must never crash the timeline
 
@@ -163,6 +163,14 @@ class _OuterRow(QWidget):
         self._inner_rows: List[_InnerStepRow] = []
         self._setup_ui(step, is_last)
 
+    def set_index(self, index: int) -> None:
+        """Update the index reported by :attr:`clicked`, after a reorder."""
+        self._index = index
+
+    def set_is_last(self, is_last: bool) -> None:
+        """Show or hide the connector line — the last row has nothing to join to."""
+        self._line.setVisible(not is_last)
+
     def _setup_ui(self, step: TimelineStep, is_last: bool) -> None:
         root = QHBoxLayout(self)
         root.setContentsMargins(8, 0, 8, 0)
@@ -179,13 +187,16 @@ class _OuterRow(QWidget):
         self._dot = _DotWidget(_status_color(step.status))
         left_layout.addWidget(self._dot, 0, Qt.AlignHCenter)
 
-        if not is_last:
-            line = QFrame()
-            line.setFrameShape(QFrame.VLine)
-            line.setFixedWidth(_LINE_W)
-            line.setStyleSheet(f"background: {_LINE_COLOR}; border: none;")
-            line.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
-            left_layout.addWidget(line, 1, Qt.AlignHCenter)
+        # Always built, shown or hidden by position: a row can become (or stop
+        # being) the last one when the queue is reordered. A hidden widget is
+        # empty to the layout, so this matches never creating it.
+        self._line = QFrame()
+        self._line.setFrameShape(QFrame.VLine)
+        self._line.setFixedWidth(_LINE_W)
+        self._line.setStyleSheet(f"background: {_LINE_COLOR}; border: none;")
+        self._line.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
+        self._line.setVisible(not is_last)
+        left_layout.addWidget(self._line, 1, Qt.AlignHCenter)
 
         root.addWidget(left)
 
@@ -208,6 +219,7 @@ class _OuterRow(QWidget):
         right.addWidget(self._subtitle)
 
         # Error label — shown on failed rows
+        self._error_msg = ""
         self._error_label = QLabel()
         self._error_label.setStyleSheet(f"color: {_DOT_FAILED}; font-size: 11px;")
         self._error_label.setWordWrap(True)
@@ -235,15 +247,24 @@ class _OuterRow(QWidget):
         self._label.setFont(f)
         self._subtitle.setText(step.subtitle)
         self._subtitle.setVisible(bool(step.subtitle))
-        # Clear error on refresh — errors are set separately via set_error()
-        self._error_label.setVisible(False)
+        # The timeline refreshes every row on every update, so an error has to
+        # survive a refresh or it would vanish the moment the next task starts.
+        # It belongs to a failed row, so a row that is no longer failed (a
+        # re-run, say) drops it.
+        if step.status is not StepStatus.FAILED:
+            self._error_msg = ""
+        self._error_label.setText(self._error_msg)
+        self._error_label.setVisible(bool(self._error_msg))
 
     def set_error(self, msg: str) -> None:
         """Show an error message below the subtitle."""
+        self._error_msg = msg
         self._error_label.setText(msg)
         self._error_label.setVisible(bool(msg))
 
     def set_selected(self, selected: bool) -> None:
+        if selected == self._selected:
+            return
         self._selected = selected
         self.setStyleSheet(f"background: {_SELECTED_BG if selected else 'transparent'};")
 
@@ -282,6 +303,8 @@ class WorkflowTimelineWidget(QWidget):
         super().__init__(parent)
         self._steps: List[TimelineStep] = []
         self._rows: List[_OuterRow] = []
+        self._keys: List[str] = []
+        self._selected_key: Optional[str] = None
         self._selected_index: Optional[int] = None
         self._setup_ui()
 
@@ -309,12 +332,84 @@ class WorkflowTimelineWidget(QWidget):
 
     # ── Public API ────────────────────────────────────────────────────────
     def set_steps(self, steps: List[TimelineStep]) -> None:
+        """Replace the timeline wholesale. Rows are keyed by position."""
         self.clear()
-        self._steps = list(steps)
-        for i, step in enumerate(self._steps):
-            row = _OuterRow(step, i, is_last=(i == len(self._steps) - 1))
-            row.clicked.connect(self._on_row_clicked)
-            self._rows.append(row)
+        self.sync_steps([str(i) for i in range(len(steps))], steps)
+
+    def sync_steps(self, keys: List[str], steps: List[TimelineStep]) -> None:
+        """Reconcile the rows against *keys*, reusing the widgets already built.
+
+        Rows are matched by key, so a row keeps its identity — and with it its
+        inner step list, error text and subtitle — across an insertion, a
+        removal or a reorder.
+
+        Only ``status`` and ``label`` are taken from *steps* for a row that
+        already exists. Subtitles are written by the caller as the run
+        progresses (elapsed time, completion time, skip reason) and would be
+        wiped if every sync rebuilt them from scratch.
+        """
+        by_key: Dict[str, _OuterRow] = dict(zip(self._keys, self._rows))
+        step_by_key: Dict[str, TimelineStep] = dict(zip(self._keys, self._steps))
+
+        for key in self._keys:
+            if key not in keys:
+                row = by_key.pop(key)
+                step_by_key.pop(key, None)
+                self._contents_layout.removeWidget(row)
+                # Unparent before deleting: deleteLater() does not run until the
+                # event loop comes back round, and until it does the row keeps
+                # its last geometry and paints over whatever moved up into it.
+                row.setParent(None)
+                row.deleteLater()
+
+        new_steps: List[TimelineStep] = []
+        new_rows: List[_OuterRow] = []
+        for i, (key, step) in enumerate(zip(keys, steps)):
+            row = by_key.get(key)
+            if row is None:
+                row = _OuterRow(step, i, is_last=False)
+                row.clicked.connect(self._on_row_clicked)
+                new_steps.append(step)
+            else:
+                kept = step_by_key[key]
+                kept.label = step.label
+                kept.status = step.status
+                new_steps.append(kept)
+            new_rows.append(row)
+
+        reordered = self._keys != keys
+        self._keys = list(keys)
+        self._steps = new_steps
+        self._rows = new_rows
+
+        if reordered:
+            self._relayout()
+
+        last = len(self._rows) - 1
+        for i, row in enumerate(self._rows):
+            row.set_index(i)
+            row.set_is_last(i == last)
+            row.refresh(self._steps[i])
+
+        # Selection is held by key so it follows its row rather than staying
+        # behind on whatever moved into that position.
+        self._selected_index = (
+            self._keys.index(self._selected_key)
+            if self._selected_key in self._keys else None
+        )
+        for i, row in enumerate(self._rows):
+            row.set_selected(i == self._selected_index)
+
+    def _relayout(self) -> None:
+        """Re-add every row to the layout in ``self._rows`` order.
+
+        Taking a widget out of a layout does not delete or reparent it, and the
+        rows go straight back in before the event loop runs again, so nothing
+        the rows own (inner steps in particular) is disturbed.
+        """
+        while self._contents_layout.count():
+            self._contents_layout.takeAt(0)
+        for row in self._rows:
             self._contents_layout.addWidget(row)
         self._contents_layout.addStretch(1)
 
@@ -337,12 +432,15 @@ class WorkflowTimelineWidget(QWidget):
         self._steps.clear()
         for row in self._rows:
             self._contents_layout.removeWidget(row)
+            row.setParent(None)  # see sync_steps: it paints until the loop runs
             row.deleteLater()
         self._rows.clear()
+        self._keys.clear()
         item = self._contents_layout.takeAt(0)
         while item:
             item = self._contents_layout.takeAt(0)
         self._selected_index = None
+        self._selected_key = None
 
     # ── Internal ──────────────────────────────────────────────────────────
     def _on_row_clicked(self, index: int) -> None:
@@ -351,6 +449,7 @@ class WorkflowTimelineWidget(QWidget):
         if self._selected_index is not None and self._selected_index < len(self._rows):
             self._rows[self._selected_index].set_selected(False)
         self._selected_index = index
+        self._selected_key = self._keys[index] if index < len(self._keys) else None
         self._rows[index].set_selected(True)
         self.step_selected.emit(index)
 
@@ -373,7 +472,11 @@ class WorkflowProgressWidget(QWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self._items: list = []  # List[WorkItem] from queue snapshot
+        self._items: list = []  # visible WorkItems from the last queue snapshot
+        # The active row is held by WorkItem id; _outer_index is derived from it
+        # on every sync, so it survives rows being added, removed or reordered
+        # above it.
+        self._active_id: Optional[str] = None
         self._outer_index: int = -1
         self._inner_finished: bool = False
         self._active_start_time: Optional[float] = None
@@ -397,19 +500,22 @@ class WorkflowProgressWidget(QWidget):
 
     # ── Public API ────────────────────────────────────────────────────────
     def set_workflow(self, items: list) -> None:
-        """Pre-populate the outer timeline from queue items (WorkItem instances)."""
-        self._items = list(items)
-        self._outer_index = -1
-        steps = [
-            TimelineStep(
-                label=item.lamella_name,
-                subtitle=item.task_name,
-                status=_queue_status_to_step_status(item.status),
-            )
-            for item in self._items
-        ]
-        self._outer.set_steps(steps)
-        self._update_header(self._items)
+        """Populate the outer timeline from queue items, starting fresh.
+
+        Resets the active row, so this is the entry point for a new run. Use
+        :meth:`refresh_queue` to re-sync a run already in progress.
+        """
+        self._active_id = None
+        self._sync(items)
+
+    def refresh_queue(self, items: list) -> None:
+        """Re-sync the timeline with a queue snapshot, mid-run.
+
+        Called when the queue itself is edited (added to, reordered, or an item
+        removed) rather than when a task starts or finishes. The active row and
+        its inner step list are preserved.
+        """
+        self._sync(items)
 
     def update_from_status(self, status: dict) -> None:
         """Advance the timeline from a workflow_update_signal payload.
@@ -425,28 +531,27 @@ class WorkflowProgressWidget(QWidget):
         task_status = status.get("status", None)
         task_duration = status.get("task_duration", None)
 
-        # Update all row statuses from queue snapshot
-        active_idx = -1
-        for i, item in enumerate(queue_items):
-            if i >= len(self._outer._rows):
-                break
-            step_status = _queue_status_to_step_status(item.status)
-            self._outer.set_step_status(i, step_status)
-            if item.status == AutoLamellaTaskStatus.InProgress:
-                active_idx = i
+        # Reconcile rows with the snapshot; this also refreshes every status.
+        self._sync(queue_items)
 
-        # New active row — show inner container, start elapsed timer
-        if active_idx >= 0 and active_idx != self._outer_index:
-            self._outer_index = active_idx
+        active_id = next((i.id for i in self._items
+                          if i.status == AutoLamellaTaskStatus.InProgress), None)
+
+        # New active row — show inner container, start elapsed timer. Compared by
+        # id, so a reorder that moves the running task does not restart it.
+        if active_id is not None and active_id != self._active_id:
+            self._active_id = active_id
+            self._outer_index = next(
+                n for n, i in enumerate(self._items) if i.id == active_id
+            )
             self._inner_finished = False
             self._active_start_time = status.get("timestamp", time.time())
             self._elapsed_timer.start(1000)
-            self._show_inner_at(active_idx)
+            self._show_inner_at(self._outer_index)
             # Auto-scroll to the active row
-            if active_idx < len(self._outer._rows):
-                self._outer._scroll.ensureWidgetVisible(
-                    self._outer._rows[active_idx]
-                )
+            self._outer._scroll.ensureWidgetVisible(
+                self._outer._rows[self._outer_index]
+            )
 
         # Completion/failure/cancel — set subtitle, hide inner, resolve last inner step
         if task_status in (AutoLamellaTaskStatus.Completed, AutoLamellaTaskStatus.Failed,
@@ -455,16 +560,16 @@ class WorkflowProgressWidget(QWidget):
             self._active_start_time = None
             idx = self._outer_index
             if 0 <= idx < len(self._outer._rows):
-                task_name = queue_items[idx].task_name if idx < len(queue_items) else ""
+                task_name = self._items[idx].task_name
                 self._set_completion_subtitle(idx, task_duration, task_name, completed_at=status.get("timestamp"))
-                # Refresh the row so the updated subtitle is rendered
-                self._outer._rows[idx].refresh(self._outer._steps[idx])
-                self._outer._rows[idx].set_inner_visible(False)
-                # Show error message on failed rows
+                # Show error message on failed rows, before the refresh that renders it
                 if task_status == AutoLamellaTaskStatus.Failed:
                     error_msg = status.get("error_message", None)
                     if error_msg:
                         self._outer._rows[idx].set_error(error_msg)
+                # Refresh the row so the updated subtitle is rendered
+                self._outer._rows[idx].refresh(self._outer._steps[idx])
+                self._outer._rows[idx].set_inner_visible(False)
             self._finish_inner(failed=(task_status == AutoLamellaTaskStatus.Failed))
 
         elif task_status == AutoLamellaTaskStatus.Skipped:
@@ -472,15 +577,35 @@ class WorkflowProgressWidget(QWidget):
             task_name = status.get("task_name", "")
             item_name = status.get("item_name", "")
             reason_str = _SKIP_REASON_LABELS.get(skip_reason, skip_reason or "Skipped")
-            for i, item in enumerate(queue_items):
+            for i, item in enumerate(self._items):
                 if item.lamella_name == item_name and item.task_name == task_name:
-                    if 0 <= i < len(self._outer._rows):
-                        self._outer._steps[i].subtitle = reason_str
-                        self._outer._rows[i].refresh(self._outer._steps[i])
+                    self._outer._steps[i].subtitle = reason_str
+                    self._outer._rows[i].refresh(self._outer._steps[i])
                     break
 
-        # Update progress header
-        self._update_header(queue_items)
+    def _sync(self, items: list) -> None:
+        """Reconcile the timeline against a queue snapshot, keyed by WorkItem id.
+
+        Removed items are dropped from the view rather than struck through in
+        place: the user asked for them to go, so leaving the row behind would
+        overstate how much work is left and make a move past one look like it
+        jumped two rows. They stay in the queue itself for the run summary.
+        """
+        from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+
+        self._items = [i for i in items
+                       if i.status is not AutoLamellaTaskStatus.Removed]
+        self._outer.sync_steps(
+            [i.id for i in self._items],
+            [TimelineStep(label=i.lamella_name,
+                          subtitle=i.task_name,
+                          status=_queue_status_to_step_status(i.status))
+             for i in self._items],
+        )
+        self._outer_index = next(
+            (n for n, i in enumerate(self._items) if i.id == self._active_id), -1
+        )
+        self._update_header(self._items)
 
     def update_step(self, step_name: str) -> None:
         """Mark the previous inner step completed and append a new ACTIVE one."""
@@ -508,6 +633,7 @@ class WorkflowProgressWidget(QWidget):
 
     def clear(self) -> None:
         self._items.clear()
+        self._active_id = None
         self._outer_index = -1
         self._inner_finished = False
         self._elapsed_timer.stop()
@@ -522,6 +648,7 @@ class WorkflowProgressWidget(QWidget):
         rather than through update_from_status().
         """
         self._outer_index = index
+        self._active_id = self._items[index].id if 0 <= index < len(self._items) else None
         self._show_inner_at(index)
 
     # ── Internal ──────────────────────────────────────────────────────────
@@ -548,11 +675,10 @@ class WorkflowProgressWidget(QWidget):
         if total == 0:
             self._header.setText("Workflow")
             return
-        # Removed counts as resolved — otherwise the counter can never reach the
-        # total once a user pulls an item from the queue.
+        # Removed items are already filtered out of the view, so they leave both
+        # sides of this fraction rather than counting as work done.
         done = sum(1 for i in queue_items if i.status in (
-            AutoLamellaTaskStatus.Completed, AutoLamellaTaskStatus.Skipped,
-            AutoLamellaTaskStatus.Removed))
+            AutoLamellaTaskStatus.Completed, AutoLamellaTaskStatus.Skipped))
         failed = sum(1 for i in queue_items if i.status == AutoLamellaTaskStatus.Failed)
         text = f"Workflow — {done}/{total}"
         if failed:

--- a/tests/ui/test_workflow_timeline_sync.py
+++ b/tests/ui/test_workflow_timeline_sync.py
@@ -1,0 +1,376 @@
+"""Headless tests for the workflow timeline reconciling against a mutable queue.
+
+The timeline used to be built exactly once per run and could only shrink to fit
+(`_workflow_timeline_initialized` in AutoLamellaMainUI, plus a `break` past the
+initial row count in `update_from_status`), so an item added mid-run never
+appeared and a removed one left a stale row behind.
+
+Rows are now matched to queue items by `WorkItem.id`. That is what lets a row
+keep its widget — and therefore its inner step list, error text and subtitle —
+while items around it are added, removed or reordered. Note that `queue.items`
+hands out *copies*, so a snapshot never shares object identity with the queue
+or with the previous snapshot; the id is the only stable handle.
+
+Uses the shared offscreen ``qapp`` fixture from tests/conftest.py.
+"""
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus as Status
+from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+from fibsem.applications.autolamella.workflows.tasks.queue import TaskQueue
+from fibsem.ui.widgets.workflow_timeline_widget import (
+    StepStatus,
+    WorkflowProgressWidget,
+)
+
+
+@pytest.fixture
+def queue() -> TaskQueue:
+    q = TaskQueue()
+    q.build_from_matrix(["Trench", "Undercut"], ["L1", "L2"])
+    return q
+
+
+@pytest.fixture
+def widget(qapp) -> WorkflowProgressWidget:
+    return WorkflowProgressWidget()
+
+
+def status_for(queue: TaskQueue, item, status, **extra) -> dict:
+    """The subset of TaskManager._emit_status's payload the timeline reads."""
+    payload = {
+        "task_name": item.task_name,
+        "item_name": item.lamella_name,
+        "status": status,
+        "queue_items": queue.items,
+        "timestamp": 1000.0,
+    }
+    payload.update(extra)
+    return payload
+
+
+def labels(widget: WorkflowProgressWidget):
+    """(lamella, task) per visible row, read back off the rendered widgets."""
+    return [(r._label.text(), r._subtitle.text().split(" (")[0])
+            for r in widget._outer._rows]
+
+
+def layout_order(widget: WorkflowProgressWidget):
+    """The order the rows actually sit in the layout.
+
+    `_rows` is bookkeeping; this is what the user sees. They only agree if
+    _relayout() really did put the widgets back in the new order.
+    """
+    layout = widget._outer._contents_layout
+    items = (layout.itemAt(i) for i in range(layout.count()))
+    return [i.widget() for i in items if i.widget() is not None]
+
+
+def start_next(widget: WorkflowProgressWidget, queue: TaskQueue):
+    """Consume the next queue item and push the resulting InProgress status."""
+    item = queue.next()
+    widget.update_from_status(status_for(queue, item, Status.InProgress))
+    return item
+
+
+def finish(widget: WorkflowProgressWidget, queue: TaskQueue, item,
+           status=Status.Completed, **extra):
+    queue.mark_done(item, status)
+    widget.update_from_status(status_for(queue, item, status, **extra))
+
+
+# ── First paint ───────────────────────────────────────────────────────────────
+
+def test_first_status_builds_the_timeline(widget, queue):
+    """Regression: this used to need a separate set_workflow() call first."""
+    assert widget._outer._rows == []
+    start_next(widget, queue)
+    assert len(widget._outer._rows) == 4
+    assert widget._outer_index == 0
+
+
+def test_a_second_run_rebuilds_from_scratch(widget, queue):
+    """The build-once flag used to be what reset this between runs."""
+    item = start_next(widget, queue)
+    finish(widget, queue, item)
+    first_row = widget._outer._rows[0]
+
+    queue.build_from_matrix(["Polish"], ["L9"])
+    start_next(widget, queue)
+
+    assert labels(widget) == [("L9", "Polish")]
+    assert widget._outer_index == 0
+    assert widget._outer._rows[0] is not first_row
+
+
+# ── Add ───────────────────────────────────────────────────────────────────────
+
+def test_item_added_mid_run_appears(widget, queue):
+    start_next(widget, queue)
+    queue.add("L9", "Polish")
+    widget.refresh_queue(queue.items)
+
+    assert labels(widget)[-1] == ("L9", "Polish")
+    assert len(widget._outer._rows) == 5
+    assert layout_order(widget) == widget._outer._rows
+
+
+def test_item_added_at_the_front_appears_directly_after_the_active_row(widget, queue):
+    """front=True means "run next", which is the row below the running one."""
+    start_next(widget, queue)
+    queue.add("L9", "Polish", front=True)
+    widget.refresh_queue(queue.items)
+
+    assert labels(widget)[1] == ("L9", "Polish")
+    assert widget._outer_index == 0  # the active row did not move
+
+
+# ── Remove ────────────────────────────────────────────────────────────────────
+
+def test_removed_item_disappears_from_the_timeline(widget, queue):
+    start_next(widget, queue)
+    before = labels(widget)
+    target = queue.pending[-1]
+    queue.remove(target.id)
+    widget.refresh_queue(queue.items)
+
+    assert len(widget._outer._rows) == 3
+    assert (target.lamella_name, target.task_name) not in labels(widget)
+    assert labels(widget) == before[:-1]
+    assert layout_order(widget) == widget._outer._rows
+
+
+def test_a_removed_row_stops_painting_immediately(widget, queue):
+    """deleteLater() does not run until the event loop comes back round, so a
+    row that is merely dropped from the layout keeps its last geometry and
+    paints over whatever moved up into its place — a visible ghost row."""
+    start_next(widget, queue)
+    ghost = widget._outer._rows[-1]
+    queue.remove(queue.pending[-1].id)
+    widget.refresh_queue(queue.items)
+
+    assert ghost not in widget._outer._rows
+    assert ghost.isHidden()
+    assert ghost.parent() is None
+
+
+def test_removed_item_leaves_both_sides_of_the_header_fraction(widget, queue):
+    """It is not work that got done, so counting it as done would be a lie —
+    and leaving it in the total would mean the counter could never finish."""
+    item = start_next(widget, queue)
+    finish(widget, queue, item)
+    assert widget._header.text() == "Workflow — 1/4"
+
+    queue.remove(queue.pending[-1].id)
+    widget.refresh_queue(queue.items)
+    assert widget._header.text() == "Workflow — 1/3"
+
+
+# ── Reorder ───────────────────────────────────────────────────────────────────
+
+def test_reorder_moves_the_rows(widget, queue):
+    start_next(widget, queue)
+    last = queue.pending[-1]
+    queue.move_to_front(last.id)
+    widget.refresh_queue(queue.items)
+
+    assert labels(widget)[1] == (last.lamella_name, last.task_name)
+
+
+def test_reorder_moves_the_row_widgets_rather_than_rebuilding_them(widget, queue):
+    """The load-bearing property: a row keeps its widget, so it keeps its state."""
+    start_next(widget, queue)
+    rows_before = {id(r) for r in widget._outer._rows}
+
+    last = queue.pending[-1]
+    moved_row = widget._outer._rows[-1]
+    queue.move_to_front(last.id)
+    widget.refresh_queue(queue.items)
+
+    assert {id(r) for r in widget._outer._rows} == rows_before
+    assert widget._outer._rows[1] is moved_row
+    assert layout_order(widget) == widget._outer._rows
+
+
+def test_reorder_keeps_the_connector_line_on_every_row_but_the_last(widget, queue):
+    start_next(widget, queue)
+    queue.move_to_front(queue.pending[-1].id)
+    widget.refresh_queue(queue.items)
+
+    visible = [r._line.isVisibleTo(r) for r in widget._outer._rows]
+    assert visible == [True, True, True, False]
+
+
+def test_reorder_carries_the_selection_with_its_row(widget, queue):
+    start_next(widget, queue)
+    widget._outer._on_row_clicked(3)
+    selected = widget._outer._rows[3]
+
+    queue.move_to_front(queue.pending[-1].id)
+    widget.refresh_queue(queue.items)
+
+    assert widget._outer._rows[widget._outer._selected_index] is selected
+    assert selected._selected is True
+
+
+# ── The active row survives all of it ─────────────────────────────────────────
+
+@pytest.mark.parametrize("mutate", [
+    pytest.param(lambda q: q.add("L9", "Polish"), id="add"),
+    pytest.param(lambda q: q.add("L9", "Polish", front=True), id="add-front"),
+    pytest.param(lambda q: q.remove(q.pending[-1].id), id="remove"),
+    pytest.param(lambda q: q.move_to_front(q.pending[-1].id), id="reorder"),
+])
+def test_active_row_keeps_its_inner_steps_and_timer(widget, queue, mutate):
+    """_show_inner_at() clears the inner list, so a rebuild on every edit would
+    wipe the running task's step history in front of the user."""
+    start_next(widget, queue)
+    widget.update_step("Setup")
+    widget.update_step("Mill")
+    active_row = widget._outer._rows[0]
+    started_at = widget._active_start_time
+    assert len(active_row._inner_rows) == 2
+
+    mutate(queue)
+    widget.refresh_queue(queue.items)
+
+    assert widget._outer._rows[0] is active_row
+    assert [r._label.text() for r in active_row._inner_rows] == ["Setup", "Mill"]
+    assert active_row._inner_container.isVisibleTo(active_row)
+    assert widget._elapsed_timer.isActive()
+    assert widget._active_start_time == started_at
+    assert widget._outer_index == 0
+
+
+def test_a_reorder_does_not_restart_the_running_task(widget, queue):
+    """The active row is detected by id: comparing positions would read a
+    shuffled queue as a new task starting."""
+    start_next(widget, queue)
+    widget.update_step("Setup")
+
+    queue.move_to_front(queue.pending[-1].id)
+    widget.refresh_queue(queue.items)
+    # a status update after the edit must not re-trigger the "new active" branch
+    widget.update_from_status(status_for(queue, queue.active, Status.InProgress))
+
+    assert [r._label.text() for r in widget._outer._rows[0]._inner_rows] == ["Setup"]
+
+
+# ── Statuses still render ─────────────────────────────────────────────────────
+
+def test_statuses_track_the_queue_through_a_full_run(widget, queue):
+    for _ in range(4):
+        finish(widget, queue, start_next(widget, queue))
+
+    assert all(s.status is StepStatus.COMPLETED for s in widget._outer._steps)
+    assert widget._header.text() == "Workflow — 4/4"
+
+
+def test_failure_error_text_survives_the_next_task_starting(widget, queue):
+    """refresh() used to hide the error label, so the message vanished as soon
+    as the next status arrived — which is one row later, every time."""
+    item = start_next(widget, queue)
+    finish(widget, queue, item, status=Status.Failed, error_message="beam is off")
+    failed_row = widget._outer._rows[0]
+    assert failed_row._error_label.text() == "beam is off"
+
+    start_next(widget, queue)
+
+    assert failed_row._error_label.text() == "beam is off"
+    assert failed_row._error_label.isVisibleTo(failed_row)
+
+
+def test_skip_reason_lands_on_the_right_row(widget, queue):
+    item = queue.next()
+    queue.mark_done(item, Status.Skipped)
+    widget.update_from_status(
+        status_for(queue, item, Status.Skipped, skip_reason="missing_prereqs")
+    )
+
+    assert widget._outer._steps[0].subtitle == "Prerequisites not met"
+    assert widget._outer._steps[1].subtitle == "Trench"  # untouched
+
+
+def test_completion_subtitle_is_not_wiped_by_a_later_sync(widget, queue):
+    item = start_next(widget, queue)
+    finish(widget, queue, item, task_duration=12.0)
+    subtitle = widget._outer._steps[0].subtitle
+    assert "12" in subtitle
+
+    queue.add("L9", "Polish")
+    widget.refresh_queue(queue.items)
+
+    assert widget._outer._steps[0].subtitle == subtitle
+
+
+# ── Through the real TaskManager ──────────────────────────────────────────────
+
+class _SignalToWidget:
+    """Stands in for workflow_update_signal, routing payloads into the widget
+    exactly as AutoLamellaMainUI._on_workflow_update does.
+
+    The payload shape is the seam between the manager and the timeline; going
+    through the real _emit_status is what stops the two drifting apart.
+    """
+
+    def __init__(self, widget: WorkflowProgressWidget):
+        self._widget = widget
+
+    def emit(self, info: dict) -> None:
+        queue_changed = info.get("queue_changed", None)
+        if queue_changed is not None:
+            self._widget.refresh_queue(queue_changed.get("queue_items", []))
+        status = info.get("status", None)
+        if status is not None:
+            self._widget.update_from_status(status)
+
+
+@pytest.fixture
+def manager(widget) -> TaskManager:
+    experiment = SimpleNamespace(register_metadata=lambda microscope: None)
+    parent_ui = SimpleNamespace(workflow_update_signal=_SignalToWidget(widget))
+    m = TaskManager(microscope=None, experiment=experiment, parent_ui=parent_ui)
+    m.queue.build_from_matrix(["Trench", "Undercut"], ["L1", "L2"])
+    return m
+
+
+def emit(manager: TaskManager, item, status, **extra) -> None:
+    manager._emit_status(item=item, lamella=SimpleNamespace(name=item.lamella_name),
+                         status=status, **extra)
+
+
+def test_the_managers_own_payload_builds_the_timeline(widget, manager):
+    item = manager.queue.next()
+    emit(manager, item, Status.InProgress)
+
+    assert labels(widget) == [("L1", "Trench"), ("L2", "Trench"),
+                              ("L1", "Undercut"), ("L2", "Undercut")]
+    assert widget._outer_index == 0
+    assert widget._outer._steps[0].status is StepStatus.ACTIVE
+
+
+def test_notify_queue_changed_reaches_the_timeline(widget, manager):
+    item = manager.queue.next()
+    emit(manager, item, Status.InProgress)
+    widget.update_step("Setup")
+
+    manager.queue.add("L9", "Polish", front=True)
+    manager.notify_queue_changed()
+
+    assert labels(widget)[1] == ("L9", "Polish")
+    # and the running task is undisturbed by the edit
+    assert [r._label.text() for r in widget._outer._rows[0]._inner_rows] == ["Setup"]
+
+
+def test_notify_queue_changed_is_a_noop_headless():
+    experiment = SimpleNamespace(register_metadata=lambda microscope: None)
+    m = TaskManager(microscope=None, experiment=experiment, parent_ui=None)
+    m.queue.build_from_matrix(["Trench"], ["L1"])
+    m.notify_queue_changed()  # must not raise


### PR DESCRIPTION
Follows #268. That made the task queue safely mutable; this makes a mutation visible.

## The problem

The timeline was built exactly once per run and could only shrink to fit — a build-once guard in `AutoLamellaMainUI`, plus a `break` past the initial row count in `update_from_status`. An item added mid-run never appeared, and a removed one left a stale row behind that no longer corresponded to anything in the queue.

## The change

**Rows reconcile against the queue snapshot by `WorkItem.id`** (`WorkflowTimelineWidget.sync_steps`). Identity is what lets a row keep its *widget* — and with it its inner step list, error text and subtitle — while items around it move. It has to be the id: `queue.items` hands out copies, so a snapshot shares object identity with neither the queue nor the previous snapshot.

**The active row is held as `_active_id`,** with `_outer_index` derived on every sync. Comparing positions would read a reordered queue as a task restarting and clear the running task's step list in front of the user.

**`TaskManager.notify_queue_changed()`** emits a `queue_changed` payload on the existing `workflow_update_signal`. Status updates only fire when a task starts, finishes or is skipped, so an edit made between two tasks would otherwise stay invisible until the next one began. Reusing the signal keeps the UI's view of the queue single-sourced and makes an edit from the worker thread as safe as one from the UI thread.

**The build-once guard is gone,** including its reset in `_on_workflow_finished` — a new run's items carry new ids, so the timeline rebuilds itself.

## Decision worth a look: removed rows are hidden, not struck through in place

This was the question left open in FIB-478. Hidden, because leaving the row behind overstates the work remaining and makes a move past one look like it jumped two rows — and unlike a skip, a user-initiated removal needs no explanation on screen. They stay in the queue for the run summary; the header fraction drops them from both sides (`1/4` → `1/3`) rather than counting a removal as work done.

One filter in `WorkflowProgressWidget._sync` if it reads wrong on hardware.

## Two adjacent bugs fixed

**Ghost rows.** `removeWidget()` + `deleteLater()` left a row alive and painting at its old geometry until the event loop came back round, covering whatever moved up into its place. `setParent(None)` first, as `autofocus_widget` and `fm_canvas` already do. Every unit test was green while this was happening — it was caught by rendering the widget offscreen and looking at the image.

**Error text was being wiped.** `_OuterRow.refresh()` hid the error label while every row refreshes on every update, so a failure message disappeared the moment the next task started — one row later, every time. Pre-existing, but this change refreshes more often.

## Testing

23 new tests in `tests/ui/test_workflow_timeline_sync.py`, driven off a real `TaskQueue`. Three go through the real `_emit_status` / `notify_queue_changed` so the payload contract cannot drift from the widget that reads it, and assertions check the actual Qt layout order rather than only the bookkeeping list.

Note `tests/ui/` skips in CI — PyQt5 is not in the `[test]` extra. These run locally.

Full suite: 2404 passed. The existing `test_workflow_timeline_animation` harness still runs, restart path included.

## Manual checks on Demo

Add/remove/reorder have no GUI entry point yet (FIB-476/477), so the useful checks are that nothing regressed:

1. Timeline renders and advances normally through a multi-lamella run
2. A failing task's error text now persists once the next task starts
3. A second run without restarting the app rebuilds the timeline
4. Stop mid-run — the cancelled row resolves and the header count stays sane
