### PR TITLE
[imaging] Reduce images for display by averaging, not sampling (FIB-589)

### DIFF
--- a/fibsem/imaging/__init__.py
+++ b/fibsem/imaging/__init__.py
@@ -1,4 +1,5 @@
 from fibsem.imaging.spot import *
 from fibsem.autofunctions.gamma import auto_gamma, apply_gamma, apply_clahe
 from fibsem.imaging.masks import *
+from fibsem.imaging.reduce import downsample
 from fibsem.imaging.utils import *

--- a/fibsem/imaging/reduce.py
+++ b/fibsem/imaging/reduce.py
@@ -70,6 +70,16 @@ def downsample(arr: np.ndarray, max_px: int) -> np.ndarray:
     this cheap: ``cv2.resize`` has a fast path for an exactly-integer scale and a generic
     one about fifty times slower, so padding to an exact multiple is what buys the
     former. A 1024x1024 RGBA image reduces to 512 in 0.14 ms; the same in numpy is 72 ms.
+
+    Padding rather than shortening biases one output row and one output column toward
+    the edge pixel, since the block is completed with copies of it. On a 1024x4712 plane
+    at factor 10 that block is 60% replicated, but it is one row of 103, and the error
+    tracks how much the last few rows resemble each other: 0.1/255 on smooth data,
+    1.8 on lightly textured, 32 on pure noise, 76 on an alternating hard edge. Accepted
+    because an overview's tiles overlap, so that row is covered by the neighbour drawn
+    over it -- 10% by default for FM. Note the beam tiler defaults to no overlap at all,
+    where nothing covers it; still negligible at these magnitudes, but not for the same
+    reason. Switch to :func:`_box_mean_numpy` for the exact short-block answer at ~5x.
     """
     h, w = arr.shape[:2]
     if h <= max_px and w <= max_px:

--- a/fibsem/imaging/reduce.py
+++ b/fibsem/imaging/reduce.py
@@ -28,9 +28,11 @@ import numpy as np
 __all__ = ["downsample"]
 
 
-# Element types `cv2.resize` accepts. Anything else takes the numpy path, which is a few
-# hundred times slower but answers for every dtype. Pinned by a test that feeds each one
-# to cv2 for real, so the list cannot quietly rot against a new OpenCV.
+# Element types `cv2.resize` accepts. Anything else takes the numpy path, which answers
+# for every dtype at 5x to 217x the cost -- nearer the top of that range for the square
+# images this mostly sees, and nearer the bottom for a long mosaic plane. Pinned by a
+# test that feeds each one to cv2 for real, so the list cannot quietly rot against a new
+# OpenCV.
 _CV2_DTYPES = frozenset(
     np.dtype(name) for name in ("uint8", "uint16", "int16", "float32", "float64")
 )
@@ -79,7 +81,8 @@ def downsample(arr: np.ndarray, max_px: int) -> np.ndarray:
     because an overview's tiles overlap, so that row is covered by the neighbour drawn
     over it -- 10% by default for FM. Note the beam tiler defaults to no overlap at all,
     where nothing covers it; still negligible at these magnitudes, but not for the same
-    reason. Switch to :func:`_box_mean_numpy` for the exact short-block answer at ~5x.
+    reason. :func:`_box_mean_numpy` gives the exact short-block answer instead, at
+    anywhere from 5x to 217x the cost depending on shape.
     """
     h, w = arr.shape[:2]
     if h <= max_px and w <= max_px:

--- a/fibsem/imaging/reduce.py
+++ b/fibsem/imaging/reduce.py
@@ -1,0 +1,83 @@
+"""Reducing an image to a display size without deleting what is in it.
+
+Anything that shows a large image in a small space has to throw pixels away, and there
+are two ways to do it. Sampling — ``arr[::n, ::n]`` — is free, and wrong: it does not
+blur what it leaves out, it deletes it. A feature a pixel or two across survives only
+when it happens to land on a sampled row, so it is absent at one zoom and present at the
+next, and blinks when the view moves by a single pixel, with nothing on screen saying
+the picture is incomplete. For fluorescence that is the worst available failure mode,
+the small bright thing being what someone is looking for.
+
+Averaging over each block instead attenuates such a feature rather than removing it, and
+holds it steady while panning. It costs an allocation where sampling returned a view --
+though a strided view is not the saving it appears to be, since it keeps its parent's
+whole buffer alive behind it.
+
+Kept out of the UI package so it is usable, and testable, without Qt.
+"""
+
+from __future__ import annotations
+
+import math
+
+import cv2
+import numpy as np
+
+__all__ = ["downsample"]
+
+
+# Element types `cv2.resize` accepts. Anything else takes the numpy path, which is a few
+# hundred times slower but answers for every dtype. Pinned by a test that feeds each one
+# to cv2 for real, so the list cannot quietly rot against a new OpenCV.
+_CV2_DTYPES = frozenset(
+    np.dtype(name) for name in ("uint8", "uint16", "int16", "float32", "float64")
+)
+
+
+def _box_mean_numpy(arr: np.ndarray, factor: int, out_h: int, out_w: int) -> np.ndarray:
+    """Block mean in numpy, for the arrays cv2 will not take."""
+    pad = [(0, out_h * factor - arr.shape[0]), (0, out_w * factor - arr.shape[1])]
+    pad += [(0, 0)] * (arr.ndim - 2)
+    # float32 for anything narrower, so an 8-bit mosaic is not accumulated at 8 bytes a
+    # pixel; float64 input stays float64. A block holds at most `factor**2` values, well
+    # short of what either accumulator can represent exactly.
+    acc = np.promote_types(arr.dtype, np.float32)
+    padded = np.pad(arr.astype(acc, copy=False), pad, mode="edge")
+    out = padded.reshape(out_h, factor, out_w, factor, *arr.shape[2:]).mean(axis=(1, 3))
+    if np.issubdtype(arr.dtype, np.integer):
+        out = np.rint(out)  # truncating would bias every reduced image darker
+    return out.astype(arr.dtype, copy=False)
+
+
+def downsample(arr: np.ndarray, max_px: int) -> np.ndarray:
+    """*arr* reduced until neither side exceeds *max_px*, by averaging over each block.
+
+    Averaged, not sampled — see the module docstring for why that distinction is the
+    whole point of this function. Returns *arr* itself when it is already small enough.
+
+    Shape is ``ceil(n / factor)`` per axis, which is what ``arr[::factor, ::factor]``
+    gave, so this drops into a sampling call site unchanged. Note that the reduction is
+    uniform across both axes, so a non-square image keeps its aspect ratio but may exceed
+    *max_px* on neither side and fall well under it on one.
+
+    dtype is preserved, which matters more than it looks: matplotlib reads an RGB array's
+    value range from its dtype, ``uint8`` meaning 0-255 and float meaning 0-1, so
+    returning a float for a ``uint8`` image renders it white.
+
+    The ragged final block is edge-padded rather than left short, and that is what keeps
+    this cheap: ``cv2.resize`` has a fast path for an exactly-integer scale and a generic
+    one about fifty times slower, so padding to an exact multiple is what buys the
+    former. A 1024x1024 RGBA image reduces to 512 in 0.14 ms; the same in numpy is 72 ms.
+    """
+    h, w = arr.shape[:2]
+    if h <= max_px and w <= max_px:
+        return arr
+    factor = max(1, math.ceil(max(h, w) / max_px))
+    out_h, out_w = math.ceil(h / factor), math.ceil(w / factor)
+    too_many_channels = arr.ndim > 3 or (arr.ndim == 3 and arr.shape[2] > 4)
+    if arr.dtype not in _CV2_DTYPES or too_many_channels:
+        return _box_mean_numpy(arr, factor, out_h, out_w)
+    pad_h, pad_w = out_h * factor - h, out_w * factor - w
+    if pad_h or pad_w:
+        arr = cv2.copyMakeBorder(arr, 0, pad_h, 0, pad_w, cv2.BORDER_REPLICATE)
+    return cv2.resize(arr, (out_w, out_h), interpolation=cv2.INTER_AREA)

--- a/fibsem/imaging/reduce.py
+++ b/fibsem/imaging/reduce.py
@@ -9,9 +9,11 @@ the picture is incomplete. For fluorescence that is the worst available failure 
 the small bright thing being what someone is looking for.
 
 Averaging over each block instead attenuates such a feature rather than removing it, and
