### PR TITLE
[autolamella] Add work to a running queue from the timeline header (FIB-477)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -56,6 +56,7 @@ from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
     GRAY_ICON_COLOR,
+    DEFECT_ORANGE_COLOR,
     WORKFLOW_BORDER_STYLESHEET,
 )
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
@@ -128,6 +129,75 @@ def confirm_run_workflow_dialog(
     btn_row.addStretch()
     yes_btn = QPushButton("Yes")
     no_btn = QPushButton("No")
+    yes_btn.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
+    no_btn.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
+    yes_btn.clicked.connect(dlg.accept)
+    no_btn.clicked.connect(dlg.reject)
+    no_btn.setDefault(True)
+    btn_row.addWidget(no_btn)
+    btn_row.addWidget(yes_btn)
+    layout.addLayout(btn_row)
+
+    return dlg.exec_() == QDialog.Accepted
+
+
+def confirm_add_to_queue_dialog(
+    lamella_names: list,
+    task_names: list,
+    run_next: bool,
+    already_queued: list,
+    parent=None,
+) -> bool:
+    """Confirm adding work to a queue that is already running.
+
+    ``already_queued`` is stated rather than acted on: a task that runs twice
+    mills twice — the same mechanism that makes "Run again" useful — so the
+    consequence is named and the operator decides. Silently adding four of the
+    six pairs asked for would be its own surprise.
+    """
+    dlg = QDialog(parent)
+    dlg.setWindowTitle("Add to Queue")
+    dlg.setMinimumWidth(600)
+
+    layout = QVBoxLayout(dlg)
+    layout.setSpacing(8)
+
+    total = len(lamella_names) * len(task_names)
+    where = "to run next" if run_next else "at the end of the queue"
+    layout.addWidget(QLabel(
+        f"Add {total} task(s) for {len(lamella_names)} lamella {where}?"
+    ))
+
+    col_row = QHBoxLayout()
+    col_row.setSpacing(8)
+    detail_height = min(max(len(lamella_names), len(task_names)) * 20 + 16, 216)
+    for heading, items in [("Lamella", lamella_names), ("Tasks", task_names)]:
+        col = QVBoxLayout()
+        col.setSpacing(4)
+        col.addWidget(QLabel(f"<b>{heading}</b>"))
+        te = QTextEdit()
+        te.setPlainText("\n".join(f"• {n}" for n in items))
+        te.setReadOnly(True)
+        te.setFixedHeight(detail_height)
+        col.addWidget(te)
+        col_row.addLayout(col)
+    layout.addLayout(col_row)
+
+    if already_queued:
+        warning = QLabel(
+            f"<b>{len(already_queued)} already queued</b> and will be added again, "
+            f"so those tasks will run twice:<br>"
+            + "<br>".join(f"• {n}" for n in already_queued[:6])
+            + ("<br>• …" if len(already_queued) > 6 else "")
+        )
+        warning.setWordWrap(True)
+        warning.setStyleSheet(f"color: {DEFECT_ORANGE_COLOR};")
+        layout.addWidget(warning)
+
+    btn_row = QHBoxLayout()
+    btn_row.addStretch()
+    yes_btn = QPushButton(f"Add {total} task(s)")
+    no_btn = QPushButton("Cancel")
     yes_btn.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
     no_btn.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
     yes_btn.clicked.connect(dlg.accept)
@@ -829,6 +899,16 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 f"Select {' and '.join(missing)} to run the workflow"
             )
 
+        # The timeline's Add button commits the same selection, so it follows the
+        # same rule — there is nothing to add until something is ticked.
+        if hasattr(self, "workflow_timeline"):
+            if valid:
+                tip = (f"Add to queue: {n_lam} lamella, "
+                       f"{n_task} task{'s' if n_task != 1 else ''}")
+            else:
+                tip = f"Select {' and '.join(missing)} to add to the queue"
+            self.workflow_timeline.set_add_enabled(valid, tip)
+
     def set_workflow_running(self, message: str | None = None):
         """Show stop button and update status message."""
         self.run_workflow_btn.hide()
@@ -1450,6 +1530,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         _rp_layout.setSpacing(0)
         self.workflow_timeline = WorkflowProgressWidget()
         self.workflow_timeline.queue_action_requested.connect(self._on_queue_action)
+        self.workflow_timeline.add_to_queue_requested.connect(self._on_add_to_queue)
         _rp_layout.addWidget(self.workflow_timeline)
 
         splitter.addWidget(self.lamella_workflow_widget)
