### PR TITLE
[ui] Flash the focus target on the FM canvas, and fix Shift+scroll on a macOS mouse (FIB-635, FIB-552)

### DIFF
--- a/fibsem/ui/fm/widgets/objective_control_widget.py
+++ b/fibsem/ui/fm/widgets/objective_control_widget.py
@@ -252,6 +252,30 @@ class ObjectiveControlWidget(QWidget):
         self.pushButton_insert_objective.setEnabled(enabled)
         self.pushButton_retract_objective.setEnabled(enabled)
 
+    def _flash_focus_target(self, new_pos_um: float, step_um: float) -> None:
+        """Flash where the objective is going, on the canvas being scrolled (FIB-635).
+
+        The beam canvases have done this for the working distance since the quad view
+        shipped -- `flash_message(f"WD {v:.3f} mm")` -- and the FM, the one you focus by
+        while watching the stream, showed nothing.
+
+        Not a duplicate of the `OBJECTIVE` field in the info bar, which reports where the
+        objective *is*: persistent, device-truthful, and deliberately behind during a
+        burst, because `_wheel_is_driving` suppresses the intermediates rather than let
+        the number snap backwards past your own scrolling (FIB-625). This is the
+        *command* -- where the next move is headed -- so a target is the right thing to
+        show, and transient is the right lifetime.
+
+        The step is included because it is the one piece of state that silently changes
+        what the gesture means: leave it at 50 um and your first notch jumps 50. Signed,
+        so it doubles as a direction indicator. It does not change across a burst, which
+        is why it costs nothing to read twice.
+        """
+        canvas = self.sender()
+        if canvas is None or not hasattr(canvas, "flash_message"):
+            return
+        canvas.flash_message(f"OBJ {new_pos_um:.1f} um  ({step_um:+.1f} um)")
+
     def _objective_busy_reason(self) -> Optional[str]:
         """What is driving the objective right now, phrased for a warning, or None.
 
@@ -711,6 +735,7 @@ class ObjectiveControlWidget(QWidget):
         self.doubleSpinBox_objective_position.blockSignals(True)
         self.doubleSpinBox_objective_position.setValue(new_pos_um)
         self.doubleSpinBox_objective_position.blockSignals(False)
+        self._flash_focus_target(new_pos_um, step_um)
 
         self._wheel_target_um = new_pos_um
         self._execute_wheel_move()

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
+from matplotlib.backend_bases import MouseEvent
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 from PyQt5.QtCore import QSize, QTimer, Qt, pyqtSignal
@@ -1096,6 +1097,43 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             ):
                 self.canvas_clicked.emit(event.xdata, event.ydata, self._press_modifiers)
         self._pan_start = None
+
+    def wheelEvent(self, event):
+        """Rescue the modified wheel event matplotlib declines to deliver (FIB-552).
+
+        `FigureCanvasQT.wheelEvent` reads only the *vertical* delta, and emits nothing at
+        all when it is zero — not a zero-magnitude scroll, nothing. macOS supplies exactly
+        that shape: AppKit turns Shift+wheel into *horizontal* scrolling at the system
+        level, before Qt sees it, so the magnitude arrives in `angleDelta().x()` with
+        `y() == 0`. Every Shift+scroll feature is then silently dead there — the objective
+        step, the working-distance nudge, and the correlation z-slice step, all three of
+        which open with `if "Shift" not in modifiers: return`.
+
+        Windows and Linux apply no such transform, so this branch never runs for them.
+        Trackpads take matplotlib's `pixelDelta` path and are unaffected either way.
+
+        Synthesised into a normal `scroll_event` rather than emitting `canvas_scrolled`
+        directly, which is what the retired `ImagePointCanvas` did: going through
+        `_on_scroll` keeps the in-axes check, the real `xdata`/`ydata`, and
+        modifier-suppresses-zoom, so every consumer is served with no per-widget flag. The
+        old shortcut also fired for Shift+wheel *outside* the image.
+
+        `modifiers=` is deliberately not passed: `_modifiers_from_event` reads the Qt
+        event off `guiEvent`, and the kwarg's private backing only exists in newer
+        matplotlib than the `>=3.7.0` pin. CI cannot catch that — it has no PyQt5, so the
+        Qt backend is never imported.
+        """
+        angle, pixel = event.angleDelta(), event.pixelDelta()
+        if angle.y() == 0 and pixel.y() == 0 and event.modifiers():
+            steps = (angle.x() / 120) or pixel.x()
+            if steps:
+                MouseEvent(
+                    "scroll_event", self, *self.mouseEventCoords(event),
+                    step=steps, guiEvent=event,
+                )._process()
+                event.accept()
+                return
+        super().wheelEvent(event)
 
     def _on_scroll(self, event):
         if event.inaxes is not self._ax or event.xdata is None:

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -125,6 +125,10 @@ _OVERLAY_ICON_SIZE = QSize(14, 14)
 _OVERLAY_BTN_SIZE = 22
 _OVERLAY_MARGIN = 4
 _OVERLAY_GAP = 2
+# How far below the widget's top edge the canvas's top labels (hint, title, flash) start:
+# clear of the toolbar row, which is `_OVERLAY_MARGIN` above buttons `_OVERLAY_BTN_SIZE`
+# tall, plus a gap. In *pixels*, because what they have to miss is measured in pixels.
+_TOP_CHROME_INSET = _OVERLAY_MARGIN + _OVERLAY_BTN_SIZE + 4
 # The "● LIVE" chip shares the toolbar row, so it takes the buttons' height and corner
 # radius; the green is the badge's own, not a button state.
 _LIVE_BADGE_STYLE = (
@@ -391,8 +395,8 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             self._hint_artist = None
         if self._hint_text:
             self._hint_artist = self._ax.text(
-                0.012, 0.985, self._hint_text,
-                transform=self._ax.transAxes, ha="left", va="top",
+                0.012, self._top_chrome_y(), self._hint_text,
+                transform=self.figure.transFigure, ha="left", va="top",
                 fontsize=8, color=NEUTRAL_900, zorder=11,
                 bbox=dict(boxstyle="round,pad=0.3", facecolor="#e6e6e6",
                           edgecolor="none", alpha=0.85),
@@ -417,6 +421,27 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._refresh_title()
         self.draw_idle()
 
+    def _top_chrome_y(self, extra_px: float = 0.0) -> float:
+        """Figure-fraction y for the canvas's top labels, clear of the toolbar row.
+
+        One rule for all three -- hint, title, flash -- so they share a row rather than
+        each picking a height. The hint used to be anchored in `transAxes` at the axes'
+        own top, which put it *above* the flash on a frame that filled its pane and
+        *below* it on a letterboxed one: the two labels swapped vertical order with the
+        image's aspect ratio, and a long hint ran under the toolbar buttons.
+
+        In figure coordinates, not axes: the toolbar buttons and the LIVE chip are laid
+        out in widget pixels, and the figure is edge-to-edge (`subplots_adjust(top=1)`)
+        so a figure fraction *is* a widget fraction. Anchoring here in `transAxes` is what
+        put this chrome on the same horizontal band as the chip, separated only by however
+        much room a centred string happened to leave -- which collided below about 560 px
+        of canvas width, and the FM pane in a 2x2 grid is narrower than that.
+
+        Recomputed on resize (see `resizeEvent`), since the inset is a pixel count.
+        """
+        height = max(float(self.figure.bbox.height), 1.0)
+        return 1.0 - (_TOP_CHROME_INSET + extra_px) / height
+
     def _refresh_title(self) -> None:
         """(Re)create the title artist from the cached text, or remove it."""
         if self._title_artist is not None:
@@ -427,8 +452,8 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             self._title_artist = None
         if self._title_text:
             self._title_artist = self._ax.text(
-                0.5, 0.985, self._title_text,
-                transform=self._ax.transAxes, ha="center", va="top",
+                0.5, self._top_chrome_y(), self._title_text,
+                transform=self.figure.transFigure, ha="center", va="top",
                 fontsize=10, color=WHITE_ICON_COLOR, zorder=11,
                 bbox=dict(boxstyle="round,pad=0.3", facecolor=_BG,
                           edgecolor="none", alpha=0.55),
@@ -514,8 +539,8 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             self._flash_artist = None
         if self._flash_text:
             self._flash_artist = self._ax.text(
-                0.5, 0.975, self._flash_text,
-                transform=self._ax.transAxes, ha="center", va="top",
+                0.5, self._top_chrome_y(4.0), self._flash_text,
+                transform=self.figure.transFigure, ha="center", va="top",
                 fontsize=9, color="#e8e8e8", zorder=12,
                 bbox=dict(boxstyle="round,pad=0.35", facecolor=_BG,
                           edgecolor=_ACCENT, linewidth=1.0, alpha=0.85),
@@ -686,6 +711,14 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
     def resizeEvent(self, event) -> None:
         super().resizeEvent(event)
         self._reposition_overlay_buttons()
+        # The top-centre chrome is inset by a pixel count, so its figure fraction has to
+        # be recomputed when the figure changes size or it drifts across the toolbar row.
+        if self._hint_text:
+            self._refresh_hint()
+        if self._title_text:
+            self._refresh_title()
+        if self._flash_text:
+            self._refresh_flash()
         contrast = getattr(self, "_contrast", None)
         if contrast is not None and contrast.isVisible():
             contrast.reposition()

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -438,8 +438,16 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         of canvas width, and the FM pane in a 2x2 grid is narrower than that.
 
         Recomputed on resize (see `resizeEvent`), since the inset is a pixel count.
+
+        Against the *widget's* height, not `figure.bbox.height`. matplotlib keeps the
+        figure bbox in **device** pixels, so on a Retina display it is twice the logical
+        height -- and the toolbar row this has to clear is `_OVERLAY_MARGIN` plus
+        `_OVERLAY_BTN_SIZE`, which Qt lays out in *logical* pixels. Dividing a logical
+        inset by a device height halved it, and the labels landed back inside the row on
+        exactly the machines that have a Retina screen. Both sides of the division are
+        logical now.
         """
