### PR TITLE
[ui] Add a correlation point overlay on the shared canvas stack (FIB-535)

### DIFF
--- a/fibsem/ui/correlation/widgets/correlation_point_overlay.py
+++ b/fibsem/ui/correlation/widgets/correlation_point_overlay.py
@@ -1,0 +1,219 @@
+"""Correlation points on the shared canvas stack (FIB-535).
+
+``CorrelationPointOverlay`` subclasses :class:`PointOverlay` and swaps its point
+model for ``Coordinate`` — which is the whole reason this class exists.
+
+Correlation points are not interchangeable: a ``Coordinate`` carries a
+``PointType``, and the tab widget's registry keys exclusivity and lifecycle off
+that identity (every handler's first line is ``self._point_specs[...]``, and one
+removal path filters with ``c is not coord`` — object identity, not equality).
+An index cannot stand in for that.
+
+Two things follow, and they are why a subclass beats widening ``PointOverlay``:
+
+* **Identity travels in the signals.** Base signals stay index-based for their
+  five existing consumers; the identity-carrying ones live here, where they are
+  the API rather than dead weight.
+* **One surface shows several ``PointType``s at once.** ``PointOverlay`` is a
+  single flat list with one style; holding ``List[Coordinate]`` here makes that
+  a non-problem instead of something to translate.
+
+``_coords`` is index-aligned with the base's ``_points``. That alignment is safe
+because the base mutates ``_points`` structurally in exactly four public methods
+(``set_points`` / ``add_point`` / ``remove_point`` / ``clear_points``), all
+overridden below; its fifth mutation is the drag, which moves a point without
+reordering. Index bookkeeping on removal — including shifting ``_selected`` —
+stays in the base, which is precisely the part a translation layer would have
+had to reimplement.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from PyQt5.QtCore import pyqtSignal
+
+from fibsem.correlation.structures import Coordinate, PointType
+from fibsem.ui.tokens import ORANGE_COLOR
+from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
+
+# Saturated primaries, chosen to stay legible against arbitrary image content
+# rather than to match the app palette — the same reasoning that keeps the
+# NEUTRAL_* ramp out of the tinted tokens.
+POINT_COLORS: Dict[PointType, str] = {
+    PointType.FIB:        "#00ff00",
+    PointType.FM:         "#00e5ff",
+    PointType.POI:        "#ff00ff",
+    PointType.SURFACE:    ORANGE_COLOR,
+    PointType.SURFACE_FM: "#ffea00",
+}
+POINT_MARKERS: Dict[PointType, str] = {
+    PointType.FIB:        "o",
+    PointType.FM:         "o",
+    PointType.POI:        "o",
+    PointType.SURFACE:    "+",
+    PointType.SURFACE_FM: "+",
+}
+MARKER_SIZE = 5.0  # the base draws the selected marker at size * 1.4 = 7.0
+
+
+def generate_names(coordinates: List[Coordinate]) -> List[str]:
+    """Per-type 1-based names: ``FIB 1``, ``FIB 2``, ``POI 1`` ...
+
+    Numbered within a type rather than across the list, so a point's label does
+    not change when an unrelated type gains or loses one.
+    """
+    counters: Dict[PointType, int] = {}
+    names = []
+    for c in coordinates:
+        counters[c.point_type] = counters.get(c.point_type, 0) + 1
+        names.append(f"{c.point_type.value} {counters[c.point_type]}")
+    return names
+
+
+class CorrelationPointOverlay(PointOverlay):
+    """Interactive correlation points, addressed by ``Coordinate`` identity."""
+
+    # Identity-carrying counterparts of the base's index-based signals. The base
+    # ones still fire; consumers here should use these.
+    coordinate_selected = pyqtSignal(object)  # Coordinate
+    coordinate_moved = pyqtSignal(object)  # Coordinate (drag finished)
+    coordinate_removed = pyqtSignal(object)  # Coordinate (before removal)
+    # The view decides which PointType a new point gets (it owns the menu), so
+    # the overlay only reports where the user asked for one.
+    add_requested = pyqtSignal(float, float)  # x, y
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(size=MARKER_SIZE, parent=parent)
+        self._coords: List[Coordinate] = []
+        self._names: List[str] = []
+        self.point_selected.connect(self._emit_selected)
+        self.point_moved.connect(self._emit_moved)
+        self.point_removed.connect(self._emit_removed)
+
+    # ── model ─────────────────────────────────────────────────────────────
+
+    def set_coordinates(self, coords: List[Coordinate]) -> None:
+        """Replace the displayed set. Coordinates are held by reference, so the
+        objects handed back by the signals are the caller's own."""
+        self._coords = list(coords)
+        self._names = generate_names(self._coords)
+        self.set_points([(c.point.x, c.point.y) for c in self._coords])
+
+    def add_coordinate(self, coord: Coordinate) -> int:
+        self._coords.append(coord)
+        self._names = generate_names(self._coords)
+        idx = super().add_point(coord.point.x, coord.point.y)
+        self._refresh_labels()
+        return idx
+
+    def remove_coordinate(self, coord: Coordinate) -> None:
+        idx = self.index_of(coord)
+        if idx is not None:
+            self.remove_point(idx)
+
+    def coordinates(self) -> List[Coordinate]:
+        return list(self._coords)
+
+    def index_of(self, coord: Optional[Coordinate]) -> Optional[int]:
+        """Index of *coord* by object identity, not equality — two coordinates
+        can hold equal values and still be different points."""
+        for i, c in enumerate(self._coords):
+            if c is coord:
+                return i
+        return None
+
+    def selected_coordinate(self) -> Optional[Coordinate]:
+        idx = self._selected
+        return self._coords[idx] if idx is not None and idx < len(self._coords) else None
+
+    def set_selected_coordinate(self, coord: Optional[Coordinate]) -> None:
+        """Select by identity. Silent, like the base's ``set_selected``."""
+        self.set_selected(self.index_of(coord))
+
+    def refresh_coordinate(self, coord: Coordinate) -> None:
+        """Re-read a coordinate's position after an external edit."""
+        idx = self.index_of(coord)
+        if idx is None:
+            return
+        self._points[idx] = [float(coord.point.x), float(coord.point.y)]
+        self._update_artist_position(idx)
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    # ── base overrides keeping _coords aligned ────────────────────────────
+
+    def add_point(self, x: float, y: float) -> int:
+        """Not available: a correlation point needs a PointType, which only the
+        view can supply. Raises rather than appending, because a point without a
+        matching entry in ``_coords`` desynchronises the two lists silently."""
+        raise NotImplementedError("use add_coordinate(); a bare point has no PointType")
+
+    def remove_point(self, index: int) -> None:
+        if index < 0 or index >= len(self._coords):
+            return
+        # super() emits point_removed(index) before it pops, so _emit_removed can
+        # still read _coords[index]; pop only once it returns.
+        super().remove_point(index)
+        self._coords.pop(index)
+        self._names = generate_names(self._coords)
+        self._refresh_labels()
+
+    def clear_points(self) -> None:
+        super().clear_points()
+        self._coords.clear()
+        self._names = []
+
+    # ── per-point style ───────────────────────────────────────────────────
+
+    def _point_color(self, idx: int, selected: bool) -> str:
+        """Colour by type. A selected point keeps its own colour — the rim and
+        size carry the selection instead, so the type stays readable."""
+        if idx >= len(self._coords):
+            return super()._point_color(idx, selected)
+        return POINT_COLORS.get(self._coords[idx].point_type, "white")
+
+    def _point_marker(self, idx: int) -> str:
+        if idx >= len(self._coords):
+            return super()._point_marker(idx)
+        return POINT_MARKERS.get(self._coords[idx].point_type, "o")
+
+    def _point_label(self, idx: int) -> Optional[str]:
+        return self._names[idx] if idx < len(self._names) else None
+
+    def _marker_edge(self, idx: int, color: str, selected: bool):
+        """Filled markers show selection as a white rim; unfilled ones ("+") are
+        drawn entirely by their edge, so a white edge would replace the type
+        colour and "none" would erase the marker — they thicken instead."""
+        from matplotlib.lines import Line2D
+
+        if self._point_marker(idx) in Line2D.filled_markers:
+            return ("white" if selected else "none"), 2.0
+        return color, (3.0 if selected else 2.0)
+
+    # ── interaction ───────────────────────────────────────────────────────
+
+    def _on_right_click(self, x: float, y: float) -> None:
+        """Report the request and add nothing: the view has to ask which
+        PointType before a Coordinate can exist."""
+        self.add_requested.emit(x, y)
+
+    # ── index → identity ──────────────────────────────────────────────────
+
+    def _emit_selected(self, idx: int, x: float, y: float) -> None:
+        if idx < len(self._coords):
+            self.coordinate_selected.emit(self._coords[idx])
+
+    def _emit_moved(self, idx: int, x: float, y: float) -> None:
+        if idx >= len(self._coords):
+            return
+        coord = self._coords[idx]
+        coord.point.x, coord.point.y = float(x), float(y)
+        self.coordinate_moved.emit(coord)
+
+    def _emit_removed(self, idx: int) -> None:
+        if idx < len(self._coords):
+            self.coordinate_removed.emit(self._coords[idx])
+
+    def _refresh_labels(self) -> None:
+        if self._anns:
+            self._refresh_ann_text()

