### PR TITLE
[ui] Declare field metadata through a typed constructor (FIB-531)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -19,6 +19,7 @@ from fibsem.applications.autolamella.workflows.ui import (
 from fibsem.fm.acquisition import acquire_image
 from fibsem.fm.structures import AutoFocusSettings, ChannelSettings, ZParameters
 from fibsem.fm.calibration import run_coarse_fine_autofocus, AutoFocusResult
+from fibsem.structures import field_meta
 
 
 @dataclass
@@ -27,20 +28,20 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
     task_type: ClassVar[str] = "ACQUIRE_FLUORESCENCE_IMAGE"
     display_name: ClassVar[str] = "Acquire Fluorescence Image"
     channel_settings: list[ChannelSettings] = field(default_factory=list,
-                                                    metadata={"tooltip": "Settings for each fluorescence channel",
-                                                             "label": "Channel Settings"})
-    zparams: ZParameters = field(default_factory=ZParameters, 
-                                  metadata={"tooltip": "Z-stack acquisition parameters",
-                                            "label": "Z-Stack Parameters"})
+                                                    metadata=field_meta(tooltip="Settings for each fluorescence channel",
+                                                                        label="Channel Settings"))
+    zparams: ZParameters = field(default_factory=ZParameters,
+                                  metadata=field_meta(tooltip="Z-stack acquisition parameters",
+                                                      label="Z-Stack Parameters"))
     autofocus_settings: AutoFocusSettings = field(default_factory=AutoFocusSettings,
-                                                  metadata={"tooltip": "Settings for autofocus before acquiring fluorescence images",
-                                                            "label": "Autofocus Settings"})
+                                                  metadata=field_meta(tooltip="Settings for autofocus before acquiring fluorescence images",
+                                                                      label="Autofocus Settings"))
     orientation: Optional[str] = field(default=None,
-                                       metadata={"tooltip": "Orientation for acquisition. 'FM' or 'SEM'. None = use fluorescence_pose as-is.",
-                                                 "label": "Orientation"})
+                                       metadata=field_meta(tooltip="Orientation for acquisition. 'FM' or 'SEM'. None = use fluorescence_pose as-is.",
+                                                           label="Orientation"))
     retract_objective: bool = field(default=True,
-                                    metadata={"tooltip": "Retract the objective when the task finishes, so it is clear of the stage for subsequent moves. Disable for back-to-back fluorescence tasks.",
-                                              "label": "Retract Objective"})
+                                    metadata=field_meta(tooltip="Retract the objective when the task finishes, so it is clear of the stage for subsequent moves. Disable for back-to-back fluorescence tasks.",
+                                                        label="Retract Objective"))
 
     def to_dict(self) -> dict:
         ddict = {}

--- a/fibsem/applications/autolamella/workflows/tasks/fiducial.py
+++ b/fibsem/applications/autolamella/workflows/tasks/fiducial.py
@@ -21,7 +21,7 @@ from fibsem.applications.autolamella.workflows.tasks.base import (
 )
 from fibsem.milling.patterning.utils import get_pattern_reduced_area
 from fibsem.milling.tasks import FibsemMillingTaskConfig
-from fibsem.structures import FibsemImage
+from fibsem.structures import FibsemImage, field_meta
 
 
 @dataclass
@@ -30,16 +30,16 @@ class MillFiducialTaskConfig(AutoLamellaTaskConfig):
 
     alignment_expansion: float = field(
         default=100.0,
-        metadata={
-            "tooltip": "The percentage to expand the alignment area around the fiducial",
-            "unit": "%",
-        },
+        metadata=field_meta(
+            tooltip="The percentage to expand the alignment area around the fiducial",
+            unit="%",
+        ),
     )
     align_to_reference: bool = field(
         default=True,
-        metadata={
-            "tooltip": "Align to the reference image before milling fiducial (if available)"
-        }
+        metadata=field_meta(
+            tooltip="Align to the reference image before milling fiducial (if available)"
+        )
 
     )
     task_type: ClassVar[str] = "MILL_FIDUCIAL"

--- a/fibsem/applications/autolamella/workflows/tasks/grid_tasks.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid_tasks.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, ClassVar, Dict, Literal, Optional, Type
 from fibsem.imaging.tiled import tiled_image_acquisition_and_stitch
 from fibsem.microscope import FibsemMicroscope
 from fibsem.microscopes._stage import GridSlot, SampleGrid, SampleHolder
-from fibsem.structures import BeamType, FibsemStagePosition, ImageSettings, OverviewAcquisitionSettings
+from fibsem.structures import BeamType, FibsemStagePosition, ImageSettings, OverviewAcquisitionSettings, field_meta
 
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.structures import Experiment
@@ -143,7 +143,7 @@ class AcquireImageGridTaskConfig(GridTaskConfig):
     task_type: ClassVar[str] = "ACQUIRE_IMAGE_GRID"
     display_name: ClassVar[str] = "Acquire Image"
     orientation: Optional[Literal["SEM", "FIB", "MILLING"]] = "SEM"
-    voltage: float = field(default=5_000, metadata={"label": "Imaging Voltage" })
+    voltage: float = field(default=5_000, metadata=field_meta(label="Imaging Voltage"))
 
 
 class AcquireImageTask(GridTask):

--- a/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
+++ b/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 from fibsem.milling.patterning.patterns2 import RectanglePattern
 from fibsem.milling.tasks import FibsemMillingTaskConfig, FibsemMillingStage
 from fibsem.milling.base import FibsemMillingSettings
