### PR TITLE
[ui] Take the system setup and cryo deposition harnesses off napari

### DIFF
--- a/fibsem/ui/FibsemCryoDepositionWidget.py
+++ b/fibsem/ui/FibsemCryoDepositionWidget.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
-import napari
 from PyQt5 import QtWidgets
 from PyQt5.QtGui import QFont
 
@@ -119,15 +118,25 @@ class FibsemCryoDepositionWidget(QtWidgets.QDialog):
 
 
 def main():
+    """Standalone harness: show the dialog in a plain Qt window.
 
-    viewer = napari.Viewer(ndisplay=2)
+    napari was only ever hosting the dialog here (FIB-407). It also supplied the
+    QApplication and the dark theme the dialog is shown against in the app, so
+    both are set up explicitly.
+    """
+    import sys
+
+    from fibsem.ui import stylesheets
+
+    app = QtWidgets.QApplication(sys.argv)
+    app.setStyleSheet(stylesheets.NAPARI_STYLE)
+
     microscope, settings = utils.setup_session()
     cryo_sputter_widget = FibsemCryoDepositionWidget(microscope)
-    viewer.window.add_dock_widget(
-        cryo_sputter_widget, area="right", add_vertical_stretch=False
-    )
-    napari.run()
+    cryo_sputter_widget.show()
+
+    sys.exit(app.exec_())
 
 
 if __name__ == "__main__":
-    main()  
+    main()

--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -2,7 +2,6 @@ import logging
 from pprint import pprint
 from typing import Optional
 
-import napari
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import pyqtSignal
 from fibsem.ui.icon import fibsem_icon
@@ -285,13 +284,24 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
 
 
 def main():
+    """Standalone harness: show the widget in a plain Qt window.
 
-    viewer = napari.Viewer(ndisplay=2)
+    napari was only ever hosting the widget here (FIB-407). It also supplied the
+    QApplication and the dark theme, so both are set up explicitly — this widget
+    paints itself in the dark palette (PANEL_COLOR, BORDER_COLOR, the status
+    icons), which needs NAPARI_STYLE underneath it to read correctly.
+    """
+    import sys
+
+    app = QtWidgets.QApplication(sys.argv)
+    app.setStyleSheet(stylesheets.NAPARI_STYLE)
+
     system_widget = FibsemSystemSetupWidget()
-    viewer.window.add_dock_widget(
-        system_widget, area="right", add_vertical_stretch=False
-    )
-    napari.run()
+    system_widget.setWindowTitle("Microscope Setup")
+    system_widget.resize(400, 300)
+    system_widget.show()
+
+    sys.exit(app.exec_())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two more harness-only importers, **15 down to 13**. Continues the phase 5 napari
removal (FIB-407) after #332 and #335.

Both widgets used napari purely to host themselves in `main()` —
`napari.Viewer(ndisplay=2)`, `add_dock_widget`, `napari.run()` — and neither widget
body referenced it at all. #332's body filed these two under FIB-357 alongside the
segmentation and labelling widgets; that was wrong. They have nothing to do with
FIB-357 and were never blocked on it.

## What changed

Each `main()` now builds a `QApplication` explicitly — napari had been supplying one
implicitly — and applies `NAPARI_STYLE`.

The stylesheet is a deliberate departure from the eight harnesses converted in #332.
`FibsemSystemSetupWidget` paints itself in `PANEL_COLOR`/`BORDER_COLOR` with dark
status icons, so on the default Qt light theme it reads wrong. The #332 widgets only
ever set `font-weight`, so they didn't need it.

## Verification

Stronger than #332, where `setup_session()` made the harnesses unrunnable and
pyflakes was the most that could be checked. Both of these were **run headless** with
`exec_()` stubbed to return, so construction, styling and `show()` all execute for
real. Both reach `sys.exit(0)` with the widget shown and a 6420-char stylesheet
applied.

`tests/ui/` + `fibsem/ui/widgets/tests/`: 1232 passed, 1 skipped.

## Two findings, neither fixed here

**`fibsem/ui/__init__.py` makes napari unavoidable.** It imports
`FibsemMinimapWidget` eagerly, so *any* `fibsem.ui.*` import pulls napari in —
`import fibsem.ui.tokens` alone is enough, confirmed by tracing `__import__`. The lazy
minimap import added in phase 4a therefore buys nothing today, and no amount of
per-file cleanup will make napari optional until that line moves. Left alone because
it needs a considered change rather than a quiet one: `AutoLamellaMainUI.py:49` relies
on the class rebinding that `from fibsem.ui import FibsemMinimapWidget` performs, so
this wants PEP 562 `__getattr__`, not a deletion.

**A latent crash in the cryo dialog**, pre-existing and unrelated to napari.
`FibsemCryoDepositionWidget.setup_connections` loads `cfg.POSITION_PATH` unguarded,
and `saved-positions.yaml` is gitignored, so constructing the dialog on a fresh
checkout raises `FileNotFoundError`. This is what stopped the harness running until I
made a temporary file. Latent rather than live: `AutoLamellaUI.cryo_deposition` (line
1677) has no callers, so nothing in the app can open it today — but it would bite
whoever rewires that menu entry, and per FIB-329 an exception escaping that slot
aborts the process.

---

Branch and title deliberately omit the issue ID: FIB-407 has auto-closed twice
already, once from a branch name and once from a PR title.
