### PR TITLE
[autolamella] Add --quickstart and --quickload developer flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ To run:
 fibsem-autolamella-ui
 ```
 
+Two flags skip the clicks that start every session, for development against a
+simulator or an instrument you reconnect to all day. `--quickstart` connects with the
+default microscope configuration as soon as the window is up; `--quickload` does that
+and then reopens the most recent experiment:
+```bash
+fibsem-autolamella-ui --quickload
+```
+
 ### Offline Installation
 For computers with no internet connection, you can download the dependencies on a separate internet connected computer and transfer it to the Support PC (e.g. via USB).
 

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import argparse
 import logging
 import sys
 import time
-from typing import Optional
+from typing import List, Optional
 
 try:
     sys.modules.pop("PySide6.QtCore")
@@ -2389,10 +2390,33 @@ def _start_update_check() -> None:
     _check().start()
 
 
-def run_ui():
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """Parse the command-line flags accepted by the AutoLamella UI."""
+    parser = argparse.ArgumentParser(
+        prog="fibsem-autolamella-ui",
+        description="Launch the AutoLamella user interface.",
+    )
+    parser.add_argument(
+        "--quickstart",
+        action="store_true",
+        help="Connect to the microscope with the default configuration as soon as the "
+             "window is up, instead of waiting for the Connection tab.",
+    )
+    parser.add_argument(
+        "--quickload",
+        action="store_true",
+        help="Connect as --quickstart does, then reopen the most recent experiment. "
+             "Implies --quickstart -- the experiment tabs are built at connection time.",
+    )
+    return parser.parse_args(argv)
+
+
+def run_ui(argv: Optional[List[str]] = None):
     """Run the AutoLamella embedded example."""
     import faulthandler
     import signal
+
+    args = _parse_args(argv)
 
     from fibsem.tools.bug_report import init_sentry
 
@@ -2419,6 +2443,15 @@ def run_ui():
     window = AutoLamellaSingleWindowUI()
     window.show()
     _start_update_check()
+    if args.quickstart or args.quickload:
+        # Once the event loop is running, not inline here: connecting blocks for
+        # seconds against real hardware, and doing it before exec_() would hold up
+        # the first paint — an empty window frame for the whole wait. A zero timer
+        # fires as soon as the window system's queue, that first paint included,
+        # has drained.
+        QTimer.singleShot(
+            0, lambda: window.autolamella_ui.quickstart(load_experiment=args.quickload)
+        )
     sys.exit(app.exec_())
 
 

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -12,6 +12,7 @@ import logging
 import os
 import threading
 from copy import deepcopy
+from pathlib import Path
 from typing import List, Optional, TYPE_CHECKING
 from fibsem import conversions
 from fibsem.constants import METRE_TO_MICRON, MICRON_TO_METRE
@@ -490,6 +491,69 @@ class AutoLamellaUI(QMainWindow):
             return
 
         self._adopt_experiment(experiment)
+
+    def quickstart(self, load_experiment: bool = False) -> None:
+        """Connect to the microscope without waiting to be clicked (``--quickstart``).
+
+        The developer shortcut past the two clicks that start every session: the same
+        calls the Connection tab and the load dialog make, with the default microscope
+        configuration and the most recent experiment assumed.
+
+        Every failure here is reported and swallowed rather than raised. This runs
+        unattended on the way up, and an unreachable microscope or an experiment that
+        has moved should still leave the ordinary window -- the one where the user can
+        pick a different configuration -- rather than a half-started application.
+        """
+        if self.system_widget.microscope is None:
+            try:
+                self.system_widget.connect_to_microscope()
+            except Exception as e:
+                logging.warning(f"Quickstart: unable to connect to the microscope: {e}")
+                notification_service.show_toast(
+                    f"Quickstart: could not connect to the microscope: {e}", "error"
+                )
+                return
+
+        # connect_to_microscope reports its own failures and returns without a
+        # microscope (an unselectable configuration, say). Nothing below works
+        # without one, so stop here rather than reporting a second failure.
+        if self.system_widget.microscope is None:
+            return
+
+        if load_experiment:
+            self.quickload_experiment()
+
+    def quickload_experiment(self) -> None:
+        """Reopen the most recent experiment, skipping the load dialog (``--quickload``).
+
+        Requires a connected microscope, as the dialog path does: the tabs that adopt
+        an experiment are built at connection time.
+        """
+        experiment_path = fibsem_cfg.get_last_experiment_file()
+
+        if experiment_path is None:
+            msg = "Quickload: no recent experiment to load."
+            logging.warning(msg)
+            notification_service.show_toast(msg, "warning")
+            return
+
+        try:
+            experiment = Experiment.load(Path(experiment_path))
+        except Exception as e:
+            logging.warning(f"Quickload: unable to load {experiment_path}: {e}")
+            notification_service.show_toast(f"Quickload: could not load experiment: {e}", "error")
+            return
+
+        # The same bar the load dialog sets. An experiment with no protocol has
+        # nothing to run, and adopting one here would only look loaded.
+        if experiment.task_protocol is None:
+            msg = f"Quickload: {experiment.name} has no protocol; not loaded."
+            logging.warning(msg)
+            notification_service.show_toast(msg, "warning")
+            return
+
+        self._adopt_experiment(experiment)
+        logging.info(f"Quickload: loaded experiment {experiment.name} from {experiment_path}")
 
     def _adopt_experiment(self, experiment: Experiment) -> None:
         """Make ``experiment`` the current one, and point logging at its logfile.

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -592,6 +592,34 @@ def get_recent_experiments(prune_missing: bool = True) -> List[ExperimentSummary
     return infos
 
 
+def get_last_experiment_file() -> Optional[str]:
+    """Path to the ``experiment.yaml`` of the last experiment opened, or None.
+
+    ``last_experiment_path`` is the experiment *directory* -- that is how both the
+    create and the load dialog record it -- so callers do not have to know where
+    the file sits inside it.
+
+    Falls back to the newest recent entry still on disk, because the two lists go
+    stale differently: recents are pruned when their file disappears and this one
+    never is, so the last experiment opened is routinely a scratch experiment that
+    has since been deleted. The next-newest one is the useful answer there, not
+    nothing.
+    """
+    prefs = load_user_preferences()
+
+    last_path = str(prefs.experiment.last_experiment_path or "")
+    if last_path:
+        candidate = os.path.join(last_path, "experiment.yaml")
+        if os.path.exists(candidate):
+            return candidate
+
+    for path in prefs.experiment.recent_experiments:
+        if os.path.exists(str(path)):
+            return str(path)
+
+    return None
+
+
 def apply_feature_flags(prefs: UserPreferences) -> None:
     """Update module-level FEATURE_* constants from user preferences.
 

--- a/tests/ui/test_quickstart_flags.py
+++ b/tests/ui/test_quickstart_flags.py
@@ -1,0 +1,180 @@
+"""The --quickstart / --quickload developer flags.
+
+Both do the same thing the first two clicks of every session do -- connect with
+the default configuration, reopen the last experiment -- so the tests drive the
+real widget against the real Demo microscope and a real Experiment on disk. The
+only stand-in is the preferences file, redirected to a temp directory so a test
+run never reads or rewrites the developer's own recents.
+"""
+import os
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem import config as cfg
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaTaskProtocol,
+    AutoLamellaWorkflowConfig,
+    Experiment,
+)
+from fibsem.applications.autolamella.ui.AutoLamellaMainUI import _parse_args
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.applications.autolamella.workflows.tasks.reference_image import (
+    AcquireReferenceImageConfig,
+)
+
+TASKS = ["Trench", "Polishing"]
+
+
+@pytest.fixture
+def prefs_env(tmp_path, monkeypatch):
+    """Point the preferences helpers at an isolated temp file."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_dir))
+    monkeypatch.setattr(cfg, "USER_PREFERENCES_PATH", str(config_dir / "user-preferences.yaml"))
+    return tmp_path
+
+
+def make_experiment(path: Path, name: str, with_protocol: bool = True) -> Experiment:
+    """Write a real experiment (and, by default, its protocol) to disk."""
+    experiment = Experiment.create(path=path, name=name)
+    if with_protocol:
+        experiment.task_protocol = AutoLamellaTaskProtocol(
+            workflow_config=AutoLamellaWorkflowConfig(
+                tasks=[
+                    AutoLamellaTaskDescription(name=n, supervise=False, required=False)
+                    for n in TASKS
+                ]
+            ),
+            task_config={n: AcquireReferenceImageConfig(task_name=n) for n in TASKS},
+        )
+        experiment.task_protocol.save(os.path.join(experiment.path, "protocol.yaml"))
+    experiment.save()
+    return experiment
+
+
+def remember(experiment: Experiment) -> None:
+    """Record an experiment the way the create and load dialogs do."""
+    prefs = cfg.load_user_preferences()
+    prefs.experiment.last_experiment_path = str(experiment.path)
+    cfg.add_recent_experiment(prefs, os.path.join(experiment.path, "experiment.yaml"))
+    cfg.save_user_preferences(prefs)
+
+
+@pytest.fixture
+def ui(qapp):
+    """A real AutoLamellaUI, without the main window that normally hosts it."""
+    widget = AutoLamellaUI(parent_ui=None)
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+
+
+# ── Flags ─────────────────────────────────────────────────────────────────────
+
+def test_neither_flag_is_set_by_default():
+    args = _parse_args([])
+
+    assert args.quickstart is False
+    assert args.quickload is False
+
+
+@pytest.mark.parametrize("flag", ["--quickstart", "--quickload"])
+def test_each_flag_sets_only_itself(flag):
+    args = _parse_args([flag])
+
+    assert getattr(args, flag.lstrip("-")) is True
+
+
+def test_an_unknown_flag_is_rejected():
+    """A typo should not silently start an ordinary, unattended session."""
+    with pytest.raises(SystemExit):
+        _parse_args(["--quickstrat"])
+
+
+# ── Which experiment is "the last one" ────────────────────────────────────────
+
+def test_last_experiment_is_resolved_to_its_yaml(prefs_env):
+    experiment = make_experiment(prefs_env, "exp-a")
+    remember(experiment)
+
+    assert cfg.get_last_experiment_file() == os.path.join(experiment.path, "experiment.yaml")
+
+
+def test_a_deleted_last_experiment_falls_back_to_the_next_newest(prefs_env):
+    kept = make_experiment(prefs_env, "exp-kept")
+    remember(kept)
+    deleted = make_experiment(prefs_env, "exp-deleted")
+    remember(deleted)
+    os.remove(os.path.join(deleted.path, "experiment.yaml"))
+
+    assert cfg.get_last_experiment_file() == os.path.normpath(
+        os.path.join(kept.path, "experiment.yaml")
+    )
+
+
+def test_nothing_recorded_resolves_to_nothing(prefs_env):
+    assert cfg.get_last_experiment_file() is None
+
+
+# ── Connecting and loading ────────────────────────────────────────────────────
+
+def test_quickstart_connects_without_being_clicked(ui, prefs_env):
+    ui.quickstart()
+
+    assert ui.microscope is not None
+    assert ui.system_widget.microscope is ui.microscope
+
+
+def test_quickload_reopens_the_last_experiment(ui, prefs_env):
+    experiment = make_experiment(prefs_env, "exp-a")
+    remember(experiment)
+
+    ui.quickstart(load_experiment=True)
+
+    assert ui.microscope is not None
+    assert ui.experiment is not None
+    assert ui.experiment.name == "exp-a"
+    assert ui.experiment.path == experiment.path
+
+
+def test_quickstart_alone_leaves_the_experiment_unloaded(ui, prefs_env):
+    remember(make_experiment(prefs_env, "exp-a"))
+
+    ui.quickstart()
+
+    assert ui.microscope is not None
+    assert ui.experiment is None
+
+
+def test_an_experiment_without_a_protocol_is_not_adopted(ui, prefs_env):
+    """The bar the load dialog sets: there would be nothing to run."""
+    remember(make_experiment(prefs_env, "exp-no-protocol", with_protocol=False))
+
+    ui.quickstart(load_experiment=True)
+
+    assert ui.microscope is not None
+    assert ui.experiment is None
+
+
+def test_no_recent_experiment_still_leaves_a_connected_window(ui, prefs_env):
+    ui.quickstart(load_experiment=True)
+
+    assert ui.microscope is not None
+    assert ui.experiment is None
+
+
+def test_quickstart_does_not_disconnect_an_existing_connection(ui, prefs_env):
+    ui.quickstart()
+    microscope = ui.microscope
+
+    ui.quickstart()
+
+    assert ui.microscope is microscope


### PR DESCRIPTION
Two clicks start every session — Connect, then load the experiment — and developers iterating against a simulator do them dozens of times a day.

```bash
fibsem-autolamella-ui --quickload
```

- `--quickstart` connects with the default microscope configuration as soon as the window is up, instead of waiting for the Connection tab.
- `--quickload` does that and then reopens the most recent experiment.

Both make the same calls the Connection tab and the load dialog make, so there is no second path to keep in step. `--quickload` implies `--quickstart` rather than being independent of it: the tabs that adopt an experiment are built at connection time, so an experiment loaded without a microscope would only look loaded.

### Flags, not preferences

Connecting takes over the instrument, and a persisted "always auto-connect" would do that at every launch long after anyone remembers setting it. A flag is opt-in per launch and visible in the command that caused it.

The persistent half is already a preference either way — `get_last_experiment_file` reads `last_experiment_path`. Prefs remember *which* experiment; the flag decides *whether* to act on it.

### Notes

**`get_last_experiment_file` falls back to the newest recent entry still on disk.** The two records go stale differently: recents are pruned when their file disappears and `last_experiment_path` never is, so the last experiment opened is routinely a scratch one that has since been deleted, where the next-newest is the useful answer rather than nothing.

**Quickstart runs from a zero timer after `show()`, not inline before `exec_()`.** Connecting blocks for seconds against real hardware, and doing it before the event loop starts would hold up the first paint — an empty window frame for the whole wait.

**Every failure below it is toasted and swallowed.** This runs unattended on the way up: an unreachable microscope or a moved experiment should leave the ordinary window, the one where you can pick a different configuration, not a half-started application.

### Testing

13 new tests drive the real widget — `AutoLamellaUI` constructs headless with no parent window, and the shipped default configuration is `Demo`, so the connect and the adopt are real, against a real experiment on disk.

Verified by running the app under both flags as well, which is what the widget tests would not have caught:

```
INFO — connect_to_microscope:234 — Connected to microscope at 192.168.0.1
INFO — _adopt_experiment:576 — Logging to experiment quickload-demo at …/quickload-demo
INFO — quickload_experiment:556 — Quickload: loaded experiment quickload-demo from …/experiment.yaml
```

### Found along the way, not fixed here

Loading an experiment whose lamella has no `MILLING` pose aborts the process (`qFatal` out of a Qt slot): the minimap's crosshair overlay reads `Lamella.stage_position`, which is `self.milling_pose.stage_position`, and `milling_pose` is `None`. Same path for the ordinary File → Load Experiment, so it is pre-existing and unrelated to these flags. The symptom is misleading — it surfaces as `'FibsemMinimapWidget' object has no attribute 'positions'`, but `positions` is a property and the `AttributeError` comes from inside it.
