### PR TITLE
[autolamella] Stop the lamella card reading a half-written thumbnail (FIB-602)

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -947,10 +947,35 @@ class Lamella:
             if _THUMBNAIL_PLACEHOLDER is None:
                 _THUMBNAIL_PLACEHOLDER = _make_thumbnail_placeholder()
             return _THUMBNAIL_PLACEHOLDER
-        return np.asarray(Image.open(thumb_path).convert("RGB"))
+        try:
+            return np.asarray(Image.open(thumb_path).convert("RGB"))
+        except OSError as e:
+            # A thumbnail that will not open is not a reason to lose the card. `save_thumbnail`
+            # writes atomically now, so a torn file should no longer be produced -- but one
+            # written before that fix is still on disk, and any other corruption lands here
+            # too. This is reached from a Qt slot, where an escaping exception aborts the
+            # process under PyQt5 rather than raising (FIB-329).
+            logging.warning(f"Could not read the thumbnail at {thumb_path}: {e}")
+            if _THUMBNAIL_PLACEHOLDER is None:
+                _THUMBNAIL_PLACEHOLDER = _make_thumbnail_placeholder()
+            return _THUMBNAIL_PLACEHOLDER
 
     def save_thumbnail(self, image: "FibsemImage") -> None:
-        """Save a thumbnail of the given image to disk as thumbnail.png."""
+        """Save a thumbnail of the given image to disk as thumbnail.png.
+
+        Written to a temporary file and moved into place, so a reader never sees a
+        partly-written one. `get_thumbnail` runs from the lamella cards on the GUI
+        thread while saving happens on a worker (FIB-563), so the two do overlap: the
+        reported failure was `OSError: image file is truncated` out of `Image.open`,
+        with the existence check passing because the file was there, just incomplete.
+
+        `os.replace` is atomic on POSIX and on Windows, provided the temporary file is
+        on the same filesystem -- hence writing it in the same directory rather than
+        somewhere under /tmp. A reader sees either the previous thumbnail or the new
+        one, never a partial.
+        """
+        import tempfile
+
         from PIL import Image
         import numpy as np
         data = image.filtered_data
@@ -959,7 +984,22 @@ class Lamella:
         # writes directly rather than through FibsemImage.save, so it makes its
         # own directory -- construction no longer does (FIB-420).
         os.makedirs(self.path, exist_ok=True)
-        Image.fromarray(data.astype(np.uint8)).save(os.path.join(self.path, "thumbnail.png"))
+        destination = os.path.join(self.path, "thumbnail.png")
+        handle, staged = tempfile.mkstemp(
+            dir=self.path, prefix=".thumbnail-", suffix=".png"
+        )
+        os.close(handle)
+        try:
+            Image.fromarray(data.astype(np.uint8)).save(staged)
+            os.replace(staged, destination)
+        except BaseException:
+            # Including cancellation: a staged file left behind would accumulate in the
+            # lamella directory, and it is hidden, so nobody would notice it doing so.
+            try:
+                os.remove(staged)
+            except OSError:
+                pass
+            raise
 
     # def get_task_config_by_type(self, task_type: Type['AutoLamellaTaskConfig']) -> Dict[str, AutoLamellaTaskConfig]:
     #     """Get the task configuration by type."""

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -257,14 +257,30 @@ class AutoLamellaTask(ABC):
         # post-task
         if self.lamella.task_state is None:
             raise ValueError("Task state is not set. Did you run pre_task()?")
+        # Before the status, not after. Setting the status fires `task_state.events.status`,
+        # which the lamella card subscribes to; its handler is `@ensure_main_thread`, so the
+        # read is queued to the GUI thread while this one carries straight on. Writing
+        # afterwards meant the card read the file at the moment it was being written --
+        # `OSError: image file is truncated`, reported from the microscope -- and, even
+        # when it survived that, read the *previous* thumbnail, so the picture from the
+        # task that had just finished was never the one shown.
+        #
+        # Guarded, because ordering it first would otherwise let a thumbnail failure stop
+        # a finished task being marked Completed. A missing picture is worth far less than
+        # an accurate task state.
+        if self._last_fib_image is not None:
+            try:
+                self.lamella.save_thumbnail(self._last_fib_image)
+            except Exception as e:
+                logging.warning(
+                    f"Could not save the thumbnail for {self.lamella.name}: {e}"
+                )
         self.lamella.task_state.status = AutoLamellaTaskStatus.Completed
         self.lamella.task_state.status_message = ""
         self.log_status_message(message="FINISHED", display_message="Finished")
         self.log_task_config()
         self.lamella.task_config[self.task_name] = deepcopy(self.config)
         self._record_outcome()
-        if self._last_fib_image is not None:
-            self.lamella.save_thumbnail(self._last_fib_image)
 
     def log_task_config(self) -> None:
         """Log the task configuration to the log file. This can be used for debugging or reporting."""

