### PR TITLE
[fibsem] Do not create a save directory that arrived inside an image

### DIFF
--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2432,12 +2432,23 @@ class FibsemImage:
             if self.metadata is None:
                 raise ValueError("No metadata provided, cannot determine save path. Please provide a path.")
             filename = self.metadata.image_settings.filename
-            path = self.metadata.image_settings.path
+            directory = self.metadata.image_settings.path
             if filename is None:
                 raise ValueError("No filename provided in metadata, cannot determine save path. Please provide a path.")
-            if path is None:
+            if directory is None:
                 raise ValueError("No path provided in metadata, cannot determine save path. Please provide a path.")
-            path = os.path.join(path, filename)
+            # The recorded path is an absolute directory on whichever machine acquired
+            # the image, and it travels inside the file. Creating it would mean loading
+            # a colleague's image and re-saving it silently reconstructs their directory
+            # tree here -- `D:\SharedData\<their name>\...` and all. A path the caller
+            # passes in is theirs to create; one that arrived in a file is not.
+            if not os.path.isdir(directory):
+                raise ValueError(
+                    f"The directory recorded in this image's metadata does not exist: "
+                    f"{directory}. It is from the machine that acquired the image. "
+                    f"Please provide a path."
+                )
+            path = os.path.join(directory, filename)
         os.makedirs(os.path.dirname(path), exist_ok=True)
         path = Path(path).with_suffix(".tif")
 

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2475,9 +2475,12 @@ class FibsemImage:
 
         md = self.metadata
         microscope = Microscope(
-            manufacturer=md.system.info.manufacturer,
-            model=md.system.info.model,
-            serial_number=md.system.info.serial_number,
+            # md.system_info since FIB-481; this was md.system.info, which no longer
+            # exists. Nothing calls this -- see FIB-485 for whether it should live at
+            # all -- but leaving a known-broken reference is worse than fixing it.
+            manufacturer=md.system_info.manufacturer,
+            model=md.system_info.model,
+            serial_number=md.system_info.serial_number,
         )
         instrument = Instrument(microscope=microscope)
 

--- a/tests/test_image_save_paths.py
+++ b/tests/test_image_save_paths.py
@@ -1,0 +1,81 @@
+"""Saving an image must not reconstruct another machine's directory tree.
+
+`ImageSettings.path` is an absolute directory, and it travels inside the file. So a
+loaded image carries wherever it was acquired -- on Windows, `D:\\SharedData\\<name>\\...`
+-- and `FibsemImage.save()` falls back to it when no path is given. It used to
+`os.makedirs` that unconditionally, which meant opening a colleague's image and
+re-saving it silently created their layout locally.
+
+A path the caller passes in is theirs to create. One that arrived in a file is not.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from fibsem.structures import (
+    BeamType,
+    FibsemImage,
+    FibsemImageMetadata,
+    ImageSettings,
+    MicroscopeState,
+    Point,
+)
+
+
+def _image(path, filename: str = "an-image") -> FibsemImage:
+    """An image whose metadata names a directory, as an acquired one does."""
+    return FibsemImage(
+        data=np.zeros((8, 8), dtype=np.uint8),
+        metadata=FibsemImageMetadata(
+            image_settings=ImageSettings(
+                beam_type=BeamType.ELECTRON, path=str(path), filename=filename
+            ),
+            pixel_size=Point(1e-9, 1e-9),
+            microscope_state=MicroscopeState(),
+        ),
+    )
+
+
+def test_saving_uses_the_recorded_directory_when_it_exists(tmp_path) -> None:
+    """The ordinary case: a task sets the path, then acquires and saves into it."""
+    written = _image(tmp_path).save()
+
+    assert os.path.isfile(written)
+    assert os.path.dirname(written) == str(tmp_path)
+
+
+def test_saving_does_not_create_a_directory_that_came_out_of_a_file(tmp_path) -> None:
+    """The footgun. The directory must not spring into existence."""
+    absent = tmp_path / "SharedData" / "someone-else" / "their-experiment"
+    image = _image(absent)
+
+    with pytest.raises(ValueError, match="does not exist"):
+        image.save()
+
+    assert not absent.exists()
+    # ...and no partial tree either.
+    assert not (tmp_path / "SharedData").exists()
+
+
+def test_an_explicit_path_is_still_created(tmp_path) -> None:
+    """A caller asking for a directory gets one. Only the recorded path is untrusted."""
+    target = tmp_path / "deliberately" / "nested" / "output.tif"
+
+    written = _image(tmp_path).save(str(target))
+
+    assert os.path.isfile(written)
+
+
+def test_the_error_says_where_the_directory_came_from(tmp_path) -> None:
+    """Otherwise this reads as a bug in the caller rather than a stale record."""
+    absent = tmp_path / "not-here"
+
+    with pytest.raises(ValueError) as raised:
+        _image(absent).save()
+
+    message = str(raised.value)
+    assert str(absent) in message
+    assert "acquired" in message
+    assert "provide a path" in message.lower()


### PR DESCRIPTION
Two unrelated one-file fixes, one commit each.

## 1. `save()` reconstructed another machine's directory tree

`ImageSettings.path` is an absolute directory on whichever machine acquired the image, and it is serialised into the file. `FibsemImage.save()` falls back to it when given no path, then ran:

```python
os.makedirs(os.path.dirname(path), exist_ok=True)
```

unconditionally. So opening a colleague's image and re-saving it silently created their layout locally — `D:\SharedData\<their name>\...` and all.

A path the caller passes in is theirs to create. One that arrived in a file is not. The fallback now requires the directory to already exist, and otherwise raises naming it and saying where it came from, so the failure reads as a stale record rather than a bug in the caller.

**No legitimate caller is affected.** Lamella directories are created up front (`applications/autolamella/structures.py:947`, `:1414`), every acquisition site points `image_settings.path` at one that exists, and an explicit path is still created exactly as before. Four tests cover it, including that no *partial* tree is left behind.

Found while investigating FIB-483, which was cancelled — the metadata change that would also have addressed this was not worth its own schema version, but this hazard is real on its own and does not need one.

## 2. FIB-481 left a broken reference in the OME writer

`_save_ome_tiff` still read `md.system.info.manufacturer` and friends. FIB-481 replaced `FibsemImageMetadata.system` with `system_info` and `hardware_geometry`, so that attribute no longer exists.

Nothing calls it — it sits inside an `### EXPERIMENTAL START ####` block with zero callers, and FIB-485 is the open question of whether FIB/SEM images should converge on OME-TIFF at all — so nothing broke. But it went from *unused* to *definitively broken*, and a reference that cannot possibly work is worse left alone than corrected, whichever way FIB-485 goes.

Separated into its own commit since it has nothing to do with the first.

## Verification

2617 passed, 24 skipped.