### PR TITLE
[fix] Hold the imaging channel across the view-dependent operations (FIB-569, FIB-545)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -2253,11 +2253,15 @@ class ThermoMicroscope(FibsemMicroscope):
         Raises:
             Exception: If there's an error while getting the last image.
         """
-        # set active view and device
-        self.set_channel(beam_type)
-
-        # get the last image
-        image = self.connection.imaging.get_image()
+        # One lock over the channel and the read, as `acquire_image` holds it over
+        # `set_channel` + `grab_frame` (FIB-542). `get_image` retrieves the image "in the
+        # active view", so this is the same pair on the retrieval path: a channel that is
+        # not still ours when the read lands returns whoever took it, and the metadata
+        # below is built from `beam_type` rather than from what came back, so it is
+        # labelled as though nothing happened (FIB-569).
+        with self._threading_lock:
+            self.set_channel(beam_type)
+            image = self.connection.imaging.get_image()
         image = AdornedImage(data=image.data.astype(np.uint8), metadata=image.metadata)
 
         # get the microscope state (for metadata)
@@ -2279,9 +2283,20 @@ class ThermoMicroscope(FibsemMicroscope):
 
     def acquire_chamber_image(self) -> FibsemImage:
         """Acquire an image of the chamber inside."""
-        self.connection.imaging.set_active_view(4)
-        self.connection.imaging.set_active_device(3)
-        image = self.connection.imaging.get_image()
+        # The chamber camera is a third device on the channel the beams and the FM
+        # share, so a glance at it takes the microscope away from whatever had it.
+        # Captured and put back in a `finally`: leaving the connection on the chamber
+        # camera strands whoever was mid-operation, which is FIB-517 with a different
+        # thief (FIB-545). Restores the view alone -- `set_active_device` changes the
+        # device *in the active view*, so the device comes back with it.
+        with self._threading_lock:
+            restore_view = self.connection.imaging.get_active_view()
+            self.connection.imaging.set_active_view(4)
+            self.connection.imaging.set_active_device(3)
+            try:
+                image = self.connection.imaging.get_image()
+            finally:
+                self.connection.imaging.set_active_view(restore_view)
         logging.debug({"msg": "acquire_chamber_image"})
         return FibsemImage(data=image.data, metadata=None)
 
@@ -2364,11 +2379,24 @@ class ThermoMicroscope(FibsemMicroscope):
             beam_type (BeamType) The imaging beam type for which to adjust the contrast.
         """
         logging.debug(f"Running autocontrast on {beam_type.name}.")
-        self.set_channel(beam_type)
-        if reduced_area is not None:
-            self.set_reduced_area_scanning_mode(reduced_area, beam_type)
+        # `run_auto_cb` optimises "the active detector in the active view", so the
+        # channel has to be ours for the whole routine, not just when it starts. Unlike
+        # a stolen grab this is a *write*: a routine that runs on the wrong view tunes
+        # the other column's brightness and contrast and leaves it that way (FIB-569).
+        #
+        # The reduced-area write is inside for the same reason -- outside it, the
+        # routine could run on the right view with someone else's scan region.
+        #
+        # A longer hold than FIB-542's single grab, and deliberately so: the operation
+        # itself is what needs the channel, so there is no narrower correct scope. It is
+        # seconds, and anything wanting the microscope during an autocontrast conflicts
+        # with it physically in any case.
+        with self._threading_lock:
+            self.set_channel(beam_type)
+            if reduced_area is not None:
+                self.set_reduced_area_scanning_mode(reduced_area, beam_type)
 
-        self.connection.auto_functions.run_auto_cb()
+            self.connection.auto_functions.run_auto_cb()
         if reduced_area is not None:
             self.set_full_frame_scanning_mode(beam_type)
 
