### PR TITLE
[fibsem] Record which item and task an image was acquired for (FIB-466)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -162,6 +162,12 @@ class AutoLamellaTask(ABC):
                 logging.exception(f"Could not record the outcome of {self.task_name}")
             self._fire_hook("task_cancelled" if cancelled else "task_failed", error=str(e))
             raise
+        finally:
+            # In a finally, not in post_task, which never runs when _run() raises. Left
+            # set, the next thing acquired -- an operator looking at what went wrong,
+            # a supervision step -- would be stamped with the task that just failed.
+            # That is silently wrong, and wrong exactly when the record matters most.
+            self.microscope.experiment.clear_workflow_metadata()
         self.post_task()
         self._fire_hook("task_completed")
 
@@ -233,6 +239,16 @@ class AutoLamellaTask(ABC):
         self.lamella.task_state.status = AutoLamellaTaskStatus.InProgress
         self.lamella.task_state.status_message = ""
         self.lamella.task_state.outputs = {}
+
+        # Stamp onto everything acquired from here until run() clears it, so an image
+        # says which lamella and task produced it rather than relying on which folder
+        # it happens to sit in (FIB-466).
+        self.microscope.experiment.set_workflow_metadata(
+            item_id=self.lamella.id,
+            item_name=self.lamella.name,
+            task_id=self.task_id,
+            task_name=self.task_name,
+        )
         self.log_status_message(message="STARTED",
                                 display_message="Started",
                                 workflow_display_message=f"{self.lamella.name} [{self.display_name}]")

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -21,7 +21,10 @@ import fibsem
 # flag, which up to v5 had to be inferred from the model name.
 # v7 dropped `autogamma` from the recorded image settings along with the feature
 # itself (FIB-505). Older files still carry the key; it is ignored.
-METADATA_VERSION = "v7"
+# v8 added `workflow` -- which item and which task an image was acquired for
+# (FIB-466). Absent in earlier files, and absent in any image acquired outside a
+# workflow, which is a real answer rather than a missing one.
+METADATA_VERSION = "v8"
 # What an unversioned file is. Absent means written before versioning existed, i.e.
 # older than v1 -- not "current", which is what defaulting to METADATA_VERSION claimed.
 UNVERSIONED_METADATA = "v0"

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import threading
 from abc import ABC
+from copy import deepcopy
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Optional, Tuple, Union, Literal
 
@@ -945,6 +946,11 @@ class FluorescenceMicroscope(ABC):
         # parent records nothing rather than recording a default that looks valid.
         geometry = self.parent.fm_image_geometry() if self.parent else None
 
+        # Which experiment, item and task, from the same place the beam path reads it.
+        # Copied rather than referenced: the workflow half is rewritten as the run
+        # moves on, and an image should keep saying where it was taken (FIB-466).
+        experiment = deepcopy(self.parent.experiment) if self.parent else None
+
         # Create complete image metadata
         return FluorescenceImageMetadata(
             acquisition_date=datetime.now().isoformat(),
@@ -953,6 +959,7 @@ class FluorescenceMicroscope(ABC):
             resolution=(self.camera.resolution[0], self.camera.resolution[1]),
             stage_position=stage_position,
             geometry=geometry,
+            experiment=experiment,
             channels=[channel_metadata],
         )
 

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -51,6 +51,7 @@ from ome_types.model import (
 from fibsem.structures import (  # noqa: F401
     AutoFocusMode,
     CameraImageTransform,
+    FibsemExperimentRef,
     FibsemHardwareGeometry,
     FibsemRectangle,
     FibsemStagePosition,
@@ -848,6 +849,10 @@ class FluorescenceImage:
             filename=self.metadata.filename,
             description=self.metadata.description,
             system_info=self.metadata.system_info,
+            # A projection of a lamella's image is still that lamella's. Carried
+            # forward so a derived image does not lose what produced it (FIB-466).
+            experiment=self.metadata.experiment,
+            geometry=self.metadata.geometry,
             dimension_order=self.metadata.dimension_order,
         )
 
@@ -980,6 +985,10 @@ class FluorescenceImage:
             filename=self.metadata.filename,
             description=self.metadata.description,
             system_info=self.metadata.system_info,
+            # A projection of a lamella's image is still that lamella's. Carried
+            # forward so a derived image does not lose what produced it (FIB-466).
+            experiment=self.metadata.experiment,
+            geometry=self.metadata.geometry,
             dimension_order=self.metadata.dimension_order,
         )
 
