### PR TITLE
[fm] Announce objective moves instead of polling for them (FIB-534)

### DIFF
--- a/fibsem/fm/autoscript.py
+++ b/fibsem/fm/autoscript.py
@@ -155,6 +155,8 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
         """
         current_position = self.position
         new_position = current_position + delta
+        # Delegates, so the announcement comes from `move_absolute`. Not every driver
+        # does -- see `_notify_moved`.
         self.move_absolute(new_position)
 
     def move_absolute(self, position: float):
@@ -173,6 +175,7 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
             position = np.clip(position, 0, self._limit_position)
         with self.parent.active_channel():
             self.parent.fm_settings.focus.value = position
+        self._notify_moved()
 
     def insert(self) -> None:
         """Insert the objective lens into the working position.
@@ -184,6 +187,9 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
                 logging.warning("Objective lens is already inserted.")
                 return
             self.parent.connection.detector.insert()
+        # Outside the scope, and after the early return: nothing moved in that case, so
+        # there is nothing to announce.
+        self._notify_moved()
 
     def retract(self) -> None:
         """Retract the objective lens from the working position.
@@ -195,6 +201,7 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
                 logging.warning("Objective lens is already retracted.")
                 return
             self.parent.connection.detector.retract()
+        self._notify_moved()
 
     @property
     def state(self) -> Literal["Inserted", "Retracted", "Busy", "Error", "Other"]:
@@ -223,6 +230,7 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
         """
         with self.parent.active_channel():
             self.parent.connection.detector.home()
+        self._notify_moved()
 
 
 class ThermoFisherCamera(Camera):

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import threading
 from abc import ABC
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from copy import deepcopy
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Optional, Tuple, Union, Literal
@@ -56,6 +56,34 @@ ALLOW_UNKNOWN_ORIENTATIONS = True  # allow fm control at any orientation
 
 
 class ObjectiveLens(ABC):
+    # Raised after the objective moves, carrying position (metres) and state, so a
+    # display can refresh instead of polling the device for numbers it mostly does not
+    # need (FIB-534). On a TFS system each such read takes the shared imaging channel,
+    # so a label refreshed on every stage poll moves the microscope's own active view to
+    # the FM and back to fetch a millimetre reading -- which is how FIB-517 happened.
+    #
+    # Carries the values rather than being a bare "something moved", for the reason
+    # `stage_position_changed` does: subscribers that each re-read would turn one move
+    # into a read per subscriber, and there are at least three displays. Read once, at
+    # the source, under the channel scope the move already holds -- see `_notify_moved`.
+    #
+    # State travels with position because every display that wants one wants both: the
+    # overview info bar renders "objective 10.061 mm (inserted)" from a single line.
+    #
+    # On the objective rather than the microscope, following `Stage.position_changed`
+    # (`fibsem/microscopes/_stage.py`). It also keeps the name unambiguous --
+    # `objective_position_changed` already means something else on the lamella widget --
+    # and lets an objective built without a parent announce its own moves.
+    #
+    # For displays only. Guards read the device, every time -- one of them suppresses z
+    # and r from a stage move while the objective is inserted, and a stale "Retracted"
+    # there moves the stage with the objective in the chamber.
+    #
+    # Emitted from whichever thread made the move -- connect with `@ensure_main_thread`
+    # if the slot touches widgets, and disconnect on teardown: this is psygnal, so
+    # nothing is severed for you when the C++ object goes (FIB-550).
+    position_changed = Signal(float, str)
+
     """Abstract base class for objective lens control in fluorescence microscopy.
 
     Provides a standardized interface for controlling objective lens positioning,
@@ -80,6 +108,43 @@ class ObjectiveLens(ABC):
         self._retract_position = SIM_OBJECTIVE_RETRACT_POSITION
         self._focus_position: Optional[float] = SIM_OBJECTIVE_FOCUS_POSITION
         self._limit_position: float = SIM_OBJECTIVE_USER_POSITION_LIMIT
+
+    def _notify_moved(self) -> None:
+        """Announce where the objective ended up, for displays to refresh on (FIB-534).
+
+        Called by every write method that actually moves the device, in every
+        implementation -- there is no single chokepoint to put it behind, and the shape
+        differs per driver: the simulated `move_relative` adjusts its own field rather
+        than delegating, the TFS one delegates to `move_absolute`, and `insert`/`retract`
+        delegate on the simulator but not on TFS or odemis. `tests/fm/
+        test_objective_signal.py` pins that every one of them calls this, since a driver
+        that silently stops announcing is a display that silently goes stale.
+
+        Deliberately not called when a method returns early without moving -- an
+        `insert` on an already-inserted objective has nothing to announce.
+
+        Both reads share one channel scope. On a TFS system that is what makes carrying
+        a payload nearly free: the scope is depth-counted, so this nests inside the one
+        the move already holds and costs no extra change of the microscope's active
+        view. Reading twice unscoped would cost two.
+
+        A read that fails must not turn a move that worked into a raised exception, so a
+        failure here is logged and swallowed. The cost of missing one notification is a
+        stale label until the next move; the cost of propagating would be a move that
+        reports failure after succeeding.
+        """
+        # Parentless objectives are constructed directly in several tests, and there is
+        # no shared channel to take when there is no microscope holding it.
+        scope = (
+            self.parent.active_channel() if self.parent is not None else nullcontext()
+        )
+        try:
+            with scope:
+                position, state = self.position, self.state
+        except Exception as e:
+            logging.debug(f"Could not read the objective after moving it: {e}")
+            return
+        self.position_changed.emit(position, state)
 
     @property
     def magnification(self) -> float:
@@ -169,6 +234,9 @@ class ObjectiveLens(ABC):
         logging.info(
             f"Objective moved to new position: {self._position * 1e3:.3f} mm (delta: {delta * 1e3:.3f} mm)"
         )
+        # Announced here rather than relying on `move_absolute`: this implementation
+        # adjusts the field itself instead of delegating.
+        self._notify_moved()
 
     def move_absolute(self, position: float):
         """Move the objective lens to an absolute z-axis position.
