### PR TITLE
[ui] Delete the napari halves of the image and movement widgets (FIB-407)

### DIFF
--- a/fibsem/ui/FibsemImageSettingsWidget.py
+++ b/fibsem/ui/FibsemImageSettingsWidget.py
@@ -1,17 +1,13 @@
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional
 
-import numpy as np
-from napari.layers import Image as NapariImageLayer
-from napari.layers import Points as NapariPointLayer
-from napari.layers import Shapes as NapariShapesLayer
 from fibsem.ui.qt.threading import thread_worker
 from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtCore import QEvent, pyqtSignal
 from superqt import ensure_main_thread
 from fibsem.ui.icon import fibsem_icon
 
-from fibsem import acquire, constants, utils
+from fibsem import acquire, utils
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import (
     BeamSettings,
@@ -23,22 +19,6 @@ from fibsem.structures import (
 )
 from fibsem.ui import stylesheets as stylesheets
 from fibsem.ui import notification_service
-from fibsem.ui.napari.patterns import (
-    convert_reduced_area_to_napari_shape,
-    convert_shape_to_image_area,
-)
-from fibsem.ui.napari.properties import (
-    ALIGNMENT_LAYER_PROPERTIES,
-    IMAGE_TEXT_LAYER_PROPERTIES,
-    IMAGING_RULER_LAYER_PROPERTIES,
-    RULER_LAYER_NAME,
-    RULER_LINE_LAYER_NAME,
-)
-from fibsem.ui.napari.utilities import (
-    add_points_layer,
-    draw_crosshair_in_napari,
-    draw_scalebar_in_napari,
-)
 from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel, _SpinnerLabel
 from fibsem.ui.widgets.dual_beam_widget import FibsemDualBeamWidget
 from fibsem.ui.widgets.image_settings_widget import ImageSettingsWidget
@@ -59,29 +39,11 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
 
         self.parent = parent
         self.microscope = microscope
-        # Optional viewer. A host that supplies one (AutoLamella today) gets the napari
-        # layer display; a host that supplies a `view_controller` instead (standalone
-        # FibsemUI) gets the quad-view canvas. Exactly one of the two is live per
-        # instance — see `_view_controller` and `uses_napari`.
-        self.viewer = getattr(parent, "viewer", None)
-        self.eb_layer: Optional["NapariImageLayer"] = None
-        self.ib_layer: Optional["NapariImageLayer"] = None
-
-        # TODO: migrate to this structure
-        self.imaging_layers: Dict[BeamType, Optional["NapariImageLayer"]] = {}
-        self.imaging_layers[BeamType.ELECTRON] = None
-        self.imaging_layers[BeamType.ION] = None
-
         # generate initial blank images
         self.eb_image = FibsemImage.generate_blank_image(resolution=image_settings.resolution, hfw=image_settings.hfw)
         self.ib_image = FibsemImage.generate_blank_image(resolution=image_settings.resolution, hfw=image_settings.hfw)
 
-        # overlay layers
-        self.ruler_layer: Optional["NapariPointLayer"] = None
-        self.alignment_layer: Optional["NapariShapesLayer"] = None
-
         self.is_acquiring: bool = False
-        self._ruler_enabled: bool = False
         self._live_beam: Optional[BeamType] = None  # beam currently live (canvas LIVE badge)
         self._overlay_edited_wired = False  # subscribed to controller.overlay_edited
 
@@ -93,12 +55,6 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
             self._set_image_settings_to_ui(image_settings)
             self.update_ui_saving_settings()
 
-        if self.uses_napari:
-            # register initial images
-            self.eb_layer = self.viewer.add_image(self.eb_image.data, name=BeamType.ELECTRON.name, blending='additive')
-            self.ib_layer = self.viewer.add_image(self.ib_image.data, name=BeamType.ION.name, blending='additive')
-            self._on_acquire(self.eb_image)
-            self._on_acquire(self.ib_image)
         # NOTE: the canvases are intentionally left empty ("No image") on connect — no
         # blank placeholder is seeded. eb_image / ib_image remain as internal fallbacks
         # and appear once a real acquisition arrives (sem/fib_acquisition_signal).
@@ -107,11 +63,6 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
     # Display backend
     # ------------------------------------------------------------------
 
-    @property
-    def uses_napari(self) -> bool:
-        """True when this instance draws into a napari viewer rather than the quad view."""
-        return self.viewer is not None
-
     def _view_controller(self):
         """Return the quad-view MicroscopeViewController, or None when inactive.
 
@@ -119,14 +70,7 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         ``view_controller``) and AutoLamella (parent -> ``AutoLamellaUI`` ->
         ``parent_widget`` -> the main window). Check the direct parent first, then the
         AutoLamella chain; ``None`` if neither holds one.
-
-        A viewer takes precedence, keeping the two display paths strictly exclusive.
-        ``FibsemUI`` always builds a controller, so a caller that also passes a viewer
-        would otherwise get both at once — images drawn twice, and the alignment area
-        living in the model while the layer it is read back from stays empty.
         """
-        if self.uses_napari:
-            return None
         controller = getattr(self.parent, "view_controller", None)
         if controller is not None:
             return controller
@@ -184,24 +128,8 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         self._spinner = _SpinnerLabel(parent=self)
         self._spinner.setVisible(False)
 
-        # View tool buttons (scalebar, crosshair) + spinner — right-aligned alongside the lamella checkbox.
-        # These drive napari layers only; the quad-view canvas draws its own scalebar and
-        # crosshair from its own controls, so they are hidden (not just inert) when
-        # viewer-less — an unresponsive button reads as a bug.
-        self.btn_scalebar = IconToolButton(
-            icon="mdi:arrow-expand-horizontal",
-            checked_color=stylesheets.GRAY_WHITE_COLOR,
-            tooltip="Scale Bar",
-            checked=False,
-        )
-        self.btn_crosshair = IconToolButton(
-            icon="mdi:target",
-            checked_color=stylesheets.GRAY_WHITE_COLOR,
-            tooltip="Cross Hair",
-            checked=True,
-        )
-        self.btn_scalebar.setVisible(self.uses_napari)
-        self.btn_crosshair.setVisible(self.uses_napari)
+        # Scalebar and crosshair used to live here as napari-layer toggles. The canvas
+        # owns both now, with its own controls.
 
         tools_row = QtWidgets.QWidget()
         tools_layout = QtWidgets.QHBoxLayout(tools_row)
@@ -210,8 +138,6 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         tools_layout.addWidget(self.checkBox_save_with_selected_lamella)
         tools_layout.addStretch()
         tools_layout.addWidget(self._spinner)
-        tools_layout.addWidget(self.btn_scalebar)
-        tools_layout.addWidget(self.btn_crosshair)
 
         # add buttons to layout — scroll area at row 1, tools row at row 2, buttons below
         self.gridLayout.addWidget(tools_row, 2, 0, 1, 2)
@@ -278,13 +204,8 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         # image advanced toggle
         self._btn_advanced_image.toggled.connect(self.image_settings_widget.set_show_advanced)
 
-        # util
-        self.btn_scalebar.toggled.connect(self.update_ui_tools)
-        self.btn_crosshair.toggled.connect(self.update_ui_tools)
-
         # signals
         self.acquisition_progress_signal.connect(self.handle_acquisition_progress_update)
-        self.viewer_update_signal.connect(self.update_ui_tools)
 
         # auto functions
         self.pushButton_run_autocontrast.clicked.connect(self.run_autocontrast)
@@ -315,7 +236,7 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         self._connect_canvas_controls()
 
     def _connect_canvas_controls(self) -> None:
-        """Wire the quad-view-only controls. No-op on the napari path."""
+        """Wire the canvas controls. No-op until a controller is resolvable."""
         self._wd_scroll_connections: List[tuple] = []
         self._view_sync_connections: List[tuple] = []
         controller = self._view_controller()
@@ -370,15 +291,11 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
 
     @ensure_main_thread
     def _on_acquire(self, image: FibsemImage):
-        """Update the display from the main thread (napari layer or quad-view canvas)."""
+        """Update the display from the main thread."""
         try:
             if image.metadata is None:
                 raise ValueError("Image metadata is None, cannot update the display without beam type information.")
 
-            if self.uses_napari:
-                # Update existing layer
-                layer = self.viewer.layers[image.metadata.beam_type.name]
-                layer.data = image.filtered_data
             # update images references
             if self.microscope.is_acquiring:
                 if image.metadata.beam_type is BeamType.ELECTRON:
@@ -392,10 +309,6 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         except Exception as e:
             logging.error(f"Error updating image: {e}")
 
-        if self.uses_napari:
-            # dont reset view when live acq
-            self._update_layer_positions()
-            self.restore_active_layer_for_movement()
         self.viewer_update_signal.emit()
 
     def toggle_live_acquisition(self, event=None):
@@ -432,115 +345,13 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
 
     def _set_live_indicator(self, beam_type: Optional[BeamType]) -> None:
         """Drive the quad-view live indicator (green border + 'LIVE' badge): pass the live beam,
-        or None to clear. Also clears a previously-live beam (on stop or a beam switch).
-        No-op on the napari path, which has no per-view indicator."""
+        or None to clear. Also clears a previously-live beam (on stop or a beam switch)."""
         controller = self._view_controller()
         if self._live_beam is not None and self._live_beam is not beam_type and controller is not None:
             controller.set_live(self._live_beam, False)
         self._live_beam = beam_type
         if beam_type is not None and controller is not None:
             controller.set_live(beam_type, True)
-
-    def update_ruler(self):
-        """Initialise the ruler in the viewer"""
-
-        # TODO: migrate to using a line layer for everything, and enable 'select vertices' mode to move it.
-        # TODO: allow multiple rulers
-        # TODO: re-do this and consolidate into napari.utilities
-
-        if not self.uses_napari:
-            return  # napari-only tool; the quad-view canvas has no ruler yet (FIB-359)
-
-        if not self._ruler_enabled:
-            # remove the ruler layers
-            try:
-                self.viewer.layers.remove(self.ruler_layer)
-                self.viewer.layers.remove(RULER_LINE_LAYER_NAME)
-            except Exception as e:
-                logging.debug(f"Error removing ruler layers: {e}")
-            self.ruler_layer = None
-            self.restore_active_layer_for_movement()
-            return
-
-        # create an initial ruler in SEM image
-        sem_shape = self.eb_image.data.shape
-        pixelsize = self.eb_image.metadata.pixel_size.x
-        cy, cx = sem_shape[0] // 2, sem_shape[1] // 2
-        length = 400
-        data = [[cy, cx - length/2], [cy, cx + length]]
-
-        # create text label
-        dist_um = length * pixelsize * constants.SI_TO_MICRO
-        text = {
-            "string": [f"{dist_um:.2f} um", ""],
-            "color": IMAGING_RULER_LAYER_PROPERTIES["text"]["color"],
-            "translation": IMAGING_RULER_LAYER_PROPERTIES["text"]["translation"],
-            "size": IMAGING_RULER_LAYER_PROPERTIES["text"]["size"],
-        }
-
-        # create initial layers, and select the ruler layer for interaction
-        self.ruler_layer = add_points_layer(
-            self.viewer,
-            data=data,
-            name=RULER_LAYER_NAME,
-            size=IMAGING_RULER_LAYER_PROPERTIES["size"],
-            face_color=IMAGING_RULER_LAYER_PROPERTIES["face_color"],
-            border_color=IMAGING_RULER_LAYER_PROPERTIES["edge_color"],
-            text=text,
-        )
-        self.viewer.add_shapes(data, shape_type='line', edge_color='lime', name=RULER_LINE_LAYER_NAME, edge_width=5)
-        self.ruler_layer.mouse_drag_callbacks.append(self.update_ruler_points)
-        self.ruler_layer.mode = 'select'
-        self.viewer.layers.selection.active = self.ruler_layer
-
-    def update_ruler_points(self, layer: NapariPointLayer, event):
-        """Update the ruler line and value when the mouse is dragged"""
-
-        # TODO: update this to use the new data changed api in napari
-        # self.ruler_layer.events.data.connect(self._update_ruler)
-        # event.action == "changing", "changed", "added", "removed"...
-
-        dragged = False
-        yield
-
-        def check_point_image_in_eb(point: Tuple[int, int]) -> bool:
-            if point[1] >= 0 and point[1] <= self.eb_layer.data.shape[1]:
-                return True
-            else:
-                return False
-
-        while event.type == 'mouse_move':
-
-            # if no points are selected, do nothing
-            if self.ruler_layer.selected_data is None:
-                yield
-
-            data = self.ruler_layer.data
-
-            p1, p2 = data[0], data[1]
-            dist_px = np.linalg.norm(p1-p2)
-
-            if check_point_image_in_eb(p1):
-                pixelsize = self.eb_image.metadata.pixel_size.x
-            else:
-                pixelsize = self.ib_image.metadata.pixel_size.x
-
-            dist_um = dist_px * pixelsize * constants.SI_TO_MICRO
-
-            text = {
-                "string": [f"{dist_um:.2f} um", ""],
-                "color": IMAGING_RULER_LAYER_PROPERTIES["text"]["color"],
-                "translation": IMAGING_RULER_LAYER_PROPERTIES["text"]["translation"],
-                "size": IMAGING_RULER_LAYER_PROPERTIES["text"]["size"],
-            }
-
-            self.viewer.layers[RULER_LAYER_NAME].text = text
-            self.viewer.layers.selection.active = self.ruler_layer
-            self.viewer.layers[RULER_LINE_LAYER_NAME].data = [p1, p2]
-            self.viewer.layers[RULER_LINE_LAYER_NAME].refresh()
-
-            dragged = True
-            yield
 
     def run_autocontrast(self) -> None:
         """Run autocontrast for the selected beam type."""
@@ -776,100 +587,8 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
 
         logging.debug({"msg": "acquisition_worker", "image_settings": self.image_settings.to_dict()})
 
-    def update_ui_tools(self):
-        """Redraw the ui tools (scalebar, crosshair)"""
-
-        if not self.uses_napari:
-            return  # the quad-view canvas draws its own scalebar/crosshair
-
-        # draw scalebar and crosshair
-        if self.eb_image is not None and self.ib_image is not None:
-            draw_scalebar_in_napari(
-                viewer=self.viewer,
-                sem_shape=self.eb_image.data.shape,
-                fib_shape=self.ib_image.data.shape,
-                sem_fov=self.eb_image.metadata.image_settings.hfw,
-                fib_fov=self.ib_image.metadata.image_settings.hfw,
-                is_checked=self.btn_scalebar.isChecked(),
-            )
-            fm_shape = None
-            if self.microscope.fm is not None:
-                try:
-                    fm_shape = self.microscope.fm.camera.resolution[::-1]
-                except Exception as e:
-                    logging.error(f"Failed to get fm image shape: {e}", exc_info=True)
-            draw_crosshair_in_napari(
-                viewer=self.viewer,
-                sem_shape=self.eb_image.data.shape,
-                fib_shape=self.ib_image.data.shape,
-                fm_shape=fm_shape,
-                is_checked=self.btn_crosshair.isChecked(),
-            )
-
-        # restore active layer for movement
-        self.restore_active_layer_for_movement()
-
-    def _update_layer_positions(self):
-        """Update the positions of the image layers in the viewer. Ion beam to the right of electron beam."""
-        if not self.uses_napari:
-            return  # the quad view gives each beam its own canvas — nothing to translate
-        # translate ion beam layer to the right of electron beam, adjust the camera
-        if self.eb_layer and self.ib_layer:
-            self.ib_layer.translate = [0.0, self.eb_layer.data.shape[1]]
-
-            # position the image text layer
-            points = np.array([[-20, 200], [-20, self.ib_layer.translate[1] + 150]])
-
-            try:
-                self.viewer.layers[IMAGE_TEXT_LAYER_PROPERTIES["name"]].data = points
-            except KeyError:
-                add_points_layer(
-                    viewer=self.viewer,
-                    data=points,
-                    name=IMAGE_TEXT_LAYER_PROPERTIES["name"],
-                    size=IMAGE_TEXT_LAYER_PROPERTIES["size"],
-                    text=IMAGE_TEXT_LAYER_PROPERTIES["text"],
-                    border_width=IMAGE_TEXT_LAYER_PROPERTIES["border_width"],
-                    border_width_is_relative=IMAGE_TEXT_LAYER_PROPERTIES[
-                        "border_width_is_relative"
-                    ],
-                    border_color=IMAGE_TEXT_LAYER_PROPERTIES["border_color"],
-                    face_color=IMAGE_TEXT_LAYER_PROPERTIES["face_color"],
-                )
-                self.viewer.reset_view()
-
-    def get_data_from_coord(self, coords: Tuple[float, float]) -> Tuple[Tuple[float, float], BeamType, FibsemImage]:
-
-        # TODO: change this to use the image layers, and extent
-
-        # check inside image dimensions, (y, x)
-        eb_shape = self.eb_image.data.shape[0], self.eb_image.data.shape[1]
-        ib_shape = self.ib_image.data.shape[0], self.ib_image.data.shape[1] + self.eb_image.data.shape[1]
-
-        if (coords[0] > 0 and coords[0] < eb_shape[0]) and (
-            coords[1] > 0 and coords[1] < eb_shape[1]
-        ):
-            image = self.eb_image
-            beam_type = BeamType.ELECTRON
-
-        elif (coords[0] > 0 and coords[0] < ib_shape[0]) and (
-            coords[1] > eb_shape[0] and coords[1] < ib_shape[1]
-        ):
-            image = self.ib_image
-            coords = (coords[0], coords[1] - ib_shape[1] // 2)
-            beam_type = BeamType.ION
-        else:
-            beam_type, image = None, None
-
-        # logging
-        logging.debug({"msg": "get_data_from_coord", "coords": coords, "beam_type": beam_type})
-
-        return coords, beam_type, image
-
     def closeEvent(self, event: QEvent):
         self._teardown_connections()
-        if self.uses_napari:
-            self.viewer.layers.clear()
         event.accept()
 
     def _teardown_connections(self) -> None:
@@ -910,46 +629,28 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         self._view_sync_connections = []
 
     def clear_viewer(self):
-        if self.uses_napari:
-            self.viewer.layers.clear()
-        self.eb_layer = None
-        self.ib_layer = None
         controller = self._view_controller()
         if controller is not None:
             controller.clear()
-
-    def restore_active_layer_for_movement(self):
-        """Restore the active layer to the electron beam for movement"""
-        if not self.uses_napari:
-            return  # no layer stack; the quad view routes input per canvas
-        if self.eb_layer in self.viewer.layers:
-            self.viewer.layers.selection.active = self.eb_layer
 
     def clear_alignment_area(self):
         """Hide the alignment area, keeping its value.
 
         The workflow reads ``get_alignment_area()`` straight after sending its "clear"
-        (``update_alignment_area_ui``), so the rect must survive being hidden — on the napari
-        path the layer keeps its data, and on the quad view the model keeps its value.
+        (``update_alignment_area_ui``), so the rect has to survive being hidden — the
+        model keeps its value while the overlay comes off.
         """
         controller = self._view_controller()
         if controller is not None:
             controller.set_alignment_edit(BeamType.ION, None, editing=False)
-            return
-        if self.alignment_layer is not None:
-            self.alignment_layer.mode = "pan_zoom"
-            self.alignment_layer.visible = False
-        self.restore_active_layer_for_movement()
 
     def toggle_alignment_area(self, reduced_area: FibsemRectangle, editable: bool = True):
-        """Toggle the alignment area layer to selection mode, and display the alignment area."""
+        """Display the editable alignment area on the FIB canvas."""
         controller = self._view_controller()
         if controller is not None:
             self._ensure_overlay_edited_wiring(controller)
             # editing wins over the milling read-only display + owns FIB input
             controller.set_alignment_edit(BeamType.ION, reduced_area, editing=editable)
-            return
-        self.set_alignment_layer(reduced_area, editable=editable)
 
     def _ensure_overlay_edited_wiring(self, controller) -> None:
         """Subscribe (once) to the controller's overlay-edit signal so a user drag of the
@@ -967,49 +668,6 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
         just drives validation, so it forwards the edit without caching it."""
         if overlay_id == "alignment":
             self.alignment_area_updated.emit(value)
-
-    def set_alignment_layer(
-        self,
-        reduced_area: FibsemRectangle = FibsemRectangle(0.25, 0.25, 0.5, 0.5),
-        editable: bool = True,
-    ):
-        """Set the alignment area layer in napari."""
-
-        # add alignment area to napari
-        data = convert_reduced_area_to_napari_shape(
-            reduced_area=reduced_area,
-            image_shape=self.ib_image.data.shape,
-        )
-        if self.alignment_layer is None or ALIGNMENT_LAYER_PROPERTIES["name"] not in self.viewer.layers:
-            self.alignment_layer = self.viewer.add_shapes(
-                data=data,
-                name=ALIGNMENT_LAYER_PROPERTIES["name"],
-                shape_type=ALIGNMENT_LAYER_PROPERTIES["shape_type"],
-                edge_color=ALIGNMENT_LAYER_PROPERTIES["edge_color"],
-                edge_width=ALIGNMENT_LAYER_PROPERTIES["edge_width"],
-                face_color=ALIGNMENT_LAYER_PROPERTIES["face_color"],
-                opacity=ALIGNMENT_LAYER_PROPERTIES["opacity"],
-                translate=self.ib_layer.translate,  # match the fib layer translation
-            )
-            self.alignment_layer.metadata = ALIGNMENT_LAYER_PROPERTIES["metadata"]
-            self.alignment_layer.events.data.connect(self.update_alignment)
-            self.alignment_area_updated.connect(self._on_alignment_area_updated)
-        else:
-            self.alignment_layer.data = data
-
-        if editable:
-            self.alignment_layer.visible = True
-            self.viewer.layers.selection.active = self.alignment_layer
-            self.alignment_layer.mode = "select"
-            self.alignment_layer.selected_data.clear()
-        # TODO: prevent rotation of rectangles?
-
-    def update_alignment(self, event):
-        """Validate the alignment area, and update the parent ui."""
-        reduced_area = self.get_alignment_area()
-        if reduced_area is None:
-            return
-        self.alignment_area_updated.emit(reduced_area)
 
     def _on_alignment_area_updated(self, reduced_area: FibsemRectangle):
         """Update the parent ui with the new alignment area. (compatibility for AutoLamellaUI)
@@ -1030,14 +688,8 @@ class FibsemImageSettingsWidget(QtWidgets.QWidget):
             logging.info(f"Error updating alignment area: {e}")
 
     def get_alignment_area(self) -> Optional[FibsemRectangle]:
-        """Get the alignment area — from the scene model (quad view) or the layer (napari)."""
+        """Get the alignment area from the scene model."""
         controller = self._view_controller()
         if controller is not None:
             return controller.alignment_area(BeamType.ION)
-        if self.alignment_layer is None:
-            return None
-        data = self.alignment_layer.data
-        if data is None or len(data) == 0:
-            return None
-        data = data[0]
-        return convert_shape_to_image_area(data, self.ib_image.data.shape)
+        return None

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -18,7 +18,6 @@ from fibsem.structures import (
     Point,
 )
 from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
-from fibsem.ui.napari.utilities import update_text_overlay
 from fibsem.ui.stylesheets import (
     LABEL_INSTRUCTIONS_STYLE,
     PRIMARY_BUTTON_STYLESHEET,
@@ -46,27 +45,15 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             raise ValueError("Parent must have an 'image_widget' attribute of type FibsemImageSettingsWidget")
 
         self.microscope = microscope
-        # Optional: quad-view hosts run viewer-less (double-click and the position readout
-        # come from the canvases and the controller's info bar instead).
-        self.viewer = getattr(parent, "viewer", None)
         self.image_widget: FibsemImageSettingsWidget = parent.image_widget
         self.setup_connections()
-
-    @property
-    def uses_napari(self) -> bool:
-        """True when this instance takes its input from a napari viewer."""
-        return self.viewer is not None
 
     def _view_controller(self):
         """Return the quad-view MicroscopeViewController, or None if unavailable.
 
         Resolved like the image widget: the direct parent (standalone ``FibsemUI``) or
-        parent -> ``parent_widget`` (AutoLamella) holds ``view_controller``. A viewer takes
-        precedence, keeping the two input paths strictly exclusive — otherwise a host with
-        both would arm napari *and* canvas double-click and move the stage twice per click.
+        parent -> ``parent_widget`` (AutoLamella) holds ``view_controller``.
         """
-        if self.uses_napari:
-            return None
         controller = getattr(self.parent, "view_controller", None)
         if controller is not None:
             return controller
@@ -186,30 +173,22 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.pushButton_move_to_sem_orientation.clicked.connect(lambda: self.move_to_orientation("SEM"))
         self.btn_refresh_stage.clicked.connect(lambda: self.update_ui(None))
 
-        # register mouse callbacks
+        # register mouse callbacks — one canvas per beam. The canvases are app-lifetime
+        # (owned by the controller), so store each (canvas, slot) pair and disconnect it in
+        # _teardown_connections: this widget is torn down via removeTab + deleteLater
+        # (which fires neither closeEvent nor close), and a stale double-click firing on the
+        # deleted widget makes PyQt call qFatal -> the process aborts (FIB-329).
+        # partial (not lambda) so the exact slot object can be disconnected.
         self._canvas_dbl_click_conns = []
-        if self.uses_napari:
-            if cfg.FEATURE_VIEWER_MOVEMENT_EVENTS:
-                self.viewer.mouse_double_click_callbacks.append(self._viewer_double_click)
-            else:
-                self.image_widget.eb_layer.mouse_double_click_callbacks.append(self._double_click)
-                self.image_widget.ib_layer.mouse_double_click_callbacks.append(self._double_click)
-        else:
-            # One canvas per beam (quad-view). The canvases are app-lifetime (owned by the
-            # controller), so store each (canvas, slot) pair and disconnect it in
-            # _teardown_connections: this widget is torn down via removeTab + deleteLater
-            # (which fires neither closeEvent nor close), and a stale double-click firing on
-            # the deleted widget makes PyQt call qFatal -> the process aborts (FIB-329).
-            # partial (not lambda) so the exact slot object can be disconnected.
-            controller = self._view_controller()
-            if controller is not None:
-                for canvas, beam in (
-                    (controller.sem_canvas, BeamType.ELECTRON),
-                    (controller.fib_canvas, BeamType.ION),
-                ):
-                    slot = partial(self._on_canvas_double_click, beam)
-                    canvas.canvas_double_clicked.connect(slot)
-                    self._canvas_dbl_click_conns.append((canvas, slot))
+        controller = self._view_controller()
+        if controller is not None:
+            for canvas, beam in (
+                (controller.sem_canvas, BeamType.ELECTRON),
+                (controller.fib_canvas, BeamType.ION),
+            ):
+                slot = partial(self._on_canvas_double_click, beam)
+                canvas.canvas_double_clicked.connect(slot)
+                self._canvas_dbl_click_conns.append((canvas, slot))
 
         # disable ui elements
         self.label_movement_instructions.setText(INSTRUCTIONS_TEXT)
@@ -341,11 +320,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     def _update_position_readout(
         self, stage_position: Optional[FibsemStagePosition] = None
     ) -> None:
-        """Refresh the stage/beam readout — the napari text overlay or, viewer-less, the
-        quad-view info bar (debounced render)."""
-        if self.uses_napari:
-            update_text_overlay(self.viewer, self.microscope, stage_position=stage_position)
-            return
+        """Refresh the stage/beam readout on the quad-view info bar (debounced render)."""
         controller = self._view_controller()
         if controller is not None:
             controller.update_info(self.microscope, stage_position=stage_position)
@@ -446,16 +421,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
 
         return stage_position
 
-    def _viewer_double_click(self, viewer, event):
-        """Viewer-level double-click callback (FEATURE_VIEWER_MOVEMENT_EVENTS).
-        Determines which image layer was clicked and delegates to _double_click."""
-        for layer in [self.image_widget.eb_layer, self.image_widget.ib_layer]:
-            coords = layer.world_to_data(event.position)
-            _, beam_type, _ = self.image_widget.get_data_from_coord(coords)
-            if beam_type is not None:
-                self._double_click(layer, event)
-                return
-
     def _click_to_move_available(self) -> bool:
         """Whether a click may start a stage move right now.
 
@@ -469,56 +434,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         """
         return self.pushButton_move.isEnabled()
 
-    def _double_click(self, layer, event):
-        """Callback for double-click mouse events on the image widget"""
-        if not self._click_to_move_available():
-            return
-        self._toggle_interactions(enable= False)
-
-        worker = self._double_click_worker(layer, event)
-        worker.finished.connect(self.move_stage_finished)
-        worker.start()
-
-    @thread_worker
-    def _double_click_worker(self, layer, event):
-        """Thread worker for double-click mouse events on the image widget"""
-        if event.button != 1 or "Shift" in event.modifiers:
-            return
-
-        if hasattr(self.parent, "milling_widget") and self.parent.milling_widget.is_milling:
-            notification_service.show_toast("Cannot move stage while milling is in progress.")
-            return
-
-        # get coords
-        coords = layer.world_to_data(event.position)
-
-        # TODO: dimensions are mixed which makes this confusing to interpret... resolve
-        coords, beam_type, image = self.image_widget.get_data_from_coord(coords)
-        self.movement_progress_signal.emit({"msg": "Click to move in progress..."})
-
-        if beam_type is None:
-            notification_service.show_toast(
-                "Clicked outside image dimensions. Please click inside the image to move."
-            )
-            return
-        if image.metadata is None:
-            notification_service.show_toast(
-                "Image metadata is not set. Please set the image metadata before moving."
-            )
-            return
-
-        point = conversions.image_to_microscope_image_coordinates(
-            coord=Point(x=coords[1], y=coords[0]),
-            image=image.data,
-            pixelsize=image.metadata.pixel_size.x,
-        )
-
-        # move
-        vertical_move = True if "Alt" in event.modifiers else False
-        self._execute_stage_move(
-            beam_type, point, vertical_move, coords={"x": coords[1], "y": coords[0]}
-        )
-
     def _execute_stage_move(
         self,
         beam_type: BeamType,
@@ -528,8 +443,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     ) -> None:
         """Dispatch a stage move from a microscope-space delta (worker thread).
 
-        Shared by the napari and quad-view double-click paths — the two differ only in how
-        they turn a click into ``point``, not in what the move does. ``coords`` is the
+        ``coords`` is the
         originating image-space click, carried through purely so the debug log still
         records where the operator actually clicked when a move goes wrong on hardware.
         """
@@ -561,7 +475,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.update_ui_after_movement()
 
     def _on_canvas_double_click(self, beam_type: BeamType, x: float, y: float, modifiers) -> None:
-        """Quad-view canvas double-click -> move stage (mirrors ``_double_click``)."""
+        """Canvas double-click -> move stage."""
         if not self._click_to_move_available():
             return
         self._toggle_interactions(enable=False)
@@ -573,9 +487,8 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     def _canvas_double_click_worker(self, beam_type: BeamType, x: float, y: float, modifiers):
         """Thread worker for quad-view double-clicks (one image per canvas).
 
-        ``x, y`` are already beam-local, full-resolution image pixels (the canvas emits data
-        coords), so no napari ``world_to_data`` / side-by-side offset handling is needed —
-        unlike ``_double_click_worker``, which has to work out which half was clicked.
+        ``x, y`` are already beam-local, full-resolution image pixels — the canvas emits
+        data coords, one image per canvas, so there is no side-by-side offset to undo.
         """
         if "Shift" in modifiers:
             return

--- a/fibsem/ui/widgets/milling_task_viewer_widget.py
+++ b/fibsem/ui/widgets/milling_task_viewer_widget.py
@@ -148,11 +148,11 @@ class MillingTaskViewerWidget(QWidget):
         if iw is not None:
             try:
                 self._fib_image = iw.ib_image
-                # Still load-bearing: the napari pattern path and the right-click
-                # reposition menu are both gated on _fib_image_layer, and the Microscope
-                # tab never calls set_fib_image() — this pickup is its only source. It
-                # goes unused (harmlessly) once a controller is attached.
-                self._fib_image_layer = iw.ib_layer
+                # No layer pickup: the image widget is canvas-only now, so the hosts that
+                # inject an image_widget always take the controller path below. Callers
+                # still on napari (the coincidence viewer) supply their own layer through
+                # set_fib_image(). NOTE both reads used to sit in this try together — an
+                # AttributeError on the layer would have silently skipped the connect.
                 iw.viewer_update_signal.connect(self._on_viewer_image_updated)
             except Exception:
                 pass
@@ -408,7 +408,6 @@ class MillingTaskViewerWidget(QWidget):
                 return
         try:
             self._fib_image = iw.ib_image
-            self._fib_image_layer = iw.ib_layer  # re-read per frame; see _setup_viewer_integration
             self._schedule_pattern_update()
         except Exception as e:
             logging.error(f"MillingTaskViewerWidget: viewer image update error: {e}")
@@ -465,11 +464,6 @@ class MillingTaskViewerWidget(QWidget):
             if self._pattern_update_pending:
                 self._schedule_pattern_update()
 
-        # Drawing the pattern shapes leaves them selected in napari; reselect the beam
-        # layer or click-to-move starts hitting the shapes layer. Napari path only —
-        # the canvas path returned above and has no layer selection to restore.
-        if self._image_widget is not None:
-            self._image_widget.restore_active_layer_for_movement()
 
     def _update_canvas_patterns(self) -> None:
         """Push the current enabled stages to the FIB canvas via the reducer (quad-view)."""

--- a/fibsem/ui/widgets/tests/test-image-settings-widget.py
+++ b/fibsem/ui/widgets/tests/test-image-settings-widget.py
@@ -5,12 +5,18 @@ Run with:
     python fibsem/ui/widgets/tests/test-image-settings-widget.py
 """
 import sys
-from PyQt5.QtWidgets import QApplication, QPushButton, QVBoxLayout, QWidget
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QPushButton,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+)
 
-import napari
 from fibsem import utils
-from fibsem.structures import ImageSettings, BeamType
 from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
+from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
 
 
 class _MockMovementWidget:
@@ -20,10 +26,14 @@ class _MockMovementWidget:
 
 
 class MockParent(QWidget):
-    """Minimal parent that satisfies FibsemImageSettingsWidget requirements."""
-    def __init__(self, viewer: napari.Viewer):
+    """Minimal parent that satisfies FibsemImageSettingsWidget requirements.
+
+    The widget resolves its display through ``view_controller`` on the parent — the
+    shape standalone FibsemUI presents. It has no napari path left.
+    """
+    def __init__(self):
         super().__init__()
-        self.viewer = viewer
+        self.view_controller = MicroscopeViewController(parent=self)
         self.movement_widget = _MockMovementWidget()
 
 
@@ -33,9 +43,7 @@ def main():
     microscope, settings = utils.setup_session(manufacturer="Demo", ip_address="localhost")
     image_settings = settings.image
 
-    viewer = napari.Viewer()
-
-    parent = MockParent(viewer=viewer)
+    parent = MockParent()
 
     widget = FibsemImageSettingsWidget(
         microscope=microscope,
@@ -84,10 +92,20 @@ def main():
     btn_det.clicked.connect(print_detector_settings)
     layout.addWidget(btn_det)
 
-    viewer.window.add_dock_widget(widget, area="right", name="Image Settings")
-    viewer.window.add_dock_widget(panel, area="right", name="Test Controls")
+    # quad view (left) | widget + diagnostics (right), as the real host lays it out
+    right = QWidget()
+    right_layout = QVBoxLayout(right)
+    right_layout.setContentsMargins(0, 0, 0, 0)
+    right_layout.addWidget(widget)
+    right_layout.addWidget(panel)
 
-    napari.run()
+    window = QSplitter(Qt.Horizontal)
+    window.addWidget(parent.view_controller.widget)
+    window.addWidget(right)
+    window.setSizes([720, 460])
+    window.resize(1280, 800)
+    window.show()
+    app.exec_()
 
 
 if __name__ == "__main__":

--- a/fibsem/ui/widgets/tests/test_lamella_protocol_editor_canvas.py
+++ b/fibsem/ui/widgets/tests/test_lamella_protocol_editor_canvas.py
@@ -334,32 +334,28 @@ def test_milling_widget_switches_to_the_canvas_when_given_a_controller():
 
 
 class _FakeImageWidget(QWidget):
-    """Stands in for FibsemImageSettingsWidget: the napari Microscope tab feeds the
-    milling widget through these three attributes and nothing else."""
+    """Stands in for FibsemImageSettingsWidget, which is canvas-only now: it still
+    carries the FIB image and still emits on every new frame, but has no napari layer."""
 
     viewer_update_signal = pyqtSignal()
 
-    def __init__(self, image, layer):
+    def __init__(self, image):
         super().__init__()
         self.ib_image = image
-        self.ib_layer = layer
 
 
-def test_napari_callers_still_get_their_fib_image_layer():
-    """The napari pattern path is gated on _fib_image_layer, and the only thing that
-    ever supplies it for the Microscope tab is `iw.ib_layer` being picked up here —
-    that tab never calls set_fib_image(). Lose the pickup and milling patterns silently
-    stop drawing and the right-click reposition menu stops appearing, in a tab this
-    phase is not supposed to touch at all.
+def test_napari_callers_supply_their_own_fib_image_layer():
+    """The napari pattern path is gated on ``_fib_image_layer``, and ``set_fib_image()``
+    is now its *only* source. It used to also be picked up from ``iw.ib_layer``, but the
+    image widget dropped its layers when the Microscope tab moved to the canvas; the
+    remaining napari caller (the coincidence viewer) has always used set_fib_image().
     """
     microscope, _ = _session()
     image = FibsemImage.generate_blank_image(resolution=_RESOLUTION, hfw=_HFW)
     sentinel = object()  # a napari layer, only ever passed through
-    iw = _FakeImageWidget(image, sentinel)
 
-    w = MillingTaskViewerWidget(
-        microscope=microscope, viewer=None, image_widget=iw, milling_enabled=False
-    )
+    w = MillingTaskViewerWidget(microscope=microscope, viewer=None, milling_enabled=False)
+    w.set_fib_image(image, sentinel)
     assert w._fib_image is image
     assert w._fib_image_layer is sentinel, (
         "napari callers lost their image layer — patterns and the reposition menu "
@@ -367,22 +363,31 @@ def test_napari_callers_still_get_their_fib_image_layer():
     )
 
 
-def test_napari_callers_keep_the_layer_across_an_image_update():
-    """Same gate, on the live-acquisition path: every new FIB frame re-reads ib_layer."""
+def test_a_new_frame_refreshes_the_image_and_reschedules_the_patterns():
+    """``_setup_viewer_integration`` and ``_on_viewer_image_updated`` both read from the
+    image widget inside a bare try/except. They used to read ``ib_layer`` there too —
+    once the image widget lost its layers, that read would have raised *inside the try*
+    and silently skipped the ``viewer_update_signal`` connect and the reschedule after
+    it, so patterns would quietly stop following the live image.
+    """
     microscope, _ = _session()
     image = FibsemImage.generate_blank_image(resolution=_RESOLUTION, hfw=_HFW)
-    iw = _FakeImageWidget(image, object())
+    iw = _FakeImageWidget(image)
+
     w = MillingTaskViewerWidget(
         microscope=microscope, viewer=None, image_widget=iw, milling_enabled=False
     )
+    assert w._fib_image is image
+
+    scheduled = []
+    w._schedule_pattern_update = lambda: scheduled.append(1)
 
     new_image = FibsemImage.generate_blank_image(resolution=_RESOLUTION, hfw=_HFW)
-    new_layer = object()
-    iw.ib_image, iw.ib_layer = new_image, new_layer
-    w._on_viewer_image_updated()
+    iw.ib_image = new_image
+    iw.viewer_update_signal.emit()  # drive the connection, not the handler
 
-    assert w._fib_image is new_image
-    assert w._fib_image_layer is new_layer, "image update dropped the layer"
+    assert w._fib_image is new_image, "a new frame did not reach the milling widget"
+    assert scheduled, "a new frame did not reschedule the pattern update"
 
 
 def test_eye_toggle_routes_through_the_reducer_when_wired():

--- a/fibsem/ui/widgets/tests/test_viewer_less_widgets.py
+++ b/fibsem/ui/widgets/tests/test_viewer_less_widgets.py
@@ -1,16 +1,12 @@
-"""The image and movement widgets must work with OR without a napari viewer (FIB-406, P4a).
+"""The image and movement widgets drive the quad-view canvas (FIB-406 / FIB-407).
 
-Standalone ``FibsemUI`` now runs viewer-less on the quad-view canvas while AutoLamella's
-Microscope tab still runs on napari, so both widgets carry two display paths at once,
-selected per instance by whether the host supplies a ``viewer`` or a ``view_controller``.
-The failure mode this guards is a silent one: pick the wrong branch and the widget still
-constructs, still acquires, and simply draws nothing.
+Both widgets carried two display paths while the tabs migrated one at a time, selected
+per instance by whether the host supplied a ``viewer`` or a ``view_controller``. Every
+host is viewer-less now and the napari halves are deleted, so the tests that pinned
+*which branch ran* went with them — what is left pins the canvas behaviour itself.
 
-The viewer-less half runs against a **real** ``MicroscopeViewController`` and real canvases.
-The napari half runs against a stub viewer — napari's GL canvas cannot be constructed under
-``QT_QPA_PLATFORM=offscreen`` (it aborts the process), so a stub is the only way to assert
-the napari branch at all here. That is a real limit on this file: it pins *which branch runs
-and what it calls*, not napari's own rendering.
+The failure mode worth guarding is still a silent one: get the wiring wrong and the
+widget constructs, acquires, and simply draws nothing.
 
 Run directly (no display needed):
     QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_viewer_less_widgets.py
@@ -93,106 +89,12 @@ def _movement_widget(host) -> FibsemMovementWidget:
     return widget
 
 
-# --- napari stubs ------------------------------------------------------------
+# --- the controller is found -------------------------------------------------
 
 
-class _StubLayer:
-    def __init__(self, data, name):
-        self.data = data
-        self.name = name
-        self.translate = [0.0, 0.0]
-        self.visible = True
-        self.mode = "pan_zoom"
-        self.metadata = {}
-        self.mouse_double_click_callbacks = []
-        self.mouse_drag_callbacks = []
-        self.selected_data = set()
-        self.events = _StubEvents()
-
-
-class _StubEvents:
-    def __init__(self):
-        self.data = _StubSignal()
-
-
-class _StubSignal:
-    def __init__(self):
-        self.callbacks = []
-
-    def connect(self, fn):
-        self.callbacks.append(fn)
-
-
-class _StubLayerList(list):
-    """napari's LayerList iterates *layers* but indexes by name — a dict subclass would
-    yield names on iteration and break ``draw_scalebar_in_napari``, which reads ``.name``
-    off each item."""
-
-    def __init__(self):
-        super().__init__()
-        self.selection = type("S", (), {"active": None})()
-
-    def __getitem__(self, key):
-        if isinstance(key, str):
-            for layer in self:
-                if layer.name == key:
-                    return layer
-            raise KeyError(key)
-        return super().__getitem__(key)
-
-    def __contains__(self, item):
-        if isinstance(item, str):
-            return any(layer.name == item for layer in self)
-        return any(layer is item for layer in self)
-
-    def remove(self, item):
-        for layer in list(self):
-            if layer is item or layer.name == item:
-                super().remove(layer)
-                return
-
-
-class _StubViewer:
-    """The slice of napari.Viewer these widgets touch. See the module docstring for why."""
-
-    def __init__(self):
-        self.layers = _StubLayerList()
-        self.title = ""
-        # the stage/beam readout the movement widget writes on the napari path
-        self.text_overlay = type("T", (), {"text": "", "visible": False, "position": ""})()
-
-    def add_image(self, data, name=None, blending=None, **kw):
-        layer = _StubLayer(data, name)
-        self.layers.append(layer)
-        return layer
-
-    def add_shapes(self, data=None, name=None, **kw):
-        layer = _StubLayer(data, name)
-        self.layers.append(layer)
-        return layer
-
-    def add_points(self, data=None, name=None, **kw):
-        layer = _StubLayer(data, name)
-        self.layers.append(layer)
-        return layer
-
-    def reset_view(self):
-        pass
-
-
-class _NapariHost(QWidget):
-    def __init__(self) -> None:
-        super().__init__()
-        self.viewer = _StubViewer()
-
-
-# --- which display backend is chosen -----------------------------------------
-
-
-def test_viewer_less_host_uses_the_controller():
+def test_host_with_a_controller_resolves_it():
     host = _CanvasHost()
     widget = _image_widget(host)
-    assert widget.uses_napari is False
     assert widget._view_controller() is host.view_controller
 
 
@@ -203,55 +105,6 @@ def test_controller_resolves_through_parent_widget():
     host = _NestedCanvasHost(outer)
     widget = _image_widget(host)
     assert widget._view_controller() is outer.view_controller
-
-
-def test_napari_host_keeps_the_layer_path():
-    host = _NapariHost()
-    widget = _image_widget(host)
-    assert widget.uses_napari is True
-    assert widget._view_controller() is None, "a viewer host must not pick up a controller"
-    assert widget.eb_layer is not None and widget.ib_layer is not None
-    names = {layer.name for layer in host.viewer.layers}
-    assert names >= {BeamType.ELECTRON.name, BeamType.ION.name}
-
-
-class _BothHost(QWidget):
-    """A misconfigured host holding both. ``FibsemUI`` always builds a controller, so
-    ``FibsemUI(viewer=...)`` reaches exactly this shape."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.viewer = _StubViewer()
-        self.view_controller = MicroscopeViewController(parent=self)
-
-
-def test_a_viewer_wins_when_a_host_offers_both():
-    """The two paths must be strictly exclusive. Running both would draw every image
-    twice and, worse, put the alignment area in the model while ``get_alignment_area``
-    reads it back off an empty layer."""
-    host = _BothHost()
-    widget = _image_widget(host)
-    assert widget.uses_napari is True
-    assert widget._view_controller() is None, "both display paths active at once"
-
-    movement = _movement_widget(host)
-    assert movement._view_controller() is None
-    assert movement._canvas_dbl_click_conns == [], "a click here would move the stage twice"
-
-    widget._on_acquire(_image(BeamType.ELECTRON))
-    assert host.view_controller.get_canvas(BeamType.ELECTRON)._content_extent() is None
-
-
-def test_scalebar_and_crosshair_buttons_are_napari_only():
-    """They drive napari layers; the canvas has its own. Left visible they would be dead
-    controls — hidden, not merely inert, so nothing reads as broken."""
-    canvas_widget = _image_widget(_CanvasHost())
-    assert not canvas_widget.btn_scalebar.isVisibleTo(canvas_widget)
-    assert not canvas_widget.btn_crosshair.isVisibleTo(canvas_widget)
-
-    napari_widget = _image_widget(_NapariHost())
-    assert napari_widget.btn_scalebar.isVisibleTo(napari_widget)
-    assert napari_widget.btn_crosshair.isVisibleTo(napari_widget)
 
 
 # --- images actually reach the display ---------------------------------------
@@ -272,22 +125,13 @@ def test_acquired_image_lands_on_its_own_beam_canvas():
     assert fib_canvas._content_extent() is not None, "FIB image did not reach the canvas"
 
 
-def test_no_blank_placeholder_is_seeded_viewer_less():
+def test_no_blank_placeholder_is_seeded():
     """napari seeded two blank images at construction; the canvas shows "No image"
     instead. Seeding would put a grey rectangle up that looks like a failed acquisition."""
     host = _CanvasHost()
     _image_widget(host)
     assert host.view_controller.get_canvas(BeamType.ELECTRON)._content_extent() is None
     assert host.view_controller.get_canvas(BeamType.ION)._content_extent() is None
-
-
-def test_napari_path_still_writes_to_the_layer():
-    host = _NapariHost()
-    widget = _image_widget(host)
-    image = _image(BeamType.ELECTRON)
-    widget._on_acquire(image)
-    layer = host.viewer.layers[BeamType.ELECTRON.name]
-    assert np.array_equal(layer.data, image.filtered_data), "layer not updated"
 
 
 # --- the alignment-area contract ---------------------------------------------
@@ -313,7 +157,7 @@ def test_clearing_the_alignment_area_keeps_its_value():
 
 
 def test_alignment_edit_forwards_to_the_existing_signal():
-    """A canvas drag must drive the same validation path the napari layer event did."""
+    """A canvas drag must drive the widget's existing validation path."""
     host = _CanvasHost()
     widget = _image_widget(host)
     seen = []
@@ -368,11 +212,6 @@ def test_working_distance_spinbox_resolves_the_scroll_step():
     )
 
 
-def test_wd_scroll_is_not_wired_on_the_napari_path():
-    widget = _image_widget(_NapariHost())
-    assert widget._wd_scroll_connections == []
-
-
 # --- quad-view selection <-> beam radio --------------------------------------
 
 
@@ -407,22 +246,11 @@ def test_selecting_the_fm_view_leaves_the_beam_radios_alone():
 # --- movement: double-click input --------------------------------------------
 
 
-def test_movement_binds_double_click_to_both_canvases_viewer_less():
+def test_movement_binds_double_click_to_both_canvases():
     host = _CanvasHost()
     _image_widget(host)
     movement = _movement_widget(host)
-    assert movement.uses_napari is False
     assert len(movement._canvas_dbl_click_conns) == 2
-
-
-def test_movement_keeps_napari_layer_callbacks_with_a_viewer():
-    host = _NapariHost()
-    image_widget = _image_widget(host)
-    movement = _movement_widget(host)
-    assert movement.uses_napari is True
-    assert movement._canvas_dbl_click_conns == [], "canvas input wired on the napari path"
-    assert movement._double_click in image_widget.eb_layer.mouse_double_click_callbacks
-    assert movement._double_click in image_widget.ib_layer.mouse_double_click_callbacks
 
 
 def test_a_second_double_click_during_a_move_is_ignored():
@@ -464,16 +292,6 @@ def test_click_to_move_is_blocked_while_acquiring_after_a_move():
     assert not movement._click_to_move_available(), (
         "click-to-move re-armed while the post-move acquisition was still running"
     )
-
-
-def test_the_napari_double_click_honours_the_same_gate():
-    """Same guard on both paths — the napari one has the identical overlap."""
-    import inspect
-
-    # `from fibsem.ui import FibsemMovementWidget` yields the *class* (re-exported by
-    # fibsem/ui/__init__.py), not the module — read the method off the class directly.
-    source = inspect.getsource(FibsemMovementWidget._double_click)
-    assert "_click_to_move_available" in source
 
 
 class _NoopWorker:
@@ -534,15 +352,6 @@ def test_teardown_is_idempotent():
     assert widget._wd_scroll_connections == []
     assert widget._view_sync_connections == []
     assert movement._canvas_dbl_click_conns == []
-
-
-def test_teardown_on_the_napari_path_does_not_raise():
-    """FibsemUI calls it unconditionally on disconnect, whichever path is live."""
-    host = _NapariHost()
-    widget = _image_widget(host)
-    movement = _movement_widget(host)
-    widget._teardown_connections()
-    movement._teardown_connections()
 
 
 # --- position readout ---------------------------------------------------------


### PR DESCRIPTION
Both widgets carried two display paths so the tabs could migrate one at a time. Every host has passed `viewer=None` since 4a/4b, so **the napari halves have been dead in the app since the Microscope tab flipped**. This deletes them: **−717 lines, +108**.

## What goes

**`FibsemImageSettingsWidget`** — the eb/ib/ruler/alignment layers, the ruler, the scalebar and crosshair toggles (the canvas owns both), `_update_layer_positions`, `get_data_from_coord`, `restore_active_layer_for_movement`, `update_ui_tools`, and the napari half of the alignment area. 1043 → 696 lines.

**`FibsemMovementWidget`** — `_viewer_double_click`, `_double_click`, `_double_click_worker`, and the napari text-overlay readout.

`uses_napari` goes with them — and with it the guard that kept the two paths mutually exclusive, so the five `_view_controller()` resolvers now agree on one shape. That was the drift the 4b review flagged as worth fixing when the halves came out.

## One removal was not safe on its own

`MillingTaskViewerWidget` picked up `iw.ib_layer` in two places, each inside a bare `try/except` with load-bearing statements *after* it:

```python
self._fib_image = iw.ib_image
self._fib_image_layer = iw.ib_layer      # <- would now raise AttributeError
iw.viewer_update_signal.connect(...)      # <- silently skipped
...
self._schedule_pattern_update()           # <- silently skipped
```

Deleting the layers would have **quietly stopped milling patterns following the live image**, with nothing raising and no log line. Both pickups are removed instead. The remaining napari caller — the coincidence viewer — supplies its layer through `set_fib_image()`, which it always did.

`test_a_new_frame_refreshes_the_image_and_reschedules_the_patterns` pins this, and it **emits `viewer_update_signal` rather than calling the handler**, so it tests the connection and not just the slot. Restoring either read fails it; I checked.

## Tests

The two tests that guarded the old pickup are **rewritten, not deleted** — their premise was "the Microscope tab never calls `set_fib_image()`, so `ib_layer` is its only source", and that tab is not on this path at all any more.

The napari-branch tests in `test_viewer_less_widgets.py` go, along with the stub viewer they needed: there is only one branch left to select. `test-image-settings-widget.py` now runs the widget against a real quad view instead of a napari dock.

## Verification

- **3,549 tests pass**
- an AST pass over every changed class lists each removed/shortened method; all 30 are intentional, and no method lost its tail
- AutoLamella launched and driven — no errors
- no new lint against main's baseline

## Not in scope

`MillingTaskViewerWidget` **keeps** its napari path: the coincidence viewer still constructs it with a viewer and no controller. That is [FIB-429](https://linear.app/fibsemos/issue/FIB-429), and it is what blocks sub-phase 5a.
