### PR TITLE
[ui] Add the correlation canvas widget on the shared stack (FIB-535)

### DIFF
--- a/fibsem/ui/correlation/widgets/correlation_canvas_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_canvas_widget.py
@@ -1,0 +1,137 @@
+"""Correlation point-picking on the shared canvas stack (FIB-535).
+
+`FibsemImageCanvas` + :class:`CorrelationPointOverlay`, exposing the same signals
+and methods as :class:`ImagePointCanvas` so the eventual swap in
+``correlation_tab_widget`` is a construction-site change and nothing more.
+
+**Not wired in yet.** `ImagePointCanvas` remains what the correlation tab uses;
+this is built alongside so each piece can be reviewed and tested on its own. The
+old canvas is deleted only in the last PR of the series, once all three of its
+consumers have moved.
+
+Skeleton scope — image display, points, selection, and the add-menu. Still to
+come: legend, per-point labels, `render_to_axes`, and the reprojected-result
+overlay (`add_overlay_points` / `clear_overlay`).
+
+What comes free with the shared canvas, and is the reason for the whole exercise:
+**contrast and gamma**, which `ImagePointCanvas` has never had — on FM data,
+where they are exactly the controls an operator wants while picking points. Also
+zoom/pan, the scalebar, the toolbar and the 11 other overlay types.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+import numpy as np
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtGui import QCursor
+from PyQt5.QtWidgets import QAction, QMenu, QVBoxLayout, QWidget
+
+from fibsem.correlation.structures import Coordinate, PointType
+from fibsem.structures import FibsemImage
+from fibsem.ui.correlation.widgets.correlation_point_overlay import (
+    CorrelationPointOverlay,
+)
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+
+class CorrelationCanvasWidget(QWidget):
+    """Image + draggable correlation points, on the shared canvas.
+
+    Signal shapes are deliberately identical to ``ImagePointCanvas``: the tab
+    widget's four handlers connect unchanged when this replaces it.
+    """
+
+    point_selected = pyqtSignal(object)  # Coordinate
+    point_moved = pyqtSignal(object)  # Coordinate
+    point_removed = pyqtSignal(object)  # Coordinate
+    point_add_requested = pyqtSignal(float, float, object)  # x, y, PointType
+
+    def __init__(
+        self,
+        allowed_point_types: Optional[List[PointType]] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        # None means "every type"; an empty list means "adding is off" -- the same
+        # convention ImagePointCanvas uses, kept so the swap does not silently
+        # re-enable adding in the result widget, which passes [].
+        self._allowed_types = allowed_point_types
+
+        self.canvas = FibsemImageCanvas()
+        self.points = CorrelationPointOverlay()
+        self.canvas.add_overlay(self.points)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.canvas)
+
+        # Identity signals straight through; only the add path needs translating,
+        # because the overlay reports *where* and this widget decides *what*.
+        self.points.coordinate_selected.connect(self.point_selected)
+        self.points.coordinate_moved.connect(self.point_moved)
+        self.points.coordinate_removed.connect(self.point_removed)
+        self.points.add_requested.connect(self._show_add_menu)
+
+    # ── the _CanvasAdapter surface ────────────────────────────────────────
+
+    def set_coordinates(self, coords: List[Coordinate]) -> None:
+        self.points.set_coordinates(coords)
+
+    def set_selected(self, coord: Optional[Coordinate]) -> None:
+        self.points.set_selected_coordinate(coord)
+
+    def refresh_coordinate(self, coord: Coordinate) -> None:
+        self.points.refresh_coordinate(coord)
+
+    # ── image ─────────────────────────────────────────────────────────────
+
+    def set_image(self, image: FibsemImage, cmap: str = "gray") -> None:
+        self.canvas.set_image(image, cmap=cmap)
+
+    def update_display(
+        self, image: np.ndarray, pixel_size: Optional[float] = None
+    ) -> None:
+        """Replace the displayed array, keeping zoom/pan across a same-size update.
+
+        ``ImagePointCanvas.update_display`` took an array and nothing else; the
+        optional *pixel_size* is the shared canvas's scalebar input, and omitting
+        it leaves the current value alone.
+        """
+        self.canvas.update_display(image, pixel_size=pixel_size)
+
+    def set_pixel_size(self, pixel_size_m: float) -> None:
+        self.canvas.pixel_size = pixel_size_m
+
+    def reset_view(self) -> None:
+        self.canvas.reset_view()
+
+    # ── add menu ──────────────────────────────────────────────────────────
+
+    def _show_add_menu(self, x: float, y: float) -> None:
+        """Ask which PointType to add at *x*, *y*, then report it.
+
+        The overlay cannot do this itself -- it is a QObject, not a widget, so it
+        has no parent to hang a QMenu from, and the allowed-type list is per-side
+        config the tab widget already owns. No stylesheet: QMenu is styled
+        app-wide in napari_style, and ImagePointCanvas overriding that locally is
+        the anomaly, not the rule.
+
+        Emits nothing when adding is disabled (``allowed_point_types=[]``) or the
+        menu is dismissed -- the point is created by the caller, not here, so the
+        Coordinate still gets its z from the adapter as it does today.
+        """
+        types = self._allowed_types if self._allowed_types is not None else list(PointType)
+        if not types:
+            return
+
+        menu = QMenu(self)
+        for pt in types:
+            action = QAction(f"Add {pt.value}", self)
+            action.setData((x, y, pt))
+            menu.addAction(action)
+
+        chosen = menu.exec_(QCursor.pos())
+        if chosen is not None:
+            cx, cy, pt = chosen.data()
+            self.point_add_requested.emit(cx, cy, pt)

--- a/fibsem/ui/correlation/widgets/correlation_point_overlay.py
+++ b/fibsem/ui/correlation/widgets/correlation_point_overlay.py
@@ -1,0 +1,219 @@
+"""Correlation points on the shared canvas stack (FIB-535).
+
+``CorrelationPointOverlay`` subclasses :class:`PointOverlay` and swaps its point
+model for ``Coordinate`` — which is the whole reason this class exists.
+
+Correlation points are not interchangeable: a ``Coordinate`` carries a
+``PointType``, and the tab widget's registry keys exclusivity and lifecycle off
+that identity (every handler's first line is ``self._point_specs[...]``, and one
+removal path filters with ``c is not coord`` — object identity, not equality).
+An index cannot stand in for that.
+
+Two things follow, and they are why a subclass beats widening ``PointOverlay``:
+
+* **Identity travels in the signals.** Base signals stay index-based for their
+  five existing consumers; the identity-carrying ones live here, where they are
+  the API rather than dead weight.
+* **One surface shows several ``PointType``s at once.** ``PointOverlay`` is a
+  single flat list with one style; holding ``List[Coordinate]`` here makes that
+  a non-problem instead of something to translate.
+
+``_coords`` is index-aligned with the base's ``_points``. That alignment is safe
+because the base mutates ``_points`` structurally in exactly four public methods
+(``set_points`` / ``add_point`` / ``remove_point`` / ``clear_points``), all
+overridden below; its fifth mutation is the drag, which moves a point without
+reordering. Index bookkeeping on removal — including shifting ``_selected`` —
+stays in the base, which is precisely the part a translation layer would have
+had to reimplement.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from PyQt5.QtCore import pyqtSignal
+
+from fibsem.correlation.structures import Coordinate, PointType
+from fibsem.ui.tokens import ORANGE_COLOR
+from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
+
+# Saturated primaries, chosen to stay legible against arbitrary image content
+# rather than to match the app palette — the same reasoning that keeps the
+# NEUTRAL_* ramp out of the tinted tokens.
+POINT_COLORS: Dict[PointType, str] = {
+    PointType.FIB:        "#00ff00",
+    PointType.FM:         "#00e5ff",
+    PointType.POI:        "#ff00ff",
+    PointType.SURFACE:    ORANGE_COLOR,
+    PointType.SURFACE_FM: "#ffea00",
+}
+POINT_MARKERS: Dict[PointType, str] = {
+    PointType.FIB:        "o",
+    PointType.FM:         "o",
+    PointType.POI:        "o",
+    PointType.SURFACE:    "+",
+    PointType.SURFACE_FM: "+",
+}
+MARKER_SIZE = 5.0  # the base draws the selected marker at size * 1.4 = 7.0
+
+
+def generate_names(coordinates: List[Coordinate]) -> List[str]:
+    """Per-type 1-based names: ``FIB 1``, ``FIB 2``, ``POI 1`` ...
+
+    Numbered within a type rather than across the list, so a point's label does
+    not change when an unrelated type gains or loses one.
+    """
+    counters: Dict[PointType, int] = {}
+    names = []
+    for c in coordinates:
+        counters[c.point_type] = counters.get(c.point_type, 0) + 1
+        names.append(f"{c.point_type.value} {counters[c.point_type]}")
+    return names
+
+
+class CorrelationPointOverlay(PointOverlay):
+    """Interactive correlation points, addressed by ``Coordinate`` identity."""
+
+    # Identity-carrying counterparts of the base's index-based signals. The base
+    # ones still fire; consumers here should use these.
+    coordinate_selected = pyqtSignal(object)  # Coordinate
+    coordinate_moved = pyqtSignal(object)  # Coordinate (drag finished)
+    coordinate_removed = pyqtSignal(object)  # Coordinate (before removal)
+    # The view decides which PointType a new point gets (it owns the menu), so
+    # the overlay only reports where the user asked for one.
+    add_requested = pyqtSignal(float, float)  # x, y
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(size=MARKER_SIZE, parent=parent)
+        self._coords: List[Coordinate] = []
+        self._names: List[str] = []
+        self.point_selected.connect(self._emit_selected)
+        self.point_moved.connect(self._emit_moved)
+        self.point_removed.connect(self._emit_removed)
+
+    # ── model ─────────────────────────────────────────────────────────────
+
+    def set_coordinates(self, coords: List[Coordinate]) -> None:
+        """Replace the displayed set. Coordinates are held by reference, so the
+        objects handed back by the signals are the caller's own."""
+        self._coords = list(coords)
+        self._names = generate_names(self._coords)
+        self.set_points([(c.point.x, c.point.y) for c in self._coords])
+
+    def add_coordinate(self, coord: Coordinate) -> int:
+        self._coords.append(coord)
+        self._names = generate_names(self._coords)
+        idx = super().add_point(coord.point.x, coord.point.y)
+        self._refresh_labels()
+        return idx
+
+    def remove_coordinate(self, coord: Coordinate) -> None:
+        idx = self.index_of(coord)
+        if idx is not None:
+            self.remove_point(idx)
+
+    def coordinates(self) -> List[Coordinate]:
+        return list(self._coords)
+
+    def index_of(self, coord: Optional[Coordinate]) -> Optional[int]:
+        """Index of *coord* by object identity, not equality — two coordinates
+        can hold equal values and still be different points."""
+        for i, c in enumerate(self._coords):
+            if c is coord:
+                return i
+        return None
+
+    def selected_coordinate(self) -> Optional[Coordinate]:
+        idx = self._selected
+        return self._coords[idx] if idx is not None and idx < len(self._coords) else None
+
+    def set_selected_coordinate(self, coord: Optional[Coordinate]) -> None:
+        """Select by identity. Silent, like the base's ``set_selected``."""
+        self.set_selected(self.index_of(coord))
+
+    def refresh_coordinate(self, coord: Coordinate) -> None:
+        """Re-read a coordinate's position after an external edit."""
+        idx = self.index_of(coord)
+        if idx is None:
+            return
+        self._points[idx] = [float(coord.point.x), float(coord.point.y)]
+        self._update_artist_position(idx)
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    # ── base overrides keeping _coords aligned ────────────────────────────
+
+    def add_point(self, x: float, y: float) -> int:
+        """Not available: a correlation point needs a PointType, which only the
+        view can supply. Raises rather than appending, because a point without a
+        matching entry in ``_coords`` desynchronises the two lists silently."""
+        raise NotImplementedError("use add_coordinate(); a bare point has no PointType")
+
+    def remove_point(self, index: int) -> None:
+        if index < 0 or index >= len(self._coords):
+            return
+        # super() emits point_removed(index) before it pops, so _emit_removed can
+        # still read _coords[index]; pop only once it returns.
+        super().remove_point(index)
+        self._coords.pop(index)
+        self._names = generate_names(self._coords)
+        self._refresh_labels()
+
+    def clear_points(self) -> None:
+        super().clear_points()
+        self._coords.clear()
+        self._names = []
+
+    # ── per-point style ───────────────────────────────────────────────────
+
+    def _point_color(self, idx: int, selected: bool) -> str:
+        """Colour by type. A selected point keeps its own colour — the rim and
+        size carry the selection instead, so the type stays readable."""
+        if idx >= len(self._coords):
+            return super()._point_color(idx, selected)
+        return POINT_COLORS.get(self._coords[idx].point_type, "white")
+
+    def _point_marker(self, idx: int) -> str:
+        if idx >= len(self._coords):
+            return super()._point_marker(idx)
+        return POINT_MARKERS.get(self._coords[idx].point_type, "o")
+
+    def _point_label(self, idx: int) -> Optional[str]:
+        return self._names[idx] if idx < len(self._names) else None
+
+    def _marker_edge(self, idx: int, color: str, selected: bool):
+        """Filled markers show selection as a white rim; unfilled ones ("+") are
+        drawn entirely by their edge, so a white edge would replace the type
+        colour and "none" would erase the marker — they thicken instead."""
+        from matplotlib.lines import Line2D
+
+        if self._point_marker(idx) in Line2D.filled_markers:
+            return ("white" if selected else "none"), 2.0
+        return color, (3.0 if selected else 2.0)
+
+    # ── interaction ───────────────────────────────────────────────────────
+
+    def _on_right_click(self, x: float, y: float) -> None:
+        """Report the request and add nothing: the view has to ask which
+        PointType before a Coordinate can exist."""
+        self.add_requested.emit(x, y)
+
+    # ── index → identity ──────────────────────────────────────────────────
+
+    def _emit_selected(self, idx: int, x: float, y: float) -> None:
+        if idx < len(self._coords):
+            self.coordinate_selected.emit(self._coords[idx])
+
+    def _emit_moved(self, idx: int, x: float, y: float) -> None:
+        if idx >= len(self._coords):
+            return
+        coord = self._coords[idx]
+        coord.point.x, coord.point.y = float(x), float(y)
+        self.coordinate_moved.emit(coord)
+
+    def _emit_removed(self, idx: int) -> None:
+        if idx < len(self._coords):
+            self.coordinate_removed.emit(self._coords[idx])
+
+    def _refresh_labels(self) -> None:
+        if self._anns:
+            self._refresh_ann_text()

