### PR TITLE
[fm] Name the FM's acquisition state after the questions widgets ask (FIB-513)

### DIFF
--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -589,7 +589,7 @@ class FluorescenceMicroscope(ABC):
     # Raised when something starts or stops driving the FM, so a widget that did not
     # start it can grey its controls out. Emitted from whichever thread set the flag --
     # connect with `@ensure_main_thread` if the slot touches widgets.
-    busy_changed = Signal(bool)
+    acquiring_changed = Signal(bool)
 
     def __init__(self, parent: Optional["FibsemMicroscope"] = None):
         """Initialize the fluorescence microscope with default components.
@@ -605,9 +605,10 @@ class FluorescenceMicroscope(ABC):
         self._stop_acquisition_event = threading.Event()
         self._acquisition_thread: Optional[threading.Thread] = None
         # Something other than the live stream is driving the FM: an overview tileset,
-        # a z-stack, an autofocus sweep. Set by whoever is driving it. See `is_busy`.
-        self._busy: bool = False
-        self._busy_reason: str = ""
+        # a z-stack, an autofocus sweep. Set by whoever is driving it. The stream is not
+        # in here -- it reports itself through `_acquisition_thread`. See `is_acquiring`.
+        self._acquiring: bool = False
+        self._acquiring_reason: str = ""
 
         self.channel_name: str = "channel-01"
         self.channel_color: str = "gray"
@@ -683,48 +684,76 @@ class FluorescenceMicroscope(ABC):
         """
         return f"{self.__class__.__name__}(objective={self.objective}, filter_set={self.filter_set}, camera={self.camera}, light_source={self.light_source})"
 
-    @property
-    def is_acquiring(self) -> bool:
-        """Check if the microscope is currently in live acquisition mode.
+    # ── what is running ──────────────────────────────────────────────────
+    #
+    # Three questions, because widgets ask three. Assembling them at each call site is
+    # what produced six overlapping flags and one wrong answer (FIB-513):
+    #
+    #   is_streaming    the live view is on
+    #   is_acquiring    anything is running: the stream, or a claimed operation
+    #   is_interactive  the user may drive the hardware
 
-        Returns:
-            True if live acquisition is active, False otherwise
+    @property
+    def is_streaming(self) -> bool:
+        """Whether the live view is on -- a stream of frames off the camera.
+
+        Narrower than `is_acquiring`, and the difference matters twice: this is what
+        labels the start/stop button, since stopping is the one thing that must stay
+        possible while it runs, and it is what makes `is_interactive` true.
         """
         if not self._acquisition_thread:
             return False
         return self._acquisition_thread and self._acquisition_thread.is_alive()
 
     @property
-    def is_busy(self) -> bool:
-        """Whether anything is driving the FM: a live stream, or some other acquisition.
+    def is_acquiring(self) -> bool:
+        """Whether anything is driving the FM: the live stream, or some other operation.
 
-        The question a widget deciding what to enable should be asking. `is_acquiring`
-        reports the live stream alone, which an overview tileset drops between every
-        pair of tiles while it moves the stage -- so a widget watching that flag sees an
-        idle microscope for most of somebody else's run (FIB-441).
+        The question to ask before starting new work. A tileset moves the stage between
+        every pair of tiles with no stream running, so `is_streaming` reads idle for most
+        of somebody else's run -- which is how a live stream came to be startable
+        mid-tileset (FIB-441).
         """
-        return self.is_acquiring or self._busy
+        return self.is_streaming or self._acquiring
 
     @property
-    def busy_reason(self) -> str:
+    def is_interactive(self) -> bool:
+        """Whether the user may drive the hardware -- the objective, channel parameters.
+
+        True while idle, and true while streaming: focusing during live view is what the
+        objective control is *for*. False while a tileset, z-stack or autofocus sweep is
+        running, because those drive the objective themselves and a second hand on it
+        corrupts the run.
+
+        Widgets used to derive this per call site from two or three flags, and the
+        objective panel got it wrong -- it asked only whether *this* widget was busy, so
+        another tab's tileset left it live (FIB-513).
+        """
+        return not self.is_acquiring or self.is_streaming
+
+    @property
+    def acquiring_reason(self) -> str:
         """What is driving the FM, phrased for a warning, or "" if nothing is."""
-        if self._busy:
-            return self._busy_reason
-        if self.is_acquiring:
+        if self._acquiring:
+            return self._acquiring_reason
+        if self.is_streaming:
             return "live acquisition"
         return ""
 
-    def set_busy(self, busy: bool, reason: str = "") -> None:
-        """Mark the FM as driven, or not. Call in a `finally` when the work ends.
+    def set_acquiring(self, acquiring: bool, reason: str = "") -> None:
+        """Mark an operation as running, or finished. Call in a `finally` when it ends.
+
+        Not for the live stream, which reports itself through its thread: a flag that
+        outlived a dead thread would strand the instrument.
 
         Args:
-            busy: Whether something is now driving the microscope.
+            acquiring: Whether something is now driving the microscope.
             reason: What it is, e.g. "overview acquisition". Shown to the user by
                 whatever gets refused, so it should read as a noun phrase.
         """
-        self._busy = busy
-        self._busy_reason = reason if busy else ""
-        self.busy_changed.emit(self.is_busy)
+        self._acquiring = acquiring
+        self._acquiring_reason = reason if acquiring else ""
+        self.acquiring_changed.emit(self.is_acquiring)
 
     def set_channel(self, channel_settings: ChannelSettings):
         """Configure the microscope for a specific fluorescence channel.
@@ -1057,7 +1086,7 @@ class FluorescenceMicroscope(ABC):
             Images are emitted via the acquisition_signal. Connect to this signal
             to receive live images. Call stop_acquisition() to end the process.
         """
-        if self.is_acquiring:
+        if self.is_streaming:
             logging.warning("Acquisition thread is already running.")
             return
 
@@ -1069,10 +1098,10 @@ class FluorescenceMicroscope(ABC):
             target=self._acquisition_worker, args=(channel_settings,), daemon=True
         )
         self._acquisition_thread.start()
-        # A live stream makes the FM busy just as anything else does, so it announces
-        # itself the same way -- a widget deriving its controls from `is_busy` would
-        # otherwise notice tilesets and never notice streaming.
-        self.busy_changed.emit(self.is_busy)
+        # A live stream counts as acquiring just as anything else does, so it announces
+        # itself the same way -- a widget deriving its controls from `is_acquiring`
+        # would otherwise notice tilesets and never notice streaming.
+        self.acquiring_changed.emit(self.is_acquiring)
 
     def stop_acquisition(self) -> None:
         """Stop the continuous live image acquisition.
@@ -1090,7 +1119,7 @@ class FluorescenceMicroscope(ABC):
                 self._acquisition_thread.join(timeout=2)
             # Asked rather than asserted: the join has a timeout, so a thread that has
             # not stopped yet must not be announced as stopped.
