### PR TITLE
[ui] Show that the FM panel is streaming (FIB-596)

### DIFF
--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -39,7 +39,7 @@ import numpy as np
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 from PyQt5.QtCore import QSize, QTimer, Qt, pyqtSignal
-from PyQt5.QtWidgets import QApplication, QPushButton, QSizePolicy
+from PyQt5.QtWidgets import QApplication, QLabel, QPushButton, QSizePolicy
 
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.stylesheets import CANVAS_BG as _BG, PRIMARY_ACCENT as _ACCENT
@@ -124,6 +124,12 @@ _OVERLAY_ICON_SIZE = QSize(14, 14)
 _OVERLAY_BTN_SIZE = 22
 _OVERLAY_MARGIN = 4
 _OVERLAY_GAP = 2
+# The "● LIVE" chip shares the toolbar row, so it takes the buttons' height and corner
+# radius; the green is the badge's own, not a button state.
+_LIVE_BADGE_STYLE = (
+    f"QLabel {{ background: {_LIVE_BADGE_BG}; color: {WHITE_ICON_COLOR};"
+    " border-radius: 3px; padding: 0px 6px; font-size: 10px; font-weight: bold; }"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -228,7 +234,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._title_text: Optional[str] = None  # remembered so it survives set_image
         self._info_artist = None  # bottom-left microscope-state info bar
         self._info_text: Optional[str] = None  # remembered so it survives set_image
-        self._live_artist = None  # top-right "LIVE" badge during live acquisition
+        self._live_badge = None  # top-right "● LIVE" chip during live acquisition
         self._live_on: bool = False  # remembered so it survives set_image
 
         # Transient top-centre flash message (e.g. "WD 4.001 mm" on Shift+scroll); auto-clears
@@ -454,30 +460,35 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             )
 
     def set_live_badge(self, on: bool) -> None:
-        """Show/hide a green "● LIVE" badge in the top-right during live acquisition.
+        """Show/hide a green "● LIVE" chip in the top-right during live acquisition.
 
-        Remembered + re-applied after each image change (like the info bar), so it stays put as
-        live frames stream in."""
+        A child widget laid out beside the toolbar buttons, not an axes artist. In axes
+        coordinates it collided with them whenever the axes reached the widget's top
+        edge, which — the axes being ``aspect="equal"`` inside an edge-to-edge figure —
+        happens for any frame at least as tall in aspect as its pane. A square FM frame
+        in a square pane does it every time; a beam pane dragged taller than 3:2 does it
+        too (FIB-596). Sharing the toolbar's coordinate system and its layout pass makes
+        the overlap impossible rather than tuned around.
+
+        Being a widget, it also survives ``set_image`` on its own — no re-applying after
+        each frame, which the artists around it still need.
+        """
         self._live_on = bool(on)
-        self._refresh_live_badge()
-        self.draw_idle()
+        if self._live_badge is None:
+            if not self._live_on:
+                return  # never shown, nothing to hide
+            self._live_badge = self._make_live_badge()
+        self._live_badge.setVisible(self._live_on)
+        self._reposition_overlay_buttons()
 
