### PR TITLE
[hooks] Report a rejected webhook, and add a Slack hook (FIB-498)

### DIFF
--- a/fibsem/hooks.py
+++ b/fibsem/hooks.py
@@ -387,10 +387,13 @@ class WebhookHook(Hook):
         _validate_webhook_url(self.url)
         threading.Thread(target=self._post, args=(context,), daemon=True).start()
 
-    def _post(self, context: HookContext) -> None:
-        try:
-            import requests
-            payload = {
+    def _payload(self, context: HookContext) -> dict:
+        """The JSON body to post.
+
+        Subclasses override this for services that require a particular shape -- a
+        generic endpoint takes the structured event, Slack does not. See SlackHook.
+        """
+        return {
                 "event": context.event,
                 "task_name": context.task_name,
                 "task_type": context.task_type,
@@ -407,10 +410,27 @@ class WebhookHook(Hook):
                 "error": context.error,
                 "skip_reason": context.skip_reason,
                 "timestamp": context.timestamp,
-            }
-            requests.request(self.method, self.url, json=payload, timeout=self.timeout)
+        }
+
+    def _post(self, context: HookContext) -> None:
+        try:
+            import requests
+            response = requests.request(
+                self.method, self.url, json=self._payload(context), timeout=self.timeout
+            )
+            # A rejected request is not an exception, so without this check an endpoint
+            # that refuses the body -- Slack answering invalid_payload to a generic
+            # payload, an expired URL, a typo in the path -- fails in complete silence.
+            # The hook sits in the configuration looking connected and delivers nothing.
+            # The response body is where the reason lives, so include it, truncated
+            # because an error page can be arbitrarily long.
+            if not response.ok:
+                logging.warning(
+                    f"{type(self).__name__} '{self.name}' was rejected: "
+                    f"HTTP {response.status_code} {response.text[:200]}"
+                )
         except Exception:
-            logging.exception(f"WebhookHook '{self.name}' failed")
+            logging.exception(f"{type(self).__name__} '{self.name}' failed")
 
     def to_dict(self) -> dict:
         return {**super().to_dict(), "url": self.url, "method": self.method, "timeout": self.timeout}
@@ -433,6 +453,36 @@ class WebhookHook(Hook):
 
 
 @dataclass
+class SlackHook(WebhookHook):
+    """Posts a rendered message to a Slack incoming webhook.
+
+    Its own type rather than a WebhookHook pointed at a Slack URL, because Slack
+    rejects an arbitrary JSON body with ``invalid_payload``: an incoming webhook wants
+    ``{"text": ...}`` or a blocks array, not the structured event. Everything else --
+    URL validation, the daemon thread, the timeout, the rejection warning -- comes from
+    WebhookHook.
+
+    The same shape serves Discord with ``content`` instead of ``text``; each service
+    that dictates its own body is a few lines here.
+    """
+    message_template: str = DEFAULT_MESSAGE_TEMPLATE
+
+    def _payload(self, context: HookContext) -> dict:
+        return {"text": render_template(self.message_template, context)}
+
+    def to_dict(self) -> dict:
+        return {**super().to_dict(), "message_template": self.message_template}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "SlackHook":
+        # super() builds via cls(), so this is already a SlackHook; only the field
+        # WebhookHook does not know about is left to set.
+        hook = super().from_dict(d)
+        hook.message_template = d.get("message_template", DEFAULT_MESSAGE_TEMPLATE)
+        return hook
+
+
+@dataclass
 class FunctionHook(Hook):
     """Hook that calls a Python callable. Not serializable — registered in code only."""
     callback: Optional[Callable[["HookContext"], None]] = field(default=None, repr=False)
@@ -446,6 +496,7 @@ HOOK_TYPES: Dict[str, Type[Hook]] = {
     "LoggingHook": LoggingHook,
     "NotificationHook": NotificationHook,
     "WebhookHook": WebhookHook,
+    "SlackHook": SlackHook,
 }
 
 

--- a/fibsem/ui/widgets/hook_config_widget.py
+++ b/fibsem/ui/widgets/hook_config_widget.py
@@ -33,6 +33,7 @@ from fibsem.hooks import (
     HookManager,
     LoggingHook,
     NotificationHook,
+    SlackHook,
     WebhookHook,
     resolve_events,
 )
