### PR TITLE
[autolamella] Edit the workflow queue from the timeline while it runs (FIB-476)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -40,6 +40,7 @@ from fibsem.versioning import get_version_string
 import fibsem.config as fibsem_cfg
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus, Lamella
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI, INSTRUCTIONS
+from fibsem.applications.autolamella.workflows.tasks.queue import QueueOp, QueueResult
 from fibsem.applications.autolamella.workflows.tasks.tasks import get_task_supervision
 from fibsem.ui import FibsemMinimapWidget
 from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
@@ -835,6 +836,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if message and self.status_bar is not None:
             self.status_bar.showMessage(message)
         self._set_minimap_workflow_enabled(False)
+        if hasattr(self, "workflow_timeline"):
+            self.workflow_timeline.set_actions_enabled(
+                fibsem_cfg.FEATURE_EDIT_RUNNING_QUEUE_ENABLED
+            )
 
     def hide_workflow_running(self):
         """Hide the stop button and show run button."""
@@ -842,6 +847,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.supervised_status_btn.hide()
         self.run_workflow_btn.show()
         self._set_minimap_workflow_enabled(True)
+        # The timeline stays on screen after a run, but there is no longer a
+        # queue behind it — offering to reorder one would be a lie.
+        if hasattr(self, "workflow_timeline"):
+            self.workflow_timeline.set_actions_enabled(False)
 
     def _set_minimap_workflow_enabled(self, enabled: bool):
         """Enable/disable overview acquisition in both overview tabs during a workflow.
@@ -1096,6 +1105,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         # Connect to workflow update signal from AutoLamellaUI
         self.autolamella_ui.workflow_update_signal.connect(self._on_workflow_update)
+        self.autolamella_ui.queue_changed_signal.connect(self._on_queue_changed)
         self.autolamella_ui.step_update_signal.connect(self._on_step_update)
         self.autolamella_ui.experiment_update_signal.connect(self._on_experiment_update)
         self.autolamella_ui._workflow_finished_signal.connect(
@@ -1439,6 +1449,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         _rp_layout.setContentsMargins(0, 0, 0, 0)
         _rp_layout.setSpacing(0)
         self.workflow_timeline = WorkflowProgressWidget()
+        self.workflow_timeline.queue_action_requested.connect(self._on_queue_action)
         _rp_layout.addWidget(self.workflow_timeline)
 
         splitter.addWidget(self.lamella_workflow_widget)
@@ -1521,6 +1532,75 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         protocol.workflow_config.tasks[:] = self.lamella_workflow_widget.get_tasks()
         self.autolamella_ui._on_workflow_config_changed(protocol.workflow_config)
 
+    def _on_queue_changed(self, info: dict) -> None:
+        """The queue was edited between tasks — no task lifecycle to hang it off."""
+        self.workflow_timeline.refresh_queue(info.get("queue_items", []))
+
+    def _on_queue_action(self, action: str, item_id: str) -> None:
+        """Apply a timeline row action to the live queue.
+
+        The timeline emits an intent keyed on WorkItem.id and nothing more; the
+        queue is reached from here because the widget is generic and has no
+        business knowing what a queue is.
+        """
+        manager = getattr(self.autolamella_ui, "_task_manager", None)
+        if manager is None:
+            return
+
+        queue = manager.queue
+        item = next((i for i in queue.items if i.id == item_id), None)
+        if item is None:
+            self._show_queue_message("That task is no longer in the queue.")
+            return
+        label = f"{item.task_name} for {item.lamella_name}"
+
+        if action == "run_again":
+            # A fresh item rather than a rewind: the original attempt still
+            # happened and stays in the run record.
+            added = queue.add(item.lamella_name, item.task_name, front=True)
+            message = (f"Queued {label} to run next." if added is not None
+                       else f"Could not queue {label}.")
+        else:
+            call = {
+                "move_up":   lambda: queue.nudge(item_id, -1),
+                "move_down": lambda: queue.nudge(item_id, +1),
+                "run_next":  lambda: queue.move_to_front(item_id),
+                "remove":    lambda: queue.remove(item_id),
+            }.get(action)
+            if call is None:
+                logging.warning(f"Unknown queue action from the timeline: {action}")
+                return
+            message = self._queue_action_message(action, label, call())
+
+        manager.notify_queue_changed()
+        self._show_queue_message(message)
+
+    @staticmethod
+    def _queue_action_message(action: str, label: str, result: QueueResult) -> str:
+        """Describe the outcome of a queue action, or "" to say nothing.
+
+        The row may have started running between the menu opening and the click,
+        which is the whole reason the queue returns a structured result rather
+        than a bool — say so instead of appearing to do nothing.
+        """
+        if result.op is QueueOp.NO_OP:
+            return ""  # already first or last; the user can see that
+        if result.op is QueueOp.NOT_PENDING:
+            return f"{label} is already running."
+        if not result.ok:
+            return f"{label} is no longer in the queue."
+        return {
+            "move_up":   f"Moved {label} up.",
+            "move_down": f"Moved {label} down.",
+            "run_next":  f"{label} will run next.",
+            "remove":    f"Removed {label} from the queue.",
+        }.get(action, "")
+
+    def _show_queue_message(self, message: str) -> None:
+        """Transient confirmation for a queue edit — no modal, no interruption."""
+        if message and self.status_bar is not None:
+            self.status_bar.showMessage(message, 4000)
+
     def _on_workflow_update(self, info: dict):
         """Handle workflow update signal and update the workflow status bar."""
         t0 = t1 = time.time()
@@ -1530,12 +1610,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         status_bar_msg = info.get("status_bar", None)
         if status_bar_msg is not None and self.status_bar is not None:
             self.status_bar.showMessage(status_bar_msg)
-
-        # Queue edited between tasks (added to, reordered, item removed) — no task
-        # lifecycle to hang it off, so refresh the timeline on its own.
-        queue_changed = info.get("queue_changed", None)
-        if queue_changed is not None:
-            self.workflow_timeline.refresh_queue(queue_changed.get("queue_items", []))
 
         status_msg = info.get("status", None)
         if status_msg is not None:

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -150,6 +150,11 @@ INSTRUCTIONS = {
 
 class AutoLamellaUI(QMainWindow):
     workflow_update_signal = pyqtSignal(dict)
+    # Kept separate from workflow_update_signal on purpose: that one drives
+    # handle_workflow_update, which reconfigures the interaction UI and clears
+    # WAITING_FOR_UI_UPDATE on every emission. A queue edit is not a step in the
+    # task lifecycle and must not disturb any of that.
+    queue_changed_signal = pyqtSignal(dict)
     step_update_signal = pyqtSignal(str)  # emits human-readable step label
     detection_confirmed_signal = pyqtSignal(bool)
     _workflow_finished_signal = pyqtSignal(bool)

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -224,17 +224,18 @@ class TaskManager:
 
         Status updates only fire when a task starts, finishes or is skipped, so
         an edit made between two tasks would otherwise stay invisible until the
-        next one began. Routing it through the same signal keeps the UI's view
-        of the queue single-sourced, and makes an edit from the worker thread
-        (a script, say) as safe as one from the UI thread.
+        next one began.
+
+        Deliberately its own signal rather than workflow_update_signal: that one
+        also drives AutoLamellaUI.handle_workflow_update, which rebuilds the
+        interaction UI and clears WAITING_FOR_UI_UPDATE every time it fires. A
+        queue edit is not a step in the task lifecycle.
         """
         if self.parent_ui is None:
             return