--- a/tests/autolamella/test_post_task_thumbnail_order.py
+++ b/tests/autolamella/test_post_task_thumbnail_order.py
@@ -1,0 +1,141 @@
+"""The thumbnail is on disk before anything is told the task finished.
+
+`post_task` set `task_state.status = Completed` and wrote the thumbnail afterwards. The
+lamella card subscribes to `task_state.events.status`, and its handler is
+`@ensure_main_thread` — so the status assignment queued a read onto the GUI thread while
+this thread carried on to write the file. The read landed inside the write:
+
+    OSError: image file is truncated
+      lamella_card_widget.py:344 in refresh -> lamella.get_thumbnail()
+
+Structural rather than unlucky: it happens on the same two adjacent statements at the end
+of every task.
+
+A quieter consequence of the same ordering: the refresh fired *before* the write, so the
+card read the **previous** thumbnail. The picture from the task that had just finished was
+never the one displayed.
+
+The write is guarded, because ordering it first would otherwise let a thumbnail failure
+stop a finished task being marked Completed — a much worse failure than a missing picture.
+
+The atomic write in `save_thumbnail` is the other half and is kept: it holds the property
+independent of anyone's call ordering, including future callers.
+"""
+
+import ast
+import inspect
+import textwrap
+
+import pytest
+
+
+def _post_task_body():
+    from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+
+    return ast.parse(textwrap.dedent(inspect.getsource(AutoLamellaTask.post_task)))
+
+
+def _statement_index(tree, predicate) -> int:
+    """Index of the first top-level statement in `post_task` matching *predicate*."""
+    body = tree.body[0].body
+    for i, node in enumerate(body):
+        if predicate(ast.dump(node)):
+            return i
+    return -1
+
+
+class TestTheOrder:
+    def test_the_thumbnail_is_written_before_the_status_is_set(self):
+        tree = _post_task_body()
+
+        thumbnail = _statement_index(tree, lambda d: "save_thumbnail" in d)
+        status = _statement_index(
+            tree, lambda d: "AutoLamellaTaskStatus" in d and "Completed" in d
+        )
+
+        assert thumbnail != -1, "post_task no longer saves a thumbnail"
+        assert status != -1, "post_task no longer marks the task Completed"
+        assert thumbnail < status, (
+            "the thumbnail is written after the status is set, so the card's refresh "
+            "(queued to the GUI thread by that assignment) races the write and reads "
+            "the previous thumbnail even when it wins"
+        )
+
+    def test_the_write_is_guarded(self):
+        """Ordering it first must not let a thumbnail failure block task completion."""
+        tree = _post_task_body()
+        body = tree.body[0].body
+
+        guarded = any(
+            isinstance(node, ast.Try) and "save_thumbnail" in ast.dump(node)
+            for node in ast.walk(tree)
+        )
+        assert guarded, (
+            "the thumbnail write is not wrapped — a failure would now stop a finished "
+            "task being marked Completed, which is worse than a missing picture"
+        )
+        assert body, "post_task is empty"
+
+
+@pytest.fixture
+def task(tmp_path):
+    """A real task, run through `post_task`. Only `_run` is abstract."""
+    from fibsem import utils
+    from fibsem.applications.autolamella.structures import (
+        AutoLamellaTaskState,
+        Lamella,
+    )
+    # A real, registered config: `task_type` is a ClassVar the abstract base leaves
+    # unset, so the base class cannot be instantiated on its own.
+    from fibsem.applications.autolamella.workflows.tasks import MillTrenchTaskConfig
+    from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+
+    class _Task(AutoLamellaTask):
+        def _run(self):  # pragma: no cover - never called here
+            raise NotImplementedError
+
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    lamella = Lamella(path=str(tmp_path / "lam"), number=1, petname="test")
+    lamella.task_state = AutoLamellaTaskState(name="TestTask")
+    return _Task(
+        microscope=microscope,
+        config=MillTrenchTaskConfig(task_name="TestTask"),
+        lamella=lamella,
+    )
+
+
+class TestItActuallyBehaves:
+    def test_the_thumbnail_is_on_disk_before_the_status_changes(self, task):
+        """What the card sees. The status change is what triggers its read."""
+        import numpy as np
+
+        from fibsem.structures import FibsemImage
+
+        task._last_fib_image = FibsemImage(data=np.full((32, 32), 9, np.uint8))
+        seen = []
+        task.lamella.task_state.events.status.connect(
+            lambda *_: seen.append(int(task.lamella.get_thumbnail()[0, 0, 0]))
+        )
+
+        task.post_task()
+
+        assert seen == [9], (
+            f"the subscriber saw {seen} — the thumbnail from the task that just "
+            f"finished should already be the one on disk when the status is announced"
+        )
+
+    def test_a_failing_thumbnail_does_not_stop_the_task_completing(self, task, monkeypatch):
+        from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+
+        def exploding(self, image):
+            raise RuntimeError("disk went away")
+
+        monkeypatch.setattr(type(task.lamella), "save_thumbnail", exploding)
+        task._last_fib_image = object()  # never reaches PIL
+
+        task.post_task()
+
+        assert task.lamella.task_state.status is AutoLamellaTaskStatus.Completed, (
+            "a thumbnail failure stopped a finished task being marked Completed — the "
+            "picture is worth far less than an accurate task state"
+        )

