### PR TITLE
[fm] Stop a sparse overview painting black over the one beneath it (FIB-519)

### DIFF
--- a/fibsem/fm/composite.py
+++ b/fibsem/fm/composite.py
@@ -129,3 +129,48 @@ def composite_fm_layers(
         tint = np.asarray(tint_rgb(layer.color), dtype=np.float32) * float(layer.opacity)
         rgb += norm[..., None] * tint
     return (np.clip(rgb, 0.0, 1.0) * 255.0).astype(np.uint8)
+
+
+def to_rgba(rgb: np.ndarray) -> np.ndarray:
+    """Re-express an opaque composite as colour plus coverage, for placing over others.
+
+    A composite drawn over black loses nothing by being opaque, which is why
+    :func:`composite_fm_layers` returns RGB. But a canvas holding several images at
+    once draws them over *each other*, and there an opaque frame hides whatever it
+    covers -- including with pixels that hold nothing. A sparse overview acquired over
+    a full one painted its unacquired tiles as black over real data (FIB-519).
+
+    Splitting the same picture into a colour and how much of it there is fixes that
+    without anyone having to say which pixels were acquired. Signal strength becomes
+    alpha, so a region with none is transparent and the image beneath shows through,
+    and the colour is divided back out so that colour x alpha still reconstructs the
+    original. Over the canvas's black background the result is the same picture to
+    within a rounding step; over another image it reveals it exactly.
+
+    The consequence is that a genuinely dark region is transparent too, so this cannot
+    distinguish "imaged, and dark" from "not imaged". For display that is the better
+    answer -- what you see is the union of the signal -- but it is why this is a
+    display transform and not a substitute for knowing which tiles were acquired.
+
+    Not folded into `composite_fm_layers`, because the un-premultiplied colour is
+    saturated: the brightness has moved into alpha, and a caller that reads the RGB
+    channels without applying it gets a different image. `fm.preview.load_projection`
+    is exactly such a caller. So this is asked for, by the one canvas that composites.
+
+    Args:
+        rgb: ``(H, W, 3)`` uint8, as returned by :func:`composite_fm_layers`.
+
+    Returns:
+        ``(H, W, 4)`` uint8 RGBA.
+    """
+    values = np.asarray(rgb, dtype=np.float32) / 255.0
+    # The brightest channel, rather than a luminance weighting: this is asking how
+    # much signal is here, and a lone blue channel is no less present than a green one.
+    alpha = values.max(axis=-1)
+    # Where there is nothing, the colour is arbitrary -- alpha is zero, so it is never
+    # drawn -- and dividing by zero to find it would only produce warnings and NaNs.
+    divisor = np.where(alpha > 0.0, alpha, 1.0)[..., None]
+    out = np.empty((*values.shape[:2], 4), dtype=np.uint8)
+    out[..., :3] = np.clip(values / divisor, 0.0, 1.0) * 255.0
+    out[..., 3] = alpha * 255.0
+    return out

--- a/fibsem/fm/composite.py
+++ b/fibsem/fm/composite.py
@@ -7,10 +7,9 @@ the colocalised multi-channel result.
 Qt-free by design, so it can be imported and tested without the UI extras (CI has
 no napari or PyQt5, and anything reaching through `fibsem.ui` is skipped there).
 
-Originally written for the quad-view FM canvas on PR #111 and lifted here
-unchanged so the review panel can use it too. When #111 lands, its copy at
-`fibsem/ui/widgets/canvas/fm_composite.py` should become a re-export of this
-module rather than a second implementation.
+Originally written for the quad-view FM canvas on PR #111 and lifted here so the
+review panel could use it too; `fibsem/ui/widgets/canvas/fm_composite.py` is now a
+re-export of this module rather than the second copy it used to be.
 """
 from __future__ import annotations
 

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -25,7 +25,7 @@ from superqt import QRangeSlider
 
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.widgets.canvas.fm_composite import (
-    AVAILABLE_COLORS, FMLayer, auto_clim, composite_fm_layers,
+    AVAILABLE_COLORS, FMLayer, auto_clim, composite_fm_layers, to_rgba,
 )
 from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase, _downsample
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
@@ -612,9 +612,14 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         self._held[key] = {
             layer.name: layer.data for layer in self._layers if layer.data is not None
         }
+        # Placed over other images rather than over a background, so it goes on as
+        # colour plus coverage: an opaque frame hides whatever it covers, including
+        # where it holds nothing itself. That is what painted a sparse overview's
+        # unacquired tiles black over the full one beneath it (FIB-519).
+        placed = to_rgba(rgb)
         if reshaped or key not in self.canvas.placed_keys:
             self.canvas.add_image(
-                rgb,
+                placed,
                 centre=self._placement,
                 pixel_size=self._pixel_size,
                 key=key,
@@ -624,7 +629,7 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
                 zorder=self._detail_zorder(self._pixel_size),
             )
         else:
-            self.canvas.update_image(key, rgb)
+            self.canvas.update_image(key, placed)
         self._restyle_others(key)
 
     def _reduce(self, plane: np.ndarray) -> np.ndarray:
@@ -686,7 +691,10 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
             shape = layers[0].data.shape[:2]
             rgb = composite_fm_layers(layers, shape)
             if rgb is not None:
-                self.canvas.update_image(key, rgb)
+                # Same transform as the image that triggered this: these are placed
+                # over each other too, and re-rendering one opaque would put back the
+                # occlusion `_show_composite` just avoided.
+                self.canvas.update_image(key, to_rgba(rgb))
 
     def set_pixel_size(self, pixel_size: Optional[float]) -> None:
         """Record the scale without touching the canvas's own.

--- a/fibsem/ui/widgets/canvas/fm_composite.py
+++ b/fibsem/ui/widgets/canvas/fm_composite.py
@@ -1,127 +1,30 @@
 """Multi-channel fluorescence compositing for the quad-view FM canvas.
 
-Blends per-channel grayscale frames into one RGB image the way napari does on the
-main tab — each channel tinted by its colour and **additively** summed — so the
-matplotlib `FibsemImageCanvas` can show the colocalised multi-channel result.
+Re-exports :mod:`fibsem.fm.composite`, which is the implementation. This module was
+a second, byte-identical copy of it: the compositor was written here for the
+quad-view canvas on PR #111 and lifted into `fibsem.fm` so the review panel could
+use it without importing the UI package. #111 has landed, so this becomes the
+re-export its counterpart's docstring always said it should.
 
-Reusable + Qt-free: the coincidence viewer (which currently max-projects to
-grayscale) could converge onto this later.
+Kept as a module rather than deleted because the canvas package is where a caller
+working on the FM canvas looks for it, and both import paths are in use. There is
+now one `FMLayer` class rather than two that merely looked alike -- which is what
+made this worth doing rather than leaving alone.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from fibsem.fm.composite import (
+    AVAILABLE_COLORS,
+    FMLayer,
+    auto_clim,
+    composite_fm_layers,
+    tint_rgb,
+)
 
-import numpy as np
-from matplotlib.colors import to_rgb
-
-# Canonical channel colours (mirrors channel_list_widget.AVAILABLE_COLORS).
-AVAILABLE_COLORS = ["violet", "blue", "cyan", "green", "yellow", "red", "gray"]
-
-_WHITE = (1.0, 1.0, 1.0)
-
-
-@dataclass
-class FMLayer:
-    """One fluorescence channel's display state (separate from acquisition
-    ``ChannelSettings``, which only carries ``name`` + ``color``)."""
-
-    name: str
-    data: Optional[np.ndarray] = None        # 2D (H, W)
-    color: str = "gray"
-    opacity: float = 1.0                      # 0..1
-    clim: Optional[Tuple[float, float]] = None  # manual limits (used when not auto)
-    visible: bool = True
-    autocontrast: bool = True                 # recompute clim from data each composite
-    # The user explicitly chose manual contrast (turned Auto off). Distinct from
-    # ``autocontrast``, which the z-scrub display path also toggles internally: the
-    # single-plane / MIP display path keeps a manual channel's clim across live frames /
-    # MIP toggles, but still restores auto for a channel the user left on Auto.
-    manual: bool = False
-    gamma: float = 1.0                        # display = norm ** gamma (1 = linear)
-    # cached auto clim, keyed on the data array identity so it's recomputed only
-    # when the channel's data actually changes (not on every unrelated recomposite,
-    # e.g. an opacity-slider drag). Not part of the layer's value.
-    _clim_cache: Optional[Tuple] = field(default=None, repr=False, compare=False)
-
-
-# Canonical channel-colour tints = napari's colormap endpoints (the colour each
-# colormap ramps to at full intensity), so the composite matches the napari main
-# tab. These mostly agree with matplotlib's named colours; the notable difference
-# is "green" (mpl (0, 0.5, 0) vs napari (0, 1, 0)). "gray" ramps to white.
-_CANONICAL_TINTS = {
-    "violet": (0.933, 0.510, 0.933),
-    "blue": (0.0, 0.0, 1.0),
-    "cyan": (0.0, 1.0, 1.0),
-    "green": (0.0, 1.0, 0.0),
-    "yellow": (1.0, 1.0, 0.0),
-    "red": (1.0, 0.0, 0.0),
-    "magenta": (1.0, 0.0, 1.0),
-    "gray": _WHITE,
-}
-
-
-def tint_rgb(color: str) -> Tuple[float, float, float]:
-    """RGB tint for a channel colour. Canonical channel colours use napari's
-    colormap endpoint (so the composite matches the napari main tab); unknown
-    names fall back to matplotlib, and anything unrecognised to white."""
-    if color in _CANONICAL_TINTS:
-        return _CANONICAL_TINTS[color]
-    try:
-        return to_rgb(color)
-    except (ValueError, TypeError):
-        return _WHITE
-
-
-def auto_clim(data: np.ndarray, max_samples: int = 250_000) -> Tuple[float, float]:
-    """Robust auto contrast limits (1st/99th percentile, min/max fallback).
-
-    The full-resolution percentile is the dominant per-frame cost on live FM, so
-    for large frames the data is strided down to ~*max_samples* points first — the
-    1st/99th percentiles are visually identical on the subsample.
-    """
-    if data.ndim == 2 and data.size > max_samples:
-        step = int(np.ceil(np.sqrt(data.size / max_samples)))
-        data = data[::step, ::step]
-    lo = float(np.percentile(data, 1.0))
-    hi = float(np.percentile(data, 99.0))
-    if hi <= lo:
-        lo, hi = float(np.min(data)), float(np.max(data))
-        if hi <= lo:
-            hi = lo + 1.0
-    return lo, hi
-
-
-def composite_fm_layers(
-    layers: List[FMLayer], shape: Optional[Tuple[int, int]] = None
-) -> Optional[np.ndarray]:
-    """Blend the visible *layers* into an ``(H, W, 3)`` uint8 RGB image.
-
-    Each visible layer is contrast-normalised by its ``clim`` (or auto), tinted by
-    ``color`` scaled by ``opacity``, and additively summed; the result is clipped.
-    Returns ``None`` if there is nothing to show and *shape* is unknown.
-    """
-    visible = [l for l in layers if l.visible and l.data is not None]
-    if not visible:
-        return np.zeros((*shape, 3), dtype=np.uint8) if shape is not None else None
-    H, W = shape if shape is not None else visible[0].data.shape[:2]
-    rgb = np.zeros((H, W, 3), dtype=np.float32)
-    for layer in visible:
-        d = np.asarray(layer.data, dtype=np.float32)
-        if d.shape[:2] != (H, W):
-            continue  # ignore mismatched-shape channels
-        if layer.autocontrast or layer.clim is None:
-            cache = layer._clim_cache
-            if cache is not None and cache[0] is layer.data:
-                lo, hi = cache[1]  # data unchanged → reuse (skip the percentile)
-            else:
-                lo, hi = auto_clim(d)
-                layer._clim_cache = (layer.data, (lo, hi))
-        else:
-            lo, hi = layer.clim
-        norm = np.clip((d - lo) / (hi - lo), 0.0, 1.0) if hi > lo else np.zeros_like(d)
-        if layer.gamma != 1.0:
-            norm = np.power(norm, layer.gamma)
-        tint = np.asarray(tint_rgb(layer.color), dtype=np.float32) * float(layer.opacity)
-        rgb += norm[..., None] * tint
-    return (np.clip(rgb, 0.0, 1.0) * 255.0).astype(np.uint8)
+__all__ = [
+    "AVAILABLE_COLORS",
+    "FMLayer",
+    "auto_clim",
+    "composite_fm_layers",
+    "tint_rgb",
+]

--- a/fibsem/ui/widgets/canvas/fm_composite.py
+++ b/fibsem/ui/widgets/canvas/fm_composite.py
@@ -19,6 +19,7 @@ from fibsem.fm.composite import (
     auto_clim,
     composite_fm_layers,
     tint_rgb,
+    to_rgba,
 )
 
 __all__ = [
@@ -27,4 +28,5 @@ __all__ = [
     "auto_clim",
     "composite_fm_layers",
     "tint_rgb",
+    "to_rgba",
 ]

--- a/tests/fm/test_composite.py
+++ b/tests/fm/test_composite.py
@@ -8,7 +8,13 @@ The module was written for the quad-view canvas on PR #111 and lifted to
 import numpy as np
 import pytest
 
-from fibsem.fm.composite import FMLayer, auto_clim, composite_fm_layers, tint_rgb
+from fibsem.fm.composite import (
+    FMLayer,
+    auto_clim,
+    composite_fm_layers,
+    tint_rgb,
+    to_rgba,
+)
 
 
 def _layer(color: str, shape=(4, 4), **kwargs) -> FMLayer:
@@ -134,3 +140,92 @@ def test_nothing_visible_returns_zeros_for_a_known_shape():
 def test_nothing_visible_and_no_shape_returns_none():
     """There is no sensible image to show, and guessing a size would be worse."""
     assert composite_fm_layers([]) is None
+
+
+# to_rgba
+
+
+def _render(*images) -> np.ndarray:
+    """Draw *images* over a black background, in order, and read back the pixels.
+
+    The canvas this stands in for places many images at once over
+    ``GRAY_CANVAS_COLOR`` (black), so that is the background here. Matplotlib rather
+    than the canvas itself: what is under test is how the frames composite, and the
+    canvas needs Qt.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(1, 1), dpi=64)
+    ax.set_position([0, 0, 1, 1])
+    ax.set_axis_off()
+    fig.patch.set_facecolor("black")  # set_axis_off hides the axes patch
+    for image in images:
+        # One zorder for all of them, so arrival order decides -- which is the case
+        # that bit: two overviews at the same pixel size tie in `_detail_zorder`.
+        ax.imshow(image, extent=(0, 4, 4, 0), zorder=1)
+    fig.canvas.draw()
+    out = np.asarray(fig.canvas.buffer_rgba())[..., :3].astype(np.float32)
+    plt.close(fig)
+    return out
+
+
+def test_it_is_the_same_picture_over_black():
+    """The regression that matters. Every FM overview is drawn through this, and most
+    of them have nothing underneath -- so the transform has to be invisible there."""
+    rgb = composite_fm_layers([_layer("green")])
+
+    difference = np.abs(_render(rgb) - _render(to_rgba(rgb))).max()
+
+    assert difference <= 1.0, f"the picture changed by {difference}/255 over black"
+
+
+def test_it_shows_the_overview_underneath_where_this_one_has_nothing():
+    """The reported bug (FIB-519): a sparse overview acquired over a full one drew
+    its unacquired tiles as black over real data."""
+    beneath = composite_fm_layers([_layer("green")])
+    # `stitch_tileset` leaves an unacquired tile as canvas zeros, so that is what the
+    # top half of this one holds.
+    sparse = _layer("green")
+    sparse.data = sparse.data.copy()
+    sparse.data[:2] = 0
+    above = composite_fm_layers([sparse])
+
+    opaque = _render(beneath, above)
+    layered = _render(beneath, to_rgba(above))
+    alone = _render(beneath)
+
+    unacquired = np.s_[:24]  # the top half, in rendered pixels
+    assert opaque[unacquired].max() == 0, "expected today's behaviour: black"
+    np.testing.assert_allclose(
+        layered[unacquired], alone[unacquired], atol=1.0,
+        err_msg="the overview beneath is not showing through",
+    )
+
+
+def test_alpha_carries_the_signal_and_colour_survives_it():
+    """Colour times alpha has to reconstruct the composite -- that is what makes the
+    substitution invisible -- while alpha alone says how much is there."""
+    rgb = composite_fm_layers([_layer("green")])
+
+    rgba = to_rgba(rgb)
+
+    reconstructed = (
+        rgba[..., :3].astype(np.float32) * rgba[..., 3:4].astype(np.float32) / 255.0
+    )
+    np.testing.assert_allclose(reconstructed, rgb.astype(np.float32), atol=1.0)
+
+
+def test_a_region_holding_nothing_is_fully_transparent():
+    """Not merely dark: an unacquired tile has to disappear, not dim what is beneath."""
+    blank = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    assert to_rgba(blank)[..., 3].max() == 0
+
+
+def test_it_returns_rgba_the_canvas_accepts():
+    rgba = to_rgba(composite_fm_layers([_layer("red")]))
+
+    assert rgba.dtype == np.uint8
+    assert rgba.shape == (4, 4, 4)

