### PR TITLE
[ui] Stop a double-click on the tile grid editing the acquisition plan (FIB-520)

### DIFF
--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
 
-from PyQt5.QtCore import QObject, Qt, pyqtSignal
+from PyQt5.QtCore import QObject, Qt, QTimer, pyqtSignal
+from PyQt5.QtWidgets import QApplication
 
 from fibsem.imaging.tiling.geometry import TilePosition
 from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
@@ -95,6 +96,12 @@ class TileGridOverlay(QObject, CanvasOverlay):
         # coordinates drive the threshold, the data coordinates the displacement.
         self._move_start: Optional[Tuple[float, float, float, float, float, float]] = None
         self._move_active: bool = False
+        # A toggle waiting to find out whether it was half of a double-click. See
+        # `_schedule_toggle` for why it waits rather than firing and being undone.
+        self._pending_toggle: Optional[Tuple[int, int, bool]] = None
+        self._toggle_timer = QTimer(self)
+        self._toggle_timer.setSingleShot(True)
+        self._toggle_timer.timeout.connect(self._emit_pending_toggle)
 
     # ── lifecycle ────────────────────────────────────────────────────────
 
@@ -112,6 +119,9 @@ class TileGridOverlay(QObject, CanvasOverlay):
         ]
 
     def detach(self) -> None:
+        # A toggle still waiting out the double-click interval would otherwise fire into
+        # a host that has stopped listening -- or, on a rebuilt tab, into the wrong one.
+        self._cancel_pending_toggle()
         if self._canvas is not None:
             for cid in self._cids:
                 self._canvas.mpl_disconnect(cid)
@@ -448,6 +458,18 @@ class TileGridOverlay(QObject, CanvasOverlay):
         if not self._visible or not self._tiles:
             return
 
+        if getattr(event, "dblclick", False):
+            # The second press of a double-click, and the only warning that the first
+            # click was never a tile edit: the canvas turns this same press into a stage
+            # move. Drop the toggle the first release left pending and take no part in
+            # the gesture -- returning without claiming leaves `_move_start` unset, so
+            # the release that follows does nothing either.
+            #
+            # `getattr` because matplotlib sets `dblclick` on real events and the tests
+            # build the minimum an overlay reads.
+            self._cancel_pending_toggle()
+            return
+
         edges = self._edge_at(event.xdata, event.ydata)
         if edges is not None:
             self._resize_axes = edges
@@ -606,9 +628,41 @@ class TileGridOverlay(QObject, CanvasOverlay):
         ):
             tile = self._tile_at(event.xdata, event.ydata)
             if tile is not None:
-                self.tile_toggled.emit(tile.row, tile.col, not tile.enabled)
+                self._schedule_toggle(tile.row, tile.col, not tile.enabled)
 
         self._update_cursor(event)
+
+    # ── the click / double-click split ───────────────────────────────────
+
+    def _schedule_toggle(self, row: int, col: int, enabled: bool) -> None:
+        """Hold a toggle for the double-click interval before emitting it.
+
+        Double-clicking the canvas moves the stage. Inside the grid both gestures start
+        the same way, and this release arrives before anything knows whether a second
+        click is coming -- so a double-click used to move the stage *and* toggle the
+        tile under it. Twice, in fact: the overlay's own tiles are not updated between
+        the two releases, so both emissions carried the same value rather than undoing
+        each other (FIB-520).
+
+        Deferring, rather than emitting and undoing on the second press. Undoing is
+        snappier and writes a mask it then has to rewrite; this state decides what the
+        next run acquires, and never being briefly wrong is worth more here than never
+        being briefly slow.
+
+        The wait is the user's own `doubleClickInterval`, so it is as short as it can be
+        and still catch the double-clicks they actually make.
+        """
+        self._pending_toggle = (row, col, enabled)
+        self._toggle_timer.start(QApplication.doubleClickInterval())
+
+    def _cancel_pending_toggle(self) -> None:
+        self._toggle_timer.stop()
+        self._pending_toggle = None
+
+    def _emit_pending_toggle(self) -> None:
+        pending, self._pending_toggle = self._pending_toggle, None
+        if pending is not None:
+            self.tile_toggled.emit(*pending)
 
     def _restore_margin(self) -> None:
         if self._previous_margin is not None and self._canvas is not None:

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -558,9 +558,19 @@ def _end_gesture(overlay, event):
 
 
 def _click(overlay, x, y):
-    """Press and release at one point -- the gesture that toggles a tile."""
+    """Press and release at one point -- the gesture that toggles a tile.
+
+    Ends by letting the deferred toggle out. A release schedules the toggle rather than
+    emitting it, waiting out the double-click interval first, because a double-click on
+    the canvas is a stage move and used to toggle the tile under it as well (FIB-520).
+    Firing the timer by hand keeps these tests instant and about the wiring rather than
+    about the delay; the delay itself is pinned in `test_tile_grid_overlay.py`.
+    """
     overlay._on_press(_mouse(overlay, x, y))
     _end_gesture(overlay, _mouse(overlay, x, y))
