### PR TITLE
[ui] Swap both correlation canvases onto the shared stack

### DIFF
--- a/fibsem/ui/correlation/widgets/correlation_fm_canvas_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_fm_canvas_widget.py
@@ -70,6 +70,30 @@ class CorrelationFMCanvasWidget(FMCanvasWidget):
         self.picking.point_removed.connect(self.point_removed)
         self.picking.point_add_requested.connect(self.point_add_requested)
 
+        # Shift+scroll steps the z-plane, as it did on FMImageDisplayWidget.
+        # `canvas_scrolled` rather than a bespoke signal: the shared canvas
+        # already broadcasts modified scroll and already declines to zoom under
+        # any modifier, and two widgets consume it in exactly this shape --
+        # objective_control_widget and beam_settings_widget.
+        self.canvas.canvas_scrolled.connect(self._on_canvas_scrolled)
+        # Shift+scroll has no visible affordance, so the slider tooltip is the
+        # only place it can be discovered. Set here rather than on FMCanvasWidget
+        # because only this widget wires it -- the quad view would be advertising
+        # something that does nothing.
+        self._z_slider.setToolTip("Drag to change Z-slice, or Shift+scroll on the image")
+
+    def _on_canvas_scrolled(self, x, y, direction: int, modifiers) -> None:
+        """Shift+scroll → one z-plane. Plain scroll is left to the canvas (zoom).
+
+        Note for macOS: matplotlib's Qt backend reads only the vertical wheel
+        delta, and AppKit turns Shift+wheel horizontal on a discrete mouse, so
+        this never fires there. Windows and Linux are unaffected; the ‹ › buttons
+        and the slider work everywhere. FIB-552, deliberately parked.
+        """
+        if "Shift" not in modifiers:
+            return
+        self.step_z(direction)
+
     @property
     def points(self):
         """The interactive point overlay."""

--- a/fibsem/ui/correlation/widgets/correlation_picking.py
+++ b/fibsem/ui/correlation/widgets/correlation_picking.py
@@ -86,6 +86,21 @@ class CorrelationPicking(QObject):
         self.points.coordinate_removed.connect(self.point_removed)
         self.points.add_requested.connect(self._show_add_menu)
 
+        # Legend and label toggles. The shared toolbar has neither -- they are
+        # correlation's chrome, not the canvas's -- but ImagePointCanvas carried
+        # both, so without these the swap would quietly cost two controls that
+        # exist today. Same icons and tooltips it used.
+        self.btn_legend = canvas.add_toolbar_button(
+            "mdi:format-list-bulleted", "Toggle legend",
+            self.set_legend_visible, checkable=True,
+        )
+        self.btn_legend.setChecked(True)
+        self.btn_labels = canvas.add_toolbar_button(
+            "mdi:label-outline", "Toggle point labels",
+            self.set_labels_visible, checkable=True,
+        )
+        self.btn_labels.setChecked(True)
+
     def dispose(self) -> None:
         """Unregister both overlays from the canvas.
 
@@ -115,6 +130,7 @@ class CorrelationPicking(QObject):
     def set_legend_visible(self, visible: bool) -> None:
         """Show or hide the point-type legend (one swatch per type on screen)."""
         self.points.set_legend_visible(visible)
+        self.btn_legend.setChecked(visible)
 
     def set_labels_visible(self, visible: bool) -> None:
         """Show or hide the per-point names. Independent of marker visibility --
