### PR TITLE
[ui] Name three stylesheets for what they do, not what first used them

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -48,9 +48,9 @@ from fibsem.applications.autolamella.workflows.tasks.tasks import get_task_super
 from fibsem.ui import FibsemMinimapWidget
 from fibsem.ui.qt.gc import install_main_thread_gc
 from fibsem.ui.stylesheets import (
-    MILLING_PROGRESS_BAR_STYLESHEET,
+    PROGRESS_BAR_STYLESHEET,
     NAPARI_STYLE,
-    STOP_WORKFLOW_BUTTON_STYLESHEET,
+    DANGER_BUTTON_STYLESHEET,
     SUPERVISION_STATUS_AUTOMATED_STYLESHEET,
     SUPERVISION_STATUS_SUPERVISED_STYLESHEET,
     USER_ATTENTION_BUTTON_STYLESHEET,
@@ -799,7 +799,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.milling_progress_bar.setValue(0)
         self.milling_progress_bar.setTextVisible(True)
         self.milling_progress_bar.setAlignment(Qt.AlignCenter)
-        self.milling_progress_bar.setStyleSheet(MILLING_PROGRESS_BAR_STYLESHEET)
+        self.milling_progress_bar.setStyleSheet(PROGRESS_BAR_STYLESHEET)
         self.milling_progress_bar.hide()  # Hidden by default
         self.status_bar.addPermanentWidget(self.milling_progress_bar)
 
@@ -838,7 +838,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         # Add stop workflow button
         self.stop_workflow_btn = QPushButton("Stop Workflow")
-        self.stop_workflow_btn.setStyleSheet(STOP_WORKFLOW_BUTTON_STYLESHEET)
+        self.stop_workflow_btn.setStyleSheet(DANGER_BUTTON_STYLESHEET)
         self.stop_workflow_btn.setIcon(
             fibsem_icon("mdi:stop-circle", color=GRAY_ICON_COLOR)
         )

--- a/fibsem/ui/FMAcquisitionWidget.py
+++ b/fibsem/ui/FMAcquisitionWidget.py
@@ -79,7 +79,7 @@ from fibsem.ui.napari.utilities import (
     NapariShapeOverlay,
 )
 from fibsem.ui.stylesheets import (
-    MILLING_PROGRESS_BAR_STYLESHEET,
+    PROGRESS_BAR_STYLESHEET,
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
 )
@@ -544,9 +544,9 @@ class FMAcquisitionWidget(QWidget):
         self.progressBar_current_acquisition = QProgressBar(self)
         self.progressBar_acquisition_task = QProgressBar(self)
         self.progressText = QLabel("Acquisition Progress", self)
-        self.progressBar_acquisition_task.setStyleSheet(MILLING_PROGRESS_BAR_STYLESHEET)
+        self.progressBar_acquisition_task.setStyleSheet(PROGRESS_BAR_STYLESHEET)
         self.progressBar_current_acquisition.setStyleSheet(
-            MILLING_PROGRESS_BAR_STYLESHEET
+            PROGRESS_BAR_STYLESHEET
         )
         self.progressBar_current_acquisition.hide()
         self.progressBar_acquisition_task.hide()

--- a/fibsem/ui/FibsemImageSettingsWidget.py
+++ b/fibsem/ui/FibsemImageSettingsWidget.py
@@ -322,7 +322,7 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         beam_type = self.dual_beam_widget.beam_type
         self.microscope.start_acquisition(beam_type)
         self.pushButton_start_acquisition.setText("Stop Acquisition")
-        self.pushButton_start_acquisition.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
+        self.pushButton_start_acquisition.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET)
 
     def update_ruler(self):
         """Initialise the ruler in the viewer"""

--- a/fibsem/ui/FibsemLabellingUI.py
+++ b/fibsem/ui/FibsemLabellingUI.py
@@ -325,7 +325,7 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         # style
         self.pushButton_load_data.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
         self.model_widget.pushButton_load_model.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
