### PR TITLE
[fibsem] Always register an imported microscope configuration

### DIFF
--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -3,7 +3,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import yaml
 
@@ -177,6 +177,13 @@ if not os.path.exists(DEFAULT_CONFIGURATION_PATH):
         
 print(f"Default configuration {DEFAULT_CONFIGURATION_NAME}. Configuration Path: {DEFAULT_CONFIGURATION_PATH}")
 
+def _is_same_path(path: Optional[str], other: Optional[str]) -> bool:
+    """Compare two configuration paths, either of which may be unset."""
+    if path is None or other is None:
+        return False
+    return os.path.normpath(path) == os.path.normpath(other)
+
+
 def add_configuration(configuration_name: str, path: str):
     """Add a new configuration to the user configurations file."""
     if configuration_name in USER_CONFIGURATIONS:
@@ -186,6 +193,27 @@ def add_configuration(configuration_name: str, path: str):
     USER_CONFIGURATIONS_YAML["configurations"] = USER_CONFIGURATIONS
     with open(USER_CONFIGURATIONS_PATH, "w") as f:
         yaml.dump(USER_CONFIGURATIONS_YAML, f)
+
+
+def register_configuration(path: str, configuration_name: Optional[str] = None) -> str:
+    """Register a configuration file, and return the name it was registered under.
+
+    Registering is the only thing that makes a configuration selectable, so unlike
+    add_configuration this never refuses: a name already taken by a different file
+    is given a numeric suffix instead of raising.
+    """
+    if configuration_name is None:
+        configuration_name = os.path.splitext(os.path.basename(path))[0]
+
+    name, index = configuration_name, 2
+    while name in USER_CONFIGURATIONS:
+        if _is_same_path(USER_CONFIGURATIONS[name].get("path"), path):
+            return name  # already registered
+        name = f"{configuration_name} ({index})"
+        index += 1
+
+    add_configuration(configuration_name=name, path=path)
+    return name
 
 
 def remove_configuration(configuration_name: str):

--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pprint import pprint
 from typing import Optional
 
@@ -138,14 +137,23 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
         if configuration_name is None:
             configuration_name = self.comboBox_configuration.currentText()
 
-        configuration_path = cfg.USER_CONFIGURATIONS[configuration_name]["path"]
+        # this runs as a currentTextChanged slot, where an exception is fatal rather
+        # than merely logged, so an unregistered name or an unreadable file has to
+        # report itself instead of raising.
+        configuration = cfg.USER_CONFIGURATIONS.get(configuration_name)
+        configuration_path = configuration.get("path") if configuration else None
 
         if configuration_path is None:
             notification_service.show_toast(f"Configuration {configuration_name} not found.", "error")
-            return
+            return None
 
         # load the configuration
-        self.settings = utils.load_microscope_configuration(configuration_path)
+        try:
+            self.settings = utils.load_microscope_configuration(configuration_path)
+        except Exception as e:
+            logging.warning(f"Unable to load configuration {configuration_name} from {configuration_path}: {e}")
+            notification_service.show_toast(f"Unable to load configuration {configuration_name}: {e}", "error")
+            return None
 
         pprint(self.settings.to_dict()["info"])
 
@@ -165,30 +173,34 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
 
         # TODO: validate configuration
 
-        # ask user to add to user configurations
-        if hasattr(str, "removesuffix"):
-            configuration_name = os.path.basename(path).removesuffix(".yaml")
-        else:
-            configuration_name = os.path.basename(path).replace(".yaml", "")
+        # register the configuration. this is unconditional: registering is what makes a
+        # configuration selectable, so skipping it left the combo box holding a name that
+        # resolved to nothing, and selecting it took the app down.
+        known_names = set(cfg.USER_CONFIGURATIONS)
+        configuration_name = cfg.register_configuration(path=path)
 
-        if configuration_name not in cfg.USER_CONFIGURATIONS:
-            msg = "Would you like to add this configuration to the user configurations?"
-            ret = message_box_ui(text=msg, title="Add to user configurations?", parent=self)
+        # set default configuration. only worth asking for a configuration we hadn't
+        # already seen; re-importing a known one shouldn't re-prompt.
+        if configuration_name not in known_names:
+            msg = "Would you like to make this the default configuration?"
+            ret = message_box_ui(text=msg, title="Set default configuration?", parent=self)
 