@@ -2381,12 +2409,18 @@ class ThermoMicroscope(FibsemMicroscope):
             beam_type (BeamType): The imaging beam type for which to focus.
         """
         logging.debug(f"Running auto-focus on {beam_type.name}.")
-        self.set_channel(beam_type)
-        if reduced_area is not None:
-            self.set_reduced_area_scanning_mode(reduced_area, beam_type)
+        # Held for the same reason as `autocontrast`, and it matters more here:
+        # `run_auto_focus` runs "in the active view", and `imaging/tiled.py` calls this
+        # once per tile of an unattended tileset -- exactly the long run interleaved
+        # with GUI-thread reads that stopped a workflow task in FIB-517. Losing the
+        # channel focuses the other column and every later acquisition inherits it.
+        with self._threading_lock:
+            self.set_channel(beam_type)
+            if reduced_area is not None:
+                self.set_reduced_area_scanning_mode(reduced_area, beam_type)
 
-        # run the auto focus
-        self.connection.auto_functions.run_auto_focus()
+            # run the auto focus
+            self.connection.auto_functions.run_auto_focus()
 
         # restore the full frame scanning mode
         if reduced_area is not None:

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -176,6 +176,11 @@ class ImagingSystem:
 FM_ACTIVE_VIEW = 3
 FM_ACTIVE_DEVICE = 3
 
+# The chamber camera's place on the same channel, matching the numbers
+# `ThermoMicroscope.acquire_chamber_image` writes.
+CHAMBER_ACTIVE_VIEW = 4
+CHAMBER_ACTIVE_DEVICE = 3
+
 
 class SimulatedFluorescenceMicroscope(FluorescenceMicroscope):
     """The FM half of the one imaging channel a TFS system shares (FIB-518).
