### PR TITLE
[ui] Rebuild the FM Image Viewer on the canvas, off napari

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1325,7 +1325,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.main_viewer = None
 
         # Create the AutoLamellaUI widget
-        self.autolamella_ui = AutoLamellaUI(viewer=None, parent_ui=self)
+        self.autolamella_ui = AutoLamellaUI(parent_ui=self)
 
         # Connect to workflow update signal from AutoLamellaUI
         self.autolamella_ui.workflow_update_signal.connect(self._on_workflow_update)

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -13,7 +13,6 @@ import os
 import threading
 from copy import deepcopy
 from typing import List, Optional, TYPE_CHECKING
-import napari
 from fibsem import conversions
 from fibsem.constants import METRE_TO_MICRON, MICRON_TO_METRE
 from fibsem.ui import notification_service
@@ -103,7 +102,9 @@ if TYPE_CHECKING:
         AutoLamellaSingleWindowUI,
     )
 
-# Suppress a specific upstream Napari/NumPy warning from shapes miter computation.
+# Suppress a specific upstream Napari/NumPy warning from shapes miter computation. This
+# module no longer imports napari, but the minimap still loads it, and a filter is matched
+# by module *name* — so this keeps working and is still worth having.
 warnings.filterwarnings(
     "ignore",
     message=r"'where' used without 'out', expect unit?ialized memory in output\. If this is intentional, use out=None\.",
@@ -169,7 +170,6 @@ class AutoLamellaUI(QMainWindow):
 
     def __init__(
         self,
-        viewer: napari.Viewer,
         parent_ui: "AutoLamellaSingleWindowUI",
     ) -> None:
         super().__init__()
@@ -178,9 +178,6 @@ class AutoLamellaUI(QMainWindow):
         self.parent_widget = parent_ui
 
         self._protocol_lock = threading.RLock()
-
-        # The main tab runs viewer-less; display is via the controller.
-        self.viewer = viewer
 
         self.experiment: Optional[Experiment] = None
         self.microscope: Optional[FibsemMicroscope] = None
@@ -567,7 +564,7 @@ class AutoLamellaUI(QMainWindow):
 
             if self.microscope.fm is not None:
                 self.fm_control_widget = FMControlWidget(
-                    microscope=self.microscope, viewer=self.viewer, parent=self
+                    microscope=self.microscope, parent=self
                 )
                 if self.settings is not None and self.settings.fm is not None:
                     self.fm_control_widget._apply_fluorescence_configuration(
@@ -773,22 +770,23 @@ class AutoLamellaUI(QMainWindow):
     #### FLUORESCENCE IMAGE VIEWER
 
     def _open_fm_image_viewer(self):
-        """Open a new napari viewer with the FM Image Viewer widget."""
+        """Open the FM Image Viewer as a standalone window."""
         if self.experiment is None:
             notification_service.show_toast(
                 "Please load an experiment first... [No Experiment Loaded]", "warning"
             )
             return
 
-        viewer = napari.Viewer(title="FM Image Viewer")
         experiment_path = str(self.experiment.path) if self.experiment.path else None
-        fm_image_viewer = FMImageViewerWidget(
-            viewer=viewer, start_directory=experiment_path, parent=self
+        # Parented to None so it gets its own taskbar entry and native minimise, like the
+        # coincidence viewer. That means nothing else owns it, so the reference here is
+        # what keeps it alive — drop it and Python collects the window mid-session.
+        self._fm_image_viewer_window = FMImageViewerWidget(
+            start_directory=experiment_path
         )
-        viewer.window.add_dock_widget(
-            fm_image_viewer, name="FM Image Viewer", area="right"
-        )
-        viewer.window.activate()
+        self._fm_image_viewer_window.resize(1180, 700)
+        self._fm_image_viewer_window.show()
+        self._fm_image_viewer_window.activateWindow()
 
     def _open_coincidence_milling_viewer(self):
         """Open FluorescenceCoincidenceViewerWidget as a standalone dialog."""

--- a/fibsem/ui/fm/widgets/fm_image_viewer_widget.py
+++ b/fibsem/ui/fm/widgets/fm_image_viewer_widget.py
@@ -1,193 +1,225 @@
-"""
-Simple napari widget for loading and displaying FluorescenceImages from file.
-"""
+"""Standalone viewer for loading and displaying FluorescenceImages from file."""
 from __future__ import annotations
-import logging
-from pathlib import Path
-from typing import Optional, Union
 
-import napari
-import numpy as np
-from PyQt5.QtCore import pyqtSignal, pyqtSlot
-from PyQt5.QtWidgets import QPushButton, QVBoxLayout, QWidget
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional, Union
+
+from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
+from PyQt5.QtWidgets import (
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+)
 from superqt import ensure_main_thread
 
-from fibsem.fm.structures import FluorescenceImage, FluorescenceChannelMetadata, FluorescenceImageMetadata
+from fibsem.fm.structures import FluorescenceImage
 from fibsem.ui.fm.widgets.load_image_dialog import LoadImageDialog
-from fibsem.ui.stylesheets import PRIMARY_BUTTON_STYLESHEET
+from fibsem.ui.stylesheets import NAPARI_STYLE, PRIMARY_BUTTON_STYLESHEET
+from fibsem.ui.widgets.canvas.fm_canvas import FMCanvasWidget
 
-
-def _image_metadata_to_napari_image_layer(
-    metadata: FluorescenceImageMetadata, image_shape: tuple[int, int], channel_index: int = 0
-) -> dict:
-    """Convert FluorescenceImageMetadata to a dictionary compatible with napari image layer.
-
-    This function extracts relevant metadata from the FluorescenceImageMetadata object
-    and formats it into a dictionary that can be used to create a napari image layer.
-
-    Args:
-        metadata: FluorescenceImageMetadata object containing image metadata
-        image_shape: Shape of the image (height, width)
-        channel_index: Index of the channel to extract metadata for (default is 0)
-
-    Returns:
-        A dictionary containing the metadata formatted for napari image layer.
-    """
-    # Convert structured metadata to dictionary for napari compatibility
-    metadata_dict = metadata.to_dict() if metadata else {}
-
-    channel_name = metadata.channels[channel_index].name
-    colormap = metadata.channels[channel_index].color or "gray"
-    pixel_size_x = metadata.pixel_size_x
-    pixel_size_y = metadata.pixel_size_y
-    pixel_size_z = metadata.pixel_size_z
-
-    return {
-        "name": channel_name,
-        "description": metadata.description or channel_name,
-        "metadata": metadata_dict,
-        "colormap": colormap,
-        "scale": (pixel_size_y, pixel_size_x),  # yx order for napari
-        "pixel_size_z": pixel_size_z,
-        "blending": "additive",
-    }
+# Qt.UserRole payload on each list row: the FluorescenceImage that row displays.
+_IMAGE_ROLE = int(Qt.UserRole)
 
 
 class FMImageViewerWidget(QWidget):
-    """Simple widget for loading and displaying FluorescenceImages."""
+    """Load FluorescenceImages from file and display them on the FM canvas.
+
+    One image is displayed at a time. Loading appends to the list rather than replacing,
+    so several files can be held open and switched between; ``FMCanvasWidget.set_fm_image``
+    resets the channel set on each call, and blending two *different* images was never a
+    workflow, so a list beats stacking them onto one canvas.
+
+    The canvas brings the per-channel colour/visibility/contrast popover, z-scrubbing,
+    max-projection and the scalebar with it — this widget only has to load files and
+    choose which one is shown.
+    """
 
     image_loaded_signal = pyqtSignal(FluorescenceImage)
 
     def __init__(
         self,
-        viewer: napari.Viewer,
         parent: Optional[QWidget] = None,
         start_directory: Optional[Union[str, Path]] = None,
     ):
         super().__init__(parent)
 
-        self.viewer = viewer
         self.start_directory = str(start_directory) if start_directory else None
+        self._images: List[FluorescenceImage] = []
 
-        self.initUI()
+        self.setWindowTitle("FM Image Viewer")
+        self._setup_ui()
+        self._connect_signals()
 
-    def initUI(self):
-        """Initialize the user interface."""
-        # Create load button
-        self.pushButton_load_image = QPushButton("Load Image...", self)
+    # ------------------------------------------------------------------
+    # UI
+    # ------------------------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        # This opens as a top-level window with no parent, and a Qt stylesheet only
+        # cascades to children — so it inherits nothing from the main window and has to
+        # carry the dark theme itself. Same as the coincidence viewer and FibsemUI.
+        self.setStyleSheet(NAPARI_STYLE)
+
+        self.canvas = FMCanvasWidget()
+
+        self.pushButton_load_image = QPushButton("Load Images...")
         self.pushButton_load_image.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
+
+        self.label_images = QLabel("Loaded Images")
+        self.label_images.setStyleSheet("font-weight: bold; margin-top: 6px;")
+
+        self.listWidget_images = QListWidget()
+        self.listWidget_images.setToolTip(
+            "Loaded fluorescence images. Selecting one displays it on the canvas."
+        )
+
+        self.label_metadata = QLabel("No image loaded.")
+        self.label_metadata.setWordWrap(True)
+        self.label_metadata.setStyleSheet("color: #a0a0a0; font-size: 11px;")
+
+        sidebar = QWidget()
+        sidebar.setMaximumWidth(280)
+        sidebar_layout = QVBoxLayout(sidebar)
+        sidebar_layout.setContentsMargins(10, 10, 10, 10)
+        sidebar_layout.setSpacing(8)
+        sidebar_layout.addWidget(self.pushButton_load_image)
+        sidebar_layout.addWidget(self.label_images)
+        sidebar_layout.addWidget(self.listWidget_images, 1)
+        sidebar_layout.addWidget(self.label_metadata)
+
+        splitter = QSplitter(Qt.Horizontal)
+        splitter.addWidget(self.canvas)
+        splitter.addWidget(sidebar)
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 0)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(splitter)
+
+    def _connect_signals(self) -> None:
         self.pushButton_load_image.clicked.connect(self.show_load_image_dialog)
+        self.listWidget_images.currentRowChanged.connect(self._on_row_changed)
+        self.image_loaded_signal.connect(self.add_image)
 
-        # Create layout
-        layout = QVBoxLayout()
-        layout.addWidget(self.pushButton_load_image)
-        layout.addStretch()
-        self.setLayout(layout)
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
 
-        # Configure napari scale bar
-        self.viewer.scale_bar.visible = True
-        self.viewer.scale_bar.unit = "m"
-
-        # Connect signal
-        self.image_loaded_signal.connect(self.display_image)
-
-    def show_load_image_dialog(self):
-        """Show the load image dialog and display the loaded image."""
+    def show_load_image_dialog(self) -> None:
+        """Show the load dialog; every image it emits is appended to the list."""
         dialog = LoadImageDialog(self, start_directory=self.start_directory)
-
-        # Connect the dialog's signal to our signal
         dialog.image_loaded_signal.connect(self.image_loaded_signal.emit)
 
-        ret = dialog.exec_()
-        if ret:
+        if dialog.exec_():
             logging.info("Image loaded successfully")
         else:
             logging.info("Image loading canceled")
 
     @ensure_main_thread
     @pyqtSlot(FluorescenceImage)
-    def display_image(self, image: FluorescenceImage):
-        """Display the loaded image in napari viewer.
+    def add_image(self, image: FluorescenceImage) -> None:
+        """Append *image* to the list and show it.
 
-        Args:
-            image: FluorescenceImage object containing the image data and metadata
+        The dialog emits once per file, so a multi-file load lands here repeatedly and
+        the last one ends up displayed.
         """
+        self._images.append(image)
+
+        item = QListWidgetItem(self._display_name(image))
+        item.setData(_IMAGE_ROLE, len(self._images) - 1)
+        item.setToolTip(image.filepath or "")
+        self.listWidget_images.addItem(item)
+
+        # Selecting the new row drives _on_row_changed, which does the display.
+        self.listWidget_images.setCurrentRow(self.listWidget_images.count() - 1)
+
+    def display_image(self, image: FluorescenceImage) -> None:
+        """Display *image* on the canvas, replacing whatever was shown."""
         try:
-            # Convert structured metadata to dictionary for napari compatibility
-            image_height, image_width = image.data.shape[-2:]
-
-            for channel_index in range(image.data.shape[0]):
-                metadata_dict = _image_metadata_to_napari_image_layer(
-                    image.metadata, (image_height, image_width), channel_index=channel_index
-                )
-                layer_name = f"{metadata_dict['description']}-{metadata_dict['name']}"
-                self._update_napari_image_layer(
-                    layer_name, image.data[channel_index], metadata_dict
-                )
-
+            self.canvas.set_fm_image(image)
+            self.label_metadata.setText(self._describe(image))
             logging.info(f"Displayed image: {image.metadata.description}")
-
         except Exception as e:
             logging.error(f"Error displaying image: {e}")
 
-    def _update_napari_image_layer(
-        self, layer_name: str, image: np.ndarray, metadata_dict: dict
-    ):
-        """Update or create a napari image layer with the given metadata.
+    def _on_row_changed(self, row: int) -> None:
+        if 0 <= row < len(self._images):
+            self.display_image(self._images[row])
 
-        Args:
-            layer_name: Name of the napari image layer
-            image: Image data array
-            metadata_dict: Dictionary containing metadata for the image layer
+    # ------------------------------------------------------------------
+    # Presentation helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _display_name(image: FluorescenceImage) -> str:
+        """A filename where there is one, else the image's own description."""
+        if image.filepath:
+            return os.path.basename(image.filepath)
+        return getattr(image.metadata, "description", None) or "Untitled image"
+
+    @staticmethod
+    def _describe(image: FluorescenceImage) -> str:
+        """The summary shown under the list. Everything here is best-effort: images
+        loaded from disk vary in how much metadata they carry."""
+        md = image.metadata
+        parts: List[str] = [f"<b>{FMImageViewerWidget._display_name(image)}</b>"]
+
+        channels = getattr(md, "channels", None) or []
+        shape = getattr(image.data, "shape", ())
+        if channels:
+            n_z = shape[-3] if len(shape) >= 3 else 1
+            parts.append(f"{len(channels)} channel{'s' if len(channels) != 1 else ''} · {n_z} z-slice{'s' if n_z != 1 else ''}")
+            parts.append(", ".join(c.name for c in channels))
+        if len(shape) >= 2:
+            parts.append(f"{shape[-1]} × {shape[-2]} px")
+
+        pixel_size = getattr(md, "pixel_size_x", None)
+        if pixel_size:
+            parts.append(f"{pixel_size * 1e9:.0f} nm/px")
+        acquired = getattr(md, "acquisition_date", None)
+        if acquired:
+            parts.append(FMImageViewerWidget._format_acquired(acquired))
+
+        return "<br>".join(parts)
+
+    @staticmethod
+    def _format_acquired(acquired: str) -> str:
+        """ISO timestamps read badly in a sidebar; show a date and time instead.
+
+        The field is a free-form string, and images from other sources need not carry a
+        parseable one — anything unrecognised is shown as-is rather than dropped.
         """
-        # Make sure all images are 3D for napari reasons (required to transform)
-        if image.ndim == 2:
-            image = image[np.newaxis, ...]
-
-        # Add a singleton dimension for z if needed
-        if image.ndim == 3 and len(metadata_dict["scale"]) == 2:
-            metadata_dict["scale"] = (metadata_dict["pixel_size_z"], *metadata_dict["scale"])
-
-        if layer_name in self.viewer.layers:
-            # If the layer already exists, update it
-            self.viewer.layers[layer_name].data = image
-            self.viewer.layers[layer_name].metadata = metadata_dict["metadata"]
-            self.viewer.layers[layer_name].colormap = metadata_dict["colormap"]
-        else:
-            # If the layer does not exist, create a new one
-            self.viewer.add_image(
-                data=image,
-                name=layer_name,
-                metadata=metadata_dict["metadata"],
-                colormap=metadata_dict["colormap"],
-                scale=metadata_dict["scale"],
-                blending="additive",
-            )
+        try:
+            return datetime.fromisoformat(str(acquired)).strftime("%Y-%m-%d %H:%M")
+        except (TypeError, ValueError):
+            return str(acquired)
 
 
-def create_widget(
-    viewer: napari.Viewer, experiment_path: Optional[Union[str, Path]] = None
-) -> FMImageViewerWidget:
-    """Factory function to create the widget for napari plugin.
+def main() -> None:
+    """Standalone harness: the viewer in a plain Qt window."""
+    import sys
 
-    Args:
-        viewer: napari Viewer instance
-        experiment_path: Optional path to experiment directory to use as start directory
+    from PyQt5.QtWidgets import QApplication
 
-    Returns:
-        FMImageViewerWidget instance
-    """
-    widget = FMImageViewerWidget(viewer=viewer, start_directory=experiment_path)
-    return widget
-
-
-def main():
-    """Standalone application for testing."""
     from fibsem.config import LOG_PATH
-    viewer = napari.Viewer()
-    widget = create_widget(viewer, LOG_PATH)
-    viewer.window.add_dock_widget(widget, area="right", name="FM Image Viewer")
-    napari.run()
+    from fibsem.ui.stylesheets import NAPARI_STYLE
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    app.setStyleSheet(NAPARI_STYLE)
+
+    widget = FMImageViewerWidget(start_directory=LOG_PATH)
+    widget.resize(1180, 700)
+    widget.show()
+
+    sys.exit(app.exec_())
 
 
 if __name__ == "__main__":

--- a/fibsem/ui/fm/widgets/load_image_dialog.py
+++ b/fibsem/ui/fm/widgets/load_image_dialog.py
@@ -22,7 +22,11 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem.fm.structures import FluorescenceImage
-from fibsem.ui.stylesheets import CONFIRM_BUTTON_STYLESHEET, SECONDARY_BUTTON_STYLESHEET
+from fibsem.ui.stylesheets import (
+    CONFIRM_BUTTON_STYLESHEET,
+    NAPARI_STYLE,
+    SECONDARY_BUTTON_STYLESHEET,
+)
 from fibsem.ui.tokens import (
     NEUTRAL_650,
 )
@@ -38,6 +42,10 @@ class LoadImageDialog(QDialog):
         self.setWindowTitle("Load Fluorescence Image")
         self.setModal(True)
         self.resize(500, 200)
+        # A dialog is its own top-level window and does not pick up the stylesheet its
+        # parent carries, so it has to set the theme itself. This used to come free from
+        # napari, which styles the QApplication; nothing does that any more.
+        self.setStyleSheet(NAPARI_STYLE)
 
         self.loaded_images: List[FluorescenceImage] = []
         self.selected_file_paths: List[str] = []

--- a/tests/ui/test_fm_image_viewer.py
+++ b/tests/ui/test_fm_image_viewer.py
@@ -1,0 +1,176 @@
+"""The standalone FM Image Viewer — loading, the image list, and what it displays.
+
+This widget used to host a napari viewer and push one layer per channel. It now composites
+on ``FMCanvasWidget``, and because ``set_fm_image`` resets the channel set on every call,
+*which* image is displayed became this widget's own responsibility — the list is the new
+logic, so it is what these tests pin.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_fm_image_viewer.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.fm.structures import (
+    FluorescenceChannelMetadata,
+    FluorescenceImage,
+    FluorescenceImageMetadata,
+)
+from fibsem.ui.fm.widgets.fm_image_viewer_widget import FMImageViewerWidget
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _channel(name: str, color: str) -> FluorescenceChannelMetadata:
+    return FluorescenceChannelMetadata(
+        name=name,
+        excitation_wavelength=488.0,
+        emission_wavelength=509.0,
+        power=0.5,
+        exposure_time=0.1,
+        gain=1.0,
+        offset=100.0,
+        color=color,
+    )
+
+
+def _image(
+    filepath: str | None = "/experiments/run/fm-stack-01.ome.tiff",
+    channels=(("DAPI", "cyan"), ("GFP", "green")),
+    z: int = 4,
+    shape=(64, 96),
+) -> FluorescenceImage:
+    h, w = shape
+    data = (np.random.default_rng(0).random((len(channels), z, h, w)) * 4095).astype(np.uint16)
+    md = FluorescenceImageMetadata(
+        acquisition_date="2026-08-12T15:00:00",
+        pixel_size_x=100e-9,
+        pixel_size_y=100e-9,
+        pixel_size_z=500e-9,
+        resolution=(w, h),
+        channels=[_channel(n, c) for n, c in channels],
+        z_positions=[i * 500e-9 for i in range(z)],
+    )
+    return FluorescenceImage(data=data, metadata=md, filepath=filepath)
+
+
+def test_the_viewer_holds_no_napari_viewer():
+    """The whole point of the swap: display is the canvas, not a napari Viewer.
+
+    Also guards the constructor signature — every caller stopped passing ``viewer``, and a
+    reintroduced parameter would silently accept one again.
+    """
+    widget = FMImageViewerWidget()
+    assert not hasattr(widget, "viewer"), "the viewer attribute came back"
+    with pytest.raises(TypeError):
+        FMImageViewerWidget(viewer=object())  # type: ignore[call-arg]
+
+
+def test_the_viewer_carries_the_dark_theme_itself():
+    """It opens parentless, and a Qt stylesheet only cascades to *children* — so it
+    inherits nothing from the main window and must set the theme on itself.
+
+    This shipped wrong once. Every standalone window in the app does this (the
+    coincidence viewer, the task config editor, FibsemUI), but a rendering harness that
+    styles the QApplication hides the omission completely: the widget looks correct in
+    isolation and comes up light-on-dark inside the app.
+    """
+    widget = FMImageViewerWidget()
+    assert widget.styleSheet(), "no stylesheet — the sidebar renders light against the canvas"
+
+
+def test_the_load_dialog_carries_the_dark_theme_too():
+    """A QDialog is its own top-level window: it does *not* pick up the stylesheet its
+    parent carries, even though it is a child in the object tree (verified — the child's
+    ``styleSheet()`` comes back empty).
+
+    The dialog used to be styled by napari, which sets a stylesheet on the QApplication.
+    Nothing does that now, so it has to carry the theme itself.
+    """
+    from fibsem.ui.fm.widgets.load_image_dialog import LoadImageDialog
+
+    parent = FMImageViewerWidget()
+    dialog = LoadImageDialog(parent)
+    assert dialog.styleSheet(), "the load dialog renders light against a dark app"
+
+
+def test_loading_appends_to_the_list_and_shows_the_new_image():
+    widget = FMImageViewerWidget()
+    first, second = _image(filepath="/a/first.ome.tiff"), _image(filepath="/b/second.ome.tiff")
+
+    widget.add_image(first)
+    widget.add_image(second)
+
+    assert widget.listWidget_images.count() == 2, "loading replaced instead of appending"
+    assert [widget.listWidget_images.item(i).text() for i in range(2)] == [
+        "first.ome.tiff",
+        "second.ome.tiff",
+    ]
+    # the newest is selected, and therefore displayed
+    assert widget.listWidget_images.currentRow() == 1
+
+
+def test_selecting_a_row_switches_which_image_is_displayed():
+    """The list is the only thing choosing what the canvas shows, so a selection that
+    does not reach ``set_fm_image`` leaves the viewer showing the wrong file."""
+    widget = FMImageViewerWidget()
+    widget.add_image(_image(filepath="/a/first.ome.tiff", channels=(("DAPI", "cyan"),)))
+    widget.add_image(_image(filepath="/b/second.ome.tiff", channels=(("GFP", "green"), ("RFP", "red"))))
+
+    assert [layer.name for layer in widget.canvas.layers] == ["GFP", "RFP"]
+
+    widget.listWidget_images.setCurrentRow(0)
+    assert [layer.name for layer in widget.canvas.layers] == ["DAPI"], (
+        "selecting an earlier image did not re-composite the canvas"
+    )
+    assert "first.ome.tiff" in widget.label_metadata.text()
+
+
+def test_an_image_with_no_filepath_still_gets_a_row_label():
+    """Images handed over in memory have no filepath; an empty row is unusable."""
+    widget = FMImageViewerWidget()
+    image = _image(filepath=None)
+    image.metadata.description = "acquired stack"
+
+    widget.add_image(image)
+    assert widget.listWidget_images.item(0).text() == "acquired stack"
+
+    bare = _image(filepath=None)
+    bare.metadata.description = None
+    widget.add_image(bare)
+    assert widget.listWidget_images.item(1).text().strip(), "row label was blank"
+
+
+def test_the_acquisition_timestamp_is_readable_but_never_dropped():
+    """ISO strings read badly in a sidebar, but the field is free-form and images from
+    other sources need not carry a parseable one — those must still be shown."""
+    widget = FMImageViewerWidget()
+
+    widget.add_image(_image())  # acquisition_date="2026-08-12T15:00:00"
+    assert "2026-08-12 15:00" in widget.label_metadata.text()
+
+    odd = _image()
+    odd.metadata.acquisition_date = "sometime last Tuesday"
+    widget.add_image(odd)
+    assert "sometime last Tuesday" in widget.label_metadata.text()
+
+
+def test_the_metadata_summary_survives_a_sparsely_described_image():
+    """Files loaded from disk vary in what metadata they carry, and the summary is
+    rendered on every selection — a missing field must not take the display down."""
+    widget = FMImageViewerWidget()
+    image = _image()
+    image.metadata.acquisition_date = None
+    image.metadata.pixel_size_x = None
+
+    widget.add_image(image)  # must not raise
+    text = widget.label_metadata.text()
+    assert "2 channels" in text and "96 × 64 px" in text

--- a/tests/ui/test_fm_image_viewer.py
+++ b/tests/ui/test_fm_image_viewer.py
@@ -17,7 +17,12 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 import numpy as np
 import pytest
-from PyQt5.QtWidgets import QApplication
+
+# CI installs `.[test]`, not `.[ui]`, so PyQt5 is absent there. Without this the
+# module-level imports below turn a skip into a collection error.
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication  # noqa: E402
 
 from fibsem.fm.structures import (
     FluorescenceChannelMetadata,


### PR DESCRIPTION
**Two direct importers gone — 11 → 9** (16 → 14 counting the helper package).

The viewer opened its own `napari.Viewer` and pushed one layer per channel through ~90 lines
of metadata-to-layer plumbing. `FMCanvasWidget` already does all of that — additive
per-channel compositing, the colour/visibility/contrast popover, z-scrubbing, max projection,
the scalebar — and `set_fm_image()` reads pixel size and per-channel colour straight off the
image metadata. So this is mostly assembly: the canvas plus the existing `LoadImageDialog` in
a plain Qt window.

**`AutoLamellaUI` drops out too.** Opening this viewer was its last real napari use. The two
remaining references were a warnings-filter regex (a string, still wanted — the minimap still
loads napari) and a `viewer` parameter that has been `None` since 4b; the parameter and its
passthrough to `FMControlWidget` go with it.

## Loading appends instead of replacing

`set_fm_image` resets the channel set on every call, so several files cannot share one canvas.
Blending two *different* images was never a workflow, so loading appends to a list and
selecting a row displays that image. That list is also where a file tree lands later — which
is deliberately **not** in this PR, so the swap is one judgeable change.

## Two things this got wrong first, both the same defect

- **The viewer opens parentless**, and a Qt stylesheet only cascades to children — so it
  inherited nothing from the main window and came up light-on-dark inside the app. Every other
  standalone window here sets `NAPARI_STYLE` on itself (the coincidence viewer, the task
  config editor, `FibsemUI`); this now does too. My rendering harness hid it completely by
  styling the `QApplication`: the widget looked right in isolation and wrong in the app. The
  harness now deliberately leaves the app unstyled so it reproduces how `AutoLamellaUI` opens
  it.
- **`LoadImageDialog` had the same symptom for a different reason.** A `QDialog` is its own
  top-level window and does *not* pick up its parent's stylesheet even though it is a child in
  the object tree — verified, the child's `styleSheet()` comes back empty. It used to be
  styled by napari, which sets a stylesheet on the `QApplication`. Nothing does that any more.

Both are pinned by tests, because "looks wrong" is invisible to every other kind of check.

## Tests

Eight, where there were none: no `viewer` attribute and a constructor that refuses one;
load-appends-and-selects; selection re-composites the canvas; a row label for images with no
filepath; a metadata summary that survives missing fields; a readable timestamp that still
shows unparseable ones; and the two styling guards. The selection and styling assertions are
mutation-verified.

`tests/ui/` + the autolamella UI suite: 1227 passed, 1 skipped.

## Verification

Run in the app: the viewer opens from the menu, renders on the canvas, and the sidebar and
load dialog both read dark. Confirmed by @patrickcleeve2 on the branch.
