### PR TITLE
[autolamella] Disable the last two cross-thread task-state subscriptions

### DIFF
--- a/fibsem/applications/autolamella/ui/lamella_card_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_card_widget.py
@@ -177,8 +177,21 @@ class LamellaCardWidget(QWidget):
         self._apply_layout()
 
         # ── evented connections ──────────────────────────────────────────
-        lamella.task_state.events.name.connect(self.refresh)    # type: ignore[union-attr]
-        lamella.task_state.events.status.connect(self.refresh)  # type: ignore[union-attr]
+        # The two task_state connections are DISABLED, not deleted -- see FIB-604 for
+        # why they cannot simply go, and `lamella_list_widget` for the same block.
+        # Written by the workflow's worker thread, so the @ensure_main_thread refresh
+        # arrives later, by which point `clear()`'s deleteLater may have taken this card
+        # down. An exception escaping a Qt slot aborts the process under PyQt5 (FIB-329,
+        # no excepthook installed) -- this card is where that was proved on 2026-08-12,
+        # crashing on a thumbnail the worker was still writing, killing the write partway
+        # and leaving a 0-byte file (FIB-602).
+        #
+        # `_on_workflow_update` refreshes this card by name, so it still follows a run;
+        # what is lost is determinism, since that update is emitted before `pre_task`
+        # writes the state it should show. Stale beats a lost run while the crash is
+        # fatal. Delete these once FIB-604 lands a trigger that fires after the write.
+        # lamella.task_state.events.name.connect(self.refresh)    # DISABLED: FIB-604
+        # lamella.task_state.events.status.connect(self.refresh)  # DISABLED: FIB-604
         lamella.events.defect.connect(self.refresh)             # type: ignore[union-attr]
         lamella.events.description.connect(self.refresh)        # type: ignore[union-attr]
 

--- a/fibsem/applications/autolamella/ui/lamella_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_list_widget.py
@@ -176,9 +176,27 @@ class LamellaRowWidget(QWidget):
         # written by GUI widgets; marshalling is a no-op for them, because
         # ensure_main_thread runs inline when already on the GUI thread.
         #
+        # The two task_state connections are DISABLED, not deleted, and the difference
+        # matters -- see FIB-604. Marshalling makes the refresh arrive *later*, by which
+        # point `clear()` may have destroyed this widget, and an exception escaping a Qt
+        # slot is not a logged traceback: PyQt5 calls qFatal and the process aborts
+        # (FIB-329, no excepthook installed). That is what happened on 2026-08-12 --
+        # the app died mid-workflow, and the abort killed a thumbnail write partway
+        # through, leaving a 0-byte file that then aborted every later load (FIB-602).
+        #
+        # `_on_workflow_update` refreshes this row by name, so the display still follows
+        # a run. What is lost is determinism: its InProgress update is emitted *before*
+        # `pre_task` writes the new name and status, and only arrives after because
+        # delivery is queued. A row can therefore show the previous task for the length
+        # of the current one. Slightly stale beats a lost run -- Patrick's call, and the
+        # right one while the crash is fatal.
+        #
+        # Restore these only once FIB-604 gives the refresh a trigger that fires after
+        # the write; at that point they should be deleted rather than re-enabled.
+        #
         # type: ignore because @evented adds .events dynamically and pyright can't see it.
-        lamella.task_state.events.name.connect(self.refresh)    # type: ignore[union-attr]
-        lamella.task_state.events.status.connect(self.refresh)  # type: ignore[union-attr]
+        # lamella.task_state.events.name.connect(self.refresh)    # DISABLED: FIB-604
+        # lamella.task_state.events.status.connect(self.refresh)  # DISABLED: FIB-604
         lamella.events.defect.connect(self.refresh)             # type: ignore[union-attr]
         lamella.events.description.connect(self.refresh)        # type: ignore[union-attr]
 

--- a/tests/ui/test_lamella_card_layout.py
+++ b/tests/ui/test_lamella_card_layout.py
@@ -163,16 +163,48 @@ def test_the_menus_and_thumbnail_survive_a_toggle():
 
 
 def test_the_lamella_events_still_refresh_after_a_toggle():
-    """`refresh` is one path for both arrangements, and stays connected across a switch."""
+    """`refresh` is one path for both arrangements, and stays connected across a switch.
+
+    Driven from `description` rather than `task_state`: the two task_state connections
+    are disabled (FIB-604), so writing them no longer refreshes anything. What this test
+    is actually about is unaffected -- that `set_mode` rebuilds the arrangement without
+    dropping the subscriptions that remain.
+    """
     lamella = _lamella()
     card = _shown(LamellaCardWidget(lamella, mode=MODE_STANDARD))
 
     card.set_mode(MODE_COZY)
     assert card.mode() == MODE_COZY, "the switch has to have happened"
