### PR TITLE
[autolamella] Record the session that worked on an experiment — instrument, operator, software (FIB-451)

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -1052,7 +1052,7 @@ class Experiment:
         experiment.metadata = ddict.get("metadata", {})
 
         # Absent from every experiment written before FIB-451, and from any that no
-        # run has adopted yet. Both mean the same thing -- nothing is known about
+        # session has adopted yet. Both mean the same thing -- nothing is known about
         # what produced this -- and None says that without guessing.
         session = ddict.get("session")
         experiment.session = SessionInfo.from_dict(session) if session else None

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -36,10 +36,12 @@ from fibsem.structures import (
     FibsemImage,
     FibsemRectangle,
     FibsemStagePosition,
+    FibsemUser,
     ImageSettings,
     MicroscopeState,
     Point,
     ReferenceImageParameters,
+    RunProvenance,
 )
 from fibsem.utils import configure_logging as _configure_logging
 from fibsem.utils import format_duration
@@ -992,6 +994,7 @@ class Experiment:
     created_at: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
     task_protocol: 'AutoLamellaTaskProtocol' = field(default_factory=lambda: AutoLamellaTaskProtocol())
     metadata: Dict[str, Any] = field(default_factory=dict)
+    provenance: Optional[RunProvenance] = None
 
     def __init__(self, path: Path,
                  name: str = cfg.EXPERIMENT_NAME,
@@ -1013,6 +1016,10 @@ class Experiment:
 
         self.task_protocol: AutoLamellaTaskProtocol = None # must be set externally
         self.metadata: Dict[str, Any] = metadata if metadata is not None else {}
+        # What produced this: filled in by register_metadata, when a run adopts the
+        # experiment and there is a microscope to ask. None until then -- creating
+        # an experiment happens in a dialog that has no microscope. See FIB-451.
+        self.provenance: Optional[RunProvenance] = None
 
     def to_dict(self, include_protocol: bool = False) -> dict:
 
@@ -1024,6 +1031,7 @@ class Experiment:
             "landing_positions": [pos.to_dict() for pos in self.landing_positions],
             "created_at": self.created_at,
             "metadata": self.metadata,
+            "provenance": self.provenance.to_dict() if self.provenance is not None else None,
         }
 
         if include_protocol:
@@ -1041,6 +1049,14 @@ class Experiment:
         experiment.id = ddict.get("_id", "NULL")
 
         experiment.metadata = ddict.get("metadata", {})
+
+        # Absent from every experiment written before FIB-451, and from any that no
+        # run has adopted yet. Both mean the same thing -- nothing is known about
+        # what produced this -- and None says that without guessing.
+        provenance = ddict.get("provenance")
+        experiment.provenance = (
+            RunProvenance.from_dict(provenance) if provenance else None
+        )
 
         # load lamella from dict
         for lamella_dict in ddict["positions"]:
@@ -1368,6 +1384,10 @@ class Experiment:
         microscope. Callers that own the run say so. The app calls it when it adopts
         an experiment, TaskManager calls it when it takes one to run, and a script
         driving the microscope directly calls it itself.
