### PR TITLE
[fix] Keep the core importable without the ui extra, and guard it repo-wide

### DIFF
--- a/fibsem/applications/autolamella/tools/reporting.py
+++ b/fibsem/applications/autolamella/tools/reporting.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.figure import Figure
-from matplotlib_scalebar.scalebar import ScaleBar
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4, letter
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
@@ -487,6 +486,11 @@ def plot_lamella_task_workflow_summary(p: Lamella,
 
                 # add scalebar
                 if show_scalebar:
+                    # Deferred: matplotlib_scalebar is in the `ui` extra, and this
+                    # module is imported on non-UI paths. See the module-level import
+                    # guard in tests/test_ui_extra_isolation.py.
+                    from matplotlib_scalebar.scalebar import ScaleBar
+
                     ax[j].add_artist(ScaleBar(
                         dx=img.metadata.pixel_size.x * (shape[1] / target_size),
                         color="black",

--- a/tests/test_tiling_package.py
+++ b/tests/test_tiling_package.py
@@ -122,32 +122,17 @@ def test_the_package_exposes_the_public_surface():
         assert getattr(tiling, name) is not None
 
 
-# Packages declared in the `ui` extra of pyproject.toml. CI installs `.[test]`, not
-# `.[ui]`, so a module-level import of any of these from code on a non-UI path fails
-# the whole test run at collection time.
-UI_ONLY_PACKAGES = ("matplotlib_scalebar", "napari", "PyQt5", "pyqt5", "qtawesome")
+# The `ui`-extra import guard that used to live here is now repo-wide, in
+# tests/test_ui_extra_isolation.py. It was parametrised over this package alone, which
+# protected the module FIB-390 had just broken and nothing else -- reporting.py
+# acquired the same module-level import afterwards and kept it. The general version
+# walks the tree, so this package stays covered without naming it.
+_MOVED_TO = "tests/test_ui_extra_isolation.py"
 
-IMPORTED_BY_NON_UI_CODE = PURE_MODULES + ["imaging/tiled.py"]
 
-
-@pytest.mark.parametrize("path", IMPORTED_BY_NON_UI_CODE)
-def test_no_module_level_import_of_a_ui_only_dependency(path):
-    """Optional UI dependencies must stay deferred to the functions that need them.
-
-    `matplotlib_scalebar` is in the `ui` extra. `plot_stage_positions_on_image` and
-    `plot_minimap` both use it and both import it inside their own bodies, which is
-    what lets headless installs import this module at all.
-
-    That was nearly lost in the extraction (FIB-390): the moved function bodies were
-    verified AST-identical to their originals, but the module headers were written by
-    hand, and hoisting the lazy import into one of them broke every CI job on every
-    Python version -- at collection time, so it read as unrelated tests failing.
-    """
-    offending = sorted(
-        m for m in _module_level_imports(path)
-        if m.split(".")[0] in UI_ONLY_PACKAGES
-    )
-    assert not offending, (
-        f"{path} imports {offending} at module level. Those live in the `ui` extra, "
-        f"which CI does not install -- defer the import into the function that needs it."
+def test_the_ui_extra_guard_still_exists():
+    """This package relies on that guard; a rename should fail here, not go quiet."""
+    assert (Path(__file__).resolve().parents[1] / _MOVED_TO).exists(), (
+        f"{_MOVED_TO} is missing -- the `ui` extra import guard for this package "
+        f"(FIB-390) went with it."
     )

--- a/tests/test_ui_extra_isolation.py
+++ b/tests/test_ui_extra_isolation.py
@@ -1,0 +1,155 @@
+"""The core of fibsem must import without the `ui` extra installed.
+
+`pip install fibsem` gets napari, PyQt5, qtawesome and matplotlib_scalebar only if
+you ask for `.[ui]`. CI asks for `.[test]`. So a module-level import of one of those
+from code on a non-UI path does not degrade gracefully -- it raises at *collection*
+time, which reads as a pile of unrelated tests failing rather than as one bad import.
+
+That has happened: FIB-390 hoisted a deferred `matplotlib_scalebar` import into a
+module header during an extraction and broke every CI job on every Python version.
+The guard written in response lived in `test_tiling_package.py` and was parametrised
+over the tiling package alone, so it protected the module that had just been fixed and
+nothing else. `applications/autolamella/tools/reporting.py` then acquired the same
+module-level import and kept it, because nothing was looking.
+
+The cost was not hypothetical: `tests/autolamella/test_report_sections.py` cannot
+import the module it tests, and reads it as source text instead, specifically because
+of that import.
+
+This file is the general version. It walks the tree rather than naming modules, so a
+new file on a non-UI path is covered the day it is written.
+
+The pattern being protected is deferral, not avoidance -- an optional dependency
+imported inside the one function that needs it is correct and is what these tests
+allow. Only module scope is checked.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import List, Set, Tuple
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIBSEM = REPO_ROOT / "fibsem"
+
+# The distributions declared in the `ui` extra of pyproject.toml, plus the two that
+# arrive transitively with napari and are equally absent without it.
+UI_ONLY_PACKAGES = (
+    "napari",
+    "PyQt5",
+    "pyqt5",
+    "qtawesome",
+    "matplotlib_scalebar",
+    "superqt",
+    "vispy",
+    "qtpy",
+)
+
+# Importing anything under fibsem.ui pulls Qt in transitively -- `fibsem/ui/__init__.py`
+# imports every widget eagerly (FIB-352), so even a leaf module costs the whole tree.
+UI_PACKAGE_PREFIX = "fibsem.ui"
+
+# Modules that violate the rule and are not being fixed here. Each entry needs a
+# reason; an allow-list without one is just a disabled test.
+KNOWN_VIOLATIONS = {
+    # The legacy workflow package is unreachable and does not import at all --
+    # `_draw_milling_stages_on_image` has not existed in fibsem.ui.utils for some
+    # time. Listed rather than fixed because the package is slated for a decision of
+    # its own, and repairing an import in code that cannot run would be misleading.
+    "applications/autolamella/workflows/legacy/experimental.py",
+}
+
+
+def _is_ui_path(rel: str) -> bool:
+    return rel.startswith("ui/") or "/ui/" in rel
+
+
+def _core_modules() -> List[str]:
+    """Every non-UI, non-test module under fibsem/, relative to the package root."""
+    out = []
+    for path in sorted(FIBSEM.rglob("*.py")):
+        rel = path.relative_to(FIBSEM).as_posix()
+        parts = rel.split("/")
+        if "__pycache__" in parts or "tests" in parts or "test" in parts:
+            continue
+        if path.name.startswith("test"):
+            continue
+        if _is_ui_path(rel):
+            continue
+        out.append(rel)
+    return out
+
+
+CORE_MODULES = _core_modules()
+
+
+def _module_level_imports(rel: str) -> Set[str]:
+    """Imports at module scope only -- the ones that cost something to `import`.
+
+    Anything nested inside a function or an `if TYPE_CHECKING:` block is excluded on
+    purpose: that is the pattern this file protects, not a violation of it.
+    """
+    source = (FIBSEM / rel).read_text(encoding="utf-8", errors="ignore")
+    names: Set[str] = set()
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module)
+        elif isinstance(node, ast.Import):
+            names.update(a.name for a in node.names)
+    return names
+
+
+def _offenders(rel: str) -> Tuple[List[str], List[str]]:
+    imports = _module_level_imports(rel)
+    ui_dists = sorted(m for m in imports if m.split(".")[0] in UI_ONLY_PACKAGES)
+    ui_pkg = sorted(
+        m for m in imports
+        if m == UI_PACKAGE_PREFIX or m.startswith(UI_PACKAGE_PREFIX + ".")
+    )
+    return ui_dists, ui_pkg
+
+
+def test_the_scan_actually_found_modules():
+    """A walk that silently matches nothing would make every test below vacuous."""
+    assert len(CORE_MODULES) > 100, f"only found {len(CORE_MODULES)} core modules"
+
+
+@pytest.mark.parametrize("rel", CORE_MODULES)
+def test_no_module_level_import_of_a_ui_only_dependency(rel):
+    if rel in KNOWN_VIOLATIONS:
+        pytest.skip("known violation, see KNOWN_VIOLATIONS")
+    offending, _ = _offenders(rel)
+    assert not offending, (
+        f"fibsem/{rel} imports {offending} at module level. Those live in the `ui` "
+        f"extra, which CI does not install -- defer the import into the function that "
+        f"needs it, as fibsem/imaging/tiling/plotting.py does."
+    )
+
+
+@pytest.mark.parametrize("rel", CORE_MODULES)
+def test_no_module_level_import_of_the_ui_package(rel):
+    if rel in KNOWN_VIOLATIONS:
+        pytest.skip("known violation, see KNOWN_VIOLATIONS")
+    _, offending = _offenders(rel)
+    assert not offending, (
+        f"fibsem/{rel} imports {offending} at module level. fibsem.ui pulls in Qt "
+        f"transitively, so importing it from a non-UI path costs the whole widget "
+        f"tree -- defer it, or invert the dependency so the UI calls this module."
+    )
+
+
+@pytest.mark.parametrize("rel", sorted(KNOWN_VIOLATIONS))
+def test_known_violations_are_still_violations(rel):
+    """Delete the entry when the module is fixed, rather than leaving it to rot.
+
+    An allow-list nobody prunes eventually hides a regression behind an entry that
+    describes something already repaired.
+    """
+    assert (FIBSEM / rel).exists(), f"{rel} is gone -- drop it from KNOWN_VIOLATIONS"
+    ui_dists, ui_pkg = _offenders(rel)
+    assert ui_dists or ui_pkg, (
+        f"fibsem/{rel} no longer imports UI code at module level -- "
+        f"drop it from KNOWN_VIOLATIONS"
+    )


### PR DESCRIPTION
The core of `fibsem` is supposed to import without `.[ui]`. It didn't, in exactly one place — and the test that should have caught it was scoped to one package.

## The violation

```python
# fibsem/applications/autolamella/tools/reporting.py:12
from matplotlib_scalebar.scalebar import ScaleBar
```

`matplotlib_scalebar` is in the `ui` extra. CI installs `.[test]`, and a headless user generating reports need not have it, so this module simply could not be imported without the UI dependencies.

Deferred into the one function that uses it (`plot_lamella_task_workflow_summary`), matching what **every other** non-UI consumer of `matplotlib_scalebar` already does — `imaging/tiling/plotting.py:227,368` and `milling/patterning/plotting.py:732`.

## Why nothing caught it

The guard already existed. `test_tiling_package.py::test_no_module_level_import_of_a_ui_only_dependency` had the right package list and a docstring recording exactly this failure from FIB-390 — a hoisted lazy import broke every CI job on every Python version, at collection time, so it read as unrelated tests failing.

But it was parametrised over `PURE_MODULES + ["imaging/tiled.py"]`: **the tiling package alone**. It protected the module that had just been fixed, and nothing else. `reporting.py` acquired the same import afterwards and kept it.

**The cost was already being paid.** `tests/autolamella/test_report_sections.py` opens by explaining that it reads both sides as *source text rather than importing*, because "the reporting module pulls in reportlab and matplotlib_scalebar… all in the `[ui]` extra, which CI does not install." A regression test that cannot import its own subject, because of the import this PR removes.

## The general guard

New `tests/test_ui_extra_isolation.py` walks the tree instead of naming modules, so a new file on a non-UI path is covered the day it is written. Two checks, both at module scope only:

1. no import of a `ui`-extra distribution (`napari`, `PyQt5`, `qtawesome`, `matplotlib_scalebar`, `superqt`, `vispy`, `qtpy`)
2. no import of `fibsem.ui` — which pulls Qt in transitively, since `fibsem/ui/__init__.py` imports every widget eagerly (FIB-352), so even a leaf module costs the whole tree

**Deferred imports are explicitly allowed.** Deferral into the function that needs it is the pattern being protected, not a violation of it.

The narrow version in `test_tiling_package.py` is replaced by a one-line check that the general guard still exists, so a rename fails loudly rather than silently dropping that package's coverage.

## One allow-list entry

`workflows/legacy/experimental.py` imports `fibsem.ui.utils` at module level. Left alone: that whole package **does not import at all** — it wants `_draw_milling_stages_on_image`, which no longer exists in `fibsem.ui.utils` — and repairing an import in code that cannot run would be misleading. A separate test asserts every allow-list entry is *still* a violation, so the list cannot outlive what it describes.

## Verification

Empirical, not inferred. Blocked `napari`, `PyQt5`, `qtawesome`, `matplotlib_scalebar`, `superqt` and `vispy` at the import hook, then imported **all 176 non-UI modules**:

| | breakages |
| --- | --- |
| before | 1 (`reporting.py`) |
| after | **0** |

The new guard was also checked to fail: reverting the `reporting.py` fix makes it fail on exactly that module, rather than passing vacuously.

Full suite: **3969 passed, 36 skipped** (+349 from the new parametrised guard). All three touched files parse under Python 3.8, CI's oldest.

One deselect, pre-existing on `main` and unrelated: `test_no_shipped_configuration_still_declares_it` (FIB-561).