### PR TITLE
[ui] Show config fields the task form cannot edit read-only, instead of corrupting them

### DIFF
--- a/fibsem/ui/widgets/autolamella_task_config_widget.py
+++ b/fibsem/ui/widgets/autolamella_task_config_widget.py
@@ -2,7 +2,17 @@ import inspect
 import logging
 from dataclasses import fields
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union, get_type_hints
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
@@ -46,6 +56,11 @@ def resolve_field_types(config: Any) -> Dict[str, Any]:
 
 class ParameterWidget:
     """Base class for parameter editing widgets."""
+
+    # Whether this widget's get_value() may be written back onto the config.
+    # False for widgets that can only display a value they cannot reconstruct
+    # (see ReadOnlyParameterWidget).
+    editable: bool = True
     
     def __init__(self, name: str, value: Any, annotation: type):
         self.name = name
@@ -181,6 +196,54 @@ class StringParameterWidget(ParameterWidget):
         self.widget.setText(str(value))
 
 
+class ReadOnlyParameterWidget(ParameterWidget):
+    """Read-only display for a field this form has no editor for.
+
+    The alternative used to be a plain ``QLineEdit`` holding ``str(value)``, on the
+    assumption that an unknown type could be round-tripped through its text. That
+    holds for almost nothing: for a nested dataclass such as ``ZParameters`` or
+    ``ChannelSettings`` the box shows a ``repr`` that cannot be parsed back, and
+    ``get_value()`` returns a ``str`` which was then written straight onto the
+    config -- destroying the object on a focus-out alone, no typing required. The
+    field then fails at run time (``'str' object has no attribute ...``) and again
+    when the experiment is saved.
+
+    Showing the value disabled keeps it visible -- these are real settings an
+    operator wants to read -- while ``editable = False`` stops anything writing the
+    displayed text back. Edit such fields through a config-specific widget, or the
+    protocol file.
+    """
+
+    editable = False
+
+    def create_widget(self) -> QWidget:
+        self.widget = QLineEdit()
+        self.widget.setText(str(self.value))
+        self.widget.setReadOnly(True)
+        self.widget.setEnabled(False)
+        self.widget.setToolTip(
+            f"{self._type_name()} is not editable in this form.\n"
+            "Edit it in this task's own settings panel, or in the protocol file."
+        )
+        return self.widget
+
+    def _type_name(self) -> str:
+        return getattr(self.annotation, "__name__", None) or str(self.annotation)
+
+    def get_value(self) -> Any:
+        """Return the original value, never the displayed text.
+
+        Nothing should call this -- `editable` is False -- but if something does,
+        handing back the untouched value is the answer that cannot corrupt the
+        config.
+        """
+        return self.value
+
+    def set_value(self, value: Any) -> None:
+        self.value = value
+        self.widget.setText(str(value))
+
+
 class EnumParameterWidget(ParameterWidget):
     """Widget for enum parameters."""
     
@@ -288,6 +351,66 @@ class ListParameterWidget(ParameterWidget):
         else:
             text = str(value)
         self.widget.setText(text)
