### PR TITLE
[ui] Groundwork for the correlation canvas swap: shared picking, a canvas-agnostic Save Plot

### DIFF
--- a/fibsem/ui/correlation/widgets/correlation_canvas_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_canvas_widget.py
@@ -1,7 +1,7 @@
 """Correlation point-picking on the shared canvas stack (FIB-535).
 
-`FibsemImageCanvas` + :class:`CorrelationPointOverlay`, exposing the same signals
-and methods as :class:`ImagePointCanvas` so the eventual swap in
+`FibsemImageCanvas` + :class:`CorrelationPicking`, exposing the same signals and
+methods as :class:`ImagePointCanvas` so the eventual swap in
 ``correlation_tab_widget`` is a construction-site change and nothing more.
 
 **Not wired in yet.** `ImagePointCanvas` remains what the correlation tab and the
@@ -9,11 +9,10 @@ FM display use; this is built alongside so each piece can be reviewed and tested
 on its own. The old canvas is deleted only in the last PR of the series, once
 both have moved.
 
-Scope so far — image display, points, selection, the add-menu, the legend and
-labels, and the reprojected-result markers. The two-panel Save Plot export no
-longer needs anything here: `save_plot` renders any matplotlib canvas through
-`_render_canvas_to_axes`, so `render_to_axes` has no successor and dies with the
-old canvas.
+Everything about *picking* lives in :mod:`correlation_picking`, shared with the
+FM side, which puts the identical behaviour on an `FMCanvasWidget` instead. What
+stays here is the half that genuinely differs between the two: how an image gets
+onto the canvas.
 
 What comes free with the shared canvas, and is the reason for the whole exercise:
 **contrast and gamma**, which `ImagePointCanvas` has never had — on FM data,
@@ -26,14 +25,10 @@ from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
 from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtGui import QCursor
-from PyQt5.QtWidgets import QAction, QMenu, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
 from fibsem.correlation.structures import Coordinate, PointType
-from fibsem.ui.correlation.widgets.correlation_point_overlay import (
-    CorrelationPointOverlay,
-    CorrelationResultOverlay,
-)
+from fibsem.ui.correlation.widgets.correlation_picking import CorrelationPicking
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 
 
@@ -55,42 +50,51 @@ class CorrelationCanvasWidget(QWidget):
         allowed_point_types: Optional[List[PointType]] = None,
     ) -> None:
         super().__init__(parent)
-        # None means "every type"; an empty list means "adding is off" -- the same
-        # convention ImagePointCanvas uses, kept so a read-only canvas cannot
-        # silently regain an add menu across the swap.
-        self._allowed_types = allowed_point_types
-
         self.canvas = FibsemImageCanvas()
-        self.points = CorrelationPointOverlay()
-        self.canvas.add_overlay(self.points)
-        # Result markers get their own overlay: they are computed output, never
-        # picked, and keeping them off `points` is what makes them unpickable
-        # rather than something to remember. Registered second so they draw over
-        # the picked points, matching the old canvas's artist order.
-        self.results = CorrelationResultOverlay(legend_host=self.points)
-        self.canvas.add_overlay(self.results)
+        # The shared canvas draws a yellow "+" at image centre by default and the
+        # old correlation canvas drew none. Correlation draws SURFACE as an orange
+        # "+", so the two are easy to confuse on the one point whose whole job is
+        # marking a position -- and it would land in a saved plot. The toolbar
+        # toggle still brings it back.
+        self.canvas.set_crosshair_visible(False)
+
+        self.picking = CorrelationPicking(
+            self.canvas,
+            allowed_point_types=allowed_point_types,
+            menu_parent=self,
+        )
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.canvas)
 
-        # Identity signals straight through; only the add path needs translating,
-        # because the overlay reports *where* and this widget decides *what*.
-        self.points.coordinate_selected.connect(self.point_selected)
-        self.points.coordinate_moved.connect(self.point_moved)
-        self.points.coordinate_removed.connect(self.point_removed)
-        self.points.add_requested.connect(self._show_add_menu)
+        # Forwarded rather than left on `.picking`, so the tab widget and its
+        # _CanvasAdapter connect to this exactly as they do to ImagePointCanvas.
+        self.picking.point_selected.connect(self.point_selected)
+        self.picking.point_moved.connect(self.point_moved)
+        self.picking.point_removed.connect(self.point_removed)
+        self.picking.point_add_requested.connect(self.point_add_requested)
+
+    @property
+    def points(self):
+        """The interactive point overlay."""
+        return self.picking.points
+
+    @property
+    def results(self):
+        """The static result-marker overlay."""
+        return self.picking.results
 
     # ── the _CanvasAdapter surface ────────────────────────────────────────
 
     def set_coordinates(self, coords: List[Coordinate]) -> None:
-        self.points.set_coordinates(coords)
+        self.picking.set_coordinates(coords)
 
     def set_selected(self, coord: Optional[Coordinate]) -> None:
-        self.points.set_selected_coordinate(coord)
+        self.picking.set_selected(coord)
 
     def refresh_coordinate(self, coord: Coordinate) -> None:
-        self.points.refresh_coordinate(coord)
+        self.picking.refresh_coordinate(coord)
 
     # ── image ─────────────────────────────────────────────────────────────
 
@@ -125,17 +129,15 @@ class CorrelationCanvasWidget(QWidget):
 
     def set_legend_visible(self, visible: bool) -> None:
         """Show or hide the point-type legend (one swatch per type on screen)."""
-        self.points.set_legend_visible(visible)
+        self.picking.set_legend_visible(visible)
 
     def set_labels_visible(self, visible: bool) -> None:
-        """Show or hide the per-point names. Independent of marker visibility --
-        a crowded image often wants the points without the text.
+        """Show or hide the per-point names, the result markers' numbers included."""
+        self.picking.set_labels_visible(visible)
 
