### PR TITLE
[ui] Cut the AutoLamella Microscope tab over to the quad view (FIB-406, phase 4b)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -14,6 +14,7 @@ import warnings
 
 import napari
 from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtGui import QKeySequence
 from PyQt5.QtWidgets import (
     QAction,
     QApplication,
@@ -72,6 +73,8 @@ from fibsem.ui.widgets.autolamella_task_config_editor import (
 )
 from fibsem.ui.widgets.lamella_card_widget import LamellaCardContainer
 from fibsem.ui.widgets.lamella_task_image_widget import LamellaTaskImageWidget
+from fibsem.structures import BeamType
+from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
 from fibsem.ui.widgets.lamella_workflow_widget import LamellaWorkflowWidget
 from fibsem.ui.widgets.notifications import NotificationBell, ToastManager
 from fibsem.ui.widgets.workflow_timeline_widget import WorkflowProgressWidget
@@ -330,13 +333,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         layer_controls_menu = view_menu.addMenu("Show Layer Controls")
 
-        self.action_layer_controls_microscope = QAction("Microscope", self)
-        self.action_layer_controls_microscope.setCheckable(True)
-        self.action_layer_controls_microscope.setChecked(True)
-        self.action_layer_controls_microscope.triggered.connect(
-            lambda checked: self._on_toggle_viewer_layer_controls(checked, "microscope")
-        )
-
         self.action_layer_controls_overview = QAction("Overview", self)
         self.action_layer_controls_overview.setCheckable(True)
         self.action_layer_controls_overview.setChecked(True)
@@ -344,13 +340,66 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             lambda checked: self._on_toggle_viewer_layer_controls(checked, "overview")
         )
 
-        # No "Lamella Editor" entry: that tab renders on the matplotlib canvas now and
-        # has no napari layer docks to show. The submenu goes entirely once the last
-        # napari viewer does.
-        layer_controls_menu.addAction(self.action_layer_controls_microscope)
+        # Overview is the only entry left: the Lamella Editor and now the Microscope tab
+        # both render on the matplotlib canvas and have no napari layer docks to show.
+        # The submenu goes entirely when the minimap migrates (FIB-405).
         layer_controls_menu.addAction(self.action_layer_controls_overview)
 
         view_menu.addAction(self.action_show_minimap)
+
+        # Quad-view display controls. The F5/Esc shortcuts live on these QActions — one
+        # source of truth for the menu item and its keybinding (Qt renders the shortcut
+        # text in the menu automatically). They are scoped to the Microscope tab via
+        # setShortcutContext + container.addAction (see _create_main_tab), so they only
+        # fire when focus is inside that tab.
+        view_menu.addSeparator()
+        self.action_toggle_fullscreen = QAction("Full Screen", self)
+        self.action_toggle_fullscreen.setCheckable(True)
+        self.action_toggle_fullscreen.setShortcut(QKeySequence(Qt.Key_F5))
+        self.action_toggle_fullscreen.setShortcutContext(Qt.WidgetWithChildrenShortcut)
+        self.action_toggle_fullscreen.triggered.connect(self._hotkey_toggle_fullscreen)
+        view_menu.addAction(self.action_toggle_fullscreen)
+
+        self.action_exit_fullscreen = QAction("Exit Full Screen", self)
+        self.action_exit_fullscreen.setShortcut(QKeySequence(Qt.Key_Escape))
+        self.action_exit_fullscreen.setShortcutContext(Qt.WidgetWithChildrenShortcut)
+        self.action_exit_fullscreen.triggered.connect(self._hotkey_exit_fullscreen)
+        view_menu.addAction(self.action_exit_fullscreen)
+
+        fullscreen_menu = view_menu.addMenu("Full Screen View")
+        for label, key in (
+            ("SEM", BeamType.ELECTRON),
+            ("FIB", BeamType.ION),
+            ("Fluorescence", "fm"),
+        ):
+            act = QAction(label, self)
+            act.triggered.connect(
+                lambda _checked=False, k=key: self.view_controller.set_fullscreen(k)
+            )
+            fullscreen_menu.addAction(act)
+
+        # keep the checkable / enabled state honest each time the menu opens
+        view_menu.aboutToShow.connect(self._sync_view_menu)
+
+        # Imaging hotkeys (Microscope tab; scoped via container.addAction). Live / auto
+        # contrast / auto focus act on the selected beam — the view <-> radio sync keeps
+        # dual_beam_widget.beam_type aligned with the selected view.
+        imaging_menu = menu_bar.addMenu("Imaging")
+        if imaging_menu is None:
+            raise RuntimeError("Failed to create Imaging menu in AutoLamella UI.")
+        self._imaging_actions: list = []  # added to the Microscope-tab container for scoping
+        for label, key, handler in (
+            ("Acquire", Qt.Key_F2, self._hotkey_acquire),
+            ("Live Acquisition", Qt.Key_F6, self._hotkey_toggle_live),
+            ("Auto Contrast", Qt.Key_F9, self._hotkey_autocontrast),
+            ("Auto Focus", Qt.Key_F11, self._hotkey_autofocus),
+        ):
+            action = QAction(label, self)
+            action.setShortcut(QKeySequence(key))
+            action.setShortcutContext(Qt.WidgetWithChildrenShortcut)
+            action.triggered.connect(handler)
+            imaging_menu.addAction(action)
+            self._imaging_actions.append(action)
 
         # add tools menu, reporting submenu
         tools_menu = menu_bar.addMenu("Tools")
@@ -720,6 +769,84 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.autolamella_ui.minimap_plot_dock.setVisible(checked)
             self.autolamella_ui.minimap_plot_dock.activateWindow()
 
+    def _sync_view_menu(self) -> None:
+        """Refresh the View menu's dynamic state right before it opens: reflect whether a
+        view is full-screened (check + Exit-enabled)."""
+        if getattr(self, "view_controller", None) is None:
+            return
+        fullscreen = self.view_controller.fullscreen is not None
+        self.action_toggle_fullscreen.setChecked(fullscreen)
+        self.action_exit_fullscreen.setEnabled(fullscreen)
+
+    def _hotkey_toggle_fullscreen(self) -> None:
+        """F5: toggle full screen for the selected view."""
+        self.view_controller.toggle_fullscreen()
+
+    def _hotkey_exit_fullscreen(self) -> None:
+        """Esc: exit full screen (no-op when already showing the grid)."""
+        self.view_controller.set_fullscreen(None)
+
+    def _hotkey_acquire(self) -> None:
+        """F2: acquire the selected view (SEM / FIB / FM), if a microscope is connected
+        and an acquisition isn't already running."""
+        view = self.view_controller.selected_view
+        ui = self.autolamella_ui
+        if view in (BeamType.ELECTRON, BeamType.ION):
+            image_widget = getattr(ui, "image_widget", None)
+            if image_widget is None:
+                logging.info("F2 acquire: no image widget (microscope not connected)")
+                return
+            if getattr(image_widget, "is_acquiring", False):
+                logging.info("F2 acquire: acquisition already in progress")
+                return
+            if view is BeamType.ELECTRON:
+                image_widget.acquire_sem_image()
+            else:
+                image_widget.acquire_fib_image()
+        elif view == "fm":
+            fm_widget = getattr(ui, "fm_control_widget", None)
+            if fm_widget is None:
+                logging.info("F2 acquire: no fluorescence widget")
+                return
+            # `is_acquisition_active`, not `is_acquiring` — the latter does not exist on
+            # this widget, so a getattr default of False would make the guard inert and
+            # let F2 start a second FM acquisition mid-run (cf. FIB-441 / FIB-436).
+            if fm_widget.is_acquisition_active:
+                logging.info("F2 acquire: fluorescence acquisition already in progress")
+                return
+            fm_widget.acquire_image()
+
+    def _selected_em_image_widget(self):
+        """The image widget when a SEM/FIB view is selected, else None (FM / not
+        connected). Backs the EM-only imaging hotkeys (live / auto contrast / auto focus)."""
+        if self.view_controller.selected_view not in (BeamType.ELECTRON, BeamType.ION):
+            return None
+        return getattr(self.autolamella_ui, "image_widget", None)
+
+    def _hotkey_toggle_live(self) -> None:
+        """F6: toggle live acquisition on the selected SEM/FIB beam."""
+        image_widget = self._selected_em_image_widget()
+        if image_widget is None:
+            logging.info("F6 live: only SEM/FIB support live acquisition")
+            return
+        image_widget.toggle_live_acquisition()
+
+    def _hotkey_autocontrast(self) -> None:
+        """F9: auto-contrast the selected SEM/FIB beam."""
+        image_widget = self._selected_em_image_widget()
+        if image_widget is None:
+            logging.info("F9 autocontrast: only SEM/FIB supported")
+            return
+        image_widget.run_autocontrast()
+
+    def _hotkey_autofocus(self) -> None:
+        """F11: auto-focus the selected SEM/FIB beam."""
+        image_widget = self._selected_em_image_widget()
+        if image_widget is None:
+            logging.info("F11 autofocus: only SEM/FIB supported")
+            return
+        image_widget.run_autofocus()
+
     def _on_toggle_viewer_layer_controls(self, checked: bool, viewer_key: str):
         """Toggle the layer list and layer controls for a specific viewer.
 
@@ -730,7 +857,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         under PyQt5 (FIB-329).
         """
         viewer_map = {
-            "microscope": getattr(self, "main_viewer", None),
             "overview": getattr(self, "minimap_viewer", None),
         }
         viewer = viewer_map.get(viewer_key)
@@ -1197,14 +1323,12 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         layout = QVBoxLayout(container)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        # Create napari viewer for main UI
-        self.main_viewer = napari.Viewer(show=False, title="AutoLamella Main")
-        self.main_viewer.window._qt_window.menuBar().hide()
-        self.main_viewer.window._qt_window.statusBar().hide()
-        self.viewers.append(self.main_viewer)
+        # Viewer-less: the quad-view controller is the display, so no napari viewer is
+        # created here. (The minimap keeps its own until FIB-405.)
+        self.main_viewer = None
 
         # Create the AutoLamellaUI widget
-        self.autolamella_ui = AutoLamellaUI(viewer=self.main_viewer, parent_ui=self)
+        self.autolamella_ui = AutoLamellaUI(viewer=None, parent_ui=self)
 
         # Connect to workflow update signal from AutoLamellaUI
         self.autolamella_ui.workflow_update_signal.connect(self._on_workflow_update)
@@ -1230,11 +1354,14 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.autolamella_ui.menuBar().setVisible(False)
         self.autolamella_ui.setMinimumWidth(550)
 
-        # Layout: napari viewer (left) | autolamella controls (right) via splitter
+        # Layout: quad view (left) | autolamella controls (right) via splitter.
+        # The controller's SEM/FIB/FM canvases are the display and drive the control
+        # widgets, which resolve it through parent -> parent_widget -> view_controller.
         splitter = QSplitter(Qt.Horizontal)
         splitter.setChildrenCollapsible(False)
 
-        splitter.addWidget(self.main_viewer.window._qt_window)
+        self.view_controller = MicroscopeViewController(parent=self)
+        splitter.addWidget(self.view_controller.widget)
         splitter.addWidget(self.autolamella_ui)
 
         splitter.setSizes([700, 550])
@@ -1246,6 +1373,17 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             fibsem_icon("mdi:microscope", color=GRAY_ICON_COLOR),
             "Microscope",
         )
+        # The F5/Esc (View) and F2/F6/F9/F11 (Imaging) shortcuts are defined on QActions —
+        # one source of truth for the menu item and its keybinding. Adding those actions to
+        # the Microscope-tab container makes their WidgetWithChildrenShortcut scope resolve
+        # against this tab, so the keys only fire when focus is inside it (not the minimap,
+        # editor or workflow tabs).
+        for action in (
+            self.action_toggle_fullscreen,
+            self.action_exit_fullscreen,
+            *self._imaging_actions,
+        ):
+            container.addAction(action)
 
     def create_tabs(self):
         """Create the tabs for the AutoLamella UI."""

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -13,7 +13,6 @@ import os
 import threading
 from copy import deepcopy
 from typing import List, Optional, TYPE_CHECKING
