### PR TITLE
[fix] Three canvas and header formatting fixes from the testing session (FIB-582, FIB-583, FIB-584)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1918,7 +1918,13 @@ class AutoLamellaUI(QMainWindow):
             BeamType.ION,
             PointsSpec(
                 id="poi", points=[(col, row)],
-                color="magenta", selected_color="magenta", marker="+", size=18,
+                # Matches the protocol editor's POI, down to the legend entry: same
+                # concept, same marker. Left to the defaults this drew at size 18 with
+                # PointOverlay's 2.0 edge, a cross visibly fatter than the thin one the
+                # editor and the config preview draw, and absent from the legend
+                # (FIB-582). 1.2 keeps it reading like the centre crosshair.
+                color="magenta", selected_color="magenta", marker="+",
+                size=14, edge_width=1.2, legend_label="Point of Interest",
                 add_on_right_click=False, removable=False,
             ),
         )

--- a/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
@@ -614,9 +614,13 @@ class WorkflowProgressWidget(QWidget):
         # progress, attention, supervised, Stop) and putting an additive button
         # next to Stop invites the wrong click.
         header_row = QHBoxLayout()
-        # Right margin clears the scroll bar column below, so the button's menu
-        # arrow does not sit directly on top of the scroll bar's arrow.
-        header_row.setContentsMargins(0, 0, 20, 0)
+        # 2px + the button's own 6px padding = the 8px the header label is inset by,
+        # so the two ends of the strip match. This used to reserve 20px for the
+        # scroll bar column below, which only appears when the queue overflows -- so
+        # on a short queue the button floated in an empty gutter. Nothing is lost by
+        # dropping it: the reservation was there to keep the button's menu arrow off
+        # the scroll bar's, and _ADD_BTN_STYLE hides that arrow (FIB-584).
+        header_row.setContentsMargins(0, 0, 2, 0)
         header_row.setSpacing(4)
 
         self._header = QLabel("Workflow")

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -976,6 +976,10 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
                     box_color=_BG,
                     box_alpha=0.6,
                     location="lower right",
+                    # Unset, this inherits matplotlib's 10pt default, which is large
+                    # against the rest of the canvas chrome -- the hint, title, info
+                    # bar and legend are all 10-12px Qt text (FIB-583).
+                    font_properties={"size": 8},
                 )
                 self._ax.add_artist(self._scalebar_artist)
             except Exception:

--- a/tests/ui/test_canvas_base.py
+++ b/tests/ui/test_canvas_base.py
@@ -138,3 +138,19 @@ if __name__ == "__main__":
             fn()
             print(f"ok  {name}")
     print("all passed")
+
+
+def test_the_scalebar_is_drawn_at_the_smaller_font():
+    """The size is pinned because the constructor is wrapped in a bare except.
+
+    A kwarg matplotlib_scalebar does not accept is swallowed there and the bar simply
+    stops appearing, with nothing in the log to say why -- so "it still constructs"
+    is as much the point of this test as the size itself (FIB-583).
+    """
+    c = FibsemImageCanvas()
+    c.set_array(_img(32, 32), pixel_size=1e-8)
+
+    assert c._scalebar_artist is not None
+    assert c._scalebar_artist.font_properties.get_size() == 8.0
+
+    c.draw()  # a bad font spec raises here rather than at construction