-        self.parent_ui.workflow_update_signal.emit({
-            "queue_changed": {
-                "queue_items": self.queue.items,  # thread-safe snapshot
-                "version": self.queue.version,
-            }
+        self.parent_ui.queue_changed_signal.emit({
+            "queue_items": self.queue.items,  # thread-safe snapshot
+            "version": self.queue.version,
         })
 
     def hook_run_context(self) -> dict:

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -304,6 +304,10 @@ class FeatureFlags:
     # being finished -- it sits beside the existing Overview tab and drives the same
     # instrument, so it is offered only to people who have asked for it (FIB-432).
     fm_overview_tab: bool = False
+    # Editing the workflow queue from the timeline while a run is in progress. The
+    # first thing that lets a user change what a running workflow will do, on a real
+    # sample, mid-session -- so it is offered only to people who ask (FIB-476).
+    edit_running_queue: bool = False
 
 @dataclass
 class MovementPreferences:
@@ -513,6 +517,7 @@ def apply_feature_flags(prefs: UserPreferences) -> None:
     global FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED
     global FEATURE_SCHEDULED_TASKS_ENABLED
     global FEATURE_FM_OVERVIEW_TAB_ENABLED
+    global FEATURE_EDIT_RUNNING_QUEUE_ENABLED
     f = prefs.features
     FEATURE_LAMELLA_POSITION_ON_LIVE_VIEW_ENABLED = f.lamella_position_on_live_view
     FEATURE_VIEWER_MOVEMENT_EVENTS = f.viewer_movement_events
@@ -520,6 +525,7 @@ def apply_feature_flags(prefs: UserPreferences) -> None:
     FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED = f.sample_holder_widget
     FEATURE_SCHEDULED_TASKS_ENABLED = f.scheduled_tasks
     FEATURE_FM_OVERVIEW_TAB_ENABLED = f.fm_overview_tab
+    FEATURE_EDIT_RUNNING_QUEUE_ENABLED = f.edit_running_queue
 
     # Also update the autolamella config module which re-exports these
     try:
@@ -548,3 +554,4 @@ FEATURE_COINCIDENCE_MILLING_ENABLED = False
 FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED = False
 FEATURE_SCHEDULED_TASKS_ENABLED = False
 FEATURE_FM_OVERVIEW_TAB_ENABLED = False
+FEATURE_EDIT_RUNNING_QUEUE_ENABLED = False

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -127,6 +127,13 @@ QMenu::item:selected {
     background-color: #3d4251;
 }
 
+/* Without this, `QMenu { color }` above also paints disabled items, so a greyed
+   action is indistinguishable from an available one. Matches the disabled
+   colour used by the button and field rules below. */
+QMenu::item:disabled {
+    color: #6b6b6b;
+}
+
 QTabWidget::pane {
     border: none;
     background-color: #262930;

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -59,6 +59,12 @@ _TIP_FM_OVERVIEW   = (
     "canvas, beside the existing Overview tab. Still being finished, and it drives the "
     "same microscope as the Fluorescence controls."
 )
+_LBL_EDIT_QUEUE    = "Enable Editing the Running Queue"
+_TIP_EDIT_QUEUE    = (
+    "Let the workflow timeline reorder, remove and re-run queued tasks while a run "
+    "is in progress. Only queued work can be changed — the running task and "
+    "everything already done are left alone."
+)
 _LBL_SCRIPTS       = "Enable User Scripts"
 _TIP_SCRIPTS       = (
     "Show Tools > Scripts, for running your own .py files against the open "
@@ -152,6 +158,8 @@ class PreferencesDialog(QDialog):
         self._chk_scripts.setToolTip(_TIP_SCRIPTS)
         self._chk_fm_overview = QCheckBox()
         self._chk_fm_overview.setToolTip(_TIP_FM_OVERVIEW)
+        self._chk_edit_queue = QCheckBox()
+        self._chk_edit_queue.setToolTip(_TIP_EDIT_QUEUE)
         features_form.addRow(_LBL_LAMELLA_LIVE, self._chk_lamella_live)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
         features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
@@ -159,6 +167,7 @@ class PreferencesDialog(QDialog):
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
         features_form.addRow(_LBL_SCRIPTS, self._chk_scripts)
         features_form.addRow(_LBL_FM_OVERVIEW, self._chk_fm_overview)
+        features_form.addRow(_LBL_EDIT_QUEUE, self._chk_edit_queue)
         self._stack.addWidget(features_page)
 
         # --- Experiment Defaults ---
@@ -222,6 +231,7 @@ class PreferencesDialog(QDialog):
         self._chk_bug_report.setChecked(f.bug_report_enabled)
         self._chk_scripts.setChecked(f.scripts_enabled)
         self._chk_fm_overview.setChecked(f.fm_overview_tab)
+        self._chk_edit_queue.setChecked(f.edit_running_queue)
 
         e = prefs.experiment
         self._dir_experiment.setText(e.default_experiment_directory)
@@ -294,6 +304,7 @@ class PreferencesDialog(QDialog):
                 bug_report_enabled=self._chk_bug_report.isChecked(),
                 scripts_enabled=self._chk_scripts.isChecked(),
                 fm_overview_tab=self._chk_fm_overview.isChecked(),
+                edit_running_queue=self._chk_edit_queue.isChecked(),
             ),
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),

--- a/fibsem/ui/widgets/workflow_timeline_widget.py
+++ b/fibsem/ui/widgets/workflow_timeline_widget.py
@@ -381,12 +381,16 @@ class WorkflowTimelineWidget(QWidget):
         self._scroll.setWidgetResizable(True)
         self._scroll.setFrameShape(QFrame.NoFrame)
         self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        self._scroll.setStyleSheet(
-            f"QScrollArea {{ background: {stylesheets.GRAY_BACKGROUND_COLOR}; border: none; }}"
-        )
+        # Transparent rather than a hardcoded colour: this widget is embedded in
+        # panels that set their own background (workflow_right_panel is #2b2d31),
+        # and painting GRAY_BACKGROUND_COLOR here left the rows as a visibly
+        # darker rectangle inside a lighter panel, with the header strip above
+        # them a third shade again.
+        self._scroll.setStyleSheet("QScrollArea { background: transparent; border: none; }")
+        self._scroll.viewport().setStyleSheet("background: transparent;")
 
         self._contents = QWidget()
-        self._contents.setStyleSheet(f"background: {stylesheets.GRAY_BACKGROUND_COLOR};")
+        self._contents.setStyleSheet("background: transparent;")
         self._contents_layout = QVBoxLayout(self._contents)
         self._contents_layout.setContentsMargins(0, 4, 0, 4)
         self._contents_layout.setSpacing(0)

--- a/fibsem/ui/widgets/workflow_timeline_widget.py
+++ b/fibsem/ui/widgets/workflow_timeline_widget.py
@@ -5,21 +5,24 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Dict, List, Optional
 
-from PyQt5.QtCore import Qt, QTimer, pyqtSignal
+from PyQt5.QtCore import QPoint, Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import QColor, QPainter
 from PyQt5.QtWidgets import (
     QApplication,
     QFrame,
     QHBoxLayout,
     QLabel,
+    QMenu,
     QScrollArea,
     QSizePolicy,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
 
 from fibsem.constants import TIME_DISPLAY_AMPM_SHORT
 from fibsem.ui import stylesheets
+from fibsem.ui.icon import fibsem_icon
 
 # ── Colours ───────────────────────────────────────────────────────────────────
 _DOT_COMPLETED  = stylesheets.GREEN_COLOR
@@ -39,6 +42,13 @@ _SKIP_REASON_LABELS = {
 _SELECTED_BG    = "#2d3f5c"
 _LABEL_COLOR    = stylesheets.GRAY_TEXT_COLOR
 _SUBTITLE_COLOR = stylesheets.GRAY_SECONDARY_COLOR
+
+_ACTIONS_BTN    = 20   # px — the hover-revealed "..." button
+_ACTIONS_STYLE  = (
+    "QToolButton { background: transparent; border: none; border-radius: 3px; }"
+    "QToolButton:hover { background: #3a3d42; }"
+    "QToolButton::menu-indicator { image: none; }"
+)
 
 _DOT_SIZE       = 12
 _INNER_DOT_SIZE = 8
@@ -155,11 +165,13 @@ class _OuterRow(QWidget):
     """One outer (lamella, task) row with an embedded collapsible inner step list."""
 
     clicked = pyqtSignal(int)
+    menu_requested = pyqtSignal(int, QPoint)  # index, global position
 
     def __init__(self, step: TimelineStep, index: int, is_last: bool, parent=None):
         super().__init__(parent)
         self._index = index
         self._selected = False
+        self._actions_enabled = False
         self._inner_rows: List[_InnerStepRow] = []
         self._setup_ui(step, is_last)
 
@@ -237,6 +249,50 @@ class _OuterRow(QWidget):
 
         root.addLayout(right, 1)
 
+        # Hover-revealed actions button. The timeline is dense enough that a
+        # permanent button on every row would be noise, but right-click alone is
+        # undiscoverable — so both, and the button only while the pointer is here.
+        self._btn_actions = QToolButton()
+        self._btn_actions.setFixedSize(_ACTIONS_BTN, _ACTIONS_BTN)
+        self._btn_actions.setStyleSheet(_ACTIONS_STYLE)
+        self._btn_actions.setIcon(
+            fibsem_icon("mdi:dots-horizontal", color=stylesheets.GRAY_ICON_COLOR)
+        )
+        self._btn_actions.setToolTip("Queue actions")
+        self._btn_actions.setVisible(False)
+        self._btn_actions.clicked.connect(self._on_actions_clicked)
+        root.addWidget(self._btn_actions, 0, Qt.AlignTop)
+
+    # ── Queue actions ─────────────────────────────────────────────────────
+    def set_actions_enabled(self, enabled: bool) -> None:
+        """Whether this row can offer queue actions at all.
+
+        False when no run is live: there is no queue to act on, so the button
+        is hidden rather than opening a menu with every entry greyed out. Which
+        *individual* actions apply to this row is decided when the menu opens.
+        """
+        self._actions_enabled = enabled
+        if not enabled:
+            self._btn_actions.setVisible(False)
+
+    def _on_actions_clicked(self) -> None:
+        self.menu_requested.emit(
+            self._index,
+            self._btn_actions.mapToGlobal(self._btn_actions.rect().bottomLeft()),
+        )
+
+    def contextMenuEvent(self, event):
+        if self._actions_enabled:
+            self.menu_requested.emit(self._index, event.globalPos())
+
+    def enterEvent(self, event):
+        self._btn_actions.setVisible(self._actions_enabled)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        self._btn_actions.setVisible(False)
+        super().leaveEvent(event)
+
     # ── Outer row refresh ─────────────────────────────────────────────────
     def refresh(self, step: TimelineStep) -> None:
         self._dot.set_color(_status_color(step.status))
@@ -298,6 +354,7 @@ class WorkflowTimelineWidget(QWidget):
     """Scrollable vertical list of outer workflow rows."""
 
     step_selected = pyqtSignal(int)
+    row_menu_requested = pyqtSignal(int, QPoint)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -306,7 +363,14 @@ class WorkflowTimelineWidget(QWidget):
         self._keys: List[str] = []
         self._selected_key: Optional[str] = None
         self._selected_index: Optional[int] = None
+        self._actions_enabled = False
         self._setup_ui()
+
+    def set_actions_enabled(self, enabled: bool) -> None:
+        """Offer queue actions on every row, or on none of them."""
+        self._actions_enabled = enabled
+        for row in self._rows:
+            row.set_actions_enabled(enabled)
 
     def _setup_ui(self) -> None:
         root = QVBoxLayout(self)
@@ -369,6 +433,8 @@ class WorkflowTimelineWidget(QWidget):
             if row is None:
                 row = _OuterRow(step, i, is_last=False)
                 row.clicked.connect(self._on_row_clicked)
+                row.menu_requested.connect(self.row_menu_requested)
+                row.set_actions_enabled(self._actions_enabled)
                 new_steps.append(step)
             else:
                 kept = step_by_key[key]
@@ -470,6 +536,11 @@ class WorkflowProgressWidget(QWidget):
                  hidden automatically when the task completes or fails.
     """
 
+    # (action, WorkItem.id). The widget never mutates the queue itself — it has
+    # no business knowing what a queue is — so the owner performs the action and
+    # feeds the result back through refresh_queue().
+    queue_action_requested = pyqtSignal(str, str)
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._items: list = []  # visible WorkItems from the last queue snapshot
@@ -496,9 +567,18 @@ class WorkflowProgressWidget(QWidget):
         root.addWidget(self._header)
 
         self._outer = WorkflowTimelineWidget()
+        self._outer.row_menu_requested.connect(self._show_row_menu)
         root.addWidget(self._outer, 1)
 
     # ── Public API ────────────────────────────────────────────────────────
+    def set_actions_enabled(self, enabled: bool) -> None:
+        """Offer queue actions on the rows, or not at all.
+
+        False when no run is live — the timeline stays on screen after a
+        workflow finishes, and there is no queue left to reorder.
+        """
+        self._outer.set_actions_enabled(enabled)
+
     def set_workflow(self, items: list) -> None:
         """Populate the outer timeline from queue items, starting fresh.
 
@@ -652,6 +732,66 @@ class WorkflowProgressWidget(QWidget):
         self._show_inner_at(index)
 
     # ── Internal ──────────────────────────────────────────────────────────
+    _FINISHED = (StepStatus.COMPLETED, StepStatus.FAILED,
+                 StepStatus.SKIPPED, StepStatus.CANCELLED)
+
+    def build_row_menu(self, index: int) -> Optional[QMenu]:
+        """The queue-actions menu for a row, or None if the row is unknown.
+
+        Enablement is worked out when the menu is built rather than cached on
+        the row: the worker may have consumed the row since the last paint. That
+        still leaves a race between opening the menu and clicking it, which is
+        why the owner has to handle a refusal rather than assume success.
+
+        Every row gets the same menu with the inapplicable entries greyed out —
+        a row with no menu teaches nothing about why it has no menu.
+        """
+        steps = self._outer._steps
+        if not (0 <= index < len(self._items)) or index >= len(steps):
+            return None
+
+        item_id = self._items[index].id
+        pending = [i for i, s in enumerate(steps) if s.status is StepStatus.PENDING]
+        rank = pending.index(index) if index in pending else -1
+        is_pending = rank >= 0
+        is_finished = steps[index].status in self._FINISHED
+
+        menu = QMenu(self)
+        menu.setToolTipsVisible(True)
+
+        def add(action_id: str, label: str, icon: str, enabled: bool):
+            act = menu.addAction(
+                fibsem_icon(icon, color=stylesheets.GRAY_ICON_COLOR), label
+            )
+            act.setEnabled(enabled)
+            act.setData(action_id)
+            if not (is_pending or is_finished):
+                act.setToolTip("This task is already running")
+            act.triggered.connect(
+                lambda _checked=False, a=action_id: self.queue_action_requested.emit(a, item_id)
+            )
+            return act
+
+        add("move_up", "Move up", "mdi:arrow-up", is_pending and rank > 0)
+        add("move_down", "Move down", "mdi:arrow-down",
+            is_pending and rank < len(pending) - 1)
+        add("run_next", "Run next", "mdi:skip-next", is_pending and rank > 0)
+        menu.addSeparator()
+        add("remove", "Remove from queue", "mdi:trash-can-outline", is_pending)
+        if is_finished:
+            menu.addSeparator()
+            add("run_again", "Run again", "mdi:refresh", True)
+        return menu
+
+    def _show_row_menu(self, index: int, pos: QPoint) -> None:
+        menu = self.build_row_menu(index)
+        if menu is None:
+            return
+        menu.exec_(pos)
+        # exec_ returns only after the chosen action has already fired, so the
+        # menu can go. Otherwise every right-click leaves one parented to us.
+        menu.deleteLater()
+
     def _show_inner_at(self, index: int) -> None:
         """Clear and show the inner container at *index*; hide all others."""
         for i, row in enumerate(self._outer._rows):

--- a/tests/autolamella/test_task_manager_status.py
+++ b/tests/autolamella/test_task_manager_status.py
@@ -5,71 +5,93 @@ broke as soon as the queue could be mutated: an added task raised ValueError
 out of _emit_status, and an added lamella was silently skipped as
 "not_required". Progress is now measured against the live queue instead.
 
-These exercise _emit_status/_should_skip directly with stubs — no microscope,
-no Qt, no experiment on disk.
+These drive _emit_status/_should_skip against a real Experiment, real Lamellas
+and a real task protocol. The only stand-ins are the two the environment cannot
+provide: a microscope and the Qt UI.
 """
 
-from types import SimpleNamespace
-from typing import Optional
+from pathlib import Path
+from typing import Dict, List, Optional
 
 import pytest
 
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaTaskProtocol,
+    AutoLamellaTaskState,
+)
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus as Status
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaWorkflowConfig,
+    DefectType,
+    Experiment,
+    Lamella,
+)
 from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
 
 
-class FakeSignal:
-    def __init__(self):
-        self.emitted = []
+class RecordingUI:
+    """The one stand-in here: a recorder in place of AutoLamellaUI.
 
-    def emit(self, payload):
+    AutoLamellaUI needs a live napari viewer with docked widgets, so it cannot be
+    built in a test. Everything else below is the real object. Deliberately not a
+    QObject with real pyqtSignals — this module has no Qt dependency, and adding
+    one would take it out of CI, where PyQt5 is not installed.
+    """
+
+    def __init__(self):
+        self.workflow_update_signal = self
+        self.emitted: List[dict] = []
+        self._task_manager = None  # _check_for_abort reads this
+
+    def emit(self, payload: dict) -> None:
         self.emitted.append(payload)
 
 
-class FakeUI:
-    def __init__(self):
-        self.workflow_update_signal = FakeSignal()
-        self._task_manager = None  # _check_for_abort reads this
+class NoMicroscope:
+    """Enough microscope to construct a TaskManager and retract the objective.
+
+    Experiment.register_metadata stamps the user and experiment ref onto it, so
+    it has to be something attributes can be set on — None will not do.
+    """
+    fm = None
 
 
-def fake_lamella(name: str, is_failure: bool = False, completed=()):
-    return SimpleNamespace(
-        name=name,
-        id=f"id-{name}",
-        is_failure=is_failure,
-        has_completed_task=lambda task, _done=set(completed): task in _done,
-        task_config={},
-        task_state=SimpleNamespace(status=Status.NotStarted, status_message="",
-                                   duration=0.0, task_type="", task_id=f"task-{name}"),
-    )
+def make_lamella(experiment: Experiment, name: str, is_failure: bool = False,
+                 completed=()) -> Lamella:
+    lamella = Lamella(path=Path(experiment.path) / name,
+                      number=len(experiment.positions) + 1, petname=name)
+    if is_failure:
+        lamella.defect.state = DefectType.FAILURE
+    for task_name in completed:
+        lamella.task_history.append(
+            AutoLamellaTaskState(name=task_name, status=Status.Completed)
+        )
+    experiment.positions.append(lamella)
+    return lamella
 
 
-def fake_experiment(requirements: Optional[dict] = None):
+def make_experiment(tmp_path: Path, requirements: Optional[Dict[str, List[str]]] = None,
+                    lamella_names=("L1", "L2")) -> Experiment:
+    """A real Experiment with a real task protocol.
+
+    ``required=False`` throughout so nothing is ever "complete" — the completion
+    hooks are a different test module's subject and would only add noise here.
+    """
     reqs = requirements or {}
-    lamellas: dict = {}
-
-    def get_lamella_by_name(name: str):
-        return lamellas.setdefault(name, fake_lamella(name))
-
-    return SimpleNamespace(
-        positions=[],
-        id="exp-1",
-        name="test-exp",
-        save=lambda: None,
-        task_history_dataframe=lambda: "",
-        get_lamella_by_name=get_lamella_by_name,
-        register_metadata=lambda microscope: None,
-        task_protocol=SimpleNamespace(
-            workflow_config=SimpleNamespace(
-                requirements=lambda name: reqs.get(name, []),
-                get_scheduled_at=lambda name: None,
-                # no required tasks -> _is_complete is False, so the completion
-                # hooks stay out of the way of what these tests are about
-                required_tasks=[],
-                is_completed=lambda lamella: False,
-            ),
-        ),
+    experiment = Experiment(path=tmp_path, name="test-exp")
+    experiment.task_protocol = AutoLamellaTaskProtocol(
+        workflow_config=AutoLamellaWorkflowConfig(
+            tasks=[
+                AutoLamellaTaskDescription(name=name, supervise=False, required=False,
+                                           requires=reqs.get(name, []))
+                for name in ("Trench", "Undercut", "Polishing")
+            ]
+        )
     )
+    for name in lamella_names:
+        make_lamella(experiment, name)
+    return experiment
 
 
 def run_queue_with(manager: TaskManager, on_task=None):
@@ -87,7 +109,6 @@ def run_queue_with(manager: TaskManager, on_task=None):
             on_task(task_name, lamella)
         return None
 
-    manager.microscope = SimpleNamespace(fm=None)
     manager.parent_ui._task_manager = manager
     manager._run_single_task = _run_single_task
     manager._run_queue()
@@ -95,8 +116,9 @@ def run_queue_with(manager: TaskManager, on_task=None):
 
 
 @pytest.fixture
-def manager() -> TaskManager:
-    m = TaskManager(microscope=None, experiment=fake_experiment(), parent_ui=FakeUI())
+def manager(tmp_path) -> TaskManager:
+    m = TaskManager(microscope=NoMicroscope(),
+                    experiment=make_experiment(tmp_path), parent_ui=RecordingUI())
     m.queue.build_from_matrix(["Trench", "Undercut"], ["L1", "L2"])
     return m
 
@@ -109,7 +131,7 @@ def last_status(manager: TaskManager) -> dict:
 
 def test_emit_reports_position_in_the_live_queue(manager):
     item = manager.queue.items[2]
-    manager._emit_status(item=item, lamella=fake_lamella(item.lamella_name),
+    manager._emit_status(item=item, lamella=manager.experiment.get_lamella_by_name(item.lamella_name),
                          status=Status.InProgress)
     status = last_status(manager)
     assert status["queue_position"] == 3
@@ -121,7 +143,7 @@ def test_emit_for_a_task_outside_the_launch_plan(manager):
     added = manager.queue.add("L1", "Polishing")
     assert added.task_name not in manager.queue.task_names
 
-    manager._emit_status(item=added, lamella=fake_lamella("L1"),
+    manager._emit_status(item=added, lamella=manager.experiment.get_lamella_by_name("L1"),
                          status=Status.InProgress)
     status = last_status(manager)
     assert status["task_name"] == "Polishing"
@@ -131,7 +153,8 @@ def test_emit_for_a_task_outside_the_launch_plan(manager):
 
 def test_emit_for_a_lamella_outside_the_launch_plan(manager):
     added = manager.queue.add("L99", "Trench")
-    manager._emit_status(item=added, lamella=fake_lamella("L99"),
+    manager._emit_status(item=added,
+                         lamella=make_lamella(manager.experiment, "L99"),
                          status=Status.InProgress)
     status = last_status(manager)
     assert status["item_name"] == "L99"
@@ -143,14 +166,14 @@ def test_emit_for_a_lamella_outside_the_launch_plan(manager):
 def test_emit_position_follows_a_reorder(manager):
     item = manager.queue.items[3]
     manager.queue.move_to_front(item.id)
-    manager._emit_status(item=item, lamella=fake_lamella(item.lamella_name),
+    manager._emit_status(item=item, lamella=manager.experiment.get_lamella_by_name(item.lamella_name),
                          status=Status.InProgress)
     assert last_status(manager)["queue_position"] == 1
 
 
 def test_emit_carries_the_launch_plan_as_context(manager):
     item = manager.queue.items[0]
-    manager._emit_status(item=item, lamella=fake_lamella("L1"), status=Status.InProgress)
+    manager._emit_status(item=item, lamella=manager.experiment.get_lamella_by_name("L1"), status=Status.InProgress)
     status = last_status(manager)
     assert status["task_names"] == ["Trench", "Undercut"]
     assert status["lamella_names"] == ["L1", "L2"]
@@ -158,7 +181,7 @@ def test_emit_carries_the_launch_plan_as_context(manager):
 
 def test_emit_includes_a_queue_snapshot(manager):
     item = manager.queue.items[0]
-    manager._emit_status(item=item, lamella=fake_lamella("L1"), status=Status.InProgress)
+    manager._emit_status(item=item, lamella=manager.experiment.get_lamella_by_name("L1"), status=Status.InProgress)
     snapshot = last_status(manager)["queue_items"]
     assert len(snapshot) == 4
     snapshot[0].status = Status.Failed
@@ -167,7 +190,7 @@ def test_emit_includes_a_queue_snapshot(manager):
 
 def test_emit_passes_through_error_and_skip_detail(manager):
     item = manager.queue.items[0]
-    manager._emit_status(item=item, lamella=fake_lamella("L1"), status=Status.Failed,
+    manager._emit_status(item=item, lamella=manager.experiment.get_lamella_by_name("L1"), status=Status.Failed,
                          msg="boom", error_message="it broke", task_duration=12.5)
     status = last_status(manager)
     assert status["error_message"] == "it broke"
@@ -175,10 +198,12 @@ def test_emit_passes_through_error_and_skip_detail(manager):
     assert manager.parent_ui.workflow_update_signal.emitted[-1]["msg"] == "boom"
 
 
-def test_emit_is_a_noop_headless():
-    m = TaskManager(microscope=None, experiment=fake_experiment(), parent_ui=None)
+def test_emit_is_a_noop_headless(tmp_path):
+    experiment = make_experiment(tmp_path, lamella_names=["L1"])
+    m = TaskManager(microscope=NoMicroscope(), experiment=experiment, parent_ui=None)
     m.queue.build_from_matrix(["Trench"], ["L1"])
-    m._emit_status(item=m.queue.items[0], lamella=fake_lamella("L1"),
+    m._emit_status(item=m.queue.items[0],
+                   lamella=experiment.get_lamella_by_name("L1"),
                    status=Status.InProgress)  # must not raise
 
 
@@ -186,25 +211,34 @@ def test_emit_is_a_noop_headless():
 
 def test_lamella_outside_the_launch_selection_is_not_skipped(manager):
     """Regression: the old allow-list check skipped anything added mid-run."""
+    lamella = make_lamella(manager.experiment, "L99")
     assert "L99" not in manager.queue.lamella_names
-    assert manager._should_skip(fake_lamella("L99"), "Trench") is None
+    assert manager._should_skip(lamella, "Trench") is None
 
 
 def test_failed_lamella_is_skipped(manager):
-    assert manager._should_skip(fake_lamella("L1", is_failure=True), "Trench") == "failure"
+    lamella = manager.experiment.get_lamella_by_name("L1")
+    lamella.defect.state = DefectType.FAILURE
+    assert manager._should_skip(lamella, "Trench") == "failure"
 
 
-def test_missing_prerequisites_are_skipped():
-    m = TaskManager(microscope=None,
-                    experiment=fake_experiment({"Undercut": ["Trench"]}),
-                    parent_ui=FakeUI())
+def test_missing_prerequisites_are_skipped(tmp_path):
+    experiment = make_experiment(tmp_path, requirements={"Undercut": ["Trench"]},
+                                 lamella_names=["L1"])
+    m = TaskManager(microscope=NoMicroscope(), experiment=experiment,
+                    parent_ui=RecordingUI())
     m.queue.build_from_matrix(["Trench", "Undercut"], ["L1"])
-    assert m._should_skip(fake_lamella("L1"), "Undercut") == "missing_prereqs"
-    assert m._should_skip(fake_lamella("L1", completed=["Trench"]), "Undercut") is None
+    lamella = experiment.get_lamella_by_name("L1")
+    assert m._should_skip(lamella, "Undercut") == "missing_prereqs"
+
+    lamella.task_history.append(
+        AutoLamellaTaskState(name="Trench", status=Status.Completed)
+    )
+    assert m._should_skip(lamella, "Undercut") is None
 
 
 def test_no_requirements_runs(manager):
-    assert manager._should_skip(fake_lamella("L1"), "Trench") is None
+    assert manager._should_skip(manager.experiment.get_lamella_by_name("L1"), "Trench") is None
 
 
 # ── _run_queue: mid-run queue edits ───────────────────────────────────────────
@@ -229,7 +263,13 @@ def test_task_added_mid_run_executes(manager):
 
 
 def test_lamella_added_mid_run_executes(manager):
-    """An out-of-plan lamella used to be silently skipped as not_required."""
+    """An out-of-plan lamella used to be silently skipped as not_required.
+
+    It still has to exist in the experiment: queueing work for a name the
+    experiment has never heard of is skipped with a warning, which a fake
+    experiment that conjured lamellas on lookup used to hide.
+    """
+    make_lamella(manager.experiment, "L99")
     added = []
 
     def on_task(task_name, lamella):

--- a/tests/ui/test_workflow_timeline_actions.py
+++ b/tests/ui/test_workflow_timeline_actions.py
@@ -1,0 +1,286 @@
+"""Headless tests for the timeline's queue-actions menu (FIB-476).
+
+Every row gets the same menu; what varies is which entries are enabled. A row
+with no menu would teach nothing about why it has no menu, so the rule is shown
+rather than inferred.
+
+Enablement is computed when the menu is built, not cached on the row — the
+worker may have consumed the row since the last paint. That still leaves a race
+between the menu opening and the click, which the owner handles via QueueResult.
+
+Uses the shared offscreen ``qapp`` fixture from tests/conftest.py.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus as Status
+from fibsem.applications.autolamella.workflows.tasks.queue import QueueOp, TaskQueue
+from fibsem.ui.widgets.workflow_timeline_widget import WorkflowProgressWidget
+
+
+@pytest.fixture
+def queue() -> TaskQueue:
+    q = TaskQueue()
+    q.build_from_matrix(["Trench", "Undercut"], ["L1", "L2"])
+    return q
+
+
+@pytest.fixture
+def widget(qapp, queue) -> WorkflowProgressWidget:
+    """A timeline mid-run: item 0 finished, item 1 running, 2 and 3 pending."""
+    w = WorkflowProgressWidget()
+    done = queue.next()
+    queue.mark_done(done, Status.Completed)
+    queue.next()  # marks item 1 InProgress
+    w.set_workflow(queue.items)
+    w.set_actions_enabled(True)
+    return w
+
+
+def actions(widget: WorkflowProgressWidget, index: int) -> dict:
+    """{action_id: enabled} for the menu on row *index*."""
+    menu = widget.build_row_menu(index)
+    return {a.data(): a.isEnabled() for a in menu.actions() if a.data()}
+
+
+# ── What each row state offers ────────────────────────────────────────────────
+
+def test_a_pending_row_offers_every_move(widget):
+    assert actions(widget, 2) == {
+        "move_up": False,       # already the first pending item
+        "move_down": True,
+        "run_next": False,      # already runs next
+        "remove": True,
+    }
+
+
+def test_the_last_pending_row_cannot_move_down(widget):
+    assert actions(widget, 3) == {
+        "move_up": True,
+        "move_down": False,
+        "run_next": True,
+        "remove": True,
+    }
+
+
+def test_the_running_row_offers_nothing(widget):
+    """Not an empty menu — the greyed entries are what explain the rule."""
+    assert actions(widget, 1) == {
+        "move_up": False, "move_down": False,
+        "run_next": False, "remove": False,
+    }
+
+
+def test_the_running_row_says_why_it_is_greyed(widget):
+    menu = widget.build_row_menu(1)
+    assert all(a.toolTip() == "This task is already running"
+               for a in menu.actions() if a.data())
+
+
+def test_a_finished_row_offers_only_run_again(widget):
+    assert actions(widget, 0) == {
+        "move_up": False, "move_down": False,
+        "run_next": False, "remove": False,
+        "run_again": True,
+    }
+
+
+def test_run_again_is_absent_while_a_row_could_still_run(widget):
+    """It would be meaningless on a queued row and wrong on the running one."""
+    for index in (1, 2, 3):
+        assert "run_again" not in actions(widget, index)
+
+
+def test_a_skipped_row_can_be_run_again(widget, queue):
+    """A skip is often a prerequisite that has since been satisfied."""
+    item = queue.pending[0]
+    queue.mark_done(item, Status.Skipped)
+    widget.refresh_queue(queue.items)
+    assert actions(widget, 2)["run_again"] is True
+
+
+def test_no_menu_for_a_row_that_is_gone(widget):
+    assert widget.build_row_menu(99) is None
+
+
+# ── The signal the owner acts on ──────────────────────────────────────────────
+
+def test_triggering_an_action_reports_it_against_the_row_id(widget, queue):
+    seen = []
+    widget.queue_action_requested.connect(lambda a, i: seen.append((a, i)))
+
+    menu = widget.build_row_menu(3)
+    next(a for a in menu.actions() if a.data() == "run_next").trigger()
+
+    assert seen == [("run_next", widget._items[3].id)]
+
+
+def test_the_id_survives_the_row_moving_under_the_menu(widget, queue):
+    """The menu is keyed on identity, so a reorder between opening and clicking
+    cannot redirect the action onto whatever slid into that position."""
+    target = widget._items[3]
+    menu = widget.build_row_menu(3)
+
+    queue.move_to_front(target.id)
+    widget.refresh_queue(queue.items)
+
+    seen = []
+    widget.queue_action_requested.connect(lambda a, i: seen.append((a, i)))
+    next(a for a in menu.actions() if a.data() == "remove").trigger()
+
+    assert seen == [("remove", target.id)]
+
+
+# ── Actions off ───────────────────────────────────────────────────────────────
+
+def test_the_button_appears_on_hover_and_leaves_again(widget):
+    """Right-click alone is undiscoverable; a permanent button on every row of a
+    dense timeline is noise. Hover is the compromise."""
+    from PyQt5.QtCore import QEvent
+
+    row = widget._outer._rows[2]
+    assert not row._btn_actions.isVisibleTo(row)
+
+    row.enterEvent(QEvent(QEvent.Enter))
+    assert row._btn_actions.isVisibleTo(row)
+
+    row.leaveEvent(QEvent(QEvent.Leave))
+    assert not row._btn_actions.isVisibleTo(row)
+
+
+def test_hovering_a_row_shows_nothing_when_no_run_is_live(widget):
+    from PyQt5.QtCore import QEvent
+
+    widget.set_actions_enabled(False)
+    row = widget._outer._rows[2]
+    row.enterEvent(QEvent(QEvent.Enter))
+    assert not row._btn_actions.isVisibleTo(row)
+
+
+def test_rows_hide_the_button_when_no_run_is_live(widget):
+    widget.set_actions_enabled(False)
+    assert all(not r._btn_actions.isVisible() for r in widget._outer._rows)
+    assert all(not r._actions_enabled for r in widget._outer._rows)
+
+
+def test_rows_added_later_inherit_the_current_setting(widget, queue):
+    queue.add("L9", "Polish")
+    widget.refresh_queue(queue.items)
+    assert widget._outer._rows[-1]._actions_enabled is True
+
+    widget.set_actions_enabled(False)
+    queue.add("L8", "Polish")
+    widget.refresh_queue(queue.items)
+    assert widget._outer._rows[-1]._actions_enabled is False
+
+
+# ── The queue calls the menu maps onto ────────────────────────────────────────
+
+def test_each_action_does_what_the_menu_says(queue):
+    """Guards the mapping in AutoLamellaMainUI._on_queue_action."""
+    queue.next()  # item 0 running; 1, 2, 3 pending
+    last = queue.pending[-1]
+
+    assert queue.nudge(last.id, -1).op is QueueOp.OK
+    assert queue.pending[-2].id == last.id
+
+    assert queue.move_to_front(last.id).op is QueueOp.OK
+    assert queue.pending[0].id == last.id
+
+    assert queue.nudge(last.id, -1).op is QueueOp.NO_OP  # already first
+    assert queue.remove(last.id).op is QueueOp.OK
+    assert last.id not in [i.id for i in queue.pending]
+
+
+def test_acting_on_the_running_row_is_refused_not_misapplied(queue):
+    """What the owner turns into "... is already running"."""
+    active = queue.next()
+    for result in (queue.nudge(active.id, -1), queue.move_to_front(active.id),
+                   queue.remove(active.id)):
+        assert result.op is QueueOp.NOT_PENDING
+
+
+def test_run_again_queues_a_fresh_item_without_touching_the_original(queue):
+    done = queue.next()
+    queue.mark_done(done, Status.Failed)
+
+    added = queue.add(done.lamella_name, done.task_name, front=True)
+
+    assert added.id != done.id
+    assert queue.pending[0].id == added.id
+    assert queue.items[0].status is Status.Failed  # the original attempt stands
+
+
+# ── What the user is told ─────────────────────────────────────────────────────
+
+def describe(action: str, op: QueueOp) -> str:
+    from fibsem.applications.autolamella.workflows.tasks.queue import QueueResult
+    from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+        AutoLamellaSingleWindowUI,
+    )
+    return AutoLamellaSingleWindowUI._queue_action_message(
+        action, "Trench for L1", QueueResult(op, 1)
+    )
+
+
+def test_every_successful_action_is_confirmed():
+    """There is no modal on remove, so the status line is the only acknowledgement
+    the user gets that a queued task is gone."""
+    assert describe("remove", QueueOp.OK) == "Removed Trench for L1 from the queue."
+    assert describe("run_next", QueueOp.OK) == "Trench for L1 will run next."
+    assert describe("move_up", QueueOp.OK) == "Moved Trench for L1 up."
+    assert describe("move_down", QueueOp.OK) == "Moved Trench for L1 down."
+
+
+def test_a_row_that_started_running_says_so_rather_than_nothing():
+    assert describe("remove", QueueOp.NOT_PENDING) == "Trench for L1 is already running."
+
+
+def test_hitting_the_end_of_the_queue_says_nothing():
+    """Already first or last — the user can see that; a message would be noise."""
+    assert describe("move_up", QueueOp.NO_OP) == ""
+
+
+def test_a_vanished_row_is_reported():
+    assert describe("move_up", QueueOp.NOT_FOUND) == "Trench for L1 is no longer in the queue."
+
+
+def test_the_feature_flag_reaches_the_runtime_constant():
+    """Editing a live queue is off unless asked for, like every other flag here.
+
+    The dialog round trip is covered in test_preferences_dialog.py; this is the
+    last link, from the preference to the constant AutoLamellaMainUI reads when
+    it decides whether to offer the actions at all.
+    """
+    import fibsem.config as fibsem_cfg
+    from fibsem.config import FeatureFlags, UserPreferences
+
+    assert FeatureFlags().edit_running_queue is False
+
+    previous = fibsem_cfg.FEATURE_EDIT_RUNNING_QUEUE_ENABLED
+    try:
+        fibsem_cfg.apply_feature_flags(
+            UserPreferences(features=FeatureFlags(edit_running_queue=True))
+        )
+        assert fibsem_cfg.FEATURE_EDIT_RUNNING_QUEUE_ENABLED is True
+
+        fibsem_cfg.apply_feature_flags(UserPreferences(features=FeatureFlags()))
+        assert fibsem_cfg.FEATURE_EDIT_RUNNING_QUEUE_ENABLED is False
+    finally:
+        fibsem_cfg.FEATURE_EDIT_RUNNING_QUEUE_ENABLED = previous
+
+
+def test_the_dark_theme_greys_disabled_menu_items():
+    """Load-bearing for the whole menu design, and easy to lose in a restyle.
+
+    NAPARI_STYLE sets a colour on QMenu, which also paints disabled items unless
+    an explicit :disabled rule overrides it — so without this a greyed action is
+    pixel-identical to an available one, and the menu teaches nothing.
+    """
+    from fibsem.ui.stylesheets import NAPARI_STYLE
+    assert "QMenu::item:disabled" in NAPARI_STYLE

--- a/tests/ui/test_workflow_timeline_sync.py
+++ b/tests/ui/test_workflow_timeline_sync.py
@@ -14,7 +14,6 @@ or with the previous snapshot; the id is the only stable handle.
 Uses the shared offscreen ``qapp`` fixture from tests/conftest.py.
 """
 import os
-from types import SimpleNamespace
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -22,7 +21,10 @@ import pytest
 
 pytest.importorskip("PyQt5")
 
+from PyQt5.QtCore import QObject, pyqtSignal
+
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus as Status
+from fibsem.applications.autolamella.structures import Experiment, Lamella
 from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
 from fibsem.applications.autolamella.workflows.tasks.queue import TaskQueue
 from fibsem.ui.widgets.workflow_timeline_widget import (
@@ -312,38 +314,73 @@ def test_completion_subtitle_is_not_wiped_by_a_later_sync(widget, queue):
 
 # ── Through the real TaskManager ──────────────────────────────────────────────
 
-class _SignalToWidget:
-    """Stands in for workflow_update_signal, routing payloads into the widget
-    exactly as AutoLamellaMainUI._on_workflow_update does.
+class _ParentUI(QObject):
+    """The signals TaskManager emits on, declared as real pyqtSignals.
 
-    The payload shape is the seam between the manager and the timeline; going
-    through the real _emit_status is what stops the two drifting apart.
+    AutoLamellaUI itself needs a live napari viewer with docked widgets, so it
+    cannot be built here — but the signals are real Qt signals with real
+    connection and dispatch, not a Python object with an ``emit`` method. That
+    matters: a queue edit reaching the wrong signal is what crashed the app.
     """
 
-    def __init__(self, widget: WorkflowProgressWidget):
-        self._widget = widget
+    workflow_update_signal = pyqtSignal(dict)
+    queue_changed_signal = pyqtSignal(dict)
 
-    def emit(self, info: dict) -> None:
-        queue_changed = info.get("queue_changed", None)
-        if queue_changed is not None:
-            self._widget.refresh_queue(queue_changed.get("queue_items", []))
-        status = info.get("status", None)
-        if status is not None:
-            self._widget.update_from_status(status)
+    def __init__(self):
+        super().__init__()
+        self.workflow_updates = []
+        self.queue_changes = []
+        self.workflow_update_signal.connect(self.workflow_updates.append)
+        self.queue_changed_signal.connect(self.queue_changes.append)
+
+
+class _NoMicroscope:
+    """Enough microscope for TaskManager's constructor and its objective retract.
+
+    Experiment.register_metadata stamps the user and experiment ref onto it, so
+    it has to be something attributes can be set on. Same stand-in as
+    tests/autolamella/test_task_manager_hooks.py.
+    """
+    fm = None
+
+
+def _experiment(tmp_path, names=("L1", "L2")) -> Experiment:
+    experiment = Experiment(path=tmp_path, name="test-exp")
+    for i, name in enumerate(names, start=1):
+        experiment.positions.append(
+            Lamella(path=experiment.path, number=i, petname=name)
+        )
+    return experiment
 
 
 @pytest.fixture
-def manager(widget) -> TaskManager:
-    experiment = SimpleNamespace(register_metadata=lambda microscope: None)
-    parent_ui = SimpleNamespace(workflow_update_signal=_SignalToWidget(widget))
-    m = TaskManager(microscope=None, experiment=experiment, parent_ui=parent_ui)
-    m.queue.build_from_matrix(["Trench", "Undercut"], ["L1", "L2"])
+def manager(widget, tmp_path) -> TaskManager:
+    """A real TaskManager, on a real Experiment, wired to the real widget.
+
+    The slots mirror AutoLamellaMainUI._on_workflow_update and _on_queue_changed.
+    Going through the real _emit_status / notify_queue_changed is what stops the
+    payload contract drifting from the widget that reads it.
+    """
+    experiment = _experiment(tmp_path)
+    parent_ui = _ParentUI()
+    parent_ui.workflow_update_signal.connect(
+        lambda info: widget.update_from_status(info["status"])
+    )
+    parent_ui.queue_changed_signal.connect(
+        lambda info: widget.refresh_queue(info["queue_items"])
+    )
+
+    m = TaskManager(microscope=_NoMicroscope(), experiment=experiment,
+                    parent_ui=parent_ui)
+    m.queue.build_from_matrix(
+        ["Trench", "Undercut"], [p.name for p in experiment.positions]
+    )
     return m
 
 
 def emit(manager: TaskManager, item, status, **extra) -> None:
-    manager._emit_status(item=item, lamella=SimpleNamespace(name=item.lamella_name),
-                         status=status, **extra)
+    lamella = manager.experiment.get_lamella_by_name(item.lamella_name)
+    manager._emit_status(item=item, lamella=lamella, status=status, **extra)
 
 
 def test_the_managers_own_payload_builds_the_timeline(widget, manager):
@@ -369,8 +406,46 @@ def test_notify_queue_changed_reaches_the_timeline(widget, manager):
     assert [r._label.text() for r in widget._outer._rows[0]._inner_rows] == ["Setup"]
 
 
-def test_notify_queue_changed_is_a_noop_headless():
-    experiment = SimpleNamespace(register_metadata=lambda microscope: None)
-    m = TaskManager(microscope=None, experiment=experiment, parent_ui=None)
+def test_notify_queue_changed_is_a_noop_headless(tmp_path):
+    m = TaskManager(microscope=_NoMicroscope(),
+                    experiment=_experiment(tmp_path, names=["L1"]), parent_ui=None)
     m.queue.build_from_matrix(["Trench"], ["L1"])
     m.notify_queue_changed()  # must not raise
+
+
+def test_a_queue_edit_never_reaches_the_workflow_update_slot(manager):
+    """Regression: this crashed the app on every queue action.
+
+    workflow_update_signal also drives AutoLamellaUI.handle_workflow_update,
+    which reads info["msg"] with no default — so a payload without it raised
+    KeyError out of a slot, and PyQt5 aborts the process on that. Beyond the
+    missing key, that handler rebuilds the interaction UI and clears
+    WAITING_FOR_UI_UPDATE, none of which a queue edit should touch.
+    """
+    manager.queue.add("L9", "Polish")
+    manager.notify_queue_changed()
+
+    assert manager.parent_ui.workflow_updates == []
+    assert len(manager.parent_ui.queue_changes) == 1
+
+
+def test_task_status_still_goes_out_on_the_workflow_signal(manager):
+    """The other half of the split: don't quietly reroute the lifecycle stream."""
+    item = manager.queue.next()
+    emit(manager, item, Status.InProgress)
+
+    assert len(manager.parent_ui.workflow_updates) == 1
+    assert manager.parent_ui.queue_changes == []
+
+
+def test_every_workflow_update_carries_the_key_its_other_slot_requires(manager):
+    """AutoLamellaUI.handle_workflow_update reads info["msg"] with no default, and
+    PyQt5 aborts the process on an exception escaping a slot. Every payload put on
+    this signal has to satisfy that, whoever emits it."""
+    item = manager.queue.next()
+    emit(manager, item, Status.InProgress)
+    manager.queue.mark_done(item, Status.Completed)
+    emit(manager, item, Status.Completed, task_duration=1.0)
+
+    assert manager.parent_ui.workflow_updates
+    assert all("msg" in info for info in manager.parent_ui.workflow_updates)


### PR DESCRIPTION
Follows #277. That made a queue mutation visible; this lets a user make one. Off by default behind a new `edit_running_queue` feature flag — it acts on a real sample mid-session, so it's opt-in like the other flags here.

## The menu

Every row carries the same menu — move up, move down, run next, remove — with inapplicable entries greyed rather than absent, because a row with no menu teaches nothing about why it has no menu. Only queued rows are mutable. A finished row offers **Run again** instead, which queues a fresh item rather than rewinding, so the original attempt stays in the run record.

Enablement is computed when the menu is built, not cached on the row — the worker may have consumed it since the last paint. That still leaves a race between opening the menu and clicking, which is what `QueueResult` is for: the refusal is reported ("… is already running") rather than silently doing nothing.

Removal isn't behind a modal — it's already two clicks deep and the row vanishing is its own acknowledgement — but every action reports what it did in the status bar.

Discoverability is a hover-revealed `⋯` plus right-click. Right-click alone is invisible; a permanent button on every row of a dense timeline is noise.

The widget stays generic: it emits `queue_action_requested(action, item_id)` and `AutoLamellaMainUI` performs the mutation, so `fibsem/ui/widgets/` still knows nothing about queues.

## Two bugs found by running it, not by testing it

**Queue edits needed their own signal.** I first reused `workflow_update_signal`. It has a second subscriber I hadn't checked — `AutoLamellaUI.handle_workflow_update` — which reads `info["msg"]` with no default. PyQt5 calls `qFatal` on an exception escaping a slot, so *every* action aborted the app.

Underneath that was a worse one: the same handler ends with `WAITING_FOR_UI_UPDATE = False`, and worker threads block on that flag in eight places. Had I only added a `msg` key, reordering the queue during a supervised step would have released a task still waiting on the user. A queue edit is not a step in the task lifecycle, so it now has its own signal.

**Disabled menu items didn't look disabled.** `NAPARI_STYLE` sets a colour on `QMenu`, which also paints disabled items unless an explicit `:disabled` rule overrides it — so a greyed action was pixel-identical to an available one, in every menu in the app. `QMenu` was the only control missing the rule `QPushButton`, `QLineEdit`, `QComboBox` and `QSpinBox` all have.

## Tests now use real objects

The status and timeline tests build a real `Experiment`, real `Lamella`s and a real `AutoLamellaTaskProtocol` instead of `SimpleNamespace` stand-ins — the pattern already used in `test_task_manager_hooks.py`.

That immediately caught two tests asserting behaviour the app doesn't have. The fake experiment conjured a lamella for any name looked up, so "a lamella added mid-run executes" passed; against a real `Experiment` it's skipped with *"no lamella named L99 in the experiment"*. Worth knowing before the add-to-queue dialog lands — it has to pick from existing lamellae, not accept free text.

The remaining stand-ins are the two the environment can't provide, both documented in place: no microscope, and `AutoLamellaUI` (which needs a live napari viewer with docked widgets — one more reason the napari work matters).

## Flag wiring

`FeatureFlags.edit_running_queue`, default `False`, with a preferences checkbox. `test_preferences_dialog.py` enumerates the dataclass, so the round trip is covered automatically; one added test covers the last link from preference to runtime constant.

Full suite: 2452 passed. Verified in the app against the Demo microscope.
