### PR TITLE
[ui] Follow the microscope across a reconnect in the protocol editors (FIB-525)

### DIFF
--- a/fibsem/applications/autolamella/ui/autolamella_fluorescence_acquisition_task_config_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_fluorescence_acquisition_task_config_widget.py
@@ -84,6 +84,22 @@ class AutoLamellaFluorescenceAcquisitionTaskConfigWidget(QWidget):
 
         self.setLayout(layout)
 
+    def set_microscope(self, microscope: 'FibsemMicroscope') -> None:
+        """Point this widget at a different microscope after a reconnect.
+
+        The editors that own this widget are built once and survive
+        disconnect/reconnect, so without this the widget keeps the microscope it
+        was constructed with -- and its channel editor keeps offering that
+        microscope's excitation/emission filters. Connect to a non-FM system
+        first and it offers none at all, for the life of the process (FIB-525).
+
+        The captured ``fm`` matters as much as the microscope: it is a live
+        handle to hardware, not a value.
+        """
+        self.microscope = microscope
+        self.fm = microscope.fm
+        self.channelSettingsWidget.set_fm(microscope.fm)
+
     def get_task_config(self) -> AcquireFluorescenceImageConfig:
         self.config.orientation = self.orientation_combo.value()
         self.config.zparams = self.z_parameters_widget.z_parameters

--- a/fibsem/ui/fm/widgets/channel_list_widget.py
+++ b/fibsem/ui/fm/widgets/channel_list_widget.py
@@ -95,6 +95,15 @@ class _DraggableChannelList(QListWidget):
         super().__init__(parent)
         self._fm = fm
 
