### PR TITLE
[ui] Load a saved overview onto the canvas (FIB-438)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -9,6 +9,7 @@ actions along the bottom.
 """
 
 import logging
+import os
 import threading
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
@@ -41,6 +42,7 @@ from fibsem.fm.structures import (
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import FibsemStagePosition
 from fibsem.ui import notification_service, stylesheets
+from fibsem.ui import utils as ui_utils
 from fibsem.ui.fm.widgets.fm_multi_channel_widget import FluorescenceMultiChannelWidget
 from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     FMOverviewConfirmationDialog,
@@ -60,6 +62,7 @@ from fibsem.ui.widgets.custom_widgets import (
     ContextMenu,
     ContextMenuConfig,
     ElidedLabel,
+    IconToolButton,
     TitledPanel,
 )
 from fibsem.ui.widgets.progress_widget import (
@@ -118,6 +121,12 @@ SLOT_COLOUR = "#90a4ae"
 # Wide enough for millimetre-scale coordinates without the row re-laying out as the
 # cursor moves -- a readout that shoves the buttons sideways is worse than none.
 CURSOR_READOUT_WIDTH = 210
+
+# Icon buttons in a `TitledPanel` header. Not smaller than this: `TOOLBUTTON_ICON_STYLESHEET`
+# pads 6px each side, so a 22px button leaves 10px of width for a 16px icon and clips it --
+# the frame's sides vanish and what is left reads as a rendering fault. Matches the size the
+# row buttons use.
+_HEADER_BTN_SIZE = 26
 
 
 @dataclass
@@ -373,7 +382,22 @@ class FMOverviewWidget(QWidget):
         self.overview_list = OverviewListWidget()
         self.overview_list.visibility_toggled.connect(self.set_overview_visible)
         self.overview_list.remove_requested.connect(self.remove_overview)
-        self._controls_layout.addWidget(self._section("Overviews", self.overview_list))
+        overviews_panel = self._section("Overviews", self.overview_list)
+        # In the panel header rather than under the list: loading acts on the section
+        # as a whole, not on any row in it, and a full-width button below the rows read
+        # as a fourth row. It also keeps the list widget free of the filesystem -- the
+        # button belongs to the section, which this widget builds.
+        # An image being added, rather than a folder being opened: the folder is where
+        # it came from, not what you end up with. Outline weight to match the eye and
+        # trash on the rows below it.
+        self.btn_load_overview = IconToolButton(
+            icon="mdi:image-plus-outline",
+            tooltip="Load a saved overview",
+            size=_HEADER_BTN_SIZE,
+        )
+        self.btn_load_overview.clicked.connect(self._prompt_for_overview)
+        overviews_panel.add_header_widget(self.btn_load_overview)
+        self._controls_layout.addWidget(overviews_panel)
         self._controls_layout.addWidget(self._section("Channels", self.channel_widget))
         self._controls_layout.addWidget(self.settings_widget)
         self._controls_layout.addStretch()
@@ -819,6 +843,63 @@ class FMOverviewWidget(QWidget):
     def overviews(self) -> List[PlacedOverviewImageRecord]:
         """Every overview on the canvas, oldest first."""
         return list(self._records.values())
+
+    def load_overview(self, path: str) -> Optional[PlacedOverviewImageRecord]:
+        """Place a saved overview from *path*. None if it could not be read.
+
+        Almost all of this is already done: `set_image` places an image by projecting
+        through the image's *own* recorded geometry, so that one acquired under a
+        configuration the instrument is no longer in lands where it was taken. A file
+        off disk is that case exactly, and everything the projection needs -- the
+        stage position's r and t, the hardware geometry, the pixel size -- survives the
+        OME-TIFF intact.
+
+        What does not survive is `stage_position.name`, which `stitch_tileset` uses to
+        carry the grid size. A loaded overview's row therefore shows its scale without
+        its grid. Accepted rather than worked around: the alternative is teaching the
+        OME serialization to carry a field only the list reads (FIB-438).
+
+        Separate from the dialog so it can be called with a path -- by a test, by a
+        host restoring a session, or later by whatever knows an experiment's own
+        overviews (FIB-547).
+        """
+        try:
+            image = FluorescenceImage.load(path)
+        except Exception as e:
+            logging.error(f"Could not load an overview from {path}: {e}")
+            notification_service.show_toast(f"Could not load that overview.\n{e}", "error")
+            return None
+
+        # Placed even without a geometry, but said out loud. `_offset_of` falls back to
+        # the origin, which puts it in the middle of the view rather than where it was
+        # taken -- and an overview silently in the wrong place is worse than one you
+        # have been told to distrust. Anything acquired before FIB-416 is this case.
+        if FMStageProjection.from_image(image) is None:
+            logging.warning(f"Overview {path} has no recorded geometry; placing at the origin.")
+            notification_service.show_toast(
+                "That overview has no recorded geometry, so it cannot be placed where "
+                "it was taken. Showing it at the canvas origin.",
+                "warning",
+            )
+
+        self.set_image(image)
+        record = self._record_for(image)
+        logging.info(f"Loaded overview {record.label} from {path}")
+        return record
+
+    def _prompt_for_overview(self) -> None:
+        """Ask for a file and load it. The dialog half of `load_overview`."""
+        path = ui_utils.open_existing_file_dialog(
+            msg="Select an overview to load",
+            # Where this tab writes them, when a host has said. Opening at the last
+            # place anything was saved beats opening at the home directory.
+            path=self._save_directory or os.getcwd(),
+            _filter="Fluorescence images (*.ome.tiff *.ome.tif *.tiff *.tif)",
+            parent=self,
+        )
+        if not path:
+            return
+        self.load_overview(path)
 
     def set_overview_visible(self, record_id: str, visible: bool) -> bool:
         """Show or hide one overview. False if there is no such record.

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -4186,3 +4186,170 @@ def test_the_list_does_not_grow_a_row_for_the_live_preview(qapp, blank_canvas):
     qapp.processEvents()
 
     assert widget.overview_list._list.count() == 0
