### PR TITLE
[fm] Follow the microscope across a reconnect in the fluorescence channel editor (FIB-525)

### DIFF
--- a/fibsem/applications/autolamella/ui/autolamella_fluorescence_acquisition_task_config_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_fluorescence_acquisition_task_config_widget.py
@@ -84,6 +84,22 @@ class AutoLamellaFluorescenceAcquisitionTaskConfigWidget(QWidget):
 
         self.setLayout(layout)
 
+    def set_microscope(self, microscope: 'FibsemMicroscope') -> None:
+        """Point this widget at a different microscope after a reconnect.
+
+        The editors that own this widget are built once and survive
+        disconnect/reconnect, so without this the widget keeps the microscope it
+        was constructed with -- and its channel editor keeps offering that
+        microscope's excitation/emission filters. Connect to a non-FM system
+        first and it offers none at all, for the life of the process (FIB-525).
+
+        The captured ``fm`` matters as much as the microscope: it is a live
+        handle to hardware, not a value.
+        """
+        self.microscope = microscope
+        self.fm = microscope.fm
+        self.channelSettingsWidget.set_fm(microscope.fm)
+
     def get_task_config(self) -> AcquireFluorescenceImageConfig:
         self.config.orientation = self.orientation_combo.value()
         self.config.zparams = self.z_parameters_widget.z_parameters

--- a/fibsem/ui/fm/widgets/channel_list_widget.py
+++ b/fibsem/ui/fm/widgets/channel_list_widget.py
@@ -95,6 +95,15 @@ class _DraggableChannelList(QListWidget):
         super().__init__(parent)
         self._fm = fm
 
