### PR TITLE
[fm] Hand the shared imaging channel back after an FM read (FIB-517)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -566,8 +566,13 @@ class FMTiledAcquisitionRunner:
         # left its tiles on disk with nothing saying what grid they belonged to.
         self._save_parameters()
         try:
-            self._autofocus_if_mode(AutoFocusMode.ONCE)
-            self._run_tile_loop()
+            # Taken once for the whole run rather than per frame. On a TFS system the FM
+            # and the beams share one imaging channel, and handing it back between every
+            # pair of tiles would flick the microscope's own UI between views for the
+            # length of the acquisition. A no-op on any other mount (FIB-517).
+            with self.microscope.fm.active_channel():
+                self._autofocus_if_mode(AutoFocusMode.ONCE)
+                self._run_tile_loop()
         except OperationCancelledError:
             logging.info("Tileset acquisition cancelled")
             raise

--- a/fibsem/fm/autoscript.py
+++ b/fibsem/fm/autoscript.py
@@ -716,8 +716,13 @@ class ThermoFisherFluorescenceMicroscope(FluorescenceMicroscope):
         with self._channel_lock:
             if self._channel_depth == 0:
                 self._restore_view = self.connection.imaging.get_active_view()
-            self._channel_depth += 1
             self.set_active_channel()
+            # Counted only once the channel is actually ours. Raising here comes out of
+            # `__enter__`, so the caller's block never runs and the `finally` below never
+            # runs either -- a depth left too high would mean no later scope ever
+            # restored the view again. That is FIB-517 back, silently, for the rest of
+            # the session, and a dropped connection is enough to cause it.
+            self._channel_depth += 1
         try:
             yield
         finally:

--- a/fibsem/fm/autoscript.py
+++ b/fibsem/fm/autoscript.py
@@ -1,4 +1,6 @@
 import logging
+import threading
+from contextlib import contextmanager
 from typing import Literal, Tuple, Optional, Union, Dict, Any
 
 import numpy as np
@@ -113,7 +115,6 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
         Returns:
             The current magnification value
         """
-        self.parent.set_active_channel()
         return self._magnification
 
     @magnification.setter
@@ -123,7 +124,6 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
         Args:
             value: The magnification value to set
         """
-        self.parent.set_active_channel()
         self._magnification = value
 
     @property
@@ -133,10 +133,8 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
         Returns:
             The current focus position in metres
         """
-        active_view = self.parent.connection.imaging.get_active_view()
-        position = self.parent.fm_settings.focus.value
-        self.parent.connection.imaging.set_active_view(active_view)
-        return position
+        with self.parent.active_channel():
+            return self.parent.fm_settings.focus.value
 
     @property
     def limits(self) -> Tuple[float, float]:
@@ -145,9 +143,9 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
         Returns:
             A tuple of (minimum, maximum) focus position limits in metres
         """
-        self.parent.set_active_channel()
-        limits = self.parent.fm_settings.focus.limits
-        return (limits.min, limits.max)
+        with self.parent.active_channel():
+            limits = self.parent.fm_settings.focus.limits
+            return (limits.min, limits.max)
 
     def move_relative(self, delta: float):
         """Move the objective lens by a relative distance.
@@ -155,7 +153,6 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
         Args:
             delta: The distance to move in metres (positive = towards sample)
         """
-        self.parent.set_active_channel()
         current_position = self.position
         new_position = current_position + delta
         self.move_absolute(new_position)
@@ -174,29 +171,30 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
         if not position <= self._limit_position:
             logging.warning(f"Clipping position {position} to user-defined limits {self._limit_position}")
             position = np.clip(position, 0, self._limit_position)
-        self.parent.fm_settings.focus.value = position
+        with self.parent.active_channel():
+            self.parent.fm_settings.focus.value = position
 
     def insert(self) -> None:
         """Insert the objective lens into the working position.
 
         Moves the objective lens to the active/inserted position for imaging.
         """
-        self.parent.set_active_channel()
-        if self.state == "Inserted":
-            logging.warning("Objective lens is already inserted.")
-            return
-        self.parent.connection.detector.insert()
+        with self.parent.active_channel():
+            if self.state == "Inserted":
+                logging.warning("Objective lens is already inserted.")
+                return
+            self.parent.connection.detector.insert()
 
     def retract(self) -> None:
         """Retract the objective lens from the working position.
 
         Moves the objective lens to the inactive/retracted position for safety.
         """
-        self.parent.set_active_channel()
-        if self.state == "Retracted":
-            logging.warning("Objective lens is already retracted.")
-            return
-        self.parent.connection.detector.retract()
+        with self.parent.active_channel():
+            if self.state == "Retracted":
+                logging.warning("Objective lens is already retracted.")
+                return
+            self.parent.connection.detector.retract()
 
     @property
     def state(self) -> Literal["Inserted", "Retracted", "Busy", "Error", "Other"]:
@@ -206,8 +204,8 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
             The objective lens state (RetractableDeviceState) (e.g., 'Inserted', 'Retracted', 'Busy', 'Error', 'Other')
         """
         # TODO: migrate to standard enum, rather than string
-        self.parent.set_active_channel()
-        return self.parent.connection.detector.state
+        with self.parent.active_channel():
+            return self.parent.connection.detector.state
 
     def is_homed(self) -> bool:
         """Check if the objective lens is in the homed position.
