### PR TITLE
[fm] Keep the focus an overview sweep finds, instead of resetting past it (FIB-516)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -592,15 +592,21 @@ class FMTiledAcquisitionRunner:
 
         The mosaic is an ordinary fluorescence image that happens to be large, and it
         reports where it is from what the run captured rather than from what the
-        stitcher can infer: the grid is centred on `centre_position`, and every tile is
-        taken at the starting objective position.
+        stitcher can infer: the grid is centred on `centre_position`, and the objective
+        position is the one tiles were acquired at.
+
+        That is the run's starting position with autofocus off or in `once` mode, where
+        every tile really is taken at one position. `each_row` and `each_tile` vary it
+        per tile and there is no single answer -- the last one is recorded, which is
+        true of one tile and close to the rest. The run's *starting* position would be
+        true of none of them.
         """
         self.run()
         return stitch_tileset(
             self.tileset,
             self.overview_parameters.overlap,
             centre_position=self.centre_position,
-            objective_position=self._initial_objective_position,
+            objective_position=self._tile_objective_position,
         )
 
     # ── phases ───────────────────────────────────────────────────────────
@@ -659,6 +665,12 @@ class FMTiledAcquisitionRunner:
         # name somewhere else, and then the stage still comes back here afterwards.
         self._initial_position = microscope.get_stage_position()
         self._initial_objective_position = microscope.fm.objective.position
+        # Where tiles are acquired, which is only the same thing until an autofocus
+        # succeeds. Each tile resets the objective to this before acquiring, so that a
+        # run does not accumulate drift -- but resetting to where the *run* started
+        # threw away whatever the sweep had just found, and `once` and `each_row` do
+        # their sweeping before the tile that would use it (FIB-516).
+        self._tile_objective_position = self._initial_objective_position
         if self.centre_position is None:
             self.centre_position = self._initial_position
 
@@ -877,6 +889,16 @@ class FMTiledAcquisitionRunner:
                 f"Tileset autofocus ({mode.value}) cancelled by user."
             )
 
+        # Autofocus leaves the objective at best focus, so this is the answer it found.
+        # Kept, because the next tile resets the objective before acquiring and would
+        # otherwise undo the sweep that just ran -- which is what made `once` and
+        # `each_row` cost time and change nothing (FIB-516).
+        self._tile_objective_position = self.microscope.fm.objective.position
+        logging.info(
+            f"Autofocus ({mode.value}) found "
+            f"{self._tile_objective_position * 1e3:.4f} mm; tiles acquired there."
+        )
+
     def _run_tile_loop(self) -> None:
         """Visit the enabled tiles in traversal order.
 
@@ -914,7 +936,12 @@ class FMTiledAcquisitionRunner:
 
         # Absolute, from the grid computed up front -- no accumulation.
         microscope.safe_absolute_stage_movement(self._tile_stage_positions[(row, col)])
-        microscope.fm.objective.move_absolute(self._initial_objective_position)
+        # The focus tiles are meant to be acquired at, which is the run's starting
+        # position until a sweep finds something better. Resetting to the *start* here
+        # is what discarded the `once` and `each_row` sweeps (FIB-516); for `each_tile`
+        # it now means each sweep begins from the last tile's answer rather than
+        # walking back to the start every time.
+        microscope.fm.objective.move_absolute(self._tile_objective_position)
 
         self._autofocus_if_mode(AutoFocusMode.EACH_TILE)
 

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -1971,3 +1971,120 @@ def test_a_grid_within_the_limits_is_untouched(fm_microscope):
     runner.run()
 
     assert sum(t is not None for row in runner.tileset for t in row) == 4
