### PR TITLE
[ui] Start the correlation FM canvas mid-stack again

### DIFF
--- a/fibsem/ui/correlation/widgets/correlation_fm_canvas_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_fm_canvas_widget.py
@@ -82,6 +82,19 @@ class CorrelationFMCanvasWidget(FMCanvasWidget):
         # something that does nothing.
         self._z_slider.setToolTip("Drag to change Z-slice, or Shift+scroll on the image")
 
+    def set_fm_image(self, image) -> None:
+        """Load a stack and start in the middle of it.
+
+        `FMCanvasWidget` starts at plane 0, which is fine for a viewer that opens
+        on the max projection. A picker opens on planes, and plane 0 is the edge
+        of the volume — usually out of focus, so every operator would scrub to
+        the middle before picking anything. `FMImageDisplayWidget` started at
+        ``n_z // 2`` for that reason, and the swap onto the shared canvas lost it.
+        """
+        super().set_fm_image(image)
+        if self._z_max > 0:
+            self._z_slider.setValue(self._z_max // 2 + self._z_max % 2)
+
     def _on_canvas_scrolled(self, x, y, direction: int, modifiers) -> None:
         """Shift+scroll → one z-plane. Plain scroll is left to the canvas (zoom).
 

--- a/tests/correlation/test_correlation_fm_canvas_widget.py
+++ b/tests/correlation/test_correlation_fm_canvas_widget.py
@@ -70,6 +70,31 @@ def test_max_projection_is_off_so_points_get_a_real_z():
     assert w._btn_mip.isChecked() is False  # button agrees with what is drawn
 
 
+@pytest.mark.parametrize("nz", [1, 2, 5, 9, 10])
+def test_a_loaded_stack_starts_in_the_middle(nz):
+    """FMCanvasWidget starts at plane 0, which suits a viewer that opens on the
+    max projection. A picker opens on planes, and plane 0 is the out-of-focus
+    edge of the volume, so every operator would scrub to the middle first.
+
+    FMImageDisplayWidget started at ``n_z // 2``; the swap onto the shared canvas
+    silently lost that, and this is the fix.
+    """
+    w = CorrelationFMCanvasWidget()
+    w.set_fm_image(_fm_image(nz=nz))
+    assert w.current_z == nz // 2
+
+
+def test_the_starting_plane_matches_the_widget_it_replaced():
+    """Belt and braces on the regression: the same stack through both, so the
+    number is compared rather than restated."""
+    old = FMImageDisplayWidget()
+    old.set_fm_image(_fm_image(nz=9))
+    new = CorrelationFMCanvasWidget()
+    new.set_fm_image(_fm_image(nz=9))
+
+    assert new.current_z == old.current_z == 4
+
+
 @pytest.mark.parametrize("z", [0, 4, 8])
 def test_current_z_matches_the_widget_it_replaces(z):
     """Same slider position, same answer — this is the number that becomes a


### PR DESCRIPTION
A regression from the canvas swap (#345), affecting anyone picking FM points right now. Split out of the deletion PR so it can land on its own.

## What happened

`FMImageDisplayWidget` put the z-slider at `n_z // 2` when a stack loaded. `FMCanvasWidget` starts at **0** — right for a viewer that opens on the max projection, where the plane index does not matter until you scrub.

The correlation display opens on *planes*, and plane 0 is the edge of the volume, usually out of focus. So since #345 merged, every operator has landed on the wrong plane and scrubbed to the middle before picking anything.

## The fix

```python
def set_fm_image(self, image) -> None:
    super().set_fm_image(image)
    if self._z_max > 0:
        self._z_slider.setValue(self._z_max // 2 + self._z_max % 2)
```

On `CorrelationFMCanvasWidget` rather than `FMCanvasWidget`, because it is the picker/viewer distinction that motivates it — the quad view and FM overview open on MIP and should keep their current behaviour.

## How it was found

Retiring `FMImageDisplayWidget`'s test suite in the deletion PR. Its z test was the only thing documenting this behaviour, and reading each old test before deleting it is what surfaced it — the suite would have stayed green either way.

## Testing

Two tests. Parametrised across stack sizes:

```
nz= 1  z=0     nz= 2  z=1     nz= 5  z=2     nz= 9  z=4     nz=10  z=5
```

…and one comparing both widgets on the same stack, which is only possible while the old one still exists — worth having now, and it goes with it.

`1485 passed, 8 skipped`.

Worth a quick look in a real session: load an FM stack and confirm it opens mid-volume rather than on plane 0.