-import numpy as np
 import napari
 from fibsem import conversions
 from fibsem.constants import METRE_TO_MICRON, MICRON_TO_METRE
@@ -42,7 +41,7 @@ from fibsem.ui.FMAcquisitionWidget import open_fm_acquisition_dialog
 from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.fm.widgets import FMImageViewerWidget
 from fibsem.ui import utils as fui
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QGridLayout,
     QLabel,
@@ -55,6 +54,7 @@ from PyQt5.QtWidgets import (
     QTabWidget,
     QWidget,
 )
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.widgets.custom_widgets import LamellaNameListWidget
 from fibsem.ui.widgets.selected_lamella_widget import SelectedLamellaWidget
 
@@ -180,10 +180,8 @@ class AutoLamellaUI(QMainWindow):
 
         self._protocol_lock = threading.RLock()
 
+        # The main tab runs viewer-less; display is via the controller.
         self.viewer = viewer
-
-        # add placeholder layer
-        self.viewer.add_image(np.zeros((10, 10)), name="Placeholder", visible=False)
 
         self.experiment: Optional[Experiment] = None
         self.microscope: Optional[FibsemMicroscope] = None
@@ -198,16 +196,12 @@ class AutoLamellaUI(QMainWindow):
         self.milling_task_config_widget: Optional[MillingTaskViewerWidget] = None
         self.det_widget: Optional["FibsemEmbeddedDetectionWidget"] = None
 
-        # minimap plot widget
+        # minimap plot widget — a floating tool window, shown on demand (was a
+        # napari dock; relocated here so it no longer needs a viewer).
         self.minimap_plot_widget = MinimapPlotWidget(self)
-        self.minimap_plot_dock = self.viewer.window.add_dock_widget(
-            self.minimap_plot_widget,
-            name="Minimap Plot",
-            area="left",
-            add_vertical_stretch=False,
-            tabify=True,
-        )
-        self.minimap_plot_dock.setVisible(False)
+        self.minimap_plot_widget.setWindowFlags(Qt.Tool)
+        self.minimap_plot_widget.setWindowTitle("Minimap Plot")
+        self.minimap_plot_widget.hide()
 
         # add widgets to tabs
         self.tabWidget.insertTab(0, self.system_widget, "Connection")
@@ -620,10 +614,14 @@ class AutoLamellaUI(QMainWindow):
 
             # remove tabs
             if self.fm_control_widget is not None:
+                # deleteLater fires neither closeEvent nor close_widget, so tear
+                # down the FM widget's external signal connections explicitly
+                self.fm_control_widget._teardown_connections()
                 self.tabWidget.removeTab(self.tabWidget.indexOf(self.fm_control_widget))
                 self.fm_control_widget.deleteLater()
                 self.fm_control_widget = None
             if self.det_widget is not None:
+                self.det_widget._teardown_connections()
                 self.tabWidget.removeTab(self.tabWidget.indexOf(self.det_widget))
                 self.det_widget.deleteLater()
                 self.det_widget = None
@@ -639,12 +637,13 @@ class AutoLamellaUI(QMainWindow):
                 self.milling_task_config_widget.deleteLater()
                 self.milling_task_config_widget = None
             if self.movement_widget is not None:
+                self.movement_widget._teardown_connections()
                 self.tabWidget.removeTab(self.tabWidget.indexOf(self.movement_widget))
                 self.movement_widget.deleteLater()
                 self.movement_widget = None
             if self.image_widget is not None:
+                self.image_widget._teardown_connections()
                 self.tabWidget.removeTab(self.tabWidget.indexOf(self.image_widget))
-                self.image_widget.clear_viewer()
                 self.image_widget.acquisition_progress_signal.disconnect(
                     self.handle_acquisition_update
                 )
@@ -1805,9 +1804,6 @@ class AutoLamellaUI(QMainWindow):
             self.microscope.turn_off(BeamType.ELECTRON)
             self.microscope.turn_off(BeamType.ION)
 
-        # set electron image as active layer
-        self.image_widget.restore_active_layer_for_movement()
-
         self.set_current_workflow_message(msg=None, show=False)
 
         # show the post-workflow summary of tasks run this session
@@ -1879,6 +1875,9 @@ class AutoLamellaUI(QMainWindow):
         if isinstance(alignment_area, FibsemRectangle):
             self.image_widget.toggle_alignment_area(alignment_area)
         if alignment_area == "clear":
+            # `clear` here means hide-but-keep: update_alignment_area_ui reads
+            # get_alignment_area() straight after, so the rect has to survive.
+            # (#111 renamed this to hide_alignment_area; 4a kept main's name.)
             self.image_widget.clear_alignment_area()
 
         # POI selection
@@ -1895,9 +1894,9 @@ class AutoLamellaUI(QMainWindow):
             if self.spot_burn_widget is not None:
                 # hide the widget's own Burn button; the burn is run from the workflow control
                 self.spot_burn_widget.set_workflow_mode(True)
-        spot_burn_parameters = info.get("spot_burn_parameters", None)
-        if spot_burn_parameters is not None and self.spot_burn_widget is not None:
-            self.spot_burn_widget.update_parameters(spot_burn_parameters)
+        spot_burn_settings = info.get("spot_burn_settings", None)
+        if spot_burn_settings is not None and self.spot_burn_widget is not None:
+            self.spot_burn_widget.set_settings(spot_burn_settings)
         if info.get("clear_spot_burn", False) and self.spot_burn_widget is not None:
             self.spot_burn_widget.clear_points_layer()
             self.spot_burn_widget.set_workflow_mode(False)
@@ -1927,51 +1926,49 @@ class AutoLamellaUI(QMainWindow):
     _POI_LAYER_NAME = "Point of Interest"
 
     def _show_poi_selection_layer(self, initial_poi: Optional[Point] = None) -> None:
-        """Add a draggable point marker on the FIB image for POI selection.
+        """Show a draggable POI marker on the FIB canvas (via the controller)."""
+        controller = getattr(self.parent_widget, "view_controller", None)
+        if controller is not None:
+            self._show_poi_overlay(controller, initial_poi)
 
-        Positions the marker at initial_poi (milling coords) if provided, otherwise image center.
-        """
-        ib_translate = self.image_widget.ib_layer.translate
+    def _show_poi_overlay(self, controller, initial_poi: Optional[Point]) -> None:
+        """Quad-view POI: a magenta '+' point on the FIB canvas (move-only), via the reducer."""
+        from fibsem.ui.widgets.canvas.canvas_state import PointsSpec
+
         ib_image = self.image_widget.ib_image
         if initial_poi is not None:
             px = conversions.microscope_image_to_image_coordinates(
                 initial_poi, ib_image.data.shape, ib_image.metadata.pixel_size.x
             )
-            row = ib_translate[0] + px.y
-            col = ib_translate[1] + px.x
+            col, row = px.x, px.y
         else:
-            row = ib_translate[0] + ib_image.data.shape[0] / 2
-            col = ib_translate[1] + ib_image.data.shape[1] / 2
-        data = [[row, col]]
-        from fibsem.ui.napari.utilities import add_points_layer
-
-        self._poi_layer = add_points_layer(
-            viewer=self.viewer,
-            data=data,
-            name=self._POI_LAYER_NAME,
-            size=20,
-            face_color="magenta",
-            border_color="white",
-            symbol="cross",
-            blending="additive",
-            border_width=None,
-            border_width_is_relative=False,
+            row = ib_image.data.shape[0] / 2
+            col = ib_image.data.shape[1] / 2
+        controller.set_overlay(
+            BeamType.ION,
+            PointsSpec(
+                id="poi", points=[(col, row)],
+                color="magenta", selected_color="magenta", marker="+", size=18,
+                add_on_right_click=False, removable=False,
+            ),
         )
-        self._poi_layer.mode = "select"
-        self.viewer.layers.selection.active = self._poi_layer
+        # POI owns FIB-canvas input: stage-move + milling menu stand down. The toolbar
+        # toggle lets the user drop to Move and back. (See active-overlay model.)
+        controller.arm_overlay(BeamType.ION, "poi", label="POI", icon="mdi:map-marker")
+        controller.fib_canvas.set_hint("drag to move")
 
     def _compute_and_clear_poi_layer(self) -> None:
-        """Compute POI from current layer position, remove the layer, store in SELECTED_POI."""
-        if self._poi_layer is not None and self._POI_LAYER_NAME in self.viewer.layers:
-            pos = self._poi_layer.data[0]  # [row, col] napari coords
-            ib_translate = self.image_widget.ib_layer.translate
-            py = pos[0] - ib_translate[0]  # pixel y in IB image
-            px = pos[1] - ib_translate[1]  # pixel x in IB image
+        """Compute POI from the current marker position, clear it, store in SELECTED_POI."""
+        controller = getattr(self.parent_widget, "view_controller", None)
+        if controller is None:
+            return
+        pts = controller.overlay_points(BeamType.ION, "poi")
+        if pts:
+            col, row = pts[0]
             ib_image = self.image_widget.ib_image
             self.SELECTED_POI = conversions.image_to_microscope_image_coordinates(
-                Point(x=px, y=py),
-                ib_image.data,
-                ib_image.metadata.pixel_size.x,
+                Point(x=col, y=row), ib_image.data, ib_image.metadata.pixel_size.x
             )
-            self.viewer.layers.remove(self._poi_layer)
-            self._poi_layer = None
+        controller.arm_overlay(BeamType.ION, None)  # restore Move
+        controller.remove_overlay(BeamType.ION, "poi")
+        controller.fib_canvas.set_hint(None)

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -210,7 +210,6 @@ class AutoLamellaUI(QMainWindow):
         self.USER_RESPONSE: bool = False
         self.WAITING_FOR_UI_UPDATE: bool = False
         self.SELECTED_POI: Optional[Point] = None
-        self._poi_layer = None
         self._workflow_stop_event: threading.Event = threading.Event()
         self._task_worker_thread: Optional[FunctionWorker] = None
         self._task_manager: Optional[TaskManager] = None

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import time
-from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import ClassVar, Optional, Type
 
@@ -148,7 +147,8 @@ class SpotBurnFiducialTask(AutoLamellaTask):
         Supervised runs let the user place/adjust points and run the burn in the spot
         burn widget; unsupervised/headless runs burn the stored coordinates directly.
         """
-        # automatic path: no user in the loop (unsupervised or headless)
+        # automatic path: no user in the loop (unsupervised or headless). Skip (rather than
+        # block on the interactive prompt) when there are no coordinates to burn.
         if not self.validate or self.parent_ui is None:
             if not self.config.coordinates:
                 logging.warning(
@@ -169,11 +169,13 @@ class SpotBurnFiducialTask(AutoLamellaTask):
             logging.warning("Spot burn widget not available in UI.")
             return
 
-        parameters = deepcopy({"milling_current": self.config.milling_current,
-                    "exposure_time": self.config.exposure_time,
-                    "coordinates": self.config.coordinates})
-        update_spot_burn_parameters(parent_ui=self.parent_ui, parameters=parameters)
+        update_spot_burn_parameters(
+            parent_ui=self.parent_ui, settings=self.config.to_settings()
+        )
 
+        # supervised run/wait/re-prompt loop (mirrors milling): the user runs each burn
+        # via the workflow "Run Spot Burn" control, and the task waits for it to finish
+        # before continuing so the workflow can't advance mid-burn.
         spot_burn_widget = self.parent_ui.spot_burn_widget
         msg = f"Place points and run the spot burn for {self.lamella.name}. Press Continue when finished."
         response = ask_user(self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True)
@@ -196,8 +198,8 @@ class SpotBurnFiducialTask(AutoLamellaTask):
                 raise
             response = ask_user(self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True)
 
-        # store the coordinates from the UI back to the config
-        self.config.coordinates = spot_burn_widget.get_coordinates()
+        # store the user's settings (coordinates + current/exposure) back to the config
+        self.config.apply_settings(spot_burn_widget.get_settings())
 
-        # clear the spot burn parameters from the UI
+        # clear the spot burn UI
         clear_spot_burn_ui(self.parent_ui)

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -20,6 +20,7 @@ from fibsem.structures import (
 from fibsem.applications.autolamella.structures import Experiment
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.ui import AutoLamellaUI
+    from fibsem.imaging.spot import SpotBurnSettings
 
 # CORE UI FUNCTIONS -> PROBS SEPARATE FILE
 def _check_for_abort(parent_ui: Optional['AutoLamellaUI'], msg: str = "Workflow aborted by user.") -> bool:
@@ -251,14 +252,14 @@ def update_experiment_ui(parent_ui: Optional['AutoLamellaUI'], experiment: Exper
     parent_ui.update_experiment_signal.emit(deepcopy(experiment))
 
 def update_spot_burn_parameters(parent_ui: 'AutoLamellaUI',
-                                parameters: dict | None = None,
+                                settings: Optional['SpotBurnSettings'] = None,
                                 clear_spots: bool = False):
-    """Update the spot burn parameters in the UI."""
+    """Push spot-burn settings to the UI (or clear them)."""
     _check_for_abort(parent_ui)
 
     INFO = {
         "msg": "Updating Spot Burn Parameters",
-        "spot_burn_parameters": parameters,
+        "spot_burn_settings": settings,
         "clear_spot_burn": clear_spots,
     }
 
@@ -269,4 +270,4 @@ def update_spot_burn_parameters(parent_ui: 'AutoLamellaUI',
 
 def clear_spot_burn_ui(parent_ui: 'AutoLamellaUI'):
     """Clear the spot burn UI."""
-    update_spot_burn_parameters(parent_ui=parent_ui, parameters=None, clear_spots=True)
+    update_spot_burn_parameters(parent_ui=parent_ui, settings=None, clear_spots=True)

--- a/fibsem/ui/FibsemEmbeddedDetectionWidget.py
+++ b/fibsem/ui/FibsemEmbeddedDetectionWidget.py
@@ -1,15 +1,9 @@
 import logging
 import os
 from copy import deepcopy
-from typing import List, Optional
+from typing import Optional
 
-import napari
-import napari.utils.notifications
 import numpy as np
-from napari.layers import Image as NapariImageLayer
-from napari.layers import Labels as NapariLabelsLayer
-from napari.layers import Points as NapariPointsLayer
-from napari.layers import Shapes as NapariShapesLayer
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtGui import QFont
@@ -20,13 +14,12 @@ from fibsem.versioning import get_version_string
 from fibsem.detection import detection
 from fibsem.detection import utils as det_utils
 from fibsem.detection.detection import DetectedFeatures
-from fibsem.segmentation.config import CLASS_COLORS
 from fibsem.segmentation.model import load_model
 from fibsem.structures import (
+    BeamType,
     FibsemImage,
     Point,
 )
-from fibsem.ui.napari.utilities import add_points_layer
 
 
 class FibsemEmbeddedDetectionUI(QtWidgets.QWidget):
@@ -40,20 +33,106 @@ class FibsemEmbeddedDetectionUI(QtWidgets.QWidget):
         self._setup_ui()
 
         self.parent = parent
-        if parent is not None:
-            viewer = parent.viewer
-        else:
-            viewer = napari.current_viewer()
-        self.viewer: napari.Viewer = viewer
-
         self.has_user_corrected: bool = False
 
-        self.image_layer: NapariImageLayer = None
-        self.mask_layer: NapariLabelsLayer = None
-        self.features_layer: NapariPointsLayer = None
-        self.cross_hair_layer: NapariShapesLayer = None
+        # quad-view: a "mask" MaskSpec + a modal "detection" PointsSpec on a beam
+        # canvas, owned by the controller.
+        self._host_beam = None         # BeamType the detection overlays are hosted on
+        self._detection_wired = False  # subscribed to controller.overlay_edited
 
         self.setup_connections()
+
+    # ------------------------------------------------------------------
+    # Quad-view overlays (controller-owned)
+    # ------------------------------------------------------------------
+
+    def _view_controller(self):
+        """Return the quad-view MicroscopeViewController, or None if unavailable."""
+        parent_ui = getattr(self.parent, "parent_widget", None)
+        return getattr(parent_ui, "view_controller", None)
+
+    def _host_beam_for(self, det):
+        """Pick the beam to host detection — the beam of ``det.fibsem_image``
+        (fallback ION), or None if there's no controller."""
+        if self._view_controller() is None:
+            return None
+        fib = getattr(det, "fibsem_image", None)
+        beam = fib.metadata.beam_type if fib is not None and fib.metadata is not None else None
+        return beam if beam in (BeamType.ELECTRON, BeamType.ION) else BeamType.ION
+
+    def _detach_detection(self, beam):
+        """Remove the detection overlays from *beam* (e.g. when the host beam changes)."""
+        controller = self._view_controller()
+        if controller is None or beam is None:
+            return
+        controller.arm_overlay(beam, None)
+        controller.remove_overlay(beam, "detection")
+        controller.remove_overlay(beam, "mask")
+        canvas = controller.get_canvas(beam)
+        if canvas is not None:
+            canvas.set_hint(None)
+
+    def _update_features(self, beam):
+        """Show the detection image + read-only mask + draggable feature points on the
+        *beam* canvas via the reducer (quad-view equivalent of update_features_ui)."""
+        from fibsem.ui.widgets.canvas.canvas_state import MaskSpec, PointsSpec
+
+        controller = self._view_controller()
+        if controller is None:
+            return
+        if self._host_beam is not None and self._host_beam is not beam:
+            self._detach_detection(self._host_beam)  # host beam changed
+        self._host_beam = beam
+        if not self._detection_wired:
+            controller.overlay_edited.connect(self._on_detection_edited)
+            self._detection_wired = True
+
+        # the detection image: its pixel space matches det.mask + feature.px
+        if self.det.fibsem_image is not None:
+            controller.set_image(beam, self.det.fibsem_image)
+        controller.set_overlay(beam, MaskSpec(mask=self.det.mask))  # display-only
+        controller.set_overlay(
+            beam,
+            PointsSpec(
+                id="detection",
+                points=[(f.px.x, f.px.y) for f in self.det.features],
+                colors=[f.color for f in self.det.features],
+                labels=[f.name for f in self.det.features],
+                marker="+", size=16, removable=False, add_on_right_click=False, modal=True,
+            ),
+        )
+        controller.arm_overlay(beam, "detection", label="Detection", icon="mdi:vector-point")
+        canvas = controller.get_canvas(beam)
+        if canvas is not None:
+            canvas.set_hint("drag features to correct  ·  Continue when done")
+        self.update_info()
+
+    def _on_detection_edited(self, beam, overlay_id, points):
+        """A feature point was dragged → update ``feature.px`` (mirrors update_point)."""
+        if overlay_id != "detection":
+            return
+        for i, (x, y) in enumerate(points):
+            if i < len(self.det.features):
+                self.det.features[i].px = Point(x=x, y=y)
+        self.has_user_corrected = True
+        self.update_info()
+
+    def closeEvent(self, event) -> None:
+        self._teardown_connections()
+        super().closeEvent(event)
+
+    def _teardown_connections(self) -> None:
+        """Drop the controller subscription (idempotent). Called from ``closeEvent`` AND
+        the AutoLamella teardown path (``deleteLater`` fires neither), so a recreated
+        widget doesn't leave a dead slot on the persistent controller."""
+        if self._detection_wired:
+            controller = self._view_controller()
+            if controller is not None:
+                try:
+                    controller.overlay_edited.disconnect(self._on_detection_edited)
+                except (TypeError, RuntimeError):
+                    pass
+            self._detection_wired = False
 
     def _setup_ui(self):
         self.gridLayout = QGridLayout(self)
@@ -94,39 +173,22 @@ class FibsemEmbeddedDetectionUI(QtWidgets.QWidget):
         )
 
     def clear_layers(self):
-        """Remove the layers added by the detection widget and reshow all other layers."""
-        # remove feature detection layers
-        if self.image_layer is not None:
-            if self.image_layer in self.viewer.layers:
-                self.viewer.layers.remove(self.image_layer)
-            if self.mask_layer in self.viewer.layers:
-                self.viewer.layers.remove(self.mask_layer)
-            if self.features_layer in self.viewer.layers:
-                self.viewer.layers.remove(self.features_layer)
-            if self.cross_hair_layer in self.viewer.layers:
-                self.viewer.layers.remove(self.cross_hair_layer)
-
-        # reshow all other layers
-        excluded_layers = ["alignment_area"]
-        for layer in self.viewer.layers:
-            if layer.name in excluded_layers:
-                continue
-            layer.visible = True
+        """Remove the detection overlays from the canvas."""
+        controller = self._view_controller()
+        if controller is not None:
+            if self._host_beam is not None:
+                self._detach_detection(self._host_beam)
+            self._host_beam = None
 
     def confirm_button_clicked(self):
-        """Confirm the detected features, save the data and and remove the layers from the viewer."""
-
-        # update the mask as the user may edit it
-        self.det.mask = self.mask_layer.data.astype(np.uint8) # type: ignore
-        
-        # log the difference between initial and final detections
-        # TODO: move this to outside the widget, into the same place as the non-supervised logging.
-        det_utils.save_ml_feature_data(det=self.det, 
+        """Confirm the detected features, save the data and clear the overlays."""
+        # mask is display-only (no painting), so det.mask stays the model output — but
+        # normalise its dtype to uint8 (save_feature_data_to_csv -> PIL.Image.fromarray needs it).
+        if self.det.mask is not None:
+            self.det.mask = np.asarray(self.det.mask).astype(np.uint8)
+        det_utils.save_ml_feature_data(det=self.det,
                                        initial_features=self._intial_det.features)
-
-        # reset layers and camera
         self.clear_layers()
-        self.viewer.reset_view()
 
     def set_detected_features(self, det_features: DetectedFeatures):
         """Set the detected features and update the UI"""
@@ -138,72 +200,11 @@ class FibsemEmbeddedDetectionUI(QtWidgets.QWidget):
 
     def update_features_ui(self):
         """Update the UI with the detected features"""
-        # hide all other layers?
-        for layer in self.viewer.layers:
-            layer.visible = False
-
-        self.image_layer = self.viewer.add_image( # type: ignore
-            self.det.image,
-            name="image",
-            opacity=0.7,
-            blending="additive",
-        )
-
-        # add mask to viewer
-        self.mask_layer = self.viewer.add_labels(self.det.mask, 
-                                                    name="mask", 
-                                                    opacity=0.3,
-                                                    blending="additive", 
-                                                    )
-        if hasattr(self.mask_layer, "colormap"):
-            self.mask_layer.colormap = CLASS_COLORS
-        else:
-            self.mask_layer.color = CLASS_COLORS
-
-        # add points to viewer
-        data = []
-        for feature in self.det.features:
-            x, y = feature.px
-            data.append([y, x])
-
-        text = {
-            "string": [feature.name for feature in self.det.features],
-            "color": "white",
-            "translation": np.array([-30, 0]),
-        }
-
-        self.features_layer = add_points_layer(
-            viewer=self.viewer,
-            data=data,
-            name="features",
-            text=text,
-            size=20,
-            border_width=7,
-            border_width_is_relative=False,
-            border_color="transparent",
-            face_color=[feature.color for feature in self.det.features],
-            blending="translucent",
-        )
-
-        # draw cross hairs
-        self.cross_hair_layer = None
-        self.draw_feature_crosshairs()
-
-        # set points layer to select mode and active
-        self.viewer.layers.selection.active = self.features_layer
-        self.features_layer.mode = "select"
-        
-        # when the point is moved update the feature
-        self.features_layer.events.data.connect(self.update_point)
-        self.update_info()
-            
-        # set camera
-        self.viewer.reset_view()
-
+        beam = self._host_beam_for(self.det)
+        if beam is not None:
+            self._update_features(beam)
         if self.det.checkpoint:
-            self.label_model.setText(f"Checkpont: {os.path.basename(self.det.checkpoint)}")
-        
-        napari.utils.notifications.show_info(f"Features ({', '.join([f.name for f in self.det.features])}) Detected")
+            self.label_model.setText(f"Checkpoint: {os.path.basename(self.det.checkpoint)}")
 
     def update_info(self):
         """Update the info label with the feature information"""
@@ -229,71 +230,6 @@ class FibsemEmbeddedDetectionUI(QtWidgets.QWidget):
                 )
             return
 