-        Covers the result markers' numbers too: one toggle, all the text, which is
-        what the old canvas did and what makes the button mean something on an
-        image showing a result."""
-        self.points.set_labels_visible(visible)
-        self.results.set_labels_visible(visible)
+    def set_scalebar_visible(self, visible: bool) -> None:
+        """Show or hide the scalebar."""
+        self.canvas.set_scalebar_visible(visible)
 
     # ── result markers ────────────────────────────────────────────────────
 
@@ -152,13 +154,8 @@ class CorrelationCanvasWidget(QWidget):
         hollow: bool = False,
         legend_label: Optional[str] = None,
     ) -> None:
-        """Append a group of non-interactive result markers.
-
-        Signature kept identical to ``ImagePointCanvas.add_overlay_points`` -- the
-        tab widget's three calls move across untouched. Groups accumulate; call
-        :meth:`clear_overlay` first when replacing a previous result.
-        """
-        self.results.add_points(
+        """Append a group of non-interactive result markers."""
+        self.picking.add_overlay_points(
             points,
             color=color,
             label_prefix=label_prefix,
@@ -172,34 +169,4 @@ class CorrelationCanvasWidget(QWidget):
 
     def clear_overlay(self) -> None:
         """Remove every marker added via :meth:`add_overlay_points`."""
-        self.results.clear()
-
-    # ── add menu ──────────────────────────────────────────────────────────
-
-    def _show_add_menu(self, x: float, y: float) -> None:
-        """Ask which PointType to add at *x*, *y*, then report it.
-
-        The overlay cannot do this itself -- it is a QObject, not a widget, so it
-        has no parent to hang a QMenu from, and the allowed-type list is per-side
-        config the tab widget already owns. No stylesheet: QMenu is styled
-        app-wide in napari_style, and ImagePointCanvas overriding that locally is
-        the anomaly, not the rule.
-
-        Emits nothing when adding is disabled (``allowed_point_types=[]``) or the
-        menu is dismissed -- the point is created by the caller, not here, so the
-        Coordinate still gets its z from the adapter as it does today.
-        """
-        types = self._allowed_types if self._allowed_types is not None else list(PointType)
-        if not types:
-            return
-
-        menu = QMenu(self)
-        for pt in types:
-            action = QAction(f"Add {pt.value}", self)
-            action.setData((x, y, pt))
-            menu.addAction(action)
-
-        chosen = menu.exec_(QCursor.pos())
-        if chosen is not None:
-            cx, cy, pt = chosen.data()
-            self.point_add_requested.emit(cx, cy, pt)
+        self.picking.clear_overlay()

--- a/fibsem/ui/correlation/widgets/correlation_canvas_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_canvas_widget.py
@@ -10,9 +10,10 @@ on its own. The old canvas is deleted only in the last PR of the series, once
 both have moved.
 
 Scope so far — image display, points, selection, the add-menu, the legend and
-labels, and the reprojected-result markers. Still to come: the two-panel Save
-Plot export, which `ImagePointCanvas` served with `render_to_axes` but which is
-better rewritten in `save_plot` itself when the swap happens.
+labels, and the reprojected-result markers. The two-panel Save Plot export no
+longer needs anything here: `save_plot` renders any matplotlib canvas through
+`_render_canvas_to_axes`, so `render_to_axes` has no successor and dies with the
+old canvas.
 
 What comes free with the shared canvas, and is the reason for the whole exercise:
 **contrast and gamma**, which `ImagePointCanvas` has never had — on FM data,

--- a/fibsem/ui/correlation/widgets/correlation_fm_canvas_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_fm_canvas_widget.py
@@ -1,0 +1,141 @@
+"""Correlation point-picking on the shared FM canvas (FIB-535).
+
+`FMCanvasWidget` + :class:`CorrelationPicking` — the FM half of the migration,
+and the counterpart to :class:`CorrelationCanvasWidget` on the FIB side. Both
+present the same picking surface; they differ only in how an image reaches the
+canvas, which is the one thing that genuinely differs between them.
+
+**Not wired in yet.** `fm_image_display_widget.FMImageDisplayWidget` is still what
+the correlation tab uses; this is built alongside so it can be reviewed and
+compared side by side first. Both old widgets are deleted in the last PR of the
+series.
+
+Replacing `FMImageDisplayWidget` rather than porting it is what puts the
+correlation FM display on the *standard* FM control set — the z-slider, the
+per-channel layers popover and the max-projection toolbar button that the quad
+view and the FM overview already use — instead of a private second
+implementation of all three. The visible trades, agreed 2026-08-10: per-channel
+intensity moves from a clip percentage to the layers panel's contrast/gamma, and
+the channel rows move from an always-visible pane into the popover.
+"""
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple
+
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import QWidget
+
+from fibsem.correlation.structures import Coordinate, PointType
+from fibsem.ui.correlation.widgets.correlation_picking import CorrelationPicking
+from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
+
+
+class CorrelationFMCanvasWidget(FMCanvasWidget):
+    """Multi-channel FM display with draggable correlation points on top.
+
+    Signal shapes are deliberately identical to ``FMImageDisplayWidget``, which is
+    in turn identical to ``ImagePointCanvas``: the tab widget wires both of its
+    surfaces in one loop, and that loop does not change.
+    """
+
+    point_selected = pyqtSignal(object)  # Coordinate
+    point_moved = pyqtSignal(object)  # Coordinate
+    point_removed = pyqtSignal(object)  # Coordinate
+    point_add_requested = pyqtSignal(float, float, object)  # x, y, PointType
+
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        allowed_point_types: Optional[List[PointType]] = None,
+    ) -> None:
+        super().__init__(parent)
+        # Same reasoning as the FIB canvas: correlation draws SURFACE as an orange
+        # "+", which the yellow centre "+" is easy to mistake for. Toolbar toggle
+        # brings it back.
+        self.canvas.set_crosshair_visible(False)
+        # Planes, not a projection. FMCanvasWidget defaults to max-projection
+        # because the quad view is a viewer; correlation is a picker, and
+        # `current_z` has no meaningful answer under a projection — every point
+        # picked on it would silently take z=0. FMImageDisplayWidget defaulted
+        # the same way, with its Max Projection checkbox unticked.
+        self.set_max_projection(False)
+
+        self.picking = CorrelationPicking(
+            self.canvas,
+            allowed_point_types=allowed_point_types,
+            menu_parent=self,
+        )
+        self.picking.point_selected.connect(self.point_selected)
+        self.picking.point_moved.connect(self.point_moved)
+        self.picking.point_removed.connect(self.point_removed)
+        self.picking.point_add_requested.connect(self.point_add_requested)
+
+    @property
+    def points(self):
+        """The interactive point overlay."""
+        return self.picking.points
+
+    @property
+    def results(self):
+        """The static result-marker overlay."""
+        return self.picking.results
+
+    # ── the _CanvasAdapter surface ────────────────────────────────────────
+
+    def set_coordinates(self, coords: List[Coordinate]) -> None:
+        self.picking.set_coordinates(coords)
+
+    def set_selected(self, coord: Optional[Coordinate]) -> None:
+        self.picking.set_selected(coord)
+
+    def refresh_coordinate(self, coord: Coordinate) -> None:
+        self.picking.refresh_coordinate(coord)
+
+    # ── chrome, mirroring CorrelationCanvasWidget ─────────────────────────
+
+    def set_legend_visible(self, visible: bool) -> None:
+        self.picking.set_legend_visible(visible)
+
+    def set_labels_visible(self, visible: bool) -> None:
+        self.picking.set_labels_visible(visible)
+
+    def set_scalebar_visible(self, visible: bool) -> None:
+        self.canvas.set_scalebar_visible(visible)
+
+    # No set_pixel_size override: FMCanvasWidget's also records `_pixel_size`,
+    # which the compositing path reads. Shadowing it would drop that quietly.
+
+    def reset_view(self) -> None:
+        self.canvas.reset_view()
+
+    # ── result markers ────────────────────────────────────────────────────
+
+    def add_overlay_points(
+        self,
+        points: Sequence[Tuple[float, float]],
+        *,
+        color: str = "#ff0000",
+        label_prefix: str = "",
+        size: float = 7.0,
+        marker: str = "o",
+        alpha: float = 1.0,
+        show_labels: bool = True,
+        hollow: bool = False,
+        legend_label: Optional[str] = None,
+    ) -> None:
+        """Append a group of non-interactive result markers."""
+        self.picking.add_overlay_points(
+            points,
+            color=color,
+            label_prefix=label_prefix,
+            size=size,
+            marker=marker,
+            alpha=alpha,
+            show_labels=show_labels,
+            hollow=hollow,
+            legend_label=legend_label,
+        )
+
+    def clear_overlay(self) -> None:
+        """Remove every marker added via :meth:`add_overlay_points`."""
+        self.picking.clear_overlay()

--- a/fibsem/ui/correlation/widgets/correlation_picking.py
+++ b/fibsem/ui/correlation/widgets/correlation_picking.py
@@ -1,0 +1,194 @@
+"""Correlation point picking over any `FibsemImageCanvas` (FIB-535).
+
+**Goal: one implementation of "pick correlation points on a canvas",** so the FIB
+and FM surfaces cannot drift apart. Both are moving onto the shared canvas stack
+— `CorrelationCanvasWidget` for FIB, `FMCanvasWidget` for FM — and both need the
+identical picking behaviour on top of a completely different image pipeline.
+
+**Explicit non-goal: sharing image display.** The two hosts genuinely differ:
+`set_image(ndarray)` on one, `set_fm_image(FluorescenceImage)` plus z-slice, MIP
+and per-channel layers on the other. Conflating "shows an image" with "lets you
+pick points on it" is what produced two 600–1000 line widgets in the first place.
+This needs a canvas to hang overlays on and nothing else.
+
+Composition rather than a mixin. A mixin would work — PyQt5 does pick up
+`pyqtSignal` from a plain-object mixin — but its dependency on ``self.canvas``
+would be implicit and unenforced: the attribute must exist, be a
+`FibsemImageCanvas`, and be constructed *before* the mixin's own init runs. Here
+all three are one constructor argument. It also matches the package, where
+`.canvas` / `.points` / `.results` are already reach-through attributes and the
+overlay system is composition end to end.
+
+Hosts forward the four signals rather than making callers reach through
+`.picking`, which keeps `correlation_tab_widget` and its `_CanvasAdapter`
+untouched by the migration.
+"""
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple
+
+from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt5.QtGui import QCursor
+from PyQt5.QtWidgets import QAction, QMenu, QWidget
+
+from fibsem.correlation.structures import Coordinate, PointType
+from fibsem.ui.correlation.widgets.correlation_point_overlay import (
+    CorrelationPointOverlay,
+    CorrelationResultOverlay,
+)
+
+
+class CorrelationPicking(QObject):
+    """Draggable correlation points and result markers on a shared canvas.
+
+    Signal shapes are deliberately identical to ``ImagePointCanvas``: the tab
+    widget's four handlers connect unchanged, via whichever host forwards them.
+    """
+
+    point_selected = pyqtSignal(object)  # Coordinate
+    point_moved = pyqtSignal(object)  # Coordinate
+    point_removed = pyqtSignal(object)  # Coordinate
+    point_add_requested = pyqtSignal(float, float, object)  # x, y, PointType
+
+    def __init__(
+        self,
+        canvas,
+        *,
+        allowed_point_types: Optional[List[PointType]] = None,
+        menu_parent: Optional[QWidget] = None,
+    ) -> None:
+        """Attach picking to *canvas*.
+
+        *menu_parent* is the widget the add-menu hangs from — a parameter rather
+        than an assumption, because neither this nor the overlay is a QWidget and
+        a QMenu needs one. *allowed_point_types*: None means "every type", an
+        empty list means "adding is off" — the convention ``ImagePointCanvas``
+        uses, kept so a read-only canvas cannot silently regain an add menu.
+        """
+        super().__init__(menu_parent)
+        self._canvas = canvas
+        self._menu_parent = menu_parent
+        self._allowed_types = allowed_point_types
+
+        self.points = CorrelationPointOverlay()
+        canvas.add_overlay(self.points)
+        # Result markers get their own overlay: they are computed output, never
+        # picked, and keeping them off `points` is what makes them unpickable
+        # rather than something to remember. Registered second so they draw over
+        # the picked points, matching the old canvas's artist order.
+        self.results = CorrelationResultOverlay(legend_host=self.points)
+        canvas.add_overlay(self.results)
+
+        # Identity signals straight through; only the add path needs translating,
+        # because the overlay reports *where* and this decides *what*.
+        self.points.coordinate_selected.connect(self.point_selected)
+        self.points.coordinate_moved.connect(self.point_moved)
+        self.points.coordinate_removed.connect(self.point_removed)
+        self.points.add_requested.connect(self._show_add_menu)
+
+    def dispose(self) -> None:
+        """Unregister both overlays from the canvas.
+
+        Not needed for teardown — the canvas and this object die together, and
+        the overlay signals are ``pyqtSignal``, which Qt disconnects itself. It
+        exists because the canvas, not this object, owns the overlay registry:
+        dropping a `CorrelationPicking` leaves its overlays registered, so
+        attaching a second one to the same canvas would silently stack a
+        duplicate pair.
+        """
+        for overlay in (self.results, self.points):
+            self._canvas.remove_overlay(overlay)
+
+    # ── the _CanvasAdapter surface ────────────────────────────────────────
+
+    def set_coordinates(self, coords: List[Coordinate]) -> None:
+        self.points.set_coordinates(coords)
+
+    def set_selected(self, coord: Optional[Coordinate]) -> None:
+        self.points.set_selected_coordinate(coord)
+
+    def refresh_coordinate(self, coord: Coordinate) -> None:
+        self.points.refresh_coordinate(coord)
+
+    # ── chrome ────────────────────────────────────────────────────────────
+
+    def set_legend_visible(self, visible: bool) -> None:
+        """Show or hide the point-type legend (one swatch per type on screen)."""
+        self.points.set_legend_visible(visible)
+
+    def set_labels_visible(self, visible: bool) -> None:
+        """Show or hide the per-point names. Independent of marker visibility --
+        a crowded image often wants the points without the text.
+
+        Covers the result markers' numbers too: one toggle, all the text, which is
+        what the old canvas did and what makes the button mean something on an
+        image showing a result."""
+        self.points.set_labels_visible(visible)
+        self.results.set_labels_visible(visible)
+
+    # ── result markers ────────────────────────────────────────────────────
+
+    def add_overlay_points(
+        self,
+        points: Sequence[Tuple[float, float]],
+        *,
+        color: str = "#ff0000",
+        label_prefix: str = "",
+        size: float = 7.0,
+        marker: str = "o",
+        alpha: float = 1.0,
+        show_labels: bool = True,
+        hollow: bool = False,
+        legend_label: Optional[str] = None,
+    ) -> None:
+        """Append a group of non-interactive result markers.
+
+        Signature kept identical to ``ImagePointCanvas.add_overlay_points`` -- the
+        tab widget's three calls move across untouched. Groups accumulate; call
+        :meth:`clear_overlay` first when replacing a previous result.
+        """
+        self.results.add_points(
+            points,
+            color=color,
+            label_prefix=label_prefix,
+            size=size,
+            marker=marker,
+            alpha=alpha,
+            show_labels=show_labels,
+            hollow=hollow,
+            legend_label=legend_label,
+        )
+
+    def clear_overlay(self) -> None:
+        """Remove every marker added via :meth:`add_overlay_points`."""
+        self.results.clear()
+
+    # ── add menu ──────────────────────────────────────────────────────────
+
+    def _show_add_menu(self, x: float, y: float) -> None:
+        """Ask which PointType to add at *x*, *y*, then report it.
+
+        The overlay cannot do this itself -- it is a QObject, not a widget, so it
+        has no parent to hang a QMenu from, and the allowed-type list is per-side
+        config the tab widget already owns. No stylesheet: QMenu is styled
+        app-wide in napari_style, and ImagePointCanvas overriding that locally is
+        the anomaly, not the rule.
+
+        Emits nothing when adding is disabled (``allowed_point_types=[]``) or the
+        menu is dismissed -- the point is created by the caller, not here, so the
+        Coordinate still gets its z from the adapter as it does today.
+        """
+        types = self._allowed_types if self._allowed_types is not None else list(PointType)
+        if not types:
+            return
+
+        menu = QMenu(self._menu_parent)
+        for pt in types:
+            action = QAction(f"Add {pt.value}", self._menu_parent)
+            action.setData((x, y, pt))
+            menu.addAction(action)
+
+        chosen = menu.exec_(QCursor.pos())
+        if chosen is not None:
+            cx, cy, pt = chosen.data()
+            self.point_add_requested.emit(cx, cy, pt)

--- a/fibsem/ui/correlation/widgets/correlation_tab_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_tab_widget.py
@@ -32,6 +32,7 @@ result_changed : CorrelationResult    — after a successful correlation run
 from __future__ import annotations
 
 import copy
+import io
 import logging
 import os
 import time
@@ -209,6 +210,50 @@ def _ro_item(text: str) -> QTableWidgetItem:
     item.setFlags(Qt.ItemFlag.ItemIsEnabled)
     item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
     return item
+
+
+_PLOT_DPI = 150          # the saved figure's dpi
+_PLOT_PANEL_INCHES = 8.0  # each panel of the 16x8 two-panel figure
+
+
+def _render_canvas_to_axes(canvas, ax, *, dpi: int = _PLOT_DPI) -> None:
+    """Draw whatever *canvas* is currently showing into *ax*.
+
+    Deliberately canvas-agnostic: it needs a matplotlib figure and nothing else,
+    so it works for ``ImagePointCanvas`` and the shared ``FibsemImageCanvas``
+    alike and does not have to be rewritten when the correlation tab swaps from
+    one to the other (FIB-535). It replaces ``ImagePointCanvas.render_to_axes``,
+    which re-created every artist by hand and had no equivalent on the shared
+    stack.
+
+    ``savefig`` re-renders the figure offscreen at the requested dpi, so
+    resolution comes from *dpi* rather than from the on-screen widget size — the
+    reason this is not a plain ``buffer_rgba()`` grab, which would cap the export
+    at however large the window happened to be.
+
+    One deliberate behaviour change: what lands on the page is now what is on the
+    screen, aspect ratio included. ``render_to_axes`` re-fitted the content to the
+    panel, which stretched a square image into a 2:1 rectangle — measuring off
+    that plot gave the wrong answer.
+    """
+    from matplotlib.image import imread
+
+    fig = canvas.figure
+    # Render large enough that scaling into the panel never has to upsample.
+    width_inches = max(fig.get_size_inches()[0], 0.1)
+    render_dpi = max(dpi, int(dpi * _PLOT_PANEL_INCHES / width_inches))
+
+    buf = io.BytesIO()
+    fig.savefig(
+        buf,
+        format="png",
+        dpi=render_dpi,
+        facecolor=fig.get_facecolor(),
+        pad_inches=0,
+    )
+    buf.seek(0)
+    ax.imshow(imread(buf))
+    ax.axis("off")
 
 
 def _form_label(text: str) -> QLabel:
@@ -2892,10 +2937,10 @@ class CorrelationTabWidget(QWidget):
         for ax in (ax_fib, ax_fm):
             ax.set_facecolor(CANVAS_BG)
 
-        self._fib_canvas.render_to_axes(ax_fib)
+        _render_canvas_to_axes(self._fib_canvas, ax_fib, dpi=_PLOT_DPI)
         ax_fib.set_title("FIB", color="white", fontsize=12)
 
-        self._fm_display.canvas.render_to_axes(ax_fm)
+        _render_canvas_to_axes(self._fm_display.canvas, ax_fm, dpi=_PLOT_DPI)
         ax_fm.set_title("FM", color="white", fontsize=12)
 
         fig.tight_layout()

--- a/fibsem/ui/correlation/widgets/test_correlation_fm_canvas_demo.py
+++ b/fibsem/ui/correlation/widgets/test_correlation_fm_canvas_demo.py
@@ -1,0 +1,305 @@
+"""Side-by-side harness: FMImageDisplayWidget (old) vs CorrelationFMCanvasWidget (new).
+
+Same synthetic 3-channel z-stack and the same starting points on both. Built
+before the swap, deliberately — the FIB side had `test_correlation_canvas_demo.py`
+to compare against and this is the FM equivalent, because the correlation tab is
+in production and 925 passing Qt tests have previously said nothing useful about
+whether a widget actually works.
+
+Usage
+-----
+    PYTHONPATH=$PWD python fibsem/ui/correlation/widgets/test_correlation_fm_canvas_demo.py
+
+What to compare
+---------------
+* **Points** — right-click to add, drag to move, click to select, Delete to
+  remove. The log shows what each side emits; the payloads should match.
+* **Z** — both have a slider, `‹` / `›` step buttons and an ``n/N`` readout. The
+  arrows are new on the shared widget, added here so the swap does not lose a
+  control the correlation display has today (the quad view and FM overview gain
+  them too).
+* **Max projection** — an inline checkbox on the left, a toolbar button on the
+  right. Deliberate: it keeps the z row thin.
+* **Channels** — an always-visible pane on the left, the layers popover (the
+  ``mdi:layers`` toolbar button) on the right. The popover offers colormap,
+  opacity, gamma and a dual-handle contrast, against the left's clip percentage.
+  This is the agreed UX trade; check it is liveable while actually picking points.
+* **Contrast / gamma** — per channel, right side only.
+* **Crosshair** — off on both correlation canvases, on elsewhere. Toolbar toggle
+  brings it back.
+* **Show result** — the three marker groups the tab widget draws after a run.
+"""
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QPushButton,
+    QSplitter,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.correlation.structures import Coordinate, PointType, PointXYZ
+from fibsem.fm.structures import (
+    FluorescenceChannelMetadata,
+    FluorescenceImage,
+    FluorescenceImageMetadata,
+)
+from fibsem.ui.correlation.widgets.correlation_fm_canvas_widget import (
+    CorrelationFMCanvasWidget,
+)
+from fibsem.ui.correlation.widgets.fm_image_display_widget import FMImageDisplayWidget
+from fibsem.ui.tokens import (
+    ACCENT_COLOR,
+    OK_COLOR,
+    SURFACE_COLOR,
+    TEXT_MUTED_COLOR,
+    TEXT_STRONG_COLOR,
+)
+
+# The types _POINT_TYPE_SIDES assigns to the FM side, so the add menu matches production.
+_FM_TYPES = [PointType.FM, PointType.POI, PointType.SURFACE_FM]
+_CHANNELS = (("GFP", "#00ff00"), ("RFP", "#ff3030"), ("DAPI", "#4090ff"))
+_NZ, _SIZE = 9, 256
+
+
+def _fm_image() -> FluorescenceImage:
+    """A 3-channel z-stack whose blobs come into focus on different planes, so the
+    z-slider and max-projection visibly do something."""
+    rng = np.random.default_rng(7)
+    data = np.zeros((len(_CHANNELS), _NZ, _SIZE, _SIZE), dtype=np.uint16)
+    yy, xx = np.mgrid[0:_SIZE, 0:_SIZE]
+    for c, (_, _colour) in enumerate(_CHANNELS):
+        cy, cx = 80 + 45 * c, 90 + 40 * c
+        best_z = 2 + 3 * c  # each channel sharpest on a different plane
+        for z in range(_NZ):
+            spread = 18 + 9 * abs(z - best_z)
+            blob = np.exp(-(((yy - cy) ** 2 + (xx - cx) ** 2) / (2.0 * spread**2)))
+            frame = 900 * blob / (1 + 0.35 * abs(z - best_z))
+            frame += rng.normal(60, 12, (_SIZE, _SIZE))
+            data[c, z] = np.clip(frame, 0, 65535).astype(np.uint16)
+
+    metadata = FluorescenceImageMetadata(
+        acquisition_date="2026-08-10T00:00:00",
+        pixel_size_x=1e-7,
+        pixel_size_y=1e-7,
+        resolution=(_SIZE, _SIZE),
+        channels=[
+            FluorescenceChannelMetadata(
+                name=name, color=colour, excitation_wavelength=488,
+                emission_wavelength=509, power=1.0, exposure_time=0.1,
+                gain=1.0, offset=0.0,
+            )
+            for name, colour in _CHANNELS
+        ],
+        filename="synthetic_zstack",
+    )
+    return FluorescenceImage(data=data, metadata=metadata)
+
+
+def _seed_points() -> list:
+    return [
+        Coordinate(PointXYZ(90.0, 80.0, 2.0), PointType.FM),
+        Coordinate(PointXYZ(130.0, 125.0, 5.0), PointType.FM),
+        Coordinate(PointXYZ(170.0, 170.0, 8.0), PointType.SURFACE_FM),
+    ]
+
+
+# The groups CorrelationTabWidget._overlay_result_on_fib draws, in FM colours.
+_RESULT_GROUPS = (
+    (
+        [(96.0, 86.0), (125.0, 132.0)],
+        dict(color="#ff4444", label_prefix="E", size=4, legend_label="reprojected (E)"),
+    ),
+    (
+        [(150.0, 150.0)],
+        dict(color="#ff00ff", size=7, alpha=0.7, show_labels=False, hollow=True,
+             legend_label="POI uncorrected"),
+    ),
+    (
+        [(156.0, 154.0)],
+        dict(color="#ff00ff", label_prefix="P", size=5, legend_label="POI (P)"),
+    ),
+)
+
+
+class DemoWindow(QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle(
+            "FIB-535 — FMImageDisplayWidget (old) vs CorrelationFMCanvasWidget (new)"
+        )
+        self.resize(1600, 900)
+
+        image = _fm_image()
+
+        root = QWidget()
+        root_layout = QVBoxLayout(root)
+        self.setCentralWidget(root)
+
+        panes = QSplitter(Qt.Orientation.Horizontal)
+        panes.addWidget(self._titled("OLD — FMImageDisplayWidget", self._build_old(image)))
+        panes.addWidget(
+            self._titled(
+                "NEW — CorrelationFMCanvasWidget  (layers popover + contrast/gamma)",
+                self._build_new(image),
+            )
+        )
+        panes.setSizes([780, 780])
+        root_layout.addWidget(panes, 1)
+
+        controls = QHBoxLayout()
+        for label, slot in (
+            ("Reset both", self._reset),
+            ("Clear both", self._clear),
+            ("Show result", self._show_result),
+            ("Clear result", self._clear_result),
+            ("Clear log", lambda: self.log.clear()),
+        ):
+            btn = QPushButton(label)
+            btn.clicked.connect(slot)
+            controls.addWidget(btn)
+
+        for label, setter in (("Legend", "set_legend_visible"), ("Labels", "set_labels_visible")):
+            btn = QPushButton(label)
+            btn.setCheckable(True)
+            btn.setChecked(True)
+            btn.toggled.connect(lambda on, s=setter, n=label: self._toggle_both(s, on, n))
+            controls.addWidget(btn)
+
+        controls.addStretch()
+        controls.addWidget(
+            QLabel(
+                f"<span style='color:{TEXT_MUTED_COLOR}'>right-click to add · drag to move · "
+                f"Delete to remove · uncheck Max Projection to reach the z controls</span>"
+            )
+        )
+        root_layout.addLayout(controls)
+
+        self.log = QTextEdit()
+        self.log.setReadOnly(True)
+        self.log.setFixedHeight(150)
+        self.log.setStyleSheet(
+            f"background: {SURFACE_COLOR}; color: {TEXT_STRONG_COLOR}; "
+            "font-family: monospace; font-size: 11px;"
+        )
+        root_layout.addWidget(self.log)
+
+        self._reset()
+
+    # ── construction ──────────────────────────────────────────────────────
+
+    def _titled(self, title: str, widget: QWidget) -> QWidget:
+        box = QWidget()
+        layout = QVBoxLayout(box)
+        layout.setContentsMargins(0, 0, 0, 0)
+        label = QLabel(f"<b>{title}</b>")
+        label.setStyleSheet(f"color: {TEXT_STRONG_COLOR}; padding: 4px;")
+        layout.addWidget(label)
+        layout.addWidget(widget, 1)
+        return box
+
+    def _wire(self, widget, side: str) -> None:
+        widget.point_selected.connect(lambda c: self._say(side, "selected", c))
+        widget.point_moved.connect(lambda c: self._say(side, "moved", c))
+        widget.point_removed.connect(lambda c: self._say(side, "removed", c))
+        widget.point_add_requested.connect(lambda x, y, pt: self._added(side, x, y, pt))
+
+    def _build_old(self, image: FluorescenceImage) -> QWidget:
+        self.old = FMImageDisplayWidget(allowed_point_types=_FM_TYPES)
+        self.old.set_fm_image(image)
+        self._wire(self.old, "old")
+        return self.old
+
+    def _build_new(self, image: FluorescenceImage) -> QWidget:
+        self.new = CorrelationFMCanvasWidget(allowed_point_types=_FM_TYPES)
+        self.new.set_fm_image(image)
+        self._wire(self.new, "new")
+        return self.new
+
+    # ── behaviour ─────────────────────────────────────────────────────────
+
+    def _reset(self) -> None:
+        # Separate Coordinate objects per side: they are held by reference, so
+        # sharing one list would let a drag on one widget silently move the other
+        # and hide exactly the difference this harness exists to show.
+        self.old.set_coordinates(_seed_points())
+        self.new.set_coordinates(_seed_points())
+        self._log("reset both to 3 seed points")
+
+    def _clear(self) -> None:
+        for w in (self.old, self.new):
+            w.set_coordinates([])
+        self._log("cleared both")
+
+    @staticmethod
+    def _surface(widget, method: str):
+        """Whichever of the widget or its canvas answers to *method*.
+
+        FMImageDisplayWidget exposes almost nothing at widget level -- the tab
+        widget reaches through `.canvas` for the chrome toggles, and result
+        markers were never on the FM side at all (only the FIB canvas drew
+        them). CorrelationFMCanvasWidget offers all of it directly, which is
+        both why the swap touches those call sites and what FIB-289 (overlay the
+        correlated POI on the FM display) needs.
+        """
+        return widget if hasattr(widget, method) else widget.canvas
+
+    def _show_result(self) -> None:
+        for w in (self.old, self.new):
+            surface = self._surface(w, "add_overlay_points")
+            surface.clear_overlay()
+            for points, style in _RESULT_GROUPS:
+                surface.add_overlay_points(points, **style)
+        self._log("drew the reprojected result on both", OK_COLOR)
+
+    def _clear_result(self) -> None:
+        for w in (self.old, self.new):
+            self._surface(w, "clear_overlay").clear_overlay()
+        self._log("cleared the result on both")
+
+    def _toggle_both(self, setter: str, on: bool, name: str) -> None:
+        for w in (self.old, self.new):
+            getattr(self._surface(w, setter), setter)(on)
+        self._log(f"{name.lower()} {'shown' if on else 'hidden'} on both")
+
+    def _added(self, side: str, x: float, y: float, pt: PointType) -> None:
+        """Both widgets only *request* an add — the tab widget builds the
+        Coordinate, because it owns the z. Mirror that here, reading z from
+        whichever widget was clicked."""
+        widget = self.old if side == "old" else self.new
+        coord = Coordinate(PointXYZ(x, y, float(widget.current_z)), pt)
+        widget.set_coordinates(list(widget.points.coordinates()) + [coord])
+        self._log(
+            f"[{side}] add_requested  {pt.value:12} ({x:7.1f}, {y:7.1f})  z={widget.current_z}",
+            ACCENT_COLOR,
+        )
+
+    def _say(self, side: str, what: str, coord: Coordinate) -> None:
+        self._log(
+            f"[{side}] {what:9} {coord.point_type.value:12} "
+            f"({coord.point.x:7.1f}, {coord.point.y:7.1f}, z={coord.point.z:5.1f})",
+            OK_COLOR if side == "new" else None,
+        )
+
+    def _log(self, message: str, color: str = None) -> None:
+        self.log.append(f"<span style='color:{color}'>{message}</span>" if color else message)
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    window = DemoWindow()
+    window.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -348,9 +348,28 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
     # ── public API ────────────────────────────────────────────────────────
 
     def set_crosshair_visible(self, visible: bool) -> None:
-        """Show or hide the yellow crosshair centred on the image."""
+        """Show or hide the yellow crosshair centred on the image.
+
+        Syncs the toolbar button here rather than only in :meth:`toggle_crosshair`,
+        so a host that overrides the default right after constructing its canvas —
+        the correlation canvases turn the crosshair off — does not leave a checked
+        button whose tooltip offers to hide something that is not drawn.
+        """
         self._crosshair_visible = visible
+        self._sync_toggle_button(self.btn_toggle_crosshair, visible, "crosshair")
         self._refresh_crosshair()
+        self.draw_idle()
+
+    def set_scalebar_visible(self, visible: bool) -> None:
+        """Show or hide the scalebar. Mirrors :meth:`set_crosshair_visible`.
+
+        Present because ``ImagePointCanvas`` has it and the correlation tab calls
+        it; the shared canvas previously offered only the toggle, which cannot
+        express "off" without knowing what it is currently set to.
+        """
+        self._scalebar_visible = visible
+        self._sync_toggle_button(self.btn_toggle_scalebar, visible, "scalebar")
+        self._refresh_scalebar()
         self.draw_idle()
 
     def set_hint(self, text: Optional[str]) -> None:
@@ -863,22 +882,17 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         )
 
     def toggle_scalebar(self) -> None:
-        """Show or hide the scalebar and update the button tooltip."""
-        self._scalebar_visible = not self._scalebar_visible
-        self.btn_toggle_scalebar.setChecked(self._scalebar_visible)
-        self.btn_toggle_scalebar.setToolTip(
-            "Hide scalebar" if self._scalebar_visible else "Show scalebar"
-        )
-        self._refresh_scalebar()
-        self.draw_idle()
+        """Flip the scalebar, from its toolbar button."""
+        self.set_scalebar_visible(not self._scalebar_visible)
 
     def toggle_crosshair(self) -> None:
-        """Show or hide the crosshair and update the button tooltip."""
+        """Flip the crosshair, from its toolbar button."""
         self.set_crosshair_visible(not self._crosshair_visible)
-        self.btn_toggle_crosshair.setChecked(self._crosshair_visible)
-        self.btn_toggle_crosshair.setToolTip(
-            "Hide crosshair" if self._crosshair_visible else "Show crosshair"
-        )
+
+    def _sync_toggle_button(self, button, shown: bool, noun: str) -> None:
+        """Keep a show/hide toolbar button in step with the state it reports."""
+        button.setChecked(shown)
+        button.setToolTip(f"Hide {noun}" if shown else f"Show {noun}")
 
     def toggle_ruler(self) -> None:
         """Toggle the drag-to-measure ruler (a generic canvas tool).

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -59,6 +59,15 @@ _ACCENT_WASH = "rgba({}, {}, {}, 0.16)".format(
     *(int(ACCENT_COLOR[i:i + 2], 16) for i in (1, 3, 5))
 )
 