@@ -215,16 +213,16 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
         Returns:
             True if the objective lens is homed, False otherwise
         """
-        self.parent.set_active_channel()
-        return self.parent.connection.detector.is_homed
+        with self.parent.active_channel():
+            return self.parent.connection.detector.is_homed
 
     def home(self) -> None:
         """Home the objective lens to its reference position.
 
         Moves the objective lens to its home/reference position for calibration.
         """
-        self.parent.set_active_channel()
-        self.parent.connection.detector.home()
+        with self.parent.active_channel():
+            self.parent.connection.detector.home()
 
 
 class ThermoFisherCamera(Camera):
@@ -259,12 +257,20 @@ class ThermoFisherCamera(Camera):
         frame_settings = GrabFrameSettings(emission_type=emission_type)
         # Uses current camera settings for binning and exposure time
 
+        # Deliberately unscoped: every path here comes through
+        # `FluorescenceMicroscope.acquire_image`, which holds the channel around the
+        # whole acquisition, and a tileset holds it around the whole run. Taking and
+        # returning it per frame would flick the microscope's own UI between views once
+        # per tile (FIB-517).
         self.parent.set_active_channel()
         image = self.parent.connection.imaging.grab_frame(frame_settings)
-
         return image.data  # AdornedImage.data -> np.ndarray
 
     def _start_fast_acquisition(self):
+        # The one place that deliberately keeps the channel rather than handing it back.
+        # A live stream owns the instrument for as long as it runs -- that is what it is
+        # -- and re-forces the channel each frame because something else may have taken
+        # it. Everything discrete goes through `active_channel()` instead (FIB-517).
         try:
             with self.parent.parent._threading_lock:
                 self.parent.set_active_channel()
@@ -318,7 +324,8 @@ class ThermoFisherCamera(Camera):
         Returns:
             The exposure time in seconds
         """
-        return self.parent.fm_settings.exposure_time.value
+        with self.parent.active_channel():
+            return self.parent.fm_settings.exposure_time.value
 
     @exposure_time.setter
     def exposure_time(self, value: float) -> None:
@@ -335,7 +342,8 @@ class ThermoFisherCamera(Camera):
             raise ValueError(
                 f"Exposure time must be between {limits[0]} and {limits[1]}, got {value}"
             )
-        self.parent.fm_settings.exposure_time.value = value
+        with self.parent.active_channel():
+            self.parent.fm_settings.exposure_time.value = value
 
     @property
     def exposure_time_limits(self) -> Tuple[float, float]:
@@ -344,8 +352,9 @@ class ThermoFisherCamera(Camera):
         Returns:
             A tuple of (minimum, maximum) exposure times in seconds
         """
-        limits = self.parent.fm_settings.exposure_time.limits
-        return (limits.min, limits.max)
+        with self.parent.active_channel():
+            limits = self.parent.fm_settings.exposure_time.limits
+            return (limits.min, limits.max)
 
     @property
     def binning(self) -> int:
@@ -354,7 +363,8 @@ class ThermoFisherCamera(Camera):
         Returns:
             The current binning value (e.g., 1, 2, 4, 8)
         """
-        return self.parent.fm_settings.binning.value
+        with self.parent.active_channel():
+            return self.parent.fm_settings.binning.value
 
     @binning.setter
     def binning(self, value: int) -> None:
@@ -370,7 +380,8 @@ class ThermoFisherCamera(Camera):
             raise ValueError(
                 f"Binning must be one of {self.available_binnings}, got {value}"
             )
-        self.parent.fm_settings.binning.value = value
+        with self.parent.active_channel():
+            self.parent.fm_settings.binning.value = value
 
     @property
     def available_binnings(self) -> Tuple[int, ...]:
@@ -379,7 +390,8 @@ class ThermoFisherCamera(Camera):
         Returns:
             A tuple of supported binning values (e.g., (1, 2, 4, 8))
         """
-        return self.parent.fm_settings.binning.available_values
+        with self.parent.active_channel():
+            return self.parent.fm_settings.binning.available_values
 
     @property
     def gain(self) -> float:
@@ -388,8 +400,8 @@ class ThermoFisherCamera(Camera):
         Returns:
             The current gain value
         """
-        self.parent.set_active_channel()
-        return self.parent.connection.detector.contrast.value
+        with self.parent.active_channel():
+            return self.parent.connection.detector.contrast.value
     
     @gain.setter
     def gain(self, value: float) -> None:
@@ -398,8 +410,8 @@ class ThermoFisherCamera(Camera):
         Args:
             value: The gain value to set
         """
-        self.parent.set_active_channel()
-        self.parent.connection.detector.contrast.value = value
+        with self.parent.active_channel():
+            self.parent.connection.detector.contrast.value = value
 
 
 class ThermoFisherLightSource(LightSource):
@@ -427,8 +439,8 @@ class ThermoFisherLightSource(LightSource):
         Returns:
             The current light source power as a percentage (0.0-1.0)
         """
-        self.parent.set_active_channel()
-        return self.parent.connection.detector.brightness.value
+        with self.parent.active_channel():
+            return self.parent.connection.detector.brightness.value
 
     @power.setter
     def power(self, value: float) -> None:
@@ -437,14 +449,14 @@ class ThermoFisherLightSource(LightSource):
         Args:
             value: The power level as a percentage (0.0-1.0)
         """
-        self.parent.set_active_channel()
-        # to set the power for a specific channel, we need to change to that emission type
-        # to change to that emission type we need to start emission...
-        # so we start, change power, stop
-        emission_color = self.parent.filter_set._emission_type
-        self.parent.light_source.start_emission(emission_type=emission_color)
-        self.parent.connection.detector.brightness.value = value
-        self.parent.light_source.stop_emission()
+        with self.parent.active_channel():
+            # to set the power for a specific channel, we need to change to that emission type
+            # to change to that emission type we need to start emission...
+            # so we start, change power, stop
+            emission_color = self.parent.filter_set._emission_type
+            self.parent.light_source.start_emission(emission_type=emission_color)
+            self.parent.connection.detector.brightness.value = value
+            self.parent.light_source.stop_emission()
 
     @property
     def power_limits(self) -> Tuple[float, float]:
@@ -453,9 +465,9 @@ class ThermoFisherLightSource(LightSource):
         Returns:
             A tuple of (minimum, maximum) power levels as percentages (0.0-1.0)
         """
