### PR TITLE
[fm] Mark and save lamella positions from the FM overview (FIB-437)

### DIFF
--- a/fibsem/applications/autolamella/poses.py
+++ b/fibsem/applications/autolamella/poses.py
@@ -1,0 +1,178 @@
+"""Deriving a lamella's poses from the position it was marked at.
+
+A lamella carries two poses: where it is milled, and where it is looked at under
+fluorescence. Only one of them is ever picked by a user — the other is derived by
+re-posing the stage position into the other orientation.
+
+Which one was picked depends on where the marking happened, and *that* is the thing
+worth being careful about. Every caller until now marked positions on the beam side, so
+`AutoLamellaUI.add_new_lamella` could take its argument as the milling pose and derive
+the fluorescence pose from it. The FM overview tab marks positions on the fluorescence
+side, and handing one of those to the same function sets a milling pose at t = -180 --
+an orientation nothing mills at. Nothing rejects it; it fails later, somewhere else.
+
+So the orientation is read off the position rather than assumed. It is already there,
+in the rotation and tilt, which is how `get_target_position` works at all.
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from fibsem.structures import FibsemStagePosition, MicroscopeState
+
+if TYPE_CHECKING:  # pragma: no cover - annotation only
+    from fibsem.microscope import FibsemMicroscope
+
+# The orientation a lamella is milled at, when one has to be chosen rather than
+# recovered. See `build_lamella_poses` for when that happens.
+MILLING_ORIENTATION = "MILLING"
+
+FLUORESCENCE_ORIENTATION = "FM"
+
+
+@dataclass(frozen=True)
+class LamellaPoses:
+    """Both poses for a lamella, whichever side it was marked from.
+
+    `fluorescence` is None when the microscope has no fluorescence detector — there is
+    nothing to derive it from, and a pose invented for an instrument that does not exist
+    would be worse than its absence.
+    """
+
+    milling: MicroscopeState
+    fluorescence: Optional[MicroscopeState] = None
+
+
+def build_lamella_poses(
+    microscope: "FibsemMicroscope",
+    position: Optional[FibsemStagePosition] = None,
+    objective_position: Optional[float] = None,
+    state: Optional[MicroscopeState] = None,
+    marked_at: Optional[str] = None,
+) -> LamellaPoses:
+    """The milling and fluorescence poses for a lamella marked at *position*.
+
+    *position* may be in any orientation. A position in the fluorescence orientation is
+    taken as the fluorescence pose and the milling pose derived from it; anything else
+    is taken as the milling pose, which is what every beam-side caller has always meant.
+
+    Args:
+        microscope: the instrument, for the orientation transform and the objective.
+        position: where the lamella was marked. Defaults to where the stage is.
+        objective_position: the focus for the fluorescence pose. Defaults to the
+            objective's configured focus position, which is what a beam-side caller
+            wants — it has no way to know a better one.
+        state: the microscope state to base both poses on. Defaults to the live one.
+        marked_at: the orientation *position* is in, for a caller that knows. Defaults
+            to reading it off the position, which is right on a compustage and **not
+            good enough on an offset mount** — see below.
+
+    Raises:
+        ValueError: if a fluorescence position is given on a system that cannot convert
+            it to a beam orientation.
+
+    Note:
+        Orientation is normally derived rather than declared, because it is already in
+        the rotation and tilt and a caller that has to declare it is a caller that can
+        get it wrong — which is the bug this function exists to remove.
+
+        That fails on an offset mount, where the fluorescence position is distinguished
+        by travelling ~48 mm in x and *not* by its tilt. Measured on the simulator, the
+        FM and FIB orientations there share a tilt of 17 degrees and both classify as
+        MILLING, so a fluorescence position is indistinguishable from somewhere to mill.
+        A caller that knows which side it is marking from says so, and gets a refusal
+        rather than a plausible wrong answer.
+    """
+    state = deepcopy(state if state is not None else microscope.get_microscope_state())
+    if position is not None:
+        state.stage_position = deepcopy(position)
+
+    if marked_at is None:
+        marked_at = microscope.get_stage_orientation(state.stage_position)
+
+    if marked_at == FLUORESCENCE_ORIENTATION:
+        milling_position = _to_milling(microscope, state.stage_position)
+        fluorescence_position = deepcopy(state.stage_position)
+    else:
+        # Unchanged from what every beam-side caller has always got: the position is
+        # the milling pose verbatim, whatever orientation it happens to be in. That is
+        # not always the MILLING orientation -- a lamella marked while looking at the
+        # SEM keeps the SEM tilt -- and `update_milling_angle` derives the angle from
+        # whatever is there, so re-posing it here would change existing behaviour.
+        milling_position = deepcopy(state.stage_position)
+        fluorescence_position = _to_fluorescence(microscope, state.stage_position)
+
+    milling = deepcopy(state)
+    milling.stage_position = milling_position
+
+    if microscope.fm is None or fluorescence_position is None:
+        return LamellaPoses(milling=milling, fluorescence=None)
+
+    fluorescence = deepcopy(state)
+    fluorescence.stage_position = fluorescence_position
+    if objective_position is None:
+        objective_position = microscope.fm.objective.focus_position
+    fluorescence.objective_position = objective_position
+
+    return LamellaPoses(milling=milling, fluorescence=fluorescence)
+
+
+def _to_milling(
+    microscope: "FibsemMicroscope", position: FibsemStagePosition
+) -> FibsemStagePosition:
+    """A fluorescence position re-posed for milling.
+
+    The canonical milling orientation, not a recovered one: a fluorescence pose does not
+    record which beam orientation it came from -- the transform only rewrites rotation
+    and tilt, so a lamella marked at the SEM and one marked at the milling angle both
+    arrive at t = -180 and are indistinguishable afterwards. For a target found *in*
+    fluorescence there is no earlier pose to recover anyway, and the orientation milling
+    actually happens at is the only defensible answer.
+    """
+    # Checked here rather than left to `get_target_position` to complain, because it
+    # will not. That function re-derives the orientation from the position, and on an
+    # offset mount a fluorescence position already classifies as MILLING -- so the
+    # conversion returns early, unchanged, and the caller gets its own position back as
+    # somewhere to mill. The precondition is about the *system*, so ask the system.
+    if not microscope.stage_is_compustage:
+        raise ValueError(
+            "Cannot mark a lamella from the fluorescence view on this system: there is "
+            "no transform between the fluorescence and beam positions on an offset "
+            "mount, so the milling pose cannot be derived (FIB-93). Mark it from the "
+            "beam side instead."
+        )
+    try:
+        return microscope.get_target_position(
+            stage_position=deepcopy(position),
+            target_orientation=MILLING_ORIENTATION,
+        )
+    except ValueError as e:
+        raise ValueError(
+            f"Could not derive a milling pose from the fluorescence position: {e}"
+        ) from e
+
+
+def _to_fluorescence(
+    microscope: "FibsemMicroscope", position: FibsemStagePosition
+) -> Optional[FibsemStagePosition]:
+    """A beam position re-posed for fluorescence, or None if it cannot be.
+
+    Unavailability is not an error here, unlike the other direction. A beam-side caller
+    is marking somewhere to mill and the fluorescence pose is a convenience; refusing
+    the whole lamella because the system cannot work one out would break marking
+    lamellae on every offset system.
+    """
+    if microscope.fm is None:
+        return None
+    try:
+        return microscope.get_target_position(
+            stage_position=deepcopy(position),
+            target_orientation=microscope.fm.default_orientation,
+        )
+    except ValueError as e:
+        logging.debug(f"Could not derive a fluorescence pose for {position}: {e}")
+        return None

--- a/fibsem/applications/autolamella/poses.py
+++ b/fibsem/applications/autolamella/poses.py
@@ -121,6 +121,55 @@ def build_lamella_poses(
     return LamellaPoses(milling=milling, fluorescence=fluorescence)
 
 
+def sync_fluorescence_pose(microscope: "FibsemMicroscope", lamella) -> bool:
+    """Bring a lamella's fluorescence pose back in line with its milling pose.
+
+    For the callers that move a lamella on the beam side. They set the milling pose and
+    have historically stopped there, which leaves the fluorescence pose describing where
+    the lamella *used to be* -- a stale pose being worse than a missing one, because
+    nothing about it looks wrong.
+
+    Only the stage position is rewritten. Everything else the fluorescence pose carries
+    is kept, the objective position most of all: someone focused on this lamella by hand,
+    and moving it sideways is not a reason to throw that away.
+
+    Deliberately does **not** invent a pose for a lamella that has none. A lamella with
+    no fluorescence pose has never been marked under fluorescence, and `fluorescence_
+    selected` asks only whether an objective position exists -- so conjuring one here
+    would make a lamella nobody has ever looked at report itself as focused.
+
+    Returns:
+        True if the pose was updated; False if there was none to update, or the
+        instrument cannot work one out (an offset mount -- see FIB-93).
+    """
+    pose = getattr(lamella, "fluorescence_pose", None)
+    if pose is None:
+        return False
+
+    milling = getattr(lamella, "milling_pose", None)
+    if milling is None or milling.stage_position is None:
+        logging.debug(
+            f"Cannot sync the fluorescence pose of {getattr(lamella, 'name', '?')}: "
+            f"it has no milling pose to derive one from."
+        )
+        return False
+
+    position = _to_fluorescence(microscope, milling.stage_position)
+    if position is None:
+        # Left as it stands rather than cleared. It cannot be derived on this system, so
+        # whatever is there was put there deliberately and is the better of two bad
+        # answers -- but it is now stale, and saying so is the only thing left to do.
+        logging.warning(
+            f"Could not update the fluorescence pose of "
+            f"{getattr(lamella, 'name', '?')} to follow its milling pose; it still "
+            f"describes the previous position."
+        )
+        return False
+
+    pose.stage_position = position
+    return True
+
+
 def _to_milling(
     microscope: "FibsemMicroscope", position: FibsemStagePosition
 ) -> FibsemStagePosition:

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -1446,8 +1446,20 @@ class Experiment:
     def add_new_lamella(self,
                         microscope_state: MicroscopeState,
                         task_config: EventedDict[str, AutoLamellaTaskConfig],
-                        name: Optional[str] = None) -> None:
-        """Create a new lamella and add it to the experiment."""
+                        name: Optional[str] = None,
+                        fluorescence_pose: Optional[MicroscopeState] = None) -> None:
+        """Create a new lamella and add it to the experiment.
+
+        Args:
+            fluorescence_pose: where the lamella is under the objective, if the caller
+                worked one out. Passed in rather than assigned by the caller afterwards
+                because `add_lamella` publishes `positions.events.inserted`, and
+                everything drawing the experiment redraws on it -- a pose attached a
+                moment later arrives after every listener has already decided this
+                lamella has none. That is not hypothetical: it left each newly marked
+                lamella missing from the FM overview until something else forced a
+                refresh.
+        """
         template = self.task_protocol.lamella_defaults
         number = max((pos.number for pos in self.positions), default=0) + 1
         if name is None:
@@ -1468,6 +1480,8 @@ class Experiment:
         if template.poi is not None:
             lamella.poi = deepcopy(template.poi)
         lamella.milling_pose = microscope_state
+        if fluorescence_pose is not None:
+            lamella.fluorescence_pose = fluorescence_pose
 
         # create the lamella directory
         os.makedirs(lamella.path, exist_ok=True)

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -2098,6 +2098,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.fm_overview_tab.availability_changed.connect(
             self._on_fm_overview_availability
         )
+        self.fm_overview_tab.lamella_selected.connect(self._on_fm_overview_lamella_selected)
 
         self.tab_widget.insertTab(
             2, self.fm_overview_tab,
@@ -2107,6 +2108,22 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.tab_widget.indexOf(self.fm_overview_tab), False
         )
         self._apply_fm_overview_visibility()
+
+    def _on_fm_overview_lamella_selected(self, lamella):
+        """Sync the other lists when the FM overview's list selection changes.
+
+        The same shape as `_on_minimap_lamella_selected`, minus the call back into the
+        FM tab: it raised this, and it has already highlighted what was clicked.
+        """
+        if getattr(self, "_syncing_selection", False) or lamella is None:
+            return
+        self._syncing_selection = True
+        try:
+            self.autolamella_ui.lamella_list.select(lamella.name)
+            if hasattr(self, "lamella_card_container"):
+                self.lamella_card_container.select_lamella(lamella.name)
+        finally:
+            self._syncing_selection = False
 
     def _refresh_fm_overview_positions(self):
         """Re-mark the FM overview, tolerating there being no tab.

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import sys
 import time
-from copy import deepcopy
 from typing import Optional
 
 try:
@@ -39,18 +38,15 @@ from fibsem.ui.icon import fibsem_icon
 import fibsem
 from fibsem.versioning import get_version_string
 import fibsem.config as fibsem_cfg
-from fibsem.applications.autolamella.poses import (
-    FLUORESCENCE_ORIENTATION,
-    build_lamella_poses,
-)
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus, Lamella
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI, INSTRUCTIONS
+from fibsem.applications.autolamella.ui.fluorescence_overview_tab import (
+    FluorescenceOverviewTab,
+)
 from fibsem.applications.autolamella.workflows.tasks.queue import QueueOp, QueueResult
 from fibsem.applications.autolamella.workflows.tasks.tasks import get_task_supervision
 from fibsem.ui import FibsemMinimapWidget
-from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
 from fibsem.ui.qt.gc import install_main_thread_gc
-from fibsem.ui.utils import message_box_ui
 from fibsem.ui.stylesheets import (
     MILLING_PROGRESS_BAR_STYLESHEET,
     NAPARI_STYLE,
@@ -966,8 +962,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if hasattr(self, "minimap_widget"):
             self.minimap_widget.pushButton_run_tile_collection.setEnabled(enabled)
             self.minimap_widget.pushButton_load_image.setEnabled(enabled)
-        if getattr(self, "fm_overview_widget", None) is not None:
-            self.fm_overview_widget.set_interactive(enabled)
+        if getattr(self, "fm_overview_tab", None) is not None:
+            self.fm_overview_tab.set_interactive(enabled)
 
     def _set_border_state(self, state: str):
         """Update the tab widget border to reflect current workflow state.
@@ -1268,7 +1264,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             return
 
         self.minimap_widget.set_experiment()
-        self._update_fm_overview_experiment()
+        self.fm_overview_tab.refresh_experiment()
         self.task_widget.set_experiment(self.autolamella_ui.experiment)
         self.lamella_widget.set_experiment()
         experiment = self.autolamella_ui.experiment
@@ -1305,9 +1301,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # by an experiment, so loading one must not switch it on for a system that has
         # no FM -- it would open onto an empty container.
         fm_overview_tab_index = (
-            self.tab_widget.indexOf(self._fm_overview_container)
-            if getattr(self, "fm_overview_widget", None) is None
-            and hasattr(self, "_fm_overview_container")
+            self.tab_widget.indexOf(self.fm_overview_tab)
+            if getattr(self, "fm_overview_tab", None) is not None
+            and not self.fm_overview_tab.is_available
             else -1
         )
         for i in range(self.tab_widget.count()):
@@ -1341,7 +1337,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             try:
                 events.inserted.disconnect(self._rebuild_lamella_list)
                 events.removed.disconnect(self._rebuild_lamella_list)
-                events.changed.disconnect(self._update_fm_overview_positions)
+                events.changed.disconnect(self._refresh_fm_overview_positions)
             except Exception as e:
                 logging.debug(f"Could not disconnect position events: {e}")
 
@@ -1360,7 +1356,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             # -- `update_lamella_position_ui` emits it after replacing a milling pose.
             # The list rows do not care, but the canvas draws the positions themselves,
             # so it has to be told.
-            events.changed.connect(self._update_fm_overview_positions)
+            events.changed.connect(self._refresh_fm_overview_positions)
         self._lamella_list_experiment = experiment
 
     def create_notification_button(self):
@@ -1607,7 +1603,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             return
 
         self._selected_card_lamella = lamella
-        self._update_fm_overview_selection(lamella)
+        self.fm_overview_tab.set_selected(lamella)
         self.lamella_task_image_widget.set_lamella(lamella)
         if lamella is not None:
             self.lamella_widget.select_lamella(lamella.name)
@@ -1622,7 +1618,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def _on_experiment_lamella_selected(self, lamella):
         """Sync card container and minimap when experiment-tab list selection changes."""
-        self._update_fm_overview_selection(lamella)
+        self.fm_overview_tab.set_selected(lamella)
         if getattr(self, "_syncing_selection", False) or lamella is None:
             return
         if not hasattr(self, "lamella_card_container"):
@@ -1637,7 +1633,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def _on_minimap_lamella_selected(self, lamella):
         """Sync experiment list and card container when minimap list selection changes."""
-        self._update_fm_overview_selection(lamella)
+        self.fm_overview_tab.set_selected(lamella)
         if getattr(self, "_syncing_selection", False) or lamella is None:
             return
         self._syncing_selection = True
@@ -1939,7 +1935,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # the two cannot end up disagreeing about what the experiment holds. Before the
         # `experiment is None` return, because an experiment closing has to clear the
         # canvas as much as an experiment opening has to fill it.
-        self._update_fm_overview_positions()
+        self._refresh_fm_overview_positions()
         if experiment is None:
             return
         for lamella in experiment.positions:
@@ -2092,29 +2088,48 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         two show different stage poses -- milling pose on the beam side, FM pose here --
         and relating them is what the correlation workflow is for.
 
-        Only the container is made here. `FMOverviewWidget` requires a microscope with a
+        The tab is created empty. `FMOverviewWidget` requires a microscope with a
         fluorescence detector at construction -- it has no meaningful empty state, since
-        every scale on its canvas comes from the camera -- and at this point there may
-        be no microscope at all. The widget is built on connection instead, by
-        :meth:`_build_fm_overview_widget`, and the tab stays disabled until then.
+        every scale on its canvas comes from the camera -- and at this point there may be
+        no microscope at all. :class:`FluorescenceOverviewTab` fills itself in on
+        connection, and says so through `availability_changed`.
         """
-        self._fm_overview_container = QWidget()
-        layout = QVBoxLayout(self._fm_overview_container)
-        layout.setContentsMargins(0, 0, 0, 0)
-        self.fm_overview_widget: Optional[FMOverviewWidget] = None
-        # The microscope the current widget was built for. A reconnection hands out a
-        # new object, and the old widget would go on reading geometry from an instrument
-        # nobody is driving (FIB-433), so the identity is worth keeping.
-        self._fm_overview_microscope = None
+        self.fm_overview_tab = FluorescenceOverviewTab(self.autolamella_ui)
+        self.fm_overview_tab.availability_changed.connect(
+            self._on_fm_overview_availability
+        )
 
         self.tab_widget.insertTab(
-            2, self._fm_overview_container,
+            2, self.fm_overview_tab,
             fibsem_icon("mdi:microscope", color=GRAY_ICON_COLOR), "FM Overview",
         )
         self.tab_widget.setTabEnabled(
-            self.tab_widget.indexOf(self._fm_overview_container), False
+            self.tab_widget.indexOf(self.fm_overview_tab), False
         )
         self._apply_fm_overview_visibility()
+
+    def _refresh_fm_overview_positions(self):
+        """Re-mark the FM overview, tolerating there being no tab.
+
+        A method on the window rather than connecting `fm_overview_tab.refresh_positions`
+        straight to the experiment's signal: the tab is rebuilt when the microscope
+        changes, and a subscription holding the old one's bound method would be both
+        stale and undisconnectable. This one is stable for the window's lifetime, which
+        is what `_wire_position_events`' disconnect needs.
+        """
+        if getattr(self, "fm_overview_tab", None) is None:
+            return
+        self.fm_overview_tab.refresh_positions()
+
+    def _on_fm_overview_availability(self, available: bool):
+        """Enable the tab when it has something to drive.
+
+        The one thing about the tab that is not the tab's own business: it has no
+        business reaching out to the tab bar it happens to sit in.
+        """
+        self.tab_widget.setTabEnabled(
+            self.tab_widget.indexOf(self.fm_overview_tab), available
+        )
 
     def _apply_fm_overview_visibility(self):
         """Show or hide the FM Overview tab to match the preference, immediately.
@@ -2132,9 +2147,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         * **No microscope yet** is temporary, so the tab stays visible and disabled,
           which is what every other tab does while waiting for a connection.
         """
-        if not hasattr(self, "_fm_overview_container"):
+        if getattr(self, "fm_overview_tab", None) is None:
             return
-        index = self.tab_widget.indexOf(self._fm_overview_container)
+        index = self.tab_widget.indexOf(self.fm_overview_tab)
         microscope = (
             self.autolamella_ui.microscope if self.autolamella_ui is not None else None
         )
@@ -2143,290 +2158,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             index, fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED and not has_no_fm
         )
         # Builds when the flag is on and there is an FM, tears down otherwise.
