### PR TITLE
[release] Document the pre-release path and guard the publish version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,69 @@ on:
       - "v*.*.*"
 
 jobs:
+  # The version in pyproject.toml is written by hand and the tag is created
+  # separately, so the two can disagree. Nothing downstream notices: the build
+  # takes its version from pyproject, so a tag of v0.5.2rc1 on a commit that
+  # still says 0.5.2.dev0 uploads 0.5.2.dev0 to PyPI -- wrong version, no error,
+  # and unfixable afterwards because PyPI never allows a version to be reused.
+  # Runs alongside the tests rather than inside publish so the failure lands in
+  # seconds, while retagging is still cheap.
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install packaging
+      - name: Tag must match the packaged version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import sys
+          import tomllib
+
+          from packaging.version import InvalidVersion, Version
+
+          tag = os.environ["TAG"]
+
+          with open("pyproject.toml", "rb") as fh:
+              project = tomllib.load(fh)["project"]
+          if "version" not in project:
+              sys.exit(
+                  "::error::pyproject.toml declares no static [project] version. "
+                  "The versioning scheme changed; this check needs updating."
+              )
+          declared = project["version"]
+
+          try:
+              tagged = Version(tag.removeprefix("v"))
+          except InvalidVersion:
+              sys.exit(f"::error::tag {tag} is not a PEP 440 version")
+
+          # is_devrelease, not is_prerelease: packaging counts rcN as a
+          # pre-release too, and those are exactly what we do publish.
+          if tagged.is_devrelease:
+              sys.exit(
+                  f"::error::tag {tag} is a development version. .devN marks "
+                  f"the working state of main and is never published; it is "
+                  f"also the one form that matches pyproject.toml unchanged, so "
+                  f"the check below would not catch it. Tag an rcN for Early "
+                  f"Access, or a final release. See RELEASE.md."
+              )
+
+          if tagged != Version(declared):
+              sys.exit(
+                  f"::error::tag {tag} would publish {declared}. pyproject.toml "
+                  f'says version = "{declared}". Fix one or the other and retag: '
+                  f"a version cannot be reused once it is on PyPI."
+              )
+
+          print(f"tag {tag} matches pyproject.toml version {declared}")
+          PY
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -19,7 +82,7 @@ jobs:
         run: pytest tests/ -n auto --dist worksteal --timeout=300
 
   publish:
-    needs: test
+    needs: [check-version, test]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ jobs:
   # seconds, while retagging is still cheap.
   check-version:
     runs-on: ubuntu-latest