--- a/tests/autolamella/test_thumbnail_atomic_write.py
+++ b/tests/autolamella/test_thumbnail_atomic_write.py
@@ -1,0 +1,150 @@
+"""A lamella thumbnail is never read half-written.
+
+Reported from the microscope, 2026-08-11:
+
+    OSError: image file is truncated
+      ... lamella_card_widget.py:344 in refresh -> lamella.get_thumbnail()
+      ... structures.py:950 -> Image.open(thumb_path).convert("RGB")
+
+`save_thumbnail` wrote straight to `thumbnail.png`, and `get_thumbnail` reads that same
+path from the lamella cards. Saving moved off the GUI thread in FIB-563, so the two
+genuinely overlap, and the existence check does not help: the file is there, just
+incomplete.
+
+Two changes, and both are needed. Writing through a temporary file and `os.replace`
+means a reader sees the old thumbnail or the new one and never a partial. The read is
+also guarded, because torn files written before the fix are still on disk, and this runs
+from a Qt slot, where an escaping exception aborts the process under PyQt5 rather than
+raising (FIB-329).
+"""
+
+import os
+import threading
+
+import numpy as np
+import pytest
+
+from fibsem.structures import FibsemImage
+
+
+@pytest.fixture
+def lamella(tmp_path):
+    from fibsem.applications.autolamella.structures import Lamella
+
+    lam = Lamella(path=str(tmp_path / "lamella"), number=1, petname="test-lamella")
+    os.makedirs(lam.path, exist_ok=True)
+    return lam
+
+
+def image(value: int = 128) -> FibsemImage:
+    return FibsemImage(data=np.full((64, 64), value, dtype=np.uint8))
+
+
+class TestTheWriteIsAtomic:
+    def test_the_final_file_never_exists_partly_written(self, lamella):
+        """The property that fixes it: readers only ever see a complete file.
+
+        Checked by watching the destination while a save runs — every version of it that
+        exists at all must open cleanly.
+        """
+        from PIL import Image
+
+        lamella.save_thumbnail(image(64))  # a complete one to start from
+        destination = os.path.join(lamella.path, "thumbnail.png")
+
+        failures = []
+        stop = threading.Event()
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    if os.path.exists(destination):
+                        Image.open(destination).convert("RGB")
+                except OSError as e:
+                    failures.append(str(e))
+
+        watcher = threading.Thread(target=reader, daemon=True)
+        watcher.start()
+        try:
+            for value in range(20):
+                lamella.save_thumbnail(image(value * 10 % 256))
+        finally:
+            stop.set()
+            watcher.join(timeout=5)
+
+        assert failures == [], (
+            f"a reader saw {len(failures)} torn thumbnails during 20 saves: "
+            f"{failures[0]}"
+        )
+
+    def test_it_leaves_no_staging_files_behind(self, lamella):
+        """They are hidden, so they would pile up in the lamella directory unnoticed."""
+        for _ in range(5):
+            lamella.save_thumbnail(image())
+
+        leftovers = [n for n in os.listdir(lamella.path) if n.startswith(".thumbnail-")]
+
+        assert leftovers == [], f"staging files left behind: {leftovers}"
+
+    def test_a_failed_write_cleans_up_and_still_raises(self, lamella, monkeypatch):
+        """A save that fails must not leave the staging file, nor swallow the failure."""
+        from PIL import Image as PILImage
+
+        def exploding(self, *args, **kwargs):
+            raise RuntimeError("disk went away")
+
+        monkeypatch.setattr(PILImage.Image, "save", exploding)
+
+        with pytest.raises(RuntimeError):
+            lamella.save_thumbnail(image())
+
+        leftovers = [n for n in os.listdir(lamella.path) if n.startswith(".thumbnail-")]
+        assert leftovers == [], f"a failed save left {leftovers} behind"
+
+    def test_the_previous_thumbnail_survives_a_failed_write(self, lamella, monkeypatch):
+        """`os.replace` never runs, so what was there stays there — readable throughout."""
+        from PIL import Image as PILImage
+
+        lamella.save_thumbnail(image(200))
+        before = lamella.get_thumbnail().copy()
+
+        def exploding(self, *args, **kwargs):
+            raise RuntimeError("disk went away")
+
+        monkeypatch.setattr(PILImage.Image, "save", exploding)
+        with pytest.raises(RuntimeError):
+            lamella.save_thumbnail(image(10))
+
+        assert np.array_equal(lamella.get_thumbnail(), before)
+
+
+class TestTheReadIsGuarded:
+    def test_a_truncated_thumbnail_returns_the_placeholder(self, lamella):
+        """Files torn before this fix are still on disk, and this runs in a Qt slot."""
+        lamella.save_thumbnail(image())
+        destination = os.path.join(lamella.path, "thumbnail.png")
+        with open(destination, "r+b") as handle:  # keep the header, lose the rest
+            handle.truncate(20)
+
+        result = lamella.get_thumbnail()
+
+        assert result is not None
+        assert result.ndim == 3 and result.shape[2] == 3
+
+    def test_an_empty_thumbnail_returns_the_placeholder(self, lamella):
+        """Zero bytes: what the reported traceback actually hit."""
+        open(os.path.join(lamella.path, "thumbnail.png"), "wb").close()
+
+        result = lamella.get_thumbnail()
+
+        assert result is not None
+        assert result.ndim == 3 and result.shape[2] == 3
+
+    def test_a_good_thumbnail_still_round_trips(self, lamella):
+        """The guard must not swallow a working read."""
+        lamella.save_thumbnail(image(77))
+
+        result = lamella.get_thumbnail()
+
+        assert result.shape == (64, 64, 3)
+        assert int(result[0, 0, 0]) == 77