+    if overlay._toggle_timer.isActive():
+        overlay._toggle_timer.stop()
+        overlay._emit_pending_toggle()
 
 
 @pytest.fixture(scope="module")

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -93,9 +93,40 @@ def _event(overlay, x, y, button=1, px=0.0, py=0.0):
 
 
 def _click(overlay, x, y):
-    """Press and release at one point, without moving between the two."""
+    """Press and release at one point, without moving between the two.
+
+    Ends by letting the deferred toggle out. A release no longer emits `tile_toggled`
+    directly -- it waits out the double-click interval first, because a double-click
+    here is a stage move rather than a tile edit (FIB-520). Firing the timer by hand
+    rather than waiting on it keeps these tests about *which* tile and *what value*,
+    and instant; the deferral itself is pinned separately below.
+    """
     overlay._on_press(_event(overlay, x, y))
     overlay._on_release(_event(overlay, x, y))
+    _flush_toggle(overlay)
+
+
+def _flush_toggle(overlay):
+    """Let a pending toggle out without waiting for the real interval."""
+    if overlay._toggle_timer.isActive():
+        overlay._toggle_timer.stop()
+        overlay._emit_pending_toggle()
+
+
+def _double_click(overlay, x, y):
+    """The four events matplotlib delivers for a double-click, in order.
+
+    press, release, press(dblclick=True), release -- the second press is the first
+    thing that says a double-click is happening, and it arrives *after* the release
+    that would otherwise have toggled.
+    """
+    for dblclick in (False, True):
+        press = _event(overlay, x, y)
+        press.dblclick = dblclick
+        overlay._on_press(press)
+        release = _event(overlay, x, y)
+        release.dblclick = False
+        overlay._on_release(release)
 
 
 def _drag(overlay, start, end, px_travel=50.0):
@@ -103,6 +134,7 @@ def _drag(overlay, start, end, px_travel=50.0):
     overlay._on_press(_event(overlay, *start))
     overlay._on_drag(_event(overlay, *end, px=px_travel, py=px_travel))
     overlay._on_release(_event(overlay, *end, px=px_travel, py=px_travel))
+    _flush_toggle(overlay)
 
 
 def test_the_centre_tile_coincides_with_the_displayed_image(qapp):
@@ -617,3 +649,126 @@ def test_a_move_drag_survives_the_grid_being_cleared_underneath_it(qapp):
 
     overlay._on_drag(_event(overlay, cx + 400.0, cy, px=50.0, py=50.0))
     overlay._on_release(_event(overlay, cx + 400.0, cy, px=50.0, py=50.0))
