### PR TITLE
[autolamella] Stop the running task without ending the workflow (FIB-499)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1702,6 +1702,34 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             return
         label = f"{item.task_name} for {item.lamella_name}"
 
+        if action == "stop_task":
+            # Confirmed, unlike Remove: that edits a list, this interrupts an
+            # operation already under way on the sample.
+            # Built rather than QMessageBox.question(...): the difference from Stop
+            # is the point of asking at all, and everything in the text slot renders
+            # at question weight. The explanation belongs in the informative slot.
+            box = QMessageBox(self)
+            box.setIcon(QMessageBox.Question)
+            box.setWindowTitle("Stop Task")
+            box.setText(f"Stop <b>{label}</b>?")
+            box.setInformativeText(
+                "It will be marked cancelled and the workflow will carry on with "
+                "the next queued task. Use Stop to end the whole run instead."
+            )
+            box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+            box.setDefaultButton(QMessageBox.No)
+            if box.exec_() != QMessageBox.Yes:
+                return
+            # Two halves, as Stop Workflow has: tell the queue this task is being
+            # abandoned, and bring the hardware to a halt. Without the second, the
+            # task stops waiting for the mill but the mill keeps going.
+            manager.stop_task()
+            self.autolamella_ui.stop_current_operations()
+            # No queue mutation here: the task unwinds on the worker thread and the
+            # status it emits on the way out is what updates the timeline.
+            self._show_queue_message(f"Stopping {label}...")
+            return
+
         if action == "run_again":
             # A fresh item rather than a rewind: the original attempt still
             # happened and stays in the run record.

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1846,15 +1846,28 @@ class AutoLamellaUI(QMainWindow):
         if self.det_widget is not None:
             self.det_widget.confirm_button_clicked()
 
+    def stop_current_operations(self) -> None:
+        """Interrupt whatever the microscope is doing right now.
+
+        Shared by Stop Workflow and Stop Task, which have to bring the hardware to
+        a halt identically and differ only in what the queue does afterwards.
+
+        A task raising is not enough on its own: milling runs on its own thread
+        with its own stop event, owned by the milling widget, and the task merely
+        waits for it. Unwinding the task without this stops the waiting, not the
+        mill.
+        """
+        if self.milling_task_config_widget is not None:
+            self.milling_task_config_widget.milling_widget.stop_milling()
+        if self.spot_burn_widget is not None:
+            self.spot_burn_widget.cancel_spot_burn()
+
     def _stop_workflow_thread(self):
         if self._task_manager is not None:
             self._task_manager.stop()
         else:
             self._workflow_stop_event.set()
-        if self.milling_task_config_widget is not None:
-            self.milling_task_config_widget.milling_widget.stop_milling()
-        if self.spot_burn_widget is not None:
-            self.spot_burn_widget.cancel_spot_burn()
+        self.stop_current_operations()
 
     def _workflow_finished(self):
         """Handle the completion of the workflow."""

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -111,7 +111,9 @@ class AutoLamellaTask(ABC):
         self.parent_ui = parent_ui
         self.task_manager = task_manager
         self.task_id = str(uuid.uuid4())
-        self._stop_event = task_manager._stop_event if task_manager else None
+        # The manager's token, not its raw event: what counts as "cancelled" is
+        # the manager's to decide, and a task should not have to know.
+        self._stop_event = task_manager.abort_token if task_manager else None
         self._last_fib_image: Optional[FibsemImage] = None
 
     @property
