### PR TITLE
[ui] Move the task-parameters form onto the shared vocabulary (FIB-526, step 2)

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -42,6 +42,7 @@ from fibsem.structures import (
     Point,
     ReferenceImageParameters,
     SessionInfo,
+    get_fields_with_metadata,
 )
 from fibsem.utils import configure_logging as _configure_logging
 from fibsem.utils import format_duration
@@ -152,6 +153,17 @@ class AutoLamellaTaskConfig(ABC):
             for f in fields(self)
             if f.name not in core_params
         )
+
+    @property
+    def field_metadata(self) -> Dict[str, Dict[str, Any]]:
+        """Return dataclass fields with metadata, filling any missing keys with defaults.
+
+        Matches the property patterns and milling strategies already expose. The
+        task form used to read raw `dataclasses.fields(...).metadata` instead, so
+        the whole vocabulary past four keys was unavailable to it -- a task
+        config could declare `minimum` and nothing would read it.
+        """
+        return get_fields_with_metadata(self.__class__)
 
     def to_dict(self) -> dict:
         """Convert configuration to a dictionary."""

--- a/fibsem/ui/widgets/autolamella_task_config_widget.py
+++ b/fibsem/ui/widgets/autolamella_task_config_widget.py
@@ -1,48 +1,60 @@
-import inspect
+"""The task-parameters form.
+
+Renders an AutoLamellaTaskConfig's own fields -- the ones past the base class --
+as a grid of controls, using the shared builder that the pattern, strategy and
+milling-settings forms use (FIB-526).
+
+This form used to read raw ``dataclasses.fields(...).metadata`` and understood
+four keys, so most of the vocabulary was simply unavailable to it: an int field
+got the full 32-bit range because nothing could say otherwise, floats got Qt's
+defaults, and there was no way to mark a field advanced or hidden. Going through
+``config.field_metadata`` means a task config now declares those the same way a
+pattern does.
+
+The container stays separate from the milling ones on purpose: it has milling
+sub-configs and reference imaging to show, and no type selector.
+"""
+
 import logging
-from dataclasses import fields
-from enum import Enum
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Union,
-    get_args,
-    get_origin,
-    get_type_hints,
-)
+from typing import Any, Dict, List, Optional, get_type_hints
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
-    QCheckBox,
-    QComboBox,
-    QDoubleSpinBox,
     QGridLayout,
     QLabel,
-    QLineEdit,
-    QSpinBox,
     QVBoxLayout,
     QWidget,
 )
 from superqt import QCollapsible
 
+from dataclasses import dataclass
+
 from fibsem import utils
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
-from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.ui.widgets.form_builder import Control, FormDefaults, build_control
+
+# What this form falls back to for keys a field does not declare. These are the
+# bounds and precision it already had hardcoded; passing them keeps the form
+# looking the same, so declaring a real `minimum` is a visible change rather
+# than a side effect of moving onto the shared builder.
+TASK_FORM_DEFAULTS = FormDefaults(
+    float_range=(-1e10, 1e10),
+    int_range=(-2147483648, 2147483647),
+    step=1.0,
+    decimals=2,
+)
+
 
 def resolve_field_types(config: Any) -> Dict[str, Any]:
     """Resolve a dataclass's field annotations to concrete types.
 
-    Task configs that use ``from __future__ import annotations`` store their field
-    annotations as strings (e.g. ``'float'``), so ``dataclasses.fields(...).type`` is a
-    string, not a type. The identity-based dispatch in ``_create_parameter_widget``
-    (``annotation is float`` etc.) then never matches and silently falls back to a
-    string ``QLineEdit`` — which stores numeric values (e.g. a milling current) as raw
-    strings. Resolving the real types up front keeps numeric fields on spinboxes.
+    Task configs that use ``from __future__ import annotations`` store their
+    field annotations as strings (e.g. ``'float'``), so
+    ``dataclasses.fields(...).type`` is a string, not a type. The builder
+    dispatches on the real type, and a string matches nothing -- the field would
+    fall through to the read-only display.
     """
     try:
         return get_type_hints(type(config))
@@ -54,368 +66,56 @@ def resolve_field_types(config: Any) -> Dict[str, Any]:
         return {}
 
 