-holds it steady while panning. It costs an allocation where sampling returned a view --
-though a strided view is not the saving it appears to be, since it keeps its parent's
-whole buffer alive behind it.
+holds it steady while panning. It costs an allocation where sampling returned a view.
+That is a real cost and not a hidden saving: a strided view does keep its parent's whole
+buffer alive, but matplotlib copies at ``imshow`` anyway, so on the canvas path the
+source was already released either way. Measured with weakrefs over twenty placed tiles,
+neither reduction leaves a single source alive.
 
 Kept out of the UI package so it is usable, and testable, without Qt.
 """

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -32,7 +32,6 @@ and the milling / mask / alignment / minimap overlays).
 from __future__ import annotations
 
 import logging
-import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
@@ -130,14 +129,6 @@ _OVERLAY_GAP = 2
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _downsample(arr: np.ndarray, max_px: int) -> np.ndarray:
-    h, w = arr.shape[:2]
-    if h <= max_px and w <= max_px:
-        return arr
-    stride = max(1, math.ceil(max(h, w) / max_px))
-    return arr[::stride, ::stride] if arr.ndim == 2 else arr[::stride, ::stride, :]
 
 
 # Keyboard modifiers mapped to napari-style strings, so handler bodies that

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -42,7 +42,8 @@ from fibsem.ui.tokens import (
 from fibsem.ui.widgets.canvas.fm_composite import (
     AVAILABLE_COLORS, FMLayer, auto_clim, composite_fm_layers, to_rgba,
 )
-from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase, _downsample
+from fibsem.imaging.reduce import downsample
+from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
 from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
 
@@ -726,10 +727,15 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
     def _reduce(self, plane: np.ndarray) -> np.ndarray:
         """A plane at the resolution the canvas will actually store.
 
-        `_downsample` strides, so this is a view rather than a copy — the reduction
-        itself costs nothing, and the blend that follows costs what is displayed.
+        `downsample` box-averages, so this allocates rather than returning a view — 2 ms
+        for a 1024x4712 mosaic plane, against the ~150 ms blend it saves by running
+        before the blend rather than after. It used to stride, which cost nothing at all;
+        the change bought back the fine structure that striding deleted.
+
+        Runs on every layer change, once per held image per channel, so it is the one
+        place where that per-call cost is multiplied. Watch it if either count grows.
         """
-        return _downsample(np.asarray(plane), self.canvas._display_max_px)
+        return downsample(np.asarray(plane), self.canvas._display_max_px)
 
     def _composite_inputs(self) -> Tuple[List[FMLayer], Optional[Tuple[int, int]]]:
         """Blend at display resolution, not acquisition resolution.

--- a/fibsem/ui/widgets/canvas/image_canvas.py
+++ b/fibsem/ui/widgets/canvas/image_canvas.py
@@ -12,11 +12,11 @@ from typing import Optional, Tuple
 
 import numpy as np
 
+from fibsem.imaging.reduce import downsample
 from fibsem.structures import FibsemImage
 from fibsem.ui.widgets.canvas.canvas_base import (
     _MAX_DISPLAY_PX,
     FibsemCanvasBase,
-    _downsample,
 )
 
 _logger = logging.getLogger(__name__)
@@ -78,7 +78,7 @@ class FibsemImageCanvas(FibsemCanvasBase):
         self._ax.axis("off")
         self._fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
 
-        self._display_base = _downsample(arr, _MAX_DISPLAY_PX)
+        self._display_base = downsample(arr, _MAX_DISPLAY_PX)
         self._is_gray = arr.ndim == 2
         self._norm = None  # recomputed lazily when contrast is engaged
         extent = (-0.5, w - 0.5, h - 0.5, -0.5)
@@ -128,7 +128,7 @@ class FibsemImageCanvas(FibsemCanvasBase):
         imgs = self._ax.get_images()
         if not imgs:
             return
-        self._display_base = _downsample(arr, _MAX_DISPLAY_PX)
+        self._display_base = downsample(arr, _MAX_DISPLAY_PX)
         self._is_gray = arr.ndim == 2
         self._norm = None
         to_show, clim = self._contrast_display()

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -31,12 +31,12 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
+from fibsem.imaging.reduce import downsample
 from fibsem.ui.stylesheets import GRAY_CANVAS_COLOR
 from fibsem.ui.widgets.canvas.canvas_base import (
     EMPTY_CONTENT,
     ContentRect,
     FibsemCanvasBase,
-    _downsample,
 )
 
 _logger = logging.getLogger(__name__)
