### PR TITLE
[ui] Take the standalone harnesses and stray helpers off napari (FIB-407, phase 5)

### DIFF
--- a/fibsem/applications/autolamella/ui/autolamella_fluorescence_acquisition_task_config_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_fluorescence_acquisition_task_config_widget.py
@@ -145,7 +145,8 @@ class AutoLamellaFluorescenceAcquisitionTaskConfigWidget(QWidget):
 
 
 def main():
-    import napari
+    from PyQt5.QtWidgets import QApplication
+
     from fibsem import utils
 
     microscope, settings = utils.setup_session()
@@ -158,9 +159,11 @@ def main():
             autofocus_settings=AutoFocusSettings.from_coarse_fine(fine_enabled=False, method=FocusMethod.SOBEL, channel_name="Reflection Channel")
         )
 
-    viewer = napari.Viewer()
+    # Standalone harness: a plain Qt window, not a napari dock. napari was only ever
+    # hosting the widget here (FIB-407).
+    app = QApplication.instance() or QApplication([])
     widget = AutoLamellaFluorescenceAcquisitionTaskConfigWidget(microscope=microscope, config=None)
-    viewer.window.add_dock_widget(widget, area='right')
+    widget.show()
 
     widget.set_task_config(config)
 
@@ -168,7 +171,7 @@ def main():
         print("Task config updated:", updated.autofocus_settings)
     widget.settings_changed.connect(_on_settings_changed)
 
-    napari.run()
+    app.exec_()
 
 
 if __name__ == "__main__":

--- a/fibsem/ui/FibsemManipulatorWidget.py
+++ b/fibsem/ui/FibsemManipulatorWidget.py
@@ -17,13 +17,7 @@ from fibsem.ui.qtdesigner_files import (
 from fibsem.ui.utils import install_wheel_blocker_recursive, message_box_ui
 
 if TYPE_CHECKING:
-    # Annotation-only. `viewer` is still handed a napari Viewer by FibsemUI, so the
-    # type stays documented without importing napari here; image_widget likewise
-    # avoids a runtime dependency on a sibling widget module. (napari still reaches
-    # this module transitively via fibsem/ui/__init__.py, which eagerly imports every
-    # widget — that one belongs to the wider cutover.)
-    import napari
-
+    # Annotation-only, to avoid a runtime dependency on a sibling widget module.
     from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
 
 
@@ -32,7 +26,9 @@ class FibsemManipulatorWidget(FibsemManipulatorWidgetUI.Ui_Form, QtWidgets.QWidg
         self,
         microscope: FibsemMicroscope = None,
         settings: MicroscopeSettings = None,
-        viewer: Optional["napari.Viewer"] = None,  # unused; retained for call-site compatibility
+        # Unused, retained for call-site compatibility. Untyped: every host now passes
+        # None, so naming napari here would be the module's only reason to know it exists.
+        viewer=None,
         image_widget: Optional["FibsemImageSettingsWidget"] = None,
         parent=None,
     ):

--- a/fibsem/ui/utils.py
+++ b/fibsem/ui/utils.py
@@ -411,15 +411,18 @@ if __name__ == "__main__":
                                array_size=array_size,
                                orange_size=orange_size,
                                green_size=green_size)
-    import napari
+    # Standalone harness: matplotlib rather than a napari labels layer (FIB-407).
+    # Extent is in metres so the axes carry the same scale the napari scale bar did.
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import BoundaryNorm, ListedColormap
 
-    cmap = {0: 'red', 1: 'orange', 2: 'green'}
+    cmap = ListedColormap(['red', 'orange', 'green'])
+    norm = BoundaryNorm([0, 1, 2, 3], cmap.N)
 
-    viewer = napari.view_labels(grid,
-                                name="Grid Overlay",
-                                scale=(pixelsize, pixelsize),
-                                colormap=cmap)
-    viewer.scale_bar.visible = True
-    viewer.scale_bar.unit = "m"
-
-    napari.run()
+    extent = (0, grid.shape[1] * pixelsize, grid.shape[0] * pixelsize, 0)
+    fig, ax = plt.subplots()
+    ax.imshow(grid, cmap=cmap, norm=norm, extent=extent, interpolation="nearest")
+    ax.set_title("Grid Overlay")
+    ax.set_xlabel("m")
+    ax.set_ylabel("m")
+    plt.show()

--- a/fibsem/ui/widgets/autolamella_create_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_create_experiment_widget.py
@@ -465,11 +465,12 @@ def create_experiment_dialog(parent: Optional[QtWidgets.QWidget] = None) -> Opti
 
 def main():
     """Test the AutoLamellaCreateExperimentWidget."""