-        self.parent.set_active_channel()
-        limits = self.parent.connection.detector.brightness.limits
-        return (limits.min, limits.max)
+        with self.parent.active_channel():
+            limits = self.parent.connection.detector.brightness.limits
+            return (limits.min, limits.max)
 
     @property
     def is_emitting(self) -> bool:
@@ -464,26 +476,26 @@ class ThermoFisherLightSource(LightSource):
         Returns:
             True if the light source is actively emitting, False otherwise
         """
-        self.parent.set_active_channel()
-        return self.parent.connection.detector.camera_settings.emission.is_on
+        with self.parent.active_channel():
+            return self.parent.connection.detector.camera_settings.emission.is_on
 
     def start_emission(self, emission_type: CameraEmissionType) -> None:
         """Start the light source emission.
 
         Begins light emission from the active light source for imaging.
         """
-        self.parent.set_active_channel()
-        self.parent.connection.detector.camera_settings.emission.start(
-            emission_type=emission_type
-        )
+        with self.parent.active_channel():
+            self.parent.connection.detector.camera_settings.emission.start(
+                emission_type=emission_type
+            )
 
     def stop_emission(self) -> None:
         """Stop the light source emission.
 
         Stops light emission from the active light source.
         """
-        self.parent.set_active_channel()
-        self.parent.connection.detector.camera_settings.emission.stop()
+        with self.parent.active_channel():
+            self.parent.connection.detector.camera_settings.emission.stop()
 
 
 class ThermoFisherFilterSet(FilterSet):
@@ -577,7 +589,8 @@ class ThermoFisherFilterSet(FilterSet):
             None for reflection mode, or the excitation wavelength for
             fluorescence mode (as the system uses multi-band filters)
         """
-        mode = self.parent.fm_settings.filter.type.value
+        with self.parent.active_channel():
+            mode = self.parent.fm_settings.filter.type.value
         if mode is CameraFilterType.REFLECTION:
             return None
         elif mode is CameraFilterType.FLUORESCENCE:
@@ -594,10 +607,11 @@ class ThermoFisherFilterSet(FilterSet):
             value: None for reflection mode, any non-None value for
                    fluorescence mode
         """
-        if value is None:
-            self.parent.fm_settings.filter.type.value = CameraFilterType.REFLECTION
-        else:
-            self.parent.fm_settings.filter.type.value = CameraFilterType.FLUORESCENCE
+        with self.parent.active_channel():
+            if value is None:
+                self.parent.fm_settings.filter.type.value = CameraFilterType.REFLECTION
+            else:
+                self.parent.fm_settings.filter.type.value = CameraFilterType.FLUORESCENCE
 
 
 class ThermoFisherFluorescenceMicroscope(FluorescenceMicroscope):
@@ -645,15 +659,72 @@ class ThermoFisherFluorescenceMicroscope(FluorescenceMicroscope):
 
         self._active_view = 3  # default active view for FLM (Arctis)
         self._active_device = ImagingDevice.FLUORESCENCE_LIGHT_MICROSCOPE
+        # Serialises `active_channel`. The parent's lock when there is one -- the live
+        # stream already takes it, so FM channel scopes and beam operations queue
+        # against each other rather than interleaving. `parent` is optional, and a
+        # parentless FM still needs a lock of its own to be internally consistent.
+        self._channel_lock = (
+            getattr(parent, "_threading_lock", None) or threading.RLock()
+        )
+        # How many scopes are open. Only the outermost captures and restores, so an
+        # acquisition inside a run does not put the view back mid-run.
+        self._channel_depth = 0
+        self._restore_view: Optional[int] = None
 
     def set_active_channel(self):
         """Set the active imaging channel for the fluorescence microscope.
 
         Configures the microscope to use the fluorescence light microscope
         device and the appropriate view for FLM operations.
