### PR TITLE
[ui] Result markers and the surface datum row for the correlation canvas

### DIFF
--- a/fibsem/ui/correlation/widgets/correlation_canvas_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_canvas_widget.py
@@ -9,9 +9,10 @@ this is built alongside so each piece can be reviewed and tested on its own. The
 old canvas is deleted only in the last PR of the series, once all three of its
 consumers have moved.
 
-Skeleton scope — image display, points, selection, and the add-menu. Still to
-come: legend, per-point labels, `render_to_axes`, and the reprojected-result
-overlay (`add_overlay_points` / `clear_overlay`).
+Scope so far — image display, points, selection, the add-menu, the legend and
+labels, and the reprojected-result markers. Still to come: the two-panel Save
+Plot export, which `ImagePointCanvas` served with `render_to_axes` but which is
+better rewritten in `save_plot` itself when the swap happens.
 
 What comes free with the shared canvas, and is the reason for the whole exercise:
 **contrast and gamma**, which `ImagePointCanvas` has never had — on FM data,
@@ -20,7 +21,7 @@ zoom/pan, the scalebar, the toolbar and the 11 other overlay types.
 """
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
 from PyQt5.QtCore import pyqtSignal
@@ -31,6 +32,7 @@ from fibsem.correlation.structures import Coordinate, PointType
 from fibsem.structures import FibsemImage
 from fibsem.ui.correlation.widgets.correlation_point_overlay import (
     CorrelationPointOverlay,
+    CorrelationResultOverlay,
 )
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 
@@ -61,6 +63,12 @@ class CorrelationCanvasWidget(QWidget):
         self.canvas = FibsemImageCanvas()
         self.points = CorrelationPointOverlay()
         self.canvas.add_overlay(self.points)
+        # Result markers get their own overlay: they are computed output, never
+        # picked, and keeping them off `points` is what makes them unpickable
+        # rather than something to remember. Registered second so they draw over
+        # the picked points, matching the old canvas's artist order.
+        self.results = CorrelationResultOverlay(legend_host=self.points)
+        self.canvas.add_overlay(self.results)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -114,8 +122,50 @@ class CorrelationCanvasWidget(QWidget):
 
     def set_labels_visible(self, visible: bool) -> None:
         """Show or hide the per-point names. Independent of marker visibility --
-        a crowded image often wants the points without the text."""
+        a crowded image often wants the points without the text.
+
+        Covers the result markers' numbers too: one toggle, all the text, which is
+        what the old canvas did and what makes the button mean something on an
+        image showing a result."""
         self.points.set_labels_visible(visible)
+        self.results.set_labels_visible(visible)
+
+    # ── result markers ────────────────────────────────────────────────────
+
+    def add_overlay_points(
+        self,
+        points: Sequence[Tuple[float, float]],
+        *,
+        color: str = "#ff0000",
+        label_prefix: str = "",
+        size: float = 7.0,
+        marker: str = "o",
+        alpha: float = 1.0,
+        show_labels: bool = True,
+        hollow: bool = False,
+        legend_label: Optional[str] = None,
+    ) -> None:
+        """Append a group of non-interactive result markers.
+
+        Signature kept identical to ``ImagePointCanvas.add_overlay_points`` -- the
+        tab widget's three calls move across untouched. Groups accumulate; call
+        :meth:`clear_overlay` first when replacing a previous result.
+        """
+        self.results.add_points(
+            points,
+            color=color,
+            label_prefix=label_prefix,
+            size=size,
+            marker=marker,
+            alpha=alpha,
+            show_labels=show_labels,
+            hollow=hollow,
+            legend_label=legend_label,
+        )
+
+    def clear_overlay(self) -> None:
+        """Remove every marker added via :meth:`add_overlay_points`."""
+        self.results.clear()
 
     # ── add menu ──────────────────────────────────────────────────────────
 

--- a/fibsem/ui/correlation/widgets/correlation_point_overlay.py
+++ b/fibsem/ui/correlation/widgets/correlation_point_overlay.py
@@ -1,5 +1,14 @@
 """Correlation points on the shared canvas stack (FIB-535).
 
+Two overlays, the same split the base module makes between ``PointsOverlay`` and
+``PointOverlay``:
+
+* :class:`CorrelationPointOverlay` — the interactive picked points, plus the
+  dashed datum row marking the FIB surface height.
+* :class:`CorrelationResultOverlay` — the static markers a correlation *result*
+  reprojects onto the FIB image. Not pickable, not ``Coordinate``s, and cleared
+  whenever the image beneath them changes.
+
 ``CorrelationPointOverlay`` subclasses :class:`PointOverlay` and swaps its point
 model for ``Coordinate`` — which is the whole reason this class exists.
 
@@ -28,14 +37,21 @@ had to reimplement.
 """
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
 import matplotlib.patheffects as pe
 from PyQt5.QtCore import pyqtSignal
 
 from fibsem.correlation.structures import Coordinate, PointType
 from fibsem.ui.tokens import ORANGE_COLOR
+from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
+
+if TYPE_CHECKING:
+    from matplotlib.lines import Line2D
+
+    from fibsem.ui.widgets.canvas.canvas_base import ContentRect
 
 # Saturated primaries, chosen to stay legible against arbitrary image content
 # rather than to match the app palette — the same reasoning that keeps the
@@ -63,6 +79,47 @@ MARKER_SIZE = 5.0  # the base draws the selected marker at size * 1.4 = 7.0
 # exactly where the outline has to work. 0.5 matches the old canvas; heavier
 # starts eating the glyph at this font size.
 LABEL_OUTLINE = [pe.withStroke(linewidth=0.5, foreground="black")]