--- a/fibsem/ui/correlation/widgets/correlation_tab_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_tab_widget.py
@@ -1388,6 +1388,14 @@ class _CanvasAdapter:
     stack (fibsem.ui.widgets.canvas, PR #111, index-based PointOverlay
     signals) therefore means new adapters PLUS an inbound translation layer;
     what stays untouched is the registry, exclusivity, and lifecycle logic.
+
+    Superseded in part (FIB-535): the translation layer above is no longer the
+    plan. A CorrelationPointOverlay subclassing PointOverlay carries Coordinate
+    identity in its own signals, so nothing has to be translated back from an
+    index — and it also resolves the second mismatch this note misses, that one
+    canvas shows several PointTypes at once while PointOverlay is a single flat
+    list. The last sentence still holds: registry, exclusivity and lifecycle
+    stay untouched.
     """
 
     def __init__(

--- a/fibsem/ui/correlation/widgets/image_point_canvas.py
+++ b/fibsem/ui/correlation/widgets/image_point_canvas.py
@@ -60,24 +60,19 @@ from fibsem.ui.tokens import (
     GRAY_TEXT_COLOR,
     NEUTRAL_200,
     NEUTRAL_450,
-    ORANGE_COLOR,
 )
+from fibsem.ui.correlation.widgets.correlation_point_overlay import (
+    POINT_COLORS,
+    POINT_MARKERS,
+)
+
 _logger = logging.getLogger(__name__)
 
-_POINT_COLORS: Dict[PointType, str] = {
-    PointType.FIB:        "#00ff00",
-    PointType.FM:         "#00e5ff",
-    PointType.POI:        "#ff00ff",
-    PointType.SURFACE:    f"{ORANGE_COLOR}",
-    PointType.SURFACE_FM: "#ffea00",
-}
-_POINT_MARKERS: Dict[PointType, str] = {
-    PointType.FIB:        "o",
-    PointType.FM:         "o",
-    PointType.POI:        "o",
-    PointType.SURFACE:    "+",
-    PointType.SURFACE_FM: "+",
-}
+# Single source while this canvas and CorrelationPointOverlay coexist (FIB-535):
+# the same points are about to be drawn by both, and two copies of the table
+# would let them drift apart mid-migration. Deleted with this module.
+_POINT_COLORS = POINT_COLORS
+_POINT_MARKERS = POINT_MARKERS
 _MARKER_SIZE     = 5
 _SELECTED_SIZE   = 7
 _PICK_RADIUS_PX  = 15

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -441,7 +441,33 @@ class PointOverlay(QObject):
         self._ax.add_artist(leg)
         self._legend = leg
 
-    def _marker_edge(self, color: str, selected: bool):
+    def _on_right_click(self, x: float, y: float) -> None:
+        """Handle a right-click at content coordinates *x*, *y*.
+
+        Adds a point immediately and selects it. Split out from ``_on_press`` so a
+        subclass can defer instead — correlation has to ask which ``PointType``
+        before a point exists, so it emits a request and adds nothing here.
+        """
+        idx = self.add_point(x, y)
+        old_sel = self._selected
+        self._selected = idx
+        if old_sel is not None:
+            self._update_artist_appearance(old_sel)
+        self._update_artist_appearance(idx)
+        self.point_added.emit(idx, x, y)
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def _point_marker(self, idx: int) -> str:
+        """Marker glyph for a point.
+
+        One glyph for every point here. Overridable so a subclass can vary it per
+        point without reimplementing the artist path — correlation draws SURFACE
+        types as "+" and everything else as "o".
+        """
+        return self._marker
+
+    def _marker_edge(self, idx: int, color: str, selected: bool):
         """Edge colour/width for the marker. Unfilled markers (+, x, ...) are drawn
         in their edge colour, so they take the point colour and a thicker line;
         filled markers (o, s, ...) keep a thin white outline for contrast.
