### PR TITLE
[ui] Share the dark-theme palette and widgets, and fix the tooltips it hid

### DIFF
--- a/fibsem/correlation/ui/widgets/coordinate_list_widget.py
+++ b/fibsem/correlation/ui/widgets/coordinate_list_widget.py
@@ -46,7 +46,7 @@ _ROW_RIGHT_WIDTH = 10
 # Fit-state indicator colours. A fitted point (unmodified auto-fit result) is
 # white so it reads as "lit up"; otherwise a muted grey — dimmer than the light
 # trash/edit icons — so it recedes to a placeholder.
-_FITTED_ICON_COLOR = "#ffffff"
+_FITTED_ICON_COLOR = stylesheets.WHITE_ICON_COLOR
 _UNFITTED_ICON_COLOR = "#6b6f76"
 
 _POINT_TYPE_COLORS: Dict[PointType, str] = {

--- a/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
@@ -31,12 +31,12 @@ from fibsem.fm.timing import estimate_tileset_acquisition_time
 from fibsem.structures import TileOrderStrategy
 from fibsem.ui import stylesheets
 
-BACKGROUND = "#262930"
-PANEL = "#1e2027"
-BORDER = "#3d4251"
-TEXT = "#d6d6d6"
-TEXT_STRONG = "#f0f1f2"
-TEXT_MUTED = "#868e93"
+BACKGROUND = stylesheets.SURFACE_COLOR
+PANEL = stylesheets.PANEL_COLOR
+BORDER = stylesheets.BORDER_COLOR
+TEXT = stylesheets.TEXT_COLOR
+TEXT_STRONG = stylesheets.TEXT_STRONG_COLOR
+TEXT_MUTED = stylesheets.TEXT_MUTED_COLOR
 
 def format_duration(seconds: float) -> str:
     """`2m 14s`, `1h 03m`, `45s` — whichever reads best at that magnitude."""

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -61,7 +61,7 @@ from fibsem.ui.widgets.progress_widget import (
 from fibsem.ui.widgets.canvas.fm_canvas import FMRealSpaceCanvasWidget
 from fibsem.ui.widgets.canvas.stage_frame import FMStageProjection, StageFrame
 
-TEXT_MUTED = "#868e93"
+TEXT_MUTED = stylesheets.TEXT_MUTED_COLOR
 PROGRESS_FONT_PX = 10
 # Inset for chrome drawn over the canvas, matching the toolbar buttons' own margin so
 # the cursor readout in the top left lines up with the buttons in the top right.

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -660,6 +660,53 @@ DEFECT_RED_COLOR = "#d04040"
 CANVAS_BG = "#1e2124"
 PRIMARY_ACCENT = "#3a6ea5"  # matches the quad-view selection border
 
+# ---------------------------------------------------------------------------
+# Napari-dark surface palette
+#
+# The tokens the hand-built dialogs style themselves from. Named for the role
+# they play rather than the shade they are, because that is what a caller is
+# choosing: a panel is a panel whether or not it stays #1e2027.
+#
+# Four of these already existed above under shade-derived names, and those are
+# deliberately left in place for their current callers rather than renamed --
+# the churn would reach well past the widgets that share this palette:
+#
+#     SURFACE_COLOR      == GRAY_BACKGROUND_COLOR
+#     TEXT_STRONG_COLOR  == GRAY_TEXT_COLOR
+#     TEXT_MUTED_COLOR   == GRAY_SECONDARY_COLOR
+#     OK_COLOR           == AUTOMATED_COLOR, GREEN_COLOR
+#     ERROR_COLOR        == DEFECT_RED_COLOR
+#
+# So: prefer these when styling a new dialog, and do not add a third spelling
+# of a colour that is already here twice.
+SURFACE_COLOR = "#262930"       # dialog background
+PANEL_COLOR = "#1e2027"         # inset panels, table headers
+ROW_ALT_COLOR = "#2b2f38"       # alternating row tint, hover
+BORDER_COLOR = "#3d4251"        # panel and control borders
+TEXT_COLOR = "#d6d6d6"          # body text
+TEXT_STRONG_COLOR = "#f0f1f2"   # titles, emphasis
+TEXT_MUTED_COLOR = "#868e93"    # secondary text, disabled
+ACCENT_COLOR = "#50a6ff"        # links, selected state, informational chips
+OK_COLOR = "#4caf50"            # success
+ERROR_COLOR = "#d04040"         # failure
+
+# The tooltip rule, for restating alongside a selector-less widget stylesheet.
+#
+# A stylesheet set on a widget with no selector applies to every type Qt renders
+# through it -- including the QToolTip shown over it -- and it wins over the
+# application sheet because it sits nearer. So `background: transparent` on a
+# table cell leaves that cell's tooltip as floating text with no panel behind it.
+# Prefer custom_widgets.style_with_tooltip() to using this constant directly.
+TOOLTIP_STYLESHEET = f"""
+QToolTip {{
+    background-color: {PANEL_COLOR};
+    color: {TEXT_COLOR};
+    border: 1px solid {BORDER_COLOR};
+    padding: 4px 8px;
+    border-radius: 3px;
+}}
+"""
+
 WORKFLOW_BORDER_STYLESHEET = """
     QFrame#workflow_border_frame[borderState="idle"]       { border: 4px solid #262930; }
     QFrame#workflow_border_frame[borderState="automated"]  { border: 4px solid #4caf50; }

--- a/fibsem/ui/widgets/about_dialog.py
+++ b/fibsem/ui/widgets/about_dialog.py
@@ -24,7 +24,17 @@ from PyQt5.QtWidgets import (
 
 from fibsem.versioning import get_branch, get_revision
 from fibsem.ui.icon import fibsem_icon
-from fibsem.ui.stylesheets import SECONDARY_BUTTON_STYLESHEET
+from fibsem.ui.stylesheets import (
+    ACCENT_COLOR,
+    BORDER_COLOR,
+    OK_COLOR,
+    PANEL_COLOR,
+    SECONDARY_BUTTON_STYLESHEET,
+    SURFACE_COLOR,
+    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
+    TEXT_STRONG_COLOR,
+)
 from fibsem.ui.widgets.custom_widgets import IconToolButton, _SpinnerLabel
 
 _logger = logging.getLogger(__name__)
@@ -32,15 +42,16 @@ _logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
 
-# Palette (matching fibsem.ui.stylesheets napari theme)
-_BG = "#262930"
-_PANEL = "#1e2027"
-_BORDER = "#3d4251"
-_TEXT = "#d6d6d6"
-_TEXT_STRONG = "#f0f1f2"
-_TEXT_MUTED = "#868e93"
-_ACCENT = "#50a6ff"
-_OK = "#4caf50"
+# Short local names for the shared palette. These appear inside dozens of
+# f-strings below, where the full names would wrap every one of them.
+_BG = SURFACE_COLOR
+_PANEL = PANEL_COLOR
+_BORDER = BORDER_COLOR
+_TEXT = TEXT_COLOR
+_TEXT_STRONG = TEXT_STRONG_COLOR
+_TEXT_MUTED = TEXT_MUTED_COLOR
+_ACCENT = ACCENT_COLOR
+_OK = OK_COLOR
 _MONO = "Menlo, Consolas, 'DejaVu Sans Mono', monospace"
 
 # Characters of the serial number left visible; the rest is masked so a

--- a/fibsem/ui/widgets/autolamella_load_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_load_experiment_widget.py
@@ -25,6 +25,7 @@ from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
     PRIMARY_COLOR_PRESSED,
     SECONDARY_BUTTON_STYLESHEET,
+    TEXT_COLOR,
 )
 from fibsem.ui.widgets.custom_widgets import TitledPanel
 
@@ -71,7 +72,7 @@ RECENT_LAMELLA_ICON = "mdi:layers-triple-outline"
 RECENT_ALERT_ICON = "mdi:alert-circle-outline"
 RECENT_ICON_COLOR = "#9aa0ab"
 RECENT_PILL_TEXT_COLOR = "#b7bcc6"
-RECENT_NAME_COLOR = "#d6d6d6"
+RECENT_NAME_COLOR = TEXT_COLOR
 # Muted colour for rows whose experiment.yaml is missing or unreadable
 RECENT_UNAVAILABLE_COLOR = "#6b6b6b"
 

--- a/fibsem/ui/widgets/canvas/quad_view.py
+++ b/fibsem/ui/widgets/canvas/quad_view.py
@@ -36,7 +36,11 @@ from fibsem.ui.widgets.canvas.canvas_state import (
     PointsSpec,
     SceneModel,
 )
-from fibsem.ui.stylesheets import CANVAS_BG as _BG, PRIMARY_ACCENT as _SELECT_ACCENT
+from fibsem.ui.stylesheets import (
+    CANVAS_BG as _BG,
+    GREEN_COLOR,
+    PRIMARY_ACCENT as _SELECT_ACCENT,
+)
 from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 
@@ -57,7 +61,7 @@ _PLACEHOLDER_STYLE = "color: #777; font-size: 12px;"
 _PANEL_QSS = "#viewPanel {{ background: {bg}; border: 2px solid {border}; }}"
 # Live-acquisition border: green, and it takes priority over the blue selected border so a
 # live view is obvious even when you've clicked away to another cell.
-_LIVE_ACCENT = "#4caf50"
+_LIVE_ACCENT = GREEN_COLOR
 
 
 def _titled(title: str, inner: QWidget) -> QFrame:

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -31,6 +31,7 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
+from fibsem.ui.stylesheets import GRAY_CANVAS_COLOR
 from fibsem.ui.widgets.canvas.canvas_base import (
     EMPTY_CONTENT,
     ContentRect,
@@ -40,7 +41,7 @@ from fibsem.ui.widgets.canvas.canvas_base import (
 
 _logger = logging.getLogger(__name__)
 
-_DEFAULT_BACKGROUND = "#000000"  # empty space reads as "nothing acquired here"
+_DEFAULT_BACKGROUND = GRAY_CANVAS_COLOR  # empty space reads as "nothing acquired here"
 _ORIGIN_MARKER_SIZE = 11  # points; fixed on screen, so zoom-independent
 # Red, matching the grid boundary this marks the centre of. The current stage
 # position is the yellow one -- the pair have to stay distinguishable.

--- a/fibsem/ui/widgets/coincidence_milling_confirmation_dialog.py
+++ b/fibsem/ui/widgets/coincidence_milling_confirmation_dialog.py
@@ -41,7 +41,7 @@ from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     format_duration,
 )
 
-BACKGROUND = "#262930"
+BACKGROUND = stylesheets.SURFACE_COLOR
 
 # The dimensions that determine the milled volume, in the order they read. Driven off
 # the pattern's own to_dict() rather than isinstance checks, so a new pattern type

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any, List, Optional, Union
 
 from PyQt5.QtCore import QSize, Qt, pyqtSignal
-from PyQt5.QtGui import QCursor, QIcon, QPainter
+from PyQt5.QtGui import QColor, QCursor, QFontMetrics, QIcon, QPainter
 from PyQt5.QtWidgets import (
     QAbstractItemView,
     QAbstractSpinBox,
@@ -23,6 +23,7 @@ from PyQt5.QtWidgets import (
     QListWidgetItem,
     QMenu,
     QMessageBox,
+    QSizePolicy,
     QToolButton,
     QVBoxLayout,
     QWidget,
@@ -1194,3 +1195,73 @@ class LamellaNameListWidget(QWidget):
                     return
         if self._list.count() > 0:
             self._list.setCurrentRow(0)
+
+
+# ---------------------------------------------------------------------------
+# Shared pieces of the hand-built dark-theme dialogs
+# ---------------------------------------------------------------------------
+
+
+def style_with_tooltip(widget: QWidget, css: str) -> None:
+    """Set a selector-less stylesheet without swallowing the widget's tooltip.
+
+    A stylesheet with no selector applies to every type Qt renders through the
+    widget, the QToolTip included, and beats the application sheet because it
+    sits nearer -- so a cell styled ``background: transparent`` shows its tooltip
+    as floating text with nothing behind it.
+
+    Use this for any rule that does not name a type. Rules that do
+    (``QPushButton {...}``) cannot leak and can be set directly.
+    """
+    widget.setStyleSheet(css + stylesheets.TOOLTIP_STYLESHEET)
+
+
+class ElidedLabel(QLabel):
+    """A QLabel that elides rather than clipping mid-glyph.
+
+    For a column that stretches, where the width is not known when the row is
+    built and any one-off elide would be wrong at the next size. The size policy
+    is Ignored so long unbreakable text -- a dotted class path, a file path --
+    cannot drive the column wider, which would defeat the point.
+    """
+
+    def __init__(self, text: str, parent: Optional[QWidget] = None) -> None:
+        super().__init__(text, parent)
+        self._full_text = text
+        self.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
+
+    def paintEvent(self, event) -> None:  # noqa: N802 - Qt naming
+        # At paint time the width is always the real one. Doing this on resize
+        # instead misses a label that is laid out at its final size and never
+        # resized, which then clips. Re-eliding from _full_text rather than from
+        # the displayed text keeps it stable: setText schedules one more paint,
+        # the second computes the same string, and it settles.
+        metrics = QFontMetrics(self.font())
+        elided = metrics.elidedText(self._full_text, Qt.ElideRight, self.width())
+        if elided != self.text():
+            self.setText(elided)  # QLabel draws it, so the stylesheet colour survives
+        super().paintEvent(event)
+
+
+def chip(text: str, colour: str, font_size: int = 11) -> QLabel:
+    """A pill label: text on a tint of its own colour.
+
+    No dot. Once every chip has one it separates nothing, and it costs real width
+    in the narrow columns these sit in.
+
+    The minimum width is set explicitly because a QLabel inside a table cell
+    reports a size hint that ignores stylesheet padding, so the pill would
+    otherwise render clipped at both ends.
+    """
+    rgb = QColor(colour)
+    tint = f"rgba({rgb.red()}, {rgb.green()}, {rgb.blue()}, 0.15)"
+    label = QLabel(text)
+    style_with_tooltip(
+        label,
+        f"background-color: {tint}; color: {colour};"
+        f"padding: 2px 9px; border-radius: 10px; font-size: {font_size}px;",
+    )
+    font = label.font()
+    font.setPixelSize(font_size)
+    label.setMinimumWidth(QFontMetrics(font).horizontalAdvance(text) + 26)
+    return label

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -63,6 +63,7 @@ from fibsem.fm.structures import FluorescenceImage
 from fibsem.milling.strategy.coincidence import CoincidenceMillingStrategy
 from fibsem.structures import BeamType, FibsemImage, Point
 from fibsem.ui import notification_service, stylesheets
+from fibsem.ui.stylesheets import CANVAS_BG, SURFACE_COLOR
 from fibsem.ui.fm.widgets import LinePlotWidget
 from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.widgets.custom_widgets import (
@@ -82,8 +83,10 @@ if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
     from fibsem.milling.tasks import FibsemMillingTaskConfig
 
-_BG = "#262930"
-_HEADER_BG = "#1e2124"
+# Short local names for the shared palette. These appear inside dozens of
+# f-strings below, where the full names would wrap every one of them.
+_BG = SURFACE_COLOR
+_HEADER_BG = CANVAS_BG
 
 # name used for the coincidence entry in the lamella review panel / task history
 COINCIDENCE_REVIEW_TASK_NAME = "Coincidence Milling"

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -38,22 +38,33 @@ from PyQt5.QtWidgets import (
 from fibsem.cancellation import OperationCancelledError
 from fibsem.scripting import DiscoveredScript, ScriptResult
 from fibsem.ui.stylesheets import (
+    ACCENT_COLOR,
+    BORDER_COLOR,
+    ERROR_COLOR,
+    PANEL_COLOR,
     PRIMARY_BUTTON_STYLESHEET,
+    ROW_ALT_COLOR,
     STOP_WORKFLOW_BUTTON_STYLESHEET,
+    SURFACE_COLOR,
+    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
+    TEXT_STRONG_COLOR,
 )
 from fibsem.ui.utils import open_path_in_file_explorer
+from fibsem.ui.widgets.custom_widgets import ElidedLabel, chip, style_with_tooltip
 from fibsem.ui.widgets.script_runner import ScriptRunner
 
-# Palette (matching fibsem.ui.stylesheets napari theme)
-_BG = "#262930"
-_PANEL = "#1e2027"
-_ROW_ALT = "#2b2f38"
-_BORDER = "#3d4251"
-_TEXT = "#d6d6d6"
-_TEXT_STRONG = "#f0f1f2"
-_TEXT_MUTED = "#868e93"
-_ACCENT = "#50a6ff"
-_ERROR = "#d04040"
+# Short local names for the shared palette. These appear inside dozens of
+# f-strings below, where the full names would wrap every one of them.
+_BG = SURFACE_COLOR
+_PANEL = PANEL_COLOR
+_ROW_ALT = ROW_ALT_COLOR
+_BORDER = BORDER_COLOR
+_TEXT = TEXT_COLOR
+_TEXT_STRONG = TEXT_STRONG_COLOR
+_TEXT_MUTED = TEXT_MUTED_COLOR
+_ACCENT = ACCENT_COLOR
+_ERROR = ERROR_COLOR
 
 # Colour here says *what a script is*, not how frightened to be. Amber for
 # Microscope and Writes meant the two most common rows were permanently lit as
@@ -139,33 +150,6 @@ QPushButton:disabled {{ color: {_TEXT_MUTED}; }}
 """
 
 
-class _ElidedLabel(QLabel):
-    """A QLabel that elides rather than clipping mid-glyph.
-
-    The Script column stretches, so the width is not known when the row is built
-    and any one-off elide would be wrong at the next size. Re-eliding on resize
-    tracks it. The size policy is Ignored so the full text cannot drive the
-    column wider, which would defeat the point.
-    """
-
-    def __init__(self, text: str, parent: Optional[QWidget] = None) -> None:
-        super().__init__(text, parent)
-        self._full_text = text
-        self.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
-
-    def paintEvent(self, event) -> None:  # noqa: N802 - Qt naming
-        # At paint time the width is always the real one. Doing this on resize
-        # instead misses a label that is laid out at its final size and never
-        # resized, which then clips. Re-eliding from _full_text rather than from
-        # the displayed text keeps it stable: setText schedules one more paint,
-        # the second computes the same string, and it settles.
-        metrics = QFontMetrics(self.font())
-        elided = metrics.elidedText(self._full_text, Qt.ElideRight, self.width())
-        if elided != self.text():
-            self.setText(elided)  # QLabel draws it, so the stylesheet colour survives
-        super().paintEvent(event)
-
-
 def _script_type(script: DiscoveredScript) -> "tuple[str, Optional[str]]":
     """(label, chip colour) describing what a script is allowed to touch.
 
@@ -210,13 +194,11 @@ class ScriptManagerDialog(QDialog):
         titles = QVBoxLayout()
         titles.setSpacing(2)
         self.title_label = QLabel("User scripts")
-        self.title_label.setStyleSheet(
-            f"font-size: {_FS_TITLE}px; font-weight: 500; color: {_TEXT_STRONG};"
-        )
+        style_with_tooltip(self.title_label, f"font-size: {_FS_TITLE}px; font-weight: 500; color: {_TEXT_STRONG};")
         # counts and location are meta, not the heading -- the heading says what
         # this dialog is, the line under it says what is currently in it.
         self.meta_label = QLabel()
-        self.meta_label.setStyleSheet(f"font-size: {_FS_BODY}px; color: {_TEXT_MUTED};")
+        style_with_tooltip(self.meta_label, f"font-size: {_FS_BODY}px; color: {_TEXT_MUTED};")
         self.meta_label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
         self.meta_label.setMinimumWidth(160)
         titles.addWidget(self.title_label)
@@ -254,29 +236,25 @@ class ScriptManagerDialog(QDialog):
         layout.addWidget(self.stack)
 
         self.detail_panel = detail_panel = QWidget()
-        detail_panel.setStyleSheet(
-            f"background-color: {_PANEL}; border: 1px solid {_BORDER}; border-radius: 6px;"
-        )
+        style_with_tooltip(detail_panel, f"background-color: {_PANEL}; border: 1px solid {_BORDER}; border-radius: 6px;")
         detail_layout = QHBoxLayout(detail_panel)
         detail_layout.setContentsMargins(11, 9, 11, 9)
         self.detail_label = QLabel()
         self.detail_label.setTextFormat(Qt.RichText)
-        self.detail_label.setStyleSheet(
-            f"border: none; font-size: {_FS_BODY}px; color: {_TEXT};"
-        )
+        style_with_tooltip(self.detail_label, f"border: none; font-size: {_FS_BODY}px; color: {_TEXT};")
         # the consequence of running this sits opposite the facts about it, so it
         # reads as a warning rather than another line of metadata
         self.consequence_label = QLabel()
         self.consequence_label.setTextFormat(Qt.RichText)
         self.consequence_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
-        self.consequence_label.setStyleSheet(f"border: none; font-size: {_FS_BODY}px;")
+        style_with_tooltip(self.consequence_label, f"border: none; font-size: {_FS_BODY}px;")
         detail_layout.addWidget(self.detail_label, 1)
         detail_layout.addWidget(self.consequence_label, 0)
         layout.addWidget(detail_panel)
 
         footer = QHBoxLayout()
         self.hint_label = QLabel()
-        self.hint_label.setStyleSheet(f"font-size: {_FS_BODY}px; color: {_TEXT_MUTED};")
+        style_with_tooltip(self.hint_label, f"font-size: {_FS_BODY}px; color: {_TEXT_MUTED};")
         footer.addWidget(self.hint_label)
         footer.addStretch()
         close_button = QPushButton("Close")
@@ -296,27 +274,21 @@ class ScriptManagerDialog(QDialog):
         anything else in the dialog.
         """
         panel = QWidget()
-        panel.setStyleSheet(
-            f"background-color: {_PANEL}; border: 1px solid {_BORDER};"
-            f"border-radius: 6px;"
-        )
+        style_with_tooltip(panel, f"background-color: {_PANEL}; border: 1px solid {_BORDER};"
+            f"border-radius: 6px;")
         layout = QVBoxLayout(panel)
         layout.setAlignment(Qt.AlignCenter)
         layout.setSpacing(6)
 
         headline = QLabel("No scripts in this folder")
         headline.setAlignment(Qt.AlignCenter)
-        headline.setStyleSheet(
-            f"border: none; font-size: {_FS_NAME}px; color: {_TEXT};"
-        )
+        style_with_tooltip(headline, f"border: none; font-size: {_FS_NAME}px; color: {_TEXT};")
         hint = QLabel(
             "Use New script… to start one from a template, "
             "or Change folder… to look somewhere else."
         )
         hint.setAlignment(Qt.AlignCenter)
-        hint.setStyleSheet(
-            f"border: none; font-size: {_FS_BODY}px; color: {_TEXT_MUTED};"
-        )
+        style_with_tooltip(hint, f"border: none; font-size: {_FS_BODY}px; color: {_TEXT_MUTED};")
         # Says "repository" on purpose: examples/ is not shipped in the wheel, so a
         # pip-installed user will not find it on disk and would otherwise be told
         # only to write one from scratch. FIB-341 owns seeding them properly.
@@ -324,9 +296,7 @@ class ScriptManagerDialog(QDialog):
         examples.setTextFormat(Qt.RichText)
         examples.setAlignment(Qt.AlignCenter)
         examples.setWordWrap(True)
-        examples.setStyleSheet(
-            f"border: none; font-size: {_FS_BODY}px; color: {_TEXT_MUTED};"
-        )
+        style_with_tooltip(examples, f"border: none; font-size: {_FS_BODY}px; color: {_TEXT_MUTED};")
         layout.addWidget(headline)
         layout.addWidget(hint)
         layout.addSpacing(4)
@@ -356,49 +326,22 @@ class ScriptManagerDialog(QDialog):
         table.setColumnWidth(2, 130)
         return table
 
-    @staticmethod
-    def _chip(text: str, colour: str) -> QLabel:
-        """A pill label: text on a tint of its own colour.
-
-        No dot. Once every chip had one it separated nothing, and it cost real
-        width in a 130px column that has to fit three chips on one row.
-        """
-        rgb = QColor(colour)
-        tint = f"rgba({rgb.red()}, {rgb.green()}, {rgb.blue()}, 0.15)"
-        chip = QLabel(text)
-        chip.setStyleSheet(
-            f"background-color: {tint}; color: {colour};"
-            f"padding: 2px 9px; border-radius: 10px; font-size: {_FS_SMALL}px;"
-        )
-        # sizeHint does not account for the stylesheet padding, so the last character
-        # clips. Measure the text and pin the width -- at the size it actually
-        # renders at, or the default font's metrics pad every chip by the difference.
-        font = chip.font()
-        font.setPixelSize(_FS_SMALL)
-        metrics = QFontMetrics(font)
-        chip.setMinimumWidth(metrics.horizontalAdvance(text) + 26)
-        return chip
-
     def _name_cell(self, script: DiscoveredScript) -> QWidget:
         """Two lines: the filename, and what it does (or why it will not load)."""
         widget = QWidget()
-        widget.setStyleSheet("background: transparent;")
+        style_with_tooltip(widget, "background: transparent;")
         layout = QVBoxLayout(widget)
         layout.setContentsMargins(12, 8, 10, 8)
         layout.setSpacing(2)
 
         summary = script.description if script.is_runnable else script.error
-        name = _ElidedLabel(script.name)
-        name.setStyleSheet(
-            f"font-family: Menlo, monospace; font-size: {_FS_NAME}px;"
+        name = ElidedLabel(script.name)
+        style_with_tooltip(name, f"font-family: Menlo, monospace; font-size: {_FS_NAME}px;"
             f"background: transparent;"
-            f"color: {_TEXT_STRONG if script.is_runnable else _TEXT_MUTED};"
-        )
-        detail = _ElidedLabel(summary)
-        detail.setStyleSheet(
-            f"font-size: {_FS_BODY}px; background: transparent;"
-            f"color: {_TEXT if script.is_runnable else _ERROR};"
-        )
+            f"color: {_TEXT_STRONG if script.is_runnable else _TEXT_MUTED};")
+        detail = ElidedLabel(summary)
+        style_with_tooltip(detail, f"font-size: {_FS_BODY}px; background: transparent;"
+            f"color: {_TEXT if script.is_runnable else _ERROR};")
         layout.addWidget(name)
         layout.addWidget(detail)
         # the summary is elided in the row, so the tooltip has to carry it in full
@@ -413,16 +356,16 @@ class ScriptManagerDialog(QDialog):
         constantly and tell you no more than their absence would.
         """
         widget = QWidget()
-        widget.setStyleSheet("background: transparent;")
+        style_with_tooltip(widget, "background: transparent;")
         layout = QHBoxLayout(widget)
         layout.setContentsMargins(8, 6, 8, 6)
         layout.setSpacing(4)
 
         label, colour = _script_type(script)
         if colour is not None:
-            layout.addWidget(self._chip(label, colour))
+            layout.addWidget(chip(label, colour, _FS_SMALL))
         if script.writes:
-            layout.addWidget(self._chip("Writes", _WRITES))
+            layout.addWidget(chip("Writes", _WRITES, _FS_SMALL))
         layout.addStretch()
         notes = [f"Type: {label}"]
         if script.writes:
@@ -587,7 +530,7 @@ class ScriptManagerDialog(QDialog):
         self.consequence_label.setToolTip(explain)
         # sizeHint does not cover the stylesheet's own font-size, so the tail clips.
         # Pin from the plain text before it is wrapped in the colour span. Unlike
-        # _chip, this label was styled back in _build(), so by now font() has the
+        # chip(), this label was styled back in _build(), so by now font() has the
         # stylesheet size and needs no explicit setPixelSize.
         metrics = QFontMetrics(self.consequence_label.font())
         self.consequence_label.setMinimumWidth(metrics.horizontalAdvance(consequence) + 10)

--- a/fibsem/ui/widgets/spot_burn_coordinates_widget.py
+++ b/fibsem/ui/widgets/spot_burn_coordinates_widget.py
@@ -14,9 +14,10 @@ from fibsem.imaging.spot import SpotBurnSettings
 from fibsem.structures import BeamType, Point
 from fibsem.ui.widgets.canvas.canvas_state import PointsSpec
 from fibsem.ui.widgets.custom_widgets import IconToolButton
+from fibsem.ui.stylesheets import CANVAS_BG
 
 
-_HEADER_BG = "#1e2124"
+_HEADER_BG = CANVAS_BG
 _MUTED = "#8a9099"
 
 

--- a/fibsem/ui/widgets/tiled_overview_widget.py
+++ b/fibsem/ui/widgets/tiled_overview_widget.py
@@ -29,16 +29,19 @@ from matplotlib.text import Text as MplText
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QLabel, QSizePolicy, QVBoxLayout, QWidget
 
+from fibsem.ui.stylesheets import CANVAS_BG, GRAY_WHITE_COLOR, OK_COLOR
+
 _logger = logging.getLogger(__name__)
 
-# Colours
-_COLOR_ENABLED = "#4CAF50"
+# Colours. The local names say what each is *for* here; the shared constants say
+# what the value is, so the two stay in step without this file naming a shade.
+_COLOR_ENABLED = OK_COLOR
 _COLOR_ENABLED_EDGE = "#81C784"
 _COLOR_DISABLED = "#37474F"
 _COLOR_DISABLED_EDGE = "#546E7A"
 _COLOR_DISABLED_ALPHA = 0.45
-_COLOR_BG = "#1e2124"
-_COLOR_TEXT = "#FFFFFF"
+_COLOR_BG = CANVAS_BG
+_COLOR_TEXT = GRAY_WHITE_COLOR
 _COLOR_TEXT_DISABLED = "#78909C"
 
 _TILE_PAD = 0.06   # fractional gap in grid-unit mode

--- a/fibsem/ui/widgets/workflow_summary_dialog.py
+++ b/fibsem/ui/widgets/workflow_summary_dialog.py
@@ -22,21 +22,31 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from fibsem.ui.stylesheets import PRIMARY_BUTTON_STYLESHEET
+from fibsem.ui.stylesheets import (
+    BORDER_COLOR,
+    PANEL_COLOR,
+    PRIMARY_BUTTON_STYLESHEET,
+    ROW_ALT_COLOR,
+    SURFACE_COLOR,
+    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
+    TEXT_STRONG_COLOR,
+)
 from fibsem.ui.widgets.task_summary_formatting import (
     STATUS_BADGE_COLORS,
     STATUS_CHIP_ORDER,
     format_duration_short,
 )
 
-# Palette (matching fibsem.ui.stylesheets napari theme)
-_BG = "#262930"
-_PANEL = "#1e2027"
-_ROW_ALT = "#2b2f38"
-_BORDER = "#3d4251"
-_TEXT = "#d6d6d6"
-_TEXT_STRONG = "#f0f1f2"
-_TEXT_MUTED = "#868e93"
+# Short local names for the shared palette. These appear inside dozens of
+# f-strings below, where the full names would wrap every one of them.
+_BG = SURFACE_COLOR
+_PANEL = PANEL_COLOR
+_ROW_ALT = ROW_ALT_COLOR
+_BORDER = BORDER_COLOR
+_TEXT = TEXT_COLOR
+_TEXT_STRONG = TEXT_STRONG_COLOR
+_TEXT_MUTED = TEXT_MUTED_COLOR
 
 _TABLE_STYLE = f"""
 QTableWidget {{

--- a/fibsem/ui/widgets/workflow_timeline_widget.py
+++ b/fibsem/ui/widgets/workflow_timeline_widget.py
@@ -28,7 +28,7 @@ from fibsem.ui.icon import fibsem_icon
 _DOT_COMPLETED  = stylesheets.GREEN_COLOR
 _DOT_ACTIVE     = "#ff9800"
 _DOT_PENDING    = "#606060"
-_DOT_FAILED     = "#99121F"
+_DOT_FAILED     = stylesheets.RED_COLOR
 _DOT_SKIPPED    = "#9e9e9e"
 # Slate, not amber: the old #e0a030 was indistinguishable from the active orange,
 # so a cancelled row read as still running — especially when it was the last thing

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -552,3 +552,33 @@ def test_the_type_column_fits_the_widest_row_of_chips(qapp, tmp_path):
         for row in range(dialog.table.rowCount())
     )
     assert dialog.table.columnWidth(1) >= widest
+
+
+def test_no_widget_swallows_its_own_tooltip(qapp, tmp_path):
+    """A selector-less stylesheet on a widget also styles the QToolTip over it.
+
+    It beats the application sheet because it sits nearer, so
+    ``background: transparent`` on a table cell leaves that cell's tooltip as
+    floating text with no panel behind it -- unreadable against whatever is
+    underneath. The four tooltips this dialog sets were all affected.
+
+    Asserted over every widget rather than the four known ones: the trap is that
+    a widget acquires a tooltip later, and nothing about ``setStyleSheet`` warns
+    you. ``_style()`` restates the tooltip rule; rules that name their own type
+    do not leak and are left alone.
+
+    Not verifiable by rendering -- the offscreen platform never realises a
+    tooltip window, so QTipLabel is absent from topLevelWidgets().
+    """
+    from PyQt5.QtWidgets import QWidget
+
+    _write(tmp_path, "demo.py", '"""A demo script.\n\nReads the experiment.\n"""\ndef run(ctx):\n    pass\n')
+    dialog = _dialog(tmp_path, context=FakeContext())
+
+    offenders = [
+        (type(w).__name__, w.styleSheet()[:60])
+        for w in dialog.findChildren(QWidget) + [dialog]
+        if w.styleSheet().strip() and "{" not in w.styleSheet()
+    ]
+
+    assert offenders == []

--- a/tests/ui/test_shared_palette.py
+++ b/tests/ui/test_shared_palette.py
@@ -1,0 +1,58 @@
+"""No widget should re-declare a colour that already exists in stylesheets.py.
+
+Five hand-built dialogs had each pasted the same napari-dark palette locally, and
+four of those values already existed in ``stylesheets.py`` under shade-derived
+names -- ``#262930`` was ``GRAY_BACKGROUND_COLOR``, ``#d04040`` was
+``DEFECT_RED_COLOR``. Nothing detects that: the copies agree until someone
+adjusts one of them, and then two dialogs disagree with the rest of the app for
+no reason anybody can see in a diff.
+
+So the rule is enforced rather than documented: if a colour is already in
+stylesheets.py, import it.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+WIDGETS = Path(__file__).resolve().parents[2] / "fibsem" / "ui" / "widgets"
+STYLESHEETS = Path(__file__).resolve().parents[2] / "fibsem" / "ui" / "stylesheets.py"
+
+_DECLARATION = re.compile(r'^(_?[A-Z][A-Z_0-9]*) *= *"(#[0-9a-fA-F]{3,8})"', re.M)
+
+
+def _shared_colours():
+    """{value: [names]} for every colour constant in stylesheets.py."""
+    shared = {}
+    for name, value in _DECLARATION.findall(STYLESHEETS.read_text()):
+        shared.setdefault(value.lower(), []).append(name)
+    return shared
+
+
+def _widget_modules():
+    return sorted(p for p in WIDGETS.glob("*.py") if p.name != "__init__.py")
+
+
+def test_stylesheets_itself_has_the_palette():
+    """Guard the guard: a typo in the regex would make every case below vacuous."""
+    shared = _shared_colours()
+    assert shared.get("#262930")  # SURFACE_COLOR / GRAY_BACKGROUND_COLOR
+    assert shared.get("#1e2027")  # PANEL_COLOR
+    assert len(shared) > 20
+
+
+@pytest.mark.parametrize("module", _widget_modules(), ids=lambda p: p.name)
+def test_no_widget_redeclares_a_shared_colour(module):
+    shared = _shared_colours()
+
+    offenders = [
+        f"{name} = {value!r} is already {' / '.join(shared[value.lower()])}"
+        for name, value in _DECLARATION.findall(module.read_text())
+        if value.lower() in shared
+    ]
+
+    assert offenders == [], (
+        f"{module.name} re-declares colours that stylesheets.py already defines. "
+        f"Import them instead: " + "; ".join(offenders)
+    )

--- a/tests/ui/test_shared_palette.py
+++ b/tests/ui/test_shared_palette.py
@@ -1,6 +1,6 @@
-"""No widget should re-declare a colour that already exists in stylesheets.py.
+"""Nothing should re-declare a colour that already exists in stylesheets.py.
 
-Five hand-built dialogs had each pasted the same napari-dark palette locally, and
+Six hand-built dialogs had each pasted the same napari-dark palette locally, and
 four of those values already existed in ``stylesheets.py`` under shade-derived
 names -- ``#262930`` was ``GRAY_BACKGROUND_COLOR``, ``#d04040`` was
 ``DEFECT_RED_COLOR``. Nothing detects that: the copies agree until someone
@@ -16,8 +16,8 @@ from pathlib import Path
 
 import pytest
 
-WIDGETS = Path(__file__).resolve().parents[2] / "fibsem" / "ui" / "widgets"
-STYLESHEETS = Path(__file__).resolve().parents[2] / "fibsem" / "ui" / "stylesheets.py"
+PACKAGE = Path(__file__).resolve().parents[2] / "fibsem"
+STYLESHEETS = PACKAGE / "ui" / "stylesheets.py"
 
 _DECLARATION = re.compile(r'^(_?[A-Z][A-Z_0-9]*) *= *"(#[0-9a-fA-F]{3,8})"', re.M)
 
@@ -30,8 +30,29 @@ def _shared_colours():
     return shared
 
 
-def _widget_modules():
-    return sorted(p for p in WIDGETS.glob("*.py") if p.name != "__init__.py")
+def _modules():
+    """Modules for which importing the palette is free.
+
+    Everything under ``fibsem/ui``, plus anything elsewhere that already imports
+    ``stylesheets``. Not the whole package, and the boundary is not arbitrary:
+    ``fibsem/ui/__init__`` imports the widget layer, so ``import
+    fibsem.ui.stylesheets`` from outside costs 133 fibsem modules instead of the
+    one it looks like. Applying this rule to ``correlation/fit_diagnostics.py``
+    tripled that module's import weight, and ``correlation.util`` imports it at
+    module level -- so every correlation user would have paid for the entire UI.
+
+    Scoped to ``fibsem/ui/widgets/*.py`` alone at first, which is how a sixth
+    full copy of the palette in ``fibsem/ui/fm/widgets`` went unnoticed: a
+    boundary drawn where the search happened to start is not one the next dialog
+    will respect.
+    """
+    modules = []
+    for path in PACKAGE.rglob("*.py"):
+        if path == STYLESHEETS:
+            continue
+        if PACKAGE / "ui" in path.parents or "stylesheets" in path.read_text():
+            modules.append(path)
+    return sorted(modules)
 
 
 def test_stylesheets_itself_has_the_palette():
@@ -42,8 +63,8 @@ def test_stylesheets_itself_has_the_palette():
     assert len(shared) > 20
 
 
-@pytest.mark.parametrize("module", _widget_modules(), ids=lambda p: p.name)
-def test_no_widget_redeclares_a_shared_colour(module):
+@pytest.mark.parametrize("module", _modules(), ids=lambda p: p.name)
+def test_no_module_redeclares_a_shared_colour(module):
     shared = _shared_colours()
 
     offenders = [


### PR DESCRIPTION
Two related changes to the hand-built dark-theme dialogs: one removes duplication, the other fixes a bug that duplication was hiding. They share a file and a helper, so they are here together.

## The duplication

Six dialogs had each pasted the same napari-dark palette locally, byte-identical. Four of those values already existed in `stylesheets.py` under shade-derived names:

| local | value | already was |
|---|---|---|
| `_BG` | `#262930` | `GRAY_BACKGROUND_COLOR` |
| `_TEXT_MUTED` | `#868e93` | `GRAY_SECONDARY_COLOR` |
| `_TEXT_STRONG` | `#f0f1f2` | `GRAY_TEXT_COLOR` |
| `_ERROR` | `#d04040` | `DEFECT_RED_COLOR` |
| `_OK` | `#4caf50` | `AUTOMATED_COLOR` *and* `GREEN_COLOR` |

Nothing detects this. The copies agree right up until someone adjusts one, and then two dialogs disagree with the rest of the app for no reason visible in a diff.

Adds a role-named set — `SURFACE_COLOR`, `PANEL_COLOR`, `ROW_ALT_COLOR`, `BORDER_COLOR`, `TEXT_COLOR`, `TEXT_STRONG_COLOR`, `TEXT_MUTED_COLOR`, `ACCENT_COLOR`, `OK_COLOR`, `ERROR_COLOR` — **alongside** the legacy `GRAY_*` names rather than renaming them, since that churn would reach well past the widgets that share this palette. A comment lists the overlaps so nobody adds a third spelling.

Each widget keeps its short local name as an alias (`_BG = SURFACE_COLOR`): the value gets one home, and the dozens of f-strings below are untouched. `ElidedLabel`, `chip()` and `style_with_tooltip()` move to `custom_widgets.py`.

Left local on purpose: `_MICROSCOPE`/`_WRITES` (script-specific semantics), `_HEADER_BG` in the fluorescence viewer (`#1e2124`, a *different* near-black from `_PANEL` — it is `CANVAS_BG`, and now imports it).

## The bug

A stylesheet set on a widget with no selector applies to every type Qt renders through it, the `QToolTip` included — and it beats the application sheet because it sits nearer. So `background: transparent` on a table cell leaves that cell's tooltip as floating text with nothing behind it, unreadable against whatever is underneath.

Fifteen widgets in the Scripts dialog carried such a rule; four had live tooltips. `style_with_tooltip()` restates the tooltip rule alongside. Rules that name their own type (`QPushButton {...}`) cannot leak and are left alone.

I tried to find the offenders statically twice and got it backwards both times: an f-string's interpolation braces are indistinguishable from a CSS block, so `"{" in css` answers the opposite question depending on how you read it. The test therefore walks every widget of a constructed dialog rather than checking the four known ones — the trap is a widget acquiring a tooltip later, which nothing about `setStyleSheet` warns you about. Not verifiable by rendering: the offscreen platform never realises a tooltip window.

## Testing

- Both dialogs render **pixel-identical** to pristine `main`, which is the whole safety argument for the palette move. It also confirms the tooltip change is inert on the dialogs themselves.
- A second test refuses any widget re-declaring a colour `stylesheets.py` already defines. It immediately found four more files (`tiled_overview_widget`, `workflow_timeline_widget`, `spot_burn_coordinates_widget`, `autolamella_load_experiment_widget`), migrated here rather than grandfathered — a guard with an exemption list invites "why is my file exempt". `workflow_timeline_widget` was already using `stylesheets.GREEN_COLOR` two lines above its hardcoded red.
- Both new guards mutation-tested.
- Full suite: 2118 passed, 24 skipped.

## Scope of the guard

The guard first globbed only `fibsem/ui/widgets/*.py`, and CI caught the consequence immediately: `coincidence_milling_confirmation_dialog.py` landed on `main` in #258 *after* this branch was cut, with `#262930` pasted in again. The branch was green locally; the merge commit was not — which is where a guard like this should bite.

Widening it turned up 11 more declarations across 6 files, including a **sixth full copy of the palette** in `fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py` — the dialog the coincidence one imports its chip helper from.

It does **not** cover the whole package, and that boundary is measured rather than assumed. `fibsem/ui/__init__` imports the widget layer, so `import fibsem.ui.stylesheets` from outside costs 133 fibsem modules instead of the one it looks like. Applying the rule to `correlation/fit_diagnostics.py` took that module from 44 to 133, and `correlation.util` imports it at module level — so every correlation user would have paid for the entire UI stack to avoid repeating two hex strings. That file keeps its literals; the guard covers `fibsem/ui` plus anything elsewhere that already imports `stylesheets`.

## On the pixel comparison

`scripts.png` renders identically to `main`, which is the safety argument for the palette move. `about.png` does **not**, and cannot: the About dialog displays the git revision, which differs by commit and gains a `-dirty` suffix on an uncommitted tree. That baseline was giving a false signal in both directions.

The real guarantee is a runtime check — import every migrated module and assert each constant still holds its original literal. 26 constants across 14 modules, all identical.

## Follow-up

`WARN_COLOR` is deliberately absent: its only user is the plugins dialog in #222, which is not on `main` yet, so adding it here would mean guessing the value. It lands with that PR, which also drops its chip's coloured dot to adopt the shared `chip()`.

