### PR TITLE
[fm] Model the imaging channel the FM and the beams share in the simulator (FIB-518)

### DIFF
--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -763,6 +763,20 @@ class FluorescenceMicroscope(ABC):
         self._acquiring_reason = reason if acquiring else ""
         self.acquiring_changed.emit(self.is_acquiring)
 
+    def set_active_channel(self) -> None:
+        """Point the microscope's imaging channel at the FM, and leave it there.
+
+        A no-op here, for the same reason `active_channel` is. Part of the contract
+        rather than a driver detail so that code which needs the unscoped form -- taking
+        the channel for a live stream that owns it until it stops -- can call it on any
+        FM without asking what it is talking to.
+
+        Prefer :meth:`active_channel`. This is the form that caused FIB-517: a read that
+        takes the channel and walks away leaves the microscope pointed at the FM, and
+        the next beam operation to read a buffer reads the FM's.
+        """
+        return
+
     @contextmanager
     def active_channel(self):
         """Hold the microscope's imaging channel on the FM for the length of the block.

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -5,8 +5,10 @@ import glob
 import logging
 import os
 import random
+import threading
 import time
 from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from itertools import cycle
 from typing import Dict, List, Optional, Tuple, Union
@@ -166,6 +168,95 @@ class ImagingSystem:
     last_image: Dict[BeamType, Optional[FibsemImage]] = field(default_factory=dict)
     image_iterators: Dict[BeamType, Iterator[str]] = field(default_factory=dict)  # Image filename iterators
 
+
+# The FM's place on the shared imaging channel. The view number is the driver's
+# (`ThermoFisherFluorescenceMicroscope._active_view = 3`, quadrant 3 on an Arctis); all
+# that matters here is that it is neither beam's, so a beam operation can tell that the
+# FM took the channel out from under it.
+FM_ACTIVE_VIEW = 3
+FM_ACTIVE_DEVICE = 3
+
+
+class SimulatedFluorescenceMicroscope(FluorescenceMicroscope):
+    """The FM half of the one imaging channel a TFS system shares (FIB-518).
+
+    `DemoMicroscope` simulates a TFS system, where the FM and the beams are one
+    connection with one active view and one active device: whoever writes last owns the
+    microscope. The base class's `active_channel()` is a no-op -- right for a system
+    whose FM has a connection of its own, and the reason the simulator could show none
+    of FIB-517/542/544/545. Every one of those was found on hardware instead, one of
+    them by a workflow task stopping.
+
+    So this participates in `parent.imaging_system` the way
+    `ThermoFisherFluorescenceMicroscope` participates in the shared connection: same
+    depth count, same lock, same restore. Deliberately a mirror rather than an
+    approximation, so a test written against the simulator says something about the
+    hardware.
+    """
+
+    def __init__(self, parent: Optional["FibsemMicroscope"] = None):
+        super().__init__(parent=parent)
+        self._active_view = FM_ACTIVE_VIEW
+        self._active_device = FM_ACTIVE_DEVICE
+        # The parent's lock, as the driver takes it: an FM scope and a beam acquisition
+        # then queue against each other rather than interleaving, which is what makes
+        # the scoped and unscoped paths behave differently here as they do on hardware.
+        self._channel_lock = (
+            getattr(parent, "_threading_lock", None) or threading.RLock()
+        )
+        self._channel_depth = 0
+        self._restore_view: Optional[int] = None
+        self._restore_device: Optional[int] = None
+
+    def set_active_channel(self) -> None:
+        """Point the shared channel at the FM and leave it there.
+
+        The unscoped form, and the shape of the bug: a property getter that calls this
+        and walks away leaves the microscope on the FM, and the next beam operation to
+        read a buffer reads the FM's. Mirrors
+        `ThermoFisherFluorescenceMicroscope.set_active_channel`.
+        """
+        if self.parent is None:
+            return
+        self.parent.imaging_system.active_view = self._active_view
+        self.parent.imaging_system.active_device = self._active_device
+
+    @contextmanager
+    def active_channel(self):
+        """Hold the channel on the FM for the length of the block, then put it back.
+
+        Depth counted, so a tileset that holds it for a whole run is not undone by each
+        tile's acquisition restoring between frames; the lock covers the bookkeeping and
+        never the body, since the body can be that whole run. Both rules are the
+        driver's -- see `ThermoFisherFluorescenceMicroscope.active_channel` for why.
+
+        Restores the device alongside the view, where the driver restores the view
+        alone. Not a divergence: on hardware `set_active_device` changes the device *in
+        the active view*, so the view owns it and it comes back with it. Here the two
+        are independent fields, and putting only the view back would leave
+        `active_device` reporting the FM for the rest of the session.
+        """
+        if self.parent is None:
+            yield
+            return
+
+        imaging = self.parent.imaging_system
+        with self._channel_lock:
+            if self._channel_depth == 0:
+                self._restore_view = imaging.active_view
+                self._restore_device = imaging.active_device
+            self.set_active_channel()
+            self._channel_depth += 1
+        try:
+            yield
+        finally:
+            with self._channel_lock:
+                self._channel_depth -= 1
+                if self._channel_depth == 0:
+                    imaging.active_view = self._restore_view
+                    imaging.active_device = self._restore_device
+
+
 class DemoMicroscope(FibsemMicroscope):
     """Simulator microscope client based on TFS microscopes"""
 
@@ -253,7 +344,11 @@ class DemoMicroscope(FibsemMicroscope):
             
         # fluorescence microscope
         if self.stage_is_compustage:
-            self.fm = FluorescenceMicroscope(self)
+            self.fm = SimulatedFluorescenceMicroscope(self)
+            # Bringing the FM up leaves the shared channel on it, as
+            # `ThermoMicroscope.__init__` does; taking it back is the next beam
+            # operation's job.
+            self.fm.set_active_channel()
         else:
             logging.warning("Fluorescence microscope module is currently only implemented for compustage systems. FM will not be available.")
             self.fm = None
@@ -312,6 +407,33 @@ class DemoMicroscope(FibsemMicroscope):
         self.imaging_system.active_view = beam_type.value
         self.imaging_system.active_device = beam_type.value
 
+    def _warn_if_channel_moved(self, expected: BeamType, operation: str) -> bool:
+        """Report a beam operation whose imaging channel was taken out from under it.
+
+        Warns rather than raises. What this models is a *silent* hardware failure -- the
+        grab returns whoever owns the view now, and the metadata is built from the
+        settings that were asked for rather than from what came back -- so the value
+        here is making it visible in a log and catchable in a test, not changing what
+        the simulator returns. Raising would also take down the very callers this exists
+        to help debug, and it would turn a diagnostic into a new failure mode that
+        hardware does not have.
+
+        Returns True when the channel was still the operation's own.
+        """
+        view = self.imaging_system.active_view
+        if view == expected.value:
+            return True
+        logging.warning(
+            "Imaging channel changed during %s: set to %s (view %d), found view %d. "
+            "The FM and the beams share one channel on a TFS system, so the grab here "
+            "would return the other view's buffer (FIB-517).",
+            operation,
+            expected.name,
+            expected.value,
+            view,
+        )
+        return False
+
     def acquire_image(self, image_settings: Optional[ImageSettings] = None, beam_type: Optional[BeamType] = None) -> FibsemImage:
         """
         Acquire a new image with the specified settings or current settings for the given beam type.
