### PR TITLE
[autolamella] Load hooks from user preferences (FIB-497)

### DIFF
--- a/fibsem/applications/autolamella/hook_defaults.py
+++ b/fibsem/applications/autolamella/hook_defaults.py
@@ -10,9 +10,10 @@ be something you can round-trip through YAML and diff. They were previously four
 by reading the source.
 """
 
-from typing import List
+import logging
+from typing import List, Optional
 
-from fibsem.hooks import Hook, HookEvent, LoggingHook, NotificationHook
+from fibsem.hooks import Hook, HookEvent, HookManager, LoggingHook, NotificationHook
 
 
 def default_hooks() -> List[Hook]:
@@ -62,3 +63,41 @@ def default_hooks() -> List[Hook]:
             message_template="Task {task_name} cancelled for {item_name}",
         ),
     ]
+
+
+def build_hook_manager(configured: Optional[List[dict]]) -> HookManager:
+    """Build the manager for a run from a user's saved hooks, or from the defaults.
+
+    ``configured`` is ``UserPreferences.hooks``. The three states are distinct:
+
+    * ``None`` -- never configured. Use the defaults, and note they are *not* written
+      to disk on first run: materialising them would freeze every user who never opens
+      the dialog on this version's defaults forever, so improving them later would
+      reach nobody.
+    * a list -- **replaces** the defaults rather than merging with them. Someone who
+      deleted the failure toast must get no failure toast; merging would put it back.
+    * ``[]`` -- everything turned off. A real answer, not an empty file.
+
+    A configuration that cannot be read falls back to the defaults with a warning
+    rather than raising: a bad hooks section must not stop the application starting,
+    and running with no notifications at all is worse than running with the standard
+    ones. The whole section falls back rather than the offending entry, so the warning
+    describes something a user can actually find and fix.
+    """
+    if configured is None:
+        manager = HookManager()
+        for hook in default_hooks():
+            manager.register(hook)
+        return manager
+
+    try:
+        return HookManager.from_dict({"hooks": configured})
+    except Exception:
+        logging.exception(
+            "Could not build hooks from your saved configuration; falling back to the "
+            "defaults. Fix or remove the 'hooks' section of user-preferences.yaml."
+        )
+        manager = HookManager()
+        for hook in default_hooks():
+            manager.register(hook)
+        return manager

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -85,7 +85,8 @@ from fibsem.applications.autolamella.structures import (
 # Paired with the disabled completion_summary hook in setup_hooks; FunctionHook and
 # HookEvent come back from fibsem.hooks below at the same time.
 # from fibsem.applications.autolamella.tools.artifacts import write_completion_summary
-from fibsem.applications.autolamella.hook_defaults import default_hooks
+import fibsem.config as fibsem_cfg
+from fibsem.applications.autolamella.hook_defaults import build_hook_manager
 from fibsem.hooks import HookManager
 from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
 from fibsem.ui.widgets.workflow_summary_dialog import WorkflowSummaryDialog
@@ -1099,14 +1100,16 @@ class AutoLamellaUI(QMainWindow):
         effect on the next run without a restart, and means the config dialog can never
         be editing a manager a running workflow is holding. See FIB-497.
 
-        The defaults live in hook_defaults.default_hooks() rather than here, so they can
-        be serialized and diffed without a QApplication. Code-registered hooks go after
-        them: a configuration load must never be able to remove a hook that only exists
-        in Python.
+        The hook set comes from the user's saved configuration when there is one, and
+        from hook_defaults.default_hooks() when there is not. Re-read here rather than
+        cached at startup, so editing user-preferences.yaml by hand takes effect on the
+        next run of a workflow instead of needing a restart.
+
+        Code-registered hooks go after: a configuration load replaces the *defaults*,
+        and must never be able to remove a hook that only exists in Python.
         """
-        manager = HookManager()
-        for hook in default_hooks():
-            manager.register(hook)
+        preferences = fibsem_cfg.load_user_preferences()
+        manager = build_hook_manager(preferences.hooks)
 
         # Deliberately not registered yet. The trigger is proven end to end and the
         # writer is tested, but completion-summary.json is a placeholder for the real

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -348,6 +348,17 @@ class UserPreferences:
     movement: MovementPreferences = field(default_factory=MovementPreferences)
     experiment: ExperimentPreferences = field(default_factory=ExperimentPreferences)
     reporting: ReportingPreferences = field(default_factory=ReportingPreferences)
