### PR TITLE
[ui] Retire the milling widget's napari half, which nothing could reach

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -560,7 +560,6 @@ class AutoLamellaUI(QMainWindow):
             self.tabWidget.addTab(self.movement_widget, "Movement")
             self.milling_task_config_widget = MillingTaskViewerWidget(
                 microscope=self.microscope,
-                viewer=self.viewer,
                 image_widget=self.image_widget,
                 parent=self,
             )

--- a/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
@@ -170,7 +170,6 @@ class AutoLamellaProtocolEditorWidget(QWidget):
 
         self.milling_task_editor = MillingTaskViewerWidget(
             microscope=self.microscope,
-            viewer=None,
             milling_enabled=False,
             parent=self,
         )
@@ -655,8 +654,7 @@ class AutoLamellaProtocolEditorWidget(QWidget):
 
         if milling_task_config:
             self._current_milling_key = next(iter(milling_task_config))
-            # image_layer is unused on the canvas path (patterns render via the reducer)
-            self.milling_task_editor.set_fib_image(self.image, None)
+            self.milling_task_editor.set_fib_image(self.image)
             self.milling_task_editor.set_config(
                 milling_task_config[self._current_milling_key]
             )

--- a/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
@@ -240,10 +240,9 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         self.task_parameters_config_widget = AutoLamellaTaskParametersConfigWidget(parent=self)
         self.ref_image_params_widget = ReferenceImageParametersWidget(parent=self)
 
-        # Milling task editor (Column 3 — viewer=None, config panels only)
+        # Milling task editor (Column 3 — no controller, config panels only)
         self.milling_task_editor = MillingTaskViewerWidget(
             microscope=self.microscope,  # type: ignore[arg-type]
-            viewer=None,
             milling_enabled=False,
             parent=self,
         )

