### PR TITLE
[fm] Refuse a second FM acquisition, and gate the overview on stage pose (FIB-441, FIB-436)

### DIFF
--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -627,6 +627,17 @@ class FluorescenceMicroscope(ABC):
         ]  # valid orientations for fluorescence acquisition
         self._allow_unknown_orientations: bool = ALLOW_UNKNOWN_ORIENTATIONS
         self.default_orientation: str = "FM"  # orientation used when computing fluorescence pose for new lamellas
+        # Orientations the objective can actually image the sample from -- a stricter
+        # question than `valid_orientations`, which asks only whether FM control is
+        # allowed. Turning the light on and watching the camera from a beam pose is
+        # harmless and sometimes useful, so `valid_orientations` includes SEM and
+        # MILLING; driving the stage across a grid and stitching the result from one is
+        # not, since on a compustage the sample is flipped away from the objective there
+        # and on an offset mount it is translated out from under it.
+        #
+        # A list rather than `default_orientation` alone: a system whose objective sees
+        # the sample from more than one pose says so here, and has somewhere to say it.
+        self.acquisition_orientations: list[str] = [self.default_orientation]
 
     def has_valid_orientation(
         self, stage_position: Optional["FibsemStagePosition"] = None
@@ -636,6 +647,22 @@ class FluorescenceMicroscope(ABC):
             return True
         orientation = self.parent.get_stage_orientation(stage_position)
         return orientation in self.valid_orientations
+
+    def is_acquisition_orientation(
+        self, stage_position: Optional["FibsemStagePosition"] = None
+    ) -> bool:
+        """Return True if the objective can image the sample at the current (or given) pose.
+
+        The question anything that drives the stage should ask, and stricter than
+        `has_valid_orientation` in two ways: it asks the narrower
+        `acquisition_orientations`, and it has no `ALLOW_UNKNOWN_ORIENTATIONS` escape
+        hatch. The hatch exists so live FM control works from anywhere while a system is
+        being set up; an unrecognised pose is not an inconvenience to a tileset, which
+        would walk the stage across a grid and stitch the result against a frame nobody
+        has checked.
+        """
+        orientation = self.parent.get_stage_orientation(stage_position)
+        return orientation in self.acquisition_orientations
 
     def __repr__(self):
         """Return a string representation of the fluorescence microscope.

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -586,6 +586,10 @@ class FluorescenceMicroscope(ABC):
     # live acquisition signals (psygnal binds these per-instance on access)
     acquisition_signal = Signal(FluorescenceImage)
     acquisition_progress_signal = Signal(dict)
+    # Raised when something starts or stops driving the FM, so a widget that did not
+    # start it can grey its controls out. Emitted from whichever thread set the flag --
+    # connect with `@ensure_main_thread` if the slot touches widgets.
+    busy_changed = Signal(bool)
 
     def __init__(self, parent: Optional["FibsemMicroscope"] = None):
         """Initialize the fluorescence microscope with default components.
@@ -600,6 +604,10 @@ class FluorescenceMicroscope(ABC):
         # per-instance acquisition state (previously shared class attributes)
         self._stop_acquisition_event = threading.Event()
         self._acquisition_thread: Optional[threading.Thread] = None
+        # Something other than the live stream is driving the FM: an overview tileset,
+        # a z-stack, an autofocus sweep. Set by whoever is driving it. See `is_busy`.
+        self._busy: bool = False
+        self._busy_reason: str = ""
 
         self.channel_name: str = "channel-01"
         self.channel_color: str = "gray"
@@ -647,6 +655,38 @@ class FluorescenceMicroscope(ABC):
         if not self._acquisition_thread:
             return False
         return self._acquisition_thread and self._acquisition_thread.is_alive()
+
+    @property
+    def is_busy(self) -> bool:
+        """Whether anything is driving the FM: a live stream, or some other acquisition.
+
+        The question a widget deciding what to enable should be asking. `is_acquiring`
+        reports the live stream alone, which an overview tileset drops between every
+        pair of tiles while it moves the stage -- so a widget watching that flag sees an
+        idle microscope for most of somebody else's run (FIB-441).
+        """
+        return self.is_acquiring or self._busy
+
+    @property
+    def busy_reason(self) -> str:
+        """What is driving the FM, phrased for a warning, or "" if nothing is."""
+        if self._busy:
+            return self._busy_reason
+        if self.is_acquiring:
+            return "live acquisition"
+        return ""
+
+    def set_busy(self, busy: bool, reason: str = "") -> None:
+        """Mark the FM as driven, or not. Call in a `finally` when the work ends.
+
+        Args:
+            busy: Whether something is now driving the microscope.
+            reason: What it is, e.g. "overview acquisition". Shown to the user by
+                whatever gets refused, so it should read as a noun phrase.
+        """
+        self._busy = busy
+        self._busy_reason = reason if busy else ""
+        self.busy_changed.emit(self.is_busy)
 
     def set_channel(self, channel_settings: ChannelSettings):
         """Configure the microscope for a specific fluorescence channel.
@@ -991,6 +1031,10 @@ class FluorescenceMicroscope(ABC):
             target=self._acquisition_worker, args=(channel_settings,), daemon=True
         )
         self._acquisition_thread.start()
+        # A live stream makes the FM busy just as anything else does, so it announces
+        # itself the same way -- a widget deriving its controls from `is_busy` would
+        # otherwise notice tilesets and never notice streaming.
+        self.busy_changed.emit(self.is_busy)
 
     def stop_acquisition(self) -> None:
         """Stop the continuous live image acquisition.
@@ -1006,6 +1050,9 @@ class FluorescenceMicroscope(ABC):
             self._stop_acquisition_event.set()
             if self._acquisition_thread:
                 self._acquisition_thread.join(timeout=2)
+            # Asked rather than asserted: the join has a timeout, so a thread that has
+            # not stopped yet must not be announced as stopped.
+            self.busy_changed.emit(self.is_busy)
 
     def _acquisition_worker(self, channel_settings: Optional[ChannelSettings] = None):
         """Internal worker thread for continuous image acquisition.

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -660,7 +660,18 @@ class FluorescenceMicroscope(ABC):
         being set up; an unrecognised pose is not an inconvenience to a tileset, which
         would walk the stage across a grid and stitch the result against a frame nobody
         has checked.
+
+        Answers True unconditionally on an offset mount, where the question cannot be
+        asked: `_update_orientations` gives a non-compustage system an FM orientation
+        copied from its FIB one, so `get_stage_orientation` at the fluorescence position
+        returns a beam orientation -- measured, "MILLING", since the milling tilt band
+        matches first. It cannot tell a fluorescence position from a beam one at all,
+        which is the same limitation `build_lamella_poses` refuses over (FIB-93).
+        Refusing on a question with no answer is not a guard, it is a lockout: it would
+        leave the overview tab permanently dead on every METEOR.
         """
+        if not self.parent.stage_is_compustage:
+            return True
         orientation = self.parent.get_stage_orientation(stage_position)
         return orientation in self.acquisition_orientations
 

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1754,7 +1754,13 @@ class FibsemMicroscope(ABC):
         self.fm.objective.retract()  # retract objective (safety precaution)
 
         if target == "FIBSEM":
-            self.move_flat_to_beam(BeamType.ELECTRON) # or ION?
+            # The same move `move_flat_to_beam(BeamType.ELECTRON)` made -- the
+            # deprecated method's electron branch is `orientations["SEM"]` (measured:
+            # identical r, t and coordinate system on a compustage), and its one
+            # compustage special case applies to the ion beam only. `move_to_orientation`
+            # is now how the FM side reaches a beam pose, and the FM branch below has
+            # always gone through `get_orientation`.
+            self.move_to_orientation("SEM")
 
         if target == "FM":
             fm_orientation = self.get_orientation("FM")

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -1228,26 +1228,40 @@ class FMOverviewWidget(QWidget):
         # Not followed by a refresh: the move raises `stage_position_changed`, which
         # arrives at `_on_stage_moved` and re-derives everything the pose feeds.
 
-    def _refresh_orientation_banner(self) -> None:
-        """Say where the stage is, when it is not somewhere an overview can be acquired.
+    def _where_the_stage_is(self) -> str:
+        """The current orientation as a noun phrase, for a sentence.
 
-        Names every orientation that would do, not only the one the button goes to: on a
-        system configured for more than one the stage may already be a shorter move from
-        a different one, and a banner naming only `default_orientation` would be sending
-        the user further than they have to go.
+        "NONE" is what `get_stage_orientation` returns for a pose it cannot name, and
+        "the NONE orientation" is not a thing to say to anyone.
         """
+        orientation = self.microscope.get_stage_orientation()
+        if orientation == "NONE":
+            return "a position that is not a recognised orientation"
+        return f"the {orientation} orientation"
+
+    def _where_the_stage_needs_to_be(self) -> str:
+        """The orientations an overview may be acquired from, as a noun phrase.
+
+        Every one of them, not only the one the button goes to: on a system configured
+        for more than one the stage may already be a shorter move from a different one,
+        and naming only `default_orientation` would send the user further than they have
+        to go.
+        """
+        allowed = self.fm.acquisition_orientations
+        if len(allowed) == 1:
+            named = allowed[0]
+        else:
+            named = f"{', '.join(allowed[:-1])} or {allowed[-1]}"
+        return f"the {named} orientation"
+
+    def _refresh_orientation_banner(self) -> None:
+        """Say where the stage is, when it is not somewhere an overview can be acquired."""
         wrong = not self.at_acquisition_orientation()
         self.orientation_banner.setVisible(wrong)
         if wrong:
-            allowed = self.fm.acquisition_orientations
-            # "needs FM" reads better than "needs one of: FM", which is what a plain
-            # join gives on the single-orientation systems that are all of them today.
-            needed = (
-                allowed[0] if len(allowed) == 1 else f"one of: {', '.join(allowed)}"
-            )
             self.orientation_notice.setText(
-                f"Stage is at {self.microscope.get_stage_orientation()} — an overview "
-                f"needs {needed}."
+                f"Stage is at {self._where_the_stage_is()} — an overview needs to be at "
+                f"{self._where_the_stage_needs_to_be()}."
             )
             self.button_move_to_fm.setText(f"Move to {self.fm.default_orientation}")
 
@@ -1407,8 +1421,8 @@ class FMOverviewWidget(QWidget):
             return False
         if not self.at_acquisition_orientation():
             notification_service.show_toast(
-                f"Cannot move the stage from the "
-                f"{self.microscope.get_stage_orientation()} orientation.",
+                f"Cannot move the stage from {self._where_the_stage_is()} — the "
+                f"overview needs to be at {self._where_the_stage_needs_to_be()}.",
                 "warning",
             )
             return False
@@ -1713,15 +1727,14 @@ class FMOverviewWidget(QWidget):
         # pose -- the button is not the guard, and a host calling this directly, or a
         # stage that moved between the click and here, is exactly what this is for.
         if not self.at_acquisition_orientation():
-            orientation = self.microscope.get_stage_orientation()
-            allowed = ", ".join(self.fm.acquisition_orientations)
+            where, needed = self._where_the_stage_is(), self._where_the_stage_needs_to_be()
             logging.warning(
-                f"Cannot acquire an overview: the stage is at {orientation}, which is "
-                f"not one of {allowed}."
+                f"Cannot acquire an overview: the stage is at {where}, and an overview "
+                f"needs to be at {needed}."
             )
             notification_service.show_toast(
-                f"Move the stage to one of {allowed} before acquiring an overview "
-                f"(it is at {orientation}).",
+                f"Move the stage to {needed} before acquiring an overview "
+                f"(it is at {where}).",
                 "warning",
             )
             return

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -14,7 +14,6 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 from PyQt5.QtCore import QPoint, Qt, pyqtSignal
-from PyQt5.QtGui import QFontMetrics
 from PyQt5.QtWidgets import (
     QDialog,
     QHBoxLayout,
@@ -57,6 +56,7 @@ from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import TileGridOverlay
 from fibsem.ui.widgets.custom_widgets import (
     ContextMenu,
     ContextMenuConfig,
+    ElidedLabel,
     TitledPanel,
 )
 from fibsem.ui.widgets.progress_widget import (
@@ -88,48 +88,6 @@ def shrink_progress_text(progress: FibsemProgressWidget) -> FibsemProgressWidget
     progress.setStyleSheet(f"QProgressBar {{ font-size: {PROGRESS_FONT_PX}px; }}")
     progress.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
     return progress
-
-
-class ElidedLabel(QLabel):
-    """A label that shortens its text to fit, instead of forcing its parent wider.
-
-    A plain `QLabel` reports the full width of its text as its size hint, and in a
-    layout that hint becomes a minimum: a 132-character acquisition failure dragged this
-    widget's minimum width from 1030 px to 1728 px, so a message pushed the window
-    around. Here the text gives way instead.
-
-    `text()` still returns what was set, not what is drawn -- callers compare against it
-    to decide whether the line is theirs to overwrite, and eliding is presentation.
-    """
-
-    def __init__(self, text: str = "", parent: Optional[QWidget] = None) -> None:
-        super().__init__(parent)
-        self._full_text = ""
-        # Ignored horizontally: the label neither asks for room nor refuses to shrink,
-        # which is the whole point -- its content must not set anyone's minimum.
-        self.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
-        self.setText(text)
-
-    def setText(self, text: Optional[str]) -> None:
-        self._full_text = text or ""
-        # The full message, for anything too long to show. Set before the caller gets a
-        # chance to override it: `_finish` follows its own `setText` with a tooltip of
-        # its own, and that one should win.
-        self.setToolTip(self._full_text)
-        self._elide()
-
-    def text(self) -> str:
-        return self._full_text
-
-    def resizeEvent(self, event) -> None:
-        super().resizeEvent(event)
-        self._elide()
-
-    def _elide(self) -> None:
-        metrics = QFontMetrics(self.font())
-        super().setText(
-            metrics.elidedText(self._full_text, Qt.ElideRight, max(0, self.width() - 2))
-        )
 
 
 # Key the in-progress mosaic is drawn under. Distinct from a finished overview's

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -1163,19 +1163,29 @@ class FMOverviewWidget(QWidget):
 
     # ── stage orientation ────────────────────────────────────────────────
 
-    def at_fm_orientation(self) -> bool:
-        """Whether the stage is posed for fluorescence acquisition.
+    def at_acquisition_orientation(self) -> bool:
+        """Whether the stage is somewhere the objective can image the sample from.
 
-        Asked of `fm.default_orientation` rather than a constant of our own, because
-        that is the orientation `build_lamella_poses` derives a fluorescence pose
-        *into*. Two names for the same thing could drift; one cannot.
+        `fm.acquisition_orientations`, and not a single pose of our own choosing: a
+        system whose objective sees the sample from more than one orientation says so
+        there, and hard-coding one here would lock the other out.
 
-        Not `fm.has_valid_orientation()`, which asks a looser question -- whether FM
-        acquisition is allowed at all, which SEM and MILLING both are -- and which
-        `ALLOW_UNKNOWN_ORIENTATIONS` currently answers yes to unconditionally. An
-        overview is not merely unhelpful from the wrong pose: the canvas frame is built
-        from the origin's rotation and tilt (see `_posed`), so the tiles would be placed
-        against a projection that does not describe them.
+        Not `fm.has_valid_orientation()`, which asks the looser question of whether FM
+        *control* is allowed -- true at SEM and MILLING, where a compustage has flipped
+        the sample away from the objective -- and which `ALLOW_UNKNOWN_ORIENTATIONS`
+        answers yes to unconditionally anyway. The canvas frame is built from the pose
+        (see `_posed`), so tiles acquired somewhere the code cannot name are placed
+        against a projection nobody has checked.
+        """
+        return self.fm.is_acquisition_orientation()
+
+    def at_fluorescence_pose(self) -> bool:
+        """Whether the stage is at *the* fluorescence orientation, not merely a workable one.
+
+        Stricter than `at_acquisition_orientation`, and asked only where something is written
+        down. Asked of `fm.default_orientation` because that is the orientation
+        `build_lamella_poses` derives a fluorescence pose *into*: two names for the same
+        thing could drift, one cannot.
         """
         return self.microscope.get_stage_orientation() == self.fm.default_orientation
 
@@ -1219,13 +1229,25 @@ class FMOverviewWidget(QWidget):
         # arrives at `_on_stage_moved` and re-derives everything the pose feeds.
 
     def _refresh_orientation_banner(self) -> None:
-        """Say where the stage is, when it is not where an overview needs it."""
-        wrong = not self.at_fm_orientation()
+        """Say where the stage is, when it is not somewhere an overview can be acquired.
+
+        Names every orientation that would do, not only the one the button goes to: on a
+        system configured for more than one the stage may already be a shorter move from
+        a different one, and a banner naming only `default_orientation` would be sending
+        the user further than they have to go.
+        """
+        wrong = not self.at_acquisition_orientation()
         self.orientation_banner.setVisible(wrong)
         if wrong:
+            allowed = self.fm.acquisition_orientations
+            # "needs FM" reads better than "needs one of: FM", which is what a plain
+            # join gives on the single-orientation systems that are all of them today.
+            needed = (
+                allowed[0] if len(allowed) == 1 else f"one of: {', '.join(allowed)}"
+            )
             self.orientation_notice.setText(
-                f"Stage is at {self.microscope.get_stage_orientation()} — "
-                f"{self.fm.default_orientation} is needed to acquire an overview."
+                f"Stage is at {self.microscope.get_stage_orientation()} — an overview "
+                f"needs {needed}."
             )
             self.button_move_to_fm.setText(f"Move to {self.fm.default_orientation}")
 
@@ -1371,16 +1393,23 @@ class FMOverviewWidget(QWidget):
     def _may_move(self) -> bool:
         """Whether driving the stage from this tab is allowed right now, and say if not.
 
-        Deliberately not gated on the orientation. Moving works from any pose: the whole
-        scene -- images, markers, grid -- is re-placed through the pose the stage is in
-        (see `_posed`), so a click still lands on the feature it points at. What used to
-        be here asked `fm.has_valid_orientation()`, which `ALLOW_UNKNOWN_ORIENTATIONS`
-        answers yes to unconditionally -- so it refused nothing, and would have refused
-        the wrong thing if it ever started working (FIB-436).
+        The orientation check here used to be `fm.has_valid_orientation()`, which
+        `ALLOW_UNKNOWN_ORIENTATIONS` answers yes to unconditionally -- so it refused
+        nothing. It now asks the same question with the escape hatch off, which is what
+        it was always meant to mean: a click is a stage move computed through a frame
+        built from the current pose, and from a pose the code cannot name there is
+        nothing that has checked where it would send the stage (FIB-436).
         """
         if self.is_acquiring:
             notification_service.show_toast(
                 "Cannot move the stage during an acquisition.", "warning"
+            )
+            return False
+        if not self.at_acquisition_orientation():
+            notification_service.show_toast(
+                f"Cannot move the stage from the "
+                f"{self.microscope.get_stage_orientation()} orientation.",
+                "warning",
             )
             return False
         return True
@@ -1442,11 +1471,11 @@ class FMOverviewWidget(QWidget):
                 "Cannot mark positions while an acquisition is running.", "warning"
             )
             return None