@@ -188,6 +256,7 @@ class ObjectiveLens(ABC):
         logging.info(
             f"Objective moved to absolute position: {self._position * 1e3:.3f} mm"
         )
+        self._notify_moved()
 
     def insert(self):
         """Insert the objective lens into the working position for imaging.

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -64,8 +64,8 @@ class ObjectiveLens(ABC):
     #
     # Carries the values rather than being a bare "something moved", for the reason
     # `stage_position_changed` does: subscribers that each re-read would turn one move
-    # into a read per subscriber, and there are at least three displays. Read once, at
-    # the source, under the channel scope the move already holds -- see `_notify_moved`.
+    # into a read per subscriber, and there are at least three displays. Read once at
+    # the source instead -- see `_notify_moved` for what that costs.
     #
     # State travels with position because every display that wants one wants both: the
     # overview info bar renders "objective 10.061 mm (inserted)" from a single line.
@@ -123,10 +123,14 @@ class ObjectiveLens(ABC):
         Deliberately not called when a method returns early without moving -- an
         `insert` on an already-inserted objective has nothing to announce.
 
-        Both reads share one channel scope. On a TFS system that is what makes carrying
-        a payload nearly free: the scope is depth-counted, so this nests inside the one
-        the move already holds and costs no extra change of the microscope's active
-        view. Reading twice unscoped would cost two.
+        Both reads share one channel scope, so on a TFS system a move costs **one** extra
+        take of the shared imaging channel rather than two. Not zero: every caller
+        invokes this *after* its own scope has closed, deliberately, because psygnal is
+        synchronous -- inside, every subscriber's slot would run while the channel was
+        held, and a display refresh is not something to hold the microscope for.
+
+        One take per move is still the point of the exercise. What this replaces is a
+        read per *poll tick* by each display, and there are at least three of them.
 
         A read that fails must not turn a move that worked into a raised exception, so a
         failure here is logged and swallowed. The cost of missing one notification is a

--- a/fibsem/fm/odemis.py
+++ b/fibsem/fm/odemis.py
@@ -224,6 +224,9 @@ class OdemisObjectiveLens(ObjectiveLens):
             raise TypeError("Delta must be an integer or float.")
         f = self._focuser.moveRel({"z": delta})
         f.result()
+        # Announced here rather than relying on `move_absolute`: this driver moves the
+        # focuser directly instead of delegating.
+        self._notify_moved()
 
     @property
     def limits(self) -> Tuple[float, float]:
@@ -266,6 +269,7 @@ class OdemisObjectiveLens(ObjectiveLens):
 
         f = self._focuser.moveAbs({"z": position})
         f.result()
+        self._notify_moved()
 
     def insert(self):
         """Move the objective lens to the active (inserted) position.