+
+        Registration also runs the other way: this is the only moment the experiment
+        meets a microscope, so it is where the experiment learns which instrument,
+        which operator and which software are running it (FIB-451).
         """
         from fibsem.utils import _register_metadata
 
@@ -1377,6 +1397,46 @@ class Experiment:
             experiment_id=self.id,
             experiment_name=self.name,
         )
+
+        # After _register_metadata, which sets `application` on the very SystemInfo
+        # being snapshotted here.
+        self.provenance = RunProvenance.collect(
+            microscope, user=self._declared_user()
+        )
+
+        # Written now rather than left to whatever saves next -- relying on someone
+        # else's save is how FIB-490 lost every failed task. Only for an experiment
+        # that already has a file, though: constructing one deliberately does not
+        # touch the disk (FIB-420), and both `create` and `load` guarantee a file
+        # exists, so in a real run this always writes. A caller driving an
+        # in-memory experiment is not asking this method to give it a directory.
+        if os.path.exists(os.path.join(self.path, "experiment.yaml")):
+            self.save()
+
+    def _declared_user(self) -> Optional[FibsemUser]:
+        """The operator named when the experiment was created, if anyone was.
+
+        The create dialog collects a name and organisation as free text into the
+        untyped ``metadata`` dict. Those beat ``FibsemUser.from_environment()``,
+        which reads the OS account -- on a shared facility login that names the
+        workstation rather than the person, and somebody who typed a name meant it.
+
+        Only the two fields the dialog offers are overridden. ``hostname`` stays as
+        the environment reports it, because it answers a different question: which
+        machine, not which person.
+        """
+        metadata = self.metadata or {}
+        name = metadata.get("user")
+        organization = metadata.get("organisation")
+        if not name and not organization:
+            return None
+
+        user = FibsemUser.from_environment()
+        if name:
+            user.name = name
+        if organization:
+            user.organization = organization
+        return user
 
     def save_protocol(self) -> None:
         """Save the task protocol to disk in the experiment directory."""

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -41,7 +41,7 @@ from fibsem.structures import (
     MicroscopeState,
     Point,
     ReferenceImageParameters,
-    RunProvenance,
+    SessionInfo,
 )
 from fibsem.utils import configure_logging as _configure_logging
 from fibsem.utils import format_duration
@@ -994,7 +994,7 @@ class Experiment:
     created_at: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
     task_protocol: 'AutoLamellaTaskProtocol' = field(default_factory=lambda: AutoLamellaTaskProtocol())
     metadata: Dict[str, Any] = field(default_factory=dict)
-    provenance: Optional[RunProvenance] = None
+    session: Optional[SessionInfo] = None
 
     def __init__(self, path: Path,
                  name: str = cfg.EXPERIMENT_NAME,
@@ -1016,10 +1016,11 @@ class Experiment:
 
         self.task_protocol: AutoLamellaTaskProtocol = None # must be set externally
         self.metadata: Dict[str, Any] = metadata if metadata is not None else {}
-        # What produced this: filled in by register_metadata, when a run adopts the
-        # experiment and there is a microscope to ask. None until then -- creating
-        # an experiment happens in a dialog that has no microscope. See FIB-451.
-        self.provenance: Optional[RunProvenance] = None
+        # The instrument, operator and software that last worked on this. Filled in
+        # by register_metadata, when a session adopts the experiment and there is a
+        # microscope to ask; None until then, because creating an experiment happens
+        # in a dialog that has no microscope. See FIB-451.
+        self.session: Optional[SessionInfo] = None
 
     def to_dict(self, include_protocol: bool = False) -> dict:
 
@@ -1031,7 +1032,7 @@ class Experiment:
             "landing_positions": [pos.to_dict() for pos in self.landing_positions],
             "created_at": self.created_at,
             "metadata": self.metadata,
-            "provenance": self.provenance.to_dict() if self.provenance is not None else None,
+            "session": self.session.to_dict() if self.session is not None else None,
         }
 
         if include_protocol:
@@ -1053,10 +1054,8 @@ class Experiment:
         # Absent from every experiment written before FIB-451, and from any that no
         # run has adopted yet. Both mean the same thing -- nothing is known about
         # what produced this -- and None says that without guessing.
-        provenance = ddict.get("provenance")
-        experiment.provenance = (
-            RunProvenance.from_dict(provenance) if provenance else None
-        )
+        session = ddict.get("session")
+        experiment.session = SessionInfo.from_dict(session) if session else None
 
         # load lamella from dict
         for lamella_dict in ddict["positions"]:
@@ -1386,8 +1385,8 @@ class Experiment:
         driving the microscope directly calls it itself.
 
         Registration also runs the other way: this is the only moment the experiment
-        meets a microscope, so it is where the experiment learns which instrument,
-        which operator and which software are running it (FIB-451).
+        meets a microscope, so it is where the experiment learns which session is
+        working on it -- instrument, operator, software and plugins (FIB-451).
         """
         from fibsem.utils import _register_metadata
 
@@ -1400,7 +1399,7 @@ class Experiment:
 
         # After _register_metadata, which sets `application` on the very SystemInfo
         # being snapshotted here.