@@ -179,10 +181,14 @@ class AutoLamellaTask(ABC):
     def _is_cancellation(self, exc: Exception) -> bool:
         """Whether ``exc`` is a user Stop rather than a genuine failure: it surfaces as
         OperationCancelledError (milling / autofocus) or InterruptedError (_check_for_abort),
-        or the task manager's stop event is set."""
+        or the task manager says this task should be unwinding.
+
+        should_abort, not is_stopped: abandoning one task is as much a cancellation
+        as ending the run, and an exception thrown on the way out of one should not
+        be recorded as a failure."""
         if isinstance(exc, (OperationCancelledError, InterruptedError)):
             return True
-        return bool(getattr(getattr(self, "task_manager", None), "is_stopped", False))
+        return bool(getattr(getattr(self, "task_manager", None), "should_abort", False))
 
     def _fire_hook(self, event: str, error: Optional[str] = None) -> None:
         from fibsem.hooks import fire_event
@@ -288,7 +294,12 @@ class AutoLamellaTask(ABC):
                          workflow_info=workflow_info)
 
     def _check_for_abort(self) -> None:
-        """Check if the workflow has been aborted from the UI, and raise an InterruptedError if so."""
+        """Raise InterruptedError if this task should stop.
+
+        Polls the manager's token, which already answers for every kind of stop —
+        so this needs no second way to ask, and neither do the inline token checks
+        in the fluorescence, coincidence-milling and grid tasks.
+        """
         if self._stop_event is not None and self._stop_event.is_set():
             raise InterruptedError("Workflow aborted by user.")
 

--- a/fibsem/applications/autolamella/workflows/tasks/grid_tasks.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid_tasks.py
@@ -47,7 +47,9 @@ class GridTask(ABC):
         self.parent_ui = parent_ui
         self.task_manager = task_manager
         self.task_id = str(uuid.uuid4())
-        self._stop_event = task_manager._stop_event if task_manager else None
+        # The manager's token, as AutoLamellaTask takes: GridTask is a parallel
+        # hierarchy, so it has to be kept in step by hand.
+        self._stop_event = task_manager.abort_token if task_manager else None
 
     @property
     def slot(self) -> Optional[GridSlot]:

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -11,7 +11,7 @@ from fibsem.constants import DATETIME_DISPLAY_AMPM
 import pandas as pd
 
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
-from fibsem.cancellation import OperationCancelledError
+from fibsem.cancellation import AnyStopEvent, OperationCancelledError
 from fibsem.hooks import HookEvent, HookManager, fire_event
 from fibsem.applications.autolamella.workflows.tasks.queue import TaskQueue, WorkItem
 from fibsem.applications.autolamella.workflows.ui import update_status_ui
@@ -60,6 +60,13 @@ class TaskManager:
         self.parent_ui = parent_ui
         self.hook_manager = hook_manager
         self._stop_event = threading.Event()
+        # Stopping one task is a different intent from stopping the run, so it is a
+        # different event. A flag on a single event would need care not to be
+        # downgraded when a run-wide Stop arrives mid-unwind; with two, there is no
+        # path by which cancelling a task can set is_stopped.
+        self._task_stop_event = threading.Event()
+        # Built once: the token's identity is captured by every task at construction.
+        self._abort_token = AnyStopEvent(self._stop_event, self._task_stop_event)
         self.queue = TaskQueue()
 
         # Stamp the experiment onto the images this run acquires. Done here rather
@@ -95,6 +102,10 @@ class TaskManager:
             item = self.queue.next()
             if item is None:
                 break
+
+            # A stop_task click that landed between two tasks was aimed at the one
+            # that has just finished, not at this one.
+            self._task_stop_event.clear()
 
             lamella = self.experiment.get_lamella_by_name(item.lamella_name)
             if lamella is None:
@@ -215,9 +226,50 @@ class TaskManager:
         """Signal the manager to stop after current task completes."""
         self._stop_event.set()
 
+    def stop_task(self) -> None:
+        """Abandon the task now running and carry on with the rest of the queue.
+
+        The task unwinds through the same path a run-wide Stop uses, so it ends
+        Cancelled and whatever it was doing to the hardware is undone the same
+        way. Only the loop's reaction differs: is_stopped is untouched, so
+        _run_queue moves to the next item instead of ending the run.
+
+        Cleared at the top of each task, so a click that lands between two tasks
+        is discarded rather than killing the next one.
+        """
+        self._task_stop_event.set()
+
     @property
     def is_stopped(self) -> bool:
+        """Whether the *run* should end. Only _run_queue's loop asks this.
+
+        Deliberately narrow. "Should this task unwind?" is a different question
+        with a different answer -- see `should_abort` -- and conflating the two
+        is what makes any cancel end the whole run.
+        """
         return self._stop_event.is_set()
+
+    @property
+    def should_abort(self) -> bool:
+        """Whether the task now running should unwind.
+
+        For the one caller with no token to poll: workflows.ui._check_for_abort
+        only ever gets a parent_ui. Everything task-side reads `abort_token`
+        instead, which answers the same question without a second route to it.
+        """
+        return self.abort_token.is_set()
+
+    @property
+    def abort_token(self) -> AnyStopEvent:
+        """What anything inside a task polls to know it has been cancelled.
+
+        Captured by AutoLamellaTask and GridTask, handed on to milling and
+        autofocus via `raise_if_cancelled`, and read directly by the fluorescence,
+        coincidence-milling and grid tasks. Only `is_set()` is ever called on it,
+        which is what lets it widen beyond a bare Event without touching any of
+        those call sites.
+        """
+        return self._abort_token
 
     def notify_queue_changed(self) -> None:
         """Tell the UI the queue's contents changed, outside the task lifecycle.
@@ -382,8 +434,12 @@ class TaskManager:
                               lamella: 'Lamella') -> None:
         """Block until ``scheduled_at`` is reached, emitting a periodic countdown.
 
-        The wait is interruptible: if ``stop()`` is called the loop exits early
-        and the caller skips running the task.
+        The wait is interruptible by either kind of stop. The item is already
+        InProgress by this point, so it is the row the user sees running and
+        stop_task has to reach it — otherwise a cancel would sit unanswered until
+        the scheduled time arrived. On a task stop the loop falls through and the
+        task aborts at its first checkpoint, taking the same path as any other
+        mid-task cancel rather than needing its own.
         """
         # Times are naive-local throughout, but a hand-edited/externally-produced
         # protocol may carry a tz-aware scheduled_at. Normalize to naive-local so