-        self._build_fm_overview_widget()
-
-    def _build_fm_overview_widget(self):
-        """Put a widget in the FM Overview tab, once there is something to drive.
-
-        Called on every connection. Rebuilds when the microscope object has changed,
-        because the widget holds its microscope for life and would otherwise be talking
-        to the previous one -- destructive of anything on the canvas, and the reason
-        FIB-433 exists to do this without throwing the view away.
-        """
-        # `connected_signal` is subscribed in `_create_main_tab`, which runs before this
-        # tab is reserved. Nothing can fire in between synchronously, but the ordering is
-        # not this method's to rely on.
-        if not hasattr(self, "_fm_overview_container"):
-            return
-
-        microscope = (
-            self.autolamella_ui.microscope if self.autolamella_ui is not None else None
-        )
-        index = self.tab_widget.indexOf(self._fm_overview_container)
-
-        if (
-            not fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED
-            or microscope is None
-            or microscope.fm is None
-        ):
-            # Switched off, or no fluorescence detector. The tab stays in place but dead
-            # rather than being removed, so the tab bar does not change shape between
-            # systems; hiding it is `_apply_fm_overview_visibility`'s job.
-            self._teardown_fm_overview_widget()
-            self.tab_widget.setTabEnabled(index, False)
-            return
-
-        if self.fm_overview_widget is not None:
-            if self._fm_overview_microscope is microscope:
-                return
-            self._teardown_fm_overview_widget()
-
-        try:
-            self.fm_overview_widget = FMOverviewWidget(microscope)
-        except Exception as e:
-            logging.error(f"Could not create the FM overview tab: {e}")
-            self.tab_widget.setTabEnabled(index, False)
-            return
-
-        self.fm_overview_widget.position_add_requested.connect(
-            self._on_fm_overview_add_position
-        )
-        self.fm_overview_widget.position_move_requested.connect(
-            self._on_fm_overview_move_position
-        )
-
-        self._fm_overview_microscope = microscope
-        self._fm_overview_container.layout().addWidget(self.fm_overview_widget)
-        self.tab_widget.setTabEnabled(index, True)
-        self._update_fm_overview_experiment()
-
-    def _teardown_fm_overview_widget(self):
-        """Drop the current FM overview widget, if there is one.
-
-        `close()` rather than `deleteLater()` alone: the widget's `closeEvent` is what
-        releases its psygnal subscriptions on the microscope, and those outlive the
-        widget -- a stale one left connected emits into a torn-down Qt object.
-        """
-        if self.fm_overview_widget is None:
-            return
-        try:
-            self.fm_overview_widget.close()
-        except Exception as e:
-            logging.debug(f"Error closing the FM overview widget: {e}")
-        self._fm_overview_container.layout().removeWidget(self.fm_overview_widget)
-        self.fm_overview_widget.deleteLater()
-        self.fm_overview_widget = None
-        self._fm_overview_microscope = None
-
-    def _update_fm_overview_experiment(self):
-        """Tell the FM overview tab where to save.
-
-        Told rather than handed the experiment: the widget knows nothing about
-        experiments, and keeping it that way is what lets it open standalone against a
-        simulator and be constructed in a test from a microscope alone.
-        """
-        if getattr(self, "fm_overview_widget", None) is None:
-            return
-        experiment = (
-            self.autolamella_ui.experiment if self.autolamella_ui is not None else None
-        )
-        self.fm_overview_widget.set_save_directory(
-            str(experiment.path) if experiment is not None else None
-        )
-        self._update_fm_overview_positions()
-
-    def _update_fm_overview_selection(self, lamella):
-        """Highlight the selected lamella on the FM overview.
-
-        Called from each of the selection handlers *before* their `_syncing_selection`
-        guard, and deliberately: that guard exists to stop three lists selecting each
-        other in circles, and this is not a fourth list. It emits nothing and only
-        repaints, so it wants to run whichever list the selection came from — which is
-        exactly what the guard suppresses.
-        """
-        if getattr(self, "fm_overview_widget", None) is None:
-            return
-        self.fm_overview_widget.set_selected_position(
-            lamella.name if lamella is not None else None
-        )
-
-    def _update_fm_overview_positions(self):
-        """Mark the experiment's lamellae on the FM overview.
-
-        **Fluorescence poses, not the primary stage position.** A lamella carries one of
-        each and they are different places on this canvas — on a compustage the stage
-        flips 180 degrees between them — so passing the milling pose would mark every
-        lamella somewhere the sample is not.
-
-        A lamella with no fluorescence pose cannot be placed here at all, which is the
-        normal state on a system with no FM and possible on one loaded from an older
-        experiment. Those are counted rather than dropped in silence: a canvas showing
-        three of five positions and saying nothing is worse than one saying which two
-        it cannot show.
-        """
-        if getattr(self, "fm_overview_widget", None) is None:
-            return
-        experiment = (
-            self.autolamella_ui.experiment if self.autolamella_ui is not None else None
-        )
-        if experiment is None:
-            self.fm_overview_widget.set_positions([])
-            return
-
-        positions, unplaceable = [], []
-        for lamella in experiment.positions:
-            pose = lamella.fluorescence_pose
-            if pose is None or pose.stage_position is None:
-                unplaceable.append(lamella.name)
-                continue
-            # Named here rather than relying on whatever the stored position carries:
-            # the marker's label is the lamella's name, and a pose saved before names
-            # were stamped on positions would otherwise draw an unlabelled dot.
-            position = deepcopy(pose.stage_position)
-            position.name = lamella.name
-            positions.append(position)
-
-        self.fm_overview_widget.set_positions(positions)
-        if unplaceable:
-            logging.info(
-                f"{len(unplaceable)} lamella(e) have no fluorescence pose and are not "
-                f"shown on the FM overview: {', '.join(unplaceable)}"
-            )
-
-    def _fm_overview_objective_position(self) -> Optional[float]:
-        """Where the objective is right now, for a pose marked on the FM overview.
-
-        The focus a user is actually looking through beats the objective's *configured*
-        focus position, which `build_lamella_poses` falls back to: that one is a property
-        of the instrument and says nothing about this sample. Anyone marking a position
-        here has the feature in focus, and that focus is part of what they marked.
-
-        Unless the objective is retracted, in which case its position is a parking spot
-        ~10 mm from anything and nobody focused on anything. None hands the decision back
-        to the fallback -- which matters because `fluorescence_selected` only asks
-        whether an objective position exists, so a parked one would read as a focused
-        lamella.
-        """
-        microscope = (
-            self.autolamella_ui.microscope if self.autolamella_ui is not None else None
-        )
-        if microscope is None or microscope.fm is None:
-            return None
-        try:
-            objective = microscope.fm.objective
-            if objective.state != "Inserted":
-                logging.debug(
-                    f"Objective is {objective.state}; falling back to its focus position."
-                )
-                return None
-            return objective.position
-        except Exception as e:
-            logging.debug(f"Could not read the objective position: {e}")
-            return None
-
-    def _on_fm_overview_add_position(self, position):
-        """A user asked for a new lamella at a point on the FM overview.
-
-        The orientation is *declared* rather than left to be derived. On a compustage
-        deriving it would give the same answer; on an offset mount it would not, and the
-        wrong answer there is a lamella with a milling pose 48 mm off the beam axis that
-        nothing rejects until something tries to mill it (FIB-93). Declaring it turns
-        that into a refusal here, where there is a user to tell.
-        """
-        if self.autolamella_ui is None or self.autolamella_ui.experiment is None:
-            notification_service.show_toast(
-                "Load an experiment before marking positions.", "warning"
-            )
-            return
-        try:
-            lamella = self.autolamella_ui.add_new_lamella(
-                stage_position=position,
-                objective_position=self._fm_overview_objective_position(),
-                marked_at=FLUORESCENCE_ORIENTATION,
-            )
-        except Exception as e:
-            logging.error(f"Could not add a lamella from the FM overview: {e}")
-            notification_service.show_toast(str(e), "error")
-            return
-
-        self._update_fm_overview_positions()
-        self._update_fm_overview_selection(lamella)
-        notification_service.show_toast(f"Added {lamella.name}.", "info")
-
-    def _on_fm_overview_move_position(self, name: str, position):
-        """A user asked to move a marked lamella to a point on the FM overview.
-
-        Confirmed first, because moving one pose moves both: the milling pose is derived
-        from this one, so a lamella dragged across the fluorescence view also stops being
-        where the beam was going to mill it. That is usually the point -- the two describe
-        one piece of sample -- but it is not visible from this canvas, which shows only
-        the fluorescence side, so it gets said rather than assumed.
-        """
-        experiment = (
-            self.autolamella_ui.experiment if self.autolamella_ui is not None else None
-        )
-        if experiment is None:
-            return
-        lamella = next((p for p in experiment.positions if p.name == name), None)
-        if lamella is None:
-            logging.debug(f"Cannot move {name!r}: no such lamella in the experiment.")
-            return
-        if lamella.milling_pose is None:
-            notification_service.show_toast(
-                f"{name} has no milling pose to move.", "warning"
-            )
-            return
-
-        try:
-            poses = build_lamella_poses(
-                microscope=self.autolamella_ui.microscope,
-                position=position,
-                objective_position=self._fm_overview_objective_position(),
-                # Only reaches the result in one case, and it is worth it for that one:
-                # a lamella with no fluorescence pose yet gets a whole new one below, and
-                # it should be built on what this lamella recorded rather than on
-                # whatever the microscope happens to be set to now. Everywhere else only
-                # the stage positions are read, and those come from `position`.
-                state=lamella.milling_pose,
-                marked_at=FLUORESCENCE_ORIENTATION,
-            )
-        except Exception as e:
-            logging.error(f"Could not move {name} from the FM overview: {e}")
-            notification_service.show_toast(str(e), "error")
-            return
-
-        history = (
-            f"\n\n{name} has already completed "
-            f"{', '.join(lamella.completed_tasks)}."
-            if lamella.completed_tasks
-            else ""
-        )
-        if not message_box_ui(
-            title=f"Move {name}?",
-            text=(
-                f"Move {name} to {poses.fluorescence.stage_position.pretty_string}?"
-                f"\n\nThis moves the milling pose with it, to "
-                f"{poses.milling.stage_position.pretty_string}."
-                f"{history}"
-            ),
-            parent=self,
-        ):
-            return
-
-        # Only the stage positions are replaced, so anything else the poses carry --
-        # notably the objective position on a lamella that was focused by hand -- is
-        # kept. `stage_position` is the milling pose's, via the property.
-        lamella.stage_position = poses.milling.stage_position
-        lamella.update_milling_angle(self.autolamella_ui.microscope)
-        if lamella.fluorescence_pose is None:
-            lamella.fluorescence_pose = poses.fluorescence
-        else:
-            lamella.fluorescence_pose.stage_position = poses.fluorescence.stage_position
-
-        experiment.save()
-        self._update_fm_overview_positions()
-        self.autolamella_ui.update_ui()
-        notification_service.show_toast(f"Moved {name}.", "info")
+        self.fm_overview_tab.refresh_microscope()
 
     def _on_notification_service(
         self, message: str, notification_type: str, temporary: bool

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import sys
 import time
+from copy import deepcopy
 from typing import Optional
 
 try:
@@ -1582,6 +1583,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             return
 
         self._selected_card_lamella = lamella
+        self._update_fm_overview_selection(lamella)
         self.lamella_task_image_widget.set_lamella(lamella)
         if lamella is not None:
             self.lamella_widget.select_lamella(lamella.name)
@@ -1596,6 +1598,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def _on_experiment_lamella_selected(self, lamella):
         """Sync card container and minimap when experiment-tab list selection changes."""
+        self._update_fm_overview_selection(lamella)
         if getattr(self, "_syncing_selection", False) or lamella is None:
             return
         if not hasattr(self, "lamella_card_container"):
@@ -1610,6 +1613,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def _on_minimap_lamella_selected(self, lamella):
         """Sync experiment list and card container when minimap list selection changes."""
+        self._update_fm_overview_selection(lamella)
         if getattr(self, "_syncing_selection", False) or lamella is None:
             return
         self._syncing_selection = True
@@ -2192,6 +2196,65 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.fm_overview_widget.set_save_directory(
             str(experiment.path) if experiment is not None else None
         )
+        self._update_fm_overview_positions()
+
+    def _update_fm_overview_selection(self, lamella):
+        """Highlight the selected lamella on the FM overview.
+
+        Called from each of the selection handlers *before* their `_syncing_selection`
+        guard, and deliberately: that guard exists to stop three lists selecting each
+        other in circles, and this is not a fourth list. It emits nothing and only
+        repaints, so it wants to run whichever list the selection came from — which is
+        exactly what the guard suppresses.
+        """
+        if getattr(self, "fm_overview_widget", None) is None:
+            return
+        self.fm_overview_widget.set_selected_position(
+            lamella.name if lamella is not None else None
+        )
+
+    def _update_fm_overview_positions(self):
+        """Mark the experiment's lamellae on the FM overview.
+
+        **Fluorescence poses, not the primary stage position.** A lamella carries one of
+        each and they are different places on this canvas — on a compustage the stage
+        flips 180 degrees between them — so passing the milling pose would mark every
+        lamella somewhere the sample is not.
+
+        A lamella with no fluorescence pose cannot be placed here at all, which is the
+        normal state on a system with no FM and possible on one loaded from an older
+        experiment. Those are counted rather than dropped in silence: a canvas showing
+        three of five positions and saying nothing is worse than one saying which two
+        it cannot show.
+        """
+        if getattr(self, "fm_overview_widget", None) is None:
+            return
+        experiment = (
+            self.autolamella_ui.experiment if self.autolamella_ui is not None else None
+        )
+        if experiment is None:
+            self.fm_overview_widget.set_positions([])
+            return
+
+        positions, unplaceable = [], []
+        for lamella in experiment.positions:
+            pose = lamella.fluorescence_pose
+            if pose is None or pose.stage_position is None:
+                unplaceable.append(lamella.name)
+                continue
+            # Named here rather than relying on whatever the stored position carries:
+            # the marker's label is the lamella's name, and a pose saved before names
+            # were stamped on positions would otherwise draw an unlabelled dot.
+            position = deepcopy(pose.stage_position)
+            position.name = lamella.name
+            positions.append(position)
+
+        self.fm_overview_widget.set_positions(positions)
+        if unplaceable:
+            logging.info(
+                f"{len(unplaceable)} lamella(e) have no fluorescence pose and are not "
+                f"shown on the FM overview: {', '.join(unplaceable)}"
+            )
 
     def _on_notification_service(
         self, message: str, notification_type: str, temporary: bool

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -40,8 +40,8 @@ from fibsem.versioning import get_version_string
 import fibsem.config as fibsem_cfg
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus, Lamella
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI, INSTRUCTIONS
-from fibsem.applications.autolamella.ui.fluorescence_overview_tab import (
-    FluorescenceOverviewTab,
+from fibsem.applications.autolamella.ui.autolamella_fluorescence_overview_tab import (
+    AutoLamellaFluorescenceOverviewTab,
 )
 from fibsem.applications.autolamella.workflows.tasks.queue import QueueOp, QueueResult
 from fibsem.applications.autolamella.workflows.tasks.tasks import get_task_supervision
@@ -2091,10 +2091,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         The tab is created empty. `FMOverviewWidget` requires a microscope with a
         fluorescence detector at construction -- it has no meaningful empty state, since
         every scale on its canvas comes from the camera -- and at this point there may be
-        no microscope at all. :class:`FluorescenceOverviewTab` fills itself in on
+        no microscope at all. :class:`AutoLamellaFluorescenceOverviewTab` fills itself in on
         connection, and says so through `availability_changed`.
         """
-        self.fm_overview_tab = FluorescenceOverviewTab(self.autolamella_ui)
+        self.fm_overview_tab = AutoLamellaFluorescenceOverviewTab(self.autolamella_ui)
         self.fm_overview_tab.availability_changed.connect(
             self._on_fm_overview_availability
         )

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1321,28 +1321,47 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self._rebuild_lamella_list()
         self._on_workflow_selection_changed()  # evaluate after lamella are populated
         self.lamella_workflow_widget._update_summary()
+        self._wire_position_events()
+
+    def _wire_position_events(self):
+        """Follow the current experiment's position list, and stop following the last.
+
+        Everything that draws the set of lamellae -- the list rows, the cards, the FM
+        overview canvas -- is rebuilt from these, so a display that is not reachable from
+        here is a display that goes stale the moment a lamella is added anywhere else.
+        That was how a position marked on the FIB/SEM overview never appeared on the FM
+        one.
+        """
         experiment = self.autolamella_ui.experiment if self.autolamella_ui else None
-        if experiment is not self._lamella_list_experiment:
-            # Disconnect from the old experiment's position events
-            if self._lamella_list_experiment is not None:
-                try:
-                    self._lamella_list_experiment.positions.events.inserted.disconnect(
-                        self._rebuild_lamella_list
-                    )
-                    self._lamella_list_experiment.positions.events.removed.disconnect(
-                        self._rebuild_lamella_list
-                    )
-                except Exception:
-                    pass
-            # Connect to the new experiment's position events
-            if experiment is not None:
-                experiment.positions.events.inserted.connect(
-                    lambda *_: self._rebuild_lamella_list()
-                )
-                experiment.positions.events.removed.connect(
-                    lambda *_: self._rebuild_lamella_list()
-                )
-            self._lamella_list_experiment = experiment
+        if experiment is self._lamella_list_experiment:
+            return
+
+        if self._lamella_list_experiment is not None:
+            events = self._lamella_list_experiment.positions.events
+            try:
+                events.inserted.disconnect(self._rebuild_lamella_list)
+                events.removed.disconnect(self._rebuild_lamella_list)
+                events.changed.disconnect(self._update_fm_overview_positions)
+            except Exception as e:
+                logging.debug(f"Could not disconnect position events: {e}")
+
+        # Bound methods rather than lambdas, so the disconnects above can find them.
+        # psygnal passes each callback only as many arguments as it accepts, so a
+        # no-argument handler needs no wrapper -- and a lambda cannot be disconnected by
+        # naming the method it calls, which made the disconnect a silent no-op (psygnal
+        # does not complain about disconnecting something that was never connected).
+        # Nothing broke, because the experiment being disconnected from is on its way out
+        # and never emits again, but it did not do what it said.
+        if experiment is not None:
+            events = experiment.positions.events
+            events.inserted.connect(self._rebuild_lamella_list)
+            events.removed.connect(self._rebuild_lamella_list)
+            # `changed` means a lamella was edited in place rather than added or removed
+            # -- `update_lamella_position_ui` emits it after replacing a milling pose.
+            # The list rows do not care, but the canvas draws the positions themselves,
+            # so it has to be told.
+            events.changed.connect(self._update_fm_overview_positions)
+        self._lamella_list_experiment = experiment
 
     def create_notification_button(self):
         """Add buttons to the tab bar for adding Protocol Editor, Lamella, and Minimap tabs."""
@@ -1915,6 +1934,12 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.lamella_list_widget.clear()
         self.lamella_card_container.clear()
         self._on_lamella_card_selected(None)
+        # The FM canvas is another display of the same set, so it is rebuilt here rather
+        # than from its own subscription -- one handler for "the lamellae changed" means
+        # the two cannot end up disagreeing about what the experiment holds. Before the
+        # `experiment is None` return, because an experiment closing has to clear the
+        # canvas as much as an experiment opening has to fill it.
+        self._update_fm_overview_positions()
         if experiment is None:
             return
         for lamella in experiment.positions:

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -39,6 +39,10 @@ from fibsem.ui.icon import fibsem_icon
 import fibsem
 from fibsem.versioning import get_version_string
 import fibsem.config as fibsem_cfg
+from fibsem.applications.autolamella.poses import (
+    FLUORESCENCE_ORIENTATION,
+    build_lamella_poses,
+)
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus, Lamella
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI, INSTRUCTIONS
 from fibsem.applications.autolamella.workflows.tasks.queue import QueueOp, QueueResult
@@ -46,6 +50,7 @@ from fibsem.applications.autolamella.workflows.tasks.tasks import get_task_super
 from fibsem.ui import FibsemMinimapWidget
 from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
 from fibsem.ui.qt.gc import install_main_thread_gc
+from fibsem.ui.utils import message_box_ui
 from fibsem.ui.stylesheets import (
     MILLING_PROGRESS_BAR_STYLESHEET,
     NAPARI_STYLE,
@@ -2158,6 +2163,13 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.tab_widget.setTabEnabled(index, False)
             return
 
+        self.fm_overview_widget.position_add_requested.connect(
+            self._on_fm_overview_add_position
+        )
+        self.fm_overview_widget.position_move_requested.connect(
+            self._on_fm_overview_move_position
+        )
+
         self._fm_overview_microscope = microscope
         self._fm_overview_container.layout().addWidget(self.fm_overview_widget)
         self.tab_widget.setTabEnabled(index, True)
@@ -2255,6 +2267,141 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 f"{len(unplaceable)} lamella(e) have no fluorescence pose and are not "
                 f"shown on the FM overview: {', '.join(unplaceable)}"
             )
+
+    def _fm_overview_objective_position(self) -> Optional[float]:
+        """Where the objective is right now, for a pose marked on the FM overview.
+
+        The focus a user is actually looking through beats the objective's *configured*
+        focus position, which `build_lamella_poses` falls back to: that one is a property
+        of the instrument and says nothing about this sample. Anyone marking a position
+        here has the feature in focus, and that focus is part of what they marked.
+
+        Unless the objective is retracted, in which case its position is a parking spot
+        ~10 mm from anything and nobody focused on anything. None hands the decision back
+        to the fallback -- which matters because `fluorescence_selected` only asks
+        whether an objective position exists, so a parked one would read as a focused
+        lamella.
+        """
+        microscope = (
+            self.autolamella_ui.microscope if self.autolamella_ui is not None else None
+        )
+        if microscope is None or microscope.fm is None:
+            return None
+        try:
+            objective = microscope.fm.objective
+            if objective.state != "Inserted":
+                logging.debug(
+                    f"Objective is {objective.state}; falling back to its focus position."
+                )
+                return None
+            return objective.position
+        except Exception as e:
+            logging.debug(f"Could not read the objective position: {e}")
+            return None
+
+    def _on_fm_overview_add_position(self, position):
+        """A user asked for a new lamella at a point on the FM overview.
+
+        The orientation is *declared* rather than left to be derived. On a compustage
+        deriving it would give the same answer; on an offset mount it would not, and the
+        wrong answer there is a lamella with a milling pose 48 mm off the beam axis that
+        nothing rejects until something tries to mill it (FIB-93). Declaring it turns
+        that into a refusal here, where there is a user to tell.
+        """
+        if self.autolamella_ui is None or self.autolamella_ui.experiment is None:
+            notification_service.show_toast(
+                "Load an experiment before marking positions.", "warning"
+            )
+            return
+        try:
+            lamella = self.autolamella_ui.add_new_lamella(
+                stage_position=position,
+                objective_position=self._fm_overview_objective_position(),
+                marked_at=FLUORESCENCE_ORIENTATION,
+            )
+        except Exception as e:
+            logging.error(f"Could not add a lamella from the FM overview: {e}")
+            notification_service.show_toast(str(e), "error")
+            return
+
+        self._update_fm_overview_positions()
+        self._update_fm_overview_selection(lamella)
+        notification_service.show_toast(f"Added {lamella.name}.", "info")
+
+    def _on_fm_overview_move_position(self, name: str, position):
+        """A user asked to move a marked lamella to a point on the FM overview.
+
+        Confirmed first, because moving one pose moves both: the milling pose is derived
+        from this one, so a lamella dragged across the fluorescence view also stops being
+        where the beam was going to mill it. That is usually the point -- the two describe
+        one piece of sample -- but it is not visible from this canvas, which shows only
+        the fluorescence side, so it gets said rather than assumed.
+        """
+        experiment = (
+            self.autolamella_ui.experiment if self.autolamella_ui is not None else None
+        )
+        if experiment is None:
+            return
+        lamella = next((p for p in experiment.positions if p.name == name), None)
+        if lamella is None:
+            logging.debug(f"Cannot move {name!r}: no such lamella in the experiment.")
+            return
+        if lamella.milling_pose is None:
+            notification_service.show_toast(
+                f"{name} has no milling pose to move.", "warning"
+            )
+            return
+
+        try:
+            poses = build_lamella_poses(
+                microscope=self.autolamella_ui.microscope,
+                position=position,
+                objective_position=self._fm_overview_objective_position(),
+                # Only reaches the result in one case, and it is worth it for that one:
+                # a lamella with no fluorescence pose yet gets a whole new one below, and
+                # it should be built on what this lamella recorded rather than on
+                # whatever the microscope happens to be set to now. Everywhere else only
+                # the stage positions are read, and those come from `position`.
+                state=lamella.milling_pose,
+                marked_at=FLUORESCENCE_ORIENTATION,
+            )
+        except Exception as e:
+            logging.error(f"Could not move {name} from the FM overview: {e}")
+            notification_service.show_toast(str(e), "error")
+            return
+
+        history = (
+            f"\n\n{name} has already completed "
+            f"{', '.join(lamella.completed_tasks)}."
+            if lamella.completed_tasks
+            else ""
+        )
+        if not message_box_ui(
+            title=f"Move {name}?",
+            text=(
+                f"Move {name} to {poses.fluorescence.stage_position.pretty_string}?"
+                f"\n\nThis moves the milling pose with it, to "
+                f"{poses.milling.stage_position.pretty_string}."
+                f"{history}"
+            ),
+            parent=self,
+        ):
+            return
+
+        # Only the stage positions are replaced, so anything else the poses carry --
+        # notably the objective position on a lamella that was focused by hand -- is
+        # kept. `stage_position` is the milling pose's, via the property.
+        lamella.stage_position = poses.milling.stage_position
+        lamella.update_milling_angle(self.autolamella_ui.microscope)
+        if lamella.fluorescence_pose is None:
+            lamella.fluorescence_pose = poses.fluorescence
+        else:
+            lamella.fluorescence_pose.stage_position = poses.fluorescence.stage_position
+
+        experiment.save()
+        self._update_fm_overview_positions()
+        self.autolamella_ui.update_ui()
+        notification_service.show_toast(f"Moved {name}.", "info")
 
     def _on_notification_service(
         self, message: str, notification_type: str, temporary: bool

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -75,7 +75,10 @@ from fibsem.ui.widgets.autolamella_load_task_protocol_widget import (
 from fibsem.ui.fm.widgets import MinimapPlotWidget
 from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget
 from fibsem.applications.autolamella import config as cfg
-from fibsem.applications.autolamella.poses import build_lamella_poses
+from fibsem.applications.autolamella.poses import (
+    build_lamella_poses,
+    sync_fluorescence_pose,
+)
 from fibsem.applications.autolamella.structures import (
     AutoLamellaTaskProtocol,
     AutoLamellaWorkflowConfig,
@@ -1374,6 +1377,10 @@ class AutoLamellaUI(QMainWindow):
 
         # keep the milling angle consistent with the updated milling pose
         lamella.update_milling_angle(self.microscope)
+        # ...and the fluorescence pose, which describes the same piece of sample from
+        # the other side. Left behind, it would go on naming where this lamella used to
+        # be -- and nothing about a stale pose looks wrong.
+        sync_fluorescence_pose(self.microscope, lamella)
 
         self.update_lamella_combobox()
         self.update_ui()

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1257,19 +1257,20 @@ class AutoLamellaUI(QMainWindow):
             marked_at=marked_at,
         )
 
-        # create the lamella
+        # create the lamella, with both poses already on it -- see
+        # `Experiment.add_new_lamella`. Assigning the fluorescence pose after the append
+        # left every listener that redraws on `inserted` deciding the new lamella had
+        # none, which is how each newly marked lamella went missing from the FM overview.
         self.experiment.add_new_lamella(
             microscope_state=poses.milling,
             task_config=self.experiment.task_protocol.task_config,
             name=name,
+            fluorescence_pose=poses.fluorescence,
         )
         lamella = self.experiment.positions[-1]
 
         # derive the milling angle from the milling-pose stage tilt
         lamella.update_milling_angle(self.microscope)
-
-        if poses.fluorescence is not None:
-            lamella.fluorescence_pose = poses.fluorescence
 
         self.experiment.save()
         self.update_lamella_combobox(latest=True)

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -75,6 +75,7 @@ from fibsem.ui.widgets.autolamella_load_task_protocol_widget import (
 from fibsem.ui.fm.widgets import MinimapPlotWidget
 from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget
 from fibsem.applications.autolamella import config as cfg
+from fibsem.applications.autolamella.poses import build_lamella_poses
 from fibsem.applications.autolamella.structures import (
     AutoLamellaTaskProtocol,
     AutoLamellaWorkflowConfig,
@@ -1222,8 +1223,12 @@ class AutoLamellaUI(QMainWindow):
         objective_position: Optional[float] = None,
     ) -> Lamella:
         """Add a lamella to the experiment.
+
         Args:
-            stage_position: The stage position of the lamella. If None, the current stage position is used.
+            stage_position: Where the lamella is, in any orientation -- which one is
+                read off the position itself, so a position picked on the fluorescence
+                side is taken as the fluorescence pose rather than as somewhere to mill.
+                If None, the current stage position is used.
             name: The name of the lamella. If None, a default name will be generated.
             objective_position: The objective position of the lamella. If None, the 'focused' objective position is used.
         Returns:
@@ -1238,14 +1243,15 @@ class AutoLamellaUI(QMainWindow):
                 "No microscope connected. Please connect a microscope first."
             )
 
-        # get microscope state
-        microscope_state = self.microscope.get_microscope_state()
-        if stage_position is not None:
-            microscope_state.stage_position = deepcopy(stage_position)
+        poses = build_lamella_poses(
+            microscope=self.microscope,
+            position=stage_position,
+            objective_position=objective_position,
+        )
 
         # create the lamella
         self.experiment.add_new_lamella(
-            microscope_state=microscope_state,
+            microscope_state=poses.milling,
             task_config=self.experiment.task_protocol.task_config,
             name=name,
         )
@@ -1254,19 +1260,8 @@ class AutoLamellaUI(QMainWindow):
         # derive the milling angle from the milling-pose stage tilt
         lamella.update_milling_angle(self.microscope)
 
-        # if the objective position is not provided, use the 'focus' position from the microscope
-        if self.microscope.fm is not None:
-            # convert the fluorescence pose to the configured orientation
-            fluorescence_stage_position = self.microscope.get_target_position(
-                stage_position=deepcopy(microscope_state.stage_position),
-                target_orientation=self.microscope.fm.default_orientation,
-            )
-            fluorescence_pose = deepcopy(microscope_state)
-            fluorescence_pose.stage_position = fluorescence_stage_position
-            if objective_position is None:
-                objective_position = self.microscope.fm.objective.focus_position
-            fluorescence_pose.objective_position = objective_position
-            lamella.fluorescence_pose = fluorescence_pose
+        if poses.fluorescence is not None:
+            lamella.fluorescence_pose = poses.fluorescence
 
         self.experiment.save()
         self.update_lamella_combobox(latest=True)

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1221,6 +1221,7 @@ class AutoLamellaUI(QMainWindow):
         stage_position: Optional[FibsemStagePosition] = None,
         name: Optional[str] = None,
         objective_position: Optional[float] = None,
+        marked_at: Optional[str] = None,
     ) -> Lamella:
         """Add a lamella to the experiment.
 
@@ -1231,6 +1232,9 @@ class AutoLamellaUI(QMainWindow):
                 If None, the current stage position is used.
             name: The name of the lamella. If None, a default name will be generated.
             objective_position: The objective position of the lamella. If None, the 'focused' objective position is used.
+            marked_at: The orientation *stage_position* is in, for a caller that knows.
+                Left alone it is read off the position, which is right on a compustage
+                and cannot be on an offset mount -- see `build_lamella_poses`.
         Returns:
             lamella: The created lamella.
         """
@@ -1247,6 +1251,7 @@ class AutoLamellaUI(QMainWindow):
             microscope=self.microscope,
             position=stage_position,
             objective_position=objective_position,
+            marked_at=marked_at,
         )
 
         # create the lamella

--- a/fibsem/applications/autolamella/ui/autolamella_fluorescence_overview_tab.py
+++ b/fibsem/applications/autolamella/ui/autolamella_fluorescence_overview_tab.py
@@ -131,6 +131,7 @@ class AutoLamellaFluorescenceOverviewTab(QWidget):
 
         self.overview.position_add_requested.connect(self._on_add_requested)
         self.overview.position_move_requested.connect(self._on_move_requested)
+        self.overview.position_selected.connect(self._on_marker_clicked)
         # In the settings column rather than beside it: the positions are the subject of
         # this tab, and a column of their own would read as a third pane.
         self.overview.add_settings_section("Lamella Positions", self.lamella_list)
@@ -265,13 +266,39 @@ class AutoLamellaFluorescenceOverviewTab(QWidget):
         The flag is what stops the round trip. The window answers by syncing every list
         it knows about, this tab included, and re-selecting the row under a click that
         is still happening moves the selection out from under the user.
+
+        Checked as well as set: `_on_marker_clicked` selects the row itself, and the row
+        answering by coming back through here announced the same lamella twice.
         """
+        if self._syncing_selection:
+            return
         self._syncing_selection = True
         try:
             if self.overview is not None:
                 self.overview.set_selected_position(
                     lamella.name if lamella is not None else None
                 )
+            self.lamella_selected.emit(lamella)
+        finally:
+            self._syncing_selection = False
+
+    def _on_marker_clicked(self, name: str) -> None:
+        """A crosshair on the canvas was clicked: select that lamella everywhere.
+
+        The canvas has already highlighted it -- it knows the name it drew. What it
+        cannot do is turn a name into a lamella, so the list and the window are told from
+        here, through the same path a row click takes.
+        """
+        experiment = self.experiment
+        if experiment is None:
+            return
+        lamella = next((p for p in experiment.positions if p.name == name), None)
+        if lamella is None:
+            logging.debug(f"Clicked {name!r}, which is not in the experiment.")
+            return
+        self._syncing_selection = True
+        try:
+            self.lamella_list.select(name)
             self.lamella_selected.emit(lamella)
         finally:
             self._syncing_selection = False

--- a/fibsem/applications/autolamella/ui/autolamella_fluorescence_overview_tab.py
+++ b/fibsem/applications/autolamella/ui/autolamella_fluorescence_overview_tab.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:  # pragma: no cover - annotation only
     from fibsem.applications.autolamella.structures import Lamella
 
 
-class FluorescenceOverviewTab(QWidget):
+class AutoLamellaFluorescenceOverviewTab(QWidget):
     """Drives `FMOverviewWidget` on behalf of an experiment.
 
     Built empty and filled in on connection: `FMOverviewWidget` requires a microscope

