### PR TITLE
[ui] Draw the overview's stage-space overlays in the view (FIB-615)

### DIFF
--- a/fibsem/ui/widgets/canvas/overlays/minimap_overlays.py
+++ b/fibsem/ui/widgets/canvas/overlays/minimap_overlays.py
@@ -40,9 +40,15 @@ _LABEL_FONTSIZE = 7
 class ShapeSpec:
     """One overlay primitive in image-pixel coordinates.
 
-    ``kind`` is ``"rect"`` (uses ``width``/``height``), ``"circle"`` (uses ``radius``),
-    or ``"crosshair"`` (a ``+`` of ``crosshair_half`` arms). ``label`` is optional text
-    drawn near the shape in the shape's colour.
+    ``kind`` is ``"rect"`` or ``"ellipse"`` (both use ``width``/``height``),
+    ``"circle"`` (uses ``radius``), or ``"crosshair"`` (a ``+`` of ``crosshair_half``
+    arms). ``label`` is optional text drawn near the shape in the shape's colour.
+
+    ``"ellipse"`` exists because a circle on the *sample* is not a circle on screen.
+    A view foreshortens one axis and not the other, so anything round in stage space
+    -- a grid's boundary -- is an ellipse in every view but the two where the beam
+    looks straight down the pose it is named after. ``"circle"`` remains for the
+    things that are round because they are drawn round, like a marker.
     """
 
     kind: str
@@ -153,6 +159,18 @@ class MinimapShapesOverlay(CanvasOverlay):
             self._artists.append(patch)
             self._draw_label(spec, spec.cx - spec.width / 2.0,
                               spec.cy - spec.height / 2.0, va="bottom")
