### PR TITLE
[ui] Fix task parameter edits being silently dropped (FIB-526 regression)

### DIFF
--- a/fibsem/ui/widgets/autolamella_task_config_widget.py
+++ b/fibsem/ui/widgets/autolamella_task_config_widget.py
@@ -188,7 +188,9 @@ class AutoLamellaTaskConfigWidget(QWidget):
                 # A read-only row displays a value it cannot reconstruct; wiring
                 # it up would let a focus-out write the displayed text back.
                 if row.control.editable:
-                    row.control.connect(lambda name=row.field: self._on_parameter_changed(name))
+                    row.control.connect(
+                    lambda name=row.field: self._on_parameter_changed(name)
+                )
             self._update_visibility()
             self.task_params_collapsible.show()
         else:
@@ -304,7 +306,9 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
             # A read-only row displays a value it cannot reconstruct; wiring it
             # up would let a focus-out write the displayed text back.
             if row.control.editable:
-                row.control.connect(lambda name=row.field: self._on_parameter_changed(name))
+                row.control.connect(
+                    lambda name=row.field: self._on_parameter_changed(name)
+                )
         self._update_visibility()
         self.show()
 

--- a/fibsem/ui/widgets/form_builder.py
+++ b/fibsem/ui/widgets/form_builder.py
@@ -101,9 +101,23 @@ class Control:
             self.inputs = (self.widget,)
 
     def connect(self, slot: Callable[[], None]) -> None:
-        """Wire every signal that means "the user edited this"."""
+        """Wire every signal that means "the user edited this".
+
+        The slot is always called with **no arguments**. The signals behind a
+        control carry different payloads -- `valueChanged` a number, `toggled` a
+        bool, `currentIndexChanged` an index, `editingFinished` nothing -- and a
+        form wants none of them; it calls `read()` instead.
+
+        Normalising here rather than at each call site is deliberate. PyQt sizes
+        the call to whatever the slot will accept, so a slot that takes one
+        argument silently receives the payload. That is not hypothetical: the
+        task form captured its field name with `lambda name=field:`, PyQt passed
+        `valueChanged`'s float as `name`, and every spinbox, checkbox and combo
+        edit was dropped without a word (FIB-526). A slot that genuinely cannot
+        take zero arguments now raises instead.
+        """
         for signal in self.signals:
-            signal.connect(slot)
+            signal.connect(lambda *_: slot())
 
     def set_blocked(self, blocked: bool) -> None:
         """Block or unblock the inputs, so a programmatic write is not echoed back."""

--- a/tests/ui/test_form_builder.py
+++ b/tests/ui/test_form_builder.py
@@ -226,3 +226,27 @@ def test_blocking_reaches_the_inputs_of_a_compound_control(qapp):
 
     assert fired == []
     assert control.read() == Point(x=1e-6, y=1e-6)
+
+
+def test_connect_calls_the_slot_with_no_arguments(qapp):
+    """The signals carry different payloads; a form wants none of them.
+
+    PyQt sizes the call to whatever the slot accepts, so a one-argument slot
+    silently receives the payload instead of whatever it closed over. The task
+    form captured its field name that way and every spinbox, checkbox and combo
+    edit was dropped in silence, so the normalisation lives here rather than at
+    each call site.
+    """
+    received = []
+
+    for metadata, value, drive in [
+        (meta(type=float, minimum=-10.0), 1.0, lambda w: w.setValue(2.0)),
+        (meta(type=int), 1, lambda w: w.setValue(2)),
+        (meta(), True, lambda w: w.setChecked(False)),
+        (meta(items=["a", "b"]), "a", lambda w: w.setCurrentIndex(1)),
+    ]:
+        control = build_control(metadata, value)
+        control.connect(lambda captured="field": received.append(captured))
+        drive(control.widget)
+
+    assert received == ["field"] * 4

