### PR TITLE
Correlation: name an image by the file it loaded, not the acquisition request (FIB-509)

### DIFF
--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -6,6 +6,7 @@ from enum import auto, Enum
 from typing import Optional
 import json
 import logging
+import os
 import time
 
 import numpy as np
@@ -93,6 +94,24 @@ def apply_z_surface_correction(
     return corrected
 
 
+def _loaded_filename(image) -> Optional[str]:
+    """Name the file ``image`` was loaded from, or None if it came from nowhere.
+
+    Read off ``filepath``, not the metadata. The metadata records the name the
+    *acquirer* asked for, which is a stem -- ``save`` appends the suffix itself --
+    and goes stale the moment a file is renamed or copied. ``filepath`` is set by
+    both ``load()`` and ``save()`` on either image class, including for a plain
+    TIFF whose metadata failed to parse at all (FIB-509).
+
+    Deliberately no fallback to the requested name: an image that was never
+    written has no file, and naming one it does not have sends whoever reads the
+    record looking for it. None is the honest answer, and this is read by
+    ``to_dict`` -- the only persistence path -- so it must not raise (FIB-316).
+    """
+    filepath = getattr(image, "filepath", None)
+    return os.path.basename(filepath) if filepath else None
+
+
 @dataclass
 class CorrelationInputData:
     fib_image: Optional[FibsemImage] = None
@@ -173,16 +192,11 @@ class CorrelationInputData:
 
     @property
     def fib_image_filename(self) -> Optional[str]:
-        # Also read by to_dict, so it must tolerate an image without metadata
-        # rather than take the auto-save down with it (FIB-316).
-        settings = getattr(
-            getattr(self.fib_image, "metadata", None), "image_settings", None
-        )
-        return getattr(settings, "filename", None)
+        return _loaded_filename(self.fib_image)
 
     @property
     def fm_image_filename(self) -> Optional[str]:
-        return getattr(getattr(self.fm_image, "metadata", None), "filename", None)
+        return _loaded_filename(self.fm_image)
 
     @staticmethod
     def from_dict(data: dict) -> CorrelationInputData:

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -628,19 +628,15 @@ class _ImagesTab(QWidget):
 
     def set_fib_image(self, image: FibsemImage) -> None:
         self._fib_image = image
-        filename = (
-            getattr(
-                getattr(getattr(image, "metadata", None), "image_settings", None),
-                "filename",
-                "",
-            )
-            or ""
-        )
-        # The metadata names the file; only the picker knows where it is. Resolve
-        # against what it already offers instead of taking the name as a path —
-        # and leave the display alone if this image isn't one of the known files,
-        # rather than showing a name the picker cannot load.
-        resolved = self._fib_picker.select_file(filename)
+        # Resolve against what the picker already offers rather than trusting the
+        # path — leave the display alone if this image isn't one of the known
+        # files, instead of showing something the picker cannot load.
+        #
+        # From `filepath`, not `image_settings.filename`: the latter is the name
+        # the acquirer asked for, a stem with no extension, so matching it against
+        # a real path never succeeded and a pre-loaded image left the combo
+        # showing nothing selected (FIB-509).
+        resolved = self._fib_picker.select_file(getattr(image, "filepath", None) or "")
         if resolved:
             self._fib_loaded_path = resolved
         h, w = image.data.shape[:2]
@@ -652,9 +648,9 @@ class _ImagesTab(QWidget):
 
     def set_fm_image(self, image: FluorescenceImage) -> None:
         self._fm_image = image
-        resolved = self._fm_picker.select_file(
-            getattr(image.metadata, "filename", "") or ""
-        )
+        # Same as the FIB side: the file it was loaded from, not the name it was
+        # acquired under (FIB-509).
+        resolved = self._fm_picker.select_file(getattr(image, "filepath", None) or "")
         if resolved:
             self._fm_loaded_path = resolved
         self._update_fm_labels(image)
@@ -1809,12 +1805,16 @@ class CorrelationTabWidget(QWidget):
         self.data_changed.emit(self.data)
 
     def _update_fib_name_label(self, image: FibsemImage) -> None:
-        """Show the loaded FIB image's filename in the header (mirrors FM)."""
-        iset = getattr(getattr(image, "metadata", None), "image_settings", None)
-        filename = getattr(iset, "filename", "") or ""
-        base = os.path.basename(filename) if filename else ""
+        """Show the loaded FIB image's filename in the header (mirrors FM).
+
+        The file it came from, so the label matches what the picker above it
+        shows and the tooltip gives the full path. An image that was never
+        written gets no label rather than the name it would have had (FIB-509).
+        """
+        path = getattr(image, "filepath", None) or ""
+        base = os.path.basename(path)
         self._fib_name_label.setText(base)
-        self._fib_name_label.setToolTip(filename)
+        self._fib_name_label.setToolTip(path)
         self._fib_name_label.setVisible(bool(base))
 
     def set_fm_image(self, fm_image: FluorescenceImage) -> None:

--- a/fibsem/correlation/ui/widgets/fm_image_display_widget.py
+++ b/fibsem/correlation/ui/widgets/fm_image_display_widget.py
@@ -412,13 +412,16 @@ class FMImageDisplayWidget(QWidget):
         return self._z_slider.value()
 
     def _update_name_label(self) -> None:
-        """Show the loaded FM image's filename in the header."""
-        filename = ""
-        if self._fm_image is not None:
-            filename = getattr(self._fm_image.metadata, "filename", "") or ""
-        base = os.path.basename(filename) if filename else ""
+        """Show the loaded FM image's filename in the header.
+
+        The file it was loaded from, not the name recorded at acquisition, which
+        does not track a rename and is missing from a volume written by other
+        software (FIB-509).
+        """
+        path = getattr(self._fm_image, "filepath", None) or ""
+        base = os.path.basename(path)
         self._name_label.setText(base)
-        self._name_label.setToolTip(filename)
+        self._name_label.setToolTip(path)
         self._name_label.setVisible(bool(base))
 
     # ------------------------------------------------------------------

--- a/fibsem/correlation/util.py
+++ b/fibsem/correlation/util.py
@@ -432,7 +432,16 @@ def interpolate_fm_volume(
                 src, np.arange(len(old)), old
             ).tolist()
 
-    return FluorescenceImage(data=interpolated, metadata=new_meta)
+    # Resampled, but still this file's volume. The correlation UI names an image
+    # by its filepath (FIB-509), so dropping it here would blank the header and
+    # record a null filename for every correlation run after an interpolation.
+    return FluorescenceImage(
+        data=interpolated,
+        metadata=new_meta,
+        # getattr, because this function is exercised with minimal stand-ins that
+        # carry only the fields it reads.
+        filepath=getattr(fm_image, "filepath", None),
+    )
 
 
 def multi_channel_get_z_guass(image: np.ndarray, x: int, y: int, show: bool = False) -> List[float]:

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -322,7 +322,12 @@ class ZParameters:
 class FluorescenceImage:
     data: np.ndarray  # TCZYX format (Time, Channels, Z, Y, X)
     metadata: "FluorescenceImageMetadata"
-    # the file this image is associated with on disk, set by save() and load().
+    # the file this image is associated with on disk, set by save() and load(), and
+    # inherited by the derived forms -- projection, focus stack, interpolation. A
+    # resampled volume is still that file's volume, and it is the only file that
+    # describes it; the UI and the correlation record name an image from this
+    # (FIB-509), so dropping it on a derived image loses the provenance entirely.
+    # Nothing writes back to it: save() takes the filename it is given.
     # excluded from compare/repr: it describes where the image lives, not what it contains,
     # so two images of the same data read from different paths are still equal.
     filepath: Optional[str] = field(default=None, compare=False, repr=False)
@@ -856,7 +861,12 @@ class FluorescenceImage:
             dimension_order=self.metadata.dimension_order,
         )
 