-            self.busy_changed.emit(self.is_busy)
+            self.acquiring_changed.emit(self.is_acquiring)
 
     def _acquisition_worker(self, channel_settings: Optional[ChannelSettings] = None):
         """Internal worker thread for continuous image acquisition.

--- a/fibsem/ui/FMAcquisitionWidget.py
+++ b/fibsem/ui/FMAcquisitionWidget.py
@@ -422,7 +422,11 @@ class FMAcquisitionWidget(QWidget):
 
     @property
     def is_acquiring(self) -> bool:
-        """Check if any acquisition is currently active."""
+        """Check if any acquisition is currently active.
+
+        Still a union: this tab does not mark its work through `fm.set_acquiring`, so
+        the microscope cannot see its worker (FIB-513 leaves this tab alone).
+        """
         return self.fm.is_acquiring or bool(
             self._acquisition_thread and self._acquisition_thread.is_alive()
         )
@@ -1784,7 +1788,7 @@ class FMAcquisitionWidget(QWidget):
 
     def toggle_acquisition(self):
         """Toggle acquisition start/stop with F6 key."""
-        if self.fm.is_acquiring:
+        if self.fm.is_streaming:
             logging.info("F6 pressed: Stopping acquisition")
             self.stop_acquisition()
         else:
@@ -1872,7 +1876,7 @@ class FMAcquisitionWidget(QWidget):
         self.pushButton_cancel_acquisition.setVisible(self.is_acquisition_active)
 
         # Update toggle acquisition button text based on state
-        if self.fm.is_acquiring:
+        if self.fm.is_streaming:
             self.pushButton_toggle_acquisition.setText("Stop Acquisition")
         else:
             self.pushButton_toggle_acquisition.setText("Start Acquisition")
@@ -2033,7 +2037,7 @@ class FMAcquisitionWidget(QWidget):
 
     def _on_channel_field_changed(self, channel, field: str, value) -> None:
         """Update a single microscope parameter during live acquisition."""
-        if not self.fm.is_acquiring:
+        if not self.fm.is_streaming:
             return
         if channel is not self.channelSettingsWidget.selected_channel:
             return
@@ -2062,7 +2066,7 @@ class FMAcquisitionWidget(QWidget):
         )
         if self.experiment is not None:
             self.experiment.events.disconnect(self._on_experiment_positions_changed)
-        if self.fm.is_acquiring:
+        if self.fm.is_streaming:
             try:
                 self.stop_acquisition()
             except Exception as e:

--- a/fibsem/ui/fm/widgets/channel_list_widget.py
+++ b/fibsem/ui/fm/widgets/channel_list_widget.py
@@ -109,7 +109,7 @@ class _DraggableChannelList(QListWidget):
                 item.setSizeHint(QSize(width, item.sizeHint().height()))
 
     def mousePressEvent(self, event) -> None:
-        if self._fm is not None and self._fm.is_acquiring:
+        if self._fm is not None and self._fm.is_streaming:
             return  # swallow — prevent highlight change during live acquisition
         super().mousePressEvent(event)
 
@@ -960,7 +960,7 @@ class ChannelListWidget(QWidget):
         return True
 
     def _on_remove_clicked(self, channel: ChannelSettings) -> None:
-        if self.fm is not None and self.fm.is_acquiring and channel is self._selected_channel:
+        if self.fm is not None and self.fm.is_streaming and channel is self._selected_channel:
             self._show_status_warning("Cannot remove the active channel during live acquisition.")
             return
         for i in range(self._list.count()):
@@ -969,7 +969,7 @@ class ChannelListWidget(QWidget):
                 return
 
     def _on_row_clicked(self, channel: ChannelSettings) -> None:
-        if self.fm is not None and self.fm.is_acquiring and channel is not self._selected_channel:
+        if self.fm is not None and self.fm.is_streaming and channel is not self._selected_channel:
             self._show_status_warning("Cannot change channel selection during live acquisition.")
             return
         self._set_selected(channel)

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -147,9 +147,9 @@ class FMOverviewWidget(QWidget):
     # Same hop for stage moves: `stage_position_changed` is a psygnal, so it fires
     # on whichever thread moved the stage -- a worker, during an acquisition.
     _stage_moved = pyqtSignal(object)
-    # And for the FM being taken or given back by somebody else, which is cleared from
+    # And for something starting or finishing on the FM, which is reported from
     # whichever thread finished with it -- for our own runs, the acquisition worker.
-    _fm_busy_changed = pyqtSignal(bool)
+    _fm_acquiring_changed = pyqtSignal(bool)
 
     def __init__(
         self,
@@ -216,8 +216,8 @@ class FMOverviewWidget(QWidget):
         # match it at disconnect time -- and says nothing when the disconnect therefore
         # removes nothing. Emitting into a widget Qt had already torn down was a segfault.
         self.microscope.stage_position_changed.connect(self._on_stage_signal)
-        self._fm_busy_changed.connect(self._on_fm_busy_changed)
-        self.fm.busy_changed.connect(self._on_fm_busy_signal)
+        self._fm_acquiring_changed.connect(self._on_fm_acquiring_changed)
+        self.fm.acquiring_changed.connect(self._on_fm_acquiring_signal)
         self._refresh_current_position()
         self._refresh_orientation_banner()
 
@@ -1154,7 +1154,7 @@ class FMOverviewWidget(QWidget):
         widget -- and the same worker, since `move_to_microscope` blocks for as long as
         the stage takes.
         """
-        if self._running or self.fm.is_busy:
+        if self._running or self.fm.is_acquiring:
             notification_service.show_toast(
                 "Cannot move the stage during an acquisition.", "warning"
             )
@@ -1223,17 +1223,17 @@ class FMOverviewWidget(QWidget):
             )
             self.button_move_to_fm.setText(f"Move to {self.fm.default_orientation}")
 
-    def _on_fm_busy_signal(self, busy: bool) -> None:
+    def _on_fm_acquiring_signal(self, acquiring: bool) -> None:
         """Called by psygnal, on whichever thread started or stopped. No widgets here."""
-        self._fm_busy_changed.emit(busy)
+        self._fm_acquiring_changed.emit(acquiring)
 
-    def _on_fm_busy_changed(self, busy: bool) -> None:
+    def _on_fm_acquiring_changed(self, acquiring: bool) -> None:
         """Something started driving the fluorescence microscope, or stopped.
 
-        Only the controls need to know. Whether the FM is busy is not this widget's
-        state -- it is a fact about the microscope that `_apply_enabled_state` reads,
-        alongside the two that *are* this widget's -- so there is nothing to store here,
-        only a reason to re-derive.
+        Only the controls need to know. What the FM is doing is not this widget's state
+        -- it is a fact about the microscope that `_apply_enabled_state` reads, alongside
+        the two that *are* this widget's -- so there is nothing to store here, only a
+        reason to re-derive.
         """
         self._apply_enabled_state()
 
@@ -1641,10 +1641,10 @@ class FMOverviewWidget(QWidget):
         their own half of the truth is how a control gets stuck; deriving all of it from
         all five every time is the version that cannot.
 
