### PR TITLE
[fix] Keep a cleared selection cleared, in the header and on the cards (FIB-577, FIB-578)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1018,8 +1018,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # waiting for a scheduled first task (before any task status arrives).
         self.set_workflow_running()
         # Clear selections after starting workflow
-        self.lamella_workflow_widget.lamella_list._on_select_all(False)
-        self.lamella_workflow_widget.workflow._on_select_all(False)
+        self.lamella_workflow_widget.lamella_list.set_all_selected(False)
+        self.lamella_workflow_widget.workflow.set_all_selected(False)
 
     def _on_workflow_selection_changed(self, _=None) -> None:
         """Enable the run button only when at least one lamella and one task are selected."""
@@ -1853,8 +1853,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         # Clear the selection, as starting a workflow does — the work is committed,
         # and leaving it ticked invites adding the same batch twice.
-        self.lamella_workflow_widget.lamella_list._on_select_all(False)
-        self.lamella_workflow_widget.workflow._on_select_all(False)
+        self.lamella_workflow_widget.lamella_list.set_all_selected(False)
+        self.lamella_workflow_widget.workflow.set_all_selected(False)
 
     def _on_queue_changed(self, info: dict) -> None:
         """The queue was edited between tasks — no task lifecycle to hang it off."""

--- a/fibsem/applications/autolamella/ui/lamella_card_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_card_widget.py
@@ -298,6 +298,8 @@ class LamellaCardContainer(QWidget):
         card = self._cards.pop(lamella.id, None)
         if card is not None:
             card.deleteLater()
+            if self._selected_id == lamella.id:
+                self._selected_id = None
             self._rebuild_grid()
 
     def refresh_lamella(self, lamella: Lamella) -> None:
@@ -313,6 +315,11 @@ class LamellaCardContainer(QWidget):
         for card in self._cards.values():
             card.deleteLater()
         self._cards.clear()
+        # Lamella ids are stable, and the host clears then re-adds the same set on
+        # every rebuild -- so a surviving id would name a card that is drawn
+        # unselected while the container thinks it is selected, and the next click on
+        # it would toggle off rather than select (FIB-578).
+        self._selected_id = None
 
     def select_lamella(self, name: str) -> None:
         """Programmatically select the card matching name. Does NOT emit lamella_selected."""

--- a/fibsem/applications/autolamella/ui/lamella_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_list_widget.py
@@ -319,7 +319,7 @@ class LamellaListWidget(QWidget):
         self._list.setFocusPolicy(Qt.NoFocus)
         layout.addWidget(self._list)
 
