### PR TITLE
[fm] Choose the objective position an overview starts from (FIB-417)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -24,6 +24,7 @@ from fibsem.fm.structures import (
     AutoFocusMode,
     ChannelSettings,
     FluorescenceImage,
+    ObjectiveStartPosition,
     OverviewParameters,
     ZParameters,
     ZStackOrder,
@@ -663,6 +664,10 @@ class FMTiledAcquisitionRunner:
         # Captured for the restore in _restore(). The grid's centre defaults to it --
         # an overview is normally taken of what you are looking at -- but a caller can
         # name somewhere else, and then the stage still comes back here afterwards.
+        # Before the objective is read for anything else: a retracted objective makes
+        # every number below it meaningless, and the run impossible.
+        self._require_inserted_objective()
+
         self._initial_position = microscope.get_stage_position()
         self._initial_objective_position = microscope.fm.objective.position
         # Where tiles are acquired, which is only the same thing until an autofocus
@@ -670,7 +675,7 @@ class FMTiledAcquisitionRunner:
         # run does not accumulate drift -- but resetting to where the *run* started
         # threw away whatever the sweep had just found, and `once` and `each_row` do
         # their sweeping before the tile that would use it (FIB-516).
-        self._tile_objective_position = self._initial_objective_position
+        self._tile_objective_position = self._resolve_objective_start()
         if self.centre_position is None:
             self.centre_position = self._initial_position
 
@@ -689,6 +694,65 @@ class FMTiledAcquisitionRunner:
         )
         self._total_estimated_time = time_estimates["total_time"]
         self._acquisition_start_time = time.time()
+
+    def _require_inserted_objective(self) -> None:
+        """Refuse to run with the objective retracted.
+
+        Nothing an overview does works without it: the tiles would be whatever a
+        retracted objective sees, and a sweep would search for focus that cannot exist.
+        Checked before anything moves, so a run that cannot succeed costs nothing.
+
+        Not inserted automatically. Inserting is a physical move toward the sample and
+        the run is not the place to decide it is safe -- particularly when the reason it
+        is retracted may be that someone retracted it on purpose.
+
+        Raises:
+            ValueError: if the objective is anywhere but inserted.
+        """
+        state = self.microscope.fm.objective.state
+        if state != "Inserted":
+            raise ValueError(
+                f"The objective is {state.lower()}, so an overview cannot be acquired. "
+                f"Insert it and try again."
+            )
+
+    def _resolve_objective_start(self) -> float:
+        """Where the objective should be for this run, and move it there.
+
+        Moved now rather than at the first tile, because `once` autofocus sweeps before
+        the tile loop and centres on wherever the objective is: starting from a saved
+        focus is worth most precisely when a sweep is about to search around it
+        (FIB-417). `_restore` still puts the objective back where the user left it --
+        choosing where to start is not moving house.
+
+        Raises:
+            ValueError: if the saved focus position was asked for and there is not one.
+        """
+        objective = self.microscope.fm.objective
+        start = self.overview_parameters.objective_start
+
+        if start is ObjectiveStartPosition.CURRENT:
+            return self._initial_objective_position
+
+        position = objective.focus_position
+        if position is None:
+            # Refused rather than quietly falling back to the current position, which
+            # is the option the caller did not choose -- and the failure would be a
+            # blurred overview an hour later rather than a message now.
+            raise ValueError(
+                "This overview is set to start from the saved focus position, but none "
+                "has been saved. Set one with 'Set Focus Position', or start from the "
+                "current position instead."
+            )
+
+        if position != self._initial_objective_position:
+            logging.info(
+                f"Starting the overview at the saved focus position "
+                f"({position * 1e3:.4f} mm), from "
+                f"{self._initial_objective_position * 1e3:.4f} mm."
+            )
+            objective.move_absolute(position)
+        return position
 
     def _setup_autofocus(self) -> None:
         """Resolve the autofocus channel, method and z-range once, up front."""

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -120,13 +120,20 @@ class ObjectiveLens(ABC):
         return self._focus_position
 
     @focus_position.setter
-    def focus_position(self, position: float):
-        """Set the focus position of the objective lens.
+    def focus_position(self, position: Optional[float]):
+        """Set the focus position of the objective lens, or None to clear it.
+
+        The getter has always been `Optional[float]` -- an objective has no saved focus
+        until someone saves one -- but the setter took a bare float and formatted it
+        into its own log line, so clearing raised a TypeError from inside logging.
 
         Args:
-            position: The focus position in meters
+            position: The focus position in metres, or None to forget it.
         """
         self._focus_position = position
+        if position is None:
+            logging.info("Objective focus position cleared.")
+            return
         logging.info(
             f"Objective focus position set to: {self._focus_position * 1e3:.3f} mm"
         )

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -1528,6 +1528,24 @@ class FluorescenceImageMetadata:
         )
 
 
+class ObjectiveStartPosition(Enum):
+    """Where the objective is put before an overview begins.
+
+    Only ever a focus value -- neither option inserts or retracts the objective, which
+    is a different mechanism and a physical move no start-position setting should imply.
+    A run started with the objective retracted has a problem this does not solve.
+    """
+
+    # Wherever it is. What every overview did before this existed, and still the
+    # default: an overview is usually taken of what you have just been looking at.
+    CURRENT = "current"
+    # The focus a user saved with "Set Focus Position". Worth choosing when the
+    # objective has since been moved by something unrelated -- and worth more with
+    # autofocus set to `once`, whose sweep centres on wherever it starts, so beginning
+    # from a known-good focus sweeps around the answer rather than around an accident.
+    FOCUS = "focus"
+
+
 @dataclass
 class OverviewParameters:
     """Parameters for FM overview/tileset acquisition.
@@ -1539,6 +1557,7 @@ class OverviewParameters:
         use_zstack: Acquire a z-stack at each tile.
         autofocus_mode: When to autofocus during the traversal.
         tile_order: Traversal strategy over the grid.
+        objective_start: Where the objective is put before the run begins.
         tile_mask: Optional per-tile enable mask, `tile_mask[row][col]`. None acquires
             every tile. Disabled tiles are skipped but keep their place: the mosaic is
             still the full grid size and acquired tiles land at the same canvas
@@ -1552,6 +1571,7 @@ class OverviewParameters:
     autofocus_mode: AutoFocusMode = AutoFocusMode.NONE
     tile_order: TileOrderStrategy = TileOrderStrategy.TYPEWRITER
     tile_mask: Optional[List[List[bool]]] = None
+    objective_start: ObjectiveStartPosition = ObjectiveStartPosition.CURRENT
 
     def to_dict(self) -> dict:
         """Convert to dictionary representation."""
@@ -1562,6 +1582,7 @@ class OverviewParameters:
             "use_zstack": self.use_zstack,
             "autofocus_mode": self.autofocus_mode.value,
             "tile_order": self.tile_order.value,
+            "objective_start": self.objective_start.value,
             # plain bools: np.bool_ does not survive yaml.safe_dump
             "tile_mask": None if self.tile_mask is None
             else [[bool(v) for v in row] for row in self.tile_mask],
@@ -1581,6 +1602,11 @@ class OverviewParameters:
                 ddict.get("tile_order", TileOrderStrategy.TYPEWRITER.value)
             ),
             tile_mask=None if mask is None else [[bool(v) for v in row] for row in mask],
+            # Defaulted, not required: every overview saved before this existed started
+            # from wherever the objective was, so that is what its parameters mean.
+            objective_start=ObjectiveStartPosition(
+                ddict.get("objective_start", ObjectiveStartPosition.CURRENT.value)
+            ),
         )
 
     @property

--- a/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
@@ -24,6 +24,7 @@ from fibsem.fm.structures import (
     AutoFocusMode,
     AutoFocusSettings,
     ChannelSettings,
+    ObjectiveStartPosition,
     OverviewParameters,
     ZParameters,
 )
@@ -76,6 +77,8 @@ class FMOverviewConfirmationDialog(QDialog):
         zparams: Optional[ZParameters] = None,
         tile_fov: Optional[tuple] = None,
         autofocus_settings: Optional[AutoFocusSettings] = None,
+        objective_current: Optional[float] = None,
+        objective_focus: Optional[float] = None,
         parent: Optional[QWidget] = None,
     ):
         super().__init__(parent)
@@ -84,6 +87,10 @@ class FMOverviewConfirmationDialog(QDialog):
         self.zparams = zparams if parameters.use_zstack else None
         self.tile_fov = tile_fov
         self.autofocus_settings = autofocus_settings
+        # Read by the caller and passed in, so this dialog needs no microscope -- and
+        # so the number it reports is the one the settings panel was showing.
+        self.objective_current = objective_current
+        self.objective_focus = objective_focus
 
         self.setWindowTitle("Start Overview Acquisition")
         self.setMinimumWidth(430)
@@ -158,6 +165,22 @@ class FMOverviewConfirmationDialog(QDialog):
             detail.append(("Z-stack", f"{self.zparams.num_planes} planes per tile"))
         else:
             detail.append(("Z-stack", "off"))
+
+        # Before the auto-focus row, in the order they take effect: the objective is put
+        # here, and then a sweep searches around it.
+        focus = p.objective_start is ObjectiveStartPosition.FOCUS
+        target = self.objective_focus if focus else self.objective_current
+        where = "the saved focus position" if focus else "the current objective position"
+        if target is not None:
+            where += f", {target * constants.SI_TO_MILLI:.3f} mm"
+            # How far it will travel, which is the part worth checking before a run:
+            # a start position an unexpected distance away is a setting left over from
+            # something else.
+            if (self.objective_current is not None
+                    and abs(target - self.objective_current) > 1e-9):
+                delta = (target - self.objective_current) * constants.SI_TO_MILLI
+                where += f"  ({delta:+.3f} mm from here)"
+        detail.append(("Start from", where))
 
         if p.autofocus_mode is AutoFocusMode.NONE:
             detail.append(("Auto-focus", "off"))

