### PR TITLE
[ui] Retire the legacy colour-named button sheets

### DIFF
--- a/fibsem/ui/FibsemLabellingUI.py
+++ b/fibsem/ui/FibsemLabellingUI.py
@@ -323,10 +323,10 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         self.pushButton_model_clear.setVisible(False)
 
         # style
-        self.pushButton_load_data.setStyleSheet(stylesheets.BLUE_PUSHBUTTON_STYLE)
-        self.model_widget.pushButton_load_model.setStyleSheet(stylesheets.BLUE_PUSHBUTTON_STYLE)
-        self.pushButton_model_confirm.setStyleSheet(stylesheets.GREEN_PUSHBUTTON_STYLE)
-        self.pushButton_model_clear.setStyleSheet(stylesheets.RED_PUSHBUTTON_STYLE)
+        self.pushButton_load_data.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.model_widget.pushButton_load_model.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.pushButton_model_confirm.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.pushButton_model_clear.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
 
         # tooltips
         self.checkBox_autosave.setToolTip(CONFIGURATION["TOOLTIPS"]["AUTOSAVE"])

--- a/fibsem/ui/FibsemManipulatorWidget.py
+++ b/fibsem/ui/FibsemManipulatorWidget.py
@@ -191,16 +191,16 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
     def setup_connections(self):
 
         self.insertManipulator_button.clicked.connect(self.insert_retract_manipulator)
-        self.insertManipulator_button.setStyleSheet(stylesheets.GREEN_PUSHBUTTON_STYLE)
+        self.insertManipulator_button.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
         self.addSavedPosition_button.clicked.connect(self.add_saved_position)
-        self.addSavedPosition_button.setStyleSheet(stylesheets.GREEN_PUSHBUTTON_STYLE)
+        self.addSavedPosition_button.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
         self.goToPosition_button.clicked.connect(self.move_to_saved_position)
-        self.goToPosition_button.setStyleSheet(stylesheets.BLUE_PUSHBUTTON_STYLE)
+        self.goToPosition_button.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
         self.moveRelative_button.clicked.connect(self.move_relative)
-        self.moveRelative_button.setStyleSheet(stylesheets.BLUE_PUSHBUTTON_STYLE)
+        self.moveRelative_button.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
 
         self.pushButton_refresh_data.clicked.connect(self.refresh_data)
-        self.pushButton_refresh_data.setStyleSheet(stylesheets.GRAY_PUSHBUTTON_STYLE)
+        self.pushButton_refresh_data.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
 
 
     def refresh_data(self):
@@ -208,7 +208,7 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
         
         self._hide_show_buttons(self.manipulator_inserted)
         self.insertManipulator_button.setText("Retract" if self.manipulator_inserted else "Insert")
-        self.insertManipulator_button.setStyleSheet(stylesheets.RED_PUSHBUTTON_STYLE if self.manipulator_inserted else stylesheets.GREEN_PUSHBUTTON_STYLE)
+        self.insertManipulator_button.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET if self.manipulator_inserted else stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
         self.manipulatorStatus_label.setText("Manipulator Status: Inserted" if self.manipulator_inserted else "Manipulator Status: Retracted")        
         
 
@@ -269,7 +269,7 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
             self.microscope.retract_manipulator()
             self.insertManipulator_button.setText("Insert")
             self.manipulatorStatus_label.setText("Manipulator Status: Retracted")
-            self.insertManipulator_button.setStyleSheet(stylesheets.GREEN_PUSHBUTTON_STYLE)
+            self.insertManipulator_button.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
             self.update_ui()
             self._hide_show_buttons(show=False)
         
@@ -278,7 +278,7 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
             self.microscope.insert_manipulator()
             self.insertManipulator_button.setText("Retract")
             self.manipulatorStatus_label.setText("Manipulator Status: Inserted")
-            self.insertManipulator_button.setStyleSheet(stylesheets.RED_PUSHBUTTON_STYLE)
+            self.insertManipulator_button.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
             self.update_ui()
             self._hide_show_buttons(show=True)
 

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -442,7 +442,7 @@ class FibsemMinimapWidget(QWidget):
         # set styles
         self.pushButton_run_tile_collection.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
         self.pushButton_cancel_acquisition.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