+# The ‹ › buttons flanking the z-slider. Outside _PANEL_QSS because that stylesheet
+# is applied to the floating layers panel, and these live on the z row.
+_Z_STEP_BTN_STYLE = (
+    f"QToolButton {{ color: {TEXT_COLOR}; background: {SURFACE_COLOR}; "
+    f"border: 1px solid {BORDER_COLOR}; border-radius: 3px; font-size: 13px; }}"
+    f"QToolButton:hover {{ background: {BORDER_COLOR}; }}"
+    f"QToolButton:disabled {{ color: {TEXT_MUTED_COLOR}; }}"
+)
+
 # napari-style dark theme for the floating layers panel. An f-string, so every
 # literal QSS brace is doubled -- Qt discards a malformed rule silently, so a
 # missed pair shows up as an unstyled widget rather than an error.
@@ -237,10 +246,19 @@ class FMCanvasWidget(QWidget):
         zrl.setContentsMargins(6, 2, 6, 4)
         zrl.setSpacing(6)
         zrl.addWidget(QLabel("z"))
+        # Step buttons either side of the slider: a slider alone cannot be nudged
+        # one plane at a time reliably, and single-plane stepping is how you
+        # actually find focus in a stack.
+        self._z_prev = self._z_step_button("‹", "Previous Z-slice", -1)
+        zrl.addWidget(self._z_prev)
         self._z_slider = QSlider(Qt.Horizontal)
         self._z_slider.setMinimum(0)