-        # Stricter than the double-click's check, and deliberately so -- see `_may_move`
-        # for why moving is allowed from anywhere. Marking has to survive being written
-        # down: the position becomes a lamella's *fluorescence* pose, and one carrying
-        # SEM rotation and tilt is not one, however right it looked on screen.
-        if not self.at_fm_orientation():
+        # Stricter than the double-click's check, and deliberately so. Moving needs only
+        # a pose the FM can work from; marking has to survive being written down, since
+        # the position becomes a lamella's *fluorescence* pose -- and one carrying SEM
+        # rotation and tilt is not one, however right it looked on screen.
+        if not self.at_fluorescence_pose():
             notification_service.show_toast(
                 f"Move to the fluorescence position before marking on the overview "
                 f"(the stage is at {self.microscope.get_stage_orientation()}).",
@@ -1649,7 +1678,9 @@ class FMOverviewWidget(QWidget):
         # overview that has already been acquired is harmless wherever the stage is, and
         # the settings panel stays editable so a run can be set up while the stage is on
         # its way (FIB-436).
-        self.button_acquire.setEnabled(idle and has_tiles and self.at_fm_orientation())
+        self.button_acquire.setEnabled(
+            idle and has_tiles and self.at_acquisition_orientation()
+        )
         # Cancel is deliberately not gated on `_interactive`: a host locking the tab
         # mid-run must not take away the only way to stop the stage. Once a cancel has
         # been asked for, the button goes and stays away -- the stop event is the record
@@ -1681,15 +1712,16 @@ class FMOverviewWidget(QWidget):
         # Not only on the button, which `_apply_enabled_state` disables from the wrong
         # pose -- the button is not the guard, and a host calling this directly, or a
         # stage that moved between the click and here, is exactly what this is for.
-        if not self.at_fm_orientation():
+        if not self.at_acquisition_orientation():
             orientation = self.microscope.get_stage_orientation()
+            allowed = ", ".join(self.fm.acquisition_orientations)
             logging.warning(
-                f"Cannot acquire an overview: the stage is at {orientation}, not "
-                f"{self.fm.default_orientation}."
+                f"Cannot acquire an overview: the stage is at {orientation}, which is "
+                f"not one of {allowed}."
             )
             notification_service.show_toast(
-                f"Move the stage to {self.fm.default_orientation} before acquiring an "
-                f"overview (it is at {orientation}).",
+                f"Move the stage to one of {allowed} before acquiring an overview "
+                f"(it is at {orientation}).",
                 "warning",
             )
             return

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -19,6 +19,7 @@ from PyQt5.QtWidgets import (
     QDialog,
     QHBoxLayout,
     QLabel,
+    QMessageBox,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -188,6 +189,9 @@ class FMOverviewWidget(QWidget):
     # Same hop for stage moves: `stage_position_changed` is a psygnal, so it fires
     # on whichever thread moved the stage -- a worker, during an acquisition.
     _stage_moved = pyqtSignal(object)
+    # And for the FM being taken or given back by somebody else, which is cleared from
+    # whichever thread finished with it -- for our own runs, the acquisition worker.
+    _fm_busy_changed = pyqtSignal(bool)
 
     def __init__(
         self,
@@ -254,7 +258,10 @@ class FMOverviewWidget(QWidget):
         # match it at disconnect time -- and says nothing when the disconnect therefore
         # removes nothing. Emitting into a widget Qt had already torn down was a segfault.
         self.microscope.stage_position_changed.connect(self._on_stage_signal)
+        self._fm_busy_changed.connect(self._on_fm_busy_changed)
+        self.fm.busy_changed.connect(self._on_fm_busy_signal)
         self._refresh_current_position()
+        self._refresh_orientation_banner()
 
     def _default_channels(self) -> List[ChannelSettings]:
         """The saved FM configuration if there is one, otherwise a single channel."""
@@ -397,6 +404,29 @@ class FMOverviewWidget(QWidget):
         self.status = ElidedLabel("")
         self.status.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px;")
 
+        # Shown only when the stage is somewhere an overview cannot be acquired from.
+        # A line saying what is wrong and a button that fixes it, rather than a greyed
+        # Acquire button with no explanation -- which is what the old FM tab did, and
+        # which leaves you looking at a dead panel (FIB-436).
+        self.orientation_notice = ElidedLabel("")
+        self.orientation_notice.setStyleSheet(
+            f"color: {stylesheets.WARN_COLOR}; font-size: 11px;"
+        )
+        # Labelled in `_refresh_orientation_banner`, from the same `default_orientation`
+        # the move targets -- the control widget lets that be changed at runtime, and a
+        # button naming one orientation while going to another is worse than no button.
+        self.button_move_to_fm = QPushButton()
+        self.button_move_to_fm.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.button_move_to_fm.clicked.connect(self.move_to_fm_orientation)
+
+        self.orientation_banner = QWidget()
+        banner_layout = QHBoxLayout(self.orientation_banner)
+        banner_layout.setContentsMargins(0, 0, 0, 0)
+        banner_layout.setSpacing(6)
+        banner_layout.addWidget(self.orientation_notice, stretch=1)
+        banner_layout.addWidget(self.button_move_to_fm)
+        self.orientation_banner.setVisible(False)
+
         self.button_acquire = QPushButton("Acquire Overview")
         self.button_acquire.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
         self.button_acquire.setMinimumHeight(30)
@@ -426,6 +456,7 @@ class FMOverviewWidget(QWidget):
         actions_layout.setContentsMargins(8, 4, 8, 8)
         actions_layout.setSpacing(5)
         actions_layout.addWidget(self.status)
+        actions_layout.addWidget(self.orientation_banner)
         actions_layout.addWidget(self.progress_tiles)
         actions_layout.addWidget(self.progress_tile_detail)
         actions_layout.addWidget(buttons)
@@ -1130,6 +1161,88 @@ class FMOverviewWidget(QWidget):
             selected_points, labels=selected_labels
         )
 
+    # ── stage orientation ────────────────────────────────────────────────
+
+    def at_fm_orientation(self) -> bool:
+        """Whether the stage is posed for fluorescence acquisition.
+
+        Asked of `fm.default_orientation` rather than a constant of our own, because
+        that is the orientation `build_lamella_poses` derives a fluorescence pose
+        *into*. Two names for the same thing could drift; one cannot.
+
+        Not `fm.has_valid_orientation()`, which asks a looser question -- whether FM
+        acquisition is allowed at all, which SEM and MILLING both are -- and which
+        `ALLOW_UNKNOWN_ORIENTATIONS` currently answers yes to unconditionally. An
+        overview is not merely unhelpful from the wrong pose: the canvas frame is built
+        from the origin's rotation and tilt (see `_posed`), so the tiles would be placed
+        against a projection that does not describe them.
+        """
+        return self.microscope.get_stage_orientation() == self.fm.default_orientation
+
+    def move_to_fm_orientation(self) -> None:
+        """Drive the stage to the fluorescence orientation, having asked first.
+
+        A real stage move, so it gets the same confirmation as the other moves in this
+        widget -- and the same worker, since `move_to_microscope` blocks for as long as
+        the stage takes.
+        """
+        if self._running or self.fm.is_busy:
+            notification_service.show_toast(
+                "Cannot move the stage during an acquisition.", "warning"
+            )
+            return
+        orientation = self.fm.default_orientation
+        reply = QMessageBox.question(
+            self,
+            "Confirm Movement",
+            f"Move the stage to the {orientation} orientation?\n\n"
+            f"The stage is currently at {self.microscope.get_stage_orientation()}.",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if reply != QMessageBox.Yes:
+            logging.info("Move to FM orientation cancelled by user")
+            return
+
+        self.status.setText(f"Moving to {orientation}…")
+        worker = FunctionWorker(self._move_to_orientation_worker, orientation)
+        worker.start()
+
+    def _move_to_orientation_worker(self, orientation: str) -> None:
+        """Runs off the GUI thread. Only signals may cross back."""
+        try:
+            self.microscope.move_to_microscope(orientation)
+            logging.info(f"Moved to {orientation} orientation")
+        except Exception as e:
+            logging.error(f"Failed to move to {orientation} orientation: {e}")
+        # Not followed by a refresh: the move raises `stage_position_changed`, which
+        # arrives at `_on_stage_moved` and re-derives everything the pose feeds.
+
+    def _refresh_orientation_banner(self) -> None:
+        """Say where the stage is, when it is not where an overview needs it."""
+        wrong = not self.at_fm_orientation()
+        self.orientation_banner.setVisible(wrong)
+        if wrong:
+            self.orientation_notice.setText(
+                f"Stage is at {self.microscope.get_stage_orientation()} — "
+                f"{self.fm.default_orientation} is needed to acquire an overview."
+            )
+            self.button_move_to_fm.setText(f"Move to {self.fm.default_orientation}")
+
+    def _on_fm_busy_signal(self, busy: bool) -> None:
+        """Called by psygnal, on whichever thread started or stopped. No widgets here."""
+        self._fm_busy_changed.emit(busy)
+
+    def _on_fm_busy_changed(self, busy: bool) -> None:
+        """Something started driving the fluorescence microscope, or stopped.
+
+        Only the controls need to know. Whether the FM is busy is not this widget's
+        state -- it is a fact about the microscope that `_apply_enabled_state` reads,
+        alongside the two that *are* this widget's -- so there is nothing to store here,
+        only a reason to re-derive.
+        """
+        self._apply_enabled_state()
+
     # ── canvas interaction ───────────────────────────────────────────────
 
     def _on_stage_signal(self, position: FibsemStagePosition) -> None:
@@ -1159,6 +1272,10 @@ class FMOverviewWidget(QWidget):
         if reposed:
             self._refresh_positions()
             self._refresh_stage_metadata()
+            # The orientation is read off rotation and tilt, so it can only have changed
+            # when they did -- the same reason the redraws above are gated on it.
+            self._refresh_orientation_banner()
+            self._apply_enabled_state()
         # The grid follows the stage only when it is not pinned to a target and not
         # mid-run. During a run the stage visits every tile in turn, and a grid that
         # followed would crawl across the canvas describing nothing.
@@ -1252,17 +1369,18 @@ class FMOverviewWidget(QWidget):
         self.move_to(target)
 
     def _may_move(self) -> bool:
-        """Whether driving the stage from this tab is allowed right now, and say if not."""
+        """Whether driving the stage from this tab is allowed right now, and say if not.
+
+        Deliberately not gated on the orientation. Moving works from any pose: the whole
+        scene -- images, markers, grid -- is re-placed through the pose the stage is in
+        (see `_posed`), so a click still lands on the feature it points at. What used to
+        be here asked `fm.has_valid_orientation()`, which `ALLOW_UNKNOWN_ORIENTATIONS`
+        answers yes to unconditionally -- so it refused nothing, and would have refused
+        the wrong thing if it ever started working (FIB-436).
+        """
         if self.is_acquiring:
             notification_service.show_toast(
                 "Cannot move the stage during an acquisition.", "warning"
-            )
-            return False
-        if not self.fm.has_valid_orientation():
-            notification_service.show_toast(
-                f"Stage must be in a valid FM orientation to move via the overview "
-                f"(currently {self.microscope.get_stage_orientation()}).",
-                "warning",
             )
             return False
         return True
@@ -1324,25 +1442,14 @@ class FMOverviewWidget(QWidget):
                 "Cannot mark positions while an acquisition is running.", "warning"
             )
             return None
-        # Stricter than the double-click's check, and deliberately so. Moving works from
-        # any pose: the whole scene -- images, markers, grid -- is re-placed through the
-        # pose the stage is in (see `_posed`), so a click still lands on the feature it
-        # points at. Marking has to survive being written down: the position becomes a
-        # lamella's *fluorescence* pose, and one carrying SEM rotation and tilt is not
-        # one, however right it looked on screen.
-        #
-        # `fm.has_valid_orientation()` is the wrong question here -- it asks whether FM
-        # acquisition is allowed, which SEM and MILLING both are, and which
-        # `ALLOW_UNKNOWN_ORIENTATIONS` currently answers yes to unconditionally.
-        #
-        # Asked of `fm.default_orientation` rather than a constant of our own, because
-        # that is the orientation `build_lamella_poses` derives a fluorescence pose
-        # *into*. Two names for the same thing could drift; one cannot.
-        orientation = self.microscope.get_stage_orientation()
-        if orientation != self.fm.default_orientation:
+        # Stricter than the double-click's check, and deliberately so -- see `_may_move`
+        # for why moving is allowed from anywhere. Marking has to survive being written
+        # down: the position becomes a lamella's *fluorescence* pose, and one carrying
+        # SEM rotation and tilt is not one, however right it looked on screen.
+        if not self.at_fm_orientation():
             notification_service.show_toast(
                 f"Move to the fluorescence position before marking on the overview "
-                f"(the stage is at {orientation}).",
+                f"(the stage is at {self.microscope.get_stage_orientation()}).",
                 "warning",
             )
             return None
@@ -1523,18 +1630,26 @@ class FMOverviewWidget(QWidget):
             self.status.setText("")
 
     def _apply_enabled_state(self) -> None:
-        """One place decides what is clickable, from three independent facts.
+        """One place decides what is clickable, from five independent facts.
 
-        A run in progress, a host that has locked the tab, and a grid with nothing
-        selected each disable different things, and they overlap: a workflow finishing
-        while an overview runs must not re-enable Acquire, and a run finishing inside a
-        locked tab must not either. Two places each setting the buttons from their own
-        half of the truth is how a control gets stuck; deriving all of it from all three
-        every time is the version that cannot.
+        A run in progress, a host that has locked the tab, something else driving the
+        FM, a stage posed somewhere an overview cannot be acquired from, and a grid with
+        nothing selected each disable different things, and they overlap: a workflow
+        finishing while an overview runs must not re-enable Acquire, and a run finishing
+        inside a locked tab must not either. Two places each setting the buttons from
+        their own half of the truth is how a control gets stuck; deriving all of it from
+        all five every time is the version that cannot.
+
+        `fm.is_busy` covers this widget's own run too, since it sets the flag for the
+        length of one -- harmless, because `_running` is true throughout that.
         """
-        idle = self._interactive and not self._running
+        idle = self._interactive and not self._running and not self.fm.is_busy
         has_tiles = self.settings_widget.parameters.n_enabled_tiles > 0
-        self.button_acquire.setEnabled(idle and has_tiles)
+        # Acquisition only. Display and navigation stay live from any pose: looking at an
+        # overview that has already been acquired is harmless wherever the stage is, and
+        # the settings panel stays editable so a run can be set up while the stage is on
+        # its way (FIB-436).
+        self.button_acquire.setEnabled(idle and has_tiles and self.at_fm_orientation())
         # Cancel is deliberately not gated on `_interactive`: a host locking the tab
         # mid-run must not take away the only way to stop the stage. Once a cancel has
         # been asked for, the button goes and stays away -- the stop event is the record
@@ -1550,8 +1665,33 @@ class FMOverviewWidget(QWidget):
         if self.is_acquiring:
             logging.warning("An overview acquisition is already running.")
             return
-        if self.fm.is_acquiring:
-            logging.warning("Stop live acquisition before acquiring an overview.")
+        # `is_busy`, not `is_acquiring`. The latter reports the live stream alone, so a
+        # z-stack or an autofocus sweep running in the control widget was invisible
+        # here -- and this widget's own tileset was invisible to that one, which is the
+        # direction that mattered (FIB-441).
+        if self.fm.is_busy:
+            reason = self.fm.busy_reason or "another acquisition"
+            logging.warning(f"Cannot acquire an overview: the FM is in use ({reason}).")
+            notification_service.show_toast(
+                f"The fluorescence microscope is in use ({reason}). "
+                f"Wait for it to finish before acquiring an overview.",
+                "warning",
+            )
+            return
+        # Not only on the button, which `_apply_enabled_state` disables from the wrong
+        # pose -- the button is not the guard, and a host calling this directly, or a
+        # stage that moved between the click and here, is exactly what this is for.
+        if not self.at_fm_orientation():
+            orientation = self.microscope.get_stage_orientation()
+            logging.warning(
+                f"Cannot acquire an overview: the stage is at {orientation}, not "
+                f"{self.fm.default_orientation}."
+            )
+            notification_service.show_toast(
+                f"Move the stage to {self.fm.default_orientation} before acquiring an "
+                f"overview (it is at {orientation}).",
+                "warning",
+            )
             return
 
         parameters = self.settings_widget.parameters
@@ -1581,6 +1721,10 @@ class FMOverviewWidget(QWidget):
         # Claimed on the GUI thread, before the worker starts: it makes a directory, so
         # an unwritable path is reported now rather than after the stage has moved.
         self._destination = self._claim_destination()
+
+        # Held for the length of the run, so nothing else drives the FM while the stage
+        # is walking the grid. Cleared in the worker's `finally` (FIB-441).
+        self.fm.set_busy(True, "overview acquisition")
 
         self._stop_event.clear()
         self._set_running(True)
@@ -1647,6 +1791,12 @@ class FMOverviewWidget(QWidget):
             self.fm.acquisition_progress_signal.emit(
                 {"state": "overview-failed", "task": "tileset", "error": str(e)}
             )
+        finally:
+            # A run that ends still marked busy leaves the FM unusable for the rest of
+            # the session, with nothing on screen to say why -- so this goes in a
+            # `finally` rather than after the emits, and stays right if a future edit
+            # narrows one of the `except` clauses above.
+            self.fm.set_busy(False)
 
     def cancel(self) -> None:
         if not self.is_acquiring:

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -1219,28 +1219,55 @@ def style_with_tooltip(widget: QWidget, css: str) -> None:
 class ElidedLabel(QLabel):
     """A QLabel that elides rather than clipping mid-glyph.
 
-    For a column that stretches, where the width is not known when the row is
-    built and any one-off elide would be wrong at the next size. The size policy
-    is Ignored so long unbreakable text -- a dotted class path, a file path --
-    cannot drive the column wider, which would defeat the point.
+    For a column that stretches, where the width is not known when the row is built and
+    any one-off elide would be wrong at the next size. The size policy is Ignored so long
+    unbreakable text -- a dotted class path, a file path, a 132-character acquisition
+    failure -- cannot drive the column wider, which would defeat the point. One such
+    message dragged the FM overview's minimum width from 1030 px to 1728 px.
+
+    `text()` returns what was set, not what is drawn: callers compare against it to
+    decide whether the line is theirs to overwrite, and eliding is presentation. The
+    tooltip carries the whole string, which is the only way to read one that does not
+    fit; a caller wanting a different tooltip sets it after `setText`.
     """
 
-    def __init__(self, text: str, parent: Optional[QWidget] = None) -> None:
-        super().__init__(text, parent)
-        self._full_text = text
+    def __init__(self, text: str = "", parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._full_text = ""
+        # Ignored horizontally: the label neither asks for room nor refuses to shrink,
+        # which is the whole point -- its content must not set anyone's minimum.
         self.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
+        self.setText(text)
+
+    def setText(self, text: Optional[str]) -> None:  # noqa: N802 - Qt naming
+        self._full_text = text or ""
+        self.setToolTip(self._full_text)
+        self._elide()
+
+    def text(self) -> str:
+        return self._full_text
+
+    def resizeEvent(self, event) -> None:  # noqa: N802 - Qt naming
+        super().resizeEvent(event)
+        self._elide()
 
     def paintEvent(self, event) -> None:  # noqa: N802 - Qt naming
-        # At paint time the width is always the real one. Doing this on resize
-        # instead misses a label that is laid out at its final size and never
-        # resized, which then clips. Re-eliding from _full_text rather than from
-        # the displayed text keeps it stable: setText schedules one more paint,
-        # the second computes the same string, and it settles.
-        metrics = QFontMetrics(self.font())
-        elided = metrics.elidedText(self._full_text, Qt.ElideRight, self.width())
-        if elided != self.text():
-            self.setText(elided)  # QLabel draws it, so the stylesheet colour survives
+        # Belt and braces with the resize: a label laid out at its final size and never
+        # resized after would otherwise keep whatever `setText` computed from a width it
+        # did not yet have, and clip.
+        self._elide()
         super().paintEvent(event)
+
+    def _elide(self) -> None:
+        metrics = QFontMetrics(self.font())
+        elided = metrics.elidedText(
+            self._full_text, Qt.ElideRight, max(0, self.width() - 2)
+        )
+        # `super().text()`, not ours: ours returns the full string, so this would differ
+        # on every paint of an elided label and schedule another one forever. QLabel
+        # draws the elided string, so the stylesheet colour survives.
+        if elided != super().text():
+            super().setText(elided)
 
 
 def chip(text: str, colour: str, font_size: int = 11) -> QLabel:

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -1860,6 +1860,17 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
                 stylesheets.SECONDARY_BUTTON_STYLESHEET
             )
         else:
+            # The third place in the app that can start a live stream, and so the third
+            # that has to ask whether the microscope is free -- an overview tileset does
+            # not show up in `is_acquiring` (FIB-441).
+            if fm.is_busy:
+                QMessageBox.warning(
+                    self,
+                    "Fluorescence Microscope In Use",
+                    f"The fluorescence microscope is in use ({fm.busy_reason}).\n\n"
+                    f"Wait for it to finish before starting acquisition.",
+                )
+                return
             selected_channel_settings = self.fm_channel_widget.selected_channel
             if selected_channel_settings is None:
                 QMessageBox.warning(

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -290,6 +290,7 @@ class FMControlWidget(QWidget):
         self.fm.acquisition_signal.connect(self.update_image)
         self.acquisition_finished_signal.connect(self._on_acquisition_finished)
         self.fm.acquisition_progress_signal.connect(self._on_acquisition_progress)
+        self.fm.busy_changed.connect(self._on_fm_busy_changed)
 
         # live parameter updates from channel list
         self.channelSettingsWidget.channel_field_changed.connect(
@@ -588,6 +589,32 @@ class FMControlWidget(QWidget):
             )
             self.viewer.reset_view()
 
+    def _refuse_if_fm_busy(self, what: str) -> bool:
+        """Whether the FM is already in use, having logged why. True means "do not start".
+
+        Asks the microscope, not just this widget. `self.is_acquiring` sees the live
+        stream and this widget's own worker; it cannot see the overview tab's tileset,
+        which drops the stream between every pair of tiles while the stage moves -- so a
+        live stream could be started mid-run, and the remaining tiles would land at
+        whatever settings it applied on the way past (FIB-441).
+        """
+        if not (self.is_acquiring or self.fm.is_busy):
+            return False
+        reason = self.fm.busy_reason or "another acquisition"
+        logging.warning(
+            f"Cannot start {what}: the fluorescence microscope is in use ({reason})."
+        )
+        return True
+
+    @ensure_main_thread
+    def _on_fm_busy_changed(self, busy: bool) -> None:
+        """Something started driving the FM, or stopped -- re-derive what is clickable.
+
+        Marshalled, because the flag is cleared on whichever thread finished with the
+        instrument, and this ends in `setEnabled` calls.
+        """
+        self._update_acquisition_button_states()
+
     def start_acquisition(self):
         """Start the fluorescence acquisition."""
 
@@ -595,8 +622,7 @@ class FMControlWidget(QWidget):
             logging.warning(f"Stage is not in a valid FM orientation. Cannot start acquisition (current: {self.microscope.get_stage_orientation()})")
             return
 
-        if self.is_acquiring:
-            logging.warning("Another acquisition is already in progress.")
+        if self._refuse_if_fm_busy("live acquisition"):
             return
 
         # Get current settings
@@ -783,8 +809,7 @@ class FMControlWidget(QWidget):
     def acquire_image(self):
         """Start threaded image acquisition using the current Z parameters and channel settings."""
 
-        if self.is_acquiring:
-            logging.warning("Another acquisition is already in progress.")
+        if self._refuse_if_fm_busy("image acquisition"):
             return
 
         logging.info("Starting image acquisition")
@@ -813,6 +838,11 @@ class FMControlWidget(QWidget):
             return
 
         record_recent_channels(channel_settings)
+
+        # Marked busy as late as possible: everything above can still abort -- the
+        # filename step opens a modal -- and an abort leaving the flag set would lock
+        # out the overview tab with nothing running.
+        self.fm.set_busy(True, "z-stack" if z_parameters else "image acquisition")
 
         # Start acquisition thread
         self._acquisition_thread = FunctionWorker(
@@ -854,6 +884,7 @@ class FMControlWidget(QWidget):
             logging.error(f"Error during image acquisition: {e}")
 
         finally:
+            self.fm.set_busy(False)
             self.acquisition_finished_signal.emit()
 
     def _update_acquisition_button_states(self):
@@ -865,8 +896,12 @@ class FMControlWidget(QWidget):
             self.pushButton_cancel_acquisition.setEnabled(False)
             return
 
-        # Check if any acquisition is active (live or specific acquisitions)
-        any_acquisition_active = self.is_acquiring or self.is_acquisition_active
+        # Check if any acquisition is active (live or specific acquisitions), here or
+        # anywhere else on this microscope -- `fm.is_busy` is what covers the overview
+        # tab, whose tileset this widget has no other way of seeing.
+        any_acquisition_active = (
+            self.is_acquiring or self.fm.is_busy or self.is_acquisition_active
+        )
 
         # Special case buttons with unique behavior
         self.pushButton_cancel_acquisition.setVisible(self.is_acquisition_active)
@@ -876,6 +911,15 @@ class FMControlWidget(QWidget):
             self.pushButton_toggle_acquisition.setText("Stop Acquisition")
         else:
             self.pushButton_toggle_acquisition.setText("Start Acquisition")
+
+        # Clickable while the live stream *is* what is running -- it is the only way to
+        # stop one -- but not while anything else has the microscope. This is the button
+        # FIB-441 is about: it was the one thing that stayed live through an overview
+        # run, and starting a stream mid-tileset changes the settings the remaining
+        # tiles are acquired at.
+        self.pushButton_toggle_acquisition.setEnabled(
+            self.fm.is_acquiring or not any_acquisition_active
+        )
 
         # Enable/disable standard buttons based on acquisition state
         for button in (
@@ -906,10 +950,7 @@ class FMControlWidget(QWidget):
 
     def run_autofocus(self):
         """Start threaded auto-focus using the current channel settings and Z parameters."""
-        if self.is_acquiring:
-            logging.warning(
-                "Cannot run auto-focus while another acquisition is in progress. Stop acquisition first."
-            )
+        if self._refuse_if_fm_busy("auto-focus"):
             return
 
         logging.info("Starting auto-focus")
@@ -922,6 +963,8 @@ class FMControlWidget(QWidget):
         settings = self._get_current_settings()
         channel_settings = settings["selected_channel_settings"]
         autofocus_settings = settings["autofocus_settings"]
+
+        self.fm.set_busy(True, "auto-focus")
 
         # Start auto-focus thread
         self._acquisition_thread = FunctionWorker(
@@ -966,6 +1009,7 @@ class FMControlWidget(QWidget):
         except Exception as e:
             logging.error(f"Auto-focus failed: {e}")
         finally:
+            self.fm.set_busy(False)
             self.acquisition_finished_signal.emit()
 
     def closeEvent(self, event: QEvent):

--- a/fibsem/ui/widgets/plugins_dialog.py
+++ b/fibsem/ui/widgets/plugins_dialog.py
@@ -269,6 +269,11 @@ class PluginsDialog(QDialog):
         layout.addWidget(name)
         layout.addWidget(detail)
         widget.setToolTip(_tooltip(extension))
+        # `ElidedLabel` gives itself one of its own full text, which is right where a
+        # label is on its own and wrong here: a child's tooltip shadows its parent's, so
+        # hovering the row would lose everything `_tooltip` says about the extension.
+        name.setToolTip("")
+        detail.setToolTip("")
         return widget
 
     def _source_cell(self, extension: Extension) -> QWidget:

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -346,6 +346,11 @@ class ScriptManagerDialog(QDialog):
         layout.addWidget(detail)
         # the summary is elided in the row, so the tooltip has to carry it in full
         widget.setToolTip(f"{summary}\n\n{script.path}\n{script.content_hash}")
+        # `ElidedLabel` gives itself one of its own full text, which is right where a
+        # label is on its own and wrong here: a child's tooltip shadows its parent's, so
+        # hovering the row would lose the path and the hash.
+        name.setToolTip("")
+        detail.setToolTip("")
         return widget
 
     def _type_cell(self, script: DiscoveredScript) -> QWidget:

--- a/tests/test_microscope.py
+++ b/tests/test_microscope.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 
@@ -82,6 +84,78 @@ def test_move_to_orientation_round_trip(orientation):
     microscope, _ = utils.setup_session(manufacturer="Demo")
     microscope.move_to_orientation(orientation)
     assert microscope.get_stage_orientation() == orientation
+
+
+# ---------------------------------------------------------------------------
+# move_to_microscope: FIBSEM <-> FM on a compustage
+# ---------------------------------------------------------------------------
+
+
+def _compustage_with_fm():
+    """A compustage Demo microscope with fluorescence attached."""
+    from fibsem.fm.microscope import FluorescenceMicroscope
+
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.stage_is_compustage = True
+    microscope.system.stage.shuttle_pre_tilt = 0
+    microscope._update_orientations()
+    if microscope.fm is None:
+        microscope.fm = FluorescenceMicroscope(parent=microscope)
+    return microscope
+
+
+@pytest.mark.parametrize("target,expected", [("FIBSEM", "SEM"), ("FM", "FM")])
+def test_move_to_microscope_compustage_lands_on_the_named_orientation(target, expected):
+    microscope = _compustage_with_fm()
+
+    microscope.move_to_microscope(target)
+
+    assert microscope.get_stage_orientation() == expected
+
+
+def test_move_to_microscope_compustage_round_trip():
+    microscope = _compustage_with_fm()
+    microscope.move_to_microscope("FM")
+    start = microscope.get_stage_position()
+
+    microscope.move_to_microscope("FIBSEM")
+    microscope.move_to_microscope("FM")
+
+    end = microscope.get_stage_position()
+    assert np.isclose(end.r, start.r, atol=1e-6)
+    assert np.isclose(end.t, start.t, atol=1e-6)
+
+
+def test_move_to_microscope_compustage_raises_no_deprecation_warning():
+    """It reached the beam pose through `move_flat_to_beam`, which is on its way out.
+
+    Left as a test rather than only a fix because the replacement has to agree with the
+    deprecated method exactly -- `move_to_orientation("SEM")` is what its docstring says
+    the electron branch means -- and the next caller reaching for the old one would
+    otherwise only be caught by a warning nobody reads.
+    """
+    microscope = _compustage_with_fm()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        microscope.move_to_microscope("FIBSEM")
+
+
+def test_the_replacement_move_matches_the_deprecated_one():
+    """Same r and t, from the same starting pose."""
+    deprecated = _compustage_with_fm()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        deprecated.move_flat_to_beam(BeamType.ELECTRON)
+    expected = deprecated.get_stage_position()
+
+    microscope = _compustage_with_fm()
+    microscope.move_to_microscope("FIBSEM")
+
+    actual = microscope.get_stage_position()
+    assert np.isclose(actual.r, expected.r, atol=1e-6)
+    assert np.isclose(actual.t, expected.t, atol=1e-6)
+
 
 # ---------------------------------------------------------------------------
 # get_target_position: MILLING <-> FM conversions (FIB-234)

--- a/tests/ui/test_elided_label.py
+++ b/tests/ui/test_elided_label.py
@@ -1,0 +1,135 @@
+"""One ElidedLabel, shared (was two: `custom_widgets` and `fm_overview_widget`).
+
+The two had drifted into different contracts. The overview's kept `_full_text` across
+`setText`, returned it from `text()` and set a tooltip; the other did none of that, so a
+label built empty and filled later would have painted itself blank -- latent, since its
+callers all passed the text to the constructor and never set it again. The surviving
+class is the overview's, whose behaviour these pin, plus the other's paint-time elide.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
+
+from fibsem.ui.widgets.custom_widgets import ElidedLabel
+
+LONG = "Overview acquisition failed: the stage refused to move to tile 14 of 25"
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def shown(qapp):
+    """A label in a holder narrow enough that it has to elide."""
+
+    def _build(text: str = "", width: int = 200) -> ElidedLabel:
+        holder = QWidget()
+        QVBoxLayout(holder).addWidget(label := ElidedLabel(text))
+        holder.resize(width, 60)
+        holder.show()
+        label._holder = holder  # keep it alive for the length of the test
+        for _ in range(3):
+            qapp.processEvents()
+        return label
+
+    return _build
+
+
+def drawn(label: ElidedLabel) -> str:
+    """What QLabel will actually paint, as opposed to what was set."""
+    return QLabel.text(label)
+
+
+class TestTheContract:
+    def test_text_returns_what_was_set_not_what_is_drawn(self, shown):
+        """Callers compare against it to decide whether a line is theirs to overwrite --
+        the overview's status label does -- and eliding is presentation."""
+        label = shown(LONG)
+
+        assert label.text() == LONG
+        assert drawn(label) != LONG
+        assert drawn(label).endswith("…")
+
+    def test_the_tooltip_carries_the_whole_string(self, shown):
+        """The only way to read one that does not fit."""
+        assert shown(LONG).toolTip() == LONG
+
+    def test_a_caller_can_override_the_tooltip_afterwards(self, shown):
+        """The overview's result message does, with the save path."""
+        label = shown(LONG)
+
+        label.setToolTip("/data/experiment/overview-01.ome.tiff")
+
+        assert label.toolTip() == "/data/experiment/overview-01.ome.tiff"
+
+    def test_a_label_built_empty_keeps_what_it_is_given_later(self, shown, qapp):
+        """How the overview builds both of its labels. The version that did not override
+        `setText` elided from the constructor's text forever, so this went blank."""
+        label = shown("")
+
+        label.setText(LONG)
+        for _ in range(3):
+            qapp.processEvents()
+            label.repaint()
+
+        assert label.text() == LONG
+        assert drawn(label).startswith("Overview acquisition")
+
+    def test_none_is_not_the_string_none(self, shown):
+        label = shown(LONG)
+
+        label.setText(None)
+
+        assert label.text() == ""
+
+
+class TestElidingSettles:
+    def test_repeated_paints_do_not_eat_the_text(self, shown, qapp):
+        """`paintEvent` puts the elided string on the label, so it must not be taken as
+        the real one -- each pass would elide the ellipsis a little further."""
+        label = shown(LONG)
+        first = drawn(label)
+
+        for _ in range(10):
+            qapp.processEvents()
+            label.repaint()
+
+        assert drawn(label) == first
+
+    def test_a_wider_label_shows_more(self, shown, qapp):
+        """`text()` returning the full string is what makes this possible: the elided
+        one is recomputed from it, never from itself.
+
+        Also the trap in merging the two classes. `paintEvent` used to compare its
+        result against `self.text()`, which now returns the full string -- so the
+        comparison was "elided vs full", never equal for an elided label and always
+        equal for one that fits, which is exactly backwards.
+        """
+        label = shown(LONG, width=200)
+        assert drawn(label) != LONG
+
+        label._holder.resize(900, 60)
+        for _ in range(3):
+            qapp.processEvents()
+            label.repaint()
+
+        assert drawn(label) == LONG
+
+
+class TestTheOtherCallers:
+    """`plugins_dialog` and `script_manager_dialog` build theirs with the text and never
+    set it again. That path has to keep working, since it was the surviving class's."""
+
+    def test_the_constructor_path_elides(self, shown):
+        assert drawn(shown(LONG)).endswith("…")
+
+    def test_short_text_is_left_alone(self, shown):
+        assert drawn(shown("Ready", width=400)) == "Ready"

--- a/tests/ui/test_fm_busy_guard.py
+++ b/tests/ui/test_fm_busy_guard.py
@@ -1,0 +1,333 @@
+"""Two widgets, one fluorescence microscope, one flag saying it is in use (FIB-441).
+
+The hazard: an overview tileset spends much of its time moving the stage between tiles,
+so the live-stream flag drops repeatedly during a run. A widget asking `fm.is_acquiring`
+about somebody else's tileset therefore sees "free" for most of it, and starting a live
+stream mid-run leaves the remaining tiles acquired at whatever settings it applied on
+the way past.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication, QDialog
+
+from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def widget(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    return FMOverviewWidget(build_microscope())
+
+
+@pytest.fixture()
+def accept_dialog(monkeypatch):
+    """Confirm the run, and count how many times the dialog was reached.
+
+    Patched in every test that calls `acquire`, refusal cases included: the dialog is
+    modal, so a guard that stopped working would hang the suite rather than fail it.
+    """
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    opened = []
+
+    class _Dialog:
+        def __init__(self, **kwargs):
+            opened.append(kwargs)
+
+        def exec_(self):
+            return QDialog.Accepted
+
+    monkeypatch.setattr(module, "FMOverviewConfirmationDialog", _Dialog)
+    return opened
+
+
+@pytest.fixture()
+def no_worker(monkeypatch):
+    """Stop `acquire` short of actually running a tileset.
+
+    The flag is set on the GUI thread before the worker starts, which is the part under
+    test; running the acquisition would only add simulated stage travel to each of these.
+    """
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    class _Worker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+        def is_alive(self):
+            return True
+
+    monkeypatch.setattr(module, "FunctionWorker", _Worker)
+
+
+class TestBusy:
+    """`is_busy` is the union of both ways the FM can be in use, which is the point."""
+
+    @pytest.fixture()
+    def fm(self):
+        return FluorescenceMicroscope()
+
+    def test_a_free_microscope_is_not_busy(self, fm):
+        assert fm.is_busy is False
+        assert fm.busy_reason == ""
+
+    def test_set_busy_says_why(self, fm):
+        fm.set_busy(True, "overview acquisition")
+        assert fm.is_busy is True
+        assert fm.busy_reason == "overview acquisition"
+
+    def test_clearing_frees_it(self, fm):
+        fm.set_busy(True, "overview acquisition")
+        fm.set_busy(False)
+        assert fm.is_busy is False
+        assert fm.busy_reason == ""
+
+    def test_a_live_stream_counts_as_busy(self, fm):
+        fm.start_acquisition()
+        try:
+            assert fm.is_busy is True
+            assert fm.busy_reason == "live acquisition"
+        finally:
+            fm.stop_acquisition()
+        assert fm.is_busy is False
+
+    def test_it_announces_itself(self, fm):
+        """So a widget that did not start it can grey out, not only refuse the click."""
+        seen = []
+        fm.busy_changed.connect(seen.append)
+
+        fm.set_busy(True, "overview acquisition")
+        fm.set_busy(False)
+
+        assert seen == [True, False]
+
+
+class TestTheOverviewMarksTheInstrument:
+    def test_a_run_marks_the_microscope(self, widget, accept_dialog, no_worker):
+        widget.acquire()
+
+        assert widget.fm.is_busy is True
+        assert widget.fm.busy_reason == "overview acquisition"
+
+    def test_the_worker_gives_it_back(self, widget, accept_dialog, no_worker):
+        widget.acquire()
+        widget._runner = _RunnerStub()
+
+        widget._acquire_worker()
+
+        assert widget.fm.is_busy is False
+
+    def test_a_failed_run_gives_it_back(self, widget, accept_dialog, no_worker):
+        """A run that dies holding the FM locks out every FM widget for the rest of the
+        session, with nothing on screen to say why."""
+        widget.acquire()
+        widget._runner = _RunnerStub(error=RuntimeError("stage refused"))
+
+        widget._acquire_worker()
+
+        assert widget.fm.is_busy is False
+
+    def test_a_cancelled_run_gives_it_back(self, widget, accept_dialog, no_worker):
+        from fibsem.cancellation import OperationCancelledError
+
+        widget.acquire()
+        widget._runner = _RunnerStub(error=OperationCancelledError())
+
+        widget._acquire_worker()
+
+        assert widget.fm.is_busy is False
+
+
+class TestTheOverviewRespectsTheInstrument:
+    def test_it_will_not_start_while_something_else_has_it(
+        self, widget, accept_dialog, no_worker
+    ):
+        """What `fm.is_acquiring` could not answer.
+
+        A z-stack running in the control widget is not a live stream, so the old guard
+        saw an idle microscope and started a tileset straight through it.
+        """
+        widget.fm.set_busy(True, "z-stack")
+
+        assert widget.fm.is_acquiring is False  # the flag the old guard asked
+        widget.acquire()
+
+        assert accept_dialog == [], "asked the user to confirm a run it then refused"
+
+    def test_it_starts_once_the_instrument_is_free(self, widget, accept_dialog, no_worker):
+        widget.fm.set_busy(True, "z-stack")
+        widget.fm.set_busy(False)
+
+        widget.acquire()
+
+        assert len(accept_dialog) == 1
+
+
+class TestTheAcquireButtonFollowsTheInstrument:
+    def test_it_greys_out_when_something_else_starts(self, widget, qapp):
+        assert widget.button_acquire.isEnabled() is True
+
+        widget.fm.set_busy(True, "z-stack")
+        qapp.processEvents()
+
+        assert widget.button_acquire.isEnabled() is False
+
+    def test_it_comes_back_when_that_finishes(self, widget, qapp):
+        widget.fm.set_busy(True, "z-stack")
+        qapp.processEvents()
+        assert widget.button_acquire.isEnabled() is False, "nothing to come back from"
+
+        widget.fm.set_busy(False)
+        qapp.processEvents()
+
+        assert widget.button_acquire.isEnabled() is True
+
+    def test_a_live_stream_greys_it_out_too(self, widget, qapp):
+        widget.fm.start_acquisition()
+        try:
+            qapp.processEvents()
+            assert widget.button_acquire.isEnabled() is False
+        finally:
+            widget.fm.stop_acquisition()
+        qapp.processEvents()
+        assert widget.button_acquire.isEnabled() is True
+
+
+class TestTheControlWidgetGuard:
+    """`FMControlWidget`, the other half of the pair.
+
+    Built without `__init__`. It takes a `napari.Viewer`, and constructing one under the
+    offscreen platform segfaults this process (measured: SIGSEGV, no OpenGL) -- which is
+    why nothing else in the suite instantiates it either. The guard itself reads three
+    attributes and no widgets, so it is testable; that it is reached from each entry
+    point is covered structurally below.
+    """
+
+    @staticmethod
+    def _widget(fm):
+        from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget
+
+        widget = FMControlWidget.__new__(FMControlWidget)
+        widget.fm = fm
+        widget._acquisition_thread = None
+        return widget
+
+    @pytest.fixture()
+    def fm(self):
+        return FluorescenceMicroscope()
+
+    def test_an_idle_instrument_is_not_refused(self, fm):
+        assert self._widget(fm)._refuse_if_fm_busy("live acquisition") is False
+
+    def test_an_overview_elsewhere_is_refused(self, fm):
+        """The case the old `self.is_acquiring` guard could not see."""
+        fm.set_busy(True, "overview acquisition")
+
+        assert fm.is_acquiring is False  # the flag the old guard asked
+        assert self._widget(fm)._refuse_if_fm_busy("live acquisition") is True
+
+    def test_its_own_worker_is_still_refused(self, fm):
+        """Widening to the instrument must not drop what the widget already knew."""
+        widget = self._widget(fm)
+        widget._acquisition_thread = _AliveThread()
+
+        assert fm.is_busy is False  # nothing streaming, nothing marked
+        assert widget._refuse_if_fm_busy("image acquisition") is True
+
+
+class TestTheControlWidgetWiring:
+    """That the guard is reached, and the flag actually cleared.
+
+    Structural, because the widget cannot be instantiated here. It states the two
+    invariants a new acquisition path would have to keep: ask before starting, and
+    clear on every way out.
+    """
+
+    @staticmethod
+    def _functions():
+        import ast
+        from pathlib import Path
+
+        import fibsem.ui.widgets.fluorescence_control_widget as module
+
+        tree = ast.parse(Path(module.__file__).read_text())
+        return {
+            node.name: node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+        }
+
+    @staticmethod
+    def _calls(node):
+        import ast
+
+        return {
+            child.func.attr
+            for child in ast.walk(node)
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute)
+        }
+
+    @pytest.mark.parametrize(
+        "name", ["start_acquisition", "acquire_image", "run_autofocus"]
+    )
+    def test_every_way_in_asks_first(self, name):
+        assert "_refuse_if_fm_busy" in self._calls(self._functions()[name])
+
+    @pytest.mark.parametrize("name", ["acquire_image", "run_autofocus"])
+    def test_every_worker_is_marked_for(self, name):
+        assert "set_busy" in self._calls(self._functions()[name])
+
+    @pytest.mark.parametrize(
+        "name", ["_image_acquistion_worker", "_autofocus_worker"]
+    )
+    def test_every_worker_clears_on_the_way_out(self, name):
+        """In the `finally`, not the happy path: a worker that raises still holds it."""
+        import ast
+
+        node = self._functions()[name]
+        cleared = any(
+            "set_busy"
+            in self._calls(ast.Module(body=block.finalbody, type_ignores=[]))
+            for block in ast.walk(node)
+            if isinstance(block, ast.Try)
+        )
+        assert cleared
+
+
+class _AliveThread:
+    """A worker that has not finished, for `is_acquiring`."""
+
+    def is_alive(self) -> bool:
+        return True
+
+
+class _RunnerStub:
+    """Stands in for `FMTiledAcquisitionRunner` so a run can end three ways."""
+
+    def __init__(self, error=None):
+        self.error = error
+
+    def run_and_stitch(self):
+        if self.error is not None:
+            raise self.error
+        import numpy as np
+
+        from fibsem.fm.structures import FluorescenceImage
+
+        return FluorescenceImage(data=np.zeros((4, 4), dtype=np.uint16))

--- a/tests/ui/test_fm_overview_orientation.py
+++ b/tests/ui/test_fm_overview_orientation.py
@@ -179,6 +179,46 @@ class TestTheGate:
         assert widget._position_menu(0.0, 0.0) is None
 
 
+class TestOffsetMounts:
+    """Where the question cannot be asked, it must not be answered "no" (FIB-93).
+
+    `_update_orientations` gives a non-compustage system an FM orientation copied from
+    its FIB one, so `get_stage_orientation` at the fluorescence position comes back as a
+    beam orientation and never as "FM". A gate that refused on that would leave the tab
+    permanently dead on every METEOR rather than guarding anything.
+    """
+
+    @pytest.fixture()
+    def offset_widget(self, qapp):
+        from fibsem import utils
+        from fibsem.fm.microscope import FluorescenceMicroscope
+
+        microscope, _ = utils.setup_session(manufacturer="Demo")
+        microscope.stage_is_compustage = False
+        microscope._update_orientations()
+        if microscope.fm is None:
+            microscope.fm = FluorescenceMicroscope(parent=microscope)
+        return FMOverviewWidget(microscope)
+
+    def test_the_fluorescence_pose_does_not_report_itself_as_fm(self, offset_widget):
+        """The premise. If this ever starts returning "FM", the exemption below can go."""
+        microscope = offset_widget.microscope
+        microscope.move_stage_absolute(microscope.get_orientation("FM"))
+
+        assert microscope.get_stage_orientation() != "FM"
+
+    def test_acquisition_is_not_gated_there(self, offset_widget, qapp):
+        microscope = offset_widget.microscope
+        microscope.move_stage_absolute(microscope.get_orientation("FM"))
+        offset_widget._on_stage_moved(microscope.get_stage_position())
+        qapp.processEvents()
+
+        assert offset_widget.at_acquisition_orientation() is True
+        assert offset_widget.button_acquire.isEnabled() is True
+        assert offset_widget._may_move() is True
+        assert offset_widget.orientation_banner.isVisibleTo(offset_widget) is False
+
+
 class TestTheRefusal:
     def test_acquire_refuses_from_the_wrong_pose(self, widget, accept_dialog, no_worker):
         """The button is not the guard: a host can call this, and the stage can move
@@ -202,23 +242,39 @@ class TestTheBanner:
     def test_it_is_hidden_when_the_pose_is_right(self, widget):
         assert widget.orientation_banner.isVisibleTo(widget) is False
 
-    def test_it_appears_and_names_where_the_stage_is_and_what_would_do(self, widget):
-        _pose(widget, "NONE")
+    def test_it_names_where_the_stage_is_and_where_it_needs_to_be(self, widget):
+        _pose(widget, "SEM")
 
         assert widget.orientation_banner.isVisibleTo(widget) is True
         assert widget.orientation_notice.text() == (
-            "Stage is at NONE — an overview needs FM."
+            "Stage is at the SEM orientation — an overview needs to be at the FM "
+            "orientation."
         )
 
-    def test_it_names_every_orientation_that_would_do(self, widget):
-        """Not only the one the button goes to: on a system configured for more than one
-        the stage may already be a shorter move from a different one."""
-        widget.fm.acquisition_orientations = ["FM", "SEM"]
+    def test_an_unrecognised_pose_is_not_called_the_none_orientation(self, widget):
+        """`get_stage_orientation` returns "NONE" for a pose it cannot name, and "the
+        NONE orientation" is not a thing to say to anyone."""
         _pose(widget, "NONE")
 
         assert widget.orientation_notice.text() == (
-            "Stage is at NONE — an overview needs one of: FM, SEM."
+            "Stage is at a position that is not a recognised orientation — an overview "
+            "needs to be at the FM orientation."
         )
+
+    @pytest.mark.parametrize(
+        "allowed,expected",
+        [
+            (["FM", "SEM"], "the FM or SEM orientation"),
+            (["FM", "SEM", "MILLING"], "the FM, SEM or MILLING orientation"),
+        ],
+    )
+    def test_it_names_every_orientation_that_would_do(self, widget, allowed, expected):
+        """Not only the one the button goes to: on a system configured for more than one
+        the stage may already be a shorter move from a different one."""
+        widget.fm.acquisition_orientations = allowed
+        _pose(widget, "NONE")
+
+        assert widget.orientation_notice.text().endswith(f"needs to be at {expected}.")
 
     def test_it_stays_hidden_at_a_valid_but_non_fluorescence_pose(self, widget):
         widget.fm.acquisition_orientations = ["FM", "SEM"]

--- a/tests/ui/test_fm_overview_orientation.py
+++ b/tests/ui/test_fm_overview_orientation.py
@@ -1,0 +1,251 @@
+"""The overview tab, from a stage that is not posed for fluorescence (FIB-436).
+
+An overview acquired at the wrong orientation is not merely unhelpful: the canvas frame
+is built from the origin's rotation and tilt, so the tiles would be placed against a
+projection that does not describe them. The tab used to let you configure and start one
+from anywhere.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication, QDialog, QMessageBox
+
+from fibsem.ui.fm.widgets import fm_overview_widget as module
+from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def widget(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    return FMOverviewWidget(build_microscope())
+
+
+# Compustage tilts the whole orientation question: -180° is where the FM looks at the
+# sample, 0° is where the electron beam does. Posed directly rather than through
+# `move_to_microscope("FIBSEM")`, whose compustage path still goes via the deprecated
+# `move_flat_to_beam` and so cannot be called from a suite that errors on warnings.
+_TILT_DEG = {"FM": -180.0, "SEM": 0.0, "MILLING": 20.0}
+
+
+def _pose(widget, orientation: str) -> None:
+    """Put the stage at *orientation*, then tell the widget as a real move would."""
+    import numpy as np
+
+    from fibsem.structures import FibsemStagePosition
+
+    widget.microscope.move_stage_absolute(
+        FibsemStagePosition(
+            x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(_TILT_DEG[orientation])
+        )
+    )
+    assert widget.microscope.get_stage_orientation() == orientation
+    widget._on_stage_moved(widget.microscope.get_stage_position())
+
+
+@pytest.fixture()
+def accept_dialog(monkeypatch):
+    """Confirm the run, and count how many times the dialog was reached.
+
+    Patched in the refusal tests too: it is modal, so a guard that stopped working would
+    hang the suite rather than fail it.
+    """
+    opened = []
+
+    class _Dialog:
+        def __init__(self, **kwargs):
+            opened.append(kwargs)
+
+        def exec_(self):
+            return QDialog.Accepted
+
+    monkeypatch.setattr(module, "FMOverviewConfirmationDialog", _Dialog)
+    return opened
+
+
+@pytest.fixture()
+def no_worker(monkeypatch):
+    """Stop anything that would start a thread, and record what it was handed."""
+    started = []
+
+    class _Worker:
+        def __init__(self, func, *args, **kwargs):
+            started.append((func, args))
+
+        def start(self):
+            pass
+
+        def is_alive(self):
+            return True
+
+    monkeypatch.setattr(module, "FunctionWorker", _Worker)
+    return started
+
+
+class TestTheGate:
+    def test_the_simulator_starts_posed_for_fluorescence(self, widget):
+        """The premise of every other test here, and worth asserting rather than
+        assuming: a gate that was open because nothing could close it would look
+        exactly like a gate that works."""
+        assert widget.microscope.get_stage_orientation() == "FM"
+        assert widget.at_fm_orientation() is True
+
+    def test_the_wrong_pose_closes_it(self, widget):
+        _pose(widget, "SEM")
+
+        assert widget.at_fm_orientation() is False
+
+    def test_acquire_is_disabled_from_the_wrong_pose(self, widget, qapp):
+        assert widget.button_acquire.isEnabled() is True
+
+        _pose(widget, "SEM")
+        qapp.processEvents()
+
+        assert widget.button_acquire.isEnabled() is False
+
+    def test_acquire_comes_back_on_the_way_home(self, widget, qapp):
+        _pose(widget, "SEM")
+        qapp.processEvents()
+        assert widget.button_acquire.isEnabled() is False, "nothing to come back from"
+
+        _pose(widget, "FM")
+        qapp.processEvents()
+
+        assert widget.button_acquire.isEnabled() is True
+
+    def test_display_and_navigation_are_left_alone(self, widget):
+        """Looking at an already-acquired overview from the wrong pose is harmless, and
+        the settings stay editable so a run can be set up while the stage is moving."""
+        _pose(widget, "SEM")
+
+        assert widget.settings_widget.isEnabled() is True
+        assert widget.channel_widget.isEnabled() is True
+
+    def test_the_stage_can_still_be_driven_from_the_wrong_pose(self, widget):
+        """What the deleted `has_valid_orientation` check claimed to stop.
+
+        The whole scene is re-placed through whatever pose the stage is in, so a click
+        still lands on the feature it points at.
+        """
+        _pose(widget, "SEM")
+
+        assert widget._may_move() is True
+
+    def test_marking_is_still_refused_from_the_wrong_pose(self, widget):
+        """Stricter than moving, and unchanged: a marked position becomes a lamella's
+        fluorescence pose, and one carrying SEM rotation and tilt is not one."""
+        _pose(widget, "SEM")
+
+        assert widget._position_menu(0.0, 0.0) is None
+
+
+class TestTheRefusal:
+    def test_acquire_refuses_from_the_wrong_pose(self, widget, accept_dialog, no_worker):
+        """The button is not the guard: a host can call this, and the stage can move
+        between the click and here."""
+        _pose(widget, "SEM")
+
+        widget.acquire()
+
+        assert accept_dialog == [], "asked the user to confirm a run it then refused"
+
+    def test_acquire_runs_once_the_stage_is_posed(self, widget, accept_dialog, no_worker):
+        _pose(widget, "SEM")
+        _pose(widget, "FM")
+
+        widget.acquire()
+
+        assert len(accept_dialog) == 1
+
+
+class TestTheBanner:
+    def test_it_is_hidden_when_the_pose_is_right(self, widget):
+        assert widget.orientation_banner.isVisibleTo(widget) is False
+
+    def test_it_appears_and_names_both_orientations(self, widget):
+        _pose(widget, "SEM")
+
+        assert widget.orientation_banner.isVisibleTo(widget) is True
+        notice = widget.orientation_notice.text()
+        assert "SEM" in notice, notice
+        assert "FM" in notice, notice
+
+    def test_the_button_names_where_it_goes(self, widget):
+        """From `default_orientation`, which the control widget can change at runtime --
+        a button naming one orientation while going to another is worse than none."""
+        _pose(widget, "SEM")
+
+        assert widget.button_move_to_fm.text() == "Move to FM"
+
+        widget.fm.default_orientation = "SEM-ish"
+        widget._refresh_orientation_banner()
+
+        assert widget.button_move_to_fm.text() == "Move to SEM-ish"
+
+    def test_it_goes_away_again(self, widget):
+        _pose(widget, "SEM")
+        assert widget.orientation_banner.isVisibleTo(widget) is True
+
+        _pose(widget, "FM")
+
+        assert widget.orientation_banner.isVisibleTo(widget) is False
+
+
+class TestTheMoveAction:
+    def test_it_asks_before_moving(self, widget, no_worker, monkeypatch):
+        """A real stage move, so it gets the same confirmation as the others here."""
+        _pose(widget, "SEM")
+        monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.No)
+
+        widget.move_to_fm_orientation()
+
+        assert no_worker == [], "moved the stage without asking"
+
+    def test_it_moves_when_confirmed(self, widget, no_worker, monkeypatch):
+        _pose(widget, "SEM")
+        monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.Yes)
+
+        widget.move_to_fm_orientation()
+
+        assert len(no_worker) == 1
+        func, args = no_worker[0]
+        assert func == widget._move_to_orientation_worker
+        assert args == ("FM",)
+
+    def test_the_worker_drives_the_stage(self, widget):
+        _pose(widget, "SEM")
+
+        widget._move_to_orientation_worker("FM")
+
+        assert widget.microscope.get_stage_orientation() == "FM"
+
+    def test_a_failed_move_is_logged_not_raised(self, widget, monkeypatch, caplog):
+        """It runs on a worker thread, where an exception has nowhere to go."""
+        def _boom(target):
+            raise RuntimeError("stage refused")
+
+        monkeypatch.setattr(widget.microscope, "move_to_microscope", _boom)
+
+        widget._move_to_orientation_worker("FM")
+
+        assert "stage refused" in caplog.text
+
+    def test_it_refuses_during_a_run(self, widget, no_worker, monkeypatch):
+        """The stage is walking the grid; taking it somewhere else mid-tileset is not a
+        thing a confirmation dialog should be able to authorise."""
+        monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.Yes)
+        widget._set_running(True)
+
+        widget.move_to_fm_orientation()
+
+        assert no_worker == []

--- a/tests/ui/test_fm_overview_orientation.py
+++ b/tests/ui/test_fm_overview_orientation.py
@@ -1,9 +1,17 @@
-"""The overview tab, from a stage that is not posed for fluorescence (FIB-436).
+"""The overview tab, from a stage the FM cannot work at (FIB-436).
 
 An overview acquired at the wrong orientation is not merely unhelpful: the canvas frame
 is built from the origin's rotation and tilt, so the tiles would be placed against a
 projection that does not describe them. The tab used to let you configure and start one
-from anywhere.
+from anywhere, and the one orientation check it did have -- before a click-to-move --
+asked `fm.has_valid_orientation()`, which the `ALLOW_UNKNOWN_ORIENTATIONS` escape hatch
+answers yes to unconditionally.
+
+Two different questions are asked, and which one goes where is most of what is tested
+here: `acquisition_orientations` (where the objective can image the sample) gates
+acquiring and driving the stage; `default_orientation` (the single pose a fluorescence
+position is written down as) gates marking. Neither is `valid_orientations`, which is
+the looser "FM control is allowed here" and still includes the beam poses.
 """
 import os
 
@@ -35,7 +43,9 @@ def widget(qapp):
 # sample, 0° is where the electron beam does. Posed directly rather than through
 # `move_to_microscope("FIBSEM")`, whose compustage path still goes via the deprecated
 # `move_flat_to_beam` and so cannot be called from a suite that errors on warnings.
-_TILT_DEG = {"FM": -180.0, "SEM": 0.0, "MILLING": 20.0}
+#
+# "NONE" is what `get_stage_orientation` returns for a pose it cannot name at all.
+_TILT_DEG = {"FM": -180.0, "SEM": 0.0, "MILLING": 20.0, "NONE": -90.0}
 
 
 def _pose(widget, orientation: str) -> None:
@@ -98,23 +108,23 @@ class TestTheGate:
         assuming: a gate that was open because nothing could close it would look
         exactly like a gate that works."""
         assert widget.microscope.get_stage_orientation() == "FM"
-        assert widget.at_fm_orientation() is True
+        assert widget.at_acquisition_orientation() is True
 
     def test_the_wrong_pose_closes_it(self, widget):
-        _pose(widget, "SEM")
+        _pose(widget, "NONE")
 
-        assert widget.at_fm_orientation() is False
+        assert widget.at_acquisition_orientation() is False
 
     def test_acquire_is_disabled_from_the_wrong_pose(self, widget, qapp):
         assert widget.button_acquire.isEnabled() is True
 
-        _pose(widget, "SEM")
+        _pose(widget, "NONE")
         qapp.processEvents()
 
         assert widget.button_acquire.isEnabled() is False
 
     def test_acquire_comes_back_on_the_way_home(self, widget, qapp):
-        _pose(widget, "SEM")
+        _pose(widget, "NONE")
         qapp.processEvents()
         assert widget.button_acquire.isEnabled() is False, "nothing to come back from"
 
@@ -126,26 +136,46 @@ class TestTheGate:
     def test_display_and_navigation_are_left_alone(self, widget):
         """Looking at an already-acquired overview from the wrong pose is harmless, and
         the settings stay editable so a run can be set up while the stage is moving."""
-        _pose(widget, "SEM")
+        _pose(widget, "NONE")
 
         assert widget.settings_widget.isEnabled() is True
         assert widget.channel_widget.isEnabled() is True
 
-    def test_the_stage_can_still_be_driven_from_the_wrong_pose(self, widget):
-        """What the deleted `has_valid_orientation` check claimed to stop.
+    @pytest.mark.parametrize("orientation", ["SEM", "MILLING", "NONE"])
+    def test_every_beam_pose_closes_it(self, widget, qapp, orientation):
+        """MILLING especially: it is in `valid_orientations`, so a gate asking that
+        question let a full tileset be started from it -- and on every mount we support
+        the sample is flipped or translated away from the objective there, so the tiles
+        would be of nothing."""
+        _pose(widget, orientation)
+        qapp.processEvents()
 
-        The whole scene is re-placed through whatever pose the stage is in, so a click
-        still lands on the feature it points at.
-        """
+        assert widget.at_acquisition_orientation() is False
+        assert widget.button_acquire.isEnabled() is False
+        assert widget._may_move() is False
+
+    def test_the_list_is_what_decides_not_a_hard_coded_pose(self, widget, qapp):
+        """A system whose objective sees the sample from more than one pose widens
+        `acquisition_orientations`; nothing here compares against `default_orientation`."""
+        widget.fm.acquisition_orientations = ["FM", "SEM"]
         _pose(widget, "SEM")
+        qapp.processEvents()
 
+        assert widget.at_acquisition_orientation() is True
+        assert widget.button_acquire.isEnabled() is True
         assert widget._may_move() is True
 
-    def test_marking_is_still_refused_from_the_wrong_pose(self, widget):
-        """Stricter than moving, and unchanged: a marked position becomes a lamella's
-        fluorescence pose, and one carrying SEM rotation and tilt is not one."""
+    def test_marking_stays_on_the_fluorescence_pose_alone(self, widget):
+        """The distinction the gate rests on. Stricter than acquiring or moving: a
+        marked position becomes a lamella's *fluorescence* pose, and one carrying SEM
+        rotation and tilt is not one, however right it looked on screen -- so widening
+        `acquisition_orientations` must not widen this."""
+        widget.fm.acquisition_orientations = ["FM", "SEM"]
         _pose(widget, "SEM")
 
+        assert widget.at_acquisition_orientation() is True
+        assert widget.at_fluorescence_pose() is False
+        assert widget._may_move() is True, "the looser check should still pass here"
         assert widget._position_menu(0.0, 0.0) is None
 
 
@@ -153,14 +183,14 @@ class TestTheRefusal:
     def test_acquire_refuses_from_the_wrong_pose(self, widget, accept_dialog, no_worker):
         """The button is not the guard: a host can call this, and the stage can move
         between the click and here."""
-        _pose(widget, "SEM")
+        _pose(widget, "NONE")
 
         widget.acquire()
 
         assert accept_dialog == [], "asked the user to confirm a run it then refused"
 
     def test_acquire_runs_once_the_stage_is_posed(self, widget, accept_dialog, no_worker):
-        _pose(widget, "SEM")
+        _pose(widget, "NONE")
         _pose(widget, "FM")
 
         widget.acquire()
@@ -172,18 +202,34 @@ class TestTheBanner:
     def test_it_is_hidden_when_the_pose_is_right(self, widget):
         assert widget.orientation_banner.isVisibleTo(widget) is False
 
-    def test_it_appears_and_names_both_orientations(self, widget):
-        _pose(widget, "SEM")
+    def test_it_appears_and_names_where_the_stage_is_and_what_would_do(self, widget):
+        _pose(widget, "NONE")
 
         assert widget.orientation_banner.isVisibleTo(widget) is True
-        notice = widget.orientation_notice.text()
-        assert "SEM" in notice, notice
-        assert "FM" in notice, notice
+        assert widget.orientation_notice.text() == (
+            "Stage is at NONE — an overview needs FM."
+        )
+
+    def test_it_names_every_orientation_that_would_do(self, widget):
+        """Not only the one the button goes to: on a system configured for more than one
+        the stage may already be a shorter move from a different one."""
+        widget.fm.acquisition_orientations = ["FM", "SEM"]
+        _pose(widget, "NONE")
+
+        assert widget.orientation_notice.text() == (
+            "Stage is at NONE — an overview needs one of: FM, SEM."
+        )
+
+    def test_it_stays_hidden_at_a_valid_but_non_fluorescence_pose(self, widget):
+        widget.fm.acquisition_orientations = ["FM", "SEM"]
+        _pose(widget, "SEM")
+
+        assert widget.orientation_banner.isVisibleTo(widget) is False
 
     def test_the_button_names_where_it_goes(self, widget):
         """From `default_orientation`, which the control widget can change at runtime --
         a button naming one orientation while going to another is worse than none."""
-        _pose(widget, "SEM")
+        _pose(widget, "NONE")
 
         assert widget.button_move_to_fm.text() == "Move to FM"
 
@@ -193,7 +239,7 @@ class TestTheBanner:
         assert widget.button_move_to_fm.text() == "Move to SEM-ish"
 
     def test_it_goes_away_again(self, widget):
-        _pose(widget, "SEM")
+        _pose(widget, "NONE")
         assert widget.orientation_banner.isVisibleTo(widget) is True
 
         _pose(widget, "FM")
@@ -204,7 +250,7 @@ class TestTheBanner:
 class TestTheMoveAction:
     def test_it_asks_before_moving(self, widget, no_worker, monkeypatch):
         """A real stage move, so it gets the same confirmation as the others here."""
-        _pose(widget, "SEM")
+        _pose(widget, "NONE")
         monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.No)
 
         widget.move_to_fm_orientation()
@@ -212,7 +258,7 @@ class TestTheMoveAction:
         assert no_worker == [], "moved the stage without asking"
 
     def test_it_moves_when_confirmed(self, widget, no_worker, monkeypatch):
-        _pose(widget, "SEM")
+        _pose(widget, "NONE")
         monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.Yes)
 
         widget.move_to_fm_orientation()
@@ -223,7 +269,7 @@ class TestTheMoveAction:
         assert args == ("FM",)
 
     def test_the_worker_drives_the_stage(self, widget):
-        _pose(widget, "SEM")
+        _pose(widget, "NONE")
 
         widget._move_to_orientation_worker("FM")
 

--- a/tests/ui/test_fm_overview_orientation.py
+++ b/tests/ui/test_fm_overview_orientation.py
@@ -41,8 +41,8 @@ def widget(qapp):
 
 # Compustage tilts the whole orientation question: -180° is where the FM looks at the
 # sample, 0° is where the electron beam does. Posed directly rather than through
-# `move_to_microscope("FIBSEM")`, whose compustage path still goes via the deprecated
-# `move_flat_to_beam` and so cannot be called from a suite that errors on warnings.
+# `move_to_microscope`, which only knows FIBSEM and FM -- MILLING and NONE have to be
+# set here anyway, so all four come from one place.
 #
 # "NONE" is what `get_stage_orientation` returns for a pose it cannot name at all.
 _TILT_DEG = {"FM": -180.0, "SEM": 0.0, "MILLING": 20.0, "NONE": -90.0}

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -31,7 +31,6 @@ from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
 )
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
 from fibsem.ui.fm.widgets.fm_overview_widget import (
-    ElidedLabel,
     FMOverviewWidget,
     shrink_progress_text,
 )

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -505,9 +505,17 @@ def test_a_long_description_elides_instead_of_clipping(qapp, tmp_path):
     dialog.grab()  # forces the paint pass that does the eliding
 
     from PyQt5.QtWidgets import QLabel
-    shown = dialog.table.cellWidget(0, 0).findChildren(QLabel)[1].text()
+    label = dialog.table.cellWidget(0, 0).findChildren(QLabel)[1]
+    # `QLabel.text`, not `ElidedLabel.text`: the latter returns what was set, so that a
+    # caller can tell whether a line is theirs to overwrite. What is *drawn* is the
+    # elided string, and eliding rather than clipping is what this is about.
+    shown = QLabel.text(label)
 
     assert shown.endswith("…") and shown != summary
+    assert label.text() == summary, "the label should still know its full text"
+    # A child's tooltip shadows its parent's, and the row's carries the path and hash
+    # as well as the summary.
+    assert label.toolTip() == ""
     assert summary in dialog.table.cellWidget(0, 0).toolTip()
 
 


### PR DESCRIPTION
Two guards on the FM overview tab, both of which make the app refuse things rather than do more.

## FIB-441 — nothing stopped a live stream being started during an overview run

A tileset spends much of its time moving the stage between tiles, so `fm.is_acquiring` — which reports the live stream alone — drops repeatedly during one. Every widget asking that flag about somebody else's run therefore saw an idle microscope for most of it, and starting a stream mid-tileset leaves the remaining tiles acquired at whatever settings it applied on the way past.

`FluorescenceMicroscope` now carries the flag itself: `set_busy(True, reason)` while something is driving it, `is_busy` as the union of that and the live stream, `busy_reason` for the message, and a `busy_changed` signal so a widget that did not start the work can grey its controls out rather than only refusing the click.

- The overview sets it for the length of a run and clears it in the worker's `finally`.
- `FMControlWidget` asks before all three of its entry points (`start_acquisition`, `acquire_image`, `run_autofocus`) and holds it around both its workers. Its **Start Acquisition** button was the one control that stayed live through an overview run, and is now disabled unless the live stream is what is running.
- The coincidence viewer asks before starting a stream — the third path in the app that can.

## FIB-436 — the tab was live regardless of where the stage was

A full tileset could be configured and started from a pose the FM cannot see anything from, and the canvas frame is built from the pose (`_posed`), so those tiles would be placed against a projection that does not describe them.

Acquire is now disabled from the wrong orientation, behind a hard guard in `acquire()` for the host path, with a banner naming the current pose and a button that moves there. Display, navigation and the settings panel are left alone: looking at an overview already acquired is harmless from anywhere, and a run can be set up while the stage is on its way.


### Which orientation list

Three different questions were tangled together, and separating them is most of the second commit:

| | asked by | why |
|---|---|---|
| `acquisition_orientations` **(new)** | acquiring an overview, click-to-move | where the objective can actually image the sample. Defaults to `[default_orientation]`; a system that sees the sample from more than one pose widens it |
| `valid_orientations` | unchanged, every existing caller | the looser "FM control is allowed here" — true at SEM and MILLING, where turning the light on and watching the camera is harmless |
| `default_orientation` | marking a position | a marked point becomes a lamella's *fluorescence* pose, so widening where an overview may be acquired must not widen where one may be written down |

Gating acquisition on `valid_orientations` was tried and reverted: it includes MILLING, where a compustage has flipped the sample away from the objective. `is_acquisition_orientation()` also has no `ALLOW_UNKNOWN_ORIENTATIONS` escape hatch — that exists so live control works from anywhere while a system is being set up, and an unrecognised pose is not an inconvenience to something that walks the stage across a grid.

The double-click guard's old `fm.has_valid_orientation()` check refused nothing (the escape hatch answers it yes unconditionally). It now asks the new question, which is what it was always meant to mean.

## Testing

45 new tests across `tests/ui/test_fm_busy_guard.py` and `tests/ui/test_fm_overview_orientation.py`; 722 passing across every affected file. `FMControlWidget` cannot be instantiated under the offscreen platform (`napari.Viewer` segfaults — no OpenGL, which is why nothing else in the suite builds one either), so its guard is tested directly and its wiring structurally: that each entry point reaches the guard, and each worker clears the flag in a `finally`.

Nine guards mutation-checked. One survivor was an equivalent mutant — moving the overview's `set_busy(False)` out of its `finally` changes nothing while `except Exception` covers every exit — and its comment now claims only that.



## Also here

`move_to_microscope_compustage("FIBSEM")` reached the beam pose through `move_flat_to_beam(BeamType.ELECTRON)`, which is deprecated and warns. It now calls `move_to_orientation("SEM")`, which is what that branch means — the deprecated method builds `(rotation_reference, shuttle_pre_tilt)`, exactly `orientations["SEM"]`, and its one compustage special case tests for the ion beam. Measured identical from a non-trivial starting pose. `OdemisMicroscope` overrides `move_flat_to_beam` but sets `stage_is_compustage = False`, so it never reached this line and is untouched.

Separate commit (`953fdcab`), reviewable on its own.