-        self.pushButton_model_confirm.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.pushButton_model_confirm.setStyleSheet(stylesheets.CONFIRM_BUTTON_STYLESHEET)
         self.pushButton_model_clear.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
 
         # tooltips

--- a/fibsem/ui/FibsemManipulatorWidget.py
+++ b/fibsem/ui/FibsemManipulatorWidget.py
@@ -191,9 +191,9 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
     def setup_connections(self):
 
         self.insertManipulator_button.clicked.connect(self.insert_retract_manipulator)
-        self.insertManipulator_button.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.insertManipulator_button.setStyleSheet(stylesheets.CONFIRM_BUTTON_STYLESHEET)
         self.addSavedPosition_button.clicked.connect(self.add_saved_position)
-        self.addSavedPosition_button.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.addSavedPosition_button.setStyleSheet(stylesheets.CONFIRM_BUTTON_STYLESHEET)
         self.goToPosition_button.clicked.connect(self.move_to_saved_position)
         self.goToPosition_button.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
         self.moveRelative_button.clicked.connect(self.move_relative)
@@ -208,7 +208,7 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
         
         self._hide_show_buttons(self.manipulator_inserted)
         self.insertManipulator_button.setText("Retract" if self.manipulator_inserted else "Insert")
-        self.insertManipulator_button.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET if self.manipulator_inserted else stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.insertManipulator_button.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET if self.manipulator_inserted else stylesheets.CONFIRM_BUTTON_STYLESHEET)
         self.manipulatorStatus_label.setText("Manipulator Status: Inserted" if self.manipulator_inserted else "Manipulator Status: Retracted")        
         
 
@@ -269,7 +269,7 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
             self.microscope.retract_manipulator()
             self.insertManipulator_button.setText("Insert")
             self.manipulatorStatus_label.setText("Manipulator Status: Retracted")
-            self.insertManipulator_button.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
+            self.insertManipulator_button.setStyleSheet(stylesheets.CONFIRM_BUTTON_STYLESHEET)
             self.update_ui()
             self._hide_show_buttons(show=False)
         
@@ -278,7 +278,7 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
             self.microscope.insert_manipulator()
             self.insertManipulator_button.setText("Retract")
             self.manipulatorStatus_label.setText("Manipulator Status: Inserted")
-            self.insertManipulator_button.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
+            self.insertManipulator_button.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET)
             self.update_ui()
             self._hide_show_buttons(show=True)
 

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -247,7 +247,7 @@ class FibsemMinimapWidget(QWidget):
         self.progressBar_acquisition = QProgressBar()
         self.progressBar_acquisition.setValue(24)
         self.progressBar_acquisition.setAlignment(Qt.AlignCenter)
-        self.progressBar_acquisition.setStyleSheet(stylesheets.MILLING_PROGRESS_BAR_STYLESHEET)
+        self.progressBar_acquisition.setStyleSheet(stylesheets.PROGRESS_BAR_STYLESHEET)
         self.gridLayout.addWidget(self.progressBar_acquisition, 4, 0)
 
         # --- Acquisition settings widget ---
@@ -441,8 +441,8 @@ class FibsemMinimapWidget(QWidget):
 
         # set styles
         self.pushButton_run_tile_collection.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
-        self.pushButton_cancel_acquisition.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
-        self.progressBar_acquisition.setStyleSheet(stylesheets.MILLING_PROGRESS_BAR_STYLESHEET)
+        self.pushButton_cancel_acquisition.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET)
+        self.progressBar_acquisition.setStyleSheet(stylesheets.PROGRESS_BAR_STYLESHEET)
         self.pushButton_enable_correlation.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         self.pushButton_load_image.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         self.pushButton_load_correlation_image.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -341,7 +341,7 @@ class FibsemSpotBurnWidget(QWidget):
         self.stop_event.clear()
         self._is_burning = True
         self.pushButton_run_spot_burn.setText("Cancel")
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
+        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET)
         self.pushButton_run_spot_burn.clicked.disconnect()
         self.pushButton_run_spot_burn.clicked.connect(self.cancel_spot_burn)
         # in workflow mode the button is hidden when idle — show it as "Cancel" while burning