-from fibsem.structures import CrossSectionPattern
+from fibsem.structures import CrossSectionPattern, field_meta
 import fibsem.utils as utils
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
 from fibsem.applications.autolamella.workflows._default_milling_config import (
@@ -59,32 +59,32 @@ class MillCoincidentTaskConfig(AutoLamellaTaskConfig):
 
     acquire_sem: bool = field(
         default=True,
-        metadata={
-            "tooltip": "Whether to acquire an SEM reference image",
-            "label": "Acquire SEM Image",
-        },
+        metadata=field_meta(
+            tooltip="Whether to acquire an SEM reference image",
+            label="Acquire SEM Image",
+        ),
     )
     acquire_fib: bool = field(
         default=True,
-        metadata={
-            "tooltip": "Whether to acquire a FIB reference image",
-            "label": "Acquire FIB Image",
-        },
+        metadata=field_meta(
+            tooltip="Whether to acquire a FIB reference image",
+            label="Acquire FIB Image",
+        ),
     )
     acquire_fluorescence_images: bool = field(
         default=True,
-        metadata={
-            "label": "Acquire Fluorescence Images",
-            "tooltip": "Whether to acquire fluorescence images before and after coincident milling",
-        },
+        metadata=field_meta(
+            label="Acquire Fluorescence Images",
+            tooltip="Whether to acquire fluorescence images before and after coincident milling",
+        ),
     )
     orientation: Literal["SEM", "FIB", "MILLING"] = field(
         default="MILLING",
-        metadata={"tooltip": "The orientation to perform coincident milling in"},
+        metadata=field_meta(tooltip="The orientation to perform coincident milling in"),
     )
     channel_name: str = field(
         default="Red Channel",
-        metadata={"tooltip": "The fluorescence channel to use for coincident milling"},
+        metadata=field_meta(tooltip="The fluorescence channel to use for coincident milling"),
     )
     task_type: ClassVar[str] = "MILL_COINCIDENT"
     display_name: ClassVar[str] = "Coincident Milling"

--- a/fibsem/applications/autolamella/workflows/tasks/polishing.py
+++ b/fibsem/applications/autolamella/workflows/tasks/polishing.py
@@ -14,6 +14,7 @@ from fibsem.applications.autolamella.workflows.tasks.base import (
     ALIGNMENT_REFERENCE_IMAGE_FILENAME,
     AutoLamellaTask,
 )
+from fibsem.structures import field_meta
 
 
 @dataclass
@@ -21,9 +22,9 @@ class MillPolishingTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the MillPolishingTask."""
     sync_to_poi: bool = field(
         default=True,
-        metadata={
-            "label": "Link to Point of Interest",
-            "tooltip": "Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated."},
+        metadata=field_meta(
+            label="Link to Point of Interest",
+            tooltip="Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated."),
     )
     task_type: ClassVar[str] = "MILL_POLISHING"
     display_name: ClassVar[str] = "Polishing"

--- a/fibsem/applications/autolamella/workflows/tasks/reference_image.py
+++ b/fibsem/applications/autolamella/workflows/tasks/reference_image.py
@@ -8,6 +8,7 @@ from fibsem import utils
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
 from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
 from fibsem.applications.autolamella.workflows.ui import ask_user
+from fibsem.structures import field_meta
 
 
 @dataclass
@@ -17,11 +18,11 @@ class AcquireReferenceImageConfig(AutoLamellaTaskConfig):
     display_name: ClassVar[str] = "Acquire Reference Image"
     orientation: Literal["SEM", "FIB", "MILLING"] = field(
         default="MILLING",
-        metadata={"tooltip": "The orientation to acquire reference images in (SEM, FIB, MILLING)", "items": ("SEM", "FIB", "MILLING")},
+        metadata=field_meta(tooltip="The orientation to acquire reference images in (SEM, FIB, MILLING)", items=("SEM", "FIB", "MILLING")),
     ) # change to pose?
     filename: Optional[str] = field(
         default=None,
-        metadata={"tooltip": "Custom filename for reference images. If None, auto-generates from last completed task name and timestamp."},
+        metadata=field_meta(tooltip="Custom filename for reference images. If None, auto-generates from last completed task name and timestamp."),
     )
 
 

--- a/fibsem/applications/autolamella/workflows/tasks/rough.py
+++ b/fibsem/applications/autolamella/workflows/tasks/rough.py
@@ -20,7 +20,7 @@ from fibsem.applications.autolamella.workflows.tasks.base import (
     AutoLamellaTask,
 )
 from fibsem.milling.tasks import FibsemMillingTaskConfig
-from fibsem.structures import Point
+from fibsem.structures import Point, field_meta
 
 
 @dataclass
@@ -28,21 +28,21 @@ class MillRoughTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the MillRoughTask."""
     sync_polishing_position: bool = field(
         default=True,
-        metadata={
-            "label": "Synchronize Polishing Position",
-            "tooltip": "Whether to synchronize the polishing position with the rough milling position (recommended.)"},
+        metadata=field_meta(
+            label="Synchronize Polishing Position",
+            tooltip="Whether to synchronize the polishing position with the rough milling position (recommended.)"),
     )
     sync_to_poi: bool = field(
         default=True,
-        metadata={
-            "label": "Link to Point of Interest",
-            "tooltip": "Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated."},
+        metadata=field_meta(
+            label="Link to Point of Interest",
+            tooltip="Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated."),
     )
     reacquire_alignment_reference: bool = field(
         default=False,
-        metadata={
-            "label": "Reacquire Alignment Reference",
-            "tooltip": "Whether to reacquire the alignment reference after milling"},
+        metadata=field_meta(
+            label="Reacquire Alignment Reference",
+            tooltip="Whether to reacquire the alignment reference after milling"),
     )
     task_type: ClassVar[str] = "MILL_ROUGH"
     display_name: ClassVar[str] = "Rough Milling"

--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -11,7 +11,7 @@ from fibsem import constants
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
 from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
 from fibsem.applications.autolamella.workflows.ui import ask_user, select_poi_ui
-from fibsem.structures import BeamType, ImageSettings
+from fibsem.structures import BeamType, ImageSettings, field_meta
 
 
 @dataclass
@@ -20,27 +20,27 @@ class SelectMillingPositionTaskConfig(AutoLamellaTaskConfig):
 
     milling_angle: float = field(
         default=15,
-        metadata={
-            "tooltip": "The angle between the FIB and sample used for milling",
-            "unit": constants.DEGREE_SYMBOL,
-        },)
+        metadata=field_meta(
+            tooltip="The angle between the FIB and sample used for milling",
+            unit=constants.DEGREE_SYMBOL,
+        ),)
     auto_milling_alignment: bool = field(
         default=False,
-        metadata={
-            "label": "Auto Milling Angle Alignment",
-            "tooltip": "Whether to automatically align for a milling position"},
+        metadata=field_meta(
+            label="Auto Milling Angle Alignment",
+            tooltip="Whether to automatically align for a milling position"),
     )
     use_autofocus: bool = field(
         default=True,
-        metadata={
-            "label": "Use Autofocus",
-            "tooltip": "Whether to autofocus before moving to the milling position"},
+        metadata=field_meta(
+            label="Use Autofocus",
+            tooltip="Whether to autofocus before moving to the milling position"),
     )
     select_poi: bool = field(
         default=True,
-        metadata={
-            "label": "Select Point of Interest",
-            "tooltip": "Whether to ask the user to select a point of interest in the FIB image"},
+        metadata=field_meta(
+            label="Select Point of Interest",
+            tooltip="Whether to ask the user to select a point of interest in the FIB image"),
     )
     task_type: ClassVar[str] = "SELECT_MILLING_POSITION"
     display_name: ClassVar[str] = "Select Milling Position"

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -20,7 +20,7 @@ from fibsem.applications.autolamella.workflows.ui import (
     update_spot_burn_parameters,
 )
 from fibsem.imaging.spot import SpotBurnSettings, run_spot_burn