@@ -450,7 +476,7 @@ class PointOverlay(QObject):
         adds a fixed bump, so backward-compatible defaults are preserved when unset.
         """
         from matplotlib.lines import Line2D
-        if self._marker in Line2D.filled_markers:
+        if self._point_marker(idx) in Line2D.filled_markers:
             base = self._edge_width if self._edge_width is not None else 0.8
             return "white", (base + 1.2 if selected else base)
         base = self._edge_width if self._edge_width is not None else 2.0
@@ -482,11 +508,11 @@ class PointOverlay(QObject):
         selected = idx == self._selected
         color = self._point_color(idx, selected)
         ms = self._size * 1.4 if selected else self._size
-        edge_color, mew = self._marker_edge(color, selected)
+        edge_color, mew = self._marker_edge(idx, color, selected)
         (line,) = self._ax.plot(
             x,
             y,
-            marker=self._marker,
+            marker=self._point_marker(idx),
             markersize=ms,
             color=color,
             markeredgecolor=edge_color,
@@ -519,7 +545,7 @@ class PointOverlay(QObject):
         selected = idx == self._selected
         color = self._point_color(idx, selected)
         ms = self._size * 1.4 if selected else self._size
-        edge_color, mew = self._marker_edge(color, selected)
+        edge_color, mew = self._marker_edge(idx, color, selected)
         line = self._artists[idx]
         line.set_color(color)
         line.set_markersize(ms)
@@ -605,15 +631,7 @@ class PointOverlay(QObject):
         if event.button == 3:  # right-click → add a new point
             if not self._add_on_right_click:
                 return
-            x, y = self._clamp_to_content(event.xdata, event.ydata)
-            idx = self.add_point(x, y)
-            old_sel = self._selected
-            self._selected = idx
-            if old_sel is not None:
-                self._update_artist_appearance(old_sel)
-            self._update_artist_appearance(idx)
-            self.point_added.emit(idx, x, y)
-            self._canvas.draw_idle()
+            self._on_right_click(*self._clamp_to_content(event.xdata, event.ydata))
             return
 
         if event.button != 1:

--- a/tests/correlation/test_correlation_point_overlay.py
+++ b/tests/correlation/test_correlation_point_overlay.py
@@ -9,6 +9,9 @@ import sys
 
 import numpy as np
 import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] without the UI extra
+
 from PyQt5.QtWidgets import QApplication
 
 from fibsem.correlation.structures import Coordinate, PointType, PointXYZ

--- a/tests/correlation/test_correlation_point_overlay.py
+++ b/tests/correlation/test_correlation_point_overlay.py
@@ -1,0 +1,202 @@
+"""CorrelationPointOverlay: Coordinate identity survives the index-based base.
+
+The point of the subclass is that callers address points by object identity while
+PointOverlay addresses them by index. These tests pin the seam between the two --
+above all the cases where indices shift under the caller (removal), which is where
+an index<->identity translation layer would have broken.
+"""
+import sys
+
+import numpy as np
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.correlation.structures import Coordinate, PointType, PointXYZ
+from fibsem.ui.correlation.widgets.correlation_point_overlay import (
+    POINT_COLORS,
+    CorrelationPointOverlay,
+    generate_names,
+)
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _coord(x, y, pt=PointType.FIB):
+    return Coordinate(PointXYZ(x, y, 0.0), pt)
+
+
+def _attached(coords):
+    canvas = FibsemImageCanvas()
+    canvas.set_array(np.zeros((64, 64), dtype=np.uint8))
+    ov = CorrelationPointOverlay()
+    canvas.add_overlay(ov)
+    ov.set_coordinates(coords)
+    return canvas, ov
+
+
+# ── identity ──────────────────────────────────────────────────────────────
+
+
+def test_selection_emits_the_caller_s_own_object():
+    a, b = _coord(10, 10), _coord(20, 20)
+    _, ov = _attached([a, b])
+    seen = []
+    ov.coordinate_selected.connect(seen.append)
+
+    ov.point_selected.emit(1, 20.0, 20.0)
+
+    assert len(seen) == 1
+    assert seen[0] is b  # identity, not equality
+
+
+def test_drag_writes_back_into_the_coordinate():
+    c = _coord(10, 10)
+    _, ov = _attached([c])
+    seen = []
+    ov.coordinate_moved.connect(seen.append)
+
+    ov.point_moved.emit(0, 33.0, 44.0)
+
+    assert (c.point.x, c.point.y) == (33.0, 44.0)
+    assert seen == [c]
+
+
+def test_removal_reports_identity_before_the_point_goes():
+    a, b = _coord(10, 10), _coord(20, 20)
+    _, ov = _attached([a, b])
+    seen = []
+    ov.coordinate_removed.connect(seen.append)
+
+    ov.remove_coordinate(a)
+
+    assert seen == [a]
+    assert ov.coordinates() == [b]
+
+
+# ── the case a translation layer would have broken ────────────────────────
+
+
+def test_indices_shift_but_identity_does_not():
+    a, b, c = _coord(10, 10), _coord(20, 20), _coord(30, 30)
+    _, ov = _attached([a, b, c])
+
+    ov.remove_coordinate(a)  # every later index shifts down by one
+
+    assert ov.coordinates() == [b, c]
+    assert ov.index_of(b) == 0 and ov.index_of(c) == 1
+    seen = []
+    ov.coordinate_selected.connect(seen.append)
+    ov.point_selected.emit(1, 30.0, 30.0)
+    assert seen == [c]  # index 1 is now c, not b
+
+
+def test_selection_follows_its_point_across_a_removal():
+    a, b = _coord(10, 10), _coord(20, 20)
+    _, ov = _attached([a, b])
+    ov.set_selected_coordinate(b)
+    assert ov.selected_coordinate() is b
+
+    ov.remove_coordinate(a)  # base shifts _selected 1 -> 0
+
+    assert ov.selected_coordinate() is b
+
+
+def test_equal_but_distinct_coordinates_are_not_confused():
+    a, b = _coord(10, 10), _coord(10, 10)  # equal values, different objects
+    _, ov = _attached([a, b])
+
+    assert a == b
+    assert ov.index_of(a) == 0 and ov.index_of(b) == 1
+
+
+def test_geometry_and_identity_stay_aligned_after_edits():
+    a, b, c = _coord(10, 10), _coord(20, 20), _coord(30, 30)
+    _, ov = _attached([a, b, c])
+    ov.remove_coordinate(b)
+    ov.add_coordinate(_coord(40, 40, PointType.POI))
+
+    assert ov.get_points() == [(c.point.x, c.point.y) for c in ov.coordinates()]
+
+
+# ── heterogeneous types on one surface ────────────────────────────────────
+
+
+def test_one_overlay_carries_several_point_types():
+    fib, poi, surf = (
+        _coord(10, 10, PointType.FIB),
+        _coord(20, 20, PointType.POI),
+        _coord(30, 30, PointType.SURFACE),
+    )
+    _, ov = _attached([fib, poi, surf])
+
+    assert ov._point_color(0, False) == POINT_COLORS[PointType.FIB]
+    assert ov._point_color(1, False) == POINT_COLORS[PointType.POI]
+    assert ov._point_marker(0) == "o"
+    assert ov._point_marker(2) == "+"  # SURFACE is a crosshair
+
+
+def test_selected_point_keeps_its_type_colour():
+    """Selection is carried by rim and size so the type stays readable."""
+    c = _coord(10, 10, PointType.POI)
+    _, ov = _attached([c])
+    assert ov._point_color(0, True) == POINT_COLORS[PointType.POI]
+    assert ov._marker_edge(0, POINT_COLORS[PointType.POI], True)[0] == "white"
+
+
+def test_unfilled_markers_thicken_rather_than_whiten():
+    c = _coord(10, 10, PointType.SURFACE)
+    _, ov = _attached([c])
+    colour = POINT_COLORS[PointType.SURFACE]
+    assert ov._marker_edge(0, colour, False) == (colour, 2.0)
+    assert ov._marker_edge(0, colour, True) == (colour, 3.0)
+
+
+# ── labels ────────────────────────────────────────────────────────────────
+
+
+def test_names_are_numbered_within_a_type():
+    coords = [
+        _coord(0, 0, PointType.FIB),
+        _coord(1, 1, PointType.POI),
+        _coord(2, 2, PointType.FIB),
+    ]
+    assert generate_names(coords) == ["FIB 1", "POI 1", "FIB 2"]
+
+
+def test_labels_renumber_after_a_removal():
+    a, b, c = (
+        _coord(0, 0, PointType.FIB),
+        _coord(1, 1, PointType.FIB),
+        _coord(2, 2, PointType.FIB),
+    )
+    _, ov = _attached([a, b, c])
+    ov.remove_coordinate(a)
+    assert [ov._point_label(i) for i in range(2)] == ["FIB 1", "FIB 2"]
+
+
+# ── interaction contract ──────────────────────────────────────────────────
+
+
+def test_right_click_asks_rather_than_adds():
+    _, ov = _attached([])
+    seen = []
+    ov.add_requested.connect(lambda x, y: seen.append((x, y)))
+
+    ov._on_right_click(12.0, 34.0)
+
+    assert seen == [(12.0, 34.0)]
+    assert ov.coordinates() == []  # nothing added until the view supplies a type
+
+
+def test_bare_add_point_is_refused():
+    """A point with no matching Coordinate would desync the two lists silently."""
+    _, ov = _attached([])
+    with pytest.raises(NotImplementedError):
+        ov.add_point(1.0, 2.0)
+
+
+def test_clear_drops_both_lists():
+    _, ov = _attached([_coord(10, 10), _coord(20, 20)])
+    ov.clear_points()
+    assert ov.coordinates() == [] and ov.get_points() == []


### PR DESCRIPTION
First step of FIB-535. **Groundwork only — nothing imports `CorrelationPointOverlay` yet**, so the correlation tab still draws on `ImagePointCanvas` and behaviour is unchanged.

## The problem

Correlation points are addressed by identity, not position. A `Coordinate` carries a `PointType`; every registry handler in `correlation_tab_widget` dispatches on it as its first line, and one removal path filters with `c is not coord` — object identity, not equality. `PointOverlay` is index-based. Those two contracts have to meet somewhere.

## Why a subclass

The issue originally proposed two options, and measuring changed the answer:

- **A translation layer** (`index -> Coordinate`) would have to reproduce the base's index bookkeeping — including shifting `_selected` down when an earlier point is removed — and hand back the *same* object, not an equal one. That's reimplementing the fiddly part.
- **Widening `PointOverlay`** with optional identity taxes five consumers with a concept none of them has. And it doesn't even save code: a subclass can't change an inherited signal's type, so identity-carrying signals have to be new either way. On the base they're dead weight; here they're the API.

The subclass also **dissolves a second mismatch instead of bridging it**: one correlation canvas shows several `PointType`s at once, each with its own colour and glyph, where `PointOverlay` is a single flat list with one style. Holding `List[Coordinate]` makes that a non-problem rather than something to translate.

## Why the alignment is safe

`_coords` is index-aligned with the base's `_points`. That holds because the base mutates `_points` **structurally** in exactly four places, all public and all overridden here:

```
set_points  add_point  remove_point  clear_points
```

Its fifth mutation is the drag (`_points[i] = [x, y]`), which moves a point without reordering, so alignment survives it untouched. `remove_point` also emits `point_removed(index)` *before* popping, so the identity signal can still read `_coords[index]`.

Index bookkeeping stays in the base — which is exactly the part a translation layer would have owned and got wrong.

`add_point()` raises rather than appending: a point with no matching `Coordinate` desyncs the two lists silently, and silent is the failure mode worth spending an exception on.

## Base changes — three, all behaviour-neutral

`PointOverlay`'s per-point policy was *already* factored into hooks (`_point_color(idx, selected)`, `_point_label(idx)` are methods, not inline lookups). Only the glyph was still fixed:

- **`_point_marker(idx)`** added alongside them, returning `self._marker`.
- **`_marker_edge()` takes `idx`** so it can consult that hook. Private, two internal call sites, no external users.
- **The right-click branch of `_on_press()` extracted to `_on_right_click(x, y)`**, so a subclass can defer instead of adding immediately.

Correlation overrides that last one to emit `add_requested(x, y)` and add *nothing* — the view owns the `PointType` menu, so the overlay reports where the user asked rather than guessing what they meant. That also keeps a `QMenu` out of an overlay class.

## No behaviour change — how it was checked

- The three base refactors were verified **before** the subclass existed: `1023 passed` across `tests/ui/` and the four overlay test files.
- `image_point_canvas` now imports the colour/marker tables rather than holding a second copy (with both classes drawing the same points mid-migration, two copies would drift). Both tables were compared against `HEAD` by evaluating the original literals — **identical, 5 entries each**. The alias is deleted with that module.
- Nothing imports `CorrelationPointOverlay`; `git grep` confirms the only references are two comments.
- The `_CanvasAdapter` docstring gets a note that its "inbound translation layer" plan is superseded, so the code and FIB-535 don't disagree. The original paragraph is left intact — it's the account written by whoever built the seam, and only the plan changed.

## Testing

`1337 passed, 7 skipped` — `tests/correlation/`, `tests/ui/`, `tests/test_import_cycles.py`, and the four overlay test files. Python 3.8 parse-checked on all four changed files (CI builds 3.8; this env is 3.11).

15 new tests, aimed at the seam rather than the drawing. Mutation-checked so they aren't vacuous:

| deliberate break | caught by |
| --- | --- |
| `index_of` uses `==` instead of `is` | `test_equal_but_distinct_coordinates_are_not_confused` |
| `remove_point` forgets to pop `_coords` | `test_selection_follows_its_point_across_a_removal`, +3 |

The second is the one that matters: deleting point 0 of 3 shifts every later index, and the test asserts identity survives it.

## What's next (not in this PR)

The correlation view on `FibsemImageCanvas`, the `render_to_axes` equivalent, and the swap of `_fib_canvas`. `image_point_canvas.py` can only be deleted in the last PR of the series — it has three consumers.
