### PR TITLE
[ui] Move the objective off the GUI thread, and guard it from two hands (FIB-625)

### DIFF
--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -35,6 +35,13 @@ SIM_OBJECTIVE_RETRACT_POSITION = -10e-3  # z-axis
 SIM_OBJECTIVE_POSITION_LIMITS = (-12e-3, 10e-3)  # z-axis limits for the objective lens
 SIM_OBJECTIVE_USER_POSITION_LIMIT = 8.6e-3  # user-defined limits for the objective lens
 SIM_OBJECTIVE_FOCUS_POSITION = 8.0e-3
+# Insertion and retraction traverse the objective's whole range -- 16 mm here -- where a
+# focus nudge moves it by microns, so they are seconds of travel on a real system rather
+# than the fraction of one `move_absolute` simulates. Modelled because the difference is
+# what makes a second command *during* one reachable by hand (FIB-628); a delegating
+# `insert` that returned as fast as a nudge made that window too small to click into.
+# `sim_sleep`, so `FIBSEM_SIM_NO_DELAY=1` keeps it out of the test suite.
+SIM_OBJECTIVE_TRAVEL_SECONDS = 2.0
 
 SIM_CAMERA_EXPOSURE_TIME = 0.1  # seconds
 SIM_CAMERA_EXPOSURE_LIMITS = (1e-6, 60.0)  # seconds
@@ -268,6 +275,7 @@ class ObjectiveLens(ABC):
         Moves the objective lens to the predefined insertion position,
         typically at or near the sample focal plane.
         """
+        sim_sleep(SIM_OBJECTIVE_TRAVEL_SECONDS)  # the traverse, on top of the move
         self.move_absolute(self._insert_position)
         logging.info(
             f"Objective lens inserted to position: {self._insert_position:.3f} mm"
@@ -279,6 +287,7 @@ class ObjectiveLens(ABC):
         Moves the objective lens to the predefined retraction position
         to prevent damage during stage movements or sample changes.
         """