--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -28,6 +28,7 @@ from PyQt5.QtWidgets import (
 from fibsem import constants
 from fibsem.fm.structures import (
     AutoFocusMode,
+    ObjectiveStartPosition,
     AutoFocusSettings,
     ChannelSettings,
     OverviewParameters,
@@ -44,6 +45,32 @@ from fibsem.ui.tokens import (
 )
 
 MUTED = f"color: {TEXT_MUTED_COLOR}; font-size: 11px;"
+
+OBJECTIVE_START_LABELS = {
+    ObjectiveStartPosition.CURRENT: "Current position",
+    ObjectiveStartPosition.FOCUS: "Saved focus position",
+}
+
+def format_objective_start(start, position: Optional[float]) -> str:
+    """Label one start option, with what it currently means in millimetres.
+
+    An option that names a position should say which one -- "saved focus position" is
+    only actionable if you can see it is 8.000 mm and the objective is at 6.000. Shared
+    with the confirmation dialog so the two cannot describe the same run differently.
+    """
+    label = OBJECTIVE_START_LABELS.get(start, start.name)
+    if position is None:
+        return f"{label} (none saved)"
+    return f"{label} ({position * constants.SI_TO_MILLI:.3f} mm)"
+
+
+OBJECTIVE_START_TOOLTIPS = {
+    ObjectiveStartPosition.CURRENT: "Start from wherever the objective is now.",
+    ObjectiveStartPosition.FOCUS: (
+        "Start from the focus saved with 'Set Focus Position'. Refuses to run if none "
+        "has been saved."
+    ),
+}
 
 AUTOFOCUS_LABELS = {
     AutoFocusMode.NONE: "Don't auto-focus",
@@ -83,6 +110,10 @@ class FMOverviewSettingsWidget(QWidget):
     ):
         super().__init__(parent)
         self._tile_fov: Optional[tuple] = None   # (fov_x, fov_y) metres, set externally
+        # What the start options currently mean. None until a host says -- the standalone
+        # settings widget has no microscope to ask.
+        self._objective_current: Optional[float] = None
+        self._objective_focus: Optional[float] = None
         # Owned here rather than by the parent, so every overview setting sits in one
         # widget and their order is this widget's to decide.
         self.z_widget = ZParametersWidget(z_parameters or ZParameters())
@@ -138,10 +169,21 @@ class FMOverviewSettingsWidget(QWidget):
             format_fn=lambda m: AUTOFOCUS_LABELS.get(m, m.name),
         )
 
+        # Above the auto-focus mode, because it decides where a sweep starts from.
+        self.combo_objective_start = ValueComboBox(
+            items=list(ObjectiveStartPosition),
+            format_fn=lambda s: OBJECTIVE_START_LABELS.get(s, s.name),
+        )
+        for index, start in enumerate(ObjectiveStartPosition):
+            self.combo_objective_start.setItemData(
+                index, OBJECTIVE_START_TOOLTIPS.get(start, ""), Qt.ToolTipRole
+            )
+
         # The app's spinboxes carry -/+ buttons, which eat most of a narrow field and
         # leave the value clipped ("0" for an overlap of 0.10). Give them a floor.
         for widget in (self.spin_rows, self.spin_cols, self.spin_overlap,
-                       self.combo_tile_order, self.combo_autofocus_mode):
+                       self.combo_tile_order, self.combo_autofocus_mode,
+                       self.combo_objective_start):
             widget.setMinimumWidth(SPINBOX_MIN_WIDTH)
             widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         for widget in (self.spin_rows, self.spin_cols, self.spin_overlap):
@@ -180,6 +222,7 @@ class FMOverviewSettingsWidget(QWidget):
         focus_form = QFormLayout()
         focus_form.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
         focus_form.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        focus_form.addRow("Start from", self.combo_objective_start)
         focus_form.addRow("Auto-focus", self.combo_autofocus_mode)
 
         focus_layout = QVBoxLayout()
@@ -232,6 +275,7 @@ class FMOverviewSettingsWidget(QWidget):
         self.combo_tile_order.currentIndexChanged.connect(self._on_tile_order_changed)
         self.check_zstack.stateChanged.connect(self._on_zstack_toggled)
         self.combo_autofocus_mode.currentIndexChanged.connect(self._on_autofocus_changed)
+        self.combo_objective_start.currentIndexChanged.connect(self._on_any_change)
         self.autofocus_widget.settings_changed.connect(self._on_any_change)
         self.tile_mask.changed.connect(self._on_any_change)
 
@@ -277,6 +321,26 @@ class FMOverviewSettingsWidget(QWidget):
     def _on_tile_order_changed(self) -> None:
         self._warn_if_spiral_conflicts()
         self._on_any_change()
