### PR TITLE
[ui] Overview defaults, a pre-flight, and layers that do not hide each other (FIB-619/630/631)

### DIFF
--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -741,6 +741,23 @@ class ImageSettings:
             isinstance(self.reduced_area, FibsemRectangle) or self.reduced_area is None
         ), f"reduced area must be a fibsemRectangle object, currently is {type(self.reduced_area)}"
 
+    @property
+    def scan_time(self) -> float:
+        """Seconds of beam-on time for one frame at these settings.
+
+        Dwell time per pixel, over every pixel, times the passes each one gets. Line and
+        frame integration both re-scan: `line_integration` sweeps each line N times,
+        `frame_integration` acquires and averages N frames. `scan_interlacing` changes
+        the order lines are visited in, not how many are visited, so it does not appear.
+
+        Scan time, not run time: it excludes flyback, autocontrast, saving, and -- for a
+        tileset -- the stage, which dominates. `OverviewAcquisitionSettings.scan_time`
+        says more about why that last one is left out rather than guessed at.
+        """
+        width, height = self.resolution
+        passes = (self.line_integration or 1) * (self.frame_integration or 1)
+        return self.dwell_time * width * height * passes
+
     @staticmethod
     def from_dict(settings: dict) -> "ImageSettings":
         if "reduced_area" in settings and settings["reduced_area"] is not None:
@@ -925,6 +942,26 @@ class OverviewAcquisitionSettings:
         if self.tile_mask is None:
             return self.nrows * self.ncols
         return sum(1 for row in self.tile_mask for enabled in row if enabled)
+
+    @property
+    def scan_time(self) -> float:
+        """Seconds of beam-on time for the whole overview.
+
+        Counts the tiles a run would actually acquire, not the grid's shape: a masked
+        overview scans only what is enabled, and reporting the full grid would overstate
+        a typical sparse selection roughly threefold.
+
+        Deliberately **scan time only**, and not an estimate of how long a run will take.
+        The two differ by a lot: a 3 x 3 tileset of 1024 x 1024 pixels at 1 us scans for
+        about 9 seconds and takes minutes, because the stage has to move and settle
+        eight times in between. That missing term is not something to guess at --
+        `fibsem/fm/timing.py` assumes 5 seconds per stage move, which nobody has
+        measured, and a total built on it would be mostly that assumption quoted as
+        though it were arithmetic. This is arithmetic, so it is reported under its own
+        name, and answers what the number is consulted for: whether the dwell time and
+        resolution just chosen make a run of seconds or of hours.
+        """
+        return self.image_settings.scan_time * self.n_enabled_tiles
 
     @property
     def total_fov_x(self) -> float:

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -51,7 +51,6 @@ from fibsem.structures import (
     BeamType,
     FibsemImage,
     FibsemStagePosition,
-    ImageSettings,
     OverviewAcquisitionSettings,
     Point,
 )