-class ParameterWidget:
-    """Base class for parameter editing widgets."""
-
-    # Whether this widget's get_value() may be written back onto the config.
-    # False for widgets that can only display a value they cannot reconstruct
-    # (see ReadOnlyParameterWidget).
-    editable: bool = True
-    
-    def __init__(self, name: str, value: Any, annotation: type):
-        self.name = name
-        self.value = value
-        self.annotation = annotation
-        self.widget = None
-        
-    def create_widget(self) -> QWidget:
-        """Create the appropriate widget for this parameter type."""
-        raise NotImplementedError
-        
-    def get_value(self) -> Any:
-        """Get the current value from the widget."""
-        raise NotImplementedError
-        
-    def set_value(self, value: Any) -> None:
-        """Set the value in the widget."""
-        raise NotImplementedError
+@dataclass
+class _Row:
+    """One built form row."""
+    label: QLabel
+    control: Control
+    field: str
+    advanced: bool
 
 
-class BoolParameterWidget(ParameterWidget):
-    """Widget for boolean parameters."""
-    
-    def create_widget(self) -> QWidget:
-        self.widget = QCheckBox()
-        self.widget.setChecked(bool(self.value))
-        return self.widget
-        
-    def get_value(self) -> bool:
-        return self.widget.isChecked()
+def build_parameter_rows(config: AutoLamellaTaskConfig, grid: QGridLayout) -> List[_Row]:
+    """Fill *grid* with a control per configurable parameter, and return the rows.
 
-    def set_value(self, value: bool) -> None:
-        self.widget.setChecked(bool(value))
-
-
-class IntParameterWidget(ParameterWidget):
-    """Widget for integer parameters with optional units suffix."""
-
-    def __init__(self, name: str, value: Any, annotation: type, metadata: Optional[dict] = None):
-        super().__init__(name, value, annotation)
-        self.metadata = metadata or {}
-        self.scale = self.metadata.get('scale', 1.0)
-        self.units = self.metadata.get('unit', '')
-
-    def create_widget(self) -> QWidget:
-        self.widget = QSpinBox()
-        self.widget.setRange(-2147483648, 2147483647)  # 32-bit int range
-        self.widget.setValue(int(round(self.value * self.scale)))
-        self.widget.setKeyboardTracking(False)
-        install_wheel_blocker(self.widget)
-
-        # Add units suffix if available (e.g. " s" for exposure time)
-        suffix = get_si_prefix_suffix(self.scale, self.units)
-        if suffix:
-            self.widget.setSuffix(suffix)
-        return self.widget
-
-    def get_value(self) -> int:
-        return int(round(self.widget.value() / self.scale))
-
-    def set_value(self, value: int) -> None:
-        self.widget.setValue(int(round(value * self.scale)))
-
-
-def get_si_prefix_suffix(scale: float, units: str) -> str:
-    """Get the appropriate SI prefix suffix based on scale factor."""
-    si_prefixes = {
-        1e12: 'p',    # pico
-        1e9: 'n',     # nano
-        1e6: 'μ',     # micro
-        1e3: 'm',     # milli
-        1.0: '',      # no prefix
-        1e-3: 'k',    # kilo
-        1e-6: 'M',    # mega
-        1e-9: 'G',    # giga
-        1e-12: 'T',   # tera
-    }
-    
-    prefix = si_prefixes.get(scale, '')
-    return f" {prefix}{units}" if units else ""
-
-
-class FloatParameterWidget(ParameterWidget):
-    """Widget for float parameters with units and scaling support."""
-    
-    def __init__(self, name: str, value: Any, annotation: type, metadata: Optional[dict] = None):
-        super().__init__(name, value, annotation)
-        self.metadata = metadata or {}
-        self.scale = self.metadata.get('scale', 1.0)
-        self.units = self.metadata.get('unit', '')
-        
-    def create_widget(self) -> QWidget:
-        self.widget = QDoubleSpinBox()
-        self.widget.setRange(-1e10, 1e10)
-        self.widget.setDecimals(2)
-        self.widget.setKeyboardTracking(False)
-        install_wheel_blocker(self.widget)
-        
-        # Apply scaling for display (multiply by scale to show user-friendly values)
-        display_value = float(self.value) * self.scale
-        self.widget.setValue(display_value)
-        
-        # Add units suffix if available
-        suffix = get_si_prefix_suffix(self.scale, self.units)
-        if suffix:
-            self.widget.setSuffix(suffix)
-        
-        return self.widget
-        
-    def get_value(self) -> float:
-        # Convert from display value back to stored value (divide by scale)
-        display_value = self.widget.value()
-        return display_value / self.scale
-        
-    def set_value(self, value: float) -> None:
-        # Convert to display value (multiply by scale)
-        display_value = float(value) * self.scale
-        self.widget.setValue(display_value)
-
-
-class StringParameterWidget(ParameterWidget):
-    """Widget for string parameters."""
-    
-    def create_widget(self) -> QWidget:
-        self.widget = QLineEdit()
-        self.widget.setText(str(self.value))
-        return self.widget
-        
-    def get_value(self) -> str:
-        return self.widget.text()
-        
-    def set_value(self, value: str) -> None:
-        self.widget.setText(str(value))
-
-
-class ReadOnlyParameterWidget(ParameterWidget):
-    """Read-only display for a field this form has no editor for.
-
-    The alternative used to be a plain ``QLineEdit`` holding ``str(value)``, on the
-    assumption that an unknown type could be round-tripped through its text. That
-    holds for almost nothing: for a nested dataclass such as ``ZParameters`` or
-    ``ChannelSettings`` the box shows a ``repr`` that cannot be parsed back, and
-    ``get_value()`` returns a ``str`` which was then written straight onto the
-    config -- destroying the object on a focus-out alone, no typing required. The
-    field then fails at run time (``'str' object has no attribute ...``) and again
-    when the experiment is saved.
-
-    Showing the value disabled keeps it visible -- these are real settings an
-    operator wants to read -- while ``editable = False`` stops anything writing the
-    displayed text back. Edit such fields through a config-specific widget, or the
-    protocol file.
+    Shared by both containers in this module, which each carried their own copy
+    of this loop -- and had already drifted: only one of them honoured `label`.
     """
+    type_hints = resolve_field_types(config)
+    metadata = config.field_metadata
+    rows: List[_Row] = []
 
-    editable = False
+    for name in config.parameters:
+        m = metadata.get(name, {})
+        if m.get("hidden", False):
+            continue
 
-    def create_widget(self) -> QWidget:
-        self.widget = QLineEdit()
-        self.widget.setText(str(self.value))
-        self.widget.setReadOnly(True)
-        self.widget.setEnabled(False)
-        self.widget.setToolTip(
-            f"{self._type_name()} is not editable in this form.\n"
-            "Edit it in this task's own settings panel, or in the protocol file."
+        control = build_control(
+            m,
+            getattr(config, name),
+            annotation=type_hints.get(name),
+            defaults=TASK_FORM_DEFAULTS,
         )
-        return self.widget
+        if control is None:
+            continue
 
-    def _type_name(self) -> str:
-        return getattr(self.annotation, "__name__", None) or str(self.annotation)
+        label = QLabel(m.get("label") or name.replace("_", " ").title())
+        if m.get("tooltip"):
+            label.setToolTip(m["tooltip"])
 
-    def get_value(self) -> Any:
-        """Return the original value, never the displayed text.
+        row_index = len(rows)
+        grid.addWidget(label, row_index, 0)
+        grid.addWidget(control.widget, row_index, 1)
+        rows.append(
+            _Row(
+                label=label,
+                control=control,
+                field=name,
+                advanced=m.get("advanced", False),
+            )
+        )
 