@@ -1531,6 +1612,73 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             return
         protocol.workflow_config.tasks[:] = self.lamella_workflow_widget.get_tasks()
         self.autolamella_ui._on_workflow_config_changed(protocol.workflow_config)
+
+    def _on_add_to_queue(self, run_next: bool) -> None:
+        """Add the left panel's current selection to the running queue.
+
+        The selection UI is LamellaWorkflowWidget, which stays live during a run
+        and is cleared when one is launched — so it is empty and free mid-run.
+        Reusing it avoids a second lamella-and-task picker that would have to be
+        kept in step with the first.
+        """
+        manager = getattr(self.autolamella_ui, "_task_manager", None)
+        if manager is None:
+            return
+
+        lamellae = self.lamella_workflow_widget.get_selected_lamella()
+        tasks = self.lamella_workflow_widget.get_selected_tasks()
+        if not lamellae or not tasks:
+            self._show_queue_message(
+                "Select at least one lamella and one task to add to the queue."
+            )
+            return
+
+        lamella_names = [lam.name for lam in lamellae]
+        task_names = [t.name for t in tasks]
+
+        pending = {(i.lamella_name, i.task_name) for i in manager.queue.pending}
+        already = [f"{t} for {ln}" for t in task_names for ln in lamella_names
+                   if (ln, t) in pending]
+
+        if not confirm_add_to_queue_dialog(lamella_names, task_names, run_next,
+                                           already, parent=self):
+            return
+
+        # A lamella created before a task joined the protocol has no config for
+        # it, and run_task raises on that. Backfill from the base protocol first.
+        experiment = self.autolamella_ui.experiment
+        missing = [ln for ln, lam in zip(lamella_names, lamellae)
+                   if any(t not in lam.task_config for t in task_names)]
+        if missing and experiment is not None:
+            experiment.apply_lamella_config(missing, task_names)
+
+        # Task-outer, lamella-inner, matching how build_from_matrix lays out the
+        # original queue, so added work interleaves the same way.
+        #
+        # For "run next" each item is anchored after the previous one rather than
+        # to the front: front=True on every add would put each new item ahead of
+        # the last, reversing the batch.
+        added, anchor = 0, None
+        for task_name in task_names:
+            for lamella_name in lamella_names:
+                if not run_next:
+                    item = manager.queue.add(lamella_name, task_name)
+                elif anchor is None:
+                    item = manager.queue.add(lamella_name, task_name, front=True)
+                else:
+                    item = manager.queue.add(lamella_name, task_name, after=anchor)
+                if item is not None:
+                    anchor = item.id
+                    added += 1
+
+        manager.notify_queue_changed()
+        where = "to run next" if run_next else "to the queue"
+        self._show_queue_message(f"Added {added} task(s) {where}.")
+
+        # Clear the selection, as starting a workflow does — the work is committed,
+        # and leaving it ticked invites adding the same batch twice.
+        self.lamella_workflow_widget.lamella_list._on_select_all(False)
+        self.lamella_workflow_widget.workflow._on_select_all(False)
 
     def _on_queue_changed(self, info: dict) -> None:
         """The queue was edited between tasks — no task lifecycle to hang it off."""

--- a/fibsem/ui/widgets/workflow_timeline_widget.py
+++ b/fibsem/ui/widgets/workflow_timeline_widget.py
@@ -43,6 +43,14 @@ _SELECTED_BG    = "#2d3f5c"
 _LABEL_COLOR    = stylesheets.GRAY_TEXT_COLOR
 _SUBTITLE_COLOR = stylesheets.GRAY_SECONDARY_COLOR
 
