### PR TITLE
[hooks] Let a hook subscribe to a group of events (FIB-494)

### DIFF
--- a/fibsem/hooks.py
+++ b/fibsem/hooks.py
@@ -33,6 +33,106 @@ class HookEvent(str, Enum):
     EXPERIMENT_COMPLETED = "experiment_completed"
 
 
+def _event_name(value: Any) -> str:
+    """A HookEvent member or a plain string, as a plain string.
+
+    Not str(): for a str-mixin Enum that returns "HookEvent.TASK_FAILED" on some
+    Python versions and "task_failed" on others, and this runs on 3.8 through 3.13.
+    """
+    return value.value if hasattr(value, "value") else value
+
+
+# Every HookEvent belongs to exactly one category. A partition rather than loose
+# grouping, and deliberately: overlapping categories would let a new event be filed
+# under a broad one only, leaving a narrower group silently not covering it -- which
+# is the bug this whole mechanism exists to prevent. A test fails if any event is
+# unclassified, so adding one to HookEvent without deciding what it *is* breaks CI
+# rather than quietly breaking someone's notifications months later.
+EVENT_CATEGORIES: Dict[str, List[HookEvent]] = {
+    "any_start": [
+        HookEvent.TASK_STARTED,
+        HookEvent.WORKFLOW_STARTED,
+    ],
+    "any_completion": [
+        HookEvent.TASK_COMPLETED,
+        HookEvent.ITEM_COMPLETED,
+        HookEvent.WORKFLOW_COMPLETED,
+        HookEvent.EXPERIMENT_COMPLETED,
+    ],
+    # Only what went wrong on its own. A cancellation is someone pressing Stop, which
+    # is not a failure and is not something to wake anyone up about -- if you were
+    # there to cancel it, you already know.
+    "any_failure": [
+        HookEvent.TASK_FAILED,
+    ],
+    "any_cancellation": [
+        HookEvent.TASK_CANCELLED,
+        HookEvent.WORKFLOW_CANCELLED,
+    ],
+    "any_skip": [
+        HookEvent.TASK_SKIPPED,
+    ],
+}
+
+# Broader groups are unions of categories, computed rather than hand-listed, so
+# classifying a new event once puts it into every group that should contain it.
+_GROUP_UNIONS: Dict[str, List[str]] = {
+    "any_terminal": ["any_completion", "any_failure", "any_cancellation", "any_skip"],
+}
+
+EVENT_GROUPS: Dict[str, List[HookEvent]] = dict(EVENT_CATEGORIES)
+for _group_name, _members in _GROUP_UNIONS.items():
+    EVENT_GROUPS[_group_name] = [
+        event for category in _members for event in EVENT_CATEGORIES[category]
+    ]
+
+# What a hook's `events` list may legally contain: any single event, or any group.
+KNOWN_SUBSCRIPTIONS = {event.value for event in HookEvent} | set(EVENT_GROUPS)
+
+
+def covers_event(subscriptions: List[str], event: str) -> bool:
+    """Whether a hook subscribed to ``subscriptions`` should receive ``event``.
+
+    A subscription is either an exact event name or a group name. Exact names still
+    work unchanged -- every configuration written before groups existed uses them,
+    and a hook that genuinely wants one specific event should be able to say so.
+    """
+    event = _event_name(event)
+    for subscription in subscriptions:
+        name = _event_name(subscription)
+        if name == event:
+            return True
+        group = EVENT_GROUPS.get(name)
+        if group is not None and any(_event_name(e) == event for e in group):
+            return True
+    return False
+
+
+def resolve_events(subscriptions: List[str]) -> List[str]:
+    """Expand groups to the events they currently cover, for display only.
+
+    Never persist this. A configuration that stores the expansion stops covering
+    events added later, which is precisely the drift groups exist to avoid -- the
+    saved form must stay the group name.
+    """
+    resolved: List[str] = []
+    for subscription in subscriptions:
+        name = _event_name(subscription)
+        for event in EVENT_GROUPS.get(name, [name]):
+            event = _event_name(event)
+            if event not in resolved:
+                resolved.append(event)
+    return resolved
+
+
+def unknown_subscriptions(subscriptions: List[str]) -> List[str]:
+    """Names that are neither an event nor a group, and so will never match."""
+    return [
+        name for name in (_event_name(s) for s in subscriptions)
+        if name not in KNOWN_SUBSCRIPTIONS
+    ]
+
+
 @dataclass
 class HookContext:
     event: str