@@ -51,7 +51,9 @@ _ORIGIN_MARKER_COLOUR = "#ff5252"
 # redraw costs the *total* stored pixels — 100 tiles kept at 1024 px square take ~2.7 s,
 # against ~0.75 s at 512. And 512 is already more than the display can use for the case
 # this canvas exists for: tiles in a 3x3 occupy ~330 screen px each, in a 10x10 ~100 px.
-# It only costs detail when zooming deep into one image; see FIB-414 for the real fix.
+# The reduction box-averages, so the cap costs resolution and nothing else — a feature
+# smaller than a stored pixel is dimmed into its neighbours rather than dropped. What it
+# still cannot do is give the detail back on zoom; that is FIB-414, the pyramid.
 _DEFAULT_DISPLAY_PX = 512
 
 
@@ -194,7 +196,7 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
             self._remove_artist(existing)
 
         extent = self._extent_for(data.shape, centre, pixel_size, covers)
-        shown = _downsample(data, self._display_max_px)
+        shown = downsample(data, self._display_max_px)
         kw = {} if zorder is None else {"zorder": zorder}
         artist = self._ax.imshow(
             shown,
@@ -226,7 +228,7 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
             return False
         data = np.asarray(data)
         _require_displayable(data)
-        placed.artist.set_data(_downsample(data, self._display_max_px))
+        placed.artist.set_data(downsample(data, self._display_max_px))
         self.draw_idle()
         return True
 

--- a/tests/test_image_reduction.py
+++ b/tests/test_image_reduction.py
@@ -1,0 +1,184 @@
+"""Images are reduced for display by averaging, not by sampling (FIB-589).
+
+Every canvas caps what each placed image stores, so a 1024-px tile is drawn from a few
+hundred. The reduction used to be `arr[::n, ::n]`, which does not blur what it leaves
+out — it deletes it. A punctum a pixel or two across survived only when it happened to
+land on a sampled row, so it vanished when zoomed out, came back when zoomed in, and
+blinked when the view shifted by a pixel, with nothing on screen saying so. For
+fluorescence that is the worst available failure mode: the small bright thing is the
+thing being looked for.
+
+What is pinned here is the property, not the implementation — `test_a_lone_punctum...`
+fails outright against striding. The rest guard the things a faster implementation is
+likely to quietly break: the output shape downstream inherited, the dtype matplotlib
+reads the value range from, and the ragged final block.
+
+Lives in `tests/` rather than `tests/ui/` because `fibsem.imaging.reduce` needs no Qt.
+That is the point of it being there: everything under `fibsem.ui` is skipped in CI,
+which installs `.[test]` without the UI extra.
+"""
+
+import math
+
+import cv2
+import numpy as np
+import pytest
+
+from fibsem.imaging.reduce import _CV2_DTYPES, _box_mean_numpy, downsample
+
+
+def stride(arr: np.ndarray, max_px: int) -> np.ndarray:
+    """The implementation this replaced, for shape parity and discrimination."""
+    h, w = arr.shape[:2]
+    if h <= max_px and w <= max_px:
+        return arr
+    n = max(1, math.ceil(max(h, w) / max_px))
+    return arr[::n, ::n] if arr.ndim == 2 else arr[::n, ::n, :]
+
+
+def block_mean(arr: np.ndarray, factor: int) -> np.ndarray:
+    """Reference block mean, edge-padding the ragged final block. Deliberately naive."""
+    h, w = arr.shape[:2]
+    out_h, out_w = math.ceil(h / factor), math.ceil(w / factor)
+    pad = [(0, out_h * factor - h), (0, out_w * factor - w)] + [(0, 0)] * (arr.ndim - 2)
+    padded = np.pad(arr.astype(np.float64), pad, mode="edge")
+    return padded.reshape(out_h, factor, out_w, factor, *arr.shape[2:]).mean(axis=(1, 3))
+
+
+class TestFineStructureSurvives:
+    def test_a_lone_punctum_does_not_blink_with_the_sampling_grid(self):
+        """The reported failure. Striding fails this test at five offsets out of six.
+
+        One bright pixel, moved a few pixels at a time, reduced 8x. Sampling reports 255
+        at the one offset that lands on the grid and 0 at every other — so panning makes
+        the feature flash. Averaging reports the same attenuated value wherever it sits.
+        """
+        seen = set()
+        for shift in range(8):
+            frame = np.zeros((512, 512), np.uint8)
+            frame[100 + shift, 100 + shift] = 255
+            seen.add(int(downsample(frame, 64).max()))
+
+        assert len(seen) == 1, (
+            f"the same punctum reduced to {sorted(seen)} depending only on where it sat "
+            f"relative to the sampling grid — it will blink as the view is panned"
+        )
+        assert seen != {0}, "the punctum was dropped at every offset"
+
+    def test_fine_structure_is_averaged_rather_than_deleted(self):
+        """The checkerboard from the issue: 1-px structure, reduced 8x."""
+        board = (np.indices((512, 512)).sum(axis=0) % 2 * 255).astype(np.uint8)
+
+        assert set(np.unique(stride(board, 64))) == {0}, "premise: striding deletes it"
+        assert set(np.unique(downsample(board, 64))) == {128}, "expected mid-grey"
+
+    def test_a_reduced_image_keeps_the_brightness_of_the_original(self):
+        """Sampling reports whatever it landed on; a mean cannot drift off the source."""
+        rng = np.random.default_rng(0)
+        img = (rng.random((1024, 1024)) * 200 + 20).astype(np.uint8)
+
+        assert downsample(img, 128).mean() == pytest.approx(img.mean(), abs=0.5)
+
+
+class TestTheContractDownstreamInherited:
+    SHAPES = [(1024, 1024), (1000, 900), (1023, 777), (10, 10000), (513, 512), (5, 5),
+              (4096, 4096), (777, 1023, 3), (100, 3000, 4)]
+
+    @pytest.mark.parametrize("shape", SHAPES)
+    @pytest.mark.parametrize("max_px", [512, 128, 64])
+    def test_the_output_shape_is_what_striding_gave(self, shape, max_px):
+        """`ceil(n / factor)` per axis. Nothing downstream should notice the change."""
+        arr = np.zeros(shape, np.uint8)
+
+        assert downsample(arr, max_px).shape == stride(arr, max_px).shape
+
+    def test_an_image_small_enough_is_returned_untouched(self):
+        """Not merely equal — the same object, as before. The common case allocates nothing."""
+        small = np.zeros((100, 100), np.uint8)
+
+        assert downsample(small, 512) is small
+
+    @pytest.mark.parametrize("dtype", ["uint8", "uint16", "int16", "float32", "float64", "int32"])
+    @pytest.mark.parametrize("shape", [(1024, 1024), (1024, 1024, 3), (1024, 1024, 4)])
+    def test_dtype_and_channels_are_preserved(self, dtype, shape):
+        """matplotlib reads an RGB array's value range from its dtype — uint8 is 0-255
+        and float is 0-1, so returning a float from a uint8 image renders white."""
+        arr = (np.random.default_rng(1).random(shape) * 100).astype(dtype)
+
+        out = downsample(arr, 128)
+
+        assert out.dtype == arr.dtype
+        assert out.shape[2:] == arr.shape[2:]
+
+
+class TestTheBlocksThemselves:
+    @pytest.mark.parametrize("shape,max_px", [
+        ((1024, 1024), 512),   # factor 2, divides exactly
+        ((1024, 1024), 128),   # factor 8, divides exactly
+        ((1023, 777), 512),    # factor 2, ragged on both axes
+        ((1024, 4712), 512),   # factor 10, ragged — the mosaic case
+        ((7, 7), 3),           # tiny, so a wrong tail is a third of the picture
+    ])
+    def test_each_output_pixel_is_the_mean_of_its_block(self, shape, max_px):
+        rng = np.random.default_rng(2)
+        arr = (rng.random(shape) * 255).astype(np.uint8)
+        factor = max(1, math.ceil(max(shape[:2]) / max_px))
+
+        out = downsample(arr, max_px).astype(float)
+
+        # 0.5 is integer rounding; anything larger is a real disagreement.
+        assert np.abs(out - block_mean(arr, factor)).max() <= 0.5
+
+    def test_the_ragged_final_block_is_not_cropped_away(self):
+        """Cropping the remainder instead of padding it would stretch the picture inside
+        the extent it is drawn at, which for the real-space canvas means placing it
+        somewhere it was not acquired."""
+        arr = np.zeros((10, 10), np.uint8)
+        arr[-1, -1] = 255  # only in the final, short block
+
+        # factor 3 -> blocks of 3, 3, 3, and a last one of 1
+        assert downsample(arr, 4)[-1, -1] > 0, "the last row and column were dropped"
+
+
+class TestTheTwoImplementationsAgree:
+    """cv2 does the work; numpy answers for the dtypes cv2 refuses. They must match."""
+
+    @pytest.mark.parametrize("dtype", sorted(str(d) for d in _CV2_DTYPES))
+    def test_cv2_really_does_accept_every_listed_dtype(self, dtype):
+        """The list is a hand-written claim about OpenCV. Check it against OpenCV.
+
+        Getting it wrong in this direction is the silent failure: an unsupported dtype
+        would raise `cv2.error` out of a paint, which PyQt5 turns into a process abort
+        (FIB-329) rather than a traceback.
+        """
+        arr = (np.random.default_rng(3).random((600, 600)) * 100).astype(dtype)
+
+        assert downsample(arr, 128).dtype == np.dtype(dtype)
+
+    @pytest.mark.parametrize("dtype", ["int8", "int32", "int64", "bool"])
+    def test_a_dtype_cv2_refuses_still_reduces(self, dtype):
+        """Striding worked on anything. The fallback keeps that true."""
+        arr = (np.random.default_rng(4).random((600, 600)) * 100).astype(dtype)
+        with pytest.raises(cv2.error):
+            cv2.resize(arr, (128, 128), interpolation=cv2.INTER_AREA)
+
+        out = downsample(arr, 128)
+
+        assert out.dtype == arr.dtype
+        assert out.shape == stride(arr, 128).shape
+
+    def test_the_fallback_gives_what_cv2_gives(self):
+        """Cross-checked on a dtype both take, since no input exercises both paths."""
+        rng = np.random.default_rng(5)
+        arr = (rng.random((1023, 777)) * 255).astype(np.uint8)
+        factor = 2
+
+        by_cv2 = downsample(arr, 512)
+        by_numpy = _box_mean_numpy(arr, factor, math.ceil(1023 / factor), math.ceil(777 / factor))
+
+        assert by_numpy.shape == by_cv2.shape
+        assert np.abs(by_numpy.astype(int) - by_cv2.astype(int)).max() <= 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_image_reduction.py
+++ b/tests/test_image_reduction.py
@@ -98,6 +98,19 @@ class TestTheContractDownstreamInherited:
 
         assert downsample(small, 512) is small
 
+    def test_a_reduced_image_is_a_copy_rather_than_a_view(self):
+        """The cost the caller is paying, stated so it cannot be mistaken for a saving.
+
+        `arr[::n, ::n]` was free and shared the source's buffer, which also kept the
+        source alive. That sounds like this change reduces memory, and on the canvas it
+        does not: matplotlib copies at `imshow`, so the source was released either way.
+        Measured with weakrefs over twenty placed tiles, neither reduction leaves a
+        single source alive. What changes here is only that the copy happens earlier.
+        """
+        arr = np.zeros((1024, 1024), np.uint8)
+
+        assert not np.shares_memory(downsample(arr, 512), arr)
+
     @pytest.mark.parametrize("dtype", ["uint8", "uint16", "int16", "float32", "float64", "int32"])
     @pytest.mark.parametrize("shape", [(1024, 1024), (1024, 1024, 3), (1024, 1024, 4)])
     def test_dtype_and_channels_are_preserved(self, dtype, shape):


### PR DESCRIPTION
Closes FIB-589. Split out of FIB-414, which bundled a bug and a feature — FIB-414 now keeps the pyramid alone, and has been retitled and dropped to Medium.

## The bug

Every canvas caps what each placed image stores (`display_max_px`, default 512), so a 1024 px tile is drawn from 512. `_downsample` did that with `arr[::n, ::n]`, which does not blur what it leaves out — it deletes it.

A punctum a pixel or two across therefore survived only when it happened to land on a sampled row. Absent when zoomed out, present when zoomed in, and blinking as the view panned by a single pixel, with nothing on screen saying the picture was incomplete. For fluorescence that is the worst available failure mode, the small bright thing being what someone is looking for.

Measured on 200 synthetic puncta reduced 8x:

| | 3x3 puncta | 1x1 puncta |
| -- | -- | -- |
| sampled | 15 / 100 | 12 / 100 |
| averaged | 100 / 100 | 44 / 100 |

Walking one punctum across the sampling grid, striding reports 255 at every eighth position and 0 everywhere else. Averaging reports 4 at all of them.

## The fix

Box-averaging, via `cv2.resize` with `INTER_AREA`. The ragged final block is edge-padded rather than left short: OpenCV has a fast path for an exactly-integer scale and a generic one about fifty times slower, so padding to an exact multiple is what buys the former. A numpy block-mean covers the dtypes cv2 refuses (`int8`, `int32`, `int64`, `bool`), so the helper stays as total as striding was.

| input, uint8 -> 512 cap | before | after (cv2) | numpy fallback |
| -- | -- | -- | -- |
| 1024^2 | free (a view) | 0.071 ms | 6.8 ms (96x) |
| 1024^2 RGBA | free | 0.141 ms | 30.5 ms (217x) |
| 2048^2 RGBA | free | 0.559 ms | 91.2 ms (163x) |
| 1024x4712 mosaic plane | free | 2.06 ms | 10.6 ms (5x) |

The fallback ratio depends on shape: near the top for square images, near the bottom for a long mosaic plane where cv2's own cost rises as the scale stops being a small integer.

Output shape is unchanged — `ceil(n / factor)` per axis, as striding gave — so no caller sees a difference. Placement was never affected either way, since an image is drawn at an extent computed from its original shape, not from the reduction.

## Moved out of the UI package

`canvas_base` defined `_downsample` for its three subclasses and never called it. It is now `fibsem/imaging/reduce.py::downsample`, which needs no Qt — verified by importing it with `PyQt5`, `napari` and `qtpy` blocked at `sys.meta_path`; it loads without even pulling matplotlib.

That matters for coverage: everything under `fibsem.ui` is skipped in CI, which installs `.[test]` without the UI extra. The tests are in `tests/test_image_reduction.py` and **actually run**. FIB-414 will want the same reduction to build its levels, so it is in the right place for that too.

## The cost, stated plainly

The reduction is now a copy where it used to be a view, and that is a straight cost.

An earlier revision of this PR claimed otherwise — that the strided view held its parent's whole buffer alive, so the cap had never been capping memory. That was an RSS measurement (80.9 MB against 2.2 MB over fifty tiles) reading back allocator warm-up: running the *same* implementation twice gives 78.1 MB then 3.7 MB. Checked properly with weakrefs over twenty tiles, zero sources survive under either reduction, because matplotlib copies at `imshow`. The cap was doing its job. Corrected in `6c3aba63`, and pinned by a test.

**`FMRealSpaceCanvasWidget._reduce` is no longer free.** It runs once per held image per channel on every layer change and used to return a view. At 2 ms per mosaic plane it sits well inside the ~150 ms blend it saves by running before the blend rather than after, but it is the one place where the per-call cost multiplies with two counts. Noted in its docstring.

## What this does not fix

A single-pixel punctum reduced 8x is worth 4/255 — present, stable and recoverable with contrast, but at the noise floor. Averaging stops the structure being deleted; it cannot make one pixel visible at that zoom. Giving detail back on zoom is FIB-414.

## Testing

12 tests, 66 cases with parametrisation, pinning the property rather than the implementation. Nine cases fail against striding, checked by putting it back:

- a lone punctum reports the same value at all eight offsets across the sampling grid (striding gives `{0, 255}`)
- the reduction is a copy, not a view sharing the source's buffer
- the 1-px checkerboard reduces to mid-grey rather than to a single flat value
- each output pixel equals the mean of its block, including for ragged shapes
- output shape matches striding across 27 shape/cap combinations
- dtype and channel axis preserved, since matplotlib reads an RGB array's value range from its dtype
- `cv2` really does accept every dtype in `_CV2_DTYPES`, and really does reject the ones routed to numpy — so the list cannot rot in either direction
- the two implementations agree on a dtype both accept

374 canvas tests pass unchanged.