@@ -358,13 +480,25 @@ class DemoMicroscope(FibsemMicroscope):
         # get state for image metadata
         microscope_state = self.get_microscope_state(beam_type=effective_beam_type)
 
+        # One lock over the channel and the frame, as `ThermoMicroscope.acquire_image`
+        # holds it over `set_channel` + `grab_frame` (FIB-542): the grab reads the
+        # active view's buffer, so a channel that is not still ours when the frame lands
+        # returns whoever took it in between. Deliberately just that pair --
+        # `_threading_lock` is a class attribute every caller in the process shares.
+        with self._threading_lock:
+            self.set_channel(effective_beam_type)
+            # The frame. On hardware this is the one `grab_frame` RPC; here the sleep is
+            # the only part of it with any duration, so it is the window an unguarded FM
+            # read would land in.
+            sim_sleep(effective_image_settings.dwell_time * effective_image_settings.resolution[0] * effective_image_settings.resolution[1])  # simulate acquisition time
+            self._warn_if_channel_moved(effective_beam_type, "acquire_image")
+
         # construct image (random noise)
         image = FibsemImage.generate_blank_image(
             resolution=effective_image_settings.resolution,
             hfw=effective_image_settings.hfw,
             random=True
         )
-        sim_sleep(effective_image_settings.dwell_time * effective_image_settings.resolution[0] * effective_image_settings.resolution[1])  # simulate acquisition time
 
         # generate the next image from the sequence iterator
         if self.use_image_sequence:

--- a/tests/fm/test_fm_contract.py
+++ b/tests/fm/test_fm_contract.py
@@ -66,6 +66,21 @@ class TestPerInstanceAcquisitionState:
         assert fm_b._acquisition_thread is None
 
 
