### PR TITLE
[autolamella] Drop the lamella row's cross-thread task-state subscription (FIB-603)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -2012,6 +2012,13 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             if experiment is not None and lamella_name is not None:
                 lamella = experiment.get_lamella_by_name(lamella_name)
 
+            # The name list is refreshed from here rather than subscribing per row.
+            # `_LamellaRow` used to connect to `task_state.events.name`/`.status`, which
+            # the workflow writes from its worker thread; the marshalled refresh then
+            # arrived after the row had been replaced and its widgets destroyed
+            # (`RuntimeError: wrapped C/C++ object of type QLabel has been deleted`).
+            # It joins the other two on the same named-lamella path, so it costs one row
+            # -- unlike them, though, nothing else was refreshing this list mid-workflow.
             if lamella is not None:
                 self.lamella_list_widget.refresh_lamella(lamella)
                 timings["lamella_list.refresh_lamella"] = time.time() - t1
@@ -2019,12 +2026,18 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 self.lamella_card_container.refresh_lamella(lamella)
                 timings["lamella_cards.refresh_lamella"] = time.time() - t1
                 t1 = time.time()
+                self.autolamella_ui.lamella_list.refresh_lamella(lamella)
+                timings["lamella_name_list.refresh_lamella"] = time.time() - t1
+                t1 = time.time()
             else:
                 self.lamella_list_widget.refresh_all()
                 timings["lamella_list.refresh_all"] = time.time() - t1
                 t1 = time.time()
                 self.lamella_card_container.refresh_all()
                 timings["lamella_cards.refresh_all"] = time.time() - t1
+                t1 = time.time()
+                self.autolamella_ui.lamella_list.refresh_all()
+                timings["lamella_name_list.refresh_all"] = time.time() - t1
                 t1 = time.time()
             self._on_lamella_card_selected(
                 getattr(self, "_selected_card_lamella", None)

--- a/fibsem/applications/autolamella/ui/lamella_name_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_name_list_widget.py
@@ -159,33 +159,29 @@ class _LamellaRow(QWidget):
         # Redraw when the model changes, whichever widget changed it. Only `description`
         # was subscribed, so a defect set anywhere else left a stale icon here (FIB-564).
         #
-        # `task_state.name`/`.status` are written by the running workflow
-        # (`workflows/tasks/base.py:234,239`) on the FunctionWorker thread, and psygnal
-        # delivers synchronously on the emitting thread. This row skipped them for that
-        # reason until `refresh` gained @ensure_main_thread (FIB-565); with the callback
-        # marshalled they are safe, and the row now tracks a running workflow like
-        # `lamella_list_widget` and `lamella_card_widget` do.
+        # `defect` and `description` only: both are written by GUI widgets, on the GUI
+        # thread, and nothing else refreshes this list when one changes.
         #
-        # `defect` and `description` are only ever written by GUI widgets, so
-        # marshalling is a no-op for them: ensure_main_thread runs inline when the
-        # caller is already on the GUI thread.
+        # **Not** `task_state.name`/`.status`. FIB-565 added those so the row would
+        # follow a running workflow, and they crashed it:
         #
-        # No matching disconnect: the lamella outlives the row, but psygnal holds bound
-        # methods weakly and `set_lamella` keeps no reference to the rows it replaces, so
-        # a cleared row is collected and its subscriptions go with it. The decorator does
-        # not change that -- verified that a decorated bound method is still dropped on GC.
+        #     RuntimeError: wrapped C/C++ object of type QLabel has been deleted
+        #       lamella_name_list_widget.py in refresh -> name_label.setText(...)
+        #
+        # They are written from the workflow's FunctionWorker thread, so `refresh` is
+        # marshalled and arrives *later* -- by which point `set_lamella` may have
+        # replaced this row and Qt may have destroyed its widgets. psygnal holds bound
+        # methods weakly, which was the argument for not disconnecting, but that only
+        # covers the *Python* object: Qt's teardown does not wait for the collector, so
+        # a live weakref over a destroyed QLabel is exactly the reachable state.
+        #
+        # `AutoLamellaMainUI._on_workflow_update` drives this list instead, over a Qt
+        # signal, and it names the lamella that changed -- so it costs one
+        # `refresh_lamella` rather than a subscription per row, and the row follows a
+        # running workflow either way.
         # type: ignore because @evented adds .events dynamically.
         self.lamella.events.description.connect(self.refresh)  # type: ignore[union-attr]
         self.lamella.events.defect.connect(self.refresh)  # type: ignore[union-attr]
-
-        # Guarded, unlike the sibling widgets, because this list also renders duck-typed
-        # positions that are not `Lamella` and carry no `task_state` at all -- which is
-        # why `_lamella_status_text` reaches for it with `getattr` too. The siblings take
-        # real `Lamella` objects, where the field always exists.
-        task_state = getattr(self.lamella, "task_state", None)
-        if task_state is not None:
-            task_state.events.name.connect(self.refresh)  # type: ignore[union-attr]
-            task_state.events.status.connect(self.refresh)  # type: ignore[union-attr]
 
         self.refresh()
 
@@ -341,12 +337,27 @@ class LamellaNameListWidget(QWidget):
         self._restore_selection(current)
         self._list.blockSignals(False)
 
+    def refresh_lamella(self, lamella: Any) -> None:
+        """Refresh the one row displaying *lamella*, matched by identity.
+
+        The workflow path calls this rather than ``refresh_all``: a running workflow
+        changes one lamella at a time, and ``refresh_all`` is O(rows) of GUI-thread work
+        for it. A row repaint measures ~0.03 ms, two thirds of it the ``setStyleSheet``
+        re-parse, so 70 lamellae cost ~2.4 ms per update against ~0.05 ms here.
+
+        Identity, like ``LamellaListWidget.refresh_lamella``: rows and the caller's
+        ``get_lamella_by_name`` both come from ``experiment.positions``, and nothing
+        replaces an entry in it.
+        """
+        for row in self._rows():
+            if row.lamella is lamella:
+                row.refresh()
+                return
+
     def refresh_all(self) -> None:
         """Refresh the display of all rows (e.g. after status changes)."""
-        for i in range(self._list.count()):
-            row = self._list.itemWidget(self._list.item(i))
-            if isinstance(row, _LamellaRow):
-                row.refresh()
+        for row in self._rows():
+            row.refresh()
 
     # ------------------------------------------------------------------
     # Button visibility

--- a/tests/ui/test_lamella_defect_sync.py
+++ b/tests/ui/test_lamella_defect_sync.py
@@ -72,92 +72,52 @@ def test_row_redraws_when_the_defect_changes_elsewhere(row, lamella):
     )
 
 