+
+
+# ---------------------------------------------------------------------------
+# Autofocus has to survive the objective reset before each tile (FIB-516).
+#
+# Every tile resets the objective before acquiring, so that a long run does not
+# accumulate drift. That reset used to target the position the *run* started at,
+# which lands after the `once` and `each_row` sweeps have already found focus --
+# so two of the four modes paid for a sweep and changed nothing about the images.
+# ---------------------------------------------------------------------------
+
+FOUND_FOCUS = 77e-6  # what the stubbed sweep "finds", far from where the run starts
+
+
+def _acquired_at(monkeypatch, microscope, mode, rows=1, cols=2, order=None):
+    """Run a tileset and report the objective position each tile was acquired at.
+
+    Both hardware-facing pieces are stubbed: the sweep moves the objective the way a
+    real one does ("run_autofocus centres on the current objective position and moves
+    to best") and reports success, and the acquisition records where the objective
+    actually was when the tile was taken. No microscope needed, which is the point --
+    this is exactly the measurement that found the bug.
+    """
+    positions = []
+
+    def sweep(*args, **kwargs):
+        microscope.fm.objective.move_absolute(FOUND_FOCUS)
+        return True
+
+    monkeypatch.setattr(acquisition, "run_tileset_autofocus", sweep)
+
+    real_acquire_image = acquisition.acquire_image
+
+    def spy(*args, **kwargs):
+        positions.append(microscope.fm.objective.position)
+        return real_acquire_image(*args, **kwargs)
+
+    monkeypatch.setattr(acquisition, "acquire_image", spy)
+
+    parameters = OverviewParameters(
+        rows=rows, cols=cols, overlap=0.1, use_zstack=False, autofocus_mode=mode,
+    )
+    if order is not None:
+        parameters.tile_order = order
+    runner = acquisition.FMTiledAcquisitionRunner(
+        microscope=microscope,
+        channel_settings=ChannelSettings(
+            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
+            power=0.1, exposure_time=0.1,
+        ),
+        overview_parameters=parameters,
+        autofocus_settings=AutoFocusSettings(),
+    )
+    runner.run()
+    return positions, runner
+
+
+def test_autofocus_off_acquires_every_tile_where_the_run_started(
+    fm_microscope, monkeypatch
+):
+    """The reset's actual purpose, and it still works: with no sweep to preserve,
+    every tile is taken at one known position rather than wherever the last one
+    drifted to."""
+    started_at = fm_microscope.fm.objective.position
+
+    positions, _ = _acquired_at(monkeypatch, fm_microscope, AutoFocusMode.NONE)
+
+    assert positions == [pytest.approx(started_at)] * 2
+
+
+def test_a_once_sweep_is_kept_for_every_tile(fm_microscope, monkeypatch):
+    """`once` exists to focus one time and acquire the whole grid there. It ran
+    before the tile loop, and the first tile's reset undid it -- so it cost a sweep
+    and changed nothing (FIB-516)."""
+    positions, _ = _acquired_at(monkeypatch, fm_microscope, AutoFocusMode.ONCE)
+
+    assert positions == [pytest.approx(FOUND_FOCUS)] * 2
+
+
+def test_an_each_row_sweep_is_kept_for_that_rows_tiles(fm_microscope, monkeypatch):
+    """Same failure one level down: the sweep ran immediately before the first tile
+    of the row, and every tile in the row undid it, including that first one."""
+    positions, _ = _acquired_at(
+        monkeypatch, fm_microscope, AutoFocusMode.EACH_ROW, rows=2, cols=2
+    )
+
+    assert positions == [pytest.approx(FOUND_FOCUS)] * 4
+
+
+def test_each_tile_still_focuses_at_every_tile(fm_microscope, monkeypatch):
+    """The mode that always worked. It has to keep working: the reset before each
+    tile now targets the previous tile's focus rather than the run's start, so the
+    sweep begins near the answer instead of walking back every time."""
+    positions, _ = _acquired_at(monkeypatch, fm_microscope, AutoFocusMode.EACH_TILE)
+
+    assert positions == [pytest.approx(FOUND_FOCUS)] * 2
+
+
+def test_the_objective_goes_back_where_the_user_left_it(fm_microscope, monkeypatch):
+    """Keeping the focus is about the tiles, not about the instrument. Whatever a
+    sweep found, the run still hands the objective back at the end."""
+    started_at = fm_microscope.fm.objective.position
+
+    _acquired_at(monkeypatch, fm_microscope, AutoFocusMode.ONCE)
+
+    assert fm_microscope.fm.objective.position == pytest.approx(started_at)
+
+
+def test_the_mosaic_records_where_its_tiles_were_actually_taken(
+    fm_microscope, monkeypatch
+):
+    """The mosaic's objective position is read back by anything reloading it. Stamping
+    the run's starting position was true of no tile at all once a sweep had moved."""
+    _, runner = _acquired_at(monkeypatch, fm_microscope, AutoFocusMode.ONCE)
+
+    assert runner._tile_objective_position == pytest.approx(FOUND_FOCUS)
+    assert runner._initial_objective_position != pytest.approx(FOUND_FOCUS)