+
+
+# ── loading a saved overview (FIB-438) ───────────────────────────────────
+
+
+def _saved(widget, tmp_path, date="2026-08-07T09:00:00", name="overview-14-02-33"):
+    """An overview written to disk the way an acquisition writes one."""
+    image = _acquire(widget, date)
+    image.metadata.description = name  # what OverviewDestination.save_mosaic stamps
+    path = str(tmp_path / f"{name}.ome.tiff")
+    image.save(path)
+    return image, path
+
+
+def test_a_loaded_overview_lands_where_the_acquired_one_did(qapp, blank_canvas, tmp_path):
+    """The claim the whole feature rests on. `set_image` places by projecting through
+    the image's *own* recorded geometry, and everything that projection needs -- the
+    stage position's r and t, the hardware geometry, the pixel size -- survives the
+    OME-TIFF. So a file off disk is placed identically to the image it came from."""
+    widget = blank_canvas
+    image, path = _saved(widget, tmp_path)
+
+    widget.set_image(image)
+    qapp.processEvents()
+    acquired_extent = widget.canvas.canvas._placed[widget.overviews()[0].id].extent
+
+    widget.canvas.clear_overviews()
+    widget._records.clear()
+    widget.load_overview(path)
+    qapp.processEvents()
+    loaded_extent = widget.canvas.canvas._placed[widget.overviews()[0].id].extent
+
+    assert loaded_extent == pytest.approx(acquired_extent)
+
+
+def test_loading_gives_the_overview_a_record_and_a_row(qapp, blank_canvas, tmp_path):
+    widget = blank_canvas
+    _, path = _saved(widget, tmp_path)
+
+    record = widget.load_overview(path)
+    qapp.processEvents()
+
+    assert record is not None
+    assert widget.overviews() == [record]
+    assert widget.overview_list._list.count() == 1
+
+
+def test_a_loaded_overview_is_named_for_the_run_that_made_it(qapp, blank_canvas, tmp_path):
+    """`description` survives the round trip, so the row still names the folder the
+    tiles are in rather than falling back to a number."""
+    widget = blank_canvas
+    _, path = _saved(widget, tmp_path, name="overview-11-20-05")
+
+    record = widget.load_overview(path)
+
+    assert record.label == "overview-11-20-05"
+
+
+def test_a_loaded_overview_keeps_its_scale_but_loses_its_grid(qapp, blank_canvas, tmp_path):
+    """Documented, not a bug. `stitch_tileset` carries the grid in
+    `stage_position.name`, which the OME-TIFF drops -- so a loaded row shows what it
+    still knows rather than guessing (FIB-438)."""
+    widget = blank_canvas
+    image, path = _saved(widget, tmp_path)
+    image.metadata.stage_position.name = "stitched_mosaic_3x3"
+    image.save(path)
+
+    record = widget.load_overview(path)
+
+    assert "µm/px" in record.detail
+    assert "×" not in record.detail, "the grid came back after all -- update the docs"
+
+
+def test_a_file_that_cannot_be_read_places_nothing(qapp, blank_canvas, tmp_path):
+    """Reported, not raised: a bad file is a thing a user picked, not a bug in the tab."""
+    widget = blank_canvas
+    bad = tmp_path / "not-an-image.ome.tiff"
+    bad.write_text("this is not a tiff")
+
+    assert widget.load_overview(str(bad)) is None
+    assert widget.overviews() == []
+
+
+def test_an_overview_with_no_geometry_is_shown_but_not_trusted(
+    qapp, blank_canvas, tmp_path, monkeypatch
+):
+    """Anything acquired before FIB-416 has no geometry, so it cannot be placed where
+    it was taken -- it lands at the canvas origin instead. The pixels are still worth
+    seeing, so it is shown; being shown *silently* in the wrong place is the part that
+    would mislead, so it is also said."""
+    widget = blank_canvas
+    image, path = _saved(widget, tmp_path)
+    image.metadata.geometry = None
+    image.save(path)
+    toasts = []
+    monkeypatch.setattr(
+        "fibsem.ui.fm.widgets.fm_overview_widget.notification_service.show_toast",
+        lambda message, level="info", *a, **k: toasts.append((message, level)),
+    )
+
+    record = widget.load_overview(path)
+    qapp.processEvents()
+
+    assert record is not None
+    assert record.id in widget.canvas.canvas.placed_keys
+    assert any(level == "warning" for _, level in toasts), "placed with no warning"
+
+
+def test_loading_the_same_file_twice_does_not_stack_two_copies(qapp, blank_canvas, tmp_path):
+    """The acquisition date survives the round trip, so the record match still holds
+    across a reload."""
+    widget = blank_canvas
+    _, path = _saved(widget, tmp_path)
+
+    widget.load_overview(path)
+    widget.load_overview(path)
+    qapp.processEvents()
+
+    assert len(widget.overviews()) == 1
+
+
+def test_a_loaded_overview_can_anchor_an_empty_canvas(qapp, blank_canvas, tmp_path):
+    """First image placed fixes the origin, loaded or acquired. Everything is drawn
+    relative to it, so which one it is only decides where canvas zero sits."""
+    widget = blank_canvas
+    widget._origin = None
+    _, path = _saved(widget, tmp_path)
+
+    widget.load_overview(path)
+
+    assert widget._origin is not None
+
+
+def test_the_header_button_opens_a_file_dialog(qapp, blank_canvas, monkeypatch):
+    """The real wiring, clicked for real.
+
+    Safe because the dialog itself is stubbed: it is modal, so a genuine one would
+    hang the run waiting for a human -- which it did, when this test clicked through
+    to the real thing.
+    """
+    widget = blank_canvas
+    asked = []
+    monkeypatch.setattr(
+        "fibsem.ui.fm.widgets.fm_overview_widget.ui_utils.open_existing_file_dialog",
+        lambda **kwargs: asked.append(kwargs) or "",
+    )
+
+    widget.btn_load_overview.click()
+
+    assert len(asked) == 1
+    assert "ome.tiff" in asked[0]["_filter"], "the dialog does not offer overviews"
+
+
+def test_picking_no_file_places_nothing(qapp, blank_canvas, monkeypatch):
+    """Cancelling the dialog is not an error, and must not reach the loader."""
+    widget = blank_canvas
+    monkeypatch.setattr(
+        "fibsem.ui.fm.widgets.fm_overview_widget.ui_utils.open_existing_file_dialog",
+        lambda **kwargs: "",
+    )
+    loaded = []
+    monkeypatch.setattr(widget, "load_overview", lambda path: loaded.append(path))
+
+    widget.btn_load_overview.click()
+
+    assert loaded == []
+    assert widget.overviews() == []