+        self._z_slider.setSingleStep(1)
+        self._z_slider.setPageStep(1)
         self._z_slider.valueChanged.connect(self._on_z_changed)
         zrl.addWidget(self._z_slider, 1)
+        self._z_next = self._z_step_button("›", "Next Z-slice", 1)
+        zrl.addWidget(self._z_next)
         self._z_label = QLabel("1/1")
         zrl.addWidget(self._z_label)
         self._z_row.setVisible(False)
@@ -487,6 +505,31 @@ class FMCanvasWidget(QWidget):
             layer.data = self._plane_for(stack)
         self._recomposite()
 
+    def _z_step_button(self, glyph: str, tooltip: str, delta: int) -> QToolButton:
+        button = QToolButton()
+        button.setText(glyph)
+        button.setFixedSize(20, 20)
+        button.setToolTip(tooltip)
+        button.setStyleSheet(_Z_STEP_BTN_STYLE)
+        button.clicked.connect(lambda: self.step_z(delta))
+        return button
+
+    @property
+    def current_z(self) -> int:
+        """The displayed z-plane. 0 while max-projection is on, which has no plane.
+
+        Correlation reads this to give a point picked on the FM image its z.
+        """
+        return 0 if self._max_projection else self._z_index
+
+    def step_z(self, delta: int) -> None:
+        """Move the z-slider by *delta* planes; a no-op under max-projection."""
+        if self._max_projection or self._z_max <= 0:
+            return
+        self._z_slider.setValue(
+            max(0, min(self._z_max, self._z_slider.value() + int(delta)))
+        )
+
     def _on_z_changed(self, value: int) -> None:
         self._z_index = value
         self._z_label.setText(f"{value + 1}/{self._z_max + 1}")