--- a/fibsem/applications/autolamella/ui/fluorescence_overview_tab.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_overview_tab.py
@@ -33,6 +33,7 @@ from fibsem.applications.autolamella.poses import (
 from fibsem.ui import notification_service
 from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
 from fibsem.ui.utils import message_box_ui
+from fibsem.ui.widgets.custom_widgets import LamellaNameListWidget
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
     from fibsem.applications.autolamella.structures import Lamella
@@ -51,6 +52,10 @@ class FluorescenceOverviewTab(QWidget):
     # disable the tab; this object deliberately does not touch the tab bar, which is the
     # one thing about the tab that is not its business.
     availability_changed = pyqtSignal(bool)
+    # A lamella was picked in this tab's own list. The window forwards it to the other
+    # lists; nothing here selects them directly, which is what keeps the sync in one
+    # place instead of four.
+    lamella_selected = pyqtSignal(object)
 
     def __init__(self, autolamella_ui, parent: Optional[QWidget] = None):
         super().__init__(parent)
@@ -60,9 +65,20 @@ class FluorescenceOverviewTab(QWidget):
         # object, and the old widget would go on reading geometry from an instrument
         # nobody is driving (FIB-433), so the identity is worth keeping.
         self._microscope = None
+        # Set while this tab is the one driving a selection, so the highlight it gets
+        # back does not re-enter the list and fight whatever the user just clicked.
+        self._syncing_selection = False
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
+
+        self.lamella_list = LamellaNameListWidget()
+        self.lamella_list.enable_actions_button(True)
+        self.lamella_list.enable_move_to_action(True)
+        self.lamella_list.enable_remove_button(True)
+        self.lamella_list.lamella_selected.connect(self._on_list_selection)
+        self.lamella_list.move_to_requested.connect(self._on_move_to_requested)
+        self.lamella_list.remove_requested.connect(self._on_remove_requested)
 
     # ── what the window asks ─────────────────────────────────────────────
 
@@ -115,6 +131,9 @@ class FluorescenceOverviewTab(QWidget):
 
         self.overview.position_add_requested.connect(self._on_add_requested)
         self.overview.position_move_requested.connect(self._on_move_requested)
+        # In the settings column rather than beside it: the positions are the subject of
+        # this tab, and a column of their own would read as a third pane.
+        self.overview.add_settings_section("Lamella Positions", self.lamella_list)
 
         self._microscope = microscope
         self.layout().addWidget(self.overview)
@@ -130,6 +149,18 @@ class FluorescenceOverviewTab(QWidget):
         """
         if self.overview is None:
             return
+        # Taken back before the widget goes. `add_settings_section` reparents the list
+        # into the overview's column, so Qt destroying the overview would destroy the
+        # list with it, and the next `refresh_microscope` would hand a dead C++ object to
+        # `add_settings_section`. The list belongs to this tab and outlives any one
+        # overview, so it is moved out rather than left to be collected.
+        #
+        # Kept as a precondition rather than because a test proves it: under the
+        # offscreen platform the deferred delete does not actually run, so the failure it
+        # prevents cannot be reproduced here. `test_the_list_survives_the_overview_being_
+        # rebuilt` covers the reuse, not this mechanism.
+        self.lamella_list.setParent(self)
+        self.lamella_list.hide()
         try:
             self.overview.close()
         except Exception as e:
@@ -168,6 +199,10 @@ class FluorescenceOverviewTab(QWidget):
         self.overview.set_selected_position(
             lamella.name if lamella is not None else None
         )
+        # Not while this tab is the one that raised the selection: the list already shows
+        # what the user clicked, and re-selecting it would fight them mid-click.
+        if not self._syncing_selection and lamella is not None:
+            self.lamella_list.select(lamella.name)
 
     def refresh_positions(self) -> None:
         """Mark the experiment's lamellae on the fluorescence canvas.
@@ -188,7 +223,13 @@ class FluorescenceOverviewTab(QWidget):
         experiment = self.experiment
         if experiment is None:
             self.overview.set_positions([])
+            self.lamella_list.set_lamella([])
             return
+
+        # Every lamella, including the ones the canvas cannot place. The list is how you
+        # find out a lamella exists but has no fluorescence pose -- dropping those here
+        # too would leave the log as the only place that says so.
+        self.lamella_list.set_lamella(list(experiment.positions))
 
         positions, unplaceable = [], []
         for lamella in experiment.positions:
@@ -215,6 +256,64 @@ class FluorescenceOverviewTab(QWidget):
         if self.overview is None:
             return
         self.overview.set_interactive(enabled)
+
+    # ── the list ─────────────────────────────────────────────────────────
+
+    def _on_list_selection(self, lamella) -> None:
+        """A row was clicked: highlight it on the canvas, and tell the window.
+
+        The flag is what stops the round trip. The window answers by syncing every list
+        it knows about, this tab included, and re-selecting the row under a click that
+        is still happening moves the selection out from under the user.
+        """
+        self._syncing_selection = True
+        try:
+            if self.overview is not None:
+                self.overview.set_selected_position(
+                    lamella.name if lamella is not None else None
+                )
+            self.lamella_selected.emit(lamella)
+        finally:
+            self._syncing_selection = False
+
+    def _on_move_to_requested(self, lamella) -> None:
+        """Drive the stage to a lamella's *fluorescence* pose.
+
+        Not `stage_position`, which is the milling pose: this tab looks at the sample
+        from the fluorescence side, and moving to the milling pose from here would swing
+        the stage 180 degrees away from the view you asked to centre.
+        """
+        if lamella is None:
+            return
+        pose = lamella.fluorescence_pose
+        if pose is None or pose.stage_position is None:
+            notification_service.show_toast(
+                f"{lamella.name} has no fluorescence pose to move to.", "warning"
+            )
+            return
+        if self.overview is None:
+            return
+        self.overview.move_to(pose.stage_position)
+
+    def _on_remove_requested(self, lamella) -> None:
+        """Remove a lamella from the experiment.
+
+        The row's own button already asked -- `_LamellaRow._on_remove_clicked` puts up
+        the confirmation before it emits -- so this does not ask twice.
+        """
+        experiment = self.experiment
+        if experiment is None or lamella is None:
+            return
+        try:
+            experiment.positions.remove(lamella)
+        except ValueError:
+            logging.debug(f"Cannot remove {lamella.name!r}: not in the experiment.")
+            return
+        experiment.save()
+        # `positions` is an EventedList, so the window's own rebuild has already run off
+        # `removed` and re-marked this canvas. Saying it again would be a second full
+        # redraw for nothing.
+        notification_service.show_toast(f"Removed {lamella.name}.", "info")
 
     # ── turning a request into a lamella ─────────────────────────────────
 

--- a/fibsem/applications/autolamella/ui/fluorescence_overview_tab.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_overview_tab.py
@@ -1,0 +1,350 @@
+"""The FM Overview tab: the fluorescence overview, plus what an experiment adds to it.
+
+`FMOverviewWidget` knows nothing about lamellae. That is deliberate and worth keeping --
+it is what lets the same widget open standalone against a simulator, and be built in a
+test from a microscope alone. It says *where* a user pointed and leaves the meaning to
+whoever is listening.
+
+This is whoever is listening. It lives in the autolamella package because everything it
+adds is autolamella's: experiments, lamellae, poses, and the milling side of a sample the
+fluorescence canvas cannot see.
+
+A widget rather than a plain controller, because part of what it adds is *visible* --
+`LamellaNameListWidget` needs real `Lamella` objects (it subscribes to
+`lamella.events.description` and reads the defect and task state), so it cannot live
+inside the fluorescence widget. Something has to lay the two out together, and a QWidget
+that owns both is simpler than a controller reaching into another widget's layout.
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from typing import TYPE_CHECKING, Optional
+
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import QVBoxLayout, QWidget
+
+import fibsem.config as fibsem_cfg
+from fibsem.applications.autolamella.poses import (
+    FLUORESCENCE_ORIENTATION,
+    build_lamella_poses,
+)
+from fibsem.ui import notification_service
+from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+from fibsem.ui.utils import message_box_ui
+
+if TYPE_CHECKING:  # pragma: no cover - annotation only
+    from fibsem.applications.autolamella.structures import Lamella
+
+
+class FluorescenceOverviewTab(QWidget):
+    """Drives `FMOverviewWidget` on behalf of an experiment.
+
+    Built empty and filled in on connection: `FMOverviewWidget` requires a microscope
+    with a fluorescence detector at construction -- it has no meaningful empty state,
+    since every scale on its canvas comes from the camera -- and at the point the tab is
+    reserved there may be no microscope at all.
+    """
+
+    # Whether there is a live widget to drive. The window listens so it can enable or
+    # disable the tab; this object deliberately does not touch the tab bar, which is the
+    # one thing about the tab that is not its business.
+    availability_changed = pyqtSignal(bool)
+
+    def __init__(self, autolamella_ui, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.autolamella_ui = autolamella_ui
+        self.overview: Optional[FMOverviewWidget] = None
+        # The microscope the current widget was built for. A reconnection hands out a new
+        # object, and the old widget would go on reading geometry from an instrument
+        # nobody is driving (FIB-433), so the identity is worth keeping.
+        self._microscope = None
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+    # ── what the window asks ─────────────────────────────────────────────
+
+    @property
+    def is_available(self) -> bool:
+        """Whether there is a widget to drive, i.e. whether the tab does anything."""
+        return self.overview is not None
+
+    @property
+    def microscope(self):
+        return self.autolamella_ui.microscope if self.autolamella_ui is not None else None
+
+    @property
+    def experiment(self):
+        return self.autolamella_ui.experiment if self.autolamella_ui is not None else None
+
+    def refresh_microscope(self) -> None:
+        """Build, rebuild or drop the fluorescence widget to match the instrument.
+
+        Called on every connection. Rebuilds when the microscope object has changed,
+        because the widget holds its microscope for life and would otherwise be talking
+        to the previous one -- destructive of anything on the canvas, and the reason
+        FIB-433 exists to do this without throwing the view away.
+        """
+        microscope = self.microscope
+
+        if (
+            not fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED
+            or microscope is None
+            or microscope.fm is None
+        ):
+            # Switched off, or no fluorescence detector. The tab stays in place but dead
+            # rather than being removed, so the tab bar does not change shape between
+            # systems; hiding it is the window's job.
+            self._drop_overview()
+            self.availability_changed.emit(False)
+            return
+
+        if self.overview is not None:
+            if self._microscope is microscope:
+                return
+            self._drop_overview()
+
+        try:
+            self.overview = FMOverviewWidget(microscope)
+        except Exception as e:
+            logging.error(f"Could not create the FM overview tab: {e}")
+            self.availability_changed.emit(False)
+            return
+
+        self.overview.position_add_requested.connect(self._on_add_requested)
+        self.overview.position_move_requested.connect(self._on_move_requested)
+
+        self._microscope = microscope
+        self.layout().addWidget(self.overview)
+        self.availability_changed.emit(True)
+        self.refresh_experiment()
+
+    def _drop_overview(self) -> None:
+        """Retire the current fluorescence widget, if there is one.
+
+        `close()` rather than `deleteLater()` alone: the widget's `closeEvent` is what
+        releases its psygnal subscriptions on the microscope, and those outlive the
+        widget -- a stale one left connected emits into a torn-down Qt object.
+        """
+        if self.overview is None:
+            return
+        try:
+            self.overview.close()
+        except Exception as e:
+            logging.debug(f"Error closing the FM overview widget: {e}")
+        self.layout().removeWidget(self.overview)
+        self.overview.deleteLater()
+        self.overview = None
+        self._microscope = None
+
+    def refresh_experiment(self) -> None:
+        """Tell the fluorescence widget where to save, and what to mark.
+
+        Told rather than handed the experiment: the widget knows nothing about
+        experiments, and keeping it that way is what lets it open standalone against a
+        simulator and be constructed in a test from a microscope alone.
+        """
+        if self.overview is None:
+            return
+        experiment = self.experiment
+        self.overview.set_save_directory(
+            str(experiment.path) if experiment is not None else None
+        )
+        self.refresh_positions()
+
+    def set_selected(self, lamella) -> None:
+        """Highlight the selected lamella.
+
+        Called from each of the window's selection handlers *before* their
+        `_syncing_selection` guard, and deliberately: that guard exists to stop three
+        lists selecting each other in circles, and this is not a fourth list. It emits
+        nothing and only repaints, so it wants to run whichever list the selection came
+        from -- which is exactly what the guard suppresses.
+        """
+        if self.overview is None:
+            return
+        self.overview.set_selected_position(
+            lamella.name if lamella is not None else None
+        )
+
+    def refresh_positions(self) -> None:
+        """Mark the experiment's lamellae on the fluorescence canvas.
+
+        **Fluorescence poses, not the primary stage position.** A lamella carries one of
+        each and they are different places on this canvas -- on a compustage the stage
+        flips 180 degrees between them -- so passing the milling pose would mark every
+        lamella somewhere the sample is not.
+
+        A lamella with no fluorescence pose cannot be placed here at all, which is the
+        normal state on a system with no FM and possible on one loaded from an older
+        experiment. Those are counted rather than dropped in silence: a canvas showing
+        three of five positions and saying nothing is worse than one saying which two it
+        cannot show.
+        """
+        if self.overview is None:
+            return
+        experiment = self.experiment
+        if experiment is None:
+            self.overview.set_positions([])
+            return
+
+        positions, unplaceable = [], []
+        for lamella in experiment.positions:
+            pose = lamella.fluorescence_pose
+            if pose is None or pose.stage_position is None:
+                unplaceable.append(lamella.name)
+                continue
+            # Named here rather than relying on whatever the stored position carries:
+            # the marker's label is the lamella's name, and a pose saved before names
+            # were stamped on positions would otherwise draw an unlabelled dot.
+            position = deepcopy(pose.stage_position)
+            position.name = lamella.name
+            positions.append(position)
+
+        self.overview.set_positions(positions)
+        if unplaceable:
+            logging.info(
+                f"{len(unplaceable)} lamella(e) have no fluorescence pose and are not "
+                f"shown on the FM overview: {', '.join(unplaceable)}"
+            )
+
+    def set_interactive(self, enabled: bool) -> None:
+        """Allow or forbid starting work, for a host that has taken the instrument."""
+        if self.overview is None:
+            return
+        self.overview.set_interactive(enabled)
+
+    # ── turning a request into a lamella ─────────────────────────────────
+
+    def _objective_position(self) -> Optional[float]:
+        """Where the objective is right now, for a pose marked on the overview.
+
+        The focus a user is actually looking through beats the objective's *configured*
+        focus position, which `build_lamella_poses` falls back to: that one is a property
+        of the instrument and says nothing about this sample. Anyone marking a position
+        here has the feature in focus, and that focus is part of what they marked.
+
+        Unless the objective is retracted, in which case its position is a parking spot
+        ~10 mm from anything and nobody focused on anything. None hands the decision back
+        to the fallback -- which matters because `fluorescence_selected` only asks
+        whether an objective position exists, so a parked one would read as a focused
+        lamella.
+        """
+        microscope = self.microscope
+        if microscope is None or microscope.fm is None:
+            return None
+        try:
+            objective = microscope.fm.objective
+            if objective.state != "Inserted":
+                logging.debug(
+                    f"Objective is {objective.state}; falling back to its focus position."
+                )
+                return None
+            return objective.position
+        except Exception as e:
+            logging.debug(f"Could not read the objective position: {e}")
+            return None
+
+    def _on_add_requested(self, position) -> None:
+        """A user asked for a new lamella at a point on the overview.
+
+        The orientation is *declared* rather than left to be derived. On a compustage
+        deriving it would give the same answer; on an offset mount it would not, and the
+        wrong answer there is a lamella with a milling pose 48 mm off the beam axis that
+        nothing rejects until something tries to mill it (FIB-93). Declaring it turns
+        that into a refusal here, where there is a user to tell.
+        """
+        if self.autolamella_ui is None or self.experiment is None:
+            notification_service.show_toast(
+                "Load an experiment before marking positions.", "warning"
+            )
+            return
+        try:
+            lamella = self.autolamella_ui.add_new_lamella(
+                stage_position=position,
+                objective_position=self._objective_position(),
+                marked_at=FLUORESCENCE_ORIENTATION,
+            )
+        except Exception as e:
+            logging.error(f"Could not add a lamella from the FM overview: {e}")
+            notification_service.show_toast(str(e), "error")
+            return
+
+        self.refresh_positions()
+        self.set_selected(lamella)
+        notification_service.show_toast(f"Added {lamella.name}.", "info")
+
+    def _on_move_requested(self, name: str, position) -> None:
+        """A user asked to move a marked lamella to a point on the overview.
+
+        Confirmed first, because moving one pose moves both: the milling pose is derived
+        from this one, so a lamella dragged across the fluorescence view also stops being
+        where the beam was going to mill it. That is usually the point -- the two describe
+        one piece of sample -- but it is not visible from this canvas, which shows only
+        the fluorescence side, so it gets said rather than assumed.
+        """
+        experiment = self.experiment
+        if experiment is None:
+            return
+        lamella = next((p for p in experiment.positions if p.name == name), None)
+        if lamella is None:
+            logging.debug(f"Cannot move {name!r}: no such lamella in the experiment.")
+            return
+        if lamella.milling_pose is None:
+            notification_service.show_toast(
+                f"{name} has no milling pose to move.", "warning"
+            )
+            return
+
+        try:
+            poses = build_lamella_poses(
+                microscope=self.microscope,
+                position=position,
+                objective_position=self._objective_position(),
+                # Only reaches the result in one case, and it is worth it for that one:
+                # a lamella with no fluorescence pose yet gets a whole new one below, and
+                # it should be built on what this lamella recorded rather than on
+                # whatever the microscope happens to be set to now. Everywhere else only
+                # the stage positions are read, and those come from `position`.
+                state=lamella.milling_pose,
+                marked_at=FLUORESCENCE_ORIENTATION,
+            )
+        except Exception as e:
+            logging.error(f"Could not move {name} from the FM overview: {e}")
+            notification_service.show_toast(str(e), "error")
+            return
+
+        history = (
+            f"\n\n{name} has already completed "
+            f"{', '.join(lamella.completed_tasks)}."
+            if lamella.completed_tasks
+            else ""
+        )
+        if not message_box_ui(
+            title=f"Move {name}?",
+            text=(
+                f"Move {name} to {poses.fluorescence.stage_position.pretty_string}?"
+                f"\n\nThis moves the milling pose with it, to "
+                f"{poses.milling.stage_position.pretty_string}."
+                f"{history}"
+            ),
+            parent=self,
+        ):
+            return
+
+        # Only the stage positions are replaced, so anything else the poses carry --
+        # notably the objective position on a lamella that was focused by hand -- is
+        # kept. `stage_position` is the milling pose's, via the property.
+        lamella.stage_position = poses.milling.stage_position
+        lamella.update_milling_angle(self.microscope)
+        if lamella.fluorescence_pose is None:
+            lamella.fluorescence_pose = poses.fluorescence
+        else:
+            lamella.fluorescence_pose.stage_position = poses.fluorescence.stage_position
+
+        experiment.save()
+        self.refresh_positions()
+        self.autolamella_ui.update_ui()
+        notification_service.show_toast(f"Moved {name}.", "info")

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -31,6 +31,7 @@ from superqt import ensure_main_thread
 
 from fibsem import constants, conversions
 from fibsem.ui import notification_service
+from fibsem.applications.autolamella.poses import sync_fluorescence_pose
 from fibsem.applications.autolamella.protocol.constants import (
     FIDUCIAL_KEY,
     MICROEXPANSION_KEY,
@@ -979,6 +980,10 @@ class FibsemMinimapWidget(QWidget):
 
         # keep the milling angle consistent with the updated milling pose
         lamella.update_milling_angle(self.microscope)
+        # ...and the fluorescence pose, which describes the same piece of sample from
+        # the other side. Left behind, it would go on naming where this lamella used to
+        # be -- and nothing about a stale pose looks wrong.
+        sync_fluorescence_pose(self.microscope, lamella)
 
         self.parent_widget.experiment.save()
         self._update_position_display()

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -527,6 +527,10 @@ class FMOverviewWidget(QWidget):
                 f"{offset[1] * constants.SI_TO_MICRO:+.0f} µm from the stage"
             )
         self.tile_grid_panel.set_summary(summary)
+        # The text just changed, and it wraps -- so the panel may need to be a different
+        # height than it was. Only worth doing while it is up; opening it fits it anyway.
+        if self.tile_grid_panel.isVisible():
+            self._fit_tile_grid_panel()
 
     def _target_offset(self) -> Optional[Tuple[float, float]]:
         """How far the target sits from the stage, in metres, or None if not set.
@@ -664,14 +668,30 @@ class FMOverviewWidget(QWidget):
             self.tile_grid_panel.hide()
             return
 
+        self._fit_tile_grid_panel()
+        self.tile_grid_panel.show()
+        self.tile_grid_panel.raise_()
+
+    def _fit_tile_grid_panel(self) -> None:
+        """Size the tile grid panel to its contents and put it back in its corner.
+
+        Both together, and both whenever the summary changes rather than only when the
+        panel opens. The panel is a fixed width with a word-wrapped summary, so its
+        height is however many lines that text takes -- and the text grows: dragging the
+        grid adds a line saying how far it now sits from the stage. Sized once at open
+        time, the panel kept that height and clipped the extra lines top and bottom
+        (FIB-510).
+
+        The move is not optional after a resize. The panel is anchored by its top-*right*
+        corner, so its x is computed from its own width; leaving it alone would be fine
+        for a height change and wrong the moment the width followed.
+        """
         self.tile_grid_panel.adjustSize()
         # Anchored in global coordinates: the panel is a top-level tool window, so it
         # cannot be placed relative to the canvas in widget coordinates.
         canvas = self.canvas.canvas
         anchor = canvas.mapToGlobal(QPoint(canvas.width() - 8, 44))
         self.tile_grid_panel.move(anchor.x() - self.tile_grid_panel.width(), anchor.y())
-        self.tile_grid_panel.show()
-        self.tile_grid_panel.raise_()
 
     def set_image(self, image: FluorescenceImage) -> None:
         """Show an image at the stage position it was acquired at.

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -138,8 +138,11 @@ PREVIEW_KEY = "fm-preview"
 # Radius of the specimen grid, for the boundary circle. Matches the minimap's.
 GRID_RADIUS_M = 1000e-6
 
-# Yellow for "you are here", against the red grid origin and the amber of saved
-# positions -- three markers that must not be mistaken for each other.
+# All three position markers are crosshairs, so colour is the only thing telling them
+# apart -- they have to stay far enough apart to read at a glance, and away from the red
+# the canvas draws its origin in.
+#
+# Yellow for "you are here".
 CURRENT_POSITION_COLOUR = "#ffee58"
 # Cyan for positions a user saved, against the yellow of where the stage is.
 SAVED_POSITION_COLOUR = "#26c6da"
@@ -307,8 +310,11 @@ class FMOverviewWidget(QWidget):
         )
         self.canvas.canvas.add_overlay(self.current_position_overlay)
 
+        # Crosshairs rather than dots: a marked position is a point on the sample, and
+        # a filled dot covers the feature it is naming. The gap in the middle is the
+        # whole reason -- you can see what you marked.
         self.position_overlay = PointsOverlay(
-            color=SAVED_POSITION_COLOUR, marker="o", size=7
+            color=SAVED_POSITION_COLOUR, marker="+", size=11
         )
         self.canvas.canvas.add_overlay(self.position_overlay)
 
@@ -317,7 +323,7 @@ class FMOverviewWidget(QWidget):
         # marker is not worth teaching it per-point colours for. Added last, so it
         # draws over its unselected neighbours where markers crowd together.
         self.selected_position_overlay = PointsOverlay(
-            color=SELECTED_POSITION_COLOUR, marker="o", size=10
+            color=SELECTED_POSITION_COLOUR, marker="+", size=15
         )
         self.canvas.canvas.add_overlay(self.selected_position_overlay)
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -53,7 +53,11 @@ from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
 )
 from fibsem.ui.widgets.canvas.overlays.point_overlay import PointsOverlay
 from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import TileGridOverlay
-from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.ui.widgets.custom_widgets import (
+    ContextMenu,
+    ContextMenuConfig,
+    TitledPanel,
+)
 from fibsem.ui.widgets.progress_widget import (
     FibsemProgressWidget,
     ProgressUpdate,
@@ -155,6 +159,18 @@ class FMOverviewWidget(QWidget):
     """Configure, run and view a fluorescence overview acquisition."""
 
     overview_acquired = pyqtSignal(FluorescenceImage)
+
+    # A user right-clicked the canvas and asked for a position there. Both carry a
+    # *fluorescence* stage position -- the canvas is anchored on the FM side, and both
+    # are only ever emitted with the stage in a valid FM orientation, so the rotation
+    # and tilt they carry are the fluorescence ones.
+    #
+    # Requests, not commands, and deliberately: this widget knows nothing about
+    # lamellae or experiments, which is what lets it open standalone against a
+    # simulator. A host that owns an experiment decides what a position *means*, whether
+    # the user should be asked first, and what else moves with it.
+    position_add_requested = pyqtSignal(object)  # FibsemStagePosition
+    position_move_requested = pyqtSignal(str, object)  # name, FibsemStagePosition
 
     # Internal hop from the acquisition thread to the GUI thread. The microscope's
     # progress signal is a psygnal, which calls its callbacks synchronously on
@@ -430,6 +446,7 @@ class FMOverviewWidget(QWidget):
         self.tile_grid_overlay.grid_resize_requested.connect(self._on_grid_resize)
         self.tile_grid_overlay.grid_move_requested.connect(self._on_grid_move)
         self.canvas.canvas.canvas_double_clicked.connect(self._on_canvas_double_clicked)
+        self.canvas.canvas.canvas_right_clicked.connect(self._on_canvas_right_clicked)
         self.canvas.canvas.cursor_moved.connect(self._on_cursor_moved)
 
     def _section(self, title: str, widget: QWidget) -> QWidget:
@@ -1103,25 +1120,116 @@ class FMOverviewWidget(QWidget):
             )
             return
 
+        target = self._stage_position_at(x, y)
+        if target is None:
+            return
+
+        self.status.setText(f"Moving to {self._describe(target)}…")
+        worker = FunctionWorker(self._move_worker, target)
+        worker.start()
+
+    def _on_canvas_right_clicked(self, x: float, y: float, modifiers=None) -> None:
+        """Offer to put a position at the right-clicked point."""
+        config = self._position_menu(x, y)
+        if config is None:
+            return
+        ContextMenu(config, parent=self).show_at_cursor()
+
+    def _position_menu(self, x: float, y: float) -> Optional[ContextMenuConfig]:
+        """What right-clicking at a canvas point offers, or None to offer nothing.
+
+        Separate from showing it because `show_at_cursor` runs a modal event loop, and
+        everything worth checking -- whether the menu appears at all, what it offers,
+        and which position each entry would request -- is decided here. A test that had
+        to open the menu could only hang.
+
+        The widget creates nothing itself: each entry emits a request and lets a host
+        that owns an experiment decide. So the menu appears whenever the point is
+        somewhere the stage could go, even with nobody listening -- there is nothing
+        here that could tell the difference, and a menu that stayed shut because no host
+        was connected would make the standalone app behave differently for no visible
+        reason.
+        """
+        if self._running or self.is_acquiring or not self._interactive:
+            # `_running` and `_interactive` are the two facts `_apply_enabled_state`
+            # gates the controls on, and this is gated on the same two for the same
+            # reason: marking is cheap in itself, but a host that has taken the
+            # instrument is usually a workflow iterating `experiment.positions`, and
+            # adding one underneath it is not a thing to do quietly. `is_acquiring`
+            # comes along because the double-click asks it, and a right-click that was
+            # allowed where a double-click was refused would just be confusing.
+            notification_service.show_toast(
+                "Cannot mark positions while an acquisition is running.", "warning"
+            )
+            return None
+        # Stricter than the double-click's check, and deliberately so. Moving works from
+        # any pose: the whole scene -- images, markers, grid -- is re-placed through the
+        # pose the stage is in (see `_posed`), so a click still lands on the feature it
+        # points at. Marking has to survive being written down: the position becomes a
+        # lamella's *fluorescence* pose, and one carrying SEM rotation and tilt is not
+        # one, however right it looked on screen.
+        #
+        # `fm.has_valid_orientation()` is the wrong question here -- it asks whether FM
+        # acquisition is allowed, which SEM and MILLING both are, and which
+        # `ALLOW_UNKNOWN_ORIENTATIONS` currently answers yes to unconditionally.
+        #
+        # Asked of `fm.default_orientation` rather than a constant of our own, because
+        # that is the orientation `build_lamella_poses` derives a fluorescence pose
+        # *into*. Two names for the same thing could drift; one cannot.
+        orientation = self.microscope.get_stage_orientation()
+        if orientation != self.fm.default_orientation:
+            notification_service.show_toast(
+                f"Move to the fluorescence position before marking on the overview "
+                f"(the stage is at {orientation}).",
+                "warning",
+            )
+            return None
+
+        target = self._stage_position_at(x, y)
+        if target is None:
+            return None
+
+        config = ContextMenuConfig()
+        config.add_action(
+            "Add Position Here",
+            callback=lambda: self.position_add_requested.emit(target),
+            tooltip=f"Add a position at {self._describe(target)}",
+        )
+        selected = self._selected_position
+        if selected:
+            config.add_action(
+                f"Move Selected Position Here ({selected})",
+                callback=lambda: self.position_move_requested.emit(selected, target),
+                tooltip=f"Move {selected} to {self._describe(target)}",
+            )
+        return config
+
+    def _stage_position_at(self, x: float, y: float) -> Optional[FibsemStagePosition]:
+        """The stage position a canvas point names, or None if it is not usable.
+
+        Shared by clicking to move and right-clicking to mark, so the two cannot
+        disagree about where a point is -- which they would eventually, being the same
+        arithmetic written twice.
+
+        Outside the limits counts as not usable for both: the stage cannot go there, so
+        it is neither somewhere to move nor somewhere to put a lamella.
+        """
         frame = self._frame()
         if frame is None:
-            return
+            return None
         try:
             target = frame.to_stage(x, y)
         except Exception as e:
             logging.debug(f"Could not resolve the clicked position: {e}")
-            return
+            return None
 
         limits = getattr(self.microscope._stage, "limits", None)
         if limits and not target.is_within_limits(limits, axes=["x", "y"]):
             notification_service.show_toast(
                 "That position is outside the stage limits.", "warning"
             )
-            return
-
-        self.status.setText(f"Moving to {self._describe(target)}…")
-        worker = FunctionWorker(self._move_worker, target)
-        worker.start()
+            return None
+        return target
 
     def _move_worker(self, target: FibsemStagePosition) -> None:
         """Runs off the GUI thread. Only signals may cross back."""

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -139,6 +139,9 @@ GRID_RADIUS_M = 1000e-6
 CURRENT_POSITION_COLOUR = "#ffee58"
 # Cyan for positions a user saved, against the yellow of where the stage is.
 SAVED_POSITION_COLOUR = "#26c6da"
+# Lime for the one selected, matching the minimap so the same position reads the same
+# way on both. Bright enough to find at a glance among a grid full of cyan.
+SELECTED_POSITION_COLOUR = "#76ff03"
 # Muted, because the holder slots are structural context like the limits rather
 # than something anyone marked -- and they would otherwise read as saved positions.
 SLOT_COLOUR = "#90a4ae"
@@ -187,6 +190,8 @@ class FMOverviewWidget(QWidget):
         # whole scene each time one arrived. Taken from the first image displayed.
         self._origin: Optional[FibsemStagePosition] = None
         self._positions: List[FibsemStagePosition] = []
+        # Which marked position is selected, by name. See `set_selected_position`.
+        self._selected_position: Optional[str] = None
         self._grid_footprint: Optional[tuple] = None
         self._enabled_channels: Optional[List[ChannelSettings]] = None
         # Where the stage is, as far as anyone has told us. Cached rather than polled
@@ -290,6 +295,15 @@ class FMOverviewWidget(QWidget):
             color=SAVED_POSITION_COLOUR, marker="o", size=7
         )
         self.canvas.canvas.add_overlay(self.position_overlay)
+
+        # The selected position, on its own layer rather than as a colour within the
+        # one above: `PointsOverlay` paints every point the same, and one selected
+        # marker is not worth teaching it per-point colours for. Added last, so it
+        # draws over its unselected neighbours where markers crowd together.
+        self.selected_position_overlay = PointsOverlay(
+            color=SELECTED_POSITION_COLOUR, marker="o", size=10
+        )
+        self.canvas.canvas.add_overlay(self.selected_position_overlay)
 
         # The list alone shows only name/excitation/emission, with no way to set the
         # exposure, power or gain a tile is actually acquired at. This composes the
@@ -719,9 +733,28 @@ class FMOverviewWidget(QWidget):
 
         Names are carried onto the markers, so a caller does not have to keep a
         parallel list of labels in the order it happened to pass them.
+
+        These are *fluorescence* poses. A lamella carries one of each, and the beam-side
+        pose is a different place on this canvas -- on a compustage the stage flips
+        between them -- so a host passing the wrong one would mark every position
+        somewhere the sample is not. See `build_lamella_poses`.
         """
         self._positions = list(positions)
         self._refresh_positions()
+
+    def set_selected_position(self, name: Optional[str]) -> None:
+        """Pick out one of the marked positions, or None for none.
+
+        By name rather than index: the host's list and this one are rebuilt
+        independently from the same experiment, and an index would silently point at a
+        different lamella the moment one was removed.
+        """
+        self._selected_position = name or None
+        self._refresh_positions()
+
+    @property
+    def selected_position(self) -> Optional[str]:
+        return self._selected_position
 
     def set_save_directory(self, path: Optional[str]) -> None:
         """Write acquired overviews under *path*, or None to keep them in memory only.
@@ -1000,18 +1033,29 @@ class FMOverviewWidget(QWidget):
         frame = self._frame()
         if not self._positions or frame is None:
             self.position_overlay.set_points([])
+            self.selected_position_overlay.set_points([])
             return
 
         points, labels = [], []
+        selected_points, selected_labels = [], []
         for position in self._positions:
             try:
-                points.append(frame.to_canvas(position))
+                point = frame.to_canvas(position)
             except Exception as e:
                 logging.debug(f"Cannot mark {position.name!r}: {e}")
                 continue
-            labels.append(position.name or "")
+            name = position.name or ""
+            if name and name == self._selected_position:
+                selected_points.append(point)
+                selected_labels.append(name)
+            else:
+                points.append(point)
+                labels.append(name)
 
         self.position_overlay.set_points(points, labels=labels)
+        self.selected_position_overlay.set_points(
+            selected_points, labels=selected_labels
+        )
 
     # ── canvas interaction ───────────────────────────────────────────────
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -1124,13 +1124,43 @@ class FMOverviewWidget(QWidget):
         the poll that raised the signal saw, so taking it costs nothing and cannot
         disagree with what prompted the update.
         """
+        reposed = self._pose_changed(position)
         self._stage_position = position
         self._refresh_current_position()
+        # Everything else on the canvas is placed through a frame whose rotation and
+        # tilt come from wherever the stage is (see `_posed`), so a re-pose moves all of
+        # it. Redrawn only when the pose actually changes: the stage is polled
+        # constantly, and a translation leaves every one of these exactly where it was --
+        # the origin they are measured from moves with nothing.
+        if reposed:
+            self._refresh_positions()
+            self._refresh_stage_metadata()
         # The grid follows the stage only when it is not pinned to a target and not
         # mid-run. During a run the stage visits every tile in turn, and a grid that
         # followed would crawl across the canvas describing nothing.
         if self._target is None and not self.is_acquiring:
             self._refresh_tile_grid()
+
+    def _pose_changed(self, position: FibsemStagePosition) -> bool:
+        """Whether *position* is at a different rotation or tilt from the last one.
+
+        Only r and t, because only they enter the frame. Where the stage has travelled
+        to is not part of how stage space maps onto the canvas -- canvas zero is the
+        origin, and it does not move.
+        """
+        previous = self._stage_position
+        if previous is None:
+            return position.r is not None or position.t is not None
+        for now, before in ((position.r, previous.r), (position.t, previous.t)):
+            if now is None or before is None:
+                if now is not before:
+                    return True
+                continue
+            # Well below anything a user could mean and well above float noise on a
+            # value that has been through a couple of transforms.
+            if abs(now - before) > 1e-9:
+                return True
+        return False
 
     def _on_canvas_double_clicked(self, x: float, y: float, modifiers=None) -> None:
         """Move the stage to the double-clicked point.

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -174,6 +174,9 @@ class FMOverviewWidget(QWidget):
     # the user should be asked first, and what else moves with it.
     position_add_requested = pyqtSignal(object)  # FibsemStagePosition
     position_move_requested = pyqtSignal(str, object)  # name, FibsemStagePosition
+    # A marked position was clicked. Emitted with the name it was marked under, so a
+    # host can select whatever that name means to it.
+    position_selected = pyqtSignal(str)
 
     # Internal hop from the acquisition thread to the GUI thread. The microscope's
     # progress signal is a psygnal, which calls its callbacks synchronously on
@@ -451,6 +454,7 @@ class FMOverviewWidget(QWidget):
         self.tile_grid_overlay.tile_toggled.connect(self._on_tile_toggled)
         self.tile_grid_overlay.grid_resize_requested.connect(self._on_grid_resize)
         self.tile_grid_overlay.grid_move_requested.connect(self._on_grid_move)
+        self.canvas.canvas.canvas_clicked.connect(self._on_canvas_clicked)
         self.canvas.canvas.canvas_double_clicked.connect(self._on_canvas_double_clicked)
         self.canvas.canvas.canvas_right_clicked.connect(self._on_canvas_right_clicked)
         self.canvas.canvas.cursor_moved.connect(self._on_cursor_moved)
@@ -1161,6 +1165,59 @@ class FMOverviewWidget(QWidget):
             if abs(now - before) > 1e-9:
                 return True
         return False
+
+    def _on_canvas_clicked(self, x: float, y: float, modifiers=None) -> None:
+        """Select a marked position if the click landed on one.
+
+        A miss leaves the selection alone rather than clearing it, which is where this
+        parts company with the minimap's interactive overlay. Clearing would have to
+        travel: the host syncs its other lists from the selection, and their handlers
+        ignore None -- so an empty click would blank this canvas and nothing else, which
+        is worse than a selection that outstays its welcome. Nothing here is destroyed
+        by keeping it.
+        """
+        name = self._position_at(x, y)
+        if name is None:
+            return
+        self.set_selected_position(name)
+        self.position_selected.emit(name)
+
+    # Screen-space hit radius, matching `PointOverlay`'s. In pixels rather than stage
+    # microns so that how close you have to click does not change with the zoom.
+    PICK_RADIUS_PX = 12
+
+    def _position_at(self, x: float, y: float) -> Optional[str]:
+        """The marked position under a canvas point, or None.
+
+        Measured on screen, not in data units: at a wide zoom every marker would be
+        within any sensible micron radius of the click, and at a tight one none would be.
+        """
+        frame = self._frame()
+        ax = getattr(self.canvas.canvas, "_ax", None)
+        if frame is None or ax is None or not self._positions:
+            return None
+        try:
+            transform = ax.transData
+            click = transform.transform((x, y))
+        except Exception as e:
+            logging.debug(f"Could not resolve the click for picking: {e}")
+            return None
+
+        best_name, best_distance = None, float(self.PICK_RADIUS_PX)
+        for position in self._positions:
+            name = position.name
+            if not name:
+                continue
+            try:
+                point = transform.transform(frame.to_canvas(position))
+            except Exception:
+                continue
+            distance = (
+                (click[0] - point[0]) ** 2 + (click[1] - point[1]) ** 2
+            ) ** 0.5
+            if distance < best_distance:
+                best_name, best_distance = name, distance
+        return best_name
 
     def _on_canvas_double_clicked(self, x: float, y: float, modifiers=None) -> None:
         """Move the stage to the double-clicked point.

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -338,12 +338,12 @@ class FMOverviewWidget(QWidget):
         )
 
         controls = QWidget()
