### PR TITLE
[fm] Skip the channel scope entirely when the channel is already ours (FIB-599)

### DIFF
--- a/fibsem/fm/autoscript.py
+++ b/fibsem/fm/autoscript.py
@@ -692,6 +692,18 @@ class ThermoFisherFluorescenceMicroscope(FluorescenceMicroscope):
         self.connection.imaging.set_active_view(self._active_view)
         self.connection.imaging.set_active_device(self._active_device)
 
+    def _channel_is_ours(self) -> bool:
+        """Whether the connection is already pointed at the FM.
+
+        The view alone answers it, for the same reason only the view is captured and
+        restored: AutoScript documents `set_active_device` as changing the device *in
+        the active view*, so the device follows the view rather than varying under it.
+
+        One read, and deliberately not under the lock -- taking the lock to find out
+        whether we need the lock would defeat the whole point.
+        """
+        return self.connection.imaging.get_active_view() == self._active_view
+
     @contextmanager
     def active_channel(self):
         """Point the shared connection at the FM for the length of the block, then put
@@ -720,7 +732,27 @@ class ThermoFisherFluorescenceMicroscope(FluorescenceMicroscope):
         outermost scope. A tileset holds the channel for the whole run; each tile's
         acquisition opens a scope inside it and must not restore the beam view between
         tiles.
+
+        **Nothing to change means nothing to lock.** When the connection is already on
+        the FM there is no view to set and therefore none to put back, so the scope does
+        no work and takes no lock. That is not a micro-optimisation: the live stream
+        re-takes this lock every frame in a loop with nothing between iterations, so a
+        waiter is *starved* rather than delayed -- Python locks are not fair, and a
+        thread that releases and immediately re-acquires usually wins against one that
+        was already waiting. Moving the objective while streaming was unusable for
+        exactly this reason, and it was unaffected by halving the number of acquisitions,
+        which is what a queueing problem would have responded to.
+
+        The fast path is safe against FIB-517 by construction: it performs **no writes**
+        to the channel, so it cannot leave the connection somewhere the next beam
+        operation does not expect. What it does accept is reading a value that another
+        thread has since invalidated -- but the body has always run unlocked, so that
+        race is not new, and a live stream re-forces the FM every frame anyway.
         """
+        if self._channel_depth == 0 and self._channel_is_ours():
+            yield
+            return
+
         with self._channel_lock:
             if self._channel_depth == 0:
                 self._restore_view = self.connection.imaging.get_active_view()

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -226,6 +226,15 @@ class SimulatedFluorescenceMicroscope(FluorescenceMicroscope):
         self.parent.imaging_system.active_view = self._active_view
         self.parent.imaging_system.active_device = self._active_device
 
+    def _channel_is_ours(self) -> bool:
+        """Whether the shared channel is already pointed at the FM.
+
+        The view alone answers it, matching the driver, where the device follows the
+        view. Read outside the lock on purpose: taking the lock to find out whether the
+        lock is needed would defeat the point of asking.
+        """
+        return self.parent.imaging_system.active_view == self._active_view
+
     @contextmanager
     def active_channel(self):
         """Hold the channel on the FM for the length of the block, then put it back.
@@ -240,8 +249,18 @@ class SimulatedFluorescenceMicroscope(FluorescenceMicroscope):
         the active view*, so the view owns it and it comes back with it. Here the two
         are independent fields, and putting only the view back would leave
         `active_device` reporting the FM for the rest of the session.
+
+        Skips both the lock and the bookkeeping when the channel is already the FM, as
+        the driver does -- there is nothing to set, so nothing to put back. Modelled
+        here because that fast path is what makes the objective usable while streaming,
+        and a simulator that always took the lock would let a change reintroduce the
+        contention with every test still green.
         """
         if self.parent is None:
+            yield
+            return
+
+        if self._channel_depth == 0 and self._channel_is_ours():
             yield
             return
 

