### PR TITLE
[ui] Run the standalone FibsemUI on the quad-view canvas (FIB-406, phase 4a)

### DIFF
--- a/fibsem/ui/FibsemImageSettingsWidget.py
+++ b/fibsem/ui/FibsemImageSettingsWidget.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Dict, List, Optional, Tuple
 
-import napari
 import numpy as np
 from napari.layers import Image as NapariImageLayer
 from napari.layers import Points as NapariPointLayer
@@ -57,17 +56,19 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         parent: QtWidgets.QWidget,
     ):
         super().__init__(parent=parent)
-        if not hasattr(parent, "viewer") and not isinstance(parent.viewer, napari.Viewer):
-            raise ValueError("Parent must have a 'viewer' attribute of type napari.Viewer")
 
         self.parent = parent
         self.microscope = microscope
-        self.viewer = parent.viewer
-        self.eb_layer: NapariImageLayer = None
-        self.ib_layer: NapariImageLayer = None
+        # Optional viewer. A host that supplies one (AutoLamella today) gets the napari
+        # layer display; a host that supplies a `view_controller` instead (standalone
+        # FibsemUI) gets the quad-view canvas. Exactly one of the two is live per
+        # instance — see `_view_controller` and `uses_napari`.
+        self.viewer = getattr(parent, "viewer", None)
+        self.eb_layer: Optional["NapariImageLayer"] = None
+        self.ib_layer: Optional["NapariImageLayer"] = None
 
         # TODO: migrate to this structure
-        self.imaging_layers: Dict[BeamType, NapariImageLayer] = {}
+        self.imaging_layers: Dict[BeamType, Optional["NapariImageLayer"]] = {}
         self.imaging_layers[BeamType.ELECTRON] = None
         self.imaging_layers[BeamType.ION] = None
 
@@ -76,11 +77,13 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         self.ib_image = FibsemImage.generate_blank_image(resolution=image_settings.resolution, hfw=image_settings.hfw)
 
         # overlay layers
-        self.ruler_layer: Optional[NapariPointLayer] = None
-        self.alignment_layer: Optional[NapariShapesLayer] = None
+        self.ruler_layer: Optional["NapariPointLayer"] = None
+        self.alignment_layer: Optional["NapariShapesLayer"] = None
 
         self.is_acquiring: bool = False
         self._ruler_enabled: bool = False
+        self._live_beam: Optional[BeamType] = None  # beam currently live (canvas LIVE badge)
+        self._overlay_edited_wired = False  # subscribed to controller.overlay_edited
 
         self._setup_ui()
         self.setup_connections()
@@ -90,11 +93,45 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
             self._set_image_settings_to_ui(image_settings)
             self.update_ui_saving_settings()
 
-        # register initial images
-        self.eb_layer = self.viewer.add_image(self.eb_image.data, name=BeamType.ELECTRON.name, blending='additive')
-        self.ib_layer = self.viewer.add_image(self.ib_image.data, name=BeamType.ION.name, blending='additive')
-        self._on_acquire(self.eb_image)
-        self._on_acquire(self.ib_image)
+        if self.uses_napari:
+            # register initial images
+            self.eb_layer = self.viewer.add_image(self.eb_image.data, name=BeamType.ELECTRON.name, blending='additive')
+            self.ib_layer = self.viewer.add_image(self.ib_image.data, name=BeamType.ION.name, blending='additive')
+            self._on_acquire(self.eb_image)
+            self._on_acquire(self.ib_image)
+        # NOTE: the canvases are intentionally left empty ("No image") on connect — no
+        # blank placeholder is seeded. eb_image / ib_image remain as internal fallbacks
+        # and appear once a real acquisition arrives (sem/fib_acquisition_signal).
+
+    # ------------------------------------------------------------------
+    # Display backend
+    # ------------------------------------------------------------------
+
+    @property
+    def uses_napari(self) -> bool:
+        """True when this instance draws into a napari viewer rather than the quad view."""
+        return self.viewer is not None
+
+    def _view_controller(self):
+        """Return the quad-view MicroscopeViewController, or None when inactive.
+
+        Two hosts expose it: standalone ``FibsemUI`` (the direct parent holds
+        ``view_controller``) and AutoLamella (parent -> ``AutoLamellaUI`` ->
+        ``parent_widget`` -> the main window). Check the direct parent first, then the
+        AutoLamella chain; ``None`` if neither holds one.
+
+        A viewer takes precedence, keeping the two display paths strictly exclusive.
+        ``FibsemUI`` always builds a controller, so a caller that also passes a viewer
+        would otherwise get both at once — images drawn twice, and the alignment area
+        living in the model while the layer it is read back from stays empty.
+        """
+        if self.uses_napari:
+            return None
+        controller = getattr(self.parent, "view_controller", None)
+        if controller is not None:
+            return controller
+        parent_ui = getattr(self.parent, "parent_widget", None)
+        return getattr(parent_ui, "view_controller", None)
 
     # ------------------------------------------------------------------
     # Backward-compatibility properties for callers outside this widget
@@ -147,7 +184,10 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         self._spinner = _SpinnerLabel(parent=self)
         self._spinner.setVisible(False)
 
-        # View tool buttons (scalebar, crosshair) + spinner — right-aligned alongside the lamella checkbox
+        # View tool buttons (scalebar, crosshair) + spinner — right-aligned alongside the lamella checkbox.
+        # These drive napari layers only; the quad-view canvas draws its own scalebar and
+        # crosshair from its own controls, so they are hidden (not just inert) when
+        # viewer-less — an unresponsive button reads as a bug.
         self.btn_scalebar = IconToolButton(
             icon="mdi:arrow-expand-horizontal",
             checked_color=stylesheets.GRAY_WHITE_COLOR,
@@ -160,6 +200,8 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
             tooltip="Cross Hair",
             checked=True,
         )
+        self.btn_scalebar.setVisible(self.uses_napari)
+        self.btn_crosshair.setVisible(self.uses_napari)
 
         tools_row = QtWidgets.QWidget()
         tools_layout = QtWidgets.QHBoxLayout(tools_row)
@@ -270,34 +312,97 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         self.microscope.fib_acquisition_signal.connect(self._on_acquire)
         self.pushButton_start_acquisition.clicked.connect(self.toggle_live_acquisition)
 
+        self._connect_canvas_controls()
+
+    def _connect_canvas_controls(self) -> None:
+        """Wire the quad-view-only controls. No-op on the napari path."""
+        self._wd_scroll_connections: List[tuple] = []
+        self._view_sync_connections: List[tuple] = []
+        controller = self._view_controller()
+        if controller is None:
+            return
+
+        # Working-distance Shift+scroll nudge on the SEM/FIB canvases (mirrors the FM
+        # objective wheel). Store the bound-method connections for teardown — the canvases
+        # outlive this widget, so a leaked connection would drive a dead slot on reconnect.
+        for beam, canvas in (
+            (BeamType.ELECTRON, controller.sem_canvas),
+            (BeamType.ION, controller.fib_canvas),
+        ):
+            beam_widget = (
+                self.dual_beam_widget.sem_widget
+                if beam is BeamType.ELECTRON
+                else self.dual_beam_widget.fib_widget
+            )
+            slot = beam_widget.beam_settings_widget._on_canvas_scroll
+            canvas.canvas_scrolled.connect(slot)
+            self._wd_scroll_connections.append((canvas, slot))
+
+        # Two-way sync between the quad-view selection and the SEM/FIB beam radios:
+        # selecting a canvas checks its radio (revealing that beam's settings), and checking
+        # a radio selects its canvas. The controller is persistent, so store the connections
+        # for teardown (else a reconnect leaks onto a dead widget). Loop-safe: set_selected
+        # no-ops on re-select and setChecked emits no toggled when already set.
+        controller.view_selected.connect(self._on_view_selected)
+        self._view_sync_connections.append((controller.view_selected, self._on_view_selected))
+        self._on_view_selected(controller.selected_view)  # align radio to current selection
+        self.dual_beam_widget.sem_radio.toggled.connect(self._on_beam_radio_toggled)
+        self._view_sync_connections.append(
+            (self.dual_beam_widget.sem_radio.toggled, self._on_beam_radio_toggled)
+        )
+
+    def _on_view_selected(self, key) -> None:
+        """Quad-view selection changed -> check the matching beam radio (view -> radio).
+        Ignores ``"fm"`` / ``None`` (no beam radio)."""
+        if key is BeamType.ELECTRON:
+            self.dual_beam_widget.sem_radio.setChecked(True)
+        elif key is BeamType.ION:
+            self.dual_beam_widget.fib_radio.setChecked(True)
+
+    def _on_beam_radio_toggled(self, sem_checked: bool) -> None:
+        """Beam radio toggled -> select the matching canvas in the quad view (radio -> view)."""
+        controller = self._view_controller()
+        if controller is None:
+            return
+        widget = getattr(controller, "widget", None)
+        if widget is not None and hasattr(widget, "set_selected"):
+            widget.set_selected(BeamType.ELECTRON if sem_checked else BeamType.ION)
+
     @ensure_main_thread
     def _on_acquire(self, image: FibsemImage):
-        """Update the viewer from the main thread"""
+        """Update the display from the main thread (napari layer or quad-view canvas)."""
         try:
             if image.metadata is None:
-                raise ValueError("Image metadata is None, cannot update viewer layer without beam type information.")
+                raise ValueError("Image metadata is None, cannot update the display without beam type information.")
 
-            # Update existing layer
-            layer = self.viewer.layers[image.metadata.beam_type.name]
-            layer.data = image.filtered_data
+            if self.uses_napari:
+                # Update existing layer
+                layer = self.viewer.layers[image.metadata.beam_type.name]
+                layer.data = image.filtered_data
             # update images references
             if self.microscope.is_acquiring:
                 if image.metadata.beam_type is BeamType.ELECTRON:
                     self.eb_image = image
                 elif image.metadata.beam_type is BeamType.ION:
                     self.ib_image = image
-        except Exception as e:
-            logging.error(f"Error updating image layer: {e}")
 
-        # dont reset view when live acq
-        self._update_layer_positions()
-        self.restore_active_layer_for_movement()
+            controller = self._view_controller()
+            if controller is not None:
+                controller.set_image(image.metadata.beam_type, image)
+        except Exception as e:
+            logging.error(f"Error updating image: {e}")
+
+        if self.uses_napari:
+            # dont reset view when live acq
+            self._update_layer_positions()
+            self.restore_active_layer_for_movement()
         self.viewer_update_signal.emit()
 
     def toggle_live_acquisition(self, event=None):
         if self.microscope.is_acquiring:
             logging.info("Microscope is already acquiring. Stopping acquisition...")
             self.microscope.stop_acquisition()
+            self._set_live_indicator(None)  # clear the green border + LIVE badge
             self.pushButton_start_acquisition.setText("Start Acquisition")
             self.pushButton_start_acquisition.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
             for btn in self.acquisition_buttons:
@@ -321,8 +426,20 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
 
         beam_type = self.dual_beam_widget.beam_type
         self.microscope.start_acquisition(beam_type)
+        self._set_live_indicator(beam_type)  # green border + LIVE badge on the live view
         self.pushButton_start_acquisition.setText("Stop Acquisition")
         self.pushButton_start_acquisition.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
+
+    def _set_live_indicator(self, beam_type: Optional[BeamType]) -> None:
+        """Drive the quad-view live indicator (green border + 'LIVE' badge): pass the live beam,
+        or None to clear. Also clears a previously-live beam (on stop or a beam switch).
+        No-op on the napari path, which has no per-view indicator."""
+        controller = self._view_controller()
+        if self._live_beam is not None and self._live_beam is not beam_type and controller is not None:
+            controller.set_live(self._live_beam, False)
+        self._live_beam = beam_type
+        if beam_type is not None and controller is not None:
+            controller.set_live(beam_type, True)
 
     def update_ruler(self):
         """Initialise the ruler in the viewer"""
@@ -330,6 +447,9 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         # TODO: migrate to using a line layer for everything, and enable 'select vertices' mode to move it.
         # TODO: allow multiple rulers
         # TODO: re-do this and consolidate into napari.utilities
+
+        if not self.uses_napari:
+            return  # napari-only tool; the quad-view canvas has no ruler yet (FIB-359)
 
         if not self._ruler_enabled:
             # remove the ruler layers
@@ -659,6 +779,9 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
     def update_ui_tools(self):
         """Redraw the ui tools (scalebar, crosshair)"""
 