+
+    def set_objective_positions(
+        self, current: Optional[float], focus: Optional[float]
+    ) -> None:
+        """Tell the start options what they currently mean, in metres.
+
+        Passed in rather than read: this widget takes no microscope, which is what lets
+        it be built and tested on its own, and reading the objective is not free -- on
+        a shared connection it takes the imaging channel (FIB-517).
+        """
+        self._objective_current = current
+        self._objective_focus = focus
+        combo = self.combo_objective_start
+        # No `blockSignals`: `setItemText` changes a label, not the selection, so this
+        # cannot read as a settings edit to anything listening on `currentIndexChanged`.
+        # Repopulating the items instead would, which is why it does not.
+        for index in range(combo.count()):
+            start = combo.itemData(index)
+            position = current if start is ObjectiveStartPosition.CURRENT else focus
+            combo.setItemText(index, format_objective_start(start, position))
 
     def _on_autofocus_changed(self) -> None:
         mode = self.combo_autofocus_mode.value()
@@ -402,13 +466,15 @@ class FMOverviewSettingsWidget(QWidget):
             autofocus_mode=self.combo_autofocus_mode.value(),
             tile_order=self.combo_tile_order.value(),
             tile_mask=self.tile_mask.mask,
+            objective_start=self.combo_objective_start.value(),
         )
 
     @parameters.setter
     def parameters(self, value: OverviewParameters) -> None:
         for widget in (self.spin_rows, self.spin_cols, self.spin_overlap,
                        self.combo_tile_order, self.check_zstack,
-                       self.combo_autofocus_mode, self.tile_mask):
+                       self.combo_autofocus_mode, self.combo_objective_start,
+                       self.tile_mask):
             widget.blockSignals(True)
         try:
             self.spin_rows.setValue(value.rows)
@@ -417,6 +483,7 @@ class FMOverviewSettingsWidget(QWidget):
             self.combo_tile_order.set_value(value.tile_order)
             self.check_zstack.setChecked(value.use_zstack)
             self.combo_autofocus_mode.set_value(value.autofocus_mode)
+            self.combo_objective_start.set_value(value.objective_start)
             self.tile_mask.set_grid_size(value.rows, value.cols)
             self.tile_mask.mask = value.tile_mask
         finally:

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -37,6 +37,7 @@ from fibsem.fm.structures import (
     ChannelSettings,
     FluorescenceImage,
     FluorescenceImageMetadata,
+    ObjectiveStartPosition,
     OverviewParameters,
 )
 from fibsem.microscope import FibsemMicroscope
@@ -1268,6 +1269,37 @@ class FMOverviewWidget(QWidget):
             logging.debug(f"No objective position for the info bar: {e}")
             self._objective_info = None
         self._refresh_stage_info()
