### PR TITLE
[ui] Delete the unreachable half of the napari helper package

### DIFF
--- a/fibsem/ui/napari/patterns.py
+++ b/fibsem/ui/napari/patterns.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import logging
-import time
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional, Tuple, Dict, Any, Set, Union, Type
+from typing import List, Optional, Tuple, Dict, Any, Set, Union, Type
 
-import matplotlib.pyplot as plt
 from matplotlib.colors import to_rgba
 import napari
 import numpy as np
@@ -33,8 +31,7 @@ from fibsem.structures import (
     Point,
     calculate_fiducial_area_v2,
 )
-from fibsem.milling.patterning.utils import create_pattern_mask
-from fibsem.ui.napari.properties import ALIGNMENT_LAYER_PROPERTIES, MILLING_FOV_LAYER_PROPERTIES
+from fibsem.ui.napari.properties import ALIGNMENT_LAYER_PROPERTIES
 
 # colour wheel
 COLOURS = ["yellow", "cyan", "magenta", "lime", "orange", "hotpink", "green", "blue", "red", "purple"]
@@ -563,161 +560,6 @@ def draw_milling_patterns_in_napari(
     )
 
     return layer_name_list  # list of milling pattern layers
-
-def draw_alignment_area(viewer: napari.Viewer,
-                        reduced_area: FibsemRectangle,
-                        image_shape: Tuple[int, int],
-                        translate: Tuple[float, float]):
-    """Draw the alignment area layer in napari.
-    Args:
-        viewer: napari viewer instance
-        reduced_area: FibsemRectangle defining the alignment area
-        image_shape: shape of the image to draw on
-        translate: translation of the FIB image layer
-    Returns:
-        layer_name: name of the alignment area layer"""
-
-    # add alignment area to napari
-    data = convert_reduced_area_to_napari_shape(reduced_area=reduced_area,
-                                                image_shape=image_shape,
-                                                )
-    layer_name = MILLING_ALIGNMENT_AREA_LAYER_NAME
-    if layer_name in viewer.layers:
-        viewer.layers.remove(layer_name)
-
-    viewer.add_shapes(data=data, name=layer_name,
-        shape_type=ALIGNMENT_LAYER_PROPERTIES["shape_type"],
-        edge_color=ALIGNMENT_LAYER_PROPERTIES["edge_color"],
-        edge_width=ALIGNMENT_LAYER_PROPERTIES["edge_width"],
-        face_color=ALIGNMENT_LAYER_PROPERTIES["face_color"],
-        opacity=ALIGNMENT_LAYER_PROPERTIES["opacity"],
-        translate=translate) # match the fib layer translation
-
-    return layer_name
-
-
-def setup_editable_alignment_layer(
-    viewer: napari.Viewer,
-    reduced_area: FibsemRectangle,
-    image_shape: Tuple[int, int],
-    translate: Tuple[float, float],
-    on_change: Callable[[FibsemRectangle], None],
-    editable: bool = True,
-) -> None:
-    """Create or update an alignment area shapes layer.
-
-    If the layer already exists it is updated in-place (preserving the event
-    connection).  If it does not exist it is created and on_change is connected
-    to layer.events.data.
-
-    Args:
-        viewer: napari viewer instance
-        reduced_area: initial rectangle to display
-        image_shape: (H, W) of the reference image — used for coordinate conversion
-        translate: translation of the FIB image layer
-        on_change: called with the updated FibsemRectangle after each drag/resize
-        editable: if True, activate the layer in select mode; if False, set pan_zoom
-    """
-    data = convert_reduced_area_to_napari_shape(reduced_area, image_shape)
-    layer_name = MILLING_ALIGNMENT_AREA_LAYER_NAME
-
-    if layer_name in viewer.layers:
-        shapes_layer: NapariShapesLayers = viewer.layers[layer_name]  # type: ignore
-        shapes_layer.data = data
-    else:
-        shapes_layer = viewer.add_shapes(
-            data=data,
-            name=layer_name,
-            shape_type=ALIGNMENT_LAYER_PROPERTIES["shape_type"],
-            edge_color=ALIGNMENT_LAYER_PROPERTIES["edge_color"],
-            edge_width=ALIGNMENT_LAYER_PROPERTIES["edge_width"],
-            face_color=ALIGNMENT_LAYER_PROPERTIES["face_color"],
-            opacity=ALIGNMENT_LAYER_PROPERTIES["opacity"],
-            translate=translate,
-        )
-
-        def _on_data_changed(event):
-            layer_data = shapes_layer.data
-            if not layer_data:
-                return
-            rect = convert_shape_to_image_area(layer_data[0], image_shape)
-            on_change(rect)
-
-        shapes_layer.events.data.connect(_on_data_changed)
-
-    shapes_layer.visible = True
-    if editable:
-        viewer.layers.selection.active = shapes_layer
-        shapes_layer.mode = "select"
-        shapes_layer.selected_data.clear()
-    else:
-        shapes_layer.mode = "pan_zoom"
-
-
-def draw_milling_fov_rect(
-    viewer: napari.Viewer,
-    image_layer: NapariImageLayer,
-    field_of_view: float,
-    pixelsize: float,
-) -> Optional[str]:
-    """Draw a rectangle showing the milling FOV when it is smaller than the image FOV.
-
-    Args:
-        viewer: napari viewer instance
-        image_layer: the reference image layer
-        field_of_view: milling horizontal field of view in metres
-        pixelsize: image pixel size in metres/pixel
-    Returns:
-        layer name if drawn, else None
-    """
-    image_shape = image_layer.data.shape
-    image_fov = pixelsize * image_shape[1]
-    layer_name = MILLING_FOV_LAYER_NAME
-
-    if field_of_view >= image_fov:
-        if layer_name in viewer.layers:
-            viewer.layers.remove(layer_name)
-        return None
-
-    ratio = field_of_view / image_fov
-    cy, cx = image_shape[0] / 2, image_shape[1] / 2
-    half_h = ratio * image_shape[0] / 2
-    half_w = ratio * image_shape[1] / 2
-    data = np.array([
-        [cy - half_h, cx - half_w],
-        [cy - half_h, cx + half_w],
-        [cy + half_h, cx + half_w],
-        [cy + half_h, cx - half_w],
-    ])
-
-    fov_um = field_of_view * 1e6
-    label = f"Milling FOV ({fov_um:.0f}um)"
-    text_props = {
-        "string": [label],
-        "size": 12,
-        "color": "white",
-        "anchor": "upper_left",
-        "translation": np.array([5, 5]),
-    }
-
-    if layer_name in viewer.layers:
-        viewer.layers[layer_name].data = [data]
-        viewer.layers[layer_name].text.string = [label]
-    else:
-        viewer.add_shapes(
-            data=[data],
-            name=layer_name,
-            shape_type=MILLING_FOV_LAYER_PROPERTIES["shape_type"],
-            edge_color=MILLING_FOV_LAYER_PROPERTIES["edge_color"],
-            edge_width=MILLING_FOV_LAYER_PROPERTIES["edge_width"],
-            face_color=MILLING_FOV_LAYER_PROPERTIES["face_color"],
-            opacity=MILLING_FOV_LAYER_PROPERTIES["opacity"],
-            translate=image_layer.translate,
-            text=text_props,
-        )
-
-    return layer_name
-
 
 def convert_point_to_napari(resolution: list, pixel_size: float, centre: Point):
     icy, icx = resolution[1] // 2, resolution[0] // 2

