### PR TITLE
[fix] Marshal the lamella rows' refresh to the GUI thread (FIB-565)

### DIFF
--- a/fibsem/applications/autolamella/ui/lamella_card_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_card_widget.py
@@ -16,6 +16,8 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from superqt import ensure_main_thread
+
 from fibsem.ui.icon import fibsem_icon
 
 from fibsem.applications.autolamella.structures import DefectState, DefectType, Lamella
@@ -184,6 +186,7 @@ class LamellaCardWidget(QWidget):
 
     # ------------------------------------------------------------------
 
+    @ensure_main_thread
     def refresh(self) -> None:
         """Re-read all display fields from the stored Lamella."""
         self._name_label.setText(self.lamella.name)

--- a/fibsem/applications/autolamella/ui/lamella_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_list_widget.py
@@ -19,6 +19,8 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from superqt import ensure_main_thread
+
 from fibsem.ui.icon import fibsem_icon
 
 from fibsem.applications.autolamella.structures import (
@@ -165,8 +167,16 @@ class LamellaRowWidget(QWidget):
 
         # Connect to evented fields so only this row updates when its data changes.
         # task_history is a plain List so append won't fire; task_state.events covers
-        # in-progress and completion transitions. type: ignore because @evented adds
-        # .events dynamically and pyright can't see it.
+        # in-progress and completion transitions.
+        #
+        # `task_state.name`/`.status` are written by the running workflow
+        # (`workflows/tasks/base.py:234,239`) on the FunctionWorker thread, and psygnal
+        # delivers synchronously on the emitting thread -- so `refresh` carries
+        # @ensure_main_thread (FIB-565). `defect` and `description` are only ever
+        # written by GUI widgets; marshalling is a no-op for them, because
+        # ensure_main_thread runs inline when already on the GUI thread.
+        #
+        # type: ignore because @evented adds .events dynamically and pyright can't see it.
         lamella.task_state.events.name.connect(self.refresh)    # type: ignore[union-attr]
         lamella.task_state.events.status.connect(self.refresh)  # type: ignore[union-attr]
         lamella.events.defect.connect(self.refresh)             # type: ignore[union-attr]
@@ -229,6 +239,7 @@ class LamellaRowWidget(QWidget):
         self._popup.set_image(self.lamella.get_thumbnail())
         self._popup.show_near_cursor()
 
+    @ensure_main_thread
     def refresh(self) -> None:
         """Re-read all display fields from the stored Lamella."""
         self.name_label.setText(self.lamella.name)

--- a/fibsem/applications/autolamella/ui/lamella_name_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_name_list_widget.py
@@ -33,6 +33,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from superqt import ensure_main_thread
 
 from fibsem.applications.autolamella.structures import (
     AutoLamellaTaskStatus,
@@ -158,20 +159,33 @@ class _LamellaRow(QWidget):
         # Redraw when the model changes, whichever widget changed it. Only `description`
         # was subscribed, so a defect set anywhere else left a stale icon here (FIB-564).
         #
-        # Deliberately NOT subscribing to `task_state.events.name/.status`, though the
-        # row draws those too and `lamella_list_widget`/`lamella_card_widget` both do.
-        # Those two fields are written by the running workflow
+        # `task_state.name`/`.status` are written by the running workflow
         # (`workflows/tasks/base.py:234,239`) on the FunctionWorker thread, and psygnal
-        # delivers synchronously on the emitting thread -- so the callback would touch Qt
-        # widgets off the GUI thread. `defect` and `description` are only ever written by
-        # GUI widgets, so both are safe. The status column stays refresh-driven.
+        # delivers synchronously on the emitting thread. This row skipped them for that
+        # reason until `refresh` gained @ensure_main_thread (FIB-565); with the callback
+        # marshalled they are safe, and the row now tracks a running workflow like
+        # `lamella_list_widget` and `lamella_card_widget` do.
+        #
+        # `defect` and `description` are only ever written by GUI widgets, so
+        # marshalling is a no-op for them: ensure_main_thread runs inline when the
+        # caller is already on the GUI thread.
         #
         # No matching disconnect: the lamella outlives the row, but psygnal holds bound
         # methods weakly and `set_lamella` keeps no reference to the rows it replaces, so
-        # a cleared row is collected and its subscriptions go with it.
+        # a cleared row is collected and its subscriptions go with it. The decorator does
+        # not change that -- verified that a decorated bound method is still dropped on GC.
         # type: ignore because @evented adds .events dynamically.
         self.lamella.events.description.connect(self.refresh)  # type: ignore[union-attr]
         self.lamella.events.defect.connect(self.refresh)  # type: ignore[union-attr]
+
+        # Guarded, unlike the sibling widgets, because this list also renders duck-typed
+        # positions that are not `Lamella` and carry no `task_state` at all -- which is
+        # why `_lamella_status_text` reaches for it with `getattr` too. The siblings take
+        # real `Lamella` objects, where the field always exists.
+        task_state = getattr(self.lamella, "task_state", None)
+        if task_state is not None:
+            task_state.events.name.connect(self.refresh)  # type: ignore[union-attr]
+            task_state.events.status.connect(self.refresh)  # type: ignore[union-attr]
 
         self.refresh()
 
@@ -206,6 +220,7 @@ class _LamellaRow(QWidget):
         if reply == QMessageBox.Yes:
             self.remove_clicked.emit(self.lamella)
 
+    @ensure_main_thread
     def refresh(self) -> None:
         self.name_label.setText(self.lamella.name)
         self.setToolTip(self.lamella.description or "")

--- a/tests/ui/test_lamella_defect_sync.py
+++ b/tests/ui/test_lamella_defect_sync.py
@@ -72,28 +72,65 @@ def test_row_redraws_when_the_defect_changes_elsewhere(row, lamella):
     )
 
 
-def test_row_does_not_subscribe_to_task_state(row, lamella):
-    """The row draws task status but must NOT subscribe to it.
+def test_row_redraws_from_a_task_state_event(row, lamella):
+    """The row subscribes to task_state, so a running workflow keeps it current.
 
-    `task_state.name`/`.status` are written by the running workflow
-    (`workflows/tasks/base.py:234,239`) on the FunctionWorker thread, and psygnal
-    delivers synchronously on the emitting thread -- so a subscription here would call
-    `setText` off the GUI thread. `defect` and `description` are only ever written by
-    GUI widgets, which is what makes those two safe to watch.
-
-    Pinned as a test because the obvious "match the sibling widgets" tidy-up reintroduces
-    it, and the failure it causes is a crash under load rather than a red test.
+    It deliberately did not, until FIB-565: `task_state.name`/`.status` are written by
+    the workflow on the FunctionWorker thread and psygnal delivers synchronously on the
+    emitting thread, so the callback reached Qt off the GUI thread. `refresh` is now
+    marshalled with @ensure_main_thread, which is what makes this safe -- see the
+    thread test below, which is the one that would catch the decorator being dropped.
     """
     from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
 
     lamella.task_state.name = "Rough Milling"
     lamella.task_state.status = AutoLamellaTaskStatus.InProgress
 
-    assert row.status_label.text() == "", (
-        "the row redrew from a task_state event -- that fires on the worker thread"
-    )
-    row.refresh()  # the supported path: the host refreshes on the GUI thread
     assert row.status_label.text() == "Rough Milling"
+
+
+def test_task_state_refresh_is_marshalled_to_the_gui_thread(qapp, row, lamella):
+    """A worker-thread write must redraw the row *on the GUI thread*.
+
+    This is the invariant FIB-565 turns on, and the only one that fails if
+    @ensure_main_thread is removed from `refresh`. Asserting the label updated is not
+    enough on its own: Qt does not raise on a cross-thread `setText`, it corrupts or
+    crashes under load, so an undecorated `refresh` would still leave the right text
+    behind and pass.
+
+    The thread is observed by spying on `setText`, which `refresh` calls. Patched on the
+    label instance rather than on `refresh`: psygnal captured the bound `refresh` at
+    connect time, so replacing it on the row afterwards is never seen by the signal.
+    """
+    import threading
+
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+
+    main_thread = threading.current_thread()
+    seen: list = []
+    original = row.status_label.setText
+
+    def spy(text: str) -> None:
+        seen.append(threading.current_thread())
+        original(text)
+
+    row.status_label.setText = spy  # type: ignore[method-assign]
+
+    def write_from_worker() -> None:
+        lamella.task_state.name = "Polishing"
+        lamella.task_state.status = AutoLamellaTaskStatus.InProgress
+
+    worker = threading.Thread(target=write_from_worker, name="fib565-worker")
+    worker.start()
+    worker.join()
+    qapp.processEvents()
+
+    assert seen, "the row never redrew -- the task_state subscription is missing"
+    assert all(t is main_thread for t in seen), (
+        f"refresh touched Qt from {[t.name for t in seen]}, not the GUI thread -- "
+        "@ensure_main_thread has been dropped from refresh"
+    )
+    assert row.status_label.text() == "Polishing"
 
 
 def test_row_redraws_when_the_description_changes(row, lamella):
@@ -152,3 +189,45 @@ def test_every_host_of_the_list_can_persist_a_defect(module, widget, handler):
     )
     assert f"def {handler}" in src, f"{widget}.{handler} is missing"
     assert "experiment.save()" in src, f"{widget}.{handler} must persist the change"
+
+
+@pytest.mark.parametrize(
+    "module, widget",
+    [
+        (
+            "fibsem.applications.autolamella.ui.lamella_name_list_widget",
+            "_LamellaRow",
+        ),
+        ("fibsem.applications.autolamella.ui.lamella_list_widget", "LamellaRowWidget"),
+        (
+            "fibsem.applications.autolamella.ui.lamella_card_widget",
+            "LamellaCardWidget",
+        ),
+    ],
+)
+def test_every_task_state_subscriber_marshals_its_refresh(module, widget):
+    """All three lists subscribe to task_state, so all three must marshal (FIB-565).
+
+    The behavioural test above covers `_LamellaRow` only -- the other two need a
+    microscope-shaped host to construct. This reads the source instead, which is enough
+    to catch the failure that matters: someone removing @ensure_main_thread from one
+    widget while the subscription stays.
+
+    Resolved through `importlib` rather than a hardcoded path: these three files moved
+    package twice in one day (FIB-558/559), and a path-based read would have broken
+    silently rather than failed loudly.
+    """
+    import importlib
+    from pathlib import Path
+
+    src = Path(importlib.import_module(module).__file__).read_text()
+
+    assert "task_state.events" in src, (
+        f"{widget} no longer subscribes to task_state -- if that is deliberate, this "
+        "test and FIB-565 both need updating"
+    )
+    assert "from superqt import ensure_main_thread" in src, f"{widget} lost the import"
+    assert "    @ensure_main_thread\n    def refresh(self)" in src, (
+        f"{widget}.refresh is not marshalled, but it subscribes to task_state, which "
+        "the workflow writes from the FunctionWorker thread (FIB-565)"
+    )


### PR DESCRIPTION
Three lamella list widgets subscribe to `task_state.events.name/.status`. Those fields are
written by the running workflow (`workflows/tasks/base.py:234,239`) on the FunctionWorker
thread, and **psygnal delivers synchronously on the emitting thread** — so `refresh`
(`setText`, `setStyleSheet`, `setIcon`, `setToolTip`) ran on a worker thread on every task
transition.

Cross-thread widget access is undefined rather than fatal, which is why this was neither an
exception nor a red test. Same reason FIB-329 went misdiagnosed for months.

`refresh` now carries `@ensure_main_thread` in all three widgets.

## Checked before relying on it

`ensure_main_thread` + psygnal is not an obvious combination, so all four properties were
verified empirically rather than assumed:

| | result |
| -- | -- |
| psygnal accepts the wrapped bound method | OK — `refresh(self)` introspects to the right arity |
| main-thread emit | stays **synchronous** (runs inline), so defect/description paths and the FIB-564 tests are unchanged |
| worker-thread emit | marshalled to `MainThread` |
| psygnal weakref auto-disconnect | **preserved** |

The last one mattered most. These rows have **no explicit disconnect** — teardown relies on
psygnal holding bound methods weakly, so a cleared row is collected and its subscriptions go
with it. If the decorator had introduced a strong reference, this would have traded a
threading bug for the FIB-550 teardown crash.

## The third widget gets its subscriptions back

`lamella_name_list_widget` was deliberately denied `task_state` subscriptions under #354,
*because of* this hazard — with a test pinning their absence. Removing the hazard removes the
reason, so all three lists now track a running workflow identically rather than one of them
silently going stale mid-run.

**Its subscription is guarded where the siblings' are not.** This list also renders duck-typed
positions that carry no `task_state` — which is why `_lamella_status_text` already reaches for
it with `getattr`. Subscribing unconditionally crashed exactly the case that guard exists for;
an existing test caught it. The asymmetry is commented so it does not read as an oversight.

## On the tests

`test_row_does_not_subscribe_to_task_state` is replaced by two, and **only one is
load-bearing**. Qt does not raise on a cross-thread `setText` — it corrupts under load — so
asserting the label updated passes with *or without* the decorator. The real test spies on
`setText` to observe which thread `refresh` ran on.

The differential was checked both ways: strip `@ensure_main_thread` and exactly that test
fails; restore it and all pass.

The spy is patched on the label, not on `refresh` — psygnal captures the bound method at
connect time, so replacing `refresh` on the row afterwards is never seen by the signal. That
mistake produced a silently-vacuous test earlier in this series.

A parametrised source check keeps the import, decorator and subscription together across all
three widgets, resolved through `importlib` rather than a hardcoded path — these files changed
package twice this week (#356, #359), and a path-based read breaks silently rather than loudly.

## Verification

Full suite offscreen: **4012 passed, 1 failed** — FIB-561, which reads the working directory.