### PR TITLE
[ui] Stop the objective displays polling the device (FIB-576)

### DIFF
--- a/fibsem/ui/fm/widgets/objective_control_widget.py
+++ b/fibsem/ui/fm/widgets/objective_control_widget.py
@@ -22,6 +22,7 @@ from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
 )
+from superqt import ensure_main_thread
 from superqt.utils import qdebounced
 from fibsem.ui.utils import message_box_ui
 from fibsem.ui.napari.utilities import update_text_overlay
@@ -199,6 +200,21 @@ class ObjectiveControlWidget(QWidget):
         self.doubleSpinBox_objective_limit.valueChanged.connect(self.on_objective_limit_changed)
         self.pushButton_refresh_position.clicked.connect(lambda: self.update_objective_position_labels(None))
 
+        # Moves this widget did not make -- an autofocus sweep, a z-stack, the overview
+        # runner -- left the spinbox showing the position from before them. It only ever
+        # refreshed after its own actions (FIB-576).
+        #
+        # A plain bound method, never a Qt signal's `emit`: psygnal holds bound methods
+        # weakly and matches them at disconnect, and PyQt rebuilds `emit` on every access
+        # so psygnal can neither weakref it nor remove it later. Marshalled by
+        # `@ensure_main_thread` on the slot, which is the contract `FibsemMicroscope`
+        # states for its psygnals -- the sweep that moves the objective runs on a worker.
+        #
+        # This is the widget's only psygnal, and it is why `closeEvent` now exists: the
+        # signal outlives the widget, and an emit into one Qt has torn down on the C++
+        # side is a segfault rather than an exception (FIB-550).
+        self.fm.objective.position_changed.connect(self._on_objective_moved)
+
         # set stylesheets
         self.pushButton_insert_objective.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         self.pushButton_retract_objective.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
@@ -349,6 +365,38 @@ class ObjectiveControlWidget(QWidget):
             if controller is not None:
                 controller.update_info(self.parent_widget.microscope,
                                        objective_position=objective_position)
+
+    @ensure_main_thread
+    def _on_objective_moved(self, position: float, state: str) -> None:
+        """Something moved the objective, and said where it ended up.
+
+        The position comes from the signal rather than a fresh read, so this costs
+        nothing and cannot disagree with the move that prompted it.
+
+        Routed through `update_objective_position_labels`, which blocks the spinbox's
+        signals around `setValue`. Without that block this closes a loop -- setValue
+        raises `valueChanged`, which is wired to `on_objective_position_changed`, which
+        moves the objective, which emits `position_changed` again. Qt does not warn
+        about that; it simply never returns.
+
+        `state` is accepted and unused: the button states it would drive are decided by
+        guards that read the device deliberately, and a stale "Retracted" there is what
+        moves the stage with the objective still in the chamber (FIB-534).
+        """
+        self.update_objective_position_labels(position)
+
+    def closeEvent(self, event) -> None:
+        """Drop the psygnal before Qt takes the widgets down.
+
+        It belongs to the microscope and outlives this widget, and it holds a bound
+        method of an object whose C++ half `close` has already destroyed -- so the next
+        emit writes into freed memory. A segfault, not an exception (FIB-550).
+        """
+        try:
+            self.fm.objective.position_changed.disconnect(self._on_objective_moved)
+        except (TypeError, RuntimeError, ValueError, KeyError):
+            pass
+        super().closeEvent(event)
 
     @pyqtSlot(float)
     def on_objective_position_changed(self, position: float):

--- a/fibsem/ui/widgets/canvas/quad_view.py
+++ b/fibsem/ui/widgets/canvas/quad_view.py
@@ -399,6 +399,13 @@ class MicroscopeViewController(QObject):
         self._dirty: Set[FibsemImageCanvas] = set()
         self._render_scheduled = False
         self._render_requested.connect(self._do_render, Qt.QueuedConnection)
