### PR TITLE
[ui] Collapse colour drift, and name the neutral ramp behind the plots

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -77,6 +77,7 @@ from fibsem.ui.widgets.notifications import NotificationBell, ToastManager
 from fibsem.ui.widgets.workflow_timeline_widget import WorkflowProgressWidget
 from fibsem.utils import format_duration
 from fibsem.ui.tokens import (
+    SURFACE_COLOR,
     TEXT_COLOR,
 )
 
@@ -1564,7 +1565,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         )
 
         self.workflow_right_panel = QWidget()
-        self.workflow_right_panel.setStyleSheet("background: #2b2d31;")
+        self.workflow_right_panel.setStyleSheet(f"background: {SURFACE_COLOR};")
 
         _rp_layout = QVBoxLayout(self.workflow_right_panel)
         _rp_layout.setContentsMargins(0, 0, 0, 0)

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -112,6 +112,7 @@ from fibsem.ui.widgets.custom_widgets import (
 from fibsem.correlation.ui.widgets.refractive_index_widget import RefractiveIndexWidget
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    NEUTRAL_200,
     SURFACE_COLOR,
     TEXT_MUTED_COLOR,
 )
@@ -470,9 +471,9 @@ class _ImagesTab(QWidget):
         fib_form.setContentsMargins(0, 0, 0, 0)
         fib_form.setSpacing(2)
         self._lbl_fib_shape = QLabel("—")
-        self._lbl_fib_shape.setStyleSheet("color: #e0e0e0; font-size: 11px;")
+        self._lbl_fib_shape.setStyleSheet(f"color: {NEUTRAL_200}; font-size: 11px;")
         self._lbl_fib_px = QLabel("—")
-        self._lbl_fib_px.setStyleSheet("color: #e0e0e0; font-size: 11px;")
+        self._lbl_fib_px.setStyleSheet(f"color: {NEUTRAL_200}; font-size: 11px;")
         fib_form.addRow(_form_label("Shape:"), self._lbl_fib_shape)
         fib_form.addRow(_form_label("Pixel size:"), self._lbl_fib_px)
         fib_layout.addLayout(fib_form)
@@ -495,14 +496,14 @@ class _ImagesTab(QWidget):
         fm_form.setContentsMargins(0, 0, 0, 0)
         fm_form.setSpacing(2)
         self._lbl_fm_shape = QLabel("—")
-        self._lbl_fm_shape.setStyleSheet("color: #e0e0e0; font-size: 11px;")
+        self._lbl_fm_shape.setStyleSheet(f"color: {NEUTRAL_200}; font-size: 11px;")
         self._lbl_fm_ch = QLabel("—")
-        self._lbl_fm_ch.setStyleSheet("color: #e0e0e0; font-size: 11px;")
+        self._lbl_fm_ch.setStyleSheet(f"color: {NEUTRAL_200}; font-size: 11px;")
         self._lbl_fm_ch.setWordWrap(True)
         self._lbl_fm_z = QLabel("—")
-        self._lbl_fm_z.setStyleSheet("color: #e0e0e0; font-size: 11px;")
+        self._lbl_fm_z.setStyleSheet(f"color: {NEUTRAL_200}; font-size: 11px;")
         self._lbl_fm_px = QLabel("—")
-        self._lbl_fm_px.setStyleSheet("color: #e0e0e0; font-size: 11px;")
+        self._lbl_fm_px.setStyleSheet(f"color: {NEUTRAL_200}; font-size: 11px;")
         self._lbl_fm_px.setWordWrap(True)
         fm_form.addRow(_form_label("Shape (C×Z×Y×X):"), self._lbl_fm_shape)
         fm_form.addRow(_form_label("Channels:"), self._lbl_fm_ch)
@@ -933,7 +934,7 @@ class _ResultsTab(QWidget):
     @staticmethod
     def _val(text: str = "—") -> QLabel:
         lbl = QLabel(text)
-        lbl.setStyleSheet("color: #e0e0e0; font-size: 12px;")
+        lbl.setStyleSheet(f"color: {NEUTRAL_200}; font-size: 12px;")
         return lbl
 
     def set_result(self, result: CorrelationResult) -> None:

--- a/fibsem/correlation/ui/widgets/correlation_tab_widget.py
+++ b/fibsem/correlation/ui/widgets/correlation_tab_widget.py
@@ -112,6 +112,8 @@ from fibsem.ui.widgets.custom_widgets import (
 from fibsem.correlation.ui.widgets.refractive_index_widget import RefractiveIndexWidget
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    SURFACE_COLOR,
+    TEXT_MUTED_COLOR,
 )
 
 _FIT_METHODS = ["None", "Hole", "Gaussian"]
@@ -725,10 +727,10 @@ class _CoordinatesTab(QWidget):
         scroll = QScrollArea(self)
         scroll.setWidgetResizable(True)
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        scroll.setStyleSheet("background: #2b2d31; border: none;")
+        scroll.setStyleSheet(f"background: {SURFACE_COLOR}; border: none;")
 
         container = QWidget()
-        container.setStyleSheet("background: #2b2d31;")
+        container.setStyleSheet(f"background: {SURFACE_COLOR};")
         layout = QVBoxLayout(container)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(4)
@@ -834,7 +836,7 @@ class _CoordinatesTab(QWidget):
             "(failed or far-off fits still ask)."
         )
         fit_help.setWordWrap(True)
-        fit_help.setStyleSheet("color: #8a8d93; font-size: 11px; padding-top: 4px;")
+        fit_help.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 11px; padding-top: 4px;")
         fit_form.addRow(fit_help)
 
         self._fit_panel = TitledPanel("Fit Settings", collapsible=True)

--- a/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
+++ b/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
@@ -28,6 +28,7 @@ from fibsem.correlation.structures import Coordinate, PointXYZ
 from fibsem.ui import stylesheets
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    TEXT_MUTED_COLOR,
 )
 
 # Per-axis displacement below which a fit is treated as "no change" (the fit
@@ -159,7 +160,7 @@ def _kv(key: str, value: str, value_color: str = "#d0d0d0") -> QWidget:
     row = QHBoxLayout(w)
     row.setContentsMargins(0, 0, 0, 0)
     k = QLabel(key)
-    k.setStyleSheet("color: #8a8d93; font-size: 12px;")
+    k.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 12px;")
     v = QLabel(value)
     v.setStyleSheet(f"color: {value_color}; font-size: 12px;")
     v.setTextFormat(Qt.TextFormat.PlainText)

--- a/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
+++ b/fibsem/correlation/ui/widgets/fit_confirmation_dialog.py
@@ -28,6 +28,7 @@ from fibsem.correlation.structures import Coordinate, PointXYZ
 from fibsem.ui import stylesheets
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    NEUTRAL_300,
     TEXT_MUTED_COLOR,
 )
 
@@ -155,7 +156,7 @@ def _fmt_delta(initial: PointXYZ, fitted: PointXYZ) -> str:
     )
 
 
-def _kv(key: str, value: str, value_color: str = "#d0d0d0") -> QWidget:
+def _kv(key: str, value: str, value_color: str = NEUTRAL_300) -> QWidget:
     w = QWidget()
     row = QHBoxLayout(w)
     row.setContentsMargins(0, 0, 0, 0)
@@ -187,7 +188,7 @@ class FitConfirmationDialog(QDialog):
         self._result = result
         self.setWindowTitle("Confirm fit")
         self.setModal(True)
-        self.setStyleSheet(f"background: {CANVAS_BG}; color: #d0d0d0;")
+        self.setStyleSheet(f"background: {CANVAS_BG}; color: {NEUTRAL_300};")
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(14, 14, 14, 12)

--- a/fibsem/correlation/ui/widgets/fm_interpolate_dialog.py
+++ b/fibsem/correlation/ui/widgets/fm_interpolate_dialog.py
@@ -28,6 +28,8 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.widgets.custom_widgets import ValueComboBox, ValueSpinBox
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    NEUTRAL_300,
+    NEUTRAL_400,
 )
 
 _WARN_COLOR = "#d6b57a"
@@ -53,7 +55,7 @@ class InterpolateZDialog(QDialog):
         # The label/chip colours below are picked for a dark surface, so don't
         # rely on the app-level napari stylesheet being installed — state it
         # here, as FitConfirmationDialog does.
-        self.setStyleSheet(f"background: {CANVAS_BG}; color: #d0d0d0;")
+        self.setStyleSheet(f"background: {CANVAS_BG}; color: {NEUTRAL_300};")
 
         meta = fm_image.metadata
         self._nc, self._nz, self._ny, self._nx = fm_image.data.shape
@@ -72,7 +74,7 @@ class InterpolateZDialog(QDialog):
             f"Z step: {self._z_step * 1e9:.0f} nm "
             f"({self._z_step / self._xy:.2f}× anisotropic)"
         )
-        info.setStyleSheet("color: #b8b8b8; font-size: 12px;")
+        info.setStyleSheet(f"color: {NEUTRAL_400}; font-size: 12px;")
         root.addWidget(info)
 
         line = QFrame()

--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -18,6 +18,7 @@ from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
 )
 from fibsem.ui.tokens import (
+    NEUTRAL_500,
     WHITE_ICON_COLOR,
 )
 
@@ -93,7 +94,7 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
 
         self._label_status_subtitle = QtWidgets.QLabel("")
         self._label_status_subtitle.setStyleSheet(
-            "background-color: transparent; color: #a0a0a0; font-size: 10px; border: none;"
+            f"background-color: transparent; color: {NEUTRAL_500}; font-size: 10px; border: none;"
         )
 
         text_layout.addWidget(self._label_status_title)
@@ -102,19 +103,19 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
         layout.addStretch()
 
         self._button_disconnect = QtWidgets.QPushButton("Disconnect")
