### PR TITLE
[ui] Draw the overview canvas before the first image (FIB-616)

### DIFF
--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -122,12 +122,7 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         if reference_pixel_size:
             self._pixel_size = reference_pixel_size  # drives the scalebar
 
-        # Square pixels from the outset, not just once an image happens to arrive.
-        # imshow sets this per-artist, so an empty canvas would otherwise be "auto":
-        # the axes would stretch to the widget and draw a square grid as a rectangle --
-        # a resize alone distorted it 3x. Overlays are drawn in this frame whether or
-        # not anything has been acquired, so the frame has to be honest first.
-        self._ax.set_aspect("equal", adjustable="box")
+        self._apply_axes_convention()
 
         self.set_background_color(_DEFAULT_BACKGROUND)
         # Contrast/gamma acts on a single frame; there is no meaning yet for "the"
@@ -273,6 +268,30 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         self._placed.clear()
         self._fitted_extent = None
         super().clear()
+        # `cla()` takes the aspect and the y direction with it.
+        self._apply_axes_convention()
+
+    def _apply_axes_convention(self) -> None:
+        """Square pixels and y running *down*, whether or not anything is placed.
+
+        Both are set by `imshow` per artist, so a canvas with no images inherits
+        matplotlib's defaults instead: axes that stretch to the widget, and a y axis
+        that increases upwards. Neither is survivable here, because overlays are drawn
+        in this frame whether or not anything has been acquired.
+
+        The aspect was the visible one first -- a resize alone drew a square lattice as
+        a rectangle, 3x out. The y direction is worse and stayed hidden longer: with
+        nothing placed the scene is drawn *vertically mirrored*, and flips the right way
+        up the moment the first tile lands. Nothing showed it while an empty canvas drew
+        nothing; it appeared as soon as the overlays did (FIB-616), first as labels
+        sitting under their shapes instead of over them.
+
+        Applied by inverting rather than by setting limits: matplotlib's autoscale
+        preserves the axis direction, so this survives every later refit.
+        """
+        self._ax.set_aspect("equal", adjustable="box")
+        if not self._ax.yaxis_inverted():
+            self._ax.invert_yaxis()
 
     def set_reference_pixel_size(self, pixel_size: float) -> bool:
         """Fix the canvas scale before anything is placed.

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -249,8 +249,17 @@ class FibsemOverviewWidget(QWidget):
         # the SEM one happened to start.
         self._origins: Dict["OverviewView", FibsemStagePosition] = {}
         self._projections: Dict["OverviewView", BeamStageProjection] = {}
-        # The view the canvas is currently showing. None until something is placed.
+        # Views anchored on the stage rather than on an image, so the tab could draw
+        # before anything was acquired. The first image in one replaces its anchor --
+        # see `_seed_frame` and `_set_origin_from`.
+        self._provisional: Set["OverviewView"] = set()
+        # The view the canvas is showing. None only before the stage position and the
+        # settings are both known; `_seed_frame` fills it in from where the stage is.
         self._current_view: Optional["OverviewView"] = None
+        # Whether the displayed view has been decided by something other than where the
+        # stage happens to be -- an image arriving, or the user picking one. Until then
+        # the canvas is a live plan of the next run and follows the stage.
+        self._view_pinned = False
         self._positions: List[FibsemStagePosition] = []
         self._selected_position: Optional[str] = None
         # Positions a host has flagged, by name. What "flagged" means is the host's
@@ -457,6 +466,9 @@ class FibsemOverviewWidget(QWidget):
     def _on_view_selected(self, _index: int) -> None:
         view = self.combo_view.value()
         if isinstance(view, OverviewView):
+            # Chosen, so the canvas stops following the stage -- otherwise re-posing
+            # would silently undo the choice.
+            self._view_pinned = True
             self.show_view(view)
 
     def _refresh_view_selector(self) -> None:
@@ -679,15 +691,78 @@ class FibsemOverviewWidget(QWidget):
         """Force every projection to be re-read. For a host that changed the instrument."""
         self._projections.clear()
 
+    def _seed_frame(self) -> None:
+        """Give the canvas a frame before anything has been acquired.
+
+        A frame needs three things: a projection, a scale and an origin. The projection
+        is read from the instrument, but the other two used to arrive only with the
+        first image -- so the tab opened blank. No travel limits, no grid boundary, no
+        holder slots, no lamella markers, not even the stage. Everything appeared at
+        once when the first tile landed, which is the moment it stopped being the most
+        useful. The fluorescence overview has never behaved this way.
+
+        Both are free here. The scale is `hfw / width` off the settings widget -- a
+        widget read, not a device one -- and it is only "how many metres a canvas pixel
+        is worth", so the first image being a little coarser or finer than planned does
+        not matter: `add_image` scales each image by its own pixel size against this
+        one. The origin is the stage position already cached for the markers.
+
+        Anchored rather than re-derived on each call. Fixing it means the travel
+        envelope stays put and the stage marker moves inside it, which is the way round
+        that matches what the overlays describe; following the stage would pin the
+        marker to the middle and slide the grid past it.
+
+        Provisional, though, and marked as such: the first real image in the view
+        replaces it, so a canvas that ends up holding data is anchored on the data
+        rather than on wherever the stage happened to be when the tab was opened.
+        """
+        settings = self._settings()
+        if settings is None:
+            return
+
+        if self.canvas.reference_pixel_size is None:
+            try:
+                width = settings.image_settings.resolution[0]
+                pixel_size = settings.image_settings.hfw / width
+            except Exception as e:
+                logger.debug(f"Could not work out a canvas scale: {e}")
+                pixel_size = None
+            if pixel_size:
+                self.canvas.set_reference_pixel_size(pixel_size)
+
+        view = self.acquisition_view
+        if view is None or self._stage_position is None:
+            return
+
+        # Follow the stage only while nothing has decided otherwise. Once an image has
+        # been placed, or the user has picked a view, the displayed view is theirs and
+        # re-posing the stage must not drag them off it -- that is what
+        # `_refresh_view_note` is for.
+        #
+        # A pin rather than "is the canvas empty": `show_view` clears the canvas before
+        # re-placing, and this runs from inside it, so an emptiness test flips the view
+        # back to the stage's half way through switching to another one.
+        if not self._view_pinned and view != self._current_view:
+            self._current_view = view
+            self._refresh_view_selector()
+
+        if view not in self._origins:
+            self._origins[view] = deepcopy(self._stage_position)
+            self._provisional.add(view)
+
     def _frame(
         self, view: Optional["OverviewView"] = None, fresh: bool = False
     ) -> Optional[StageFrame]:
         """Stage positions and canvas coordinates, about a view's own origin.
 
