### PR TITLE
[ui] Derive the default correction factor from the lookup table (FIB-593)

### DIFF
--- a/fibsem/ui/correlation/widgets/refractive_index_widget.py
+++ b/fibsem/ui/correlation/widgets/refractive_index_widget.py
@@ -10,6 +10,7 @@ Usage::
 
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 from PyQt5.QtCore import pyqtSignal
@@ -31,16 +32,49 @@ _LUT_MISSING_MSG = (
     "The correction factor can still be edited manually."
 )
 
-# Default values representative of typical cryo-CLEM conditions
+# The configuration Perez et al. use for depth correction throughout: vitrified
+# cytoplasm (n = 1.35) through the Arctis iFLM's NA 0.75 objective, for which the
+# paper reports a scaling factor of 1.5 (doi:10.64898/2026.05.11.724418 — the
+# source of the lookup table below). Only NA and n2 move zeta appreciably; it is
+# near-flat in tilt, depth and wavelength, so those stay at typical values.
 _DEFAULTS = ZetaParams(
     tilt_deg=15.0,
     depth_um=4.0,
-    NA=0.8,
-    n2=1.4,
+    NA=0.75,
+    n2=1.35,
     wavelength_um=0.515,
 )
 
-_DEFAULT_FACTOR = 1.47
+# Only used when the lookup table cannot be read. Must equal the LUT's value at
+# _DEFAULTS — pinned by tests/correlation/test_default_correction_factor.py, so
+# change the two together or that test fails.
+_FALLBACK_FACTOR = 1.502
+
+
+def _default_factor() -> float:
+    """The correction factor for `_DEFAULTS`, from the lookup table.
+
+    Derived rather than declared. A literal constant beside a lookup table is a
+    second source of truth for the same number, and it drifts silently the moment
+    either side moves: the previous constant (1.470) described no configuration
+    the widget could be in, while its own defaults asked the table for 1.595
+    (FIB-593). Deriving means the reset button can only ever hand back the factor
+    the parameters above it describe.
+    """
+    try:
+        return lookup_zeta(
+            tilt_deg=_DEFAULTS.tilt_deg,
+            depth_um=_DEFAULTS.depth_um,
+            NA=_DEFAULTS.NA,
+            n2=_DEFAULTS.n2,
+            wavelength_um=_DEFAULTS.wavelength_um,
+        )
+    except Exception:
+        logging.debug(
+            "Lookup table unusable; falling back to the stored default correction factor",
+            exc_info=True,
+        )
+        return _FALLBACK_FACTOR
 
 # The correlation panels run at 11-12px. Controls and QFormLayout's auto-built
 # string labels default to the app font, which renders larger than the values
@@ -94,7 +128,6 @@ class RefractiveIndexWidget(QWidget):
         try:
             _ensure_lut()
         except Exception as e:
-            import logging
             logging.warning(f"Failed to download refractive index LUT: {e}")
         self._setup_ui()
         self._connect_signals()
@@ -147,14 +180,19 @@ class RefractiveIndexWidget(QWidget):
             minimum=0.1, maximum=10.0, step=0.01, decimals=3,
             tooltip="Correction factor (ζ) applied to the depth below the surface",
         )
-        self._spin_factor.setValue(_DEFAULT_FACTOR)
+        # Resolved once, so the initial value, the tooltip that advertises it and
+        # the button that restores it cannot disagree.
+        self._default_factor = _default_factor()
+        self._spin_factor.setValue(self._default_factor)
         form.addRow(_form_label("Correction Factor (ζ)"), self._spin_factor)
 
         self._btn_reset_factor = IconToolButton(
             "mdi:refresh",
-            tooltip=f"Reset correction factor to default ({_DEFAULT_FACTOR:.3f})",
+            tooltip=f"Reset correction factor to default ({self._default_factor:.3f})",
         )
-        self._btn_reset_factor.clicked.connect(lambda: self._spin_factor.setValue(_DEFAULT_FACTOR))
+        self._btn_reset_factor.clicked.connect(
+            lambda: self._spin_factor.setValue(self._default_factor)
+        )
 
         lut_available = _LUT_PATH.exists()
         self._lut_available = lut_available