-        self._button_disconnect.setStyleSheet("""
-            QPushButton {
+        self._button_disconnect.setStyleSheet(f"""
+            QPushButton {{
                 background-color: transparent;
-                color: #a0a0a0;
+                color: {NEUTRAL_500};
                 border: 1px solid #3d4251;
                 border-radius: 3px;
                 padding: 3px 8px;
                 font-size: 10px;
-            }
-            QPushButton:hover {
+            }}
+            QPushButton:hover {{
                 color: #f44336;
                 border-color: #f44336;
-            }
+            }}
         """)
         self._button_disconnect.clicked.connect(self.connect_to_microscope)
         layout.addWidget(self._button_disconnect)
@@ -134,7 +135,7 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
 
         self.pushButton_apply_configuration.clicked.connect(lambda: self.apply_microscope_configuration(None))
         self.pushButton_apply_configuration.setToolTip("Apply configuration can take some time. Please make sure the microscope beams are both on.")
-        self.toolButton_import_configuration.setIcon(fibsem_icon("mdi:add", color="#a0a0a0"))
+        self.toolButton_import_configuration.setIcon(fibsem_icon("mdi:add", color=NEUTRAL_500))
 
     def load_configuration(self, configuration_name: Optional[str] = None) -> Optional[str]:
         if configuration_name is None:

--- a/fibsem/ui/fm/widgets/acquisition_summary_dialog.py
+++ b/fibsem/ui/fm/widgets/acquisition_summary_dialog.py
@@ -13,6 +13,7 @@ from PyQt5.QtWidgets import (
 from fibsem.fm.structures import ChannelSettings, ZParameters, FMStagePosition
 from fibsem.fm.timing import estimate_positions_acquisition_time
 from fibsem.ui.stylesheets import (
+    NEUTRAL_650,
     RUN_WORKFLOW_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
 )
@@ -50,7 +51,7 @@ class AcquisitionSummaryDialog(QDialog):
             position_list_text += f"\n  • ... and {len(position_names) - 10} more"
 
         position_details = QLabel(position_list_text)
-        position_details.setStyleSheet("font-size: 10px; color: #666666;")
+        position_details.setStyleSheet(f"font-size: 10px; color: {NEUTRAL_650};")
         layout.addWidget(position_details)
 
         # Channel information
@@ -60,7 +61,7 @@ class AcquisitionSummaryDialog(QDialog):
 
         for i, channel in enumerate(self.channel_settings):
             channel_details = QLabel(channel.pretty_name)
-            channel_details.setStyleSheet("font-size: 10px; color: #666666;")
+            channel_details.setStyleSheet(f"font-size: 10px; color: {NEUTRAL_650};")
             layout.addWidget(channel_details)
 
         # Z-stack information
@@ -72,7 +73,7 @@ class AcquisitionSummaryDialog(QDialog):
             z_details = QLabel("No Z-Stack")
         zlabel = QLabel("Z-Stack: " + str(num_planes) + " planes")
         zlabel.setStyleSheet("font-weight: bold; font-size: 12px;")
-        z_details.setStyleSheet("font-size: 10px; color: #666666;")
+        z_details.setStyleSheet(f"font-size: 10px; color: {NEUTRAL_650};")
         layout.addWidget(zlabel)
         layout.addWidget(z_details)
         
@@ -82,7 +83,7 @@ class AcquisitionSummaryDialog(QDialog):
         layout.addWidget(autofocus_label)
         
         autofocus_details = QLabel("Autofocus will run at each position before acquisition" if self.use_autofocus else "No autofocus will be performed")
-        autofocus_details.setStyleSheet("font-size: 10px; color: #666666;")
+        autofocus_details.setStyleSheet(f"font-size: 10px; color: {NEUTRAL_650};")
         layout.addWidget(autofocus_details)
 
         # Time estimation

--- a/fibsem/ui/fm/widgets/autofocus_widget_demo.py
+++ b/fibsem/ui/fm/widgets/autofocus_widget_demo.py
@@ -18,6 +18,9 @@ from PyQt5.QtWidgets import (
 
 from fibsem.fm.structures import ChannelSettings
 from fibsem.ui.fm.widgets.autofocus_widget import AutofocusWidget
+from fibsem.ui.tokens import (
+    SURFACE_COLOR,
+)
 
 
 def _format(settings) -> str:
@@ -43,7 +46,7 @@ def main() -> None:
 
     win = QWidget()
     win.setWindowTitle("AutofocusWidget — demo")
-    win.setStyleSheet("background: #2b2d31; color: #d1d2d4;")
+    win.setStyleSheet(f"background: {SURFACE_COLOR}; color: #d1d2d4;")
     root = QVBoxLayout(win)
     root.setContentsMargins(12, 12, 12, 12)
     root.setSpacing(10)

--- a/fibsem/ui/fm/widgets/channel_list_widget.py
+++ b/fibsem/ui/fm/widgets/channel_list_widget.py
@@ -38,6 +38,7 @@ from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueComboBox, ValueSpinBox
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    NEUTRAL_700,
     ORANGE_COLOR,
 )
 
@@ -666,7 +667,7 @@ class ChannelListWidget(QWidget):
         layout.addWidget(self._list)
 
         self._empty_label = QLabel("No channels. Click + to add one.")
-        self._empty_label.setStyleSheet("color: #606060; font-style: italic; padding: 12px;")
+        self._empty_label.setStyleSheet(f"color: {NEUTRAL_700}; font-style: italic; padding: 12px;")
         self._empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self._empty_label)
 

--- a/fibsem/ui/fm/widgets/fluorescence_plot_widget.py
+++ b/fibsem/ui/fm/widgets/fluorescence_plot_widget.py
@@ -17,6 +17,10 @@ from PyQt5.QtWidgets import (
 from fibsem.fm.structures import FluorescenceImage
 from fibsem.fm.plotting import plot_fluorescence_image
 from fibsem.ui.tokens import (
+    NEUTRAL_400,
+    NEUTRAL_750,
+    NEUTRAL_800,
+    NEUTRAL_850,
     SURFACE_COLOR,
 )
 
@@ -80,20 +84,20 @@ class FluorescencePlotWidget(QWidget):
             self.load_image_button = QToolButton(self)
             self.load_image_button.setText("Load Image")
             self.load_image_button.setToolTip("Load a fluorescence image file")
-            self.load_image_button.setStyleSheet("""
-                QToolButton {
-                    background-color: #3a3a3a;
+            self.load_image_button.setStyleSheet(f"""
+                QToolButton {{
+                    background-color: {NEUTRAL_800};
                     color: white;
                     border: 1px solid #555;
                     padding: 4px 8px;
                     font-size: 10px;
-                }
-                QToolButton:hover {
-                    background-color: #4a4a4a;
-                }
-                QToolButton:pressed {
-                    background-color: #2a2a2a;
-                }
+                }}
+                QToolButton:hover {{
+                    background-color: {NEUTRAL_750};
+                }}
+                QToolButton:pressed {{
+                    background-color: {NEUTRAL_850};
+                }}
             """)
             self.load_image_button.clicked.connect(self._on_load_image_clicked)
             button_layout.addWidget(self.load_image_button)
@@ -129,24 +133,24 @@ class FluorescencePlotWidget(QWidget):
 
         # Create navigation toolbar
         self.toolbar = NavigationToolbar(self.canvas, self)
-        self.toolbar.setStyleSheet("""
-            QToolBar {
-                background-color: #3a3a3a;
+        self.toolbar.setStyleSheet(f"""
+            QToolBar {{
+                background-color: {NEUTRAL_800};
                 border: 1px solid #555;
                 spacing: 3px;
-            }
-            QToolButton {
-                background-color: #3a3a3a;
+            }}
+            QToolButton {{
+                background-color: {NEUTRAL_800};
                 color: white;
                 border: 1px solid #555;
                 padding: 3px;
-            }
-            QToolButton:hover {
-                background-color: #4a4a4a;
-            }
-            QToolButton:pressed {
-                background-color: #2a2a2a;
-            }
+            }}
+            QToolButton:hover {{
+                background-color: {NEUTRAL_750};
+            }}
+            QToolButton:pressed {{
+                background-color: {NEUTRAL_850};
+            }}
         """)
 
         # Clear the plot layout and add new widgets
@@ -192,7 +196,7 @@ class FluorescencePlotWidget(QWidget):
             verticalalignment="center",
             transform=self.ax.transAxes,
             fontsize=12,
-            color="#bbbbbb",
+            color=NEUTRAL_400,
         )
         self.ax.set_title("Fluorescence Image")
         self.ax.axis("off")
@@ -227,15 +231,15 @@ class FluorescencePlotWidget(QWidget):
 
         # Create "All Channels" radio button
         all_channels_button = QRadioButton("All Channels", self)
-        all_channels_button.setStyleSheet("""
-            QRadioButton {
-                color: #bbbbbb;
+        all_channels_button.setStyleSheet(f"""
+            QRadioButton {{
+                color: {NEUTRAL_400};
                 font-size: 10px;
-            }
-            QRadioButton::indicator {
+            }}
+            QRadioButton::indicator {{
                 width: 13px;
                 height: 13px;
-            }
+            }}
         """)
         # Set "All Channels" as checked if that's the current selection
         if self.selected_channel_idx is None:
@@ -250,15 +254,15 @@ class FluorescencePlotWidget(QWidget):
         for i, channel_metadata in enumerate(self.image.metadata.channels):
             channel_name = channel_metadata.name or f"Channel {i+1}"
             radio_button = QRadioButton(channel_name, self)
-            radio_button.setStyleSheet("""
-                QRadioButton {
-                    color: #bbbbbb;
+            radio_button.setStyleSheet(f"""
+                QRadioButton {{
+                    color: {NEUTRAL_400};
                     font-size: 10px;
-                }
-                QRadioButton::indicator {
+                }}
+                QRadioButton::indicator {{
                     width: 13px;
                     height: 13px;
-                }
+                }}
             """)
 
             # Set as checked if this is the currently selected channel
@@ -325,24 +329,24 @@ class FluorescencePlotWidget(QWidget):
 
             # Create new toolbar with the new canvas
             self.toolbar = NavigationToolbar(self.canvas, self)
-            self.toolbar.setStyleSheet("""
-                QToolBar {
-                    background-color: #3a3a3a;
+            self.toolbar.setStyleSheet(f"""
+                QToolBar {{
+                    background-color: {NEUTRAL_800};
                     border: 1px solid #555;
                     spacing: 3px;
-                }
-                QToolButton {
-                    background-color: #3a3a3a;
+                }}
+                QToolButton {{
+                    background-color: {NEUTRAL_800};
                     color: white;
                     border: 1px solid #555;
                     padding: 3px;
-                }
-                QToolButton:hover {
-                    background-color: #4a4a4a;
-                }
-                QToolButton:pressed {
-                    background-color: #2a2a2a;
-                }
+                }}
+                QToolButton:hover {{
+                    background-color: {NEUTRAL_750};
+                }}
+                QToolButton:pressed {{
+                    background-color: {NEUTRAL_850};
+                }}
             """)
 
             # Clear the plot layout and add new widgets

--- a/fibsem/ui/fm/widgets/histogram_widget.py
+++ b/fibsem/ui/fm/widgets/histogram_widget.py
@@ -10,6 +10,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 from fibsem.ui.tokens import (
+    NEUTRAL_400,
     SURFACE_COLOR,
     WHITE_ICON_COLOR,
 )
@@ -74,7 +75,7 @@ class HistogramWidget(QWidget):
             
             # Info label for statistics with napari-style colors
             self.label_stats = QLabel("No image selected", self)
-            self.label_stats.setStyleSheet("QLabel { color: #bbbbbb; font-size: 10px; background-color: transparent; }")
+            self.label_stats.setStyleSheet(f"QLabel {{ color: {NEUTRAL_400}; font-size: 10px; background-color: transparent; }}")
             self.label_stats.setWordWrap(True)
             layout.addWidget(self.label_stats)
         
@@ -91,7 +92,7 @@ class HistogramWidget(QWidget):
         
         self.ax.text(0.5, 0.5, 'No image selected', 
                     horizontalalignment='center', verticalalignment='center',
-                    transform=self.ax.transAxes, fontsize=12, color='#bbbbbb')
+                    transform=self.ax.transAxes, fontsize=12, color=NEUTRAL_400)
         self.ax.set_xlabel('Intensity')
         self.ax.set_ylabel('Frequency')
         self.ax.set_title('Image Histogram')

--- a/fibsem/ui/fm/widgets/line_plot_widget.py
+++ b/fibsem/ui/fm/widgets/line_plot_widget.py
@@ -18,6 +18,8 @@ from PyQt5.QtWidgets import (
 )
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.tokens import (
+    NEUTRAL_400,
+    NEUTRAL_450,
     ORANGE_COLOR,
     SURFACE_COLOR,
 )
@@ -131,7 +133,7 @@ class LinePlotWidget(QWidget):
         # ── Overlay buttons (parented to canvas, stacked right-to-left) ──────
         def _obtn(icon_name: str, tooltip: str, checkable: bool = False) -> QPushButton:
             btn = QPushButton(self.canvas)
-            btn.setIcon(fibsem_icon(icon_name, color="#aaaaaa"))
+            btn.setIcon(fibsem_icon(icon_name, color=NEUTRAL_450))
             btn.setIconSize(_OVERLAY_ICON_SIZE)
             btn.setFixedSize(_OVERLAY_BTN_SIZE, _OVERLAY_BTN_SIZE)
             btn.setToolTip(tooltip)
@@ -178,7 +180,7 @@ class LinePlotWidget(QWidget):
         # Stats label (below canvas — text, not a button)
         self.label_stats = QLabel("No data", self)
         self.label_stats.setStyleSheet(
-            "QLabel { color: #bbbbbb; font-size: 10px; background-color: transparent; }"
+            f"QLabel {{ color: {NEUTRAL_400}; font-size: 10px; background-color: transparent; }}"
         )
         self.label_stats.setWordWrap(True)
         self.label_stats.setVisible(False)
@@ -200,7 +202,7 @@ class LinePlotWidget(QWidget):
             verticalalignment="center",
             transform=self.ax.transAxes,
             fontsize=12,
-            color="#bbbbbb",
+            color=NEUTRAL_400,
         )
         self.ax.set_xlabel("Time" if self.use_datetime_axis else "Sample")
         self.ax.set_ylabel("Value")
@@ -497,7 +499,7 @@ class LinePlotWidget(QWidget):
             self.pause_button.setIcon(fibsem_icon("mdi:play", color=ORANGE_COLOR))
             self.pause_button.setToolTip("Resume live updates")
         else:
-            self.pause_button.setIcon(fibsem_icon("mdi:pause", color="#aaaaaa"))
+            self.pause_button.setIcon(fibsem_icon("mdi:pause", color=NEUTRAL_450))
             self.pause_button.setToolTip("Pause live updates")
             # Trigger a plot update with the current data when resuming
             if len(self.data_buffer) > 0:
@@ -507,10 +509,10 @@ class LinePlotWidget(QWidget):
         """Toggle between datetime and sample index x-axis."""
         self.use_datetime_axis = not self.use_datetime_axis
         if self.use_datetime_axis:
-            self.xaxis_button.setIcon(fibsem_icon("mdi:clock-outline", color="#aaaaaa"))
+            self.xaxis_button.setIcon(fibsem_icon("mdi:clock-outline", color=NEUTRAL_450))
             self.xaxis_button.setToolTip("X axis: Time — click to switch to Sample index")
         else:
-            self.xaxis_button.setIcon(fibsem_icon("mdi:numeric", color="#aaaaaa"))
+            self.xaxis_button.setIcon(fibsem_icon("mdi:numeric", color=NEUTRAL_450))
             self.xaxis_button.setToolTip("X axis: Sample index — click to switch to Time")
 
         # Force axes re-setup and replot

--- a/fibsem/ui/fm/widgets/load_image_dialog.py
+++ b/fibsem/ui/fm/widgets/load_image_dialog.py
@@ -23,6 +23,9 @@ from PyQt5.QtWidgets import (
 
 from fibsem.fm.structures import FluorescenceImage
 from fibsem.ui.stylesheets import RUN_WORKFLOW_BUTTON_STYLESHEET, SECONDARY_BUTTON_STYLESHEET
+from fibsem.ui.tokens import (
+    NEUTRAL_650,
+)
 
 
 class LoadImageDialog(QDialog):
@@ -72,7 +75,7 @@ class LoadImageDialog(QDialog):
         info_label = QLabel(
             "Only OME-TIFF files (.ome.tiff, .ome.tif) are supported. Hold Ctrl to select multiple files."
         )
-        info_label.setStyleSheet("color: #666666; font-size: 11px;")
+        info_label.setStyleSheet(f"color: {NEUTRAL_650}; font-size: 11px;")
         layout.addWidget(info_label)
 
         # Progress bar (initially hidden)

--- a/fibsem/ui/fm/widgets/minimap_plot_widget.py
+++ b/fibsem/ui/fm/widgets/minimap_plot_widget.py
@@ -18,6 +18,10 @@ from fibsem.conversions import is_inside_image_bounds
 from fibsem.structures import FibsemImage, FibsemStagePosition, Point
 from fibsem.imaging.tiled import reproject_stage_positions_onto_image2
 from fibsem.ui.tokens import (
+    NEUTRAL_400,
+    NEUTRAL_750,
+    NEUTRAL_800,
+    NEUTRAL_850,
     SURFACE_COLOR,
 )
 try:
@@ -129,80 +133,80 @@ class MinimapPlotWidget(QWidget):
             self.load_image_button = QToolButton(self)
             self.load_image_button.setText("Load Image")
             self.load_image_button.setToolTip("Load an image file for the minimap")
-            self.load_image_button.setStyleSheet("""
-                QToolButton {
-                    background-color: #3a3a3a;
+            self.load_image_button.setStyleSheet(f"""
+                QToolButton {{
+                    background-color: {NEUTRAL_800};
                     color: white;
                     border: 1px solid #555;
                     padding: 4px 8px;
                     font-size: 10px;
-                }
-                QToolButton:hover {
-                    background-color: #4a4a4a;
-                }
-                QToolButton:pressed {
-                    background-color: #2a2a2a;
-                }
+                }}
+                QToolButton:hover {{
+                    background-color: {NEUTRAL_750};
+                }}
+                QToolButton:pressed {{
+                    background-color: {NEUTRAL_850};
+                }}
             """)
             self.load_image_button.clicked.connect(self._on_load_image_clicked)
             button_layout.addWidget(self.load_image_button)
 
             # Refresh button
             self.refresh_button = QPushButton("Refresh", self)
-            self.refresh_button.setStyleSheet("""
-                QPushButton {
-                    background-color: #3a3a3a;
+            self.refresh_button.setStyleSheet(f"""
+                QPushButton {{
+                    background-color: {NEUTRAL_800};
                     color: white;
                     border: 1px solid #555;
                     padding: 4px 8px;
                     font-size: 10px;
-                }
-                QPushButton:hover {
-                    background-color: #4a4a4a;
-                }
-                QPushButton:pressed {
-                    background-color: #2a2a2a;
-                }
+                }}
+                QPushButton:hover {{
+                    background-color: {NEUTRAL_750};
+                }}
+                QPushButton:pressed {{
+                    background-color: {NEUTRAL_850};
+                }}
             """)
             self.refresh_button.clicked.connect(self.update_minimap)
             button_layout.addWidget(self.refresh_button)
 
             # Reset Zoom button
             self.reset_zoom_button = QPushButton("Reset Zoom", self)
-            self.reset_zoom_button.setStyleSheet("""
-                QPushButton {
-                    background-color: #3a3a3a;
+            self.reset_zoom_button.setStyleSheet(f"""
+                QPushButton {{
+                    background-color: {NEUTRAL_800};
                     color: white;
                     border: 1px solid #555;
                     padding: 4px 8px;
                     font-size: 10px;
-                }
-                QPushButton:hover {
-                    background-color: #4a4a4a;
-                }
-                QPushButton:pressed {
-                    background-color: #2a2a2a;
-                }
+                }}
+                QPushButton:hover {{
+                    background-color: {NEUTRAL_750};
+                }}
+                QPushButton:pressed {{
+                    background-color: {NEUTRAL_850};
+                }}
             """)
             self.reset_zoom_button.clicked.connect(self.reset_zoom)
             button_layout.addWidget(self.reset_zoom_button)
 
             # Clear button
             self.clear_button = QPushButton("Clear", self)
-            self.clear_button.setStyleSheet("""
-                QPushButton {
-                    background-color: #3a3a3a;
+            self.clear_button.setStyleSheet(f"""
+                QPushButton {{
+                    background-color: {NEUTRAL_800};
                     color: white;
                     border: 1px solid #555;
                     padding: 4px 8px;
                     font-size: 10px;
-                }
-                QPushButton:hover {
-                    background-color: #4a4a4a;
-                }
-                QPushButton:pressed {
-                    background-color: #2a2a2a;
-                }
+                }}
+                QPushButton:hover {{
+                    background-color: {NEUTRAL_750};
+                }}
+                QPushButton:pressed {{
+                    background-color: {NEUTRAL_850};
+                }}
             """)
             self.clear_button.clicked.connect(self.clear_minimap)
             button_layout.addWidget(self.clear_button)
@@ -215,15 +219,15 @@ class MinimapPlotWidget(QWidget):
             # Show names checkbox
             self.show_names_checkbox = QCheckBox("Show Names", self)
             self.show_names_checkbox.setChecked(self.show_names)
-            self.show_names_checkbox.setStyleSheet("""
-                QCheckBox {
-                    color: #bbbbbb;
+            self.show_names_checkbox.setStyleSheet(f"""
+                QCheckBox {{
+                    color: {NEUTRAL_400};
                     font-size: 10px;
-                }
-                QCheckBox::indicator {
+                }}
+                QCheckBox::indicator {{
                     width: 13px;
                     height: 13px;
-                }
+                }}
             """)
             self.show_names_checkbox.stateChanged.connect(self._on_show_names_changed)
             checkbox_layout1.addWidget(self.show_names_checkbox)
@@ -231,15 +235,15 @@ class MinimapPlotWidget(QWidget):
             # Show current FOV checkbox
             self.show_current_fov_checkbox = QCheckBox("Current FOV", self)
             self.show_current_fov_checkbox.setChecked(self.show_current_fov)
-            self.show_current_fov_checkbox.setStyleSheet("""
-                QCheckBox {
-                    color: #bbbbbb;
+            self.show_current_fov_checkbox.setStyleSheet(f"""
+                QCheckBox {{
+                    color: {NEUTRAL_400};
                     font-size: 10px;
-                }
-                QCheckBox::indicator {
+                }}
+                QCheckBox::indicator {{
                     width: 13px;
                     height: 13px;
-                }
+                }}
             """)
             self.show_current_fov_checkbox.stateChanged.connect(self._on_show_current_fov_changed)
             checkbox_layout1.addWidget(self.show_current_fov_checkbox)
@@ -253,15 +257,15 @@ class MinimapPlotWidget(QWidget):
             # Show grid positions checkbox
             self.show_grid_positions_checkbox = QCheckBox("Grid Positions", self)
             self.show_grid_positions_checkbox.setChecked(self.show_grid_positions)
-            self.show_grid_positions_checkbox.setStyleSheet("""
-                QCheckBox {
-                    color: #bbbbbb;
+            self.show_grid_positions_checkbox.setStyleSheet(f"""
+                QCheckBox {{
+                    color: {NEUTRAL_400};
                     font-size: 10px;
-                }
-                QCheckBox::indicator {
+                }}
+                QCheckBox::indicator {{
                     width: 13px;
                     height: 13px;
-                }
+                }}
             """)
             self.show_grid_positions_checkbox.stateChanged.connect(self._on_show_grid_positions_changed)
             checkbox_layout2.addWidget(self.show_grid_positions_checkbox)
@@ -269,15 +273,15 @@ class MinimapPlotWidget(QWidget):
             # Show grid boundary checkbox
             self.show_grid_boundary_checkbox = QCheckBox("Grid Boundary", self)
             self.show_grid_boundary_checkbox.setChecked(self.show_grid_boundary)
-            self.show_grid_boundary_checkbox.setStyleSheet("""
-                QCheckBox {
-                    color: #bbbbbb;
+            self.show_grid_boundary_checkbox.setStyleSheet(f"""
+                QCheckBox {{
+                    color: {NEUTRAL_400};
                     font-size: 10px;
-                }
-                QCheckBox::indicator {
+                }}
+                QCheckBox::indicator {{
                     width: 13px;
                     height: 13px;
-                }
+                }}
             """)
             self.show_grid_boundary_checkbox.stateChanged.connect(self._on_show_grid_boundary_changed)
             checkbox_layout2.addWidget(self.show_grid_boundary_checkbox)
@@ -304,7 +308,7 @@ class MinimapPlotWidget(QWidget):
             verticalalignment="center",
             transform=self.ax.transAxes,
             fontsize=12,
-            color="#bbbbbb",
+            color=NEUTRAL_400,
         )
         self.ax.set_title("Minimap")
         self.ax.axis("off")

--- a/fibsem/ui/fm/widgets/overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/overview_confirmation_dialog.py
@@ -13,6 +13,7 @@ from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.structures import ChannelSettings, ZParameters, OverviewParameters
 from fibsem.fm.timing import estimate_tileset_acquisition_time
 from fibsem.ui.stylesheets import (
+    NEUTRAL_650,
     RUN_WORKFLOW_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
 )
@@ -60,7 +61,7 @@ class OverviewConfirmationDialog(QDialog):
 
         for i, channel in enumerate(channel_settings):  # Show all channels
             channel_info = QLabel(f"  • {channel.pretty_name}")
-            channel_info.setStyleSheet("font-size: 10px; color: #666666;")
+            channel_info.setStyleSheet(f"font-size: 10px; color: {NEUTRAL_650};")
             params_layout.addWidget(channel_info)
 
         # Z-stack parameters

--- a/fibsem/ui/fm/widgets/overview_parameters_widget.py
+++ b/fibsem/ui/fm/widgets/overview_parameters_widget.py
@@ -21,6 +21,9 @@ from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
     ValueSpinBox,
 )
+from fibsem.ui.tokens import (
+    NEUTRAL_650,
+)
 
 if TYPE_CHECKING:
     from fibsem.ui.FMAcquisitionWidget import FMAcquisitionWidget
@@ -94,7 +97,7 @@ class OverviewParametersWidget(QWidget):
 
         # Z-stack planes info (shown when z-stack is enabled)
         self.label_zstack_planes_value = QLabel(self._calculate_zstack_planes(), self)
-        self.label_zstack_planes_value.setStyleSheet("QLabel { color: #666666; }")
+        self.label_zstack_planes_value.setStyleSheet(f"QLabel {{ color: {NEUTRAL_650}; }}")
         self.label_zstack_planes_value.setAlignment(Qt.AlignmentFlag.AlignRight)
         
         # Auto-focus mode selection
@@ -122,7 +125,7 @@ class OverviewParametersWidget(QWidget):
         # Total area (calculated, read-only)
         self.label_total_area = QLabel("Total Area", self)
         self.label_total_area_value = QLabel(self._calculate_total_area(), self)
-        self.label_total_area_value.setStyleSheet("QLabel { color: #666666; }")
+        self.label_total_area_value.setStyleSheet(f"QLabel {{ color: {NEUTRAL_650}; }}")
 
         # Create the layout
         layout = QGridLayout()

--- a/fibsem/ui/fm/widgets/saved_positions_widget.py
+++ b/fibsem/ui/fm/widgets/saved_positions_widget.py
@@ -15,6 +15,7 @@ from PyQt5.QtWidgets import (
 
 from fibsem.fm.structures import FMStagePosition
 from fibsem.ui.stylesheets import (
+    NEUTRAL_650,
     PRIMARY_BUTTON_STYLESHEET,
     RUN_WORKFLOW_BUTTON_STYLESHEET,
     STOP_WORKFLOW_BUTTON_STYLESHEET,
@@ -64,7 +65,7 @@ class SavedPositionsWidget(QWidget):
 
         # Position info label
         self.label_position_info = QLabel("No positions saved", self)
-        self.label_position_info.setStyleSheet("QLabel { color: #666666; font-size: 10px; }")
+        self.label_position_info.setStyleSheet(f"QLabel {{ color: {NEUTRAL_650}; font-size: 10px; }}")
         self.label_position_info.setWordWrap(True)
 
         # Auto Focus checkbox

--- a/fibsem/ui/fm/widgets/tile_grid_options_panel.py
+++ b/fibsem/ui/fm/widgets/tile_grid_options_panel.py
@@ -32,6 +32,13 @@ from PyQt5.QtWidgets import (
 
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.tokens import (
+    BORDER_COLOR,
+    DISABLED_BG_COLOR,
+    GRAY_PRIMARY_COLOR,
+    PANEL_COLOR,
+    ROW_ALT_COLOR,
+    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
     WHITE_ICON_COLOR,
 )
 
@@ -52,18 +59,18 @@ def _color_icon(color: str, size: int = 12) -> QIcon:
     return QIcon(pixmap)
 
 
-_PANEL_QSS = """
-QFrame#tileGridPanel { background: #1e2027; border: 1px solid #3d4251; border-radius: 6px; }
-QLabel { color: #d6d6d6; font-size: 11px; background: transparent; }
-QLabel#panelTitle { color: #9aa0a6; font-size: 10px; font-weight: 600; letter-spacing: 1px; }
-QCheckBox { color: #d6d6d6; font-size: 11px; background: transparent; }
-QLabel#gridSummary { color: #868e93; font-size: 10px; background: transparent; }
-QPushButton#centreButton {
-    background: #2a2d38; color: #d6d6d6; font-size: 11px;
-    border: 1px solid #3d4251; border-radius: 4px; padding: 4px 8px;
-}
-QPushButton#centreButton:hover:enabled { background: #333744; }
-QPushButton#centreButton:disabled { color: #5c6169; border-color: #2e323d; }
+_PANEL_QSS = f"""
+QFrame#tileGridPanel {{ background: {PANEL_COLOR}; border: 1px solid {BORDER_COLOR}; border-radius: 6px; }}
+QLabel {{ color: {TEXT_COLOR}; font-size: 11px; background: transparent; }}
+QLabel#panelTitle {{ color: #9aa0a6; font-size: 10px; font-weight: 600; letter-spacing: 1px; }}
+QCheckBox {{ color: {TEXT_COLOR}; font-size: 11px; background: transparent; }}
+QLabel#gridSummary {{ color: {TEXT_MUTED_COLOR}; font-size: 10px; background: transparent; }}
+QPushButton#centreButton {{
+    background: {ROW_ALT_COLOR}; color: {TEXT_COLOR}; font-size: 11px;
+    border: 1px solid {BORDER_COLOR}; border-radius: 4px; padding: 4px 8px;
+}}
+QPushButton#centreButton:hover:enabled {{ background: #333744; }}
+QPushButton#centreButton:disabled {{ color: {GRAY_PRIMARY_COLOR}; border-color: {DISABLED_BG_COLOR}; }}
 """
 
 

--- a/fibsem/ui/fm/widgets/z_parameters_widget.py
+++ b/fibsem/ui/fm/widgets/z_parameters_widget.py
@@ -14,6 +14,9 @@ from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
     ValueSpinBox,
 )
+from fibsem.ui.tokens import (
+    NEUTRAL_650,
+)
 
 Z_PARAMETERS_CONFIG = {
     "step_size": 0.1,  # µm
@@ -82,7 +85,7 @@ class ZParametersWidget(QWidget):
         # Number of planes (calculated, read-only)
         self.label_num_planes = QLabel("Planes", self)
         self.label_num_planes_value = QLabel(self._calculate_num_planes(), self)
-        self.label_num_planes_value.setStyleSheet("QLabel { color: #666666; }")
+        self.label_num_planes_value.setStyleSheet(f"QLabel {{ color: {NEUTRAL_650}; }}")
 
         # Acquisition order
         self.label_order = QLabel("Order", self)

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -51,6 +51,9 @@ from fibsem.ui.tokens import (  # noqa: F401  (re-exported for existing callers)
 # `from fibsem.ui.stylesheets import NAPARI_STYLE` and `stylesheets.NAPARI_STYLE`
 # keep resolving.
 from fibsem.ui.napari_style import NAPARI_STYLE  # noqa: F401
+from fibsem.ui.tokens import (
+    SURFACE_COLOR,
+)
 
 _ICONS_DIR = _os.path.join(_os.path.dirname(__file__), "icons").replace("\\", "/")
 
@@ -336,20 +339,20 @@ TOOLBUTTON_ICON_STYLESHEET = """
     }
 """
 
-# TODO: no token -- #2b2d31, #2d3f5c, #3a3d42
-LIST_WIDGET_STYLESHEET = """
-            QListWidget {
-                background: #2b2d31;
+# TODO: no token -- #2d3f5c, #3a3d42
+LIST_WIDGET_STYLESHEET = f"""
+            QListWidget {{
+                background: {SURFACE_COLOR};
                 border: none;
                 outline: none;
-            }
-            QListWidget::item {
-                background: #2b2d31;
+            }}
+            QListWidget::item {{
+                background: {SURFACE_COLOR};
                 border-bottom: 1px solid #3a3d42;
-            }
-            QListWidget::item:selected {
+            }}
+            QListWidget::item:selected {{
                 background: #2d3f5c;
-            }
+            }}
         """
 
 # QDateTimeEdit with visible up/down step arrows (calendar popup must be OFF for

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -52,6 +52,7 @@ from fibsem.ui.tokens import (  # noqa: F401  (re-exported for existing callers)
 # keep resolving.
 from fibsem.ui.napari_style import NAPARI_STYLE  # noqa: F401
 from fibsem.ui.tokens import (
+    NEUTRAL_650,
     SURFACE_COLOR,
 )
 
@@ -322,21 +323,21 @@ WORKFLOW_BORDER_STYLESHEET = f"""
 """
 
 # TODO: no token -- #6a6a6a, #8a8a8a
-TOOLBUTTON_ICON_STYLESHEET = """
-    QToolButton {
+TOOLBUTTON_ICON_STYLESHEET = f"""
+    QToolButton {{
         border: 1px solid transparent;
         border-radius: 4px;
         padding: 2px 6px;
         background-color: transparent;
-    }
-    QToolButton:hover {
-        border: 1px solid #6a6a6a;
+    }}
+    QToolButton:hover {{
+        border: 1px solid {NEUTRAL_650};
         background-color: rgba(255, 255, 255, 25);
-    }
-    QToolButton:checked {
+    }}
+    QToolButton:checked {{
         border: 1px solid #8a8a8a;
         background-color: rgba(255, 255, 255, 35);
-    }
+    }}
 """
 
 # TODO: no token -- #2d3f5c, #3a3d42

--- a/fibsem/ui/tokens.py
+++ b/fibsem/ui/tokens.py
@@ -79,6 +79,36 @@ DISABLED_BG_COLOR = "#2d313b"   # disabled control background
 DISABLED_TEXT_COLOR = "#6b6b6b" # disabled label and control text
 
 # ---------------------------------------------------------------------------
+# Neutral ramp
+#
+# A second palette, and a deliberate one. Everything above is faintly blue --
+# BORDER_COLOR is #3d4251, not a grey -- which is right for the app's chrome and
+# wrong behind image data, where a colour cast reads as part of the picture. So
+# the plot and canvas widgets built their own neutral scale: 30 pure greys
+# across 167 uses, concentrated in minimap_plot_widget, fluorescence_plot_widget
+# and canvas_base.
+#
+# It was never written down, so it drifted -- #e0e0e0 and #dddddd and #e6e6e6
+# all doing the same job. These are the rungs that carry real weight; naming
+# them is what stops the next one being invented.
+#
+# Numbered rather than role-named, unlike the palette above, because a neutral
+# does not have one role: #909090 is an axis label here and a disabled glyph
+# there. The number tracks darkness, so NEUTRAL_900 is nearly black.
+NEUTRAL_200 = "#e0e0e0"
+NEUTRAL_300 = "#d0d0d0"
+NEUTRAL_400 = "#bbbbbb"
+NEUTRAL_450 = "#aaaaaa"
+NEUTRAL_500 = "#a0a0a0"
+NEUTRAL_550 = "#909090"
+NEUTRAL_650 = "#666666"
+NEUTRAL_700 = "#606060"
+NEUTRAL_750 = "#4a4a4a"
+NEUTRAL_800 = "#3a3a3a"
+NEUTRAL_850 = "#2a2a2a"
+NEUTRAL_900 = "#1a1b1e"
+
+# ---------------------------------------------------------------------------
 # Deprecated aliases.
 #
 # Each of these was a second literal spelling of the colour above it, which is

--- a/fibsem/ui/widgets/autolamella_experiment_task_summary_widget.py
+++ b/fibsem/ui/widgets/autolamella_experiment_task_summary_widget.py
@@ -30,6 +30,10 @@ from fibsem.applications.autolamella.tools.reporting import (
     plot_lamella_task_workflow_summary,
 )
 from fibsem.ui.tokens import (
+    NEUTRAL_400,
+    NEUTRAL_750,
+    NEUTRAL_800,
+    NEUTRAL_850,
     SURFACE_COLOR,
 )
 
@@ -38,42 +42,42 @@ if TYPE_CHECKING:
 
 
 # Stylesheet constants
-COMBOBOX_STYLESHEET = """
-    QComboBox {
-        background-color: #3a3a3a;
+COMBOBOX_STYLESHEET = f"""
+    QComboBox {{
+        background-color: {NEUTRAL_800};
         color: white;
         border: 1px solid #555;
         padding: 4px 8px;
         font-size: 10px;
         min-width: 150px;
-    }
-    QComboBox:hover {
-        background-color: #4a4a4a;
-    }
-    QComboBox::drop-down {
+    }}
+    QComboBox:hover {{
+        background-color: {NEUTRAL_750};
+    }}
+    QComboBox::drop-down {{
         border: none;
-    }
-    QComboBox QAbstractItemView {
-        background-color: #3a3a3a;
+    }}
+    QComboBox QAbstractItemView {{
+        background-color: {NEUTRAL_800};
         color: white;
-        selection-background-color: #4a4a4a;
-    }
+        selection-background-color: {NEUTRAL_750};
+    }}
 """
 
-BUTTON_STYLESHEET = """
-    QPushButton {
-        background-color: #3a3a3a;
+BUTTON_STYLESHEET = f"""
+    QPushButton {{
+        background-color: {NEUTRAL_800};
         color: white;
         border: 1px solid #555;
         padding: 4px 8px;
         font-size: 10px;
-    }
-    QPushButton:hover {
-        background-color: #4a4a4a;
-    }
-    QPushButton:pressed {
-        background-color: #2a2a2a;
-    }
+    }}
+    QPushButton:hover {{
+        background-color: {NEUTRAL_750};
+    }}
+    QPushButton:pressed {{
+        background-color: {NEUTRAL_850};
+    }}
 """
 
 SUMMARY_MODE_TASK = "task"
@@ -139,7 +143,7 @@ class ExperimentTaskSummaryWidget(QWidget):
         """)
 
         self.summary_mode_label = QLabel("Summary:")
-        self.summary_mode_label.setStyleSheet("color: #bbbbbb; font-size: 10px;")
+        self.summary_mode_label.setStyleSheet(f"color: {NEUTRAL_400}; font-size: 10px;")
 
         self.summary_mode_selector = QComboBox(self)
         self.summary_mode_selector.setStyleSheet(COMBOBOX_STYLESHEET)
@@ -148,14 +152,14 @@ class ExperimentTaskSummaryWidget(QWidget):
         self.summary_mode_selector.currentIndexChanged.connect(self._on_summary_mode_changed)
 
         self.task_label = QLabel("Task:")
-        self.task_label.setStyleSheet("color: #bbbbbb; font-size: 10px;")
+        self.task_label.setStyleSheet(f"color: {NEUTRAL_400}; font-size: 10px;")
 
         self.task_selector = QComboBox(self)
         self.task_selector.setStyleSheet(COMBOBOX_STYLESHEET)
         self.task_selector.currentIndexChanged.connect(self._on_task_changed)
 
         self.lamella_label = QLabel("Lamella:")
-        self.lamella_label.setStyleSheet("color: #bbbbbb; font-size: 10px;")
+        self.lamella_label.setStyleSheet(f"color: {NEUTRAL_400}; font-size: 10px;")
 
         self.lamella_selector = QComboBox(self)
         self.lamella_selector.setStyleSheet(COMBOBOX_STYLESHEET)
@@ -171,7 +175,7 @@ class ExperimentTaskSummaryWidget(QWidget):
         self.export_button.clicked.connect(self._on_export_clicked)
 
         self.info_label = QLabel("No experiment loaded")
-        self.info_label.setStyleSheet("color: #bbbbbb; font-size: 10px;")
+        self.info_label.setStyleSheet(f"color: {NEUTRAL_400}; font-size: 10px;")
         self.info_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
 
         # Right side selector panels
@@ -269,7 +273,7 @@ class ExperimentTaskSummaryWidget(QWidget):
             verticalalignment="center",
             transform=ax.transAxes,
             fontsize=12,
-            color="#bbbbbb",
+            color=NEUTRAL_400,
         )
         ax.set_title("Experiment Task Summary", color="white")
         ax.axis("off")

--- a/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
+++ b/fibsem/ui/widgets/autolamella_lamella_protocol_editor.py
@@ -62,6 +62,9 @@ from fibsem.applications.autolamella.workflows.tasks.tasks import (
 from fibsem.ui.widgets.spot_burn_coordinates_widget import (
     SpotBurnCoordinatesWidget,
 )
+from fibsem.ui.tokens import (
+    NEUTRAL_200,
+)
 
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.ui import AutoLamellaUI
@@ -261,7 +264,7 @@ class AutoLamellaProtocolEditorWidget(QWidget):
 
         self.label_lamella_name = QLabel("")
         self.label_lamella_name.setStyleSheet(
-            "font-size: 14px; font-weight: bold; color: #e0e0e0; background: transparent;"
+            f"font-size: 14px; font-weight: bold; color: {NEUTRAL_200}; background: transparent;"
         )
 
         # free-text lamella description (this editor is the source of truth for it)

--- a/fibsem/ui/widgets/autolamella_load_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_load_experiment_widget.py
@@ -25,8 +25,10 @@ from fibsem.ui.stylesheets import (
     DISABLED_TEXT_COLOR,
     PRIMARY_BUTTON_STYLESHEET,
     PRIMARY_COLOR_PRESSED,
+    ROW_ALT_COLOR,
     SECONDARY_BUTTON_STYLESHEET,
     TEXT_COLOR,
+    TEXT_MUTED_COLOR,
 )
 from fibsem.ui.widgets.custom_widgets import TitledPanel
 
@@ -128,7 +130,7 @@ QListWidget::item:selected {{
     background-color: {PRIMARY_COLOR_PRESSED};
 }}
 QListWidget::item:hover:!selected {{
-    background-color: #2a2e39;
+    background-color: {ROW_ALT_COLOR};
 }}
 """
 
@@ -616,7 +618,7 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
             date_str = datetime.fromtimestamp(info.created_at).strftime("%Y-%m-%d")
         else:
             date_str = "unknown date"
-        date_color = "#8a8f99" if available else RECENT_UNAVAILABLE_COLOR
+        date_color = TEXT_MUTED_COLOR if available else RECENT_UNAVAILABLE_COLOR
         date_label = QtWidgets.QLabel(date_str)
         date_label.setStyleSheet(
             f"color: {date_color}; font-size: 11px; background: transparent;"
@@ -637,7 +639,7 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         """Build a small rounded pill showing a layers icon and the lamella count."""
         pill = QtWidgets.QFrame()
         pill.setObjectName("lamellaPill")
-        pill.setStyleSheet("#lamellaPill { background: #2a2e39; border-radius: 9px; }")
+        pill.setStyleSheet(f"#lamellaPill {{ background: {ROW_ALT_COLOR}; border-radius: 9px; }}")
 
         pill_layout = QtWidgets.QHBoxLayout(pill)
         pill_layout.setContentsMargins(7, 2, 8, 2)

--- a/fibsem/ui/widgets/autolamella_overview_image_widget.py
+++ b/fibsem/ui/widgets/autolamella_overview_image_widget.py
@@ -34,6 +34,10 @@ from fibsem.imaging.tiled import plot_minimap
 from fibsem.structures import FibsemImage
 import glob
 from fibsem.ui.tokens import (
+    NEUTRAL_400,
+    NEUTRAL_750,
+    NEUTRAL_800,
+    NEUTRAL_850,
     SURFACE_COLOR,
 )
 if TYPE_CHECKING:
@@ -41,84 +45,84 @@ if TYPE_CHECKING:
 
 
 # Stylesheet constants
-LINEEDIT_STYLESHEET = """
-    QLineEdit {
-        background-color: #3a3a3a;
+LINEEDIT_STYLESHEET = f"""
+    QLineEdit {{
+        background-color: {NEUTRAL_800};
         color: white;
         border: 1px solid #555;
         padding: 4px 8px;
         font-size: 10px;
-    }
-    QLineEdit:hover {
-        background-color: #4a4a4a;
-    }
+    }}
+    QLineEdit:hover {{
+        background-color: {NEUTRAL_750};
+    }}
 """
 
-SPINBOX_STYLESHEET = """
-    QSpinBox {
-        background-color: #3a3a3a;
+SPINBOX_STYLESHEET = f"""
+    QSpinBox {{
+        background-color: {NEUTRAL_800};
         color: white;
         border: 1px solid #555;
         padding: 4px 8px;
         font-size: 10px;
-    }
-    QSpinBox:hover {
-        background-color: #4a4a4a;
-    }
+    }}
+    QSpinBox:hover {{
+        background-color: {NEUTRAL_750};
+    }}
 """
 
-COMBOBOX_STYLESHEET = """
-    QComboBox {
-        background-color: #3a3a3a;
+COMBOBOX_STYLESHEET = f"""
+    QComboBox {{
+        background-color: {NEUTRAL_800};
         color: white;
         border: 1px solid #555;
         padding: 4px 8px;
         font-size: 10px;
         min-width: 150px;
-    }
-    QComboBox:hover {
-        background-color: #4a4a4a;
-    }
-    QComboBox::drop-down {
+    }}
+    QComboBox:hover {{
+        background-color: {NEUTRAL_750};
+    }}
+    QComboBox::drop-down {{
         border: none;
-    }
-    QComboBox QAbstractItemView {
-        background-color: #3a3a3a;
+    }}
+    QComboBox QAbstractItemView {{
+        background-color: {NEUTRAL_800};
         color: white;
-        selection-background-color: #4a4a4a;
-    }
+        selection-background-color: {NEUTRAL_750};
+    }}
 """
 
-BUTTON_STYLESHEET = """
-    QPushButton {
-        background-color: #3a3a3a;
+BUTTON_STYLESHEET = f"""
+    QPushButton {{
+        background-color: {NEUTRAL_800};
         color: white;
         border: 1px solid #555;
         padding: 4px 8px;
         font-size: 10px;
-    }
-    QPushButton:hover {
-        background-color: #4a4a4a;
-    }
-    QPushButton:pressed {
-        background-color: #2a2a2a;
-    }
+    }}
+    QPushButton:hover {{
+        background-color: {NEUTRAL_750};
+    }}
+    QPushButton:pressed {{
+        background-color: {NEUTRAL_850};
+    }}
 """
 
-CHECKBOX_STYLESHEET = """
-    QCheckBox {
+CHECKBOX_STYLESHEET = f"""
+    QCheckBox {{
         color: white;
         font-size: 10px;
-    }
-    QCheckBox::indicator {
+    }}
+    QCheckBox::indicator {{
         width: 15px;
         height: 15px;
         border: 1px solid #555;
-        background-color: #3a3a3a;
-    }
-    QCheckBox::indicator:checked {
+        background-color: {NEUTRAL_800};
+    }}
+    QCheckBox::indicator:checked {{
         background-color: #4a90e2;
-    }
+    }}
 """
 
 
@@ -275,7 +279,7 @@ class OverviewImageWidget(QWidget):
 
         # Info label
         self.info_label = QLabel("No experiment loaded")
-        self.info_label.setStyleSheet("color: #bbbbbb; font-size: 10px;")
+        self.info_label.setStyleSheet(f"color: {NEUTRAL_400}; font-size: 10px;")
         self.info_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
 
         # main layout
@@ -313,7 +317,7 @@ class OverviewImageWidget(QWidget):
             verticalalignment="center",
             transform=ax.transAxes,
             fontsize=12,
-            color="#bbbbbb",
+            color=NEUTRAL_400,
         )
         ax.set_title("Overview Image Preview", color="white")
         ax.axis("off")

--- a/fibsem/ui/widgets/autolamella_task_config_editor.py
+++ b/fibsem/ui/widgets/autolamella_task_config_editor.py
@@ -42,6 +42,9 @@ from fibsem.ui.widgets.autolamella_protocol_information_widget import ProtocolIn
 from fibsem.ui.widgets.autolamella_task_config_widget import AutoLamellaTaskParametersConfigWidget
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 from fibsem.ui.widgets.reference_image_parameters_widget import ReferenceImageParametersWidget
+from fibsem.ui.tokens import (
+    TEXT_MUTED_COLOR,
+)
 
 # Frame used by the spot-burn coordinate dialog when the task's stored reference
 # imaging is unusable (missing/zero). Matches ImageSettings' own defaults.
@@ -515,7 +518,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
             "Right-click the frame to add a point, drag to move, Delete to remove."
         )
         hint.setWordWrap(True)
-        hint.setStyleSheet("color: #8a9099; font-size: 11px;")
+        hint.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 11px;")
         layout.addWidget(hint)
 
         btn_row = QHBoxLayout()

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -46,6 +46,9 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.stylesheets import CANVAS_BG as _BG, PRIMARY_ACCENT as _ACCENT
 from fibsem.ui.widgets.canvas.contrast_gamma_control import ContrastGammaControl
 from fibsem.ui.tokens import (
+    NEUTRAL_400,
+    NEUTRAL_450,
+    NEUTRAL_900,
     WHITE_ICON_COLOR,
 )
 
@@ -372,7 +375,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             self._hint_artist = self._ax.text(
                 0.012, 0.985, self._hint_text,
                 transform=self._ax.transAxes, ha="left", va="top",
-                fontsize=8, color="#1a1a1a", zorder=11,
+                fontsize=8, color=NEUTRAL_900, zorder=11,
                 bbox=dict(boxstyle="round,pad=0.3", facecolor="#e6e6e6",
                           edgecolor="none", alpha=0.85),
             )
@@ -598,7 +601,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         repositioned automatically on resize.  Returns the button.
         """
         btn = QPushButton(self)
-        btn.setIcon(fibsem_icon(icon_name, color="#aaaaaa"))
+        btn.setIcon(fibsem_icon(icon_name, color=NEUTRAL_450))
         btn.setIconSize(_OVERLAY_ICON_SIZE)
         btn.setFixedSize(_OVERLAY_BTN_SIZE, _OVERLAY_BTN_SIZE)
         btn.setToolTip(tooltip)
@@ -809,7 +812,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         """
         self._mode_overlay = overlay
         self._mode_label = label
-        self.btn_mode.setIcon(fibsem_icon(icon, color="#aaaaaa"))
+        self.btn_mode.setIcon(fibsem_icon(icon, color=NEUTRAL_450))
         self.btn_mode.setToolTip(f"{label} active — click to enable Move")
         self.btn_mode.setChecked(True)
         self.btn_mode.show()
@@ -855,7 +858,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             va="center",
             transform=self._ax.transAxes,
             fontsize=11,
-            color="#bbbbbb",
+            color=NEUTRAL_400,
         )
 
     def toggle_scalebar(self) -> None:

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -35,6 +35,7 @@ from fibsem.ui.utils import install_wheel_blocker
 from fibsem.utils import format_value
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    NEUTRAL_550,
 )
 
 
@@ -852,7 +853,7 @@ def _lamella_status_text(lamella) -> tuple[str, str]:
             pass
     last = getattr(lamella, "last_completed_task", None)
     if last:
-        return last.completed, "color: #909090; background: transparent;"
+        return last.completed, f"color: {NEUTRAL_550}; background: transparent;"
     return "", "background: transparent;"
 
 

--- a/fibsem/ui/widgets/dataframe_table_widget.py
+++ b/fibsem/ui/widgets/dataframe_table_widget.py
@@ -7,6 +7,9 @@ from PyQt5.QtWidgets import QWidget, QVBoxLayout, QTableWidget, QTableWidgetItem
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QColor, QPalette
 from fibsem.ui.tokens import (
+    NEUTRAL_200,
+    NEUTRAL_850,
+    NEUTRAL_900,
     PRIMARY_ACCENT,
     WHITE_ICON_COLOR,
 )
@@ -47,9 +50,9 @@ class DataFrameTableWidget(QWidget):
 
         # Apply dark theme palette (matching autolamella_workflow_widget)
         palette = self.table_widget.palette()
-        palette.setColor(QPalette.ColorRole.Base, QColor("#202020"))
-        palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#2c2c2c"))
-        palette.setColor(QPalette.ColorRole.Text, QColor("#dddddd"))
+        palette.setColor(QPalette.ColorRole.Base, QColor(NEUTRAL_900))
+        palette.setColor(QPalette.ColorRole.AlternateBase, QColor(NEUTRAL_850))
+        palette.setColor(QPalette.ColorRole.Text, QColor(NEUTRAL_200))
         palette.setColor(QPalette.ColorRole.Highlight, QColor(PRIMARY_ACCENT))
         palette.setColor(QPalette.ColorRole.HighlightedText, QColor(WHITE_ICON_COLOR))
         self.table_widget.setPalette(palette)

--- a/fibsem/ui/widgets/fibsem_image_flow_widget.py
+++ b/fibsem/ui/widgets/fibsem_image_flow_widget.py
@@ -22,6 +22,8 @@ from fibsem.ui.icon import fibsem_icon
 
 from fibsem.structures import FibsemImage
 from fibsem.ui.tokens import (
+    NEUTRAL_300,
+    NEUTRAL_900,
     SURFACE_COLOR,
 )
 
@@ -81,7 +83,7 @@ class FibsemImageCard(QWidget):
         super().__init__(parent)
         self._title = title
         self.setFixedSize(_CARD_WIDTH, _CARD_HEIGHT + 24)
-        self.setStyleSheet("background: #1a1b1e; border-radius: 6px;")
+        self.setStyleSheet(f"background: {NEUTRAL_900}; border-radius: 6px;")
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(4, 4, 4, 4)
@@ -100,7 +102,7 @@ class FibsemImageCard(QWidget):
 
         # Zoom button — top-right of the image container
         self._zoom_btn = QPushButton(img_container)
-        self._zoom_btn.setIcon(fibsem_icon("mdi:magnify", color="#cccccc"))
+        self._zoom_btn.setIcon(fibsem_icon("mdi:magnify", color=NEUTRAL_300))
         self._zoom_btn.setFixedSize(28, 28)
         self._zoom_btn.setStyleSheet(
             "QPushButton {"
@@ -117,7 +119,7 @@ class FibsemImageCard(QWidget):
         if title:
             title_label = QLabel(title)
             title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            title_label.setStyleSheet("color: #cccccc; font-size: 11px; background: transparent;")
+            title_label.setStyleSheet(f"color: {NEUTRAL_300}; font-size: 11px; background: transparent;")
             title_label.setFixedHeight(20)
             layout.addWidget(title_label)
 

--- a/fibsem/ui/widgets/fibsem_image_flow_widget.py
+++ b/fibsem/ui/widgets/fibsem_image_flow_widget.py
@@ -21,6 +21,9 @@ from superqt import QFlowLayout
 from fibsem.ui.icon import fibsem_icon
 
 from fibsem.structures import FibsemImage
+from fibsem.ui.tokens import (
+    SURFACE_COLOR,
+)
 
 _CARD_WIDTH = 320
 _CARD_HEIGHT = 240
@@ -145,11 +148,11 @@ class FibsemImageFlowWidget(QWidget):
         self._scroll = QScrollArea()
         self._scroll.setWidgetResizable(True)
         self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        self._scroll.setStyleSheet("QScrollArea { border: none; background: #2b2d31; }")
+        self._scroll.setStyleSheet(f"QScrollArea {{ border: none; background: {SURFACE_COLOR}; }}")
         outer.addWidget(self._scroll)
 
         self._content = QWidget()
-        self._content.setStyleSheet("background: #2b2d31;")
+        self._content.setStyleSheet(f"background: {SURFACE_COLOR};")
         self._content.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
         self._flow = QFlowLayout(self._content)

--- a/fibsem/ui/widgets/image_settings_widget.py
+++ b/fibsem/ui/widgets/image_settings_widget.py
@@ -21,6 +21,9 @@ from fibsem.structures import ImageSettings
 from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import IconToolButton, QDirectoryLineEdit
 from fibsem.ui import stylesheets
+from fibsem.ui.tokens import (
+    NEUTRAL_400,
+)
 
 # GUI Configuration Constants
 WIDGET_CONFIG = {
@@ -86,7 +89,7 @@ class ImageSettingsWidget(QWidget):
         # --- Header row ---
         self.btn_advanced = IconToolButton(
             icon="mdi:tune",
-            color="#c0c0c0",
+            color=NEUTRAL_400,
             checked_icon="mdi:tune-variant",
             checked_color=stylesheets.GRAY_WHITE_COLOR,
             tooltip="Show advanced settings",

--- a/fibsem/ui/widgets/lamella_card_widget.py
+++ b/fibsem/ui/widgets/lamella_card_widget.py
@@ -22,6 +22,9 @@ from fibsem.applications.autolamella.structures import DefectState, DefectType, 
 from fibsem.ui.widgets.lamella_list_widget import _defect_icon, _status_text
 from fibsem.ui import stylesheets
 from fibsem.ui.tokens import (
+    NEUTRAL_200,
+    NEUTRAL_550,
+    NEUTRAL_900,
     SURFACE_COLOR,
 )
 
@@ -104,7 +107,7 @@ class LamellaCardWidget(QWidget):
         self._thumb_label = QLabel()
         self._thumb_label.setFixedSize(_thumb_w, _THUMB_HEIGHT)
         self._thumb_label.setAlignment(Qt.AlignCenter)
-        self._thumb_label.setStyleSheet("background: #1a1b1e; border-radius: 4px;")
+        self._thumb_label.setStyleSheet(f"background: {NEUTRAL_900}; border-radius: 4px;")
         card_layout.addWidget(self._thumb_label)
 
         # ── divider ─────────────────────────────────────────────────────
@@ -126,7 +129,7 @@ class LamellaCardWidget(QWidget):
 
         self._name_label = QLabel()
         self._name_label.setStyleSheet(
-            "font-size: 13px; font-weight: bold; color: #e0e0e0; background: transparent;"
+            f"font-size: 13px; font-weight: bold; color: {NEUTRAL_200}; background: transparent;"
         )
         name_row.addWidget(self._name_label, 1)
 
@@ -162,7 +165,7 @@ class LamellaCardWidget(QWidget):
 
         self._status_label = QLabel()
         self._status_label.setStyleSheet(
-            "font-size: 11px; color: #909090; background: transparent;"
+            f"font-size: 11px; color: {NEUTRAL_550}; background: transparent;"
         )
         self._status_label.setWordWrap(True)
         info_layout.addWidget(self._status_label)

--- a/fibsem/ui/widgets/lamella_card_widget.py
+++ b/fibsem/ui/widgets/lamella_card_widget.py
@@ -21,26 +21,29 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem.applications.autolamella.structures import DefectState, DefectType, Lamella
 from fibsem.ui.widgets.lamella_list_widget import _defect_icon, _status_text
 from fibsem.ui import stylesheets
+from fibsem.ui.tokens import (
+    SURFACE_COLOR,
+)
 
 _CARD_WIDTH = 300
 _THUMB_PADDING = 6        # inset from card edges so rounded corners stay visible
 _THUMB_HEIGHT = 170
 _BTN_SIZE = 24
 
-_CARD_STYLE = """
-QFrame#LamellaCard {
-    background: #2b2d31;
+_CARD_STYLE = f"""
+QFrame#LamellaCard {{
+    background: {SURFACE_COLOR};
     border: 1px solid #3a3d42;
     border-radius: 8px;
-}
+}}
 """
 
-_CARD_SELECTED_STYLE = """
-QFrame#LamellaCard {
-    background: #2b2d31;
+_CARD_SELECTED_STYLE = f"""
+QFrame#LamellaCard {{
+    background: {SURFACE_COLOR};
     border: 2px solid #007ACC;
     border-radius: 8px;
-}
+}}
 """
 
 _BTN_STYLE = """

--- a/fibsem/ui/widgets/lamella_default_config_widget.py
+++ b/fibsem/ui/widgets/lamella_default_config_widget.py
@@ -21,6 +21,7 @@ from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
 from fibsem.structures import DEFAULT_ALIGNMENT_AREA, FibsemRectangle, Point
 from fibsem.ui.stylesheets import NAPARI_STYLE
 from fibsem.ui.tokens import (
+    NEUTRAL_500,
     SEMANTIC_WARNING_COLOR,
 )
 
@@ -31,7 +32,7 @@ _SECTION_STYLE = (
     "font-size: 10px; font-weight: bold; color: #707070;"
     " padding: 4px 0px 2px 0px; letter-spacing: 0.5px;"
 )
-_LABEL_STYLE = "color: #a0a0a0; min-width: 80px; font-size: 11px; background: transparent;"
+_LABEL_STYLE = f"color: {NEUTRAL_500}; min-width: 80px; font-size: 11px; background: transparent;"
 _INVALID_STYLE = f"color: {SEMANTIC_WARNING_COLOR}; font-size: 10px; background: transparent;"
 _HINT_STYLE = (
     "color: #808080; font-size: 10px; background: transparent;"

--- a/fibsem/ui/widgets/lamella_list_widget.py
+++ b/fibsem/ui/widgets/lamella_list_widget.py
@@ -31,6 +31,7 @@ from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    NEUTRAL_550,
 )
 
 _NAME_MIN_WIDTH = 160
@@ -89,7 +90,7 @@ def _status_text(lamella: Lamella) -> tuple[str, str]:
         return f"{ts.name}", f"color: {stylesheets.PRIMARY_COLOR}; background: transparent;"
     last = lamella.last_completed_task
     if last:
-        return last.completed, "color: #909090; background: transparent;"
+        return last.completed, f"color: {NEUTRAL_550}; background: transparent;"
     return "", "background: transparent;"
 
 

--- a/fibsem/ui/widgets/lamella_pose_list_widget.py
+++ b/fibsem/ui/widgets/lamella_pose_list_widget.py
@@ -19,6 +19,7 @@ from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    NEUTRAL_550,
 )
 
 _NAME_WIDTH = 110
@@ -51,7 +52,7 @@ class LamellaPoseRowWidget(QWidget):
         layout.addWidget(self.name_label)
 
         self.position_label = QLabel(pretty)
-        self.position_label.setStyleSheet("background: transparent; color: #909090;")
+        self.position_label.setStyleSheet(f"background: transparent; color: {NEUTRAL_550};")
         layout.addWidget(self.position_label, 1)
 
         self.btn_update = IconToolButton(

--- a/fibsem/ui/widgets/lamella_task_image_widget.py
+++ b/fibsem/ui/widgets/lamella_task_image_widget.py
@@ -33,6 +33,9 @@ from fibsem.applications.autolamella.task_outputs import (
 from fibsem.fm.preview import is_fluorescence_image, load_projection
 from fibsem.imaging.drawing import draw_image_overlays
 from fibsem.structures import FibsemImage
+from fibsem.ui.tokens import (
+    SURFACE_COLOR,
+)
 
 _TARGET_WIDTH = 1024//2
 _PLACEHOLDER_HEIGHT = 768//2  # estimated height for placeholder labels
@@ -228,12 +231,12 @@ class LamellaTaskImageWidget(QWidget):
         self._scroll.setWidgetResizable(True)
         self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self._scroll.setStyleSheet(
-            "QScrollArea { border: none; background: #2b2d31; }"
+            f"QScrollArea {{ border: none; background: {SURFACE_COLOR}; }}"
         )
         outer.addWidget(self._scroll)
 
         self._content = QWidget()
-        self._content.setStyleSheet("background: #2b2d31;")
+        self._content.setStyleSheet(f"background: {SURFACE_COLOR};")
         self._content_layout = QVBoxLayout(self._content)
         self._content_layout.setContentsMargins(16, 16, 16, 16)
         self._content_layout.setSpacing(12)

--- a/fibsem/ui/widgets/lamella_task_image_widget.py
+++ b/fibsem/ui/widgets/lamella_task_image_widget.py
@@ -34,6 +34,10 @@ from fibsem.fm.preview import is_fluorescence_image, load_projection
 from fibsem.imaging.drawing import draw_image_overlays
 from fibsem.structures import FibsemImage
 from fibsem.ui.tokens import (
+    NEUTRAL_200,
+    NEUTRAL_400,
+    NEUTRAL_550,
+    NEUTRAL_900,
     SURFACE_COLOR,
 )
 
@@ -243,7 +247,7 @@ class LamellaTaskImageWidget(QWidget):
         self._content_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
         self._empty_label = QLabel("Select a lamella card to view task images.")
-        self._empty_label.setStyleSheet("color: #909090; font-size: 12px;")
+        self._empty_label.setStyleSheet(f"color: {NEUTRAL_550}; font-size: 12px;")
         self._empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._content_layout.addWidget(self._empty_label)
 
@@ -293,7 +297,7 @@ class LamellaTaskImageWidget(QWidget):
 
         if self._lamella is None:
             label = QLabel("Select a lamella card to view task images.")
-            label.setStyleSheet("color: #909090; font-size: 12px;")
+            label.setStyleSheet(f"color: {NEUTRAL_550}; font-size: 12px;")
             label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             self._content_layout.addWidget(label)
             return
@@ -303,7 +307,7 @@ class LamellaTaskImageWidget(QWidget):
         # Header: lamella name
         name_label = QLabel(lamella.name)
         name_label.setStyleSheet(
-            "font-size: 14px; font-weight: bold; color: #e0e0e0; background: transparent;"
+            f"font-size: 14px; font-weight: bold; color: {NEUTRAL_200}; background: transparent;"
         )
         self._content_layout.addWidget(name_label)
 
@@ -315,7 +319,7 @@ class LamellaTaskImageWidget(QWidget):
             subtitle = "No completed tasks"
         subtitle_label = QLabel(subtitle)
         subtitle_label.setStyleSheet(
-            "font-size: 11px; color: #909090; background: transparent;"
+            f"font-size: 11px; color: {NEUTRAL_550}; background: transparent;"
         )
         self._content_layout.addWidget(subtitle_label)
 
@@ -329,7 +333,7 @@ class LamellaTaskImageWidget(QWidget):
             runs.setdefault(t.name, []).append(t)
         if not runs:
             no_images = QLabel("No task images available.")
-            no_images.setStyleSheet("color: #909090; font-size: 11px;")
+            no_images.setStyleSheet(f"color: {NEUTRAL_550}; font-size: 11px;")
             self._content_layout.addWidget(no_images)
             self._content_layout.addStretch(1)
             return
@@ -386,7 +390,7 @@ class LamellaTaskImageWidget(QWidget):
         # Task label
         task_label = QLabel(task_name)
         task_label.setStyleSheet(
-            "font-size: 12px; font-weight: 600; color: #bbbbbb; background: transparent;"
+            f"font-size: 12px; font-weight: 600; color: {NEUTRAL_400}; background: transparent;"
         )
         layout.addWidget(task_label)
 
@@ -412,7 +416,7 @@ class LamellaTaskImageWidget(QWidget):
         for index, fpath in enumerate(filenames):
             img_label = ClickableLabel(fpath)
             img_label.setFixedSize(_TARGET_WIDTH, _PLACEHOLDER_HEIGHT)
-            img_label.setStyleSheet("background: #1a1b1e; border-radius: 4px;")
+            img_label.setStyleSheet(f"background: {NEUTRAL_900}; border-radius: 4px;")
             img_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             img_label.setText("Loading...")
             row, column = divmod(index, _IMAGES_PER_LINE)

--- a/fibsem/ui/widgets/lamella_workflow_widget.py
+++ b/fibsem/ui/widgets/lamella_workflow_widget.py
@@ -31,6 +31,7 @@ from fibsem.ui.widgets.custom_widgets import (
 )
 from fibsem.ui.tokens import (
     PRIMARY_COLOR,
+    SURFACE_COLOR,
     TEXT_COLOR,
 )
 
@@ -115,7 +116,7 @@ class _TaskEditorDialog(QDialog):
         self.setModal(True)
         self.setMinimumWidth(470)
         self.setMinimumHeight(520)
-        self.setStyleSheet(f"background: #2b2d31; color: {TEXT_COLOR};")
+        self.setStyleSheet(f"background: {SURFACE_COLOR}; color: {TEXT_COLOR};")
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/fibsem/ui/widgets/lamella_workflow_widget.py
+++ b/fibsem/ui/widgets/lamella_workflow_widget.py
@@ -30,6 +30,7 @@ from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
 )
 from fibsem.ui.tokens import (
+    NEUTRAL_500,
     PRIMARY_COLOR,
     SURFACE_COLOR,
     TEXT_COLOR,
@@ -229,7 +230,7 @@ class LamellaWorkflowWidget(QWidget):
             "Drag to reorder  \u2022  click supervision icon to toggle  \u2022  use \u270e to edit task details"
         )
         self._instructions_label.setStyleSheet(
-            "color: #a0a0a0; font-size: 10px; padding: 2px 6px 4px 6px;"
+            f"color: {NEUTRAL_500}; font-size: 10px; padding: 2px 6px 4px 6px;"
         )
         root.addWidget(self._instructions_label)
 

--- a/fibsem/ui/widgets/milling_stage_list_widget.py
+++ b/fibsem/ui/widgets/milling_stage_list_widget.py
@@ -28,6 +28,7 @@ from fibsem.ui.napari.patterns import COLOURS
 from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueComboBox, ValueSpinBox
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    NEUTRAL_700,
     ORANGE_COLOR,
 )
 
@@ -472,7 +473,7 @@ class MillingStageListWidget(QWidget):
         layout.addWidget(self._list)
 
         self._empty_label = QLabel("No milling stages. Click + to add one.")
-        self._empty_label.setStyleSheet("color: #606060; font-style: italic; padding: 12px;")
+        self._empty_label.setStyleSheet(f"color: {NEUTRAL_700}; font-style: italic; padding: 12px;")
         self._empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self._empty_label)
 

--- a/fibsem/ui/widgets/plugins_dialog.py
+++ b/fibsem/ui/widgets/plugins_dialog.py
@@ -41,6 +41,7 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.stylesheets import (
     ACCENT_COLOR,
     BORDER_COLOR,
+    DISABLED_BG_COLOR,
     ERROR_COLOR,
     GRAY_ICON_COLOR,
     OK_COLOR,
@@ -121,7 +122,7 @@ QHeaderView::section {{
     padding: 6px 8px;
     font-size: 11px;
 }}
-QTableWidget::item {{ padding: 6px 8px; border-bottom: 1px solid #31353f; }}
+QTableWidget::item {{ padding: 6px 8px; border-bottom: 1px solid {DISABLED_BG_COLOR}; }}
 QTableWidget::item:selected {{ background-color: #2d3947; color: {_TEXT_STRONG}; }}
 """
 

--- a/fibsem/ui/widgets/profile_line.py
+++ b/fibsem/ui/widgets/profile_line.py
@@ -23,6 +23,9 @@ from PyQt5.QtCore import QPoint, QRect, Qt
 from PyQt5.QtGui import QColor, QFont, QPainter, QPen
 
 from fibsem.ui.widgets.drag_distance import _MeasureOverlayBase, _fmt_distance
+from fibsem.ui.tokens import (
+    PANEL_COLOR,
+)
 
 try:
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
@@ -70,7 +73,7 @@ class _ProfilePlotWidget(QtWidgets.QWidget):
     def _style_axes(self):
         ax = self._ax
         self._fig.patch.set_alpha(0)
-        ax.set_facecolor("#23242a")
+        ax.set_facecolor(PANEL_COLOR)
         ax.tick_params(colors="#999", labelsize=8)
         for spine in ax.spines.values():
             spine.set_color("#444")

--- a/fibsem/ui/widgets/profile_line.py
+++ b/fibsem/ui/widgets/profile_line.py
@@ -24,6 +24,7 @@ from PyQt5.QtGui import QColor, QFont, QPainter, QPen
 
 from fibsem.ui.widgets.drag_distance import _MeasureOverlayBase, _fmt_distance
 from fibsem.ui.tokens import (
+    NEUTRAL_900,
     PANEL_COLOR,
 )
 
@@ -46,13 +47,13 @@ class _ProfilePlotWidget(QtWidgets.QWidget):
         super().__init__(parent)
         self.setMinimumHeight(160)
         self.setMaximumHeight(200)
-        self.setStyleSheet("background: #1a1b1e;")
+        self.setStyleSheet(f"background: {NEUTRAL_900};")
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(4, 4, 4, 4)
 
         if _MPL:
-            self._fig = Figure(figsize=(4, 1.8), facecolor="#1a1b1e")
+            self._fig = Figure(figsize=(4, 1.8), facecolor=NEUTRAL_900)
             self._ax  = self._fig.add_subplot(111)
             self._canvas = FigureCanvasQTAgg(self._fig)
             layout.addWidget(self._canvas)

--- a/fibsem/ui/widgets/sample_holder_widget.py
+++ b/fibsem/ui/widgets/sample_holder_widget.py
@@ -22,6 +22,8 @@ from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import TitledPanel, ValueSpinBox
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    NEUTRAL_500,
+    NEUTRAL_700,
     SURFACE_COLOR,
 )
 
