### PR TITLE
[ui] Keep a record of every overview on the canvas, and list them (FIB-543)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -10,7 +10,8 @@ actions along the bottom.
 
 import logging
 import threading
-from typing import List, Optional, Tuple
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from PyQt5.QtCore import QPoint, Qt, pyqtSignal
@@ -34,6 +35,7 @@ from fibsem.fm.structures import (
     AutoFocusSettings,
     ChannelSettings,
     FluorescenceImage,
+    FluorescenceImageMetadata,
     OverviewParameters,
 )
 from fibsem.microscope import FibsemMicroscope
@@ -44,6 +46,7 @@ from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     FMOverviewConfirmationDialog,
 )
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
+from fibsem.ui.fm.widgets.overview_list_widget import OverviewListWidget
 from fibsem.ui.fm.widgets.tile_grid_options_panel import TileGridOptionsPanel
 from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
@@ -117,6 +120,46 @@ SLOT_COLOUR = "#90a4ae"
 CURSOR_READOUT_WIDTH = 210
 
 
+@dataclass
+class PlacedOverviewImageRecord:
+    """One overview the canvas is holding, and what is known about it.
+
+    Named at length to stay distinct from the two neighbours it would otherwise be
+    confused with: the canvas's own `PlacedImage`, which is an artist and an extent,
+    and the `FluorescenceImage` this was built from.
+
+    The canvas can hold several overviews at once and, until this existed, nothing
+    tracked them: the widget kept a single `_displayed_image` that each new
+    acquisition overwrote, so an earlier overview's pixels stayed on screen with its
+    provenance already discarded (FIB-543).
+
+    Holds the *metadata*, not the image. What a list needs -- where it was, when, at
+    what scale -- is all in there, and keeping N full-resolution mosaics alive to
+    reach it would cost hundreds of megabytes on a canvas already short of them
+    (FIB-414). The pixels the canvas redraws from are its own decimated copies.
+    """
+
+    id: str
+    label: str
+    metadata: "FluorescenceImageMetadata"
+    visible: bool = True
+
+    @property
+    def detail(self) -> str:
+        """The grid and scale, for the second half of a list row."""
+        parts = []
+        # `stitch_tileset` names the mosaic's position `stitched_mosaic_3x3`, so the
+        # grid is already recorded -- reading it back beats plumbing it separately.
+        name = getattr(getattr(self.metadata, "stage_position", None), "name", "") or ""
+        grid = name.rsplit("_", 1)[-1] if "_" in name else ""
+        if grid and grid[0].isdigit():
+            parts.append(grid.replace("x", "×"))
+        pixel_size = getattr(self.metadata, "pixel_size_x", None)
+        if pixel_size:
+            parts.append(f"{pixel_size * constants.SI_TO_MICRO:.2f} µm/px")
+        return " · ".join(parts)
+
+
 class FMOverviewWidget(QWidget):
     """Configure, run and view a fluorescence overview acquisition."""
 
@@ -167,7 +210,16 @@ class FMOverviewWidget(QWidget):
         self._worker: Optional[FunctionWorker] = None
         self._runner: Optional[FMTiledAcquisitionRunner] = None
         self._mosaic: Optional[FluorescenceImage] = None
-        self._displayed_image: Optional[FluorescenceImage] = None
+        # Every overview the canvas is holding, oldest first, keyed by the id each was
+        # given. Replaces a single `_displayed_image` that each acquisition overwrote,
+        # which left earlier overviews on screen with nothing describing them.
+        self._records: Dict[str, PlacedOverviewImageRecord] = {}
+        # Ids are minted rather than derived from the acquisition date. The date is
+        # unique enough, but `_key_for` fell back to a bare "overview" whenever one was
+        # missing -- so every dateless overview shared one key and silently replaced the
+        # last. Matching on the date is still done, below, to keep re-showing one image
+        # a replacement rather than a second copy of itself.
+        self._record_count = 0
         # Stage position the canvas frame is built around. Everything shown -- images,
         # the planned grid, position markers -- is placed relative to it, so it has to
         # be fixed once and kept: re-deriving it from the newest image would shift the
@@ -313,6 +365,15 @@ class FMOverviewWidget(QWidget):
         self._controls_layout = QVBoxLayout(controls)
         self._controls_layout.setContentsMargins(8, 8, 8, 8)
         self._controls_layout.setSpacing(10)
+        # First: what is already on the canvas, then the settings for the next run.
+        # Reading the column top to bottom then follows the same order as using the tab
+        # -- look at what you have, then set up what comes next -- where putting it
+        # under the channels split the two halves of "the next acquisition" around it.
+        # A host's own section still goes above this, being the subject of the tab.
+        self.overview_list = OverviewListWidget()
+        self.overview_list.visibility_toggled.connect(self.set_overview_visible)
+        self.overview_list.remove_requested.connect(self.remove_overview)
+        self._controls_layout.addWidget(self._section("Overviews", self.overview_list))
         self._controls_layout.addWidget(self._section("Channels", self.channel_widget))
         self._controls_layout.addWidget(self.settings_widget)
         self._controls_layout.addStretch()