@@ -86,6 +85,7 @@ from fibsem.ui.widgets.custom_widgets import (
 from fibsem.applications.autolamella.ui.lamella_name_list_widget import LamellaNameListWidget
 from fibsem.ui.widgets.overview_acquisition_settings_widget import (
     OverviewAcquisitionSettingsWidget,
+    default_overview_acquisition_settings,
 )
 
 if TYPE_CHECKING:
@@ -93,14 +93,6 @@ if TYPE_CHECKING:
 
 
 COLOURS = CORRELATION_IMAGE_LAYER_PROPERTIES["colours"]
-
-OVERVIEW_IMAGE_PARAMETERS = {
-    "nrows": 3,
-    "ncols": 3,
-    "fov": 500, # um
-    "dwell_time": 1.0, # us
-    "autocontrast": True,
-}
 
 # Crosshair layer configuration constants
 CROSSHAIR_CONFIG = {
@@ -149,20 +141,6 @@ LABEL_INSTRUCTIONS = {
     "image-available": "Instructions: \nRight Click to Add/Move a Lamella Position or Double Click to Move the Stage...",
     "no-image": "Please take or load an overview image..."
 }
-DEFAULT_OVERVIEW_ACQUISITION_SETTINGS = OverviewAcquisitionSettings(
-    image_settings=ImageSettings(
-        hfw=OVERVIEW_IMAGE_PARAMETERS["fov"] * constants.MICRO_TO_SI,
-        dwell_time=OVERVIEW_IMAGE_PARAMETERS["dwell_time"] * constants.MICRO_TO_SI,
-        autocontrast=OVERVIEW_IMAGE_PARAMETERS["autocontrast"],
-        beam_type=BeamType.ELECTRON,
-        save=True,
-        path=None,  # will be set to experiment path when overview acquisition widget is initialized
-        filename="overview-image",
-    ),
-    nrows=OVERVIEW_IMAGE_PARAMETERS["nrows"],
-    ncols=OVERVIEW_IMAGE_PARAMETERS["ncols"],
-)
-
 
 def generate_gridbar_image(shape: Tuple[int, int], pixelsize: float, spacing: float, width: float) -> FibsemImage:
     """Generate an synthetic image of cryo gridbars."""
@@ -487,9 +465,9 @@ class FibsemMinimapWidget(QWidget):
         if self.parent_widget.experiment is None:
             raise ValueError("Experiment in parent widget is None, cannot proceed.")
 
-        path = str(self.parent_widget.experiment.path)
-        DEFAULT_OVERVIEW_ACQUISITION_SETTINGS.image_settings.path = path
-        self.overview_acquisition_widget.update_from_settings(DEFAULT_OVERVIEW_ACQUISITION_SETTINGS)
+        settings = default_overview_acquisition_settings()
+        settings.image_settings.path = str(self.parent_widget.experiment.path)
+        self.overview_acquisition_widget.update_from_settings(settings)
         try:
             self.parent_widget.experiment.positions.events.disconnect(self._on_experiment_position_changed) # type: ignore
         except Exception:

--- a/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
@@ -4,16 +4,16 @@ House style: a meta line, count chips, a detail block, a duration broken down by
 it goes, and a primary action in the footer. Each fact appears once — the window title
 is the heading, the Channels row is the channel count, and the skipped chip is what
 "sparse" would have said.
+
+The style itself now lives in `fibsem.ui.widgets.preflight`, lifted out when the third
+dialog in this shape appeared — as the second one's docstring said to do.
 """
 
 from typing import List, Optional
 
-from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
     QDialog,
-    QFrame,
     QHBoxLayout,
-    QLabel,
     QPushButton,
     QVBoxLayout,
     QWidget,
@@ -31,40 +31,13 @@ from fibsem.fm.structures import (
 from fibsem.fm.timing import estimate_tileset_acquisition_time
 from fibsem.structures import TileOrderStrategy
 from fibsem.ui import stylesheets
-
-BACKGROUND = stylesheets.SURFACE_COLOR
-PANEL = stylesheets.PANEL_COLOR
-BORDER = stylesheets.BORDER_COLOR
-TEXT = stylesheets.TEXT_COLOR
-TEXT_STRONG = stylesheets.TEXT_STRONG_COLOR
-TEXT_MUTED = stylesheets.TEXT_MUTED_COLOR
-
-def format_duration(seconds: float) -> str:
-    """`2m 14s`, `1h 03m`, `45s` — whichever reads best at that magnitude."""
-    seconds = int(round(seconds))
-    if seconds < 60:
-        return f"{seconds}s"
-    if seconds < 3600:
-        return f"{seconds // 60}m {seconds % 60:02d}s"
-    return f"{seconds // 3600}h {(seconds % 3600) // 60:02d}m"
-
-
-def _chip(text: str) -> QWidget:
-    """Plain pill label. No status dot: these are counts, not states, and a colour
-    that does not encode anything reads as though it does."""
-    chip = QFrame()
-    chip.setStyleSheet(
-        f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER};"
-        f" border-radius: 10px; }}"
-    )
-    layout = QHBoxLayout(chip)
-    layout.setContentsMargins(10, 3, 10, 3)
-    layout.setSpacing(0)
-
-    label = QLabel(text)
-    label.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
-    layout.addWidget(label)
-    return chip
+from fibsem.ui.widgets.preflight import (
+    BACKGROUND,
+    chip,
+    detail_block,
+    format_duration,
+    meta_label,
+)
 
 
 class FMOverviewConfirmationDialog(QDialog):
@@ -217,40 +190,18 @@ class FMOverviewConfirmationDialog(QDialog):
         # No in-dialog heading: the window title already says "Start Overview
         # Acquisition", and repeating it 8px below costs a line and says nothing. The
         # meta line leads instead, so it carries normal text weight rather than muted.
-        meta = QLabel(self._meta_line())
-        meta.setStyleSheet(f"color: {TEXT_STRONG}; font-size: 12px;")
-        meta.setWordWrap(True)
+        meta = meta_label(self._meta_line())
 
         # Tile counts only. The channel count was a third chip, but the Channels row
         # below lists them by name -- the chip added a number, not information.
         chips = QHBoxLayout()
         chips.setSpacing(6)
-        chips.addWidget(_chip(f"{acquired} to acquire"))
+        chips.addWidget(chip(f"{acquired} to acquire"))
         if acquired != total:
-            chips.addWidget(_chip(f"{total - acquired} skipped"))
+            chips.addWidget(chip(f"{total - acquired} skipped"))
         chips.addStretch()
 
-        detail = QFrame()
-        detail.setStyleSheet(
-            f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER};"
-            f" border-radius: 4px; }}"
-        )
-        detail_layout = QVBoxLayout(detail)
-        detail_layout.setContentsMargins(12, 10, 12, 10)
-        detail_layout.setSpacing(6)
-        for label_text, value_text in self._rows():
-            row = QHBoxLayout()
-            row.setSpacing(12)
-            label = QLabel(label_text)
-            label.setStyleSheet(
-                f"color: {TEXT_MUTED}; font-size: 11px; border: none;")
-            label.setFixedWidth(96)
-            value = QLabel(value_text)
-            value.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
-            value.setWordWrap(True)
-            row.addWidget(label, alignment=Qt.AlignTop)
-            row.addWidget(value, stretch=1)
-            detail_layout.addLayout(row)
+        detail = detail_block(self._rows())
 
         self.button_start = QPushButton("Start Acquisition")
         self.button_start.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)

--- a/fibsem/ui/widgets/coincidence_milling_confirmation_dialog.py
+++ b/fibsem/ui/widgets/coincidence_milling_confirmation_dialog.py
@@ -6,9 +6,8 @@ config dict — developer output in the one place an operator checks depth and c
 before committing.
 
 Same house style as :class:`FMOverviewConfirmationDialog`: a meta line, count chips, a
-detail block, and a primary action in the footer — with the visual constants, chip and
-duration format imported from it so the two cannot drift. If a third of these appears,
-lift the shared parts into their own module.
+detail block, and a primary action in the footer — built from
+`fibsem.ui.widgets.preflight` so the three cannot drift.
 
 Milling is irreversible, so the primary action is never the default button: starting
 takes a deliberate click.
@@ -16,12 +15,9 @@ takes a deliberate click.
 
 from typing import List, Optional, Tuple
 
-from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
     QDialog,
-    QFrame,
     QHBoxLayout,
-    QLabel,
     QPushButton,
     QVBoxLayout,
     QWidget,
@@ -31,17 +27,13 @@ from fibsem import constants
 from fibsem.milling.base import FibsemMillingStage
 from fibsem.milling.tasks import FibsemMillingTaskConfig
 from fibsem.ui import stylesheets
-from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
-    BORDER,
-    PANEL,
-    TEXT,
-    TEXT_MUTED,
-    TEXT_STRONG,
-    _chip,
+from fibsem.ui.widgets.preflight import (
+    BACKGROUND,
+    chip,
+    detail_block,
     format_duration,
+    meta_label,
 )
-
-BACKGROUND = stylesheets.SURFACE_COLOR
 
 # The dimensions that determine the milled volume, in the order they read. Driven off
 # the pattern's own to_dict() rather than isinstance checks, so a new pattern type
@@ -214,54 +206,33 @@ class CoincidenceMillingConfirmationDialog(QDialog):
         enabled = len(self.task_config.enabled_stages)
         total = len(self.task_config.stages)
 
-        meta = QLabel(self._meta_line())
-        meta.setStyleSheet(f"color: {TEXT_STRONG}; font-size: 12px;")
-        meta.setWordWrap(True)
+        meta = meta_label(self._meta_line())
 
         # Counts first, then the two facts worth reading before anything else: what
         # current is going into the sample, and whether it will stop for you. The FM
-        # dialog uses chips only for counts; these are states, but `_chip` carries no
+        # dialog uses chips only for counts; these are states, but a chip carries no
         # colour, so a state here reads as a fact rather than as a status light.
         chips = QHBoxLayout()
         chips.setSpacing(6)
-        chips.addWidget(_chip(f"{enabled} to mill"))
+        chips.addWidget(chip(f"{enabled} to mill"))
         if enabled != total:
-            chips.addWidget(_chip(f"{total - enabled} disabled"))
+            chips.addWidget(chip(f"{total - enabled} disabled"))
         current_text = self._current_chip_text()
         if current_text:
-            chips.addWidget(_chip(current_text))
+            chips.addWidget(chip(current_text))
         config = self._strategy_config()
         if config is not None:
             # "Automated", not "Unattended" or "Unsupervised": that is what the
             # supervision toggle a few pixels away already says (_update_supervised_button),
             # and what the border state is called. A third word for one mode is worse
             # than an imperfect one.
-            chips.addWidget(_chip("Supervised" if config.supervised else "Automated"))
+            chips.addWidget(chip("Supervised" if config.supervised else "Automated"))
         chips.addStretch()
 
-        detail = QFrame()
-        detail.setStyleSheet(
-            f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER};"
-            f" border-radius: 4px; }}"
-        )
-        detail_layout = QVBoxLayout(detail)
-        detail_layout.setContentsMargins(12, 10, 12, 10)
-        detail_layout.setSpacing(6)
-        for label_text, value_text in self._rows():
-            row = QHBoxLayout()
-            row.setSpacing(12)
-            label = QLabel(label_text)
-            label.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px; border: none;")
-            label.setFixedWidth(104)
-            # Stage names go in this column and are user-supplied, so wrap rather than
-            # clip — a truncated stage name in a pre-flight check is worse than two lines.
-            label.setWordWrap(True)
-            value = QLabel(value_text)
-            value.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
-            value.setWordWrap(True)
-            row.addWidget(label, alignment=Qt.AlignTop)
-            row.addWidget(value, stretch=1)
-            detail_layout.addLayout(row)
+        # Wider labels than the other two, and wrapping: stage names go in this column
+        # and are user-supplied, so a truncated one in a pre-flight check is worse than
+        # two lines.
+        detail = detail_block(self._rows(), label_width=104, wrap_labels=True)
 
         self.button_start = QPushButton("Start Milling")
         self.button_start.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)

--- a/fibsem/ui/widgets/overview_acquisition_settings_widget.py
+++ b/fibsem/ui/widgets/overview_acquisition_settings_widget.py
@@ -16,11 +16,47 @@ from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel, ValueComboBox, ValueSpinBox
 from fibsem.ui.widgets.image_settings_widget import ImageSettingsWidget
 
-# What a tileset is called if nobody says otherwise. `ImageSettings` defaults to
-# "default_image", which is a fine name for one image and a poor one for a run: the
-# tiled runner names the tile sub-folder after it, so every overview of every
-# experiment lands in a directory called `default_image`.
+# What an overview run looks like before anyone touches it.
+#
+# House defaults rather than physics: a 500 um tile and a 1 us dwell are what the napari
+# minimap has always opened with. They lived in that module, which is scheduled for
+# deletion, and nothing on the rebuilt path referenced them -- so the tab opened at
+# `ImageSettings`'s generic values instead: a 150 um tile, autocontrast off, and a run
+# called "default_image".
+#
+# The name is the one that bites. `TiledAcquisitionRunner._setup` makes the tile
+# sub-folder from it, so it decides where every overview of every experiment is written.
+OVERVIEW_TILE_HFW = 500e-6  # m
+OVERVIEW_TILE_DWELL_TIME = 1e-6  # s
 DEFAULT_OVERVIEW_FILENAME = "overview-image"
+
+
+def default_overview_acquisition_settings() -> OverviewAcquisitionSettings:
+    """A fresh set of overview settings, seeded with the house defaults.
+
+    A function, not the module-level constant it replaces. The minimap held one of those
+    and assigned an experiment path straight into it
+    (`DEFAULT_OVERVIEW_ACQUISITION_SETTINGS.image_settings.path = path`), which edits the
+    default for everything built afterwards. `ImageSettingsWidget` compounds it:
+    `update_from_settings` keeps the object it is handed and `get_settings` mutates and
+    returns that same one, so a shared default would be rewritten by every keystroke in
+    the tab.
+
+    The grid size is not named here -- `OverviewAcquisitionSettings` already defaults to
+    3 x 3, and stating it twice is how the two drift apart.
+    """
+    return OverviewAcquisitionSettings(
+        image_settings=ImageSettings(
+            resolution=tuple(int(px) for px in DEFAULT_SQUARE_RESOLUTION.split("x")),
+            hfw=OVERVIEW_TILE_HFW,
+            dwell_time=OVERVIEW_TILE_DWELL_TIME,
+            autocontrast=True,
+            beam_type=BeamType.ELECTRON,
+            save=True,
+            path=None,  # whoever owns the experiment fills this in
+            filename=DEFAULT_OVERVIEW_FILENAME,
+        ),
+    )
 
 
 class OverviewAcquisitionSettingsWidget(QWidget):
@@ -39,6 +75,8 @@ class OverviewAcquisitionSettingsWidget(QWidget):
         # No control for this yet -- see the `tile_mask` property.
         self._tile_mask: Optional[List[List[bool]]] = None
         self._setup_ui()
+        # Before `_connect_signals`, so seeding the boxes does not read as a user edit.
+        self.update_from_settings(default_overview_acquisition_settings())
         self._connect_signals()
         self._update_total_fov_label()
         self._update_advanced_visibility()
@@ -64,10 +102,9 @@ class OverviewAcquisitionSettingsWidget(QWidget):
 
         # Rows / cols
         grid_layout.addWidget(QLabel("Tiles (rows x cols)"), 1, 0)
+        # Values come from the seed in `__init__`, not from here.
         self.nrows_spinbox = ValueSpinBox(minimum=1, maximum=15, step=1, decimals=0)
-        self.nrows_spinbox.setValue(3)
         self.ncols_spinbox = ValueSpinBox(minimum=1, maximum=15, step=1, decimals=0)
-        self.ncols_spinbox.setValue(3)
         # Two spinboxes share one grid cell here, so they are the first thing a narrow
         # column squeezes -- and below about 80px the +/- buttons take the whole
         # control and the number stops being drawn at all, leaving what looks like a
@@ -155,8 +192,6 @@ class OverviewAcquisitionSettingsWidget(QWidget):
         )
         self.image_settings_widget.hfw_label.setText("Field of View")
         self.image_settings_widget.set_show_advanced_button(False)
-        # Before `_connect_signals`, so seeding the box does not read as a user edit.
-        self.image_settings_widget.filename_edit.setText(DEFAULT_OVERVIEW_FILENAME)
 
         # All standard + square resolutions are supported (non-square aspect handled in acquisition)
         self.image_settings_widget.set_available_resolutions(AVAILABLE_RESOLUTIONS_ZIP, default=DEFAULT_SQUARE_RESOLUTION)

--- a/fibsem/ui/widgets/overview_confirmation_dialog.py
+++ b/fibsem/ui/widgets/overview_confirmation_dialog.py
@@ -1,0 +1,173 @@
+"""Pre-flight summary for a FIB/SEM overview acquisition.
+
+The beam tab had nothing: pressing Run started driving the stage. That mattered less
+when a run was always centred under the stage and always acquired every tile, and it
+stopped being true twice — the grid can be dragged somewhere else (FIB-617) and tiles
+can be masked off (FIB-618). Both are set on the canvas, silently, and both survive a
+tab switch. This is the last place either announces itself.
+
+Same house style as the fluorescence and coincidence dialogs, from the same module, so
+the three cannot drift: a meta line, count chips, a detail block, a primary action in
+the footer.
+"""
+
+from typing import List, Optional, Tuple
+
+from PyQt5.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem import constants
+from fibsem.structures import OverviewAcquisitionSettings
+from fibsem.ui import stylesheets
+from fibsem.ui.widgets.preflight import (
+    BACKGROUND,
+    chip,
+    detail_block,
+    format_duration,
+    meta_label,
+)
+
+
+class OverviewConfirmationDialog(QDialog):
+    """Confirm an overview before it runs, with what it will do."""
+
+    def __init__(
+        self,
+        settings: OverviewAcquisitionSettings,
+        view_description: Optional[str] = None,
+        offset: Optional[Tuple[float, float]] = None,
+        parent: Optional[QWidget] = None,
+    ):
+        """
+        Args:
+            settings: what the run will use — already deep-copied by the caller, so the
+                numbers shown are the numbers handed to the runner.
+            view_description: the beam and the stage orientation, spelled out. Passed in
+                rather than derived: the tab knows the pose it has cached, and reading it
+                here would be a hardware call on a dialog opening.
+            offset: how far the grid's centre sits from the stage, in metres (dx, dy).
+                None means it is centred on the stage, which is also what the runner
+                falls back to.
+        """
+        super().__init__(parent)
+        self.settings = settings
+        self.view_description = view_description
+        self.offset = offset
+
+        self.setWindowTitle("Start Overview Acquisition")
+        self.setMinimumWidth(430)
+        self.setStyleSheet(f"QDialog {{ background: {BACKGROUND}; }}")
+        self._init_ui()
+
+    # ── content ──────────────────────────────────────────────────────────
+
+    def _meta_line(self) -> str:
+        s = self.settings
+        sym = constants.MICRON_SYMBOL
+        return " · ".join([
+            f"{s.nrows} × {s.ncols} grid",
+            f"{s.overlap:.0%} overlap",
+            f"{s.total_fov_x * constants.SI_TO_MICRO:.0f} × "
+            f"{s.total_fov_y * constants.SI_TO_MICRO:.0f} {sym}",
+            f"{s.tile_order.value} order",
+        ])
+
+    def _centre_text(self) -> str:
+        """Where the grid sits, in the terms it was placed in.
+
+        Components rather than a distance: the grid is dragged in x and y and checked
+        against the canvas in x and y, and "520 µm away" does not say which way.
+        """
+        if self.offset is None:
+            return "the stage position"
+        dx, dy = (v * constants.SI_TO_MICRO for v in self.offset)
+        sym = constants.MICRON_SYMBOL
+        # Under a micron in both is the grid sitting on the stage as far as anything
+        # here is concerned, and floating-point dust should not read as a dragged grid.
+        if abs(dx) < 1.0 and abs(dy) < 1.0:
+            return "the stage position"
+        return f"{dx:+.0f}, {dy:+.0f} {sym} from the stage position"
+
+    def _rows(self) -> List[Tuple[str, str]]:
+        """Label/value pairs for the detail block."""
+        s = self.settings
+        image = s.image_settings
+        sym = constants.MICRON_SYMBOL
+        width, height = image.resolution
+
+        detail: List[Tuple[str, str]] = []
+        if self.view_description:
+            detail.append(("Acquired in", self.view_description))
+        detail.append(("Centred on", self._centre_text()))
+        detail.append((
+            "Tile",
+            f"{width} × {height} px · {image.hfw * constants.SI_TO_MICRO:.0f} {sym} wide",
+        ))
+        detail.append((
+            "Dwell time",
+            f"{image.dwell_time * constants.SI_TO_MICRO:.2f} "
+            f"{constants.MICROSECOND_SYMBOL}",
+        ))
+        detail.append(("Auto contrast", "on" if image.autocontrast else "off"))
+
+        # Where it lands, which is the other thing that survives a tab switch unnoticed:
+        # the filename names the tile sub-folder, so two runs under one name interleave.
+        if image.path:
+            detail.append(("Saving to", f"{image.path}/{image.filename}"))
+
+        # "Scan time", not "Estimated time": this is dwell over pixels, and it leaves out
+        # the stage entirely. A real run is several times longer -- see
+        # `OverviewAcquisitionSettings.scan_time`, which says why that term is not
+        # guessed at here.
+        detail.append((
+            "Scan time",
+            f"{format_duration(s.scan_time)}"
+            f"   ({format_duration(image.scan_time)} per tile, before stage movement)",
+        ))
+        return detail
+
+    # ── layout ───────────────────────────────────────────────────────────
+
+    def _init_ui(self) -> None:
+        total = self.settings.nrows * self.settings.ncols
+        acquired = self.settings.n_enabled_tiles
+
+        chips = QHBoxLayout()
+        chips.setSpacing(6)
+        chips.addWidget(chip(f"{acquired} to acquire"))
+        if acquired != total:
+            chips.addWidget(chip(f"{total - acquired} skipped"))
+        chips.addStretch()
+
+        self.button_start = QPushButton("Start Acquisition")
+        self.button_start.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.button_start.setMinimumHeight(30)
+        self.button_start.clicked.connect(self.accept)
+        button_cancel = QPushButton("Cancel")
+        button_cancel.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        button_cancel.setMinimumHeight(30)
+        button_cancel.clicked.connect(self.reject)
+
+        footer = QHBoxLayout()
+        footer.addStretch()
+        footer.addWidget(button_cancel)
+        footer.addWidget(self.button_start)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 14, 16, 14)
+        layout.setSpacing(10)
+        layout.addWidget(meta_label(self._meta_line()))
+        layout.addLayout(chips)
+        layout.addWidget(detail_block(self._rows()))
+        layout.addLayout(footer)
+
+        if acquired == 0:
+            # Nothing to do: the runner refuses this anyway, so say why here rather than
+            # letting it fail after the dialog is dismissed.
+            self.button_start.setEnabled(False)
+            self.button_start.setToolTip("No tiles are selected.")

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -69,6 +69,7 @@ from fibsem.structures import (
     FibsemStagePosition,
     OverviewAcquisitionSettings,
 )
+from fibsem.utils import current_timestamp_v3
 from fibsem.ui import notification_service, stylesheets
 from fibsem.ui import utils as ui_utils
 from fibsem.ui.qt.threading import FunctionWorker
@@ -160,6 +161,27 @@ PICK_RADIUS_PX = 12
 # the same reason: the percentile over a full mosaic is the expensive part, and it is
 # visually identical on a subsample.
 _CLIM_SAMPLES = 250_000
+
+
+def _stamped(name: str) -> str:
+    """`overview-image` -> `overview-image-14-23-05`, the time the run was started.
+
+    The name is not a label, it is a location: `TiledAcquisitionRunner._setup` makes the
+    tile sub-folder from it and the stitch is written inside that, both keyed on the name
+    alone. Two runs called the same thing therefore land on each other -- the second
+    overwrites the first's tiles *and* its mosaic, and only the canvas, holding both in
+    memory, still shows two. Reloading the experiment finds one.
+
+    Time rather than date and time: the experiment directory is already dated, so inside
+    it the time of day is the whole of what distinguishes one run from another.
+
+    Applied to whatever the box says, not only to the default. A name someone typed is
+    no less prone to being reused -- more so, since a memorable name invites it -- and a
+    run that quietly replaced an earlier one is worse than a name with six digits on the
+    end. The box keeps showing the base, and the confirmation dialog reports the stamped
+    destination, which is what that row is for.
+    """
+    return f"{name}-{current_timestamp_v3(timeonly=True)}"
 
 
 def _contrast_limits(values: np.ndarray, acquired: np.ndarray) -> Tuple[float, float]:
@@ -2191,9 +2213,10 @@ class FibsemOverviewWidget(QWidget):
             # somewhere, and failing at the second tile with `os.path.join(None, ...)`
             # is the worst way to find out.
             settings.image_settings.path = self._save_directory or os.getcwd()
+        settings.image_settings.filename = _stamped(settings.image_settings.filename)
 
         # Resolved before the dialog, so what it shows is what the run gets -- including
-        # the destination filled in just above.
+        # the destination and the stamped name filled in just above.
         if not self._confirm(settings):
             logger.info("Overview acquisition cancelled before starting")
             return

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -43,7 +43,9 @@ from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
 from PyQt5.QtCore import pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QCheckBox,
+    QDialog,
     QFormLayout,
+    QHBoxLayout,
     QLabel,
     QPushButton,
     QScrollArea,
@@ -94,6 +96,7 @@ from fibsem.ui.widgets.custom_widgets import (
 from fibsem.ui.widgets.overview_acquisition_settings_widget import (
     OverviewAcquisitionSettingsWidget,
 )
+from fibsem.ui.widgets.overview_confirmation_dialog import OverviewConfirmationDialog
 from fibsem.ui.widgets.overview_list_widget import OverviewListWidget
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
 
@@ -486,13 +489,21 @@ class FibsemOverviewWidget(QWidget):
         for _spin in (self.spin_gridbar_spacing, self.spin_gridbar_width):
             _spin.valueChanged.connect(self._refresh_gridbars)
 
-        self.button_acquire = QPushButton("Run Tile Collection")
+        # "Acquire Overview" says what the button produces; "Run Tile Collection" said
+        # how it is produced, which is the part the settings above already describe.
+        self.button_acquire = QPushButton("Acquire Overview")
         self.button_acquire.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.button_acquire.setMinimumHeight(30)
         self.button_acquire.clicked.connect(self.acquire)
-        self.button_cancel = QPushButton("Cancel Acquisition")
-        self.button_cancel.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET)
+        # Beside Acquire and always present, disabled rather than hidden -- the FM tab's
+        # arrangement. Stop belongs next to go, where it is looked for, and a button
+        # that appears only once a run has started moves everything under it at the
+        # moment the user is least able to absorb a moving layout.
+        self.button_cancel = QPushButton("Cancel")
+        self.button_cancel.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.button_cancel.setMinimumHeight(30)
         self.button_cancel.clicked.connect(self.cancel)
-        self.button_cancel.setVisible(False)
+        self.button_cancel.setEnabled(False)
 
         self.label_status = QLabel("")
         self.label_status.setStyleSheet(stylesheets.LABEL_INSTRUCTIONS_STYLE)
@@ -530,7 +541,6 @@ class FibsemOverviewWidget(QWidget):
         controls_layout.addWidget(overviews_panel)
         controls_layout.addWidget(self.settings_widget)
         controls_layout.addWidget(self._section("Display", self._display_panel()))
-        controls_layout.addWidget(self._section("Overview", self._acquisition_panel()))
         controls_layout.addStretch()
 
         scroll = QScrollArea()
@@ -543,11 +553,25 @@ class FibsemOverviewWidget(QWidget):
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         scroll.setWidget(controls)
 
+        # The actions sit *below* the scroll area, not inside it, so Acquire, Cancel and
+        # the progress of a running acquisition are on screen whatever the column is
+        # scrolled to. Inside, a host adding its own section (the lamella list) pushes
+        # them past the bottom on any window short enough, and a run then reports its
+        # progress somewhere nobody is looking. Not in a titled panel either: a
+        # collapsible header over two buttons is a control that can fold Acquire and
+        # Cancel out of sight.
+        column = QWidget()
+        column_layout = QVBoxLayout(column)
+        column_layout.setContentsMargins(0, 0, 0, 0)
+        column_layout.setSpacing(0)
+        column_layout.addWidget(scroll, stretch=1)
+        column_layout.addWidget(self._acquisition_panel())
+
         # A splitter rather than a fixed column, so a user can give the canvas the whole
         # window on a small screen. The canvas takes the extra room as the window grows.
         splitter = QSplitter(Qt.Horizontal)
         splitter.addWidget(self.canvas)
-        splitter.addWidget(scroll)
+        splitter.addWidget(column)
         splitter.setStretchFactor(0, 1)
         splitter.setStretchFactor(1, 0)
 
@@ -558,9 +582,18 @@ class FibsemOverviewWidget(QWidget):
     def _acquisition_panel(self) -> QWidget:
         panel = QWidget()
         layout = QVBoxLayout(panel)
-        layout.setContentsMargins(4, 4, 4, 4)
-        layout.addWidget(self.button_acquire)
-        layout.addWidget(self.button_cancel)
+        # Left and right match the scrolled column's own 8px, so the buttons line up
+        # with the panels above them rather than sitting 4px further out.
+        layout.setContentsMargins(8, 4, 8, 8)
+
+        buttons = QWidget()
+        buttons_layout = QHBoxLayout(buttons)
+        buttons_layout.setContentsMargins(0, 0, 0, 0)
+        buttons_layout.setSpacing(6)
+        buttons_layout.addWidget(self.button_cancel)
+        buttons_layout.addWidget(self.button_acquire, stretch=1)
+
+        layout.addWidget(buttons)
         layout.addWidget(self.progress)
         layout.addWidget(self.label_status)
         return panel
@@ -812,9 +845,12 @@ class FibsemOverviewWidget(QWidget):
             "" if has_tiles else "No tiles are selected. Click a tile to include it."
         )
         self.button_acquire.setText(
-            "Running Tile Collection…" if running else "Run Tile Collection"
+            "Acquiring Overview…" if running else "Acquire Overview"
         )
-        self.button_cancel.setVisible(running)
+        # Not gated on `_interactive`: a host locking the tab must not take away the
+        # only way to stop a run that is already under way. Off once cancellation has
+        # been asked for, so a second press cannot read as "it did not work".
+        self.button_cancel.setEnabled(running and not self._stop_event.is_set())
         self.settings_widget.setEnabled(self._interactive and not running)
 
     def _planned_tile_count(self) -> int:
@@ -2060,6 +2096,12 @@ class FibsemOverviewWidget(QWidget):
             # is the worst way to find out.
             settings.image_settings.path = self._save_directory or os.getcwd()
 
+        # Resolved before the dialog, so what it shows is what the run gets -- including
+        # the destination filled in just above.
+        if not self._confirm(settings):
+            logger.info("Overview acquisition cancelled before starting")
+            return
+
         # A new record before the first tile arrives, so every tile has somewhere to go
         # and the run is on the canvas from the moment it starts.
         self._record_count += 1
@@ -2077,6 +2119,36 @@ class FibsemOverviewWidget(QWidget):
             self._acquire_worker, settings, deepcopy(self._target)
         )
         self._worker.start()
+
+    def _confirm(self, settings: OverviewAcquisitionSettings) -> bool:
+        """Show what is about to happen, and let it be called off.
+
+        Two things a run carries are set on the canvas rather than in the controls, so
+        neither is visible from the settings column at the moment Acquire is pressed:
+        where the grid was dragged to (FIB-617) and which tiles are masked off
+        (FIB-618). Both survive a tab switch. This is where they announce themselves.
+        """
+        view = self.acquisition_view
+        dialog = OverviewConfirmationDialog(
+            settings=settings,
+            view_description=view.describe if view is not None else None,
+            offset=self._target_offset(),
+            parent=self,
+        )
+        return dialog.exec_() == QDialog.Accepted
+
+    def _target_offset(self) -> Optional[Tuple[float, float]]:
+        """How far the grid's centre sits from the stage, in metres, or None for on it.
+
+        From the cached stage position, like everything else here -- opening a dialog
+        must not reach for the instrument.
+        """
+        if self._target is None or self._stage_position is None:
+            return None
+        return (
+            self._target.x - self._stage_position.x,
+            self._target.y - self._stage_position.y,
+        )
 
     def _acquire_worker(
         self,
@@ -2110,6 +2182,10 @@ class FibsemOverviewWidget(QWidget):
         logger.info("Cancelling overview acquisition")
         self._stop_event.set()
         self.label_status.setText("Cancelling…")
+        # A run stops at the next tile boundary, so the button stays there for a while
+        # after it is pressed. Disabled once asked, or a second press reads as the first
+        # one not having worked.
+        self._apply_enabled_state()
 
     def _set_running(self, running: bool) -> None:
         self._running = running

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -40,6 +40,7 @@ from copy import deepcopy
 from functools import partial
 from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
 
+import numpy as np
 from PyQt5.QtCore import pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QCheckBox,
@@ -57,6 +58,7 @@ from PyQt5.QtCore import Qt
 from superqt import ensure_main_thread
 
 from fibsem import constants
+from fibsem.fm.composite import auto_clim
 from fibsem.imaging import tiled
 from fibsem.imaging.reduce import downsample
 from fibsem.microscope import FibsemMicroscope
@@ -154,6 +156,86 @@ DEFAULT_GRIDBAR_WIDTH_UM = 20.0
 PICK_RADIUS_PX = 12
 
 
+# How many pixels the contrast limits are taken from. `auto_clim`'s own cap, and for
+# the same reason: the percentile over a full mosaic is the expensive part, and it is
+# visually identical on a subsample.
+_CLIM_SAMPLES = 250_000
+
+
+def _contrast_limits(values: np.ndarray, acquired: np.ndarray) -> Tuple[float, float]:
+    """Where to put black and white, taken from the acquired pixels only.
+
+    The unacquired zeros are most of a part-finished mosaic and are not drawn, so letting
+    them win the minimum squeezes what *is* there into the top of the range -- which
+    renders a half-done overview visibly bleached.
+
+    Percentiles rather than min/max, and the same 1st/99th `fibsem.fm.composite.auto_clim`
+    picks: the boundary between an acquired tile and the nothing beside it is not
+    perfectly sharp once a display filter has run over it, and a handful of pixels should
+    not decide the whole stretch.
+    """
+    sample = values[acquired]
+    if sample.size == 0:
+        # Nothing acquired. Any limits will do -- every pixel is about to be transparent
+        # -- but they have to be finite, and `auto_clim` indexes into what it is given.
+        return 0.0, 1.0
+    if sample.size > _CLIM_SAMPLES:
+        # `auto_clim` strides a 2-D frame down before taking percentiles, for the same
+        # reason; masking has already flattened this one, so it is done here.
+        sample = sample[:: int(np.ceil(sample.size / _CLIM_SAMPLES))]
+    return auto_clim(sample)
+
+
+def _as_colour_and_coverage(
+    data: np.ndarray, acquired: np.ndarray, clim: Tuple[float, float]
+) -> np.ndarray:
+    """Re-express a grayscale overview as colour plus where it holds anything.
+
+    An overview is rarely complete: a masked run acquires some tiles, a cancelled one
+    stops partway, and either way the rest of the mosaic is the zeros the stitch buffer
+    started as. Placed opaquely those zeros paint black *over* whatever is beneath, so a
+    second overview hides the first with pixels that hold nothing (FIB-630). Made
+    transparent instead, the image underneath shows through.
+
+    Same idea as the fluorescence canvas's `to_rgba` (FIB-519), and deliberately **not**
+    the same alpha. There, alpha is signal strength, which works because an FM composite
+    sits over black -- matplotlib draws `colour x alpha + (1 - alpha) x beneath`, and the
+    second term vanishes. Over another overview it does not: measured on a mid-grey
+    region over a textured one, intensity-as-alpha reads **0.772 against a true 0.500**,
+    a mean error of 0.27. An overview would brighten wherever something happened to be
+    behind it. Beam images are dense grayscale rather than signal over black, so "is
+    there anything here" is the honest question, and it is a step function.
+
+    Both *acquired* and *clim* are measured on the **unfiltered** array by the caller,
+    and only the colour comes from the filtered one. `filtered_data` is a median then a
+    gaussian, which smears the boundary between an acquired tile and the nothing beside
+    it in both directions: signal leaks a couple of pixels past it, so testing the
+    filtered array for "greater than zero" gives a mask a filter radius too generous;
+    and the last rows *inside* the tile are pulled part-way down toward the nothing, far
+    enough to take the low limit with them and bleach the whole mosaic. Measured: 172/255
+    where 128 was right. A display filter does not get a vote on what was acquired, nor
+    on where black is.
+
+    The cost is that a pixel of *exactly* zero inside acquired data reads as a hole.
+    Measured at 0.39% of an autocontrast-stretched frame -- but the caller reduces before
+    this runs, and `downsample`'s box mean averages an isolated zero away with its
+    neighbours: 0.39% -> 0.000% at any reduction factor. Only whole unacquired blocks
+    stay exactly zero, which is the thing being asked about. An image small enough to be
+    placed unreduced keeps that speckle, and it shows only where another overview lies
+    beneath it.
+    """
+    values = np.asarray(data, dtype=np.float32)
+    out = np.zeros((*values.shape[:2], 4), dtype=np.uint8)
+    if not acquired.any():
+        return out  # nothing acquired: wholly transparent, which is the truth
+
+    lo, hi = clim
+    norm = np.clip((values - lo) / (hi - lo), 0.0, 1.0)
+    out[..., :3] = (norm * 255.0).astype(np.uint8)[..., None]
+    out[..., 3] = np.where(acquired, 255, 0)
+    return out
+
+
 class _PlacedTile(NamedTuple):
     """One image a record placed: the pixels, where it was taken, and what it covers.
 
@@ -165,7 +247,7 @@ class _PlacedTile(NamedTuple):
     positions and the wrong size.
     """
 
-    data: object  # np.ndarray, display-reduced
+    data: object  # np.ndarray, display-reduced RGBA -- see `_as_colour_and_coverage`
     position: FibsemStagePosition
     pixel_size: float
     covers: Tuple[float, float]  # (width, height) in metres
@@ -1229,12 +1311,26 @@ class FibsemOverviewWidget(QWidget):
         holds anyway, so keeping it costs no more than the canvas already does -- where
         keeping full-resolution tiles would be hundreds of megabytes for a large
         tileset, to redraw something that is decimated on the way to the screen.
+
+        Split into colour and coverage here rather than at each placement: a view switch
+        re-places every record, and the split is the same answer every time.
         """
         data = image.filtered_data
         pixel_size = self._pixel_size_of(image)
         height, width = data.shape[0], data.shape[1]
+        max_px = self.canvas._display_max_px
+        # What was acquired, and where black is, both come off the *unfiltered* array --
+        # `filtered_data` smears the boundary in both directions and would answer either
+        # question wrong. Reduced the same way as the pixels so the three line up; box
+        # meaning a 0/1 field gives the fraction of each block that holds anything, and a
+        # block counts as acquired when most of it does.
+        raw = downsample(np.asarray(image.data, dtype=np.float32), max_px)
+        acquired = downsample(
+            (np.asarray(image.data) > 0).astype(np.float32), max_px
+        ) > 0.5
+        clim = _contrast_limits(raw, acquired)
         return _PlacedTile(
-            data=downsample(data, self.canvas._display_max_px),
+            data=_as_colour_and_coverage(downsample(data, max_px), acquired, clim),
             position=deepcopy(self._position_of(image)),
             pixel_size=pixel_size,
             # From the shape *before* reduction: this is the ground the image images.

--- a/fibsem/ui/widgets/preflight.py
+++ b/fibsem/ui/widgets/preflight.py
@@ -1,0 +1,115 @@
+"""Shared furniture for pre-flight confirmation dialogs.
+
+The house style, in one place: a meta line, count chips, a detail block of label/value
+rows, and a primary action in the footer. `FMOverviewConfirmationDialog` established it,
+`CoincidenceMillingConfirmationDialog` imported the pieces from that module rather than
+copying them, and left a note saying to lift them out if a third appeared. The FIB/SEM
+overview's dialog is the third.
+
+Only the parts all three agree on live here. The footer does not: milling makes Cancel
+the default button because a mill is irreversible, and an overview does not.
+"""
+
+from typing import Iterable, Tuple
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.ui import stylesheets
+
+BACKGROUND = stylesheets.SURFACE_COLOR
+PANEL = stylesheets.PANEL_COLOR
+BORDER = stylesheets.BORDER_COLOR
+TEXT = stylesheets.TEXT_COLOR
+TEXT_STRONG = stylesheets.TEXT_STRONG_COLOR
+TEXT_MUTED = stylesheets.TEXT_MUTED_COLOR
+
+
+def format_duration(seconds: float) -> str:
+    """`2m 14s`, `1h 03m`, `45s` — whichever reads best at that magnitude.
+
+    Not `fibsem.utils.format_duration`, which carries two decimal places: that is the
+    right shape for a milling estimate quoted to the second, and the wrong one for a
+    figure that is already approximate.
+    """
+    seconds = int(round(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m {seconds % 60:02d}s"
+    return f"{seconds // 3600}h {(seconds % 3600) // 60:02d}m"
+
+
+def chip(text: str) -> QWidget:
+    """Plain pill label. No status dot: these are counts, not states, and a colour
+    that does not encode anything reads as though it does."""
+    frame = QFrame()
+    frame.setStyleSheet(
+        f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER};"
+        f" border-radius: 10px; }}"
+    )
+    layout = QHBoxLayout(frame)
+    layout.setContentsMargins(10, 3, 10, 3)
+    layout.setSpacing(0)
+
+    label = QLabel(text)
+    label.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
+    layout.addWidget(label)
+    return frame
+
+
+def detail_block(
+    rows: Iterable[Tuple[str, str]],
+    label_width: int = 96,
+    wrap_labels: bool = False,
+) -> QFrame:
+    """The label/value block the three dialogs all show.
+
+    Args:
+        rows: (label, value) pairs, in reading order.
+        label_width: the left column's width. Fixed rather than laid out, so the values
+            line up down the block instead of stepping in and out with each label.
+        wrap_labels: whether a long label wraps rather than clipping. Wanted where the
+            labels are user-supplied (milling stage names); a truncated name in a
+            pre-flight check is worse than two lines.
+    """
+    frame = QFrame()
+    frame.setStyleSheet(
+        f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER};"
+        f" border-radius: 4px; }}"
+    )
+    layout = QVBoxLayout(frame)
+    layout.setContentsMargins(12, 10, 12, 10)
+    layout.setSpacing(6)
+    for label_text, value_text in rows:
+        row = QHBoxLayout()
+        row.setSpacing(12)
+        label = QLabel(label_text)
+        label.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px; border: none;")
+        label.setFixedWidth(label_width)
+        label.setWordWrap(wrap_labels)
+        value = QLabel(value_text)
+        value.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
+        value.setWordWrap(True)
+        row.addWidget(label, alignment=Qt.AlignTop)
+        row.addWidget(value, stretch=1)
+        layout.addLayout(row)
+    return frame
+
+
+def meta_label(text: str) -> QLabel:
+    """The line that leads the dialog: what is about to happen, in one sentence.
+
+    Normal text weight rather than muted -- there is no heading above it, because the
+    window title already says what this is and repeating it 8px below costs a line.
+    """
+    label = QLabel(text)
+    label.setStyleSheet(f"color: {TEXT_STRONG}; font-size: 12px;")
+    label.setWordWrap(True)
+    return label

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -321,6 +321,56 @@ def test_overview_acquisition_tile_order_legacy_default():
     assert s.tile_order is TileOrderStrategy.TYPEWRITER
 
 
+def test_scan_time_is_dwell_over_every_pixel():
+    """The whole of it: dwell time, times width, times height."""
+    settings = ImageSettings(resolution=(1024, 1024), dwell_time=1e-6)
+    assert settings.scan_time == pytest.approx(1.048576)
+
+
+def test_scan_time_counts_the_passes_each_pixel_gets():
+    """Line and frame integration both re-scan, so both multiply.
+
+    `scan_interlacing` changes the order lines are visited in, not how many are
+    visited -- a scan time that grew with it would be wrong by that factor.
+    """
+    base = ImageSettings(resolution=(512, 512), dwell_time=2e-6)
+    assert base.scan_time == pytest.approx(0.524288)
+
+    lines = ImageSettings(resolution=(512, 512), dwell_time=2e-6, line_integration=4)
+    assert lines.scan_time == pytest.approx(base.scan_time * 4)
+
+    frames = ImageSettings(resolution=(512, 512), dwell_time=2e-6, frame_integration=3)
+    assert frames.scan_time == pytest.approx(base.scan_time * 3)
+
+    both = ImageSettings(
+        resolution=(512, 512), dwell_time=2e-6, line_integration=4, frame_integration=3
+    )
+    assert both.scan_time == pytest.approx(base.scan_time * 12)
+
+    interlaced = ImageSettings(resolution=(512, 512), dwell_time=2e-6, scan_interlacing=8)
+    assert interlaced.scan_time == pytest.approx(base.scan_time)
+
+
+def test_overview_scan_time_counts_the_tiles_it_will_acquire():
+    """The enabled ones, not the grid's shape.
+
+    A masked run scans only what is selected; quoting the full grid would overstate a
+    typical sparse selection roughly threefold -- and this number is shown to someone
+    deciding whether to start it.
+    """
+    image = ImageSettings(resolution=(1024, 1024), dwell_time=1e-6)
+    dense = OverviewAcquisitionSettings(image_settings=image, nrows=3, ncols=3)
+    assert dense.scan_time == pytest.approx(image.scan_time * 9)
+
+    sparse = OverviewAcquisitionSettings(
+        image_settings=image,
+        nrows=3,
+        ncols=3,
+        tile_mask=[[True, False, False], [False, True, False], [False, False, True]],
+    )
+    assert sparse.scan_time == pytest.approx(image.scan_time * 3)
+
+
 if THERMO_API_AVAILABLE:
 
     from fibsem.structures import CompustagePosition, CoordinateSystem, StagePosition

--- a/tests/ui/test_overview_confirmation_dialog.py
+++ b/tests/ui/test_overview_confirmation_dialog.py
@@ -1,0 +1,197 @@
+"""What the FIB/SEM overview's pre-flight dialog says.
+
+Its job is to state the two things a run carries that are *not* visible in the settings
+column: where the grid was dragged to, and which tiles are masked off. Both are set on
+the canvas, both survive a tab switch, and neither shows up anywhere else at the moment
+Acquire is pressed.
+
+Built here from plain settings objects rather than through the widget -- the wiring is
+covered in `test_overview_widget.py`, and what is checked here is the wording.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_overview_confirmation_dialog.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+# CI installs `.[test]`, not `.[ui]`, so PyQt5 is absent there.
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication, QLabel  # noqa: E402
+
+from fibsem.structures import (  # noqa: E402
+    ImageSettings,
+    OverviewAcquisitionSettings,
+)
+from fibsem.ui.widgets.overview_confirmation_dialog import (  # noqa: E402
+    OverviewConfirmationDialog,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _settings(**kwargs) -> OverviewAcquisitionSettings:
+    image = ImageSettings(
+        resolution=(1024, 1024),
+        hfw=500e-6,
+        dwell_time=1e-6,
+        autocontrast=True,
+        filename="overview-image",
+    )
+    image_overrides = kwargs.pop("image", {})
+    for key, value in image_overrides.items():
+        setattr(image, key, value)
+    return OverviewAcquisitionSettings(image_settings=image, **kwargs)
+
+
+def _rows(dialog) -> dict:
+    return dict(dialog._rows())
+
+
+@pytest.fixture
+def dialog():
+    built = []
+
+    def build(**kwargs):
+        d = OverviewConfirmationDialog(**kwargs)
+        built.append(d)
+        return d
+
+    yield build
+    for d in built:
+        d.close()
+
+
+class TestWhereTheRunWillHappen:
+    """The half of this dialog that nothing else says."""
+
+    def test_no_target_means_the_stage(self, dialog):
+        assert dialog(settings=_settings())._centre_text() == "the stage position"
+
+    def test_a_dragged_grid_says_how_far_and_which_way(self, dialog):
+        """Components, not a distance: the grid is dragged in x and y and checked
+        against the canvas in x and y, and "520 µm away" does not say which way."""
+        text = dialog(settings=_settings(), offset=(500e-6, -150e-6))._centre_text()
+        assert "+500" in text
+        assert "-150" in text
+        assert "from the stage position" in text
+
+    def test_floating_point_dust_is_not_a_dragged_grid(self, dialog):
+        """A target resolved through the projection lands a few nanometres off where it
+        started. Reported literally, that reads as a grid someone moved."""
+        text = dialog(settings=_settings(), offset=(2e-9, -5e-9))._centre_text()
+        assert text == "the stage position"
+
+    def test_the_view_is_named_when_there_is_one(self, dialog):
+        rows = _rows(dialog(
+            settings=_settings(),
+            view_description="Ion beam, stage at the MILLING orientation.",
+        ))
+        assert rows["Acquired in"] == "Ion beam, stage at the MILLING orientation."
+
+    def test_no_view_leaves_the_row_out_rather_than_guessing(self, dialog):
+        """The tab cannot always name one -- an unrecognised pose gives no orientation.
+        A row reading "unknown" is worse than no row."""
+        assert "Acquired in" not in _rows(dialog(settings=_settings()))
+
+
+class TestWhatWillBeAcquired:
+    def test_the_meta_line_carries_the_grid_and_what_it_covers(self, dialog):
+        line = dialog(settings=_settings())._meta_line()
+        assert "3 × 3 grid" in line
+        assert "1500 × 1500" in line
+        assert "typewriter order" in line
+
+    def test_a_masked_run_counts_only_what_it_will_acquire(self, dialog):
+        """The chips are the only place the mask is stated in words."""
+        settings = _settings(
+            tile_mask=[[True, False, False], [False, True, False], [False, False, True]]
+        )
+        d = dialog(settings=settings)
+        labels = [label.text() for label in d.findChildren(QLabel)]
+        assert any("3 to acquire" in text for text in labels), labels
+        assert any("6 skipped" in text for text in labels), labels
+
+    def test_a_full_run_does_not_mention_skipping(self, dialog):
+        d = dialog(settings=_settings())
+        labels = [label.text() for label in d.findChildren(QLabel)]
+        assert any("9 to acquire" in text for text in labels), labels
+        assert not any("skipped" in text for text in labels), labels
+
+    def test_nothing_selected_cannot_be_started(self, dialog):
+        """The runner refuses an empty mask, so the refusal belongs before the dialog is
+        dismissed rather than after."""
+        settings = _settings(tile_mask=[[False] * 3 for _ in range(3)])
+        d = dialog(settings=settings)
+        assert not d.button_start.isEnabled()
+        assert "No tiles" in d.button_start.toolTip()
+
+    def test_the_tile_row_gives_pixels_and_ground(self, dialog):
+        rows = _rows(dialog(settings=_settings()))
+        assert "1024 × 1024 px" in rows["Tile"]
+        assert "500" in rows["Tile"]
+
+    def test_the_dwell_time_is_in_microseconds_not_micrometres(self, dialog):
+        """`MICRON_SYMBOL` is "µm" already, so appending an "s" to it gave "µms" --
+        which read as a unit right up until you looked at it."""
+        rows = _rows(dialog(settings=_settings()))
+        assert rows["Dwell time"] == "1.00 µs"
+
+    def test_where_it_will_be_written_when_that_is_known(self, dialog):
+        """The filename names the tile sub-folder, so two runs under one name interleave
+        on disk. It is worth a row."""
+        rows = _rows(dialog(settings=_settings(image={"path": "/data/exp-1"})))
+        assert rows["Saving to"] == "/data/exp-1/overview-image"
+
+    def test_no_destination_leaves_the_row_out(self, dialog):
+        assert "Saving to" not in _rows(dialog(settings=_settings()))
+
+
+class TestTheTimeItQuotes:
+    """Scan time, under its own name, because that is the part that is arithmetic.
+
+    A wall-clock estimate would be mostly an unmeasured guess at stage settling -- see
+    `OverviewAcquisitionSettings.scan_time`. Quoting that as "Estimated time" is the
+    failure this wording avoids.
+    """
+
+    def test_it_reports_scan_time_not_a_run_duration(self, dialog):
+        rows = _rows(dialog(settings=_settings()))
+        assert "Estimated time" not in rows
+        assert "before stage movement" in rows["Scan time"]
+
+    def test_it_matches_the_settings_it_was_given(self, dialog):
+        settings = _settings()
+        rows = _rows(dialog(settings=settings))
+        # 9 tiles x 1024^2 px x 1 us = 9.4 s, and 1.0 s each.
+        assert settings.scan_time == pytest.approx(9.437184)
+        assert rows["Scan time"].startswith("9s")
+        assert "1s per tile" in rows["Scan time"]
+
+    def test_a_masked_run_quotes_only_the_tiles_it_scans(self, dialog):
+        settings = _settings(
+            tile_mask=[[True, False, False], [False, True, False], [False, False, True]]
+        )
+        rows = _rows(dialog(settings=settings))
+        assert rows["Scan time"].startswith("3s")
+
+
+def test_the_three_preflight_dialogs_share_one_style():
+    """The coincidence dialog copied nothing from the FM one and imported instead,
+    leaving a note to lift the shared parts out if a third appeared. This is the third,
+    and the note was followed rather than the import chain extended."""
+    from fibsem.ui.fm.widgets import fm_overview_confirmation_dialog as fm
+    from fibsem.ui.widgets import coincidence_milling_confirmation_dialog as milling
+    from fibsem.ui.widgets import overview_confirmation_dialog as beam
+    from fibsem.ui.widgets import preflight
+
+    for module in (fm, milling, beam):
+        assert module.chip is preflight.chip
+        assert module.detail_block is preflight.detail_block
+        assert module.format_duration is preflight.format_duration

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -2030,3 +2030,133 @@ class TestTheAcquisitionButtons:
             assert widget.button_acquire.visibleRegion().boundingRect().height() > 0
         finally:
             widget.close()
+
+
+class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
+    """A mosaic is mostly zeros until it is finished, and those zeros are not black --
+    they are nothing. Placed opaquely they hid whatever was underneath, so a second
+    overview blanked the first wherever it had not reached yet (FIB-630).
+
+    The fluorescence canvas solved the same problem with `to_rgba`, where alpha is
+    signal strength. That is right for signal over black and wrong here: matplotlib
+    draws `colour x alpha + (1 - alpha) x beneath`, so on a dense grayscale image the
+    second term brightens everything that happens to have something behind it. Measured
+    on a mid-grey region over a textured one, it read 0.772 against a true 0.500. So
+    alpha is coverage, which is a step function.
+    """
+
+    @staticmethod
+    def _partial(rows: int = 1, shape: int = 96) -> np.ndarray:
+        """A mosaic with `rows` of three acquired and the rest still zero."""
+        data = np.zeros((shape, shape), dtype=np.uint8)
+        rng = np.random.default_rng(4)
+        filled = (rng.random((rows * shape // 3, shape)) * 110 + 90).astype(np.uint8)
+        data[: rows * shape // 3] = filled
+        return data
+
+    def test_an_unacquired_region_is_transparent_and_the_rest_is_not(self):
+        from fibsem.ui.widgets.overview_widget import (
+            _as_colour_and_coverage, _contrast_limits,
+        )
+
+        data = self._partial()
+        rgba = _as_colour_and_coverage(data, data > 0, _contrast_limits(data.astype(float), data > 0))
+        alpha = rgba[..., 3]
+        assert (alpha[: data.shape[0] // 3] == 255).all(), "acquired tiles went see-through"
+        assert (alpha[data.shape[0] // 3:] == 0).all(), (
+            "unacquired ground is still opaque, so it paints over what is beneath"
+        )
+
+    def test_coverage_is_a_step_not_a_brightness(self):
+        """The distinction that makes this correct over another image. A dark *acquired*
+        pixel has to stay opaque, or the overview beneath shows through it and the
+        result is neither picture."""
+        from fibsem.ui.widgets.overview_widget import (
+            _as_colour_and_coverage, _contrast_limits,
+        )
+
+        data = np.array([[1, 40, 128, 255]], dtype=np.uint8)
+        rgba = _as_colour_and_coverage(data, data > 0, _contrast_limits(data.astype(float), data > 0))
+        assert (rgba[..., 3] == 255).all(), (
+            f"alpha followed intensity: {rgba[..., 3].tolist()}"
+        )
+
+    def test_nothing_acquired_is_wholly_transparent(self):
+        """A run that has not produced a tile yet, and a cancelled one that never did."""
+        from fibsem.ui.widgets.overview_widget import (
+            _as_colour_and_coverage, _contrast_limits,
+        )
+
+        data = np.zeros((16, 16), dtype=np.uint8)
+        assert (_as_colour_and_coverage(data, data > 0, _contrast_limits(data.astype(float), data > 0))[..., 3] == 0).all()
+
+    def test_the_unacquired_zeros_do_not_set_the_contrast(self):
+        """They are most of a part-finished mosaic and they are not drawn, so letting
+        them win the minimum squeezes what *is* there into the top of the range. That
+        renders a half-done overview visibly bleached."""
+        from fibsem.ui.widgets.overview_widget import (
+            _as_colour_and_coverage, _contrast_limits,
+        )
+
+        data = self._partial()
+        acquired = data > 0
+        grey = _as_colour_and_coverage(data, acquired, _contrast_limits(data.astype(float), acquired))[..., 0][acquired]
+        assert grey.mean() == pytest.approx(128, abs=25), (
+            f"the acquired tiles render at a mean of {grey.mean():.0f}/255"
+        )
+        assert grey.min() < 30 and grey.max() > 225, "the stretch did not use the range"
+
+    def test_a_complete_overview_uses_the_whole_range_too(self):
+        """The common case must not change: with nothing to exclude, this is the same
+        stretch the canvas applied before."""
+        from fibsem.ui.widgets.overview_widget import (
+            _as_colour_and_coverage, _contrast_limits,
+        )
+
+        rng = np.random.default_rng(11)
+        data = (rng.random((64, 64)) * 110 + 90).astype(np.uint8)
+        rgba = _as_colour_and_coverage(data, np.ones_like(data, dtype=bool),
+                                       _contrast_limits(data.astype(float), np.ones_like(data, dtype=bool)))
+        assert (rgba[..., 3] == 255).all()
+        assert rgba[..., 0].min() == 0 and rgba[..., 0].max() == 255
+
+    def test_coverage_is_measured_before_the_display_filter(self, widget, microscope):
+        """`filtered_data` is a median then a gaussian, so it leaks signal a couple of
+        pixels *past* the last acquired row. Testing that array for "greater than zero"
+        hands back a mask a filter radius too generous, and admits a fringe of near-zero
+        values into the contrast stretch -- which is the bleached rendering again.
+        """
+        image = _tile(microscope, _at(microscope.get_stage_position()), shape=(96, 96))
+        data = np.zeros((96, 96), dtype=np.uint8)
+        rng = np.random.default_rng(5)
+        data[:32] = (rng.random((32, 96)) * 110 + 90).astype(np.uint8)
+        image.data = data
+
+        tile = widget._stored_tile(image)
+        rgba = np.asarray(tile.data)
+        acquired = rgba[..., 3] > 0
+        # A third of the image, give or take the boundary block -- not a third plus a
+        # filter radius, which is what the filtered array would have given.
+        assert acquired.mean() == pytest.approx(1 / 3, abs=0.02), (
+            f"coverage came out at {acquired.mean():.3f} of the image"
+        )
+        grey = rgba[..., 0][acquired]
+        assert grey.mean() == pytest.approx(128, abs=30), (
+            f"the acquired region renders at {grey.mean():.0f}/255 -- bleached"
+        )
+
+    def test_the_canvas_is_given_the_coverage(self, widget, microscope):
+        """End to end: what reaches the artist is RGBA, not a 2-D array the canvas would
+        colormap opaquely."""
+        image = _tile(microscope, _at(microscope.get_stage_position()), shape=(96, 96))
+        data = np.zeros((96, 96), dtype=np.uint8)
+        data[:32] = 200
+        image.data = data
+        widget.set_image(image)
+
+        artist = widget.canvas._placed[list(widget.canvas._placed)[-1]].artist
+        shown = np.asarray(artist.get_array())
+        assert shown.ndim == 3 and shown.shape[-1] == 4, (
+            f"the canvas was handed {shown.shape}, so it composites opaquely"
+        )
+        assert shown[..., 3].min() == 0, "no part of a half-finished mosaic is transparent"

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -28,7 +28,8 @@ import pytest
 # module-level imports below turn a skip into a collection error.
 pytest.importorskip("PyQt5")
 
-from PyQt5.QtWidgets import QApplication  # noqa: E402
+from PyQt5.QtCore import QPoint  # noqa: E402
+from PyQt5.QtWidgets import QApplication, QDialog  # noqa: E402
 
 from fibsem import utils  # noqa: E402
 from fibsem.structures import (  # noqa: E402
@@ -37,6 +38,7 @@ from fibsem.structures import (  # noqa: E402
     FibsemStagePosition,
     ImageSettings,
 )
+from fibsem.ui.widgets import overview_confirmation_dialog  # noqa: E402
 from fibsem.ui.widgets.overview_widget import (  # noqa: E402
     GRID_BOUNDARY_RADIUS,
     FibsemOverviewWidget,
@@ -44,6 +46,27 @@ from fibsem.ui.widgets.overview_widget import (  # noqa: E402
 )
 
 _app = QApplication.instance() or QApplication(sys.argv)
+
+
+@pytest.fixture(autouse=True)
+def confirmations(monkeypatch):
+    """Every `acquire()` opens a modal dialog, which would hang the run.
+
+    Auto-accepted so the tests below can go on testing what they were written for -- and
+    *recorded*, because a fixture that silently says yes would equally hide the dialog
+    never being shown, which is the one thing a confirmation has to do. Tests that care
+    assert against the list this yields.
+    """
+    shown = []
+
+    def _exec(dialog):
+        shown.append(dialog)
+        return QDialog.Accepted
+
+    monkeypatch.setattr(
+        overview_confirmation_dialog.OverviewConfirmationDialog, "exec_", _exec
+    )
+    return shown
 
 
 @pytest.fixture(scope="module")
@@ -644,7 +667,6 @@ class TestTheRunOwnsItsSettings:
             widget.settings_widget.image_settings_widget.filename_edit.text()
             == "overview-image"
         )
-
 
     def test_a_run_starts_from_the_overview_defaults(self, widget, monkeypatch):
         """A 500 um tile with autocontrast, not `ImageSettings`'s generic 150 um.
@@ -1778,3 +1800,233 @@ class TestTheMillingAngleIsOnTheBeamTab:
             lambda *a, **k: pytest.fail("the info bar polled the stage"),
         )
         widget._refresh_stage_info()
+
+
+class TestARunIsConfirmedFirst:
+    """Pressing Acquire drives the stage. Two things it will do are set on the canvas
+    rather than in the controls, so neither is visible from the settings column at the
+    moment it is pressed: where the grid was dragged to, and which tiles are masked off.
+    Both survive a tab switch, and both are silent.
+
+    The dialog is where they announce themselves. These check that it is asked, that a
+    refusal is honoured, and that what it is handed is what the run gets -- a dialog
+    describing a different set of settings than the one that runs is worse than none.
+    """
+
+    def _fake_worker(self, captured):
+        def factory(fn, *args):
+            captured["args"] = args
+
+            class _W:
+                def start(self_inner):
+                    pass
+
+                def is_alive(self_inner):
+                    return False
+
+            return _W()
+
+        return factory
+
+    def test_a_run_asks_before_it_starts(
+        self, widget, monkeypatch, tmp_path, confirmations
+    ):
+        captured = {}
+        widget.set_save_directory(str(tmp_path))
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker",
+            self._fake_worker(captured),
+        )
+        widget.acquire()
+        assert len(confirmations) == 1, "the run started without asking"
+        assert "args" in captured, "the run was refused after the dialog was accepted"
+
+    def test_declining_leaves_everything_as_it_was(
+        self, widget, monkeypatch, tmp_path
+    ):
+        """Not merely "no worker": a refused run must leave no record behind either, or
+        the overview list grows a row for something that never happened."""
+        captured = {}
+        widget.set_save_directory(str(tmp_path))
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker",
+            self._fake_worker(captured),
+        )
+        monkeypatch.setattr(
+            overview_confirmation_dialog.OverviewConfirmationDialog,
+            "exec_",
+            lambda self: QDialog.Rejected,
+        )
+        before = len(widget._records)
+
+        widget.acquire()
+
+        assert "args" not in captured, "a declined run started anyway"
+        assert len(widget._records) == before, "a declined run left a record behind"
+        assert not widget.is_acquiring
+
+    def test_the_dialog_is_shown_the_settings_the_run_gets(
+        self, widget, monkeypatch, tmp_path, confirmations
+    ):
+        """Including the destination, which `acquire` fills in *after* reading the
+        widget -- a dialog built before that step would show a run with nowhere to go."""
+        captured = {}
+        widget.set_save_directory(str(tmp_path))
+        widget.settings_widget.set_grid_size(2, 4)
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker",
+            self._fake_worker(captured),
+        )
+        widget.acquire()
+
+        shown = confirmations[0].settings
+        assert shown is captured["args"][0], (
+            "the dialog described a different settings object than the one that ran"
+        )
+        assert shown.image_settings.path, "the dialog was built before the path was set"
+        assert (shown.nrows, shown.ncols) == (2, 4)
+
+    def test_an_undragged_run_says_it_is_on_the_stage(
+        self, widget, monkeypatch, tmp_path, confirmations
+    ):
+        captured = {}
+        widget.set_save_directory(str(tmp_path))
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker",
+            self._fake_worker(captured),
+        )
+        widget.acquire()
+        assert confirmations[0].offset is None
+        assert confirmations[0]._centre_text() == "the stage position"
+
+    def test_the_dialog_reports_a_dragged_grid(
+        self, widget, monkeypatch, tmp_path, confirmations
+    ):
+        """The reason this dialog exists. A grid dragged half a millimetre away looks
+        identical in the settings column."""
+        captured = {}
+        widget.set_save_directory(str(tmp_path))
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker",
+            self._fake_worker(captured),
+        )
+        widget._on_grid_moved(150.0, 60.0)
+        widget.acquire()
+
+        dragged = confirmations[0]
+        assert dragged.offset is not None, "a dragged grid was reported as on the stage"
+        expected = (
+            widget.target.x - widget._stage_position.x,
+            widget.target.y - widget._stage_position.y,
+        )
+        assert dragged.offset == pytest.approx(expected)
+        assert "from the stage position" in dragged._centre_text()
+        assert dragged._centre_text() != "the stage position"
+
+    def test_opening_the_dialog_costs_no_hardware_read(
+        self, widget, monkeypatch, tmp_path, confirmations
+    ):
+        """It reports the view and the offset, both of which have a cached answer. A
+        dialog that polled the stage would do it on the click that starts a run, which
+        is the worst moment to add a set-then-read on the shared channel."""
+        captured = {}
+        widget.set_save_directory(str(tmp_path))
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker",
+            self._fake_worker(captured),
+        )
+        monkeypatch.setattr(
+            widget.microscope, "get_stage_position",
+            lambda *a, **k: pytest.fail("the confirmation dialog polled the stage"),
+        )
+        widget.acquire()
+        assert confirmations[0].view_description
+
+
+class TestTheAcquisitionButtons:
+    """`Cancel | Acquire Overview`, the fluorescence tab's arrangement."""
+
+    @staticmethod
+    def _pretend_a_run_is_going(widget):
+        """`_set_running(True)` alone is not enough: `cancel()` is gated on
+        `is_acquiring`, which asks the worker, not the flag."""
+
+        class _LiveWorker:
+            def is_alive(self):
+                return True
+
+        widget._worker = _LiveWorker()
+        widget._set_running(True)
+
+    def test_stop_sits_beside_go_and_stays_there(self, widget):
+        """Enabled and disabled rather than shown and hidden: a button that appears when
+        a run starts moves everything below it at the moment the user is least able to
+        absorb a moving layout."""
+        assert widget.button_acquire.text() == "Acquire Overview"
+        assert not widget.button_cancel.isHidden()
+        assert not widget.button_cancel.isEnabled()
+
+        widget._set_running(True)
+        assert widget.button_cancel.isEnabled()
+        assert not widget.button_acquire.isEnabled()
+        assert not widget.button_cancel.isHidden()
+
+    def test_cancel_goes_dead_once_it_has_been_asked(self, widget):
+        """A run stops at the next tile boundary, so the button is still there for a
+        while after it is pressed. Left live, a second press reads as the first one not
+        having worked."""
+        self._pretend_a_run_is_going(widget)
+        widget.cancel()
+        assert not widget.button_cancel.isEnabled()
+
+    def test_a_host_lock_cannot_take_away_the_stop(self, widget):
+        """`set_interactive(False)` is a host claiming the instrument. It must not
+        remove the only way to stop a run that is already under way."""
+        widget._set_running(True)
+        widget.set_interactive(False)
+        assert not widget.button_acquire.isEnabled()
+        assert widget.button_cancel.isEnabled()
+
+    def test_the_actions_are_not_in_the_scrolling_part(self, widget):
+        """Structural, because the failure is invisible until the window is short.
+
+        Inside the scroll area, a host adding its own section -- the lamella list, which
+        is what the AutoLamella tab does -- pushes Acquire, Cancel and the progress bar
+        below the fold. A run then reports its progress somewhere nobody is looking, and
+        stopping it means scrolling first.
+        """
+        from PyQt5.QtWidgets import QScrollArea
+
+        scroll = widget.findChild(QScrollArea)
+        assert scroll is not None, "the settings column is no longer scrolled"
+        scrolled = scroll.widget()
+        for name in ("button_acquire", "button_cancel", "progress", "label_status"):
+            child = getattr(widget, name)
+            assert not scrolled.isAncestorOf(child), f"{name} scrolls away with the column"
+
+    def test_they_stay_on_screen_in_a_window_too_short_for_the_column(
+        self, microscope, qapp
+    ):
+        """The case that motivated it: a host section on top, and a window shorter than
+        the controls need. Shown for real -- geometry on an unshown widget is whatever
+        the last layout pass left, which is how this passes for the wrong reason."""
+        from PyQt5.QtWidgets import QListWidget
+
+        widget = FibsemOverviewWidget(microscope)
+        try:
+            lamellae = QListWidget()
+            for i in range(6):
+                lamellae.addItem(f"Lamella-{i + 1:02d}")
+            widget.add_settings_section("Lamellae", lamellae)
+            widget.resize(1250, 620)
+            widget.show()
+            qapp.processEvents()
+
+            top_left = widget.button_acquire.mapTo(widget, QPoint(0, 0))
+            bottom = top_left.y() + widget.button_acquire.height()
+            assert bottom <= widget.height(), (
+                f"Acquire runs to {bottom}px in a {widget.height()}px widget"
+            )
+            assert widget.button_acquire.visibleRegion().boundingRect().height() > 0
+        finally:
+            widget.close()

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -642,6 +642,9 @@ class TestTheRunOwnsItsSettings:
         experiment is written. Asserted on what the *runner* receives rather than on the
         text box, because that is the value that names the directory -- a box seeded
         correctly and then dropped somewhere along the handover would still pass.