-    def _refresh_live_badge(self) -> None:
-        """(Re)create the LIVE badge artist, or remove it."""
-        if self._live_artist is not None:
-            try:
-                self._live_artist.remove()
-            except Exception:
-                pass
-            self._live_artist = None
-        if self._live_on:
-            self._live_artist = self._ax.text(
-                0.988, 0.985, "● LIVE",
-                transform=self._ax.transAxes, ha="right", va="top",
-                fontsize=7, color=WHITE_ICON_COLOR, zorder=12, fontweight="bold",
-                bbox=dict(boxstyle="round,pad=0.3", facecolor=_LIVE_BADGE_BG,
-                          edgecolor="none", alpha=0.9),
-            )
+    def _make_live_badge(self) -> QLabel:
+        """The "● LIVE" chip, sized to sit in the toolbar row."""
+        badge = QLabel("● LIVE", self)
+        badge.setStyleSheet(_LIVE_BADGE_STYLE)
+        badge.setFixedHeight(_OVERLAY_BTN_SIZE)
+        badge.adjustSize()
+        badge.raise_()
+        return badge
 
     def flash_message(self, text: str, duration_ms: int = 1200) -> None:
         """Show a brief top-centre status message that auto-clears after *duration_ms*.
@@ -579,7 +590,10 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._title_text = None
         self._info_artist = None
         self._info_text = None
-        self._live_artist = None
+        # The chip is a child widget, so `cla()` does not take it down the way it took
+        # the artist. Hidden by hand to keep the reset meaning what it always did.
+        if self._live_badge is not None:
+            self._live_badge.hide()
         self._live_on = False
         self._flash_artist = None
         self._flash_text = None
@@ -625,7 +639,12 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         return btn
 
     def _reposition_overlay_buttons(self) -> None:
-        """Place overlay buttons right-to-left in the top-right corner."""
+        """Place overlay buttons right-to-left in the top-right corner.
+
+        The LIVE chip joins the same pass, on the far side of the buttons — they are
+        click targets and stay anchored to the corner, so a stream starting or stopping
+        never moves one out from under the cursor.
+        """
         x = self.width() - _OVERLAY_MARGIN
         for btn in self._overlay_buttons:
             if btn.isHidden():  # contextual buttons (e.g. mode toggle) reserve no slot
@@ -633,6 +652,10 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             x -= btn.width()
             btn.move(x, _OVERLAY_MARGIN)
             x -= _OVERLAY_GAP
+        badge = self._live_badge
+        if badge is not None and not badge.isHidden():
+            x -= badge.width()
+            badge.move(x, _OVERLAY_MARGIN)
 
     def set_toolbar_visible(self, visible: bool) -> None:
         """Show or hide this canvas's top-right toolbar buttons as a group.

--- a/fibsem/ui/widgets/canvas/image_canvas.py
+++ b/fibsem/ui/widgets/canvas/image_canvas.py
@@ -108,7 +108,8 @@ class FibsemImageCanvas(FibsemCanvasBase):
         self._refresh_hint()  # axes was cleared above; restore the remembered hint
         self._refresh_title()  # ditto: restore the remembered title
         self._refresh_info_bar()  # ditto: restore the remembered info bar
-        self._refresh_live_badge()  # ditto: keep the LIVE badge across streamed frames
+        # No LIVE chip here: it is a child widget, not an artist, so `cla()` never took
+        # it down and there is nothing to restore (FIB-596).
         self._refresh_flash()  # ditto: keep a live flash (e.g. WD scroll) visible across frames
         self._refresh_legend()  # ditto: restore the patch legend
 

--- a/fibsem/ui/widgets/canvas/quad_view.py
+++ b/fibsem/ui/widgets/canvas/quad_view.py
@@ -203,8 +203,9 @@ class QuadViewWidget(QWidget):
             frame.setStyleSheet(_PANEL_QSS.format(bg=_BG, border=self._panel_border(k)))
 
     def set_live(self, key: object, live: bool) -> None:
-        """Mark view *key* (a ``BeamType``) as live-acquiring: green border + a "LIVE" badge on
-        its canvas, independent of which view is selected. The border wins over selection."""
+        """Mark view *key* (a ``BeamType``, or ``"fm"``) as live-acquiring: green border + a
+        "LIVE" badge on its canvas, independent of which view is selected. The border wins
+        over selection."""
         if key not in self._panels:
             return
         if live:
@@ -429,12 +430,23 @@ class MicroscopeViewController(QObject):
         if callable(fn):
             fn()
 
-    def set_live(self, key: BeamType, live: bool) -> None:
-        """Mark a beam view as live-acquiring (green border + LIVE badge). No-op on views
-        that don't support it."""
+    def set_live(self, key: object, live: bool) -> None:
+        """Mark a view as live-acquiring (green border + LIVE badge). No-op on views
+        that don't support it.
+
+        *key* is a view key, not a beam: the quad view keeps the FM under ``"fm"``
+        alongside the two ``BeamType``s and has since it was built. The annotation said
+        ``BeamType``, which is the whole reason the FM panel never showed that it was
+        streaming while the beam panels did -- the plumbing was there and looked closed
+        (FIB-596). Prefer :meth:`set_fm_live` over passing the string."""
         fn = getattr(self._widget, "set_live", None)
         if callable(fn):
             fn(key, live)
