### PR TITLE
[fix] Carry the fluorescence pose at the last two beam-side move doors

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1400,12 +1400,22 @@ class AutoLamellaUI(QMainWindow):
 
         lamella.poses[pose_name] = state
 
-        # if the milling pose changed, keep the milling angle consistent with it
+        # Replacing the milling pose moves the lamella, so what is derived from it has to
+        # follow: the milling angle, and the fluorescence pose, which describes the same
+        # piece of sample from the other side. Left behind, that pose would go on naming
+        # where this lamella used to be -- and nothing about a stale pose looks wrong.
         if pose_name == "MILLING":
             lamella.update_milling_angle(self.microscope)
+            if sync_fluorescence_pose(self.microscope, lamella):
+                self.selected_lamella_widget.refresh_pose(
+                    "FLUORESCENCE", lamella.fluorescence_pose.stage_position.pretty
+                )
 
         self.experiment.save()
         self.selected_lamella_widget.refresh_pose(pose_name, state.stage_position.pretty)
+        # The FM overview canvas draws these positions itself rather than reading them
+        # back, so a pose that moved here is one it only hears about by being told.
+        self.experiment.positions.events.changed.emit()
         notification_service.show_toast(
             f"Set current position as pose '{pose_name}' for {lamella.name}.", "info"
         )

--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -70,6 +70,7 @@ from fibsem.ui.widgets.custom_widgets import (
     IntegerValueSpinBox,
     TitledPanel,
 )