-        Nothing should call this -- `editable` is False -- but if something does,
-        handing back the untouched value is the answer that cannot corrupt the
-        config.
-        """
-        return self.value
-
-    def set_value(self, value: Any) -> None:
-        self.value = value
-        self.widget.setText(str(value))
-
-
-class EnumParameterWidget(ParameterWidget):
-    """Widget for enum parameters."""
-    
-    def create_widget(self) -> QWidget:
-        self.widget = QComboBox()
-        
-        # Add enum values to combo box
-        for enum_value in self.annotation:
-            self.widget.addItem(str(enum_value.value), enum_value)
-            
-        # Set current value
-        current_index = 0
-        for i, enum_value in enumerate(self.annotation):
-            if enum_value == self.value or enum_value.value == self.value:
-                current_index = i
-                break
-        self.widget.setCurrentIndex(current_index)
-        install_wheel_blocker(self.widget)
-        
-        return self.widget
-        
-    def get_value(self) -> Any:
-        return self.widget.currentData()
-        
-    def set_value(self, value: Any) -> None:
-        for i in range(self.widget.count()):
-            if self.widget.itemData(i) == value:
-                self.widget.setCurrentIndex(i)
-                break
-
-
-class ComboParameterWidget(ParameterWidget):
-    """Widget for parameters with a fixed list of allowable values (items metadata key)."""
-
-    def __init__(self, name: str, value: Any, annotation: type, items: list) -> None:
-        super().__init__(name, value, annotation)
-        self.items = items
-
-    def create_widget(self) -> QWidget:
-        self.widget = QComboBox()
-        for item in self.items:
-            self.widget.addItem(str(item), item)
-        for i in range(self.widget.count()):
-            if self.widget.itemData(i) == self.value:
-                self.widget.setCurrentIndex(i)
-                break
-        install_wheel_blocker(self.widget)
-        return self.widget
-
-    def get_value(self) -> Any:
-        return self.widget.currentData()
-
-    def set_value(self, value: Any) -> None:
-        for i in range(self.widget.count()):
-            if self.widget.itemData(i) == value:
-                self.widget.setCurrentIndex(i)
-                break
-
-
-class ListParameterWidget(ParameterWidget):
-    """Widget for list parameters (simplified as comma-separated values)."""
-    
-    def create_widget(self) -> QWidget:
-        self.widget = QLineEdit()
-        
-        # Convert list to comma-separated string
-        if isinstance(self.value, list):
-            text = ", ".join(str(item) for item in self.value)
-        else:
-            text = str(self.value)
-        self.widget.setText(text)
-        self.widget.setPlaceholderText("Enter comma-separated values")
-        
-        return self.widget
-        
-    def get_value(self) -> List[Any]:
-        text = self.widget.text().strip()
-        if not text:
-            return []
-            
-        # Split by comma and convert based on list type annotation
-        items = [item.strip() for item in text.split(",")]
-        
-        # Try to determine the list item type
-        origin = getattr(self.annotation, '__origin__', None)
-        if origin is list:
-            args = getattr(self.annotation, '__args__', ())
-            if args:
-                item_type = args[0]
-                try:
-                    if item_type == int:
-                        return [int(item) for item in items]
-                    elif item_type == float:
-                        return [float(item) for item in items]
-                    elif item_type == bool:
-                        return [item.lower() in ('true', '1', 'yes') for item in items]
-                except ValueError:
-                    pass
-        
-        return items  # Return as strings if conversion fails
-        
-    def set_value(self, value: List[Any]) -> None:
-        if isinstance(value, list):
-            text = ", ".join(str(item) for item in value)
-        else:
-            text = str(value)
-        self.widget.setText(text)
-
-
-def create_parameter_widget(
-    name: str,
-    value: Any,
-    annotation: type,
-    metadata: Optional[dict] = None,
-) -> ParameterWidget:
-    """Pick the editing widget for one config field.
-
-    Shared by both config forms in this module, which each used to carry their own
-    copy of this dispatch -- and had already drifted apart. A field type handled in
-    one and not the other is the kind of divergence that shows up as a corrupted
-    config rather than as an error.
-    """
-    metadata = metadata or {}
-
-    # Handle Union types (e.g., Optional[T])
-    origin = get_origin(annotation)
-    if origin is Union:
-        # Find the non-None type for Optional[T]
-        non_none_types = [arg for arg in get_args(annotation) if arg is not type(None)]
-        if non_none_types:
-            annotation = non_none_types[0]
-            origin = get_origin(annotation)
-
-    # items metadata takes priority -- render as combobox regardless of type
-    items = metadata.get("items")
-    if items:
-        return ComboParameterWidget(name, value, annotation, items)
-
-    # A Literal is a fixed set of allowable values written in the type itself,
-    # which is the same thing the `items` metadata key expresses -- so render it
-    # the same way rather than as a free-text box the operator can mistype.
-    if origin is Literal:
-        return ComboParameterWidget(name, value, annotation, list(get_args(annotation)))
-
-    # Determine widget type based on annotation
-    if annotation is bool:
-        return BoolParameterWidget(name, value, annotation)
-    elif annotation is int:
-        return IntParameterWidget(name, value, annotation, metadata)
-    elif annotation is float:
-        return FloatParameterWidget(name, value, annotation, metadata)
-    elif annotation is str:
-        return StringParameterWidget(name, value, annotation)
-    elif inspect.isclass(annotation) and issubclass(annotation, Enum):
-        return EnumParameterWidget(name, value, annotation)
-    elif origin is list or (inspect.isclass(annotation) and issubclass(annotation, list)):
-        # Only lists of scalars survive the round trip through comma-separated
-        # text; a list of dataclasses comes back as a list of strings.
-        item_types = get_args(annotation)
-        if not item_types or item_types[0] in (bool, int, float, str):
-            return ListParameterWidget(name, value, annotation)
-
-    # Debug, not warning: the form itself now says this, visibly and in the right
-    # place -- the field is greyed out with a tooltip naming where to edit it. At
-    # warning level this fires every time a task carrying such a field is selected,
-    # including the built-in fluorescence config, whose three are read-only by
-    # design and whose form is hidden anyway. Nothing is going wrong.
-    logging.debug(
-        f"No editor for parameter type '{annotation}' (field '{name}'); "
-        "showing it read-only."
-    )
-    return ReadOnlyParameterWidget(name, value, annotation)
+    return rows
 
 
 class AutoLamellaTaskConfigWidget(QWidget):
@@ -427,7 +127,8 @@ class AutoLamellaTaskConfigWidget(QWidget):
                  parent: Optional[QWidget] = None):
         super().__init__(parent)
         self.task_config = task_config
-        self.parameter_widgets: Dict[str, ParameterWidget] = {}
+        self._rows: List[_Row] = []
+        self._advanced_visible = False
         self.milling_task_widget: MillingTaskViewerWidget
 
         self._setup_ui()
@@ -445,7 +146,6 @@ class AutoLamellaTaskConfigWidget(QWidget):
         # Create content widget for parameters
         self.params_widget = QWidget()
         self.grid_layout = QGridLayout(self.params_widget)
-        self.current_row = 0
         
         self.task_params_collapsible.addWidget(self.params_widget)
 
@@ -479,48 +179,21 @@ class AutoLamellaTaskConfigWidget(QWidget):
         """Update the UI from the current task configuration."""
         if not self.task_config:
             return
-            
-        # Clear existing widgets
+
         self._clear_form()
-        
-        # Show/hide task parameters section
+
         if self.task_config.parameters:
-            # Resolve annotations to concrete types (see resolve_field_types) so that
-            # `from __future__ import annotations` configs don't fall back to QLineEdit.
-            type_hints = resolve_field_types(self.task_config)
-
-            # Get all configurable parameters using the parameters property
-            for param_name in self.task_config.parameters:
-                # Get field info and current value
-                field = next(f for f in fields(self.task_config) if f.name == param_name)
-                value = getattr(self.task_config, param_name)
-                annotation = type_hints.get(param_name, field.type)
-
-                # Create parameter widget
-                param_widget = self._create_parameter_widget(param_name, value, annotation, field.metadata)
-                if param_widget:
-                    self.parameter_widgets[param_name] = param_widget
-                    
-                    # Add to form
-                    widget = param_widget.create_widget()
-                    
-                    # Connect change signals to update config
-                    self._connect_widget_signals(widget, param_name)
-                    
-                    # Create label with tooltip if available
-                    label = QLabel(self._format_field_name(param_name))
-                    tooltip = getattr(field, 'metadata', {}).get('tooltip')
-                    if tooltip:
-                        label.setToolTip(tooltip)
-                        
-                    self.grid_layout.addWidget(label, self.current_row, 0)
-                    self.grid_layout.addWidget(widget, self.current_row, 1)
-                    self.current_row += 1
-            
+            self._rows = build_parameter_rows(self.task_config, self.grid_layout)
+            for row in self._rows:
+                # A read-only row displays a value it cannot reconstruct; wiring
+                # it up would let a focus-out write the displayed text back.
+                if row.control.editable:
+                    row.control.connect(lambda name=row.field: self._on_parameter_changed(name))
+            self._update_visibility()
             self.task_params_collapsible.show()
         else:
             self.task_params_collapsible.hide()
-    
+
         # Show/hide milling parameters section
         if self.task_config.milling:
             self._current_milling_key = next(iter(self.task_config.milling))
@@ -531,39 +204,23 @@ class AutoLamellaTaskConfigWidget(QWidget):
             self.milling_task_widget.clear()
             self.milling_params_collapsible.hide()
 
-    def _create_parameter_widget(self, name: str, value: Any, annotation: type, metadata: Optional[dict] = None) -> Optional[ParameterWidget]:
-        """Create the appropriate parameter widget for the given type."""
-        return create_parameter_widget(name, value, annotation, metadata)
-    
-    def _connect_widget_signals(self, widget: QWidget, field_name: str):
-        """Connect widget change signals to update the configuration."""
-        if not self.parameter_widgets[field_name].editable:
-            return
-        if isinstance(widget, QCheckBox):
-            widget.toggled.connect(lambda: self._on_parameter_changed(field_name))
-        elif isinstance(widget, (QSpinBox, QDoubleSpinBox)):
-            widget.valueChanged.connect(lambda: self._on_parameter_changed(field_name))
-        elif isinstance(widget, QLineEdit):
-            widget.editingFinished.connect(lambda: self._on_parameter_changed(field_name))
-        elif isinstance(widget, QComboBox):
-            widget.currentIndexChanged.connect(lambda: self._on_parameter_changed(field_name))
-    
+    def _update_visibility(self) -> None:
+        for row in self._rows:
+            visible = (not row.advanced) or self._advanced_visible
+            row.label.setVisible(visible)
+            row.control.widget.setVisible(visible)
+
+    def set_advanced_visible(self, show: bool) -> None:
+        self._advanced_visible = show
+        self._update_visibility()
+
     def _on_parameter_changed(self, field_name: str):
         """Handle parameter value changes."""
-        if field_name in self.parameter_widgets:
-            param_widget = self.parameter_widgets[field_name]
-            # Never write back a value the widget cannot reconstruct -- see
-            # ReadOnlyParameterWidget. Checked here as well as at connection time
-            # because the cost of getting it wrong is a silently corrupted config.
-            if not param_widget.editable:
-                return
-            new_value = param_widget.get_value()
-
-            # Update the task config
-            setattr(self.task_config, field_name, new_value)
-
-            # Emit change signal
-            self.config_changed.emit(self.task_config)
+        row = next((r for r in self._rows if r.field == field_name), None)
+        if row is None or not row.control.editable:
+            return
+        setattr(self.task_config, field_name, row.control.read())
+        self.config_changed.emit(self.task_config)
 
     def _on_milling_config_updated(self, milling_config):
         """Handle milling task config updates."""
@@ -576,17 +233,18 @@ class AutoLamellaTaskConfigWidget(QWidget):
             self.config_changed.emit(self.task_config)
 
     def _clear_form(self):
-        """Clear all widgets from the grid layout."""
+        """Clear all widgets from the grid layout.
+
+        Rows are dropped BEFORE the widgets are removed: if Qt moves focus
+        during removal, a re-entrant rebuild would iterate self._rows and touch
+        already-deleted C++ wrappers.
+        """
+        self._rows = []
         while self.grid_layout.count():
             child = self.grid_layout.takeAt(0)
             if child and child.widget():
                 child.widget().setParent(None)
-        self.parameter_widgets.clear()
-        self.current_row = 0
-    
-    def _format_field_name(self, field_name: str) -> str:
-        """Format field name for display (convert snake_case to Title Case)."""
-        return field_name.replace('_', ' ').title()
+
     
     def get_task_config(self) -> Optional[AutoLamellaTaskConfig]:
         """Get the current task configuration."""
@@ -594,8 +252,12 @@ class AutoLamellaTaskConfigWidget(QWidget):
 
 
 class AutoLamellaTaskParametersConfigWidget(QWidget):
-    """Widget for configuring AutoLamella task parameters."""
-    
+    """The task parameters on their own, in a titled panel.
+
+    Same rows as AutoLamellaTaskConfigWidget, without the milling and reference
+    imaging sections -- used where those are shown elsewhere.
+    """
+
     config_changed = pyqtSignal(AutoLamellaTaskConfig)
     parameter_changed = pyqtSignal(str, object)  # field name, new value
 
@@ -603,22 +265,20 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
                  parent: Optional[QWidget] = None):
         super().__init__(parent)
         self.task_config = task_config
-        self.parameter_widgets: Dict[str, ParameterWidget] = {}
+        self._rows: List[_Row] = []
+        self._advanced_visible = False
 
         self._setup_ui()
         if self.task_config:
             self._update_from_config()
 
     def _setup_ui(self):
-        """Create and configure all UI elements."""
         self.main_layout = QVBoxLayout()
         self.main_layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(self.main_layout)
 
-        # Create content widget for parameters
         self.params_widget = QWidget()
         self.grid_layout = QGridLayout(self.params_widget)
-        self.current_row = 0
         self.params_panel = TitledPanel("Task Parameters", content=self.params_widget)
         self.params_panel._btn_collapse.setChecked(True)
 
@@ -630,114 +290,53 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
         self._update_from_config()
 
     def _update_from_config(self):
-        """Update the UI from the current task configuration."""
         if not self.task_config:
             return
 
-        # Clear existing widgets
         self._clear_form()
 
-        # Show/hide task parameters section
         if not self.task_config.parameters:
             self.hide()
             return
 
-        # Resolve annotations to concrete types (see resolve_field_types) so that
-        # `from __future__ import annotations` configs don't fall back to QLineEdit.
-        type_hints = resolve_field_types(self.task_config)
-
-        # Get all configurable parameters using the parameters property
-        for param_name in self.task_config.parameters:
-            # Get field info and current value
-            field = next(f for f in fields(self.task_config) if f.name == param_name)
-            value = getattr(self.task_config, param_name)
-            annotation = type_hints.get(param_name, field.type)
-
-            # Create parameter widget
-            param_widget = self._create_parameter_widget(name = param_name,
-                                                         value = value,
-                                                         annotation = annotation,
-                                                         metadata = field.metadata)
-            if param_widget:
-                self.parameter_widgets[param_name] = param_widget
-
-                # Add to form
-                widget = param_widget.create_widget()
-
-                # Connect change signals to update config
-                self._connect_widget_signals(widget, param_name)
-
-                # Create label with tooltip if available
-                label = QLabel(self._format_field_name(param_name, field.metadata))
-                tooltip = getattr(field, 'metadata', {}).get('tooltip')
-                if tooltip:
-                    label.setToolTip(tooltip)
-
-                self.grid_layout.addWidget(label, self.current_row, 0)
-                self.grid_layout.addWidget(widget, self.current_row, 1)
-                self.current_row += 1
-
+        self._rows = build_parameter_rows(self.task_config, self.grid_layout)
+        for row in self._rows:
+            # A read-only row displays a value it cannot reconstruct; wiring it
+            # up would let a focus-out write the displayed text back.
+            if row.control.editable:
+                row.control.connect(lambda name=row.field: self._on_parameter_changed(name))
+        self._update_visibility()
         self.show()
 
-    def _create_parameter_widget(self,
-                                 name: str,
-                                 value: Any,
-                                 annotation: type,
-                                 metadata: Optional[dict] = None) -> Optional[ParameterWidget]:
-        """Create the appropriate parameter widget for the given type."""
-        return create_parameter_widget(name, value, annotation, metadata)
-    
-    def _connect_widget_signals(self, widget: QWidget, field_name: str):
-        """Connect widget change signals to update the configuration."""
-        if not self.parameter_widgets[field_name].editable:
-            return
-        if isinstance(widget, QCheckBox):
-            widget.toggled.connect(lambda: self._on_parameter_changed(field_name))
-        elif isinstance(widget, (QSpinBox, QDoubleSpinBox)):
-            widget.valueChanged.connect(lambda: self._on_parameter_changed(field_name))
-        elif isinstance(widget, QLineEdit):
-            widget.editingFinished.connect(lambda: self._on_parameter_changed(field_name))
-        elif isinstance(widget, QComboBox):
-            widget.currentIndexChanged.connect(lambda: self._on_parameter_changed(field_name))
-    
+    def _update_visibility(self) -> None:
+        for row in self._rows:
+            visible = (not row.advanced) or self._advanced_visible
+            row.label.setVisible(visible)
+            row.control.widget.setVisible(visible)
+
+    def set_advanced_visible(self, show: bool) -> None:
+        self._advanced_visible = show
+        self._update_visibility()
+
     def _on_parameter_changed(self, field_name: str):
-        """Handle parameter value changes."""
-        if field_name in self.parameter_widgets:
-            param_widget = self.parameter_widgets[field_name]
-            # Never write back a value the widget cannot reconstruct -- see
-            # ReadOnlyParameterWidget. Checked here as well as at connection time
-            # because the cost of getting it wrong is a silently corrupted config.
-            if not param_widget.editable:
-                return
-            new_value = param_widget.get_value()
-
-            # Update the task config
-            setattr(self.task_config, field_name, new_value)
-
-            # Emit change signal
-            # self.config_changed.emit(self.task_config)
-            self.parameter_changed.emit(field_name, new_value)
+        row = next((r for r in self._rows if r.field == field_name), None)
+        if row is None or not row.control.editable:
+            return
+        value = row.control.read()
+        setattr(self.task_config, field_name, value)
+        self.parameter_changed.emit(field_name, value)
 
     def _clear_form(self):
-        """Clear all widgets from the grid layout."""
+        """Clear the grid. Rows are dropped first -- see the sibling container."""
+        self._rows = []
         while self.grid_layout.count():
             child = self.grid_layout.takeAt(0)
             if child and child.widget():
                 child.widget().setParent(None)
-        self.parameter_widgets.clear()
-        self.current_row = 0
 
-    def _format_field_name(self, field_name: str, metadata: Optional[dict] = None) -> str:
-        """Format field name for display (convert snake_case to Title Case)."""
-        if metadata and 'label' in metadata:
-            return metadata['label']
-        return field_name.replace('_', ' ').title()
-    
     def get_task_config(self) -> Optional[AutoLamellaTaskConfig]:
         """Get the current task configuration."""
         return self.task_config
-
-
 
 
 if __name__ == "__main__":

--- a/fibsem/ui/widgets/form_builder.py
+++ b/fibsem/ui/widgets/form_builder.py
@@ -20,9 +20,21 @@ hardware.
 
 from __future__ import annotations
 
+import inspect
 import logging
 from dataclasses import dataclass, field as dataclass_field
-from typing import Any, Callable, Optional, Sequence, Tuple
+from enum import Enum
+from typing import (
+    Any,
+    Callable,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    get_args,
+    get_origin,
+)
 
 from PyQt5.QtWidgets import QCheckBox, QHBoxLayout, QWidget
 
@@ -44,6 +56,22 @@ from fibsem.ui.widgets.custom_widgets import (
 # explicitly; the milling forms keep the spinbox defaults by passing None.
 DEFAULT_FLOAT_RANGE = (-1e10, 1e10)
 DEFAULT_INT_RANGE = (-2147483648, 2147483647)
+
+
+@dataclass(frozen=True)
+class FormDefaults:
+    """What a form falls back to for keys a field does not declare.
+
+    A form's existing look is not something a shared builder should quietly
+    change, and the spinbox classes' own defaults are not neutral -- a range of
+    (0.0, 1e6) puts a floor of zero on anything that never declared a minimum,
+    and clamping is silent. Each form passes what it already had.
+    """
+
+    float_range: Optional[Tuple[float, float]] = None
+    int_range: Optional[Tuple[int, int]] = None
+    step: Optional[float] = None
+    decimals: Optional[int] = None
 
 # A point is an offset from the image centre, so it is signed by definition and
 # must never inherit a floor of zero. The pattern form carried this same pair as
@@ -113,6 +141,11 @@ def _combo(items: Sequence[Any], value: Any, metadata: dict) -> Control:
     control = ValueComboBox(
         list(items), value, metadata.get("unit"), format_fn=metadata.get("format_fn")
     )
+    # ValueComboBox's constructor skips `set_value` for None, which leaves the
+    # first item selected. `None` is a real choice for an Optional field -- the
+    # trench task's orientation defaults to it -- so select it explicitly.
+    if value is None:
+        control.set_value(None)
 
     def read() -> Any:
         # A combo with nothing selected returns None; writing that onto the
@@ -184,25 +217,118 @@ def _bounds(
     return minimum, maximum
 
 
+def _is_optional(annotation: Any) -> bool:
+    """Whether the field may legitimately hold None."""
+    return get_origin(annotation) is not None and type(None) in get_args(annotation)
+
+
+def _resolve(annotation: Any) -> Any:
+    """Unwrap Optional[T] to T.
+
+    A task config declaring `Optional[str]` is a string field that may be unset,
+    not an unrenderable one -- without this it falls through to the read-only
+    display.
+    """
+    if get_origin(annotation) is not None and type(None) in get_args(annotation):
+        real = [a for a in get_args(annotation) if a is not type(None)]
+        if len(real) == 1:
+            return real[0]
+    return annotation
+
+
+def _read_only(value: Any, annotation: Any) -> Control:
+    """Show a value this form has no editor for, without letting it be written back.
+
+    A plain QLineEdit holding str(value) looks equivalent and is not: for a
+    nested dataclass the box shows a repr that cannot be parsed back, and
+    reading it returns a str which then replaces the object on the config --
+    destroying it on a focus-out alone. `read` hands back the untouched value
+    and `editable` stops anything calling it in the first place.
+    """
+    name = getattr(annotation, "__name__", None) or str(annotation)
+    control = QLineEdit()
+    control.setText(str(value))
+    control.setReadOnly(True)
+    control.setEnabled(False)
+    control.setToolTip(
+        f"{name} is not editable in this form.\n"
+        "Edit it in this task's own settings panel, or in the protocol file."
+    )
+    return Control(
+        widget=control,
+        read=lambda: value,
+        write=lambda new: control.setText(str(new)),
+        signals=(),
+        editable=False,
+    )
+
+
+def _scalar_list(value: Any, annotation: Any) -> Control:
+    """A list of scalars as comma-separated text.
+
+    Only scalars survive the round trip: a list of dataclasses comes back as a
+    list of strings, which is why the caller checks the item type first.
+    """
+    item_types = get_args(annotation)
+    item_type = item_types[0] if item_types else str
+    control = QLineEdit()
+    control.setPlaceholderText("Enter comma-separated values")
+    control.setText(", ".join(str(v) for v in value) if isinstance(value, list) else str(value))
+
+    def read() -> List[Any]:
+        text = control.text().strip()
+        if not text:
+            return []
+        parts = [p.strip() for p in text.split(",")]
+        try:
+            if item_type is int:
+                return [int(p) for p in parts]
+            if item_type is float:
+                return [float(p) for p in parts]
+            if item_type is bool:
+                return [p.lower() in ("true", "1", "yes") for p in parts]
+        except ValueError:
+            # Half-typed input is not a reason to throw away what was typed.
+            return parts
+        return parts
+
+    return Control(
+        widget=control,
+        read=read,
+        write=lambda new: control.setText(
+            ", ".join(str(v) for v in new) if isinstance(new, list) else str(new)
+        ),
+        signals=(control.editingFinished,),
+    )
+
+
 def build_control(
     metadata: dict,
     value: Any,
     *,
+    annotation: Any = None,
     dynamic_items: Optional[Callable[[str], Sequence[Any]]] = None,
-    float_range: Optional[Tuple[float, float]] = None,
-    int_range: Optional[Tuple[int, int]] = None,
+    defaults: FormDefaults = FormDefaults(),
 ) -> Optional[Control]:
     """Build the control for one field, or None if nothing here can render it.
 
     `metadata` is the merged view from `get_fields_with_metadata`, so every key