+
+        A prefix, not the whole name: the run appends the time it started, so that two
+        of them cannot land in one directory. See `TestTwoRunsCannotLandOnEachOther`.
         """
         captured = {}
 
@@ -661,7 +664,7 @@ class TestTheRunOwnsItsSettings:
             "fibsem.ui.widgets.overview_widget.FunctionWorker", fake_worker
         )
         widget.acquire()
-        assert captured["settings"].image_settings.filename == "overview-image"
+        assert captured["settings"].image_settings.filename.startswith("overview-image")
         # And visible, so it can be changed before a run rather than discovered after.
         assert (
             widget.settings_widget.image_settings_widget.filename_edit.text()
@@ -2160,3 +2163,95 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
             f"the canvas was handed {shown.shape}, so it composites opaquely"
         )
         assert shown[..., 3].min() == 0, "no part of a half-finished mosaic is transparent"
+
+
+class TestTwoRunsCannotLandOnEachOther:
+    """The filename is not a label, it is a location. `TiledAcquisitionRunner._setup`
+    makes the tile sub-folder from it and writes the stitch inside that, both keyed on
+    the name alone -- so two runs called the same thing overwrite each other's tiles
+    *and* mosaics. The canvas, holding both in memory, still shows two; reloading the
+    experiment finds one.
+
+    Seen for real: a simulator session ended with three of four rows in the Overviews
+    list called `overview-image`, all sharing one directory.
+    """
+
+    def _capture(self, widget, monkeypatch, tmp_path):
+        captured = {}
+
+        def fake_worker(fn, *args):
+            captured["settings"] = args[0]
+
+            class _W:
+                def start(self_inner):
+                    pass
+
+                def is_alive(self_inner):
+                    return False
+
+            return _W()
+
+        widget.set_save_directory(str(tmp_path))
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker", fake_worker
+        )
+        widget.acquire()
+        return captured["settings"].image_settings.filename
+
+    def test_a_run_is_stamped_with_the_time_it_started(
+        self, widget, monkeypatch, tmp_path
+    ):
+        import re
+
+        name = self._capture(widget, monkeypatch, tmp_path)
+        assert re.fullmatch(r"overview-image-\d{2}-\d{2}-\d{2}", name), name
+
+    def test_two_runs_do_not_share_a_directory(self, widget, monkeypatch, tmp_path):
+        """The stamp is only worth having if it actually differs. Frozen rather than
+        raced: two real runs are minutes apart, and a test that acquires twice in the
+        same second would pass for the wrong reason either way."""
+        from fibsem.ui.widgets import overview_widget as module
+
+        times = iter(["14-23-05", "14-31-40"])
+        monkeypatch.setattr(
+            module, "current_timestamp_v3", lambda timeonly=True: next(times)
+        )
+        first = self._capture(widget, monkeypatch, tmp_path)
+        widget._set_running(False)
+        second = self._capture(widget, monkeypatch, tmp_path)
+
+        assert first != second
+        assert first == "overview-image-14-23-05"
+        assert second == "overview-image-14-31-40"
+
+    def test_a_name_someone_typed_is_stamped_too(self, widget, monkeypatch, tmp_path):
+        """A memorable name invites reuse, so it is the *more* likely to collide. The
+        base is kept as a prefix, so what was typed is still what you look for."""
+        widget.settings_widget.image_settings_widget.filename_edit.setText("grid-2-survey")
+        name = self._capture(widget, monkeypatch, tmp_path)
+        assert name.startswith("grid-2-survey-")
+        assert name != "grid-2-survey"
+
+    def test_the_box_still_shows_the_base_name(self, widget, monkeypatch, tmp_path):
+        """Stamped at the run, not in the control: a box that rewrote itself on every
+        acquisition would make the name unusable as a thing you set once."""
+        self._capture(widget, monkeypatch, tmp_path)
+        assert (
+            widget.settings_widget.image_settings_widget.filename_edit.text()
+            == "overview-image"
+        )
+
+    def test_the_dialog_reports_where_it_will_actually_land(
+        self, widget, monkeypatch, tmp_path, confirmations
+    ):
+        """The one place the stamped name is shown before the run. Without this the
+        stamp is invisible until the files appear."""
+        name = self._capture(widget, monkeypatch, tmp_path)
+        saving_to = dict(confirmations[0]._rows())["Saving to"]
+        assert saving_to.endswith(name), f"{saving_to} does not name {name}"
+
+    def test_the_record_carries_the_stamped_name(self, widget, monkeypatch, tmp_path):
+        """So the Overviews list can tell two runs apart, which is where the collision
+        was noticed."""
+        name = self._capture(widget, monkeypatch, tmp_path)
+        assert [r.label for r in widget._records.values()] == [name]

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -646,6 +646,94 @@ class TestTheRunOwnsItsSettings:
         )
 
 
+    def test_a_run_starts_from_the_overview_defaults(self, widget, monkeypatch):
+        """A 500 um tile with autocontrast, not `ImageSettings`'s generic 150 um.
+
+        The tab referenced the overview defaults nowhere at all, so it opened at
+        whatever `ImageSettingsWidget` happens to default to. Every value below differs
+        from that, which is the point: a tab that looks right and images a ninth of the
+        area asked for is not something the picture shows you.
+
+        Asserted on the runner's copy for the same reason the filename is -- these are
+        the numbers that reach the instrument.
+        """
+        captured = {}
+
+        def fake_worker(fn, *args):
+            captured["settings"] = args[0]
+
+            class _W:
+                def start(self_inner):
+                    pass
+
+                def is_alive(self_inner):
+                    return False
+
+            return _W()
+
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker", fake_worker
+        )
+        widget.acquire()
+        settings = captured["settings"]
+        assert settings.image_settings.hfw == pytest.approx(500e-6)
+        assert settings.image_settings.dwell_time == pytest.approx(1e-6)
+        assert settings.image_settings.autocontrast is True
+        assert tuple(settings.image_settings.resolution) == (1024, 1024)
+        assert (settings.nrows, settings.ncols) == (3, 3)
+
+
+class TestTheDefaultsAreNotShared:
+    """The defaults are a factory, and the one thing a factory must not do is hand back
+    the same object twice.
+
+    What it replaced was a module-level `DEFAULT_OVERVIEW_ACQUISITION_SETTINGS`, and the
+    minimap assigned an experiment path straight into it. That edits the default: open a
+    second experiment and the "default" carries the first one's path. Worse in this
+    widget, where `ImageSettingsWidget.update_from_settings` keeps the object it is
+    handed and `get_settings` mutates and returns that same one -- so a shared default
+    would be rewritten by every keystroke in the tab.
+    """
+
+    def test_each_call_hands_back_its_own_settings(self):
+        from fibsem.ui.widgets.overview_acquisition_settings_widget import (
+            default_overview_acquisition_settings,
+        )
+
+        first = default_overview_acquisition_settings()
+        first.image_settings.path = "/experiments/one"
+        first.image_settings.hfw = 1e-3
+        first.nrows = 7
+
+        second = default_overview_acquisition_settings()
+        assert second.image_settings.path is None
+        assert second.image_settings.hfw == pytest.approx(500e-6)
+        assert second.nrows == 3
+
+    def test_the_widget_does_not_hold_the_defaults(self, qapp):
+        """Seeding a widget must not leave it editing the shared object either.
+
+        Constructing two and typing into one is the cheapest way to catch a factory
+        that returns a cached instance.
+        """
+        from fibsem.ui.widgets.overview_acquisition_settings_widget import (
+            OverviewAcquisitionSettingsWidget,
+        )
+
+        first = OverviewAcquisitionSettingsWidget()
+        second = OverviewAcquisitionSettingsWidget()
+        try:
+            first.image_settings_widget.hfw_spinbox.setValue(42.0)
+            first.set_grid_size(5, 4)
+
+            settings = second.get_settings()
+            assert settings.image_settings.hfw == pytest.approx(500e-6)
+            assert (settings.nrows, settings.ncols) == (3, 3)
+        finally:
+            first.close()
+            second.close()
+
+
 class TestViews:
     """Images from different beams or orientations must not share the canvas.
 