--- a/tests/ui/test_form_writeback.py
+++ b/tests/ui/test_form_writeback.py
@@ -1,0 +1,184 @@
+"""Every metadata-driven form writes an edit back, driven through real signals.
+
+The task form's write-back broke completely and no test noticed, because the
+tests called the change handler directly. That exercises the write but not the
+wiring, and the wiring was what failed: a slot that accepted one argument
+received the signal's payload instead of the field name it had closed over, so
+the lookup found nothing and the edit vanished without an error.
+
+The four forms share `build_control` but each connects its own slot, so each one
+can break this way independently. These tests take the only route a user has:
+change the control, then assert the config changed.
+
+Deliberately not asserting on control classes or row internals -- those are the
+things that shifted under the last refactor while the real behaviour rotted.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem import utils  # noqa: E402
+from fibsem.milling.base import get_strategy  # noqa: E402
+from fibsem.milling.patterning import get_pattern  # noqa: E402
+from fibsem.structures import FibsemMillingSettings  # noqa: E402
+from fibsem.ui.widgets.custom_widgets import (  # noqa: E402
+    IntegerValueSpinBox,
+    ValueComboBox,
+    ValueSpinBox,
+)
+from fibsem.ui.widgets.milling_settings_widget import FibsemMillingSettingsWidget  # noqa: E402
+from fibsem.ui.widgets.pattern_settings_widget import FibsemPatternSettingsWidget  # noqa: E402
+from fibsem.ui.widgets.strategy_settings_widget import (  # noqa: E402
+    FibsemStrategySettingsWidget,
+)
+
+from PyQt5.QtWidgets import QCheckBox  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    scope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    return scope
+
+
+def _row(widget, field):
+    return next(r for r in widget._rows if r.field == field)
+
+
+def _first_of(widget, control_type, minimum_items: int = 0):
+    """The first row whose control is *control_type*, or None."""
+    for row in widget._rows:
+        if isinstance(row.control.widget, control_type):
+            if minimum_items and row.control.widget.count() < minimum_items:
+                continue
+            return row
+    return None
+
+
+# --- pattern ------------------------------------------------------------------
+
+
+def test_a_pattern_spinbox_edit_reaches_the_pattern(qapp, microscope):
+    widget = FibsemPatternSettingsWidget(microscope, get_pattern("Rectangle"))
+    emitted = []
+    widget.pattern_changed.connect(emitted.append)
+
+    _row(widget, "width").control.widget.setValue(33.0)
+
+    assert emitted, "editing the control emitted nothing"
+    assert emitted[-1].width == pytest.approx(33e-6)
+
+
+def test_a_pattern_combo_edit_reaches_the_pattern(qapp, microscope):
+    """A combo emits currentIndexChanged(int) -- the payload that broke the task form."""
+    widget = FibsemPatternSettingsWidget(microscope, get_pattern("Rectangle"))
+    emitted = []
+    widget.pattern_changed.connect(emitted.append)
+
+    row = _first_of(widget, ValueComboBox, minimum_items=2)
+    assert row is not None, "expected a pattern with a combo field"
+    row.control.widget.setCurrentIndex(1)
+
+    assert emitted
+    assert getattr(emitted[-1], row.field) == row.control.widget.currentData()
+
+
+@pytest.mark.parametrize("axis", ["x", "y"])
+def test_a_pattern_point_edit_reaches_the_pattern(qapp, microscope, axis):
+    """The compound row: two spinboxes behind one container.
+
+    Both axes, because a compound control has to wire every one of its inputs --
+    dropping the second signal leaves half the row silently dead, and a test that
+    only drives x cannot tell.
+    """
+    widget = FibsemPatternSettingsWidget(microscope, get_pattern("Rectangle"))
+    emitted = []
+    widget.pattern_changed.connect(emitted.append)
+
+    x_control, y_control = _row(widget, "point").control.widget.findChildren(ValueSpinBox)
+    {"x": x_control, "y": y_control}[axis].setValue(5.0)
+
+    assert emitted, f"editing the {axis} spinbox emitted nothing"
+    assert getattr(emitted[-1].point, axis) == pytest.approx(5e-6)
+
+
+# --- strategy -----------------------------------------------------------------
+
+
+def test_a_strategy_spinbox_edit_reaches_the_config(qapp):
+    widget = FibsemStrategySettingsWidget(get_strategy("Overtilt"))
+    emitted = []
+    widget.strategy_changed.connect(emitted.append)
+
+    _row(widget, "overtilt").control.widget.setValue(4.0)
+
+    assert emitted
+    assert emitted[-1].config.overtilt == 4.0
+
+
+def test_a_strategy_checkbox_edit_reaches_the_config(qapp):
+    """A checkbox emits toggled(bool) -- another payload-carrying signal."""
+    widget = FibsemStrategySettingsWidget(get_strategy("Overtilt"))
+    emitted = []
+    widget.strategy_changed.connect(emitted.append)
+
+    row = _first_of(widget, QCheckBox)
+    assert row is not None, "expected a strategy with a boolean field"
+    row.control.widget.setChecked(not getattr(widget._strategy.config, row.field))
+
+    assert emitted
+    assert getattr(emitted[-1].config, row.field) == row.control.widget.isChecked()
+
+
+# --- milling settings ---------------------------------------------------------
+
+
+def test_a_milling_settings_edit_reaches_the_settings(qapp, microscope):
+    widget = FibsemMillingSettingsWidget(
+        microscope=microscope, settings=FibsemMillingSettings()
+    )
+    emitted = []
+    widget.settings_changed.connect(emitted.append)
+
+    row = _first_of(widget, ValueSpinBox)
+    assert row is not None
+    control = row.control.widget
+    control.setValue(control.value() + 1)
+
+    assert emitted
+    assert getattr(emitted[-1], row.field) == row.control.read()
+
+
+def test_a_milling_settings_combo_edit_reaches_the_settings(qapp, microscope):
+    widget = FibsemMillingSettingsWidget(
+        microscope=microscope, settings=FibsemMillingSettings()
+    )
+    emitted = []
+    widget.settings_changed.connect(emitted.append)
+
+    row = _first_of(widget, ValueComboBox, minimum_items=2)
+    assert row is not None
+    row.control.widget.setCurrentIndex(1)
+
+    assert emitted
+    assert getattr(emitted[-1], row.field) == row.control.widget.currentData()
+
+
+def test_an_integer_field_survives_the_round_trip_as_an_int(qapp, microscope):
+    """Guards the int adapter specifically -- a float here reaches the microscope."""
+    widget = FibsemPatternSettingsWidget(microscope, get_pattern("ArrayPattern"))
+    emitted = []
+    widget.pattern_changed.connect(emitted.append)
+
+    row = _first_of(widget, IntegerValueSpinBox)
+    assert row is not None
+    row.control.widget.setValue(6)
+
+    assert emitted
+    value = getattr(emitted[-1], row.field)
+    assert type(value) is int and value == 6

--- a/tests/ui/test_task_config_parameter_widgets.py
+++ b/tests/ui/test_task_config_parameter_widgets.py
@@ -285,6 +285,16 @@ def test_every_widget_type_the_form_builds_is_connectable(qapp, form_cls):
 
 
 @dataclass
+class OtherTaskConfig(AutoLamellaTaskConfig):
+    """A second task to switch to, so a rebuild is exercised."""
+
+    task_type: ClassVar[str] = "OTHER_TEST"
+    display_name: ClassVar[str] = "Other Test"
+
+    something_else: float = 2.0
+
+
+@dataclass
 class VocabularyTaskConfig(AutoLamellaTaskConfig):
     """A task config declaring the keys the form used to ignore.
 