@@ -52,18 +53,21 @@ _HOOK_DISPLAY_NAMES = {
     "LoggingHook": "Logging",
     "NotificationHook": "Notification",
     "WebhookHook": "Webhook",
+    "SlackHook": "Slack",
 }
 
 _HOOK_CLASSES: dict[str, Type[Hook]] = {
     "LoggingHook": LoggingHook,
     "NotificationHook": NotificationHook,
     "WebhookHook": WebhookHook,
+    "SlackHook": SlackHook,
 }
 
 _TYPE_COLORS = {
     "LoggingHook":      "#50a6ff",
     "NotificationHook": stylesheets.GREEN_COLOR,
     "WebhookHook":      stylesheets.ORANGE_COLOR,
+    "SlackHook":        "#a67cff",
 }
 
 
@@ -184,6 +188,19 @@ class HookEditDialog(QDialog):
             specific_form.addRow("Timeout", timeout_spin)
             self._specific_widgets["timeout"] = timeout_spin
 
+        elif cls_name == "SlackHook":
+            # Only the two fields a user actually sets. Slack incoming webhooks are
+            # always POST, and the timeout default is fine, so neither is worth asking.
+            url_edit = QLineEdit()
+            url_edit.setPlaceholderText("https://hooks.slack.com/services/...")
+            specific_form.addRow("Webhook URL", url_edit)
+            self._specific_widgets["url"] = url_edit
+
+            tmpl = QLineEdit()
+            tmpl.setPlaceholderText(DEFAULT_MESSAGE_TEMPLATE)
+            specific_form.addRow("Message", tmpl)
+            self._specific_widgets["message_template"] = tmpl
+
         if self._specific_widgets:
             layout.addWidget(TitledPanel(
                 _HOOK_DISPLAY_NAMES.get(cls_name, cls_name),
@@ -219,6 +236,9 @@ class HookEditDialog(QDialog):
             self._specific_widgets["url"].setText(hook.url)
             self._specific_widgets["method"].setCurrentText(hook.method)
             self._specific_widgets["timeout"].setValue(hook.timeout)
+        elif cls_name == "SlackHook":
+            self._specific_widgets["url"].setText(hook.url)
+            self._specific_widgets["message_template"].setText(hook.message_template)
 
     def get_hook(self) -> Hook:
         """Return a new hook instance with the current dialog values."""
@@ -248,6 +268,13 @@ class HookEditDialog(QDialog):
                 url=self._specific_widgets["url"].text().strip(),
                 method=self._specific_widgets["method"].currentText(),
                 timeout=self._specific_widgets["timeout"].value(),
+            )
+        elif cls_name == "SlackHook":
+            return SlackHook(
+                name=name, enabled=enabled, events=events,
+                url=self._specific_widgets["url"].text().strip(),
+                message_template=self._specific_widgets["message_template"].text()
+                    or DEFAULT_MESSAGE_TEMPLATE,
             )
         return LoggingHook(name=name, enabled=enabled, events=events)
 

--- a/tests/test_webhook_delivery.py
+++ b/tests/test_webhook_delivery.py
@@ -1,0 +1,191 @@
+"""What actually reaches the other end, and what happens when it is refused.
+
+WebhookHook posted its body and never looked at the reply, so an endpoint that
+rejected it -- Slack answering invalid_payload, an expired URL, a typo in the path --
+failed in complete silence: the hook sat in the configuration looking connected and
+delivered nothing. A rejected request is not an exception, so the try/except around it
+caught nothing.
+
+SlackHook exists for the same reason: Slack refuses an arbitrary JSON body, so
+pointing a plain WebhookHook at a Slack URL could never have worked.
+"""
+
+import logging
+
+import pytest
+
+from fibsem.hooks import (
+    HOOK_TYPES,
+    DEFAULT_MESSAGE_TEMPLATE,
+    HookContext,
+    HookEvent,
+    SlackHook,
+    WebhookHook,
+)
+
+requests = pytest.importorskip("requests")
+
+
+class _Response:
+    def __init__(self, status_code=200, text=""):
+        self.status_code = status_code
+        self.text = text
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+
+@pytest.fixture
+def posted(monkeypatch):
+    """Capture what would have been sent, and control what comes back."""
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json, "timeout": timeout})
+        return calls[-1].get("_response") or _Response()
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    return calls
+
+
+def _context(**kwargs) -> HookContext:
+    fields = dict(
+        event=HookEvent.TASK_FAILED,
+        task_name="MillTrench",
+        item_name="lam-01",
+        error="stage timeout",
+        tasks_remaining=3,
+    )
+    fields.update(kwargs)
+    return HookContext(**fields)
+
+
+# ---------------------------------------------------------------------------
+# the generic webhook
+# ---------------------------------------------------------------------------
+
+def test_a_generic_webhook_still_posts_the_structured_event(posted):
+    hook = WebhookHook(name="w", events=["any_failure"], url="https://example.com/x")
+
+    hook._post(_context())
+
+    body = posted[0]["json"]
+    assert body["event"] == "task_failed"
+    assert body["item_name"] == "lam-01"
+    assert body["error"] == "stage timeout"
+    assert body["tasks_remaining"] == 3
+
+
+def test_a_rejected_post_warns_with_the_reason(monkeypatch, caplog):
+    """The failure that was previously silent. Slack's own reply is one word, and it
+    is the whole diagnosis, so the body has to be in the message."""
+    def fake_request(method, url, json=None, timeout=None):
+        return _Response(400, "invalid_payload")
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    hook = WebhookHook(name="slack-ish", events=["any_failure"], url="https://x/y")
+
+    with caplog.at_level(logging.WARNING):
+        hook._post(_context())
+
+    message = " ".join(r.message for r in caplog.records)
+    assert "slack-ish" in message and "400" in message and "invalid_payload" in message
+
+
+def test_a_long_error_body_is_truncated(monkeypatch, caplog):
+    """An endpoint can answer with an arbitrarily long HTML error page."""
+    def fake_request(method, url, json=None, timeout=None):
+        return _Response(500, "x" * 5000)
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    hook = WebhookHook(name="w", events=["any_failure"], url="https://x/y")
+
+    with caplog.at_level(logging.WARNING):
+        hook._post(_context())
+
+    assert len(caplog.records[0].message) < 400
+
+
+def test_a_successful_post_is_quiet(posted, caplog):
+    hook = WebhookHook(name="w", events=["any_failure"], url="https://x/y")
+
+    with caplog.at_level(logging.WARNING):
+        hook._post(_context())
+
+    assert not caplog.records
+
+
+def test_a_connection_failure_is_still_logged(monkeypatch, caplog):
+    """The exception path must survive the response check being added around it."""
+    def boom(method, url, json=None, timeout=None):
+        raise OSError("no route to host")
+
+    monkeypatch.setattr(requests, "request", boom)
+    hook = WebhookHook(name="w", events=["any_failure"], url="https://x/y")
+
+    with caplog.at_level(logging.ERROR):
+        hook._post(_context())  # must not raise into the workflow
+
+    assert any("no route to host" in r.exc_text for r in caplog.records if r.exc_text)
+
+
+# ---------------------------------------------------------------------------
+# slack
+# ---------------------------------------------------------------------------
+
+def test_slack_posts_the_shape_slack_accepts(posted):
+    """An incoming webhook wants {"text": ...}; the structured event gets a 400."""
+    hook = SlackHook(
+        name="slack",
+        events=["any_failure"],
+        url="https://hooks.slack.com/services/x",
+        message_template="{task_name} failed for {item_name}: {error}",
+    )
+
+    hook._post(_context())
+
+    assert posted[0]["json"] == {"text": "MillTrench failed for lam-01: stage timeout"}
+
+
+def test_slack_inherits_the_webhook_plumbing(posted):
+    hook = SlackHook(name="s", events=["any_failure"], url="https://hooks.slack.com/x")
+
+    hook._post(_context())
+
+    assert posted[0]["method"] == "POST"
+    assert posted[0]["timeout"] == 5
+
+
+def test_slack_validates_its_url_like_any_webhook():
+    hook = SlackHook(name="s", events=["any_failure"], url="ftp://nope")
+
+    with pytest.raises(ValueError):
+        hook.run(_context())
+
+
+def test_slack_round_trips_including_the_message(posted):
+    hook = SlackHook(
+        name="s", events=["any_failure"], url="https://hooks.slack.com/x",
+        message_template="{item_name} broke",
+    )
+
+    restored = SlackHook.from_dict(hook.to_dict())
+
+    assert restored.message_template == "{item_name} broke"
+    assert restored.url == "https://hooks.slack.com/x"
+    assert restored.events == ["any_failure"]
+    assert isinstance(restored, SlackHook)
+
+
+def test_slack_without_a_message_uses_the_default():
+    restored = SlackHook.from_dict(
+        {"name": "s", "events": ["any_failure"], "url": "https://hooks.slack.com/x"}
+    )
+
+    assert restored.message_template == DEFAULT_MESSAGE_TEMPLATE
+
+
+def test_slack_is_a_configurable_type():
+    """In HOOK_TYPES, so it survives a save and appears in the editor's type list."""
+    assert HOOK_TYPES["SlackHook"] is SlackHook