+
+        Leaves the connection pointed at the FM. For anything that should hand it back
+        -- which is everything except an acquisition that owns it for its duration --
+        use :meth:`active_channel` instead.
         """
         self.connection.imaging.set_active_view(self._active_view)
         self.connection.imaging.set_active_device(self._active_device)
+
+    @contextmanager
+    def active_channel(self):
+        """Point the shared connection at the FM for the length of the block, then put
+        it back where it was.
+
+        The FM and the beams are one connection with one active view and one active
+        device, so whoever sets it last owns it. A property getter that sets it and
+        walks away steals the microscope from whatever else is using it -- which is what
+        `objective.state` did to a running workflow task: the stage is polled constantly,
+        every poll read the objective for the overview tab's info bar, and each read left
+        the connection on the FM. A beam acquisition that had set its own channel then
+        found the FM there instead (FIB-517).
+
+        The view is what is captured and put back, and that is sufficient: AutoScript
+        documents `set_active_device` as changing the device *in the active view*, so the
+        device belongs to the view and comes back with it.
+
+        The lock covers the bookkeeping only, and deliberately **not** the body. A scope
+        can span a whole tileset, and this is `FibsemMicroscope._threading_lock` -- a
+        class attribute every caller in the process shares. Holding it for minutes would
+        block all of them, and while the callers today are ones that should not overlap
+        an FM run anyway, a shared lock held that long makes a hostage of whoever takes
+        it next.
+
+        A depth count rather than a captured local, so the view is put back once, by the
+        outermost scope. A tileset holds the channel for the whole run; each tile's
+        acquisition opens a scope inside it and must not restore the beam view between
+        tiles.
+        """
+        with self._channel_lock:
+            if self._channel_depth == 0:
+                self._restore_view = self.connection.imaging.get_active_view()
+            self._channel_depth += 1
+            self.set_active_channel()
+        try:
+            yield
+        finally:
+            with self._channel_lock:
+                self._channel_depth -= 1
+                if self._channel_depth == 0:
+                    self.connection.imaging.set_active_view(self._restore_view)
 
     @property
     def fm_settings(self) -> "CameraSettings":

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import threading
 from abc import ABC
+from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Optional, Tuple, Union, Literal
@@ -755,6 +756,22 @@ class FluorescenceMicroscope(ABC):
         self._acquiring_reason = reason if acquiring else ""
         self.acquiring_changed.emit(self.is_acquiring)
 
+    @contextmanager
+    def active_channel(self):
+        """Hold the microscope's imaging channel on the FM for the length of the block.
+
+        A no-op here, and on any system where the FM has a connection of its own. On a
+        TFS system the FM and the beams share one -- one active view, one active device,
+        last writer wins -- so the driver overrides this to point it at the FM and put it
+        back afterwards (FIB-517).
+
+        Wrap whole operations rather than individual reads. Each frame of a tileset
+        taking and returning the channel would flick the microscope's own UI between
+        views per tile; the run takes it once instead. Nesting is safe, so an inner
+        acquisition inside an outer run costs nothing.
+        """
+        yield
+
     def set_channel(self, channel_settings: ChannelSettings):
         """Configure the microscope for a specific fluorescence channel.
 
@@ -970,11 +987,11 @@ class FluorescenceMicroscope(ABC):
         Returns:
             A FluorescenceImage object containing the image data and metadata
         """
-        if channel_settings is not None:
-            self.set_channel(channel_settings)
-        data = self.camera.acquire_image()
-        img = self._construct_image(data)
-        return img
+        with self.active_channel():
+            if channel_settings is not None:
+                self.set_channel(channel_settings)
+            data = self.camera.acquire_image()
+        return self._construct_image(data)
 
     def _construct_image(
         self, data: np.ndarray, frame_metadata: Optional[dict] = None

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -991,7 +991,13 @@ class FluorescenceMicroscope(ABC):
             if channel_settings is not None:
                 self.set_channel(channel_settings)
             data = self.camera.acquire_image()
-        return self._construct_image(data)
+            # Inside the scope, not after it. `_construct_image` looks like formatting
+            # but calls `get_metadata`, which reads 14 device properties that each take
+            # the channel themselves -- outside, that is 56 round trips and 28 changes
+            # of the microscope's active view per image, and the metadata would then
+            # describe the state *after* the channel had been handed back rather than
+            # the one the frame was taken under.
+            return self._construct_image(data)
 
     def _construct_image(
         self, data: np.ndarray, frame_metadata: Optional[dict] = None

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -183,6 +183,9 @@ class FMOverviewWidget(QWidget):
         # agrees by construction instead of because two callers happened to poll
         # together. See `_current_stage_position` for why polling is the odd one out.
         self._stage_position: Optional[FibsemStagePosition] = None
+        # The objective half of the canvas info bar, cached. Read from hardware only
+        # when something may have moved it -- see `_refresh_objective_info`.
+        self._objective_info: Optional[str] = None
         # Where the next overview will be centred, once a user has dragged the grid
         # somewhere. None means "wherever the stage is", which is what the runner does
         # by default -- so an untouched grid describes exactly what would be acquired.
@@ -219,6 +222,7 @@ class FMOverviewWidget(QWidget):
         self._fm_acquiring_changed.connect(self._on_fm_acquiring_changed)
         self.fm.acquiring_changed.connect(self._on_fm_acquiring_signal)
         self._refresh_current_position()
+        self._refresh_objective_info()
         self._refresh_orientation_banner()
 
     def _default_channels(self) -> List[ChannelSettings]:
@@ -1028,16 +1032,32 @@ class FMOverviewWidget(QWidget):
             return
 
         parts = [position.pretty]
+        if self._objective_info is not None:
+            parts.append(self._objective_info)
 
+        self.canvas.canvas.set_info_text("   |   ".join(parts))
+
+    def _refresh_objective_info(self) -> None:
+        """Re-read the objective for the info bar. Touches hardware -- call sparingly.
+
+        This used to happen inside `_refresh_stage_info`, which runs on every stage poll.
+        On a real system that is not a cheap read: the FM and the beams share one
+        connection, so reading the objective points it at the FM, and every poll was
+        doing it. It stopped a workflow task (FIB-517).
+
+        The driver now hands the connection back, so this is no longer dangerous -- but
+        it is still a round-trip per poll for a number that only changes when something
+        moves the objective, which is why it is cached rather than re-read.
+        """
         try:
-            parts.append(
+            self._objective_info = (
                 f"objective {self.fm.objective.position * constants.SI_TO_MILLI:.3f} mm"
                 f" ({self.fm.objective.state.lower()})"
             )
         except Exception as e:
             logging.debug(f"No objective position for the info bar: {e}")
-
-        self.canvas.canvas.set_info_text("   |   ".join(parts))
+            self._objective_info = None
+        self._refresh_stage_info()
 
     def _current_stage_position(self) -> Optional[FibsemStagePosition]:
         """Where the stage is, polling the microscope only when nothing has said yet.
