### PR TITLE
Treat an unreadable refractive-index lookup table as missing (FIB-592)

### DIFF
--- a/fibsem/correlation/refractive_index.py
+++ b/fibsem/correlation/refractive_index.py
@@ -26,6 +26,9 @@ Usage::
 from __future__ import annotations
 
 import logging
+import os
+import shutil
+import tempfile
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
@@ -41,16 +44,72 @@ _LUT_URL = (
     "https://github.com/fibsem-os/fibsem-os/releases/download/data-0.1.0/"
     + _LUT_FILENAME
 )
+_LUT_COLUMNS = ("tilt_deg", "depth_um", "n2", "wavelength_um", "NA", "zeta")
+
+# The download runs on the GUI thread when the correlation window opens, and
+# microscope PCs are commonly offline or behind a proxy that blackholes the
+# connection rather than refusing it — without this the window hangs until the
+# OS gives up, which on some platforms is over a minute.
+_LUT_DOWNLOAD_TIMEOUT_S = 10.0
+
+# One attempt per process. A machine that cannot reach the release will not
+# start being able to mid-session, and the cost of pretending otherwise is the
+# stall above on every single open of the window.
+_download_attempted = False
+
+
+def _download_lut() -> None:
+    """Fetch the LUT CSV from the data release, atomically.
+
+    Writes to a temporary file beside the destination and renames it into place.
+    A transfer that dies half way must never leave a truncated CSV at the real
+    path: that file *exists*, so nothing re-fetches it, and every lookup fails
+    against it for the life of the install (FIB-592).
+    """
+    _LUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    logging.info(f"Downloading the refractive-index LUT from {_LUT_URL}")
+    tmp_path: Optional[Path] = None
+    try:
+        with urllib.request.urlopen(
+            _LUT_URL, timeout=_LUT_DOWNLOAD_TIMEOUT_S
+        ) as response:
+            with tempfile.NamedTemporaryFile(
+                dir=str(_LUT_PATH.parent),
+                prefix=_LUT_PATH.name + ".",
+                suffix=".part",
+                delete=False,
+            ) as tmp:
+                tmp_path = Path(tmp.name)
+                shutil.copyfileobj(response, tmp)
+        os.replace(str(tmp_path), str(_LUT_PATH))  # atomic within the directory
+        tmp_path = None
+        logging.info(f"Refractive-index LUT saved to {_LUT_PATH}")
+    finally:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
 
 
 def _ensure_lut() -> None:
-    """Download the LUT CSV from the data release if not present locally."""
-    if _LUT_PATH.exists():
+    """Make sure a *usable* LUT is on disk, downloading one if it is not.
+
+    Also the re-fetch path for a file that is present but will not parse — an
+    install that picked up a truncated CSV before the atomic write above would
+    otherwise stay broken forever, with no way out but deleting the file by hand.
+
+    Raises whatever the download raises, plus RuntimeError if what arrived still
+    does not parse. Callers on the GUI thread are expected to catch and report.
+    """
+    global _download_attempted
+    if lut_error() is None:
         return
-    logging.info(f"Lookup table not found — downloading from {_LUT_URL}")
-    _LUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    urllib.request.urlretrieve(_LUT_URL, _LUT_PATH)
-    logging.info(f"Lookup table saved to {_LUT_PATH}")
+    if _download_attempted:
+        return
+    _download_attempted = True
+    _download_lut()
+    reset_lut_cache()  # re-validate what we just wrote rather than assuming
+    error = lut_error()
+    if error is not None:
+        raise RuntimeError(f"downloaded refractive-index LUT is unusable: {error}")
 
 
 @dataclass