-        height = max(float(self.figure.bbox.height), 1.0)
+        height = max(float(self.height()), 1.0)
         return 1.0 - (_TOP_CHROME_INSET + extra_px) / height
 
     def _refresh_title(self) -> None:

--- a/tests/ui/test_canvas_base.py
+++ b/tests/ui/test_canvas_base.py
@@ -19,6 +19,8 @@ import pytest
 
 pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
 
+from PyQt5.QtCore import QSize
+from PyQt5.QtGui import QResizeEvent
 from PyQt5.QtWidgets import QApplication
 
 from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase
@@ -29,6 +31,11 @@ _app = QApplication.instance() or QApplication(sys.argv)
 
 def _img(h, w):
     return np.zeros((h, w), dtype=np.uint8)
+
+
+def _resize_event(w, h):
+    """Offscreen, `resize()` does not deliver one on its own."""
+    return QResizeEvent(QSize(w, h), QSize(w, h))
 
 
 def test_image_canvas_is_a_base_canvas():
@@ -130,6 +137,120 @@ def test_the_toolbar_toggle_still_round_trips(noun):
     assert button.isChecked() is False and button.toolTip() == f"Show {noun}"
     toggle()
     assert button.isChecked() is True and button.toolTip() == f"Hide {noun}"
+
+
+class TestTheTopLabelsClearTheToolbarRow:
+    """The hint, title and flash sit along the canvas's top edge; the toolbar buttons and
+    the LIVE chip sit top-right. Anchoring the labels in `transAxes` and the controls in
+    widget pixels left them on one horizontal band, separated only by however much room a
+    centred string happened to leave — which ran out below about 560 px of canvas width,
+    and the FM pane in a 2x2 grid is narrower than that.
+
+    All three labels follow one rule now. The hint especially needed it: anchored at the
+    axes' own top it sat *above* the flash on a frame that filled its pane and *below* it
+    on a letterboxed one, so the two swapped order with the image's aspect ratio.
+
+    Same fault as the chip-under-the-toolbar one below, one slot along.
+    """
+
+    @staticmethod
+    def _canvas(w=460, h=380):
+        c = FibsemImageCanvas()
+        dpi = c.figure.dpi
+        # Both, and in this order: the figure drives the artists, the widget drives the
+        # chip. Offscreen, `resize` alone leaves the figure at its default and the two
+        # are then measured in different worlds.
+        c.figure.set_size_inches(w / dpi, h / dpi)
+        c.resize(w, h)
+        c.set_array(_img(512, 512), pixel_size=1e-8)
+        c.set_live_badge(True)
+        c._reposition_overlay_buttons()
+        return c
+
+    @staticmethod
+    def _rows_overlap(canvas, artist):
+        chip = canvas._live_badge.geometry()
+        bb = artist.get_window_extent(canvas.get_renderer())
+        h = canvas.height()
+        top, bottom = h - bb.y1, h - bb.y0  # matplotlib y is bottom-up
+        return bottom > chip.y() and top < chip.y() + chip.height()
+
+    @pytest.mark.parametrize("width", [360, 420, 480, 520, 560, 900])
+    def test_the_flash_never_shares_a_row_with_the_live_chip(self, width):
+        c = self._canvas(w=width)
+        c.flash_message("OBJ 6000.0 um  (+1.0 um)")
+        c.draw()
+
+        assert not self._rows_overlap(c, c._flash_artist)
+
+    @pytest.mark.parametrize("width", [360, 480, 900])
+    def test_the_title_never_shares_a_row_with_it_either(self, width):
+        """Same slot, same fault — a long z-slice caption would have collided too."""
+        c = self._canvas(w=width)
+        c.set_title("z 42 / 120")
+        c.draw()
+
+        assert not self._rows_overlap(c, c._title_artist)
+
+    @pytest.mark.parametrize("width", [360, 480, 900])
+    def test_the_hint_never_shares_a_row_with_it_either(self, width):
+        """Top-left, but a long enough hint reaches the buttons — and it was the one
+        anchored at the axes' top, so on a filling frame it sat level with them."""
+        c = self._canvas(w=width)
+        c.set_hint("Shift+scroll to focus the objective, double-click to move the stage")
+        c.draw()
+
+        assert not self._rows_overlap(c, c._hint_artist)
+
+    @pytest.mark.parametrize(
+        "image", [(512, 512), (512, 768), (768, 512)], ids=["square", "wide", "tall"]
+    )
+    def test_the_three_labels_share_a_row_whatever_the_aspect(self, image):
+        """The hint used to swap places with the flash depending on the image's aspect,
+        because one was anchored to the axes and the other to the figure."""
+        c = self._canvas(w=460, h=380)
+        c.set_array(_img(*image), pixel_size=1e-8)
+        c.set_hint("Shift+scroll to focus")
+        c.set_title("z 42 / 120")
+        c.flash_message("OBJ 6000.0 um  (+1.0 um)")
+        c.draw()
+
+        r = c.get_renderer()
+        tops = [
+            c.height() - a.get_window_extent(r).y1
+            for a in (c._hint_artist, c._title_artist, c._flash_artist)
+        ]
+        assert max(tops) - min(tops) < 10, f"labels scattered across {tops}"
+
+    def test_it_sits_below_the_toolbar_rather_than_above_it(self):
+        """Below, so it never covers a button. Above would clear the chip too."""
+        c = self._canvas()
+        c.flash_message("OBJ 6000.0 um")
+        c.draw()
+
+        bb = c._flash_artist.get_window_extent(c.get_renderer())
+        top = c.height() - bb.y1
+        assert top >= c._live_badge.geometry().y() + c._live_badge.height()
+
+    def test_shrinking_the_canvas_keeps_it_clear(self):
+        """The inset is a pixel count, so its figure fraction has to be recomputed when
+        the figure changes size or it drifts back across the toolbar row.
+
+        Shrinking, specifically. A stale fraction on a *taller* figure resolves to a
+        larger pixel inset and stays clear by luck — so growing proves nothing, and a
+        test that grew was the one this replaced.
+        """
+        c = self._canvas(w=460, h=900)
+        c.flash_message("OBJ 6000.0 um  (+1.0 um)")
+        c.draw()
+
+        dpi = c.figure.dpi
+        c.figure.set_size_inches(460 / dpi, 300 / dpi)
+        c.resize(460, 300)
+        c.resizeEvent(_resize_event(460, 300))
+        c.draw()
+
+        assert not self._rows_overlap(c, c._flash_artist)
 
 
 class TestTheLiveChipClearsTheToolbar:

--- a/tests/ui/test_canvas_base.py
+++ b/tests/ui/test_canvas_base.py
@@ -232,6 +232,32 @@ class TestTheTopLabelsClearTheToolbarRow:
         top = c.height() - bb.y1
         assert top >= c._live_badge.geometry().y() + c._live_badge.height()
 
+    @pytest.mark.parametrize("device_ratio", [1, 2], ids=["standard", "retina"])
+    def test_the_inset_is_logical_pixels_whatever_the_device_ratio(self, device_ratio):
+        """The bug the first fix shipped with, and the one this suite could not see.
+
+        matplotlib keeps `figure.bbox` in **device** pixels, so on a Retina display it is
+        twice the widget's logical height. The toolbar row the labels must clear is laid
+        out by Qt in *logical* pixels, so dividing a logical inset by a device height
+        halved it and put them back inside the row — on exactly the machines with a
+        Retina screen, which is every Mac and no CI runner.
+
+        Simulated by sizing the figure at `device_ratio` times the widget, which is what
+        the Qt backend does. Offscreen the real ratio is always 1, so the situation
+        cannot be reached any other way.
+        """
+        c = FibsemImageCanvas()
+        dpi = c.figure.dpi
+        c.resize(460, 380)
+        c.figure.set_size_inches(460 * device_ratio / dpi, 380 * device_ratio / dpi)
+
+        inset_logical = (1.0 - c._top_chrome_y()) * c.height()
+
+        assert inset_logical == pytest.approx(30.0), (
+            f"inset came out {inset_logical:.1f} logical px at device ratio "
+            f"{device_ratio}; the toolbar row it must clear is 26"
+        )
+
     def test_shrinking_the_canvas_keeps_it_clear(self):
         """The inset is a pixel count, so its figure fraction has to be recomputed when
         the figure changes size or it drifts back across the toolbar row.

--- a/tests/ui/test_focus_flash.py
+++ b/tests/ui/test_focus_flash.py
@@ -1,0 +1,192 @@
+"""Shift+scroll on the FM canvas says where the objective is going (FIB-635),
+and the gesture reaches the canvas at all on a macOS mouse (FIB-552).
+
+The beam canvases have flashed the working distance on this gesture since the quad view
+shipped. The FM -- the canvas you focus by while watching the stream -- showed nothing,
+and its info-bar `OBJECTIVE` field is deliberately behind during a burst, because
+FIB-625's `_wheel_is_driving` suppresses the intermediates rather than let the number
+snap backwards past the user's own scrolling.
+
+Underneath both: `FigureCanvasQT.wheelEvent` reads only the vertical delta and emits
+*nothing* when it is zero, while macOS turns Shift+wheel into horizontal scrolling before
+Qt sees it. Every Shift+scroll feature was silently dead there.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtCore import QPoint, Qt
+from PyQt5.QtGui import QWheelEvent
+from PyQt5.QtWidgets import QApplication, QWidget
+
+import numpy as np
+
+from fibsem.constants import METRE_TO_MICRON
+from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.ui.fm.widgets.objective_control_widget import ObjectiveControlWidget
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+class _Host(QWidget):
+    is_acquisition_active = False
+    viewer = None
+    microscope = None
+
+    def _view_controller(self):
+        return None
+
+
+@pytest.fixture
+def fm():
+    return FluorescenceMicroscope()
+
+
+@pytest.fixture
+def widget(fm):
+    w = ObjectiveControlWidget(fm, parent=_Host())
+    yield w
+    w.cleanup()
+    w.close()
+
+
+@pytest.fixture
+def canvas():
+    c = FibsemImageCanvas()
+    c.resize(400, 400)
+    c.set_array(np.zeros((64, 64), dtype=np.uint8), pixel_size=1e-8)
+    return c
+
+
+def _wheel(dx: int, dy: int, modifiers=Qt.ShiftModifier) -> QWheelEvent:
+    """A wheel event with the delta on the axis of our choosing.
+
+    macOS puts a Shift+wheel magnitude on x with y zero; Windows and Linux put it on y.
+    """
+    pos = QPoint(200, 200)
+    return QWheelEvent(
+        pos, pos, QPoint(0, 0), QPoint(dx, dy), Qt.NoButton, modifiers,
+        Qt.NoScrollPhase, False,
+    )
+
+
+class TestTheGestureSurvivesAHorizontalDelta:
+    """FIB-552. Not reproducible on this machine's platform alone -- the event is
+    synthesised in the shape macOS delivers, which is the only part that differs."""
+
+    def test_a_horizontal_shift_wheel_reaches_the_canvas(self, canvas):
+        seen = []
+        canvas.canvas_scrolled.connect(lambda x, y, d, m: seen.append((d, m)))
+
+        canvas.wheelEvent(_wheel(dx=120, dy=0))
+
+        assert seen, "matplotlib dropped it and nothing rescued it (FIB-552)"
+        direction, mods = seen[0]
+        assert direction == 1
+        assert "Shift" in mods
+
+    def test_the_direction_follows_the_sign(self, canvas):
+        seen = []
+        canvas.canvas_scrolled.connect(lambda x, y, d, m: seen.append(d))
+
+        canvas.wheelEvent(_wheel(dx=-120, dy=0))
+
+        assert seen == [-1]
+
+    def test_a_normal_vertical_wheel_is_untouched(self, canvas):
+        """Windows and Linux take this path, and it must keep going through
+        matplotlib rather than the rescue."""
+        seen = []
+        canvas.canvas_scrolled.connect(lambda x, y, d, m: seen.append(d))
+
+        canvas.wheelEvent(_wheel(dx=0, dy=120))
+
+        assert seen == [1]
+
+    def test_an_unmodified_horizontal_wheel_is_left_alone(self, canvas):
+        """The rescue is scoped to modified scrolls. A bare horizontal wheel is a
+        legitimate no-op, not something to synthesise a zoom out of."""
+        seen = []
+        canvas.canvas_scrolled.connect(lambda x, y, d, m: seen.append(d))
+
+        canvas.wheelEvent(_wheel(dx=120, dy=0, modifiers=Qt.NoModifier))
+
+        assert seen == []
+
+
+class TestTheFlashSaysWhereItIsGoing:
+    """FIB-635."""
+
+    @pytest.fixture(autouse=True)
+    def _wire(self, widget, canvas):
+        """Connect once. Qt permits duplicate connections, so reconnecting per scroll
+        would fire the handler once per previous call and the objective would run away."""
+        canvas.canvas_scrolled.connect(widget._on_canvas_scroll)
+
+    @staticmethod
+    def _scroll(widget, canvas, direction=+1):
+        """Drive the handler the way the canvas does, so `sender()` resolves."""
+        canvas.canvas_scrolled.emit(0.0, 0.0, direction, ("Shift",))
+
+    def test_it_flashes_the_target_and_the_step(self, fm, widget, canvas):
+        widget.doubleSpinBox_objective_step_size.setValue(1.0)
+        base = widget.doubleSpinBox_objective_position.value()
+
+        self._scroll(widget, canvas)
+
+        assert canvas._flash_text == f"OBJ {base + 1.0:.1f} um  (+1.0 um)"
+
+    def test_the_step_is_signed_so_it_shows_direction(self, fm, widget, canvas):
+        widget.doubleSpinBox_objective_step_size.setValue(2.5)
+
+        self._scroll(widget, canvas, direction=-1)
+
+        assert "(-2.5 um)" in canvas._flash_text
+
+    def test_it_shows_the_step_currently_set_not_the_distance_travelled(
+        self, fm, widget, canvas
+    ):
+        """The point of showing it: the step is what silently changes what the gesture
+        means. Three notches at 1 um is still '+1.0 um', not '+3.0 um'."""
+        widget.doubleSpinBox_objective_step_size.setValue(1.0)
+        base = widget.doubleSpinBox_objective_position.value()
+
+        for _ in range(3):
+            self._scroll(widget, canvas)
+
+        assert canvas._flash_text == f"OBJ {base + 3.0:.1f} um  (+1.0 um)"
+
+    def test_a_refused_scroll_flashes_nothing(self, fm, widget, canvas):
+        """Nothing is going anywhere, so there is no target to show."""
+        widget._action_worker = object()  # a retract in flight
+
+        self._scroll(widget, canvas)
+
+        assert canvas._flash_text is None
+
+    def test_a_plain_scroll_flashes_nothing(self, fm, widget, canvas):
+        canvas.canvas_scrolled.emit(0.0, 0.0, +1, ())
+
+        assert canvas._flash_text is None
+
+    def test_it_does_not_disturb_the_info_bar(self, fm, widget, canvas):
+        """The two surfaces answer different questions -- the flash is the command,
+        the info bar is the device -- so the flash must not write the field."""
+        canvas.set_info_text("OBJECTIVE: 0.0 um")
+
+        self._scroll(widget, canvas)
+
+        assert canvas._info_text == "OBJECTIVE: 0.0 um"
+
+    def test_no_canvas_is_not_an_error(self, fm, widget):
+        """The napari host has no `FibsemCanvas` behind the callback, and the standalone
+        objective widget has no host at all."""
+        widget._flash_focus_target(1.0, 1.0)  # sender() is None here; must not raise