-        controls_layout = QVBoxLayout(controls)
-        controls_layout.setContentsMargins(8, 8, 8, 8)
-        controls_layout.setSpacing(10)
-        controls_layout.addWidget(self._section("Channels", self.channel_widget))
-        controls_layout.addWidget(self.settings_widget)
-        controls_layout.addStretch()
+        self._controls_layout = QVBoxLayout(controls)
+        self._controls_layout.setContentsMargins(8, 8, 8, 8)
+        self._controls_layout.setSpacing(10)
+        self._controls_layout.addWidget(self._section("Channels", self.channel_widget))
+        self._controls_layout.addWidget(self.settings_widget)
+        self._controls_layout.addStretch()
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
@@ -751,6 +751,32 @@ class FMOverviewWidget(QWidget):
             logging.debug(f"Could not place {position} in the canvas frame: {e}")
             return (0.0, 0.0)
 
+    def add_settings_section(self, title: str, widget: QWidget, first: bool = True) -> None:
+        """Put a host's own controls in the settings column, under *title*.
+
+        Part of the host contract, alongside `set_positions` and `set_save_directory`,
+        and for the same reason: some of what belongs on this tab needs to know things
+        this widget must not. A list of the experiment's lamellae is the case in point --
+        its rows subscribe to `lamella.events.description` and read task and defect
+        state, so it cannot be built here without dragging the whole application layer
+        in behind it.
+
+        A slot rather than the host laying out its own column beside this one, because
+        the alternative reads as a third pane: the settings already have a column, and
+        these controls belong *in* it, next to everything else that is about the run.
+
+        `first` because a host's section is usually the subject of the tab rather than a
+        footnote to it -- what you came to look at, above the parameters of the next
+        acquisition. Appended before the trailing stretch either way, so the column
+        stays top-aligned.
+        """
+        section = self._section(title, widget)
+        if first:
+            self._controls_layout.insertWidget(0, section)
+        else:
+            # -1 is the stretch added in `_init_ui`; stay above it.
+            self._controls_layout.insertWidget(self._controls_layout.count() - 1, section)
+
     def set_positions(self, positions: List[FibsemStagePosition]) -> None:
         """Stage positions to mark on the overview, e.g. saved lamella positions.
 
@@ -1113,25 +1139,48 @@ class FMOverviewWidget(QWidget):
         coincidence viewer: a single click is how the canvas is explored, and a stage
         that moved on every stray click would be unusable.
         """
+        target = self._stage_position_at(x, y) if self._may_move() else None
+        if target is None:
+            return
+        self.move_to(target)
+
+    def _may_move(self) -> bool:
+        """Whether driving the stage from this tab is allowed right now, and say if not."""
         if self.is_acquiring:
             notification_service.show_toast(
                 "Cannot move the stage during an acquisition.", "warning"
             )
-            return
+            return False
         if not self.fm.has_valid_orientation():
             notification_service.show_toast(
                 f"Stage must be in a valid FM orientation to move via the overview "
                 f"(currently {self.microscope.get_stage_orientation()}).",
                 "warning",
             )
+            return False
+        return True
+
+    def move_to(self, position: FibsemStagePosition) -> None:
+        """Drive the stage to *position*, off the GUI thread.
+
+        Public because a host drives it too -- picking a saved position out of a list is
+        the same act as double-clicking where it is drawn, and they should not be able to
+        disagree about whether a move is allowed or how it is reported.
+
+        The limits are checked here rather than trusted from the caller: a stored
+        position can be outside them on a system it was not recorded on.
+        """
+        if not self._may_move():
+            return
+        limits = getattr(self.microscope._stage, "limits", None)
+        if limits and not position.is_within_limits(limits, axes=["x", "y"]):
+            notification_service.show_toast(
+                "That position is outside the stage limits.", "warning"
+            )
             return
 
-        target = self._stage_position_at(x, y)
-        if target is None:
-            return
-
-        self.status.setText(f"Moving to {self._describe(target)}…")
-        worker = FunctionWorker(self._move_worker, target)
+        self.status.setText(f"Moving to {self._describe(position)}…")
+        worker = FunctionWorker(self._move_worker, position)
         worker.start()
 
     def _on_canvas_right_clicked(self, x: float, y: float, modifiers=None) -> None:

--- a/fibsem/ui/fm/widgets/tile_grid_options_panel.py
+++ b/fibsem/ui/fm/widgets/tile_grid_options_panel.py
@@ -139,8 +139,23 @@ class TileGridOptionsPanel(QFrame):
         root.addWidget(self.slider_alpha)
 
     def set_summary(self, text: str) -> None:
-        """What the grid currently describes, e.g. `3 x 3 - 10% overlap - 9/9 tiles`."""
+        """What the grid currently describes, e.g. `3 x 3 - 10% overlap - 9/9 tiles`.
+
+        The minimum height is set from the label's own `heightForWidth` because nothing
+        else will. A word-wrapped QLabel's height depends on the width it is given, and
+        that dependency does not reach this panel's own size hint -- so as the summary
+        grew (dragging the grid adds a line saying how far it sits from the stage, and
+        that line wraps) the label kept a height computed for fewer lines and clipped
+        the text top and bottom, the overflow split evenly because a QLabel centres its
+        text vertically (FIB-510).
+
+        Measured rather than reasoned: at 196px wide the label reported height 36 for
+        text needing 48 -- exactly one line short.
+        """
         self.label_summary.setText(text)
+        label = self.label_summary
+        width = label.width() or (self.width() - 24)  # 24 = the layout's l/r margins
+        label.setMinimumHeight(label.heightForWidth(width))
 
     def set_centre_enabled(self, enabled: bool) -> None:
         """Whether the grid is off the stage position, and so worth re-centring."""

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -82,9 +82,27 @@ class PointsOverlay(CanvasOverlay):
                 pass
         self._artists.clear()
 
+    def _marker_edge(self):
+        """Edge colour and width for the marker.
+
+        Unfilled markers (+, x, ...) have no face, so they are drawn entirely in their
+        edge colour: giving them a white one painted every point white whatever colour
+        it was asked for, and left the label as the only thing carrying the colour.
+        Filled markers (o, s, ...) keep the thin white outline, which is what makes them
+        legible against a bright image.
+
+        Same rule as `PointOverlay._marker_edge` below, which had it right.
+        """
+        from matplotlib.lines import Line2D
+
+        if self._marker in Line2D.filled_markers:
+            return "white", 0.8
+        return self._color, 2.0
+
     def _draw(self):
         if self._ax is None:
             return
+        edge_color, edge_width = self._marker_edge()
         for i, (x, y) in enumerate(self._points, 1):
             (line,) = self._ax.plot(
                 x,
@@ -92,8 +110,8 @@ class PointsOverlay(CanvasOverlay):
                 marker=self._marker,
                 markersize=self._size,
                 color=self._color,
-                markeredgecolor="white",
-                markeredgewidth=0.8,
+                markeredgecolor=edge_color,
+                markeredgewidth=edge_width,
                 linestyle="none",
                 zorder=8,
             )

--- a/tests/autolamella/test_poses.py
+++ b/tests/autolamella/test_poses.py
@@ -11,6 +11,8 @@ No Qt and no experiment here: this is the arithmetic, and it is worth being able
 it without either.
 """
 
+from copy import deepcopy
+
 import numpy as np
 import pytest
 
@@ -19,6 +21,7 @@ from fibsem.applications.autolamella.poses import (
     FLUORESCENCE_ORIENTATION,
     MILLING_ORIENTATION,
     build_lamella_poses,
+    sync_fluorescence_pose,
 )
 from fibsem.structures import FibsemStagePosition
 
@@ -248,3 +251,112 @@ def test_marking_from_the_beam_side_still_works_on_an_offset_mount():
 
     assert poses.milling.stage_position.x == pytest.approx(marked.x)
     assert poses.fluorescence is None
+
+
+# ── keeping the two in step when only one of them moves ──────────────────
+
+
+def _lamella(microscope, x=100e-6, y=50e-6, with_fluorescence=True):
+    """A stand-in lamella with both poses, built the way the app builds them."""
+    poses = build_lamella_poses(microscope, _at(microscope, MILLING_ORIENTATION, x, y))
+
+    class _Lamella:
+        name = "Lamella-01"
+
+    lamella = _Lamella()
+    lamella.milling_pose = poses.milling
+    lamella.fluorescence_pose = poses.fluorescence if with_fluorescence else None
+    return lamella
+
+
+def _move_milling_to(microscope, lamella, x, y):
+    """Move only the milling pose, as every beam-side caller has always done."""
+    lamella.milling_pose.stage_position = _at(microscope, MILLING_ORIENTATION, x, y)
+
+
+def test_the_fluorescence_pose_follows_a_milling_pose_that_moved():
+    """The bug this exists for. A lamella moved on the beam side kept a fluorescence
+    pose describing where it used to be -- and nothing about a stale pose looks wrong."""
+    microscope = _microscope()
+    lamella = _lamella(microscope)
+    _move_milling_to(microscope, lamella, 400e-6, -200e-6)
+
+    assert sync_fluorescence_pose(microscope, lamella) is True
+
+    assert lamella.fluorescence_pose.stage_position.x == pytest.approx(400e-6)
+    assert lamella.fluorescence_pose.stage_position.y == pytest.approx(-200e-6)
+
+
+def test_the_synced_pose_is_still_in_the_fluorescence_orientation():
+    """Only the place moves. A pose that came back carrying the milling tilt would put
+    the stage 157 degrees from where the objective is."""
+    microscope = _microscope()
+    lamella = _lamella(microscope)
+    _move_milling_to(microscope, lamella, 400e-6, -200e-6)
+
+    sync_fluorescence_pose(microscope, lamella)
+
+    assert (
+        microscope.get_stage_orientation(lamella.fluorescence_pose.stage_position)
+        == FLUORESCENCE_ORIENTATION
+    )
+
+
+def test_syncing_keeps_the_objective_position():
+    """Someone focused on this lamella by hand. Moving it sideways is not a reason to
+    throw that away, and re-deriving the whole pose would."""
+    microscope = _microscope()
+    lamella = _lamella(microscope)
+    lamella.fluorescence_pose.objective_position = 7.7e-3
+    _move_milling_to(microscope, lamella, 400e-6, -200e-6)
+
+    sync_fluorescence_pose(microscope, lamella)
+
+    assert lamella.fluorescence_pose.objective_position == pytest.approx(7.7e-3)
+
+
+def test_a_lamella_with_no_fluorescence_pose_is_not_given_one():
+    """It has never been marked under fluorescence, and `fluorescence_selected` asks
+    only whether an objective position exists -- so conjuring one here would make a
+    lamella nobody has looked at report itself as focused."""
+    microscope = _microscope()
+    lamella = _lamella(microscope, with_fluorescence=False)
+    _move_milling_to(microscope, lamella, 400e-6, -200e-6)
+
+    assert sync_fluorescence_pose(microscope, lamella) is False
+    assert lamella.fluorescence_pose is None
+
+
+def test_an_offset_mount_says_so_rather_than_inventing_a_pose():
+    """There is no transform between the two sides there (FIB-93). The existing pose is
+    left alone -- it was put there deliberately and is the better of two bad answers --
+    and the caller is told the sync did not happen."""
+    microscope = _microscope(compustage=False)
+    lamella = _lamella(microscope)
+    lamella.fluorescence_pose = deepcopy(lamella.milling_pose)
+    lamella.fluorescence_pose.stage_position = _at(
+        microscope, FLUORESCENCE_ORIENTATION, 1e-6, 2e-6
+    )
+    _move_milling_to(microscope, lamella, 400e-6, -200e-6)
+
+    assert sync_fluorescence_pose(microscope, lamella) is False
+    assert lamella.fluorescence_pose.stage_position.x == pytest.approx(1e-6)
+
+
+def test_syncing_agrees_with_marking_the_same_position_afresh():
+    """A moved lamella and a newly marked one at the same place have to describe the
+    same thing. Two routes to a fluorescence pose that disagreed would be a bug that
+    only showed up on lamellae with a history."""
+    microscope = _microscope()
+    lamella = _lamella(microscope)
+    _move_milling_to(microscope, lamella, 400e-6, -200e-6)
+    sync_fluorescence_pose(microscope, lamella)
+
+    fresh = build_lamella_poses(
+        microscope, _at(microscope, MILLING_ORIENTATION, 400e-6, -200e-6)
+    )
+
+    moved = lamella.fluorescence_pose.stage_position
+    assert moved.x == pytest.approx(fresh.fluorescence.stage_position.x, abs=1e-12)
+    assert moved.y == pytest.approx(fresh.fluorescence.stage_position.y, abs=1e-12)
+    assert moved.t == pytest.approx(fresh.fluorescence.stage_position.t, abs=1e-9)

--- a/tests/autolamella/test_poses.py
+++ b/tests/autolamella/test_poses.py
@@ -1,0 +1,250 @@
+"""Deriving a lamella's two poses from wherever it was marked.
+
+The property under test is a round trip: a lamella marked on the beam side gets a
+fluorescence pose derived from it, and feeding *that* back in has to describe the same
+lamella. It did not, before the orientation was read off the position — a fluorescence
+position was taken as somewhere to mill, giving a milling pose at t = -180, which is not
+an orientation anything mills at. Nothing rejected it; it would have failed later,
+somewhere else.
+
+No Qt and no experiment here: this is the arithmetic, and it is worth being able to test
+it without either.
+"""
+
+import numpy as np
+import pytest
+
+from fibsem import utils
+from fibsem.applications.autolamella.poses import (
+    FLUORESCENCE_ORIENTATION,
+    MILLING_ORIENTATION,
+    build_lamella_poses,
+)
+from fibsem.structures import FibsemStagePosition
+
+
+def _microscope(compustage: bool = True, with_fm: bool = True):
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.stage_is_compustage = compustage
+    microscope.system.stage.shuttle_pre_tilt = 0
+    microscope._update_orientations()
+    if with_fm and microscope.fm is None:
+        from fibsem.fm.microscope import FluorescenceMicroscope
+
+        microscope.fm = FluorescenceMicroscope(parent=microscope)
+    if not with_fm:
+        microscope.fm = None
+    return microscope
+
+
+def _at(microscope, orientation: str, x: float = 100e-6, y: float = 50e-6):
+    """A stage position in a named orientation, off-centre so a lost x/y shows up."""
+    pose = microscope.get_orientation(orientation)
+    return FibsemStagePosition(x=x, y=y, z=0.0, r=pose.r, t=pose.t)
+
+
+# ── the round trip ───────────────────────────────────────────────────────
+
+
+def test_a_fluorescence_pose_fed_back_describes_the_same_lamella():
+    """The invariant. Mark a lamella on the beam side, take the fluorescence pose it
+    derives, hand that back — both poses must come out the same."""
+    microscope = _microscope()
+    marked = _at(microscope, MILLING_ORIENTATION)
+
+    first = build_lamella_poses(microscope, marked)
+    again = build_lamella_poses(microscope, first.fluorescence.stage_position)
+
+    assert again.milling.stage_position.x == pytest.approx(
+        first.milling.stage_position.x, abs=1e-12
+    )
+    assert again.milling.stage_position.y == pytest.approx(
+        first.milling.stage_position.y, abs=1e-12
+    )
+    assert again.milling.stage_position.t == pytest.approx(
+        first.milling.stage_position.t, abs=1e-9
+    )
+    assert again.fluorescence.stage_position.t == pytest.approx(
+        first.fluorescence.stage_position.t, abs=1e-9
+    )
+
+
+def test_a_fluorescence_position_is_not_taken_as_somewhere_to_mill():
+    """The failure this exists to stop. Handed a fluorescence position, the old path
+    set it as the milling pose verbatim — a milling pose at t = -180."""
+    microscope = _microscope()
+    fm_position = _at(microscope, FLUORESCENCE_ORIENTATION)
+
+    poses = build_lamella_poses(microscope, fm_position)
+
+    assert (
+        microscope.get_stage_orientation(poses.milling.stage_position)
+        == MILLING_ORIENTATION
+    )
+    assert np.rad2deg(poses.milling.stage_position.t) != pytest.approx(-180.0)
+
+
+def test_a_fluorescence_position_is_kept_as_the_fluorescence_pose():
+    """It is what the user actually picked — deriving it back would be a round trip
+    through an orientation for no reason, and any error in the transform would land on
+    the one position that was known exactly."""
+    microscope = _microscope()
+    fm_position = _at(microscope, FLUORESCENCE_ORIENTATION)
+
+    poses = build_lamella_poses(microscope, fm_position)
+
+    assert poses.fluorescence.stage_position.x == pytest.approx(fm_position.x)
+    assert poses.fluorescence.stage_position.y == pytest.approx(fm_position.y)
+    assert poses.fluorescence.stage_position.t == pytest.approx(fm_position.t)
+
+
+def test_marking_moves_neither_pose_laterally():
+    """Only the orientation is rewritten. A transform that shifted x or y would put the
+    lamella somewhere nobody pointed at, which is the whole family of bug this comes
+    from."""
+    microscope = _microscope()
+    fm_position = _at(microscope, FLUORESCENCE_ORIENTATION, x=321e-6, y=-123e-6)
+
+    poses = build_lamella_poses(microscope, fm_position)
+
+    for pose in (poses.milling, poses.fluorescence):
+        assert pose.stage_position.x == pytest.approx(321e-6, abs=1e-12)
+        assert pose.stage_position.y == pytest.approx(-123e-6, abs=1e-12)
+
+
+# ── beam-side behaviour must not change ──────────────────────────────────
+
+
+@pytest.mark.parametrize("orientation", ["SEM", "MILLING"])
+def test_a_beam_position_is_still_the_milling_pose_verbatim(orientation):
+    """Every caller before this marked positions on the beam side, and the position
+    they gave became the milling pose unchanged — including its tilt, which is not
+    always the milling orientation. `update_milling_angle` reads the angle off that
+    tilt, so re-posing it here would quietly change every existing lamella."""
+    microscope = _microscope()
+    marked = _at(microscope, orientation)
+
+    poses = build_lamella_poses(microscope, marked)
+
+    assert poses.milling.stage_position.t == pytest.approx(marked.t)
+    assert poses.milling.stage_position.r == pytest.approx(marked.r)
+
+
+def test_a_beam_position_still_derives_a_fluorescence_pose():
+    microscope = _microscope()
+    marked = _at(microscope, MILLING_ORIENTATION)
+
+    poses = build_lamella_poses(microscope, marked)
+
+    assert (
+        microscope.get_stage_orientation(poses.fluorescence.stage_position)
+        == FLUORESCENCE_ORIENTATION
+    )
+
+
+# ── the objective ────────────────────────────────────────────────────────
+
+
+def test_the_fluorescence_pose_carries_an_objective_position():
+    """Without one the pose does not count as selected — `fluorescence_selected` checks
+    exactly this — so a lamella could be marked and still read as unmarked."""
+    microscope = _microscope()
+
+    poses = build_lamella_poses(microscope, _at(microscope, MILLING_ORIENTATION))
+
+    assert poses.fluorescence.objective_position is not None
+    assert poses.fluorescence.objective_position == pytest.approx(
+        microscope.fm.objective.focus_position
+    )
+
+
+def test_a_given_objective_position_wins():
+    """The FM tab knows where the objective actually was; the focus position is only
+    the fallback for a caller that cannot know."""
+    microscope = _microscope()
+
+    poses = build_lamella_poses(
+        microscope, _at(microscope, MILLING_ORIENTATION), objective_position=4.2e-3
+    )
+
+    assert poses.fluorescence.objective_position == pytest.approx(4.2e-3)
+
+
+# ── systems that cannot do it ────────────────────────────────────────────
+
+
+def test_a_microscope_without_fluorescence_gets_no_fluorescence_pose():
+    """None rather than an invented one: a pose for an instrument that does not exist
+    is worse than its absence."""
+    microscope = _microscope(with_fm=False)
+
+    poses = build_lamella_poses(microscope, _at(microscope, MILLING_ORIENTATION))
+
+    assert poses.fluorescence is None
+    assert poses.milling is not None
+
+
+def test_an_offset_mount_cannot_tell_a_fluorescence_position_apart():
+    """Why `marked_at` exists at all.
+
+    Deriving the orientation from the position works on a compustage, where each
+    orientation has its own tilt. On an offset mount the fluorescence position is
+    distinguished by travelling ~48 mm in x, and the tilt is no help: measured on the
+    simulator, FM and FIB share a tilt of 17 degrees and both come back as MILLING.
+
+    So a caller there cannot rely on the derivation, and this test says so rather than
+    leaving the next person to discover it.
+    """
+    microscope = _microscope(compustage=False)
+
+    fm_orientation = microscope.get_orientation(FLUORESCENCE_ORIENTATION)
+
+    assert microscope.get_stage_orientation(fm_orientation) != FLUORESCENCE_ORIENTATION
+
+
+def test_marking_from_fluorescence_is_refused_on_an_offset_mount():
+    """There is no transform between the fluorescence and beam positions there — the
+    ~48 mm shuttle is not modelled (FIB-93). Refused, because the alternative is a
+    lamella with a milling pose nothing can mill at.
+
+    Declared rather than derived, because on this system it cannot be derived."""
+    microscope = _microscope(compustage=False)
+    fm_position = FibsemStagePosition(
+        x=48.8e-3, y=50e-6, z=0.0, r=0.0, t=np.deg2rad(17)
+    )
+
+    with pytest.raises(ValueError, match="FIB-93"):
+        build_lamella_poses(
+            microscope, fm_position, marked_at=FLUORESCENCE_ORIENTATION
+        )
+
+
+def test_a_declared_orientation_wins_over_the_derived_one():
+    """The FM tab knows which side it is marking from; the position may not say."""
+    microscope = _microscope()
+    # A beam-side position by its tilt, declared as fluorescence anyway.
+    beam_position = _at(microscope, MILLING_ORIENTATION)
+
+    poses = build_lamella_poses(
+        microscope, beam_position, marked_at=FLUORESCENCE_ORIENTATION
+    )
+
+    # Treated as the fluorescence pose: kept as given, and a milling pose derived.
+    assert poses.fluorescence.stage_position.t == pytest.approx(beam_position.t)
+    assert (
+        microscope.get_stage_orientation(poses.milling.stage_position)
+        == MILLING_ORIENTATION
+    )
+
+
+def test_marking_from_the_beam_side_still_works_on_an_offset_mount():
+    """The other direction is a convenience, not a requirement. Refusing the whole
+    lamella because no fluorescence pose could be worked out would stop offset systems
+    marking lamellae at all."""
+    microscope = _microscope(compustage=False)
+    marked = _at(microscope, MILLING_ORIENTATION)
+
+    poses = build_lamella_poses(microscope, marked)
+
+    assert poses.milling.stage_position.x == pytest.approx(marked.x)
+    assert poses.fluorescence is None

--- a/tests/ui/test_beam_side_move_syncs_fm_pose.py
+++ b/tests/ui/test_beam_side_move_syncs_fm_pose.py
@@ -1,0 +1,201 @@
+"""Moving a lamella on the beam side has to carry its fluorescence pose along.
+
+A lamella describes one piece of sample from two sides. Both of the beam-side ways to
+say "this lamella is somewhere else" -- dragging it on the FIB/SEM overview, and saving
+the current stage position onto it from the lamella list -- set the milling pose and
+historically stopped there, leaving the fluorescence pose naming where the lamella used
+to be. Nothing about a stale pose looks wrong, which is what made it worth pinning.
+
+`tests/autolamella/test_poses.py` covers what `sync_fluorescence_pose` computes. This
+covers the other half: that these two callers actually call it. A correct helper nothing
+invokes is not a fix.
+
+The methods are borrowed onto stubs rather than driven through real widgets, because the
+minimap needs a napari viewer and those segfault under the offscreen platform.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication, QMessageBox
+
+import fibsem.applications.autolamella.ui.AutoLamellaUI  # noqa: F401  (for sys.modules)
+from fibsem.applications.autolamella.poses import (
+    FLUORESCENCE_ORIENTATION,
+    MILLING_ORIENTATION,
+    build_lamella_poses,
+)
+from fibsem.structures import FibsemStagePosition
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _microscope():
+    from fibsem import utils
+    from fibsem.fm.microscope import FluorescenceMicroscope
+
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.stage_is_compustage = True
+    microscope.system.stage.shuttle_pre_tilt = 0
+    microscope._update_orientations()
+    if microscope.fm is None:
+        microscope.fm = FluorescenceMicroscope(parent=microscope)
+    return microscope
+
+
+def _at(microscope, orientation, x, y):
+    pose = microscope.get_orientation(orientation)
+    return FibsemStagePosition(x=x, y=y, z=0.0, r=pose.r, t=pose.t)
+
+
+def _lamella(microscope, tmp_path, x=100e-6, y=50e-6):
+    from fibsem.applications.autolamella.structures import Lamella
+
+    poses = build_lamella_poses(microscope, _at(microscope, MILLING_ORIENTATION, x, y))
+    lamella = Lamella(petname="Lamella-01", path=str(tmp_path / "Lamella-01"), number=1)
+    lamella.milling_pose = poses.milling
+    lamella.fluorescence_pose = poses.fluorescence
+    return lamella
+
+
+class _Experiment:
+    def __init__(self, positions):
+        # An EventedList, because `update_lamella_position_ui` emits `changed` on it --
+        # which is how the FM overview canvas hears about the move.
+        from psygnal.containers import EventedList
+
+        self.positions = EventedList(positions)
+        self.saves = 0
+
+    def save(self):
+        self.saves += 1
+
+
+class _SelectedList:
+    selected_index = 0
+
+    def select(self, name):
+        pass
+
+
+def test_dragging_a_lamella_on_the_minimap_moves_its_fluorescence_pose(tmp_path):
+    """`FibsemMinimapWidget._update_selected_position` -- right-click the FIB/SEM
+    overview, Move Selected Position Here."""
+    from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
+
+    microscope = _microscope()
+    lamella = _lamella(microscope, tmp_path)
+    before = lamella.fluorescence_pose.stage_position.x
+
+    class _Minimap:
+        _update_selected_position = FibsemMinimapWidget._update_selected_position
+
+        def __init__(self):
+            self.microscope = microscope
+            self.lamella_list = _SelectedList()
+            self.parent_widget = type(
+                "_UI", (), {"experiment": _Experiment([lamella])}
+            )()
+
+        def _update_position_display(self):
+            pass
+
+    _Minimap()._update_selected_position(
+        _at(microscope, MILLING_ORIENTATION, 400e-6, -200e-6)
+    )
+
+    assert lamella.milling_pose.stage_position.x == pytest.approx(400e-6)
+    assert lamella.fluorescence_pose.stage_position.x == pytest.approx(400e-6)
+    assert lamella.fluorescence_pose.stage_position.x != pytest.approx(before)
+    # ...and it is still a fluorescence pose, not the milling one copied across
+    assert (
+        microscope.get_stage_orientation(lamella.fluorescence_pose.stage_position)
+        == FLUORESCENCE_ORIENTATION
+    )
+
+
+def test_saving_a_new_position_from_the_lamella_list_moves_it_too(tmp_path, monkeypatch):
+    """`AutoLamellaUI.update_lamella_position_ui` -- the list row's Update Position,
+    which records wherever the stage is now onto the selected lamella."""
+    module = sys.modules["fibsem.applications.autolamella.ui.AutoLamellaUI"]
+
+    microscope = _microscope()
+    lamella = _lamella(microscope, tmp_path)
+    before = lamella.fluorescence_pose.stage_position.x
+    microscope.move_stage_absolute(
+        _at(microscope, MILLING_ORIENTATION, 400e-6, -200e-6)
+    )
+    monkeypatch.setattr(
+        module.QMessageBox, "question", staticmethod(lambda *a, **k: QMessageBox.Yes)
+    )
+
+    class _UI:
+        update_lamella_position_ui = module.AutoLamellaUI.update_lamella_position_ui
+
+        def __init__(self):
+            self.microscope = microscope
+            self.protocol = object()
+            self.experiment = _Experiment([lamella])
+            self.lamella_list = _SelectedList()
+
+        def update_lamella_combobox(self, latest=False):
+            pass
+
+        def update_ui(self):
+            pass
+
+    _UI().update_lamella_position_ui()
+
+    assert lamella.milling_pose.stage_position.x == pytest.approx(400e-6)
+    assert lamella.fluorescence_pose.stage_position.x == pytest.approx(400e-6)
+    assert lamella.fluorescence_pose.stage_position.x != pytest.approx(before)
+    assert (
+        microscope.get_stage_orientation(lamella.fluorescence_pose.stage_position)
+        == FLUORESCENCE_ORIENTATION
+    )
+
+
+def test_declining_the_confirmation_moves_neither_pose(tmp_path, monkeypatch):
+    """The sync must sit after the confirmation, not before it."""
+    module = sys.modules["fibsem.applications.autolamella.ui.AutoLamellaUI"]
+
+    microscope = _microscope()
+    lamella = _lamella(microscope, tmp_path)
+    before = (
+        lamella.milling_pose.stage_position.x,
+        lamella.fluorescence_pose.stage_position.x,
+    )
+    microscope.move_stage_absolute(
+        _at(microscope, MILLING_ORIENTATION, 400e-6, -200e-6)
+    )
+    monkeypatch.setattr(
+        module.QMessageBox, "question", staticmethod(lambda *a, **k: QMessageBox.No)
+    )
+
+    class _UI:
+        update_lamella_position_ui = module.AutoLamellaUI.update_lamella_position_ui
+
+        def __init__(self):
+            self.microscope = microscope
+            self.protocol = object()
+            self.experiment = _Experiment([lamella])
+            self.lamella_list = _SelectedList()
+
+        def update_lamella_combobox(self, latest=False):
+            pass
+
+        def update_ui(self):
+            pass
+
+    _UI().update_lamella_position_ui()
+
+    assert (
+        lamella.milling_pose.stage_position.x,
+        lamella.fluorescence_pose.stage_position.x,
+    ) == before

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1736,6 +1736,8 @@ class _StubHost:
     _update_fm_overview_positions = _Real._update_fm_overview_positions
     _update_fm_overview_selection = _Real._update_fm_overview_selection
     _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
