### PR TITLE
[refactor] Drop the AutoLamellaUI re-export from the package __init__ (FIB-571)

### DIFF
--- a/fibsem/applications/autolamella/ui/__init__.py
+++ b/fibsem/applications/autolamella/ui/__init__.py
@@ -1,40 +1,12 @@
 """AutoLamella's UI package.
 
-`AutoLamellaUI` is exported lazily (PEP 562) rather than imported here.
+Deliberately exports nothing. `AutoLamellaUI` used to be re-exported here, which meant
+importing *any* leaf widget in this package ran the whole application's import first --
+the package `__init__` runs before the submodule. That closed import loops with
+`fibsem.ui`, and the `except ImportError` wrapped around it bound `AutoLamellaUI` to
+None, so the failure surfaced as a dead application rather than a traceback.
 
-Importing it eagerly meant that importing *any* leaf widget in this package pulled
-the whole application in first, because the package `__init__` runs before the
-submodule. Once widgets under `fibsem/ui/` began importing widgets from here, that
-closed a loop: `fibsem.ui.<widget>` -> this package -> `AutoLamellaUI` -> back into
-`fibsem.ui`. The `except ImportError` below then swallowed it and bound
-`AutoLamellaUI` to None, so the failure showed up as a dead application rather than
-a traceback, and only for some import orders.
+Import it from its own module instead:
 
-Deferring the import to first attribute access keeps `from ... .ui import
-AutoLamellaUI` working exactly as before while leaving leaf-widget imports cheap and
-loop-free.
-"""
-
-import logging
-from typing import TYPE_CHECKING
-
-__all__ = ["AutoLamellaUI"]
-
-if TYPE_CHECKING:
     from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