-    is present. `dynamic_items` resolves `items: "dynamic"` against the
-    microscope; without it such a field falls back to its current value alone.
+    is present. `annotation` is the field's resolved type, consulted only where
+    the metadata declares no `type`: the milling forms declare one, the task
+    configs mostly do not, and dispatching on the value alone cannot tell a
+    Literal or an Enum from a plain string.
 
-    `float_range` / `int_range` supply bounds for fields that declare none.
-    Leave them None to keep the spinbox classes' own defaults.
+    `dynamic_items` resolves `items: "dynamic"` against the microscope; without
+    it such a field falls back to its current value alone.
+
+    Returns a read-only Control -- `editable=False` -- for a type this form has
+    no editor for, rather than None, so the value stays visible.
     """
     items = metadata.get("items")
     type_ = metadata.get("type")
+    optional = _is_optional(annotation)
+    annotation = _resolve(annotation)
+    kind = type_ if type_ is not None else annotation
 
     if items == "dynamic":
         resolved = dynamic_items(metadata["microscope_parameter"]) if dynamic_items else None
@@ -211,22 +337,38 @@ def build_control(
     if items:
         return _combo(items, value, metadata)
 
-    if type_ is Point or isinstance(value, Point):
-        return _point(value, metadata, float_range)
+    # A Literal is a fixed set of allowable values written in the type itself,
+    # which is what `items` expresses -- render it the same way rather than as a
+    # free-text box the operator can mistype.
+    if get_origin(annotation) is Literal:
+        return _combo(list(get_args(annotation)), value, metadata)
 
-    if type_ is str:
+    if kind is Point or isinstance(value, Point):
+        return _point(value, metadata, defaults.float_range)
+
+    if kind is str:
         control = QFilePathLineEdit() if metadata.get("filepath") else QLineEdit()
         control.setText(str(value) if value else "")
+
+        def read_text():
+            # An empty box on an Optional[str] field means "unset", not "".
+            # Rendering used to be str(value), so a None field showed the literal
+            # text "None" and read it straight back onto the config -- an
+            # AcquireReferenceImage filename of "None" instead of the
+            # auto-generated one, from a focus-out alone.
+            text = control.text()
+            return None if (optional and not text) else text
+
         return Control(
             widget=control,
-            read=control.text,
+            read=read_text,
             write=lambda new: control.setText(str(new) if new else ""),
             signals=(control.editingFinished,),
         )
 
     # Before int: bool is a subclass of int, so an isinstance check for int
     # would swallow every checkbox field.
-    if type_ is bool or isinstance(value, bool):
+    if kind is bool or isinstance(value, bool):
         control = QCheckBox()
         control.setChecked(bool(value))
         return Control(
@@ -236,12 +378,14 @@ def build_control(
             signals=(control.toggled,),
         )
 
-    if type_ is int:
+    if kind is int:
         scale = int(round(effective_scale(metadata) or 1))
-        minimum, maximum = _bounds(metadata, int_range)
+        minimum, maximum = _bounds(metadata, defaults.int_range)
         # An integer spinbox stepping by less than its own scale cannot reach
         # every representable value, so the step is floored at the scale.
-        step = max(metadata.get("step") or 1, scale)
+        # int(): QSpinBox.setSingleStep rejects a float outright, and a form's
+        # fallback step is naturally written as one.
+        step = int(max(metadata.get("step") or defaults.step or 1, scale))
         control = IntegerValueSpinBox(display_suffix(metadata), minimum, maximum, step)
         control.setValue(int(round(value * scale)))
         return Control(
@@ -251,15 +395,15 @@ def build_control(
             signals=(control.valueChanged,),
         )
 
-    if type_ is float or isinstance(value, (float, int)):
+    if kind is float or (annotation is None and isinstance(value, (float, int))):
         scale = effective_scale(metadata) or 1
-        minimum, maximum = _bounds(metadata, float_range)
+        minimum, maximum = _bounds(metadata, defaults.float_range)
         control = ValueSpinBox(
             display_suffix(metadata),
             minimum,
             maximum,
-            metadata.get("step"),
-            metadata.get("decimals"),
+            metadata.get("step") if metadata.get("step") is not None else defaults.step,
+            metadata.get("decimals") if metadata.get("decimals") is not None else defaults.decimals,
         )
         control.setValue(value * scale)
         return Control(
@@ -269,5 +413,23 @@ def build_control(
             signals=(control.valueChanged,),
         )
 
-    logging.warning("No control for field of type %r (value %r)", type_, type(value))
-    return None
+    if inspect.isclass(kind) and issubclass(kind, Enum):
+        return _combo(list(kind), value, metadata)
+
+    if get_origin(annotation) is list or (
+        inspect.isclass(kind) and issubclass(kind, list)
+    ):
+        item_types = get_args(annotation)
+        if not item_types or item_types[0] in (bool, int, float, str):
+            return _scalar_list(value, annotation)
+
+    if annotation is None:
+        # A milling form, which has no annotation to fall back on: nothing here
+        # can render this, and there is no value in showing it disabled.
+        logging.warning("No control for field of type %r (value %r)", type_, type(value))
+        return None
+
+    # Debug, not warning: the form says this itself, visibly and in the right
+    # place -- greyed out with a tooltip naming where to edit it instead.
+    logging.debug("No editor for %r; showing it read-only.", kind)
+    return _read_only(value, kind)

--- a/tests/ui/test_form_builder.py
+++ b/tests/ui/test_form_builder.py
@@ -26,7 +26,12 @@ from fibsem.ui.widgets.custom_widgets import (
     ValueComboBox,
     ValueSpinBox,
 )
-from fibsem.ui.widgets.form_builder import build_control, display_suffix, effective_scale
+from fibsem.ui.widgets.form_builder import (
+    FormDefaults,
+    build_control,
+    display_suffix,
+    effective_scale,
+)
 
 
 def meta(**kwargs) -> dict:
@@ -134,7 +139,11 @@ def test_an_int_field_steps_by_at_least_its_own_scale(qapp):
 
 
 def test_declared_bounds_win_over_the_fallback(qapp):
-    control = build_control(meta(type=float, minimum=-5.0, maximum=5.0), 0.0, float_range=(-1e9, 1e9))
+    control = build_control(
+        meta(type=float, minimum=-5.0, maximum=5.0),
+        0.0,
+        defaults=FormDefaults(float_range=(-1e9, 1e9)),
+    )
 
     assert (control.widget.minimum(), control.widget.maximum()) == (-5.0, 5.0)
 
@@ -147,7 +156,7 @@ def test_the_fallback_range_fills_in_undeclared_bounds(qapp):
     passes the bounds it already had, so a form's ranges do not change just
     because the builder is now shared.
     """
