### PR TITLE
[ui] Outline the correlation point labels so they survive a bright image

### DIFF
--- a/fibsem/ui/correlation/widgets/correlation_point_overlay.py
+++ b/fibsem/ui/correlation/widgets/correlation_point_overlay.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
+import matplotlib.patheffects as pe
 from PyQt5.QtCore import pyqtSignal
 
 from fibsem.correlation.structures import Coordinate, PointType
@@ -54,6 +55,14 @@ POINT_MARKERS: Dict[PointType, str] = {
     PointType.SURFACE_FM: "+",
 }
 MARKER_SIZE = 5.0  # the base draws the selected marker at size * 1.4 = 7.0
+
+# Every label colour above is a bright saturated hue, so a dark stroke is the
+# complement of all of them: it rescues SURFACE and FM-SURFACE against a bright
+# image, where they otherwise disappear entirely. A *white* stroke is the wrong
+# choice for the same reason -- it merges into a bright background, which is
+# exactly where the outline has to work. 0.5 matches the old canvas; heavier
+# starts eating the glyph at this font size.
+LABEL_OUTLINE = [pe.withStroke(linewidth=0.5, foreground="black")]
 
 
 def generate_names(coordinates: List[Coordinate]) -> List[str]:
@@ -224,9 +233,11 @@ class CorrelationPointOverlay(PointOverlay):
 
     def _append_artist(self, idx: int) -> None:
         super()._append_artist(idx)
-        # a point added while labels are off must not arrive with its name showing
-        if self._anns and self._anns[-1] is not None:
-            self._anns[-1].set_visible(self._labels_visible and self._visible)
+        ann = self._anns[-1] if self._anns else None
+        if ann is not None:
+            # a point added while labels are off must not arrive showing its name
+            ann.set_visible(self._labels_visible and self._visible)
+            ann.set_path_effects(LABEL_OUTLINE)
 
     def _legend_entries(self):
         """One swatch per PointType currently on screen.

--- a/tests/correlation/test_correlation_point_overlay.py
+++ b/tests/correlation/test_correlation_point_overlay.py
@@ -313,3 +313,34 @@ def test_labels_renumber_and_stay_hidden_after_a_removal():
     ov.remove_coordinate(a)
     assert [ov._point_label(i) for i in range(2)] == ["FIB 1", "FIB 2"]
     assert _label_states(ov) == [False, False]
+
+
+# ── label legibility ──────────────────────────────────────────────────────
+
+
+def test_labels_carry_a_dark_outline():
+    """Every label colour is a bright saturated hue, so SURFACE and FM-SURFACE
+    vanish against a bright image without a dark stroke behind them. Matches the
+    old canvas, which applies the same effect at three sites."""
+    import matplotlib.patheffects as pe
+
+    _, ov = _attached([_coord(10, 10, PointType.SURFACE), _coord(20, 20)])
+    for ann in ov._anns:
+        assert ann is not None
+        effects = ann.get_path_effects()
+        assert effects, "label has no outline"
+        assert any(isinstance(e, pe.withStroke) for e in effects)
+
+
+def test_the_outline_is_dark_not_light():
+    """A white stroke would merge into a bright background -- exactly where the
+    outline has to work -- so the foreground must be dark."""
+    _, ov = _attached([_coord(10, 10)])
+    stroke = ov._anns[0].get_path_effects()[0]
+    assert stroke._gc.get("foreground") == "black"
+
+
+def test_a_point_added_later_gets_the_outline_too():
+    _, ov = _attached([_coord(10, 10)])
+    ov.add_coordinate(_coord(20, 20, PointType.POI))
+    assert all(a.get_path_effects() for a in ov._anns if a is not None)


### PR DESCRIPTION
Follow-up to #321 / #324 / #325 — part of the correlation canvas consolidation ([the Linear issue](https://linear.app/fibsemos/issue/FIB-535/consolidate-the-correlation-point-canvas-onto-the-shared-canvas-stack)).

> The identifier is kept out of the title and commit subject deliberately: it auto-closed that issue on all three previous merges, including once when written as "(partial)". Linear matches it anywhere in the text.

## The defect

Found while checking whether the export path (`render_to_axes`) actually needed porting — it mostly doesn't, but the check turned this up instead.

The new correlation overlay draws its point labels with **no stroke behind them**, while the canvas it replaces applies one at three separate sites. Missed when the marker rules were ported in #321.

It matters because every label colour is a bright saturated hue. Over a blown-out region — routine on FM data — `SURFACE` (orange) and `FM-SURFACE` (yellow) become effectively invisible.

## Black, not white

Checked rather than assumed, by rendering all five point colours over a black-to-white gradient with four treatments:

| | result |
| --- | --- |
| no outline | SURFACE and FM-SURFACE vanish at the bright end |
| **black, lw=0.5** | **rescues both; dark end unaffected** |
| black, lw=1.5 | too heavy, the stroke starts eating the glyph |
| white, lw=1.5 | useless — merges into the bright background, which is exactly where the outline has to work; adds glare at the dark end where labels were already legible |

A dark stroke is the complement of all five colours. A white one is nearly the same *value* as several of them, so it does nothing where it is needed and adds noise where it is not.

`linewidth=0.5` matches the old canvas exactly, so this is parity with what ships today rather than a new choice.

## Scope

Applied in `CorrelationPointOverlay`, on the annotation the base already creates:

```python
ann.set_path_effects(LABEL_OUTLINE)
```

No base-class change, so the five other `PointOverlay` consumers are untouched. They would benefit too — any coloured label over image data has this problem — but that is five shipped widgets and a separate decision.

## Testing

`1362 passed, 7 skipped` — `tests/correlation/`, `tests/ui/`. Three new tests, mutation-checked:

| deliberate break | caught by |
| --- | --- |
| outline never applied | 3 tests |
| white stroke instead of black | `test_the_outline_is_dark_not_light` |

Verified visually on the real widget over a deliberately blown-out gradient, not just in the abstract.

## Incidentally settled: `render_to_axes` is smaller than billed

The issue lists it as 78 lines with no prior art. Investigating showed the premise was wrong — it is *not* there because `animated=True` artists get dropped by `savefig`. `ImagePointCanvas._on_draw_event` calls `draw_artist` for every animated artist on every draw, including the one `savefig` triggers, so export works on both canvases:

```
OLD  canvas.figure.savefig()             FIB 571px  SURFACE 1808px   captured
OLD  render_to_axes() [current path]     FIB 539px  SURFACE  425px   captured
NEW  canvas.figure.savefig()             FIB 479px  SURFACE  386px   captured
```

The real requirement is duller: the export is a **two-panel** figure and needs content from two canvases in one output. Composing from per-canvas buffers reproduces it in roughly 10 lines instead of 78 — leaving only the crosshair to suppress (`set_crosshair_visible(False)`, already on the shared canvas) and this label outline, which is why it is fixed first.