--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -815,7 +815,6 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
 
         self.milling_viewer_widget = MillingTaskViewerWidget(
             microscope=self.microscope,
-            viewer=self.viewer,
             milling_task_config=milling_task_config,
             milling_enabled=False,
             parent=self,

--- a/fibsem/applications/autolamella/ui/tests/test_coincidence_viewer_canvas.py
+++ b/fibsem/applications/autolamella/ui/tests/test_coincidence_viewer_canvas.py
@@ -61,6 +61,32 @@ def _fm_stack(channels: int = 2, z: int = 3, h: int = 512, w: int = 768) -> _Fak
     return _FakeFmImage((rng.random((channels, z, h, w)) * 4095).astype(np.uint16))
 
 
+def _coincidence_viewer():
+    """Build the whole viewer on a simulated FM microscope.
+
+    The FM configuration is not incidental: ``_connect_signals`` returns immediately when
+    ``microscope.fm is None``, so on a plain demo session the viewer constructs with none
+    of its signals wired and every interaction test would pass without testing anything.
+    """
+    import tempfile
+
+    from fibsem import config as cfg
+    from fibsem import utils
+    from fibsem.applications.autolamella.structures import Experiment
+    from fibsem.applications.autolamella.ui.fluorescence_coincidence_viewer_widget import (
+        FluorescenceCoincidenceViewerWidget,
+    )
+
+    microscope, _ = utils.setup_session(
+        config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+    )
+    assert microscope.fm is not None, "expected an FM on the simulated Arctis"
+    return FluorescenceCoincidenceViewerWidget(
+        microscope=microscope,
+        experiment=Experiment(path=tempfile.mkdtemp(), name="coincidence-canvas-test"),
+    )
+
+
 # --- the regression this issue exists for --------------------------------------
 
 
@@ -296,6 +322,69 @@ def test_clear_resets_both_quadrants():
     fm.clear()
     assert fm._image is None and fm._data is None and fm._img_shape is None
     assert fm.canvas._display_base is None
+
+
+def test_the_viewer_builds_and_its_milling_widget_draws_nothing_itself():
+    """The whole widget, not just the two quadrants — nothing else covered this.
+
+    The coincidence viewer holds a ``MillingTaskViewerWidget`` for its config panels only:
+    it renders the selected stage itself, as the yellow rect on ``fib_canvas``. It never
+    hands that widget a controller, so the widget must display nothing and must not raise
+    when a pattern update fires.
+
+    This used to be true by accident rather than design. The widget took a ``viewer``
+    argument that defaulted to ``napari.current_viewer()``, so passing ``None`` did not
+    mean "no viewer" — it latched whichever napari viewer happened to be open (the
+    minimap's) and appended a mouse callback to it. The napari draw stayed inert only
+    because ``_fib_image_layer`` was also never set. Two independent accidents; the
+    argument is gone now (FIB-407).
+    """
+    widget = _coincidence_viewer()
+    milling = widget.milling_viewer_widget
+
+    assert not hasattr(milling, "viewer"), (
+        "the milling widget grew a viewer back — napari.current_viewer() latches the "
+        "minimap's viewer when one is open"
+    )
+    assert milling._controller is None, "coincidence viewer must not attach a controller"
+
+    image = _fib_image()
+    widget.set_fib_image(image)
+    assert milling._fib_image is image, "the widget lost the frame patterns are placed against"
+
+    # Reaches here through a QTimer.singleShot in the app, where a raise would escape the
+    # Qt event loop and abort the process under PyQt5 (FIB-329) rather than fail a test.
+    milling._update_pattern_display()
+    assert milling._pattern_update_pending is False
+
+
+def test_dragging_the_fib_rect_still_repositions_the_pattern():
+    """The drag is how an operator positions a coincidence mill, and it is the one path
+    that runs *through* the milling widget rather than around it
+    (``_on_fib_rect_changed`` → ``MillingTaskViewerWidget._move_patterns``).
+
+    Note the FM-enabled configuration: ``_connect_signals`` returns at its first line
+    when ``microscope.fm is None``, so on a plain demo session the viewer wires up
+    *nothing* and a drag test would pass vacuously against any breakage.
+    """
+    widget = _coincidence_viewer()
+    milling = widget.milling_viewer_widget
+    widget.set_fib_image(_fib_image())
+
+    overlay = widget.fib_canvas.rect_overlay
+    assert overlay.receivers(overlay.rect_changed), "the rect drag is not wired to anything"
+
+    stages = milling.config_widget.milling_stages_widget.get_enabled_stages()
+    assert stages, "no enabled milling stage to reposition"
+    before = stages[0].pattern.point
+
+    overlay.set_rect(x0=470.0, y0=150.0, width=60.0, height=60.0)
+    overlay.rect_changed.emit(overlay.get_rect())
+
+    after = milling.config_widget.milling_stages_widget.get_enabled_stages()[0].pattern.point
+    assert (after.x, after.y) != (before.x, before.y), (
+        "dragging the FIB rect no longer moves the milling pattern"
+    )
 
 
 def _main() -> int:

--- a/fibsem/applications/autolamella/ui/tests/test_lamella_protocol_editor_canvas.py
+++ b/fibsem/applications/autolamella/ui/tests/test_lamella_protocol_editor_canvas.py
@@ -315,11 +315,11 @@ def _row_for(list_widget, name):
 # --- the shared widget must not regress for the other tabs ---------------------
 
 
-def test_milling_widget_keeps_its_napari_path_without_a_controller():
-    """set_controller is opt-in. Every caller that doesn't call it — the Microscope tab,
-    both task-config editors, the coincidence viewer — must be untouched by this phase."""
+def test_milling_widget_has_no_display_without_a_controller():
+    """set_controller is opt-in. Callers that never call it — both task-config editors and
+    the coincidence viewer — get a config editor with no pattern display."""
     microscope, _ = _session()
-    w = MillingTaskViewerWidget(microscope=microscope, viewer=None, milling_enabled=False)
+    w = MillingTaskViewerWidget(microscope=microscope, milling_enabled=False)
     assert w._controller is None, "widget claimed a controller it was never given"
     assert w._fib_canvas is None
 
@@ -327,7 +327,7 @@ def test_milling_widget_keeps_its_napari_path_without_a_controller():
 def test_milling_widget_switches_to_the_canvas_when_given_a_controller():
     microscope, _ = _session()
     controller = MicroscopeViewController(view=LamellaEditorView())
-    w = MillingTaskViewerWidget(microscope=microscope, viewer=None, milling_enabled=False)
+    w = MillingTaskViewerWidget(microscope=microscope, milling_enabled=False)
     w.set_controller(controller)
     assert w._controller is controller
     assert w._fib_canvas is controller.get_canvas(BeamType.ION)
@@ -344,22 +344,25 @@ class _FakeImageWidget(QWidget):
         self.ib_image = image
 
 
-def test_napari_callers_supply_their_own_fib_image_layer():
-    """The napari pattern path is gated on ``_fib_image_layer``, and ``set_fib_image()``
-    is now its *only* source. It used to also be picked up from ``iw.ib_layer``, but the
-    image widget dropped its layers when the Microscope tab moved to the canvas; the
-    remaining napari caller (the coincidence viewer) has always used set_fib_image().
+def test_a_controller_less_widget_takes_an_image_and_draws_nothing():
+    """The coincidence viewer holds this widget without ever giving it a controller: it
+    renders its own overlay on its own canvas and only wants the config panels.
+
+    So a controller-less pattern update must be a quiet no-op, not a raise. It reaches
+    here through the debounce, which sits behind a ``QTimer.singleShot`` — an exception
+    would surface from the Qt event loop rather than the caller, and under PyQt5 that
+    aborts the process (FIB-329) rather than failing a test.
     """
     microscope, _ = _session()
     image = FibsemImage.generate_blank_image(resolution=_RESOLUTION, hfw=_HFW)
-    sentinel = object()  # a napari layer, only ever passed through
 
-    w = MillingTaskViewerWidget(microscope=microscope, viewer=None, milling_enabled=False)
-    w.set_fib_image(image, sentinel)
+    w = MillingTaskViewerWidget(microscope=microscope, milling_enabled=False)
+    w.set_fib_image(image)
     assert w._fib_image is image
-    assert w._fib_image_layer is sentinel, (
-        "napari callers lost their image layer — patterns and the reposition menu "
-        "are both gated on it"
+
+    w._update_pattern_display()  # must not raise
+    assert w._pattern_update_pending is False, (
+        "the debounce flag was left set — every later update would be swallowed"
     )
 
 
@@ -375,7 +378,7 @@ def test_a_new_frame_refreshes_the_image_and_reschedules_the_patterns():
     iw = _FakeImageWidget(image)
 
     w = MillingTaskViewerWidget(
-        microscope=microscope, viewer=None, image_widget=iw, milling_enabled=False
+        microscope=microscope, image_widget=iw, milling_enabled=False
     )
     assert w._fib_image is image
 
@@ -393,7 +396,7 @@ def test_a_new_frame_refreshes_the_image_and_reschedules_the_patterns():
 def test_eye_toggle_routes_through_the_reducer_when_wired():
     microscope, _ = _session()
     controller = MicroscopeViewController(view=LamellaEditorView())
-    w = MillingTaskViewerWidget(microscope=microscope, viewer=None, milling_enabled=False)
+    w = MillingTaskViewerWidget(microscope=microscope, milling_enabled=False)
     w.set_controller(controller)
     w._on_eye_toggled(False)
     assert w._patterns_visible is False

--- a/fibsem/ui/FibsemUI.py
+++ b/fibsem/ui/FibsemUI.py
@@ -135,7 +135,6 @@ class FibsemUI(FibsemUIMainWindow.Ui_MainWindow, QtWidgets.QMainWindow):
             self.milling_widget = MillingTaskViewerWidget(
                 microscope=self.microscope,
                 parent=self,
-                viewer=self.viewer,
                 image_widget=self.image_widget,  # lets it resolve the quad controller
             )
             if self.microscope.system.manipulator.enabled:

--- a/fibsem/ui/widgets/milling_task_viewer_widget.py
+++ b/fibsem/ui/widgets/milling_task_viewer_widget.py
@@ -4,8 +4,6 @@ import copy
 import logging
 from typing import Callable, List, Optional, TYPE_CHECKING
 
-import napari
-from napari.layers import Image as NapariImageLayer
 from PyQt5.QtCore import QTimer, pyqtSignal
 from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
@@ -16,14 +14,11 @@ from fibsem.milling.base import FibsemMillingStage
 from fibsem.milling.patterning.patterns2 import LinePattern
 from fibsem.milling.tasks import FibsemMillingTaskConfig
 from fibsem.structures import BeamType, FibsemImage, Point
-from fibsem.ui.napari.patterns import (
-    draw_milling_patterns_in_napari,
-    draw_milling_fov_rect,
-    is_pattern_placement_valid,
-    MILLING_PATTERN_LAYER_NAME,
-    MILLING_FOV_LAYER_NAME,
-)
-from fibsem.ui.napari.utilities import is_position_inside_layer
+# `is_pattern_placement_valid` is pure geometry despite living under `fibsem/ui/napari/`
+# — it validates a pattern against the image bounds and never touches a Viewer or Layer.
+# It is the last thing keeping this module coupled to that package, and it moves out with
+# the geometry extraction tracked on FIB-407 §1.
+from fibsem.ui.napari.patterns import is_pattern_placement_valid
 from fibsem.ui.widgets.custom_widgets import ContextMenu, ContextMenuConfig
 from fibsem.ui.widgets.milling_task_config_widget2 import MillingTaskConfigWidget2
 from fibsem.ui.widgets.milling_widget import FibsemMillingWidget2
@@ -44,18 +39,22 @@ def _apply_diff_to_pattern(pattern, diff: Point) -> None:
 
 
 class MillingTaskViewerWidget(QWidget):
-    """MillingTaskConfigWidget2 + napari pattern visualization + milling execution.
+    """MillingTaskConfigWidget2 + canvas pattern visualization + milling execution.
 
     Layout (top → bottom):
         MillingTaskConfigWidget2   — collapsible config panels (Task / Alignment / Acquisition / Stages)
         FibsemMillingWidget2       — Run / Pause / Stop + progress bars (hidden when milling_enabled=False)
 
-    Pattern visualization is driven by ``settings_changed`` — whenever the config changes the
-    milling pattern Shapes layers in the napari viewer are redrawn.  A FIB image layer must be
-    available (injected via ``set_fib_image()`` or discovered from the parent's ``image_widget``).
+    Pattern visualization is driven by ``settings_changed``: whenever the config changes the
+    stages are pushed to the FIB canvas through the reducer as a ``MillingSpec``. This needs
+    a :class:`MicroscopeViewController` — supplied directly via :meth:`set_controller`, or
+    discovered from an injected ``image_widget`` — and a FIB image, from
+    :meth:`set_fib_image` or the same image widget. Without a controller the widget is a
+    config editor with no display, which is how the coincidence viewer uses it (it draws
+    its own overlay on its own canvas).
 
-    Right-click on the FIB image layer shows a context menu to move patterns
-    and any extra actions injected by the parent widget.
+    Right-click on the FIB canvas shows a context menu to move patterns and any extra
+    actions injected by the parent widget.
     """
 
     settings_changed = pyqtSignal(FibsemMillingTaskConfig)
@@ -63,7 +62,6 @@ class MillingTaskViewerWidget(QWidget):
     def __init__(
         self,
         microscope: FibsemMicroscope,
-        viewer: Optional[napari.Viewer] = None,
         milling_task_config: Optional[FibsemMillingTaskConfig] = None,
         milling_enabled: bool = True,
         image_widget: Optional["FibsemImageSettingsWidget"] = None,
@@ -71,29 +69,23 @@ class MillingTaskViewerWidget(QWidget):
     ) -> None:
         super().__init__(parent)
         self.microscope = microscope
-        self.viewer: Optional[napari.Viewer] = viewer or napari.current_viewer()
         self._milling_enabled = milling_enabled
         self._image_widget = image_widget
         self._show_alignment_area: bool = True
         self.parent_widget = parent
 
         self._fib_image: Optional[FibsemImage] = None
-        self._fib_image_layer: Optional[NapariImageLayer] = None
-        self._pattern_layer_names: List[str] = []
         # Quad-view path (set in _init_canvas_overlay when a controller exists)
         self._controller = None
         self._fib_canvas = None
         self._background_milling_stages: List[FibsemMillingStage] = []
         self._patterns_visible = True  # eye-toggle state (mirrored onto MillingSpec.visible)
-        self._pattern_update_inflight = False
         self._pattern_update_pending = False
         self._settings_emit_pending: bool = False
         self._pending_settings: Optional[FibsemMillingTaskConfig] = None
         self._right_click_menu_action_provider: Optional[
             Callable[[ContextMenuConfig, Point], None]
         ] = None
-
-        self._right_click_callback = None
 
         self._setup_ui(milling_task_config)
         self._connect_signals()
@@ -148,11 +140,9 @@ class MillingTaskViewerWidget(QWidget):
         if iw is not None:
             try:
                 self._fib_image = iw.ib_image
-                # No layer pickup: the image widget is canvas-only now, so the hosts that
-                # inject an image_widget always take the controller path below. Callers
-                # still on napari (the coincidence viewer) supply their own layer through
-                # set_fib_image(). NOTE both reads used to sit in this try together — an
-                # AttributeError on the layer would have silently skipped the connect.
+                # NOTE this connect sits inside the try with a load-bearing statement
+                # after it — an exception on the line above silently skips both it and
+                # the wiring below, and patterns quietly stop following the live image.
                 iw.viewer_update_signal.connect(self._on_viewer_image_updated)
             except Exception:
                 pass
@@ -165,9 +155,10 @@ class MillingTaskViewerWidget(QWidget):
         Milling patterns and the read-only alignment-area display are reducer-owned
         (pushed via ``controller.set_overlay`` / ``set_alignment_display``); this just
         stores the controller + FIB canvas. Only the main microscope tab injects an
-        image_widget tied to the controller, so only it takes this path. Every other
-        caller — including the napari-based Lamella Editor — leaves ``_controller``
-        None and keeps the existing napari pattern path.
+        image_widget tied to the controller, so only it takes this path. Callers with no
+        image widget attach one themselves via :meth:`set_controller` (the Lamella
+        Editor), or leave ``_controller`` None and display nothing (the coincidence
+        viewer, which renders its own overlay).
         """
         self._controller = None
         self._fib_canvas = None
@@ -191,19 +182,10 @@ class MillingTaskViewerWidget(QWidget):
         """Directly attach a :class:`MicroscopeViewController` for callers that have no
         ``image_widget`` to discover one through (e.g. the Lamella Editor).
 
-        Switches this widget onto the canvas pattern path *additively* — patterns and
-        the read-only alignment display go through the reducer, and right-click
-        reposition moves to the FIB canvas signal. The napari path is left intact for
-        any caller that never sets a controller.
+        Switches this widget onto the canvas pattern path — patterns and the read-only
+        alignment display go through the reducer, and right-click reposition is driven by
+        the FIB canvas signal.
         """
-        # tear down the napari right-click callback if it was wired at construction
-        if self.viewer is not None and self._right_click_callback is not None:
-            try:
-                self.viewer.mouse_drag_callbacks.remove(self._right_click_callback)
-            except ValueError:
-                pass
-            self._right_click_callback = None
-
         self._controller = controller
         self._fib_canvas = (
             controller.get_canvas(BeamType.ION) if controller is not None else None
@@ -226,11 +208,6 @@ class MillingTaskViewerWidget(QWidget):
                 self._controller.set_alignment_display(BeamType.ION, None, False)
             except Exception:
                 pass
-        if self.viewer is not None and self._right_click_callback is not None:
-            try:
-                self.viewer.mouse_drag_callbacks.remove(self._right_click_callback)
-            except ValueError:
-                pass
         super().closeEvent(event)
 
     # ------------------------------------------------------------------
@@ -249,49 +226,16 @@ class MillingTaskViewerWidget(QWidget):
         self._right_click_menu_action_provider = action_provider
 
     def _register_right_click_callback(self) -> None:
-        if self._controller is not None:
-            # quad-view: reposition via the FIB canvas right-click signal
-            self._fib_canvas.canvas_right_clicked.connect(self._on_canvas_right_click)
+        if self._controller is None:
             return
-        if self.viewer is None:
-            return
-        if self._right_click_callback is not None:
-            try:
-                self.viewer.mouse_drag_callbacks.remove(self._right_click_callback)
-            except ValueError:
-                pass
-        self._right_click_callback = self._on_right_click
-        self.viewer.mouse_drag_callbacks.append(self._right_click_callback)
-
-    def _on_right_click(self, viewer: napari.Viewer, event) -> None:
-        if event.button != 2 or event.type != "mouse_press":
-            return
-        if self._fib_image_layer is None or self._fib_image is None:
-            return
-        if self._fib_image.metadata is None:
-            return
-        stages = self.config_widget.milling_stages_widget.get_enabled_stages()
-        if not stages:
-            return
-        if not is_position_inside_layer(event.position, self._fib_image_layer):
-            return
-
-        event.handled = True
-
-        coords = self._fib_image_layer.world_to_data(event.position)
-        point_clicked = conversions.image_to_microscope_image_coordinates(
-            coord=Point(x=coords[1], y=coords[0]),
-            image=self._fib_image.data,
-            pixelsize=self._fib_image.metadata.pixel_size.x,
-        )
-
-        self._show_reposition_menu(point_clicked, stages)
+        # quad-view: reposition via the FIB canvas right-click signal
+        self._fib_canvas.canvas_right_clicked.connect(self._on_canvas_right_click)
 
     def _on_canvas_right_click(self, x: float, y: float, modifiers) -> None:
-        """Quad-view FIB canvas right-click → pattern reposition menu.
+        """FIB canvas right-click → pattern reposition menu.
 
-        Mirrors ``_on_right_click`` but takes pixel coords straight from the canvas
-        signal (no napari ``world_to_data`` / layer hit-test). Reuses ``_move_patterns``.
+        Takes pixel coords straight from the canvas signal and reuses
+        ``_move_patterns``.
         """
         if self._fib_image is None or self._fib_image.metadata is None:
             return
@@ -311,12 +255,7 @@ class MillingTaskViewerWidget(QWidget):
         self._show_reposition_menu(point_clicked, stages)
 
     def _show_reposition_menu(self, point_clicked: Point, stages: list) -> None:
-        """Build + show the pattern-reposition context menu at the cursor.
-
-        Shared by the napari (:meth:`_on_right_click`) and canvas
-        (:meth:`_on_canvas_right_click`) entry points, which differ only in how
-        they derive ``point_clicked``.
-        """
+        """Build + show the pattern-reposition context menu at the cursor."""
         selected = self.config_widget.milling_stages_widget._list._selected_stage
         # Fall back to first enabled stage if selected stage is disabled
         if selected is None or not selected.enabled:
@@ -383,19 +322,16 @@ class MillingTaskViewerWidget(QWidget):
         self._on_settings_changed(self.config_widget.get_settings())
 
     # ------------------------------------------------------------------
-    # Viewer / pattern display
+    # Pattern display
     # ------------------------------------------------------------------
 
-    def set_fib_image(
-        self, image: FibsemImage, image_layer: Optional[NapariImageLayer]
-    ) -> None:
-        """Inject a FIB image and its napari layer for pattern display."""
+    def set_fib_image(self, image: FibsemImage) -> None:
+        """Inject the FIB image that patterns are drawn against."""
         self._fib_image = image
-        self._fib_image_layer = image_layer
         self._schedule_pattern_update()
 
     def set_alignment_area_visible(self, visible: bool) -> None:
-        """Show/hide the alignment area rectangle in the viewer."""
+        """Show/hide the alignment area rectangle on the canvas."""
         self._show_alignment_area = visible
         self._schedule_pattern_update()
 
@@ -413,60 +349,17 @@ class MillingTaskViewerWidget(QWidget):
             logging.error(f"MillingTaskViewerWidget: viewer image update error: {e}")
 
     def _update_pattern_display(self) -> None:
-        if self._pattern_update_inflight:
-            return
-        self._pattern_update_pending = False
+        """Debounced entry point: render the current stages onto the FIB canvas.
 
-        # quad-view canvas path: render on the FIB canvas overlay, skip napari
+        Clears the pending flag first, so a change arriving while the reducer call is in
+        flight schedules a fresh pass rather than being swallowed.
+        """
+        self._pattern_update_pending = False
         if self._controller is not None:
             self._update_canvas_patterns()
-            return
-
-        if self.viewer is None or self._fib_image_layer is None:
-            return
-        if self._fib_image is None or self._fib_image.metadata is None:
-            return
-
-        self._pattern_update_inflight = True
-        config = self.config_widget.get_settings()
-        stages = config.enabled_stages
-
-        if not stages:
-            self._clear_pattern_display()
-            self._pattern_update_inflight = False
-            return
-
-        pixelsize = self._fib_image.metadata.pixel_size.x
-
-        alignment_area = None
-        if config.alignment.enabled and self._show_alignment_area:
-            alignment_area = config.alignment.rect
-        try:
-            self._pattern_layer_names = draw_milling_patterns_in_napari(
-                viewer=self.viewer,
-                image_layer=self._fib_image_layer,
-                milling_stages=stages,
-                pixelsize=pixelsize,
-                draw_crosshair=True,
-                background_milling_stages=self._background_milling_stages,
-                alignment_area=alignment_area,
-            )
-            draw_milling_fov_rect(
-                viewer=self.viewer,
-                image_layer=self._fib_image_layer,
-                field_of_view=config.field_of_view,
-                pixelsize=pixelsize,
-            )
-        except Exception as e:
-            logging.error(f"MillingTaskViewerWidget: pattern display error: {e}")
-        finally:
-            self._pattern_update_inflight = False
-            if self._pattern_update_pending:
-                self._schedule_pattern_update()
-
 
     def _update_canvas_patterns(self) -> None:
-        """Push the current enabled stages to the FIB canvas via the reducer (quad-view)."""
+        """Push the current enabled stages to the FIB canvas via the reducer."""
         if self._controller is None:
             return
         if self._fib_image is None or self._fib_image.metadata is None:
@@ -475,7 +368,7 @@ class MillingTaskViewerWidget(QWidget):
         stages = config.enabled_stages
         if not stages:
             self._controller.remove_overlay(BeamType.ION, "milling")
-            self._update_canvas_alignment(None)  # no patterns → no alignment (match napari)
+            self._update_canvas_alignment(None)  # no patterns → no alignment
             return
         self._update_canvas_alignment(config)
         selected = self.config_widget.milling_stages_widget._list._selected_stage
@@ -493,8 +386,8 @@ class MillingTaskViewerWidget(QWidget):
     def _update_canvas_alignment(self, config) -> None:
         """Push the read-only alignment-area display to the controller (quad-view).
 
-        Mirrors napari: only shown alongside patterns (i.e. when stages exist);
-        pass ``config=None`` to hide. Yields to an active edit in the reducer.
+        Only shown alongside patterns (i.e. when stages exist); pass ``config=None`` to
+        hide. Yields to an active edit in the reducer.
         """
         if self._controller is None:
             return
@@ -505,20 +398,6 @@ class MillingTaskViewerWidget(QWidget):
         )
         rect = config.alignment.rect if show else None
         self._controller.set_alignment_display(BeamType.ION, rect, show)