+    outputs:
+      # Consumed by github-release, so the pre-release decision is made once,
+      # by packaging, rather than re-derived from the tag string in shell.
+      prerelease: ${{ steps.check.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -22,6 +26,7 @@ jobs:
           python-version: "3.11"
       - run: pip install packaging
       - name: Tag must match the packaged version
+        id: check
         env:
           TAG: ${{ github.ref_name }}
         run: |
@@ -67,6 +72,11 @@ jobs:
               )
 
           print(f"tag {tag} matches pyproject.toml version {declared}")
+
+          # is_prerelease is the right test *here*, unlike above: dev releases
+          # are already rejected, so anything still prerelease is an rc/a/b.
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              fh.write(f"prerelease={str(tagged.is_prerelease).lower()}\n")
           PY
 
   test:
@@ -97,3 +107,36 @@ jobs:
       - run: pip install build
       - run: python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  # The Release page is how Early Access finds out a candidate exists, and its
+  # Atom feed (/releases.atom) is the only notification channel the programme
+  # has. Created by hand until now, which meant it could simply be forgotten.
+  #
+  # Separate job rather than a step in publish: this needs contents: write,
+  # and publish holds the id-token used for trusted publishing to PyPI. Runs
+  # after it, so a failed upload never announces a release nobody can install.
+  github-release:
+    needs: [check-version, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          PRERELEASE: ${{ needs.check-version.outputs.prerelease }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists, leaving it alone"
+            exit 0
+          fi
+
+          args=(--generate-notes --verify-tag)
+          # Keeps a candidate from taking the "Latest" badge from a real release.
+          if [ "$PRERELEASE" = "true" ]; then
+            args+=(--prerelease)
+          fi
+
+          gh release create "$TAG" "${args[@]}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,7 +38,7 @@ pip does not install a pre-release unless asked, so a published `rc` reaches onl
    git push && git push --tags
    ```
 
-4. **GitHub Actions takes over** — the tag and the packaged version are checked against each other, the tests must pass, and the package is uploaded to PyPI, where `rcN` is treated as a pre-release automatically.
+4. **GitHub Actions takes over** — the tag and the packaged version are checked against each other, the tests must pass, and the package is uploaded to PyPI, where `rcN` is treated as a pre-release automatically. A GitHub Release is then created from the tag with generated notes, marked as a pre-release so it does not take the "Latest" badge from the last real release.
 
 5. **Put the version back** to the development marker, so `main` does not sit on a version that has already been published:
    ```
@@ -53,6 +53,9 @@ pip does not install a pre-release unless asked, so a published `rc` reaches onl
    ```bash
    pip install fibsem==0.5.2rc1
    ```
+   Members who would rather not wait to be told can subscribe to
+   `https://github.com/fibsem-os/fibsem-os/releases.atom` in any feed reader —
+   it carries pre-releases and their notes, and needs no GitHub account.
 
 For a second candidate, repeat with `rc2`.
 
@@ -74,7 +77,7 @@ For a second candidate, repeat with `rc2`.
    git push && git push --tags
    ```
 
-4. **GitHub Actions takes over** — same checks, then the upload to PyPI.
+4. **GitHub Actions takes over** — same checks, then the upload to PyPI and the GitHub Release, which this time becomes "Latest".
 
 5. **Open the next development version** in `pyproject.toml`:
    ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,32 +1,99 @@
 # Release Process
 
-## Steps
+## Versions and tags
 
-1. **Bump the version** in `pyproject.toml`:
-   ```
-   version = "0.5.0"
-   ```
-   Remove the `.dev0` suffix for a stable release. Follow [semantic versioning](https://semver.org): `MAJOR.MINOR.PATCH`.
+The version in `pyproject.toml` is written by hand and the git tag is created separately, so the two can disagree. They must not: the build takes its version from `pyproject.toml` rather than from the tag, so a mismatch uploads the wrong version silently. The publish workflow checks them against each other before building.
 
-2. **Update the changelog** in `CHANGES.md` with release notes for this version.
+| Version | Example | Tag | Published | Installed by |
+|---------|---------|-----|-----------|--------------|
+| Development | `0.5.2.dev0` | none | no | nobody — an in-repo marker for "between releases" |
+| Release candidate | `0.5.2rc1` | `v0.5.2rc1` | yes, as a pre-release | Early Access, by exact pin |
+| Release | `0.5.2` | `v0.5.2` | yes | everyone |
+
+Release candidates use `rcN`, numbered from 1 — not `aN` or `bN`. `rc` means "this ships unless someone finds a problem", which is the contract with Early Access testers; `a` would say "expect churn". Two older pre-releases used `a0` (`v0.5.0a0`, `v0.5.1a0`); they stay as they are, and PEP 440 still orders them correctly ahead of the releases that followed.
+
+`.devN` is never tagged and never published. It marks the working state of `main` between releases, and it is not worth incrementing: `fibsem_revision` (see `fibsem/versioning.py`) already identifies the exact commit, which is far finer than a hand-bumped dev number.
+
+**The `v*` prefix is reserved for published releases.** Give build tags — a snapshot for a site, a partner, or a demo — any other prefix, such as a date. Two things key off `v*`, and neither is restricted to `main`:
+
+- **Publishing.** A tag matching `v*.*.*` triggers the publish workflow from *any* branch, or from a commit on no branch at all: tag pushes are not branch-scoped, and no filter can make them so. The version check blocks the accidents, but not creating the tag is cheaper than recovering from one.
+- **Revision reporting.** `get_revision()` measures from the nearest `v*` tag, so a stray one becomes the base of `fibsem_revision` for everyone downstream of it once the branch merges — replacing `v0.5.1-185-g…` with `v0.6.0test-12-g…` in saved experiment metadata.
+
+pip does not install a pre-release unless asked, so a published `rc` reaches only people who pin it exactly. That is the entire distribution mechanism for Early Access — no access control is involved.
+
+## Cutting a release candidate
+
+1. **Update the changelog** in `CHANGES.md` for the version being prepared. Do this *before* the candidate, not at final release: testers cannot know what to exercise otherwise.
+
+2. **Bump the version** in `pyproject.toml`:
+   ```
+   version = "0.5.2rc1"
+   ```
 
 3. **Commit, tag, and push**:
    ```bash
    git add pyproject.toml CHANGES.md
-   git commit -m "release v0.5.0"
-   git tag v0.5.0
+   git commit -m "release candidate v0.5.2rc1"
+   git tag v0.5.2rc1
    git push && git push --tags
    ```
 
-4. **GitHub Actions takes over** — the publish workflow runs automatically:
-   - Tests must pass before publishing
-   - Package is built and uploaded to PyPI
+4. **GitHub Actions takes over** — the tag and the packaged version are checked against each other, the tests must pass, and the package is uploaded to PyPI, where `rcN` is treated as a pre-release automatically.
 
-5. **After release**, bump the version to the next dev version in `pyproject.toml`:
+5. **Put the version back** to the development marker, so `main` does not sit on a version that has already been published:
    ```
-   version = "0.5.1.dev0"
+   version = "0.5.2.dev0"
    ```
-   Commit with `git commit -m "bump version to 0.5.1.dev0"`.
+   ```bash
+   git add pyproject.toml
+   git commit -m "bump version to 0.5.2.dev0"
+   ```
+
+6. **Tell Early Access**, with an exact pin rather than `--pre`, which would loosen resolution for every dependency in the command and not just this one:
+   ```bash
+   pip install fibsem==0.5.2rc1
+   ```
+
+For a second candidate, repeat with `rc2`.
+
+## Cutting a release
+
+1. **Finalise the changelog** in `CHANGES.md`.
+
+2. **Bump the version** in `pyproject.toml`, dropping the suffix:
+   ```
+   version = "0.5.2"
+   ```
+   Follow [semantic versioning](https://semver.org): `MAJOR.MINOR.PATCH`.
+
+3. **Commit, tag, and push**:
+   ```bash
+   git add pyproject.toml CHANGES.md
+   git commit -m "release v0.5.2"
+   git tag v0.5.2
+   git push && git push --tags
+   ```
+
+4. **GitHub Actions takes over** — same checks, then the upload to PyPI.
+
+5. **Open the next development version** in `pyproject.toml`:
+   ```
+   version = "0.5.3.dev0"
+   ```
+   ```bash
+   git add pyproject.toml
+   git commit -m "bump version to 0.5.3.dev0"
+   ```
+
+## The sequence, end to end
+
+```
+0.5.2.dev0  →  0.5.2rc1  →  0.5.2.dev0  →  0.5.2  →  0.5.3.dev0
+   main         tagged         main         tagged       main
+                published                  published
+```
+
+Each step is a commit. The two returns to `.dev0` exist because the version is static — `main` should never claim to be a version that has already been uploaded.
 
 ## Versioning
 
@@ -38,4 +105,13 @@ Releases follow `MAJOR.MINOR.PATCH`:
 | `MINOR` | New features, backwards compatible |
 | `MAJOR` | Breaking API changes |
 
-Development versions use the `.dev0` suffix (e.g. `0.5.1.dev0`) between releases.
+## If the publish fails
+
+The version check runs alongside the tests and finishes in seconds. If it fails, the tag and `pyproject.toml` disagree and **nothing has been uploaded**. Delete the tag, fix whichever side is wrong, and tag again:
+
+```bash
+git tag -d v0.5.2rc1
+git push --delete origin v0.5.2rc1
+```
+
+A version that has actually reached PyPI cannot be replaced or reused, even after yanking it. That is what the check exists to prevent.


### PR DESCRIPTION
Groundwork for the Early Access programme, which depends on cutting release candidates — a path that existed in practice (two alphas cut) and nowhere in writing.

Covers items 1, 2, 5 and 7 of the release-side list in the Linear **User Programs** doc.

## The bug being closed

The version in `pyproject.toml` is hand-written and the tag is created separately, so they can disagree — and nothing downstream notices, because the build takes its version from `pyproject.toml`, not from the tag. Tagging `v0.5.2rc1` on a commit that still says `0.5.2.dev0` uploads **`0.5.2.dev0`** to PyPI: wrong version, no error, and unfixable afterwards, because PyPI never allows a version to be reused.

A new `check-version` job compares the two using `packaging.Version`, so PEP 440 normalisation is handled (`0.5.2.rc1` and `0.5.2rc1` are the same version; `v0.5.10` and `0.5.1` are not). It runs alongside the tests rather than as a step inside `publish`, so the failure lands in seconds — the fix is retagging, and you want to know before walking away.

It also **rejects `.devN` tags outright**. That case is not redundant: `.devN` is the one form that matches `pyproject.toml` *unchanged*, since `.devN` is what `main` carries, so the comparison alone would pass it and publish a development build. The test is `is_devrelease`, not `is_prerelease` — `packaging` classifies `rcN` as a pre-release too, and those are exactly what we do ship.

| tag | fires publish | version check | result |
|---|---|---|---|
| `v0.5.2rc1` (matching commit) | yes | pass | publishes |
| `v0.5.2` (matching commit) | yes | pass | publishes |
| `v0.5.2.dev0` | yes | fail | blocked |
| `v0.6.0test` | yes | fail | blocked |
| `v0.5.2rc1` (wrong commit) | yes | fail | blocked |
| `251111-example` | no | — | never reaches CI |

Verified by extracting the script from the workflow itself and running it against 13 cases, rather than by inspection: correct and incorrect RCs and releases, a respun RC, PEP 440 normalisation both ways, an unparseable tag, both dev-tag forms, and a `pyproject.toml` with `dynamic = ["version"]` (which refuses to publish rather than silently skipping the check).

## RELEASE.md

Rewritten around two paths instead of one:

- **Version vocabulary** — what `.devN`, `rcN` and a final release each mean, which are tagged, which are published, and who installs them.
- **Cutting a release candidate** and **cutting a release** as separate step lists.
- **The full sequence** — `0.5.2.dev0 → 0.5.2rc1 → 0.5.2.dev0 → 0.5.2 → 0.5.3.dev0` — including why the two returns to `.devN` exist (the version is static, so `main` must never claim a version already uploaded).
- **Recovery** from a failed version check, including that a version on PyPI can never be replaced or reused.

Decisions written down as part of this:

- **`rcN`, not `aN`.** `rc` means "this ships unless someone finds a problem", which is the contract with Early Access testers; `a` says "expect churn". The two published `a0` tags stay as they are, and PEP 440 still orders them correctly ahead of the releases that followed.
- **`.devN` is never published.** Neither tier consumes one: partners test unmerged branches from an editable clone, Early Access tests the `rc`. A site that cannot build from source gets a CI wheel from the branch, not a permanent PyPI version.
- **`v*` is reserved for published releases.** A `v*.*.*` tag fires this workflow from *any* branch — tag pushes are not branch-scoped — and `get_revision()` measures from the nearest `v*` tag, so a stray one both triggers a build and rebases the revision string recorded in saved experiment metadata. Build tags for a site or demo take another prefix.
- **The changelog moves earlier**, to before the RC. Testers cannot know what to exercise if it lands after the build they are testing.

## Item 6 — the GitHub Release, now automated

Releases already existed and already behaved correctly (`v0.5.1a0` is published as a Pre-release with generated notes), but they were created by hand after each tag — so they could be forgotten, and a forgotten Release means an RC that ships silently.

A `github-release` job now creates it with `--generate-notes`, adding `--prerelease` when the version carries a suffix so a candidate never takes the "Latest" badge. It exits cleanly if a Release for the tag already exists, so re-running the workflow is safe.

It is a separate job rather than a step in `publish` because it needs `contents: write` while `publish` holds the `id-token` for trusted publishing — neither should carry a permission it does not use. It runs after `publish`, so a failed upload never announces a release nobody can install.

The pre-release flag comes from `check-version` as a job output rather than being re-derived in shell. `is_prerelease` is the correct test there, unlike the dev-release rejection above it, precisely because `.devN` tags are already refused by that point.

This matters for the programme because the Release page carries an Atom feed at `/releases.atom` — it includes pre-releases and their full notes, needs no GitHub account, and is therefore the whole notification channel for Early Access with no mailing list to run. The feed reflects Releases, not tags or PyPI, so it only works if the Release actually gets created.

## Not covered

Nothing outstanding from the release-side list. Items 3 and 4 are decisions rather than code: `rcN` is documented here and takes effect at the next pre-release, and “never publish `.devN`” is now enforced by the guard rather than by memory.