+
+    def set_fm_live(self, live: bool) -> None:
+        """Mark the FM view as live-acquiring (FM isn't a ``BeamType``) -- the
+        counterpart to :meth:`set_fm_info`."""
+        self.set_live("fm", live)
 
     @property
     def sem_canvas(self) -> FibsemImageCanvas:

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -385,6 +385,18 @@ class FMControlWidget(QWidget):
                 except (TypeError, RuntimeError):
                     pass
             self._fm_canvas = None
+
+        # Clear the FM panel's live chrome. The canvas outlives this widget, and the
+        # host tears down without stopping the acquisition first
+        # (`AutoLamellaUI.setup_experiment`), so the green border and badge would
+        # otherwise stay on a panel with nothing left to drive them.
+        controller = self._view_controller()
+        if controller is not None:
+            try:
+                controller.set_fm_live(False)
+            except RuntimeError:
+                pass  # the view went first
+
         self.objectiveControlWidget.cleanup()
 
         if self.parent_widget is not None and hasattr(
@@ -980,6 +992,15 @@ class FMControlWidget(QWidget):
 
         # Parameters for the *next* run, so they follow the same rule.
         self.zParametersWidget.setEnabled(may_start)
+
+        # The FM panel's own green border + "LIVE" badge, the chrome the beam panels have
+        # had all along. Driven from `is_streaming` rather than inferred from a button or
+        # this widget's own worker: the stream is the microscope's state, and another tab
+        # can start or stop one (FIB-513). Costs nothing when there is no quad view --
+        # the standalone hosts have no controller (FIB-596).
+        controller = self._view_controller()
+        if controller is not None:
+            controller.set_fm_live(streaming)
 
         # Hardware the user drives by hand. Live during a stream -- focusing and tuning
         # exposure while watching is the point of them -- and not while a tileset,

--- a/tests/ui/test_canvas_base.py
+++ b/tests/ui/test_canvas_base.py
@@ -132,6 +132,99 @@ def test_the_toolbar_toggle_still_round_trips(noun):
     assert button.isChecked() is True and button.toolTip() == f"Hide {noun}"
 
 
+class TestTheLiveChipClearsTheToolbar:
+    """The chip used to be an axes artist at ``transAxes`` (0.988, 0.985) while the
+    toolbar buttons are laid out in *widget* pixels. The axes are ``aspect="equal"``
+    inside an edge-to-edge figure, so they reach the widget's top edge for any frame at
+    least as tall in aspect as its pane -- and the chip landed underneath the buttons.
+    A square FM frame in a square pane did it every time (FIB-596).
+
+    It is a child widget in the toolbar's own layout pass now, so the two cannot
+    collide whatever the aspect ratio is.
+    """
+
+    @staticmethod
+    def _live_square_canvas(w=420, h=420, img=(512, 512)):
+        c = FibsemImageCanvas()
+        c.resize(w, h)
+        c.set_array(_img(*img), pixel_size=1e-8)
+        c.set_live_badge(True)
+        return c
+
+    def test_the_chip_does_not_overlap_any_visible_button(self):
+        c = self._live_square_canvas()
+
+        chip = c._live_badge.geometry()
+        clashes = [
+            b for b in c._overlay_buttons
+            if not b.isHidden() and chip.intersects(b.geometry())
+        ]
+
+        assert not clashes, f"{len(clashes)} toolbar button(s) under the LIVE chip"
+
+    @pytest.mark.parametrize(
+        "pane,image",
+        [
+            ((420, 420), (512, 512)),  # square frame, square pane -- the reported case
+            ((420, 300), (512, 512)),  # square frame, wide pane
+            ((300, 420), (512, 768)),  # wide frame in a pane taller than its aspect
+            ((900, 200), (512, 512)),  # extreme letterbox
+        ],
+    )
+    def test_no_aspect_ratio_puts_it_under_the_buttons(self, pane, image):
+        """The old bug was aspect-dependent, which is why it showed on the FM and not
+        the beams. Placement must not depend on the aspect at all now."""
+        c = self._live_square_canvas(pane[0], pane[1], image)
+
+        chip = c._live_badge.geometry()
+        assert not any(
+            chip.intersects(b.geometry())
+            for b in c._overlay_buttons
+            if not b.isHidden()
+        )
+
+    def test_the_buttons_stay_put_when_a_stream_starts(self):
+        """The buttons are click targets. The chip appearing must not slide one out
+        from under the cursor -- which is why the chip goes on their far side."""
+        c = FibsemImageCanvas()
+        c.resize(420, 420)
+        c.set_array(_img(512, 512), pixel_size=1e-8)
+        # Settle the layout at the resized width first: offscreen, `resize` lands
+        # lazily, so an unsettled `before` would record the default width and the test
+        # would blame the chip for the resize.
+        c._reposition_overlay_buttons()
+        before = [b.geometry() for b in c._overlay_buttons]
+
+        c.set_live_badge(True)
+
+        assert [b.geometry() for b in c._overlay_buttons] == before
+
+    def test_a_new_frame_does_not_take_the_chip_down(self):
+        """It is a widget, so `cla()` never removes it and `set_image` has nothing to
+        restore -- unlike the info bar and title, which are re-applied per frame."""
+        c = self._live_square_canvas()
+
+        c.set_array(_img(512, 512), pixel_size=1e-8)  # the next streamed frame
+
+        assert c._live_on
+        assert c._live_badge is not None and not c._live_badge.isHidden()
+
+    def test_it_hides_without_being_destroyed(self):
+        c = self._live_square_canvas()
+
+        c.set_live_badge(False)
+
+        assert not c._live_on
+        assert c._live_badge.isHidden()
+
+    def test_asking_to_hide_one_that_was_never_shown_is_a_no_op(self):
+        c = FibsemImageCanvas()
+
+        c.set_live_badge(False)
+
+        assert c._live_badge is None  # not built just to be hidden
+
+
 if __name__ == "__main__":
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):