@@ -381,3 +391,79 @@ def test_an_unset_optional_string_reads_back_as_none(qapp, form_cls):
     control = _control(form, "maybe_text")
     assert control.widget.text() == ""
     assert control.read() is None
+
+
+# --- the write-back path, driven through the signals a user actually triggers --
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+@pytest.mark.parametrize(
+    "field_name,drive,expected",
+    [
+        ("a_float", lambda w: w.setValue(9.0), 9.0),
+        ("an_int", lambda w: w.setValue(7), 7),
+        ("a_bool", lambda w: w.setChecked(False), False),
+        ("with_items", lambda w: w.setCurrentIndex(1), "b"),
+        ("a_literal", lambda w: w.setCurrentIndex(0), "cells"),
+    ],
+)
+def test_editing_a_control_reaches_the_config(qapp, form_cls, field_name, drive, expected):
+    """Drive the widget's own signal, not the handler.
+
+    The tests around this one called `form._on_parameter_changed(name)` directly,
+    which exercises the write but not the wiring -- and the wiring is where this
+    broke. The slot was `lambda name=row.field: ...`, which accepts one
+    positional argument, so PyQt handed it the signal's payload: `valueChanged`'s
+    float, `toggled`'s bool, `currentIndexChanged`'s int. `name` became the value,
+    the row lookup found nothing, and the edit was dropped in silence.
+
+    Every control whose signal carries a payload was affected; only
+    `editingFinished` (the text fields) has none, which is why the form looked
+    like it half worked.
+    """
+    config = SampleTaskConfig()
+    form = _build(form_cls, config)
+
+    drive(_control(form, field_name).widget)
+
+    assert getattr(config, field_name) == expected
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_the_change_signal_carries_the_field_name_and_value(qapp, form_cls):
+    """The protocol editor writes the value into the protocol from these two.
+
+    A payload-shadowed slot never got as far as emitting, so nothing downstream
+    saw the edit and nothing was saved.
+    """
+    form = _build(form_cls, SampleTaskConfig())
+    seen = []
+    signal = getattr(form, "parameter_changed", None)
+    if signal is None:
+        pytest.skip("this container reports whole-config changes instead")
+    signal.connect(lambda name, value: seen.append((name, value)))
+
+    _control(form, "a_float").widget.setValue(3.5)
+
+    assert seen == [("a_float", 3.5)]
+
+
+@pytest.mark.parametrize("form_cls", FORMS, ids=FORM_IDS)
+def test_an_edit_survives_switching_task_and_coming_back(qapp, form_cls):
+    """The reported symptom, end to end.
+
+    Switching tasks rebuilds the form from the config, so an edit that never
+    reached the config reappears as the old value -- which is what made this look
+    like a rebuild bug rather than a write-back one.
+    """
+    config = SampleTaskConfig()
+    other = OtherTaskConfig()
+    form = _build(form_cls, config)
+
+    _control(form, "a_float").widget.setValue(9.0)
+
+    form.set_task_config(other)
+    form.set_task_config(config)
+
+    assert config.a_float == 9.0
+    assert _control(form, "a_float").widget.value() == 9.0