@@ -1217,6 +1226,13 @@ class FluorescenceImageMetadata:
     # the right place.
     geometry: Optional[FibsemHardwareGeometry] = None
 
+    # Which experiment, item and task produced this. The same record the beam path
+    # carries, for the same reason: a forwarded file should say what produced it
+    # without the surrounding directory (FIB-466). None on images written before this
+    # was recorded, on ones acquired outside a workflow, and on ones written by other
+    # software -- `from_ome` reconstructs from OME's own fields and cannot recover it.
+    experiment: Optional[FibsemExperimentRef] = None
+
     # File information
     filename: Optional[str] = None  # original filename
     description: Optional[str] = None  # image description/notes
@@ -1276,6 +1292,7 @@ class FluorescenceImageMetadata:
             "description": self.description,
             "system_info": self.system_info,
             "geometry": self.geometry.to_dict() if self.geometry else None,
+            "experiment": self.experiment.to_dict() if self.experiment else None,
             "channels": [
                 {
                     "name": ch.name,
@@ -1349,11 +1366,24 @@ class FluorescenceImageMetadata:
                 if metadata_dict.get("geometry")
                 else None
             ),
+            experiment=(
+                FibsemExperimentRef.from_dict(metadata_dict["experiment"])
+                if metadata_dict.get("experiment")
+                else None
+            ),
         )
     
     @classmethod
     def from_ome(cls, ome: OMEMetadata) -> 'FluorescenceImageMetadata':