+
+
+def create_parameter_widget(
+    name: str,
+    value: Any,
+    annotation: type,
+    metadata: Optional[dict] = None,
+) -> ParameterWidget:
+    """Pick the editing widget for one config field.
+
+    Shared by both config forms in this module, which each used to carry their own
+    copy of this dispatch -- and had already drifted apart. A field type handled in
+    one and not the other is the kind of divergence that shows up as a corrupted
+    config rather than as an error.
+    """
+    metadata = metadata or {}
+
+    # Handle Union types (e.g., Optional[T])
+    origin = get_origin(annotation)
+    if origin is Union:
+        # Find the non-None type for Optional[T]
+        non_none_types = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if non_none_types:
+            annotation = non_none_types[0]
+            origin = get_origin(annotation)
+
+    # items metadata takes priority -- render as combobox regardless of type
+    items = metadata.get("items")
+    if items:
+        return ComboParameterWidget(name, value, annotation, items)
+
+    # A Literal is a fixed set of allowable values written in the type itself,
+    # which is the same thing the `items` metadata key expresses -- so render it
+    # the same way rather than as a free-text box the operator can mistype.
+    if origin is Literal:
+        return ComboParameterWidget(name, value, annotation, list(get_args(annotation)))
+
+    # Determine widget type based on annotation
+    if annotation is bool:
+        return BoolParameterWidget(name, value, annotation)
+    elif annotation is int:
+        return IntParameterWidget(name, value, annotation, metadata)
+    elif annotation is float:
+        return FloatParameterWidget(name, value, annotation, metadata)
+    elif annotation is str:
+        return StringParameterWidget(name, value, annotation)
+    elif inspect.isclass(annotation) and issubclass(annotation, Enum):
+        return EnumParameterWidget(name, value, annotation)
+    elif origin is list or (inspect.isclass(annotation) and issubclass(annotation, list)):
+        # Only lists of scalars survive the round trip through comma-separated
+        # text; a list of dataclasses comes back as a list of strings.
+        item_types = get_args(annotation)
+        if not item_types or item_types[0] in (bool, int, float, str):
+            return ListParameterWidget(name, value, annotation)
+
+    logging.warning(
+        f"No editor for parameter type '{annotation}' (field '{name}'); "
+        "showing it read-only."
+    )
+    return ReadOnlyParameterWidget(name, value, annotation)
 
 
 class AutoLamellaTaskConfigWidget(QWidget):
@@ -404,42 +527,12 @@ class AutoLamellaTaskConfigWidget(QWidget):
 
     def _create_parameter_widget(self, name: str, value: Any, annotation: type, metadata: Optional[dict] = None) -> Optional[ParameterWidget]:
         """Create the appropriate parameter widget for the given type."""
-        metadata = metadata or {}
-
-        # Handle Union types (e.g., Optional[T])
-        origin = getattr(annotation, '__origin__', None)
-        if origin is Union:
-            args = getattr(annotation, '__args__', ())
-            # Find the non-None type for Optional[T]
-            non_none_types = [arg for arg in args if arg is not type(None)]
-            if non_none_types:
-                annotation = non_none_types[0]
-
-        # items metadata takes priority — render as combobox regardless of type
-        items = metadata.get("items")
-        if items:
-            return ComboParameterWidget(name, value, annotation, items)
-
-        # Determine widget type based on annotation
-        if annotation is bool:
-            return BoolParameterWidget(name, value, annotation)
-        elif annotation is int:
-            return IntParameterWidget(name, value, annotation, metadata)
-        elif annotation is float:
-            return FloatParameterWidget(name, value, annotation, metadata)
-        elif annotation is str:
-            return StringParameterWidget(name, value, annotation)
-        elif inspect.isclass(annotation) and issubclass(annotation, Enum):
-            return EnumParameterWidget(name, value, annotation)
-        elif origin is list or (inspect.isclass(annotation) and issubclass(annotation, list)):
-            return ListParameterWidget(name, value, annotation)
-        else:
-            logging.warning(f"Unsupported parameter type '{annotation}' for field '{name}'. Using string widget as fallback.")
-            # Fallback to string widget for unknown types
-            return StringParameterWidget(name, value, annotation)
+        return create_parameter_widget(name, value, annotation, metadata)
     
     def _connect_widget_signals(self, widget: QWidget, field_name: str):
         """Connect widget change signals to update the configuration."""
+        if not self.parameter_widgets[field_name].editable:
+            return
         if isinstance(widget, QCheckBox):
             widget.toggled.connect(lambda: self._on_parameter_changed(field_name))
         elif isinstance(widget, (QSpinBox, QDoubleSpinBox)):