### PR DESCRIPTION
Closes FIB-635 and FIB-552. Three commits: make the gesture work, say what it did, then give the canvas's top labels somewhere coherent to say it from.

## FIB-552 — Shift+scroll is dead on a macOS mouse

`FigureCanvasQT.wheelEvent` reads only the vertical delta, on both branches, and `if steps:` means a zero vertical delta emits **no** `scroll_event` at all — not a zero-magnitude one, nothing. AppKit turns Shift+wheel into *horizontal* scrolling before Qt sees it, so the magnitude arrives in `angleDelta().x()` with `y() == 0`.

Three features fail identically, all opening with `if "Shift" not in modifiers: return`: the objective step, the working-distance nudge, and the correlation z-slice step. The retired `ImagePointCanvas` had a workaround — that was FIB-323's fix — and it died with the file in FIB-535 with nothing replacing it.

Synthesised into a normal `scroll_event` rather than emitting `canvas_scrolled` directly, so `_on_scroll` still applies the in-axes check, real `xdata`/`ydata`, and modifier-suppresses-zoom. All three consumers are served with no per-widget flag; the old shortcut also fired for Shift+wheel *outside* the image.

### Effect on Windows and Linux

The branch needs **all** of `angle.y() == 0`, `pixel.y() == 0`, a modifier held, and a non-zero horizontal magnitude. Shift+wheel there arrives as a vertical delta, so the first condition fails and it falls straight to `super().wheelEvent`. Every event that *does* enter the branch is one matplotlib was about to discard entirely. Strictly additive: it can turn a no-op into an event, and cannot alter, suppress or double one that already worked.