+        sim_sleep(SIM_OBJECTIVE_TRAVEL_SECONDS)
         self.move_absolute(self._retract_position)
         logging.info(
             f"Objective lens retracted to position: {self._retract_position:.3f} mm"

--- a/fibsem/ui/fm/widgets/objective_control_widget.py
+++ b/fibsem/ui/fm/widgets/objective_control_widget.py
@@ -14,7 +14,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 import numpy as np
-from fibsem.ui.qt.threading import thread_worker
+from fibsem.ui.qt.threading import FunctionWorker, thread_worker
 from fibsem.constants import METRE_TO_MICRON, MICRON_TO_METRE
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.ui import notification_service
@@ -224,8 +224,21 @@ class ObjectiveControlWidget(QWidget):
         # set initial ranges based on user-defined limit
         self.on_objective_limit_changed(self.doubleSpinBox_objective_limit.value())
 
-        # Debounce state for mouse wheel objective movement
+        # Debounce state for mouse wheel objective movement.
+        #
+        # `_wheel_target_um` is where the user has scrolled to; `_wheel_worker` is the
+        # move currently on its way there, or None. One field, not a separate "busy"
+        # flag: it is set when a move starts and cleared only in the completion slots,
+        # which run on the GUI thread -- so `is not None` means "in flight, or landed
+        # and not yet accounted for", with no window between the two. `is_alive()`
+        # would open exactly that window.
         self._wheel_target_um: float = 0.0
+        self._wheel_worker: Optional[FunctionWorker] = None
+        # The threaded insert / retract, tracked for the same reason: it drives the
+        # objective, so everything else must be able to see that it is doing so
+        # (FIB-628). Cleared in the completion slots, which run on the GUI thread.
+        self._action_worker: Optional[FunctionWorker] = None
+        self._wheel_moving_to_um: Optional[float] = None
         self._execute_wheel_move = qdebounced(self._execute_wheel_move_impl, timeout=150)
 
         # `hasattr` is not enough once hosts go viewer-less — the attribute is still
@@ -239,13 +252,68 @@ class ObjectiveControlWidget(QWidget):
         self.pushButton_insert_objective.setEnabled(enabled)
         self.pushButton_retract_objective.setEnabled(enabled)
 
+    def _objective_busy_reason(self) -> Optional[str]:
+        """What is driving the objective right now, phrased for a warning, or None.
+
+        One question — *is anything driving the objective* — with three sources, because
+        three different parties can be:
+
+        * **Another acquisition.** A tileset, z-stack or autofocus sweep steps the
+          objective itself, and a second hand on it corrupts the run. The microscope
+          answers this and only the microscope can: asking whether *this widget* was
+          busy is what let another tab's tileset through (FIB-513). A live stream is
+          deliberately not busy — focusing while watching is what this panel is for.
+        * **A focus adjustment.** The wheel move runs on a worker now (FIB-625), so
+          everything here stays clickable while it is on its way.
+        * **An insert or retract.** Also threaded, and always was — so a scroll during a
+          retraction has always gone through (FIB-628). This is the collision-relevant
+          one: `insert_objective` moves the *stage* before inserting.
+
+        A guard on the action, not on the button. The buttons are not this widget's to
+        drive — `FMControlWidget._update_acquisition_button_states` owns them and
+        re-derives them from `may_start` — so disabling them here and re-enabling on
+        completion overwrote its answer, and scrolling during a live stream left Insert
+        and Retract clickable when the stream forbids them. That is the shape FIB-513
+        closed one layer up (FIB-515).
+
+        What it cannot see is another `ObjectiveControlWidget` — the coincidence viewer
+        holds a second one, with its own workers. Closing that means the objective
+        marking itself busy rather than the widget doing it, which is the FIB-441 shape
+        and a driver-level change; recorded on FIB-628 rather than assumed here.
+        """
+        if not self.fm.is_interactive:
+            return self.fm.acquiring_reason or "another acquisition"
+        if self._wheel_worker is not None:
+            return "a focus adjustment"
+        if self._action_worker is not None:
+            return "an objective insert or retract"
+        return None
+
+    def _refuse_if_objective_busy(self, what: str) -> bool:
+        """Whether *what* must stand down, saying so in the log and on screen.
+
+        Visible rather than silent: the control that triggered it stays enabled — that
+        is the point of guarding the action instead of the button — so a refusal with no
+        feedback reads as a dead button.
+        """
+        reason = self._objective_busy_reason()
+        if reason is None:
+            return False
+        logging.info(f"{what} refused: {reason} is driving the objective")
+        notification_service.show_toast(
+            f"The objective is busy with {reason}.", "warning"
+        )
+        return True
+
     def _on_objective_action_finished(self, *_) -> None:
         """Re-enable controls and refresh labels after a threaded objective move."""
+        self._action_worker = None
         self._set_objective_actions_enabled(True)
         self.update_objective_position_labels()
 
     def _on_objective_action_error(self, exc: Exception) -> None:
         """Report a failed objective operation without crashing the app."""
+        self._action_worker = None
         logging.error(f"Objective operation failed: {exc}", exc_info=exc)
         self._set_objective_actions_enabled(True)
         self.update_objective_position_labels()
@@ -258,6 +326,8 @@ class ObjectiveControlWidget(QWidget):
 
     def insert_objective(self):
         """Insert the objective. The hardware move runs on a worker thread."""
+        if self._refuse_if_objective_busy("Objective insertion"):
+            return
         if self.fm.objective.state == "Inserted":
             message_box_ui(
                 title="Objective Already Inserted",
@@ -291,7 +361,7 @@ class ObjectiveControlWidget(QWidget):
             target_stage_pos = stage_pos
 
         self._set_objective_actions_enabled(False)
-        worker = self._insert_objective_worker(target_stage_pos)
+        self._action_worker = worker = self._insert_objective_worker(target_stage_pos)
         worker.returned.connect(self._on_objective_action_finished)
         worker.errored.connect(self._on_objective_action_error)
         worker.start()
@@ -311,6 +381,8 @@ class ObjectiveControlWidget(QWidget):
 
     def retract_objective(self):
         """Retract the objective. The hardware move runs on a worker thread."""
+        if self._refuse_if_objective_busy("Objective retraction"):
+            return
         if self.fm.objective.state == "Retracted":
             message_box_ui(
                 title="Objective Already Retracted",
@@ -331,7 +403,7 @@ class ObjectiveControlWidget(QWidget):
             return
 
         self._set_objective_actions_enabled(False)
-        worker = self._retract_objective_worker()
+        self._action_worker = worker = self._retract_objective_worker()
         worker.returned.connect(self._on_objective_action_finished)
         worker.errored.connect(self._on_objective_action_error)
         worker.start()
@@ -382,7 +454,13 @@ class ObjectiveControlWidget(QWidget):
         `state` is accepted and unused: the button states it would drive are decided by
         guards that read the device deliberately, and a stale "Retracted" there is what
         moves the stage with the objective still in the chamber (FIB-534).
+
+        Stands aside while the wheel is driving: every emit then comes from the wheel's
+        own move and reports a position the user has already scrolled past. Not decided
+        by which slot Qt happens to deliver first -- both consult the same predicate.
         """
+        if self._wheel_is_driving():
+            return
         self.update_objective_position_labels(position)
 
     def closeEvent(self, event) -> None:
@@ -401,6 +479,14 @@ class ObjectiveControlWidget(QWidget):
     @pyqtSlot(float)
     def on_objective_position_changed(self, position: float):
         """Handle changes to the objective position."""
+        # The last unguarded way in, and the awkward one: refusing a `valueChanged` means
+        # putting the spinbox back, and that would raise `valueChanged` again and re-enter
+        # here. `update_objective_position_labels` blocks the spinbox's signals around
+        # `setValue`, which is what makes the put-back safe -- the same reason the
+        # large-move cancel below already routes through it (FIB-515).
+        if self._refuse_if_objective_busy("Objective move"):
+            self.update_objective_position_labels()
+            return
 
         is_large_change = abs(self.fm.objective.position - (position * MICRON_TO_METRE)) > 1e-3  # 1 mm threshold
 
@@ -454,6 +540,8 @@ class ObjectiveControlWidget(QWidget):
 
     def move_to_focus_position(self):
         """Move the objective to the stored focus position."""
+        if self._refuse_if_objective_busy("Move to focus position"):
+            return
         if self.fm.objective.focus_position is None:
             logging.warning("No focus position has been set")
             return
@@ -492,6 +580,12 @@ class ObjectiveControlWidget(QWidget):
 
     def set_focus_position(self):
         """Set the focus position to the current objective position."""
+        # Records rather than moves, so it looked exempt -- but the number it records is
+        # a fresh device read, and mid-move that is wherever the objective happens to be
+        # passing. Saving a focus of "halfway there" is the failure. FIB-515 left this
+        # one to be decided rather than assumed; this is the reason to guard it.
+        if self._refuse_if_objective_busy("Set focus position"):
+            return
         current_position_um = self.fm.objective.position * METRE_TO_MICRON
 
         ret = message_box_ui(
@@ -547,13 +641,18 @@ class ObjectiveControlWidget(QWidget):
             event.handled = False  # Let napari handle zooming if Shift is not pressed
             return
 
-        # Prevent objective movement while something is driving the objective itself.
+        # Prevent objective movement while something is driving the objective itself:
+        # another acquisition, or this widget's own threaded insert / retract (FIB-628).
         # Asked of the microscope, not the parent widget: `is_acquisition_active` is only
         # the parent's own work, so another tab's tileset let this through (FIB-513).
         # Still allowed during a live stream -- shift-scrolling to focus while watching
         # is what this handler is for.
-        if not self.fm.is_interactive:
-            logging.info("Objective movement disabled during acquisition")
+        #
+        # Logged, not toasted: this fires per notch, and a burst would be a burst of
+        # toasts. The deliberate single actions each say so on screen instead.
+        reason = self._objective_busy_reason()
+        if reason is not None:
+            logging.info(f"Objective movement disabled: {reason}")
             event.handled = True
             return
 
@@ -588,7 +687,15 @@ class ObjectiveControlWidget(QWidget):
         if "Shift" not in modifiers:
             return  # plain scroll -> canvas zoom
 
-        if self.parent_widget is None or self.parent_widget.is_acquisition_active:
+        if self.parent_widget is None:
+            return
+        # The microscope's answer, not the parent's: `is_acquisition_active` is only that
+        # widget's own work, so another tab's tileset went straight through here
+        # (FIB-513), and neither of them notices this widget's threaded insert or retract
+        # (FIB-628). Logged rather than toasted -- see `_on_mouse_wheel`.
+        reason = self._objective_busy_reason()
+        if reason is not None:
+            logging.info(f"Objective movement disabled: {reason}")
             return
 
         step_um = float(
@@ -609,20 +716,126 @@ class ObjectiveControlWidget(QWidget):
         self._execute_wheel_move()
 
     def _execute_wheel_move_impl(self):
-        """Execute the actual hardware move after scrolling settles."""
+        """Scrolling has settled: send the objective after it, on a worker thread.
+
+        `qdebounced` fires on a QTimer in the GUI thread, so running the move here --
+        as this did -- blocked every repaint for its duration, and the live FM canvas
+        stopped updating while you focused. Frames kept arriving throughout: the stream
+        has its own thread, they simply could not be drawn (FIB-625).
+
+        A move already on its way is not joined by a second one. It re-reads the target
+        when it lands, so a nudge arriving mid-move *replaces* where the objective is
+        going instead of queueing another trip -- which is the same coalescing the
+        150 ms debounce does for the burst, extended over the move itself.
+        """
+        if self._wheel_worker is not None:
+            return  # in flight; `_on_wheel_move_finished` picks up the newer target
+        self._start_wheel_move()
+
+    def _start_wheel_move(self) -> None:
+        """Send one move to the current target, unless something else has the objective.
+
+        The last moment before the command goes out, and the only one that is safe to
+        check at: the scroll handlers guard when the notch arrives, but the debounce
+        puts 150 ms between that and the move, and the chase below can dispatch later
+        still. An insert, a retract or a tileset starting inside either window would
+        otherwise find a move already on its way to it.
+
+        Both callers come through here, so this is the single place that dispatches.
+        """
+        reason = self._objective_busy_reason()
+        if reason is not None:
+            logging.info(f"Wheel move abandoned: {reason} is driving the objective")
+            self._wheel_moving_to_um = None  # give the readout back to the device
+            self.update_objective_position_labels()
+            return
         position_um = self._wheel_target_um
-        position_m = position_um * MICRON_TO_METRE
         logging.info(f"Executing debounced wheel move to: {position_um:.1f} µm")
-        try:
-            self.fm.objective.move_absolute(position_m)
-            self.update_objective_position_labels(objective_position=position_m)
-        except Exception as e:
-            logging.error(f"Objective wheel move failed: {e}", exc_info=e)
-            notification_service.show_toast(f"Objective move failed: {e}", "warning")
-            self.update_objective_position_labels()  # re-sync to actual position
+        self._wheel_moving_to_um = position_um
+        worker = self._wheel_move_worker(position_um * MICRON_TO_METRE)
+        worker.returned.connect(self._on_wheel_move_finished)
+        worker.errored.connect(self._on_wheel_move_error)
+        self._wheel_worker = worker
+        worker.start()
+
+    @thread_worker
+    def _wheel_move_worker(self, position_m: float) -> float:
+        """Worker: move the objective, and report back where it was sent."""
+        self.fm.objective.move_absolute(position_m)
+        return position_m
+
+    def _wheel_is_driving(self) -> bool:
+        """Whether the readout belongs to the wheel rather than to the device.
+
+        True from the moment a wheel move starts until the objective has caught up with
+        the last notch. In between, where the objective *is* runs behind where the user
+        has scrolled to, and writing it to the spinbox snaps the number backwards past
+        their own scrolling for the length of the next move -- several hundred ms of
+        showing the wrong position, on the readout they are focusing by. The scroll
+        handler already writes each notch, so there is nothing to restore: the wheel's
+        target is the truthful answer to "where is this going".
+
+        Invisible before the move came off the GUI thread, because nothing repainted
+        between the notch and the move landing.
+        """
+        if self._wheel_worker is not None:
+            return True
+        return (
+            self._wheel_moving_to_um is not None
+            and self._wheel_target_um != self._wheel_moving_to_um
+        )
+
+    def _on_wheel_move_finished(self, position_m: float) -> None:
+        """The move landed. Chase the target if it has moved on, else settle."""
+        self._wheel_worker = None
+        if self._wheel_target_um != self._wheel_moving_to_um:
+            self._start_wheel_move()  # stale before it could be shown; do not write it
+            return
+        self._wheel_moving_to_um = None  # the burst is over; the device owns the readout
+        # Kept even though `position_changed` now drives the same labels (FIB-576):
+        # that signal is skipped when the read behind it fails, by design, and this is
+        # the path that always reports. Two label updates cost ~0.4 ms together.
+        self.update_objective_position_labels(objective_position=position_m)
+
+    def _detach_wheel_worker(self) -> None:
+        """Cut a move in flight loose from this widget.
+
+        Not joined. The objective finishes moving either way, and waiting for it is the
+        blocking this change exists to remove — teardown would be the one place still
+        doing it. What must not survive is the callback: these slots touch widgets, and
+        an emit into one Qt has already destroyed on the C++ side is a segfault rather
+        than an exception (FIB-550). Cutting the connections leaves the worker to finish
+        into nothing, which is what we want.
+        """
+        worker = self._wheel_worker
+        self._wheel_worker = None
+        # Cleared with it, or `_wheel_is_driving` stays true with nothing left to drive
+        # and the readout never follows the device again.
+        self._wheel_moving_to_um = None
+        if worker is None:
+            return
+        for signal, slot in (
+            (worker.returned, self._on_wheel_move_finished),
+            (worker.errored, self._on_wheel_move_error),
+        ):
+            try:
+                signal.disconnect(slot)
+            except (TypeError, RuntimeError):
+                pass
+
+    def _on_wheel_move_error(self, exc: Exception) -> None:
+        """The move failed. Report it and re-sync to wherever the objective actually is."""
+        self._wheel_worker = None
+        # Abandon the chase too: the target is unreachable, and the honest thing to show
+        # is where the objective actually stopped, not where the wheel was pointing.
+        self._wheel_moving_to_um = None
+        logging.error(f"Objective wheel move failed: {exc}", exc_info=exc)
+        notification_service.show_toast(f"Objective move failed: {exc}", "warning")
+        self.update_objective_position_labels()  # re-sync to actual position
 
     def cleanup(self):
-        """Drop the napari mouse-wheel callback and any pending debounced move.
+        """Drop the napari mouse-wheel callback, any pending debounced move, and any
+        move already on its way.
 
         Call on widget teardown: the callback binds this widget onto a viewer that
         outlives it, so without this a scroll after a microscope reconnect drives a dead
@@ -631,6 +844,7 @@ class ObjectiveControlWidget(QWidget):
             self._execute_wheel_move.cancel()
         except Exception:
             pass
+        self._detach_wheel_worker()
         if (self.parent_widget is not None
                 and getattr(self.parent_widget, "viewer", None) is not None):
             try:

--- a/tests/ui/test_objective_wheel_move_threading.py
+++ b/tests/ui/test_objective_wheel_move_threading.py
@@ -1,0 +1,468 @@
+"""The wheel move runs off the GUI thread, and coalesces (FIB-625).
+
+`_execute_wheel_move` is a `qdebounced` wrapper, and `qdebounced` fires on a QTimer in
+the GUI thread -- so the blocking `move_absolute` inside it stopped every repaint for
+its duration, and the live FM canvas froze while you focused. Measured on the simulator:
+150 ms debounce + ~500 ms move + ~210 ms of the device reads `_notify_moved` does,
+roughly 860 ms of dead interface per nudge. The frames were arriving the whole time --
+`FluorescenceMicroscope.start_acquisition` streams on its own thread -- they just could
+not be drawn.
+
+The debounce coalesces a scroll *burst* into one move. What it cannot do is coalesce
+across the move itself, because the move used to hold the thread the debounce runs on.
+Now that it does not, a nudge landing mid-move has to replace the target rather than
+queue a second trip, or a slow objective turns a flick of the wheel into a march.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication, QWidget
+
+from fibsem.constants import METRE_TO_MICRON
+from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.ui.fm.widgets.objective_control_widget import ObjectiveControlWidget
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+_GUI_THREAD = threading.current_thread()
+
+
+class _Host(QWidget):
+    """The duck-typed parent `_on_canvas_scroll` consults before moving anything."""
+
+    is_acquisition_active = False
+    viewer = None
+    microscope = None
+
+    def _view_controller(self):
+        return None
+
+
+@pytest.fixture
+def fm():
+    return FluorescenceMicroscope()
+
+
+@pytest.fixture
+def widget(fm):
+    w = ObjectiveControlWidget(fm)
+    yield w
+    w.cleanup()
+    w.close()
+
+
+def _drain(timeout=5.0):
+    """Spin the event loop until the queued worker signals have been delivered."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        _app.processEvents()
+        time.sleep(0.005)
+
+
+def _settle(widget, timeout=5.0):
+    """Spin until no move is in flight."""
+    deadline = time.monotonic() + timeout
+    while widget._wheel_worker is not None and time.monotonic() < deadline:
+        _app.processEvents()
+        time.sleep(0.005)
+    _drain(0.05)
+
+
+class TestTheMoveLeavesTheGuiThread:
+    def test_the_hardware_call_happens_on_a_worker(self, fm, widget, monkeypatch):
+        """The whole point. `move_absolute` must not run on the thread that repaints."""
+        threads = []
+        real = type(fm.objective).move_absolute
+
+        def recording(self, position):
+            threads.append(threading.current_thread())
+            return real(self, position)
+
+        monkeypatch.setattr(type(fm.objective), "move_absolute", recording)
+
+        widget._wheel_target_um = fm.objective.position * METRE_TO_MICRON + 1.0
+        widget._execute_wheel_move_impl()
+        _settle(widget)
+
+        assert threads, "no move ran"
+        assert all(t is not _GUI_THREAD for t in threads)
+
+    def test_the_call_returns_before_the_move_does(self, fm, widget, monkeypatch):
+        """It has to return promptly or the repaint is still blocked -- just at a
+        different call site."""
+        started = threading.Event()
+        release = threading.Event()
+        real = type(fm.objective).move_absolute
+
+        def blocking(self, position):
+            started.set()
+            release.wait(5.0)
+            return real(self, position)
+
+        monkeypatch.setattr(type(fm.objective), "move_absolute", blocking)
+
+        widget._wheel_target_um = fm.objective.position * METRE_TO_MICRON + 1.0
+        t0 = time.perf_counter()
+        widget._execute_wheel_move_impl()
+        elapsed = time.perf_counter() - t0
+
+        try:
+            assert started.wait(5.0), "the worker never started"
+            assert elapsed < 0.5, f"the GUI thread was held for {elapsed * 1e3:.0f} ms"
+        finally:
+            release.set()
+            _settle(widget)
+
+
+class TestItCoalescesAcrossTheMove:
+    def test_a_nudge_mid_move_replaces_the_target_rather_than_queueing(
+        self, fm, widget, monkeypatch
+    ):
+        """Two nudges during one move must produce two moves total, not three: the
+        first, then one more to wherever the wheel ended up."""
+        started = threading.Event()
+        release = threading.Event()
+        targets = []
+        real = type(fm.objective).move_absolute
+
+        def blocking(self, position):
+            targets.append(position)
+            if len(targets) == 1:
+                started.set()
+                release.wait(5.0)
+            return real(self, position)
+
+        monkeypatch.setattr(type(fm.objective), "move_absolute", blocking)
+        base = fm.objective.position * METRE_TO_MICRON
+
+        widget._wheel_target_um = base + 1.0
+        widget._execute_wheel_move_impl()
+        assert started.wait(5.0)
+
+        # two more notches while the first move is still going
+        widget._wheel_target_um = base + 2.0
+        widget._execute_wheel_move_impl()
+        widget._wheel_target_um = base + 3.0
+        widget._execute_wheel_move_impl()
+
+        release.set()
+        _settle(widget)
+
+        assert len(targets) == 2, f"expected 2 moves, got {len(targets)}"
+        assert targets[-1] * METRE_TO_MICRON == pytest.approx(base + 3.0)
+
+    def test_a_target_unchanged_since_the_move_started_does_not_move_again(
+        self, fm, widget, monkeypatch
+    ):
+        """The chase must not run on every completion, or one nudge loops forever."""
+        targets = []
+        real = type(fm.objective).move_absolute
+
+        def recording(self, position):
+            targets.append(position)
+            return real(self, position)
+
+        monkeypatch.setattr(type(fm.objective), "move_absolute", recording)
+
+        widget._wheel_target_um = fm.objective.position * METRE_TO_MICRON + 1.0
+        widget._execute_wheel_move_impl()
+        _settle(widget)
+
+        assert len(targets) == 1
+
+    def test_the_readout_never_jumps_backwards_during_a_burst(
+        self, fm, widget, monkeypatch
+    ):
+        """A move that lands mid-burst has already been scrolled past. Writing its
+        position to the spinbox snapped the number backwards, and it sat there for the
+        whole of the next move -- several hundred ms of showing the wrong position on
+        the readout you are focusing by. Invisible before the move came off the GUI
+        thread, because nothing repainted in between."""
+        widget.parent_widget = _Host()
+        seen = []
+        spin = widget.doubleSpinBox_objective_position
+        real_set = spin.setValue
+        monkeypatch.setattr(
+            spin, "setValue", lambda v: (seen.append(round(v, 1)), real_set(v))[1]
+        )
+
+        started = threading.Event()
+        release = threading.Event()
+        real = type(fm.objective).move_absolute
+
+        def blocking(self, position):
+            if not started.is_set():
+                started.set()
+                release.wait(5.0)
+            return real(self, position)
+
+        monkeypatch.setattr(type(fm.objective), "move_absolute", blocking)
+
+        widget._on_canvas_scroll(0, 0, +1, {"Shift"})
+        widget._execute_wheel_move_impl()
+        assert started.wait(5.0)
+        seen.clear()  # from here on: what the user watches
+        for _ in range(4):  # keep scrolling while the first move is out
+            widget._on_canvas_scroll(0, 0, +1, {"Shift"})
+        release.set()
+        _settle(widget)
+
+        backwards = [b for a, b in zip(seen, seen[1:]) if b < a]
+        assert not backwards, f"readout went backwards to {backwards} in {seen}"
+
+    def test_the_spinbox_ends_where_the_wheel_left_it(self, fm, widget):
+        base = fm.objective.position * METRE_TO_MICRON
+        widget._wheel_target_um = base + 2.0
+        widget._execute_wheel_move_impl()
+        _settle(widget)
+
+        assert widget.doubleSpinBox_objective_position.value() == pytest.approx(
+            base + 2.0
+        )
+
+
+class TestItDoesNotRaceTheOtherObjectiveActions:
+    """With the move off the GUI thread everything here stays clickable through it,
+    where the frozen interface used to make a second command impossible. Two commands
+    for one objective is the hazard, and retracting it out from under a move in
+    progress is the one that matters."""
+
+    @pytest.fixture
+    def mid_move(self, fm, widget, monkeypatch):
+        """A widget with a move in flight, held there for the length of the test."""
+        started = threading.Event()
+        release = threading.Event()
+        real = type(fm.objective).move_absolute
+
+        def blocking(self, position):
+            started.set()
+            release.wait(5.0)
+            return real(self, position)
+
+        monkeypatch.setattr(type(fm.objective), "move_absolute", blocking)
+        widget._wheel_target_um = fm.objective.position * METRE_TO_MICRON + 1.0
+        widget._execute_wheel_move_impl()
+        assert started.wait(5.0)
+        _app.processEvents()
+        yield widget
+        release.set()
+        _settle(widget)
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            "insert_objective",
+            "retract_objective",
+            "move_to_focus_position",
+            # Records rather than moves -- but the number it records is a fresh device
+            # read, and mid-move that is wherever the objective is passing.
+            "set_focus_position",
+        ],
+    )
+    def test_each_one_stands_down_mid_move(self, fm, mid_move, action, monkeypatch):
+        commanded = []
+        for name in ("move_absolute", "insert", "retract"):
+            monkeypatch.setattr(
+                type(fm.objective),
+                name,
+                lambda self, *a, _n=name: commanded.append(_n),
+            )
+        # Any dialog reached would mean the guard let the action through; offscreen it
+        # would also hang the run rather than fail it.
+        monkeypatch.setattr(
+            "fibsem.ui.fm.widgets.objective_control_widget.message_box_ui",
+            lambda *a, **k: pytest.fail("the action ran and opened a dialog"),
+        )
+
+        getattr(mid_move, action)()
+
+        assert commanded == []
+
+    def test_it_does_not_touch_the_buttons(self, fm, mid_move):
+        """The regression this replaces. The buttons belong to
+        `FMControlWidget._update_acquisition_button_states`, which re-derives them from
+        `may_start` -- disabling them here and re-enabling on completion overwrote its
+        answer, so scrolling during a live stream left Insert and Retract clickable when
+        the stream forbids them. A guard on the action needs no button at all."""
+        assert mid_move.pushButton_retract_objective.isEnabled()
+        assert mid_move.pushButton_insert_objective.isEnabled()
+
+    def test_the_actions_work_again_once_the_move_lands(self, fm, widget, monkeypatch):
+        widget._wheel_target_um = fm.objective.position * METRE_TO_MICRON + 1.0
+        widget._execute_wheel_move_impl()
+        _settle(widget)
+
+        assert widget._objective_busy_reason() is None
+
+    def test_a_failed_move_does_not_leave_the_guard_stuck_on(
+        self, fm, widget, monkeypatch
+    ):
+        def boom(self, position):
+            raise RuntimeError("objective unreachable")
+
+        monkeypatch.setattr(type(fm.objective), "move_absolute", boom)
+
+        widget._wheel_target_um = fm.objective.position * METRE_TO_MICRON + 1.0
+        widget._execute_wheel_move_impl()
+        _settle(widget)
+
+        assert widget._objective_busy_reason() is None
+
+
+class TestNothingDrivesTheObjectiveOverSomethingElse:
+    """One question -- is anything driving the objective -- asked by every way in.
+
+    Three parties can be: another acquisition (FIB-515, and only the microscope can
+    answer it -- FIB-513), a focus adjustment (FIB-625), or a threaded insert/retract
+    (FIB-628). Each of the five entry points used to ask a different question, or none.
+    """
+
+    @pytest.fixture
+    def widget(self, fm):
+        w = ObjectiveControlWidget(fm, parent=_Host())
+        yield w
+        w.cleanup()
+        w.close()
+
+    def test_an_insert_or_retract_blocks_the_wheel(self, fm, widget, monkeypatch):
+        """The direction that was always open: insert and retract have always been
+        threaded, so a scroll during a retraction went straight through -- and retract
+        is the collision-relevant motion (FIB-628)."""
+        moves = []
+        monkeypatch.setattr(
+            type(fm.objective), "move_absolute", lambda self, p: moves.append(p)
+        )
+        widget._action_worker = object()  # a retract on its way
+
+        widget._on_canvas_scroll(0, 0, +1, {"Shift"})
+        widget._execute_wheel_move_impl()
+        _drain(0.1)
+
+        assert moves == []
+        assert widget._objective_busy_reason() == "an objective insert or retract"
+
+    def test_something_starting_inside_the_debounce_window_stops_the_move(
+        self, fm, widget, monkeypatch
+    ):
+        """The scroll handlers guard when the notch arrives, but the debounce puts
+        150 ms between that and the move. A retract starting in between would otherwise
+        find a move already on its way."""
+        moves = []
+        monkeypatch.setattr(
+            type(fm.objective), "move_absolute", lambda self, p: moves.append(p)
+        )
+        widget._on_canvas_scroll(0, 0, +1, {"Shift"})  # accepted: nothing busy yet
+        widget._action_worker = object()  # ... and now a retract starts
+
+        widget._execute_wheel_move_impl()  # what the debounce timer fires
+        _drain(0.1)
+
+        assert moves == []
+
+    def test_an_acquisition_blocks_the_wheel(self, fm, widget, monkeypatch):
+        """`is_interactive` is the microscope's answer. Asking whether *this widget* was
+        busy is what let another tab's tileset through (FIB-513)."""
+        moves = []
+        monkeypatch.setattr(
+            type(fm.objective), "move_absolute", lambda self, p: moves.append(p)
+        )
+        fm.set_acquiring(True, reason="a tileset")
+        try:
+            widget._on_canvas_scroll(0, 0, +1, {"Shift"})
+            widget._execute_wheel_move_impl()
+            _drain(0.1)
+
+            assert moves == []
+            assert widget._objective_busy_reason() == "a tileset"
+        finally:
+            fm.set_acquiring(False)
+
+    def test_a_live_stream_does_not_block_the_wheel(self, fm, widget):
+        """Deliberately not busy. Focusing while watching the stream is what this panel
+        is for, and is the whole point of FIB-625."""
+        fm.start_acquisition(channel_settings=None)
+        try:
+            assert widget._objective_busy_reason() is None
+        finally:
+            fm.stop_acquisition()
+
+    def test_the_spinbox_stands_down_too(self, fm, widget, monkeypatch):
+        """The last unguarded way in (FIB-515)."""
+        moves = []
+        monkeypatch.setattr(
+            type(fm.objective), "move_absolute", lambda self, p: moves.append(p)
+        )
+        widget._action_worker = object()
+
+        widget.on_objective_position_changed(
+            fm.objective.position * METRE_TO_MICRON + 1.0
+        )
+
+        assert moves == []
+
+    def test_refusing_the_spinbox_does_not_reenter(self, fm, widget, monkeypatch):
+        """Putting the spinbox back raises `valueChanged`, which is wired straight back
+        to this handler. Qt does not warn; it simply never returns."""
+        widget.doubleSpinBox_objective_position.valueChanged.connect(
+            widget.on_objective_position_changed
+        )
+        widget._action_worker = object()
+        calls = []
+        real = widget.on_objective_position_changed
+        monkeypatch.setattr(
+            widget,
+            "on_objective_position_changed",
+            lambda p: (calls.append(p), real(p))[1],
+        )
+        monkeypatch.setattr(type(fm.objective), "move_absolute", lambda self, p: None)
+
+        widget.on_objective_position_changed(
+            fm.objective.position * METRE_TO_MICRON + 1.0
+        )
+
+        assert len(calls) <= 1
+
+
+class TestTeardown:
+    def test_cleanup_cuts_a_move_in_flight_loose(self, fm, widget, monkeypatch):
+        """The slots touch widgets, and an emit into one Qt has destroyed on the C++
+        side is a segfault rather than an exception (FIB-550). The move itself is left
+        to finish -- waiting for it is the blocking this change removes."""
+        started = threading.Event()
+        release = threading.Event()
+        real = type(fm.objective).move_absolute
+
+        def blocking(self, position):
+            started.set()
+            release.wait(5.0)
+            return real(self, position)
+
+        monkeypatch.setattr(type(fm.objective), "move_absolute", blocking)
+
+        landed = []
+        widget._on_wheel_move_finished = lambda *a: landed.append(a)
+
+        widget._wheel_target_um = fm.objective.position * METRE_TO_MICRON + 1.0
+        widget._execute_wheel_move_impl()
+        assert started.wait(5.0)
+
+        widget.cleanup()
+        release.set()
+        _drain(1.0)
+
+        assert widget._wheel_worker is None
+        assert landed == [], "the worker called back into a torn-down widget"
+
+    def test_cleanup_is_safe_with_no_move_in_flight(self, widget):
+        widget.cleanup()
+        widget.cleanup()  # idempotent, like the rest of the teardown


### PR DESCRIPTION
Closes FIB-625, FIB-515 and FIB-628. Reported from the app: Shift+scroll focusing during a live FM stream had a noticeable delay before the canvas showed the new focus.

## The stall

`_execute_wheel_move` is a `qdebounced` wrapper, and `qdebounced` fires on a QTimer **in the GUI thread** — so the blocking `move_absolute` inside it stopped every repaint for as long as the objective took to move.

| | GUI thread blocked per nudge |
|---|---|
| before | ~860 ms (150 ms debounce + ~500 ms move + ~210 ms of `_notify_moved`'s reads) |
| after | **0.4 ms** |

The frames were arriving the whole time — `start_acquisition` streams on its own thread — they simply could not be drawn. The move still takes its 816 ms; it no longer takes it on the thread that repaints.

## Three things follow from that, each a correctness problem

**Coalescing had to extend across the move.** The 150 ms debounce collapses a scroll *burst*, and could only ever do that because the move held the thread the debounce runs on. A notch landing mid-move would otherwise start a second trip behind the first, and a slow objective would turn a flick of the wheel into a march. A move in flight is left alone and re-reads the target when it lands.

The in-flight test is `self._wheel_worker is not None`, deliberately **not** `is_alive()` — the reference is cleared only in the completion slots, which run on the GUI thread, so there is no window between the thread ending and the result being accounted for. `is_alive()` would open exactly that window.

**The readout jumps backwards.** A move landing mid-burst has already been scrolled past, and writing its position to the spinbox snapped the number backwards, where it then sat for the whole of the next move:

```
-9998, -9997, -9996, -9995,   <- the notches
-9999,                        <- the first move landing
-9995                         <- the chase catching up
```

Several hundred ms of the wrong position on the readout being focused by. Both writers — the completion slot and `position_changed` from FIB-576 — now consult one predicate rather than depending on which Qt delivers first.

**Everything stays clickable through the move.** That turned out to be three issues, not one.

## One predicate, three issues

They are the same question — *is anything driving the objective right now* — with three parties that can be:

| source | asks | issue |
|---|---|---|
| another acquisition | `fm.is_interactive` — the microscope's answer, not the widget's | FIB-515 |
| a focus adjustment | the wheel worker | FIB-625 |
| an insert or retract | the action worker, now tracked | FIB-628 |

`_objective_busy_reason` answers it once and all six ways in consult it: the four button actions, both scroll paths, and the position spinbox. A live stream is deliberately **not** busy — focusing while watching is what the panel is for.

**Guards on the actions, not on the buttons.** The first attempt disabled the buttons for the length of the move, which was wrong twice over: they are not this widget's to drive (`FMControlWidget._update_acquisition_button_states` owns them via `may_start`), and the unconditional re-enable overwrote its answer — so a scroll during a live stream left Insert and Retract clickable when the stream forbids them. Caught in the app; it is the "the button is not the guard" shape FIB-513 closed one layer up, which is what FIB-515 was opened for.

**The guard also sits in `_start_wheel_move`, and that is not belt and braces.** The scroll handlers guard when the notch arrives, but the debounce puts 150 ms between that and the move, and the chase can dispatch later still. A retract starting inside either window would find a move already on its way. `_start_wheel_move` is the single dispatch point and the last moment before the command goes out.

**Two decisions FIB-515 left open, made rather than assumed.** `set_focus_position` is guarded — it only records a number, but the number is a fresh device read, so mid-move you would save a focus of "halfway there". And refusing the spinbox is safe because `update_objective_position_labels` blocks the spinbox's signals around `setValue`; the large-move cancel already relied on that, so the pattern was there. Pinned with a re-entry test.

The scroll paths log rather than toast — they fire per notch. The deliberate single actions say so on screen, because the control stays enabled and a silent refusal reads as a dead button.

## Teardown

`cleanup` cuts a move in flight loose rather than joining it — waiting would leave teardown as the one place still blocking on the objective. The callback is what must not survive: those slots touch widgets, and an emit into one Qt has already destroyed is a segfault, not an exception (FIB-550).

## Second commit: a travel time for the simulator

Insert and retract traverse the objective's whole range, seconds on a real system, but both delegated to `move_absolute` and returned as fast as a focus nudge. That made FIB-628's window unreachable by hand — you cannot click into a few hundred milliseconds. They now take ~2.7 s. `sim_sleep`, and `tests/conftest.py` sets `FIBSEM_SIM_NO_DELAY` by default, so the suite pays nothing (measured: 2.72 s in the app, 0.00 s under pytest).

## Known limit

This cannot see another `ObjectiveControlWidget` — the coincidence viewer holds a second one with its own workers. Closing that means the objective marking itself busy rather than the widget doing it, a driver-level change in the FIB-441 shape. Recorded on FIB-628 rather than assumed here.

## Testing

21 tests. Mutation-checked throughout:

| mutant | fails |
|---|---|
| move back on the GUI thread | 5 |
| no in-flight guard / no chase | 1 |
| either writer through mid-burst | 1 |
| predicate blind to insert/retract | 3 |
| predicate blind to acquisitions | 1 |
| spinbox unguarded | 1 |
| no guard at dispatch | 3 |
| buttons driven again (the first attempt) | 1 |

`tests/ui/` + `tests/fm/` — 1862 passed, 1 skipped. Confirmed in the app.