@@ -41,7 +43,7 @@ QToolButton:hover { background: rgba(255, 255, 255, 30); }
 QToolButton:pressed { background: rgba(255, 255, 255, 15); }
 """
 
-_EMPTY_STYLE = "color: #606060; font-style: italic; background: transparent;"
+_EMPTY_STYLE = f"color: {NEUTRAL_700}; font-style: italic; background: transparent;"
 _LOADED_STYLE = "background: transparent;"
 
 
@@ -178,7 +180,7 @@ class _GridSlotEditPanel(QWidget):
         self.slot_name_label = QLabel()
         self.slot_name_label.setStyleSheet("font-weight: bold;")
         self.position_label = QLabel()
-        self.position_label.setStyleSheet("color: #a0a0a0;")
+        self.position_label.setStyleSheet(f"color: {NEUTRAL_500};")
         header_row.addWidget(self.slot_name_label)
         header_row.addWidget(self.position_label, 1)
         layout.addLayout(header_row)
@@ -298,7 +300,7 @@ class SampleHolderWidget(QWidget):
 
         self._empty_label = QLabel("No slots defined.")
         self._empty_label.setStyleSheet(
-            "color: #606060; font-style: italic; padding: 8px;"
+            f"color: {NEUTRAL_700}; font-style: italic; padding: 8px;"
         )
         self._empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 

--- a/fibsem/ui/widgets/sample_holder_widget.py
+++ b/fibsem/ui/widgets/sample_holder_widget.py
@@ -22,6 +22,7 @@ from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import TitledPanel, ValueSpinBox
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    SURFACE_COLOR,
 )
 
 _ROW_HEIGHT = 40
@@ -499,7 +500,7 @@ if __name__ == "__main__":
     holder = microscope._stage.holder
 
     widget = SampleHolderWidget(microscope=microscope)
-    widget.setStyleSheet("background: #2b2d31; color: #d1d2d4;")
+    widget.setStyleSheet(f"background: {SURFACE_COLOR}; color: #d1d2d4;")
     widget.set_holder(holder)
 
     def on_holder_changed(h: SampleHolder) -> None:

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -40,6 +40,7 @@ from fibsem.scripting import DiscoveredScript, ScriptResult
 from fibsem.ui.stylesheets import (
     ACCENT_COLOR,
     BORDER_COLOR,
+    DISABLED_BG_COLOR,
     ERROR_COLOR,
     PANEL_COLOR,
     PRIMARY_BUTTON_STYLESHEET,
@@ -132,7 +133,7 @@ QHeaderView::section {{
     padding: 6px 8px;
     font-size: {_FS_SMALL}px;
 }}
-QTableWidget::item {{ padding: 6px 8px; border-bottom: 1px solid #31353f; }}
+QTableWidget::item {{ padding: 6px 8px; border-bottom: 1px solid {DISABLED_BG_COLOR}; }}
 QTableWidget::item:selected {{ background-color: #2d3947; color: {_TEXT_STRONG}; }}
 """
 