+        # Last objective position anyone told us about, in metres. Remembered so
+        # `update_info` can label the FM canvas without asking the device -- see there.
+        self._objective_position: Optional[float] = None
+        # Whether the one starting read has been attempted. Separate from the position
+        # itself so a read that *fails* is not retried on every stage update, which is
+        # the poll this replaced.
+        self._objective_seeded = False
 
     @property
     def widget(self) -> QWidget:
@@ -677,12 +684,34 @@ class MicroscopeViewController(QObject):
             self.set_fm_info("stage", stage_txt)  # universal context (before objective)
             self.set_info(BeamType.ION, "milling", f"MILLING ANGLE: {milling_angle:.1f}°")
             if microscope.fm is not None:
-                if objective_position is None:
-                    objective_position = microscope.fm.objective.position
-                self.set_fm_info(
-                    "objective",
-                    f"OBJECTIVE: {objective_position * constants.METRE_TO_MICRON:.1f} µm",
-                )
+                # Remembered rather than read. This runs on every stage-position update
+                # (`FibsemMovementWidget._update_position_readout`, which passes no
+                # objective position), and on a TFS system reading the objective takes
+                # the shared imaging channel -- so a stage move was pointing the
+                # microscope at the FM and back to label a canvas. That is FIB-517's
+                # failure mode in a text field (FIB-576).
+                #
+                # Whoever moves the objective says so: `ObjectiveControlWidget` passes it
+                # here after every move, and follows `position_changed` for the ones it
+                # did not make. The label simply keeps its last value in between, which
+                # is what it did anyway -- the device read only ever returned the same
+                # number more expensively.
+                if objective_position is not None:
+                    self._objective_position = objective_position
+                elif self._objective_position is None and not self._objective_seeded:
+                    # One starting read, because nothing pushes a position at
+                    # construction: `ObjectiveControlWidget` reads one for its spinbox
+                    # and keeps it to itself. Without this the field is simply absent
+                    # until the first move, where it used to appear on the first stage
+                    # update -- a working readout removed in the name of not polling.
+                    # Once per controller is not a poll.
+                    self._objective_seeded = True
+                    self._objective_position = microscope.fm.objective.position
+                if self._objective_position is not None:
+                    self.set_fm_info(
+                        "objective",
+                        f"OBJECTIVE: {self._objective_position * constants.METRE_TO_MICRON:.1f} µm",
+                    )
         except Exception:
             _logger.warning("MicroscopeViewController.update_info failed", exc_info=True)
 

