### PR TITLE
[fibsem] Remove acquisition-time gamma correction (FIB-505)

### DIFF
--- a/fibsem/acquire.py
+++ b/fibsem/acquire.py
@@ -4,7 +4,6 @@ import copy
 import os
 from typing import Optional, Tuple
 
-from fibsem.autofunctions import gamma as autogamma
 from fibsem.autofunctions.acb import run_auto_contrast_brightness
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import (
@@ -48,9 +47,6 @@ def new_image(
     image = microscope.acquire_image(
         image_settings=settings,
     )
-
-    if settings.autogamma:
-        image = autogamma.auto_gamma(image, method="autogamma")
 
     # save image
     if settings.save:

--- a/fibsem/applications/autolamella/tools/reporting.py
+++ b/fibsem/applications/autolamella/tools/reporting.py
@@ -347,7 +347,6 @@ def generate_report2(experiment: Experiment,
     if sections["overview"]:
         try:
             filenames = glob.glob(os.path.join(experiment.path, "*overview*.tif"))
-            filenames = [f for f in filenames if "autogamma" not in f]
             if len(filenames) > 0:
                 pdf.add_page_break()
                 pdf.add_heading("Overview (Positions)")

--- a/fibsem/applications/autolamella/workflows/legacy/autoliftout.py
+++ b/fibsem/applications/autolamella/workflows/legacy/autoliftout.py
@@ -292,7 +292,6 @@ def land_needle_on_milled_lamella(
             beam_type=BeamType.ION,
             save=False,
             autocontrast=False,
-            autogamma=False,
             filename=None,
         )
     )
@@ -312,7 +311,6 @@ def land_needle_on_milled_lamella(
     microscope.move_manipulator_corrected(dx=0, dy=dz, beam_type=BeamType.ION)
 
     # restore imaging settings
-    settings.image.autogamma = True
     settings.image.reduced_area = None
 
     acquire.take_set_of_reference_images(
@@ -334,7 +332,6 @@ def _liftout_contact_detection(microscope: FibsemMicroscope, settings: Microscop
     settings.image.hfw = fcfg.REFERENCE_HFW_SUPER
     settings.image.filename = f"ref_{lamella.state.stage.name}_manipulator_land_initial"
     settings.image.save = True
-    settings.image.autogamma = False
     reduced_area = FibsemRectangle(
         0.2, 0.2, 0.70, 0.70
     )  # TODO: improve contact detection

--- a/fibsem/autofunctions/acb.py
+++ b/fibsem/autofunctions/acb.py
@@ -200,7 +200,6 @@ def run_auto_contrast_brightness(
         hfw=hfw,
         beam_type=beam_type,
         autocontrast=False,
-        autogamma=False,
         save=False,
         reduced_area=FibsemRectangle(0.25, 0.25, 0.5, 0.5)
     )

--- a/fibsem/autofunctions/autofocus.py
+++ b/fibsem/autofunctions/autofocus.py
@@ -360,7 +360,6 @@ def run_auto_focus(
         hfw=hfw,
         beam_type=beam_type,
         autocontrast=False,
-        autogamma=False,
         save=False,
         reduced_area=settings.reduced_area,
     )

--- a/fibsem/autofunctions/charge_neutralisation.py
+++ b/fibsem/autofunctions/charge_neutralisation.py
@@ -40,7 +40,6 @@ def auto_charge_neutralisation(
             beam_type=BeamType.ELECTRON,
             save=False,
             autocontrast=False,
-            autogamma=False,
             filename=None,
         )
 

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -19,7 +19,9 @@ import fibsem
 # `system_info` and `hardware_geometry` (FIB-481). from_dict recovers both from a v5-
 # and-earlier `system` blob, so older files still load -- including their compustage
 # flag, which up to v5 had to be inferred from the model name.
-METADATA_VERSION = "v6"
+# v7 dropped `autogamma` from the recorded image settings along with the feature
+# itself (FIB-505). Older files still carry the key; it is ignored.
+METADATA_VERSION = "v7"
 # What an unversioned file is. Absent means written before versioning existed, i.e.
 # older than v1 -- not "current", which is what defaulting to METADATA_VERSION claimed.
 UNVERSIONED_METADATA = "v0"

--- a/fibsem/config/microscope-configuration.yaml
+++ b/fibsem/config/microscope-configuration.yaml
@@ -51,7 +51,6 @@ imaging:
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
     imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               true                        # use autocontrast                                              [USER]
-    autogamma:                  false                       # use autogamma                                                 [USER]
     save:                       false                       # auto save images                                              [USER]
 milling:
     milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]

--- a/fibsem/config/odemis-configuration.yaml
+++ b/fibsem/config/odemis-configuration.yaml
@@ -51,7 +51,6 @@ imaging:
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
     imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               true                        # use autocontrast                                              [USER]
-    autogamma:                  false                       # use autogamma                                                 [USER]
     save:                       false                       # auto save images                                              [USER]
 milling:
     milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]

--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -52,7 +52,6 @@ imaging:
     dwell_time:                 1.0e-06                     
     imaging_current:            2.0e-11                     
     autocontrast:               false                        
-    autogamma:                  false                       
     save:                       false                       
 milling:
     milling_voltage:            30000                       

--- a/fibsem/config/tescan-configuration.yaml
+++ b/fibsem/config/tescan-configuration.yaml
@@ -51,7 +51,6 @@ imaging:
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
     imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               false                        # use autocontrast                                              [USER]
-    autogamma:                  false                       # use autogamma                                                 [USER]
     save:                       false                       # auto save images                                              [USER]
 milling:
     milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]

--- a/fibsem/config/tfs-aquilos2-configuration.yaml
+++ b/fibsem/config/tfs-aquilos2-configuration.yaml
@@ -51,7 +51,6 @@ imaging:
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
     imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               true                        # use autocontrast                                              [USER]
-    autogamma:                  false                       # use autogamma                                                 [USER]
     save:                       false                       # auto save images                                              [USER]
 milling:
     milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]

--- a/fibsem/config/tfs-arctis-configuration.yaml
+++ b/fibsem/config/tfs-arctis-configuration.yaml
@@ -51,7 +51,6 @@ imaging:
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
     imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               true                        # use autocontrast                                              [USER]
-    autogamma:                  false                       # use autogamma                                                 [USER]
     save:                       false                       # auto save images                                              [USER]
 milling:
     milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]

