### PR TITLE
[ui] Paint the timeline's selected row instead of styling it

### DIFF
--- a/fibsem/ui/widgets/workflow_timeline_widget.py
+++ b/fibsem/ui/widgets/workflow_timeline_widget.py
@@ -39,7 +39,18 @@ _SKIP_REASON_LABELS = {
     "failure": "Marked as failure",
     "missing_prereqs": "Prerequisites not met",
 }
-_SELECTED_BG    = "#2d3f5c"
+# Selection marks the row you are acting on; it drives nothing else, so it stays
+# quiet. Painted rather than set as a stylesheet: a stylesheet set on the row
+# cascades to its child labels, which do not span the row, so the fill came out
+# as disconnected bands with a gap between label and subtitle.
+#
+# PRIMARY_COLOR is what selection means across the app — the lamella cards mark
+# themselves with a 2px border in it, so the timeline agrees rather than
+# inventing a second selection blue.
+_SELECTED_BG    = QColor(stylesheets.PRIMARY_COLOR)
+_SELECTED_BG.setAlpha(30)
+_SELECTED_BAR   = QColor(stylesheets.PRIMARY_COLOR)
+_SELECTED_BAR_W = 2
 _LABEL_COLOR    = stylesheets.GRAY_TEXT_COLOR
 _SUBTITLE_COLOR = stylesheets.GRAY_SECONDARY_COLOR
 
@@ -330,7 +341,18 @@ class _OuterRow(QWidget):
         if selected == self._selected:
             return
         self._selected = selected
-        self.setStyleSheet(f"background: {_SELECTED_BG if selected else 'transparent'};")
+        self.update()
+
+    def paintEvent(self, event):
+        if not self._selected:
+            return
+        p = QPainter(self)
+        p.setPen(Qt.NoPen)
+        # One contiguous rect across the whole row, including the inner steps when
+        # the active row is the selected one — they belong to it.
+        p.fillRect(self.rect(), _SELECTED_BG)
+        if _SELECTED_BAR_W:
+            p.fillRect(0, 0, _SELECTED_BAR_W, self.height(), _SELECTED_BAR)
 
     # ── Inner step management ─────────────────────────────────────────────
     def set_inner_visible(self, visible: bool) -> None:


### PR DESCRIPTION
Follow-up to #284, from looking at the selected row in the app.

## The bug

`set_selected` did `setStyleSheet("background: …")` on the row. A stylesheet set on a widget cascades to its children — so the blue landed on the child *labels*, not on the row. The labels don't span the row width, so it rendered as two disconnected bands with a gap between title and subtitle, plus an offset block in the dot column. The row itself was never painted at all.

## The fix

Painted in `paintEvent`: one contiguous rect over the real row rect, dot column and inner steps included, no cascade. Also cheaper than a stylesheet recalc, which matters a little because every row is refreshed on every queue update.

## Colour

A 2px left bar plus a 12% tint in `stylesheets.PRIMARY_COLOR`.

The lamella list and workflow list in that tab turn out not to have a selection highlight at all — their selection is the checkbox and their rows are flat `#1e2124`. The one sibling with a visual selected state is the lamella card container, which keeps its background and draws a 2px `#007ACC` border. So rather than matching a tint that doesn't exist, this matches the colour that already *means* selected in the app. A full border reads fine on a card and noisy on a dense list row, so the treatment differs while the colour agrees.

Deliberately quiet: `step_selected` is connected to nothing, so the highlight only marks the row you clicked or right-clicked.

Full suite: 2542 passed. Checked by rendering the widget offscreen with the active row and a pending row selected.

## Worth a sweep later

The underlying trap isn't unique to this widget: anywhere the app highlights a composite row by setting a background stylesheet on the container will band the same way. Not investigated here.
