### PR TITLE
[ui] Consolidate colour onto the palette tokens

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -76,6 +76,9 @@ from fibsem.ui.widgets.lamella_workflow_widget import LamellaWorkflowWidget
 from fibsem.ui.widgets.notifications import NotificationBell, ToastManager
 from fibsem.ui.widgets.workflow_timeline_widget import WorkflowProgressWidget
 from fibsem.utils import format_duration
+from fibsem.ui.tokens import (
+    TEXT_COLOR,
+)
 
 # Suppress a specific upstream Napari/NumPy warning from shapes miter computation.
 warnings.filterwarnings(
@@ -1382,7 +1385,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         # Experiment name label
         self.experiment_name_label = QLabel("No Experiment")
-        self.experiment_name_label.setStyleSheet("color: #d6d6d6; font-size: 12px;")
+        self.experiment_name_label.setStyleSheet(f"color: {TEXT_COLOR}; font-size: 12px;")
 
         # Notification bell
         self.notification_bell = NotificationBell(self)

--- a/fibsem/correlation/ui/widgets/coordinate_list_widget.py
+++ b/fibsem/correlation/ui/widgets/coordinate_list_widget.py
@@ -30,6 +30,10 @@ from fibsem.correlation.structures import Coordinate, PointType
 from fibsem.ui import stylesheets
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueSpinBox
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+    GRAY_TEXT_COLOR,
+)
 
 _DRAG_HANDLE_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
@@ -135,7 +139,7 @@ class _CoordinateListHeader(QWidget):
     ) -> None:
         self._default_color = default_color
         super().__init__(parent)
-        self.setStyleSheet("background: #1e2124;")
+        self.setStyleSheet(f"background: {CANVAS_BG};")
         self.setFixedHeight(_ROW_HEIGHT)
 
         layout = QHBoxLayout(self)
@@ -230,7 +234,7 @@ class CoordinateRowWidget(QWidget):
         self.name_label.setFixedWidth(name_width)
         # Omit `background: transparent` — it's the QLabel default, and an
         # unscoped rule bleeds into this label's QToolTip background.
-        self.name_label.setStyleSheet("color: #F0F1F2; font-size: 11px;")
+        self.name_label.setStyleSheet(f"color: {GRAY_TEXT_COLOR}; font-size: 11px;")
         self.name_label.setToolTip("Auto-generated coordinate name")
         layout.addWidget(self.name_label)
 

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -2877,9 +2877,9 @@ class CorrelationTabWidget(QWidget):
         self._fib_canvas.reset_view()
         self._fm_display.canvas.reset_view()
 
-        fig, (ax_fib, ax_fm) = plt.subplots(1, 2, figsize=(16, 8), facecolor=f"{CANVAS_BG}")
+        fig, (ax_fib, ax_fm) = plt.subplots(1, 2, figsize=(16, 8), facecolor=CANVAS_BG)
         for ax in (ax_fib, ax_fm):
-            ax.set_facecolor(f"{CANVAS_BG}")
+            ax.set_facecolor(CANVAS_BG)
 
         self._fib_canvas.render_to_axes(ax_fib)
         ax_fib.set_title("FIB", color="white", fontsize=12)

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -110,6 +110,9 @@ from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
 )
 from fibsem.correlation.ui.widgets.refractive_index_widget import RefractiveIndexWidget
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 _FIT_METHODS = ["None", "Hole", "Gaussian"]
 
@@ -1599,7 +1602,7 @@ class CorrelationTabWidget(QWidget):
         right_layout.addWidget(self._tabs, stretch=1)
 
         run_bar = QWidget()
-        run_bar.setStyleSheet("background: #1e2124; border-top: 1px solid #3a3d42;")
+        run_bar.setStyleSheet(f"background: {CANVAS_BG}; border-top: 1px solid #3a3d42;")
         run_layout = QVBoxLayout(run_bar)
         run_layout.setContentsMargins(8, 6, 8, 6)
         run_layout.setSpacing(4)
@@ -2874,9 +2877,9 @@ class CorrelationTabWidget(QWidget):
         self._fib_canvas.reset_view()
         self._fm_display.canvas.reset_view()
 
-        fig, (ax_fib, ax_fm) = plt.subplots(1, 2, figsize=(16, 8), facecolor="#1e2124")
+        fig, (ax_fib, ax_fm) = plt.subplots(1, 2, figsize=(16, 8), facecolor=f"{CANVAS_BG}")
         for ax in (ax_fib, ax_fm):
-            ax.set_facecolor("#1e2124")
+            ax.set_facecolor(f"{CANVAS_BG}")
 
         self._fib_canvas.render_to_axes(ax_fib)
         ax_fib.set_title("FIB", color="white", fontsize=12)

--- a/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
+++ b/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
@@ -26,6 +26,9 @@ from PyQt5.QtWidgets import (
 
 from fibsem.correlation.structures import Coordinate, PointXYZ
 from fibsem.ui import stylesheets
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 # Per-axis displacement below which a fit is treated as "no change" (the fit
 # fell back to the input). Well under the 3-decimal coordinate precision, so
@@ -183,7 +186,7 @@ class FitConfirmationDialog(QDialog):
         self._result = result
         self.setWindowTitle("Confirm fit")
         self.setModal(True)
-        self.setStyleSheet("background: #1e2124; color: #d0d0d0;")
+        self.setStyleSheet(f"background: {CANVAS_BG}; color: #d0d0d0;")
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(14, 14, 14, 12)

--- a/fibsem/correlation/ui/widgets/fm_interpolate_dialog.py
+++ b/fibsem/correlation/ui/widgets/fm_interpolate_dialog.py
@@ -26,6 +26,9 @@ from fibsem.fm.structures import FluorescenceImage
 from fibsem.ui import stylesheets
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.widgets.custom_widgets import ValueComboBox, ValueSpinBox
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 _WARN_COLOR = "#d6b57a"
 
@@ -50,7 +53,7 @@ class InterpolateZDialog(QDialog):
         # The label/chip colours below are picked for a dark surface, so don't
         # rely on the app-level napari stylesheet being installed — state it
         # here, as FitConfirmationDialog does.
-        self.setStyleSheet("background: #1e2124; color: #d0d0d0;")
+        self.setStyleSheet(f"background: {CANVAS_BG}; color: #d0d0d0;")
 
         meta = fm_image.metadata
         self._nc, self._nz, self._ny, self._nx = fm_image.data.shape

--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -17,6 +17,9 @@ from fibsem.ui.utils import message_box_ui, open_existing_file_dialog
 from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
 )
+from fibsem.ui.tokens import (
+    WHITE_ICON_COLOR,
+)
 
 
 class FibsemSystemSetupWidget(QtWidgets.QWidget):
@@ -85,7 +88,7 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
 
         self._label_status_title = QtWidgets.QLabel("Microscope Connected")
         self._label_status_title.setStyleSheet(
-            "background-color: transparent; color: #ffffff; font-weight: bold; font-size: 11px; border: none;"
+            f"background-color: transparent; color: {WHITE_ICON_COLOR}; font-weight: bold; font-size: 11px; border: none;"
         )
 
         self._label_status_subtitle = QtWidgets.QLabel("")

--- a/fibsem/ui/fm/widgets/channel_list_widget.py
+++ b/fibsem/ui/fm/widgets/channel_list_widget.py
@@ -36,6 +36,10 @@ from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.structures import ChannelSettings
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueComboBox, ValueSpinBox
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+    ORANGE_COLOR,
+)
 
 _DRAG_HANDLE_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
@@ -541,7 +545,7 @@ class _ChannelListHeader(QWidget):
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self.setStyleSheet("background: #1e2124;")
+        self.setStyleSheet(f"background: {CANVAS_BG};")
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(6, 4, 6, 4)
@@ -667,7 +671,7 @@ class ChannelListWidget(QWidget):
         layout.addWidget(self._empty_label)
 
         self._status_label = QLabel("")
-        self._status_label.setStyleSheet("color: #ff9800; font-style: italic; padding: 2px 12px;")
+        self._status_label.setStyleSheet(f"color: {ORANGE_COLOR}; font-style: italic; padding: 2px 12px;")
         self._status_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
         self._status_label.setVisible(False)
         layout.addWidget(self._status_label)