+
+
+LABEL_FONTSIZE = 8
+LABEL_OFFSET = (7, 5)  # points, from the marker
+
+
+def marker_edge(color: str, marker: str, hollow: bool) -> Tuple[str, float]:
+    """Edge colour and width for a marker.
+
+    An unfilled marker ("+") *is* its edge, and a hollow ring is drawn by its edge
+    too, so both keep their own colour there — a white edge would swallow the
+    colour and leave nothing carrying it. Filled markers keep the thin white
+    outline that makes them legible against a bright image.
+
+    Shared by the drawn marker and its legend swatch so the two cannot disagree.
+    """
+    from matplotlib.lines import Line2D
+
+    if hollow or marker not in Line2D.filled_markers:
+        return color, 1.5
+    return "white", 0.8
+
+
+def legend_handle(
+    color: str, marker: str = "o", hollow: bool = False, alpha: float = 1.0
+) -> "Line2D":
+    """Proxy artist for one legend entry, styled like the marker it stands for."""
+    from matplotlib.lines import Line2D
+
+    edge_color, edge_width = marker_edge(color, marker, hollow)
+    return Line2D(
+        [], [],
+        marker=marker,
+        markersize=7,
+        color=color,
+        markerfacecolor="none" if hollow else color,
+        markeredgecolor=edge_color,
+        markeredgewidth=edge_width,
+        alpha=alpha,
+        linestyle="none",
+    )
 
 
 def generate_names(coordinates: List[Coordinate]) -> List[str]:
@@ -97,6 +154,10 @@ class CorrelationPointOverlay(PointOverlay):
         self._names: List[str] = []
         self._legend_visible = True
         self._labels_visible = True
+        # entries contributed by CorrelationResultOverlay; see set_extra_legend_entries
+        self._extra_legend: Tuple[List["Line2D"], List[str]] = ([], [])
+        self._surface_line = None  # dashed datum row; see _draw_surface_line
+        self._surface_coord: Optional[Coordinate] = None
         self.point_selected.connect(self._emit_selected)
         self.point_moved.connect(self._emit_moved)
         self.point_removed.connect(self._emit_removed)
@@ -225,6 +286,8 @@ class CorrelationPointOverlay(PointOverlay):
         # the base turns every annotation back on with the markers; labels the
         # operator switched off should stay off
         self._apply_label_visibility()
+        if self._surface_line is not None:
+            self._surface_line.set_visible(visible)
 
     def _apply_label_visibility(self) -> None:
         for ann in self._anns:
@@ -247,9 +310,10 @@ class CorrelationPointOverlay(PointOverlay):
         from a POI — so the legend is what makes the display readable, not
         decoration. Iterating ``PointType`` rather than the coordinates keeps the
         order stable as points come and go.
-        """
-        from matplotlib.lines import Line2D
 
+        The result overlay's entries are appended, so hiding the legend hides all
+        of it and the picked-point types always read first.
+        """
         if not self._legend_visible:
             return [], []
         handles, labels = [], []
@@ -257,27 +321,118 @@ class CorrelationPointOverlay(PointOverlay):
             if any(c.point_type is pt for c in self._coords):
                 handles.append(self._legend_handle(pt))
                 labels.append(pt.value)
-        return handles, labels
+        extra_handles, extra_labels = self._extra_legend
+        return handles + extra_handles, labels + extra_labels
 
     def _legend_handle(self, point_type: PointType) -> "Line2D":
         """A proxy artist matching how the point is actually drawn — same rule as
         `_marker_edge`, so an unfilled "+" keeps its colour instead of going white."""