+    lamella.description = "notched on the left"
+
+    assert card._card.toolTip() == "notched on the left"
+
+
+def test_a_task_state_write_no_longer_refreshes_the_card():
+    """The disabling, asserted where it is visible rather than only in the source.
+
+    Written by the workflow's worker thread, so the marshalled refresh arrived after
+    `clear()` may have destroyed the card -- and that is a process abort, not a logged
+    traceback (FIB-329). `_on_workflow_update` refreshes the card by name instead.
+
+    The status label is therefore expected to lag a live write until that update lands,
+    which is the whole trade: slightly stale beats a lost run.
+    """
+    lamella = _lamella()
+    card = _shown(LamellaCardWidget(lamella, mode=MODE_STANDARD))
+    before = card._status_label.text()
+
     lamella.task_state.name = "Mill Undercut"
     lamella.task_state.status = AutoLamellaTaskStatus.InProgress
 
-    assert card._status_label.text() == "Mill Undercut"
+    assert card._status_label.text() == before, (
+        "a task_state write reached the card -- the cross-thread subscription is back"
+    )
+    card.refresh()
+    assert card._status_label.text() == "Mill Undercut", (
+        "and an explicit refresh must still pick the new state up, or the card would "
+        "never show it at all"
+    )
 
 
 def test_the_container_keeps_its_selection_across_a_toggle():