-def test_row_redraws_from_a_task_state_event(row, lamella):
-    """The row subscribes to task_state, so a running workflow keeps it current.
+def test_the_row_does_not_subscribe_to_task_state(row, lamella):
+    """FIB-565 subscribed it; that is reverted, and the reason is worth keeping.
 
-    It deliberately did not, until FIB-565: `task_state.name`/`.status` are written by
-    the workflow on the FunctionWorker thread and psygnal delivers synchronously on the
-    emitting thread, so the callback reached Qt off the GUI thread. `refresh` is now
-    marshalled with @ensure_main_thread, which is what makes this safe -- see the
-    thread test below, which is the one that would catch the decorator being dropped.
+    `task_state.name`/`.status` are written by the workflow on the FunctionWorker
+    thread. @ensure_main_thread made the callback land on the GUI thread, which is
+    necessary and not sufficient: it also lands *later*, and by then `set_lamella` may
+    have replaced the row and Qt destroyed its widgets --
+
+        RuntimeError: wrapped C/C++ object of type QLabel has been deleted
+
+    -- reported from a workflow run. Marshalling fixes which thread touches the widget,
+    not whether the widget is still there.
+
+    The row is refreshed from `_on_workflow_update` now, on the same named-lamella call
+    as the two lists that were already refreshed there. `defect` and `description` keep
+    their subscriptions: both are GUI-thread writes, and nothing else refreshes this
+    list for them.
     """
-    from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
-
-    lamella.task_state.name = "Rough Milling"
-    lamella.task_state.status = AutoLamellaTaskStatus.InProgress
-
-    assert row.status_label.text() == "Rough Milling"
-
-
-def test_task_state_refresh_is_marshalled_to_the_gui_thread(qapp, row, lamella):
-    """A worker-thread write must redraw the row *on the GUI thread*.
-
-    This is the invariant FIB-565 turns on, and the only one that fails if
-    @ensure_main_thread is removed from `refresh`. Asserting the label updated is not
-    enough on its own: Qt does not raise on a cross-thread `setText`, it corrupts or
-    crashes under load, so an undecorated `refresh` would still leave the right text
-    behind and pass.
-
-    The thread is observed by spying on `setText`, which `refresh` calls. Patched on the
-    label instance rather than on `refresh`: psygnal captured the bound `refresh` at
-    connect time, so replacing it on the row afterwards is never seen by the signal.
-    """
-    import threading
-
-    from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
-
-    main_thread = threading.current_thread()
-    seen: list = []
-    original = row.status_label.setText
-
-    def spy(text: str) -> None:
-        seen.append(threading.current_thread())
-        original(text)
-
-    row.status_label.setText = spy  # type: ignore[method-assign]
-
-    def write_from_worker() -> None:
-        lamella.task_state.name = "Polishing"
-        lamella.task_state.status = AutoLamellaTaskStatus.InProgress
-
-    worker = threading.Thread(target=write_from_worker, name="fib565-worker")
-    worker.start()
-    worker.join()
-    qapp.processEvents()
-
-    assert seen, "the row never redrew -- the task_state subscription is missing"
-    assert all(t is main_thread for t in seen), (
-        f"refresh touched Qt from {[t.name for t in seen]}, not the GUI thread -- "
-        "@ensure_main_thread has been dropped from refresh"
+    assert len(lamella.task_state.events.status) == 0, (
+        "the row is connected to task_state.status again -- a cross-thread subscription "
+        "on a widget that gets replaced"
     )
-    assert row.status_label.text() == "Polishing"
+    assert len(lamella.task_state.events.name) == 0
+    assert len(lamella.events.defect) == 1, "the GUI-thread subscriptions must stay"
+    assert len(lamella.events.description) == 1
 
 
-def test_row_redraws_when_the_description_changes(row, lamella):
-    """The one subscription that already existed, kept honest while three were added."""
-    lamella.description = "edited elsewhere"
-    assert row.toolTip() == "edited elsewhere"
+def test_the_workflow_update_refreshes_the_name_list(row, lamella):
+    """What replaces the subscription. Without this the row goes stale mid-workflow.
 