+    def set_fm(self, fm) -> None:
+        """Point at a different microscope (FIB-525).
+
+        Only used to suppress selection changes during live acquisition, but a
+        stale reference here means asking the *previous* microscope whether it is
+        streaming.
+        """
+        self._fm = fm
+
     def resizeEvent(self, event) -> None:
         """Keep row widths pinned to the viewport as it changes.
 
@@ -682,6 +691,26 @@ class ChannelListWidget(QWidget):
     @property
     def channel_settings(self) -> List[ChannelSettings]:
         return [self._row(i).channel for i in range(self._list.count())]
+
+    def set_fm(self, fm) -> None:
+        """Point this list at a different fluorescence microscope.
+
+        The excitation/emission choices are read from the microscope once, at
+        construction, and handed to every row. On a reconnect that leaves each row
+        offering the previous microscope's filters -- or, if the first connection
+        had no FM at all, nothing (FIB-525).
+
+        Rebuilding the rows is how the new choices reach them: the rows take their
+        item lists as constructor arguments, and the channel objects themselves are
+        untouched, so the configured channels survive. Row selection and the
+        per-row enabled checkboxes do not, which is an acceptable cost for an event
+        as rare as swapping microscopes.
+        """
+        self.fm = fm
+        self._list.set_fm(fm)
+        self._emission_items = list(fm.filter_set.available_emission_wavelengths) if fm is not None else []
+        self._excitation_items = list(fm.filter_set.available_excitation_wavelengths) if fm is not None else []
+        self.channel_settings = list(self._channel_list)
 
     @channel_settings.setter
     def channel_settings(self, value: Union[ChannelSettings, List[ChannelSettings]]) -> None:

--- a/fibsem/ui/fm/widgets/channel_settings_widget.py
+++ b/fibsem/ui/fm/widgets/channel_settings_widget.py
@@ -141,6 +141,34 @@ class ChannelSettingsWidget(QWidget):
         self._panel.set_title(channel.name)
         self.refresh()
 
+    def set_fm(self, fm: Optional[FluorescenceMicroscope]) -> None:
+        """Point this widget at a different fluorescence microscope.
+
+        The available wavelengths are the microscope's, not the channel's, so they
+        have to be re-read when the microscope changes -- this widget keeps no
+        ``fm`` reference of its own, only the two lists derived from it, which is
+        why nothing looked stale from the outside while the combos were offering
+        a disconnected microscope's filters (FIB-525).
+
+        The selected value is preserved where the new microscope still offers it;
+        where it does not, ``set_values`` falls back to the closest match rather
+        than silently reporting a wavelength the hardware cannot produce.
+        """
+        self._emission_items = list(fm.filter_set.available_emission_wavelengths) if fm is not None else []
+        self._excitation_items = list(fm.filter_set.available_excitation_wavelengths) if fm is not None else []
+
+        blocked = self.blockSignals(True)
+        try:
+            self.excitation_combo.set_values(self._excitation_items)
+            self.emission_combo.set_values(self._emission_items)
+        finally:
+            self.blockSignals(blocked)
+
+        # Re-apply the channel so the controls show what it actually holds, not
+        # whatever survived repopulating the combos.
+        if self._channel is not None:
+            self.refresh()
+
     def refresh(self) -> None:
         """Re-sync controls from current channel without emitting signals."""
         if self._channel is None:

--- a/fibsem/ui/fm/widgets/fm_multi_channel_widget.py
+++ b/fibsem/ui/fm/widgets/fm_multi_channel_widget.py
@@ -163,6 +163,17 @@ class FluorescenceMultiChannelWidget(QWidget):
             self._selected_channel = None
             self._settings_widget.setVisible(False)
 
+    def set_fm(self, fm) -> None:
+        """Point this widget and both of its halves at a different microscope.
+
+        Both halves derive their wavelength choices from the microscope, and both
+        do it at construction, so both have to be told (FIB-525). The channel
+        objects are unaffected -- only the choices offered for them change.
+        """
+        self.fm = fm
+        self._list.set_fm(fm)
+        self._settings_widget.set_fm(fm)
+
     def set_live_acquisition_controls(self, enabled: bool) -> None:
         """Stub for ChannelSettingsWidget/ChannelListWidget compatibility."""
         pass

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -106,8 +106,25 @@ class AutoLamellaProtocolEditorWidget(QWidget):
             raise ValueError("Microscope in parent widget is None, cannot proceed.")
         self.microscope = self.parent_widget.microscope
         if hasattr(self, "milling_task_editor"):
-            # Reconnect: widget already initialized, just update microscope reference
+            # Reconnect: this editor is built once and survives disconnect, so every
+            # widget under it still holds the microscope it was built with, and each
+            # one has to be told. See FIB-525: updating only the milling editor left
+            # the fluorescence channel editor offering a disconnected microscope's
+            # filters -- or none at all, if the first connection had no FM.
+            #
+            # The milling subtree has the same fault and is deliberately not fixed
+            # here (FIB-530): the line below updates this widget but not the two
+            # children it handed the microscope to at construction.
             self.milling_task_editor.microscope = self.microscope
+            # Asked for by name rather than assumed present: the condition above
+            # tests one widget, but _create_widgets assigns it before the others and
+            # is not guarded, so a constructor raising midway leaves this branch
+            # reachable with the rest missing.
+            fluorescence_widget = getattr(
+                self, "fluorescence_acquisition_task_config_widget", None
+            )
+            if fluorescence_widget is not None:
+                fluorescence_widget.set_microscope(self.microscope)
         else:
             # First connect: build the full UI
             self._create_widgets()

--- a/fibsem/ui/widgets/autolamella_task_config_editor.py
+++ b/fibsem/ui/widgets/autolamella_task_config_editor.py
@@ -196,7 +196,25 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
             raise ValueError("Microscope is None, cannot open protocol editor.")
         self.microscope = self.parent_widget.microscope
         if self.milling_task_editor is not None:
+            # Reconnect: this editor is built once and survives disconnect, so every
+            # widget under it still holds the microscope it was built with, and each
+            # one has to be told. See FIB-525: updating only the milling editor left
+            # the fluorescence channel editor offering a disconnected microscope's
+            # filters -- or none at all, if the first connection had no FM.
+            #
+            # The milling subtree has the same fault and is deliberately not fixed
+            # here (FIB-530): the line below updates this widget but not the two
+            # children it handed the microscope to at construction.
             self.milling_task_editor.microscope = self.microscope
+            # Asked for by name rather than assumed present: the condition above
+            # tests one widget, but _create_widgets assigns it before the others and
+            # is not guarded, so a constructor raising midway leaves this branch
+            # reachable with the rest missing.
+            fluorescence_widget = getattr(
+                self, "fluorescence_acquisition_task_config_widget", None
+            )
+            if fluorescence_widget is not None:
+                fluorescence_widget.set_microscope(self.microscope)
         else:
             self._try_initialize()
 

--- a/tests/ui/test_editor_microscope_reconnect.py
+++ b/tests/ui/test_editor_microscope_reconnect.py
@@ -1,0 +1,305 @@
+"""The protocol editors' fluorescence editor must follow the microscope on reconnect.
+
+Both editors are built once and survive disconnect, unlike the main tabs, which
+`update_microscope_ui` destroys and rebuilds on every connect. So every widget
+under them keeps whatever microscope it was constructed with unless something
+tells it otherwise -- and reconnecting is exactly when that matters, because the
+new microscope may have a fluorescence detector where the previous one had none.
+
+Reported as FIB-525: connect to a non-FM system, disconnect, reconnect to an
+FM-enabled one, and the channel editor's excitation/emission dropdowns stay
+empty for the life of the process.
+
+Two kinds of staleness, needing different assertions:
+
+* a widget that **holds** the old microscope (or its `fm`) -- an identity walk
+  over the tree finds these, including in widgets added long after this file.
+* a widget holding only values **derived** from it. `ChannelSettingsWidget` keeps
+  the two wavelength lists and no `fm` at all, so an identity walk is blind to
+  it; those are asserted against what the new microscope reports.
+
+The fixture deliberately configures **real channels**. An earlier version of
+these tests used the config default, which is an empty channel list, so the row
+rebuild -- the mechanism that actually fixes the reported symptom -- was never
+exercised and the "channels survive" assertion compared two empty lists.
+"""
+
+import logging
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtWidgets import QWidget  # noqa: E402
+
+import fibsem.config as fconfig  # noqa: E402
+from fibsem import utils  # noqa: E402
+from fibsem.applications.autolamella.structures import (  # noqa: E402
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.applications.autolamella.workflows.tasks.acquire_fluorescence import (  # noqa: E402
+    AcquireFluorescenceImageConfig,
+)
+from fibsem.fm.structures import ChannelSettings  # noqa: E402
+from fibsem.ui.widgets.autolamella_lamella_protocol_editor import (  # noqa: E402
+    AutoLamellaProtocolEditorWidget,
+)
+from fibsem.ui.widgets.autolamella_task_config_editor import (  # noqa: E402
+    AutoLamellaProtocolTaskConfigEditor,
+)
+
+EDITORS = [AutoLamellaProtocolTaskConfigEditor, AutoLamellaProtocolEditorWidget]
+EDITOR_IDS = ["task_config_editor", "lamella_protocol_editor"]
+
+# Resolved from the package, not the cwd: the suite's _isolate_cwd fixture chdirs
+# each test into a tmp_path, so a relative path finds nothing.
+SIM_ARCTIS = os.path.join(fconfig.CONFIG_PATH, "sim-arctis-configuration.yaml")
+
+
+def _channels():
+    return [
+        ChannelSettings(
+            name="Reflection",
+            excitation_wavelength=550,
+            emission_wavelength=None,
+            power=0.02,
+            exposure_time=0.005,
+        ),
+        ChannelSettings(
+            name="Red",
+            excitation_wavelength=550,
+            emission_wavelength="FLUORESCENCE",
+            power=0.3,
+            exposure_time=0.1,
+            color="red",
+        ),
+    ]
+
+
+def _microscope_without_fm():
+    """A system with no fluorescence detector, as in the reported sequence."""
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    microscope.fm = None
+    return microscope
+
+
+def _microscope_with_fm():
+    microscope, _ = utils.setup_session(
+        manufacturer="Demo", ip_address="localhost", config_path=SIM_ARCTIS
+    )
+    assert microscope.fm is not None, "the arctis sim is the FM-capable fixture"
+    return microscope
+
+
+def _experiment():
+    experiment = Experiment(path=pathlib.Path(tempfile.mkdtemp()), name="reconnect")
+    experiment.task_protocol = AutoLamellaTaskProtocol()
+    experiment.task_protocol.task_config = {
+        "Acquire Fluorescence Image": AcquireFluorescenceImageConfig(
+            task_name="Acquire Fluorescence Image", channel_settings=_channels()
+        )
+    }
+    return experiment
+
+
+def _build(editor_cls, microscope):
+    """An editor on *microscope*, plus the host it reads the microscope from."""
+    host = QWidget()
+    host.experiment, host.microscope = _experiment(), microscope
+    editor = editor_cls(parent=host)
+    editor._host = host  # keep the parent alive for the test's duration
+    return editor, host
+
+
+def _reconnect(editor, host, microscope):
+    host.microscope = microscope
+    editor._on_microscope_connected()
+
+
+def _channel_list(editor):
+    return editor.fluorescence_acquisition_task_config_widget.channelSettingsWidget
+
+
+def _references_to(editor, *targets):
+    """Every `Widget.attribute` in the tree holding one of *targets*."""
+    found = set()
+    for widget in [editor] + editor.findChildren(QWidget):
+        for attr, value in list(vars(widget).items()):
+            if any(value is target for target in targets if target is not None):
+                found.add(f"{type(widget).__name__}.{attr}")
+    return found
+
+
+@pytest.fixture(autouse=True)
+def _quiet():
+    logging.disable(logging.CRITICAL)
+    yield
+    logging.disable(logging.NOTSET)
+
+
+@pytest.mark.parametrize("editor_cls", EDITORS, ids=EDITOR_IDS)
+def test_the_fluorescence_subtree_keeps_no_reference_to_the_old_microscope(
+    qapp, editor_cls
+):
+    """Nothing under the fluorescence widget still points at the old microscope.
+
+    Deliberately not a list of widget names: the bug being fixed was an incomplete
+    list -- the reconnect handler updated one widget and the rest were found only
+    by walking the tree. A future widget capturing an `fm` fails here without
+    anyone remembering to add it.
+
+    Scoped to the fluorescence subtree because the milling subtree has the same
+    fault and is fixed separately (FIB-530); widening this to the whole editor is
+    part of that change.
+    """
+    old = _microscope_without_fm()
+    editor, host = _build(editor_cls, old)
+    fluorescence = editor.fluorescence_acquisition_task_config_widget
+
+    new = _microscope_with_fm()
+    _reconnect(editor, host, new)
+
+    assert _references_to(fluorescence, old, old.fm) == set()
+    # ...and it really does hold the new one, so the assertion above is not passing
+    # merely because every reference was dropped.
+    assert _references_to(fluorescence, new, new.fm)
+
+
+@pytest.mark.parametrize("editor_cls", EDITORS, ids=EDITOR_IDS)
+def test_channel_editor_offers_the_new_microscope_filters(qapp, editor_cls):
+    """The reported symptom: empty dropdowns after reconnecting to an FM system.
+
+    Asserted on the derived lists as well as the widgets, because the widget
+    holding them keeps no `fm` -- the identity walk above cannot see it.
+    """
+    old = _microscope_without_fm()
+    editor, host = _build(editor_cls, old)
+    channels = _channel_list(editor)
+    detail = channels._settings_widget
+
+    assert detail.excitation_combo.count() == 0, "no FM, so nothing to offer"
+
+    new = _microscope_with_fm()
+    _reconnect(editor, host, new)
+
+    expected = list(new.fm.filter_set.available_excitation_wavelengths)
+    assert expected, "the fixture must offer some excitation wavelengths"
+    assert [
+        detail.excitation_combo.itemData(i) for i in range(detail.excitation_combo.count())
+    ] == expected
+    assert channels._list._excitation_items == expected
+    assert channels._list._emission_items == list(
+        new.fm.filter_set.available_emission_wavelengths
+    )
+
+
+# --- widget-level: the row rebuild itself ------------------------------------
+# Tested on the widget directly rather than through an editor, because the two
+# editors populate it at different times: the task-config editor passes the
+# selected task's config in, while the lamella editor constructs it with
+# `config=None` and fills it when a lamella/task is chosen. Driving each editor's
+# population lifecycle would test that lifecycle, not the rebuild.
+
+
+def _fluorescence_widget(microscope):
+    from fibsem.applications.autolamella.ui.autolamella_fluorescence_acquisition_task_config_widget import (
+        AutoLamellaFluorescenceAcquisitionTaskConfigWidget,
+    )
+
+    config = AcquireFluorescenceImageConfig(
+        task_name="Acquire Fluorescence Image", channel_settings=_channels()
+    )
+    widget = AutoLamellaFluorescenceAcquisitionTaskConfigWidget(
+        microscope=microscope, config=config
+    )
+    assert widget.channelSettingsWidget._list._list.count() == len(_channels())
+    return widget
+
+
+def test_every_channel_row_offers_the_new_filters(qapp):
+    """Each row's own combos, not just the detail pane and the cached lists.
+
+    The rows take their choices as constructor arguments, so they are rebuilt
+    rather than updated -- and with the empty-channel fixture this file used to
+    have, that rebuild ran over zero rows and proved nothing.
+    """
+    widget = _fluorescence_widget(_microscope_without_fm())
+    rows = widget.channelSettingsWidget._list
+
+    new = _microscope_with_fm()
+    widget.set_microscope(new)
+
+    expected = list(new.fm.filter_set.available_excitation_wavelengths)
+    assert rows._list.count() == len(_channels())
+    for i in range(rows._list.count()):
+        combo = rows._row(i).excitation_combo
+        assert [combo.itemData(j) for j in range(combo.count())] == expected
+
+
+def test_reconnect_keeps_the_very_same_channel_objects(qapp):
+    """Swapping microscopes changes the choices offered, not the configuration.
+
+    Identity, not equality: the rows are rebuilt, and the channel objects they
+    display are the protocol's own. Replacing them with copies would leave the
+    editor writing to objects the experiment no longer holds.
+    """
+    widget = _fluorescence_widget(_microscope_without_fm())
+    rows = widget.channelSettingsWidget._list
+    before = list(rows.channel_settings)
+
+    widget.set_microscope(_microscope_with_fm())
+
+    after = list(rows.channel_settings)
+    assert [id(ch) for ch in after] == [id(ch) for ch in before]
+    assert [ch.name for ch in after] == [ch.name for ch in before]
+    assert [ch.exposure_time for ch in after] == [ch.exposure_time for ch in before]
+
+
+@pytest.mark.parametrize("editor_cls", EDITORS, ids=EDITOR_IDS)
+def test_reconnect_does_not_edit_or_save_the_protocol(qapp, editor_cls, monkeypatch):
+    """Reconnecting must not look like the operator changed something.
+
+    The rebuild runs through the same setter a real edit uses, so it could
+    plausibly emit the change signals the editors treat as "protocol is dirty,
+    write it to disk". Swapping a microscope is not an edit, and an experiment
+    that rewrites itself on reconnect would be a nasty way to find that out.
+    """
+    old = _microscope_without_fm()
+    editor, host = _build(editor_cls, old)
+
+    events = []
+    fluorescence = editor.fluorescence_acquisition_task_config_widget
+    fluorescence.settings_changed.connect(lambda *_: events.append("settings_changed"))
+    fluorescence.channel_settings_changed.connect(
+        lambda *_: events.append("channel_settings_changed")
+    )
+    saves = []
+    monkeypatch.setattr(editor, "_save_experiment", lambda *a, **k: saves.append(1))
+
+    _reconnect(editor, host, _microscope_with_fm())
+    qapp.processEvents()
+
+    assert events == []
+    assert saves == []
+
+
+@pytest.mark.parametrize("editor_cls", EDITORS, ids=EDITOR_IDS)
+def test_a_half_built_editor_still_reconnects_what_it_has(qapp, editor_cls):
+    """A widget missing from a partial build is skipped, not fatal.
+
+    The reconnect branch is entered on `milling_task_editor` existing, but
+    `_create_widgets` assigns that first and is not wrapped in a try/except -- so a
+    constructor raising midway leaves the branch reachable with later widgets
+    absent. The fluorescence widget is exactly the one with previous form here
+    (5777bb35, "prevent crash when opening fluorescence config widget with no
+    FM"), and an AttributeError from this handler would mask the real failure.
+    """
+    old = _microscope_without_fm()
+    editor, host = _build(editor_cls, old)
+    del editor.fluorescence_acquisition_task_config_widget
+
+    _reconnect(editor, host, _microscope_with_fm())  # must not raise


### PR DESCRIPTION
Fixes FIB-525. Replaces #305, which bundled this with the milling half — that is now FIB-530.

## The bug

The protocol editors are built once and survive a disconnect, unlike the main tabs (`update_microscope_ui` destroys and rebuilds those on every connect). So every widget under them keeps whatever microscope it was constructed with, and on reconnect the handlers updated exactly one attribute — not the fluorescence channel editor.

**Symptom**: connect to a system with no fluorescence detector → disconnect → reconnect to an FM-enabled one, and the excitation/emission dropdowns stay empty for the life of the process. The wavelengths are read from the microscope once, at construction, so an FM-less first connection caches two empty lists.

**The mirror case is the better reason to fix it**: connect to an FM microscope *first*, then reconnect to a different one, and the widget keeps a live handle to the **previous microscope's `fm`**.

## The fix

`set_fm` / `set_microscope` down the chain, each re-deriving what it cached:

- **`ChannelSettingsWidget`** keeps the two wavelength lists and *no* `fm` reference at all — nothing about it looks stale from the outside while it offers a disconnected microscope's filters.
- **`ChannelListWidget`** re-reads the lists and rebuilds the rows, which take their choices as constructor arguments. The channel objects are **reused, not copied**, so the protocol's own objects stay in place. Row selection does not survive the rebuild.
- **The refresh emits no change signals.** This is load-bearing, not incidental — see below.

## Scope note

The milling subtree has the same fault: `self.milling_task_editor.microscope = self.microscope` updates one attribute, while that widget handed the microscope to two children at construction, and the available currents/presets sit a level below that as constructor arguments. Five stale references, plus a `milling_progress_signal` subscription.

Deliberately **not** fixed here — split out as **FIB-530**, with the full measured list. It touches the widget that drives milling, and it should be reviewed on its own rather than riding along with a fluorescence fix.

## Two findings worth surfacing

**Emitting on refresh crashes the process.** As a mutation test, I made the refresh emit `settings_changed`. It re-enters the editor's dirty/save path and **aborts the interpreter** — not a test failure, a hard crash. So a reconnect that announced itself as an edit would both rewrite the experiment file and take the app down. There is a test asserting the refresh is signal-silent and performs no save.

**The first version of these tests was vacuous.** `AcquireFluorescenceImageConfig()` defaults `channel_settings` to `[]`, so every test ran with zero channel rows — the row rebuild, which is the mechanism that fixes the reported symptom, was never exercised, and the "channels survive" assertion compared two empty lists. The fixture now configures real channels, and the row-level assertions are tested on the widget directly rather than through an editor (the two editors populate it at different times: the task-config editor passes the config in, the lamella editor constructs with `config=None` and fills it on task selection).

## Tests

`tests/ui/test_editor_microscope_reconnect.py`, 10 cases.

The primary guard walks the fluorescence subtree after a simulated reconnect and asserts nothing still points at the old microscope — a guard against the incomplete-list failure that caused this bug, rather than a list of widget names. It also asserts the subtree *does* hold the new one, so it can't pass by everything being dropped. Derived state (the wavelength lists) is asserted separately, since an identity walk is blind to a widget that keeps values but no reference.

Mutation tested — each caught:

| mutation | caught by |
|---|---|
| editor never calls `set_microscope` | subtree walk + filters |
| channel list keeps its cached wavelengths | filters ×2 + rows |
| rows not rebuilt (lists updated, rows left alone) | per-row filters |
| detail widget keeps its cached wavelengths | filters ×2 |
| refresh emits change signals | interpreter abort (see above) |

Also audited: no pre-existing method on this branch gained or lost a decorator (checked by AST-diffing decorator lists against `main` — that check exists because displacing `@ensure_main_thread` is exactly how #305 went wrong). All changed files parse under 3.8.

`tests/ui` + `tests/milling` + `tests/autolamella` + `tests/fm`: **2017 passed**.