-        """Convert OME metadata to FluorescenceImageMetadata with availability checks."""
+        """Convert OME metadata to FluorescenceImageMetadata with availability checks.
+
+        For importing images from **external software**. `load` prefers the
+        `FluorescenceImageMetadata` map annotation, which is what this package writes
+        and which round-trips everything; this reconstructs from OME's own structured
+        fields, so anything with no OME equivalent -- `system_info`, `geometry`,
+        `experiment` -- comes back None. That is the honest answer for a file another
+        program produced, not a gap to fill in with defaults.
+        """
 
         # TODO: add test cases for this function
         # TODO: support loading power, gain, offset from OME if available

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -112,9 +112,9 @@ from fibsem.structures import (
     FibsemManipulatorPosition,
     FibsemMillingSettings,
     FibsemPatternSettings,
+    FibsemPolygonSettings,
     FibsemRectangle,
     FibsemRectangleSettings,
-    FibsemPolygonSettings,
     FibsemStagePosition,
     FibsemUser,
     ImageSettings,
@@ -123,7 +123,6 @@ from fibsem.structures import (
     Point,
     RangeLimit,
     SystemSettings,
-    RangeLimit,
 )
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.transformations import get_stage_tilt_from_milling_angle
@@ -1611,7 +1610,11 @@ class FibsemMicroscope(ABC):
         change to what an image records meant finding all eight.
         """
         image.metadata.user = self.user
-        image.metadata.experiment = self.experiment
+        # Copied, not referenced. This now carries the item and task as well as the
+        # experiment (FIB-466), and those change as the run progresses -- sharing one
+        # object would rewrite the item on every image already acquired. It was shared
+        # before, which was harmless only because nothing mutated it.
+        image.metadata.experiment = deepcopy(self.experiment)
         # Copied, not referenced. `hardware_geometry()` returns a fresh record, so
         # aliasing the live SystemInfo here would leave one field on the image a
         # snapshot and the other a window onto the microscope. TescanMicroscope

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1989,10 +1989,21 @@ class FibsemExperimentRef:
     The deference rule applies here because a richer record exists to defer to. It
     does not apply to every embedded copy -- see ``FibsemUser``.
 
-    **Identity only.** Which experiment, and when. What software was running is a
-    property of the running system, not of an experiment, so it lives on
-    ``SystemInfo`` and only there (FIB-445 D1, FIB-448). This carried duplicates of
-    it until v5.
+    **Identity only.** Which experiment, which item, which task, and when. What
+    software was running is a property of the running system, not of an experiment,
+    so it lives on ``SystemInfo`` and only there (FIB-445 D1, FIB-448). This carried
+    duplicates of it until v5.
+
+    **Two write rates, one record.** The experiment is set once at registration; the
+    item and task change as a run progresses and are written and cleared around each
+    one (FIB-466). They are kept together because they are one answer to one question
+    -- *what produced this image* -- and a reader wants "experiment X, lamella Y, task
+    Z" in one place rather than assembled from two.
+
+    That only works because every image gets its **own copy**: `_set_additional_metadata`
+    deepcopies this. It used to be shared by reference, which was harmless while
+    nothing mutated it, and would have silently rewritten the item on every
+    already-acquired image the moment one did.
     """
 
     # Experiment.id, a UUID -- stable, the join key. Held the experiment *name* up to
@@ -2005,12 +2016,58 @@ class FibsemExperimentRef:
     # time rather than its own creation time.
     date: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
 
+    # Where in the run. None outside a workflow -- the minimap, a manual acquisition,
+    # a script -- which is a real answer rather than missing information.
+    #
+    # "item" rather than "lamella": the core library has no reason to know what an
+    # application works through one at a time, and ``HookContext`` settled on the same
+    # word for the same reason. IDs *and* names because they answer different
+    # questions -- the name is what a person reads, the id is what a reader joins on
+    # and it survives a rename. Recording only names is the mistake FIB-446 fixed for
+    # the experiment itself.
+    item_id: Optional[str] = None
+    item_name: Optional[str] = None
+    task_id: Optional[str] = None
+    task_name: Optional[str] = None
+
+    def set_workflow_metadata(
+        self,
+        item_id: Optional[str] = None,
+        item_name: Optional[str] = None,
+        task_id: Optional[str] = None,
+        task_name: Optional[str] = None,
+    ) -> None:
+        """Record what subsequent images should say about where in the run they were
+        taken, leaving experiment identity alone.
+
+        Named ``..._metadata`` because that is all it does. It does not start, select
+        or configure a workflow -- several widgets have a ``set_workflow*`` that does
+        something along those lines, and this is not one of them.
+        """
+        self.item_id = item_id
+        self.item_name = item_name
+        self.task_id = task_id
+        self.task_name = task_name
+
+    def clear_workflow_metadata(self) -> None:
+        """Stop stamping an item and task, keeping the experiment.
+
+        A method rather than four assignments at the call site: this has to run on
+        every path out of a task, and the one thing it must never do is take the
+        experiment's own identity with it.
+        """
+        self.set_workflow_metadata()
+
     def to_dict(self) -> dict:
         """Converts to a dictionary."""
         return {
             "id": self.id,
             "name": self.name,
             "date": self.date,
+            "item_id": self.item_id,
+            "item_name": self.item_name,
+            "task_id": self.task_id,
+            "task_name": self.task_name,
         }
 
     @staticmethod
@@ -2031,6 +2088,11 @@ class FibsemExperimentRef:
             # eras apart instead of being handed a name that claims to be an ID.
             name=settings.get("name"),
             date=settings.get("date", "Unknown"),
+            # Absent before v8, and in any image acquired outside a workflow.
+            item_id=settings.get("item_id"),
+            item_name=settings.get("item_name"),
+            task_id=settings.get("task_id"),
+            task_name=settings.get("task_name"),
         )
 
 