+class TestTheImagingChannelIsPartOfTheContract:
+    """Both forms exist on every FM, so callers need not ask what they are talking to.
+
+    A no-op on a system whose FM has a connection of its own, and overridden by the two
+    that share one with the beams: `ThermoFisherFluorescenceMicroscope` and, so the
+    sharing can be tested without hardware, `SimulatedFluorescenceMicroscope` (FIB-518).
+    """
+
+    def test_both_forms_exist_and_are_harmless(self, fm):
+        fm.set_active_channel()
+
+        with fm.active_channel():
+            pass
+
+
 class TestConstructImageFrameMetadata:
     """Optional per-frame metadata overrides the state snapshot (F20)."""
 

--- a/tests/fm/test_simulated_shared_channel.py
+++ b/tests/fm/test_simulated_shared_channel.py
@@ -1,0 +1,220 @@
+"""The simulator models the imaging channel the FM and the beams share (FIB-518).
+
+On a TFS system the FM and the beams are one connection with one active view and one
+active device -- whoever writes last owns the microscope. Every bug in that class
+(FIB-517, FIB-542, FIB-544, FIB-545) had to be found on hardware, because the simulator
+modelled the beam half only: `imaging_system.active_view` existed, but the simulated FM
+never contended for it, so no test could show a beam operation losing the channel. One
+of those bugs stopped a running workflow task.
+
+The behavioural counterpart to the two tests that had to settle for less:
+`tests/fm/test_active_channel.py` pins the driver's contract against a hand copy, and
+`tests/test_imaging_channel_lock.py` pins the beam side by reading its source -- both
+because `fibsem/microscope.py`'s TFS half needs an SDK that is not installed off the
+microscope. Here the contract can be run instead of inspected.
+"""
+
+import logging
+import threading
+
+import pytest
+
+from fibsem.microscopes.simulator import FM_ACTIVE_DEVICE, FM_ACTIVE_VIEW
+from fibsem.structures import BeamType, ImageSettings
+
+STOLEN = "Imaging channel changed"
+
+
+@pytest.fixture
+def microscope():
+    from fibsem import utils
+
+    scope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    assert scope.fm is not None, "the simulated compustage system should have an FM"
+    return scope
+
+
+@pytest.fixture
+def settings():
+    return ImageSettings(
+        hfw=80e-6,
+        resolution=(256, 256),
+        beam_type=BeamType.ION,
+        dwell_time=1e-6,
+    )
+
+
+def frame_seconds(settings: ImageSettings) -> float:
+    """How long the simulator spends on the frame itself.
+
+    The simulator sleeps twice per acquisition -- once reading the microscope state for
+    the metadata, once for the frame -- and only the second is inside the channel lock.
+    Tests that want to act *during the frame* discriminate on this.
+    """
+    return settings.dwell_time * settings.resolution[0] * settings.resolution[1]
+
+
+class TestTheFMTakesTheChannel:
+    """The half the simulator was missing entirely."""
+
+    def test_bringing_the_fm_up_leaves_the_channel_on_it(self, microscope):
+        """As `ThermoMicroscope.__init__` does. Taking it back is the next beam
+        operation's job, and the fact that this is the starting state is half of why
+        that matters."""
+        assert microscope.imaging_system.active_view == FM_ACTIVE_VIEW
+
+    def test_a_bare_set_leaves_it_on_the_fm(self, microscope):
+        """The shape of the bug: this is what a property getter does. `objective.state`
+        called it on every stage poll, and the poll runs constantly."""
+        microscope.set_channel(BeamType.ELECTRON)
+
+        microscope.fm.set_active_channel()
+
+        assert microscope.imaging_system.active_view == FM_ACTIVE_VIEW
+        assert microscope.imaging_system.active_device == FM_ACTIVE_DEVICE
+
+    def test_the_scope_hands_it_back(self, microscope):
+        microscope.set_channel(BeamType.ELECTRON)
+
+        with microscope.fm.active_channel():
+            assert microscope.imaging_system.active_view == FM_ACTIVE_VIEW
+
+        assert microscope.imaging_system.active_view == BeamType.ELECTRON.value
+
+    def test_it_restores_whatever_was_there(self, microscope):
+        """Not a hardcoded beam view: it puts back what it found."""
+        for beam_type in (BeamType.ELECTRON, BeamType.ION):
+            microscope.set_channel(beam_type)
+
+            with microscope.fm.active_channel():
+                pass
+
+            assert microscope.imaging_system.active_view == beam_type.value
+
+    def test_the_device_comes_back_with_the_view(self, microscope):
+        """A view left correct with the device still on the FM would be a half-restore
+        that reads as clean."""
+        microscope.set_channel(BeamType.ION)
+
+        with microscope.fm.active_channel():
+            pass
+
+        assert microscope.imaging_system.active_device == BeamType.ION.value
+
+    def test_it_hands_it_back_when_the_body_fails(self, microscope):
+        """An FM that is off, or answering slowly, must not strand the beam side."""
+        microscope.set_channel(BeamType.ION)
+
+        with pytest.raises(RuntimeError):
+            with microscope.fm.active_channel():
+                raise RuntimeError("detector did not answer")
+
+        assert microscope.imaging_system.active_view == BeamType.ION.value
+
+    def test_only_the_outermost_scope_restores(self, microscope):
+        """A tileset holds the channel for the whole run and each tile opens a scope
+        inside it. An inner scope that restored would put the beam view back between
+        every pair of tiles."""
+        microscope.set_channel(BeamType.ION)
+
+        with microscope.fm.active_channel():
+            with microscope.fm.active_channel():
+                assert microscope.imaging_system.active_view == FM_ACTIVE_VIEW
+            assert microscope.imaging_system.active_view == FM_ACTIVE_VIEW, (
+                "the inner scope restored"
+            )
+
+        assert microscope.imaging_system.active_view == BeamType.ION.value
+
+    def test_acquiring_an_fm_image_hands_the_channel_back(self, microscope):
+        """The path everything above the driver actually takes:
+        `FluorescenceMicroscope.acquire_image` is the chokepoint every FM image passes
+        through, and it is scoped."""
+        microscope.set_channel(BeamType.ELECTRON)
+
+        microscope.fm.acquire_image()
+
+        assert microscope.imaging_system.active_view == BeamType.ELECTRON.value
+
+
+class TestTheBeamNoticesATheft:
+    """The other half: a beam operation can now tell that it lost the channel."""
+
+    def test_a_beam_acquisition_takes_the_channel(self, microscope, settings):
+        microscope.fm.set_active_channel()
+
+        microscope.acquire_image(image_settings=settings)
+
+        assert microscope.imaging_system.active_view == settings.beam_type.value
+
+    def test_a_clean_acquisition_says_nothing(self, microscope, settings, caplog):
+        with caplog.at_level(logging.WARNING):
+            microscope.acquire_image(image_settings=settings)
+
+        assert STOLEN not in caplog.text
+
+    def test_an_unguarded_fm_read_during_the_frame_is_reported(
+        self, microscope, settings, monkeypatch, caplog
+    ):
+        """The failure FIB-517 was, reproduced without hardware.
+
+        The FM read is unscoped -- `set_active_channel` and walk away -- which is what
+        every property getter did before FIB-517, and what the getters FIB-544 covers
+        still do. It lands mid-frame, where on hardware `grab_frame` would then read the
+        FM's buffer and hand it back labelled as an ion image.
+        """
+        during_the_frame = frame_seconds(settings)
+
+        def steal(seconds: float) -> None:
+            if seconds == during_the_frame:
+                microscope.fm.set_active_channel()
+
+        monkeypatch.setattr("fibsem.microscopes.simulator.sim_sleep", steal)
+
+        with caplog.at_level(logging.WARNING):
+            microscope.acquire_image(image_settings=settings)
+
+        assert STOLEN in caplog.text
+        assert "found view 3" in caplog.text
+
+    def test_the_scoped_form_cannot_steal_during_the_frame(
+        self, microscope, settings, monkeypatch, caplog
+    ):
+        """Why the scoped form is the fix and not just good manners.
+
+        `active_channel()` takes the same lock the acquisition holds over its channel
+        and its frame, so an FM operation on another thread -- the live stream, an
+        overview run -- queues behind the frame instead of landing inside it. The thief
+        here is a real second thread, and the test asserts it was genuinely blocked
+        during the frame *and* that it eventually got in, so a thief that never ran
+        cannot pass this by doing nothing.
+        """
+        during_the_frame = frame_seconds(settings)
+        at_the_door = threading.Event()
+        got_in = threading.Event()
+        blocked_during_the_frame = []
+
+        def steal() -> None:
+            at_the_door.wait(timeout=5)
+            with microscope.fm.active_channel():
+                got_in.set()
+
+        thief = threading.Thread(target=steal, daemon=True)
+        thief.start()
+
+        def frame(seconds: float) -> None:
+            if seconds != during_the_frame:
+                return
+            at_the_door.set()
+            # Long enough that a thief who could get in, would have.
+            blocked_during_the_frame.append(not got_in.wait(timeout=0.5))
+
+        monkeypatch.setattr("fibsem.microscopes.simulator.sim_sleep", frame)
+
+        with caplog.at_level(logging.WARNING):
+            microscope.acquire_image(image_settings=settings)
+
+        thief.join(timeout=5)
+        assert got_in.is_set(), "the thief never ran -- the test proved nothing"
+        assert blocked_during_the_frame == [True], "the scoped form got in mid-frame"
+        assert STOLEN not in caplog.text