### PR DESCRIPTION
Closes FIB-602. Your traceback from the hardware session:

```
OSError: image file is truncated
  lamella_card_widget.py:344 in refresh -> lamella.get_thumbnail()
  structures.py:950 -> Image.open(thumb_path).convert("RGB")
```

Structural rather than unlucky. `post_task` did this, in this order:

```python
self.lamella.task_state.status = AutoLamellaTaskStatus.Completed   # → psygnal → refresh
...
self.lamella.save_thumbnail(self._last_fib_image)                   # the write, microseconds later
```

The card subscribes to `task_state.events.status`, and its `refresh` is `@ensure_main_thread` — so the status assignment **queues** a read onto the GUI thread while the worker carries straight on to write the file. The read lands inside the write. The existence check does not help: the file is there, just unfinished. FIB-563 moving saves off the GUI thread is what made the two overlap.

The same ordering had a quieter cost: the refresh fires *before* the write, so the card reads the **previous** thumbnail. The picture from the task that just finished was never the one shown.

## It outlives the race

I first described this as read-while-write, which undersells it. From a later run, 38 seconds after the traceback above:

```
PIL.UnidentifiedImageError: cannot identify image file '.../01-square-stag/thumbnail.png'
  lamella_card_widget.py:185 in __init__ -> self.refresh()
  AutoLamellaMainUI.py:2098 in _rebuild_lamella_list -> add_lamella
```

No workflow running — that is a fresh experiment load, and the file is **0 bytes**. Same file, two stages: partial at 15:24:37, empty by 15:25:17, and it survived a restart that way.

So the write was *interrupted*, not merely raced. `Image.save` opens `"wb"`, which truncates to zero before any data is written; a process that dies in that window has destroyed the previous thumbnail permanently. Every experiment load then hits it. Atomic staging is what makes that impossible — an interrupted write leaves a stray `.thumbnail-*.png` and the existing thumbnail untouched.

`UnidentifiedImageError` subclasses `OSError`, so the guard below catches this second failure too. Checked against the real 0-byte file rather than the class hierarchy.

## Three parts, all needed

**Write atomically** — staged to a temporary file in the same directory, moved into place with `os.replace`, which is atomic on POSIX and Windows. A reader sees the old thumbnail or the new one, never a partial. A failed write cleans up its staging file and leaves the previous thumbnail intact.

**Write before announcing** — `save_thumbnail` moves above the status assignment, so the file is complete before anything is notified. That also fixes the staleness. Guarded, because ordering it first would otherwise let a thumbnail failure stop a finished task being marked Completed; a missing picture is worth far less than an accurate task state.

**Guard the read** — files torn before this fix are still on disk, and `get_thumbnail` runs from a Qt slot, where an escaping exception aborts the process under PyQt5 rather than raising (FIB-329). A thumbnail that will not open now logs and falls back to the placeholder.

The ordering fixes this caller, the atomic write holds for callers that do not exist yet, and the guard covers what is already on disk.

## Testing

11 tests across two files. The race test reproduces the original failure directly — a reader thread watching the destination through twenty saves sees torn files without the fix and none with it. Three of seven fail against the old `save_thumbnail`; two of four against the old ordering.

`tests/autolamella/` — 471 passed.