--- a/tests/ui/test_hook_config_groups.py
+++ b/tests/ui/test_hook_config_groups.py
@@ -84,3 +84,32 @@ def test_ticking_a_group_produces_the_group(qapp):
 
     assert result.events == ["any_failure"]
     assert result.url == "https://hooks.example.com/x"
+
+
+# ---------------------------------------------------------------------------
+# a new hook type has to be editable, or it can only be written by hand
+# ---------------------------------------------------------------------------
+
+def test_a_slack_hook_round_trips_through_the_dialog(qapp):
+    from fibsem.hooks import SlackHook
+
+    hook = SlackHook(
+        name="slack", events=["any_failure"],
+        url="https://hooks.slack.com/services/x",
+        message_template="{item_name} broke",
+    )
+
+    result = HookEditDialog(hook=hook).get_hook()
+
+    assert isinstance(result, SlackHook)
+    assert result.url == "https://hooks.slack.com/services/x"
+    assert result.message_template == "{item_name} broke"
+    assert result.events == ["any_failure"]
+
+
+def test_slack_is_offered_when_adding_a_hook(qapp):
+    """A type missing from the editor's list can only be configured by hand."""
+    from fibsem.hooks import HOOK_TYPES
+    from fibsem.ui.widgets.hook_config_widget import _HOOK_CLASSES
+
+    assert set(_HOOK_CLASSES) == set(HOOK_TYPES)