### PR DESCRIPTION
Closes [FIB-438](https://linear.app/fibsemos/issue/FIB-438/load-a-saved-overview-into-the-fm-overview-tab). The tab could only show an overview it had acquired this session, so reopening AutoLamella meant re-acquiring — twenty minutes of stage time to look at something already on disk.

## Almost none of this is new work

`set_image` already places an image by projecting through the image's **own** recorded geometry, precisely so one acquired under a configuration the instrument is no longer in lands where it was taken. [FIB-543](https://linear.app/fibsemos/issue/FIB-543/track-each-placed-overview-as-a-record-and-list-them-in-the-settings) then gave every placed overview a record. A file off disk is that case exactly, so loading is `FluorescenceImage.load` handed to machinery that already existed — 70 production lines.

## Measured before relying on it

Round-tripped through the OME-TIFF with real non-zero values, not the all-zero defaults that would have proved nothing. Everything placement needs survives exactly:

| | |
|---|---|
| `stage_position` x/y/z/**r**/**t**/`coordinate_system` | exact |
| `geometry` — `FibsemHardwareGeometry`, incl. `camera_tilt` and `transform` | exact |
| `pixel_size_x`, `acquisition_date`, `description`, channels, `objective_position` | exact |

`r` and `t` matter most: they're what the projection turns, and a compustage flip lives in them.

**One field doesn't survive.** `stage_position.name` comes back `None`, and `stitch_tileset` uses it to carry the grid size — so a loaded overview's row shows its scale without its grid. Accepted rather than worked around: persisting it means teaching the OME serialization to carry a field only the list reads. A test asserts the degradation, so it'll say so if that ever changes.

## Behaviour

- **No geometry recorded** → still shown, at the canvas origin, and said out loud. Anything acquired before [FIB-416](https://linear.app/fibsemos/issue/FIB-416/acquired-fm-tiles-lose-their-geometry-and-the-stitched-mosaic-inherits) is that case, and being drawn *silently* in the wrong place is what would mislead — the pixels are still worth seeing.
- **Unreadable file** → reported, not raised. A bad file is something a user picked, not a bug in the tab.
- **First image placed anchors the origin**, loaded or acquired.
- `load_overview(path)` is separate from the dialog so it can be called with a path — by a test, or later by whatever knows an experiment's own overviews ([FIB-547](https://linear.app/fibsemos/issue/FIB-547/track-an-experiments-acquired-overviews-instead-of-globbing-its), split out because globbing for `*.ome.tiff` can't tell an overview from any other fluorescence image saved beside it).

The button is `mdi:image-plus-outline` in the section header rather than under the list: loading acts on the section, not on any row in it, and a full-width button below the rows read as a fourth row. That also keeps `OverviewListWidget` free of the filesystem — **it ends up unchanged**, having briefly grown a button and a signal it didn't need.

## Testing

372 pass across the overview widget, the list widget, all three canvas suites and the tile-grid overlay. The strongest test saves an image, places the original, clears, loads the file, and asserts the two extents match — the round-trip claim proved end to end rather than field by field.

Four mutations caught by the test written for each: loading without placing, dropping the no-geometry warning, building the button without connecting it, and ignoring the dialog's empty result.

**Two test problems worth flagging**, both mine rather than the code's:

- One test **hung the suite for six minutes**. Clicking the load button runs the real handler, which opens a modal `QFileDialog` and waits for a human. The dialog helper is stubbed now — which is better than the workaround it first replaced, since the button, the connection and the file filter are all exercised for real rather than bypassed.
- The no-geometry test only checked the image was *placed*, not that anything warned — which was the entire point of that branch. It spies on the toast now, and removing the warning fails it.