-    def update_point(self, event):
-        """Update the feature when the point is moved"""
-        # TODO: events have been updated so we can tell which point was deleted/moved/etc. Update this function to use that.
-        logging.debug(f"{event.source.name} changed its data!")
-
-        layer = self.viewer.layers[f"{event.source.name}"]  # type: ignore
-
-        # get the data
-        data = layer.data
-
-        # get which point was moved
-        index: List[int] = list(layer.selected_data)  
-                
-        if len(data) != len(self.det.features):
-            # loop backwards to remove the features
-            for idx in index[::-1]:
-                logging.debug({"msg": "detection_point_deleted",
-                               "idx": idx, "data": data[idx], 
-                               "feature": self.det.features[idx].name})
-                self.det.features.pop(idx)
-
-        else: 
-            for idx in index:
-                logging.debug({"msg": "detection_point_moved", 
-                               "idx": idx, "data": data[idx], 
-                               "feature": self.det.features[idx].name})
-                
-                # update the feature
-                self.det.features[idx].px = Point(
-                    x=data[idx][1], y=data[idx][0]
-                )
-
-        self.draw_feature_crosshairs()
-        self.has_user_corrected = True
-        self.update_info()
-
-    def draw_feature_crosshairs(self):
-        """Draw crosshairs for each feature on the image"""
-
-        data = self.features_layer.data
-
-        # for each data point draw two lines from the edge of the image to the point
-        line_data, line_colors = [], []
-        for idx, point in enumerate(data):
-            y, x = point # already flipped
-            vline = [[y, 0], [y, self.det.image.data.shape[1]]]
-            hline = [[0, x], [self.det.image.data.shape[0], x]]
-            
-            line_data += [hline, vline]
-            color = self.det.features[idx].color
-            line_colors += [color, color]
-        try:
-            self.cross_hair_layer.data = line_data
-            self.cross_hair_layer.edge_color = line_colors
-        except Exception as e:
-            self.cross_hair_layer = self.viewer.add_shapes(
-                data=line_data,
-                shape_type="line",
-                edge_width=3,
-                edge_color=line_colors,
-                name="feature_cross_hair",
-                opacity=0.7,
-                blending="additive",
-            )    
-    
     def _get_detected_features(self):
 
         from fibsem import conversions
@@ -324,16 +260,11 @@ def main():
         deepcopy(image.data), model, features=features, pixelsize=pixelsize
     )
 
-    viewer = napari.Viewer(ndisplay=2)
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
     det_widget_ui = FibsemEmbeddedDetectionUI()
     det_widget_ui.set_detected_features(det)
-
-    viewer.window.add_dock_widget(
-        det_widget_ui, area="right", 
-        add_vertical_stretch=False, 
-        name=f"OpenFIBSEMv{get_version_string()} Feature Detection"
-    )
-    napari.run()
+    det_widget_ui.show()
+    app.exec_()
 
     det = det_widget_ui.det
 

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -1,22 +1,14 @@
+from __future__ import annotations
+
 import logging
 import threading
-from typing import Optional
-import numpy as np
 
-import napari
-import napari.utils.notifications
-from napari.layers import Image as NapariImageLayer
-from napari.layers import Points as NapariPointsLayer
-from fibsem.ui.qt.threading import FunctionWorker, thread_worker
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
-    QComboBox,
-    QDoubleSpinBox,
-    QGridLayout,
+    QFormLayout,
     QLabel,
-    QProgressBar,
     QPushButton,
-    QSizePolicy,
-    QSpacerItem,
+    QVBoxLayout,
     QWidget,
 )
 from PyQt5.QtCore import Qt, QTimer, pyqtSignal
@@ -24,13 +16,14 @@ from superqt import ensure_main_thread
 
 from fibsem.imaging.spot import SpotBurnSettings, run_spot_burn
 from fibsem.microscope import FibsemMicroscope
-from fibsem.structures import BeamType, Point
-from fibsem.ui import stylesheets
-from fibsem.ui.utils import install_wheel_blocker
+from fibsem.structures import BeamType
+from fibsem.ui import notification_service, stylesheets
+from fibsem.ui.qt.threading import FunctionWorker
+from fibsem.ui.widgets.custom_widgets import ValueComboBox, ValueSpinBox
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
+from fibsem.ui.widgets.spot_burn_coordinates_widget import SpotBurnCoordinatesWidget
 from fibsem.utils import format_value
 
-SPOT_BURN_POINTS_LAYER_NAME = "spot-burn-points"
 DEFAULT_BEAM_CURRENT = 60e-12  # 60 pA
 HIDE_PROGRESS_DELAY_MS = 2000  # how long the "Done" bar stays up before hiding
 
@@ -53,135 +46,153 @@ def build_spot_burn_progress_update(ddict: dict) -> ProgressUpdate:
         message="Burning spots",
     )
 
+
 class FibsemSpotBurnWidget(QWidget):
+    """Live spot-burn tab: place coordinates + set current/exposure + run.
+
+    The *coordinate* half is the shared :class:`SpotBurnCoordinatesWidget` (canvas points
+    overlay + list); this widget adds the beam-current/exposure form and the run / cancel
+    / progress machinery. Everything is one :class:`SpotBurnSettings`: the editor writes
+    ``coordinates``, the form writes current/exposure, and the burn runs the settings.
+
+    Progress is driven by ``microscope.spot_burn_progress_signal`` (shared with the
+    status bar). The burn runs directly from the widget's button, or — in a supervised
+    workflow — via ``start_spot_burn_signal`` (mirrors milling's task-orchestrated hook).
+    """
+
     # emitted by the workflow task to trigger a burn (mirrors milling's start_milling_signal)
     start_spot_burn_signal = pyqtSignal()
 
     def __init__(self, parent: QWidget):
         super().__init__(parent=parent)
-        self._setup_ui()
-
         self.parent = parent
-        self.viewer: napari.Viewer = parent.viewer
         self.microscope: FibsemMicroscope = parent.microscope
-        self.worker: FunctionWorker = None
+        self.worker = None  # FunctionWorker while a burn is running
         self.stop_event: threading.Event = threading.Event()
-        self._is_burning: bool = False
-        self._workflow_mode: bool = False
+        self._is_burning = False  # guards the Run/Cancel button while a burn runs
+        self._workflow_mode = False  # supervised workflow hides the widget's own button
 
-        # napari layers
-        self.pts_layer: Optional[NapariPointsLayer] = None
-        self.image_layer: Optional[NapariImageLayer] = None
+        self._build_ui()
+        self._setup_connections()
 
-        self.setup_connections()
+    # ------------------------------------------------------------------
+    # UI
+    # ------------------------------------------------------------------
 
-    def _setup_ui(self):
-        """Hand-built replacement for the former Qt Designer form.
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
 
-        ``setup_connections`` swaps ``progressBar`` for a ``FibsemProgressWidget`` and
-        drops ``label_workflow_hint`` into the run button's cell, so the grid, the
-        ``progressBar`` placeholder, and the widget object names are reproduced here.
-        """
-        self.gridLayout_2 = QGridLayout(self)
+        # coordinate editor (shared canvas overlay + list)
+        self.coord_editor = SpotBurnCoordinatesWidget(
+            controller=self._view_controller(), beam=BeamType.ION, parent=self,
+        )
+        layout.addWidget(self.coord_editor)
 
-        self.label_title = QLabel("Spot Burn")
-        self.gridLayout_2.addWidget(self.label_title, 0, 0, 1, 2)
-
-        self.label_exposure_time = QLabel("Exposure Time")
-        self.doubleSpinBox_exposure_time = QDoubleSpinBox()
-        self.gridLayout_2.addWidget(self.label_exposure_time, 1, 0)
-        self.gridLayout_2.addWidget(self.doubleSpinBox_exposure_time, 1, 1)
-
-        self.label_beam_current = QLabel("Beam Current")
-        self.comboBox_beam_current = QComboBox()
-        self.gridLayout_2.addWidget(self.label_beam_current, 2, 0)
-        self.gridLayout_2.addWidget(self.comboBox_beam_current, 2, 1)
-
-        self.label_information = QLabel("")
-        self.gridLayout_2.addWidget(self.label_information, 3, 0, 1, 2)
-
-        self.progressBar = QProgressBar()
-        self.gridLayout_2.addWidget(self.progressBar, 4, 0, 1, 2)
-
-        self.pushButton_run_spot_burn = QPushButton("Run Spot Burn")
-        self.gridLayout_2.addWidget(self.pushButton_run_spot_burn, 5, 0, 1, 2)
-
-        spacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
-        self.gridLayout_2.addItem(spacer, 6, 0, 1, 2)
-
-        # block accidental scroll-to-change on the input widgets
-        for w in (self.comboBox_beam_current, self.doubleSpinBox_exposure_time):
-            install_wheel_blocker(w)
-
-    def setup_connections(self):
-        self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
-
+        # beam current + exposure
         beam_currents = self.microscope.get_available_values("current", BeamType.ION)
-        for current in beam_currents:
-            label = format_value(current, unit="A", precision=1)
-            self.comboBox_beam_current.addItem(label, current)
-
-        # find the current closest to 60pA, set index to that
-        closest_current = min(beam_currents, key=lambda x: abs(x - DEFAULT_BEAM_CURRENT))
-        closest_index = beam_currents.index(closest_current)
-        self.comboBox_beam_current.setCurrentIndex(closest_index)
-
-        # set parameters for exposure time
-        self.doubleSpinBox_exposure_time.setSuffix(" s")
-        self.doubleSpinBox_exposure_time.setRange(0.1, 60)
+        closest = min(beam_currents, key=lambda x: abs(x - DEFAULT_BEAM_CURRENT))
+        self.comboBox_beam_current = ValueComboBox(
+            items=beam_currents, value=closest, unit="A", decimals=1,
+        )
+        self.doubleSpinBox_exposure_time = ValueSpinBox(
+            suffix="s", minimum=0.1, maximum=60, decimals=3,
+        )
         self.doubleSpinBox_exposure_time.setValue(10)
-        self.doubleSpinBox_exposure_time.valueChanged.connect(self._on_data_changed)
+        form = QFormLayout()
+        form.addRow("Beam Current", self.comboBox_beam_current)
+        form.addRow("Exposure Time", self.doubleSpinBox_exposure_time)
+        layout.addLayout(form)
 
-        # initial state (PRIMARY greys out via its :disabled rule while no points are selected)
-        self.label_information.setText("No points selected. Please add points to the layer.")
-        self.pushButton_run_spot_burn.setEnabled(False)
+        # info
+        self.label_information = QLabel("")
+        self.label_information.setWordWrap(True)
+        layout.addWidget(self.label_information)
 
-        # replace the .ui QProgressBar with the shared FibsemProgressWidget (in the same
-        # grid cell) so the widget and the status bar render progress identically.
-        bar_pos = self.gridLayout_2.getItemPosition(
-            self.gridLayout_2.indexOf(self.progressBar)
-        )
-        self.gridLayout_2.removeWidget(self.progressBar)
-        self.progressBar.deleteLater()
+        # progress — the shared FibsemProgressWidget (renders identically to the status bar)
         self.progress_widget = FibsemProgressWidget(self)
-        self.gridLayout_2.addWidget(self.progress_widget, *bar_pos)
+        layout.addWidget(self.progress_widget)
 