-        None until the view has an origin *and* the canvas has a scale: the canvas takes
-        its scale from the first image placed, so nothing can be drawn in stage
-        coordinates before then. That is why `_refresh_context_overlays` is safe to call
-        at any time and simply does nothing early on.
+        None until the view has an origin *and* the canvas has a scale. Both are seeded
+        for the view the *next run* would produce (see :meth:`_seed_frame`), so this is
+        None in practice only for a view nothing has been acquired in and the stage is
+        not pointing at -- which has no honest origin to invent.
+
+        A pure read: the seeding is done by `_refresh_context_overlays`, so the many
+        callers that only want to draw or resolve a point cannot quietly re-anchor the
+        canvas by asking.
         """
         view = view or self._current_view
         if view is None:
@@ -701,13 +776,21 @@ class FibsemOverviewWidget(QWidget):
         return StageFrame(self.canvas, origin, projection)
 
     def _set_origin_from(self, image: FibsemImage, view: "OverviewView") -> None:
-        """Anchor a view on the first image placed in it, if it is not anchored yet."""
-        if view in self._origins:
+        """Anchor a view on the first image placed in it, if it is not anchored yet.
+
+        A *provisional* anchor -- one `_seed_frame` invented so the tab could draw
+        before anything was acquired -- is replaced rather than kept. Nothing is placed
+        in the view at that point, so re-anchoring moves nothing; it just stops the
+        canvas being centred on wherever the stage happened to be when the tab opened,
+        which can be millimetres from the data.
+        """
+        if view in self._origins and view not in self._provisional:
             return
         position = self._position_of(image)
         if position is None:
             return
         self._origins[view] = deepcopy(position)
+        self._provisional.discard(view)
 
     # ── views ────────────────────────────────────────────────────────────
 
@@ -834,6 +917,10 @@ class FibsemOverviewWidget(QWidget):
         view = self._view_of(image)
         if view is None:
             return None
+        # An image decides the view from here on, so the canvas stops following the
+        # stage. Set before the switch below, because `show_view` refreshes the
+        # overlays and the seeding that runs there would otherwise pull the view back.
+        self._view_pinned = True
         if self._current_view is None:
             self._current_view = view
             self._refresh_view_selector()
@@ -842,9 +929,10 @@ class FibsemOverviewWidget(QWidget):
 
         self._set_origin_from(image, view)
         # The canvas needs a scale before a frame can exist, and the frame is what turns
-        # a stage position into an offset -- so the first image sets the scale and is
-        # placed at the origin by definition. Shared across views: the scale is only how
-        # many metres a canvas pixel is worth, and placement is in metres either way.
+        # a stage position into an offset. Usually seeded from the settings before any
+        # image arrives (`_seed_frame`); this is the fallback for a widget that has been
+        # handed an image without ever drawing. Which pixel size wins does not matter
+        # beyond the units: `add_image` scales each image by its own against this one.
         if self.canvas.reference_pixel_size is None:
             self.canvas.set_reference_pixel_size(pixel_size)
 
@@ -995,7 +1083,12 @@ class FibsemOverviewWidget(QWidget):
 
         Everything here is derived from configuration and the cached stage position, so
         it costs no hardware access and is safe to call on any UI event.
+
+        The one place that anchors the canvas, so `_frame` stays a pure read: this runs
+        on construction, on a stage move, on a settings change and on a view change,
+        which is every moment the answer could have changed.
         """