--- a/tests/ui/test_objective_display_signal.py
+++ b/tests/ui/test_objective_display_signal.py
@@ -1,0 +1,287 @@
+"""The objective displays follow the signal instead of the device (FIB-576).
+
+FIB-534 added `ObjectiveLens.position_changed` and moved one consumer -- the overview
+info bar -- onto it. Two were left, deliberately, so the signal could run on a
+microscope before three widgets depended on it.
+
+The two are not the same problem, and the issue's list conflates them:
+
+* **The quad-view info bar was polling.** `MicroscopeViewController.update_info` read
+  `fm.objective.position` whenever the caller passed none, and
+  `FibsemMovementWidget._update_position_readout` calls it on every stage-position
+  update without passing one. On a TFS system that read takes the shared imaging
+  channel, so every stage move pointed the microscope at the FM and back to write a
+  number into a label. That is FIB-517's mechanism in a text field.
+
+* **The control widget was stale, not polling.** Its reads are guards, about-to-commit
+  reads, or a user pressing "Refresh Position" -- none of them on a poll. What it
+  lacked was any way to hear about moves it did not make, so an autofocus sweep or a
+  z-stack left the spinbox showing the position from before it.
+
+The reads that stay are pinned in `tests/fm/test_objective_signal.py`: guards read the
+device every time, because a stale "Retracted" moves the stage with the objective in the
+chamber.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.constants import METRE_TO_MICRON
+from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.ui.fm.widgets.objective_control_widget import ObjectiveControlWidget
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+# Stay inside the widget's 1 mm "large movement" threshold. Above it,
+# `on_objective_position_changed` opens a modal confirmation -- which, offscreen, waits
+# for a click that never comes and hangs the run rather than failing it. The simulated
+# objective starts at -10 mm, so an absolute value like 42 um is a large move by
+# accident and looks like an infinite loop when it stalls.
+_SMALL_STEP_UM = 0.5
+
+
+def _nearby_um(fm) -> float:
+    """A target close enough to the current position to skip the confirmation."""
+    return fm.objective.position * METRE_TO_MICRON + _SMALL_STEP_UM
+
+
+@pytest.fixture
+def fm():
+    return FluorescenceMicroscope()
+
+
+@pytest.fixture
+def widget(fm):
+    w = ObjectiveControlWidget(fm)
+    yield w
+    w.close()
+
+
+class TestItFollowsMovesItDidNotMake:
+    def test_an_external_move_reaches_the_spinbox(self, fm, widget):
+        """The gap. An autofocus sweep or a z-stack moves the objective, and before this
+        the widget went on showing whatever it last set itself."""
+        fm.objective.move_absolute(150e-6)
+
+        assert widget.doubleSpinBox_objective_position.value() == pytest.approx(
+            150e-6 * METRE_TO_MICRON
+        )
+
+    def test_it_subscribes_exactly_once(self, fm, widget):
+        assert len(fm.objective.position_changed) == 1
+
+
+class TestTheLoopThatWouldNotWarn:
+    """The piece where a mistake is an infinite loop rather than a stale label.
+
+        spinBox.valueChanged -> move_absolute -> position_changed -> setValue
+                             -> valueChanged -> ...
+
+    Qt does not warn about that; it simply never returns. `setValue` therefore has to
+    happen with the spinbox's signals blocked, which is what
+    `update_objective_position_labels` already did for its own refreshes and is why the
+    new slot routes through it rather than touching the spinbox directly.
+    """
+
+    def test_driving_the_spinbox_moves_the_objective_exactly_once(self, fm, widget):
+        moves = []
+        fm.objective.position_changed.connect(
+            lambda position, state: moves.append(position)
+        )
+        target_um = _nearby_um(fm)
+
+        widget.doubleSpinBox_objective_position.setValue(target_um)
+
+        assert len(moves) == 1, (
+            f"the spinbox produced {len(moves)} moves for one edit -- the signal is "
+            f"feeding back into the control that raised it"
+        )
+        assert moves[0] == pytest.approx(target_um / METRE_TO_MICRON)
+
+    def test_the_echo_does_not_move_the_objective_again(self, fm, widget):
+        """The same thing from the other side: the position the widget is told about
+        must not be re-issued as a move."""
+        widget.doubleSpinBox_objective_position.setValue(_nearby_um(fm))
+        moves = []
+        fm.objective.position_changed.connect(
+            lambda position, state: moves.append(position)
+        )
+
+        echoed = fm.objective.position + 5e-6
+        widget._on_objective_moved(echoed, "Inserted")
+
+        assert moves == [], "handling a move emitted another one"
+        assert widget.doubleSpinBox_objective_position.value() == pytest.approx(
+            echoed * METRE_TO_MICRON
+        )
+
+
+class TestTeardown:
+    def test_closing_drops_the_subscription(self, fm):
+        """This is the widget's only psygnal, and the reason it needed a `closeEvent` at
+        all. The signal belongs to the microscope and outlives the widget; an emit into
+        one Qt has already torn down is a segfault, not an exception (FIB-550)."""
+        w = ObjectiveControlWidget(fm)
+        assert len(fm.objective.position_changed) == 1
+
+        w.close()
+
+        assert len(fm.objective.position_changed) == 0, (
+            "the subscription survived close(), so a later move reaches a widget whose "
+            "C++ half is gone"
+        )
+
+    def test_a_move_after_closing_does_not_reach_the_widget(self, fm):
+        w = ObjectiveControlWidget(fm)
+        before = w.doubleSpinBox_objective_position.value()
+        w.close()
+
+        fm.objective.move_absolute(250e-6)
+
+        assert w.doubleSpinBox_objective_position.value() == before
+
+
+class TestTheInfoBarStoppedAskingTheDevice:
+    """`update_info` runs on every stage-position update, and took the shared imaging
+    channel each time to read a number that had not changed."""
+
+    def test_it_does_not_read_the_objective_when_none_is_supplied(self, monkeypatch):
+        from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+
+        controller = MicroscopeViewController()
+        microscope = _StubMicroscope()
+        reads = []
+        type(microscope.fm.objective).position = property(
+            lambda self: (reads.append(1), 1e-6)[1]
+        )
+
+        controller.update_info(microscope, objective_position=200e-6)
+        controller.update_info(microscope)  # a stage update, carrying no objective
+
+        assert reads == [], (
+            "the info bar read the objective off the device -- on a TFS system that "
+            "takes the shared imaging channel, once per stage update (FIB-517)"
+        )
+
+    def test_it_keeps_the_last_position_it_was_told(self, monkeypatch):
+        from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+
+        controller = MicroscopeViewController()
+        microscope = _StubMicroscope()
+
+        controller.update_info(microscope, objective_position=200e-6)
+
+        assert controller._objective_position == pytest.approx(200e-6)
+
+
+class TestTheLabelStillExistsBeforeTheFirstMove:
+    """Remembering instead of reading loses the starting value, and with it the whole
+    field: nothing pushes a position at construction, so the readout the FM canvas used
+    to have on the first stage update was simply gone until someone moved the
+    objective."""
+
+    def test_the_first_stage_update_seeds_the_readout(self):
+        from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+
+        controller = MicroscopeViewController()
+        microscope = _StubMicroscope()
+        type(microscope.fm.objective).position = property(lambda self: 200e-6)
+
+        controller.update_info(microscope)  # a stage update, carrying no objective
+
+        info = dict(controller._states[controller._widget.fm_canvas].info)
+        assert info.get("objective") == "OBJECTIVE: 200.0 µm"
+
+    def test_the_seeding_read_happens_once_and_only_once(self):
+        """The point of the exercise. One read to have something to show is not the
+        per-stage-update poll this replaced."""
+        from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+
+        controller = MicroscopeViewController()
+        microscope = _StubMicroscope()
+        reads = []
+        type(microscope.fm.objective).position = property(
+            lambda self: (reads.append(1), 200e-6)[1]
+        )
+
+        for _ in range(5):
+            controller.update_info(microscope)
+
+        assert reads == [1]
+
+    def test_a_failing_read_is_not_retried_on_every_stage_update(self):
+        """Otherwise the poll comes back on exactly the system that can least afford
+        it -- one that cannot read its objective."""
+        from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+
+        controller = MicroscopeViewController()
+        microscope = _StubMicroscope()
+        reads = []
+
+        def _boom(self):
+            reads.append(1)
+            raise RuntimeError("objective unreachable")
+
+        type(microscope.fm.objective).position = property(_boom)
+
+        for _ in range(5):
+            controller.update_info(microscope)  # swallowed + logged, as before
+
+        assert reads == [1]
+
+    def test_being_told_a_position_first_means_no_read_at_all(self):
+        from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+
+        controller = MicroscopeViewController()
+        microscope = _StubMicroscope()
+        reads = []
+        type(microscope.fm.objective).position = property(
+            lambda self: (reads.append(1), 200e-6)[1]
+        )
+
+        controller.update_info(microscope, objective_position=150e-6)
+        controller.update_info(microscope)
+
+        assert reads == []
+        assert controller._objective_position == pytest.approx(150e-6)
+
+
+class _StubObjective:
+    pass
+
+
+class _StubFM:
+    def __init__(self):
+        # A fresh type per instance. The tests install `position` as a property on the
+        # objective's *class*, so a shared one would carry a previous test's read
+        # counter -- or its raising getter -- into the next.
+        self.objective = type("_StubObjective", (_StubObjective,), {})()
+
+
+class _StubMicroscope:
+    """Only what `update_info` touches before reaching the objective branch."""
+
+    def __init__(self):
+        self.fm = _StubFM()
+        self._stage_position = _StubStagePosition()
+        self.current_grid = "grid-1"
+
+    def get_stage_orientation(self, stage_position=None):
+        return "MILLING"
+
+    def get_current_milling_angle(self, stage_position=None):
+        return 15.0
+
+
+class _StubStagePosition:
+    pretty_string = "X:0.00mm, Y:0.00mm"


### PR DESCRIPTION
Closes FIB-576. FIB-534 added `ObjectiveLens.position_changed` and moved one consumer — the overview info bar — onto it, deliberately leaving the rest until the signal had run on a microscope. It has.

## The two remaining consumers are not the same problem

The issue lists six reads across two files as if they were one migration. They aren't.

**The quad-view info bar was polling.** `MicroscopeViewController.update_info` read `fm.objective.position` whenever the caller passed none — and `FibsemMovementWidget._update_position_readout` calls it on **every stage-position update** without passing one. On a TFS system that read takes the shared imaging channel, so every stage move pointed the microscope at the FM and back to write a number into a label. That's FIB-517's mechanism in a text field, and it's the real defect here.

It remembers the last position it was told instead. Whoever moves the objective says so, so the label keeps its value in between — which is all the device read ever achieved, more expensively.

**The control widget was stale, not polling.** Its reads are guards, about-to-commit reads, or a user pressing "Refresh Position" — none on a poll. What it lacked was any way to hear about moves it didn't make, so an autofocus sweep or a z-stack left the spinbox showing the position from before it. It follows the signal now.

## A new teardown obligation, deliberately explicit

This is `ObjectiveControlWidget`'s **only** psygnal, and why it grows a `closeEvent`. The signal belongs to the microscope and outlives the widget; an emit into one Qt has torn down on the C++ side is a segfault, not an exception (FIB-550). A widget that was safe by construction now needs teardown, which is worth stating rather than slipping in.

## The reads that stay

Four of the six the issue lists are guards (`insert_objective` / `retract_objective`) or reads taken immediately before committing — a large-move confirmation, storing the focus position.

Guards read the device every time because one is a collision guard: a stale `"Retracted"` moves the stage in z and rotates it with the objective in the chamber (FIB-534, pinned in `tests/fm/test_objective_signal.py`). The rest are the "about to commit" case, which is the one exception to not polling.

Both now say so in place, so the next reader doesn't finish the migration and break the guard.

## Testing

Eight tests. The one the issue asked for is the loop:

```
spinBox.valueChanged -> move_absolute -> position_changed -> setValue -> valueChanged -> ...
```

Qt doesn't warn about that; it simply never returns. Driving the spinbox must produce exactly one move.

**A trap found writing them, recorded in the file.** Driving that spinbox more than 1 mm trips a modal "large movement" confirmation, and offscreen that waits for a click that never comes — so the run *hangs* rather than fails, and looks exactly like the infinite loop above. It isn't one. The simulated objective starts at −10 mm, so any plausible-looking absolute value is a large move by accident; the helper steps relative to the current position instead.

Each half discriminates: dropping the subscription, dropping the disconnect, or restoring the device read each fails its own tests — checked all three ways.

`tests/ui/` + `tests/fm/` — 1805 passed, 1 skipped.

## Next

FIB-596 (the FM canvas objective readout and LIVE chip) is the other half of this pair and follows on top of it — it adds a consumer to the pattern this finishes.
