### PR TITLE
[fibsem] Hold the imaging channel across the detector property pairs (FIB-544)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -3853,12 +3853,25 @@ class ThermoMicroscope(FibsemMicroscope):
             values = [v for v in VALUES if limits.min <= v <= limits.max]
             return values
         
-        if key == "detector_type":
-            values = self.connection.detector.type.available_values
-        
-        if key == "detector_mode":
-            values = self.connection.detector.mode.available_values
-        
+        # The same shared-channel pair as `_get`/`_set` -- except these two never set the
+        # channel at all, so this is not a race: they answer from whichever detector is
+        # active and report it as the requested beam's, ignoring `beam_type` entirely
+        # (FIB-544).
+        #
+        # Worse than one wrong read, because `get_available_values_cached` keeps the
+        # answer for the rest of the session -- including an answer given while the FM
+        # held the channel, which is then never revisited.
+        if key in ("detector_type", "detector_mode"):
+            with self._threading_lock:
+                # No channel to claim when the caller named no beam; the pre-existing
+                # behaviour of answering for whatever is active is all that is available.
+                if beam_type is not None:
+                    self.set_channel(beam_type)
+                if key == "detector_type":
+                    values = self.connection.detector.type.available_values
+                if key == "detector_mode":
+                    values = self.connection.detector.mode.available_values
+
         if key == "scan_direction":
             TFS_SCAN_DIRECTIONS = [
                 "BottomToTop",
@@ -3885,6 +3898,27 @@ class ThermoMicroscope(FibsemMicroscope):
         logging.debug({"msg": "get_available_values", "key": key, "values": values})
 
         return values
+
+    def get_detector_settings(self, beam_type: BeamType = BeamType.ELECTRON) -> FibsemDetectorSettings:
+        """Read all four detector properties as one consistent group.
+
+        Overridden here rather than fixed on the base class because the reason is
+        TFS-specific: the FM and the beams share one connection with one active view, so
+        each property read below is a set-then-read pair against a channel another client
+        can take (FIB-544). Other backends have their own connections and want no lock.
+
+        Locking each pair on its own would make every value correct and still let the
+        channel move *between* them, so the four could describe two different states --
+        and each pair would re-claim the channel, so a contended read flips the active
+        view four times rather than once. `_threading_lock` is an RLock, so the pairs
+        inside keep their own guard at no cost.
+
+        Not extended to `get_microscope_state`, which is this twice plus two beam reads
+        plus a stage read: `_threading_lock` is shared by every caller in the process,
+        and that is too long to hold them all.
+        """
+        with self._threading_lock:
+            return super().get_detector_settings(beam_type)
 
     def _get(self, key: str, beam_type: Optional[BeamType] = None) -> Union[int, float, str, list, Point, FibsemStagePosition, FibsemManipulatorPosition, None]:
         """Get a property of the microscope."""
@@ -3982,19 +4016,29 @@ class ThermoMicroscope(FibsemMicroscope):
             return self.connection.vacuum.chamber_pressure.value
 
         # detector mode and type
+        #
+        # One lock over the pair, for the same reason `acquire_image` holds one over its
+        # set-and-grab (FIB-542). `connection.detector` resolves against the *active
+        # device*, so a channel that is no longer ours when the read lands answers from
+        # the other column -- and answers silently, because a bare float or string carries
+        # nothing to say which device replied (FIB-544).
+        #
+        # Narrow on purpose: `_threading_lock` is a class attribute shared by every caller
+        # in the process. `get_detector_settings` takes it across all four of these so the
+        # group describes one state rather than four, which an RLock makes free to nest.
         if key in ["detector_mode", "detector_type", "detector_brightness", "detector_contrast"]:
-            
-            # set beam active view and device
-            self.set_channel(beam_type)
+            with self._threading_lock:
+                # set beam active view and device
+                self.set_channel(beam_type)
 
-            if key == "detector_type":
-                return self.connection.detector.type.value
-            if key == "detector_mode":
-                return self.connection.detector.mode.value
-            if key == "detector_brightness":
-                return self.connection.detector.brightness.value
-            if key == "detector_contrast":
-                return self.connection.detector.contrast.value
+                if key == "detector_type":
+                    return self.connection.detector.type.value
+                if key == "detector_mode":
+                    return self.connection.detector.mode.value
+                if key == "detector_brightness":
+                    return self.connection.detector.brightness.value
+                if key == "detector_contrast":
+                    return self.connection.detector.contrast.value
 
         # manipulator properties
         if key == "manipulator_position":
@@ -4104,37 +4148,43 @@ class ThermoMicroscope(FibsemMicroscope):
             return
 
         # detector properties
+        #
+        # The write half of the pair, and the one that does damage rather than reporting
+        # it: the value lands on whichever detector is active when the assignment goes
+        # out, so a stolen channel sets brightness or contrast on the other column and
+        # leaves it there (FIB-544). Locked for the same reason as the read above.
         if key in ["detector_mode", "detector_type", "detector_brightness", "detector_contrast"]:
-            self.set_channel(beam_type)
+            with self._threading_lock:
+                self.set_channel(beam_type)
 
-            if key == "detector_mode":
-                if value in self.connection.detector.mode.available_values:
-                    self.connection.detector.mode.value = value
-                    logging.info(f"Detector mode set to {value}.")
-                else:
-                    logging.warning(f"Detector mode {value} not available.")
-                return
-            if key == "detector_type":
-                if value in self.connection.detector.type.available_values:
-                    self.connection.detector.type.value = value
-                    logging.info(f"Detector type set to {value}.")
-                else:
-                    logging.warning(f"Detector type {value} not available.")
-                return
-            if key == "detector_brightness":
-                if 0 < value <= 1 :
-                    self.connection.detector.brightness.value = value
-                    logging.info(f"Detector brightness set to {value}.")
-                else:
-                    logging.warning(f"Detector brightness {value} not available, must be between 0 and 1.")
-                return
-            if key == "detector_contrast":
-                if 0 < value <= 1 :
-                    self.connection.detector.contrast.value = value
-                    logging.info(f"Detector contrast set to {value}.")
-                else:
-                    logging.warning(f"Detector contrast {value} not available, mut be between 0 and 1.")
-                return
+                if key == "detector_mode":
+                    if value in self.connection.detector.mode.available_values:
+                        self.connection.detector.mode.value = value
+                        logging.info(f"Detector mode set to {value}.")
+                    else:
+                        logging.warning(f"Detector mode {value} not available.")
+                    return
+                if key == "detector_type":
+                    if value in self.connection.detector.type.available_values:
+                        self.connection.detector.type.value = value
+                        logging.info(f"Detector type set to {value}.")
+                    else:
+                        logging.warning(f"Detector type {value} not available.")
+                    return
+                if key == "detector_brightness":
+                    if 0 < value <= 1 :
+                        self.connection.detector.brightness.value = value
+                        logging.info(f"Detector brightness set to {value}.")
+                    else:
+                        logging.warning(f"Detector brightness {value} not available, must be between 0 and 1.")
+                    return
+                if key == "detector_contrast":
+                    if 0 < value <= 1 :
+                        self.connection.detector.contrast.value = value
+                        logging.info(f"Detector contrast set to {value}.")
+                    else:
+                        logging.warning(f"Detector contrast {value} not available, mut be between 0 and 1.")
+                    return
 
         # system properties
         if key == "beam_enabled":

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -1199,14 +1199,27 @@ class DemoMicroscope(FibsemMicroscope):
             return self.stage_system.is_linked
         
         # detector properties
-        if key == "detector_type":
-            return detector.type
-        if key == "detector_mode":
-            return detector.mode
-        if key == "detector_brightness":
-            return detector.brightness
-        if key == "detector_contrast":
-            return detector.contrast
+        #
+        # Set-then-read against the shared channel, modelled for the same reason FIB-518
+        # modelled the acquisition pair: on hardware `connection.detector` resolves
+        # against the *active device*, so a read whose channel has moved answers from the
+        # other column's detector. Silently, because the value is a bare float or string
+        # with nothing in it to say which device replied (FIB-544).
+        #
+        # Warned rather than answered wrongly, as everywhere else here -- the point is to
+        # make a silent hardware failure visible in a log and catchable in a test, not to
+        # give the simulator a second way to be wrong.
+        if key in ("detector_type", "detector_mode", "detector_brightness", "detector_contrast"):
+            self.set_channel(beam_type)
+            self._warn_if_channel_moved(beam_type, f"reading {key}")
+            if key == "detector_type":
+                return detector.type
+            if key == "detector_mode":
+                return detector.mode
+            if key == "detector_brightness":
+                return detector.brightness
+            if key == "detector_contrast":
+                return detector.contrast
 
         # manipulator properties
         if key == "manipulator_position":
@@ -1294,18 +1307,26 @@ class DemoMicroscope(FibsemMicroscope):
             return
 
         # detector
-        if key == "detector_type":
-            detector.type = value
-            return
-        if key == "detector_mode":
-            detector.mode = value
-            return 
-        if key == "detector_contrast":
-            detector.contrast = value
-            return
-        if key == "detector_brightness":
-            detector.brightness = value
-            return
+        #
+        # The write half of the same pair, and the worse one: a read whose channel moved
+        # misreports a value, a write whose channel moved reconfigures the *other*
+        # column's detector -- brightness or contrast landing on the beam nobody asked
+        # about, and staying there (FIB-544).
+        if key in ("detector_type", "detector_mode", "detector_brightness", "detector_contrast"):
+            self.set_channel(beam_type)
+            self._warn_if_channel_moved(beam_type, f"writing {key}")
+            if key == "detector_type":
+                detector.type = value
+                return
+            if key == "detector_mode":
+                detector.mode = value
+                return
+            if key == "detector_contrast":
+                detector.contrast = value
+                return
+            if key == "detector_brightness":
+                detector.brightness = value
+                return
         
         # system properties
         if key == "beam_enabled":

--- a/tests/fm/test_simulated_detector_pairs.py
+++ b/tests/fm/test_simulated_detector_pairs.py
@@ -1,0 +1,149 @@
+"""Detector reads and writes take the shared imaging channel in two steps (FIB-544).
+
+`ThermoMicroscope._get` and `._set` both do this for the four detector properties:
+
+    self.set_channel(beam_type)          # 2 RPCs
+    return self.connection.detector.type.value   # 1 RPC, resolves against the *active
+                                                 # device*
+
+Two RPCs, no lock. `connection.detector` resolves against whatever device is active when
+the second one lands, so anything taking the channel in between makes the read answer
+from the other column -- silently, because the value is a bare float or string with
+nothing in it to say which device replied. The write half is worse: brightness or
+contrast lands on a detector nobody asked about, and stays there.
+
+This is FIB-542's defect on the property path, and it is more exposed than the
+acquisition pair was. `get_detector_settings` is four of these back to back, and
+`get_microscope_state()` calls it once per beam -- so one state read with no `beam_type`
+is eight unguarded pairs, and it is polled from the GUI thread by the minimap's stage
+refresh and the coincidence viewer.
+
+FIB-601 raised the stakes: holding the FM channel for a whole autofocus sweep means the
+FM now sits on the channel for an uninterrupted stretch rather than handing it back
+between steps, so a poll landing mid-sweep is likelier to have the view moved under it.
+
+These run against the simulator, which models the shared channel on both sides since
+FIB-518 and the detector pair since this change. The hardware class cannot be built here
+(no AutoScript SDK), so its side is pinned structurally in
+`tests/test_imaging_channel_lock.py`.
+"""
+
+import logging
+
+import pytest
+
+from fibsem.microscopes.simulator import FM_ACTIVE_VIEW
+from fibsem.structures import BeamType
+
+STOLEN = "Imaging channel changed"
+
+DETECTOR_PROPERTIES = [
+    "detector_type",
+    "detector_mode",
+    "detector_brightness",
+    "detector_contrast",
+]
+
+
+@pytest.fixture
+def microscope():
+    from fibsem import utils
+
+    scope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    assert scope.fm is not None, "the simulated compustage system should have an FM"
+    return scope
+
+
+def steal_after_set_channel(microscope, monkeypatch) -> None:
+    """Have the FM take the channel the instant a beam operation claims it.
+
+    The other pairs in this suite hook `sim_sleep`, which stands in for the operation's
+    duration. A detector read has no duration to hook -- it is two RPCs back to back --
+    so the window is opened where it actually is: between the `set_channel` and the read
+    that follows it. Patching `set_channel` to hand the channel straight to the FM models
+    another thread winning in exactly that gap.
+    """
+    original = type(microscope).set_channel
+
+    def set_then_lose(self, beam_type):
+        original(self, beam_type)
+        self.imaging_system.active_view = FM_ACTIVE_VIEW
+
+    monkeypatch.setattr(type(microscope), "set_channel", set_then_lose)
+
+
+class TestTheReadPath:
+    @pytest.mark.parametrize("key", DETECTOR_PROPERTIES)
+    def test_a_read_notices_the_channel_moving_under_it(
+        self, microscope, monkeypatch, caplog, key
+    ):
+        """The defect. Without the lock the read lands on the FM's device.
+
+        Asserted on the warning rather than on the returned value, matching
+        `_warn_if_channel_moved`'s deliberate choice not to answer wrongly: what hardware
+        does here is return the wrong number with no way to tell, so the simulator makes
+        it visible instead of adding a second way to be wrong.
+        """
+        steal_after_set_channel(microscope, monkeypatch)
+
+        with caplog.at_level(logging.WARNING):
+            microscope.get(key, BeamType.ELECTRON)
+
+        assert STOLEN in caplog.text, (
+            f"reading {key} did not notice the channel moving between its set and its "
+            f"read -- on hardware that returns the other column's detector, silently"
+        )
+
+    def test_the_channel_is_the_beams_when_nothing_steals_it(self, microscope, caplog):
+        """The other direction, so the test above cannot pass by warning always."""
+        with caplog.at_level(logging.WARNING):
+            microscope.get("detector_type", BeamType.ION)
+
+        assert STOLEN not in caplog.text
+        assert microscope.imaging_system.active_view == BeamType.ION.value
+
+
+class TestTheWritePath:
+    @pytest.mark.parametrize("key, value", [
+        ("detector_brightness", 0.5),
+        ("detector_contrast", 0.5),
+    ])
+    def test_a_write_notices_the_channel_moving_under_it(
+        self, microscope, monkeypatch, caplog, key, value
+    ):
+        """The dangerous half: this one reconfigures hardware rather than misreporting."""
+        steal_after_set_channel(microscope, monkeypatch)
+
+        with caplog.at_level(logging.WARNING):
+            microscope.set(key, value, BeamType.ELECTRON)
+
+        assert STOLEN in caplog.text, (
+            f"writing {key} did not notice the channel moving -- on hardware that "
+            f"applies the value to whichever detector is active, and leaves it there"
+        )
+
+
+class TestWhatTheStateReadCosts:
+    def test_get_detector_settings_is_four_pairs(self, microscope, monkeypatch):
+        """Why this is more exposed than the acquisition pair was.
+
+        Four properties, four independent set-then-read pairs. Locking each one makes
+        every value correct on its own and still lets something interleave *between*
+        them, so the four can describe two different states -- which is why the fix
+        holds the lock across the group rather than only per pair.
+        """
+        claims = []
+        original = type(microscope).set_channel
+        monkeypatch.setattr(
+            type(microscope),
+            "set_channel",
+            lambda self, beam_type: (claims.append(beam_type), original(self, beam_type))[1],
+        )
+
+        microscope.get_detector_settings(BeamType.ELECTRON)
+
+        assert len(claims) == 4, (
+            f"expected one channel claim per detector property, got {len(claims)} -- "
+            f"if this changed, the interleaving window changed with it"
+        )
+        assert all(bt is BeamType.ELECTRON for bt in claims)

--- a/tests/test_imaging_channel_lock.py
+++ b/tests/test_imaging_channel_lock.py
@@ -220,3 +220,103 @@ def test_the_locked_region_stays_narrow(thermo):
             f"the block at line {block.lineno} holds the process-wide lock across "
             f"{widened}, which blocks every other caller for longer than the frame"
         )