-from fibsem.structures import BeamType, Point
+from fibsem.structures import BeamType, Point, field_meta
 
 
 @dataclass
@@ -30,31 +30,31 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
     display_name: ClassVar[str] = "Spot Burn Fiducial"
     milling_current: float = field(
         default=60.0e-12,  # in Amperes
-        metadata={
-            'tooltip': 'Milling current in Amperes',
-            'unit': 'A',
-            'scale': 1e12
-        }
+        metadata=field_meta(
+            tooltip='Milling current in Amperes',
+            unit='A',
+            scale=1e12
+        )
     )
     exposure_time: int = field(
         default=10,
-        metadata={
-            'tooltip': 'Exposure time in seconds',
-            'unit': 's',
-            'scale': 1
-        }
+        metadata=field_meta(
+            tooltip='Exposure time in seconds',
+            unit='s',
+            scale=1
+        )
     )
     autofocus: bool = field(
         default=False,
-        metadata={
-            "tooltip": "Run a FIB autofocus before acquiring the reference image, so the "
+        metadata=field_meta(
+            tooltip="Run a FIB autofocus before acquiring the reference image, so the "
                     "points are placed on (and burned into) a focused image",
-            "label": "Autofocus",
-        },
+            label="Autofocus",
+        ),
     )
     coordinates: list[Point] = field(
         default_factory=list,
-        metadata={"tooltip": "Spot burn positions in normalised image coordinates (0-1)"},
+        metadata=field_meta(tooltip="Spot burn positions in normalised image coordinates (0-1)"),
     )
 
     @property

--- a/fibsem/applications/autolamella/workflows/tasks/trench.py
+++ b/fibsem/applications/autolamella/workflows/tasks/trench.py
@@ -19,7 +19,7 @@ from fibsem.applications.autolamella.workflows.tasks.base import (
     MAX_ALIGNMENT_ATTEMPTS,
 )
 from fibsem.alignment import AlignmentSubsystem
-from fibsem.structures import BeamType, FibsemImage
+from fibsem.structures import BeamType, FibsemImage, field_meta
 
 
 @dataclass
@@ -27,15 +27,15 @@ class MillTrenchTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the MillTrenchTask."""
     align_reference: bool = field(
         default=False,  # whether to align to a trench reference image
-        metadata={"tooltip": "Whether to align to a trench reference image"},
+        metadata=field_meta(tooltip="Whether to align to a trench reference image"),
     )
     charge_neutralisation: bool = field(
         default=True,  # whether to perform charge neutralisation
-        metadata={"tooltip": "Whether to perform charge neutralisation"},
+        metadata=field_meta(tooltip="Whether to perform charge neutralisation"),
     )
     orientation: Optional[Literal["SEM", "FIB", "MILLING"]] = field(
         default=None,
-        metadata={"tooltip": "The orientation to perform trench milling in", "items": ("SEM", "FIB", "MILLING", None)},
+        metadata=field_meta(tooltip="The orientation to perform trench milling in", items=("SEM", "FIB", "MILLING", None)),
     )
     task_type: ClassVar[str] = "MILL_TRENCH"
     display_name: ClassVar[str] = "Trench Milling"

--- a/fibsem/applications/autolamella/workflows/tasks/undercut.py
+++ b/fibsem/applications/autolamella/workflows/tasks/undercut.py
@@ -20,7 +20,7 @@ from fibsem.applications.autolamella.workflows.core import (
 )
 from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
 from fibsem.detection.detection import LamellaCentre, LamellaBottomEdge, LamellaTopEdge
-from fibsem.structures import BeamType
+from fibsem.structures import BeamType, field_meta
 
 
 @dataclass
@@ -28,12 +28,12 @@ class MillUndercutTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the MillUndercutTask."""
     orientation: Optional[Literal["SEM", "FIB", "MILLING"]] = field(
         default="SEM",
-        metadata={"tooltip": "The orientation to perform undercut milling in", "items": ("SEM", "FIB", "MILLING", None)},
+        metadata=field_meta(tooltip="The orientation to perform undercut milling in", items=("SEM", "FIB", "MILLING", None)),
     )
     milling_angles: List[float] = field(
         default_factory=lambda: [25, 20],  # in degrees
-        metadata={"tooltip": "The angles to mill the undercuts at",
-                  "unit": constants.DEGREE_SYMBOL},
+        metadata=field_meta(tooltip="The angles to mill the undercuts at",
+                            unit=constants.DEGREE_SYMBOL),
     )
     task_type: ClassVar[str] = "MILL_UNDERCUT"
     display_name: ClassVar[str] = "Undercut Milling"