--- a/tests/autolamella/test_workflow_context_stamping.py
+++ b/tests/autolamella/test_workflow_context_stamping.py
@@ -1,0 +1,193 @@
+"""An image should say which item and task produced it, not rely on its folder.
+
+The association existed only as filesystem position -- every task hand-set
+`image_settings.path = self.lamella.path` -- which is lost the moment a file is
+copied, emailed or pulled into an export. See FIB-466.
+
+It is recorded on `FibsemExperimentRef` alongside the experiment, because that is one
+answer to one question. Two things have to hold for that to be safe: the workflow half
+is *cleared* on every path out of a task, and every image gets its own copy. A stale
+record stamps the previous lamella onto an image, and a shared one rewrites images
+already acquired -- both silent, both worse than recording nothing.
+"""
+
+import pytest
+
+from fibsem import utils
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskConfig,
+    Lamella,
+)
+from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+from fibsem.structures import BeamType, FibsemExperimentRef
+
+
+@pytest.fixture
+def microscope():
+    scope, _ = utils.setup_session(manufacturer="Demo")
+    scope.experiment = FibsemExperimentRef(id="exp-1", name="an-experiment")
+    return scope
+
+
+@pytest.fixture
+def lamella(tmp_path) -> Lamella:
+    return Lamella(path=str(tmp_path), petname="grand-dodo", number=1)
+
+
+class _Config(AutoLamellaTaskConfig):
+    task_type = "test-task"
+    display_name = "Test Task"
+
+
+class _Task(AutoLamellaTask):
+    """A task whose body is supplied per test, so failure paths are reachable."""
+
+    def __init__(self, microscope, lamella, body=None, **kwargs):
+        super().__init__(
+            microscope=microscope,
+            lamella=lamella,
+            config=_Config(task_name="Test Task"),
+            parent_ui=None,
+            **kwargs,
+        )
+        self._body = body or (lambda: None)
+
+    def _run(self) -> None:
+        self._body()
+
+
+def _stamped(microscope) -> FibsemExperimentRef:
+    """What an image acquired right now would carry."""
+    return microscope.acquire_image(beam_type=BeamType.ELECTRON).metadata.experiment
+
+
+def test_outside_a_workflow_there_is_no_item(microscope) -> None:
+    """The experiment is still recorded; the item simply is not, which is correct."""
+    stamped = _stamped(microscope)
+
+    assert stamped.id == "exp-1"
+    assert stamped.item_id is None
+    assert stamped.task_id is None
+
+
+def test_an_image_acquired_during_a_task_carries_both(microscope, lamella) -> None:
+    captured = {}
+
+    task = _Task(microscope, lamella, body=lambda: captured.update(seen=_stamped(microscope)))
+    task.run()
+
+    stamped = captured["seen"]
+    assert stamped.id == "exp-1"
+    assert stamped.item_id == lamella.id
+    assert stamped.item_name == lamella.name
+    assert stamped.task_id == task.task_id
+    assert stamped.task_name == "Test Task"
+
+
+def test_the_workflow_half_is_cleared_after_the_task_completes(microscope, lamella) -> None:
+    _Task(microscope, lamella).run()
+
+    assert _stamped(microscope).item_id is None
+
+
+def test_the_workflow_half_is_cleared_when_the_task_fails(microscope, lamella) -> None:
+    """The case the `finally` exists for.
+
+    `post_task` never runs when the body raises, so clearing there alone would leave
+    the record set. The next thing acquired -- an operator looking at what went wrong
+    -- would claim to belong to the task that just failed.
+    """
+
+    def explode():
+        raise RuntimeError("the task went wrong")
+
+    with pytest.raises(RuntimeError, match="the task went wrong"):
+        _Task(microscope, lamella, body=explode).run()
+
+    assert _stamped(microscope).item_id is None
+
+
+def test_clearing_the_workflow_keeps_the_experiment(microscope, lamella) -> None:
+    """The reason clearing is a method rather than four assignments at the call site."""
+    _Task(microscope, lamella).run()
+
+    assert microscope.experiment.id == "exp-1"
+    assert microscope.experiment.name == "an-experiment"
+
+
+def test_a_failing_task_still_stamped_while_it_ran(microscope, lamella) -> None:
+    """Clearing afterwards must not mean images from a failed task lose it.
+
+    Those are the ones worth having.
+    """
+    captured = {}
+
+    def acquire_then_fail():
+        captured["seen"] = _stamped(microscope)
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        _Task(microscope, lamella, body=acquire_then_fail).run()
+
+    assert captured["seen"].item_name == lamella.name
+
+
+def test_a_second_task_replaces_the_first(microscope, lamella) -> None:
+    first = _Task(microscope, lamella)
+    first.run()
+
+    captured = {}
+    second = _Task(microscope, lamella, body=lambda: captured.update(seen=_stamped(microscope)))
+    second.run()
+
+    assert captured["seen"].task_id == second.task_id
+    assert captured["seen"].task_id != first.task_id
+
+
+def test_each_image_keeps_its_own_copy(microscope, lamella) -> None:
+    """The record is mutated per task, so sharing one object would rewrite history.
+
+    This is what makes it safe to keep the item on the same record as the experiment:
+    without the deepcopy in `_set_additional_metadata`, moving to the next lamella
+    would silently relabel every image already acquired.
+    """
+    captured = {}
+
+    _Task(
+        microscope,
+        lamella,
+        body=lambda: captured.update(
+            image=microscope.acquire_image(beam_type=BeamType.ELECTRON)
+        ),
+    ).run()
+
+    image = captured["image"]
+    assert image.metadata.experiment.item_name == lamella.name
+
+    microscope.experiment.set_workflow_metadata(item_name="a-different-lamella")
+
+    assert image.metadata.experiment.item_name == lamella.name
+
+
+def test_the_record_round_trips(microscope, lamella) -> None:
+    captured = {}
+
+    _Task(
+        microscope, lamella, body=lambda: captured.update(seen=_stamped(microscope))
+    ).run()
+
+    stamped = captured["seen"]
+    assert FibsemExperimentRef.from_dict(stamped.to_dict()) == stamped
+
+
+def test_a_pre_v8_file_has_no_item() -> None:
+    """Images written before this existed load with the workflow half absent."""
+    legacy = {"id": "exp-1", "name": "an-experiment", "date": 1700000000.0}
+
+    ref = FibsemExperimentRef.from_dict(legacy)
+
+    assert ref.id == "exp-1"
+    assert ref.item_id is None
+    assert ref.item_name is None
+    assert ref.task_id is None
+    assert ref.task_name is None