@@ -496,6 +539,16 @@ class FMCanvasWidget(QWidget):
         self._max_projection = bool(on)
         self._update_z_visibility()
         self._apply_z_mode()
+
+    def set_max_projection(self, on: bool) -> None:
+        """Show the max projection, or a single z-plane.
+
+        The setter syncs the toolbar button, so a subclass can choose a different
+        default without the button disagreeing with what is drawn — correlation
+        wants planes, because a projection has no z to give a picked point.
+        """
+        self._btn_mip.setChecked(bool(on))
+        self._on_max_projection_toggled(bool(on))
 
     def _on_mip_button(self) -> None:
         """Toolbar toggle → max-projection on/off (checked = MIP)."""

--- a/tests/correlation/test_correlation_canvas_widget.py
+++ b/tests/correlation/test_correlation_canvas_widget.py
@@ -188,7 +188,7 @@ def test_adding_is_off_when_no_types_are_allowed(monkeypatch):
             return None
 
     monkeypatch.setattr(
-        "fibsem.ui.correlation.widgets.correlation_canvas_widget.QMenu",
+        "fibsem.ui.correlation.widgets.correlation_picking.QMenu",
         _DismissedMenu,
     )
     w = _widget(allowed=[])
@@ -216,7 +216,7 @@ def test_a_dismissed_menu_adds_nothing():
         def exec_(self, pos):
             return None
 
-    import fibsem.ui.correlation.widgets.correlation_canvas_widget as mod
+    import fibsem.ui.correlation.widgets.correlation_picking as mod
 
     real, mod.QMenu = mod.QMenu, _Dismissed
     try:
@@ -241,7 +241,7 @@ def test_a_chosen_type_is_reported_with_the_click_position():
         def exec_(self, pos):
             return self._actions[1]
 
-    import fibsem.ui.correlation.widgets.correlation_canvas_widget as mod
+    import fibsem.ui.correlation.widgets.correlation_picking as mod
 
     real, mod.QMenu = mod.QMenu, _PicksSecond
     try:
@@ -267,7 +267,7 @@ def test_the_widget_adds_no_point_itself():
         def exec_(self, pos):
             return self._actions[0]
 
-    import fibsem.ui.correlation.widgets.correlation_canvas_widget as mod
+    import fibsem.ui.correlation.widgets.correlation_picking as mod
 
     real, mod.QMenu = mod.QMenu, _PicksFirst
     try:

--- a/tests/correlation/test_correlation_canvas_widget.py
+++ b/tests/correlation/test_correlation_canvas_widget.py
@@ -14,6 +14,7 @@ import pytest
 
 pytest.importorskip("PyQt5")  # CI installs .[test] without the UI extra
 
+from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QApplication
 
 from fibsem.correlation.structures import Coordinate, PointType, PointXYZ
@@ -52,7 +53,65 @@ def test_adapter_surface_matches_the_canvas_it_replaces():
         assert callable(getattr(ImagePointCanvas, name, None)), name
 
 