--- a/fibsem/ui/widgets/selected_lamella_widget.py
+++ b/fibsem/ui/widgets/selected_lamella_widget.py
@@ -20,6 +20,9 @@ from fibsem.ui.widgets.custom_widgets import (
     ValueSpinBox,
 )
 from fibsem.ui.widgets.lamella_pose_list_widget import LamellaPoseListWidget
+from fibsem.ui.tokens import (
+    NEUTRAL_550,
+)
 
 
 class SelectedLamellaWidget(QWidget):
@@ -46,7 +49,7 @@ class SelectedLamellaWidget(QWidget):
         self.description_label = QLabel()
         self.description_label.setWordWrap(True)
         self.description_label.setStyleSheet(
-            "color: #909090; font-style: italic; background: transparent;"
+            f"color: {NEUTRAL_550}; font-style: italic; background: transparent;"
         )
         self.description_label.setToolTip("Free-text note (edit in the Lamella editor)")
 

--- a/fibsem/ui/widgets/spot_burn_coordinates_widget.py
+++ b/fibsem/ui/widgets/spot_burn_coordinates_widget.py
@@ -15,10 +15,13 @@ from fibsem.structures import BeamType, Point
 from fibsem.ui.widgets.canvas.canvas_state import PointsSpec
 from fibsem.ui.widgets.custom_widgets import IconToolButton
 from fibsem.ui.stylesheets import CANVAS_BG
