### PR TITLE
[fix] Three lamella card layouts, chosen from display preferences (FIB-585)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -30,6 +30,7 @@ from PyQt5.QtWidgets import (
     QTextEdit,
     QSplitter,
     QTabWidget,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -61,6 +62,7 @@ from fibsem.ui.stylesheets import (
     GRAY_ICON_COLOR,
     DEFECT_ORANGE_COLOR,
     WORKFLOW_BORDER_STYLESHEET,
+    TOOLBUTTON_ICON_STYLESHEET,
 )
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
 from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
@@ -1586,9 +1588,30 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         card_scroll.setStyleSheet(
             "QScrollArea { border: none; background: transparent; }"
         )
-        card_scroll.setMaximumWidth(340)
 
-        outer_splitter.addWidget(card_scroll)
+        # Density toggle. Above the scroll area rather than inside it, so it does not
+        # scroll away with the cards. The icon shows what you get by clicking, not the
+        # state you are in, so the button needs no checked styling to be readable.
+        self.btn_card_density = QToolButton()
+        self.btn_card_density.setStyleSheet(TOOLBUTTON_ICON_STYLESHEET)
+        self.btn_card_density.setAutoRaise(True)
+        self.btn_card_density.clicked.connect(self._on_toggle_card_density)
+        self._sync_card_density_button()
+
+        card_header = QHBoxLayout()
+        card_header.setContentsMargins(8, 2, 8, 2)
+        card_header.addStretch(1)
+        card_header.addWidget(self.btn_card_density)
+
+        card_panel = QWidget()
+        card_panel.setMaximumWidth(340)
+        card_panel_layout = QVBoxLayout(card_panel)
+        card_panel_layout.setContentsMargins(0, 0, 0, 0)
+        card_panel_layout.setSpacing(0)
+        card_panel_layout.addLayout(card_header)
+        card_panel_layout.addWidget(card_scroll, 1)
+
+        outer_splitter.addWidget(card_panel)
         outer_splitter.setStretchFactor(0, 0)
 
         # ── Right: sub-tab widget ──────────────────────────────────────────
@@ -1731,6 +1754,21 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.task_widget.workflow_config_changed.connect(
             self.lamella_workflow_widget.set_workflow_config
         )
+
+    def _on_toggle_card_density(self):
+        """Flip the lamella strip between the compact row and the large tile."""
+        self.lamella_card_container.set_compact(
+            not self.lamella_card_container.is_compact()
+        )
+        self._sync_card_density_button()
+
+    def _sync_card_density_button(self):
+        """Point the button at the arrangement it would switch to."""
+        compact = self.lamella_card_container.is_compact()
+        icon = "mdi:view-agenda" if compact else "mdi:view-list"
+        tip = "Show large cards" if compact else "Show compact cards"
+        self.btn_card_density.setIcon(fibsem_icon(icon, color=GRAY_ICON_COLOR))
+        self.btn_card_density.setToolTip(tip)
 
     def _on_lamella_card_selected(self, lamella: Lamella | None):
         """Update task image panel and protocol editor for selected lamella card."""

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -30,7 +30,6 @@ from PyQt5.QtWidgets import (
     QTextEdit,
     QSplitter,
     QTabWidget,
-    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -62,7 +61,6 @@ from fibsem.ui.stylesheets import (
     GRAY_ICON_COLOR,
     DEFECT_ORANGE_COLOR,
     WORKFLOW_BORDER_STYLESHEET,
-    TOOLBUTTON_ICON_STYLESHEET,
 )
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
 from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
@@ -638,6 +636,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self._toasts_enabled = d.toasts_enabled
         self._border_enabled = d.border_enabled
         self.dev_mode = d.dev_mode
+        # The lamella strip's density. Guarded because _apply_preferences also runs
+        # before the Lamella tab is built.
+        if hasattr(self, "lamella_card_container"):
+            self.lamella_card_container.set_mode(d.lamella_card_mode)
         # Sync Test menu toggle actions
         self.action_sound_toggle.setChecked(d.sound_enabled)
         self.action_toasts_toggle.setChecked(d.toasts_enabled)
@@ -1567,7 +1569,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         outer_splitter.setChildrenCollapsible(True)
 
         # ── Left: 1-column card strip ──────────────────────────────────────
-        self.lamella_card_container = LamellaCardContainer(columns=1)
+        self.lamella_card_container = LamellaCardContainer(
+            columns=1, mode=self._preferences.display.lamella_card_mode
+        )
         self.lamella_card_container.defect_changed.connect(
             self._on_lamella_defect_changed
         )
@@ -1589,29 +1593,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             "QScrollArea { border: none; background: transparent; }"
         )
 
-        # Density toggle. Above the scroll area rather than inside it, so it does not
-        # scroll away with the cards. The icon shows what you get by clicking, not the
-        # state you are in, so the button needs no checked styling to be readable.
-        self.btn_card_density = QToolButton()
-        self.btn_card_density.setStyleSheet(TOOLBUTTON_ICON_STYLESHEET)
-        self.btn_card_density.setAutoRaise(True)
-        self.btn_card_density.clicked.connect(self._on_toggle_card_density)
-        self._sync_card_density_button()
+        card_scroll.setMaximumWidth(340)
 
-        card_header = QHBoxLayout()
-        card_header.setContentsMargins(8, 2, 8, 2)
-        card_header.addStretch(1)
-        card_header.addWidget(self.btn_card_density)
-
-        card_panel = QWidget()
-        card_panel.setMaximumWidth(340)
-        card_panel_layout = QVBoxLayout(card_panel)
-        card_panel_layout.setContentsMargins(0, 0, 0, 0)
-        card_panel_layout.setSpacing(0)
-        card_panel_layout.addLayout(card_header)
-        card_panel_layout.addWidget(card_scroll, 1)
-
-        outer_splitter.addWidget(card_panel)
+        outer_splitter.addWidget(card_scroll)
         outer_splitter.setStretchFactor(0, 0)
 
         # ── Right: sub-tab widget ──────────────────────────────────────────
@@ -1754,21 +1738,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.task_widget.workflow_config_changed.connect(
             self.lamella_workflow_widget.set_workflow_config
         )
-
-    def _on_toggle_card_density(self):
-        """Flip the lamella strip between the compact row and the large tile."""
-        self.lamella_card_container.set_compact(
-            not self.lamella_card_container.is_compact()
-        )
-        self._sync_card_density_button()
-
-    def _sync_card_density_button(self):
-        """Point the button at the arrangement it would switch to."""
-        compact = self.lamella_card_container.is_compact()
-        icon = "mdi:view-agenda" if compact else "mdi:view-list"
-        tip = "Show large cards" if compact else "Show compact cards"
-        self.btn_card_density.setIcon(fibsem_icon(icon, color=GRAY_ICON_COLOR))
-        self.btn_card_density.setToolTip(tip)
 
     def _on_lamella_card_selected(self, lamella: Lamella | None):
         """Update task image panel and protocol editor for selected lamella card."""

--- a/fibsem/applications/autolamella/ui/lamella_card_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_card_widget.py
@@ -40,6 +40,10 @@ _THUMB_PADDING = 6        # inset from card edges so rounded corners stay visibl
 # width it takes comes off the status line, which is the part carrying detail.
 _THUMB_W = 66
 _THUMB_H = 44
+# The tile arrangement's thumbnail: the full card width less its padding, at the
+# height the card carried before it was made compact.
+_FULL_THUMB_W = _CARD_WIDTH - 8 - _THUMB_PADDING * 2
+_FULL_THUMB_H = 170
 _BTN_SIZE = 24
 
 _CARD_STYLE = f"""
@@ -92,9 +96,15 @@ class LamellaCardWidget(QWidget):
     update_position_requested = pyqtSignal(object)  # Lamella
     remove_requested = pyqtSignal(object)           # Lamella
 
-    def __init__(self, lamella: Lamella, parent: Optional[QWidget] = None) -> None:
+    def __init__(
+        self,
+        lamella: Lamella,
+        compact: bool = True,
+        parent: Optional[QWidget] = None,
+    ) -> None:
         super().__init__(parent)
         self.lamella = lamella
+        self._compact = compact
         self.setFixedWidth(_CARD_WIDTH)
 
         outer = QVBoxLayout(self)
@@ -107,33 +117,24 @@ class LamellaCardWidget(QWidget):
         self._card.setStyleSheet(_CARD_STYLE)
         self._card.setFixedWidth(_CARD_WIDTH - 8)
 
-        # A row, not a stack: the strip is one column in a 340px-wide scroll area,
-        # so height is what limits how many lamellae are visible at once. The old
-        # portrait card with its 170px thumbnail showed two (FIB-585).
-        card_layout = QHBoxLayout(self._card)
-        card_layout.setContentsMargins(_THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING)
-        card_layout.setSpacing(6)
+        # The frame holds one content widget, which `_apply_layout` swaps. The two
+        # arrangements differ in geometry only -- same children, same signals, same
+        # refresh() -- so nothing below this line knows which one is showing, and
+        # there is no second display path to keep correct.
+        self._frame_layout = QVBoxLayout(self._card)
+        self._frame_layout.setContentsMargins(0, 0, 0, 0)
+        self._frame_layout.setSpacing(0)
+        self._content: Optional[QWidget] = None
 
         # ── thumbnail ───────────────────────────────────────────────────
         self._thumb_label = QLabel()
-        self._thumb_label.setFixedSize(_THUMB_W, _THUMB_H)
         self._thumb_label.setAlignment(Qt.AlignCenter)
         self._thumb_label.setStyleSheet(f"background: {NEUTRAL_900}; border-radius: 4px;")
-        card_layout.addWidget(self._thumb_label)
-
-        # ── info section ─────────────────────────────────────────────────
-        info = QWidget()
-        info.setStyleSheet("background: transparent;")
-        info_layout = QVBoxLayout(info)
-        info_layout.setContentsMargins(0, 0, 0, 0)
-        info_layout.setSpacing(2)
-        info_layout.addStretch(1)
 
         self._name_label = QLabel()
         self._name_label.setStyleSheet(
             f"font-size: 13px; font-weight: bold; color: {NEUTRAL_200}; background: transparent;"
         )
-        info_layout.addWidget(self._name_label)
 
         self._btn_actions = QToolButton()
         self._btn_actions.setFixedSize(_BTN_SIZE, _BTN_SIZE)
@@ -162,20 +163,17 @@ class LamellaCardWidget(QWidget):
         self._btn_defect.clicked.connect(self._on_defect_clicked)
 
         # Elided, not wrapped: the status is a task name or a completion stamp, and
-        # wrapping one in this narrow middle column would grow the row and undo the
-        # density this layout exists for. ElidedLabel keeps the full string as its
-        # tooltip, and its Ignored width policy stops a long name widening the card.
+        # wrapping one in the compact row's narrow middle column would grow the row and
+        # undo the density that layout exists for. ElidedLabel keeps the full string as
+        # its tooltip, and its Ignored width policy stops a long name widening the card.
+        # Used in both arrangements so the fixed height holds either way.
         self._status_label = ElidedLabel()
         self._status_label.setStyleSheet(
             f"font-size: 11px; color: {NEUTRAL_550}; background: transparent;"
         )
-        info_layout.addWidget(self._status_label)
-        info_layout.addStretch(1)
 
-        card_layout.addWidget(info, 1)
-        card_layout.addWidget(self._btn_defect, 0, Qt.AlignVCenter)
-        card_layout.addWidget(self._btn_actions, 0, Qt.AlignVCenter)
         outer.addWidget(self._card)
+        self._apply_layout()
 
         # ── evented connections ──────────────────────────────────────────
         lamella.task_state.events.name.connect(self.refresh)    # type: ignore[union-attr]
@@ -186,6 +184,106 @@ class LamellaCardWidget(QWidget):
         self.refresh()
 
     # ------------------------------------------------------------------
+
+    def set_compact(self, compact: bool) -> None:
+        """Switch between the dense row and the large tile.
+
+        Cheap enough to call on every card at once: it rebuilds one container widget
+        and re-parents the existing children into it. Nothing is recreated, so the
+        menus, connections and selection state all survive the switch.
+        """
+        if compact == self._compact:
+            return
+        self._compact = compact
+        self._apply_layout()
+        self.refresh()  # the thumbnail is drawn at the new size
+
+    def _apply_layout(self) -> None:
+        """(Re)build the card's content in the current arrangement."""
+        if self._content is not None:
+            # Re-parent the shared children out first, or deleting their container
+            # takes them with it.
+            for widget in (self._thumb_label, self._name_label,
+                           self._status_label, self._btn_defect, self._btn_actions):
+                widget.setParent(None)
+            self._frame_layout.removeWidget(self._content)
+            self._content.deleteLater()
+
+        self._content = (self._build_compact() if self._compact else self._build_full())
+        self._content.setStyleSheet("background: transparent;")
+        self._frame_layout.addWidget(self._content)
+
+        for widget in (self._thumb_label, self._name_label,
+                       self._status_label, self._btn_defect, self._btn_actions):
+            widget.show()
+
+        # Qt caches size hints and only recomputes them when the layout is activated,
+        # which for a card that has never been shown never happens -- so without this
+        # a toggled card keeps reporting the height of the arrangement it replaced.
+        self._frame_layout.invalidate()
+        self._card.updateGeometry()
+        self.updateGeometry()
+
+    def _build_compact(self) -> QWidget:
+        """Row: thumbnail | name over status | defect | actions.
+
+        The strip is one column in a 340px-wide scroll area, so height is what limits
+        how many lamellae are visible at once (FIB-585).
+        """
+        self._thumb_label.setFixedSize(_THUMB_W, _THUMB_H)
+
+        content = QWidget()
+        row = QHBoxLayout(content)
+        row.setContentsMargins(_THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING)
+        row.setSpacing(6)
+        row.addWidget(self._thumb_label)
+
+        info = QWidget()
+        info.setStyleSheet("background: transparent;")
+        info_layout = QVBoxLayout(info)
+        info_layout.setContentsMargins(0, 0, 0, 0)
+        info_layout.setSpacing(2)
+        info_layout.addStretch(1)
+        info_layout.addWidget(self._name_label)
+        info_layout.addWidget(self._status_label)
+        info_layout.addStretch(1)
+
+        row.addWidget(info, 1)
+        row.addWidget(self._btn_defect, 0, Qt.AlignVCenter)
+        row.addWidget(self._btn_actions, 0, Qt.AlignVCenter)
+        return content
+
+    def _build_full(self) -> QWidget:
+        """Tile: large thumbnail over a name row and status — the original card."""
+        self._thumb_label.setFixedSize(_FULL_THUMB_W, _FULL_THUMB_H)
+
+        content = QWidget()
+        column = QVBoxLayout(content)
+        column.setContentsMargins(_THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING, 0)
+        column.setSpacing(0)
+        column.addWidget(self._thumb_label)
+
+        sep = QFrame()
+        sep.setFrameShape(QFrame.HLine)
+        sep.setStyleSheet("color: #3a3d42;")
+        column.addWidget(sep)
+
+        info = QWidget()
+        info.setStyleSheet("background: transparent;")
+        info_layout = QVBoxLayout(info)
+        info_layout.setContentsMargins(10, 8, 10, 10)
+        info_layout.setSpacing(3)
+
+        name_row = QHBoxLayout()
+        name_row.setSpacing(4)
+        name_row.addWidget(self._name_label, 1)
+        name_row.addWidget(self._btn_actions)
+        name_row.addWidget(self._btn_defect)
+        info_layout.addLayout(name_row)
+        info_layout.addWidget(self._status_label)
+
+        column.addWidget(info)
+        return content
 
     @ensure_main_thread
     def refresh(self) -> None:
@@ -203,8 +301,12 @@ class LamellaCardWidget(QWidget):
             f"font-size: 11px; background: transparent; {status_style}"
         )
 