-        # progress is driven by the microscope's spot_burn_progress_signal (shared with the
-        # status bar). psygnal fires on the worker thread, so _update_progress_bar is
-        # marshalled to the GUI thread via @ensure_main_thread.
-        self.microscope.spot_burn_progress_signal.connect(self._update_progress_bar)
+        # run button + workflow hint. Exactly one is visible at a time
+        # (_update_run_button_visibility): outside a workflow the button is used directly;
+        # in a supervised workflow the burn is run from the workflow control, so the button
+        # is hidden (except as "Cancel" mid-burn) and the hint is shown instead.
+        self.pushButton_run_spot_burn = QPushButton("Run Spot Burn")
+        layout.addWidget(self.pushButton_run_spot_burn)
 
-        # the workflow task drives the burn via start_spot_burn_signal (mirrors milling).
-        # BlockingQueuedConnection: emit() returns only after run_spot_burn_worker has
-        # run, so the burn is then either in progress (is_burning=True) or was refused
-        # (no in-bounds points), in which case the task re-prompts.
-        self.start_spot_burn_signal.connect(
-            self.run_spot_burn_worker, Qt.BlockingQueuedConnection  # type: ignore
-        )
-
-        # workflow-mode hint, shown when the widget's own Burn button is hidden during a
-        # supervised workflow (the burn is run from the workflow "Run Spot Burn" control).
-        # It shares the Burn button's grid cell on purpose: exactly one of the two is
-        # visible at any time (_update_run_button_visibility), so the hint appears in
-        # place of the hidden button without the layout shifting.
         self.label_workflow_hint = QLabel(
             "Use the 'Run Spot Burn' button in the workflow controls to burn the selected points."
         )
         self.label_workflow_hint.setWordWrap(True)
         self.label_workflow_hint.setStyleSheet("color: gray; font-style: italic;")
         self.label_workflow_hint.setVisible(False)
-        btn_pos = self.gridLayout_2.getItemPosition(
-            self.gridLayout_2.indexOf(self.pushButton_run_spot_burn)
+        layout.addWidget(self.label_workflow_hint)
+
+        layout.addStretch()
+
+    def _setup_connections(self) -> None:
+        self.comboBox_beam_current.currentIndexChanged.connect(self._refresh_info)
+        self.doubleSpinBox_exposure_time.valueChanged.connect(self._refresh_info)
+
+        # run button
+        self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)
+        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.pushButton_run_spot_burn.setEnabled(False)
+
+        # the workflow task drives the burn via start_spot_burn_signal (mirrors milling).
+        # BlockingQueuedConnection: emit() returns only after run_spot_burn_worker has run,
+        # so the burn is then either in progress (is_burning=True) or was refused (no
+        # in-bounds points), in which case the task re-prompts.
+        self.start_spot_burn_signal.connect(
+            self.run_spot_burn_worker, Qt.BlockingQueuedConnection  # type: ignore
         )
-        self.gridLayout_2.addWidget(self.label_workflow_hint, *btn_pos)
+
+        # coordinate signal
+        self.coord_editor.settings_changed.connect(self._refresh_info)
+
+        # progress is driven by the microscope's spot_burn_progress_signal (shared with the
+        # status bar). It fires on the worker thread, so _update_progress_bar is marshalled
+        # to the GUI thread via @ensure_main_thread.
+        self.microscope.spot_burn_progress_signal.connect(self._update_progress_bar)
+
+        # re-feed the FIB image shape to the editor on each acquisition
+        iw = self._image_widget()
+        if iw is not None:
+            try:
+                iw.viewer_update_signal.connect(self._feed_image_shape)
+            except Exception:
+                pass
+
+        self._refresh_info()
+
+    # ------------------------------------------------------------------
+    # Controller / image plumbing
+    # ------------------------------------------------------------------
+
+    def _view_controller(self):
+        """Return the quad-view MicroscopeViewController, or None."""
+        parent_ui = getattr(self.parent, "parent_widget", None)
+        return getattr(parent_ui, "view_controller", None)
+
+    def _image_widget(self):
+        return getattr(self.parent, "image_widget", None)
+
+    def _feed_image_shape(self, *args) -> None:
+        """Push the current FIB image shape to the editor (for 0-1 <-> px conversion)."""
+        iw = self._image_widget()
+        img = getattr(iw, "ib_image", None) if iw is not None else None
+        if img is not None:
+            self.coord_editor.set_image_shape(img.data.shape[:2])
+
+    # ------------------------------------------------------------------
+    # Workflow mode (button/hint visibility) + teardown
+    # ------------------------------------------------------------------
 
     @property
     def is_burning(self) -> bool:
         """Whether a spot burn is currently running."""
         return self._is_burning
 
-    def set_workflow_mode(self, active: bool):
+    def set_workflow_mode(self, active: bool) -> None:
         """Toggle workflow mode.
 
         During a supervised workflow the burn is task-orchestrated (like milling), so the
@@ -192,7 +203,7 @@ class FibsemSpotBurnWidget(QWidget):
         self._workflow_mode = active
         self._update_run_button_visibility()
 
-    def _update_run_button_visibility(self):
+    def _update_run_button_visibility(self) -> None:
         """Show/hide the run button and workflow hint for the current mode + burn state."""
         if self._workflow_mode:
             # idle: hidden (run via the workflow control); burning: shown as "Cancel"
@@ -202,141 +213,103 @@ class FibsemSpotBurnWidget(QWidget):
             self.pushButton_run_spot_burn.setVisible(True)
             self.label_workflow_hint.setVisible(False)
 
-    def disconnect_signals(self):
+    def disconnect_signals(self) -> None:
         """Disconnect from the microscope's progress signal before the widget is destroyed.
 
-        The microscope outlives this widget; without this, the strong psygnal connection
-        would leak the widget and fire _update_progress_bar on a deleted object.
+        The microscope outlives this widget; without this, the connection would leak the
+        widget and fire _update_progress_bar on a deleted object.
         """
         try:
             self.microscope.spot_burn_progress_signal.disconnect(self._update_progress_bar)
         except Exception:
             pass
 
-    def _add_points_layer(self):
-        # check if the points layer exists, if not create it
-        if SPOT_BURN_POINTS_LAYER_NAME not in self.viewer.layers:
-            self.pts_layer = self.viewer.add_points(data=[],
-                                name=SPOT_BURN_POINTS_LAYER_NAME,
-                                visible=True,
-                                size=20)
-            self.pts_layer.events.data.connect(self._on_data_changed)
-        else:
-            self.pts_layer = self.viewer.layers[SPOT_BURN_POINTS_LAYER_NAME]
+    # ------------------------------------------------------------------
+    # Activation lifecycle (called by the workflow via AutoLamellaUI)
+    # ------------------------------------------------------------------
 
-    def set_active(self):
-        """Called when the widget is activated."""
+    def set_active(self) -> None:
+        """Activate: feed the image shape and arm the overlay."""
+        self._feed_image_shape()
+        self.coord_editor.set_active(True)
+        self._refresh_info()
 
-        # add the points layer if it doesn't exist
-        self._add_points_layer()
-        if self.pts_layer is None:
-            raise RuntimeError("Failed to create points layer for spot burn.")
+    def set_inactive(self) -> None:
+        """Deactivate: disarm the overlay."""
+        self.coord_editor.set_active(False)
 
-        self.viewer.layers.selection.active = self.pts_layer
-        self.pts_layer.visible = True
-        self.pts_layer.mode = "add"
+    def clear_points_layer(self) -> None:
+        """Clear the coordinates + overlay (called when the task exits)."""
+        self.coord_editor.set_settings(SpotBurnSettings())
+        self._refresh_info()
 
-    def set_inactive(self):
-        """Called when the widget is deactivated."""
+    # ------------------------------------------------------------------
+    # Workflow API (SpotBurnSettings in / out)
+    # ------------------------------------------------------------------
 
-        # hide the points layer
-        if SPOT_BURN_POINTS_LAYER_NAME in self.viewer.layers:
-            self.viewer.layers[SPOT_BURN_POINTS_LAYER_NAME].visible = False
+    def set_settings(self, settings: SpotBurnSettings) -> None:
+        """Apply a settings payload (current / exposure / coordinates)."""
+        # keep an off-grid (protocol) current exactly selectable so an untouched value
+        # round-trips losslessly — otherwise the closest-match snap would rewrite the config
+        if self.comboBox_beam_current.findData(settings.milling_current) == -1:
+            self.comboBox_beam_current.addItem(
+                format_value(settings.milling_current, unit="A", precision=1),
+                settings.milling_current,
+            )
+        self.comboBox_beam_current.set_value(settings.milling_current)
+        self.doubleSpinBox_exposure_time.setValue(settings.exposure_time)
 
-        self.parent.image_widget.restore_active_layer_for_movement()
+        self._feed_image_shape()
+        # the editor only owns coordinates; current/exposure live on the form
+        self.coord_editor.set_settings(SpotBurnSettings(coordinates=list(settings.coordinates)))
+        self._refresh_info()  # set_settings is programmatic (no settings_changed)
 
-    def update_parameters(self, parameters: dict):
-        """Update the parameters for the spot burn."""
-        milling_current = parameters.get("milling_current", None)
-        exposure_time = parameters.get("exposure_time", None)
-        coordinates = parameters.get("coordinates", None)
-
-        if self.pts_layer is None:
-            self._add_points_layer() # ensure points layer exists
-    
-        if milling_current is not None:
-            index = self.comboBox_beam_current.findData(milling_current)
-            if index != -1:
-                self.comboBox_beam_current.setCurrentIndex(index)
-
-        if exposure_time is not None:
-            self.doubleSpinBox_exposure_time.setValue(exposure_time)
-
-        if coordinates and self.pts_layer is not None:
-            self._set_coordinates(coordinates)
-
-    def _set_coordinates(self, coordinates: list):
-        """Pre-populate the points layer from normalised image coordinates (0-1)."""
-
-        self.image_layer = self.parent.image_widget.ib_layer
-        if self.image_layer is None or not isinstance(self.image_layer, NapariImageLayer):
-            return
-
-        image_shape = self.image_layer.data.shape
-        translate = self.image_layer.translate
-
-        # convert normalised (0-1) Point coordinates to napari pixel coordinates
-        pts = np.array([[pt.y * image_shape[0] + translate[0],
-                         pt.x * image_shape[1] + translate[1]]
-                        for pt in coordinates])
-        self.pts_layer.data = pts
-        self._on_data_changed()
+    def get_settings(self) -> SpotBurnSettings:
+        """The run payload — coordinates from the editor, current/exposure from the form."""
+        return SpotBurnSettings(
+            coordinates=self.get_coordinates(),
+            milling_current=self.comboBox_beam_current.value(),
+            exposure_time=self.doubleSpinBox_exposure_time.value(),
+        )
 
     def get_coordinates(self) -> list:
-        """Get the current spot burn positions as normalised image coordinates (0-1)."""
-        if self.pts_layer is None or len(self.pts_layer.data) == 0:
-            return []
+        """Current spot positions (normalised 0-1), filtered to image bounds."""
+        coords = self.coord_editor.get_settings().coordinates
+        return [pt for pt in coords if 0 <= pt.x <= 1 and 0 <= pt.y <= 1]
 
-        self.image_layer = self.parent.image_widget.ib_layer
-        if self.image_layer is None or not isinstance(self.image_layer, NapariImageLayer):
-            return []
+    # ------------------------------------------------------------------
+    # Info / run
+    # ------------------------------------------------------------------
 
-        layer_translated = self.pts_layer.data - self.image_layer.translate
-        image_shape = self.image_layer.data.shape
-
-        coordinates = [Point(float(pt[1] / image_shape[1]), float(pt[0] / image_shape[0]))
-                       for pt in layer_translated]
-        # exclude points outside of image bounds
-        coordinates = [pt for pt in coordinates if 0 <= pt.x <= 1 and 0 <= pt.y <= 1]
-        return coordinates
-
-    def clear_points_layer(self):
-        """Clear the points layer."""
-        if SPOT_BURN_POINTS_LAYER_NAME in self.viewer.layers:
-            self.viewer.layers.remove(SPOT_BURN_POINTS_LAYER_NAME)
-            self.pts_layer = None
-
-    def _on_data_changed(self, event = None):
-        """Called when the data in the points layer changes."""
-        if self.pts_layer is None:
-            return
-        coordinates = self.pts_layer.data
-        
-        enabled = bool(len(coordinates) > 0)
-        self.pushButton_run_spot_burn.setEnabled(enabled)
-        if enabled:
-            self.label_information.setText(f"Selected {len(coordinates)} points. Estimated time: {len(coordinates) * self.doubleSpinBox_exposure_time.value()} seconds")
+    def _refresh_info(self, *args) -> None:
+        n = len(self.coord_editor.get_settings().coordinates)
+        exposure = self.doubleSpinBox_exposure_time.value()
+        # while a burn runs the button is "Cancel" and must stay enabled — don't let a
+        # mid-burn coordinate edit (n -> 0) disable it, or the burn can't be cancelled
+        if not self._is_burning:
+            self.pushButton_run_spot_burn.setEnabled(n > 0)
+        if n > 0:
+            self.label_information.setText(
+                f"Selected {n} points. Estimated time: {n * exposure:.0f} seconds"
+            )
         else:
-            self.label_information.setText("No points selected. Please add points to the layer.")
+            self.label_information.setText(
+                "No points selected. Right-click the FIB image to add points."
+            )
 
-    def run_spot_burn_worker(self):
+    def run_spot_burn_worker(self) -> None:
         """Run the spot burn worker."""
-
-        # get the points layer
-        if SPOT_BURN_POINTS_LAYER_NAME not in self.viewer.layers:
-            napari.utils.notifications.show_warning("No points layer found. Requires 'spot-burn-points' layer.")
+        settings = self.get_settings()
+        if len(settings.coordinates) == 0:
+            notification_service.show_toast(
+                "No points selected within FIB image bounds.", "warning"
+            )
             return
 
-        coordinates = self.get_coordinates()  # ensure coordinates are valid and within bounds
-
-        if len(coordinates) == 0:
-            napari.utils.notifications.show_warning("No points selected within FIB image bounds.")
-            return
-
-        beam_current = self.comboBox_beam_current.currentData()     # amps
-        exposure_time = self.doubleSpinBox_exposure_time.value()    # seconds
-
-        logging.info(f"Running spot burn with {len(coordinates)} points. Beam current: {beam_current} A, exposure time: {exposure_time} s")
+        logging.info(
+            f"Running spot burn with {len(settings.coordinates)} points. "
+            f"Beam current: {settings.milling_current} A, exposure time: {settings.exposure_time} s"
+        )
 
         self.stop_event.clear()
         self._is_burning = True
@@ -347,34 +320,30 @@ class FibsemSpotBurnWidget(QWidget):
         # in workflow mode the button is hidden when idle — show it as "Cancel" while burning
         self._update_run_button_visibility()
 
-        self.worker = self._spot_burn_worker(
-            microscope=self.microscope,
-            settings=SpotBurnSettings(coordinates=coordinates,
-                                      exposure_time=exposure_time,
-                                      milling_current=beam_current),
-        )
+        self.worker = FunctionWorker(self._run_spot_burn, settings)
         self.worker.returned.connect(self.spot_burn_finished)
         self.worker.errored.connect(self.spot_burn_errored)
         self.worker.start()
 
-    def cancel_spot_burn(self):
+    def cancel_spot_burn(self) -> None:
         """Cancel the running spot burn."""
         logging.info("Cancelling spot burn...")
         self.stop_event.set()
 
-    @thread_worker
-    def _spot_burn_worker(self, microscope: FibsemMicroscope, settings: SpotBurnSettings):
-        """Worker function to run the spot burn."""
-        run_spot_burn(microscope=microscope,
+    def _run_spot_burn(self, settings: SpotBurnSettings) -> None:
+        """Worker body (off the GUI thread). Progress flows through
+        ``microscope.spot_burn_progress_signal``; completion is delivered on the GUI
+        thread via the FunctionWorker's returned / errored signals, so a failure anywhere
+        here — including the post-burn acquire — resets the UI via spot_burn_errored."""
+        run_spot_burn(microscope=self.microscope,
                       settings=settings,
                       beam_type=BeamType.ION,
                       stop_event=self.stop_event)
+        # acquire a post-burn fib image and push it to the view (off the GUI thread)
+        image = self.microscope.acquire_image(beam_type=BeamType.ION)
+        self.microscope.fib_acquisition_signal.emit(image)
 
-        # acquire a post-burn fib image and update the view
-        image = microscope.acquire_image(beam_type=BeamType.ION)
-        microscope.fib_acquisition_signal.emit(image)
-
-    def spot_burn_finished(self, result):
+    def spot_burn_finished(self, result) -> None:
         """Called when the spot burn completes successfully."""
         self._restore_idle_state()
         # hide the "Done" bar after a moment, so it doesn't linger for the rest of the
@@ -382,7 +351,7 @@ class FibsemSpotBurnWidget(QWidget):
         # another burn has already started rendering progress in the meantime.
         QTimer.singleShot(HIDE_PROGRESS_DELAY_MS, self.progress_widget.reset_if_finished)
 
-    def spot_burn_errored(self, error):
+    def spot_burn_errored(self, error) -> None:
         """Called when the spot burn fails.
 
         The failed bar is deliberately left on screen (no auto-hide) so the failure is
