### PR TITLE
[refactor] Make matplotlib_scalebar a core dependency (FIB-562)

### DIFF
--- a/fibsem/applications/autolamella/tools/reporting.py
+++ b/fibsem/applications/autolamella/tools/reporting.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.figure import Figure
+from matplotlib_scalebar.scalebar import ScaleBar
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4, letter
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
@@ -486,11 +487,6 @@ def plot_lamella_task_workflow_summary(p: Lamella,
 
                 # add scalebar
                 if show_scalebar:
-                    # Deferred: matplotlib_scalebar is in the `ui` extra, and this
-                    # module is imported on non-UI paths. See the module-level import
-                    # guard in tests/test_ui_extra_isolation.py.
-                    from matplotlib_scalebar.scalebar import ScaleBar
-
                     ax[j].add_artist(ScaleBar(
                         dx=img.metadata.pixel_size.x * (shape[1] / target_size),
                         color="black",

--- a/fibsem/milling/patterning/plotting.py
+++ b/fibsem/milling/patterning/plotting.py
@@ -728,7 +728,8 @@ def draw_milling_patterns(
     # draw scalebar
     if scalebar:
         try:
-            # optional dependency, best effort
+            # A core dependency since FIB-562; the guard below is now only for a
+            # ScaleBar that cannot be constructed, not for a missing package.
             from matplotlib_scalebar.scalebar import ScaleBar
 
             ax.add_artist(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "opencv-python-headless>=4.7.0.72",
     "scikit-image>=0.19.3",
     "matplotlib>=3.7.0",
+    "matplotlib_scalebar>=0.8.1",
     "petname>=2.6",
     "pandas>=2.0.0",
     "pyyaml>=6.0",
@@ -56,7 +57,6 @@ ui = [
     "napari>=0.5.1,<=0.5.6; python_version >= '3.9'", # NumPy 2 well supported from 0.5.1
     "pyqt5>=5.15.9",
     "pyqt5-qt5 == 5.15.2 ; platform_system == 'Windows'",
-    "matplotlib_scalebar>=0.8.1",
     "qtawesome>=1.4.0", # bundled Material Design Icons font (offline icon rendering); >=1.4.0 guards Spin.start/stop before first paint
 ]
 odemis = ["pylibtiff", "shapely"]

--- a/tests/autolamella/test_report_sections.py
+++ b/tests/autolamella/test_report_sections.py
@@ -5,11 +5,15 @@ control: the checkbox moves, the default wins, the report is unchanged. A column
 rename that matches nothing leaves the raw column name in the PDF. Neither raises,
 so neither surfaced until someone compared the output against what they asked for.
 
-Both sides are read as source text rather than imported. The reporting module pulls
-in reportlab and matplotlib_scalebar, and the dialog pulls in PyQt5 -- all in the
-[ui] extra, which CI does not install. Importing them would make these skip in CI,
-and a regression test that never runs is not much of a guard against a regression.
-What is being checked is the literal spelling on each side, which the text carries.
+Both sides are read as source text rather than imported. The reporting module pulls in
+reportlab (the `reporting` extra) and the dialog pulls in PyQt5 (the `ui` extra), and
+CI installs neither. Importing them would make these skip in CI, and a regression test
+that never runs is not much of a guard against a regression. What is being checked is
+the literal spelling on each side, which the text carries.
+
+(This used to name matplotlib_scalebar as a third reason and put all three in the `ui`
+extra. Neither was right: scalebar is a core dependency now (FIB-562), and reportlab
+was always its own extra. reportlab alone still makes the import unavailable here.)
 """
 
 import re

--- a/tests/test_ui_extra_isolation.py
+++ b/tests/test_ui_extra_isolation.py
@@ -1,9 +1,9 @@
 """The core of fibsem must import without the `ui` extra installed.
 
-`pip install fibsem` gets napari, PyQt5, qtawesome and matplotlib_scalebar only if
-you ask for `.[ui]`. CI asks for `.[test]`. So a module-level import of one of those
-from code on a non-UI path does not degrade gracefully -- it raises at *collection*
-time, which reads as a pile of unrelated tests failing rather than as one bad import.
+`pip install fibsem` gets napari, PyQt5 and qtawesome only if you ask for `.[ui]`.
+CI asks for `.[test]`. So a module-level import of one of those from code on a non-UI
+path does not degrade gracefully -- it raises at *collection* time, which reads as a
+pile of unrelated tests failing rather than as one bad import.
 
 That has happened: FIB-390 hoisted a deferred `matplotlib_scalebar` import into a
 module header during an extraction and broke every CI job on every Python version.
@@ -12,9 +12,10 @@ over the tiling package alone, so it protected the module that had just been fix
 nothing else. `applications/autolamella/tools/reporting.py` then acquired the same
 module-level import and kept it, because nothing was looking.
 
-The cost was not hypothetical: `tests/autolamella/test_report_sections.py` cannot
-import the module it tests, and reads it as source text instead, specifically because
-of that import.
+`matplotlib_scalebar` has since been promoted to a core dependency (FIB-562) -- it was
+the wrong thing to gate, being a matplotlib plugin the non-UI plotting code needed --
+so that particular breakage cannot recur. The rule it motivated still holds for the
+packages that really are UI-only.
 
 This file is the general version. It walks the tree rather than naming modules, so a
 new file on a non-UI path is covered the day it is written.
@@ -36,12 +37,17 @@ FIBSEM = REPO_ROOT / "fibsem"
 
 # The distributions declared in the `ui` extra of pyproject.toml, plus the two that
 # arrive transitively with napari and are equally absent without it.
+#
+# `matplotlib_scalebar` is deliberately NOT here. It used to be, and it was the one
+# package on this list that half the core drew on -- tile plotting, pattern plotting
+# and the report figures all wanted a scalebar, so each deferred the import into a
+# function body purely to satisfy this rule. It is a core dependency now, so those
+# deferrals are a choice rather than a requirement.
 UI_ONLY_PACKAGES = (
     "napari",
     "PyQt5",
     "pyqt5",
     "qtawesome",
-    "matplotlib_scalebar",
     "superqt",
     "vispy",
     "qtpy",


### PR DESCRIPTION
`matplotlib_scalebar` was in the `ui` extra, but **half its uses are not UI**. Each of those had to import it inside a function body to keep the core importable — the same workaround written four times.

## What it costs to make core

```
matplotlib-scalebar 0.9.0
  requires: ['matplotlib']    <- already a core dependency
  files:    13
```

A 13-file pure-Python plugin over a library we already ship. No transitive weight, no compiled extension, no Qt.

## Why it was the wrong thing to gate

| non-UI (deferred out of necessity) | UI |
| --- | --- |
| `imaging/tiling/plotting.py` ×2 | `ui/correlation/widgets/image_point_canvas.py` ×2 |
| `milling/patterning/plotting.py` | `ui/widgets/canvas/canvas_base.py` |
| `applications/autolamella/tools/reporting.py` | `ui/fm/widgets/minimap_plot_widget.py` |

Drawing a scalebar on a micrograph is a plotting concern. The classification was wrong, not the code.

## What changes

- `reporting.py` imports it at module level again — where it was before #347 deferred it. That deferral existed *only* to satisfy the `ui` rule, and #347's own comment said so.
- Out of `UI_ONLY_PACKAGES` in `tests/test_ui_extra_isolation.py`.
- The FIB-390 breakage class — hoist a deferred scalebar import, take out every CI job on every Python version at collection time — cannot recur for this package.

**Left alone:** the three pre-existing `try/except` sites in `imaging/tiling/plotting.py` and `milling/patterning/plotting.py`. They degrade gracefully and that still works; only the comment calling the package "optional" needed correcting. Hoisting them would be churn without benefit.

## A stale explanation, corrected

`tests/autolamella/test_report_sections.py` justified reading its subject as source text by naming reportlab, matplotlib_scalebar and PyQt5 as "all in the `[ui]` extra". Two of the three were wrong: **reportlab has always been its own `reporting` extra**, and scalebar is core as of this PR. reportlab alone is still reason enough, so the approach stands — but the reasoning now matches reality.

## Verification

- `pyproject.toml` parses; scalebar in `dependencies`, absent from `ui`, which is now napari/PyQt5/qtawesome only.
- Blocked napari, PyQt5, qtawesome, superqt and vispy at the import hook and imported **all 176 core modules: 0 failures**. (The harness itself needed updating — it was still blocking scalebar, which no longer models a `[ui]`-less install and produced a false positive until fixed.)
- **Re-checked the guard for teeth**: injecting `import napari` into `imaging/tiled.py` makes `test_ui_extra_isolation` fail on exactly that module. Removing an entry from a list-driven test is the kind of change that can quietly defang it, so this was worth proving rather than assuming.
- Full suite: **3971 passed, 36 skipped.**

One deselect, pre-existing on `main` and unrelated: `test_no_shipped_configuration_still_declares_it` (FIB-561).