### PR TITLE
[autolamella] Enumerate experiments by instrument and time window (FIB-457)

### DIFF
--- a/fibsem/applications/autolamella/tools/experiments.py
+++ b/fibsem/applications/autolamella/tools/experiments.py
@@ -1,0 +1,142 @@
+"""Find experiments, and narrow them down to a question worth asking.
+
+The facility-manager question is *"what did this microscope do this week?"*
+Answering it needs two things: something to group by, and a way to find the
+experiments. The first arrived with the session record (FIB-451); this is the
+second (FIB-457).
+
+Deliberately reads only, and never imports :class:`Experiment`. Enumerating a
+directory means opening files written by other versions, half-finished runs, and
+whatever else is under the root -- loading each one properly would be slow and
+would let a single bad file take out the listing. ``peek_experiment`` reads the
+few keys that matter and flags what it could not parse.
+
+**What this can and cannot see.** There is no global registry of experiments: the
+default root is inside the installed package, users create experiments anywhere,
+and the recents list holds the last ten a machine opened. So an answer here is
+complete for the roots it was given and silent about everything else. That gap
+closes when the user-data directory lands (FIB-336) and the index can live
+somewhere an upgrade does not destroy.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, Iterable, List, Optional
+
+from fibsem.config import ExperimentSummary, get_recent_experiments, peek_experiment
+
+__all__ = [
+    "discover_experiments",
+    "filter_experiments",
+    "group_by_instrument",
+]
+
+# How deep to look for an experiment.yaml below the root. An experiment directory
+# sits directly under the root it was created in, so 2 covers the normal layout
+# and one level of grouping (a per-project or per-user folder). Unbounded descent
+# over a whole data drive is slow enough to look like a hang.
+DEFAULT_MAX_DEPTH = 3
+
+
+def discover_experiments(
+    root: str, max_depth: int = DEFAULT_MAX_DEPTH
+) -> List[ExperimentSummary]:
+    """Every experiment under ``root``, newest first.
+
+    An experiment is a directory containing ``experiment.yaml``. Descends at most
+    ``max_depth`` levels; a directory that is itself an experiment is not
+    descended into, so a nested run folder cannot be reported twice.
+
+    A root that does not exist returns nothing rather than raising: pointing this
+    at a drive that is not mounted is an ordinary mistake, and an empty answer
+    with a warning is more useful than a traceback.
+    """
+    if not os.path.isdir(root):
+        logging.warning("Not a directory, so nothing to enumerate: %s", root)
+        return []
+
+    found: List[ExperimentSummary] = []
+    root = os.path.abspath(root)
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        depth = dirpath[len(root):].count(os.sep)
+        if "experiment.yaml" in filenames:
+            found.append(peek_experiment(os.path.join(dirpath, "experiment.yaml")))
+            # Whatever is inside an experiment belongs to it. Pruning here also
+            # keeps the walk off the image directories, which is most of the
+            # files on disk.
+            dirnames[:] = []
+            continue
+        if depth >= max_depth:
+            dirnames[:] = []
+
+    return sorted(found, key=lambda e: e.created_at, reverse=True)
+
+
+def filter_experiments(
+    experiments: Iterable[ExperimentSummary],
+    instrument: Optional[str] = None,
+    operator: Optional[str] = None,
+    since: Optional[float] = None,
+    until: Optional[float] = None,
+) -> List[ExperimentSummary]:
+    """Narrow a listing. Every argument left as None does not filter.
+
+    ``instrument`` matches the serial number or the model, case-insensitively --
+    a facility manager knows their instrument by whichever of those they use, and
+    making them guess which one this wants is not worth a second flag.
+
+    An experiment with no session record matches no instrument and no operator.
+    It is not evidence of the instrument you asked about, and quietly including
+    unknowns is how a per-instrument total comes out wrong.
+    """
+    results = list(experiments)
+
+    if instrument is not None:
+        needle = instrument.casefold()
+        results = [
+            e for e in results
+            if needle in (e.instrument_serial or "").casefold()
+            or needle in (e.instrument_model or "").casefold()
+        ]
+
+    if operator is not None:
+        needle = operator.casefold()
+        results = [e for e in results if needle in (e.operator or "").casefold()]
+
+    if since is not None:
+        results = [e for e in results if e.created_at >= since]
+
+    if until is not None:
+        results = [e for e in results if e.created_at <= until]
+
+    return results
+
+
+def group_by_instrument(
+    experiments: Iterable[ExperimentSummary],
+) -> Dict[Optional[str], List[ExperimentSummary]]:
+    """Bucket by instrument serial, keeping the order given.
+
+    Serial rather than model, because it is what distinguishes two of the same
+    model in one facility -- the case the grouping exists for. Experiments with
+    no session record collect under ``None``, which is a bucket worth seeing:
+    it is how many runs cannot be attributed at all.
+    """
+    grouped: Dict[Optional[str], List[ExperimentSummary]] = {}
+    for experiment in experiments:
+        grouped.setdefault(experiment.instrument_serial, []).append(experiment)
+    return grouped
+
+
+def recent_experiments() -> List[ExperimentSummary]:
+    """The experiments this machine has opened, newest first.
+
+    A second source alongside a directory walk, and the only one that reaches
+    experiments created outside any root the caller knows to look in. Capped at
+    ten by the preference that stores it, and stored inside the installed
+    package, so it is neither complete nor durable -- see FIB-336.
+    """
+    return get_recent_experiments(prune_missing=False)

--- a/fibsem/cli.py
+++ b/fibsem/cli.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 import argparse
 import logging
 import math
+import os
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -523,6 +524,152 @@ def _add_mill_angle_parser(sub, conn) -> None:
     p.set_defaults(func=cmd_mill_angle)
 
 
+def _experiment_roots(args) -> "list[str]":
+    """Where to look, given what the user asked for.
+
+    Defaults to the experiment directory they have configured, falling back to
+    the packaged default. Neither is authoritative -- experiments can be created
+    anywhere -- which is why --root exists and why the command says how many
+    places it actually looked.
+    """
+    from fibsem import config as cfg
+
+    if args.root:
+        return list(args.root)
+
+    prefs = cfg.load_user_preferences()
+    configured = prefs.experiment.default_experiment_directory
+    return [configured or cfg.AUTOLAMELLA_LOG_PATH]
+
+
+def _since_timestamp(args) -> Optional[float]:
+    """Resolve --days / --since into one lower bound, or None."""
+    if args.days is not None and args.since is not None:
+        raise ValueError("--days and --since both set a start; use one or the other")
+    if args.days is not None:
+        return (datetime.now() - timedelta(days=args.days)).timestamp()
+    if args.since is not None:
+        return datetime.strptime(args.since, "%Y-%m-%d").timestamp()
+    return None
+
+
+def cmd_experiments(args) -> int:
+    """List experiments, optionally narrowed to one instrument or time window.
+
+    Answers "what did this microscope do this week?" for the roots it is given.
+    It cannot answer it for the whole facility: nothing records where experiments
+    are created, so this is only ever as complete as the places it looked. The
+    summary line says how many that was, so an empty answer reads as "not here"
+    rather than "never happened". See FIB-457.
+
+    Takes no microscope: this is a question about files.
+    """
+    from fibsem.applications.autolamella.tools.experiments import (
+        discover_experiments,
+        filter_experiments,
+        group_by_instrument,
+        recent_experiments,
+    )
+
+    try:
+        since = _since_timestamp(args)
+    except ValueError as e:
+        print(f"error: {e}")
+        return 2
+
+    roots = _experiment_roots(args)
+    found = {}
+    for root in roots:
+        for experiment in discover_experiments(root):
+            found[os.path.realpath(experiment.path)] = experiment
+    if args.recent:
+        for experiment in recent_experiments():
+            found.setdefault(os.path.realpath(experiment.path), experiment)
+
+    experiments = filter_experiments(
+        sorted(found.values(), key=lambda e: e.created_at, reverse=True),
+        instrument=args.instrument,
+        operator=args.operator,
+        since=since,
+        until=(
+            datetime.strptime(args.until, "%Y-%m-%d").timestamp() if args.until else None
+        ),
+    )
+
+    if not experiments:
+        print(f"No experiments found in {len(roots)} location(s): {', '.join(roots)}")
+        return 0
+
+    if args.group:
+        for serial, group in group_by_instrument(experiments).items():
+            model = next((e.instrument_model for e in group if e.instrument_model), None)
+            heading = f"{model} ({serial})" if serial else "No session recorded"
+            print(f"\n{heading} — {len(group)} experiment(s)")
+            _print_experiments(group)
+    else:
+        _print_experiments(experiments)
+
+    print(f"\n{len(experiments)} experiment(s) in {len(roots)} location(s)")
+    return 0
+
+
+def _print_experiments(experiments) -> None:
+    """One row each: when, what, where it ran, who ran it, how much was in it."""
+    for e in experiments:
+        when = (
+            datetime.fromtimestamp(e.created_at).strftime("%Y-%m-%d %H:%M")
+            if e.created_at
+            else "unknown"
+        )
+        # An experiment written before the session record has no instrument and no
+        # operator. Shown as "-" rather than blank so the column stays readable and
+        # missing does not look like empty.
+        instrument = e.instrument_model or "-"
+        if e.instrument_serial:
+            instrument = f"{instrument}/{e.instrument_serial}"
+        note = "" if e.available else "  [unreadable]"
+        print(
+            f"  {when}  {e.name[:28]:28s} {instrument[:24]:24s} "
+            f"{(e.operator or '-')[:16]:16s} {e.num_lamella:3d} lamella{note}"
+        )
+        print(f"      {os.path.dirname(e.path)}")
+
+
+def _add_experiments_parser(sub) -> None:
+    """Enumerate experiments on disk.
+
+    Deliberately takes no connection arguments, for the same reason as `plugins`:
+    this is a question about files, usually asked away from the instrument, and
+    requiring a microscope to answer "what ran last week" would make it useless
+    where it is most wanted.
+    """
+    p = sub.add_parser(
+        "experiments",
+        help="List experiments on disk, by instrument or time window",
+    )
+    p.add_argument(
+        "--root",
+        action="append",
+        metavar="PATH",
+        help="Directory to search; repeatable. Defaults to your configured "
+             "experiment directory",
+    )
+    p.add_argument(
+        "--recent",
+        action="store_true",
+        help="Also include experiments this machine has opened, which may live "
+             "outside any searched root (last 10 only)",
+    )
+    p.add_argument("--instrument", metavar="SERIAL|MODEL",
+                   help="Only experiments run on this instrument")
+    p.add_argument("--operator", metavar="NAME", help="Only experiments run by this operator")
+    p.add_argument("--days", type=int, metavar="N", help="Only the last N days")
+    p.add_argument("--since", metavar="YYYY-MM-DD", help="Only on or after this date")
+    p.add_argument("--until", metavar="YYYY-MM-DD", help="Only on or before this date")
+    p.add_argument("--group", action="store_true", help="Group the listing by instrument")
+    p.set_defaults(func=cmd_experiments, needs_microscope=False)
+
+
 def _add_plugins_parser(sub) -> None:
     """List what resolved under each entry point group.
 