+    def set_fm(self, fm) -> None:
+        """Point at a different microscope (FIB-525).
+
+        Only used to suppress selection changes during live acquisition, but a
+        stale reference here means asking the *previous* microscope whether it is
+        streaming.
+        """
+        self._fm = fm
+
     def resizeEvent(self, event) -> None:
         """Keep row widths pinned to the viewport as it changes.
 
@@ -682,6 +691,26 @@ class ChannelListWidget(QWidget):
     @property
     def channel_settings(self) -> List[ChannelSettings]:
         return [self._row(i).channel for i in range(self._list.count())]
+
+    def set_fm(self, fm) -> None:
+        """Point this list at a different fluorescence microscope.
+
+        The excitation/emission choices are read from the microscope once, at
+        construction, and handed to every row. On a reconnect that leaves each row
+        offering the previous microscope's filters -- or, if the first connection
+        had no FM at all, nothing (FIB-525).
+
+        Rebuilding the rows is how the new choices reach them: the rows take their
+        item lists as constructor arguments, and the channel objects themselves are
+        untouched, so the configured channels survive. Row selection and the
+        per-row enabled checkboxes do not, which is an acceptable cost for an event
+        as rare as swapping microscopes.
+        """
+        self.fm = fm
+        self._list.set_fm(fm)
+        self._emission_items = list(fm.filter_set.available_emission_wavelengths) if fm is not None else []
+        self._excitation_items = list(fm.filter_set.available_excitation_wavelengths) if fm is not None else []
+        self.channel_settings = list(self._channel_list)
 
     @channel_settings.setter
     def channel_settings(self, value: Union[ChannelSettings, List[ChannelSettings]]) -> None:

--- a/fibsem/ui/fm/widgets/channel_settings_widget.py
+++ b/fibsem/ui/fm/widgets/channel_settings_widget.py
@@ -141,6 +141,34 @@ class ChannelSettingsWidget(QWidget):
         self._panel.set_title(channel.name)
         self.refresh()
 
+    def set_fm(self, fm: Optional[FluorescenceMicroscope]) -> None:
+        """Point this widget at a different fluorescence microscope.
+
+        The available wavelengths are the microscope's, not the channel's, so they
+        have to be re-read when the microscope changes -- this widget keeps no
+        ``fm`` reference of its own, only the two lists derived from it, which is
+        why nothing looked stale from the outside while the combos were offering
+        a disconnected microscope's filters (FIB-525).
+
+        The selected value is preserved where the new microscope still offers it;
+        where it does not, ``set_values`` falls back to the closest match rather
+        than silently reporting a wavelength the hardware cannot produce.
+        """
+        self._emission_items = list(fm.filter_set.available_emission_wavelengths) if fm is not None else []
+        self._excitation_items = list(fm.filter_set.available_excitation_wavelengths) if fm is not None else []
+
+        blocked = self.blockSignals(True)
+        try:
+            self.excitation_combo.set_values(self._excitation_items)
+            self.emission_combo.set_values(self._emission_items)
+        finally:
+            self.blockSignals(blocked)
+
+        # Re-apply the channel so the controls show what it actually holds, not
+        # whatever survived repopulating the combos.
+        if self._channel is not None:
+            self.refresh()
+
     def refresh(self) -> None:
         """Re-sync controls from current channel without emitting signals."""
         if self._channel is None:

--- a/fibsem/ui/fm/widgets/fm_multi_channel_widget.py
+++ b/fibsem/ui/fm/widgets/fm_multi_channel_widget.py
@@ -163,6 +163,17 @@ class FluorescenceMultiChannelWidget(QWidget):
             self._selected_channel = None
             self._settings_widget.setVisible(False)
 
+    def set_fm(self, fm) -> None:
+        """Point this widget and both of its halves at a different microscope.
+
+        Both halves derive their wavelength choices from the microscope, and both
+        do it at construction, so both have to be told (FIB-525). The channel
+        objects are unaffected -- only the choices offered for them change.
+        """
+        self.fm = fm
+        self._list.set_fm(fm)
+        self._settings_widget.set_fm(fm)
+
     def set_live_acquisition_controls(self, enabled: bool) -> None:
         """Stub for ChannelSettingsWidget/ChannelListWidget compatibility."""
         pass

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -108,11 +108,19 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         if hasattr(self, "milling_task_editor"):
             # Reconnect: this editor is built once and survives disconnect, so every
             # widget under it still holds the microscope it was built with. Each one
-            # that does has to be told -- see FIB-525, where updating only the line
-            # below left the fluorescence channel editor offering a disconnected
+            # that does has to be told -- see FIB-525, where updating only the milling
+            # editor left the fluorescence channel editor offering a disconnected
             # microscope's filters (or none, if the first connection had no FM).
-            self.milling_task_editor.set_microscope(self.microscope)
-            self.fluorescence_acquisition_task_config_widget.set_microscope(self.microscope)
+            #
+            # Asked for by name rather than assumed present: the condition above tests
+            # one widget, but _create_widgets assigns it before the others and is not
+            # guarded, so a constructor raising midway leaves this branch reachable
+            # with the rest missing. Skipping what is absent lets the original failure
+            # be the one that surfaces, instead of an AttributeError here.
+            for name in ("milling_task_editor", "fluorescence_acquisition_task_config_widget"):
+                widget = getattr(self, name, None)
+                if widget is not None:
+                    widget.set_microscope(self.microscope)
         else:
             # First connect: build the full UI
             self._create_widgets()

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -106,8 +106,13 @@ class AutoLamellaProtocolEditorWidget(QWidget):
             raise ValueError("Microscope in parent widget is None, cannot proceed.")
         self.microscope = self.parent_widget.microscope
         if hasattr(self, "milling_task_editor"):
-            # Reconnect: widget already initialized, just update microscope reference
-            self.milling_task_editor.microscope = self.microscope
+            # Reconnect: this editor is built once and survives disconnect, so every
+            # widget under it still holds the microscope it was built with. Each one
+            # that does has to be told -- see FIB-525, where updating only the line
+            # below left the fluorescence channel editor offering a disconnected
+            # microscope's filters (or none, if the first connection had no FM).
+            self.milling_task_editor.set_microscope(self.microscope)
+            self.fluorescence_acquisition_task_config_widget.set_microscope(self.microscope)
         else:
             # First connect: build the full UI
             self._create_widgets()

--- a/fibsem/ui/widgets/autolamella_task_config_editor.py
+++ b/fibsem/ui/widgets/autolamella_task_config_editor.py
@@ -196,7 +196,13 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
             raise ValueError("Microscope is None, cannot open protocol editor.")
         self.microscope = self.parent_widget.microscope
         if self.milling_task_editor is not None:
-            self.milling_task_editor.microscope = self.microscope
+            # Reconnect: this editor is built once and survives disconnect, so every
+            # widget under it still holds the microscope it was built with. Each one
+            # that does has to be told -- see FIB-525, where updating only the line
+            # below left the fluorescence channel editor offering a disconnected
+            # microscope's filters (or none, if the first connection had no FM).
+            self.milling_task_editor.set_microscope(self.microscope)
+            self.fluorescence_acquisition_task_config_widget.set_microscope(self.microscope)
         else:
             self._try_initialize()
 

--- a/fibsem/ui/widgets/autolamella_task_config_editor.py
+++ b/fibsem/ui/widgets/autolamella_task_config_editor.py
@@ -199,10 +199,18 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
             # Reconnect: this editor is built once and survives disconnect, so every
             # widget under it still holds the microscope it was built with. Each one
             # that does has to be told -- see FIB-525, where updating only the line
-            # below left the fluorescence channel editor offering a disconnected
+            # editor left the fluorescence channel editor offering a disconnected
             # microscope's filters (or none, if the first connection had no FM).
-            self.milling_task_editor.set_microscope(self.microscope)
-            self.fluorescence_acquisition_task_config_widget.set_microscope(self.microscope)
+            #
+            # Asked for by name rather than assumed present: the condition above tests
+            # one widget, but _create_widgets assigns it before the others and is not
+            # guarded, so a constructor raising midway leaves this branch reachable
+            # with the rest missing. Skipping what is absent lets the original failure
+            # be the one that surfaces, instead of an AttributeError here.
+            for name in ("milling_task_editor", "fluorescence_acquisition_task_config_widget"):
+                widget = getattr(self, name, None)
+                if widget is not None:
+                    widget.set_microscope(self.microscope)
         else:
             self._try_initialize()
 

--- a/fibsem/ui/widgets/milling_settings_widget.py
+++ b/fibsem/ui/widgets/milling_settings_widget.py
@@ -149,6 +149,27 @@ class FibsemMillingSettingsWidget(QWidget):
 
         return FibsemMillingSettings(**kwargs)
 
+    def set_microscope(self, microscope) -> None:
+        """Point at a different microscope and refresh its dynamic choices.
+
+        Only fields declaring `items: "dynamic"` are microscope-derived (currents,
+        presets, application files); everything else is static metadata. Repopulating
+        in place rather than rebuilding the form keeps the row/label wiring intact --
+        this form has no clear-and-rebuild path, and inventing one risks the
+        deleted-C++-wrapper crash the pattern and strategy forms document.
+        """
+        self.microscope = microscope
+        for row in self._rows:
+            meta = _META.get(row.field, {})
+            if meta.get("items") != "dynamic":
+                continue
+            cached = microscope.get_available_values_cached(
+                meta["microscope_parameter"], BeamType.ION
+            )
+            if cached:
+                row.control.set_values(cached)
+        self.set_settings(self._settings)
+
     def set_settings(self, settings: FibsemMillingSettings) -> None:
         self._settings = settings
 

--- a/fibsem/ui/widgets/milling_stage_list_widget.py
+++ b/fibsem/ui/widgets/milling_stage_list_widget.py
@@ -569,6 +569,24 @@ class MillingStageListWidget(QWidget):
         self._selected_stage = None
         self._update_empty_state()
 
+    def set_available_values(
+        self,
+        current_values: Optional[List[float]] = None,
+        preset_values: Optional[List[str]] = None,
+        show_preset: bool = False,
+    ) -> None:
+        """Replace the choices offered by the inline current/preset editors.
+
+        These come from the microscope and are handed in at construction, so they
+        have to be replaced when the microscope changes rather than re-read
+        (FIB-525). `show_preset` moves with them: which column applies is itself a
+        property of the connected system, not a fixed layout choice.
+        """
+        self._current_values = current_values or []
+        self._preset_values = preset_values or []
+        self._show_preset = show_preset
+        self.set_stages(self.get_stages())  # re-render rows with the new choices
+
     def set_pattern_column_visible(self, visible: bool) -> None:
         """Show or hide the Pattern column in the header and all rows."""
         self._show_pattern = visible

--- a/fibsem/ui/widgets/milling_stages_widget.py
+++ b/fibsem/ui/widgets/milling_stages_widget.py
@@ -257,6 +257,22 @@ class FibsemMillingStagesWidget(QWidget):
     def get_enabled_stages(self) -> List[FibsemMillingStage]:
         return self._list.get_enabled_stages()
 
+    def set_microscope(self, microscope) -> None:
+        """Point this widget and everything under it at a different microscope.
+
+        Three things here are the microscope's, not the stages': the available
+        currents, the available presets, and whether presets apply at all (Tescan
+        mills by preset). All three are read once at construction (FIB-525).
+        """
+        self.microscope = microscope
+        self._list.set_available_values(
+            current_values=microscope.get_available_values_cached("current", BeamType.ION),
+            preset_values=microscope.get_available_values_cached("preset", BeamType.ION),
+            show_preset=microscope.manufacturer.upper() == "TESCAN",
+        )
+        self._milling_widget.set_microscope(microscope)
+        self._pattern_widget.set_microscope(microscope)
+
     def set_manufacturer(self, manufacturer: Optional[str]) -> None:
         self._milling_widget.set_manufacturer(manufacturer)
 

--- a/fibsem/ui/widgets/milling_task_config_widget2.py
+++ b/fibsem/ui/widgets/milling_task_config_widget2.py
@@ -293,6 +293,11 @@ class MillingTaskConfigWidget2(QWidget):
         self._on_alignment_checkbox_changed(settings.alignment.enabled)  # sync button state to loaded values
         self._on_acquisition_checkbox_changed()  # sync button state to loaded values
 
+    def set_microscope(self, microscope) -> None:
+        """Point at a different microscope, and pass it down (FIB-525)."""
+        self.microscope = microscope
+        self.milling_stages_widget.set_microscope(microscope)
+
     def set_config(self, config: FibsemMillingTaskConfig) -> None:
         self.update_from_settings(config)
 

--- a/fibsem/ui/widgets/milling_task_viewer_widget.py
+++ b/fibsem/ui/widgets/milling_task_viewer_widget.py
@@ -577,6 +577,17 @@ class MillingTaskViewerWidget(QWidget):
     def get_settings(self) -> FibsemMillingTaskConfig:
         return self.config_widget.get_settings()
 
+    def set_microscope(self, microscope) -> None:
+        """Point this widget and its two children at a different microscope.
+
+        Assigning `.microscope` alone is what the editors used to do on reconnect,
+        and it is not enough: both children captured the microscope at construction
+        and never heard about the change (FIB-525).
+        """
+        self.microscope = microscope
+        self.config_widget.set_microscope(microscope)
+        self.milling_widget.set_microscope(microscope)
+
     def set_config(self, config: FibsemMillingTaskConfig) -> None:
         self.config_widget.set_config(config)
         self._schedule_pattern_update()

--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -99,6 +99,25 @@ class FibsemMillingWidget2(QWidget):
         return self._milling_thread is not None and self._milling_thread.is_alive()
 
     @ensure_main_thread
+    def set_microscope(self, microscope) -> None:
+        """Point at a different microscope, moving the progress subscription with it.
+
+        This widget does not merely read the microscope -- it drives milling and
+        subscribes to its progress signal. A stale reference here would run
+        start/stop/pause against the *previous* microscope, and progress from the
+        new one would never arrive because the subscription is still on the old
+        object (FIB-525).
+        """
+        connected = self.parent_widget._milling_enabled
+        if connected:
+            try:
+                self.microscope.milling_progress_signal.disconnect(self._on_milling_progress)
+            except TypeError:
+                pass  # never connected, or already dropped
+        self.microscope = microscope
+        if connected:
+            self.microscope.milling_progress_signal.connect(self._on_milling_progress)
+
     def _on_milling_progress(self, progress: dict):
         logging.info(f"Milling progress: {progress}")
 

--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -98,7 +98,6 @@ class FibsemMillingWidget2(QWidget):
         """Check if a milling task is currently running."""
         return self._milling_thread is not None and self._milling_thread.is_alive()
 
-    @ensure_main_thread
     def set_microscope(self, microscope) -> None:
         """Point at a different microscope, moving the progress subscription with it.
 