--- a/fibsem/ui/correlation/widgets/correlation_tab_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_tab_widget.py
@@ -1388,6 +1388,14 @@ class _CanvasAdapter:
     stack (fibsem.ui.widgets.canvas, PR #111, index-based PointOverlay
     signals) therefore means new adapters PLUS an inbound translation layer;
     what stays untouched is the registry, exclusivity, and lifecycle logic.
+
+    Superseded in part (FIB-535): the translation layer above is no longer the
+    plan. A CorrelationPointOverlay subclassing PointOverlay carries Coordinate
+    identity in its own signals, so nothing has to be translated back from an
+    index — and it also resolves the second mismatch this note misses, that one
+    canvas shows several PointTypes at once while PointOverlay is a single flat
+    list. The last sentence still holds: registry, exclusivity and lifecycle
+    stay untouched.
     """
 
     def __init__(

--- a/fibsem/ui/correlation/widgets/image_point_canvas.py
+++ b/fibsem/ui/correlation/widgets/image_point_canvas.py
@@ -60,24 +60,19 @@ from fibsem.ui.tokens import (
     GRAY_TEXT_COLOR,
     NEUTRAL_200,
     NEUTRAL_450,
-    ORANGE_COLOR,
 )
+from fibsem.ui.correlation.widgets.correlation_point_overlay import (
+    POINT_COLORS,
+    POINT_MARKERS,
+)
+
 _logger = logging.getLogger(__name__)
 
-_POINT_COLORS: Dict[PointType, str] = {
-    PointType.FIB:        "#00ff00",
-    PointType.FM:         "#00e5ff",
-    PointType.POI:        "#ff00ff",
-    PointType.SURFACE:    f"{ORANGE_COLOR}",
-    PointType.SURFACE_FM: "#ffea00",
-}
-_POINT_MARKERS: Dict[PointType, str] = {
-    PointType.FIB:        "o",
-    PointType.FM:         "o",
-    PointType.POI:        "o",
-    PointType.SURFACE:    "+",
-    PointType.SURFACE_FM: "+",
-}
+# Single source while this canvas and CorrelationPointOverlay coexist (FIB-535):
+# the same points are about to be drawn by both, and two copies of the table
+# would let them drift apart mid-migration. Deleted with this module.
+_POINT_COLORS = POINT_COLORS
+_POINT_MARKERS = POINT_MARKERS
 _MARKER_SIZE     = 5
 _SELECTED_SIZE   = 7
 _PICK_RADIUS_PX  = 15

--- a/fibsem/ui/correlation/widgets/test_correlation_canvas_demo.py
+++ b/fibsem/ui/correlation/widgets/test_correlation_canvas_demo.py
@@ -1,0 +1,211 @@
+"""Side-by-side harness: ImagePointCanvas (old) vs CorrelationCanvasWidget (new).
+
+Same synthetic image, same starting points, on both. Use it to check the
+replacement behaves like the thing it replaces before anything is wired in --
+and to see what the shared canvas adds, which is the point of FIB-535.
+
+Usage
+-----
+    PYTHONPATH=$PWD python fibsem/ui/correlation/widgets/test_correlation_canvas_demo.py
+
+What to try
+-----------
+* **Right-click** either canvas -> the add menu. Both should offer the same
+  types and drop a point in the same place.
+* **Drag** a point, **click** to select, **Delete** to remove. The log shows
+  what each side emits; the payloads should match.
+* **Contrast / gamma** -- the toolbar button on the RIGHT canvas only. The old
+  canvas has never had it, and on FM data it is the control you actually want
+  while picking points.
+* **Scalebar, zoom, pan, fit-to-view** -- right canvas toolbar, also new.
+"""
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QPushButton,
+    QSplitter,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.correlation.structures import Coordinate, PointType, PointXYZ
+from fibsem.ui.correlation.widgets.correlation_canvas_widget import (
+    CorrelationCanvasWidget,
+)
+from fibsem.ui.correlation.widgets.image_point_canvas import ImagePointCanvas
+from fibsem.ui.tokens import (
+    ACCENT_COLOR,
+    OK_COLOR,
+    SURFACE_COLOR,
+    TEXT_MUTED_COLOR,
+    TEXT_STRONG_COLOR,
+)
+
+_FIB_TYPES = [PointType.FIB, PointType.SURFACE]
+
+
+def _synthetic_image(h: int = 512, w: int = 512) -> np.ndarray:
+    """Gradient + blobs, deliberately low-contrast so the contrast control on the
+    new canvas has something to do."""
+    rng = np.random.default_rng(42)
+    base = np.linspace(0.0, 0.3, w)[None, :] + np.linspace(0.0, 0.3, h)[:, None]
+    img = base + rng.normal(0, 0.04, (h, w))
+    yy, xx = np.mgrid[0:h, 0:w]
+    for cy, cx, amp, sigma in ((150, 180, 0.5, 40), (330, 300, 0.4, 55), (200, 400, 0.3, 30)):
+        img += amp * np.exp(-(((yy - cy) ** 2 + (xx - cx) ** 2) / (2.0 * sigma**2)))
+    img = np.clip(img, 0, None)
+    return (img / img.max() * 255).astype(np.uint8)
+
+
+def _seed_points() -> list:
+    return [
+        Coordinate(PointXYZ(180.0, 150.0, 0.0), PointType.FIB),
+        Coordinate(PointXYZ(300.0, 330.0, 0.0), PointType.FIB),
+        Coordinate(PointXYZ(400.0, 200.0, 0.0), PointType.SURFACE),
+    ]
+
+
+class DemoWindow(QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("FIB-535 — ImagePointCanvas (old) vs CorrelationCanvasWidget (new)")
+        self.resize(1500, 820)
+
+        image = _synthetic_image()
+
+        root = QWidget()
+        root_layout = QVBoxLayout(root)
+        self.setCentralWidget(root)
+
+        canvases = QSplitter(Qt.Orientation.Horizontal)
+        canvases.addWidget(self._titled("OLD — ImagePointCanvas", self._build_old(image)))
+        canvases.addWidget(
+            self._titled(
+                "NEW — CorrelationCanvasWidget  (contrast/gamma + toolbar)",
+                self._build_new(image),
+            )
+        )
+        canvases.setSizes([700, 700])
+        root_layout.addWidget(canvases, 1)
+
+        controls = QHBoxLayout()
+        for label, slot in (
+            ("Reset both", self._reset),
+            ("Clear both", self._clear),
+            ("Clear log", lambda: self.log.clear()),
+        ):
+            btn = QPushButton(label)
+            btn.clicked.connect(slot)
+            controls.addWidget(btn)
+        controls.addStretch()
+        controls.addWidget(
+            QLabel(
+                f"<span style='color:{TEXT_MUTED_COLOR}'>right-click to add · drag to move · "
+                f"Delete to remove · contrast button on the right canvas only</span>"
+            )
+        )
+        root_layout.addLayout(controls)
+
+        self.log = QTextEdit()
+        self.log.setReadOnly(True)
+        self.log.setFixedHeight(170)
+        self.log.setStyleSheet(
+            f"background: {SURFACE_COLOR}; color: {TEXT_STRONG_COLOR}; "
+            "font-family: monospace; font-size: 11px;"
+        )
+        root_layout.addWidget(self.log)
+
+        self._reset()
+
+    # ── construction ──────────────────────────────────────────────────────
+
+    def _titled(self, title: str, widget: QWidget) -> QWidget:
+        box = QWidget()
+        layout = QVBoxLayout(box)
+        layout.setContentsMargins(0, 0, 0, 0)
+        label = QLabel(f"<b>{title}</b>")
+        label.setStyleSheet(f"color: {TEXT_STRONG_COLOR}; padding: 4px;")
+        layout.addWidget(label)
+        layout.addWidget(widget, 1)
+        return box
+
+    def _build_old(self, image: np.ndarray) -> QWidget:
+        self.old = ImagePointCanvas(allowed_point_types=_FIB_TYPES)
+        self.old.set_image(image)
+        self.old.point_selected.connect(lambda c: self._say("old", "selected", c))
+        self.old.point_moved.connect(lambda c: self._say("old", "moved", c))
+        self.old.point_removed.connect(lambda c: self._say("old", "removed", c))
+        self.old.point_add_requested.connect(
+            lambda x, y, pt: self._added("old", x, y, pt)
+        )
+        return self.old
+
+    def _build_new(self, image: np.ndarray) -> QWidget:
+        self.new = CorrelationCanvasWidget(allowed_point_types=_FIB_TYPES)
+        self.new.canvas.set_array(image)
+        self.new.point_selected.connect(lambda c: self._say("new", "selected", c))
+        self.new.point_moved.connect(lambda c: self._say("new", "moved", c))
+        self.new.point_removed.connect(lambda c: self._say("new", "removed", c))
+        self.new.point_add_requested.connect(
+            lambda x, y, pt: self._added("new", x, y, pt)
+        )
+        return self.new
+
+    # ── behaviour ─────────────────────────────────────────────────────────
+
+    def _reset(self) -> None:
+        # Separate Coordinate objects per side: they are held by reference, so
+        # sharing one list would let a drag on one canvas silently move the other
+        # and hide exactly the difference this harness exists to show.
+        self.old.set_coordinates(_seed_points())
+        self.new.set_coordinates(_seed_points())
+        self._log("reset both canvases to 3 seed points")
+
+    def _clear(self) -> None:
+        self.old.set_coordinates([])
+        self.new.set_coordinates([])
+        self._log("cleared both")
+
+    def _added(self, side: str, x: float, y: float, pt: PointType) -> None:
+        """Both canvases only *request* an add -- the tab widget builds the
+        Coordinate, because it owns the z. Mirror that here."""
+        surface = self.old if side == "old" else self.new
+        coord = Coordinate(PointXYZ(x, y, 0.0), pt)
+        current = list(
+            surface.points.coordinates() if side == "new" else surface._coordinates
+        )
+        surface.set_coordinates(current + [coord])
+        self._log(f"[{side}] add_requested  {pt.value:12} ({x:7.1f}, {y:7.1f})", ACCENT_COLOR)
+
+    def _say(self, side: str, what: str, coord: Coordinate) -> None:
+        self._log(
+            f"[{side}] {what:9} {coord.point_type.value:12} "
+            f"({coord.point.x:7.1f}, {coord.point.y:7.1f})",
+            OK_COLOR if side == "new" else None,
+        )
+
+    def _log(self, message: str, color: str = None) -> None:
+        if color:
+            self.log.append(f"<span style='color:{color}'>{message}</span>")
+        else:
+            self.log.append(message)
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    window = DemoWindow()
+    window.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -441,7 +441,33 @@ class PointOverlay(QObject):
         self._ax.add_artist(leg)
         self._legend = leg
 
-    def _marker_edge(self, color: str, selected: bool):
+    def _on_right_click(self, x: float, y: float) -> None:
+        """Handle a right-click at content coordinates *x*, *y*.
+
+        Adds a point immediately and selects it. Split out from ``_on_press`` so a
+        subclass can defer instead — correlation has to ask which ``PointType``
+        before a point exists, so it emits a request and adds nothing here.
+        """
+        idx = self.add_point(x, y)
+        old_sel = self._selected
+        self._selected = idx
+        if old_sel is not None:
+            self._update_artist_appearance(old_sel)
+        self._update_artist_appearance(idx)
+        self.point_added.emit(idx, x, y)
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def _point_marker(self, idx: int) -> str:
+        """Marker glyph for a point.
+
+        One glyph for every point here. Overridable so a subclass can vary it per
+        point without reimplementing the artist path — correlation draws SURFACE
+        types as "+" and everything else as "o".
+        """
+        return self._marker
+
+    def _marker_edge(self, idx: int, color: str, selected: bool):
         """Edge colour/width for the marker. Unfilled markers (+, x, ...) are drawn
         in their edge colour, so they take the point colour and a thicker line;
         filled markers (o, s, ...) keep a thin white outline for contrast.