-    import napari
-    viewer = napari.Viewer()
+    # Standalone harness: a plain Qt window, not a napari dock. napari was only ever
+    # hosting the widget here (FIB-407).
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
 
     qwidget = QtWidgets.QWidget()
-    viewer.window.add_dock_widget(qwidget, area='right')
+    qwidget.show()
 
     # Use the standalone function to create experiment
     experiment = create_experiment_dialog(qwidget)
@@ -483,7 +484,7 @@ def main():
     else:
         print("Experiment creation cancelled")
 
-    napari.run()
+    app.exec_()
     # sys.exit()
 
 

--- a/fibsem/ui/widgets/autolamella_load_experiment_widget.py
+++ b/fibsem/ui/widgets/autolamella_load_experiment_widget.py
@@ -783,11 +783,12 @@ def load_experiment_dialog(parent: Optional[QtWidgets.QWidget] = None) -> Option
 
 def main():
     """Test the AutoLamellaLoadExperimentWidget."""
-    import napari
-    viewer = napari.Viewer()
+    # Standalone harness: a plain Qt window, not a napari dock. napari was only ever
+    # hosting the widget here (FIB-407).
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
 
     qwidget = QtWidgets.QWidget()
-    viewer.window.add_dock_widget(qwidget, area='right')
+    qwidget.show()
 
     # Use the standalone function to load experiment
     experiment = load_experiment_dialog(qwidget)
@@ -800,7 +801,7 @@ def main():
     else:
         print("Experiment loading cancelled")
 
-    napari.run()
+    app.exec_()
 
 
 if __name__ == "__main__":