-def test_image_methods_match_the_canvas_it_replaces():
+# Public methods of ImagePointCanvas that the replacement deliberately does not
+# forward, each with the reason. Anything not listed here must be forwarded --
+# see test_every_public_method_is_forwarded_or_waived.
+_WAIVED = {
+    "canvas_clicked": "a 3-arg signal on the shared canvas; reachable via .canvas",
+    "keyPressEvent": "Qt event handler, inherited by the canvas widget itself",
+    "resizeEvent": "Qt event handler, inherited by the canvas widget itself",
+    "wheelEvent": "Qt event handler; the macOS Shift-scroll rescue is FIB-552, parked",
+    "render_to_axes": "no successor -- save_plot renders any canvas via _render_canvas_to_axes",
+    "set_shift_z_scroll_enabled": "superseded by canvas_scrolled, which already suppresses zoom under a modifier",
+    "z_scroll_requested": "superseded by canvas_scrolled",
+}
+
+
+# Parameter annotations that deliberately differ. Only *widenings* belong here --
+# every call the old signature accepts, the new one still accepts. Declaring them
+# individually keeps the check strict, so a narrowing (the set_image FibsemImage
+# bug, ndarray -> FibsemImage) cannot hide behind a blanket exemption.
+_WIDENED = {
+    ("add_overlay_points", "points"): "Sequence accepts tuples as well as lists",
+    ("add_overlay_points", "size"): "float accepts the ints the old signature took",
+}
+
+
+def _public_names(cls):
+    """Everything callable on the class -- methods and pyqtSignals alike."""
+    return {n for n, v in vars(cls).items() if not n.startswith("_") and callable(v)}
+
+
+def _public_methods(cls):
+    """Just the methods. Signals are callable but have no inspectable signature,
+    and are covered by test_signals_match_the_canvas_it_replaces."""
+    return {
+        n for n, v in vars(cls).items()
+        if not n.startswith("_") and callable(v) and not isinstance(v, pyqtSignal)
+    }
+
+
+def test_every_public_method_is_forwarded_or_waived():
+    """Enumerates instead of spot-checking.
+
+    The hardcoded list this replaces only covered what someone remembered to
+    type, which is exactly how `set_scalebar_visible` went missing -- present on
+    the old canvas, called by the tab widget, absent here, and the parity test
+    said nothing. Adding a method to ImagePointCanvas without forwarding it now
+    fails until it is either forwarded or waived with a reason.
+    """
+    # hasattr, not a set difference: the replacement exposes `points` / `results`
+    # as properties, which are not callable and would read as missing.
+    missing = {n for n in _public_names(ImagePointCanvas)
+               if not hasattr(CorrelationCanvasWidget, n)}
+    unexplained = sorted(missing - set(_WAIVED))
+    assert not unexplained, f"not forwarded and not waived: {unexplained}"
+
+    stale = sorted(set(_WAIVED) - _public_names(ImagePointCanvas))
+    assert not stale, f"waived but no longer on the old canvas: {stale}"
+
+
+def test_forwarded_methods_keep_their_signatures():
     """Signatures, not just callability.
 
     `set_image` used to take a FibsemImage here while both remaining consumers
@@ -60,12 +119,8 @@ def test_image_methods_match_the_canvas_it_replaces():
     callable-only check sailed straight past it, so this compares each
     parameter's position, annotation and default against the old canvas.
     """
-    for name in ("__init__", "set_image", "update_display", "set_coordinates",
-                 "set_selected", "refresh_coordinate", "set_pixel_size",
-                 "reset_view", "set_legend_visible", "set_labels_visible",
-                 "clear_overlay"):
-        assert callable(getattr(CorrelationCanvasWidget, name, None)), name
-        assert callable(getattr(ImagePointCanvas, name, None)), name
+    shared = _public_methods(ImagePointCanvas) & _public_methods(CorrelationCanvasWidget)
+    for name in sorted(shared | {"__init__"}):
         _assert_accepts_old_calls(name)
 
 
@@ -86,6 +141,8 @@ def _assert_accepts_old_calls(name: str) -> None:
         assert got.name == want.name, f"{name}: {want.name} -> {got.name}"
         assert got.kind == want.kind, f"{name}.{want.name}: {want.kind} -> {got.kind}"
         assert got.default == want.default, f"{name}.{want.name}: default changed"
+        if (name, want.name) in _WIDENED:
+            continue
         assert got.annotation == want.annotation, (
             f"{name}.{want.name}: {want.annotation} -> {got.annotation}"
         )

--- a/tests/correlation/test_correlation_fm_canvas_widget.py
+++ b/tests/correlation/test_correlation_fm_canvas_widget.py
@@ -149,3 +149,30 @@ def test_the_crosshair_is_off():
     w = _widget()
     assert w.canvas._crosshair_artists == []
     assert w.canvas.btn_toggle_crosshair.isChecked() is False
+
+
+# ── the contract with the tab widget ──────────────────────────────────────
+
+# Public names on FMImageDisplayWidget the replacement deliberately does not
+# carry, with the reason. Everything else must be present.
+_WAIVED = {
+    "canvas_clicked": "on the shared canvas as a 3-arg signal; reachable via .canvas",
+}
+
+
+def test_every_public_name_is_carried_over_or_waived():
+    """Enumerates rather than spot-checks, for the same reason the FIB side does:
+    a hardcoded list only covers what someone remembered to type, and that is how
+    `set_scalebar_visible` went missing on the other canvas.
+
+    `hasattr` on the new side, not `vars` -- this widget subclasses FMCanvasWidget,
+    so most of what it offers is inherited and a `vars` check would report the
+    whole FM API as missing.
+    """
+    own = {
+        n for n, v in vars(FMImageDisplayWidget).items()
+        if not n.startswith("_") and (callable(v) or isinstance(v, property))
+    }
+    missing = {n for n in own if not hasattr(CorrelationFMCanvasWidget, n)}
+    unexplained = sorted(missing - set(_WAIVED))
+    assert not unexplained, f"not carried over and not waived: {unexplained}"

--- a/tests/correlation/test_correlation_fm_canvas_widget.py
+++ b/tests/correlation/test_correlation_fm_canvas_widget.py
@@ -1,0 +1,151 @@
+"""CorrelationFMCanvasWidget: the FM half of the canvas migration (FIB-535).
+
+Picking behaviour is covered by the picking and overlay suites. What is pinned
+here is what putting correlation on the *standard* FM widget has to preserve —
+the controls it keeps, and the z semantics a picked point depends on.
+
+The z tests are the ones that matter. `FMCanvasWidget` defaults to
+max-projection because the quad view is a viewer; correlation is a picker, and a
+projection has no z to give a point. Getting that wrong is silent: every FM point
+lands at z=0 and the correlation is quietly wrong.
+"""
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] without the UI extra
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.correlation.structures import Coordinate, PointType, PointXYZ
+from fibsem.fm.structures import (
+    FluorescenceChannelMetadata,
+    FluorescenceImage,
+    FluorescenceImageMetadata,
+)
+from fibsem.ui.correlation.widgets.correlation_fm_canvas_widget import (
+    CorrelationFMCanvasWidget,
+)
+from fibsem.ui.correlation.widgets.fm_image_display_widget import FMImageDisplayWidget
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+_NZ = 9
+
+
+def _fm_image(nz=_NZ, size=32):
+    metadata = FluorescenceImageMetadata(
+        acquisition_date="2026-08-10T00:00:00",
+        pixel_size_x=1e-7,
+        pixel_size_y=1e-7,
+        resolution=(size, size),
+        channels=[
+            FluorescenceChannelMetadata(
+                name="GFP", color="#00ff00", excitation_wavelength=488,
+                emission_wavelength=509, power=1.0, exposure_time=0.1,
+                gain=1.0, offset=0.0,
+            )
+        ],
+        filename="stack",
+    )
+    data = np.zeros((1, nz, size, size), dtype=np.uint16)
+    return FluorescenceImage(data=data, metadata=metadata)
+
+
+def _widget():
+    w = CorrelationFMCanvasWidget(allowed_point_types=[PointType.FM])
+    w.set_fm_image(_fm_image())
+    return w
+
+
+# ── z, and why it is not the shared default ───────────────────────────────
+
+
+def test_max_projection_is_off_so_points_get_a_real_z():
+    """FMCanvasWidget defaults it on; a projection has no plane, so `current_z`
+    would answer 0 for every point picked on it."""
+    w = _widget()
+    assert w._max_projection is False
+    assert w._btn_mip.isChecked() is False  # button agrees with what is drawn
+
+
+@pytest.mark.parametrize("z", [0, 4, 8])
+def test_current_z_matches_the_widget_it_replaces(z):
+    """Same slider position, same answer — this is the number that becomes a
+    picked Coordinate's z, so a divergence is a silently wrong correlation."""
+    old = FMImageDisplayWidget()
+    old.set_fm_image(_fm_image())
+    new = _widget()
+
+    old._z_slider.setValue(z)
+    new._z_slider.setValue(z)
+
+    assert new.current_z == old.current_z == z
+
+
+def test_the_step_arrows_move_one_plane_and_stop_at_the_ends():
+    """Present because FMImageDisplayWidget has them; without them the swap would
+    lose a control the correlation display has today."""
+    w = _widget()
+    w._z_slider.setValue(0)
+
+    w._z_next.click()
+    assert w.current_z == 1
+    w._z_prev.click()
+    w._z_prev.click()  # already at 0
+    assert w.current_z == 0
+
+    w._z_slider.setValue(_NZ - 1)
+    w._z_next.click()
+    assert w.current_z == _NZ - 1
+
+
+def test_stepping_does_nothing_under_max_projection():
+    w = _widget()
+    w.set_max_projection(True)
+    w.step_z(3)
+    assert w.current_z == 0
+
+
+# ── the standard FM control set, kept ─────────────────────────────────────
+
+
+def test_it_keeps_the_shared_fm_controls():
+    """The point of replacing FMImageDisplayWidget rather than porting it: the
+    correlation FM display gets the same z-slider, layers popover and
+    max-projection button the quad view and FM overview use."""
+    w = _widget()
+    assert w._btn_layers is not None
+    assert w._btn_mip is not None
+    assert (w._z_prev.text(), w._z_next.text()) == ("‹", "›")
+    assert w._panel is not None  # the per-channel layers popover
+
+
+def test_pixel_size_is_not_shadowed():
+    """FMCanvasWidget.set_pixel_size also records _pixel_size, which compositing
+    reads; an override that only touched the canvas would drop it."""
+    w = _widget()
+    assert w._pixel_size == pytest.approx(1e-7)
+
+
+# ── the picking surface ───────────────────────────────────────────────────
+
+
+def test_points_and_signals_come_through():
+    w = _widget()
+    a = Coordinate(PointXYZ(10.0, 12.0, 3.0), PointType.FM)
+    seen = []
+    w.point_selected.connect(seen.append)
+
+    w.set_coordinates([a])
+    w.points.coordinate_selected.emit(a)
+
+    assert w.points.get_points() == [(10.0, 12.0)]
+    assert seen == [a]
+
+
+def test_the_crosshair_is_off():
+    w = _widget()
+    assert w.canvas._crosshair_artists == []
+    assert w.canvas.btn_toggle_crosshair.isChecked() is False