+    # Serialized hooks, as HookManager.to_dict()["hooks"] produces them. Held as plain
+    # dicts rather than Hook objects on purpose: to_dict() below is dataclasses.asdict,
+    # which would recurse into a Hook, strip the "type" key that reconstructs it, and
+    # then hit NotificationHook._notify -- a callable, which yaml.safe_dump refuses.
+    # Keeping them opaque also keeps this module free of any hook imports.
+    #
+    # None and [] are different, and the difference is the whole feature: None means
+    # never configured, so the application uses its defaults, while [] means the user
+    # turned everything off. Conflating them either resurrects hooks someone deleted or
+    # silences a fresh install. See FIB-497.
+    hooks: Optional[List[dict]] = None
 
     def to_dict(self) -> dict:
         return dataclasses.asdict(self)
@@ -355,13 +366,16 @@ class UserPreferences:
     @classmethod
     def from_dict(cls, d: dict) -> "UserPreferences":
         """Reconstruct from a dict, handling both nested and legacy flat formats."""
-        if any(k in d for k in ("display", "features", "movement", "experiment", "reporting")):
+        if any(k in d for k in ("display", "features", "movement", "experiment",
+                                "reporting", "hooks")):
             return cls(
                 display=_sub_from_dict(DisplayPreferences, d.get("display", {})),
                 features=_sub_from_dict(FeatureFlags, d.get("features", {})),
                 movement=_sub_from_dict(MovementPreferences, d.get("movement", {})),
                 experiment=_sub_from_dict(ExperimentPreferences, d.get("experiment", {})),
                 reporting=_sub_from_dict(ReportingPreferences, d.get("reporting", {})),
+                # .get() rather than a default, so an absent key stays None
+                hooks=d.get("hooks"),
             )
         # Legacy flat format
         prefs = cls()

--- a/fibsem/hooks.py
+++ b/fibsem/hooks.py
@@ -355,6 +355,33 @@ _WEBHOOK_ALLOWED_METHODS = {"POST", "GET"}
 _WEBHOOK_ALLOWED_SCHEMES = {"http", "https"}
 
 
+def _safe_url(url: str) -> str:
+    """The part of a webhook URL that is safe to write down: scheme and host.
+
+    For a Slack incoming webhook the path *is* the credential -- there is no separate
+    token -- so the host is as much as a log or an error message may carry.
+    """
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    if not parsed.netloc:
+        return "<invalid url>"
+    return f"{parsed.scheme}://{parsed.netloc}/<redacted>"
+
+
+def _redact_url(text: str, url: str) -> str:
+    """Strip a webhook URL, and its bare path, out of ``text``.
+
+    requests reports the path on its own -- "Max retries exceeded with url:
+    /services/T.../B.../TOKEN" -- so replacing the whole URL is not enough.
+    """
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    for secret in (url, parsed.path):
+        if secret and len(secret) > 1:
+            text = text.replace(secret, "/<redacted>")
+    return text
+
+
 def _validate_webhook_url(url: str) -> str:
     """Raise ValueError if url is empty or uses a disallowed scheme."""
     if not url:
@@ -382,6 +409,18 @@ class WebhookHook(Hook):
                 f"WebhookHook: method '{self.method}' is not allowed (must be one of {sorted(_WEBHOOK_ALLOWED_METHODS)})"
             )
         self.method = self.method.upper()
+        # Warned rather than refused. http is a real choice for a service on the lab's
+        # own network -- a self-hosted Mattermost, an internal automation endpoint --
+        # and there would be no way around a hard block. But for a hosted service the
+        # URL usually *is* the credential, and over http it crosses the network in
+        # clear text along with the experiment and item names, so it should be a
+        # decision someone made rather than a default they inherited.
+        if self.url.lower().startswith("http://"):
+            logging.warning(
+                f"{type(self).__name__} '{self.name}' posts over http, so its URL and "
+                f"payload cross the network unencrypted. Use https unless this is a "
+                f"service on your own network."
+            )
 
     def run(self, context: HookContext) -> None:
         _validate_webhook_url(self.url)
@@ -429,8 +468,19 @@ class WebhookHook(Hook):
                     f"{type(self).__name__} '{self.name}' was rejected: "
                     f"HTTP {response.status_code} {response.text[:200]}"
                 )
