### PR TITLE
[fix] Hold the imaging channel across the beam grab (FIB-542)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -2083,8 +2083,18 @@ class ThermoMicroscope(FibsemMicroscope):
             drift_correction=image_settings.drift_correction,
         )
 
-        self.set_channel(image_settings.beam_type)
-        image = self.connection.imaging.grab_frame(frame_settings)
+        # One lock over both RPCs. `grab_frame` reads the active view's buffer, so a
+        # channel that is not still ours when the grab lands returns whoever took it in
+        # between -- silently, since the metadata below is built from `image_settings`
+        # rather than from what came back. That is FIB-517 on the beam side (FIB-542),
+        # and it is the discipline every other set-then-act pair here already keeps.
+        #
+        # Deliberately just the pair: `_threading_lock` is a class attribute shared by
+        # every caller in the process, so holding it over the metadata reads or the
+        # state fetch below would block all of them for the length of a frame.
+        with self._threading_lock:
+            self.set_channel(image_settings.beam_type)
+            image = self.connection.imaging.grab_frame(frame_settings)
 
         # restore to full frame imaging
         if image_settings.reduced_area is not None:
@@ -2110,38 +2120,6 @@ class ThermoMicroscope(FibsemMicroscope):
         logging.debug({"msg": "acquire_image", "metadata": fibsem_image.metadata.to_dict()})
 
         return fibsem_image