+        self._seed_frame()
         frame = self._frame()
         if frame is None:
             self.context_overlay.set_shapes([])

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -1031,12 +1031,24 @@ class FibsemOverviewWidget(QWidget):
         return True
 
     def remove_overview(self, record_id: str) -> bool:
-        """Take one overview off the canvas entirely. False if the id is unknown."""
+        """Take one overview off the canvas entirely. False if the id is unknown.
+
+        Removing the last one puts the tab back where it started, so it goes back to
+        following the stage too. Otherwise you would be left looking at an empty canvas
+        pinned to a view nothing is in, which is the state this whole seeding exists to
+        avoid -- and the pin came from an image that is no longer there to justify it.
+        Cleared before the refresh below, so the canvas re-points in the same pass.
+
+        Hidden is not removed: `set_overview_visible` leaves the record, and a view you
+        can bring back with a checkbox is still a view you chose to be in.
+        """
         record = self._records.pop(record_id, None)
         if record is None:
             return False
         for key in record.keys:
             self.canvas.remove_image(key)
+        if not self._records:
+            self._view_pinned = False
         self._refresh_context_overlays()
         self._refresh_overview_list()
         return True

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -40,6 +40,7 @@ from fibsem.structures import (  # noqa: E402
 from fibsem.ui.widgets.overview_widget import (  # noqa: E402
     GRID_BOUNDARY_RADIUS,
     FibsemOverviewWidget,
+    OverviewView,
 )
 
 _app = QApplication.instance() or QApplication(sys.argv)
@@ -722,16 +723,25 @@ class TestViews:
 
     def test_each_view_keeps_its_own_origin(self, widget):
         """Everything in a view is placed relative to that view's anchor. One shared
-        origin would put the FIB tiles wherever the SEM overview happened to start."""
+        origin would put the FIB tiles wherever the SEM overview happened to start.
+
+        Looked up by view rather than counted: the widget also anchors the view the
+        *stage* is in, before anything is acquired, so the dict holds more than the
+        views images were placed in — and that provisional anchor is a third entry
+        whose pose says nothing about these two.
+        """
         scope = widget.microscope
         widget.set_image(self._image(scope, "SEM", BeamType.ELECTRON))
         widget.set_image(self._image(scope, "FIB", BeamType.ION))
 
-        assert len(widget._origins) == 2
-        origins = list(widget._origins.values())
-        assert origins[0].t != pytest.approx(origins[1].t), (
+        sem = OverviewView(beam_type=BeamType.ELECTRON, orientation="SEM")
+        fib = OverviewView(beam_type=BeamType.ION, orientation="FIB")
+        assert sem in widget._origins and fib in widget._origins
+        assert widget._origins[sem].t != pytest.approx(widget._origins[fib].t), (
             "the two views share an origin pose"
         )
+        # Both were fixed by an image, so neither is still the stage's stand-in.
+        assert not ({sem, fib} & widget._provisional)
 
     def test_the_projection_is_per_view(self, widget):
         """The stale-cache bug: after switching beam, drawing kept using the electron
@@ -881,6 +891,98 @@ class TestViews:
         assert widget.position_overlay._points == pytest.approx(in_sem), (
             "coming back to a view did not restore where its markers sit"
         )
+
+
+class TestTheCanvasDrawsBeforeAnythingIsAcquired:
+    """Opening the tab has to show where you are, not a black rectangle.
+
+    A frame needs a projection, a scale and an origin. The projection comes off the
+    instrument, but the other two used to arrive only with the first image -- so the
+    tab was blank until a tile landed, and then everything appeared at once. That is
+    the wrong way round: a planned footprint, the travel limits and the lamella
+    markers are worth the most *before* you acquire.
+    """
+
+    @staticmethod
+    def _at(scope, orientation):
+        pose = scope.get_orientation(orientation)
+        return FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
+
+    def test_a_freshly_opened_tab_has_a_frame(self, widget):
+        assert widget._frame() is not None, "nothing can be drawn in stage coordinates"
+        assert widget.current_view is not None, "no view to draw in"
+        assert widget.canvas.reference_pixel_size, "the canvas has no scale"
+
+    def test_it_draws_the_context_with_nothing_placed(self, widget):
+        """The whole point. Every one of these used to wait for the first tile."""
+        assert not widget.canvas.placed_keys, "this test is about the empty canvas"
+        drawn = {spec.label for spec in widget.context_overlay._specs}
+        assert "Stage Limits" in drawn
+        assert "Grid Boundary" in drawn
+        assert "Overview FoV" in drawn, "the planned run is not shown"
+        assert widget.current_position_overlay._points, "the stage is not marked"
+
+    def test_marked_positions_appear_before_any_image(self, widget, microscope):
+        """The host hands over the experiment's lamellae as soon as one is loaded, and
+        that is usually before anything has been acquired in this session."""
+        mark = self._at(microscope, "SEM")
+        mark.name = "L1"
+        widget.set_positions([mark])
+        assert widget.position_overlay._points, "a marked lamella was not drawn"
+
+    def test_the_scale_comes_from_the_settings(self, widget):
+        """A widget read, not a device one — and it tracks the field of view, so the
+        planned footprint is drawn at the size the next run would actually cover."""
+        settings = widget._settings()
+        expected = settings.image_settings.hfw / settings.image_settings.resolution[0]
+        assert widget.canvas.reference_pixel_size == pytest.approx(expected)
+
+    def test_the_first_image_replaces_the_stand_in_anchor(self, widget, microscope):
+        """The seeded anchor is where the stage happened to be when the tab opened,
+        which can be millimetres from the data. Nothing is placed against it yet, so
+        the first real image takes the anchor over rather than sitting at an offset
+        from a position that means nothing."""
+        view = widget.current_view
+        assert view in widget._provisional, "the anchor was not marked provisional"
+
+        base = microscope.get_stage_position()
+        far = _at(base, dx=4e-3, dy=2e-3)
+        widget.place_image(_tile(microscope, far), key="first")
+
+        assert view not in widget._provisional
+        assert widget._origins[view].x == pytest.approx(far.x)
+        assert widget._origins[view].y == pytest.approx(far.y)
+
+    def test_the_view_follows_the_stage_until_an_image_pins_it(self, widget, microscope):
+        """While the canvas is a plan of the next run it should describe where the
+        stage *is*. Once an image has been placed the displayed view is about data,
+        and re-posing the stage must not drag the user off it."""
+        widget._on_stage_moved(self._at(microscope, "MILLING"))
+        assert widget.current_view.orientation == "MILLING", "the plan did not follow"
+
+        widget._on_stage_moved(self._at(microscope, "SEM"))
+        widget.place_image(_tile(microscope, self._at(microscope, "SEM")), key="a")
+        pinned = widget.current_view
+
+        widget._on_stage_moved(self._at(microscope, "MILLING"))
+        assert widget.current_view == pinned, (
+            "moving the stage switched the canvas away from the acquired view"
+        )
+
+    def test_an_image_is_drawn_at_its_own_size_whatever_the_scale_was_seeded_to(
+        self, widget, microscope
+    ):
+        """The seeded scale is only the canvas unit — how many metres a canvas pixel is
+        worth. An image coarser or finer than the plan is still drawn covering the
+        ground it images, because `add_image` scales each one by its own pixel size."""
+        hfw = 37e-6  # deliberately unlike the settings' field of view
+        base = microscope.get_stage_position()
+        widget.place_image(
+            _tile(microscope, _at(base), shape=(64, 64), hfw=hfw), key="odd"
+        )
+        extent = widget.canvas._placed["odd"].extent
+        drawn = (extent[1] - extent[0]) * widget.canvas.reference_pixel_size
+        assert drawn == pytest.approx(hfw, rel=1e-9)
 
 
 class TestOverlaysAreDrawnInTheView:

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -969,6 +969,49 @@ class TestTheCanvasDrawsBeforeAnythingIsAcquired:
             "moving the stage switched the canvas away from the acquired view"
         )
 