--- a/tests/fm/test_channel_fast_path.py
+++ b/tests/fm/test_channel_fast_path.py
@@ -1,0 +1,223 @@
+"""A channel scope that changes nothing takes no lock.
+
+Found at the microscope: moving the objective while the FM streamed was unusable, and
+focusing was close to impossible. The live stream holds the shared lock across every
+frame in a loop with nothing between iterations, so it releases and immediately
+re-acquires — and Python locks are not fair. Anything else wanting that lock is
+*starved*, not queued.
+
+Two observations rule out the queueing explanation, and both matter because a queueing
+problem has a completely different fix:
+
+* the exposure was 2 ms, so waiting on a frame cannot account for seconds of lag;
+* halving the number of acquisitions per move (by disabling the objective's readback)
+  changed nothing, where a queueing problem would have roughly halved.
+
+The fix is to stop entering the race. When the connection is already on the FM there is
+no view to set and therefore none to put back, so the scope does no work and takes no
+lock. Safe against FIB-517 by construction: the fast path performs no writes, so it
+cannot leave the channel anywhere the next beam operation does not expect.
+"""
+
+import threading
+import time
+
+import pytest
+
+from fibsem.microscopes.simulator import FM_ACTIVE_VIEW
+
+
+@pytest.fixture
+def microscope():
+    from fibsem import utils
+
+    scope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    assert scope.fm is not None, "the simulated compustage system should have an FM"
+    return scope
+
+
+class TestTheFastPath:
+    def test_a_scope_that_changes_nothing_does_not_wait_for_the_lock(self, microscope):
+        """The property the whole change exists for.
+
+        Another thread holds the shared lock for the duration. If the scope needed it,
+        this blocks for the full hold; the fast path does not ask for it at all.
+        """
+        fm = microscope.fm
+        microscope.imaging_system.active_view = FM_ACTIVE_VIEW  # the stream owns it
+
+        holding = threading.Event()
+        release = threading.Event()
+
+        def hog():
+            with microscope._threading_lock:
+                holding.set()
+                release.wait(timeout=5)
+
+        t = threading.Thread(target=hog, daemon=True)
+        t.start()
+        assert holding.wait(timeout=5), "the hogging thread never took the lock"
+
+        started = time.perf_counter()
+        with fm.active_channel():
+            pass
+        elapsed = time.perf_counter() - started
+
+        release.set()
+        t.join(timeout=5)
+
+        assert elapsed < 0.2, (
+            f"entering the channel scope took {elapsed:.2f}s while another thread held "
+            f"the lock — it is still contending, which is what starves the objective "
+            f"against a live stream"
+        )
+
+    def test_an_objective_move_completes_against_a_stream_that_never_lets_go(
+        self, microscope
+    ):
+        """The reported scenario, as close as the simulator gets to it.
+
+        A loop that takes the lock, does a little work and immediately re-takes it —
+        the shape of `_start_fast_acquisition`. Before the fast path an objective move
+        could wait behind an unbounded number of iterations.
+        """
+        fm = microscope.fm
+        microscope.imaging_system.active_view = FM_ACTIVE_VIEW
+        stop = threading.Event()
+
+        def stream():
+            while not stop.is_set():
+                with microscope._threading_lock:
+                    microscope.imaging_system.active_view = FM_ACTIVE_VIEW
+                    time.sleep(0.002)  # the 2 ms exposure, under the lock
+
+        t = threading.Thread(target=stream, daemon=True)
+        t.start()
+        time.sleep(0.05)  # let it get into its stride
+
+        started = time.perf_counter()
+        for _ in range(20):
+            fm.objective.move_relative(1e-6)
+        elapsed = time.perf_counter() - started
+
+        stop.set()
+        t.join(timeout=5)
+
+        assert elapsed < 1.0, (
+            f"20 objective steps took {elapsed:.2f}s against a live stream — focusing "
+            f"is a burst of steps, so this is what made it unusable"
+        )
+
+    def test_it_writes_nothing_when_the_channel_is_already_ours(self, microscope):
+        """No writes is what makes skipping the lock safe: FIB-517 was a stray *write*."""
+        fm = microscope.fm
+        imaging = microscope.imaging_system
+        imaging.active_view = FM_ACTIVE_VIEW
+        imaging.active_device = fm._active_device
+
+        before = (imaging.active_view, imaging.active_device)
+        with fm.active_channel():
+            during = (imaging.active_view, imaging.active_device)
+        after = (imaging.active_view, imaging.active_device)
+
+        assert before == during == after
+
+
+class TestTheSlowPathIsUnchanged:
+    def test_a_beam_view_is_still_taken_and_put_back(self, microscope):
+        """The FIB-517 guarantee, which the fast path must not weaken."""
+        fm = microscope.fm
+        imaging = microscope.imaging_system
+        imaging.active_view = 1  # a beam view — not ours
+
+        with fm.active_channel():
+            assert imaging.active_view == FM_ACTIVE_VIEW, "the scope did not take the channel"
+
+        assert imaging.active_view == 1, "the scope did not put the beam view back"
+
+    def test_nested_scopes_restore_once_at_the_outermost(self, microscope):
+        """The tileset case: an inner acquisition must not restore between tiles."""
+        fm = microscope.fm
+        imaging = microscope.imaging_system
+        imaging.active_view = 1
+
+        with fm.active_channel():
+            with fm.active_channel():
+                assert imaging.active_view == FM_ACTIVE_VIEW
+            assert imaging.active_view == FM_ACTIVE_VIEW, (
+                "the inner scope restored the beam view mid-run"
+            )
+
+        assert imaging.active_view == 1
+
+    def test_a_scope_entered_from_a_beam_view_still_serialises(self, microscope):
+        """It still takes the lock when it has real work to do — only the no-op skips."""
+        fm = microscope.fm
+        microscope.imaging_system.active_view = 1  # not ours, so the slow path
+
+        holding = threading.Event()
+        release = threading.Event()
+        entered = threading.Event()
+
+        def hog():
+            with microscope._threading_lock:
+                holding.set()
+                release.wait(timeout=5)
+
+        def enter():
+            with fm.active_channel():
+                entered.set()
+
+        t = threading.Thread(target=hog, daemon=True)
+        t.start()
+        assert holding.wait(timeout=5)
+
+        e = threading.Thread(target=enter, daemon=True)
+        e.start()
+        blocked = not entered.wait(timeout=0.3)
+        release.set()
+        t.join(timeout=5)
+        e.join(timeout=5)
+
+        assert blocked, (
+            "a scope that has to change the channel entered while another thread held "
+            "the lock — the set-then-restore bookkeeping is no longer serialised"
+        )
+
+
+class TestBothDriversHaveIt:
+    """Structural: `ThermoFisherFluorescenceMicroscope` needs an SDK absent off the
+    microscope, and the hardware driver is the one that actually hurt."""
+
+    def test_the_driver_and_the_simulator_both_short_circuit(self):
+        import ast
+        from pathlib import Path
+
+        import fibsem
+
+        root = Path(fibsem.__file__).parent
+        for module, cls_name in (
+            ("fm/autoscript.py", "ThermoFisherFluorescenceMicroscope"),
+            ("microscopes/simulator.py", "SimulatedFluorescenceMicroscope"),
+        ):
+            tree = ast.parse((root / module).read_text())
+            cls = next(
+                n for n in ast.walk(tree)
+                if isinstance(n, ast.ClassDef) and n.name == cls_name
+            )
+            names = {n.name for n in cls.body if isinstance(n, ast.FunctionDef)}
+            assert "_channel_is_ours" in names, f"{cls_name} lost its fast-path check"
+
+            scope = next(
+                n for n in cls.body
+                if isinstance(n, ast.FunctionDef) and n.name == "active_channel"
+            )
+            calls = {
+                c.func.attr for c in ast.walk(scope)
+                if isinstance(c, ast.Call) and isinstance(c.func, ast.Attribute)
+            }
+            assert "_channel_is_ours" in calls, (
+                f"{cls_name}.active_channel no longer consults `_channel_is_ours`, so "
+                f"every scope contends for the lock again and the objective starves "
+                f"against a live stream"
+            )