--- a/tests/ui/test_fm_live_indicator.py
+++ b/tests/ui/test_fm_live_indicator.py
@@ -1,0 +1,179 @@
+"""The FM panel shows that it is streaming, like the beam panels do (FIB-596).
+
+Neither half of this needed new chrome. `FibsemCanvasBase.set_live_badge` gives every
+canvas the green border and the "● LIVE" badge, and the quad view has kept the FM under
+the view key `"fm"` alongside the two `BeamType`s since it was built -- so
+`QuadViewWidget.set_live("fm", True)` already worked.
+
+What stopped short was one type annotation and one caller.
+`MicroscopeViewController.set_live` was typed `BeamType`, which read as "beams only" and
+was believed, and nothing ever drove it from the FM's own state. The plumbing looked
+closed from the outside, which is why the panel that streams was the one panel that
+never said so.
+
+Driven from `fm.is_streaming` rather than from a button press or this widget's own
+worker: the live stream is the microscope's state, and another tab can start or stop one
+(FIB-513).
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem import utils
+from fibsem.structures import BeamType
+from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController, QuadViewWidget
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+@pytest.fixture
+def controller():
+    return MicroscopeViewController(view=QuadViewWidget())
+
+
+def _badge_on(controller, canvas) -> bool:
+    return bool(canvas._live_on)
+
+
+class TestTheFMCanvasCanBeMarkedLive:
+    def test_the_badge_and_border_reach_the_fm_panel(self, controller):
+        controller.set_fm_live(True)
+
+        assert _badge_on(controller, controller.fm_canvas)
+        assert "fm" in controller.widget._live
+
+    def test_it_clears(self, controller):
+        controller.set_fm_live(True)
+        controller.set_fm_live(False)
+
+        assert not _badge_on(controller, controller.fm_canvas)
+        assert "fm" not in controller.widget._live
+
+    def test_it_does_not_touch_the_beam_panels(self, controller):
+        controller.set_fm_live(True)
+
+        assert not _badge_on(controller, controller.sem_canvas)
+        assert not _badge_on(controller, controller.fib_canvas)
+
+    def test_a_live_beam_and_a_live_fm_coexist(self, controller):
+        """They are separate instruments and can both be running. The beam path clears
+        its *own* previous beam on a switch (`_set_live_indicator`); nothing should
+        clear the FM."""
+        controller.set_live(BeamType.ELECTRON, True)
+        controller.set_fm_live(True)
+
+        assert _badge_on(controller, controller.sem_canvas)
+        assert _badge_on(controller, controller.fm_canvas)
+
+    def test_a_view_without_live_support_is_a_no_op(self):
+        """The lamella editor view has no panels to border. `set_live` is guarded for
+        it, and so `set_fm_live` must be too."""
+
+        class _ViewWithoutLive:
+            sem_canvas = fib_canvas = fm_canvas = None
+            fm_widget = None
+
+        controller = MicroscopeViewController.__new__(MicroscopeViewController)
+        controller._widget = _ViewWithoutLive()
+
+        controller.set_fm_live(True)  # must not raise
+
+
+class TestTheStreamDrivesIt:
+    """The half that was missing. `_update_acquisition_button_states` is the one place
+    that already asks `fm.is_streaming` and re-derives the whole panel from it, so the
+    chrome follows the stream however it was started."""
+
+    @pytest.fixture
+    def widget(self, controller):
+        from PyQt5.QtWidgets import QWidget
+
+        from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget
+
+        microscope, _ = utils.setup_session(manufacturer="Demo")
+
+        class _Host(QWidget):
+            """The chain `_view_controller` walks: parent -> parent_widget -> the UI
+            holding `view_controller`."""
+
+            def __init__(self):
+                super().__init__()
+                self.view_controller = controller
+                self.parent_widget = self
+                self.microscope = microscope
+
+        host = _Host()
+        w = FMControlWidget(microscope=microscope, parent=host)
+        yield w
+        w.close()
+
+    def test_starting_a_stream_lights_the_panel(self, widget, controller):
+        widget.fm.start_acquisition(channel_settings=widget.channel_settings)
+        try:
+            widget._update_acquisition_button_states()
+
+            assert _badge_on(controller, controller.fm_canvas)
+        finally:
+            widget.fm.stop_acquisition()
+
+    def test_stopping_it_clears_the_panel(self, widget, controller):
+        widget.fm.start_acquisition(channel_settings=widget.channel_settings)
+        widget._update_acquisition_button_states()
+        assert _badge_on(controller, controller.fm_canvas), "never lit; nothing to clear"
+
+        widget.fm.stop_acquisition()
+        widget._update_acquisition_button_states()
+
+        assert not _badge_on(controller, controller.fm_canvas)
+
+    def test_a_still_acquisition_is_not_a_stream(self, widget, controller):
+        """`is_acquiring` covers a z-stack, a tileset, an autofocus sweep. None of them
+        is the live view, and the badge means the live view."""
+        widget.fm.start_acquisition(channel_settings=widget.channel_settings)
+        widget._update_acquisition_button_states()
+        widget.fm.stop_acquisition()
+
+        widget.fm.set_acquiring(True)  # a z-stack, say, on the same instrument
+        try:
+            widget._update_acquisition_button_states()
+
+            assert widget.fm.is_acquiring, "the distinction under test is not set up"
+            assert not _badge_on(controller, controller.fm_canvas)
+        finally:
+            widget.fm.set_acquiring(False)
+
+    def test_a_stream_nobody_pressed_a_button_for_still_lights_it(
+        self, widget, controller
+    ):
+        """No direct `_update_acquisition_button_states` call here. The microscope emits
+        `acquiring_changed` on start and stop, this widget is subscribed, and that is
+        what makes the chrome follow a stream another tab started -- the reason it reads
+        the microscope's state instead of tracking its own buttons."""
+        widget.fm.start_acquisition(channel_settings=widget.channel_settings)
+        try:
+            assert _badge_on(controller, controller.fm_canvas)
+        finally:
+            widget.fm.stop_acquisition()
+
+        assert not _badge_on(controller, controller.fm_canvas)
+
+    def test_teardown_clears_it(self, widget, controller):
+        """The canvas outlives the widget, and the host tears down without stopping the
+        acquisition first (`AutoLamellaUI.setup_experiment`) -- so a green border would
+        be left on a panel with nothing driving it."""
+        widget.fm.start_acquisition(channel_settings=widget.channel_settings)
+        widget._update_acquisition_button_states()
+        assert _badge_on(controller, controller.fm_canvas)
+
+        widget._teardown_connections()
+
+        assert not _badge_on(controller, controller.fm_canvas)


