### PR TITLE
[fix][FIB-590/591] arm the FM surface correction, and say what a run will use

### DIFF
--- a/fibsem/ui/correlation/widgets/correlation_tab_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_tab_widget.py
@@ -1118,18 +1118,19 @@ class _RITab(QWidget):
         self._chk_rerun.setVisible(False)
         apply_layout.addWidget(self._chk_rerun)
 
+        apply_layout.addStretch(1)
+        layout.addWidget(apply_row)
+
+        # Its own row, under the button rather than beside it. Wrapping is what
+        # stops a long sentence setting the panel's minimum width — an unwrapped
+        # QLabel reports its whole line, and the pane's splitter has to honour it
+        # — but wrapping *inside* the button row only moved the problem: at 330px
+        # the text got an ~85px column and came out four ragged lines deep. Full
+        # width, two lines, and the row keeps its height.
         self._lbl_warning = QLabel("")
         self._lbl_warning.setStyleSheet("color: #e07b39; font-size: 11px;")
-        # Wrapped, so the sentence sets the panel's height rather than its width.
-        # An unwrapped QLabel reports its whole line as its minimum width, which
-        # this pane's splitter then has to honour — one long warning and the
-        # correlation window can no longer be made narrow.
         self._lbl_warning.setWordWrap(True)
-        # The label takes the leftover room itself; a trailing stretch would hand
-        # that room to empty space and leave it wrapping in a column of its own
-        # width, which is the opposite of the point.
-        apply_layout.addWidget(self._lbl_warning, stretch=1)
-        layout.addWidget(apply_row)
+        layout.addWidget(self._lbl_warning)
 
         self._lbl_distance = QLabel("")
         self._lbl_distance.setStyleSheet("color: #a0c8ff; font-size: 11px;")

--- a/fibsem/ui/correlation/widgets/correlation_tab_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_tab_widget.py
@@ -1120,12 +1120,20 @@ class _RITab(QWidget):
 
         self._lbl_warning = QLabel("")
         self._lbl_warning.setStyleSheet("color: #e07b39; font-size: 11px;")
-        apply_layout.addWidget(self._lbl_warning)
-        apply_layout.addStretch(1)
+        # Wrapped, so the sentence sets the panel's height rather than its width.
+        # An unwrapped QLabel reports its whole line as its minimum width, which
+        # this pane's splitter then has to honour — one long warning and the
+        # correlation window can no longer be made narrow.
+        self._lbl_warning.setWordWrap(True)
+        # The label takes the leftover room itself; a trailing stretch would hand
+        # that room to empty space and leave it wrapping in a column of its own
+        # width, which is the opposite of the point.
+        apply_layout.addWidget(self._lbl_warning, stretch=1)
         layout.addWidget(apply_row)
 
         self._lbl_distance = QLabel("")
         self._lbl_distance.setStyleSheet("color: #a0c8ff; font-size: 11px;")
+        self._lbl_distance.setWordWrap(True)
         self._lbl_distance.setVisible(False)
         layout.addWidget(self._lbl_distance)
 
@@ -1162,6 +1170,10 @@ class _RITab(QWidget):
         # and until Apply is pressed that value is not the one a run would use
         # (FIB-591).
         self._ri_widget.factor_changed.connect(lambda _f: self._refresh_warning())
+
+        # set_result maintains this from here on, but it is not called until the
+        # first data change — and the tab is reachable before that now.
+        self._refresh_apply_enabled()
 
     @property
     def mode(self) -> Optional[str]:
@@ -1244,7 +1256,39 @@ class _RITab(QWidget):
         if mode == "pre" and self._input_pre_factor is not None:
             self._populate_pre_table(self._input_pre_factor)
 
+        self._refresh_apply_enabled()
         self._refresh_warning()