### PR DESCRIPTION
Three items off the overview tab's feedback list, stacked on #401.

## The tab opened at the wrong settings (FIB-619)

It referenced the overview acquisition defaults nowhere at all, so it opened at whatever `ImageSettings` defaults to: **a 150 µm tile with autocontrast off**, imaging a ninth of the area the napari tab would. Nothing about the tab says so — settings read as settings.

Those defaults lived in `FibsemMinimapWidget`, which is scheduled for deletion, so they moved regardless. They land beside the settings widget as a **factory, not a constant** — the minimap did `DEFAULT_OVERVIEW_ACQUISITION_SETTINGS.image_settings.path = path`, which edits the default for everything built afterwards, and `ImageSettingsWidget` compounds it by keeping the object it is handed and mutating it on every read.

## A run started without saying what it would do (FIB-631)

Pressing Run drove the stage immediately. Two things a run carries are set on the **canvas**, not in the controls, and neither is visible from the settings column: a dragged grid (#397) and a tile mask (#398). Both survive a tab switch.

`OverviewConfirmationDialog` states them, plus the view, tile geometry, destination and counts. Everything comes from the cached pose, so opening it costs no hardware read — pinned by a test, since it fires on the click that starts a run.

**The duration row is deliberately narrower than the FM tab's.** Scan time is arithmetic (dwell × pixels × integration passes). The stage term is not: `fm/timing.py` assumes 5 s per move, unmeasured, which at 3×3 is 40 s against 9 s of scanning — a "total" would be **81% assumption** presented as arithmetic. So the row says `Scan time … before stage movement`. Timing is `ImageSettings.scan_time` / `OverviewAcquisitionSettings.scan_time`, tested in `tests/test_structures.py` — which runs in CI, where the UI tests do not.

**The actions**: `Cancel | Acquire Overview` on one row, the FM tab's arrangement, **below the scroll area** rather than inside it. Inside, a host adding its own section pushes them past the bottom on any short window, and a run then reports progress where nobody is looking. Cancel is disabled rather than hidden, is not gated on `set_interactive` (a host lock must not remove the only way to stop a run), and goes dead once pressed.

## An overview hid the one beneath it (FIB-630)

A mosaic is mostly zeros until it is finished, and those zeros are not black — they are nothing. Placed opaquely they painted over whatever was underneath, so a second overview blanked the first wherever it had not reached yet.

Overviews are now placed as colour plus coverage. **Coverage, not intensity** — the FM canvas's `to_rgba` makes alpha the signal strength, which does not transfer: matplotlib draws `colour × alpha + (1-α) × beneath`, so on a dense grayscale image anything with something behind it brightens. Measured on a mid-grey region over a textured one, it read **0.772 against a true 0.500**. FM never meets this because its composite sits over black.

**And the display filter does not get a vote.** `filtered_data` is a median(3) then a gaussian(σ=1), which smears the tile boundary *both* ways — signal leaks past it, so `filtered > 0` gives a mask a filter radius too generous, and the rows just inside get pulled down far enough to take the low contrast limit with them and bleach the whole mosaic (172/255 where 128 was right). So the mask and the limits come off `image.data`; only the colour comes from `filtered_data`.

No metadata changes: it is a display transform of the pixels, so a loaded overview behaves identically to one just acquired.

**Two measured costs.** A real pixel of exactly zero reads as a hole — 0.39% of an autocontrast-stretched frame, but 0.000% after the box-mean `downsample` that already runs first, so only whole unacquired blocks survive. And a *complete* overview renders slightly flatter than before (std 31.6 → 22.7) because the limits come off the unsmoothed array; stretching the filtered range back up would amplify the filter rather than the sample. FIB-415's contrast controls make that the user's choice.

## Shared furniture

`CoincidenceMillingConfirmationDialog` left a note: *"If a third of these appears, lift the shared parts into their own module."* This is the third, so the constants, chip, duration format, detail block and meta line moved to `fibsem/ui/widgets/preflight.py`. That removes ~25 duplicated layout lines from each existing dialog and the import chain where a beam-side milling dialog reached into an FM widget module for a `_chip`. A test asserts all three share one implementation.

## Verification

- 4719 tests pass (`tests/`, `tests/ui/`, `fibsem/applications/autolamella/ui/tests/`)
- Mutants killed: removing the defaults seed (3 tests), a cached factory instance (2), actions back inside the scroll area (2), forgetting the coverage (3), FM's intensity alpha (3), limits off the filtered array (1)
- Rendered and inspected: the tab at its defaults, the dialog for a dragged and partly-masked run, a 620 px window with a host section on top, and one overview placed over another

🤖 Generated with [Claude Code](https://claude.com/claude-code)