-        except Exception:
-            logging.exception(f"{type(self).__name__} '{self.name}' failed")
+        except Exception as exc:
+            # Deliberately not logging.exception. requests puts the full URL in its
+            # message -- and the bare path separately -- and for an incoming webhook
+            # that path *is* the credential. Logfiles are the first thing a user sends
+            # when something goes wrong, so a DNS blip must not put a working Slack
+            # credential into a file that then gets emailed around. The exception type
+            # and a redacted message are the diagnosis; the traceback added nothing but
+            # frame locations here.
+            logging.error(
+                f"{type(self).__name__} '{self.name}' failed posting to "
+                f"{_safe_url(self.url)}: {type(exc).__name__}: "
+                f"{_redact_url(str(exc), self.url)}"
+            )
 
     def to_dict(self) -> dict:
         return {**super().to_dict(), "url": self.url, "method": self.method, "timeout": self.timeout}

--- a/tests/autolamella/test_hook_config_loading.py
+++ b/tests/autolamella/test_hook_config_loading.py
@@ -1,0 +1,196 @@
+"""Hooks come from the user's saved configuration, or from the defaults.
+
+The step that makes hooks configurable without editing Python — the whole claim the
+hook layer has over a plain signal connection. See FIB-497.
+
+The three states of the `hooks` key are distinct and the distinction is the feature:
+absent means never configured, a list replaces the defaults, and [] means the user
+turned everything off.
+"""
+
+import logging
+
+import pytest
+import yaml
+
+from fibsem import config as fcfg
+from fibsem.applications.autolamella.hook_defaults import (
+    build_hook_manager,
+    default_hooks,
+)
+from fibsem.hooks import (
+    FunctionHook,
+    HookContext,
+    HookEvent,
+    HookManager,
+    NotificationHook,
+    SlackHook,
+)
+
+
+def _names(manager: HookManager):
+    return [hook.name for hook in manager._hooks]
+
+
+# ---------------------------------------------------------------------------
+# the three states
+# ---------------------------------------------------------------------------
+
+def test_never_configured_uses_the_defaults():
+    manager = build_hook_manager(None)
+
+    assert _names(manager) == [hook.name for hook in default_hooks()]
+
+
+def test_a_saved_configuration_replaces_the_defaults():
+    """Not merged. Someone who deleted the failure toast must get no failure toast."""
+    saved = [{
+        "type": "SlackHook", "name": "slack", "events": ["any_failure"],
+        "enabled": True, "task_types": [], "url": "https://hooks.slack.com/x",
+    }]
+
+    manager = build_hook_manager(saved)
+
+    assert _names(manager) == ["slack"]
+    assert "failure_toast" not in _names(manager)
+
+
+def test_an_empty_list_means_no_hooks_at_all():
+    """[] is an answer -- everything turned off -- not an empty file."""
+    manager = build_hook_manager([])
+
+    assert manager._hooks == []
+
+
+def test_empty_and_absent_are_not_the_same_thing():
+    """Conflating them either resurrects hooks a user deleted or silences a fresh
+    install. This is why the field is Optional rather than a plain list."""
+    assert build_hook_manager([])._hooks == []
+    assert build_hook_manager(None)._hooks != []
+
+
+# ---------------------------------------------------------------------------
+# what survives a round trip
+# ---------------------------------------------------------------------------
+
+def test_the_defaults_round_trip_through_the_preferences_field():
+    """Save the defaults, reload them, get the defaults."""
+    manager = build_hook_manager(None)
+
+    restored = build_hook_manager(manager.to_dict()["hooks"])
+
+    assert _names(restored) == _names(manager)
+
+
+def test_a_group_subscription_survives_the_file():
+    """Stored as the group name, so it keeps covering events added later."""
+    saved = build_hook_manager([{
+        "type": "SlackHook", "name": "slack", "events": ["any_failure"],
+        "url": "https://hooks.slack.com/x",
+    }]).to_dict()["hooks"]
+
+    assert saved[0]["events"] == ["any_failure"]
+    assert isinstance(build_hook_manager(saved)._hooks[0], SlackHook)
+
+
+def test_the_whole_thing_survives_yaml():
+    """yaml.safe_dump refuses callables and arbitrary objects, so this is not
+    hypothetical -- NotificationHook holds a _notify callable at runtime."""
+    manager = build_hook_manager(None)
+    manager.set_notifier(lambda message, kind: None)
+
+    written = yaml.safe_dump({"hooks": manager.to_dict()["hooks"]})
+    reloaded = build_hook_manager(yaml.safe_load(written)["hooks"])
+
+    assert _names(reloaded) == _names(manager)
+
+
+# ---------------------------------------------------------------------------
+# a configuration that is wrong
+# ---------------------------------------------------------------------------
+
+def test_an_unknown_hook_type_is_skipped_not_fatal():
+    saved = [
+        {"type": "SomeFutureHook", "name": "future", "events": ["any_failure"]},
+        {"type": "LoggingHook", "name": "keep", "events": ["any_failure"]},
+    ]
+
+    manager = build_hook_manager(saved)
+
+    assert _names(manager) == ["keep"]
+
+
+def test_a_broken_configuration_falls_back_to_the_defaults(caplog):
+    """A bad hooks section must not stop the application starting, and running with no
+    notifications is worse than running with the standard ones."""
+    with caplog.at_level(logging.ERROR):
+        manager = build_hook_manager(["not a hook dict"])
+
+    assert _names(manager) == [hook.name for hook in default_hooks()]
+    assert any("user-preferences" in r.message for r in caplog.records)
+
+
+def test_a_configured_hook_actually_fires():
+    """Through the manager, not just constructed."""
+    manager = build_hook_manager([{
+        "type": "NotificationHook", "name": "mine", "events": ["any_failure"],
+        "notification_type": "error", "message_template": "{item_name} broke",
+    }])
+    delivered = []
+    manager.set_notifier(lambda message, kind: delivered.append((message, kind)))
+
+    manager.fire(HookContext(event=HookEvent.TASK_FAILED, item_name="lam-01"))
+    manager.fire(HookContext(event=HookEvent.TASK_COMPLETED, item_name="lam-01"))
+
+    assert delivered == [("lam-01 broke", "error")]
+
+
+# ---------------------------------------------------------------------------
+# the preferences field itself
+# ---------------------------------------------------------------------------
+
+def test_an_absent_hooks_key_loads_as_none():
+    prefs = fcfg.UserPreferences.from_dict({"display": {}})
+
+    assert prefs.hooks is None
+
+
+def test_an_empty_hooks_key_loads_as_empty_not_none():
+    prefs = fcfg.UserPreferences.from_dict({"display": {}, "hooks": []})
+
+    assert prefs.hooks == []
+
+
+def test_a_file_containing_only_hooks_is_not_mistaken_for_the_legacy_format():
+    """The nested-format check is by key; without "hooks" in that list a file with no
+    other section would fall through to the flat legacy branch and lose them."""
+    prefs = fcfg.UserPreferences.from_dict(
+        {"hooks": [{"type": "LoggingHook", "name": "only", "events": ["any_failure"]}]}
+    )
+
+    assert prefs.hooks is not None
+    assert prefs.hooks[0]["name"] == "only"
+
+
+def test_preferences_round_trip_keeps_hooks(tmp_path, monkeypatch):
+    """Through the real save/load pair, including the yaml on disk."""
+    monkeypatch.setattr(fcfg, "CONFIG_PATH", str(tmp_path))
+    monkeypatch.setattr(fcfg, "USER_PREFERENCES_PATH", str(tmp_path / "prefs.yaml"))
+
+    prefs = fcfg.UserPreferences()
+    prefs.hooks = build_hook_manager(None).to_dict()["hooks"]
+    fcfg.save_user_preferences(prefs)
+
+    reloaded = fcfg.load_user_preferences()
+
+    assert [h["name"] for h in reloaded.hooks] == [h.name for h in default_hooks()]
+
+
+def test_a_function_hook_is_not_written_to_the_file():
+    """FunctionHooks are code-only. to_dict drops them, which is what keeps a callable
+    out of the yaml -- and means a config load can never remove one."""
+    manager = build_hook_manager(None)
+    manager.register(FunctionHook(name="code_only", events=["any_completion"]))
+
+    assert "code_only" not in [h["name"] for h in manager.to_dict()["hooks"]]
+    assert "code_only" in _names(manager)