@@ -282,6 +286,9 @@ class OdemisObjectiveLens(ObjectiveLens):
             return
         f = self._focuser.moveAbs(active_position)
         f.result()
+        # After the early return above: an insert with no calibrated position never
+        # moved, so it has nothing to announce.
+        self._notify_moved()
 
     def retract(self):
         """Move the objective lens to the deactive (retracted) position.
@@ -296,6 +303,7 @@ class OdemisObjectiveLens(ObjectiveLens):
             return
         f = self._focuser.moveAbs(deactive_position)
         f.result()
+        self._notify_moved()
 
     @property
     def state(self) -> Literal["Inserted", "Retracted", "Busy", "Error", "Other"]:

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -28,6 +28,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from superqt import ensure_main_thread
 
 from fibsem import constants
 from fibsem.fm.acquisition import FMTiledAcquisitionRunner, OverviewDestination
@@ -203,8 +204,6 @@ class FMOverviewWidget(QWidget):
     # And for something starting or finishing on the FM, which is reported from
     # whichever thread finished with it -- for our own runs, the acquisition worker.
     _fm_acquiring_changed = pyqtSignal(bool)
-    # position (metres), state -- relayed off whichever thread moved the objective
-    _objective_moved = pyqtSignal(float, str)
 
     def __init__(
         self,
@@ -285,8 +284,12 @@ class FMOverviewWidget(QWidget):
         self.microscope.stage_position_changed.connect(self._on_stage_signal)
         self._fm_acquiring_changed.connect(self._on_fm_acquiring_changed)
         self.fm.acquiring_changed.connect(self._on_fm_acquiring_signal)
-        self._objective_moved.connect(self._on_objective_moved)
-        self.fm.objective.position_changed.connect(self._on_objective_signal)
+        # Marshalled by `@ensure_main_thread` on the slot rather than by relaying
+        # through a Qt signal like the three above. That decorator is the contract
+        # `FibsemMicroscope` states for its psygnals and what most of the UI does; the
+        # relay is this widget's own dialect. Still a plain bound method, so psygnal can
+        # hold it weakly and match it at disconnect time.
+        self.fm.objective.position_changed.connect(self._on_objective_moved)
         self._refresh_current_position()
         self._refresh_objective_info()
         self._refresh_orientation_banner()
@@ -1266,16 +1269,13 @@ class FMOverviewWidget(QWidget):
             position, self.fm.objective.focus_position
         )
 
-    def _on_objective_signal(self, position: float, state: str) -> None:
-        """Called by psygnal, on whichever thread moved the objective. No widgets here.
-
-        The counterpart of `_on_stage_signal` -- a real method rather than the Qt
-        signal's `emit` for the reason given where it is connected.
-        """
-        self._objective_moved.emit(position, state)
-
+    @ensure_main_thread
     def _on_objective_moved(self, position: float, state: str) -> None:
         """Something moved the objective, and said where it ended up.
+
+        Reached from psygnal, which fires on whichever thread did the moving -- a
+        z-stack or an autofocus sweep runs on a worker -- so this touches widgets only
+        because the decorator has already marshalled it.
 
         The values come from the signal rather than a fresh read, so this costs nothing
         and cannot disagree with the move that prompted it. That is the whole point:
@@ -2374,7 +2374,7 @@ class FMOverviewWidget(QWidget):
         for signal, slot in (
             (self.fm.acquisition_progress_signal, self._on_progress),
             (self.microscope.stage_position_changed, self._on_stage_signal),
-            (self.fm.objective.position_changed, self._on_objective_signal),
+            (self.fm.objective.position_changed, self._on_objective_moved),
             # Subscribed since FIB-441 and never in this list, though the comment above
             # has always claimed "without exception".
             (self.fm.acquiring_changed, self._on_fm_acquiring_signal),

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -203,6 +203,8 @@ class FMOverviewWidget(QWidget):
     # And for something starting or finishing on the FM, which is reported from
     # whichever thread finished with it -- for our own runs, the acquisition worker.
     _fm_acquiring_changed = pyqtSignal(bool)
+    # position (metres), state -- relayed off whichever thread moved the objective
+    _objective_moved = pyqtSignal(float, str)
 
     def __init__(
         self,
@@ -283,6 +285,8 @@ class FMOverviewWidget(QWidget):
         self.microscope.stage_position_changed.connect(self._on_stage_signal)
         self._fm_acquiring_changed.connect(self._on_fm_acquiring_changed)
         self.fm.acquiring_changed.connect(self._on_fm_acquiring_signal)
+        self._objective_moved.connect(self._on_objective_moved)
+        self.fm.objective.position_changed.connect(self._on_objective_signal)
         self._refresh_current_position()
         self._refresh_objective_info()
         self._refresh_orientation_banner()
@@ -1248,6 +1252,38 @@ class FMOverviewWidget(QWidget):
 
         self.canvas.canvas.set_info_text("   |   ".join(parts))
 
+    def _set_objective_info(self, position: float, state: str) -> None:
+        """Render the info bar from values already in hand -- no device read.
+
+        The path the signal takes. Split out of `_refresh_objective_info` so a move can
+        update the bar from what it announced rather than by asking again.
+        """
+        self._objective_info = (
+            f"objective {position * constants.SI_TO_MILLI:.3f} mm ({state.lower()})"
+        )
+        self._refresh_stage_info()
+        self.settings_widget.set_objective_positions(
+            position, self.fm.objective.focus_position
+        )
+
+    def _on_objective_signal(self, position: float, state: str) -> None:
+        """Called by psygnal, on whichever thread moved the objective. No widgets here.
+
+        The counterpart of `_on_stage_signal` -- a real method rather than the Qt
+        signal's `emit` for the reason given where it is connected.
+        """
+        self._objective_moved.emit(position, state)
+
+    def _on_objective_moved(self, position: float, state: str) -> None:
+        """Something moved the objective, and said where it ended up.
+
+        The values come from the signal rather than a fresh read, so this costs nothing
+        and cannot disagree with the move that prompted it. That is the whole point:
+        this label used to be rebuilt from two device reads on every stage poll, and on
+        a shared connection each of those took the imaging channel (FIB-534).
+        """
+        self._set_objective_info(position, state)
+
     def _refresh_objective_info(self) -> None:
         """Re-read the objective for the info bar. Touches hardware -- call sparingly.
 
@@ -1256,24 +1292,23 @@ class FMOverviewWidget(QWidget):
         connection, so reading the objective points it at the FM, and every poll was
         doing it. It stopped a workflow task (FIB-517).
 
-        The driver now hands the connection back, so this is no longer dangerous -- but
-        it is still a round-trip per poll for a number that only changes when something
-        moves the objective, which is why it is cached rather than re-read.
+        Now a backstop rather than the usual path: `ObjectiveLens.position_changed`
+        carries the values whenever *we* move the objective, and this covers the moves we
+        do not make -- the microscope's own UI, or a routine driving the device -- at the
+        two moments something external may have acted, on entry and when an acquisition
+        or autofocus sweep finishes.
         """
         try:
-            self._objective_info = (
-                f"objective {self.fm.objective.position * constants.SI_TO_MILLI:.3f} mm"
-                f" ({self.fm.objective.state.lower()})"
-            )
+            position, state = self.fm.objective.position, self.fm.objective.state
         except Exception as e:
             logging.debug(f"No objective position for the info bar: {e}")
             self._objective_info = None
-        self._refresh_stage_info()
-        # The same read serves the start-position options, which say what each one
-        # currently means. Here rather than on its own timer so the objective is read
-        # once for both -- on a shared connection that read takes the imaging channel
-        # (FIB-517), and two of them would be two.
-        self._refresh_objective_start_options()
+            self._refresh_stage_info()
+            return
+        # `_set_objective_info` also feeds the start-position options, which say what
+        # each one currently means -- one read serving both, since on a shared
+        # connection two reads are two takes of the imaging channel (FIB-517).
+        self._set_objective_info(position, state)
 
     def _objective_state(self) -> Optional[str]:
         """Whether the objective is inserted, or None if it cannot be asked.
@@ -2339,6 +2374,10 @@ class FMOverviewWidget(QWidget):
         for signal, slot in (
             (self.fm.acquisition_progress_signal, self._on_progress),
             (self.microscope.stage_position_changed, self._on_stage_signal),
+            (self.fm.objective.position_changed, self._on_objective_signal),
+            # Subscribed since FIB-441 and never in this list, though the comment above
+            # has always claimed "without exception".
+            (self.fm.acquiring_changed, self._on_fm_acquiring_signal),
         ):
             try:
                 signal.disconnect(slot)

--- a/tests/fm/test_objective_signal.py
+++ b/tests/fm/test_objective_signal.py
@@ -1,0 +1,260 @@
+"""The objective announces its moves, so displays stop polling for them (FIB-534).
+
+Around twenty call sites outside the drivers read `fm.objective.position` or `.state`.
+On a TFS system every one of those takes the shared imaging channel, so a label that
+refreshes on each stage poll moves the microscope's own active view to the FM and back
+to fetch a millimetre reading. That is the mechanism behind FIB-517.
+
+`ObjectiveLens.position_changed` replaces the poll with a notification carrying position and
+state, as `stage_position_changed` does. Read once at the source rather than by each
+subscriber: three displays each re-reading would turn one move into six channel takes.
+
+Two things are pinned here, and the second is the one that will decay:
+
+1. the simulated objective announces every kind of move, and stays quiet when a call
+   does not actually move anything;
+2. **every** write method in **every** driver announces -- structurally, because
+   `autoscript.py` and `odemis.py` need SDKs that are absent off the microscope, and
+   because there is no single chokepoint to rely on. Delegation differs per driver:
+   the simulated `move_relative` adjusts its own field, the TFS one delegates to
+   `move_absolute`, and `insert`/`retract` delegate on the simulator but not on TFS or
+   odemis.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import fibsem
+from fibsem.fm.microscope import FluorescenceMicroscope
+
+
+@pytest.fixture
+def fm():
+    return FluorescenceMicroscope()
+
+
+@pytest.fixture
+def moves(fm):
+    """Every `(position, state)` emitted."""
+    seen = []
+    fm.objective.position_changed.connect(lambda position, state: seen.append((position, state)))
+    return seen
+
+
+class TestTheSimulatedObjectiveAnnounces:
+    def test_move_absolute(self, fm, moves):
+        fm.objective.move_absolute(fm.objective.position + 1e-4)
+        assert len(moves) == 1
+
+    def test_move_relative(self, fm, moves):
+        """Not covered by `move_absolute`: this implementation adjusts its own field."""
+        fm.objective.move_relative(1e-4)
+        assert len(moves) == 1
+
+    def test_insert(self, fm, moves):
+        fm.objective.retract()
+        moves.clear()
+
+        fm.objective.insert()
+
+        assert moves, "an insert that moved the objective announced nothing"
+
+    def test_retract(self, fm, moves):
+        fm.objective.insert()
+        moves.clear()
+
+        fm.objective.retract()
+
+        assert moves, "a retract that moved the objective announced nothing"
+
+    def test_a_parentless_objective_announces_its_own_moves(self):
+        """The signal lives on the objective, so it does not need a microscope.
+
+        The earlier design emitted through `self.parent` and so went quiet on an
+        objective built alone -- silently, which is the worst way for a notification to
+        fail.
+        """
+        from fibsem.fm.microscope import ObjectiveLens
+
+        objective = ObjectiveLens()
+        seen = []
+        objective.position_changed.connect(lambda position, state: seen.append(position))
+
+        objective.move_absolute(1e-3)
+
+        assert seen == [pytest.approx(1e-3)]
+
+
+class TestThePayload:
+    def test_it_carries_where_the_objective_actually_ended_up(self, fm, moves):
+        target = fm.objective.position + 2e-4
+
+        fm.objective.move_absolute(target)
+
+        position, state = moves[-1]
+        assert position == pytest.approx(fm.objective.position)
+        assert position == pytest.approx(target)
+        assert state == fm.objective.state
+
+    def test_the_state_travels_with_it(self, fm, moves):
+        """The info bar renders both from one line, so both have to arrive."""
+        fm.objective.insert()
+        assert moves[-1][1] == "Inserted"
+
+        fm.objective.retract()
+        assert moves[-1][1] == "Retracted"
+
+    def test_both_reads_share_one_channel_scope(self, fm, monkeypatch):
+        """What makes the payload nearly free on a TFS system.
+
+        Position and state are each a device read that takes the shared imaging channel.
+        Read under one scope they cost a single change of the microscope's active view;
+        read separately they cost two, on every move, forever.
+        """
+        from contextlib import contextmanager
+
+        entries = []
+
+        @contextmanager
+        def counting_scope():
+            entries.append(1)
+            yield
+
+        monkeypatch.setattr(fm, "active_channel", counting_scope)
+
+        fm.objective._notify_moved()
+
+        assert len(entries) == 1, (
+            f"the objective was read under {len(entries)} channel scopes; both reads "
+            f"belong in one"
+        )
+
+    def test_a_read_that_fails_does_not_break_the_move(self, fm, moves, monkeypatch):
+        """A move that worked must not report failure because the readback did not.
+
+        A stale label until the next move is the cheaper failure.
+
+        Patched through `monkeypatch`, not by assigning to the class: `state` lives on
+        `ObjectiveLens` itself, so a hand-rolled set-then-`del` removes the real property
+        rather than an override and leaves every later reader with an AttributeError --
+        which surfaces as a *process abort* rather than a failure once a Qt slot reads it
+        (FIB-329).
+        """
+        def raises(self):
+            raise RuntimeError("detector did not answer")
+
+        monkeypatch.setattr(type(fm.objective), "state", property(raises))
+
+        fm.objective.move_absolute(fm.objective.position + 1e-4)
+
+        assert moves == [], "a failed readback still emitted"
+
+
+class TestEveryDriverAnnounces:
+    """Structural, over the source of all three implementations.
+
+    A driver that silently stops announcing is a display that silently goes stale, and
+    nothing else would catch it: the TFS and odemis classes cannot be constructed here.
+    """
+
+    WRITE_METHODS = ["move_absolute", "move_relative", "insert", "retract", "home"]
+
+    @staticmethod
+    def _objective_classes() -> dict:
+        """Every `ObjectiveLens` implementation, by qualified name."""
+        found = {}
+        for module in ("fm/microscope.py", "fm/autoscript.py", "fm/odemis.py"):
+            source = (Path(fibsem.__file__).parent / module).read_text()
+            for node in ast.walk(ast.parse(source)):
+                if isinstance(node, ast.ClassDef) and "Objective" in node.name:
+                    found[f"{module}:{node.name}"] = node
+        return found
+
+    @staticmethod
+    def _announces(method: ast.FunctionDef) -> bool:
+        """Either it notifies, or it delegates to something that does."""
+        for child in ast.walk(method):
+            if not isinstance(child, ast.Call) or not isinstance(child.func, ast.Attribute):
+                continue
+            if child.func.attr in ("_notify_moved", "move_absolute", "move_relative"):
+                return True
+        return False
+
+    def test_all_three_implementations_are_found(self):
+        """Guard against the probe silently matching nothing."""
+        classes = self._objective_classes()
+        assert len(classes) == 3, f"expected three ObjectiveLens classes, found {sorted(classes)}"
+
+    @pytest.mark.parametrize("write_method", WRITE_METHODS)
+    def test_every_write_method_announces(self, write_method):
+        offenders = []
+        for name, cls in self._objective_classes().items():
+            method = next(
+                (
+                    node
+                    for node in cls.body
+                    if isinstance(node, ast.FunctionDef) and node.name == write_method
+                ),
+                None,
+            )
+            if method is None:
+                continue  # not every driver implements every one -- `home` is TFS only
+            if not self._announces(method):
+                offenders.append(f"{name}.{write_method}")
+
+        assert offenders == [], (
+            f"{offenders} move the objective without calling `_notify_moved` or "
+            f"delegating to something that does, so any display subscribed to "
+            f"`position_changed` goes stale after that call"
+        )
+
+
+class TestTheGuardsStillReadTheDevice:
+    """The boundary this design depends on, and the one most likely to erode.
+
+    `ObjectiveLens.position_changed` is for *displays*. Guards read the device, every time, because one
+    of them is a collision guard: `ThermoMicroscope.move_stage_absolute` suppresses z and
+    r from a stage move while the objective is inserted, and a stale `"Retracted"` there
+    means the stage changes height and rotates with the objective in the chamber.
+
+    That is affordable because the guards were never the polling load -- this one runs
+    once per stage move, not once per poll tick. But routing it through a cached value is
+    exactly the sort of tidy-up that reads as an optimisation, so it is pinned.
+
+    Structural, since `ThermoMicroscope` needs an SDK that is absent here.
+    """
+
+    @staticmethod
+    def _method(class_name: str, method_name: str) -> ast.FunctionDef:
+        source = (Path(fibsem.__file__).parent / "microscope.py").read_text()
+        cls = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.ClassDef) and node.name == class_name
+        )
+        return next(
+            node
+            for node in ast.walk(cls)
+            if isinstance(node, ast.FunctionDef) and node.name == method_name
+        )
+
+    def test_the_stage_move_reads_the_objective_state_directly(self):
+        guard = self._method("ThermoMicroscope", "move_stage_absolute")
+
+        reads = [
+            node
+            for node in ast.walk(guard)
+            if isinstance(node, ast.Attribute)
+            and node.attr == "state"
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "objective"
+        ]
+
+        assert reads, (
+            "move_stage_absolute no longer reads `objective.state` off the device. If "
+            "that is now a cached or pushed value, the collision guard can be wrong: a "
+            "stale 'Retracted' lets the stage move in z and rotate with the objective "
+            "inserted (FIB-534)"
+        )

