### PR TITLE
[ui] Interpolate the exact-match colours inside braced QSS blocks

### DIFF
--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -18,7 +18,9 @@ from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
 )
 from fibsem.ui.tokens import (
+    BORDER_COLOR,
     NEUTRAL_500,
+    PANEL_COLOR,
     WHITE_ICON_COLOR,
 )
 
@@ -67,12 +69,12 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
     def _create_connection_status_card(self) -> QtWidgets.QFrame:
         frame = QtWidgets.QFrame()
         frame.setObjectName("frame_connection_status")
-        frame.setStyleSheet("""
-            QFrame#frame_connection_status {
-                background-color: #1e2027;
+        frame.setStyleSheet(f"""
+            QFrame#frame_connection_status {{
+                background-color: {PANEL_COLOR};
                 border-radius: 6px;
-                border: 1px solid #3d4251;
-            }
+                border: 1px solid {BORDER_COLOR};
+            }}
         """)
 
         layout = QtWidgets.QHBoxLayout(frame)
@@ -107,7 +109,7 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
             QPushButton {{
                 background-color: transparent;
                 color: {NEUTRAL_500};
-                border: 1px solid #3d4251;
+                border: 1px solid {BORDER_COLOR};
                 border-radius: 3px;
                 padding: 3px 8px;
                 font-size: 10px;

--- a/fibsem/ui/correlation/widgets/correlation_result_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_result_widget.py
@@ -37,8 +37,11 @@ from fibsem.correlation.structures import (
 )
 from fibsem.ui.correlation.widgets.image_point_canvas import ImagePointCanvas
 from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.ui.tokens import (
+    NEUTRAL_200,
+)
 
-_VALUE_STYLE = "color: #e0e0e0; font-size: 12px;"
+_VALUE_STYLE = f"color: {NEUTRAL_200}; font-size: 12px;"
 
 
 def _value_label(text: str = "—") -> QLabel:

--- a/fibsem/ui/correlation/widgets/fm_image_display_widget.py
+++ b/fibsem/ui/correlation/widgets/fm_image_display_widget.py
@@ -45,6 +45,10 @@ from fibsem.ui.widgets.custom_widgets import IconToolButton
 from fibsem.correlation.structures import Coordinate, PointType
 from fibsem.ui.correlation.widgets.image_point_canvas import ImagePointCanvas
 from fibsem.fm.structures import FluorescenceImage
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+    NEUTRAL_300,
+)
 
 # Fallback palette when channel metadata has no color field
 _DEFAULT_COLORS = ["cyan", "magenta", "yellow", "green", "red", "blue", "gray"]
@@ -59,7 +63,7 @@ _CH_INIT_HEIGHT = _CH_MIN_HEIGHT + 48  # a bit taller by default; user-resizable
 
 # Compact step buttons flanking the Z slider
 _Z_BTN_STYLE = (
-    "QToolButton { color: #d0d0d0; background: #2b2d31; border: 1px solid #3a3d42; "
+    f"QToolButton {{ color: {NEUTRAL_300}; background: #2b2d31; border: 1px solid #3a3d42; "
     "border-radius: 3px; font-size: 13px; }"
     "QToolButton:hover { background: #3a3d42; }"
     "QToolButton:disabled { color: #5a5d62; }"
@@ -67,8 +71,8 @@ _Z_BTN_STYLE = (
 
 # Filename header shown above the FM (and FIB) image canvas
 IMAGE_HEADER_STYLE = (
-    "color: #d0d0d0; font-size: 11px; padding: 3px 8px; "
-    "background: #1e2124; border-bottom: 1px solid #3a3d42;"
+    f"color: {NEUTRAL_300}; font-size: 11px; padding: 3px 8px; "
+    f"background: {CANVAS_BG}; border-bottom: 1px solid #3a3d42;"
 )
 
 
@@ -179,7 +183,7 @@ class _ChannelRow(QWidget):
 
         # Channel name
         lbl = QLabel(name)
-        lbl.setStyleSheet("color: #d0d0d0; font-size: 11px;")
+        lbl.setStyleSheet(f"color: {NEUTRAL_300}; font-size: 11px;")
         lbl.setFixedWidth(_CH_NAME_WIDTH)
         lbl.setToolTip(name)
         lbl.setTextFormat(Qt.TextFormat.PlainText)
@@ -302,13 +306,13 @@ class FMImageDisplayWidget(QWidget):
         # Z / MIP row
         self._z_row = QWidget()
         self._z_row.setFixedHeight(_CTRL_HEIGHT)
-        self._z_row.setStyleSheet("background: #1e2124;")
+        self._z_row.setStyleSheet(f"background: {CANVAS_BG};")
         z_layout = QHBoxLayout(self._z_row)
         z_layout.setContentsMargins(8, 0, 8, 0)
         z_layout.setSpacing(8)
 
         self._mip_check = QCheckBox("Max Projection")
-        self._mip_check.setStyleSheet("color: #d0d0d0; font-size: 11px;")
+        self._mip_check.setStyleSheet(f"color: {NEUTRAL_300}; font-size: 11px;")
         z_layout.addWidget(self._mip_check)
 
         z_layout.addWidget(_sep_label())
@@ -354,10 +358,10 @@ class FMImageDisplayWidget(QWidget):
         self._ch_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self._ch_scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self._ch_scroll.setMinimumHeight(_CH_MIN_HEIGHT)  # ≥ 3 channel rows + margin
-        self._ch_scroll.setStyleSheet("background: #1e2124; border: none;")
+        self._ch_scroll.setStyleSheet(f"background: {CANVAS_BG}; border: none;")
 
         self._ch_container = QWidget()
-        self._ch_container.setStyleSheet("background: #1e2124;")
+        self._ch_container.setStyleSheet(f"background: {CANVAS_BG};")
         self._ch_layout = QVBoxLayout(self._ch_container)
         self._ch_layout.setContentsMargins(4, 2, 4, 2)
         self._ch_layout.setSpacing(2)

--- a/fibsem/ui/correlation/widgets/image_point_canvas.py
+++ b/fibsem/ui/correlation/widgets/image_point_canvas.py
@@ -55,13 +55,20 @@ from PyQt5.QtWidgets import (
 
 from fibsem.correlation.structures import Coordinate, PointType
 from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.tokens import (
+    CANVAS_BG,
+    GRAY_TEXT_COLOR,
+    NEUTRAL_200,
+    NEUTRAL_450,
+    ORANGE_COLOR,
+)
 _logger = logging.getLogger(__name__)
 
 _POINT_COLORS: Dict[PointType, str] = {
     PointType.FIB:        "#00ff00",
     PointType.FM:         "#00e5ff",
     PointType.POI:        "#ff00ff",
-    PointType.SURFACE:    "#ff9800",
+    PointType.SURFACE:    f"{ORANGE_COLOR}",
     PointType.SURFACE_FM: "#ffea00",
 }
 _POINT_MARKERS: Dict[PointType, str] = {
@@ -150,9 +157,9 @@ _LEGEND_KWARGS = dict(
     loc="upper left",
     fontsize=8,
     framealpha=0.75,
-    facecolor="#1e2124",
+    facecolor=f"{CANVAS_BG}",
     edgecolor="#3a3d42",
-    labelcolor="#e0e0e0",
+    labelcolor=f"{NEUTRAL_200}",
     handletextpad=0.4,
     borderpad=0.5,
     labelspacing=0.35,
@@ -215,7 +222,7 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         parent: Optional[QWidget] = None,
         allowed_point_types: Optional[List[PointType]] = None,
     ) -> None:
-        self._fig = Figure(facecolor="#1e2124")
+        self._fig = Figure(facecolor=f"{CANVAS_BG}")
         super().__init__(self._fig)
         self.setParent(parent)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
@@ -223,7 +230,7 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         self._allowed_types = allowed_point_types
 
         self._ax = self._fig.add_subplot(111)
-        self._ax.set_facecolor("#1e2124")
+        self._ax.set_facecolor(f"{CANVAS_BG}")
         self._ax.axis("off")
         self._fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
 
@@ -415,7 +422,7 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         ``callback`` (checkable buttons receive the new checked state).
         """
         btn = QPushButton(self)