+
+    def _apply_blocked_reason(self) -> Optional[str]:
+        """Why Apply cannot be pressed right now, or None when it can.
+
+        Each mode needs something different, and only *post* needs a finished
+        run: it corrects a POI the correlation produced, whereas *pre* corrects
+        the input z and is set up before a run rather than after one.
+        """
+        mode = self.mode
+        if mode is None:
+            return (
+                "Place a surface point first — in the FIB image to correct the "
+                "correlated POI, or in the FM volume to correct the POI depth."
+            )
+        if mode == "pre":
+            if not self._input_poi:
+                return "Place at least one POI for the correction to move."
+            return None
+        if not self._poi:
+            return (
+                "Run the correlation first — the FIB-surface correction adjusts "
+                "a POI the correlation has already produced."
+            )
+        return None
+
+    def _refresh_apply_enabled(self) -> None:
+        reason = self._apply_blocked_reason()
+        self._btn_apply.setEnabled(reason is None)
+        self._btn_apply.setToolTip(
+            reason or "Store the correction factor and apply it."
+        )
 
     def _refresh_warning(self) -> None:
         """Report where the correction stands, most actionable state first.
@@ -1724,8 +1768,11 @@ class CorrelationTabWidget(QWidget):
         self._tabs.addTab(self._coords_tab, "Coordinates")
         self._tabs.addTab(self._results_tab, "Results")
         self._tabs.addTab(self._ri_tab, "Refractive Index")
-        self._tabs.setTabEnabled(3, False)
-        self._tabs.setTabToolTip(3, "Run correlation first to enable RI correction")
+        # Deliberately always enabled. Gating the whole tab on a finished run hid
+        # the optical parameters, the surface→POI depth readout and the preview
+        # table at exactly the moment an FM surface point has just been placed and
+        # the user wants to check them. Apply is what needs a run behind it, so
+        # Apply is what reports when it cannot be pressed (see _apply_blocked_reason).
 
         right_pane = QWidget()
         right_layout = QVBoxLayout(right_pane)
@@ -2570,11 +2617,17 @@ class CorrelationTabWidget(QWidget):
     # Run correlation
     # ------------------------------------------------------------------
 
-    def _update_run_button(self, data: Optional[CorrelationInputData] = None) -> None:
+    def _can_run(self, data: Optional[CorrelationInputData] = None) -> bool:
+        """Whether the current inputs can support a correlation run.
+
+        A predicate rather than a read of ``_btn_run.isEnabled()``: the button is
+        re-derived from ``data_changed``, so a caller that emits and then asks the
+        button gets the answer for the state it just announced, not the one it
+        meant to test.
+        """
         d = data if data is not None else self.data
-        running = self._worker is not None and self._worker.isRunning()
-        ok = (
-            not running
+        return (
+            not (self._worker is not None and self._worker.isRunning())
             and self._fib_image is not None
             and self._fm_image is not None
             and len(d.fib_coordinates) >= 4
@@ -2582,6 +2635,11 @@ class CorrelationTabWidget(QWidget):
             and len(d.poi_coordinates) >= 1
             and len(d.fib_coordinates) == len(d.fm_coordinates)
         )
+
+    def _update_run_button(self, data: Optional[CorrelationInputData] = None) -> None:
+        d = data if data is not None else self.data
+        running = self._worker is not None and self._worker.isRunning()
+        ok = self._can_run(d)
         self._btn_run.setEnabled(ok)
         if self._autosave_error is not None:
             # Outranks the readiness text: "Ready." while nothing is being saved
@@ -2637,7 +2695,6 @@ class CorrelationTabWidget(QWidget):
         self._ri_tab.set_result(
             result, input_data=self.data, fm_pixel_size_z=self._fm_pixel_size_z()
         )
-        self._tabs.setTabEnabled(3, True)
         self._overlay_result_on_fib(result)
         self._set_result_live(live)
         # after _update_run_button, which would otherwise overwrite it with "Ready."
@@ -2784,7 +2841,10 @@ class CorrelationTabWidget(QWidget):
         """Store the pre-correlation RI factor and optionally re-run."""
         self._ri_pre_correction_factor = factor
         self.data_changed.emit(self.data)  # auto-save + RI tab refresh
-        if rerun:
+        # Apply is reachable before the points can support a correlation now the
+        # RI tab is no longer gated on a finished run, and _run does not check --
+        # it would start a worker whose only outcome is an error on the status line.
+        if rerun and self._can_run():
             self._run()
         else:
             self._lbl_status.setText(

--- a/fibsem/ui/correlation/widgets/correlation_tab_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_tab_widget.py
@@ -1202,12 +1202,14 @@ class _RITab(QWidget):
 
         # Mode banner + pre-mode controls
         if mode == "pre":
-            # Deliberately not "applied during the run": the surface point alone
-            # corrects nothing, and a banner promising otherwise is what made a
-            # never-Applied correction read as a broken feature (FIB-590).
+            # Deliberately not "applied during the run": placing the point arms
+            # a factor only when one can be computed, and a banner promising the
+            # run does it regardless is what made a never-armed correction read
+            # as a broken feature (FIB-590). The warning line below carries which
+            # of the two it is; this only names the control that decides.
             self._lbl_mode.setText(
                 "FM surface mode: corrects the z of every input POI before "
-                "correlation. Press Apply to arm the factor — runs then use it."
+                "correlation. Apply sets the factor a run will use."
             )
         elif mode == "post":
             self._lbl_mode.setText(
@@ -2789,6 +2791,21 @@ class CorrelationTabWidget(QWidget):
                 "Pre-correction factor stored — run correlation to apply."
             )
 
+    def _auto_arm_pre_correction(self) -> Optional[float]:
+        """Arm the factor on screen as the FM surface point lands, so a plain Run
+        applies the correction (FIB-590). Returns what was armed, or None.
+
+        The spinbox value as-is, not a fresh ζ: it is already what the optical
+        parameters produced unless someone typed over it, and recomputing is a
+        parameter edit away. The one thing this must not be is silent — the
+        status line names the factor, and the RI tab reports it from there on.
+        """
+        if self._ri_pre_correction_factor is not None:
+            return None  # a factor already chosen outranks arming a fresh one
+        factor = self._ri_tab._ri_widget.get_factor()
+        self._ri_pre_correction_factor = factor
+        return factor
+
     def _clear_pre_correction_factor(self) -> None:
         """The pre-correction factor's lifecycle is tied to the FM surface point:
         removing the surface disarms the factor so it cannot silently re-apply