--- a/fibsem/milling/properties.py
+++ b/fibsem/milling/properties.py
@@ -1,69 +1,73 @@
 from fibsem import constants, config as cfg
 from typing import List
-from fibsem.structures import CrossSectionPattern
+from fibsem.structures import CrossSectionPattern, field_meta
 from fibsem.utils import format_resolution_as_str
 
+# Shared metadata for the parameters that recur across patterns and strategies.
+# Declared through `field_meta` so the keys are checked once here rather than at
+# each of the ~110 sites that spread these in -- a typo in a shared dict is a
+# typo in every pattern that uses it.
 
-DEFAULT_DISTANCE_METADATA = {
-    "type": float,
-    "unit": "m",
-    "scale": 1e6,
-    "minimum": 0.01,
-    "maximum": 1000.0,
-    "step": 0.1,
-    "decimals": 2,
-}
+DEFAULT_DISTANCE_METADATA = field_meta(
+    type=float,
+    unit="m",
+    scale=1e6,
+    minimum=0.01,
+    maximum=1000.0,
+    step=0.1,
+    decimals=2,
+)
 
-DEFAULT_ANGLE_METADATA = {
-    "label": "Rotation",
-    "type": float,
-    "unit": constants.DEGREE_SYMBOL,
-    "scale": None,
-    "minimum": 0.0,
-    "maximum": 360.0,
-    "step": 1.0,
-    "decimals": 2,
-}
-DEFAULT_DURATION_METADATA = {
-    "label": "Time",
-    "type": float,
-    "unit": "s",
-    "minimum": 0.0,
-    "maximum": 10000.0,
-    "step": 0.1,
-    "decimals": 1,
-    "advanced": True,
-    "tooltip": "Specify the duration of the milling pattern in seconds. Set to 0 for automatic calculation.",
-}
-DEFAULT_SCAN_DIRECTION_METADATA = {
-    "label": "Scan Direction",
-    "type": str,
-    "items": "dynamic",
-    "microscope_parameter": "scan_direction",
-    "tooltip": "Direction of the scan for the pattern.",
-}
+DEFAULT_ANGLE_METADATA = field_meta(
+    label="Rotation",
+    type=float,
+    unit=constants.DEGREE_SYMBOL,
+    scale=None,
+    minimum=0.0,
+    maximum=360.0,
+    step=1.0,
+    decimals=2,
+)
+DEFAULT_DURATION_METADATA = field_meta(
+    label="Time",
+    type=float,
+    unit="s",
+    minimum=0.0,
+    maximum=10000.0,
+    step=0.1,
+    decimals=1,
+    advanced=True,
+    tooltip="Specify the duration of the milling pattern in seconds. Set to 0 for automatic calculation.",
+)
+DEFAULT_SCAN_DIRECTION_METADATA = field_meta(
+    label="Scan Direction",
+    type=str,
+    items="dynamic",
+    microscope_parameter="scan_direction",
+    tooltip="Direction of the scan for the pattern.",
+)
 
-DEFAULT_CROSS_SECTION_METADATA = {
-    "label": "Cross Section",
-    "type": CrossSectionPattern,
-    "items": [cs for cs in CrossSectionPattern],
-    "tooltip": "The type of cross section for the milling pattern.",
-}
+DEFAULT_CROSS_SECTION_METADATA = field_meta(
+    label="Cross Section",
+    type=CrossSectionPattern,
+    items=[cs for cs in CrossSectionPattern],
+    tooltip="The type of cross section for the milling pattern.",
+)
 
-DEFAULT_PASSES_METADATA = {
-    "label": "Passes",
-    "type": int,
-    "minimum": 0,
-    "maximum": 100000000,
-    "step": 1,
-    "advanced": True,
-    "tooltip": "Number of passes for the pattern. Set to 0 for automatic calculation." 
-}
+DEFAULT_PASSES_METADATA = field_meta(
+    label="Passes",
+    type=int,
+    minimum=0,
+    maximum=100000000,
+    step=1,
+    advanced=True,
+    tooltip="Number of passes for the pattern. Set to 0 for automatic calculation.",
+)
 
-DEFAULT_IMAGE_RESOLUTION_METADATA = {
-    "label": "Image Resolution",
-    "type": List[int],
-    "items": cfg.STANDARD_RESOLUTIONS_LIST,
-    "tooltip": "The imaging resolution in pixels (Width x Height).",
-    "format_fn": format_resolution_as_str,
-}
+DEFAULT_IMAGE_RESOLUTION_METADATA = field_meta(
+    label="Image Resolution",
+    type=List[int],
+    items=cfg.STANDARD_RESOLUTIONS_LIST,
+    tooltip="The imaging resolution in pixels (Width x Height).",
+    format_fn=format_resolution_as_str,
+)

--- a/fibsem/milling/strategy/coincidence.py
+++ b/fibsem/milling/strategy/coincidence.py
@@ -21,7 +21,7 @@ from fibsem.milling import (
     MillingStrategy,
     MillingStrategyConfig,
 )
-from fibsem.structures import BeamType, FibsemImage, FibsemRectangle
+from fibsem.structures import BeamType, FibsemImage, FibsemRectangle, field_meta
 from fibsem.microscopes.simulator import DemoMicroscope
 
 if TYPE_CHECKING:
@@ -36,77 +36,77 @@ class CoincidenceMillingStrategyConfig(MillingStrategyConfig):
     # zparams: ZParameters = field(default_factory=lambda: ZParameters(-5e-6, 5e-6, 0.5e-6))
     timeout: int = field(
         default=1800,
-        metadata={
-            "label": "Timeout",
-            "unit": "s",
-            "minimum": 30,
-            "maximum": 9000,
-            "tooltip": "Milling will timeout after this duration in seconds, without user intervention",
-        },
+        metadata=field_meta(
+            label="Timeout",
+            unit="s",
+            minimum=30,
+            maximum=9000,
+            tooltip="Milling will timeout after this duration in seconds, without user intervention",
+        ),
     )  # seconds, default timeout for milling
     save_fm_images: bool = field(
         default=True,
-        metadata={
-            "label": "Save FM Images",
-            "tooltip": "Save FM images during milling",
-        },
+        metadata=field_meta(
+            label="Save FM Images",
+            tooltip="Save FM images during milling",
+        ),
     )  # save FM images during milling
     save_rate_limit: int = field(
         default=2,
-        metadata={
-            "label": "Save Rate Limit",
-            "tooltip": "Save one image every n seconds",
-        },
+        metadata=field_meta(
+            label="Save Rate Limit",
+            tooltip="Save one image every n seconds",
+        ),
     )  # save one image every n seconds
     # acquire_z_stack: bool = False  # acquire a z-stack after milling
     acquire_fib_image: bool = field(
         default=True,
-        metadata={
-            "label": "Acquire FIB Image",
-            "tooltip": "Acquire a FIB image after milling",
-        },
+        metadata=field_meta(
+            label="Acquire FIB Image",
+            tooltip="Acquire a FIB image after milling",
+        ),
     )  # acquire a FIB image after milling
     intensity_drop_fraction: float = field(
         default=0.4,
-        metadata={
-            "label": "Drop Fraction",
-            "minimum": 0.05,
-            "maximum": 0.95,
-            "tooltip": "Trigger when the rolling mean drops by this fraction below its peak (e.g. 0.4 = 40% drop)",
-        },
+        metadata=field_meta(
+            label="Drop Fraction",
+            minimum=0.05,
+            maximum=0.95,
+            tooltip="Trigger when the rolling mean drops by this fraction below its peak (e.g. 0.4 = 40% drop)",
+        ),
     )
     rolling_window: int = field(
         default=10,
-        metadata={
-            "label": "Rolling Window",
-            "tooltip": "Number of frames for rolling mean calculation",
-        },
+        metadata=field_meta(
+            label="Rolling Window",
+            tooltip="Number of frames for rolling mean calculation",
+        ),
     )
     warmup_duration: float = field(
         default=30.0,
-        metadata={
-            "label": "Warmup Duration",
-            "unit": "s",
-            "tooltip": "Seconds to ignore at start before tracking the peak",
-        },
+        metadata=field_meta(
+            label="Warmup Duration",
+            unit="s",
+            tooltip="Seconds to ignore at start before tracking the peak",
+        ),
     )
     consecutive_triggers: int = field(
         default=10,
-        metadata={
-            "label": "Consecutive Triggers",
-            "tooltip": "Number of consecutive frames below threshold required to fire the signal",
-        },
+        metadata=field_meta(
+            label="Consecutive Triggers",
+            tooltip="Number of consecutive frames below threshold required to fire the signal",
+        ),
     )
     supervised: bool = field(
         default=True,
-        metadata={
-            "label": "Supervised",
-            "tooltip": "Supervised: operator stops milling manually. Unsupervised (False): automatically stop when an intensity drop is detected.",
-        },
+        metadata=field_meta(
+            label="Supervised",
+            tooltip="Supervised: operator stops milling manually. Unsupervised (False): automatically stop when an intensity drop is detected.",
+        ),
     )
     bbox: Optional[FibsemRectangle] = field(
         default=None,
-        metadata={"hidden": True},  # set interactively via the FM ROI, not a form control
+        metadata=field_meta(hidden=True),  # set interactively via the FM ROI, not a form control
     )  # reduced area for intensity monitoring
     # oscillation parameters
 

--- a/fibsem/milling/strategy/overtilt.py
+++ b/fibsem/milling/strategy/overtilt.py
@@ -24,6 +24,7 @@ from fibsem.milling.patterning.patterns2 import TrenchPattern
 from fibsem.structures import (
     FibsemStagePosition,
     ImageSettings,
+    field_meta,
 )
 
 