@@ -690,16 +751,26 @@ class FMOverviewWidget(QWidget):
         """Show an image at the stage position it was acquired at.
 
         Overlays are positioned against the canvas frame, not against whatever is
-        currently displayed, so the image has to be recorded when it is set rather than
-        fetched from the canvas later -- the canvas keeps channel stacks, not the
+        currently displayed, so the image is recorded when it is set rather than fetched
+        from the canvas later -- the canvas keeps channel stacks, not the
         `FluorescenceImage` and its metadata, and the metadata is what carries the pose.
+
+        Each image gets a record, so several overviews on the canvas stay individually
+        addressable. The in-progress preview never comes through here -- it goes
+        straight to `canvas.set_channel` under its own key -- so it gets no record, and
+        never appears in a list of what has been acquired.
         """
-        self._displayed_image = image
+        record = self._record_for(image)
         if self._origin is None:
             self._origin = self._position_of(image)
-        self.canvas.set_composite_key(self._key_for(image))
+        self.canvas.set_composite_key(record.id)
         self.canvas.set_placement(self._offset_of(image))
         self.canvas.set_fm_image(image)
+        # Re-asserted, not assumed: a reshaped frame is placed as a *new* artist, which
+        # starts visible. Re-showing a hidden overview would otherwise bring it back
+        # while its row still said it was hidden.
+        self.canvas.canvas.set_image_visible(record.id, record.visible)
+        self.overview_list.set_records(self.overviews())
         self._refresh_positions()
         self._refresh_stage_metadata()
         self._refresh_tile_grid()
@@ -708,20 +779,78 @@ class FMOverviewWidget(QWidget):
     def _position_of(image: FluorescenceImage) -> Optional[FibsemStagePosition]:
         return getattr(image.metadata, "stage_position", None)
 
-    @staticmethod
-    def _key_for(image: FluorescenceImage) -> str:
-        """Identify an overview by when it was acquired.
+    def _record_for(self, image: FluorescenceImage) -> PlacedOverviewImageRecord:
+        """The record *image* belongs to, creating one if it is new.
 
-        Not by position: a small overview and a wider one taken over the same area at
-        different times are both worth keeping, and keying on position would silently
-        drop the first. `stitch_tileset` carries the first tile's acquisition date onto
-        the mosaic, so this is unique per run.
-
-        A property of the image rather than a counter, so showing the same image twice
-        replaces it instead of drawing a second copy on top of itself.
+        Matched on the acquisition date when there is one, so showing the same image
+        twice replaces it rather than drawing a second copy on top of itself -- the one
+        property the old date-derived key had that is worth keeping. An image without a
+        date gets a record of its own instead of joining every other dateless overview
+        under a shared key, which is what the old fallback did.
         """
         stamp = getattr(image.metadata, "acquisition_date", None)
-        return f"overview@{stamp}" if stamp else "overview"
+        if stamp:
+            for record in self._records.values():
+                if getattr(record.metadata, "acquisition_date", None) == stamp:
+                    record.metadata = image.metadata
+                    return record
+
+        self._record_count += 1
+        record = PlacedOverviewImageRecord(
+            id=f"overview-{self._record_count}",
+            label=self._label_for(image, self._record_count),
+            metadata=image.metadata,
+        )
+        self._records[record.id] = record
+        return record
+
+    @staticmethod
+    def _label_for(image: FluorescenceImage, index: int) -> str:
+        """What a list calls this overview.
+
+        `OverviewDestination` stamps the run's directory name onto the mosaic it saves,
+        so a saved overview is named for the folder its tiles are in -- which is what
+        someone looking for it on disk would search for. An unsaved one has no such
+        name, and a number beats an empty row.
+        """
+        description = getattr(image.metadata, "description", None)
+        return description or f"Overview {index}"
+
+    def overviews(self) -> List[PlacedOverviewImageRecord]:
+        """Every overview on the canvas, oldest first."""
+        return list(self._records.values())
+
+    def set_overview_visible(self, record_id: str, visible: bool) -> bool:
+        """Show or hide one overview. False if there is no such record.
+
+        Hidden rather than removed, so it can come back without being re-acquired. The
+        canvas skips drawing a hidden image entirely, so this also takes it out of the
+        redraw cost -- which is the point on a canvas holding several (FIB-414).
+        """
+        record = self._records.get(record_id)
+        if record is None:
+            return False
+        record.visible = visible
+        self.canvas.canvas.set_image_visible(record_id, visible)
+        # In place rather than a rebuild: this is usually the list telling us about its
+        # own click, and replacing the row under the cursor mid-click would drop the
+        # hover the buttons are showing for. The rows ignore a value they already have,
+        # so the click that started this does not come back round.
+        self.overview_list.refresh(self.overviews())
+        return True
+
+    def remove_overview(self, record_id: str) -> bool:
+        """Drop one overview from the canvas for good. False if there is no such record.
+
+        The record and the canvas artist go together: leaving either behind means a row
+        with nothing under it, or pixels nothing can reach.
+        """
+        if self._records.pop(record_id, None) is None:
+            return False
+        self.canvas.canvas.remove_image(record_id)
+        self.canvas.forget_overview(record_id)
+        self.overview_list.set_records(self.overviews())
+        return True
 
     def _offset_of(self, image: FluorescenceImage) -> Tuple[float, float]:
         """Where *image*'s centre sits relative to the canvas origin, in metres.