--- a/tests/fm/test_objective_signal.py
+++ b/tests/fm/test_objective_signal.py
@@ -107,11 +107,15 @@ class TestThePayload:
         assert moves[-1][1] == "Retracted"
 
     def test_both_reads_share_one_channel_scope(self, fm, monkeypatch):
-        """What makes the payload nearly free on a TFS system.
+        """What keeps the payload cheap on a TFS system.
 
         Position and state are each a device read that takes the shared imaging channel.
-        Read under one scope they cost a single change of the microscope's active view;
-        read separately they cost two, on every move, forever.
+        Under one scope a move costs a single change of the microscope's active view;
+        read separately it costs two, on every move, forever.
+
+        One rather than none: this runs after the move's own scope has closed, so that
+        subscribers do not execute while the channel is held. The saving is against the
+        per-poll reads it replaces, not against zero.
         """
         from contextlib import contextmanager
 

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -2281,6 +2281,57 @@ def test_an_unreadable_objective_does_not_cost_the_stage_position(qapp, interact
     assert "objective" not in info
 
 
+def test_a_move_updates_the_info_bar_without_reading_the_device(qapp, interactive_widget):
+    """The point of FIB-534: the bar is rebuilt from what the move announced.
+
+    Reading it back would take the shared imaging channel again for numbers the signal
+    already carried -- and could disagree with the move that prompted the update.
+    """
+    widget = interactive_widget
+    reads = []
+
+    class _Counting:
+        def __init__(self, real):
+            self._real = real
+
+        def __getattr__(self, name):
+            if name in ("position", "state"):
+                reads.append(name)
+            return getattr(self._real, name)
+
+    original = widget.fm.objective
+    widget.fm.objective = _Counting(original)
+    try:
+        widget._on_objective_moved(1.2345e-2, "Inserted")
+        info = widget.canvas.canvas._info_text
+    finally:
+        widget.fm.objective = original
+
+    assert "objective 12.345 mm (inserted)" in (info or "")
+    assert "position" not in reads and "state" not in reads, (
+        f"the info bar re-read the device after being told: {reads}"
+    )
+
+
+def test_the_objective_signal_is_dropped_on_close(qapp, interactive_widget):
+    """psygnal outlives the widget and holds a bound method of a torn-down Qt object.
+
+    Closing the tab and then moving the objective from anywhere else was the segfault
+    `closeEvent` already guards for the stage; this is the same for the objective.
+    """
+    widget = interactive_widget
+    objective = widget.fm.objective
+    before = len(objective.position_changed)
+    assert before, "the widget never subscribed -- the test proves nothing"
+
+    widget.close()
+
+    assert len(objective.position_changed) < before, (
+        "the widget is still subscribed after close, so the next objective move emits "
+        "into a torn-down Qt object"
+    )
+
+
 def test_the_stage_marker_carries_no_caption(qapp, interactive_widget):
     """It sits on top of the data, and a caption riding along with the crosshair
     obscures the sample it is pointing at. The info bar says what it is instead."""


### PR DESCRIPTION
Around twenty call sites outside the drivers read `fm.objective.position` or `.state`. On a TFS system every one of those takes the shared imaging channel, so a label refreshed on each stage poll moves the microscope's own active view to the FM and back to fetch a millimetre reading.

That is the mechanism behind FIB-517 — the overview info bar did exactly this, on every stage poll, and it stopped a workflow task. The locking made it safe; this makes it stop happening.

`ObjectiveLens.position_changed(position, state)` replaces the poll with a notification.

## On the objective, not the microscope

Following `Stage.position_changed` (`fibsem/microscopes/_stage.py:225`), which is the same shape already in the tree. Two things fall out of it: the name stays unambiguous, since `objective_position_changed` already means something else on the lamella widget and is a spinbox slot name in the objective widget; and an objective built without a parent announces its own moves, where the first draft reached through `self.parent` and so went silently quiet.

## There is no chokepoint to emit from

The issue assumed every move funnels through `move_absolute`. It does not, and the shape differs per driver:

| | `move_relative` | `insert` / `retract` |
|---|---|---|
| simulator | adjusts its own field | delegates |
| TFS | delegates | direct `detector.insert()` |
| odemis | direct `moveRel` | direct `moveAbs` |

Emitting from `move_absolute` alone would have missed relative moves on two of three drivers and insert/retract on two of three. So every write method announces, and a structural test enforces it across all three implementations — a driver that silently stops announcing is a display that silently goes stale, and nothing else would catch it, since neither the TFS nor the odemis class can be constructed without an SDK that is absent off the microscope.

## It carries the values

For the reason `stage_position_changed` does: three displays each re-reading would turn one move into six channel takes rather than two.

Both reads go under **one** `active_channel()` scope, so a move costs **one** extra take of the shared channel rather than two. Not zero: the readback runs after the move's own scope has closed, deliberately, because psygnal is synchronous and subscribers must not execute while the channel is held. There is a test pinning the single scope, because splitting it would silently double the cost on every move forever.

The saving is against the per-poll reads this replaces — a read per poll tick by each of three displays — not against zero.

A readback that raises is logged and swallowed. A move that worked must not report failure because the readback did not; a stale label until the next move is the cheaper failure.

## Guards are deliberately not on this

`move_stage_absolute` suppresses z and r from a stage move while the objective is inserted — a collision guard. A stale `"Retracted"` there means the stage changes height and rotates with the objective in the chamber, so it keeps reading the device, and a test pins that boundary.

That is affordable because the guards were never the polling load: `move_stage_absolute` reads once per stage move, workflow gates once per task. The cost was always reads on a *repeating* GUI signal. The full classification of every guard by what a stale value costs is on FIB-534.

## One consumer, on purpose

The overview info bar now rebuilds from the payload with no device read, with a test that fails if it re-reads. `objective_control_widget.py` and `quad_view.py` are **FIB-576**, deferred until this has run on a microscope — if the notification behaves differently on real hardware, one converted consumer is a smaller thing to debug than three. The control widget also needs care its own right: its spinbox drives moves, so subscribing closes a `valueChanged → move → position_changed → setValue` loop.

## How the subscription is marshalled

psygnal fires on whichever thread moved the objective — a z-stack or an autofocus sweep runs on a worker — so the slot that touches widgets has to be marshalled.

Done with `@superqt.ensure_main_thread`, which is both the contract `FibsemMicroscope` states for its psygnals and what most of the UI actually does. Counted across `fibsem/ui` and `fibsem/applications`:

| | count |
|---|---|
| `@ensure_main_thread` | 14, across eight widgets |
| relay through a Qt signal | 5 — **four of them in this file** |

The first draft used the relay, to match the three subscriptions immediately above it. That looked like a convention from the inside and is really this widget's own dialect, so it was collapsed: one signal and one method fewer, same marshalling.

The part of the relay that was *not* about threading still holds, and is easy to lose in the simplification. Connecting `signal.emit` directly would break teardown — PyQt rebuilds that wrapper on every attribute access, so psygnal can neither hold it weakly nor match it at disconnect time, and stays silent when the disconnect removes nothing. A decorated method keeps both properties; `test_the_objective_signal_is_dropped_on_close` is what pins it.

The three other relays in this file are left alone. Converting them is its own change.

## Also

`FMOverviewWidget.closeEvent` claims to disconnect "every psygnal this widget subscribed to, without exception". `fm.acquiring_changed` had never been in that list, subscribed since FIB-441 — same failure mode the comment describes, where an emit into a Qt object already torn down on the C++ side is a segfault rather than an exception. Fixed alongside.

## Verification

The structural test was run against `origin/main` before being trusted: it would have failed there for **all five** write methods across all three drivers, so it discriminates rather than passing vacuously. Seven mutants killed, each by its intended test — including splitting the channel scope and emitting a wrong position.

1674 pass across `tests/fm` and `tests/ui`. Parse-checked for Python 3.8.