+
+
+"""The detector property pairs (FIB-544).
+
+The same defect on the property path, and the most exposed instance of it. `_get` and
+`_set` each did `set_channel(beam_type)` and then reached for `connection.detector.…`,
+which resolves against the *active device* — so a channel taken in between makes the read
+answer from the other column, silently, and makes the write land on the other column's
+detector and stay there.
+
+More exposed than the acquisition pair for two reasons. `get_detector_settings` is four
+of these back to back, and `get_microscope_state()` calls it once per beam — so one state
+read with no `beam_type` is eight pairs. And that path is polled from the GUI thread by
+the minimap's stage refresh and the coincidence viewer, which is exactly how FIB-517
+stopped a workflow task.
+
+Attribute accesses rather than calls, so these key on `self.connection.detector.…`
+instead of going through `_calls_named`.
+"""
+
+
+def _attr_chain(node: ast.AST) -> list:
+    """`self.connection.detector.type.value` -> the parts, outermost last."""
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    return list(reversed(parts))
+
+
+def _detector_accesses(node: ast.AST) -> list:
+    """Every `self.connection.detector.<something>` access anywhere under `node`.
+
+    Deduplicated by line: walking an attribute chain yields the outer node and each of
+    its prefixes, so one access would otherwise be reported several times.
+    """
+    lines = {}
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Attribute):
+            continue
+        chain = _attr_chain(child)
+        if chain[:3] == ["self", "connection", "detector"] and len(chain) > 3:
+            lines[child.lineno] = child
+    return list(lines.values())
+
+
+def test_every_detector_access_is_locked(thermo):
+    """The defect. A read or a write against a channel that may no longer be ours."""
+    accesses = _detector_accesses(thermo)
+    assert accesses, "no connection.detector access found -- the probe missed, not the code"
+
+    locked = {
+        access.lineno
+        for block in _locked_blocks(thermo)
+        for access in _detector_accesses(block)
+    }
+    unlocked = sorted({a.lineno for a in accesses} - locked)
+    assert unlocked == [], (
+        f"connection.detector is reached without the lock at line(s) {unlocked}: it "
+        f"resolves against the active device, so whatever took the shared channel after "
+        f"set_channel is the detector this reads or writes (FIB-544)"
+    )
+
+
+def test_the_detector_pairs_set_the_channel_in_the_same_block(thermo):
+    """A lock around the access alone guards nothing — the pair has to be together."""
+    for block in _locked_blocks(thermo):
+        if not _detector_accesses(block):
+            continue
+        assert _calls_named(block, "set_channel"), (
+            f"the block at line {block.lineno} locks a detector access but not the "
+            f"set_channel that precedes it, so the channel can still be taken in between"
+        )
+
+
+def test_get_detector_settings_holds_the_lock_across_the_group(thermo):
+    """Four locked pairs still let the channel move between them.
+
+    Each value would be correct on its own and the four could still describe two
+    different states, and each pair re-claims the channel — so a contended read flips the
+    active view four times rather than once. `_threading_lock` is an RLock, so holding it
+    across the group costs the pairs inside nothing.
+    """
+    override = next(
+        (
+            node
+            for node in ast.walk(thermo)
+            if isinstance(node, ast.FunctionDef) and node.name == "get_detector_settings"
+        ),
+        None,
+    )
+    assert override is not None, (
+        "ThermoMicroscope no longer overrides get_detector_settings, so its four reads "
+        "are four independent claims on the shared channel"
+    )
+    assert _locked_blocks(override), (
+        "get_detector_settings does not hold the lock across its four reads"
+    )