+from fibsem.ui.tokens import (
+    TEXT_MUTED_COLOR,
+)
 
 
 _HEADER_BG = CANVAS_BG
-_MUTED = "#8a9099"
+_MUTED = TEXT_MUTED_COLOR
 
 
 class _SpotBurnRow(QWidget):

--- a/fibsem/ui/widgets/strategy_settings_widget.py
+++ b/fibsem/ui/widgets/strategy_settings_widget.py
@@ -24,6 +24,9 @@ from fibsem.ui.widgets.custom_widgets import (
     ValueSpinBox,
     IntegerValueSpinBox,
 )
+from fibsem.ui.tokens import (
+    NEUTRAL_700,
+)
 
 
 class FibsemStrategySettingsWidget(QWidget):
@@ -75,7 +78,7 @@ class FibsemStrategySettingsWidget(QWidget):
 
         # Empty-state label (shown when strategy has no config fields)
         self._empty_label = QLabel("No configuration options.")
-        self._empty_label.setStyleSheet("color: #606060; font-style: italic;")
+        self._empty_label.setStyleSheet(f"color: {NEUTRAL_700}; font-style: italic;")
         self._empty_label.setVisible(False)
         outer.addWidget(self._empty_label)
 

--- a/fibsem/ui/widgets/tiled_overview_widget.py
+++ b/fibsem/ui/widgets/tiled_overview_widget.py
@@ -30,6 +30,9 @@ from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QLabel, QSizePolicy, QVBoxLayout, QWidget
 
 from fibsem.ui.stylesheets import CANVAS_BG, GRAY_WHITE_COLOR, OK_COLOR