-            # add to user configurations
             if ret:
-                cfg.add_configuration(configuration_name=configuration_name, path=path)
+                cfg.set_default_configuration(configuration_name=configuration_name)
 
-                # set default configuration
-                msg = "Would you like to make this the default configuration?"
-                ret = message_box_ui(text=msg, title="Set default configuration?", parent=self)
+        # add configuration to combobox, reusing the entry if it is already listed.
+        # select it quietly and load once: setCurrentIndex stays silent when the entry is
+        # already current, so leaving the load to the signal would skip it on re-import.
+        combo = self.comboBox_configuration
+        combo.blockSignals(True)
+        index = combo.findText(configuration_name)
+        if index == -1:
+            combo.addItem(configuration_name)
+            index = combo.count() - 1
+        combo.setCurrentIndex(index)
+        combo.blockSignals(False)
 
-                if ret:
-                    cfg.set_default_configuration(configuration_name=configuration_name)
-
-        # add configuration to combobox
-        self.comboBox_configuration.addItem(configuration_name)
-        self.comboBox_configuration.setCurrentText(configuration_name)
+        self.load_configuration(configuration_name)
 
     def connect_to_microscope(self):
 

--- a/tests/test_user_configurations.py
+++ b/tests/test_user_configurations.py
@@ -1,0 +1,121 @@
+"""Registering imported microscope configurations (fibsem/config.py).
+
+Importing a configuration used to be conditional on the user accepting a prompt,
+while the combo box entry was added either way. Declining left the combo box
+holding a name that resolved to nothing, and selecting it raised a KeyError out
+of a Qt slot -- which aborts the process rather than logging. Registration is now
+unconditional, so it has to tolerate the names it will be handed repeatedly.
+"""
+
+import os
+
+import pytest
+
+import fibsem.config as cfg
+
+
+@pytest.fixture
+def user_configurations(tmp_path, monkeypatch) -> dict:
+    """Isolate the module-level user configuration state and its yaml file."""
+    configurations = {"default-configuration": {"path": str(tmp_path / "default.yaml")}}
+    yaml_state = {"configurations": configurations, "default": "default-configuration"}
+
+    monkeypatch.setattr(cfg, "USER_CONFIGURATIONS", configurations)
+    monkeypatch.setattr(cfg, "USER_CONFIGURATIONS_YAML", yaml_state)
+    monkeypatch.setattr(
+        cfg, "USER_CONFIGURATIONS_PATH", str(tmp_path / "user-configurations.yaml")
+    )
+    return configurations
+
+
+def test_registers_a_new_configuration(user_configurations, tmp_path):
+    path = str(tmp_path / "my-microscope.yaml")
+
+    name = cfg.register_configuration(path=path)
+
+    assert name == "my-microscope"
+    assert user_configurations[name]["path"] == path
+
+
+def test_registration_persists_to_disk(user_configurations, tmp_path):
+    cfg.register_configuration(path=str(tmp_path / "my-microscope.yaml"))
+
+    assert os.path.exists(cfg.USER_CONFIGURATIONS_PATH)
+    written = cfg.load_yaml(cfg.USER_CONFIGURATIONS_PATH)
+    assert "my-microscope" in written["configurations"]
+
+
+def test_reimporting_the_same_file_is_a_no_op(user_configurations, tmp_path):
+    path = str(tmp_path / "my-microscope.yaml")
+
+    first = cfg.register_configuration(path=path)
+    second = cfg.register_configuration(path=path)
+
+    assert first == second == "my-microscope"
+    assert len(user_configurations) == 2  # the default, plus this one
+
+
+def test_reimport_survives_a_path_written_in_another_form(user_configurations, tmp_path):
+    """The stored path and the one the file dialog hands back need not match textually."""
+    path = str(tmp_path / "my-microscope.yaml")
+
+    first = cfg.register_configuration(path=path)
+    second = cfg.register_configuration(path=str(tmp_path / "." / "my-microscope.yaml"))
+
+    assert first == second
+    assert len(user_configurations) == 2
+
+
+def test_a_different_file_with_the_same_name_gets_its_own_entry(
+    user_configurations, tmp_path
+):
+    """Two configurations can share a basename; neither may displace the other."""
+    first_path = str(tmp_path / "a" / "microscope-configuration.yaml")
+    second_path = str(tmp_path / "b" / "microscope-configuration.yaml")
+
+    first = cfg.register_configuration(path=first_path)
+    second = cfg.register_configuration(path=second_path)
+    third = cfg.register_configuration(path=str(tmp_path / "c" / "microscope-configuration.yaml"))
+
+    assert first == "microscope-configuration"
+    assert second == "microscope-configuration (2)"
+    assert third == "microscope-configuration (3)"
+    assert user_configurations[first]["path"] == first_path
+    assert user_configurations[second]["path"] == second_path
+
+
+def test_registration_never_raises_on_a_taken_name(user_configurations, tmp_path):
+    """add_configuration refuses duplicates; register_configuration must not.
+
+    An unconditional import runs this on every file the user picks, including one
+    named after an entry they already have, and it is called straight from a
+    button handler where raising would take the app down.
+    """
+    with pytest.raises(ValueError):
+        cfg.add_configuration(
+            configuration_name="default-configuration", path=str(tmp_path / "other.yaml")
+        )
+
+    name = cfg.register_configuration(path=str(tmp_path / "default-configuration.yaml"))
+    assert name == "default-configuration (2)"
+
+
+def test_registered_name_always_resolves_to_a_path(user_configurations, tmp_path):
+    """The property the combo box depends on: whatever name comes back is selectable."""
+    for path in ["a/config.yaml", "b/config.yaml", "b/config.yaml", "other.yml"]:
+        name = cfg.register_configuration(path=str(tmp_path / path))
+        assert cfg.USER_CONFIGURATIONS.get(name, {}).get("path") is not None
+
+
+def test_yml_suffix_is_stripped(user_configurations, tmp_path):
+    """The import dialog accepts *.yml too, which .removesuffix('.yaml') left on the name."""
+    assert cfg.register_configuration(path=str(tmp_path / "my-microscope.yml")) == "my-microscope"
+
+
+def test_explicit_name_overrides_the_filename(user_configurations, tmp_path):
+    name = cfg.register_configuration(
+        path=str(tmp_path / "my-microscope.yaml"), configuration_name="METEOR"
+    )
+
+    assert name == "METEOR"
+    assert "METEOR" in user_configurations

