### PR TITLE
[fm] Hold the channel for a whole autofocus sweep and z-stack (FIB-601)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -77,78 +77,84 @@ def acquire_z_stack(
 ) -> Optional[FluorescenceImage]:
     """Acquire a Z-stack of images for a given channel."""
 
-    z_init = microscope.objective.position  # initial z position of the objective
-    z_positions = zparams.generate_positions(z_init=z_init)
-    images: List[FluorescenceImage] = []
+    # Claimed for the whole stack, as a tileset claims it for a whole run. Each z
+    # step is a move and an acquisition, and each of those opened and closed its own
+    # scope -- 23 for a single-channel 11-slice stack, 45 for two channels, every one
+    # a capture, a set and a restore, and a visible flick of the microscope's own
+    # active view. The depth count stops the inner scopes restoring between slices.
+    with microscope.active_channel():
+        z_init = microscope.objective.position  # initial z position of the objective
+        z_positions = zparams.generate_positions(z_init=z_init)
+        images: List[FluorescenceImage] = []
 
-    if not isinstance(channel_settings, list):
-        channel_settings = [channel_settings]
+        if not isinstance(channel_settings, list):
+            channel_settings = [channel_settings]
 
-    if zparams.order == ZStackOrder.Z_LEVEL:
-        # Z-level-wise: for each z-plane, acquire all channels
-        z_level_images: List[List[FluorescenceImage]] = []
-        for j, z in enumerate(z_positions):
-            if stop_event and stop_event.is_set():
-                logging.info("Z-stack acquisition cancelled before z-level acquisition")
-                microscope.objective.move_absolute(z_init)
-                return None
-
-            microscope.objective.move_absolute(z)
-            ch_images: List[FluorescenceImage] = []
-            for i, ch in enumerate(channel_settings):
-                microscope.acquisition_progress_signal.emit({
-                    "state": "acquiring",
-                    "task": "z-stack",
-                    "channel": ch.name,
-                    "channel_index": i + 1,
-                    "total_channels": len(channel_settings),
-                    "zlevel": j + 1,
-                    "total_zlevels": len(z_positions),
-                })
-                if stop_event and stop_event.is_set():
-                    logging.info("Z-stack acquisition cancelled during z-level acquisition")
-                    microscope.objective.move_absolute(z_init)
-                    return None
-                ch_images.append(microscope.acquire_image(channel_settings=ch))
-            z_level_images.append(ch_images)
-
-        # Transpose [z][ch] -> per-channel z-stacks
-        for i in range(len(channel_settings)):
-            ch_z_imgs = [z_level_images[j][i] for j in range(len(z_positions))]
-            images.append(FluorescenceImage.create_z_stack(ch_z_imgs))
-    else:
-        # Channel-wise (default): for each channel, acquire all z-planes
-        for i, ch in enumerate(channel_settings):
-            if stop_event and stop_event.is_set():
-                logging.info("Z-stack acquisition cancelled before channel acquisition")
-                microscope.objective.move_absolute(z_init)
-                return None
-
-            ch_images = []
+        if zparams.order == ZStackOrder.Z_LEVEL:
+            # Z-level-wise: for each z-plane, acquire all channels
+            z_level_images: List[List[FluorescenceImage]] = []
             for j, z in enumerate(z_positions):
-                microscope.acquisition_progress_signal.emit({
-                    "state": "acquiring",
-                    "task": "z-stack",
-                    "channel": ch.name,
-                    "channel_index": i + 1,
-                    "total_channels": len(channel_settings),
-                    "zlevel": j + 1,
-                    "total_zlevels": len(z_positions),
-                })
                 if stop_event and stop_event.is_set():
-                    logging.info("Z-stack acquisition cancelled during z-stack")
+                    logging.info("Z-stack acquisition cancelled before z-level acquisition")
                     microscope.objective.move_absolute(z_init)
                     return None
 
                 microscope.objective.move_absolute(z)
-                ch_images.append(microscope.acquire_image(channel_settings=ch))
+                ch_images: List[FluorescenceImage] = []
+                for i, ch in enumerate(channel_settings):
+                    microscope.acquisition_progress_signal.emit({
+                        "state": "acquiring",
+                        "task": "z-stack",
+                        "channel": ch.name,
+                        "channel_index": i + 1,
+                        "total_channels": len(channel_settings),
+                        "zlevel": j + 1,
+                        "total_zlevels": len(z_positions),
+                    })
+                    if stop_event and stop_event.is_set():
+                        logging.info("Z-stack acquisition cancelled during z-level acquisition")
+                        microscope.objective.move_absolute(z_init)
+                        return None
+                    ch_images.append(microscope.acquire_image(channel_settings=ch))
+                z_level_images.append(ch_images)
 