-        from matplotlib.lines import Line2D
-
-        color = POINT_COLORS.get(point_type, "white")
-        marker = POINT_MARKERS.get(point_type, "o")
-        unfilled = marker not in Line2D.filled_markers
-        return Line2D(
-            [], [],
-            marker=marker,
-            markersize=7,
-            color=color,
-            markerfacecolor=color,
-            markeredgecolor=color if unfilled else "white",
-            markeredgewidth=1.5 if unfilled else 0.8,
-            linestyle="none",
-            label=point_type.value,
+        return legend_handle(
+            POINT_COLORS.get(point_type, "white"),
+            POINT_MARKERS.get(point_type, "o"),
         )
+
+    def set_extra_legend_entries(
+        self, handles: Sequence["Line2D"], labels: Sequence[str]
+    ) -> None:
+        """Adopt legend entries owned by another overlay on the same axes.
+
+        Correlation's result markers live on :class:`CorrelationResultOverlay`, but
+        a second ``Legend`` would land in the same corner as this one and sit on
+        top of it. They describe the same thing anyway — what a marker on this
+        image means — so there is one box, and this overlay draws it.
+        """
+        self._extra_legend = (list(handles), list(labels))
+        self._draw_legend()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    # ── the surface datum line ────────────────────────────────────────────
+
+    def _draw_all(self) -> None:
+        super()._draw_all()
+        self._draw_surface_line()
+
+    def _remove_all_artists(self) -> None:
+        super()._remove_all_artists()
+        self._remove_surface_line()
+
+    def _draw_surface_line(self) -> None:
+        """A dashed row across the image at the FIB surface height.
+
+        The FIB surface is a datum an operator reads other features against, and a
+        single marker on a large image is a poor way to read a height off. An FM
+        surface is a z-plane instead, so no in-plane line applies to it — which is
+        why only ``SURFACE`` gets one.
+
+        Only the first is drawn: the tab widget's registry makes SURFACE exclusive,
+        so a second one means the caller is mid-edit, not that two datums exist.
+        """
+        self._remove_surface_line()
+        if self._ax is None:
+            return
+        surf = next(
+            (c for c in self._coords if c.point_type is PointType.SURFACE), None
+        )
+        if surf is None:
+            return
+        self._surface_coord = surf
+        self._surface_line = self._ax.axhline(
+            surf.point.y,
+            color=POINT_COLORS[PointType.SURFACE],
+            linestyle="--",
+            zorder=4,  # under the markers, which sit at 8
+            visible=self._visible,
+        )
+        self._style_surface_line()
+
+    def _remove_surface_line(self) -> None:
+        if self._surface_line is not None:
+            try:
+                self._surface_line.remove()
+            except Exception:
+                pass  # already gone with ax.cla()
+            self._surface_line = None
+        self._surface_coord = None
+
+    def _style_surface_line(self) -> None:
+        """Selection reads as a heavier, brighter line — the colour stays the type's,
+        the same rule the markers follow."""
+        if self._surface_line is None:
+            return
+        selected = self._surface_coord is self.selected_coordinate()
+        self._surface_line.set_linewidth(1.5 if selected else 1.0)
+        self._surface_line.set_alpha(0.9 if selected else 0.6)
+
+    def _update_artist_appearance(self, idx: int) -> None:
+        super()._update_artist_appearance(idx)
+        self._style_surface_line()
+
+    def _update_artist_position(self, idx: int) -> None:
+        super()._update_artist_position(idx)
+        if self._surface_line is None or idx >= len(self._coords):
+            return
+        if self._coords[idx] is self._surface_coord:
+            y = self._points[idx][1]
+            self._surface_line.set_ydata([y, y])
+
+    def _blit_artists(self) -> List:
+        artists = super()._blit_artists()
+        if self._surface_line is not None:
+            artists.insert(0, self._surface_line)  # under the dragged marker
+        return artists
+
+    def _start_drag(self, idx: int, event) -> None:
+        # Animated *before* super() captures the background, or the line is baked
+        # into it at its old y and the blit paints a second one at the new y.
+        if self._surface_line is not None:
+            self._surface_line.set_animated(True)
+        super()._start_drag(idx, event)
+
+    def _on_release(self, event) -> None:
+        if self._surface_line is not None:
+            self._surface_line.set_animated(False)
+        super()._on_release(event)
 
     # ── interaction ───────────────────────────────────────────────────────
 
@@ -308,9 +463,203 @@ class CorrelationPointOverlay(PointOverlay):
 
         ``set_points`` redraws both via ``_draw_all``, but ``add_point`` and
         ``remove_point`` only touch one artist -- and both can change which
-        PointTypes are on screen, which is exactly what the legend reports.
+        PointTypes are on screen, which is exactly what the legend reports, and
+        whether a SURFACE point exists to hang the datum line off.
         """
         if self._anns:
             self._refresh_ann_text()
         self._apply_label_visibility()
         self._draw_legend()
+        self._draw_surface_line()
+
+
+@dataclass
+class _ResultGroup:
+    """One styled batch of result markers, exactly as ``add_points`` received it.
+
+    Kept rather than only drawn, because the axes is cleared and rebuilt on every
+    image change and the group has to be redrawable from its own description.
+    """
+
+    points: List[Tuple[float, float]] = field(default_factory=list)
+    color: str = "#ff0000"
+    label_prefix: str = ""
+    size: float = 7.0
+    marker: str = "o"
+    alpha: float = 1.0
+    show_labels: bool = True
+    hollow: bool = False
+    legend_label: Optional[str] = None
+
+
+class CorrelationResultOverlay(CanvasOverlay):
+    """Static markers reporting a correlation result — reprojected fiducials, POI.
+
+    Separate from :class:`CorrelationPointOverlay` because these are a different
+    kind of thing: they are computed output, not picked input. Nothing here is
+    draggable, deletable or addressed by ``Coordinate`` identity, and keeping them
+    off the interactive overlay is what makes that true by construction — the
+    interactive overlay hit-tests ``_points``, which these never enter.
+
+    Groups accumulate: call :meth:`clear` before the first :meth:`add_points` when
+    replacing a previous result set.
+
+    Parameters
+    ----------
+    legend_host :
+        Overlay that draws the shared legend, i.e. the ``CorrelationPointOverlay``
+        on the same canvas. See
+        :meth:`CorrelationPointOverlay.set_extra_legend_entries` for why there is
+        one box rather than two.
+    """
+
+    def __init__(self, legend_host: Optional[CorrelationPointOverlay] = None) -> None:
+        self._legend_host = legend_host
+        self._groups: List[_ResultGroup] = []
+        self._labels_visible = True
+        self._ax = None
+        self._canvas = None
+        self._artists: list = []
+        self._label_artists: list = []
+
+    # ── overlay protocol ──────────────────────────────────────────────────
+
+    def attach(self, ax, canvas) -> None:
+        self._ax = ax
+        self._canvas = canvas
+
+    def detach(self) -> None:
+        self._remove_artists()
+        self._ax = None
+        self._canvas = None
+
+    def on_content_changed(self, rect: "ContentRect") -> None:
+        """A new image discards the result rather than redrawing it.
+
+        The markers describe a correlation against the image that was underneath
+        them; over a different one they are wrong, not merely stale. The old
+        canvas made the same choice in ``set_image``, after "POI (P)" was left in
+        the legend of an image that had no POI (FIB-321).
+        """
+        self.clear()
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    def add_points(
+        self,
+        points: Sequence[Tuple[float, float]],
+        *,
+        color: str = "#ff0000",
+        label_prefix: str = "",
+        size: float = 7.0,
+        marker: str = "o",
+        alpha: float = 1.0,
+        show_labels: bool = True,
+        hollow: bool = False,
+        legend_label: Optional[str] = None,
+    ) -> None:
+        """Append a styled group of markers, numbered ``label_prefix`` + 1, 2, ...
+
+        ``hollow`` draws an unfilled ring, so the marker survives another one
+        landing on top of it — which is the normal case for the uncorrected-POI
+        ghost. ``legend_label`` adds a matching entry to the canvas legend.
+        """
+        group = _ResultGroup(
+            points=[(float(x), float(y)) for x, y in points],
+            color=color,
+            label_prefix=label_prefix,
+            size=size,
+            marker=marker,
+            alpha=alpha,
+            show_labels=show_labels,
+            hollow=hollow,
+            legend_label=legend_label,
+        )
+        self._groups.append(group)
+        self._draw_group(group)
+        self._push_legend()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def clear(self) -> None:
+        """Remove every group added via :meth:`add_points`."""
+        self._remove_artists()
+        self._groups.clear()
+        self._push_legend()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def set_labels_visible(self, visible: bool) -> None:
+        """Show or hide the per-marker numbers, leaving the markers themselves.
+
+        Driven by the same toggle as the picked points' labels: on a crowded
+        result the numbers are the first thing an operator wants gone.
+        """
+        self._labels_visible = visible
+        for ann in self._label_artists:
+            ann.set_visible(visible)
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def legend_entries(self) -> Tuple[List["Line2D"], List[str]]:
+        """``(handles, labels)`` for the groups that asked for a legend entry."""
+        handles, labels = [], []
+        for group in self._groups:
+            if not group.legend_label:
+                continue
+            handles.append(
+                legend_handle(group.color, group.marker, group.hollow, group.alpha)
+            )
+            labels.append(group.legend_label)
+        return handles, labels
+
+    # ── drawing ───────────────────────────────────────────────────────────
+
+    def _push_legend(self) -> None:
+        if self._legend_host is not None:
+            self._legend_host.set_extra_legend_entries(*self.legend_entries())
+
+    def _remove_artists(self) -> None:
+        for artist in self._artists + self._label_artists:
+            try:
+                artist.remove()
+            except Exception:
+                pass  # already gone with ax.cla()
+        self._artists.clear()
+        self._label_artists.clear()
+
+    def _draw_group(self, group: _ResultGroup) -> None:
+        if self._ax is None:
+            return
+        edge_color, edge_width = marker_edge(group.color, group.marker, group.hollow)
+        for i, (x, y) in enumerate(group.points, start=1):
+            (line,) = self._ax.plot(
+                x, y,
+                marker=group.marker,
+                markersize=group.size,
+                color=group.color,
+                markerfacecolor="none" if group.hollow else group.color,
+                markeredgecolor=edge_color,
+                markeredgewidth=edge_width,
+                linestyle="none",
+                alpha=group.alpha,
+                zorder=8,
+            )
+            self._artists.append(line)
+
+            if not group.show_labels:
+                continue
+            label = f"{group.label_prefix}{i}" if group.label_prefix else str(i)
+            ann = self._ax.annotate(
+                label,
+                xy=(x, y),
+                xytext=LABEL_OFFSET,
+                textcoords="offset points",
+                color=group.color,
+                fontsize=LABEL_FONTSIZE,
+                alpha=group.alpha,
+                zorder=9,
+                path_effects=LABEL_OUTLINE,
+            )
+            ann.set_visible(self._labels_visible)
+            self._label_artists.append(ann)

--- a/fibsem/ui/correlation/widgets/test_correlation_canvas_demo.py
+++ b/fibsem/ui/correlation/widgets/test_correlation_canvas_demo.py
@@ -14,6 +14,11 @@ What to try
   types and drop a point in the same place.
 * **Drag** a point, **click** to select, **Delete** to remove. The log shows
   what each side emits; the payloads should match.
+* **Show result** -- draws the same three marker groups the tab widget draws
+  after a correlation run (reprojected fiducials, the uncorrected-POI ghost, the
+  corrected POI). Check the legend picks up all three, the ghost stays a visible
+  ring under the marker on top of it, and that clicking a result marker does
+  nothing -- they are output, not points.
 * **Contrast / gamma** -- the toolbar button on the RIGHT canvas only. The old
   canvas has never had it, and on FM data it is the control you actually want
   while picking points.
@@ -74,6 +79,29 @@ def _seed_points() -> list:
     ]
 
 
+# The three groups CorrelationTabWidget._overlay_result_on_fib draws, verbatim.
+# The reprojected fiducials sit a few pixels off the seed points, as a real fit
+# would leave them; the ghost sits under the corrected POI, which is the case
+# `hollow` exists for.
+_RESULT_GROUPS = (
+    (
+        [(186.0, 156.0), (295.0, 337.0)],
+        dict(color="#ff4444", label_prefix="E", size=4, marker="o",
+             legend_label="FM reprojected (E)"),
+    ),
+    (
+        [(250.0, 250.0)],
+        dict(color="#ff00ff", size=7, marker="o", alpha=0.7, show_labels=False,
+             hollow=True, legend_label="POI uncorrected"),
+    ),
+    (
+        [(256.0, 254.0)],
+        dict(color="#ff00ff", label_prefix="P", size=5, marker="o",
+             legend_label="POI (P)"),
+    ),
+)
+
+
 class DemoWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
@@ -101,6 +129,8 @@ class DemoWindow(QMainWindow):
         for label, slot in (
             ("Reset both", self._reset),
             ("Clear both", self._clear),
+            ("Show result", self._show_result),
+            ("Clear result", self._clear_result),
             ("Clear log", lambda: self.log.clear()),
         ):
             btn = QPushButton(label)
@@ -189,6 +219,19 @@ class DemoWindow(QMainWindow):
         self.old.set_coordinates([])
         self.new.set_coordinates([])
         self._log("cleared both")
+
+    def _show_result(self) -> None:
+        """Same call sequence as CorrelationTabWidget._overlay_result_on_fib."""
+        for surface in (self.old, self.new):
+            surface.clear_overlay()
+            for points, style in _RESULT_GROUPS:
+                surface.add_overlay_points(points, **style)
+        self._log("drew the reprojected result on both", OK_COLOR)
+
+    def _clear_result(self) -> None:
+        for surface in (self.old, self.new):
+            surface.clear_overlay()
+        self._log("cleared the result on both")
 
     def _toggle_both(self, setter: str, on: bool, name: str) -> None:
         for surface in (self.old, self.new):

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -411,10 +411,15 @@ class PointOverlay(QObject):
         all look alike. Split from :meth:`_draw_legend` so a subclass whose points
         do *not* — correlation shows several PointTypes on one surface — can vary
         the content without restating the styling.
+
+        "No points, no legend" is decided here rather than in :meth:`_draw_legend`
+        so a subclass carrying entries that its own points do not back — the
+        correlation result markers, which live on a separate overlay — can still
+        show them.
         """
         from matplotlib.lines import Line2D
 
-        if not self._legend_label:
+        if not self._points or not self._legend_label:
             return [], []
         handle = Line2D(
             [], [], linestyle="None", marker=self._marker, markersize=9,
@@ -427,7 +432,7 @@ class PointOverlay(QObject):
     def _draw_legend(self) -> None:
         """Opt-in legend (top-left), styled like the milling-stage legend."""
         self._remove_legend()
-        if self._ax is None or not self._points or not self._visible:
+        if self._ax is None or not self._visible:
             return
         handles, labels = self._legend_entries()
         if not handles:
@@ -613,6 +618,19 @@ class PointOverlay(QObject):
         self._canvas.draw()
         self._blit_bg = self._canvas.copy_from_bbox(self._ax.bbox)
 
+    def _blit_artists(self) -> List:
+        """Artists redrawn on every drag step, in draw order.
+
+        The dragged point and its label. Split out so a subclass with an artist
+        that *tracks* a point — correlation's surface datum line — can keep it in
+        step during the drag instead of leaving it behind until release.
+        """
+        artists = [self._artists[self._drag_idx]]
+        ann = self._anns[self._drag_idx] if self._drag_idx < len(self._anns) else None
+        if ann is not None:
+            artists.append(ann)
+        return artists
+
     def _blit(self):
         if self._canvas is None or self._ax is None:
             return
@@ -620,10 +638,8 @@ class PointOverlay(QObject):
             self._canvas.draw_idle()
             return
         self._canvas.restore_region(self._blit_bg)
-        self._ax.draw_artist(self._artists[self._drag_idx])
-        ann = self._anns[self._drag_idx] if self._drag_idx < len(self._anns) else None
-        if ann is not None:
-            self._ax.draw_artist(ann)
+        for artist in self._blit_artists():
+            self._ax.draw_artist(artist)
         self._canvas.blit(self._ax.bbox)
 
     # ── mouse / key events ────────────────────────────────────────────────

--- a/tests/correlation/test_correlation_canvas_widget.py
+++ b/tests/correlation/test_correlation_canvas_widget.py
@@ -59,6 +59,21 @@ def test_image_methods_match_the_canvas_it_replaces():
         assert callable(getattr(ImagePointCanvas, name, None)), name
 
 
+def test_result_overlay_signature_matches_the_canvas_it_replaces():
+    """_overlay_result_on_fib passes these by keyword; a renamed or dropped one
+    turns the swap from a construction-site change into a rewrite."""
+    import inspect
+
+    for name in ("add_overlay_points", "clear_overlay"):
+        assert callable(getattr(CorrelationCanvasWidget, name, None)), name
+    old = inspect.signature(ImagePointCanvas.add_overlay_points).parameters
+    new = inspect.signature(CorrelationCanvasWidget.add_overlay_points).parameters
+    assert set(new) == set(old)
+    for key in old:
+        if old[key].default is not inspect.Parameter.empty:
+            assert new[key].default == old[key].default, key
+
+
 # ── points through the widget ─────────────────────────────────────────────
 
 
@@ -234,3 +249,29 @@ def test_label_toggle_reaches_the_overlay_without_hiding_points():
     w.set_labels_visible(False)
     assert [a.get_visible() for a in w.points._anns if a is not None] == [False]
     assert all(a.get_visible() for a in w.points._artists)
+
+
+def test_label_toggle_covers_the_result_markers_too():
+    """One button, all the text. Leaving the result's E1/P1 numbers behind would
+    make the toggle look broken on exactly the image that needs it most."""
+    w = _widget()
+    w.set_coordinates([_coord(10, 10)])
+    w.add_overlay_points([(20.0, 20.0)], color="#ff4444", label_prefix="E")
+
+    w.set_labels_visible(False)
+
+    assert [a.get_visible() for a in w.points._anns if a is not None] == [False]
+    assert [a.get_visible() for a in w.results._label_artists] == [False]
+
+
+def test_result_markers_go_to_the_result_overlay():
+    w = _widget()
+    w.set_coordinates([_coord(10, 10)])
+    w.add_overlay_points([(20.0, 20.0), (30.0, 30.0)], color="#ff4444",
+                         legend_label="FM reprojected (E)")
+
+    assert len(w.results._artists) == 2
+    assert w.points.get_points() == [(10.0, 10.0)]  # untouched by the result
+
+    w.clear_overlay()
+    assert w.results._artists == []

--- a/tests/correlation/test_correlation_point_overlay.py
+++ b/tests/correlation/test_correlation_point_overlay.py
@@ -4,6 +4,9 @@ The point of the subclass is that callers address points by object identity whil
 PointOverlay addresses them by index. These tests pin the seam between the two --
 above all the cases where indices shift under the caller (removal), which is where
 an index<->identity translation layer would have broken.
+
+The tail of the file covers CorrelationResultOverlay, the static sibling that
+carries a correlation result's reprojected markers.
 """
 import sys
 
@@ -18,6 +21,7 @@ from fibsem.correlation.structures import Coordinate, PointType, PointXYZ
 from fibsem.ui.correlation.widgets.correlation_point_overlay import (
     POINT_COLORS,
     CorrelationPointOverlay,
+    CorrelationResultOverlay,
     generate_names,
 )
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
@@ -36,6 +40,14 @@ def _attached(coords):
     canvas.add_overlay(ov)
     ov.set_coordinates(coords)
     return canvas, ov
+
+
+def _with_results(coords):
+    """A canvas carrying both overlays, wired as CorrelationCanvasWidget wires them."""
+    canvas, points = _attached(coords)
+    results = CorrelationResultOverlay(legend_host=points)
+    canvas.add_overlay(results)
+    return canvas, points, results
 
 
 # ── identity ──────────────────────────────────────────────────────────────
@@ -344,3 +356,268 @@ def test_a_point_added_later_gets_the_outline_too():
     _, ov = _attached([_coord(10, 10)])
     ov.add_coordinate(_coord(20, 20, PointType.POI))
     assert all(a.get_path_effects() for a in ov._anns if a is not None)
+
+
+# ── the surface datum row ─────────────────────────────────────────────────
+
+
+def _datum(ov):
+    """The dashed datum line on the axes, or None."""
+    lines = [ln for ln in ov._ax.get_lines() if ln.get_linestyle() == "--"]
+    return lines[0] if lines else None
+
+
+def test_a_fib_surface_gets_a_datum_row():
+    """A single marker is a poor way to read a height off a large image; the FIB
+    surface is a datum other features are read against."""
+    _, ov = _attached([_coord(50, 60), _coord(100, 120, PointType.SURFACE)])
+    line = _datum(ov)
+    assert line is not None
+    assert line.get_ydata()[0] == 120.0
+    assert line.get_color() == POINT_COLORS[PointType.SURFACE]
+    assert line.get_zorder() < 8  # under the markers
+
+
+def test_an_fm_surface_gets_no_datum_row():
+    """An FM surface is a z-plane, so no in-plane line applies to it."""
+    _, ov = _attached([_coord(30, 40, PointType.SURFACE_FM)])
+    assert _datum(ov) is None
+
+
+def test_the_datum_row_arrives_and_leaves_with_its_point():
+    surf = _coord(100, 120, PointType.SURFACE)
+    _, ov = _attached([_coord(50, 60)])
+    assert _datum(ov) is None
+
+    ov.add_coordinate(surf)
+    assert _datum(ov) is not None
+
+    ov.remove_coordinate(surf)
+    assert _datum(ov) is None
+
+
+def test_the_datum_row_follows_an_external_edit():
+    surf = _coord(100, 120, PointType.SURFACE)
+    _, ov = _attached([surf])
+    surf.point.y = 200.0
+    ov.refresh_coordinate(surf)
+    assert _datum(ov).get_ydata()[0] == 200.0
+
+
+def test_selecting_the_surface_weights_its_row():
+    """Selection reads as a heavier, brighter line -- the colour stays the type's,
+    the same rule the markers follow."""
+    surf = _coord(100, 120, PointType.SURFACE)
+    other = _coord(50, 60)
+    _, ov = _attached([other, surf])
+    normal = (_datum(ov).get_linewidth(), _datum(ov).get_alpha())
+
+    ov.set_selected_coordinate(surf)
+    assert (_datum(ov).get_linewidth(), _datum(ov).get_alpha()) > normal
+
+    ov.set_selected_coordinate(other)
+    assert (_datum(ov).get_linewidth(), _datum(ov).get_alpha()) == normal
+
+
+def test_the_datum_row_hides_with_the_overlay():
+    _, ov = _attached([_coord(100, 120, PointType.SURFACE)])
+    ov.set_visible(False)
+    assert not _datum(ov).get_visible()
+    ov.set_visible(True)
+    assert _datum(ov).get_visible()
+
+
+def test_a_new_image_redraws_the_datum_row():
+    canvas, ov = _attached([_coord(100, 120, PointType.SURFACE)])
+    canvas.set_array(np.zeros((64, 64), dtype=np.uint8))
+    assert _datum(ov) is not None
+    assert len([ln for ln in ov._ax.get_lines() if ln.get_linestyle() == "--"]) == 1
+
+
+def test_the_datum_row_keeps_up_with_a_drag():
+    """The base blits only the dragged marker and its label. Without the row in
+    that set it would stay at its old y until the mouse came up -- on exactly the
+    point whose whole purpose is marking that y."""
+
+    class _Event:
+        xdata, ydata, x, y = 100.0, 120.0, 0.0, 0.0
+
+    _, ov = _attached([_coord(100, 120, PointType.SURFACE)])
+    ov._start_drag(0, _Event())
+
+    line = _datum(ov)
+    # animated, so the captured background does not contain it at the old y...
+    assert line.get_animated()
+    # ...and painted on every drag step, so it appears at the new one
+    assert line in ov._blit_artists()
+
+    ov._on_release(_Event())
+    assert not line.get_animated()
+
+
+# ── result markers ────────────────────────────────────────────────────────
+#
+# The three calls below mirror CorrelationTabWidget._overlay_result_on_fib: the
+# reprojected fiducials, the uncorrected-POI ghost, and the corrected POI.
+
+
+def _add_reprojected(results):
+    results.add_points(
+        [(70.0, 65.0), (125.0, 95.0)],
+        color="#ff4444", label_prefix="E", size=4, legend_label="FM reprojected (E)",
+    )
+
+
+def _add_ghost(results):
+    results.add_points(
+        [(150.0, 150.0)],
+        color="#ff00ff", size=7, alpha=0.7, show_labels=False, hollow=True,
+        legend_label="POI uncorrected",
+    )
+
+
+def test_result_markers_never_become_pickable_points():
+    """The whole reason results live on their own overlay: the interactive one
+    hit-tests _points, so a marker that never enters it cannot be dragged or
+    deleted by a stray click, without anything having to remember that."""
+    _, points, results = _with_results([_coord(10, 10)])
+    _add_reprojected(results)
+    _add_ghost(results)
+
+    assert points.get_points() == [(10.0, 10.0)]
+    assert len(points.coordinates()) == 1
+    assert len(results._artists) == 3  # 2 reprojected + 1 ghost, all outside _points
+
+
+def test_result_groups_accumulate():
+    _, _, results = _with_results([])
+    _add_reprojected(results)
+    _add_ghost(results)
+    assert len(results._groups) == 2
+    assert len(results._artists) == 3
+
+
+def test_result_entries_are_appended_to_the_point_legend():
+    """One legend box, not two: a second Legend would be drawn in the same corner
+    and sit on top of the first. Point types read first, results after."""
+    _, points, results = _with_results([_coord(10, 10, PointType.FIB)])
+    _add_reprojected(results)
+    _add_ghost(results)
+
+    assert _drawn_legend(points) == ["FIB", "FM reprojected (E)", "POI uncorrected"]
+
+
+def test_a_group_without_a_legend_label_adds_no_entry():
+    _, points, results = _with_results([_coord(10, 10)])
+    results.add_points([(20.0, 20.0)], color="#ff4444")
+    assert _drawn_legend(points) == ["FIB"]
+
+
+def test_clearing_the_result_takes_its_legend_entries_with_it():
+    _, points, results = _with_results([_coord(10, 10)])
+    _add_reprojected(results)
+    assert _drawn_legend(points) == ["FIB", "FM reprojected (E)"]
+
+    results.clear()
+
+    assert _drawn_legend(points) == ["FIB"]
+    assert results._artists == []
+
+
+def test_a_new_image_discards_the_result():
+    """The markers describe a correlation against the image beneath them; over a
+    different one they are wrong, not stale. Matches ImagePointCanvas.set_image,
+    which started clearing them after "POI (P)" was left in the legend of an image
+    that had no POI (FIB-321)."""
+    canvas, points, results = _with_results([_coord(10, 10)])
+    _add_reprojected(results)
+
+    canvas.set_array(np.zeros((64, 64), dtype=np.uint8))
+
+    assert results._groups == []
+    assert results._artists == []
+    assert _drawn_legend(points) == ["FIB"]  # the picked point survives, the result does not
+
+
+def test_hiding_the_legend_hides_the_result_entries_too():
+    _, points, results = _with_results([_coord(10, 10)])
+    _add_reprojected(results)
+    points.set_legend_visible(False)
+    assert _drawn_legend(points) == []
+
+
+def test_a_result_with_no_picked_points_still_gets_a_legend():
+    """correlation_result_widget shows a saved result on a canvas with nothing
+    picked. The base suppresses the legend when it holds no points of its own, so
+    that rule has to key off the entries rather than the points."""
+    _, points, results = _with_results([])
+    _add_reprojected(results)
+    assert _drawn_legend(points) == ["FM reprojected (E)"]
+
+
+def test_a_hollow_swatch_matches_its_hollow_marker():
+    """The ghost is a ring: filled swatch or white edge in the legend would claim
+    a marker that is not on the image."""
+    _, points, results = _with_results([])
+    _add_ghost(results)
+    (handle,), _ = results.legend_entries()
+    marker = results._artists[0]
+
+    assert str(marker.get_markerfacecolor()) == "none"
+    assert str(handle.get_markerfacecolor()) == "none"
+    assert handle.get_markeredgecolor() == marker.get_markeredgecolor() == "#ff00ff"
+    assert handle.get_alpha() == marker.get_alpha() == pytest.approx(0.7)
+
+
+def test_result_labels_are_numbered_within_their_group():
+    _, _, results = _with_results([])
+    _add_reprojected(results)
+    results.add_points([(155.0, 152.0)], color="#ff00ff", label_prefix="P")
+    assert [a.get_text() for a in results._label_artists] == ["E1", "E2", "P1"]
+
+
+def test_show_labels_false_draws_no_numbers():
+    """The ghost sits under the corrected POI; a number there would just collide
+    with the one that matters."""
+    _, _, results = _with_results([])
+    _add_ghost(results)
+    assert results._label_artists == []
+    assert len(results._artists) == 1
+
+
+def test_result_labels_follow_the_label_toggle():
+    _, _, results = _with_results([])
+    _add_reprojected(results)
+    results.set_labels_visible(False)
+    assert [a.get_visible() for a in results._label_artists] == [False, False]
+    assert all(a.get_visible() for a in results._artists)  # markers stay
+
+
+def test_a_group_added_while_labels_are_off_arrives_hidden():
+    _, _, results = _with_results([])
+    results.set_labels_visible(False)
+    _add_reprojected(results)
+    assert [a.get_visible() for a in results._label_artists] == [False, False]
+
+
+def test_result_labels_carry_the_same_dark_outline_as_the_points():
+    """Same reason: #ff4444 and #ff00ff both disappear over a blown-out region."""
+    import matplotlib.patheffects as pe
+
+    _, _, results = _with_results([])
+    _add_reprojected(results)
+    for ann in results._label_artists:
+        effects = ann.get_path_effects()
+        assert effects, "result label has no outline"
+        assert any(isinstance(e, pe.withStroke) for e in effects)
+
+
+def test_a_result_overlay_without_a_host_still_draws():
+    """legend_host is optional -- a canvas with no point overlay (or a test) gets
+    markers without needing somewhere to put a legend."""
+    canvas = FibsemImageCanvas()
+    canvas.set_array(np.zeros((64, 64), dtype=np.uint8))
+    results = CorrelationResultOverlay()
+    canvas.add_overlay(results)
+    _add_reprojected(results)
+    assert len(results._artists) == 2


### PR DESCRIPTION
Follow-up to #321 / #324 / #325 / #329 — part of the correlation canvas consolidation ([the Linear issue](https://linear.app/fibsemos/issue/FIB-535/consolidate-the-correlation-point-canvas-onto-the-shared-canvas-stack)).

**Still not wired in.** `ImagePointCanvas` remains what the correlation tab uses; this builds alongside it, so nothing changes for the running widget.

## What was missing

Two things the old canvas draws that the replacement did not:

- **The reprojected result** — `add_overlay_points` / `clear_overlay`, i.e. the three marker groups `_overlay_result_on_fib` draws after a run.
- **The FIB surface datum row** — the dashed line across the image at the surface height. This one was not on the issue's sizing table at all; I found it by putting the two canvases side by side.

## Result markers get their own overlay

`CorrelationResultOverlay` sits alongside the interactive one — the same split the base module already makes between `PointsOverlay` and `PointOverlay`.

They are computed output, not picked input, and keeping them off the interactive overlay is what makes them unpickable: it hit-tests `_points`, which they never enter. Nothing has to remember to exclude them.

`add_overlay_points` / `clear_overlay` keep their old signature on the widget, so the tab widget's three calls move across untouched — there is a test asserting the parameter names and defaults still match.

### One legend, not two

The old canvas puts result entries in the *same* legend as the point types. Two separate legends would both land in the top-left corner and sit on top of each other.

So the result overlay hands its handles to the point overlay (`set_extra_legend_entries`, one constructor arg: `legend_host=self.points`). Pushed on every change rather than pulled at draw time, so overlay notification order does not matter.

That needed the **"no points, no legend" rule moved** out of `_draw_legend` and into `_legend_entries`, so a subclass can carry entries its own points do not back. `correlation_result_widget` shows a saved result on a canvas with nothing picked, which is exactly that case.

Behaviour-neutral for the base's five other consumers — checked exhaustively rather than argued:

| points | legend_label | visible | drawn before | drawn after |
| --- | --- | --- | --- | --- |
| ✓ | ✓ | ✓ | yes | yes |
| *all seven other combinations* | | | no | no |

## The datum row needed one base hook

`PointOverlay` blits only the dragged marker and its label. An artist that *tracks* a point would sit at its old position until the mouse came up — on the one point whose entire purpose is marking that position.

`_blit_artists()` splits that set out. The base returns exactly what it drew inline before (verified for both the labelled and unlabelled case); the correlation overlay prepends the row and animates it for the drag.

Everything else hangs off hooks that already existed: `_draw_all`, `_remove_all_artists`, `_update_artist_appearance`, `_update_artist_position`.

## Verified against the canvas it replaces

Not in the abstract — both surfaces driven through `_overlay_result_on_fib`'s exact call sequence, and through the seven states the datum row can be in.

```
result:  legend · marker styles · label texts     OK
         labels toggled off                       OK
         legend hidden                            OK
         clear_overlay()                          OK
         image swapped while a result is showing  OK
         result markers not pickable              OK

datum:   FIB only -> no row                       OK
         SURFACE present     (120.0, #ff9800, 1.0, 0.6)   OK
         SURFACE selected    (120.0, #ff9800, 1.5, 0.9)   OK
         another point selected                   OK
         dragged to y=200    (200.0, #ff9800, 1.0, 0.6)   OK
         SURFACE removed -> no row                OK
         FM surface only -> no row                OK
```

The FM-surface case is deliberate, not an omission: an FM surface is a z-plane, so no in-plane line applies to it. The old canvas made the same call.

## Testing

`1421 passed, 8 skipped` — `tests/correlation/`, `tests/ui/`. 26 new tests, **18/18 mutations caught**:

| deliberate break | caught by |
| --- | --- |
| a new image keeps the previous result | `test_a_new_image_discards_the_result` |
| legend entries not appended | `test_result_entries_are_appended_to_the_point_legend` |
| `hollow` ignored when styling the edge | `test_a_hollow_swatch_matches_its_hollow_marker` |
| the label toggle skips the result markers | `test_label_toggle_covers_the_result_markers_too` |
| the base still suppresses a legend with no points of its own | `test_a_result_with_no_picked_points_still_gets_a_legend` |
| an FM surface also gets a datum row | `test_an_fm_surface_gets_no_datum_row` |
| the row left out of the drag blit | `test_the_datum_row_keeps_up_with_a_drag` |
| selection does not weight the row | `test_selecting_the_surface_weights_its_row` |
| *…10 more* | |

Two of my mutations came back as ambiguous rather than passing, because `on_content_changed` and `clear()` had byte-identical bodies. That is now `on_content_changed` → `self.clear()`.

## How to look at it

```
PYTHONPATH=$PWD python fibsem/ui/correlation/widgets/test_correlation_canvas_demo.py
```

Old canvas left, new right, same points on both. **Show result** draws the three groups; check the legend picks up all three, the uncorrected-POI ghost stays a visible ring under the marker on top of it, and that clicking a result marker does nothing. **Reset both** puts a SURFACE point back — drag it and the datum row should track the marker, not lag it.

## Noticed while doing this

- **The shared canvas shows a crosshair by default**, which the old correlation canvas never had. It is a yellow `+` at image centre, and correlation draws `SURFACE` as an orange `+` — confusable. There is a toolbar toggle, so it is a new affordance rather than a regression; left as-is pending a call on whether the correlation canvas should default it off.
- **`ImagePointCanvas.set_image()` crashes** with `NotImplementedError: cannot remove artist` when a SURFACE point is already picked — `_surface_line` is not reset by `cla()`, and the guard catches `ValueError` only. Reachable via `set_fib_image()`. Being fixed separately; it dies with the old canvas but that is several PRs out.
