### PR TITLE
[tests] Add metadata fixtures from real instruments and older schema versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,11 @@ fibsem/correlation/data/
 # Belt-and-braces: a path built from an unset (None) save path lands here
 None/
 publications/*
+# Real acquisition images used to generate the metadata fixtures. The images stay
+# local: they embed the acquiring site's directory layout, hostname and instrument
+# serial number, and this remote is public. Only the scrubbed metadata is committed
+# -- see tests/fixtures/metadata/README.md.
+tests/data/
+# Those scrubbed fixtures are the committed artifact, so they have to be re-included
+# against the blanket `*.json` above.
+!tests/fixtures/metadata/*.json

--- a/tests/fixtures/metadata/README.md
+++ b/tests/fixtures/metadata/README.md
@@ -1,0 +1,58 @@
+# Image metadata fixtures
+
+Metadata blocks lifted out of real acquisition TIFFs, so the metadata schema can be
+tested against files this code no longer writes.
+
+The point is backwards compatibility. `FibsemImageMetadata.from_dict` has to keep
+loading images acquired by earlier versions, and nothing else in the suite exercises
+that against genuine output — synthetic dicts test the shape the current code
+believes in, which is exactly the assumption at risk.
+
+## The fixtures
+
+| File | Source | Covers |
+| -- | -- | -- |
+| `thermo_arctis_compustage_v3.json` | Real, Thermo Arctis | Compustage detected via the **model name**; `experiment` with no `name`, `id` holding the experiment *name* |
+| `thermo_aquilos_v3.json` | Real, Thermo Aquilos | Non-compustage; a real pretilted-shuttle geometry |
+| `demo_simulator_v4.json` | Simulator | Compustage detected via the **`sim` flag**; `experiment` after it gained `name` |
+| `demo_simulator_v5.json` | Simulator | Current-era `experiment` (`id`/`name`/`date`) |
+
+Between them: both arms of compustage detection, both real instruments, and three
+generations of `FibsemExperimentRef`.
+
+Two details that make these more useful than they look:
+
+**The Arctis geometry is all zeros** — `shuttle_pre_tilt`, `rotation_reference` and
+`rotation_180` are `0`, against the Aquilos's `35.0` / `110` / `290`. That is correct:
+a compustage tilts the sample directly rather than using a pre-tilted shuttle, and
+`imaging/tiling/reprojection.py` already assumes the rotation is always 0 for one.
+It means **absence must never be inferred from zero-valued angles** — a migration
+that treats all-zeros as "not recorded" breaks Arctis and nothing else.
+
+**`demo_simulator_v5.json` carries `system.info.application_version`**, which current
+code no longer writes. It was acquired mid-change. Keep it: it is the legacy case for
+that field, on a file that also claims to be the current version.
+
+## The images are not in the repository
+
+`.gitignore` excludes `tests/data/` and `fibsem/log/*`. The real images embed the
+acquiring site's directory layout, hostname and instrument serial number, and this
+remote is public. Only the scrubbed metadata is committed.
+
+`extract_fixtures.py` regenerates the JSON when a source image is present, and skips
+sources that are not. Its `SCRUB` dict is the complete list of what is replaced:
+`image.path`, `user.name`, `user.hostname`, `experiment.id`, `system.info.name`,
+`system.info.ip_address`, `system.info.serial_number`.
+
+Replacements keep the *shape* of what they replace — a Windows absolute path stays a
+Windows absolute path, because that shape is itself a thing under test. Nothing else
+is altered, and the script asserts that the model, manufacturer and all five geometry
+angles survived before it writes anything.
+
+To add a fixture, drop the image somewhere ignored, add it to `SOURCES`, and run:
+
+```bash
+python tests/fixtures/metadata/extract_fixtures.py
+```
+
+Then check the output for anything site-identifying that `SCRUB` does not yet cover.

--- a/tests/fixtures/metadata/demo_simulator_v4.json
+++ b/tests/fixtures/metadata/demo_simulator_v4.json
@@ -1,0 +1,193 @@
+{
+  "experiment": {
+    "application": "fibsemOS",
+    "application_version": null,
+    "date": 1785813017.683109,
+    "fibsem_revision": "v0.5.1-111-ga09d57e6-dirty",
+    "fibsem_version": "0.5.2.dev0",
+    "id": "test-experiment",
+    "method": null,
+    "name": null
+  },
+  "image": {
+    "autocontrast": false,
+    "autogamma": false,
+    "beam_type": "ION",
+    "drift_correction": false,
+    "dwell_time": 1e-06,
+    "filename": "ref_ot_initial_alignment_1785813018_628903",
+    "frame_integration": null,
+    "hfw": 0.00015,
+    "line_integration": null,
+    "path": "D:\\SharedData\\user\\test-experiment\\01-test-lamella",
+    "reduced_area": {
+      "height": 0.4,
+      "left": 0.7,
+      "top": 0.3,
+      "width": 0.25
+    },
+    "resolution": [
+      1536,
+      1024
+    ],
+    "save": true,
+    "scan_interlacing": null
+  },
+  "microscope_state": {
+    "electron_beam": null,
+    "electron_detector": null,
+    "ion_beam": {
+      "beam_current": 2e-11,
+      "beam_type": "ION",
+      "dwell_time": 1e-06,
+      "hfw": 0.00015,
+      "preset": null,
+      "resolution": [
+        1536,
+        1024
+      ],
+      "scan_rotation": 0.0,
+      "shift": {
+        "x": 0,
+        "y": 0
+      },
+      "stigmation": {
+        "x": 0,
+        "y": 0
+      },
+      "voltage": 30000,
+      "working_distance": 0.0165
+    },
+    "ion_detector": {
+      "brightness": 0.5,
+      "contrast": 0.5,
+      "mode": "SecondaryElectrons",
+      "type": "ETD"
+    },
+    "objective_position": null,
+    "stage_position": {
+      "coordinate_system": "RAW",
+      "name": null,
+      "r": 0.0,
+      "t": -0.017453292519943295,
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "timestamp": 1785813018.629308
+  },
+  "pixel_size": {
+    "x": 9.765624999999999e-08,
+    "y": 9.765624999999999e-08
+  },
+  "system": {
+    "electron": {
+      "beam_type": "ELECTRON",
+      "column_tilt": 0,
+      "current": 5e-11,
+      "detector_brightness": 0.0,
+      "detector_contrast": 0.0,
+      "detector_mode": "Unknown",
+      "detector_type": "Unknown",
+      "dwell_time": 1e-06,
+      "enabled": true,
+      "eucentric_height": 0.007,
+      "hfw": 0.00015,
+      "plasma": false,
+      "plasma_gas": null,
+      "preset": null,
+      "resolution": [
+        1536,
+        1024
+      ],
+      "scan_rotation": 0.0,
+      "shift": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "stigmation": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "voltage": 2000,
+      "working_distance": 0.007
+    },
+    "gis": {
+      "enabled": true,
+      "multichem": false,
+      "sputter_coater": false
+    },
+    "info": {
+      "application": null,
+      "application_version": null,
+      "fibsem_revision": "v0.5.1-111-ga09d57e6-dirty",
+      "fibsem_version": "0.5.2.dev0",
+      "hardware_version": "v0.23",
+      "ip_address": "127.0.0.1",
+      "manufacturer": "Demo",
+      "model": "DemoMicroscope",
+      "name": "test-configuration",
+      "serial_number": "0000000",
+      "software_version": "0.1"
+    },
+    "ion": {
+      "beam_type": "ION",
+      "column_tilt": 52,
+      "current": 2e-11,
+      "detector_brightness": 0.0,
+      "detector_contrast": 0.0,
+      "detector_mode": "Unknown",
+      "detector_type": "Unknown",
+      "dwell_time": 1e-06,
+      "enabled": true,
+      "eucentric_height": 0.0165,
+      "hfw": 0.00015,
+      "plasma": false,
+      "plasma_gas": "None",
+      "preset": null,
+      "resolution": [
+        1536,
+        1024
+      ],
+      "scan_rotation": 0.0,
+      "shift": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "stigmation": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "voltage": 30000,
+      "working_distance": 0.0165
+    },
+    "manipulator": {
+      "enabled": false,
+      "rotation": false,
+      "tilt": false
+    },
+    "sim": {
+      "fib": null,
+      "is_compustage": true,
+      "sem": null,
+      "use_cycle": true
+    },
+    "stage": {
+      "enabled": true,
+      "manipulator_height_limit": 0.0037,
+      "milling_angle": 15.0,
+      "rotation": true,
+      "rotation_180": 0,
+      "rotation_reference": 0,
+      "shuttle_pre_tilt": 0,
+      "tilt": true
+    }
+  },
+  "user": {
+    "email": "null",
+    "hostname": "TEST-PC",
+    "name": "user",
+    "organization": "null"
+  },
+  "version": "v4"
+}

--- a/tests/fixtures/metadata/demo_simulator_v5.json
+++ b/tests/fixtures/metadata/demo_simulator_v5.json
@@ -1,0 +1,188 @@
+{
+  "experiment": {
+    "date": 1785817134.553929,
+    "id": "test-experiment",
+    "name": null
+  },
+  "image": {
+    "autocontrast": false,
+    "autogamma": false,
+    "beam_type": "ION",
+    "drift_correction": false,
+    "dwell_time": 1e-06,
+    "filename": "ref_ot_initial_alignment_1785817135_490401",
+    "frame_integration": null,
+    "hfw": 0.00015,
+    "line_integration": null,
+    "path": "D:\\SharedData\\user\\test-experiment\\01-test-lamella",
+    "reduced_area": {
+      "height": 0.4,
+      "left": 0.7,
+      "top": 0.3,
+      "width": 0.25
+    },
+    "resolution": [
+      1536,
+      1024
+    ],
+    "save": true,
+    "scan_interlacing": null
+  },
+  "microscope_state": {
+    "electron_beam": null,
+    "electron_detector": null,
+    "ion_beam": {
+      "beam_current": 2e-11,
+      "beam_type": "ION",
+      "dwell_time": 1e-06,
+      "hfw": 0.00015,
+      "preset": null,
+      "resolution": [
+        1536,
+        1024
+      ],
+      "scan_rotation": 0.0,
+      "shift": {
+        "x": 0,
+        "y": 0
+      },
+      "stigmation": {
+        "x": 0,
+        "y": 0
+      },
+      "voltage": 30000,
+      "working_distance": 0.0165
+    },
+    "ion_detector": {
+      "brightness": 0.5,
+      "contrast": 0.5,
+      "mode": "SecondaryElectrons",
+      "type": "ETD"
+    },
+    "objective_position": null,
+    "stage_position": {
+      "coordinate_system": "RAW",
+      "name": null,
+      "r": 0.0,
+      "t": -0.017453292519943295,
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "timestamp": 1785817135.490981
+  },
+  "pixel_size": {
+    "x": 9.765624999999999e-08,
+    "y": 9.765624999999999e-08
+  },
+  "system": {
+    "electron": {
+      "beam_type": "ELECTRON",
+      "column_tilt": 0,
+      "current": 5e-11,
+      "detector_brightness": 0.0,
+      "detector_contrast": 0.0,
+      "detector_mode": "Unknown",
+      "detector_type": "Unknown",
+      "dwell_time": 1e-06,
+      "enabled": true,
+      "eucentric_height": 0.007,
+      "hfw": 0.00015,
+      "plasma": false,
+      "plasma_gas": null,
+      "preset": null,
+      "resolution": [
+        1536,
+        1024
+      ],
+      "scan_rotation": 0.0,
+      "shift": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "stigmation": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "voltage": 2000,
+      "working_distance": 0.007
+    },
+    "gis": {
+      "enabled": true,
+      "multichem": false,
+      "sputter_coater": false
+    },
+    "info": {
+      "application": null,
+      "application_version": null,
+      "fibsem_revision": "v0.5.1-114-g1181a794-dirty",
+      "fibsem_version": "0.5.2.dev0",
+      "hardware_version": "v0.23",
+      "ip_address": "127.0.0.1",
+      "manufacturer": "Demo",
+      "model": "DemoMicroscope",
+      "name": "test-configuration",
+      "serial_number": "0000000",
+      "software_version": "0.1"
+    },
+    "ion": {
+      "beam_type": "ION",
+      "column_tilt": 52,
+      "current": 2e-11,
+      "detector_brightness": 0.0,
+      "detector_contrast": 0.0,
+      "detector_mode": "Unknown",
+      "detector_type": "Unknown",
+      "dwell_time": 1e-06,
+      "enabled": true,
+      "eucentric_height": 0.0165,
+      "hfw": 0.00015,
+      "plasma": false,
+      "plasma_gas": "None",
+      "preset": null,
+      "resolution": [
+        1536,
+        1024
+      ],
+      "scan_rotation": 0.0,
+      "shift": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "stigmation": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "voltage": 30000,
+      "working_distance": 0.0165
+    },
+    "manipulator": {
+      "enabled": false,
+      "rotation": false,
+      "tilt": false
+    },
+    "sim": {
+      "fib": null,
+      "is_compustage": true,
+      "sem": null,
+      "use_cycle": true
+    },
+    "stage": {
+      "enabled": true,
+      "manipulator_height_limit": 0.0037,
+      "milling_angle": 15.0,
+      "rotation": true,
+      "rotation_180": 0,
+      "rotation_reference": 0,
+      "shuttle_pre_tilt": 0,
+      "tilt": true
+    }
+  },
+  "user": {
+    "email": "null",
+    "hostname": "TEST-PC",
+    "name": "user",
+    "organization": "null"
+  },
+  "version": "v5"
+}

--- a/tests/fixtures/metadata/extract_fixtures.py
+++ b/tests/fixtures/metadata/extract_fixtures.py
@@ -1,0 +1,111 @@
+"""Regenerate the metadata fixtures from acquisition TIFFs.
+
+The fixtures exist so the metadata schema can be tested against files produced by
+real instruments and by earlier versions of this code, without committing the images
+themselves. Run this only when adding a new source file; the JSON is the artifact.
+
+    python tests/fixtures/metadata/extract_fixtures.py
+
+The source images are deliberately not in the repository (`.gitignore`: `tests/data/`,
+`fibsem/log/*`). They embed the acquiring site's directory layout, hostname and
+instrument serial number, and this remote is public. SCRUB below is the full list of
+what is removed; everything else is copied through untouched, including every value
+the reprojection path reads.
+"""
+
+import json
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import tifffile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", "..", ".."))
+
+# (source image, fixture name). The real files come from two different instruments and
+# the simulator files supply the metadata versions the real ones predate.
+SOURCES: List[Tuple[str, str]] = [
+    ("tests/data/ref_Setup Lamella Position_start_eb.tif", "thermo_arctis_compustage_v3.json"),
+    ("tests/data/ref_Mill Fiducial_start_eb.tif", "thermo_aquilos_v3.json"),
+    # The real instruments both wrote v3. These cover the later schema versions, and
+    # the simulator's is_compustage flag -- the other arm of the compustage check.
+    (
+        "fibsem/log/data/crosscorrelation/ref_ot_initial_alignment_1785813018_628903_ib.tif",
+        "demo_simulator_v4.json",
+    ),
+    (
+        "fibsem/log/data/crosscorrelation/ref_ot_initial_alignment_1785817135_490401_ib.tif",
+        "demo_simulator_v5.json",
+    ),
+]
+
+# Replaced wherever they appear. The values are placeholders of the same *shape* as
+# what they replace -- a Windows path stays a Windows path -- because the shape is
+# itself under test (an embedded absolute path is the point of FIB-483).
+SCRUB: Dict[str, Any] = {
+    "image.path": "D:\\SharedData\\user\\test-experiment\\01-test-lamella",
+    "user.name": "user",
+    "user.hostname": "TEST-PC",
+    "experiment.id": "test-experiment",
+    "system.info.name": "test-configuration",
+    "system.info.ip_address": "127.0.0.1",
+    "system.info.serial_number": "0000000",
+}
+
+# Never scrubbed, and asserted present afterwards: the fixtures are worthless without
+# them. `model` in particular is what compustage detection string-matches on.
+REQUIRED = [
+    "system.info.model",
+    "system.info.manufacturer",
+    "system.stage.rotation_reference",
+    "system.stage.rotation_180",
+    "system.stage.shuttle_pre_tilt",
+    "system.electron.column_tilt",
+    "system.ion.column_tilt",
+]
+
+
+def _dig(d: Dict[str, Any], path: str) -> Tuple[Optional[Dict[str, Any]], str]:
+    """Resolve a dotted path to its parent dict and final key, or (None, key)."""
+    parts = path.split(".")
+    node: Any = d
+    for p in parts[:-1]:
+        if not isinstance(node, dict) or p not in node:
+            return None, parts[-1]
+        node = node[p]
+    if not isinstance(node, dict):
+        return None, parts[-1]
+    return node, parts[-1]
+
+
+def scrub(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    for path, replacement in SCRUB.items():
+        parent, key = _dig(metadata, path)
+        if parent is not None and key in parent:
+            parent[key] = replacement
+    for path in REQUIRED:
+        parent, key = _dig(metadata, path)
+        if parent is None or key not in parent:
+            raise AssertionError(f"{path} missing -- fixture would not be useful")
+    return metadata
+
+
+def main() -> None:
+    for relative_source, fixture_name in SOURCES:
+        source = os.path.join(REPO, relative_source)
+        if not os.path.exists(source):
+            print(f"skip (source not present): {relative_source}")
+            continue
+        with tifffile.TiffFile(source) as tif:
+            metadata = json.loads(tif.pages[0].description)
+        # The pixel dimensions travel with the image, not the metadata schema.
+        metadata.pop("shape", None)
+        destination = os.path.join(HERE, fixture_name)
+        with open(destination, "w") as f:
+            json.dump(scrub(metadata), f, indent=2, sort_keys=True)
+            f.write("\n")
+        print(f"wrote {fixture_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/metadata/thermo_aquilos_v3.json
+++ b/tests/fixtures/metadata/thermo_aquilos_v3.json
@@ -1,0 +1,180 @@
+{
+  "experiment": {
+    "application": "autolamella",
+    "application_version": "0.5.1.dev0",
+    "date": 1784188826.620654,
+    "fibsem_version": "0.5.1.dev0",
+    "id": "test-experiment",
+    "method": "null"
+  },
+  "image": {
+    "autocontrast": false,
+    "autogamma": false,
+    "beam_type": "ELECTRON",
+    "drift_correction": false,
+    "dwell_time": 1e-06,
+    "filename": "ref_Mill Fiducial_start",
+    "frame_integration": null,
+    "hfw": 4.9999999999999996e-05,
+    "line_integration": null,
+    "path": "D:\\SharedData\\user\\test-experiment\\01-test-lamella",
+    "reduced_area": null,
+    "resolution": [
+      1536,
+      1024
+    ],
+    "save": true,
+    "scan_interlacing": null
+  },
+  "microscope_state": {
+    "electron_beam": {
+      "beam_current": 5e-11,
+      "beam_type": "ELECTRON",
+      "dwell_time": 5e-07,
+      "hfw": 4.9999999999999996e-05,
+      "preset": null,
+      "resolution": [
+        1536,
+        1024
+      ],
+      "scan_rotation": 3.141592653589793,
+      "shift": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "stigmation": {
+        "x": 0.0007350985034412339,
+        "y": -0.00028516460339771674
+      },
+      "voltage": 5000.0,
+      "working_distance": 0.007
+    },
+    "electron_detector": {
+      "brightness": 0.33552499542378617,
+      "contrast": 0.7881260104734966,
+      "mode": "SecondaryElectrons",
+      "type": "ETD"
+    },
+    "ion_beam": null,
+    "ion_detector": null,
+    "objective_position": null,
+    "stage_position": {
+      "coordinate_system": "RAW",
+      "name": null,
+      "r": 1.9199378812145955,
+      "t": 0.10468250101574306,
+      "x": -0.0032723333333333337,
+      "y": 0.0034050833333333337,
+      "z": 0.03238159079218107
+    },
+    "timestamp": "07/16/2026 11:07:27"
+  },
+  "pixel_size": {
+    "x": 3.255208333333333e-08,
+    "y": 3.255208333333333e-08
+  },
+  "system": {
+    "electron": {
+      "beam_type": "ELECTRON",
+      "column_tilt": 0,
+      "current": 5e-11,
+      "detector_brightness": 0.0,
+      "detector_contrast": 0.0,
+      "detector_mode": "Unknown",
+      "detector_type": "Unknown",
+      "dwell_time": 1e-06,
+      "enabled": true,
+      "eucentric_height": 0.007,
+      "hfw": 0.00015,
+      "plasma": false,
+      "plasma_gas": null,
+      "preset": null,
+      "resolution": [
+        1536,
+        1024
+      ],
+      "scan_rotation": 0.0,
+      "shift": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "stigmation": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "voltage": 2000,
+      "working_distance": 0.007
+    },
+    "gis": {
+      "enabled": true,
+      "multichem": false,
+      "sputter_coater": false
+    },
+    "info": {
+      "application": null,
+      "application_version": null,
+      "fibsem_version": "0.5.1.dev0",
+      "hardware_version": "32.1.1.21605",
+      "ip_address": "127.0.0.1",
+      "manufacturer": "Thermo",
+      "model": "Aquilos",
+      "name": "test-configuration",
+      "serial_number": "0000000",
+      "software_version": "4.9.0.902"
+    },
+    "ion": {
+      "beam_type": "ION",
+      "column_tilt": 52,
+      "current": 2e-11,
+      "detector_brightness": 0.0,
+      "detector_contrast": 0.0,
+      "detector_mode": "Unknown",
+      "detector_type": "Unknown",
+      "dwell_time": 1e-06,
+      "enabled": true,
+      "eucentric_height": 0.019,
+      "hfw": 0.00015,
+      "plasma": false,
+      "plasma_gas": "None",
+      "preset": null,
+      "resolution": [
+        1536,
+        1024
+      ],
+      "scan_rotation": 0.0,
+      "shift": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "stigmation": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "voltage": 30000,
+      "working_distance": 0.019
+    },
+    "manipulator": {
+      "enabled": true,
+      "rotation": false,
+      "tilt": false
+    },
+    "sim": {},
+    "stage": {
+      "enabled": true,
+      "manipulator_height_limit": 0.0037,
+      "milling_angle": 9.0,
+      "rotation": true,
+      "rotation_180": 290,
+      "rotation_reference": 110,
+      "shuttle_pre_tilt": 35.0,
+      "tilt": true
+    }
+  },
+  "user": {
+    "email": "null",
+    "hostname": "TEST-PC",
+    "name": "user",
+    "organization": "null"
+  },
+  "version": "v3"
+}

--- a/tests/fixtures/metadata/thermo_arctis_compustage_v3.json
+++ b/tests/fixtures/metadata/thermo_arctis_compustage_v3.json
@@ -1,0 +1,182 @@
+{
+  "experiment": {
+    "application": "autolamella",
+    "application_version": "0.5.1.dev0",
+    "date": 1785373273.631822,
+    "fibsem_revision": "v0.5.1-67-g4b678ebe",
+    "fibsem_version": "0.5.1.dev0",
+    "id": "test-experiment",
+    "method": "null"
+  },
+  "image": {
+    "autocontrast": false,
+    "autogamma": false,
+    "beam_type": "ELECTRON",
+    "drift_correction": false,
+    "dwell_time": 1e-06,
+    "filename": "ref_Setup Lamella Position_start",
+    "frame_integration": null,
+    "hfw": 0.0001,
+    "line_integration": null,
+    "path": "D:\\SharedData\\user\\test-experiment\\01-test-lamella",
+    "reduced_area": null,
+    "resolution": [
+      1536,
+      1024
+    ],
+    "save": true,
+    "scan_interlacing": null
+  },
+  "microscope_state": {
+    "electron_beam": {
+      "beam_current": 2.5e-11,
+      "beam_type": "ELECTRON",
+      "dwell_time": 5e-07,
+      "hfw": 0.0001,
+      "preset": null,
+      "resolution": [
+        3072,
+        2048
+      ],
+      "scan_rotation": 3.141592653589793,
+      "shift": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "stigmation": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "voltage": 2000.0,
+      "working_distance": 0.009696511526305079
+    },
+    "electron_detector": {
+      "brightness": 0.41574497993628995,
+      "contrast": 0.7502107381426273,
+      "mode": "SecondaryElectrons",
+      "type": "ETD"
+    },
+    "ion_beam": null,
+    "ion_detector": null,
+    "objective_position": null,
+    "stage_position": {
+      "coordinate_system": "SPECIMEN",
+      "name": null,
+      "r": 0.0,
+      "t": -0.40123600762621425,
+      "x": 0.00021309624259999984,
+      "y": 9.034410988800037e-06,
+      "z": -7.517508000000004e-05
+    },
+    "timestamp": "07/29/2026 18:05:38"
+  },
+  "pixel_size": {
+    "x": 6.510416666666667e-08,
+    "y": 6.510416666666667e-08
+  },
+  "system": {
+    "electron": {
+      "beam_type": "ELECTRON",
+      "column_tilt": 0,
+      "current": 5e-11,
+      "detector_brightness": 0.0,
+      "detector_contrast": 0.0,
+      "detector_mode": "Unknown",
+      "detector_type": "Unknown",
+      "dwell_time": 1e-06,
+      "enabled": true,
+      "eucentric_height": 0.01,
+      "hfw": 0.00015,
+      "plasma": false,
+      "plasma_gas": null,
+      "preset": null,
+      "resolution": [
+        1536,
+        1024
+      ],
+      "scan_rotation": 0.0,
+      "shift": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "stigmation": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "voltage": 2000,
+      "working_distance": 0.01
+    },
+    "gis": {
+      "enabled": false,
+      "multichem": false,
+      "sputter_coater": false
+    },
+    "info": {
+      "application": null,
+      "application_version": null,
+      "fibsem_revision": "v0.5.1-67-g4b678ebe",
+      "fibsem_version": "0.5.1.dev0",
+      "hardware_version": "28.6.0.35173",
+      "ip_address": "127.0.0.1",
+      "manufacturer": "Thermo",
+      "model": "Arctis",
+      "name": "test-configuration",
+      "serial_number": "0000000",
+      "software_version": "4.13.2.112"
+    },
+    "ion": {
+      "beam_type": "ION",
+      "column_tilt": 52,
+      "current": 2e-11,
+      "detector_brightness": 0.0,
+      "detector_contrast": 0.0,
+      "detector_mode": "Unknown",
+      "detector_type": "Unknown",
+      "dwell_time": 1e-06,
+      "enabled": true,
+      "eucentric_height": 0.0165,
+      "hfw": 0.00015,
+      "plasma": true,
+      "plasma_gas": "Xenon",
+      "preset": null,
+      "resolution": [
+        1536,
+        1024
+      ],
+      "scan_rotation": 0.0,
+      "shift": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "stigmation": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "voltage": 30000,
+      "working_distance": 0.0165
+    },
+    "manipulator": {
+      "enabled": false,
+      "rotation": false,
+      "tilt": false
+    },
+    "sim": {},
+    "stage": {
+      "enabled": true,
+      "manipulator_height_limit": 0.0037,
+      "milling_angle": 15.0,
+      "rotation": false,
+      "rotation_180": 0,
+      "rotation_reference": 0,
+      "shuttle_pre_tilt": 0,
+      "tilt": true
+    }
+  },
+  "user": {
+    "email": "null",
+    "hostname": "TEST-PC",
+    "name": "user",
+    "organization": "null"
+  },
+  "version": "v3"
+}

--- a/tests/test_metadata_fixtures.py
+++ b/tests/test_metadata_fixtures.py
@@ -1,0 +1,192 @@
+"""Metadata written by earlier versions, and by real instruments, must keep loading.
+
+Synthetic dicts test the shape the current code believes in, which is the assumption
+actually at risk when the schema changes. These fixtures are the real output of two
+Thermo instruments and of three generations of this code -- see
+`tests/fixtures/metadata/README.md` for their provenance and what was scrubbed.
+
+This is the guard for FIB-481, which replaces the embedded `SystemSettings` with a
+compact geometry record. Every value asserted here is one the reprojection path reads.
+"""
+
+import json
+import os
+from typing import Any, Dict
+
+import pytest
+
+from fibsem.structures import FibsemImageMetadata
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "metadata")
+
+# (fixture, model, is_compustage, detected_via)
+#
+# `detected_via` records which arm of the check in reprojection.py fires:
+#
+#     "Arctis" in system.info.model or system.sim.get("is_compustage", False)
+#
+# The distinction matters because the simulator only ever exercises the `sim` arm --
+# it reports model "DemoMicroscope" -- so without a real Arctis file the model-name
+# arm, which is the one real hardware uses, is never covered.
+FIXTURES = [
+    ("thermo_arctis_compustage_v3.json", "Arctis", True, "model"),
+    ("thermo_aquilos_v3.json", "Aquilos", False, "neither"),
+    ("demo_simulator_v4.json", "DemoMicroscope", True, "sim"),
+    ("demo_simulator_v5.json", "DemoMicroscope", True, "sim"),
+]
+
+ALL = [f[0] for f in FIXTURES]
+
+
+def load(name: str) -> Dict[str, Any]:
+    with open(os.path.join(FIXTURE_DIR, name)) as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize("name", ALL)
+def test_fixture_metadata_still_loads(name: str) -> None:
+    """The whole point: a file written by an older build must not raise."""
+    metadata = FibsemImageMetadata.from_dict(load(name))
+
+    assert metadata.system is not None
+    assert metadata.microscope_state is not None
+
+
+@pytest.mark.parametrize("name,model,_compustage,_via", FIXTURES)
+def test_instrument_identity_survives_the_load(
+    name: str, model: str, _compustage: bool, _via: str
+) -> None:
+    metadata = FibsemImageMetadata.from_dict(load(name))
+
+    assert metadata.system.info.model == model
+    # The serial is the key any per-instrument aggregation joins on (FIB-445), so it
+    # has to survive even though the fixture's value is scrubbed to a placeholder.
+    assert metadata.system.info.serial_number == "0000000"
+
+
+@pytest.mark.parametrize("name", ALL)
+def test_reprojection_geometry_is_readable(name: str) -> None:
+    """The five angles `_inverse_y_corrected_stage_movement` needs.
+
+    Asserted as `is not None` rather than by value: the Arctis records 0 for three of
+    them, correctly -- a compustage tilts the sample directly instead of using a
+    pre-tilted shuttle. Anything inferring "not recorded" from a zero here would break
+    compustage instruments and nothing else.
+    """
+    system = FibsemImageMetadata.from_dict(load(name)).system
+
+    assert system.electron.column_tilt is not None
+    assert system.ion.column_tilt is not None
+    assert system.stage.shuttle_pre_tilt is not None
+    assert system.stage.rotation_reference is not None
+    assert system.stage.rotation_180 is not None
+
+
+@pytest.mark.parametrize("name,model,compustage,via", FIXTURES)
+def test_compustage_detection(name: str, model: str, compustage: bool, via: str) -> None:
+    """Pins the current behaviour of the detection in reprojection.py:299.
+
+    FIB-481 replaces this expression with a recorded boolean. When it does, this test
+    should keep passing against the same fixtures -- that is what makes it a
+    migration guard rather than a description.
+    """
+    system = FibsemImageMetadata.from_dict(load(name)).system
+
+    by_model = "Arctis" in system.info.model
+    by_sim = system.sim.get("is_compustage", False)
+
+    assert (by_model or by_sim) is compustage
+    assert by_model is (via == "model")
+    assert by_sim is (via == "sim")
+
+
+def test_real_hardware_records_an_empty_sim_dict() -> None:
+    """`system.sim` is `{}` on real instruments -- a dict, not None.
+
+    Worth pinning: `reprojection.py` calls `system.sim.get(...)` unguarded, so a None
+    here would be an AttributeError on the reprojection path of real acquired data.
+    """
+    for name in ("thermo_arctis_compustage_v3.json", "thermo_aquilos_v3.json"):
+        system = FibsemImageMetadata.from_dict(load(name)).system
+        assert system.sim == {}
+
+
+def test_experiment_reference_spans_three_eras() -> None:
+    """The fixtures cover every shape `FibsemExperimentRef` has had.
+
+    v3 has no `name` and its `id` holds the experiment *name* (FIB-446); v4 added
+    `name`; v5 dropped the duplicated version fields (FIB-448). All three must load,
+    and the v3 case must not be silently backfilled -- a reader has to be able to tell
+    that its `id` is a name rather than being handed one that claims to be an ID.
+    """
+    v3 = load("thermo_arctis_compustage_v3.json")["experiment"]
+    v4 = load("demo_simulator_v4.json")["experiment"]
+    v5 = load("demo_simulator_v5.json")["experiment"]
+
+    assert "name" not in v3
+    assert "name" in v4
+    assert set(v5) == {"id", "name", "date"}
+
+    # Keys v5 dropped are still in the older files, and must not stop them loading.
+    assert "application_version" in v3
+    assert "method" in v3
+
+    from fibsem.structures import FibsemExperimentRef
+
+    assert FibsemExperimentRef.from_dict(v3).name is None
+    assert FibsemExperimentRef.from_dict(v3).id == "test-experiment"
+
+
+def test_compustage_angles_are_recorded_as_zero_not_absent() -> None:
+    """The Arctis records 0 for all three stage angles; the Aquilos records real ones.
+
+    This is the trap in migrating the geometry off `SystemSettings`: a shim that reads
+    "falsy" as "this file did not record it" and falls back to a default would corrupt
+    every compustage image and no other kind, which is close to undetectable without
+    a real Arctis file to test against.
+    """
+    arctis = FibsemImageMetadata.from_dict(load("thermo_arctis_compustage_v3.json")).system
+    aquilos = FibsemImageMetadata.from_dict(load("thermo_aquilos_v3.json")).system
+
+    assert (
+        arctis.stage.shuttle_pre_tilt,
+        arctis.stage.rotation_reference,
+        arctis.stage.rotation_180,
+    ) == (0, 0, 0)
+    assert (
+        aquilos.stage.shuttle_pre_tilt,
+        aquilos.stage.rotation_reference,
+        aquilos.stage.rotation_180,
+    ) == (35.0, 110, 290)
+
+
+@pytest.mark.parametrize("missing", ["stage", "electron", "ion", "manipulator", "gis", "info"])
+def test_system_settings_from_dict_is_not_a_safe_migration_path(missing: str) -> None:
+    """`SystemSettings.from_dict` is bracket-indexed throughout, so it raises rather
+    than degrading when a key is absent.
+
+    Recorded as a test because it constrains how the geometry record is derived: read
+    the raw dict with `.get()` chains instead of constructing a full `SystemSettings`
+    first, or the migration inherits this on exactly the old files it exists to
+    protect. See FIB-481.
+    """
+    from fibsem.structures import SystemSettings
+
+    full = load("thermo_arctis_compustage_v3.json")["system"]
+    partial = {k: v for k, v in full.items() if k != missing}
+
+    with pytest.raises(KeyError):
+        SystemSettings.from_dict(partial)
+
+
+def test_a_removed_system_info_field_does_not_break_the_load() -> None:
+    """`demo_simulator_v5.json` carries `system.info.application_version`, which this
+    build no longer declares. `SystemInfo.from_dict` builds field by field, so an
+    unknown key is ignored rather than raising -- that is what made removing the field
+    safe for files already on disk (FIB-448)."""
+    raw = load("demo_simulator_v5.json")
+    assert "application_version" in raw["system"]["info"]
+
+    info = FibsemImageMetadata.from_dict(raw).system.info
+    assert not hasattr(info, "application_version")
+    assert info.model == "DemoMicroscope"


### PR DESCRIPTION
Nothing in the suite exercised metadata deserialisation against genuine output. Synthetic dicts test the shape the current code believes in, which is the assumption actually at risk whenever the schema changes — and it is about to change again for FIB-481, which replaces the embedded `SystemSettings` with a compact geometry record.

Test infrastructure only; no production code changes.

## The fixtures

| File | Source | Covers |
| -- | -- | -- |
| `thermo_arctis_compustage_v3.json` | Real Thermo Arctis | Compustage detected via the **model name** |
| `thermo_aquilos_v3.json` | Real Thermo Aquilos | Not a compustage; a real pretilted-shuttle geometry |
| `demo_simulator_v4.json` | Simulator | Compustage detected via the **`sim` flag** |
| `demo_simulator_v5.json` | Simulator | Current-era `experiment` block |

Between them: both arms of compustage detection, both real instruments, and three generations of `FibsemExperimentRef` (v3 has no `name` and its `id` holds the experiment *name*; v4 added `name`; v5 dropped the duplicated version fields).

**Why the real files matter.** The simulator reports model `"DemoMicroscope"`, so simulator-only data reaches compustage exclusively through `sim["is_compustage"]` and never exercises the `"Arctis" in model` branch — which is the branch real hardware uses. Measured against a local corpus of 102 simulator TIFFs: all 102 take the `sim` arm, none take the model arm. The available data was testing the inverse of the case that matters.

## Two findings recorded as executable tests

Both constrain how FIB-481 may be implemented, so they are assertions rather than prose in a tracker.

**`SystemSettings.from_dict` raises `KeyError` for every missing sub-key** — verified for all six (`stage`, `electron`, `ion`, `manipulator`, `gis`, `info`). A migration must derive the geometry from the raw dict with `.get()` chains rather than constructing a `SystemSettings` first, or it inherits this brittleness on exactly the old files it exists to protect.

**The Arctis records `0` for `shuttle_pre_tilt`, `rotation_reference` and `rotation_180`**, against the Aquilos's `35.0` / `110` / `290`. That is correct — a compustage tilts the sample directly instead of using a pre-tilted shuttle, which `reprojection.py` already assumes. It means absence must never be inferred from a zero angle: that heuristic corrupts compustage images and no other kind, which is close to undetectable without a real Arctis file to test against.

## The images are not in the repository

They embed the acquiring site's directory layout, hostname and instrument serial number, and this remote is public, so `.gitignore` excludes `tests/data/` and only scrubbed metadata is committed.

`extract_fixtures.py` records exactly what is replaced — `image.path`, `user.name`, `user.hostname`, `experiment.id`, `system.info.name`, `system.info.ip_address`, `system.info.serial_number` — and asserts the model, manufacturer and all five geometry angles survived before writing. Replacements keep the *shape* of what they replace (a Windows absolute path stays one), because that shape is itself under test.

Verified by dumping every distinct string value across all four fixtures and checking the committed blobs, not the working tree. What remains real: acquisition timestamps, vendor firmware versions, git revisions and stage coordinates. None name a person, host, instrument or path.

The fixtures needed re-including against a blanket `*.json` rule at `.gitignore:12`.

## Verification

2450 passed, 24 skipped, on top of `73e5fe2e`.