### PR TITLE
[fibsem] Measure the revision string from release tags only

### DIFF
--- a/fibsem/versioning.py
+++ b/fibsem/versioning.py
@@ -126,9 +126,10 @@ def _describe() -> Optional[str]:
     #
     # --match v* because git describe measures from the *nearest* reachable tag,
     # whatever it happens to be named: a one-off build tag on a recent commit
-    # (this repo has 251111-rosalind, 20250616, data-0.1.0) would otherwise
-    # become the base for every user downstream of it, and land in the
-    # fibsem_revision recorded in saved experiment metadata. --tags is still
+    # (this repo carries dated and per-site build tags alongside releases, plus
+    # data-0.1.0) would otherwise become the base for every user downstream of
+    # it, and land in the fibsem_revision recorded in saved experiment metadata,
+    # where a wrong base goes unnoticed for months. --tags is still
     # required alongside it: release tags here are lightweight (see RELEASE.md),
     # and plain describe considers only annotated ones.
     #

--- a/fibsem/versioning.py
+++ b/fibsem/versioning.py
@@ -124,9 +124,17 @@ def _describe() -> Optional[str]:
     # Not --broken: that needs git >= 2.13, and on older git the whole command
     # fails, losing the revision entirely.
     #
+    # --match v* because git describe measures from the *nearest* reachable tag,
+    # whatever it happens to be named: a one-off build tag on a recent commit
+    # (this repo has 251111-rosalind, 20250616, data-0.1.0) would otherwise
+    # become the base for every user downstream of it, and land in the
+    # fibsem_revision recorded in saved experiment metadata. --tags is still
+    # required alongside it: release tags here are lightweight (see RELEASE.md),
+    # and plain describe considers only annotated ones.
+    #
     # Cached because FibsemImageMetadata builds a FibsemExperimentRef for every
     # acquired image — without this that would be one git fork per image.
-    return _run_git("describe", "--tags", "--always", "--dirty")
+    return _run_git("describe", "--tags", "--always", "--dirty", "--match", "v*")
 
 
 @cache
@@ -141,8 +149,10 @@ def get_revision() -> Optional[str]:
     """Return ``git describe`` of the running checkout, or None.
 
     For example ``"v0.5.1-48-g4cd11d9c"``, ``"v0.5.1-48-g4cd11d9c-dirty"``, or a
-    bare ``"4cd11d9c"`` in a clone with no tags. None for a wheel install, or on
-    any failure. Cached: the first call forks git, later calls are free.
+    bare ``"4cd11d9c"`` in a clone with no ``v*`` release tags. None for a wheel
+    install, or on any failure. Measured only from release tags, so an unrelated
+    tag nearer to HEAD cannot become the base. Cached: the first call forks git,
+    later calls are free.
     """
     return _describe()
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -303,15 +303,15 @@ def test_describe_measures_from_release_tags_only(monkeypatch, tmp_path):
     # Lightweight, as RELEASE.md creates them.
     _git(repo, "tag", "v1.0.0")
     _git(repo, "commit", "--allow-empty", "--quiet", "-m", "second")
-    # Annotated, as the real 251111-rosalind is: nearer to HEAD *and* the type
-    # plain `git describe` prefers, so it wins on both of git's selection rules.
-    _git(repo, "tag", "-a", "251111-rosalind", "-m", "build for a partner site")
+    # Annotated, as this repo's ad-hoc build tags are: nearer to HEAD *and* the
+    # type plain `git describe` prefers, so it wins on both of git's rules.
+    _git(repo, "tag", "-a", "251111-example", "-m", "build for a partner site")
     _git(repo, "commit", "--allow-empty", "--quiet", "-m", "third")
 
     # Control: assert the bug is actually reachable in this repo, so the test
     # below cannot pass simply because the decoy was never a candidate.
     unfiltered = _git(repo, "describe", "--tags", "--always", "--dirty")
-    assert unfiltered.startswith("251111-rosalind-"), unfiltered
+    assert unfiltered.startswith("251111-example-"), unfiltered
 
     monkeypatch.setattr(versioning, "_source_checkout_root", lambda: repo)
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -8,6 +8,7 @@ is therefore failure-mode coverage rather than happy-path coverage.
 
 import logging
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -56,6 +57,34 @@ def _completed(returncode=0, stdout="", stderr=""):
     return subprocess.CompletedProcess(
         args=["git"], returncode=returncode, stdout=stdout, stderr=stderr
     )
+
+
+def _git(repo, *args):
+    """Run git in `repo`, independently of the developer's own git config.
+
+    identity is passed with -c rather than assumed: CI has no global user.email,
+    and signing is forced off so the test does not prompt for a key (or fail) on
+    a machine that signs commits and tags by default.
+    """
+    return subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=test@example.invalid",
+            "-c",
+            "user.name=test",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "tag.gpgsign=false",
+            *args,
+        ],
+        cwd=str(repo),
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    ).stdout.strip()
 
 
 # --- happy path ------------------------------------------------------------