@@ -392,7 +448,7 @@ class TaskManager:
             scheduled_at = scheduled_at.astimezone().replace(tzinfo=None)
         target_str = scheduled_at.strftime(DATETIME_DISPLAY_AMPM)
         next_update = 0.0  # force an immediate first message
-        while not self.is_stopped:
+        while not self.should_abort:
             remaining = (scheduled_at - datetime.now()).total_seconds()
             if remaining <= 0:
                 break
@@ -496,7 +552,7 @@ class TaskManager:
             # an unknown task name, or a construction failure -- where nothing else has.
             # The predicate matches AutoLamellaTaskBase._is_cancellation so the frozen
             # history entry and the live task_state cannot disagree.
-            if self.is_stopped or isinstance(e, (OperationCancelledError, InterruptedError)):
+            if self.should_abort or isinstance(e, (OperationCancelledError, InterruptedError)):
                 logging.info(f"Task {task_name} for lamella {lamella.name} cancelled by user.")
                 lamella.task_state.status = AutoLamellaTaskStatus.Cancelled
                 lamella.task_state.status_message = "Cancelled by user."

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -27,10 +27,13 @@ def _check_for_abort(parent_ui: Optional['AutoLamellaUI'], msg: str = "Workflow 
     if parent_ui is None:
         return False
 
-    # Use task_manager's stop event if available, fall back to legacy
+    # Ask the manager whether this task should unwind, rather than reading its
+    # stop event: the same predicate AutoLamellaTask._check_for_abort uses, so
+    # the two cannot disagree about what counts as cancelled. Falls back to the
+    # legacy UI event for the window before the manager exists.
     task_manager = getattr(parent_ui, '_task_manager', None)
     if task_manager is not None:
-        if task_manager.is_stopped:
+        if task_manager.should_abort:
             raise InterruptedError(msg)
     elif parent_ui._workflow_stop_event.is_set():
         raise InterruptedError(msg)

--- a/fibsem/cancellation.py
+++ b/fibsem/cancellation.py
@@ -9,7 +9,7 @@ cleanly. Callers distinguish a cancel from a real failure — surface it as a ne
 from __future__ import annotations
 
 import threading
-from typing import Optional
+from typing import Optional, Union
 
 
 class OperationCancelledError(Exception):
@@ -24,8 +24,28 @@ class OperationCancelledError(Exception):
     """
 
 
+class AnyStopEvent:
+    """A stop signal that is set when any of its component events is set.
+
+    ``is_set()`` is the only thing :func:`raise_if_cancelled` and its callers ask of
+    a stop event, so this stands in wherever a bare :class:`threading.Event` does.
+    That lets several independent cancel signals — "stop the whole run", "abandon
+    just this task" — share one token, without every polling site having to know
+    there is more than one of them.
+
+    Read-only on purpose: there is no ``set()``, because setting a composite would
+    have to guess which underlying signal was meant. Set the one you mean.
+    """
+
+    def __init__(self, *events: threading.Event):
+        self._events = events
+
+    def is_set(self) -> bool:
+        return any(event.is_set() for event in self._events)
+
+
 def raise_if_cancelled(
-    stop_event: Optional[threading.Event],
+    stop_event: Optional[Union[threading.Event, AnyStopEvent]],
     msg: str = "Operation cancelled by user.",
 ) -> None:
     """Raise :class:`OperationCancelledError` if ``stop_event`` is set.

--- a/fibsem/ui/widgets/workflow_timeline_widget.py
+++ b/fibsem/ui/widgets/workflow_timeline_widget.py
@@ -30,7 +30,11 @@ _DOT_ACTIVE     = "#ff9800"
 _DOT_PENDING    = "#606060"
 _DOT_FAILED     = "#99121F"
 _DOT_SKIPPED    = "#9e9e9e"
-_DOT_CANCELLED  = "#e0a030"  # amber: user-aborted, not an error
+# Slate, not amber: the old #e0a030 was indistinguishable from the active orange,
+# so a cancelled row read as still running — especially when it was the last thing
+# to run and there was no active row beside it to compare against. Still not red:
+# a user abort is not an error.
+_DOT_CANCELLED  = "#6f7d8c"
 
 _LINE_COLOR     = "#3a3d42"
 
@@ -846,17 +850,21 @@ class WorkflowProgressWidget(QWidget):
         rank = pending.index(index) if index in pending else -1
         is_pending = rank >= 0
         is_finished = steps[index].status in self._FINISHED
+        is_active = steps[index].status is StepStatus.ACTIVE
 
         menu = QMenu(self)
         menu.setToolTipsVisible(True)
 
-        def add(action_id: str, label: str, icon: str, enabled: bool):
+        def add(action_id: str, label: str, icon: str, enabled: bool,
+                colour: Optional[str] = None):
             act = menu.addAction(
-                fibsem_icon(icon, color=stylesheets.GRAY_ICON_COLOR), label
+                fibsem_icon(icon, color=colour or stylesheets.GRAY_ICON_COLOR), label
             )
             act.setEnabled(enabled)
             act.setData(action_id)
-            if not (is_pending or is_finished):
+            # Explains why an entry is greyed, so only on the greyed ones — the
+            # running row now has one entry that is not.
+            if not enabled and is_active:
                 act.setToolTip("This task is already running")
             act.triggered.connect(
                 lambda _checked=False, a=action_id: self.queue_action_requested.emit(a, item_id)
@@ -872,6 +880,12 @@ class WorkflowProgressWidget(QWidget):
         if is_finished:
             menu.addSeparator()
             add("run_again", "Run again", "mdi:refresh", True)
+        if is_active:
+            # Red where Remove is grey: Remove edits a list, this interrupts an
+            # operation on the sample.
+            menu.addSeparator()
+            add("stop_task", "Stop Task", "mdi:stop-circle-outline", True,
+                colour=_DOT_FAILED)
         return menu
 
     def _show_row_menu(self, index: int, pos: QPoint) -> None:
@@ -906,14 +920,22 @@ class WorkflowProgressWidget(QWidget):
         if total == 0:
             self._header.setText("Workflow")
             return
-        # Removed items are already filtered out of the view, so they leave both
-        # sides of this fraction rather than counting as work done.
+        # Everything with a terminal status counts as resolved, whether or not it
+        # succeeded — otherwise the counter can never reach the total once anything
+        # is cancelled. Removed items are already filtered out of the view, so they
+        # leave both sides of the fraction rather than counting as work done.
         done = sum(1 for i in queue_items if i.status in (
-            AutoLamellaTaskStatus.Completed, AutoLamellaTaskStatus.Skipped))
+            AutoLamellaTaskStatus.Completed, AutoLamellaTaskStatus.Skipped,
+            AutoLamellaTaskStatus.Cancelled))
         failed = sum(1 for i in queue_items if i.status == AutoLamellaTaskStatus.Failed)