--- a/fibsem/ui/widgets/autolamella_load_task_protocol_widget.py
+++ b/fibsem/ui/widgets/autolamella_load_task_protocol_widget.py
@@ -414,11 +414,12 @@ def load_task_protocol_dialog(
 
 def main():
     """Test the AutoLamellaLoadTaskProtocolWidget."""
-    import napari
-    viewer = napari.Viewer()
+    # Standalone harness: a plain Qt window, not a napari dock. napari was only ever
+    # hosting the widget here (FIB-407).
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
 
     qwidget = QtWidgets.QWidget()
-    viewer.window.add_dock_widget(qwidget, area='right')
+    qwidget.show()
 
     # Create a test experiment
     from fibsem.applications.autolamella.structures import Experiment
@@ -438,7 +439,7 @@ def main():
     else:
         print("Protocol loading cancelled")
 
-    napari.run()
+    app.exec_()
 
 
 if __name__ == "__main__":

--- a/fibsem/ui/widgets/autolamella_task_config_widget.py
+++ b/fibsem/ui/widgets/autolamella_task_config_widget.py
@@ -344,7 +344,7 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
 
 
 if __name__ == "__main__":
-    import napari
+    from PyQt5.QtWidgets import QApplication
 
     from fibsem.applications.autolamella.workflows.tasks.tasks import (
         AcquireReferenceImageConfig,
@@ -356,17 +356,19 @@ if __name__ == "__main__":
     acquire_config = AcquireReferenceImageConfig()
     # test_config = DEFAULT_PROTOCOL.task_config['MILL_ROUGH']
 
-    # Create widget
-    viewer = napari.Viewer()
-    widget = AutoLamellaTaskConfigWidget(test_config)
-    widget.config_changed.connect(lambda config: print(f"Config changed: {config}"))
-    widget.setWindowTitle("AutoLamella Task Config Widget Test")
-    viewer.window.add_dock_widget(widget, area="right", add_vertical_stretch=False)
+    # Standalone harness: two plain Qt windows, not napari docks. napari was only ever
+    # hosting the widgets here (FIB-407). Both are kept alive in a list — a QWidget with
+    # no parent is destroyed when its last Python reference goes.
+    app = QApplication.instance() or QApplication([])
+    windows = []
+    for config, title in (
+        (test_config, "AutoLamella Task Config Widget Test"),
+        (acquire_config, acquire_config.task_name),
+    ):
+        widget = AutoLamellaTaskConfigWidget(config)
+        widget.config_changed.connect(lambda config: print(f"Config changed: {config}"))
+        widget.setWindowTitle(title)
+        widget.show()
+        windows.append(widget)
 
-
-    widget = AutoLamellaTaskConfigWidget(acquire_config)
-    widget.config_changed.connect(lambda config: print(f"Config changed: {config}"))
-    widget.setWindowTitle(acquire_config.task_name)
-    viewer.window.add_dock_widget(widget, area="right", add_vertical_stretch=False)
-
-    napari.run()
+    app.exec_()

--- a/fibsem/ui/widgets/beam_settings_widget.py
+++ b/fibsem/ui/widgets/beam_settings_widget.py
@@ -503,7 +503,6 @@ class FibsemBeamSettingsWidget(QWidget):
 if __name__ == "__main__":
     import sys
 
-    import napari
     from PyQt5.QtWidgets import QApplication, QPushButton, QVBoxLayout
 
     from fibsem import utils
@@ -543,6 +542,7 @@ if __name__ == "__main__":
 
     widget.settings_changed.connect(lambda s: print(f"settings_changed: {s}"))
 
-    viewer = napari.Viewer()
-    viewer.window.add_dock_widget(main_widget, area="right")
-    napari.run()
+    # Standalone harness: a plain Qt window, not a napari dock. napari was only ever
+    # hosting the widget here (FIB-407).
+    main_widget.show()
+    app.exec_()

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -481,9 +481,11 @@ class ContextMenu(QMenu):
         except Exception:
             logging.exception("Context menu action '%s' raised an exception.", menu_action.label)
             try:
-                from napari.utils import notifications
+                from fibsem.ui import notification_service
 
-                notifications.show_warning(f"Action '{menu_action.label}' failed.")
+                notification_service.show_toast(
+                    f"Action '{menu_action.label}' failed.", "warning"
+                )
             except Exception:
                 pass
 

--- a/fibsem/ui/widgets/detector_settings_widget.py
+++ b/fibsem/ui/widgets/detector_settings_widget.py
@@ -255,7 +255,6 @@ class FibsemDetectorSettingsWidget(QWidget):
 if __name__ == "__main__":
     import sys
 
-    import napari
     from PyQt5.QtWidgets import QApplication, QPushButton, QVBoxLayout
 
     from fibsem import utils
@@ -294,6 +293,7 @@ if __name__ == "__main__":
 
     widget.settings_changed.connect(lambda s: print(f"settings_changed: {s}"))
 
-    viewer = napari.Viewer()
-    viewer.window.add_dock_widget(main_widget, area="right")
-    napari.run()
+    # Standalone harness: a plain Qt window, not a napari dock. napari was only ever
+    # hosting the widget here (FIB-407).
+    main_widget.show()
+    app.exec_()

--- a/fibsem/ui/widgets/dual_beam_widget.py
+++ b/fibsem/ui/widgets/dual_beam_widget.py
@@ -269,9 +269,9 @@ if __name__ == "__main__":
     btn.clicked.connect(_print)
     main_layout.addWidget(btn)
 
-    import napari
-    viewer = napari.Viewer()
-    viewer.window.add_dock_widget(main_widget, area="right")
-    napari.run()
+    # Standalone harness: a plain Qt window, not a napari dock. napari was only ever
+    # hosting the widget here (FIB-407).
+    main_widget.show()
+    app.exec_()
     # main_widget.show()
     # sys.exit(app.exec_())

--- a/tests/ui/test_context_menu_action_failure.py
+++ b/tests/ui/test_context_menu_action_failure.py
@@ -1,0 +1,79 @@
+"""A failing context-menu action warns the user without breaking the caller (FIB-407).
+
+`_invoke_action_callback` used to reach for `napari.utils.notifications` inside a bare
+`except Exception: pass`. Phase 5 repoints it at `notification_service`, and the shape of
+that code means a mistake there is completely silent — a wrong module, a wrong function
+name or a wrong signature would be swallowed by the same `except`, and the user would get
+no warning at all while every test still passed.
+
+So this asserts on the toast actually arriving, not on the call not raising.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5", reason="UI dependencies not installed")
+
+from PyQt5.QtWidgets import QApplication  # noqa: E402
+
+from fibsem.ui import notification_service  # noqa: E402
+from fibsem.ui.widgets.custom_widgets import (  # noqa: E402
+    ContextMenuAction,
+    ContextMenu,
+)
+
+
+@pytest.fixture(scope="module")
+def _app():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def toasts():
+    """Every toast emitted during the test, as (message, type, temporary)."""
+    received = []
+    service = notification_service._get_service()
+    service.toast.connect(lambda *args: received.append(args))
+    yield received
+
+
+def _invoke(label, callback):
+    """Drive the private handler the context menu calls when an action is chosen."""
+    menu = ContextMenu.__new__(ContextMenu)  # the handler needs no Qt setup
+    menu._invoke_action_callback(ContextMenuAction(label=label, callback=callback))
+
+
+def test_a_failing_action_warns_the_user(_app, toasts):
+    def boom():
+        raise RuntimeError("no")
+
+    _invoke("Move Patterns Here", boom)
+
+    assert toasts, "a failing context-menu action produced no warning"
+    message, kind = toasts[-1][0], toasts[-1][1]
+    assert "Move Patterns Here" in message, f"warning does not name the action: {message!r}"
+    assert kind == "warning", f"expected a warning, got {kind!r}"
+
+
+def test_a_failing_action_does_not_propagate(_app, toasts):
+    """The whole point of the try/except: one bad action must not break the caller."""
+    def boom():
+        raise RuntimeError("no")
+
+    _invoke("Anything", boom)  # must not raise
+
+
+def test_a_successful_action_warns_about_nothing(_app, toasts):
+    calls = []
+    _invoke("Fine", lambda: calls.append(1))
+    assert calls == [1]
+    assert not toasts, f"a successful action emitted a warning: {toasts}"
+
+
+def test_an_action_without_a_callback_is_a_no_op(_app, toasts):
+    _invoke("No callback", None)
+    assert not toasts


### PR DESCRIPTION
First slice of the napari removal ([FIB-407](https://linear.app/fibsemos/issue/FIB-407)), chosen deliberately for having **no shipping behaviour in it**. Importers go from **28 to 17**.

## Eight demo harnesses

`main()` / `__main__` blocks that used napari purely to host a widget — `napari.Viewer()`, `add_dock_widget`, `napari.run()`. They now show the widget in a plain Qt window. None of these run in the app; they exist to eyeball one widget during development.

`autolamella_fluorescence_acquisition_task_config_widget` · `autolamella_create_experiment_widget` · `autolamella_load_experiment_widget` · `autolamella_load_task_protocol_widget` · `autolamella_task_config_widget` · `beam_settings_widget` · `detector_settings_widget` · `dual_beam_widget`

## Three real, if small, uses

**`custom_widgets._invoke_action_callback`** warned through `napari.utils.notifications` when a context-menu action raised; now `notification_service`. Worth a test rather than a glance: that call sits inside a bare `except Exception: pass`, so a wrong module, function name or signature would be **swallowed** — the user would get no warning and every existing test would still pass. [tests/ui/test_context_menu_action_failure.py](tests/ui/test_context_menu_action_failure.py) asserts the toast actually arrives, names the action, and is a warning. Mutation-checked: reverting to the napari call fails it, and so does changing the toast type.

**`ui/utils.py`**'s grid-overlay demo used `napari.view_labels`. Now matplotlib with a `ListedColormap`/`BoundaryNorm`, extent in metres so the axes carry the scale the napari scale bar did.

**`FibsemManipulatorWidget`**'s `viewer` parameter was annotated `Optional["napari.Viewer"]` under `TYPE_CHECKING`. Every host has passed `None` since 4a, so the annotation was the module's only reason to know napari exists.

## What is left, and one correction to FIB-407

The remainder is the real work, and most of it is blocked:

* the minimap viewer — [FIB-405](https://linear.app/fibsemos/issue/FIB-405), phase 3
* `FMAcquisitionWidget`, `FibsemCryoDepositionWidget`, `FibsemSystemSetupWidget`, `FibsemLabellingUI`, `FibsemSegmentationModelWidget`, `fm_image_viewer_widget` — [FIB-357](https://linear.app/fibsemos/issue/FIB-357)
* the `fibsem/ui/napari/` helper package itself

**FIB-407 says sub-phase 5a (retiring the `MillingTaskViewerWidget` dual path) is unblocked once phase 4 lands. It is not.** The coincidence viewer still constructs that widget *with* a viewer and *without* a controller, so the napari pattern path remains live — that is [FIB-429](https://linear.app/fibsemos/issue/FIB-429), and 5a is blocked behind it.

## Verification

- every converted harness is free of undefined names (pyflakes — which is what caught a `QtWidgets` reference in a module that never imported it)
- the one demo that needs no microscope was run end to end; the `ui/utils.py` demo likewise
- 3,532 tests pass
- 4 new tests, mutation-checked

The single failure in the full run is a pre-existing local artefact, not code: a **gitignored, untracked** `fibsem/config/coincidence-milling-config.yaml` in my working tree declares `autogamma`, which `test_no_shipped_configuration_still_declares_it` scans for on disk. It is not in this diff and CI checks out clean.