+
+
+class TestADoubleClickIsAStageMoveNotATileEdit:
+    """FIB-520, found on hardware.
+
+    Double-clicking the canvas moves the stage. Inside the grid that same gesture also
+    toggled the tile under the cursor, so a deliberate move silently edited what the
+    next run would acquire.
+
+    Both paths see the gesture: the canvas emits `canvas_double_clicked` from the second
+    press, and the overlay took raw press/release and treated each release as a click.
+    Nothing arbitrated, because the first release lands before anything knows a second
+    click is coming.
+    """
+
+    def test_a_double_click_does_not_toggle_the_tile(self, qapp):
+        """The defect. Measured before the fix: two emissions, not zero."""
+        overlay, _ = build(3, 3)
+        toggled = []
+        overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+        cx, cy = _centre(overlay)
+
+        _double_click(overlay, cx, cy)
+        _flush_toggle(overlay)  # nothing should be left waiting, but prove it
+
+        assert toggled == [], (
+            "a double-click toggled the tile under the cursor -- it is a stage move, "
+            "and editing the acquisition plan on the way to one is silent"
+        )
+
+    def test_the_two_emissions_did_not_cancel_each_other(self, qapp):
+        """Why the bug was visible rather than harmlessly self-undoing.
+
+        The overlay reads `tile.enabled` from its own tiles, and those are not updated
+        between the two releases -- the mask lives in the settings widget and comes back
+        through a redraw. So both emissions carried the *same* value. This pins the
+        state that made that true, so a later change that starts mutating tiles in place
+        cannot quietly turn the double-emission into a no-op and look fixed.
+        """
+        overlay, tiles = build(3, 3)
+        centre = next(t for t in tiles if (t.row, t.col) == (1, 1))
+        cx, cy = _centre(overlay)
+
+        _double_click(overlay, cx, cy)
+
+        assert centre.enabled is True, (
+            "the overlay mutated its own tile -- it emits and lets the settings widget "
+            "own the mask, and two writers is how the two views drift apart"
+        )
+
+    def test_a_single_click_still_toggles(self, qapp):
+        """The other direction. Suppressing the double-click must not cost the click."""
+        overlay, _ = build(3, 3)
+        toggled = []
+        overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+        cx, cy = _centre(overlay)
+
+        _click(overlay, cx, cy)
+
+        assert toggled == [(1, 1, False)]
+
+    def test_the_toggle_waits_rather_than_firing_and_being_undone(self, qapp):
+        """The mechanism, not just the outcome.
+
+        A release schedules the toggle and emits nothing yet; only the timer does. An
+        implementation that emitted immediately and undid it on the second press would
+        pass the two tests above and still write a mask it had to rewrite.
+        """
+        overlay, _ = build(3, 3)
+        toggled = []
+        overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+        cx, cy = _centre(overlay)
+
+        overlay._on_press(_event(overlay, cx, cy))
+        overlay._on_release(_event(overlay, cx, cy))
+
+        assert toggled == [], "the toggle was emitted before the double-click interval"
+        assert overlay._pending_toggle == (1, 1, False)
+        assert overlay._toggle_timer.isActive()
+
+    def test_the_second_press_cancels_the_pending_toggle(self, qapp):
+        overlay, _ = build(3, 3)
+        cx, cy = _centre(overlay)
+        overlay._on_press(_event(overlay, cx, cy))
+        overlay._on_release(_event(overlay, cx, cy))
+
+        press = _event(overlay, cx, cy)
+        press.dblclick = True
+        overlay._on_press(press)
+
+        assert overlay._pending_toggle is None
+        assert not overlay._toggle_timer.isActive()
+
+    def test_the_second_press_takes_no_part_in_the_gesture(self, qapp):
+        """It returns before claiming, so the release after it does nothing either.
+
+        Without that, the second press would arm `_move_start` again and its release
+        would schedule a fresh toggle -- putting the bug straight back, one click later.
+        """
+        overlay, _ = build(3, 3)
+        cx, cy = _centre(overlay)
+
+        press = _event(overlay, cx, cy)
+        press.dblclick = True
+        overlay._on_press(press)
+
+        assert overlay._move_start is None
+
+    def test_detaching_drops_a_pending_toggle(self, qapp):
+        """It would otherwise fire into a host that has stopped listening, or -- on a
+        rebuilt tab -- into the wrong one."""
+        overlay, _ = build(3, 3)
+        toggled = []
+        overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+        cx, cy = _centre(overlay)
+        overlay._on_press(_event(overlay, cx, cy))
+        overlay._on_release(_event(overlay, cx, cy))
+
+        overlay.detach()
+
+        assert overlay._pending_toggle is None
+        assert not overlay._toggle_timer.isActive()
+        assert toggled == []


### PR DESCRIPTION
Closes FIB-520, found on hardware 2026-08-06.

Double-clicking the FM overview canvas inside the tile grid moves the stage — correct, and what you were doing — and toggles the tile under the cursor on the way, silently changing what the next run will acquire.

Two paths see the same gesture. The canvas emits `canvas_double_clicked` from the second press; the overlay takes raw press/release and treats every release that didn't travel as a click on a tile. Nothing arbitrated, because the first release lands before anything knows a second click is coming.

## It's worse than the issue described

Measured before fixing:

```
tile_toggled emissions from ONE double-click: [(1, 1, False), (1, 1, False)]
```

**Twice, both the same value.** They don't cancel. The overlay reads `tile.enabled` from its own tiles, and those aren't updated between the two releases — the mask belongs to the settings widget and comes back through a redraw — so the second emission repeats the first rather than undoing it.

That's why the bug is visible rather than harmlessly self-neutralising, and a test now pins the state that makes it true. A later change that starts mutating tiles in place could otherwise turn the double emission into a silent no-op and look fixed.

## The mechanism, which the issue flagged as the real decision

The first release can't know a second click is coming, so the choice is to **defer** the toggle or to **emit and undo** it on the second press.

Deferring, deliberately. Undoing is snappier and writes a mask it then has to rewrite; this state decides what the next run acquires, and never being briefly wrong is worth more than never being briefly slow.

The wait is `QApplication.doubleClickInterval()` — your own system setting, so it's as short as it can be and still catch the double-clicks you actually make.

**The cost is real and worth feeling for on hardware:** a single click no longer toggles a tile instantly. If that reads as sluggish, undo-on-second-press is the other half of the trade and I'd swap it.

Two smaller pieces:

- The second press returns **before claiming** the gesture, so `_move_start` stays unset and the release after it does nothing either. Without that, the second press would arm a fresh toggle and put the bug back one click later — a test covers it.
- `detach` drops a pending toggle. It would otherwise fire into a host that's stopped listening, or — on a tab rebuilt by a reconnect — into the wrong one.

## Testing

Reproduction first: a `_double_click` helper delivering the four events matplotlib actually sends (press, release, press with `dblclick=True`, release), which is what surfaced the double emission.

Both test helpers that click a tile now flush the timer by hand rather than waiting on it, so the existing tests stay instant and stay about *which* tile and *what value*. The delay itself is pinned separately, on the timer rather than on the clock.

Dropping either half of the fix fails three of the new tests — checked both ways.

`tests/ui/` — 1181 passed, 1 skipped.