--- a/tests/correlation/test_correlation_picking.py
+++ b/tests/correlation/test_correlation_picking.py
@@ -1,0 +1,141 @@
+"""CorrelationPicking: one picking implementation, any FibsemImageCanvas (FIB-535).
+
+The behaviour itself is covered by the point-overlay and canvas-widget suites.
+What is pinned here is the property the extraction exists for — that picking is
+not welded to one host — because that is the claim the FM side depends on and
+the one a future refactor could quietly break.
+"""
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] without the UI extra
+
+from PyQt5.QtWidgets import QApplication, QWidget
+
+from fibsem.correlation.structures import Coordinate, PointType, PointXYZ
+from fibsem.ui.correlation.widgets.correlation_canvas_widget import (
+    CorrelationCanvasWidget,
+)
+from fibsem.ui.correlation.widgets.correlation_picking import CorrelationPicking
+from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+# Hosts own their canvases; letting them fall out of scope deletes the C++ side
+# while the test still holds the Python wrapper.
+_ALIVE = []
+
+
+def _bare_canvas():
+    c = FibsemImageCanvas()
+    c.set_array(np.zeros((64, 64), dtype=np.uint8))
+    _ALIVE.append(c)
+    return c
+
+
+def _fm_canvas():
+    """The canvas the FM side will pick on: FMCanvasWidget's, complete with its
+    own z-slider, layers popover and MIP toolbar button."""
+    w = FMCanvasWidget()
+    _ALIVE.append(w)
+    return w.canvas
+
+
+def _coord(x, y, pt=PointType.FIB):
+    return Coordinate(PointXYZ(x, y, 0.0), pt)
+
+
+# ── the reason it was extracted ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize("make_canvas", [_bare_canvas, _fm_canvas],
+                         ids=["FibsemImageCanvas", "FMCanvasWidget.canvas"])
+def test_picking_attaches_to_any_shared_canvas(make_canvas):
+    """The FIB side puts this on a bare canvas, the FM side on FMCanvasWidget's.
+    If it only worked on one, the FM display would need its own copy of the
+    picking plumbing — which is exactly the duplication being removed."""
+    canvas = make_canvas()
+    picking = CorrelationPicking(canvas, menu_parent=QWidget())
+
+    picking.set_coordinates([_coord(10, 10), _coord(20, 20, PointType.POI)])
+
+    assert picking.points.get_points() == [(10.0, 10.0), (20.0, 20.0)]
+    assert picking.points in canvas._overlays
+    assert picking.results in canvas._overlays
+
+
+def test_result_markers_reach_the_result_overlay_on_any_canvas():
+    picking = CorrelationPicking(_fm_canvas(), menu_parent=QWidget())
+    picking.set_coordinates([_coord(10, 10)])
+
+    picking.add_overlay_points([(20.0, 20.0), (30.0, 30.0)], color="#ff4444")
+
+    assert len(picking.results._artists) == 2
+    assert picking.points.get_points() == [(10.0, 10.0)]  # untouched
+
+
+# ── ownership ─────────────────────────────────────────────────────────────
+
+
+def test_dispose_unregisters_both_overlays():
+    canvas = _bare_canvas()
+    picking = CorrelationPicking(canvas, menu_parent=QWidget())
+    assert len(canvas._overlays) == 2
+
+    picking.dispose()
+
+    assert canvas._overlays == []
+    assert picking.points._ax is None  # detached, not merely dropped
+
+
+def test_a_second_attachment_without_dispose_stacks_overlays():
+    """Why dispose() exists. The canvas owns `_overlays`, not picking, so simply
+    dropping a CorrelationPicking leaves its overlays drawing — two sets of
+    markers, one of them answering to nothing."""
+    canvas = _bare_canvas()
+    CorrelationPicking(canvas, menu_parent=QWidget())
+
+    CorrelationPicking(canvas, menu_parent=QWidget())
+
+    assert len(canvas._overlays) == 4  # the trap
+    canvas.clear_overlays()
+
+
+# ── the host's side of the contract ───────────────────────────────────────
+
+
+def test_the_widget_forwards_the_four_signals():
+    """Forwarded rather than left on `.picking`, so `correlation_tab_widget` and
+    its _CanvasAdapter connect to this exactly as they do to ImagePointCanvas."""
+    w = CorrelationCanvasWidget()
+    w.set_image(np.zeros((64, 64), dtype=np.uint8))
+    a = _coord(10, 10)
+    w.set_coordinates([a])
+    seen = {"sel": [], "moved": [], "removed": []}
+    w.point_selected.connect(seen["sel"].append)
+    w.point_moved.connect(seen["moved"].append)
+    w.point_removed.connect(seen["removed"].append)
+
+    w.points.coordinate_selected.emit(a)
+    w.points.coordinate_moved.emit(a)
+    w.points.remove_coordinate(a)
+
+    assert seen["sel"] == [a] and seen["moved"] == [a] and seen["removed"] == [a]
+
+
+def test_the_correlation_canvas_hides_the_crosshair():
+    """The shared canvas defaults it on; correlation draws SURFACE as an orange
+    "+" that a yellow centre "+" is easy to confuse with — and it would land in a
+    saved plot. The toolbar toggle still brings it back."""
+    w = CorrelationCanvasWidget()
+    w.set_image(np.zeros((64, 64), dtype=np.uint8))
+
+    assert w.canvas._crosshair_artists == []
+    assert w.canvas.btn_toggle_crosshair.isChecked() is False
+    assert w.canvas.btn_toggle_crosshair.toolTip() == "Show crosshair"
+
+    w.canvas.toggle_crosshair()
+    assert w.canvas._crosshair_artists  # still available on demand

--- a/tests/correlation/test_correlation_save_plot.py
+++ b/tests/correlation/test_correlation_save_plot.py
@@ -1,0 +1,119 @@
+"""Save Plot's render path (FIB-535).
+
+`save_plot` used to call `ImagePointCanvas.render_to_axes`, which the shared
+canvas has no equivalent for — so swapping either canvas would have broken the
+export with an AttributeError. It now goes through `_render_canvas_to_axes`,
+which needs a matplotlib figure and nothing else.
+
+These tests exist to keep that true. The one that earns its keep is the
+parametrised one: it renders the canvas in production today *and* the one it is
+being swapped to, through the same code path.
+"""
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] without the UI extra
+
+from matplotlib.figure import Figure
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.correlation.structures import Coordinate, PointType, PointXYZ
+from fibsem.ui.correlation.widgets.correlation_canvas_widget import (
+    CorrelationCanvasWidget,
+)
+from fibsem.ui.correlation.widgets.correlation_tab_widget import (
+    _render_canvas_to_axes,
+)
+from fibsem.ui.correlation.widgets.image_point_canvas import ImagePointCanvas
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+_COORDS = [
+    Coordinate(PointXYZ(40.0, 30.0, 0.0), PointType.FIB),
+    Coordinate(PointXYZ(80.0, 60.0, 0.0), PointType.SURFACE),
+]
+_IMAGE = np.linspace(0, 255, 128 * 128, dtype=np.uint8).reshape(128, 128)
+
+# Kept alive for the session: the widget owns its canvas, and letting it fall out
+# of scope deletes the C++ side while the test still holds the Python wrapper.
+_ALIVE = []
+
+
+def _old_canvas():
+    c = ImagePointCanvas(allowed_point_types=[PointType.FIB])
+    c.set_image(_IMAGE)
+    c.set_coordinates(list(_COORDS))
+    _ALIVE.append(c)
+    return c
+
+
+def _new_canvas():
+    w = CorrelationCanvasWidget(allowed_point_types=[PointType.FIB])
+    w.set_image(_IMAGE)
+    w.set_coordinates(list(_COORDS))
+    _ALIVE.append(w)
+    return w.canvas
+
+
+@pytest.fixture
+def ax():
+    """A bare Figure, not `plt.subplots`.
+
+    pyplot would build the figure through the *interactive* backend, which spins
+    up a Qt figure manager and mutates application-wide state — enough to change
+    the default font and break an unrelated widget test later in the run.
+    """
+    return Figure(figsize=(8, 8)).add_subplot(111)
+
+
+# ── the reason this was rewritten ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize("make_canvas", [_old_canvas, _new_canvas],
+                         ids=["ImagePointCanvas", "FibsemImageCanvas"])
+def test_any_matplotlib_canvas_can_be_rendered(make_canvas, ax):
+    """The canvas in production today and the one it is being swapped to, through
+    one code path. If this only passed for one of them, a half-migrated
+    correlation tab would break Save Plot."""
+    _render_canvas_to_axes(make_canvas(), ax)
+
+    assert ax.get_images(), "nothing was drawn into the axes"
+    assert not ax.axison  # the panel frame is hidden, as the old path did
+
+
+def test_the_export_does_not_disturb_the_live_canvas(ax):
+    """savefig runs through the canvas's own Qt draw path, so this is not
+    self-evident — the figure it renders is the one still on screen."""
+    canvas = _old_canvas()
+    before = (canvas.figure.get_size_inches().tolist(), canvas.figure.get_dpi())
+
+    _render_canvas_to_axes(canvas, ax)
+
+    assert (canvas.figure.get_size_inches().tolist(), canvas.figure.get_dpi()) == before
+    canvas.draw()  # must not raise
+
+
+def test_the_rendered_panel_is_not_stretched(ax):
+    """A square image comes out square. `render_to_axes` re-fitted content to the
+    panel, turning a 1:1 image into the panel's 2:1 — measuring off that export
+    gave the wrong answer."""
+    _render_canvas_to_axes(_old_canvas(), ax)
+
+    buffer = ax.get_images()[0].get_array()
+    h, w = buffer.shape[:2]
+    canvas_w, canvas_h = _old_canvas().figure.get_size_inches()
+    assert w / h == pytest.approx(canvas_w / canvas_h, rel=0.02)
+
+
+def test_resolution_comes_from_the_request_not_the_widget(ax):
+    """A plain buffer_rgba() grab would cap the export at the on-screen widget
+    size; a small window would silently produce a low-resolution plot."""
+    canvas = _old_canvas()
+    canvas.resize(120, 120)
+
+    _render_canvas_to_axes(canvas, ax, dpi=150)
+
+    height = ax.get_images()[0].get_array().shape[0]
+    assert height > 600, f"exported at only {height}px — widget size leaked in"