**The one real change off macOS:** a tilt-wheel mouse tilted horizontally *with a modifier held* will now step the objective where before it did nothing. Narrow, and the action is the intended one, but untested on that hardware. A `sys.platform == "darwin"` gate would remove it — deliberately not added, because a platform gate means the path is only ever exercised by Mac users and rots quietly.

## FIB-635 — the FM canvas says nothing while you focus

Beam canvases flash `WD 4.001 mm` on this gesture. `flash_message` had exactly one caller; the FM — the canvas you focus by while watching the stream — showed nothing.

Not a duplicate of the `OBJECTIVE` field FIB-596 put in the info bar. That reports where the objective **is**: persistent, device-truthful, and deliberately behind during a burst, because `_wheel_is_driving` suppresses the intermediates rather than let the number snap backwards past your own scrolling (FIB-625). The flash is the **command** — where the next move is headed — which is why a target is right there and transient is the right lifetime. Writing the target into the info bar instead would blur exactly the distinction `_wheel_is_driving` exists to hold.

```
OBJ 6000.0 um  (+1.0 um)
```

The step is included because it is the one piece of state that silently changes what the gesture means: leave it at 50 µm, come back later, and the first notch jumps 50. It is the **current step, not the distance travelled** — three notches at 1 µm still reads `(+1.0 um)` — and it is signed, so it doubles as a direction indicator.