+        # Size read off the label rather than branched on the mode, so this method
+        # stays the single display path whichever arrangement is showing.
         arr = self.lamella.get_thumbnail()
-        self._thumb_label.setPixmap(_arr_to_pixmap(arr, _THUMB_W, _THUMB_H))
+        self._thumb_label.setPixmap(
+            _arr_to_pixmap(arr, self._thumb_label.width(), self._thumb_label.height())
+        )
 
     def mousePressEvent(self, event) -> None:
         self.clicked.emit(self.lamella)
@@ -267,11 +369,17 @@ class LamellaCardContainer(QWidget):
     update_position_requested = pyqtSignal(object)  # Lamella
     remove_requested = pyqtSignal(object)           # Lamella
 
-    def __init__(self, columns: int = _N_COLS, parent: Optional[QWidget] = None) -> None:
+    def __init__(
+        self,
+        columns: int = _N_COLS,
+        parent: Optional[QWidget] = None,
+        compact: bool = True,
+    ) -> None:
         super().__init__(parent)
         self._cards: Dict[str, LamellaCardWidget] = {}   # lamella.id → card
         self._selected_id: Optional[str] = None
         self._n_cols: int = max(1, columns)
+        self._compact: bool = compact
 
         self._grid = QGridLayout(self)
         self._grid.setSpacing(12)
@@ -282,8 +390,17 @@ class LamellaCardContainer(QWidget):
     # Public API
     # ------------------------------------------------------------------
 
+    def set_compact(self, compact: bool) -> None:
+        """Switch every card, and any added later, between the row and the tile."""
+        self._compact = compact
+        for card in self._cards.values():
+            card.set_compact(compact)
+
+    def is_compact(self) -> bool:
+        return self._compact
+
     def add_lamella(self, lamella: Lamella) -> LamellaCardWidget:
-        card = LamellaCardWidget(lamella)
+        card = LamellaCardWidget(lamella, compact=self._compact)
         card.defect_changed.connect(self.defect_changed)
         card.clicked.connect(self._on_card_clicked)
         card.move_to_requested.connect(self.move_to_requested)

--- a/fibsem/applications/autolamella/ui/lamella_card_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_card_widget.py
@@ -21,6 +21,7 @@ from superqt import ensure_main_thread
 from fibsem.ui.icon import fibsem_icon
 
 from fibsem.applications.autolamella.structures import DefectState, DefectType, Lamella
+from fibsem.config import CARD_MODES, MODE_COMPACT, MODE_LIST, MODE_TILE
 from fibsem.applications.autolamella.ui.lamella_list_widget import _defect_icon, _status_text
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import ElidedLabel
@@ -99,12 +100,12 @@ class LamellaCardWidget(QWidget):
     def __init__(
         self,
         lamella: Lamella,
-        compact: bool = True,
+        mode: str = MODE_COMPACT,
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
         self.lamella = lamella
-        self._compact = compact
+        self._mode = mode if mode in CARD_MODES else MODE_COMPACT
         self.setFixedWidth(_CARD_WIDTH)
 
         outer = QVBoxLayout(self)
@@ -185,18 +186,21 @@ class LamellaCardWidget(QWidget):
 
     # ------------------------------------------------------------------
 
-    def set_compact(self, compact: bool) -> None:
-        """Switch between the dense row and the large tile.
+    def set_mode(self, mode: str) -> None:
+        """Switch arrangement: tile, compact row, or one-line list.
 
         Cheap enough to call on every card at once: it rebuilds one container widget
         and re-parents the existing children into it. Nothing is recreated, so the
         menus, connections and selection state all survive the switch.
         """
-        if compact == self._compact:
+        if mode not in CARD_MODES or mode == self._mode:
             return
-        self._compact = compact
+        self._mode = mode
         self._apply_layout()
         self.refresh()  # the thumbnail is drawn at the new size
+
+    def mode(self) -> str:
+        return self._mode
 
     def _apply_layout(self) -> None:
         """(Re)build the card's content in the current arrangement."""
@@ -209,13 +213,26 @@ class LamellaCardWidget(QWidget):
             self._frame_layout.removeWidget(self._content)
             self._content.deleteLater()
 
-        self._content = (self._build_compact() if self._compact else self._build_full())
+        builder = {
+            MODE_TILE: self._build_tile,
+            MODE_COMPACT: self._build_compact,
+            MODE_LIST: self._build_list,
+        }[self._mode]
+        self._content = builder()
         self._content.setStyleSheet("background: transparent;")
         self._frame_layout.addWidget(self._content)
+        # A widget created after its parent is already on screen starts hidden, and its
+        # children report themselves hidden with it -- so without this, switching mode
+        # on a live card empties it. Harmless before the card is shown: the flag just
+        # says "visible once the parent is".
+        self._content.show()
 
-        for widget in (self._thumb_label, self._name_label,
-                       self._status_label, self._btn_defect, self._btn_actions):
+        for widget in (self._name_label, self._status_label,
+                       self._btn_defect, self._btn_actions):
             widget.show()
+        # The list arrangement leaves the thumbnail out of the layout entirely; showing
+        # an unparented widget would pop it up as its own top-level window.
+        self._thumb_label.setVisible(self._mode != MODE_LIST)
 
         # Qt caches size hints and only recomputes them when the layout is activated,
         # which for a card that has never been shown never happens -- so without this
@@ -253,7 +270,25 @@ class LamellaCardWidget(QWidget):
         row.addWidget(self._btn_actions, 0, Qt.AlignVCenter)
         return content
 
-    def _build_full(self) -> QWidget:
+    def _build_list(self) -> QWidget:
+        """One line: name, then status, then the buttons. No thumbnail.
+
+        The status stays. Without it this is a name and two buttons, which is what
+        `LamellaNameListWidget` already draws in the Experiment tab -- and the status is
+        the field worth scanning during a run, since it says which task each lamella is
+        on. Inline rather than stacked so the row keeps its single-line height.
+        """
+        content = QWidget()
+        row = QHBoxLayout(content)
+        row.setContentsMargins(10, 2, _THUMB_PADDING, 2)
+        row.setSpacing(8)
+        row.addWidget(self._name_label)
+        row.addWidget(self._status_label, 1)
+        row.addWidget(self._btn_defect, 0, Qt.AlignVCenter)
+        row.addWidget(self._btn_actions, 0, Qt.AlignVCenter)
+        return content
+
+    def _build_tile(self) -> QWidget:
         """Tile: large thumbnail over a name row and status — the original card."""
         self._thumb_label.setFixedSize(_FULL_THUMB_W, _FULL_THUMB_H)
 
@@ -301,12 +336,15 @@ class LamellaCardWidget(QWidget):
             f"font-size: 11px; background: transparent; {status_style}"
         )
 