@@ -74,10 +133,23 @@ class SliceScalingFactorLUT:
         bundled with the package.
     """
 
-    def __init__(self, csv_path: Path = _LUT_PATH) -> None:
-        if csv_path == _LUT_PATH:
-            _ensure_lut()
+    def __init__(self, csv_path: Optional[Path] = None) -> None:
+        # Resolved here, not as a default argument: a default binds _LUT_PATH at
+        # import, so this class would go on reading the original file after
+        # anything repointed the module — which is every test, and would be a
+        # silent disagreement with lut_error() rather than a failure.
+        csv_path = Path(csv_path) if csv_path is not None else _LUT_PATH
+        # Deliberately does not download: fetching is _ensure_lut's job, so that
+        # merely asking whether the LUT works cannot reach the network.
         lut = pd.read_csv(csv_path)
+
+        missing = [c for c in _LUT_COLUMNS if c not in lut.columns]
+        if missing:
+            # A proxy error page or an HTML 404 saved under the CSV's name parses
+            # as *something*; say what it is rather than dying on a KeyError.
+            raise ValueError(
+                f"{csv_path} is not the LUT: missing column(s) {', '.join(missing)}"
+            )
 
         # Sort in the order that defines the tensor axes
         sort_cols = ["tilt_deg", "depth_um", "n2", "wavelength_um", "NA"]
@@ -143,17 +215,58 @@ class SliceScalingFactorLUT:
 # ---------------------------------------------------------------------------
 
 _lut: Optional[SliceScalingFactorLUT] = None
+_lut_error: Optional[str] = None
+_lut_checked = False
+
+
+def _load_lut_once() -> None:
+    """Fill the cache with either the LUT or the reason there isn't one."""
+    global _lut, _lut_error, _lut_checked
+    if _lut_checked:
+        return
+    _lut_checked = True
+    if not _LUT_PATH.exists():
+        _lut_error = f"file not found at {_LUT_PATH}"
+        return
+    try:
+        _lut = SliceScalingFactorLUT(_LUT_PATH)
+    except Exception as exc:
+        _lut_error = f"file at {_LUT_PATH} could not be read ({exc})"
+        logging.warning(f"Refractive-index LUT unusable: {_lut_error}")
+
+
+def lut_error() -> Optional[str]:
+    """Why the LUT cannot be used, or None when it can. Never downloads.
+
+    "The file exists" is not "the file works". A transfer that died half way, or
+    a proxy error page saved under the CSV's name, leaves a file that every
+    lookup raises against — and testing existence let exactly that state present
+    as a working calculator: five live spinboxes, no warning, and a correction
+    factor that silently never moved (FIB-592).
+
+    The verdict is cached. Neither failure mode fixes itself within a session,
+    and the alternative is re-parsing a 9 MB CSV on every spinbox keystroke.
+    """
+    _load_lut_once()
+    return _lut_error
+
+
+def reset_lut_cache() -> None:
+    """Forget the cached LUT and its verdict — after a download, or in tests."""
+    global _lut, _lut_error, _lut_checked
+    _lut, _lut_error, _lut_checked = None, None, False
 
 
 def get_lut() -> SliceScalingFactorLUT:
     """Return the module-level :class:`SliceScalingFactorLUT` singleton.
 
-    The LUT is loaded from disk on the first call and cached for subsequent
-    calls.
+    Loaded from disk on the first call and cached. Raises RuntimeError when the
+    LUT is missing or unreadable — the failure is cached too, so a caller in a
+    spinbox callback is not re-parsing a broken 9 MB CSV on every keystroke.
     """
-    global _lut
+    _load_lut_once()
     if _lut is None:
-        _lut = SliceScalingFactorLUT()
+        raise RuntimeError(f"refractive-index LUT unavailable: {_lut_error}")
     return _lut
 
 

--- a/fibsem/ui/correlation/widgets/refractive_index_widget.py
+++ b/fibsem/ui/correlation/widgets/refractive_index_widget.py
@@ -10,6 +10,7 @@ Usage::
 
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 from PyQt5.QtCore import pyqtSignal
@@ -20,16 +21,23 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from fibsem.correlation.refractive_index import ZetaParams, _LUT_PATH, _ensure_lut, lookup_zeta
+from fibsem.correlation.refractive_index import (
+    ZetaParams,
+    _ensure_lut,
+    lookup_zeta,
+    lut_error,
+)
 from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel, ValueSpinBox
 from fibsem.ui.tokens import (
     NEUTRAL_500,
 )
 
