### PR TITLE
[fix][FIB-587] make the milling and channel lists' select-all bring the header with it

### DIFF
--- a/fibsem/ui/fm/widgets/channel_list_widget.py
+++ b/fibsem/ui/fm/widgets/channel_list_widget.py
@@ -682,7 +682,7 @@ class ChannelListWidget(QWidget):
         self._status_timer.setSingleShot(True)
         self._status_timer.timeout.connect(lambda: self._status_label.setVisible(False))
 
-        self._header.select_all_changed.connect(self._on_select_all)
+        self._header.select_all_changed.connect(self.set_all_selected)
         self._header.add_clicked.connect(self._on_add_channel)
         self._list.reordered.connect(self._on_reordered)
 
@@ -786,6 +786,29 @@ class ChannelListWidget(QWidget):
             if self._row(i).channel is self._selected_channel:
                 self.remove_channel_by_index(i)
                 return
+
+    def set_all_selected(self, checked: bool) -> None:
+        """Enable or disable every channel, and bring the header and cache with them.
+
+        Nothing can reach this today: the only connection is the header checkbox,
+        which is constructed hidden and never shown. It is written to survive that
+        changing, because the cache write and the header sync are exactly what the
+        AutoLamella lists were missing (FIB-577), and the cache one is not cosmetic.
+        `_checkbox_states` is what `_on_reordered` rebuilds rows from, so leaving it
+        stale means a drag-and-drop after a clear silently re-ticks every channel --
+        and the rebuild emits no `enabled_changed`, so the consumer that just heard
+        "nothing enabled" would go on believing it while the list shows otherwise.
+        """
+        for i in range(self._list.count()):
+            row = self._row(i)
+            row.checkbox.blockSignals(True)
+            row.checkbox.setChecked(checked)
+            row.checkbox.blockSignals(False)
+            self._checkbox_states[id(row.channel)] = checked
+        self._sync_select_all()
+        self.enabled_changed.emit(
+            [self._row(i).channel for i in range(self._list.count())] if checked else []
+        )
 
     def set_live_acquisition_controls(self, enabled: bool) -> None:
         """Stub for ChannelSettingsWidget compatibility — no separate live list."""
@@ -1031,16 +1054,6 @@ class ChannelListWidget(QWidget):
             self._row(i).channel for i in range(self._list.count())
             if self._row(i).checkbox.isChecked()
         ])
-
-    def _on_select_all(self, checked: bool) -> None:
-        for i in range(self._list.count()):
-            row = self._row(i)
-            row.checkbox.blockSignals(True)
-            row.checkbox.setChecked(checked)
-            row.checkbox.blockSignals(False)
-        self.enabled_changed.emit(
-            [self._row(i).channel for i in range(self._list.count())] if checked else []
-        )
 
     def _sync_select_all(self) -> None:
         count = self._list.count()

--- a/fibsem/ui/widgets/milling_stage_list_widget.py
+++ b/fibsem/ui/widgets/milling_stage_list_widget.py
@@ -487,7 +487,7 @@ class MillingStageListWidget(QWidget):
         self._status_timer.setSingleShot(True)
         self._status_timer.timeout.connect(lambda: self._status_label.setVisible(False))
 
-        self._header.select_all_changed.connect(self._on_select_all)
+        self._header.select_all_changed.connect(self.set_all_selected)
         self._header.add_clicked.connect(self._on_add_stage)
         self._header.eye_toggled.connect(self.eye_toggled)
         self._list.reordered.connect(self._on_reordered)
@@ -573,6 +573,30 @@ class MillingStageListWidget(QWidget):
         self._list.clear()
         self._selected_stage = None
         self._update_empty_state()