@@ -2877,9 +2894,19 @@ class CorrelationTabWidget(QWidget):
             self._clear_exclusive_siblings(spec)
         else:
             spec.list_widget.add_coordinate(coord)
+        # Before the emit: the armed factor is part of the data being announced.
+        armed = (
+            self._auto_arm_pre_correction() if pt is PointType.SURFACE_FM else None
+        )
         self._refresh_canvas(spec.adapter)
         self._coords_tab.update_headers()
         self.data_changed.emit(self.data)
+        if armed is not None:
+            # After the emit, which routes through _update_run_button and its
+            # "Ready." — the same ordering the RI status note already needs.
+            self._lbl_status.setText(
+                f"FM surface placed — RI ×{armed:.3f} armed. Run to apply."
+            )
 
     def _clear_exclusive_siblings(self, spec: _PointTypeSpec) -> None:
         """Enforce mutual exclusivity (one surface point at a time): clear the

--- a/fibsem/ui/correlation/widgets/correlation_tab_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_tab_widget.py
@@ -1059,6 +1059,10 @@ class _RITab(QWidget):
         "armed":   "color: #e0c060; font-size: 11px;",
     }
 
+    # Half the factor spinbox's last decimal: a stored 1.5950000000000002 shows
+    # as 1.595, and that rounding must not read as an unapplied edit.
+    _FACTOR_EPS = 5e-4
+
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self._poi: List[CorrelationPointOfInterest] = []
@@ -1152,6 +1156,13 @@ class _RITab(QWidget):
         layout.addWidget(self._lbl_multi_poi)
         layout.addStretch(1)
 
+        # Last, not beside the widget it listens to: the slot writes to
+        # _lbl_warning, which is built further down this method. The factor can
+        # move with no data change behind it — a parameter edit recomputes it —
+        # and until Apply is pressed that value is not the one a run would use
+        # (FIB-591).
+        self._ri_widget.factor_changed.connect(lambda _f: self._refresh_warning())
+
     @property
     def mode(self) -> Optional[str]:
         """'pre' when an FM surface exists, 'post' for a FIB surface, else None."""
@@ -1191,9 +1202,12 @@ class _RITab(QWidget):
 
         # Mode banner + pre-mode controls
         if mode == "pre":
+            # Deliberately not "applied during the run": the surface point alone
+            # corrects nothing, and a banner promising otherwise is what made a
+            # never-Applied correction read as a broken feature (FIB-590).
             self._lbl_mode.setText(
                 "FM surface mode: corrects the z of every input POI before "
-                "correlation (applied during the run)."
+                "correlation. Press Apply to arm the factor — runs then use it."
             )
         elif mode == "post":
             self._lbl_mode.setText(
@@ -1211,7 +1225,6 @@ class _RITab(QWidget):
         self._update_distance_label()
 
         result_factor = result.refractive_index_correction_factor if result else None
-        result_mode = result.refractive_index_correction_mode if result else None
 
         # Factor spinbox mirrors the authoritative stored factor. In pre mode a
         # newly armed input factor is the latest user intent and outranks the
@@ -1228,6 +1241,50 @@ class _RITab(QWidget):
         # Pre-mode preview table (stored factor, applied or armed)
         if mode == "pre" and self._input_pre_factor is not None:
             self._populate_pre_table(self._input_pre_factor)
+
+        self._refresh_warning()
+
+    def _refresh_warning(self) -> None:
+        """Report where the correction stands, most actionable state first.
+
+        Split out of :meth:`set_result` because the correction factor moves
+        without any data change — a parameter edit recomputes it — and a value
+        on screen that no run would use has to say so (FIB-591).
+        """
+        mode = self.mode
+        result_factor = (
+            self._result.refractive_index_correction_factor if self._result else None
+        )
+        result_mode = (
+            self._result.refractive_index_correction_mode if self._result else None
+        )
+
+        # An FM surface point on its own corrects nothing: the engine needs a
+        # factor too, and only Apply stores one. Nothing else on screen asks for
+        # that press, which is how placing the point and running read as a
+        # feature that does nothing (FIB-590).
+        if mode == "pre" and self._input_pre_factor is None and self._input_poi:
+            self._set_warning(
+                "FM surface placed — press Apply to arm the correction.",
+                level="armed",
+            )
+            return
+
+        # A factor typed or recomputed since the last Apply is not the one a run
+        # would use. Name both numbers: the disagreement is the whole point, and
+        # silently running the older one is what this replaces (FIB-591).
+        shown = self._ri_widget.get_factor()
+        if (
+            mode == "pre"
+            and self._input_pre_factor is not None
+            and abs(shown - self._input_pre_factor) > self._FACTOR_EPS
+        ):
+            self._set_warning(
+                f"Factor {shown:.3f} not applied — press Apply to use it "
+                f"(runs use {self._input_pre_factor:.3f}).",
+                level="armed",
+            )
+            return
 
         # "Armed" means the stored factor is not what produced the POI on screen.
         # Matching factors are not enough — a result corrected in *post* mode was
@@ -2617,6 +2674,18 @@ class CorrelationTabWidget(QWidget):
             if shift is not None:
                 msg += f", POI Δ{shift:.1f} px"
             self._lbl_status.setText(msg)
+        elif (
+            result.input_data is not None
+            and result.input_data.fm_surface_coordinate is not None
+            and result.input_data.ri_pre_correction_factor is None
+        ):
+            # The RI tab says this too, but it opens only after a run and the
+            # user has no reason to look: the run they just watched do nothing
+            # is where the FM surface point stops being self-explanatory.
+            self._lbl_status.setText(
+                "Done — no RI correction. Press Apply on the Refractive Index "
+                "tab to use the FM surface point."
+            )
         else:
             self._lbl_status.setText("Done.")
         self.result_changed.emit(result)

--- a/fibsem/ui/correlation/widgets/refractive_index_widget.py
+++ b/fibsem/ui/correlation/widgets/refractive_index_widget.py
@@ -73,9 +73,16 @@ class RefractiveIndexWidget(QWidget):
     -------
     zeta_computed(float):
         Emitted after each recompute with the new zeta value.
+    factor_changed(float):
+        Emitted when the correction-factor spinbox moves under the user -- typed
+        directly, reset, or recomputed from an optical parameter. Deliberately
+        silent for :meth:`set_factor`, which mirrors an already-stored value:
+        the point of the signal is to tell a consumer that what is on screen is
+        no longer what has been applied (FIB-591).
     """
 
     zeta_computed = pyqtSignal(float)
