### PR TITLE
[fm] Tell the overview when the camera transform changes (FIB-521)

### DIFF
--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -671,6 +671,11 @@ class FluorescenceMicroscope(ABC):
     # start it can grey its controls out. Emitted from whichever thread set the flag --
     # connect with `@ensure_main_thread` if the slot touches widgets.
     acquiring_changed = Signal(bool)
+    # Raised when the user's image transform changes. It is part of
+    # `fm_image_geometry()`, so it is an input to every projection between stage space
+    # and a canvas -- a display that keeps one has to be told, and had no way to know
+    # (FIB-521). Same threading contract as the signals above.
+    transform_changed = Signal(object)  # CameraImageTransform
 
     def __init__(self, parent: Optional["FibsemMicroscope"] = None):
         """Initialize the fluorescence microscope with default components.
@@ -997,10 +1002,18 @@ class FluorescenceMicroscope(ABC):
             raise ValueError(
                 f"Invalid transform '{transform}'. Must be a CameraImageTransform enum value or None"
             )
+        previous = self._transform
         self._transform = (
             transform if transform is not None else CameraImageTransform.NONE
         )
         logging.info(f"Image transform set to: {transform}")
+        # Announced, because this is not only a display preference: `fm_image_geometry()`
+        # carries it, so it is an input to every projection between stage space and a
+        # canvas. A view holding a projection has no other way to learn it moved
+        # (FIB-521). Only on a real change -- the camera widget re-applies the saved
+        # transform on load, and a redraw for a value that did not move is noise.
+        if self._transform is not previous:
+            self.transform_changed.emit(self._transform)
 
     @property
     def camera_tilt(self) -> float:

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -293,6 +293,10 @@ class FMOverviewWidget(QWidget):
         # relay is this widget's own dialect. Still a plain bound method, so psygnal can
         # hold it weakly and match it at disconnect time.
         self.fm.objective.position_changed.connect(self._on_objective_moved)
+        # Same contract as the objective's, and for the same reason: the transform is an
+        # input to every projection this widget draws through, and the projection is kept
+        # rather than re-read, so nothing else would notice it moved (FIB-521).
+        self.fm.transform_changed.connect(self._on_transform_changed)
         self._refresh_current_position()
         self._refresh_objective_info()
         self._refresh_orientation_banner()
@@ -1332,6 +1336,33 @@ class FMOverviewWidget(QWidget):
         a shared connection each of those took the imaging channel (FIB-534).
         """
         self._set_objective_info(position, state)
