### PR TITLE
[fix] Disconnect every microscope signal when the FM widget is torn down (FIB-550)

### DIFF
--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -91,6 +91,11 @@ class FMControlWidget(QWidget):
         self._acquisition_thread: Optional[FunctionWorker] = None
         self._acquisition_stop_event = threading.Event()
         self._current_acquisition_type: Optional[str] = None
+        # Initialised here, not only in the acquire methods: the widget is connected to
+        # the microscope's progress signal from construction, so a workflow task driving
+        # the FM reaches _on_acquisition_progress without this widget having started
+        # anything.
+        self._last_remaining_time: Optional[float] = None
 
         # FM canvas click context (quad-view): retained from the latest image so a
         # double-click can convert pixel -> stage without napari layer metadata
@@ -352,11 +357,23 @@ class FMControlWidget(QWidget):
         fires). The quad-view ``fm_canvas`` outlives this widget, so its connections
         MUST come down or a stale double-click/scroll drives the stage or objective
         through a destroyed widget — and PyQt turns that into qFatal (FIB-329).
+
+        The three ``fm`` signals are psygnal, not Qt, so nothing disconnects them for
+        us when the widget dies: psygnal's weak ref is to the *Python* object, and
+        ``deleteLater`` destroys the C++ one underneath it while that stays alive. The
+        host tears down without stopping the acquisition first
+        (``AutoLamellaUI.setup_experiment``), so a disconnect during a live run leaves
+        a worker emitting into these slots (FIB-550).
         """
-        try:
-            self.fm.acquisition_signal.disconnect(self.update_image)
-        except (TypeError, RuntimeError):
-            pass
+        for signal, slot in (
+            (self.fm.acquisition_signal, self.update_image),
+            (self.fm.acquisition_progress_signal, self._on_acquisition_progress),
+            (self.fm.acquiring_changed, self._on_fm_acquiring_changed),
+        ):
+            try:
+                signal.disconnect(slot)
+            except (TypeError, RuntimeError):
+                pass
 
         if self._fm_canvas is not None:
             for signal, slot in (

--- a/tests/ui/test_fm_control_widget_teardown.py
+++ b/tests/ui/test_fm_control_widget_teardown.py
@@ -1,0 +1,103 @@
+"""What must stop reaching FMControlWidget once the host has torn it down (FIB-550).
+
+The three signals it takes from the microscope are psygnal, not Qt, so nothing
+disconnects them on its behalf: psygnal's weak reference is to the *Python* object, and
+``deleteLater`` destroys the C++ one underneath while that stays alive. The host
+(``AutoLamellaUI``) tears down without stopping the acquisition first, so a disconnect
+mid-run leaves a worker emitting into slots whose widgets are gone.
+
+The failure this pins is not a wrong value -- it is a `RuntimeError: wrapped C/C++
+object ... has been deleted` raised inside somebody else's worker thread, which reads
+as a broken acquisition rather than as a teardown bug.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5 import sip
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget, _DemoHost
+
+# Enough of a progress payload to reach the task bar and the remaining-time branch.
+PROGRESS = {"zlevel": 1, "total_zlevels": 3, "current": 1, "total": 4}
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def widget(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _DemoHost()
+    w = FMControlWidget(microscope=build_microscope(), parent=host)
+    # Keep the host alive for the test's duration; the widget only weakly needs it,
+    # but a collected parent would destroy the child and mask what we are testing.
+    w._test_host = host
+    return w
+
+
+def _fm_slots(signal):
+    return [repr(s) for s in signal._slots]
+
+
+def test_teardown_disconnects_every_microscope_signal(widget):
+    """All three, not just `acquisition_signal` -- the other two were missed."""
+    fm = widget.fm
+    widget._teardown_connections()
+
+    for name, signal, slot_name in (
+        ("acquisition_signal", fm.acquisition_signal, "update_image"),
+        (
+            "acquisition_progress_signal",
+            fm.acquisition_progress_signal,
+            "_on_acquisition_progress",
+        ),
+        ("acquiring_changed", fm.acquiring_changed, "_on_fm_acquiring_changed"),
+    ):
+        assert not any(slot_name in s for s in _fm_slots(signal)), (
+            f"{name} still connected to {slot_name} after teardown"
+        )
+
+
+def test_emitting_after_teardown_and_delete_does_not_raise(widget):
+    """The real sequence, verbatim: teardown -> the C++ object goes -> a worker emits.
+
+    ``sip.delete`` is the synchronous stand-in for ``deleteLater``, so this needs no
+    event loop. Before the fix each of these raised RuntimeError out of the emit.
+    """
+    fm = widget.fm
+    widget._current_acquisition_type = "overview"
+
+    widget._teardown_connections()
+    sip.delete(widget)
+    assert sip.isdeleted(widget)
+
+    # Would raise psygnal's EmitLoopError (from RuntimeError) if either slot survived.
+    fm.acquisition_progress_signal.emit(PROGRESS)
+    fm.acquiring_changed.emit(False)
+    fm.acquisition_signal.emit(None)
+
+
+def test_teardown_is_idempotent(widget):
+    """Called from `closeEvent` AND the host's `deleteLater` path, so it runs twice."""
+    for _ in range(3):
+        widget._teardown_connections()
+
+
+def test_progress_before_any_local_acquisition_does_not_raise(widget):
+    """A workflow task drives the FM while the tab sits open.
+
+    The widget is connected from construction, so it receives progress for an
+    acquisition it never started -- reaching the remaining-time branch with
+    `_last_remaining_time` never assigned by one of its own acquire methods.
+    """
+    widget._current_acquisition_type = "overview"
+    widget.fm.acquisition_progress_signal.emit(PROGRESS)


### PR DESCRIPTION
`FMControlWidget._teardown_connections` exists to bring down every external connection before the host calls `deleteLater` — its docstring cites FIB-329 by name. It covered `acquisition_signal`, both `fm_canvas` signals and `lamella_selected`, but **not** the two other signals `connect_signals` takes from the microscope ([`:297-298`](https://github.com/fibsem-os/fibsem-os/blob/main/fibsem/ui/widgets/fluorescence_control_widget.py#L297-L298)):

```python
self.fm.acquisition_progress_signal.connect(self._on_acquisition_progress)
self.fm.acquiring_changed.connect(self._on_fm_acquiring_changed)
```

## Why nothing caught it

Both are **psygnal** `Signal`s on `FluorescenceMicroscope`, not Qt signals — so Qt's disconnect-when-the-receiver-dies never applies. psygnal's weak reference is to the *Python* object, while `deleteLater` destroys the **C++** one underneath it, leaving the callback live and pointed at dead widgets.

`AutoLamellaUI` tears the widget down **without stopping the acquisition first** (unlike `closeEvent`, which does):

```python
self.fm_control_widget._teardown_connections()
self.tabWidget.removeTab(...)
self.fm_control_widget.deleteLater()
```

So a microscope disconnect during a run left a worker emitting into a destroyed widget:

```
acquisition_progress_signal -> _on_acquisition_progress:492
  RuntimeError: wrapped C/C++ object of type QProgressBar has been deleted
acquiring_changed -> _update_acquisition_button_states:940
  RuntimeError: wrapped C/C++ object of type QPushButton has been deleted
```

**Severity, not overstated:** psygnal re-raises those into the emitter — the acquisition worker thread — so the symptom is a dead acquisition with a confusing traceback. I did *not* observe the SIGABRT the FIB-329 comments describe; the callback runs through psygnal rather than Qt's meta-object system, so PyQt's qFatal hook may not be in play.

## How it surfaced

The deleted `FMAcquisitionWidget` (#334) carried a hand-rolled guard: `_on_acquisition_progress` touched the progress bar inside `try/except RuntimeError` and disconnected itself on failure. Reviewing that deletion raised the question of whether `FMControlWidget` needed the same thing. It did — but the guard was the weaker form: it covered only one of the two signals, and healed after the fact instead of preventing it. Disconnecting at teardown is the same fix done once, in the method whose entire job that is.

## Also

`_last_remaining_time` was assigned in the three acquire paths but never in `__init__`, so a progress payload arriving before any of them raised `AttributeError` at `:566`. Reachable when a workflow task drives the FM while the Fluorescence tab sits open — the widget is connected from construction and receives progress for acquisitions it did not start. One-line initialisation.

## Tests

New `tests/ui/test_fm_control_widget_teardown.py`, driving the real sequence (`_teardown_connections` → `sip.delete` → emit). **3 of its 4 cases fail on `main` and pass with the fix**; the idempotency case correctly passes both ways.

It goes in `tests/ui/` rather than beside the existing teardown tests in `fibsem/ui/widgets/tests/`, because `testpaths = ["tests"]` never collects that directory — those three FIB-329 teardown tests have never run in CI.

821 tests pass across `tests/fm/` and the FM UI suites.