+    factor_changed = pyqtSignal(float)
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
@@ -201,6 +208,11 @@ class RefractiveIndexWidget(QWidget):
         )
 
         self.zeta_computed.connect(self._spin_factor.setValue)
+
+        # Relayed rather than exposed: set_factor blocks this spinbox's signals,
+        # so mirroring a stored factor stays silent while every user-facing route
+        # to it (typing, reset, a parameter edit feeding zeta through) reports.
+        self._spin_factor.valueChanged.connect(self.factor_changed)
 
     # ------------------------------------------------------------------
     # Public API

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -454,11 +454,51 @@ def test_typed_factor_survives_refresh_and_armed_priority(qapp):
     assert tab._ri_widget.get_factor() == pytest.approx(1.8)
 
 
-def test_fm_surface_alone_asks_for_the_apply_press(qapp):
-    """FIB-590: the surface point corrects nothing until a factor is armed, and
-    nothing else on screen says so."""
+def _loaded_surface_without_a_factor(w):
+    """The state a saved correlation restores when it was never Applied: an FM
+    surface point and a POI, but no armed factor. Placing the point by hand arms
+    one, so this is the only route left to the un-armed state."""
+    w.set_data(
+        CorrelationInputData(
+            fm_surface_coordinate=_coord(z=10.0, pt=PointType.SURFACE_FM),
+            poi_coordinates=[_coord(z=30.0, pt=PointType.POI)],
+        )
+    )
+    w.data_changed.emit(w.data)
+
+
+def test_placing_the_fm_surface_arms_the_factor_on_screen(qapp):
+    """FIB-590: a plain Run has to apply the correction, so the point arms the
+    factor as it lands — whatever the spinbox is showing."""
+    w = _widget(qapp)
+    w._ri_tab._ri_widget.set_factor(1.42)
+
+    w._on_canvas_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+
+    assert w._ri_pre_correction_factor == pytest.approx(1.42)
+    assert w.data.ri_pre_correction_factor == pytest.approx(1.42)
+    assert "not applied" not in w._ri_tab._lbl_warning.text()
+    # named as it lands; the next edit is free to reclaim the status line
+    assert "1.420" in w._lbl_status.text()
+
+
+def test_auto_arm_does_not_overwrite_a_chosen_factor(qapp):
+    """Re-placing the surface must not discard a factor the user applied."""
     w = _widget(qapp)
     _setup_pre_mode(w)