+    _rebuild_lamella_list = _Real._rebuild_lamella_list
+    _wire_position_events = _Real._wire_position_events
     # Connected by `_build_fm_overview_widget`, so every host needs them present.
     _on_fm_overview_add_position = _Real._on_fm_overview_add_position
     _on_fm_overview_move_position = _Real._on_fm_overview_move_position
@@ -3119,6 +3121,147 @@ def test_a_move_that_names_nothing_does_nothing(qapp, tmp_path, monkeypatch):
 
     assert asked == [], "asked about a lamella that is not there"
     assert host.autolamella_ui.experiment.saves == 0
+
+    host._teardown_fm_overview_widget()
+
+
+# ── positions marked anywhere reach the FM canvas ────────────────────────
+
+
+class _ListStub:
+    """Stands in for the lamella list and card container in `_rebuild_lamella_list`."""
+
+    def __init__(self):
+        self.lamellae = []
+
+    def clear(self):
+        self.lamellae.clear()
+
+    def add_lamella(self, lamella):
+        self.lamellae.append(lamella)
+
+
+def _list_host(qapp, tmp_path, experiment=None):
+    """A `_StubHost` that can run the real `_rebuild_lamella_list`."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope())
+    host._build_fm_overview_widget()
+    host.autolamella_ui.experiment = experiment
+    host.lamella_list_widget = _ListStub()
+    host.lamella_card_container = _ListStub()
+    host._lamella_list_experiment = None
+    host._on_lamella_card_selected = lambda lamella: None
+    host._on_workflow_selection_changed = lambda: None
+    host._update_lamella_tab_enabled = lambda: None
+    return host
+
+
+def _real_experiment(tmp_path, name="fm-overview-test"):
+    from fibsem.applications.autolamella.structures import Experiment
+
+    return Experiment(path=tmp_path, name=name)
+
+
+def test_a_lamella_added_anywhere_reaches_the_fm_canvas(qapp, tmp_path):
+    """The reported bug: a position marked on the FIB/SEM overview never appeared on the
+    FM one. Nothing was wrong with the marking -- the canvas was simply never told, so it
+    kept showing whatever it had last been handed.
+
+    Appending is how every add arrives, whatever marked it: the minimap calls
+    `add_new_lamella` and trusts `inserted` to refresh the displays.
+    """
+    experiment = _real_experiment(tmp_path)
+    host = _list_host(qapp, tmp_path, experiment)
+    host._wire_position_events()
+    assert host.fm_overview_widget._positions == []
+
+    microscope = host.autolamella_ui.microscope
+    lamella = _real_lamella("Lamella-01", microscope, tmp_path)
+    experiment.positions.append(lamella)  # nobody calls the FM refresh by hand
+
+    assert [p.name for p in host.fm_overview_widget._positions] == ["Lamella-01"]
+    assert host.lamella_list_widget.lamellae == [lamella]
+
+    host._teardown_fm_overview_widget()
+
+
+def test_removing_a_lamella_takes_its_marker_away(qapp, tmp_path):
+    experiment = _real_experiment(tmp_path)
+    host = _list_host(qapp, tmp_path, experiment)
+    host._wire_position_events()
+    microscope = host.autolamella_ui.microscope
+    experiment.positions.append(_real_lamella("Lamella-01", microscope, tmp_path))
+    assert host.fm_overview_widget._positions
+
+    experiment.positions.pop()
+
+    assert host.fm_overview_widget._positions == []
+
+    host._teardown_fm_overview_widget()
+
+
+def test_editing_a_position_in_place_re_marks_the_canvas(qapp, tmp_path):
+    """`update_lamella_position_ui` replaces a milling pose and emits `changed` -- no
+    insert, no removal, and the list rows have nothing to redraw. The canvas does."""
+    experiment = _real_experiment(tmp_path)
+    host = _list_host(qapp, tmp_path, experiment)
+    host._wire_position_events()
+    microscope = host.autolamella_ui.microscope
+    lamella = _real_lamella("Lamella-01", microscope, tmp_path)
+    experiment.positions.append(lamella)
+    before = host.fm_overview_widget._positions[0].x
+
+    lamella.fluorescence_pose.stage_position.x = before + 500e-6
+    experiment.positions.events.changed.emit()
+
+    assert host.fm_overview_widget._positions[0].x == pytest.approx(before + 500e-6)
+
+    host._teardown_fm_overview_widget()
+
+
+def test_closing_an_experiment_clears_the_canvas(qapp, tmp_path):
+    """Before the `experiment is None` return in the rebuild, because an experiment
+    closing has to clear the canvas as much as one opening has to fill it."""
+    experiment = _real_experiment(tmp_path)
+    host = _list_host(qapp, tmp_path, experiment)
+    microscope = host.autolamella_ui.microscope
+    experiment.positions.append(_real_lamella("Lamella-01", microscope, tmp_path))
+    host._rebuild_lamella_list()
+    assert host.fm_overview_widget._positions
+
+    host.autolamella_ui.experiment = None
+    host._rebuild_lamella_list()
+
+    assert host.fm_overview_widget._positions == []
+
+    host._teardown_fm_overview_widget()
+
+
+def test_switching_experiments_lets_go_of_the_old_one(qapp, tmp_path):
+    """The disconnect has to actually disconnect. It did not: the connections were
+    lambdas and the disconnects named the methods those lambdas called, which psygnal
+    accepts and silently ignores.
+
+    Asserted on the subscriber count rather than on what gets drawn, because drawing
+    cannot tell the difference -- `_rebuild_lamella_list` reads the *current* experiment,
+    so a leaked subscription only does redundant work. The claim being tested is the one
+    the code makes, which is that it stops following the experiment it is leaving.
+    """
+    first = _real_experiment(tmp_path / "one", name="one")
+    host = _list_host(qapp, tmp_path, first)
+    host._wire_position_events()
+    assert len(first.positions.events.inserted) == 1
+
+    second = _real_experiment(tmp_path / "two", name="two")
+    host.autolamella_ui.experiment = second
+    host._wire_position_events()
+
+    for signal in ("inserted", "removed", "changed"):
+        assert len(getattr(first.positions.events, signal)) == 0, (
+            f"still subscribed to the old experiment's {signal}"
+        )
+        assert len(getattr(second.positions.events, signal)) == 1
 
     host._teardown_fm_overview_widget()
 

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1730,18 +1730,11 @@ class _StubHost:
 
     add_fm_overview_tab = _Real.add_fm_overview_tab
     _apply_fm_overview_visibility = _Real._apply_fm_overview_visibility
-    _build_fm_overview_widget = _Real._build_fm_overview_widget
-    _teardown_fm_overview_widget = _Real._teardown_fm_overview_widget
-    _update_fm_overview_experiment = _Real._update_fm_overview_experiment
-    _update_fm_overview_positions = _Real._update_fm_overview_positions
-    _update_fm_overview_selection = _Real._update_fm_overview_selection
+    _on_fm_overview_availability = _Real._on_fm_overview_availability
+    _refresh_fm_overview_positions = _Real._refresh_fm_overview_positions
     _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
     _rebuild_lamella_list = _Real._rebuild_lamella_list
     _wire_position_events = _Real._wire_position_events
-    # Connected by `_build_fm_overview_widget`, so every host needs them present.
-    _on_fm_overview_add_position = _Real._on_fm_overview_add_position
-    _on_fm_overview_move_position = _Real._on_fm_overview_move_position
-    _fm_overview_objective_position = _Real._fm_overview_objective_position
 
     def __init__(self, microscope=None, experiment=None, tab_enabled=True):
         import fibsem.config as fibsem_cfg
@@ -1766,8 +1759,32 @@ class _StubHost:
     @property
     def tab_enabled(self):
         return self.tab_widget.isTabEnabled(
-            self.tab_widget.indexOf(self._fm_overview_container)
+            self.tab_widget.indexOf(self.fm_overview_tab)
         )
+
+    # ── reading through to the tab ───────────────────────────────────────
+    # Test scaffolding, not production shims: these say "what the window can see of the
+    # tab" so the window-level tests below read as they did before the tab was split
+    # out, while still going through the real `FluorescenceOverviewTab`.
+
+    @property
+    def fm_overview_widget(self):
+        return self.fm_overview_tab.overview
+
+    def _build_fm_overview_widget(self):
+        self.fm_overview_tab.refresh_microscope()
+
+    def _teardown_fm_overview_widget(self):
+        self.fm_overview_tab._drop_overview()
+
+    def _update_fm_overview_experiment(self):
+        self.fm_overview_tab.refresh_experiment()
+
+    def _update_fm_overview_positions(self):
+        self._refresh_fm_overview_positions()
+
+    def _update_fm_overview_selection(self, lamella):
+        self.fm_overview_tab.set_selected(lamella)
 
 
 def _plain_microscope():
@@ -1813,7 +1830,7 @@ def test_a_microscope_without_fluorescence_hides_the_tab(qapp):
 
     host._apply_fm_overview_visibility()
 
-    index = host.tab_widget.indexOf(host._fm_overview_container)
+    index = host.tab_widget.indexOf(host.fm_overview_tab)
     assert not host.tab_widget.isTabVisible(index)
     assert host.fm_overview_widget is None
 
@@ -1825,7 +1842,7 @@ def test_no_microscope_yet_leaves_the_tab_visible_but_disabled(qapp):
 
     host._apply_fm_overview_visibility()
 
-    index = host.tab_widget.indexOf(host._fm_overview_container)
+    index = host.tab_widget.indexOf(host.fm_overview_tab)
     assert host.tab_widget.isTabVisible(index)
     assert not host.tab_widget.isTabEnabled(index)
     assert host.fm_overview_widget is None
@@ -1835,7 +1852,7 @@ def test_connecting_a_microscope_without_fluorescence_takes_the_tab_away(qapp):
     """Whether the system has an FM is only known once something is connected, so the
     tab starts visible and has to be withdrawn rather than never shown."""
     host = _StubHost(microscope=None)
-    index = host.tab_widget.indexOf(host._fm_overview_container)
+    index = host.tab_widget.indexOf(host.fm_overview_tab)
     assert host.tab_widget.isTabVisible(index)
 
     host.autolamella_ui.microscope = _plain_microscope()
@@ -1850,7 +1867,7 @@ def test_a_microscope_with_fluorescence_brings_the_tab_back(qapp):
 
     host = _StubHost(microscope=_plain_microscope())
     host._apply_fm_overview_visibility()
-    index = host.tab_widget.indexOf(host._fm_overview_container)
+    index = host.tab_widget.indexOf(host.fm_overview_tab)
     assert not host.tab_widget.isTabVisible(index)
 
     host.autolamella_ui.microscope = build_microscope()
@@ -1893,7 +1910,7 @@ def test_a_different_microscope_replaces_the_widget(qapp):
     host._build_fm_overview_widget()
 
     assert host.fm_overview_widget is not first
-    assert host._fm_overview_microscope is host.autolamella_ui.microscope
+    assert host.fm_overview_tab._microscope is host.autolamella_ui.microscope
 
     host._teardown_fm_overview_widget()
 
@@ -1980,7 +1997,7 @@ def test_the_fm_overview_tab_is_behind_a_preference(qapp):
     from fibsem.ui.fm.overview_app import build_microscope
 
     host = _StubHost(microscope=build_microscope(), tab_enabled=False)
-    index = host.tab_widget.indexOf(host._fm_overview_container)
+    index = host.tab_widget.indexOf(host.fm_overview_tab)
 
     assert not host.tab_widget.isTabVisible(index)
     assert host.fm_overview_widget is None
@@ -1991,7 +2008,7 @@ def test_switching_the_preference_on_shows_the_tab_without_a_restart(qapp):
     from fibsem.ui.fm.overview_app import build_microscope
 
     host = _StubHost(microscope=build_microscope(), tab_enabled=False)
-    index = host.tab_widget.indexOf(host._fm_overview_container)
+    index = host.tab_widget.indexOf(host.fm_overview_tab)
 
     host.set_flag(True)
 
@@ -2011,7 +2028,7 @@ def test_switching_it_off_again_releases_the_widget(qapp):
     microscope = build_microscope()
     before = len(microscope.stage_position_changed)
     host = _StubHost(microscope=microscope, tab_enabled=True)
-    index = host.tab_widget.indexOf(host._fm_overview_container)
+    index = host.tab_widget.indexOf(host.fm_overview_tab)
     assert len(microscope.stage_position_changed) == before + 1
 
     host.set_flag(False)
@@ -2908,7 +2925,7 @@ def test_adding_declares_the_fluorescence_orientation(qapp, tmp_path):
     host = _wired_host(qapp, tmp_path)
     position = _named("wherever", 120e-6, -60e-6)
 
-    host._on_fm_overview_add_position(position)
+    host.fm_overview_tab._on_add_requested(position)
 
     assert host.autolamella_ui.added[0]["marked_at"] == FLUORESCENCE_ORIENTATION
     assert host.autolamella_ui.added[0]["position"] is position
@@ -2927,7 +2944,7 @@ def test_adding_records_where_the_objective_actually_is(qapp, tmp_path):
     objective.move_absolute(objective.position + 50e-6)  # focused by hand
     assert objective.state == "Inserted"
 
-    host._on_fm_overview_add_position(_named("wherever", 0.0, 0.0))
+    host.fm_overview_tab._on_add_requested(_named("wherever", 0.0, 0.0))
 
     assert host.autolamella_ui.added[0]["objective_position"] == pytest.approx(
         objective.position
@@ -2944,7 +2961,7 @@ def test_a_retracted_objective_is_not_recorded_as_a_focus(qapp, tmp_path):
     objective.retract()
     assert objective.state == "Retracted"
 
-    host._on_fm_overview_add_position(_named("wherever", 0.0, 0.0))
+    host.fm_overview_tab._on_add_requested(_named("wherever", 0.0, 0.0))
 
     assert host.autolamella_ui.added[0]["objective_position"] is None
 
@@ -2957,7 +2974,7 @@ def test_adding_without_an_experiment_is_refused_not_crashed(qapp, tmp_path):
     host = _wired_host(qapp, tmp_path)
     host.autolamella_ui.experiment = None
 
-    host._on_fm_overview_add_position(_named("wherever", 0.0, 0.0))  # must not raise
+    host.fm_overview_tab._on_add_requested(_named("wherever", 0.0, 0.0))  # must not raise
 
     assert host.autolamella_ui.added == []
 
@@ -2974,7 +2991,7 @@ def test_a_refused_add_is_reported_rather_than_raised(qapp, tmp_path):
 
     host.autolamella_ui.add_new_lamella = refuse
 
-    host._on_fm_overview_add_position(_named("wherever", 0.0, 0.0))  # must not raise
+    host.fm_overview_tab._on_add_requested(_named("wherever", 0.0, 0.0))  # must not raise
 
     host._teardown_fm_overview_widget()
 
@@ -2982,7 +2999,7 @@ def test_a_refused_add_is_reported_rather_than_raised(qapp, tmp_path):
 def test_moving_asks_before_it_moves_anything(qapp, tmp_path, monkeypatch):
     """Moving one pose moves both, and the milling pose is not visible from this canvas.
     Said rather than assumed."""
-    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
     from fibsem.ui.fm.overview_app import build_microscope
 
     host = _wired_host(qapp, tmp_path)
@@ -2996,7 +3013,7 @@ def test_moving_asks_before_it_moves_anything(qapp, tmp_path, monkeypatch):
         module, "message_box_ui", lambda **kwargs: asked.append(kwargs) or False
     )
 
-    host._on_fm_overview_move_position("Lamella-01", _named("target", 400e-6, -200e-6))
+    host.fm_overview_tab._on_move_requested("Lamella-01", _named("target", 400e-6, -200e-6))
 
     assert len(asked) == 1, "moved without asking"
     assert lamella.poses["MILLING"].stage_position.x == before["MILLING"].stage_position.x
@@ -3011,7 +3028,7 @@ def test_moving_asks_before_it_moves_anything(qapp, tmp_path, monkeypatch):
 
 
 def test_confirming_a_move_moves_both_poses(qapp, tmp_path, monkeypatch):
-    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     microscope = host.autolamella_ui.microscope
@@ -3020,7 +3037,7 @@ def test_confirming_a_move_moves_both_poses(qapp, tmp_path, monkeypatch):
     monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
 
     target = _named("target", 400e-6, -200e-6)
-    host._on_fm_overview_move_position("Lamella-01", target)
+    host.fm_overview_tab._on_move_requested("Lamella-01", target)
 
     # the fluorescence pose is where the user clicked...
     assert lamella.fluorescence_pose.stage_position.x == pytest.approx(400e-6)
@@ -3040,7 +3057,7 @@ def test_a_move_rewrites_the_stage_positions_and_nothing_else(qapp, tmp_path, mo
     """A move is a move. The poses are edited in place rather than replaced, so the beam
     settings the lamella was marked with survive -- and so does the objective position,
     because the user moved sideways, they did not refocus."""
-    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     microscope = host.autolamella_ui.microscope
@@ -3050,7 +3067,7 @@ def test_a_move_rewrites_the_stage_positions_and_nothing_else(qapp, tmp_path, mo
     host.autolamella_ui.experiment.positions = [lamella]
     monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
 
-    host._on_fm_overview_move_position("Lamella-01", _named("target", 400e-6, -200e-6))
+    host.fm_overview_tab._on_move_requested("Lamella-01", _named("target", 400e-6, -200e-6))
 
     assert lamella.milling_pose.electron_detector.brightness == pytest.approx(0.123)
     assert lamella.fluorescence_pose.objective_position == pytest.approx(7.7e-3)
@@ -3062,7 +3079,7 @@ def test_moving_a_lamella_that_has_no_fluorescence_pose_gives_it_one(
     """Possible on a lamella marked before there was an FM. It gets a whole new pose
     rather than an edit, and that one is built on what the lamella itself recorded --
     not on whatever the microscope happens to be set to now."""
-    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     microscope = host.autolamella_ui.microscope
@@ -3072,7 +3089,7 @@ def test_moving_a_lamella_that_has_no_fluorescence_pose_gives_it_one(
     host.autolamella_ui.experiment.positions = [lamella]
     monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
 
-    host._on_fm_overview_move_position("Lamella-01", _named("target", 400e-6, -200e-6))
+    host.fm_overview_tab._on_move_requested("Lamella-01", _named("target", 400e-6, -200e-6))
 
     assert lamella.fluorescence_pose is not None
     assert lamella.fluorescence_pose.stage_position.x == pytest.approx(400e-6)
@@ -3085,7 +3102,7 @@ def test_moving_a_lamella_that_has_no_fluorescence_pose_gives_it_one(
 def test_a_move_re_derives_the_milling_angle(qapp, tmp_path, monkeypatch):
     """It is computed from the milling-pose stage tilt, so a pose that moved without it
     would leave the lamella claiming an angle its own pose no longer implies."""
-    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     microscope = host.autolamella_ui.microscope
@@ -3094,7 +3111,7 @@ def test_a_move_re_derives_the_milling_angle(qapp, tmp_path, monkeypatch):
     host.autolamella_ui.experiment.positions = [lamella]
     monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
 
-    host._on_fm_overview_move_position("Lamella-01", _named("target", 400e-6, -200e-6))
+    host.fm_overview_tab._on_move_requested("Lamella-01", _named("target", 400e-6, -200e-6))
 
     assert lamella.milling_angle != pytest.approx(999.0)
     assert lamella.milling_angle == pytest.approx(
@@ -3107,7 +3124,7 @@ def test_a_move_re_derives_the_milling_angle(qapp, tmp_path, monkeypatch):
 def test_a_move_that_names_nothing_does_nothing(qapp, tmp_path, monkeypatch):
     """The canvas holds its selection by name and is rebuilt independently of the host's
     list, so a name can arrive for a lamella that is no longer there."""
-    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     lamella = _real_lamella("Lamella-01", host.autolamella_ui.microscope, tmp_path)
@@ -3117,7 +3134,7 @@ def test_a_move_that_names_nothing_does_nothing(qapp, tmp_path, monkeypatch):
         module, "message_box_ui", lambda **kwargs: asked.append(kwargs) or True
     )
 
-    host._on_fm_overview_move_position("Lamella-99", _named("target", 0.0, 0.0))
+    host.fm_overview_tab._on_move_requested("Lamella-99", _named("target", 0.0, 0.0))
 
     assert asked == [], "asked about a lamella that is not there"
     assert host.autolamella_ui.experiment.saves == 0
@@ -3269,7 +3286,7 @@ def test_switching_experiments_lets_go_of_the_old_one(qapp, tmp_path):
 def test_a_confirmed_move_re_marks_the_canvas(qapp, tmp_path, monkeypatch):
     """Otherwise the marker stays where the lamella used to be until something else
     happens to refresh it."""
-    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     microscope = host.autolamella_ui.microscope
@@ -3279,7 +3296,7 @@ def test_a_confirmed_move_re_marks_the_canvas(qapp, tmp_path, monkeypatch):
     before = host.fm_overview_widget._positions[0].x
     monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
 
-    host._on_fm_overview_move_position("Lamella-01", _named("target", 400e-6, -200e-6))
+    host.fm_overview_tab._on_move_requested("Lamella-01", _named("target", 400e-6, -200e-6))
 
     assert host.fm_overview_widget._positions[0].x == pytest.approx(400e-6)
     assert host.fm_overview_widget._positions[0].x != pytest.approx(before)

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1766,7 +1766,7 @@ class _StubHost:
     # ── reading through to the tab ───────────────────────────────────────
     # Test scaffolding, not production shims: these say "what the window can see of the
     # tab" so the window-level tests below read as they did before the tab was split
-    # out, while still going through the real `FluorescenceOverviewTab`.
+    # out, while still going through the real `AutoLamellaFluorescenceOverviewTab`.
 
     @property
     def fm_overview_widget(self):
@@ -3006,7 +3006,7 @@ def test_a_refused_add_is_reported_rather_than_raised(qapp, tmp_path):
 def test_moving_asks_before_it_moves_anything(qapp, tmp_path, monkeypatch):
     """Moving one pose moves both, and the milling pose is not visible from this canvas.
     Said rather than assumed."""
-    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
+    from fibsem.applications.autolamella.ui import autolamella_fluorescence_overview_tab as module
     from fibsem.ui.fm.overview_app import build_microscope
 
     host = _wired_host(qapp, tmp_path)
@@ -3035,7 +3035,7 @@ def test_moving_asks_before_it_moves_anything(qapp, tmp_path, monkeypatch):
 
 
 def test_confirming_a_move_moves_both_poses(qapp, tmp_path, monkeypatch):
-    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
+    from fibsem.applications.autolamella.ui import autolamella_fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     microscope = host.autolamella_ui.microscope
@@ -3064,7 +3064,7 @@ def test_a_move_rewrites_the_stage_positions_and_nothing_else(qapp, tmp_path, mo
     """A move is a move. The poses are edited in place rather than replaced, so the beam
     settings the lamella was marked with survive -- and so does the objective position,
     because the user moved sideways, they did not refocus."""
-    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
+    from fibsem.applications.autolamella.ui import autolamella_fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     microscope = host.autolamella_ui.microscope
@@ -3086,7 +3086,7 @@ def test_moving_a_lamella_that_has_no_fluorescence_pose_gives_it_one(
     """Possible on a lamella marked before there was an FM. It gets a whole new pose
     rather than an edit, and that one is built on what the lamella itself recorded --
     not on whatever the microscope happens to be set to now."""
-    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
+    from fibsem.applications.autolamella.ui import autolamella_fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     microscope = host.autolamella_ui.microscope
@@ -3109,7 +3109,7 @@ def test_moving_a_lamella_that_has_no_fluorescence_pose_gives_it_one(
 def test_a_move_re_derives_the_milling_angle(qapp, tmp_path, monkeypatch):
     """It is computed from the milling-pose stage tilt, so a pose that moved without it
     would leave the lamella claiming an angle its own pose no longer implies."""
-    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
+    from fibsem.applications.autolamella.ui import autolamella_fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     microscope = host.autolamella_ui.microscope
@@ -3131,7 +3131,7 @@ def test_a_move_re_derives_the_milling_angle(qapp, tmp_path, monkeypatch):
 def test_a_move_that_names_nothing_does_nothing(qapp, tmp_path, monkeypatch):
     """The canvas holds its selection by name and is rebuilt independently of the host's
     list, so a name can arrive for a lamella that is no longer there."""
-    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
+    from fibsem.applications.autolamella.ui import autolamella_fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     lamella = _real_lamella("Lamella-01", host.autolamella_ui.microscope, tmp_path)
@@ -3293,7 +3293,7 @@ def test_switching_experiments_lets_go_of_the_old_one(qapp, tmp_path):
 def test_a_confirmed_move_re_marks_the_canvas(qapp, tmp_path, monkeypatch):
     """Otherwise the marker stays where the lamella used to be until something else
     happens to refresh it."""
-    from fibsem.applications.autolamella.ui import fluorescence_overview_tab as module
+    from fibsem.applications.autolamella.ui import autolamella_fluorescence_overview_tab as module
 
     host = _wired_host(qapp, tmp_path)
     microscope = host.autolamella_ui.microscope
@@ -3315,10 +3315,10 @@ def test_a_confirmed_move_re_marks_the_canvas(qapp, tmp_path, monkeypatch):
 
 
 def _tab_with(qapp, tmp_path, positions=()):
-    """A `FluorescenceOverviewTab` with a live overview and an experiment."""
+    """A `AutoLamellaFluorescenceOverviewTab` with a live overview and an experiment."""
     import fibsem.config as fibsem_cfg
-    from fibsem.applications.autolamella.ui.fluorescence_overview_tab import (
-        FluorescenceOverviewTab,
+    from fibsem.applications.autolamella.ui.autolamella_fluorescence_overview_tab import (
+        AutoLamellaFluorescenceOverviewTab,
     )
     from fibsem.ui.fm.overview_app import build_microscope
 
@@ -3331,7 +3331,7 @@ def _tab_with(qapp, tmp_path, positions=()):
         "_UI", (), {"microscope": microscope, "experiment": experiment}
     )()
     ui.update_ui = lambda: None
-    tab = FluorescenceOverviewTab(ui)
+    tab = AutoLamellaFluorescenceOverviewTab(ui)
     tab.refresh_microscope()
     qapp.processEvents()
     return tab

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -3750,3 +3750,125 @@ def test_the_stage_limits_re_pose_even_with_the_grid_pinned(qapp):
     assert [(spec.cx, spec.cy) for spec in widget.stage_overlay._specs] != before
 
     widget.close()
+
+
+# ── clicking a marker selects it ─────────────────────────────────────────
+
+
+def test_clicking_a_marker_selects_it(qapp, interactive_widget):
+    """As the minimap does. The markers are drawn by a non-interactive overlay, so the
+    canvas's own click signal does the picking."""
+    widget = interactive_widget
+    widget.set_positions([
+        _named("Lamella-01", 120e-6, 90e-6),
+        _named("Lamella-02", -160e-6, 40e-6),
+    ])
+    picked = []
+    widget.position_selected.connect(lambda name: picked.append(name))
+    frame = widget._frame()
+
+    widget._on_canvas_clicked(*frame.to_canvas(_named("Lamella-02", -160e-6, 40e-6)))
+
+    assert picked == ["Lamella-02"]
+    assert widget.selected_position == "Lamella-02"
+    # ...and it moved onto the selected overlay, so it is drawn as selected too
+    assert widget.selected_position_overlay._labels == ["Lamella-02"]
+
+    widget.set_selected_position(None)
+    widget.set_positions([])
+
+
+def test_clicking_empty_space_keeps_the_selection(qapp, interactive_widget):
+    """Where this parts company with the minimap's interactive overlay, on purpose: the
+    host syncs its other lists from the selection and their handlers ignore None, so a
+    clearing click would blank this canvas and nothing else."""
+    widget = interactive_widget
+    widget.set_positions([_named("Lamella-01", 120e-6, 90e-6)])
+    widget.set_selected_position("Lamella-01")
+    frame = widget._frame()
+    picked = []
+    widget.position_selected.connect(lambda name: picked.append(name))
+
+    widget._on_canvas_clicked(*frame.to_canvas(_named("far", 900e-6, -900e-6)))
+
+    assert picked == []
+    assert widget.selected_position == "Lamella-01"
+
+    widget.set_selected_position(None)
+    widget.set_positions([])
+
+
+def test_the_pick_radius_is_screen_space(qapp, interactive_widget):
+    """In pixels, not microns: how close you have to click must not change with the
+    zoom. The same stage point is a hit when zoomed out and a miss when zoomed in."""
+    widget = interactive_widget
+    widget.set_positions([_named("Lamella-01", 120e-6, 90e-6)])
+    frame = widget._frame()
+    ax = widget.canvas.canvas._ax
+    before = (ax.get_xlim(), ax.get_ylim())
+    # 80 um away from the marker, in stage terms
+    near = frame.to_canvas(_named("probe", 200e-6, 90e-6))
+
+    ax.set_xlim(-50000, 50000)
+    ax.set_ylim(-50000, 50000)
+    qapp.processEvents()
+    zoomed_out = widget._position_at(*near)
+
+    ax.set_xlim(-200, 200)
+    ax.set_ylim(-200, 200)
+    qapp.processEvents()
+    zoomed_in = widget._position_at(*near)
+
+    assert zoomed_out == "Lamella-01", "should be within 12px when zoomed right out"
+    assert zoomed_in is None, "should be far outside 12px when zoomed right in"
+
+    ax.set_xlim(*before[0])
+    ax.set_ylim(*before[1])
+    widget.set_positions([])
+
+
+def test_the_nearest_marker_wins(qapp, interactive_widget):
+    """Two markers can both be inside the radius when they are close together.
+
+    The nearest one is deliberately *first* in the list: keeping a hit without also
+    keeping its distance leaves the last match winning, which would agree with the right
+    answer if the nearest happened to come last.
+    """
+    widget = interactive_widget
+    widget.set_positions([
+        _named("Lamella-02", 121e-6, 90e-6),   # nearest to the probe, and first
+        _named("Lamella-01", 120e-6, 90e-6),
+    ])
+    frame = widget._frame()
+
+    assert widget._position_at(
+        *frame.to_canvas(_named("probe", 120.9e-6, 90e-6))
+    ) == "Lamella-02"
+
+    widget.set_positions([])
+
+
+def test_clicking_a_marker_selects_the_lamella_everywhere(qapp, tmp_path):
+    """The canvas knows the name it drew; turning that into a lamella is the tab's job,
+    and it goes out on the same path a row click takes."""
+    tab = _tab_with(qapp, tmp_path)
+    microscope = tab.microscope
+    tab.experiment.positions.extend([
+        _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
+        _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
+    ])
+    tab.refresh_positions()
+    qapp.processEvents()
+    seen = []
+    tab.lamella_selected.connect(lambda lamella: seen.append(lamella))
+
+    frame = tab.overview._frame()
+    marker = frame.to_canvas(tab.overview._positions[1])
+    tab.overview._on_canvas_clicked(*marker)
+    qapp.processEvents()
+
+    assert [lamella.name for lamella in seen] == ["Lamella-02"]
+    assert tab.lamella_list.selected_name == "Lamella-02"
+    assert tab.overview.selected_position == "Lamella-02"
+
+    tab._drop_overview()

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1732,6 +1732,7 @@ class _StubHost:
     _apply_fm_overview_visibility = _Real._apply_fm_overview_visibility
     _on_fm_overview_availability = _Real._on_fm_overview_availability
     _refresh_fm_overview_positions = _Real._refresh_fm_overview_positions
