### PR TITLE
[ui] Legend and label control for the correlation canvas (FIB-535 partial)

### DIFF
--- a/fibsem/ui/correlation/widgets/correlation_canvas_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_canvas_widget.py
@@ -106,6 +106,17 @@ class CorrelationCanvasWidget(QWidget):
     def reset_view(self) -> None:
         self.canvas.reset_view()
 
+    # ── chrome ────────────────────────────────────────────────────────────
+
+    def set_legend_visible(self, visible: bool) -> None:
+        """Show or hide the point-type legend (one swatch per type on screen)."""
+        self.points.set_legend_visible(visible)
+
+    def set_labels_visible(self, visible: bool) -> None:
+        """Show or hide the per-point names. Independent of marker visibility --
+        a crowded image often wants the points without the text."""
+        self.points.set_labels_visible(visible)
+
     # ── add menu ──────────────────────────────────────────────────────────
 
     def _show_add_menu(self, x: float, y: float) -> None:

--- a/fibsem/ui/correlation/widgets/correlation_point_overlay.py
+++ b/fibsem/ui/correlation/widgets/correlation_point_overlay.py
@@ -86,6 +86,8 @@ class CorrelationPointOverlay(PointOverlay):
         super().__init__(size=MARKER_SIZE, parent=parent)
         self._coords: List[Coordinate] = []
         self._names: List[str] = []
+        self._legend_visible = True
+        self._labels_visible = True
         self.point_selected.connect(self._emit_selected)
         self.point_moved.connect(self._emit_moved)
         self.point_removed.connect(self._emit_removed)
@@ -103,7 +105,7 @@ class CorrelationPointOverlay(PointOverlay):
         self._coords.append(coord)
         self._names = generate_names(self._coords)
         idx = super().add_point(coord.point.x, coord.point.y)
-        self._refresh_labels()
+        self._refresh_chrome()
         return idx
 
     def remove_coordinate(self, coord: Coordinate) -> None:
@@ -156,7 +158,7 @@ class CorrelationPointOverlay(PointOverlay):
         super().remove_point(index)
         self._coords.pop(index)
         self._names = generate_names(self._coords)
-        self._refresh_labels()
+        self._refresh_chrome()
 
     def clear_points(self) -> None:
         super().clear_points()
@@ -190,6 +192,82 @@ class CorrelationPointOverlay(PointOverlay):
             return ("white" if selected else "none"), 2.0
         return color, (3.0 if selected else 2.0)
 
+    # ── legend and labels ─────────────────────────────────────────────────
+
+    def set_legend_visible(self, visible: bool) -> None:
+        self._legend_visible = visible
+        self._draw_legend()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def set_labels_visible(self, visible: bool) -> None:
+        """Show or hide the per-point names without discarding the points.
+
+        Separate from ``set_visible``, which hides the markers too: an operator
+        clearing labels off a crowded image still wants to see the points.
+        """
+        self._labels_visible = visible
+        self._apply_label_visibility()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def set_visible(self, visible: bool) -> None:
+        super().set_visible(visible)
+        # the base turns every annotation back on with the markers; labels the
+        # operator switched off should stay off
+        self._apply_label_visibility()
+
+    def _apply_label_visibility(self) -> None:
+        for ann in self._anns:
+            if ann is not None:
+                ann.set_visible(self._labels_visible and self._visible)
+
+    def _append_artist(self, idx: int) -> None:
+        super()._append_artist(idx)
+        # a point added while labels are off must not arrive with its name showing
+        if self._anns and self._anns[-1] is not None:
+            self._anns[-1].set_visible(self._labels_visible and self._visible)
+
+    def _legend_entries(self):
+        """One swatch per PointType currently on screen.
+
+        The base draws a single entry because its points are homogeneous. Here
+        they are not, and the colour is the only thing distinguishing a FIB point
+        from a POI — so the legend is what makes the display readable, not
+        decoration. Iterating ``PointType`` rather than the coordinates keeps the
+        order stable as points come and go.
+        """
+        from matplotlib.lines import Line2D
+
+        if not self._legend_visible:
+            return [], []
+        handles, labels = [], []
+        for pt in PointType:
+            if any(c.point_type is pt for c in self._coords):
+                handles.append(self._legend_handle(pt))
+                labels.append(pt.value)
+        return handles, labels
+
+    def _legend_handle(self, point_type: PointType) -> "Line2D":
+        """A proxy artist matching how the point is actually drawn — same rule as
+        `_marker_edge`, so an unfilled "+" keeps its colour instead of going white."""
+        from matplotlib.lines import Line2D
+
+        color = POINT_COLORS.get(point_type, "white")
+        marker = POINT_MARKERS.get(point_type, "o")
+        unfilled = marker not in Line2D.filled_markers
+        return Line2D(
+            [], [],
+            marker=marker,
+            markersize=7,
+            color=color,
+            markerfacecolor=color,
+            markeredgecolor=color if unfilled else "white",
+            markeredgewidth=1.5 if unfilled else 0.8,
+            linestyle="none",
+            label=point_type.value,
+        )
+
     # ── interaction ───────────────────────────────────────────────────────
 
     def _on_right_click(self, x: float, y: float) -> None:
@@ -214,6 +292,14 @@ class CorrelationPointOverlay(PointOverlay):
         if idx < len(self._coords):
             self.coordinate_removed.emit(self._coords[idx])
 
-    def _refresh_labels(self) -> None:
+    def _refresh_chrome(self) -> None:
+        """Re-derive the labels and the legend after the coordinate set changes.
+
+        ``set_points`` redraws both via ``_draw_all``, but ``add_point`` and
+        ``remove_point`` only touch one artist -- and both can change which
+        PointTypes are on screen, which is exactly what the legend reports.
+        """
         if self._anns:
             self._refresh_ann_text()
+        self._apply_label_visibility()
+        self._draw_legend()

--- a/fibsem/ui/correlation/widgets/test_correlation_canvas_demo.py
+++ b/fibsem/ui/correlation/widgets/test_correlation_canvas_demo.py
@@ -106,6 +106,21 @@ class DemoWindow(QMainWindow):
             btn = QPushButton(label)
             btn.clicked.connect(slot)
             controls.addWidget(btn)
+
+        # Toggled on both sides at once, so the legends and labels can be compared
+        # rather than just inspected one at a time.
+        for label, setter in (
+            ("Legend", "set_legend_visible"),
+            ("Labels", "set_labels_visible"),
+        ):
+            btn = QPushButton(label)
+            btn.setCheckable(True)
+            btn.setChecked(True)
+            btn.toggled.connect(
+                lambda on, s=setter, name=label: self._toggle_both(s, on, name)
+            )
+            controls.addWidget(btn)
+
         controls.addStretch()
         controls.addWidget(
             QLabel(
@@ -174,6 +189,11 @@ class DemoWindow(QMainWindow):
         self.old.set_coordinates([])
         self.new.set_coordinates([])
         self._log("cleared both")
+
+    def _toggle_both(self, setter: str, on: bool, name: str) -> None:
+        for surface in (self.old, self.new):
+            getattr(surface, setter)(on)
+        self._log(f"{name.lower()} {'shown' if on else 'hidden'} on both")
 
     def _added(self, side: str, x: float, y: float, pt: PointType) -> None:
         """Both canvases only *request* an add -- the tab widget builds the

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -404,32 +404,42 @@ class PointOverlay(QObject):
                 pass
             self._legend = None
 
-    def _draw_legend(self) -> None:
-        """Opt-in legend (top-left); the swatch is the overlay's own marker glyph
-        (e.g. a "+" for the POI), styled like the milling-stage legend."""
-        self._remove_legend()
-        if (
-            not self._legend_label
-            or self._ax is None
-            or not self._points
-            or not self._visible
-        ):
-            return
-        from matplotlib.legend import Legend
+    def _legend_entries(self):
+        """``(handles, labels)`` for the legend, or two empty lists for none.
+
+        One entry, drawn with the overlay's own glyph, because the base's points
+        all look alike. Split from :meth:`_draw_legend` so a subclass whose points
+        do *not* — correlation shows several PointTypes on one surface — can vary
+        the content without restating the styling.
+        """
         from matplotlib.lines import Line2D
 
+        if not self._legend_label:
+            return [], []
         handle = Line2D(
             [], [], linestyle="None", marker=self._marker, markersize=9,
             color=self._color,
             markeredgewidth=(self._edge_width if self._edge_width is not None else 2.0),
             label=self._legend_label,
         )
+        return [handle], [self._legend_label]
+
+    def _draw_legend(self) -> None:
+        """Opt-in legend (top-left), styled like the milling-stage legend."""
+        self._remove_legend()
+        if self._ax is None or not self._points or not self._visible:
+            return
+        handles, labels = self._legend_entries()
+        if not handles:
+            return
+        from matplotlib.legend import Legend
+
         # build the Legend directly (not ax.legend()) so it doesn't replace another
         # overlay's primary legend (e.g. the milling stages, top-right)
         leg = Legend(
             self._ax,
-            [handle],
-            [self._legend_label],
+            handles,
+            labels,
             loc="upper left",
             fontsize=8,
             facecolor=CANVAS_BG,

--- a/tests/correlation/test_correlation_canvas_widget.py
+++ b/tests/correlation/test_correlation_canvas_widget.py
@@ -53,7 +53,8 @@ def test_adapter_surface_matches_the_canvas_it_replaces():
 
 
 def test_image_methods_match_the_canvas_it_replaces():
-    for name in ("set_image", "update_display", "set_pixel_size", "reset_view"):
+    for name in ("set_image", "update_display", "set_pixel_size", "reset_view",
+                 "set_legend_visible", "set_labels_visible"):
         assert callable(getattr(CorrelationCanvasWidget, name, None)), name
         assert callable(getattr(ImagePointCanvas, name, None)), name
 
@@ -214,3 +215,22 @@ def test_contrast_and_gamma_are_available():
     assert w.canvas.btn_contrast is not None
     # and the old canvas genuinely lacks it -- this is a real gain, not a rename
     assert not hasattr(ImagePointCanvas, "toggle_contrast")
+
+
+# ── chrome delegates to the overlay ───────────────────────────────────────
+
+
+def test_legend_toggle_reaches_the_overlay():
+    w = _widget()
+    w.set_coordinates([_coord(10, 10), _coord(20, 20, PointType.POI)])
+    assert w.points._legend_entries()[1] == ["FIB", "POI"]
+    w.set_legend_visible(False)
+    assert w.points._legend_entries() == ([], [])
+
+
+def test_label_toggle_reaches_the_overlay_without_hiding_points():
+    w = _widget()
+    w.set_coordinates([_coord(10, 10)])
+    w.set_labels_visible(False)
+    assert [a.get_visible() for a in w.points._anns if a is not None] == [False]
+    assert all(a.get_visible() for a in w.points._artists)

--- a/tests/correlation/test_correlation_point_overlay.py
+++ b/tests/correlation/test_correlation_point_overlay.py
@@ -203,3 +203,113 @@ def test_clear_drops_both_lists():
     _, ov = _attached([_coord(10, 10), _coord(20, 20)])
     ov.clear_points()
     assert ov.coordinates() == [] and ov.get_points() == []
+
+
+# ── legend ────────────────────────────────────────────────────────────────
+
+
+def test_legend_shows_one_entry_per_type_on_screen():
+    """The base draws a single swatch; correlation's points are heterogeneous and
+    the colour is the only thing telling a FIB point from a POI."""
+    _, ov = _attached([
+        _coord(10, 10, PointType.FIB),
+        _coord(20, 20, PointType.POI),
+        _coord(30, 30, PointType.FIB),  # a second FIB must not add a second entry
+    ])
+    handles, labels = ov._legend_entries()
+    assert labels == ["FIB", "POI"]
+    assert len(handles) == 2
+
+
+def test_legend_order_is_the_type_order_not_arrival_order():
+    """Iterating PointType keeps the legend stable as points come and go."""
+    _, ov = _attached([_coord(10, 10, PointType.POI), _coord(20, 20, PointType.FIB)])
+    _, labels = ov._legend_entries()
+    assert labels == ["FIB", "POI"]  # declaration order, not [POI, FIB]
+
+
+def _drawn_legend(ov):
+    """Texts of the legend actually on the axes.
+
+    Deliberately not ``_legend_entries()``: that recomputes from _coords and would
+    pass even if the legend artist were never redrawn, which is the bug this test
+    exists to catch (add_point/remove_point touch one artist and would otherwise
+    leave a stale legend on screen).
+    """
+    return [] if ov._legend is None else [t.get_text() for t in ov._legend.get_texts()]
+
+
+def test_legend_follows_the_points():
+    a = _coord(10, 10, PointType.FIB)
+    b = _coord(20, 20, PointType.SURFACE)
+    _, ov = _attached([a, b])
+    assert _drawn_legend(ov) == ["FIB", "SURFACE"]
+
+    ov.remove_coordinate(b)
+    assert _drawn_legend(ov) == ["FIB"]
+
+    ov.add_coordinate(_coord(30, 30, PointType.POI))
+    assert _drawn_legend(ov) == ["FIB", "POI"]
+
+
+def test_legend_swatch_matches_how_the_point_is_drawn():
+    """An unfilled '+' keeps its own colour as the edge; a white edge would swallow
+    it and leave the legend claiming the wrong colour."""
+    _, ov = _attached([_coord(10, 10, PointType.SURFACE)])
+    handle = ov._legend_handle(PointType.SURFACE)
+    colour = POINT_COLORS[PointType.SURFACE]
+    assert handle.get_marker() == "+"
+    assert handle.get_markeredgecolor() == colour
+
+    filled = ov._legend_handle(PointType.FIB)
+    assert filled.get_marker() == "o"
+    assert filled.get_markeredgecolor() == "white"
+
+
+def test_legend_can_be_hidden():
+    _, ov = _attached([_coord(10, 10)])
+    ov.set_legend_visible(False)
+    assert ov._legend_entries() == ([], [])
+    assert ov._legend is None
+    ov.set_legend_visible(True)
+    assert ov._legend is not None
+
+
+# ── labels ────────────────────────────────────────────────────────────────
+
+
+def _label_states(ov):
+    return [a.get_visible() for a in ov._anns if a is not None]
+
+
+def test_labels_hide_without_hiding_the_points():
+    _, ov = _attached([_coord(10, 10), _coord(20, 20)])
+    ov.set_labels_visible(False)
+    assert _label_states(ov) == [False, False]
+    assert all(a.get_visible() for a in ov._artists)  # markers stay
+
+
+def test_a_point_added_while_labels_are_off_arrives_hidden():
+    _, ov = _attached([_coord(10, 10)])
+    ov.set_labels_visible(False)
+    ov.add_coordinate(_coord(20, 20))
+    assert _label_states(ov) == [False, False]
+
+
+def test_showing_the_overlay_does_not_override_the_label_preference():
+    """set_visible turns every annotation back on; a label the operator switched
+    off should stay off."""
+    _, ov = _attached([_coord(10, 10)])
+    ov.set_labels_visible(False)
+    ov.set_visible(False)
+    ov.set_visible(True)
+    assert _label_states(ov) == [False]
+
+
+def test_labels_renumber_and_stay_hidden_after_a_removal():
+    a, b, c = (_coord(0, 0), _coord(1, 1), _coord(2, 2))
+    _, ov = _attached([a, b, c])
+    ov.set_labels_visible(False)
+    ov.remove_coordinate(a)
+    assert [ov._point_label(i) for i in range(2)] == ["FIB 1", "FIB 2"]
+    assert _label_states(ov) == [False, False]


### PR DESCRIPTION
Third step of FIB-535, following #321 and #324. **Still inert** — the correlation tab constructs `ImagePointCanvas` and `FMImageDisplayWidget` exactly as before, and the only mentions of the new classes in production are two comments.

> Tagged `(FIB-535 partial)` on purpose. A bare tag in the subject auto-closes the issue on merge, which happened on both #321 and #324.

## The legend is load-bearing here

One surface shows several `PointType`s at once, and **colour is the only thing distinguishing a FIB point from a POI**. So the legend is what makes the display readable, not decoration — which is why it gets one swatch per type *actually on screen* rather than a fixed key.

Each swatch is built with the same rule as the marker it stands for: an unfilled `+` keeps its own colour as the edge, because a white one would swallow it and leave the legend claiming the wrong colour. Filled markers keep the thin white rim.

Entries iterate `PointType` rather than the coordinate list, so the order stays put as points come and go instead of following arrival order.

## Labels toggle independently of markers

A crowded image often wants the points without the text. Two cases that are easy to get wrong, both covered:

- a point added *while labels are off* must not arrive showing its name;
- the base's `set_visible` turns every annotation back on with the markers, and must not override a preference the operator set.

## One base change, behaviour-neutral

`PointOverlay._draw_legend` split into `_legend_entries()` (content) and `_draw_legend()` (styling):

```python
def _legend_entries(self):
    """(handles, labels), or two empty lists for none."""
```

Legend styling stays in one place for every overlay in the app, and a subclass whose points are *not* homogeneous supplies only the content. The early return moved from `not self._legend_label` to `not handles` — same condition, since the base returns empty lists in exactly that case.

Verified on its own before the subclass was touched: `1030 passed`.

## The mutation testing earned its keep

| mutation | result |
| --- | --- |
| legend iterates coords instead of `PointType` | caught |
| `set_visible` drops the label preference | caught |
| add/remove stop refreshing the legend | **not caught** ✗ |

That third one exposed a bad test. `test_legend_follows_the_points` called `_legend_entries()`, which recomputes from `_coords` — so it passed with the refresh deleted, testing the *calculation* while the legend on screen went stale. It now reads the texts off the drawn `Legend` artist:

```python
def _drawn_legend(ov):
    """Deliberately not _legend_entries(): that recomputes and would pass even if
    the legend artist were never redrawn, which is the bug this test exists to catch."""
    return [] if ov._legend is None else [t.get_text() for t in ov._legend.get_texts()]
```

The refresh itself is needed because `set_points` redraws the legend via `_draw_all`, but `add_point` and `remove_point` only touch one artist — and both can change which types are on screen.

## Testing

`1366 passed, 7 skipped` — `tests/correlation/`, `tests/ui/`, `tests/test_import_cycles.py`, and the base overlay legend test. 14 new tests.

## How to review it

```
PYTHONPATH=$PWD python fibsem/ui/correlation/widgets/test_correlation_canvas_demo.py
```

The harness gains **Legend** and **Labels** toggles that apply to *both* canvases at once, so the old and new can be compared rather than inspected one at a time. Add points of different types and watch the legend follow.

## Next

`render_to_axes` equivalent, the reprojected-result overlay, then the actual swap of `_fib_canvas` plus its 15 test sites.