+        cancelled = sum(1 for i in queue_items
+                        if i.status == AutoLamellaTaskStatus.Cancelled)
         text = f"Workflow — {done}/{total}"
-        if failed:
-            text += f" ({failed} failed)"
+        # A run that ended with tasks abandoned should not read like one that did not.
+        notes = [f"{n} {label}" for n, label in
+                 ((failed, "failed"), (cancelled, "cancelled")) if n]
+        if notes:
+            text += f" ({', '.join(notes)})"
         self._header.setText(text)
 
     def _update_elapsed(self) -> None:

--- a/tests/autolamella/test_abort_predicate.py
+++ b/tests/autolamella/test_abort_predicate.py
@@ -1,0 +1,161 @@
+"""One predicate behind every abort check (groundwork for FIB-499).
+
+There are two `_check_for_abort` functions at different layers: the method on
+AutoLamellaTask, which has a task to ask, and the module-level one in
+workflows.ui, which only has a parent_ui. They previously reached for raw state
+by two different routes — `self._stop_event` and `task_manager.is_stopped` — and
+so could disagree about what counts as cancelled.
+
+Both now answer from `TaskManager`: the task side polls `abort_token` (which is
+also what milling, autofocus and the inline checks in the fluorescence,
+coincidence-milling and grid tasks already read), and workflows.ui asks
+`should_abort` because it has no token to poll. Today both are the run-wide stop
+event, so this is a no-op; the point is that adding a per-task stop has exactly
+one place to change.
+
+`is_stopped` keeps its own narrow meaning — should the *run* end — and only
+_run_queue's loop asks it.
+"""
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from fibsem.applications.autolamella.structures import Experiment, Lamella
+from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+from fibsem.applications.autolamella.workflows.ui import _check_for_abort
+
+
+class NoMicroscope:
+    fm = None
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> TaskManager:
+    experiment = Experiment(path=tmp_path, name="test-exp")
+    experiment.positions.append(
+        Lamella(path=Path(experiment.path) / "L1", number=1, petname="L1")
+    )
+    return TaskManager(microscope=NoMicroscope(), experiment=experiment,
+                       parent_ui=None)
+
+
+class FakeUI:
+    """A parent_ui is all workflows.ui._check_for_abort ever gets."""
+
+    def __init__(self, task_manager: Optional[TaskManager]):
+        self._task_manager = task_manager
+
+
+# ── The predicate ─────────────────────────────────────────────────────────────
+
+def test_nothing_aborts_a_manager_that_has_not_been_stopped(manager):
+    assert manager.should_abort is False
+    assert manager.is_stopped is False
+    assert manager.abort_token.is_set() is False
+
+
+def test_stopping_the_run_aborts_the_task_too(manager):
+    manager.stop()
+
+    assert manager.is_stopped is True
+    assert manager.should_abort is True
+    assert manager.abort_token.is_set() is True
+
+
+# ── Both checks answer from it ────────────────────────────────────────────────
+
+def test_the_ui_check_follows_the_predicate(manager):
+    ui = FakeUI(manager)
+    assert _check_for_abort(ui) is False
+
+    manager.stop()
+    with pytest.raises(InterruptedError):
+        _check_for_abort(ui)
+
+
+def test_the_task_check_follows_the_predicate(manager):
+    """The task polls the manager's token, so it cannot diverge from the UI check."""
+    from types import SimpleNamespace
+
+    task = SimpleNamespace(task_manager=manager, _stop_event=manager.abort_token)
+    from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+
+    check = AutoLamellaTask._check_for_abort
+    check(task)  # must not raise
+
+    manager.stop()
+    with pytest.raises(InterruptedError):
+        check(task)
+
+
+def test_the_two_checks_agree(manager):
+    """The property that matters: whatever the predicate says, both obey."""
+    from types import SimpleNamespace
+
+    from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+
+    ui = FakeUI(manager)
+    task = SimpleNamespace(task_manager=manager, _stop_event=manager.abort_token)
+
+    for stopped in (False, True):
+        if stopped:
+            manager.stop()
+
+        ui_aborted = task_aborted = False
+        try:
+            _check_for_abort(ui)
+        except InterruptedError:
+            ui_aborted = True
+        try:
+            AutoLamellaTask._check_for_abort(task)
+        except InterruptedError:
+            task_aborted = True
+
+        assert ui_aborted == task_aborted == stopped
+
+
+# ── Fallbacks for a task with no manager ──────────────────────────────────────
+
+def test_a_task_without_a_manager_falls_back_to_its_token():
+    """A script or test driving a task directly has no manager to ask."""
+    import threading
+    from types import SimpleNamespace
+
+    from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+
+    event = threading.Event()
+    task = SimpleNamespace(task_manager=None, _stop_event=event)
+    AutoLamellaTask._check_for_abort(task)  # must not raise
+
+    event.set()
+    with pytest.raises(InterruptedError):
+        AutoLamellaTask._check_for_abort(task)
+
+
+def test_a_task_with_neither_never_aborts():
+    from types import SimpleNamespace
+
+    from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+
+    task = SimpleNamespace(task_manager=None, _stop_event=None)
+    AutoLamellaTask._check_for_abort(task)  # must not raise
+
+
+def test_the_ui_check_is_a_noop_headless():
+    assert _check_for_abort(None) is False
+
+
+# ── What tasks are handed ─────────────────────────────────────────────────────
+
+def test_both_task_hierarchies_take_the_managers_token(manager):
+    """GridTask is a parallel hierarchy with its own __init__, so it has to be
+    kept in step by hand — it would otherwise miss a per-task stop entirely."""
+    import inspect
+
+    from fibsem.applications.autolamella.workflows.tasks import base, grid_tasks
+
+    for module in (base, grid_tasks):
+        source = inspect.getsource(module)
+        assert "task_manager.abort_token if task_manager else None" in source
+        assert "task_manager._stop_event" not in source