+    _on_fm_overview_lamella_selected = _Real._on_fm_overview_lamella_selected
     _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
     _rebuild_lamella_list = _Real._rebuild_lamella_list
     _wire_position_events = _Real._wire_position_events
@@ -2538,27 +2539,32 @@ def test_the_selection_survives_the_positions_being_rebuilt(qapp):
     widget.close()
 
 
-def _lamella_with_poses(name: str, microscope, x: float, y: float):
-    """A stand-in lamella carrying both poses, built the way the app builds them."""
+def _lamella_with_poses(name: str, microscope, tmp_path, x: float, y: float):
+    """A lamella carrying both poses, built the way the app builds them.
+
+    A real `Lamella`, not a stand-in with the two attributes this used to need. The
+    settings column now holds a `LamellaNameListWidget`, whose rows subscribe to
+    `lamella.events.description` and read the task and defect state -- which is exactly
+    why that list cannot live inside `FMOverviewWidget`, and why the tab that owns it is
+    in the autolamella package.
+    """
     from fibsem.applications.autolamella.poses import (
         MILLING_ORIENTATION,
         build_lamella_poses,
     )
+    from fibsem.applications.autolamella.structures import Lamella
     from fibsem.structures import FibsemStagePosition
 
     beam = microscope.get_orientation(MILLING_ORIENTATION)
     marked = FibsemStagePosition(x=x, y=y, z=0.0, r=beam.r, t=beam.t)
     poses = build_lamella_poses(microscope, marked)
-    return type(
-        "_Lamella", (), {
-            "name": name,
-            "fluorescence_pose": poses.fluorescence,
-            "milling_pose": poses.milling,
-        },
-    )()
+    lamella = Lamella(petname=name, path=str(tmp_path / name), number=1)
+    lamella.milling_pose = poses.milling
+    lamella.fluorescence_pose = poses.fluorescence
+    return lamella
 
 
-def test_the_host_marks_lamellae_by_their_fluorescence_pose(qapp):
+def test_the_host_marks_lamellae_by_their_fluorescence_pose(qapp, tmp_path):
     """The trap this half exists to avoid. A lamella carries a milling pose and a
     fluorescence pose, and on a compustage the stage flips 180 degrees between them —
     so marking the milling pose would put every lamella somewhere the sample is not.
@@ -2570,7 +2576,7 @@ def test_the_host_marks_lamellae_by_their_fluorescence_pose(qapp):
     widget = host.fm_overview_widget
     microscope = host.autolamella_ui.microscope
 
-    lamella = _lamella_with_poses("Lamella-01", microscope, 100e-6, 50e-6)
+    lamella = _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6)
     host.autolamella_ui.experiment = type(
         "_Exp", (), {"path": "/tmp", "positions": [lamella]}
     )()
@@ -2585,7 +2591,7 @@ def test_the_host_marks_lamellae_by_their_fluorescence_pose(qapp):
     host._teardown_fm_overview_widget()
 
 
-def test_a_lamella_with_no_fluorescence_pose_is_skipped_not_misplaced(qapp):
+def test_a_lamella_with_no_fluorescence_pose_is_skipped_not_misplaced(qapp, tmp_path):
     """It cannot be placed on this canvas at all — normal on a system with no FM, and
     possible on an older experiment. Better absent than drawn somewhere invented."""
     from fibsem.ui.fm.overview_app import build_microscope
@@ -2594,8 +2600,9 @@ def test_a_lamella_with_no_fluorescence_pose_is_skipped_not_misplaced(qapp):
     host._build_fm_overview_widget()
     microscope = host.autolamella_ui.microscope
 
-    placeable = _lamella_with_poses("Lamella-01", microscope, 100e-6, 50e-6)
-    orphan = type("_Lamella", (), {"name": "Lamella-02", "fluorescence_pose": None})()
+    placeable = _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6)
+    orphan = _lamella_with_poses("Lamella-02", microscope, tmp_path, 0.0, 0.0)
+    del orphan.poses["FLUORESCENCE"]
     host.autolamella_ui.experiment = type(
         "_Exp", (), {"path": "/tmp", "positions": [placeable, orphan]}
     )()
@@ -2607,7 +2614,7 @@ def test_a_lamella_with_no_fluorescence_pose_is_skipped_not_misplaced(qapp):
     host._teardown_fm_overview_widget()
 
 
-def test_no_experiment_clears_the_marked_positions(qapp):
+def test_no_experiment_clears_the_marked_positions(qapp, tmp_path):
     from fibsem.ui.fm.overview_app import build_microscope
 
     host = _StubHost(microscope=build_microscope())
@@ -2616,7 +2623,7 @@ def test_no_experiment_clears_the_marked_positions(qapp):
     host.autolamella_ui.experiment = type(
         "_Exp", (), {
             "path": "/tmp",
-            "positions": [_lamella_with_poses("Lamella-01", microscope, 100e-6, 50e-6)],
+            "positions": [_lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6)],
         },
     )()
     host._update_fm_overview_positions()
@@ -3302,3 +3309,316 @@ def test_a_confirmed_move_re_marks_the_canvas(qapp, tmp_path, monkeypatch):
     assert host.fm_overview_widget._positions[0].x != pytest.approx(before)
 
     host._teardown_fm_overview_widget()
+
+
+# ── the lamella list in the settings column ──────────────────────────────
+
+
+def _tab_with(qapp, tmp_path, positions=()):
+    """A `FluorescenceOverviewTab` with a live overview and an experiment."""
+    import fibsem.config as fibsem_cfg
+    from fibsem.applications.autolamella.ui.fluorescence_overview_tab import (
+        FluorescenceOverviewTab,
+    )
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    # The tab is behind a preference that is off by default, and `refresh_microscope`
+    # reads it. `_restore_fm_overview_flag` puts it back afterwards.
+    fibsem_cfg.FEATURE_FM_OVERVIEW_TAB_ENABLED = True
+    microscope = build_microscope()
+    experiment = _experiment_with(positions, tmp_path)
+    ui = type(
+        "_UI", (), {"microscope": microscope, "experiment": experiment}
+    )()
+    ui.update_ui = lambda: None
+    tab = FluorescenceOverviewTab(ui)
+    tab.refresh_microscope()
+    qapp.processEvents()
+    return tab
+
+
+def test_the_list_sits_in_the_settings_column(qapp, tmp_path):
+    """Not in a column of its own beside it: the positions are the subject of this tab,
+    and a third pane would read as somewhere else to look."""
+    tab = _tab_with(qapp, tmp_path)
+
+    # its way up the tree reaches the overview, not the tab directly
+    parents, w = [], tab.lamella_list
+    while w is not None:
+        parents.append(w)
+        w = w.parent()
+
+    assert tab.overview in parents
+    assert tab.lamella_list.isVisibleTo(tab.overview)
+
+    tab._drop_overview()
+
+
+def test_the_list_shows_every_lamella_including_the_unplaceable(qapp, tmp_path):
+    """The canvas can only draw the ones with a fluorescence pose. The list is how you
+    find out the others exist at all -- dropping them here too would leave the log as the
+    only place that says so."""
+    tab = _tab_with(qapp, tmp_path)
+    microscope = tab.microscope
+    placeable = _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6)
+    orphan = _lamella_with_poses("Lamella-02", microscope, tmp_path, 0.0, 0.0)
+    del orphan.poses["FLUORESCENCE"]
+    tab.experiment.positions.extend([placeable, orphan])
+
+    tab.refresh_positions()
+
+    from PyQt5.QtCore import Qt
+
+    names = [
+        tab.lamella_list._list.item(i).data(Qt.UserRole).name
+        for i in range(tab.lamella_list._list.count())
+    ]
+    assert names == ["Lamella-01", "Lamella-02"]
+    # ...while the canvas draws only the one it can place
+    assert [p.name for p in tab.overview._positions] == ["Lamella-01"]
+
+    tab._drop_overview()
+
+
+def test_picking_a_row_highlights_it_on_the_canvas(qapp, tmp_path):
+    tab = _tab_with(qapp, tmp_path)
+    microscope = tab.microscope
+    tab.experiment.positions.extend([
+        _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
+        _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
+    ])
+    tab.refresh_positions()
+    qapp.processEvents()
+
+    tab.lamella_list.select("Lamella-02")
+    qapp.processEvents()
+
+    assert tab.overview.selected_position == "Lamella-02"
+
+    tab._drop_overview()
+
+
+def test_picking_a_row_tells_the_window(qapp, tmp_path):
+    """The other lists are synced by the window, not from here -- one place doing it
+    beats four talking to each other."""
+    tab = _tab_with(qapp, tmp_path)
+    microscope = tab.microscope
+    tab.experiment.positions.extend([
+        _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
+        _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
+    ])
+    tab.refresh_positions()
+    qapp.processEvents()
+    seen = []
+    tab.lamella_selected.connect(lambda lamella: seen.append(lamella))
+
+    # the second, because populating restores the selection to the first -- picking a
+    # row that is already current emits nothing
+    tab.lamella_list.select("Lamella-02")
+    qapp.processEvents()
+
+    assert [lamella.name for lamella in seen if lamella is not None] == ["Lamella-02"]
+
+    tab._drop_overview()
+
+
+def test_a_selection_arriving_from_elsewhere_reaches_the_list(qapp, tmp_path):
+    tab = _tab_with(qapp, tmp_path)
+    microscope = tab.microscope
+    tab.experiment.positions.extend([
+        _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
+        _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
+    ])
+    tab.refresh_positions()
+    qapp.processEvents()
+
+    tab.set_selected(tab.experiment.positions[1])
+    qapp.processEvents()
+
+    assert tab.lamella_list.selected_name == "Lamella-02"
+    assert tab.overview.selected_position == "Lamella-02"
+
+    tab._drop_overview()
+
+
+def test_move_to_drives_the_stage_to_the_fluorescence_pose(qapp, tmp_path, monkeypatch):
+    """Not `stage_position`, which is the milling pose. This tab looks at the sample from
+    the fluorescence side, and moving to the milling pose would swing the stage 180
+    degrees away from the view you asked to centre."""
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    tab = _tab_with(qapp, tmp_path)
+    monkeypatch.setattr(module, "FunctionWorker", _SynchronousWorker)
+    microscope = tab.microscope
+    lamella = _lamella_with_poses("Lamella-01", microscope, tmp_path, 300e-6, -150e-6)
+    tab.experiment.positions.append(lamella)
+    tab.refresh_positions()
+
+    tab._on_move_to_requested(lamella)
+    qapp.processEvents()
+
+    arrived = microscope.get_stage_position()
+    fm_pose = lamella.fluorescence_pose.stage_position
+    assert arrived.x == pytest.approx(fm_pose.x, abs=1e-9)
+    assert arrived.y == pytest.approx(fm_pose.y, abs=1e-9)
+    assert microscope.get_stage_orientation(arrived) == "FM"
+    assert arrived.t != pytest.approx(lamella.milling_pose.stage_position.t)
+
+    tab._drop_overview()
+
+
+def test_move_to_a_lamella_with_no_fluorescence_pose_is_refused(qapp, tmp_path, monkeypatch):
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    tab = _tab_with(qapp, tmp_path)
+    monkeypatch.setattr(module, "FunctionWorker", _SynchronousWorker)
+    microscope = tab.microscope
+    lamella = _lamella_with_poses("Lamella-01", microscope, tmp_path, 300e-6, -150e-6)
+    del lamella.poses["FLUORESCENCE"]
+    tab.experiment.positions.append(lamella)
+    before = microscope.get_stage_position()
+
+    tab._on_move_to_requested(lamella)  # must not raise
+    qapp.processEvents()
+
+    assert microscope.get_stage_position().x == pytest.approx(before.x)
+
+    tab._drop_overview()
+
+
+def test_removing_a_lamella_takes_it_off_the_list_and_the_canvas(qapp, tmp_path):
+    tab = _tab_with(qapp, tmp_path)
+    microscope = tab.microscope
+    keep = _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6)
+    drop = _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6)
+    tab.experiment.positions.extend([keep, drop])
+    tab.refresh_positions()
+
+    tab._on_remove_requested(drop)
+    tab.refresh_positions()  # the window's rebuild does this off `removed`
+
+    assert list(tab.experiment.positions) == [keep]
+    assert [p.name for p in tab.overview._positions] == ["Lamella-01"]
+    assert tab.experiment.saves == 1
+
+    tab._drop_overview()
+
+
+def test_the_list_survives_the_overview_being_rebuilt(qapp, tmp_path):
+    """A reconnection replaces the overview. The list belongs to the tab, so it is the
+    same object afterwards, still populated, and sitting in the *new* column.
+
+    It does not verify the reparent in `_drop_overview` that makes this safe against Qt
+    ownership: the offscreen platform never actually runs the deferred delete, so the
+    old overview is still alive either way and the mechanism cannot be reproduced here.
+    Removing that reparent leaves this test passing -- checked."""
+    tab = _tab_with(qapp, tmp_path)
+    microscope = tab.microscope
+    tab.experiment.positions.append(
+        _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6)
+    )
+    tab.refresh_positions()
+    first = tab.lamella_list
+
+    from PyQt5.QtCore import QEvent
+
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    tab.autolamella_ui.microscope = build_microscope()
+    tab.refresh_microscope()  # a reconnection: new microscope, new overview
+    # `deleteLater` is deferred, so without this the old overview is still alive at
+    # assert time and a list left inside it would look fine. A running event loop does
+    # this for you; a test has to ask.
+    qapp.sendPostedEvents(None, QEvent.DeferredDelete)
+    qapp.processEvents()
+
+    assert tab.lamella_list is first, "the list was replaced"
+    assert tab.lamella_list.selected_name == "Lamella-01", "the list lost its contents"
+    parents, w = [], tab.lamella_list
+    while w is not None:
+        parents.append(w)
+        w = w.parent()
+    assert tab.overview in parents, "the list did not move to the new overview"
+
+    tab._drop_overview()
+
+
+def test_a_lamella_is_complete_before_anyone_is_told_about_it(qapp, tmp_path):
+    """The reported bug: a position added from the FIB/SEM minimap was missing from the
+    FM overview -- always the newest one, and only until something else forced a refresh.
+
+    `add_lamella` publishes `inserted`, and everything drawing the experiment redraws on
+    it. The fluorescence pose used to be assigned three lines *after* that, so every
+    listener decided the new lamella had none and skipped it as unplaceable.
+
+    Asserted at the moment the signal fires, because that is the only moment it was ever
+    wrong: by the time `add_new_lamella` returned, the pose was there.
+    """
+    from psygnal.containers import EventedDict
+
+    from fibsem.applications.autolamella.poses import (
+        MILLING_ORIENTATION,
+        build_lamella_poses,
+    )
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskProtocol
+    from fibsem.structures import FibsemStagePosition
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    microscope = build_microscope()
+    experiment = _real_experiment(tmp_path)
+    experiment.task_protocol = AutoLamellaTaskProtocol()
+
+    seen = []
+    experiment.positions.events.inserted.connect(
+        lambda *_: seen.append(experiment.positions[-1].fluorescence_pose is not None)
+    )
+
+    beam = microscope.get_orientation(MILLING_ORIENTATION)
+    poses = build_lamella_poses(
+        microscope,
+        FibsemStagePosition(x=100e-6, y=50e-6, z=0.0, r=beam.r, t=beam.t),
+    )
+    experiment.add_new_lamella(
+        microscope_state=poses.milling,
+        task_config=EventedDict(),
+        fluorescence_pose=poses.fluorescence,
+    )
+
+    assert seen == [True], "the lamella was published before it had a fluorescence pose"
+
+
+def test_a_lamella_added_from_elsewhere_lands_on_the_canvas_immediately(qapp, tmp_path):
+    """The same bug, end to end: nothing calls the FM refresh by hand on this path, so
+    the marker has to be there off the `inserted` event alone."""
+    from psygnal.containers import EventedDict
+
+    from fibsem.applications.autolamella.poses import (
+        MILLING_ORIENTATION,
+        build_lamella_poses,
+    )
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskProtocol
+    from fibsem.structures import FibsemStagePosition
+
+    tab = _tab_with(qapp, tmp_path)
+    microscope = tab.microscope
+    experiment = _real_experiment(tmp_path / "exp")
+    experiment.task_protocol = AutoLamellaTaskProtocol()
+    tab.autolamella_ui.experiment = experiment
+    experiment.positions.events.inserted.connect(lambda *_: tab.refresh_positions())
+
+    beam = microscope.get_orientation(MILLING_ORIENTATION)
+    poses = build_lamella_poses(
+        microscope,
+        FibsemStagePosition(x=100e-6, y=50e-6, z=0.0, r=beam.r, t=beam.t),
+    )
+    experiment.add_new_lamella(
+        microscope_state=poses.milling,
+        task_config=EventedDict(),
+        name="Lamella-01",
+        fluorescence_pose=poses.fluorescence,
+    )
+    qapp.processEvents()
+
+    assert [p.name for p in tab.overview._positions] == ["Lamella-01"]
+
+    tab._drop_overview()

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -3622,3 +3622,131 @@ def test_a_lamella_added_from_elsewhere_lands_on_the_canvas_immediately(qapp, tm
     assert [p.name for p in tab.overview._positions] == ["Lamella-01"]
 
     tab._drop_overview()
+
+
+# ── the scene follows the stage's pose ───────────────────────────────────
+
+
+def test_marked_positions_move_when_the_stage_re_poses(qapp):
+    """Reported: tilt the stage 180 degrees and the markers stay put, when they should
+    move. Everything on this canvas is placed through a frame whose rotation and tilt
+    come from wherever the stage is, so a re-pose moves all of it -- but only the current
+    position crosshair and the tile grid were being redrawn."""
+    from fibsem.structures import FibsemStagePosition
+
+    microscope = _microscope_at(-180.0)  # FM
+    widget = FMOverviewWidget(microscope)
+    widget._refresh_tile_grid()
+    qapp.processEvents()
+
+    marked = _named("Lamella-01", 100e-6, 50e-6)
+    widget.set_positions([marked])
+    at_fm = list(widget.position_overlay._points)
+
+    milling = microscope.get_orientation("MILLING")
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=milling.r, t=milling.t)
+    )
+    widget._on_stage_moved(microscope.get_stage_position())
+    qapp.processEvents()
+
+    after = list(widget.position_overlay._points)
+    assert after != at_fm, "the markers did not follow the re-pose"
+    # ...and they are where the frame now says they are, not merely somewhere else
+    assert after[0] == pytest.approx(widget._frame().to_canvas(marked), abs=1e-6)
+
+    widget.close()
+
+
+def test_the_selected_marker_re_poses_too(qapp):
+    """It is on its own overlay, so it is a second thing that has to be redrawn."""
+    from fibsem.structures import FibsemStagePosition
+
+    microscope = _microscope_at(-180.0)
+    widget = FMOverviewWidget(microscope)
+    widget._refresh_tile_grid()
+    widget.set_positions([_named("Lamella-01", 100e-6, 50e-6)])
+    widget.set_selected_position("Lamella-01")
+    qapp.processEvents()
+    before = list(widget.selected_position_overlay._points)
+
+    milling = microscope.get_orientation("MILLING")
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=milling.r, t=milling.t)
+    )
+    widget._on_stage_moved(microscope.get_stage_position())
+    qapp.processEvents()
+
+    assert list(widget.selected_position_overlay._points) != before
+
+    widget.close()
+
+
+def test_translating_the_stage_leaves_the_markers_alone(qapp):
+    """The stage is polled constantly and a translation moves none of this: the origin
+    everything is measured from does not move with it. Redrawing anyway would be work
+    per poll for no visible change."""
+    from fibsem.structures import FibsemStagePosition
+
+    microscope = _microscope_at(-180.0)
+    widget = FMOverviewWidget(microscope)
+    widget._refresh_tile_grid()
+    widget.set_positions([_named("Lamella-01", 100e-6, 50e-6)])
+    qapp.processEvents()
+    before = list(widget.position_overlay._points)
+
+    redraws = []
+    original = widget._refresh_positions
+    widget._refresh_positions = lambda: redraws.append(1) or original()
+
+    here = microscope.get_stage_position()
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=here.x + 200e-6, y=here.y - 90e-6, z=here.z,
+                            r=here.r, t=here.t)
+    )
+    widget._on_stage_moved(microscope.get_stage_position())
+    qapp.processEvents()
+
+    assert redraws == [], "redrew the markers for a move that cannot have moved them"
+    assert list(widget.position_overlay._points) == before
+
+    widget.close()
+
+
+def test_the_stage_limits_re_pose_even_with_the_grid_pinned(qapp):
+    """Drawn from the same frame, so they had the same bug.
+
+    With the grid free, `_refresh_tile_grid` redraws them on its way past and this
+    passes either way. The target is pinned first so that path is skipped -- dragging the
+    grid somewhere and then re-posing the stage is exactly when nothing else would.
+
+    The origin is also put *off* the grid centre. Anchored on it, the limits box and the
+    grid boundary sit at canvas zero whatever the pose -- a zero offset stays zero
+    through any rotation -- so the test would pass by drawing nothing that could move.
+    """
+    from fibsem.structures import FibsemStagePosition
+
+    microscope = _microscope_at(-180.0)
+    fm = microscope.get_orientation("FM")
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=250e-6, y=-180e-6, z=0.0, r=fm.r, t=fm.t)
+    )
+    widget = FMOverviewWidget(microscope)
+    widget._refresh_tile_grid()  # fixes the origin, off-centre
+    qapp.processEvents()
+    before = [(spec.cx, spec.cy) for spec in widget.stage_overlay._specs]
+    assert any(cx or cy for cx, cy in before), "nothing drawn that a re-pose could move"
+
+    # Pin the grid, so `_on_stage_moved` will not redraw it -- and with it, the limits.
+    widget._target = microscope.get_stage_position()
+
+    milling = microscope.get_orientation("MILLING")
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=250e-6, y=-180e-6, z=0.0, r=milling.r, t=milling.t)
+    )
+    widget._on_stage_moved(microscope.get_stage_position())
+    qapp.processEvents()
+
+    assert [(spec.cx, spec.cy) for spec in widget.stage_overlay._specs] != before
+
+    widget.close()

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -7,9 +7,11 @@ combo box shows the label it was given.
 Uses PyQt5 directly with the offscreen platform (no pytest-qt dependency).
 """
 import os