@@ -1236,6 +1256,11 @@ class FMOverviewWidget(QWidget):
         reason to re-derive.
         """
         self._apply_enabled_state()
+        # Something that just finished may have moved the objective -- a z-stack and an
+        # autofocus sweep both do. One read when it stops, rather than one per stage poll
+        # while it runs.
+        if not acquiring:
+            self._refresh_objective_info()
 
     # ── canvas interaction ───────────────────────────────────────────────
 

--- a/tests/fm/test_active_channel.py
+++ b/tests/fm/test_active_channel.py
@@ -210,6 +210,70 @@ class TestTheContract:
         assert fm.connection.imaging.view == _FM.FM_VIEW
 
 
+class TestEveryMetadataReadIsInsideTheScope:
+    """`acquire_image` must cover `_construct_image` too, not just the exposure.
+
+    `_construct_image` reads like formatting, but it calls `get_metadata`, which reads
+    the exposure, gain, binning, power, emission wavelength and objective position back
+    off the device. On the TFS driver each of those takes the shared channel on its own
+    account. Left outside the scope they are 14 separate capture-set-restore cycles per
+    image -- 56 round trips, and the microscope's active view changing 28 times -- and
+    the metadata would describe the state after the channel went back rather than the
+    state the frame was taken under.
+
+    Behavioural rather than structural: `fibsem.fm.microscope` imports without the SDK,
+    so the real `acquire_image` can be run against the demo FM and asked what it did.
+    """
+
+    @staticmethod
+    def _watch(fm, monkeypatch) -> list:
+        """Record the scope depth at each device read. Returns the log."""
+        from contextlib import contextmanager
+
+        depth = [0]
+        reads: list = []
+
+        @contextmanager
+        def counting_scope():
+            depth[0] += 1
+            try:
+                yield
+            finally:
+                depth[0] -= 1
+
+        monkeypatch.setattr(fm, "active_channel", counting_scope)
+
+        # binning stands in for the whole set: `get_metadata` reaches it more than any
+        # other, directly and through pixel_size and resolution.
+        camera = type(fm.camera)
+        original = camera.binning
+
+        def fget(self):
+            reads.append(depth[0])
+            return original.fget(self)
+
+        monkeypatch.setattr(camera, "binning", property(fget, original.fset))
+        return reads
+
+    @pytest.fixture
+    def fm(self):
+        from fibsem import utils
+
+        microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+        return microscope.fm
+
+    def test_the_metadata_is_read_with_the_channel_still_held(self, fm, monkeypatch):
+        reads = self._watch(fm, monkeypatch)
+
+        fm.acquire_image()
+
+        assert reads, "no device read was observed -- the probe missed"
+        assert all(d > 0 for d in reads), (
+            f"{sum(1 for d in reads if d == 0)} of {len(reads)} device reads happened "
+            f"outside the channel scope"
+        )
+
+
 class TestTheRealDriverMatches:
     """Structural, since the SDK import cannot be satisfied here.
 

--- a/tests/fm/test_active_channel.py
+++ b/tests/fm/test_active_channel.py
@@ -69,8 +69,8 @@ class _FM:
         with self._channel_lock:
             if self._channel_depth == 0:
                 self._restore_view = self.connection.imaging.get_active_view()
-            self._channel_depth += 1
             self.set_active_channel()
+            self._channel_depth += 1
         try:
             yield
         finally:
@@ -151,6 +151,54 @@ class TestTheContract:
             other.join(timeout=2)
 
         assert acquired.is_set(), "another thread could not take the lock mid-scope"