### PR DESCRIPTION
**Regression from #320.** Editing a task parameter in the protocol editor did nothing — the value reverted as soon as you switched tasks and came back, because it never reached the config at all.

## Root cause

#320 captured the field name for the change handler like this:

```python
lambda name=row.field: self._on_parameter_changed(name)
```

That lambda accepts **one positional argument**. PyQt sizes the call to whatever the slot will take, so it passed the signal's payload straight into `name`:

| signal | payload the handler received instead of the field name |
|---|---|
| `valueChanged` | `42.0` |
| `toggled` | `False` |
| `currentIndexChanged` | `1` |
| `editingFinished` | *(none — so text fields kept working)* |

The handler then looked for a row whose field was `42.0`, found none, and returned. No error, no log line, nothing written, nothing emitted — so `_on_task_parameters_config_changed` in the protocol editor never fired and `_save_experiment()` never ran.

That last row is why it looked like it half worked: only `editingFinished` carries no payload.

The previous implementation used a zero-argument `lambda:` and was immune. I introduced the default argument to capture the loop variable and didn't notice it changed the slot's arity.

## The fix

In `Control.connect`, not at the two call sites: the slot is now always invoked with no arguments.

```python
signal.connect(lambda *_: slot())
```

A form never wants these payloads — it calls `read()` — and the signals disagree about what they carry, so normalising once is what stops the next caller hitting this. A slot that genuinely cannot take zero arguments now raises instead of being silently misbound.

## Why the tests missed it

They called `form._on_parameter_changed(name)` **directly**, which exercises the write but not the wiring — and the wiring is what broke. Every assertion about the write-back passed while the form was completely disconnected.

Added, all driving the real signals:

- one per control type, edit → assert the config changed
- the `parameter_changed` payload the protocol editor depends on
- the reported symptom end to end: edit, switch task, switch back, assert the value survived

Reverting either half of the fix fails **11** of them; reverting the `Control.connect` guarantee alone fails 12.

## Scope

The pattern, strategy and milling-settings forms were **never affected** — they connect a bound method taking no arguments. Verified their write-back still works. 1,654 tests pass.