+    def test_removing_the_last_overview_goes_back_to_following_the_stage(
+        self, widget, microscope
+    ):
+        """An empty canvas pinned to a view nothing is in is the state this seeding
+        exists to avoid, and the image that pinned it is no longer there to justify
+        it."""
+        widget.set_image(_tile(microscope, self._at(microscope, "SEM")))
+        widget._on_stage_moved(self._at(microscope, "MILLING"))
+        assert widget.current_view.orientation == "SEM", "pinned by the image"
+
+        record_id = widget.overviews[0].id
+        assert widget.remove_overview(record_id) is True
+        assert widget.current_view.orientation == "MILLING", (
+            "the canvas is empty but still pinned to the removed image's view"
+        )
+
+    def test_removing_one_of_several_keeps_the_view(self, widget, microscope):
+        """Only the *last* one releases the pin. Tidying one overview off a canvas that
+        still holds others must not hand the view back to the stage underneath the
+        user -- they are still looking at data."""
+        widget.set_image(_tile(microscope, self._at(microscope, "SEM")))
+        widget.set_image(
+            _tile(microscope, _at(self._at(microscope, "SEM"), dx=200e-6))
+        )
+        assert len(widget.overviews) == 2
+
+        assert widget.remove_overview(widget.overviews[0].id) is True
+        widget._on_stage_moved(self._at(microscope, "MILLING"))
+        assert widget.current_view.orientation == "SEM", (
+            "removing one of two overviews unpinned the view"
+        )
+
+    def test_hiding_an_overview_is_not_removing_it(self, widget, microscope):
+        """A view you can bring back with a checkbox is still a view you chose."""
+        widget.set_image(_tile(microscope, self._at(microscope, "SEM")))
+        record_id = widget.overviews[0].id
+        widget.set_overview_visible(record_id, False)
+
+        widget._on_stage_moved(self._at(microscope, "MILLING"))
+        assert widget.current_view.orientation == "SEM", (
+            "hiding an overview unpinned the view"
+        )
+
     def test_an_image_is_drawn_at_its_own_size_whatever_the_scale_was_seeded_to(
         self, widget, microscope
     ):

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -94,6 +94,50 @@ def test_positive_x_is_right_and_positive_y_is_down():
     assert (f[2] + f[3]) / 2 > (o[2] + o[3]) / 2  # +y drew further down
 
 