-
-    def _clear_pattern_display(self) -> None:
-        """Remove milling pattern layers from the viewer."""
-        if self.viewer is None:
-            return
-        try:
-            for name in self._pattern_layer_names:
-                if name in self.viewer.layers:
-                    self.viewer.layers.remove(name)  # type: ignore
-            if MILLING_FOV_LAYER_NAME in self.viewer.layers:
-                self.viewer.layers.remove(MILLING_FOV_LAYER_NAME)  # type: ignore
-        except Exception as e:
-            logging.debug(f"MillingTaskViewerWidget: error removing layers: {e}")
-        self._pattern_layer_names = []
 
     # ------------------------------------------------------------------
     # Slots
@@ -549,13 +428,8 @@ class MillingTaskViewerWidget(QWidget):
     def _on_eye_toggled(self, visible: bool) -> None:
         self._patterns_visible = visible
         if self._controller is not None:
-            # quad-view: toggle the milling overlay's visibility through the reducer
+            # toggle the milling overlay's visibility through the reducer
             self._controller.set_overlay_visible(BeamType.ION, "milling", visible)
-            return
-        if self.viewer is None:
-            return
-        if MILLING_PATTERN_LAYER_NAME in self.viewer.layers:
-            self.viewer.layers[MILLING_PATTERN_LAYER_NAME].visible = visible
 
     # ------------------------------------------------------------------
     # Public API — required by FibsemMillingWidget2