-    control = build_control(meta(type=float), 0.0, float_range=(-1e10, 1e10))
+    control = build_control(meta(type=float), 0.0, defaults=FormDefaults(float_range=(-1e10, 1e10)))
 
     assert (control.widget.minimum(), control.widget.maximum()) == (-1e10, 1e10)
 

--- a/tests/ui/test_task_config_parameter_widgets.py
+++ b/tests/ui/test_task_config_parameter_widgets.py
@@ -35,17 +35,24 @@ from PyQt5.QtWidgets import (  # noqa: E402
 
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig  # noqa: E402
 from fibsem.ui.widgets.autolamella_task_config_widget import (  # noqa: E402
+    TASK_FORM_DEFAULTS,
     AutoLamellaTaskConfigWidget,
     AutoLamellaTaskParametersConfigWidget,
-    BoolParameterWidget,
-    ComboParameterWidget,
-    EnumParameterWidget,
-    FloatParameterWidget,
-    IntParameterWidget,
-    ListParameterWidget,
-    ReadOnlyParameterWidget,
-    StringParameterWidget,
 )
+from fibsem.ui.widgets.custom_widgets import (  # noqa: E402
+    IntegerValueSpinBox,
+    ValueComboBox,
+    ValueSpinBox,
+)
+
+
+def _control(form, field_name):
+    """The Control adapter the shared builder produced for *field_name*.
+
+    The form used to hold a ParameterWidget per field; it now holds a row whose
+    `control` carries the widget and its read/write adapters (FIB-526).
+    """
+    return next(row.control for row in form._rows if row.field == field_name)
 
 
 class Flavour(Enum):
@@ -97,14 +104,14 @@ def _build(form_cls, config):
 @pytest.mark.parametrize(
     "field_name,expected_widget",
     [
-        ("a_bool", BoolParameterWidget),
-        ("an_int", IntParameterWidget),
-        ("a_float", FloatParameterWidget),
-        ("a_string", StringParameterWidget),
-        ("an_enum", EnumParameterWidget),
-        ("a_scalar_list", ListParameterWidget),
-        ("an_optional_float", FloatParameterWidget),
-        ("with_items", ComboParameterWidget),
+        ("a_bool", QCheckBox),
+        ("an_int", IntegerValueSpinBox),
+        ("a_float", ValueSpinBox),
+        ("a_string", QLineEdit),
+        ("an_enum", ValueComboBox),
+        ("a_scalar_list", QLineEdit),
+        ("an_optional_float", ValueSpinBox),
+        ("with_items", ValueComboBox),
     ],
 )
 def test_editable_field_types_keep_their_editors(
@@ -113,10 +120,10 @@ def test_editable_field_types_keep_their_editors(
     """Every type the form genuinely supports is untouched by the read-only fallback."""
     form = _build(form_cls, SampleTaskConfig())
 
-    param_widget = form.parameter_widgets[field_name]
+    control = _control(form, field_name)
 
-    assert isinstance(param_widget, expected_widget)
-    assert param_widget.editable
+    assert isinstance(control.widget, expected_widget)
+    assert control.editable
 
 
 @pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
@@ -129,10 +136,10 @@ def test_a_field_the_form_cannot_edit_is_shown_read_only(qapp, form_cls, field_n
     """
     form = _build(form_cls, SampleTaskConfig())
 
-    param_widget = form.parameter_widgets[field_name]
+    param_widget = _control(form, field_name)
     widget = param_widget.widget
 
-    assert isinstance(param_widget, ReadOnlyParameterWidget)
+    assert not param_widget.editable
     assert not param_widget.editable
     assert isinstance(widget, QLineEdit)
     assert widget.isReadOnly() and not widget.isEnabled()
@@ -160,7 +167,7 @@ def test_tabbing_past_an_uneditable_field_leaves_the_value_alone(
     layout.addWidget(elsewhere)
     host.show()
 
-    nested_box = form.parameter_widgets["nested"].widget
+    nested_box = _control(form, "nested").widget
     nested_box.setFocus(Qt.MouseFocusReason)
     qapp.processEvents()
     elsewhere.setFocus(Qt.MouseFocusReason)
@@ -211,7 +218,7 @@ def test_an_editable_field_still_writes_through(qapp, form_cls):
     config = SampleTaskConfig()
     form = _build(form_cls, config)
 
-    form.parameter_widgets["a_float"].widget.setValue(9.0)
+    _control(form, "a_float").widget.setValue(9.0)
     form._on_parameter_changed("a_float")
 
     assert config.a_float == 9.0
@@ -229,11 +236,10 @@ def test_a_literal_field_offers_its_allowed_values(qapp, form_cls):
     config = SampleTaskConfig()
     form = _build(form_cls, config)
 
-    param_widget = form.parameter_widgets["a_literal"]
+    param_widget = _control(form, "a_literal")
     combo = param_widget.widget
 
-    assert isinstance(param_widget, ComboParameterWidget)
-    assert isinstance(combo, QComboBox)
+    assert isinstance(combo, ValueComboBox)
     assert [combo.itemData(i) for i in range(combo.count())] == ["cells", "hpf", "other"]
     assert combo.currentData() == "hpf"
 
@@ -248,8 +254,8 @@ def test_no_signal_is_connected_to_an_uneditable_field(qapp, form_cls):
     config = SampleTaskConfig()
     form = _build(form_cls, config)
 
-    nested_box = form.parameter_widgets["nested"].widget
-    editable_box = form.parameter_widgets["a_string"].widget
+    nested_box = _control(form, "nested").widget
+    editable_box = _control(form, "a_string").widget
 
     assert nested_box.receivers(nested_box.editingFinished) == 0
     assert editable_box.receivers(editable_box.editingFinished) == 1
@@ -268,8 +274,110 @@ def test_every_widget_type_the_form_builds_is_connectable(qapp, form_cls):
 
     unconnectable = [
         name
-        for name, param_widget in form.parameter_widgets.items()
+        for name, param_widget in ((r.field, r.control) for r in form._rows)
         if param_widget.editable and not isinstance(param_widget.widget, known)
     ]
 
     assert unconnectable == []
+
+
+# --- the vocabulary the task form could not read before (FIB-526) -------------
+
+
+@dataclass
+class VocabularyTaskConfig(AutoLamellaTaskConfig):
+    """A task config declaring the keys the form used to ignore.
+
+    Every one of these was already valid metadata that a pattern or strategy
+    honoured. The task form read four keys and silently dropped the rest, so
+    declaring them here did nothing at all.
+    """
+
+    task_type: ClassVar[str] = "VOCABULARY_TEST"
+    display_name: ClassVar[str] = "Vocabulary Test"
+
+    bounded: float = field(
+        default=5.0,
+        metadata={"minimum": -20.0, "maximum": 20.0, "step": 0.5, "decimals": 4},
+    )
+    bounded_int: int = field(default=3, metadata={"minimum": 1, "maximum": 9})
+    tucked_away: bool = field(default=True, metadata={"advanced": True})
+    not_shown: bool = field(default=True, metadata={"hidden": True})
+    labelled: float = field(default=1.0, metadata={"label": "Custom Label"})
+    maybe_text: Optional[str] = None
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_declared_bounds_reach_the_spinbox(qapp, form_cls):
+    """The headline: an int field used to get the full 32-bit range regardless.
+
+    Nothing could tell the form otherwise, so a field with a real range had no
+    way to say so and an operator could type any integer at all.
+    """
+    form = _build(form_cls, VocabularyTaskConfig())
+
+    spin = _control(form, "bounded").widget
+    assert (spin.minimum(), spin.maximum()) == (-20.0, 20.0)
+    assert spin.singleStep() == 0.5
+    assert spin.decimals() == 4
+
+    int_spin = _control(form, "bounded_int").widget
+    assert (int_spin.minimum(), int_spin.maximum()) == (1, 9)
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_an_undeclared_field_keeps_the_form_defaults(qapp, form_cls):
+    """Moving onto the shared builder must not silently retune existing forms.
+
+    `ValueSpinBox` would otherwise supply (0.0, 1e6) -- a floor of zero on every
+    float field that never declared a minimum, which clamps without erroring.
+    """
+    form = _build(form_cls, VocabularyTaskConfig())
+
+    spin = _control(form, "labelled").widget
+    assert (spin.minimum(), spin.maximum()) == TASK_FORM_DEFAULTS.float_range
+    assert spin.decimals() == TASK_FORM_DEFAULTS.decimals
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_a_hidden_field_gets_no_row(qapp, form_cls):
+    form = _build(form_cls, VocabularyTaskConfig())
+
+    assert [row.field for row in form._rows].count("not_shown") == 0
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_an_advanced_field_is_built_but_hidden_until_asked_for(qapp, form_cls):
+    """Advanced is a disclosure level, not a deletion -- the row still exists."""
+    form = _build(form_cls, VocabularyTaskConfig())
+
+    row = next(r for r in form._rows if r.field == "tucked_away")
+    assert row.advanced
+    assert not row.control.widget.isVisibleTo(form)
+
+    form.set_advanced_visible(True)
+    assert row.control.widget.isVisibleTo(form)
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_a_declared_label_is_used(qapp, form_cls):
+    """One of the two containers already did this and the other did not."""
+    form = _build(form_cls, VocabularyTaskConfig())
+
+    row = next(r for r in form._rows if r.field == "labelled")
+    assert row.label.text() == "Custom Label"
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_an_unset_optional_string_reads_back_as_none(qapp, form_cls):
+    """It used to render the literal text "None" and read that straight back.
+
+    AcquireReferenceImage.filename is Optional[str] and defaults to None,
+    meaning "generate one". The box showed "None", and a focus-out was enough to
+    write that four-character string onto the config as the filename.
+    """
+    form = _build(form_cls, VocabularyTaskConfig())
+
+    control = _control(form, "maybe_text")
+    assert control.widget.text() == ""
+    assert control.read() is None


### PR DESCRIPTION
Completes FIB-526, on top of #319.

The task form read raw `dataclasses.fields(...).metadata` and understood **four keys**, so most of the canonical vocabulary was simply unavailable to it:

- no `minimum` / `maximum` — an int field got the full 32-bit range because nothing could say otherwise
- no `step` / `decimals` — floats got Qt's defaults
- no `hidden` / `advanced` — every field always shown
- no `format_fn`

Patterns and strategies had all of this already.

`AutoLamellaTaskConfig` gains the `field_metadata` property its milling counterparts have, and both containers build rows through the shared `build_control()` from #319. The `ParameterWidget` hierarchy — eight classes, each with its own get/set and its own copy of the SI-suffix logic — is gone.

## What the builder had to grow

Only what the task form needed and the milling forms never did: annotation-based dispatch for configs that declare no metadata `type`, `Optional[T]` unwrapping, `Literal` and `Enum` combos, scalar lists, and a read-only control for a type it has no editor for.

Metadata `type` still wins where declared, so **the milling forms are untouched** — verified, 0 differences across both dumps.

## `FormDefaults`, and why the rendering does not change

The task form passes the bounds and precision it already hardcoded (`±1e10`, 32-bit ints, step 1.0, 2 decimals). So declaring a real `minimum` is now a **visible change** rather than a side effect of this move.

Without it, every float field would have inherited `ValueSpinBox`'s `(0.0, 1e6)` — a silent floor of zero on anything that never declared a minimum. That is not hypothetical: #319 hit exactly this on the Point row.

## Verification

Dumped the rendered form for **all twelve built-in task configs** and diffed against main — every bound, step, decimal, suffix, value, tooltip and editable flag unchanged.

| Form | Differences vs main |
|---|---|
| Pattern + strategy | **0** |
| Milling settings | **0** |
| Task parameters | control classes (now the shared subclasses of the same Qt types), plus one bug fix |

1,599 tests pass. The 8 ported tests from #301 keep their coverage — they now assert on the Qt control and the `editable` contract rather than on class identity — plus 6 new ones for the newly honoured keys.

## A real bug fixed

An `Optional[str]` field defaulting to `None` rendered the **literal text `"None"`** and read it straight back.

`AcquireReferenceImageConfig.filename` is `Optional[str]` where `None` means "auto-generate from the last task name and a timestamp". So tabbing through the form was enough to set the filename to the four-character string `"None"` — a `QLineEdit` emits `editingFinished` on focus loss, no typing required. `AcquireFluorescenceImageConfig.orientation` was affected the same way.

An empty box on an `Optional` field now reads as `None`. Both fields round-trip exactly where they previously did not.