+
+    def test_a_failed_entry_does_not_poison_every_later_scope(self):
+        """Entering is two RPCs, and a dropped connection can fail the second.
+
+        That raises out of `__enter__`, so the caller's block never runs and the
+        `finally` never runs either. Counting the scope before the channel was actually
+        taken left the depth permanently too high -- every later scope then looked
+        nested, nothing ever restored the view again, and FIB-517 was back for the rest
+        of the session with nothing on screen to say so.
+        """
+        fm = _FM(view=1)
+
+        def connection_reset(device):
+            raise RuntimeError("connection reset")
+
+        fm.connection.imaging.set_active_device = connection_reset
+        with pytest.raises(RuntimeError):
+            with fm.active_channel():
+                pass
+
+        assert fm._channel_depth == 0, "a failed entry left a scope counted as open"
+
+        # And the next healthy scope still hands the view back.
+        fm.connection.imaging.set_active_device = lambda device: None
+        fm.connection.imaging.view = 1
+        with fm.active_channel():
+            pass
+
+        assert fm.connection.imaging.view == 1
+
+    def test_an_inner_scope_that_fails_leaves_the_outer_one_intact(self):
+        """The same failure one level down must not decrement the run's own scope: a
+        tileset still owns the channel, and its restore is still the outermost one."""
+        fm = _FM(view=1)
+
+        with fm.active_channel():
+            fm.connection.imaging.set_active_device = self._raises
+            with pytest.raises(RuntimeError):
+                with fm.active_channel():
+                    pass
+            assert fm._channel_depth == 1
+            fm.connection.imaging.set_active_device = lambda device: None
+
+        assert fm.connection.imaging.view == 1
+
+    @staticmethod
+    def _raises(device):
+        raise RuntimeError("connection reset")
 
     def test_set_active_channel_alone_does_not_restore(self):
         """The unscoped call still exists, for the live stream that owns the channel for
@@ -250,6 +298,43 @@ class TestTheRealDriverMatches:
             for block in locked
             for inner in ast.walk(block)
         ), "the lock is held across the body"
+
+    def test_the_scope_is_counted_only_after_the_channel_is_taken(self):
+        """Order matters, and only in one direction.
+
+        Entering is two RPCs. If the depth is incremented first and the second RPC then
+        fails, the exception comes out of `__enter__`, no `finally` ever runs, and the
+        count stays high forever -- after which every scope looks nested and nothing
+        restores the view again. Incrementing last costs nothing and cannot strand it.
+        """
+        import ast
+
+        node = self._functions(self._source())["active_channel"]
+        entry = next(
+            child
+            for child in ast.walk(node)
+            if isinstance(child, ast.With) and "set_active_channel" in ast.dump(child)
+        )
+
+        def index_of(predicate) -> int:
+            return next(i for i, stmt in enumerate(entry.body) if predicate(stmt))
+
+        took_it = index_of(
+            lambda stmt: any(
+                isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Attribute)
+                and n.func.attr == "set_active_channel"
+                for n in ast.walk(stmt)
+            )
+        )
+        counted_it = index_of(
+            lambda stmt: isinstance(stmt, ast.AugAssign)
+            and "_channel_depth" in ast.dump(stmt.target)
+        )
+        assert took_it < counted_it, (
+            "the scope is counted before the channel is taken, so a connection that "
+            "drops mid-entry leaves the depth permanently too high"
+        )
 
     def test_the_objective_state_getter_is_scoped(self):
         """The one that stopped a workflow task, named so a regression is legible."""

--- a/tests/fm/test_active_channel.py
+++ b/tests/fm/test_active_channel.py
@@ -1,0 +1,263 @@
+"""The FM and the beams share one connection, so an FM read must hand it back (FIB-517).
+
+`ThermoFisherFluorescenceMicroscope.set_active_channel()` points the shared connection at
+the FM. A property getter that called it and walked away left the microscope there --
+and since the FM overview's info bar read the objective on every stage poll, a beam
+acquisition that had set its own channel found the FM instead. It stopped a workflow task.
+
+`autoscript.py` cannot be imported without the AutoScript SDK, which is not installed off
+the microscope, so the context manager is exercised against a stub connection through a
+stub of the class rather than the real import. What is under test is the contract --
+capture, set, restore, restore-on-failure -- not the SDK.
+"""
+from contextlib import contextmanager
+
+import pytest
+
+
+class _Imaging:
+    """The half of the connection that owns the active view."""
+
+    def __init__(self, view: int = 1):
+        self.view = view
+        self.history: list = []
+
+    def get_active_view(self) -> int:
+        return self.view
+
+    def set_active_view(self, view: int) -> None:
+        self.view = view
+        self.history.append(("view", view))
+
+    def set_active_device(self, device) -> None:
+        self.history.append(("device", device))
+
+
+class _Connection:
+    def __init__(self, view: int = 1):
+        self.imaging = _Imaging(view)
+
+
+class _FM:
+    """`ThermoFisherFluorescenceMicroscope`'s channel handling, without the SDK import.
+
+    Copied rather than imported: `fibsem/fm/autoscript.py` imports
+    `autoscript_sdb_microscope_client` at module scope, which is absent off the
+    microscope. The structural test below pins this against the real source so the two
+    cannot drift.
+    """
+
+    FM_VIEW = 3
+    FM_DEVICE = "FLM"
+
+    def __init__(self, view: int = 1):
+        import threading
+
+        self.connection = _Connection(view)
+        self._active_view = self.FM_VIEW
+        self._active_device = self.FM_DEVICE
+        self._channel_lock = threading.RLock()
+        self._channel_depth = 0
+        self._restore_view = None
+
+    def set_active_channel(self):
+        self.connection.imaging.set_active_view(self._active_view)
+        self.connection.imaging.set_active_device(self._active_device)
+
+    @contextmanager
+    def active_channel(self):
+        with self._channel_lock:
+            if self._channel_depth == 0:
+                self._restore_view = self.connection.imaging.get_active_view()
+            self._channel_depth += 1
+            self.set_active_channel()
+        try:
+            yield
+        finally:
+            with self._channel_lock:
+                self._channel_depth -= 1
+                if self._channel_depth == 0:
+                    self.connection.imaging.set_active_view(self._restore_view)
+
+
+class TestTheContract:
+    def test_the_block_runs_on_the_fm(self, ):
+        fm = _FM(view=1)  # the beam side owns it
+
+        with fm.active_channel():
+            assert fm.connection.imaging.view == _FM.FM_VIEW
+
+    def test_it_hands_the_view_back(self):
+        """The whole point. Leaving it on the FM is what broke a running beam task."""
+        fm = _FM(view=1)
+
+        with fm.active_channel():
+            pass
+
+        assert fm.connection.imaging.view == 1
+
+    def test_it_hands_it_back_when_the_read_fails(self):
+        """A getter that raises must not leave the microscope pointed elsewhere -- an
+        FM that is off, or answering slowly, would otherwise strand the beam side."""
+        fm = _FM(view=1)
+
+        with pytest.raises(RuntimeError):
+            with fm.active_channel():
+                raise RuntimeError("detector did not answer")
+
+        assert fm.connection.imaging.view == 1
+
+    def test_it_restores_whatever_was_there(self):
+        """Not a hardcoded beam view: it puts back what it found."""
+        for view in (0, 1, 2, 7):
+            fm = _FM(view=view)
+            with fm.active_channel():
+                pass
+            assert fm.connection.imaging.view == view
+
+    def test_only_the_outermost_scope_restores(self):
+        """A tileset holds the channel for the whole run and each tile opens a scope
+        inside it. An inner scope that restored would put the beam view back between
+        every pair of tiles -- the flicker the run-level scope exists to avoid."""
+        fm = _FM(view=1)
+
+        with fm.active_channel():
+            with fm.active_channel():
+                assert fm.connection.imaging.view == _FM.FM_VIEW
+            assert fm.connection.imaging.view == _FM.FM_VIEW, "inner scope restored"
+
+        assert fm.connection.imaging.view == 1
+
+    def test_the_lock_is_not_held_across_the_body(self):
+        """The scope can span a whole tileset, and the lock it takes is
+        `FibsemMicroscope._threading_lock` -- a class attribute, shared by every caller
+        in the process. Holding it for minutes would block them all; the known ones are
+        a Pause/Resume click and the milling monitor loop, neither of which should
+        overlap an FM run, but the point is that a shared lock held that long makes any
+        future caller a hostage.
+        """
+        import threading
+
+        fm = _FM(view=1)
+        acquired = threading.Event()
+
+        def take_the_lock():
+            with fm._channel_lock:
+                acquired.set()
+
+        with fm.active_channel():
+            other = threading.Thread(target=take_the_lock)
+            other.start()
+            other.join(timeout=2)
+
+        assert acquired.is_set(), "another thread could not take the lock mid-scope"
+
+    def test_set_active_channel_alone_does_not_restore(self):
+        """The unscoped call still exists, for the live stream that owns the channel for
+        its duration. This is what every other caller must not use."""
+        fm = _FM(view=1)
+
+        fm.set_active_channel()
+
+        assert fm.connection.imaging.view == _FM.FM_VIEW
+
+
+class TestTheRealDriverMatches:
+    """Structural, since the SDK import cannot be satisfied here.
+
+    Pins that every place in the driver that needs the FM channel goes through the
+    scoped form -- with the live stream, which owns it deliberately, as the exception.
+    """
+
+    @staticmethod
+    def _source() -> str:
+        from pathlib import Path
+
+        import fibsem.fm as fm_package
+
+        return (Path(fm_package.__file__).parent / "autoscript.py").read_text()
+
+    @staticmethod
+    def _functions(source: str):
+        import ast
+
+        return {
+            node.name: node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.FunctionDef)
+        }
+
+    def test_the_context_manager_captures_and_restores_the_view(self):
+        import ast
+
+        node = self._functions(self._source())["active_channel"]
+        body = ast.dump(node)
+        assert "get_active_view" in body, "does not capture the view"
+        assert "set_active_view" in body, "does not restore the view"
+        assert any(isinstance(n, ast.Try) and n.finalbody for n in ast.walk(node)), (
+            "restores outside a finally, so a failing read strands the connection"
+        )
+
+    def test_only_the_live_stream_sets_the_channel_unscoped(self):
+        """Everything discrete hands the connection back. `_start_fast_acquisition`,
+        `start_acquisition` and `stop_acquisition` are the live stream, which holds it
+        for as long as it runs and re-forces it per frame."""
+        import ast
+
+        source = self._source()
+        allowed = {
+            "set_active_channel",  # the primitive itself
+            "active_channel",  # the scoped form, which calls it
+            "fm_settings",  # every caller of this is inside a scope
+            "_start_fast_acquisition",
+            "start_acquisition",
+            "stop_acquisition",
+            # every path here comes through `FluorescenceMicroscope.acquire_image`,
+            # which scopes, and a tileset scopes the whole run
+            "acquire_image",
+        }
+        offenders = sorted(
+            name
+            for name, node in self._functions(source).items()
+            if name not in allowed
+            and "set_active_channel"
+            in {
+                child.func.attr
+                for child in ast.walk(node)
+                if isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Attribute)
+            }
+        )
+        assert offenders == [], (
+            f"these take the shared channel without handing it back: {offenders}"
+        )
+
+    def test_the_bookkeeping_is_locked_but_the_body_is_not(self):
+        """Both halves matter. Unlocked, two scopes interleave and leave the view on the
+        FM. Locked across the body, a run-length scope holds a process-wide lock for
+        minutes and blocks everything else that takes it."""
+        import ast
+
+        node = self._functions(self._source())["active_channel"]
+        locked = [
+            child
+            for child in ast.walk(node)
+            if isinstance(child, ast.With) and "channel_lock" in ast.dump(child)
+        ]
+        assert locked, "the bookkeeping is not locked"
+        assert not any(
+            isinstance(inner, ast.Expr) and isinstance(inner.value, ast.Yield)
+            for block in locked
+            for inner in ast.walk(block)
+        ), "the lock is held across the body"
+
+    def test_the_objective_state_getter_is_scoped(self):
+        """The one that stopped a workflow task, named so a regression is legible."""
+        import ast
+
+        node = self._functions(self._source())["state"]
+        assert any(
+            isinstance(child, ast.With)
+            and "active_channel" in ast.dump(child.items[0].context_expr)
+            for child in ast.walk(node)
+        )

--- a/tests/ui/test_fm_overview_orientation.py
+++ b/tests/ui/test_fm_overview_orientation.py
@@ -351,3 +351,60 @@ class TestTheMoveAction:
         widget.move_to_fm_orientation()
 
         assert no_worker == []
+
+
+class TestTheInfoBarDoesNotPollHardware:
+    """A stage poll must not read the objective (FIB-517).
+
+    The canvas info bar shows the objective position, and it used to read it inside
+    `_refresh_stage_info` — which runs on every `stage_position_changed`. On a real
+    system the FM and the beams share one connection, so each of those reads pointed it
+    at the FM, and a beam acquisition mid-workflow found the FM there instead. The
+    driver hands the connection back now, but a round-trip per poll for a number that
+    only changes when something moves the objective is still the wrong shape.
+    """
+
+    @staticmethod
+    def _count_objective_reads(widget, monkeypatch) -> list:
+        """Replace the objective with one that records every attribute read.
+
+        Through `monkeypatch` so it is put back: the microscope outlives the widget, so
+        a spy left in place leaks into whatever runs next.
+        """
+        reads = []
+        real = widget.fm.objective
+
+        class _Spy:
+            def __getattr__(self, name):
+                reads.append(name)
+                return getattr(real, name)
+
+        monkeypatch.setattr(widget.fm, "objective", _Spy())
+        return reads
+
+    def test_a_stage_poll_reads_nothing(self, widget, qapp, monkeypatch):
+        reads = self._count_objective_reads(widget, monkeypatch)
+
+        widget._on_stage_moved(widget.microscope.get_stage_position())
+        qapp.processEvents()
+
+        assert reads == [], f"stage poll touched the objective: {reads}"
+
+    def test_the_info_bar_still_says_the_objective(self, widget, qapp):
+        """Cached, not dropped — the number is still there, it is just not re-read."""
+        widget._refresh_objective_info()
+        qapp.processEvents()
+
+        assert "objective" in widget.canvas.canvas._info_text
+
+    def test_a_finished_acquisition_rereads_it(self, widget, qapp, monkeypatch):
+        """A z-stack and an autofocus sweep both move the objective, so the cache has to
+        be refreshed when one ends — one read, rather than one per poll while it runs."""
+        widget.fm.set_acquiring(True, "z-stack")
+        qapp.processEvents()
+        reads = self._count_objective_reads(widget, monkeypatch)
+
+        widget.fm.set_acquiring(False)
+        qapp.processEvents()
+
+        assert "position" in reads, f"did not re-read the objective: {reads}"

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -2262,7 +2262,10 @@ def test_an_unreadable_objective_does_not_cost_the_stage_position(qapp, interact
     original = widget.fm.objective
     widget.fm.objective = _Broken()
     try:
-        widget._refresh_stage_info()
+        # `_refresh_objective_info`, not `_refresh_stage_info`: the hardware read moved
+        # there when it stopped happening on every stage poll (FIB-517). This is still
+        # the same question -- a field that cannot be read is dropped, not the line.
+        widget._refresh_objective_info()
         info = widget.canvas.canvas._info_text
     finally:
         widget.fm.objective = original


### PR DESCRIPTION
Closes FIB-517. Found on hardware yesterday: a workflow task failed because the active imaging channel switched to the FM underneath it.

## What was happening

On a TFS system the FM and the beams are **one connection with one active view and one active device**, and whoever sets it last owns the microscope. AutoScript documents `set_active_device` as changing the device *in the active view*, so the view owns the device, and `get_image` as returning "the image buffer of **the active view**".

```
FMOverviewWidget._refresh_stage_info        every stage_position_changed
  -> fm.objective.state
    -> ThermoFisherObjectiveLens.state       autoscript.py:201
      -> self.parent.set_active_channel()    autoscript.py:649
        -> imaging.set_active_view(FM) + set_active_device(FLM)   ← never restored
```

The stage is polled constantly, so this fired whether or not the FM Overview tab was visible. A beam operation that had set its own channel and was about to acquire found the FM there instead.

`objective.position` already handled this by hand — capture the view, read, restore — so the hazard was known and fixed in exactly one getter out of a dozen.

## The fix

`active_channel()` on the driver: capture the view, point the connection at the FM, put the view back. Every property getter and setter goes through it.

**Two deliberate exceptions**, both marked in the source and pinned by an allow-list test:

- the **live stream** owns the channel for as long as it runs and re-forces it per frame — that's what a live view *is*
- **`grab_frame`**, because its callers hold the channel around the whole operation instead

**Scoped by operation, not by read.** `set_active_view` changes the view in the microscope's own UI, so taking and returning it per frame would flick the display between views once per tile — 75 times in a 25-tile, 3-channel run. So:

| scope | holds the channel for |
|---|---|
| `FluorescenceMicroscope.acquire_image` | one acquisition — the chokepoint every FM image passes through, so nothing leaks |
| `FMTiledAcquisitionRunner.run` | the whole run — no per-tile flicker |

A no-op `active_channel()` on the base class keeps everything above the driver mount-agnostic and working on the simulator.

**The lock covers the bookkeeping, not the body.** A run-length scope holding `FibsemMicroscope._threading_lock` — a class attribute every caller in the process shares — would block all of them for minutes. A depth count replaces a captured local so only the outermost scope restores; without it, each tile's acquisition would put the beam view back between tiles and reintroduce the flicker the run-level scope exists to prevent.

## Two things that turned up on the way

`magnification`'s getter **and** setter called `set_active_channel()` to read and write a cached Python attribute — pure side effect, no hardware involved. Deleted rather than scoped.

Several properties (exposure, binning, filter mode) never called it directly but went through `fm_settings`, which sets the channel for every caller. Same leak, less visibly.

## Widget side

The overview's info bar caches the objective and re-reads it when an acquisition finishes, instead of on every stage poll. The driver hands the connection back now so this is no longer dangerous — but a round-trip per poll for a number that only changes when something moves the objective is still the wrong shape.

## Testing

`autoscript.py` can't be imported without the SDK, so the contract is exercised against a stub connection, and pinned to the real source structurally:

- an **allow-list** of the functions permitted to take the channel unscoped, so a new getter that forgets fails by name
- the restore being inside a `finally`
- the lock covering the bookkeeping but **not** the body

Five mutations checked, all caught: `objective.state` reverting, the context manager not restoring, the info bar polling again, the lock held across the body, and an inner scope capturing. 1478 pass across `tests/ui`, `tests/fm` and `tests/test_microscope.py`.

## Not verified off the microscope

That restoring the **view alone** routes subsequent reads back to the beam (the docs say the device belongs to the view, and `objective.position` already assumed this), and that a tileset no longer flicks the microscope UI between views. Both are one session's observation.