-
-def test_row_survives_a_lamella_without_task_state(qapp):
-    """This list also takes plain positions, unlike its two siblings.
-
-    `_lamella_status_text` reaches for `task_state` with `getattr`, so subscribing to it
-    unconditionally would crash on exactly the objects that guard exists for.
+    Nothing else refreshed this list during a run -- unlike the workflow list and the
+    cards, which `_on_workflow_update` already covered -- so removing the subscription
+    without adding this would have traded a crash for a stale display.
     """
-    from dataclasses import dataclass, field
+    import inspect
 
-    from psygnal import evented
+    from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+        AutoLamellaSingleWindowUI,
+    )
 
-    @evented
-    @dataclass
-    class PlainPosition:
-        name: str = "P1"
-        description: str = ""
-        defect: object = None
-        # deliberately no task_state
+    source = inspect.getsource(AutoLamellaSingleWindowUI._on_workflow_update)
 
-    _LamellaRow(PlainPosition())  # must not raise
+    assert "autolamella_ui.lamella_list.refresh_lamella(" in source, (
+        "`_on_workflow_update` does not refresh the name list, and the row no longer "
+        "subscribes -- so nothing keeps it current while a workflow runs"
+    )
 
 
 @pytest.mark.parametrize(
@@ -194,10 +154,11 @@ def test_every_host_of_the_list_can_persist_a_defect(module, widget, handler):
 @pytest.mark.parametrize(
     "module, widget",
     [
-        (
-            "fibsem.applications.autolamella.ui.lamella_name_list_widget",
-            "_LamellaRow",
-        ),
+        # `_LamellaRow` is deliberately absent: it no longer subscribes to task_state at
+        # all. The marshalled callback still arrived after `set_lamella` had replaced the
+        # row and Qt had destroyed its widgets -- @ensure_main_thread makes the *thread*
+        # right and says nothing about whether the receiver still exists. It is refreshed
+        # from `_on_workflow_update` instead, like the other two.
         ("fibsem.applications.autolamella.ui.lamella_list_widget", "LamellaRowWidget"),
         (
             "fibsem.applications.autolamella.ui.lamella_card_widget",

--- a/tests/ui/test_lamella_row_task_state.py
+++ b/tests/ui/test_lamella_row_task_state.py
@@ -1,0 +1,206 @@
+"""A lamella row does not subscribe to task state across threads.
+
+Reported from a workflow run:
+
+    RuntimeError: wrapped C/C++ object of type QLabel has been deleted
+      lamella_name_list_widget.py in refresh -> self.name_label.setText(...)
+
+FIB-565 subscribed the row to `task_state.events.name` / `.status` so it would follow a
+running workflow. Those are written from the workflow's FunctionWorker thread, so
+`refresh` is marshalled and arrives *later* — by which point `set_lamella` may have
+replaced the row and Qt may have destroyed its widgets.
+
+The comment above those connections argued no disconnect was needed, because psygnal
+holds bound methods weakly and a dropped row would be collected. True of the Python
+object and beside the point: Qt's teardown does not wait for the collector, so a live
+weakref over a destroyed QLabel is exactly the reachable state. Same family as FIB-550.
+
+The fix is removal rather than a disconnect. What replaces it is
+`AutoLamellaMainUI._on_workflow_update`, which already refreshed the workflow list and
+the cards on every update, over a Qt signal -- and already knew *which* lamella changed,
+so the name list joins them on `refresh_lamella` rather than `refresh_all`. A workflow
+touches one lamella at a time, and `refresh_all` is O(rows) of GUI-thread work for it:
+~2.4 ms per update at 70 lamellae, against ~0.05 ms targeted.
+
+`defect` and `description` stay. They are written by GUI widgets on the GUI thread, and
+nothing else refreshes this list when one changes (FIB-564).
+"""
+
+import ast
+import inspect
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+import textwrap
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskState,
+    AutoLamellaTaskStatus,
+    Lamella,
+)
+from fibsem.applications.autolamella.ui.lamella_name_list_widget import (
+    LamellaNameListWidget,
+    _LamellaRow,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def lamella(tmp_path, number: int = 1) -> Lamella:
+    lam = Lamella(
+        path=str(tmp_path / f"lam{number}"), number=number, petname=f"lam-{number}"
+    )
+    lam.task_state = AutoLamellaTaskState(name="MillTrench")
+    return lam
+
+
+@pytest.fixture
+def widget():
+    w = LamellaNameListWidget()
+    yield w
+    w.deleteLater()
+
+
+class TestItDoesNotSubscribeAcrossThreads:
+    def test_the_row_does_not_connect_to_task_state(self):
+        """Structural, and the whole fix.
+
+        Behavioural coverage cannot carry this alone: reaching the crash needs the row's
+        C++ object destroyed while its Python wrapper lives, and `QListWidget.clear()`
+        does not destroy it in an offscreen test — measured with `sip.isdeleted`. So what
+        is pinned is the absence of the subscription, since that is what makes the state
+        unreachable however it would otherwise have been arrived at.
+        """
+        source = textwrap.dedent(inspect.getsource(_LamellaRow.__init__))
+        connects = [
+            ast.unparse(node)
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "connect"
+        ]
+        task_state_subscriptions = [c for c in connects if "task_state" in c]
+
+        assert task_state_subscriptions == [], (
+            f"the row subscribes to {task_state_subscriptions} — written from the "
+            f"workflow thread and delivered to a row that may have been replaced by "
+            f"then. `_on_workflow_update` already calls `refresh_all()` for this"
+        )
+
+    def test_the_row_is_not_connected_to_task_state(self, widget, tmp_path):
+        """The behavioural counterpart, asserted on the connection itself.
+
+        Not by counting calls: psygnal binds the method at connect time, so replacing
+        `row.refresh` afterwards intercepts nothing and such a test passes against the
+        unfixed code too. `len(signal)` is the number of live callbacks, which is the
+        thing that actually decides whether the row can be reached.
+        """
+        lam = lamella(tmp_path, 1)
+
+        widget.set_lamella([lam])
+
+        assert len(lam.task_state.events.status) == 0, (
+            "the row is connected to task_state.status — written from the workflow "
+            "thread, delivered to a row that may since have been replaced"
+        )
+        assert len(lam.task_state.events.name) == 0
+
+
+class TestWhatItStillFollows:
+    def test_it_still_follows_defect_and_description(self, widget, tmp_path):
+        """GUI-thread writes, and nothing else refreshes the list for them (FIB-564)."""
+        lam = lamella(tmp_path, 1)
+
+        widget.set_lamella([lam])
+
+        assert len(lam.events.defect) == 1, "the row stopped following defect changes"
+        assert len(lam.events.description) == 1
+
+    def test_refresh_lamella_is_what_follows_a_workflow(self, widget, tmp_path):
+        """What replaces the subscription, and it must actually update the row."""
+        lamellae = [lamella(tmp_path, i) for i in range(1, 4)]
+        widget.set_lamella(lamellae)
+        running = lamellae[1]
+        running.task_state.name = "MillPolishing"
+        running.task_state.status = AutoLamellaTaskStatus.InProgress
+
+        widget.refresh_lamella(running)
+
+        row = widget._list.itemWidget(widget._list.item(1))
+        assert row.status_label.text() == "MillPolishing", (
+            "refresh_lamella did not bring the row up to date, so removing the "
+            "subscription does lose the live status after all"
+        )
+
+    def test_it_refreshes_only_the_lamella_that_changed(
+        self, widget, tmp_path, monkeypatch
+    ):
+        """The reason it is not `refresh_all`.
+
+        A workflow update names one lamella; repainting the rest is O(rows) of
+        GUI-thread work for nothing, on every update of a run (~2.4 ms at 70 lamellae,
+        mostly `setStyleSheet` re-parsing). Patching the class attribute works where the
+        psygnal equivalent did not -- `refresh_lamella` looks the method up on the
+        instance each call, rather than having bound it once.
+        """
+        lamellae = [lamella(tmp_path, i) for i in range(1, 4)]
+        widget.set_lamella(lamellae)
+        refreshed: list = []
+        monkeypatch.setattr(
+            _LamellaRow, "refresh", lambda self: refreshed.append(self.lamella.name)
+        )
+
+        widget.refresh_lamella(lamellae[1])
+
+        assert refreshed == [lamellae[1].name], (
+            f"refreshed {refreshed} for a change to one lamella -- every extra row is a "
+            f"wasted repaint on every workflow update"
+        )
+
+    def test_refresh_all_remains_for_an_unidentified_lamella(self, widget, tmp_path):
+        """The fallback branch: no name to match on, so every row is refreshed."""
+        lamellae = [lamella(tmp_path, i) for i in range(1, 4)]
+        widget.set_lamella(lamellae)
+        for lam in lamellae:
+            lam.task_state.name = "MillPolishing"
+            lam.task_state.status = AutoLamellaTaskStatus.InProgress
+
+        widget.refresh_all()
+
+        for i in range(widget._list.count()):
+            row = widget._list.itemWidget(widget._list.item(i))
+            assert row.status_label.text() == "MillPolishing"
+
+    def test_the_main_ui_refreshes_the_name_list_on_every_workflow_update(self):
+        """The claim that makes removal a fix rather than a trade.
+
+        Both branches, because they are what the subscription is traded for: the named
+        one on the path a running workflow takes, `refresh_all` when the update cannot
+        be tied to a lamella.
+        """
+        from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+            AutoLamellaSingleWindowUI,
+        )
+
+        source = inspect.getsource(AutoLamellaSingleWindowUI._on_workflow_update)
+
+        # `autolamella_ui.lamella_list`, not `lamella_list_widget`. Those are different
+        # widgets -- `lamella_list_widget` is the *workflow* list, which was already
+        # refreshed here and is not the one this file is about. An earlier version
+        # asserted the wrong one and passed while proving nothing.
+        assert "autolamella_ui.lamella_list.refresh_lamella(" in source, (
+            "`_on_workflow_update` no longer refreshes the name list, so nothing "
+            "follows a running workflow now that the subscription is gone"
+        )
+        assert "autolamella_ui.lamella_list.refresh_all()" in source, (
+            "the name list is not refreshed when the update names no lamella, so it "
+            "goes stale on exactly the updates the other two lists still handle"
+        )


### PR DESCRIPTION
Closes FIB-603. Your second traceback:

```
RuntimeError: wrapped C/C++ object of type QLabel has been deleted
  lamella_name_list_widget.py:225 in refresh -> self.name_label.setText(...)
```

FIB-565 subscribed `_LamellaRow` to `task_state.events.name` / `.status` so it would follow a running workflow, and marshalled `refresh` with `@ensure_main_thread` to make that safe.

Marshalling fixes *which thread* touches the widget and says nothing about *whether the widget still exists*. The workflow writes from its FunctionWorker thread, so the callback arrives later — and by then `set_lamella` may have replaced the row and Qt destroyed its labels.

The comment above those connections argued no disconnect was needed, because psygnal holds bound methods weakly and a dropped row gets collected. True of the Python object and beside the point: Qt's teardown does not wait for the collector, so a live weakref over a destroyed QLabel is exactly the reachable state. Same family as FIB-550.

## Removal, not a disconnect

I wrote a `detach` / `_detach_rows` pair first and threw it away — lifecycle bookkeeping to preserve a subscription that did not need to exist. Patrick's call, and the right one.

**But removal alone would have been a trade, and that is the part worth checking.** I claimed the subscription was redundant because `_on_workflow_update` calls `refresh_all()`; it does, on the *workflow* list and the cards — not this one. Nothing refreshed the name list mid-workflow. So it is driven from there now, on the same Qt signal.

## One row, not the whole list

`_on_workflow_update` already knows *which* lamella changed — `item_name` in the status message is always `lamella.name`. So the name list joins the other two on that branch, with a new `refresh_lamella`, rather than the `refresh_all()` this PR originally had.

A workflow touches one lamella at a time, and `refresh_all` is O(rows) of GUI-thread work for it. Measured at 70 rows:

| | per workflow update |
|---|---|
| `refresh_all` | 2.4 ms |
| `refresh_lamella` | 0.05 ms |

Two thirds of the ~0.03 ms row repaint is the `setStyleSheet` re-parse. Not the icon render — I wrote that into the comments first, then measured it at ~0.006 ms and cached, so the comments now name `setStyleSheet`.

`refresh_all` stays on the fallback branch, where the update names no lamella to match — exactly as it already does for the other two lists.

Identity match, like `LamellaListWidget.refresh_lamella`: rows and `get_lamella_by_name` both come from `experiment.positions`, and nothing in the tree replaces an entry in it.

`defect` and `description` keep their subscriptions — GUI-thread writes, and nothing else refreshes this list when one changes (FIB-564).

## Not fixed here

`lamella_list_widget` and `lamella_card_widget` hold the same cross-thread subscription. They are refreshed by name from `_on_workflow_update`, so their rows are not replaced the same way — but the hazard is the same shape, and the card widget is where FIB-602 surfaced. Noted on FIB-603 rather than assumed safe.

## Testing

`test_lamella_defect_sync` enforced the old design and anticipated this — *"if that is deliberate, this test and FIB-565 both need updating"*. Both updated: the two behavioural tests now pin the absence of the subscription and the presence of the refresh, and `_LamellaRow` is out of the must-marshal parametrisation with the reason recorded.

Every new test was run against code without the fix. Two check the targeted refresh specifically: putting `refresh_all()` back in `_on_workflow_update` fails the two source assertions, and making `refresh_lamella` loop over every row fails the counting test.

Two earlier drafts passed unfixed and were replaced: reaching the crash needs the row's C++ object destroyed while its Python wrapper lives, and `QListWidget.clear()` does not do that in an offscreen test (measured with `sip.isdeleted`) — and counting calls by reassigning `row.refresh` intercepts nothing, because psygnal bound the method at connect time. `len(signal)` is the assertion that actually holds. (The new counting test patches the *class* attribute, which `refresh_lamella` does look up per call.)

`tests/ui/` + `tests/autolamella/` — 1621 passed, 1 skipped.