--- a/tests/ui/test_configuration_import.py
+++ b/tests/ui/test_configuration_import.py
@@ -1,0 +1,191 @@
+"""Importing a microscope configuration from the connection tab.
+
+Declining the old "add to user configurations?" prompt still put the name in the
+combo box, so selecting it raised KeyError out of a currentTextChanged slot. That
+is not a catchable error: PyQt5 prints the traceback and then aborts the process,
+so the whole app died and the configuration stayed permanently unselectable.
+
+These tests assert the property that keeps the app alive -- every name the combo
+box offers resolves to a registered path, and selecting one never raises.
+"""
+
+import importlib
+import shutil
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+pytest.importorskip("napari")
+
+import fibsem.config as cfg
+from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
+
+# fibsem.ui re-exports the class under the submodule's name, so `import
+# fibsem.ui.FibsemSystemSetupWidget as ...` binds the class rather than the module.
+widget_module = importlib.import_module("fibsem.ui.FibsemSystemSetupWidget")
+
+
+@pytest.fixture
+def configuration_file(tmp_path):
+    """A real configuration, so the import path is exercised end to end."""
+
+    def _make(name: str, subdirectory: str = "") -> str:
+        directory = tmp_path / subdirectory if subdirectory else tmp_path
+        directory.mkdir(parents=True, exist_ok=True)
+        destination = directory / name
+        shutil.copyfile(cfg.MICROSCOPE_CONFIGURATION_PATH, destination)
+        return str(destination)
+
+    return _make
+
+
+@pytest.fixture
+def setup_widget(qapp, tmp_path, monkeypatch):
+    """The connection tab, with the user configuration state isolated per test."""
+    configurations = {
+        "default-configuration": {"path": cfg.MICROSCOPE_CONFIGURATION_PATH}
+    }
+    monkeypatch.setattr(cfg, "USER_CONFIGURATIONS", configurations)
+    monkeypatch.setattr(
+        cfg,
+        "USER_CONFIGURATIONS_YAML",
+        {"configurations": configurations, "default": "default-configuration"},
+    )
+    monkeypatch.setattr(
+        cfg, "USER_CONFIGURATIONS_PATH", str(tmp_path / "user-configurations.yaml")
+    )
+    monkeypatch.setattr(cfg, "DEFAULT_CONFIGURATION_NAME", "default-configuration")
+
+    toasts = []
+    monkeypatch.setattr(
+        widget_module.notification_service,
+        "show_toast",
+        lambda message, notification_type="info": toasts.append(
+            (notification_type, message)
+        ),
+    )
+
+    widget = FibsemSystemSetupWidget()
+    widget.toasts = toasts
+    return widget
+
+
+def _import_file(widget, monkeypatch, path: str, set_as_default: bool = False):
+    """Drive import_configuration_from_file with the dialogs answered for us."""
+    monkeypatch.setattr(widget_module, "open_existing_file_dialog", lambda **kwargs: path)
+    monkeypatch.setattr(widget_module, "message_box_ui", lambda **kwargs: set_as_default)
+    widget.import_configuration_from_file()
+
+
+def _items(widget) -> list:
+    combo = widget.comboBox_configuration
+    return [combo.itemText(i) for i in range(combo.count())]
+
+
+def test_imported_configuration_is_selectable(setup_widget, monkeypatch, configuration_file):
+    """The reported crash: import a configuration, then select it."""
+    widget = setup_widget
+    path = configuration_file("meteor.yaml")
+
+    _import_file(widget, monkeypatch, path)
+
+    assert "meteor" in _items(widget)
+    assert cfg.USER_CONFIGURATIONS["meteor"]["path"] == path
+    assert widget.comboBox_configuration.currentText() == "meteor"
+
+    # the action that used to abort the process
+    for index in range(widget.comboBox_configuration.count()):
+        widget.comboBox_configuration.setCurrentIndex(index)
+
+    assert not [t for t in widget.toasts if t[0] == "error"]
+
+
+def test_every_offered_name_resolves_to_a_path(setup_widget, monkeypatch, configuration_file):
+    """The invariant the combo box depends on -- no entry may be unregistered."""
+    widget = setup_widget
+
+    _import_file(widget, monkeypatch, configuration_file("meteor.yaml", "a"))
+    _import_file(widget, monkeypatch, configuration_file("meteor.yaml", "b"))
+    _import_file(widget, monkeypatch, configuration_file("hydra.yml"))
+
+    for name in _items(widget):
+        assert cfg.USER_CONFIGURATIONS.get(name, {}).get("path") is not None
+
+
+def test_reimporting_the_same_file_adds_no_duplicate(setup_widget, monkeypatch, configuration_file):
+    widget = setup_widget
+    path = configuration_file("meteor.yaml")
+
+    _import_file(widget, monkeypatch, path)
+    _import_file(widget, monkeypatch, path)
+
+    items = _items(widget)
+    assert items.count("meteor") == 1
+    assert len(items) == len(set(items))
+
+
+def test_configurations_sharing_a_basename_keep_their_own_paths(
+    setup_widget, monkeypatch, configuration_file
+):
+    """Two microscope-configuration.yaml files must not collapse onto one entry."""
+    widget = setup_widget
+    first = configuration_file("microscope-configuration.yaml", "a")
+    second = configuration_file("microscope-configuration.yaml", "b")
+
+    _import_file(widget, monkeypatch, first)
+    _import_file(widget, monkeypatch, second)
+
+    assert cfg.USER_CONFIGURATIONS["microscope-configuration"]["path"] == first
+    assert cfg.USER_CONFIGURATIONS["microscope-configuration (2)"]["path"] == second
+    assert widget.comboBox_configuration.currentText() == "microscope-configuration (2)"
+
+
+def test_import_loads_the_configuration(setup_widget, monkeypatch, configuration_file):
+    widget = setup_widget
+    widget.settings = None
+
+    _import_file(widget, monkeypatch, configuration_file("meteor.yaml"))
+
+    assert widget.settings is not None
+
+
+def test_declining_the_default_prompt_still_leaves_it_selectable(
+    setup_widget, monkeypatch, configuration_file
+):
+    """Answering No to "make this the default?" must not strand the entry."""
+    widget = setup_widget
+
+    _import_file(widget, monkeypatch, configuration_file("meteor.yaml"), set_as_default=False)
+
+    assert cfg.USER_CONFIGURATIONS_YAML["default"] == "default-configuration"
+    assert cfg.USER_CONFIGURATIONS.get("meteor", {}).get("path") is not None
+
+
+def test_cancelling_the_dialog_imports_nothing(setup_widget, monkeypatch):
+    widget = setup_widget
+    before = _items(widget)
+
+    _import_file(widget, monkeypatch, "")
+
+    assert _items(widget) == before
+
+
+def test_selecting_an_unregistered_name_reports_instead_of_raising(setup_widget):
+    """A stale combo entry -- hand-edited yaml, or a configuration since removed."""
+    widget = setup_widget
+    widget.comboBox_configuration.addItem("ghost-configuration")
+
+    widget.comboBox_configuration.setCurrentText("ghost-configuration")
+
+    assert ("error", "Configuration ghost-configuration not found.") in widget.toasts
+
+
+def test_unreadable_configuration_reports_instead_of_raising(setup_widget, tmp_path):
+    """The registered file was moved or corrupted after it was added."""
+    widget = setup_widget
+    cfg.USER_CONFIGURATIONS["missing"] = {"path": str(tmp_path / "gone.yaml")}
+    widget.comboBox_configuration.addItem("missing")
+
+    widget.comboBox_configuration.setCurrentText("missing")
+
+    assert [t for t in widget.toasts if t[0] == "error"]