+def _renders_y_downward(canvas) -> bool:
+    """Whether a larger canvas y actually lands lower on screen.
+
+    Through `transData` rather than off the axis flag, because the flag is a means:
+    what matters is where a point is drawn. Display y increases upward, so drawing
+    +y downward means +y transforms to a *smaller* display y than -y.
+    """
+    lower = canvas._ax.transData.transform((0.0, 100.0))[1]
+    upper = canvas._ax.transData.transform((0.0, -100.0))[1]
+    return lower < upper
+
+
+def test_y_runs_down_before_any_image_is_placed():
+    """The extents above are only half the statement -- which way the axis *runs*
+    decides where they land on screen, and matplotlib's default is y up.
+
+    `imshow` sets the direction per artist, so a canvas holding images was right by
+    accident while an empty one drew the whole scene **vertically mirrored**: a marker
+    at +100 um appeared where -100 um belongs, and the scene flipped the right way up
+    the moment the first tile arrived. Nothing showed it while an empty canvas drew
+    nothing, so it surfaced only once the overlays did (FIB-616) -- first as shape
+    labels sitting under their shapes instead of over them.
+    """
+    assert _renders_y_downward(_canvas())
+
+
+def test_y_still_runs_down_once_an_image_is_placed():
+    """The direction must not depend on what is on the canvas, or the scene flips
+    under the user as the first tile lands."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="a")
+    assert _renders_y_downward(c)
+
+
+def test_the_axes_convention_survives_a_clear():
+    """`cla()` takes the aspect and the y direction with it, and `clear` is how a host
+    hands the canvas to a different experiment."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="a")
+    c.clear()
+    assert _renders_y_downward(c)
+    assert c._ax.get_aspect() == 1.0, "square pixels were lost with the axes"
+
+
 def test_a_coarser_image_covers_proportionally_more_ground():
     """Different binning must compose at true relative size, not equal size."""
     c = _canvas()