-        self.provenance = RunProvenance.collect(
+        self.session = SessionInfo.collect(
             microscope, user=self._declared_user()
         )
 

--- a/fibsem/plugins/report.py
+++ b/fibsem/plugins/report.py
@@ -394,7 +394,7 @@ def installed_plugin_versions() -> Dict[str, str]:
 
     Having a distribution *is* the filter: a built-in has none, and a
     script-loaded extension carries a path instead. What is left is what somebody
-    installed, which is the question an experiment's provenance needs to answer --
+    installed, which is the question an experiment's session record needs to answer --
     a plugin developer debugging a remote site otherwise has no way to know which
     build of their own code ran (FIB-451).
 

--- a/fibsem/plugins/report.py
+++ b/fibsem/plugins/report.py
@@ -42,6 +42,7 @@ __all__ = [
     "Extension",
     "ExtensionGroup",
     "collect_extensions",
+    "installed_plugin_versions",
     "render_report",
     "group_counts_phrase",
     "environment_line",
@@ -386,6 +387,27 @@ def collect_extensions() -> Tuple[ExtensionGroup, ...]:
     are worth showing without it.
     """
     return tuple(_collect_group(*spec) for spec in _GROUPS)
+
+
+def installed_plugin_versions() -> Dict[str, str]:
+    """Distribution name to version, for every out-of-tree extension visible here.
+
+    Having a distribution *is* the filter: a built-in has none, and a
+    script-loaded extension carries a path instead. What is left is what somebody
+    installed, which is the question an experiment's provenance needs to answer --
+    a plugin developer debugging a remote site otherwise has no way to know which
+    build of their own code ran (FIB-451).
+
+    Includes a distribution whose entry point failed to load. It was installed and
+    it shaped the run by being absent from the registry, so leaving it out would
+    make the record agree with a machine that never had it.
+    """
+    versions: Dict[str, str] = {}
+    for group in collect_extensions():
+        for extension in group.extensions:
+            if extension.distribution:
+                versions[extension.distribution] = extension.version or "unknown"
+    return versions
 
 
 # ---------------------------------------------------------------------------

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2188,26 +2188,30 @@ class FibsemUser:
 
 
 @dataclass
-class RunProvenance:
-    """Which instrument, whose account, and what software produced an experiment.
+class SessionInfo:
+    """Which instrument, whose account, and what software worked on an experiment.
 
-    An experiment directory records what it contains but nothing about what made
-    it, so "was this run before or after the upgrade", "which machine was this on"
+    A session is what ``setup_session`` establishes: a connected instrument and the
+    configuration around it. ``SystemInfo`` answers the instrument half and rides in
+    every image; this is that plus who is at the keyboard and which plugins are
+    installed, recorded once on the experiment itself.
+
+    An experiment directory otherwise says what it contains and nothing about what
+    made it, so "was this before or after the upgrade", "which machine was this on"
     and "which build of my plugin ran" are all unanswerable from the record. Every
-    part of this is already collected per-image; this promotes it to the
-    experiment (FIB-451).
+    part of this was already collected per-image; this promotes it (FIB-451).
 
-    **This describes the last run to touch the experiment, not the one that created
-    it.** ``Experiment.create()` has no microscope -- the dialog that calls it never
-    holds one -- so the instrument is simply unknown until a run adopts the
-    experiment. The last run is the fact that can actually be established, and it
-    has the useful property of backfilling onto experiments that predate this.
+    **The latest session, not the one that created the experiment.**
+    ``Experiment.create()`` has no microscope -- the dialog that calls it never
+    holds one -- so the instrument is simply unknown until a session adopts the
+    experiment. The latest is the fact that can actually be established, and it has
+    the useful property of backfilling onto experiments that predate this.
 
     Overwriting loses less than it looks like. Every image already carries its own
     ``SystemInfo``, so an experiment spanning an upgrade shows v0.5.1 on day-one
     images and v0.5.2 here -- two true facts, which is the same reasoning that put
-    the version fields on ``SystemInfo`` in the first place (FIB-445 D1). A
-    per-session history is FIB-452's shape, not this record's.
+    the version fields on ``SystemInfo`` in the first place (FIB-445 D1). Keeping
+    every session rather than the latest is FIB-452's shape, not this record's.
     """
 
     recorded_at: float = field(
@@ -2223,7 +2227,7 @@ class RunProvenance:
     @classmethod
     def collect(
         cls, microscope: "FibsemMicroscope", user: Optional[FibsemUser] = None
-    ) -> "RunProvenance":
+    ) -> "SessionInfo":
         """Snapshot what is running right now.
 
         ``user`` overrides the environment's, for a caller that knows better: on a
@@ -2256,10 +2260,10 @@ class RunProvenance:
         }
 
     @staticmethod
-    def from_dict(ddict: dict) -> "RunProvenance":
+    def from_dict(ddict: dict) -> "SessionInfo":
         system = ddict.get("system")
         user = ddict.get("user")
-        return RunProvenance(
+        return SessionInfo(
             recorded_at=ddict.get("recorded_at"),
             system=SystemInfo.from_dict(system) if system else None,
             user=FibsemUser.from_dict(user) if user else None,

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2188,6 +2188,86 @@ class FibsemUser:
 
 
 @dataclass
+class RunProvenance:
+    """Which instrument, whose account, and what software produced an experiment.
+
+    An experiment directory records what it contains but nothing about what made
+    it, so "was this run before or after the upgrade", "which machine was this on"
+    and "which build of my plugin ran" are all unanswerable from the record. Every
+    part of this is already collected per-image; this promotes it to the
+    experiment (FIB-451).
+
+    **This describes the last run to touch the experiment, not the one that created
+    it.** ``Experiment.create()` has no microscope -- the dialog that calls it never
+    holds one -- so the instrument is simply unknown until a run adopts the
+    experiment. The last run is the fact that can actually be established, and it
+    has the useful property of backfilling onto experiments that predate this.
+
+    Overwriting loses less than it looks like. Every image already carries its own
+    ``SystemInfo``, so an experiment spanning an upgrade shows v0.5.1 on day-one
+    images and v0.5.2 here -- two true facts, which is the same reasoning that put
+    the version fields on ``SystemInfo`` in the first place (FIB-445 D1). A
+    per-session history is FIB-452's shape, not this record's.
+    """
+
+    recorded_at: float = field(
+        default_factory=lambda: datetime.timestamp(datetime.now())
+    )
+    system: Optional[SystemInfo] = None
+    user: Optional[FibsemUser] = None
+    # Distribution name -> version for every installed extension; see
+    # `installed_plugin_versions`. A plain dict so it survives `yaml.safe_dump`,
+    # which is how an experiment is written.
+    plugins: Dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def collect(
+        cls, microscope: "FibsemMicroscope", user: Optional[FibsemUser] = None
+    ) -> "RunProvenance":
+        """Snapshot what is running right now.
+
+        ``user`` overrides the environment's, for a caller that knows better: on a
+        shared facility login the OS account names the workstation rather than the
+        operator, so a name somebody actually typed is the stronger evidence.
+
+        The system info is copied. It is a live object on the microscope -- the
+        application field is set on it during registration, and a driver may update
+        it -- and a record that quietly changes after the fact is not a record.
+        """
+        from copy import deepcopy
+
+        # Lazy: `report` imports all three registries, so importing it here would
+        # cycle straight back through this module.
+        from fibsem.plugins.report import installed_plugin_versions
+
+        info = getattr(getattr(microscope, "system", None), "info", None)
+        return cls(
+            system=deepcopy(info) if info is not None else None,
+            user=user if user is not None else FibsemUser.from_environment(),
+            plugins=installed_plugin_versions(),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "recorded_at": self.recorded_at,
+            "system": self.system.to_dict() if self.system is not None else None,
+            "user": self.user.to_dict() if self.user is not None else None,
+            "plugins": dict(self.plugins),
+        }
+
+    @staticmethod
+    def from_dict(ddict: dict) -> "RunProvenance":
+        system = ddict.get("system")
+        user = ddict.get("user")
+        return RunProvenance(
+            recorded_at=ddict.get("recorded_at"),
+            system=SystemInfo.from_dict(system) if system else None,
+            user=FibsemUser.from_dict(user) if user else None,
+            plugins=dict(ddict.get("plugins") or {}),
+        )
+
+
+@dataclass
 class FibsemImageMetadata:
     """Metadata for a FibsemImage.
 

--- a/tests/autolamella/test_experiment_provenance.py
+++ b/tests/autolamella/test_experiment_provenance.py
@@ -1,0 +1,350 @@
+"""An experiment directory should say what produced it (FIB-451).
+
+`Experiment` recorded what it contains and nothing about what made it, so "was
+this before or after the upgrade", "which instrument was this on" and "which
+build of my plugin ran" were all unanswerable from the record -- for the five
+personas the project is built around, it is the one fact they all need.
+
+Every part of it was already collected per-image. What was missing was a moment
+to promote it, and `register_metadata` is that moment: the only place the
+experiment meets a microscope.
+
+It describes the **last run to touch the experiment**, not the run that created
+it -- `Experiment.create()` has no microscope to ask.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from fibsem import utils
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.microscope import FibsemMicroscope
+
+
+@pytest.fixture
+def microscope() -> FibsemMicroscope:
+    scope, _ = utils.setup_session(manufacturer="Demo")
+    return scope
+
+
+def _stored(experiment: Experiment) -> dict:
+    """What is actually on disk for this experiment."""
+    with open(os.path.join(experiment.path, "experiment.yaml")) as f:
+        return yaml.safe_load(f)
+
+
+def _experiment(tmp_path: Path, metadata=None) -> Experiment:
+    exp = Experiment(path=tmp_path, name="test-experiment", metadata=metadata)
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    # Constructing an Experiment deliberately does not write to disk (FIB-420).
+    os.makedirs(exp.path, exist_ok=True)
+    return exp
+
+
+# ---------------------------------------------------------------------------
+# What gets recorded
+# ---------------------------------------------------------------------------
+
+
+def test_an_experiment_nothing_has_run_knows_nothing(tmp_path: Path) -> None:
+    """None, rather than a half-filled record.
+
+    Creating an experiment happens in a dialog with no microscope, so the
+    instrument genuinely is unknown until a run adopts it.
+    """
+    assert _experiment(tmp_path).provenance is None
+
+
+def test_registering_records_the_instrument(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    experiment = _experiment(tmp_path)
+
+    experiment.register_metadata(microscope)
+
+    system = experiment.provenance.system
+    assert system.serial_number == microscope.system.info.serial_number
+    assert system.manufacturer == microscope.system.info.manufacturer
+    assert system.model == microscope.system.info.model
+
+
+def test_it_records_the_software_that_ran(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """`fibsem_revision` is the point -- the version alone cannot pin a dev build."""
+    import fibsem
+
+    experiment = _experiment(tmp_path)
+
+    experiment.register_metadata(microscope)
+
+    assert experiment.provenance.system.fibsem_version == fibsem.__version__
+    # Set by _register_metadata onto the very SystemInfo snapshotted here, so this
+    # also pins the ordering: collect after registration, or it reads None.
+    assert experiment.provenance.system.application == "autolamella"
+
+
+def test_it_records_installed_plugin_versions(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """Shape, not contents: which plugins exist depends on the environment."""
+    experiment = _experiment(tmp_path)
+
+    experiment.register_metadata(microscope)
+
+    plugins = experiment.provenance.plugins
+    assert isinstance(plugins, dict)
+    assert all(isinstance(k, str) and isinstance(v, str) for k, v in plugins.items())
+
+
+def test_the_system_info_is_copied_not_referenced(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """A record that changes after the fact is not a record.
+
+    `microscope.system.info` is live -- registration writes `application` to it,
+    and a driver may update it -- so holding the same object would let the
+    experiment's account of a finished run be rewritten later.
+    """
+    experiment = _experiment(tmp_path)
+    experiment.register_metadata(microscope)
+
+    microscope.system.info.model = "SomethingElse"
+
+    assert experiment.provenance.system.model != "SomethingElse"
+
+
+# ---------------------------------------------------------------------------
+# Who ran it
+# ---------------------------------------------------------------------------
+
+
+def test_without_a_declared_operator_it_falls_back_to_the_account(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    experiment = _experiment(tmp_path)
+
+    experiment.register_metadata(microscope)
+
+    from fibsem.structures import FibsemUser
+
+    assert experiment.provenance.user.name == FibsemUser.from_environment().name
+
+
+def test_a_declared_operator_beats_the_os_account(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """Shared facility logins make the OS account name the workstation, not the
+    person. Somebody who typed a name into the create dialog meant it."""
+    experiment = _experiment(
+        tmp_path, metadata={"user": "Dr Someone", "organisation": "Some Institute"}
+    )
+
+    experiment.register_metadata(microscope)
+
+    assert experiment.provenance.user.name == "Dr Someone"
+    assert experiment.provenance.user.organization == "Some Institute"
+
+
+def test_the_hostname_still_comes_from_the_environment(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """It answers a different question -- which machine, not which person -- so a
+    declared operator must not overwrite it."""
+    from fibsem.structures import FibsemUser
+
+    experiment = _experiment(tmp_path, metadata={"user": "Dr Someone"})
+
+    experiment.register_metadata(microscope)
+
+    assert experiment.provenance.user.hostname == FibsemUser.from_environment().hostname
+
+
+def test_an_unrelated_metadata_entry_declares_nobody(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """Only the two fields the dialog offers count; a description is not a user."""
+    from fibsem.structures import FibsemUser
+
+    experiment = _experiment(tmp_path, metadata={"description": "a test run"})
+
+    experiment.register_metadata(microscope)
+
+    assert experiment.provenance.user.name == FibsemUser.from_environment().name
+
+
+# ---------------------------------------------------------------------------
+# Last run wins, and it reaches disk
+# ---------------------------------------------------------------------------
+
+
+def test_registering_again_records_the_later_run(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """The chosen semantics: this describes the run that last touched the
+    experiment. Version drift within a run is not lost -- every image carries its
+    own SystemInfo (FIB-445 D1)."""
+    experiment = _experiment(tmp_path)
+    experiment.register_metadata(microscope)
+    first = experiment.provenance.system.software_version
+
+    microscope.system.info.software_version = "9.9-after-the-upgrade"
+    experiment.register_metadata(microscope)
+
+    assert first != "9.9-after-the-upgrade"
+    assert experiment.provenance.system.software_version == "9.9-after-the-upgrade"
+
+
+def test_registering_persists_it(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """The value of this record is that it is *in experiment.yaml*.
+
+    Leaving it to whatever saves next is how FIB-490 lost every failed task, so
+    registration writes it itself.
+    """
+    experiment = _experiment(tmp_path)
+    experiment.save()  # as `create` and `load` both guarantee
+
+    experiment.register_metadata(microscope)
+
+    written = _stored(experiment)
+    assert written["provenance"]["system"]["serial_number"] == (
+        microscope.system.info.serial_number
+    )
+
+
+def test_registering_does_not_conjure_a_file(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    """An Experiment may legitimately exist without one -- constructing one does
+    not touch the disk (FIB-420), and much of the suite drives TaskManager that
+    way. Registering is not the moment to decide it should have a directory.
+    """
+    experiment = _experiment(tmp_path)
+
+    experiment.register_metadata(microscope)
+
+    assert not os.path.exists(os.path.join(experiment.path, "experiment.yaml"))
+    # Still recorded in memory, so the next real save carries it.
+    assert experiment.provenance is not None
+
+
+def test_it_survives_a_round_trip(
+    microscope: FibsemMicroscope, tmp_path: Path
+) -> None:
+    experiment = _experiment(tmp_path, metadata={"user": "Dr Someone"})
+    experiment.save()
+    experiment.register_metadata(microscope)
+
+    reloaded = Experiment.load(Path(experiment.path) / "experiment.yaml")
+
+    assert reloaded.provenance.user.name == "Dr Someone"
+    assert reloaded.provenance.system.model == experiment.provenance.system.model
+    assert reloaded.provenance.plugins == experiment.provenance.plugins
+    assert reloaded.provenance.recorded_at == experiment.provenance.recorded_at
+
+
+def test_an_experiment_written_before_this_loads_with_none(tmp_path: Path) -> None:
+    """Absent and unknown are the same answer, and None says it without guessing."""
+    experiment = _experiment(tmp_path)
+    experiment.save()
+
+    stored = _stored(experiment)
+    del stored["provenance"]
+    with open(os.path.join(experiment.path, "experiment.yaml"), "w") as f:
+        yaml.safe_dump(stored, f, indent=4)
+
+    assert Experiment.load(Path(experiment.path) / "experiment.yaml").provenance is None
+
+
+# ---------------------------------------------------------------------------
+# The plugin collector
+# ---------------------------------------------------------------------------
+
+
+def test_only_installed_distributions_are_recorded(monkeypatch) -> None:
+    """Having a distribution is the filter: built-ins have none, and a
+    script-loaded extension carries a path instead."""
+    from fibsem.plugins import report
+    from fibsem.plugins.report import (
+        Extension,
+        ExtensionGroup,
+        ExtensionSource,
+        installed_plugin_versions,
+    )
+
+    group = ExtensionGroup(
+        group="fibsem.patterns",
+        label="Milling patterns",
+        extensions=(
+            Extension(
+                group="fibsem.patterns",
+                name="Trench",
+                source=ExtensionSource.BUILTIN,
+                target="fibsem.Trench",
+            ),
+            Extension(
+                group="fibsem.patterns",
+                name="Waffle",
+                source=ExtensionSource.PLUGIN,
+                target="lab.Waffle",
+                distribution="lab-patterns",
+                version="0.3.1",
+            ),
+            Extension(
+                group="fibsem.patterns",
+                name=None,
+                source=ExtensionSource.FAILED,
+                target="broken:Thing",
+                distribution="broken-plugin",
+                version="1.2",
+                problem="ImportError",
+            ),
+        ),
+    )
+    monkeypatch.setattr(report, "collect_extensions", lambda: (group,))
+
+    assert installed_plugin_versions() == {
+        "lab-patterns": "0.3.1",
+        # Installed, did not load, and shaped the run by being absent from the
+        # registry -- omitting it would make the record match a machine that never
+        # had it.
+        "broken-plugin": "1.2",
+    }
+
+
+def test_a_distribution_without_a_version_is_still_recorded(monkeypatch) -> None:
+    """An editable install can resolve a name but no version. Recording "unknown"
+    beats dropping the plugin from the record entirely."""
+    from fibsem.plugins import report
+    from fibsem.plugins.report import (
+        Extension,
+        ExtensionGroup,
+        ExtensionSource,
+        installed_plugin_versions,
+    )
+
+    group = ExtensionGroup(
+        group="fibsem.patterns",
+        label="Milling patterns",
+        extensions=(
+            Extension(
+                group="fibsem.patterns",
+                name="Waffle",
+                source=ExtensionSource.PLUGIN,
+                target="lab.Waffle",
+                distribution="lab-patterns",
+                version=None,
+            ),
+        ),
+    )
+    monkeypatch.setattr(report, "collect_extensions", lambda: (group,))
+
+    assert installed_plugin_versions() == {"lab-patterns": "unknown"}

--- a/tests/autolamella/test_experiment_session.py
+++ b/tests/autolamella/test_experiment_session.py
@@ -58,7 +58,7 @@ def test_an_experiment_no_session_has_touched_knows_nothing(tmp_path: Path) -> N
     """None, rather than a half-filled record.
 
     Creating an experiment happens in a dialog with no microscope, so the
-    instrument genuinely is unknown until a run adopts it.
+    instrument genuinely is unknown until a session adopts it.
     """
     assert _experiment(tmp_path).session is None
 
@@ -182,7 +182,7 @@ def test_an_unrelated_metadata_entry_declares_nobody(
 
 
 # ---------------------------------------------------------------------------
-# Last run wins, and it reaches disk
+# The latest session wins, and it reaches disk
 # ---------------------------------------------------------------------------
 
 

--- a/tests/autolamella/test_experiment_session.py
+++ b/tests/autolamella/test_experiment_session.py
@@ -1,4 +1,4 @@
-"""An experiment directory should say what produced it (FIB-451).
+"""An experiment should record which session worked on it (FIB-451).
 
 `Experiment` recorded what it contains and nothing about what made it, so "was
 this before or after the upgrade", "which instrument was this on" and "which
@@ -9,8 +9,10 @@ Every part of it was already collected per-image. What was missing was a moment
 to promote it, and `register_metadata` is that moment: the only place the
 experiment meets a microscope.
 
-It describes the **last run to touch the experiment**, not the run that created
-it -- `Experiment.create()` has no microscope to ask.
+A session is what `setup_session` establishes -- a connected instrument and the
+configuration around it -- plus who is at the keyboard. It is the **latest** one,
+not the one that created the experiment: `Experiment.create()` has no microscope
+to ask.
 """
 
 import os
@@ -52,13 +54,13 @@ def _experiment(tmp_path: Path, metadata=None) -> Experiment:
 # ---------------------------------------------------------------------------
 
 
-def test_an_experiment_nothing_has_run_knows_nothing(tmp_path: Path) -> None:
+def test_an_experiment_no_session_has_touched_knows_nothing(tmp_path: Path) -> None:
     """None, rather than a half-filled record.
 
     Creating an experiment happens in a dialog with no microscope, so the
     instrument genuinely is unknown until a run adopts it.
     """
-    assert _experiment(tmp_path).provenance is None
+    assert _experiment(tmp_path).session is None
 
 
 def test_registering_records_the_instrument(
@@ -68,7 +70,7 @@ def test_registering_records_the_instrument(
 
     experiment.register_metadata(microscope)
 
-    system = experiment.provenance.system
+    system = experiment.session.system
     assert system.serial_number == microscope.system.info.serial_number
     assert system.manufacturer == microscope.system.info.manufacturer
     assert system.model == microscope.system.info.model
@@ -84,10 +86,10 @@ def test_it_records_the_software_that_ran(
 
     experiment.register_metadata(microscope)
 
-    assert experiment.provenance.system.fibsem_version == fibsem.__version__
+    assert experiment.session.system.fibsem_version == fibsem.__version__
     # Set by _register_metadata onto the very SystemInfo snapshotted here, so this
     # also pins the ordering: collect after registration, or it reads None.
-    assert experiment.provenance.system.application == "autolamella"
+    assert experiment.session.system.application == "autolamella"
 
 
 def test_it_records_installed_plugin_versions(
@@ -98,7 +100,7 @@ def test_it_records_installed_plugin_versions(
 
     experiment.register_metadata(microscope)
 
-    plugins = experiment.provenance.plugins
+    plugins = experiment.session.plugins
     assert isinstance(plugins, dict)
     assert all(isinstance(k, str) and isinstance(v, str) for k, v in plugins.items())
 
@@ -117,7 +119,7 @@ def test_the_system_info_is_copied_not_referenced(
 
     microscope.system.info.model = "SomethingElse"
 
-    assert experiment.provenance.system.model != "SomethingElse"
+    assert experiment.session.system.model != "SomethingElse"
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +136,7 @@ def test_without_a_declared_operator_it_falls_back_to_the_account(
 
     from fibsem.structures import FibsemUser
 
-    assert experiment.provenance.user.name == FibsemUser.from_environment().name
+    assert experiment.session.user.name == FibsemUser.from_environment().name
 
 
 def test_a_declared_operator_beats_the_os_account(
@@ -148,8 +150,8 @@ def test_a_declared_operator_beats_the_os_account(
 
     experiment.register_metadata(microscope)
 
-    assert experiment.provenance.user.name == "Dr Someone"
-    assert experiment.provenance.user.organization == "Some Institute"
+    assert experiment.session.user.name == "Dr Someone"
+    assert experiment.session.user.organization == "Some Institute"
 
 
 def test_the_hostname_still_comes_from_the_environment(
@@ -163,7 +165,7 @@ def test_the_hostname_still_comes_from_the_environment(
 
     experiment.register_metadata(microscope)
 
-    assert experiment.provenance.user.hostname == FibsemUser.from_environment().hostname
+    assert experiment.session.user.hostname == FibsemUser.from_environment().hostname
 
 
 def test_an_unrelated_metadata_entry_declares_nobody(
@@ -176,7 +178,7 @@ def test_an_unrelated_metadata_entry_declares_nobody(
 
     experiment.register_metadata(microscope)
 
-    assert experiment.provenance.user.name == FibsemUser.from_environment().name
+    assert experiment.session.user.name == FibsemUser.from_environment().name
 
 
 # ---------------------------------------------------------------------------
@@ -184,21 +186,20 @@ def test_an_unrelated_metadata_entry_declares_nobody(
 # ---------------------------------------------------------------------------
 
 
-def test_registering_again_records_the_later_run(
+def test_registering_again_records_the_later_session(
     microscope: FibsemMicroscope, tmp_path: Path
 ) -> None:
-    """The chosen semantics: this describes the run that last touched the
-    experiment. Version drift within a run is not lost -- every image carries its
-    own SystemInfo (FIB-445 D1)."""
+    """The chosen semantics: the latest session, not the first. Version drift is
+    not lost by overwriting -- every image carries its own SystemInfo (FIB-445 D1)."""
     experiment = _experiment(tmp_path)
     experiment.register_metadata(microscope)
-    first = experiment.provenance.system.software_version
+    first = experiment.session.system.software_version
 
     microscope.system.info.software_version = "9.9-after-the-upgrade"
     experiment.register_metadata(microscope)
 
     assert first != "9.9-after-the-upgrade"
-    assert experiment.provenance.system.software_version == "9.9-after-the-upgrade"
+    assert experiment.session.system.software_version == "9.9-after-the-upgrade"
 
 
 def test_registering_persists_it(
@@ -215,7 +216,7 @@ def test_registering_persists_it(
     experiment.register_metadata(microscope)
 
     written = _stored(experiment)
-    assert written["provenance"]["system"]["serial_number"] == (
+    assert written["session"]["system"]["serial_number"] == (
         microscope.system.info.serial_number
     )
 
@@ -233,7 +234,7 @@ def test_registering_does_not_conjure_a_file(
 
     assert not os.path.exists(os.path.join(experiment.path, "experiment.yaml"))
     # Still recorded in memory, so the next real save carries it.
-    assert experiment.provenance is not None
+    assert experiment.session is not None
 
 
 def test_it_survives_a_round_trip(
@@ -245,10 +246,10 @@ def test_it_survives_a_round_trip(
 
     reloaded = Experiment.load(Path(experiment.path) / "experiment.yaml")
 
-    assert reloaded.provenance.user.name == "Dr Someone"
-    assert reloaded.provenance.system.model == experiment.provenance.system.model
-    assert reloaded.provenance.plugins == experiment.provenance.plugins
-    assert reloaded.provenance.recorded_at == experiment.provenance.recorded_at
+    assert reloaded.session.user.name == "Dr Someone"
+    assert reloaded.session.system.model == experiment.session.system.model
+    assert reloaded.session.plugins == experiment.session.plugins
+    assert reloaded.session.recorded_at == experiment.session.recorded_at
 
 
 def test_an_experiment_written_before_this_loads_with_none(tmp_path: Path) -> None:
@@ -257,11 +258,11 @@ def test_an_experiment_written_before_this_loads_with_none(tmp_path: Path) -> No
     experiment.save()
 
     stored = _stored(experiment)
-    del stored["provenance"]
+    del stored["session"]
     with open(os.path.join(experiment.path, "experiment.yaml"), "w") as f:
         yaml.safe_dump(stored, f, indent=4)
 
-    assert Experiment.load(Path(experiment.path) / "experiment.yaml").provenance is None
+    assert Experiment.load(Path(experiment.path) / "experiment.yaml").session is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
An experiment directory records what it contains and nothing about what made it. "Was this run before or after the upgrade?", "which machine was this on?" and "which build of my plugin ran?" are all unanswerable from the record — the one fact all five personas in the project need.

Closes FIB-451.

## The hook

Every part of this was already collected per-image. What was missing was a moment to promote it, and `Experiment.register_metadata(microscope)` is that moment — the only place an experiment meets a microscope, already called by the app when it adopts one, by `TaskManager` when it takes one to run, and by scripts directly (FIB-449). Registration now runs both ways: identity down to the microscope as before, provenance up to the experiment.

A real run records:

```yaml
provenance:
  plugins: {fibsem-plugin-example: 0.1.0}
  recorded_at: 1785907692.139788
  system:
    application: autolamella
    fibsem_revision: v0.5.1-138-g295badb7-dirty
    fibsem_version: 0.5.2.dev0
    manufacturer: Demo
    model: DemoMicroscope
    serial_number: '123456'
  user: {name: Dr Someone, organization: Some Institute, hostname: ...}
```

`installed_plugin_versions()` derives the plugin map from the existing extension report. **Having a distribution is the filter** — built-ins have none and script-loaded extensions carry a path instead. A plugin whose entry point *failed* to load stays in: it was installed, and being absent from the registry shaped the run, so omitting it would make the record match a machine that never had it.

## The last run, not the creating run

`Experiment.create()` has no microscope — the dialog that calls it holds none — so the instrument is genuinely unknown until a run adopts the experiment. Recording the last run is the fact that can actually be established, and it backfills onto experiments that predate this.

Overwriting loses less than it looks like. Every image already carries its own `SystemInfo`, so an experiment spanning an upgrade shows v0.5.1 on day-one images and v0.5.2 here — two true facts, the same reasoning that put the version fields on `SystemInfo` (FIB-445 D1). A per-session history is FIB-452's shape, not this record's.

## Who ran it

A name typed into the create dialog beats `FibsemUser.from_environment()`: on a shared facility login the OS account names the workstation, not the operator, and somebody who typed a name meant it. Only the two fields the dialog offers are overridden — `hostname` stays as the environment reports it, because it answers a different question.

The `SystemInfo` is **deep-copied**. It is live on the microscope — this very call writes `application` to it — and a record that quietly changes after the fact is not a record. Same-object aliasing has bitten this area twice already (FIB-481, FIB-466), so it is pinned by a test.

## The save is conditional, deliberately

First version called `self.save()` unconditionally, on the FIB-490 reasoning that a record nothing persists is not a record. **That broke 69 tests** — not a fixture problem: there are 29 `Experiment(path=...)` construction sites across 19 test modules, 12 of which never create the directory. An `Experiment` without its directory is a legitimate state (FIB-420) that `TaskManager` is routinely driven in, and registration is not the moment to decide it should have one.

So it saves only when `experiment.yaml` already exists. Both `create` and `load` guarantee that, so a real run always writes; an in-memory experiment keeps it in memory for the next real save. Both halves are pinned by tests.

## Testing

`tests/autolamella/test_experiment_session.py` — 16 tests covering what is recorded, the copy-not-reference guarantee, operator-vs-account precedence, last-run-wins, persistence and its deliberate limit, the round trip, an experiment written before this loading as `None`, and the plugin filter (built-ins out, failed-to-load in, missing version recorded as `unknown`).

- **3096 passed, 21 skipped** — full suite
- All changed files parse under 3.8 grammar

## Not done here

The create dialog still writes `user` / `organisation` into the untyped `metadata` dict, and `_declared_user()` reads them from there. Promoting those to typed fields is a UI change and deserves its own issue rather than riding along in this one.
