### PR TITLE
[fix] Lock the milling controls while a mill is running (FIB-580)

### DIFF
--- a/fibsem/ui/widgets/milling_task_viewer_widget.py
+++ b/fibsem/ui/widgets/milling_task_viewer_widget.py
@@ -237,6 +237,12 @@ class MillingTaskViewerWidget(QWidget):
         Takes pixel coords straight from the canvas signal and reuses
         ``_move_patterns``.
         """
+        # The canvas is not part of the editor, so disabling that panel does not reach
+        # this menu -- it has to be turned away itself while a mill is running
+        # (FIB-580). Offering "Move Patterns Here" over a lamella being milled invites
+        # exactly the edit the lock exists to prevent.
+        if self.is_milling:
+            return
         if self._fib_image is None or self._fib_image.metadata is None:
             return
         stages = self.config_widget.milling_stages_widget.get_enabled_stages()
@@ -285,6 +291,10 @@ class MillingTaskViewerWidget(QWidget):
 
     def _move_patterns(self, point: Point, move_all: bool) -> None:
         """Move patterns to point. move_all=True shifts all relative to selected; False moves only selected."""
+        # Guarded as well as the menu that opens it: this is the mutation, and a menu
+        # already on screen when a run starts would otherwise still act on it.
+        if self.is_milling:
+            return
         stages = self.config_widget.milling_stages_widget.get_enabled_stages()
         if not stages or self._fib_image is None:
             return

--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -183,6 +183,12 @@ class FibsemMillingWidget2(QWidget):
 
         self._milling_thread.start()
 
+        # Lock the controls now rather than waiting for the first progress signal to
+        # arrive -- preparing the milling conditions takes seconds, and the editor was
+        # live for all of them. `config` above is already built, so a late edit could
+        # not have reached this run anyway; what it could do is be written back after.
+        self._update_button_states()
+
     def _milling_worker(
         self, microscope: FibsemMicroscope, milling_task_config: FibsemMillingTaskConfig
     ):
@@ -224,8 +230,9 @@ class FibsemMillingWidget2(QWidget):
 
     @ensure_main_thread
     def _update_button_states(self):
-        """Update the enabled/disabled state of buttons based on current milling state."""
-        if self.is_milling:
+        """Update the enabled/disabled state of the controls for the milling state."""
+        milling = self.is_milling
+        if milling:
             self.pushButton_run_milling.setEnabled(False)
             self.pushButton_stop_milling.setEnabled(True)
             self.pushButton_stop_milling.setVisible(True)
@@ -237,3 +244,12 @@ class FibsemMillingWidget2(QWidget):
             self.pushButton_stop_milling.setVisible(False)
             self.pushButton_pause_milling.setEnabled(False)
             self.pushButton_pause_milling.setVisible(False)
+
+        # The stage and pattern editor is part of the milling controls, not scenery:
+        # the run holds its own deep copy of the config, so an edit made mid-mill does
+        # not reach the beam -- but it is written back as the task's config when the
+        # task finishes, leaving the protocol claiming a pattern position that was
+        # never milled (FIB-580). Explicitly disabling a child survives the workflow
+        # enabling this widget's parent, and the `finally` in _milling_worker means
+        # the unlock runs even when the task raises.
+        self.parent_widget.config_widget.setEnabled(not milling)

--- a/tests/ui/test_milling_lockout.py
+++ b/tests/ui/test_milling_lockout.py
@@ -225,3 +225,18 @@ def fib_image():
             microscope_state=MicroscopeState(),
         ),
     )
+
+
+def test_the_lock_survives_the_workflow_enabling_this_widget(widget):
+    """`update_milling_config_ui` calls setEnabled(True) on the *viewer* when it hands a
+    config to the UI. Qt re-enables children on that call unless they were disabled in
+    their own right -- which is why the lock is applied to `config_widget` directly
+    rather than by disabling the panel through its parent.
+    """
+    _start_milling(widget)
+
+    widget.setEnabled(True)  # what the workflow does
+
+    assert widget.config_widget.isEnabled() is False
+    _finish_milling(widget)
+    assert widget.config_widget.isEnabled() is True

--- a/tests/ui/test_milling_lockout.py
+++ b/tests/ui/test_milling_lockout.py
@@ -1,0 +1,227 @@
+"""The milling controls are locked while a mill is running (FIB-580).
+
+Reported from the 2026-08-11 testing session as "properly disable the milling controls
+when milling". Before this, `_update_button_states` governed only Run / Stop / Pause:
+the stage and pattern editor stayed fully editable, and the FIB canvas still offered
+"Move Patterns Here" over a lamella that was being milled.
+
+The beam is not at risk -- `get_settings()` deep-copies before the worker starts, so the
+run holds its own config. The damage is to the record: the supervised loop writes the
+widget's config back as the task's when it finishes, so an edit made mid-mill lands in
+the protocol as the position that was milled, when it is not.
+
+Every test here has a not-milling counterpart. A lock test that only ever asserts "this
+did nothing" passes just as well against a widget that does nothing at all.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem import utils
+from fibsem.milling.base import FibsemMillingStage
+from fibsem.milling.patterning.patterns2 import RectanglePattern
+from fibsem.milling.tasks import FibsemMillingTaskConfig
+from fibsem.structures import FibsemMillingSettings, Point
+from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+class _RunningThread:
+    """Stands in for the FunctionWorker; `is_milling` asks it exactly this."""
+
+    def is_alive(self) -> bool:
+        return True
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    scope, _ = utils.setup_session(manufacturer="Demo")
+    return scope
+
+
+def _config_with_a_stage() -> FibsemMillingTaskConfig:
+    """A config with one enabled stage.
+
+    The default `FibsemMillingTaskConfig()` has none, and both guarded paths return
+    early when there are no enabled stages -- so a widget built from the default makes
+    every "nothing happened" assertion below pass for the wrong reason. The idle
+    counterpart tests caught exactly that.
+    """
+    return FibsemMillingTaskConfig(
+        stages=[
+            FibsemMillingStage(
+                name="test-stage",
+                milling=FibsemMillingSettings(milling_current=2e-9),
+                pattern=RectanglePattern(width=10e-6, height=5e-6, depth=1e-6),
+            )
+        ]
+    )
+
+
+@pytest.fixture()
+def widget(microscope):
+    w = MillingTaskViewerWidget(
+        microscope=microscope,
+        milling_task_config=_config_with_a_stage(),
+        milling_enabled=True,
+    )
+    yield w
+    w.deleteLater()
+
+
+def _start_milling(widget) -> None:
+    """Put the widget in the state a running mill leaves it in."""
+    widget.milling_widget._milling_thread = _RunningThread()
+    widget.milling_widget._update_button_states()
+
+
+def _finish_milling(widget) -> None:
+    """What `_milling_worker`'s finally block does."""
+    widget.milling_widget._milling_thread = None
+    widget.milling_widget._update_button_states()
+
+
+# ── the editor ────────────────────────────────────────────────────────────────
+
+
+def test_the_editor_is_editable_when_nothing_is_milling(widget):
+    """The control for everything below: the panel is not simply always disabled."""
+    assert widget.is_milling is False
+    assert widget.config_widget.isEnabled() is True
+
+
+def test_the_editor_locks_while_milling(widget):
+    _start_milling(widget)
+
+    assert widget.config_widget.isEnabled() is False
+    # the stage list is the part that would rewrite a pattern, and it is a child, so
+    # this also pins that disabling the panel actually reaches it
+    assert widget.config_widget.milling_stages_widget.isEnabled() is False
+
+
+def test_the_editor_unlocks_when_the_mill_finishes(widget):
+    _start_milling(widget)
+    _finish_milling(widget)
+
+    assert widget.config_widget.isEnabled() is True
+
+
+def test_the_lock_lands_at_start_not_at_the_first_progress_signal(widget, monkeypatch):
+    """`run_milling` used to disable only the Run button and leave the rest until a
+    progress signal arrived. Preparing the milling conditions takes seconds, and the
+    editor was live for all of them."""
+    import fibsem.ui.widgets.milling_widget as milling_widget_module
+
+    class _StubWorker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass  # never actually mill
+
+        def is_alive(self):
+            return True
+
+    monkeypatch.setattr(milling_widget_module, "FunctionWorker", _StubWorker)
+
+    widget.milling_widget.run_milling(_config_with_a_stage())
+
+    assert widget.config_widget.isEnabled() is False
+
+
+# ── the canvas right-click ────────────────────────────────────────────────────
+
+
+def _record_menu(widget, monkeypatch) -> list:
+    opened = []
+    monkeypatch.setattr(
+        widget, "_show_reposition_menu", lambda *a, **k: opened.append(a)
+    )
+    return opened
+
+
+def test_the_reposition_menu_opens_when_nothing_is_milling(widget, monkeypatch, fib_image):
+    """The control: without this, the milling case below proves nothing."""
+    widget.set_fib_image(fib_image)
+    opened = _record_menu(widget, monkeypatch)
+
+    widget._on_canvas_right_click(10.0, 10.0, None)
+
+    assert opened, "right-click should offer the menu when idle"
+
+
+def test_the_reposition_menu_stays_shut_while_milling(widget, monkeypatch, fib_image):
+    """The canvas is not inside the editor, so disabling that panel does not reach it."""
+    widget.set_fib_image(fib_image)
+    opened = _record_menu(widget, monkeypatch)
+    _start_milling(widget)
+
+    widget._on_canvas_right_click(10.0, 10.0, None)
+
+    assert opened == []
+
+
+def test_moving_patterns_is_refused_while_milling(widget, fib_image):
+    """Guarded at the mutation too: a menu already on screen when a run starts would
+    otherwise still act on it."""
+    widget.set_fib_image(fib_image)
+    stages = widget.config_widget.milling_stages_widget.get_enabled_stages()
+    assert stages, "the fixture must supply a stage, or this test proves nothing"
+    before = Point(x=stages[0].pattern.point.x, y=stages[0].pattern.point.y)
+    _start_milling(widget)
+
+    widget._move_patterns(Point(x=1e-6, y=1e-6), move_all=True)
+
+    after = widget.config_widget.milling_stages_widget.get_enabled_stages()[0].pattern.point
+    assert (after.x, after.y) == (before.x, before.y)
+
+
+def test_moving_patterns_still_works_when_idle(widget, fib_image):
+    """The counterpart. Without it the test above passes against a broken mover."""
+    widget.set_fib_image(fib_image)
+    stages = widget.config_widget.milling_stages_widget.get_enabled_stages()
+    assert stages, "the fixture must supply a stage, or this test proves nothing"
+    before = Point(x=stages[0].pattern.point.x, y=stages[0].pattern.point.y)
+
+    widget._move_patterns(Point(x=before.x + 5e-6, y=before.y + 5e-6), move_all=True)
+
+    after = widget.config_widget.milling_stages_widget.get_enabled_stages()[0].pattern.point
+    assert (after.x, after.y) != (before.x, before.y)
+
+
+@pytest.fixture()
+def fib_image():
+    """512px at 200nm/px = a ~102um field.
+
+    Sized in metres, not pixels: `_move_patterns` refuses a move that would put the
+    pattern outside the image, and the 10x5um stage above does not fit in a field
+    smaller than itself. A 64px/10nm image looks fine and silently makes every move a
+    no-op, which reads exactly like the lock working.
+    """
+    import numpy as np
+
+    from fibsem.structures import (
+        BeamType,
+        FibsemImage,
+        FibsemImageMetadata,
+        ImageSettings,
+        MicroscopeState,
+    )
+
+    return FibsemImage(
+        data=np.zeros((512, 512), dtype=np.uint8),
+        metadata=FibsemImageMetadata(
+            image_settings=ImageSettings(resolution=(512, 512), beam_type=BeamType.ION),
+            pixel_size=Point(2e-7, 2e-7),
+            microscope_state=MicroscopeState(),
+        ),
+    )