### PR DESCRIPTION
Closes FIB-596. The FM panel is the one that streams, and it was the only panel that never said so.

Two commits, separately reviewable: the driver, then the layout fix the driver exposed.

## The plumbing was already there

Neither half of this needed new chrome. `FibsemCanvasBase.set_live_badge` gives every canvas the green border and the "● LIVE" badge, and the quad view has kept the FM under the view key `"fm"` alongside the two `BeamType`s since it was built — so `QuadViewWidget.set_live("fm", True)` already worked, and always had.

What stopped short was a type annotation and a caller. `MicroscopeViewController.set_live` was typed `BeamType`, which read as "beams only" and was believed; the issue reasoned from it that "there is no path to the FM". There was. The annotation is widened to what the method actually accepts, and `set_fm_live` added as the counterpart to the `set_fm_info` that has been there all along — so the next reader is told by the surface rather than having to check.

## Driven from the microscope, not from a button

In `_update_acquisition_button_states`, which is the one place that already asks `fm.is_streaming` and re-derives the whole panel from the answer. Asking the microscope is the point: the stream is the instrument's state, not this widget's, and another tab can start or stop one (FIB-513). The widget is subscribed to `acquiring_changed`, so a stream nobody pressed a button here for still lights the panel — its own test.

`is_streaming`, deliberately, not `is_acquiring`. A z-stack, a tileset or an autofocus sweep is the instrument being busy; the badge means the live view specifically, which is what the beam panels' badge means.