+
+    def set_all_selected(self, checked: bool) -> None:
+        """Enable or disable every stage, and bring the header checkbox with them.
+
+        The `_sync_select_all()` is not redundant even though the header is the only
+        caller today. Unticking one row leaves the header tristate for good --
+        `_sync_select_all` never turns it back off -- and a user click on a tristate
+        box cycles through PartiallyChecked, which the header reports as
+        `bool(Qt.PartiallyChecked)`, i.e. True. So the third click ticks every row
+        while the header itself stays showing a dash. Syncing after the loop settles
+        it back onto the rows it just changed (FIB-577).
+
+        Public for the same reason as the AutoLamella lists: any caller that clears
+        the selection programmatically needs the header to follow, and reaching for
+        a private slot is how those lists acquired the bug in the first place.
+        """
+        for i in range(self._list.count()):
+            row = self._row(i)
+            row.checkbox.blockSignals(True)
+            row.checkbox.setChecked(checked)
+            row.checkbox.blockSignals(False)
+            row.stage.enabled = checked
+        self._sync_select_all()
+        self.enabled_changed.emit(self.get_enabled_stages())
 
     def set_pattern_column_visible(self, visible: bool) -> None:
         """Show or hide the Pattern column in the header and all rows."""
@@ -691,15 +715,6 @@ class MillingStageListWidget(QWidget):
     def _on_enabled_changed(self, stage: FibsemMillingStage, enabled: bool) -> None:
         stage.enabled = enabled
         self._sync_select_all()
-        self.enabled_changed.emit(self.get_enabled_stages())
-
-    def _on_select_all(self, checked: bool) -> None:
-        for i in range(self._list.count()):
-            row = self._row(i)
-            row.checkbox.blockSignals(True)
-            row.checkbox.setChecked(checked)
-            row.checkbox.blockSignals(False)
-            row.stage.enabled = checked
         self.enabled_changed.emit(self.get_enabled_stages())
 
     def _sync_select_all(self) -> None:

--- a/tests/ui/test_select_all_sync.py
+++ b/tests/ui/test_select_all_sync.py
@@ -1,0 +1,220 @@
+"""A select-all has to leave the header agreeing with the rows it just changed.
+
+The same shape as FIB-577, in the two list widgets the AutoLamella fix did not cover:
+`_on_select_all` ticked every row and emitted, but never called `_sync_select_all()`.
+
+`MillingStageListWidget` is the one that shows it. `_sync_select_all` turns the header
+tristate the first time a row is unticked and never turns it back off, and a click on a
+tristate box cycles through PartiallyChecked, which the header reports as
+`bool(Qt.PartiallyChecked)` -- True. So the click that ticks every row can leave the
+header showing a dash, with no external caller involved at all.
+
+`ChannelListWidget` cannot show it today: its header checkbox is built hidden and never
+shown, so nothing reaches the slot. Its `_checkbox_states` cache is tested anyway,
+because it is the same trap as the workflow list's `_checked` -- `_on_reordered` rebuilds
+rows from it, and a stale entry re-enables channels for acquisition, silently.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.fm.structures import ChannelSettings
+from fibsem.milling.base import FibsemMillingStage
+from fibsem.milling.patterning import get_pattern
+from fibsem.structures import FibsemMillingSettings
+from fibsem.ui.fm.widgets.channel_list_widget import ChannelListWidget
+from fibsem.ui.widgets.milling_stage_list_widget import MillingStageListWidget
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+class _FakeFilterSet:
+    available_excitation_wavelengths = [405.0, 488.0, 550.0]
+    available_emission_wavelengths = [450.0, 520.0]
+
+
+class _FakeFM:
+    filter_set = _FakeFilterSet()
+    is_acquiring = False
+
+
+def _stage(name: str) -> FibsemMillingStage:
+    return FibsemMillingStage(
+        name=name,
+        milling=FibsemMillingSettings(milling_current=2e-9),
+        pattern=get_pattern("Rectangle", {"depth": 1e-6, "width": 10e-6, "height": 5e-6}),
+    )
+
+
+def _milling_list(enabled: bool = True) -> MillingStageListWidget:
+    widget = MillingStageListWidget()
+    widget.set_stages([_stage("A"), _stage("B"), _stage("C")])
+    if not enabled:
+        widget.set_all_selected(False)
+    return widget
+
+
+def _channel_list() -> ChannelListWidget:
+    channels = [
+        ChannelSettings(
+            name=f"Channel-{i:02d}", excitation_wavelength=405.0, emission_wavelength=450.0
+        )
+        for i in range(1, 4)
+    ]
+    return ChannelListWidget(fm=_FakeFM(), channel_settings=channels)
+
+
+def _header_matches_rows(widget) -> bool:
+    """The invariant both widgets are supposed to hold after any select-all."""
+    rows = [widget._row(i).checkbox.isChecked() for i in range(widget._list.count())]
+    state = widget._header.checkbox_all.checkState()
+    if all(rows):
+        return state == Qt.Checked
+    if not any(rows):
+        return state == Qt.Unchecked
+    return state == Qt.PartiallyChecked
+
+
+# ── MillingStageListWidget ───────────────────────────────────────────────────
+
+
+def test_tristate_header_clicks_never_disagree_with_the_rows(qapp):
+    """The live bug: the third click ticked every row and left the header on a dash.
+
+    Nothing here is programmatic -- one row toggle to make the header tristate, then
+    plain clicks on it, which is all a user has to do.
+    """
+    widget = _milling_list()
+    header = widget._header.checkbox_all
+
+    widget._row(0).checkbox.setChecked(False)
+    assert header.checkState() == Qt.PartiallyChecked
+    assert header.isTristate(), "the premise: the header stays tristate from here on"
+
+    for click in range(4):
+        header.click()
+        assert _header_matches_rows(widget), f"header disagrees with the rows on click {click + 1}"
+
+
+def test_clearing_the_stage_selection_unticks_the_header(qapp):
+    widget = _milling_list()
+    assert widget._header.checkbox_all.checkState() == Qt.Checked
+
+    widget.set_all_selected(False)
+
+    assert widget.get_enabled_stages() == []
+    assert widget._header.checkbox_all.checkState() == Qt.Unchecked
+
+
+def test_selecting_all_stages_ticks_every_row(qapp):
+    widget = _milling_list(enabled=False)
+
+    widget.set_all_selected(True)
+
+    assert len(widget.get_enabled_stages()) == 3
+    assert widget._header.checkbox_all.checkState() == Qt.Checked
+
+
+@pytest.mark.parametrize("checked", [True, False])
+def test_select_all_writes_through_to_the_stages(qapp, checked):
+    """`enabled` lives on the stage, not just the checkbox -- milling reads the model."""
+    widget = _milling_list(enabled=not checked)
+    seen = []
+    widget.enabled_changed.connect(seen.append)
+
+    widget.set_all_selected(checked)
+
+    assert [s.enabled for s in widget.get_stages()] == [checked] * 3
+    assert seen == [widget.get_enabled_stages()]
+
+
+def test_reorder_after_clearing_the_stages_keeps_them_cleared(qapp):
+    widget = _milling_list()
+
+    widget.set_all_selected(False)
+    widget._on_reordered(list(reversed(widget.get_stages())))
+
+    assert widget.get_enabled_stages() == []
+    assert widget._header.checkbox_all.checkState() == Qt.Unchecked
+
+
+@pytest.mark.parametrize("checked", [True, False])
+def test_the_stage_header_checkbox_still_drives_the_rows(qapp, checked):
+    """Regression guard: the header signal now lands on the public method."""
+    widget = _milling_list(enabled=not checked)
+    seen = []
+    widget.enabled_changed.connect(seen.append)
+
+    widget._header.checkbox_all.setChecked(checked)
+
+    assert len(widget.get_enabled_stages()) == (3 if checked else 0)
+    assert seen, "the header path must still emit enabled_changed"
+
+
+# ── ChannelListWidget ────────────────────────────────────────────────────────
+
+
+def test_clearing_the_channel_selection_unticks_the_header(qapp):
+    widget = _channel_list()
+    assert widget._header.checkbox_all.checkState() == Qt.Checked
+
+    widget.set_all_selected(False)
+
+    assert not any(widget._row(i).checkbox.isChecked() for i in range(3))
+    assert widget._header.checkbox_all.checkState() == Qt.Unchecked
+
+
+def test_reorder_after_a_clear_does_not_resurrect_the_channels(qapp):
+    """`_on_reordered` rebuilds rows from `_checkbox_states`, defaulting to enabled.
+
+    A cleared selection that skipped the cache came back ticked after a drag-and-drop,
+    and the rebuild emits no `enabled_changed`, so a consumer that had just been told
+    "nothing enabled" would never hear otherwise.
+    """
+    widget = _channel_list()
+    channels = widget.channel_settings
+
+    widget.set_all_selected(False)
+    assert set(widget._checkbox_states.values()) == {False}
+
+    widget._on_reordered(list(reversed(channels)))
+
+    assert not any(widget._row(i).checkbox.isChecked() for i in range(3))
+    assert widget._header.checkbox_all.checkState() == Qt.Unchecked
+
+
+def test_selecting_all_channels_ticks_every_row(qapp):
+    widget = _channel_list()
+    widget.set_all_selected(False)
+    seen = []
+    widget.enabled_changed.connect(seen.append)
+
+    widget.set_all_selected(True)
+
+    assert all(widget._row(i).checkbox.isChecked() for i in range(3))
+    assert widget._header.checkbox_all.checkState() == Qt.Checked
+    assert seen == [widget.channel_settings]
+
+
+@pytest.mark.parametrize("checked", [True, False])
+def test_the_channel_header_checkbox_still_drives_the_rows(qapp, checked):
+    """The header is hidden, so this only guards the connection, not a user path."""
+    widget = _channel_list()
+    widget.set_all_selected(not checked)
+
+    widget._header.checkbox_all.setChecked(checked)
+
+    assert all(
+        widget._row(i).checkbox.isChecked() == checked for i in range(3)
+    )
+    assert _header_matches_rows(widget)


### PR DESCRIPTION
Fixes FIB-587.

Two list widgets whose `_on_select_all` ticked every row, emitted, and never called `_sync_select_all()` — the same shape as the AutoLamella select-all fix that landed in #366. These two are the only other widgets with the pattern, so this completes the set.

That fix was justified by its programmatic callers; neither of these widgets has one. One of them turns out not to need one.

## The milling list is a live defect

No external caller is involved. `_sync_select_all` calls `setTristate(True)` the first time a row is unticked and never turns it back off, and Qt cycles a tristate checkbox through `PartiallyChecked` on click. The header reports that as `bool(Qt.PartiallyChecked)` — `True`. So the click that lands on Partial ticks every row *and* sets `stage.enabled = True` on every stage, while the box itself goes on showing a dash.

Measured on three stages, one row unticked, then nothing but clicks on the header:

```
                     before                            after
click #2   header=Unchecked  rows=[F,F,F]    header=Unchecked  rows=[F,F,F]
click #3   header=Partial    rows=[T,T,T]    header=Checked    rows=[T,T,T]
```

Confirmed in the real host as well — `FibsemMillingStagesWidget` on a simulator microscope, where the header checkbox is visible. With the sync, the cycle behaves as the two-state toggle it looks like.

## The channel list is genuinely unreachable

More so than a caller search shows: its header checkbox is constructed hidden (`channel_list_widget.py:560`) and never shown, so even the wired path is dead code.

Fixed to match anyway, because it carries the worse half of the bug. `_checkbox_states` is what `_on_reordered` rebuilds rows from, defaulting to enabled, so a clear that skipped the cache came back ticked after a drag-and-drop — and the rebuild emits no `enabled_changed`, leaving a consumer that had just been told "nothing enabled" with no way to hear otherwise. Four lines of insurance for the day that checkbox gets un-hidden.

## Changes

- `MillingStageListWidget.set_all_selected()` — keeps the `row.stage.enabled = checked` model write, syncs before emitting.
- `ChannelListWidget.set_all_selected()` — same, plus the `_checkbox_states` write.
- Both headers connect straight to the public method, so the next caller that needs to clear a selection has something to call that is not a private slot.

## Tests

`tests/ui/test_select_all_sync.py`, 13 tests. A separate file from the AutoLamella branch's `test_selection_clearing.py` on purpose — that file does not exist on `main`, so writing into it here would be an add/add conflict when both land.

12 of the 13 fail without the fix, and the one that matters most (`test_tristate_header_clicks_never_disagree_with_the_rows`, which touches nothing but the header checkbox) fails on the behaviour rather than a missing attribute: `header disagrees with the rows on click 3`.

`QT_QPA_PLATFORM=offscreen pytest tests/ui -q` → 1117 passed, 1 skipped.

## Not done here

Resetting `setTristate(False)` in the full/empty branches of `_sync_select_all` would stop the header cycling through a state it never rests in. Now that the sync always corrects the outcome it is cleanup rather than a fix, and it would want doing across all four list widgets, not two.