+        if not self.uses_napari:
+            return  # the quad-view canvas draws its own scalebar/crosshair
+
         # draw scalebar and crosshair
         if self.eb_image is not None and self.ib_image is not None:
             draw_scalebar_in_napari(
@@ -688,6 +811,8 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
 
     def _update_layer_positions(self):
         """Update the positions of the image layers in the viewer. Ion beam to the right of electron beam."""
+        if not self.uses_napari:
+            return  # the quad view gives each beam its own canvas — nothing to translate
         # translate ion beam layer to the right of electron beam, adjust the camera
         if self.eb_layer and self.ib_layer:
             self.ib_layer.translate = [0.0, self.eb_layer.data.shape[1]]
@@ -742,21 +867,75 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         return coords, beam_type, image
 
     def closeEvent(self, event: QEvent):
-        self.viewer.layers.clear()
+        self._teardown_connections()
+        if self.uses_napari:
+            self.viewer.layers.clear()
         event.accept()
 
+    def _teardown_connections(self) -> None:
+        """Drop this widget's subscriptions to the app-lifetime quad-view controller and
+        canvases. Idempotent, and called from ``closeEvent`` AND the host's disconnect path —
+        ``deleteLater`` fires neither ``closeEvent`` nor ``close``, so without this a scroll
+        or overlay edit after a reconnect would drive the dead widget's slot on the still-live
+        controller, and PyQt aborts the process on an exception in a slot (FIB-329)."""
+        if self._overlay_edited_wired:
+            controller = self._view_controller()
+            if controller is not None:
+                try:
+                    controller.overlay_edited.disconnect(self._on_controller_overlay_edited)
+                except (TypeError, RuntimeError):
+                    pass
+            self._overlay_edited_wired = False
+
+        # WD Shift+scroll: disconnect from the (persistent) canvases and cancel any pending
+        # debounced move so it can't fire on a torn-down beam-settings widget.
+        for canvas, slot in getattr(self, "_wd_scroll_connections", []):
+            try:
+                canvas.canvas_scrolled.disconnect(slot)
+            except (TypeError, RuntimeError):
+                pass
+        self._wd_scroll_connections = []
+        for beam_widget in (self.dual_beam_widget.sem_widget, self.dual_beam_widget.fib_widget):
+            try:
+                beam_widget.beam_settings_widget._execute_wd_wheel_move.cancel()
+            except Exception:
+                pass
+
+        # View <-> beam-radio sync: drop both directions (controller is persistent).
+        for signal, slot in getattr(self, "_view_sync_connections", []):
+            try:
+                signal.disconnect(slot)
+            except (TypeError, RuntimeError):
+                pass
+        self._view_sync_connections = []
+
     def clear_viewer(self):
-        self.viewer.layers.clear()
+        if self.uses_napari:
+            self.viewer.layers.clear()
         self.eb_layer = None
         self.ib_layer = None
+        controller = self._view_controller()
+        if controller is not None:
+            controller.clear()
 
     def restore_active_layer_for_movement(self):
         """Restore the active layer to the electron beam for movement"""
+        if not self.uses_napari:
+            return  # no layer stack; the quad view routes input per canvas
         if self.eb_layer in self.viewer.layers:
             self.viewer.layers.selection.active = self.eb_layer
 
     def clear_alignment_area(self):
-        """Hide the alignment area layer"""
+        """Hide the alignment area, keeping its value.
+
+        The workflow reads ``get_alignment_area()`` straight after sending its "clear"
+        (``update_alignment_area_ui``), so the rect must survive being hidden — on the napari
+        path the layer keeps its data, and on the quad view the model keeps its value.
+        """
+        controller = self._view_controller()
+        if controller is not None:
+            controller.set_alignment_edit(BeamType.ION, None, editing=False)
+            return
         if self.alignment_layer is not None:
             self.alignment_layer.mode = "pan_zoom"
             self.alignment_layer.visible = False
@@ -764,7 +943,30 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
 
     def toggle_alignment_area(self, reduced_area: FibsemRectangle, editable: bool = True):
         """Toggle the alignment area layer to selection mode, and display the alignment area."""
+        controller = self._view_controller()
+        if controller is not None:
+            self._ensure_overlay_edited_wiring(controller)
+            # editing wins over the milling read-only display + owns FIB input
+            controller.set_alignment_edit(BeamType.ION, reduced_area, editing=editable)
+            return
         self.set_alignment_layer(reduced_area, editable=editable)
+
+    def _ensure_overlay_edited_wiring(self, controller) -> None:
+        """Subscribe (once) to the controller's overlay-edit signal so a user drag of the
+        alignment area drives the existing validation/workflow path unchanged."""
+        if self._overlay_edited_wired:
+            return
+        controller.overlay_edited.connect(self._on_controller_overlay_edited)
+        self.alignment_area_updated.connect(self._on_alignment_area_updated)
+        self._overlay_edited_wired = True
+
+    def _on_controller_overlay_edited(self, beam, overlay_id, value) -> None:
+        """Route a committed alignment-area edit into the existing signal/workflow.
+
+        The authoritative value lives in the model (``controller.alignment_area``); this
+        just drives validation, so it forwards the edit without caching it."""
+        if overlay_id == "alignment":
+            self.alignment_area_updated.emit(value)
 
     def set_alignment_layer(
         self,
@@ -828,7 +1030,12 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
             logging.info(f"Error updating alignment area: {e}")
 
     def get_alignment_area(self) -> Optional[FibsemRectangle]:
-        """Get the alignment area from the alignment layer."""
+        """Get the alignment area — from the scene model (quad view) or the layer (napari)."""
+        controller = self._view_controller()
+        if controller is not None:
+            return controller.alignment_area(BeamType.ION)
+        if self.alignment_layer is None:
+            return None
         data = self.alignment_layer.data
         if data is None or len(data) == 0:
             return None

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -212,18 +212,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
                     canvas.canvas_double_clicked.connect(slot)
                     self._canvas_dbl_click_conns.append((canvas, slot))
 
-    def _teardown_connections(self) -> None:
-        """Disconnect from the app-lifetime quad-view canvases before this widget is
-        destroyed. The canvases outlive the per-connection movement widget; without this a
-        stale double-click after teardown fires on a deleted widget and PyQt aborts the
-        process. Idempotent — safe to call more than once."""
-        for canvas, slot in getattr(self, "_canvas_dbl_click_conns", []):
-            try:
-                canvas.canvas_double_clicked.disconnect(slot)
-            except (TypeError, RuntimeError):
-                pass
-        self._canvas_dbl_click_conns = []
-
         # disable ui elements
         self.label_movement_instructions.setText(INSTRUCTIONS_TEXT)
         self.label_movement_instructions.setStyleSheet(LABEL_INSTRUCTIONS_STYLE)
@@ -312,6 +300,18 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             self.gridLayout_2.addWidget(self.sample_holder_widget, 3, 0)
 
         self.update_ui()
+
+    def _teardown_connections(self) -> None:
+        """Disconnect from the app-lifetime quad-view canvases before this widget is
+        destroyed. The canvases outlive the per-connection movement widget; without this a
+        stale double-click after teardown fires on a deleted widget and PyQt aborts the
+        process. Idempotent — safe to call more than once."""
+        for canvas, slot in getattr(self, "_canvas_dbl_click_conns", []):
+            try:
+                canvas.canvas_double_clicked.disconnect(slot)
+            except (TypeError, RuntimeError):
+                pass
+        self._canvas_dbl_click_conns = []
 
     def _toggle_interactions(self, enable: bool, caller: Optional[str] = None):
         """Toggle the interactions in the widget depending on microscope state"""
@@ -456,8 +456,23 @@ class FibsemMovementWidget(QtWidgets.QWidget):
                 self._double_click(layer, event)
                 return
 
+    def _click_to_move_available(self) -> bool:
+        """Whether a click may start a stage move right now.
+
+        Click-to-move is the same action as the Move button, so it honours the same
+        enabled state — `_toggle_interactions` disables the buttons for the whole move
+        *and* the acquisition that follows it (`move_stage_finished` deliberately returns
+        early while `image_widget.is_acquiring`). Only the buttons were ever gated,
+        though: a click landing in that window started a second, overlapping stage move
+        and a second acquisition on the same microscope, which is how a SEM frame ended
+        up on the FIB canvas.
+        """
+        return self.pushButton_move.isEnabled()
+
     def _double_click(self, layer, event):
         """Callback for double-click mouse events on the image widget"""
+        if not self._click_to_move_available():
+            return
         self._toggle_interactions(enable= False)
 
         worker = self._double_click_worker(layer, event)
@@ -547,6 +562,8 @@ class FibsemMovementWidget(QtWidgets.QWidget):
 
     def _on_canvas_double_click(self, beam_type: BeamType, x: float, y: float, modifiers) -> None:
         """Quad-view canvas double-click -> move stage (mirrors ``_double_click``)."""
+        if not self._click_to_move_available():
+            return
         self._toggle_interactions(enable=False)
         worker = self._canvas_double_click_worker(beam_type, x, y, modifiers)
         worker.finished.connect(self.move_stage_finished)

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -1,8 +1,8 @@
 
 import logging
+from functools import partial
 from typing import Optional
 
-import napari
 import numpy as np
 from fibsem.ui.qt.threading import thread_worker
 from PyQt5 import QtCore, QtWidgets
@@ -45,13 +45,34 @@ class FibsemMovementWidget(QtWidgets.QWidget):
 
         if not hasattr(parent, 'image_widget') or not isinstance(parent.image_widget, FibsemImageSettingsWidget):
             raise ValueError("Parent must have an 'image_widget' attribute of type FibsemImageSettingsWidget")
-        if not hasattr(parent, "viewer") or not isinstance(parent.viewer, napari.Viewer):
-            raise ValueError("Parent must have a 'viewer' attribute of type napari.Viewer")
 
         self.microscope = microscope
-        self.viewer = parent.viewer
+        # Optional: quad-view hosts run viewer-less (double-click and the position readout
+        # come from the canvases and the controller's info bar instead).
+        self.viewer = getattr(parent, "viewer", None)
         self.image_widget: FibsemImageSettingsWidget = parent.image_widget
         self.setup_connections()
+
+    @property
+    def uses_napari(self) -> bool:
+        """True when this instance takes its input from a napari viewer."""
+        return self.viewer is not None
+
+    def _view_controller(self):
+        """Return the quad-view MicroscopeViewController, or None if unavailable.
+
+        Resolved like the image widget: the direct parent (standalone ``FibsemUI``) or
+        parent -> ``parent_widget`` (AutoLamella) holds ``view_controller``. A viewer takes
+        precedence, keeping the two input paths strictly exclusive — otherwise a host with
+        both would arm napari *and* canvas double-click and move the stage twice per click.
+        """
+        if self.uses_napari:
+            return None
+        controller = getattr(self.parent, "view_controller", None)
+        if controller is not None:
+            return controller
+        parent_ui = getattr(self.parent, "parent_widget", None)
+        return getattr(parent_ui, "view_controller", None)
 
     def _setup_ui(self):
         # Outer layout
@@ -167,11 +188,41 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.btn_refresh_stage.clicked.connect(lambda: self.update_ui(None))
 
         # register mouse callbacks
-        if cfg.FEATURE_VIEWER_MOVEMENT_EVENTS:
-            self.viewer.mouse_double_click_callbacks.append(self._viewer_double_click)
+        self._canvas_dbl_click_conns = []
+        if self.uses_napari:
+            if cfg.FEATURE_VIEWER_MOVEMENT_EVENTS:
+                self.viewer.mouse_double_click_callbacks.append(self._viewer_double_click)
+            else:
+                self.image_widget.eb_layer.mouse_double_click_callbacks.append(self._double_click)
+                self.image_widget.ib_layer.mouse_double_click_callbacks.append(self._double_click)
         else:
-            self.image_widget.eb_layer.mouse_double_click_callbacks.append(self._double_click)
-            self.image_widget.ib_layer.mouse_double_click_callbacks.append(self._double_click)
+            # One canvas per beam (quad-view). The canvases are app-lifetime (owned by the
+            # controller), so store each (canvas, slot) pair and disconnect it in
+            # _teardown_connections: this widget is torn down via removeTab + deleteLater
+            # (which fires neither closeEvent nor close), and a stale double-click firing on
+            # the deleted widget makes PyQt call qFatal -> the process aborts (FIB-329).
+            # partial (not lambda) so the exact slot object can be disconnected.
+            controller = self._view_controller()
+            if controller is not None:
+                for canvas, beam in (
+                    (controller.sem_canvas, BeamType.ELECTRON),
+                    (controller.fib_canvas, BeamType.ION),
+                ):
+                    slot = partial(self._on_canvas_double_click, beam)
+                    canvas.canvas_double_clicked.connect(slot)
+                    self._canvas_dbl_click_conns.append((canvas, slot))
+
+    def _teardown_connections(self) -> None:
+        """Disconnect from the app-lifetime quad-view canvases before this widget is
+        destroyed. The canvases outlive the per-connection movement widget; without this a
+        stale double-click after teardown fires on a deleted widget and PyQt aborts the
+        process. Idempotent — safe to call more than once."""
+        for canvas, slot in getattr(self, "_canvas_dbl_click_conns", []):
+            try:
+                canvas.canvas_double_clicked.disconnect(slot)
+            except (TypeError, RuntimeError):
+                pass
+        self._canvas_dbl_click_conns = []
 
         # disable ui elements
         self.label_movement_instructions.setText(INSTRUCTIONS_TEXT)
@@ -285,7 +336,19 @@ class FibsemMovementWidget(QtWidgets.QWidget):
 
         is_finished = ddict.get("finished", False)
         if is_finished:
-            update_text_overlay(self.viewer, self.microscope)
+            self._update_position_readout()
+
+    def _update_position_readout(
+        self, stage_position: Optional[FibsemStagePosition] = None
+    ) -> None:
+        """Refresh the stage/beam readout — the napari text overlay or, viewer-less, the
+        quad-view info bar (debounced render)."""
+        if self.uses_napari:
+            update_text_overlay(self.viewer, self.microscope, stage_position=stage_position)
+            return
+        controller = self._view_controller()
+        if controller is not None:
+            controller.update_info(self.microscope, stage_position=stage_position)
 
     def handle_acquisition_update(self, ddict: dict):
         """Handle acquisition updates from the image widget"""
@@ -306,7 +369,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.doubleSpinBox_movement_stage_tilt.setValue(np.degrees(stage_position.t))
 
         # update the current position label
-        update_text_overlay(self.viewer, self.microscope, stage_position=stage_position)
+        self._update_position_readout(stage_position=stage_position)
 
     @ensure_main_thread
     def update_ui_after_movement(self, retake: bool = True):
@@ -337,7 +400,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         # refresh tooltip and overlay
         milling = self.microscope.get_orientation("MILLING")
         self.pushButton_move_to_milling_angle.setToolTip(milling.pretty_orientation)
-        update_text_overlay(self.viewer, self.microscope)
+        self._update_position_readout()
 
 #### MOVEMENT
 
@@ -430,13 +493,31 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             return
 
         point = conversions.image_to_microscope_image_coordinates(
-            coord=Point(x=coords[1], y=coords[0]), 
-            image=image.data, 
+            coord=Point(x=coords[1], y=coords[0]),
+            image=image.data,
             pixelsize=image.metadata.pixel_size.x,
         )
 
         # move
         vertical_move = True if "Alt" in event.modifiers else False
+        self._execute_stage_move(
+            beam_type, point, vertical_move, coords={"x": coords[1], "y": coords[0]}
+        )
+
+    def _execute_stage_move(
+        self,
+        beam_type: BeamType,
+        point: Point,
+        vertical_move: bool,
+        coords: Optional[dict] = None,
+    ) -> None:
+        """Dispatch a stage move from a microscope-space delta (worker thread).
+
+        Shared by the napari and quad-view double-click paths — the two differ only in how
+        they turn a click into ``point``, not in what the move does. ``coords`` is the
+        originating image-space click, carried through purely so the debug log still
+        records where the operator actually clicked when a move goes wrong on hardware.
+        """
         movement_mode = "Vertical" if vertical_move else "Stable"
 
         logging.debug({
@@ -444,7 +525,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             "movement_mode": movement_mode,             # movement mode
             "beam_type": beam_type.name,                # beam type
             "dm": point.to_dict(),                      # shift in microscope coordinates
-            "coords": {"x": coords[1], "y": coords[0]}, # coords in image coordinates
+            "coords": coords,                           # coords in image coordinates
         })
 
         self.movement_progress_signal.emit({"msg": "Moving stage..."})
@@ -463,6 +544,47 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             )
         self.movement_progress_signal.emit({"msg": "Move finished, updating UI"})
         self.update_ui_after_movement()
+
+    def _on_canvas_double_click(self, beam_type: BeamType, x: float, y: float, modifiers) -> None:
+        """Quad-view canvas double-click -> move stage (mirrors ``_double_click``)."""
+        self._toggle_interactions(enable=False)
+        worker = self._canvas_double_click_worker(beam_type, x, y, modifiers)
+        worker.finished.connect(self.move_stage_finished)
+        worker.start()
+
+    @thread_worker
+    def _canvas_double_click_worker(self, beam_type: BeamType, x: float, y: float, modifiers):
+        """Thread worker for quad-view double-clicks (one image per canvas).
+
+        ``x, y`` are already beam-local, full-resolution image pixels (the canvas emits data
+        coords), so no napari ``world_to_data`` / side-by-side offset handling is needed —
+        unlike ``_double_click_worker``, which has to work out which half was clicked.
+        """
+        if "Shift" in modifiers:
+            return
+        if hasattr(self.parent, "milling_widget") and self.parent.milling_widget.is_milling:
+            notification_service.show_toast("Cannot move stage while milling is in progress.")
+            return
+        image = (
+            self.image_widget.eb_image
+            if beam_type is BeamType.ELECTRON
+            else self.image_widget.ib_image
+        )
+        if image is None or image.metadata is None:
+            notification_service.show_toast("No image available to move from.")
+            return
+        h, w = image.data.shape[:2]
+        if not (0 <= x < w and 0 <= y < h):
+            return  # click landed outside the image area
+        self.movement_progress_signal.emit({"msg": "Click to move in progress..."})
+        point = conversions.image_to_microscope_image_coordinates(
+            coord=Point(x=x, y=y),
+            image=image.data,
+            pixelsize=image.metadata.pixel_size.x,
+        )
+        self._execute_stage_move(
+            beam_type, point, "Alt" in modifiers, coords={"x": x, "y": y}
+        )
 
     def move_to_orientation(self, orientation: str)-> None:
         """Move to the specifed orientation"""

--- a/fibsem/ui/FibsemUI.py
+++ b/fibsem/ui/FibsemUI.py
@@ -1,30 +1,51 @@
-import napari
 from PyQt5 import QtWidgets
-from PyQt5.QtCore import pyqtSignal
-import napari.utils.notifications
-import fibsem
+from PyQt5.QtCore import Qt
+
 from fibsem.versioning import get_version_string
 from fibsem.microscope import FibsemMicroscope
-from fibsem.structures import BeamType, MicroscopeSettings
+from fibsem.structures import MicroscopeSettings
+from fibsem.ui import notification_service
 from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
 from fibsem.ui.FibsemManipulatorWidget import FibsemManipulatorWidget
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
-from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
 from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
 from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
 from fibsem.ui.qtdesigner_files import FibsemUI as FibsemUIMainWindow
+from fibsem.ui.stylesheets import NAPARI_STYLE
+from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
 
 
 class FibsemUI(FibsemUIMainWindow.Ui_MainWindow, QtWidgets.QMainWindow):
 
-    def __init__(self, viewer: napari.Viewer):
+    def __init__(self, viewer=None):
         super().__init__()
         self.setupUi(self)
 
-        self.label_title.setText(f"fibsemOS v{get_version_string()}")
+        # napari-style dark theme, matching AutoLamellaMainUI. The napari window used to
+        # supply this; a standalone window has to set it itself.
+        self.setStyleSheet(NAPARI_STYLE)
 
+        # Title now lives in the window titlebar; drop the in-panel label.
+        # get_version_string (not fibsem.__version__) so the running git revision still
+        # shows once napari's viewer.title is gone — see FIB-349 / #202.
+        self.setWindowTitle(f"fibsemOS v{get_version_string()}")
+        self.gridLayout.removeWidget(self.label_title)
+        self.label_title.deleteLater()
+
+        # Viewer-less by default: the quad-view controller is the display. `viewer` is
+        # retained so a caller that still has a napari Viewer gets the old layer path —
+        # the image/movement widgets read it off this attribute.
         self.viewer = viewer
-        self.viewer.title = f"fibsemOS v{get_version_string()}"
+
+        # Quad-view display: the controller's SEM/FIB canvases are the left pane; the
+        # existing tab panel becomes the right pane.
+        self.view_controller = MicroscopeViewController(parent=self)
+        splitter = QtWidgets.QSplitter(Qt.Horizontal)
+        splitter.setChildrenCollapsible(False)
+        splitter.addWidget(self.view_controller.widget)
+        splitter.addWidget(self.centralwidget)
+        splitter.setSizes([720, 460])
+        self.setCentralWidget(splitter)
 
         self.microscope: FibsemMicroscope = None
         self.settings: MicroscopeSettings = None
@@ -48,12 +69,19 @@ class FibsemUI(FibsemUIMainWindow.Ui_MainWindow, QtWidgets.QMainWindow):
 
     def open_minimap_widget(self):
         if self.microscope is None:
-            napari.utils.notifications.show_warning("Please connect to a microscope first... [No Microscope Connected]")
+            notification_service.show_toast("Please connect to a microscope first... [No Microscope Connected]", "warning")
             return
 
         if self.movement_widget is None:
-            napari.utils.notifications.show_warning("Please connect to a microscope first... [No Movement Widget]")
+            notification_service.show_toast("Please connect to a microscope first... [No Movement Widget]", "warning")
             return
+
+        # NOTE: the minimap still opens its own napari viewer. It is being rebuilt on the
+        # FM-overview (multi-image) model in Phase 3 / FIB-405, so it is deliberately left
+        # alone here rather than ported twice.
+        import napari
+
+        from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
 
         self.viewer_minimap = napari.Viewer(ndisplay=2)
         self.minimap_widget = FibsemMinimapWidget(viewer=self.viewer_minimap, parent=self)
@@ -108,6 +136,7 @@ class FibsemUI(FibsemUIMainWindow.Ui_MainWindow, QtWidgets.QMainWindow):
                 microscope=self.microscope,
                 parent=self,
                 viewer=self.viewer,
+                image_widget=self.image_widget,  # lets it resolve the quad controller
             )
             if self.microscope.system.manipulator.enabled:
                 self.manipulator_widget = FibsemManipulatorWidget(
@@ -143,7 +172,12 @@ class FibsemUI(FibsemUIMainWindow.Ui_MainWindow, QtWidgets.QMainWindow):
             self.tabWidget.removeTab(2)
             self.tabWidget.removeTab(1)
             self.image_widget.clear_viewer()
+            # Drop the widgets' controller/canvas connections before deleteLater — the
+            # canvases persist across a reconnect, so a leaked slot would fire on a dead
+            # widget (deleteLater fires neither closeEvent nor close).
+            self.image_widget._teardown_connections()
             self.image_widget.deleteLater()
+            self.movement_widget._teardown_connections()
             self.movement_widget.deleteLater()
             self.milling_widget.deleteLater()
             if self.manipulator_widget is not None:
@@ -153,13 +187,13 @@ class FibsemUI(FibsemUIMainWindow.Ui_MainWindow, QtWidgets.QMainWindow):
 
 def main():
 
-    viewer = napari.Viewer(ndisplay=2)
-    fibsem_ui = FibsemUI(viewer=viewer)
-    viewer.window.add_dock_widget(fibsem_ui, 
-                                  area="right", 
-                                  add_vertical_stretch=False, 
-                                  name=f"fibsemOS v{get_version_string()}")
-    napari.run()
+    # Fully viewer-less: the quad-view controller is the display, so there is no napari
+    # main viewer. (The minimap still opens its own, on demand — see open_minimap_widget.)
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    app.setStyle("Fusion")
+    fibsem_ui = FibsemUI()
+    fibsem_ui.show()
+    app.exec_()
 
 
 if __name__ == "__main__":

--- a/fibsem/ui/widgets/beam_settings_widget.py
+++ b/fibsem/ui/widgets/beam_settings_widget.py
@@ -11,12 +11,17 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from superqt.utils import qdebounced
+
 from fibsem import constants, utils
 from fibsem import config as cfg
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamSettings, BeamType, Point
 from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import _create_combobox_control
+
+# Working-distance step per Shift+scroll notch (mm). 1 um — fine focus control.
+WD_WHEEL_STEP_MM = 0.001
 
 # GUI Configuration Constants
 WIDGET_CONFIG = {
@@ -58,7 +63,7 @@ WIDGET_CONFIG = {
     "working_distance": {
         "label": "Working Distance",
         "range": (1.0, 30.0),
-        "decimals": 2,
+        "decimals": 3,  # mm -> 1 um resolution (matches the Shift+scroll step)
         "step": 0.01,
         "suffix": f" {constants.MILLIMETRE_SYMBOL}",
     },
@@ -85,6 +90,12 @@ class FibsemBeamSettingsWidget(QWidget):
         self._setup_ui()
         self._connect_signals()
         self._update_visibility()
+
+        # Shift+scroll working-distance nudge (mirrors the FM objective wheel): the spinbox
+        # updates immediately for feedback, the hardware move is debounced so a burst of
+        # scroll notches coalesces into a single move.
+        self._wd_wheel_target_mm: float = self.working_distance_spinbox.value()
+        self._execute_wd_wheel_move = qdebounced(self._execute_wd_wheel_move_impl, timeout=150)
 
     # ------------------------------------------------------------------
     # UI setup
@@ -249,6 +260,49 @@ class FibsemBeamSettingsWidget(QWidget):
         self.microscope.set_working_distance(wd, self.beam_type)
         logging.info({"msg": "_on_working_distance_changed", "beam_type": self.beam_type.name, "working_distance": wd})
         self.settings_changed.emit(self.get_settings())
+
+    # ------------------------------------------------------------------
+    # Working-distance mouse-wheel nudge (Shift + scroll on the beam canvas)
+    # ------------------------------------------------------------------
+
+    def _on_canvas_scroll(self, x: float, y: float, direction: int, modifiers) -> None:
+        """Shift+scroll on this beam's canvas nudges the working distance by one spinbox step;
+        plain scroll is left to the canvas (zoom). The hardware move is debounced so a burst of
+        notches coalesces into one move. Unlike the FM objective, WD (beam focus) can be adjusted
+        live while scanning — that's how you focus — so there is deliberately no acquisition lockout."""
+        if "Shift" not in modifiers:
+            return
+        sb = self.working_distance_spinbox
+        new_val = float(
+            np.clip(sb.value() + WD_WHEEL_STEP_MM * direction, sb.minimum(), sb.maximum())
+        )
+        # immediate visual feedback without a hardware call; debounce the actual move
+        sb.blockSignals(True)
+        sb.setValue(new_val)
+        sb.blockSignals(False)
+        self._wd_wheel_target_mm = new_val
+        # transient flash on the canvas that emitted the scroll (fades after scrolling stops)
+        canvas = self.sender()
+        if canvas is not None and hasattr(canvas, "flash_message"):
+            canvas.flash_message(f"WD {new_val:.3f} mm")
+        self._execute_wd_wheel_move()
+
+    def _execute_wd_wheel_move_impl(self) -> None:
+        """Apply the settled Shift+scroll target to hardware. No large-change confirmation —
+        WD is beam focus (lens), not a physical objective, so a big move isn't a collision risk."""
+        target_m = self._wd_wheel_target_mm * constants.MILLI_TO_SI
+        logging.info(
+            {"msg": "_on_canvas_scroll", "beam_type": self.beam_type.name, "working_distance": target_m}
+        )
+        self.microscope.set_working_distance(target_m, self.beam_type)
+        self._set_working_distance_spinbox(self.microscope.get_working_distance(self.beam_type))
+        self.settings_changed.emit(self.get_settings())
+
+    def _set_working_distance_spinbox(self, wd_m: float) -> None:
+        """Set the WD spinbox from a value in metres without triggering a hardware move."""
+        self.working_distance_spinbox.blockSignals(True)
+        self.working_distance_spinbox.setValue(wd_m * constants.SI_TO_MILLI)
+        self.working_distance_spinbox.blockSignals(False)
 
     def _on_scan_rotation_changed(self, value: float):
         self.microscope.set_scan_rotation(np.deg2rad(value), self.beam_type)

--- a/fibsem/ui/widgets/milling_task_viewer_widget.py
+++ b/fibsem/ui/widgets/milling_task_viewer_widget.py
@@ -567,6 +567,19 @@ class MillingTaskViewerWidget(QWidget):
     # Public API — required by FibsemMillingWidget2
     # ------------------------------------------------------------------
 
+    @property
+    def is_milling(self) -> bool:
+        """Whether a milling task is currently running.
+
+        Delegates to the embedded run controls, which own the milling thread. Hosts hold
+        *this* widget as ``milling_widget``, so callers asking "is it milling?" land here
+        rather than on ``FibsemMillingWidget2`` — ``FibsemMovementWidget`` blocks
+        click-to-move on it. That guard was written against the widget this class
+        replaced and had been raising ``AttributeError`` in ``FibsemUI`` ever since,
+        which is what broke click-to-move there.
+        """
+        return self.milling_widget.is_milling
+
     def get_config(self) -> FibsemMillingTaskConfig:
         return self.config_widget.get_config()
 

--- a/fibsem/ui/widgets/tests/test_viewer_less_widgets.py
+++ b/fibsem/ui/widgets/tests/test_viewer_less_widgets.py
@@ -84,6 +84,15 @@ def _image_widget(host) -> FibsemImageSettingsWidget:
     return widget
 
 
+def _movement_widget(host) -> FibsemMovementWidget:
+    """Both real hosts publish the widget as ``movement_widget``, and the image widget
+    reaches back through it when interactions are toggled — so a host that omits it
+    passes tests the app would fail."""
+    widget = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    host.movement_widget = widget
+    return widget
+
+
 # --- napari stubs ------------------------------------------------------------
 
 
@@ -225,7 +234,7 @@ def test_a_viewer_wins_when_a_host_offers_both():
     assert widget.uses_napari is True
     assert widget._view_controller() is None, "both display paths active at once"
 
-    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    movement = _movement_widget(host)
     assert movement._view_controller() is None
     assert movement._canvas_dbl_click_conns == [], "a click here would move the stage twice"
 
@@ -401,7 +410,7 @@ def test_selecting_the_fm_view_leaves_the_beam_radios_alone():
 def test_movement_binds_double_click_to_both_canvases_viewer_less():
     host = _CanvasHost()
     _image_widget(host)
-    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    movement = _movement_widget(host)
     assert movement.uses_napari is False
     assert len(movement._canvas_dbl_click_conns) == 2
 
@@ -409,11 +418,74 @@ def test_movement_binds_double_click_to_both_canvases_viewer_less():
 def test_movement_keeps_napari_layer_callbacks_with_a_viewer():
     host = _NapariHost()
     image_widget = _image_widget(host)
-    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    movement = _movement_widget(host)
     assert movement.uses_napari is True
     assert movement._canvas_dbl_click_conns == [], "canvas input wired on the napari path"
     assert movement._double_click in image_widget.eb_layer.mouse_double_click_callbacks
     assert movement._double_click in image_widget.ib_layer.mouse_double_click_callbacks
+
+
+def test_a_second_double_click_during_a_move_is_ignored():
+    """Reported from the app: double-click FIB, then double-click again while the
+    post-move acquisition is still running, and a SEM frame lands on the FIB canvas.
+
+    Two overlapping stage moves each trigger their own acquisition on one microscope.
+    `_toggle_interactions` disabled the *buttons* for that whole window — including the
+    acquisition, which is why `move_stage_finished` returns early while
+    `is_acquiring` — but nothing gated canvas input, so the click got through."""
+    host = _CanvasHost()
+    _image_widget(host)
+    movement = _movement_widget(host)
+
+    started = []
+    movement._canvas_double_click_worker = lambda *a, **k: started.append(a) or _NoopWorker()
+
+    assert movement._click_to_move_available()
+    movement._on_canvas_double_click(BeamType.ION, 10.0, 10.0, set())
+    assert len(started) == 1, "first double-click did not start a move"
+
+    # the first move is in flight: interactions are off, so a second click must not fire
+    assert not movement._click_to_move_available()
+    movement._on_canvas_double_click(BeamType.ION, 20.0, 20.0, set())
+    assert len(started) == 1, "a second move started while the first was still running"
+
+
+def test_click_to_move_is_blocked_while_acquiring_after_a_move():
+    """The exact window in the report: the move itself has finished, but the images it
+    triggered have not. `move_stage_finished` leaves interactions off on purpose."""
+    host = _CanvasHost()
+    image_widget = _image_widget(host)
+    movement = _movement_widget(host)
+
+    movement._toggle_interactions(enable=False)
+    image_widget.is_acquiring = True
+    movement.move_stage_finished()  # move done, acquisition still running
+
+    assert not movement._click_to_move_available(), (
+        "click-to-move re-armed while the post-move acquisition was still running"
+    )
+
+
+def test_the_napari_double_click_honours_the_same_gate():
+    """Same guard on both paths — the napari one has the identical overlap."""
+    import inspect
+
+    # `from fibsem.ui import FibsemMovementWidget` yields the *class* (re-exported by
+    # fibsem/ui/__init__.py), not the module — read the method off the class directly.
+    source = inspect.getsource(FibsemMovementWidget._double_click)
+    assert "_click_to_move_available" in source
+
+
+class _NoopWorker:
+    """Stands in for a FunctionWorker without starting a thread."""
+
+    finished = property(lambda self: self)
+
+    def connect(self, *a, **k):
+        pass
+
+    def start(self):
+        pass
 
 
 # --- teardown: the process-abort guard ---------------------------------------
@@ -425,7 +497,7 @@ def test_movement_teardown_stops_canvas_double_clicks_reaching_a_dead_widget():
     that into qFatal — the process aborts rather than logging (FIB-329)."""
     host = _CanvasHost()
     _image_widget(host)
-    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    movement = _movement_widget(host)
 
     calls = []
     movement._toggle_interactions = lambda *a, **k: calls.append(1)
@@ -455,7 +527,7 @@ def test_teardown_is_idempotent():
     """Both ``closeEvent`` and the host's disconnect path call it, and either may run first."""
     host = _CanvasHost()
     widget = _image_widget(host)
-    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    movement = _movement_widget(host)
     for _ in range(3):
         widget._teardown_connections()
         movement._teardown_connections()
@@ -468,7 +540,7 @@ def test_teardown_on_the_napari_path_does_not_raise():
     """FibsemUI calls it unconditionally on disconnect, whichever path is live."""
     host = _NapariHost()
     widget = _image_widget(host)
-    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    movement = _movement_widget(host)
     widget._teardown_connections()
     movement._teardown_connections()
 
@@ -479,11 +551,81 @@ def test_teardown_on_the_napari_path_does_not_raise():
 def test_position_readout_goes_to_the_controller_info_bar():
     host = _CanvasHost()
     _image_widget(host)
-    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    movement = _movement_widget(host)
     seen = []
     host.view_controller.update_info = lambda *a, **k: seen.append((a, k))
     movement._update_position_readout()
     assert seen, "stage readout never reached the quad-view info bar"
+
+
+def test_the_stage_position_shows_without_touching_anything():
+    """``setup_connections`` ends with ``update_ui()``, which is the *only* thing that
+    puts a position on the canvas before the operator moves or acquires. Truncating that
+    method leaves the info bar blank on connect and everything else still looks fine —
+    which is exactly how it shipped and got caught by hand."""
+    host = _CanvasHost()
+    _image_widget(host)
+    _movement_widget(host)
+    info = host.view_controller._states[host.view_controller.sem_canvas].info
+    assert any(key == "stage" for key, _ in info), (
+        f"no stage readout after construction; info bar holds {info}"
+    )
+
+
+def test_setup_connections_wires_the_whole_widget():
+    """Guards the shape of the bug above rather than one symptom of it: every one of
+    these is set at a different point in ``setup_connections``, so a method truncated
+    anywhere shows up here."""
+    host = _CanvasHost()
+    image_widget = _image_widget(host)
+    movement = _movement_widget(host)
+
+    from fibsem.ui.FibsemMovementWidget import INSTRUCTIONS_TEXT
+
+    # early: the instructions label
+    assert movement.label_movement_instructions.text() == INSTRUCTIONS_TEXT
+    # middle: stage limits pushed onto the spinboxes, and the acquisition hook
+    assert movement.doubleSpinBox_movement_stage_x.maximum() != 99.99, "stage limits unset"
+    assert movement.saved_positions_widget.microscope is not None, "saved positions unwired"
+    # late: milling-angle controls
+    assert movement.doubleSpinBox_milling_angle.maximum() == 45
+    assert movement.doubleSpinBox_milling_angle.suffix(), "milling angle suffix unset"
+    # the acquisition signal must reach the widget (drives update_ui after each acquire)
+    image_widget.acquisition_progress_signal.emit({"finished": True})
+
+
+# --- click-to-move must not raise --------------------------------------------
+
+
+def test_milling_widget_reports_whether_it_is_milling():
+    """``FibsemMovementWidget`` blocks click-to-move on ``milling_widget.is_milling``.
+    That attribute lives on the embedded run controls, not on the task viewer the hosts
+    actually store, so the guard raised ``AttributeError`` inside the worker and every
+    double-click died there."""
+    from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
+
+    widget = MillingTaskViewerWidget(microscope=_session()[0])
+    assert widget.is_milling is False
+
+
+def test_double_click_to_move_survives_a_host_that_owns_a_milling_widget():
+    """``FibsemUI`` sets ``self.milling_widget``; ``AutoLamellaUI`` does not — which is
+    why only the standalone app hit this. The move must be dispatched, not swallowed."""
+    from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
+
+    host = _CanvasHost()
+    image_widget = _image_widget(host)
+    host.milling_widget = MillingTaskViewerWidget(microscope=_session()[0])
+    movement = _movement_widget(host)
+
+    image_widget._on_acquire(_image(BeamType.ELECTRON))
+    moves = []
+    movement._execute_stage_move = lambda *a, **k: moves.append((a, k))
+    # call the worker body directly — @thread_worker would swallow the raise onto a thread
+    movement._canvas_double_click_worker.__wrapped__(
+        movement, BeamType.ELECTRON, 100.0, 100.0, set()
+    )
+    assert moves, "double-click did not dispatch a stage move"
 
 
 def _main() -> int:

--- a/fibsem/ui/widgets/tests/test_viewer_less_widgets.py
+++ b/fibsem/ui/widgets/tests/test_viewer_less_widgets.py
@@ -1,0 +1,505 @@
+"""The image and movement widgets must work with OR without a napari viewer (FIB-406, P4a).
+
+Standalone ``FibsemUI`` now runs viewer-less on the quad-view canvas while AutoLamella's
+Microscope tab still runs on napari, so both widgets carry two display paths at once,
+selected per instance by whether the host supplies a ``viewer`` or a ``view_controller``.
+The failure mode this guards is a silent one: pick the wrong branch and the widget still
+constructs, still acquires, and simply draws nothing.
+
+The viewer-less half runs against a **real** ``MicroscopeViewController`` and real canvases.
+The napari half runs against a stub viewer — napari's GL canvas cannot be constructed under
+``QT_QPA_PLATFORM=offscreen`` (it aborts the process), so a stub is the only way to assert
+the napari branch at all here. That is a real limit on this file: it pins *which branch runs
+and what it calls*, not napari's own rendering.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_viewer_less_widgets.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+from PyQt5.QtWidgets import QApplication, QWidget
+
+from fibsem import utils
+from fibsem.structures import BeamType, FibsemImage, FibsemRectangle
+from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
+from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
+from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+_RESOLUTION = (768, 512)  # (x, y) — non-square, so an axis mix-up shows up
+_HFW = 80e-6
+
+_microscope = None
+_settings = None
+
+
+def _session():
+    """One Demo microscope for the whole file — setup_session is slow."""
+    global _microscope, _settings
+    if _microscope is None:
+        _microscope, _settings = utils.setup_session(manufacturer="Demo")
+    return _microscope, _settings
+
+
+def _image(beam: BeamType = BeamType.ELECTRON) -> FibsemImage:
+    image = FibsemImage.generate_blank_image(resolution=_RESOLUTION, hfw=_HFW, random=True)
+    image.metadata.image_settings.beam_type = beam
+    return image
+
+
+# --- hosts -------------------------------------------------------------------
+
+
+class _CanvasHost(QWidget):
+    """Stands in for standalone FibsemUI: a view_controller, no viewer."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.view_controller = MicroscopeViewController(parent=self)
+
+
+class _NestedCanvasHost(QWidget):
+    """Stands in for AutoLamella's shape: the controller lives one level up, on
+    ``parent_widget``. Both hosts must resolve, or the Microscope tab silently keeps
+    drawing nothing after Phase 4b flips it."""
+
+    def __init__(self, outer) -> None:
+        super().__init__()
+        self.parent_widget = outer
+
+
+def _image_widget(host) -> FibsemImageSettingsWidget:
+    _, settings = _session()
+    widget = FibsemImageSettingsWidget(
+        microscope=_session()[0], image_settings=settings.image, parent=host
+    )
+    host.image_widget = widget
+    return widget
+
+
+# --- napari stubs ------------------------------------------------------------
+
+
+class _StubLayer:
+    def __init__(self, data, name):
+        self.data = data
+        self.name = name
+        self.translate = [0.0, 0.0]
+        self.visible = True
+        self.mode = "pan_zoom"
+        self.metadata = {}
+        self.mouse_double_click_callbacks = []
+        self.mouse_drag_callbacks = []
+        self.selected_data = set()
+        self.events = _StubEvents()
+
+
+class _StubEvents:
+    def __init__(self):
+        self.data = _StubSignal()
+
+
+class _StubSignal:
+    def __init__(self):
+        self.callbacks = []
+
+    def connect(self, fn):
+        self.callbacks.append(fn)
+
+
+class _StubLayerList(list):
+    """napari's LayerList iterates *layers* but indexes by name — a dict subclass would
+    yield names on iteration and break ``draw_scalebar_in_napari``, which reads ``.name``
+    off each item."""
+
+    def __init__(self):
+        super().__init__()
+        self.selection = type("S", (), {"active": None})()
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            for layer in self:
+                if layer.name == key:
+                    return layer
+            raise KeyError(key)
+        return super().__getitem__(key)
+
+    def __contains__(self, item):
+        if isinstance(item, str):
+            return any(layer.name == item for layer in self)
+        return any(layer is item for layer in self)
+
+    def remove(self, item):
+        for layer in list(self):
+            if layer is item or layer.name == item:
+                super().remove(layer)
+                return
+
+
+class _StubViewer:
+    """The slice of napari.Viewer these widgets touch. See the module docstring for why."""
+
+    def __init__(self):
+        self.layers = _StubLayerList()
+        self.title = ""
+        # the stage/beam readout the movement widget writes on the napari path
+        self.text_overlay = type("T", (), {"text": "", "visible": False, "position": ""})()
+
+    def add_image(self, data, name=None, blending=None, **kw):
+        layer = _StubLayer(data, name)
+        self.layers.append(layer)
+        return layer
+
+    def add_shapes(self, data=None, name=None, **kw):
+        layer = _StubLayer(data, name)
+        self.layers.append(layer)
+        return layer
+
+    def add_points(self, data=None, name=None, **kw):
+        layer = _StubLayer(data, name)
+        self.layers.append(layer)
+        return layer
+
+    def reset_view(self):
+        pass
+
+
+class _NapariHost(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.viewer = _StubViewer()
+
+
+# --- which display backend is chosen -----------------------------------------
+
+
+def test_viewer_less_host_uses_the_controller():
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    assert widget.uses_napari is False
+    assert widget._view_controller() is host.view_controller
+
+
+def test_controller_resolves_through_parent_widget():
+    """AutoLamella nests the controller one level up. A resolver that only checked the
+    direct parent would leave the Microscope tab blank after 4b, with no error."""
+    outer = _CanvasHost()
+    host = _NestedCanvasHost(outer)
+    widget = _image_widget(host)
+    assert widget._view_controller() is outer.view_controller
+
+
+def test_napari_host_keeps_the_layer_path():
+    host = _NapariHost()
+    widget = _image_widget(host)
+    assert widget.uses_napari is True
+    assert widget._view_controller() is None, "a viewer host must not pick up a controller"
+    assert widget.eb_layer is not None and widget.ib_layer is not None
+    names = {layer.name for layer in host.viewer.layers}
+    assert names >= {BeamType.ELECTRON.name, BeamType.ION.name}
+
+
+class _BothHost(QWidget):
+    """A misconfigured host holding both. ``FibsemUI`` always builds a controller, so
+    ``FibsemUI(viewer=...)`` reaches exactly this shape."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.viewer = _StubViewer()
+        self.view_controller = MicroscopeViewController(parent=self)
+
+
+def test_a_viewer_wins_when_a_host_offers_both():
+    """The two paths must be strictly exclusive. Running both would draw every image
+    twice and, worse, put the alignment area in the model while ``get_alignment_area``
+    reads it back off an empty layer."""
+    host = _BothHost()
+    widget = _image_widget(host)
+    assert widget.uses_napari is True
+    assert widget._view_controller() is None, "both display paths active at once"
+
+    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    assert movement._view_controller() is None
+    assert movement._canvas_dbl_click_conns == [], "a click here would move the stage twice"
+
+    widget._on_acquire(_image(BeamType.ELECTRON))
+    assert host.view_controller.get_canvas(BeamType.ELECTRON)._content_extent() is None
+
+
+def test_scalebar_and_crosshair_buttons_are_napari_only():
+    """They drive napari layers; the canvas has its own. Left visible they would be dead
+    controls — hidden, not merely inert, so nothing reads as broken."""
+    canvas_widget = _image_widget(_CanvasHost())
+    assert not canvas_widget.btn_scalebar.isVisibleTo(canvas_widget)
+    assert not canvas_widget.btn_crosshair.isVisibleTo(canvas_widget)
+
+    napari_widget = _image_widget(_NapariHost())
+    assert napari_widget.btn_scalebar.isVisibleTo(napari_widget)
+    assert napari_widget.btn_crosshair.isVisibleTo(napari_widget)
+
+
+# --- images actually reach the display ---------------------------------------
+
+
+def test_acquired_image_lands_on_its_own_beam_canvas():
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    sem_canvas = host.view_controller.get_canvas(BeamType.ELECTRON)
+    fib_canvas = host.view_controller.get_canvas(BeamType.ION)
+    assert sem_canvas._content_extent() is None, "canvas should start empty"
+
+    widget._on_acquire(_image(BeamType.ELECTRON))
+    assert sem_canvas._content_extent() is not None, "SEM image did not reach the canvas"
+    assert fib_canvas._content_extent() is None, "SEM image leaked onto the FIB canvas"
+
+    widget._on_acquire(_image(BeamType.ION))
+    assert fib_canvas._content_extent() is not None, "FIB image did not reach the canvas"
+
+
+def test_no_blank_placeholder_is_seeded_viewer_less():
+    """napari seeded two blank images at construction; the canvas shows "No image"
+    instead. Seeding would put a grey rectangle up that looks like a failed acquisition."""
+    host = _CanvasHost()
+    _image_widget(host)
+    assert host.view_controller.get_canvas(BeamType.ELECTRON)._content_extent() is None
+    assert host.view_controller.get_canvas(BeamType.ION)._content_extent() is None
+
+
+def test_napari_path_still_writes_to_the_layer():
+    host = _NapariHost()
+    widget = _image_widget(host)
+    image = _image(BeamType.ELECTRON)
+    widget._on_acquire(image)
+    layer = host.viewer.layers[BeamType.ELECTRON.name]
+    assert np.array_equal(layer.data, image.filtered_data), "layer not updated"
+
+
+# --- the alignment-area contract ---------------------------------------------
+
+
+def test_alignment_area_round_trips_through_the_model():
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    widget.toggle_alignment_area(FibsemRectangle(0.3, 0.3, 0.4, 0.4), editable=True)
+    got = widget.get_alignment_area()
+    assert got is not None
+    assert (got.left, got.top, got.width, got.height) == (0.3, 0.3, 0.4, 0.4)
+
+
+def test_clearing_the_alignment_area_keeps_its_value():
+    """``update_alignment_area_ui`` sends "clear" and then reads ``get_alignment_area()``
+    straight after. A clear that discarded the rect would hand the workflow None mid-run."""
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    widget.toggle_alignment_area(FibsemRectangle(0.3, 0.3, 0.4, 0.4), editable=True)
+    widget.clear_alignment_area()
+    assert widget.get_alignment_area() is not None, "clear discarded the alignment area"
+
+
+def test_alignment_edit_forwards_to_the_existing_signal():
+    """A canvas drag must drive the same validation path the napari layer event did."""
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    seen = []
+    widget.alignment_area_updated.connect(seen.append)
+    widget.toggle_alignment_area(FibsemRectangle(0.3, 0.3, 0.4, 0.4), editable=True)
+    edited = FibsemRectangle(0.1, 0.1, 0.2, 0.2)
+    host.view_controller.overlay_edited.emit(BeamType.ION, "alignment", edited)
+    assert seen and seen[-1] is edited, f"alignment edit not forwarded: {seen}"
+
+
+def test_unrelated_overlay_edits_are_ignored():
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    seen = []
+    widget.alignment_area_updated.connect(seen.append)
+    widget.toggle_alignment_area(FibsemRectangle(0.3, 0.3, 0.4, 0.4), editable=True)
+    host.view_controller.overlay_edited.emit(BeamType.ION, "milling", object())
+    assert not seen, "a non-alignment overlay edit was forwarded as an alignment change"
+
+
+# --- working-distance Shift+scroll -------------------------------------------
+
+
+def _sem_beam_settings(widget):
+    return widget.dual_beam_widget.sem_widget.beam_settings_widget
+
+
+def test_shift_scroll_nudges_working_distance_and_plain_scroll_does_not():
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    assert len(widget._wd_scroll_connections) == 2, "WD scroll not wired to both canvases"
+
+    settings_widget = _sem_beam_settings(widget)
+    spinbox = settings_widget.working_distance_spinbox
+    start = spinbox.value()
+
+    host.view_controller.sem_canvas.canvas_scrolled.emit(0.0, 0.0, 1, set())
+    assert spinbox.value() == start, "plain scroll changed the working distance"
+
+    host.view_controller.sem_canvas.canvas_scrolled.emit(0.0, 0.0, 1, {"Shift"})
+    assert spinbox.value() > start, "Shift+scroll did not nudge the working distance"
+
+
+def test_working_distance_spinbox_resolves_the_scroll_step():
+    """The step is 1 um; at 2 decimals (0.01 mm) a notch would round away to nothing."""
+    from fibsem.ui.widgets.beam_settings_widget import WD_WHEEL_STEP_MM
+
+    widget = _image_widget(_CanvasHost())
+    decimals = _sem_beam_settings(widget).working_distance_spinbox.decimals()
+    assert 10 ** -decimals <= WD_WHEEL_STEP_MM, (
+        f"spinbox resolves {10 ** -decimals} mm but the scroll step is {WD_WHEEL_STEP_MM} mm"
+    )
+
+
+def test_wd_scroll_is_not_wired_on_the_napari_path():
+    widget = _image_widget(_NapariHost())
+    assert widget._wd_scroll_connections == []
+
+
+# --- quad-view selection <-> beam radio --------------------------------------
+
+
+def test_selecting_a_canvas_checks_its_beam_radio():
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    host.view_controller.widget.set_selected(BeamType.ION)
+    assert widget.dual_beam_widget.fib_radio.isChecked()
+    host.view_controller.widget.set_selected(BeamType.ELECTRON)
+    assert widget.dual_beam_widget.sem_radio.isChecked()
+
+
+def test_checking_a_beam_radio_selects_its_canvas():
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    widget.dual_beam_widget.fib_radio.setChecked(True)
+    assert host.view_controller.selected_view is BeamType.ION
+    widget.dual_beam_widget.sem_radio.setChecked(True)
+    assert host.view_controller.selected_view is BeamType.ELECTRON
+
+
+def test_selecting_the_fm_view_leaves_the_beam_radios_alone():
+    """There is no FM radio. Forcing one of the beam radios would misreport which beam
+    the Acquire buttons are about to use."""
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    widget.dual_beam_widget.fib_radio.setChecked(True)
+    widget._on_view_selected("fm")
+    assert widget.dual_beam_widget.fib_radio.isChecked(), "FM selection moved the beam radio"
+
+
+# --- movement: double-click input --------------------------------------------
+
+
+def test_movement_binds_double_click_to_both_canvases_viewer_less():
+    host = _CanvasHost()
+    _image_widget(host)
+    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    assert movement.uses_napari is False
+    assert len(movement._canvas_dbl_click_conns) == 2
+
+
+def test_movement_keeps_napari_layer_callbacks_with_a_viewer():
+    host = _NapariHost()
+    image_widget = _image_widget(host)
+    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    assert movement.uses_napari is True
+    assert movement._canvas_dbl_click_conns == [], "canvas input wired on the napari path"
+    assert movement._double_click in image_widget.eb_layer.mouse_double_click_callbacks
+    assert movement._double_click in image_widget.ib_layer.mouse_double_click_callbacks
+
+
+# --- teardown: the process-abort guard ---------------------------------------
+
+
+def test_movement_teardown_stops_canvas_double_clicks_reaching_a_dead_widget():
+    """The canvases outlive the widget (removeTab + deleteLater fires neither closeEvent
+    nor close). A double-click delivered afterwards raises inside a slot, and PyQt5 turns
+    that into qFatal — the process aborts rather than logging (FIB-329)."""
+    host = _CanvasHost()
+    _image_widget(host)
+    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+
+    calls = []
+    movement._toggle_interactions = lambda *a, **k: calls.append(1)
+
+    host.view_controller.sem_canvas.canvas_double_clicked.emit(10.0, 10.0, set())
+    assert calls, "double-click never reached the widget while connected"
+
+    movement._teardown_connections()
+    calls.clear()
+    host.view_controller.sem_canvas.canvas_double_clicked.emit(10.0, 10.0, set())
+    host.view_controller.fib_canvas.canvas_double_clicked.emit(10.0, 10.0, set())
+    assert not calls, "double-click still reached the widget after teardown"
+
+
+def test_image_widget_teardown_stops_scroll_reaching_a_dead_widget():
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    spinbox = _sem_beam_settings(widget).working_distance_spinbox
+
+    widget._teardown_connections()
+    before = spinbox.value()
+    host.view_controller.sem_canvas.canvas_scrolled.emit(0.0, 0.0, 1, {"Shift"})
+    assert spinbox.value() == before, "WD scroll still reached the widget after teardown"
+
+
+def test_teardown_is_idempotent():
+    """Both ``closeEvent`` and the host's disconnect path call it, and either may run first."""
+    host = _CanvasHost()
+    widget = _image_widget(host)
+    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    for _ in range(3):
+        widget._teardown_connections()
+        movement._teardown_connections()
+    assert widget._wd_scroll_connections == []
+    assert widget._view_sync_connections == []
+    assert movement._canvas_dbl_click_conns == []
+
+
+def test_teardown_on_the_napari_path_does_not_raise():
+    """FibsemUI calls it unconditionally on disconnect, whichever path is live."""
+    host = _NapariHost()
+    widget = _image_widget(host)
+    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    widget._teardown_connections()
+    movement._teardown_connections()
+
+
+# --- position readout ---------------------------------------------------------
+
+
+def test_position_readout_goes_to_the_controller_info_bar():
+    host = _CanvasHost()
+    _image_widget(host)
+    movement = FibsemMovementWidget(microscope=_session()[0], parent=host)
+    seen = []
+    host.view_controller.update_info = lambda *a, **k: seen.append((a, k))
+    movement._update_position_readout()
+    assert seen, "stage readout never reached the quad-view info bar"
+
+
+def _main() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        try:
+            fn()
+            print(f"PASS  {name}")
+        except Exception as exc:  # noqa: BLE001 - standalone runner
+            failures += 1
+            print(f"FAIL  {name}: {type(exc).__name__}: {exc}")
+    print(f"\n{'FAILED' if failures else 'OK'} — {failures} failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())


### PR DESCRIPTION
First half of the Microscope-tab cutover ([FIB-406](https://linear.app/fibsemos/issue/FIB-406)). `fibsem_ui` now displays through `MicroscopeViewController` with **no napari viewer**. AutoLamella's Microscope tab is untouched and still runs on napari — that flip is 4b.

## Why split it here

Phases 1–3 were separable because each tab owned its own viewer. That does not hold for the Microscope tab: every widget resolves `self.viewer = parent.viewer`, and `FibsemImageSettingsWidget` *raised* without one, so the widget ports and the shell flip are coupled.

But **two** shells host these widgets, not one — `AutoLamellaUI` and `FibsemUI` (the `fibsem_ui` entry point). Flipping the standalone one first gives the canvas path a live consumer instead of leaving it dead until 4b. That is exactly what made `set_controller()` safe in phase 2: the Lamella Editor exercised the new path from day one.

The cost is that the two widgets carry both paths in the interim. 4b deletes the napari halves.

## How the path is chosen

Per instance, by what the host supplies: `viewer` → napari layers, `view_controller` → canvas. `_view_controller()` returns `None` whenever a viewer is present, keeping the two **strictly exclusive**. `FibsemUI` always builds a controller, so `FibsemUI(viewer=...)` would otherwise run both at once — every image drawn twice, and the alignment area living in the model while `get_alignment_area()` reads it back off an empty layer. There is a test for that shape.

## Also in here

- **Shift+scroll on a beam canvas nudges the working distance** — 1 µm per notch, spinbox updates immediately, the hardware move is debounced so a burst coalesces. Plain scroll still zooms. No acquisition lockout, unlike the FM objective: WD is beam focus, and adjusting it live is *how you focus*.
- **Quad-view selection ↔ SEM/FIB beam radios sync both ways.** Selecting the FM view leaves the radios alone — there is no FM radio, and forcing one would misreport which beam Acquire is about to use.
- **`_teardown_connections()` on both widgets.** The canvases outlive a reconnect; a stale double-click or scroll delivered to a deleted widget raises inside a slot, and PyQt5 turns that into `qFatal` — the process aborts rather than logging ([FIB-329](https://linear.app/fibsemos/issue/FIB-329)). Two tests emit the signals after teardown to prove nothing arrives.

## Worth a reviewer's attention

**The WD spinbox went from 2 to 3 decimals, and that is visible in AutoLamella too.** At 0.01 mm resolution a 1 µm notch rounds away to nothing, so the scroll step forced it. A test pins the two together so they cannot drift apart.

**A removed guard was already dead.** `FibsemImageSettingsWidget` had `if not hasattr(parent, "viewer") and not isinstance(parent.viewer, napari.Viewer)` — `and`, so it needed both to hold, and a parent genuinely missing `viewer` would raise `AttributeError` evaluating the second clause first. It never fired as written.

**napari is still imported**, because the widgets need `napari.layers` for the AutoLamella branch. No `Viewer` is created — checked separately. The import goes in 4b.

**`open_minimap_widget` deliberately keeps its own napari viewer.** The overview surface is being rebuilt on the FM-overview (multi-image) model in phase 3 ([FIB-405](https://linear.app/fibsemos/issue/FIB-405)); porting it here would mean porting it twice.

## Verification

`FibsemUI()` now constructs under `QT_QPA_PLATFORM=offscreen` — impossible before, since napari's GL canvas does not merely warn headless, it aborts the process. So the viewer-less half of the tests runs against a **real** controller and real canvases.

The napari half has to use a stub viewer for that same reason. That is a real limit and it is stated in the test file: those cases pin *which branch runs and what it calls*, not napari's own rendering.

- 25 new headless tests, both paths
- 900 `tests/ui` + 34 canvas widget tests still pass
- 13 mutations tried, 13 caught — including deleting the teardown disconnects, and making `clear_alignment_area` destroy the rect instead of hiding it (which would hand the workflow `None` mid-run, since `update_alignment_area_ui` reads it back straight after the clear)

**Still needs hardware**, on the standalone app: live acquisition on both beams, click and double-click to move, Shift+scroll WD, auto-contrast/auto-focus, detection → mill. [FIB-358](https://linear.app/fibsemos/issue/FIB-358) (FM canvas double-click after the `fm_stable_move` convergence) remains the highest-risk unverified item.
