### PR TITLE
[ui] Extract one control builder for the metadata-driven forms (FIB-526, step 1)

### DIFF
--- a/fibsem/milling/patterning/patterns2.py
+++ b/fibsem/milling/patterning/patterns2.py
@@ -19,6 +19,7 @@ from fibsem.structures import (
     FibsemPolygonSettings,
     Point,
     TFibsemPatternSettings,
+    field_meta,
     get_fields_with_metadata,
 )
 from fibsem.milling.properties import (DEFAULT_DISTANCE_METADATA,
@@ -35,17 +36,26 @@ TPattern = TypeVar("TPattern", bound="BasePattern")
 @dataclass
 class BasePattern(ABC, Generic[TFibsemPatternSettings]):
     name: ClassVar[str] = field(init=False)
-    point: Point = field(default_factory=Point, 
-                         metadata={
-                            "label": "Point",
-                            "type": Point,
-                            **DEFAULT_DISTANCE_METADATA,
-                            "minimum": -1000.0,
-                            "maximum": 1000.0,
-                            "tooltip": "Point coordinates for the milling pattern.",
-                            "advanced" : True,
-                         })
-    shapes: Optional[List[TFibsemPatternSettings]] = field(default=None, init=False)
+    # `type` has to be Point, and has to win over the base: the form dispatches
+    # the two-spinbox row on it. The dict literal this replaces declared
+    # `"type": Point` *before* spreading DEFAULT_DISTANCE_METADATA, so the
+    # spread's `float` silently won and the declaration was a lie -- which is
+    # why the row had to be special-cased on the field being named "point".
+    point: Point = field(default_factory=Point,
+                         metadata=field_meta(
+                            DEFAULT_DISTANCE_METADATA,
+                            label="Point",
+                            type=Point,
+                            minimum=-1000.0,
+                            maximum=1000.0,
+                            tooltip="Point coordinates for the milling pattern.",
+                            advanced=True,
+                         ))
+    # Computed by define(), never edited: the form skips it on `hidden` rather
+    # than on a hardcoded field name, so a plugin can hide its own fields too.
+    shapes: Optional[List[TFibsemPatternSettings]] = field(
+        default=None, init=False, metadata=field_meta(hidden=True)
+    )
 
     @abstractmethod
     def define(self) -> List[TFibsemPatternSettings]:

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -515,17 +515,6 @@ def show_context_menu(
     selected = menu.show_at_cursor()
     return selected.label if selected else None
 
-@dataclass
-class FormRow:
-    """Shared form-row descriptor for metadata-driven settings widgets (milling, pattern, etc.)."""
-    label: QLabel
-    control: QWidget
-    field: str
-    advanced: bool
-    scale: Optional[float]      # effective scale (base_scale ** dims); None = no scaling
-    mfr: Optional[str] = None   # manufacturer filter; None = show for all
-
-
 class TitledPanel(QWidget):
     """A styled panel with a dark header row (title label + optional widgets) and a collapsible content area.
 

--- a/fibsem/ui/widgets/form_builder.py
+++ b/fibsem/ui/widgets/form_builder.py
@@ -1,0 +1,273 @@
+"""One control builder for every metadata-driven config form.
+
+The pattern, strategy and milling-settings widgets each carried their own copy of
+the same loop: map field metadata to a control, then a matching `isinstance`
+ladder in `get_*` to read the value back and a third in `set_*` to push one in.
+Three ladders per form, four forms, and they had already drifted -- the strategy
+form honoured `format_fn` on comboboxes and the pattern form did not; the pattern
+form could resolve `items="dynamic"` against the microscope and the strategy form
+could not.
+
+`build_control` returns the control *together with* the adapters that move values
+through it, so a form never inspects a control's type. Adding a control type is
+one branch here rather than four branches in three places each.
+
+Deliberately Qt-only: no microscope, no pattern or strategy imports. `items:
+"dynamic"` needs the microscope, so the caller passes a resolver rather than the
+builder reaching for one -- which is also what makes this testable without
+hardware.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field as dataclass_field
+from typing import Any, Callable, Optional, Sequence, Tuple
+
+from PyQt5.QtWidgets import QCheckBox, QHBoxLayout, QWidget
+
+from fibsem import utils
+from fibsem.structures import Point
+from fibsem.ui.widgets.custom_widgets import (
+    IntegerValueSpinBox,
+    QFilePathLineEdit,
+    QLineEdit,
+    ValueComboBox,
+    ValueSpinBox,
+)
+
+# Fallback spinbox bounds, used when a field declares no minimum/maximum.
+#
+# `ValueSpinBox` itself falls back to (0.0, 1e6), which is wrong for any field
+# that can go negative -- and a floor of zero does not error, it silently clamps.
+# The forms that had their own hardcoded ranges keep them by passing this
+# explicitly; the milling forms keep the spinbox defaults by passing None.
+DEFAULT_FLOAT_RANGE = (-1e10, 1e10)
+DEFAULT_INT_RANGE = (-2147483648, 2147483647)
+
+# A point is an offset from the image centre, so it is signed by definition and
+# must never inherit a floor of zero. The pattern form carried this same pair as
+# a literal default before the row was generalised.
+POINT_FALLBACK_RANGE = (-1000.0, 1000.0)
+
+
+@dataclass
+class Control:
+    """A built form control plus the adapters that move values through it.
+
+    `widget` is what goes into the form layout and what gets shown or hidden --
+    for a compound control it is the container, so visibility stays one call.
+    `inputs` is the actual input widgets, which is what `blockSignals` has to
+    reach; they differ only for compound controls.
+    """
+
+    widget: QWidget
+    read: Callable[[], Any]
+    write: Callable[[Any], None]
+    signals: Tuple[Any, ...] = ()
+    inputs: Tuple[QWidget, ...] = dataclass_field(default_factory=tuple)
+    editable: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.inputs:
+            self.inputs = (self.widget,)
+
+    def connect(self, slot: Callable[[], None]) -> None:
+        """Wire every signal that means "the user edited this"."""
+        for signal in self.signals:
+            signal.connect(slot)
+
+    def set_blocked(self, blocked: bool) -> None:
+        """Block or unblock the inputs, so a programmatic write is not echoed back."""
+        for widget in self.inputs:
+            widget.blockSignals(blocked)
+
+
+def effective_scale(metadata: dict) -> Optional[float]:
+    """The scale actually applied to a value, raised to `dimensions` if declared.
+
+    An area declares `scale=1e6, dimensions=2` because m² -> µm² is 1e12, not
+    1e6. The display *suffix* is still built from the base scale, so that a
+    cubic rate reads "mm³/A/s" rather than being prefixed by 1e9.
+    """
+    base = metadata.get("scale")
+    dims = metadata.get("dimensions")
+    return (base ** dims) if (base and dims) else base
+
+
+def display_suffix(metadata: dict) -> str:
+    """The spinbox suffix, prefixed for the scale (1e6 + "m" -> "µm").
+
+    Empty when the field declares no unit, even if it declares a scale. The
+    milling forms used to render a bare prefix -- a lone "µ" with nothing after
+    it -- for a scaled field with no unit.
+    """
+    unit = metadata.get("unit")
+    if not unit:
+        return ""
+    base = metadata.get("scale")
+    return utils._get_display_unit(base, unit) if base else unit
+
+
+def _combo(items: Sequence[Any], value: Any, metadata: dict) -> Control:
+    control = ValueComboBox(
+        list(items), value, metadata.get("unit"), format_fn=metadata.get("format_fn")
+    )
+
+    def read() -> Any:
+        # A combo with nothing selected returns None; writing that onto the
+        # config would replace a real value with nothing.
+        return control.value()
+
+    return Control(
+        widget=control,
+        read=read,
+        write=control.set_value,
+        signals=(control.currentIndexChanged,),
+    )
+
+
+def _point(value: Point, metadata: dict, fallback: Optional[Tuple[float, float]]) -> Control:
+    """Two spinboxes for a Point-typed field.
+
+    Dispatched on the declared `type`, not on the field being called "point", so
+    a plugin pattern with its own Point field gets the same row.
+    """
+    scale = effective_scale(metadata) or 1.0
+    suffix = display_suffix(metadata)
+    minimum, maximum = _bounds(metadata, fallback or POINT_FALLBACK_RANGE)
+
+    def spinbox(initial: float) -> ValueSpinBox:
+        box = ValueSpinBox(
+            suffix, minimum, maximum, metadata.get("step"), metadata.get("decimals")
+        )
+        box.setValue(initial * scale)
+        return box
+
+    point = value if isinstance(value, Point) else Point()
+    x_control = spinbox(point.x)
+    y_control = spinbox(point.y)
+
+    container = QWidget()
+    layout = QHBoxLayout(container)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(4)
+    layout.addWidget(x_control)
+    layout.addWidget(y_control)
+
+    def read() -> Point:
+        return Point(x=x_control.value() / scale, y=y_control.value() / scale)
+
+    def write(new: Any) -> None:
+        new = new if isinstance(new, Point) else Point()
+        x_control.setValue(new.x * scale)
+        y_control.setValue(new.y * scale)
+
+    return Control(
+        widget=container,
+        read=read,
+        write=write,
+        signals=(x_control.valueChanged, y_control.valueChanged),
+        inputs=(x_control, y_control),
+    )
+
+
+def _bounds(
+    metadata: dict, fallback: Optional[Tuple[float, float]]
+) -> Tuple[Optional[float], Optional[float]]:
+    """Declared bounds, falling back to the form's own defaults when unset."""
+    minimum = metadata.get("minimum")
+    maximum = metadata.get("maximum")
+    if fallback is not None:
+        minimum = fallback[0] if minimum is None else minimum
+        maximum = fallback[1] if maximum is None else maximum
+    return minimum, maximum
+
+
+def build_control(
+    metadata: dict,
+    value: Any,
+    *,
+    dynamic_items: Optional[Callable[[str], Sequence[Any]]] = None,
+    float_range: Optional[Tuple[float, float]] = None,
+    int_range: Optional[Tuple[int, int]] = None,
+) -> Optional[Control]:
+    """Build the control for one field, or None if nothing here can render it.
+
+    `metadata` is the merged view from `get_fields_with_metadata`, so every key
+    is present. `dynamic_items` resolves `items: "dynamic"` against the
+    microscope; without it such a field falls back to its current value alone.
+
+    `float_range` / `int_range` supply bounds for fields that declare none.
+    Leave them None to keep the spinbox classes' own defaults.
+    """
+    items = metadata.get("items")
+    type_ = metadata.get("type")
+
+    if items == "dynamic":
+        resolved = dynamic_items(metadata["microscope_parameter"]) if dynamic_items else None
+        return _combo(resolved if resolved else [value], value, metadata)
+
+    if items:
+        return _combo(items, value, metadata)
+
+    if type_ is Point or isinstance(value, Point):
+        return _point(value, metadata, float_range)
+
+    if type_ is str:
+        control = QFilePathLineEdit() if metadata.get("filepath") else QLineEdit()
+        control.setText(str(value) if value else "")
+        return Control(
+            widget=control,
+            read=control.text,
+            write=lambda new: control.setText(str(new) if new else ""),
+            signals=(control.editingFinished,),
+        )
+
+    # Before int: bool is a subclass of int, so an isinstance check for int
+    # would swallow every checkbox field.
+    if type_ is bool or isinstance(value, bool):
+        control = QCheckBox()
+        control.setChecked(bool(value))
+        return Control(
+            widget=control,
+            read=control.isChecked,
+            write=lambda new: control.setChecked(bool(new)),
+            signals=(control.toggled,),
+        )
+
+    if type_ is int:
+        scale = int(round(effective_scale(metadata) or 1))
+        minimum, maximum = _bounds(metadata, int_range)
+        # An integer spinbox stepping by less than its own scale cannot reach
+        # every representable value, so the step is floored at the scale.
+        step = max(metadata.get("step") or 1, scale)
+        control = IntegerValueSpinBox(display_suffix(metadata), minimum, maximum, step)
+        control.setValue(int(round(value * scale)))
+        return Control(
+            widget=control,
+            read=lambda: int(round(control.value() / scale)) if scale else control.value(),
+            write=lambda new: control.setValue(int(round(new * scale))),
+            signals=(control.valueChanged,),
+        )
+
+    if type_ is float or isinstance(value, (float, int)):
+        scale = effective_scale(metadata) or 1
+        minimum, maximum = _bounds(metadata, float_range)
+        control = ValueSpinBox(
+            display_suffix(metadata),
+            minimum,
+            maximum,
+            metadata.get("step"),
+            metadata.get("decimals"),
+        )
+        control.setValue(value * scale)
+        return Control(
+            widget=control,
+            read=lambda: control.value() / scale if scale else control.value(),
+            write=lambda new: control.setValue(new * scale),
+            signals=(control.valueChanged,),
+        )
+
+    logging.warning("No control for field of type %r (value %r)", type_, type(value))
+    return None

--- a/fibsem/ui/widgets/milling_settings_widget.py
+++ b/fibsem/ui/widgets/milling_settings_widget.py
@@ -9,10 +9,22 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from fibsem import utils
+from dataclasses import dataclass
+
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, FibsemMillingSettings
-from fibsem.ui.widgets.custom_widgets import FormRow, ValueComboBox, ValueSpinBox
+from fibsem.ui.widgets.form_builder import Control, build_control
+
+
+@dataclass
+class _Row:
+    """One built form row. `mfr` is this form's own twist: a field declared for
+    one manufacturer is hidden on the others."""
+    label: QLabel
+    control: Control
+    field: str
+    advanced: bool
+    mfr: Optional[str]
 
 _META = FibsemMillingSettings().field_metadata
 
@@ -35,7 +47,7 @@ class FibsemMillingSettingsWidget(QWidget):
         self._manufacturer: str = microscope.manufacturer
         self._settings = settings
         self._advanced_visible = False
-        self._rows: List[FormRow] = []
+        self._rows: List[_Row] = []
         self._setup_ui()
         self._connect_signals()
         self._update_visibility()
@@ -50,61 +62,40 @@ class FibsemMillingSettingsWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         for field_name, m in _META.items():
-            if field_name in _HIDDEN_FIELDS or m.get("hidden", False):
+            if m.get("hidden", False):
                 continue
 
-            value = getattr(self._settings, field_name)
-            mfr = m.get("manufacturer")
-            advanced = m.get("advanced", False)
-            items = m.get("items")
+            control = build_control(
+                m,
+                getattr(self._settings, field_name),
+                dynamic_items=self._dynamic_items,
+            )
+            if control is None:
+                continue
 
-            # Compute effective scale (applies dimensions for cubic/area units)
-            base_scale = m.get("scale")
-            dims = m.get("dimensions")
-            effective_scale = (base_scale ** dims) if (base_scale and dims) else base_scale
-
-            # Create control
-            if items == "dynamic":
-                cached = self.microscope.get_available_values_cached(m["microscope_parameter"], BeamType.ION)
-                items_list = cached if cached else [value]
-                control = ValueComboBox(items_list, value, m.get("unit"))
-                attr_name = f"{field_name}_combo"
-            elif items:
-                control = ValueComboBox(items, value, m.get("unit"))
-                attr_name = f"{field_name}_combo"
-            elif isinstance(value, (float, int)):
-                # Display suffix uses base scale (not effective) for correct SI prefix
-                suffix = utils._get_display_unit(base_scale, m.get("unit")) if base_scale else (m.get("unit") or "")
-                control = ValueSpinBox(suffix, m.get("minimum"), m.get("maximum"), m.get("step"), m.get("decimals"))
-                attr_name = f"{field_name}_spinbox"
-            else:
-                continue  # unsupported type
-
-            label_text = m.get("label") or field_name.replace("_", " ").title()
-            label = QLabel(label_text)
+            label = QLabel(m.get("label") or field_name.replace("_", " ").title())
             if m.get("tooltip"):
                 label.setToolTip(m["tooltip"])
-                control.setToolTip(m["tooltip"])
+                control.widget.setToolTip(m["tooltip"])
 
-            layout.addRow(label, control)
-            setattr(self, attr_name, control)
-            setattr(self, f"{field_name}_label", label)
+            layout.addRow(label, control.widget)
+            self._rows.append(
+                _Row(
+                    label=label,
+                    control=control,
+                    field=field_name,
+                    advanced=m.get("advanced", False),
+                    mfr=m.get("manufacturer"),
+                )
+            )
 
-            self._rows.append(FormRow(
-                label=label,
-                control=control,
-                field=field_name,
-                mfr=mfr,
-                advanced=advanced,
-                scale=effective_scale,
-            ))
+    def _dynamic_items(self, parameter: str):
+        """Resolve an `items: "dynamic"` field against the microscope."""
+        return self.microscope.get_available_values_cached(parameter, BeamType.ION)
 
     def _connect_signals(self) -> None:
         for row in self._rows:
-            if isinstance(row.control, ValueComboBox):
-                row.control.currentIndexChanged.connect(self._on_changed)
-            elif isinstance(row.control, ValueSpinBox):
-                row.control.valueChanged.connect(self._on_changed)
+            row.control.connect(self._on_changed)
 
     def _on_changed(self) -> None:
         self.settings_changed.emit(self.get_settings())
@@ -118,7 +109,7 @@ class FibsemMillingSettingsWidget(QWidget):
             mfr_ok = (row.mfr is None) or (row.mfr == self._manufacturer)
             adv_ok = (not row.advanced) or self._advanced_visible
             row.label.setVisible(mfr_ok and adv_ok)
-            row.control.setVisible(mfr_ok and adv_ok)
+            row.control.widget.setVisible(mfr_ok and adv_ok)
 
     def set_manufacturer(self, manufacturer: Optional[str]) -> None:
         self._manufacturer = manufacturer or ""
@@ -135,17 +126,18 @@ class FibsemMillingSettingsWidget(QWidget):
     def get_settings(self) -> FibsemMillingSettings:
         kwargs: Dict[str, object] = {}
 
-        # Pass through hidden fields unchanged
+        # Hidden fields have no control, so they pass through untouched rather
+        # than reverting to the dataclass default.
         for field_name in _HIDDEN_FIELDS:
             kwargs[field_name] = getattr(self._settings, field_name)
 
         for row in self._rows:
-            if isinstance(row.control, ValueComboBox):
-                data = row.control.value()
-                kwargs[row.field] = data if data is not None else getattr(self._settings, row.field)
-            elif isinstance(row.control, ValueSpinBox):
-                val = row.control.value()
-                kwargs[row.field] = val / row.scale if row.scale else val
+            value = row.control.read()
+            # A combobox with nothing selected reads None; keep what we had
+            # rather than handing the constructor a hole.
+            kwargs[row.field] = (
+                value if value is not None else getattr(self._settings, row.field)
+            )
 
         return FibsemMillingSettings(**kwargs)
 
@@ -153,14 +145,10 @@ class FibsemMillingSettingsWidget(QWidget):
         self._settings = settings
 
         for row in self._rows:
-            row.control.blockSignals(True)
-
-        for row in self._rows:
-            value = getattr(settings, row.field)
-            if isinstance(row.control, ValueComboBox):
-                row.control.set_value(value)
-            elif isinstance(row.control, ValueSpinBox):
-                row.control.setValue(value * row.scale if row.scale else value)
-
-        for row in self._rows:
-            row.control.blockSignals(False)
+            row.control.set_blocked(True)
+        try:
+            for row in self._rows:
+                row.control.write(getattr(settings, row.field))
+        finally:
+            for row in self._rows:
+                row.control.set_blocked(False)

--- a/fibsem/ui/widgets/pattern_settings_widget.py
+++ b/fibsem/ui/widgets/pattern_settings_widget.py
@@ -3,47 +3,31 @@ from __future__ import annotations
 import logging
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
-    QCheckBox,
     QFormLayout,
-    QHBoxLayout,
     QLabel,
     QVBoxLayout,
     QWidget,
 )
 
-from fibsem import utils
 from fibsem.microscope import FibsemMicroscope
-from fibsem.milling.base import FibsemMillingStage
 from fibsem.milling.patterning import get_pattern, get_pattern_names
 from fibsem.milling.patterning.patterns2 import BasePattern
-from fibsem.structures import BeamType, Point
-from fibsem.ui.widgets.custom_widgets import (
-    FormRow,
-    QLineEdit,
-    QFilePathLineEdit,
-    ValueComboBox,
-    ValueSpinBox,
-    IntegerValueSpinBox,
-)
-
-_HIDDEN_FIELDS = {"shapes"}
-
-_POINT_SCALE = 1e6      # µm display for x/y
-_POINT_SUFFIX = "µm"
+from fibsem.structures import BeamType
+from fibsem.ui.widgets.custom_widgets import ValueComboBox
+from fibsem.ui.widgets.form_builder import Control, build_control
 
 
 @dataclass
-class _PointRow:
-    """Special form row for the Point field (two spinboxes: x and y)."""
+class _Row:
+    """One built form row: the label, the control, and whether it is advanced."""
     label: QLabel
-    x_control: ValueSpinBox
-    y_control: ValueSpinBox
-    field: str = "point"
-    advanced: bool = False
+    control: Control
+    field: str
+    advanced: bool
 
 
 class FibsemPatternSettingsWidget(QWidget):
@@ -64,7 +48,7 @@ class FibsemPatternSettingsWidget(QWidget):
         self.microscope = microscope
         self._pattern = pattern
         self._advanced_visible = False
-        self._rows: List[Union[FormRow, _PointRow]] = []
+        self._rows: List[_Row] = []
 
         self._setup_ui()
         self._connect_signals()
@@ -108,142 +92,40 @@ class FibsemPatternSettingsWidget(QWidget):
             self._fields_form.removeRow(0)
 
         for field_name, m in pattern.field_metadata.items():
-            if field_name in _HIDDEN_FIELDS or m.get("hidden", False):
+            if m.get("hidden", False):
                 continue
 
-            advanced = m.get("advanced", False)
-            label_text = m.get("label") or field_name.replace("_", " ").title()
-            tooltip = m.get("tooltip", "")
-
-            # --- Point: two spinboxes side-by-side ---
-            if field_name == "point":
-                point: Point = getattr(pattern, "point")
-                x_ctrl = ValueSpinBox(
-                    suffix=_POINT_SUFFIX,
-                    minimum=m.get("minimum", -1000.0),
-                    maximum=m.get("maximum", 1000.0),
-                    step=m.get("step", 0.01),
-                    decimals=m.get("decimals", 2),
-                )
-                x_ctrl.setValue(point.x * _POINT_SCALE)
-                y_ctrl = ValueSpinBox(
-                    suffix=_POINT_SUFFIX,
-                    minimum=m.get("minimum", -1000.0),
-                    maximum=m.get("maximum", 1000.0),
-                    step=m.get("step", 0.01),
-                    decimals=m.get("decimals", 2),
-                )
-                y_ctrl.setValue(point.y * _POINT_SCALE)
-
-                point_widget = QWidget()
-                point_layout = QHBoxLayout(point_widget)
-                point_layout.setContentsMargins(0, 0, 0, 0)
-                point_layout.setSpacing(4)
-                point_layout.addWidget(x_ctrl)
-                point_layout.addWidget(y_ctrl)
-
-                label = QLabel(label_text)
-                if tooltip:
-                    label.setToolTip(tooltip)
-                    point_widget.setToolTip(tooltip)
-                self._fields_form.addRow(label, point_widget)
-
-                row = _PointRow(label=label, x_control=x_ctrl, y_control=y_ctrl, advanced=advanced)
-                x_ctrl.valueChanged.connect(self._on_changed)
-                y_ctrl.valueChanged.connect(self._on_changed)
-                self._rows.append(row)
-                continue
-
-            # --- All other fields ---
-            value = getattr(pattern, field_name)
-            items = m.get("items")
-            type_ = m.get("type")
-            base_scale = m.get("scale")
-            dims = m.get("dimensions")
-            effective_scale = (base_scale ** dims) if (base_scale and dims) else base_scale
-
-            if effective_scale is None:
-                effective_scale = 1
-
-            if items == "dynamic":
-                cached = self.microscope.get_available_values_cached(
-                    m["microscope_parameter"], BeamType.ION
-                )
-                items_list = cached if cached else [value]
-                control = ValueComboBox(items_list, value, m.get("unit"))
-            elif items:
-                control = ValueComboBox(items, value, m.get("unit"))
-            elif type_ is str:
-                if m.get("filepath"):
-                    control = QFilePathLineEdit()
-                else:
-                    control = QLineEdit()
-                control.setText(str(value) if value else "")
-            elif type_ is bool or isinstance(value, bool):
-                control = QCheckBox()
-                control.setChecked(bool(value))
-            elif type_ is int:
-                effective_scale = int(round(effective_scale))
-                suffix = (
-                    utils._get_display_unit(base_scale, m.get("unit"))
-                    if base_scale
-                    else (m.get("unit") or "")
-                )
-                # Ensure integer types don't have a step size under the effective scale or 1
-                step = max(m.get("step", 1), effective_scale)
-                control = IntegerValueSpinBox(
-                    suffix,
-                    m.get("minimum"),
-                    m.get("maximum"),
-                    step,
-                )
-                control.setValue(int(round(value * effective_scale)))
-            elif isinstance(value, (float, int)) or type_ is float:
-                suffix = (
-                    utils._get_display_unit(base_scale, m.get("unit"))
-                    if base_scale
-                    else (m.get("unit") or "")
-                )
-                control = ValueSpinBox(
-                    suffix,
-                    m.get("minimum"),
-                    m.get("maximum"),
-                    m.get("step"),
-                    m.get("decimals"),
-                )
-                control.setValue(value * effective_scale)
-            else:
+            control = build_control(
+                m,
+                getattr(pattern, field_name),
+                dynamic_items=self._dynamic_items,
+            )
+            if control is None:
                 logging.warning("Control for '%s' is unsupported", field_name)
-                continue  # unsupported type
+                continue
 
-            label = QLabel(label_text)
+            label = QLabel(m.get("label") or field_name.replace("_", " ").title())
+            tooltip = m.get("tooltip", "")
             if tooltip:
                 label.setToolTip(tooltip)
-                control.setToolTip(tooltip)
-            self._fields_form.addRow(label, control)
+                control.widget.setToolTip(tooltip)
 
-            # Connect signal
-            if isinstance(control, ValueComboBox):
-                control.currentIndexChanged.connect(self._on_changed)
-            elif isinstance(control, (ValueSpinBox, IntegerValueSpinBox)):
-                control.valueChanged.connect(self._on_changed)
-            elif isinstance(control, QCheckBox):
-                control.toggled.connect(self._on_changed)
-            elif isinstance(control, QFilePathLineEdit):
-                control.editingFinished.connect(self._on_changed)
-            else:
-                raise TypeError(
-                    f"Unsupported control type '{type(control)}' in FibsemPatternSettingsWidget"
+            self._fields_form.addRow(label, control.widget)
+            control.connect(self._on_changed)
+            self._rows.append(
+                _Row(
+                    label=label,
+                    control=control,
+                    field=field_name,
+                    advanced=m.get("advanced", False),
                 )
-            self._rows.append(FormRow(
-                label=label,
-                control=control,
-                field=field_name,
-                advanced=advanced,
-                scale=effective_scale,
-            ))
+            )
 
         self._update_visibility()
+
+    def _dynamic_items(self, parameter: str):
+        """Resolve an `items: "dynamic"` field against the microscope."""
+        return self.microscope.get_available_values_cached(parameter, BeamType.ION)
 
     # ------------------------------------------------------------------
     # Slots
@@ -268,13 +150,8 @@ class FibsemPatternSettingsWidget(QWidget):
     def _update_visibility(self) -> None:
         for row in self._rows:
             adv_ok = (not row.advanced) or self._advanced_visible
-            if isinstance(row, _PointRow):
-                row.label.setVisible(adv_ok)
-                row.x_control.setVisible(adv_ok)
-                row.y_control.setVisible(adv_ok)
-            else:
-                row.label.setVisible(adv_ok)
-                row.control.setVisible(adv_ok)
+            row.label.setVisible(adv_ok)
+            row.control.widget.setVisible(adv_ok)
 
     def set_advanced_visible(self, show: bool) -> None:
         self._advanced_visible = show
@@ -287,32 +164,11 @@ class FibsemPatternSettingsWidget(QWidget):
     def get_pattern(self) -> BasePattern:
         pattern = deepcopy(self._pattern)
         for row in self._rows:
-            if isinstance(row, _PointRow):
-                x = row.x_control.value() / _POINT_SCALE
-                y = row.y_control.value() / _POINT_SCALE
-                pattern.point = Point(x=x, y=y)
-            elif isinstance(row.control, ValueComboBox):
-                data = row.control.value()
-                if data is not None:
-                    setattr(pattern, row.field, data)
-            elif isinstance(row.control, ValueSpinBox):
-                val = row.control.value()
-                setattr(pattern, row.field, val / row.scale if row.scale else val)
-            elif isinstance(row.control, IntegerValueSpinBox):
-                val = row.control.value()
-                setattr(
-                    pattern,
-                    row.field,
-                    int(round(val / row.scale if row.scale else val)),
-                )
-            elif isinstance(row.control, QCheckBox):
-                setattr(pattern, row.field, row.control.isChecked())
-            elif isinstance(row.control, QFilePathLineEdit):
-                setattr(pattern, row.field, row.control.text())
-            else:
-                raise TypeError(
-                    f"Unsupported control type '{type(row.control)}' in FibsemPatternSettingsWidget"
-                )
+            value = row.control.read()
+            # A combobox with nothing selected reads None; writing that would
+            # replace a real setting with nothing.
+            if value is not None:
+                setattr(pattern, row.field, value)
         return pattern
 
     def set_pattern(self, pattern: BasePattern) -> None:
@@ -326,37 +182,14 @@ class FibsemPatternSettingsWidget(QWidget):
             self._build_controls(pattern)
             return  # _build_controls already reads values from pattern
 
-        # Same type — just update control values
+        # Same type — just update control values. Every control is blocked
+        # before any is written, so a mid-write signal cannot read a form that
+        # is half updated.
         for row in self._rows:
-            if isinstance(row, _PointRow):
-                row.x_control.blockSignals(True)
-                row.y_control.blockSignals(True)
-                row.x_control.setValue(pattern.point.x * _POINT_SCALE)
-                row.y_control.setValue(pattern.point.y * _POINT_SCALE)
-                row.x_control.blockSignals(False)
-                row.y_control.blockSignals(False)
-            else:
-                row.control.blockSignals(True)
-        for row in self._rows:
-            if isinstance(row, _PointRow):
-                continue
-            value = getattr(pattern, row.field)
-            if isinstance(row.control, ValueComboBox):
-                row.control.set_value(value)
-            elif isinstance(row.control, ValueSpinBox):
-                row.control.setValue(value * row.scale if row.scale else value)
-            elif isinstance(row.control, IntegerValueSpinBox):
-                row.control.setValue(
-                    int(round(value * row.scale if row.scale else value))
-                )
-            elif isinstance(row.control, QCheckBox):
-                row.control.setChecked(bool(value))
-            elif isinstance(row.control, QFilePathLineEdit):
-                row.control.setText(str(value) if value else "")
-            else:
-                raise TypeError(
-                    f"Unsupported control type '{type(row.control)}' in FibsemPatternSettingsWidget"
-                )
-        for row in self._rows:
-            if not isinstance(row, _PointRow):
-                row.control.blockSignals(False)
+            row.control.set_blocked(True)
+        try:
+            for row in self._rows:
+                row.control.write(getattr(pattern, row.field))
+        finally:
+            for row in self._rows:
+                row.control.set_blocked(False)

--- a/fibsem/ui/widgets/strategy_settings_widget.py
+++ b/fibsem/ui/widgets/strategy_settings_widget.py
@@ -2,31 +2,33 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any, List, Optional
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
-    QCheckBox,
     QFormLayout,
     QLabel,
     QVBoxLayout,
     QWidget,
 )
 
-from fibsem import utils
 from fibsem.milling.base import MillingStrategy, get_strategy
 from fibsem.milling.strategy import get_strategy_names
-from fibsem.ui.widgets.custom_widgets import (
-    FormRow,
-    QLineEdit,
-    QFilePathLineEdit,
-    ValueComboBox,
-    ValueSpinBox,
-    IntegerValueSpinBox,
-)
+from fibsem.ui.widgets.custom_widgets import ValueComboBox
+from fibsem.ui.widgets.form_builder import Control, build_control
 from fibsem.ui.tokens import (
     NEUTRAL_700,
 )
+
+
+@dataclass
+class _Row:
+    """One built form row: the label, the control, and whether it is advanced."""
+    label: QLabel
+    control: Control
+    field: str
+    advanced: bool
 
 
 class FibsemStrategySettingsWidget(QWidget):
@@ -46,7 +48,7 @@ class FibsemStrategySettingsWidget(QWidget):
         super().__init__(parent)
         self._strategy = strategy
         self._advanced_visible = False
-        self._rows: List[FormRow] = []
+        self._rows: List[_Row] = []
 
         self._setup_ui()
         self._connect_signals()
@@ -114,102 +116,29 @@ class FibsemStrategySettingsWidget(QWidget):
         while self._config_form.rowCount():
             self._config_form.removeRow(0)
 
-        meta = strategy.config.field_metadata
-        hidden_fields = {name for name, m in meta.items() if m.get("hidden", False)}
-
-        for field_name, m in meta.items():
-            if field_name in hidden_fields or m.get("hidden", False):
+        for field_name, m in strategy.config.field_metadata.items():
+            if m.get("hidden", False):
                 continue
 
-            value = getattr(strategy.config, field_name)
-            advanced = m.get("advanced", False)
-            items = m.get("items")
-            type_ = m.get("type")
-            base_scale = m.get("scale")
-            dims = m.get("dimensions")
-            effective_scale = (
-                (base_scale**dims) if (base_scale and dims) else base_scale
-            )
-
-            if effective_scale is None:
-                effective_scale = 1
-
-            if items:
-                control = ValueComboBox(
-                    items, value, m.get("unit"), format_fn=m.get("format_fn")
-                )
-            elif type_ is str:
-                if m.get("filepath"):
-                    control = QFilePathLineEdit()
-                else:
-                    control = QLineEdit()
-                control.setText(str(value) if value else "")
-            elif type_ is bool or isinstance(value, bool):
-                control = QCheckBox()
-                control.setChecked(bool(value))
-            elif type_ is int:
-                effective_scale = int(round(effective_scale))
-                suffix = (
-                    utils._get_display_unit(base_scale, m.get("unit"))
-                    if base_scale
-                    else (m.get("unit") or "")
-                )
-                # Ensure integer types don't have a step size under the effective scale or 1
-                step = max(m.get("step", 1), effective_scale)
-                control = IntegerValueSpinBox(
-                    suffix,
-                    m.get("minimum"),
-                    m.get("maximum"),
-                    step,
-                )
-                control.setValue(int(round(value * effective_scale)))
-            elif isinstance(value, (float, int)) or type_ is float:
-                suffix = (
-                    utils._get_display_unit(base_scale, m.get("unit"))
-                    if base_scale
-                    else (m.get("unit") or "")
-                )
-                control = ValueSpinBox(
-                    suffix,
-                    m.get("minimum"),
-                    m.get("maximum"),
-                    m.get("step"),
-                    m.get("decimals"),
-                )
-                control.setValue(value * effective_scale)
-            else:
+            control = build_control(m, getattr(strategy.config, field_name))
+            if control is None:
                 logging.warning("Control for '%s' is unsupported", field_name)
-                continue  # unsupported type
+                continue
 
-            label_text = m.get("label") or field_name.replace("_", " ").title()
+            label = QLabel(m.get("label") or field_name.replace("_", " ").title())
             tooltip = m.get("tooltip", "")
-            label = QLabel(label_text)
             if tooltip:
                 label.setToolTip(tooltip)
-                control.setToolTip(tooltip)
+                control.widget.setToolTip(tooltip)
 
-            self._config_form.addRow(label, control)
-
-            if isinstance(control, ValueComboBox):
-                control.currentIndexChanged.connect(self._on_changed)
-            elif isinstance(control, (ValueSpinBox, IntegerValueSpinBox)):
-                control.valueChanged.connect(self._on_changed)
-            elif isinstance(control, QCheckBox):
-                control.toggled.connect(self._on_changed)
-            elif isinstance(control, QFilePathLineEdit):
-                control.editingFinished.connect(self._on_changed)
-            else:
-                raise TypeError(
-                    f"Unsupported control type '{type(control)}' in FibsemStrategySettingsWidget"
-                )
-
+            self._config_form.addRow(label, control.widget)
+            control.connect(self._on_changed)
             self._rows.append(
-                FormRow(
+                _Row(
                     label=label,
                     control=control,
                     field=field_name,
-                    advanced=advanced,
-                    scale=effective_scale,
+                    advanced=m.get("advanced", False),
                 )
             )
 
@@ -240,7 +169,7 @@ class FibsemStrategySettingsWidget(QWidget):
         for row in self._rows:
             adv_ok = (not row.advanced) or self._advanced_visible
             row.label.setVisible(adv_ok)
-            row.control.setVisible(adv_ok)
+            row.control.widget.setVisible(adv_ok)
 
     def set_advanced_visible(self, show: bool) -> None:
         self._advanced_visible = show
@@ -253,30 +182,11 @@ class FibsemStrategySettingsWidget(QWidget):
     def get_strategy(self) -> MillingStrategy[Any]:
         strategy = deepcopy(self._strategy)
         for row in self._rows:
-            if isinstance(row.control, ValueComboBox):
-                data = row.control.value()
-                if data is not None:
-                    setattr(strategy.config, row.field, data)
-            elif isinstance(row.control, ValueSpinBox):
-                val = row.control.value()
-                setattr(
-                    strategy.config, row.field, val / row.scale if row.scale else val
-                )
-            elif isinstance(row.control, IntegerValueSpinBox):
-                val = row.control.value()
-                setattr(
-                    strategy.config,
-                    row.field,
-                    int(round(val / row.scale if row.scale else val)),
-                )
-            elif isinstance(row.control, QCheckBox):
-                setattr(strategy.config, row.field, row.control.isChecked())
-            elif isinstance(row.control, QFilePathLineEdit):
-                setattr(strategy.config, row.field, row.control.text())
-            else:
-                raise TypeError(
-                    f"Unsupported control type '{type(row.control)}' in FibsemStrategySettingsWidget"
-                )
+            value = row.control.read()
+            # A combobox with nothing selected reads None; writing that would
+            # replace a real setting with nothing.
+            if value is not None:
+                setattr(strategy.config, row.field, value)
         return strategy
 
     def set_strategy(self, strategy: MillingStrategy[Any]) -> None:
@@ -288,25 +198,13 @@ class FibsemStrategySettingsWidget(QWidget):
             self._build_controls(strategy)
             return  # _build_controls reads values from strategy.config directly
 
+        # Every control is blocked before any is written, so a mid-write signal
+        # cannot read a form that is half updated.
         for row in self._rows:
-            row.control.blockSignals(True)
-        for row in self._rows:
-            value = getattr(strategy.config, row.field)
-            if isinstance(row.control, ValueComboBox):
-                row.control.set_value(value)
-            elif isinstance(row.control, ValueSpinBox):
-                row.control.setValue(value * row.scale if row.scale else value)
-            elif isinstance(row.control, IntegerValueSpinBox):
-                row.control.setValue(
-                    int(round(value * row.scale if row.scale else value))
-                )
-            elif isinstance(row.control, QCheckBox):
-                row.control.setChecked(bool(value))
-            elif isinstance(row.control, QFilePathLineEdit):
-                row.control.setText(str(value) if value else "")
-            else:
-                raise TypeError(
-                    f"Unsupported control type '{type(row.control)}' in FibsemStrategySettingsWidget"
-                )
-        for row in self._rows:
-            row.control.blockSignals(False)
+            row.control.set_blocked(True)
+        try:
+            for row in self._rows:
+                row.control.write(getattr(strategy.config, row.field))
+        finally:
+            for row in self._rows:
+                row.control.set_blocked(False)

--- a/tests/ui/test_form_builder.py
+++ b/tests/ui/test_form_builder.py
@@ -1,0 +1,219 @@
+"""The shared control builder: one branch per control type, for every form.
+
+The pattern, strategy and milling-settings widgets each carried their own copy
+of this dispatch, plus a matching `isinstance` ladder to read values back and a
+third to push them in. They had already drifted apart. These tests pin the
+behaviour the single builder now owns, and in particular the two places where it
+had to stop keying on field *names*.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from dataclasses import dataclass, field
+
+from PyQt5.QtWidgets import QCheckBox
+
+from fibsem.structures import Point, field_meta, get_fields_with_metadata
+from fibsem.ui.widgets.custom_widgets import (
+    IntegerValueSpinBox,
+    QFilePathLineEdit,
+    ValueComboBox,
+    ValueSpinBox,
+)
+from fibsem.ui.widgets.form_builder import build_control, display_suffix, effective_scale
+
+
+def meta(**kwargs) -> dict:
+    """Metadata as a form sees it -- merged, so every key is present."""
+
+    @dataclass
+    class Probe:
+        value: float = field(default=0.0, metadata=field_meta(**kwargs))
+
+    return get_fields_with_metadata(Probe)["value"]
+
+
+# --- the two de-hardcoded behaviours ------------------------------------------
+
+
+def test_a_point_field_is_dispatched_on_its_type_not_its_name(qapp):
+    """The compound row keys on `type is Point`, so any field can have one.
+
+    The pattern form used to test `field_name == "point"`, which meant a plugin
+    pattern with an equivalent field could not get the two-spinbox row no matter
+    what it declared. Nothing here is named "point".
+    """
+    control = build_control(meta(type=Point, scale=1e6, unit="m"), Point(x=1e-6, y=-2e-6))
+
+    spinboxes = control.widget.findChildren(ValueSpinBox)
+    assert len(spinboxes) == 2
+    assert (spinboxes[0].value(), spinboxes[1].value()) == (1.0, -2.0)
+
+    assert control.read() == Point(x=1e-6, y=-2e-6)
+
+
+def test_a_point_control_round_trips_through_its_own_scale(qapp):
+    """Scale comes from the metadata, not a module constant.
+
+    The old row hardcoded 1e6 and a "µm" suffix, so a Point declared in any
+    other unit would have rendered wrong.
+    """
+    control = build_control(meta(type=Point, scale=1e3, unit="m"), Point())
+    control.write(Point(x=0.25, y=-0.5))
+
+    spinboxes = control.widget.findChildren(ValueSpinBox)
+    assert (spinboxes[0].value(), spinboxes[1].value()) == (250.0, -500.0)
+    assert control.read() == Point(x=0.25, y=-0.5)
+
+
+def test_a_scaled_field_with_no_unit_gets_no_suffix():
+    """The milling forms used to render a bare SI prefix.
+
+    `_get_display_unit(1e6, "")` is "µ" -- a lone prefix with nothing after it,
+    which the spinbox then showed as " µ". The task form's own helper returned
+    "" for the same input, and it was the one that was right.
+    """
+    assert display_suffix(meta(scale=1e6)) == ""
+    assert display_suffix(meta(scale=1e6, unit="m")) == "μm"
+    assert display_suffix(meta(unit="m")) == "m"
+
+
+# --- scaling ------------------------------------------------------------------
+
+
+def test_dimensions_raise_the_scale_but_not_the_suffix():
+    """An area is m² -> µm², which is 1e12, but it still reads "µm²"."""
+    area = meta(scale=1e6, dimensions=2, unit="m²")
+
+    assert effective_scale(area) == 1e12
+    assert display_suffix(area) == "μm²"
+
+
+# --- one branch per control type, each round-tripping -------------------------
+
+
+@pytest.mark.parametrize(
+    "metadata, value, control_type, new_value",
+    [
+        (dict(type=bool), True, QCheckBox, False),
+        (dict(type=str), "abc", None, "xyz"),
+        (dict(type=str, filepath=True), "/tmp/a", QFilePathLineEdit, "/tmp/b"),
+        (dict(type=int), 3, IntegerValueSpinBox, 8),
+        (dict(type=float, minimum=-10.0), 1.5, ValueSpinBox, -2.5),
+        (dict(items=["a", "b"]), "a", ValueComboBox, "b"),
+    ],
+)
+def test_each_control_round_trips(qapp, metadata, value, control_type, new_value):
+    control = build_control(meta(**metadata), value)
+
+    if control_type is not None:
+        assert isinstance(control.widget, control_type)
+    assert control.read() == value
+
+    control.write(new_value)
+    assert control.read() == new_value
+
+
+def test_a_bool_is_a_checkbox_even_though_bool_subclasses_int(qapp):
+    """Ordering guard: an isinstance check for int would swallow every checkbox."""
+    assert isinstance(build_control(meta(), True).widget, QCheckBox)
+
+
+def test_an_int_field_steps_by_at_least_its_own_scale(qapp):
+    """A step below the scale cannot reach every representable value."""
+    control = build_control(meta(type=int, scale=1000, step=1), 2)
+
+    assert control.widget.singleStep() == 1000
+    assert control.read() == 2
+
+
+def test_declared_bounds_win_over_the_fallback(qapp):
+    control = build_control(meta(type=float, minimum=-5.0, maximum=5.0), 0.0, float_range=(-1e9, 1e9))
+
+    assert (control.widget.minimum(), control.widget.maximum()) == (-5.0, 5.0)
+
+
+def test_the_fallback_range_fills_in_undeclared_bounds(qapp):
+    """Why the fallback is a parameter rather than baked in.
+
+    `ValueSpinBox` defaults to (0.0, 1e6), which puts a floor of zero on any
+    field that never declared a minimum -- and clamping is silent. Each form
+    passes the bounds it already had, so a form's ranges do not change just
+    because the builder is now shared.
+    """
+    control = build_control(meta(type=float), 0.0, float_range=(-1e10, 1e10))
+
+    assert (control.widget.minimum(), control.widget.maximum()) == (-1e10, 1e10)
+
+
+def test_dynamic_items_are_resolved_through_the_caller(qapp):
+    """The builder never reaches for a microscope itself.
+
+    That is what keeps it importable and testable without hardware, and keeps
+    the microscope out of the strategy and task forms that have no use for one.
+    """
+    asked = []
+
+    def resolver(parameter):
+        asked.append(parameter)
+        return ["TopToBottom", "BottomToTop"]
+
+    control = build_control(
+        meta(items="dynamic", microscope_parameter="scan_direction", type=str),
+        "TopToBottom",
+        dynamic_items=resolver,
+    )
+
+    assert asked == ["scan_direction"]
+    assert isinstance(control.widget, ValueComboBox)
+    assert control.read() == "TopToBottom"
+
+
+def test_dynamic_items_fall_back_to_the_current_value(qapp):
+    """No resolver, or nothing cached: the field still shows what it holds."""
+    control = build_control(
+        meta(items="dynamic", microscope_parameter="scan_direction", type=str), "TopToBottom"
+    )
+
+    assert control.read() == "TopToBottom"
+
+
+def test_an_unrenderable_field_returns_none(qapp):
+    """The caller logs and skips; it must not get a control it cannot drive."""
+    assert build_control(meta(), object()) is None
+
+
+# --- the adapters -------------------------------------------------------------
+
+
+def test_connect_wires_every_signal_of_a_compound_control(qapp):
+    """Both spinboxes of a Point row have to report edits, not just the first."""
+    control = build_control(meta(type=Point, scale=1e6, unit="m"), Point())
+    fired = []
+    control.connect(lambda: fired.append(1))
+
+    x_control, y_control = control.widget.findChildren(ValueSpinBox)
+    x_control.setValue(5.0)
+    y_control.setValue(6.0)
+
+    assert len(fired) == 2
+
+
+def test_blocking_reaches_the_inputs_of_a_compound_control(qapp):
+    """Blocking the container would not stop its children emitting."""
+    control = build_control(meta(type=Point, scale=1e6, unit="m"), Point())
+    fired = []
+    control.connect(lambda: fired.append(1))
+
+    control.set_blocked(True)
+    control.write(Point(x=1e-6, y=1e-6))
+    control.set_blocked(False)
+
+    assert fired == []
+    assert control.read() == Point(x=1e-6, y=1e-6)

--- a/tests/ui/test_settings_widgets_integer.py
+++ b/tests/ui/test_settings_widgets_integer.py
@@ -45,7 +45,8 @@ def _row(widget, field):
 def test_integer_fields_use_integer_spinbox(qapp, microscope):
     widget = FibsemPatternSettingsWidget(microscope=microscope, pattern=_array_pattern())
     for field in _INT_FIELDS:
-        assert isinstance(_row(widget, field).control, IntegerValueSpinBox), field
+        # `.control` is the builder's Control adapter; `.widget` is the Qt control.
+        assert isinstance(_row(widget, field).control.widget, IntegerValueSpinBox), field
 
 
 def test_get_pattern_returns_int_not_float(qapp, microscope):


### PR DESCRIPTION
First half of FIB-526. This is the shared control builder; **moving the task-parameters form onto it is the follow-up**, where the actual behaviour change lands.

Four widgets — pattern, strategy, milling-settings, and the task form — each carried their own copy of the same loop: map field metadata to a control, then a matching `isinstance` ladder in `get_*` to read values back, and a third in `set_*` to push them in. Three ladders per form. They had already drifted: the strategy form honoured `format_fn` on comboboxes and the pattern form did not; the pattern form could resolve `items="dynamic"` against the microscope and the strategy form could not.

`build_control()` returns the control **together with** the adapters that move values through it, so a form never inspects a control's type:

```python
control = build_control(metadata, value)
...
value = control.read()          # was a 6-branch isinstance ladder
control.write(new_value)        # was another one
```

Adding a control type is now one branch here rather than four branches in three places each.

The builder takes **no microscope** — `items="dynamic"` resolves through a callback the caller supplies. That keeps it importable and testable without hardware, and keeps the microscope out of the two forms that have no use for one.

## Both name-keyed behaviours are gone

The issue flagged these as the things not to carry across, because they bake plugin-hostility into shared code:

`_HIDDEN_FIELDS = {"shapes"}` → `shapes` declares `hidden=True`.

`if field_name == "point"` → dispatch on `type is Point`. This needed the declaration fixed first: `BasePattern.point` declared `"type": Point` *before* spreading `DEFAULT_DISTANCE_METADATA`, so the spread's `float` silently won and the metadata was a lie — the live example filed as FIB-533, now resolved. **A plugin pattern with its own `Point` field gets the same two-spinbox row.**

`FormRow` goes too: the builder carries the scale inside its adapters, so a row no longer needs to know one.

## Verification

Diffed the rendered state of every form — control class, bounds, step, decimals, suffix, displayed value, tooltip, visibility at both advanced settings and (for milling) all four manufacturer values — plus a config round-trip through each.

- **Pattern and strategy: 3,511 properties, zero differences.**
- **Milling settings: 572 properties, byte-identical.**
- Round-trips unchanged, including the 7 pre-existing `0` vs `0.0` repr mismatches already on main.
- 1,554 tests pass; 19 new ones for the builder.

One deliberate rendering change: the point row's suffix was a hardcoded `"µm"` (U+00B5 MICRO SIGN) while every other distance field in the same form renders `"μm"` (U+03BC) via `_get_display_unit`. It now matches the rest.

## Two bugs the new tests caught in the extraction itself

**Generalising the point row dropped its `-1000..1000` literal fallback.** A `Point` declaring no bounds then inherited `ValueSpinBox`'s `(0.0, 1e6)` and **silently clamped negative coordinates to zero**. The form still looked right — only the round-trip assertion caught it. Restored as `POINT_FALLBACK_RANGE`, since a point is an offset from the image centre and is signed by definition.

**A scaled field with no unit rendered a bare SI prefix** — a lone `" µ"` with nothing after it. `display_suffix()` returns empty instead, which is what the task form's own helper already did.

Both are why the fallback spinbox range is a **parameter** rather than baked in: the task form hardcodes `-1e10..1e10` today, and would otherwise inherit a floor of zero on every float field that never declared a minimum.

## Not in this PR

The task form still reads four metadata keys and has its own `ParameterWidget` hierarchy. Moving it across is where `minimum`/`maximum`/`step`/`decimals`/`hidden`/`advanced`/`format_fn` start being honoured — a real behaviour change, kept separate so it is reviewable on its own.