--- a/tests/autolamella/test_stop_task.py
+++ b/tests/autolamella/test_stop_task.py
@@ -1,0 +1,231 @@
+"""Stopping one task without ending the run (FIB-499).
+
+Both stops unwind the task the same way and both end as Cancelled — it is a user
+abort either way. What differs is scope, which lives on the manager: `is_stopped`
+answers "should the run end?" and only _run_queue's loop asks it, while
+`should_abort` / `abort_token` answer "should this task unwind?" and are what the
+task and its long-running operations poll.
+
+Real Experiment, real Lamellas, real TaskQueue, real _run_queue. Task execution is
+the one thing stubbed, so a stop can be raised from inside a running task without
+a microscope.
+"""
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaTaskProtocol,
+)
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus as Status
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaWorkflowConfig,
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+from fibsem.cancellation import AnyStopEvent, OperationCancelledError
+
+TASKS = ["Trench", "Undercut"]
+
+
+class NoMicroscope:
+    fm = None
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> TaskManager:
+    experiment = Experiment(path=tmp_path, name="test-exp")
+    experiment.task_protocol = AutoLamellaTaskProtocol(
+        workflow_config=AutoLamellaWorkflowConfig(
+            tasks=[AutoLamellaTaskDescription(name=n, supervise=False, required=False)
+                   for n in TASKS]
+        )
+    )
+    for i, name in enumerate(("L1", "L2"), start=1):
+        experiment.positions.append(
+            Lamella(path=Path(experiment.path) / name, number=i, petname=name)
+        )
+    m = TaskManager(microscope=NoMicroscope(), experiment=experiment, parent_ui=None)
+    m.queue.build_from_matrix(TASKS, ["L1", "L2"])
+    return m
+
+
+def run_with(manager: TaskManager, on_task=None) -> List[tuple]:
+    """Drive the real _run_queue with task execution stubbed.
+
+    ``on_task(task_name, lamella)`` stands in for the task body and may raise, as a
+    cancelled task does once it polls the abort token.
+    """
+    executed = []
+
+    def _run_single_task(task_name, lamella):
+        executed.append((lamella.name, task_name))
+        try:
+            if on_task is not None:
+                on_task(task_name, lamella)
+        except Exception as exc:
+            # Mirrors the real _run_single_task's classification.
+            if manager.should_abort or isinstance(
+                exc, (OperationCancelledError, InterruptedError)
+            ):
+                lamella.task_state.status = Status.Cancelled
+            else:
+                lamella.task_state.status = Status.Failed
+            return exc
+        lamella.task_state.status = Status.Completed
+        return None
+
+    manager._run_single_task = _run_single_task
+    manager._run_queue()
+    return executed
+
+
+def statuses(manager: TaskManager) -> List[Status]:
+    return [i.status for i in manager.queue.items]
+
+
+# ── Scope: the whole point ────────────────────────────────────────────────────
+
+def test_stopping_a_task_leaves_the_run_going(manager):
+    """The item is Cancelled and the queue carries on to the next one."""
+    def on_task(task_name, lamella):
+        if (lamella.name, task_name) == ("L1", "Trench"):
+            manager.stop_task()
+            raise OperationCancelledError("cancelled")
+
+    executed = run_with(manager, on_task)
+
+    assert len(executed) == 4          # every item was still attempted
+    assert statuses(manager)[0] is Status.Cancelled
+    assert statuses(manager)[1:] == [Status.Completed] * 3
+
+
+def test_stopping_the_run_ends_it(manager):
+    """The contrast: everything after the current item stays untouched."""
+    def on_task(task_name, lamella):
+        if (lamella.name, task_name) == ("L1", "Trench"):
+            manager.stop()
+            raise OperationCancelledError("cancelled")
+
+    executed = run_with(manager, on_task)
+
+    assert len(executed) == 1
+    assert statuses(manager)[0] is Status.Cancelled
+    assert statuses(manager)[1:] == [Status.NotStarted] * 3
+
+
+def test_stopping_a_task_never_sets_is_stopped(manager):
+    """There is no path from a task cancel to ending the run — the reason these
+    are two events rather than one event and a scope flag."""
+    manager.stop_task()
+
+    assert manager.is_stopped is False
+    assert manager.should_abort is True
+
+
+def test_a_run_stop_wins_when_both_are_set(manager):
+    def on_task(task_name, lamella):
+        manager.stop_task()
+        manager.stop()
+        raise OperationCancelledError("cancelled")
+
+    executed = run_with(manager, on_task)
+
+    assert len(executed) == 1
+    assert manager.is_stopped is True
+
+
+# ── Clearing between tasks ────────────────────────────────────────────────────
+
+def test_the_task_stop_does_not_leak_into_the_next_task(manager):
+    """Cleared at the top of each item, so one cancel cancels one task."""
+    def on_task(task_name, lamella):
+        if (lamella.name, task_name) == ("L1", "Trench"):
+            manager.stop_task()
+            raise OperationCancelledError("cancelled")
+        assert manager.should_abort is False, "the cancel leaked into a later task"
+
+    run_with(manager, on_task)
+
+    assert statuses(manager).count(Status.Cancelled) == 1
+
+
+def test_a_click_between_tasks_is_discarded(manager):
+    """It was aimed at the task that has just finished, not the next one."""
+    def on_task(task_name, lamella):
+        if (lamella.name, task_name) == ("L1", "Trench"):
+            manager.stop_task()   # set, but nothing raises: the task completes
+
+    executed = run_with(manager, on_task)
+
+    assert len(executed) == 4
+    assert statuses(manager) == [Status.Completed] * 4
+
+
+# ── The token everything inside a task polls ──────────────────────────────────
+
+def test_the_token_reports_either_stop(manager):
+    token = manager.abort_token
+    assert token.is_set() is False
+
+    manager.stop_task()
+    assert token.is_set() is True
+
+    manager._task_stop_event.clear()
+    assert token.is_set() is False
+
+    manager.stop()
+    assert token.is_set() is True
+
+
+def test_the_token_identity_is_stable(manager):
+    """Tasks capture it once at construction, so it cannot be rebuilt per access."""
+    assert manager.abort_token is manager.abort_token
+
+
+def test_a_composite_cannot_be_set_directly():
+    """Setting it would have to guess which underlying signal was meant."""
+    assert not hasattr(AnyStopEvent(), "set")
+
+
+# ── Stopping the hardware, not just the queue ─────────────────────────────────
+
+def test_both_stop_paths_interrupt_the_hardware_the_same_way():
+    """Found on the microscope: cancelling mid-mill unwound the task but the mill
+    carried on.
+
+    Milling runs on its own thread with its own stop event, owned by the milling
+    widget — the task only *waits* for it, so a task that raises stops the waiting
+    and nothing else. Stop Workflow always did the hardware half separately;
+    Stop Task has to do the same, and the only way they cannot drift is by being
+    the same call.
+    """
+    # Read the files rather than import them: both UI modules pull in napari, which
+    # is absent from the CI environment this module runs in.
+    import fibsem
+
+    ui_dir = Path(fibsem.__path__[0]) / "applications" / "autolamella" / "ui"
+    autolamella_ui = (ui_dir / "AutoLamellaUI.py").read_text()
+    main_ui = (ui_dir / "AutoLamellaMainUI.py").read_text()
+
+    def body(source: str, name: str) -> str:
+        """The text of one method, up to the next def at the same indent."""
+        start = source.index(f"    def {name}(")
+        rest = source[start + 1:]
+        end = rest.find("\n    def ")
+        return rest[:end if end != -1 else len(rest)]
+
+    halt = body(autolamella_ui, "stop_current_operations")
+    assert "stop_milling()" in halt
+    assert "cancel_spot_burn()" in halt
+
+    # Stop Workflow routes through it rather than repeating it.
+    run_stop = body(autolamella_ui, "_stop_workflow_thread")
+    assert "stop_current_operations()" in run_stop
+    assert "stop_milling()" not in run_stop
+
+    # ... and so does Stop Task.
+    assert "stop_current_operations()" in body(main_ui, "_on_queue_action")