--- a/fibsem/ui/napari/properties.py
+++ b/fibsem/ui/napari/properties.py
@@ -13,28 +13,6 @@ ALIGNMENT_LAYER_PROPERTIES = {
     "metadata": {"type": "alignment"},
 }
 
-MILLING_FOV_LAYER_PROPERTIES = {
-    "name": "milling_fov",
-    "shape_type": "rectangle",
-    "edge_color": "white",
-    "edge_width": 5,
-    "face_color": "transparent",
-    "opacity": 0.8,
-}
-
-IMAGE_TEXT_LAYER_PROPERTIES = {
-    "name": "label",
-    "text": {
-        "string": ["ELECTRON BEAM", "ION BEAM"],
-        "color": "white"
-    },
-    "size": 20,
-    "border_width": 7,
-    "border_width_is_relative": False,
-    "border_color": "transparent",
-    "face_color": "transparent",
-}
-
 IMAGING_CROSSHAIR_LAYER_PROPERTIES = {
     "name": "crosshair",
     "shape_type": "line",
@@ -60,27 +38,6 @@ IMAGING_SCALEBAR_LAYER_PROPERTIES = {
         "sze": 20,
     },
 }
-
-IMAGING_RULER_LAYER_PROPERTIES = {
-    "name": "ruler",
-    "size": 20,
-    "face_color": "lime",
-    "edge_color": "white",
-    "text": {
-        "color": "white",
-        "translation": np.array([-20, 0]),
-        "size": 10,
-    },
-    "line-layer": {
-         "name": "ruler_line",
-         "shape_type": "line",
-         "edge_width": 5,
-         "edge_color": "lime",
-    },
-}
-
-RULER_LAYER_NAME = IMAGING_RULER_LAYER_PROPERTIES["name"]
-RULER_LINE_LAYER_NAME = IMAGING_RULER_LAYER_PROPERTIES["line-layer"]["name"]
 
 # MILLING
 