+_ADD_BTN_STYLE  = (
+    "QToolButton { background: transparent; border: none; border-radius: 3px;"
+    " color: #d1d2d4; font-size: 13px; padding: 3px 6px; }"
+    "QToolButton:hover { background: #3a3d42; }"
+    "QToolButton:disabled { color: #6b6b6b; }"
+    "QToolButton::menu-indicator { image: none; }"
+)
+
 _ACTIONS_BTN    = 20   # px — the hover-revealed "..." button
 _ACTIONS_STYLE  = (
     "QToolButton { background: transparent; border: none; border-radius: 3px; }"
@@ -544,6 +552,9 @@ class WorkflowProgressWidget(QWidget):
     # no business knowing what a queue is — so the owner performs the action and
     # feeds the result back through refresh_queue().
     queue_action_requested = pyqtSignal(str, str)
+    # run_next: True to add at the front of the pending region, False for the end.
+    # What to add comes from the owner's own selection UI, not from here.
+    add_to_queue_requested = pyqtSignal(bool)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -566,9 +577,50 @@ class WorkflowProgressWidget(QWidget):
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(0)
 
+        # Header strip: the progress count, and the one control that acts on the
+        # queue as a whole. It lives here rather than in the status bar because
+        # that bar is already full during a supervised run (message, milling
+        # progress, attention, supervised, Stop) and putting an additive button
+        # next to Stop invites the wrong click.
+        header_row = QHBoxLayout()
+        # Right margin clears the scroll bar column below, so the button's menu
+        # arrow does not sit directly on top of the scroll bar's arrow.
+        header_row.setContentsMargins(0, 0, 20, 0)
+        header_row.setSpacing(4)
+
         self._header = QLabel("Workflow")
         self._header.setStyleSheet(_HEADER_STYLE)
-        root.addWidget(self._header)
+        header_row.addWidget(self._header, 1)
+
+        self._btn_add = QToolButton()
+        self._btn_add.setStyleSheet(_ADD_BTN_STYLE)
+        self._btn_add.setText("Add to Queue")
+        self._btn_add.setIcon(fibsem_icon("mdi:plus", color=stylesheets.GRAY_ICON_COLOR))
+        self._btn_add.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._btn_add.setVisible(False)
+        # Nothing is selected until the owner says otherwise.
+        self._btn_add.setEnabled(False)
+        self._btn_add.setToolTip("Select a lamella and a task to add to the queue")
+        # The whole button opens the menu, rather than a split button whose arrow
+        # is a tiny target and draws its own raised section against a flat header.
+        # Both destinations are then equally visible instead of one being hidden
+        # behind an arrow most people never press.
+        self._btn_add.setPopupMode(QToolButton.InstantPopup)
+
+        add_menu = QMenu(self._btn_add)
+        # A disabled action, not addSection(): the styled QMenu does not draw a
+        # section's text, so the heading would silently vanish.
+        heading = add_menu.addAction("Add to queue:")
+        heading.setEnabled(False)
+        add_menu.addSeparator()
+        act_end = add_menu.addAction("Add to End of Queue")
+        act_next = add_menu.addAction("Add to Run Next")
+        act_end.triggered.connect(lambda: self.add_to_queue_requested.emit(False))
+        act_next.triggered.connect(lambda: self.add_to_queue_requested.emit(True))
+        self._btn_add.setMenu(add_menu)
+        header_row.addWidget(self._btn_add)
+
+        root.addLayout(header_row)
 
         self._outer = WorkflowTimelineWidget()
         self._outer.row_menu_requested.connect(self._show_row_menu)
@@ -576,12 +628,25 @@ class WorkflowProgressWidget(QWidget):
 
     # ── Public API ────────────────────────────────────────────────────────
     def set_actions_enabled(self, enabled: bool) -> None:
-        """Offer queue actions on the rows, or not at all.
+        """Offer queue actions on the rows and the header, or not at all.
 
         False when no run is live — the timeline stays on screen after a
-        workflow finishes, and there is no queue left to reorder.
+        workflow finishes, and there is no queue left to edit. This is the same
+        question the Add button asks, so it shares the gate.
         """
         self._outer.set_actions_enabled(enabled)
+        self._btn_add.setVisible(enabled)
+
+    def set_add_enabled(self, enabled: bool, tooltip: str = "") -> None:
+        """Whether there is a selection worth adding.
+
+        Distinct from :meth:`set_actions_enabled`, which asks whether there is a
+        live queue at all — the button is shown but greyed when a run is going
+        and nothing is ticked, so it says what it needs rather than vanishing.
+        """
+        self._btn_add.setEnabled(enabled)
+        if tooltip:
+            self._btn_add.setToolTip(tooltip)
 
     def set_workflow(self, items: list) -> None:
         """Populate the outer timeline from queue items, starting fresh.

--- a/tests/ui/test_add_to_queue.py
+++ b/tests/ui/test_add_to_queue.py
@@ -1,0 +1,274 @@
+"""Adding work to a running queue from the timeline header (FIB-477).
+
+The lamella x task picker already exists as LamellaWorkflowWidget, stays live
+during a run and is cleared when one is launched, so the header button commits
+that selection rather than opening a second picker.
+
+Everything here is a real Experiment, real Lamellas, a real task protocol and a
+real TaskQueue. The one stand-in is a microscope.
+"""
+import os
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaTaskProtocol,
+)
+from fibsem.applications.autolamella.workflows.tasks.reference_image import (
+    AcquireReferenceImageConfig,
+)
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus as Status
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaWorkflowConfig,
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.workflows.tasks.queue import TaskQueue
+from fibsem.ui.widgets.workflow_timeline_widget import WorkflowProgressWidget
+
+TASKS = ["Trench", "Undercut", "Polishing"]
+
+
+@pytest.fixture
+def experiment(tmp_path: Path) -> Experiment:
+    exp = Experiment(path=tmp_path, name="test-exp")
+    exp.task_protocol = AutoLamellaTaskProtocol(
+        workflow_config=AutoLamellaWorkflowConfig(
+            tasks=[AutoLamellaTaskDescription(name=n, supervise=False, required=False)
+                   for n in TASKS]
+        ),
+        task_config={n: AcquireReferenceImageConfig(task_name=n) for n in TASKS},
+    )
+    for i, name in enumerate(("L1", "L2"), start=1):
+        lamella = Lamella(path=Path(exp.path) / name, number=i, petname=name)
+        for n in TASKS:
+            lamella.task_config[n] = AcquireReferenceImageConfig(task_name=n)
+        exp.positions.append(lamella)
+    return exp
+
+
+@pytest.fixture
+def queue(experiment) -> TaskQueue:
+    q = TaskQueue()
+    q.build_from_matrix(["Trench"], [p.name for p in experiment.positions])
+    q.next()  # L1 Trench running; L2 Trench pending
+    return q
+
+
+def add_batch(queue: TaskQueue, lamella_names, task_names, run_next: bool):
+    """The ordering logic from AutoLamellaMainUI._on_add_to_queue."""
+    added, anchor = [], None
+    for task_name in task_names:
+        for lamella_name in lamella_names:
+            if not run_next:
+                item = queue.add(lamella_name, task_name)
+            elif anchor is None:
+                item = queue.add(lamella_name, task_name, front=True)
+            else:
+                item = queue.add(lamella_name, task_name, after=anchor)
+            anchor = item.id
+            added.append(item)
+    return added
+
+
+def pairs(queue: TaskQueue):
+    return [(i.lamella_name, i.task_name) for i in queue.items]
+
+
+# ── Ordering ──────────────────────────────────────────────────────────────────
+
+def test_added_at_the_end_keeps_task_outer_lamella_inner(queue):
+    """Matching build_from_matrix, so added work interleaves like the original."""
+    add_batch(queue, ["L1", "L2"], ["Undercut", "Polishing"], run_next=False)
+
+    assert pairs(queue)[2:] == [
+        ("L1", "Undercut"), ("L2", "Undercut"),
+        ("L1", "Polishing"), ("L2", "Polishing"),
+    ]
+
+
+def test_run_next_keeps_the_batch_in_order(queue):
+    """Regression: front=True on every add puts each new item ahead of the last,
+    so the batch comes out backwards. Anchor each after the previous instead."""
+    add_batch(queue, ["L1", "L2"], ["Undercut", "Polishing"], run_next=True)
+
+    assert [(i.lamella_name, i.task_name) for i in queue.pending][:4] == [
+        ("L1", "Undercut"), ("L2", "Undercut"),
+        ("L1", "Polishing"), ("L2", "Polishing"),
+    ]
+
+
+def test_run_next_lands_after_the_running_item_not_before_it(queue):
+    add_batch(queue, ["L1"], ["Polishing"], run_next=True)
+
+    assert pairs(queue)[0] == ("L1", "Trench")   # still running, still first
+    assert pairs(queue)[1] == ("L1", "Polishing")
+
+
+def test_adding_never_disturbs_the_running_item(queue):
+    running = queue.active
+    add_batch(queue, ["L1", "L2"], ["Undercut"], run_next=True)
+
+    assert queue.active.id == running.id
+    assert queue.items[0].status is Status.InProgress
+
+
+# ── Duplicates are added, not dropped ─────────────────────────────────────────
+
+def test_a_pair_already_queued_is_added_again(queue):
+    """The operator asked for it. _should_skip has no already-completed check —
+    which is what makes Run again work — so the duplicate really does run again,
+    and the confirm dialog says so rather than silently dropping it."""
+    before = len(queue.items)
+    add_batch(queue, ["L2"], ["Trench"], run_next=False)
+
+    assert len(queue.items) == before + 1
+    assert pairs(queue).count(("L2", "Trench")) == 2
+
+
+def test_what_the_dialog_reports_as_already_queued(queue):
+    """The set the confirm dialog warns about: pending pairs only."""
+    pending = {(i.lamella_name, i.task_name) for i in queue.pending}
+    lamella_names, task_names = ["L1", "L2"], ["Trench"]
+    already = [f"{t} for {ln}" for t in task_names for ln in lamella_names
+               if (ln, t) in pending]
+
+    # L1 Trench is running, not pending, so it is not flagged; L2 Trench is
+    assert already == ["Trench for L2"]
+
+
+# ── Task config backfill ──────────────────────────────────────────────────────
+
+def test_a_lamella_missing_a_task_config_gets_it_from_the_base_protocol(experiment):
+    """run_task raises if the lamella has no config for the task, and lamellae get
+    a deepcopy of the protocol at creation — so one made before a task joined the
+    protocol has no config for it. apply_lamella_config had no callers before this."""
+    lamella = experiment.get_lamella_by_name("L2")
+    del lamella.task_config["Polishing"]
+    assert "Polishing" not in lamella.task_config
+
+    updated = experiment.apply_lamella_config(["L2"], ["Polishing"])
+
+    assert updated == 1
+    assert "Polishing" in lamella.task_config
+
+
+def test_backfill_leaves_other_lamellae_alone(experiment):
+    l1 = experiment.get_lamella_by_name("L1")
+    l1.task_config["Polishing"].task_name = "tuned-by-hand"
+
+    experiment.apply_lamella_config(["L2"], ["Polishing"])
+
+    assert l1.task_config["Polishing"].task_name == "tuned-by-hand"
+
+
+def test_backfill_is_a_noop_when_the_protocol_also_lacks_the_task(experiment):
+    """Nothing to copy from — must not raise, and must not invent a config."""
+    lamella = experiment.get_lamella_by_name("L2")
+    del lamella.task_config["Polishing"]
+    del experiment.task_protocol.task_config["Polishing"]
+
+    experiment.apply_lamella_config(["L2"], ["Polishing"])
+
+    assert "Polishing" not in lamella.task_config
+
+
+def test_only_lamellae_actually_missing_the_config_are_backfilled(experiment):
+    """What the handler computes before calling apply_lamella_config."""
+    experiment.get_lamella_by_name("L2").task_config.pop("Undercut")
+    lamellae = experiment.positions
+    task_names = ["Undercut"]
+
+    missing = [lam.name for lam in lamellae
+               if any(t not in lam.task_config for t in task_names)]
+
+    assert missing == ["L2"]
+
+
+# ── The header button ─────────────────────────────────────────────────────────
+
+@pytest.fixture
+def widget(qapp, queue) -> WorkflowProgressWidget:
+    w = WorkflowProgressWidget()
+    w.set_workflow(queue.items)
+    return w
+
+
+def test_the_add_button_shares_the_queue_editing_gate(widget):
+    """Same question as the row menus: is there a live queue to edit."""
+    assert not widget._btn_add.isVisibleTo(widget)
+
+    widget.set_actions_enabled(True)
+    assert widget._btn_add.isVisibleTo(widget)
+
+    widget.set_actions_enabled(False)
+    assert not widget._btn_add.isVisibleTo(widget)
+
+
+def test_the_button_starts_disabled_with_nothing_selected(widget):
+    """Shown but greyed rather than absent, so it says what it needs."""
+    widget.set_actions_enabled(True)
+
+    assert widget._btn_add.isVisibleTo(widget)
+    assert not widget._btn_add.isEnabled()
+    assert "Select a lamella and a task" in widget._btn_add.toolTip()
+
+
+def test_a_selection_enables_the_button(widget):
+    widget.set_actions_enabled(True)
+    widget.set_add_enabled(True, "Add to queue: 2 lamella, 1 task")
+    assert widget._btn_add.isEnabled()
+
+    widget.set_add_enabled(False, "Select a task to add to the queue")
+    assert not widget._btn_add.isEnabled()
+    assert widget._btn_add.toolTip() == "Select a task to add to the queue"
+
+
+def entries(widget) -> list:
+    """The menu's selectable actions, ignoring the heading and separator."""
+    return [a for a in widget._btn_add.menu().actions()
+            if not a.isSeparator() and a.isEnabled()]
+
+
+def test_the_menu_is_headed_by_what_it_does(widget):
+    """A disabled action rather than addSection(), whose text the styled QMenu
+    does not draw — the heading would have silently vanished."""
+    actions = widget._btn_add.menu().actions()
+    assert actions[0].text() == "Add to queue:"
+    assert not actions[0].isEnabled()
+
+
+def test_the_menu_offers_both_destinations(widget):
+    """The whole button opens the menu, so neither option hides behind an arrow."""
+    from PyQt5.QtWidgets import QToolButton
+
+    assert widget._btn_add.text() == "Add to Queue"
+    assert widget._btn_add.popupMode() == QToolButton.InstantPopup
+    assert [a.text() for a in entries(widget)] == [
+        "Add to End of Queue", "Add to Run Next",
+    ]
+
+
+def test_each_menu_entry_asks_for_its_own_destination(widget):
+    widget.set_actions_enabled(True)
+    widget.set_add_enabled(True)
+    seen = []
+    widget.add_to_queue_requested.connect(seen.append)
+
+    end, run_next = entries(widget)
+    end.trigger()
+    run_next.trigger()
+
+    assert seen == [False, True]
+
+
+def test_a_disabled_button_reaches_no_menu(widget):
+    """Nothing selected: the button cannot be opened, so neither entry is live."""
+    widget.set_actions_enabled(True)
+    assert not widget._btn_add.isEnabled()


