### PR TITLE
[fibsem] Replace the embedded SystemSettings with one hardware geometry record (FIB-481)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -989,7 +989,8 @@ class AutoLamellaUI(QMainWindow):
                     resolution=(2048, 2048), hfw=4000e-6
                 )
                 image.metadata.microscope_state = ms  # type: ignore
-                image.metadata.system = self.microscope.system  # type: ignore
+                image.metadata.system_info = self.microscope.system.info  # type: ignore
+                image.metadata.hardware_geometry = self.microscope.hardware_geometry()  # type: ignore
                 self.minimap_plot_widget.image = image
 
             beam_type = self.minimap_plot_widget.image.metadata.beam_type  # type: ignore

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -15,7 +15,11 @@ import fibsem
 # to v5 when it dropped its duplicates of the application/version fields, which
 # SystemInfo owns, and when `application_version` went entirely -- it was null in every
 # file ever written (FIB-448). Those keys are still present in v4-and-earlier files.
-METADATA_VERSION = "v5"
+# v6 replaced the embedded `system` (a whole SystemSettings, 1683 bytes) with
+# `system_info` and `hardware_geometry` (FIB-481). from_dict recovers both from a v5-
+# and-earlier `system` blob, so older files still load -- including their compustage
+# flag, which up to v5 had to be inferred from the model name.
+METADATA_VERSION = "v6"
 # What an unversioned file is. Absent means written before versioning existed, i.e.
 # older than v1 -- not "current", which is what defaulting to METADATA_VERSION claimed.
 UNVERSIONED_METADATA = "v0"

--- a/fibsem/fm/reprojection.py
+++ b/fibsem/fm/reprojection.py
@@ -6,7 +6,7 @@ would send the stage, these ask where the stage already is on screen. Both run t
 projection, so a marker drawn here lands where clicking there would take you.
 
 Microscope-free by design. Everything the projection reads comes from the image's own
-:class:`FMImageGeometry` and stage position, so a saved overview reprojects correctly
+:class:`FibsemHardwareGeometry` and stage position, so a saved overview reprojects correctly
 even when the stage has since moved or the display transform has since been flipped --
 which is precisely when someone is looking at a saved overview. Reading any of it from
 a live microscope would make the result depend on state the image does not describe.
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, List, Tuple
 
 import numpy as np
 
-from fibsem.fm.structures import FMImageGeometry
+from fibsem.fm.structures import FibsemHardwareGeometry
 from fibsem.movement import rotation_angle_is_smaller
 from fibsem.structures import FibsemStagePosition, Point
 
@@ -33,7 +33,7 @@ if TYPE_CHECKING:  # pragma: no cover - annotation only
 
 
 def _projection_terms(
-    geometry: FMImageGeometry,
+    geometry: FibsemHardwareGeometry,
     stage_rotation: float,
     stage_tilt: float,
 ) -> Tuple[float, float, float]:
@@ -92,7 +92,7 @@ def _projection_terms(
 
 def view_corrected_stage_movement(
     expected_y: float,
-    geometry: FMImageGeometry,
+    geometry: FibsemHardwareGeometry,
     stage_rotation: float,
     stage_tilt: float,
 ) -> Tuple[float, float]:
@@ -131,7 +131,7 @@ def view_corrected_stage_movement(
 def inverse_view_corrected_dy(
     dy: float,
     dz: float,
-    geometry: FMImageGeometry,
+    geometry: FibsemHardwareGeometry,
     stage_rotation: float,
     stage_tilt: float,
 ) -> float:
@@ -184,7 +184,7 @@ def project_stage_position(
     base_position: FibsemStagePosition,
     pixel_size: float,
     image_shape: Tuple[int, int],
-    geometry: FMImageGeometry,
+    geometry: FibsemHardwareGeometry,
 ) -> Point:
     """Where a stage position falls in a displayed FM image, in pixels.
 
@@ -225,7 +225,7 @@ def project_image_point(
     base_position: FibsemStagePosition,
     pixel_size: float,
     image_shape: Tuple[int, int],
-    geometry: FMImageGeometry,
+    geometry: FibsemHardwareGeometry,
 ) -> FibsemStagePosition:
     """The stage position under a pixel in a displayed FM image.
 

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -42,11 +42,20 @@ from ome_types.model import (
 # enum of the same name here, so the two tilers held different objects for the same
 # concept and `is` comparisons across them silently failed. Imported (and so
 # re-exported) rather than redefined, to keep that from happening again.
-from fibsem.structures import (
+#
+# CameraImageTransform, its parser and FibsemHardwareGeometry are canonical there for
+# the same reason: the geometry record is one structure for both modalities, it needs
+# the enum, and core cannot import from this package -- this module imports from it, so
+# the reverse is a cycle. Imported (and so re-exported) here, which is where every
+# consumer of them still is. FMImageGeometry was the FM-only half until FIB-481.
+from fibsem.structures import (  # noqa: F401
     AutoFocusMode,
+    CameraImageTransform,
+    FibsemHardwareGeometry,
     FibsemRectangle,
     FibsemStagePosition,
     TileOrderStrategy,
+    _parse_image_transform,
 )
 
 # Autofocus types are canonical in fibsem.autofunctions.autofocus; re-export here
@@ -57,130 +66,6 @@ from fibsem.autofunctions.autofocus import (  # noqa: E402,F401
     FocusMethod,
     FocusSweepPass,
 )
-
-
-class CameraImageTransform(Enum):
-    """Image transformations for aligning fluorescence images with SEM/FIB coordinate systems.
-
-    Flips only. Any fixed rotation between the sensor and the stage belongs to the
-    mount, not to user preference, and is corrected inside the driver
-    (``FluorescenceMicroscope.mount_transform``) before this is applied.
-
-    Restricting the set to flips makes it the Klein four-group: every member is its
-    own inverse and composition is order-independent, so mapping a displacement
-    between the displayed image and the stage is two sign flips with no axis swap
-    and no inverse to get backwards. Flips also preserve the array shape, so the
-    image and its geometry metadata always describe the same frame.
-    """
-
-    NONE = None
-    FLIP_X = "flip-x"
-    FLIP_Y = "flip-y"
-    FLIP_XY = "flip-xy"
-
-    def apply_to_delta(self, dx: float, dy: float) -> Tuple[float, float]:
-        """Map a displacement between the raw and displayed frames.
-
-        Every member is its own inverse, so this maps in both directions: use it to
-        take a delta measured in the displayed image back to the underlying frame,
-        and vice versa.
-        """
-        flip_x = self in (CameraImageTransform.FLIP_X, CameraImageTransform.FLIP_XY)
-        flip_y = self in (CameraImageTransform.FLIP_Y, CameraImageTransform.FLIP_XY)
-        return (-dx if flip_x else dx, -dy if flip_y else dy)
-
-
-# Transforms that stored configurations may still hold. A half turn is the same
-# element as flipping both axes, so it maps across without losing the setting; the
-# quarter turns describe a mount, which the driver now corrects, and have no
-# equivalent here.
-_LEGACY_IMAGE_TRANSFORMS = {"rotate-180": CameraImageTransform.FLIP_XY}
-
-
-def _parse_image_transform(value: Any) -> CameraImageTransform:
-    """Read a stored transform, tolerating values that are no longer members.
-
-    Rotations were removed once mount rotation moved into the driver. A half turn is
-    migrated to the equivalent flip so the setting survives; anything else falls back
-    to no transform with a warning rather than raising.
-    """
-    if value is None:
-        return CameraImageTransform.NONE
-    try:
-        return CameraImageTransform(value)
-    except ValueError:
-        pass
-
-    migrated = _LEGACY_IMAGE_TRANSFORMS.get(value)
-    if migrated is not None:
-        logging.info(
-            f"Camera image transform {value!r} is now {migrated.value!r}; migrated."
-        )
-        return migrated
-
-    logging.warning(
-        f"Unsupported camera image transform {value!r}; falling back to none. "
-        "Rotations are now applied as a fixed mount correction inside the driver."
-    )
-    return CameraImageTransform.NONE
-
-
-@dataclass
-class FMImageGeometry:
-    """The geometry an FM image was captured under.
-
-    Recorded on the image so a stage position can be projected onto it without a live
-    microscope, and — more importantly — without *assuming* the live microscope still
-    matches. Reprojecting a saved overview against the current pose is silently wrong
-    the moment the stage has moved or the user has flipped the display, which is
-    exactly when someone is looking at a saved overview.
-
-    These are the fields the projection actually reads, rather than a whole
-    `SystemSettings`: an FM image serialises to OME-TIFF, where the rest of a system
-    configuration is both irrelevant and liable to go stale on disk. Keeping the list
-    short also keeps the reprojection contract legible — what is here is what the
-    projection depends on.
-
-    `is_compustage` is explicit for the same reason. The beam's metadata-driven
-    reprojection has to infer it by sniffing the model name for "Arctis", with a TODO
-    against it; there is no reason to repeat that here.
-
-    Angles are in degrees, matching `SystemSettings`.
-    """
-
-    transform: CameraImageTransform = CameraImageTransform.NONE
-    camera_tilt: float = 0.0            # viewing axis, from the electron column
-    column_tilt: float = 0.0            # electron column
-    fib_column_tilt: float = 52.0       # ion column; fixes the compustage FIB pose
-    shuttle_pre_tilt: float = 0.0
-    rotation_reference: float = 0.0
-    rotation_180: float = 180.0
-    is_compustage: bool = False
-
-    def to_dict(self) -> dict:
-        return {
-            "transform": self.transform.value,
-            "camera_tilt": self.camera_tilt,
-            "column_tilt": self.column_tilt,
-            "fib_column_tilt": self.fib_column_tilt,
-            "shuttle_pre_tilt": self.shuttle_pre_tilt,
-            "rotation_reference": self.rotation_reference,
-            "rotation_180": self.rotation_180,
-            "is_compustage": self.is_compustage,
-        }
-
-    @classmethod
-    def from_dict(cls, ddict: dict) -> "FMImageGeometry":
-        return cls(
-            transform=_parse_image_transform(ddict.get("transform")),
-            camera_tilt=ddict.get("camera_tilt", 0.0),
-            column_tilt=ddict.get("column_tilt", 0.0),
-            fib_column_tilt=ddict.get("fib_column_tilt", 52.0),
-            shuttle_pre_tilt=ddict.get("shuttle_pre_tilt", 0.0),
-            rotation_reference=ddict.get("rotation_reference", 0.0),
-            rotation_180=ddict.get("rotation_180", 180.0),
-            is_compustage=ddict.get("is_compustage", False),
-        )
 
 
 class ZStackOrder(Enum):
@@ -1330,7 +1215,7 @@ class FluorescenceImageMetadata:
     # None on images written before this was recorded; reprojection raises rather than
     # guessing, since a marker drawn in the wrong place looks exactly like one drawn in
     # the right place.
-    geometry: Optional[FMImageGeometry] = None
+    geometry: Optional[FibsemHardwareGeometry] = None
 
     # File information
     filename: Optional[str] = None  # original filename
@@ -1460,7 +1345,7 @@ class FluorescenceImageMetadata:
             description=metadata_dict.get("description"),
             system_info=metadata_dict.get("system_info"),
             geometry=(
-                FMImageGeometry.from_dict(metadata_dict["geometry"])
+                FibsemHardwareGeometry.from_dict(metadata_dict["geometry"])
                 if metadata_dict.get("geometry")
                 else None
             ),

--- a/fibsem/imaging/tiling/reprojection.py
+++ b/fibsem/imaging/tiling/reprojection.py
@@ -272,17 +272,19 @@ def _inverse_y_corrected_stage_movement(
         Returns:
             float: expected_y input that would produce the given dy, dz movements
         """
-        if image.metadata is None or image.metadata.system is None:
-            raise ValueError("Image metadata or system metadata is not set. Cannot calculate inverse y corrected stage movement.")
+        if image.metadata is None or image.metadata.hardware_geometry is None:
+            raise ValueError("Image metadata or hardware geometry is not set. Cannot calculate inverse y corrected stage movement.")
+
+        geometry = image.metadata.hardware_geometry
 
         # all angles in radians
-        sem_column_tilt = np.deg2rad(image.metadata.system.electron.column_tilt)
-        fib_column_tilt = np.deg2rad(image.metadata.system.ion.column_tilt)
+        sem_column_tilt = np.deg2rad(geometry.column_tilt)
+        fib_column_tilt = np.deg2rad(geometry.fib_column_tilt)
 
-        stage_pretilt = np.deg2rad(image.metadata.system.stage.shuttle_pre_tilt)
+        stage_pretilt = np.deg2rad(geometry.shuttle_pre_tilt)
 
-        stage_rotation_flat_to_eb = np.deg2rad(image.metadata.system.stage.rotation_reference) % (2 * np.pi)
-        stage_rotation_flat_to_ion = np.deg2rad(image.metadata.system.stage.rotation_180) % (2 * np.pi)
+        stage_rotation_flat_to_eb = np.deg2rad(geometry.rotation_reference) % (2 * np.pi)
+        stage_rotation_flat_to_ion = np.deg2rad(geometry.rotation_180) % (2 * np.pi)
 
         # current stage position
         current_stage_position = image.metadata.stage_position
@@ -295,22 +297,27 @@ def _inverse_y_corrected_stage_movement(
         # microscope; for the compustage the rotation is always 0, so the orientation is
         # fixed by the tilt alone (FIB sits at column_tilt - pretilt - 180, i.e. ~-128 deg,
         # and the FM pose at -180 deg).
+        #
+        # NOTE: this differs from the live path and from fm/reprojection.py, which both
+        # also require the rotation to match the reference before calling a pose FIB.
+        # Deliberately left alone here so FIB-481 is a pure restructuring with no
+        # numerical difference; the divergence is FIB-500. It is latent -- a compustage
+        # image cannot carry a non-zero rotation, so the two versions only disagree
+        # about poses no acquisition can produce.
         compustage_sign = 1.0
-        stage_is_compustage = "Arctis" in image.metadata.system.info.model or image.metadata.system.sim.get("is_compustage", False)
         is_fib_orientation = False
-        if stage_is_compustage: # TODO: add compustage to metadata
-            fib_orientation_tilt = np.radians(
-                image.metadata.system.ion.column_tilt
-                - image.metadata.system.stage.shuttle_pre_tilt
-                - 180
+        if geometry.is_compustage:
+            fib_orientation_tilt = np.deg2rad(
+                geometry.fib_column_tilt - geometry.shuttle_pre_tilt - 180
             )
-            is_fib_orientation = bool(np.isclose(stage_tilt, fib_orientation_tilt, atol=0.1))
+            is_fib_orientation = bool(
+                np.isclose(stage_tilt, fib_orientation_tilt, atol=0.1)
+            )
             compustage_sign = 1.0 if is_fib_orientation else -1.0
             stage_tilt += np.pi
 
         PRETILT_SIGN = 1.0
         # pretilt angle depends on rotation
-        from fibsem import movement
         if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
             PRETILT_SIGN = 1.0
         if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
@@ -347,7 +354,7 @@ def _inverse_y_corrected_stage_movement(
         expected_y = y_sample_move * np.cos(stage_tilt + perspective_tilt_adjustment)
 
         # Apply compustage correction if needed
-        if stage_is_compustage:
+        if geometry.is_compustage:
             expected_y *= compustage_sign
 
         return expected_y

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import copy
+import dataclasses
 import datetime
 import logging
 import os
@@ -97,12 +98,14 @@ from fibsem.structures import (
     BeamSettings,
     BeamSystemSettings,
     BeamType,
+    CameraImageTransform,
     CrossSectionPattern,
     FibsemBitmapSettings,
     FibsemCircleSettings,
     FibsemDetectorSettings,
     FibsemExperimentRef,
     FibsemGasInjectionSettings,
+    FibsemHardwareGeometry,
     FibsemImage,
     FibsemImageMetadata,
     FibsemLineSettings,
@@ -1585,30 +1588,60 @@ class FibsemMicroscope(ABC):
 
         return new_position
 
-    def fm_image_geometry(self) -> "FMImageGeometry":
+    def hardware_geometry(self) -> FibsemHardwareGeometry:
+        """The fixed geometry this instrument is arranged in.
+
+        The beam counterpart of :meth:`fm_image_geometry`, and its shared core. Both
+        stamp the same terms onto an acquired image so it can be reprojected later
+        without a live microscope to consult.
+
+        ``stage_is_compustage`` is the authority here -- ThermoFisher reads it from
+        ``connection.specimen.compustage.is_installed``. Recording it is what lets
+        the reprojection stop inferring it from the model name (FIB-481).
+        """
+        return FibsemHardwareGeometry.from_system_settings(
+            self.system, is_compustage=self.stage_is_compustage
+        )
+
+    def _set_additional_metadata(self, image: FibsemImage) -> None:
+        """Stamp who, which run, which instrument and how it is arranged onto an image.
+
+        Lifted here from ``ThermoMicroscope`` in FIB-481: the same three lines were
+        written out at eight acquisition sites across three microscope classes, so a
+        change to what an image records meant finding all eight.
+        """
+        image.metadata.user = self.user
+        image.metadata.experiment = self.experiment
+        # Copied, not referenced. `hardware_geometry()` returns a fresh record, so
+        # aliasing the live SystemInfo here would leave one field on the image a
+        # snapshot and the other a window onto the microscope. TescanMicroscope
+        # rewrites system.info.model/serial/software_version on every acquisition,
+        # so the alias reached back into images already taken. Pre-dates FIB-481 --
+        # `metadata.system = self.system` aliased the whole thing -- but the two
+        # fields set together should not disagree about what they are.
+        image.metadata.system_info = deepcopy(self.system.info)
+        image.metadata.hardware_geometry = self.hardware_geometry()
+
+    def fm_image_geometry(self) -> FibsemHardwareGeometry:
         """The geometry the FM is currently imaging under.
 
-        Stamped onto acquired images so they can be reprojected later without a live
-        microscope, and used for the live view here so that both paths run the same
-        projection rather than two that merely agree today.
+        The same record :meth:`hardware_geometry` returns, with the camera's own two
+        terms filled in. Stamped onto acquired images so they can be reprojected later
+        without a live microscope, and used for the live view here so that both paths
+        run the same projection rather than two that merely agree today.
 
         Raises:
             ValueError: if no fluorescence microscope is available.
         """
-        from fibsem.fm.structures import CameraImageTransform, FMImageGeometry
-
         if self.fm is None:
             raise ValueError("Fluorescence microscope is not available.")
 
-        return FMImageGeometry(
+        # replace() on the shared record rather than rebuilding it: the instrument
+        # terms are gathered in one place, and only the camera's are added here.
+        return dataclasses.replace(
+            self.hardware_geometry(),
             transform=self.fm._transform or CameraImageTransform.NONE,
             camera_tilt=self.fm.camera_tilt,
-            column_tilt=self.system.electron.column_tilt,
-            fib_column_tilt=self.system.ion.column_tilt,
-            shuttle_pre_tilt=self.system.stage.shuttle_pre_tilt,
-            rotation_reference=self.system.stage.rotation_reference,
-            rotation_180=self.system.stage.rotation_180,
-            is_compustage=self.stage_is_compustage,
         )
 
     def fm_stable_move(self, dx: float, dy: float) -> FibsemStagePosition:
@@ -2060,10 +2093,7 @@ class ThermoMicroscope(FibsemMicroscope):
             copy.deepcopy(state),
         )
 
-        # set additional metadata
-        fibsem_image.metadata.user = self.user
-        fibsem_image.metadata.experiment = self.experiment
-        fibsem_image.metadata.system = self.system
+        self._set_additional_metadata(fibsem_image)
 
         # store last imaging settings
         self._last_imaging_settings = image_settings
@@ -2100,10 +2130,7 @@ class ThermoMicroscope(FibsemMicroscope):
             copy.deepcopy(state),
         )
 
-        # set additional metadata
-        image.metadata.user = self.user
-        image.metadata.experiment = self.experiment
-        image.metadata.system = self.system
+        self._set_additional_metadata(image)
 
         return image
 
@@ -2222,12 +2249,6 @@ class ThermoMicroscope(FibsemMicroscope):
             drift_correction=image_settings.drift_correction,
         )
 
-    def _set_additional_metadata(self, fibsem_image: FibsemImage) -> None:
-        """Set additional metadata for the FibsemImage."""
-        fibsem_image.metadata.user = self.user
-        fibsem_image.metadata.experiment = self.experiment
-        fibsem_image.metadata.system = self.system
-
     def last_image(self, beam_type: BeamType = BeamType.ELECTRON) -> FibsemImage:
         """
         Get the last previously acquired image.
@@ -2260,10 +2281,7 @@ class ThermoMicroscope(FibsemMicroscope):
             beam_type=beam_type,
         )
 
-        # set additional metadata
-        fibsem_image.metadata.user = self.user
-        fibsem_image.metadata.experiment = self.experiment
-        fibsem_image.metadata.system = self.system
+        self._set_additional_metadata(fibsem_image)
 
         logging.debug({"msg": "acquire_image", "metadata": fibsem_image.metadata.to_dict()})
 
@@ -2344,10 +2362,7 @@ class ThermoMicroscope(FibsemMicroscope):
             copy.deepcopy(state),
         )
 
-        # set additional metadata
-        image.metadata.user = self.user
-        image.metadata.experiment = self.experiment
-        image.metadata.system = self.system
+        self._set_additional_metadata(image)
 
         return image
 

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -385,9 +385,7 @@ class DemoMicroscope(FibsemMicroscope):
         # add additional metadata
         image.metadata.image_settings = copy.deepcopy(effective_image_settings)
         image.metadata.microscope_state = microscope_state
-        image.metadata.system = self.system
-        image.metadata.experiment = self.experiment
-        image.metadata.user = self.user
+        self._set_additional_metadata(image)
         
         # crop the image data if reduced area is set
         if effective_image_settings.reduced_area is not None:

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -454,9 +454,9 @@ class TescanMicroscope(FibsemMicroscope):
             self.system.info.serial_number = image.Header["MAIN"]["SerialNumber"]
             self.system.info.software_version = image.Header["MAIN"]["SoftwareVersion"]
 
-        fibsem_image.metadata.user = self.user
-        fibsem_image.metadata.experiment = self.experiment 
-        fibsem_image.metadata.system = self.system
+        # After the header read above, so the model/serial/version it just wrote onto
+        # self.system.info are the ones stamped on the image.
+        self._set_additional_metadata(fibsem_image)
 
         return fibsem_image
 
@@ -479,10 +479,8 @@ class TescanMicroscope(FibsemMicroscope):
             raise ValueError(f"Unknown beam type: {beam_type}")
 
         if image is not None:
-            image.metadata.user = self.user
-            image.metadata.experiment = self.experiment 
-            image.metadata.system = self.system
-        
+            self._set_additional_metadata(image)
+
         return image
 
     def acquire_chamber_image(self) -> FibsemImage:

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 from abc import ABC, abstractmethod
@@ -1748,6 +1749,171 @@ class SystemSettings:
         )
 
 
+class CameraImageTransform(Enum):
+    """Image transformations for aligning fluorescence images with SEM/FIB coordinate systems.
+
+    Flips only. Any fixed rotation between the sensor and the stage belongs to the
+    mount, not to user preference, and is corrected inside the driver
+    (``FluorescenceMicroscope.mount_transform``) before this is applied.
+
+    Restricting the set to flips makes it the Klein four-group: every member is its
+    own inverse and composition is order-independent, so mapping a displacement
+    between the displayed image and the stage is two sign flips with no axis swap
+    and no inverse to get backwards. Flips also preserve the array shape, so the
+    image and its geometry metadata always describe the same frame.
+
+    Lives here rather than in ``fibsem.fm.structures`` only because
+    ``FibsemHardwareGeometry`` needs it and core cannot import from the FM package --
+    ``fm.structures`` imports from this module, so the reverse is a cycle. Re-exported
+    there, which is where every consumer of it still is.
+    """
+
+    NONE = None
+    FLIP_X = "flip-x"
+    FLIP_Y = "flip-y"
+    FLIP_XY = "flip-xy"
+
+    def apply_to_delta(self, dx: float, dy: float) -> Tuple[float, float]:
+        """Map a displacement between the raw and displayed frames.
+
+        Every member is its own inverse, so this maps in both directions: use it to
+        take a delta measured in the displayed image back to the underlying frame,
+        and vice versa.
+        """
+        flip_x = self in (CameraImageTransform.FLIP_X, CameraImageTransform.FLIP_XY)
+        flip_y = self in (CameraImageTransform.FLIP_Y, CameraImageTransform.FLIP_XY)
+        return (-dx if flip_x else dx, -dy if flip_y else dy)
+
+
+# Transforms that stored configurations may still hold. A half turn is the same
+# element as flipping both axes, so it maps across without losing the setting; the
+# quarter turns describe a mount, which the driver now corrects, and have no
+# equivalent here.
+_LEGACY_IMAGE_TRANSFORMS = {"rotate-180": CameraImageTransform.FLIP_XY}
+
+
+def _parse_image_transform(value: Any) -> CameraImageTransform:
+    """Read a stored transform, tolerating values that are no longer members.
+
+    Rotations were removed once mount rotation moved into the driver. A half turn is
+    migrated to the equivalent flip so the setting survives; anything else falls back
+    to no transform with a warning rather than raising.
+    """
+    if value is None:
+        return CameraImageTransform.NONE
+    try:
+        return CameraImageTransform(value)
+    except ValueError:
+        pass
+
+    migrated = _LEGACY_IMAGE_TRANSFORMS.get(value)
+    if migrated is not None:
+        logging.info(
+            f"Camera image transform {value!r} is now {migrated.value!r}; migrated."
+        )
+        return migrated
+
+    logging.warning(
+        f"Unsupported camera image transform {value!r}; falling back to none. "
+        "Rotations are now applied as a fixed mount correction inside the driver."
+    )
+    return CameraImageTransform.NONE
+
+
+@dataclass
+class FibsemHardwareGeometry:
+    """The instrument's fixed physical arrangement: column tilts, stage reference angles.
+
+    Recorded on an image so a stage position can be projected onto it without a live
+    microscope -- and, more to the point, without *assuming* the live microscope still
+    matches. Reprojecting a saved image against the current pose is silently wrong the
+    moment the stage has moved or the instrument has been reconfigured.
+
+    Distinct from its two neighbours. ``MicroscopeState`` is dynamic observation, what
+    the instrument was *doing*; ``SystemSettings`` is the config file, the whole of it.
+    This is what the instrument *is*, in the terms a projection actually needs.
+
+    **One record for both modalities.** The beam and fluorescence paths were given
+    separate structures that named the same six terms identically, free to drift with
+    nothing to catch it. ``camera_tilt`` and ``transform`` describe the fluorescence
+    camera and stay at their defaults on a beam image; that is two dormant fields on a
+    SEM picture, accepted deliberately so there is exactly one definition of how this
+    instrument is arranged rather than two that merely agree today (FIB-481).
+
+    Angles are in degrees, matching ``SystemSettings``. Both reprojection paths convert
+    at the point of use.
+
+    ``is_compustage`` is stored rather than derived. The live value is ground truth --
+    ThermoFisher reads it from ``connection.specimen.compustage.is_installed`` -- but
+    an image had no field for it, so the beam path inferred it by matching the model
+    name against "Arctis", with a TODO against the line. A capability is not a name.
+
+    Note this is deliberately *not* grouped this way in ``SystemSettings`` itself: that
+    maps onto ``microscope-configuration.yaml``, a user-facing file, and regrouping it
+    would mean migrating every site's config for a cosmetic gain. The scatter stays
+    there; ``from_system_settings`` is the one place that knows about it.
+    """
+
+    column_tilt: float = 0.0            # electron column
+    fib_column_tilt: float = 52.0       # ion column; fixes the compustage FIB pose
+    shuttle_pre_tilt: float = 0.0
+    rotation_reference: float = 0.0
+    rotation_180: float = 180.0
+    is_compustage: bool = False
+    # Fluorescence only; left at these defaults for a beam image.
+    camera_tilt: float = 0.0            # viewing axis, from the electron column
+    transform: CameraImageTransform = CameraImageTransform.NONE
+
+    @classmethod
+    def from_system_settings(
+        cls, system: SystemSettings, is_compustage: bool = False
+    ) -> "FibsemHardwareGeometry":
+        """Gather the geometry terms out of a full system configuration.
+
+        ``is_compustage`` is a parameter because ``SystemSettings`` does not carry it:
+        it is a property of the installed hardware, which only the connected
+        microscope knows. Callers holding one should pass ``microscope.stage_is_compustage``.
+        """
+        return cls(
+            column_tilt=system.electron.column_tilt,
+            fib_column_tilt=system.ion.column_tilt,
+            shuttle_pre_tilt=system.stage.shuttle_pre_tilt,
+            rotation_reference=system.stage.rotation_reference,
+            rotation_180=system.stage.rotation_180,
+            is_compustage=is_compustage,
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "column_tilt": self.column_tilt,
+            "fib_column_tilt": self.fib_column_tilt,
+            "shuttle_pre_tilt": self.shuttle_pre_tilt,
+            "rotation_reference": self.rotation_reference,
+            "rotation_180": self.rotation_180,
+            "is_compustage": self.is_compustage,
+            "camera_tilt": self.camera_tilt,
+            "transform": self.transform.value,
+        }
+
+    @classmethod
+    def from_dict(cls, ddict: dict) -> "FibsemHardwareGeometry":
+        # `.get` throughout, with the field defaults repeated rather than referenced:
+        # a file written before this record existed has none of these keys, and the
+        # point of the record is that such a file still loads.
+        return cls(
+            column_tilt=ddict.get("column_tilt", 0.0),
+            fib_column_tilt=ddict.get("fib_column_tilt", 52.0),
+            shuttle_pre_tilt=ddict.get("shuttle_pre_tilt", 0.0),
+            rotation_reference=ddict.get("rotation_reference", 0.0),
+            rotation_180=ddict.get("rotation_180", 180.0),
+            is_compustage=ddict.get("is_compustage", False),
+            camera_tilt=ddict.get("camera_tilt", 0.0),
+            # Not a bare CameraImageTransform(...): stored configurations may hold a
+            # rotation that is no longer a member, which the parser migrates.
+            transform=_parse_image_transform(ddict.get("transform")),
+        )
+
+
 @dataclass
 class MicroscopeSettings:
 
@@ -1951,11 +2117,17 @@ class FibsemImageMetadata:
     Three kinds of claim live here, and they are easy to mistake for each other
     (FIB-445 D1). Anything added should be placed deliberately in one of them:
 
-    **Provenance** -- what produced this image. ``system`` (which instrument),
+    **Provenance** -- what produced this image. ``system_info`` (which instrument),
     ``user`` (who), ``experiment`` (which run). Constant for a run. The same
     question at a finer grain -- which lamella, which task -- is not recorded yet;
     see FIB-466. It varies *within* a run, which changes the mechanism that writes
     it, but not the kind of fact it is.
+
+    **Configuration** -- what the instrument *is*. ``hardware_geometry``: the fixed
+    physical arrangement a projection needs. Up to v5 this was the entire
+    ``SystemSettings``, 1683 bytes of it, to deliver six numbers -- and it carried
+    the manipulator configuration and the simulator flags into every picture. See
+    FIB-481.
 
     **Observation** -- what the instrument was doing. ``microscope_state``,
     ``pixel_size``. Measured at acquisition.
@@ -1975,7 +2147,11 @@ class FibsemImageMetadata:
     image_settings: ImageSettings
     pixel_size: Point
     microscope_state: MicroscopeState
-    system: Optional[SystemSettings] = None
+    # Both replaced `system: Optional[SystemSettings]` in v6 (FIB-481). Optional
+    # because a file written before v6 may carry neither in a recoverable form, and
+    # because a FibsemImage can be constructed without a microscope at all.
+    system_info: Optional[SystemInfo] = None
+    hardware_geometry: Optional[FibsemHardwareGeometry] = None
     version: str = METADATA_VERSION
     user: FibsemUser = field(default_factory=lambda: FibsemUser())
     experiment: FibsemExperimentRef = field(default_factory=lambda: FibsemExperimentRef())
@@ -2013,9 +2189,53 @@ class FibsemImageMetadata:
         # produced a plausible empty FibsemUser rather than an error. See FIB-486.
         settings_dict["user"] = self.user.to_dict()
         settings_dict["experiment"] = self.experiment.to_dict()
-        settings_dict["system"] = self.system.to_dict() if self.system is not None else {}
+        settings_dict["system_info"] = (
+            self.system_info.to_dict() if self.system_info is not None else {}
+        )
+        settings_dict["hardware_geometry"] = (
+            self.hardware_geometry.to_dict() if self.hardware_geometry is not None else {}
+        )
 
         return settings_dict
+
+    @staticmethod
+    def _geometry_from_legacy_system(system: dict) -> Optional[FibsemHardwareGeometry]:
+        """Recover the geometry from a pre-v6 `system` blob.
+
+        Read with `.get()` chains rather than by building a `SystemSettings` first.
+        That constructor is bracket-indexed throughout -- a blob missing any of
+        `stage`, `electron`, `ion`, `manipulator`, `gis` or `info` raises KeyError --
+        and inheriting that here would break exactly the old files this exists to
+        load. See `tests/test_metadata_fixtures.py`.
+
+        Compustage is recovered the way the reprojection used to detect it, by model
+        name, falling back to the simulator flag. That match is wrong -- a capability
+        inferred from a name -- which is why v6 records it instead. It survives here
+        only because a pre-v6 file has nothing better in it.
+        """
+        if not system:
+            return None
+
+        stage = system.get("stage") or {}
+        electron = system.get("electron") or {}
+        ion = system.get("ion") or {}
+        info = system.get("info") or {}
+        sim = system.get("sim") or {}
+
+        model = info.get("model") or ""
+        is_compustage = "Arctis" in model or bool(sim.get("is_compustage", False))
+
+        # Field defaults where a key is absent, so a partial blob degrades to the
+        # same values a freshly-constructed record would have.
+        default = FibsemHardwareGeometry()
+        return FibsemHardwareGeometry(
+            column_tilt=electron.get("column_tilt", default.column_tilt),
+            fib_column_tilt=ion.get("column_tilt", default.fib_column_tilt),
+            shuttle_pre_tilt=stage.get("shuttle_pre_tilt", default.shuttle_pre_tilt),
+            rotation_reference=stage.get("rotation_reference", default.rotation_reference),
+            rotation_180=stage.get("rotation_180", default.rotation_180),
+            is_compustage=is_compustage,
+        )
 
     @staticmethod
     def from_dict(settings: dict) -> "FibsemImageMetadata":
@@ -2030,11 +2250,21 @@ class FibsemImageMetadata:
                 settings["microscope_state"]
             )
 
-        # the system settings are optional
-        system_dict = settings.get("system", {})
-        system_settings = None
-        if system_dict:
-            system_settings = SystemSettings.from_dict(system_dict)
+        # Presence-detection, not a version switch (FIB-445 D3): v6 writes
+        # `system_info` and `hardware_geometry`, everything before it wrote a whole
+        # `system`. Both are optional -- an image may be built without a microscope.
+        legacy_system = settings.get("system") or {}
+
+        info_dict = settings.get("system_info") or legacy_system.get("info") or {}
+        system_info = SystemInfo.from_dict(info_dict) if info_dict else None
+
+        geometry_dict = settings.get("hardware_geometry") or {}
+        if geometry_dict:
+            hardware_geometry = FibsemHardwareGeometry.from_dict(geometry_dict)
+        else:
+            hardware_geometry = FibsemImageMetadata._geometry_from_legacy_system(
+                legacy_system
+            )
 
         metadata = FibsemImageMetadata(
             image_settings=image_settings,
@@ -2043,7 +2273,8 @@ class FibsemImageMetadata:
             microscope_state=microscope_state,
             user=FibsemUser.from_dict(settings.get("user", {})),
             experiment=FibsemExperimentRef.from_dict(settings.get("experiment", {})),
-            system=system_settings
+            system_info=system_info,
+            hardware_geometry=hardware_geometry,
         )
         return metadata
 

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -364,8 +364,9 @@ class FibsemMinimapWidget(QWidget):
         ms = self.microscope.get_microscope_state(beam_type=beam_type)
         image = FibsemImage.generate_blank_image(resolution=(4096, 4096), hfw=4000e-6)
         image.metadata.image_settings.beam_type = beam_type  # type: ignore
-        image.metadata.microscope_state = ms                # type: ignore
-        image.metadata.system = self.microscope.system      # type: ignore
+        image.metadata.microscope_state = ms                            # type: ignore
+        image.metadata.system_info = self.microscope.system.info        # type: ignore
+        image.metadata.hardware_geometry = self.microscope.hardware_geometry()  # type: ignore
         self.update_viewer(image=image)
 
     def set_experiment(self):

--- a/fibsem/ui/fm/widgets/minimap_plot_widget.py
+++ b/fibsem/ui/fm/widgets/minimap_plot_widget.py
@@ -847,11 +847,11 @@ class MinimapPlotWidget(QWidget):
             return None
 
         try:
-            if (self.image.metadata.system is not None and
+            if (self.image.metadata.hardware_geometry is not None and
                 self.image.metadata.microscope_state is not None and
                 self.image.metadata.microscope_state.stage_position is not None):
 
-                reference_rotation = self.image.metadata.system.stage.rotation_reference
+                reference_rotation = self.image.metadata.hardware_geometry.rotation_reference
                 current_rotation = self.image.metadata.microscope_state.stage_position.r
 
                 if reference_rotation is not None and current_rotation is not None:

--- a/fibsem/ui/widgets/canvas/stage_frame.py
+++ b/fibsem/ui/widgets/canvas/stage_frame.py
@@ -32,7 +32,7 @@ from fibsem.fm.reprojection import project_image_point, project_stage_position
 from fibsem.structures import FibsemStagePosition, Point
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
-    from fibsem.fm.structures import FMImageGeometry
+    from fibsem.fm.structures import FibsemHardwareGeometry
     from fibsem.microscope import FibsemMicroscope
     from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
 
@@ -70,7 +70,7 @@ class FMStageProjection:
     carried here so the two directions cannot be handed different ones.
     """
 
-    geometry: "FMImageGeometry"
+    geometry: "FibsemHardwareGeometry"
     pixel_size: float
     shape: Tuple[int, int]  # (height, width)
 
@@ -80,7 +80,7 @@ class FMStageProjection:
     ) -> Optional["FMStageProjection"]:
         """Read the projection off the live instrument, or None if it cannot be read.
 
-        Live rather than from a displayed image, for two reasons. `FMImageGeometry` is
+        Live rather than from a displayed image, for two reasons. `FibsemHardwareGeometry` is
         system configuration -- camera tilt, shuttle pre-tilt, the camera flip,
         compustage or not -- and not pose; the pose enters through the frame's origin,
         as its rotation and tilt. So a recorded geometry and the live one agree by

--- a/fibsem/ui/widgets/image_annotation_widget.py
+++ b/fibsem/ui/widgets/image_annotation_widget.py
@@ -96,8 +96,8 @@ def _get_metadata_text(image: FibsemImage) -> str:
     detector_name = detector_name or "N/A"
 
     device = None
-    if image.metadata and getattr(image.metadata, "system", None):
-        device = getattr(getattr(image.metadata.system, "info", None), "model", None)
+    if image.metadata is not None:
+        device = getattr(image.metadata.system_info, "model", None)
     device = device or "N/A"
 
     metadata_text = f"{beam_name} | {beam_voltage_str}, {beam_current_str}, {detector_name} | {acq_date} | {device}"

--- a/tests/fm/test_reprojection.py
+++ b/tests/fm/test_reprojection.py
@@ -22,7 +22,7 @@ from fibsem.fm.reprojection import (
 from fibsem.fm.structures import (
     CameraImageTransform,
     ChannelSettings,
-    FMImageGeometry,
+    FibsemHardwareGeometry,
 )
 from fibsem.structures import FibsemStagePosition, Point
 
@@ -224,13 +224,13 @@ class TestGeometryIsRecorded:
 
     @pytest.mark.parametrize("transform", TRANSFORMS)
     def test_geometry_round_trips_through_a_dict(self, transform):
-        geometry = FMImageGeometry(
+        geometry = FibsemHardwareGeometry(
             transform=transform, camera_tilt=90.0, column_tilt=0.0,
             fib_column_tilt=52.0, shuttle_pre_tilt=35.0,
             rotation_reference=10.0, rotation_180=190.0, is_compustage=True,
         )
 
-        assert FMImageGeometry.from_dict(geometry.to_dict()) == geometry
+        assert FibsemHardwareGeometry.from_dict(geometry.to_dict()) == geometry
 
 
 class TestReprojectionOntoAnImage:
@@ -299,7 +299,7 @@ class TestReprojectionOntoAnImage:
 def test_the_pure_projection_needs_no_microscope():
     """The whole point of the split: reprojection must work on a loaded file with no
     instrument attached, which is how it will usually be used."""
-    geometry = FMImageGeometry(
+    geometry = FibsemHardwareGeometry(
         transform=CameraImageTransform.NONE, camera_tilt=180.0,
         is_compustage=True, shuttle_pre_tilt=0.0,
     )

--- a/tests/fm/test_structures.py
+++ b/tests/fm/test_structures.py
@@ -2407,7 +2407,7 @@ class TestCombiningImagesKeepsTheirMetadata:
             FluorescenceChannelMetadata,
             FluorescenceImage,
             FluorescenceImageMetadata,
-            FMImageGeometry,
+            FibsemHardwareGeometry,
         )
 
         metadata = FluorescenceImageMetadata(
@@ -2423,7 +2423,7 @@ class TestCombiningImagesKeepsTheirMetadata:
                 offset=0.0,
                 objective_position=1e-3,
             )],
-            geometry=FMImageGeometry(
+            geometry=FibsemHardwareGeometry(
                 transform=CameraImageTransform.FLIP_XY,
                 camera_tilt=180.0,
                 is_compustage=True,

--- a/tests/test_acquire_image_api.py
+++ b/tests/test_acquire_image_api.py
@@ -98,7 +98,8 @@ def test_metadata_consistency(demo_microscope):
     image1 = microscope.acquire_image(image_settings=settings.image)
     assert image1.metadata.user == microscope.user
     assert image1.metadata.experiment == microscope.experiment
-    assert image1.metadata.system == microscope.system
+    assert image1.metadata.system_info == microscope.system.info
+    assert image1.metadata.hardware_geometry == microscope.hardware_geometry()
     assert image1.metadata.image_settings is not None
     assert image1.metadata.microscope_state is not None
     
@@ -106,7 +107,8 @@ def test_metadata_consistency(demo_microscope):
     image2 = microscope.acquire_image(beam_type=BeamType.ELECTRON)
     assert image2.metadata.user == microscope.user
     assert image2.metadata.experiment == microscope.experiment
-    assert image2.metadata.system == microscope.system
+    assert image2.metadata.system_info == microscope.system.info
+    assert image2.metadata.hardware_geometry == microscope.hardware_geometry()
     assert image2.metadata.image_settings is not None
     assert image2.metadata.microscope_state is not None
     

--- a/tests/test_metadata_fixtures.py
+++ b/tests/test_metadata_fixtures.py
@@ -48,7 +48,8 @@ def test_fixture_metadata_still_loads(name: str) -> None:
     """The whole point: a file written by an older build must not raise."""
     metadata = FibsemImageMetadata.from_dict(load(name))
 
-    assert metadata.system is not None
+    assert metadata.system_info is not None
+    assert metadata.hardware_geometry is not None
     assert metadata.microscope_state is not None
 
 
@@ -58,57 +59,60 @@ def test_instrument_identity_survives_the_load(
 ) -> None:
     metadata = FibsemImageMetadata.from_dict(load(name))
 
-    assert metadata.system.info.model == model
+    assert metadata.system_info.model == model
     # The serial is the key any per-instrument aggregation joins on (FIB-445), so it
     # has to survive even though the fixture's value is scrubbed to a placeholder.
-    assert metadata.system.info.serial_number == "0000000"
+    assert metadata.system_info.serial_number == "0000000"
 
 
 @pytest.mark.parametrize("name", ALL)
 def test_reprojection_geometry_is_readable(name: str) -> None:
     """The five angles `_inverse_y_corrected_stage_movement` needs.
 
-    Asserted as `is not None` rather than by value: the Arctis records 0 for three of
-    them, correctly -- a compustage tilts the sample directly instead of using a
-    pre-tilted shuttle. Anything inferring "not recorded" from a zero here would break
-    compustage instruments and nothing else.
+    Since FIB-481 these come from `hardware_geometry`, recovered from the pre-v6
+    `system` blob these fixtures carry. Asserted as `is not None` rather than by value:
+    the Arctis records 0 for three of them, correctly -- a compustage tilts the sample
+    directly instead of using a pre-tilted shuttle. Anything inferring "not recorded"
+    from a zero here would break compustage instruments and nothing else.
     """
-    system = FibsemImageMetadata.from_dict(load(name)).system
+    geometry = FibsemImageMetadata.from_dict(load(name)).hardware_geometry
 
-    assert system.electron.column_tilt is not None
-    assert system.ion.column_tilt is not None
-    assert system.stage.shuttle_pre_tilt is not None
-    assert system.stage.rotation_reference is not None
-    assert system.stage.rotation_180 is not None
+    assert geometry.column_tilt is not None
+    assert geometry.fib_column_tilt is not None
+    assert geometry.shuttle_pre_tilt is not None
+    assert geometry.rotation_reference is not None
+    assert geometry.rotation_180 is not None
 
 
 @pytest.mark.parametrize("name,model,compustage,via", FIXTURES)
 def test_compustage_detection(name: str, model: str, compustage: bool, via: str) -> None:
-    """Pins the current behaviour of the detection in reprojection.py:299.
+    """The migration guard: v6 records compustage, v5-and-earlier had it inferred.
 
-    FIB-481 replaces this expression with a recorded boolean. When it does, this test
-    should keep passing against the same fixtures -- that is what makes it a
-    migration guard rather than a description.
+    The answer must not change. `via` records which arm of the old expression fired --
+    the model name for a real Arctis, the simulator flag for Demo data -- and both must
+    still land on the same boolean now that `from_dict` recovers it rather than the
+    reprojection deriving it inline.
     """
-    system = FibsemImageMetadata.from_dict(load(name)).system
+    raw = load(name)
+    geometry = FibsemImageMetadata.from_dict(raw).hardware_geometry
 
-    by_model = "Arctis" in system.info.model
-    by_sim = system.sim.get("is_compustage", False)
+    assert geometry.is_compustage is compustage
 
-    assert (by_model or by_sim) is compustage
-    assert by_model is (via == "model")
-    assert by_sim is (via == "sim")
+    # What the recovery had to work with in the file itself.
+    system = raw["system"]
+    assert ("Arctis" in system["info"]["model"]) is (via == "model")
+    assert bool(system.get("sim", {}).get("is_compustage", False)) is (via == "sim")
 
 
 def test_real_hardware_records_an_empty_sim_dict() -> None:
-    """`system.sim` is `{}` on real instruments -- a dict, not None.
+    """`sim` is `{}` on real instruments -- a dict, not None.
 
-    Worth pinning: `reprojection.py` calls `system.sim.get(...)` unguarded, so a None
-    here would be an AttributeError on the reprojection path of real acquired data.
+    Worth pinning because the pre-v6 recovery path reads it: a None there would be an
+    AttributeError while loading real acquired data. Read from the raw fixture, since
+    v6 metadata no longer carries `sim` at all.
     """
     for name in ("thermo_arctis_compustage_v3.json", "thermo_aquilos_v3.json"):
-        system = FibsemImageMetadata.from_dict(load(name)).system
-        assert system.sim == {}
+        assert load(name)["system"]["sim"] == {}
 
 
 def test_experiment_reference_spans_three_eras() -> None:
@@ -137,26 +141,30 @@ def test_experiment_reference_spans_three_eras() -> None:
     assert FibsemExperimentRef.from_dict(v3).id == "test-experiment"
 
 
-def test_compustage_angles_are_recorded_as_zero_not_absent() -> None:
+def test_compustage_angles_are_recovered_as_zero_not_absent() -> None:
     """The Arctis records 0 for all three stage angles; the Aquilos records real ones.
 
-    This is the trap in migrating the geometry off `SystemSettings`: a shim that reads
-    "falsy" as "this file did not record it" and falls back to a default would corrupt
-    every compustage image and no other kind, which is close to undetectable without
-    a real Arctis file to test against.
+    The trap this guards: a recovery path that reads "falsy" as "this file did not
+    record it" and substitutes a default would corrupt every compustage image and no
+    other kind -- close to undetectable without a real Arctis file to test against.
+    Note the Arctis's `rotation_180` recovers as 0, *not* the field default of 180.
     """
-    arctis = FibsemImageMetadata.from_dict(load("thermo_arctis_compustage_v3.json")).system
-    aquilos = FibsemImageMetadata.from_dict(load("thermo_aquilos_v3.json")).system
+    arctis = FibsemImageMetadata.from_dict(
+        load("thermo_arctis_compustage_v3.json")
+    ).hardware_geometry
+    aquilos = FibsemImageMetadata.from_dict(
+        load("thermo_aquilos_v3.json")
+    ).hardware_geometry
 
     assert (
-        arctis.stage.shuttle_pre_tilt,
-        arctis.stage.rotation_reference,
-        arctis.stage.rotation_180,
+        arctis.shuttle_pre_tilt,
+        arctis.rotation_reference,
+        arctis.rotation_180,
     ) == (0, 0, 0)
     assert (
-        aquilos.stage.shuttle_pre_tilt,
-        aquilos.stage.rotation_reference,
-        aquilos.stage.rotation_180,
+        aquilos.shuttle_pre_tilt,
+        aquilos.rotation_reference,
+        aquilos.rotation_180,
     ) == (35.0, 110, 290)
 
 
@@ -179,6 +187,30 @@ def test_system_settings_from_dict_is_not_a_safe_migration_path(missing: str) ->
         SystemSettings.from_dict(partial)
 
 
+def test_an_acquired_image_snapshots_the_instrument_rather_than_aliasing_it() -> None:
+    """Mutating the microscope must not rewrite images already taken.
+
+    `TescanMicroscope.acquire_image` rewrites `system.info.model`, `serial_number` and
+    `software_version` from each image header, so an aliased SystemInfo reached back
+    into every image acquired earlier in the session. Both fields the acquisition
+    helper sets are snapshots.
+    """
+    from fibsem import utils
+    from fibsem.structures import BeamType
+
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    image = microscope.acquire_image(beam_type=BeamType.ELECTRON)
+
+    original_model = image.metadata.system_info.model
+    original_pretilt = image.metadata.hardware_geometry.shuttle_pre_tilt
+
+    microscope.system.info.model = "changed-after-acquisition"
+    microscope.system.stage.shuttle_pre_tilt = original_pretilt + 17.0
+
+    assert image.metadata.system_info.model == original_model
+    assert image.metadata.hardware_geometry.shuttle_pre_tilt == original_pretilt
+
+
 def test_a_removed_system_info_field_does_not_break_the_load() -> None:
     """`demo_simulator_v5.json` carries `system.info.application_version`, which this
     build no longer declares. `SystemInfo.from_dict` builds field by field, so an
@@ -187,6 +219,6 @@ def test_a_removed_system_info_field_does_not_break_the_load() -> None:
     raw = load("demo_simulator_v5.json")
     assert "application_version" in raw["system"]["info"]
 
-    info = FibsemImageMetadata.from_dict(raw).system.info
+    info = FibsemImageMetadata.from_dict(raw).system_info
     assert not hasattr(info, "application_version")
     assert info.model == "DemoMicroscope"

--- a/tests/test_view_corrected_movement.py
+++ b/tests/test_view_corrected_movement.py
@@ -29,10 +29,15 @@ import pytest
 from fibsem import movement, utils
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.structures import CameraImageTransform
-from fibsem.structures import BeamType, FibsemStagePosition
+from fibsem.structures import BeamType, FibsemHardwareGeometry, FibsemStagePosition
 
 # sweep: stage tilt x pretilt x rotation x beam x compustage
-STAGE_TILTS_DEG = [-50, -23, 0, 15, 35, 52]
+#
+# -128 is the compustage FIB orientation for pretilt 0 (fib_column_tilt - pretilt - 180
+# = 52 - 0 - 180). Without it `is_fib_orientation` was False in all 36 combinations, so
+# the compustage sign flip and the pretilt-sign override it drives went untested
+# despite compustage being parametrised. Added with FIB-481.
+STAGE_TILTS_DEG = [-128, -50, -23, 0, 15, 35, 52]
 PRETILTS_DEG = [0, 35, 45]
 ROTATIONS_DEG = [0, 180]
 BEAM_TYPES = [BeamType.ELECTRON, BeamType.ION]
@@ -169,16 +174,19 @@ def _configure(microscope, *, pretilt_deg, rotation_deg, tilt_deg, compustage):
 def _sync_image_metadata(image, microscope, position, *, is_compustage: bool) -> None:
     """Point an image's metadata at the geometry the microscope is configured for.
 
-    `tiled.py` reads geometry from image metadata rather than from a microscope, and
-    detects a compustage from `system.sim` / the model name rather than from
-    `stage_is_compustage`. The marker therefore has to be set explicitly here --
-    otherwise the test would silently depend on whatever the ambient default
-    configuration happens to advertise, which differs between machines and CI.
+    `tiled.py` reads geometry from image metadata rather than from a microscope, so the
+    compustage marker has to be set explicitly -- otherwise the test would silently
+    depend on whatever the ambient default configuration happens to advertise, which
+    differs between machines and CI.
+
+    Since FIB-481 that is a recorded field rather than a `system.sim` entry standing in
+    for one, so this sets what the projection actually reads.
     """
-    image.metadata.system = microscope.system
+    image.metadata.system_info = microscope.system.info
+    image.metadata.hardware_geometry = FibsemHardwareGeometry.from_system_settings(
+        microscope.system, is_compustage=is_compustage
+    )
     image.metadata.microscope_state.stage_position = position
-    image.metadata.system.sim = dict(image.metadata.system.sim or {})
-    image.metadata.system.sim["is_compustage"] = is_compustage
 
 
 class TestRefactorParity:

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -543,10 +543,10 @@ def test_a_projected_stage_offset_places_an_image_where_the_projection_says():
     import numpy as np
 
     from fibsem.fm.reprojection import project_stage_position
-    from fibsem.fm.structures import CameraImageTransform, FMImageGeometry
+    from fibsem.fm.structures import CameraImageTransform, FibsemHardwareGeometry
     from fibsem.structures import FibsemStagePosition
 
-    geometry = FMImageGeometry(
+    geometry = FibsemHardwareGeometry(
         transform=CameraImageTransform.NONE,
         camera_tilt=180.0,
         is_compustage=True,

--- a/tests/ui/test_stage_frame.py
+++ b/tests/ui/test_stage_frame.py
@@ -22,7 +22,7 @@ import pytest
 # collection from failing there rather than skipping.
 pytest.importorskip("PyQt5")
 
-from fibsem.fm.structures import CameraImageTransform, FMImageGeometry
+from fibsem.fm.structures import CameraImageTransform, FibsemHardwareGeometry
 from fibsem.structures import FibsemStagePosition
 from fibsem.ui.widgets.canvas.stage_frame import FMStageProjection, StageFrame
 
@@ -55,7 +55,7 @@ def _geometry(**overrides):
         is_compustage=True,
     )
     fields.update(overrides)
-    return FMImageGeometry(**fields)
+    return FibsemHardwareGeometry(**fields)
 
 
 def _frame(canvas=None, origin=None, **geometry):


### PR DESCRIPTION
Every image carried a whole `SystemSettings` — **1588 bytes** measured on a real Aquilos file — to deliver six numbers to the reprojection, dragging the manipulator configuration and simulator flags into every picture. v6 records `system_info` + `hardware_geometry` instead: **480 bytes, 70% less**.

## No numerical change

I reconstructed the old formula and ran it against the new code path across model × tilt × rotation × beam, on all four metadata fixtures:

```
compared 560 combinations across 4 fixtures (model x tilt x rotation x beam)
MISMATCHES: 0
```

This moves where the reprojection reads its terms from, and nothing else.

An earlier revision of this PR also fixed a divergence in the compustage FIB-orientation test, which produced 6 sign differences on unreachable poses. **That is now split out to FIB-500**, so a stage-sign change is not buried inside a 20-file restructuring. The site carries a `NOTE` pointing there, and the measurements live on the issue.

## One record for both modalities

`FMImageGeometry` is gone. The beam and FM paths had separate structures naming the same six terms identically, free to drift with nothing to catch it — and they *had* drifted; that is FIB-500. `FibsemHardwareGeometry` now carries the camera's `camera_tilt` and `transform`, left at defaults on a beam image: two dormant fields, 39 bytes, against the 1108 saved.

`CameraImageTransform` and its parser move to `fibsem.structures`, because the record needs the enum and core cannot import from the FM package — `fm.structures` imports from core, so the reverse is a cycle. Both are re-exported from `fm.structures`, beside `AutoFocusMode`, which is re-exported for exactly the same reason.

`fm_image_geometry()` is now `replace()` over `hardware_geometry()`, so the instrument's terms are read out of `SystemSettings` in one place.

## Loading old files

`from_dict` recovers both fields from a pre-v6 `system` blob using `.get()` chains, **never** `SystemSettings.from_dict` — that constructor is bracket-indexed throughout and raises `KeyError` on a blob missing any sub-key, which is exactly what old files risk. Enforced by a parametrised test over all six sub-keys, and guarded against real v3 files from two instruments.

Compustage is recovered by the same model-name match the reprojection used to do inline. That match now survives only inside the shim.

## Also fixed, found while reviewing this

An acquired image **aliased** the live `SystemInfo` rather than copying it, so `TescanMicroscope` rewriting `system.info.model` from each image header reached back into images already acquired. It pre-dates this change (`metadata.system = self.system` aliased the whole object), but the two fields the acquisition helper sets should not disagree about whether they are snapshots. Now both are, with a test.

## Refactor folded in

`_set_additional_metadata` moves to the `FibsemMicroscope` ABC. The same three lines were written out at **eight** acquisition sites across three microscope classes, so changing what an image records meant finding all eight. Happy to split this out if you would rather review it separately.

## Test coverage gap closed

`-128` added to the parity sweep, so the compustage sign flip is exercised at all — `is_fib_orientation` was False in **all 36** combinations before, despite compustage being parametrised. Passes under the existing formula, so this is coverage rather than a behaviour change.

## Known limitation

A v6 server writing metadata to a v5 client leaves `hardware_geometry` unset, and the reprojection raises rather than silently misprojecting. Mixed-version deployments need both sides upgraded.

## Verification

2539 passed, 24 skipped, on top of `3af5a0ae`.