### PR TITLE
[autolamella] Say why the FM Overview tab is disabled (FIB-614)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1174,9 +1174,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """Handle microscope connection and connect milling progress signal."""
         # Before the signal wiring below, which returns early on a disconnect: the FM
         # overview tab has to hear about that case too, to let go of the old microscope.
-        # Through the visibility path rather than straight to the builder, because
-        # whether this system has a fluorescence detector at all is only known now.
-        self._apply_fm_overview_visibility()
+        # It also re-answers whether the tab can be used, which is only knowable now --
+        # whether this system has a fluorescence detector at all.
+        self._refresh_fm_overview_microscope()
         if (
             self.autolamella_ui is not None
             and self.autolamella_ui.microscope is not None
@@ -2221,12 +2221,12 @@ class AutoLamellaSingleWindowUI(QMainWindow):
     def add_fm_overview_tab(self):
         """Reserve the FM Overview tab, beside the beam one.
 
-        The tab is always created and hidden when it has nothing to drive, rather than
-        skipped: the tab bar then keeps its shape whether or not the system has a
-        fluorescence detector, and a microscope arriving or changing later needs only a
-        visibility pass rather than a rebuild of the bar. The widget inside is built and
-        destroyed to match -- see :meth:`_apply_fm_overview_visibility` -- so a hidden
-        tab costs nothing but the container.
+        The tab is created on every system and never hidden, so the tab bar keeps the
+        same shape whether or not there is a fluorescence detector. When it has nothing
+        to drive it is greyed out with a tooltip saying why -- see
+        :meth:`_on_fm_overview_availability`. The widget inside is built and destroyed
+        to match -- see :meth:`_refresh_fm_overview_microscope` -- so a dead tab costs
+        nothing but the container.
 
         Separate from "Overview" deliberately, not as a step toward merging them: the
         two show different stage poses -- milling pose on the beam side, FM pose here --
@@ -2251,7 +2251,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.tab_widget.setTabEnabled(
             self.tab_widget.indexOf(self.fm_overview_tab), False
         )
-        self._apply_fm_overview_visibility()
+        # Emits availability either way, which is what puts the reason on the tab.
+        self._refresh_fm_overview_microscope()
 
     def _on_fm_overview_lamella_selected(self, lamella):
         """Sync the other lists when the FM overview's list selection changes.
@@ -2283,40 +2284,55 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.fm_overview_tab.refresh_positions()
 
     def _on_fm_overview_availability(self, available: bool):
-        """Enable the tab when it has something to drive.
+        """Enable the tab when it has something to drive, and say why when it does not.
 
         The one thing about the tab that is not the tab's own business: it has no
         business reaching out to the tab bar it happens to sit in.
+
+        The tab is never hidden. A greyed tab that explains itself is easier to live
+        with than one that appears and vanishes depending on what the microscope turned
+        out to be — but that is only true *because* of the tooltip, so the two are set
+        together here rather than in separate passes.
+
+        Qt does show a tooltip on a disabled tab: the `QTabBar` stays enabled and only
+        the tab within it is disabled, so the hover still lands. Worth stating because
+        disabled *widgets* do swallow tooltips, which makes this look doubtful.
         """
-        self.tab_widget.setTabEnabled(
-            self.tab_widget.indexOf(self.fm_overview_tab), available
+        index = self.tab_widget.indexOf(self.fm_overview_tab)
+        self.tab_widget.setTabEnabled(index, available)
+        self.tab_widget.setTabToolTip(
+            index, "" if available else self._fm_overview_unavailable_reason()
         )
 
-    def _apply_fm_overview_visibility(self):
-        """Show or hide the FM Overview tab to match the instrument, immediately.
+    def _fm_overview_unavailable_reason(self) -> str:
+        """Why the FM Overview tab is greyed out, in the user's terms.
 
-        The widget inside is built and destroyed along with the tab rather than left
-        behind hidden. It subscribes to the microscope's stage signal for its lifetime,
-        so a hidden one would go on doing work on every poll for a tab nobody can reach
-        — and would still be holding a psygnal reference to tear down later.
-
-        Two different absences, deliberately handled differently:
-
-        * **A connected microscope with no fluorescence detector** will never drive this
-          tab, so it is hidden. Leaving it visible means a permanently greyed-out tab
-          with nothing to say why, on every system without an FM.
-        * **No microscope yet** is temporary, so the tab stays visible and disabled,
-          which is what every other tab does while waiting for a connection.
+        Two absences that look identical on the tab bar but are not: one is waiting for
+        something that is about to happen, the other is a fact about this system that
+        will not change. `availability_changed` is a bool and cannot carry the
+        difference, so it is worked out here — the window already holds the microscope.
         """
-        if getattr(self, "fm_overview_tab", None) is None:
-            return
-        index = self.tab_widget.indexOf(self.fm_overview_tab)
         microscope = (
             self.autolamella_ui.microscope if self.autolamella_ui is not None else None
         )
-        has_no_fm = microscope is not None and microscope.fm is None
-        self.tab_widget.setTabVisible(index, not has_no_fm)
-        # Builds when there is an FM, tears down otherwise.
+        if microscope is None:
+            return "Connect a microscope to use the FM Overview"
+        return "No Fluorescence Microscope Available"
+
+    def _refresh_fm_overview_microscope(self):
+        """Build or drop the FM Overview widget to match the instrument.
+
+        The widget is built and destroyed rather than left behind hidden. It subscribes
+        to the microscope's stage signal for its lifetime, so one kept around would go
+        on doing work on every poll for a tab nobody can reach — and would still be
+        holding a psygnal reference to tear down later.
+
+        Whether the tab can be *used* is a separate question, answered by
+        `availability_changed` coming back through
+        :meth:`_on_fm_overview_availability`. This method does not touch the tab bar.
+        """
+        if getattr(self, "fm_overview_tab", None) is None:
+            return
         self.fm_overview_tab.refresh_microscope()
 
     def _on_notification_service(

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1723,6 +1723,11 @@ class _StubHost:
     a window that cannot be built in this environment rather than papering over
     something introduced with the tab. The methods borrowed below touch only the tab
     widget and the two attributes set in `__init__`.
+
+    Borrowing is explicit, so a method that calls a *helper* on the real window needs
+    that helper listed here too. Forgetting is not a readable failure: the missing
+    attribute raises inside a psygnal slot, and PyQt5 turns any exception escaping a
+    slot into `qFatal` -- the run aborts with a C-level traceback and no test name.
     """
 
     from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
@@ -1730,8 +1735,9 @@ class _StubHost:
     )
 
     add_fm_overview_tab = _Real.add_fm_overview_tab
-    _apply_fm_overview_visibility = _Real._apply_fm_overview_visibility
+    _refresh_fm_overview_microscope = _Real._refresh_fm_overview_microscope
     _on_fm_overview_availability = _Real._on_fm_overview_availability
+    _fm_overview_unavailable_reason = _Real._fm_overview_unavailable_reason
     _refresh_fm_overview_positions = _Real._refresh_fm_overview_positions
     _on_fm_overview_lamella_selected = _Real._on_fm_overview_lamella_selected
     _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
@@ -1813,60 +1819,106 @@ def test_the_tab_comes_alive_when_fluorescence_connects(qapp):
     host._teardown_fm_overview_widget()
 
 
-def test_a_microscope_without_fluorescence_hides_the_tab(qapp):
-    """A system with no FM will never drive this tab, so showing it means a permanently
-    greyed-out tab with nothing to say why. Distinct from *not connected yet*, which is
-    temporary and covered below."""
+def test_a_microscope_without_fluorescence_greys_the_tab_and_says_why(qapp):
+    """A system with no FM will never drive this tab. It stays in the tab bar rather
+    than being withdrawn -- a tab that vanishes once you connect is more startling than
+    one that is simply dim -- so the tooltip is what keeps that from being a greyed tab
+    with nothing to say for itself."""
     host = _StubHost(microscope=_plain_microscope())
 
-    host._apply_fm_overview_visibility()
-
-    index = host.tab_widget.indexOf(host.fm_overview_tab)
-    assert not host.tab_widget.isTabVisible(index)
-    assert host.fm_overview_widget is None
-
-
-def test_no_microscope_yet_leaves_the_tab_visible_but_disabled(qapp):
-    """The other absence. Waiting for a connection is what every other tab does, and a
-    tab that vanishes until you connect is harder to find than a dim one."""
-    host = _StubHost(microscope=None)
-
-    host._apply_fm_overview_visibility()
+    host._refresh_fm_overview_microscope()
 
     index = host.tab_widget.indexOf(host.fm_overview_tab)
     assert host.tab_widget.isTabVisible(index)
     assert not host.tab_widget.isTabEnabled(index)
+    assert host.tab_widget.tabToolTip(index) == "No Fluorescence Microscope Available"
     assert host.fm_overview_widget is None
 
 
-def test_connecting_a_microscope_without_fluorescence_takes_the_tab_away(qapp):
-    """Whether the system has an FM is only known once something is connected, so the
-    tab starts visible and has to be withdrawn rather than never shown."""
+def test_no_microscope_yet_says_something_different(qapp):
+    """The other absence. Both look identical on the tab bar, but one is waiting for
+    something about to happen and the other is a fact about this system -- so telling
+    the user to connect a microscope is only right for one of them."""
+    host = _StubHost(microscope=None)
+
+    host._refresh_fm_overview_microscope()
+
+    index = host.tab_widget.indexOf(host.fm_overview_tab)
+    assert host.tab_widget.isTabVisible(index)
+    assert not host.tab_widget.isTabEnabled(index)
+    assert host.tab_widget.tabToolTip(index) == "Connect a microscope to use the FM Overview"
+    assert host.fm_overview_widget is None
+
+
+def test_connecting_a_microscope_without_fluorescence_keeps_the_tab(qapp):
+    """Whether the system has an FM is only known once something is connected. The tab
+    does not move -- only the reason it gives changes, from 'connect one' to 'this
+    system has none'."""
     host = _StubHost(microscope=None)
     index = host.tab_widget.indexOf(host.fm_overview_tab)
     assert host.tab_widget.isTabVisible(index)
 
     host.autolamella_ui.microscope = _plain_microscope()
-    host._apply_fm_overview_visibility()
+    host._refresh_fm_overview_microscope()
 
-    assert not host.tab_widget.isTabVisible(index)
+    assert host.tab_widget.isTabVisible(index)
+    assert not host.tab_widget.isTabEnabled(index)
+    assert host.tab_widget.tabToolTip(index) == "No Fluorescence Microscope Available"
 
 
 def test_a_microscope_with_fluorescence_brings_the_tab_back(qapp):
-    """And the reverse, so swapping between systems in one session settles correctly."""
+    """And the reverse, so swapping between systems in one session settles correctly.
+
+    The tooltip has to be cleared, not just the tab enabled: a stale "No Fluorescence
+    Microscope Available" sitting on a working tab is worse than no tooltip at all."""
     from fibsem.ui.fm.overview_app import build_microscope
 
     host = _StubHost(microscope=_plain_microscope())
-    host._apply_fm_overview_visibility()
+    host._refresh_fm_overview_microscope()
     index = host.tab_widget.indexOf(host.fm_overview_tab)
-    assert not host.tab_widget.isTabVisible(index)
+    assert not host.tab_widget.isTabEnabled(index)
 
     host.autolamella_ui.microscope = build_microscope()
-    host._apply_fm_overview_visibility()
+    host._refresh_fm_overview_microscope()
 
     assert host.tab_widget.isTabVisible(index)
     assert host.tab_widget.isTabEnabled(index)
+    assert host.tab_widget.tabToolTip(index) == ""
     assert isinstance(host.fm_overview_widget, FMOverviewWidget)
+
+    host._teardown_fm_overview_widget()
+
+
+def test_a_greyed_tab_always_says_why(qapp):
+    """The invariant behind the tests above, stated once over every state the tab has.
+
+    Written as a sweep rather than another case-by-case test because the thing worth
+    protecting is that no *future* unavailable state can add a greyed tab with nothing
+    on it -- which is exactly the failure a per-case test cannot catch.
+    """
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    for label, microscope in (
+        ("no microscope", None),
+        ("no fluorescence detector", _plain_microscope()),
+        ("fluorescence available", build_microscope()),
+    ):
+        host = _StubHost(microscope=microscope)
+        host._refresh_fm_overview_microscope()
+        index = host.tab_widget.indexOf(host.fm_overview_tab)
+
+        assert host.tab_widget.isTabVisible(index), f"{label}: the tab is never hidden"
+        if host.tab_widget.isTabEnabled(index):
+            assert host.tab_widget.tabToolTip(index) == "", (
+                f"{label}: a usable tab should not carry a reason it cannot be used"
+            )
+        else:
+            assert host.tab_widget.tabToolTip(index), (
+                f"{label}: greyed out with nothing to say why"
+            )
+
+        if host.fm_overview_widget is not None:
+            host._teardown_fm_overview_widget()
 
     host._teardown_fm_overview_widget()
 
@@ -1994,7 +2046,7 @@ def test_everything_tolerates_the_tab_being_dead(qapp):
     host._build_fm_overview_widget()           # must not raise
     host._update_fm_overview_experiment()      # must not raise
     host._set_minimap_workflow_enabled(False)  # must not raise
-    host._apply_fm_overview_visibility()       # must not raise
+    host._refresh_fm_overview_microscope()       # must not raise
 
     assert getattr(host, "fm_overview_widget", None) is None
 
@@ -2627,7 +2679,7 @@ def test_the_host_tolerates_no_fm_overview_tab(qapp):
     """Both updates are called from paths that run on every system, including those
     with the tab switched off or no fluorescence detector at all."""
     host = _StubHost(microscope=_plain_microscope())
-    host._apply_fm_overview_visibility()
+    host._refresh_fm_overview_microscope()
 
     host._update_fm_overview_positions()   # must not raise
     host._update_fm_overview_selection(None)  # must not raise


### PR DESCRIPTION
The FM Overview tab used to withdraw itself from the tab bar on a system whose microscope has no fluorescence detector. Since the microscope only reports that on connection, the tab was up at launch and then vanished — more startling than a tab that was simply never usable.

It is now always visible, greyed out when there is nothing to drive it, with a tooltip saying why.

| state | visible | enabled | tooltip |
|---|---|---|---|
| at launch, no microscope | ✓ | — | `Connect a microscope to use the FM Overview` |
| connected, no FM | ✓ | — | `No Fluorescence Microscope Available` |
| connected, FM present | ✓ | ✓ | *(cleared)* |

## Why this shape

The old docstring raised exactly one objection to leaving the tab visible:

> Leaving it visible means a permanently greyed-out tab with nothing to say why, on every system without an FM.

The tooltip answers that objection directly, which is what makes always-visible the better shape rather than a compromise between hiding and showing. So the tooltip and the enabled state are set together in `_on_fm_overview_availability` rather than in separate passes — the design is only correct while both are true.

## The two absences

They look identical on the tab bar but are not: one is waiting for something about to happen, the other is a fact about this system that will not change. `availability_changed` is a `bool` and cannot carry the difference.

Rather than widen the signal, the reason is worked out window-side, where the microscope already is. The alternative — a reason string on the signal — is cleaner in that the tab knows exactly which case it is, but it touches the tab's public surface for one caller. Worth revisiting if a third unavailable state appears.

## Qt does show a tooltip on a disabled tab

Checked before building on it, because disabled *widgets* do swallow tooltips and this looks doubtful:

```
tab enabled: False | visible: True
tabAt() still finds a disabled tab: 1
ToolTip event accepted by the tab bar: True
```

The `QTabBar` stays enabled and only the tab within it is disabled, so the hover still lands. Plain `setTabToolTip` is enough — no event filter, no proxy widget.

## Rename

`_apply_fm_overview_visibility` no longer touches the tab bar, so it is now `_refresh_fm_overview_microscope`, for what it actually does: build or drop the widget to match the instrument. Whether the tab can be *used* is a separate question, answered by `availability_changed`.

## Tests

1669 pass across `tests/ui/` and `tests/autolamella/`.

The three visibility tests become tooltip tests. `test_a_microscope_with_fluorescence_brings_the_tab_back` now asserts the tooltip is **cleared** — a stale "No Fluorescence Microscope Available" sitting on a working tab would be worse than no tooltip at all, and enabling the tab alone would not catch it.

Added `test_a_greyed_tab_always_says_why`: a sweep over all three states asserting no tab is ever greyed without a reason, and no usable tab carries one. Written as a sweep because the thing worth protecting is that a *future* unavailable state cannot quietly add a silent greyed tab — which is the failure a per-case test cannot catch.

There is also a new note on `_StubHost`. It borrows methods from the real window explicitly, so a method calling a new helper needs that helper listed too; forgetting is not a readable failure. The missing attribute raises inside a psygnal slot, and PyQt5 turns any exception escaping a slot into `qFatal` — the run aborts with a C-level traceback and no test name. That cost a confusing run here, hence the note.

Since no test builds the real main window, the three states were also checked by hand against a real `AutoLamellaFluorescenceOverviewTab` with a Demo microscope, a Demo microscope with `fm = None`, and the FM overview app's microscope.

Closes FIB-614.