@@ -453,6 +546,11 @@ class AutoLamellaTaskConfigWidget(QWidget):
         """Handle parameter value changes."""
         if field_name in self.parameter_widgets:
             param_widget = self.parameter_widgets[field_name]
+            # Never write back a value the widget cannot reconstruct -- see
+            # ReadOnlyParameterWidget. Checked here as well as at connection time
+            # because the cost of getting it wrong is a silently corrupted config.
+            if not param_widget.editable:
+                return
             new_value = param_widget.get_value()
 
             # Update the task config
@@ -580,41 +678,12 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
                                  annotation: type,
                                  metadata: Optional[dict] = None) -> Optional[ParameterWidget]:
         """Create the appropriate parameter widget for the given type."""
-        metadata = metadata or {}
-
-        # Handle Union types (e.g., Optional[T])
-        origin = getattr(annotation, '__origin__', None)
-        if origin is Union:
-            args = getattr(annotation, '__args__', ())
-            # Find the non-None type for Optional[T]
-            non_none_types = [arg for arg in args if arg is not type(None)]
-            if non_none_types:
-                annotation = non_none_types[0]
-
-        # items metadata takes priority — render as combobox regardless of type
-        items = metadata.get("items")
-        if items:
-            return ComboParameterWidget(name, value, annotation, items)
-
-        # Determine widget type based on annotation
-        if annotation == bool:
-            return BoolParameterWidget(name, value, annotation)
-        elif annotation == int:
-            return IntParameterWidget(name, value, annotation, metadata)
-        elif annotation == float:
-            return FloatParameterWidget(name, value, annotation, metadata)
-        elif annotation == str:
-            return StringParameterWidget(name, value, annotation)
-        elif inspect.isclass(annotation) and issubclass(annotation, Enum):
-            return EnumParameterWidget(name, value, annotation)
-        elif origin is list or (inspect.isclass(annotation) and issubclass(annotation, list)):
-            return ListParameterWidget(name, value, annotation)
-        else:
-            # Fallback to string widget for unknown types
-            return StringParameterWidget(name, value, annotation)
+        return create_parameter_widget(name, value, annotation, metadata)
     
     def _connect_widget_signals(self, widget: QWidget, field_name: str):
         """Connect widget change signals to update the configuration."""
+        if not self.parameter_widgets[field_name].editable:
+            return
         if isinstance(widget, QCheckBox):
             widget.toggled.connect(lambda: self._on_parameter_changed(field_name))
         elif isinstance(widget, (QSpinBox, QDoubleSpinBox)):
@@ -628,6 +697,11 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
         """Handle parameter value changes."""
         if field_name in self.parameter_widgets:
             param_widget = self.parameter_widgets[field_name]
+            # Never write back a value the widget cannot reconstruct -- see
+            # ReadOnlyParameterWidget. Checked here as well as at connection time
+            # because the cost of getting it wrong is a silently corrupted config.
+            if not param_widget.editable:
+                return
             new_value = param_widget.get_value()
 
             # Update the task config