--- a/fibsem/ui/fm/widgets/fluorescence_plot_widget.py
+++ b/fibsem/ui/fm/widgets/fluorescence_plot_widget.py
@@ -16,6 +16,9 @@ from PyQt5.QtWidgets import (
 
 from fibsem.fm.structures import FluorescenceImage
 from fibsem.fm.plotting import plot_fluorescence_image
+from fibsem.ui.tokens import (
+    SURFACE_COLOR,
+)
 
 try:
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
@@ -115,7 +118,7 @@ class FluorescencePlotWidget(QWidget):
 
         # Create matplotlib figure and canvas with napari-style dark theme
         self.figure = Figure(figsize=(6, 6), dpi=80)
-        self.figure.patch.set_facecolor("#262930")  # napari dark background
+        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")  # napari dark background
 
         self.canvas = FigureCanvas(self.figure)
         self.canvas.setMinimumSize(300, 300)

--- a/fibsem/ui/fm/widgets/fluorescence_plot_widget.py
+++ b/fibsem/ui/fm/widgets/fluorescence_plot_widget.py
@@ -118,7 +118,7 @@ class FluorescencePlotWidget(QWidget):
 
         # Create matplotlib figure and canvas with napari-style dark theme
         self.figure = Figure(figsize=(6, 6), dpi=80)
-        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")  # napari dark background
+        self.figure.patch.set_facecolor(SURFACE_COLOR)  # napari dark background
 
         self.canvas = FigureCanvas(self.figure)
         self.canvas.setMinimumSize(300, 300)

--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -39,8 +39,11 @@ from fibsem.ui.fm.widgets.tile_mask_widget import TileMaskWidget
 from fibsem.ui.fm.widgets.z_parameters_widget import ZParametersWidget
 from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import TitledPanel, ValueComboBox
+from fibsem.ui.tokens import (
+    TEXT_MUTED_COLOR,
+)
 
-MUTED = "color: #868e93; font-size: 11px;"
+MUTED = f"color: {TEXT_MUTED_COLOR}; font-size: 11px;"
 
 AUTOFOCUS_LABELS = {
     AutoFocusMode.NONE: "Don't auto-focus",

--- a/fibsem/ui/fm/widgets/histogram_widget.py
+++ b/fibsem/ui/fm/widgets/histogram_widget.py
@@ -9,6 +9,10 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from fibsem.ui.tokens import (
+    SURFACE_COLOR,
+    WHITE_ICON_COLOR,
+)
 
 try:
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
@@ -53,7 +57,7 @@ class HistogramWidget(QWidget):
         else:
             # Create matplotlib figure and canvas with napari-style dark theme
             self.figure = Figure(figsize=(4, 3), dpi=80)
-            self.figure.patch.set_facecolor('#262930')  # napari dark background
+            self.figure.patch.set_facecolor(f'{SURFACE_COLOR}')  # napari dark background
             
             self.canvas = FigureCanvas(self.figure)
             self.canvas.setMinimumSize(200, 150)
@@ -100,7 +104,7 @@ class HistogramWidget(QWidget):
         if not MATPLOTLIB_AVAILABLE:
             return
             
-        self.ax.set_facecolor('#262930')  # napari dark background
+        self.ax.set_facecolor(f'{SURFACE_COLOR}')  # napari dark background
         self.ax.tick_params(colors='white', which='both')
         self.ax.spines['bottom'].set_color('white')
         self.ax.spines['top'].set_color('white')
@@ -135,7 +139,7 @@ class HistogramWidget(QWidget):
         # Create empty bars (will be updated with data)
         self.histogram_patches = self.ax.bar(bin_centers, np.zeros(self.n_bins), 
                                            width=bin_width, alpha=0.8, color='#0f7aad', 
-                                           edgecolor='#ffffff', animated=True)
+                                           edgecolor=f'{WHITE_ICON_COLOR}', animated=True)
         
         # Create mean line artist
         self.mean_line_artist = self.ax.axvline(0, color='#ff6600', linestyle='--', 

--- a/fibsem/ui/fm/widgets/line_plot_widget.py
+++ b/fibsem/ui/fm/widgets/line_plot_widget.py
@@ -17,6 +17,10 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.tokens import (
+    ORANGE_COLOR,
+    SURFACE_COLOR,
+)
 
 _OVERLAY_BTN_STYLE = (
     "QPushButton { background: rgba(40,41,48,180); border: 1px solid #555;"
@@ -111,7 +115,7 @@ class LinePlotWidget(QWidget):
 
         # Create matplotlib figure and canvas with napari-style dark theme
         self.figure = Figure(figsize=(4, 3), dpi=80)
-        self.figure.patch.set_facecolor("#262930")
+        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")
 
         self.canvas = FigureCanvas(self.figure)
         self.canvas.setMinimumSize(200, 150)
@@ -207,7 +211,7 @@ class LinePlotWidget(QWidget):
 
     def _apply_dark_theme(self):
         """Apply napari-style dark theme to the axes."""
-        self.ax.set_facecolor("#262930")
+        self.ax.set_facecolor(f"{SURFACE_COLOR}")
         self.ax.tick_params(colors="white", which="both")
         self.ax.spines["bottom"].set_color("white")
         self.ax.spines["top"].set_color("white")
@@ -273,7 +277,7 @@ class LinePlotWidget(QWidget):
         )
         self.peak_rolling_mean_artist = self.ax.axhline(
             0,
-            color="#ff9800",
+            color=f"{ORANGE_COLOR}",
             linestyle="-",
             linewidth=1.2,
             alpha=0.85,
@@ -294,7 +298,7 @@ class LinePlotWidget(QWidget):
 
         # Set up legend in fixed top left corner
         self.legend = self.ax.legend(loc="upper left", fontsize=8)
-        self.legend.get_frame().set_facecolor("#262930")
+        self.legend.get_frame().set_facecolor(f"{SURFACE_COLOR}")
         self.legend.get_frame().set_edgecolor("white")
         for text in self.legend.get_texts():
             text.set_color("white")
@@ -429,7 +433,7 @@ class LinePlotWidget(QWidget):
             if legend_needs_update and self.legend is not None:
                 self.legend.remove()
                 self.legend = self.ax.legend(loc="upper left", fontsize=8)
-                self.legend.get_frame().set_facecolor("#262930")
+                self.legend.get_frame().set_facecolor(f"{SURFACE_COLOR}")
                 self.legend.get_frame().set_edgecolor("white")
                 for text in self.legend.get_texts():
                     text.set_color("white")
@@ -490,7 +494,7 @@ class LinePlotWidget(QWidget):
         self.updates_paused = not self.updates_paused
 
         if self.updates_paused:
-            self.pause_button.setIcon(fibsem_icon("mdi:play", color="#ff9800"))
+            self.pause_button.setIcon(fibsem_icon("mdi:play", color=f"{ORANGE_COLOR}"))
             self.pause_button.setToolTip("Resume live updates")
         else:
             self.pause_button.setIcon(fibsem_icon("mdi:pause", color="#aaaaaa"))

--- a/fibsem/ui/fm/widgets/line_plot_widget.py
+++ b/fibsem/ui/fm/widgets/line_plot_widget.py
@@ -115,7 +115,7 @@ class LinePlotWidget(QWidget):
 
         # Create matplotlib figure and canvas with napari-style dark theme
         self.figure = Figure(figsize=(4, 3), dpi=80)
-        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")
+        self.figure.patch.set_facecolor(SURFACE_COLOR)
 
         self.canvas = FigureCanvas(self.figure)
         self.canvas.setMinimumSize(200, 150)
@@ -211,7 +211,7 @@ class LinePlotWidget(QWidget):
 
     def _apply_dark_theme(self):
         """Apply napari-style dark theme to the axes."""
-        self.ax.set_facecolor(f"{SURFACE_COLOR}")
+        self.ax.set_facecolor(SURFACE_COLOR)
         self.ax.tick_params(colors="white", which="both")
         self.ax.spines["bottom"].set_color("white")
         self.ax.spines["top"].set_color("white")
@@ -277,7 +277,7 @@ class LinePlotWidget(QWidget):
         )
         self.peak_rolling_mean_artist = self.ax.axhline(
             0,
-            color=f"{ORANGE_COLOR}",
+            color=ORANGE_COLOR,
             linestyle="-",
             linewidth=1.2,
             alpha=0.85,
@@ -298,7 +298,7 @@ class LinePlotWidget(QWidget):
 
         # Set up legend in fixed top left corner
         self.legend = self.ax.legend(loc="upper left", fontsize=8)
-        self.legend.get_frame().set_facecolor(f"{SURFACE_COLOR}")
+        self.legend.get_frame().set_facecolor(SURFACE_COLOR)
         self.legend.get_frame().set_edgecolor("white")
         for text in self.legend.get_texts():
             text.set_color("white")
@@ -433,7 +433,7 @@ class LinePlotWidget(QWidget):
             if legend_needs_update and self.legend is not None:
                 self.legend.remove()
                 self.legend = self.ax.legend(loc="upper left", fontsize=8)
-                self.legend.get_frame().set_facecolor(f"{SURFACE_COLOR}")
+                self.legend.get_frame().set_facecolor(SURFACE_COLOR)
                 self.legend.get_frame().set_edgecolor("white")
                 for text in self.legend.get_texts():
                     text.set_color("white")
@@ -494,7 +494,7 @@ class LinePlotWidget(QWidget):
         self.updates_paused = not self.updates_paused
 
         if self.updates_paused:
-            self.pause_button.setIcon(fibsem_icon("mdi:play", color=f"{ORANGE_COLOR}"))
+            self.pause_button.setIcon(fibsem_icon("mdi:play", color=ORANGE_COLOR))
             self.pause_button.setToolTip("Resume live updates")
         else:
             self.pause_button.setIcon(fibsem_icon("mdi:pause", color="#aaaaaa"))

--- a/fibsem/ui/fm/widgets/minimap_plot_widget.py
+++ b/fibsem/ui/fm/widgets/minimap_plot_widget.py
@@ -17,6 +17,9 @@ from fibsem import conversions
 from fibsem.conversions import is_inside_image_bounds
 from fibsem.structures import FibsemImage, FibsemStagePosition, Point
 from fibsem.imaging.tiled import reproject_stage_positions_onto_image2
+from fibsem.ui.tokens import (
+    SURFACE_COLOR,
+)
 try:
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
     from matplotlib.figure import Figure
@@ -96,7 +99,7 @@ class MinimapPlotWidget(QWidget):
         else:
             # Create matplotlib figure and canvas with napari-style dark theme
             self.figure = Figure(figsize=(6, 6), dpi=80)
-            self.figure.patch.set_facecolor("#262930")  # napari dark background
+            self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")  # napari dark background
 
             self.canvas = FigureCanvas(self.figure)
             self.canvas.setMinimumSize(300, 300)

--- a/fibsem/ui/fm/widgets/minimap_plot_widget.py
+++ b/fibsem/ui/fm/widgets/minimap_plot_widget.py
@@ -99,7 +99,7 @@ class MinimapPlotWidget(QWidget):
         else:
             # Create matplotlib figure and canvas with napari-style dark theme
             self.figure = Figure(figsize=(6, 6), dpi=80)
-            self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")  # napari dark background
+            self.figure.patch.set_facecolor(SURFACE_COLOR)  # napari dark background
 
             self.canvas = FigureCanvas(self.figure)
             self.canvas.setMinimumSize(300, 300)

--- a/fibsem/ui/fm/widgets/tile_grid_options_panel.py
+++ b/fibsem/ui/fm/widgets/tile_grid_options_panel.py
@@ -42,7 +42,7 @@ GRID_COLORS = [
     ("Yellow", "#ffd54f"),
     ("Cyan", "#00e5ff"),
     ("Green", "#69f0ae"),
-    ("White", f"{WHITE_ICON_COLOR}"),
+    ("White", WHITE_ICON_COLOR),
 ]
 
 def _color_icon(color: str, size: int = 12) -> QIcon:

--- a/fibsem/ui/fm/widgets/tile_grid_options_panel.py
+++ b/fibsem/ui/fm/widgets/tile_grid_options_panel.py
@@ -31,6 +31,9 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.tokens import (
+    WHITE_ICON_COLOR,
+)
 
 # Ordered by how often an FM sample makes them useless: magenta first, because
 # fluorescence channels are usually cyan/green/blue and rarely magenta.
@@ -39,7 +42,7 @@ GRID_COLORS = [
     ("Yellow", "#ffd54f"),
     ("Cyan", "#00e5ff"),
     ("Green", "#69f0ae"),
-    ("White", "#ffffff"),
+    ("White", f"{WHITE_ICON_COLOR}"),
 ]
 
 def _color_icon(color: str, size: int = 12) -> QIcon:

--- a/fibsem/ui/fm/widgets/tile_mask_widget.py
+++ b/fibsem/ui/fm/widgets/tile_mask_widget.py
@@ -19,14 +19,28 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-# napari-dark palette, matching the rest of the app's chrome
-BACKGROUND = QColor("#262930")
-PANEL = QColor("#1e2027")
-BORDER = QColor("#3d4251")
-ENABLED_FILL = QColor("#50a6ff")
+from fibsem.ui.tokens import (
+    ACCENT_COLOR,
+    BORDER_COLOR,
+    PANEL_COLOR,
+    SURFACE_COLOR,
+    TEXT_MUTED_COLOR,
+)
+
+# napari-dark palette, matching the rest of the app's chrome. Taken from the
+# shared tokens rather than restated, so retuning the palette reaches this
+# widget too -- these were copies of the same five values.
+BACKGROUND = QColor(SURFACE_COLOR)
+PANEL = QColor(PANEL_COLOR)
+BORDER = QColor(BORDER_COLOR)
+ENABLED_FILL = QColor(ACCENT_COLOR)
+TEXT_MUTED = QColor(TEXT_MUTED_COLOR)
+
+# No token: the enabled/disabled tile edges are this widget's own, and the two
+# other widgets that draw tile state disagree with them (see tiled_overview_widget
+# and tile_grid_overlay). Needs one shared decision, not three local ones.
 ENABLED_EDGE = QColor("#7cc0ff")
 DISABLED_EDGE = QColor("#4a4f5c")
-TEXT_MUTED = QColor("#868e93")
 
 MIN_CELL_PX = 10
 MAX_CELL_PX = 44

--- a/fibsem/ui/napari_style.py
+++ b/fibsem/ui/napari_style.py
@@ -13,6 +13,8 @@ import os as _os
 from fibsem.ui.tokens import (
     ACCENT_COLOR,
     BORDER_COLOR,
+    DISABLED_BG_COLOR,
+    DISABLED_TEXT_COLOR,
     PANEL_COLOR,
     SURFACE_COLOR,
     TEXT_COLOR,
@@ -23,7 +25,12 @@ from fibsem.ui.tokens import (
 _ICONS_DIR = _os.path.join(_os.path.dirname(__file__), "icons").replace("\\", "/")
 
 # Napari-style dark theme stylesheet
-# TODO: no token -- #2d313b, #4a5168, #6b6b6b
+#
+# TODO: no token -- #4a5168 (the pressed/selected lift on controls), and the two
+# :hover rules still on #2d313b. That value now has a name -- DISABLED_BG_COLOR
+# -- but hover is not disabled, and ROW_ALT_COLOR is the token that means hover;
+# they differ by 4 units of RGB, so reconciling them is a real colour change and
+# wants a decision rather than a silent swap.
 NAPARI_STYLE = f"""
 QWidget {{
     background-color: {SURFACE_COLOR};
@@ -63,7 +70,7 @@ QMenu::item:selected {{
    action is indistinguishable from an available one. Matches the disabled
    colour used by the button and field rules below. */
 QMenu::item:disabled {{
-    color: #6b6b6b;
+    color: {DISABLED_TEXT_COLOR};
 }}
 
 QTabWidget::pane {{
@@ -89,7 +96,7 @@ QTabBar::tab:hover:!selected {{
 }}
 
 QTabBar::tab:disabled {{
-    color: #6b6b6b;
+    color: {DISABLED_TEXT_COLOR};
 }}
 
 QPushButton {{
@@ -109,8 +116,8 @@ QPushButton:pressed {{
 }}
 
 QPushButton:disabled {{
-    background-color: #2d313b;
-    color: #6b6b6b;
+    background-color: {DISABLED_BG_COLOR};
+    color: {DISABLED_TEXT_COLOR};
 }}
 
 QStatusBar {{
@@ -152,8 +159,8 @@ QLineEdit:focus {{
 }}
 
 QLineEdit:disabled {{
-    color: #6b6b6b;
-    background-color: #2d313b;
+    color: {DISABLED_TEXT_COLOR};
+    background-color: {DISABLED_BG_COLOR};
 }}
 
 QComboBox {{
@@ -185,8 +192,8 @@ QComboBox::down-arrow {{
 }}
 
 QComboBox:disabled {{
-    color: #6b6b6b;
-    background-color: #2d313b;
+    color: {DISABLED_TEXT_COLOR};
+    background-color: {DISABLED_BG_COLOR};
 }}
 
 QComboBox QAbstractItemView {{
@@ -209,8 +216,8 @@ QSpinBox:focus, QDoubleSpinBox:focus {{
 }}
 
 QSpinBox:disabled, QDoubleSpinBox:disabled {{
-    color: #6b6b6b;
-    background-color: #2d313b;
+    color: {DISABLED_TEXT_COLOR};
+    background-color: {DISABLED_BG_COLOR};
 }}
 
 QSpinBox::up-button, QDoubleSpinBox::up-button {{

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -10,6 +10,8 @@ from fibsem.ui.tokens import (  # noqa: F401  (re-exported for existing callers)
     BORDER_COLOR,
     CANVAS_BG,
     DEFECT_ORANGE_COLOR,
+    DISABLED_BG_COLOR,
+    DISABLED_TEXT_COLOR,
     DEFECT_RED_COLOR,
     ERROR_COLOR,
     GRAY_BACKGROUND_COLOR,
@@ -125,7 +127,7 @@ USER_ATTENTION_BUTTON_STYLESHEET = f"""
             }}
         """
 
-# TODO: no token -- #2d313b, #2e7d32, #388e3c, #6b6b6b
+# TODO: no token -- #2e7d32, #388e3c
 RUN_WORKFLOW_BUTTON_STYLESHEET = f"""
             QPushButton {{
                 background-color: {OK_COLOR};
@@ -142,8 +144,8 @@ RUN_WORKFLOW_BUTTON_STYLESHEET = f"""
                 background-color: #2e7d32;
             }}
             QPushButton:disabled {{
-                background-color: #2d313b;
-                color: #6b6b6b;
+                background-color: {DISABLED_BG_COLOR};
+                color: {DISABLED_TEXT_COLOR};
             }}
         """
 
@@ -151,7 +153,6 @@ RUN_WORKFLOW_BUTTON_STYLESHEET = f"""
 # The :disabled rule matches the primary/secondary/run sheets. Without it a
 # disabled stop or delete button stays full crimson and only stops responding,
 # which is what drove call sites to paint their own grey "off" state by hand.
-# TODO: no token -- #2d313b, #6b6b6b
 STOP_WORKFLOW_BUTTON_STYLESHEET = f"""
             QPushButton {{
                 background-color: {SEMANTIC_ERROR_COLOR};
@@ -167,8 +168,8 @@ STOP_WORKFLOW_BUTTON_STYLESHEET = f"""
                 background-color: {SEMANTIC_ERROR_PRESSED_COLOR};
             }}
             QPushButton:disabled {{
-                background-color: #2d313b;
-                color: #6b6b6b;
+                background-color: {DISABLED_BG_COLOR};
+                color: {DISABLED_TEXT_COLOR};
             }}
         """
 
@@ -208,7 +209,6 @@ SUPERVISION_STATUS_AUTOMATED_STYLESHEET = f"""
                 }}
             """
 
-# TODO: no token -- #2d313b, #6b6b6b
 PRIMARY_BUTTON_STYLESHEET = f"""
     QPushButton {{
         background-color: {PRIMARY_COLOR};
@@ -224,12 +224,12 @@ PRIMARY_BUTTON_STYLESHEET = f"""
         background-color: {PRIMARY_COLOR_PRESSED};
     }}
     QPushButton:disabled {{
-        background-color: #2d313b;
-        color: #6b6b6b;
+        background-color: {DISABLED_BG_COLOR};
+        color: {DISABLED_TEXT_COLOR};
     }}
 """
 
-# TODO: no token -- #2d313b, #4a5168, #6b6b6b
+# TODO: no token -- #4a5168
 SECONDARY_BUTTON_STYLESHEET = f"""
     QPushButton {{
         background-color: {BORDER_COLOR};
@@ -245,8 +245,8 @@ SECONDARY_BUTTON_STYLESHEET = f"""
         background-color: {ACCENT_COLOR};
     }}
     QPushButton:disabled {{
-        background-color: #2d313b;
-        color: #6b6b6b;
+        background-color: {DISABLED_BG_COLOR};
+        color: {DISABLED_TEXT_COLOR};
     }}
 """
 
@@ -355,7 +355,7 @@ LIST_WIDGET_STYLESHEET = """
 # QDateTimeEdit with visible up/down step arrows (calendar popup must be OFF for
 # the buttons to appear). Stepping applies to whichever field has focus
 # (year / month / day / hour / minute), also via mouse-wheel and arrow keys.
-# TODO: no token -- #2d313b, #4a5168, #6b6b6b
+# TODO: no token -- #4a5168
 DATETIME_EDIT_STYLESHEET = f"""
 QDateTimeEdit {{
     background-color: {PANEL_COLOR};
@@ -370,8 +370,8 @@ QDateTimeEdit:focus {{
 }}
 
 QDateTimeEdit:disabled {{
-    color: #6b6b6b;
-    background-color: #2d313b;
+    color: {DISABLED_TEXT_COLOR};
+    background-color: {DISABLED_BG_COLOR};
 }}
 
 QDateTimeEdit::up-button {{

--- a/fibsem/ui/tokens.py
+++ b/fibsem/ui/tokens.py
@@ -66,6 +66,18 @@ OK_COLOR = "#4caf50"            # success
 WARN_COLOR = "#e0a030"          # loaded but inactive, degraded, needs attention
 ERROR_COLOR = "#d04040"         # failure
 
+# The disabled pair. Every semantic button sheet renders its :disabled state in
+# these two, and until now both were bare literals repeated across the file --
+# the most load-bearing colours in the UI with no name.
+#
+# DISABLED_BG_COLOR sits 4 units from ROW_ALT_COLOR in RGB, which is to say they
+# are the same colour to the eye and different to a diff. Two hover rules in
+# NAPARI_STYLE use this value where ROW_ALT_COLOR is the token that means hover;
+# collapsing those is a real (if invisible) change, so they are left flagged in
+# place rather than folded in silently.
+DISABLED_BG_COLOR = "#2d313b"   # disabled control background
+DISABLED_TEXT_COLOR = "#6b6b6b" # disabled label and control text
+
 # ---------------------------------------------------------------------------
 # Deprecated aliases.
 #

--- a/fibsem/ui/widgets/autolamella_experiment_task_summary_widget.py
+++ b/fibsem/ui/widgets/autolamella_experiment_task_summary_widget.py
@@ -245,7 +245,7 @@ class ExperimentTaskSummaryWidget(QWidget):
         """Create an empty canvas with placeholder text."""
         # Create empty figure
         self.figure = Figure(figsize=(10, 6), dpi=80)
-        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")
+        self.figure.patch.set_facecolor(SURFACE_COLOR)
         self._title_artist = None
         self._ylabel_artists = []
 
@@ -311,7 +311,7 @@ class ExperimentTaskSummaryWidget(QWidget):
         self.figure = new_figure
 
         # Apply dark theme to the figure
-        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")
+        self.figure.patch.set_facecolor(SURFACE_COLOR)
 
         # Create new canvas with the figure
         self.canvas = FigureCanvas(self.figure)

--- a/fibsem/ui/widgets/autolamella_experiment_task_summary_widget.py
+++ b/fibsem/ui/widgets/autolamella_experiment_task_summary_widget.py
@@ -29,6 +29,9 @@ from fibsem.applications.autolamella.tools.reporting import (
     plot_experiment_task_summary,
     plot_lamella_task_workflow_summary,
 )
+from fibsem.ui.tokens import (
+    SURFACE_COLOR,
+)
 
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.ui import AutoLamellaUI
@@ -242,7 +245,7 @@ class ExperimentTaskSummaryWidget(QWidget):
         """Create an empty canvas with placeholder text."""
         # Create empty figure
         self.figure = Figure(figsize=(10, 6), dpi=80)
-        self.figure.patch.set_facecolor("#262930")
+        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")
         self._title_artist = None
         self._ylabel_artists = []
 
@@ -308,7 +311,7 @@ class ExperimentTaskSummaryWidget(QWidget):
         self.figure = new_figure
 
         # Apply dark theme to the figure
-        self.figure.patch.set_facecolor("#262930")
+        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")
 
         # Create new canvas with the figure
         self.canvas = FigureCanvas(self.figure)

--- a/fibsem/ui/widgets/autolamella_load_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_load_experiment_widget.py
@@ -22,6 +22,7 @@ from fibsem.config import (
 )
 from fibsem.ui import utils as fui
 from fibsem.ui.stylesheets import (
+    DISABLED_TEXT_COLOR,
     PRIMARY_BUTTON_STYLESHEET,
     PRIMARY_COLOR_PRESSED,
     SECONDARY_BUTTON_STYLESHEET,
@@ -73,8 +74,10 @@ RECENT_ALERT_ICON = "mdi:alert-circle-outline"
 RECENT_ICON_COLOR = "#9aa0ab"
 RECENT_PILL_TEXT_COLOR = "#b7bcc6"
 RECENT_NAME_COLOR = TEXT_COLOR
-# Muted colour for rows whose experiment.yaml is missing or unreadable
-RECENT_UNAVAILABLE_COLOR = "#6b6b6b"
+# Muted colour for rows whose experiment.yaml is missing or unreadable -- the
+# same disabled grey the control sheets use, so an unreadable row reads as
+# disabled rather than as its own shade.
+RECENT_UNAVAILABLE_COLOR = DISABLED_TEXT_COLOR
 
 
 class _ElidedLabel(QtWidgets.QLabel):

--- a/fibsem/ui/widgets/autolamella_overview_image_widget.py
+++ b/fibsem/ui/widgets/autolamella_overview_image_widget.py
@@ -290,7 +290,7 @@ class OverviewImageWidget(QWidget):
         """Create an empty canvas with placeholder text."""
         # Create empty figure
         self.figure = Figure(figsize=(10, 6), dpi=80)
-        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")
+        self.figure.patch.set_facecolor(SURFACE_COLOR)
 
         # Create canvas from figure
         if self.canvas is not None:
@@ -341,7 +341,7 @@ class OverviewImageWidget(QWidget):
         self.figure = new_figure
 
         # Apply dark theme to the figure
-        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")
+        self.figure.patch.set_facecolor(SURFACE_COLOR)
 
         # Create new canvas with the figure
         self.canvas = FigureCanvas(self.figure)

--- a/fibsem/ui/widgets/autolamella_overview_image_widget.py
+++ b/fibsem/ui/widgets/autolamella_overview_image_widget.py
@@ -33,6 +33,9 @@ from fibsem.ui.widgets.custom_widgets import (
 from fibsem.imaging.tiled import plot_minimap
 from fibsem.structures import FibsemImage
 import glob
+from fibsem.ui.tokens import (
+    SURFACE_COLOR,
+)
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.ui import AutoLamellaUI
 
@@ -287,7 +290,7 @@ class OverviewImageWidget(QWidget):
         """Create an empty canvas with placeholder text."""
         # Create empty figure
         self.figure = Figure(figsize=(10, 6), dpi=80)
-        self.figure.patch.set_facecolor("#262930")
+        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")
 
         # Create canvas from figure
         if self.canvas is not None:
@@ -338,7 +341,7 @@ class OverviewImageWidget(QWidget):
         self.figure = new_figure
 
         # Apply dark theme to the figure
-        self.figure.patch.set_facecolor("#262930")
+        self.figure.patch.set_facecolor(f"{SURFACE_COLOR}")
 
         # Create new canvas with the figure
         self.canvas = FigureCanvas(self.figure)

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -45,6 +45,9 @@ from PyQt5.QtWidgets import QApplication, QPushButton, QSizePolicy
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.stylesheets import CANVAS_BG as _BG, PRIMARY_ACCENT as _ACCENT
 from fibsem.ui.widgets.canvas.contrast_gamma_control import ContrastGammaControl
+from fibsem.ui.tokens import (
+    WHITE_ICON_COLOR,
+)
 
 if TYPE_CHECKING:
     from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
@@ -405,7 +408,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             self._title_artist = self._ax.text(
                 0.5, 0.985, self._title_text,
                 transform=self._ax.transAxes, ha="center", va="top",
-                fontsize=10, color="#ffffff", zorder=11,
+                fontsize=10, color=f"{WHITE_ICON_COLOR}", zorder=11,
                 bbox=dict(boxstyle="round,pad=0.3", facecolor=_BG,
                           edgecolor="none", alpha=0.55),
             )
@@ -457,7 +460,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             self._live_artist = self._ax.text(
                 0.988, 0.985, "● LIVE",
                 transform=self._ax.transAxes, ha="right", va="top",
-                fontsize=7, color="#ffffff", zorder=12, fontweight="bold",
+                fontsize=7, color=f"{WHITE_ICON_COLOR}", zorder=12, fontweight="bold",
                 bbox=dict(boxstyle="round,pad=0.3", facecolor=_LIVE_BADGE_BG,
                           edgecolor="none", alpha=0.9),
             )

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -408,7 +408,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             self._title_artist = self._ax.text(
                 0.5, 0.985, self._title_text,
                 transform=self._ax.transAxes, ha="center", va="top",
-                fontsize=10, color=f"{WHITE_ICON_COLOR}", zorder=11,
+                fontsize=10, color=WHITE_ICON_COLOR, zorder=11,
                 bbox=dict(boxstyle="round,pad=0.3", facecolor=_BG,
                           edgecolor="none", alpha=0.55),
             )
@@ -460,7 +460,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             self._live_artist = self._ax.text(
                 0.988, 0.985, "● LIVE",
                 transform=self._ax.transAxes, ha="right", va="top",
-                fontsize=7, color=f"{WHITE_ICON_COLOR}", zorder=12, fontweight="bold",
+                fontsize=7, color=WHITE_ICON_COLOR, zorder=12, fontweight="bold",
                 bbox=dict(boxstyle="round,pad=0.3", facecolor=_LIVE_BADGE_BG,
                           edgecolor="none", alpha=0.9),
             )

--- a/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
@@ -43,6 +43,9 @@ from fibsem.ui.napari.patterns import (
 from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 
 from typing import TYPE_CHECKING
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 if TYPE_CHECKING:
     from fibsem.ui.widgets.canvas.canvas_base import ContentRect
@@ -193,7 +196,7 @@ class MillingPatternOverlay(CanvasOverlay):
             handles=handles,
             loc="upper right",
             fontsize=8,
-            facecolor="#1e2124",
+            facecolor=f"{CANVAS_BG}",
             edgecolor="#555555",
             labelcolor="#d1d2d4",
             framealpha=0.85,

--- a/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
@@ -196,7 +196,7 @@ class MillingPatternOverlay(CanvasOverlay):
             handles=handles,
             loc="upper right",
             fontsize=8,
-            facecolor=f"{CANVAS_BG}",
+            facecolor=CANVAS_BG,
             edgecolor="#555555",
             labelcolor="#d1d2d4",
             framealpha=0.85,

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -432,7 +432,7 @@ class PointOverlay(QObject):
             [self._legend_label],
             loc="upper left",
             fontsize=8,
-            facecolor=f"{CANVAS_BG}",
+            facecolor=CANVAS_BG,
             edgecolor="#555555",
             labelcolor="#d1d2d4",
             framealpha=0.85,

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -13,6 +13,9 @@ from PyQt5.QtCore import QObject, pyqtSignal
 from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 
 from typing import TYPE_CHECKING
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 if TYPE_CHECKING:
     from fibsem.ui.widgets.canvas.canvas_base import ContentRect
@@ -429,7 +432,7 @@ class PointOverlay(QObject):
             [self._legend_label],
             loc="upper left",
             fontsize=8,
-            facecolor="#1e2124",
+            facecolor=f"{CANVAS_BG}",
             edgecolor="#555555",
             labelcolor="#d1d2d4",
             framealpha=0.85,

--- a/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
@@ -9,6 +9,9 @@ from fibsem.ui.stylesheets import CANVAS_BG as _BG
 from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 
 from typing import TYPE_CHECKING
+from fibsem.ui.tokens import (
+    WHITE_ICON_COLOR,
+)
 
 if TYPE_CHECKING:
     from fibsem.ui.widgets.canvas.canvas_base import ContentRect
@@ -178,7 +181,7 @@ class RulerOverlay(CanvasOverlay):
         self._label = self._ax.annotate(
             self._text(), xy=(mx, my), xytext=(0, 9),
             textcoords="offset points", ha="center", va="bottom",
-            fontsize=8, color="#ffffff", zorder=10,
+            fontsize=8, color=f"{WHITE_ICON_COLOR}", zorder=10,
             bbox=dict(boxstyle="round,pad=0.3", facecolor=_BG,
                       edgecolor=self._color, alpha=0.8, linewidth=0.8),
         )

--- a/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
@@ -181,7 +181,7 @@ class RulerOverlay(CanvasOverlay):
         self._label = self._ax.annotate(
             self._text(), xy=(mx, my), xytext=(0, 9),
             textcoords="offset points", ha="center", va="bottom",
-            fontsize=8, color=f"{WHITE_ICON_COLOR}", zorder=10,
+            fontsize=8, color=WHITE_ICON_COLOR, zorder=10,
             bbox=dict(boxstyle="round,pad=0.3", facecolor=_BG,
                       edgecolor=self._color, alpha=0.8, linewidth=0.8),
         )

--- a/fibsem/ui/widgets/canvas/quad_view.py
+++ b/fibsem/ui/widgets/canvas/quad_view.py
@@ -43,6 +43,9 @@ from fibsem.ui.stylesheets import (
 )
 from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 if TYPE_CHECKING:
     from fibsem.fm.structures import FluorescenceImage
@@ -52,7 +55,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 _TITLE_STYLE = (
-    "color: #888; font-size: 11px; padding: 2px 6px; background: #1e2124;"
+    f"color: #888; font-size: 11px; padding: 2px 6px; background: {CANVAS_BG};"
 )
 _PLACEHOLDER_STYLE = "color: #777; font-size: 12px;"
 # Selected-view border: the primary accent (matches PRIMARY_BUTTON_STYLESHEET), kept subtle.

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -33,6 +33,9 @@ from fibsem.ui.icon import ICON_MOVE_TO_POSITION, ICON_UPDATE_POSITION, fibsem_i
 from fibsem.ui import stylesheets as stylesheets
 from fibsem.ui.utils import install_wheel_blocker
 from fibsem.utils import format_value
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 
 class QFilePathLineEdit(QWidget):
@@ -548,7 +551,7 @@ class TitledPanel(QWidget):
 
         # Header
         self._header = QWidget()
-        self._header.setStyleSheet("background: #1e2124; border-radius: 3px 3px 0 0;")
+        self._header.setStyleSheet(f"background: {CANVAS_BG}; border-radius: 3px 3px 0 0;")
         self._header_layout = QHBoxLayout(self._header)
         self._header_layout.setContentsMargins(8, 3, 4, 3)
         self._header_layout.setSpacing(4)
@@ -764,7 +767,7 @@ class TaskNameListWidget(QWidget):
 
         # Header
         header = QWidget()
-        header.setStyleSheet("background: #1e2124;")
+        header.setStyleSheet(f"background: {CANVAS_BG};")
         header_layout = QHBoxLayout(header)
         header_layout.setContentsMargins(8, 3, 4, 3)
         header_layout.setSpacing(4)
@@ -1038,7 +1041,7 @@ class LamellaNameListWidget(QWidget):
 
         # Header
         header = QWidget()
-        header.setStyleSheet("background: #1e2124;")
+        header.setStyleSheet(f"background: {CANVAS_BG};")
         header_layout = QHBoxLayout(header)
         header_layout.setContentsMargins(8, 3, 4, 3)
         header_layout.setSpacing(8)

--- a/fibsem/ui/widgets/dataframe_table_widget.py
+++ b/fibsem/ui/widgets/dataframe_table_widget.py
@@ -6,6 +6,10 @@ import pandas as pd
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QTableWidget, QTableWidgetItem, QHeaderView
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QColor, QPalette
+from fibsem.ui.tokens import (
+    PRIMARY_ACCENT,
+    WHITE_ICON_COLOR,
+)
 
 
 class DataFrameTableWidget(QWidget):
@@ -46,8 +50,8 @@ class DataFrameTableWidget(QWidget):
         palette.setColor(QPalette.ColorRole.Base, QColor("#202020"))
         palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#2c2c2c"))
         palette.setColor(QPalette.ColorRole.Text, QColor("#dddddd"))
-        palette.setColor(QPalette.ColorRole.Highlight, QColor("#3a6ea5"))
-        palette.setColor(QPalette.ColorRole.HighlightedText, QColor("#ffffff"))
+        palette.setColor(QPalette.ColorRole.Highlight, QColor(f"{PRIMARY_ACCENT}"))
+        palette.setColor(QPalette.ColorRole.HighlightedText, QColor(f"{WHITE_ICON_COLOR}"))
         self.table_widget.setPalette(palette)
 
         layout.addWidget(self.table_widget)

--- a/fibsem/ui/widgets/dataframe_table_widget.py
+++ b/fibsem/ui/widgets/dataframe_table_widget.py
@@ -50,8 +50,8 @@ class DataFrameTableWidget(QWidget):
         palette.setColor(QPalette.ColorRole.Base, QColor("#202020"))
         palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#2c2c2c"))
         palette.setColor(QPalette.ColorRole.Text, QColor("#dddddd"))
-        palette.setColor(QPalette.ColorRole.Highlight, QColor(f"{PRIMARY_ACCENT}"))
-        palette.setColor(QPalette.ColorRole.HighlightedText, QColor(f"{WHITE_ICON_COLOR}"))
+        palette.setColor(QPalette.ColorRole.Highlight, QColor(PRIMARY_ACCENT))
+        palette.setColor(QPalette.ColorRole.HighlightedText, QColor(WHITE_ICON_COLOR))
         self.table_widget.setPalette(palette)
 
         layout.addWidget(self.table_widget)

--- a/fibsem/ui/widgets/hook_config_widget.py
+++ b/fibsem/ui/widgets/hook_config_widget.py
@@ -68,7 +68,7 @@ _HOOK_CLASSES: dict[str, Type[Hook]] = {
 }
 
 _TYPE_COLORS = {
-    "LoggingHook":      f"{ACCENT_COLOR}",
+    "LoggingHook":      ACCENT_COLOR,
     "NotificationHook": stylesheets.GREEN_COLOR,
     "WebhookHook":      stylesheets.ORANGE_COLOR,
     "SlackHook":        "#a67cff",

--- a/fibsem/ui/widgets/hook_config_widget.py
+++ b/fibsem/ui/widgets/hook_config_widget.py
@@ -39,6 +39,10 @@ from fibsem.hooks import (
 )
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel
+from fibsem.ui.tokens import (
+    ACCENT_COLOR,
+    TEXT_COLOR,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -64,7 +68,7 @@ _HOOK_CLASSES: dict[str, Type[Hook]] = {
 }
 
 _TYPE_COLORS = {
-    "LoggingHook":      "#50a6ff",
+    "LoggingHook":      f"{ACCENT_COLOR}",
     "NotificationHook": stylesheets.GREEN_COLOR,
     "WebhookHook":      stylesheets.ORANGE_COLOR,
     "SlackHook":        "#a67cff",
@@ -302,7 +306,7 @@ class _HookRowWidget(QWidget):
         layout.addWidget(self._chk_enabled)
 
         name_lbl = QLabel(hook.name or "<unnamed>")
-        name_lbl.setStyleSheet("color: #d6d6d6; font-weight: bold;")
+        name_lbl.setStyleSheet(f"color: {TEXT_COLOR}; font-weight: bold;")
         layout.addWidget(name_lbl)
 
         cls_name = type(hook).__name__

--- a/fibsem/ui/widgets/lamella_default_config_widget.py
+++ b/fibsem/ui/widgets/lamella_default_config_widget.py
@@ -20,6 +20,9 @@ from fibsem.ui.widgets.canvas.overlays.alignment_overlay import AlignmentAreaOve
 from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
 from fibsem.structures import DEFAULT_ALIGNMENT_AREA, FibsemRectangle, Point
 from fibsem.ui.stylesheets import NAPARI_STYLE
+from fibsem.ui.tokens import (
+    SEMANTIC_WARNING_COLOR,
+)
 
 _DEFAULT_AA = FibsemRectangle.from_dict(DEFAULT_ALIGNMENT_AREA)
 _DEFAULT_POI = Point(0, 0)
@@ -29,7 +32,7 @@ _SECTION_STYLE = (
     " padding: 4px 0px 2px 0px; letter-spacing: 0.5px;"
 )
 _LABEL_STYLE = "color: #a0a0a0; min-width: 80px; font-size: 11px; background: transparent;"
-_INVALID_STYLE = "color: #E3B617; font-size: 10px; background: transparent;"
+_INVALID_STYLE = f"color: {SEMANTIC_WARNING_COLOR}; font-size: 10px; background: transparent;"
 _HINT_STYLE = (
     "color: #808080; font-size: 10px; background: transparent;"
     " border-top: 1px solid #4a4a4a; padding-top: 6px;"

--- a/fibsem/ui/widgets/lamella_list_widget.py
+++ b/fibsem/ui/widgets/lamella_list_widget.py
@@ -29,6 +29,9 @@ from fibsem.applications.autolamella.structures import (
 )
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 _NAME_MIN_WIDTH = 160
 _BTN_SIZE = QSize(32, 32)
@@ -43,7 +46,7 @@ class _LamellaTooltip(QWidget):
     def __init__(self) -> None:
         super().__init__(None, Qt.ToolTip | Qt.FramelessWindowHint)  # type: ignore[call-overload]
         self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
-        self.setStyleSheet("background: #1e2124; border: 1px solid #3a3d42;")
+        self.setStyleSheet(f"background: {CANVAS_BG}; border: 1px solid #3a3d42;")
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(4, 4, 4, 4)
@@ -244,7 +247,7 @@ class _LamellaListHeader(QWidget):
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self.setStyleSheet("background: #1e2124;")
+        self.setStyleSheet(f"background: {CANVAS_BG};")
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(6, 4, 6, 4)

--- a/fibsem/ui/widgets/lamella_pose_list_widget.py
+++ b/fibsem/ui/widgets/lamella_pose_list_widget.py
@@ -17,6 +17,9 @@ from PyQt5.QtWidgets import (
 from fibsem.applications.autolamella.structures import Lamella
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 _NAME_WIDTH = 110
 _BTN_SIZE = QSize(32, 32)
@@ -75,7 +78,7 @@ class LamellaPoseRowWidget(QWidget):
 class _LamellaPoseListHeader(QWidget):
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self.setStyleSheet("background: #1e2124;")
+        self.setStyleSheet(f"background: {CANVAS_BG};")
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(6, 4, 6, 4)

--- a/fibsem/ui/widgets/lamella_workflow_widget.py
+++ b/fibsem/ui/widgets/lamella_workflow_widget.py
@@ -29,6 +29,10 @@ from fibsem.ui.widgets.workflow_task_editor_widget import WorkflowTaskEditorWidg
 from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
 )
+from fibsem.ui.tokens import (
+    PRIMARY_COLOR,
+    TEXT_COLOR,
+)
 
 _SECTION_LABEL_STYLE = (
     "font-size: 11px; font-weight: bold; color: #a0a0a0;"
@@ -111,7 +115,7 @@ class _TaskEditorDialog(QDialog):
         self.setModal(True)
         self.setMinimumWidth(470)
         self.setMinimumHeight(520)
-        self.setStyleSheet("background: #2b2d31; color: #d6d6d6;")
+        self.setStyleSheet(f"background: #2b2d31; color: {TEXT_COLOR};")
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -215,7 +219,7 @@ class LamellaWorkflowWidget(QWidget):
         # ── summary label ────────────────────────────────────────────────
         self._summary_label = QLabel("0 lamella, 0 tasks selected")
         self._summary_label.setStyleSheet(
-            "color: #007ACC; font-size: 11px; padding: 3px 6px;"
+            f"color: {PRIMARY_COLOR}; font-size: 11px; padding: 3px 6px;"
         )
         root.addWidget(self._summary_label)
 
@@ -320,7 +324,7 @@ class LamellaWorkflowWidget(QWidget):
             )
         else:
             self._summary_label.setStyleSheet(
-                "color: #007ACC; font-size: 11px; padding: 3px 6px;"
+                f"color: {PRIMARY_COLOR}; font-size: 11px; padding: 3px 6px;"
             )
             self._summary_label.setText(
                 f"{n_lam} lamella, {n_task} task{'s' if n_task != 1 else ''} selected"

--- a/fibsem/ui/widgets/milling_stage_list_widget.py
+++ b/fibsem/ui/widgets/milling_stage_list_widget.py
@@ -26,6 +26,10 @@ from fibsem.milling.strategy import get_strategy_names
 from fibsem.ui import stylesheets
 from fibsem.ui.napari.patterns import COLOURS
 from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueComboBox, ValueSpinBox
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+    ORANGE_COLOR,
+)
 
 _DRAG_HANDLE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "icons", "drag_handle.svg")
 # Columns are flexible: each is (minimum_width, stretch). The header and every row
@@ -346,7 +350,7 @@ class _MillingStageListHeader(QWidget):
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self.setStyleSheet("background: #1e2124;")
+        self.setStyleSheet(f"background: {CANVAS_BG};")
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(6, 4, 6, 4)
@@ -473,7 +477,7 @@ class MillingStageListWidget(QWidget):
         layout.addWidget(self._empty_label)
 
         self._status_label = QLabel("")
-        self._status_label.setStyleSheet("color: #ff9800; font-style: italic; padding: 2px 12px;")
+        self._status_label.setStyleSheet(f"color: {ORANGE_COLOR}; font-style: italic; padding: 2px 12px;")
         self._status_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
         self._status_label.setVisible(False)
         layout.addWidget(self._status_label)

--- a/fibsem/ui/widgets/notifications.py
+++ b/fibsem/ui/widgets/notifications.py
@@ -31,7 +31,7 @@ class ToastNotification(QWidget):
 
     # Notification types with colors
     TYPES = {
-        "info": f"{ACCENT_COLOR}",                      # Blue
+        "info": ACCENT_COLOR,                      # Blue
         "success": stylesheets.GREEN_COLOR,     # Green
         "warning": stylesheets.ORANGE_COLOR,    # Orange
         "error": "#f44336",                     # Red
@@ -304,7 +304,7 @@ class NotificationHistoryPopup(QWidget):
         item_layout.setSpacing(10)
 
         # Icon
-        color = ToastNotification.TYPES.get(notification_type, f"{ACCENT_COLOR}")
+        color = ToastNotification.TYPES.get(notification_type, ACCENT_COLOR)
         icons = {"info": "ℹ", "success": "✓", "warning": "⚠", "error": "✕"}
         icon_label = QLabel(icons.get(notification_type, "ℹ"))
         icon_label.setFixedSize(20, 20)
@@ -360,7 +360,7 @@ class NotificationBell(QWidget):
 
         # Bell icon button using QToolButton with a Material Design icon
         self.bell_btn = QToolButton()
-        self.bell_btn.setIcon(fibsem_icon("mdi:bell", color=f"{TEXT_COLOR}"))
+        self.bell_btn.setIcon(fibsem_icon("mdi:bell", color=TEXT_COLOR))
         self.bell_btn.setFixedSize(24, 24)
         self.bell_btn.setIconSize(self.bell_btn.size() * 0.7)
         self.bell_btn.clicked.connect(self._on_clicked)

--- a/fibsem/ui/widgets/notifications.py
+++ b/fibsem/ui/widgets/notifications.py
@@ -21,13 +21,17 @@ from PyQt5.QtWidgets import (
 from fibsem.ui.icon import fibsem_icon
 from fibsem.constants import TIME_DISPLAY
 from fibsem.ui import stylesheets
+from fibsem.ui.tokens import (
+    ACCENT_COLOR,
+    TEXT_COLOR,
+)
 
 class ToastNotification(QWidget):
     """A toast notification widget that appears in the bottom-right corner."""
 
     # Notification types with colors
     TYPES = {
-        "info": "#50a6ff",                      # Blue
+        "info": f"{ACCENT_COLOR}",                      # Blue
         "success": stylesheets.GREEN_COLOR,     # Green
         "warning": stylesheets.ORANGE_COLOR,    # Orange
         "error": "#f44336",                     # Red
@@ -224,7 +228,7 @@ class NotificationHistoryPopup(QWidget):
         header_layout.setContentsMargins(12, 10, 12, 10)
 
         header_label = QLabel("Notifications")
-        header_label.setStyleSheet("color: #d6d6d6; font-weight: bold; font-size: 14px;")
+        header_label.setStyleSheet(f"color: {TEXT_COLOR}; font-weight: bold; font-size: 14px;")
         header_layout.addWidget(header_label)
 
         header_layout.addStretch()
@@ -300,7 +304,7 @@ class NotificationHistoryPopup(QWidget):
         item_layout.setSpacing(10)
 
         # Icon
-        color = ToastNotification.TYPES.get(notification_type, "#50a6ff")
+        color = ToastNotification.TYPES.get(notification_type, f"{ACCENT_COLOR}")
         icons = {"info": "ℹ", "success": "✓", "warning": "⚠", "error": "✕"}
         icon_label = QLabel(icons.get(notification_type, "ℹ"))
         icon_label.setFixedSize(20, 20)
@@ -314,7 +318,7 @@ class NotificationHistoryPopup(QWidget):
 
         msg_label = QLabel(message)
         msg_label.setWordWrap(True)
-        msg_label.setStyleSheet("color: #d6d6d6; font-size: 13px;")
+        msg_label.setStyleSheet(f"color: {TEXT_COLOR}; font-size: 13px;")
         text_layout.addWidget(msg_label)
 
         time_label = QLabel(timestamp)
@@ -356,7 +360,7 @@ class NotificationBell(QWidget):
 
         # Bell icon button using QToolButton with a Material Design icon
         self.bell_btn = QToolButton()
-        self.bell_btn.setIcon(fibsem_icon("mdi:bell", color="#d6d6d6"))
+        self.bell_btn.setIcon(fibsem_icon("mdi:bell", color=f"{TEXT_COLOR}"))
         self.bell_btn.setFixedSize(24, 24)
         self.bell_btn.setIconSize(self.bell_btn.size() * 0.7)
         self.bell_btn.clicked.connect(self._on_clicked)

--- a/fibsem/ui/widgets/sample_holder_widget.py
+++ b/fibsem/ui/widgets/sample_holder_widget.py
@@ -20,6 +20,9 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem.microscopes._stage import GridSlot, SampleGrid, SampleHolder
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import TitledPanel, ValueSpinBox
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 _ROW_HEIGHT = 40
 _BTN_SIZE = QSize(32, 32)
@@ -134,7 +137,7 @@ class _GridSlotRowWidget(QWidget):
 class _GridListHeader(QWidget):
     def __init__(self, title: str = "Slots", parent=None):
         super().__init__(parent)
-        self.setStyleSheet("background: #1e2124;")
+        self.setStyleSheet(f"background: {CANVAS_BG};")
         self.setFixedHeight(_BTN_SIZE.height() + 8)
 
         layout = QHBoxLayout(self)

--- a/fibsem/ui/widgets/saved_position_widget.py
+++ b/fibsem/ui/widgets/saved_position_widget.py
@@ -25,6 +25,9 @@ from fibsem.structures import FibsemStagePosition
 from fibsem.ui import stylesheets
 from fibsem.ui.utils import message_box_ui
 from fibsem.ui.widgets.custom_widgets import IconToolButton
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 _NAME_MIN_WIDTH = 160
 _BTN_SIZE = QSize(32, 32)
@@ -116,7 +119,7 @@ class _SavedPositionListHeader(QWidget):
 
     def __init__(self, parent: QWidget = None) -> None:
         super().__init__(parent)
-        self.setStyleSheet("background: #1e2124;")
+        self.setStyleSheet(f"background: {CANVAS_BG};")
         self._setup_ui()
 
     def _setup_ui(self) -> None:

--- a/fibsem/ui/widgets/task_summary_formatting.py
+++ b/fibsem/ui/widgets/task_summary_formatting.py
@@ -7,6 +7,13 @@ WorkflowSummaryDialog (per-run summary) so the two stay visually consistent.
 from typing import Callable, List, Optional
 
 import pandas as pd
+from fibsem.ui.tokens import (
+    ACCENT_COLOR,
+    ERROR_COLOR,
+    OK_COLOR,
+    TEXT_MUTED_COLOR,
+    WARN_COLOR,
+)
 
 # Default per-run summary columns (in display order)
 SUMMARY_COLUMNS: List[str] = [
@@ -39,11 +46,11 @@ STATUS_COLORS = {
 # Semantic badge colours (matching the fibsem.ui.stylesheets palette) used by
 # the workflow summary dialog: status -> (dot/strong colour, muted text colour).
 STATUS_BADGE_COLORS = {
-    "Completed": ("#4caf50", "#7fd083"),
-    "Failed": ("#d04040", "#e08585"),
-    "Skipped": ("#868e93", "#aeb4b9"),
-    "InProgress": ("#50a6ff", "#9cc7f5"),
-    "Cancelled": ("#e0a030", "#e8c37f"),  # amber: user-aborted, not an error
+    "Completed": (f"{OK_COLOR}", "#7fd083"),
+    "Failed": (f"{ERROR_COLOR}", "#e08585"),
+    "Skipped": (f"{TEXT_MUTED_COLOR}", "#aeb4b9"),
+    "InProgress": (f"{ACCENT_COLOR}", "#9cc7f5"),
+    "Cancelled": (f"{WARN_COLOR}", "#e8c37f"),  # amber: user-aborted, not an error
 }
 
 # Status order for count chips (these three are always shown, even at zero)

--- a/fibsem/ui/widgets/task_summary_formatting.py
+++ b/fibsem/ui/widgets/task_summary_formatting.py
@@ -46,11 +46,11 @@ STATUS_COLORS = {
 # Semantic badge colours (matching the fibsem.ui.stylesheets palette) used by
 # the workflow summary dialog: status -> (dot/strong colour, muted text colour).
 STATUS_BADGE_COLORS = {
-    "Completed": (f"{OK_COLOR}", "#7fd083"),
-    "Failed": (f"{ERROR_COLOR}", "#e08585"),
-    "Skipped": (f"{TEXT_MUTED_COLOR}", "#aeb4b9"),
-    "InProgress": (f"{ACCENT_COLOR}", "#9cc7f5"),
-    "Cancelled": (f"{WARN_COLOR}", "#e8c37f"),  # amber: user-aborted, not an error
+    "Completed": (OK_COLOR, "#7fd083"),
+    "Failed": (ERROR_COLOR, "#e08585"),
+    "Skipped": (TEXT_MUTED_COLOR, "#aeb4b9"),
+    "InProgress": (ACCENT_COLOR, "#9cc7f5"),
+    "Cancelled": (WARN_COLOR, "#e8c37f"),  # amber: user-aborted, not an error
 }
 
 # Status order for count chips (these three are always shown, even at zero)

--- a/fibsem/ui/widgets/workflow_config_widget.py
+++ b/fibsem/ui/widgets/workflow_config_widget.py
@@ -28,6 +28,9 @@ from fibsem.applications.autolamella.structures import (
 )
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+)
 
 _DRAG_HANDLE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "icons", "drag_handle.svg")
 _NAME_MIN_WIDTH = 180
@@ -177,7 +180,7 @@ class _WorkflowTaskListHeader(QWidget):
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self.setStyleSheet("background: #1e2124;")
+        self.setStyleSheet(f"background: {CANVAS_BG};")
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(6, 4, 6, 4)

--- a/fibsem/ui/widgets/workflow_info_widget.py
+++ b/fibsem/ui/widgets/workflow_info_widget.py
@@ -16,6 +16,9 @@ from fibsem.applications.autolamella.structures import (
     AutoLamellaWorkflowConfig,
     AutoLamellaWorkflowOptions,
 )
+from fibsem.ui.tokens import (
+    TEXT_COLOR,
+)
 
 _LABEL_STYLE = "color: #a0a0a0; min-width: 80px; font-size: 11px;"
 _SECTION_STYLE = (
@@ -83,7 +86,7 @@ class WorkflowInfoWidget(QWidget):
         root.addWidget(opt_lbl)
 
         self.turn_beams_off_cb = QCheckBox("Turn beams off after completion")
-        self.turn_beams_off_cb.setStyleSheet("color: #d6d6d6; font-size: 11px;")
+        self.turn_beams_off_cb.setStyleSheet(f"color: {TEXT_COLOR}; font-size: 11px;")
         root.addWidget(self.turn_beams_off_cb)
 
         # ── signals ───────────────────────────────────────────────────────

--- a/fibsem/ui/widgets/workflow_summary_dialog.py
+++ b/fibsem/ui/widgets/workflow_summary_dialog.py
@@ -171,7 +171,7 @@ class WorkflowSummaryDialog(QDialog):
     @staticmethod
     def _make_chip(status: str, count: int) -> QLabel:
         """A pill label: coloured dot + 'N status'."""
-        dot_color, text_color = STATUS_BADGE_COLORS.get(status, (f"{TEXT_MUTED_COLOR}", "#aeb4b9"))
+        dot_color, text_color = STATUS_BADGE_COLORS.get(status, (TEXT_MUTED_COLOR, "#aeb4b9"))
         bg = QColor(dot_color)
         bg_rgba = f"rgba({bg.red()}, {bg.green()}, {bg.blue()}, 0.15)"
         chip = QLabel(f'<span style="color:{dot_color};">&#9679;</span> {count} {status.lower()}')

--- a/fibsem/ui/widgets/workflow_summary_dialog.py
+++ b/fibsem/ui/widgets/workflow_summary_dialog.py
@@ -37,6 +37,9 @@ from fibsem.ui.widgets.task_summary_formatting import (
     STATUS_CHIP_ORDER,
     format_duration_short,
 )
+from fibsem.ui.tokens import (
+    TEXT_MUTED_COLOR,
+)
 
 # Short local names for the shared palette. These appear inside dozens of
 # f-strings below, where the full names would wrap every one of them.
@@ -168,7 +171,7 @@ class WorkflowSummaryDialog(QDialog):
     @staticmethod
     def _make_chip(status: str, count: int) -> QLabel:
         """A pill label: coloured dot + 'N status'."""
-        dot_color, text_color = STATUS_BADGE_COLORS.get(status, ("#868e93", "#aeb4b9"))
+        dot_color, text_color = STATUS_BADGE_COLORS.get(status, (f"{TEXT_MUTED_COLOR}", "#aeb4b9"))
         bg = QColor(dot_color)
         bg_rgba = f"rgba({bg.red()}, {bg.green()}, {bg.blue()}, 0.15)"
         chip = QLabel(f'<span style="color:{dot_color};">&#9679;</span> {count} {status.lower()}')

--- a/tests/ui/test_shared_palette.py
+++ b/tests/ui/test_shared_palette.py
@@ -29,7 +29,17 @@ TOKENS = PACKAGE / "ui" / "tokens.py"
 # declares one is duplicating them.
 PALETTE_SOURCES = (TOKENS, STYLESHEETS)
 
-_DECLARATION = re.compile(r'^(_?[A-Z][A-Z_0-9]*) *= *"(#[0-9a-fA-F]{3,8})"', re.M)
+# Matches `NAME = "#hex"` and the wrapped form `NAME = QColor("#hex")`.
+#
+# The wrapper is not cosmetic: matching only the bare form left this test blind
+# to a whole file. tile_mask_widget.py declared five colours as QColor("...")
+# -- four of them exact copies of SURFACE_COLOR, PANEL_COLOR, BORDER_COLOR and
+# ACCENT_COLOR -- and the build stayed green, which is the exact outcome this
+# test exists to prevent.
+_DECLARATION = re.compile(
+    r'^(_?[A-Z][A-Z_0-9]*) *= *(?:[A-Za-z_][\w.]* *\( *)?"(#[0-9a-fA-F]{3,8})"',
+    re.M,
+)
 
 
 def _shared_colours():


### PR DESCRIPTION
Follow-up to #304 and #308. Those made the palette the single source of truth *inside* `stylesheets.py`; this does the same for the colour scattered through the widgets.

Three commits, each independently reviewable and each intended to be visually inert.

## 1. The palette guard had a blind spot (`ec3beb78`)

`tests/ui/test_shared_palette.py` fails the build when a module re-declares a colour the palette already defines. It matched `NAME = "#hex"` only — so wrapping the literal hid it:

```python
BACKGROUND = QColor("#262930")   # invisible to the guard
```

`tile_mask_widget.py` declared seven colours this way. **Five duplicated existing tokens** (`SURFACE_COLOR`, `PANEL_COLOR`, `BORDER_COLOR`, `ACCENT_COLOR`, `TEXT_MUTED_COLOR`) and the build stayed green — precisely the outcome that test exists to prevent. The pattern now accepts an optional callable wrapper, and those five point at the tokens.

## 2. Inline literals that already equalled a token (`c5cf49c6`)

89 hex literals across 35 files were byte-identical to a token — `"#1e2124"` where `CANVAS_BG` says the same thing. They rendered correctly and would have kept doing so right up until someone retuned the palette, at which point they would not have moved.

**Case is deliberately significant.** `#d1d2d4` is *not* replaced by `GRAY_ICON_COLOR`, whose value is `#D1D2D4`. Qt cannot tell the difference; the rendered string can. Matching case-insensitively is what took the count from 89 to a wrong 137 on the first attempt.

## 3. The disabled pair now has a name (`55afa8a6`)

`#2d313b` and `#6b6b6b` are the background and text of every `:disabled` rule in all four semantic button sheets, repeated as bare literals. They were the most load-bearing colours in the UI with no name. Now `DISABLED_BG_COLOR` and `DISABLED_TEXT_COLOR`, clearing the two largest `# TODO: no token` entries.

Adding the token immediately **failed the guard** on `RECENT_UNAVAILABLE_COLOR = "#6b6b6b"` in `autolamella_load_experiment_widget` — the guard working. That row is a disabled state and now says so.

## How this was verified

There is no golden test here, because these literals live inside methods rather than as module constants. Instead every string literal in `fibsem/` was resolved from the AST — f-strings substituted with their token values, other expressions rendered as stable markers — before and after:

**4911 resolved strings across 387 files, all identical.**

The harness was checked against a deliberately wrong swap before being trusted, and again after it was modified mid-way. `957 passed` for `tests/ui/` plus `tests/test_import_cycles.py`.

## Deliberately not included

**48 brace-carrying sites.** Converting those to f-strings means doubling every literal brace, and a missed pair silently drops a QSS rule — the failure mode `tests/ui/test_stylesheets_render.py` exists for. Separate pass.

**Files outside `fibsem/ui` that don't already import the palette.** `from fibsem.ui.tokens import ...` costs **138 fibsem modules** today, all of it from `fibsem/ui/__init__` eagerly importing the widget layer; `tokens.py`'s own cost is **0**. Adding that to e.g. a correlation module would roughly triple its import weight, which is exactly why `correlation/fit_diagnostics.py` hand-rolls `_FIG_BG = "#1e2124"` instead of importing `CANVAS_BG`. Those files stay on their local copies until that import is made lazy — the single highest-leverage fix left in this area.

**Two `:hover` rules in `NAPARI_STYLE` still on `#2d313b`.** Hover is not disabled, and `ROW_ALT_COLOR` is the token that means hover — but it is `#2b2f38`, four units of RGB away. Indistinguishable on screen, different in a diff. Reconciling them is a real colour change, so they are flagged in place rather than folded in silently.

## Still open, repo-wide

For context, the survey behind this PR found **82 distinct near-miss values over 324 occurrences** — colours within a few RGB units of a token but not equal. And three widgets render tile enabled/disabled state in three unrelated colour schemes (`tile_mask_widget` blue, `tiled_overview_widget` green, `tile_grid_overlay` magenta), which is the class where a widget can actively disagree with the image it labels.