### PR DESCRIPTION
Closes FIB-544. **Unconfirmed on hardware — that's why it's up now, so it can be tested at the next microscope session.**

FIB-542 locked the beam's set-and-grab. This is the same defect on the property path, and the most exposed instance of it.

```python
self.set_channel(beam_type)                   # 2 RPCs
return self.connection.detector.type.value    # 1 RPC
```

`connection.detector` resolves against the *active device*, so anything taking the shared channel between those two makes the read answer from the other column — silently, because a bare float or string carries nothing to say which device replied. The write half is worse: brightness or contrast lands on a detector nobody asked about, and stays there.

## Why it's the most exposed one

`get_detector_settings` is four of these back to back, and `get_microscope_state()` calls it once per beam — so one state read with no `beam_type` is **eight** unguarded pairs. That path is polled from the GUI thread by the minimap's stage refresh and the coincidence viewer, which is exactly how FIB-517 stopped a workflow task.

FIB-601 raised the stakes yesterday. Holding the FM channel for a whole autofocus sweep means the FM now sits on it for an uninterrupted stretch instead of handing it back between steps, so a poll landing mid-sweep is likelier to find the view moved under it. That change is right; this is where the fix belongs.

## A third site, found by the test rather than by me

`get_available_values` reads `connection.detector.type.available_values` and `.mode.available_values` and **never sets the channel at all**. So it isn't a race — it answers from whichever detector happens to be active and reports it as the requested beam's, ignoring `beam_type` entirely.