--- a/fibsem/ui/fm/widgets/overview_list_widget.py
+++ b/fibsem/ui/fm/widgets/overview_list_widget.py
@@ -1,0 +1,226 @@
+"""The overviews currently on the canvas, one row each.
+
+The canvas can hold several overviews at once, and until this existed nothing said
+which ones — you could see them but not name, hide or drop one (FIB-543).
+
+Shaped after `LamellaRowWidget`: a name, its details, and icon buttons that appear
+when the row is under the cursor or selected. The difference is where the reveal
+lives — the lamella list shows and hides its buttons for every row at once through
+`_btn_visible`, because there the choice is which *columns* the table has. Here it is
+per row and follows the pointer, so a resting list stays quiet.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
+
+from PyQt5.QtCore import QSize, Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.ui import stylesheets
+from fibsem.ui.tokens import TEXT_MUTED_COLOR
+from fibsem.ui.widgets.custom_widgets import IconToolButton
+
+if TYPE_CHECKING:
+    from fibsem.ui.fm.widgets.fm_overview_widget import PlacedOverviewImageRecord
+
+# Imported only for typing: the record lives on `FMOverviewWidget`, which builds this
+# widget, so a runtime import would close a cycle. Nothing here needs more than the
+# four fields it reads.
+
+_BTN_SIZE = 26
+_ROW_HEIGHT = 30
+
+
+class OverviewRowWidget(QWidget):
+    """One overview: its name, and what to do with it."""
+
+    visibility_toggled = pyqtSignal(str, bool)
+    remove_clicked = pyqtSignal(str)
+
+    def __init__(
+        self, record: "PlacedOverviewImageRecord", parent: Optional[QWidget] = None
+    ) -> None:
+        super().__init__(parent)
+        self.record_id = record.id
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 2, 6, 2)
+        layout.setSpacing(6)
+
+        self.name_label = QLabel(record.label)
+        self.name_label.setStyleSheet("background: transparent;")
+        layout.addWidget(self.name_label, 1)
+
+        # The detail and the buttons occupy the same end of the row rather than sitting
+        # side by side: a settings column is narrow, and a name long enough to matter is
+        # exactly when both would not fit.
+        self.detail_label = QLabel(record.detail)
+        self.detail_label.setStyleSheet(
+            f"background: transparent; color: {TEXT_MUTED_COLOR}; font-size: 11px;"
+        )
+        layout.addWidget(self.detail_label)
+
+        # Checked means *hidden*: the icon that shows is the state you would move to,
+        # which is how the eye reads in every layer panel.
+        self.btn_visible = IconToolButton(
+            icon="mdi:eye-outline",
+            checked_icon="mdi:eye-off-outline",
+            tooltip="Hide",
+            checked_tooltip="Show",
+            checkable=True,
+            checked=not record.visible,
+            size=_BTN_SIZE,
+        )
+        layout.addWidget(self.btn_visible)
+
+        self.btn_remove = IconToolButton(
+            icon="mdi:trash-can-outline", tooltip="Remove", size=_BTN_SIZE
+        )
+        layout.addWidget(self.btn_remove)
+
+        self.btn_visible.toggled.connect(
+            lambda hidden: self.visibility_toggled.emit(self.record_id, not hidden)
+        )
+        self.btn_remove.clicked.connect(lambda: self.remove_clicked.emit(self.record_id))
+
+        self._selected = False
+        # Through `refresh` rather than setting the resting state by hand, so a row
+        # built from an already-hidden record looks the same as one that was hidden
+        # after the fact -- which it did not, when the two paths were written separately.
+        self.refresh(record)
+
+    # ── hover and selection ───────────────────────────────────────────────
+
+    def set_selected(self, selected: bool) -> None:
+        """Selected rows keep their buttons whether or not the pointer is on them."""
+        self._selected = selected
+        self._set_actions_shown(selected or self.underMouse())
+
+    def enterEvent(self, event) -> None:
+        self._set_actions_shown(True)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event) -> None:
+        self._set_actions_shown(self._selected)
+        super().leaveEvent(event)
+
+    def _set_actions_shown(self, shown: bool) -> None:
+        # A hidden overview keeps its eye visible at rest: the row has to say *why* it
+        # looks different, and an unexplained greyed-out name is worse than an icon.
+        self.btn_visible.setVisible(shown or self.btn_visible.isChecked())
+        self.btn_remove.setVisible(shown)
+        self.detail_label.setVisible(not shown)
+
+    def refresh(self, record: "PlacedOverviewImageRecord") -> None:
+        self.name_label.setText(record.label)
+        self.detail_label.setText(record.detail)
+        # Only when it differs. `IconToolButton` drives its own icon off `toggled`, so
+        # blocking signals to set it silently would leave the icon showing the old
+        # state -- and setting it unconditionally would re-emit on every refresh.
+        if self.btn_visible.isChecked() is record.visible:
+            self.btn_visible.setChecked(not record.visible)
+        self.name_label.setEnabled(record.visible)
+        self._set_actions_shown(self._selected or self.underMouse())
+
+
+class OverviewListWidget(QWidget):
+    """Every overview on the canvas, oldest first."""
+
+    visibility_toggled = pyqtSignal(str, bool)
+    remove_requested = pyqtSignal(str)
+    selection_changed = pyqtSignal(object)  # record id, or None
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        self.empty_label = QLabel("No overviews yet.")
+        self.empty_label.setStyleSheet(
+            f"color: {TEXT_MUTED_COLOR}; font-size: 11px; background: transparent;"
+        )
+        layout.addWidget(self.empty_label)
+
+        self._list = QListWidget()
+        self._list.setSpacing(0)
+        self._list.setStyleSheet(stylesheets.LIST_WIDGET_STYLESHEET)
+        self._list.setAlternatingRowColors(False)
+        self._list.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._list.setFocusPolicy(Qt.NoFocus)
+        self._list.setFrameShape(QFrame.NoFrame)
+        self._list.itemSelectionChanged.connect(self._on_selection_changed)
+        layout.addWidget(self._list)
+
+        self._rows: dict = {}
+        self.set_records([])
+
+    # ── contents ──────────────────────────────────────────────────────────
+
+    def set_records(self, records: List["PlacedOverviewImageRecord"]) -> None:
+        """Rebuild the list from *records*, keeping the selection where it can be kept.
+
+        Rebuilt rather than diffed: the list is a handful of rows and is refreshed only
+        when one is acquired or dropped, so the bookkeeping a diff would need costs more
+        than it saves. The selection is restored by id, because the row that held it is
+        gone by then.
+        """
+        previously_selected = self.selected_id()
+        self._list.clear()
+        self._rows = {}
+
+        for record in records:
+            row = OverviewRowWidget(record)
+            row.visibility_toggled.connect(self.visibility_toggled)
+            row.remove_clicked.connect(self.remove_requested)
+            item = QListWidgetItem()
+            item.setSizeHint(QSize(0, _ROW_HEIGHT))
+            item.setData(Qt.UserRole, record.id)
+            self._list.addItem(item)
+            self._list.setItemWidget(item, row)
+            self._rows[record.id] = row
+
+        self.empty_label.setVisible(not records)
+        self._list.setVisible(bool(records))
+        # Sized to its contents: the settings column is a stack, and a list that keeps
+        # its full height empty pushes everything below it off the bottom.
+        self._list.setFixedHeight(max(len(records), 1) * _ROW_HEIGHT + 4)
+
+        if previously_selected in self._rows:
+            self.select(previously_selected)
+
+    def selected_id(self) -> Optional[str]:
+        items = self._list.selectedItems()
+        return items[0].data(Qt.UserRole) if items else None
+
+    def select(self, record_id: Optional[str]) -> None:
+        for index in range(self._list.count()):
+            item = self._list.item(index)
+            if item.data(Qt.UserRole) == record_id:
+                self._list.setCurrentItem(item)
+                return
+        self._list.clearSelection()
+
+    def refresh(self, records: List["PlacedOverviewImageRecord"]) -> None:
+        """Update the rows in place, for a change that does not add or remove one."""
+        for record in records:
+            row = self._rows.get(record.id)
+            if row is not None:
+                row.refresh(record)
+
+    def _on_selection_changed(self) -> None:
+        selected = self.selected_id()
+        for record_id, row in self._rows.items():
+            row.set_selected(record_id == selected)
+        self.selection_changed.emit(selected)

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -590,6 +590,16 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         """Keys of everything this widget has composited, oldest first."""
         return list(self._held)
 
+    def forget_overview(self, key: str) -> bool:
+        """Drop the channel planes held for one image. False if none were held.
+
+        The counterpart to the canvas's `remove_image`, and it has to be called with it:
+        the planes are what `_restyle_others` re-renders from, so keeping them for an
+        image no longer placed leaks the pixels and leaves `_channel_still_shown`
+        answering for a channel nothing displays.
+        """
+        return self._held.pop(key, None) is not None
+
     def clear_overviews(self) -> None:
         """Drop every composited image, leaving overlays and the channel model alone."""
         for key in list(self._held):

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -230,6 +230,23 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         self.draw_idle()
         return True
 
+    def set_image_visible(self, key: str, visible: bool) -> bool:
+        """Show or hide one placed image, keeping it placed. False if *key* is unknown.
+
+        Distinct from :meth:`remove_image`: the artist, its extent and its draw order
+        all survive, so showing it again costs nothing and does not disturb the fit.
+
+        Matplotlib skips a hidden artist when it draws, so this is not only a visual
+        change -- a canvas redraws every stored pixel of everything visible, and hiding
+        an image takes it out of that cost as surely as removing it would (FIB-414).
+        """
+        placed = self._placed.get(key)
+        if placed is None:
+            return False
+        placed.artist.set_visible(bool(visible))
+        self.draw_idle()
+        return True
+
     def remove_image(self, key: str) -> bool:
         """Remove one placed image. Returns False if *key* was not placed."""
         placed = self._placed.pop(key, None)

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -31,6 +31,7 @@ from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
 )
 from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
 from fibsem.ui.fm.widgets.fm_overview_widget import (
+    PREVIEW_KEY,
     FMOverviewWidget,
     shrink_progress_text,
 )
@@ -778,6 +779,7 @@ def test_overviews_are_kept_per_acquisition_not_per_position(qapp, overview_widg
     # The fixture is shared, and overviews now accumulate by design — so start clean
     # rather than counting whatever earlier tests left behind.
     widget.canvas.clear_overviews()
+    widget._records.clear()
     small = widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
     widget.set_image(small)
     qapp.processEvents()
@@ -790,9 +792,10 @@ def test_overviews_are_kept_per_acquisition_not_per_position(qapp, overview_widg
     qapp.processEvents()
 
     def overviews():
-        # Only what set_image placed: the fixture seeds the canvas directly, which
-        # lands under the widget's default key rather than an overview one.
-        return [k for k in widget.canvas.canvas.placed_keys if k.startswith("overview@")]
+        # The widget's own record of what it placed. The fixture also seeds the canvas
+        # directly, which lands under the canvas widget's default key and gets no
+        # record — so this counts acquisitions rather than artists.
+        return [record.id for record in widget.overviews()]
 
     assert len(overviews()) == 2, "the wider overview replaced the detailed one"
 
@@ -1006,7 +1009,7 @@ def test_stage_metadata_does_not_wait_for_an_image(qapp, overview_widget):
     planned tile grid is already drawn from exactly that. Requiring an image would show
     two halves of the same picture at different times."""
     widget = overview_widget
