### PR TITLE
[fix] Let a task declare its reference set final, whatever it names the files (FIB-579)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -505,8 +505,13 @@ class AutoLamellaTask(ABC):
     def _acquire_set_of_reference_images(self,
                                  image_settings: ImageSettings,
                                  filename: Optional[str] = None,
-                                 field_of_views: Optional[Tuple[float, ...]] = None) -> None:
-        """Acquire a set of reference images."""
+                                 field_of_views: Optional[Tuple[float, ...]] = None,
+                                 phase: Optional[str] = None) -> None:
+        """Acquire a set of reference images.
+
+        `phase` names the role the images are recorded under; see
+        :meth:`_acquire_set_of_channels` for when to pass one.
+        """
         acquire_fib = self.config.reference_imaging.acquire_fib
         acquire_sem = self.config.reference_imaging.acquire_sem
         if field_of_views is None:
@@ -516,7 +521,8 @@ class AutoLamellaTask(ABC):
                                                 field_of_views=field_of_views,
                                                 filename=filename,
                                                 acquire_sem=acquire_sem,
-                                                acquire_fib=acquire_fib)
+                                                acquire_fib=acquire_fib,
+                                                phase=phase)
 
     def _record_output(self, role: str, image: Optional[Union[FibsemImage, "FluorescenceImage"]]) -> None:
         """Record where an acquired image was written, under the given role.
@@ -573,14 +579,23 @@ class AutoLamellaTask(ABC):
                                  field_of_views: Optional[Tuple[float, ...]] = None,
                                  filename: Optional[str] = None,
                                  acquire_sem: bool = True,
-                                 acquire_fib: bool = True) -> None:
-        """Acquire a set of images for each sem/fib channel at given field of views."""
+                                 acquire_fib: bool = True,
+                                 phase: Optional[str] = None) -> None:
+        """Acquire a set of images for each sem/fib channel at given field of views.
+
+        `phase` is the role the images are recorded under, and defaults to reading it
+        off the filename. Pass it when a task names its own files but the set *is* the
+        task's reference set rather than an extra one -- AcquireReferenceImageTask
+        timestamps its filenames, so the default rule filed its only product under
+        "other" and the review panel, which asks for "final", never saw it (FIB-579).
+        """
 
         if field_of_views is None:
             field_of_views = (fcfg.REFERENCE_HFW_HIGH, fcfg.REFERENCE_HFW_SUPER)
         # only the default filename is the conventional final reference set; see
         # _acquire_channels for why one-off acquisitions are recorded separately.
-        phase = "final" if filename is None else "other"
+        if phase is None:
+            phase = "final" if filename is None else "other"
         if filename is None:
             filename = f"ref_{self.task_name}_final"
 

--- a/fibsem/applications/autolamella/workflows/tasks/reference_image.py
+++ b/fibsem/applications/autolamella/workflows/tasks/reference_image.py
@@ -59,4 +59,10 @@ class AcquireReferenceImageTask(AutoLamellaTask):
             base = f"ReferenceImage-{task_name}"
 
         filename = f"ref_{base}-{utils.current_timestamp_v3()}"
-        self._acquire_set_of_reference_images(image_settings=image_settings, filename=filename)
+        # phase="final" because this set is what the task exists to produce. The
+        # default rule reads the role off the filename and would file a named set
+        # under "other", which is right for a task grabbing an extra set mid-run and
+        # wrong here -- it hid these images from the review panel entirely (FIB-579).
+        self._acquire_set_of_reference_images(image_settings=image_settings,
+                                              filename=filename,
+                                              phase="final")

--- a/tests/autolamella/test_tasks.py
+++ b/tests/autolamella/test_tasks.py
@@ -231,3 +231,81 @@ def test_task_is_cancellation_classifies_stop_vs_failure(tmp_path: Path):
     stopped_task.stop_task()
     assert _isc(ValueError("real bug"), stopped_task) is True
     assert stopped_task.is_stopped is False  # ... and the run is untouched
+
+
+# ── which role a task's reference set is recorded under (FIB-579) ──────────────
+#
+# The default rule -- default filename means "final", a caller-supplied one means
+# "other" -- is already pinned in both directions above, by
+# test_default_filename_is_recorded_as_the_final_reference_set and
+# test_a_custom_filename_is_not_recorded_as_a_final_reference_set. Those still pass
+# unchanged, which is the point: this adds a way for a task to opt out of the rule
+# rather than altering it.
+
+
+def _fake_acquire_set_of_channels(image_settings, hfws, filename):
+    """Stand in for a real acquisition: write the files it would have written.
+
+    The reader requires the files to exist, so touching them is what makes the
+    round trip through `final_reference_images` meaningful rather than a check on
+    a dict of strings.
+    """
+    images = []
+    for i, _ in enumerate(hfws, start=1):
+        pair = []
+        for beam in ("eb", "ib"):
+            path = Path(image_settings.path) / f"{filename}_res_{i:02d}_{beam}.tif"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+            pair.append(_image_written_to(path))
+        images.append(tuple(pair))
+    return images
+
+
+@pytest.fixture
+def stub_acquisition(monkeypatch):
+    """Patch out the hardware, keeping the filename convention the real one uses."""
+    from fibsem import acquire
+
+    monkeypatch.setattr(
+        acquire,
+        "acquire_set_of_channels",
+        lambda microscope, image_settings, hfws, filename="ref_image", **kwargs:
+            _fake_acquire_set_of_channels(image_settings, hfws, filename),
+    )
+
+
+def _make_reference_image_task(microscope: FibsemMicroscope, tmp_path: Path):
+    from fibsem.applications.autolamella.workflows.tasks.reference_image import (
+        AcquireReferenceImageConfig,
+        AcquireReferenceImageTask,
+    )
+
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+    lamella.milling_pose = microscope.get_microscope_state()
+    return AcquireReferenceImageTask(
+        microscope=microscope, config=AcquireReferenceImageConfig(), lamella=lamella
+    )
+
+
+def test_acquire_reference_image_task_reaches_the_review_panel(
+    compustage_microscope: FibsemMicroscope, tmp_path: Path, stub_acquisition
+) -> None:
+    """The task names its own files, and the role used to be read off that name.
+
+    A named set means "an extra one this task happened to grab", which is right for
+    a task acquiring mid-run and wrong for the one whose entire product is a
+    reference set -- it landed in `other_*` and the review panel, which asks for
+    `final_*`, showed nothing for it on every run.
+    """
+    from fibsem.applications.autolamella.task_outputs import final_reference_images
+
+    task = _make_reference_image_task(compustage_microscope, tmp_path)
+
+    task._run()
+
+    outputs = task.lamella.task_state.outputs
+    assert set(outputs) == {"final_sem", "final_fib"}
+    found = final_reference_images(task.lamella, task.lamella.task_state)
+    assert len(found) == 4, "both resolutions, both beams"
+    assert all(Path(path).is_file() for path in found)


### PR DESCRIPTION
From today's testing session: "Acquire Reference Image doesn't supply outputs correctly for review tab".

## The bug

The review panel asks `final_reference_images()` for a task's images, which reads the `final_sem` / `final_fib` roles and falls back to the filename convention `ref_{task}*_final_*res*.tif*`.

`_acquire_set_of_channels` derived the role from the filename:

```python
phase = "final" if filename is None else "other"
```

`AcquireReferenceImageTask` always passes one — `ref_ReferenceImage-{last-task}-{timestamp}` — so its images went to `other_*` on every run, and the glob fallback missed them too (no `_final_` in the name). Both discovery routes failed, and the panel showed nothing for the one task whose entire product is a reference set.

## The fix

`phase` is now an explicit argument, defaulting to the filename-derived value, and `AcquireReferenceImageTask` passes `"final"`.

Deliberately an opt-out rather than a change to the rule. I checked the other callers that supply a filename before touching it, and the existing derivation is right for all of them: Undercut's ML-alignment image and its mid-run undercut set are both genuinely extra, and it acquires the real final set separately afterwards. `AcquireReferenceImageTask` was the only misclassified one.

That is also why `test_default_filename_is_recorded_as_the_final_reference_set` and `test_a_custom_filename_is_not_recorded_as_a_final_reference_set` pass unchanged — they pin the default rule in both directions and this does not move it.

## Testing

One new test, running the task end to end with the acquisition stubbed, asserting through `final_reference_images` that the panel's own reader finds the four files on disk. The reader also requires the files to exist, so a dict of role names alone would not have shown that. Stashing the fix fails it. 31 pass across the task and task-output files.

## Follow-up, not fixed here

The generated filename stamps `current_timestamp_v3()`, which is time-of-day only (`%H-%M-%S`). `final_reference_images` sorts by path and the panel slices the last two, so a lamella with two runs of this task spanning midnight will show the older pair. Unreachable before (the panel showed nothing for this task at all) and reachable now. Fixing it means a new on-disk filename format — `timeonly=False` is worse, being 12-hour — so it is noted on FIB-579 instead.

While tracing this I also checked whether `_acquire_set_of_reference_images` overwriting its `image_settings` argument with `config.reference_imaging.imaging` drops the lamella path. It does not: `config.imaging` is a property proxying the same object, so the assignment is redundant but harmless. Left alone.