### PR TITLE
[fibsem] One derivation for the FIB/SEM stage projection, in both directions

### DIFF
--- a/fibsem/fm/reprojection.py
+++ b/fibsem/fm/reprojection.py
@@ -5,6 +5,11 @@ inverse of :meth:`FibsemMicroscope.project_fm_stable_move`: that one asks where 
 would send the stage, these ask where the stage already is on screen. Both run the same
 projection, so a marker drawn here lands where clicking there would take you.
 
+The projection itself is not fluorescence-specific and lives in
+:mod:`fibsem.transformations`, taking the camera's view tilt as an argument. What is
+fluorescence-specific, and stays here, is the camera image transform and the shape of a
+fluorescence image's metadata.
+
 Microscope-free by design. Everything the projection reads comes from the image's own
 :class:`FibsemHardwareGeometry` and stage position, so a saved overview reprojects correctly
 even when the stage has since moved or the display transform has since been flipped --
@@ -25,158 +30,14 @@ from typing import TYPE_CHECKING, List, Tuple
 import numpy as np
 
 from fibsem.fm.structures import FibsemHardwareGeometry
-from fibsem.movement import rotation_angle_is_smaller
 from fibsem.structures import FibsemStagePosition, Point
+from fibsem.transformations import (
+    inverse_view_corrected_dy,
+    view_corrected_stage_movement,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
     from fibsem.fm.structures import FluorescenceImage
-
-
-def _projection_terms(
-    geometry: FibsemHardwareGeometry,
-    stage_rotation: float,
-    stage_tilt: float,
-) -> Tuple[float, float, float]:
-    """The sign and angle terms both directions of the projection share.
-
-    Factored out rather than written twice: the forward and the inverse differ only in
-    the arithmetic that follows, and a sign convention that drifts between them would
-    make a click land somewhere other than where the marker was drawn -- while each
-    direction on its own still looked self-consistent.
-
-    Returns:
-        (compustage_sign, corrected_pretilt_angle, stage_tilt), where `stage_tilt` has
-        the compustage half-turn already folded in.
-    """
-    sem_column_tilt = np.deg2rad(geometry.column_tilt)
-    stage_pretilt = np.deg2rad(geometry.shuttle_pre_tilt)
-    rotation_flat_to_eb = np.deg2rad(geometry.rotation_reference) % (2 * np.pi)
-    rotation_flat_to_ion = np.deg2rad(geometry.rotation_180) % (2 * np.pi)
-
-    stage_rotation = stage_rotation % (2 * np.pi)
-
-    # The forward flips expected_y once for a compustage and a second time at the FIB
-    # orientation, so the two cancel there. The orientation is derived from the pose
-    # rather than from a live microscope's `get_stage_orientation`.
-    #
-    # The rotation test is not redundant with the tilt test: a compustage cannot
-    # rotate, so `get_stage_orientation` reports FIB only at the reference rotation.
-    # Keying on tilt alone would call an unreachable pose FIB and flip the sign
-    # against the live path -- which is a disagreement no physical run can surface,
-    # and so exactly the kind that survives.
-    compustage_sign = 1.0
-    is_fib_orientation = False
-    if geometry.is_compustage:
-        fib_orientation_tilt = np.deg2rad(
-            geometry.fib_column_tilt - geometry.shuttle_pre_tilt - 180
-        )
-        is_fib_orientation = bool(
-            np.isclose(stage_tilt, fib_orientation_tilt, atol=0.1)
-            and rotation_angle_is_smaller(stage_rotation, rotation_flat_to_eb, atol=5)
-        )
-        compustage_sign = 1.0 if is_fib_orientation else -1.0
-        stage_tilt = stage_tilt + np.pi
-
-    pretilt_sign = 1.0
-    if rotation_angle_is_smaller(stage_rotation, rotation_flat_to_eb, atol=5):
-        pretilt_sign = 1.0
-    if rotation_angle_is_smaller(stage_rotation, rotation_flat_to_ion, atol=5):
-        pretilt_sign = -1.0
-    if is_fib_orientation:
-        pretilt_sign = -1.0
-
-    corrected_pretilt_angle = pretilt_sign * (stage_pretilt + sem_column_tilt)
-
-    return compustage_sign, corrected_pretilt_angle, stage_tilt
-
-
-def view_corrected_stage_movement(
-    expected_y: float,
-    geometry: FibsemHardwareGeometry,
-    stage_rotation: float,
-    stage_tilt: float,
-) -> Tuple[float, float]:
-    """Split an in-image y-displacement across the stage y- and z-axes.
-
-    The microscope-free form of
-    :meth:`FibsemMicroscope._view_corrected_stage_movement` at the camera's view tilt.
-
-    Args:
-        expected_y: displacement along the image y-axis, in metres.
-        geometry: the geometry the image was captured under.
-        stage_rotation: stage rotation at acquisition, in radians.
-        stage_tilt: stage tilt at acquisition, in radians.
-
-    Returns:
-        (dy, dz) stage movement, in metres.
-    """
-    compustage_sign, corrected_pretilt_angle, stage_tilt = _projection_terms(
-        geometry, stage_rotation, stage_tilt
-    )
-
-    if geometry.is_compustage:
-        expected_y = expected_y * compustage_sign
-
-    perspective_tilt_adjustment = (
-        -corrected_pretilt_angle - np.deg2rad(geometry.camera_tilt)
-    )
-    y_sample_move = expected_y / np.cos(stage_tilt + perspective_tilt_adjustment)
-
-    return (
-        float(y_sample_move * np.cos(corrected_pretilt_angle)),
-        float(-y_sample_move * np.sin(corrected_pretilt_angle)),
-    )
-
-
-def inverse_view_corrected_dy(
-    dy: float,
-    dz: float,
-    geometry: FibsemHardwareGeometry,
-    stage_rotation: float,
-    stage_tilt: float,
-) -> float:
-    """Recover an in-image y-displacement from a y/z stage movement.
-
-    The microscope-free form of
-    :meth:`FibsemMicroscope._inverse_view_corrected_stage_movement`, parameterised by
-    the geometry rather than reading it off a live instrument. The two are held
-    together by a parity test across the full pose matrix, because a projection that
-    silently disagrees with the one used to move the stage puts every overlay in the
-    wrong place.
-
-    Args:
-        dy: stage y movement, in metres.
-        dz: stage z movement, in metres.
-        geometry: the geometry the image was captured under.
-        stage_rotation: stage rotation at acquisition, in radians.
-        stage_tilt: stage tilt at acquisition, in radians.
-
-    Returns:
-        The in-image y-displacement that would produce that stage movement, in metres.
-    """
-    compustage_sign, corrected_pretilt_angle, stage_tilt = _projection_terms(
-        geometry, stage_rotation, stage_tilt
-    )
-
-    perspective_tilt_adjustment = (
-        -corrected_pretilt_angle - np.deg2rad(geometry.camera_tilt)
-    )
-
-    # Undo y_move = y_sample_move * cos(a) and z_move = -y_sample_move * sin(a),
-    # taking whichever component is larger so the division stays conditioned.
-    cos_pretilt = np.cos(corrected_pretilt_angle)
-    sin_pretilt = np.sin(corrected_pretilt_angle)
-    if abs(cos_pretilt) > abs(sin_pretilt):
-        y_sample_move = dy / cos_pretilt
-    else:
-        y_sample_move = -dz / sin_pretilt
-
-    expected_y = y_sample_move * np.cos(stage_tilt + perspective_tilt_adjustment)
-
-    if geometry.is_compustage:
-        expected_y *= compustage_sign
-
-    return float(expected_y)
 
 
 def project_stage_position(
@@ -205,6 +66,7 @@ def project_stage_position(
     dy = inverse_view_corrected_dy(
         dy=delta.y,
         dz=delta.z,
+        view_tilt=np.deg2rad(geometry.camera_tilt),
         geometry=geometry,
         stage_rotation=base_position.r or 0.0,
         stage_tilt=base_position.t or 0.0,
@@ -248,6 +110,7 @@ def project_image_point(
     dx, dy = geometry.transform.apply_to_delta(dx, dy)
     y_move, z_move = view_corrected_stage_movement(
         expected_y=dy,
+        view_tilt=np.deg2rad(geometry.camera_tilt),
         geometry=geometry,
         stage_rotation=base_position.r or 0.0,
         stage_tilt=base_position.t or 0.0,

--- a/fibsem/imaging/tiling/reprojection.py
+++ b/fibsem/imaging/tiling/reprojection.py
@@ -9,7 +9,7 @@ through the baked-in inverse here.
 from __future__ import annotations
 
 import logging
-from typing import List
+from typing import List, Tuple
 
 import numpy as np
 
@@ -409,6 +409,67 @@ def _inverse_y_corrected_stage_movement_tescan(
         dy=dy,
         dz=dz,
         beam_type=beam_type,
+    )
+
+
+def y_corrected_stage_movement_tescan_from_geometry(
+    geometry: FibsemHardwareGeometry,
+    stage_position: FibsemStagePosition,
+    expected_y: float,
+    beam_type: BeamType = BeamType.ELECTRON,
+) -> Tuple[float, float]:
+    """Tescan forward of the sample-plane move — the microscope-free form.
+
+    The counterpart of :func:`inverse_y_corrected_stage_movement_tescan_from_geometry`,
+    and the microscope-free form of :meth:`TescanMicroscope._y_corrected_stage_movement`.
+    Added so a caller that has an image but no live instrument -- an overview canvas
+    resolving a click on a saved image -- can run the same projection the stage would.
+
+    Thermo's pair is parameterised by a *view tilt* and lives in
+    :mod:`fibsem.transformations`; Tescan cannot join it, because its z-axis sits below
+    the tilt axis and the decomposition uses the full chamber-frame sample inclination
+    rather than the pre-tilt alone. Same reason ``TescanMicroscope`` overrides the
+    method instead of passing a different view tilt.
+
+    Args:
+        geometry: fixed instrument geometry (column tilts, pre-tilt, rotation refs).
+        stage_position: stage pose at acquisition (rotation r and tilt t, radians).
+        expected_y: distance along the image y-axis, in metres.
+        beam_type: beam perspective to correct for.
+
+    Returns:
+        (y_move, z_move) in the **chamber** frame, in metres -- before the stage-axis
+        inversion ``stable_move`` applies (``y_stage = -y_chamber``, z unchanged). The
+        inverse undoes that same inversion on its way in, so the two compose.
+    """
+    sem_column_tilt = np.deg2rad(geometry.column_tilt)
+    fib_column_tilt = np.deg2rad(geometry.fib_column_tilt)
+    stage_pretilt = np.deg2rad(geometry.shuttle_pre_tilt)
+
+    stage_rotation_flat_to_eb = np.deg2rad(geometry.rotation_reference) % (2 * np.pi)
+    stage_rotation_flat_to_ion = np.deg2rad(geometry.rotation_180) % (2 * np.pi)
+
+    stage_rotation = stage_position.r % (2 * np.pi) if stage_position.r is not None else 0.0
+    stage_tilt = stage_position.t if stage_position.t is not None else 0.0
+
+    PRETILT_SIGN = 1.0
+    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
+        PRETILT_SIGN = 1.0
+    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
+        PRETILT_SIGN = -1.0
+
+    corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
+    sample_inclination = stage_tilt - corrected_pretilt_angle
+
+    beam_tilt = sem_column_tilt if beam_type is BeamType.ELECTRON else fib_column_tilt
+
+    y_sample_move = expected_y / np.cos(sample_inclination - beam_tilt)
+
+    # z is negated because Tescan +z increases downward -- see
+    # TescanMicroscope._y_corrected_stage_movement, verified on hardware 2026-07-23.
+    return (
+        float(y_sample_move * np.cos(sample_inclination)),
+        float(-y_sample_move * np.sin(sample_inclination)),
     )
 
 

--- a/fibsem/projection.py
+++ b/fibsem/projection.py
@@ -1,0 +1,351 @@
+"""Stage positions and the plane a canvas shows them in, in both directions.
+
+The instrument works in stage coordinates; a display works in the plane it is showing.
+Everything drawn from a stage position -- a marker, the travel limits, a planned
+acquisition grid -- needs the same mapping between the two, and every click needs its
+inverse.
+
+A :class:`StageProjection` is that mapping, in metres, for one way of looking at the
+sample. Which one differs by modality: a fluorescence camera projects through its own
+axis tilt and image transform, a beam through scan rotation and a column tilt. Both are
+here, so the display layer can be handed one and stay free of microscope geometry --
+see :class:`fibsem.ui.widgets.canvas.stage_frame.StageFrame`, which composes a
+projection with a canvas scale.
+
+Deliberately outside ``fibsem/ui``. This is arithmetic over recorded geometry with no
+Qt in it, and importing ``fibsem.ui`` pulls in the whole widget package -- which CI
+does not install, so a projection living there could not be tested where it matters.
+
+Microscope-free where it can be. Each class has a ``from_image`` reading the geometry
+an image recorded, and a ``from_microscope`` reading the live instrument. They are not
+interchangeable: ``from_image`` is what a saved overview needs, because it must project
+as it was taken rather than as things stand now.
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Protocol, Tuple
+
+import numpy as np
+
+from fibsem.fm.reprojection import project_image_point, project_stage_position
+from fibsem.imaging.tiling.reprojection import (
+    inverse_y_corrected_stage_movement_tescan_from_geometry,
+    y_corrected_stage_movement_tescan_from_geometry,
+)
+from fibsem.structures import BeamType, FibsemStagePosition, Point
+from fibsem.transformations import (
+    inverse_view_corrected_dy,
+    view_corrected_stage_movement,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - annotation only
+    from fibsem.fm.structures import FibsemHardwareGeometry
+    from fibsem.microscope import FibsemMicroscope
+    from fibsem.structures import FibsemImage
+
+
+class StageProjection(Protocol):
+    """Stage coordinates to the displayed plane and back, both in metres.
+
+    Metres rather than pixels on purpose. The underlying projections answer in pixels
+    of a hypothetical image, but pixels are a property of a detector, not of the
+    geometry, and a real-space canvas has its own scale -- so a projection that spoke
+    in pixels would have to be told which pixels, and the answer would cancel out
+    immediately afterwards.
+    """
+
+    def to_plane(
+        self, position: FibsemStagePosition, base: FibsemStagePosition
+    ) -> Tuple[float, float]:
+        """Where *position* falls relative to *base*, in metres in the displayed plane."""
+        ...
+
+    def from_plane(
+        self, dx: float, dy: float, base: FibsemStagePosition
+    ) -> FibsemStagePosition:
+        """The stage position a displayed-plane offset from *base* corresponds to."""
+        ...
+
+
+@dataclass(frozen=True)
+class FMStageProjection:
+    """The fluorescence projection: camera axis tilt, image transform, sample tilt.
+
+    `pixel_size` and `shape` are arguments to functions that measure in pixels, not
+    inputs to the geometry -- they cancel between the projection and the conversion
+    back to metres, verified identical across a 27,000x range of pixel sizes. They are
+    carried here so the two directions cannot be handed different ones.
+    """
+
+    geometry: "FibsemHardwareGeometry"
+    pixel_size: float
+    shape: Tuple[int, int]  # (height, width)
+
+    @classmethod
+    def from_microscope(
+        cls, microscope: "FibsemMicroscope"
+    ) -> Optional["FMStageProjection"]:
+        """Read the projection off the live instrument, or None if it cannot be read.
+
+        Live rather than from a displayed image, for two reasons. `FibsemHardwareGeometry` is
+        system configuration -- camera tilt, shuttle pre-tilt, the camera flip,
+        compustage or not -- and not pose; the pose enters through the frame's origin,
+        as its rotation and tilt. So a recorded geometry and the live one agree by
+        construction.
+
+        And, at present, an acquired tile has no geometry to read: the metadata
+        constructors that combine channels and z-planes rebuild it field by field, and
+        a stitched mosaic inherits the gap (FIB-416). Taking it from the displayed
+        image made everything drawn from a stage position vanish the moment an overview
+        was acquired.
+        """
+        if microscope.fm is None:
+            return None
+        try:
+            width, height = microscope.fm.camera.resolution
+            pixel_size = microscope.fm.camera.pixel_size[0]
+            if not pixel_size:
+                return None
+            return cls(
+                geometry=microscope.fm_image_geometry(),
+                pixel_size=pixel_size,
+                shape=(height, width),
+            )
+        except Exception as e:
+            logging.debug(f"Could not read the live FM geometry: {e}")
+            return None
+
+    @classmethod
+    def from_image(cls, image) -> Optional["FMStageProjection"]:
+        """Read the projection off an image's own metadata, or None if it has none.
+
+        For placing an image rather than drawing on top of one, and the reason the
+        projection is not simply always taken live: an image may have been acquired
+        under a configuration the instrument is no longer in -- a different camera
+        transform, or loaded from disk entirely -- and it has to be placed as it was
+        taken, not as things stand now.
+        """
+        metadata = getattr(image, "metadata", None)
+        geometry = getattr(metadata, "geometry", None)
+        pixel_size = getattr(metadata, "pixel_size_x", None)
+        if geometry is None or not pixel_size:
+            return None
+        shape = np.asarray(image.data).shape[-2:]
+        return cls(geometry=geometry, pixel_size=pixel_size, shape=shape)
+
+    def to_plane(
+        self, position: FibsemStagePosition, base: FibsemStagePosition
+    ) -> Tuple[float, float]:
+        point = project_stage_position(
+            position, base, self.pixel_size, self.shape, self.geometry
+        )
+        # `project_stage_position` answers in pixels measured from the corner; the
+        # frame wants metres measured from the centre.
+        return (
+            (point.x - self.shape[1] / 2) * self.pixel_size,
+            (point.y - self.shape[0] / 2) * self.pixel_size,
+        )
+
+    def from_plane(
+        self, dx: float, dy: float, base: FibsemStagePosition
+    ) -> FibsemStagePosition:
+        # `project_image_point` is the exact inverse of `project_stage_position`,
+        # sharing its sign terms, so a click on a marker resolves to the position that
+        # marker was drawn from rather than to somewhere plausibly near it.
+        point = Point(
+            x=self.shape[1] / 2 + dx / self.pixel_size,
+            y=self.shape[0] / 2 + dy / self.pixel_size,
+        )
+        return project_image_point(
+            point, base, self.pixel_size, self.shape, self.geometry
+        )
+
+
+@dataclass(frozen=True)
+class BeamStageProjection:
+    """The beam projection: column tilt, shuttle pre-tilt, scan rotation.
+
+    The FIB/SEM counterpart of :class:`FMStageProjection`. Both directions run one
+    derivation, which is the point: today they are two. Where a stage position lands on
+    an overview comes from
+    :func:`~fibsem.imaging.tiling.reprojection.calculate_reprojected_stage_position2`,
+    working from image metadata; where a click sends the stage comes from
+    :meth:`FibsemMicroscope.project_stable_move`, working from the live instrument. They
+    are meant to be inverses and are written separately, so nothing holds them together
+    -- and a disagreement shows up as markers that are subtly, consistently in the wrong
+    place, which looks like a calibration problem rather than a bug.
+
+    Two consequences of taking the projection off the instrument, both wanted:
+
+    * **No hardware read per click.** ``project_stable_move`` calls ``get_scan_rotation``
+      every time, which on a TFS system is a set-then-read on the shared imaging channel
+      -- from the GUI thread, on a mouse event. Here the scan rotation is read once, when
+      the projection is built, and carried.
+    * **A saved overview projects as it was taken.** Clicking one after the stage has
+      moved, or after the scan rotation has changed, still answers about that image.
+
+    ``scan_rotation`` is in radians and only its proximity to pi matters: both directions
+    flip x and y together at 180 degrees and do nothing otherwise, matching the live path.
+    Intermediate rotations are not modelled by either -- that is pre-existing, and this
+    class is deliberately not the place to start.
+    """
+
+    geometry: "FibsemHardwareGeometry"
+    beam_type: BeamType
+    scan_rotation: float  # radians
+    # Tescan's stage geometry is different enough that it overrides the projection
+    # rather than passing a different view tilt -- its z-axis sits below the tilt axis,
+    # so the decomposition uses the full chamber-frame sample inclination. It also
+    # inverts stage x against image x. Carried as a flag rather than re-derived from a
+    # manufacturer string at each use (FIB-300 is the string check itself).
+    is_tescan: bool = False
+
+    @classmethod
+    def from_microscope(
+        cls, microscope: "FibsemMicroscope", beam_type: BeamType
+    ) -> Optional["BeamStageProjection"]:
+        """Read the projection off the live instrument, or None if it cannot be read.
+
+        The one hardware read is ``get_scan_rotation``, done here so it is not done per
+        click. A projection built this way describes the instrument as it is *now*, so
+        it is the right one for drawing on a live view and the wrong one for a saved
+        image -- see :meth:`from_image`.
+        """
+        try:
+            return cls(
+                geometry=microscope.hardware_geometry(),
+                beam_type=beam_type,
+                scan_rotation=microscope.get_scan_rotation(beam_type=beam_type),
+                is_tescan=microscope.system.info.manufacturer.upper() == "TESCAN",
+            )
+        except Exception as e:
+            logging.debug(f"Could not read the live beam geometry: {e}")
+            return None
+
+    @classmethod
+    def from_image(cls, image: "FibsemImage") -> Optional["BeamStageProjection"]:
+        """Read the projection off an image's own metadata, or None if it has none.
+
+        For placing or clicking an image that was acquired under a configuration the
+        instrument may no longer be in -- a different scan rotation, or loaded from disk
+        entirely. It has to be projected as it was taken, not as things stand now.
+        """
+        metadata = getattr(image, "metadata", None)
+        geometry = getattr(metadata, "hardware_geometry", None)
+        if metadata is None or geometry is None:
+            return None
+        try:
+            beam_type = metadata.image_settings.beam_type
+            state = metadata.microscope_state
+            beam = (
+                state.electron_beam
+                if beam_type is BeamType.ELECTRON
+                else state.ion_beam
+            )
+            if beam is None or beam.scan_rotation is None:
+                return None
+            info = metadata.system_info
+            return cls(
+                geometry=geometry,
+                beam_type=beam_type,
+                scan_rotation=beam.scan_rotation,
+                is_tescan=(
+                    info is not None and info.manufacturer.upper() == "TESCAN"
+                ),
+            )
+        except Exception as e:
+            logging.debug(f"Could not read the beam geometry from the image: {e}")
+            return None
+
+    # ── the protocol ──────────────────────────────────────────────────────
+
+    def to_plane(
+        self, position: FibsemStagePosition, base: FibsemStagePosition
+    ) -> Tuple[float, float]:
+        delta = position - base
+        dx = -delta.x if self.is_tescan else delta.x
+        expected_y = self._expected_y(delta.y or 0.0, delta.z or 0.0, base)
+        # The plane's y runs *down*, image-fashion, while `expected_y` is the
+        # microscope's image-space y, which runs up. `FMStageProjection` inherits the
+        # same flip from `project_stage_position`.
+        return self._scan_rotated(dx or 0.0, -expected_y)
+
+    def from_plane(
+        self, dx: float, dy: float, base: FibsemStagePosition
+    ) -> FibsemStagePosition:
+        # Undone in the reverse order to `to_plane`, though both terms are sign flips
+        # and so commute -- written this way because an inverse that reads as one is
+        # easier to keep correct than one that relies on the commuting.
+        dx, dy = self._scan_rotated(dx, dy)
+        expected_y = -dy
+        if self.is_tescan:
+            dx = -dx
+
+        position = deepcopy(base)
+        if self.is_tescan:
+            y_chamber, z_chamber = y_corrected_stage_movement_tescan_from_geometry(
+                geometry=self.geometry,
+                stage_position=base,
+                expected_y=expected_y,
+                beam_type=self.beam_type,
+            )
+            # `stable_move` inverts stage y against the chamber frame and leaves z; the
+            # Tescan inverse undoes that same inversion on its way in.
+            y_move, z_move = -y_chamber, z_chamber
+        else:
+            y_move, z_move = view_corrected_stage_movement(
+                expected_y=expected_y,
+                view_tilt=self._view_tilt(),
+                geometry=self.geometry,
+                stage_rotation=base.r or 0.0,
+                stage_tilt=base.t or 0.0,
+            )
+
+        position.x = (position.x or 0.0) + dx
+        position.y = (position.y or 0.0) + y_move
+        position.z = (position.z or 0.0) + z_move
+        return position
+
+    # ── internals ─────────────────────────────────────────────────────────
+
+    def _view_tilt(self) -> float:
+        """How far this beam's axis is tilted from the electron column, in radians.
+
+        The same quantity :meth:`FibsemMicroscope._beam_view_tilt` returns, and the same
+        one the fluorescence path passes as the camera tilt -- which is what lets all
+        three share one projection.
+        """
+        if self.beam_type is BeamType.ELECTRON:
+            return 0.0
+        return np.deg2rad(self.geometry.fib_column_tilt)
+
+    def _expected_y(
+        self, dy: float, dz: float, base: FibsemStagePosition
+    ) -> float:
+        """The image-space y-displacement a y/z stage movement corresponds to."""
+        if self.is_tescan:
+            return inverse_y_corrected_stage_movement_tescan_from_geometry(
+                geometry=self.geometry,
+                stage_position=base,
+                dy=dy,
+                dz=dz,
+                beam_type=self.beam_type,
+            )
+        return inverse_view_corrected_dy(
+            dy=dy,
+            dz=dz,
+            view_tilt=self._view_tilt(),
+            geometry=self.geometry,
+            stage_rotation=base.r or 0.0,
+            stage_tilt=base.t or 0.0,
+        )
+
+    def _scan_rotated(self, x: float, y: float) -> Tuple[float, float]:
+        """Apply a 180-degree scan rotation, which is its own inverse."""
+        if np.isclose(self.scan_rotation, np.pi):
+            return -x, -y
+        return x, y

--- a/fibsem/transformations.py
+++ b/fibsem/transformations.py
@@ -1,10 +1,13 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
+
 import numpy as np
 
+from fibsem.movement import rotation_angle_is_smaller
 
 if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
+    from fibsem.structures import FibsemHardwareGeometry
 
 def convert_milling_angle_to_stage_tilt(
     milling_angle: float, pretilt: float, column_tilt: float = np.deg2rad(52)
@@ -80,3 +83,175 @@ def is_close_to_milling_angle(
         f"the stage tilt for the milling angle is {np.degrees(stage_tilt):.2f} deg"
     )
     return np.isclose(stage_tilt, current_stage_tilt, atol=atol)
+
+
+# ── the view projection, without a microscope ────────────────────────────────
+#
+# Every view of the sample runs the same projection and differs only in how far its
+# viewing axis is tilted from the electron column: the electron column is 0, the ion
+# column is its `column_tilt`, the fluorescence camera is its `camera_tilt`. That is
+# already how the live path is written -- `FibsemMicroscope._view_corrected_stage_
+# movement(expected_y, view_tilt)`, with `_beam_view_tilt` and `camera_tilt` as its two
+# callers -- and these are the microscope-free form of the same thing, parameterised by
+# a recorded `FibsemHardwareGeometry` and pose instead of reading a live instrument.
+#
+# Microscope-free matters because these answer questions *about a saved image*: where a
+# stage position falls on it, and where a click on it points. Reading the pose or the
+# transform from the live instrument would make the answer depend on state the image
+# does not describe -- and looking at a saved image after the stage has moved is exactly
+# when someone asks.
+#
+# They live here rather than beside either modality's reprojection module because both
+# use them. They arrived in `fibsem/fm/reprojection.py` with the camera tilt baked in,
+# which read as fluorescence-specific and was not.
+
+
+def _projection_terms(
+    geometry: "FibsemHardwareGeometry",
+    stage_rotation: float,
+    stage_tilt: float,
+) -> Tuple[float, float, float]:
+    """The sign and angle terms both directions of the projection share.
+
+    Factored out rather than written twice: the forward and the inverse differ only in
+    the arithmetic that follows, and a sign convention that drifts between them would
+    make a click land somewhere other than where the marker was drawn -- while each
+    direction on its own still looked self-consistent.
+
+    Returns:
+        (compustage_sign, corrected_pretilt_angle, stage_tilt), where `stage_tilt` has
+        the compustage half-turn already folded in.
+    """
+    sem_column_tilt = np.deg2rad(geometry.column_tilt)
+    stage_pretilt = np.deg2rad(geometry.shuttle_pre_tilt)
+    rotation_flat_to_eb = np.deg2rad(geometry.rotation_reference) % (2 * np.pi)
+    rotation_flat_to_ion = np.deg2rad(geometry.rotation_180) % (2 * np.pi)
+
+    stage_rotation = stage_rotation % (2 * np.pi)
+
+    # The forward flips expected_y once for a compustage and a second time at the FIB
+    # orientation, so the two cancel there. The orientation is derived from the pose
+    # rather than from a live microscope's `get_stage_orientation`.
+    #
+    # The rotation test is not redundant with the tilt test: a compustage cannot
+    # rotate, so `get_stage_orientation` reports FIB only at the reference rotation.
+    # Keying on tilt alone would call an unreachable pose FIB and flip the sign
+    # against the live path -- which is a disagreement no physical run can surface,
+    # and so exactly the kind that survives. `fibsem/imaging/tiling/reprojection.py`
+    # still keys on tilt alone; that is FIB-500, deliberately left for its own change
+    # because it moves a stage sign.
+    compustage_sign = 1.0
+    is_fib_orientation = False
+    if geometry.is_compustage:
+        fib_orientation_tilt = np.deg2rad(
+            geometry.fib_column_tilt - geometry.shuttle_pre_tilt - 180
+        )
+        is_fib_orientation = bool(
+            np.isclose(stage_tilt, fib_orientation_tilt, atol=0.1)
+            and rotation_angle_is_smaller(stage_rotation, rotation_flat_to_eb, atol=5)
+        )
+        compustage_sign = 1.0 if is_fib_orientation else -1.0
+        stage_tilt = stage_tilt + np.pi
+
+    pretilt_sign = 1.0
+    if rotation_angle_is_smaller(stage_rotation, rotation_flat_to_eb, atol=5):
+        pretilt_sign = 1.0
+    if rotation_angle_is_smaller(stage_rotation, rotation_flat_to_ion, atol=5):
+        pretilt_sign = -1.0
+    if is_fib_orientation:
+        pretilt_sign = -1.0
+
+    corrected_pretilt_angle = pretilt_sign * (stage_pretilt + sem_column_tilt)
+
+    return compustage_sign, corrected_pretilt_angle, stage_tilt
+
+
+def view_corrected_stage_movement(
+    expected_y: float,
+    view_tilt: float,
+    geometry: "FibsemHardwareGeometry",
+    stage_rotation: float,
+    stage_tilt: float,
+) -> Tuple[float, float]:
+    """Split an in-image y-displacement across the stage y- and z-axes.
+
+    The microscope-free form of
+    :meth:`FibsemMicroscope._view_corrected_stage_movement`.
+
+    Args:
+        expected_y: displacement along the image y-axis, in metres.
+        view_tilt: tilt of the viewing axis from the electron column, in radians.
+            0 for the electron beam, the ion column tilt for the ion beam, the camera
+            tilt for fluorescence.
+        geometry: the geometry the image was captured under.
+        stage_rotation: stage rotation at acquisition, in radians.
+        stage_tilt: stage tilt at acquisition, in radians.
+
+    Returns:
+        (dy, dz) stage movement, in metres.
+    """
+    compustage_sign, corrected_pretilt_angle, stage_tilt = _projection_terms(
+        geometry, stage_rotation, stage_tilt
+    )
+
+    if geometry.is_compustage:
+        expected_y = expected_y * compustage_sign
+
+    perspective_tilt_adjustment = -corrected_pretilt_angle - view_tilt
+    y_sample_move = expected_y / np.cos(stage_tilt + perspective_tilt_adjustment)
+
+    return (
+        float(y_sample_move * np.cos(corrected_pretilt_angle)),
+        float(-y_sample_move * np.sin(corrected_pretilt_angle)),
+    )
+
+
+def inverse_view_corrected_dy(
+    dy: float,
+    dz: float,
+    view_tilt: float,
+    geometry: "FibsemHardwareGeometry",
+    stage_rotation: float,
+    stage_tilt: float,
+) -> float:
+    """Recover an in-image y-displacement from a y/z stage movement.
+
+    The microscope-free form of
+    :meth:`FibsemMicroscope._inverse_view_corrected_stage_movement`, parameterised by
+    the geometry rather than reading it off a live instrument. The two are held
+    together by a parity test across the full pose matrix, because a projection that
+    silently disagrees with the one used to move the stage puts every overlay in the
+    wrong place.
+
+    Args:
+        dy: stage y movement, in metres.
+        dz: stage z movement, in metres.
+        view_tilt: tilt of the viewing axis from the electron column, in radians.
+        geometry: the geometry the image was captured under.
+        stage_rotation: stage rotation at acquisition, in radians.
+        stage_tilt: stage tilt at acquisition, in radians.
+
+    Returns:
+        The in-image y-displacement that would produce that stage movement, in metres.
+    """
+    compustage_sign, corrected_pretilt_angle, stage_tilt = _projection_terms(
+        geometry, stage_rotation, stage_tilt
+    )
+
+    perspective_tilt_adjustment = -corrected_pretilt_angle - view_tilt
+
+    # Undo y_move = y_sample_move * cos(a) and z_move = -y_sample_move * sin(a),
+    # taking whichever component is larger so the division stays conditioned.
+    cos_pretilt = np.cos(corrected_pretilt_angle)
+    sin_pretilt = np.sin(corrected_pretilt_angle)
+    if abs(cos_pretilt) > abs(sin_pretilt):
+        y_sample_move = dy / cos_pretilt
+    else:
+        y_sample_move = -dz / sin_pretilt
+
+    expected_y = y_sample_move * np.cos(stage_tilt + perspective_tilt_adjustment)
+
+    if geometry.is_compustage:
+        expected_y *= compustage_sign
+
+    return float(expected_y)

--- a/fibsem/ui/widgets/canvas/stage_frame.py
+++ b/fibsem/ui/widgets/canvas/stage_frame.py
@@ -18,140 +18,28 @@ enough alone:
 The frame is anchored at an *origin*: the stage position it is built around. Whoever
 owns the frame fixes that once and keeps it, because re-deriving it from whatever
 arrived last would shift the whole scene each time something did.
+
+The projections themselves live in :mod:`fibsem.projection`, outside ``fibsem/ui``:
+they are arithmetic over recorded geometry with no Qt in them, and importing
+``fibsem.ui`` pulls in the whole widget package, which CI does not install. They are
+re-exported here because this is where callers expect to find them alongside the frame
+they are handed to.
 """
 
 from __future__ import annotations
 
-import logging
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Protocol, Tuple
+from typing import TYPE_CHECKING, Tuple
 
-import numpy as np
-
-from fibsem.fm.reprojection import project_image_point, project_stage_position
-from fibsem.structures import FibsemStagePosition, Point
+# Re-exported for the callers that reach for a projection and a frame together.
+from fibsem.projection import (  # noqa: F401
+    BeamStageProjection,
+    FMStageProjection,
+    StageProjection,
+)
+from fibsem.structures import FibsemStagePosition
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
-    from fibsem.fm.structures import FibsemHardwareGeometry
-    from fibsem.microscope import FibsemMicroscope
     from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
-
-
-class StageProjection(Protocol):
-    """Stage coordinates to the displayed plane and back, both in metres.
-
-    Metres rather than pixels on purpose. The underlying projections answer in pixels
-    of a hypothetical image, but pixels are a property of a detector, not of the
-    geometry, and a real-space canvas has its own scale -- so a projection that spoke
-    in pixels would have to be told which pixels, and the answer would cancel out
-    immediately afterwards.
-    """
-
-    def to_plane(
-        self, position: FibsemStagePosition, base: FibsemStagePosition
-    ) -> Tuple[float, float]:
-        """Where *position* falls relative to *base*, in metres in the displayed plane."""
-        ...
-
-    def from_plane(
-        self, dx: float, dy: float, base: FibsemStagePosition
-    ) -> FibsemStagePosition:
-        """The stage position a displayed-plane offset from *base* corresponds to."""
-        ...
-
-
-@dataclass(frozen=True)
-class FMStageProjection:
-    """The fluorescence projection: camera axis tilt, image transform, sample tilt.
-
-    `pixel_size` and `shape` are arguments to functions that measure in pixels, not
-    inputs to the geometry -- they cancel between the projection and the conversion
-    back to metres, verified identical across a 27,000x range of pixel sizes. They are
-    carried here so the two directions cannot be handed different ones.
-    """
-
-    geometry: "FibsemHardwareGeometry"
-    pixel_size: float
-    shape: Tuple[int, int]  # (height, width)
-
-    @classmethod
-    def from_microscope(
-        cls, microscope: "FibsemMicroscope"
-    ) -> Optional["FMStageProjection"]:
-        """Read the projection off the live instrument, or None if it cannot be read.
-
-        Live rather than from a displayed image, for two reasons. `FibsemHardwareGeometry` is
-        system configuration -- camera tilt, shuttle pre-tilt, the camera flip,
-        compustage or not -- and not pose; the pose enters through the frame's origin,
-        as its rotation and tilt. So a recorded geometry and the live one agree by
-        construction.
-
-        And, at present, an acquired tile has no geometry to read: the metadata
-        constructors that combine channels and z-planes rebuild it field by field, and
-        a stitched mosaic inherits the gap (FIB-416). Taking it from the displayed
-        image made everything drawn from a stage position vanish the moment an overview
-        was acquired.
-        """
-        if microscope.fm is None:
-            return None
-        try:
-            width, height = microscope.fm.camera.resolution
-            pixel_size = microscope.fm.camera.pixel_size[0]
-            if not pixel_size:
-                return None
-            return cls(
-                geometry=microscope.fm_image_geometry(),
-                pixel_size=pixel_size,
-                shape=(height, width),
-            )
-        except Exception as e:
-            logging.debug(f"Could not read the live FM geometry: {e}")
-            return None
-
-    @classmethod
-    def from_image(cls, image) -> Optional["FMStageProjection"]:
-        """Read the projection off an image's own metadata, or None if it has none.
-
-        For placing an image rather than drawing on top of one, and the reason the
-        projection is not simply always taken live: an image may have been acquired
-        under a configuration the instrument is no longer in -- a different camera
-        transform, or loaded from disk entirely -- and it has to be placed as it was
-        taken, not as things stand now.
-        """
-        metadata = getattr(image, "metadata", None)
-        geometry = getattr(metadata, "geometry", None)
-        pixel_size = getattr(metadata, "pixel_size_x", None)
-        if geometry is None or not pixel_size:
-            return None
-        shape = np.asarray(image.data).shape[-2:]
-        return cls(geometry=geometry, pixel_size=pixel_size, shape=shape)
-
-    def to_plane(
-        self, position: FibsemStagePosition, base: FibsemStagePosition
-    ) -> Tuple[float, float]:
-        point = project_stage_position(
-            position, base, self.pixel_size, self.shape, self.geometry
-        )
-        # `project_stage_position` answers in pixels measured from the corner; the
-        # frame wants metres measured from the centre.
-        return (
-            (point.x - self.shape[1] / 2) * self.pixel_size,
-            (point.y - self.shape[0] / 2) * self.pixel_size,
-        )
-
-    def from_plane(
-        self, dx: float, dy: float, base: FibsemStagePosition
-    ) -> FibsemStagePosition:
-        # `project_image_point` is the exact inverse of `project_stage_position`,
-        # sharing its sign terms, so a click on a marker resolves to the position that
-        # marker was drawn from rather than to somewhere plausibly near it.
-        point = Point(
-            x=self.shape[1] / 2 + dx / self.pixel_size,
-            y=self.shape[0] / 2 + dy / self.pixel_size,
-        )
-        return project_image_point(
-            point, base, self.pixel_size, self.shape, self.geometry
-        )
 
 
 class StageFrame:

--- a/tests/fm/test_reprojection.py
+++ b/tests/fm/test_reprojection.py
@@ -12,12 +12,10 @@ import pytest
 from fibsem import utils
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.reprojection import (
-    inverse_view_corrected_dy,
     project_image_point,
     project_stage_position,
     reproject_stage_positions_onto_fm_image,
     stage_position_from_fm_image,
-    view_corrected_stage_movement,
 )
 from fibsem.fm.structures import (
     CameraImageTransform,
@@ -25,6 +23,10 @@ from fibsem.fm.structures import (
     FibsemHardwareGeometry,
 )
 from fibsem.structures import FibsemStagePosition, Point
+from fibsem.transformations import (
+    inverse_view_corrected_dy,
+    view_corrected_stage_movement,
+)
 
 TRANSFORMS = list(CameraImageTransform)
 SHAPE = (1024, 1024)
@@ -92,6 +94,7 @@ class TestParityWithTheLiveMicroscope:
         )
         pure = inverse_view_corrected_dy(
             dy=12e-6, dz=-3e-6,
+            view_tilt=np.deg2rad(microscope.fm.camera_tilt),
             geometry=microscope.fm_image_geometry(),
             stage_rotation=position.r,
             stage_tilt=position.t,
@@ -119,6 +122,7 @@ class TestParityWithTheLiveMicroscope:
         )
         dy, dz = view_corrected_stage_movement(
             17e-6,
+            view_tilt=np.deg2rad(microscope.fm.camera_tilt),
             geometry=microscope.fm_image_geometry(),
             stage_rotation=position.r,
             stage_tilt=position.t,
@@ -142,6 +146,7 @@ class TestParityWithTheLiveMicroscope:
         )
         pure = inverse_view_corrected_dy(
             dy=12e-6, dz=-3e-6,
+            view_tilt=np.deg2rad(microscope.fm.camera_tilt),
             geometry=microscope.fm_image_geometry(),
             stage_rotation=position.r,
             stage_tilt=position.t,

--- a/tests/test_beam_stage_projection.py
+++ b/tests/test_beam_stage_projection.py
@@ -1,0 +1,372 @@
+"""The FIB/SEM stage projection: agreement with both halves it replaces.
+
+`BeamStageProjection` exists because the beam side currently runs *two* derivations of
+one formula. Where a stage position lands on an overview comes from
+`reproject_stage_positions_onto_image2`, off image metadata. Where a click sends the
+stage comes from `microscope.project_stable_move`, off the live instrument. Nothing
+holds them together, and a disagreement between them draws every marker consistently
+slightly wrong -- which reads as a calibration problem, not a bug.
+
+So the tests that matter here are not "does it compute something plausible" but three
+agreements:
+
+* forward, against `reproject_stage_positions_onto_image2` on a real image
+* inverse, against `microscope.project_stable_move` on a live (simulated) instrument
+* with itself, round-trip, which is the property neither of the above can give
+
+Run directly:
+    PYTHONPATH=$PWD python -m pytest tests/test_beam_stage_projection.py
+"""
+from __future__ import annotations
+
+import itertools
+
+import numpy as np
+import pytest
+
+from fibsem import utils
+from fibsem.imaging.tiling.reprojection import (
+    reproject_stage_positions_onto_image2,
+    y_corrected_stage_movement_tescan_from_geometry,
+)
+from fibsem.structures import (
+    BeamType,
+    FibsemHardwareGeometry,
+    FibsemImage,
+    FibsemStagePosition,
+    ImageSettings,
+)
+from fibsem.projection import BeamStageProjection
+
+SHAPE = (1024, 1536)  # (height, width) -- deliberately non-square, so an axis swap shows
+PIXEL_SIZE = 2e-7
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    scope, _ = utils.setup_session(manufacturer="Demo")
+    return scope
+
+
+def _pose(microscope, *, compustage, pretilt_deg, rotation_deg, tilt_deg):
+    """Pin the microscope into a known geometry without moving the stage."""
+    microscope.stage_is_compustage = compustage
+    microscope.system.stage.shuttle_pre_tilt = pretilt_deg
+    microscope._update_orientations()
+    position = FibsemStagePosition(
+        x=0.0, y=0.0, z=0.0,
+        r=np.deg2rad(rotation_deg),
+        t=np.deg2rad(tilt_deg),
+    )
+    microscope.get_stage_position = lambda: position  # type: ignore[method-assign]
+    return position
+
+
+# A compustage cannot rotate, so only the reference rotation is a reachable pose for it
+# -- the same restriction `tests/fm/test_reprojection.py` applies, and for the same
+# reason (FIB-500 documents why the unreachable poses still matter).
+POSES = [
+    pytest.param(True, 0, 0, tilt, id=f"compustage-t{tilt}")
+    for tilt in (0, -30, -128, -180)
+] + [
+    pytest.param(False, pretilt, rot, tilt, id=f"stage-p{pretilt}-r{rot}-t{tilt}")
+    for pretilt in (0, 35)
+    for rot in (0, 180)
+    for tilt in (0, 25, -30)
+]
+
+BEAMS = [BeamType.ELECTRON, BeamType.ION]
+SCAN_ROTATIONS = [0.0, np.pi]
+
+# A Tescan-shaped instrument, stated rather than read off the shared fixture — see
+# `test_tescan_survives_a_round_trip_too`.
+_TESCAN_GEOMETRY = FibsemHardwareGeometry(
+    column_tilt=0.0,
+    fib_column_tilt=55.0,
+    shuttle_pre_tilt=0.0,
+    rotation_reference=0.0,
+    rotation_180=180.0,
+    is_compustage=False,
+)
+# Chosen to straddle 45 degrees of sample inclination, which is where the Tescan
+# inverse switches from reading dy to reading dz — and so where a round trip stops
+# being able to see the stage-y sign at all.
+TESCAN_TILTS = [0, 15, 40, 50, 75]
+
+
+def _geometry(microscope, compustage: bool) -> FibsemHardwareGeometry:
+    return FibsemHardwareGeometry.from_system_settings(
+        microscope.system, is_compustage=compustage
+    )
+
+
+class TestParityWithTheLiveMicroscope:
+    """`from_plane` must reproduce `project_stable_move` exactly.
+
+    That method is what actually drives the stage today, so anything this class lets
+    through is a click that lands somewhere other than where the user pointed.
+    """
+
+    @pytest.mark.parametrize("compustage, pretilt, rot, tilt", POSES)
+    @pytest.mark.parametrize("beam_type", BEAMS)
+    @pytest.mark.parametrize("scan_rotation", SCAN_ROTATIONS)
+    def test_the_inverse_matches_project_stable_move(
+        self, microscope, compustage, pretilt, rot, tilt, beam_type, scan_rotation,
+        monkeypatch,
+    ):
+        base = _pose(
+            microscope, compustage=compustage, pretilt_deg=pretilt,
+            rotation_deg=rot, tilt_deg=tilt,
+        )
+        monkeypatch.setattr(
+            microscope, "get_scan_rotation", lambda beam_type: scan_rotation
+        )
+
+        dx, dy_up = 31e-6, -17e-6  # dy_up is the microscope's image y, pointing up
+        live = microscope.project_stable_move(
+            dx=dx, dy=dy_up, beam_type=beam_type, base_position=base
+        )
+
+        projection = BeamStageProjection.from_microscope(microscope, beam_type)
+        assert projection is not None
+        # The canvas plane's y runs down, so it is handed the negation of the
+        # microscope's image y -- the one conversion this class is asserting about.
+        pure = projection.from_plane(dx, -dy_up, base)
+
+        assert pure.x == pytest.approx(live.x, abs=1e-15)
+        assert pure.y == pytest.approx(live.y, abs=1e-15)
+        assert pure.z == pytest.approx(live.z, abs=1e-15)
+
+    def test_the_scan_rotation_is_read_once_not_per_call(self, microscope, monkeypatch):
+        """The reason this class exists at all, beyond agreement.
+
+        `project_stable_move` calls `get_scan_rotation` on every invocation, and on a
+        TFS system that is a set-then-read on the shared imaging channel -- fired from
+        the GUI thread on a mouse event. Building the projection reads it once; using it
+        reads nothing.
+        """
+        _pose(microscope, compustage=False, pretilt_deg=35, rotation_deg=0, tilt_deg=0)
+        calls = []
+
+        def counting(beam_type):
+            calls.append(beam_type)
+            return 0.0
+
+        monkeypatch.setattr(microscope, "get_scan_rotation", counting)
+        projection = BeamStageProjection.from_microscope(microscope, BeamType.ELECTRON)
+        assert len(calls) == 1, "construction should read the scan rotation exactly once"
+
+        base = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0)
+        for _ in range(20):
+            projection.from_plane(10e-6, 10e-6, base)
+            projection.to_plane(base, base)
+        assert len(calls) == 1, "using the projection read hardware"
+
+
+class TestParityWithTheTiledReprojection:
+    """`to_plane` must reproduce `reproject_stage_positions_onto_image2`.
+
+    That function is what draws every marker on the Overview tab today, so this is the
+    test that says the new canvas will put them in the same places as the old one.
+    """
+
+    @staticmethod
+    def _image(microscope, base, beam_type, scan_rotation) -> FibsemImage:
+        state = microscope.get_microscope_state(beam_type=beam_type)
+        state.stage_position = base
+        beam = state.electron_beam if beam_type is BeamType.ELECTRON else state.ion_beam
+        beam.scan_rotation = scan_rotation
+        image = FibsemImage.generate_blank_image(
+            resolution=(SHAPE[1], SHAPE[0]), hfw=SHAPE[1] * PIXEL_SIZE
+        )
+        image.metadata.image_settings = ImageSettings(
+            hfw=SHAPE[1] * PIXEL_SIZE, beam_type=beam_type
+        )
+        image.metadata.microscope_state = state
+        image.metadata.system_info = microscope.system.info
+        image.metadata.hardware_geometry = microscope.hardware_geometry()
+        return image
+
+    @pytest.mark.parametrize("compustage, pretilt, rot, tilt", POSES)
+    @pytest.mark.parametrize("beam_type", BEAMS)
+    @pytest.mark.parametrize("scan_rotation", SCAN_ROTATIONS)
+    def test_the_forward_matches_the_tiled_reprojection(
+        self, microscope, compustage, pretilt, rot, tilt, beam_type, scan_rotation,
+    ):
+        base = _pose(
+            microscope, compustage=compustage, pretilt_deg=pretilt,
+            rotation_deg=rot, tilt_deg=tilt,
+        )
+        image = self._image(microscope, base, beam_type, scan_rotation)
+
+        target = FibsemStagePosition(
+            x=base.x + 120e-6, y=base.y - 45e-6, z=base.z + 8e-6, r=base.r, t=base.t,
+        )
+        (point,) = reproject_stage_positions_onto_image2(image, [target])
+        # The tiled function answers in pixels from the image corner; the projection
+        # answers in metres from the image centre. Same place, different units.
+        expected = (
+            (point.x - SHAPE[1] / 2) * PIXEL_SIZE,
+            (point.y - SHAPE[0] / 2) * PIXEL_SIZE,
+        )
+
+        projection = BeamStageProjection.from_image(image)
+        assert projection is not None
+        got = projection.to_plane(target, base)
+
+        assert got[0] == pytest.approx(expected[0], abs=1e-12)
+        assert got[1] == pytest.approx(expected[1], abs=1e-12)
+
+    def test_it_reads_the_image_not_the_instrument(self, microscope, monkeypatch):
+        """A saved overview must project as it was taken.
+
+        The scan rotation is the visible case: change it on the instrument after
+        acquisition and the markers on a loaded image must not all invert. Reading it
+        live -- which `project_stable_move` does -- gets this wrong, and the wrongness
+        is a 180-degree flip, so it is not subtle once it happens.
+        """
+        base = _pose(
+            microscope, compustage=False, pretilt_deg=35, rotation_deg=0, tilt_deg=0
+        )
+        image = self._image(microscope, base, BeamType.ELECTRON, scan_rotation=0.0)
+        monkeypatch.setattr(microscope, "get_scan_rotation", lambda beam_type: np.pi)
+
+        from_image = BeamStageProjection.from_image(image)
+        from_live = BeamStageProjection.from_microscope(microscope, BeamType.ELECTRON)
+
+        target = FibsemStagePosition(
+            x=100e-6, y=0.0, z=0.0, r=base.r, t=base.t
+        )
+        assert from_image.to_plane(target, base)[0] == pytest.approx(100e-6)
+        assert from_live.to_plane(target, base)[0] == pytest.approx(-100e-6), (
+            "the live projection should have flipped -- otherwise this test proves nothing"
+        )
+
+
+class TestRoundTrip:
+    """A click on a marker must resolve to the position that marker was drawn from.
+
+    Neither parity test above can establish this: they each pin one direction against
+    one existing implementation, and the two existing implementations have never been
+    checked against *each other*. This is the property the class was created for.
+    """
+
+    @pytest.mark.parametrize("compustage, pretilt, rot, tilt", POSES)
+    @pytest.mark.parametrize("beam_type", BEAMS)
+    @pytest.mark.parametrize("scan_rotation", SCAN_ROTATIONS)
+    def test_a_position_survives_a_round_trip(
+        self, microscope, compustage, pretilt, rot, tilt, beam_type, scan_rotation,
+    ):
+        base = _pose(
+            microscope, compustage=compustage, pretilt_deg=pretilt,
+            rotation_deg=rot, tilt_deg=tilt,
+        )
+        projection = BeamStageProjection(
+            geometry=_geometry(microscope, compustage),
+            beam_type=beam_type,
+            scan_rotation=scan_rotation,
+        )
+
+        for dx, dy in itertools.product((-250e-6, 0.0, 90e-6), (-40e-6, 0.0, 310e-6)):
+            recovered = projection.from_plane(dx, dy, base)
+            back = projection.to_plane(recovered, base)
+            assert back[0] == pytest.approx(dx, abs=1e-12), f"x drifted at {(dx, dy)}"
+            assert back[1] == pytest.approx(dy, abs=1e-12), f"y drifted at {(dx, dy)}"
+
+    @pytest.mark.parametrize("beam_type", BEAMS)
+    @pytest.mark.parametrize("tilt_deg", TESCAN_TILTS)
+    def test_tescan_survives_a_round_trip_too(self, beam_type, tilt_deg):
+        """Tescan gets its own case because it is a genuinely different derivation --
+        z below the tilt axis, and stage x inverted against image x -- so it shares
+        none of the arithmetic the cases above exercise.
+
+        Built from an explicit geometry rather than the shared microscope fixture. That
+        fixture is module-scoped and every pose test mutates its pre-tilt and
+        orientations, so a Tescan case reading it was really testing whatever the
+        previous parameter left behind -- which is how it ended up at a sample
+        inclination past 45 degrees, where `test_the_chamber_frame_inversion_is_pinned`
+        explains this round trip goes blind.
+        """
+        projection = BeamStageProjection(
+            geometry=_TESCAN_GEOMETRY, beam_type=beam_type, scan_rotation=0.0,
+            is_tescan=True,
+        )
+        base = FibsemStagePosition(
+            x=1e-3, y=-2e-3, z=5e-3, r=0.0, t=np.deg2rad(tilt_deg)
+        )
+
+        for dx, dy in itertools.product((-250e-6, 90e-6), (-40e-6, 310e-6)):
+            back = projection.to_plane(projection.from_plane(dx, dy, base), base)
+            assert back[0] == pytest.approx(dx, abs=1e-12)
+            assert back[1] == pytest.approx(dy, abs=1e-12)
+
+    @pytest.mark.parametrize("tilt_deg", TESCAN_TILTS)
+    def test_the_chamber_frame_inversion_is_pinned(self, tilt_deg):
+        """`stable_move` inverts stage y against the chamber frame; assert it directly.
+
+        A round trip cannot be trusted to catch this. The Tescan inverse recovers the
+        sample-plane move from whichever of dy/dz is the larger component, so once the
+        sample inclination passes 45 degrees it reads **dz alone** and never looks at
+        dy -- at which point flipping the y sign changes nothing that comes back, and
+        the round-trip test passes over a projection that would drive the stage the
+        wrong way. Verified: this assertion fails under that flip at every tilt here,
+        while the round trip above only fails below 45 degrees.
+        """
+        projection = BeamStageProjection(
+            geometry=_TESCAN_GEOMETRY, beam_type=BeamType.ELECTRON, scan_rotation=0.0,
+            is_tescan=True,
+        )
+        base = FibsemStagePosition(
+            x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(tilt_deg)
+        )
+        # The canvas plane's y runs down, so this is +30 um in the microscope's image y.
+        y_chamber, z_chamber = y_corrected_stage_movement_tescan_from_geometry(
+            geometry=_TESCAN_GEOMETRY, stage_position=base, expected_y=30e-6,
+            beam_type=BeamType.ELECTRON,
+        )
+
+        got = projection.from_plane(0.0, -30e-6, base)
+
+        assert got.y == pytest.approx(-y_chamber, abs=1e-15), "stage y is not inverted"
+        assert got.z == pytest.approx(z_chamber, abs=1e-15), "stage z should not invert"
+
+    def test_tescan_inverts_stage_x_where_thermo_does_not(self):
+        """The one Tescan difference visible without doing the trig, kept as its own
+        assertion so a lost `is_tescan` branch fails loudly rather than shifting every
+        marker to the opposite side of the image (the FIB-300 symptom)."""
+        base = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0)
+        target = FibsemStagePosition(x=75e-6, y=0.0, z=0.0, r=0.0, t=0.0)
+        kw = dict(
+            geometry=_TESCAN_GEOMETRY, beam_type=BeamType.ELECTRON, scan_rotation=0.0
+        )
+
+        thermo = BeamStageProjection(**kw, is_tescan=False).to_plane(target, base)[0]
+        tescan = BeamStageProjection(**kw, is_tescan=True).to_plane(target, base)[0]
+
+        assert thermo == pytest.approx(75e-6)
+        assert tescan == pytest.approx(-75e-6)
+
+
+class TestRefusesRatherThanGuesses:
+    """An image that cannot be projected has to say so.
+
+    A projection built from partial metadata draws markers that look right and are not,
+    and there is nothing on screen to tell the difference -- the same argument
+    `fm/reprojection.py` makes for raising on a missing geometry.
+    """
+
+    def test_an_image_with_no_geometry_gives_no_projection(self, microscope):
+        _pose(microscope, compustage=False, pretilt_deg=0, rotation_deg=0, tilt_deg=0)
+        image = FibsemImage.generate_blank_image(resolution=(256, 256), hfw=1e-4)
+        image.metadata.hardware_geometry = None
+        assert BeamStageProjection.from_image(image) is None
+
+    def test_an_image_with_no_beam_state_gives_no_projection(self, microscope):
+        base = _pose(
+            microscope, compustage=False, pretilt_deg=0, rotation_deg=0, tilt_deg=0
+        )
+        image = TestParityWithTheTiledReprojection._image(
+            microscope, base, BeamType.ELECTRON, scan_rotation=0.0
+        )
+        image.metadata.microscope_state.electron_beam = None
+        assert BeamStageProjection.from_image(image) is None


### PR DESCRIPTION
Groundwork for moving the FIB/SEM Overview tab onto the real-space canvas (FIB-413,
and with it the napari removal for that tab, FIB-405). No UI consumers yet — nothing
here is user-visible.

## The problem

The beam side runs **two derivations of one formula**.

| direction | implementation | reads |
| -- | -- | -- |
| stage → overview | `calculate_reprojected_stage_position2` | image metadata |
| overview → stage | `microscope.project_stable_move` | the live instrument |

They are meant to be inverses. They are written separately, share no code, and nothing
holds them together — so a disagreement puts every marker consistently slightly wrong,
which on screen reads as a calibration problem rather than a bug.

The fluorescence side closed exactly this gap on purpose. `fm/reprojection.py` says
`project_image_point` "is the exact inverse of `project_stage_position`, sharing its
sign terms, so a click resolves to the position the marker was drawn from." This is
the same move for the beams.

## What changed

**The shared projection was already shared — only the camera tilt was baked in.**
`view_corrected_stage_movement` / `inverse_view_corrected_dy` lived in
`fibsem/fm/reprojection.py` and read `geometry.camera_tilt` directly. They are the
microscope-free form of `FibsemMicroscope._view_corrected_stage_movement(expected_y,
view_tilt)`, whose three callers are the electron column (0), the ion column (its
column tilt) and the camera. So they take a `view_tilt` argument and move to
`fibsem/transformations.py`; the beam side becomes a second caller rather than a
fourth copy.

**`BeamStageProjection`** implements the existing `StageProjection` protocol, so it
drops straight into `StageFrame` beside `FMStageProjection`. Two consequences beyond
agreement, both pinned by tests:

* **No hardware read per click.** `project_stable_move` calls `get_scan_rotation`
  every time — on a TFS system a set-then-read on the shared imaging channel
  (FIB-544), fired from the GUI thread on a mouse event. The projection reads it once,
  at construction. This is the rule FIB-600 established: UI events must not read the
  microscope.
* **A saved overview projects as it was taken.** `from_image` reads the scan rotation
  the image recorded, so clicking a loaded overview after the instrument has changed
  still answers about that image. Reading it live gets this wrong by 180°.

**`fibsem/projection.py` is a new top-level module**, and the projections move out of
`fibsem/ui/widgets/canvas/stage_frame.py`. They are arithmetic over recorded geometry
with no Qt in them, and importing `fibsem.ui` pulls in the whole widget package —
which CI does not install, so a test of this would have been a *collection error*
rather than coverage. `stage_frame.py` re-exports them; no existing import site
changes.

Also adds `y_corrected_stage_movement_tescan_from_geometry` — the microscope-free
Tescan forward, whose inverse already existed.

## How "no behaviour change" was established

**Structurally, which is the argument that matters** — it holds for all inputs, not
sampled ones. Every definition that is meant to be a pure move, compared by AST
before vs after:

| definition | result |
| -- | -- |
| `StageProjection`, `FMStageProjection`, `StageFrame` | byte-identical ASTs, no normalisation |
| `_projection_terms` | statement-for-statement identical |
| `view_corrected_stage_movement`, `inverse_view_corrected_dy` | identical once `np.deg2rad(geometry.camera_tilt)` → `view_tilt` is normalised; the only signature change is the added parameter |
| `project_stage_position`, `project_image_point` | identical once the added `view_tilt=np.deg2rad(geometry.camera_tilt)` keyword is removed — the caller passes exactly what the callee used to compute |
| `imaging/tiling/reprojection.py` | 1 definition added, 0 removed, 0 changed |

**Numerically**, as a cross-check: the pre-move functions materialised out of git into
their own module and run side by side with the post-move ones in a single process,
varying all seven `FibsemHardwareGeometry` fields plus stage tilt, stage rotation and
displacement — **49,152 combinations, 0 mismatches at `repr` precision, worst absolute
difference 0.0**.

**By test:**

| check | result |
| -- | -- |
| commit 1 green on its own (before the second is applied) | 548 passed |
| affected suite — every file mentioning the touched symbols | **946 passed** |
| mutation sweep on the new projection | **10/10 caught, no survivors** |
| CI-shaped run (napari, PyQt5, qtawesome, qtpy, superqt, magicgui all unimportable) | **212 run, 0 skipped** |

**Scope limit, stated plainly.** For the second commit, "no behaviour change" rests on
nothing calling the new code — confirmed, not assumed: `BeamStageProjection` appears
only in its own module, the `stage_frame.py` re-export and the test, and
`y_corrected_stage_movement_tescan_from_geometry` has no callers at all. It is
deliberately dead until the widget lands. So this cannot change behaviour; equally,
nothing here proves the new projection correct *on hardware* — the parity tests
establish that it agrees with what ships today, which is a weaker and different claim.

## One thing worth knowing about the Tescan pair

The Tescan inverse recovers the sample-plane move from **whichever of `dy`/`dz` is the
larger component**. Past 45° of sample inclination it therefore reads `dz` alone and
never looks at `dy` — at which point flipping the stage-y sign changes nothing that
comes back, and **a round-trip test cannot see the error at all**. A mutation survived
there, which is how it surfaced. `test_the_chamber_frame_inversion_is_pinned` now
asserts the inversion directly, and the round-trip tilts straddle 45°.

## Note on FIB-500

`imaging/tiling/reprojection.py` still decides the compustage FIB orientation from
tilt alone. This projection uses the rotation-aware version, matching the live path and
the fluorescence one. The divergent poses are structurally unreachable — a compustage
has no rotation axis — so nothing changes today, but FIB-500 now has one more consumer
on the correct side of it, and its fix stays worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