--- a/tests/ui/test_fm_real_space_canvas.py
+++ b/tests/ui/test_fm_real_space_canvas.py
@@ -320,3 +320,68 @@ def test_the_single_image_canvas_drops_a_channel_outright():
     widget.retain_channels(["Channel-01"])
 
     assert [layer.name for layer in widget.layers] == ["Channel-01"]
+
+
+# ── placed images do not hide each other where they hold nothing (FIB-519) ──
+
+
+def _sparse_plane(h=128, w=128):
+    """A plane whose top half was never acquired.
+
+    `stitch_tileset` leaves a skipped tile as canvas zeros, so that is what an
+    unacquired region of a real mosaic holds.
+    """
+    plane = np.random.randint(120, 255, (h, w), dtype=np.uint8)
+    plane[: h // 2] = 0
+    return plane
+
+
+def test_a_placed_composite_carries_transparency():
+    """Placed images are drawn over each other, so an opaque one hides whatever it
+    covers -- including with pixels holding nothing."""
+    w = _widget()
+    w.set_composite_key("a")
+    w.set_channel("GFP", _plane(), "green")
+
+    placed = np.asarray(w.canvas._placed["a"].artist.get_array())
+
+    assert placed.shape[-1] == 4, "placed opaque, so it can only occlude"
+
+
+def test_an_unacquired_region_does_not_paint_over_the_overview_beneath():
+    """The reported bug: acquire a full overview, then a sparse one over the top, and
+    the second run's unacquired tiles were drawn as black over the first's real data."""
+    w = _widget()
+    w.set_composite_key("full")
+    w.set_placement((0.0, 0.0))
+    w.set_channel("GFP", _plane(), "green")
+
+    w.set_composite_key("sparse")
+    w.set_placement((0.0, 0.0))  # the same ground, drawn over it
+    w.set_channel("GFP", _sparse_plane(), "green")
+
+    alpha = np.asarray(w.canvas._placed["sparse"].artist.get_array())[..., 3]
+
+    assert alpha[:60].max() == 0, "the unacquired half still covers what is beneath"
+    assert alpha[68:].max() > 0, "the acquired half is not being shown"
+
+
+def test_restyling_the_others_keeps_their_transparency():
+    """`_restyle_others` re-renders every image except the current one, so it has to
+    make the same picture -- rendering one opaque would put the occlusion back, and
+    only on the images the user was not looking at."""
+    w = _widget()
+    for key in ("full", "sparse"):
+        w.set_composite_key(key)
+        w.set_placement((0.0, 0.0))
+        w.set_channel("GFP", _sparse_plane() if key == "sparse" else _plane(), "green")
+
+    # A colour change re-renders everything held, including "sparse".
+    w.set_composite_key("full")
+    w._layers[0].color = "red"
+    w._recomposite()
+
+    placed = np.asarray(w.canvas._placed["sparse"].artist.get_array())
+
+    assert placed.shape[-1] == 4, "restyled back to opaque"
+    assert placed[..., 3][:60].max() == 0, "the unacquired half lost its transparency"


### PR DESCRIPTION
Fixes [FIB-519](https://linear.app/fibsemos/issue/FIB-519/a-sparse-overviews-unacquired-tiles-paint-opaque-black-over-the). Found on hardware: acquire a full overview, then a sparse one over the top, and the second run's *unacquired* tiles are drawn as opaque black over the first run's real data. Confirmed fixed in the running app.

## Why it happened

`stitch_tileset` allocates the mosaic with `np.zeros` and writes only the tiles it acquired, so a sparse run produces a full-size, fully opaque image whose masked-off region is zeros. `composite_fm_layers` returns RGB, so the canvas paints all of it. Two overviews at the same pixel size also tie in `_detail_zorder`, so arrival order decides — and the sparse one arrives second.

## The fix

Stop handing the canvas something opaque. `to_rgba` re-expresses a finished composite as colour plus how much of it there is: signal strength becomes alpha, and the colour is divided back out so that colour × alpha still reconstructs the original.

- Over the canvas's black background: the same picture to within a rounding step (measured 1/255).
- Over another image: reveals it exactly where this one holds nothing.

Nothing has to record which tiles were acquired. That is the point — the alternative was threading a mask from the runner through `FluorescenceImage` and out the other side of save/load, at ~89 MB for a 5×5. This is five lines, and it fixes the live preview and reloaded overviews without touching either, because both already end at the same compositor. The live preview is the more visible case: its canvas starts as zeros, so the whole not-yet-acquired grid was painting black over anything beneath it for the length of a run.

## Applied at the call sites, not inside the compositor

The un-premultiplied colour is saturated — brightness has moved into alpha — so a caller that reads the RGB channels without applying it gets a different image. `fm.preview.load_projection` feeds exactly such a caller in `lamella_task_image_widget`. So the conversion happens in `FMRealSpaceCanvasWidget`, and the single-image canvas, the preview path and `composite_fm_layers`' own ten tests are all untouched.

## Worth knowing

A genuinely dark region is transparent too, so this cannot tell "imaged, and dark" from "not imaged". For display that is the better answer — what you see is the union of the signal — but it is a display transform, not a substitute for knowing which tiles were acquired. That is still what correlation and targeting would need, and this does not close that gap.

## The first commit

`fibsem/ui/widgets/canvas/fm_composite.py` and `fibsem/fm/composite.py` were byte-identical apart from their docstrings, and `fm/composite.py`'s docstring already asked for the copy to become a re-export once #111 landed. It has. Doing it first avoided writing `to_rgba` into two files, and collapses `FMLayer` from two distinct classes into one.

## Testing

302 tests pass across the compositor, the preview path, all three canvas suites and the overview widget. Every mutation is caught by the test written for it:

| mutation | caught by |
|---|---|
| alpha always opaque (the bug restored) | 4 tests, including the reported case |
| forget to un-premultiply | the lone-overview-unchanged guard |
| drop `to_rgba` from `_show_composite` | 3 tests |
| drop it from `_restyle_others` only | its own test — the silent one, where a colour change would restore the occlusion on every overview *except* the one being looked at |

The wiring test asserts the real thing rather than the pure function: it places a full overview, then a sparse one over the same ground, and reads the placed artist's alpha — `0` across the unacquired half, non-zero across the acquired half.