-        `fm.is_busy` covers this widget's own run too, since it sets the flag for the
-        length of one -- harmless, because `_running` is true throughout that.
+        `fm.is_acquiring` covers this widget's own run too, since it marks the FM for
+        the length of one -- harmless, because `_running` is true throughout that.
         """
-        idle = self._interactive and not self._running and not self.fm.is_busy
+        idle = self._interactive and not self._running and not self.fm.is_acquiring
         has_tiles = self.settings_widget.parameters.n_enabled_tiles > 0
         # Acquisition only. Display and navigation stay live from any pose: looking at an
         # overview that has already been acquired is harmless wherever the stage is, and
@@ -1668,12 +1668,11 @@ class FMOverviewWidget(QWidget):
         if self.is_acquiring:
             logging.warning("An overview acquisition is already running.")
             return
-        # `is_busy`, not `is_acquiring`. The latter reports the live stream alone, so a
-        # z-stack or an autofocus sweep running in the control widget was invisible
-        # here -- and this widget's own tileset was invisible to that one, which is the
-        # direction that mattered (FIB-441).
-        if self.fm.is_busy:
-            reason = self.fm.busy_reason or "another acquisition"
+        # `is_acquiring`, not `is_streaming`: a z-stack or an autofocus sweep in the
+        # control widget is not a stream, and this widget's own tileset was invisible to
+        # that one, which is the direction that mattered (FIB-441).
+        if self.fm.is_acquiring:
+            reason = self.fm.acquiring_reason or "another acquisition"
             logging.warning(f"Cannot acquire an overview: the FM is in use ({reason}).")
             notification_service.show_toast(
                 f"The fluorescence microscope is in use ({reason}). "
@@ -1727,7 +1726,7 @@ class FMOverviewWidget(QWidget):
 
         # Held for the length of the run, so nothing else drives the FM while the stage
         # is walking the grid. Cleared in the worker's `finally` (FIB-441).
-        self.fm.set_busy(True, "overview acquisition")
+        self.fm.set_acquiring(True, "overview acquisition")
 
         self._stop_event.clear()
         self._set_running(True)
@@ -1795,11 +1794,11 @@ class FMOverviewWidget(QWidget):
                 {"state": "overview-failed", "task": "tileset", "error": str(e)}
             )
         finally:
-            # A run that ends still marked busy leaves the FM unusable for the rest of
-            # the session, with nothing on screen to say why -- so this goes in a
-            # `finally` rather than after the emits, and stays right if a future edit
-            # narrows one of the `except` clauses above.
-            self.fm.set_busy(False)
+            # A run that ends still marked as acquiring leaves the FM unusable for
+            # the rest of the session, with nothing on screen to say why -- so this goes
+            # in a `finally` rather than after the emits, and stays right if a future
+            # edit narrows one of the `except` clauses above.
+            self.fm.set_acquiring(False)
 
     def cancel(self) -> None:
         if not self.is_acquiring:

--- a/fibsem/ui/fm/widgets/objective_control_widget.py
+++ b/fibsem/ui/fm/widgets/objective_control_widget.py
@@ -487,8 +487,12 @@ class ObjectiveControlWidget(QWidget):
             event.handled = False  # Let napari handle zooming if Shift is not pressed
             return
 
-        # Prevent objective movement during acquisitions
-        if self.parent_widget.is_acquisition_active:
+        # Prevent objective movement while something is driving the objective itself.
+        # Asked of the microscope, not the parent widget: `is_acquisition_active` is only
+        # the parent's own work, so another tab's tileset let this through (FIB-513).
+        # Still allowed during a live stream -- shift-scrolling to focus while watching
+        # is what this handler is for.
+        if not self.fm.is_interactive:
             logging.info("Objective movement disabled during acquisition")
             event.handled = True
             return

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -1853,7 +1853,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         if self.microscope is None or self.microscope.fm is None:
             return
         fm = self.microscope.fm
-        if fm.is_acquiring:
+        if fm.is_streaming:
             fm.stop_acquisition()
             self.btn_toggle_fm_acquisition.setText("Start Acquisition")
             self.btn_toggle_fm_acquisition.setStyleSheet(
@@ -1861,13 +1861,13 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             )
         else:
             # The third place in the app that can start a live stream, and so the third
-            # that has to ask whether the microscope is free -- an overview tileset does
-            # not show up in `is_acquiring` (FIB-441).
-            if fm.is_busy:
+            # that has to ask whether the microscope is free -- a tileset never streams,
+            # so `is_streaming` would read idle right through one (FIB-441).
+            if fm.is_acquiring:
                 QMessageBox.warning(
                     self,
                     "Fluorescence Microscope In Use",
-                    f"The fluorescence microscope is in use ({fm.busy_reason}).\n\n"
+                    f"The fluorescence microscope is in use ({fm.acquiring_reason}).\n\n"
                     f"Wait for it to finish before starting acquisition.",
                 )
                 return
@@ -1903,7 +1903,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         if self.microscope is None or self.microscope.fm is None:
             return
         fm = self.microscope.fm
-        if fm.is_acquiring:
+        if fm.is_streaming:
             fm.stop_acquisition()
             self._act_pause_acquisition.setText("Resume Acquisition")
         else:
@@ -1915,7 +1915,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         if self.microscope is None or self.microscope.fm is None:
             return
         fm = self.microscope.fm
-        if not fm.is_acquiring:
+        if not fm.is_streaming:
             return
         if channel is not self.fm_channel_widget.selected_channel:
             return

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -236,11 +236,16 @@ class FMControlWidget(QWidget):
         self.setLayout(layout)
 
     @property
-    def is_acquiring(self) -> bool:
-        """Check if any acquisition is currently active."""
-        return self.fm.is_acquiring or bool(
-            self._acquisition_thread and self._acquisition_thread.is_alive()
-        )
+    def _has_worker(self) -> bool:
+        """Whether *this widget's* acquisition thread is still going.
+
+        All that is left of the old `is_acquiring` property, which was
+        `fm.is_acquiring or <my own worker>`. The microscope answers that now -- both
+        halves of it, since this widget marks its own work through `set_acquiring` --
+        and the only caller that wanted the local half is `cancel_acquisition`, which
+        joins the thread and would hit `None.join()` on somebody else's run (FIB-513).
+        """
+        return bool(self._acquisition_thread and self._acquisition_thread.is_alive())
 
     @property
     def is_acquisition_active(self) -> bool:
@@ -290,7 +295,7 @@ class FMControlWidget(QWidget):
         self.fm.acquisition_signal.connect(self.update_image)
         self.acquisition_finished_signal.connect(self._on_acquisition_finished)
         self.fm.acquisition_progress_signal.connect(self._on_acquisition_progress)
-        self.fm.busy_changed.connect(self._on_fm_busy_changed)
+        self.fm.acquiring_changed.connect(self._on_fm_acquiring_changed)
 
         # live parameter updates from channel list
         self.channelSettingsWidget.channel_field_changed.connect(
@@ -420,7 +425,7 @@ class FMControlWidget(QWidget):
 
     def _on_channel_field_changed(self, channel, field: str, value) -> None:
         """Update a single microscope parameter during live acquisition."""
-        if not self.fm.is_acquiring:
+        if not self.fm.is_streaming:
             return
         if channel is not self.channelSettingsWidget.selected_channel:
             return
@@ -589,25 +594,24 @@ class FMControlWidget(QWidget):
             )
             self.viewer.reset_view()
 
-    def _refuse_if_fm_busy(self, what: str) -> bool:
+    def _refuse_if_acquiring(self, what: str) -> bool:
         """Whether the FM is already in use, having logged why. True means "do not start".
 
-        Asks the microscope, not just this widget. `self.is_acquiring` sees the live
-        stream and this widget's own worker; it cannot see the overview tab's tileset,
-        which drops the stream between every pair of tiles while the stage moves -- so a
-        live stream could be started mid-run, and the remaining tiles would land at
-        whatever settings it applied on the way past (FIB-441).
+        One question to the microscope, where this used to be a union of three: the
+        widget's own worker, the live stream, and everybody else. `fm.is_acquiring`
+        covers all of them, this widget's own work included -- it marks that through
+        `set_acquiring` like anyone else (FIB-513).
         """
-        if not (self.is_acquiring or self.fm.is_busy):
+        if not self.fm.is_acquiring:
             return False
-        reason = self.fm.busy_reason or "another acquisition"
+        reason = self.fm.acquiring_reason or "another acquisition"
         logging.warning(
             f"Cannot start {what}: the fluorescence microscope is in use ({reason})."
         )
         return True
 
     @ensure_main_thread
-    def _on_fm_busy_changed(self, busy: bool) -> None:
+    def _on_fm_acquiring_changed(self, acquiring: bool) -> None:
         """Something started driving the FM, or stopped -- re-derive what is clickable.
 
         Marshalled, because the flag is cleared on whichever thread finished with the
@@ -622,7 +626,7 @@ class FMControlWidget(QWidget):
             logging.warning(f"Stage is not in a valid FM orientation. Cannot start acquisition (current: {self.microscope.get_stage_orientation()})")
             return
 
-        if self._refuse_if_fm_busy("live acquisition"):
+        if self._refuse_if_acquiring("live acquisition"):
             return
 
         # Get current settings
@@ -652,7 +656,7 @@ class FMControlWidget(QWidget):
         """Cancel all ongoing acquisitions (single image, z-stack, overview, positions, autofocus)."""
 
         # Cancel consolidated acquisition (single image or future consolidated types)