--- a/fibsem/ui/fm/widgets/acquisition_summary_dialog.py
+++ b/fibsem/ui/fm/widgets/acquisition_summary_dialog.py
@@ -14,7 +14,7 @@ from fibsem.fm.structures import ChannelSettings, ZParameters, FMStagePosition
 from fibsem.fm.timing import estimate_positions_acquisition_time
 from fibsem.ui.stylesheets import (
     NEUTRAL_650,
-    RUN_WORKFLOW_BUTTON_STYLESHEET,
+    CONFIRM_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
 )
 from fibsem.utils import format_duration
@@ -99,7 +99,7 @@ class AcquisitionSummaryDialog(QDialog):
         # Buttons
         button_layout = QGridLayout()
         self.button_start = QPushButton("Start Acquisition")
-        self.button_start.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.button_start.setStyleSheet(CONFIRM_BUTTON_STYLESHEET)
         self.button_start.clicked.connect(self.accept)
         button_layout.addWidget(self.button_start, 0, 0)
 

--- a/fibsem/ui/fm/widgets/load_image_dialog.py
+++ b/fibsem/ui/fm/widgets/load_image_dialog.py
@@ -22,7 +22,7 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem.fm.structures import FluorescenceImage
-from fibsem.ui.stylesheets import RUN_WORKFLOW_BUTTON_STYLESHEET, SECONDARY_BUTTON_STYLESHEET
+from fibsem.ui.stylesheets import CONFIRM_BUTTON_STYLESHEET, SECONDARY_BUTTON_STYLESHEET
 from fibsem.ui.tokens import (
     NEUTRAL_650,
 )
@@ -87,7 +87,7 @@ class LoadImageDialog(QDialog):
         button_layout = QHBoxLayout()
 
         self.load_button = QPushButton("Load Images")
-        self.load_button.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.load_button.setStyleSheet(CONFIRM_BUTTON_STYLESHEET)
         self.load_button.clicked.connect(self.load_images)
         self.load_button.setEnabled(False)
         button_layout.addWidget(self.load_button)

--- a/fibsem/ui/fm/widgets/overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/overview_confirmation_dialog.py
@@ -14,7 +14,7 @@ from fibsem.fm.structures import ChannelSettings, ZParameters, OverviewParameter
 from fibsem.fm.timing import estimate_tileset_acquisition_time
 from fibsem.ui.stylesheets import (
     NEUTRAL_650,
-    RUN_WORKFLOW_BUTTON_STYLESHEET,
+    CONFIRM_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
 )
 from fibsem.utils import format_duration
@@ -90,7 +90,7 @@ class OverviewConfirmationDialog(QDialog):
         # Buttons
         button_layout = QGridLayout()
         self.button_start = QPushButton("Start Acquisition")
-        self.button_start.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.button_start.setStyleSheet(CONFIRM_BUTTON_STYLESHEET)
         self.button_start.clicked.connect(self.accept)
         button_layout.addWidget(self.button_start, 0, 0)
 

--- a/fibsem/ui/fm/widgets/saved_positions_widget.py
+++ b/fibsem/ui/fm/widgets/saved_positions_widget.py
@@ -17,8 +17,8 @@ from fibsem.fm.structures import FMStagePosition
 from fibsem.ui.stylesheets import (
     NEUTRAL_650,
     PRIMARY_BUTTON_STYLESHEET,
-    RUN_WORKFLOW_BUTTON_STYLESHEET,
-    STOP_WORKFLOW_BUTTON_STYLESHEET,
+    CONFIRM_BUTTON_STYLESHEET,
+    DANGER_BUTTON_STYLESHEET,
 )
 from fibsem.ui.utils import message_box_ui
 from fibsem.applications.autolamella.structures import Lamella