@@ -125,6 +141,7 @@ class CorrelationPicking(QObject):
         image showing a result."""
         self.points.set_labels_visible(visible)
         self.results.set_labels_visible(visible)
+        self.btn_labels.setChecked(visible)
 
     # ── result markers ────────────────────────────────────────────────────
 

--- a/fibsem/ui/correlation/widgets/correlation_tab_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_tab_widget.py
@@ -98,11 +98,13 @@ from fibsem.ui.correlation.widgets.fit_confirmation_dialog import (
 from fibsem.ui import notification_service, stylesheets
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.utils import install_wheel_blocker
-from fibsem.ui.correlation.widgets.fm_image_display_widget import (
-    IMAGE_HEADER_STYLE,
-    FMImageDisplayWidget,
+from fibsem.ui.correlation.widgets.correlation_canvas_widget import (
+    CorrelationCanvasWidget,
 )
-from fibsem.ui.correlation.widgets.image_point_canvas import ImagePointCanvas
+from fibsem.ui.correlation.widgets.correlation_fm_canvas_widget import (
+    CorrelationFMCanvasWidget,
+)
+from fibsem.ui.stylesheets import IMAGE_HEADER_STYLE
 from fibsem.fm.structures import FluorescenceImage
 from fibsem.structures import FibsemImage, Point
 from fibsem.ui.widgets.custom_widgets import (
@@ -1624,17 +1626,32 @@ class CorrelationTabWidget(QWidget):
         self._fib_name_label.setVisible(False)
         fib_layout.addWidget(self._fib_name_label)
 
-        self._fib_canvas = ImagePointCanvas(
+        self._fib_canvas = CorrelationCanvasWidget(
             allowed_point_types=self._point_types_for_side("fib"),
         )
         fib_layout.addWidget(self._fib_canvas, stretch=1)
         splitter.addWidget(fib_pane)
 
-        # Middle: FM image display
-        self._fm_display = FMImageDisplayWidget(
+        # Middle: FM image display, in a pane matching the FIB one. The filename
+        # header used to live inside FMImageDisplayWidget; the shared FM canvas
+        # has no such thing, and putting it here makes the two panes the same
+        # shape rather than one carrying its own header and one not.
+        fm_pane = QWidget()
+        fm_layout = QVBoxLayout(fm_pane)
+        fm_layout.setContentsMargins(0, 0, 0, 0)
+        fm_layout.setSpacing(0)
+
+        self._fm_name_label = QLabel("")
+        self._fm_name_label.setStyleSheet(IMAGE_HEADER_STYLE)
+        self._fm_name_label.setTextFormat(Qt.TextFormat.PlainText)
+        self._fm_name_label.setVisible(False)
+        fm_layout.addWidget(self._fm_name_label)
+
+        self._fm_display = CorrelationFMCanvasWidget(
             allowed_point_types=self._point_types_for_side("fm"),
         )
-        splitter.addWidget(self._fm_display)
+        fm_layout.addWidget(self._fm_display, stretch=1)
+        splitter.addWidget(fm_pane)
 
         # Right: tab widget stacked above run button
         self._tabs = QTabWidget()
@@ -1864,25 +1881,35 @@ class CorrelationTabWidget(QWidget):
         self.data_changed.emit(self.data)
 
     def _update_fib_name_label(self, image: FibsemImage) -> None:
-        """Show the loaded FIB image's filename in the header (mirrors FM).
+        """Show the loaded FIB image's filename in the header (mirrors FM)."""
+        self._set_name_label(self._fib_name_label, image)
+
+    @staticmethod
+    def _set_name_label(label: QLabel, image) -> None:
+        """Show *image*'s filename in a canvas header label.
 
         The file it came from, so the label matches what the picker above it
         shows and the tooltip gives the full path. An image that was never
         written gets no label rather than the name it would have had (FIB-509).
+
+        One implementation for both panes: the FM header used to be
+        FMImageDisplayWidget's own, with its own copy of this, and the two could
+        have drifted.
         """
         path = getattr(image, "filepath", None) or ""
         base = os.path.basename(path)
-        self._fib_name_label.setText(base)
-        self._fib_name_label.setToolTip(path)
-        self._fib_name_label.setVisible(bool(base))
+        label.setText(base)
+        label.setToolTip(path)
+        label.setVisible(bool(base))
 
     def set_fm_image(self, fm_image: FluorescenceImage) -> None:
         """Load FM image into canvas and update images tab."""
         self._fm_image = fm_image
         self._fm_display.set_fm_image(fm_image)
+        self._set_name_label(self._fm_name_label, fm_image)
         px = self._effective_fm_pixel_size(fm_image)
         if px:
-            self._fm_display.canvas.set_pixel_size(px)
+            self._fm_display.set_pixel_size(px)
         _, n_z, h, w = fm_image.data.shape
         for spec in self._point_specs.values():
             if spec.adapter is self._fm_adapter:
@@ -2882,19 +2909,19 @@ class CorrelationTabWidget(QWidget):
 
     def _reset_views(self) -> None:
         self._fib_canvas.reset_view()
-        self._fm_display.canvas.reset_view()
+        self._fm_display.reset_view()
 
     def _on_scalebar_toggled(self, visible: bool) -> None:
         self._fib_canvas.set_scalebar_visible(visible)
-        self._fm_display.canvas.set_scalebar_visible(visible)
+        self._fm_display.set_scalebar_visible(visible)
 
     def _on_legend_toggled(self, visible: bool) -> None:
         self._fib_canvas.set_legend_visible(visible)
-        self._fm_display.canvas.set_legend_visible(visible)
+        self._fm_display.set_legend_visible(visible)
 
     def _on_labels_toggled(self, visible: bool) -> None:
         self._fib_canvas.set_labels_visible(visible)
-        self._fm_display.canvas.set_labels_visible(visible)
+        self._fm_display.set_labels_visible(visible)
 
     def _on_save_plot_clicked(self) -> None:
         """Prompt for a path and save the side-by-side FIB + FM plot."""
@@ -2931,13 +2958,13 @@ class CorrelationTabWidget(QWidget):
         path = self._ensure_dir_for(path)
 
         self._fib_canvas.reset_view()
-        self._fm_display.canvas.reset_view()
+        self._fm_display.reset_view()
 
         fig, (ax_fib, ax_fm) = plt.subplots(1, 2, figsize=(16, 8), facecolor=CANVAS_BG)
         for ax in (ax_fib, ax_fm):
             ax.set_facecolor(CANVAS_BG)
 