@@ -643,17 +648,39 @@ class DemoMicroscope(FibsemMicroscope):
         Returns:
             FibsemImage: The last acquired image.
         """
-        image = self.imaging_system.last_image.get(beam_type)
+        # `ThermoMicroscope.last_image` sets the channel and then reads the *active
+        # view's* buffer -- `imaging.get_image` "retrieves a microscope image currently
+        # present in the active view" -- so it is FIB-542's pair on the retrieval path
+        # (FIB-569). Claimed and checked here for the same reason, though the simulator
+        # has no window between the two: it reads a dict rather than making a second
+        # round trip, so only a caller that already lost the channel can trip the check.
+        with self._threading_lock:
+            self.set_channel(beam_type)
+            self._warn_if_channel_moved(beam_type, "last_image")
+            image = self.imaging_system.last_image.get(beam_type)
         logging.debug({"msg": "last_image", "beam_type": beam_type.name, "metadata": image.metadata.to_dict()})
         return image
 
     def acquire_chamber_image(self) -> FibsemImage:
         """Acquire an image of the chamber inside."""
-        image = FibsemImage(
-            data=np.random.randint(low=0, high=256, 
-                size=(1024, 1536), 
-                dtype=np.uint8),
-                metadata=None)
+        # The chamber camera is a third device on the shared channel, so looking at it
+        # takes the microscope away from whichever beam had it. Captured and put back in
+        # a `finally`, because a glance at the chamber that strands a running beam
+        # operation is FIB-517 with a different thief (FIB-545).
+        with self._threading_lock:
+            restore_view = self.imaging_system.active_view
+            restore_device = self.imaging_system.active_device
+            self.imaging_system.active_view = CHAMBER_ACTIVE_VIEW
+            self.imaging_system.active_device = CHAMBER_ACTIVE_DEVICE
+            try:
+                image = FibsemImage(
+                    data=np.random.randint(low=0, high=256,
+                        size=(1024, 1536),
+                        dtype=np.uint8),
+                        metadata=None)
+            finally:
+                self.imaging_system.active_view = restore_view
+                self.imaging_system.active_device = restore_device
         logging.debug({"msg": "acquire_chamber_image"})
         return image
 
@@ -688,28 +715,41 @@ class DemoMicroscope(FibsemMicroscope):
             logging.error(f"Error in acquisition worker: {e}")
 
     def autocontrast(self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None) -> None:
-        if reduced_area is not None:
-            self.set_reduced_area_scanning_mode(reduced_area, beam_type)
-        # TODO: implement auto-contrast
-        logging.info(f"Autocontrasting {beam_type.name} beam.")
-        sim_sleep(random.uniform(0.5, 1.0))  # simulate time taken to calculate auto-contrast
-        self.set_detector_brightness(random.uniform(0.4, 0.6), beam_type)
-        self.set_detector_contrast(random.uniform(0.4, 0.6), beam_type)
+        # Claims the channel and holds it for the routine, as `ThermoMicroscope`'s does:
+        # `run_auto_cb` optimises "the active detector in the active view", so a channel
+        # that is not still ours when it runs tunes the other column -- and unlike a
+        # stolen grab, that damage persists (FIB-569).
+        with self._threading_lock:
+            self.set_channel(beam_type)
+            if reduced_area is not None:
+                self.set_reduced_area_scanning_mode(reduced_area, beam_type)
+            # TODO: implement auto-contrast
+            logging.info(f"Autocontrasting {beam_type.name} beam.")
+            sim_sleep(random.uniform(0.5, 1.0))  # simulate time taken to calculate auto-contrast
+            self._warn_if_channel_moved(beam_type, "autocontrast")
+            self.set_detector_brightness(random.uniform(0.4, 0.6), beam_type)
+            self.set_detector_contrast(random.uniform(0.4, 0.6), beam_type)
 
         if reduced_area:
             self.set_full_frame_scanning_mode(beam_type)
         logging.debug({"msg": "autocontrast", "beam_type": beam_type.name})
 
     def auto_focus(self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None) -> None:        
-        if reduced_area is not None:
-            self.set_reduced_area_scanning_mode(reduced_area, beam_type)
-        # TODO: implement auto-focus
-        logging.info(f"Auto-focusing {beam_type.name} beam.")
-        wd: float = self.get("eucentric_height", beam_type=beam_type) # type: ignore
-        sim_sleep(random.uniform(0.5, 1.0))  # simulate time taken to calculate auto-focus
-        focus_adjustment = random.uniform(-100e-6, 100e-6)
-        new_wd = wd + focus_adjustment
-        self.set_working_distance(new_wd, beam_type)
+        # Same claim as `autocontrast`, for the same reason: `run_auto_focus` runs "in
+        # the active view", so losing the channel focuses the other column and leaves it
+        # that way. `imaging/tiled.py` calls this once per tile of an unattended run.
+        with self._threading_lock:
+            self.set_channel(beam_type)
+            if reduced_area is not None:
+                self.set_reduced_area_scanning_mode(reduced_area, beam_type)
+            # TODO: implement auto-focus
+            logging.info(f"Auto-focusing {beam_type.name} beam.")
+            wd: float = self.get("eucentric_height", beam_type=beam_type) # type: ignore
+            sim_sleep(random.uniform(0.5, 1.0))  # simulate time taken to calculate auto-focus
+            self._warn_if_channel_moved(beam_type, "auto_focus")
+            focus_adjustment = random.uniform(-100e-6, 100e-6)
+            new_wd = wd + focus_adjustment
+            self.set_working_distance(new_wd, beam_type)
 
         if reduced_area:
             self.set_full_frame_scanning_mode(beam_type)

--- a/tests/fm/test_simulated_channel_pairs.py
+++ b/tests/fm/test_simulated_channel_pairs.py
@@ -1,0 +1,186 @@
+"""The other operations that take the shared imaging channel (FIB-569, FIB-545).
+
+FIB-542 locked the beam's set-and-grab. Sweeping `ThermoMicroscope` for the same shape
+found three more places where the action is documented as operating on the *active view*
+and the pair is unguarded, plus one that takes the channel and never gives it back:
+
+| operation | the vendor doc's words | why it matters |
+| -- | -- | -- |
+| `auto_focus` | "Runs the automatic focus routine in the active view" | a **write** -- focuses the wrong column and leaves it there |
+| `autocontrast` | "optimizes contrast and brightness of the active detector in the active view" | a **write**, same |
+| `last_image` | "Retrieves a microscope image currently present in the active view" | FIB-542's twin on the retrieval path |
+| `acquire_chamber_image` | takes view 4 / device 3 | never restores, so it strands whoever had the channel |
+
+The autofunctions are the dangerous pair: a stolen grab returns one wrong image, a stolen
+autofocus misconfigures the beam for everything after it. `imaging/tiled.py:359` runs
+`auto_focus` once per tile of an unattended tileset.
+
+These run against the simulator, which models the shared channel since FIB-518. The
+hardware class cannot be built here (no SDK), so its side is pinned structurally in
+`tests/test_imaging_channel_lock.py`.
+"""
+
+import logging
+import threading
+
+import pytest
+
+from fibsem.microscopes.simulator import CHAMBER_ACTIVE_VIEW, FM_ACTIVE_VIEW
+from fibsem.structures import BeamType
+
+STOLEN = "Imaging channel changed"
+
+
+@pytest.fixture
+def microscope():
+    from fibsem import utils
+
+    scope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    assert scope.fm is not None, "the simulated compustage system should have an FM"
+    return scope
+
+
+def steal_during(monkeypatch, thief) -> None:
+    """Run `thief` inside the operation's simulated duration.
+
+    The autofunctions sleep to emulate the routine, and that sleep is the window an
+    unguarded FM read would land in -- the same hook `test_simulated_shared_channel.py`
+    uses for the acquisition. Patched on the module, so it fires for whichever
+    `sim_sleep` the operation under test reaches.
+    """
+    monkeypatch.setattr("fibsem.microscopes.simulator.sim_sleep", lambda seconds: thief())
+
+
+class TestTheAutofunctionsHoldTheChannel:
+    """The two writes. Each asserts the channel is theirs when the routine runs."""
+
+    @pytest.mark.parametrize("operation", ["autocontrast", "auto_focus"])
+    def test_it_claims_the_channel(self, microscope, operation):
+        """Neither took the channel at all before FIB-569 -- the simulated versions did
+        not touch it, and neither does the hardware one until it is fixed."""
+        microscope.fm.set_active_channel()
+
+        getattr(microscope, operation)(BeamType.ION)
+
+        assert microscope.imaging_system.active_view == BeamType.ION.value
+
+    @pytest.mark.parametrize("operation", ["autocontrast", "auto_focus"])
+    def test_a_clean_run_says_nothing(self, microscope, operation, caplog):
+        with caplog.at_level(logging.WARNING):
+            getattr(microscope, operation)(BeamType.ION)
+
+        assert STOLEN not in caplog.text
+
+    @pytest.mark.parametrize("operation", ["autocontrast", "auto_focus"])
+    def test_an_unguarded_fm_read_during_the_routine_is_reported(
+        self, microscope, operation, monkeypatch, caplog
+    ):
+        """The FIB-517 shape: a getter takes the channel and walks away, mid-routine.
+
+        On hardware the routine then tunes the FM's view instead of the beam's, and
+        nothing downstream can tell -- which is why this needs to be caught here.
+        """
+        steal_during(monkeypatch, microscope.fm.set_active_channel)
+
+        with caplog.at_level(logging.WARNING):
+            getattr(microscope, operation)(BeamType.ION)
+
+        assert STOLEN in caplog.text
+        assert f"found view {FM_ACTIVE_VIEW}" in caplog.text
+
+    def test_the_scoped_form_cannot_steal_during_the_routine(
+        self, microscope, monkeypatch, caplog
+    ):
+        """An FM operation that uses `active_channel()` queues behind the routine
+        instead of landing inside it, because both take the same lock.
+
+        The thief is a real second thread, and the test asserts it was blocked *and*
+        that it eventually ran, so a thief that never started cannot pass by doing
+        nothing.
+        """
+        at_the_door = threading.Event()
+        got_in = threading.Event()
+        blocked = []
+
+        def steal():
+            at_the_door.wait(timeout=5)
+            with microscope.fm.active_channel():
+                got_in.set()
+
+        thief = threading.Thread(target=steal, daemon=True)
+        thief.start()
+
+        def during_the_routine():
+            at_the_door.set()
+            blocked.append(not got_in.wait(timeout=0.5))
+
+        steal_during(monkeypatch, during_the_routine)
+
+        with caplog.at_level(logging.WARNING):
+            microscope.auto_focus(BeamType.ION)
+
+        thief.join(timeout=5)
+        assert got_in.is_set(), "the thief never ran -- the test proved nothing"
+        assert blocked == [True], "the scoped form got the channel mid-routine"
+        assert STOLEN not in caplog.text
+
+
+class TestLastImageClaimsTheChannel:
+    def test_it_takes_the_channel_before_reading(self, microscope):
+        """`get_image` reads the active view's buffer, so a `last_image` that does not
+        set the channel first returns whoever owns it."""
+        settings_beam = BeamType.ION
+        microscope.acquire_image(beam_type=settings_beam)
+        microscope.fm.set_active_channel()
+
+        microscope.last_image(settings_beam)
+
+        assert microscope.imaging_system.active_view == settings_beam.value
+
+
+class TestTheChamberCameraGivesTheChannelBack:
+    """FIB-545. Different failure: not a race, a channel taken and abandoned."""
+
+    def test_it_takes_the_channel(self, microscope, monkeypatch):
+        """The premise -- if it did not take the channel there would be nothing to give
+        back, and the test below would pass for the wrong reason.
+
+        Observed at the grab, not after the call: by the time it returns the channel is
+        back where it started, which is the whole point.
+        """
+        seen = {}
+        real_randint = __import__("numpy").random.randint
+
+        def watching_randint(*args, **kwargs):
+            seen["view"] = microscope.imaging_system.active_view
+            return real_randint(*args, **kwargs)
+
+        monkeypatch.setattr("numpy.random.randint", watching_randint)
+        microscope.set_channel(BeamType.ELECTRON)
+
+        microscope.acquire_chamber_image()
+
+        assert seen["view"] == CHAMBER_ACTIVE_VIEW
+
+    @pytest.mark.parametrize("beam_type", [BeamType.ELECTRON, BeamType.ION])
+    def test_it_puts_the_channel_back(self, microscope, beam_type):
+        """A glance at the chamber must not strand the beam that had the microscope."""
+        microscope.set_channel(beam_type)
+
+        microscope.acquire_chamber_image()
+
+        assert microscope.imaging_system.active_view == beam_type.value
+        assert microscope.imaging_system.active_device == beam_type.value
+
+    def test_it_puts_it_back_even_when_the_grab_fails(self, microscope, monkeypatch):
+        microscope.set_channel(BeamType.ION)
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("chamber camera did not answer")
+
+        monkeypatch.setattr("numpy.random.randint", boom)
+
+        with pytest.raises(RuntimeError):
+            microscope.acquire_chamber_image()
+
+        assert microscope.imaging_system.active_view == BeamType.ION.value

--- a/tests/test_imaging_channel_lock.py
+++ b/tests/test_imaging_channel_lock.py
@@ -96,6 +96,106 @@ def test_the_channel_is_set_inside_the_same_block(thermo):
         )
 
 
+"""The other view-dependent actions (FIB-569, FIB-545).
+
+Sweeping the class for the same shape found three more. Each is documented by the vendor
+as acting on the active view, so each needs the channel to still be its own when it runs:
+
+* `imaging.get_image` — "Retrieves a microscope image currently present in the active
+  view". `last_image` is FIB-542's pair on the retrieval path.
+* `auto_functions.run_auto_cb` — "optimizes contrast and brightness of the active
+  detector in the active view".
+* `auto_functions.run_auto_focus` — "Runs the automatic focus routine in the active
+  view".
+
+The autofunctions are the ones that matter most, and they are not covered by
+`test_the_locked_region_stays_narrow` on purpose: the routine *is* the thing that needs
+the channel, so there is no narrower correct scope and the hold is deliberately as long
+as the routine. That exception is the reason the narrowness test keys on `grab_frame`
+rather than applying to every locked block.
+"""
+
+VIEW_DEPENDENT_ACTIONS = ["get_image", "run_auto_cb", "run_auto_focus"]
+
+
+@pytest.mark.parametrize("action", VIEW_DEPENDENT_ACTIONS)
+def test_every_view_dependent_action_is_locked(thermo, action):
+    calls = _calls_named(thermo, action)
+    assert calls, f"no {action} call found -- the probe missed, not the code"
+
+    locked = {
+        id(call)
+        for block in _locked_blocks(thermo)
+        for call in _calls_named(block, action)
+    }
+    unlocked = [call.lineno for call in calls if id(call) not in locked]
+    assert unlocked == [], (
+        f"{action} runs without the lock at line(s) {unlocked}: it acts on the active "
+        f"view, so whatever took the shared channel is what it acts on"
+    )
+
+
+@pytest.mark.parametrize("action", ["run_auto_cb", "run_auto_focus"])
+def test_the_autofunctions_claim_the_channel_in_the_same_block(thermo, action):
+    """Setting the channel before the lock would leave the window open."""
+    for block in _locked_blocks(thermo):
+        if not _calls_named(block, action):
+            continue
+        assert _calls_named(block, "set_channel"), (
+            f"the block at line {block.lineno} locks {action} but not the set_channel "
+            f"that precedes it, so the channel can still be taken in between"
+        )
+
+
+def test_the_autofunctions_hold_the_reduced_area_too(thermo):
+    """The pair is a triple when a reduced area is given.
+
+    A reduced-area write left outside the lock lets the routine run on the right view
+    with someone else's scan region -- the channel is guarded and the result is still
+    wrong.
+    """
+    for action in ("run_auto_cb", "run_auto_focus"):
+        blocks = [b for b in _locked_blocks(thermo) if _calls_named(b, action)]
+        assert blocks, f"no locked {action} block found"
+        for block in blocks:
+            assert _calls_named(block, "set_reduced_area_scanning_mode"), (
+                f"the block at line {block.lineno} runs {action} without the "
+                f"reduced-area write inside it"
+            )
+
+
+def test_the_chamber_camera_puts_the_view_back(thermo):
+    """FIB-545. Not a race -- a channel taken and abandoned.
+
+    `acquire_chamber_image` points the connection at view 4 / device 3. Before this it
+    never pointed it back, so a glance at the chamber stranded whatever had the
+    microscope for the rest of the session. The restore has to be in a `finally`: a
+    chamber camera that does not answer would otherwise strand it just the same.
+    """
+    chamber = next(
+        node
+        for node in ast.walk(thermo)
+        if isinstance(node, ast.FunctionDef) and node.name == "acquire_chamber_image"
+    )
+
+    assert _calls_named(chamber, "get_active_view"), (
+        "acquire_chamber_image never reads the view it is about to replace, so it has "
+        "nothing to put back"
+    )
+
+    tries = [node for node in ast.walk(chamber) if isinstance(node, ast.Try)]
+    restored = [
+        call
+        for node in tries
+        for handler in node.finalbody
+        for call in _calls_named(handler, "set_active_view")
+    ]
+    assert restored, (
+        "acquire_chamber_image does not restore the active view in a `finally`, so a "
+        "failed grab leaves the connection on the chamber camera"
+    )
+
+
 def test_the_locked_region_stays_narrow(thermo):
     """`_threading_lock` is a class attribute, shared by every caller in the process.
 


