### PR TITLE
[test] Move the viewer-less widget tests into tests/ where pytest collects them

### DIFF
--- a/tests/ui/test_viewer_less_widgets.py
+++ b/tests/ui/test_viewer_less_widgets.py
@@ -9,7 +9,7 @@ The failure mode worth guarding is still a silent one: get the wiring wrong and 
 widget constructs, acquires, and simply draws nothing.
 
 Run directly (no display needed):
-    QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_viewer_less_widgets.py
+    QT_QPA_PLATFORM=offscreen python tests/ui/test_viewer_less_widgets.py
 """
 from __future__ import annotations
 
@@ -18,7 +18,12 @@ import sys
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-import numpy as np
+import pytest
+
+# CI installs `.[test]`, not `.[ui]`, so PyQt5 is absent there. Without this the
+# module-level import below turns a skip into a collection error.
+pytest.importorskip("PyQt5")
+
 from PyQt5.QtWidgets import QApplication, QWidget
 
 from fibsem import utils


### PR DESCRIPTION
`pyproject.toml` sets `testpaths = ["tests"]`, so **nothing under `fibsem/` is ever collected**. `fibsem/ui/widgets/tests/test_viewer_less_widgets.py` is 24 real headless tests — not a GUI harness — and none of them have run since they were written.

Among them are the three that pin the FIB-329 teardown contract: that a canvas double-click or Shift+scroll delivered after `_teardown_connections` cannot reach a destroyed widget. That gap surfaced while reviewing #336, which fixes the same class of bug in the FM widget.

## The change

`git mv` plus a 7-line header edit. The only substantive addition:

```python
pytest.importorskip("PyQt5")
```

ahead of the module-level PyQt5 import, matching every other file in `tests/ui`. CI installs `.[test]`, not `.[ui]`, so without it the import turns what should be a skip into a **collection error** — one red build for the whole matrix. (Dropped an unused `import numpy as np` while in the header.)

## Verified both ways

| | |
| --- | --- |
| PyQt5 present | 24 collected by `pytest tests/`, 24 passed |
| PyQt5 unimportable | `1 skipped` — byte-identical to what an existing `tests/ui` file emits under the same conditions |
| `tests/ui -n auto --dist worksteal` | 1090 passed, 1 skipped — the module-level `QApplication` does not collide with the per-module `qapp` fixtures |

The no-PyQt5 case was checked with a `MetaPathFinder` raising `ModuleNotFoundError` for `PyQt5.*`, which is what an absent module actually raises — worth stating because raising plain `ImportError` instead produces a `PytestDeprecationWarning`, and this repo runs `filterwarnings = ["error"]`, so that would fail. Real CI hits the `ModuleNotFoundError` path.

## What this does not do

**It does not make these run in CI.** Like every file in `tests/ui`, they will *skip* there until a job installs the `[ui]` extra — and the workflow's exclusion is deliberate and commented:

```yaml
# UI deps (the [ui] extra) are intentionally not installed: the
# napari/PyQt5 tests importorskip and are skipped on CI.
```

This PR puts them where such a job would pick them up, and makes them run for anyone who has the extra locally. Adding the job is a separate decision — it means installing napari/PyQt5 and running under `QT_QPA_PLATFORM=offscreen` across some or all of the six-version matrix, at real CI-minute cost, and reversing a documented choice. Happy to open it if wanted.

## Not addressed

~56 other `test_*.py` files live under `fibsem/` and are likewise never collected. Most are genuine GUI demo harnesses that should stay put; a handful are real tests. This PR moves only the file in question rather than sweeping them all.