-        _render_canvas_to_axes(self._fib_canvas, ax_fib, dpi=_PLOT_DPI)
+        _render_canvas_to_axes(self._fib_canvas.canvas, ax_fib, dpi=_PLOT_DPI)
         ax_fib.set_title("FIB", color="white", fontsize=12)
 
         _render_canvas_to_axes(self._fm_display.canvas, ax_fm, dpi=_PLOT_DPI)

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -52,6 +52,7 @@ from fibsem.ui.tokens import (  # noqa: F401  (re-exported for existing callers)
 # keep resolving.
 from fibsem.ui.napari_style import NAPARI_STYLE  # noqa: F401
 from fibsem.ui.tokens import (
+    NEUTRAL_300,
     NEUTRAL_650,
     SURFACE_COLOR,
 )
@@ -59,6 +60,18 @@ from fibsem.ui.tokens import (
 _ICONS_DIR = _os.path.join(_os.path.dirname(__file__), "icons").replace("\\", "/")
 
 LABEL_INSTRUCTIONS_STYLE = """font-style: italic; color: gray; font-size: 12px;"""
+
+# Filename header sitting above an image canvas. Lived in
+# fm_image_display_widget until that module was retired (FIB-535); it describes a
+# label, not an FM display, so this is where it belongs.
+#
+# The border keeps its literal rather than becoming BORDER_COLOR (#3d4251) --
+# they are different colours, #3a3d42 is used raw in 39 other places, and a move
+# is not the place to change one. Tokenising it is separate work.
+IMAGE_HEADER_STYLE = (
+    f"color: {NEUTRAL_300}; font-size: 11px; padding: 3px 8px; "
+    f"background: {CANVAS_BG}; border-bottom: 1px solid #3a3d42;"
+)
 
 
 PROGRESS_BAR_STYLESHEET = f"""

--- a/tests/correlation/test_correlation_fm_canvas_widget.py
+++ b/tests/correlation/test_correlation_fm_canvas_widget.py
@@ -101,6 +101,31 @@ def test_the_step_arrows_move_one_plane_and_stop_at_the_ends():
     assert w.current_z == _NZ - 1
 
 
+def test_shift_scroll_steps_z_and_plain_scroll_does_not():
+    """Rides `canvas_scrolled` rather than the old bespoke z_scroll_requested --
+    the shared canvas already broadcasts modified scroll and already declines to
+    zoom under a modifier, which is how objective_control_widget and
+    beam_settings_widget consume it."""
+    w = _widget()
+    w._z_slider.setValue(4)
+
+    w.canvas.canvas_scrolled.emit(0.0, 0.0, 1, ("Shift",))
+    assert w.current_z == 5
+    w.canvas.canvas_scrolled.emit(0.0, 0.0, -1, ("Shift",))
+    assert w.current_z == 4
+
+    w.canvas.canvas_scrolled.emit(0.0, 0.0, 1, ())  # plain scroll is the canvas's zoom
+    assert w.current_z == 4
+
+
+def test_the_z_slider_advertises_shift_scroll():
+    """The gesture has no visible affordance, so the tooltip is the only place it
+    can be discovered. Set here, not on FMCanvasWidget: only this widget wires
+    it, so the quad view would be advertising something that does nothing."""
+    tip = _widget()._z_slider.toolTip()
+    assert "Shift" in tip and "scroll" in tip.lower()
+
+
 def test_stepping_does_nothing_under_max_projection():
     w = _widget()
     w.set_max_projection(True)

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -364,8 +364,8 @@ def test_canvas_allow_lists_derive_from_registry_map(qapp):
     w = _widget(qapp)
     fib_expected = [pt for pt, s in _POINT_TYPE_SIDES.items() if s == "fib"]
     fm_expected = [pt for pt, s in _POINT_TYPE_SIDES.items() if s == "fm"]
-    assert w._fib_canvas._allowed_types == fib_expected
-    assert w._fm_display.canvas._allowed_types == fm_expected
+    assert w._fib_canvas.picking._allowed_types == fib_expected
+    assert w._fm_display.picking._allowed_types == fm_expected
     # every mapped type has a spec (checked at build time too)
     assert set(w._point_specs) == set(_POINT_TYPE_SIDES)
 
@@ -642,31 +642,57 @@ def test_render_to_axes_replicates_legend(qapp):
 
 
 def test_canvas_toolbar_buttons_toggle_state(qapp):
-    """Each canvas gets reset/scalebar/legend buttons; checkable buttons drive
-    only their own canvas and stay in sync with the View-menu master toggle."""
+    """Checkable toolbar buttons drive only their own canvas and stay in sync
+    with the View-menu master toggle.
+
+    Scalebar and reset come from the shared canvas; legend and labels are
+    correlation's own, added by CorrelationPicking because the shared toolbar has
+    neither and ImagePointCanvas carried both.
+    """
     w = _widget(qapp)
-    canvas = w._fib_canvas
-    assert len(canvas._overlay_buttons) == 4
+    fib, fm = w._fib_canvas, w._fm_display
 
     # startup: the menu handler enabled the scalebar on both canvases
-    assert canvas._btn_scalebar.isChecked()
-    assert w._fm_display.canvas._btn_scalebar.isChecked()
-    assert canvas._btn_legend.isChecked()
+    assert fib.canvas.btn_toggle_scalebar.isChecked()
+    assert fm.canvas.btn_toggle_scalebar.isChecked()
+    assert fib.picking.btn_legend.isChecked()
 
     # a button toggles only its own canvas
-    canvas._btn_scalebar.click()
-    assert canvas._show_scalebar is False
-    assert w._fm_display.canvas._show_scalebar is True
+    fib.canvas.btn_toggle_scalebar.click()
+    assert fib.canvas._scalebar_visible is False
+    assert fm.canvas._scalebar_visible is True
 
-    canvas._btn_legend.click()
-    assert canvas._legend_visible is False
-    canvas._btn_legend.click()
-    assert canvas._legend_visible is True
+    fib.picking.btn_legend.click()
+    assert fib.points._legend_visible is False
+    fib.picking.btn_legend.click()
+    assert fib.points._legend_visible is True
 
     # the View menu still drives both canvases and re-syncs button state
     w._on_scalebar_toggled(True)
-    assert canvas._show_scalebar is True
-    assert canvas._btn_scalebar.isChecked()
+    assert fib.canvas._scalebar_visible is True
+    assert fib.canvas.btn_toggle_scalebar.isChecked()
+
+
+def test_canvas_toolbar_reset_button(qapp):
+    """Asserts the view actually resets, not that a method was called.
+
+    The shared canvas connects the bound `reset_view` at construction, so
+    replacing the attribute afterwards -- which worked on ImagePointCanvas, whose
+    button went through a late-binding lambda -- intercepts nothing.
+    """
+    import numpy as np
+
+    from fibsem.structures import FibsemImage
+
+    w = _widget(qapp)
+    w.set_fib_image(FibsemImage(data=np.zeros((64, 64), dtype=np.uint8)))
+    canvas = w._fib_canvas.canvas
+    fitted = canvas._ax.get_xlim()
+    canvas._ax.set_xlim(10, 20)  # as a zoom would leave it
+
+    canvas.btn_reset_view.click()
+
+    assert canvas._ax.get_xlim() == fitted
 
 
 def test_fm_scalebar_pixel_size_corrects_for_resize(qapp):
@@ -700,15 +726,6 @@ def test_fm_scalebar_pixel_size_corrects_for_resize(qapp):
         metadata=SimpleNamespace(pixel_size_x=150e-9, resolution=None),
     )
     assert eff(raw) == pytest.approx(150e-9)
-
-
-def test_canvas_toolbar_reset_button(qapp):
-    w = _widget(qapp)
-    canvas = w._fib_canvas
-    calls = []
-    canvas.reset_view = lambda: calls.append(True)
-    canvas._overlay_buttons[0].click()  # reset is the first-added (rightmost)
-    assert calls == [True]
 
 
 def test_ghost_export_preserves_hollow_style(qapp):
@@ -925,8 +942,8 @@ def test_save_plot_in_view_menu_and_test_menu_removed(qapp):
     assert w._action_save_plot.text() == "Save Plot"  # View menu, not the run bar
     assert not hasattr(w, "_btn_save_plot")
     assert not hasattr(w, "_action_test_save_plot")
-    # The FM display opts its canvas into Shift+scroll Z stepping.
-    assert w._fm_display.canvas._shift_z_enabled is True
+    # Shift+scroll Z stepping rides canvas_scrolled now; it needs a loaded
+    # stack, so it is tested in test_correlation_fm_canvas_widget.py.
 
 
 def test_dialog_allows_window_minimise(qapp):
@@ -1299,17 +1316,25 @@ def test_point_labels_have_outline(qapp):
 
 
 def test_labels_toggle_hides_labels(qapp):
+    import numpy as np
+
+    from fibsem.structures import FibsemImage
+
     w = _widget(qapp)
+    # The overlay draws artists only once the axes has content -- a point
+    # added first is kept and drawn when the image arrives, but this test is
+    # about the artists, so load one.
+    w.set_fib_image(FibsemImage(data=np.zeros((64, 64), dtype=np.uint8)))
     w._on_canvas_add_requested(5.0, 5.0, PointType.FIB)
     fib = w._fib_canvas
-    assert fib._label_artists[0].get_visible() is True  # shown by default
+    assert fib.points._anns[0].get_visible() is True  # shown by default
 
     w._on_labels_toggled(False)  # View → Show Labels off
-    assert fib._label_artists[0].get_visible() is False
-    assert fib._btn_labels.isChecked() is False
+    assert fib.points._anns[0].get_visible() is False
+    assert fib.picking.btn_labels.isChecked() is False
 
     w._on_labels_toggled(True)
-    assert fib._label_artists[0].get_visible() is True
+    assert fib.points._anns[0].get_visible() is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #342 — the correlation canvas consolidation ([the Linear issue](https://linear.app/fibsemos/issue/FIB-535/consolidate-the-correlation-point-canvas-onto-the-shared-canvas-stack)).

**This is the one users see.** Both correlation canvases move onto the shared stack in a single change, so the tab changes exactly once rather than spending a release half-migrated.

```
_fib_canvas  ->  CorrelationCanvasWidget      (FibsemImageCanvas + CorrelationPicking)
_fm_display  ->  CorrelationFMCanvasWidget    (FMCanvasWidget    + CorrelationPicking)
```

**Both old files stay on disk and unused.** Nothing in production imports them any more. Deleting them is the next PR — so if anything here misbehaves, the revert is one click and does not have to resurrect ~1600 lines.

## What changes for a user

**Gained:** contrast and gamma on both canvases — which `ImagePointCanvas` never had, and the reason for the whole exercise — plus zoom/pan, the ruler and the rest of the shared toolbar.

**Changed on the FM side:** the always-visible channel pane becomes the standard layers popover, so per-channel intensity is colormap / opacity / gamma / dual-handle contrast instead of a clip percentage. Max projection moves from an inline checkbox to a toolbar button. This is the agreed trade — the correlation FM display now uses the same controls as the quad view and the FM overview instead of a private second implementation.

**Off by default:** the crosshair, on both. Correlation draws `SURFACE` as an orange `+` and the shared canvas's yellow centre `+` is easy to mistake for it — on the one point whose whole job is marking a position. Toolbar toggle brings it back.

## Four things the swap turned up that a green suite had not

**`save_plot` broke.** It passed `self._fib_canvas`, which *was* a canvas and is now a widget wrapping one. Caught by the folder-creation tests, which is what they are for — and a payoff for having rewritten `save_plot` first in #342 rather than last.

**The legend and label toolbar buttons did not exist on the shared canvas.** `ImagePointCanvas` had four; the shared toolbar has reset and scalebar but neither of these. They are correlation's chrome, not the canvas's, so they are added through `add_toolbar_button` in `CorrelationPicking` — both surfaces get them, with the icons and tooltips the old canvas used. Without this the swap would have quietly cost two controls.

**Shift+scroll z-stepping was never wired.** The plan said it would ride `canvas_scrolled` and I never made the connection, so it would have been dead on *every* platform rather than just on a macOS mouse. Now connected, filtering for `Shift` exactly as `objective_control_widget` and `beam_settings_widget` do.

**The FM filename header lived inside `FMImageDisplayWidget`,** which is going away. The tab widget now owns both headers, so the two panes are the same shape rather than one carrying its own and one not, and the duplicated name-label logic collapses into one helper. `IMAGE_HEADER_STYLE` moves to `stylesheets`, keeping its literal border colour — `BORDER_COLOR` is a *different* colour and a move is not the place to change one.

## Test changes

All of the form "reaching into the old canvas's internals" — `_allowed_types`, `_label_artists`, `_overlay_buttons`. Two came out stronger:

- **the reset button** now asserts the view actually resets rather than that a method was called. The shared canvas binds `reset_view` at construction, so the old monkeypatch intercepted nothing — it would have passed against a disconnected button.
- **shift+scroll** moved to the FM widget's own suite, where a stack is loaded. In the tab-widget test `_z_max` was 0, so stepping was correctly a no-op and the assertion proved nothing.

## Testing

`1479 passed, 8 skipped` — `tests/correlation/`, `tests/ui/`.

Tests are not the gate. Driven end to end through a real `CorrelationTabWidget`:

```
images loaded          FIB 512x512   FM z-planes 9
filename headers       fib='fib_tile_007.tif' fm='fm_stack_002.ome.tiff'
points drawn           FIB 2 artists / 2 coords   FM 2 / 2
FM point z             [4.0, 4.0]  (slider at 4)
FIB datum row          drawn
result markers         1
view toggles           round-tripped, buttons in sync
shift+scroll z         4 -> 5
save_plot              1915x1182  written OK
crosshairs off         fib=True fm=True
contrast available     fib=True
```

**Worth a real session before merge**, particularly:

1. **z on a new FM point** matches the slider — the failure mode here is silent.
2. **The layers popover while actually picking.** If it turns out to be wrong for that, now is the moment: it is a one-line revert today and a much bigger deal after the next PR deletes the old widget.
3. **Save Plot**, both panels.