--- a/fibsem/config/tfs-hydra-configuration.yaml
+++ b/fibsem/config/tfs-hydra-configuration.yaml
@@ -51,7 +51,6 @@ imaging:
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
     imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               true                        # use autocontrast                                              [USER]
-    autogamma:                  false                       # use autogamma                                                 [USER]
     save:                       false                       # auto save images                                              [USER]
 milling:
     milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -95,7 +95,7 @@ class TiledAcquisitionRunner:
         self.microscope = microscope
         self.settings = settings
         self.stop_event = stop_event
-        # _setup()        → _image_settings, _cryo, _prev_path, _prev_label,
+        # _setup()        → _image_settings, _prev_path, _prev_label,
         #                   _focus_stack_settings, _af_mode
         # _compute_grid() → _tiles, _ordered, _centre_position, _start_state,
         #                   _tile_stage_positions, _canvas, _dx_step, _dy_step
@@ -166,12 +166,9 @@ class TiledAcquisitionRunner:
     def _setup(self) -> None:
         """Prepare image settings and paths; emit initial progress signal."""
         image_settings = self.settings.image_settings
-        self._cryo = image_settings.autogamma  # capture before clearing below
         self._focus_stack_settings = self.settings.focus_stack_settings
         self._af_mode = self.settings.autofocus_settings.mode
 
-        # autogamma is applied post-stitch for cryo; disable during tile acquisition
-        image_settings.autogamma = False
         image_settings.autocontrast = False
         image_settings.save = True
         image_settings.reduced_area = None