@@ -101,8 +101,8 @@ class SavedPositionsWidget(QWidget):
 
         # Set button styles
         self.pushButton_goto_position.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
-        self.pushButton_delete_position.setStyleSheet(STOP_WORKFLOW_BUTTON_STYLESHEET)
-        self.pushButton_set_objective.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.pushButton_delete_position.setStyleSheet(DANGER_BUTTON_STYLESHEET)
+        self.pushButton_set_objective.setStyleSheet(CONFIRM_BUTTON_STYLESHEET)
 
     def update_positions(self, positions: List[Lamella]):
         """Update the combobox and checkbox list with current saved positions."""

--- a/fibsem/ui/fm/widgets/sem_acquisition_widget.py
+++ b/fibsem/ui/fm/widgets/sem_acquisition_widget.py
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import QWidget, QGridLayout, QLabel, QDoubleSpinBox, QPushB
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import ImageSettings, BeamType
 from fibsem.config import SQUARE_RESOLUTIONS_LIST
-from fibsem.ui.stylesheets import RUN_WORKFLOW_BUTTON_STYLESHEET
+from fibsem.ui.stylesheets import CONFIRM_BUTTON_STYLESHEET
 from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
     ValueSpinBox,
@@ -60,7 +60,7 @@ class SEMAcquisitionWidget(QWidget):
 
         # Image acquisition controls
         self.button_acquire_image = QPushButton("Acquire Image")
