### PR TITLE
[ui] Accept one metadata vocabulary across all four config forms (FIB-384)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -27,19 +27,19 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
     task_type: ClassVar[str] = "ACQUIRE_FLUORESCENCE_IMAGE"
     display_name: ClassVar[str] = "Acquire Fluorescence Image"
     channel_settings: list[ChannelSettings] = field(default_factory=list,
-                                                    metadata={"help": "Settings for each fluorescence channel",
+                                                    metadata={"tooltip": "Settings for each fluorescence channel",
                                                              "label": "Channel Settings"})
     zparams: ZParameters = field(default_factory=ZParameters, 
-                                  metadata={"help": "Z-stack acquisition parameters",
+                                  metadata={"tooltip": "Z-stack acquisition parameters",
                                             "label": "Z-Stack Parameters"})
     autofocus_settings: AutoFocusSettings = field(default_factory=AutoFocusSettings,
-                                                  metadata={"help": "Settings for autofocus before acquiring fluorescence images",
+                                                  metadata={"tooltip": "Settings for autofocus before acquiring fluorescence images",
                                                             "label": "Autofocus Settings"})
     orientation: Optional[str] = field(default=None,
-                                       metadata={"help": "Orientation for acquisition. 'FM' or 'SEM'. None = use fluorescence_pose as-is.",
+                                       metadata={"tooltip": "Orientation for acquisition. 'FM' or 'SEM'. None = use fluorescence_pose as-is.",
                                                  "label": "Orientation"})
     retract_objective: bool = field(default=True,
-                                    metadata={"help": "Retract the objective when the task finishes, so it is clear of the stage for subsequent moves. Disable for back-to-back fluorescence tasks.",
+                                    metadata={"tooltip": "Retract the objective when the task finishes, so it is clear of the stage for subsequent moves. Disable for back-to-back fluorescence tasks.",
                                               "label": "Retract Objective"})
 
     def to_dict(self) -> dict:

--- a/fibsem/applications/autolamella/workflows/tasks/fiducial.py
+++ b/fibsem/applications/autolamella/workflows/tasks/fiducial.py
@@ -31,14 +31,14 @@ class MillFiducialTaskConfig(AutoLamellaTaskConfig):
     alignment_expansion: float = field(
         default=100.0,
         metadata={
-            "help": "The percentage to expand the alignment area around the fiducial",
-            "units": "%",
+            "tooltip": "The percentage to expand the alignment area around the fiducial",
+            "unit": "%",
         },
     )
     align_to_reference: bool = field(
         default=True,
         metadata={
-            "help": "Align to the reference image before milling fiducial (if available)"
+            "tooltip": "Align to the reference image before milling fiducial (if available)"
         }
 
     )

--- a/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
+++ b/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
@@ -60,14 +60,14 @@ class MillCoincidentTaskConfig(AutoLamellaTaskConfig):
     acquire_sem: bool = field(
         default=True,
         metadata={
-            "help": "Whether to acquire an SEM reference image",
+            "tooltip": "Whether to acquire an SEM reference image",
             "label": "Acquire SEM Image",
         },
     )
     acquire_fib: bool = field(
         default=True,
         metadata={
-            "help": "Whether to acquire a FIB reference image",
+            "tooltip": "Whether to acquire a FIB reference image",
             "label": "Acquire FIB Image",
         },
     )
@@ -75,16 +75,16 @@ class MillCoincidentTaskConfig(AutoLamellaTaskConfig):
         default=True,
         metadata={
             "label": "Acquire Fluorescence Images",
-            "help": "Whether to acquire fluorescence images before and after coincident milling",
+            "tooltip": "Whether to acquire fluorescence images before and after coincident milling",
         },
     )
     orientation: Literal["SEM", "FIB", "MILLING"] = field(
         default="MILLING",
-        metadata={"help": "The orientation to perform coincident milling in"},
+        metadata={"tooltip": "The orientation to perform coincident milling in"},
     )
     channel_name: str = field(
         default="Red Channel",
-        metadata={"help": "The fluorescence channel to use for coincident milling"},
+        metadata={"tooltip": "The fluorescence channel to use for coincident milling"},
     )
     task_type: ClassVar[str] = "MILL_COINCIDENT"
     display_name: ClassVar[str] = "Coincident Milling"

--- a/fibsem/applications/autolamella/workflows/tasks/polishing.py
+++ b/fibsem/applications/autolamella/workflows/tasks/polishing.py
@@ -23,7 +23,7 @@ class MillPolishingTaskConfig(AutoLamellaTaskConfig):
         default=True,
         metadata={
             "label": "Link to Point of Interest",
-            "help": "Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated."},
+            "tooltip": "Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated."},
     )
     task_type: ClassVar[str] = "MILL_POLISHING"
     display_name: ClassVar[str] = "Polishing"

--- a/fibsem/applications/autolamella/workflows/tasks/reference_image.py
+++ b/fibsem/applications/autolamella/workflows/tasks/reference_image.py
@@ -17,11 +17,11 @@ class AcquireReferenceImageConfig(AutoLamellaTaskConfig):
     display_name: ClassVar[str] = "Acquire Reference Image"
     orientation: Literal["SEM", "FIB", "MILLING"] = field(
         default="MILLING",
-        metadata={"help": "The orientation to acquire reference images in (SEM, FIB, MILLING)", "items": ("SEM", "FIB", "MILLING")},
+        metadata={"tooltip": "The orientation to acquire reference images in (SEM, FIB, MILLING)", "items": ("SEM", "FIB", "MILLING")},
     ) # change to pose?
     filename: Optional[str] = field(
         default=None,
-        metadata={"help": "Custom filename for reference images. If None, auto-generates from last completed task name and timestamp."},
+        metadata={"tooltip": "Custom filename for reference images. If None, auto-generates from last completed task name and timestamp."},
     )
 
 

--- a/fibsem/applications/autolamella/workflows/tasks/rough.py
+++ b/fibsem/applications/autolamella/workflows/tasks/rough.py
@@ -30,19 +30,19 @@ class MillRoughTaskConfig(AutoLamellaTaskConfig):
         default=True,
         metadata={
             "label": "Synchronize Polishing Position",
-            "help": "Whether to synchronize the polishing position with the rough milling position (recommended.)"},
+            "tooltip": "Whether to synchronize the polishing position with the rough milling position (recommended.)"},
     )
     sync_to_poi: bool = field(
         default=True,
         metadata={
             "label": "Link to Point of Interest",
-            "help": "Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated."},
+            "tooltip": "Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated."},
     )
     reacquire_alignment_reference: bool = field(
         default=False,
         metadata={
             "label": "Reacquire Alignment Reference",
-            "help": "Whether to reacquire the alignment reference after milling"},
+            "tooltip": "Whether to reacquire the alignment reference after milling"},
     )
     task_type: ClassVar[str] = "MILL_ROUGH"
     display_name: ClassVar[str] = "Rough Milling"