### PR DESCRIPTION
FIB-542 locked the beam's set-and-grab. Sweeping `ThermoMicroscope` for the same shape found three more places where the action operates on the **active view** and the pair is unguarded, plus one that takes the channel and never gives it back.

Each is checked against the vendor documentation rather than inferred:

| SDK call | the docs' words | our method |
|---|---|---|
| `imaging.get_image` | "Retrieves a microscope image currently present in **the active view**" | `last_image` |
| `auto_functions.run_auto_cb` | "optimizes contrast and brightness of the active detector **in the active view**" | `autocontrast` |
| `auto_functions.run_auto_focus` | "Runs the automatic focus routine **in the active view**" | `auto_focus` |

## Why the autofunctions are worse than FIB-542

A stolen grab returns one wrong image. A stolen autofocus **focuses the other column, and every later acquisition inherits it** — silently, because nothing downstream reports which view answered. `imaging/tiled.py` calls `auto_focus` once per tile of an unattended tileset, which is the long-run-meets-GUI-poll shape that stopped a workflow task in FIB-517.

`autocontrast` is the same, writing brightness and contrast to whichever column is active.

## `acquire_chamber_image` (FIB-545)

A different failure — not a race, a channel taken and abandoned. It pointed the connection at view 4 / device 3 and never pointed it back, stranding whatever had the microscope for the rest of the session. It now captures the view and restores it in a `finally`, so a chamber camera that does not answer cannot strand it either.