--- a/tests/ui/test_lamella_defect_sync.py
+++ b/tests/ui/test_lamella_defect_sync.py
@@ -14,6 +14,7 @@ Driven through `LamellaNameListWidget` rather than a bare `_LamellaRow`: the def
 button is hidden until `enable_defect_button(True)`, and `refresh` skips a hidden
 button, so a bare row silently asserts nothing.
 """
+import ast
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -151,14 +152,41 @@ def test_every_host_of_the_list_can_persist_a_defect(module, widget, handler):
     assert "experiment.save()" in src, f"{widget}.{handler} must persist the change"
 
 
+def _connect_chains(source: str):
+    """Every `a.b.c.connect(...)` in *source*, as its attribute chain.
+
+    AST rather than substring matching, because the two task_state connections in the
+    list and card widgets are commented out rather than deleted (FIB-604) -- and a
+    `"task_state.events" in src` check passes happily on a comment. That is the shape
+    of test that passes for the wrong reason; the parser does not read comments at all.
+
+    Hand-walked rather than `ast.unparse`, which is 3.9+. CI never catches that here
+    (these tests need PyQt5, which the CI env does not install, so they are skipped
+    there) but the package supports 3.8 and someone runs them locally on it.
+    """
+    chains = []
+    for node in ast.walk(ast.parse(source)):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr != "connect":
+            continue
+        parts, cur = [], node.func
+        while isinstance(cur, ast.Attribute):
+            parts.append(cur.attr)
+            cur = cur.value
+        if isinstance(cur, ast.Name):
+            parts.append(cur.id)
+        chains.append(list(reversed(parts)))
+    return chains
+
+
 @pytest.mark.parametrize(
     "module, widget",
     [
-        # `_LamellaRow` is deliberately absent: it no longer subscribes to task_state at
-        # all. The marshalled callback still arrived after `set_lamella` had replaced the
-        # row and Qt had destroyed its widgets -- @ensure_main_thread makes the *thread*
-        # right and says nothing about whether the receiver still exists. It is refreshed
-        # from `_on_workflow_update` instead, like the other two.
+        (
+            "fibsem.applications.autolamella.ui.lamella_name_list_widget",
+            "_LamellaRow",
+        ),
         ("fibsem.applications.autolamella.ui.lamella_list_widget", "LamellaRowWidget"),
         (
             "fibsem.applications.autolamella.ui.lamella_card_widget",
@@ -166,29 +194,70 @@ def test_every_host_of_the_list_can_persist_a_defect(module, widget, handler):
         ),
     ],
 )
-def test_every_task_state_subscriber_marshals_its_refresh(module, widget):
-    """All three lists subscribe to task_state, so all three must marshal (FIB-565).
+def test_no_widget_holds_a_live_task_state_subscription(module, widget):
+    """None of the three may subscribe to task_state. Inverted from FIB-565.
 
-    The behavioural test above covers `_LamellaRow` only -- the other two need a
-    microscope-shaped host to construct. This reads the source instead, which is enough
-    to catch the failure that matters: someone removing @ensure_main_thread from one
-    widget while the subscription stays.
+    FIB-565 required the opposite -- subscribe, but marshal. That was the wrong
+    conclusion, and it took a day to show it. Marshalling fixes *which thread* touches
+    the widget and says nothing about *whether the widget still exists*: the callback
+    arrives later, by which point the list may have been cleared and Qt may have
+    destroyed the receiver.
 
-    Resolved through `importlib` rather than a hardcoded path: these three files moved
-    package twice in one day (FIB-558/559), and a path-based read would have broken
-    silently rather than failed loudly.
+    The cost of being wrong is not a logged traceback. No `sys.excepthook` is installed
+    anywhere in the package, so PyQt5 calls qFatal and the process aborts (FIB-329). On
+    2026-08-12 that killed a run mid-workflow and, because the abort landed inside a
+    thumbnail write, left a 0-byte file that aborted every subsequent load (FIB-602).
+
+    `_LamellaRow`'s connections are deleted (FIB-603); the other two are commented out
+    pending FIB-604, which has to give the refresh a trigger that fires after the write
+    before they can go for good. Either way there is nothing live for the parser to
+    find, which is what this asserts.
+
+    Resolved through `importlib` rather than a hardcoded path: these files moved package
+    twice in one day (FIB-558/559), and a path-based read would have broken silently
+    rather than failed loudly.
+    """
+    import importlib
+    from pathlib import Path
+
+    src = Path(importlib.import_module(module).__file__).read_text()
+    live = [c for c in _connect_chains(src) if "task_state" in c]
+
+    assert live == [], (
+        f"{widget} has a live task_state subscription {live} -- written from the "
+        f"workflow's worker thread, delivered to a widget that may since have been "
+        f"destroyed, and fatal rather than logged when it lands (FIB-329/603/604)"
+    )
+
+
+@pytest.mark.parametrize(
+    "module, widget",
+    [
+        (
+            "fibsem.applications.autolamella.ui.lamella_name_list_widget",
+            "_LamellaRow",
+        ),
+        ("fibsem.applications.autolamella.ui.lamella_list_widget", "LamellaRowWidget"),
+        (
+            "fibsem.applications.autolamella.ui.lamella_card_widget",
+            "LamellaCardWidget",
+        ),
+    ],
+)
+def test_every_refresh_stays_marshalled(module, widget):
+    """@ensure_main_thread stays on all three, even with the subscriptions gone.
+
+    Not redundant. It is what makes re-enabling a connection -- or any future
+    cross-thread caller -- land on the GUI thread rather than corrupting Qt state from
+    a worker. Removing the marshalling is the change that would make the commented-out
+    lines in the list and card widgets dangerous to restore.
     """
     import importlib
     from pathlib import Path
 
     src = Path(importlib.import_module(module).__file__).read_text()
 
-    assert "task_state.events" in src, (
-        f"{widget} no longer subscribes to task_state -- if that is deliberate, this "
-        "test and FIB-565 both need updating"
-    )
     assert "from superqt import ensure_main_thread" in src, f"{widget} lost the import"
     assert "    @ensure_main_thread\n    def refresh(self)" in src, (
-        f"{widget}.refresh is not marshalled, but it subscribes to task_state, which "
-        "the workflow writes from the FunctionWorker thread (FIB-565)"
+        f"{widget}.refresh is not marshalled (FIB-565)"
     )