--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -21,26 +21,26 @@ class SelectMillingPositionTaskConfig(AutoLamellaTaskConfig):
     milling_angle: float = field(
         default=15,
         metadata={
-            "help": "The angle between the FIB and sample used for milling",
-            "units": constants.DEGREE_SYMBOL,
+            "tooltip": "The angle between the FIB and sample used for milling",
+            "unit": constants.DEGREE_SYMBOL,
         },)
     auto_milling_alignment: bool = field(
         default=False,
         metadata={
             "label": "Auto Milling Angle Alignment",
-            "help": "Whether to automatically align for a milling position"},
+            "tooltip": "Whether to automatically align for a milling position"},
     )
     use_autofocus: bool = field(
         default=True,
         metadata={
             "label": "Use Autofocus",
-            "help": "Whether to autofocus before moving to the milling position"},
+            "tooltip": "Whether to autofocus before moving to the milling position"},
     )
     select_poi: bool = field(
         default=True,
         metadata={
             "label": "Select Point of Interest",
-            "help": "Whether to ask the user to select a point of interest in the FIB image"},
+            "tooltip": "Whether to ask the user to select a point of interest in the FIB image"},
     )
     task_type: ClassVar[str] = "SELECT_MILLING_POSITION"
     display_name: ClassVar[str] = "Select Milling Position"

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -31,30 +31,30 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
     milling_current: float = field(
         default=60.0e-12,  # in Amperes
         metadata={
-            'help': 'Milling current in Amperes',
-            'units': 'A',
+            'tooltip': 'Milling current in Amperes',
+            'unit': 'A',
             'scale': 1e12
         }
     )
     exposure_time: int = field(
         default=10,
         metadata={
-            'help': 'Exposure time in seconds',
-            'units': 's',
+            'tooltip': 'Exposure time in seconds',
+            'unit': 's',
             'scale': 1
         }
     )
     autofocus: bool = field(
         default=False,
         metadata={
-            "help": "Run a FIB autofocus before acquiring the reference image, so the "
+            "tooltip": "Run a FIB autofocus before acquiring the reference image, so the "
                     "points are placed on (and burned into) a focused image",
             "label": "Autofocus",
         },
     )
     coordinates: list[Point] = field(
         default_factory=list,
-        metadata={"help": "Spot burn positions in normalised image coordinates (0-1)"},
+        metadata={"tooltip": "Spot burn positions in normalised image coordinates (0-1)"},
     )
 
     @property

--- a/fibsem/applications/autolamella/workflows/tasks/trench.py
+++ b/fibsem/applications/autolamella/workflows/tasks/trench.py
@@ -27,15 +27,15 @@ class MillTrenchTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the MillTrenchTask."""
     align_reference: bool = field(
         default=False,  # whether to align to a trench reference image
-        metadata={"help": "Whether to align to a trench reference image"},
+        metadata={"tooltip": "Whether to align to a trench reference image"},
     )
     charge_neutralisation: bool = field(
         default=True,  # whether to perform charge neutralisation
-        metadata={"help": "Whether to perform charge neutralisation"},
+        metadata={"tooltip": "Whether to perform charge neutralisation"},
     )
     orientation: Optional[Literal["SEM", "FIB", "MILLING"]] = field(
         default=None,
-        metadata={"help": "The orientation to perform trench milling in", "items": ("SEM", "FIB", "MILLING", None)},
+        metadata={"tooltip": "The orientation to perform trench milling in", "items": ("SEM", "FIB", "MILLING", None)},
     )
     task_type: ClassVar[str] = "MILL_TRENCH"
     display_name: ClassVar[str] = "Trench Milling"

--- a/fibsem/applications/autolamella/workflows/tasks/undercut.py
+++ b/fibsem/applications/autolamella/workflows/tasks/undercut.py
@@ -28,12 +28,12 @@ class MillUndercutTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the MillUndercutTask."""
     orientation: Optional[Literal["SEM", "FIB", "MILLING"]] = field(
         default="SEM",
-        metadata={"help": "The orientation to perform undercut milling in", "items": ("SEM", "FIB", "MILLING", None)},
+        metadata={"tooltip": "The orientation to perform undercut milling in", "items": ("SEM", "FIB", "MILLING", None)},
     )
     milling_angles: List[float] = field(
         default_factory=lambda: [25, 20],  # in degrees
-        metadata={"help": "The angles to mill the undercuts at",
-                  "units": constants.DEGREE_SYMBOL},
+        metadata={"tooltip": "The angles to mill the undercuts at",
+                  "unit": constants.DEGREE_SYMBOL},
     )
     task_type: ClassVar[str] = "MILL_UNDERCUT"
     display_name: ClassVar[str] = "Undercut Milling"

--- a/fibsem/microscopes/_stage.py
+++ b/fibsem/microscopes/_stage.py
@@ -29,7 +29,7 @@ class SampleGrid:
     description: str = ""
     radius: float = field(
         default=GRID_RADIUS,
-        metadata={"units": "mm", "tooltip": "Radius of the sample grid", "scale": 1e3},
+        metadata={"unit": "mm", "tooltip": "Radius of the sample grid", "scale": 1e3},
     )
 
     def to_dict(self) -> dict:

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -52,18 +52,16 @@ DEFAULT_FIELD_METADATA: Dict[str, Any] = {
     "filepath": None,               # render a string field as a file picker rather than a line edit
 }
 
-# Alias -> canonical key. The AutoLamella task configs grew their own spellings
-# for two keys the rest of the codebase already had, and the form that renders
-# them reads only those spellings, so neither side is "the mistake" from the
-# other's point of view. The canonical names are the ones in
-# DEFAULT_FIELD_METADATA; the aliases are accepted so that a config written in
-# either dialect renders correctly in any form.
+# Superseded spelling -> the key that replaced it. Used **only** to make the
+# warning below say something useful; nothing resolves these at runtime, so a
+# field still declaring one renders without a tooltip or a unit suffix.
 #
