### PR TITLE
[ui] Stop the FM overview display reading hardware on UI events, and recompositing per channel (FIB-600)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -658,13 +658,18 @@ class FMOverviewWidget(QWidget):
             self.tile_grid_overlay.clear()
             return
 
-        try:
-            width, height = self.fm.camera.resolution
-            pixel_size = self.fm.camera.pixel_size[0]
-        except Exception as e:
-            logging.debug(f"Could not read the camera geometry for the tile grid: {e}")
+        # Off the kept projection, which carries exactly these two. Read straight from
+        # the camera they are two `active_channel()` scopes, and this runs on every
+        # motion event of a grid drag -- so each scope set the shared view to the FM and
+        # put it back, per mouse-move, which is visible as the active view flicking in
+        # the microscope's own UI. See `_projection` for why keeping it is safe.
+        projection = self._projection()
+        if projection is None:
+            logging.debug("Could not read the camera geometry for the tile grid")
             self.tile_grid_overlay.clear()
             return
+        height, width = projection.shape
+        pixel_size = projection.pixel_size
 
         parameters = self.settings_widget.parameters
         tiles = compute_tile_grid_from_fov(
@@ -2349,7 +2354,14 @@ class FMOverviewWidget(QWidget):
             # so saying so is all that is needed: coarser pixels over the same count
             # cover the same ground, and the mosaic lands at the size it represents.
             stride = payload.get("preview_stride", 1) or 1
-            self.canvas.set_pixel_size(self.fm.camera.pixel_size[0] * stride)
+            # Off the kept projection: read from the camera this is an `active_channel()`
+            # scope, and this runs once a tile *during the run* -- so the display was
+            # taking the shared channel from the acquisition that was using it. `acquire`
+            # invalidates first, so the value is this run's.
+            projection = self._projection()
+            if projection is None:
+                return
+            self.canvas.set_pixel_size(projection.pixel_size * stride)
 
             # This run's channels, and only these. `set_channel` upserts, so a channel
             # switched off since the last run would otherwise keep its layer -- still

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -2304,8 +2304,17 @@ class FMOverviewWidget(QWidget):
             # holding the previous overview's pixels -- and be blended into this one.
             channels = self.channels
             self.canvas.retain_channels([channel.name for channel in channels])
-            for channel, plane in zip(channels, planes):
-                self.canvas.set_channel(channel.name, plane, channel.color)
+            # One composite for the whole update, not one per channel. `set_channel`
+            # recomposites on every call -- reducing every layer here and re-rendering
+            # every other overview on the canvas -- so a loop did that C times and threw
+            # C-1 of the results away. 148 ms an update against 37 ms with one 10x10
+            # overview also placed, and this runs once a tile for the length of a run.
+            self.canvas.set_channels(
+                [
+                    (channel.name, plane, channel.color)
+                    for channel, plane in zip(channels, planes)
+                ]
+            )
         except Exception as e:
             logging.debug(f"Could not display the overview preview: {e}")
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -236,6 +236,9 @@ class FMOverviewWidget(QWidget):
         # be fixed once and kept: re-deriving it from the newest image would shift the
         # whole scene each time one arrived. Taken from the first image displayed.
         self._origin: Optional[FibsemStagePosition] = None
+        # The camera half of the frame, kept rather than re-read -- see `_projection`.
+        # None until first resolved, and set back to None to force a re-read.
+        self._cached_projection: Optional[FMStageProjection] = None
         self._positions: List[FibsemStagePosition] = []
         # Which marked position is selected, by name. See `set_selected_position`.
         self._selected_position: Optional[str] = None
@@ -1105,7 +1108,46 @@ class FMOverviewWidget(QWidget):
         """The stage position canvas zero corresponds to, once one has been fixed."""
         return self._origin
 
-    def _frame(self) -> Optional[StageFrame]:
+    def _projection(self, fresh: bool = False) -> Optional[FMStageProjection]:
+        """The camera half of the frame, read once and kept.
+
+        `FMStageProjection.from_microscope` reads `camera.resolution`, `camera.pixel_size`
+        and `fm_image_geometry()`. On a TFS system the first two go through
+        `camera.binning`, which is a device read inside an `active_channel()` scope -- so
+        resolving a projection is several AutoScript round trips, and on the shared
+        connection at that.
+
+        `_frame` is called from the cursor readout and from the grid drag, both of which
+        fire on **every mouse-move event**. Reading the instrument once per pixel of
+        pointer travel, to render a text label, is what made the grid drag stutter on
+        hardware; the tile-grid overlay's own docstring asks the host to keep that
+        response cheap, and it had stopped being cheap.
+
+        Caching is safe because nothing in it varies the way the pointer does.
+        `FibsemHardwareGeometry` is system configuration -- camera tilt, shuttle
+        pre-tilt, the flip, compustage or not -- and does not change within a session.
+        Resolution and pixel size vary only with binning, which changes when somebody
+        changes it.
+
+        *fresh* re-reads, for the callers that need the current value rather than a
+        current-enough one. The split is the same one `ObjectiveLens.position_changed`
+        draws: **displays use the kept value, anything that commands the instrument
+        reads the device.** Of the ten callers here exactly one commands anything --
+        `_stage_position_at`, which turns a double-click into a stage move.
+        """
+        if fresh or self._cached_projection is None:
+            self._cached_projection = FMStageProjection.from_microscope(self.microscope)
+        return self._cached_projection
+
+    def invalidate_projection(self) -> None:
+        """Forget the kept projection, so the next frame re-reads it.
+
+        Called wherever the camera geometry could have moved under us -- a reconnect, a
+        binning change, the start of a run. Cheap: the next `_frame` pays one read.
+        """
+        self._cached_projection = None
+
+    def _frame(self, fresh: bool = False) -> Optional[StageFrame]:
         """The mapping between stage space and the canvas, or None if it cannot be had.
 
         The one place the two meet. Everything drawn from a stage position goes through
@@ -1117,8 +1159,10 @@ class FMOverviewWidget(QWidget):
         displayed, so a marker names the same piece of sample no matter what is on
         screen. The origin's rotation and tilt are what put the drawing in the current
         stage orientation -- t = -180 for FM.
+
+        *fresh* forces the camera geometry to be re-read -- see :meth:`_projection`.
         """
-        projection = FMStageProjection.from_microscope(self.microscope)
+        projection = self._projection(fresh=fresh)
         if projection is None:
             return None
 
@@ -1785,8 +1829,12 @@ class FMOverviewWidget(QWidget):
 
         Outside the limits counts as not usable for both: the stage cannot go there, so
         it is neither somewhere to move nor somewhere to put a lamella.
+
+        Reads the camera geometry rather than using the kept value: this is the one
+        caller whose answer drives the instrument, and a stale binning here would send
+        the stage somewhere other than where the click was.
         """
-        frame = self._frame()
+        frame = self._frame(fresh=True)
         if frame is None:
             return None
         try:
@@ -1970,6 +2018,10 @@ class FMOverviewWidget(QWidget):
         if self.is_acquiring:
             logging.warning("An overview acquisition is already running.")
             return
+        # A run plans a grid and drives the stage from the camera geometry, so it starts
+        # from a freshly read one rather than whatever the last drawing kept. The natural
+        # boundary: binning cannot change mid-run, and it is the only thing that moves.
+        self.invalidate_projection()
         # `is_acquiring`, not `is_streaming`: a z-stack or an autofocus sweep in the
         # control widget is not a stream, and this widget's own tileset was invisible to
         # that one, which is the direction that mattered (FIB-441).

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -229,6 +229,12 @@ class FMCanvasWidget(QWidget):
         self._layers: List[FMLayer] = []
         self._pixel_size: Optional[float] = None
         self._canvas_shape: Optional[Tuple[int, int]] = None  # drawn-axes shape
+        # Planes as the last blend used them: reduced to display resolution. Set by
+        # `_recomposite` for `_show_composite` to keep, so a subclass holding an image
+        # does not reduce the originals a second time. Empty until the first composite,
+        # rather than absent -- an AttributeError inside a paint aborts the process
+        # under PyQt5 rather than raising (FIB-329).
+        self._blended_planes: Dict[str, np.ndarray] = {}
         self._shape: Optional[Tuple[int, int]] = None  # composite target shape (last upserted layer)
         # z-stack scrubbing: keep the full ZYX stack per channel + display state
         self._stacks: Dict[str, np.ndarray] = {}   # channel name -> ZYX stack
@@ -346,7 +352,39 @@ class FMCanvasWidget(QWidget):
         return False
 
     def set_channel(self, name: str, data: np.ndarray, color: Optional[str] = None) -> None:
-        """Upsert a channel's 2-D image (live path — no z-stack); display props preserved."""
+        """Upsert a channel's 2-D image (live path — no z-stack); display props preserved.
+
+        Setting several channels? Use :meth:`set_channels`. Each call here recomposites,
+        and a recomposite is not cheap.
+        """
+        self._set_channel_data(name, data, color)
+        self._recomposite()
+
+    def set_channels(
+        self, items: Sequence[Tuple[str, np.ndarray, Optional[str]]]
+    ) -> None:
+        """Upsert several channels and composite **once**, where a loop composites once
+        each.
+
+        A recomposite reduces every layer of this image and then re-renders every other
+        held image, reducing all of *their* layers too. So setting C channels one at a
+        time does C times the work of setting them together, and C-1 of the blends are
+        discarded by the next call in the same loop.
+
+        That was invisible while the reduction was a strided view costing nothing. It is
+        not invisible now it box-averages: measured on a 4-channel preview with one 10x10
+        overview also on the canvas, 148 ms per update channel-by-channel against 37 ms
+        batched -- for the same picture. The live overview preview updates once a tile,
+        so this is the difference between a run you can watch and one you cannot.
+        """
+        for name, data, color in items:
+            self._set_channel_data(name, data, color)
+        self._recomposite()
+
+    def _set_channel_data(
+        self, name: str, data: np.ndarray, color: Optional[str]
+    ) -> None:
+        """The layer half of `set_channel`, without the composite."""
         had_stack = self._stacks.pop(name, None) is not None
         self._mip_clim.pop(name, None)
         layer = self._upsert_layer(name, data, color)
@@ -354,7 +392,6 @@ class FMCanvasWidget(QWidget):
             layer.autocontrast = True
             layer.clim = None
             self._refresh_z_controls()  # a stack went away → maybe hide the z-controls
-        self._recomposite()
 
     def set_fm_image(self, image: "FluorescenceImage") -> None:
         """Composite every channel of an acquired ``FluorescenceImage`` (CZYX), keeping the
@@ -429,6 +466,12 @@ class FMCanvasWidget(QWidget):
         h, w = rgb.shape[:2]
         reshaped = self._canvas_shape != (h, w)
         self._canvas_shape = (h, w)
+        # The reduced planes the blend just used, for a subclass that wants to keep
+        # them. Handing them over rather than letting it reduce the originals again --
+        # the same arrays, the same answer, at full acquisition size.
+        self._blended_planes = {
+            layer.name: layer.data for layer in layers if layer.data is not None
+        }
         self._show_composite(rgb, reshaped)
 
     def _show_composite(self, rgb: np.ndarray, reshaped: bool) -> None:
@@ -614,6 +657,10 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         # Channel planes of everything placed, so a layer change can re-render images
         # composited long ago. Only the newest is in `_layers`; the rest are here.
         self._held: Dict[str, Dict[str, np.ndarray]] = {}
+        # The same planes at display resolution. Held images do not change while held,
+        # so their reduction is computed once here rather than on every re-render.
+        # Invalidated wherever `_held` is, and wherever the display cap moves.
+        self._held_reduced: Dict[str, Dict[str, np.ndarray]] = {}
 
     def _make_canvas(self) -> FibsemCanvasBase:
         return FibsemRealSpaceCanvas()
@@ -652,6 +699,7 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         image no longer placed leaks the pixels and leaves `_channel_still_shown`
         answering for a channel nothing displays.
         """
+        self._held_reduced.pop(key, None)
         return self._held.pop(key, None) is not None
 
     def clear_overviews(self) -> None:
@@ -659,6 +707,7 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         for key in list(self._held):
             self.canvas.remove_image(key)
         self._held.clear()
+        self._held_reduced.clear()
 
     def set_placement(self, centre: Tuple[float, float]) -> None:
         """Where the composite sits, in metres from the canvas origin.
@@ -700,9 +749,20 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         if self._shape:
             covers = (self._shape[1] * self._pixel_size, self._shape[0] * self._pixel_size)
         # Keep this image's planes, so a later layer change can re-render it once its
-        # channels are no longer the ones in `_layers`.
+        # channels are no longer the ones in `_layers`. Reduced once here rather than on
+        # every re-render: these are held at *acquisition* resolution -- a stitched 10x10
+        # mosaic is 10240px square per channel -- and they do not change while they are
+        # held, so re-reducing them per re-render is the same answer computed repeatedly.
+        # That cost nothing while the reduction was a strided view and is 9 ms a plane
+        # now it averages; `_restyle_others` runs it for every held image on every layer
+        # change, so it multiplied by both counts at once.
         self._held[key] = {
             layer.name: layer.data for layer in self._layers if layer.data is not None
+        }
+        self._held_reduced[key] = {
+            name: reduced
+            for name, reduced in self._blended_planes.items()
+            if name in self._held[key]
         }
         # Placed over other images rather than over a background, so it goes on as
         # colour plus coverage: an opaque frame hides whatever it covers, including
@@ -723,6 +783,16 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         else:
             self.canvas.update_image(key, placed)
         self._restyle_others(key)
+
+    def _reduced_plane(
+        self,
+        cached: Dict[str, np.ndarray],
+        planes: Dict[str, np.ndarray],
+        name: str,
+    ) -> np.ndarray:
+        """A held plane at display resolution, from the cache when it is there."""
+        hit = cached.get(name)
+        return self._reduce(planes[name]) if hit is None else hit
 
     def _reduce(self, plane: np.ndarray) -> np.ndarray:
         """A plane at the resolution the canvas will actually store.
@@ -778,8 +848,18 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         for key, planes in self._held.items():
             if key == current or key not in self.canvas.placed_keys:
                 continue
+            reduced = self._held_reduced.get(key) or {}
             layers = [
-                replace(layer, data=self._reduce(planes[layer.name]), _clim_cache=None)
+                replace(
+                    layer,
+                    # Cached at hold time: a held image's planes do not change, so the
+                    # reduction is the same answer on every re-render. Falls back rather
+                    # than indexing, so a cache that somehow missed an entry costs time
+                    # instead of raising out of a paint (FIB-329). Compared against None
+                    # explicitly -- `or` on an array raises rather than testing presence.
+                    data=self._reduced_plane(reduced, planes, layer.name),
+                    _clim_cache=None,
+                )
                 for layer in self._layers
                 if layer.name in planes
             ]

--- a/tests/ui/test_fm_frame_projection_cache.py
+++ b/tests/ui/test_fm_frame_projection_cache.py
@@ -1,0 +1,155 @@
+"""Moving the mouse over the overview canvas must not talk to the microscope.
+
+Found on hardware: dragging the tile grid stuttered. The cause was not the drag — it
+was `_frame()`, which every drawing path goes through, resolving
+`FMStageProjection.from_microscope` on each call. That reads `camera.resolution`,
+`camera.pixel_size` and `fm_image_geometry()`, and on a TFS system the first two go
+through `camera.binning`, which is a device read inside an `active_channel()` scope.
+
+Two handlers call `_frame()` on **every mouse-move event** — the cursor readout and the
+grid drag — so the widget was issuing AutoScript round trips continuously while the
+pointer was over the canvas, on the connection the beams share. The tile-grid overlay's
+own docstring asks the host to keep that response cheap.
+
+The split pinned here is the one `ObjectiveLens.position_changed` established: displays
+use the kept value, anything that commands the instrument reads the device. Exactly one
+caller commands anything — `_stage_position_at`, which turns a double-click into a stage
+move — and it must keep re-reading, because a stale binning there sends the stage
+somewhere other than where the click was.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+@pytest.fixture
+def widget():
+    from fibsem.ui.fm.overview_app import build_microscope
+    from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+
+    microscope = build_microscope()
+    microscope.fm.objective.insert()
+    w = FMOverviewWidget(microscope)
+    w.resize(900, 600)
+    yield w
+    w.deleteLater()
+
+
+@pytest.fixture
+def reads(widget, monkeypatch):
+    """Every resolve of the projection, i.e. every burst of device reads."""
+    import fibsem.ui.fm.widgets.fm_overview_widget as module
+
+    seen = []
+    original = module.FMStageProjection.from_microscope
+
+    def counting(microscope):
+        seen.append(1)
+        return original(microscope)
+
+    monkeypatch.setattr(module.FMStageProjection, "from_microscope", staticmethod(counting))
+    widget.invalidate_projection()  # so the count starts from a known state
+    return seen
+
+
+class TestTheProjectionIsKept:
+    def test_repeated_frames_resolve_it_once(self, widget, reads):
+        for _ in range(20):
+            widget._frame()
+
+        assert len(reads) == 1, (
+            f"{len(reads)} projection reads for 20 frames — each one is several "
+            f"AutoScript round trips on the shared connection"
+        )
+
+    def test_moving_the_mouse_does_not_read_the_microscope(self, widget, reads):
+        """The worst of the two: this fires whenever the pointer is over the canvas."""
+        widget._frame()  # the one legitimate read
+        reads.clear()
+
+        for i in range(30):
+            widget._on_cursor_moved(float(i), float(i))
+
+        assert reads == [], (
+            f"the cursor readout resolved the projection {len(reads)} times over 30 "
+            f"mouse-move events — it renders a text label, and it was reading the camera "
+            f"to do it"
+        )
+
+    def test_dragging_the_grid_does_not_read_the_microscope(self, widget, reads):
+        widget._frame()
+        reads.clear()
+
+        for i in range(30):
+            widget._on_grid_move(float(i) * 1e-6, 0.0)
+
+        assert reads == [], (
+            f"the grid drag resolved the projection {len(reads)} times over 30 motion "
+            f"events — this is what stuttered on hardware"
+        )
+
+
+class TestWhatStillReadsTheDevice:
+    def test_resolving_a_click_to_a_stage_position_re_reads(self, widget, reads):
+        """The one caller that commands the instrument.
+
+        A kept binning would be a stale pixel size, and the stage would go somewhere
+        other than where the click was — worse than the lag this all fixes.
+        """
+        widget._frame()
+        reads.clear()
+
+        widget._stage_position_at(10.0, 10.0)
+
+        assert len(reads) == 1, (
+            "clicking to move used the kept projection — that value drives the stage, "
+            "so it has to come from the device"
+        )
+
+    def test_invalidating_forces_the_next_frame_to_re_read(self, widget, reads):
+        widget._frame()
+        reads.clear()
+
+        widget.invalidate_projection()
+        widget._frame()
+
+        assert len(reads) == 1
+
+    def test_starting_a_run_invalidates(self):
+        """A run plans a grid and drives the stage, so it starts from a fresh read.
+
+        Structural: `acquire` opens a modal confirmation dialog, which blocks a headless
+        run rather than failing it.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+
+        source = textwrap.dedent(inspect.getsource(FMOverviewWidget.acquire))
+        called = {
+            node.func.attr
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+
+        assert "invalidate_projection" in called, (
+            "`acquire` does not invalidate the projection, so a run could plan its grid "
+            "and drive the stage from a binning read taken before it was set up"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/ui/test_fm_frame_projection_cache.py
+++ b/tests/ui/test_fm_frame_projection_cache.py
@@ -48,29 +48,58 @@ def widget():
 
 @pytest.fixture
 def reads(widget, monkeypatch):
-    """Every resolve of the projection, i.e. every burst of device reads."""
-    import fibsem.ui.fm.widgets.fm_overview_widget as module
+    """Every read of the camera's geometry, by whatever route.
 
+    Two earlier versions of this fixture were wrong, and both failures are worth keeping
+    in mind because they are easy to repeat:
+
+    * counting `FMStageProjection.from_microscope` went green with the bug reinstated,
+      because `_refresh_tile_grid` reads `camera.resolution` **directly** rather than
+      through the projection;
+    * counting `active_channel()` entries counted nothing at all, because only the *TFS*
+      camera's `binning` takes the channel. The simulated one returns a plain attribute,
+      so the very cost being tested does not exist here — the same blind spot that sent
+      the whole FIB-517 class to hardware to be found (FIB-518).
+
+    So this counts the geometry access itself, which is what the UI does and is identical
+    on both. On hardware each of these is an `active_channel()` scope and a handful of
+    AutoScript round trips; here it is free, and only the *count* carries over.
+    """
+    camera = type(widget.fm.camera)
     seen = []
-    original = module.FMStageProjection.from_microscope
 
-    def counting(microscope):
-        seen.append(1)
-        return original(microscope)
+    for name in ("resolution", "pixel_size"):
+        original = getattr(camera, name)
 
-    monkeypatch.setattr(module.FMStageProjection, "from_microscope", staticmethod(counting))
+        def counting(self, _original=original, _name=name):
+            seen.append(_name)
+            return _original.fget(self)
+
+        monkeypatch.setattr(camera, name, property(counting))
+
     widget.invalidate_projection()  # so the count starts from a known state
     return seen
 
 
 class TestTheProjectionIsKept:
     def test_repeated_frames_resolve_it_once(self, widget, reads):
-        for _ in range(20):
+        """The cost must not scale with the number of frames drawn.
+
+        Asserted against the first frame's own cost rather than against a fixed number:
+        one resolve is several scopes -- `resolution` and `pixel_size` each take one --
+        and how many is an implementation detail. That it does not *grow* is not.
+        """
+        widget._frame()
+        first = len(reads)
+        assert first > 0, "the first frame did not read the device at all"
+
+        for _ in range(19):
             widget._frame()
 
-        assert len(reads) == 1, (
-            f"{len(reads)} projection reads for 20 frames — each one is several "
-            f"AutoScript round trips on the shared connection"
+        assert len(reads) == first, (
+            f"{len(reads)} channel scopes for 20 frames against {first} for one — the "
+            f"cost is scaling with frames, and each scope is AutoScript round trips on "
+            f"the connection the beams share"
         )
 
     def test_moving_the_mouse_does_not_read_the_microscope(self, widget, reads):
@@ -99,6 +128,42 @@ class TestTheProjectionIsKept:
             f"events — this is what stuttered on hardware"
         )
 
+    def test_redrawing_the_planned_grid_does_not_read_the_microscope(self, widget, reads):
+        """`_refresh_tile_grid` had its own camera reads, separate from `_frame`.
+
+        Caching the frame's projection alone left these, so a drag still took the shared
+        channel twice per motion event -- visible as the active view flicking in the
+        microscope's own UI, which is how it was reported.
+        """
+        widget._frame()
+        reads.clear()
+
+        for _ in range(30):
+            widget._refresh_tile_grid()
+
+        assert reads == [], (
+            f"the grid redraw took the channel {len(reads)} times over 30 calls"
+        )
+
+    def test_showing_a_preview_tile_does_not_read_the_microscope(self, widget, reads):
+        """Runs once a tile *during* a run, so it competes with the acquisition."""
+        import numpy as np
+
+        widget._frame()
+        reads.clear()
+
+        payload = {
+            "image": np.zeros((1, 64, 64), np.uint8),
+            "preview_stride": 4,
+        }
+        for _ in range(10):
+            widget._show_preview(payload)
+
+        assert reads == [], (
+            f"the preview took the channel {len(reads)} times over 10 tiles — "
+            f"that is the display taking the channel from the run that is using it"
+        )
+
 
 class TestWhatStillReadsTheDevice:
     def test_resolving_a_click_to_a_stage_position_re_reads(self, widget, reads):
@@ -112,7 +177,7 @@ class TestWhatStillReadsTheDevice:
 
         widget._stage_position_at(10.0, 10.0)
 
-        assert len(reads) == 1, (
+        assert reads, (
             "clicking to move used the kept projection — that value drives the stage, "
             "so it has to come from the device"
         )
@@ -124,7 +189,7 @@ class TestWhatStillReadsTheDevice:
         widget.invalidate_projection()
         widget._frame()
 
-        assert len(reads) == 1
+        assert reads, "invalidating did not force the next frame to re-read"
 
     def test_starting_a_run_invalidates(self):
         """A run plans a grid and drives the stage, so it starts from a fresh read.

--- a/tests/ui/test_fm_preview_recomposite_cost.py
+++ b/tests/ui/test_fm_preview_recomposite_cost.py
@@ -1,0 +1,174 @@
+"""One composite per preview update, and held planes reduced once (FIB-589 follow-up).
+
+Found by measurement after the FM overview preview went sluggish on hardware. Two things
+multiply, and neither is visible from reading either site on its own:
+
+* `set_channel` recomposites on every call, so setting C channels in a loop does C
+  composites and discards C-1 of them;
+* a recomposite re-renders every *other* held image, reducing all of its planes — and
+  those are held at acquisition resolution, so a stitched 10x10 mosaic is 10240px square
+  per channel.
+
+Together that is C x (C + held x C) reductions per update. It cost nothing while the
+reduction was a strided view; box-averaging made each one real (FIB-589), and the live
+preview runs it once a tile for the length of a run. Measured with one 10x10 overview
+also placed: 148 ms an update against 37 ms batched, and ~0 with the held planes cached.
+
+What is pinned is the call count, not the timing — a timing assertion would be flaky on
+CI and would not say which of the two regressed.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.fm_canvas import FMRealSpaceCanvasWidget
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+CHANNELS = [("red", "red"), ("green", "green"), ("cyan", "cyan"), ("magenta", "magenta")]
+
+
+def plane(side: int = 900, seed: int = 0) -> np.ndarray:
+    """Big enough that the reduction does not early-return."""
+    return (np.random.default_rng(seed).random((side, side)) * 255).astype(np.uint8)
+
+
+@pytest.fixture
+def widget(qtbot=None):
+    w = FMRealSpaceCanvasWidget()
+    w.set_pixel_size(1e-7)
+    yield w
+    w.deleteLater()
+
+
+@pytest.fixture
+def reductions(widget, monkeypatch):
+    """Every plane the widget reduces, counted."""
+    calls = []
+    original = type(widget)._reduce
+
+    def counting(self, p):
+        calls.append(p.shape)
+        return original(self, p)
+
+    monkeypatch.setattr(type(widget), "_reduce", counting)
+    return calls
+
+
+class TestOneCompositePerUpdate:
+    def test_setting_channels_together_costs_one_composite(self, widget, reductions):
+        """C reductions, not C squared. The loop threw C-1 blends away."""
+        items = [(name, plane(seed=i), color) for i, (name, color) in enumerate(CHANNELS)]
+
+        widget.set_channels(items)
+
+        assert len(reductions) == len(CHANNELS), (
+            f"{len(reductions)} reductions for {len(CHANNELS)} channels — a batched "
+            f"update should reduce each layer once, so this is compositing more than once"
+        )
+
+    def test_setting_them_one_at_a_time_is_what_it_replaced(self, widget, reductions):
+        """The premise, so the number above is read against something."""
+        for i, (name, color) in enumerate(CHANNELS):
+            widget.set_channel(name, plane(seed=i), color)
+
+        n = len(CHANNELS)
+        assert len(reductions) == n * (n + 1) // 2, (
+            "`set_channel` is expected to recomposite per call — if this changed, the "
+            "batching in `_show_preview` may no longer be buying anything"
+        )
+
+    def test_the_picture_is_the_same_either_way(self, widget):
+        """Batching is an optimisation; it must not change what is drawn."""
+        items = [(name, plane(seed=i), color) for i, (name, color) in enumerate(CHANNELS)]
+
+        widget.set_channels(items)
+        batched = widget.canvas._placed[widget._composite_key].artist.get_array().copy()
+
+        widget.clear_overviews()
+        for name, data, color in items:
+            widget.set_channel(name, data, color)
+        looped = widget.canvas._placed[widget._composite_key].artist.get_array()
+
+        assert np.array_equal(np.asarray(batched), np.asarray(looped))
+
+
+class TestHeldPlanesAreReducedOnce:
+    def test_re_rendering_a_held_overview_does_not_reduce_it_again(self, widget, reductions):
+        """The dominant cost: held planes are at acquisition resolution and never change.
+
+        Place one overview, then place a second somewhere else — which re-renders the
+        first through `_restyle_others`. The first one's planes must come from the cache.
+        """
+        widget.set_composite_key("first")
+        widget.set_channels([(n, plane(seed=i), c) for i, (n, c) in enumerate(CHANNELS)])
+        reductions.clear()
+
+        widget.set_composite_key("second")
+        widget.set_placement((1e-3, 0.0))
+        widget.set_channels([(n, plane(seed=i + 9), c) for i, (n, c) in enumerate(CHANNELS)])
+
+        assert len(reductions) == len(CHANNELS), (
+            f"{len(reductions)} reductions placing a second overview — only the new "
+            f"one's {len(CHANNELS)} planes should be reduced. The first overview is "
+            f"held and unchanged, so re-reducing it recomputes the same answer"
+        )
+
+    def test_the_cache_is_dropped_with_the_overview(self, widget):
+        """It holds full-size arrays, so a leak here is a memory leak."""
+        widget.set_composite_key("first")
+        widget.set_channels([(n, plane(seed=i), c) for i, (n, c) in enumerate(CHANNELS)])
+        assert widget._held_reduced.get("first")
+
+        widget.forget_overview("first")
+
+        assert "first" not in widget._held_reduced
+
+    def test_clearing_drops_every_cached_reduction(self, widget):
+        widget.set_composite_key("first")
+        widget.set_channels([(n, plane(seed=i), c) for i, (n, c) in enumerate(CHANNELS)])
+
+        widget.clear_overviews()
+
+        assert widget._held_reduced == {}
+
+
+class TestThePreviewUsesTheBatchedPath:
+    """Structural. The widget's own tests cover the canvas; this pins the caller, which
+    is where the cost was actually being paid."""
+
+    def test_show_preview_does_not_set_channels_one_at_a_time(self):
+        import ast
+        import inspect
+        import textwrap
+
+        from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+
+        # dedent: a method's source is indented, which `ast.parse` rejects outright
+        source = textwrap.dedent(inspect.getsource(FMOverviewWidget._show_preview))
+        tree = ast.parse(source)
+        called = {
+            node.func.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+
+        assert "set_channels" in called, "_show_preview no longer batches its channels"
+        assert "set_channel" not in called, (
+            "_show_preview calls `set_channel`, which recomposites per channel — that is "
+            "C composites an update, and it runs once a tile for a whole overview run"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes FIB-600. Three symptoms reported at the microscope, two causes, both confirmed fixed on hardware — *"much more performant and smooth"*.

The clue that cracked it was yours: **the active view flicking in the microscope's own XT UI while only the mouse was moving.** That is `active_channel()` entering and exiting, made visible — so the GUI was reading hardware it had no business reading.

## 1. The display read the microscope on UI events

`_frame()` resolved `FMStageProjection.from_microscope` on every call, reading `camera.resolution`, `camera.pixel_size` and `fm_image_geometry()`. On TFS the first two go through `camera.binning`, which is a device read inside an `active_channel()` scope. Two handlers call `_frame()` on **every mouse-move event** — the cursor readout and the grid drag.

`_refresh_tile_grid` had its **own** direct camera reads on top, also per motion event, and `_show_preview` read `camera.pixel_size` once a tile *during a run* — the display taking the shared channel from the acquisition that was using it.

Resolved once and kept now. Nothing in it varies the way a pointer does: `FibsemHardwareGeometry` is system configuration — camera tilt, shuttle pre-tilt, the flip — and resolution and pixel size vary only with binning.

The split follows the one FIB-534 drew: **displays use the kept value, anything that commands the instrument reads the device.** Of ten `_frame()` callers exactly one commands anything — `_stage_position_at`, turning a double-click into a stage move — and it asks for a fresh read, because a stale binning there would send the stage somewhere other than where you clicked. `acquire` invalidates too, so a run always plans from a fresh read.

## 2. The preview recomposited once per channel

`set_channel` recomposites on every call, so `_show_preview` setting C channels in a loop did C composites and threw C-1 away. And a recomposite re-renders every *other* held image through `_restyle_others`, reducing all of its planes — held at acquisition resolution, so a stitched 10×10 mosaic is 10240 px square per channel, re-reduced on every update despite never changing.

That was free while the reduction was a strided view. It stopped being free when FIB-589 made it a real box-average — this is that change's bill arriving.

Measured on the widget, per preview update, which is per tile for a whole run:

| held overview | before | after |
| -- | -- | -- |
| none | 126 ms / 14 reduces | **41 ms / 4** |
| one 5×5 | 244 ms / 16 | **64 ms / 4** |
| one 10×10 | 260 ms / 16 | **61 ms / 4** |

A batched `set_channels` composites once, and each held image's reduced planes are kept — taken from the blend that just ran rather than recomputed. The reduction count is now constant in what else is on the canvas, which was the point. What remains is the blend and the canvas redraw.

## Why they compounded

Interacting with the canvas during a run put three consumers on one shared channel — the acquisition per tile, the preview's own read per tile, and `_frame()` per mouse-move — on top of a 260 ms recomposite per tile. That is why it was worse than any single symptom suggested.

## The test fixture was wrong twice, and both ways are easy to repeat

- counting `FMStageProjection.from_microscope` **passed with the bug reinstated**, because `_refresh_tile_grid` reads the camera directly rather than through the projection;
- counting `active_channel()` entries counted **zero**, because only the *TFS* camera's `binning` takes the channel — the simulated one returns a plain attribute, so the cost under test does not exist on the simulator.

It now counts the geometry access itself, which is what the UI does and is identical on both. That blind spot is FIB-518's, showing up in a third place; the general answer — a fixture that drives synthetic UI events and asserts zero device reads — is noted on FIB-600 and not built here.

## Testing

Nine new tests across two files. Verified by reinstating each bug: the reported one (grid redraw reading the camera) fails 2, removing the projection cache entirely fails 5, and removing the batching fails 3.

`tests/ui/` + `tests/fm/` — **1736 passed**, 1 pre-existing skip.