--- a/tests/ui/test_canvas_base.py
+++ b/tests/ui/test_canvas_base.py
@@ -87,6 +87,51 @@ def test_a_subclass_extent_drives_the_fit():
     assert c._ax.get_ylim() == (250.0, 50.0)
 
 
+# ── chrome toggles keep their buttons honest ──────────────────────────────
+
+
+def test_setting_crosshair_visibility_syncs_its_button():
+    """The setter, not only the toggle, has to sync — a widget picking its own
+    default at construction would otherwise show a checked button whose tooltip
+    offers to hide a crosshair that is not drawn."""
+    c = FibsemImageCanvas()
+    c.set_array(_img(32, 32))
+
+    c.set_crosshair_visible(False)
+
+    assert c._crosshair_artists == []
+    assert c.btn_toggle_crosshair.isChecked() is False
+    assert c.btn_toggle_crosshair.toolTip() == "Show crosshair"
+
+
+def test_setting_scalebar_visibility_syncs_its_button():
+    """`set_scalebar_visible` is new: the shared canvas had only a toggle, which
+    cannot express "off" without first knowing what it is currently set to."""
+    c = FibsemImageCanvas()
+    c.set_array(_img(32, 32), pixel_size=1e-8)
+
+    assert c._scalebar_artist is not None  # drawn, because pixel_size is known
+
+    c.set_scalebar_visible(False)
+
+    assert c._scalebar_artist is None  # actually removed, not just flagged
+    assert c.btn_toggle_scalebar.isChecked() is False
+    assert c.btn_toggle_scalebar.toolTip() == "Show scalebar"
+
+
+@pytest.mark.parametrize("noun", ["crosshair", "scalebar"])
+def test_the_toolbar_toggle_still_round_trips(noun):
+    c = FibsemImageCanvas()
+    c.set_array(_img(32, 32), pixel_size=1e-8)
+    toggle = getattr(c, f"toggle_{noun}")
+    button = getattr(c, f"btn_toggle_{noun}")
+
+    toggle()
+    assert button.isChecked() is False and button.toolTip() == f"Show {noun}"
+    toggle()
+    assert button.isChecked() is True and button.toolTip() == f"Hide {noun}"
+
+
 if __name__ == "__main__":
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):


### PR DESCRIPTION
Follow-up to #321 / #324 / #325 / #329 / #333 / #339 — the correlation canvas consolidation ([the Linear issue](https://linear.app/fibsemos/issue/FIB-535/consolidate-the-correlation-point-canvas-onto-the-shared-canvas-stack)).

**Groundwork. Nothing is swapped.** The correlation tab still uses `ImagePointCanvas` and `FMImageDisplayWidget`. One PR from now both surfaces move together; the PR after that deletes the old files.

The end state, decided this week — both correlation canvases on the shared stack, and `fm_image_display_widget.py` (574 lines) deleted alongside `image_point_canvas.py` (1030):

```
FIB:  CorrelationCanvasWidget    = FibsemImageCanvas + CorrelationPicking
FM:   CorrelationFMCanvasWidget  = FMCanvasWidget    + CorrelationPicking
                                   └─ the standard z-slider / layers popover / MIP
```

## ⚠️ Two commits reach outside correlation

`canvas_base.py` and `fm_canvas.py` are behind **every** canvas in the app — quad view, FM overview, coincidence viewer, milling task viewer, lamella config. Reviewing those two on their own terms is worth more than reviewing the correlation work.

- **`canvas_base`** — `set_scalebar_visible` is new and purely additive. The behaviour change is that both `set_*_visible` setters now sync their toolbar button and tooltip, which previously only the toggles did. Three existing callers, all of which get *more* correct.
- **`fm_canvas`** — `current_z`, `set_max_projection`, and `‹` `›` step buttons flanking the z-slider. All additive. The arrows show up in the quad view and FM overview too.

Both consumer suites green: `1481 passed, 8 skipped`.

## The migration would have broken Save Plot

`save_plot` called `render_to_axes` on **both** canvases (`:2895`, `:2898`). The shared canvas has no such method, so swapping either one would have taken Save Plot down with an `AttributeError` — a production feature killed by an intermediate state.

So it is rewritten **first**, against today's canvases, and neither swap touches it afterwards. `_render_canvas_to_axes` needs a matplotlib figure and nothing else. Verified across all three states:

```
old + old   (production today)   renders
old + new   (mid-swap)           renders
new + new   (after the swap)     renders
```

`savefig` re-renders offscreen at a requested dpi, so resolution comes from the request rather than the window size — the reason this is not a `buffer_rgba()` grab, which would silently export at whatever size the window happened to be.

### It also fixes a real defect

The export was stretching content to fill the panel — a square image became the panel's 2:1. Blobs that are circular on screen came out elliptical in the file, so **anyone measuring off a saved plot was reading a distorted image**. It now preserves aspect ratio.

| | before | after |
| --- | --- | --- |
| 512×512 image in an 8×8in panel | stretched to 2:1 | square, letterboxed |

## `CorrelationPicking`

**Goal: one implementation of "pick correlation points on a canvas",** so the FIB and FM surfaces cannot drift. Both need identical picking on top of a completely different image pipeline.

**Explicit non-goal: sharing image display.** `set_image(ndarray)` versus `set_fm_image(FluorescenceImage)` plus z/MIP/layers. Conflating "shows an image" with "lets you pick points on it" is what produced two 600–1000 line widgets in the first place.

Composition rather than a mixin. A mixin does work — PyQt5 picks up `pyqtSignal` from a plain-object mixin, verified — so this was a design call, not a constraint. A mixin's dependency on `self.canvas` would be implicit: the attribute must exist, be a `FibsemImageCanvas`, and be constructed *before* the mixin's init. Here all three are one constructor argument.

Each host forwards the four signals, so **`correlation_tab_widget` and its duck-typed `_CanvasAdapter` do not change at all** when the swap lands.

`CorrelationFMCanvasWidget` comes out at ~130 lines, standing in for 574.

## The harness found two bugs a green suite did not

Built *before* the swap on purpose — the FIB side had `test_correlation_canvas_demo.py`, and this is the FM equivalent.

**Max projection.** `FMCanvasWidget` defaults it **on** (the quad view is a viewer); `FMImageDisplayWidget` defaults it **off**. A projection has no plane, so `current_z` answers 0 — **every FM point picked in correlation would silently have taken z=0**, and the correlation would have been quietly wrong. Now off by default, with a parametrised test asserting `current_z` matches the old widget across the z range.

**`set_pixel_size`.** My override shadowed `FMCanvasWidget`'s, which also records `_pixel_size` for the compositing path. Removed.

## The parity test had a structural blind spot

It iterated a **hardcoded list**, so it only checked what someone remembered to type. That is exactly how `set_scalebar_visible` went missing — on the old canvas, called by the tab widget, absent from the replacement, and the test said nothing.

It now enumerates and requires every public name to be forwarded or waived with a reason. Verified against the original bug:

```
AssertionError: not forwarded and not waived: ['set_scalebar_visible']
```

Enumerating immediately found two more divergences nobody had looked at — `add_overlay_points`: `points` is `List`→`Sequence`, `size` is `int`→`float`. Both are widenings, so every call the old signature accepted the new one still accepts, but they are declared individually rather than tolerated: a blanket exemption would let a *narrowing* hide, which is the class the `set_image` `FibsemImage` bug belonged to.

## Crosshair off on the correlation canvases

The shared canvas defaults it on and the old correlation canvas drew none. Correlation draws `SURFACE` as an orange `+`, which the yellow centre `+` is easy to confuse with — on the one point whose whole job is marking a position — and it lands in a saved plot. Toolbar toggle still brings it back.

## Testing

`1481 passed, 8 skipped` — `tests/correlation/`, `tests/ui/`. 5/5 mutations caught on the `canvas_base` change.

Tests are not the gate here, though. Two harnesses, both runnable with no hardware:

```bash
PYTHONPATH=$PWD python fibsem/ui/correlation/widgets/test_correlation_fm_canvas_demo.py
```

```bash
PYTHONPATH=$PWD python fibsem/ui/correlation/widgets/test_correlation_canvas_demo.py
```

Old left, new right, same image and points on both.