-        # Size read off the label rather than branched on the mode, so this method
-        # stays the single display path whichever arrangement is showing.
-        arr = self.lamella.get_thumbnail()
-        self._thumb_label.setPixmap(
-            _arr_to_pixmap(arr, self._thumb_label.width(), self._thumb_label.height())
-        )
+        # Size read off the label rather than branched on the mode, so this stays one
+        # display path for every arrangement that has a thumbnail. The list has none,
+        # and reading a lamella's thumbnail off disk to scale it for a hidden label is
+        # the one thing worth skipping.
+        if self._mode != MODE_LIST:
+            arr = self.lamella.get_thumbnail()
+            self._thumb_label.setPixmap(
+                _arr_to_pixmap(arr, self._thumb_label.width(), self._thumb_label.height())
+            )
 
     def mousePressEvent(self, event) -> None:
         self.clicked.emit(self.lamella)
@@ -373,13 +411,13 @@ class LamellaCardContainer(QWidget):
         self,
         columns: int = _N_COLS,
         parent: Optional[QWidget] = None,
-        compact: bool = True,
+        mode: str = MODE_COMPACT,
     ) -> None:
         super().__init__(parent)
         self._cards: Dict[str, LamellaCardWidget] = {}   # lamella.id → card
         self._selected_id: Optional[str] = None
         self._n_cols: int = max(1, columns)
-        self._compact: bool = compact
+        self._mode: str = mode if mode in CARD_MODES else MODE_COMPACT
 
         self._grid = QGridLayout(self)
         self._grid.setSpacing(12)
@@ -390,17 +428,19 @@ class LamellaCardContainer(QWidget):
     # Public API
     # ------------------------------------------------------------------
 
-    def set_compact(self, compact: bool) -> None:
-        """Switch every card, and any added later, between the row and the tile."""
-        self._compact = compact
+    def set_mode(self, mode: str) -> None:
+        """Switch every card, and any added later, to one of the CARD_MODES."""
+        if mode not in CARD_MODES:
+            return
+        self._mode = mode
         for card in self._cards.values():
-            card.set_compact(compact)
+            card.set_mode(mode)
 
-    def is_compact(self) -> bool:
-        return self._compact
+    def mode(self) -> str:
+        return self._mode
 
     def add_lamella(self, lamella: Lamella) -> LamellaCardWidget:
-        card = LamellaCardWidget(lamella, compact=self._compact)
+        card = LamellaCardWidget(lamella, mode=self._mode)
         card.defect_changed.connect(self.defect_changed)
         card.clicked.connect(self._on_card_clicked)
         card.move_to_requested.connect(self.move_to_requested)

--- a/fibsem/applications/autolamella/ui/lamella_card_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_card_widget.py
@@ -21,7 +21,7 @@ from superqt import ensure_main_thread
 from fibsem.ui.icon import fibsem_icon
 
 from fibsem.applications.autolamella.structures import DefectState, DefectType, Lamella
-from fibsem.config import CARD_MODES, MODE_COMPACT, MODE_LIST, MODE_TILE
+from fibsem.config import CARD_MODES, MODE_COMPACT, MODE_COZY, MODE_STANDARD
 from fibsem.applications.autolamella.ui.lamella_list_widget import _defect_icon, _status_text
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import ElidedLabel
@@ -41,10 +41,10 @@ _THUMB_PADDING = 6        # inset from card edges so rounded corners stay visibl
 # width it takes comes off the status line, which is the part carrying detail.
 _THUMB_W = 66
 _THUMB_H = 44
-# The tile arrangement's thumbnail: the full card width less its padding, at the
-# height the card carried before it was made compact.
-_FULL_THUMB_W = _CARD_WIDTH - 8 - _THUMB_PADDING * 2
-_FULL_THUMB_H = 170
+# The cozy arrangement's thumbnail: the full card width less its padding, at the
+# height the card carried before the denser layouts existed.
+_COZY_THUMB_W = _CARD_WIDTH - 8 - _THUMB_PADDING * 2
+_COZY_THUMB_H = 170
 _BTN_SIZE = 24
 
 _CARD_STYLE = f"""
@@ -100,12 +100,12 @@ class LamellaCardWidget(QWidget):
     def __init__(
         self,
         lamella: Lamella,
-        mode: str = MODE_COMPACT,
+        mode: str = MODE_STANDARD,
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
         self.lamella = lamella
-        self._mode = mode if mode in CARD_MODES else MODE_COMPACT
+        self._mode = mode if mode in CARD_MODES else MODE_STANDARD
         self.setFixedWidth(_CARD_WIDTH)
 
         outer = QVBoxLayout(self)
@@ -118,7 +118,7 @@ class LamellaCardWidget(QWidget):
         self._card.setStyleSheet(_CARD_STYLE)
         self._card.setFixedWidth(_CARD_WIDTH - 8)
 
-        # The frame holds one content widget, which `_apply_layout` swaps. The two
+        # The frame holds one content widget, which `_apply_layout` swaps. The three
         # arrangements differ in geometry only -- same children, same signals, same
         # refresh() -- so nothing below this line knows which one is showing, and
         # there is no second display path to keep correct.
@@ -164,10 +164,10 @@ class LamellaCardWidget(QWidget):
         self._btn_defect.clicked.connect(self._on_defect_clicked)
 
         # Elided, not wrapped: the status is a task name or a completion stamp, and
-        # wrapping one in the compact row's narrow middle column would grow the row and
+        # wrapping one in the standard row's narrow middle column would grow the row and
         # undo the density that layout exists for. ElidedLabel keeps the full string as
         # its tooltip, and its Ignored width policy stops a long name widening the card.
-        # Used in both arrangements so the fixed height holds either way.
+        # Used in all three arrangements so the fixed height holds whichever is showing.
         self._status_label = ElidedLabel()
         self._status_label.setStyleSheet(
             f"font-size: 11px; color: {NEUTRAL_550}; background: transparent;"
@@ -187,7 +187,7 @@ class LamellaCardWidget(QWidget):
     # ------------------------------------------------------------------
 
     def set_mode(self, mode: str) -> None:
-        """Switch arrangement: tile, compact row, or one-line list.
+        """Switch arrangement: cozy tile, standard row, or compact one-liner.
 
         Cheap enough to call on every card at once: it rebuilds one container widget
         and re-parents the existing children into it. Nothing is recreated, so the
@@ -214,9 +214,9 @@ class LamellaCardWidget(QWidget):
             self._content.deleteLater()
 
         builder = {
-            MODE_TILE: self._build_tile,
+            MODE_COZY: self._build_cozy,
+            MODE_STANDARD: self._build_standard,
             MODE_COMPACT: self._build_compact,
-            MODE_LIST: self._build_list,
         }[self._mode]
         self._content = builder()
         self._content.setStyleSheet("background: transparent;")
@@ -230,9 +230,9 @@ class LamellaCardWidget(QWidget):
         for widget in (self._name_label, self._status_label,
                        self._btn_defect, self._btn_actions):
             widget.show()
-        # The list arrangement leaves the thumbnail out of the layout entirely; showing
-        # an unparented widget would pop it up as its own top-level window.
-        self._thumb_label.setVisible(self._mode != MODE_LIST)
+        # The compact arrangement leaves the thumbnail out of the layout entirely;
+        # showing an unparented widget would pop it up as its own top-level window.
+        self._thumb_label.setVisible(self._mode != MODE_COMPACT)
 
         # Qt caches size hints and only recomputes them when the layout is activated,
         # which for a card that has never been shown never happens -- so without this
@@ -241,7 +241,7 @@ class LamellaCardWidget(QWidget):
         self._card.updateGeometry()
         self.updateGeometry()
 
-    def _build_compact(self) -> QWidget:
+    def _build_standard(self) -> QWidget:
         """Row: thumbnail | name over status | defect | actions.
 
         The strip is one column in a 340px-wide scroll area, so height is what limits
@@ -270,7 +270,7 @@ class LamellaCardWidget(QWidget):
         row.addWidget(self._btn_actions, 0, Qt.AlignVCenter)
         return content
 
-    def _build_list(self) -> QWidget:
+    def _build_compact(self) -> QWidget:
         """One line: name, then status, then the buttons. No thumbnail.
 
         The status stays. Without it this is a name and two buttons, which is what
@@ -288,9 +288,9 @@ class LamellaCardWidget(QWidget):
         row.addWidget(self._btn_actions, 0, Qt.AlignVCenter)
         return content
 
-    def _build_tile(self) -> QWidget:
-        """Tile: large thumbnail over a name row and status — the original card."""
-        self._thumb_label.setFixedSize(_FULL_THUMB_W, _FULL_THUMB_H)
+    def _build_cozy(self) -> QWidget:
+        """Cozy: large thumbnail over a name row and status — the original card."""
+        self._thumb_label.setFixedSize(_COZY_THUMB_W, _COZY_THUMB_H)
 
         content = QWidget()
         column = QVBoxLayout(content)
@@ -337,10 +337,10 @@ class LamellaCardWidget(QWidget):
         )
 
         # Size read off the label rather than branched on the mode, so this stays one
-        # display path for every arrangement that has a thumbnail. The list has none,
-        # and reading a lamella's thumbnail off disk to scale it for a hidden label is
-        # the one thing worth skipping.
-        if self._mode != MODE_LIST:
+        # display path for every arrangement that has a thumbnail. The compact one has
+        # none, and reading a lamella's thumbnail off disk to scale it for a hidden
+        # label is the one thing worth skipping.
+        if self._mode != MODE_COMPACT:
             arr = self.lamella.get_thumbnail()
             self._thumb_label.setPixmap(
                 _arr_to_pixmap(arr, self._thumb_label.width(), self._thumb_label.height())
@@ -411,13 +411,13 @@ class LamellaCardContainer(QWidget):
         self,
         columns: int = _N_COLS,
         parent: Optional[QWidget] = None,
-        mode: str = MODE_COMPACT,
+        mode: str = MODE_STANDARD,
     ) -> None:
         super().__init__(parent)
         self._cards: Dict[str, LamellaCardWidget] = {}   # lamella.id → card
         self._selected_id: Optional[str] = None
         self._n_cols: int = max(1, columns)
-        self._mode: str = mode if mode in CARD_MODES else MODE_COMPACT
+        self._mode: str = mode if mode in CARD_MODES else MODE_STANDARD
 
         self._grid = QGridLayout(self)
         self._grid.setSpacing(12)

--- a/fibsem/applications/autolamella/ui/lamella_card_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_card_widget.py
@@ -23,6 +23,7 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem.applications.autolamella.structures import DefectState, DefectType, Lamella
 from fibsem.applications.autolamella.ui.lamella_list_widget import _defect_icon, _status_text
 from fibsem.ui import stylesheets
+from fibsem.ui.widgets.custom_widgets import ElidedLabel
 from fibsem.ui.tokens import (
     NEUTRAL_200,
     NEUTRAL_550,
@@ -33,7 +34,12 @@ from fibsem.ui.tokens import (
 
 _CARD_WIDTH = 300
 _THUMB_PADDING = 6        # inset from card edges so rounded corners stay visible
-_THUMB_HEIGHT = 170
+# 3:2, matching the 1536x1024 frames the microscope acquires, so the thumbnail
+# scales rather than crops -- _arr_to_pixmap expands to fill. Kept small: at this
+# size it is a scanning cue ("which of these looks milled"), and every pixel of
+# width it takes comes off the status line, which is the part carrying detail.
+_THUMB_W = 66
+_THUMB_H = 44
 _BTN_SIZE = 24
 
 _CARD_STYLE = f"""