@@ -31,41 +32,41 @@ from fibsem.structures import (
 class OvertiltTrenchMillingConfig(MillingStrategyConfig):
     overtilt: float = field(
         default=1.0,
-        metadata={
-            **DEFAULT_ANGLE_METADATA,
-            "label": "Overtilt",
-            "minimum": 0.1,
-            "maximum": 10.0,
-            "step": 0.5,
-            "tooltip": "The overtilt angle for the milling strategy.",
-        },
+        metadata=field_meta(
+            DEFAULT_ANGLE_METADATA,
+            label="Overtilt",
+            minimum=0.1,
+            maximum=10.0,
+            step=0.5,
+            tooltip="The overtilt angle for the milling strategy.",
+        ),
     )
     image_resolution: tuple[int, int] = field(
         default_factory=lambda: (1536, 1024),
-        metadata={
-            **DEFAULT_IMAGE_RESOLUTION_METADATA,
-            "tooltip": "The imaging resolution for the milling strategy.",
-        },
+        metadata=field_meta(
+            DEFAULT_IMAGE_RESOLUTION_METADATA,
+            tooltip="The imaging resolution for the milling strategy.",
+        ),
     )
     secret_parameter: bool = field(
         default=False,
-        metadata={
-            "label": "Secret Parameter",
-            "type": bool,
-            "advanced": True,
-            "tooltip": "A secret parameter for internal use (testing).",
-        },
+        metadata=field_meta(
+            label="Secret Parameter",
+            type=bool,
+            advanced=True,
+            tooltip="A secret parameter for internal use (testing).",
+        ),
     )
     area_parameter: float = field(
         default=1e-6,
-        metadata={
-            "label": "Area Parameter",
-            "type": float,
-            "unit": "m²",
-            "dimensions": 2,
-            "scale": 1e6,
-            "tooltip": "An area parameter for internal use (testing).",
-        },
+        metadata=field_meta(
+            label="Area Parameter",
+            type=float,
+            unit="m²",
+            dimensions=2,
+            scale=1e6,
+            tooltip="An area parameter for internal use (testing).",
+        ),
     )
 
 

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field, fields, asdict, InitVar
 from datetime import datetime
 from enum import Enum, auto
 from pathlib import Path
-from typing import List, Mapping, Optional, Tuple, Union, Set, Any, Dict, Type, TypeVar, Literal, TYPE_CHECKING
+from typing import Callable, List, Mapping, Optional, Sequence, Tuple, Union, Set, Any, Dict, Type, TypeVar, Literal, TYPE_CHECKING
 
 import numpy as np
 import tifffile as tff
@@ -52,9 +52,9 @@ DEFAULT_FIELD_METADATA: Dict[str, Any] = {
     "filepath": None,               # render a string field as a file picker rather than a line edit
 }
 
-# Superseded spelling -> the key that replaced it. Used **only** to make the
-# warning below say something useful; nothing resolves these at runtime, so a
-# field still declaring one renders without a tooltip or a unit suffix.
+# Superseded spelling -> the key that replaced it. Nothing resolves these at
+# runtime, so a field still declaring one renders without a tooltip or a unit
+# suffix; this map exists only so the diagnostics below say something useful.
 #
 # The AutoLamella task configs used to spell two keys differently from the rest
 # of the codebase, and the form that rendered them read only those spellings. All
@@ -65,6 +65,78 @@ RENAMED_METADATA_KEYS: Dict[str, str] = {
     "help": "tooltip",
     "units": "unit",
 }
+
+
+def field_meta(
+    base: Optional[Mapping[str, Any]] = None,
+    *,
+    label: Optional[str] = None,
+    type: Optional[Any] = None,
+    unit: Optional[str] = None,
+    tooltip: Optional[str] = None,
+    scale: Optional[float] = None,
+    dimensions: Optional[int] = None,
+    default: Optional[Any] = None,
+    minimum: Optional[float] = None,
+    maximum: Optional[float] = None,
+    step: Optional[float] = None,
+    decimals: Optional[int] = None,
+    items: Optional[Union[str, Sequence[Any]]] = None,
+    hidden: Optional[bool] = None,
+    advanced: Optional[bool] = None,
+    manufacturer: Optional[str] = None,
+    microscope_parameter: Optional[str] = None,
+    format_fn: Optional[Callable[..., str]] = None,
+    format_fn_kwargs: Optional[Dict[str, Any]] = None,
+    filepath: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Build a form-metadata dict, checking the keys at import time.
+
+        width: float = field(default=10e-6, metadata=field_meta(unit="m", scale=1e6))
+
+    Every key is spelled out as a keyword argument, so a misspelling is a
+    TypeError when the module is imported rather than a form that silently
+    renders without its tooltip or its unit suffix. That failure mode is not
+    hypothetical: two spellings of two keys coexisted across the codebase for a
+    long time and neither side ever got an error (FIB-384).
+
+    `base` extends a shared metadata dict, the way `dict(base, key=value)` does,
+    which is how most patterns and strategies are declared:
+
+        overtilt: float = field(metadata=field_meta(DEFAULT_ANGLE_METADATA, label="Overtilt"))
+
+    Keywords override the base, matching the `{**BASE, "label": ...}` literal it
+    replaces. The base's keys are checked too, so this cannot be used to launder
+    a raw dict past the check it exists to perform.
+
+    Passing the base by `**` instead is stricter, since Python rejects a keyword
+    the base already supplies:
+
+        field_meta(**DEFAULT_DISTANCE_METADATA, type=Point)   # TypeError
+
+    Worth preferring where nothing needs overriding, because a dict literal
+    silently resolves that collision instead -- `patterns2.BasePattern.point`
+    declares `"type": Point` and renders as a float because the spread that
+    follows wins.
+
+    This returns the plain dict every form already reads, so raw-dict
+    declarations keep working and files convert as they are touched. Arguments
+    left unset are omitted rather than returned as None, which is what lets the
+    base, a struct-level DEFAULT_METADATA, or `get_fields_with_metadata`'s own
+    defaults supply them instead.
+    """
+    # `locals()` here is exactly the parameters, which is the point: listing them
+    # again would let a newly added one be silently dropped -- the same class of
+    # bug this function exists to prevent.
+    declared = dict(locals())
+    inherited = declared.pop("base") or {}
+    for key in inherited:
+        if key not in DEFAULT_FIELD_METADATA:
+            renamed = RENAMED_METADATA_KEYS.get(key)
+            hint = f", which was renamed to {renamed!r}" if renamed else ""
+            raise TypeError(f"field_meta() base declares unknown metadata key {key!r}{hint}")
+    return {**inherited, **{key: value for key, value in declared.items() if value is not None}}
+
 
 _warned_metadata_keys: set = set()
 

--- a/tests/test_field_metadata_keys.py
+++ b/tests/test_field_metadata_keys.py
@@ -233,6 +233,32 @@ def test_unset_keys_are_omitted():
     assert field_meta(label="Width") == {"label": "Width"}
 
 
+def test_omitting_a_key_renders_the_same_as_declaring_it_None():
+    """Why converting a declaration that said `"scale": None` is not a change.
+
+    Dropping an explicitly-None key does alter the raw `field.metadata` -- and
+    six pattern and strategy fields lost one that way, via the shared angle
+    metadata. It is invisible because every form reads the merged
+    `field_metadata`, which refills the key from the vocabulary either way. A
+    reader going to `field.metadata` directly with a non-None fallback would be
+    able to tell, so this pins the equivalence the conversion relied on.
+    """
+
+    @dataclass
+    class Omitted:
+        angle: float = field(default=0.0, metadata=field_meta(unit="deg"))
+
+    @dataclass
+    class ExplicitNone:
+        angle: float = field(default=0.0, metadata={"unit": "deg", "scale": None})
+
+    assert "scale" not in Omitted.__dataclass_fields__["angle"].metadata
+    assert (
+        get_fields_with_metadata(Omitted)["angle"]
+        == get_fields_with_metadata(ExplicitNone)["angle"]
+    )
+
+
 def test_an_explicit_false_is_kept():
     """`hidden=False` means hidden=False, not "unspecified".
 
@@ -304,12 +330,13 @@ def test_a_spread_base_rejects_a_keyword_it_already_supplies():
         field_meta(**base, unit="µm")
 
 
-def test_the_shared_pattern_metadata_is_built_through_the_constructor():
-    """The highest-leverage place to check keys, so worth keeping that way.
+def test_the_shared_pattern_metadata_declares_only_known_keys():
+    """The highest-leverage place to check keys.
 
     These handful of dicts are spread into roughly a hundred pattern and strategy
-    fields. Declared through `field_meta`, one typo is caught once here rather
-    than rendering blank in every field that inherits it.
+    fields, so one typo here renders blank in every field that inherits it.
+    Declaring them through `field_meta` is what currently guarantees this, but
+    the guarantee is what matters, so this asserts the keys directly.
     """
     from fibsem.milling import properties
 

--- a/tests/test_field_metadata_keys.py
+++ b/tests/test_field_metadata_keys.py
@@ -10,8 +10,14 @@ All in-tree declarations were converted and the old spellings are **not**
 accepted (FIB-384). What makes that safe rather than silent is the warning: a
 field still declaring a superseded key is told which key replaced it, instead of
 simply losing its tooltip.
+
+`field_meta` closes the same hole from the other end (FIB-531): it spells the
+vocabulary out as keyword arguments, so a declaration written through it fails at
+import instead of rendering blank. The warning is still what serves the plugins
+we cannot convert, which keep writing raw dicts.
 """
 
+import inspect
 import logging
 from dataclasses import dataclass, field
 
@@ -20,9 +26,18 @@ import pytest
 from fibsem.structures import (
     DEFAULT_FIELD_METADATA,
     RENAMED_METADATA_KEYS,
+    field_meta,
     get_fields_with_metadata,
 )
 import fibsem.structures as fstructures
+
+
+def keyword_only_parameters():
+    return [
+        name
+        for name, p in inspect.signature(field_meta).parameters.items()
+        if p.kind is inspect.Parameter.KEYWORD_ONLY
+    ]
 
 
 @dataclass
@@ -160,3 +175,151 @@ def test_in_tree_configs_declare_no_unreadable_keys(caplog):
 
     offenders = [r.message for r in caplog.records if "declares metadata key" in r.message]
     assert offenders == []
+
+
+# --- field_meta: the same vocabulary, enforced at import time (FIB-531) -------
+
+
+def test_the_constructor_accepts_exactly_the_vocabulary():
+    """The signature *is* the documentation, so it must not drift from the dict.
+
+    A key in the vocabulary but not the signature cannot be declared through
+    `field_meta` at all; one in the signature but not the vocabulary would be
+    accepted here and then warned about at render time. Either way the two
+    disagree about what a valid key is.
+    """
+    assert keyword_only_parameters() == list(DEFAULT_FIELD_METADATA)
+
+
+def test_every_parameter_reaches_the_result():
+    """Guards the `locals()` trick that builds the returned dict.
+
+    Spelling the keys out a second time inside the body is what this avoids: a
+    parameter added to the signature but missed there would accept its value and
+    silently drop it, which is precisely the bug class `field_meta` exists to
+    prevent -- and it would be invisible to every other test here.
+    """
+    marker = object()
+    for name in keyword_only_parameters():
+        assert field_meta(**{name: marker}) == {name: marker}, name
+
+
+def test_a_superseded_spelling_is_rejected_at_import():
+    """The headline: FIB-384's bug is unrepresentable through this door.
+
+    A raw dict takes `help` happily and renders without a tooltip. Here it is a
+    TypeError, raised while the module is being imported -- before any form is
+    built and long before anyone squints at a blank label.
+    """
+    with pytest.raises(TypeError, match="help"):
+        field_meta(help="old spelling")
+    with pytest.raises(TypeError, match="units"):
+        field_meta(units="m")
+
+
+def test_a_misspelled_key_is_rejected_at_import():
+    with pytest.raises(TypeError, match="toolip"):
+        field_meta(toolip="typo")
+
+
+def test_unset_keys_are_omitted():
+    """The result has to be the dict you would have written by hand.
+
+    Returning all nineteen keys with None would look equivalent -- the merge in
+    `get_fields_with_metadata` fills them anyway -- but it would override
+    whatever a base or a struct-level DEFAULT_METADATA had supplied, turning a
+    conversion into a behaviour change.
+    """
+    assert field_meta(label="Width") == {"label": "Width"}
+
+
+def test_an_explicit_false_is_kept():
+    """`hidden=False` means hidden=False, not "unspecified".
+
+    Filtering on falsiness rather than None would drop it, and a field could then
+    no longer turn off a flag its base had turned on.
+    """
+    assert field_meta(hidden=False) == {"hidden": False}
+
+
+def test_it_produces_the_dict_it_replaces():
+    """Converting a declaration must not change what the form renders."""
+
+    @dataclass
+    class Constructed:
+        width: float = field(default=1.0, metadata=field_meta(unit="m", scale=1e6))
+
+    @dataclass
+    class Literal:
+        width: float = field(default=1.0, metadata={"unit": "m", "scale": 1e6})
+
+    assert (
+        get_fields_with_metadata(Constructed)["width"]
+        == get_fields_with_metadata(Literal)["width"]
+    )
+
+
+def test_a_base_is_extended_and_overridden():
+    """`field_meta(BASE, ...)` has to mean exactly `{**BASE, ...}`.
+
+    Patterns and strategies are overwhelmingly declared by extending a shared
+    dict, so a constructor that could not express that would be unusable at most
+    of the sites that need it.
+    """
+    base = {"unit": "m", "scale": 1e6, "label": "Distance"}
+
+    assert field_meta(base, label="Overtilt", minimum=0.1) == {
+        "unit": "m",
+        "scale": 1e6,
+        "label": "Overtilt",
+        "minimum": 0.1,
+    }
+
+
+def test_a_base_cannot_launder_an_unreadable_key():
+    """Otherwise the base is a hole straight through the check.
+
+    `field_meta(some_raw_dict)` would look like a converted declaration while
+    carrying the same typo the raw dict had.
+    """
+    with pytest.raises(TypeError, match="toolip"):
+        field_meta({"toolip": "typo"})
+
+
+def test_a_base_naming_a_superseded_key_says_what_replaced_it():
+    with pytest.raises(TypeError, match="renamed to 'tooltip'"):
+        field_meta({"help": "old spelling"})
+
+
+def test_a_spread_base_rejects_a_keyword_it_already_supplies():
+    """The stricter idiom, and the reason to prefer it where nothing overrides.
+
+    `{"type": Point, **DISTANCE}` silently resolves to the spread's `type` --
+    that exact collision is live in `patterns2.BasePattern.point`, which declares
+    `Point` and renders as a float. Spread as arguments, Python refuses it.
+    """
+    base = {"unit": "m", "scale": 1e6}
+
+    with pytest.raises(TypeError, match="unit"):
+        field_meta(**base, unit="µm")
+
+
+def test_the_shared_pattern_metadata_is_built_through_the_constructor():
+    """The highest-leverage place to check keys, so worth keeping that way.
+
+    These handful of dicts are spread into roughly a hundred pattern and strategy
+    fields. Declared through `field_meta`, one typo is caught once here rather
+    than rendering blank in every field that inherits it.
+    """
+    from fibsem.milling import properties
+
+    shared = [
+        value
+        for name, value in vars(properties).items()
+        if name.startswith("DEFAULT_") and name.endswith("_METADATA")
+    ]
+    assert shared, "expected the shared pattern metadata dicts to be importable"
+
+    for meta in shared:
+        unknown = set(meta) - set(DEFAULT_FIELD_METADATA)
+        assert not unknown, unknown


### PR DESCRIPTION
Closes FIB-531.

Form metadata is a bare `dict[str, Any]`, so nothing checks the keys. A wrong one is completely silent: the form renders, the value is right, and the label or the unit suffix is simply missing. That is how FIB-384 happened — two spellings of two keys coexisted across 37 declarations and neither side ever got an error.

`field_meta()` spells the vocabulary out as keyword arguments:

```python
width: float = field(default=10e-6, metadata=field_meta(unit="m", scale=1e6, tooltip="Pattern width"))
```

- `help=` / `units=` are now a **TypeError at import time** rather than a blank tooltip.
- Editor completion and type checking on keys *and* values.
- It returns the same dict every form already reads, so raw-dict declarations keep working and files convert as they are touched. No reader changed.

## The `base` argument was not in the plan, and is load-bearing

A pure keyword constructor turned out to be unusable at most in-tree sites. Patterns and strategies are overwhelmingly declared by extending a shared dict:

```python
metadata={**DEFAULT_ANGLE_METADATA, "label": "Overtilt", "minimum": 0.1}
```

Passing both the spread and the overriding keywords raises `TypeError: multiple values for 'label'`, so ~114 of the 192 in-tree declarations could not convert. `field_meta(BASE, label=...)` means exactly `dict(BASE, label=...)`. The base is key-checked too, so it cannot be used to launder a raw dict past the check.

## A live instance of the bug class, found while converting

`patterns2.BasePattern.point` declares `"type": Point` and renders as a **float**, because the `**DEFAULT_DISTANCE_METADATA` that follows overrides it. Confirmed at runtime. Not fixed here — the forms have always rendered it as a float and changing that is a behaviour change, not a conversion. It is documented in the docstring as the reason to prefer `field_meta(**BASE, ...)` where nothing needs overriding, since that spelling refuses the collision.

## What was converted

The AutoLamella task configs, both milling strategies, and the seven shared dicts in `milling/properties.py` — those are spread into roughly a hundred pattern and strategy fields, so checking them once covers all of them.

`patterns2.py` (102 declarations) is deliberately left for a separate pass: its declarations surface real conflicts like the one above rather than converting mechanically.

## Verification

Diffed `get_fields_with_metadata` across every dataclass in the package, before and after: **165 classes, 18,830 metadata values, zero differences**. Every form reads that merged view, so identical output means identical forms.

Diffing the **raw** `field.metadata` as well — which the merged view cannot see — turns up exactly one class of change: six pattern and strategy fields lose an explicit `"scale": None` inherited from the shared angle metadata, because `field_meta` omits unset keys. Invisible in practice, since every form goes through the merged `field_metadata` property and the few readers that touch `field.metadata` directly only ask for `advanced` and `hidden`. A reader with a non-None fallback could tell the difference (`.get('scale', 1.0)` already exists in the task config widget), so `test_omitting_a_key_renders_the_same_as_declaring_it_None` pins it rather than leaving it as an argument.

- 22 tests in `tests/test_field_metadata_keys.py`; each new guard mutation-tested (drop base validation, filter on truthiness instead of None, ignore the base, silently drop a parameter, remove a vocabulary key — all caught).
- 673 passed across the affected test files.
- AST decorator audit across all 16 changed files: no existing decorator moved.
- All changed files parse under Python 3.8.

## A deliberate departure from the issue

The issue proposed deriving `DEFAULT_FIELD_METADATA` from the signature. It stays hand-written, because the two disagree on purpose: a signature default of `None` means "not specified", while the dict's value is what the form uses when nobody specified — which is `False`, not `None`, for `hidden` and `advanced`. A test asserts the key sets match exactly, which buys the anti-drift guarantee without conflating the two meanings.

## Follow-up

The example plugin repo is converted and committed locally but **not pushed**: it needs a fibsem carrying `field_meta`, and an ImportError in a pattern module means the plugin silently never appears.