@@ -450,7 +476,7 @@ class PointOverlay(QObject):
         adds a fixed bump, so backward-compatible defaults are preserved when unset.
         """
         from matplotlib.lines import Line2D
-        if self._marker in Line2D.filled_markers:
+        if self._point_marker(idx) in Line2D.filled_markers:
             base = self._edge_width if self._edge_width is not None else 0.8
             return "white", (base + 1.2 if selected else base)
         base = self._edge_width if self._edge_width is not None else 2.0
@@ -482,11 +508,11 @@ class PointOverlay(QObject):
         selected = idx == self._selected
         color = self._point_color(idx, selected)
         ms = self._size * 1.4 if selected else self._size
-        edge_color, mew = self._marker_edge(color, selected)
+        edge_color, mew = self._marker_edge(idx, color, selected)
         (line,) = self._ax.plot(
             x,
             y,
-            marker=self._marker,
+            marker=self._point_marker(idx),
             markersize=ms,
             color=color,
             markeredgecolor=edge_color,
@@ -519,7 +545,7 @@ class PointOverlay(QObject):
         selected = idx == self._selected
         color = self._point_color(idx, selected)
         ms = self._size * 1.4 if selected else self._size
-        edge_color, mew = self._marker_edge(color, selected)
+        edge_color, mew = self._marker_edge(idx, color, selected)
         line = self._artists[idx]
         line.set_color(color)
         line.set_markersize(ms)
@@ -605,15 +631,7 @@ class PointOverlay(QObject):
         if event.button == 3:  # right-click → add a new point
             if not self._add_on_right_click:
                 return
-            x, y = self._clamp_to_content(event.xdata, event.ydata)
-            idx = self.add_point(x, y)
-            old_sel = self._selected
-            self._selected = idx
-            if old_sel is not None:
-                self._update_artist_appearance(old_sel)
-            self._update_artist_appearance(idx)
-            self.point_added.emit(idx, x, y)
-            self._canvas.draw_idle()
+            self._on_right_click(*self._clamp_to_content(event.xdata, event.ydata))
             return
 
         if event.button != 1:

--- a/tests/correlation/test_correlation_canvas_widget.py
+++ b/tests/correlation/test_correlation_canvas_widget.py
@@ -1,0 +1,216 @@
+"""CorrelationCanvasWidget: the shared-canvas replacement for ImagePointCanvas.
+
+Two things are pinned here. First, that points survive the trip through the
+widget with their identity intact. Second -- and this is the one that earns its
+keep -- that the widget's signals and methods still match ImagePointCanvas's, so
+the eventual swap in correlation_tab_widget stays a construction-site change.
+That test fails the moment the two drift, which is the failure mode of building
+a replacement alongside the thing it replaces.
+"""
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] without the UI extra
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.correlation.structures import Coordinate, PointType, PointXYZ
+from fibsem.ui.correlation.widgets.correlation_canvas_widget import (
+    CorrelationCanvasWidget,
+)
+from fibsem.ui.correlation.widgets.image_point_canvas import ImagePointCanvas
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _coord(x, y, pt=PointType.FIB):
+    return Coordinate(PointXYZ(x, y, 0.0), pt)
+
+
+def _widget(allowed=None):
+    w = CorrelationCanvasWidget(allowed_point_types=allowed)
+    w.canvas.set_array(np.zeros((64, 64), dtype=np.uint8))
+    return w
+
+
+# ── the contract with the tab widget ──────────────────────────────────────
+
+
+def test_signals_match_the_canvas_it_replaces():
+    """The tab widget connects these four by name; a rename breaks the swap."""
+    for name in ("point_selected", "point_moved", "point_removed", "point_add_requested"):
+        assert hasattr(CorrelationCanvasWidget, name), name
+        assert hasattr(ImagePointCanvas, name), name
+
+
+def test_adapter_surface_matches_the_canvas_it_replaces():
+    """_CanvasAdapter calls exactly these three on whatever surface it holds."""
+    for name in ("set_coordinates", "set_selected", "refresh_coordinate"):
+        assert callable(getattr(CorrelationCanvasWidget, name, None)), name
+        assert callable(getattr(ImagePointCanvas, name, None)), name
+
+
+def test_image_methods_match_the_canvas_it_replaces():
+    for name in ("set_image", "update_display", "set_pixel_size", "reset_view"):
+        assert callable(getattr(CorrelationCanvasWidget, name, None)), name
+        assert callable(getattr(ImagePointCanvas, name, None)), name
+
+
+# ── points through the widget ─────────────────────────────────────────────
+
+
+def test_coordinates_reach_the_overlay():
+    a, b = _coord(10, 10), _coord(20, 20, PointType.SURFACE)
+    w = _widget()
+    w.set_coordinates([a, b])
+    assert w.points.coordinates() == [a, b]
+    assert w.points.get_points() == [(10.0, 10.0), (20.0, 20.0)]
+
+
+def test_selection_round_trips_by_identity():
+    a, b = _coord(10, 10), _coord(20, 20)
+    w = _widget()
+    w.set_coordinates([a, b])
+    w.set_selected(b)
+    assert w.points.selected_coordinate() is b
+    w.set_selected(None)
+    assert w.points.selected_coordinate() is None
+
+
+def test_overlay_signals_are_re_emitted_by_the_widget():
+    a = _coord(10, 10)
+    w = _widget()
+    w.set_coordinates([a])
+    seen = {"sel": [], "moved": [], "removed": []}
+    w.point_selected.connect(seen["sel"].append)
+    w.point_moved.connect(seen["moved"].append)
+    w.point_removed.connect(seen["removed"].append)
+
+    w.points.point_selected.emit(0, 10.0, 10.0)
+    w.points.point_moved.emit(0, 11.0, 12.0)
+    w.points.remove_coordinate(a)
+
+    assert seen["sel"] == [a] and seen["moved"] == [a] and seen["removed"] == [a]
+
+
+def test_refresh_picks_up_an_external_edit():
+    a = _coord(10, 10)
+    w = _widget()
+    w.set_coordinates([a])
+    a.point.x, a.point.y = 40.0, 50.0
+    w.refresh_coordinate(a)
+    assert w.points.get_points() == [(40.0, 50.0)]
+
+
+# ── the add menu ──────────────────────────────────────────────────────────
+
+
+def test_adding_is_off_when_no_types_are_allowed(monkeypatch):
+    """correlation_result_widget passes [] to make its overlay read-only."""
+    w = _widget(allowed=[])
+    called = []
+    monkeypatch.setattr(
+        "fibsem.ui.correlation.widgets.correlation_canvas_widget.QMenu",
+        lambda *a, **k: called.append(1),
+    )
+    seen = []
+    w.point_add_requested.connect(lambda *a: seen.append(a))
+
+    w.points.add_requested.emit(5.0, 6.0)
+
+    assert called == []  # no menu is even built
+    assert seen == []
+
+
+def test_a_dismissed_menu_adds_nothing():
+    w = _widget()
+    seen = []
+    w.point_add_requested.connect(lambda *a: seen.append(a))
+
+    class _Dismissed:
+        def __init__(self, *a, **k):
+            pass
+
+        def addAction(self, action):
+            pass
+
+        def exec_(self, pos):
+            return None
+
+    import fibsem.ui.correlation.widgets.correlation_canvas_widget as mod
+
+    real, mod.QMenu = mod.QMenu, _Dismissed
+    try:
+        w.points.add_requested.emit(5.0, 6.0)
+    finally:
+        mod.QMenu = real
+    assert seen == []
+
+
+def test_a_chosen_type_is_reported_with_the_click_position():
+    w = _widget(allowed=[PointType.FIB, PointType.SURFACE])
+    seen = []
+    w.point_add_requested.connect(lambda x, y, pt: seen.append((x, y, pt)))
+
+    class _PicksSecond:
+        def __init__(self, *a, **k):
+            self._actions = []
+
+        def addAction(self, action):
+            self._actions.append(action)
+
+        def exec_(self, pos):
+            return self._actions[1]
+
+    import fibsem.ui.correlation.widgets.correlation_canvas_widget as mod
+
+    real, mod.QMenu = mod.QMenu, _PicksSecond
+    try:
+        w.points.add_requested.emit(5.0, 6.0)
+    finally:
+        mod.QMenu = real
+
+    assert seen == [(5.0, 6.0, PointType.SURFACE)]
+
+
+def test_the_widget_adds_no_point_itself():
+    """The Coordinate is built by the caller, which owns the z. The widget only
+    reports x/y and the chosen type -- same contract as today."""
+    w = _widget(allowed=[PointType.FIB])
+
+    class _PicksFirst:
+        def __init__(self, *a, **k):
+            self._actions = []
+
+        def addAction(self, action):
+            self._actions.append(action)
+
+        def exec_(self, pos):
+            return self._actions[0]
+
+    import fibsem.ui.correlation.widgets.correlation_canvas_widget as mod
+
+    real, mod.QMenu = mod.QMenu, _PicksFirst
+    try:
+        w.points.add_requested.emit(5.0, 6.0)
+    finally:
+        mod.QMenu = real
+
+    assert w.points.coordinates() == []
+
+
+# ── the reason for the migration ──────────────────────────────────────────
+
+
+def test_contrast_and_gamma_are_available():
+    """ImagePointCanvas has neither; on FM data they are the controls an operator
+    actually wants while picking points. The shared canvas brings a
+    ContrastGammaControl and a toolbar button to raise it."""
+    w = _widget()
+    assert w.canvas._contrast is not None
+    assert callable(w.canvas.toggle_contrast)
+    assert w.canvas.btn_contrast is not None
+    # and the old canvas genuinely lacks it -- this is a real gain, not a rename
+    assert not hasattr(ImagePointCanvas, "toggle_contrast")

--- a/tests/correlation/test_correlation_point_overlay.py
+++ b/tests/correlation/test_correlation_point_overlay.py
@@ -9,6 +9,9 @@ import sys
 
 import numpy as np
 import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] without the UI extra
+
 from PyQt5.QtWidgets import QApplication
 
 from fibsem.correlation.structures import Coordinate, PointType, PointXYZ

--- a/tests/correlation/test_correlation_point_overlay.py
+++ b/tests/correlation/test_correlation_point_overlay.py
@@ -1,0 +1,202 @@
+"""CorrelationPointOverlay: Coordinate identity survives the index-based base.
+
+The point of the subclass is that callers address points by object identity while
+PointOverlay addresses them by index. These tests pin the seam between the two --
+above all the cases where indices shift under the caller (removal), which is where
+an index<->identity translation layer would have broken.
+"""
+import sys
+
+import numpy as np
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.correlation.structures import Coordinate, PointType, PointXYZ
+from fibsem.ui.correlation.widgets.correlation_point_overlay import (
+    POINT_COLORS,
+    CorrelationPointOverlay,
+    generate_names,
+)
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _coord(x, y, pt=PointType.FIB):
+    return Coordinate(PointXYZ(x, y, 0.0), pt)
+
+
+def _attached(coords):
+    canvas = FibsemImageCanvas()
+    canvas.set_array(np.zeros((64, 64), dtype=np.uint8))
+    ov = CorrelationPointOverlay()
+    canvas.add_overlay(ov)
+    ov.set_coordinates(coords)
+    return canvas, ov
+
+
+# ── identity ──────────────────────────────────────────────────────────────
+
+
+def test_selection_emits_the_caller_s_own_object():
+    a, b = _coord(10, 10), _coord(20, 20)
+    _, ov = _attached([a, b])
+    seen = []
+    ov.coordinate_selected.connect(seen.append)
+
+    ov.point_selected.emit(1, 20.0, 20.0)
+
+    assert len(seen) == 1
+    assert seen[0] is b  # identity, not equality
+
+
+def test_drag_writes_back_into_the_coordinate():
+    c = _coord(10, 10)
+    _, ov = _attached([c])
+    seen = []
+    ov.coordinate_moved.connect(seen.append)
+
+    ov.point_moved.emit(0, 33.0, 44.0)
+
+    assert (c.point.x, c.point.y) == (33.0, 44.0)
+    assert seen == [c]
+
+
+def test_removal_reports_identity_before_the_point_goes():
+    a, b = _coord(10, 10), _coord(20, 20)
+    _, ov = _attached([a, b])
+    seen = []
+    ov.coordinate_removed.connect(seen.append)
+
+    ov.remove_coordinate(a)
+
+    assert seen == [a]
+    assert ov.coordinates() == [b]
+
+
+# ── the case a translation layer would have broken ────────────────────────
+
+
+def test_indices_shift_but_identity_does_not():
+    a, b, c = _coord(10, 10), _coord(20, 20), _coord(30, 30)
+    _, ov = _attached([a, b, c])
+
+    ov.remove_coordinate(a)  # every later index shifts down by one
+
+    assert ov.coordinates() == [b, c]
+    assert ov.index_of(b) == 0 and ov.index_of(c) == 1
+    seen = []
+    ov.coordinate_selected.connect(seen.append)
+    ov.point_selected.emit(1, 30.0, 30.0)
+    assert seen == [c]  # index 1 is now c, not b
+
+
+def test_selection_follows_its_point_across_a_removal():
+    a, b = _coord(10, 10), _coord(20, 20)
+    _, ov = _attached([a, b])
+    ov.set_selected_coordinate(b)
+    assert ov.selected_coordinate() is b
+
+    ov.remove_coordinate(a)  # base shifts _selected 1 -> 0
+
+    assert ov.selected_coordinate() is b
+
+
+def test_equal_but_distinct_coordinates_are_not_confused():
+    a, b = _coord(10, 10), _coord(10, 10)  # equal values, different objects
+    _, ov = _attached([a, b])
+
+    assert a == b
+    assert ov.index_of(a) == 0 and ov.index_of(b) == 1
+
+
+def test_geometry_and_identity_stay_aligned_after_edits():
+    a, b, c = _coord(10, 10), _coord(20, 20), _coord(30, 30)
+    _, ov = _attached([a, b, c])
+    ov.remove_coordinate(b)
+    ov.add_coordinate(_coord(40, 40, PointType.POI))
+
+    assert ov.get_points() == [(c.point.x, c.point.y) for c in ov.coordinates()]
+
+
+# ── heterogeneous types on one surface ────────────────────────────────────
+
+
+def test_one_overlay_carries_several_point_types():
+    fib, poi, surf = (
+        _coord(10, 10, PointType.FIB),
+        _coord(20, 20, PointType.POI),
+        _coord(30, 30, PointType.SURFACE),
+    )
+    _, ov = _attached([fib, poi, surf])
+
+    assert ov._point_color(0, False) == POINT_COLORS[PointType.FIB]
+    assert ov._point_color(1, False) == POINT_COLORS[PointType.POI]
+    assert ov._point_marker(0) == "o"
+    assert ov._point_marker(2) == "+"  # SURFACE is a crosshair
+
+
+def test_selected_point_keeps_its_type_colour():
+    """Selection is carried by rim and size so the type stays readable."""
+    c = _coord(10, 10, PointType.POI)
+    _, ov = _attached([c])
+    assert ov._point_color(0, True) == POINT_COLORS[PointType.POI]
+    assert ov._marker_edge(0, POINT_COLORS[PointType.POI], True)[0] == "white"
+
+
+def test_unfilled_markers_thicken_rather_than_whiten():
+    c = _coord(10, 10, PointType.SURFACE)
+    _, ov = _attached([c])
+    colour = POINT_COLORS[PointType.SURFACE]
+    assert ov._marker_edge(0, colour, False) == (colour, 2.0)
+    assert ov._marker_edge(0, colour, True) == (colour, 3.0)
+
+
+# ── labels ────────────────────────────────────────────────────────────────
+
+
+def test_names_are_numbered_within_a_type():
+    coords = [
+        _coord(0, 0, PointType.FIB),
+        _coord(1, 1, PointType.POI),
+        _coord(2, 2, PointType.FIB),
+    ]
+    assert generate_names(coords) == ["FIB 1", "POI 1", "FIB 2"]
+
+
+def test_labels_renumber_after_a_removal():
+    a, b, c = (
+        _coord(0, 0, PointType.FIB),
+        _coord(1, 1, PointType.FIB),
+        _coord(2, 2, PointType.FIB),
+    )
+    _, ov = _attached([a, b, c])
+    ov.remove_coordinate(a)
+    assert [ov._point_label(i) for i in range(2)] == ["FIB 1", "FIB 2"]
+
+
+# ── interaction contract ──────────────────────────────────────────────────
+
+
+def test_right_click_asks_rather_than_adds():
+    _, ov = _attached([])
+    seen = []
+    ov.add_requested.connect(lambda x, y: seen.append((x, y)))
+
+    ov._on_right_click(12.0, 34.0)
+
+    assert seen == [(12.0, 34.0)]
+    assert ov.coordinates() == []  # nothing added until the view supplies a type
+
+
+def test_bare_add_point_is_refused():
+    """A point with no matching Coordinate would desync the two lists silently."""
+    _, ov = _attached([])
+    with pytest.raises(NotImplementedError):
+        ov.add_point(1.0, 2.0)
+
+
+def test_clear_drops_both_lists():
+    _, ov = _attached([_coord(10, 10), _coord(20, 20)])
+    ov.clear_points()
+    assert ov.coordinates() == [] and ov.get_points() == []


### PR DESCRIPTION
Second step of FIB-535, following #321. **Three new files, none modified** — the correlation tab still constructs `ImagePointCanvas` and `FMImageDisplayWidget`, nothing imports the new widget, and behaviour is unchanged.

## What it is

`CorrelationCanvasWidget` = `FibsemImageCanvas` + the `CorrelationPointOverlay` from #321, exposing the **same** four signals and the same `set_coordinates` / `set_selected` / `refresh_coordinate` / `set_image` / `update_display` / `set_pixel_size` / `reset_view` as the canvas it replaces. The eventual swap should be a construction-site change and nothing more.

## Why bother — contrast and gamma

`ImagePointCanvas` has never had either. On FM data they are exactly the controls an operator wants *while picking correlation points*, so this is a real gap rather than a tidiness argument. Zoom/pan, the scalebar and the toolbar come along with it.

A test asserts both that the new widget has it **and** that `ImagePointCanvas` genuinely lacks it, so it's proof of a gain rather than a rename.

## The add menu lives here

Per the decision recorded on FIB-535: the overlay emits `add_requested(x, y)` — it's a `QObject`, so it has no parent to hang a `QMenu` from — this widget asks which `PointType`, then emits `point_add_requested(x, y, pt)`, **the identical signal the tab widget already connects**. The `Coordinate` is still built by the caller, which owns the z.

Two smaller calls:

- **No menu stylesheet.** `QMenu` is styled app-wide in `napari_style`; `ImagePointCanvas` overriding it locally with hardcoded hexes is the anomaly, not the rule.
- **`allowed_point_types=[]` still means "adding is off".** Kept rather than improved, because `correlation_result_widget` relies on it and a silent re-enable would be a real regression. A test names that explicitly.

## Keeping the two from drifting

Building a replacement alongside the original has one specific failure mode: they diverge quietly and you find out at swap time. Three tests assert the APIs match by checking `ImagePointCanvas` too, rather than against a hardcoded list — so a rename on *either* side fails.

Mutation-checked so they aren't vacuous:

| deliberate break | caught by |
| --- | --- |
| `set_coordinates` → `set_coords` | 5 tests |
| `point_moved` signal renamed | 2, including the parity test |

## How to review it

There is nothing to click in the app yet, so this PR ships a side-by-side harness — old canvas left, new widget right, same synthetic image, same seed points, shared event log:

```
PYTHONPATH=$PWD python fibsem/ui/correlation/widgets/test_correlation_canvas_demo.py
```

Worth trying:

* **Right-click** either side → the add menu. Same types, same drop position.
* **Drag / click / Delete** a point. The log prints what each side emits; the payloads should match.
* **The contrast button on the right canvas only.** The image is deliberately low-contrast so it has something to do.
* **Scalebar, zoom, pan, fit-to-view** — right toolbar, also new.

Each side holds its own `Coordinate` objects. They're held by reference, so a shared list would let a drag on one canvas move the other and hide exactly the difference the harness exists to show.

The harness has no test functions, so pytest collects nothing from it.

## Testing

`1325 passed, 7 skipped` — `tests/correlation/`, `tests/ui/`, `tests/test_import_cycles.py`. 12 new tests. The new test module carries `pytest.importorskip("PyQt5")`, since CI installs `.[test]` without the UI extra.

## Next

`render_to_axes` equivalent, the reprojected-result overlay, then the actual swap of `_fib_canvas` plus its 15 test sites. `image_point_canvas.py` can only be deleted in the last PR of the series — it has three consumers.
