### PR TITLE
[autolamella] Make the default hooks data instead of UI code (FIB-497)

### DIFF
--- a/fibsem/applications/autolamella/hook_defaults.py
+++ b/fibsem/applications/autolamella/hook_defaults.py
@@ -1,0 +1,64 @@
+"""AutoLamella's default hook set, expressed as data rather than as UI code.
+
+Deliberately outside the UI package and free of Qt, so the same hooks a GUI run gets
+can be built headlessly, and so the defaults can be serialized and compared against a
+user's saved configuration without a QApplication.
+
+First step of FIB-497: before a user can override the defaults, the defaults have to
+be something you can round-trip through YAML and diff. They were previously four
+`manager.register(...)` calls inlined in `AutoLamellaUI.setup_hooks()`, reachable only
+by reading the source.
+"""
+
+from typing import List
+
+from fibsem.hooks import Hook, HookEvent, LoggingHook, NotificationHook
+
+
+def default_hooks() -> List[Hook]:
+    """The hooks AutoLamella registers when the user has not configured any.
+
+    Returns **fresh instances on every call**, deliberately. `HookManager.set_notifier`
+    injects a callable into each `NotificationHook` and `HookConfigWidget` edits hooks
+    in place, so a shared module-level list would leak one run's notifier -- and one
+    session's edits -- into the next. `setup_hooks()` runs once per workflow run.
+
+    Every hook here must be a type in `HOOK_TYPES`. `HookManager.to_dict` silently
+    drops anything that is not, so a `FunctionHook` default would vanish the first time
+    a user saved their configuration. Pinned by a test.
+    """
+    return [
+        LoggingHook(
+            name="task_logger",
+            events=[
+                HookEvent.TASK_STARTED,
+                HookEvent.TASK_COMPLETED,
+                HookEvent.TASK_FAILED,
+                HookEvent.TASK_CANCELLED,
+            ],
+        ),
+        NotificationHook(
+            name="completion_toast",
+            events=[HookEvent.TASK_COMPLETED],
+            notification_type="success",
+            message_template="Task {task_name} complete for {item_name}",
+        ),
+        NotificationHook(
+            name="failure_toast",
+            events=[HookEvent.TASK_FAILED],
+            notification_type="error",
+            # A failure does not stop the run, so say what happens next: without the
+            # remaining count this reads as a dead workflow to someone at the
+            # instrument who is not watching the timeline.
+            message_template=(
+                "Task {task_name} FAILED for {item_name}: {error} "
+                "— continuing, {tasks_remaining} tasks remaining"
+            ),
+        ),
+        NotificationHook(
+            name="cancellation_toast",
+            events=[HookEvent.TASK_CANCELLED],
+            notification_type="warning",
+            message_template="Task {task_name} cancelled for {item_name}",
+        ),
+    ]

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -82,15 +82,11 @@ from fibsem.applications.autolamella.structures import (
     Experiment,
     Lamella,
 )
-# Paired with the disabled completion_summary hook in setup_hooks; FunctionHook comes
-# back from fibsem.hooks below at the same time.
+# Paired with the disabled completion_summary hook in setup_hooks; FunctionHook and
+# HookEvent come back from fibsem.hooks below at the same time.
 # from fibsem.applications.autolamella.tools.artifacts import write_completion_summary
-from fibsem.hooks import (
-    HookEvent,
-    HookManager,
-    LoggingHook,
-    NotificationHook,
-)
+from fibsem.applications.autolamella.hook_defaults import default_hooks
+from fibsem.hooks import HookManager
 from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
 from fibsem.ui.widgets.workflow_summary_dialog import WorkflowSummaryDialog
 from psygnal import EmissionInfo
@@ -1091,55 +1087,29 @@ class AutoLamellaUI(QMainWindow):
         self._stop_workflow_thread()
 
     def setup_hooks(self) -> HookManager:
-        """Build the default HookManager for task lifecycle events."""
+        """Build the HookManager for one workflow run.
+
+        Called per run from the workflow worker, not once at startup, so the hook set is
+        rebuilt each time — which is what will let a user's saved configuration take
+        effect on the next run without a restart, and means the config dialog can never
+        be editing a manager a running workflow is holding. See FIB-497.
+
+        The defaults live in hook_defaults.default_hooks() rather than here, so they can
+        be serialized and diffed without a QApplication. Code-registered hooks go after
+        them: a configuration load must never be able to remove a hook that only exists
+        in Python.
+        """
         manager = HookManager()