Cleared in `_teardown_connections` alongside the canvas signals, for the same reason they are: the canvas outlives the widget and the host tears down without stopping the acquisition first (`AutoLamellaUI.setup_experiment`).

## Then the chip landed under the toolbar

Turning it on for the FM put it beneath the canvas toolbar buttons. The two were positioned in different coordinate systems — buttons in widget pixels, chip as an axes artist at `transAxes` (0.988, 0.985) — which agree only when the axes stop short of the widget's top edge.

The axes are `aspect="equal"` inside an edge-to-edge figure, so they are letterboxed to the image aspect. A 3:2 beam frame in a taller pane leaves a band above the axes and the chip lands below the buttons, which is why the beam panels have never shown this. A square frame in a square pane leaves no band at all.

**So it was never an FM problem, and never about the FM being square** — it is any frame at least as tall in aspect as its pane. Drag a beam pane taller than 3:2 and it collides too. Latent today; this closes it everywhere rather than at the FM.

The chip is a `QLabel` child now, placed by `_reposition_overlay_buttons` in the same right-to-left pass as the buttons. Sharing their coordinate system is what makes the overlap impossible; tuning an offset in axes fractions would have had to be recomputed against geometry that moves with every resize and every image aspect.

It goes on the **far side** of the buttons rather than in the corner. The buttons are click targets: putting the chip outermost would shift all five left when a stream starts and back when it stops, moving one out from under the cursor. Status text may move; click targets may not. The consequence is that the chip slides to the corner when the panel is deselected and its toolbar hides — a deliberate click, and it moves nothing clickable.

Two things fall out of it being a widget: `set_image` no longer re-applies it (`cla()` removes artists, and this is not one), and `_reset` hides it by hand instead.

## What the issue got wrong

Its other half reports that "nothing ever feeds" `set_fm_info` an objective position. `update_info` has labelled the FM canvas with one since the canvas was built (#199). That gap was real for about a day — FIB-576 stopped the read and left nothing pushing a starting value — and #392 seeds it. Nothing to do here.

## Testing

19 tests. Each half mutation-checked:

| mutant | fails |
|---|---|
| driver removed | 4 |
| teardown clear removed | 1 |
| `is_streaming` → `is_acquiring` | 1 |
| `is_streaming` → `True` | 2 |
| chip pinned back to the corner | 5 |
| chip outermost (the rejected variant) | 1 |

The non-overlap test is parametrised over four pane/image aspect pairs including the reported square-in-square.

`tests/ui/` + `tests/fm/` green. Confirmed in the app.

## Independent of #392

Branched off `main`, not off #392 — the two touch different regions of `quad_view.py` and merge in either order.