### PR DESCRIPTION
Fixes [FIB-516](https://linear.app/fibsemos/issue/FIB-516/overview-autofocus-is-discarded-before-every-tile-except-in-each-tile). Two of the four overview autofocus modes ran a sweep, paid for it in time, reported progress — and changed nothing about the images.

## Measured before the fix

Simulator, objective starting at 10 µm, `run_tileset_autofocus` stubbed to find 77 µm, 1×2 grid:

```
once       autofocus -> 77.0    tiles acquired at 10.0, 10.0
each_row   autofocus -> 77.0    tiles acquired at 10.0, 10.0
each_tile  autofocus -> 77.0    tiles acquired at 77.0, 77.0   OK
```

## Why

Every tile resets the objective before acquiring, so a long run doesn't accumulate drift. That reset targeted the position the *run* started at — and it lands **after** the `once` and `each_row` sweeps have already found focus. `once` runs before the tile loop, and the first tile undoes it. `each_row` runs immediately before the row's first tile, and every tile in the row undoes it.

`each_tile` was correct by accident of ordering: reset to a baseline, then focus from it.

## The fix

`_tile_objective_position` separates two things that were one attribute:

- **where the objective was when the run started** — what `_restore` puts back
- **where tiles should be acquired** — what the reset targets

They're the same value until a sweep succeeds. `_autofocus_if_mode` updates the second after a successful sweep; `_acquire_tile` resets to it.

No ordering changes, and all four modes come out right:

| mode | behaviour |
|---|---|
| `none` | never updated — every tile at the run's start, unchanged |
| `once` | updated once — every tile at the found focus |
| `each_row` | updated per row — the row's tiles at that row's focus |
| `each_tile` | updated per tile, and each sweep now begins from the previous tile's answer rather than walking back to the start |

## Mosaic metadata

`run_and_stitch` claimed "every tile is taken at the starting objective position". This makes that false, so the mosaic now records the position tiles were actually acquired at.

For `none` and `once` there's still one position and it's now the right one. For the per-row and per-tile modes there's no single answer — the last is recorded, which is true of one tile and close to the rest, where the run's start would be true of none. The docstring says this rather than continuing to claim otherwise.

The parameters sidecar needs nothing: it records what was *requested*, not what happened, and is written before the loop deliberately.

## Testing

88 tests pass in `tests/fm/test_acquisition.py` — the 82 that existed plus 6 new. The new ones are the measurement above made permanent: a stubbed sweep and a spy on `acquire_image`, no hardware.

| mutation | failures |
|---|---|
| restore the old reset (the bug) | exactly `once` and `each_row`, while `none` and `each_tile` keep passing — the bug's own signature |
| forget to record what the sweep found | those two, plus the mosaic-metadata test |

## Still open

[FIB-417](https://linear.app/fibsemos/issue/FIB-417/choose-the-objective-position-an-overview-starts-from) — which objective position an overview *should* start from. This fix makes that matter less for the autofocus modes, but it is still the whole answer for `none`, which is what the workaround told people to use. [FIB-532](https://linear.app/fibsemos/issue/FIB-532/set-up-and-acquire-several-overviews-in-one-unattended-run) can't be built without settling it.

On hardware, the check is that `once` now produces a uniformly sharp overview where it previously produced one focused at wherever the objective happened to be.