+from fibsem.ui.tokens import (
+    NEUTRAL_450,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -199,7 +202,7 @@ class TiledOverviewWidget(QWidget):
         self._ax.set_facecolor(_COLOR_BG)
 
         self._status = QLabel()
-        self._status.setStyleSheet("color: #AAAAAA; font-size: 11px; padding: 2px 4px;")
+        self._status.setStyleSheet(f"color: {NEUTRAL_450}; font-size: 11px; padding: 2px 4px;")
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/fibsem/ui/widgets/workflow_config_widget.py
+++ b/fibsem/ui/widgets/workflow_config_widget.py
@@ -30,6 +30,7 @@ from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    NEUTRAL_700,
 )
 
 _DRAG_HANDLE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "icons", "drag_handle.svg")
@@ -170,7 +171,7 @@ class WorkflowTaskRowWidget(QWidget):
                 f"Scheduled: {self.task.scheduled_at.strftime(DATETIME_DISPLAY_AMPM)}"
             )
         else:
-            self.btn_schedule.setIcon(fibsem_icon("mdi:clock-outline", color="#606060"))
+            self.btn_schedule.setIcon(fibsem_icon("mdi:clock-outline", color=NEUTRAL_700))
             self.btn_schedule.setToolTip("Not scheduled — click to set")
 
 