-        if self.is_acquiring:
+        if self._has_worker:
             logging.info(f"Cancelling {self._current_acquisition_type} acquisition")
             self._acquisition_stop_event.set()
             self._acquisition_thread.join(timeout=5)  # type: ignore[union-attr]
@@ -661,7 +665,7 @@ class FMControlWidget(QWidget):
 
     def toggle_acquisition(self):
         """Toggle acquisition start/stop with F6 key."""
-        if self.fm.is_acquiring:
+        if self.fm.is_streaming:
             logging.info("F6 pressed: Stopping acquisition")
             self.stop_acquisition()
         else:
@@ -809,7 +813,7 @@ class FMControlWidget(QWidget):
     def acquire_image(self):
         """Start threaded image acquisition using the current Z parameters and channel settings."""
 
-        if self._refuse_if_fm_busy("image acquisition"):
+        if self._refuse_if_acquiring("image acquisition"):
             return
 
         logging.info("Starting image acquisition")
@@ -842,7 +846,7 @@ class FMControlWidget(QWidget):
         # Marked busy as late as possible: everything above can still abort -- the
         # filename step opens a modal -- and an abort leaving the flag set would lock
         # out the overview tab with nothing running.
-        self.fm.set_busy(True, "z-stack" if z_parameters else "image acquisition")
+        self.fm.set_acquiring(True, "z-stack" if z_parameters else "image acquisition")
 
         # Start acquisition thread
         self._acquisition_thread = FunctionWorker(
@@ -884,7 +888,7 @@ class FMControlWidget(QWidget):
             logging.error(f"Error during image acquisition: {e}")
 
         finally:
-            self.fm.set_busy(False)
+            self.fm.set_acquiring(False)
             self.acquisition_finished_signal.emit()
 
     def _update_acquisition_button_states(self):
@@ -896,61 +900,52 @@ class FMControlWidget(QWidget):
             self.pushButton_cancel_acquisition.setEnabled(False)
             return
 
-        # Check if any acquisition is active (live or specific acquisitions), here or
-        # anywhere else on this microscope -- `fm.is_busy` is what covers the overview
-        # tab, whose tileset this widget has no other way of seeing.
-        any_acquisition_active = (
-            self.is_acquiring or self.fm.is_busy or self.is_acquisition_active
-        )
+        # Every control below answers one of three questions, and the microscope owns
+        # all three -- this used to assemble its own union per line, which is how the
+        # objective panel came to ask the wrong one (FIB-513).
+        acquiring = self.fm.is_acquiring  # anything running, here or anywhere
+        streaming = self.fm.is_streaming  # the live view specifically
+        interactive = self.fm.is_interactive  # may the user drive the hardware
 
         # Special case buttons with unique behavior
         self.pushButton_cancel_acquisition.setVisible(self.is_acquisition_active)
 
         # Update toggle acquisition button text based on state
-        if self.fm.is_acquiring:
-            self.pushButton_toggle_acquisition.setText("Stop Acquisition")
-        else:
-            self.pushButton_toggle_acquisition.setText("Start Acquisition")
-
+        self.pushButton_toggle_acquisition.setText(
+            "Stop Acquisition" if streaming else "Start Acquisition"
+        )
         # Clickable while the live stream *is* what is running -- it is the only way to
         # stop one -- but not while anything else has the microscope. This is the button
-        # FIB-441 is about: it was the one thing that stayed live through an overview
-        # run, and starting a stream mid-tileset changes the settings the remaining
-        # tiles are acquired at.
-        self.pushButton_toggle_acquisition.setEnabled(
-            self.fm.is_acquiring or not any_acquisition_active
-        )
+        # FIB-441 was about: it stayed live through an overview run, and starting a
+        # stream mid-tileset changes the settings the remaining tiles are acquired at.
+        self.pushButton_toggle_acquisition.setEnabled(streaming or not acquiring)
 
-        # Enable/disable standard buttons based on acquisition state
+        # Anything that starts new work waits for whatever is running to finish.
         for button in (
             self.pushButton_acquire_single_image,
             self.pushButton_acquire_zstack,
             self.pushButton_run_autofocus,
+            self.objectiveControlWidget.pushButton_insert_objective,
+            self.objectiveControlWidget.pushButton_move_to_focus,
+            self.objectiveControlWidget.pushButton_retract_objective,
         ):
-            button.setEnabled(not any_acquisition_active)
+            button.setEnabled(not acquiring)
 
-        # Disable control widgets during acquisition
-        self.objectiveControlWidget.setEnabled(not self.is_acquisition_active)
-        self.zParametersWidget.setEnabled(not any_acquisition_active)
+        # Parameters for the *next* run, so they follow the same rule.
+        self.zParametersWidget.setEnabled(not acquiring)
 
-        # Disable channel settings during specific acquisitions (but allow during live imaging)
-        self.channelSettingsWidget.setEnabled(not self.is_acquisition_active)
-        self.objectiveControlWidget.pushButton_insert_objective.setEnabled(
-            not any_acquisition_active
-        )
-        self.objectiveControlWidget.pushButton_move_to_focus.setEnabled(
-            not any_acquisition_active
-        )
-        self.objectiveControlWidget.pushButton_retract_objective.setEnabled(
-            not any_acquisition_active
-        )
-
-        # Disable channel list selection during any acquisition to prevent switching channels mid-acquisition
-        # self.channelSettingsWidget.channel_list.setEnabled(not any_acquisition_active)
+        # Hardware the user drives by hand. Live during a stream -- focusing and tuning
+        # exposure while watching is the point of them -- and not while a tileset,
+        # z-stack or autofocus sweep is driving the same hardware itself. The objective
+        # panel used to ask `is_acquisition_active`, which is only *this* widget's work,
+        # so another tab's tileset left the position spinbox live against a runner that
+        # was stepping the objective per z-level.
+        self.objectiveControlWidget.setEnabled(interactive)
+        self.channelSettingsWidget.setEnabled(interactive)
 
     def run_autofocus(self):
         """Start threaded auto-focus using the current channel settings and Z parameters."""
-        if self._refuse_if_fm_busy("auto-focus"):
+        if self._refuse_if_acquiring("auto-focus"):
             return
 
         logging.info("Starting auto-focus")
@@ -964,7 +959,7 @@ class FMControlWidget(QWidget):
         channel_settings = settings["selected_channel_settings"]
         autofocus_settings = settings["autofocus_settings"]
 
-        self.fm.set_busy(True, "auto-focus")
+        self.fm.set_acquiring(True, "auto-focus")
 
         # Start auto-focus thread
         self._acquisition_thread = FunctionWorker(
@@ -1009,7 +1004,7 @@ class FMControlWidget(QWidget):
         except Exception as e:
             logging.error(f"Auto-focus failed: {e}")
         finally:
-            self.fm.set_busy(False)
+            self.fm.set_acquiring(False)
             self.acquisition_finished_signal.emit()
 
     def closeEvent(self, event: QEvent):
@@ -1024,7 +1019,7 @@ class FMControlWidget(QWidget):
 
         # Stop live acquisition
         self.microscope.fm.acquisition_signal.disconnect(self.update_image)
-        if self.microscope.fm.is_acquiring:
+        if self.microscope.fm.is_streaming:
             try:
                 self.microscope.fm.stop_acquisition()
             except Exception as e:

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -594,21 +594,32 @@ class FMControlWidget(QWidget):
             )
             self.viewer.reset_view()
 
-    def _refuse_if_acquiring(self, what: str) -> bool:
-        """Whether the FM is already in use, having logged why. True means "do not start".
+    def _refuse_to_start(self, what: str) -> bool:
+        """Whether *what* may not be started, having logged why. True means "do not".
 
-        One question to the microscope, where this used to be a union of three: the
-        widget's own worker, the live stream, and everybody else. `fm.is_acquiring`
-        covers all of them, this widget's own work included -- it marks that through
-        `set_acquiring` like anyone else (FIB-513).
+        Both reasons in one place, asked by all three ways in. The running check used to
+        be a union of three assembled here -- the widget's own worker, the live stream,
+        and everybody else -- and `fm.is_acquiring` covers all of them now, this widget's
+        own work included, since it marks that through `set_acquiring` like anyone else
+        (FIB-513).
+
+        The pose check used to live in `start_acquisition` alone, so an image, a z-stack
+        or an autofocus sweep could be started from a pose the FM cannot see anything
+        from. Nothing but the buttons stopped them, and the buttons are not the guard.
         """
-        if not self.fm.is_acquiring:
-            return False
-        reason = self.fm.acquiring_reason or "another acquisition"
-        logging.warning(
-            f"Cannot start {what}: the fluorescence microscope is in use ({reason})."
-        )
-        return True
+        if self.fm.is_acquiring:
+            reason = self.fm.acquiring_reason or "another acquisition"
+            logging.warning(
+                f"Cannot start {what}: the fluorescence microscope is in use ({reason})."
+            )
+            return True
+        if not self.fm.has_valid_orientation():
+            logging.warning(
+                f"Cannot start {what}: the stage is not in a valid FM orientation "
+                f"(currently {self.microscope.get_stage_orientation()})."
+            )
+            return True
+        return False
 
     @ensure_main_thread
     def _on_fm_acquiring_changed(self, acquiring: bool) -> None:
@@ -622,11 +633,7 @@ class FMControlWidget(QWidget):
     def start_acquisition(self):
         """Start the fluorescence acquisition."""
 
-        if not self.microscope.fm.has_valid_orientation():
-            logging.warning(f"Stage is not in a valid FM orientation. Cannot start acquisition (current: {self.microscope.get_stage_orientation()})")
-            return
-
-        if self._refuse_if_acquiring("live acquisition"):
+        if self._refuse_to_start("live acquisition"):
             return
 
         # Get current settings
@@ -813,7 +820,7 @@ class FMControlWidget(QWidget):
     def acquire_image(self):
         """Start threaded image acquisition using the current Z parameters and channel settings."""
 
-        if self._refuse_if_acquiring("image acquisition"):
+        if self._refuse_to_start("image acquisition"):
             return
 
         logging.info("Starting image acquisition")
@@ -893,13 +900,6 @@ class FMControlWidget(QWidget):
 
     def _update_acquisition_button_states(self):
         """Update acquisition button states and control widgets based on live acquisition or specific acquisition status."""
-        if not self.microscope.fm.has_valid_orientation():
-            # If not in FM or SEM orientation, disable all acquisition buttons
-            self.pushButton_toggle_acquisition.setEnabled(False)
-            self.pushButton_acquire_zstack.setEnabled(False)
-            self.pushButton_cancel_acquisition.setEnabled(False)
-            return
-
         # Every control below answers one of three questions, and the microscope owns
         # all three -- this used to assemble its own union per line, which is how the
         # objective panel came to ask the wrong one (FIB-513).
@@ -907,7 +907,24 @@ class FMControlWidget(QWidget):
         streaming = self.fm.is_streaming  # the live view specifically
         interactive = self.fm.is_interactive  # may the user drive the hardware
 
-        # Special case buttons with unique behavior
+        # A fourth input, not a fourth question: where the stage is does not change what
+        # is running, but it does stop new work being started -- `start_acquisition`
+        # refuses on it too -- and stops the hardware being driven by hand.
+        #
+        # Folded in rather than returned early. The early return here disabled three
+        # buttons and skipped every line below, so the objective panel and the channel
+        # settings kept whatever they were last set to, including enabled during
+        # somebody else's tileset. It also missed two of the buttons it claimed to
+        # cover. Dead as shipped -- `ALLOW_UNKNOWN_ORIENTATIONS` answers this yes
+        # unconditionally -- which is why nobody noticed.
+        posed = self.microscope.fm.has_valid_orientation()
+        may_start = posed and not acquiring
+        may_touch = posed and interactive
+
+        # Deliberately not gated on the pose, unlike everything else here: taking Cancel
+        # away from a run that is under way leaves no way to stop it, and a stage that
+        # has wandered somewhere unrecognised is exactly when you want it. The old early
+        # return disabled it.
         self.pushButton_cancel_acquisition.setVisible(self.is_acquisition_active)
 
         # Update toggle acquisition button text based on state
@@ -915,10 +932,11 @@ class FMControlWidget(QWidget):
             "Stop Acquisition" if streaming else "Start Acquisition"
         )
         # Clickable while the live stream *is* what is running -- it is the only way to
-        # stop one -- but not while anything else has the microscope. This is the button
-        # FIB-441 was about: it stayed live through an overview run, and starting a
-        # stream mid-tileset changes the settings the remaining tiles are acquired at.
-        self.pushButton_toggle_acquisition.setEnabled(streaming or not acquiring)
+        # stop one, and stopping is allowed from any pose -- but not while anything else
+        # has the microscope. This is the button FIB-441 was about: it stayed live
+        # through an overview run, and starting a stream mid-tileset changes the
+        # settings the remaining tiles are acquired at.
+        self.pushButton_toggle_acquisition.setEnabled(streaming or may_start)
 
         # Anything that starts new work waits for whatever is running to finish.
         for button in (
@@ -929,10 +947,10 @@ class FMControlWidget(QWidget):
             self.objectiveControlWidget.pushButton_move_to_focus,
             self.objectiveControlWidget.pushButton_retract_objective,
         ):
-            button.setEnabled(not acquiring)
+            button.setEnabled(may_start)
 
         # Parameters for the *next* run, so they follow the same rule.
-        self.zParametersWidget.setEnabled(not acquiring)
+        self.zParametersWidget.setEnabled(may_start)
 
         # Hardware the user drives by hand. Live during a stream -- focusing and tuning
         # exposure while watching is the point of them -- and not while a tileset,
@@ -940,12 +958,12 @@ class FMControlWidget(QWidget):
         # panel used to ask `is_acquisition_active`, which is only *this* widget's work,
         # so another tab's tileset left the position spinbox live against a runner that
         # was stepping the objective per z-level.
-        self.objectiveControlWidget.setEnabled(interactive)
-        self.channelSettingsWidget.setEnabled(interactive)
+        self.objectiveControlWidget.setEnabled(may_touch)
+        self.channelSettingsWidget.setEnabled(may_touch)
 
     def run_autofocus(self):
         """Start threaded auto-focus using the current channel settings and Z parameters."""
-        if self._refuse_if_acquiring("auto-focus"):
+        if self._refuse_to_start("auto-focus"):
             return
 
         logging.info("Starting auto-focus")

--- a/tests/ui/test_fm_acquisition_state.py
+++ b/tests/ui/test_fm_acquisition_state.py
@@ -278,14 +278,14 @@ class TestTheControlWidgetGuard:
         return FluorescenceMicroscope()
 
     def test_an_idle_instrument_is_not_refused(self, fm):
-        assert self._widget(fm)._refuse_if_acquiring("live acquisition") is False
+        assert self._widget(fm)._refuse_to_start("live acquisition") is False
 
     def test_an_overview_elsewhere_is_refused(self, fm):
         """The case the old per-widget union could not see."""
         fm.set_acquiring(True, "overview acquisition")
 
         assert fm.is_streaming is False  # the flag the old guard asked
-        assert self._widget(fm)._refuse_if_acquiring("live acquisition") is True
+        assert self._widget(fm)._refuse_to_start("live acquisition") is True
 
     def test_its_own_worker_is_still_refused(self, fm):
         """One question replacing a union must not drop what the union knew. This widget
@@ -294,7 +294,7 @@ class TestTheControlWidgetGuard:
         fm.set_acquiring(True, "z-stack")
         widget._acquisition_thread = _AliveThread()
 
-        assert widget._refuse_if_acquiring("image acquisition") is True
+        assert widget._refuse_to_start("image acquisition") is True
 
     def test_cancel_asks_about_its_own_thread(self, fm):
         """Not the microscope: `cancel_acquisition` joins `_acquisition_thread`, so on
@@ -348,7 +348,7 @@ class TestTheControlWidgetWiring:
         "name", ["start_acquisition", "acquire_image", "run_autofocus"]
     )
     def test_every_way_in_asks_first(self, name):
-        assert "_refuse_if_acquiring" in self._calls(self._functions()[name])
+        assert "_refuse_to_start" in self._calls(self._functions()[name])
 
     @pytest.mark.parametrize("name", ["acquire_image", "run_autofocus"])
     def test_every_worker_is_marked_for(self, name):
@@ -370,6 +370,34 @@ class TestTheControlWidgetWiring:
         )
         assert cleared
 
+    def test_it_refuses_a_pose_the_fm_cannot_see_from(self):
+        """`start_acquisition` had this check and the other two did not, so an image, a
+        z-stack or an autofocus sweep could be started from a beam pose with nothing but
+        the button stopping it."""
+        from fibsem.fm.microscope import FluorescenceMicroscope
+
+        fm = FluorescenceMicroscope()
+        fm._allow_unknown_orientations = False  # the escape hatch is on by default
+        fm.valid_orientations = []  # so no pose is a valid one
+        fm.parent = _StageAt("SEM")
+        widget = TestTheControlWidgetGuard._widget(fm)
+        widget.microscope = fm.parent
+
+        assert fm.is_acquiring is False, "refused for the pose, not for being busy"
+        assert widget._refuse_to_start("image acquisition") is True
+
+    def test_every_control_is_set_on_every_path(self):
+        """`_update_acquisition_button_states` returned early on a bad pose, setting
+        three buttons and skipping the rest -- so the objective panel and the channel
+        settings kept whatever they were last set to, including enabled during somebody
+        else's tileset. Dead as shipped, since `ALLOW_UNKNOWN_ORIENTATIONS` answers that
+        check yes unconditionally, which is why nobody noticed.
+        """
+        import ast
+
+        node = self._functions()["_update_acquisition_button_states"]
+        assert not [n for n in ast.walk(node) if isinstance(n, ast.Return)]
+
     def test_the_hardware_controls_ask_whether_the_user_may_drive(self):
         """The bug FIB-513 closes. The objective panel gated on `is_acquisition_active`
         -- this widget's own work -- so another tab's tileset left the position spinbox
@@ -380,8 +408,20 @@ class TestTheControlWidgetWiring:
         """
         source = self._source()
         for control in ("objectiveControlWidget", "channelSettingsWidget"):
-            assert f"self.{control}.setEnabled(interactive)" in source, control
+            assert f"self.{control}.setEnabled(may_touch)" in source, control
         assert "interactive = self.fm.is_interactive" in source
+        assert "may_touch = posed and interactive" in source
+
+
+class _StageAt:
+    """The parent microscope, for the two orientation questions the FM forwards."""
+
+    def __init__(self, orientation: str):
+        self._orientation = orientation
+        self.stage_is_compustage = True
+
+    def get_stage_orientation(self, stage_position=None) -> str:
+        return self._orientation
 
 
 class _AliveThread:

--- a/tests/ui/test_fm_acquisition_state.py
+++ b/tests/ui/test_fm_acquisition_state.py
@@ -1,10 +1,14 @@
-"""Two widgets, one fluorescence microscope, one flag saying it is in use (FIB-441).
+"""Three questions about the FM, asked in one place (FIB-441, FIB-513).
 
-The hazard: an overview tileset spends much of its time moving the stage between tiles,
-so the live-stream flag drops repeatedly during a run. A widget asking `fm.is_acquiring`
-about somebody else's tileset therefore sees "free" for most of it, and starting a live
-stream mid-run leaves the remaining tiles acquired at whatever settings it applied on
-the way past.
+    is_streaming    the live view is on
+    is_acquiring    anything is running: the stream, or a claimed operation
+    is_interactive  the user may drive the hardware
+
+They are not interchangeable, and every bug here came from asking the wrong one. A
+tileset moves the stage between every pair of tiles with no stream running, so
+`is_streaming` reads idle for most of somebody else's run -- which is how a live stream
+came to be startable mid-tileset, and how the objective panel came to stay live against
+a runner that was stepping the objective itself.
 """
 import os
 
@@ -58,7 +62,7 @@ def accept_dialog(monkeypatch):
 def no_worker(monkeypatch):
     """Stop `acquire` short of actually running a tileset.
 
-    The flag is set on the GUI thread before the worker starts, which is the part under
+    The FM is marked on the GUI thread before the worker starts, which is the part under
     test; running the acquisition would only add simulated stage travel to each of these.
     """
     from fibsem.ui.fm.widgets import fm_overview_widget as module
@@ -76,54 +80,97 @@ def no_worker(monkeypatch):
     monkeypatch.setattr(module, "FunctionWorker", _Worker)
 
 
-class TestBusy:
-    """`is_busy` is the union of both ways the FM can be in use, which is the point."""
-
+class TestTheThreeQuestions:
     @pytest.fixture()
     def fm(self):
         return FluorescenceMicroscope()
 
-    def test_a_free_microscope_is_not_busy(self, fm):
-        assert fm.is_busy is False
-        assert fm.busy_reason == ""
+    def test_an_idle_microscope(self, fm):
+        assert (fm.is_streaming, fm.is_acquiring, fm.is_interactive) == (
+            False,
+            False,
+            True,
+        )
+        assert fm.acquiring_reason == ""
 
-    def test_set_busy_says_why(self, fm):
-        fm.set_busy(True, "overview acquisition")
-        assert fm.is_busy is True
-        assert fm.busy_reason == "overview acquisition"
+    def test_a_claimed_operation(self, fm):
+        """A tileset, a z-stack, an autofocus sweep. Not a stream, and the hardware is
+        being driven by whatever claimed it."""
+        fm.set_acquiring(True, "overview acquisition")
 
-    def test_clearing_frees_it(self, fm):
-        fm.set_busy(True, "overview acquisition")
-        fm.set_busy(False)
-        assert fm.is_busy is False
-        assert fm.busy_reason == ""
+        assert (fm.is_streaming, fm.is_acquiring, fm.is_interactive) == (
+            False,
+            True,
+            False,
+        )
+        assert fm.acquiring_reason == "overview acquisition"
 
-    def test_a_live_stream_counts_as_busy(self, fm):
+    def test_a_live_stream(self, fm):
+        """The case the whole split exists for: acquiring, but the user may still focus
+        and tune exposure, because watching while adjusting is the point of live view."""
         fm.start_acquisition()
         try:
-            assert fm.is_busy is True
-            assert fm.busy_reason == "live acquisition"
+            assert (fm.is_streaming, fm.is_acquiring, fm.is_interactive) == (
+                True,
+                True,
+                True,
+            )
+            assert fm.acquiring_reason == "live acquisition"
         finally:
             fm.stop_acquisition()
-        assert fm.is_busy is False
+
+        assert (fm.is_streaming, fm.is_acquiring, fm.is_interactive) == (
+            False,
+            False,
+            True,
+        )
+
+    def test_finishing_gives_it_back(self, fm):
+        fm.set_acquiring(True, "overview acquisition")
+        fm.set_acquiring(False)
+
+        assert fm.is_acquiring is False
+        assert fm.is_interactive is True
+        assert fm.acquiring_reason == ""
 
     def test_it_announces_itself(self, fm):
         """So a widget that did not start it can grey out, not only refuse the click."""
         seen = []
-        fm.busy_changed.connect(seen.append)
+        fm.acquiring_changed.connect(seen.append)
 
-        fm.set_busy(True, "overview acquisition")
-        fm.set_busy(False)
+        fm.set_acquiring(True, "overview acquisition")
+        fm.set_acquiring(False)
 
         assert seen == [True, False]
+
+    def test_a_stream_announces_itself_too(self, fm):
+        """It does not go through `set_acquiring` -- it reports through its thread -- so
+        `start_acquisition` has to raise the signal itself."""
+        seen = []
+        fm.acquiring_changed.connect(seen.append)
+
+        fm.start_acquisition()
+        try:
+            assert seen == [True]
+        finally:
+            fm.stop_acquisition()
+        assert seen[-1] is False
 
 
 class TestTheOverviewMarksTheInstrument:
     def test_a_run_marks_the_microscope(self, widget, accept_dialog, no_worker):
         widget.acquire()
 
-        assert widget.fm.is_busy is True
-        assert widget.fm.busy_reason == "overview acquisition"
+        assert widget.fm.is_acquiring is True
+        assert widget.fm.acquiring_reason == "overview acquisition"
+
+    def test_a_run_is_not_a_stream(self, widget, accept_dialog, no_worker):
+        """The distinction the hazard rests on: a widget watching `is_streaming` sees an
+        idle microscope right through somebody else's tileset."""
+        widget.acquire()
+
+        assert widget.fm.is_streaming is False
+        assert widget.fm.is_interactive is False
 
     def test_the_worker_gives_it_back(self, widget, accept_dialog, no_worker):
         widget.acquire()
@@ -131,7 +178,7 @@ class TestTheOverviewMarksTheInstrument:
 
         widget._acquire_worker()
 
-        assert widget.fm.is_busy is False
+        assert widget.fm.is_acquiring is False
 
     def test_a_failed_run_gives_it_back(self, widget, accept_dialog, no_worker):
         """A run that dies holding the FM locks out every FM widget for the rest of the
@@ -141,7 +188,7 @@ class TestTheOverviewMarksTheInstrument:
 
         widget._acquire_worker()
 
-        assert widget.fm.is_busy is False
+        assert widget.fm.is_acquiring is False
 
     def test_a_cancelled_run_gives_it_back(self, widget, accept_dialog, no_worker):
         from fibsem.cancellation import OperationCancelledError
@@ -151,28 +198,26 @@ class TestTheOverviewMarksTheInstrument:
 
         widget._acquire_worker()
 
-        assert widget.fm.is_busy is False
+        assert widget.fm.is_acquiring is False
 
 
 class TestTheOverviewRespectsTheInstrument:
-    def test_it_will_not_start_while_something_else_has_it(
+    def test_it_will_not_start_while_something_else_is_running(
         self, widget, accept_dialog, no_worker
     ):
-        """What `fm.is_acquiring` could not answer.
+        """What `is_streaming` could not answer: a z-stack in the control widget is not
+        a stream, so the old guard saw an idle microscope and started a tileset straight
+        through it."""
+        widget.fm.set_acquiring(True, "z-stack")
 
-        A z-stack running in the control widget is not a live stream, so the old guard
-        saw an idle microscope and started a tileset straight through it.
-        """
-        widget.fm.set_busy(True, "z-stack")
-
-        assert widget.fm.is_acquiring is False  # the flag the old guard asked
+        assert widget.fm.is_streaming is False  # the flag the old guard asked
         widget.acquire()
 
         assert accept_dialog == [], "asked the user to confirm a run it then refused"
 
     def test_it_starts_once_the_instrument_is_free(self, widget, accept_dialog, no_worker):
-        widget.fm.set_busy(True, "z-stack")
-        widget.fm.set_busy(False)
+        widget.fm.set_acquiring(True, "z-stack")
+        widget.fm.set_acquiring(False)
 
         widget.acquire()
 
@@ -183,17 +228,17 @@ class TestTheAcquireButtonFollowsTheInstrument:
     def test_it_greys_out_when_something_else_starts(self, widget, qapp):
         assert widget.button_acquire.isEnabled() is True
 
-        widget.fm.set_busy(True, "z-stack")
+        widget.fm.set_acquiring(True, "z-stack")
         qapp.processEvents()
 
         assert widget.button_acquire.isEnabled() is False
 
     def test_it_comes_back_when_that_finishes(self, widget, qapp):
-        widget.fm.set_busy(True, "z-stack")
+        widget.fm.set_acquiring(True, "z-stack")
         qapp.processEvents()
         assert widget.button_acquire.isEnabled() is False, "nothing to come back from"
 
-        widget.fm.set_busy(False)
+        widget.fm.set_acquiring(False)
         qapp.processEvents()
 
         assert widget.button_acquire.isEnabled() is True
@@ -214,8 +259,8 @@ class TestTheControlWidgetGuard:
 
     Built without `__init__`. It takes a `napari.Viewer`, and constructing one under the
     offscreen platform segfaults this process (measured: SIGSEGV, no OpenGL) -- which is
-    why nothing else in the suite instantiates it either. The guard itself reads three
-    attributes and no widgets, so it is testable; that it is reached from each entry
+    why nothing else in the suite instantiates it either. The guard itself reads one
+    attribute and no widgets, so it is testable; that it is reached from each entry
     point is covered structurally below.
     """
 
@@ -233,40 +278,56 @@ class TestTheControlWidgetGuard:
         return FluorescenceMicroscope()
 
     def test_an_idle_instrument_is_not_refused(self, fm):
-        assert self._widget(fm)._refuse_if_fm_busy("live acquisition") is False
+        assert self._widget(fm)._refuse_if_acquiring("live acquisition") is False
 
     def test_an_overview_elsewhere_is_refused(self, fm):
-        """The case the old `self.is_acquiring` guard could not see."""
-        fm.set_busy(True, "overview acquisition")
+        """The case the old per-widget union could not see."""
+        fm.set_acquiring(True, "overview acquisition")
 
-        assert fm.is_acquiring is False  # the flag the old guard asked
-        assert self._widget(fm)._refuse_if_fm_busy("live acquisition") is True
+        assert fm.is_streaming is False  # the flag the old guard asked
+        assert self._widget(fm)._refuse_if_acquiring("live acquisition") is True
 
     def test_its_own_worker_is_still_refused(self, fm):
-        """Widening to the instrument must not drop what the widget already knew."""
+        """One question replacing a union must not drop what the union knew. This widget
+        marks its own work through `set_acquiring`, so the microscope answers for it."""
         widget = self._widget(fm)
+        fm.set_acquiring(True, "z-stack")
         widget._acquisition_thread = _AliveThread()
 
-        assert fm.is_busy is False  # nothing streaming, nothing marked
-        assert widget._refuse_if_fm_busy("image acquisition") is True
+        assert widget._refuse_if_acquiring("image acquisition") is True
+
+    def test_cancel_asks_about_its_own_thread(self, fm):
+        """Not the microscope: `cancel_acquisition` joins `_acquisition_thread`, so on
+        somebody else's run the old `is_acquiring` union sent it to `None.join()`."""
+        widget = self._widget(fm)
+        fm.set_acquiring(True, "overview acquisition")
+
+        assert widget._has_worker is False
+
+        widget._acquisition_thread = _AliveThread()
+        assert widget._has_worker is True
 
 
 class TestTheControlWidgetWiring:
-    """That the guard is reached, and the flag actually cleared.
+    """That the questions are asked where they should be.
 
-    Structural, because the widget cannot be instantiated here. It states the two
-    invariants a new acquisition path would have to keep: ask before starting, and
-    clear on every way out.
+    Structural, because the widget cannot be instantiated here. These state the
+    invariants a new acquisition path would have to keep.
     """
 
     @staticmethod
-    def _functions():
-        import ast
+    def _source():
         from pathlib import Path
 
         import fibsem.ui.widgets.fluorescence_control_widget as module
 
-        tree = ast.parse(Path(module.__file__).read_text())
+        return Path(module.__file__).read_text()
+
+    @classmethod
+    def _functions(cls):
+        import ast
+
+        tree = ast.parse(cls._source())
         return {
             node.name: node
             for node in ast.walk(tree)
@@ -287,11 +348,11 @@ class TestTheControlWidgetWiring:
         "name", ["start_acquisition", "acquire_image", "run_autofocus"]
     )
     def test_every_way_in_asks_first(self, name):
-        assert "_refuse_if_fm_busy" in self._calls(self._functions()[name])
+        assert "_refuse_if_acquiring" in self._calls(self._functions()[name])
 
     @pytest.mark.parametrize("name", ["acquire_image", "run_autofocus"])
     def test_every_worker_is_marked_for(self, name):
-        assert "set_busy" in self._calls(self._functions()[name])
+        assert "set_acquiring" in self._calls(self._functions()[name])
 
     @pytest.mark.parametrize(
         "name", ["_image_acquistion_worker", "_autofocus_worker"]
@@ -302,16 +363,29 @@ class TestTheControlWidgetWiring:
 
         node = self._functions()[name]
         cleared = any(
-            "set_busy"
+            "set_acquiring"
             in self._calls(ast.Module(body=block.finalbody, type_ignores=[]))
             for block in ast.walk(node)
             if isinstance(block, ast.Try)
         )
         assert cleared
 
+    def test_the_hardware_controls_ask_whether_the_user_may_drive(self):
+        """The bug FIB-513 closes. The objective panel gated on `is_acquisition_active`
+        -- this widget's own work -- so another tab's tileset left the position spinbox
+        live while `FMTiledAcquisitionRunner` was stepping the objective per z-level.
+
+        Not `any_acquisition_active` either: that includes the live stream, and focusing
+        during live view is what the panel is for.
+        """
+        source = self._source()
+        for control in ("objectiveControlWidget", "channelSettingsWidget"):
+            assert f"self.{control}.setEnabled(interactive)" in source, control
+        assert "interactive = self.fm.is_interactive" in source
+
 
 class _AliveThread:
-    """A worker that has not finished, for `is_acquiring`."""
+    """A worker that has not finished."""
 
     def is_alive(self) -> bool:
         return True


### PR DESCRIPTION
Closes FIB-513.

`fm.is_acquiring` did not mean "the FM is acquiring" — it meant "the live stream thread is alive". Every widget that wanted the general question assembled its own union, and they all assembled a slightly different one. #299 added `is_busy` rather than fix the name, which made it six overlapping flags.

They were all answering one of three questions, and only two had names:

```python
is_streaming      # the live view is on            (was is_acquiring)
is_acquiring      # anything is running            (was is_busy)
is_interactive    # the user may drive hardware    (new)
```

`is_interactive` is `not is_acquiring or is_streaming` — true while idle *and* while streaming, because focusing and tuning exposure while watching is what the objective and channel controls are for; false while a tileset, z-stack or autofocus sweep is driving that same hardware itself.

## The four states

| | `is_streaming` | `is_acquiring` | `is_interactive` | `is_acquisition_active` |
|---|---|---|---|---|
| idle | · | · | ✅ | · |
| live view running | ✅ | ✅ | ✅ | · |
| my own image / z-stack / autofocus | · | ✅ | · | ✅ |
| **another tab's overview tileset** | · | ✅ | · | · |

The last row is the one everything went wrong on: both flags a widget could see read idle, because a tileset never streams and it belongs to somebody else.

## What each control asks

| control | asks | idle | streaming | my own work | another tab's tileset |
|---|---|---|---|---|---|
| Start/Stop Acquisition | `streaming or not acquiring` | Start | **Stop** | ✗ | ✗ |
| Acquire Image / Z-Stack / Auto-Focus | `not acquiring` | ✅ | ✗ | ✗ | ✗ |
| Insert / Retract / Move-to-Focus objective | `not acquiring` | ✅ | ✗ | ✗ | ✗ |
| Z-Stack Parameters | `not acquiring` | ✅ | ✗ | ✗ | ✗ |
| **Objective panel** (position spinbox, shift-scroll) | `interactive` | ✅ | ✅ | ✗ | ✗ **(was ✅)** |
| **Channel settings** | `interactive` | ✅ | ✅ | ✗ | ✗ **(was ✅)** |
| Cancel Acquisition (visible) | `is_acquisition_active` | · | · | ✅ | · |
| live parameter push (`_on_channel_field_changed`) | `streaming` | ✗ | ✅ | ✗ | ✗ |
| channel select / remove | `not streaming` | ✅ | ✗ | ✅ | ✅ |
| Overview: Acquire | `not acquiring` + pose + tiles + host | ✅ | ✗ | ✗ | ✗ |
| Overview: Move to FM | `not acquiring` | ✅ | ✗ | ✗ | ✗ |
| Coincidence viewer: Start Acquisition | `not acquiring` | ✅ | Stop | ✗ | ✗ |

Two rows changed behaviour; the rest are renames.

## Not just renames

**`cancel_acquisition`** guarded `self._acquisition_thread.join()` with the old union, so during somebody else's run it would have reached `None.join()`. It asks `_has_worker` now — its own thread, which is what it always meant.

**The objective panel** is the bug this closes. It gated on `is_acquisition_active` (this widget's own work), so another tab's tileset left the position spinbox live while `FMTiledAcquisitionRunner` was stepping the objective per z-level and running `run_coarse_fine_autofocus`. Gating on the old `any_acquisition_active` would have been wrong in the other direction — it includes the live stream, so it would have taken focusing away during live view. Same wrong question and same fix in `ObjectiveControlWidget`'s shift-scroll handler.

## The pose, guarded in the functions too

Asking which entry points actually had the orientation check that the button states assume turned up two more holes of the same shape, both dead as shipped (`ALLOW_UNKNOWN_ORIENTATIONS` answers `has_valid_orientation` yes unconditionally) and both live the moment that flag is turned off:

* `start_acquisition` had the check; `acquire_image` and `run_autofocus` did not. All three go through `_refuse_to_start` now, which asks both questions — is something running, and is the stage somewhere this can run from.
* `_update_acquisition_button_states` returned early on a bad pose, disabling three buttons (two short of the five it claimed) and skipping every line below — which is where the objective panel and channel settings are set, so they kept whatever they last had, including enabled during somebody else's tileset. The pose is a fourth input now: `may_start = posed and not acquiring`, `may_touch = posed and interactive`, every control set on every path.

One deliberate behaviour change: **Cancel is no longer disabled by a bad pose.** The early return took it away, and taking Cancel from a run that is under way leaves no way to stop it — a stage that has wandered somewhere unrecognised is exactly when you want it. Same reasoning the overview tab already applies to its own Cancel.

## Scope

`.is_acquiring` appears 50 times but on three different objects. `FibsemMicroscope.is_acquiring` (the beam side) and the widget-level properties on `FMAcquisitionWidget` / `FMOverviewWidget` are untouched; the rename is the 24 `fm.is_acquiring` sites, each read rather than sed'd. `FMControlWidget.is_acquiring` and `any_acquisition_active` are deleted — the microscope answers for them.

`FMAcquisitionWidget` is renamed but otherwise unchanged: it never marks its own work through `set_acquiring`, so its union stays. The tab this work replaces does not get a vote in the design.

No compatibility aliases — a property keeping the old name pointed at the new meaning is exactly the confusion being removed.

## Testing

`test_fm_busy_guard.py` → `test_fm_acquisition_state.py`, 28 tests, opening on the state table above. Both easy-to-invert properties mutation-checked: dropping `or is_streaming` from `is_interactive` fails the live-stream case, dropping `or self._acquiring` from `is_acquiring` fails nine. 1430 pass across `tests/ui`, `tests/fm` and `tests/test_microscope.py`.