-        self.button_acquire_image.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.button_acquire_image.setStyleSheet(CONFIRM_BUTTON_STYLESHEET)
         self.button_acquire_image.clicked.connect(self.acquire_image)
 
         layout.addWidget(self.fov_label, 0, 0)

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -58,33 +58,10 @@ from fibsem.ui.tokens import (
 
 _ICONS_DIR = _os.path.join(_os.path.dirname(__file__), "icons").replace("\\", "/")
 
-# TODO: no token -- #68a0dd, #3a6ea5
-#
-# #3a6ea5 is the one left literal on purpose rather than for want of a token:
-# PRIMARY_ACCENT holds that exact value, but it is documented as the quad-view
-# selection border, and pointing a checkbox at it would silently restyle this
-# widget the next time the canvas is retuned. Needs a decision, not a
-# substitution.
-CHECKBOX_STYLE = """
-QCheckBox::indicator {
-        width: 16px;"
-        height: 16px;
-        border: 1px solid rgba(220, 220, 220, 0.7);
-        border-radius: 3px;
-        background-color: rgba(255, 255, 255, 0.05);
-        }
-QCheckBox::indicator:hover {
-        border: 1px solid rgba(120, 180, 255, 0.9);
-}
-QCheckBox::indicator:checked {
-        background-color: #3a6ea5;
-        border: 1px solid #68a0dd;
-}"""
-
 LABEL_INSTRUCTIONS_STYLE = """font-style: italic; color: gray; font-size: 12px;"""
 
 
-MILLING_PROGRESS_BAR_STYLESHEET = f"""
+PROGRESS_BAR_STYLESHEET = f"""
             QProgressBar {{
                 border: 1px solid {BORDER_COLOR};
                 border-radius: 3px;
@@ -132,7 +109,7 @@ USER_ATTENTION_BUTTON_STYLESHEET = f"""
         """
 
 # TODO: no token -- #2e7d32, #388e3c
-RUN_WORKFLOW_BUTTON_STYLESHEET = f"""
+CONFIRM_BUTTON_STYLESHEET = f"""
             QPushButton {{
                 background-color: {OK_COLOR};
                 color: white;
@@ -157,7 +134,7 @@ RUN_WORKFLOW_BUTTON_STYLESHEET = f"""
 # The :disabled rule matches the primary/secondary/run sheets. Without it a
 # disabled stop or delete button stays full crimson and only stops responding,
 # which is what drove call sites to paint their own grey "off" state by hand.
-STOP_WORKFLOW_BUTTON_STYLESHEET = f"""
+DANGER_BUTTON_STYLESHEET = f"""
             QPushButton {{
                 background-color: {SEMANTIC_ERROR_COLOR};
                 color: white;
@@ -430,3 +407,17 @@ QDateTimeEdit::down-arrow {{
     height: 10px;
 }}
 """.replace("__ICONS_DIR__", _ICONS_DIR)
+
+# ---------------------------------------------------------------------------
+# Deprecated aliases.
+#
+# These three were named for the first thing that used them, and then used for
+# everything else. Only one of the progress bar's four consumers was milling;
+# the "run workflow" green ended up on Load Images, Set Objective and Acquire;
+# the "stop workflow" red ended up on Delete Position and Retract Manipulator.
+#
+# Kept so an out-of-tree plugin importing the old name still works. Prefer the
+# names above in new code.
+MILLING_PROGRESS_BAR_STYLESHEET = PROGRESS_BAR_STYLESHEET
+RUN_WORKFLOW_BUTTON_STYLESHEET = CONFIRM_BUTTON_STYLESHEET
+STOP_WORKFLOW_BUTTON_STYLESHEET = DANGER_BUTTON_STYLESHEET

--- a/fibsem/ui/widgets/autolamella_generate_report_widget.py
+++ b/fibsem/ui/widgets/autolamella_generate_report_widget.py
@@ -11,7 +11,7 @@ from fibsem.applications.autolamella.structures import Experiment
 from fibsem.applications.autolamella.tools.reporting import generate_report2
 from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
-    RUN_WORKFLOW_BUTTON_STYLESHEET,
+    CONFIRM_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
 )
 
@@ -166,7 +166,7 @@ class AutoLamellaGenerateReportWidget(QtWidgets.QDialog):
         button_box = QtWidgets.QDialogButtonBox()
 
         self.btn_generate = QtWidgets.QPushButton("Generate Report")
-        self.btn_generate.setStyleSheet(RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.btn_generate.setStyleSheet(CONFIRM_BUTTON_STYLESHEET)
         self.btn_generate.setDefault(True)
         self.btn_generate.setEnabled(False)  # Disabled until an experiment is attached
 

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -1081,7 +1081,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
 
         self.progressBar_stages = QProgressBar()
         self.progressBar_stages.setStyleSheet(
-            stylesheets.MILLING_PROGRESS_BAR_STYLESHEET
+            stylesheets.PROGRESS_BAR_STYLESHEET
         )
         self.progressBar_stages.setFixedHeight(24)
         self.progressBar_stages.setFixedWidth(180)
@@ -1089,7 +1089,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
 
         self.progressBar_stage = QProgressBar()
         self.progressBar_stage.setStyleSheet(
-            stylesheets.MILLING_PROGRESS_BAR_STYLESHEET
+            stylesheets.PROGRESS_BAR_STYLESHEET
         )
         self.progressBar_stage.setFixedHeight(24)
         self.progressBar_stage.setFixedWidth(180)
@@ -1099,7 +1099,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         self.btn_milling.setIcon(
             fibsem_icon("mdi:play-circle", color=stylesheets.GRAY_ICON_COLOR)
         )
-        self.btn_milling.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.btn_milling.setStyleSheet(stylesheets.CONFIRM_BUTTON_STYLESHEET)
 
         # single pause control: tool button with milling/acquisition menu options
         self._milling_paused = False
@@ -1882,7 +1882,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             fm.start_acquisition(channel_settings=selected_channel_settings)
             self.btn_toggle_fm_acquisition.setText("Stop Acquisition")
             self.btn_toggle_fm_acquisition.setStyleSheet(
-                stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET
+                stylesheets.DANGER_BUTTON_STYLESHEET
             )
 
     def _on_pause_milling_action(self):
@@ -2053,7 +2053,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             self.btn_milling.setIcon(
                 fibsem_icon("mdi:stop-circle", color=stylesheets.GRAY_ICON_COLOR)
             )
-            self.btn_milling.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
+            self.btn_milling.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET)
             # reveal the run-time controls (hidden until milling starts)
             self.btn_pause.setVisible(True)
             self.btn_supervised.setVisible(True)
@@ -2100,7 +2100,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         self.btn_milling.setIcon(
             fibsem_icon("mdi:play-circle", color=stylesheets.GRAY_ICON_COLOR)
         )
-        self.btn_milling.setStyleSheet(stylesheets.RUN_WORKFLOW_BUTTON_STYLESHEET)
+        self.btn_milling.setStyleSheet(stylesheets.CONFIRM_BUTTON_STYLESHEET)
         # hide the run-time-only controls again
         self.btn_pause.setVisible(False)
         self.btn_supervised.setVisible(False)

--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -51,7 +51,7 @@ class FibsemMillingWidget2(QWidget):
         self.pushButton_stop_milling = QPushButton("Stop Milling")
         self.pushButton_stop_milling.clicked.connect(self.stop_milling)
         self.pushButton_stop_milling.setStyleSheet(
-            stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET
+            stylesheets.DANGER_BUTTON_STYLESHEET
         )
         self.pushButton_stop_milling.setVisible(False)
 
@@ -67,10 +67,10 @@ class FibsemMillingWidget2(QWidget):
         self.progressBar_milling.setVisible(False)
         self.progressBar_milling_stages.setVisible(False)
         self.progressBar_milling_stages.setStyleSheet(
-            stylesheets.MILLING_PROGRESS_BAR_STYLESHEET
+            stylesheets.PROGRESS_BAR_STYLESHEET
         )
         self.progressBar_milling.setStyleSheet(
-            stylesheets.MILLING_PROGRESS_BAR_STYLESHEET
+            stylesheets.PROGRESS_BAR_STYLESHEET
         )
 
         self.start_milling_signal.connect(self.run_milling, Qt.BlockingQueuedConnection)  # type: ignore

--- a/fibsem/ui/widgets/progress_widget.py
+++ b/fibsem/ui/widgets/progress_widget.py
@@ -154,7 +154,7 @@ class FibsemProgressWidget(QWidget):
         self._bar = QProgressBar()
         self._bar.setTextVisible(True)
         self._failed_style = False
-        self._bar.setStyleSheet(stylesheets.MILLING_PROGRESS_BAR_STYLESHEET)
+        self._bar.setStyleSheet(stylesheets.PROGRESS_BAR_STYLESHEET)
         layout.addWidget(self._bar)
 
     def _set_failed_style(self, failed: bool) -> None:
@@ -169,7 +169,7 @@ class FibsemProgressWidget(QWidget):
         self._bar.setStyleSheet(
             stylesheets.FAILED_PROGRESS_BAR_STYLESHEET
             if failed
-            else stylesheets.MILLING_PROGRESS_BAR_STYLESHEET
+            else stylesheets.PROGRESS_BAR_STYLESHEET
         )
 
     # ------------------------------------------------------------------

--- a/fibsem/ui/widgets/script_manager_dialog.py
+++ b/fibsem/ui/widgets/script_manager_dialog.py
@@ -45,7 +45,7 @@ from fibsem.ui.stylesheets import (
     PANEL_COLOR,
     PRIMARY_BUTTON_STYLESHEET,
     ROW_ALT_COLOR,
-    STOP_WORKFLOW_BUTTON_STYLESHEET,
+    DANGER_BUTTON_STYLESHEET,
     SURFACE_COLOR,
     TEXT_COLOR,
     TEXT_MUTED_COLOR,
@@ -618,7 +618,7 @@ class ScriptManagerDialog(QDialog):
         running = self.runner.is_running
         self.run_button.setText("Stop script" if running else "Run script")
         self.run_button.setStyleSheet(
-            STOP_WORKFLOW_BUTTON_STYLESHEET if running else PRIMARY_BUTTON_STYLESHEET
+            DANGER_BUTTON_STYLESHEET if running else PRIMARY_BUTTON_STYLESHEET
         )
         if running:
             self.run_button.setEnabled(True)  # Stop must never be the disabled one

--- a/fibsem/ui/widgets/tests/test_workflow_timeline_animation.py
+++ b/fibsem/ui/widgets/tests/test_workflow_timeline_animation.py
@@ -99,7 +99,7 @@ class AnimatedDemo(QWidget):
 
         self._btn_stop = QPushButton("Stop")
         self._btn_stop.setFixedHeight(24)
-        self._btn_stop.setStyleSheet(stylesheets.STOP_WORKFLOW_BUTTON_STYLESHEET)
+        self._btn_stop.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET)
         top_layout.addWidget(self._btn_stop)
 
         layout.addWidget(top_bar)

--- a/tests/ui/test_progress_widget_states.py
+++ b/tests/ui/test_progress_widget_states.py
@@ -100,6 +100,6 @@ def test_reset_if_finished_resets_after_a_failure(widget):
 
 def test_failed_stylesheet_is_the_bar_with_an_error_chunk():
     """The failed sheet should differ from the normal one only in chunk colour."""
-    normal = stylesheets.MILLING_PROGRESS_BAR_STYLESHEET
+    normal = stylesheets.PROGRESS_BAR_STYLESHEET
     failed = stylesheets.FAILED_PROGRESS_BAR_STYLESHEET
     assert failed.replace(RED, GREEN) == normal


### PR DESCRIPTION
Small follow-up to the palette work. Renames only — verified against `main` that all 61 constants render identical values, with one deliberate deletion.

## Named for their first consumer, then used for everything else

| old | new | why |
|---|---|---|
| `MILLING_PROGRESS_BAR_STYLESHEET` | `PROGRESS_BAR_STYLESHEET` | one of its four consumers is milling; the rest are FM acquisition, the minimap and the coincidence viewer |
| `RUN_WORKFLOW_BUTTON_STYLESHEET` | `CONFIRM_BUTTON_STYLESHEET` | it is on Load Images, Set Objective, Acquire Image and Generate Report as much as on Run Workflow |
| `STOP_WORKFLOW_BUTTON_STYLESHEET` | `DANGER_BUTTON_STYLESHEET` | also Delete Position, Retract Manipulator, Cancel Acquisition — and the *running* state of the spot-burn and acquisition toggles |

Old names kept as aliases, so an out-of-tree plugin importing one still works.

## `CHECKBOX_STYLE` deleted

Zero callers. Two widgets define their own local checkbox styling, so the shared one was not what anyone reached for.

Its removal also settles a question left open in #304: `#3a6ea5` was left a literal there because `PRIMARY_ACCENT` holds that exact value but *means* the quad-view selection border, and coupling a checkbox to canvas chrome would have restyled it invisibly the next time the canvas was retuned. The only consumer is now gone, so the coupling can no longer happen.

## Two things deliberately left

**`LABEL_INSTRUCTIONS_STYLE` keeps its `_STYLE` suffix.** It is a bare property fragment with no selectors, unlike the `_STYLESHEET` constants which are full QSS blocks. With `CHECKBOX_STYLE` gone that distinction is consistent rather than accidental, so renaming it would make the naming *worse*.

**`SUPERVISION_STATUS_AUTOMATED/SUPERVISED` stay.** They look like near-duplicates of the confirm and primary sheets, but differ in font weight and in their hover/pressed shades, and that difference is intended.

## Testing

`1253 passed, 15 skipped` — `tests/ui/`, `tests/correlation/`, `tests/test_import_cycles.py`.

Verified by snapshotting every public string constant on `main` and on this branch: 61 → 63 (three new names, three old kept as aliases, one deletion) with **no value differences**.