### PR DESCRIPTION
Reported from the AutoLamella connection tab: importing a configuration and declining the "add to user configurations?" prompt kills the app, and the configuration can then never be selected.

## The crash

`import_configuration_from_file` asked whether to add the configuration, but added it to the combo box **either way**. Declining meant `cfg.add_configuration()` never ran, so the combo box held a name absent from `USER_CONFIGURATIONS`. Selecting it — including the `setCurrentText` at the end of the import itself — reached `cfg.USER_CONFIGURATIONS[name]["path"]` and raised `KeyError` inside a `currentTextChanged` slot.

That is not a catchable error. PyQt5 calls `qFatal()` when an exception escapes a slot invoked from C++, so the process aborts. Measured on this branch: reverting the widget and running the new tests exits **134 (SIGABRT)** and takes the pytest process down with it — a `try/except` around the `setCurrentText` call does not see the exception at all. The orphaned combo box entry also persisted, so every later attempt to pick that configuration re-entered the same slot, which is the "can't select the config" half of the report.

## The fix

Registration is the only thing that makes a configuration selectable, so the decline branch had no coherent behaviour to offer. The prompt is gone and registration is unconditional; the one real choice — make it the default? — is still asked, now only for a configuration that was not already known.

`add_configuration` refuses a duplicate name, so an unconditional add on its own would have relocated the abort to **re-importing a file**, the more common of the two actions. `register_configuration` handles the names an always-add import actually receives:

- same file again → no-op, no duplicate combo entry, no repeated prompt
- different file sharing a basename (two `microscope-configuration.yaml` from different folders) → its own `name (2)` entry, instead of the previous behaviour of silently resolving to the **first** file's path
- paths compared normalised, since the dialog need not return the string that was stored

`load_configuration` now reports instead of raising, because a stale entry from a hand-edited yaml, or a file moved after registration, reaches that same fatal slot.

Also swaps the `removesuffix` compatibility branch for `os.path.splitext`, fixing `.yml` imports being named `my-config.yml` — the dialog filter accepts `*.yml` but the suffix strip only handled `.yaml`.

## Testing

- `tests/test_user_configurations.py` — 9 tests, no Qt, **runs in CI**.
- `tests/ui/test_configuration_import.py` — 9 tests driving the real widget through the reported path. Guarded with `importorskip`, so it skips in CI as per house convention; verified locally with `.[ui]` present.
- Both files were run against the pre-fix widget to confirm they detect the bug — they abort the runner with SIGABRT rather than failing, which is the defect itself.
- Full suite: 2073 passed + 360 autolamella passed, no new skips. Checked for 3.8 syntax.
- Confirmed in the running app.

## Related

One confirmed instance of [FIB-329](https://linear.app/fibsemos/issue/FIB-329) (unhandled exception in a Qt slot aborts the app), but **does not close it** — this guards one slot, whereas FIB-329 wants the `sys.excepthook` at the boundary. Same class as FIB-263, which was the correlation tab.