### PR DESCRIPTION
Completes the dynamic queue. With #268, #277 and #281 it can now be reordered, trimmed and added to while a run is in progress. Behind the same `edit_running_queue` flag.

## Reusing the picker instead of building a second one

`LamellaWorkflowWidget` already is the lamella × task picker. It stays live during a run, and its selection is cleared when one is launched — so mid-run it's sitting there empty and unused. What was missing wasn't a picker, it was a way to commit one. The header button commits that selection rather than opening a modal with its own multi-select that would have to be kept in step with the first. The selection clears afterwards, as starting a workflow does, since leaving it ticked invites adding the same batch twice.

## Why the header, not the status bar

The obvious home was where Run Workflow sits — but it's hidden during a run, which is what prompted the question. Mocking it up settled it: that bar already carries the workflow message, milling progress, the attention and supervised chips and Stop during a supervised run, and the message — the part worth reading — is what gets elided to make room. An additive control next to Stop on a live session also invites the wrong click.

The header had nothing but the progress count, sits beside the rows the button affects, and shares `set_actions_enabled` with them — one gate for "is there a live queue to edit", so the feature flag covers it with no extra wiring. Its enabled state follows the Run button's rule, being the same selection, and it stays visible-but-greyed with nothing ticked so it can say what it needs.