--- a/tests/autolamella/test_tasks.py
+++ b/tests/autolamella/test_tasks.py
@@ -189,19 +189,45 @@ def test_record_output_does_not_record_the_same_file_twice(
     }
 
 
-def test_task_is_cancellation_classifies_stop_vs_failure():
+def test_task_is_cancellation_classifies_stop_vs_failure(tmp_path: Path):
     """AutoLamellaTask._is_cancellation decides which hook event a raise produces: a user
-    Stop (cancel exc / stop event) fires task_cancelled, a real failure fires task_failed."""
+    Stop (cancel exc / stopping manager) fires task_cancelled, a real failure fires
+    task_failed.
+
+    Driven off a real TaskManager: this asks the manager whether the task should be
+    unwinding, and a stand-in would only confirm whatever shape the test assumed.
+    """
     import types
 
+    from fibsem.applications.autolamella.structures import Experiment
     from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+    from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
     from fibsem.cancellation import OperationCancelledError
 
-    def _isc(exc, stopped=False):
-        s = types.SimpleNamespace(task_manager=types.SimpleNamespace(is_stopped=stopped))
+    class _NoMicroscope:
+        fm = None
+
+    def _manager() -> TaskManager:
+        return TaskManager(microscope=_NoMicroscope(),
+                           experiment=Experiment(path=tmp_path, name="test-exp"),
+                           parent_ui=None)
+
+    def _isc(exc, manager=None):
+        s = types.SimpleNamespace(task_manager=manager)
         return AutoLamellaTask._is_cancellation(s, exc)
 
-    assert _isc(OperationCancelledError("x")) is True
-    assert _isc(InterruptedError("Workflow aborted by user.")) is True
-    assert _isc(ValueError("real bug")) is False
-    assert _isc(ValueError("real bug"), stopped=True) is True  # stop event set → cancelled
+    running = _manager()
+    assert _isc(OperationCancelledError("x"), running) is True
+    assert _isc(InterruptedError("Workflow aborted by user."), running) is True
+    assert _isc(ValueError("real bug"), running) is False
+
+    # Either kind of stop makes an exception thrown on the way out a cancellation,
+    # not a failure — abandoning one task is as much a user Stop as ending the run.
+    stopped_run = _manager()
+    stopped_run.stop()
+    assert _isc(ValueError("real bug"), stopped_run) is True
+
+    stopped_task = _manager()
+    stopped_task.stop_task()
+    assert _isc(ValueError("real bug"), stopped_task) is True
+    assert stopped_task.is_stopped is False  # ... and the run is untouched

--- a/tests/ui/test_workflow_timeline_actions.py
+++ b/tests/ui/test_workflow_timeline_actions.py
@@ -68,18 +68,31 @@ def test_the_last_pending_row_cannot_move_down(widget):
     }
 
 
-def test_the_running_row_offers_nothing(widget):
-    """Not an empty menu — the greyed entries are what explain the rule."""
+def test_the_running_row_offers_only_stop_task(widget):
+    """It cannot be moved or removed — but it can be abandoned (FIB-499). The
+    greyed entries are still what explain the rest of the rule."""
     assert actions(widget, 1) == {
         "move_up": False, "move_down": False,
         "run_next": False, "remove": False,
+        "stop_task": True,
     }
 
 
-def test_the_running_row_says_why_it_is_greyed(widget):
+def test_the_running_row_says_why_the_rest_are_greyed(widget):
+    """The tooltip explains a disabled entry, so it does not land on Stop Task."""
     menu = widget.build_row_menu(1)
-    assert all(a.toolTip() == "This task is already running"
-               for a in menu.actions() if a.data())
+    tips = {a.data(): a.toolTip() for a in menu.actions() if a.data()}
+
+    assert tips["remove"] == "This task is already running"
+    # Qt defaults an action's tooltip to its own text, so the check is that Stop
+    # Task did not inherit the explanation meant for the disabled entries.
+    assert tips["stop_task"] != tips["remove"]
+
+
+def test_only_the_running_row_can_be_stopped(widget):
+    """Nothing else is under way, so there is nothing to interrupt."""
+    for index in (0, 2, 3):
+        assert "stop_task" not in actions(widget, index)
 
 
 def test_a_finished_row_offers_only_run_again(widget):

--- a/tests/ui/test_workflow_timeline_sync.py
+++ b/tests/ui/test_workflow_timeline_sync.py
@@ -163,6 +163,33 @@ def test_a_removed_row_stops_painting_immediately(widget, queue):
     assert ghost.parent() is None
 
 
+def test_a_cancelled_task_counts_as_resolved(widget, queue):
+    """Found on the microscope: the counter sat at 0/4 with a task cancelled, so it
+    could never reach the total. Cancelled is terminal — it just is not success."""
+    item = start_next(widget, queue)
+    finish(widget, queue, item, status=Status.Cancelled)
+
+    assert widget._header.text() == "Workflow — 1/4 (1 cancelled)"
+
+
+def test_failures_and_cancellations_are_both_named(widget, queue):
+    finish(widget, queue, start_next(widget, queue), status=Status.Failed)
+    finish(widget, queue, start_next(widget, queue), status=Status.Cancelled)
+
+    assert widget._header.text() == "Workflow — 1/4 (1 failed, 1 cancelled)"
+
+
+def test_a_cancelled_row_does_not_look_like_a_running_one(widget, queue):
+    """They were #e0a030 and #ff9800 — the same colour to the eye."""
+    from fibsem.ui.widgets.workflow_timeline_widget import (
+        _DOT_ACTIVE, _DOT_CANCELLED, _status_color,
+    )
+    from fibsem.ui.widgets.workflow_timeline_widget import StepStatus
+
+    assert _DOT_CANCELLED != _DOT_ACTIVE
+    assert _status_color(StepStatus.CANCELLED) == _DOT_CANCELLED
+
+
 def test_removed_item_leaves_both_sides_of_the_header_fraction(widget, queue):
     """It is not work that got done, so counting it as done would be a lie —
     and leaving it in the total would mean the counter could never finish."""