@@ -101,40 +107,33 @@ class LamellaCardWidget(QWidget):
         self._card.setStyleSheet(_CARD_STYLE)
         self._card.setFixedWidth(_CARD_WIDTH - 8)
 
-        card_layout = QVBoxLayout(self._card)
-        card_layout.setContentsMargins(_THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING, 0)
-        card_layout.setSpacing(0)
+        # A row, not a stack: the strip is one column in a 340px-wide scroll area,
+        # so height is what limits how many lamellae are visible at once. The old
+        # portrait card with its 170px thumbnail showed two (FIB-585).
+        card_layout = QHBoxLayout(self._card)
+        card_layout.setContentsMargins(_THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING)
+        card_layout.setSpacing(6)
 
         # ── thumbnail ───────────────────────────────────────────────────
-        _thumb_w = _CARD_WIDTH - 8 - _THUMB_PADDING * 2
         self._thumb_label = QLabel()
-        self._thumb_label.setFixedSize(_thumb_w, _THUMB_HEIGHT)
+        self._thumb_label.setFixedSize(_THUMB_W, _THUMB_H)
         self._thumb_label.setAlignment(Qt.AlignCenter)
         self._thumb_label.setStyleSheet(f"background: {NEUTRAL_900}; border-radius: 4px;")
         card_layout.addWidget(self._thumb_label)
-
-        # ── divider ─────────────────────────────────────────────────────
-        sep = QFrame()
-        sep.setFrameShape(QFrame.HLine)
-        sep.setStyleSheet("color: #3a3d42;")
-        card_layout.addWidget(sep)
 
         # ── info section ─────────────────────────────────────────────────
         info = QWidget()
         info.setStyleSheet("background: transparent;")
         info_layout = QVBoxLayout(info)
-        info_layout.setContentsMargins(10, 8, 10, 10)
-        info_layout.setSpacing(3)
-
-        # name row: label + actions menu + defect icon
-        name_row = QHBoxLayout()
-        name_row.setSpacing(4)
+        info_layout.setContentsMargins(0, 0, 0, 0)
+        info_layout.setSpacing(2)
+        info_layout.addStretch(1)
 
         self._name_label = QLabel()
         self._name_label.setStyleSheet(
             f"font-size: 13px; font-weight: bold; color: {NEUTRAL_200}; background: transparent;"
         )
-        name_row.addWidget(self._name_label, 1)
+        info_layout.addWidget(self._name_label)
 
         self._btn_actions = QToolButton()
         self._btn_actions.setFixedSize(_BTN_SIZE, _BTN_SIZE)
@@ -156,24 +155,26 @@ class LamellaCardWidget(QWidget):
         self._action_move.triggered.connect(lambda: self.move_to_requested.emit(self.lamella))
         self._action_update.triggered.connect(lambda: self.update_position_requested.emit(self.lamella))
         self._action_remove.triggered.connect(self._on_remove_clicked)
-        name_row.addWidget(self._btn_actions)
 
         self._btn_defect = QToolButton()
         self._btn_defect.setFixedSize(_BTN_SIZE, _BTN_SIZE)
         self._btn_defect.setStyleSheet(_BTN_STYLE)
         self._btn_defect.clicked.connect(self._on_defect_clicked)
-        name_row.addWidget(self._btn_defect)
 
-        info_layout.addLayout(name_row)
-
-        self._status_label = QLabel()
+        # Elided, not wrapped: the status is a task name or a completion stamp, and
+        # wrapping one in this narrow middle column would grow the row and undo the
+        # density this layout exists for. ElidedLabel keeps the full string as its
+        # tooltip, and its Ignored width policy stops a long name widening the card.
+        self._status_label = ElidedLabel()
         self._status_label.setStyleSheet(
             f"font-size: 11px; color: {NEUTRAL_550}; background: transparent;"
         )
-        self._status_label.setWordWrap(True)
         info_layout.addWidget(self._status_label)
+        info_layout.addStretch(1)
 
-        card_layout.addWidget(info)
+        card_layout.addWidget(info, 1)
+        card_layout.addWidget(self._btn_defect, 0, Qt.AlignVCenter)
+        card_layout.addWidget(self._btn_actions, 0, Qt.AlignVCenter)
         outer.addWidget(self._card)
 
         # ── evented connections ──────────────────────────────────────────
@@ -203,9 +204,7 @@ class LamellaCardWidget(QWidget):
         )
 
         arr = self.lamella.get_thumbnail()
-        self._thumb_label.setPixmap(
-            _arr_to_pixmap(arr, _CARD_WIDTH - 8 - _THUMB_PADDING * 2, _THUMB_HEIGHT)
-        )
+        self._thumb_label.setPixmap(_arr_to_pixmap(arr, _THUMB_W, _THUMB_H))
 
     def mousePressEvent(self, event) -> None:
         self.clicked.emit(self.lamella)

--- a/fibsem/applications/autolamella/ui/lamella_card_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_card_widget.py
@@ -100,12 +100,12 @@ class LamellaCardWidget(QWidget):
     def __init__(
         self,
         lamella: Lamella,
-        mode: str = MODE_STANDARD,
+        mode: str = MODE_COZY,
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
         self.lamella = lamella
-        self._mode = mode if mode in CARD_MODES else MODE_STANDARD
+        self._mode = mode if mode in CARD_MODES else MODE_COZY
         self.setFixedWidth(_CARD_WIDTH)
 
         outer = QVBoxLayout(self)
@@ -411,13 +411,13 @@ class LamellaCardContainer(QWidget):
         self,
         columns: int = _N_COLS,
         parent: Optional[QWidget] = None,
-        mode: str = MODE_STANDARD,
+        mode: str = MODE_COZY,
     ) -> None:
         super().__init__(parent)
         self._cards: Dict[str, LamellaCardWidget] = {}   # lamella.id → card
         self._selected_id: Optional[str] = None
         self._n_cols: int = max(1, columns)
-        self._mode: str = mode if mode in CARD_MODES else MODE_STANDARD
+        self._mode: str = mode if mode in CARD_MODES else MODE_COZY
 
         self._grid = QGridLayout(self)
         self._grid.setSpacing(12)

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -290,12 +290,45 @@ def save_tescan_manipulator_calibration(config: dict) -> None:
 # User Preferences
 # ---------------------------------------------------------------------------
 
+# The lamella strip's three arrangements, densest last. Strings rather than an Enum
+# because they are persisted straight into the yaml preferences file: safe_dump raises
+# RepresenterError on an Enum, and save_user_preferences swallows that in a bare
+# `except Exception: logging.warning` -- so the failure would reach the user as "my
+# preferences do not save", with nothing pointing at the cause.
+#
+# Here rather than beside the widget that draws them so the preferences dialog can offer
+# the choice without fibsem.ui importing AutoLamella, which is the dependency direction
+# FIB-553/554/555 removed.
+MODE_TILE = "tile"
+MODE_COMPACT = "compact"
+MODE_LIST = "list"
+CARD_MODES = (MODE_TILE, MODE_COMPACT, MODE_LIST)
+_CARD_MODE_LABELS = {
+    MODE_TILE: "Large (thumbnail)",
+    MODE_COMPACT: "Compact",
+    MODE_LIST: "List (no thumbnail)",
+}
+
+
+def card_mode_label(mode: str) -> str:
+    """Human-readable name for a card mode, for the preferences dialog."""
+    return _CARD_MODE_LABELS.get(mode, mode)
+
+
 @dataclass
 class DisplayPreferences:
     sound_enabled: bool = False
     toasts_enabled: bool = False
     border_enabled: bool = True
     dev_mode: bool = False
+    # How the lamella strip draws each card: "tile" (large thumbnail), "compact"
+    # (small thumbnail beside the name) or "list" (no thumbnail, one line).
+    #
+    # A plain string rather than an Enum on purpose: preferences are written with
+    # yaml.safe_dump, which raises RepresenterError on an Enum -- and the write is
+    # wrapped in a bare `except Exception: logging.warning`, so the failure would
+    # surface as "my preferences do not save" with nothing pointing at the cause.
+    lamella_card_mode: str = "compact"
 
 @dataclass
 class FeatureFlags:

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -299,14 +299,22 @@ def save_tescan_manipulator_calibration(config: dict) -> None:
 # Here rather than beside the widget that draws them so the preferences dialog can offer
 # the choice without fibsem.ui importing AutoLamella, which is the dependency direction
 # FIB-553/554/555 removed.
-MODE_TILE = "tile"
-MODE_COMPACT = "compact"
-MODE_LIST = "list"
-CARD_MODES = (MODE_TILE, MODE_COMPACT, MODE_LIST)
+# Named for density rather than for what they draw, and ordered roomiest first, the
+# way Discord and Gmail order theirs. "Cozy" is the roomy one everywhere it appears in
+# a UI, so it cannot be the name of the tightest layout here -- someone reaching for it
+# expecting breathing room would get the densest thing on offer.
+#
+# The stored value is the label lowercased, deliberately: a preferences file that says
+# `compact` and a dialog that says "Standard" are a support conversation waiting to
+# happen.
+MODE_COZY = "cozy"          # large thumbnail tile
+MODE_STANDARD = "standard"  # small thumbnail beside the name
+MODE_COMPACT = "compact"    # one line, no thumbnail
+CARD_MODES = (MODE_COZY, MODE_STANDARD, MODE_COMPACT)
 _CARD_MODE_LABELS = {
-    MODE_TILE: "Large (thumbnail)",
+    MODE_COZY: "Cozy",
+    MODE_STANDARD: "Standard",
     MODE_COMPACT: "Compact",
-    MODE_LIST: "List (no thumbnail)",
 }
 
 