@@ -392,19 +361,28 @@ class FibsemSpotBurnWidget(QWidget):
         self.microscope.spot_burn_progress_signal.emit({"finished": True, "error": True})
         self._restore_idle_state()
 
-    def _restore_idle_state(self):
+    def _restore_idle_state(self) -> None:
         """Return the run button to its idle state after a burn ends (either way)."""
         self._is_burning = False
         self.pushButton_run_spot_burn.clicked.disconnect()
         self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)
         self.pushButton_run_spot_burn.setEnabled(True)
-        self.pushButton_run_spot_burn.setText("Burn Spot")
+        self.pushButton_run_spot_burn.setText("Run Spot Burn")
         self.pushButton_run_spot_burn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
         # in workflow mode, hide the button again now the burn is done
         self._update_run_button_visibility()
 
     @ensure_main_thread
-    def _update_progress_bar(self, ddict: dict):
+    def _update_progress_bar(self, ddict: dict) -> None:
         """Render spot burn progress (identical formatting to the status bar)."""
         self.progress_widget.update_progress(build_spot_burn_progress_update(ddict))
 
+    def closeEvent(self, event) -> None:
+        self.disconnect_signals()
+        iw = self._image_widget()
+        if iw is not None:
+            try:
+                iw.viewer_update_signal.disconnect(self._feed_image_shape)
+            except (TypeError, RuntimeError):
+                pass
+        super().closeEvent(event)

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -214,15 +214,28 @@ class FibsemSpotBurnWidget(QWidget):
             self.label_workflow_hint.setVisible(False)
 
     def disconnect_signals(self) -> None:
-        """Disconnect from the microscope's progress signal before the widget is destroyed.
+        """Drop every connection to something that outlives this widget.
 
-        The microscope outlives this widget; without this, the connection would leak the
-        widget and fire _update_progress_bar on a deleted object.
+        This is the single teardown entry point: ``closeEvent`` delegates here, and the
+        host calls it directly on the disconnect path, because ``deleteLater`` fires
+        neither ``closeEvent`` nor ``close``. Keep new external connections in here
+        rather than in ``closeEvent`` — the close path is the one that does *not* run
+        when the microscope disconnects.
+
+        Idempotent. The microscope outlives this widget, so a leaked progress connection
+        would fire ``_update_progress_bar`` on a deleted object.
         """
         try:
             self.microscope.spot_burn_progress_signal.disconnect(self._update_progress_bar)
         except Exception:
             pass
+
+        iw = self._image_widget()
+        if iw is not None:
+            try:
+                iw.viewer_update_signal.disconnect(self._feed_image_shape)
+            except (TypeError, RuntimeError):
+                pass
 
     # ------------------------------------------------------------------
     # Activation lifecycle (called by the workflow via AutoLamellaUI)
@@ -379,10 +392,4 @@ class FibsemSpotBurnWidget(QWidget):
 
     def closeEvent(self, event) -> None:
         self.disconnect_signals()
-        iw = self._image_widget()
-        if iw is not None:
-            try:
-                iw.viewer_update_signal.disconnect(self._feed_image_shape)
-            except (TypeError, RuntimeError):
-                pass
         super().closeEvent(event)

--- a/fibsem/ui/fm/widgets/objective_control_widget.py
+++ b/fibsem/ui/fm/widgets/objective_control_widget.py
@@ -213,7 +213,10 @@ class ObjectiveControlWidget(QWidget):
         self._wheel_target_um: float = 0.0
         self._execute_wheel_move = qdebounced(self._execute_wheel_move_impl, timeout=150)
 
-        if self.parent_widget is not None and hasattr(self.parent_widget, "viewer"):
+        # `hasattr` is not enough once hosts go viewer-less — the attribute is still
+        # there, holding None.
+        if (self.parent_widget is not None
+                and getattr(self.parent_widget, "viewer", None) is not None):
             self.parent_widget.viewer.mouse_wheel_callbacks.append(self._on_mouse_wheel)
 
     def _set_objective_actions_enabled(self, enabled: bool) -> None:
@@ -333,10 +336,20 @@ class ObjectiveControlWidget(QWidget):
         self.doubleSpinBox_objective_position.setValue(objective_position * METRE_TO_MICRON)  # Convert m to µm
         self.doubleSpinBox_objective_position.blockSignals(False)  # Unblock signals
 
-        if self.parent_widget is not None and hasattr(self.parent_widget, "viewer"):
-            update_text_overlay(self.parent_widget.viewer,
-                                self.parent_widget.microscope,
-                                objective_position=objective_position)  # TODO: migrate to objective_position_changed signal
+        if self.parent_widget is not None:
+            if getattr(self.parent_widget, "viewer", None) is not None:
+                update_text_overlay(self.parent_widget.viewer,
+                                    self.parent_widget.microscope,
+                                    objective_position=objective_position)  # TODO: migrate to objective_position_changed signal
+            # quad-view info bar (OBJECTIVE on the FM canvas), via the controller
+            controller = None
+            try:
+                controller = self.parent_widget._view_controller()
+            except Exception:
+                controller = None
+            if controller is not None:
+                controller.update_info(self.parent_widget.microscope,
+                                       objective_position=objective_position)
 
     @pyqtSlot(float)
     def on_objective_position_changed(self, position: float):
@@ -518,6 +531,36 @@ class ObjectiveControlWidget(QWidget):
 
         event.handled = True
 
+    def _on_canvas_scroll(self, x, y, direction, modifiers):
+        """Quad-view equivalent of :meth:`_on_mouse_wheel`: Shift + scroll on the FM
+        canvas steps the objective by the step size. Plain scroll is left to the canvas
+        (zoom). ``direction`` is +1/-1 per notch; ``modifiers`` is a set/tuple like
+        ``{"Shift"}``. The hardware move is debounced via ``_execute_wheel_move`` so
+        rapid scroll events coalesce into a single move.
+        """
+        if "Shift" not in modifiers:
+            return  # plain scroll -> canvas zoom
+
+        if self.parent_widget is None or self.parent_widget.is_acquisition_active:
+            return
+
+        step_um = float(
+            np.clip(
+                self.doubleSpinBox_objective_step_size.value() * direction,
+                -MAX_OBJECTIVE_STEP_SIZE_UM,
+                MAX_OBJECTIVE_STEP_SIZE_UM,
+            )
+        )
+        new_pos_um = self.doubleSpinBox_objective_position.value() + step_um
+
+        # update spinbox immediately for visual feedback (no hardware call)
+        self.doubleSpinBox_objective_position.blockSignals(True)
+        self.doubleSpinBox_objective_position.setValue(new_pos_um)
+        self.doubleSpinBox_objective_position.blockSignals(False)
+
+        self._wheel_target_um = new_pos_um
+        self._execute_wheel_move()
+
     def _execute_wheel_move_impl(self):
         """Execute the actual hardware move after scrolling settles."""
         position_um = self._wheel_target_um
@@ -530,3 +573,20 @@ class ObjectiveControlWidget(QWidget):
             logging.error(f"Objective wheel move failed: {e}", exc_info=e)
             notification_service.show_toast(f"Objective move failed: {e}", "warning")
             self.update_objective_position_labels()  # re-sync to actual position
+
+    def cleanup(self):
+        """Drop the napari mouse-wheel callback and any pending debounced move.
+
+        Call on widget teardown: the callback binds this widget onto a viewer that
+        outlives it, so without this a scroll after a microscope reconnect drives a dead
+        widget — and PyQt turns an exception in a callback into qFatal (FIB-329)."""
+        try:
+            self._execute_wheel_move.cancel()
+        except Exception:
+            pass
+        if (self.parent_widget is not None
+                and getattr(self.parent_widget, "viewer", None) is not None):
+            try:
+                self.parent_widget.viewer.mouse_wheel_callbacks.remove(self._on_mouse_wheel)
+            except (ValueError, RuntimeError):
+                pass

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -3,7 +3,6 @@ import os
 import threading
 from typing import List, Optional, Union
 
-import napari
 from PyQt5.QtCore import QEvent, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QCheckBox,
@@ -19,7 +18,6 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 from superqt import ensure_main_thread
-from napari.layers import Image as NapariImageLayer
 from fibsem import conversions, utils
 from fibsem import config as fcfg
 from fibsem.fm.acquisition import acquire_image
@@ -34,10 +32,7 @@ from fibsem.fm.structures import (
     ZParameters,
 )
 from fibsem.microscope import FibsemMicroscope
-from fibsem.structures import (
-    FibsemStagePosition,
-    Point,
-)
+from fibsem.structures import Point
 from fibsem.ui.fm.widgets import (
     AutofocusWidget,
     CameraWidget,
@@ -46,7 +41,7 @@ from fibsem.ui.fm.widgets import (
     ObjectiveControlWidget,
     ZParametersWidget,
 )
-from fibsem.ui.napari.utilities import is_position_inside_layer, update_text_overlay
+from fibsem.ui import notification_service
 from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
@@ -67,7 +62,7 @@ class FMControlWidget(QWidget):
     def __init__(
         self,
         microscope: FibsemMicroscope,
-        viewer: napari.Viewer,
+        viewer=None,  # optional: quad-view hosts run viewer-less
         parent: Optional[QWidget] = None,
     ):
         super().__init__(parent)
@@ -97,14 +92,19 @@ class FMControlWidget(QWidget):
         self._acquisition_stop_event = threading.Event()
         self._current_acquisition_type: Optional[str] = None
 
+        # FM canvas click context (quad-view): retained from the latest image so a
+        # double-click can convert pixel -> stage without napari layer metadata
+        self._fm_pixelsize: Optional[float] = None
+        self._fm_image_shape: Optional[tuple] = None
+        self._fm_canvas = None  # quad-view FM canvas we connect to (for teardown)
+        self._fm_move_lock = threading.Lock()  # serialize canvas-driven stage moves
+
         # guards the debounced working-state autosave while applying a config
         self._loading_config = False
 
         self.initUI()
         self.connect_signals()
         self._update_acquisition_button_states()
-
-        update_text_overlay(self.viewer, self.microscope)
 
     def initUI(self):
         """Initialize the user interface."""
@@ -320,7 +320,18 @@ class FMControlWidget(QWidget):
             self._on_fm_settings_changed
         )
 
-        self.viewer.mouse_double_click_callbacks.append(self.on_mouse_double_click)
+        # Route FM canvas double-click (-> relative move) and Shift+scroll (-> objective)
+        # to the matplotlib canvas, replacing the napari viewer's double-click hook.
+        controller = self._view_controller()
+        if controller is not None:
+            # bound methods (not lambdas) so they can be disconnected on teardown; the
+            # canvas outlives this widget, so a leaked connection would drive a stale
+            # stage move through a destroyed widget
+            self._fm_canvas = controller.fm_canvas
+            self._fm_canvas.canvas_double_clicked.connect(self._on_canvas_fm_double_click)
+            self._fm_canvas.canvas_scrolled.connect(
+                self.objectiveControlWidget._on_canvas_scroll
+            )
 
         # Update checkbox text when lamella selection changes
         if self.parent_widget is not None and hasattr(
@@ -333,14 +344,32 @@ class FMControlWidget(QWidget):
         # Initialize checkbox text
         self._update_checkbox_text()
 
-    def close_widget(self):
-        """Close the widget."""
+    def _teardown_connections(self):
+        """Disconnect every external signal/callback wired in connect_signals.
 