+    w._ri_tab._ri_widget.set_factor(1.2)
+    w._ri_tab._chk_rerun.setChecked(False)
+    w._ri_tab._apply()
+
+    w._on_canvas_add_requested(7.0, 8.0, PointType.SURFACE_FM)  # moved the point
+    assert w._ri_pre_correction_factor == pytest.approx(1.2)
+
+
+def test_a_loaded_surface_without_a_factor_asks_for_apply(qapp):
+    """FIB-590: a correlation saved before anyone pressed Apply restores a
+    surface point that corrects nothing, and has to say so."""
+    w = _widget(qapp)
+    _loaded_surface_without_a_factor(w)
 
     assert w._ri_pre_correction_factor is None
     assert w.data.ri_pre_correction_factor is None  # a run here corrects nothing
@@ -471,7 +511,7 @@ def test_run_with_a_surface_but_no_factor_says_why_nothing_moved(qapp):
     """FIB-590: the RI tab opens only after a run, so the status line has to
     carry this — it is where the user is looking when nothing moves."""
     w = _widget(qapp)
-    _setup_pre_mode(w)
+    _loaded_surface_without_a_factor(w)
 
     result = _result_from(w.data)
     w._on_result_ready(result)

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -454,6 +454,98 @@ def test_typed_factor_survives_refresh_and_armed_priority(qapp):
     assert tab._ri_widget.get_factor() == pytest.approx(1.8)
 
 