-
-    def _acquire_image2(self, beam_type: BeamType, frame_settings: Optional['GrabFrameSettings'] = None) -> FibsemImage:
-        """
-        Acquire an image with the specified beam type and frame settings, and return it as a FibsemImage.
-        NOTE: this method is used for the acquisition worker thread, don't use it directly.
-
-        Args:
-            beam_type: The beam type to use for acquisition.
-            frame_settings: The frame settings for the acquisition (Optional).
-
-        Returns:
-            FibsemImage: The acquired image.
-        """
-        # set the active view and device
-        self.set_channel(channel=beam_type)
-        
-        # acquire the frame
-        adorned_image: AdornedImage = self.connection.imaging.grab_frame(settings=frame_settings)
-
-        # get the required metadata, convert to FibsemImage
-        state = self.get_microscope_state(beam_type=beam_type)
-        image_settings = self.get_imaging_settings(beam_type=beam_type)
-
-        image = fibsem_image_from_adorned_image(
-            copy.deepcopy(adorned_image),
-            copy.deepcopy(image_settings),
-            copy.deepcopy(state),
-        )
-
-        self._set_additional_metadata(image)
-
-        return image
 
     def acquire_image3(self, image_settings: Optional[ImageSettings] = None, beam_type: Optional[BeamType] = None) -> FibsemImage:
         """
@@ -2193,8 +2171,11 @@ class ThermoMicroscope(FibsemMicroscope):
 
         logging.info(f"acquiring new {effective_beam_type.name} image.")
 
-        self.set_channel(effective_beam_type)
-        adorned_image: AdornedImage = self.connection.imaging.grab_frame(frame_settings)
+        # Locked for the same reason as `acquire_image`, and just as narrowly: this is
+        # the path every `beam_type=`-only call takes, including the live worker's.
+        with self._threading_lock:
+            self.set_channel(effective_beam_type)
+            adorned_image: AdornedImage = self.connection.imaging.grab_frame(frame_settings)
 
         # QUERY: is this required, reduced area is only set for the grab_frame?
         # Restore full frame if reduced area was used (same as acquire_image)

--- a/tests/test_imaging_channel_lock.py
+++ b/tests/test_imaging_channel_lock.py
@@ -1,0 +1,120 @@
+"""Setting the beam channel and grabbing the frame must be one locked step (FIB-542).
+
+The FM and the beams are one connection with one active view and one active device, so
+whoever sets it last owns it. `grab_frame` reads the active view's buffer, which means a
+`set_channel` that is no longer in force when the grab lands returns whoever took the
+channel in between -- and returns it silently, because the metadata is built from the
+requested `ImageSettings` rather than from what actually came back.
+
+That is FIB-517's failure mode on the beam side: an FM property getter fired from a
+GUI-thread stage poll while a workflow task acquired on a worker. FIB-517 fixed the FM
+half, so a getter now hands the channel back, but anything that holds the channel for the
+length of its own operation -- a deliberate FM acquisition, a live stream -- can still
+land inside this window.
+
+Structural, over the real source. `ThermoMicroscope` cannot be constructed without the
+AutoScript SDK, which is absent off the microscope, and the simulator never reads
+`active_view`/`active_device` at all (FIB-518), so there is no harness here that could
+observe the race. What is pinned is the discipline: the pair is locked, it is locked
+together, and the locked region stays narrow.
+"""
+import ast
+from pathlib import Path
+
+import pytest
+
+import fibsem
+
+
+def _thermo_class() -> ast.ClassDef:
+    """The `ThermoMicroscope` class body, parsed from source."""
+    source = (Path(fibsem.__file__).parent / "microscope.py").read_text()
+    return next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ClassDef) and node.name == "ThermoMicroscope"
+    )
+
+
+def _calls_named(node: ast.AST, name: str) -> list:
+    """Every `something.<name>(...)` call anywhere under `node`."""
+    return [
+        child
+        for child in ast.walk(node)
+        if isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Attribute)
+        and child.func.attr == name
+    ]
+
+
+def _locked_blocks(node: ast.AST) -> list:
+    """Every `with self._threading_lock:` block anywhere under `node`."""
+    return [
+        child
+        for child in ast.walk(node)
+        if isinstance(child, ast.With)
+        and any("_threading_lock" in ast.dump(item.context_expr) for item in child.items)
+    ]
+
+
+@pytest.fixture(scope="module")
+def thermo() -> ast.ClassDef:
+    return _thermo_class()
+
+
+def test_every_grab_is_locked(thermo):
+    """The defect itself, and the guard against a fourth copy of the pair appearing.
+
+    `_acquire_image2` was exactly that -- a second, unlocked copy with no callers, kept
+    around long enough to be a template. It was deleted with this fix.
+    """
+    grabs = _calls_named(thermo, "grab_frame")
+    assert grabs, "no grab_frame call found -- the probe missed, not the code"
+
+    locked = {id(call) for block in _locked_blocks(thermo) for call in _calls_named(block, "grab_frame")}
+    unlocked = [call.lineno for call in grabs if id(call) not in locked]
+    assert unlocked == [], (
+        f"grab_frame runs without the lock at line(s) {unlocked}: whatever took the "
+        f"shared channel after set_channel is what this returns"
+    )
+
+
+def test_the_channel_is_set_inside_the_same_block(thermo):
+    """A lock that covers only the grab guards nothing.
+
+    The whole point is that the channel is still ours when the grab lands, so the
+    `set_channel` has to be under the same lock -- not merely before it.
+    """
+    for block in _locked_blocks(thermo):
+        if not _calls_named(block, "grab_frame"):
+            continue
+        assert _calls_named(block, "set_channel"), (
+            f"the block at line {block.lineno} locks the grab but not the set_channel "
+            f"that precedes it, so the channel can still be taken in between"
+        )
+
+
+def test_the_locked_region_stays_narrow(thermo):
+    """`_threading_lock` is a class attribute, shared by every caller in the process.
+
+    Held across the metadata reads or the `get_microscope_state` fetch, an acquisition
+    would block the milling monitor, a Stop click and every FM channel scope for the
+    length of a frame. Frame-long is already the cost of the grab itself; making it
+    frame-plus-a-full-state-read is not. Pinned so a later "while we're here" widening
+    is caught rather than merged.
+    """
+    for block in _locked_blocks(thermo):
+        if not _calls_named(block, "grab_frame"):
+            continue
+        widened = sorted(
+            {
+                call.func.attr
+                for call in _calls_named(block, "get_microscope_state")
+                + _calls_named(block, "get_imaging_settings")
+                + _calls_named(block, "_set_additional_metadata")
+            }
+        )
+        assert widened == [], (
+            f"the block at line {block.lineno} holds the process-wide lock across "
+            f"{widened}, which blocks every other caller for longer than the frame"
+        )


### PR DESCRIPTION
Closes [FIB-542](https://linear.app/fibsemos/issue/FIB-542/beam-acquire-image-sets-the-imaging-channel-and-grabs-in-two-unguarded).

## The defect

The FM and the beams are one AutoScript connection with one active view and one active device, so whoever sets it last owns it. `ThermoMicroscope.acquire_image` set the channel and grabbed the frame as two separate RPCs with nothing holding it in between:

```python
self.set_channel(image_settings.beam_type)
image = self.connection.imaging.grab_frame(frame_settings)
```

`grab_frame` reads the active view's buffer, so anything that takes the channel in that window makes this return the wrong image — and return it **silently**, because the metadata is built from the requested `ImageSettings` rather than from what actually came back.

This is FIB-517's failure mode on the beam side. FIB-517 fixed the FM half (a getter now hands the channel back via `active_channel()`), which closed the case where the theft *persisted* — but not this window. A deliberate FM acquisition or a live stream still holds the channel for the length of its own operation and can land inside it.

It reads as an oversight rather than a decision because every other set-then-act pair in the class already takes `_threading_lock`:

| | |
| -- | -- |
| `_fast_acquisition_worker` | `set_channel` + `get_image` — locked, per frame |
| `start`/`stop`/`pause`/`resume_milling` | locked |
| `get_milling_state` | `set_channel` + read — locked |
| `acquire_image` | **not locked** |

## The change

- **`acquire_image`** — the pair now runs under `self._threading_lock`.
- **`acquire_image3`** — same pair, same wrap. Not in the issue's table, but it is live: `acquire_image` delegates to it for every `beam_type=`-only call, which is the path the live acquisition worker takes per frame.
- **`_acquire_image2` — deleted.** Zero callers repo-wide; introduced by an early live-acquisition experiment and superseded by `acquire_image3`. Leaving a third unlocked copy of the pair around is how this comes back.

The locked region is deliberately just the set and the grab. `_threading_lock` is a class attribute shared process-wide, so holding it across the metadata reads or the `get_microscope_state` fetch would block every other caller for the length of a frame.

**Accepted consequence:** a frame grab now holds the shared lock for its duration, so a Stop-milling click or an FM channel scope on another thread can wait up to one frame. The live stream already behaves exactly this way per frame — this is contention that exists today, not a new class of it.

## Testing

Not reproduced, and it cannot be reproduced off hardware: the simulator never reads `active_view`/`active_device` at all (FIB-518), so there is no harness that would turn this into a failing behavioural test.

`tests/test_imaging_channel_lock.py` is therefore structural over the real source, the same shape as `TestTheRealDriverMatches` in `tests/fm/test_active_channel.py` and for the same reason — `ThermoMicroscope` cannot be constructed without the AutoScript SDK. It pins that every `grab_frame` is inside a `_threading_lock` block, that the `set_channel` is inside the *same* block (a lock over only the grab guards nothing), and that the region does not creep over `get_microscope_state`.

It discriminates: run against the pre-fix source it flags all three sites (`:2087`, `:2130`, `:2197`).

```
pytest tests/test_imaging_channel_lock.py tests/test_acquire_image_api.py tests/test_acquire.py \
       tests/fm/test_active_channel.py tests/test_microscope.py tests/test_import_cycles.py -q
58 passed
```

Real confirmation is a TFS session: acquire SEM/FIB, live imaging on both beams, and an FM overview overlapping a beam acquisition.

## Follow-ups filed

Same class of defect, found while in here, deliberately out of scope:

- [FIB-544](https://linear.app/fibsemos/issue/FIB-544/detector-property-reads-set-the-shared-imaging-channel-and-read-in-two) — the detector property reads and writes. `get_microscope_state()` with no `beam_type` is eight unguarded set-then-read pairs and flips the active view four times, and it is polled from the GUI thread by the minimap and the coincidence viewer.
- [FIB-545](https://linear.app/fibsemos/issue/FIB-545/acquire-chamber-image-takes-the-shared-imaging-channel-unguarded-and) — `acquire_chamber_image`, which is unguarded *and* never hands the view back.