--- a/tests/ui/test_workflow_poi_overlay.py
+++ b/tests/ui/test_workflow_poi_overlay.py
@@ -1,0 +1,109 @@
+"""The workflow's POI marker is drawn like every other POI marker (FIB-582).
+
+The same concept is drawn in three places -- the workflow's Select Position step, the
+lamella protocol editor, and the default-config preview -- and the workflow one had
+drifted: left to `PointsSpec`'s defaults it came out at size 18 with a 2.0 edge, a
+visibly fatter cross than the thin one the other two draw, and with no `legend_label` it
+was the only one missing from the canvas legend.
+
+Driven by calling the method unbound against a stub, because its host is `AutoLamellaUI`
+-- a napari-backed window that cannot be constructed headless. The spec it builds is the
+whole of what this pins, so the stub costs nothing in coverage.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import types
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.structures import (
+    BeamType,
+    FibsemImage,
+    FibsemImageMetadata,
+    ImageSettings,
+    MicroscopeState,
+    Point,
+)
+
+# What the protocol editor asks for (autolamella_lamella_protocol_editor.py), and what
+# the config preview's PointOverlay uses for its edge. Restated rather than imported:
+# both are inline literals at their call sites, so this is a statement of the intended
+# house style for a POI, not a live comparison.
+POI_SIZE = 14
+POI_EDGE_WIDTH = 1.2
+POI_LEGEND_LABEL = "Point of Interest"
+
+
+class _Controller:
+    """Records what the method asks the quad view to draw."""
+
+    def __init__(self):
+        self.overlays = {}
+        self.armed = None
+        self.fib_canvas = types.SimpleNamespace(set_hint=lambda hint: None)
+
+    def set_overlay(self, beam, spec):
+        self.overlays[(beam, spec.id)] = spec
+
+    def arm_overlay(self, beam, overlay_id, label=None, icon=None):
+        self.armed = (beam, overlay_id)
+
+
+def _host(shape=(64, 64), pixel_size=1e-8):
+    """The one attribute `_show_poi_overlay` reads off its host: the FIB image."""
+    image = FibsemImage(
+        data=np.zeros(shape, dtype=np.uint8),
+        metadata=FibsemImageMetadata(
+            image_settings=ImageSettings(
+                resolution=(shape[1], shape[0]), beam_type=BeamType.ION
+            ),
+            pixel_size=Point(pixel_size, pixel_size),
+            microscope_state=MicroscopeState(),
+        ),
+    )
+    return types.SimpleNamespace(image_widget=types.SimpleNamespace(ib_image=image))
+
+
+def _poi_spec(initial_poi=None):
+    controller = _Controller()
+    AutoLamellaUI._show_poi_overlay(_host(), controller, initial_poi)
+    return controller.overlays[(BeamType.ION, "poi")]
+
+
+def test_the_poi_marker_is_the_thin_cross_the_other_editors_draw():
+    spec = _poi_spec()
+
+    assert spec.marker == "+"
+    assert spec.size == POI_SIZE
+    assert spec.edge_width == POI_EDGE_WIDTH
+
+
+def test_the_poi_marker_names_itself_in_the_legend():
+    """Without this the workflow's canvas showed a magenta cross and no key to it."""
+    assert _poi_spec().legend_label == POI_LEGEND_LABEL
+
+
+def test_the_poi_marker_is_magenta_selected_or_not():
+    """It is a single dragged point, so a distinct selected colour only makes it flicker."""
+    spec = _poi_spec()
+
+    assert spec.color == "magenta"
+    assert spec.selected_color == "magenta"
+
+
+def test_the_marker_stays_move_only():
+    """Formatting only -- the POI is one point the user drags, never adds to or deletes."""
+    spec = _poi_spec()
+
+    assert spec.add_on_right_click is False
+    assert spec.removable is False
+
+
+def test_the_marker_starts_at_the_image_centre_when_there_is_no_poi_yet():
+    assert _poi_spec().points == [(32.0, 32.0)]


### PR DESCRIPTION
Three small visual fixes reported in today's testing session. Independent of each other, batched because they are one line apiece.

## POI marker (FIB-582)

The workflow's Select Position marker was left on `PointsSpec`'s defaults — size 18 with a 2.0 edge — so the same concept came out a visibly fatter cross than the protocol editor and the config preview draw, and with no `legend_label` it was the only one of the three missing from the canvas legend. Now 14 / 1.2 / "Point of Interest", matching the editor.

## Scalebar (FIB-583)

No `ScaleBar` in the codebase sets `font_properties`, so every one inherits matplotlib's 10pt default — large against the canvas chrome around it, which is 10–12px Qt text. 8pt on the live canvas.

The five sites that render figures rather than the canvas (report, milling plots, tiling) are left alone; they are a separate look and were not what was reported.

## Add to Queue (FIB-584)

The timeline header reserved a 20px right margin for the scroll bar of the list below. That bar is `AsNeeded`, so on a short queue it is absent and the button floated in an empty gutter against a flush-left label. The reservation existed to keep the button's menu arrow off the scroll bar's, and `_ADD_BTN_STYLE` hides that arrow — so it bought nothing even when the bar was there. 2px plus the button's own 6px padding now matches the label's 8px inset.

Measured offscreen: the real scroll bar extent is 14px, not 20, and it is not visible with an empty queue.

### On the primary colour

The report asked whether this should be primary "maybe when items are selected". Recommend not, and not done here: `_on_workflow_selection_changed` enables Run Workflow and Add to Queue from the same condition, so that would light two primary buttons side by side, same preconditions, different consequences. Enabled-vs-disabled already carries it, and the tooltip names the selection.

## Testing

Six tests. The scalebar one pins the font size *and* that the bar still constructs — that constructor sits inside a bare `except`, so a kwarg matplotlib_scalebar does not accept would silently stop the bar appearing with nothing in the log. The POI ones drive `_show_poi_overlay` unbound against a stub, since its host is a napari-backed window that cannot be constructed headless.

Stashing the fixes fails 3 of the 6; the other 3 pin properties I deliberately did not change (colour, move-only, initial centre). 124 pass across the canvas and timeline files.