@@ -321,14 +329,14 @@ class DisplayPreferences:
     toasts_enabled: bool = False
     border_enabled: bool = True
     dev_mode: bool = False
-    # How the lamella strip draws each card: "tile" (large thumbnail), "compact"
-    # (small thumbnail beside the name) or "list" (no thumbnail, one line).
+    # How the lamella strip draws each card: "cozy" (large thumbnail), "standard"
+    # (small thumbnail beside the name) or "compact" (no thumbnail, one line).
     #
     # A plain string rather than an Enum on purpose: preferences are written with
     # yaml.safe_dump, which raises RepresenterError on an Enum -- and the write is
     # wrapped in a bare `except Exception: logging.warning`, so the failure would
     # surface as "my preferences do not save" with nothing pointing at the cause.
-    lamella_card_mode: str = "compact"
+    lamella_card_mode: str = MODE_STANDARD
 
 @dataclass
 class FeatureFlags:

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -336,7 +336,9 @@ class DisplayPreferences:
     # yaml.safe_dump, which raises RepresenterError on an Enum -- and the write is
     # wrapped in a bare `except Exception: logging.warning`, so the failure would
     # surface as "my preferences do not save" with nothing pointing at the cause.
-    lamella_card_mode: str = MODE_STANDARD
+    # Cozy, because it is what the strip drew before the other two existed: a new
+    # layout is offered, never imposed on an upgrade.
+    lamella_card_mode: str = MODE_COZY
 
 @dataclass
 class FeatureFlags:

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -16,7 +16,12 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from fibsem.config import CARD_MODES, UserPreferences, card_mode_label
+from fibsem.config import (
+    CARD_MODES,
+    DisplayPreferences,
+    UserPreferences,
+    card_mode_label,
+)
 from fibsem.ui.widgets.custom_widgets import QDirectoryLineEdit, QFileLineEdit
 
 # ---------------------------------------------------------------------------
@@ -232,11 +237,16 @@ class PreferencesDialog(QDialog):
         self._chk_border.setChecked(d.border_enabled)
         self._chk_dev_mode.setChecked(d.dev_mode)
         card_index = self._combo_card_mode.findData(d.lamella_card_mode)