+def test_fm_surface_alone_asks_for_the_apply_press(qapp):
+    """FIB-590: the surface point corrects nothing until a factor is armed, and
+    nothing else on screen says so."""
+    w = _widget(qapp)
+    _setup_pre_mode(w)
+
+    assert w._ri_pre_correction_factor is None
+    assert w.data.ri_pre_correction_factor is None  # a run here corrects nothing
+    assert "press Apply" in w._ri_tab._lbl_warning.text()
+    # and the banner must not claim the run does it by itself
+    assert "applied during the run" not in w._ri_tab._lbl_mode.text()
+
+
+def test_run_with_a_surface_but_no_factor_says_why_nothing_moved(qapp):
+    """FIB-590: the RI tab opens only after a run, so the status line has to
+    carry this — it is where the user is looking when nothing moves."""
+    w = _widget(qapp)
+    _setup_pre_mode(w)
+
+    result = _result_from(w.data)
+    w._on_result_ready(result)
+
+    assert "no RI correction" in w._lbl_status.text()
+    assert "Refractive Index" in w._lbl_status.text()
+
+
+def test_unapplied_factor_edit_is_reported(qapp):
+    """FIB-591: Run uses the armed factor, not the spinbox, so a divergence
+    between them must be visible rather than silently ignored."""
+    w = _widget(qapp)
+    _setup_pre_mode(w)
+    tab = w._ri_tab
+
+    tab._ri_widget.set_factor(1.5)
+    tab._chk_rerun.setChecked(False)
+    tab._apply()
+    assert "stored — applied on the next run" in tab._lbl_warning.text()
+
+    # typed by hand, never applied: the run would still use 1.5
+    tab._ri_widget._spin_factor.setValue(1.8)
+    assert "1.800 not applied" in tab._lbl_warning.text()
+    assert "runs use 1.500" in tab._lbl_warning.text()
+    assert w.data.ri_pre_correction_factor == pytest.approx(1.5)
+
+    # applying it clears the divergence
+    tab._apply()
+    assert "not applied" not in tab._lbl_warning.text()
+    assert w.data.ri_pre_correction_factor == pytest.approx(1.8)
+
+
+def test_an_optical_parameter_edit_counts_as_an_unapplied_factor(qapp):
+    """FIB-591: the parameters feed the factor through zeta, so editing one is
+    just as un-applied as typing the number."""
+    from fibsem.correlation.refractive_index import _LUT_PATH
+
+    if not _LUT_PATH.exists():
+        pytest.skip("LUT CSV not present — the parameter spinboxes are disabled")
+
+    w = _widget(qapp)
+    _setup_pre_mode(w)
+    tab = w._ri_tab
+
+    tab._ri_widget.set_factor(1.5)
+    tab._chk_rerun.setChecked(False)
+    tab._apply()
+
+    tab._ri_widget._spin_n2.setValue(1.22)  # moves zeta well clear of 1.5
+    assert "not applied" in tab._lbl_warning.text()
+    assert "runs use 1.500" in tab._lbl_warning.text()
+
+
+def test_mirroring_a_stored_factor_is_not_an_unapplied_edit(qapp):
+    """set_factor blocks signals precisely so this stays quiet — otherwise every
+    refresh that mirrors the stored value would report a divergence."""
+    w = _widget(qapp)
+    _setup_pre_mode(w)
+    tab = w._ri_tab
+
+    w._ri_pre_correction_factor = 1.5950000000000002  # as loaded from JSON
+    result = CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=1.0, y=2.0))],
+        refractive_index_correction_factor=1.5950000000000002,
+        refractive_index_correction_mode="pre",
+    )
+    tab.set_result(result, input_data=w.data)
+
+    # the spinbox rounds to 3 decimals; that must not read as an edit
+    assert tab._ri_widget.get_factor() == pytest.approx(1.595)
+    assert "not applied" not in tab._lbl_warning.text()
+    assert "Correction applied" in tab._lbl_warning.text()
+
+
 def test_tilt_lock_preserves_manual_factor(qapp):
     from fibsem.ui.correlation.widgets.refractive_index_widget import (
         RefractiveIndexWidget,

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -131,6 +131,56 @@ def test_ri_tab_mode_follows_surface_type(qapp):
     assert tab.mode == "pre"
 
 
+_RI_TAB_INDEX = 3
+
+
+def test_ri_tab_is_reachable_before_any_run(qapp):
+    """The optical parameters, the depth readout and the preview table are what
+    a user wants right after placing an FM surface point — gating the whole tab
+    on a finished run hid them at exactly that moment."""
+    w = _widget(qapp)
+    assert w._tabs.isTabEnabled(_RI_TAB_INDEX)
+
+    w._on_canvas_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    assert w._tabs.isTabEnabled(_RI_TAB_INDEX)
+
+
+def test_apply_is_disabled_until_it_can_do_something(qapp):
+    """Apply carries the gating the tab used to, and says why it cannot be
+    pressed rather than accepting a press and reporting failure."""
+    w = _widget(qapp)
+    btn = w._ri_tab._btn_apply
+
+    # no surface at all
+    assert not btn.isEnabled()
+    assert "Place a surface point" in btn.toolTip()
+
+    # FM surface, no POI to move
+    w._on_canvas_add_requested(1.0, 2.0, PointType.SURFACE_FM)
+    assert not btn.isEnabled()
+    assert "POI" in btn.toolTip()
+
+    # FM surface + POI: usable with no result behind it, which is the point —
+    # the pre-mode correction is set up before a run, not after one
+    w._on_canvas_add_requested(5.0, 6.0, PointType.POI)
+    assert btn.isEnabled()
+
+
+def test_apply_stays_disabled_in_post_mode_until_there_is_a_result(qapp):
+    """Post mode corrects a POI the correlation produced, so unlike pre mode it
+    genuinely does need a run first."""
+    w = _widget(qapp)
+    btn = w._ri_tab._btn_apply
+
+    w._on_canvas_add_requested(1.0, 200.0, PointType.SURFACE)
+    w._on_canvas_add_requested(5.0, 6.0, PointType.POI)
+    assert not btn.isEnabled()
+    assert "Run the correlation first" in btn.toolTip()
+
+    w._on_result_ready(_result_from(w.data))
+    assert btn.isEnabled()
+
+
 def test_tilt_locked_to_zero_in_pre_mode(qapp):
     w = _widget(qapp)
     spin_tilt = w._ri_tab._ri_widget._spin_tilt
@@ -165,6 +215,8 @@ def test_apply_pre_stores_factor_and_reruns(qapp):
 
     runs = []
     w._run = lambda: runs.append(True)
+    # stands in for a runnable set of points; _update_run_button passes the data
+    w._can_run = lambda data=None: True
 
     w._ri_tab._ri_widget.set_factor(1.5)
     w._ri_tab._chk_rerun.setChecked(True)
@@ -173,6 +225,25 @@ def test_apply_pre_stores_factor_and_reruns(qapp):
     assert w._ri_pre_correction_factor == pytest.approx(1.5)
     assert w.data.ri_pre_correction_factor == pytest.approx(1.5)
     assert runs == [True]
+
+
+def test_apply_pre_does_not_rerun_what_cannot_run(qapp):
+    """The RI tab is reachable before the points can support a correlation, and
+    _run does not check — it would start a worker that only errors."""
+    w = _widget(qapp)
+    _setup_pre_mode(w)
+
+    runs = []
+    w._run = lambda: runs.append(True)
+    assert not w._can_run()  # no images, no fiducials
+
+    w._ri_tab._ri_widget.set_factor(1.5)
+    w._ri_tab._chk_rerun.setChecked(True)
+    w._ri_tab._apply()
+
+    assert w._ri_pre_correction_factor == pytest.approx(1.5)  # still stored
+    assert runs == []
+    assert "run correlation to apply" in w._lbl_status.text()
 
 
 def test_apply_pre_without_rerun_only_stores(qapp):


### PR DESCRIPTION
A user reported that the FM-surface refractive-index correction "doesn't do anything". The correction maths is not the problem — driving the real `CorrelationTabWidget` end to end, the POI moves by exactly the predicted `s·sin(θ)·Δz`, transiently, feeding the `px_m` that Continue commits.

What was missing is that nothing ever *armed* a factor, nothing said so, and the tab where you would find out was disabled. Three changes, one per commit.

---

## FIB-590 — an FM surface point alone corrected nothing

`run_correlation_from_data` needs both the surface point and `ri_pre_correction_factor`, and only the RI tab's **Apply** set the latter — on a tab that stayed disabled until after the first run. Measured before:

```
baseline POI                   : (550.00, 605.89)
after placing FM surface + Run : (550.00, 605.89)   moved 0.00 px   mode=None
   RI tab warning: ''
   banner: 'FM surface mode: ... (applied during the run).'
```

The banner promised the run would do it, and nothing asked for the Apply press. Place the point, run, see nothing move, conclude the feature is broken.

**Placing the point now arms the factor** (`_auto_arm_pre_correction`), so a plain Run applies the correction:

```
on placing the FM surface     : status 'FM surface placed — RI ×1.595 armed. Run to apply.'
after Run (no Apply pressed)  : (550.00, 600.39)   moved 5.49 px   mode=pre factor=1.595
```

The spinbox value is taken as-is rather than recomputed — it is already what the optical parameters produced unless someone typed over it, and recomputing is a parameter edit away. Arming is never silent: the status line names the factor as the point lands. An already-chosen factor outranks it, so moving the point does not discard one the user applied.

## FIB-591 — Run used the armed factor, not the spinbox

```
after Apply           : POI (550.00, 600.39)   armed=1.595
user sets n2=1.22 -> factor box now 1.330, armed still 1.595
after bottom-bar Run  : POI (550.00, 600.39)   changed 0.00 px
   warning: 'Correction applied (pre, factor: 1.595).'   <- still reads as success
   factor in box: 1.330
```

The RI tab's warning becomes a standalone, spinbox-aware state, because the factor moves with no data change behind it:

- `RefractiveIndexWidget` gains `factor_changed`, relayed off the factor spinbox. `set_factor` already blocked that spinbox's signals, so mirroring a stored value stays quiet and only user-facing routes to it (typing, reset, a parameter edit feeding zeta through) report.
- `_RITab._refresh_warning`, split out of `set_result`, adds two states ahead of the existing ones — nothing armed yet, and a shown factor diverging from the armed one (5e-4 tolerance, so a stored `1.5950000000000002` displayed as `1.595` is not an edit).
- The status line reports a run that had a surface but no factor.
- The pre-mode banner no longer claims the run applies the correction by itself.

```
warning: 'Factor 1.330 not applied — press Apply to use it (runs use 1.595).'
```

The un-armed state is still reachable by loading a correlation saved before anyone pressed Apply, so the warning and the status note stay, and their tests drive that route rather than the canvas.

## The RI tab opens before the run, and Apply carries the gating

Gating the whole tab on a finished correlation hid the optical parameters, the surface→POI depth readout and the preview table at exactly the moment they are wanted: just after an FM surface point has been placed. The tab is now always enabled, and Apply reports through its tooltip why it cannot be pressed rather than accepting the press and answering with a warning:

| state | Apply |
|---|---|
| no surface point | disabled — "Place a surface point first…" |
| FM surface, no POI | disabled — "Place at least one POI…" |
| FM surface + POI, no result | **enabled** |
| FIB surface, no result | disabled — "Run the correlation first…" |

Only post mode needs a run behind it — it corrects a POI the correlation produced. Pre mode corrects the input z and is set up before a run, which is the whole reason the tab wanted opening early.

Two things fall out of the tab being reachable sooner:

- **Apply with "Re-run on apply" could start a correlation the points cannot support**, whose only outcome is an error on the status line. The re-run is gated on `_can_run`, extracted from `_update_run_button`. It has to be a predicate rather than a read of `_btn_run.isEnabled()`: the handler emits `data_changed` first, which re-derives the button, so asking the button answers for the state just announced instead of the one being tested.
- **The warning and depth labels now word-wrap.** Unwrapped, the longest warning reported a 362 px minimum width that the pane's splitter had to honour; it now asks for 41 px, and the tab's 275 px floor comes from the table. The trailing `addStretch(1)` gave way to stretch on the label itself — otherwise it wraps inside its own narrow column while empty space takes the room.

---

## Verification

All ten RI-tab states walked against the real widget: the pre-existing ones (no surface, applied, armed-with-rerun-off, post mode, no-POI, …) are unchanged, and only the silent ones now speak. Thirteen tests added, including the mirroring case that must *not* trigger, re-placing the point keeping a chosen factor, and Apply refusing to re-run what cannot run. 389 correlation tests pass both with and without the LUT CSV present; CI green on 3.8–3.13.

## Not in scope

FIB-592 (a corrupt LUT download silently disables the calculator) and FIB-593 (default factor 1.470 vs the LUT's 1.595) are filed separately and untouched here. FIB-593 is worth doing sooner now: the factor armed on placement is whatever the box holds, including that 1.470 fallback when the LUT is missing.