### PR DESCRIPTION
Opening the Overview tab showed a black rectangle. No travel limits, no grid boundary, no holder slots, no lamella markers, not even the stage — everything appeared at once when the first tile landed, which is the moment it stopped being the most useful. The fluorescence overview has never behaved this way.

Stacked on #388.

## Why

A frame needs three things, and two of them only arrived with an image:

| ingredient | set by | needed an image? |
| -- | -- | -- |
| the view's origin | `_set_origin_from`, called only from `place_image` | **yes** |
| `canvas.reference_pixel_size` | `place_image` | **yes** |
| the projection | `BeamStageProjection.from_microscope` | no |

No frame meant `_refresh_context_overlays` returned early, and every marker with it.

Both are free to supply. The scale is `hfw / width` off the settings widget — a widget read, not a device one — and the origin is the stage position already cached for the markers. `FMOverviewWidget` does the equivalent (`self._origin or self._current_stage_position()`, plus seeding the scale from the camera).

## Three things that had to be right

**The anchor is fixed, not re-derived per call.** Otherwise the stage marker would be pinned to the middle and the travel envelope would slide past it — the wrong way round for overlays that describe where the stage can go.

**It is provisional.** The first real image in the view replaces it, so a canvas that ends up holding data is anchored on the data rather than on wherever the stage happened to be when the tab was opened, which can be millimetres away. Nothing is placed against it at that point, so re-anchoring moves nothing.

**The displayed view follows the stage only until something decides otherwise** — an image arriving or the user picking one — tracked as an explicit pin. Inferring it from "the canvas is empty" does not work: `show_view` clears the canvas before re-placing and refreshes the overlays while it is empty, so the seeding pulled the view back to the stage's half way through switching to another one. That cost three existing tests, which is how it was found.

## Which pixel size wins

It does not matter beyond the units. The reference is only "how many metres a canvas pixel is worth"; `add_image` scales every image by its own pixel size against it, so an image coarser or finer than the plan is still drawn covering the ground it images. There is a test for exactly that, with an image whose field of view is deliberately unlike the settings'.

## Structure

Seeding lives in `_refresh_context_overlays` — the one place that runs on construction, on a stage move, on a settings change and on a view change, which is every moment the answer could have changed. `_frame` stays a pure read, so the many callers that only want to draw or resolve a point cannot quietly re-anchor the canvas by asking.

## Testing

7 new tests; 1323 pass across `fibsem/applications/autolamella/ui/tests/` and `tests/ui/`.

Three mutations, each caught by the test that should catch it:

| mutation | killed by |
| -- | -- |
| no seeding at all | 6 of the 7 |
| provisional anchor never replaced | `test_the_first_image_replaces_the_stand_in_anchor` |
| an image does not pin the view | `test_the_view_follows_the_stage_until_an_image_pins_it` |

`test_each_view_keeps_its_own_origin` now looks its two views up by name rather than counting `_origins` — the provisional anchor for the view the stage is in is a third entry, and it is meant to be there.