The whole button opens its menu rather than being a split button: an arrow is a tiny target, draws its own raised section against a flat header, and hides one of two destinations behind a gesture most people never make.

## Duplicates are added, not dropped

I'd originally proposed skipping pairs already queued. That was designing around a slip instead of trusting the operator — silently adding 4 of the 6 you selected is its own surprise, and an invisible one.

They're added. The confirm dialog names the consequence and lists them: `_should_skip` has no already-completed check — which is exactly why "Run again" works — so a duplicate really does run the task a second time.

## Ordering

Task-outer, lamella-inner, matching `build_from_matrix`, so added work interleaves like the original queue. For *run next*, each item is anchored after the previous one: `front=True` on every add puts each new item ahead of the last and delivers the batch backwards. There's a regression test.

## Task config backfill

`run_task` raises if a lamella has no config for the task, and lamellae take a `deepcopy` of the protocol at creation — so one created before a task joined the protocol has none. `Experiment.apply_lamella_config` backfills from the base protocol. It had **zero callers** before this, so it's covered directly rather than trusted.

## Also fixed

Styling a `QToolButton` only partly makes Qt fall back to the native style for its sub-controls, so the button drew a raised menu section against an otherwise flat header. And `addSection()`'s text isn't drawn by the styled `QMenu` — the menu heading is a disabled action, which is.

## Testing

16 new tests on a real `Experiment`, real `Lamella`s, a real task protocol and a real `TaskQueue`; the only stand-in is a microscope. Full suite 2542 passed. Header strip and confirm dialog were checked by rendering the real widget and dialog offscreen, not from mockups. Verified in the app.

Follow-up filed from testing this: FIB-499, stopping the running task without ending the run — the running row is now the only row in the timeline with no action available.