+        # The same read serves the start-position options, which say what each one
+        # currently means. Here rather than on its own timer so the objective is read
+        # once for both -- on a shared connection that read takes the imaging channel
+        # (FIB-517), and two of them would be two.
+        self._refresh_objective_start_options()
+
+    def _objective_state(self) -> Optional[str]:
+        """Whether the objective is inserted, or None if it cannot be asked.
+
+        None rather than a guess: a driver that cannot answer is not the same as one
+        answering "retracted", and refusing a run over a failed read would be the wrong
+        way round -- the runner checks again, where it can raise.
+        """
+        try:
+            return self.fm.objective.state
+        except Exception as e:
+            logging.debug(f"Could not read the objective state: {e}")
+            return None
+
+    def _refresh_objective_start_options(self) -> None:
+        """Tell the settings panel where the objective is and where its saved focus is.
+
+        Read here rather than by the settings widget, which takes no microscope -- that
+        is what lets it be built and tested on its own.
+        """
+        try:
+            self.settings_widget.set_objective_positions(
+                self.fm.objective.position, self.fm.objective.focus_position
+            )
+        except Exception as e:
+            logging.debug(f"No objective positions for the start options: {e}")
 
     def _current_stage_position(self) -> Optional[FibsemStagePosition]:
         """Where the stage is, polling the microscope only when nothing has said yet.
@@ -1937,11 +1969,43 @@ class FMOverviewWidget(QWidget):
             self.status.setText("No channels enabled.")
             return
 
+        # Both of these are checked in the runner too, for a caller driving it directly.
+        # Here as well because by then the dialog has said yes and the stage is moving,
+        # so the message arrives as a failed run rather than as an answer to the
+        # question that was just asked (FIB-417).
+        state = self._objective_state()
+        if state is not None and state != "Inserted":
+            message = (
+                f"The objective is {state.lower()}, so an overview cannot be acquired. "
+                f"Insert it and try again."
+            )
+            logging.warning(message)
+            notification_service.show_toast(message, "warning")
+            self.status.setText(f"Objective is {state.lower()}.")
+            return
+
+        if (parameters.objective_start is ObjectiveStartPosition.FOCUS
+                and self.fm.objective.focus_position is None):
+            message = (
+                "This overview is set to start from the saved focus position, but none "
+                "has been saved. Set one with 'Set Focus Position', or start from the "
+                "current position instead."
+            )
+            logging.warning(message)
+            notification_service.show_toast(message, "warning")
+            self.status.setText("No focus position saved.")
+            return
+
         zparams = self.settings_widget.z_parameters
         # Method, channel and sweep passes all come from the settings panel now,
         # rather than being defaulted with only the channel filled in. Resolved before
         # the dialog, because the dialog reports what will run.
         autofocus_settings = self.settings_widget.autofocus_settings
+
+        # Read now rather than reusing whatever the settings panel last showed: the
+        # objective may have been driven somewhere since, and this dialog is the last
+        # thing said before the run commits.
+        self._refresh_objective_start_options()
 
         dialog = FMOverviewConfirmationDialog(
             parameters=parameters,
@@ -1949,6 +2013,8 @@ class FMOverviewWidget(QWidget):
             zparams=zparams,
             tile_fov=self.settings_widget._tile_fov,
             autofocus_settings=autofocus_settings,
+            objective_current=self.settings_widget._objective_current,
+            objective_focus=self.settings_widget._objective_focus,
             parent=self,
         )
         if dialog.exec_() != QDialog.Accepted:

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -24,6 +24,7 @@ from fibsem.fm.acquisition import (
 from fibsem.fm.structures import (
     AutoFocusMode,
     AutoFocusSettings,
+    ObjectiveStartPosition,
     ChannelSettings,
     FluorescenceImage,
     FMStagePosition,
@@ -2088,3 +2089,154 @@ def test_the_mosaic_records_where_its_tiles_were_actually_taken(
 
     assert runner._tile_objective_position == pytest.approx(FOUND_FOCUS)
     assert runner._initial_objective_position != pytest.approx(FOUND_FOCUS)
+
+
+# ---------------------------------------------------------------------------
+# Where an overview starts from (FIB-417).
+#
+# The runner took whatever the objective happened to be at, so acquiring from a
+# known-good focus meant driving there by hand first and remembering to.
+# ---------------------------------------------------------------------------
+
+SAVED_FOCUS = 42e-6
+
+
+def _start_from(monkeypatch, microscope, start, focus=SAVED_FOCUS):
+    """Run a 1x2 tileset with the given start setting, reporting where tiles landed."""
+    microscope.fm.objective.focus_position = focus
+    positions = []
+
+    monkeypatch.setattr(acquisition, "run_tileset_autofocus", lambda *a, **k: True)
+    real = acquisition.acquire_image
+
+    def spy(*args, **kwargs):
+        positions.append(microscope.fm.objective.position)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(acquisition, "acquire_image", spy)
+
+    runner = acquisition.FMTiledAcquisitionRunner(
+        microscope=microscope,
+        channel_settings=ChannelSettings(
+            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
+            power=0.1, exposure_time=0.1,
+        ),
+        overview_parameters=OverviewParameters(
+            rows=1, cols=2, overlap=0.1, use_zstack=False,
+            autofocus_mode=AutoFocusMode.NONE, objective_start=start,
+        ),
+    )
+    runner.run()
+    return positions, runner
+
+
+def test_by_default_an_overview_starts_where_the_objective_is(fm_microscope, monkeypatch):
+    """Unchanged behaviour, and still the default: an overview is usually taken of
+    whatever you have just been looking at."""
+    started_at = fm_microscope.fm.objective.position
+
+    positions, _ = _start_from(
+        monkeypatch, fm_microscope, ObjectiveStartPosition.CURRENT
+    )
+
+    assert positions == [pytest.approx(started_at)] * 2
+
+
+def test_it_can_start_from_the_saved_focus_position(fm_microscope, monkeypatch):
+    """The point of the setting: acquire from a known-good focus without driving the
+    objective there by hand first."""
+    positions, _ = _start_from(monkeypatch, fm_microscope, ObjectiveStartPosition.FOCUS)
+
+    assert positions == [pytest.approx(SAVED_FOCUS)] * 2
+
+
+def test_the_objective_still_goes_back_where_the_user_left_it(fm_microscope, monkeypatch):
+    """Choosing where to start is not moving house."""
+    started_at = fm_microscope.fm.objective.position
+
+    _start_from(monkeypatch, fm_microscope, ObjectiveStartPosition.FOCUS)
+
+    assert fm_microscope.fm.objective.position == pytest.approx(started_at)
+
+
+def test_the_objective_is_moved_before_a_sweep_would_search(fm_microscope, monkeypatch):
+    """`once` autofocus sweeps before the tile loop and centres on wherever the
+    objective is, so the move has to happen in setup rather than at the first tile --
+    otherwise the sweep searches around the position being replaced."""
+    swept_at = []
+    fm_microscope.fm.objective.focus_position = SAVED_FOCUS
+    monkeypatch.setattr(
+        acquisition, "run_tileset_autofocus",
+        lambda microscope, *a, **k: swept_at.append(microscope.fm.objective.position) or True,
+    )
+    monkeypatch.setattr(acquisition, "acquire_image", lambda *a, **k: acquisition.acquire_image)
+
+    runner = acquisition.FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=ChannelSettings(
+            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
+            power=0.1, exposure_time=0.1,
+        ),
+        overview_parameters=OverviewParameters(
+            rows=1, cols=1, overlap=0.1, use_zstack=False,
+            autofocus_mode=AutoFocusMode.ONCE,
+            objective_start=ObjectiveStartPosition.FOCUS,
+        ),
+        autofocus_settings=AutoFocusSettings(),
+    )
+    runner.run()
+
+    assert swept_at == [pytest.approx(SAVED_FOCUS)]
+
+
+def test_asking_for_a_focus_position_that_was_never_saved_is_refused(
+    fm_microscope, monkeypatch
+):
+    """Refused rather than quietly falling back to the current position, which is the
+    option the caller did not choose -- and whose failure would arrive as a blurred
+    overview an hour later rather than a message now."""
+    fm_microscope.fm.objective.focus_position = None
+
+    with pytest.raises(ValueError, match="saved focus position"):
+        _start_from(
+            monkeypatch, fm_microscope, ObjectiveStartPosition.FOCUS, focus=None
+        )
+
+
+def test_an_overview_will_not_run_with_the_objective_retracted(fm_microscope, monkeypatch):
+    """Nothing an overview does works without it -- the tiles would be whatever a
+    retracted objective sees, and a sweep would search for a focus that cannot exist."""
+    fm_microscope.fm.objective.retract()
+
+    with pytest.raises(ValueError, match="retracted"):
+        _start_from(monkeypatch, fm_microscope, ObjectiveStartPosition.CURRENT)
+
+
+def test_the_retracted_objective_is_caught_before_anything_moves(
+    fm_microscope, monkeypatch
+):
+    """Checked first, so a run that cannot succeed costs no stage travel -- and, with
+    a start position selected, no objective travel either.
+
+    `FOCUS` rather than `CURRENT` on purpose: resolving the start position *moves* the
+    objective, so a check placed after it would refuse only once it had already driven
+    the objective somewhere. With `CURRENT` nothing moves and the test cannot tell.
+
+    The run must also not insert it: that is a physical move toward the sample, and it
+    may be retracted precisely because someone meant it to be.
+    """
+    fm_microscope.fm.objective.retract()
+    retracted_at = fm_microscope.fm.objective.position
+    moved = []
+    monkeypatch.setattr(
+        fm_microscope, "safe_absolute_stage_movement", lambda *a, **k: moved.append(a)
+    )
+
+    with pytest.raises(ValueError, match="retracted"):
+        _start_from(monkeypatch, fm_microscope, ObjectiveStartPosition.FOCUS)
+
+    assert moved == [], "the stage travelled before the run was refused"
+    assert fm_microscope.fm.objective.position == pytest.approx(retracted_at), (
+        "the objective was driven somewhere before the run was refused"
+    )
+    assert fm_microscope.fm.objective.state == "Retracted", "the run inserted it"

--- a/tests/test_view_corrected_movement.py
+++ b/tests/test_view_corrected_movement.py
@@ -779,6 +779,10 @@ class TestFmConsumersUseTheFmProjection:
 
         _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
         microscope.fm = FluorescenceMicroscope(parent=microscope)
+        # A fresh objective is retracted, and a run refuses that (FIB-417) before it
+        # projects anything. This test is about which projection tiles are placed with,
+        # so it needs a run that gets as far as placing them.
+        microscope.fm.objective.insert()
 
         fm_calls, beam_calls = [], []
         real_project_fm = microscope.project_fm_stable_move

--- a/tests/ui/test_fm_acquisition_state.py
+++ b/tests/ui/test_fm_acquisition_state.py
@@ -33,7 +33,13 @@ def qapp():
 def widget(qapp):
     from fibsem.ui.fm.overview_app import build_microscope
 
-    return FMOverviewWidget(build_microscope())
+    widget = FMOverviewWidget(build_microscope())
+    # `build_microscope` leaves the objective retracted, which `acquire` refuses
+    # (FIB-417) before it ever reaches the busy flag this file is about. Without
+    # this, the tests that assert the flag is *given back* would pass on a run that
+    # never took it.
+    widget.fm.objective.insert()
+    return widget
 
 
 @pytest.fixture()

--- a/tests/ui/test_fm_overview_orientation.py
+++ b/tests/ui/test_fm_overview_orientation.py
@@ -36,7 +36,13 @@ def qapp():
 def widget(qapp):
     from fibsem.ui.fm.overview_app import build_microscope
 
-    return FMOverviewWidget(build_microscope())
+    built = FMOverviewWidget(build_microscope())
+    # Everything except the pose has to be ready to run, or a test that varies only the
+    # orientation is really testing whichever other guard `acquire` reaches first. The
+    # objective is the one that bites: `build_microscope` leaves it retracted, and an
+    # overview refuses on that before it looks at the stage (FIB-417).
+    built.fm.objective.insert()
+    return built
 
 
 # Compustage tilts the whole orientation question: -180° is where the FM looks at the

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -570,6 +570,10 @@ def overview_widget(qapp):
     from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
 
     microscope = build_microscope()
+    # Inserted, so the widget under test is one that could actually run. Left retracted
+    # -- which is how `build_microscope` leaves it -- every test that reaches `acquire`
+    # is really testing the objective guard rather than whatever it meant to (FIB-417).
+    microscope.fm.objective.insert()
     widget = FMOverviewWidget(microscope)
     widget.resize(1200, 800)
     widget.show()
@@ -4353,3 +4357,124 @@ def test_picking_no_file_places_nothing(qapp, blank_canvas, monkeypatch):
 
     assert loaded == []
     assert widget.overviews() == []
+
+
+# ── the start options say what they currently mean (FIB-417) ─────────────
+
+
+def test_the_start_options_show_where_they_would_put_the_objective(qapp, overview_widget):
+    """An option that names a position has to say which one. "Saved focus position" is
+    only actionable next to the number, and next to where the objective is now."""
+    widget = overview_widget
+    widget.fm.objective.focus_position = 8.0e-3
+
+    widget._refresh_objective_start_options()
+
+    combo = widget.settings_widget.combo_objective_start
+    labels = [combo.itemText(i) for i in range(combo.count())]
+    assert any("mm" in label for label in labels), f"no positions shown: {labels}"
+    assert any("8.000 mm" in label for label in labels), f"saved focus missing: {labels}"
+
+
+def test_an_unsaved_focus_position_says_so_rather_than_showing_nothing(
+    qapp, overview_widget
+):
+    """The refusal comes later; the label is where you would notice first."""
+    widget = overview_widget
+    widget.fm.objective._focus_position = None
+
+    widget._refresh_objective_start_options()
+
+    combo = widget.settings_widget.combo_objective_start
+    labels = [combo.itemText(i) for i in range(combo.count())]
+    assert any("none saved" in label for label in labels), labels
+
+
+def test_relabelling_the_options_does_not_look_like_the_user_changed_one(
+    qapp, overview_widget
+):
+    """It runs on every objective refresh, so emitting `changed` would look like a
+    settings edit to anything listening for one.
+
+    Currently free: `setItemText` changes a label, not the selection. The assertion is
+    on the requirement rather than on that mechanism, so it still holds an
+    implementation that repopulated the items -- which would emit.
+    """
+    widget = overview_widget
+    changes = []
+    widget.settings_widget.changed.connect(lambda: changes.append(True))
+
+    widget._refresh_objective_start_options()
+
+    assert changes == []
+
+
+def test_starting_from_an_unsaved_focus_is_refused_before_the_dialog(
+    qapp, overview_widget, monkeypatch
+):
+    """Refused where the question was asked. The runner refuses too, but by then the
+    dialog has said yes and the stage is moving."""
+    from fibsem.fm.structures import ObjectiveStartPosition
+
+    widget = overview_widget
+    # `acquire` refuses on several counts before reaching this one, and the fixture is
+    # module-scoped -- a run left alive by an earlier test bails at the first guard and
+    # the status line still reads whatever that test put there. Start from a widget
+    # that would otherwise go ahead, or this passes without exercising anything.
+    widget._worker = None
+    widget.fm.set_acquiring(False)
+    widget.status.setText("")
+    widget.fm.objective.insert()
+    assert widget.at_acquisition_orientation(), "the stage is not where a run needs it"
+    assert widget.fm.objective.state == "Inserted", "a different guard would fire first"
+
+    widget.fm.objective._focus_position = None
+    widget.settings_widget.combo_objective_start.set_value(ObjectiveStartPosition.FOCUS)
+    shown = []
+    monkeypatch.setattr(
+        "fibsem.ui.fm.widgets.fm_overview_widget.FMOverviewConfirmationDialog",
+        lambda **kwargs: shown.append(kwargs) or (_ for _ in ()).throw(AssertionError),
+    )
+
+    widget.acquire()
+
+    assert shown == [], "the confirmation dialog was shown anyway"
+    assert "focus position" in widget.status.text().lower()
+
+
+def test_acquiring_with_the_objective_retracted_is_refused_before_the_dialog(
+    qapp, overview_widget, monkeypatch
+):
+    """The runner refuses too, but by then the dialog has said yes."""
+    widget = overview_widget
+    widget._worker = None
+    widget.fm.set_acquiring(False)
+    widget.status.setText("")
+    assert widget.at_acquisition_orientation()
+    monkeypatch.setattr(type(widget.fm.objective), "state", property(lambda self: "Retracted"))
+    shown = []
+    monkeypatch.setattr(
+        "fibsem.ui.fm.widgets.fm_overview_widget.FMOverviewConfirmationDialog",
+        lambda **kwargs: shown.append(kwargs) or (_ for _ in ()).throw(AssertionError),
+    )
+
+    widget.acquire()
+
+    assert shown == [], "the confirmation dialog was shown anyway"
+    assert "retracted" in widget.status.text().lower()
+
+
+def test_an_objective_that_cannot_be_asked_does_not_block_the_run(
+    qapp, overview_widget, monkeypatch
+):
+    """A driver that cannot answer is not one answering "retracted". Refusing over a
+    failed read would be the wrong way round; the runner checks again where it can
+    raise."""
+    widget = overview_widget
+
+    def unreadable(self):
+        raise RuntimeError("detector did not answer")
+
+    monkeypatch.setattr(type(widget.fm.objective), "state", property(unreadable))
+
+    assert widget._objective_state() is None


### PR DESCRIPTION
Closes [FIB-417](https://linear.app/fibsemos/issue/FIB-417/choose-the-objective-position-an-overview-starts-from). The runner took whatever the objective happened to be at, so acquiring from a known-good focus meant driving there by hand first and remembering to.

Unblocks [FIB-532](https://linear.app/fibsemos/issue/FIB-532/set-up-and-acquire-several-overviews-in-one-unattended-run) — an unattended batch can't ask anyone to focus at each region, and now doesn't have to.

## What's here

`ObjectiveStartPosition` on `OverviewParameters`: **current position** (unchanged, still the default) or the focus saved with "Set Focus Position". Older sidecars default to the current position, which is what they meant.

Most of the groundwork already existed — [FIB-516](https://linear.app/fibsemos/issue/FIB-516/overview-autofocus-is-discarded-before-every-tile-except-in-each-tile) split `_initial_objective_position` into *where the run started* (what `_restore` puts back) and *where tiles are acquired*, which is exactly the split this needed. What's new is choosing the second.

## Three decisions

**The objective moves in `_setup`, not at the first tile.** `_acquire_tile` moves per tile anyway, so tiles land correctly either way — but `once` autofocus sweeps *before* the tile loop and centres on wherever the objective is. A late move leaves the sweep searching around the position being replaced, which is the case the setting is worth most in.

**Both refusals happen twice.** The runner raises for a caller driving it directly; the widget refuses before the confirmation dialog. By the time the runner speaks, the dialog has said yes and the stage is moving.

**An overview won't run with the objective retracted**, checked before anything moves. Nothing an overview does works without it. It does **not** insert the objective — that's a physical move toward the sample, and it may be retracted precisely because someone meant it to be. The issue left this open; this is the answer.

## What you see

The options say what they currently mean — `Saved focus position (8.000 mm)`, or `(none saved)` — and the dialog adds `+2.000 mm from here`. The distance is the part worth checking: a start position an unexpected distance away is usually a setting left over from something else.

Both render through one formatter, so the panel and the dialog can't describe the same run differently. Values are passed in rather than fetched — the settings widget and the dialog stay microscope-free, and the objective is read once through the existing chokepoint, since on a shared connection each read takes the imaging channel ([FIB-517](https://linear.app/fibsemos/issue/FIB-517/fm-property-getters-steal-the-shared-imaging-channel-and-break-running)).

## Adjacent fix

`focus_position`'s setter was typed `float` while its getter returns `Optional[float]`, and formatted the value into its own log line — so clearing a saved focus raised a `TypeError` from inside `logging`. Found because "never saved" is exactly the state this feature has to handle. Say if you'd rather it went separately.

## Testing

815 pass across `tests/fm/` and all four overview suites, in file order and random order. Seven mutations caught by their own tests.

**Three test corrections, each found by mutation testing rather than by a failure** — worth reading, because two of them were tests that passed while proving nothing:

- *"caught before anything moves"* used `CURRENT`, which never moves the objective, so a guard placed **after** the start position resolved still passed. It uses `FOCUS` now, where a late guard refuses only once it has already driven the objective somewhere.
- The relabelling was wrapped in `blockSignals` with a comment implying it was load-bearing. `setItemText` changes a label, not the selection, so nothing was ever going to emit. Removed, and the test docstring now says why the requirement holds rather than implying a guard does it.
- `build_microscope` leaves the objective **retracted**, so three existing tests that reach `acquire` were about to start testing the new guard instead of what they meant to. The fixtures insert it, and the tests that depend on it assert so.

## One knock-on

The standalone `overview_app` has no objective control, so a user there could be refused with no way to insert. In AutoLamella the FM control widget handles it. That makes [FIB-434](https://linear.app/fibsemos/issue/FIB-434/add-objective-control-to-the-fm-overview-tab) (objective control on the overview tab, currently Low) worth more than its priority suggests.