+from fibsem.applications.autolamella.poses import sync_fluorescence_pose
 from fibsem.applications.autolamella.ui.lamella_name_list_widget import LamellaNameListWidget
 from fibsem.ui.widgets.coincidence_milling_confirmation_dialog import (
     CoincidenceMillingConfirmationDialog,
@@ -1446,8 +1447,24 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             state.objective_position = existing_pose.objective_position
 
         lamella.poses[pose_name] = state
+
+        # Replacing the milling pose moves the lamella, so what is derived from it has to
+        # follow: the milling angle, and the fluorescence pose, which describes the same
+        # piece of sample from the other side. Left behind, that pose would go on naming
+        # where this lamella used to be -- and nothing about a stale pose looks wrong.
+        if pose_name == "MILLING":
+            lamella.update_milling_angle(self.microscope)
+            if sync_fluorescence_pose(self.microscope, lamella):
+                self.selected_lamella_widget.refresh_pose(
+                    "FLUORESCENCE", lamella.fluorescence_pose.stage_position.pretty
+                )
+
         if self.experiment is not None:
             self.experiment.save()
+            # The FM overview canvas draws these positions itself rather than reading
+            # them back, so a pose that moved here is one it only hears about by being
+            # told.
+            self.experiment.positions.events.changed.emit()
         self.selected_lamella_widget.refresh_pose(
             pose_name, state.stage_position.pretty
         )

--- a/tests/ui/test_beam_side_move_syncs_fm_pose.py
+++ b/tests/ui/test_beam_side_move_syncs_fm_pose.py
@@ -1,10 +1,12 @@
 """Moving a lamella on the beam side has to carry its fluorescence pose along.
 
-A lamella describes one piece of sample from two sides. Both of the beam-side ways to
-say "this lamella is somewhere else" -- dragging it on the FIB/SEM overview, and saving
-the current stage position onto it from the lamella list -- set the milling pose and
-historically stopped there, leaving the fluorescence pose naming where the lamella used
-to be. Nothing about a stale pose looks wrong, which is what made it worth pinning.
+A lamella describes one piece of sample from two sides. Every beam-side way to say "this
+lamella is somewhere else" -- dragging it on the FIB/SEM overview, saving the current
+stage position onto it from the lamella list, and setting its milling pose from the
+Selected Lamella panel's pose rows (in the main window and in the coincidence viewer) --
+sets the milling pose and historically stopped there, leaving the fluorescence pose
+naming where the lamella used to be. Nothing about a stale pose looks wrong, which is
+what made it worth pinning.
 
 `tests/autolamella/test_poses.py` covers what `sync_fluorescence_pose` computes. This
 covers the other half: that these two callers actually call it. A correct helper nothing
@@ -82,6 +84,21 @@ class _SelectedList:
 
     def select(self, name):
         pass
+
+
+class _SelectedLamellaPanel:
+    """The Selected Lamella panel, which refreshes its pose rows in place.
+
+    Recorded rather than ignored: a synced pose whose row is not redrawn leaves the
+    panel displaying a position that pose no longer has, which is the same wrong answer
+    the sync exists to remove -- just on screen instead of on disk.
+    """
+
+    def __init__(self):
+        self.refreshed = {}
+
+    def refresh_pose(self, pose_name, pretty):
+        self.refreshed[pose_name] = pretty
 
 
 def test_dragging_a_lamella_on_the_minimap_moves_its_fluorescence_pose(tmp_path):
@@ -199,3 +216,146 @@ def test_declining_the_confirmation_moves_neither_pose(tmp_path, monkeypatch):
         lamella.milling_pose.stage_position.x,
         lamella.fluorescence_pose.stage_position.x,
     ) == before
+
+
+def _pose_row_ui(module, microscope, lamella):
+    """A stub carrying `AutoLamellaUI._set_current_position_as_pose` and nothing else."""
+
+    class _UI:
+        _set_current_position_as_pose = module.AutoLamellaUI._set_current_position_as_pose
+
+        def __init__(self):
+            self.microscope = microscope
+            self.experiment = _Experiment([lamella])
+            self.lamella_list = _SelectedList()
+            self.selected_lamella_widget = _SelectedLamellaPanel()
+
+    return _UI()
+
+
+def test_setting_the_milling_pose_from_the_pose_rows_moves_the_fluorescence_pose(
+    tmp_path, monkeypatch
+):
+    """`AutoLamellaUI._set_current_position_as_pose` -- the Selected Lamella panel's
+    per-pose Update Position button, a third door onto the same move."""
+    module = sys.modules["fibsem.applications.autolamella.ui.AutoLamellaUI"]
+
+    microscope = _microscope()
+    lamella = _lamella(microscope, tmp_path)
+    before = lamella.fluorescence_pose.stage_position.x
+    microscope.move_stage_absolute(
+        _at(microscope, MILLING_ORIENTATION, 400e-6, -200e-6)
+    )
+    monkeypatch.setattr(
+        module.QMessageBox, "question", staticmethod(lambda *a, **k: QMessageBox.Yes)
+    )
+
+    ui = _pose_row_ui(module, microscope, lamella)
+    ui._set_current_position_as_pose("MILLING")
+
+    assert lamella.milling_pose.stage_position.x == pytest.approx(400e-6)
+    assert lamella.fluorescence_pose.stage_position.x == pytest.approx(400e-6)
+    assert lamella.fluorescence_pose.stage_position.x != pytest.approx(before)
+    assert (
+        microscope.get_stage_orientation(lamella.fluorescence_pose.stage_position)
+        == FLUORESCENCE_ORIENTATION
+    )
+    assert "FLUORESCENCE" in ui.selected_lamella_widget.refreshed
+
+
+def test_setting_the_fluorescence_pose_from_the_pose_rows_is_not_undone(
+    tmp_path, monkeypatch
+):
+    """Only the milling pose fans out.
+
+    Re-deriving the fluorescence pose after a user has just set it by hand would
+    overwrite the one thing they came to that button to change.
+    """
+    module = sys.modules["fibsem.applications.autolamella.ui.AutoLamellaUI"]
+
+    microscope = _microscope()
+    lamella = _lamella(microscope, tmp_path)
+    milling_before = lamella.milling_pose.stage_position.x
+    target = _at(microscope, FLUORESCENCE_ORIENTATION, 400e-6, -200e-6)
+    microscope.move_stage_absolute(target)
+    monkeypatch.setattr(
+        module.QMessageBox, "question", staticmethod(lambda *a, **k: QMessageBox.Yes)
+    )
+
+    ui = _pose_row_ui(module, microscope, lamella)
+    ui._set_current_position_as_pose("FLUORESCENCE")
+
+    assert lamella.fluorescence_pose.stage_position.x == pytest.approx(400e-6)
+    assert lamella.milling_pose.stage_position.x == pytest.approx(milling_before)
+
+
+def test_declining_the_pose_row_confirmation_moves_neither_pose(tmp_path, monkeypatch):
+    """The sync sits after this confirmation too."""
+    module = sys.modules["fibsem.applications.autolamella.ui.AutoLamellaUI"]
+
+    microscope = _microscope()
+    lamella = _lamella(microscope, tmp_path)
+    before = (
+        lamella.milling_pose.stage_position.x,
+        lamella.fluorescence_pose.stage_position.x,
+    )
+    microscope.move_stage_absolute(
+        _at(microscope, MILLING_ORIENTATION, 400e-6, -200e-6)
+    )
+    monkeypatch.setattr(
+        module.QMessageBox, "question", staticmethod(lambda *a, **k: QMessageBox.No)
+    )
+
+    _pose_row_ui(module, microscope, lamella)._set_current_position_as_pose("MILLING")
+
+    assert (
+        lamella.milling_pose.stage_position.x,
+        lamella.fluorescence_pose.stage_position.x,
+    ) == before
+
+
+def test_setting_the_milling_pose_in_the_coincidence_viewer_moves_it_too(
+    tmp_path, monkeypatch
+):
+    """`FluorescenceCoincidenceViewerWidget._on_slw_pose_update` -- the same panel, in
+    the other window, with its own copy of the handler."""
+    from fibsem.applications.autolamella.ui import (
+        fluorescence_coincidence_viewer_widget as module,
+    )
+
+    microscope = _microscope()
+    lamella = _lamella(microscope, tmp_path)
+    before = lamella.fluorescence_pose.stage_position.x
+    lamella.milling_angle = None
+    microscope.move_stage_absolute(
+        _at(microscope, MILLING_ORIENTATION, 400e-6, -200e-6)
+    )
+    monkeypatch.setattr(
+        module.QMessageBox, "question", staticmethod(lambda *a, **k: QMessageBox.Yes)
+    )
+
+    class _Viewer:
+        _on_slw_pose_update = (
+            module.FluorescenceCoincidenceViewerWidget._on_slw_pose_update
+        )
+
+        def __init__(self):
+            self.microscope = microscope
+            self._selected_lamella = lamella
+            self.experiment = _Experiment([lamella])
+            self.selected_lamella_widget = _SelectedLamellaPanel()
+
+    viewer = _Viewer()
+    viewer._on_slw_pose_update("MILLING")
+
+    assert lamella.milling_pose.stage_position.x == pytest.approx(400e-6)
+    assert lamella.fluorescence_pose.stage_position.x == pytest.approx(400e-6)
+    assert lamella.fluorescence_pose.stage_position.x != pytest.approx(before)
+    assert (
+        microscope.get_stage_orientation(lamella.fluorescence_pose.stage_position)
+        == FLUORESCENCE_ORIENTATION
+    )
+    assert "FLUORESCENCE" in viewer.selected_lamella_widget.refreshed
+    # this copy never recomputed the milling angle either, so the lamella went on
+    # reporting the angle it was marked at rather than the one it now sits at
+    assert lamella.milling_angle is not None


### PR DESCRIPTION
## The report

> the fm pose does not match the same position on the grid as the milling pose. this was after the user moved the milling pose.

Two separate things are going on, and only one of them is fixed here.

**Most likely what the reporter hit:** `sync_fluorescence_pose` landed in #294 on 5 Aug, and the last release tag (`v0.5.1`) is 21 Jul. On any released build there is no linkage on *any* path — moving the milling pose leaves the fluorescence pose exactly where it was. `git merge-base --is-ancestor 4e8f86c7 v0.5.1` → false. For them, the answer is the upgrade, not this PR.

**What this PR fixes:** a narrower door that is still open on `main`. #294 wired the sync into the minimap's *Move Selected Position Here* and the lamella list's *Update Position*, but not into the Selected Lamella panel's **per-pose Update Position** button — which writes `lamella.poses["MILLING"]` directly, and exists in two windows with two independent copies of the handler:

- `AutoLamellaUI._set_current_position_as_pose`
- `FluorescenceCoincidenceViewerWidget._on_slw_pose_update`

Both predate #294 and were simply missed. Reachable in both: the pose rows show whenever a lamella has poses, and MILLING always does.

## What changed

Both handlers now call `sync_fluorescence_pose` when the pose being set is MILLING. The coincidence viewer's copy was also missing `update_milling_angle`, so a lamella moved there kept reporting the angle it was marked at — that is in now too, bringing all four doors in line.

Two things beyond the bare sync, because without them the reported symptom survives the fix:

- **The FLUORESCENCE row is refreshed.** The panel redraws only the row you clicked, so a synced pose would keep displaying its old position.
- **`positions.events.changed` is emitted.** That is how the FM overview canvas learns a position moved; the drawn marker would otherwise stay put. Nothing fires on its own — verified on the real objects:

  | write | signal |
  |---|---|
  | `lamella.poses["MILLING"] = state` | nothing |
  | `pose.stage_position = ...` (what the sync does) | nothing |
  | `lamella.milling_angle = 0.3` | `lamella.events.milling_angle` |

  `poses` is a plain `Dict` on an `@evented` dataclass (contrast `task_config`, an `EventedDict` one line above), and `EventedList.changed` fires on slot reassignment, not on mutating a contained object. The existing lamella-list path already emits this by hand for the same reason.

Only a MILLING write fans out — re-deriving the fluorescence pose right after a user sets it by hand would overwrite the one thing they came to that button to change.

## Blast radius

`positions.events.changed` has exactly one subscriber, `AutoLamellaMainUI._refresh_fm_overview_positions`, which early-returns without an FM overview tab and only reads poses — no re-entrancy. Cost is one canvas re-mark per click, on a click already behind a confirmation dialog, and the same redraw the two existing paths already trigger. `milling_angle` has no signal listeners; it feeds serialisation, the experiment summary and `ml_export`, so that addition changes recorded data rather than live behaviour. Offset mounts are unaffected — the sync returns False and logs, leaving the pose as it stands, as on any offset mount. Lamellae with no fluorescence pose get nothing invented. Workflow tasks are untouched.

## Known trade, deliberately not settled here

`get_target_position` for MILLING → FM keeps x/y/z verbatim and rewrites only rotation and tilt, so the fluorescence pose is fully derived: any hand-tuned lateral position is discarded on the next milling-pose move. Focus survives. This is unchanged from the two callers that already synced, but it now applies at two more doors — filed as a backlog decision rather than changed under this fix, since changing it means changing the shared helper for all four callers and needs a way to tell a derived pose from an edited one.

## Testing

```
QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_beam_side_move_syncs_fm_pose.py -q
```

- 7 passed. With the source changes stashed, the two new sync tests fail (`0.0001` vs expected `0.0004`) — they pin the behaviour rather than passing vacuously.
- 147 passed across every test file touching the two modules; 221 in `test_fm_overview_widget.py`; 28 across the pose / milling-angle suites.
- Both source files and the test file parse under `feature_version=(3, 8)` for CI.