--- a/fibsem/ui/widgets/tests/test_milling_task_viewer_widget.py
+++ b/fibsem/ui/widgets/tests/test_milling_task_viewer_widget.py
@@ -5,13 +5,14 @@ Run directly:
 """
 import sys
 
-import napari
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
     QApplication,
     QHBoxLayout,
     QLabel,
     QListWidget,
     QPushButton,
+    QSplitter,
     QVBoxLayout,
     QWidget,
 )
@@ -20,18 +21,14 @@ from fibsem import utils
 from fibsem.config import AUTOLAMELLA_TASK_PROTOCOL_PATH
 from fibsem.applications.autolamella.structures import AutoLamellaTaskProtocol
 from fibsem.milling.tasks import FibsemMillingTaskConfig
-from fibsem.structures import FibsemImage
+from fibsem.structures import BeamType, FibsemImage
+from fibsem.ui.stylesheets import NAPARI_STYLE
+from fibsem.ui.widgets.canvas.quad_view import (
+    LamellaEditorView,
+    MicroscopeViewController,
+)
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 
-import warnings
-
-# Suppress a specific upstream Napari/NumPy warning from shapes miter computation.
-warnings.filterwarnings(
-    "ignore",
-    message=r"'where' used without 'out', expect unit?ialized memory in output\. If this is intentional, use out=None\.",
-    category=UserWarning,
-    module=r"napari\.layers\.shapes\._shapes_utils",
-)
 
 def _load_task_configs(path: str) -> dict:
     try:
@@ -46,38 +43,33 @@ def _load_task_configs(path: str) -> dict:
     return configs
 
 
-def _add_fib_image(viewer: napari.Viewer, hfw: float = 150e-6):
-    """Add a blank FIB image to the viewer and return (FibsemImage, napari layer)."""
+def _show_fib_image(controller: MicroscopeViewController, hfw: float = 150e-6):
+    """Push a blank FIB image onto the canvas and return it."""
     image = FibsemImage.generate_blank_image(hfw=hfw, random=True)
-    layer = viewer.add_image(
-        image.data,
-        name="FIB Image",
-        colormap="gray",
-        opacity=0.9,
-        blending="additive",
-    )
-    return image, layer
+    controller.set_image(BeamType.ION, image)
+    return image
 
 
 def main() -> None:
     app = QApplication.instance() or QApplication(sys.argv)
-    app.setStyle("Fusion")
+    app.setStyleSheet(NAPARI_STYLE)
 
     microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
 
     task_configs = _load_task_configs(AUTOLAMELLA_TASK_PROTOCOL_PATH)
     initial_config = next(iter(task_configs.values()), FibsemMillingTaskConfig())
 
-    # ── napari viewer ────────────────────────────────────────────────────
-    viewer = napari.Viewer(title="MillingTaskViewerWidget — test")
+    # ── canvas ───────────────────────────────────────────────────────────
+    # Patterns render through the reducer onto the FIB canvas, so the harness needs a
+    # controller — this is the same view the Lamella Editor drives (FIB-407).
+    view = LamellaEditorView()
+    controller = MicroscopeViewController(view=view)
+    view.show_beams()
 
-    # Add a blank FIB image so pattern display works from the start
-    fib_image, fib_layer = _add_fib_image(viewer, hfw=initial_config.field_of_view)
+    fib_image = _show_fib_image(controller, hfw=initial_config.field_of_view)
 
     # ── sidebar container ────────────────────────────────────────────────
     sidebar = QWidget()
-    sidebar.setStyleSheet("background: #2b2d31; color: #d1d2d4;")
-    sidebar.resize(480, 900)
     sidebar_layout = QVBoxLayout(sidebar)
     sidebar_layout.setContentsMargins(8, 8, 8, 8)
     sidebar_layout.setSpacing(8)
@@ -92,7 +84,6 @@ def main() -> None:
     row_layout.addWidget(lbl)
 
     task_list = QListWidget()
-    task_list.setStyleSheet("background: #1e2124; border: none;")
     task_list.setFixedHeight(120)
     for key in task_configs:
         task_list.addItem(key)
@@ -102,16 +93,16 @@ def main() -> None:
     # ── viewer widget ────────────────────────────────────────────────────
     widget = MillingTaskViewerWidget(
         microscope=microscope,
-        viewer=viewer,
         milling_task_config=initial_config,
         milling_enabled=True,
     )
+    widget.set_controller(controller)
     # Inject the blank FIB image so patterns render immediately
-    widget.set_fib_image(fib_image, fib_layer)
+    widget.set_fib_image(fib_image)
     sidebar_layout.addWidget(widget, 1)
 
     # ── status + buttons ─────────────────────────────────────────────────
-    status = QLabel("Load a task to see patterns drawn in the viewer.")
+    status = QLabel("Load a task to see patterns drawn on the FIB canvas.")
     status.setStyleSheet("color: #909090; font-style: italic;")
     sidebar_layout.addWidget(status)
 
@@ -127,8 +118,14 @@ def main() -> None:
     btn_layout.addWidget(btn_clear)
     sidebar_layout.addWidget(btn_row)
 
-    # ── dock into napari ─────────────────────────────────────────────────
-    viewer.window.add_dock_widget(sidebar, area="right", name="Milling Task")
+    # ── window: canvas | sidebar ─────────────────────────────────────────
+    window = QSplitter(Qt.Horizontal)
+    window.addWidget(controller.widget)
+    window.addWidget(sidebar)
+    window.setStretchFactor(0, 3)
+    window.setStretchFactor(1, 2)
+    window.setWindowTitle("MillingTaskViewerWidget — test")
+    window.resize(1400, 900)
 
     # ── connections ──────────────────────────────────────────────────────
     def on_task_selected(item) -> None:
@@ -138,13 +135,9 @@ def main() -> None:
             return
         widget.update_from_settings(cfg)
         # Regenerate blank image at the task's field of view
-        nonlocal fib_image, fib_layer
-        try:
-            viewer.layers.remove("FIB Image")
-        except Exception:
-            pass
-        fib_image, fib_layer = _add_fib_image(viewer, hfw=cfg.field_of_view)
-        widget.set_fib_image(fib_image, fib_layer)
+        nonlocal fib_image
+        fib_image = _show_fib_image(controller, hfw=cfg.field_of_view)
+        widget.set_fib_image(fib_image)
         status.setText(f"Loaded: {key}  ({len(cfg.stages)} stages)")
 
     def on_settings_changed(cfg: FibsemMillingTaskConfig) -> None:
@@ -155,7 +148,7 @@ def main() -> None:
 
     def on_print() -> None:
         cfg = widget.get_config()
-        print(f"\nget_config():")
+        print("\nget_config():")
         print(f"  name={cfg.name}  fov={cfg.field_of_view * 1e6:.1f} µm")
         for s in cfg.stages:
             print(
@@ -176,7 +169,10 @@ def main() -> None:
         task_list.setCurrentRow(0)
         on_task_selected(task_list.item(0))
 
-    napari.run()
+    # Standalone harness: a plain Qt window, not a napari dock. napari was only ever
+    # hosting the widget here (FIB-407).
+    window.show()
+    sys.exit(app.exec_())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sub-phase **5a** of the napari removal (FIB-407). **13 direct importers → 11**; 17 → 16
counting the `fibsem/ui/napari/` helper package. `milling_task_viewer_widget.py` is 218
lines lighter and no longer imports napari.

## 5a was not blocked

Phase 5 recorded this as blocked behind FIB-429 — the belief being that the coincidence
viewer still drove the napari pattern path. It doesn't. The path was already unreachable,
and this deletes it without any of FIB-429's work.

The draw is gated on `self.viewer is None or self._fib_image_layer is None`, and both
halves always held:

- **No production construction passed a viewer.** Six sites, all `viewer=None` or omitted,
  since both shells went viewer-less in 4a/4b.
- **No production caller set `_fib_image_layer`.** The Lamella Editor passed it explicitly
  as `None` and drives the reducer instead. The coincidence viewer has its **own**
  `set_fib_image` — a same-named method that pokes `_fib_image` directly and never passes a
  layer. Only the demo harness ever supplied one.

A stale comment in `test_lamella_protocol_editor_canvas.py` asserted the opposite ("the
remaining napari caller (the coincidence viewer) has always used set_fib_image()"); it
conflated the two same-named methods, and is corrected here.

## The bug this removes

`self.viewer = viewer or napari.current_viewer()` meant passing `None` did not mean "no
viewer" — it latched whichever napari viewer happened to be open, in practice the
**minimap's**, and appended a `mouse_drag_callback` to it holding a strong reference to the
milling widget. That callback then returned early forever because `_fib_image_layer` was
None. Two independent accidents kept it harmless.

## What stays

`is_pattern_placement_valid` is pure geometry, shared by `_move_patterns` on both paths, so
it stays. This file therefore leaves the *direct* importer set but remains a helper-package
importer until the geometry extraction (FIB-407 §1). Accounted for rather than papered over.

The demo harness now hosts a real `MicroscopeViewController` over a `LamellaEditorView`
instead of a napari viewer, so it still shows patterns — which is the only reason it exists.

## Verification

1258 passed, 1 skipped. Since this deletes 218 lines, two checks beyond the suite:

- **AST method inventory against main** — exactly two methods removed (`_on_right_click`,
  `_clear_pattern_display`), none added, and every shrunk method matches an intended edit.
  This is the check that catches a half-truncated method.
- **Both consumers built headless.** The full coincidence viewer: no `viewer` attribute, no
  controller, silent no-op pattern update. The controller path: a `MillingSpec` still
  reaches the FIB canvas with its stage, and the eye toggle still routes through the reducer.

Rebased onto current `main` and re-run green there.

## Coverage added

The **full coincidence viewer had no test at all** — the existing 16 tests only construct
its two canvas classes, never the widget. Since this changes its construction, its build and
its rect drag are now covered; the drag assertion is mutation-verified (stubbing
`_move_patterns` fails it).

Those tests use `sim-arctis-configuration.yaml` deliberately. `_connect_signals` returns at
its **first line** when `microscope.fm is None`, so on a plain demo session the viewer
constructs with none of its signals wired and any interaction test would pass vacuously
against any breakage. That cost me a false "the drag is broken on main" reading before I
spotted it.

---

FIB-429 stays open and is **not** a phase-5 blocker — it remains a fidelity fix for the
coincidence viewer, which still renders its own first-rectangle approximation. Branch and
title omit both issue IDs on purpose; that naming has auto-closed an umbrella issue twice.