@@ -158,9 +258,23 @@ def render_template(template: str, context: HookContext) -> str:
 @dataclass
 class Hook(ABC):
     name: str = ""
+    # Event names, group names, or a mix. See EVENT_GROUPS.
     events: List[str] = field(default_factory=list)
     enabled: bool = True
     task_types: List[str] = field(default_factory=list)  # [] = all types
+
+    def __post_init__(self) -> None:
+        # A misspelled subscription matches nothing, forever, without a word -- the
+        # same silent class of failure as the drift groups exist to fix. Warn rather
+        # than raise: one bad name in a config should not stop the application, and
+        # the hook's other subscriptions still work.
+        unknown = unknown_subscriptions(self.events)
+        if unknown:
+            logging.warning(
+                f"Hook '{self.name}' subscribes to unknown event(s) {unknown}, which "
+                f"will never fire. Known events and groups: "
+                f"{sorted(KNOWN_SUBSCRIPTIONS)}"
+            )
 
     @abstractmethod
     def run(self, context: HookContext) -> None:
@@ -262,6 +376,7 @@ class WebhookHook(Hook):
     timeout: int = 5
 
     def __post_init__(self):
+        super().__post_init__()  # subscription validation
         if self.method.upper() not in _WEBHOOK_ALLOWED_METHODS:
             raise ValueError(
                 f"WebhookHook: method '{self.method}' is not allowed (must be one of {sorted(_WEBHOOK_ALLOWED_METHODS)})"
@@ -347,7 +462,7 @@ class HookManager:
         for hook in self._hooks:
             if not hook.enabled:
                 continue
-            if context.event not in hook.events:
+            if not covers_event(hook.events, context.event):
                 continue
             if hook.task_types and context.task_type not in hook.task_types:
                 continue

--- a/fibsem/ui/widgets/hook_config_widget.py
+++ b/fibsem/ui/widgets/hook_config_widget.py
@@ -26,6 +26,7 @@ from fibsem.ui.icon import fibsem_icon
 
 from fibsem.hooks import (
     DEFAULT_MESSAGE_TEMPLATE,
+    EVENT_GROUPS,
     FunctionHook,
     Hook,
     HookEvent,
@@ -33,6 +34,7 @@ from fibsem.hooks import (
     LoggingHook,
     NotificationHook,
     WebhookHook,
+    resolve_events,
 )
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel
@@ -107,6 +109,25 @@ class HookEditDialog(QDialog):
 
         layout.addWidget(TitledPanel("General", content=common_w, collapsible=False))
 
+        # --- Event groups ---
+        # Offered above the individual events, and first for a reason: a group keeps
+        # covering events added in later versions, where an enumerated list silently
+        # stops. See FIB-494.
+        groups_w = QWidget()
+        groups_layout = QVBoxLayout(groups_w)
+        groups_layout.setContentsMargins(4, 4, 4, 4)
+        groups_layout.setSpacing(2)
+        self._group_checks: dict[str, QCheckBox] = {}
+        for group_name in EVENT_GROUPS:
+            chk = QCheckBox(group_name.replace("_", " "))
+            chk.setToolTip(
+                "Currently covers: " + ", ".join(resolve_events([group_name]))
+                + "\nIncludes matching events added in future versions."
+            )
+            self._group_checks[group_name] = chk
+            groups_layout.addWidget(chk)
+        layout.addWidget(TitledPanel("Event groups", content=groups_w, collapsible=False))
+
         # --- Events ---
         events_w = QWidget()
         events_layout = QVBoxLayout(events_w)
@@ -117,7 +138,7 @@ class HookEditDialog(QDialog):
             chk = QCheckBox(event.value)
             self._event_checks[event.value] = chk
             events_layout.addWidget(chk)
-        layout.addWidget(TitledPanel("Events", content=events_w, collapsible=False))
+        layout.addWidget(TitledPanel("Individual events", content=events_w, collapsible=False))
 
         # --- Type-specific fields ---
         specific_w = QWidget()
@@ -179,8 +200,14 @@ class HookEditDialog(QDialog):
     def _load(self, hook: Hook):
         self._name_edit.setText(hook.name)
         self._enabled_chk.setChecked(hook.enabled)
+        # Load groups and events separately. Ticking the events a group *covers*
+        # would turn the group into its expansion on save, which is the drift
+        # FIB-494 exists to prevent -- reintroduced by the editor.
+        subscribed = {e.value if hasattr(e, "value") else e for e in hook.events}
+        for group_name, chk in self._group_checks.items():
+            chk.setChecked(group_name in subscribed)
         for event_val, chk in self._event_checks.items():
-            chk.setChecked(event_val in hook.events)
+            chk.setChecked(event_val in subscribed)
 
         cls_name = type(hook).__name__
         if cls_name == "LoggingHook":
@@ -197,7 +224,9 @@ class HookEditDialog(QDialog):
         """Return a new hook instance with the current dialog values."""
         name = self._name_edit.text().strip()
         enabled = self._enabled_chk.isChecked()
-        events = [v for v, chk in self._event_checks.items() if chk.isChecked()]
+        # Groups first, and stored as group names rather than expanded.
+        events = [g for g, chk in self._group_checks.items() if chk.isChecked()]
+        events += [v for v, chk in self._event_checks.items() if chk.isChecked()]
 
         cls_name = self._hook_cls.__name__
 

--- a/tests/test_hook_event_groups.py
+++ b/tests/test_hook_event_groups.py
@@ -1,0 +1,176 @@
+"""Subscribing to a group of events rather than an enumerated list.
+
+A hook that lists every terminal event silently stops covering the set the moment a
+new event is added -- HookEvent went from six members to ten in a single day, and any
+configuration written the day before missed four of them with no warning. A group is
+maintained in one place instead of in every config file on every machine. See FIB-494.
+"""
+
+import logging
+
+import pytest
+
+from fibsem.hooks import (
+    EVENT_CATEGORIES,
+    EVENT_GROUPS,
+    FunctionHook,
+    HookContext,
+    HookEvent,
+    HookManager,
+    covers_event,
+    resolve_events,
+    unknown_subscriptions,
+)
+
+
+# ---------------------------------------------------------------------------
+# the property that makes groups worth having
+# ---------------------------------------------------------------------------
+
+def test_every_event_is_classified():
+    """The requirement, not a nice-to-have: adding an event without deciding what it
+    is must fail here rather than quietly break someone's notifications months later.
+
+    If this fails, put the new event in the category that matches its outcome.
+    """
+    classified = {e for events in EVENT_CATEGORIES.values() for e in events}
+
+    assert set(HookEvent) - classified == set()
+
+
+def test_the_categories_do_not_overlap():
+    """A partition, not loose grouping. If an event could sit in two categories, a new
+    one could be filed under a broad category only, leaving a narrow group silently
+    not covering it -- which is the original bug wearing a new hat."""
+    seen = set()
+    for name, events in EVENT_CATEGORIES.items():
+        overlap = seen & set(events)
+        assert not overlap, f"{name} overlaps an earlier category on {overlap}"
+        seen |= set(events)
+
+
+def test_broader_groups_are_derived_not_hand_listed():
+    """any_terminal is the union of the terminal categories, so classifying a new
+    event once puts it in every group that should contain it."""
+    expected = set()
+    for category in ("any_completion", "any_failure", "any_cancellation", "any_skip"):
+        expected |= set(EVENT_CATEGORIES[category])
+
+    assert set(EVENT_GROUPS["any_terminal"]) == expected
+    assert HookEvent.TASK_STARTED not in EVENT_GROUPS["any_terminal"]
+
+
+def test_cancellation_is_not_a_failure():
+    """Someone pressed Stop. That is not something to wake anyone up about -- if you
+    were there to cancel it, you already know."""
+    assert HookEvent.TASK_CANCELLED not in EVENT_GROUPS["any_failure"]
+    assert HookEvent.WORKFLOW_CANCELLED not in EVENT_GROUPS["any_failure"]
+
+
+# ---------------------------------------------------------------------------
+# matching
+# ---------------------------------------------------------------------------
+
+def test_a_group_covers_its_events():
+    assert covers_event(["any_failure"], HookEvent.TASK_FAILED)
+    assert covers_event(["any_completion"], HookEvent.EXPERIMENT_COMPLETED)
+    assert not covers_event(["any_failure"], HookEvent.TASK_COMPLETED)
+
+
+def test_exact_event_names_still_work():
+    """Every configuration written before groups existed uses them."""
+    assert covers_event([HookEvent.TASK_FAILED], HookEvent.TASK_FAILED)
+    assert covers_event(["task_failed"], "task_failed")
+    assert not covers_event(["task_failed"], "task_completed")
+
+
+def test_groups_and_exact_names_mix():
+    subscriptions = ["any_failure", HookEvent.WORKFLOW_STARTED]
+
+    assert covers_event(subscriptions, HookEvent.TASK_FAILED)
+    assert covers_event(subscriptions, HookEvent.WORKFLOW_STARTED)
+    assert not covers_event(subscriptions, HookEvent.TASK_STARTED)
+
+
+def test_a_hook_subscribed_to_a_group_actually_fires():
+    """Through HookManager.fire, not just the matcher."""
+    fired = []
+    manager = HookManager()
+    manager.register(
+        FunctionHook(name="any", events=["any_terminal"], callback=fired.append)
+    )
+
+    for event in (HookEvent.TASK_STARTED, HookEvent.TASK_FAILED,
+                  HookEvent.EXPERIMENT_COMPLETED):
+        manager.fire(HookContext(event=event))
+
+    assert [c.event for c in fired] == ["task_failed", "experiment_completed"]
+
+
+def test_a_new_event_joins_its_group_without_touching_any_config(monkeypatch):
+    """The whole point. A hook subscribed to a group covers an event that did not
+    exist when the subscription was written."""
+    from fibsem import hooks
+
+    patched = dict(hooks.EVENT_GROUPS)
+    patched["any_failure"] = list(patched["any_failure"]) + ["task_timed_out"]
+    monkeypatch.setattr(hooks, "EVENT_GROUPS", patched)
+
+    assert hooks.covers_event(["any_failure"], "task_timed_out")
+
+
+# ---------------------------------------------------------------------------
+# display vs storage
+# ---------------------------------------------------------------------------
+
+def test_resolve_expands_a_group_for_display():
+    resolved = resolve_events(["any_cancellation"])
+
+    assert resolved == ["task_cancelled", "workflow_cancelled"]
+
+
+def test_resolve_does_not_repeat_an_event_named_twice():
+    resolved = resolve_events(["any_failure", "task_failed"])
+
+    assert resolved == ["task_failed"]
+
+
+def test_the_group_survives_serialization_unexpanded():
+    """The rule the whole issue turns on: store the group, not its expansion. A saved
+    expansion stops covering events added later, which is the drift groups exist to
+    prevent, reintroduced at save time."""
+    hook = FunctionHook(name="x", events=["any_failure"])
+
+    assert hook.to_dict()["events"] == ["any_failure"]
+
+
+# ---------------------------------------------------------------------------
+# a name that will never match
+# ---------------------------------------------------------------------------
+
+def test_a_misspelled_subscription_warns(caplog):
+    """It would otherwise match nothing, forever, without a word."""
+    with caplog.at_level(logging.WARNING):
+        FunctionHook(name="typo", events=["any_failuer"])
+
+    assert any("any_failuer" in r.message for r in caplog.records)
+
+
+def test_a_valid_subscription_is_quiet(caplog):
+    with caplog.at_level(logging.WARNING):
+        FunctionHook(name="fine", events=["any_failure", HookEvent.TASK_STARTED])
+
+    assert not caplog.records
+
+
+def test_unknown_subscriptions_reports_only_the_bad_ones():
+    assert unknown_subscriptions(["any_failure", "nope", HookEvent.TASK_FAILED]) == ["nope"]
+
+
+def test_a_webhook_still_validates_its_own_fields():
+    """WebhookHook has its own __post_init__; it must not lose the base one, or gain
+    an exception from it."""
+    from fibsem.hooks import WebhookHook
+
+    with pytest.raises(ValueError):
+        WebhookHook(name="w", events=["any_failure"], url="http://x", method="DELETE")

--- a/tests/ui/test_hook_config_groups.py
+++ b/tests/ui/test_hook_config_groups.py
@@ -1,0 +1,86 @@
+"""The hook editor must not destroy a group subscription.
+
+Before FIB-494 the dialog rendered one checkbox per HookEvent and rebuilt `events`
+from whatever was ticked. A hook subscribed to `any_failure` matched no checkbox, so
+it loaded with everything unticked and saved as `events=[]` -- the editor silently
+unsubscribing a hook from everything. Groups are worthless if the only tool for
+editing them deletes them.
+
+Uses the shared offscreen ``qapp`` fixture from tests/conftest.py.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.hooks import EVENT_GROUPS, HookEvent, LoggingHook, WebhookHook
+from fibsem.ui.widgets.hook_config_widget import HookEditDialog
+
+
+def test_a_group_subscription_survives_an_edit(qapp):
+    """Open and accept without changing anything: the group must come back out."""
+    hook = LoggingHook(name="failures", events=["any_failure"])
+
+    dialog = HookEditDialog(hook=hook)
+    result = dialog.get_hook()
+
+    assert result.events == ["any_failure"]
+
+
+def test_a_group_is_not_saved_as_its_expansion(qapp):
+    """The rule the issue turns on. An expansion stops covering events added later."""
+    hook = LoggingHook(name="terminal", events=["any_terminal"])
+
+    result = HookEditDialog(hook=hook).get_hook()
+
+    assert result.events == ["any_terminal"]
+    assert "task_failed" not in result.events
+
+
+def test_exact_events_still_round_trip(qapp):
+    hook = LoggingHook(
+        name="two", events=[HookEvent.TASK_STARTED, HookEvent.TASK_FAILED]
+    )
+
+    result = HookEditDialog(hook=hook).get_hook()
+
+    assert set(result.events) == {"task_started", "task_failed"}
+
+
+def test_a_group_and_an_exact_event_both_survive(qapp):
+    hook = LoggingHook(name="mixed", events=["any_failure", HookEvent.WORKFLOW_STARTED])
+
+    result = HookEditDialog(hook=hook).get_hook()
+
+    assert set(result.events) == {"any_failure", "workflow_started"}
+
+
+def test_every_group_is_offered(qapp):
+    """A group the dialog cannot show is a group a user cannot keep."""
+    dialog = HookEditDialog(hook_cls=LoggingHook)
+
+    assert set(dialog._group_checks) == set(EVENT_GROUPS)
+
+
+def test_a_group_checkbox_says_what_it_covers(qapp):
+    dialog = HookEditDialog(hook_cls=LoggingHook)
+
+    tooltip = dialog._group_checks["any_cancellation"].toolTip()
+
+    assert "task_cancelled" in tooltip and "workflow_cancelled" in tooltip
+    assert "future" in tooltip
+
+
+def test_ticking_a_group_produces_the_group(qapp):
+    dialog = HookEditDialog(hook_cls=WebhookHook)
+    dialog._name_edit.setText("slack")
+    dialog._group_checks["any_failure"].setChecked(True)
+    dialog._specific_widgets["url"].setText("https://hooks.example.com/x")
+
+    result = dialog.get_hook()
+
+    assert result.events == ["any_failure"]
+    assert result.url == "https://hooks.example.com/x"


### PR DESCRIPTION
`HookManager.fire` matched event names exactly, so a hook that wanted "any terminal outcome" had to enumerate them — and silently stopped covering the set the moment a new event was added.

Not hypothetical. `HookEvent` went from six members to ten in a single day across #263 and #264. Any configuration written the day before, carefully listing every terminal event that existed, now misses four of them. No warning; the hook just stops firing for cases its author would obviously have wanted.

```yaml
events: [task_failed, task_cancelled]   # frozen in time
events: [any_failure]                    # keeps up
```

## Groups do not remove the maintenance

Adding a new `HookEvent` still means classifying it. What changes is *where* that obligation lives: today it is spread across an unknown number of YAML files on machines we cannot reach, where it is permanent. With groups it is one dict in the repo, visible in a diff, and fixing it retroactively repairs every existing config on the next upgrade.

That only holds if nobody forgets, so exhaustiveness is enforced rather than hoped for:

```python
def test_every_event_is_classified():
    classified = {e for events in EVENT_CATEGORIES.values() for e in events}
    assert set(HookEvent) - classified == set()
```

Add an event without classifying it and CI fails immediately with the answer in the message. A silent runtime gap — a webhook that quietly stops covering a case, noticed months later when someone asks why they were not told about a failure — becomes a build error.

A second test forbids overlapping categories. Without it a new event could be filed under a broad group only, passing the exhaustiveness test while a narrower group silently failed to cover it — the original bug wearing a new hat. So `EVENT_CATEGORIES` is a partition, and broader groups like `any_terminal` are **computed** unions of categories rather than hand-listed: classify once, and the event appears in every group that should contain it.

## What the groups are

`any_start`, `any_completion`, `any_failure`, `any_cancellation`, `any_skip`, plus the derived `any_terminal`.

One judgment call worth reviewing: **`any_failure` holds only `task_failed`.** A cancellation is someone pressing Stop — not a failure, and not something to wake anyone up about, because if you were there to cancel it you already know. It lives in `any_cancellation`, and a test pins that the two stay separate. Easy to change if you disagree, but it should be a decision rather than a default.

Exact event names keep working unchanged. Every configuration written before groups uses them, and a hook that genuinely wants one specific event should be able to say so.

## The editor was destroying group subscriptions

Found while wiring this up, and it had to be fixed here rather than later — groups are worthless if the only tool for editing them deletes them.

`HookEditDialog` rendered one checkbox per `HookEvent` and rebuilt `events` from whatever was ticked. A hook subscribed to `any_failure` matched no checkbox, so it loaded with everything unticked and saved as `events=[]`. Opening a hook and clicking OK silently unsubscribed it from everything.

It now offers the groups **above** the individual events, loads the two separately, and saves group names intact. Ticking the events a group *covers* would turn the group into its expansion on save — the same drift this PR exists to prevent, reintroduced by the UI. Each group checkbox carries a tooltip saying what it currently covers and that it includes matching events added in future versions, which is only true because the group is what gets stored.

This is not the final level-2 chip editor from the FIB-497 design; it is the smallest change that makes the existing editor group-aware and non-destructive.

## Silent typos

`events: ["any_failuer"]` matched nothing, forever, without a word — the same class of silent failure as the drift itself. A subscription that is neither an event nor a group now warns at construction and lists the valid names.

## Why this lands before the config work

FIB-497 phase 2 starts writing hook configs to users' machines. Once those files exist, changing what is in them means migrating them.

## Testing

`tests/test_hook_event_groups.py` — 16 tests: the exhaustiveness and non-overlap properties, `any_terminal` derived rather than listed, cancellation not being a failure, groups and exact names matching and mixing, a group firing through `HookManager.fire`, a new event joining its group without touching any config, expansion for display only, the group surviving `to_dict` unexpanded, and the typo warning.

`tests/ui/test_hook_config_groups.py` — 7 headless Qt tests on the dialog round trip.

2525 tests pass.