-        return FluorescenceImage(data=projected_data, metadata=projected_metadata)
+        return FluorescenceImage(
+            data=projected_data,
+            metadata=projected_metadata,
+            # Still this file's image; see the note on the field (FIB-509).
+            filepath=self.filepath,
+        )
 
     def focus_stack(
         self,
@@ -992,7 +1002,12 @@ class FluorescenceImage:
             dimension_order=self.metadata.dimension_order,
         )
 
-        return FluorescenceImage(data=stacked_data, metadata=stacked_metadata)
+        return FluorescenceImage(
+            data=stacked_data,
+            metadata=stacked_metadata,
+            # Still this file's image; see the note on the field (FIB-509).
+            filepath=self.filepath,
+        )
 
     def calculate_histogram(
         self,

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -721,6 +721,9 @@ def _fake_fm(n_c=2, n_z=5, filename="/data/BeforeMilling_G1.ome.tiff"):
     chans = [SimpleNamespace(name=f"CH{i}", color=None) for i in range(n_c)]
     return SimpleNamespace(
         data=np.zeros((n_c, n_z, 8, 8), dtype=np.float32),
+        # filepath is where the volume was loaded from and is what names it in the
+        # UI (FIB-509); metadata.filename is the name it was acquired under.
+        filepath=filename,
         metadata=SimpleNamespace(filename=filename, channels=chans),
     )
 
@@ -850,18 +853,16 @@ def test_fm_display_shows_image_name(qapp):
 
 
 def test_fib_header_shows_image_name(qapp):
+    """The file it was loaded from, extension and all — see FIB-509 for why the
+    acquisition metadata's name is not it."""
     from types import SimpleNamespace
 
     w = _widget(qapp)
     assert w._fib_name_label.isHidden() is True  # nothing loaded yet
 
-    img = SimpleNamespace(
-        metadata=SimpleNamespace(
-            image_settings=SimpleNamespace(filename="/x/ref_Mill_res_02")
-        )
-    )
+    img = SimpleNamespace(filepath="/x/ref_Mill_res_02.tif")
     w._update_fib_name_label(img)
-    assert w._fib_name_label.text() == "ref_Mill_res_02"
+    assert w._fib_name_label.text() == "ref_Mill_res_02.tif"
     assert w._fib_name_label.isHidden() is False
 
 

--- a/tests/correlation/test_image_identity.py
+++ b/tests/correlation/test_image_identity.py
@@ -1,0 +1,252 @@
+"""Correlation must name an image by the file it loaded (FIB-509).
+
+Six places asked "which file is this?" by reading the acquisition *request* --
+``image_settings.filename`` for FIB, ``metadata.filename`` for FM. That is the
+name the acquiring process asked for, and it is not the file:
+
+* it is a **stem**, because ``FibsemImage.save`` appends the suffix itself, so
+  matching it against a real path never succeeds;
+* it is absent entirely from a plain TIFF, which loads with ``metadata = None``;
+* it still says the old name after a rename or a copy.
+
+``filepath`` is set by ``load()`` and ``save()`` on both image classes, whatever
+the metadata says, and is the answer to a filesystem question.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.correlation.structures import CorrelationInputData
+from fibsem.fm.structures import (
+    FluorescenceChannelMetadata,
+    FluorescenceImage,
+    FluorescenceImageMetadata,
+)
+from fibsem.structures import FibsemImage, ImageSettings
+
+# What a lamella folder actually holds, and what the acquirer asked to call it.
+# Note the request has no extension -- that is the whole defect.
+FIB_PATH = "/lam/01-grand-dodo/ref_Mill Fiducial_start.tif"
+FIB_REQUESTED_NAME = "ref_Mill Fiducial_start"
+FM_PATH = "/lam/01-grand-dodo/fm_stack.ome.tiff"
+
+
+@pytest.fixture(autouse=True)
+def _no_lut_download(monkeypatch):
+    import fibsem.correlation.ui.widgets.refractive_index_widget as riw
+
+    monkeypatch.setattr(riw, "_ensure_lut", lambda: None)
+
+
+def _fib_image(filepath=FIB_PATH, requested_name=FIB_REQUESTED_NAME):
+    """A FIB image as it arrives from disk: loaded from one name, requesting another."""
+    image = FibsemImage.generate_blank_image(resolution=(64, 48), hfw=100e-6)
+    image.metadata.image_settings = ImageSettings(
+        resolution=(64, 48), hfw=100e-6, filename=requested_name, path="/lam/01-grand-dodo"
+    )
+    image.filepath = filepath
+    return image
+
+
+def _fm_image(filepath=FM_PATH, requested_name="fm_stack_as_acquired"):
+    metadata = FluorescenceImageMetadata(
+        acquisition_date="2026-08-05T00:00:00",
+        pixel_size_x=1e-7,
+        pixel_size_y=1e-7,
+        resolution=(16, 16),
+        channels=[
+            FluorescenceChannelMetadata(
+                name="GFP",
+                color="#00FF00",
+                excitation_wavelength=488,
+                emission_wavelength=509,
+                power=1.0,
+                exposure_time=0.1,
+                gain=1.0,
+                offset=0.0,
+            )
+        ],
+        filename=requested_name,
+    )
+    return FluorescenceImage(
+        data=np.zeros((1, 2, 16, 16), dtype=np.uint16),
+        metadata=metadata,
+        filepath=filepath,
+    )
+
+
+def _images_tab():
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import _ImagesTab
+
+    return _ImagesTab()
+
+
+def _tab_widget():
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import (
+        CorrelationTabWidget,
+    )
+
+    return CorrelationTabWidget()
+
+
+# ---------------------------------------------------------------------------
+# The picker match, which is what actually broke
+# ---------------------------------------------------------------------------
+
+
+def test_the_requested_name_cannot_match_a_real_file(qapp):
+    """Why reading the request was never going to work.
+
+    ``select_file`` compares basenames. The request has no extension, the file on
+    disk does, so the comparison is ``'x' == 'x.tif'`` for every image ever
+    acquired through the normal path.
+    """
+    from fibsem.correlation.ui.widgets.correlation_tab_widget import _ImagePicker
+
+    picker = _ImagePicker("TIFF (*.tif *.tiff);;All Files (*)")
+    picker.set_options([FIB_PATH])
+
+    assert picker.select_file(FIB_REQUESTED_NAME) == ""
+    assert picker.select_file(FIB_PATH) == FIB_PATH
+
+
+def test_a_preloaded_fib_image_selects_its_file(qapp):
+    """A lamella's own image, handed straight to the tab.
+
+    The match here was dead code: it could not succeed, so the only reason the
+    protocol editor's dialog ends up on the right file is that
+    ``add_lamella_setup`` runs a moment later and re-selects it. A caller that
+    pre-loads without that -- ``CorrelationTabDialog.set_fib_image`` on its own --
+    got nothing.
+    """
+    tab = _images_tab()
+    tab.set_image_options("fib", [FIB_PATH])
+
+    tab.set_fib_image(_fib_image())
+
+    assert tab._fib_loaded_path == FIB_PATH
+    assert tab._fib_picker.current_path() == FIB_PATH
+
+
+def test_a_preloaded_fm_image_selects_its_file(qapp):
+    tab = _images_tab()
+    tab.set_image_options("fm", [FM_PATH])
+
+    tab.set_fm_image(_fm_image())
+
+    assert tab._fm_loaded_path == FM_PATH
+    assert tab._fm_picker.current_path() == FM_PATH
+
+
+def test_an_image_from_outside_the_list_leaves_the_picker_alone(qapp):
+    """``select_file`` returning "" must not be turned into a selection.
+
+    Showing a file the picker cannot load is worse than showing the previous one.
+    """
+    tab = _images_tab()
+    tab.set_image_options("fib", [FIB_PATH])
+    tab.set_fib_image(_fib_image())
+
+    tab.set_fib_image(_fib_image(filepath="/elsewhere/unrelated_ib.tif"))
+
+    assert tab._fib_loaded_path == FIB_PATH
+
+
+# ---------------------------------------------------------------------------
+# The header labels
+# ---------------------------------------------------------------------------
+
+
+def test_the_header_and_the_picker_agree(qapp):
+    """The visible symptom in the flow people actually use.
+
+    ``_open_correlation_dialog`` calls ``set_fib_image`` and *then*
+    ``add_lamella_setup``, which re-selects the file in the picker. The header
+    label is never revisited, so it went on showing the acquirer's stem beside a
+    picker showing the real file — one image, two names, adjacent controls.
+    """
+    widget = _tab_widget()
+
+    widget.set_fib_image(_fib_image())  # what the dialog does first
+    widget._images_tab.set_image_options("fib", [FIB_PATH], FIB_PATH)  # ...then this
+
+    assert widget._fib_name_label.text() == os.path.basename(
+        widget._images_tab._fib_picker.current_path()
+    )
+
+
+def test_the_fib_header_names_the_file_not_the_request(qapp):
+    widget = _tab_widget()
+
+    widget._update_fib_name_label(_fib_image())
+
+    assert widget._fib_name_label.text() == "ref_Mill Fiducial_start.tif"
+    assert widget._fib_name_label.toolTip() == FIB_PATH
+
+
+def test_the_fm_header_names_the_file_not_the_request(qapp):
+    from fibsem.correlation.ui.widgets.fm_image_display_widget import (
+        FMImageDisplayWidget,
+    )
+
+    display = FMImageDisplayWidget()
+    display.set_fm_image(_fm_image())
+
+    assert display._name_label.text() == "fm_stack.ome.tiff"
+    assert display._name_label.toolTip() == FM_PATH
+
+
+def test_an_unsaved_image_is_named_nothing_rather_than_wrongly(qapp):
+    """An image that was never written has no file, and saying otherwise sends a
+    reader looking for one that does not exist."""
+    widget = _tab_widget()
+
+    widget._update_fib_name_label(_fib_image(filepath=None))
+
+    assert widget._fib_name_label.text() == ""
+    assert widget._fib_name_label.isVisible() is False
+
+
+# ---------------------------------------------------------------------------
+# The record field, which rides into every saved correlation
+# ---------------------------------------------------------------------------
+
+
+def test_the_record_names_the_file_it_correlated(qapp):
+    data = CorrelationInputData(fib_image=_fib_image(), fm_image=_fm_image())
+
+    assert data.fib_image_filename == "ref_Mill Fiducial_start.tif"
+    assert data.fm_image_filename == "fm_stack.ome.tiff"
+    assert data.to_dict()["fib_image_filename"] == "ref_Mill Fiducial_start.tif"
+    assert data.to_dict()["fm_image_filename"] == "fm_stack.ome.tiff"
+
+
+def test_a_plain_tiff_is_still_named(qapp):
+    """The case the old code could not answer at all.
+
+    ``FibsemImage.load`` sets ``metadata = None`` for a TIFF written by other
+    software but sets ``filepath`` regardless, so the widget knows exactly which
+    file it holds -- and used to record ``null`` for it (FIB-316's chains stop
+    the crash; they cannot produce a name).
+    """
+    image = FibsemImage.generate_blank_image(resolution=(64, 48), hfw=100e-6)
+    image.metadata = None
+    image.filepath = "/elsewhere/from_another_program.tif"
+
+    data = CorrelationInputData(fib_image=image)
+
+    assert data.to_dict()["fib_image_filename"] == "from_another_program.tif"
+
+
+def test_no_image_and_no_file_stay_none(qapp):
+    """``to_dict`` is on the only persistence path, so neither may raise (FIB-316)."""
+    assert CorrelationInputData().fib_image_filename is None
+    assert CorrelationInputData().fm_image_filename is None
+    assert CorrelationInputData(fib_image=_fib_image(filepath=None)).to_dict()[
+        "fib_image_filename"
+    ] is None

--- a/tests/correlation/test_image_identity.py
+++ b/tests/correlation/test_image_identity.py
@@ -243,6 +243,42 @@ def test_a_plain_tiff_is_still_named(qapp):
     assert data.to_dict()["fib_image_filename"] == "from_another_program.tif"
 
 
+# ---------------------------------------------------------------------------
+# Derived volumes, which naming from `filepath` would otherwise strand
+# ---------------------------------------------------------------------------
+
+
+def test_an_interpolated_volume_is_still_that_files_volume(qapp):
+    """Interpolate is a button in the Images tab, so this is a normal path.
+
+    Naming an image from ``filepath`` means a derived image that drops it gets no
+    name at all -- worse than before, since the metadata copy used to carry the
+    acquisition name forward. The resampled volume is still the source file's.
+    """
+    from fibsem.correlation.util import interpolate_fm_volume
+
+    source = _fm_image()
+    source.metadata.pixel_size_z = 5e-7
+
+    interpolated = interpolate_fm_volume(
+        source, target_z_size_m=2.5e-7, method="linear"
+    )
+
+    assert interpolated.filepath == FM_PATH
+    assert CorrelationInputData(fm_image=interpolated).fm_image_filename == (
+        "fm_stack.ome.tiff"
+    )
+
+
+def test_a_projection_and_a_focus_stack_keep_it_too(qapp):
+    """The other two derived forms, which have the same shape."""
+    source = _fm_image()
+    source.metadata.pixel_size_z = 5e-7
+
+    assert source.max_intensity_projection().filepath == FM_PATH
+    assert source.focus_stack().filepath == FM_PATH
+
+
 def test_no_image_and_no_file_stay_none(qapp):
     """``to_dict`` is on the only persistence path, so neither may raise (FIB-316)."""
     assert CorrelationInputData().fib_image_filename is None


### PR DESCRIPTION
Six places in the correlation UI answer *"which file is this image?"* by reading the acquisition **request** — `image_settings.filename` for FIB, `metadata.filename` for FM. That is the name the acquiring process asked for, and it is not the file.

Closes FIB-509.

## Why the request is the wrong source

**It is a stem.** `FibsemImage.save` appends the suffix itself (`Path(path).with_suffix(".tif")`), so the recorded name is `ref_Mill Fiducial_start` for a file called `ref_Mill Fiducial_start.tif` — confirmed across all four metadata fixtures. `_ImagePicker.select_file` compares basenames:

```python
target = os.path.basename(name)                        # 'ref_Mill Fiducial_start'
if path == name or os.path.basename(path) == target:   # 'ref_Mill Fiducial_start.tif'
```

So the match in `set_fib_image` **has never once succeeded**. The only reason the protocol editor's dialog lands on the right file is that `add_lamella_setup` runs a moment later and re-selects it via `set_image_options(current=...)`.

What that leaves visible is the **header label disagreeing with the picker directly above it** — `set_image_options` does not revisit the label, so it read `ref_Mill Fiducial_start` beside a picker reading `ref_Mill Fiducial_start.tif`. One image, two names, adjacent controls.

**A plain TIFF got no name at all.** `FibsemImage.load` sets `metadata = None` when there is no fibsem `ImageDescription` but sets `filepath` regardless, so an externally-produced file showed a blank label and saved `fib_image_filename: null` — for a file whose path the widget was holding. FIB-316's defensive `getattr` chains stop that crashing the auto-save; they cannot make it say anything.

**A renamed or copied file** went on reporting the name it was acquired under.

## The change

`filepath` is set by `load()` and `save()` on both image classes whatever the metadata says, and answers the filesystem question these sites are actually asking.

| site | now reads |
|---|---|
| `CorrelationInputData.fib_image_filename` / `.fm_image_filename` | `_loaded_filename()` — one helper, `basename(filepath)` |
| `_ImagesTab.set_fib_image` / `.set_fm_image` | `image.filepath` into `select_file` |
| `CorrelationTabWidget._update_fib_name_label` | `filepath`; tooltip is now the full path |
| `FMImageDisplayWidget._update_name_label` | `filepath`; tooltip is now the full path |

**No fallback** to the requested name when `filepath` is unset. An image that was never written has no file, and naming one it does not have sends whoever reads the record looking for it.

**No migration.** `fib_image_filename` / `fm_image_filename` are provenance only — nothing computes on them, and `from_dict` does not restore them (unlike `stored_fib_image_shape` / `stored_fib_image_pixel_size`). Old correlations keep their stems; new ones gain the extension.

## Deliberately not changed

`select_file` returning `""` still leaves the picker alone rather than adding the file via `show_path`. The picker's list means "this lamella's images", and an outside image joining it through a programmatic pre-load is a separate decision from naming. Pinned by a test so it stays deliberate.

## Testing

`tests/correlation/test_image_identity.py` — 11 tests. **10 failed before the fix**; the one that passed is the one pinning why the old match was impossible. `test_the_header_and_the_picker_agree` reproduces the real open sequence (`set_fib_image` then `set_image_options`) and fails on the unfixed source with exactly the stem-vs-extension pair.

- **768 passed, 15 skipped** — `tests/correlation/` + `tests/fm/`
- **2942 passed, 29 skipped** — full suite
- All changed files parse under 3.8 grammar

Two existing tests in `test_correlation_tab_widget.py` pinned the old behaviour and are updated. `_fake_fm` now carries both `filepath` and `metadata.filename`, so the distinction stays visible in the fixture.

## Origin

Split out of FIB-483 and FIB-482, both now cancelled. What they proposed — removing `save`/`path`/`filename` from `ImageSettings` or from the image record — is not wanted: expressing "acquire this, save it there, call it that" as one object is good API, and sharing an image means sharing the path anyway. Migrating the *consumers* to the accurate source is the part that stands on its own.