-        self._header.select_all_changed.connect(self._on_select_all)
+        self._header.select_all_changed.connect(self.set_all_selected)
 
         self._btn_visible = {
             "edit": True,
@@ -401,6 +401,24 @@ class LamellaListWidget(QWidget):
     def clear(self) -> None:
         self._list.clear()
 
+    def set_all_selected(self, checked: bool) -> None:
+        """Tick or untick every row, and bring the header checkbox with them.
+
+        Public because the header is not the only thing that clears the selection --
+        starting a run and adding to the queue both do. Those callers used to invoke
+        the header's slot directly, which left the box reading "Select All" over a
+        list where nothing was ticked (FIB-577).
+        """
+        for i in range(self._list.count()):
+            row = self._row(i)
+            row.checkbox.blockSignals(True)
+            row.checkbox.setChecked(checked)
+            row.checkbox.blockSignals(False)
+        # Redundant when the header emitted into here (it is already right), and
+        # load-bearing for every other caller. Cheap enough not to branch on.
+        self._sync_select_all()
+        self.selection_changed.emit(self.get_selected())
+
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------
@@ -416,14 +434,6 @@ class LamellaListWidget(QWidget):
     def _on_remove_clicked(self, lamella: Lamella) -> None:
         self.remove_lamella(lamella)
         self.remove_requested.emit(lamella)
-
-    def _on_select_all(self, checked: bool) -> None:
-        for i in range(self._list.count()):
-            row = self._row(i)
-            row.checkbox.blockSignals(True)
-            row.checkbox.setChecked(checked)
-            row.checkbox.blockSignals(False)
-        self.selection_changed.emit(self.get_selected())
 
     def _on_row_selection_changed(self, *_) -> None:
         self._sync_select_all()

--- a/fibsem/applications/autolamella/ui/workflow_config_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_config_widget.py
@@ -253,7 +253,7 @@ class WorkflowConfigWidget(QWidget):
         self._list.setFocusPolicy(Qt.NoFocus)
         layout.addWidget(self._list)
 
-        self._header.select_all_changed.connect(self._on_select_all)
+        self._header.select_all_changed.connect(self.set_all_selected)
         self._header.add_task_clicked.connect(self.add_task_clicked)
         self._list.reordered.connect(self._on_reordered)
 
@@ -341,6 +341,26 @@ class WorkflowConfigWidget(QWidget):
         self._list.clear()
         self._checked.clear()
 
+    def set_all_selected(self, checked: bool) -> None:
+        """Tick or untick every row, and bring the header and the cache with them.
+
+        Public because the header is not the only thing that clears the selection --
+        starting a run and adding to the queue both do (FIB-577). `_checked` matters
+        as much as the header here: it is what `_on_reordered` rebuilds rows from, so
+        leaving it stale made a drag-and-drop resurrect a selection the user had
+        already seen cleared.
+        """
+        for i in range(self._list.count()):
+            row = self._row(i)
+            row.checkbox.blockSignals(True)
+            row.checkbox.setChecked(checked)
+            row.checkbox.blockSignals(False)
+            self._checked[id(row.task)] = checked
+        # Redundant when the header emitted into here (it is already right), and
+        # load-bearing for every other caller. Cheap enough not to branch on.
+        self._sync_select_all()
+        self.selection_changed.emit(self.get_selected())
+
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------
@@ -357,14 +377,6 @@ class WorkflowConfigWidget(QWidget):
     def _on_remove_clicked(self, task: AutoLamellaTaskDescription) -> None:
         self.remove_task(task)
         self.remove_requested.emit(task)
-
-    def _on_select_all(self, checked: bool) -> None:
-        for i in range(self._list.count()):
-            row = self._row(i)
-            row.checkbox.blockSignals(True)
-            row.checkbox.setChecked(checked)
-            row.checkbox.blockSignals(False)
-        self.selection_changed.emit(self.get_selected())
 
     def _on_row_selection_changed(self, task: AutoLamellaTaskDescription, checked: bool) -> None:
         self._checked[id(task)] = checked

--- a/tests/ui/test_selection_clearing.py
+++ b/tests/ui/test_selection_clearing.py
@@ -1,0 +1,195 @@
+"""Clearing a selection has to clear every part of it (FIB-577, FIB-578).
+
+Two bugs from the same shape: a widget that holds selection state in more places than
+the checkboxes the user can see, and a clear path that only reached some of them.
+
+* `LamellaListWidget` / `WorkflowConfigWidget` -- the header "Select All" box, and (in
+  the workflow one) a `_checked` cache that reorders rebuild rows from. Starting a run
+  and adding to the queue both clear the selection, and both used to call the header's
+  own slot, which updates neither.
+* `LamellaCardContainer` -- `_selected_id`, which survived the clear half of the
+  clear-then-re-add rebuild the host performs on every experiment change.
+
+The tests drive the public API the hosts actually call, and additionally the header
+signal, because that is the path where the old code was already correct and a fix must
+not regress it.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    Lamella,
+)
+from fibsem.applications.autolamella.ui.lamella_card_widget import LamellaCardContainer
+from fibsem.applications.autolamella.ui.lamella_list_widget import LamellaListWidget
+from fibsem.applications.autolamella.ui.workflow_config_widget import WorkflowConfigWidget
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def lamellae(tmp_path):
+    return [Lamella(path=str(tmp_path), number=i, petname=f"lamella-{i}") for i in range(3)]
+
+
+@pytest.fixture()
+def tasks():
+    return [
+        AutoLamellaTaskDescription(name=f"task-{i}", supervise=False, required=True)
+        for i in range(3)
+    ]
+
+
+def _lamella_list(lamellae, checked: bool) -> LamellaListWidget:
+    widget = LamellaListWidget()
+    for lamella in lamellae:
+        widget.add_lamella(lamella, checked=checked)
+    return widget
+
+
+def _workflow_list(tasks, checked: bool) -> WorkflowConfigWidget:
+    widget = WorkflowConfigWidget()
+    for task in tasks:
+        widget.add_task(task, checked=checked)
+    return widget
+
+
+# ── FIB-577: the header follows the rows ─────────────────────────────────────
+
+
+def test_clearing_the_lamella_selection_unticks_the_header(qapp, lamellae):
+    """The reported bug: rows cleared, header still reading "Select All"."""
+    widget = _lamella_list(lamellae, checked=True)
+    assert widget._header.checkbox_all.checkState() == Qt.Checked
+
+    widget.set_all_selected(False)
+
+    assert widget.get_selected() == []
+    assert widget._header.checkbox_all.checkState() == Qt.Unchecked
+
+
+def test_clearing_the_task_selection_unticks_the_header(qapp, tasks):
+    widget = _workflow_list(tasks, checked=True)
+    assert widget._header.checkbox_all.checkState() == Qt.Checked
+
+    widget.set_all_selected(False)
+
+    assert widget.get_selected() == []
+    assert widget._header.checkbox_all.checkState() == Qt.Unchecked
+
+
+def test_reorder_after_a_clear_does_not_resurrect_the_selection(qapp, tasks):
+    """`_on_reordered` rebuilds rows from `_checked`, so the cache has to be cleared too.
+
+    Otherwise a drag-and-drop after the run started re-ticks everything, and the next
+    Run Workflow queues tasks the user watched being cleared.
+    """
+    widget = _workflow_list(tasks, checked=True)
+
+    widget.set_all_selected(False)
+    assert set(widget._checked.values()) == {False}
+
+    widget._on_reordered(list(reversed(tasks)))
+
+    assert widget.get_selected() == []
+    assert widget._header.checkbox_all.checkState() == Qt.Unchecked
+
+
+def test_selecting_all_ticks_every_row(qapp, lamellae):
+    """The other direction, for a list that starts empty-handed."""
+    widget = _lamella_list(lamellae, checked=False)
+
+    widget.set_all_selected(True)
+
+    assert len(widget.get_selected()) == len(lamellae)
+    assert widget._header.checkbox_all.checkState() == Qt.Checked
+
+
+@pytest.mark.parametrize("checked", [True, False])
+def test_the_header_checkbox_still_drives_the_rows(qapp, lamellae, checked):
+    """Regression guard: the header signal now lands on the public method."""
+    widget = _lamella_list(lamellae, checked=not checked)
+    seen = []
+    widget.selection_changed.connect(seen.append)
+
+    widget._header.checkbox_all.setChecked(checked)
+
+    assert len(widget.get_selected()) == (len(lamellae) if checked else 0)
+    assert seen, "the header path must still emit selection_changed"
+
+
+# ── FIB-578: the card container forgets what was selected ────────────────────
+
+
+def test_first_click_after_a_rebuild_selects_rather_than_deselects(qapp, lamellae):
+    """The host clears and re-adds the same lamellae, whose ids are stable.
+
+    A `_selected_id` surviving the clear made the container disagree with the card it
+    had just built, and the click that should select took the toggle-off branch.
+    """
+    container = LamellaCardContainer(columns=1)
+    for lamella in lamellae:
+        container.add_lamella(lamella)
+    container._on_card_clicked(lamellae[0])
+    assert container._selected_id == lamellae[0].id
+
+    container.clear()
+    assert container._selected_id is None
+    for lamella in lamellae:
+        container.add_lamella(lamella)
+
+    seen = []
+    container.lamella_selected.connect(seen.append)
+    container._on_card_clicked(lamellae[0])
+
+    assert seen == [lamellae[0]]
+    assert container._selected_id == lamellae[0].id
+
+
+def test_clicking_the_selected_card_still_deselects(qapp, lamellae):
+    """Toggle-off is deliberate and stays -- the bug was when it fired, not that it does."""
+    container = LamellaCardContainer(columns=1)
+    for lamella in lamellae:
+        container.add_lamella(lamella)
+    container._on_card_clicked(lamellae[0])
+
+    seen = []
+    container.lamella_selected.connect(seen.append)
+    container._on_card_clicked(lamellae[0])
+
+    assert seen == [None]
+    assert container._selected_id is None
+
+
+def test_removing_the_selected_lamella_clears_the_selection(qapp, lamellae):
+    container = LamellaCardContainer(columns=1)
+    for lamella in lamellae:
+        container.add_lamella(lamella)
+    container._on_card_clicked(lamellae[0])
+
+    container.remove_lamella(lamellae[0])
+
+    assert container._selected_id is None
+
+
+def test_removing_an_unselected_lamella_leaves_the_selection_alone(qapp, lamellae):
+    container = LamellaCardContainer(columns=1)
+    for lamella in lamellae:
+        container.add_lamella(lamella)
+    container._on_card_clicked(lamellae[0])
+
+    container.remove_lamella(lamellae[1])
+
+    assert container._selected_id == lamellae[0].id


### PR DESCRIPTION
Two bugs from the same shape, both from today's testing session: selection state held in more places than the checkboxes the user can see, and clear paths that only reached some of them.

## Select All (FIB-577)

`_on_select_all` ticked the rows but never called `_sync_select_all()`. From the header's own signal the checkbox was already right, so the gap only showed on the programmatic calls — starting a run, and adding to the queue — which left the box reading "Select All" over a list where nothing was ticked. That was the reported symptom.

The workflow list had a second one behind it: it never updated `_checked`, and that cache is what `_on_reordered` rebuilds rows from (defaulting to `True`). So a drag-reorder after the clear re-ticked everything, and the next Run Workflow would queue tasks the user had watched being cleared:

```
after clear   -> selected: 0  header: 2  _checked cache: [True, True, True]
after reorder -> selected: 3
```

Both widgets now expose `set_all_selected()`, which syncs the header and the cache before emitting; the header signal connects straight to it. All four call sites in `AutoLamellaMainUI` use it — including the queue-add path at :1856, which had the same bug and was not in the report.

## Cards (FIB-578)

`clear()` left `_selected_id` set. The host clears and re-adds the same lamellae on every rebuild and their ids are stable, so the container went on believing a card was selected while that card drew unselected — and the next click on it took the toggle-off branch instead of selecting. The first click was silently eaten. Cleared there and in `remove_lamella()`.

This came in as the question "should the user be able to deselect a lamella on the lamella editor?" — they can, by design, and that stays; the bug was when the toggle fired, not that it exists.

## Testing

10 headless tests in `tests/ui/test_selection_clearing.py`. Stashing the fix fails 6 of them; the 4 that still pass are the deliberate regression guards — the header-driven path, toggle-off, and removing an unselected card — which pin behaviour this must not change.

Also checked against the composite widget the main UI actually holds, so the call sites are verified against real types rather than the leaf widgets alone. 333 pass across the affected files, including the FIB-565 threading tests this now sits on top of (the `@ensure_main_thread` decorators on `refresh` are untouched — verified by count against `origin/main`).

## Not included, on purpose

- An empty list still shows a ticked Select All: `_sync_select_all` returns early on zero rows and `clear()` does not touch the header. Same family, different path — kept out to hold this diff to the reported bug.
- `channel_list_widget.py:1035` and `milling_stage_list_widget.py:696` have the identical shape, but no callers outside their own header, so no live bug. Tracked separately.