-            images.append(FluorescenceImage.create_z_stack(ch_images))
+            # Transpose [z][ch] -> per-channel z-stacks
+            for i in range(len(channel_settings)):
+                ch_z_imgs = [z_level_images[j][i] for j in range(len(z_positions))]
+                images.append(FluorescenceImage.create_z_stack(ch_z_imgs))
+        else:
+            # Channel-wise (default): for each channel, acquire all z-planes
+            for i, ch in enumerate(channel_settings):
+                if stop_event and stop_event.is_set():
+                    logging.info("Z-stack acquisition cancelled before channel acquisition")
+                    microscope.objective.move_absolute(z_init)
+                    return None
 
-    # restore objective to initial position
-    microscope.objective.move_absolute(z_init)
+                ch_images = []
+                for j, z in enumerate(z_positions):
+                    microscope.acquisition_progress_signal.emit({
+                        "state": "acquiring",
+                        "task": "z-stack",
+                        "channel": ch.name,
+                        "channel_index": i + 1,
+                        "total_channels": len(channel_settings),
+                        "zlevel": j + 1,
+                        "total_zlevels": len(z_positions),
+                    })
+                    if stop_event and stop_event.is_set():
+                        logging.info("Z-stack acquisition cancelled during z-stack")
+                        microscope.objective.move_absolute(z_init)
+                        return None
 