-        manager.register(
-            LoggingHook(
-                name="task_logger",
-                events=[
-                    HookEvent.TASK_STARTED,
-                    HookEvent.TASK_COMPLETED,
-                    HookEvent.TASK_FAILED,
-                    HookEvent.TASK_CANCELLED,
-                ],
-            )
-        )
-        manager.register(
-            NotificationHook(
-                name="completion_toast",
-                events=[HookEvent.TASK_COMPLETED],
-                notification_type="success",
-                message_template="Task {task_name} complete for {item_name}",
-            )
-        )
-        manager.register(
-            NotificationHook(
-                name="failure_toast",
-                events=[HookEvent.TASK_FAILED],
-                notification_type="error",
-                # A failure does not stop the run, so say what happens next: without the
-                # remaining count this reads as a dead workflow to someone at the
-                # instrument who is not watching the timeline.
-                message_template=(
-                    "Task {task_name} FAILED for {item_name}: {error} "
-                    "— continuing, {tasks_remaining} tasks remaining"
-                ),
-            )
-        )
-        manager.register(
-            NotificationHook(
-                name="cancellation_toast",
-                events=[HookEvent.TASK_CANCELLED],
-                notification_type="warning",
-                message_template="Task {task_name} cancelled for {item_name}",
-            )
-        )
+        for hook in default_hooks():
+            manager.register(hook)
+
         # Deliberately not registered yet. The trigger is proven end to end and the
         # writer is tested, but completion-summary.json is a placeholder for the real
         # artifacts (the PDF and the overview PNG), and turning it on here would start
         # writing a throwaway file into every user's lamella directories. Re-enable when
-        # the artifact is the one people actually want -- see FIB-461. Two imports at the
-        # top of this file come back with it: write_completion_summary and FunctionHook.
+        # the artifact is the one people actually want -- see FIB-461. Three imports at
+        # the top of this file come back with it: write_completion_summary, and
+        # FunctionHook + HookEvent from fibsem.hooks.
         #
         # Per lamella, not per experiment: a lamella is what gets delivered, and an
         # experiment with one abandoned lamella never reaches completion at all, so

--- a/tests/autolamella/test_hook_defaults.py
+++ b/tests/autolamella/test_hook_defaults.py
@@ -1,0 +1,123 @@
+"""The default hook set, as data.
+
+These are the hooks a user gets before configuring anything, so they are pinned here:
+changing them should be a deliberate edit to this file, not a side effect. And they
+have to survive a round trip through YAML, because FIB-497 will save a user's set and
+reload it — a default that cannot serialize would vanish the first time anyone opened
+the config dialog.
+"""
+
+from typing import List
+
+from fibsem.applications.autolamella.hook_defaults import default_hooks
+from fibsem.hooks import (
+    HOOK_TYPES,
+    HookEvent,
+    HookManager,
+    LoggingHook,
+    NotificationHook,
+)
+
+
+def _by_name(hooks: List) -> dict:
+    return {hook.name: hook for hook in hooks}
+
+
+def test_the_default_set_is_what_it_is():
+    """Pins the shipped defaults. If this fails, the change was intended or it wasn't."""
+    hooks = _by_name(default_hooks())
+
+    assert set(hooks) == {
+        "task_logger",
+        "completion_toast",
+        "failure_toast",
+        "cancellation_toast",
+    }
+    assert isinstance(hooks["task_logger"], LoggingHook)
+    assert hooks["task_logger"].events == [
+        HookEvent.TASK_STARTED,
+        HookEvent.TASK_COMPLETED,
+        HookEvent.TASK_FAILED,
+        HookEvent.TASK_CANCELLED,
+    ]
+    assert [hooks[n].notification_type for n in
+            ("completion_toast", "failure_toast", "cancellation_toast")] == [
+        "success", "error", "warning",
+    ]
+
+
+def test_the_failure_toast_says_the_run_continues():
+    """A failure does not stop the run, and without the remaining count the toast reads
+    as a dead workflow to someone at the instrument."""
+    template = _by_name(default_hooks())["failure_toast"].message_template
+
+    assert "{error}" in template
+    assert "{tasks_remaining}" in template
+
+
+def test_every_default_is_a_serializable_type():
+    """HookManager.to_dict silently drops anything not in HOOK_TYPES, so a FunctionHook
+    default would disappear the first time a user saved their configuration."""
+    for hook in default_hooks():
+        assert type(hook).__name__ in HOOK_TYPES
+
+
+def test_the_defaults_survive_a_round_trip():
+    """The guarantee FIB-497 depends on: save the defaults, load them back, get the
+    defaults."""
+    manager = HookManager()
+    for hook in default_hooks():
+        manager.register(hook)
+
+    restored = HookManager.from_dict(manager.to_dict())
+
+    assert len(restored._hooks) == len(default_hooks())
+    original = _by_name(default_hooks())
+    for hook in restored._hooks:
+        assert hook.to_dict() == original[hook.name].to_dict()
+
+
+def test_each_call_returns_fresh_hooks():
+    """set_notifier injects a callable into every NotificationHook and the config widget
+    edits hooks in place, so a shared module-level list would leak one run's state into
+    the next. setup_hooks() runs once per workflow run."""
+    first, second = default_hooks(), default_hooks()
+
+    assert all(a is not b for a, b in zip(first, second))
+
+    manager = HookManager()
+    for hook in first:
+        manager.register(hook)
+    manager.set_notifier(lambda message, kind: None)
+
+    injected = [h for h in first if isinstance(h, NotificationHook)]
+    untouched = [h for h in second if isinstance(h, NotificationHook)]
+    assert all(h._notify is not None for h in injected)
+    assert all(h._notify is None for h in untouched)
+
+
+def test_a_notifier_reaches_every_default_notification_hook():
+    """What setup_hooks does after registering: the toasts must actually deliver."""
+    delivered = []
+    manager = HookManager()
+    for hook in default_hooks():
+        manager.register(hook)
+    manager.set_notifier(lambda message, kind: delivered.append((message, kind)))
+
+    from fibsem.hooks import HookContext
+
+    manager.fire(
+        HookContext(
+            event=HookEvent.TASK_FAILED,
+            task_name="MillTrench",
+            item_name="lam-1",
+            error="stage timeout",
+            tasks_remaining=3,
+        )
+    )
+
+    assert len(delivered) == 1
+    message, kind = delivered[0]
+    assert kind == "error"
+    assert "MillTrench" in message and "lam-1" in message
+    assert "stage timeout" in message and "3" in message