@@ -248,7 +277,68 @@ def test_describe_argv(monkeypatch):
     monkeypatch.setattr(versioning.subprocess, "run", _capture)
 
     assert get_revision() == "v0.5.1-48-g4cd11d9c"
-    assert seen["argv"] == ["git", "describe", "--tags", "--always", "--dirty"]
+    assert seen["argv"] == [
+        "git",
+        "describe",
+        "--tags",
+        "--always",
+        "--dirty",
+        "--match",
+        "v*",
+    ]
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is not installed")
+def test_describe_measures_from_release_tags_only(monkeypatch, tmp_path):
+    """A one-off build tag nearer to HEAD must not become the base tag.
+
+    git describe picks the *nearest* reachable tag regardless of what it means,
+    so tagging a build for a partner site would silently re-base the revision
+    string recorded in every downstream user's experiment metadata.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "commit", "--allow-empty", "--quiet", "-m", "first")
+    # Lightweight, as RELEASE.md creates them.
+    _git(repo, "tag", "v1.0.0")
+    _git(repo, "commit", "--allow-empty", "--quiet", "-m", "second")
+    # Annotated, as the real 251111-rosalind is: nearer to HEAD *and* the type
+    # plain `git describe` prefers, so it wins on both of git's selection rules.
+    _git(repo, "tag", "-a", "251111-rosalind", "-m", "build for a partner site")
+    _git(repo, "commit", "--allow-empty", "--quiet", "-m", "third")
+
+    # Control: assert the bug is actually reachable in this repo, so the test
+    # below cannot pass simply because the decoy was never a candidate.
+    unfiltered = _git(repo, "describe", "--tags", "--always", "--dirty")
+    assert unfiltered.startswith("251111-rosalind-"), unfiltered
+
+    monkeypatch.setattr(versioning, "_source_checkout_root", lambda: repo)
+
+    revision = get_revision()
+    assert revision.startswith("v1.0.0-"), revision
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is not installed")
+def test_describe_still_falls_back_to_bare_sha(monkeypatch, tmp_path):
+    """--match must not cost the --always fallback.
+
+    Filtering to `v*` means a checkout can now have tags and still have no
+    candidate. That must degrade to the bare sha, as it does for a tagless
+    clone, and not to None — the sha is the half of the revision that matters.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "commit", "--allow-empty", "--quiet", "-m", "first")
+    _git(repo, "tag", "-a", "20250616", "-m", "dated build, not a release")
+
+    monkeypatch.setattr(versioning, "_source_checkout_root", lambda: repo)
+
+    revision = get_revision()
+    assert revision is not None
+    assert not revision.startswith("20250616"), revision
+    assert re.fullmatch(r"[0-9a-f]{7,40}", revision), revision
 
 
 def test_environment_is_scrubbed(monkeypatch):


### PR DESCRIPTION
`git describe` measures from the *nearest* reachable tag, whatever it happens to be named — nothing about the tag's meaning enters the decision. This repo carries dated and per-site build tags alongside releases (plus `data-0.1.0`), so a tag cut on a recent commit becomes the base for every user downstream of it.

That matters because the result is recorded as `SystemInfo.fibsem_revision` in saved experiment metadata and in the bug report tool. A hijacked base tag is not wrong, exactly — the sha half is always correct — but it loses the "which release is this near" signal that makes the field skimmable, and it is inconsistent between users, since `describe` only sees tags present in that clone. A tag created locally and never pushed means two people on the same commit report different revisions.

The hazard is currently latent rather than active: `v0.5.1` happens to be nearer than `data-0.1.0`, so today's output is correct by luck of history rather than by rule.

## Change

`git describe --tags --always --dirty` → `... --match v*`.

`--tags` stays, and is load-bearing: release tags here are lightweight (RELEASE.md uses plain `git tag v0.5.0`), and plain `describe` considers only annotated tags. Dropping it would make every release invisible and fall through to a bare sha. Worth noting the current state is backwards — the ad-hoc build tags are annotated while the releases are not.

## Tests

- `test_describe_argv` — updated to pin the new flags.
- `test_describe_measures_from_release_tags_only` — builds a temp repo reproducing the exact situation: lightweight `v1.0.0` further back, annotated `251111-example` nearer, so the decoy wins on both of git's selection rules. Asserts a control first (the unfiltered command really does return `251111-example-…` there), so the test cannot pass because the decoy was never a candidate. Strip `--match` from the source and it fails.
- `test_describe_still_falls_back_to_bare_sha` — covers the regression `--match` introduces: a checkout can now have tags and no *eligible* tag, and must degrade to the bare sha rather than `None`.

25 passed in `tests/test_versioning.py`; 53 passed across the two `fibsem_revision` consumers (`tests/test_structures.py`, `tests/autolamella/test_experiment_session.py`).

## Not covered

Nothing stops a `v`-prefixed tag being created on a feature branch — this makes the convention structural, not enforced. A line in RELEASE.md reserving `v*` for published releases would close that, and is better written alongside the partner/early-access programme docs than here.