### PR DESCRIPTION
From the 2026-08-11 testing session: "properly disable the milling controls when milling".

## The problem

`_update_button_states` governed only Run / Stop / Pause. The stage and pattern editor stayed fully editable during a mill, and the FIB canvas went on offering "Move Patterns Here" over a lamella that was being milled.

**The beam was never at risk** — `get_settings()` deep-copies before the worker starts, so the run holds its own config and a mid-mill edit cannot reach it. The damage is to the record: the supervised loop writes the widget's config back as the task's when the task finishes, so an edit made while milling lands in the protocol as the position that *was* milled, when it wasn't. And a second Run Milling press in the same supervised loop would then mill the moved pattern with nothing having said so.

## The change

- **`_update_button_states` disables `config_widget` while milling.** It is already the one place that knows the milling state, already `@ensure_main_thread`, and the `finally` in `_milling_worker` means the unlock runs even when the task raises. An explicit disable on a child also survives the workflow enabling this widget's parent, which `update_milling_config_ui` does.
- **`run_milling` calls it after starting the thread**, so the lock lands at the start rather than whenever the first progress signal arrives. Preparing the milling conditions takes seconds and the editor was live for all of them.
- **The canvas right-click is turned away separately**, since the canvas is not inside the panel being disabled. Guarded at `_move_patterns` as well as at the menu: that is the mutation, and a menu already on screen when a run starts would otherwise still act on it.

Precedent for the shape: `FibsemMovementWidget` already blocks click-to-move on `is_milling`.

## Testing

8 tests, each lock paired with a not-milling counterpart — a lock test that only asserts "nothing happened" passes just as well against a widget that does nothing at all.

The counterparts earned their place immediately. The default `FibsemMillingTaskConfig` has **no stages**, and both guarded paths return early when there are none, so the first draft was asserting nothing four times over; the idle cases failed and exposed it. The test image needed sizing in metres too — `_move_patterns` refuses a move that would put the pattern outside the image, and a 10x5um stage does not fit in a 640nm field, which silently makes every move a no-op that reads exactly like the lock working.

Verified by removing the guards: 4 of the 8 fail, and the 4 counterparts keep passing. 428 pass across `tests/milling/` and every milling-related file in `tests/ui/`.

## Known, and left alone

Disabling the panel also disables the patterns-visible eye toggle, so patterns cannot be hidden mid-mill. Arguably worth having while watching a run — one line to carve out if it matters, but it did not seem worth a special case up front.