### PR DESCRIPTION
First step of FIB-497, and deliberately behaviour-preserving: before a user can override the default hooks, the defaults have to be something you can serialize, diff, and round-trip.

Four hooks were registered inline in `AutoLamellaUI.setup_hooks()` — a logging hook and three toasts. The set a user gets before configuring anything was readable only by reading the source, and could not be inspected or compared against a saved configuration without a `QApplication`.

They now live in `hook_defaults.default_hooks()`, outside the UI package and free of Qt. `setup_hooks()` drops from 52 lines to three:

```python
manager = HookManager()
for hook in default_hooks():
    manager.register(hook)
```

## Two properties that are load-bearing, not stylistic

**`default_hooks()` returns fresh instances on every call.** `HookManager.set_notifier` injects a callable into every `NotificationHook`, and `HookConfigWidget` edits hooks in place. A module-level `DEFAULT_HOOKS = [...]` would therefore leak one run's notifier — and one session's edits — into the next. `setup_hooks()` is called per workflow run (from the worker, at `AutoLamellaUI.py:1062`), so that would have been a live bug rather than a theoretical one.

**Every default must be a type in `HOOK_TYPES`.** `HookManager.to_dict` filters on membership and drops the rest silently, so a `FunctionHook` default would vanish the first time a user saved their configuration — no error, just a hook that stops existing. Pinned by a test, because the failure mode is silence.

## Order matters in setup_hooks

Defaults, then code-registered hooks, then the notifier. When a configuration load lands in the next step it replaces the *defaults* only: it must never be able to remove a hook that exists solely in Python, which is the category the (currently disabled) `completion_summary` hook belongs to.

## A useful thing that falls out

`setup_hooks()` runs per run rather than once at startup, so a saved configuration will take effect on the next run with no restart, and the config dialog can never be editing a manager a running workflow is holding. That was already true; this PR just documents it, since the next step depends on it.

## Testing

`tests/autolamella/test_hook_defaults.py` — 6 tests: the shipped set is pinned by name, type and events; the failure toast still carries `{error}` and `{tasks_remaining}` (a failure doesn't stop the run, and without the count the toast reads as a dead workflow); every default is serializable; the set survives `to_dict` → `from_dict` unchanged; each call returns fresh hooks, verified by injecting a notifier into one call's hooks and checking the next call's are untouched; and a notifier actually reaches the toasts, fired through a real `HookContext`.

2456 tests pass.

## Not in this PR

Loading from disk, which is the step that actually makes hooks user-configurable and discharges the hook project's exit criterion. Agreed direction is a `hooks` section in `user-preferences.yaml` rather than a new file — it reuses the existing fail-soft load, the unknown-key tolerance, and the Preferences dialog, and it inherits whatever FIB-336 decides about where user state lives.

The editor UI is also open: `HookConfigWidget` exists and works, but it presents the data model directly (a list of hook objects, each with a type and an event list), which asks the user to think in `NotificationHook`s rather than in "tell me when something fails". Worth settling before there are saved files in the wild, since the persisted shape should follow the design rather than the reverse.