@@ -108,33 +65,3 @@ CORRELATION_IMAGE_LAYER_PROPERTIES = {
     "colours": ["green", "cyan", "magenta", "red", "yellow"],
 }
 
-STAGE_POSITION_SHAPE_LAYER_PROPERTIES = {
-    "name": "stage-positions",
-    "shape_type": "line",
-    "edge_width": 5,
-    "edge_color": "yellow",
-    "face_color": "yellow",
-    "opacity": 0.8,
-    "blending": "translucent",
-    "text": {
-        "string": [],
-        "color": "white",
-        "size": 15,
-        "translation": np.array([-50, 0]), # text shown 50px above the point
-    },
-    "saved_color": "lime",
-}
-
-POINT_LAYER_PROPERTIES = {
-    "name": "Points",
-    "text": {"string": [], "color": "white"},
-    "size": 10,
-    "border_width": 1,
-    "border_width_is_relative": True,
-    "border_color": "white",
-    "face_color": "white",
-    "blending": "translucent",
-    "symbol": "o",
-    "ndim": 2,
-    "opacity": 1.0,
-}

--- a/fibsem/ui/napari/utilities.py
+++ b/fibsem/ui/napari/utilities.py
@@ -1,10 +1,9 @@
 import logging
-from typing import Any, List, Optional, Tuple
+from typing import List, Optional, Tuple
 from dataclasses import dataclass
 
 import napari
 import numpy as np
-from napari.layers import Points as NapariPointsLayer
 
 try:
     from packaging.version import InvalidVersion, Version
@@ -15,14 +14,12 @@ from fibsem import constants
 from fibsem.microscope import FibsemMicroscope
 from fibsem.microscopes.tescan import TescanMicroscope
 from fibsem.structures import (
-    FibsemImage,
     FibsemStagePosition,
     Point,
 )
 from fibsem.ui.napari.properties import (
     IMAGING_CROSSHAIR_LAYER_PROPERTIES,
     IMAGING_SCALEBAR_LAYER_PROPERTIES,
-    POINT_LAYER_PROPERTIES,
 )
 
 CROSSHAIR_LAYER_NAME = IMAGING_CROSSHAIR_LAYER_PROPERTIES["name"]
@@ -36,200 +33,6 @@ class NapariShapeOverlay:
     label: str
     shape_type: str  # "rectangle", "ellipse", or "line"
 