-
-
-def __getattr__(name: str):
-    if name != "AutoLamellaUI":
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-    try:
-        from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
-    except ImportError as e:
-        logging.info(f"Error importing autolamella.ui: {e}, using dummy instead.")
-        AutoLamellaUI = None
-
-    # Cache on the module so later accesses skip this hook entirely, matching the
-    # old behaviour where the name was bound once at import time.
-    globals()["AutoLamellaUI"] = AutoLamellaUI
-    return AutoLamellaUI
+"""

--- a/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
@@ -67,7 +67,7 @@ from fibsem.ui.tokens import (
 )
 
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.ui import AutoLamellaUI
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
     from fibsem.correlation.structures import CorrelationResult
     from fibsem.imaging.spot import SpotBurnSettings
 

--- a/fibsem/applications/autolamella/ui/autolamella_overview_image_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_overview_image_widget.py
@@ -41,7 +41,7 @@ from fibsem.ui.tokens import (
     SURFACE_COLOR,
 )
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.ui import AutoLamellaUI
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
 
 
 # Stylesheet constants

--- a/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
@@ -62,7 +62,7 @@ def _valid_resolution(resolution) -> Tuple[int, int]:
 
 
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.ui import AutoLamellaUI
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
     from fibsem.applications.autolamella.structures import Experiment
     from fibsem.structures import ReferenceImageParameters
     from fibsem.milling.tasks import FibsemMillingTaskConfig

--- a/fibsem/applications/autolamella/workflows/core.py
+++ b/fibsem/applications/autolamella/workflows/core.py
@@ -19,7 +19,7 @@ from fibsem.structures import (
 )
 
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.ui import AutoLamellaUI
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
     from fibsem.applications.autolamella.structures import Lamella
 
 # CORE WORKFLOW STEPS

--- a/fibsem/applications/autolamella/workflows/legacy/autoliftout.py
+++ b/fibsem/applications/autolamella/workflows/legacy/autoliftout.py
@@ -41,7 +41,7 @@ from fibsem.structures import (
 
 from fibsem.applications.autolamella.workflows import actions
 from fibsem.applications.autolamella.structures import AutoLamellaStage, Experiment, Lamella
-from fibsem.applications.autolamella.ui import AutoLamellaUI
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
 from fibsem import config as fcfg
 
 

--- a/fibsem/applications/autolamella/workflows/legacy/serial.py
+++ b/fibsem/applications/autolamella/workflows/legacy/serial.py
@@ -58,7 +58,7 @@ from fibsem.applications.autolamella.structures import (
     create_new_lamella,
 )
 
-from fibsem.applications.autolamella.ui import AutoLamellaUI
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
 from fibsem.applications.autolamella.workflows import actions
 from fibsem.applications.autolamella.workflows.legacy.autoliftout import (
     end_of_stage_update,

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -80,7 +80,7 @@ from fibsem.structures import (
 )
 
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.ui import AutoLamellaUI
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
     from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
     from fibsem.fm.structures import FluorescenceImage
 

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -20,7 +20,7 @@ from fibsem.utils import format_time_remaining
 
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.structures import Experiment, Lamella
-    from fibsem.applications.autolamella.ui import AutoLamellaUI
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
 
 
 def run_task(microscope: FibsemMicroscope,

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -19,7 +19,7 @@ from fibsem.structures import (
 )
 from fibsem.applications.autolamella.structures import Experiment
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.ui import AutoLamellaUI
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
     from fibsem.imaging.spot import SpotBurnSettings
 
 # CORE UI FUNCTIONS -> PROBS SEPARATE FILE

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -89,7 +89,7 @@ from fibsem.ui.widgets.overview_acquisition_settings_widget import (
 )
 
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.ui import AutoLamellaUI
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
 
 
 COLOURS = CORRELATION_IMAGE_LAYER_PROPERTIES["colours"]

--- a/fibsem/ui/fm/widgets/minimap_plot_widget.py
+++ b/fibsem/ui/fm/widgets/minimap_plot_widget.py
@@ -34,7 +34,7 @@ except ImportError:
     logging.warning("Matplotlib not available. Minimap plot widget will be disabled.")
 
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.ui import AutoLamellaUI
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
 
 
 class MinimapPlotWidget(QWidget):

--- a/fibsem/ui/widgets/milling_task_config_widget2.py
+++ b/fibsem/ui/widgets/milling_task_config_widget2.py
@@ -26,7 +26,7 @@ from fibsem.ui.widgets.milling_task_acquisition_settings_widget import (
 )
 
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.ui import AutoLamellaUI
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
 
 _WIDGET_CONFIG = {
     "name": {"default": "Milling Task", "placeholder": "Enter task name..."},


### PR DESCRIPTION
`fibsem/applications/autolamella/ui/__init__.py` existed only to re-export `AutoLamellaUI`.
#359 had to make that export lazy (PEP 562) to break an import loop; removing it outright is
the better fix, and takes the lazy hook with it.

**13 files, −28 lines net.** The `__init__` goes from 40 lines to a docstring.

## What the export was serving

| kind | count | |
| -- | -- | -- |
| `if TYPE_CHECKING:` blocks | **10** | cannot affect runtime — verified in the diff itself |
| runtime imports | **2** | both `workflows/legacy/`, and both already fail to import on `main` |

The two live consumers are in modules that don't import on `main` either, for an unrelated
reason (`AutoLamellaProtocol` no longer exists in `structures.py`, hit at `serial.py:52`,
before the line this PR touches). So nothing currently working consumed the package-level name.

All twelve edits are the same one-line swap:

```python
-from fibsem.applications.autolamella.ui import AutoLamellaUI
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
```

## Why remove rather than keep the lazy hook

The `try/except ImportError -> AutoLamellaUI = None` was migration scaffolding from
`c6576520 [refactor] Migrate autolamella into repo (#11)`. Nothing anywhere checks
`AutoLamellaUI is None` or compares against it, so the dummy could never be observed by a
caller — it only ever converted a real ImportError into a confusing one.

It cost real time. During #359 it hid a genuine circular import for most of an afternoon:
`AutoLamellaUI` silently became `None`, **the application still launched**, and all thirteen
moved modules imported cleanly. It surfaced only by running a cold-import probe against
`origin/main` and diffing the result.

This removes the mechanism rather than the instance. Importing anything from the package no
longer runs the whole application's import first, so the loop cannot re-form as more widgets
move in.

## Verification

- **38 entry points** cold-imported in fresh processes, each asserting `AutoLamellaUI` still
  resolves as a class from its own module
- The package attribute now raises `AttributeError` instead of falling back to `None` — there
  is nothing left to swallow
- Full suite offscreen: **3968 passed, 1 failed** (FIB-561, reads the working directory)
- App launched

## Out-of-tree consumers

Checked `adaptive_milling` — unaffected. It has no `from fibsem.applications.autolamella.ui`
import at all, and its only `fibsem.ui` reference is a `TYPE_CHECKING` import of
`FibsemMillingWidget2`, which has not moved.

Worth noting nothing in CI would have caught it if it had: that plugin isn't installed in the
test env and isn't built against fibsem-os, so breaking a public import path is currently found
only by remembering to look.