+from copy import deepcopy
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+import numpy as np
 import pytest
 
 pytest.importorskip("PyQt5")
@@ -1734,6 +1736,10 @@ class _StubHost:
     _update_fm_overview_positions = _Real._update_fm_overview_positions
     _update_fm_overview_selection = _Real._update_fm_overview_selection
     _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
+    # Connected by `_build_fm_overview_widget`, so every host needs them present.
+    _on_fm_overview_add_position = _Real._on_fm_overview_add_position
+    _on_fm_overview_move_position = _Real._on_fm_overview_move_position
+    _fm_overview_objective_position = _Real._fm_overview_objective_position
 
     def __init__(self, microscope=None, experiment=None, tab_enabled=True):
         import fibsem.config as fibsem_cfg
@@ -2631,3 +2637,508 @@ def test_the_host_tolerates_no_fm_overview_tab(qapp):
 
     host._update_fm_overview_positions()   # must not raise
     host._update_fm_overview_selection(None)  # must not raise
+
+
+# ── right-clicking to place a position ───────────────────────────────────
+
+
+def _menu_at_the_stage(widget, dx: float = 0.0, dy: float = 0.0):
+    """The context menu for a point on the canvas, offset from where the stage is."""
+    frame = widget._frame()
+    point = frame.to_canvas(widget._current_stage_position())
+    return widget._position_menu(point[0] + dx, point[1] + dy)
+
+
+def _labels(config):
+    return [action.label for action in config.actions]
+
+
+def _fire(config, index: int):
+    """Trigger a menu entry the way `ContextMenu` does, without opening one.
+
+    `show_at_cursor` runs a modal event loop, so a test that opened the menu would hang
+    rather than fail.
+    """
+    config.actions[index].callback()
+
+
+def test_the_canvas_right_click_reaches_the_menu(qapp, interactive_widget, monkeypatch):
+    """The one link the rest of these tests step over, by calling `_position_menu`
+    directly -- they have to, because opening the menu runs a modal loop. Returning None
+    from it here keeps that loop shut while still proving the signal arrives."""
+    widget = interactive_widget
+    seen = []
+    monkeypatch.setattr(
+        widget, "_position_menu", lambda x, y: seen.append((x, y)) or None
+    )
+
+    widget.canvas.canvas.canvas_right_clicked.emit(120.0, 340.0, None)
+    qapp.processEvents()
+
+    assert seen == [(120.0, 340.0)]
+
+
+def test_right_clicking_offers_to_put_a_position_there(qapp, interactive_widget):
+    widget = interactive_widget
+    received = []
+    widget.position_add_requested.connect(lambda p: received.append(p))
+
+    config = _menu_at_the_stage(widget, dx=800.0, dy=-400.0)
+    _fire(config, 0)
+
+    assert _labels(config)[0] == "Add Position Here"
+    assert len(received) == 1
+    # and it names the point that was clicked, not where the stage happens to be
+    frame = widget._frame()
+    assert frame.to_canvas(received[0]) == pytest.approx(
+        frame.to_canvas(widget._current_stage_position()) + np.array([800.0, -400.0]),
+        abs=1e-6,
+    )
+
+
+def test_the_position_offered_is_the_one_a_double_click_would_move_to(
+    qapp, interactive_widget, monkeypatch
+):
+    """Both gestures resolve a canvas point through the same code, so marking somewhere
+    and driving there cannot drift apart -- which they would, eventually, being the same
+    arithmetic written twice."""
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    widget = interactive_widget
+    monkeypatch.setattr(module, "FunctionWorker", _SynchronousWorker)
+    frame = widget._frame()
+    point = frame.to_canvas(widget._current_stage_position())
+    x, y = point[0] + 1500.0, point[1] + 900.0
+
+    received = []
+    widget.position_add_requested.connect(lambda p: received.append(p))
+    _fire(_menu_at_the_stage(widget, dx=1500.0, dy=900.0), 0)
+
+    widget._on_canvas_double_clicked(x, y, None)
+    qapp.processEvents()
+    moved_to = widget.microscope.get_stage_position()
+
+    assert received[0].x == pytest.approx(moved_to.x, abs=1e-9)
+    assert received[0].y == pytest.approx(moved_to.y, abs=1e-9)
+
+
+def test_the_marked_position_carries_the_fluorescence_pose(qapp, interactive_widget):
+    """It becomes a lamella's fluorescence pose, so its rotation and tilt have to be the
+    fluorescence ones. They come from wherever the stage is -- which is why the gesture
+    is refused anywhere else."""
+    widget = interactive_widget
+    received = []
+    widget.position_add_requested.connect(lambda p: received.append(p))
+
+    _fire(_menu_at_the_stage(widget, dx=300.0), 0)
+
+    assert widget.microscope.get_stage_orientation(received[0]) == "FM"
+
+
+def test_moving_is_offered_only_once_something_is_selected(qapp, interactive_widget):
+    widget = interactive_widget
+    widget.set_selected_position(None)
+
+    assert _labels(_menu_at_the_stage(widget)) == ["Add Position Here"]
+
+    widget.set_positions([_named("Lamella-04", 0.0, 0.0)])
+    widget.set_selected_position("Lamella-04")
+
+    assert _labels(_menu_at_the_stage(widget)) == [
+        "Add Position Here",
+        "Move Selected Position Here (Lamella-04)",
+    ]
+
+    widget.set_selected_position(None)
+    widget.set_positions([])
+
+
+def test_moving_requests_the_selected_name_and_the_clicked_point(qapp, interactive_widget):
+    widget = interactive_widget
+    widget.set_positions([_named("Lamella-04", 0.0, 0.0)])
+    widget.set_selected_position("Lamella-04")
+    received = []
+    widget.position_move_requested.connect(lambda n, p: received.append((n, p)))
+
+    _fire(_menu_at_the_stage(widget, dx=-600.0, dy=250.0), 1)
+
+    assert len(received) == 1
+    name, position = received[0]
+    assert name == "Lamella-04"
+    frame = widget._frame()
+    assert frame.to_canvas(position) == pytest.approx(
+        frame.to_canvas(widget._current_stage_position()) + np.array([-600.0, 250.0]),
+        abs=1e-6,
+    )
+
+    widget.set_selected_position(None)
+    widget.set_positions([])
+
+
+def test_nothing_is_offered_outside_the_stage_limits(qapp, interactive_widget):
+    """The stage cannot go there, so it is neither somewhere to move nor somewhere to
+    put a lamella."""
+    widget = interactive_widget
+    limits = widget.microscope._stage.limits
+    frame = widget._frame()
+    # A point comfortably past the x limit, in canvas units.
+    beyond = frame.length((limits["x"].max - limits["x"].min) * 2)
+
+    assert _menu_at_the_stage(widget, dx=beyond) is None
+
+
+def test_nothing_is_offered_during_an_acquisition(qapp, interactive_widget):
+    """A host that has taken the instrument is usually a workflow iterating the
+    experiment's positions, and adding one underneath it is not a thing to do quietly."""
+    widget = interactive_widget
+    widget._set_running(True)
+    try:
+        assert _menu_at_the_stage(widget) is None
+    finally:
+        widget._set_running(False)
+
+
+def test_nothing_is_offered_while_a_host_holds_the_tab(qapp, interactive_widget):
+    widget = interactive_widget
+    widget.set_interactive(False)
+    try:
+        assert _menu_at_the_stage(widget) is None
+    finally:
+        widget.set_interactive(True)
+
+
+def test_nothing_is_offered_from_a_beam_orientation(qapp):
+    """The canvas frame takes its rotation and tilt from wherever the stage is, so a
+    point resolved at a beam orientation comes back carrying *beam* rotation and tilt on
+    fluorescence-side coordinates -- a fluorescence pose that is not in the fluorescence
+    orientation."""
+    from fibsem.structures import FibsemStagePosition
+
+    microscope = _microscope_at(-180.0)  # FM, on a compustage
+    widget = FMOverviewWidget(microscope)
+    widget._refresh_tile_grid()
+    qapp.processEvents()
+    assert _menu_at_the_stage(widget) is not None
+
+    milling = microscope.get_orientation("MILLING")
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=milling.r, t=milling.t)
+    )
+    widget._on_stage_moved(microscope.get_stage_position())
+    qapp.processEvents()
+
+    assert _menu_at_the_stage(widget) is None
+
+    widget.close()
+
+
+# ── the host turns a request into a lamella ──────────────────────────────
+
+
+def _experiment_with(positions, tmp_path):
+    """An experiment stub that records saves, for the host handlers."""
+    class _Exp:
+        def __init__(self):
+            self.path = str(tmp_path)
+            self.positions = list(positions)
+            self.saves = 0
+
+        def save(self):
+            self.saves += 1
+
+    return _Exp()
+
+
+def _wired_host(qapp, tmp_path, positions=()):
+    """A `_StubHost` with an experiment and a recording AutoLamella UI."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope())
+    host._build_fm_overview_widget()
+    host.autolamella_ui.experiment = _experiment_with(positions, tmp_path)
+    host.autolamella_ui.added = []
+    host.autolamella_ui.updated = 0
+
+    def add_new_lamella(stage_position=None, name=None, objective_position=None,
+                        marked_at=None):
+        host.autolamella_ui.added.append(
+            {"position": stage_position, "objective_position": objective_position,
+             "marked_at": marked_at}
+        )
+        lamella = type("_Lamella", (), {"name": f"Lamella-{len(host.autolamella_ui.added):02d}"})()
+        return lamella
+
+    def update_ui():
+        host.autolamella_ui.updated += 1
+
+    host.autolamella_ui.add_new_lamella = add_new_lamella
+    host.autolamella_ui.update_ui = update_ui
+    return host
+
+
+def _real_lamella(name, microscope, tmp_path, x=100e-6, y=50e-6):
+    """A real `Lamella` with both poses, so the property setters behave as they do live."""
+    from fibsem.applications.autolamella.poses import (
+        MILLING_ORIENTATION,
+        build_lamella_poses,
+    )
+    from fibsem.applications.autolamella.structures import Lamella
+    from fibsem.structures import FibsemStagePosition
+
+    beam = microscope.get_orientation(MILLING_ORIENTATION)
+    poses = build_lamella_poses(
+        microscope,
+        FibsemStagePosition(x=x, y=y, z=0.0, r=beam.r, t=beam.t),
+    )
+    lamella = Lamella(petname=name, path=str(tmp_path / name), number=1)
+    lamella.milling_pose = poses.milling
+    lamella.fluorescence_pose = poses.fluorescence
+    return lamella
+
+
+def test_adding_declares_the_fluorescence_orientation(qapp, tmp_path):
+    """Not left to be derived. On a compustage the answer would be the same; on an
+    offset mount it would not, and the wrong answer there is a lamella with a milling
+    pose 48 mm off the beam axis that nothing rejects until something tries to mill it
+    (FIB-93). Declaring it turns that into a refusal with a user to tell."""
+    from fibsem.applications.autolamella.poses import FLUORESCENCE_ORIENTATION
+
+    host = _wired_host(qapp, tmp_path)
+    position = _named("wherever", 120e-6, -60e-6)
+
+    host._on_fm_overview_add_position(position)
+
+    assert host.autolamella_ui.added[0]["marked_at"] == FLUORESCENCE_ORIENTATION
+    assert host.autolamella_ui.added[0]["position"] is position
+
+    host._teardown_fm_overview_widget()
+
+
+def test_adding_records_where_the_objective_actually_is(qapp, tmp_path):
+    """Rather than the objective's configured focus position, which `build_lamella_poses`
+    falls back to: that is a property of the instrument and says nothing about this
+    sample. Whoever marked this had the feature in focus."""
+    host = _wired_host(qapp, tmp_path)
+    objective = host.autolamella_ui.microscope.fm.objective
+    objective.focus_position = 1.0e-3
+    objective.insert()
+    objective.move_absolute(objective.position + 50e-6)  # focused by hand
+    assert objective.state == "Inserted"
+
+    host._on_fm_overview_add_position(_named("wherever", 0.0, 0.0))
+
+    assert host.autolamella_ui.added[0]["objective_position"] == pytest.approx(
+        objective.position
+    )
+    assert host.autolamella_ui.added[0]["objective_position"] != pytest.approx(1.0e-3)
+
+
+def test_a_retracted_objective_is_not_recorded_as_a_focus(qapp, tmp_path):
+    """It is parked ~10 mm from anything and nobody focused on it. None hands the
+    decision to `build_lamella_poses`' fallback, because `fluorescence_selected` only
+    asks whether an objective position exists -- a parked one would read as focused."""
+    host = _wired_host(qapp, tmp_path)
+    objective = host.autolamella_ui.microscope.fm.objective
+    objective.retract()
+    assert objective.state == "Retracted"
+
+    host._on_fm_overview_add_position(_named("wherever", 0.0, 0.0))
+
+    assert host.autolamella_ui.added[0]["objective_position"] is None
+
+    host._teardown_fm_overview_widget()
+
+    host._teardown_fm_overview_widget()
+
+
+def test_adding_without_an_experiment_is_refused_not_crashed(qapp, tmp_path):
+    host = _wired_host(qapp, tmp_path)
+    host.autolamella_ui.experiment = None
+
+    host._on_fm_overview_add_position(_named("wherever", 0.0, 0.0))  # must not raise
+
+    assert host.autolamella_ui.added == []
+
+    host._teardown_fm_overview_widget()
+
+
+def test_a_refused_add_is_reported_rather_than_raised(qapp, tmp_path):
+    """The offset-mount refusal arrives here as a ValueError from `build_lamella_poses`,
+    and it is a message for the user, not a traceback."""
+    host = _wired_host(qapp, tmp_path)
+
+    def refuse(**kwargs):
+        raise ValueError("no transform between the fluorescence and beam positions")
+
+    host.autolamella_ui.add_new_lamella = refuse
+
+    host._on_fm_overview_add_position(_named("wherever", 0.0, 0.0))  # must not raise
+
+    host._teardown_fm_overview_widget()
+
+
+def test_moving_asks_before_it_moves_anything(qapp, tmp_path, monkeypatch):
+    """Moving one pose moves both, and the milling pose is not visible from this canvas.
+    Said rather than assumed."""
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _wired_host(qapp, tmp_path)
+    microscope = host.autolamella_ui.microscope
+    lamella = _real_lamella("Lamella-01", microscope, tmp_path)
+    host.autolamella_ui.experiment.positions = [lamella]
+    before = deepcopy(lamella.poses)
+
+    asked = []
+    monkeypatch.setattr(
+        module, "message_box_ui", lambda **kwargs: asked.append(kwargs) or False
+    )
+
+    host._on_fm_overview_move_position("Lamella-01", _named("target", 400e-6, -200e-6))
+
+    assert len(asked) == 1, "moved without asking"
+    assert lamella.poses["MILLING"].stage_position.x == before["MILLING"].stage_position.x
+    assert (
+        lamella.poses["FLUORESCENCE"].stage_position.x
+        == before["FLUORESCENCE"].stage_position.x
+    )
+    assert host.autolamella_ui.experiment.saves == 0
+
+    host._teardown_fm_overview_widget()
+    _ = build_microscope  # keep the import meaningful under -W error
+
+
+def test_confirming_a_move_moves_both_poses(qapp, tmp_path, monkeypatch):
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    host = _wired_host(qapp, tmp_path)
+    microscope = host.autolamella_ui.microscope
+    lamella = _real_lamella("Lamella-01", microscope, tmp_path)
+    host.autolamella_ui.experiment.positions = [lamella]
+    monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
+
+    target = _named("target", 400e-6, -200e-6)
+    host._on_fm_overview_move_position("Lamella-01", target)
+
+    # the fluorescence pose is where the user clicked...
+    assert lamella.fluorescence_pose.stage_position.x == pytest.approx(400e-6)
+    assert lamella.fluorescence_pose.stage_position.y == pytest.approx(-200e-6)
+    # ...and the milling pose followed it, into the milling orientation
+    assert (
+        microscope.get_stage_orientation(lamella.milling_pose.stage_position)
+        == "MILLING"
+    )
+    assert lamella.milling_pose.stage_position.x == pytest.approx(400e-6)
+    assert host.autolamella_ui.experiment.saves == 1
+
+    host._teardown_fm_overview_widget()
+
+
+def test_a_move_rewrites_the_stage_positions_and_nothing_else(qapp, tmp_path, monkeypatch):
+    """A move is a move. The poses are edited in place rather than replaced, so the beam
+    settings the lamella was marked with survive -- and so does the objective position,
+    because the user moved sideways, they did not refocus."""
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    host = _wired_host(qapp, tmp_path)
+    microscope = host.autolamella_ui.microscope
+    lamella = _real_lamella("Lamella-01", microscope, tmp_path)
+    lamella.milling_pose.electron_detector.brightness = 0.123
+    lamella.fluorescence_pose.objective_position = 7.7e-3
+    host.autolamella_ui.experiment.positions = [lamella]
+    monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
+
+    host._on_fm_overview_move_position("Lamella-01", _named("target", 400e-6, -200e-6))
+
+    assert lamella.milling_pose.electron_detector.brightness == pytest.approx(0.123)
+    assert lamella.fluorescence_pose.objective_position == pytest.approx(7.7e-3)
+
+
+def test_moving_a_lamella_that_has_no_fluorescence_pose_gives_it_one(
+    qapp, tmp_path, monkeypatch
+):
+    """Possible on a lamella marked before there was an FM. It gets a whole new pose
+    rather than an edit, and that one is built on what the lamella itself recorded --
+    not on whatever the microscope happens to be set to now."""
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    host = _wired_host(qapp, tmp_path)
+    microscope = host.autolamella_ui.microscope
+    lamella = _real_lamella("Lamella-01", microscope, tmp_path)
+    lamella.milling_pose.electron_detector.brightness = 0.123
+    del lamella.poses["FLUORESCENCE"]
+    host.autolamella_ui.experiment.positions = [lamella]
+    monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
+
+    host._on_fm_overview_move_position("Lamella-01", _named("target", 400e-6, -200e-6))
+
+    assert lamella.fluorescence_pose is not None
+    assert lamella.fluorescence_pose.stage_position.x == pytest.approx(400e-6)
+    # built on the lamella's own state, not the live microscope's
+    assert lamella.fluorescence_pose.electron_detector.brightness == pytest.approx(0.123)
+
+    host._teardown_fm_overview_widget()
+
+
+def test_a_move_re_derives_the_milling_angle(qapp, tmp_path, monkeypatch):
+    """It is computed from the milling-pose stage tilt, so a pose that moved without it
+    would leave the lamella claiming an angle its own pose no longer implies."""
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    host = _wired_host(qapp, tmp_path)
+    microscope = host.autolamella_ui.microscope
+    lamella = _real_lamella("Lamella-01", microscope, tmp_path)
+    lamella.milling_angle = 999.0
+    host.autolamella_ui.experiment.positions = [lamella]
+    monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
+
+    host._on_fm_overview_move_position("Lamella-01", _named("target", 400e-6, -200e-6))
+
+    assert lamella.milling_angle != pytest.approx(999.0)
+    assert lamella.milling_angle == pytest.approx(
+        microscope.get_current_milling_angle(stage_position=lamella.stage_position)
+    )
+
+    host._teardown_fm_overview_widget()
+
+
+def test_a_move_that_names_nothing_does_nothing(qapp, tmp_path, monkeypatch):
+    """The canvas holds its selection by name and is rebuilt independently of the host's
+    list, so a name can arrive for a lamella that is no longer there."""
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    host = _wired_host(qapp, tmp_path)
+    lamella = _real_lamella("Lamella-01", host.autolamella_ui.microscope, tmp_path)
+    host.autolamella_ui.experiment.positions = [lamella]
+    asked = []
+    monkeypatch.setattr(
+        module, "message_box_ui", lambda **kwargs: asked.append(kwargs) or True
+    )
+
+    host._on_fm_overview_move_position("Lamella-99", _named("target", 0.0, 0.0))
+
+    assert asked == [], "asked about a lamella that is not there"
+    assert host.autolamella_ui.experiment.saves == 0
+
+    host._teardown_fm_overview_widget()
+
+
+def test_a_confirmed_move_re_marks_the_canvas(qapp, tmp_path, monkeypatch):
+    """Otherwise the marker stays where the lamella used to be until something else
+    happens to refresh it."""
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    host = _wired_host(qapp, tmp_path)
+    microscope = host.autolamella_ui.microscope
+    lamella = _real_lamella("Lamella-01", microscope, tmp_path)
+    host.autolamella_ui.experiment.positions = [lamella]
+    host._update_fm_overview_positions()
+    before = host.fm_overview_widget._positions[0].x
+    monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
+
+    host._on_fm_overview_move_position("Lamella-01", _named("target", 400e-6, -200e-6))
+
+    assert host.fm_overview_widget._positions[0].x == pytest.approx(400e-6)
+    assert host.fm_overview_widget._positions[0].x != pytest.approx(before)
+
+    host._teardown_fm_overview_widget()

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -3872,3 +3872,88 @@ def test_clicking_a_marker_selects_the_lamella_everywhere(qapp, tmp_path):
     assert tab.overview.selected_position == "Lamella-02"
 
     tab._drop_overview()
+
+
+def test_the_tile_grid_panel_grows_with_its_summary(qapp, interactive_widget):
+    """FIB-510. The panel is a fixed width with a word-wrapped summary, so its height is
+    however many lines that text takes -- and the text grows: dragging the grid adds a
+    line saying how far it now sits from the stage. Fitted only at open time, the panel
+    kept its old height and clipped the extra line top and bottom.
+    """
+    widget = interactive_widget
+    panel = widget.tile_grid_panel
+    widget.btn_tile_grid.setChecked(True)
+    widget._toggle_tile_grid_panel()
+    qapp.processEvents()
+    short = panel.height()
+    assert short >= panel.sizeHint().height()
+
+    # drag the grid, which is what adds the offset line
+    frame = widget._frame()
+    here = frame.to_canvas(widget._current_stage_position())
+    widget._on_grid_move(here[0] + 2500.0, here[1] - 400.0)
+    qapp.processEvents()
+
+    assert "from the stage" in panel.label_summary.text(), "the summary did not grow"
+    assert panel.height() > short, "the panel did not grow with it"
+    assert panel.height() >= panel.sizeHint().height(), "the summary is clipped"
+
+    widget.btn_tile_grid.setChecked(False)
+    widget._toggle_tile_grid_panel()
+    widget.clear_target()
+
+
+def test_the_tile_grid_summary_is_never_clipped(qapp):
+    """FIB-510, at the level it actually breaks.
+
+    A word-wrapped QLabel's height depends on the width it is given, and that dependency
+    does not reach the panel's own size hint -- so past a certain length the panel stops
+    growing and the label keeps a height computed for fewer lines. The text is centred
+    vertically, so the overflow is split top and bottom, which is what the report showed.
+
+    Measured at 196 px wide: the label reported height 36 for text needing 48. Three
+    lines was not enough to trigger it, which is why the widget-level test above passes
+    either way.
+    """
+    from fibsem.ui.fm.widgets.tile_grid_options_panel import TileGridOptionsPanel
+
+    panel = TileGridOptionsPanel()
+    panel.set_summary("3 × 3  ·  10% overlap  ·  9/9 tiles\n287 × 287 µm")
+    panel.adjustSize()
+    panel.show()
+    qapp.processEvents()
+
+    # what dragging the grid adds, which wraps onto a further line
+    panel.set_summary(
+        "3 × 3  ·  10% overlap  ·  9/9 tiles\n287 × 287 µm"
+        "\nOffset +563, -93 µm from the stage"
+    )
+    qapp.processEvents()
+
+    label = panel.label_summary
+    assert label.height() >= label.heightForWidth(label.width()), (
+        f"summary clipped: {label.height()}px for text needing "
+        f"{label.heightForWidth(label.width())}px"
+    )
+
+    panel.close()
+
+
+def test_a_hidden_tile_grid_panel_is_not_refitted(qapp, interactive_widget):
+    """Opening it fits it anyway, and moving a hidden top-level window around is work
+    nobody can see."""
+    widget = interactive_widget
+    widget.btn_tile_grid.setChecked(False)
+    widget._toggle_tile_grid_panel()
+    qapp.processEvents()
+    assert not widget.tile_grid_panel.isVisible()
+
+    fits = []
+    original = widget._fit_tile_grid_panel
+    widget._fit_tile_grid_panel = lambda: fits.append(1) or original()
+
+    widget._update_grid_summary()
+
+    assert fits == []
+
+    widget._fit_tile_grid_panel = original

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1731,6 +1731,8 @@ class _StubHost:
     _build_fm_overview_widget = _Real._build_fm_overview_widget
     _teardown_fm_overview_widget = _Real._teardown_fm_overview_widget
     _update_fm_overview_experiment = _Real._update_fm_overview_experiment
+    _update_fm_overview_positions = _Real._update_fm_overview_positions
+    _update_fm_overview_selection = _Real._update_fm_overview_selection
     _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
 
     def __init__(self, microscope=None, experiment=None, tab_enabled=True):
@@ -1929,7 +1931,9 @@ def test_the_experiment_directory_reaches_the_widget(qapp, tmp_path):
     host._build_fm_overview_widget()
     assert host.fm_overview_widget._save_directory is None
 
-    host.autolamella_ui.experiment = type("_Exp", (), {"path": str(tmp_path)})()
+    host.autolamella_ui.experiment = type(
+        "_Exp", (), {"path": str(tmp_path), "positions": []}
+    )()
     host._update_fm_overview_experiment()
 
     assert host.fm_overview_widget._save_directory == str(tmp_path)
@@ -2404,3 +2408,226 @@ def test_the_placement_of_an_image_matches_a_widget_that_never_moved(qapp):
 
     stale.close()
     fresh.close()
+
+
+# ── marked positions ─────────────────────────────────────────────────────
+
+
+def _named(name: str, x: float, y: float, tilt_deg: float = -180.0):
+    import numpy as np
+
+    from fibsem.structures import FibsemStagePosition
+
+    position = FibsemStagePosition(
+        x=x, y=y, z=0.0, r=0.0, t=np.deg2rad(tilt_deg)
+    )
+    position.name = name
+    return position
+
+
+def test_marked_positions_are_drawn_where_their_stage_positions_are(qapp):
+    widget = _fresh_widget(qapp)
+    widget._refresh_tile_grid()
+    qapp.processEvents()
+
+    widget.set_positions([_named("Lamella-01", 100e-6, 50e-6)])
+
+    frame = widget._frame()
+    expected = frame.to_canvas(_named("Lamella-01", 100e-6, 50e-6))
+    assert widget.position_overlay._points == [pytest.approx(expected)]
+    assert widget.position_overlay._labels == ["Lamella-01"]
+
+    widget.close()
+
+
+def test_the_selected_position_is_drawn_on_its_own_layer(qapp):
+    """`PointsOverlay` paints every point the same colour, so one selected marker among
+    many needs a layer of its own rather than per-point colours."""
+    widget = _fresh_widget(qapp)
+    widget._refresh_tile_grid()
+    widget.set_positions(
+        [_named("Lamella-01", 100e-6, 50e-6), _named("Lamella-02", -80e-6, 20e-6)]
+    )
+    qapp.processEvents()
+
+    widget.set_selected_position("Lamella-02")
+
+    assert widget.position_overlay._labels == ["Lamella-01"]
+    assert widget.selected_position_overlay._labels == ["Lamella-02"]
+
+    widget.close()
+
+
+def test_selecting_nothing_puts_every_position_back(qapp):
+    widget = _fresh_widget(qapp)
+    widget._refresh_tile_grid()
+    widget.set_positions(
+        [_named("Lamella-01", 100e-6, 50e-6), _named("Lamella-02", -80e-6, 20e-6)]
+    )
+    widget.set_selected_position("Lamella-01")
+    qapp.processEvents()
+
+    widget.set_selected_position(None)
+
+    assert sorted(widget.position_overlay._labels) == ["Lamella-01", "Lamella-02"]
+    assert widget.selected_position_overlay._points == []
+
+    widget.close()
+
+
+def test_a_selection_that_names_nothing_marked_highlights_nothing(qapp):
+    """The host's list and this one are rebuilt independently from one experiment, so a
+    name can arrive for a lamella this canvas cannot place."""
+    widget = _fresh_widget(qapp)
+    widget._refresh_tile_grid()
+    widget.set_positions([_named("Lamella-01", 100e-6, 50e-6)])
+    qapp.processEvents()
+
+    widget.set_selected_position("Lamella-99")
+
+    assert widget.position_overlay._labels == ["Lamella-01"]
+    assert widget.selected_position_overlay._points == []
+
+    widget.close()
+
+
+def test_the_selection_survives_the_positions_being_rebuilt(qapp):
+    """Held by name rather than index for exactly this: the host rebuilds the list on
+    every experiment change, and an index would point at a different lamella the moment
+    one was removed."""
+    widget = _fresh_widget(qapp)
+    widget._refresh_tile_grid()
+    widget.set_positions(
+        [_named("Lamella-01", 100e-6, 50e-6), _named("Lamella-02", -80e-6, 20e-6)]
+    )
+    widget.set_selected_position("Lamella-02")
+    qapp.processEvents()
+
+    # Lamella-01 removed; the selected one is now at a different index.
+    widget.set_positions([_named("Lamella-02", -80e-6, 20e-6)])
+    qapp.processEvents()
+
+    assert widget.selected_position_overlay._labels == ["Lamella-02"]
+    assert widget.position_overlay._points == []
+
+    widget.close()
+
+
+def _lamella_with_poses(name: str, microscope, x: float, y: float):
+    """A stand-in lamella carrying both poses, built the way the app builds them."""
+    from fibsem.applications.autolamella.poses import (
+        MILLING_ORIENTATION,
+        build_lamella_poses,
+    )
+    from fibsem.structures import FibsemStagePosition
+
+    beam = microscope.get_orientation(MILLING_ORIENTATION)
+    marked = FibsemStagePosition(x=x, y=y, z=0.0, r=beam.r, t=beam.t)
+    poses = build_lamella_poses(microscope, marked)
+    return type(
+        "_Lamella", (), {
+            "name": name,
+            "fluorescence_pose": poses.fluorescence,
+            "milling_pose": poses.milling,
+        },
+    )()
+
+
+def test_the_host_marks_lamellae_by_their_fluorescence_pose(qapp):
+    """The trap this half exists to avoid. A lamella carries a milling pose and a
+    fluorescence pose, and on a compustage the stage flips 180 degrees between them —
+    so marking the milling pose would put every lamella somewhere the sample is not.
+    """
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope())
+    host._build_fm_overview_widget()
+    widget = host.fm_overview_widget
+    microscope = host.autolamella_ui.microscope
+
+    lamella = _lamella_with_poses("Lamella-01", microscope, 100e-6, 50e-6)
+    host.autolamella_ui.experiment = type(
+        "_Exp", (), {"path": "/tmp", "positions": [lamella]}
+    )()
+
+    host._update_fm_overview_positions()
+
+    marked = widget._positions[0]
+    assert marked.t == pytest.approx(lamella.fluorescence_pose.stage_position.t)
+    assert marked.t != pytest.approx(lamella.milling_pose.stage_position.t)
+    assert marked.name == "Lamella-01"
+
+    host._teardown_fm_overview_widget()
+
+
+def test_a_lamella_with_no_fluorescence_pose_is_skipped_not_misplaced(qapp):
+    """It cannot be placed on this canvas at all — normal on a system with no FM, and
+    possible on an older experiment. Better absent than drawn somewhere invented."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope())
+    host._build_fm_overview_widget()
+    microscope = host.autolamella_ui.microscope
+
+    placeable = _lamella_with_poses("Lamella-01", microscope, 100e-6, 50e-6)
+    orphan = type("_Lamella", (), {"name": "Lamella-02", "fluorescence_pose": None})()
+    host.autolamella_ui.experiment = type(
+        "_Exp", (), {"path": "/tmp", "positions": [placeable, orphan]}
+    )()
+
+    host._update_fm_overview_positions()
+
+    assert [p.name for p in host.fm_overview_widget._positions] == ["Lamella-01"]
+
+    host._teardown_fm_overview_widget()
+
+
+def test_no_experiment_clears_the_marked_positions(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope())
+    host._build_fm_overview_widget()
+    microscope = host.autolamella_ui.microscope
+    host.autolamella_ui.experiment = type(
+        "_Exp", (), {
+            "path": "/tmp",
+            "positions": [_lamella_with_poses("Lamella-01", microscope, 100e-6, 50e-6)],
+        },
+    )()
+    host._update_fm_overview_positions()
+    assert host.fm_overview_widget._positions
+
+    host.autolamella_ui.experiment = None
+    host._update_fm_overview_positions()
+
+    assert host.fm_overview_widget._positions == []
+
+    host._teardown_fm_overview_widget()
+
+
+def test_selection_reaches_the_overview_whichever_list_it_came_from(qapp):
+    """The three selection handlers guard against selecting each other in circles. This
+    highlight emits nothing, so it must run whichever list the selection came from —
+    which is exactly what that guard suppresses."""
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _StubHost(microscope=build_microscope())
+    host._build_fm_overview_widget()
+    lamella = type("_Lamella", (), {"name": "Lamella-07"})()
+
+    host._syncing_selection = True  # as it is while the lists sync each other
+    host._update_fm_overview_selection(lamella)
+
+    assert host.fm_overview_widget.selected_position == "Lamella-07"
+
+    host._teardown_fm_overview_widget()
+
+
+def test_the_host_tolerates_no_fm_overview_tab(qapp):
+    """Both updates are called from paths that run on every system, including those
+    with the tab switched off or no fluorescence detector at all."""
+    host = _StubHost(microscope=_plain_microscope())
+    host._apply_fm_overview_visibility()
+
+    host._update_fm_overview_positions()   # must not raise
+    host._update_fm_overview_selection(None)  # must not raise