--- a/tests/ui/test_lamella_row_task_state.py
+++ b/tests/ui/test_lamella_row_task_state.py
@@ -80,13 +80,23 @@ class TestItDoesNotSubscribeAcrossThreads:
         unreachable however it would otherwise have been arrived at.
         """
         source = textwrap.dedent(inspect.getsource(_LamellaRow.__init__))
-        connects = [
-            ast.unparse(node)
-            for node in ast.walk(ast.parse(source))
-            if isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "connect"
-        ]
+        # Hand-walked rather than `ast.unparse`, which is 3.9+. The package supports
+        # 3.8, and CI cannot catch the difference here -- these tests need PyQt5, which
+        # the CI env does not install, so they are skipped there and a 3.9-only call
+        # would only fail for someone running them locally on 3.8.
+        connects = []
+        for node in ast.walk(ast.parse(source)):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                continue
+            if node.func.attr != "connect":
+                continue
+            parts, cur = [], node.func
+            while isinstance(cur, ast.Attribute):
+                parts.append(cur.attr)
+                cur = cur.value
+            if isinstance(cur, ast.Name):
+                parts.append(cur.id)
+            connects.append(list(reversed(parts)))
         task_state_subscriptions = [c for c in connects if "task_state" in c]
 
         assert task_state_subscriptions == [], (


### PR DESCRIPTION
Prevention, not a fix. Four lines commented out, plus the tests that hold them there.

FIB-603 removed the lamella name row's subscription to `task_state.events.name` / `.status`. The workflow list and the lamella card still hold theirs — the same two lines, the same worker-thread writes, and a widget the same `clear()` can destroy underneath a queued refresh.

## Why commented out and not deleted

I proposed deleting them on the grounds that `_on_workflow_update` already calls `refresh_lamella` on both, so it would be a pure deletion. **The check said otherwise, and it also qualified what #380 did.**

`_on_workflow_update` refreshes lists only when the update carries a `"status"` key, and `TaskManager._emit_status` is the only producer of one. Its InProgress update is emitted *before* `pre_task` writes the new name and status:

```
_emit_status(InProgress)                     ← refresh #1
_run_single_task(...)
    pre_task:  task_state.name   = T2        ← the write. no refresh
               task_state.status = InProgress
    ... task body ...
_emit_status(final_status)                   ← refresh #2
```

Delivery is queued from the worker thread, so the GUI almost always reads the new values by the time it runs. The in-progress display is correct **by scheduling, not by ordering**. The subscription is what makes it deterministic — it fires on the write. Deleting these would put both widgets on that race, so FIB-604 has to land a trigger that fires after the write first; then these lines get deleted for good rather than re-enabled.

That also means #380 put the name list on the same race. Not broken — verified updating on hardware — but I described it as an equivalent replacement when I merged it, and it isn't quite. Noted on FIB-603.

## Why disable them now anyway

Because the failure they cause is not a stale row.

**No `sys.excepthook` is installed anywhere in the package**, so an exception escaping a Qt slot reaches PyQt5's `qFatal` and aborts the process (FIB-329). The 2026-08-12 logfile shows it plainly:

```
15:24:37,304  log_task_config — Mill Fiducial finishing
15:24:37,318  Traceback (truncated thumbnail)
              ── 38 seconds of silence ──
15:25:15,778  _adopt_experiment — a fresh app start
15:25:17,520  Traceback again (0-byte file, on load)
```

The application died mid-workflow and was restarted by hand. The abort also killed a thumbnail write partway through — `Image.save` opens `"wb"`, which truncates first — leaving a 0-byte file that then aborted every subsequent experiment load. One crash, a lost run, and a corrupted file.

(`run_ui` does call `init_sentry`, and Sentry's hook would suppress the abort. Crash reporting is off by default, and was off here.)

Against that, a row showing the previous task until the next workflow update is cheap. Patrick's call: slightly stale beats a lost run.

## Testing

The existing structural test asserted `"task_state.events" in src` — which a commented-out line satisfies perfectly. It would have passed while proving nothing. Rewritten to walk the AST, which does not see comments at all, and extended to all three widgets; re-enabling either line fails it, verified.

The marshalling assertion is split into its own test and kept. `@ensure_main_thread` is what would make restoring these lines safe rather than immediately dangerous.

`test_the_lamella_events_still_refresh_after_a_toggle` drove its assertion through `task_state`, so it failed here for the right reason. Moved onto `description` — which is what it was actually testing, that `set_mode` rebuilds the arrangement without dropping the remaining subscriptions — and paired with a new test pinning the disabling behaviourally: a `task_state` write does not reach the card, an explicit `refresh()` still does.

Also drops an `ast.unparse` added in the FIB-603 tests this morning. It is 3.9+, and CI cannot catch it — these tests need PyQt5, which the CI environment does not install, so they are skipped there and it would only fail for someone running them locally on 3.8.

`tests/ui/` + `tests/autolamella/` — 1637 passed, 1 skipped.

## Follow-ups

- **FIB-604** — the deterministic after-write trigger. Prerequisite for deleting these lines. **This PR mentions it, so it will auto-complete on merge; reopen it.**
- **FIB-605** — adding one lamella rebuilds every card and row, because the `inserted` / `removed` handler takes no arguments and discards the index. 70 lamellae is 70 thumbnail reads off disk to add one.
- **FIB-329** — the excepthook. One hook stops this whole class taking the application down, including the paths not yet found. Worth more than its backlog position.