## Then the flash landed on the LIVE chip

Third commit. The same fault the chip itself had against the toolbar buttons, one slot along: labels anchored in `transAxes`, controls in widget pixels, one horizontal band, and nothing between them but a centred string's leftover margin. **Measured to collide below ~560 px of canvas width** — an FM pane in a 2x2 grid is narrower than that, so it collided every time.

All three top labels — hint, title, flash — now follow one rule: figure coordinates, inset past the same constants that place the buttons. Below the toolbar, so they can never cover a button either.

The hint mattered as much as the flash and was nearly missed. Anchored at the *axes'* top it sat at 6 px on a frame that filled its pane — level with the buttons, and a long hint ran under them — and at 41 px on a letterboxed one, so the top-left and top-centre labels swapped vertical order with the image's aspect ratio. All three measure 30/30/34 now, unchanged across aspects and pane sizes.

Two deliberate consequences: the top labels are widget-anchored, so on a letterboxed frame they sit over the border rather than the image, exactly as the toolbar already does. And the canvas now has two conventions — top chrome anchored to the widget because it must miss widget-anchored controls, bottom chrome (info bar, scalebar) to the image because nothing competes down there.

Bottom-centre was considered for the flash and rejected **on a render, not an argument**: the info bar's two lines run well past centre and the flash lands on them. Every position on this canvas is taken.

## Testing

23 tests. Mutation-checked:

| mutant | fails |
|---|---|
| no macOS rescue | 2 |
| no flash | 3 |
| flash without the step | 3 |
| flash back in axes coords | 7 |
| title back in axes coords | 3 |
| hint back in axes coords | 6 |
| no recompute on resize | 1 |

Three pin what must **not** change: a normal vertical wheel still goes through matplotlib untouched, an unmodified horizontal wheel is still a no-op, and the flash never writes the info-bar field.

`tests/ui/` + `tests/fm/` — 1970 passed, 1 skipped. Note CI is blind to the wheel behaviour: no PyQt5 there, so the Qt backend never imports and these skip.