--- a/tests/fm/test_fm_provenance.py
+++ b/tests/fm/test_fm_provenance.py
@@ -1,0 +1,146 @@
+"""A fluorescence image should say what produced it, like a beam image does.
+
+FM had the geometry (FIB-481) but not the experiment, so a forwarded OME-TIFF could
+say which instrument took it and under what arrangement, but not which run, lamella or
+task. Same record, same reason: the file has to stand alone. See FIB-466.
+"""
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from fibsem.fm.structures import (
+    FluorescenceChannelMetadata,
+    FluorescenceImage,
+    FluorescenceImageMetadata,
+)
+from fibsem.structures import FibsemExperimentRef
+
+
+def _experiment() -> FibsemExperimentRef:
+    ref = FibsemExperimentRef(id="exp-1", name="an-experiment")
+    ref.set_workflow_metadata(
+        item_id="lam-1",
+        item_name="grand-dodo",
+        task_id="task-9",
+        task_name="FM Acquisition",
+    )
+    return ref
+
+
+def _channel() -> FluorescenceChannelMetadata:
+    return FluorescenceChannelMetadata(
+        name="GFP",
+        color="#00FF00",
+        excitation_wavelength=488,
+        emission_wavelength=509,
+        power=1.0,
+        exposure_time=0.1,
+        gain=1.0,
+        offset=0.0,
+    )
+
+
+def _image(experiment=None, z: int = 1) -> FluorescenceImage:
+    metadata = FluorescenceImageMetadata(
+        acquisition_date="2026-08-05T00:00:00",
+        pixel_size_x=1e-7,
+        pixel_size_y=1e-7,
+        resolution=(16, 16),
+        channels=[_channel()],
+        experiment=experiment,
+    )
+    return FluorescenceImage(
+        data=np.zeros((1, z, 16, 16), dtype=np.uint16), metadata=metadata
+    )
+
+
+def test_an_fm_image_can_carry_the_experiment() -> None:
+    image = _image(_experiment())
+
+    assert image.metadata.experiment.item_name == "grand-dodo"
+    assert image.metadata.experiment.task_name == "FM Acquisition"
+
+
+def test_it_survives_an_ome_tiff_round_trip() -> None:
+    """The whole point: the record has to reach whoever receives the file.
+
+    It rides in the `FluorescenceImageMetadata` map annotation, which `load` reads in
+    preference to reconstructing from OME's own fields.
+    """
+    experiment = _experiment()
+
+    with tempfile.TemporaryDirectory() as directory:
+        path = os.path.join(directory, "fm.ome.tiff")
+        _image(experiment).save(path)
+        reloaded = FluorescenceImage.load(path)
+
+    assert reloaded.metadata.experiment == experiment
+
+
+def test_an_image_without_one_round_trips_as_none() -> None:
+    """Acquired outside a workflow, or written by other software."""
+    with tempfile.TemporaryDirectory() as directory:
+        path = os.path.join(directory, "fm.ome.tiff")
+        _image(None).save(path)
+        reloaded = FluorescenceImage.load(path)
+
+    assert reloaded.metadata.experiment is None
+
+
+def test_a_projection_keeps_what_produced_it() -> None:
+    """A projection of a lamella's image is still that lamella's."""
+    projected = _image(_experiment(), z=3).max_intensity_projection()
+
+    assert projected.metadata.experiment.item_name == "grand-dodo"
+    assert projected.metadata.experiment.id == "exp-1"
+
+
+def test_a_projection_keeps_the_geometry_it_was_captured_under() -> None:
+    """Separate bug, found alongside: the derived paths dropped `geometry`.
+
+    They carried `stage_position` and `system_info` forward but not this, so a
+    projected image could not be reprojected -- `fm/reprojection.py` raises on a
+    missing geometry rather than guessing, since a marker drawn in the wrong place
+    looks exactly like one drawn in the right place.
+    """
+    from fibsem.structures import FibsemHardwareGeometry
+
+    image = _image(_experiment(), z=3)
+    image.metadata.geometry = FibsemHardwareGeometry(
+        shuttle_pre_tilt=35.0, is_compustage=True
+    )
+
+    projected = image.max_intensity_projection()
+
+    assert projected.metadata.geometry is not None
+    assert projected.metadata.geometry.shuttle_pre_tilt == 35.0
+    assert projected.metadata.geometry.is_compustage is True
+
+
+def test_a_focus_stack_keeps_both() -> None:
+    """The other derived path, which had the same gap."""
+    from fibsem.structures import FibsemHardwareGeometry
+
+    image = _image(_experiment(), z=3)
+    image.metadata.geometry = FibsemHardwareGeometry(shuttle_pre_tilt=35.0)
+
+    stacked = image.focus_stack()
+
+    assert stacked.metadata.experiment.item_name == "grand-dodo"
+    assert stacked.metadata.geometry.shuttle_pre_tilt == 35.0
+
+
+@pytest.mark.parametrize("missing", [{}, {"experiment": None}])
+def test_metadata_written_before_this_existed_still_loads(missing: dict) -> None:
+    """`from_dict` is how a saved FM image is read back."""
+    base = _image(_experiment()).metadata.to_dict()
+    base.pop("experiment", None)
+    base.update(missing)
+
+    metadata = FluorescenceImageMetadata.from_dict(base)
+
+    assert metadata.experiment is None
+    assert metadata.pixel_size_x == 1e-7

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -490,7 +490,17 @@ def test_only_system_info_carries_the_software_versions():
         assert key in info, f"SystemInfo should own {key}"
         assert key not in ref, f"the experiment reference should not duplicate {key}"
 