-        # -1 for a value this build does not offer -- an older preferences file, or one
-        # hand-edited. Falling back to the first entry would silently rewrite it on the
-        # next save, so leave the current selection and let the user choose.
-        if card_index != -1:
-            self._combo_card_mode.setCurrentIndex(card_index)
+        if card_index == -1:
+            # A value this build does not offer -- a preferences file from an older
+            # build, or a hand-edited one. Fall back to the same default the card
+            # widget falls back to, so the dialog shows the layout actually on screen.
+            # Falling back to index 0 instead would put "Cozy" in the box over a strip
+            # drawing Standard, and OK would then apply a layout the user never chose.
+            card_index = self._combo_card_mode.findData(
+                DisplayPreferences().lamella_card_mode
+            )
+        self._combo_card_mode.setCurrentIndex(card_index)
 
         f = prefs.features
         self._chk_coincidence_milling.setChecked(f.coincidence_milling_enabled)

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -2,6 +2,7 @@
 
 from PyQt5.QtWidgets import (
     QCheckBox,
+    QComboBox,
     QDialog,
     QDialogButtonBox,
     QFormLayout,
@@ -15,7 +16,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from fibsem.config import UserPreferences
+from fibsem.config import CARD_MODES, UserPreferences, card_mode_label
 from fibsem.ui.widgets.custom_widgets import QDirectoryLineEdit, QFileLineEdit
 
 # ---------------------------------------------------------------------------
@@ -29,6 +30,11 @@ _LBL_TOASTS        = "Enable Toast Notifications"
 _TIP_TOASTS        = "Show brief pop-up messages in the corner of the screen for workflow events."
 _LBL_BORDER        = "Enable Workflow Border"
 _TIP_BORDER        = "Highlight the viewport border while an automated workflow is running."
+_LBL_CARD_MODE     = "Lamella Card Layout"
+_TIP_CARD_MODE     = (
+    "How each lamella is drawn in the Lamella tab's strip: a large thumbnail, a "
+    "compact row, or a single line with no thumbnail."
+)
 _LBL_DEV_MODE      = "Enable Development Mode"
 _TIP_DEV_MODE      = "Show advanced developer tools and diagnostic menus. Intended for developers only."
 
@@ -133,9 +139,17 @@ class PreferencesDialog(QDialog):
         self._chk_border.setToolTip(_TIP_BORDER)
         self._chk_dev_mode = QCheckBox()
         self._chk_dev_mode.setToolTip(_TIP_DEV_MODE)
+        # The one display preference that is not a yes/no. Its values are carried as
+        # item data, not as the visible text, so the labels can be reworded without
+        # changing what lands in the preferences file.
+        self._combo_card_mode = QComboBox()
+        self._combo_card_mode.setToolTip(_TIP_CARD_MODE)
+        for mode in CARD_MODES:
+            self._combo_card_mode.addItem(card_mode_label(mode), mode)
         display_form.addRow(_LBL_SOUND, self._chk_sound)
         display_form.addRow(_LBL_TOASTS, self._chk_toasts)
         display_form.addRow(_LBL_BORDER, self._chk_border)
+        display_form.addRow(_LBL_CARD_MODE, self._combo_card_mode)
         display_form.addRow(_LBL_DEV_MODE, self._chk_dev_mode)
         self._stack.addWidget(display_page)
 
@@ -217,6 +231,12 @@ class PreferencesDialog(QDialog):
         self._chk_toasts.setChecked(d.toasts_enabled)
         self._chk_border.setChecked(d.border_enabled)
         self._chk_dev_mode.setChecked(d.dev_mode)
+        card_index = self._combo_card_mode.findData(d.lamella_card_mode)
+        # -1 for a value this build does not offer -- an older preferences file, or one
+        # hand-edited. Falling back to the first entry would silently rewrite it on the
+        # next save, so leave the current selection and let the user choose.
+        if card_index != -1:
+            self._combo_card_mode.setCurrentIndex(card_index)
 
         f = prefs.features
         self._chk_coincidence_milling.setChecked(f.coincidence_milling_enabled)
@@ -289,6 +309,7 @@ class PreferencesDialog(QDialog):
                 toasts_enabled=self._chk_toasts.isChecked(),
                 border_enabled=self._chk_border.isChecked(),
                 dev_mode=self._chk_dev_mode.isChecked(),
+                lamella_card_mode=self._combo_card_mode.currentData(),
             ),
             features=FeatureFlags(
                 coincidence_milling_enabled=self._chk_coincidence_milling.isChecked(),

--- a/tests/ui/test_lamella_card_layout.py
+++ b/tests/ui/test_lamella_card_layout.py
@@ -1,8 +1,12 @@
 """The compact lamella card stays compact, and stays clickable (FIB-585).
 
 The card was a 300x240 portrait tile with a 170px thumbnail, stacked one per row in a
-340px strip, so two lamellae filled the panel. It is now a row -- thumbnail, name and
-status, buttons -- at roughly a third the height.
+340px strip, so two lamellae filled the panel. It is now a row by default -- thumbnail,
+name and status, buttons -- at roughly a third the height, with a toolbar button in the
+host that switches back to the tile.
+
+Both arrangements share one set of child widgets, re-parented between containers, so
+`refresh` stays a single display path and there is no second one to keep correct.
 
 Two properties are worth pinning, and neither is the pixel height:
 
@@ -122,3 +126,106 @@ def test_clicking_the_defect_button_does_not_select_the_card():
     QTest.mousePress(card._btn_defect, Qt.LeftButton)
 
     assert seen == []
+
+
+# ── the density toggle (FIB-585) ──────────────────────────────────────────────
+#
+# The two arrangements share one set of child widgets, re-parented between
+# containers, so what needs pinning is that nothing is lost in the move: the menus,
+# the psygnal connections and the container's selection all outlive a switch.
+
+
+def test_toggling_to_the_tile_and_back_restores_the_compact_height():
+    card = LamellaCardWidget(_lamella())
+    compact_h = card.sizeHint().height()
+
+    card.set_compact(False)
+    tile_h = card.sizeHint().height()
+    card.set_compact(True)
+
+    assert tile_h > compact_h * 2, "the tile is the tall arrangement"
+    assert card.sizeHint().height() == compact_h
+
+
+def test_the_menus_and_thumbnail_survive_a_toggle():
+    """The children are re-parented, not rebuilt, so everything hung off them stays."""
+    card = _shown(LamellaCardWidget(_lamella()))
+
+    card.set_compact(False)
+
+    assert len(card._btn_actions.menu().actions()) == 3
+    assert card._btn_defect.toolTip() == "No defect"
+    assert not card._thumb_label.pixmap().isNull()
+    assert card._thumb_label.height() > 100, "redrawn at the tile's size"
+
+
+def test_the_lamella_events_still_refresh_after_a_toggle():
+    """`refresh` is one path for both arrangements, and stays connected across a switch."""
+    lamella = _lamella()
+    card = _shown(LamellaCardWidget(lamella))
+
+    card.set_compact(False)
+    lamella.task_state.name = "Mill Undercut"
+    lamella.task_state.status = AutoLamellaTaskStatus.InProgress
+
+    assert card._status_label.text() == "Mill Undercut"
+
+
+def test_the_container_keeps_its_selection_across_a_toggle():
+    container = LamellaCardContainer(columns=1)
+    lamella = _lamella("kept")
+    container.add_lamella(lamella)
+    container._on_card_clicked(lamella)
+
+    container.set_compact(False)
+
+    assert container._selected_id == lamella.id
+    assert container.is_compact() is False
+
+
+def test_a_card_added_later_follows_the_current_mode():
+    container = LamellaCardContainer(columns=1)
+    container.set_compact(False)
+
+    card = container.add_lamella(_lamella("late"))
+
+    assert card._thumb_label.height() > 100
+
+
+def test_the_host_button_points_at_the_arrangement_it_switches_to():
+    """The button carries no checked state, so its icon and tooltip are the only thing
+    saying what it does -- and they must describe the *destination*, not where you are.
+
+    Called unbound against a stub: the host is a napari-backed window that cannot be
+    constructed headless, and these two methods touch nothing else on it.
+    """
+    import types
+
+    from PyQt5.QtWidgets import QToolButton
+
+    from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+        AutoLamellaSingleWindowUI,
+    )
+
+    host = types.SimpleNamespace(
+        lamella_card_container=LamellaCardContainer(columns=1),
+        btn_card_density=QToolButton(),
+    )
+    host.lamella_card_container.add_lamella(_lamella())
+    # bound onto the stub, because the toggle calls it through self
+    host._sync_card_density_button = types.MethodType(
+        AutoLamellaSingleWindowUI._sync_card_density_button, host
+    )
+
+    host._sync_card_density_button()
+    assert host.btn_card_density.toolTip() == "Show large cards"
+
+    AutoLamellaSingleWindowUI._on_toggle_card_density(host)
+
+    assert host.lamella_card_container.is_compact() is False
+    assert host.btn_card_density.toolTip() == "Show compact cards"
+
+    AutoLamellaSingleWindowUI._on_toggle_card_density(host)
+
+    assert host.lamella_card_container.is_compact() is True
+    assert host.btn_card_density.toolTip() == "Show large cards"

--- a/tests/ui/test_lamella_card_layout.py
+++ b/tests/ui/test_lamella_card_layout.py
@@ -1,0 +1,124 @@
+"""The compact lamella card stays compact, and stays clickable (FIB-585).
+
+The card was a 300x240 portrait tile with a 170px thumbnail, stacked one per row in a
+340px strip, so two lamellae filled the panel. It is now a row -- thumbnail, name and
+status, buttons -- at roughly a third the height.
+
+Two properties are worth pinning, and neither is the pixel height:
+
+* **A long status must not grow the row.** The density comes from a fixed-height row,
+  and the status is the one field with unbounded content (a task name, or a completion
+  stamp). It is an `ElidedLabel` for that reason; swapping in a wrapping `QLabel` would
+  restore the old behaviour silently, for the one lamella whose task has a long name.
+* **Clicking the card selects it, wherever you click.** Selection rides on
+  `mousePressEvent` bubbling up from children that ignore the press. That is free with
+  labels and would break the moment one is replaced with something that accepts clicks
+  -- and the failure is "clicking the picture does nothing", which no other test covers.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtTest import QTest
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus, Lamella
+from fibsem.applications.autolamella.ui.lamella_card_widget import (
+    LamellaCardContainer,
+    LamellaCardWidget,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+_LONG_TASK_NAME = (
+    "Acquire Fluorescence Reference Image at super high resolution, every channel"
+)
+
+
+def _lamella(petname="test", task=None):
+    lamella = Lamella(path="/tmp", number=0, petname=petname)
+    if task:
+        lamella.task_state.name = task
+        lamella.task_state.status = AutoLamellaTaskStatus.InProgress
+    return lamella
+
+
+# Heights come from sizeHint(), not from a shown widget: a top-level window here has a
+# minimum height of 100px, which floors both a 66px row and anything smaller into the
+# same number and would make the comparison below pass whatever the layout does.
+_COMPACT_MAX_H = 80
+
+
+def _shown(card):
+    """Lay the card out, so child geometry is real."""
+    card.show()
+    _app.processEvents()
+    return card
+
+
+def test_a_long_status_does_not_make_the_card_taller():
+    short = LamellaCardWidget(_lamella("short", task="Mill Rough"))
+    long = LamellaCardWidget(_lamella("long", task=_LONG_TASK_NAME))
+
+    assert long.sizeHint().height() == short.sizeHint().height()
+    # ... and both are actually short. Without this the equality above would still
+    # hold if the row grew to fit two wrapped lines in every case.
+    assert short.sizeHint().height() <= _COMPACT_MAX_H
+
+
+def test_the_full_status_survives_as_a_tooltip():
+    """Eliding is presentation; the string still has to be readable somehow."""
+    card = _shown(LamellaCardWidget(_lamella(task=_LONG_TASK_NAME)))
+
+    assert card._status_label.toolTip() == _LONG_TASK_NAME
+
+
+def test_the_name_sits_beside_the_thumbnail_not_under_it():
+    """The layout change itself, in the one form that does not depend on any margin:
+    the old tile stacked the name below a full-width thumbnail. Mapped into the card's
+    own coordinates, because the two live in different parent widgets."""
+    card = _shown(LamellaCardWidget(_lamella()))
+
+    thumb = card._thumb_label
+    thumb_right = thumb.mapTo(card, thumb.rect().topRight()).x()
+    name_left = card._name_label.mapTo(card, card._name_label.rect().topLeft()).x()
+
+    assert name_left > thumb_right
+
+
+def test_clicking_the_thumbnail_selects_the_card():
+    """The click lands on a child, and only reaches the card because labels ignore it."""
+    container = LamellaCardContainer(columns=1)
+    lamella = _lamella("clickable")
+    card = container.add_lamella(lamella)
+    container.show()
+    _app.processEvents()
+
+    seen = []
+    container.lamella_selected.connect(seen.append)
+    QTest.mouseClick(card._thumb_label, Qt.LeftButton)
+
+    assert seen == [lamella]
+    assert container._selected_id == lamella.id
+
+
+def test_clicking_the_defect_button_does_not_select_the_card():
+    """The buttons accept the press, so it must not also reach the card underneath --
+    otherwise opening the defect menu would silently change which lamella is selected."""
+    container = LamellaCardContainer(columns=1)
+    card = container.add_lamella(_lamella("not-selected"))
+    container.show()
+    _app.processEvents()
+
+    seen = []
+    container.lamella_selected.connect(seen.append)
+    QTest.mousePress(card._btn_defect, Qt.LeftButton)
+
+    assert seen == []

--- a/tests/ui/test_lamella_card_layout.py
+++ b/tests/ui/test_lamella_card_layout.py
@@ -1,9 +1,10 @@
 """The compact lamella card stays compact, and stays clickable (FIB-585).
 
 The card was a 300x240 portrait tile with a 170px thumbnail, stacked one per row in a
-340px strip, so two lamellae filled the panel. There are now three arrangements --
-`tile`, `compact` (the default: a small thumbnail beside the name) and `list` (one line,
-no thumbnail) -- chosen from Preferences -> Display.
+340px strip, so two lamellae filled the panel. There are now three arrangements, named
+for density the way Discord and Gmail name theirs -- `cozy` (that tile), `standard` (the
+default: a small thumbnail beside the name) and `compact` (one line, no thumbnail) --
+chosen from Preferences -> Display.
 
 All three share one set of child widgets, re-parented between containers, so `refresh`
 stays a single display path and there is no second one to keep correct.
@@ -38,7 +39,7 @@ from fibsem.applications.autolamella.ui.lamella_card_widget import (
     LamellaCardContainer,
     LamellaCardWidget,
 )
-from fibsem.config import MODE_COMPACT, MODE_LIST, MODE_TILE
+from fibsem.config import MODE_COMPACT, MODE_COZY, MODE_STANDARD
 
 _app = QApplication.instance() or QApplication(sys.argv)
 
@@ -129,35 +130,35 @@ def test_clicking_the_defect_button_does_not_select_the_card():
     assert seen == []
 
 
-# ── the density toggle (FIB-585) ──────────────────────────────────────────────
+# ── switching density (FIB-585) ───────────────────────────────────────────────
 #
-# The two arrangements share one set of child widgets, re-parented between
+# All three arrangements share one set of child widgets, re-parented between
 # containers, so what needs pinning is that nothing is lost in the move: the menus,
 # the psygnal connections and the container's selection all outlive a switch.
 
 
-def test_toggling_to_the_tile_and_back_restores_the_compact_height():
+def test_toggling_to_the_cozy_tile_and_back_restores_the_standard_height():
     card = LamellaCardWidget(_lamella())
-    compact_h = card.sizeHint().height()
+    standard_h = card.sizeHint().height()
 
-    card.set_mode(MODE_TILE)
-    tile_h = card.sizeHint().height()
-    card.set_mode(MODE_COMPACT)
+    card.set_mode(MODE_COZY)
+    cozy_h = card.sizeHint().height()
+    card.set_mode(MODE_STANDARD)
 
-    assert tile_h > compact_h * 2, "the tile is the tall arrangement"
-    assert card.sizeHint().height() == compact_h
+    assert cozy_h > standard_h * 2, "cozy is the roomiest arrangement"
+    assert card.sizeHint().height() == standard_h
 
 
 def test_the_menus_and_thumbnail_survive_a_toggle():
     """The children are re-parented, not rebuilt, so everything hung off them stays."""
     card = _shown(LamellaCardWidget(_lamella()))
 
-    card.set_mode(MODE_TILE)
+    card.set_mode(MODE_COZY)
 
     assert len(card._btn_actions.menu().actions()) == 3
     assert card._btn_defect.toolTip() == "No defect"
     assert not card._thumb_label.pixmap().isNull()
-    assert card._thumb_label.height() > 100, "redrawn at the tile's size"
+    assert card._thumb_label.height() > 100, "redrawn at the cozy size"
 
 
 def test_the_lamella_events_still_refresh_after_a_toggle():
@@ -165,7 +166,7 @@ def test_the_lamella_events_still_refresh_after_a_toggle():
     lamella = _lamella()
     card = _shown(LamellaCardWidget(lamella))
 
-    card.set_mode(MODE_TILE)
+    card.set_mode(MODE_COZY)
     lamella.task_state.name = "Mill Undercut"
     lamella.task_state.status = AutoLamellaTaskStatus.InProgress
 
@@ -178,46 +179,46 @@ def test_the_container_keeps_its_selection_across_a_toggle():
     container.add_lamella(lamella)
     container._on_card_clicked(lamella)
 
-    container.set_mode(MODE_TILE)
+    container.set_mode(MODE_COZY)
 
     assert container._selected_id == lamella.id
-    assert container.mode() == MODE_TILE
+    assert container.mode() == MODE_COZY
 
 
 def test_a_card_added_later_follows_the_current_mode():
     container = LamellaCardContainer(columns=1)
-    container.set_mode(MODE_TILE)
+    container.set_mode(MODE_COZY)
 
     card = container.add_lamella(_lamella("late"))
 
     assert card._thumb_label.height() > 100
 
 
-def test_the_list_mode_drops_the_thumbnail_and_keeps_the_status():
+def test_the_compact_mode_drops_the_thumbnail_and_keeps_the_status():
     """The densest arrangement. The status stays: without it this is a name and two
     buttons, which is what LamellaNameListWidget already draws in the Experiment tab."""
     lamella = _lamella(task="Mill Rough")
-    card = _shown(LamellaCardWidget(lamella, mode=MODE_LIST))
+    card = _shown(LamellaCardWidget(lamella, mode=MODE_COMPACT))
 
     assert card._thumb_label.isVisible() is False
     assert card._status_label.text() == "Mill Rough"
     assert card._name_label.isVisible() is True
 
 
-def test_the_list_row_is_shorter_than_the_compact_row():
-    compact = LamellaCardWidget(_lamella())
-    listed = LamellaCardWidget(_lamella(), mode=MODE_LIST)
+def test_the_compact_row_is_shorter_than_the_standard_row():
+    standard = LamellaCardWidget(_lamella())
+    compact = LamellaCardWidget(_lamella(), mode=MODE_COMPACT)
 
-    assert listed.sizeHint().height() < compact.sizeHint().height()
+    assert compact.sizeHint().height() < standard.sizeHint().height()
 
 
-def test_switching_into_the_list_and_back_restores_the_thumbnail():
+def test_switching_into_compact_and_back_restores_the_thumbnail():
     """The thumbnail is left out of the list's layout entirely, so coming back has to
     both re-add it and redraw its pixmap."""
     card = _shown(LamellaCardWidget(_lamella()))
 
-    card.set_mode(MODE_LIST)
     card.set_mode(MODE_COMPACT)
+    card.set_mode(MODE_STANDARD)
 
     assert card._thumb_label.isVisible() is True
     assert not card._thumb_label.pixmap().isNull()
@@ -227,11 +228,11 @@ def test_an_unknown_mode_is_ignored_rather_than_drawn_blank():
     """A hand-edited preferences file should not be able to empty the panel."""
     card = LamellaCardWidget(_lamella(), mode="enormous")
 
-    assert card.mode() == MODE_COMPACT
+    assert card.mode() == MODE_STANDARD
 
     card.set_mode("enormous")
 
-    assert card.mode() == MODE_COMPACT
+    assert card.mode() == MODE_STANDARD
 
 
 def test_the_card_mode_survives_the_preferences_dialog():
@@ -242,10 +243,35 @@ def test_the_card_mode_survives_the_preferences_dialog():
     from fibsem.ui.widgets.preferences_dialog import PreferencesDialog
 
     prefs = UserPreferences()
-    prefs.display.lamella_card_mode = MODE_LIST
+    prefs.display.lamella_card_mode = MODE_COMPACT
 
     dialog = PreferencesDialog(prefs)
     try:
-        assert dialog.get_preferences().display.lamella_card_mode == MODE_LIST
+        assert dialog.get_preferences().display.lamella_card_mode == MODE_COMPACT
+    finally:
+        dialog.deleteLater()
+
+
+def test_a_mode_this_build_does_not_know_falls_back_the_same_way_everywhere():
+    """The dialog and the cards must agree about what an unreadable value means.
+
+    A real case, not a hypothetical: this branch renamed the modes mid-review, so a
+    preferences file written an hour earlier held a name that no longer exists. The
+    cards fall back to the default; the dialog used to fall back to its first entry,
+    which would have shown "Cozy" over a strip drawing Standard -- and pressing OK
+    would then apply a layout nobody chose.
+    """
+    from fibsem.config import DisplayPreferences, UserPreferences
+    from fibsem.ui.widgets.preferences_dialog import PreferencesDialog
+
+    prefs = UserPreferences()
+    prefs.display.lamella_card_mode = "tile"  # a name from before the rename
+
+    card = LamellaCardWidget(_lamella(), mode="tile")
+    dialog = PreferencesDialog(prefs)
+    try:
+        fallback = DisplayPreferences().lamella_card_mode
+        assert card.mode() == fallback
+        assert dialog.get_preferences().display.lamella_card_mode == fallback
     finally:
         dialog.deleteLater()

--- a/tests/ui/test_lamella_card_layout.py
+++ b/tests/ui/test_lamella_card_layout.py
@@ -1,12 +1,12 @@
 """The compact lamella card stays compact, and stays clickable (FIB-585).
 
 The card was a 300x240 portrait tile with a 170px thumbnail, stacked one per row in a
-340px strip, so two lamellae filled the panel. It is now a row by default -- thumbnail,
-name and status, buttons -- at roughly a third the height, with a toolbar button in the
-host that switches back to the tile.
+340px strip, so two lamellae filled the panel. There are now three arrangements --
+`tile`, `compact` (the default: a small thumbnail beside the name) and `list` (one line,
+no thumbnail) -- chosen from Preferences -> Display.
 
-Both arrangements share one set of child widgets, re-parented between containers, so
-`refresh` stays a single display path and there is no second one to keep correct.
+All three share one set of child widgets, re-parented between containers, so `refresh`
+stays a single display path and there is no second one to keep correct.
 
 Two properties are worth pinning, and neither is the pixel height:
 
@@ -38,6 +38,7 @@ from fibsem.applications.autolamella.ui.lamella_card_widget import (
     LamellaCardContainer,
     LamellaCardWidget,
 )
+from fibsem.config import MODE_COMPACT, MODE_LIST, MODE_TILE
 
 _app = QApplication.instance() or QApplication(sys.argv)
 
@@ -139,9 +140,9 @@ def test_toggling_to_the_tile_and_back_restores_the_compact_height():
     card = LamellaCardWidget(_lamella())
     compact_h = card.sizeHint().height()
 
-    card.set_compact(False)
+    card.set_mode(MODE_TILE)
     tile_h = card.sizeHint().height()
-    card.set_compact(True)
+    card.set_mode(MODE_COMPACT)
 
     assert tile_h > compact_h * 2, "the tile is the tall arrangement"
     assert card.sizeHint().height() == compact_h
@@ -151,7 +152,7 @@ def test_the_menus_and_thumbnail_survive_a_toggle():
     """The children are re-parented, not rebuilt, so everything hung off them stays."""
     card = _shown(LamellaCardWidget(_lamella()))
 
-    card.set_compact(False)
+    card.set_mode(MODE_TILE)
 
     assert len(card._btn_actions.menu().actions()) == 3
     assert card._btn_defect.toolTip() == "No defect"
@@ -164,7 +165,7 @@ def test_the_lamella_events_still_refresh_after_a_toggle():
     lamella = _lamella()
     card = _shown(LamellaCardWidget(lamella))
 
-    card.set_compact(False)
+    card.set_mode(MODE_TILE)
     lamella.task_state.name = "Mill Undercut"
     lamella.task_state.status = AutoLamellaTaskStatus.InProgress
 
@@ -177,55 +178,74 @@ def test_the_container_keeps_its_selection_across_a_toggle():
     container.add_lamella(lamella)
     container._on_card_clicked(lamella)
 
-    container.set_compact(False)
+    container.set_mode(MODE_TILE)
 
     assert container._selected_id == lamella.id
-    assert container.is_compact() is False
+    assert container.mode() == MODE_TILE
 
 
 def test_a_card_added_later_follows_the_current_mode():
     container = LamellaCardContainer(columns=1)
-    container.set_compact(False)
+    container.set_mode(MODE_TILE)
 
     card = container.add_lamella(_lamella("late"))
 
     assert card._thumb_label.height() > 100
 
 
-def test_the_host_button_points_at_the_arrangement_it_switches_to():
-    """The button carries no checked state, so its icon and tooltip are the only thing
-    saying what it does -- and they must describe the *destination*, not where you are.
+def test_the_list_mode_drops_the_thumbnail_and_keeps_the_status():
+    """The densest arrangement. The status stays: without it this is a name and two
+    buttons, which is what LamellaNameListWidget already draws in the Experiment tab."""
+    lamella = _lamella(task="Mill Rough")
+    card = _shown(LamellaCardWidget(lamella, mode=MODE_LIST))
 
-    Called unbound against a stub: the host is a napari-backed window that cannot be
-    constructed headless, and these two methods touch nothing else on it.
+    assert card._thumb_label.isVisible() is False
+    assert card._status_label.text() == "Mill Rough"
+    assert card._name_label.isVisible() is True
+
+
+def test_the_list_row_is_shorter_than_the_compact_row():
+    compact = LamellaCardWidget(_lamella())
+    listed = LamellaCardWidget(_lamella(), mode=MODE_LIST)
+
+    assert listed.sizeHint().height() < compact.sizeHint().height()
+
+
+def test_switching_into_the_list_and_back_restores_the_thumbnail():
+    """The thumbnail is left out of the list's layout entirely, so coming back has to
+    both re-add it and redraw its pixmap."""
+    card = _shown(LamellaCardWidget(_lamella()))
+
+    card.set_mode(MODE_LIST)
+    card.set_mode(MODE_COMPACT)
+
+    assert card._thumb_label.isVisible() is True
+    assert not card._thumb_label.pixmap().isNull()
+
+
+def test_an_unknown_mode_is_ignored_rather_than_drawn_blank():
+    """A hand-edited preferences file should not be able to empty the panel."""
+    card = LamellaCardWidget(_lamella(), mode="enormous")
+
+    assert card.mode() == MODE_COMPACT
+
+    card.set_mode("enormous")
+
+    assert card.mode() == MODE_COMPACT
+
+
+def test_the_card_mode_survives_the_preferences_dialog():
+    """The preference is only reachable if it round-trips the dialog -- the same four
+    places any preference has to survive: the field, the widget, the load and the save.
     """
-    import types
+    from fibsem.config import UserPreferences
+    from fibsem.ui.widgets.preferences_dialog import PreferencesDialog
 
-    from PyQt5.QtWidgets import QToolButton
+    prefs = UserPreferences()
+    prefs.display.lamella_card_mode = MODE_LIST
 
-    from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
-        AutoLamellaSingleWindowUI,
-    )
-
-    host = types.SimpleNamespace(
-        lamella_card_container=LamellaCardContainer(columns=1),
-        btn_card_density=QToolButton(),
-    )
-    host.lamella_card_container.add_lamella(_lamella())
-    # bound onto the stub, because the toggle calls it through self
-    host._sync_card_density_button = types.MethodType(
-        AutoLamellaSingleWindowUI._sync_card_density_button, host
-    )
-
-    host._sync_card_density_button()
-    assert host.btn_card_density.toolTip() == "Show large cards"
-
-    AutoLamellaSingleWindowUI._on_toggle_card_density(host)
-
-    assert host.lamella_card_container.is_compact() is False
-    assert host.btn_card_density.toolTip() == "Show compact cards"
-
-    AutoLamellaSingleWindowUI._on_toggle_card_density(host)
-
-    assert host.lamella_card_container.is_compact() is True
-    assert host.btn_card_density.toolTip() == "Show large cards"
+    dialog = PreferencesDialog(prefs)
+    try:
+        assert dialog.get_preferences().display.lamella_card_mode == MODE_LIST
+    finally:
+        dialog.deleteLater()

--- a/tests/ui/test_lamella_card_layout.py
+++ b/tests/ui/test_lamella_card_layout.py
@@ -2,9 +2,10 @@
 
 The card was a 300x240 portrait tile with a 170px thumbnail, stacked one per row in a
 340px strip, so two lamellae filled the panel. There are now three arrangements, named
-for density the way Discord and Gmail name theirs -- `cozy` (that tile), `standard` (the
-default: a small thumbnail beside the name) and `compact` (one line, no thumbnail) --
-chosen from Preferences -> Display.
+for density the way Discord and Gmail name theirs -- `cozy` (that tile), `standard` (a small thumbnail beside the
+name) and `compact` (one line, no thumbnail) --
+chosen from Preferences -> Display. Cozy stays the default: the strip drew it before
+the other two existed, so an upgrade offers the denser layouts rather than imposing one.
 
 All three share one set of child widgets, re-parented between containers, so `refresh`
 stays a single display path and there is no second one to keep correct.
@@ -59,7 +60,7 @@ def _lamella(petname="test", task=None):
 # Heights come from sizeHint(), not from a shown widget: a top-level window here has a
 # minimum height of 100px, which floors both a 66px row and anything smaller into the
 # same number and would make the comparison below pass whatever the layout does.
-_COMPACT_MAX_H = 80
+_STANDARD_MAX_H = 80
 
 
 def _shown(card):
@@ -70,18 +71,18 @@ def _shown(card):
 
 
 def test_a_long_status_does_not_make_the_card_taller():
-    short = LamellaCardWidget(_lamella("short", task="Mill Rough"))
-    long = LamellaCardWidget(_lamella("long", task=_LONG_TASK_NAME))
+    short = LamellaCardWidget(_lamella("short", task="Mill Rough"), mode=MODE_STANDARD)
+    long = LamellaCardWidget(_lamella("long", task=_LONG_TASK_NAME), mode=MODE_STANDARD)
 
     assert long.sizeHint().height() == short.sizeHint().height()
     # ... and both are actually short. Without this the equality above would still
     # hold if the row grew to fit two wrapped lines in every case.
-    assert short.sizeHint().height() <= _COMPACT_MAX_H
+    assert short.sizeHint().height() <= _STANDARD_MAX_H
 
 
 def test_the_full_status_survives_as_a_tooltip():
     """Eliding is presentation; the string still has to be readable somehow."""
-    card = _shown(LamellaCardWidget(_lamella(task=_LONG_TASK_NAME)))
+    card = _shown(LamellaCardWidget(_lamella(task=_LONG_TASK_NAME), mode=MODE_STANDARD))
 
     assert card._status_label.toolTip() == _LONG_TASK_NAME
 
@@ -90,7 +91,7 @@ def test_the_name_sits_beside_the_thumbnail_not_under_it():
     """The layout change itself, in the one form that does not depend on any margin:
     the old tile stacked the name below a full-width thumbnail. Mapped into the card's
     own coordinates, because the two live in different parent widgets."""
-    card = _shown(LamellaCardWidget(_lamella()))
+    card = _shown(LamellaCardWidget(_lamella(), mode=MODE_STANDARD))
 
     thumb = card._thumb_label
     thumb_right = thumb.mapTo(card, thumb.rect().topRight()).x()
@@ -138,7 +139,7 @@ def test_clicking_the_defect_button_does_not_select_the_card():
 
 
 def test_toggling_to_the_cozy_tile_and_back_restores_the_standard_height():
-    card = LamellaCardWidget(_lamella())
+    card = LamellaCardWidget(_lamella(), mode=MODE_STANDARD)
     standard_h = card.sizeHint().height()
 
     card.set_mode(MODE_COZY)
@@ -151,7 +152,7 @@ def test_toggling_to_the_cozy_tile_and_back_restores_the_standard_height():
 
 def test_the_menus_and_thumbnail_survive_a_toggle():
     """The children are re-parented, not rebuilt, so everything hung off them stays."""
-    card = _shown(LamellaCardWidget(_lamella()))
+    card = _shown(LamellaCardWidget(_lamella(), mode=MODE_STANDARD))
 
     card.set_mode(MODE_COZY)
 
@@ -164,9 +165,10 @@ def test_the_menus_and_thumbnail_survive_a_toggle():
 def test_the_lamella_events_still_refresh_after_a_toggle():
     """`refresh` is one path for both arrangements, and stays connected across a switch."""
     lamella = _lamella()
-    card = _shown(LamellaCardWidget(lamella))
+    card = _shown(LamellaCardWidget(lamella, mode=MODE_STANDARD))
 
     card.set_mode(MODE_COZY)
+    assert card.mode() == MODE_COZY, "the switch has to have happened"
     lamella.task_state.name = "Mill Undercut"
     lamella.task_state.status = AutoLamellaTaskStatus.InProgress
 
@@ -174,7 +176,7 @@ def test_the_lamella_events_still_refresh_after_a_toggle():
 
 
 def test_the_container_keeps_its_selection_across_a_toggle():
-    container = LamellaCardContainer(columns=1)
+    container = LamellaCardContainer(columns=1, mode=MODE_STANDARD)
     lamella = _lamella("kept")
     container.add_lamella(lamella)
     container._on_card_clicked(lamella)
@@ -183,15 +185,19 @@ def test_the_container_keeps_its_selection_across_a_toggle():
 
     assert container._selected_id == lamella.id
     assert container.mode() == MODE_COZY
+    # the cards themselves, not just the container's idea of the mode
+    assert all(c.mode() == MODE_COZY for c in container._cards.values())
 
 
 def test_a_card_added_later_follows_the_current_mode():
+    """Switched away from the default, so a card built from the default would fail."""
     container = LamellaCardContainer(columns=1)
-    container.set_mode(MODE_COZY)
+    container.set_mode(MODE_COMPACT)
 
     card = container.add_lamella(_lamella("late"))
 
-    assert card._thumb_label.height() > 100
+    assert card.mode() == MODE_COMPACT
+    assert card._thumb_label.isVisible() is False
 
 
 def test_the_compact_mode_drops_the_thumbnail_and_keeps_the_status():
@@ -206,7 +212,7 @@ def test_the_compact_mode_drops_the_thumbnail_and_keeps_the_status():
 
 
 def test_the_compact_row_is_shorter_than_the_standard_row():
-    standard = LamellaCardWidget(_lamella())
+    standard = LamellaCardWidget(_lamella(), mode=MODE_STANDARD)
     compact = LamellaCardWidget(_lamella(), mode=MODE_COMPACT)
 
     assert compact.sizeHint().height() < standard.sizeHint().height()
@@ -215,9 +221,10 @@ def test_the_compact_row_is_shorter_than_the_standard_row():
 def test_switching_into_compact_and_back_restores_the_thumbnail():
     """The thumbnail is left out of the list's layout entirely, so coming back has to
     both re-add it and redraw its pixmap."""
-    card = _shown(LamellaCardWidget(_lamella()))
+    card = _shown(LamellaCardWidget(_lamella(), mode=MODE_STANDARD))
 
     card.set_mode(MODE_COMPACT)
+    assert card._thumb_label.isVisible() is False, "it has to actually leave first"
     card.set_mode(MODE_STANDARD)
 
     assert card._thumb_label.isVisible() is True
@@ -226,13 +233,16 @@ def test_switching_into_compact_and_back_restores_the_thumbnail():
 
 def test_an_unknown_mode_is_ignored_rather_than_drawn_blank():
     """A hand-edited preferences file should not be able to empty the panel."""
+    from fibsem.config import DisplayPreferences
+
+    default = DisplayPreferences().lamella_card_mode
     card = LamellaCardWidget(_lamella(), mode="enormous")
 
-    assert card.mode() == MODE_STANDARD
+    assert card.mode() == default
 
     card.set_mode("enormous")
 
-    assert card.mode() == MODE_STANDARD
+    assert card.mode() == default
 
 
 def test_the_card_mode_survives_the_preferences_dialog():


### PR DESCRIPTION
From the 2026-08-11 testing session: "compact format for lamella cards".

## The problem

The card was a 300x247 portrait tile — a 280x170 thumbnail with the name and status stacked underneath. The Lamella tab puts them one per column in a scroll area capped at 340px wide, so two lamellae filled the panel. On an experiment carrying 70+ (FIB-563) that is the wrong shape.

## The change

Three layouts, chosen from **Preferences → Display**, named for density and ordered roomiest first the way Discord and Gmail order theirs:

| value | layout | height each | five lamellae |
|---|---|---|---|
| `cozy` *(default)* | large thumbnail tile | 247px | 1317px |
| `standard` | small thumbnail beside the name | 66px | 416px |
| `compact` | one line, no thumbnail | 45px | 272px |

**Cozy stays the default** — it is what the strip drew before the other two existed, so nobody's Lamella tab changes shape on upgrade. Stated plainly: that means the reported item is only fixed for people who open Preferences. Deliberate, not an oversight.

**"Cozy" names the roomy one.** It is the roomier option in every UI that uses the word, so attaching it to the densest layout would invert the one convention users arrive with.

**The stored value is the label lowercased**, so the yaml and the dialog cannot disagree.

**The compact row keeps the status.** Without it the row is a name and two buttons, which is what `LamellaNameListWidget` already draws in the Experiment tab — and the status is the field worth scanning during a run, since it says which task each lamella is on.

### Constraints that shaped it

- **The mode is a plain string, not an Enum.** Preferences are written with `yaml.safe_dump`, which raises `RepresenterError` on an Enum — and `save_user_preferences` wraps the write in a bare `except Exception: logging.warning`, so it would reach the user as "my preferences don't save" with nothing naming the cause.
- **The constants live in `fibsem/config.py`**, beside the preference. Putting them beside the widget would mean `fibsem/ui` importing `fibsem.applications.autolamella` to populate the combo — the dependency direction FIB-553/554/555 removed.
- **All three layouts share one set of child widgets**, re-parented by `_apply_layout`. Nothing is recreated, so menus, evented connections and the container's selection survive a switch, and `refresh()` stays a single display path.

## Three bugs found while building it

- **A card switched after it was on screen went blank.** A widget created once its parent is visible starts hidden, and its children report hidden with it. Every live mode switch emptied the card. `_apply_layout` now shows the new content explicitly.
- **The dialog and the cards disagreed about an unknown mode.** A preferences file holding a name this build doesn't know made the cards fall back to the default while the dialog fell back to its first entry — so the box would read "Cozy" over a strip drawing Standard, and OK would apply a layout nobody chose. Both now use the same `DisplayPreferences` default. Found on a real file: this branch's own earlier names were on disk from testing.
- **Qt caches size hints** and only recomputes on layout activation, which never happens for a widget that has not been shown — so a toggled card kept reporting the height of the arrangement it replaced. `_apply_layout` now invalidates explicitly.

## Testing

16 tests, covering the layouts, the switching, the list mode and the preference round trip.

Three of them started out passing for the wrong reason, which is worth knowing if you touch this file:

- Heights must come from `sizeHint()` — a shown top-level window floors at 100px offscreen, which made a long-status comparison hold whatever the layout did.
- "The card is wider than it is tall" is not a proxy for a dense layout: the old tile was 300x247 and already satisfied it, so the test passed against the very thing it was written to catch.
- Changing the default silently gutted five toggle tests, which switched *to* the mode that had just become the default. Every test now names the mode it builds and starts somewhere other than where it ends. Checked by stubbing `set_mode()` to a no-op: 2 of 5 failed before this, all 5 fail now.

61 pass across the card, preferences, selection, defect-sync and user-config files.