-# Deliberately not a rename-and-drop: `help` and `units` are used by installed
-# out-of-tree plugins (the example repo and a lab CLEM plugin between them
-# declare `help` 21 times and `units` 9), and dropping the aliases would
-# silently strip their tooltips and unit suffixes. See FIB-384.
-METADATA_KEY_ALIASES: Dict[str, str] = {
+# The AutoLamella task configs used to spell two keys differently from the rest
+# of the codebase, and the form that rendered them read only those spellings. All
+# in-tree declarations were converted (FIB-384); this map exists so an
+# out-of-tree config that has not been converted is told exactly what to change,
+# rather than getting the generic "no form reads this" line.
+RENAMED_METADATA_KEYS: Dict[str, str] = {
     "help": "tooltip",
     "units": "unit",
 }
@@ -71,43 +69,33 @@ METADATA_KEY_ALIASES: Dict[str, str] = {
 _warned_metadata_keys: set = set()
 
 
-def _warn_unknown_metadata_keys(struct_cls: Type[Any], field_name: str, metadata: Dict[str, Any]) -> None:
+def _warn_unknown_metadata_keys(struct_cls: Type[Any], field_name: str, metadata: Mapping[str, Any]) -> None:
     """Log once for a metadata key nothing will ever read.
 
-    A mis-keyed field is silent today: the form renders, the value is right, and
-    the label or suffix is simply missing. Plugin authors have no way to discover
-    the vocabulary, so a typo costs an afternoon. Warned once per
+    A mis-keyed field is otherwise silent: the form renders, the value is right,
+    and the label or suffix is simply missing. Plugin authors have no way to
+    discover the vocabulary, so a typo costs an afternoon. Warned once per
     (class, field, key) because form metadata is re-read on every rebuild.
     """
-    known = set(DEFAULT_FIELD_METADATA) | set(METADATA_KEY_ALIASES)
     for key in metadata:
-        if key in known:
+        if key in DEFAULT_FIELD_METADATA:
             continue
         marker = (struct_cls.__qualname__, field_name, key)
         if marker in _warned_metadata_keys:
             continue
         _warned_metadata_keys.add(marker)
-        logging.warning(
-            f"{struct_cls.__name__}.{field_name} declares metadata key {key!r}, which no "
-            f"form reads. Known keys: {', '.join(sorted(known))}."
-        )
-
-
-def metadata_value(metadata: Mapping[str, Any], key: str, default: Any = None) -> Any:
-    """Read one metadata key, accepting either spelling.
-
-    For consumers that read a field's raw ``metadata`` rather than going through
-    ``get_fields_with_metadata`` -- the AutoLamella task-parameters form does, so
-    it never saw the normalised keys. Pass the canonical name; the alias is
-    consulted only if the canonical key is absent or ``None``.
-    """
-    value = metadata.get(key)
-    if value is None:
-        for alias, canonical in METADATA_KEY_ALIASES.items():
-            if canonical == key and metadata.get(alias) is not None:
-                value = metadata[alias]
-                break
-    return default if value is None else value
+        replacement = RENAMED_METADATA_KEYS.get(key)
+        if replacement is not None:
+            logging.warning(
+                f"{struct_cls.__name__}.{field_name} declares metadata key {key!r}, which was "
+                f"renamed to {replacement!r} and is no longer read. The field will render "
+                f"without it until the declaration is updated."
+            )
+        else:
+            logging.warning(
+                f"{struct_cls.__name__}.{field_name} declares metadata key {key!r}, which no "
+                f"form reads. Known keys: {', '.join(sorted(DEFAULT_FIELD_METADATA))}."
+            )
 
 
 def get_fields_with_metadata(struct_cls: Type[Any]) -> Dict[str, Dict[str, Any]]:
@@ -122,12 +110,6 @@ def get_fields_with_metadata(struct_cls: Type[Any]) -> Dict[str, Dict[str, Any]]
     for f in fields(struct_cls):
         declared = dict(f.metadata)
         _warn_unknown_metadata_keys(struct_cls, f.name, declared)
-        # An alias fills its canonical key only when the canonical one is absent,
-        # so a field declaring both keeps the canonical value rather than having
-        # it overwritten by whichever happens to be iterated last.
-        for alias, canonical in METADATA_KEY_ALIASES.items():
-            if alias in declared and declared.get(canonical) is None:
-                declared[canonical] = declared[alias]
         merged_metadata = {**default_metadata, **declared}
         field_metadata[f.name] = merged_metadata
     return field_metadata

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field, fields, asdict, InitVar
 from datetime import datetime
 from enum import Enum, auto
 from pathlib import Path
-from typing import List, Optional, Tuple, Union, Set, Any, Dict, Type, TypeVar, Literal, TYPE_CHECKING
+from typing import List, Mapping, Optional, Tuple, Union, Set, Any, Dict, Type, TypeVar, Literal, TYPE_CHECKING
 
 import numpy as np
 import tifffile as tff
@@ -49,6 +49,7 @@ DEFAULT_FIELD_METADATA: Dict[str, Any] = {
     "microscope_parameter": None,   # the corresponding microscope parameter name, if applicable (via get/set)
     "format_fn": None,              # function to format the value for display
     "format_fn_kwargs": None,       # kwargs for the format function # NOTE: unused yet
+    "filepath": None,               # render a string field as a file picker rather than a line edit
 }
 
 # Alias -> canonical key. The AutoLamella task configs grew their own spellings
@@ -67,10 +68,6 @@ METADATA_KEY_ALIASES: Dict[str, str] = {
     "units": "unit",
 }
 
-# Keys that are read by a form but were never listed in DEFAULT_FIELD_METADATA.
-# Tracked here so `_warn_unknown_metadata_keys` does not report them as typos.
-_EXTRA_KNOWN_METADATA_KEYS = frozenset({"filepath"})
-
 _warned_metadata_keys: set = set()
 
 
@@ -82,7 +79,7 @@ def _warn_unknown_metadata_keys(struct_cls: Type[Any], field_name: str, metadata
     the vocabulary, so a typo costs an afternoon. Warned once per
     (class, field, key) because form metadata is re-read on every rebuild.
     """
-    known = set(DEFAULT_FIELD_METADATA) | set(METADATA_KEY_ALIASES) | _EXTRA_KNOWN_METADATA_KEYS
+    known = set(DEFAULT_FIELD_METADATA) | set(METADATA_KEY_ALIASES)
     for key in metadata:
         if key in known:
             continue
@@ -96,7 +93,7 @@ def _warn_unknown_metadata_keys(struct_cls: Type[Any], field_name: str, metadata
         )
 
 
-def metadata_value(metadata: Dict[str, Any], key: str, default: Any = None) -> Any:
+def metadata_value(metadata: Mapping[str, Any], key: str, default: Any = None) -> Any:
     """Read one metadata key, accepting either spelling.
 
     For consumers that read a field's raw ``metadata`` rather than going through

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -51,6 +51,68 @@ DEFAULT_FIELD_METADATA: Dict[str, Any] = {
     "format_fn_kwargs": None,       # kwargs for the format function # NOTE: unused yet
 }
 
+# Alias -> canonical key. The AutoLamella task configs grew their own spellings
+# for two keys the rest of the codebase already had, and the form that renders
+# them reads only those spellings, so neither side is "the mistake" from the
+# other's point of view. The canonical names are the ones in
+# DEFAULT_FIELD_METADATA; the aliases are accepted so that a config written in
+# either dialect renders correctly in any form.
+#
+# Deliberately not a rename-and-drop: `help` and `units` are used by installed
+# out-of-tree plugins (the example repo and a lab CLEM plugin between them
+# declare `help` 21 times and `units` 9), and dropping the aliases would
+# silently strip their tooltips and unit suffixes. See FIB-384.
+METADATA_KEY_ALIASES: Dict[str, str] = {
+    "help": "tooltip",
+    "units": "unit",
+}
+
+# Keys that are read by a form but were never listed in DEFAULT_FIELD_METADATA.
+# Tracked here so `_warn_unknown_metadata_keys` does not report them as typos.
+_EXTRA_KNOWN_METADATA_KEYS = frozenset({"filepath"})
+
+_warned_metadata_keys: set = set()
+
+
+def _warn_unknown_metadata_keys(struct_cls: Type[Any], field_name: str, metadata: Dict[str, Any]) -> None:
+    """Log once for a metadata key nothing will ever read.
+
+    A mis-keyed field is silent today: the form renders, the value is right, and
+    the label or suffix is simply missing. Plugin authors have no way to discover
+    the vocabulary, so a typo costs an afternoon. Warned once per
+    (class, field, key) because form metadata is re-read on every rebuild.
+    """
+    known = set(DEFAULT_FIELD_METADATA) | set(METADATA_KEY_ALIASES) | _EXTRA_KNOWN_METADATA_KEYS
+    for key in metadata:
+        if key in known:
+            continue
+        marker = (struct_cls.__qualname__, field_name, key)
+        if marker in _warned_metadata_keys:
+            continue
+        _warned_metadata_keys.add(marker)
+        logging.warning(
+            f"{struct_cls.__name__}.{field_name} declares metadata key {key!r}, which no "
+            f"form reads. Known keys: {', '.join(sorted(known))}."
+        )
+
+
+def metadata_value(metadata: Dict[str, Any], key: str, default: Any = None) -> Any:
+    """Read one metadata key, accepting either spelling.
+
+    For consumers that read a field's raw ``metadata`` rather than going through
+    ``get_fields_with_metadata`` -- the AutoLamella task-parameters form does, so
+    it never saw the normalised keys. Pass the canonical name; the alias is
+    consulted only if the canonical key is absent or ``None``.
+    """
+    value = metadata.get(key)
+    if value is None:
+        for alias, canonical in METADATA_KEY_ALIASES.items():
+            if canonical == key and metadata.get(alias) is not None:
+                value = metadata[alias]
+                break
+    return default if value is None else value
+
+
 def get_fields_with_metadata(struct_cls: Type[Any]) -> Dict[str, Dict[str, Any]]:
     """Return dataclass fields with metadata, filling any missing keys with defaults."""
     # Prefer a struct-level DEFAULT_METADATA if provided, layering on top of the
@@ -61,7 +123,15 @@ def get_fields_with_metadata(struct_cls: Type[Any]) -> Dict[str, Dict[str, Any]]
     }
     field_metadata: Dict[str, Dict[str, Any]] = {}
     for f in fields(struct_cls):
-        merged_metadata = {**default_metadata, **dict(f.metadata)}
+        declared = dict(f.metadata)
+        _warn_unknown_metadata_keys(struct_cls, f.name, declared)
+        # An alias fills its canonical key only when the canonical one is absent,
+        # so a field declaring both keeps the canonical value rather than having
+        # it overwritten by whichever happens to be iterated last.
+        for alias, canonical in METADATA_KEY_ALIASES.items():
+            if alias in declared and declared.get(canonical) is None:
+                declared[canonical] = declared[alias]
+        merged_metadata = {**default_metadata, **declared}
         field_metadata[f.name] = merged_metadata
     return field_metadata
 

--- a/fibsem/ui/widgets/autolamella_task_config_widget.py
+++ b/fibsem/ui/widgets/autolamella_task_config_widget.py
@@ -30,6 +30,7 @@ from superqt import QCollapsible
 
 from fibsem import utils
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.structures import metadata_value
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import TitledPanel
@@ -103,7 +104,8 @@ class IntParameterWidget(ParameterWidget):
         super().__init__(name, value, annotation)
         self.metadata = metadata or {}
         self.scale = self.metadata.get('scale', 1.0)
-        self.units = self.metadata.get('units', '')
+        # Canonical spelling first, falling back to this form's own `units` (FIB-384)
+        self.units = metadata_value(self.metadata, 'unit', '')
 
     def create_widget(self) -> QWidget:
         self.widget = QSpinBox()
@@ -150,7 +152,8 @@ class FloatParameterWidget(ParameterWidget):
         super().__init__(name, value, annotation)
         self.metadata = metadata or {}
         self.scale = self.metadata.get('scale', 1.0)
-        self.units = self.metadata.get('units', '')
+        # Canonical spelling first, falling back to this form's own `units` (FIB-384)
+        self.units = metadata_value(self.metadata, 'unit', '')
         
     def create_widget(self) -> QWidget:
         self.widget = QDoubleSpinBox()
@@ -509,8 +512,11 @@ class AutoLamellaTaskConfigWidget(QWidget):
                     
                     # Create label with tooltip if available
                     label = QLabel(self._format_field_name(param_name))
-                    if hasattr(field, 'metadata') and 'help' in field.metadata:
-                        label.setToolTip(field.metadata['help'])
+                    # Either spelling: this form's own `help`, or the canonical
+                    # `tooltip` every other form reads (FIB-384).
+                    tooltip = metadata_value(getattr(field, 'metadata', {}), 'tooltip')
+                    if tooltip:
+                        label.setToolTip(tooltip)
                         
                     self.grid_layout.addWidget(label, self.current_row, 0)
                     self.grid_layout.addWidget(widget, self.current_row, 1)
@@ -668,8 +674,11 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
 
                 # Create label with tooltip if available
                 label = QLabel(self._format_field_name(param_name, field.metadata))
-                if hasattr(field, 'metadata') and 'help' in field.metadata:
-                    label.setToolTip(field.metadata['help'])
+                # Either spelling: this form's own `help`, or the canonical
+                # `tooltip` every other form reads (FIB-384).
+                tooltip = metadata_value(getattr(field, 'metadata', {}), 'tooltip')
+                if tooltip:
+                    label.setToolTip(tooltip)
 
                 self.grid_layout.addWidget(label, self.current_row, 0)
                 self.grid_layout.addWidget(widget, self.current_row, 1)

--- a/fibsem/ui/widgets/autolamella_task_config_widget.py
+++ b/fibsem/ui/widgets/autolamella_task_config_widget.py
@@ -30,7 +30,6 @@ from superqt import QCollapsible
 
 from fibsem import utils
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
-from fibsem.structures import metadata_value
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import TitledPanel
@@ -104,8 +103,7 @@ class IntParameterWidget(ParameterWidget):
         super().__init__(name, value, annotation)
         self.metadata = metadata or {}
         self.scale = self.metadata.get('scale', 1.0)
-        # Canonical spelling first, falling back to this form's own `units` (FIB-384)
-        self.units = metadata_value(self.metadata, 'unit', '')
+        self.units = self.metadata.get('unit', '')
 
     def create_widget(self) -> QWidget:
         self.widget = QSpinBox()
@@ -152,8 +150,7 @@ class FloatParameterWidget(ParameterWidget):
         super().__init__(name, value, annotation)
         self.metadata = metadata or {}
         self.scale = self.metadata.get('scale', 1.0)
-        # Canonical spelling first, falling back to this form's own `units` (FIB-384)
-        self.units = metadata_value(self.metadata, 'unit', '')
+        self.units = self.metadata.get('unit', '')
         
     def create_widget(self) -> QWidget:
         self.widget = QDoubleSpinBox()
@@ -512,9 +509,7 @@ class AutoLamellaTaskConfigWidget(QWidget):
                     
                     # Create label with tooltip if available
                     label = QLabel(self._format_field_name(param_name))
-                    # Either spelling: this form's own `help`, or the canonical
-                    # `tooltip` every other form reads (FIB-384).
-                    tooltip = metadata_value(getattr(field, 'metadata', {}), 'tooltip')
+                    tooltip = getattr(field, 'metadata', {}).get('tooltip')
                     if tooltip:
                         label.setToolTip(tooltip)
                         
@@ -674,9 +669,7 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
 
                 # Create label with tooltip if available
                 label = QLabel(self._format_field_name(param_name, field.metadata))
-                # Either spelling: this form's own `help`, or the canonical
-                # `tooltip` every other form reads (FIB-384).
-                tooltip = metadata_value(getattr(field, 'metadata', {}), 'tooltip')
+                tooltip = getattr(field, 'metadata', {}).get('tooltip')
                 if tooltip:
                     label.setToolTip(tooltip)
 

--- a/tests/fixtures/plugin/fibsem_test_plugin/tasks.py
+++ b/tests/fixtures/plugin/fibsem_test_plugin/tasks.py
@@ -14,11 +14,7 @@ class FixtureTaskConfig(AutoLamellaTaskConfig):
     task_type: ClassVar[str] = TASK_TYPE
     display_name: ClassVar[str] = "Fixture Task"
 
-    # Deliberately the alias spelling, not the canonical `tooltip`. The in-tree
-    # configs were all renamed to canonical (FIB-384), so without this nothing in
-    # CI would exercise the alias path -- and that path exists precisely for
-    # out-of-tree plugins, which are the code CI cannot see. Do not "fix" this.
-    number: int = field(default=7, metadata={"help": "A round-trippable parameter"})
+    number: int = field(default=7, metadata={"tooltip": "A round-trippable parameter"})
 
 
 class FixtureTask(AutoLamellaTask):

--- a/tests/fixtures/plugin/fibsem_test_plugin/tasks.py
+++ b/tests/fixtures/plugin/fibsem_test_plugin/tasks.py
@@ -14,6 +14,10 @@ class FixtureTaskConfig(AutoLamellaTaskConfig):
     task_type: ClassVar[str] = TASK_TYPE
     display_name: ClassVar[str] = "Fixture Task"
 
+    # Deliberately the alias spelling, not the canonical `tooltip`. The in-tree
+    # configs were all renamed to canonical (FIB-384), so without this nothing in
+    # CI would exercise the alias path -- and that path exists precisely for
+    # out-of-tree plugins, which are the code CI cannot see. Do not "fix" this.
     number: int = field(default=7, metadata={"help": "A round-trippable parameter"})
 
 

--- a/tests/test_field_metadata_keys.py
+++ b/tests/test_field_metadata_keys.py
@@ -1,15 +1,15 @@
-"""One metadata vocabulary, two spellings accepted.
+"""One metadata vocabulary, and a diagnostic for anything outside it.
 
-`DEFAULT_FIELD_METADATA` is the canonical set, and the pattern, strategy and
-milling-settings forms all read it. The AutoLamella task-parameters form grew its
-own spellings for two of those keys -- `help` for `tooltip`, `units` for `unit` --
-and reads only those, so a field written for one form renders half-blank in the
-other: right value, no tooltip, no unit suffix, nothing logged.
+`DEFAULT_FIELD_METADATA` is the vocabulary every config form reads. The
+AutoLamella task configs used to spell two of those keys differently -- `help`
+for `tooltip`, `units` for `unit` -- and the form rendering them read only those
+spellings, so a field written for one form rendered half-blank in the other:
+right value, no tooltip, no unit suffix, nothing logged.
 
-Both spellings are now accepted everywhere (FIB-384). Deliberately *not* a
-rename-and-drop: installed out-of-tree plugins declare `help` and `units` between
-them dozens of times, and dropping the aliases would silently strip their
-tooltips and suffixes.
+All in-tree declarations were converted and the old spellings are **not**
+accepted (FIB-384). What makes that safe rather than silent is the warning: a
+field still declaring a superseded key is told which key replaced it, instead of
+simply losing its tooltip.
 """
 
 import logging
@@ -19,9 +19,8 @@ import pytest
 
 from fibsem.structures import (
     DEFAULT_FIELD_METADATA,
-    METADATA_KEY_ALIASES,
+    RENAMED_METADATA_KEYS,
     get_fields_with_metadata,
-    metadata_value,
 )
 import fibsem.structures as fstructures
 
@@ -30,23 +29,20 @@ import fibsem.structures as fstructures
 class MetadataProbe:
     """One field per spelling situation the forms have to cope with."""
 
-    task_dialect: float = field(
-        default=1.0, metadata={"help": "task spelling", "units": "m", "scale": 1e6}
+    superseded: float = field(
+        default=1.0, metadata={"help": "old spelling", "units": "m", "scale": 1e6}
     )
     canonical: float = field(
-        default=1.0, metadata={"tooltip": "canonical spelling", "unit": "m"}
-    )
-    both_spellings: float = field(
-        default=1.0, metadata={"tooltip": "canonical wins", "help": "alias loses"}
+        default=1.0, metadata={"tooltip": "current spelling", "unit": "m"}
     )
     neither: float = field(default=1.0, metadata={"label": "No text at all"})
 
 
-def test_every_alias_points_at_a_canonical_key():
-    """The alias map cannot name a key the vocabulary does not define."""
-    for alias, canonical in METADATA_KEY_ALIASES.items():
-        assert canonical in DEFAULT_FIELD_METADATA, f"{alias!r} -> unknown key {canonical!r}"
-        assert alias not in DEFAULT_FIELD_METADATA, f"{alias!r} is both an alias and canonical"
+def test_every_renamed_key_points_at_a_real_one():
+    """The diagnostic map cannot advise a key the vocabulary does not define."""
+    for old, new in RENAMED_METADATA_KEYS.items():
+        assert new in DEFAULT_FIELD_METADATA, f"{old!r} -> unknown key {new!r}"
+        assert old not in DEFAULT_FIELD_METADATA, f"{old!r} is both superseded and current"
 
 
 def test_filepath_is_part_of_the_vocabulary():
@@ -62,31 +58,24 @@ def test_filepath_is_part_of_the_vocabulary():
     assert not get_fields_with_metadata(MetadataProbe)["neither"]["filepath"]
 
 
-def test_the_task_dialect_fills_the_canonical_keys():
-    """A config written with `help`/`units` renders in the canonical-reading forms."""
-    meta = get_fields_with_metadata(MetadataProbe)["task_dialect"]
+def test_a_superseded_key_is_not_resolved():
+    """The old spellings are gone, not aliased.
 
-    assert meta["tooltip"] == "task spelling"
-    assert meta["unit"] == "m"
-
-
-def test_the_aliases_survive_for_readers_that_still_use_them():
-    """Normalising must not remove the original keys.
-
-    The task-parameters form reads a field's raw metadata in places, and existing
-    plugins declare the alias spellings. Filling the canonical key is additive.
+    This is the whole point of the decision: one vocabulary, not two accepted
+    forever. A field still declaring `help` renders without a tooltip -- and is
+    warned about, which is what makes dropping them safe rather than silent.
     """
-    meta = get_fields_with_metadata(MetadataProbe)["task_dialect"]
+    meta = get_fields_with_metadata(MetadataProbe)["superseded"]
 
-    assert meta["help"] == "task spelling"
-    assert meta["units"] == "m"
+    assert meta["tooltip"] is None
+    assert meta["unit"] is None
 
 
-def test_canonical_wins_when_a_field_declares_both():
-    """Otherwise the winner would depend on dict iteration order."""
-    meta = get_fields_with_metadata(MetadataProbe)["both_spellings"]
+def test_the_current_spellings_are_read():
+    meta = get_fields_with_metadata(MetadataProbe)["canonical"]
 
-    assert meta["tooltip"] == "canonical wins"
+    assert meta["tooltip"] == "current spelling"
+    assert meta["unit"] == "m"
 
 
 def test_a_field_declaring_neither_spelling_gets_the_default():
@@ -96,24 +85,20 @@ def test_a_field_declaring_neither_spelling_gets_the_default():
     assert meta["unit"] is None
 
 
-@pytest.mark.parametrize(
-    "metadata,expected",
-    [
-        ({"tooltip": "canonical"}, "canonical"),
-        ({"help": "alias"}, "alias"),
-        ({"tooltip": "canonical", "help": "alias"}, "canonical"),
-        ({}, None),
-        ({"tooltip": None, "help": "alias"}, "alias"),
-    ],
-    ids=["canonical", "alias", "both", "neither", "canonical_is_none"],
-)
-def test_metadata_value_reads_either_spelling(metadata, expected):
-    """For consumers reading raw field metadata rather than the normalised dict."""
-    assert metadata_value(metadata, "tooltip") == expected
+def test_a_superseded_key_is_told_what_replaced_it(caplog):
+    """A generic "no form reads this" line is useless to someone with `help`.
 
+    Out-of-tree configs are the ones that still declare the old spellings, and
+    their authors cannot see this vocabulary. The warning names the replacement
+    so the fix is obvious from the log alone.
+    """
+    fstructures._warned_metadata_keys.clear()
+    with caplog.at_level(logging.WARNING):
+        get_fields_with_metadata(MetadataProbe)
 
-def test_metadata_value_returns_the_default_rather_than_none():
-    assert metadata_value({}, "unit", "") == ""
+    messages = [r.message for r in caplog.records]
+    assert any("'help'" in m and "renamed to 'tooltip'" in m for m in messages)
+    assert any("'units'" in m and "renamed to 'unit'" in m for m in messages)
 
 
 def test_an_unreadable_metadata_key_is_reported_once(caplog):
@@ -141,32 +126,37 @@ def test_an_unreadable_metadata_key_is_reported_once(caplog):
 
 
 def test_a_known_key_is_never_reported(caplog):
-    """Including the aliases and the keys read by forms but absent from the dict."""
+    """Every key in the vocabulary, including ones added late like `filepath`."""
 
     @dataclass
     class Fine:
-        a: float = field(default=1.0, metadata={"help": "alias", "units": "m"})
-        b: str = field(default="", metadata={"filepath": True, "tooltip": "t"})
+        a: float = field(default=1.0, metadata={"tooltip": "t", "unit": "m"})
+        b: str = field(default="", metadata={"filepath": True, "label": "L"})
 
     fstructures._warned_metadata_keys.clear()
     with caplog.at_level(logging.WARNING):
         get_fields_with_metadata(Fine)
 
-    assert [r.message for r in caplog.records if "no form reads" in r.message] == []
+    assert [r.message for r in caplog.records if "declares metadata key" in r.message] == []
 
 
 def test_in_tree_configs_declare_no_unreadable_keys(caplog):
-    """Every registered task config, rendered through the real vocabulary.
+    """Every built-in task config, rendered through the real vocabulary.
 
     Catches a typo in a config that no test opens a form for -- which is most of
     them.
+
+    Deliberately `BUILTIN_TASKS` rather than `get_tasks()`: the latter includes
+    whatever plugins happen to be pip-installed, so this would pass or fail on
+    the contents of the developer's environment. Plugin configs are exactly the
+    ones we cannot fix from here -- the warning is what serves them.
     """
-    from fibsem.applications.autolamella.workflows.tasks import get_tasks
+    from fibsem.applications.autolamella.workflows.tasks import BUILTIN_TASKS
 
     fstructures._warned_metadata_keys.clear()
     with caplog.at_level(logging.WARNING):
-        for task in get_tasks().values():
+        for task in BUILTIN_TASKS.values():
             get_fields_with_metadata(task.config_cls)
 
-    offenders = [r.message for r in caplog.records if "no form reads" in r.message]
+    offenders = [r.message for r in caplog.records if "declares metadata key" in r.message]
     assert offenders == []

--- a/tests/test_field_metadata_keys.py
+++ b/tests/test_field_metadata_keys.py
@@ -1,0 +1,160 @@
+"""One metadata vocabulary, two spellings accepted.
+
+`DEFAULT_FIELD_METADATA` is the canonical set, and the pattern, strategy and
+milling-settings forms all read it. The AutoLamella task-parameters form grew its
+own spellings for two of those keys -- `help` for `tooltip`, `units` for `unit` --
+and reads only those, so a field written for one form renders half-blank in the
+other: right value, no tooltip, no unit suffix, nothing logged.
+
+Both spellings are now accepted everywhere (FIB-384). Deliberately *not* a
+rename-and-drop: installed out-of-tree plugins declare `help` and `units` between
+them dozens of times, and dropping the aliases would silently strip their
+tooltips and suffixes.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+import pytest
+
+from fibsem.structures import (
+    DEFAULT_FIELD_METADATA,
+    METADATA_KEY_ALIASES,
+    get_fields_with_metadata,
+    metadata_value,
+)
+import fibsem.structures as fstructures
+
+
+@dataclass
+class MetadataProbe:
+    """One field per spelling situation the forms have to cope with."""
+
+    task_dialect: float = field(
+        default=1.0, metadata={"help": "task spelling", "units": "m", "scale": 1e6}
+    )
+    canonical: float = field(
+        default=1.0, metadata={"tooltip": "canonical spelling", "unit": "m"}
+    )
+    both_spellings: float = field(
+        default=1.0, metadata={"tooltip": "canonical wins", "help": "alias loses"}
+    )
+    neither: float = field(default=1.0, metadata={"label": "No text at all"})
+
+
+def test_every_alias_points_at_a_canonical_key():
+    """The alias map cannot name a key the vocabulary does not define."""
+    for alias, canonical in METADATA_KEY_ALIASES.items():
+        assert canonical in DEFAULT_FIELD_METADATA, f"{alias!r} -> unknown key {canonical!r}"
+        assert alias not in DEFAULT_FIELD_METADATA, f"{alias!r} is both an alias and canonical"
+
+
+def test_the_task_dialect_fills_the_canonical_keys():
+    """A config written with `help`/`units` renders in the canonical-reading forms."""
+    meta = get_fields_with_metadata(MetadataProbe)["task_dialect"]
+
+    assert meta["tooltip"] == "task spelling"
+    assert meta["unit"] == "m"
+
+
+def test_the_aliases_survive_for_readers_that_still_use_them():
+    """Normalising must not remove the original keys.
+
+    The task-parameters form reads a field's raw metadata in places, and existing
+    plugins declare the alias spellings. Filling the canonical key is additive.
+    """
+    meta = get_fields_with_metadata(MetadataProbe)["task_dialect"]
+
+    assert meta["help"] == "task spelling"
+    assert meta["units"] == "m"
+
+
+def test_canonical_wins_when_a_field_declares_both():
+    """Otherwise the winner would depend on dict iteration order."""
+    meta = get_fields_with_metadata(MetadataProbe)["both_spellings"]
+
+    assert meta["tooltip"] == "canonical wins"
+
+
+def test_a_field_declaring_neither_spelling_gets_the_default():
+    meta = get_fields_with_metadata(MetadataProbe)["neither"]
+
+    assert meta["tooltip"] is None
+    assert meta["unit"] is None
+
+
+@pytest.mark.parametrize(
+    "metadata,expected",
+    [
+        ({"tooltip": "canonical"}, "canonical"),
+        ({"help": "alias"}, "alias"),
+        ({"tooltip": "canonical", "help": "alias"}, "canonical"),
+        ({}, None),
+        ({"tooltip": None, "help": "alias"}, "alias"),
+    ],
+    ids=["canonical", "alias", "both", "neither", "canonical_is_none"],
+)
+def test_metadata_value_reads_either_spelling(metadata, expected):
+    """For consumers reading raw field metadata rather than the normalised dict."""
+    assert metadata_value(metadata, "tooltip") == expected
+
+
+def test_metadata_value_returns_the_default_rather_than_none():
+    assert metadata_value({}, "unit", "") == ""
+
+
+def test_an_unreadable_metadata_key_is_reported_once(caplog):
+    """A mis-keyed field is otherwise completely silent.
+
+    The form renders, the value is right, and the label or suffix is simply
+    missing -- which is an afternoon of confusion for a plugin author who has no
+    way to discover the vocabulary. Warned once, because form metadata is re-read
+    on every rebuild and this would otherwise repeat on every keystroke-driven
+    form refresh.
+    """
+
+    @dataclass
+    class Misspelled:
+        speed: float = field(default=1.0, metadata={"toolip": "typo"})
+
+    fstructures._warned_metadata_keys.clear()
+    with caplog.at_level(logging.WARNING):
+        get_fields_with_metadata(Misspelled)
+        get_fields_with_metadata(Misspelled)
+
+    warnings = [r for r in caplog.records if "toolip" in r.message]
+    assert len(warnings) == 1
+    assert "which no form reads" in warnings[0].message
+
+
+def test_a_known_key_is_never_reported(caplog):
+    """Including the aliases and the keys read by forms but absent from the dict."""
+
+    @dataclass
+    class Fine:
+        a: float = field(default=1.0, metadata={"help": "alias", "units": "m"})
+        b: str = field(default="", metadata={"filepath": True, "tooltip": "t"})
+
+    fstructures._warned_metadata_keys.clear()
+    with caplog.at_level(logging.WARNING):
+        get_fields_with_metadata(Fine)
+
+    assert [r.message for r in caplog.records if "no form reads" in r.message] == []
+
+
+def test_in_tree_configs_declare_no_unreadable_keys(caplog):
+    """Every registered task config, rendered through the real vocabulary.
+
+    Catches a typo in a config that no test opens a form for -- which is most of
+    them.
+    """
+    from fibsem.applications.autolamella.workflows.tasks import get_tasks
+
+    fstructures._warned_metadata_keys.clear()
+    with caplog.at_level(logging.WARNING):
+        for task in get_tasks().values():
+            get_fields_with_metadata(task.config_cls)
+
+    offenders = [r.message for r in caplog.records if "no form reads" in r.message]
+    assert offenders == []

--- a/tests/test_field_metadata_keys.py
+++ b/tests/test_field_metadata_keys.py
@@ -14,7 +14,6 @@ tooltips and suffixes.
 
 import logging
 from dataclasses import dataclass, field
-from typing import ClassVar
 
 import pytest
 
@@ -48,6 +47,19 @@ def test_every_alias_points_at_a_canonical_key():
     for alias, canonical in METADATA_KEY_ALIASES.items():
         assert canonical in DEFAULT_FIELD_METADATA, f"{alias!r} -> unknown key {canonical!r}"
         assert alias not in DEFAULT_FIELD_METADATA, f"{alias!r} is both an alias and canonical"
+
+
+def test_filepath_is_part_of_the_vocabulary():
+    """Both milling forms read it, so it belongs in the canonical dict.
+
+    It was read but never listed, which made it undiscoverable to exactly the
+    plugin authors this vocabulary exists for. The default has to stay falsy:
+    both forms select the file-picker control with a truthy ``m.get("filepath")``,
+    so a truthy default would turn every string field into a file picker.
+    """
+    assert "filepath" in DEFAULT_FIELD_METADATA
+    assert not DEFAULT_FIELD_METADATA["filepath"]
+    assert not get_fields_with_metadata(MetadataProbe)["neither"]["filepath"]
 
 
 def test_the_task_dialect_fills_the_canonical_keys():


### PR DESCRIPTION
Fixes FIB-384. First step of the **Config Forms and Plugin Widgets** project.

## The problem, measured

`DEFAULT_FIELD_METADATA` is the vocabulary. Counting what each form actually reads:

| form | keys read |
|---|---|
| pattern | 15 |
| strategy | 15 |
| milling settings | 14 |
| **task parameters** | **4** — `items`, `scale`, plus its own `units` and `help` |

So it isn't a three-way divergence as the issue framed it — the milling family already agrees, and the task form is the outlier: it reads a quarter of the vocabulary, and the two keys it does read for text and units are spelled differently from everywhere else.

A field written for one form therefore renders half-blank in the other — right value, no tooltip, no unit suffix, nothing logged. The clearest in-tree proof is `microscopes/_stage.py`, which declared **both dialects in one metadata dict**:

```python
metadata={"units": "mm", "tooltip": "Radius of the sample grid", "scale": 1e3}
```

Whichever form rendered that, one of those two was always ignored.

## The change: one vocabulary, not two accepted forever

- **All 37 in-tree declarations renamed** to `tooltip` / `unit`, across 11 files.
- **The task form reads the canonical keys directly.** No alias resolution anywhere — `get_fields_with_metadata` resolves nothing, and the old spellings are simply not read.
- **A key nothing reads is now logged once** per (class, field, key). Once, because form metadata is re-read on every rebuild — a repeating warning was the exact noise problem fixed in #301.
- **A *superseded* key gets a targeted warning**: a field still declaring `help` is told it was renamed to `tooltip` and that the field will render without it, rather than getting the generic "no form reads this" line. `RENAMED_METADATA_KEYS` exists only to phrase that message; nothing resolves it.
- **`filepath` is now in the vocabulary.** Both milling forms read it; it was never listed, which made it undiscoverable to exactly the plugin authors this exists for.

An earlier revision of this PR kept `help`/`units` as permanent aliases. That traded a one-time conversion for a compat surface carried indefinitely, and the argument for it was weaker than it looked — **the warning is what makes dropping them safe rather than silent**. A plugin that hasn't converted loses a tooltip and is told precisely why.

## Verification

- **The rename is behaviour-preserving**: resolved metadata for all 19 registered config classes (90 fields) snapshotted before and after, asserted equal.
- **No rendering change for existing configs**: label tooltips and control suffixes for every registered task config byte-identical to `main`.
- **Adding `filepath` changed no control**: every registered pattern and strategy rendered, all 149 rows diffed against `main` — identical, with the single `QFilePathLineEdit` still the only one. Its default must stay falsy, since both forms select the file picker with a truthy `m.get("filepath")`. Pinned by a test.
- The in-tree sweep iterates `BUILTIN_TASKS`, not `get_tasks()` — the latter includes whatever plugins are pip-installed, so it passed or failed on the contents of a developer's environment.

Full suite **3348 passed**. Decorator audit clean. All changed files parse under 3.8.

## Companion change

`fibsem-os/fibsem-plugin-example` is updated in the same breath (committed locally, not yet pushed): it declared the old spellings and, worse, carried a comment documenting the divergence as a fact of life. It's the pattern plugin authors copy, so it shouldn't demonstrate keys that stopped working.

The other known out-of-tree plugin (a lab CLEM plugin) still declares `help`/`units`; it will lose those tooltips and log the targeted warning until converted.

## Follow-ups

- **FIB-531** — declare metadata through a typed constructor, so a wrong key is a `TypeError` at import rather than a warning at runtime. Also converts the example repo to that API.
- **FIB-526** — the larger win, untouched here: the task form still reads only four keys, so `minimum`/`maximum`/`step`/`decimals`/`hidden`/`advanced` remain unavailable to task configs.