## The long hold, deliberately

The lock on the autofunctions covers seconds, where FIB-542's covered one frame. There is no narrower correct scope: the routine itself is what needs the channel. It is seconds, and anything wanting the microscope during an autofocus conflicts with it physically in any case.

That is why the existing narrowness test keys on `grab_frame` rather than on every locked block. The exemption is written into the test file rather than left as a silent gap.

## How it is tested

All four are modelled in the simulator, which is what makes them testable at all — before FIB-518 none of this could be shown without hardware.

- `tests/fm/test_simulated_channel_pairs.py` (new, 12 tests) runs the contract behaviourally: each autofunction claims the channel, reports an unguarded FM read landing mid-routine, and is provably not stealable by the scoped form from a second thread.
- The chamber-camera case was **reproduced first** — modelling current hardware faithfully made three tests fail — then fixed.
- `tests/test_imaging_channel_lock.py` gains the structural half, since `ThermoMicroscope` needs an SDK absent off the microscope.

**The structural assertions were run against the pre-fix source to confirm they discriminate** rather than pass vacuously: `get_image` unlocked at 2260 and 2284, `run_auto_cb` at 2371, `run_auto_focus` at 2389, and the chamber capture absent entirely — all four would have failed on `origin/main`.

Ten simulator mutants, each killed by its intended test. 1225 tests pass across `tests/fm`, the channel-lock test, acquire / microscope / autofunctions / tiled, autolamella and milling. 39 changed lines of existing production code.

## Not in scope

FIB-544 (detector property reads) — its real fix is the deeper "build metadata from the AdornedImage" change, not a lock. FIB-570 (sputter's hand-rolled save/restore) — wants a context manager, not a lock.