--- a/fibsem/ui/widgets/autolamella_task_config_widget.py
+++ b/fibsem/ui/widgets/autolamella_task_config_widget.py
@@ -406,7 +406,12 @@ def create_parameter_widget(
         if not item_types or item_types[0] in (bool, int, float, str):
             return ListParameterWidget(name, value, annotation)
 
-    logging.warning(
+    # Debug, not warning: the form itself now says this, visibly and in the right
+    # place -- the field is greyed out with a tooltip naming where to edit it. At
+    # warning level this fires every time a task carrying such a field is selected,
+    # including the built-in fluorescence config, whose three are read-only by
+    # design and whose form is hidden anyway. Nothing is going wrong.
+    logging.debug(
         f"No editor for parameter type '{annotation}' (field '{name}'); "
         "showing it read-only."
     )

--- a/tests/ui/test_task_config_parameter_widgets.py
+++ b/tests/ui/test_task_config_parameter_widgets.py
@@ -1,0 +1,275 @@
+"""Tests for the generic task-parameters form's field dispatch.
+
+The form builds an editor per dataclass field from the field's type. Its old
+fallback for a type it had no editor for was a plain QLineEdit holding
+``str(value)`` -- on the assumption that an unknown type round-trips through its
+own text. Almost nothing does: for a nested dataclass the box shows a ``repr``
+that cannot be parsed back, and the form then wrote that string onto the config,
+replacing the object. It needed no typing -- a QLineEdit emits ``editingFinished``
+on focus loss -- so tabbing past the field was enough, and the damage only
+surfaced later, when the task ran or the experiment was saved.
+
+Built from a synthetic config rather than a real task's: the point is the type
+dispatch, and a config written here states exactly which types are under test
+instead of depending on which fields a production task happens to carry.
+"""
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from dataclasses import dataclass, field  # noqa: E402
+from enum import Enum  # noqa: E402
+from typing import ClassVar, List, Literal, Optional  # noqa: E402
+
+from PyQt5.QtCore import Qt  # noqa: E402
+from PyQt5.QtWidgets import (  # noqa: E402
+    QCheckBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QLineEdit,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig  # noqa: E402
+from fibsem.ui.widgets.autolamella_task_config_widget import (  # noqa: E402
+    AutoLamellaTaskConfigWidget,
+    AutoLamellaTaskParametersConfigWidget,
+    BoolParameterWidget,
+    ComboParameterWidget,
+    EnumParameterWidget,
+    FloatParameterWidget,
+    IntParameterWidget,
+    ListParameterWidget,
+    ReadOnlyParameterWidget,
+    StringParameterWidget,
+)
+
+
+class Flavour(Enum):
+    SWEET = "sweet"
+    SOUR = "sour"
+
+
+@dataclass
+class NestedSettings:
+    """Stands in for ZParameters/ChannelSettings -- a dataclass the form cannot edit."""
+
+    depth: float = 1.5
+    label: str = "nested"
+
+
+@dataclass
+class SampleTaskConfig(AutoLamellaTaskConfig):
+    """One field per dispatch branch the form has to get right."""
+
+    task_type: ClassVar[str] = "SAMPLE_TASK"
+    display_name: ClassVar[str] = "Sample Task"
+
+    a_bool: bool = True
+    an_int: int = 3
+    a_float: float = 2.5
+    a_string: str = "hello"
+    an_enum: Flavour = Flavour.SWEET
+    a_scalar_list: List[str] = field(default_factory=lambda: ["x", "y"])
+    a_literal: Literal["cells", "hpf", "other"] = "hpf"
+    an_optional_float: Optional[float] = 1.0
+    with_items: str = field(default="b", metadata={"items": ["a", "b", "c"]})
+    # The two that used to be silently destroyed.
+    nested: NestedSettings = field(default_factory=NestedSettings)
+    nested_list: List[NestedSettings] = field(default_factory=lambda: [NestedSettings()])
+
+
+# Both forms in the module share one dispatch; run every test against both so a
+# fix landing in only one of them fails here rather than in a user's protocol.
+FORMS = [AutoLamellaTaskParametersConfigWidget, AutoLamellaTaskConfigWidget]
+FORM_IDS = ["parameters_form", "config_form"]
+
+
+def _build(form_cls, config):
+    widget = form_cls(task_config=config)
+    return widget
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+@pytest.mark.parametrize(
+    "field_name,expected_widget",
+    [
+        ("a_bool", BoolParameterWidget),
+        ("an_int", IntParameterWidget),
+        ("a_float", FloatParameterWidget),
+        ("a_string", StringParameterWidget),
+        ("an_enum", EnumParameterWidget),
+        ("a_scalar_list", ListParameterWidget),
+        ("an_optional_float", FloatParameterWidget),
+        ("with_items", ComboParameterWidget),
+    ],
+)
+def test_editable_field_types_keep_their_editors(
+    qapp, form_cls, field_name, expected_widget
+):
+    """Every type the form genuinely supports is untouched by the read-only fallback."""
+    form = _build(form_cls, SampleTaskConfig())
+
+    param_widget = form.parameter_widgets[field_name]
+
+    assert isinstance(param_widget, expected_widget)
+    assert param_widget.editable
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+@pytest.mark.parametrize("field_name", ["nested", "nested_list"])
+def test_a_field_the_form_cannot_edit_is_shown_read_only(qapp, form_cls, field_name):
+    """A dataclass field (or a list of them) is displayed, but not as an editor.
+
+    Displayed rather than dropped: these are real settings an operator wants to
+    read off the form, even when they have to be changed elsewhere.
+    """
+    form = _build(form_cls, SampleTaskConfig())
+
+    param_widget = form.parameter_widgets[field_name]
+    widget = param_widget.widget
+
+    assert isinstance(param_widget, ReadOnlyParameterWidget)
+    assert not param_widget.editable
+    assert isinstance(widget, QLineEdit)
+    assert widget.isReadOnly() and not widget.isEnabled()
+    assert widget.toolTip()  # says where the field can be edited instead
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_tabbing_past_an_uneditable_field_leaves_the_value_alone(
+    qapp, form_cls, monkeypatch
+):
+    """The original bug: focus in, focus out, and the dataclass became a string.
+
+    No typing and no editing -- QLineEdit emits editingFinished on focus loss, the
+    form read the box's text back and assigned it to the field. The task then
+    failed at run time and the experiment could not be saved.
+    """
+    config = SampleTaskConfig()
+    form = _build(form_cls, config)
+
+    # A host with a second focusable widget, so focus can actually leave the field.
+    host = QWidget()
+    layout = QVBoxLayout(host)
+    layout.addWidget(form)
+    elsewhere = QLineEdit()
+    layout.addWidget(elsewhere)
+    host.show()
+
+    nested_box = form.parameter_widgets["nested"].widget
+    nested_box.setFocus(Qt.MouseFocusReason)
+    qapp.processEvents()
+    elsewhere.setFocus(Qt.MouseFocusReason)
+    qapp.processEvents()
+
+    assert isinstance(config.nested, NestedSettings)
+    assert config.nested.depth == 1.5
+
+    host.close()
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_the_write_back_refuses_an_uneditable_field(qapp, form_cls):
+    """Even called directly, the change handler will not write a read-only field.
+
+    The disabled box cannot take focus, so this path is unreachable through the
+    UI today -- it is guarded anyway because the failure it prevents is silent
+    data loss, and a later change to how the form is built should not be able to
+    reintroduce it.
+
+    Asserting the *signal* rather than only the value: ReadOnlyParameterWidget
+    hands back the value it was given, so an unguarded handler would assign the
+    same object and leave the config looking untouched. What gives it away is the
+    change being announced -- which marks the protocol dirty and saves it -- for
+    an edit that never happened.
+    """
+    config = SampleTaskConfig()
+    form = _build(form_cls, config)
+
+    announced = []
+    for signal_name in ("parameter_changed", "config_changed"):
+        signal = getattr(form, signal_name, None)
+        if signal is not None:
+            signal.connect(lambda *args, name=signal_name: announced.append(name))
+
+    form._on_parameter_changed("nested")
+    form._on_parameter_changed("nested_list")
+
+    assert announced == []
+    assert isinstance(config.nested, NestedSettings)
+    assert isinstance(config.nested_list, list)
+    assert all(isinstance(item, NestedSettings) for item in config.nested_list)
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_an_editable_field_still_writes_through(qapp, form_cls):
+    """The guard blocks only the fields it should -- editing is otherwise unchanged."""
+    config = SampleTaskConfig()
+    form = _build(form_cls, config)
+
+    form.parameter_widgets["a_float"].widget.setValue(9.0)
+    form._on_parameter_changed("a_float")
+
+    assert config.a_float == 9.0
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_a_literal_field_offers_its_allowed_values(qapp, form_cls):
+    """Literal[...] is a fixed set of values written in the type itself.
+
+    It used to fall through to the unknown-type fallback and render as free text,
+    so an operator could type a value the field does not accept and nothing
+    objected. It is the same thing the `items` metadata key expresses, so it gets
+    the same combo box.
+    """
+    config = SampleTaskConfig()
+    form = _build(form_cls, config)
+
+    param_widget = form.parameter_widgets["a_literal"]
+    combo = param_widget.widget
+
+    assert isinstance(param_widget, ComboParameterWidget)
+    assert isinstance(combo, QComboBox)
+    assert [combo.itemData(i) for i in range(combo.count())] == ["cells", "hpf", "other"]
+    assert combo.currentData() == "hpf"
+
+    combo.setCurrentIndex(0)
+    form._on_parameter_changed("a_literal")
+    assert config.a_literal == "cells"
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_no_signal_is_connected_to_an_uneditable_field(qapp, form_cls):
+    """The guard is applied at connection time too, not only in the handler."""
+    config = SampleTaskConfig()
+    form = _build(form_cls, config)
+
+    nested_box = form.parameter_widgets["nested"].widget
+    editable_box = form.parameter_widgets["a_string"].widget
+
+    assert nested_box.receivers(nested_box.editingFinished) == 0
+    assert editable_box.receivers(editable_box.editingFinished) == 1
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_every_widget_type_the_form_builds_is_connectable(qapp, form_cls):
+    """Guards the list in _connect_widget_signals against a new editor type.
+
+    An editable widget whose Qt class is not one of the four the connector knows
+    about is connected to nothing: it looks editable, accepts input and never
+    reaches the config. Cheaper to assert here than to notice in the app.
+    """
+    form = _build(form_cls, SampleTaskConfig())
+    known = (QCheckBox, QSpinBox, QDoubleSpinBox, QLineEdit, QComboBox)
+
+    unconnectable = [
+        name
+        for name, param_widget in form.parameter_widgets.items()
+        if param_widget.editable and not isinstance(param_widget.widget, known)
+    ]
+
+    assert unconnectable == []


### PR DESCRIPTION
Follow-up to #300, from the same investigation.

## The bug

The generic task-parameters form builds an editor per dataclass field from the field's type, and fell back to a plain `QLineEdit` holding `str(value)` for any type it had no editor for — on the assumption that an unknown type round-trips through its own text. Almost nothing does. For a nested dataclass the box shows a `repr` that cannot be parsed back, and `_on_parameter_changed` wrote that string onto the config, replacing the object.

It needed no typing. `QLineEdit.editingFinished` fires on focus loss, so **tabbing past the field was enough**:

```
before: type(cfg.zparams) = ZParameters
after focus in / focus out, nothing typed: type(cfg.zparams) = str
```

The damage surfaced later and nowhere near the form — the task failing with `'str' object has no attribute 'order'`, and `experiment.save()` failing with `'str' object has no attribute 'to_dict'` (uncaught — `_save_experiment` has no try/except).

Six fields were exposed: `zparams`, `channel_settings` and `autofocus_settings` on the built-in `AcquireFluorescenceImageConfig`, and `zparams`, `reflection_channel` and `channel_settings` on an out-of-tree CLEM plugin's config. The built-in was saved only by `autolamella_task_config_editor.py:376` hiding this form for that one task, via an `isinstance` check on the config class — an accident of that gate rather than a guard, and one no plugin config can ever satisfy.

`resolve_field_types`'s own docstring already describes the same failure shape for numeric fields ("stores numeric values as raw strings"), so the fallback was known to be sharp; this removes the edge rather than working around it again.

## The change

- **Unknown types render as `ReadOnlyParameterWidget`** — a disabled box showing the value, with a tooltip saying where to edit it instead. Displayed rather than dropped: these are real settings an operator wants to read off the form.
- **`ParameterWidget` grows `editable`.** The change handler refuses to write a field whose widget isn't editable, and no signal is connected to one. Both, deliberately — the failure being prevented is silent data loss, so it gets two independent guards, and both are tested.
- **`List[T]` keeps the comma-separated editor only for scalar `T`.** A list of dataclasses came back as a list of strings.
- **`Literal[...]` renders as a combo of its allowed values.** It used to hit the same string fallback, so an operator could type a value the field doesn't accept and nothing objected — and it's exactly what the existing `items` metadata key expresses.
- **Both forms in the module now share one `create_parameter_widget`.** They each carried their own copy of this dispatch and had already drifted: `is` vs `==` comparisons, and one was missing the warning log. A field type handled in one form and not the other shows up as a corrupted config, not an error.

## Blast radius

Every registered task config, audited before and after:

| field | before | after |
|---|---|---|
| `ACQUIRE_FLUORESCENCE_IMAGE.channel_settings` | `ListParameterWidget` | `ReadOnlyParameterWidget` |
| `ACQUIRE_FLUORESCENCE_IMAGE.zparams` | `StringParameterWidget` | `ReadOnlyParameterWidget` |
| `ACQUIRE_FLUORESCENCE_IMAGE.autofocus_settings` | `StringParameterWidget` | `ReadOnlyParameterWidget` |

Nothing else changes — every other field keeps the widget it had. No editing capability is lost: those three are edited through `AutoLamellaFluorescenceAcquisitionTaskConfigWidget`, and this form is hidden for that task anyway.

## Tests

New `tests/ui/test_task_config_parameter_widgets.py`, built on a synthetic config with one field per dispatch branch, and **run against both form classes** so a fix landing in only one fails here rather than in someone's protocol.

- every supported type keeps its editor (8 types × 2 forms)
- a dataclass field, and a list of them, render read-only and disabled
- tabbing past an uneditable field leaves the value alone — the original bug
- the change handler refuses an uneditable field even when called directly
- an editable field still writes through
- `Literal` offers its allowed values and writes the chosen one
- no signal is connected to an uneditable field
- every editable widget is one of the Qt classes `_connect_widget_signals` knows about, so a new editor type can't silently connect to nothing

Mutation tested — each guard verified to actually fail:

| mutation | caught by |
|---|---|
| unknown type → editable string box (the old behaviour) | 10 of 32 |
| no `editable` guard in the change handler | `refuses_an_uneditable_field` ×2 |
| no `editable` guard at connection time | `no_signal_is_connected` ×2 |
| `Literal` falls through to the unknown-type branch | `literal_field_offers_its_allowed_values` ×2 |
| list-of-dataclass keeps the comma-separated editor | 4 of 32 |

One of these started out vacuous: `refuses_an_uneditable_field` passed with the handler guard deleted, because `ReadOnlyParameterWidget.get_value()` returns the value it was given, so an unguarded write assigns the same object and the config looks untouched. It now asserts the *change signal* doesn't fire — which is what would mark the protocol dirty and save it for an edit that never happened.

`tests/ui/` + `tests/autolamella/test_spot_burn.py` (the other importer): **948 passed**. Verified against the real CLEM plugin config too — focus in/out plus a forced write leaves `zparams` a `ZParameters` and `to_dict()` working.

## Note on out-of-set Literal values

A config holding a value the `Literal` does not declare (hand-edited protocol, or the allowed set changed since it was saved) displays as the first declared value while the config still holds the old one. Nothing is written on build, and a write only happens if the user actively changes the selection, so the stored value is not silently replaced.

Deliberately left as-is: such a value is invalid by declaration, and restricting the field to its declared values is the point of the change. This is also how the existing `items`-metadata combos already behave, so it is consistent rather than novel — and there are no `Literal` fields in any in-tree config today.