-    assert set(ref) == {"id", "name", "date"}
+    # Identity, at both rates: which experiment (set once at registration) and where
+    # in it (set per task, FIB-466). Nothing about the software or the instrument.
+    assert set(ref) == {
+        "id",
+        "name",
+        "date",
+        "item_id",
+        "item_name",
+        "task_id",
+        "task_name",
+    }
     # Neither, since v5: it was declared in both and populated in neither. An
     # application inside fibsem has no version of its own, and fibsem_revision
     # already pins the commit doing the work.


### PR DESCRIPTION
An image said which instrument, user and experiment produced it, but not which **lamella** or which **task**. That association existed only as filesystem position — every task hand-sets `image_settings.path = self.lamella.path` — and is lost the moment a file is copied, emailed, or pulled into an export. The point of embedding metadata is that the file stands alone.

```json
"experiment": {
  "id": "20260716_train_grid1", "name": "...", "date": 1784188826.6,
  "item_id": "lam-1", "item_name": "grand-dodo",
  "task_id": "task-9", "task_name": "Mill Rough"
}
```

## On the experiment record, not beside it

Same category, same question — *what produced this image* — and a reader wants "experiment X, lamella Y, task Z" in one place rather than assembled from two blocks.

They do have different write rates: the experiment is registered once, the item and task change as the run progresses. Two methods rather than four assignments at each call site, so the one thing clearing must never do — take the experiment's identity with it — is not open-coded anywhere:

```python
experiment.set_workflow_metadata(item_id=..., task_id=...)
experiment.clear_workflow_metadata()
```

Named `..._metadata` because that is all they do. Several widgets already have a `set_workflow*` that starts or configures something; these do not.

**`item` rather than `lamella`** — the core library has no reason to know what an application works through one at a time, and `HookContext` settled on the same word for the same reason. IDs *and* names, because a name is what a person reads and an id is what a reader joins on and survives a rename.

## Two things make one record safe

**`_set_additional_metadata` now deepcopies the experiment.** It was assigned *by reference*, so every acquired image shared one object — harmless only because nothing mutated it. With the item on there, moving to the next lamella would have silently relabelled every image already acquired. Same class of bug as the `SystemInfo` aliasing fixed in FIB-481.

**The workflow half is cleared in a `finally`,** not in `post_task`, which never runs when a task raises. Left set, the next thing acquired — an operator looking at what went wrong, a supervision step — would be stamped with the task that just failed. Silently wrong, and wrong exactly when the record matters most. Tested both ways: cleared after a failure, but still stamped on images taken *during* one.

## Fluorescence too

Six lines, because the FM acquisition already reaches the parent microscope for its geometry, and the OME writer serialises `metadata.to_dict()` wholesale into a map annotation — so the field rides into OME-TIFF for free. Verified with a real write-and-reload round trip.

**Fixed while there:** `max_intensity_projection` and `focus_stack` carried `stage_position` and `system_info` forward but dropped `geometry`, so a projected image could not be reprojected — `fm/reprojection.py` raises on a missing geometry rather than guessing, since a marker drawn in the wrong place looks exactly like one drawn in the right place. Both now carry it, and the experiment.

## Backwards compatibility, checked against real files

`METADATA_VERSION` → v8. Not synthetic dicts:

* **252 real acquisition TIFFs** spanning v3–v5 — all load, workflow half `None`
* The six real Arctis/Aquilos files — load, `system_info` intact
* FM **annotation path** — absent fields return `None`, everything else intact
* FM **`from_ome`** (importing from external software) — `None` for everything with no OME equivalent, while still recovering what OME does carry

## Verification

2666 passed, 24 skipped. 18 new tests across the task lifecycle and the FM path.