-        # disconnect signals
-        self.fm.acquisition_signal.disconnect(self.update_image)
-        self.viewer.mouse_double_click_callbacks.remove(self.on_mouse_double_click)
+        Idempotent and fully guarded, so it can be called from ``closeEvent`` AND from
+        the host's teardown (the ``deleteLater`` path, where ``closeEvent`` never
+        fires). The quad-view ``fm_canvas`` outlives this widget, so its connections
+        MUST come down or a stale double-click/scroll drives the stage or objective
+        through a destroyed widget — and PyQt turns that into qFatal (FIB-329).
+        """
+        try:
+            self.fm.acquisition_signal.disconnect(self.update_image)
+        except (TypeError, RuntimeError):
+            pass
 
-        # Disconnect lamella list signal if connected
+        if self._fm_canvas is not None:
+            for signal, slot in (
+                (self._fm_canvas.canvas_double_clicked, self._on_canvas_fm_double_click),
+                (self._fm_canvas.canvas_scrolled, self.objectiveControlWidget._on_canvas_scroll),
+            ):
+                try:
+                    signal.disconnect(slot)
+                except (TypeError, RuntimeError):
+                    pass
+            self._fm_canvas = None
+        self.objectiveControlWidget.cleanup()
+
         if self.parent_widget is not None and hasattr(
             self.parent_widget, "lamella_list"
         ):
@@ -348,80 +377,73 @@ class FMControlWidget(QWidget):
                 self.parent_widget.lamella_list.lamella_selected.disconnect(
                     self._update_checkbox_text
                 )
-            except Exception:
+            except (TypeError, RuntimeError):
                 pass
 
+    def close_widget(self):
+        """Disconnect external signals and close the widget."""
+        self._teardown_connections()
         self.close()
 
-    def on_mouse_double_click(self, viewer, event):
-        # only left clicks
-        if event.button != 1:
-            return
+    def _fm_relative_move_from_pixel(self, x, y, image_shape, pixelsize):
+        """Convert an FM-image pixel (x=col, y=row) into a relative stage move that
+        recentres that point, then move via ``fm_stable_move``.
 