+        elif spec.kind == "ellipse":
+            # matplotlib's Ellipse takes full width and height, matching `rect` -- so a
+            # caller that has projected a diameter per axis passes the same two numbers
+            # to either kind, and cannot halve one and not the other.
+            patch = mpatches.Ellipse(
+                (spec.cx, spec.cy), spec.width, spec.height,
+                fill=False, edgecolor=spec.color, linewidth=self._linewidth,
+                zorder=self._zorder,
+            )
+            self._ax.add_patch(patch)
+            self._artists.append(patch)
+            self._draw_label(spec, spec.cx, spec.cy - spec.height / 2.0, va="bottom")
         elif spec.kind == "circle":
             patch = mpatches.Circle(
                 (spec.cx, spec.cy), spec.radius,

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -518,6 +518,17 @@ class FibsemOverviewWidget(QWidget):
         whatever the overview was acquired at. Silently does nothing before there is a
         frame -- the controls are usable from the moment the tab opens, and nothing is
         on screen to reference yet.
+
+        The pitch is still `frame.length()`, and still one number for both axes, which
+        is wrong in the same way the travel envelope was: a square lattice on the sample
+        is not square in a tilted view, so at the milling pose the horizontal bars sit
+        about four times too far apart. Deliberately left (FIB-615) -- the fix is
+        `_canvas_span` and a per-axis `set_lattice`, and it is not what anyone is
+        waiting on.
+
+        The lattice *centre* is fixed here, because it was a different bug: grid centre
+        is a place, and built with its own rotation it read as a position recorded half
+        a turn away. See :meth:`_landmark`.
         """
         if not self.checkbox_gridbars.isChecked():
             return
@@ -525,9 +536,7 @@ class FibsemOverviewWidget(QWidget):
         if frame is None:
             return
         try:
-            centre = frame.to_canvas(
-                FibsemStagePosition(name="Grid Centre", x=0, y=0, z=0, r=0, t=0)
-            )
+            centre = frame.to_canvas(self._landmark(frame, 0.0, 0.0, "Grid Centre"))
             pitch = frame.length(
                 self.spin_gridbar_spacing.value() * constants.MICRO_TO_SI
             )
@@ -1001,24 +1010,75 @@ class FibsemOverviewWidget(QWidget):
         self._refresh_gridbars()
         self._refresh_view_note()
 
+    @staticmethod
+    def _landmark(frame: StageFrame, x: float, y: float, name: str = "") -> FibsemStagePosition:
+        """A stage position that is a *place*, in the frame's own pose.
+
+        Grid centre and the corners of the travel envelope are places, not recorded
+        poses, so the rotation has to come from somewhere. Taking the frame's means
+        `BeamStageProjection` sees no rotation difference and leaves the compucentric
+        correction alone -- it is there to flip positions *recorded* half a turn away,
+        and firing it on a synthetic landmark would move the travel limits by the
+        instrument's compucentric calibration for no reason. Tilt is not read at all
+        (the projection takes it from the base), and is carried only so the position
+        is complete.
+        """
+        origin = frame.origin
+        return FibsemStagePosition(
+            name=name, x=x, y=y, z=0.0, r=origin.r, t=origin.t
+        )
+
+    def _canvas_span(self, frame: StageFrame, length: float) -> Tuple[float, float]:
+        """A stage-space step of *length* metres, in canvas pixels, per axis.
+
+        Not `frame.length()` twice. That divides by the canvas scale and stops, which
+        is right for x and wrong for y: the view foreshortens stage y by a factor that
+        changes with the beam and the pose -- 1.00 looking down the pose a beam is
+        named after, 0.26 for the ion beam at the milling pose. A lattice or a boundary
+        sized by the scale alone is the same size in every view, and therefore right in
+        at most one of them.
+
+        Measured through the frame rather than derived from the geometry, so it cannot
+        disagree with where the frame puts a marker. Absolute, because a view can flip
+        an axis and a span has no sign.
+        """
+        anchor = self._landmark(frame, 0.0, 0.0)
+        ox, oy = frame.to_canvas(anchor)
+        along_x, _ = frame.to_canvas(self._landmark(frame, length, 0.0))
+        _, along_y = frame.to_canvas(self._landmark(frame, 0.0, length))
+        return abs(along_x - ox), abs(along_y - oy)
+
     def _limit_shapes(self, frame: StageFrame) -> List[ShapeSpec]:
         """The travel limits, and the grid boundary a cryo holder describes."""
         limits = getattr(self.microscope._stage, "limits", None)
         if not limits or not self.microscope.stage_is_compustage:
             return []
         try:
-            centre = FibsemStagePosition(name="Grid Centre", x=0, y=0, z=0, r=0, t=0)
-            cx, cy = frame.to_canvas(centre)
-            width = frame.length(limits["x"].max - limits["x"].min)
-            height = frame.length(limits["y"].max - limits["y"].min)
+            cx, cy = frame.to_canvas(self._landmark(frame, 0.0, 0.0, "Grid Centre"))
+            # Every corner, not a width and a height: the projection can flip either
+            # axis, and reading the envelope off the extremes of the projected corners
+            # is true whatever it does to them. The box stays axis-aligned -- the
+            # terms are a scale per axis and a possible flip of both.
+            corners = [
+                frame.to_canvas(self._landmark(frame, x, y))
+                for x in (limits["x"].min, limits["x"].max)
+                for y in (limits["y"].min, limits["y"].max)
+            ]
+            xs = [point[0] for point in corners]
+            ys = [point[1] for point in corners]
+            width, height = max(xs) - min(xs), max(ys) - min(ys)
+            box_cx, box_cy = (max(xs) + min(xs)) / 2, (max(ys) + min(ys)) / 2
+            # A circle on the sample, so an ellipse on screen everywhere but the two
+            # views where the beam looks down the pose it is named after.
+            span_x, span_y = self._canvas_span(frame, GRID_BOUNDARY_RADIUS)
         except Exception as e:
             logger.debug(f"Could not draw the stage limits: {e}")
             return []
         return [
-            ShapeSpec(kind="rect", cx=cx, cy=cy, width=width, height=height,
+            ShapeSpec(kind="rect", cx=box_cx, cy=box_cy, width=width, height=height,
                       color=LIMITS_COLOUR, label="Stage Limits"),
-            ShapeSpec(kind="circle", cx=cx, cy=cy,
-                      radius=frame.length(GRID_BOUNDARY_RADIUS),
+            ShapeSpec(kind="ellipse", cx=cx, cy=cy,
+                      width=2 * span_x, height=2 * span_y,
                       color=GRID_BOUNDARY_COLOUR, label="Grid Boundary"),
         ]
 

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -37,7 +37,10 @@ from fibsem.structures import (  # noqa: E402
     FibsemStagePosition,
     ImageSettings,
 )
-from fibsem.ui.widgets.overview_widget import FibsemOverviewWidget  # noqa: E402
+from fibsem.ui.widgets.overview_widget import (  # noqa: E402
+    GRID_BOUNDARY_RADIUS,
+    FibsemOverviewWidget,
+)
 
 _app = QApplication.instance() or QApplication(sys.argv)
 
@@ -878,6 +881,193 @@ class TestViews:
         assert widget.position_overlay._points == pytest.approx(in_sem), (
             "coming back to a view did not restore where its markers sit"
         )
+
+
+class TestOverlaysAreDrawnInTheView:
+    """Anything measured in *stage* space has to be projected before it is drawn.
+
+    A view foreshortens stage y and leaves x alone, by a factor that changes with the
+    beam and the pose: 1.00 looking down the pose a beam is named after, 0.26 for the
+    ion beam at the milling pose. Sized by the canvas scale alone -- which is what
+    `StageFrame.length()` gives -- the travel envelope and the grid boundary come out
+    the same in every view, and are therefore right in at most one.
+
+    The gridbar lattice has the identical bug and is deliberately not fixed here: it
+    still takes one pitch for both axes. Its *centre* is covered below, which was a
+    different fault. See FIB-615.
+
+    Every assertion here is against `frame.to_canvas`, the mapping that puts a *marker*
+    on the canvas. That is the point: an overlay and a marker describing the same piece
+    of stage have to agree, and the bug was that one of them projected and the other
+    did not. A test that recomputed the extent the way `_limit_shapes` does could not
+    have failed.
+
+    A compustage, because that is the only stage the limits are drawn on -- and it is
+    also where all three orientations share a rotation, so nothing here is really about
+    the 180-degree flip.
+    """
+
+    # Ion at the milling pose: the view you mill in, and the worst case at 0.259.
+    FORESHORTENED = ("MILLING", BeamType.ION)
+    # Electron at the SEM pose: the one view that is *not* foreshortened, so it is
+    # what the old, unprojected code happened to be right for.
+    SQUARE = ("SEM", BeamType.ELECTRON)
+
+    @staticmethod
+    def _image(scope, orientation, beam_type):
+        pose = scope.get_orientation(orientation)
+        position = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
+        hfw = 128 * 2e-7
+        image = FibsemImage.generate_blank_image(resolution=(128, 128), hfw=hfw)
+        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(np.uint8)
+        state = scope.get_microscope_state(beam_type=beam_type)
+        state.stage_position = position
+        image.metadata.image_settings = ImageSettings(hfw=hfw, beam_type=beam_type)
+        image.metadata.microscope_state = state
+        image.metadata.system_info = scope.system.info
+        image.metadata.hardware_geometry = scope.hardware_geometry()
+        return image
+
+    @staticmethod
+    def _spec(widget, kind, label):
+        for spec in widget.context_overlay._specs:
+            if spec.kind == kind and spec.label == label:
+                return spec
+        return None
+
+    def _show(self, widget, view):
+        """Put the canvas in *view* and return its frame."""
+        widget.set_image(self._image(widget.microscope, *view))
+        return widget._frame()
+
+    @staticmethod
+    def _marker_span(widget, frame, dx=0.0, dy=0.0):
+        """How far a stage step of (dx, dy) carries a *marker*, in canvas pixels.
+
+        The independent authority. Everything drawn from a stage position goes through
+        this same call, so an overlay that disagrees with it is drawn in a frame
+        nothing else is using.
+        """
+        origin = frame.origin
+        here = frame.to_canvas(
+            FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=origin.r, t=origin.t)
+        )
+        there = frame.to_canvas(
+            FibsemStagePosition(x=dx, y=dy, z=0.0, r=origin.r, t=origin.t)
+        )
+        return abs(there[0] - here[0]), abs(there[1] - here[1])
+
+    def test_the_limits_box_lands_where_a_marker_at_the_limits_would(
+        self, widget, microscope
+    ):
+        """The strongest statement of the property: put the travel envelope's corner on
+        the canvas as a *marked position*, and the corner of the drawn box has to be
+        under it. Checked in the foreshortened view, where the two used to differ."""
+        assert microscope.stage_is_compustage, "the limits only draw on a compustage"
+        frame = self._show(widget, self.FORESHORTENED)
+        limits = microscope._stage.limits
+
+        box = self._spec(widget, "rect", "Stage Limits")
+        assert box is not None, "the stage limits were not drawn"
+
+        corner = frame.to_canvas(
+            widget._landmark(frame, limits["x"].max, limits["y"].max)
+        )
+        assert abs(corner[0] - box.cx) == pytest.approx(box.width / 2, rel=1e-9)
+        assert abs(corner[1] - box.cy) == pytest.approx(box.height / 2, rel=1e-9)
+
+    def test_the_limits_box_is_shorter_in_a_foreshortened_view(self, widget, microscope):
+        """The bug, pinned. The box was `frame.length(ymax - ymin)` in every view, so
+        it was the same height at the milling pose as at the SEM one -- nearly four
+        times too tall in the view you mill in."""
+        limits = microscope._stage.limits
+        span_y = limits["y"].max - limits["y"].min
+        span_x = limits["x"].max - limits["x"].min
+
+        heights, widths = {}, {}
+        for view in (self.SQUARE, self.FORESHORTENED):
+            frame = self._show(widget, view)
+            box = self._spec(widget, "rect", "Stage Limits")
+            assert box is not None
+            # Against the marker path, per view, so this says "the box matches what a
+            # marker would do" rather than "the box matches the formula that drew it".
+            expected = self._marker_span(widget, frame, dx=span_x, dy=span_y)
+            assert box.width == pytest.approx(expected[0], rel=1e-9)
+            assert box.height == pytest.approx(expected[1], rel=1e-9)
+            heights[view], widths[view] = box.height, box.width
+
+        assert widths[self.SQUARE] == pytest.approx(widths[self.FORESHORTENED]), (
+            "x is not foreshortened, so the box must keep its width"
+        )
+        assert heights[self.FORESHORTENED] < heights[self.SQUARE] / 2, (
+            f"the box is {heights[self.FORESHORTENED]:.1f} px tall at the milling pose "
+            f"and {heights[self.SQUARE]:.1f} px at the SEM pose — it did not foreshorten"
+        )
+
+    def test_the_grid_boundary_is_an_ellipse_where_the_view_is_not_square(self, widget):
+        """A circle on the sample is a circle on screen in two views and an ellipse in
+        every other. Drawn as a circle it claimed the grid was round from a direction
+        it is not."""
+        frame = self._show(widget, self.FORESHORTENED)
+        boundary = self._spec(widget, "ellipse", "Grid Boundary")
+        assert boundary is not None, "the grid boundary was not drawn as an ellipse"
+
+        expected = self._marker_span(
+            widget, frame, dx=GRID_BOUNDARY_RADIUS, dy=GRID_BOUNDARY_RADIUS
+        )
+        assert boundary.width == pytest.approx(2 * expected[0], rel=1e-9)
+        assert boundary.height == pytest.approx(2 * expected[1], rel=1e-9)
+        assert boundary.height < boundary.width / 2, "it is still round"
+
+    def test_the_grid_boundary_stays_round_in_a_square_view(self, widget):
+        """The other half of the same statement, and what stops the fix being "make it
+        an ellipse and hope": looking down the pose the beam is named after, the grid
+        really is round."""
+        self._show(widget, self.SQUARE)
+        boundary = self._spec(widget, "ellipse", "Grid Boundary")
+        assert boundary is not None
+        assert boundary.width == pytest.approx(boundary.height, rel=1e-9)
+
+    def test_the_lattice_is_centred_where_the_grid_centre_marker_is(self):
+        """Grid centre is a *place*, and a place has no rotation of its own.
+
+        Built with `r=0` it looked, to the projection, like a position recorded half a
+        turn from the view — which on a stage that reaches the ion beam by rotating is
+        exactly what a FIB overview is. So the compucentric correction fired on a
+        landmark that was never anywhere, and centred the whole lattice **1.96 mm**
+        away from the origin it names.
+
+        Invisible on a compustage, where every orientation shares one rotation, which
+        is why this needs its own microscope. Asserted against a marker at the same
+        stage position: the two describe the same point and a user sees them together.
+        """
+        import fibsem.config as fibsem_config
+
+        path = os.path.join(
+            os.path.dirname(fibsem_config.__file__),
+            "config",
+            "tfs-aquilos2-configuration.yaml",
+        )
+        scope, _ = utils.setup_session(manufacturer="Demo", config_path=path)
+        assert not scope.stage_is_compustage, "this is the standard-stage case"
+
+        widget = FibsemOverviewWidget(scope)
+        try:
+            widget.set_image(self._image(scope, "FIB", BeamType.ION))
+            widget.checkbox_gridbars.setChecked(True)
+
+            pose = scope.get_orientation("FIB")
+            centre = FibsemStagePosition(
+                name="Grid Centre", x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t
+            )
+            widget.set_positions([centre])
+
+            marker = widget.position_overlay._points[0]
+            assert widget.gridbar_overlay._centre == pytest.approx(marker, abs=1e-6), (
+                "the grid bars are not centred on the grid centre"
+            )
+        finally:
+            widget.close()
 
 
 class TestLifecycle:


### PR DESCRIPTION
Everything the overview canvas draws from a **stage-space length** was sized with `StageFrame.length()` — a pure divide by the canvas scale, with no view in it. A view foreshortens stage y and leaves x alone, by a factor that changes with the beam and the pose, so the travel envelope and the grid boundary came out the same in every view and were right in the two the tab was built against.

Stacked on #388, which is where the widget work lives.

## Measured

1 mm of stage y through `BeamStageProjection.to_plane`, sim-arctis, identical on both stage types:

| orientation | beam | factor |
| -- | -- | -- |
| SEM | Electron | 1.000 |
| SEM | Ion | 0.616 |
| FIB | Electron | 0.616 |
| FIB | Ion | 1.000 |
| MILLING | Electron | 0.921 |
| MILLING | Ion | **0.259** |

The box was right in exactly the two views where the beam looks down the pose it is named after. Milling · Ion — the view you mill in — was **3.9× too tall**. And since x is not foreshortened, this was wrong in *aspect*, not just size: no single scale factor would have fixed it.

After, in canvas pixels:

| view | limits box | grid boundary |
| -- | -- | -- |
| SEM · Electron | 2559.7 × 967.2 | 2560.0 × 2560.0 (round) |
| MILLING · Ion | 2559.7 × **250.3** | 2560.0 × **662.6** (ellipse) |

## What changed

- **The envelope** comes from the extremes of the four projected corners, rather than a width and a height off the limits. True whichever axis the view flips, and it stays axis-aligned because the terms are a scale per axis plus a possible flip of both.
- **The boundary** is a new `"ellipse"` spec. A circle on the sample is only a circle on screen in the two square views; drawn round elsewhere it claimed the grid was round from a direction it is not.
- **`_canvas_span`** measures a stage-space step per axis *through the frame*, so it cannot disagree with where the frame puts a marker.

## A second fault, not in the issue

The synthetic "Grid Centre" landmark was `FibsemStagePosition(x=0, y=0, z=0, r=0, t=0)`. On a stage that reaches the ion beam by rotating, a FIB overview's base is at `r = 180` — so the projection read the landmark as a position *recorded* half a turn from the view, and applied the compucentric correction to a place that was never anywhere:

```
old landmark ->  (-975.5, -1968.6) um
new landmark ->  (0.0, -0.0) um
```

**1.96 mm** out on an Aquilos2 at FIB. Invisible on a compustage, where every orientation shares one rotation — the same blind spot that hid the original transcription error in #386. Landmarks now carry the frame's own rotation, so the correction cannot fire on something with no pose of its own. (Tilt is not read by the projection at all; it comes from the base.)

## Deliberately not fixed

The **gridbar lattice** has the identical bug — one pitch for both axes, so its horizontal bars sit ~4× too far apart at the milling pose. Deprioritised; `_refresh_gridbars` says so at the call site and the test class says which half it covers, so neither reads as finished. The fix is `_canvas_span` (already here) plus a per-axis `set_lattice`.

## Testing

Every assertion is against `frame.to_canvas` — the mapping that places a **marker** — not against a recomputed extent. That is the point: an overlay and a marker describing the same piece of stage have to agree, and the bug was precisely that one projected and the other did not. A test re-deriving the extent the way `_limit_shapes` does could not have failed.

Three mutations, each caught by the test that should catch it:

| mutation | killed by |
| -- | -- |
| y takes x's scale in `_canvas_span` | the boundary tests |
| the box back on `frame.length` | both limits-box tests |
| the landmark back to `r=0` | the lattice-centre test |

1316 pass across `fibsem/applications/autolamella/ui/tests/` and `tests/ui/`.

Verified visually too, in both views — the milling render shows the flattened envelope and the ellipse.