@@ -624,6 +771,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_info_parser(sub, conn)
     _add_mill_angle_parser(sub, conn)
     _add_set_beam_parser(sub, conn)
+    _add_experiments_parser(sub)
     _add_plugins_parser(sub)
     return root
 

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -435,43 +435,72 @@ def save_user_preferences(preferences) -> None:
 
 
 @dataclass
-class RecentExperimentInfo:
-    """Display information for a recently used experiment."""
+class ExperimentSummary:
+    """What an experiment says about itself, read without loading it.
+
+    Was ``RecentExperimentInfo``, when the recents list was the only caller.
+    Enumerating a directory asks the same question of a file nobody has opened
+    (FIB-457), so the name no longer claims the file is recent.
+
+    The instrument and operator come from the ``session`` record (FIB-451) and
+    are absent from anything written before it, or from an experiment no session
+    has adopted. That is a real answer -- nothing is known -- so they stay None
+    rather than defaulting to a string that would group with other unknowns.
+    """
     path: str  # path to the experiment.yaml file
     name: str
     created_at: float = 0.0
     num_lamella: int = 0
     exists: bool = True
     available: bool = True  # False if the file is missing or could not be read
+    instrument_serial: Optional[str] = None
+    instrument_model: Optional[str] = None
+    operator: Optional[str] = None
+    software_version: Optional[str] = None
 
 
-def _peek_experiment_yaml(experiment_yaml_path: str) -> RecentExperimentInfo:
-    """Read minimal display info from an experiment.yaml without fully loading it.
+def peek_experiment(experiment_yaml_path: str) -> ExperimentSummary:
+    """Read an experiment.yaml's summary without fully loading it.
 
     Falls back to the parent directory name if the file is missing or unreadable.
     A file that exists but cannot be parsed is kept (exists=True) but flagged