--- a/tests/test_webhook_delivery.py
+++ b/tests/test_webhook_delivery.py
@@ -127,7 +127,98 @@ def test_a_connection_failure_is_still_logged(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         hook._post(_context())  # must not raise into the workflow
 
-    assert any("no route to host" in r.exc_text for r in caplog.records if r.exc_text)
+    message = " ".join(r.message for r in caplog.records)
+    assert "no route to host" in message and "OSError" in message
+
+
+# ---------------------------------------------------------------------------
+# the url is a credential
+# ---------------------------------------------------------------------------
+
+# Shaped like a real Slack incoming webhook, sharing nothing with one. The ids follow
+# Slack's own documentation placeholders; the token is a canary the assertions below
+# search for, so it must not be a string that could turn up by coincidence.
+FAKE_TOKEN = "NOTAREALTOKEN00000000000"
+SECRET_URL = f"https://hooks.slack.com/services/T00000000/B00000000/{FAKE_TOKEN}"
+
+
+def test_a_failure_does_not_write_the_url_into_the_log(monkeypatch, caplog):
+    """For an incoming webhook the path *is* the credential, and logfiles are the first
+    thing a user sends when something goes wrong. requests puts the full URL in its
+    exception message, so logging.exception here leaked a working Slack credential on
+    every DNS blip."""
+    def boom(method, url, json=None, timeout=None):
+        raise ConnectionError(
+            f"HTTPSConnectionPool(host='hooks.slack.com', port=443): Max retries "
+            f"exceeded with url: /services/T00000000/B00000000/{FAKE_TOKEN}"
+        )
+
+    monkeypatch.setattr(requests, "request", boom)
+    hook = SlackHook(name="slack", events=["any_failure"], url=SECRET_URL)
+
+    with caplog.at_level(logging.DEBUG):
+        hook._post(_context())
+
+    logged = " ".join(
+        (r.message or "") + (r.exc_text or "") for r in caplog.records
+    )
+    assert FAKE_TOKEN not in logged
+    assert "B00000000" not in logged
+
+
+def test_the_host_is_still_named_so_the_failure_is_diagnosable(monkeypatch, caplog):
+    """Redaction must not make the log useless -- the host and the error type are what
+    tell someone whether it is DNS, the network, or the wrong service."""
+    def boom(method, url, json=None, timeout=None):
+        raise OSError("Failed to resolve 'hooks.slack.com'")
+
+    monkeypatch.setattr(requests, "request", boom)
+    hook = SlackHook(name="slack", events=["any_failure"], url=SECRET_URL)
+
+    with caplog.at_level(logging.ERROR):
+        hook._post(_context())
+
+    message = caplog.records[0].message
+    assert "hooks.slack.com" in message
+    assert "OSError" in message
+    assert "slack" in message  # which hook
+
+
+def test_redaction_catches_the_bare_path_too():
+    """requests reports the path on its own, not only the whole URL."""
+    from fibsem.hooks import _redact_url
+
+    text = f"Max retries exceeded with url: /services/T00000000/B00000000/{FAKE_TOKEN}"
+
+    assert FAKE_TOKEN not in _redact_url(text, SECRET_URL)
+
+
+# ---------------------------------------------------------------------------
+# http
+# ---------------------------------------------------------------------------
+
+def test_posting_over_http_warns(caplog):
+    """The URL is usually the credential, and over http it crosses the network in the
+    clear along with the payload."""
+    with caplog.at_level(logging.WARNING):
+        WebhookHook(name="plain", events=["any_failure"], url="http://lab-server/hook")
+
+    assert any("http" in r.message and "https" in r.message for r in caplog.records)
+
+
+def test_https_is_quiet(caplog):
+    with caplog.at_level(logging.WARNING):
+        WebhookHook(name="secure", events=["any_failure"], url="https://x/y")
+
+    assert not caplog.records
+
+
+def test_http_is_warned_about_not_refused():
+    """A self-hosted service on the lab's own network is a real case, and a hard block
+    would leave no way around it."""
+    hook = WebhookHook(name="plain", events=["any_failure"], url="http://lab-server/x")
+
+    assert hook.url == "http://lab-server/x"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The step that makes hooks configurable without editing Python — which is the only thing the hook layer does that a plain `connect()` cannot, and therefore what the Task Lifecycle Hooks project's exit criterion turns on. `save_yaml` / `load_yaml` had existed with zero callers since v0.5.1.

## Nothing changes for anyone who ignores it

A user who never touches the file gets exactly the same four hooks as before, byte for byte the same code path. The only visible difference is that once anything triggers a preferences save, the file gains a `hooks: null` line — behaviour identical, since `null` reloads as "never configured". Say if you'd rather that key were omitted when unset; it's a small change to `to_dict`.

## A `hooks` section, not a new file

It reuses the existing fail-soft load and unknown-key tolerance, it has a Preferences dialog already, and it inherits whatever FIB-336 decides about where user state lives rather than adding a second thing to move.

```yaml
hooks:
- type: SlackHook
  name: slack
  events: [any_terminal]
  enabled: true
  url: https://hooks.slack.com/services/...
  message_template: ':gear: *{task_name}* → {event} for *{item_name}*'
```

**Held as plain dicts, not `Hook` objects** — and not just for tidiness. `UserPreferences.to_dict` is `dataclasses.asdict`, which would recurse into a `Hook`, strip the `type` key that reconstructs it, and then reach `NotificationHook._notify` — a callable, which `yaml.safe_dump` refuses outright. Keeping them opaque also keeps `config.py` free of any hook imports. There's a test that dumps a manager *with a notifier attached* through real YAML and reloads it.

## The three states

| `hooks` | means | behaviour |
|---|---|---|
| absent | never configured | use the defaults |
| a list | configured | **replace** the defaults |
| `[]` | turned everything off | no hooks |

Absent-vs-empty is why the field is `Optional[List[dict]]` rather than a plain list. Conflating them either resurrects hooks a user deleted or silences a fresh install.

A present list **replaces** rather than merges, because someone who deleted the failure toast must get no failure toast — merging would put it back.

And the defaults are deliberately **not** materialised on first run. Writing them out would freeze every user who never opens the dialog on this version's defaults forever, so improving them later would reach nobody.

## Two ordering properties

`setup_hooks()` re-reads preferences **per run** rather than caching at startup, so editing the file by hand takes effect on the next workflow instead of needing a restart — and the config dialog can never be editing a manager a running workflow holds.

Code-registered hooks are registered **after** the configured ones. A config load replaces the defaults; it must never be able to remove a hook that exists only in Python, which is the category the (currently disabled) `completion_summary` `FunctionHook` belongs to.

## When the file is wrong

A configuration that cannot be read falls back to the defaults with a warning naming the file, rather than raising. A bad `hooks` section must not stop the application starting, and running with no notifications at all is worse than running with the standard ones. An unknown hook type was already skipped rather than fatal, so a file written by a newer version still loads.

## Verified in the running application

Not only in tests. A hand-written `hooks` section with a `SlackHook` subscribed to `any_terminal` was loaded by the real app against a live Slack workspace: it posted on each finished task, and the two default toasts it replaced were correctly absent.

## Testing

`tests/autolamella/test_hook_config_loading.py` — 15 tests: the three states and that empty is not absent, round trips through the preferences field and through YAML with a notifier attached, a group subscription surviving the file, an unknown type skipped, a broken section falling back with a warning, a configured hook actually firing, `FunctionHook`s staying out of the file, and that a file containing only `hooks` is not mistaken for the legacy flat format.

2570 tests pass.

## Next

The two editors from the agreed design — a plain-language notifications page for level 1, and the destination dialog for level 2. This PR is what they will read and write.

---

## Also: a webhook URL was leaking into the logfile

Found by asking what the security exposure of this feature is, and confirmed against a real URL before fixing.

For a Slack incoming webhook the URL path **is** the credential — there is no separate token. `_post` caught failures with `logging.exception`, and `requests` puts the full URL in its exception message:

```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='hooks.slack.com', …):
Max retries exceeded with url: /services/T00000000/B00000000/NOTAREALTOKEN…
```

Logfiles are the first thing a user sends when something goes wrong, so a DNS blip was enough to put a working credential into a file that then gets emailed around. This matters more once hooks are configurable, because that is when anyone actually has one.

Now:

```
ERROR SlackHook 'slack' failed posting to https://hooks.slack.com/<redacted>:
ConnectionError: HTTPSConnectionPool(host='hooks.slack.com', port=443): Max retries
exceeded with url: /<redacted> (Caused by NameResolutionError(…))
```

The host stays visible deliberately — redaction must not make the log useless, and the host plus the error type are what tell someone whether it is DNS, the network, or the wrong service. Redaction strips the bare path as well as the whole URL, because requests reports the path on its own.

**And http now warns.** Not refused: a service on the lab's own network is a real case and a hard block would leave no way around it. But over http that credential-bearing URL crosses the network in clear text along with the experiment and item names, so it should be a decision rather than an inherited default. Say if you'd rather it were https-only — it is one entry in `_WEBHOOK_ALLOWED_SCHEMES`.

6 more tests, including the exact leak reproduction. 2576 pass.