--- a/tests/correlation/test_default_correction_factor.py
+++ b/tests/correlation/test_default_correction_factor.py
@@ -1,0 +1,97 @@
+"""The RI widget's default correction factor must come from the lookup table.
+
+FIB-593: the widget declared `_DEFAULT_FACTOR = 1.47` beside a lookup table that
+returned 1.595 for the widget's own default parameters. Two sources of truth for
+one number, with nothing holding them together, so the reset button handed back a
+factor that described none of the settings displayed above it.
+
+The factor is derived now. What still needs pinning is the offline fallback — a
+literal, and therefore free to drift again the moment the defaults move.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.correlation.refractive_index import _LUT_PATH, lookup_zeta
+from fibsem.ui.correlation.widgets.refractive_index_widget import (
+    _DEFAULTS,
+    _FALLBACK_FACTOR,
+    _default_factor,
+)
+
+# Unlike most tests in this directory, these need the *real* table: they are
+# about whether our constants agree with it, so a synthetic stand-in would
+# assert nothing. See FIB-637 — once the LUT ships in the package this skip goes.
+requires_lut = pytest.mark.skipif(
+    not _LUT_PATH.exists(), reason="real refractive-index LUT not present"
+)
+
+
+@requires_lut
+def test_the_fallback_matches_the_lookup_table():
+    """The guard that was missing.
+
+    `_FALLBACK_FACTOR` stands in for the LUT when it cannot be read, so it has to
+    be the value the LUT would have given. Changing `_DEFAULTS` without changing
+    it is exactly how 1.47 came to describe nothing — this test fails instead.
+    """
+    expected = lookup_zeta(
+        tilt_deg=_DEFAULTS.tilt_deg,
+        depth_um=_DEFAULTS.depth_um,
+        NA=_DEFAULTS.NA,
+        n2=_DEFAULTS.n2,
+        wavelength_um=_DEFAULTS.wavelength_um,
+    )
+    assert _FALLBACK_FACTOR == pytest.approx(expected, abs=5e-4), (
+        f"_FALLBACK_FACTOR is {_FALLBACK_FACTOR}, but the LUT gives {expected:.4f} "
+        f"at _DEFAULTS. Update the constant to match, or revert the defaults."
+    )
+
+
+@requires_lut
+def test_the_default_factor_is_read_from_the_table_not_the_constant():
+    """Derivation must be live, not a copy of the literal.
+
+    If `_default_factor()` ever returned `_FALLBACK_FACTOR` unconditionally the
+    test above would still pass, and the drift it exists to catch would be back.
+    """
+    expected = lookup_zeta(
+        tilt_deg=_DEFAULTS.tilt_deg,
+        depth_um=_DEFAULTS.depth_um,
+        NA=_DEFAULTS.NA,
+        n2=_DEFAULTS.n2,
+        wavelength_um=_DEFAULTS.wavelength_um,
+    )
+    assert _default_factor() == pytest.approx(expected, abs=1e-9)
+
+
+@requires_lut
+def test_the_defaults_reproduce_the_published_scaling_factor():
+    """`_DEFAULTS` describes a real instrument, not an arbitrary point.
+
+    Perez et al. (doi:10.64898/2026.05.11.724418) calculate 1.5 for vitrified
+    cytoplasm (n = 1.35) through the Arctis iFLM's NA 0.75 objective and use it
+    for depth correction throughout. Those are the widget's defaults, so the
+    factor it offers should be the paper's. This is the reason the defaults are
+    what they are; drift here means the widget has quietly stopped matching the
+    method it implements.
+    """
+    assert _DEFAULTS.NA == 0.75
+    assert _DEFAULTS.n2 == 1.35
+    assert _default_factor() == pytest.approx(1.5, abs=0.01)
+
+
+def test_an_unusable_lookup_table_yields_the_fallback(monkeypatch):
+    """Offline is the case the literal exists for — it must not raise."""
+    import fibsem.ui.correlation.widgets.refractive_index_widget as riw
+
+    def unusable(**kwargs):
+        raise FileNotFoundError("no lookup table")
+
+    monkeypatch.setattr(riw, "lookup_zeta", unusable)
+
+    assert riw._default_factor() == _FALLBACK_FACTOR


### PR DESCRIPTION
Fixes FIB-593.

The RI widget declared `_DEFAULT_FACTOR = 1.47` beside a lookup table that returns **1.595** for the widget's own default parameters. Two sources of truth for one number, with nothing holding them together — so the reset button, and the tooltip advertising the value it restores, handed back a factor describing none of the settings displayed above it.

Since #373 this is no longer cosmetic: placing an FM surface point arms whatever the factor box holds, so the default reaches a real correlation run.

## Where 1.470 came from

Traced against [Perez et al.](https://www.biorxiv.org/content/10.64898/2026.05.11.724418v1), the source of the lookup table. The paper reports two values:

> "we calculated the appropriate scaling factor for vitrified cytoplasm imaged with the **NA 0.75** objective of the Arctis iFLM, assuming a **refractive index of 1.35**. This yielded a value of **1.5**, which was used for depth correction throughout"

> "The average focal shift correction factor from several samples is found to be **1.43**." — beads, Hydra pFIB + Delmic Meteor, 50× NA 0.8

with an overall range of 1.3–1.6. **1.470 is neither.** It sits at NA 0.70 — an objective neither instrument has — and `git log -S` traces it to the original correlation widget, before the table existed.

## The table is right; `_DEFAULTS` was wrong

| Configuration | NA | n₂ | ζ from the LUT |
| --- | --- | --- | --- |
| Paper — Arctis iFLM, used throughout | 0.75 | 1.35 | **1.502** ✓ matches published 1.5 |
| `_DEFAULTS` before this PR | 0.8 | 1.40 | 1.595 |
| Where 1.470 would sit | 0.70 | 1.35 | 1.473 |

`_DEFAULTS` described no instrument in the paper: NA 0.8 is the Meteor objective, NA 0.75 the Arctis, and n₂ 1.4 is above the 1.35 assumed for vitrified cytoplasm.

## Changes

- **`_DEFAULTS` names the paper's Arctis configuration** — NA 0.75, n₂ 1.35. Tilt, depth and wavelength are unchanged: ζ is near-flat in all three (measured 1.585–1.600 across 0–30°, 1.595–1.600 across 420–720 nm), and only NA and n₂ move it appreciably. That matches the paper, which flags n₂ as the dominant uncertainty.
- **`_default_factor()` reads the table** at `_DEFAULTS`. `_FALLBACK_FACTOR` is the literal, used only when the table cannot be read (FIB-592), and a test pins it to the table's value so the two cannot drift apart again.
- **The resolved factor is stored once**, so the initial value, the tooltip and the reset button cannot disagree.

**Behaviour change: the default factor goes 1.470 → 1.502.** Deriving from the previous defaults would have given 1.595, so pointing them at the paper's instrument is the smaller change as well as the justified one.

## Verification

Real widget, constructed offscreen: opens at NA 0.75, n₂ 1.35, ζ 1.502, tooltip "Reset correction factor to default (1.502)". Set NA to 0.5 → 1.410; press reset → 1.502.

Four new tests, and all four mutations caught:

| Mutation | Caught by |
| --- | --- |
| Defaults changed without updating the fallback — *the original drift* | 2 tests |
| `_default_factor` returns the literal instead of reading the table | 1 |
| Defaults moved off the paper's instrument (both updated consistently) | 1 |
| The offline fallback raises instead of falling back | 1 |

`tests/correlation/`: 393 passed, 7 skipped (pre-existing `tmp/` volume skips).

Three of the four new tests skip when the real LUT is absent — they are about whether our constants agree with *that* table, so a synthetic one would assert nothing. FIB-637 removes that skip by shipping the table in the package.