Worse than one wrong read, because `get_available_values_cached` can keep that answer for the rest of the session, including one given while the FM held the channel.

I only found it because the structural test keys on the attribute access rather than on the two functions I set out to fix.

## Scope decisions

**`get_detector_settings` takes the lock across all four reads**, not just the pairs. Four locked pairs make every value correct and still let the channel move between them, so the four can describe two different states — and each pair re-claims the channel, so a contended read flips the active view four times rather than once. `_threading_lock` is an RLock, so the pairs inside keep their own guard at no cost.

Overridden on `ThermoMicroscope` rather than fixed on the base class: the reason is TFS-specific, and other backends have their own connection and want no lock.

**Deliberately not `get_microscope_state`.** That's two detector groups plus two beam reads plus a stage read, and `_threading_lock` is a class attribute shared by every caller in the process — too long to hold them all. Same judgement the acquisition pair already makes, and `test_the_locked_region_stays_narrow` pins it.

The deeper fix the TODO proposes — build image metadata from the `AdornedImage` rather than re-reading the microscope — would remove the post-grab view churn instead of locking it. Out of scope here.

## Testing

Two halves, matching how FIB-542/569 are covered.

**Structural**, over the parsed source, because `ThermoMicroscope` cannot be constructed without the AutoScript SDK. Extended to key on `self.connection.detector.…` attribute access rather than calls. Dropping either half of the fix fails it — checked both ways, and it's what surfaced `get_available_values`.

**Behavioural**, against the simulator, which models the shared channel since FIB-518 and now models the detector pair too — set the channel, then warn if it moved, rather than answering wrongly (the same choice `_warn_if_channel_moved` already makes everywhere else). The window is opened by patching `set_channel`, since a detector read has no duration to hook the way the autofunctions' `sim_sleep` does.

Worth being clear about what that second half proves: it pins that the hazard is modelled and observable, not that the lock fixes it. The simulator has no lock to test. The fix is what the structural half holds.

`tests/fm/` + `tests/test_imaging_channel_lock.py` + `tests/test_acquire.py` — 609 passed.

## At the microscope

The thing to watch is detector brightness/contrast reading or writing oddly while an FM operation holds the channel — most likely during an autofocus sweep with the minimap or coincidence viewer open. If it was firing before, it should stop.