-        btn.setIcon(fibsem_icon(icon_name, color="#aaaaaa"))
+        btn.setIcon(fibsem_icon(icon_name, color=f"{NEUTRAL_450}"))
         btn.setIconSize(_OVERLAY_ICON_SIZE)
         btn.setFixedSize(_OVERLAY_BTN_SIZE, _OVERLAY_BTN_SIZE)
         btn.setToolTip(tooltip)
@@ -994,7 +1001,7 @@ class ImagePointCanvas(FigureCanvasQTAgg):
     def _show_add_menu(self, x: float, y: float) -> None:
         menu = QMenu(self)
         menu.setStyleSheet(
-            "QMenu { background: #2b2d31; color: #F0F1F2; border: 1px solid #3a3d42; }"
+            f"QMenu {{ background: #2b2d31; color: {GRAY_TEXT_COLOR}; border: 1px solid #3a3d42; }}"
             "QMenu::item:selected { background: #2d3f5c; }"
         )
         for pt in (self._allowed_types or list(PointType)):

--- a/fibsem/ui/correlation/widgets/refractive_index_widget.py
+++ b/fibsem/ui/correlation/widgets/refractive_index_widget.py
@@ -22,6 +22,9 @@ from PyQt5.QtWidgets import (
 
 from fibsem.correlation.refractive_index import ZetaParams, _LUT_PATH, _ensure_lut, lookup_zeta
 from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel, ValueSpinBox
+from fibsem.ui.tokens import (
+    NEUTRAL_500,
+)
 
 _LUT_MISSING_MSG = (
     f"Correction factor calculator unavailable: LUT file not found at\n{_LUT_PATH}\n"
@@ -43,7 +46,7 @@ _DEFAULT_FACTOR = 1.47
 # string labels default to the app font, which renders larger than the values
 # beside them — the field name ends up shouting over its own data.
 _CONTROL_STYLE = "font-size: 12px;"
-_FORM_LABEL_STYLE = "color: #a0a0a0; font-size: 11px;"
+_FORM_LABEL_STYLE = f"color: {NEUTRAL_500}; font-size: 11px;"
 
 
 def _form_label(text: str) -> QLabel:

--- a/fibsem/ui/fm/widgets/channel_list_widget.py
+++ b/fibsem/ui/fm/widgets/channel_list_widget.py
@@ -37,6 +37,7 @@ from fibsem.fm.structures import ChannelSettings
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueComboBox, ValueSpinBox
 from fibsem.ui.tokens import (
+    BORDER_COLOR,
     CANVAS_BG,
     NEUTRAL_700,
     ORANGE_COLOR,
@@ -64,7 +65,7 @@ _FRAC_TO_PCT = 1e2
 
 _NAME_EDIT_STYLE = (
     "QLineEdit { background: transparent; border: none; }"
-    "QLineEdit:focus { background: #1e2124; border: 1px solid #555; border-radius: 2px; }"
+    f"QLineEdit:focus {{ background: {CANVAS_BG}; border: 1px solid #555; border-radius: 2px; }}"
 )
 
 AVAILABLE_COLORS = ["violet", "blue", "cyan", "green", "yellow", "red", "gray"]
@@ -443,7 +444,7 @@ class ChannelRowWidget(QWidget):
 # labels must stay transparent so the row's hover background shows through.
 _MENU_ROW_STYLE = (
     "#menuRow { background: transparent; }"
-    "#menuRow:hover { background: #3d4251; }"
+    f"#menuRow:hover {{ background: {BORDER_COLOR}; }}"
     "#menuRow QLabel { background: transparent; }"
 )
 

--- a/fibsem/ui/fm/widgets/line_plot_widget.py
+++ b/fibsem/ui/fm/widgets/line_plot_widget.py
@@ -18,6 +18,7 @@ from PyQt5.QtWidgets import (
 )
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.tokens import (
+    GRAY_WHITE_COLOR,
     NEUTRAL_400,
     NEUTRAL_450,
     ORANGE_COLOR,
@@ -29,7 +30,7 @@ _OVERLAY_BTN_STYLE = (
     " border-radius: 3px; padding: 0px; }"
     "QPushButton:hover { background: rgba(74,74,74,200); }"
     "QPushButton:pressed { background: rgba(30,30,30,220); }"
-    "QPushButton:checked { background: rgba(90,92,100,200); border-color: #FFFFFF; }"
+    f"QPushButton:checked {{ background: rgba(90,92,100,200); border-color: {GRAY_WHITE_COLOR}; }}"
 )
 _OVERLAY_ICON_SIZE = QSize(14, 14)
 _OVERLAY_BTN_SIZE = 22

--- a/fibsem/ui/widgets/autolamella_experiment_task_summary_widget.py
+++ b/fibsem/ui/widgets/autolamella_experiment_task_summary_widget.py
@@ -135,11 +135,11 @@ class ExperimentTaskSummaryWidget(QWidget):
         self.scroll_area.setWidgetResizable(False)  # Don't resize widget to fit scroll area
         self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        self.scroll_area.setStyleSheet("""
-            QScrollArea {
-                background-color: #262930;
+        self.scroll_area.setStyleSheet(f"""
+            QScrollArea {{
+                background-color: {SURFACE_COLOR};
                 border: none;
-            }
+            }}
         """)
 
         self.summary_mode_label = QLabel("Summary:")

--- a/fibsem/ui/widgets/autolamella_load_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_load_experiment_widget.py
@@ -22,7 +22,9 @@ from fibsem.config import (
 )
 from fibsem.ui import utils as fui
 from fibsem.ui.stylesheets import (
+    BORDER_COLOR,
     DISABLED_TEXT_COLOR,
+    PANEL_COLOR,
     PRIMARY_BUTTON_STYLESHEET,
     PRIMARY_COLOR_PRESSED,
     ROW_ALT_COLOR,
@@ -115,8 +117,8 @@ class _ElidedLabel(QtWidgets.QLabel):
 
 RECENT_LIST_STYLESHEET = f"""
 QListWidget {{
-    background-color: #1e2027;
-    border: 1px solid #3d4251;
+    background-color: {PANEL_COLOR};
+    border: 1px solid {BORDER_COLOR};
     border-radius: 4px;
     outline: none;
     padding: 2px;

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -46,6 +46,7 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.stylesheets import CANVAS_BG as _BG, PRIMARY_ACCENT as _ACCENT
 from fibsem.ui.widgets.canvas.contrast_gamma_control import ContrastGammaControl
 from fibsem.ui.tokens import (
+    GRAY_WHITE_COLOR,
     NEUTRAL_400,
     NEUTRAL_450,
     NEUTRAL_900,
@@ -118,7 +119,7 @@ _OVERLAY_BTN_STYLE = (
     " border-radius: 3px; padding: 0px; }"
     "QPushButton:hover { background: rgba(74,74,74,200); }"
     "QPushButton:pressed { background: rgba(30,30,30,220); }"
-    "QPushButton:checked { background: rgba(90,92,100,200); border-color: #FFFFFF; }"
+    f"QPushButton:checked {{ background: rgba(90,92,100,200); border-color: {GRAY_WHITE_COLOR}; }}"
 )
 _OVERLAY_ICON_SIZE = QSize(14, 14)
 _OVERLAY_BTN_SIZE = 22

--- a/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/ui/widgets/fluorescence_coincidence_viewer_widget.py
@@ -77,6 +77,17 @@ from fibsem.ui.widgets.coincidence_milling_confirmation_dialog import (
 from fibsem.ui.widgets.selected_lamella_widget import SelectedLamellaWidget
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 from fibsem.ui.widgets.canvas.overlays import RectOverlay, ScanDirectionArrowOverlay
+from fibsem.ui.tokens import (
+    BORDER_COLOR,
+    DISABLED_BG_COLOR,
+    DISABLED_TEXT_COLOR,
+    OK_COLOR,
+    ORANGE_COLOR,
+    PRIMARY_COLOR,
+    SEMANTIC_ERROR_COLOR,
+    SURFACE_COLOR,
+    TEXT_COLOR,
+)
 
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.structures import Experiment, Lamella
@@ -91,13 +102,13 @@ _HEADER_BG = CANVAS_BG
 # name used for the coincidence entry in the lamella review panel / task history
 COINCIDENCE_REVIEW_TASK_NAME = "Coincidence Milling"
 
-COINCIDENCE_BORDER_STYLESHEET = """
-    QFrame#coincidence_border_frame[borderState="idle"]       { border: 4px solid #262930; }
-    QFrame#coincidence_border_frame[borderState="automated"]  { border: 4px solid #4caf50; }
-    QFrame#coincidence_border_frame[borderState="supervised"] { border: 4px solid #007ACC; }
-    QFrame#coincidence_border_frame[borderState="waiting"]    { border: 4px solid #ff9800; }
-    QFrame#coincidence_border_frame[borderState="finished"]   { border: 4px solid #4caf50; }
-    QFrame#coincidence_border_frame[borderState="stopped"]    { border: 4px solid #99121F; }
+COINCIDENCE_BORDER_STYLESHEET = f"""
+    QFrame#coincidence_border_frame[borderState="idle"]       {{ border: 4px solid {SURFACE_COLOR}; }}
+    QFrame#coincidence_border_frame[borderState="automated"]  {{ border: 4px solid {OK_COLOR}; }}
+    QFrame#coincidence_border_frame[borderState="supervised"] {{ border: 4px solid {PRIMARY_COLOR}; }}
+    QFrame#coincidence_border_frame[borderState="waiting"]    {{ border: 4px solid {ORANGE_COLOR}; }}
+    QFrame#coincidence_border_frame[borderState="finished"]   {{ border: 4px solid {OK_COLOR}; }}
+    QFrame#coincidence_border_frame[borderState="stopped"]    {{ border: 4px solid {SEMANTIC_ERROR_COLOR}; }}
 """
 
 
@@ -1111,10 +1122,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         # SECONDARY_BUTTON_STYLESHEET targets QPushButton; a QToolButton needs its
         # own selector or it falls back to the unstyled default (mismatched size/font)
         self.btn_pause.setStyleSheet(
-            "QToolButton { background-color: #3d4251; color: #d6d6d6; border: none;"
+            f"QToolButton {{ background-color: {BORDER_COLOR}; color: {TEXT_COLOR}; border: none;"
             " padding: 5px 12px; border-radius: 3px; }"
             "QToolButton:hover { background-color: #4a5168; }"
-            "QToolButton:disabled { background-color: #2d313b; color: #6b6b6b; }"
+            f"QToolButton:disabled {{ background-color: {DISABLED_BG_COLOR}; color: {DISABLED_TEXT_COLOR}; }}"
             "QToolButton::menu-indicator { image: none; }"
         )
         pause_menu = QMenu(self.btn_pause)

--- a/fibsem/ui/widgets/hook_config_widget.py
+++ b/fibsem/ui/widgets/hook_config_widget.py
@@ -41,6 +41,8 @@ from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel
 from fibsem.ui.tokens import (
     ACCENT_COLOR,
+    BORDER_COLOR,
+    CANVAS_BG,
     TEXT_COLOR,
 )
 
@@ -373,9 +375,9 @@ class HookConfigWidget(QWidget):
         # List
         self._list = QListWidget()
         self._list.setSpacing(2)
-        self._list.setStyleSheet("QListWidget { background: #1e2124; border: none; }"
+        self._list.setStyleSheet(f"QListWidget {{ background: {CANVAS_BG}; border: none; }}"
                                   "QListWidget::item { border-radius: 3px; }"
-                                  "QListWidget::item:selected { background: #3d4251; }")
+                                  f"QListWidget::item:selected {{ background: {BORDER_COLOR}; }}")
 
         content = QWidget()
         content_layout = QVBoxLayout(content)

--- a/fibsem/ui/widgets/lamella_card_widget.py
+++ b/fibsem/ui/widgets/lamella_card_widget.py
@@ -25,6 +25,7 @@ from fibsem.ui.tokens import (
     NEUTRAL_200,
     NEUTRAL_550,
     NEUTRAL_900,
+    PRIMARY_COLOR,
     SURFACE_COLOR,
 )
 
@@ -44,7 +45,7 @@ QFrame#LamellaCard {{
 _CARD_SELECTED_STYLE = f"""
 QFrame#LamellaCard {{
     background: {SURFACE_COLOR};
-    border: 2px solid #007ACC;
+    border: 2px solid {PRIMARY_COLOR};
     border-radius: 8px;
 }}
 """

--- a/fibsem/ui/widgets/lamella_default_config_widget.py
+++ b/fibsem/ui/widgets/lamella_default_config_widget.py
@@ -22,6 +22,7 @@ from fibsem.structures import DEFAULT_ALIGNMENT_AREA, FibsemRectangle, Point
 from fibsem.ui.stylesheets import NAPARI_STYLE
 from fibsem.ui.tokens import (
     NEUTRAL_500,
+    NEUTRAL_750,
     SEMANTIC_WARNING_COLOR,
 )
 
@@ -36,7 +37,7 @@ _LABEL_STYLE = f"color: {NEUTRAL_500}; min-width: 80px; font-size: 11px; backgro
 _INVALID_STYLE = f"color: {SEMANTIC_WARNING_COLOR}; font-size: 10px; background: transparent;"
 _HINT_STYLE = (
     "color: #808080; font-size: 10px; background: transparent;"
-    " border-top: 1px solid #4a4a4a; padding-top: 6px;"
+    f" border-top: 1px solid {NEUTRAL_750}; padding-top: 6px;"
 )
 
 # Tells the user the preview is editable — without it the overlays look decorative

--- a/fibsem/ui/widgets/lamella_workflow_widget.py
+++ b/fibsem/ui/widgets/lamella_workflow_widget.py
@@ -30,6 +30,7 @@ from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
 )
 from fibsem.ui.tokens import (
+    CANVAS_BG,
     NEUTRAL_500,
     PRIMARY_COLOR,
     SURFACE_COLOR,
@@ -37,8 +38,8 @@ from fibsem.ui.tokens import (
 )
 
 _SECTION_LABEL_STYLE = (
-    "font-size: 11px; font-weight: bold; color: #a0a0a0;"
-    " padding: 4px 6px 2px 6px; background: #1e2124;"
+    f"font-size: 11px; font-weight: bold; color: {NEUTRAL_500};"
+    f" padding: 4px 6px 2px 6px; background: {CANVAS_BG};"
 )
 
 class AddTaskDialog(QDialog):

--- a/fibsem/ui/widgets/milling_stage_list_widget.py
+++ b/fibsem/ui/widgets/milling_stage_list_widget.py
@@ -66,7 +66,7 @@ _MICRO_TO_SI = 1e-6
 
 _NAME_EDIT_STYLE = (
     "QLineEdit { background: transparent; border: none; }"
-    "QLineEdit:focus { background: #1e2124; border: 1px solid #555; border-radius: 2px; }"
+    f"QLineEdit:focus {{ background: {CANVAS_BG}; border: 1px solid #555; border-radius: 2px; }}"
 )
 
 

--- a/fibsem/ui/widgets/notifications.py
+++ b/fibsem/ui/widgets/notifications.py
@@ -23,6 +23,11 @@ from fibsem.constants import TIME_DISPLAY
 from fibsem.ui import stylesheets
 from fibsem.ui.tokens import (
     ACCENT_COLOR,
+    BORDER_COLOR,
+    DISABLED_BG_COLOR,
+    DISABLED_TEXT_COLOR,
+    PANEL_COLOR,
+    SURFACE_COLOR,
     TEXT_COLOR,
 )
 
@@ -104,33 +109,33 @@ class ToastNotification(QWidget):
         """Apply styling based on notification type."""
         color = self.TYPES.get(notification_type, self.TYPES["info"])
 
-        self.container.setStyleSheet("""
-            #toast_container {
-                background-color: #1e2027;
-                border: 1px solid #3d4251;
+        self.container.setStyleSheet(f"""
+            #toast_container {{
+                background-color: {PANEL_COLOR};
+                border: 1px solid {BORDER_COLOR};
                 border-radius: 6px;
-            }
+            }}
         """)
 
-        self.message_label.setStyleSheet("""
-            QLabel {
+        self.message_label.setStyleSheet(f"""
+            QLabel {{
                 background-color: transparent;
-                color: #d6d6d6;
+                color: {TEXT_COLOR};
                 font-size: 13px;
-            }
+            }}
         """)
 
-        self.close_btn.setStyleSheet("""
-            QToolButton {
+        self.close_btn.setStyleSheet(f"""
+            QToolButton {{
                 background-color: transparent;
                 color: #888;
                 border: none;
                 font-size: 16px;
                 font-weight: bold;
-            }
-            QToolButton:hover {
-                color: #d6d6d6;
-            }
+            }}
+            QToolButton:hover {{
+                color: {TEXT_COLOR};
+            }}
         """)
 
         # Set icon based on type
@@ -234,16 +239,16 @@ class NotificationHistoryPopup(QWidget):
         header_layout.addStretch()
 
         self.clear_btn = QPushButton("Clear All")
-        self.clear_btn.setStyleSheet("""
-            QPushButton {
+        self.clear_btn.setStyleSheet(f"""
+            QPushButton {{
                 background-color: transparent;
-                color: #50a6ff;
+                color: {ACCENT_COLOR};
                 border: none;
                 font-size: 12px;
-            }
-            QPushButton:hover {
+            }}
+            QPushButton:hover {{
                 color: #7bc0ff;
-            }
+            }}
         """)
         header_layout.addWidget(self.clear_btn)
 
@@ -272,19 +277,19 @@ class NotificationHistoryPopup(QWidget):
         # Empty state label
         self.empty_label = QLabel("No notifications")
         self.empty_label.setAlignment(Qt.AlignCenter)
-        self.empty_label.setStyleSheet("color: #6b6b6b; padding: 20px;")
+        self.empty_label.setStyleSheet(f"color: {DISABLED_TEXT_COLOR}; padding: 20px;")
         self.notifications_layout.insertWidget(0, self.empty_label)
 
         # Apply styling
-        self.container.setStyleSheet("""
-            #notification_popup {
-                background-color: #1e2027;
-                border: 1px solid #3d4251;
+        self.container.setStyleSheet(f"""
+            #notification_popup {{
+                background-color: {PANEL_COLOR};
+                border: 1px solid {BORDER_COLOR};
                 border-radius: 8px;
-            }
-            #notification_header {
-                border-bottom: 1px solid #3d4251;
-            }
+            }}
+            #notification_header {{
+                border-bottom: 1px solid {BORDER_COLOR};
+            }}
         """)
         # The app-global NAPARI_STYLE sets `QWidget { background-color: #262930 }`, which
         # otherwise bleeds into every child surface (header / scroll area / rows). Force them
@@ -322,18 +327,18 @@ class NotificationHistoryPopup(QWidget):
         text_layout.addWidget(msg_label)
 
         time_label = QLabel(timestamp)
-        time_label.setStyleSheet("color: #6b6b6b; font-size: 11px;")
+        time_label.setStyleSheet(f"color: {DISABLED_TEXT_COLOR}; font-size: 11px;")
         text_layout.addWidget(time_label)
 
         item_layout.addLayout(text_layout, 1)
 
-        item.setStyleSheet("""
-            #notification_item {
-                border-bottom: 1px solid #2d313b;
-            }
-            #notification_item:hover {
-                background-color: #262930;
-            }
+        item.setStyleSheet(f"""
+            #notification_item {{
+                border-bottom: 1px solid {DISABLED_BG_COLOR};
+            }}
+            #notification_item:hover {{
+                background-color: {SURFACE_COLOR};
+            }}
         """)
 
         # Insert at top (before the stretch)
@@ -388,15 +393,15 @@ class NotificationBell(QWidget):
         self._apply_style()
 
     def _apply_style(self):
-        self.bell_btn.setStyleSheet("""
-            QToolButton {
+        self.bell_btn.setStyleSheet(f"""
+            QToolButton {{
                 background-color: transparent;
                 border: none;
-            }
-            QToolButton:hover {
-                background-color: #3d4251;
+            }}
+            QToolButton:hover {{
+                background-color: {BORDER_COLOR};
                 border-radius: 18px;
-            }
+            }}
         """)
 
         self.badge.setStyleSheet("""

--- a/fibsem/ui/widgets/saved_position_widget.py
+++ b/fibsem/ui/widgets/saved_position_widget.py
@@ -37,7 +37,7 @@ _BTN_SPACER_WIDTH = _BTN_SIZE.width() * _BTN_COUNT + 8 * (_BTN_COUNT - 1)  # 112
 
 _NAME_EDIT_STYLE = (
     "QLineEdit { background: transparent; border: none; }"
-    "QLineEdit:focus { background: #1e2124; border: 1px solid #555; border-radius: 2px; }"
+    f"QLineEdit:focus {{ background: {CANVAS_BG}; border: 1px solid #555; border-radius: 2px; }}"
 )
 
 

--- a/fibsem/ui/widgets/workflow_info_widget.py
+++ b/fibsem/ui/widgets/workflow_info_widget.py
@@ -19,6 +19,7 @@ from fibsem.applications.autolamella.structures import (
 from fibsem.ui.tokens import (
     NEUTRAL_500,
     PANEL_COLOR,
+    PRIMARY_COLOR,
     SURFACE_COLOR,
     TEXT_COLOR,
 )
@@ -31,13 +32,13 @@ _SECTION_STYLE = (
 _LINE_EDIT_STYLE = f"""
 QLineEdit {{
     background: {SURFACE_COLOR};
-    color: #d6d6d6;
+    color: {TEXT_COLOR};
     border: 1px solid #3a3d42;
     border-radius: 3px;
     padding: 3px 6px;
     font-size: 11px;
 }}
-QLineEdit:focus {{ border-color: #007ACC; }}
+QLineEdit:focus {{ border-color: {PRIMARY_COLOR}; }}
 """
 
 

--- a/fibsem/ui/widgets/workflow_task_editor_widget.py
+++ b/fibsem/ui/widgets/workflow_task_editor_widget.py
@@ -23,8 +23,10 @@ from fibsem.applications.autolamella.structures import AutoLamellaTaskDescriptio
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import TitledPanel
 from fibsem.ui.tokens import (
+    BORDER_COLOR,
     NEUTRAL_500,
     NEUTRAL_700,
+    TEXT_COLOR,
 )
 
 _ROW_HEIGHT = 40
@@ -33,8 +35,8 @@ _MAX_VISIBLE_REQS = 5
 # A task may be scheduled from now up to this many days in advance.
 _MAX_SCHEDULE_DAYS_AHEAD = 2
 _NAME_PILL_STYLE = (
-    "font-size: 12px; font-weight: bold; color: #d6d6d6; background: #2d3340;"
-    " border: 1px solid #3d4251; border-radius: 10px; padding: 2px 10px;"
+    f"font-size: 12px; font-weight: bold; color: {TEXT_COLOR}; background: #2d3340;"
+    f" border: 1px solid {BORDER_COLOR}; border-radius: 10px; padding: 2px 10px;"
 )
 _HINT_STYLE = "color: #707070; font-size: 11px; background: transparent;"
 _HINT_WARN_STYLE = "color: #f0a040; font-size: 11px; background: transparent;"

--- a/fibsem/ui/widgets/workflow_timeline_widget.py
+++ b/fibsem/ui/widgets/workflow_timeline_widget.py
@@ -24,6 +24,7 @@ from fibsem.constants import TIME_DISPLAY_AMPM_SHORT
 from fibsem.ui import stylesheets
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.tokens import (
+    DISABLED_TEXT_COLOR,
     NEUTRAL_500,
     NEUTRAL_700,
 )
@@ -66,7 +67,7 @@ _ADD_BTN_STYLE  = (
     "QToolButton { background: transparent; border: none; border-radius: 3px;"
     " color: #d1d2d4; font-size: 13px; padding: 3px 6px; }"
     "QToolButton:hover { background: #3a3d42; }"
-    "QToolButton:disabled { color: #6b6b6b; }"
+    f"QToolButton:disabled {{ color: {DISABLED_TEXT_COLOR}; }}"
     "QToolButton::menu-indicator { image: none; }"
 )
 


### PR DESCRIPTION
The last mechanical batch. #310 converted inline literals that exactly equalled a token, but deliberately skipped any string containing braces — turning those into f-strings means doubling every literal brace, and a missed pair silently drops a QSS rule rather than raising.

**49 literals across 21 files. Hex outside `tokens.py`: 352 → 284.**

## Why tokenize, not the AST

The AST-based approach reached only **10 of the 44**, because most of what was left is implicitly concatenated:

```python
self.setStyleSheet(
    "QLineEdit { background: transparent; border: none; }"
    "QLineEdit:focus { border: 1px solid #3d4251; }"
)
```

The AST reports that as a single `Constant` spanning several quoted pieces, which cannot be edited as one span. `tokenize` sees each piece separately — and also picks up the strings that were *already* f-strings with plain literals still inside them.

## Inert by construction, and verified

Only exact matches are substituted, so the rendered stylesheet cannot change. Verified by resolving every string literal in `fibsem/` from the AST — f-strings substituted with their token values — before and after: **4865 strings across 387 files, all identical.**

`1253 passed, 15 skipped`.

## Three exclusions

- **`napari_style.py`** — its two remaining `#2d313b` uses are `:hover` rules. That value now *has* a name, but the name is `DISABLED_BG_COLOR`, and hover is not disabled. Converting them would mislabel, not tidy.
- **`fm_canvas.py`** — still awaiting its all-or-nothing decision on its self-contained design.
- **Docstrings** — `fibsem/ui/icon.py` documents its own API with `color="#4caf50"`. Rewriting that would turn an example into code and change what the docs say.

## One thing worth flagging

The first run of this also converted `fibsem/milling/strategy/coincidence.py`, because that file mentions `fibsem.ui` — but only inside `if TYPE_CHECKING:`. Adding a real module-level import there pulls `fibsem/ui/__init__` → the widget layer → back into `fibsem.milling.strategy` while it is still initialising, and the module stopped importing at all.

Caught before commit; the file is untouched here. The scope rule is now a module-level `ImportFrom` in the AST rather than a substring match, so a `TYPE_CHECKING`-only mention no longer qualifies. It is a good illustration of why the lazy `fibsem/ui/__init__` work matters: that import is heavy enough to be circular from the wrong direction.