--- a/tests/test_imaging_channel_lock.py
+++ b/tests/test_imaging_channel_lock.py
@@ -12,11 +12,13 @@ half, so a getter now hands the channel back, but anything that holds the channe
 length of its own operation -- a deliberate FM acquisition, a live stream -- can still
 land inside this window.
 
-Structural, over the real source. `ThermoMicroscope` cannot be constructed without the
-AutoScript SDK, which is absent off the microscope, and the simulator never reads
-`active_view`/`active_device` at all (FIB-518), so there is no harness here that could
-observe the race. What is pinned is the discipline: the pair is locked, it is locked
-together, and the locked region stays narrow.
+Structural, over the real source: `ThermoMicroscope` cannot be constructed without the
+AutoScript SDK, which is absent off the microscope. What is pinned is the discipline --
+the pair is locked, it is locked together, and the locked region stays narrow.
+
+The race itself is now observable on the simulator, which models the shared channel on
+both sides since FIB-518; `tests/fm/test_simulated_shared_channel.py` runs it. That does
+not replace this file, which is about the class that cannot be built here.
 """
 import ast
 from pathlib import Path


### PR DESCRIPTION
On a TFS system the FM and the beams are **one connection with one active view and one active device** — whoever writes last owns the microscope. Every bug in that class (FIB-517, FIB-542, and the still-open FIB-544/545) had to be found on hardware, one of them by a running workflow task stopping, because the simulator could not express contention.

Neither side was modelled, as it turns out. The simulated FM had no `set_active_channel` concept at all — and `DemoMicroscope.acquire_image` never called `set_channel` either, so there was nothing to steal and nothing to steal it from.

## What changed

**`SimulatedFluorescenceMicroscope`** now participates in `parent.imaging_system` the way `ThermoFisherFluorescenceMicroscope` participates in the shared connection: same depth count, same lock, same restore. Deliberately a mirror rather than an approximation, so a test written against the simulator says something about the hardware.

One documented divergence: it restores the *device* alongside the view, where the driver restores the view alone. Not a disagreement — on hardware `set_active_device` changes the device *in the active view*, so the view owns it and brings it back; here the two are independent fields, and putting only the view back would leave `active_device` reporting the FM for the rest of the session.

**`DemoMicroscope.acquire_image`** takes one lock over `set_channel` and the frame, as `ThermoMicroscope.acquire_image` holds it over `set_channel` + `grab_frame`, and warns if the channel is no longer its own when the frame lands.

**Warning rather than raising.** What this models is a *silent* hardware failure: the grab returns whoever owns the view now, and the metadata is built from the settings that were asked for rather than from what came back. The value is in making that visible in a log and catchable in a test — not in inventing a failure mode the microscope does not have, or in taking down the very callers this exists to help debug.

**`set_active_channel` joins `active_channel` as a documented no-op on the FM base.** It was the only half of the pair missing from the contract, which left the simulated FM's method overriding nothing, and would break any generic caller against a driver that had not implemented it.

## The payoff

Two tests in `tests/fm/test_simulated_shared_channel.py` reproduce FIB-517 without hardware:

- an **unguarded** FM read (`set_active_channel` and walk away — what every property getter did before FIB-517, and what FIB-544's getters still do) landing mid-frame is reported;
- a **scoped** read from a real second thread is measurably blocked for the whole frame and let in afterwards. It asserts the thief both *was* blocked and *did* eventually run, so a thief that never started cannot pass it by doing nothing.

That is also the first behavioural coverage of the channel contract. `tests/fm/test_active_channel.py` had to pin the driver against a hand copy and `tests/test_imaging_channel_lock.py` had to read the beam side's source, both because the TFS half needs an SDK that is not installed off the microscope.

## Verification

Ten mutants, each killed by its intended test: reverting to the base FM, dropping the check, dropping the lock, never restoring, restoring at every depth, restoring a hardcoded view, skipping the device, no restore on exception, and two more.

Suites run: 1108 passed (`tests/fm` + `tests/autolamella` + `tests/milling`), 345 FM-related UI tests, 544 in `tests/fm` again after rebasing onto current main. Parse-checked against Python 3.8.

## Not in scope

FIB-544 and FIB-545 are now *expressible* in the simulator, but modelling their call paths is their own work. The issue's wider point — simulator timing, and camera transforms changing under a live view — is untouched.