--- a/tests/ui/test_point_overlay_colour.py
+++ b/tests/ui/test_point_overlay_colour.py
@@ -1,0 +1,106 @@
+"""The colour a point overlay is asked for has to reach the marker.
+
+`PointsOverlay` drew every marker with a hardcoded white edge. Filled markers (o, s)
+were fine -- a white outline is what makes them legible against a bright image -- but an
+unfilled one (+, x) has no face and is drawn *entirely* in its edge colour, so it came
+out white whatever colour it was given. The label beside it kept the colour, which is
+what made it look intentional rather than broken.
+
+Every `PointsOverlay` in the codebase uses `+`, so every one of them was affected: the
+FM overview's stage position, its saved lamella positions, and the selected one -- three
+markers meant to be told apart by colour, all drawn the same white.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_point_overlay_colour.py
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.overlays.point_overlay import PointsOverlay
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+CYAN = "#26c6da"
+
+
+def _canvas_with(overlay):
+    canvas = FibsemImageCanvas()
+    canvas.add_overlay(overlay)
+    canvas.set_array(np.zeros((64, 64), dtype=np.uint8))
+    return canvas
+
+
+def _markers(overlay):
+    """The overlay's marker artists, excluding the annotations."""
+    from matplotlib.lines import Line2D
+
+    return [a for a in overlay._artists if isinstance(a, Line2D)]
+
+
+def test_an_unfilled_marker_is_drawn_in_the_colour_it_was_given():
+    """The bug. `+` has no face, so its edge colour is the whole glyph."""
+    overlay = PointsOverlay(color=CYAN, marker="+", size=11)
+    canvas = _canvas_with(overlay)
+
+    overlay.set_points([(10.0, 10.0)])
+
+    marker = _markers(overlay)[0]
+    assert marker.get_markeredgecolor() == CYAN
+    assert marker.get_color() == CYAN
+
+
+def test_a_filled_marker_keeps_its_white_outline():
+    """Unchanged, and deliberately: a filled marker has a face to carry the colour, and
+    the white outline is what keeps it legible against a bright image."""
+    overlay = PointsOverlay(color=CYAN, marker="o", size=8)
+    canvas = _canvas_with(overlay)
+
+    overlay.set_points([(10.0, 10.0)])
+
+    marker = _markers(overlay)[0]
+    assert marker.get_markeredgecolor() == "white"
+    assert marker.get_color() == CYAN
+
+
+def test_two_overlays_of_different_colours_do_not_come_out_the_same():
+    """What this actually protects. The FM overview distinguishes the stage position
+    from saved positions from the selected one *by colour alone* -- all three are
+    crosshairs -- so a marker that ignores its colour makes them indistinguishable."""
+    saved = PointsOverlay(color=CYAN, marker="+", size=11)
+    selected = PointsOverlay(color="#76ff03", marker="+", size=15)
+    canvas = FibsemImageCanvas()
+    canvas.add_overlay(saved)
+    canvas.add_overlay(selected)
+    canvas.set_array(np.zeros((64, 64), dtype=np.uint8))
+
+    saved.set_points([(10.0, 10.0)])
+    selected.set_points([(20.0, 20.0)])
+
+    assert _markers(saved)[0].get_markeredgecolor() != _markers(selected)[
+        0
+    ].get_markeredgecolor()
+
+
+def test_the_label_and_the_marker_agree():
+    """They disagreed before -- the label took the colour and the marker did not, which
+    is exactly what made it read as a design choice rather than a bug."""
+    from matplotlib.text import Annotation
+
+    overlay = PointsOverlay(color=CYAN, marker="+", size=11)
+    canvas = _canvas_with(overlay)
+
+    overlay.set_points([(10.0, 10.0)], labels=["Lamella-01"])
+
+    label = next(a for a in overlay._artists if isinstance(a, Annotation))
+    assert label.get_color() == _markers(overlay)[0].get_markeredgecolor()


### PR DESCRIPTION
Right-click the FM overview to add a lamella at that point, or move the selected one there — the only channel by which a target found in fluorescence reaches the milling side, now that the two overview tabs are staying separate (FIB-439). Plus a list of the experiment's lamellae in the settings column.

Closes FIB-437, phases 1–4.

## The problem underneath

`AutoLamellaUI.add_new_lamella(stage_position)` took its argument as the **milling** pose. Hand it a position picked off the FM canvas and it stores a milling pose at t = −180°, which is not an orientation anything mills at. Nothing rejects it; it fails later, somewhere else.

So the orientation is read off the position rather than assumed. It is already there, in the rotation and tilt, which is how `get_target_position` works at all. `build_lamella_poses` (new, `poses.py`) is the one place that decides which pose is which, and `add_new_lamella` is 19 lines lighter for it. Beam-side behaviour is byte-identical — including the milling pose keeping whatever tilt it was marked at, because `update_milling_angle` derives the angle from it and re-posing would quietly change every existing lamella.

**A correction to the issue as filed.** It claimed the FM position would be transformed into FM space twice. Measured: `get_target_position` returns early when the position is already in the target orientation, so the fluorescence pose came out correct. Only `milling_pose` was wrong. The narrower diagnosis is what made the fix small.

## Marking is guarded differently from moving

Moving works from any pose: the whole scene — images, markers, grid — is re-placed through whatever pose the stage is in (`_posed`), so a click still lands on the feature it points at. A marked position has to survive being *written down* as a fluorescence pose, and one carrying SEM rotation and tilt is not one however right it looked on screen. Marking is therefore refused unless the stage is genuinely in the FM orientation.

`fm.has_valid_orientation()` cannot answer that, which only turned up on measuring it: it asks whether FM *acquisition* is allowed — `valid_orientations = ["FM", "SEM", "MILLING"]` — and `ALLOW_UNKNOWN_ORIENTATIONS = True` makes it return True unconditionally in the shipped config. **The existing double-click guard is dead as configured**, despite a message saying the stage must be in a valid FM orientation. Left alone here: it is pre-existing, and moving is safe from any pose. It should either be deleted or made to mean something.

## Offset mounts are refused, on purpose

`marked_at=FLUORESCENCE_ORIENTATION` is declared rather than derived. On a compustage deriving it gives the same answer; on an offset mount it does not, and the wrong answer there is a lamella with a milling pose 48 mm off the beam axis that nothing rejects until something tries to mill it.

The reason is worth stating because it is not what the issue assumed. `get_stage_orientation` reads only rotation and tilt, and on an offset mount the FM position is distinguished by travelling ~48 mm in **x**. Measured on `sim-arctis-configuration`:

| orientation | r | t | classified as |
|---|---|---|---|
| SEM | 0.00° | 0.00° | `SEM` |
| FIB | 0.00° | 52.00° | `MILLING` |
| MILLING | 0.00° | −23.00° | `MILLING` |
| FM | 0.00° | 52.00° | **`MILLING`** |

FIB misclassifies too. The `MILLING` branch is checked before both `FIB` and `FM`, and `is_milling_tilt` is just "not flat", so on a shared-rotation system it swallows everything. The FM branch is unreachable there whatever tilt FM has.

That is why the refusal guards on `microscope.stage_is_compustage` — the *system* — rather than on the derived orientation: the derivation is the thing that is wrong. Written up in full on FIB-93, which is where the fix belongs.

## Moving a lamella asks first

Moving one pose moves both, and the milling pose is not visible from this canvas. The confirmation states where each one lands and names any tasks the lamella has already completed, since moving a lamella that has been milled is a different decision from moving one that has not.

On confirmation only the stage positions are rewritten, so the beam settings and a hand-set objective position survive — a move is a move, not a re-acquisition of the microscope state. A lamella with no fluorescence pose gets a whole new one, built on what that lamella recorded rather than on the live microscope.

## The tab is its own object

`AutoLamellaMainUI` held 275 lines of FM-specific logic — building the widget, marking lamellae on it, turning its requests into poses — on a class meant to arrange tabs. `AutoLamellaFluorescenceOverviewTab` takes it, and the window keeps only what a tab bar owns: index, visibility, enabling. It learns whether there is anything to drive from `availability_changed` rather than reaching in.

A widget rather than a controller, and not for taste. `LamellaNameListWidget` needs real `Lamella` objects — `_LamellaRow` subscribes to `lamella.events.description` and reads the defect and task state — so the list cannot live inside `FMOverviewWidget`. Something has to lay the two out together, and a QWidget owning both beats a controller reaching into another widget's layout. The codebase's two existing controllers are both the other case: `ScriptMenuController` has no widget to own, `MicroscopeViewController` is a seam presenting a `napari.Viewer`-shaped API.

Landed as a no-behaviour-change refactor first, verified by the end-to-end probes coming out byte-identical, then the list on top.

## The lamella list

Select, move-to and remove, in the settings column. Every lamella appears, **including the ones the canvas cannot place** — the list is how you find out a lamella exists but has no fluorescence pose; dropping those here too would leave the log as the only place that says so.

Move-to drives the stage to the *fluorescence* pose, not `stage_position`. This tab looks at the sample from the fluorescence side, and moving to the milling pose from here would swing the stage 180° away from the view you asked to centre. `FMOverviewWidget.move_to` is now public and shares its guards with the double-click, so picking a position out of a list and double-clicking where it is drawn cannot disagree about whether a move is allowed.

`add_settings_section` is a new piece of the host contract, beside `set_positions` and `set_save_directory`, and for the same reason: some of what belongs on this tab needs to know things the widget must not.

Clicking a crosshair selects that lamella, as the minimap does. The markers are drawn by `PointsOverlay`, which is non-interactive by design, so the picking hangs off the canvas's own click signal rather than making that overlay interactive for one caller. The radius is in **screen pixels**, matching `PointOverlay`'s: zoomed right out every marker is within any sensible micron radius of a click, and zoomed right in none is. A miss leaves the selection alone rather than clearing it — clearing would have to travel, and the window's handlers ignore None, so an empty click would blank this canvas and nothing else.

## Six bugs found on the way

**A position added from the FIB/SEM overview never appeared on the FM one.** The set of lamellae only reached the FM tab when an experiment was loaded, or when the FM tab itself added something; every other route went past it. The refresh moves into `_rebuild_lamella_list`, already the one handler for "the lamellae changed", so the two displays cannot disagree about what the experiment holds. `changed` is now subscribed alongside `inserted`/`removed` — `update_lamella_position_ui` emits it after replacing a milling pose in place, which the list rows do not care about but the canvas does.

**The newest lamella was still missing.** Same symptom, different cause, found after the above. `add_lamella` publishes `positions.events.inserted` and everything drawing the experiment redraws on it, but the fluorescence pose was assigned *three lines after* the append — so every listener decided the new lamella had none and skipped it as unplaceable. Measured at the moment the signal fires:

```
at the moment `inserted` fired: [('inserted', '01-wired-pony', False)]
after add_new_lamella returns:  fluorescence_pose is not None -> True
```

`Experiment.add_new_lamella` now takes the pose and attaches it before publishing — fixed where the object is built, so there is no window in which a half-built lamella is visible at all, rather than emitting a second event to paper over one.

**The scene did not follow a stage re-pose.** Tilt 180° and the markers stayed put. Everything is placed through a frame whose rotation and tilt come from wherever the stage is, so a re-pose moves all of it; only the current-position crosshair and the tile grid were being redrawn. Measured: re-posing FM → MILLING left a marker drawn at y = −500 while the frame put it at y = +460. The sign flip is the tell — the y axis inverts across 180°, so the marker was not merely stale but mirrored. Redrawn only when rotation or tilt actually change, since the stage is polled constantly and a translation moves none of this.

**The position-event disconnects were dead.** Connections were lambdas and the disconnects named the methods those lambdas called, which psygnal accepts and silently ignores. Now bound methods. Nothing broke, because the experiment being left behind never emits again, but it did not do what it said.

**A marker click announced the same lamella twice.** `_on_list_selection` set the sync flag but never checked it, so selecting the row from the marker handler came straight back through it. Found by a test asserting on the emitted list rather than the final state.

**`PointsOverlay` painted every marker white.** It hardcoded a white marker edge, and an unfilled marker (`+`) has no face — it is drawn *entirely* in its edge colour. Every `PointsOverlay` in the codebase uses `+`, so every one was affected, including the stage-position crosshair. On this canvas that is three markers meant to be told apart by colour alone, all drawn identically. The interactive `PointOverlay` directly below it already had the rule right; `PointsOverlay` now shares it.

## Beam-side moves carry the fluorescence pose

Both beam-side ways to say "this lamella is somewhere else" — the minimap's *Move Selected Position Here* and the lamella list's *Update Position* — set the milling pose and stopped there, leaving the fluorescence pose naming where the lamella used to be. Two doors onto one bug, so one helper: `sync_fluorescence_pose`.

It rewrites only the stage position, keeping the objective position — someone focused on that lamella by hand. It deliberately does **not** invent a pose for a lamella that has none, because `fluorescence_selected` asks only whether an objective position exists, so conjuring one would make a lamella nobody has looked at report itself as focused. Where the transform cannot be done at all (offset mount) it returns False and logs rather than reporting success.

## Verification

**3211 passed, 21 skipped, nothing failing.**

Every significant change was mutation-checked: reverting it must fail the test that claims it, and nothing else. Twenty-seven mutations. **Twenty-six caught; one is not reproducible here and is called out below.** Five tests were rewritten because the first version passed against its own mutation:

- `state=lamella.milling_pose` on a move: the first test asserted on beam settings, which survive regardless because a move only ever reads `.stage_position` off the derived poses. The argument matters in exactly one branch, and the test now covers that branch.
- the disconnect: the first test asserted on what gets drawn, which cannot tell the difference — `_rebuild_lamella_list` reads the *current* experiment either way. It now asserts on the subscriber count, which is the claim the code actually makes.
- the stage limits re-posing: passed either way because `_refresh_tile_grid` redraws them on its way past. The test now pins the grid first, which is the one state where nothing else would.
- that same test also had to move the origin *off* the grid centre: anchored on it, a zero offset stays zero through any rotation, so it was asserting on shapes that could not move.
- nearest-marker-wins: passed against "keep the hit but not its distance" because that leaves the *last* match winning, and the nearest one happened to be last. The nearest is now first in the list, so the two disagree.

**One mutation survives, and the code stays anyway.** `_drop_overview` reparents the lamella list out before the overview is destroyed, so Qt does not take the list with it. Under the offscreen platform the deferred delete never runs, so removing that line leaves every test passing — probed directly to confirm. The limitation is written into both the code comment and the test docstring rather than left implied.

Also driven end-to-end against the simulator in the connect-then-move order the app uses (the ordering that produced the two stage bugs on #266): the menu appears only at FM, both requests carry FM-orientation positions, the host derives MILLING at t = −23° while the FM pose stays at t = −180°, and the menu is `None` at a beam orientation. Re-run unchanged after rebasing across #282's geometry restructuring.

## Not done

- `select_position.py` and `fiducial.py` re-record the milling pose mid-workflow after automated alignment and have the same staleness `sync_fluorescence_pose` fixes elsewhere. That is a workflow behaviour change with hardware implications, so it is not riding along here.
- Nothing in this project has run on a scope (FIB-334).
