### PR TITLE
[refactor] Promote the bug-report tool, and retire three stray autolamella hints (FIB-556, FIB-557)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -748,7 +748,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         experiment = getattr(self.autolamella_ui, "experiment", None)
         microscope = getattr(self.autolamella_ui, "microscope", None)
         open_bug_report_dialog(
-            experiment=experiment, microscope=microscope, parent=self
+            experiment_path=str(experiment.path) if experiment is not None else None,
+            microscope=microscope,
+            parent=self,
         )
 
     def _on_show_plugins(self):
@@ -2369,7 +2371,7 @@ def run_ui():
     import faulthandler
     import signal
 
-    from fibsem.applications.autolamella.tools.bug_report import init_sentry
+    from fibsem.tools.bug_report import init_sentry
 
     # Ctrl+C: PyQt never runs Python's SIGINT handler while blocked in the C++ event
     # loop — and if the GUI thread wedges, no Python runs at all — so restore the OS

--- a/fibsem/tools/bug_report.py
+++ b/fibsem/tools/bug_report.py
@@ -33,7 +33,6 @@ import fibsem.config as fibsem_cfg
 from fibsem.versioning import get_revision, get_version_string
 
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.structures import Experiment
     from fibsem.microscope import FibsemMicroscope
 
 # Support / issue destinations
@@ -143,13 +142,11 @@ def scrub_text(text: str) -> str:
     return scrubbed
 
 
-def _collect_files(
-    experiment: "Experiment", content: BugReportContent
-) -> List[str]:
+def _collect_files(experiment_path: str, content: BugReportContent) -> List[str]:
     """Resolve the absolute paths of the artifacts selected for inclusion."""
     from glob import glob
 
-    exp_path = str(experiment.path)
+    exp_path = str(experiment_path)
     files: List[str] = []
 
     def _add(path: str) -> None:
@@ -174,13 +171,13 @@ def _collect_files(
 
 
 def estimate_bundle_size(
-    experiment: Optional["Experiment"], content: BugReportContent
+    experiment_path: Optional[str], content: BugReportContent
 ) -> int:
     """Estimate the on-disk size (bytes) of the selected artifacts."""
-    if experiment is None:
+    if experiment_path is None:
         return 0
     total = 0
-    for path in _collect_files(experiment, content):
+    for path in _collect_files(experiment_path, content):
         try:
             total += os.path.getsize(path)
         except OSError:
@@ -212,7 +209,7 @@ def _render_report_text(content: BugReportContent) -> str:
 
 def build_bug_report_bundle(
     content: BugReportContent,
-    experiment: Optional["Experiment"],
+    experiment_path: Optional[str],
     output_dir: Optional[str] = None,
 ) -> str:
     """Build a scrubbed ``.zip`` bundle for the bug report and return its path.
@@ -226,8 +223,8 @@ def build_bug_report_bundle(
 
     if output_dir is None:
         # Prefer alongside the experiment; fall back to the log directory.
-        if experiment is not None and os.path.isdir(str(experiment.path)):
-            output_dir = str(experiment.path)
+        if experiment_path is not None and os.path.isdir(str(experiment_path)):
+            output_dir = str(experiment_path)
         else:
             output_dir = fibsem_cfg.LOG_PATH
     os.makedirs(output_dir, exist_ok=True)
@@ -240,9 +237,9 @@ def build_bug_report_bundle(
             scrub_text(json.dumps(content.system_context, indent=2)),
         )
 
-        if experiment is not None:
-            exp_path = str(experiment.path)
-            for path in _collect_files(experiment, content):
+        if experiment_path is not None:
+            exp_path = str(experiment_path)
+            for path in _collect_files(experiment_path, content):
                 arcname = os.path.relpath(path, os.path.dirname(exp_path))
                 ext = os.path.splitext(path)[1].lower()
                 try:

--- a/fibsem/ui/fm/widgets/fm_image_viewer_widget.py
+++ b/fibsem/ui/fm/widgets/fm_image_viewer_widget.py
@@ -183,7 +183,7 @@ def create_widget(
 
 def main():
     """Standalone application for testing."""
-    from fibsem.applications.autolamella.config import LOG_PATH
+    from fibsem.config import LOG_PATH
     viewer = napari.Viewer()
     widget = create_widget(viewer, LOG_PATH)
     viewer.window.add_dock_widget(widget, area="right", name="FM Image Viewer")

--- a/fibsem/ui/fm/widgets/minimap_plot_widget.py
+++ b/fibsem/ui/fm/widgets/minimap_plot_widget.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
@@ -33,14 +33,11 @@ except ImportError:
     MATPLOTLIB_AVAILABLE = False
     logging.warning("Matplotlib not available. Minimap plot widget will be disabled.")
 
-if TYPE_CHECKING:
-    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
-
 
 class MinimapPlotWidget(QWidget):
     """Widget for displaying a minimap with lamella positions and current stage position."""
 
-    def __init__(self, parent: Optional['AutoLamellaUI'] = None):
+    def __init__(self, parent: Optional[QWidget] = None):
         super().__init__(parent)
         self.image: Optional[FibsemImage] = None
         self.lamella_positions: List[FibsemStagePosition] = []

--- a/fibsem/ui/widgets/about_dialog.py
+++ b/fibsem/ui/widgets/about_dialog.py
@@ -85,14 +85,14 @@ def mask_serial_number(serial: Optional[str]) -> str:
 def _environment_rows() -> List[Tuple[str, str]]:
     """Python / Qt / napari / platform, reusing the bug report's collector.
 
-    Imported lazily and defensively: this dialog must still open if the
-    autolamella application package is unavailable for any reason.
+    The collector reads version and revision metadata, which can fail on an
+    unusual install, so the *call* stays guarded and falls back to the bare
+    platform facts. The import no longer needs guarding: bug_report lives in
+    `fibsem.tools` now, not inside the AutoLamella application package.
     """
-    try:
-        from fibsem.applications.autolamella.tools.bug_report import (
-            collect_system_context,
-        )
+    from fibsem.tools.bug_report import collect_system_context
 
+    try:
         ctx = collect_system_context()
     except Exception:
         import platform

--- a/fibsem/ui/widgets/bug_report_widget.py
+++ b/fibsem/ui/widgets/bug_report_widget.py
@@ -23,8 +23,8 @@ from PyQt5.QtWidgets import (
 )
 
 import fibsem.config as fibsem_cfg
-from fibsem.applications.autolamella.tools import bug_report
-from fibsem.applications.autolamella.tools.bug_report import BugReportContent
+from fibsem.tools import bug_report
+from fibsem.tools.bug_report import BugReportContent
 from fibsem.ui import stylesheets
 from fibsem.ui.utils import open_path_in_file_explorer
 from fibsem.ui.widgets.custom_widgets import (
@@ -33,7 +33,6 @@ from fibsem.ui.widgets.custom_widgets import (
 )
 
 if TYPE_CHECKING:
-    from fibsem.applications.autolamella.structures import Experiment
     from fibsem.microscope import FibsemMicroscope
 
 SEVERITY_OPTIONS = ["Low", "Normal", "High", "Crash"]
@@ -44,13 +43,13 @@ class BugReportDialog(QDialog):
 
     def __init__(
         self,
-        experiment: Optional["Experiment"] = None,
+        experiment_path: Optional[str] = None,
         microscope: Optional["FibsemMicroscope"] = None,
         traceback_text: str = "",
         parent: Optional[QWidget] = None,
     ):
         super().__init__(parent)
-        self.experiment = experiment
+        self.experiment_path = experiment_path
         self.microscope = microscope
         self._system_context = bug_report.collect_system_context(microscope)
 
@@ -121,7 +120,7 @@ class BugReportDialog(QDialog):
         self.checkbox_experiment.setChecked(True)
         self.checkbox_protocol.setChecked(True)
 
-        has_experiment = self.experiment is not None
+        has_experiment = self.experiment_path is not None
         for cb in (
             self.checkbox_logfile,
             self.checkbox_experiment,
@@ -194,7 +193,7 @@ class BugReportDialog(QDialog):
 
     def _update_preview(self):
         content = self._content()
-        size = bug_report.estimate_bundle_size(self.experiment, content)
+        size = bug_report.estimate_bundle_size(self.experiment_path, content)
         env = ", ".join(f"{k}={v}" for k, v in self._system_context.items())
         size_str = f"{size / 1e6:.1f} MB" if size else "0 MB"
         self.label_preview.setText(
@@ -237,7 +236,7 @@ class BugReportDialog(QDialog):
             return
         self._persist_email(content)
         try:
-            zip_path = bug_report.build_bug_report_bundle(content, self.experiment)
+            zip_path = bug_report.build_bug_report_bundle(content, self.experiment_path)
             bug_report.compose_support_email(content, zip_path)
         except Exception as e:
             logging.exception("Failed to create bug report bundle.")
@@ -272,14 +271,14 @@ class BugReportDialog(QDialog):
 
 
 def open_bug_report_dialog(
-    experiment: Optional["Experiment"] = None,
+    experiment_path: Optional[str] = None,
     microscope: Optional["FibsemMicroscope"] = None,
     traceback_text: str = "",
     parent: Optional[QWidget] = None,
 ) -> None:
     """Convenience helper to construct and show the bug report dialog."""
     dialog = BugReportDialog(
-        experiment=experiment,
+        experiment_path=experiment_path,
         microscope=microscope,
         traceback_text=traceback_text,
         parent=parent,

--- a/fibsem/ui/widgets/milling_task_config_widget2.py
+++ b/fibsem/ui/widgets/milling_task_config_widget2.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
@@ -24,9 +24,6 @@ from fibsem.ui.widgets.milling_stages_widget import FibsemMillingStagesWidget
 from fibsem.ui.widgets.milling_task_acquisition_settings_widget import (
     FibsemMillingTaskAcquisitionSettingsWidget,
 )
-
-if TYPE_CHECKING:
-    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
 
 _WIDGET_CONFIG = {
     "name": {"default": "Milling Task", "placeholder": "Enter task name..."},
@@ -60,7 +57,7 @@ class MillingTaskConfigWidget2(QWidget):
         milling_task_config: Optional[FibsemMillingTaskConfig] = None,
         milling_enabled: bool = True,
         correlation_enabled: bool = True,
-        parent: Optional['AutoLamellaUI'] = None,
+        parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
         self.microscope = microscope

--- a/tests/test_bug_report.py
+++ b/tests/test_bug_report.py
@@ -3,15 +3,14 @@
 import getpass
 import os
 import zipfile
-from types import SimpleNamespace
 
 import pytest
 
-from fibsem.applications.autolamella.tools import bug_report
-from fibsem.applications.autolamella.tools.bug_report import BugReportContent
+from fibsem.tools import bug_report
+from fibsem.tools.bug_report import BugReportContent
 
 
-def _make_experiment(tmp_path):
+def _make_experiment_dir(tmp_path):
     """Create a fake experiment directory with typical artifacts on disk."""
     exp_dir = tmp_path / "AutoLamella-test"
     (exp_dir / "01-lam" / "Milling").mkdir(parents=True)
@@ -23,7 +22,7 @@ def _make_experiment(tmp_path):
     (exp_dir / "01-lam" / "shot.png").write_bytes(b"PNGDATA")
     (exp_dir / "01-lam" / "Milling" / "z.ome.tiff").write_bytes(b"TIFFDATA")
 
-    return SimpleNamespace(name="AutoLamella-test", path=str(exp_dir))
+    return str(exp_dir)
 
 
 def _names(zip_path):
@@ -35,7 +34,7 @@ def test_bundle_filename_and_base_contents(tmp_path):
     """A bundle with no experiment still contains the report + system info."""
     content = BugReportContent(title="t", description="d", system_context={"a": "b"})
     zip_path = bug_report.build_bug_report_bundle(
-        content, experiment=None, output_dir=str(tmp_path)
+        content, experiment_path=None, output_dir=str(tmp_path)
     )
 
     fname = os.path.basename(zip_path)
@@ -50,11 +49,11 @@ def test_bundle_filename_and_base_contents(tmp_path):
 
 def test_bundle_includes_selected_text_files_scrubbed(tmp_path):
     """Default selection includes the log/yaml files, scrubbed of the home dir."""
-    experiment = _make_experiment(tmp_path)
+    experiment_path = _make_experiment_dir(tmp_path)
     content = BugReportContent(title="t", description="d")  # defaults: text on
 
     zip_path = bug_report.build_bug_report_bundle(
-        content, experiment=experiment, output_dir=str(tmp_path)
+        content, experiment_path=experiment_path, output_dir=str(tmp_path)
     )
 
     with zipfile.ZipFile(zip_path) as zf:
@@ -73,14 +72,14 @@ def test_bundle_includes_selected_text_files_scrubbed(tmp_path):
 
 
 def test_bundle_excludes_text_files_when_unselected(tmp_path):
-    experiment = _make_experiment(tmp_path)
+    experiment_path = _make_experiment_dir(tmp_path)
     content = BugReportContent(
         include_logfile=False,
         include_experiment_yaml=False,
         include_protocol=False,
     )
     zip_path = bug_report.build_bug_report_bundle(
-        content, experiment=experiment, output_dir=str(tmp_path)
+        content, experiment_path=experiment_path, output_dir=str(tmp_path)
     )
     names = _names(zip_path)
     assert not any(n.endswith(".log") for n in names)
@@ -91,11 +90,11 @@ def test_bundle_excludes_text_files_when_unselected(tmp_path):
 
 def test_bundle_includes_images_when_opted_in(tmp_path):
     """Binary artifacts are added verbatim only when explicitly selected."""
-    experiment = _make_experiment(tmp_path)
+    experiment_path = _make_experiment_dir(tmp_path)
     content = BugReportContent(include_screenshots=True, include_images=True)
 
     zip_path = bug_report.build_bug_report_bundle(
-        content, experiment=experiment, output_dir=str(tmp_path)
+        content, experiment_path=experiment_path, output_dir=str(tmp_path)
     )
 
     with zipfile.ZipFile(zip_path) as zf:
@@ -108,17 +107,17 @@ def test_bundle_includes_images_when_opted_in(tmp_path):
 
 
 def test_estimate_bundle_size(tmp_path):
-    experiment = _make_experiment(tmp_path)
+    experiment_path = _make_experiment_dir(tmp_path)
     empty = BugReportContent(
         include_logfile=False,
         include_experiment_yaml=False,
         include_protocol=False,
     )
-    assert bug_report.estimate_bundle_size(experiment, empty) == 0
+    assert bug_report.estimate_bundle_size(experiment_path, empty) == 0
     assert bug_report.estimate_bundle_size(None, BugReportContent()) == 0
 
     full = BugReportContent(include_screenshots=True, include_images=True)
-    assert bug_report.estimate_bundle_size(experiment, full) > 0
+    assert bug_report.estimate_bundle_size(experiment_path, full) > 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Two of the last five `fibsem/ui` modules depending on AutoLamella, plus the three one-line
stragglers grouped as FIB-556.

**`fibsem/ui` modules importing AutoLamella: 7 → 2.** Both remaining are FIB-560's
coincidence viewer and minimap.

8 files, net −9 lines.

## FIB-557 — `bug_report` moves to `fibsem/tools/`

Reporting a bug is not an AutoLamella feature: the module collects environment and version
information about *fibsem*, and the About dialog that offers it is generic.

The interesting part is how shallow the coupling was. Its entire dependency on `Experiment`
was `str(experiment.path)` — nothing else. So it needs a **path**, not the injected hook the
issue anticipated:

```python
-def _collect_files(experiment: "Experiment", content): ...
+def _collect_files(experiment_path: str, content): ...
```

That propagates one level up. `BugReportDialog` used `self.experiment` only for an
is-not-None check and those two calls, so it takes a path too — which removes the last
AutoLamella reference from `bug_report_widget.py`. `AutoLamellaMainUI` passes
`experiment.path` at the one call site.

**The guard in `about_dialog.py` is narrowed, not deleted.** Its stated reason — *"this dialog
must still open if the autolamella application package is unavailable for any reason"* — is
gone. But the same `except` also covered the *call*, which reads version and git-revision
metadata and can genuinely fail on an unusual install. The import is now unguarded; the call
keeps its platform fallback.

## FIB-556 — three one-liners

- `minimap_plot_widget.py` and `milling_task_config_widget2.py` typed their `parent` argument
  with a `TYPE_CHECKING` import of `AutoLamellaUI`. Both are duck-typed across hosts, so
  `Optional[QWidget]` is the honest type — same call FIB-546 made for three FM widgets.
- `fm_image_viewer_widget.py`'s standalone harness takes `LOG_PATH` from `fibsem.config`
  instead of AutoLamella's.

Empty `TYPE_CHECKING` blocks and now-unused imports removed in both.

## Verification

Beyond the suite, the behaviour that only a menu click would otherwise exercise:

- `BugReportDialog` constructs with and without a path; artifact checkboxes enable/disable correctly
- bundle plumbing collects the right files — `estimate_bundle_size` returns 6144 bytes exact for
  a 4096+2048 byte fixture, both artifacts land in the zip, and the `None` path still builds
- `_environment_rows()` returns its 4 rows through the narrowed guard

Full suite offscreen: **3968 passed, 1 failed** — FIB-561, which reads the working directory.

## Deliberately unchanged

`bug_report` still emits AutoLamella-branded user-visible text (`# AutoLamella Bug Report:`,
`bug-report-autolamella-*.zip`, the email subject, the GitHub issue title). Those name the
product being reported on, AutoLamella is still the only application, and changing user-visible
strings is a visible change rather than a structural one. Easy to follow up if wanted.