--- a/fibsem/ui/widgets/workflow_info_widget.py
+++ b/fibsem/ui/widgets/workflow_info_widget.py
@@ -17,6 +17,8 @@ from fibsem.applications.autolamella.structures import (
     AutoLamellaWorkflowOptions,
 )
 from fibsem.ui.tokens import (
+    PANEL_COLOR,
+    SURFACE_COLOR,
     TEXT_COLOR,
 )
 
@@ -25,16 +27,16 @@ _SECTION_STYLE = (
     "font-size: 10px; font-weight: bold; color: #707070;"
     " padding: 4px 0px 2px 0px; letter-spacing: 0.5px;"
 )
-_LINE_EDIT_STYLE = """
-QLineEdit {
-    background: #2b2d31;
+_LINE_EDIT_STYLE = f"""
+QLineEdit {{
+    background: {SURFACE_COLOR};
     color: #d6d6d6;
     border: 1px solid #3a3d42;
     border-radius: 3px;
     padding: 3px 6px;
     font-size: 11px;
-}
-QLineEdit:focus { border-color: #007ACC; }
+}}
+QLineEdit:focus {{ border-color: #007ACC; }}
 """
 
 
@@ -47,7 +49,7 @@ class WorkflowInfoWidget(QWidget):
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self.setStyleSheet("background: #23252a;")
+        self.setStyleSheet(f"background: {PANEL_COLOR};")
 
         self._config: Optional[AutoLamellaWorkflowConfig] = None
         self._options: Optional[AutoLamellaWorkflowOptions] = None

--- a/fibsem/ui/widgets/workflow_info_widget.py
+++ b/fibsem/ui/widgets/workflow_info_widget.py
@@ -17,12 +17,13 @@ from fibsem.applications.autolamella.structures import (
     AutoLamellaWorkflowOptions,
 )
 from fibsem.ui.tokens import (
+    NEUTRAL_500,
     PANEL_COLOR,
     SURFACE_COLOR,
     TEXT_COLOR,
 )
 
-_LABEL_STYLE = "color: #a0a0a0; min-width: 80px; font-size: 11px;"
+_LABEL_STYLE = f"color: {NEUTRAL_500}; min-width: 80px; font-size: 11px;"
 _SECTION_STYLE = (
     "font-size: 10px; font-weight: bold; color: #707070;"
     " padding: 4px 0px 2px 0px; letter-spacing: 0.5px;"

--- a/fibsem/ui/widgets/workflow_task_editor_widget.py
+++ b/fibsem/ui/widgets/workflow_task_editor_widget.py
@@ -22,6 +22,10 @@ import fibsem.config as fcfg
 from fibsem.applications.autolamella.structures import AutoLamellaTaskDescription
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.ui.tokens import (
+    NEUTRAL_500,
+    NEUTRAL_700,
+)
 
 _ROW_HEIGHT = 40
 # Requirements list shows up to this many rows before it starts to scroll.
@@ -107,7 +111,7 @@ class WorkflowTaskEditorWidget(QWidget):
         header_row = QHBoxLayout()
         header_row.setSpacing(8)
         icon_lbl = QLabel()
-        icon_lbl.setPixmap(fibsem_icon("mdi:pencil", color="#a0a0a0").pixmap(18, 18))
+        icon_lbl.setPixmap(fibsem_icon("mdi:pencil", color=NEUTRAL_500).pixmap(18, 18))
         icon_lbl.setStyleSheet("background: transparent;")
         header_row.addWidget(icon_lbl)
 
@@ -337,7 +341,7 @@ class WorkflowTaskEditorWidget(QWidget):
                 self._req_rows.append(row)
         else:
             empty = QLabel("No other tasks available")
-            empty.setStyleSheet("color: #606060; font-size: 11px; padding: 6px;")
+            empty.setStyleSheet(f"color: {NEUTRAL_700}; font-size: 11px; padding: 6px;")
             empty.setAlignment(Qt.AlignCenter)
             item = QListWidgetItem()
             item.setSizeHint(QSize(0, _ROW_HEIGHT))

--- a/fibsem/ui/widgets/workflow_timeline_widget.py
+++ b/fibsem/ui/widgets/workflow_timeline_widget.py
@@ -23,13 +23,17 @@ from PyQt5.QtWidgets import (
 from fibsem.constants import TIME_DISPLAY_AMPM_SHORT
 from fibsem.ui import stylesheets
 from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.tokens import (
+    NEUTRAL_500,
+    NEUTRAL_700,
+)
 
 # ── Colours ───────────────────────────────────────────────────────────────────
 _DOT_COMPLETED  = stylesheets.GREEN_COLOR
 _DOT_ACTIVE     = stylesheets.ORANGE_COLOR
-_DOT_PENDING    = "#606060"
+_DOT_PENDING    = NEUTRAL_700
 _DOT_FAILED     = stylesheets.RED_COLOR
-_DOT_SKIPPED    = "#9e9e9e"
+_DOT_SKIPPED    = NEUTRAL_500
 # Slate, not amber: the old #e0a030 was indistinguishable from the active orange,
 # so a cancelled row read as still running — especially when it was the last thing
 # to run and there was no active row beside it to compare against. Still not red:


### PR DESCRIPTION
Follow-up to #304, #308 and #310. Those consolidated colour that was *exactly* a token. This handles colour that is *nearly* one — which turned out to be two quite different problems.

Hex literals outside `tokens.py`: **522 → 352**.

## The survey

Across `fibsem/`, 81 values sat within 30 RGB units of a palette token without being it. Splitting them by chroma was the useful cut:

| | values | uses |
|---|---|---|
| tinted (same hue family as a token) | 57 | 160 |
| **pure neutral grey** (R=G=B) | 24 | 125 |

Those are not the same problem, and only the first one is drift.

## 1. Tinted drift (`b3c2f0d6`)

Twenty values within 10 RGB of a token: `#2b2d31` where `SURFACE_COLOR` is `#262930`, `#3f444b` where `BORDER_COLOR` is `#3d4251`, five separate spellings of `TEXT_MUTED_COLOR`. Nobody chose those differences.

**This changes rendered colour** — by 1.7 to 8.4 units, below the threshold of noticing but not nothing. The largest case is `#2b2d31`, which had spread across 13 files as a de-facto second surface colour and moves 6.5 units darker.

30 collapses, plus 7 exact matches in `tile_grid_options_panel` that shift nothing: that panel's QSS had to become an f-string for the one drift value in it, and finishing the exact matches in the same block was free once the braces were doubled.

## 2. The neutral ramp was never drift (`7155aab1`)

Every palette token is faintly blue — `BORDER_COLOR` is `#3d4251`, not a grey. That is right for the app's chrome and **wrong behind image data**, where a colour cast reads as part of the picture.

So the plot and canvas widgets had grown their own neutral scale: 30 pure greys over 167 uses, concentrated in `minimap_plot_widget`, `fluorescence_plot_widget` and `canvas_base`. A real design decision that was never written down — so it drifted into 30 spellings of about 12 colours, with `#e0e0e0`, `#dddddd` and `#e6e6e6` all doing the same job in different files.

Collapsing that into the tinted palette would have been the wrong call: it would give every plot panel a blue cast. So the ramp is **named instead**, `NEUTRAL_200` (lightest) through `NEUTRAL_900`.

Numbered rather than role-named, deliberately breaking the convention in the rest of `tokens.py`, because a neutral has no single role: `#909090` is an axis label in one widget and a disabled glyph in another.

The evidence it really was a scale: `minimap_plot_widget`, `fluorescence_plot_widget` and `autolamella_overview_image_widget` come out at **zero or one** remaining literal each. The ramp was essentially their whole palette.

123 of 133 conversions are the rungs themselves and shift nothing. Ten strays fold onto their nearest rung (max 8.7 RGB). Nine values with no rung within 10 units are left alone rather than forced onto one.

## How it was verified

Both commits were audited by diffing the hex census of every changed file against its committed version: every colour removed is either planned drift or an exact token match, and **no new colour was introduced anywhere**. `957 passed` for `tests/ui/` plus `tests/test_import_cycles.py`.

## Deliberately excluded

**`fm_canvas.py`.** The first pass converted 19 of its 47 colours before I looked at the diff. Its floating layers panel is a self-contained design — its own grey ladder (`#e4e6e9`, `#9aa0a6`, `#3a3f46`, `#363d46`) *and* its own accent `#5b9bd5`. Half-wiring that to the global palette is worse than leaving it: retune `SURFACE_COLOR` and the panel's combobox moves while its text does not. Reverted in full; it needs an all-or-nothing decision.

**`#37474F` in `tiled_overview_widget`** — a tile-state colour. Three widgets render tile enabled/disabled in three unrelated schemes; that wants one shared decision, not a nudge toward the nearest token.

**Values above 10 RGB from any token.** `#4a5168` (16 uses), `#e53935`, `#0066cc` are different colours, not near-misses.

## What to look at

The colour shifts are individually imperceptible, so the thing worth checking is anywhere a shifted colour sits *next to* an unshifted one. In practice: the workflow right-hand panel and lamella cards (`#2b2d31` → `SURFACE_COLOR`), and the plot widgets, where the neutral ramp is now doing the work.