-    return FluorescenceImage.create_multi_channel_image(images)
+                    microscope.objective.move_absolute(z)
+                    ch_images.append(microscope.acquire_image(channel_settings=ch))
+
+                images.append(FluorescenceImage.create_z_stack(ch_images))
+
+        # restore objective to initial position
+        microscope.objective.move_absolute(z_init)
+
+        return FluorescenceImage.create_multi_channel_image(images)
 
 
 def acquire_image(

--- a/fibsem/fm/calibration/__init__.py
+++ b/fibsem/fm/calibration/__init__.py
@@ -115,73 +115,80 @@ def run_autofocus(
     if not microscope.has_valid_orientation():
         raise ValueError("Microscope orientation is not valid for autofocus")
 
-    # Set up default z parameters if not provided
-    if z_parameters is None:
-        z_parameters = ZParameters(zmin=-10e-6, zmax=10e-6, zstep=1e-6)
+    # Held for the whole sweep, as a tileset holds it for a whole run. Without it
+    # every step took and returned the channel on its own -- measured at 43 scopes
+    # for one sweep, each a capture, a set and a restore, and each a visible flick
+    # of the active view in the microscope's own UI. The depth count is what makes
+    # this work: the moves and acquisitions inside open their own scopes and must
+    # not restore between steps.
+    with microscope.active_channel():
+        # Set up default z parameters if not provided
+        if z_parameters is None:
+            z_parameters = ZParameters(zmin=-10e-6, zmax=10e-6, zstep=1e-6)
 
-    # Generate z positions around current objective position
-    z_positions = z_parameters.generate_positions(microscope.objective.position)
+        # Generate z positions around current objective position
+        z_positions = z_parameters.generate_positions(microscope.objective.position)
 
-    # Validate focus measure method
-    get_focus_measure_function(method)  # Will raise error if invalid
+        # Validate focus measure method
+        get_focus_measure_function(method)  # Will raise error if invalid
 
-    # Apply channel settings if provided
-    if channel_settings is not None:
-        microscope.set_channel(channel_settings=channel_settings)
+        # Apply channel settings if provided
+        if channel_settings is not None:
+            microscope.set_channel(channel_settings=channel_settings)
 
-    microscope.acquisition_progress_signal.emit({"state": "autofocus"})
-    logging.info(f"Starting autofocus: {len(z_positions)} positions, method='{method}'")
+        microscope.acquisition_progress_signal.emit({"state": "autofocus"})
+        logging.info(f"Starting autofocus: {len(z_positions)} positions, method='{method}'")
 
-    initial_z = microscope.objective.position
-    iterations: list[AutoFocusIteration] = []
+        initial_z = microscope.objective.position
+        iterations: list[AutoFocusIteration] = []
 
-    for i, z_pos in enumerate(z_positions):
-        if stop_event and stop_event.is_set():
-            logging.info("Autofocus cancelled")
-            microscope.objective.move_absolute(initial_z)
-            return None
+        for i, z_pos in enumerate(z_positions):
+            if stop_event and stop_event.is_set():
+                logging.info("Autofocus cancelled")
+                microscope.objective.move_absolute(initial_z)
+                return None
 
-        # Same payload shape the z-stack and channel loops emit, so a viewer that
-        # renders within-tile progress renders this too. Without it the bars froze for
-        # the whole sweep -- which on per-tile autofocus is most of the run.
-        microscope.acquisition_progress_signal.emit({
-            "state": "acquiring",
-            "task": "autofocus",
-            "channel": channel_settings.name if channel_settings is not None else "",
-            "zlevel": i + 1,
-            "total_zlevels": len(z_positions),
-            "pass_index": pass_index,
-            "total_passes": total_passes,
-        })
+            # Same payload shape the z-stack and channel loops emit, so a viewer that
+            # renders within-tile progress renders this too. Without it the bars froze for
+            # the whole sweep -- which on per-tile autofocus is most of the run.
+            microscope.acquisition_progress_signal.emit({
+                "state": "acquiring",
+                "task": "autofocus",
+                "channel": channel_settings.name if channel_settings is not None else "",
+                "zlevel": i + 1,
+                "total_zlevels": len(z_positions),
+                "pass_index": pass_index,
+                "total_passes": total_passes,
+            })
 
-        microscope.objective.move_absolute(z_pos)
-        image = microscope.acquire_image()
-        image_data = image.crop(roi) if roi is not None else image.data
-        focus_score = calculate_focus_quality(image_data, method=method)
-        iterations.append(AutoFocusIteration(
-            working_distance=float(z_pos),
-            focus_score=float(focus_score),
-            pass_index=0,
-            image=image_data,
-        ))
-        logging.debug(
-            f"Z[{i + 1}/{len(z_positions)}]: {z_pos * 1e6:.1f} μm, Score: {focus_score:.4f}"
+            microscope.objective.move_absolute(z_pos)
+            image = microscope.acquire_image()
+            image_data = image.crop(roi) if roi is not None else image.data
+            focus_score = calculate_focus_quality(image_data, method=method)
+            iterations.append(AutoFocusIteration(
+                working_distance=float(z_pos),
+                focus_score=float(focus_score),
+                pass_index=0,
+                image=image_data,
+            ))
+            logging.debug(
+                f"Z[{i + 1}/{len(z_positions)}]: {z_pos * 1e6:.1f} μm, Score: {focus_score:.4f}"
+            )
+
+        best_idx = int(np.argmax([it.focus_score for it in iterations]))
+        best = iterations[best_idx]
+
+        microscope.objective.move_absolute(best.working_distance)
+        logging.info(f"Autofocus complete: Best position {best.working_distance * 1e6:.1f} μm (score: {best.focus_score:.4f})")
+
+        result = AutoFocusResult(
+            image=best.image,
+            working_distance=best.working_distance,
+            initial_working_distance=initial_z,
+            focus_score=best.focus_score,
+            iterations=iterations,
+            method=method,
         )
-
-    best_idx = int(np.argmax([it.focus_score for it in iterations]))
-    best = iterations[best_idx]
-
-    microscope.objective.move_absolute(best.working_distance)
-    logging.info(f"Autofocus complete: Best position {best.working_distance * 1e6:.1f} μm (score: {best.focus_score:.4f})")
-
-    result = AutoFocusResult(
-        image=best.image,
-        working_distance=best.working_distance,
-        initial_working_distance=initial_z,
-        focus_score=best.focus_score,
-        iterations=iterations,
-        method=method,
-    )
 
     if save_plot:
         plot_autofocus(result)

--- a/tests/fm/test_routines_claim_channel.py
+++ b/tests/fm/test_routines_claim_channel.py
@@ -1,0 +1,187 @@
+"""A multi-step FM routine holds the channel for its duration.
+
+The tileset runner already did this — `active_channel()`'s depth count exists for it:
+"A tileset holds the channel for the whole run; each tile's acquisition opens a scope
+inside it and must not restore the beam view between tiles." The autofocus sweep and the
+z-stack never got the same treatment, so every step took the channel and handed it back.
+
+Measured on the simulator before this change, starting from a beam view:
+
+    autofocus sweep                 43 scopes, 43 hand-backs to the beam
+    z-stack, 1 channel x 11 slices  23 scopes, 23 hand-backs
+    z-stack, 2 channels x 11 slices 45 scopes, 45 hand-backs
+
+Each hand-back is a restore on hardware and one visible flick of the active view in the
+microscope's own UI — reported from the instrument as the view flicking while nothing
+should have been touching it.
+
+Note what this does *not* change: `active_channel()` calls `set_active_channel()` on
+every entry regardless of depth, so the number of *sets* is unchanged. What goes away is
+the restore between steps, and with it the window where another client can take the
+channel mid-routine.
+"""
+
+import threading
+from contextlib import contextmanager
+
+import pytest
+
+from fibsem.microscopes.simulator import FM_ACTIVE_VIEW
+
+BEAM_VIEW = 1
+
+
+@pytest.fixture
+def microscope():
+    from fibsem import utils
+
+    scope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    assert scope.fm is not None
+    scope.fm.objective.insert()
+    return scope
+
+
+@pytest.fixture
+def channel(microscope):
+    from fibsem.fm.structures import ChannelSettings
+
+    return ChannelSettings(name="Channel-01")
+
+
+@pytest.fixture
+def zparams():
+    from fibsem.fm.structures import ZParameters
+
+    return ZParameters(zmin=-5e-6, zmax=5e-6, zstep=1e-6)
+
+
+@contextmanager
+def watching(microscope):
+    """Record every moment the view returns to the beam while a routine runs."""
+    imaging = microscope.imaging_system
+    imaging.active_view = BEAM_VIEW
+    fm_cls = type(microscope.fm)
+    original = fm_cls.set_active_channel
+    hand_backs = []
+    started = []
+
+    def counting(self):
+        # On a beam view when a set is about to happen, after the routine has already
+        # claimed it once, means it was given back in between.
+        if started and imaging.active_view == BEAM_VIEW:
+            hand_backs.append(1)
+        started.append(1)
+        original(self)
+
+    fm_cls.set_active_channel = counting
+    try:
+        yield hand_backs
+    finally:
+        fm_cls.set_active_channel = original
+
+
+class TestTheRoutineHoldsIt:
+    def test_the_autofocus_sweep_does_not_hand_the_channel_back(
+        self, microscope, channel
+    ):
+        from fibsem.fm.calibration import run_autofocus
+
+        with watching(microscope) as hand_backs:
+            run_autofocus(microscope.fm, channel)
+
+        assert hand_backs == [], (
+            f"the sweep gave the channel back {len(hand_backs)} times mid-routine — each "
+            f"is a restore on hardware and a visible flick of the microscope's own view"
+        )
+
+    def test_the_z_stack_does_not_hand_the_channel_back(
+        self, microscope, channel, zparams
+    ):
+        from fibsem.fm.acquisition import acquire_z_stack
+
+        with watching(microscope) as hand_backs:
+            acquire_z_stack(microscope.fm, [channel], zparams)
+
+        assert hand_backs == []
+
+    def test_a_multi_channel_z_stack_does_not_hand_the_channel_back(
+        self, microscope, channel, zparams
+    ):
+        """Two channels doubles the steps, so it doubled the hand-backs."""
+        from fibsem.fm.acquisition import acquire_z_stack
+        from fibsem.fm.structures import ChannelSettings
+
+        channels = [channel, ChannelSettings(name="Channel-02")]
+        with watching(microscope) as hand_backs:
+            acquire_z_stack(microscope.fm, channels, zparams)
+
+        assert hand_backs == []
+
+
+class TestItStillGivesItBackAtTheEnd:
+    """Holding it for the routine must not mean keeping it afterwards — that is FIB-517."""
+
+    def test_the_autofocus_sweep_restores_the_beam_view(self, microscope, channel):
+        from fibsem.fm.calibration import run_autofocus
+
+        microscope.imaging_system.active_view = BEAM_VIEW
+
+        run_autofocus(microscope.fm, channel)
+
+        assert microscope.imaging_system.active_view == BEAM_VIEW, (
+            "the sweep left the connection on the FM — the next beam operation would "
+            "read the FM's buffer (FIB-517)"
+        )
+
+    def test_the_z_stack_restores_the_beam_view(self, microscope, channel, zparams):
+        from fibsem.fm.acquisition import acquire_z_stack
+
+        microscope.imaging_system.active_view = BEAM_VIEW
+
+        acquire_z_stack(microscope.fm, [channel], zparams)
+
+        assert microscope.imaging_system.active_view == BEAM_VIEW
+
+    def test_a_cancelled_sweep_still_restores(self, microscope, channel):
+        """The `with` covers the early returns too, which a manual claim would miss."""
+        from fibsem.fm.calibration import run_autofocus
+
+        microscope.imaging_system.active_view = BEAM_VIEW
+        stop = threading.Event()
+        stop.set()
+
+        run_autofocus(microscope.fm, channel, stop_event=stop)
+
+        assert microscope.imaging_system.active_view == BEAM_VIEW
+
+
+class TestTheClaimIsStructural:
+    """The wrap is one line and easy to lose in a later edit of a long function."""
+
+    @pytest.mark.parametrize(
+        "module,function",
+        [("fm/calibration/__init__.py", "run_autofocus"), ("fm/acquisition.py", "acquire_z_stack")],
+    )
+    def test_the_routine_opens_a_channel_scope(self, module, function):
+        import ast
+        from pathlib import Path
+
+        import fibsem
+
+        tree = ast.parse((Path(fibsem.__file__).parent / module).read_text())
+        fn = next(
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == function
+        )
+        scoped = any(
+            isinstance(item.context_expr, ast.Call)
+            and isinstance(item.context_expr.func, ast.Attribute)
+            and item.context_expr.func.attr == "active_channel"
+            for node in ast.walk(fn)
+            if isinstance(node, ast.With)
+            for item in node.items
+        )
+        assert scoped, (
+            f"{function} no longer opens an `active_channel()` scope, so every step "
+            f"inside it takes and returns the channel on its own again"
+        )


### PR DESCRIPTION
Closes FIB-601. Noticed at the microscope after the same class was found in the overview widget — the XT active view flicking while nothing should have been touching it.

The tileset runner already claims the channel for its whole run; that is what `active_channel()`'s depth count exists for, and its docstring says so. `run_autofocus` and `acquire_z_stack` never got the same treatment, so every step took the channel and handed it straight back.

Measured on the simulator, starting from a beam view:

| routine | scopes | hand-backs to the beam |
| -- | -- | -- |
| autofocus sweep | 43 | 43 |
| z-stack, 1 channel × 11 slices | 23 | 23 |
| z-stack, 2 channels × 11 slices | 45 | 45 |
| a tileset, which already claims it | 1 | 0 |

A coarse+fine autofocus runs the sweep twice.

## What it costs, precisely

Each hand-back is a restore on hardware and one visible flick of the active view.

Worth being exact about what this is **not**, because my first reading of the measurement was wrong. `active_channel()` calls `set_active_channel()` on every entry regardless of depth, so wrapping the routine does not reduce the number of *sets* — 43 becomes 44, one more, for the outer scope. Only the restores go away, 42 of 43. It is not an RPC reduction.

Nor does it close the window for another client to take the channel mid-routine — an earlier version of this description claimed it did. The lock is released across the body (`yield` sits *outside* `with self._channel_lock`, deliberately, since the body can be a whole run), and since FIB-542 the beam side re-sets its own view under that lock before every `grab_frame`. A beam operation can still land between two steps and still gets the view it asked for. What stops is the FM volunteering the channel back.

That the lock is not held for the routine's duration is what makes this affordable. If it were, wrapping 43 objective moves would block beam imaging for a whole sweep — the starvation that made focusing unusable in FIB-599.

The FIB-599 fast path does not help these routines either: each scope restores on exit, so the next one finds a beam view and takes the slow path.

## Fix

One `active_channel()` scope around each routine body. The depth count does the rest — the moves and acquisitions inside open their own scopes and stop restoring between steps.

## Known consequences

**The view now sits on the FM for the whole routine, where it used to return to the beam between steps.** That widens the exposure of FIB-544: `_get`/`_set` for the detector properties do `set_channel(beam_type)` then read or write, unlocked, and `get_microscope_state()` is eight such pairs polled from the GUI thread. Those were always racy; before this change they raced against an FM that was pointing back at the beam most of the time. They are not made incorrect by this PR, but they are made more likely to lose. Worth doing FIB-544 sooner because of it.

**The restore target is captured once at the start and applied at the end**, so it can be up to a routine stale. If a beam operation switches the active view during a long sweep, the end-of-sweep restore puts back whatever was active when the sweep began. Cosmetic — the beam side sets its own view before every grab — but the microscope's own UI can end on the wrong view.

**A non-TFS FM is unaffected**: `FluorescenceMicroscope.active_channel` is a no-op on any system where the FM owns its connection, so Odemis takes the same code path it always did.

## Testing

Eight tests, both directions, because the fix could break the thing it protects: no hand-backs mid-routine, **and** the beam view still restored at the end — including from a cancelled sweep, which the `with` covers and a manual claim would have missed. Five fail without the wrap.
