### PR TITLE
[ui] Stop a second correlation image crashing on a surface point

### DIFF
--- a/fibsem/ui/correlation/widgets/image_point_canvas.py
+++ b/fibsem/ui/correlation/widgets/image_point_canvas.py
@@ -295,6 +295,10 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         self._ax.axis("off")
         self._point_artists.clear()
         self._label_artists.clear()
+        # cla() detached the surface line too — drop the reference or the
+        # rebuild below tries to remove an artist that has no axes
+        self._surface_line = None
+        self._surface_line_coord = None
         self._background = None
 
         h, w = image.shape[:2]
@@ -733,7 +737,8 @@ class ImagePointCanvas(FigureCanvasQTAgg):
         if self._surface_line is not None:
             try:
                 self._surface_line.remove()
-            except ValueError:
+            except (ValueError, NotImplementedError):
+                # NotImplementedError: the artist was already detached (cla())
                 pass
             self._surface_line = None
         self._surface_line_coord = None

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -584,6 +584,32 @@ def test_fm_surface_point_gets_no_line(qapp):
     assert canvas._surface_line is None
 
 
+def test_set_image_rebuilds_the_surface_line_on_the_new_axes(qapp):
+    """A second set_image() with a surface point on the canvas used to abort.
+
+    cla() detaches the datum line, so the stale reference made the next rebuild
+    call remove() on an artist with no axes — matplotlib raises
+    NotImplementedError there, not the ValueError the guard caught, and PyQt5
+    turns an exception escaping a slot into a process abort. Loading a second
+    FIB image after picking a surface point took the app down.
+    """
+    import numpy as np
+
+    from fibsem.ui.correlation.widgets.image_point_canvas import ImagePointCanvas
+
+    img = np.zeros((64, 64), dtype=np.uint8)
+    canvas = ImagePointCanvas()
+    canvas.set_image(img)
+    canvas.set_coordinates([_coord(x=10.0, y=40.0, pt=PointType.SURFACE)])
+
+    canvas.set_image(img)  # ← used to raise NotImplementedError
+
+    # and the line is live on the new axes, not merely un-crashed
+    assert canvas._surface_line is not None
+    assert canvas._surface_line in canvas._ax.lines
+    assert canvas._surface_line.get_ydata()[0] == pytest.approx(40.0)
+
+
 def test_surface_line_exported_by_render_to_axes(qapp):
     from matplotlib.figure import Figure
 


### PR DESCRIPTION
`ImagePointCanvas.set_image()` aborts the process when a `PointType.SURFACE` coordinate is already on the canvas. Reachable from the app: pick a FIB surface point, then load a second FIB image (`CorrelationTabWidget.set_fib_image` → `set_image`).

```
NotImplementedError: cannot remove artist
```

## Cause

`set_image()` calls `self._ax.cla()` and resets `_point_artists` / `_label_artists` / `_overlay_*`, but never `_surface_line` — which `cla()` has already detached. `_rebuild_artists()` then calls `self._surface_line.remove()` inside `except ValueError`; matplotlib raises `NotImplementedError('cannot remove artist')` when the artist has no `.axes`, so the guard misses it. PyQt5 turns an exception escaping a slot into a `qFatal` abort, making this a hard crash rather than a logged error.

## Fix

- `set_image()` resets `_surface_line` and `_surface_line_coord` alongside the other artist resets. `_surface_line_coord` goes too: leaving it pointing at a Coordinate whose line is gone would let `_apply_styles()` / `_sync_artist_position()` work on a mismatched pair.
- `_rebuild_artists()` also catches `NotImplementedError`.

Either change alone fixes it; the second is cheap insurance for any other path that clears the axes.

## Audit

`_scalebar_artist` has the identical fragile `except ValueError`, but is safe *by accident* — `set_image()` happens to null it before calling `_refresh_scalebar()`. The legend is safe on its own merits: `_update_legend()` reads `_ax.get_legend()` live rather than caching a reference. `_surface_line` was the only instance of the bug.

## Testing

`test_set_image_rebuilds_the_surface_line_on_the_new_axes`, next to the existing `test_fib_surface_line_*` cases. It asserts more than "didn't crash": the line must be live on the *new* axes at the right y, so a fix that only swallows the exception without rebuilding still fails.

- Reported repro reproduced first, passes after.
- Mutation-checked: reverting the source with the test in place fails with the original `NotImplementedError`.
- App path verified — `set_fib_image()` twice with a SURFACE point picked now survives and rebuilds the datum line.
- `tests/correlation/`: 326 passed, 15 skipped (pre-existing missing-LUT-CSV skips).

`ImagePointCanvas` is slated for replacement by `CorrelationCanvasWidget` under FIB-535, but that swap is several PRs away and this crashes in shipped code today.