-_LUT_MISSING_MSG = (
-    f"Correction factor calculator unavailable: LUT file not found at\n{_LUT_PATH}\n"
-    "The correction factor can still be edited manually."
-)
+
+def _lut_unavailable_msg(reason: str) -> str:
+    return (
+        f"Correction factor calculator unavailable — {reason}.\n"
+        "The correction factor can still be edited manually."
+    )
 
 # Default values representative of typical cryo-CLEM conditions
 _DEFAULTS = ZetaParams(
@@ -94,8 +102,9 @@ class RefractiveIndexWidget(QWidget):
         try:
             _ensure_lut()
         except Exception as e:
-            import logging
-            logging.warning(f"Failed to download refractive index LUT: {e}")
+            # Bounded and attempted once per process (see _ensure_lut); the panel
+            # reports the outcome, so this only needs to not take the window down.
+            logging.warning(f"Refractive-index LUT unavailable: {e}")
         self._setup_ui()
         self._connect_signals()
         self._recompute()
@@ -156,25 +165,32 @@ class RefractiveIndexWidget(QWidget):
         )
         self._btn_reset_factor.clicked.connect(lambda: self._spin_factor.setValue(_DEFAULT_FACTOR))
 
-        lut_available = _LUT_PATH.exists()
-        self._lut_available = lut_available
-        if not lut_available:
-            self._lut_warning = QLabel("LUT not found — calculator disabled. Edit correction factor manually.")
+        # Whether the LUT *works*, not whether a file is sitting there: a
+        # truncated download parses as nothing, and testing existence left every
+        # spinbox enabled over a calculator that silently never answered (FIB-592).
+        error = lut_error()
+        self._lut_available = error is None
+        self._lut_message = "" if error is None else _lut_unavailable_msg(error)
+        if error is not None:
+            self._lut_warning = QLabel(
+                "Lookup table unavailable — calculator disabled. "
+                "Edit the correction factor manually."
+            )
             self._lut_warning.setStyleSheet(
                 "color: #f0a500; font-style: italic; font-size: 11px; padding: 4px 8px;"
             )
             self._lut_warning.setWordWrap(True)
-            self._lut_warning.setToolTip(_LUT_MISSING_MSG)
+            self._lut_warning.setToolTip(self._lut_message)
             form.addRow(self._lut_warning)
 
             for spin in (self._spin_tilt, self._spin_depth, self._spin_na, self._spin_n2, self._spin_wl):
                 spin.setEnabled(False)
-                spin.setToolTip(_LUT_MISSING_MSG)
+                spin.setToolTip(self._lut_message)
 
         panel = TitledPanel("Optical Parameters", content=form_widget)
         panel.add_header_widget(self._btn_reset_factor)
-        if not lut_available:
-            panel.setToolTip(_LUT_MISSING_MSG)
+        if error is not None:
+            panel.setToolTip(self._lut_message)
         outer.addWidget(panel)
         outer.addStretch(1)
 
@@ -254,7 +270,7 @@ class RefractiveIndexWidget(QWidget):
         else:
             self._spin_tilt.setEnabled(self._lut_available)
             self._spin_tilt.setToolTip(
-                _TILT_TOOLTIP if self._lut_available else _LUT_MISSING_MSG
+                _TILT_TOOLTIP if self._lut_available else self._lut_message
             )
             if self._tilt_before_lock is not None:
                 self._spin_tilt.setValue(self._tilt_before_lock)
@@ -315,7 +331,7 @@ class RefractiveIndexWidget(QWidget):
 
     def _recompute(self, _value: object = None, *, update_factor: bool = True) -> None:
         # _value swallows the float from QDoubleSpinBox.valueChanged connections.
-        if not _LUT_PATH.exists():
+        if not self._lut_available:
             return
         params = self.get_params()
         try:
@@ -330,4 +346,13 @@ class RefractiveIndexWidget(QWidget):
             if update_factor:
                 self.zeta_computed.emit(zeta)
         except Exception:
+            # Out-of-range parameters are the ordinary case here and the controls
+            # already bound them, so this is not an error dialog — but it is not
+            # nothing either. Swallowed in silence, a LUT that answered no
+            # question read as one that agreed with every answer (FIB-592).
+            logging.warning(
+                f"Zeta lookup failed for {params}; correction factor left at "
+                f"{self._spin_factor.value():.3f}",
+                exc_info=True,
+            )
             self._zeta = None

--- a/tests/correlation/test_lut_availability.py
+++ b/tests/correlation/test_lut_availability.py
@@ -1,0 +1,237 @@
+"""The LUT's failure modes (FIB-592).
+
+Deliberately not in test_refractive_index.py: that module skips wholesale when
+the real 9 MB CSV is absent, and these are exactly the cases where it is absent
+or broken. Everything here runs against a synthetic LUT in tmp_path, so it holds
+on a machine that has never downloaded the real one.
+"""
+import itertools
+from pathlib import Path
+
+import pytest
+
+import fibsem.correlation.refractive_index as ri
+
+
+def _write_valid_lut(path: Path) -> None:
+    """A complete, if tiny, grid over the five axes the interpolator expects."""
+    axes = {
+        "tilt_deg": [0.0, 30.0],
+        "depth_um": [0.5, 14.5],
+        "n2": [1.22, 1.46],
+        "wavelength_um": [0.42, 0.72],
+        "NA": [0.2, 0.9],
+    }
+    names = list(axes)
+    rows = ["tilt_deg,depth_um,n2,wavelength_um,NA,zeta"]
+    for i, combo in enumerate(itertools.product(*(axes[n] for n in names))):
+        rows.append(",".join(str(v) for v in combo) + f",{1.0 + i * 0.01}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(rows) + "\n")
+
+
+@pytest.fixture(autouse=True)
+def lut_path(tmp_path, monkeypatch):
+    """Point the module at a scratch LUT and clear every cached verdict."""
+    path = tmp_path / "data" / "table_refractive_index_lookup.csv"
+    monkeypatch.setattr(ri, "_LUT_PATH", path)
+    monkeypatch.setattr(ri, "_download_attempted", False)
+    ri.reset_lut_cache()
+    yield path
+    ri.reset_lut_cache()
+
+
+# ---------------------------------------------------------------------------
+# lut_error — "the file exists" is not "the file works"
+# ---------------------------------------------------------------------------
+
+
+def test_valid_lut_reports_no_error(lut_path):
+    _write_valid_lut(lut_path)
+    assert ri.lut_error() is None
+    assert ri.get_lut() is not None
+
+
+def test_missing_lut_says_so(lut_path):
+    assert "not found" in ri.lut_error()
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        pytest.param(None, "could not be read", id="truncated-download"),
+        pytest.param(
+            "<html><body>403 Forbidden</body></html>\n",
+            "could not be read",
+            id="proxy-error-page",
+        ),
+        pytest.param("", "could not be read", id="empty-file"),
+    ],
+)
+def test_a_present_but_unusable_lut_is_an_error_not_availability(
+    lut_path, content, expected
+):
+    """The FIB-592 core: a file that exists but will not parse must report as
+    unavailable, or the widget enables five spinboxes over a dead calculator."""
+    if content is None:  # half a real transfer
+        _write_valid_lut(lut_path)
+        raw = lut_path.read_text()
+        lut_path.write_text(raw[: len(raw) // 3])
+    else:
+        lut_path.parent.mkdir(parents=True, exist_ok=True)
+        lut_path.write_text(content)
+
+    error = ri.lut_error()
+    assert error is not None and expected in error
+    assert lut_path.exists(), "the precondition is that the file IS there"
+
+    with pytest.raises(RuntimeError, match="unavailable"):
+        ri.get_lut()
+
+
+def test_wrong_columns_name_what_is_missing(lut_path):
+    lut_path.parent.mkdir(parents=True, exist_ok=True)
+    lut_path.write_text("a,b,c\n1,2,3\n")
+    assert "missing column" in ri.lut_error()
+
+
+def test_the_verdict_is_cached(lut_path, monkeypatch):
+    """Re-parsing a 9 MB CSV on every spinbox keystroke is the cost of not
+    caching, so the failure has to be remembered as firmly as the success."""
+    _write_valid_lut(lut_path)
+    assert ri.lut_error() is None
+
+    reads = []
+    real = ri.pd.read_csv
+    monkeypatch.setattr(ri.pd, "read_csv", lambda *a, **k: (reads.append(1), real(*a, **k))[1])
+    for _ in range(5):
+        ri.lut_error()
+        ri.get_lut()
+    assert reads == []
+
+
+# ---------------------------------------------------------------------------
+# _download_lut — a failed transfer must not land at the real path
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes, fail_after: int = -1):
+        self._payload, self._fail_after, self._sent = payload, fail_after, 0
+
+    def read(self, n=-1):
+        if self._fail_after >= 0 and self._sent >= self._fail_after:
+            raise ConnectionResetError("connection dropped mid-transfer")
+        chunk = self._payload[self._sent : self._sent + 8]
+        self._sent += len(chunk)
+        return chunk
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_download_is_atomic_and_leaves_nothing_behind(lut_path, monkeypatch):
+    """A transfer that dies half way must leave NO file at the real path — one
+    that exists is never re-fetched, so it breaks the install permanently."""
+    _write_valid_lut(lut_path)
+    payload = lut_path.read_bytes()
+    lut_path.unlink()
+
+    monkeypatch.setattr(
+        ri.urllib.request,
+        "urlopen",
+        lambda url, timeout=None: _FakeResponse(payload, fail_after=len(payload) // 2),
+    )
+    with pytest.raises(ConnectionResetError):
+        ri._download_lut()
+
+    assert not lut_path.exists()
+    assert list(lut_path.parent.glob("*.part")) == [], "temp file left behind"
+
+
+def test_download_passes_a_timeout(lut_path, monkeypatch):
+    """Microscope PCs sit behind proxies that blackhole rather than refuse; with
+    no timeout the correlation window hangs until the OS gives up."""
+    seen = {}
+
+    def _urlopen(url, timeout=None):
+        seen["timeout"] = timeout
+        return _FakeResponse(b"tilt_deg\n")
+
+    monkeypatch.setattr(ri.urllib.request, "urlopen", _urlopen)
+    ri._download_lut()
+    assert seen["timeout"] == ri._LUT_DOWNLOAD_TIMEOUT_S
+    assert seen["timeout"] is not None
+
+
+def test_successful_download_lands_at_the_real_path(lut_path, monkeypatch):
+    _write_valid_lut(lut_path)
+    payload = lut_path.read_bytes()
+    lut_path.unlink()
+
+    monkeypatch.setattr(
+        ri.urllib.request, "urlopen", lambda url, timeout=None: _FakeResponse(payload)
+    )
+    ri._download_lut()
+    assert lut_path.read_bytes() == payload
+    assert list(lut_path.parent.glob("*.part")) == []
+
+
+# ---------------------------------------------------------------------------
+# _ensure_lut — self-healing, and bounded
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_lut_is_a_noop_when_the_lut_works(lut_path, monkeypatch):
+    _write_valid_lut(lut_path)
+    monkeypatch.setattr(
+        ri.urllib.request,
+        "urlopen",
+        lambda *a, **k: pytest.fail("must not touch the network"),
+    )
+    ri._ensure_lut()
+
+
+def test_ensure_lut_refetches_a_corrupt_file(lut_path, monkeypatch):
+    """An install that picked up a truncated CSV before the atomic write existed
+    would otherwise stay broken forever, with no way out but deleting it by hand."""
+    _write_valid_lut(lut_path)
+    payload = lut_path.read_bytes()
+    lut_path.write_bytes(payload[: len(payload) // 3])
+    assert ri.lut_error() is not None
+
+    monkeypatch.setattr(
+        ri.urllib.request, "urlopen", lambda url, timeout=None: _FakeResponse(payload)
+    )
+    ri._ensure_lut()
+    assert ri.lut_error() is None
+
+
+def test_ensure_lut_attempts_the_download_once_per_process(lut_path, monkeypatch):
+    """Bounded, because it runs on the GUI thread every time the correlation
+    window opens and an offline machine will not come back mid-session."""
+    calls = []
+
+    def _urlopen(url, timeout=None):
+        calls.append(url)
+        raise OSError("offline")
+
+    monkeypatch.setattr(ri.urllib.request, "urlopen", _urlopen)
+    with pytest.raises(OSError):
+        ri._ensure_lut()
+    for _ in range(3):
+        ri._ensure_lut()  # must not raise, must not retry
+    assert len(calls) == 1
+
+
+def test_ensure_lut_raises_when_what_arrived_is_still_unusable(lut_path, monkeypatch):
+    monkeypatch.setattr(
+        ri.urllib.request,
+        "urlopen",
+        lambda url, timeout=None: _FakeResponse(b"<html>404</html>\n"),
+    )
+    with pytest.raises(RuntimeError, match="unusable"):
+        ri._ensure_lut()


### PR DESCRIPTION
Fixes FIB-592.

A truncated download, or a proxy error page saved under the CSV's name, leaves a file on disk. `lut_available = _LUT_PATH.exists()` was true for it, so the RI panel enabled all five optical-parameter spinboxes, rendered no warning, and every lookup raised into a bare `except Exception` that did not even log. Turning the knobs changed nothing — permanently and silently, because the file exists so nothing ever re-fetched it.

Measured on the same widget with the same edits:

| LUT state | NA 0.8→0.5, n2 1.4→1.22 | panel |
| --- | --- | --- |
| healthy | factor 1.595 → 1.260 | controls enabled |
| truncated | 1.470 → 1.470 | enabled, no warning, no log line |
| HTML 403 page | 1.470 → 1.470 | enabled, no warning, no log line |

This matters more since #373: placing an FM surface point now arms whatever the factor box holds, so a silently-dead calculator means the untouched default reaches a real correlation run.

## Changes

- **`lut_error()` replaces the existence test.** It parses, caches the verdict, and returns *why* the LUT is unusable. The widget reports that reason in the panel and disables the controls, exactly as it already did for an absent file.
- **`_download_lut` writes to a temp file beside the destination and `os.replace()`s it in**, so an interrupted transfer cannot leave a truncated CSV at the real path to begin with.
- **`_ensure_lut` re-fetches a file that will not parse**, so an install that already picked up a bad one self-heals instead of needing it deleted by hand.
- **`_recompute` logs the swallowed exception.**
- **`SliceScalingFactorLUT` resolves `_LUT_PATH` at call time.** As a default argument it bound at import, so the class read the original file after anything repointed the module — a silent disagreement with `lut_error()` rather than a failure. It also now names a missing column instead of dying on a `KeyError`.

## Tests

14 tests against a synthetic LUT in `tmp_path`, in their own module. The existing LUT test skips wholesale when the real CSV is absent, which is precisely the situation these need to cover.

Note for anyone touching this area: nine test files under `tests/correlation/` monkeypatch `riw._ensure_lut` to block the network. Rename or bypass that seam and all nine silently stop protecting, and the suite starts downloading.

## Two open questions, neither blocking this fix

Both are about the download existing at all, not about the bug:

1. **Ship the ~9 MB lookup table as package data and drop the runtime download.** That removes this failure mode entirely rather than handling it, along with the network dependency and the startup latency.
2. **Make the download opt-in.** It still fires automatically when the correlation window opens — on the GUI thread, now bounded by a timeout and attempted once per process. Microscope PCs are commonly offline or behind a proxy that blackholes rather than refuses.

Happy to follow up with either; this PR is the defensive fix on its own.