### PR DESCRIPTION
The only way to abandon a misbehaving task was Stop, which ends the run — on a long unattended one, throwing away every remaining queued item to escape a single bad task. Behind `edit_running_queue` with the rest of the queue editing.

## A task stop is not a different kind of stop

Both surface as `OperationCancelledError` or `InterruptedError`, and both end as `Cancelled` — it's a user abort either way. What differs is **scope**, and scope belongs to the manager. The task neither knows nor cares which kind it's unwinding from.

`TaskManager` now answers three questions instead of conflating them into one event:

| | means | asked by |
|---|---|---|
| `is_stopped` | should the **run** end? | `_run_queue`'s loop, only |
| `should_abort` | should this **task** unwind? | `workflows/ui._check_for_abort` |
| `abort_token` | the signal to poll | tasks, milling, autofocus |

The first commit routed every caller through those while all three still read the one event — a verifiable no-op. Adding `_task_stop_event` then had exactly one place to touch, and **milling, autofocus and the five inline token checks** in the fluorescence, coincidence-milling and grid tasks observe a task stop without being modified at all.

**Two events, not one event and a scope flag.** A flag has to avoid being downgraded when a run-wide Stop arrives mid-unwind, and ordering starts to matter. With two there's no path by which cancelling a task can set `is_stopped`, so Stop Workflow's meaning can't be weakened by a bug in the new code. The token that ORs them is deliberately read-only — setting a composite would have to guess which signal you meant.