-    as unavailable so the UI can show it as such rather than silently pruning it.
+    as unavailable so the caller can show it as such rather than silently
+    pruning it.
+
+    Reads only, and never raises: this runs over directories of files written by
+    other versions, and one unparseable experiment must not take out the
+    enumeration around it.
     """
     fallback_name = os.path.basename(os.path.dirname(experiment_yaml_path)) or experiment_yaml_path
     if not os.path.exists(experiment_yaml_path):
-        return RecentExperimentInfo(
+        return ExperimentSummary(
             path=experiment_yaml_path, name=fallback_name, exists=False, available=False
         )
 
     try:
         with open(experiment_yaml_path, "r") as f:
             ddict = yaml.safe_load(f) or {}
-        return RecentExperimentInfo(
+        # `or {}` at each level, not `.get(k, {})`: a key present but null is how
+        # an experiment no session has adopted serialises, and that has to read
+        # the same as the key being absent entirely.
+        session = ddict.get("session") or {}
+        system = session.get("system") or {}
+        user = session.get("user") or {}
+        return ExperimentSummary(
             path=experiment_yaml_path,
             name=ddict.get("name") or fallback_name,
             created_at=ddict.get("created_at") or 0.0,
             num_lamella=len(ddict.get("positions") or []),
             exists=True,
             available=True,
+            instrument_serial=system.get("serial_number"),
+            instrument_model=system.get("model"),
+            operator=user.get("name"),
+            software_version=system.get("fibsem_version"),
         )
     except Exception as e:
         logging.warning(f"Failed to read experiment info from {experiment_yaml_path}: {e}")
-        return RecentExperimentInfo(
+        return ExperimentSummary(
             path=experiment_yaml_path, name=fallback_name, exists=True, available=False
         )
 
@@ -510,7 +539,7 @@ def record_recent_experiment(experiment_yaml_path: str) -> None:
     save_user_preferences(prefs)
 
 
-def get_recent_experiments(prune_missing: bool = True) -> List[RecentExperimentInfo]:
+def get_recent_experiments(prune_missing: bool = True) -> List[ExperimentSummary]:
     """Return display info for recent experiments, most-recent-first.
 
     Args:
@@ -518,7 +547,7 @@ def get_recent_experiments(prune_missing: bool = True) -> List[RecentExperimentI
             persist the pruned list back to preferences.
     """
     prefs = load_user_preferences()
-    infos = [_peek_experiment_yaml(str(p)) for p in prefs.experiment.recent_experiments]
+    infos = [peek_experiment(str(p)) for p in prefs.experiment.recent_experiments]
 
     if prune_missing:
         kept = [info for info in infos if info.exists]

--- a/tests/autolamella/test_experiment_discovery.py
+++ b/tests/autolamella/test_experiment_discovery.py
@@ -1,0 +1,333 @@
+"""Finding experiments on disk, and narrowing them to a question (FIB-457).
+
+"What did this microscope do this week?" needs something to group by -- the
+session record (FIB-451) -- and a way to find the experiments. This is the
+second half.
+
+There is no global registry: the default root is inside the installed package,
+users create experiments anywhere, and the recents list holds ten. So the
+contract is "complete for the roots you gave me, silent about everywhere else",
+and the parts that must not break are the ones that make a partial answer safe:
+never raising on a bad file, never quietly folding unattributable runs in with a
+real instrument's totals.
+"""
+
+import os
+import time
+
+import pytest
+import yaml
+
+from fibsem.applications.autolamella.tools.experiments import (
+    discover_experiments,
+    filter_experiments,
+    group_by_instrument,
+)
+from fibsem.config import ExperimentSummary, peek_experiment
+
+DAY = 86400.0
+
+
+def _write(root, name, *, serial=None, model=None, operator=None, age_days=0,
+           lamellae=0, subdir=""):
+    """An experiment.yaml as the app writes one."""
+    directory = os.path.join(root, subdir, name) if subdir else os.path.join(root, name)
+    os.makedirs(directory, exist_ok=True)
+    record = {
+        "name": name,
+        "_id": f"id-{name}",
+        "path": directory,
+        "created_at": time.time() - age_days * DAY,
+        "positions": [{} for _ in range(lamellae)],
+        "metadata": {},
+        "session": None,
+    }
+    if serial is not None:
+        record["session"] = {
+            "recorded_at": record["created_at"],
+            "system": {
+                "serial_number": serial,
+                "model": model,
+                "fibsem_version": "0.5.2",
+                "application": "autolamella",
+            },
+            "user": {"name": operator, "hostname": "a-machine"},
+            "plugins": {},
+        }
+    path = os.path.join(directory, "experiment.yaml")
+    with open(path, "w") as f:
+        yaml.safe_dump(record, f)
+    return path
+
+
+@pytest.fixture
+def facility(tmp_path):
+    """Two instruments, five runs, one of them predating the session record."""
+    root = str(tmp_path)
+    _write(root, "arctis-monday", serial="SN-4471", model="Arctis",
+           operator="Dr Someone", age_days=6, lamellae=4)
+    _write(root, "arctis-friday", serial="SN-4471", model="Arctis",
+           operator="Dr Someone", age_days=1, lamellae=2)
+    _write(root, "aquilos-run", serial="SN-1102", model="Aquilos",
+           operator="A Colleague", age_days=3, lamellae=7)
+    _write(root, "old-run", serial="SN-1102", model="Aquilos",
+           operator="A Colleague", age_days=40, lamellae=1)
+    _write(root, "before-sessions", age_days=2)  # no session key
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Reading one
+# ---------------------------------------------------------------------------
+
+
+def test_a_summary_carries_the_instrument_and_operator(tmp_path) -> None:
+    path = _write(str(tmp_path), "a-run", serial="SN-4471", model="Arctis",
+                  operator="Dr Someone", lamellae=3)
+
+    summary = peek_experiment(path)
+
+    assert summary.instrument_serial == "SN-4471"
+    assert summary.instrument_model == "Arctis"
+    assert summary.operator == "Dr Someone"
+    assert summary.software_version == "0.5.2"
+    assert summary.num_lamella == 3
+
+
+@pytest.mark.parametrize("session", [None, "absent"])
+def test_an_experiment_with_no_session_reports_none(tmp_path, session) -> None:
+    """Written before FIB-451, or adopted by nothing yet. A key present but null
+    has to read the same as the key being missing -- that is how an experiment
+    that no session has touched actually serialises.
+    """
+    path = _write(str(tmp_path), "a-run")
+    if session == "absent":
+        with open(path) as f:
+            record = yaml.safe_load(f)
+        del record["session"]
+        with open(path, "w") as f:
+            yaml.safe_dump(record, f)
+
+    summary = peek_experiment(path)
+
+    assert summary.available is True
+    assert summary.instrument_serial is None
+    assert summary.operator is None
+
+
+def test_an_unreadable_file_is_flagged_not_dropped(tmp_path) -> None:
+    """Keeping it is the point: a listing that silently omits what it could not
+    parse reads as "this never happened"."""
+    directory = tmp_path / "broken"
+    directory.mkdir()
+    (directory / "experiment.yaml").write_text("{{{ not yaml")
+
+    summary = peek_experiment(str(directory / "experiment.yaml"))
+
+    assert summary.exists is True
+    assert summary.available is False
+    assert summary.name == "broken"  # falls back to the directory
+
+
+# ---------------------------------------------------------------------------
+# Finding them
+# ---------------------------------------------------------------------------
+
+
+def test_it_finds_every_experiment_under_a_root(facility) -> None:
+    assert {e.name for e in discover_experiments(facility)} == {
+        "arctis-monday", "arctis-friday", "aquilos-run", "old-run", "before-sessions",
+    }
+
+
+def test_the_listing_is_newest_first(facility) -> None:
+    found = discover_experiments(facility)
+
+    assert [e.name for e in found[:2]] == ["arctis-friday", "before-sessions"]
+    assert found[-1].name == "old-run"
+
+
+def test_it_does_not_descend_into_an_experiment(tmp_path) -> None:
+    """Everything below an experiment.yaml belongs to that experiment. Without
+    pruning, a nested run folder would be reported as a second experiment -- and
+    the walk would cover every image directory on the way."""
+    root = str(tmp_path)
+    _write(root, "outer", serial="SN-1", model="Arctis")
+    _write(os.path.join(root, "outer"), "inner-run", serial="SN-1", model="Arctis")
+
+    assert [e.name for e in discover_experiments(root)] == ["outer"]
+
+
+def test_it_finds_experiments_one_level_down(tmp_path) -> None:
+    """A per-project or per-user folder between the root and the experiments is
+    the normal facility layout."""
+    root = str(tmp_path)
+    _write(root, "a-run", serial="SN-1", model="Arctis", subdir="project-x")
+
+    assert [e.name for e in discover_experiments(root)] == ["a-run"]
+
+
+def test_it_stops_at_the_depth_limit(tmp_path) -> None:
+    """Unbounded descent over a data drive is slow enough to look like a hang."""
+    root = str(tmp_path)
+    _write(root, "deep", serial="SN-1", model="Arctis", subdir="a/b/c/d")
+
+    assert discover_experiments(root, max_depth=2) == []
+    assert len(discover_experiments(root, max_depth=6)) == 1
+
+
+def test_a_root_that_is_not_there_returns_nothing(tmp_path) -> None:
+    """Pointing this at an unmounted drive is an ordinary mistake, and an empty
+    answer beats a traceback."""
+    assert discover_experiments(str(tmp_path / "not-mounted")) == []
+
+
+def test_one_bad_file_does_not_take_out_the_walk(tmp_path) -> None:
+    root = str(tmp_path)
+    _write(root, "fine", serial="SN-1", model="Arctis")
+    broken = tmp_path / "broken"
+    broken.mkdir()
+    (broken / "experiment.yaml").write_text("{{{ not yaml")
+
+    found = discover_experiments(root)
+
+    assert len(found) == 2
+    assert [e.name for e in found if not e.available] == ["broken"]
+
+
+# ---------------------------------------------------------------------------
+# Narrowing them
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("needle", ["SN-4471", "sn-4471", "Arctis", "arctis"])
+def test_instrument_matches_serial_or_model_either_case(facility, needle) -> None:
+    """A facility manager knows their instrument by whichever they use; making
+    them guess which one the flag wants is not worth a second flag."""
+    found = filter_experiments(discover_experiments(facility), instrument=needle)
+
+    assert {e.name for e in found} == {"arctis-monday", "arctis-friday"}
+
+
+def test_an_experiment_with_no_session_matches_no_instrument(facility) -> None:
+    """It is not evidence of the instrument you asked about. Folding unknowns in
+    is how a per-instrument total comes out wrong."""
+    found = filter_experiments(discover_experiments(facility), instrument="Arctis")
+
+    assert "before-sessions" not in {e.name for e in found}
+
+
+def test_it_filters_by_operator(facility) -> None:
+    found = filter_experiments(discover_experiments(facility), operator="colleague")
+
+    assert {e.name for e in found} == {"aquilos-run", "old-run"}
+
+
+def test_it_filters_to_a_time_window(facility) -> None:
+    """The question the issue is named for: what happened this week."""
+    week = time.time() - 7 * DAY
+    found = filter_experiments(discover_experiments(facility), since=week)
+
+    assert "old-run" not in {e.name for e in found}
+    assert len(found) == 4
+
+
+def test_since_and_until_bound_both_ends(facility) -> None:
+    found = filter_experiments(
+        discover_experiments(facility),
+        since=time.time() - 5 * DAY,
+        until=time.time() - 2 * DAY,
+    )
+
+    assert {e.name for e in found} == {"aquilos-run", "before-sessions"}
+
+
+def test_no_filters_changes_nothing(facility) -> None:
+    found = discover_experiments(facility)
+
+    assert filter_experiments(found) == found
+
+
+def test_the_instrument_and_the_week_compose(facility) -> None:
+    found = filter_experiments(
+        discover_experiments(facility),
+        instrument="SN-1102",
+        since=time.time() - 7 * DAY,
+    )
+
+    assert {e.name for e in found} == {"aquilos-run"}
+
+
+# ---------------------------------------------------------------------------
+# Grouping
+# ---------------------------------------------------------------------------
+
+
+def test_it_groups_by_serial_not_model(facility) -> None:
+    """Serial is what distinguishes two of the same model in one facility, which
+    is the case grouping exists for."""
+    grouped = group_by_instrument(discover_experiments(facility))
+
+    assert {e.name for e in grouped["SN-4471"]} == {"arctis-monday", "arctis-friday"}
+    assert {e.name for e in grouped["SN-1102"]} == {"aquilos-run", "old-run"}
+
+
+def test_unattributable_runs_get_their_own_bucket(facility) -> None:
+    """Worth seeing rather than hiding: it is how many runs cannot be attributed."""
+    grouped = group_by_instrument(discover_experiments(facility))
+
+    assert [e.name for e in grouped[None]] == ["before-sessions"]
+
+
+def test_grouping_nothing_gives_nothing() -> None:
+    assert group_by_instrument([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# The CLI's own argument handling
+# ---------------------------------------------------------------------------
+
+
+def test_days_and_since_together_is_rejected() -> None:
+    """Both set a lower bound. Silently letting one win would answer a different
+    question than the one asked."""
+    from argparse import Namespace
+
+    from fibsem.cli import _since_timestamp
+
+    with pytest.raises(ValueError, match="one or the other"):
+        _since_timestamp(Namespace(days=7, since="2026-08-01"))
+
+
+def test_neither_days_nor_since_means_no_lower_bound() -> None:
+    from argparse import Namespace
+
+    from fibsem.cli import _since_timestamp
+
+    assert _since_timestamp(Namespace(days=None, since=None)) is None
+
+
+def test_days_resolves_to_a_timestamp_in_the_past() -> None:
+    from argparse import Namespace
+
+    from fibsem.cli import _since_timestamp
+
+    since = _since_timestamp(Namespace(days=7, since=None))
+
+    assert time.time() - 8 * DAY < since < time.time() - 6 * DAY
+
+
+def test_the_summary_type_is_the_one_the_recents_list_uses() -> None:
+    """One type for both, so a facility listing and the load dialog cannot drift
+    into disagreeing about what an experiment says about itself."""
+    from typing import List, get_type_hints
+
+    from fibsem.config import get_recent_experiments
+
+    # get_type_hints, not raw __annotations__: one module uses postponed
+    # evaluation and the other does not, so the raw values are a string and a
+    # type and would never compare equal however aligned the code is.
+    expected = List[ExperimentSummary]
+    assert get_type_hints(get_recent_experiments)["return"] == expected
+    assert get_type_hints(discover_experiments)["return"] == expected
+    assert peek_experiment("/nowhere/experiment.yaml").__class__ is ExperimentSummary

--- a/tests/test_recent_experiments.py
+++ b/tests/test_recent_experiments.py
@@ -63,7 +63,7 @@ def test_record_ignores_empty_path(prefs_env):
 
 def test_peek_reads_display_metadata(prefs_env):
     path = _write_experiment(prefs_env / "meta", name="cool-experiment", created_at=1234.0, num_positions=3)
-    info = cfg._peek_experiment_yaml(path)
+    info = cfg.peek_experiment(path)
     assert info.name == "cool-experiment"
     assert info.created_at == 1234.0
     assert info.num_lamella == 3
@@ -73,7 +73,7 @@ def test_peek_reads_display_metadata(prefs_env):
 
 def test_peek_missing_file(prefs_env):
     path = str(prefs_env / "gone" / "experiment.yaml")
-    info = cfg._peek_experiment_yaml(path)
+    info = cfg.peek_experiment(path)
     assert info.exists is False
     assert info.available is False
     assert info.name == "gone"  # falls back to parent dir name
@@ -86,7 +86,7 @@ def test_peek_corrupt_file_is_unavailable_but_exists(prefs_env):
     with open(yaml_path, "w") as f:
         f.write("{ this is: not: valid yaml ]")
 
-    info = cfg._peek_experiment_yaml(yaml_path)
+    info = cfg.peek_experiment(yaml_path)
     assert info.exists is True       # kept, not silently pruned
     assert info.available is False   # flagged so the UI can grey it out
 


### PR DESCRIPTION
The facility-manager question is *"what did this microscope do this week?"*. Answering it needs something to group by and a way to find the experiments. The session record (FIB-451) gave the first; this gives the second.

Closes FIB-457. CLI only — a facility dashboard is a separate piece of work.

```
$ fibsem experiments --root /data --instrument arctis --days 7
  2026-08-04 16:23  arctis-friday      Arctis/SN-4471   Dr Someone     2 lamella
      /data/arctis-friday
  2026-07-30 16:23  arctis-monday      Arctis/SN-4471   Dr Someone     4 lamella
      /data/arctis-monday

2 experiment(s) in 1 location(s)
```

```
$ fibsem experiments --root /data --group

Arctis (SN-4471) — 2 experiment(s)
  ...
Aquilos (SN-1102) — 2 experiment(s)
  ...
No session recorded — 1 experiment(s)
  ...
```

`--root` (repeatable), `--recent`, `--instrument`, `--operator`, `--days` / `--since` / `--until`, `--group`. Takes no microscope, same as `plugins`: this is a question about files, usually asked away from the instrument.

`--instrument` matches the **serial number or the model**, either case. A facility manager knows their instrument by whichever they use, and making them guess which one the flag wants is not worth a second flag.

## The issue's premise was wrong — the index already exists

FIB-457 proposed building one. `user-preferences.yaml` has carried a recents list for a while, written on **both** create ([autolamella_create_experiment_widget.py:420](fibsem/ui/widgets/autolamella_create_experiment_widget.py:420)) and load, alongside `_peek_experiment_yaml` and a summary type. So its scale note — *"genuinely new work rather than promotion of existing data"* — is half wrong: the index is a promotion, the **query** is the new part.

It is capped at ten and lives inside the installed package, so it is neither complete nor durable. `--recent` includes it with that documented. Uncapping it before FIB-336 moves it would just make more state an upgrade destroys.

## Renames

`RecentExperimentInfo` → **`ExperimentSummary`**, `_peek_experiment_yaml` → **`peek_experiment`**. The type now describes a file nobody has opened, so the old name claimed something false. One type serves both the load dialog and the facility listing, pinned by a test (via `get_type_hints`, since the two modules differ on postponed evaluation) so they cannot drift into disagreeing about what an experiment says about itself.

It gained `instrument_serial`, `instrument_model`, `operator` and `software_version`, read from the session record at no extra cost — the file was already open and parsed.

## Three things the partial answer depends on

**Unattributable runs never fold into an instrument's totals.** An experiment with no session record — written before FIB-451, or adopted by nothing yet — matches no `--instrument` and no `--operator`, and gets its own group. Quietly including unknowns is how a per-instrument count comes out wrong.

**The walk prunes at an `experiment.yaml` and stops at depth 3.** Everything below one belongs to that experiment, so a nested run folder cannot be counted twice — and pruning keeps the walk off the image directories, which is most of the files on disk. Unbounded descent over a data drive is slow enough to look like a hang.

**Nothing raises.** A root that is not there warns and returns nothing (pointing this at an unmounted drive is an ordinary mistake). An unparseable `experiment.yaml` is listed and flagged rather than dropped, because a listing that silently omits what it could not read says "this never happened".

The command reports **how many locations it searched**. There is no global registry — experiments can be created anywhere and nothing records where — so an empty answer has to read as "not here", not "never happened".

## Scope

Phase 1: the query works against any root you point it at, plus the recents list. Deliberately no persistent index, because choosing a location before FIB-336 settles means choosing a path it will move. Phase 2 puts the index in the user-data directory, uncapped, so the answer is complete.

The SQLite option the issue raises is ruled out: that branch is deprecated and unused.

## Testing

`tests/autolamella/test_experiment_discovery.py` — 26 tests: reading a summary, pre-session and null-session files reading identically, an unreadable file surviving the walk, depth limiting, experiment pruning, each filter and their composition, grouping, and the CLI's `--days`/`--since` conflict.

- **3125 passed, 21 skipped** — full suite
- All changed files parse under 3.8 grammar
- `tests/test_recent_experiments.py` updated for the rename