### PR DESCRIPTION
Closes FIB-599. Found on hardware this session: moving the objective while the FM streamed was unusable, and focusing close to impossible. **Confirmed fixed on the microscope** — "focusing is much better now".

## Starvation, not queueing

`ThermoFisherCamera._start_fast_acquisition` loops:

```python
while ...ACQUIRING:
    with self.parent.parent._threading_lock:
        self.parent.set_active_channel()   # 2 RPCs
        image = ...get_image()             # 1 RPC
```

with **nothing between iterations** — it releases the lock and immediately re-acquires. Python locks are not fair, so a thread already running beats one already waiting, and anything else wanting that lock waits an unbounded time rather than one iteration. An objective move needs it four times: enter and exit of its own `active_channel()` scope, then the same again for FIB-534's readback.

## What ruled out the obvious explanation

I first assumed queueing — each acquisition waiting behind a frame. Two measurements from the microscope killed it, and both are worth recording because they point at completely different fixes:

- **the exposure was 2 ms.** Four waits on a frame is 8 ms; nobody feels that. The cost under the lock is three AutoScript round trips, not the exposure.
- **disabling `_notify_moved` changed nothing.** That halves the acquisitions per move, from four to two. A queueing problem halves with it. Starvation does not care how many times you queue.

## The fix

Stop entering the race. `active_channel()` returns immediately when `_channel_depth == 0 and _channel_is_ours()` — when the connection is already on the FM there is no view to set, therefore none to put back, therefore no reason to take the lock. Focusing while streaming is exactly the case where the FM already owns the channel.

**Safe against FIB-517 by construction.** The fast path performs **no writes**, so it cannot leave the channel anywhere the next beam operation does not expect — that bug was a stray write, not a stray read. The race it does accept, reading a value another thread has since invalidated, is not new: the scope body has always run unlocked, and a live stream re-forces the FM every frame regardless.

**The slow path is untouched.** A scope entered from a beam view still locks, sets and restores; nested scopes still restore once at the outermost.

## Modelled in the simulator too

The same short circuit is in `SimulatedFluorescenceMicroscope`. A simulator that always took the lock would let this regress with every test still green — and modelling the shared channel only on the beam side is exactly what sent the whole FIB-517 class to hardware to be found in the first place (FIB-518).

## Testing

Six tests, three per side, and they discriminate — the three fast-path ones fail when the short circuit is removed, checked by removing it:

- a scope that changes nothing completes while another thread holds the lock
- 20 objective moves complete against a loop that takes the lock, works, and immediately re-takes it — the shape of the real stream
- a no-op scope writes nothing to the channel
- a beam view is still taken and put back
- nested scopes still restore once, at the outermost
- a scope that *must* change the channel still blocks on the lock

57 tests pass across the whole channel suite (`test_channel_fast_path`, `test_simulated_shared_channel`, `test_simulated_channel_pairs`, `test_imaging_channel_lock`, `test_objective_signal`).

## Not fixed here

The tight loop is still a tight loop. Anything else needing the lock while a stream runs — a beam operation, or a discrete FM read that finds the channel elsewhere — is still starved. A yield between iterations, or a model where the stream declares ownership rather than re-forcing per frame, would address the general case. Noted on FIB-599.
