### PR TITLE
[ui] Unblock the objective-start combo after loading overview parameters

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -487,7 +487,8 @@ class FMOverviewSettingsWidget(QWidget):
         finally:
             for widget in (self.spin_rows, self.spin_cols, self.spin_overlap,
                            self.combo_tile_order, self.check_zstack,
-                           self.combo_autofocus_mode, self.tile_mask):
+                           self.combo_autofocus_mode, self.combo_objective_start,
+                           self.tile_mask):
                 widget.blockSignals(False)
         # Both, because the setter blocked the signals that normally trigger them --
         # otherwise loading a z-stacked configuration leaves the z-parameters greyed

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -4478,3 +4478,26 @@ def test_an_objective_that_cannot_be_asked_does_not_block_the_run(
     monkeypatch.setattr(type(widget.fm.objective), "state", property(unreadable))
 
     assert widget._objective_state() is None
+
+
+def test_loading_parameters_leaves_the_objective_start_combo_able_to_notify(qapp):
+    """The `parameters` setter blocks every widget it writes and unblocks them from a
+    second list. Left out of that list, the combo stays blocked for the rest of the
+    widget's life -- so changing "Start from" would silently stop redrawing the grid,
+    the summary and everything else downstream of `changed`.
+
+    Latent until something loads a saved configuration, which is why it needs a test
+    rather than a bug report: today only tests call the setter.
+    """
+    from fibsem.fm.structures import OverviewParameters
+    from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
+
+    widget = FMOverviewSettingsWidget()
+    widget.parameters = OverviewParameters(rows=2, cols=2)
+
+    seen = []
+    widget.changed.connect(lambda: seen.append(1))
+    combo = widget.combo_objective_start
+    combo.setCurrentIndex(1 - combo.currentIndex())
+
+    assert seen, "the objective-start combo was left signal-blocked by the setter"


### PR DESCRIPTION
`FMOverviewSettingsWidget.parameters` blocks every widget it is about to write, then unblocks them from a second list. `combo_objective_start` was added to the first list and not the second, so once parameters have been loaded the combo stays signal-blocked for the rest of the widget's life — changing "Start from" would silently stop redrawing the grid, the summary, and everything else downstream of `changed`.

```python
for widget in (..., self.combo_autofocus_mode, self.combo_objective_start,
               self.tile_mask):
    widget.blockSignals(True)
...
finally:
    for widget in (..., self.combo_autofocus_mode,   # <- missing here
                   self.tile_mask):
        widget.blockSignals(False)
```

Latent today, which is why it has gone unnoticed: nothing in the app calls the setter, only tests. It bites the moment anything loads a saved configuration into the panel.

The test asserts the combo can still notify after a load, and fails without the one-line fix — verified both ways rather than assumed, since the mutation that matters here is invisible to every other test in the file.