`_task_stop_event` clears at the top of each item, so a click landing between two tasks is discarded rather than killing the next one.

## Three things this turned up

**The scheduled-start wait** looped on `is_stopped`. A stop aimed at a task waiting for its scheduled time would have gone unanswered until the time arrived — while the timeline showed that row as running.

**Both cancellation classifiers** fell back to `is_stopped`, so an exception thrown on the way out of a cancelled task was recorded as `Failed` rather than `Cancelled`.

**`GridTask` is a parallel hierarchy** with its own `__init__` capturing the manager's raw event. It would have missed the per-task stop entirely. A test greps both modules, since nothing structural keeps them in step.

## UI

The running row's menu was four greyed entries; it now offers **Stop Task** — red where Remove is grey, because Remove edits a list and this interrupts an operation on the sample.

The confirmation is built rather than `QMessageBox.question(...)`, whose text slot renders everything at question weight. The distinction from Stop is the reason for asking, so it belongs in the informative slot. The "already running" tooltip now lands only on disabled entries, where it would otherwise have contradicted the one entry that works.

## Testing

18 new tests across `test_abort_predicate.py` and `test_stop_task.py`, driving the real `_run_queue` on a real `Experiment`, `Lamella`s and `TaskQueue`. The pair that carries the design: task stop → item `Cancelled`, all four items still attempted; run stop → one attempted, the rest left `NotStarted`.

An existing test faked `TaskManager` with a `SimpleNamespace` and so broke on an API change while saying nothing about behaviour — rebuilt on a real manager, now covering both kinds of stop.

Full suite: 2632 passed.

**Not covered by any of that:** whether a real mill unwinds safely mid-pass and the next task starts cleanly. Every stop path here routes through machinery that already ships, which is the strongest argument available — but it wants a run on the Demo microscope before merging.