@@ -349,12 +346,6 @@ class TiledAcquisitionRunner:
 
         filename = os.path.join(image.metadata.image_settings.path, self._prev_label)  # type: ignore
         image.save(filename)
-
-        if self._cryo:
-            from fibsem.autofunctions.gamma import auto_gamma
-            image = auto_gamma(image, method="autogamma")
-            filename = os.path.join(image.metadata.image_settings.path, f"{self._prev_label}-autogamma")  # type: ignore
-            image.save(filename)
 
         signal.emit({"msg": "Done", "counter": total_tiles, "total": total_tiles, "finished": True})
         return image

--- a/fibsem/microscopes/autoscript.py
+++ b/fibsem/microscopes/autoscript.py
@@ -206,7 +206,6 @@ def image_settings_from_adorned_image(
         hfw=image.width * image.metadata.binary_result.pixel_size.x,
         autocontrast=True,
         beam_type=beam_type,
-        autogamma=True,
         save=False,
         path="path",
         filename=current_timestamp(),

--- a/fibsem/microscopes/odemis_microscope.py
+++ b/fibsem/microscopes/odemis_microscope.py
@@ -194,7 +194,6 @@ def from_odemis_image(image: model.DataArray, path: str = None) -> FibsemImage:
         filename=filename,
         save = True,
         autocontrast=False,
-        autogamma=False,
     )
 
     image_md = FibsemImageMetadata(

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -561,7 +561,6 @@ class ImageSettings:
         beam_type (BeamType): The type of beam to use for image acquisition.
         save (bool): Whether or not to save the acquired image to disk.
         filename (str): The filename to use when saving the acquired image.
-        autogamma (bool): Whether or not to apply gamma correction to the acquired image.
         path (Path): The path to the directory where the acquired image should be saved.
         reduced_area (FibsemRectangle): The rectangular region of interest within the acquired image, if any.
 
@@ -572,6 +571,12 @@ class ImageSettings:
             Converts the ImageSettings object to a dictionary of image settings.
     """
 
+    # There was an `autogamma` flag here, which applied gamma correction to the pixels
+    # after acquisition. It was removed (FIB-505): unlike `autocontrast`, which
+    # configures the detector *before* the image exists, gamma is a display correction
+    # applied to the array afterwards -- and baking it into the stored data is
+    # destructive and unrecoverable. The canvas's ContrastGammaControl does it at
+    # display time instead, where it is adjustable and reversible.
     resolution: Tuple[int, int] = (1536, 1024)
     dwell_time: float = 1e-6
     hfw: float = 150e-6
@@ -579,7 +584,6 @@ class ImageSettings:
     beam_type: BeamType = BeamType.ELECTRON
     save: bool = False
     filename: str = "default_image"
-    autogamma: bool = False
     path: Optional[Union[Path, str]] = None
     reduced_area: Optional[FibsemRectangle] = None
     line_integration: Optional[int] = None  # (int32) 2 - 255
@@ -610,9 +614,6 @@ class ImageSettings:
             isinstance(self.filename, str) or self.filename is None
         ), f"filename must b str, currently is {type(self.filename)}"
         assert (
-            isinstance(self.autogamma, bool) or self.autogamma is None
-        ), f"gamma enabled setting must be bool, currently is {type(self.autogamma)}"
-        assert (
             isinstance(self.path, (Path, str)) or self.path is None
         ), f"save path must be Path or str, currently is {type(self.path)}"
         assert (
@@ -637,7 +638,6 @@ class ImageSettings:
             hfw=settings.get("hfw", 150e-6),
             autocontrast=settings.get("autocontrast", False),
             beam_type=BeamType[beam_name.upper()],
-            autogamma=settings.get("autogamma", False),
             save=settings.get("save", False),
             path=settings.get("path", os.getcwd()),
             filename=settings.get("filename", "default_image"),
@@ -658,9 +658,6 @@ class ImageSettings:
             "hfw": self.hfw if self.hfw is not None else None,
             "autocontrast": self.autocontrast
             if self.autocontrast is not None
-            else None,
-            "autogamma": self.autogamma
-            if self.autogamma is not None
             else None,
             "save": self.save if self.save is not None else None,
             "path": str(self.path) if self.path is not None else None,

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -99,7 +99,6 @@ OVERVIEW_IMAGE_PARAMETERS = {
     "fov": 500, # um
     "dwell_time": 1.0, # us
     "autocontrast": True,
-    "autogamma": False,
 }
 
 # Crosshair layer configuration constants
@@ -154,7 +153,6 @@ DEFAULT_OVERVIEW_ACQUISITION_SETTINGS = OverviewAcquisitionSettings(
         hfw=OVERVIEW_IMAGE_PARAMETERS["fov"] * constants.MICRO_TO_SI,
         dwell_time=OVERVIEW_IMAGE_PARAMETERS["dwell_time"] * constants.MICRO_TO_SI,
         autocontrast=OVERVIEW_IMAGE_PARAMETERS["autocontrast"],
-        autogamma=OVERVIEW_IMAGE_PARAMETERS["autogamma"],
         beam_type=BeamType.ELECTRON,
         save=True,
         path=None,  # will be set to experiment path when overview acquisition widget is initialized

--- a/fibsem/ui/widgets/autolamella_overview_image_widget.py
+++ b/fibsem/ui/widgets/autolamella_overview_image_widget.py
@@ -505,7 +505,6 @@ class OverviewImageWidget(QWidget):
             self.stage_positions = self.experiment.get_milling_positions()
 
             filenames = glob.glob(os.path.join(experiment.path, "*overview*.tif"))
-            filenames = [f for f in filenames if "autogamma" not in f]
             if filenames:
                 self._load_overview_image(filenames[-1])
         else:

--- a/fibsem/ui/widgets/microscope_config_widget.py
+++ b/fibsem/ui/widgets/microscope_config_widget.py
@@ -182,7 +182,6 @@ class MicroscopeConfigWidget(QWidget):
         self._dsb_imaging_dwell = _dsb(0, 10000, 4, suffix=" µs")
         self._dsb_imaging_current = _dsb(0, 1e6, 4, suffix=" nA")
         self._chk_autocontrast = QCheckBox()
-        self._chk_autogamma = QCheckBox()
         self._chk_autosave = QCheckBox()
         form.addRow("Beam Type", self._cb_imaging_beam_type)
         form.addRow("Resolution X (px)", self._sb_imaging_res_x)
@@ -191,7 +190,6 @@ class MicroscopeConfigWidget(QWidget):
         form.addRow("Dwell Time (µs)", self._dsb_imaging_dwell)
         form.addRow("Imaging Current (nA)", self._dsb_imaging_current)
         form.addRow("Autocontrast", self._chk_autocontrast)
-        form.addRow("Autogamma", self._chk_autogamma)
         form.addRow("Auto-save", self._chk_autosave)
         return w
 
@@ -341,7 +339,6 @@ class MicroscopeConfigWidget(QWidget):
         self._dsb_imaging_dwell.setValue(float(imaging.get("dwell_time", 1e-6)) * constants.SI_TO_MICRO)
         self._dsb_imaging_current.setValue(float(imaging.get("imaging_current", 0)) * constants.SI_TO_NANO)
         self._chk_autocontrast.setChecked(bool(imaging.get("autocontrast", True)))
-        self._chk_autogamma.setChecked(bool(imaging.get("autogamma", False)))
         self._chk_autosave.setChecked(bool(imaging.get("save", False)))
 
         milling = c.get("milling", {})
@@ -414,7 +411,6 @@ class MicroscopeConfigWidget(QWidget):
         c["imaging"]["dwell_time"] = self._dsb_imaging_dwell.value() * constants.MICRO_TO_SI
         c["imaging"]["imaging_current"] = self._dsb_imaging_current.value() * constants.NANO_TO_SI
         c["imaging"]["autocontrast"] = self._chk_autocontrast.isChecked()
-        c["imaging"]["autogamma"] = self._chk_autogamma.isChecked()
         c["imaging"]["save"] = self._chk_autosave.isChecked()
 
         c.setdefault("milling", {})

--- a/fibsem/ui/widgets/overview_acquisition_settings_widget.py
+++ b/fibsem/ui/widgets/overview_acquisition_settings_widget.py
@@ -22,7 +22,7 @@ class OverviewAcquisitionSettingsWidget(QWidget):
 
     Composes a tile-grid section (beam type, rows, cols, total FOV) on top of
     an embedded ImageSettingsWidget (resolution, dwell time, tile FOV,
-    autocontrast, autogamma, save, path, filename).
+    autocontrast, save, path, filename).
     """
 
     settings_changed = pyqtSignal()

--- a/tests/test_no_acquisition_time_gamma.py
+++ b/tests/test_no_acquisition_time_gamma.py
@@ -1,0 +1,114 @@
+"""Acquisition does not modify the pixels it returns.
+
+`ImageSettings` used to carry an `autogamma` flag that applied gamma correction to the
+array after acquisition. It went (FIB-505): unlike `autocontrast`, which configures the
+detector *before* the image exists, gamma is a display correction applied afterwards,
+and baking it into stored data is destructive and unrecoverable. The canvas applies it
+at display time instead, where it is adjustable.
+
+Nothing shipped ever enabled it -- all seven configuration files set it false -- so this
+removes a feature that was off everywhere rather than changing what anyone was getting.
+"""
+
+import inspect
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from fibsem import acquire
+from fibsem.structures import FibsemImageMetadata, ImageSettings
+
+CONFIG_DIR = Path(__file__).resolve().parents[1] / "fibsem" / "config"
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "metadata"
+
+
+def test_image_settings_has_no_gamma_flag() -> None:
+    """The request describes the acquisition. Gamma is not part of one."""
+    settings = ImageSettings()
+
+    assert not hasattr(settings, "autogamma")
+    assert "autogamma" not in settings.to_dict()
+
+
+def test_autocontrast_stays() -> None:
+    """It is a genuine instrument operation, and is deliberately unaffected."""
+    settings = ImageSettings()
+
+    assert hasattr(settings, "autocontrast")
+    assert "autocontrast" in settings.to_dict()
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_a_stored_configuration_carrying_the_old_flag_still_loads(value: bool) -> None:
+    """`autogamma` was a `[USER]` field, so a site's own config may still set it.
+
+    It is ignored rather than raising -- `from_dict` reads named keys, so an unknown one
+    passes through harmlessly. A site that had it on stops getting gamma baked into its
+    data, which is the point of the change.
+    """
+    settings = ImageSettings.from_dict(
+        {
+            "hfw": 50e-6,
+            "dwell_time": 1e-6,
+            "beam_type": "ELECTRON",
+            "autocontrast": True,
+            "autogamma": value,
+        }
+    )
+
+    assert settings.hfw == 50e-6
+    assert settings.autocontrast is True
+    assert not hasattr(settings, "autogamma")
+
+
+def test_images_written_before_v7_still_load() -> None:
+    """The fixtures are real instrument output and all carry the key."""
+    for fixture in FIXTURE_DIR.glob("*.json"):
+        raw = json.loads(fixture.read_text())
+        assert "autogamma" in raw["image"], f"{fixture.name} should predate v7"
+
+        metadata = FibsemImageMetadata.from_dict(raw)
+
+        assert metadata.image_settings.hfw is not None
+        assert "autogamma" not in metadata.to_dict()["image"]
+
+
+def test_no_shipped_configuration_still_declares_it() -> None:
+    """Leaving the key in would advertise a setting that does nothing."""
+    declaring = [
+        path.name for path in CONFIG_DIR.glob("*.yaml") if "autogamma" in path.read_text()
+    ]
+
+    assert declaring == []
+
+
+def test_acquisition_does_not_transform_the_array() -> None:
+    """The read that matters: no post-acquisition processing step remains.
+
+    Asserted against the source rather than by acquiring, because the point is the
+    absence of a call -- an acquisition test passes whether or not gamma ran, unless it
+    happens to pick data the correction would have changed.
+    """
+    source = inspect.getsource(acquire.acquire_image)
+
+    assert "auto_gamma" not in source
+    assert "autogamma" not in source
+
+
+def test_gamma_remains_available_to_call_deliberately() -> None:
+    """Removed from the acquisition path, not from the library.
+
+    Someone who wants gamma can still apply it; it is no longer applied on their behalf
+    and written to disk.
+    """
+    from fibsem.autofunctions.gamma import auto_gamma
+
+    from fibsem.structures import FibsemImage
+
+    image = FibsemImage(data=np.full((8, 8), 200, dtype=np.uint8))
+    corrected = auto_gamma(image, method="autogamma")
+
+    assert corrected.data.shape == image.data.shape


### PR DESCRIPTION
`ImageSettings` carried `autocontrast` and `autogamma` side by side as though they were the same kind of thing. `acquire.py` shows they are not:

```python
if settings.autocontrast:
    microscope.autocontrast(...)      # instructs the INSTRUMENT, before

image = microscope.acquire_image(...)

if settings.autogamma:
    image = auto_gamma(image, ...)    # transforms the ARRAY, after
```

They sit on opposite sides of the acquisition. Autocontrast configures the detector before the image exists and **stays**. Gamma is a display correction applied to the pixels afterwards, and baking it into stored data is destructive — the raw values are not recoverable from the corrected ones. The canvas already has a `ContrastGammaControl` that applies it at display time, per-channel for FM, where it is adjustable and reversible. That is the right layer.

**22 files, +11 −48.** Almost entirely deletions.

## Nothing shipped enabled it

All seven configuration files set `autogamma: false`. The only two places passing `True`:

* `microscopes/autoscript.py:209` — a helper that *reconstructs* `ImageSettings` from an already-acquired image. It also hardcodes `path="path"`, so the flags there are placeholder noise, and nothing runs off them.
* `workflows/legacy/autoliftout.py:315` — legacy, no live callers.

So this removes a feature that was off everywhere rather than changing what anyone was getting.

## What that means downstream

**Three call sites existed only to decline it.** `acb.py`, `autofocus.py` and `charge_neutralisation.py` each passed `autogamma=False` because they need raw data. Having to say "do not post-process my image" inside an acquisition request was the smell. Deleted.

**`tiled.py` was reading the flag as something else entirely.** It captured `image_settings.autogamma` into `self._cryo`, cleared it, then applied gamma post-stitch and wrote a second `{label}-autogamma.tif`. The flag being false everywhere means that branch never ran and those files were never written — which in turn means the two filters

```python
filenames = [f for f in filenames if "autogamma" not in f]
```

in the overview widget and the report were guarding against files that no longer get created. That was **FIB-484's entire stated evidence** for missing processing lineage. All gone.

## What stays

`autofunctions/gamma.py` is untouched. `auto_gamma` and `apply_clahe` remain callable — removed from the acquisition path, not from the library. Anyone who wants gamma can apply it deliberately rather than having it applied on their behalf and written to disk.

`autocontrast` is deliberately unaffected, and there is a test asserting so.

## Compatibility

`METADATA_VERSION` → v7. Older images and site configurations still carry the key and load fine — `from_dict` reads named keys, so an unknown one passes through harmlessly. Covered against the four real metadata fixtures, all of which predate v7 and carry it.

A site that had it enabled in their own config stops getting gamma baked into their data. That is the intent, and they have the display-time control.

## Verification

2648 passed, 24 skipped. Eight new tests, including that acquisition no longer transforms the array, that no shipped config still declares the key, and that the gamma functions remain callable.