### PR TITLE
[refactor] Move the GLIR GC repro harness into scripts/

### DIFF
--- a/scripts/test_glir_gc_repro.py
+++ b/scripts/test_glir_gc_repro.py
@@ -16,9 +16,9 @@ and platform-independent.
 
 Usage (manual, opens a real window)::
 
-    python test_glir_gc_repro.py                 # stock GC: expect detections
-    python test_glir_gc_repro.py --fixed         # main-thread GC: expect zero
-    python test_glir_gc_repro.py --duration 60   # run longer (default 20 s)
+    python scripts/test_glir_gc_repro.py                 # stock GC: expect detections
+    python scripts/test_glir_gc_repro.py --fixed         # main-thread GC: expect zero
+    python scripts/test_glir_gc_repro.py --duration 60   # run longer (default 20 s)
 
 Exit code 0 = no cross-thread GLIR commands observed, 1 = at least one.
 On a Windows machine without ``--fixed`` this may also genuinely hard-crash —


### PR DESCRIPTION
Pure file move, no behaviour change. `test_glir_gc_repro.py` was the last stray file at the repository root (after #344 removed `True`).

### Why move rather than delete

The harness is still live on all three counts:

- napari is still a hard dependency (`pyproject.toml:55`) and imported by 13 modules including `AutoLamellaMainUI`, so the vispy GLIR queue it instruments is still in the running app.
- The fix it verifies is still installed — `install_main_thread_gc` at `AutoLamellaMainUI.py:2393` (#168).
- **It is not redundant with the unit test.** `tests/ui/test_main_thread_gc.py` builds a plain reference cycle under PyQt5 offscreen and never imports napari, vispy or GLIR. It proves the collector moves finalizers to the main thread; this harness proves that actually keeps GLIR traffic off worker threads under real napari layer churn. Different claims, and the original crash was Windows- and driver-dependent, so re-running it on the Tescan machine is the only real check if it recurs.

It becomes deletable when napari goes: the replacement canvas is matplotlib, so GLIR will not exist and the harness will have no subject.

### Why `scripts/`

That is already where this genre lives — `scripts/test_acb.py`, `scripts/test_autofocus.py`, `scripts/test_tiled_overview_widget.py` are all standalone window-opening harnesses with the same docstring shape.

At the root, the `test_*.py` name also meant an explicit `pytest .` would import napari, PyQt5 and vispy at collection time only to collect zero tests. A bare `pytest` was always safe — `testpaths = ["tests"]`.

### Review notes

The only content change is the three usage lines in the module docstring, updated for the new path. Git records it as a 95% rename.