-        # Prevent stage movement during acquisitions
-        if self.is_acquisition_active:
-            logging.info("Stage movement disabled during acquisition")
-            event.handled = True
-            return
+        ``fm_stable_move`` undoes the display transform itself (``FluorescenceMicroscope
+        ._transform``) and projects through the camera's axis tilt, so the move is
+        foreshortening-correct and holds focus. Do NOT pre-apply the camera transform
+        here — that would double-apply it (see #198 / FIB-133).
 
-        logging.info(f"-" * 50)
-
-        selected_layer: Optional[NapariImageLayer] = None
-        movement_type = None
-        ALT_MODIFIER = "Alt" in event.modifiers
-
-        fm_image_layers = []
-        for layer in self.viewer.layers:
-            if isinstance(layer, NapariImageLayer) and "FM Image" in layer.name:
-                fm_image_layers.append(layer.name)
-
-        for fm_layer in fm_image_layers:
-            if is_position_inside_layer(event.position, self.viewer.layers[fm_layer]):
-                selected_layer = self.viewer.layers[fm_layer]
-                pixelsize = selected_layer.metadata.get("pixel_size_x", None)
-                image_shape = selected_layer.data.shape[-2:]
-                movement_type = "FM"
-                break
-
-        if selected_layer is None:
-            logging.info(f"Position {event.position} is not in any valid layer")
-            return
-
-        if pixelsize is None:
-            logging.info("Pixelsize is None")
-            return
-
-        if not self.microscope.fm.has_valid_orientation():
-            logging.info(f"Stage must be in a valid FM orientation to move stage via FM (current: {self.microscope.get_stage_orientation()})")
-            event.handled = True
-            return
-
-        # convert from image coordinates to microscope coordinates
-        coords = selected_layer.world_to_data(event.position)
-        if len(coords) in [3, 4]:
-            coords = coords[-2:]
-
+        The click keeps the sign convention the beam paths use (y up-positive, straight
+        out of ``image_to_microscope_image_coordinates2``). There used to be a
+        ``-point_clicked[1]`` here, calibrated at t=0; on a compustage the projection
+        already reverses y between t=0 and t=-180, so a constant negation can only ever
+        be right at one of them.
+        """
         point_clicked = conversions.image_to_microscope_image_coordinates2(
-            coord=Point(x=coords[1], y=coords[0]),  # yx required
+            coord=Point(x=x, y=y),
             image_shape=image_shape,
             pixelsize=pixelsize,
         )
+        logging.info(f"FM relative move: {point_clicked}")
+        self.microscope.fm_stable_move(dx=point_clicked[0], dy=point_clicked[1])
 
-        logging.info(
-            f"Coordinates: {coords} - {point_clicked} - Movement Type {movement_type} - Alt Modifier {ALT_MODIFIER}"
-        )
-        if movement_type == "FM":
-            # fm_stable_move undoes the display transform and projects onto the tilted
-            # sample plane, so the move is foreshortening-correct and holds focus.
-            # Previously this was a raw relative move with neither correction.
-            #
-            # The click keeps the sign convention the beam paths use (y up-positive,
-            # straight out of image_to_microscope_image_coordinates2). There used to be
-            # a `-point_clicked[1]` here, calibrated at t=0; on a compustage the
-            # projection already reverses y between t=0 and t=-180, so a constant
-            # negation can only ever be right at one of them.
-            self.microscope.fm_stable_move(dx=point_clicked[0], dy=point_clicked[1])
-        logging.info(f"-" * 50)
+    def _on_canvas_fm_double_click(self, x, y, modifiers):
+        """Quad-view FM canvas double-click -> relative stage move that recentres the
+        clicked point. Every guard runs here on the UI thread, so a rejected click never
+        starts a thread; the move itself runs off-thread. Modifiers are ignored.
+        """
+        if self.is_acquisition_active:
+            logging.info("Stage movement disabled during acquisition")
+            return
+        if not self.microscope.fm.has_valid_orientation():
+            logging.info(
+                "Stage must be in a valid FM orientation to move via FM "
+                f"(current: {self.microscope.get_stage_orientation()})"
+            )
+            return
+        shape, pixelsize = self._fm_image_shape, self._fm_pixelsize
+        if shape is None or pixelsize is None:
+            logging.info("No FM image available to move from")
+            return
+        if not (0 <= x < shape[1] and 0 <= y < shape[0]):
+            return  # click landed outside the image area
+        # serialize: drop the click if a stage move is already running
+        if not self._fm_move_lock.acquire(blocking=False):
+            logging.info("FM stage move already in progress; ignoring click")
+            return
+        FunctionWorker(self._canvas_fm_move_worker, x, y, shape, pixelsize).start()
+
+    def _canvas_fm_move_worker(self, x, y, shape, pixelsize):
+        try:
+            self._fm_relative_move_from_pixel(x, y, shape, pixelsize)
+        except Exception as exc:
+            logging.exception("FM stage move failed")
+            notification_service.show_toast(
+                f"FM stage move failed: {exc}", notification_type="error"
+            )
+        finally:
+            self._fm_move_lock.release()
 
     def _on_channel_field_changed(self, channel, field: str, value) -> None:
         """Update a single microscope parameter during live acquisition."""
@@ -560,39 +582,29 @@ class FMControlWidget(QWidget):
         if not isinstance(image, FluorescenceImage):
             return
 
-        # Add to napari viewer
-        layer_name = f"FM Image {image.metadata.channels[0].name}"
-        colormap = (
-            image.metadata.channels[0].color if image.metadata.channels else "gray"
-        )
-        translation = (0, 0)
         data = image.data
         if data.ndim == 4 and data.shape[0] == 1 and data.shape[1] == 1:
-            data = data.squeeze(
-                axis=(0, 1)
-            )  # squish to 2D (required by napari for now)
+            data = data.squeeze(axis=(0, 1))  # squish to 2D
 
-        # get translation from eb_image layer if it exists
-        if "ELECTRON" in self.viewer.layers:
-            eb_layer = self.viewer.layers["ELECTRON"]
-            translation = (eb_layer.data.shape[0], 0)  # move it below the SEM image...
+        # retain click context for the FM canvas double-click -> move. The canvas emits
+        # data coords, so this is all the geometry that path needs — no layer metadata.
+        self._fm_pixelsize = getattr(image.metadata, "pixel_size_x", None)
+        self._fm_image_shape = data.shape[-2:]
 
-        if layer_name in self.viewer.layers:
-            self.viewer.layers[layer_name].data = data
-            self.viewer.layers[layer_name].metadata = image.metadata.to_dict()
-            self.viewer.layers[layer_name].translate = translation
-            self.viewer.layers[layer_name].colormap = colormap
-            self.viewer.layers[layer_name].blending = "additive"
-        else:
-            self.viewer.add_image(
-                data,
-                name=layer_name,
-                metadata=image.metadata.to_dict(),
-                colormap=colormap,
-                translate=translation,
-                blending="additive",
-            )
-            self.viewer.reset_view()
+        # Composite the acquired image onto the FM canvas via the controller. It handles
+        # per-channel colour and blending, which the napari layer stack used to do.
+        controller = self._view_controller()
+        if controller is not None:
+            controller.set_fm_image(image)
+
+    def _view_controller(self):
+        """The quad-view ``MicroscopeViewController`` on the main Microscope tab, or
+        ``None`` otherwise. Chain: this widget's ``parent_widget`` is the
+        ``AutoLamellaUI``, whose ``parent_widget`` is the main UI that owns the
+        ``view_controller``."""
+        autolamella_ui = self.parent_widget
+        main_ui = getattr(autolamella_ui, "parent_widget", None)
+        return getattr(main_ui, "view_controller", None)
 
     def _refuse_to_start(self, what: str) -> bool:
         """Whether *what* may not be started, having logged why. True means "do not".
@@ -1035,8 +1047,8 @@ class FMControlWidget(QWidget):
             event.accept()
             return
 
-        # Stop live acquisition
-        self.microscope.fm.acquisition_signal.disconnect(self.update_image)
+        # Disconnect every external signal/callback (idempotent), then stop live
+        self._teardown_connections()
         if self.microscope.fm.is_streaming:
             try:
                 self.microscope.fm.stop_acquisition()
@@ -1153,7 +1165,7 @@ class FMControlWidget(QWidget):
 
 def create_widget(
     microscope: FibsemMicroscope,
-    viewer: napari.Viewer,
+    viewer=None,
     parent: Optional[QWidget] = None,
 ) -> FMControlWidget:
     """Create the FMControlWidget with a demo microscope."""
@@ -1162,8 +1174,29 @@ def create_widget(
     return widget
 
 
+class _DemoHost(QWidget):
+    """Minimal stand-in for the AutoLamella chain this widget resolves through.
+
+    ``FMControlWidget._view_controller`` walks parent -> ``parent_widget`` -> the UI
+    holding ``view_controller``, so the harness has to present that shape or the FM
+    canvas stays empty and the demo looks broken.
+    """
+
+    def __init__(self):
+        from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+
+        super().__init__()
+        self.view_controller = MicroscopeViewController(parent=self)
+        self.parent_widget = self
+
+
 def main():
     """Main function to run the widget standalone."""
+    from PyQt5.QtCore import Qt
+    from PyQt5.QtWidgets import QApplication, QSplitter
+
+    from fibsem.ui.stylesheets import NAPARI_STYLE
+
     microscope, settings = utils.setup_session()
 
     if microscope.fm is None:
@@ -1176,10 +1209,20 @@ def main():
     assert microscope.system.stage.shuttle_pre_tilt == 0
     assert microscope.stage_is_compustage is True
 
-    viewer = napari.Viewer()
-    widget = create_widget(microscope, viewer)
-    viewer.window.add_dock_widget(widget, area="right")
-    napari.run()
+    app = QApplication.instance() or QApplication([])
+    app.setStyle("Fusion")
+
+    host = _DemoHost()
+    widget = create_widget(microscope, parent=host)
+
+    window = QSplitter(Qt.Horizontal)
+    window.setStyleSheet(NAPARI_STYLE)
+    window.addWidget(host.view_controller.widget)
+    window.addWidget(widget)
+    window.setSizes([720, 460])
+    window.resize(1280, 800)
+    window.show()
+    app.exec_()
     return
 
 

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -242,7 +242,11 @@ def _make_supervised_spot_burn_task(monkeypatch, tmp_path, ask_user_responses):
 
     widget = MagicMock()
     widget.is_burning = False  # each burn "completes" immediately
-    widget.get_coordinates.return_value = [Point(0.5, 0.5)]
+    # the task now reads back the whole settings object (coordinates + current +
+    # exposure), not just the coordinates — see update_spot_burn_parameters' typed contract
+    widget.get_settings.return_value = SpotBurnSettings(
+        coordinates=[Point(0.5, 0.5)], exposure_time=1.0, milling_current=1e-9
+    )
     parent_ui = MagicMock()  # truthy experiment.task_protocol.get_supervision -> supervised
     parent_ui.spot_burn_widget = widget
 
@@ -273,7 +277,7 @@ def test_supervised_spot_burn_runs_then_continues(monkeypatch, tmp_path):
     task.update_spot_burn_parameters_ui()
 
     widget.start_spot_burn_signal.emit.assert_called_once()
-    widget.get_coordinates.assert_called_once()
+    widget.get_settings.assert_called_once()
     assert cleared  # spot burn UI was cleared afterwards
 
 
@@ -286,7 +290,7 @@ def test_supervised_spot_burn_continue_without_running(monkeypatch, tmp_path):
     task.update_spot_burn_parameters_ui()
 
     widget.start_spot_burn_signal.emit.assert_not_called()
-    widget.get_coordinates.assert_called_once()
+    widget.get_settings.assert_called_once()
     assert cleared
 
 


### PR DESCRIPTION
Second half of the Microscope-tab cutover ([FIB-406](https://linear.app/fibsemos/issue/FIB-406)), on top of 4a ([#302](https://github.com/fibsem-os/fibsem-os/pull/302)). `AutoLamellaUI` runs viewer-less and `_create_main_tab` builds a `MicroscopeViewController` into the splitter where the napari viewer used to be.

**This leaves the minimap as the only napari viewer in the app.**

## No staging seam this time

4a worked because two shells host the image and movement widgets, so the standalone one could go first and exercise the canvas path for real. That does not apply here: spot burn, detection and FM control are constructed **only** by `AutoLamellaUI`. The widget ports and the shell flip have to land together.

## What moved

| Widget | Canvas equivalent |
| -- | -- |
| `objective_control_widget` | Shift+scroll on the FM canvas steps the objective (debounced) |
| `fluorescence_control_widget` | canvas double-click → stage move; `set_fm_image` replaces the layer stack |
| `FibsemEmbeddedDetectionWidget` | `MaskSpec` + a modal `PointsSpec`; drag-to-correct via `overlay_edited` |
| `FibsemSpotBurnWidget` | controller-owned point overlay |

The last two are now **completely napari-free**. Every widget grew a single teardown entry point, called from the host's disconnect path — the canvases outlive a reconnect, and `deleteLater` fires neither `closeEvent` nor `close`.

Worth being precise about why that matters, because it is not uniform: Qt auto-disconnects a slot whose receiver is a `QObject`, so bound methods clean themselves up on destruction. A `functools.partial` has no receiver and holds a strong reference, so calling it after the C++ object dies raises inside a slot — which PyQt5 turns into `qFatal` ([FIB-329](https://linear.app/fibsemos/issue/FIB-329)). The one `partial` connection here is the movement widget's double-click, and it has explicit teardown.

## New UX

View menu gains **Full Screen (F5)**, **Exit Full Screen (Esc)** and a per-view submenu; a new **Imaging** menu carries **Acquire (F2)**, **Live (F6)**, **Auto Contrast (F9)**, **Auto Focus (F11)**. F2 follows the selected view including FM; the other three are SEM/FIB only. All six are scoped to this tab via `WidgetWithChildrenShortcut` plus `container.addAction`, so they stay dead in the minimap, editor and workflow tabs.

The layer-controls submenu **keeps its Overview entry**. #111 removes the submenu outright as the last tab out, but the minimap still owns a viewer until [FIB-405](https://linear.app/fibsemos/issue/FIB-405).

## Three things in #111 I did not carry over

It predates fixes that have since landed on main, so lifting verbatim would have reintroduced all three:

**The compustage sign bug.** #111's FM double-click applies `-point_clicked[1]`. Main *removed* that negation deliberately — it was calibrated at t=0, and on a compustage the projection already reverses y between t=0 and t=-180, so a constant negation can only ever be right at one of them. Kept main's convention and carried its reasoning into the new method.

**A silently split contract.** #111 changes the spot-burn workflow from a `spot_burn_parameters` dict to a typed `SpotBurnSettings`. A 3-way merge applied the *reader* in `AutoLamellaUI` but not the *writer* in `workflows/ui.py` — `info.get("spot_burn_settings")` would have been `None` forever and spot-burn parameters would have stopped reaching the widget mid-workflow, with nothing raising. Exactly the [FIB-454](https://linear.app/fibsemos/issue/FIB-454) shape. Adopted the typed contract across all three files; `to_settings`/`apply_settings` already existed on main. Two tests asserting the old `get_coordinates()` call were updated.

**An inert guard.** #111's F2 handler guards the FM path with `getattr(fm_widget, "is_acquiring", False)`. That attribute does not exist on `FMControlWidget` — the property is `is_acquisition_active` — so the `getattr` default made the guard permanently false and F2 could start a second FM acquisition mid-run (cf. [FIB-441](https://linear.app/fibsemos/issue/FIB-441) / [FIB-436](https://linear.app/fibsemos/issue/FIB-436)).

## Verification — and one part of this PR has none

**`FibsemEmbeddedDetectionWidget` (303 changed lines) is unverified by any means.** It is gated behind `DETECTION_AVAILABLE`, and this environment has neither `torch` nor `segmentation_models_pytorch` — so it is not importable, not testable, and **was never constructed when the app was run**. An earlier version of this description claimed the manual pass covered it; it did not. Two attempts to salvage headless coverage by stubbing the ML stack were abandoned as proving too little. **It needs an environment with the ML extra, or a bench session that exercises a detection step.** That is the risk concentrated in one place.

Everything else:

- the app was launched and driven — on 4a that was the only thing that caught three defects 925 passing tests did not
- 1,499 tests pass across `tests/ui` and `tests/autolamella`
- an AST pass over every changed class confirms no method lost its tail (the 4a failure mode); every removal is a rename or a replacement, and a call-site sweep found nothing orphaned
- no new lint against main's baseline

`AutoLamellaMainUI` **still cannot be constructed headless**, because `add_minimap_tab` creates a napari viewer and napari's GL canvas aborts the process under `QT_QPA_PLATFORM=offscreen`. So the flipped tab gets no end-to-end automated coverage until FIB-405 lands.

**Still needs hardware**: live imaging on both beams, click/double-click to move, detection → mill, spot burn, FM acquisition and the coincidence viewer. [FIB-358](https://linear.app/fibsemos/issue/FIB-358) applies from here on — unlike 4a, this tab does host the FM canvas.