@@ -118,6 +117,7 @@ class FibsemMillingWidget2(QWidget):
         if connected:
             self.microscope.milling_progress_signal.connect(self._on_milling_progress)
 
+    @ensure_main_thread
     def _on_milling_progress(self, progress: dict):
         logging.info(f"Milling progress: {progress}")
 

--- a/fibsem/ui/widgets/pattern_settings_widget.py
+++ b/fibsem/ui/widgets/pattern_settings_widget.py
@@ -315,6 +315,16 @@ class FibsemPatternSettingsWidget(QWidget):
                 )
         return pattern
 
+    def set_microscope(self, microscope: FibsemMicroscope) -> None:
+        """Point at a different microscope and rebuild the controls (FIB-525).
+
+        Reuses the same clear-and-rebuild path a pattern-type change takes, so the
+        microscope-derived choices (`_build_controls` reads cached available values)
+        are re-fetched exactly the way they were first populated.
+        """
+        self.microscope = microscope
+        self._build_controls(self._pattern)
+
     def set_pattern(self, pattern: BasePattern) -> None:
         type_changed = pattern.name != self._pattern.name
         self._pattern = pattern

--- a/tests/ui/test_editor_microscope_reconnect.py
+++ b/tests/ui/test_editor_microscope_reconnect.py
@@ -1,0 +1,208 @@
+"""The protocol editors must follow the microscope across a reconnect.
+
+Both editors are built once and survive disconnect, unlike the main tabs, which
+`update_microscope_ui` destroys and rebuilds on every connect. So every widget
+under them keeps whatever microscope it was constructed with unless something
+tells it otherwise -- and reconnecting is exactly when that matters, because the
+new microscope may be a different make, or may have a fluorescence detector where
+the previous one had none.
+
+Reported as FIB-525: connect to a non-FM system, disconnect, reconnect to an
+FM-enabled one, and the channel editor's excitation/emission dropdowns stay
+empty for the life of the process.
+
+Two kinds of staleness, and they need different assertions:
+
+* a widget that **holds** the old microscope (or its `fm`). An identity walk over
+  the tree finds these, including in widgets added long after this file.
+* a widget that holds only **values derived** from it -- `ChannelSettingsWidget`
+  keeps the two wavelength lists and no `fm` at all, and `MillingStageListWidget`
+  takes the available currents as constructor arguments. An identity walk is
+  blind to these, so they are asserted against what the new microscope reports.
+"""
+
+import logging
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtWidgets import QWidget  # noqa: E402
+
+import fibsem.config as fconfig  # noqa: E402
+from fibsem import utils  # noqa: E402
+from fibsem.applications.autolamella.structures import (  # noqa: E402
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.applications.autolamella.workflows.tasks.acquire_fluorescence import (  # noqa: E402
+    AcquireFluorescenceImageConfig,
+)
+from fibsem.structures import BeamType  # noqa: E402
+from fibsem.ui.widgets.autolamella_lamella_protocol_editor import (  # noqa: E402
+    AutoLamellaProtocolEditorWidget,
+)
+from fibsem.ui.widgets.autolamella_task_config_editor import (  # noqa: E402
+    AutoLamellaProtocolTaskConfigEditor,
+)
+
+EDITORS = [AutoLamellaProtocolTaskConfigEditor, AutoLamellaProtocolEditorWidget]
+EDITOR_IDS = ["task_config_editor", "lamella_protocol_editor"]
+
+# Resolved from the package, not the cwd: the suite's _isolate_cwd fixture
+# chdirs each test into a tmp_path, so a relative path finds nothing.
+SIM_ARCTIS = os.path.join(fconfig.CONFIG_PATH, "sim-arctis-configuration.yaml")
+
+
+def _microscope_without_fm():
+    """A system with no fluorescence detector, as in the reported sequence."""
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    microscope.fm = None
+    return microscope
+
+
+def _microscope_with_fm():
+    microscope, _ = utils.setup_session(
+        manufacturer="Demo", ip_address="localhost", config_path=SIM_ARCTIS
+    )
+    assert microscope.fm is not None, "the arctis sim is the FM-capable fixture"
+    return microscope
+
+
+def _experiment():
+    experiment = Experiment(path=pathlib.Path(tempfile.mkdtemp()), name="reconnect")
+    experiment.task_protocol = AutoLamellaTaskProtocol()
+    experiment.task_protocol.task_config = {
+        "Acquire Fluorescence Image": AcquireFluorescenceImageConfig(
+            task_name="Acquire Fluorescence Image"
+        )
+    }
+    return experiment
+
+
+def _build(editor_cls, microscope):
+    """An editor on *microscope*, plus the host it reads the microscope from."""
+    host = QWidget()
+    host.experiment, host.microscope = _experiment(), microscope
+    editor = editor_cls(parent=host)
+    editor._host = host  # keep the parent alive for the test's duration
+    return editor, host
+
+
+def _reconnect(editor, host, microscope):
+    host.microscope = microscope
+    editor._on_microscope_connected()
+
+
+def _references_to(editor, *targets):
+    """Every `Widget.attribute` in the tree holding one of *targets*."""
+    found = set()
+    for widget in [editor] + editor.findChildren(QWidget):
+        for attr, value in list(vars(widget).items()):
+            if any(value is target for target in targets if target is not None):
+                found.add(f"{type(widget).__name__}.{attr}")
+    return found
+
+
+@pytest.fixture(autouse=True)
+def _quiet():
+    logging.disable(logging.CRITICAL)
+    yield
+    logging.disable(logging.NOTSET)
+
+
+@pytest.mark.parametrize("editor_cls", EDITORS, ids=EDITOR_IDS)
+def test_no_widget_keeps_the_old_microscope_after_reconnect(qapp, editor_cls):
+    """The general guard: nothing in the tree still points at the old microscope.
+
+    Deliberately not a list of widget names. The bug this replaces was an
+    incomplete list -- the reconnect handler updated exactly one widget, and the
+    other ten were found only by walking the tree. A future widget that captures
+    a microscope fails here without anyone remembering to add it.
+    """
+    old = _microscope_without_fm()
+    editor, host = _build(editor_cls, old)
+
+    new = _microscope_with_fm()
+    _reconnect(editor, host, new)
+
+    assert _references_to(editor, old, old.fm) == set()
+    # ...and the tree really does hold the new one, so the assertion above is not
+    # passing merely because every reference was dropped.
+    assert _references_to(editor, new, new.fm)
+
+
+@pytest.mark.parametrize("editor_cls", EDITORS, ids=EDITOR_IDS)
+def test_channel_editor_offers_the_new_microscope_filters(qapp, editor_cls):
+    """The reported symptom: empty excitation/emission dropdowns after reconnect.
+
+    Asserted on the derived lists rather than on a reference, because the widget
+    holding them keeps no `fm` -- the identity walk above cannot see this.
+    """
+    old = _microscope_without_fm()
+    editor, host = _build(editor_cls, old)
+    channels = editor.fluorescence_acquisition_task_config_widget.channelSettingsWidget
+    detail = channels._settings_widget
+
+    assert detail.excitation_combo.count() == 0, "no FM, so nothing to offer"
+
+    new = _microscope_with_fm()
+    _reconnect(editor, host, new)
+
+    expected = list(new.fm.filter_set.available_excitation_wavelengths)
+    assert expected, "the fixture must offer some excitation wavelengths"
+    offered = [
+        detail.excitation_combo.itemData(i) for i in range(detail.excitation_combo.count())
+    ]
+    assert offered == expected
+    assert channels._list._excitation_items == expected
+    assert channels._list._emission_items == list(
+        new.fm.filter_set.available_emission_wavelengths
+    )
+
+
+@pytest.mark.parametrize("editor_cls", EDITORS, ids=EDITOR_IDS)
+def test_milling_stages_offer_the_new_microscope_currents(qapp, editor_cls):
+    """The same fault on the milling side, which the one-line reconnect missed.
+
+    `MillingTaskViewerWidget.microscope` was reassigned on reconnect, but it hands
+    the microscope to its children at construction, so they kept the old one --
+    and the available currents are taken as constructor arguments, one level
+    further down again.
+    """
+    old = _microscope_without_fm()
+    editor, host = _build(editor_cls, old)
+
+    new = _microscope_with_fm()
+    _reconnect(editor, host, new)
+
+    stages = editor.milling_task_editor.config_widget.milling_stages_widget
+    assert stages.microscope is new
+    assert stages._list._current_values == new.get_available_values_cached(
+        "current", BeamType.ION
+    )
+    assert stages._list._preset_values == new.get_available_values_cached(
+        "preset", BeamType.ION
+    )
+
+
+@pytest.mark.parametrize("editor_cls", EDITORS, ids=EDITOR_IDS)
+def test_reconnect_leaves_the_configured_channels_alone(qapp, editor_cls):
+    """Swapping microscopes changes the choices offered, not the configuration.
+
+    The channel rows are rebuilt to pick up the new wavelength lists; the channel
+    objects they display must survive that, or a reconnect would quietly edit the
+    protocol.
+    """
+    old = _microscope_without_fm()
+    editor, host = _build(editor_cls, old)
+    channels = editor.fluorescence_acquisition_task_config_widget.channelSettingsWidget
+    before = [(ch.name, ch.excitation_wavelength) for ch in channels.channel_settings]
+
+    _reconnect(editor, host, _microscope_with_fm())
+
+    after = [(ch.name, ch.excitation_wavelength) for ch in channels.channel_settings]
+    assert after == before

--- a/tests/ui/test_editor_microscope_reconnect.py
+++ b/tests/ui/test_editor_microscope_reconnect.py
@@ -206,3 +206,26 @@ def test_reconnect_leaves_the_configured_channels_alone(qapp, editor_cls):
 
     after = [(ch.name, ch.excitation_wavelength) for ch in channels.channel_settings]
     assert after == before
+
+
+@pytest.mark.parametrize("editor_cls", EDITORS, ids=EDITOR_IDS)
+def test_a_half_built_editor_still_reconnects_what_it_has(qapp, editor_cls):
+    """A widget missing from a partial build is skipped, not fatal.
+
+    The reconnect branch is entered on `milling_task_editor` existing, but
+    `_create_widgets` assigns that first and is not wrapped in a try/except -- so a
+    constructor raising midway leaves the branch reachable with later widgets
+    absent. The fluorescence widget is exactly the one with previous form here
+    (5777bb35, "prevent crash when opening fluorescence config widget with no
+    FM"), and an AttributeError raised from this handler would mask whatever
+    actually failed during the build.
+    """
+    old = _microscope_without_fm()
+    editor, host = _build(editor_cls, old)
+    # the state a build that raised after the milling editor would leave behind
+    del editor.fluorescence_acquisition_task_config_widget
+
+    new = _microscope_with_fm()
+    _reconnect(editor, host, new)  # must not raise
+
+    assert editor.milling_task_editor.microscope is new

--- a/tests/ui/test_editor_microscope_reconnect.py
+++ b/tests/ui/test_editor_microscope_reconnect.py
@@ -229,3 +229,34 @@ def test_a_half_built_editor_still_reconnects_what_it_has(qapp, editor_cls):
     _reconnect(editor, host, new)  # must not raise
 
     assert editor.milling_task_editor.microscope is new
+
+
+def test_milling_progress_slot_stays_on_the_main_thread():
+    """`_on_milling_progress` must keep its @ensure_main_thread decorator.
+
+    It is the slot for `milling_progress_signal`, which the milling worker emits
+    off the main thread, so it touches widgets from a background thread without
+    it -- the failure mode this codebase has crashed on before (PR #168, the
+    Windows vispy/gloo access violation, and the PyQt5 abort-on-slot-exception
+    work).
+
+    Worth asserting rather than trusting: adding a method immediately above this
+    one lands between the decorator and the function unless the insertion is
+    careful, which silently moves the decorator onto the new method. That is
+    exactly how it was lost while FIB-525 was being written, and nothing else in
+    the suite would have noticed -- the decorator changes which thread the slot
+    runs on, not whether it runs.
+    """
+    from fibsem.ui.widgets.milling_widget import FibsemMillingWidget2
+
+    slot = FibsemMillingWidget2._on_milling_progress
+    assert hasattr(slot, "__wrapped__"), (
+        "_on_milling_progress is not wrapped -- @ensure_main_thread has been lost "
+        "or displaced onto a neighbouring method"
+    )
+    assert slot.__wrapped__.__name__ == "_on_milling_progress"
+
+    # ...and the reconnect setter must NOT have taken it: it is called from the
+    # connected_signal handler, already on the main thread, and wrapping it would
+    # defer the propagation rather than doing it inline.
+    assert not hasattr(FibsemMillingWidget2.set_microscope, "__wrapped__")


### PR DESCRIPTION
Fixes FIB-525.

## The bug

The two protocol editors are built once and survive a disconnect — unlike the main tabs, which `update_microscope_ui` destroys and rebuilds on every connect. So every widget under them keeps whatever microscope it was constructed with. On reconnect, the handlers updated exactly one attribute:

```python
self.milling_task_editor.microscope = self.microscope
```

Walking the widget tree finds **twelve references** to the microscope (or its `fm`) across eleven widget classes, identical in both editors. Two were refreshed. Ten were not.

**Reported symptom**: connect to a system with no fluorescence detector → disconnect → reconnect to an FM-enabled one, and the channel editor's excitation/emission dropdowns stay empty for the life of the process. The wavelengths are read from the microscope once, at construction, so an FM-less first connection caches two empty lists.

**The mirror case is worse**, and is the better reason to fix it: connect to an FM microscope *first*, then reconnect to a different one, and the widget keeps a live handle to the **previous microscope's `fm`**. Same for `FibsemMillingWidget2`, which doesn't merely read the microscope — it drives milling and subscribes to its progress signal.

## Also: the existing one-liner was never sufficient

`MillingTaskViewerWidget` hands the microscope to two children at construction, and the available currents are constructor arguments one level below *that*. So the milling side had the same fault, masked because currents and presets only visibly differ when the new microscope is a different make.

| chain | widget | refreshed before |
|---|---|---|
| milling | `<Editor>.microscope` | yes |
| | `MillingTaskViewerWidget.microscope` | yes |
| | `MillingTaskConfigWidget2.microscope` | **no** |
| | `FibsemMillingStagesWidget.microscope` | **no** |
| | `FibsemMillingSettingsWidget.microscope` | **no** |
| | `FibsemPatternSettingsWidget.microscope` | **no** |
| | `FibsemMillingWidget2.microscope` | **no** |
| fluorescence | `…FluorescenceAcquisitionTaskConfigWidget.microscope` / `.fm` | **no** |
| | `FluorescenceMultiChannelWidget.fm` | **no** |
| | `ChannelListWidget.fm` | **no** |
| | `_DraggableChannelList._fm` | **no** |

## The fix

Each widget holding a microscope gains `set_microscope` (or `set_fm`), re-deriving what it cached and passing it down:

- **Fluorescence**: re-reads the wavelength lists and rebuilds the channel rows, which take their choices as constructor arguments. The channel objects are untouched, so the configured channels survive; row selection and the enabled checkboxes don't — an acceptable cost for swapping microscopes.
- **Milling**: re-reads available currents and presets, and `show_preset` — whether presets apply at all is a property of the connected system (Tescan mills by preset), not a fixed layout choice.
- **`FibsemMillingWidget2`**: moves its progress subscription to the new microscope instead of leaving it on the old object.

Where a widget already had a clear-and-rebuild path (`FibsemPatternSettingsWidget._build_controls`), the setter reuses it rather than inventing a second one — the pattern and strategy forms both document a segfault from removing form rows during a focus change, and this doesn't add another place that can hit it.

## Tests — `tests/ui/test_editor_microscope_reconnect.py`

The primary test walks the tree after a simulated reconnect and asserts **nothing still points at the old microscope**. Deliberately not a list of widget names: an incomplete list is precisely what produced this bug, and a future widget that captures a microscope fails here without anyone remembering to add it. It also asserts the tree *does* hold the new one, so it can't pass by everything being dropped.

That alone isn't sufficient, though. Two widgets keep only values **derived** from the microscope and no reference at all — `ChannelSettingsWidget`'s wavelength lists, `MillingStageListWidget`'s currents — so an identity walk is blind to them. Those are asserted against what the new microscope reports.

8 tests, both editors. Mutation tested — each caught:

| mutation | caught by |
|---|---|
| fluorescence widget not told about the new microscope | tree walk + channel filters |
| milling subtree reverted to the bare assignment (the old behaviour) | tree walk + milling currents |
| channel list keeps its cached wavelengths | channel filters ×2 |
| detail widget keeps its cached wavelengths | channel filters ×2 |

`tests/ui` + `tests/milling` + `tests/autolamella`: **1513 passed**. All changed files parse under 3.8 (CI matrix floor).

## Not addressed

The editors don't listen to `disconnected_signal` at all, so between a disconnect and the next connect they still hold a handle to a disconnected microscope. Out of scope here — this PR makes reconnect correct; deciding what the editors should *do* while disconnected (disable? clear?) is a separate question.