### PR DESCRIPTION
Two things, found by asking how a Slack webhook would actually work and discovering it couldn't.

## A rejected webhook was completely silent

`WebhookHook` posted its body and never looked at the reply. A rejected request is not an exception, so the `try/except` around it caught nothing — an expired URL, a typo in the path, or a body the endpoint refuses failed without a trace. The hook sat in the configuration looking connected and delivered nothing, which is worst in exactly the case webhooks exist for: an unattended run nobody is watching.

It now checks the status and warns, including the response body — truncated, because an error page can be arbitrarily long, but included because the reason lives there. Slack's is one diagnostic word.

## Pointing a WebhookHook at Slack could never have worked

Slack incoming webhooks want `{"text": ...}` or a blocks array, not the structured event, and answer `400 invalid_payload` to anything else. So `_payload()` is extracted from `_post()`, and a service that dictates its own body becomes a subclass:

```python
@dataclass
class SlackHook(WebhookHook):
    message_template: str = DEFAULT_MESSAGE_TEMPLATE

    def _payload(self, context: HookContext) -> dict:
        return {"text": render_template(self.message_template, context)}
```

It inherits URL validation, the daemon thread, the timeout and the new rejection warning. Discord is the same shape with `content` instead of `text`.

Registered in `HOOK_TYPES` so it survives a save, and in the editor with the two fields a user actually sets — an incoming webhook is always POST and the default timeout is fine. A type missing from the editor could only be configured by hand, so a test pins that the two lists agree.

**The URL host is deliberately not validated.** Mattermost and Rocket.Chat accept the same payload on their own hosts, and a self-hosted instance is plausible in an institutional setting — restricting it would break a legitimate use to catch a typo, which the rejection warning now catches properly instead.

## Verified against a real workspace

Not just mocked. Fired through `HookManager` at a live Slack incoming webhook:

- the message delivered, rendering mrkdwn from the template
- a `task_completed` event correctly did **not** reach a hook subscribed to `any_failure`
- a URL with four characters changed reported `HTTP 403 invalid_token` instead of nothing

## Testing

`tests/test_webhook_delivery.py` — 11 tests: the generic payload unchanged, a rejection warning carrying status and reason, body truncation, silence on success, the exception path surviving the new check, Slack's payload shape, inherited plumbing and URL validation, and the round trip including `message_template`.

Plus 2 dialog tests. 2538 tests pass.