-
-
-def draw_crosshair_in_napari(
-    viewer: napari.Viewer,
-    sem_shape: Tuple[int, int],
-    fib_shape: Optional[Tuple[int, int]] = None,
-    fm_shape: Optional[Tuple[int, int]] = None,
-    is_checked: bool = False,
-    size_ratio: float = 0.05,
-) -> None:
-    """Draw a crosshair in the napari viewer at the centre of each image. 
-    The crosshair is drawn using the shapes layer in napari.
-    Args:
-        viewer: napari viewer object
-        sem_shape: shape of the SEM image
-        fib_shape: shape of the FIB image (Optional)
-        fm_shape: shape of the FM image (Optional)
-        is_checked: boolean value to check if the crosshair is displayed
-        size_ratio: size of the crosshair (percentage of the image size)
-    """
-
-    layers_in_napari = []
-    for layer in viewer.layers:
-        layers_in_napari.append(layer.name)
-
-    if not is_checked:
-        if CROSSHAIR_LAYER_NAME in layers_in_napari:
-            viewer.layers[CROSSHAIR_LAYER_NAME].opacity = 0
-            return
-
-    # get the centre points of the images
-    crosshair_centres = [[sem_shape[0] // 2, sem_shape[1] // 2]]
-    if fib_shape is not None:
-        fib_centre = [fib_shape[0] // 2, sem_shape[1] + fib_shape[1] // 2]
-        crosshair_centres.append(fib_centre)
-    if fm_shape is not None:
-        fm_centre = [sem_shape[0] + fm_shape[0] // 2, fm_shape[1] // 2]
-        crosshair_centres.append(fm_centre)
-
-    # compute the size of the crosshair
-    size_px = size_ratio * sem_shape[1]
-
-    crosshairs = []
-    for cy, cx in crosshair_centres:
-        horizontal_line = [[cy, cx - size_px], [cy, cx + size_px]]
-        vertical_line = [[cy - size_px, cx], [cy + size_px, cx]]
-        crosshairs.extend([horizontal_line, vertical_line])
-
-    # create a crosshair using shapes layer, or update the existing one
-    if CROSSHAIR_LAYER_NAME not in layers_in_napari:
-        viewer.add_shapes(
-            data=crosshairs,
-            shape_type=IMAGING_CROSSHAIR_LAYER_PROPERTIES["shape_type"],
-            edge_width=IMAGING_CROSSHAIR_LAYER_PROPERTIES["edge_width"],
-            edge_color=IMAGING_CROSSHAIR_LAYER_PROPERTIES["edge_color"],
-            face_color=IMAGING_CROSSHAIR_LAYER_PROPERTIES["face_color"],
-            opacity=IMAGING_CROSSHAIR_LAYER_PROPERTIES["opacity"],
-            blending=IMAGING_CROSSHAIR_LAYER_PROPERTIES["blending"],
-            name=CROSSHAIR_LAYER_NAME,
-        )
-    else:
-        viewer.layers[CROSSHAIR_LAYER_NAME].data = crosshairs
-        viewer.layers[CROSSHAIR_LAYER_NAME].opacity = 0.8
-
-def _scale_length_value(hfw: float) -> Tuple[float, float]:
-    scale_length_value = hfw * constants.METRE_TO_MICRON * 0.2
-
-    if scale_length_value > 0 and scale_length_value < 100:
-        scale_length_value = round(scale_length_value / 5) * 5
-    if scale_length_value > 100 and scale_length_value < 500:
-        scale_length_value = round(scale_length_value / 25) * 25
-    if scale_length_value > 500 and scale_length_value < 1000:
-        scale_length_value = round(scale_length_value / 50) * 50
-
-    scale_ratio = scale_length_value / (hfw * constants.METRE_TO_MICRON)
-
-    return scale_ratio, scale_length_value
-
-def draw_scalebar_in_napari(
-    viewer: napari.Viewer,
-    sem_shape: Tuple[int, int],
-    sem_fov: float,
-    fib_shape: Tuple[int, int],
-    fib_fov: float,
-    is_checked: bool = False,
-    width: float = 0.1,
-) -> None:
-    """Draw a scalebar in napari viewer for each image independently."""
-    layers_in_napari = []
-    for layer in viewer.layers:
-        layers_in_napari.append(layer.name)
-
-    # if not showing the scalebar, hide the layer and return
-    if not is_checked:
-        if SCALEBAR_LAYER_NAME in layers_in_napari:
-            viewer.layers[SCALEBAR_LAYER_NAME].opacity = 0
-        return
-
-    h, w = 0.9, 0.15
-    location_points = [
-        [int(sem_shape[0] * h), int(sem_shape[1] * w)],
-        [int(fib_shape[0] * h), int(sem_shape[1] + fib_shape[1] * w)],
-    ]
-
-    # making the scale bar line
-    scale_bar_shape = []
-    scale_bar_txt = []
-    h1 = 25
-    h2 = 50
-
-    for i, pt in enumerate(location_points):
-        if i == 0:
-            scale_ratio, scale_value = _scale_length_value(sem_fov)
-            length = scale_ratio * sem_shape[1]
-        else:
-            scale_ratio, scale_value = _scale_length_value(fib_fov)
-            length = scale_ratio * fib_shape[1]
-
-        hwidth = 0.5 * length
-        main_line = [
-            [pt[0] + h1, int(pt[1] - hwidth)],
-            [pt[0] + h1, int(pt[1] + hwidth)],
-        ]
-        left_line = [
-            [pt[0] + h2, int(pt[1] - hwidth)],
-            [pt[0], int(pt[1] - hwidth)],
-        ]
-        right_line = [
-            [pt[0] + h2, int(pt[1] + hwidth)],
-            [pt[0], int(pt[1] + hwidth)],
-        ]
-        scale_bar_shape.extend([main_line, left_line, right_line])
-        scale_bar_txt.extend([f"{scale_value} um", "", ""])
-
-    scale_bar_txt = {
-        "string": scale_bar_txt,
-        "color": IMAGING_SCALEBAR_LAYER_PROPERTIES["text"]["color"],
-        "translation": IMAGING_SCALEBAR_LAYER_PROPERTIES["text"]["translation"],
-    }
-
-    if SCALEBAR_LAYER_NAME not in layers_in_napari:
-        viewer.add_shapes(
-            data=scale_bar_shape,
-            shape_type=IMAGING_SCALEBAR_LAYER_PROPERTIES["shape_type"],
-            edge_width=IMAGING_SCALEBAR_LAYER_PROPERTIES["edge_width"],
-            edge_color=IMAGING_SCALEBAR_LAYER_PROPERTIES["edge_color"],
-            name=SCALEBAR_LAYER_NAME,
-            text=scale_bar_txt,
-            opacity=1,
-        )
-    else:
-        viewer.layers[SCALEBAR_LAYER_NAME].data = scale_bar_shape
-        viewer.layers[SCALEBAR_LAYER_NAME].opacity = 1
-        viewer.layers[SCALEBAR_LAYER_NAME].text = scale_bar_txt
-
-
-def is_position_inside_layer(position: Tuple[float, float], target_layer) -> bool:
-    """Check if the position of the event is inside the bounds of the target layer.
-    Args:
-        event: napari event object containing the position
-        target_layer: the layer to check against
-    Returns:
-        bool: True if the position is inside the layer bounds, False otherwise.
-    """
-    coords = target_layer.world_to_data(position)
-
-    extent_min = target_layer.extent.data[0]  # (z, y, x)
-    extent_max = target_layer.extent.data[1]
-
-    # if they are 4d, remove the first dimension
-    if len(coords) == 4:
-        logging.warning(f"4D coordinates detected: {coords}, removing first dimension")
-        coords = coords[1:]
-        extent_min = extent_min[1:]
-        extent_max = extent_max[1:]
-
-    # convert the above logs into a json msg
-    msgd = {
-        "target_layer": target_layer.name,
-        "event_position": position,
-        "coords": coords,
-        "extent_min": extent_min,
-        "extent_max": extent_max,
-    }
-    logging.debug(msgd)
-
-    for i, coord in enumerate(coords):
-        if coord < extent_min[i] or coord > extent_max[i]:
-            logging.debug(
-                f"Coordinate {coord} is out of bounds ({extent_min[i]}, {extent_max[i]})"
-            )
-            return False
-
-    return True
 
 
 def create_crosshair_shape(point: Point, size: int, scale: Optional[Tuple[float, float]] = None) -> List[np.ndarray]:
@@ -450,95 +253,3 @@ def update_text_overlay(viewer: napari.Viewer, microscope: FibsemMicroscope,
         viewer.text_overlay.position = "bottom_left"
 
 
-def _napari_supports_border_width() -> bool:
-    """Return True if the installed napari version uses border width terminology."""
-    version_str = napari.__version__
-    if Version is not None:
-        try:
-            return Version(version_str) >= Version("0.5.0")
-        except InvalidVersion:
-            logging.debug("Unable to parse napari version with packaging: %s", version_str)
-
-    try:
-        parts = version_str.split(".")
-        parts = [int("".join(filter(str.isdigit, p)) or 0) for p in parts[:3]]
-        parts.extend([0] * (3 - len(parts)))
-        return tuple(parts[:3]) >= (0, 5, 0)
-    except Exception:
-        logging.debug("Unable to parse napari version string: %s", version_str)
-        return False
-
-
-def add_points_layer(
-    viewer: napari.Viewer,
-    data: np.ndarray,
-    name: str = "Points",
-    size: int = 10,
-    text: Optional[dict] = None,
-    border_width: int = 1,
-    border_width_is_relative: bool = True,
-    border_color: str = "white",
-    face_color: str = "white",
-    blending: str = "translucent",
-    symbol: str = "o",
-    ndim: int = 2,
-    opacity: float = 1.0,
-    **kwargs: Any,
-) -> NapariPointsLayer:
-    """Version-agnostic helper for adding point annotations to napari."""
-    defaults = POINT_LAYER_PROPERTIES
-    layer_name = defaults["name"] if name is None else name
-    layer_size = defaults["size"] if size is None else size
-    layer_text = defaults["text"] if text is None else text
-    layer_blending = defaults["blending"] if blending is None else blending
-    layer_symbol = defaults["symbol"] if symbol is None else symbol
-    layer_ndim = defaults["ndim"] if ndim is None else ndim
-    layer_opacity = defaults["opacity"] if opacity is None else opacity
-    layer_border_width = (
-        defaults["border_width"] if border_width is None else border_width
-    )
-    layer_border_width_is_relative = (
-        defaults["border_width_is_relative"]
-        if border_width_is_relative is None
-        else border_width_is_relative
-    )
-    layer_border_color = (
-        defaults["border_color"] if border_color is None else border_color
-    )
-    layer_face_color = (
-        defaults["face_color"] if face_color is None else face_color
-    )
-
-    layer_kwargs = {
-        "data": data,
-        "name": layer_name,
-        "size": layer_size,
-        "text": layer_text,
-        "blending": layer_blending,
-        "symbol": layer_symbol,
-        "ndim": layer_ndim,
-        "opacity": layer_opacity,
-    }
-
-    if _napari_supports_border_width():
-        layer_kwargs.update(
-            {
-                "border_width": layer_border_width,
-                "border_width_is_relative": layer_border_width_is_relative,
-                "border_color": layer_border_color,
-                "face_color": layer_face_color,
-            }
-        )
-    else:
-        layer_kwargs.update(
-            {
-                "edge_width": layer_border_width,
-                "edge_width_is_relative": layer_border_width_is_relative,
-                "edge_color": layer_border_color,
-                "face_color": layer_face_color,
-            }
-        )
-
-    layer_kwargs.update(kwargs)
-
-    return viewer.add_points(**layer_kwargs)


### PR DESCRIPTION
**523 lines out, 3 in.** No behaviour change — every function and constant removed here has
zero callers.

`fibsem/ui/napari/` is the last thing keeping the matplotlib canvas coupled to napari, so it
needs a geometry extraction before it can go. Measuring it first showed that roughly a third
of it is simply unreachable, and deleting that part is independent of both the extraction and
the minimap rebuild — so it goes first, on its own.

## What went

| file | lines | |
|---|---|---|
| `patterns.py` | 160 | `draw_alignment_area`, `setup_editable_alignment_layer`, `draw_milling_fov_rect` |
| `utilities.py` | 290 | `draw_crosshair_in_napari`, `draw_scalebar_in_napari`, `is_position_inside_layer`, `add_points_layer`, plus `_scale_length_value` / `_napari_supports_border_width` whose only callers were those four |
| `properties.py` | 73 | seven orphaned layer-property dicts |

## Attribution

Not all of this is fallout from this change, and the commit says so rather than letting it
read that way. Two constants (`MILLING_FOV_LAYER_PROPERTIES`, `POINT_LAYER_PROPERTIES`) and
five imports were orphaned by the deletions above. The rest was **already dead on main**:
`IMAGING_RULER_LAYER_PROPERTIES`, `RULER_LAYER_NAME`, `RULER_LINE_LAYER_NAME`,
`IMAGE_TEXT_LAYER_PROPERTIES`, `STAGE_POSITION_SHAPE_LAYER_PROPERTIES`, and four imports. The
ruler ones have been dead since #335 removed the napari ruler; `is_position_inside_layer` lost
its last caller in #370, yesterday.

## Why this shape matters for what's next

What survives splits cleanly along exactly the line the extraction needs:

- **345 lines of pure geometry** — the converters, validators, `COLOURS`,
  `get_image_pixel_centre` — which the canvas imports and which need a neutral home.
- **257 lines** (`draw_milling_patterns_in_napari`, `NapariPattern`,
  `remove_all_napari_shapes_layers`) whose **only** consumer is `FibsemMinimapWidget`. Those
  go with the minimap rebuild rather than needing to be ported anywhere.

Before this PR that boundary was obscured by 450 lines that belonged to neither side.

## Verification

1689 passed, 17 skipped (skips pre-existing — a missing LUT CSV). All three modules import,
every helper-package consumer imports (`milling_overlay`, `milling_stage_list_widget`,
`milling_task_viewer_widget`, `objective_control_widget`, `quad_view`), and every name
`FibsemMinimapWidget` imports from these modules still exists — checked by resolving its
import list against the live modules rather than by eye.

## One process note

The first attempt at `properties.py` computed statement spans from the maximum child-node line
number. For a multi-line dict that stops at the last *value* and leaves the closing brace
behind — an immediate `SyntaxError`, caught by the test run. Fixed with `end_lineno`. The two
function deletions were then recomputed the correct way and diffed against what had already
been written: byte-identical apart from the intentional import edits, so only multi-line
literals were ever at risk.