-        self.progressBar_acquisition.setStyleSheet(stylesheets.PROGRESS_BAR_GREEN_STYLE)
+        self.progressBar_acquisition.setStyleSheet(stylesheets.MILLING_PROGRESS_BAR_STYLESHEET)
         self.pushButton_enable_correlation.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         self.pushButton_load_image.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         self.pushButton_load_correlation_image.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
@@ -717,7 +717,6 @@ class FibsemMinimapWidget(QWidget):
             self.pushButton_run_tile_collection.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
             self.pushButton_run_tile_collection.setText("Run Tile Collection")
         else:
-            # self.pushButton_run_tile_collection.setStyleSheet(stylesheets.DISABLED_PUSHBUTTON_STYLE)
             self.pushButton_run_tile_collection.setText("Running Tile Collection...")
 
         if self.image is None:
@@ -1495,7 +1494,7 @@ class FibsemMinimapWidget(QWidget):
         self.correlation_mode_enabled = not self.correlation_mode_enabled
 
         if self.correlation_mode_enabled:
-            self.pushButton_enable_correlation.setStyleSheet(stylesheets.ORANGE_PUSHBUTTON_STYLE)
+            self.pushButton_enable_correlation.setStyleSheet(stylesheets.USER_ATTENTION_BUTTON_STYLESHEET)
             self.pushButton_enable_correlation.setText("Disable Correlation Mode")
             self.comboBox_correlation_selected_layer.setEnabled(False)
         else:

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -20,7 +20,6 @@ from fibsem.structures import (
 from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
 from fibsem.ui.napari.utilities import update_text_overlay
 from fibsem.ui.stylesheets import (
-    DISABLED_PUSHBUTTON_STYLE,
     LABEL_INSTRUCTIONS_STYLE,
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
@@ -270,10 +269,11 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         if caller is None:
             # self.parent.milling_widget._toggle_interactions(enable, caller="movement")
             self.parent.image_widget._toggle_interactions(enable, caller="movement")
+        # No disabled branch: both sheets carry a :disabled rule, so setEnabled
+        # above is what greys these out.
         for btn in self._move_buttons:
-            btn.setStyleSheet(DISABLED_PUSHBUTTON_STYLE if not enable else
-                              PRIMARY_BUTTON_STYLESHEET if btn is self.pushButton_move else
-                              SECONDARY_BUTTON_STYLESHEET)
+            btn.setStyleSheet(PRIMARY_BUTTON_STYLESHEET if btn is self.pushButton_move
+                              else SECONDARY_BUTTON_STYLESHEET)
 
     def handle_movement_progress_update(self, ddict: dict) -> None:
         """Handle movement progress updates from the microscope"""

--- a/fibsem/ui/FibsemSegmentationModelWidget.py
+++ b/fibsem/ui/FibsemSegmentationModelWidget.py
@@ -110,7 +110,7 @@ class FibsemSegmentationModelWidget(QtWidgets.QDialog):
 
         self.pushButton_load_model.setEnabled(False)
         self.pushButton_load_model.setText("Loading...")
-        self.pushButton_load_model.setStyleSheet(stylesheets.ORANGE_PUSHBUTTON_STYLE)
+        self.pushButton_load_model.setStyleSheet(stylesheets.USER_ATTENTION_BUTTON_STYLESHEET)
         self.pushButton_load_model.setToolTip("Downloading model... check terminal for progress...")
 
         worker = self.load_model_worker(model_type=model_type, checkpoint=checkpoint)
@@ -136,7 +136,7 @@ class FibsemSegmentationModelWidget(QtWidgets.QDialog):
 
         self.pushButton_load_model.setEnabled(True)
         self.pushButton_load_model.setText("Load Model")
-        self.pushButton_load_model.setStyleSheet(stylesheets.BLUE_PUSHBUTTON_STYLE)
+        self.pushButton_load_model.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
         self.pushButton_load_model.setToolTip("")
 
         if self.model is not None:

--- a/fibsem/ui/fm/widgets/acquisition_summary_dialog.py
+++ b/fibsem/ui/fm/widgets/acquisition_summary_dialog.py
@@ -13,8 +13,8 @@ from PyQt5.QtWidgets import (
 from fibsem.fm.structures import ChannelSettings, ZParameters, FMStagePosition
 from fibsem.fm.timing import estimate_positions_acquisition_time
 from fibsem.ui.stylesheets import (
-    GREEN_PUSHBUTTON_STYLE,
-    RED_PUSHBUTTON_STYLE,
+    RUN_WORKFLOW_BUTTON_STYLESHEET,
+    SECONDARY_BUTTON_STYLESHEET,
 )
 from fibsem.utils import format_duration
 
@@ -98,12 +98,12 @@ class AcquisitionSummaryDialog(QDialog):
         # Buttons
         button_layout = QGridLayout()
         self.button_start = QPushButton("Start Acquisition")
-        self.button_start.setStyleSheet(GREEN_PUSHBUTTON_STYLE)
+        self.button_start.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
         self.button_start.clicked.connect(self.accept)
         button_layout.addWidget(self.button_start, 0, 0)
 
         self.button_cancel = QPushButton("Cancel")
-        self.button_cancel.setStyleSheet(RED_PUSHBUTTON_STYLE)
+        self.button_cancel.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
         self.button_cancel.clicked.connect(self.reject)
         button_layout.addWidget(self.button_cancel, 0, 1)
 

--- a/fibsem/ui/fm/widgets/display_options_dialog.py
+++ b/fibsem/ui/fm/widgets/display_options_dialog.py
@@ -7,8 +7,8 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem.ui.stylesheets import (
-    BLUE_PUSHBUTTON_STYLE,
-    GRAY_PUSHBUTTON_STYLE,
+    PRIMARY_BUTTON_STYLESHEET,
+    SECONDARY_BUTTON_STYLESHEET,
 )
 
 from typing import TYPE_CHECKING
@@ -59,12 +59,12 @@ class DisplayOptionsDialog(QDialog):
         button_layout = QGridLayout()
 
         self.button_ok = QPushButton("OK")
-        self.button_ok.setStyleSheet(BLUE_PUSHBUTTON_STYLE)
+        self.button_ok.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         self.button_ok.clicked.connect(self.accept)
         button_layout.addWidget(self.button_ok, 0, 0)
 
         self.button_cancel = QPushButton("Cancel")
-        self.button_cancel.setStyleSheet(GRAY_PUSHBUTTON_STYLE)
+        self.button_cancel.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
         self.button_cancel.clicked.connect(self.reject)
         button_layout.addWidget(self.button_cancel, 0, 1)
 

--- a/fibsem/ui/fm/widgets/fm_image_viewer_widget.py
+++ b/fibsem/ui/fm/widgets/fm_image_viewer_widget.py
@@ -14,7 +14,7 @@ from superqt import ensure_main_thread
 
 from fibsem.fm.structures import FluorescenceImage, FluorescenceChannelMetadata, FluorescenceImageMetadata
 from fibsem.ui.fm.widgets.load_image_dialog import LoadImageDialog
-from fibsem.ui.stylesheets import BLUE_PUSHBUTTON_STYLE
+from fibsem.ui.stylesheets import PRIMARY_BUTTON_STYLESHEET
 
 
 def _image_metadata_to_napari_image_layer(
@@ -75,7 +75,7 @@ class FMImageViewerWidget(QWidget):
         """Initialize the user interface."""
         # Create load button
         self.pushButton_load_image = QPushButton("Load Image...", self)
-        self.pushButton_load_image.setStyleSheet(BLUE_PUSHBUTTON_STYLE)
+        self.pushButton_load_image.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         self.pushButton_load_image.clicked.connect(self.show_load_image_dialog)
 
         # Create layout

--- a/fibsem/ui/fm/widgets/load_image_dialog.py
+++ b/fibsem/ui/fm/widgets/load_image_dialog.py
@@ -22,7 +22,7 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem.fm.structures import FluorescenceImage
-from fibsem.ui.stylesheets import GREEN_PUSHBUTTON_STYLE, RED_PUSHBUTTON_STYLE
+from fibsem.ui.stylesheets import RUN_WORKFLOW_BUTTON_STYLESHEET, SECONDARY_BUTTON_STYLESHEET
 
 
 class LoadImageDialog(QDialog):
@@ -84,13 +84,13 @@ class LoadImageDialog(QDialog):
         button_layout = QHBoxLayout()
 
         self.load_button = QPushButton("Load Images")
-        self.load_button.setStyleSheet(GREEN_PUSHBUTTON_STYLE)
+        self.load_button.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
         self.load_button.clicked.connect(self.load_images)
         self.load_button.setEnabled(False)
         button_layout.addWidget(self.load_button)
 
         self.cancel_button = QPushButton("Cancel")
-        self.cancel_button.setStyleSheet(RED_PUSHBUTTON_STYLE)
+        self.cancel_button.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
         self.cancel_button.clicked.connect(self.reject)
         button_layout.addWidget(self.cancel_button)
 

--- a/fibsem/ui/fm/widgets/overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/overview_confirmation_dialog.py
@@ -13,8 +13,8 @@ from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.structures import ChannelSettings, ZParameters, OverviewParameters
 from fibsem.fm.timing import estimate_tileset_acquisition_time
 from fibsem.ui.stylesheets import (
-    GREEN_PUSHBUTTON_STYLE,
-    GRAY_PUSHBUTTON_STYLE,
+    RUN_WORKFLOW_BUTTON_STYLESHEET,
+    SECONDARY_BUTTON_STYLESHEET,
 )
 from fibsem.utils import format_duration
 
@@ -89,12 +89,12 @@ class OverviewConfirmationDialog(QDialog):
         # Buttons
         button_layout = QGridLayout()
         self.button_start = QPushButton("Start Acquisition")
-        self.button_start.setStyleSheet(GREEN_PUSHBUTTON_STYLE)
+        self.button_start.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
         self.button_start.clicked.connect(self.accept)
         button_layout.addWidget(self.button_start, 0, 0)
 
         self.button_cancel = QPushButton("Cancel")
-        self.button_cancel.setStyleSheet(GRAY_PUSHBUTTON_STYLE)
+        self.button_cancel.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
         self.button_cancel.clicked.connect(self.reject)
         button_layout.addWidget(self.button_cancel, 0, 1)
 

--- a/fibsem/ui/fm/widgets/saved_positions_widget.py
+++ b/fibsem/ui/fm/widgets/saved_positions_widget.py
@@ -15,10 +15,9 @@ from PyQt5.QtWidgets import (
 
 from fibsem.fm.structures import FMStagePosition
 from fibsem.ui.stylesheets import (
-    BLUE_PUSHBUTTON_STYLE,
-    GRAY_PUSHBUTTON_STYLE,
-    GREEN_PUSHBUTTON_STYLE,
-    RED_PUSHBUTTON_STYLE,
+    PRIMARY_BUTTON_STYLESHEET,
+    RUN_WORKFLOW_BUTTON_STYLESHEET,
+    STOP_WORKFLOW_BUTTON_STYLESHEET,
 )
 from fibsem.ui.utils import message_box_ui
 from fibsem.applications.autolamella.structures import Lamella
@@ -100,9 +99,9 @@ class SavedPositionsWidget(QWidget):
         self._update_widget_state()
 
         # Set button styles
-        self.pushButton_goto_position.setStyleSheet(BLUE_PUSHBUTTON_STYLE)
-        self.pushButton_delete_position.setStyleSheet(RED_PUSHBUTTON_STYLE)
-        self.pushButton_set_objective.setStyleSheet(GREEN_PUSHBUTTON_STYLE)
+        self.pushButton_goto_position.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
+        self.pushButton_delete_position.setStyleSheet(STOP_WORKFLOW_BUTTON_STYLESHEET)
+        self.pushButton_set_objective.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
 
     def update_positions(self, positions: List[Lamella]):
         """Update the combobox and checkbox list with current saved positions."""
@@ -150,14 +149,9 @@ class SavedPositionsWidget(QWidget):
         self.comboBox_objective_source.setEnabled(has_positions)
         self.comboBox_positions.setEnabled(has_positions)
 
-        if not has_positions:
-            self.pushButton_goto_position.setStyleSheet(GRAY_PUSHBUTTON_STYLE)
-            self.pushButton_delete_position.setStyleSheet(GRAY_PUSHBUTTON_STYLE)
-            self.pushButton_set_objective.setStyleSheet(GRAY_PUSHBUTTON_STYLE)
-        else:
-            self.pushButton_goto_position.setStyleSheet(BLUE_PUSHBUTTON_STYLE)
-            self.pushButton_delete_position.setStyleSheet(RED_PUSHBUTTON_STYLE)
-            self.pushButton_set_objective.setStyleSheet(GREEN_PUSHBUTTON_STYLE)
+        # The buttons used to be repainted grey here as well. The semantic
+        # sheets carry their own :disabled rule, so setEnabled above is now the
+        # whole story and the styles can be set once, in __init__.
 
     def _update_position_info(self):
         """Update the position info label with details of the selected position."""

--- a/fibsem/ui/fm/widgets/sem_acquisition_widget.py
+++ b/fibsem/ui/fm/widgets/sem_acquisition_widget.py
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import QWidget, QGridLayout, QLabel, QDoubleSpinBox, QPushB
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import ImageSettings, BeamType
 from fibsem.config import SQUARE_RESOLUTIONS_LIST
-from fibsem.ui.stylesheets import GREEN_PUSHBUTTON_STYLE
+from fibsem.ui.stylesheets import RUN_WORKFLOW_BUTTON_STYLESHEET
 from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
     ValueSpinBox,
@@ -60,7 +60,7 @@ class SEMAcquisitionWidget(QWidget):
 
         # Image acquisition controls
         self.button_acquire_image = QPushButton("Acquire Image")
-        self.button_acquire_image.setStyleSheet(GREEN_PUSHBUTTON_STYLE)
+        self.button_acquire_image.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
         self.button_acquire_image.clicked.connect(self.acquire_image)
 
         layout.addWidget(self.fov_label, 0, 0)

--- a/fibsem/ui/fm/widgets/stage_position_control_widget.py
+++ b/fibsem/ui/fm/widgets/stage_position_control_widget.py
@@ -12,8 +12,8 @@ from PyQt5.QtWidgets import (
 
 from fibsem.microscopes.simulator import FibsemMicroscope
 from fibsem.ui.stylesheets import (
-    BLUE_PUSHBUTTON_STYLE,
-    GRAY_PUSHBUTTON_STYLE,
+    PRIMARY_BUTTON_STYLESHEET,
+    SECONDARY_BUTTON_STYLESHEET,
 )
 from fibsem.ui.widgets.custom_widgets import (
     ValueSpinBox,
@@ -35,11 +35,11 @@ class StagePositionControlWidget(QWidget):
         """Initialize the stage position control UI."""
 
         self.button_sem_orientation = QPushButton("Move to SEM Orientation", self)
-        self.button_sem_orientation.setStyleSheet(BLUE_PUSHBUTTON_STYLE)
+        self.button_sem_orientation.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         self.button_sem_orientation.clicked.connect(self.move_to_sem_orientation)
 
         self.button_fm_orientation = QPushButton("Move to FM Orientation", self)
-        self.button_fm_orientation.setStyleSheet(BLUE_PUSHBUTTON_STYLE)
+        self.button_fm_orientation.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         self.button_fm_orientation.clicked.connect(self.move_to_fm_orientation)
 
         # Milling angle controls    
@@ -52,11 +52,11 @@ class StagePositionControlWidget(QWidget):
         self.milling_angle_spinbox.valueChanged.connect(self.update_milling_angle)
 
         self.button_move_to_milling = QPushButton("Move to Milling Angle", self)
-        self.button_move_to_milling.setStyleSheet(BLUE_PUSHBUTTON_STYLE)
+        self.button_move_to_milling.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         self.button_move_to_milling.clicked.connect(self.move_to_milling_angle)
 
         self.button_refresh_stage_position = QPushButton("Refresh Stage Position Data", self)
-        self.button_refresh_stage_position.setStyleSheet(GRAY_PUSHBUTTON_STYLE)
+        self.button_refresh_stage_position.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
         self.button_refresh_stage_position.clicked.connect(self.parent_widget.display_stage_position_overlay)
 
         orientation_layout = QGridLayout()

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -52,74 +52,6 @@ from fibsem.ui.napari_style import NAPARI_STYLE  # noqa: F401
 
 _ICONS_DIR = _os.path.join(_os.path.dirname(__file__), "icons").replace("\\", "/")
 
-GREEN_PUSHBUTTON_STYLE = """
-QPushButton {
-    background-color: green;
-    }
-QPushButton:hover {
-    background-color: rgba(0, 255, 0, 125);
-    }"""
-
-RED_PUSHBUTTON_STYLE = """
-QPushButton {
-    background-color: red;
-    }
-QPushButton:hover {
-    background-color: rgba(255, 0, 0, 125);
-    }"""
-
-BLUE_PUSHBUTTON_STYLE = """
-QPushButton {
-    background-color: blue;
-    }
-QPushButton:hover {
-    background-color: rgba(0, 0, 255, 125);
-    }"""
-
-YELLOW_PUSHBUTTON_STYLE = """
-QPushButton {
-    background-color: yellow;
-    }
-QPushButton:hover {
-    background-color: rgba(255, 255, 0, 125);
-    }"""
-
-WHITE_PUSHBUTTON_STYLE = """
-QPushButton {
-    background-color: white;
-    color: black;
-    }
-QPushButton:hover {
-    background-color: rgba(255, 255, 255, 125);
-    }"""
-
-GRAY_PUSHBUTTON_STYLE = """
-QPushButton {
-    background-color: gray;
-    }
-QPushButton:hover {
-    background-color: rgba(125, 125, 125, 125);
-    }"""
-
-ORANGE_PUSHBUTTON_STYLE = """
-QPushButton {
-    background-color: orange;
-    color: black;
-    }
-QPushButton:hover {
-    background-color: rgba(255, 125, 0, 125);
-}"""
-
-DISABLED_PUSHBUTTON_STYLE = """
-QPushButton {
-    background-color: none;
-    }
-"""
-
-PROGRESS_BAR_GREEN_STYLE = "QProgressBar::chunk {background-color: green;}"
-PROGRESS_BAR_BLUE_STYLE = "QProgressBar::chunk {background-color: blue;}"
-
-
 # TODO: no token -- #68a0dd, #3a6ea5
 #
 # #3a6ea5 is the one left literal on purpose rather than for want of a token:
@@ -216,6 +148,10 @@ RUN_WORKFLOW_BUTTON_STYLESHEET = f"""
         """
 
 
+# The :disabled rule matches the primary/secondary/run sheets. Without it a
+# disabled stop or delete button stays full crimson and only stops responding,
+# which is what drove call sites to paint their own grey "off" state by hand.
+# TODO: no token -- #2d313b, #6b6b6b
 STOP_WORKFLOW_BUTTON_STYLESHEET = f"""
             QPushButton {{
                 background-color: {SEMANTIC_ERROR_COLOR};
@@ -229,6 +165,10 @@ STOP_WORKFLOW_BUTTON_STYLESHEET = f"""
             }}
             QPushButton:pressed {{
                 background-color: {SEMANTIC_ERROR_PRESSED_COLOR};
+            }}
+            QPushButton:disabled {{
+                background-color: #2d313b;
+                color: #6b6b6b;
             }}
         """
 

--- a/fibsem/ui/widgets/autolamella_generate_report_widget.py
+++ b/fibsem/ui/widgets/autolamella_generate_report_widget.py
@@ -10,9 +10,9 @@ from PyQt5 import QtWidgets, QtCore
 from fibsem.applications.autolamella.structures import Experiment
 from fibsem.applications.autolamella.tools.reporting import generate_report2
 from fibsem.ui.stylesheets import (
-    BLUE_PUSHBUTTON_STYLE,
-    GREEN_PUSHBUTTON_STYLE,
-    RED_PUSHBUTTON_STYLE,
+    PRIMARY_BUTTON_STYLESHEET,
+    RUN_WORKFLOW_BUTTON_STYLESHEET,
+    SECONDARY_BUTTON_STYLESHEET,
 )
 
 
@@ -89,7 +89,7 @@ class AutoLamellaGenerateReportWidget(QtWidgets.QDialog):
         output_button_layout = QtWidgets.QHBoxLayout()
         output_button_layout.addStretch()
         self.btn_select_output = QtWidgets.QPushButton("Select Output File")
-        self.btn_select_output.setStyleSheet(BLUE_PUSHBUTTON_STYLE)
+        self.btn_select_output.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         output_button_layout.addWidget(self.btn_select_output)
         output_layout.addLayout(output_button_layout)
 
@@ -150,11 +150,11 @@ class AutoLamellaGenerateReportWidget(QtWidgets.QDialog):
         sections_button_layout.addStretch()
 
         self.btn_select_all = QtWidgets.QPushButton("Select All")
-        self.btn_select_all.setStyleSheet(BLUE_PUSHBUTTON_STYLE)
+        self.btn_select_all.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         sections_button_layout.addWidget(self.btn_select_all)
 
         self.btn_deselect_all = QtWidgets.QPushButton("Deselect All")
-        self.btn_deselect_all.setStyleSheet(BLUE_PUSHBUTTON_STYLE)
+        self.btn_deselect_all.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         sections_button_layout.addWidget(self.btn_deselect_all)
 
         sections_layout.addLayout(sections_button_layout)
@@ -166,12 +166,12 @@ class AutoLamellaGenerateReportWidget(QtWidgets.QDialog):
         button_box = QtWidgets.QDialogButtonBox()
 
         self.btn_generate = QtWidgets.QPushButton("Generate Report")
-        self.btn_generate.setStyleSheet(GREEN_PUSHBUTTON_STYLE)
+        self.btn_generate.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
         self.btn_generate.setDefault(True)
         self.btn_generate.setEnabled(False)  # Disabled until an experiment is attached
 
         self.btn_cancel = QtWidgets.QPushButton("Cancel")
-        self.btn_cancel.setStyleSheet(RED_PUSHBUTTON_STYLE)
+        self.btn_cancel.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
 
         button_box.addButton(self.btn_generate, QtWidgets.QDialogButtonBox.AcceptRole)
         button_box.addButton(self.btn_cancel, QtWidgets.QDialogButtonBox.RejectRole)

--- a/tests/ui/test_stylesheets_render.py
+++ b/tests/ui/test_stylesheets_render.py
@@ -99,7 +99,10 @@ def test_the_stylesheets_import_and_render(rendered):
     the checks below passing vacuously: they iterate over this mapping, so an
     empty one would make them both trivially true.
     """
-    assert len(rendered) > 60, f"only {len(rendered)} constants -- did the import half-fail?"
+    # Loose on purpose: this is here to catch an import that produced nothing,
+    # not to pin the count, which would need editing every time a sheet is
+    # added or retired.
+    assert len(rendered) > 40, f"only {len(rendered)} constants -- did the import half-fail?"
     assert rendered["NAPARI_STYLE"].strip().startswith("QWidget")
     assert "#" in rendered["BORDER_COLOR"]
 


### PR DESCRIPTION
Follow-up to #304, which made the palette the single source of truth for the QSS. That PR deliberately left the legacy colour-named button layer alone, because retiring it is not visually neutral and needed decisions rather than a find-and-replace. This is those decisions.

## The problem

`GREEN_PUSHBUTTON_STYLE` and its siblings set `background-color: green` (or `red`, or `blue`) and a hover rule, and nothing else — no padding, no border-radius, no text colour, and crucially **no `:disabled` rule**. They predate the semantic sheets and disagreed with them everywhere the two met.

47 call sites across 15 files. `YELLOW_PUSHBUTTON_STYLE`, `WHITE_PUSHBUTTON_STYLE` and `PROGRESS_BAR_BLUE_STYLE` had **zero** call sites.

## This is not visually neutral

Unlike #304, this changes what the UI looks like. Two things to be aware of:

**Every migrated button changes shape, not just colour.** The semantic sheets set `padding: 5px 12px` and `border-radius: 3px`; the legacy ones set neither. That is invisible in a colour table and visible on screen.

| legacy | rendered | replacement | rendered |
|---|---|---|---|
| `green` | `#008000` | `RUN_WORKFLOW_BUTTON_STYLESHEET` | `#4caf50` |
| `red` | `#FF0000` | `STOP_WORKFLOW_BUTTON_STYLESHEET` | `#99121F` |
| `blue` | `#0000FF` | `PRIMARY_BUTTON_STYLESHEET` | `#007ACC` |
| `gray` | `#808080` | `SECONDARY_BUTTON_STYLESHEET` | `#3d4251` |
| `orange` | `#FFA500` | `USER_ATTENTION_BUTTON_STYLESHEET` | `#ff9800` |

**The hue is preserved where it carried meaning.** Blue → primary, green → run, grey → secondary, orange → attention. Re-deciding which buttons *should* be primary versus run is a design question that wants eyes on the UI, not a refactor, so it is not attempted here.

## Red did not map one-to-one

`RED_PUSHBUTTON_STYLE` was doing two different jobs:

| call site | role | now |
|---|---|---|
| `acquisition_summary_dialog`, `load_image_dialog`, `autolamella_generate_report_widget` | dialog **Cancel** | `SECONDARY_BUTTON_STYLESHEET` |
| `FibsemLabellingUI` — clear loaded model | non-destructive | `SECONDARY_BUTTON_STYLESHEET` |
| `saved_positions_widget` — **delete** position | destructive | `STOP_WORKFLOW_BUTTON_STYLESHEET` |
| `FibsemManipulatorWidget` — **retract** manipulator | stop-like | `STOP_WORKFLOW_BUTTON_STYLESHEET` |

A dialog Cancel is not destructive, and pure red implies it is. Two dialogs in the codebase (`overview_confirmation_dialog`, `display_options_dialog`) already used grey for Cancel, so this makes them agree rather than inventing a new convention.

## One shared sheet changes: `STOP_WORKFLOW_BUTTON_STYLESHEET` gains `:disabled`

It was the only one of the four semantic button sheets without a `:disabled` rule. Adding it affects the 7 other call sites that use it — but only in the disabled state, which currently renders as full crimson while ignoring clicks. That is the bug, not the fix.

It is also the keystone for the next part.

## The hand-rolled disabled states go

Two call sites were painting a fake disabled look because the legacy sheets ignored the real one:

* **`saved_positions_widget`** already called `setEnabled()` on all three buttons and *then* repainted them grey. The repaint is now redundant — deleted, and the styles set once in `__init__` rather than on every state change.
* **`FibsemMovementWidget`** was already half-migrated: primary/secondary sheets for the enabled case, `DISABLED_PUSHBUTTON_STYLE` otherwise. The disabled branch is gone.

**Neither changes behaviour** — `setEnabled()` was already being called in both. This is deletion, not a rewrite.

## Also here

* A commented-out `DISABLED_PUSHBUTTON_STYLE` line in the minimap, deleted.
* The minimap acquisition bar moves to `MILLING_PROGRESS_BAR_STYLESHEET`. **This one is not a like-for-like swap:** `PROGRESS_BAR_GREEN_STYLE` set only `::chunk`, so the trough gets restyled too (border, background, centred text).

## Testing

`957 passed` — `tests/ui/` plus `tests/test_import_cycles.py`.

Every tracked file was checked statically for stylesheet names that no longer resolve: none. Note that `FibsemLabellingUI` and `FibsemSegmentationModelWidget` cannot be import-tested without the `ml` extra (`torch`), so those two rest on that static check plus `py_compile` rather than a real import.

**Not done: launching the UI.** No test here can tell you the padding and radius changes look right. The manipulator panel, an FM dialog and the minimap are the places to look.