-    widget._displayed_image = None
+    widget._records.clear()
     widget._origin = None
 
     widget._refresh_stage_metadata()
@@ -1020,7 +1023,7 @@ def test_stage_metadata_is_dropped_when_the_geometry_is_unknown(qapp, overview_w
     """Without a geometry there is no frame, and drawing at a guessed scale would put
     plausible-looking shapes in the wrong places."""
     widget = overview_widget
-    widget._displayed_image = None
+    widget._records.clear()
     widget._origin = None
     original = widget._frame
     widget._frame = lambda: None
@@ -3959,3 +3962,227 @@ def test_a_hidden_tile_grid_panel_is_not_refitted(qapp, interactive_widget):
     assert fits == []
 
     widget._fit_tile_grid_panel = original
+
+
+# ── one record per overview on the canvas (FIB-543) ──────────────────────
+
+
+@pytest.fixture
+def blank_canvas(qapp, overview_widget):
+    """The shared widget with nothing placed, so counts mean what they say."""
+    widget = overview_widget
+    # The counter too, not just the store: the widget fixture is module-scoped, so an
+    # earlier test's acquisitions would otherwise decide what these ids are called.
+    widget.canvas.clear_overviews()
+    widget._records.clear()
+    widget._record_count = 0
+    # The list too. It is rebuilt from the store rather than reading it, so clearing
+    # only the store leaves rows from a previous test for the next one to count.
+    widget.overview_list.set_records([])
+    yield widget
+    widget.canvas.clear_overviews()
+    widget._records.clear()
+    widget.overview_list.set_records([])
+
+
+def _acquire(widget, date=None):
+    image = widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    image.metadata.acquisition_date = date
+    return image
+
+
+def test_each_acquisition_gets_its_own_record(qapp, blank_canvas):
+    """The hole this fills: a single `_displayed_image` meant the second overview
+    overwrote the first's provenance while its pixels stayed on screen."""
+    widget = blank_canvas
+
+    widget.set_image(_acquire(widget, "2026-08-07T09:00:00"))
+    widget.set_image(_acquire(widget, "2026-08-07T09:30:00"))
+    qapp.processEvents()
+
+    records = widget.overviews()
+    assert len(records) == 2
+    assert records[0].id != records[1].id
+    # Oldest first: a list reads in the order things were acquired.
+    assert [r.metadata.acquisition_date for r in records] == [
+        "2026-08-07T09:00:00",
+        "2026-08-07T09:30:00",
+    ]
+
+
+def test_two_overviews_without_a_date_do_not_share_one_record(qapp, blank_canvas):
+    """The reason ids are minted. The old key fell back to a bare "overview" when the
+    acquisition date was missing, so every dateless overview replaced the last."""
+    widget = blank_canvas
+
+    widget.set_image(_acquire(widget, None))
+    widget.set_image(_acquire(widget, None))
+    qapp.processEvents()
+
+    assert len(widget.overviews()) == 2
+    assert len(set(widget.canvas.canvas.placed_keys)) == 2
+
+
+def test_showing_one_image_twice_replaces_it(qapp, blank_canvas):
+    """The one property the old date-derived key had that was worth keeping."""
+    widget = blank_canvas
+    image = _acquire(widget, "2026-08-07T09:00:00")
+
+    widget.set_image(image)
+    widget.set_image(image)
+    qapp.processEvents()
+
+    assert len(widget.overviews()) == 1
+
+
+def test_the_live_preview_never_becomes_a_record(qapp, blank_canvas):
+    """The preview is transient -- swapped for the real stitch when the run ends -- so
+    it must not appear in a list of what has been acquired. It reaches the canvas
+    through `set_channel` under its own key rather than through `set_image`, so the
+    exclusion is structural; this pins it, because the two paths look alike."""
+    widget = blank_canvas
+    import numpy as np
+
+    widget._show_preview({"image": np.zeros((4, 4), dtype=np.uint16), "preview_stride": 1})
+    qapp.processEvents()
+
+    assert PREVIEW_KEY in widget.canvas.canvas.placed_keys, "the preview was not drawn"
+    assert widget.overviews() == [], "the preview leaked into the record store"
+
+
+def test_hiding_an_overview_takes_it_out_of_the_drawing(qapp, blank_canvas):
+    """Hidden rather than removed: it comes back without being re-acquired. Matplotlib
+    skips a hidden artist, so this also drops it from the redraw cost (FIB-414)."""
+    widget = blank_canvas
+    widget.set_image(_acquire(widget, "2026-08-07T09:00:00"))
+    qapp.processEvents()
+    record = widget.overviews()[0]
+
+    assert widget.set_overview_visible(record.id, False)
+
+    assert record.visible is False
+    assert widget.canvas.canvas._placed[record.id].artist.get_visible() is False
+    assert record.id in widget.canvas.canvas.placed_keys, "hiding removed it"
+
+    widget.set_overview_visible(record.id, True)
+    assert widget.canvas.canvas._placed[record.id].artist.get_visible() is True
+
+
+def test_a_hidden_overview_stays_hidden_when_its_frame_is_replaced(qapp, blank_canvas):
+    """A *reshaped* frame is placed as a new artist, and a new artist starts visible.
+
+    The same-shape path swaps pixels on the existing artist and keeps its visibility on
+    its own, so it does not exercise this -- the frame has to change size, which is why
+    the second image here is cropped rather than merely re-set.
+    """
+    widget = blank_canvas
+    stamp = "2026-08-07T09:00:00"
+    widget.set_image(_acquire(widget, stamp))
+    qapp.processEvents()
+    record = widget.overviews()[0]
+    widget.set_overview_visible(record.id, False)
+
+    smaller = _acquire(widget, stamp)  # same date -> same record, different size
+    smaller.data = smaller.data[..., :64, :64]
+    widget.set_image(smaller)
+    qapp.processEvents()
+
+    assert widget.canvas.canvas._placed[record.id].artist.get_visible() is False
+
+
+def test_removing_an_overview_drops_its_record_artist_and_planes(qapp, blank_canvas):
+    """All three go together. A record without an artist is a row with nothing under
+    it; planes without a record are pixels nothing can reach, and `_restyle_others`
+    would keep re-rendering them."""
+    widget = blank_canvas
+    widget.set_image(_acquire(widget, "2026-08-07T09:00:00"))
+    qapp.processEvents()
+    record = widget.overviews()[0]
+
+    assert widget.remove_overview(record.id)
+
+    assert widget.overviews() == []
+    assert record.id not in widget.canvas.canvas.placed_keys
+    assert record.id not in widget.canvas._held
+
+
+def test_removing_something_that_is_not_there_says_so(qapp, blank_canvas):
+    assert blank_canvas.remove_overview("overview-404") is False
+    assert blank_canvas.set_overview_visible("overview-404", True) is False
+
+
+def test_a_record_describes_its_grid_and_scale(qapp, blank_canvas):
+    """What the second half of a list row shows. The grid comes back off the mosaic's
+    position name, which `stitch_tileset` writes as `stitched_mosaic_3x3`."""
+    widget = blank_canvas
+    image = _acquire(widget, "2026-08-07T09:00:00")
+    image.metadata.stage_position.name = "stitched_mosaic_3x3"
+    image.metadata.pixel_size_x = 1.2e-6
+
+    widget.set_image(image)
+    qapp.processEvents()
+
+    assert widget.overviews()[0].detail == "3×3 · 1.20 µm/px"
+
+
+def test_a_saved_overview_is_labelled_by_the_folder_its_tiles_are_in(qapp, blank_canvas):
+    """`OverviewDestination` stamps the run's directory name onto the mosaic, which is
+    what someone looking for it on disk would search for."""
+    widget = blank_canvas
+    image = _acquire(widget, "2026-08-07T09:00:00")
+    image.metadata.description = "overview-14-02-33"
+
+    widget.set_image(image)
+
+    assert widget.overviews()[0].label == "overview-14-02-33"
+
+
+def test_an_acquired_overview_appears_in_the_list(qapp, blank_canvas):
+    widget = blank_canvas
+
+    widget.set_image(_acquire(widget, "2026-08-07T09:00:00"))
+    qapp.processEvents()
+
+    assert widget.overview_list._list.count() == 1
+
+
+def test_the_eye_in_the_list_hides_the_image_on_the_canvas(qapp, blank_canvas):
+    """The whole point of the wiring: the row is not a label, it drives the canvas."""
+    widget = blank_canvas
+    widget.set_image(_acquire(widget, "2026-08-07T09:00:00"))
+    qapp.processEvents()
+    record = widget.overviews()[0]
+    row = widget.overview_list._list.itemWidget(widget.overview_list._list.item(0))
+
+    row.btn_visible.setChecked(True)  # checked means hidden
+    qapp.processEvents()
+
+    assert record.visible is False
+    assert widget.canvas.canvas._placed[record.id].artist.get_visible() is False
+
+
+def test_the_trash_in_the_list_drops_the_image_from_the_canvas(qapp, blank_canvas):
+    widget = blank_canvas
+    widget.set_image(_acquire(widget, "2026-08-07T09:00:00"))
+    qapp.processEvents()
+    record_id = widget.overviews()[0].id
+    row = widget.overview_list._list.itemWidget(widget.overview_list._list.item(0))
+
+    row.btn_remove.click()
+    qapp.processEvents()
+
+    assert widget.overviews() == []
+    assert record_id not in widget.canvas.canvas.placed_keys
+    assert widget.overview_list._list.count() == 0
+
+
+def test_the_list_does_not_grow_a_row_for_the_live_preview(qapp, blank_canvas):
+    """The structural exclusion, seen from the other end: a run in progress must not
+    put a row in the list that vanishes when it finishes."""
+    widget = blank_canvas
+    import numpy as np
+
+    widget._show_preview({"image": np.zeros((4, 4), dtype=np.uint16), "preview_stride": 1})
+    qapp.processEvents()
+
+    assert widget.overview_list._list.count() == 0

--- a/tests/ui/test_overview_list_widget.py
+++ b/tests/ui/test_overview_list_widget.py
@@ -1,0 +1,182 @@
+"""The overviews on the canvas, listed in the settings column (FIB-543).
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_overview_list_widget.py
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.fm.widgets.fm_overview_widget import PlacedOverviewImageRecord
+from fibsem.ui.fm.widgets.overview_list_widget import OverviewListWidget
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+class _Metadata:
+    """Only the three fields a record reads for its label and detail."""
+
+    def __init__(self, grid="stitched_mosaic_3x3", pixel_size=1.2e-6):
+        self.stage_position = type("Position", (), {"name": grid})()
+        self.pixel_size_x = pixel_size
+        self.acquisition_date = "2026-08-07T09:00:00"
+
+
+def _record(index=1, label=None, visible=True, **kwargs):
+    return PlacedOverviewImageRecord(
+        id=f"overview-{index}",
+        label=label or f"Overview {index}",
+        metadata=_Metadata(**kwargs),
+        visible=visible,
+    )
+
+
+def _widget(*records):
+    widget = OverviewListWidget()
+    widget.set_records(list(records))
+    return widget
+
+
+# ── contents ──────────────────────────────────────────────────────────────
+
+
+def test_a_row_appears_for_each_overview_oldest_first():
+    widget = _widget(_record(1), _record(2), _record(3))
+
+    labels = [
+        widget._list.itemWidget(widget._list.item(i)).name_label.text()
+        for i in range(widget._list.count())
+    ]
+
+    assert labels == ["Overview 1", "Overview 2", "Overview 3"]
+
+
+def test_an_empty_list_says_so_rather_than_showing_an_empty_box():
+    widget = _widget()
+
+    assert widget.empty_label.isVisible() or not widget.isVisible()
+    assert widget._list.isHidden()
+
+
+def test_a_row_shows_the_grid_and_scale_while_resting():
+    widget = _widget(_record(1))
+    row = widget._list.itemWidget(widget._list.item(0))
+
+    assert row.detail_label.text() == "3×3 · 1.20 µm/px"
+
+
+# ── hover and selection ───────────────────────────────────────────────────
+
+
+def test_the_buttons_stay_out_of_the_way_until_a_row_is_wanted():
+    """A settings column is mostly read, not clicked. Rows full of icons at rest turn
+    a list you glance at into one you have to parse."""
+    widget = _widget(_record(1))
+    row = widget._list.itemWidget(widget._list.item(0))
+
+    assert row.btn_remove.isHidden()
+    assert row.detail_label.isHidden() is False
+
+
+def test_selecting_a_row_brings_its_buttons_out():
+    widget = _widget(_record(1), _record(2))
+
+    widget.select("overview-2")
+
+    first = widget._list.itemWidget(widget._list.item(0))
+    second = widget._list.itemWidget(widget._list.item(1))
+    assert second.btn_remove.isHidden() is False
+    assert first.btn_remove.isHidden(), "an unselected row showed its buttons"
+
+
+def test_a_hidden_overview_keeps_its_eye_while_resting():
+    """The row has to say *why* it looks different. A greyed-out name with no icon
+    reads as broken rather than hidden."""
+    widget = _widget(_record(1, visible=False))
+    row = widget._list.itemWidget(widget._list.item(0))
+
+    assert row.btn_visible.isHidden() is False
+    assert row.btn_remove.isHidden(), "only the eye earns its place at rest"
+    assert row.name_label.isEnabled() is False
+
+
+# ── what the rows report ──────────────────────────────────────────────────
+
+
+def test_toggling_the_eye_reports_which_overview_and_which_way():
+    widget = _widget(_record(1))
+    row = widget._list.itemWidget(widget._list.item(0))
+    seen = []
+    widget.visibility_toggled.connect(lambda rid, vis: seen.append((rid, vis)))
+
+    row.btn_visible.setChecked(True)   # checked means hidden
+    row.btn_visible.setChecked(False)
+
+    assert seen == [("overview-1", False), ("overview-1", True)]
+
+
+def test_the_trash_asks_rather_than_removing_the_row_itself():
+    """The widget does not own the canvas, so it reports and lets the owner decide --
+    otherwise a refused removal would leave a list disagreeing with the canvas."""
+    widget = _widget(_record(1))
+    row = widget._list.itemWidget(widget._list.item(0))
+    asked = []
+    widget.remove_requested.connect(asked.append)
+
+    row.btn_remove.click()
+
+    assert asked == ["overview-1"]
+    assert widget._list.count() == 1, "the row removed itself"
+
+
+def test_refreshing_in_place_does_not_re_report_what_it_was_told():
+    """`refresh` is called *from* the handler for a toggle, so a row that re-emitted on
+    every refresh would go round in a loop."""
+    widget = _widget(_record(1, visible=True))
+    seen = []
+    widget.visibility_toggled.connect(lambda rid, vis: seen.append((rid, vis)))
+
+    widget.refresh([_record(1, visible=True)])
+
+    assert seen == []
+
+
+def test_a_refresh_that_does_change_the_state_moves_the_eye():
+    widget = _widget(_record(1, visible=True))
+    row = widget._list.itemWidget(widget._list.item(0))
+
+    widget.refresh([_record(1, visible=False)])
+
+    assert row.btn_visible.isChecked() is True
+    assert row.name_label.isEnabled() is False
+
+
+# ── selection across a rebuild ────────────────────────────────────────────
+
+
+def test_the_selection_survives_a_new_overview_arriving():
+    """The list is rebuilt whenever one is acquired, and losing the selection each time
+    would make it unusable during a run."""
+    widget = _widget(_record(1), _record(2))
+    widget.select("overview-1")
+
+    widget.set_records([_record(1), _record(2), _record(3)])
+
+    assert widget.selected_id() == "overview-1"
+
+
+def test_a_selection_that_was_removed_does_not_come_back():
+    widget = _widget(_record(1), _record(2))
+    widget.select("overview-2")
+
+    widget.set_records([_record(1)])
+
+    assert widget.selected_id() is None


### PR DESCRIPTION
Closes [FIB-543](https://linear.app/fibsemos/issue/FIB-543/track-each-placed-overview-as-a-record-and-list-them-in-the-settings). Requested from the hardware session as "dedicated image controls / tile list", and the missing piece under [FIB-415](https://linear.app/fibsemos/issue/FIB-415/layer-controls-on-the-real-space-canvas-canvas-wide-now-per-image).

## The hole

The canvas can hold several overviews at once and nothing tracked them. The widget kept a single `_displayed_image` that each acquisition overwrote, so an earlier overview stayed on screen with its provenance — where it was, when, at what scale, where it was saved — already discarded.

That field turned out to be **never read**: assigned in `set_image` and nowhere else, for a reader that no longer exists.

`remove_image` and `clear_overviews` also both existed with nothing in the UI calling them, so overviews accumulated for a whole session with no way to drop one.

## What's here

`PlacedOverviewImageRecord`, one per overview. Holds the **metadata**, not the image — everything a list needs is in there, and keeping N full-resolution mosaics alive to reach it would cost hundreds of megabytes on a canvas already short of them ([FIB-414](https://linear.app/fibsemos/issue/FIB-414/real-space-canvas-redraws-every-stored-pixel-needs-image-pyramids)).

Ids are minted rather than derived from the acquisition date. The date is unique enough — microsecond precision, and the mosaic inherits its first tile's stamp — but `_key_for` fell back to a bare `"overview"` whenever one was missing, so **every dateless overview shared a key and silently replaced the last**. Matching on the date is still done when there is one, which keeps re-showing an image a replacement rather than a second copy of itself.

The list is shaped after `LamellaRowWidget`: a name, its grid and scale, and an eye and a trash that appear on hover or selection. That per-row reveal is the one new behaviour — the lamella list shows and hides its buttons for every row at once, because there the question is which columns the table has.

Hiding goes through a new `set_image_visible` rather than removing and re-adding. Matplotlib skips a hidden artist, so it leaves the redraw cost as surely as a removal would, while keeping the extent and draw order intact.

## Decisions

- **The live preview gets no record.** It reaches the canvas through `set_channel` under its own key rather than through `set_image`, so the exclusion is structural — pinned by a test, because the two paths look alike from the outside.
- **Above the channels, not below.** Reading the column top to bottom then follows the order of using the tab; under the channels it split the two halves of "the next acquisition" around it.
- **No per-image opacity, no "go to".** Opacity would earn its space only if overlapping overviews needed manual blending, and [FIB-519](https://linear.app/fibsemos/issue/FIB-519/a-sparse-overviews-unacquired-tiles-paint-opaque-black-over-the) already did that job.
- **Draw order stays with `_detail_zorder`**, which sorts by pixel size, rather than becoming something the list controls.
- **Not per-image contrast.** FIB-415's argument that a mosaic should render uniformly is right for contrast and doesn't apply to visibility or removal.

## Testing

369 tests pass across the overview widget, the new list widget, all three canvas suites and the tile-grid overlay. Seven mutations, each caught by the test written for it — including dropping the `visibility_toggled`/`remove_requested` connections, and `set_image` forgetting to refresh the list.

**Two of those failures were mine rather than the code's**, and both are worth knowing:

- The hidden-stays-hidden test first passed for the wrong reason. Re-showing the same image swaps pixels on the existing artist and keeps its visibility without help, so it never exercised the re-assert it claimed to cover — dropping the production line left it green. It now crops the second image so the frame genuinely reshapes and a new artist is created.
- The fixture cleared the record store but not the list widget, so rows survived into the next test. Invisible while everything passed; it only surfaced because a mutation made a *neighbouring* test fail and the stale row changed what a different test saw.

## Commits

`878b9422` adds the two canvas primitives on their own and stands alone (verified: it imports cleanly with no reference to the list). `b4665815` is the record, the list and the wiring.