+
+    @ensure_main_thread
+    def _on_transform_changed(self, transform) -> None:
+        """The camera's image transform changed, so every projection here is stale.
+
+        Not the tile *size*: `CameraImageTransform` is flips only and flips preserve the
+        array shape, so `camera.resolution` and the field of view derived from it are
+        untouched. The issue this closes assumed otherwise; what actually moves is the
+        mapping. `fm_image_geometry()` carries the transform, `FMStageProjection` carries
+        that geometry, and everything placed from a stage position goes through it --
+        the current-position marker, marked positions, the stage and grid limits, the
+        planned grid, and the canvas-to-stage direction a double-click moves on.
+
+        This used to be self-correcting by accident: `_frame` re-read the projection on
+        every use, so the next redraw picked the new transform up. Keeping the projection
+        (FIB-600) removed the accident and left nothing in its place, which is what makes
+        this a subscription rather than a comment.
+
+        The grid is redrawn whatever it is pinned to, unlike on a stage move: that gating
+        exists because a translation leaves a pinned grid where it was, and a transform
+        change moves the mapping itself, so it moves everything.
+        """
+        self.invalidate_projection()
+        self._refresh_current_position()
+        self._refresh_positions()
+        self._refresh_stage_metadata()
+        self._refresh_tile_grid()
 
     def _refresh_objective_info(self) -> None:
         """Re-read the objective for the info bar. Touches hardware -- call sparingly.
@@ -2451,6 +2482,7 @@ class FMOverviewWidget(QWidget):
             # Subscribed since FIB-441 and never in this list, though the comment above
             # has always claimed "without exception".
             (self.fm.acquiring_changed, self._on_fm_acquiring_signal),
+            (self.fm.transform_changed, self._on_transform_changed),
         ):
             try:
                 signal.disconnect(slot)

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -24,7 +24,7 @@ from fibsem.fm.structures import (
     OverviewParameters,
     ZParameters,
 )
-from fibsem.structures import TileOrderStrategy
+from fibsem.structures import CameraImageTransform, TileOrderStrategy
 from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     FMOverviewConfirmationDialog,
     format_duration,
@@ -4508,3 +4508,95 @@ def test_loading_parameters_leaves_the_objective_start_combo_able_to_notify(qapp
     combo.setCurrentIndex(1 - combo.currentIndex())
 
     assert seen, "the objective-start combo was left signal-blocked by the setter"
+
+
+class TestTheCameraTransformReachesTheProjection:
+    """Changing the camera transform left the overlays placed by the old one (FIB-521).
+
+    Found on hardware: the marker and the marked positions were wrong after a transform
+    change, and nothing brought them back until something else invalidated the frame.
+
+    The issue blamed the tile field of view, reading the transform as feeding "the
+    camera's effective resolution". It does not, and the first test below pins that so
+    the wrong fix is not attempted later. What the transform actually feeds is
+    `fm_image_geometry()`, which `FMStageProjection` carries, which everything placed
+    from a stage position goes through.
+    """
+
+    def test_a_flip_does_not_change_the_tile_field_of_view(self, qapp):
+        """The issue's premise, disproved rather than assumed.
+
+        `CameraImageTransform` is flips only, and flips preserve the array shape -- the
+        enum's own docstring says so. `camera.resolution` is `_resolution // binning`
+        with no transform term. So the planned grid's size cannot go stale this way, and
+        re-running `_sync_tile_fov` from a transform change would be noise dressed as
+        insurance.
+        """
+        widget = _fresh_widget(qapp)
+        fm = widget.fm
+        try:
+            fm.set_image_transform(CameraImageTransform.NONE)
+            qapp.processEvents()
+            before = (fm.camera.resolution, fm.camera.pixel_size)
+
+            fm.set_image_transform(CameraImageTransform.FLIP_XY)
+            qapp.processEvents()
+
+            assert (fm.camera.resolution, fm.camera.pixel_size) == before, (
+                "a flip changed the camera's resolution or pixel size -- if that is now "
+                "true, the tile field of view really does need re-syncing here"
+            )
+        finally:
+            widget.close()
+
+    def test_the_projection_follows_a_transform_change(self, qapp):
+        """The defect. The kept projection carried the old flip until something else
+        invalidated it, and nothing else did."""
+        widget = _fresh_widget(qapp)
+        fm = widget.fm
+        try:
+            fm.set_image_transform(CameraImageTransform.NONE)
+            qapp.processEvents()
+            widget.invalidate_projection()
+            assert widget._projection().geometry.transform is CameraImageTransform.NONE
+
+            fm.set_image_transform(CameraImageTransform.FLIP_X)
+            qapp.processEvents()
+
+            assert widget._projection().geometry.transform is CameraImageTransform.FLIP_X, (
+                "the projection still carries the old transform, so every overlay "
+                "placed through it is drawn for a flip that no longer applies"
+            )
+        finally:
+            widget.close()
+
+    def test_setting_the_same_transform_again_says_nothing(self, qapp):
+        """The camera widget re-applies the saved transform on load, and a redraw for a
+        value that did not move is noise."""
+        widget = _fresh_widget(qapp)
+        fm = widget.fm
+        seen = []
+        try:
+            fm.set_image_transform(CameraImageTransform.FLIP_Y)
+            qapp.processEvents()
+            fm.transform_changed.connect(seen.append)
+
+            fm.set_image_transform(CameraImageTransform.FLIP_Y)
+            qapp.processEvents()
+
+            assert seen == []
+        finally:
+            fm.transform_changed.disconnect(seen.append)
+            widget.close()
+
+    def test_the_subscription_is_torn_down_with_the_widget(self, qapp):
+        """`closeEvent` claims to drop every psygnal "without exception", and once did
+        not -- `acquiring_changed` was missing from it for weeks (FIB-441). A late
+        delivery into a torn-down widget is a process abort, not an exception (FIB-329).
+        """
+        import inspect
+
+        source = inspect.getsource(FMOverviewWidget.closeEvent)
+        assert "transform_changed" in source, (
+            "the transform subscription is not in closeEvent's teardown list"
+        )


### PR DESCRIPTION
Closes FIB-521. Found on hardware: changing the FM camera transform with the overview tab open left the position overlays placed by the old one.

## The issue is wrong about why

It blamed the tile field of view — the transform feeding *"the camera's effective resolution"*. It doesn't. `CameraImageTransform` is flips only, and the enum's own docstring says why that matters:

> Flips also preserve the array shape, so the image and its geometry metadata always describe the same frame.

`camera.resolution` is `_resolution // binning` with no transform term, and `_transform_array` is `fliplr`/`flipud`. So the planned grid's **size** cannot go stale this way, and re-syncing the tile FOV from a transform change would be noise dressed as insurance. A test pins that, so the wrong fix isn't attempted later.

## What actually moves is the mapping

`fm_image_geometry()` carries `transform=self.fm._transform`. `FMStageProjection` carries that geometry. Everything placed from a stage position goes through it:

- the current-position marker
- marked positions
- the stage and grid limits
- the planned grid's *position*
- the canvas→stage direction a double-click moves on

Patrick confirmed it was the overlays rather than the images, which is exactly this path. (Images are a separate question — acquired data is stored already-transformed, so an old image keeping its old flip is arguably correct, and "re-place them" would mean re-transforming stored pixels.)

## It used to be self-correcting by accident

`_frame` re-read the projection on every use, so the next redraw picked up the new transform — briefly wrong, then right. Keeping the projection (FIB-600, merged this morning) removed the accident and put nothing in its place. That's what turns this from a comment into a subscription, and it's worth fixing regardless of what the session saw.

## The change

`set_image_transform` only assigned and logged — there was no signal at all. It announces now, and only on a real change: the camera widget re-applies the saved transform on load, and a redraw for a value that didn't move is noise.

`FMOverviewWidget` subscribes, invalidates its projection, and redraws what the frame places. The grid is redrawn whatever it's pinned to, unlike on a stage move — that gating exists because a translation leaves a pinned grid where it was, and a transform change moves the mapping itself.

Added to `closeEvent`'s teardown list, which is the mistake FIB-441 made: a subscription taken and left out of a list whose comment claims *"without exception"*. A late delivery into a torn-down widget is a process abort under PyQt5, not an exception (FIB-329).

## One thing found on the way, not fixed here

The module-scoped `overview_widget` fixture in `test_fm_overview_widget.py` is closed by an earlier test, and `closeEvent` drops every psygnal — so **every test after that point runs against a widget subscribed to nothing.** All four of its signals read zero subscribers.

Nothing depended on a live subscription before, so nothing noticed. My tests build their own widget rather than paper over it. Worth an issue: it means any future test in that file that thinks it's exercising a signal path silently isn't.

## Testing

Dropping the subscription fails `test_the_projection_follows_a_transform_change`; dropping the no-change guard fails `test_setting_the_same_transform_again_says_nothing`. Checked both ways, including in the full-file run rather than only in isolation — which is how the fixture problem above surfaced.

`tests/ui/` + `tests/fm/` — 1781 passed, 1 skipped.
