### PR TITLE
[ui] Mirror the toolbar with a status zone on the left (FIB-639)

### DIFF
--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -40,6 +40,7 @@ from matplotlib.backend_bases import MouseEvent
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 from PyQt5.QtCore import QSize, QTimer, Qt, pyqtSignal
+from PyQt5.QtGui import QFontMetrics
 from PyQt5.QtWidgets import QApplication, QLabel, QPushButton, QSizePolicy
 
 from fibsem.ui.icon import fibsem_icon
@@ -134,6 +135,18 @@ _TOP_CHROME_INSET = _OVERLAY_MARGIN + _OVERLAY_BTN_SIZE + 4
 _LIVE_BADGE_STYLE = (
     f"QLabel {{ background: {_LIVE_BADGE_BG}; color: {WHITE_ICON_COLOR};"
     " border-radius: 3px; padding: 0px 6px; font-size: 10px; font-weight: bold; }"
+)
+# The status zone mirrors the toolbar on the left of the same row, and carries whichever
+# of the hint or the flash is current. Two looks, because they say different things: the
+# hint is a standing instruction, the flash is a value that just changed and is about to
+# go away, so it keeps the accent outline the artist had.
+_STATUS_HINT_STYLE = (
+    f"QLabel {{ background: #e6e6e6; color: {NEUTRAL_900};"
+    " border-radius: 3px; padding: 0px 6px; font-size: 11px; }"
+)
+_STATUS_FLASH_STYLE = (
+    f"QLabel {{ background: {_BG}; color: #e8e8e8; border: 1px solid {_ACCENT};"
+    " border-radius: 3px; padding: 0px 6px; font-size: 12px; }"
 )
 
 
@@ -233,8 +246,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._scalebar_visible: bool = True
         self._crosshair_visible: bool = True
         self._crosshair_artists: list = []
-        self._hint_artist = None  # transient top-left instruction hint
-        self._hint_text: Optional[str] = None  # remembered so it survives set_image
+        self._hint_text: Optional[str] = None  # remembered; the status zone shows it
         self._title_artist = None  # top-centre image caption (e.g. FM z-slice)
         self._title_text: Optional[str] = None  # remembered so it survives set_image
         self._info_artist = None  # bottom-left microscope-state info bar
@@ -242,9 +254,13 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._live_badge = None  # top-right "● LIVE" chip during live acquisition
         self._live_on: bool = False  # remembered so it survives set_image
 
-        # Transient top-centre flash message (e.g. "WD 4.001 mm" on Shift+scroll); auto-clears
-        self._flash_artist = None
+        # Transient status message (e.g. "WD 4.001 mm" on Shift+scroll); auto-clears.
+        # Shares the top-left status zone with the hint, and outranks it while up.
         self._flash_text: Optional[str] = None
+        # The status zone itself: one chip mirroring the toolbar at the other end of the
+        # row. Qt-laid-out, so nothing converts between logical and device pixels.
+        self._status_label = None
+        self._status_full_text: str = ""  # untruncated; the layout pass elides a copy
         self._flash_timer = QTimer(self)
         self._flash_timer.setSingleShot(True)
         self._flash_timer.timeout.connect(self._clear_flash)
@@ -375,32 +391,14 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self.draw_idle()
 
     def set_hint(self, text: Optional[str]) -> None:
-        """Show a small instruction hint in the top-left corner, or hide with None.
+        """Show a small instruction hint in the top-left status zone, or hide with None.
 
-        Drawn in axes-fraction coords so it stays fixed through zoom/pan.  The text
-        is remembered and re-applied after each image change (``set_image`` clears
-        the axes), so the hint is not silently dropped by a new acquisition.
+        Shares that zone with :meth:`flash_message`, which outranks it while it is up —
+        the flash is a value that just changed, the hint is a standing instruction that
+        will still be true afterwards.
         """
         self._hint_text = text or None
-        self._refresh_hint()
-        self.draw_idle()
-
-    def _refresh_hint(self) -> None:
-        """(Re)create the hint artist from the cached text, or remove it."""
-        if self._hint_artist is not None:
-            try:
-                self._hint_artist.remove()
-            except Exception:
-                pass
-            self._hint_artist = None
-        if self._hint_text:
-            self._hint_artist = self._ax.text(
-                0.012, self._top_chrome_y(), self._hint_text,
-                transform=self.figure.transFigure, ha="left", va="top",
-                fontsize=8, color=NEUTRAL_900, zorder=11,
-                bbox=dict(boxstyle="round,pad=0.3", facecolor="#e6e6e6",
-                          edgecolor="none", alpha=0.85),
-            )
+        self._refresh_status()
 
     def set_title(self, text: Optional[str]) -> None:
         """Show a caption centred at the top of the image, or hide with None/''.
@@ -525,39 +523,54 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         return badge
 
     def flash_message(self, text: str, duration_ms: int = 1200) -> None:
-        """Show a brief top-centre status message that auto-clears after *duration_ms*.
+        """Show a brief status message that auto-clears after *duration_ms*.
 
         Repeated calls refresh the text and restart the timer, so it stays visible during a
         burst (e.g. Shift+scroll working-distance nudges) and fades shortly after the last
-        event. Independent of :meth:`set_hint` / :meth:`set_info_text` — transient, not
-        remembered across image changes."""
+        event. Takes the top-left status zone from :meth:`set_hint` while it is up, and
+        gives it back on clearing. Not remembered across image changes."""
         self._flash_text = text or None
-        self._refresh_flash()
-        self.draw_idle()
+        self._refresh_status()
         if self._flash_text:
             self._flash_timer.start(duration_ms)
 
-    def _refresh_flash(self) -> None:
-        """(Re)create the flash artist from the cached text, or remove it."""
-        if self._flash_artist is not None:
-            try:
-                self._flash_artist.remove()
-            except Exception:
-                pass
-            self._flash_artist = None
-        if self._flash_text:
-            self._flash_artist = self._ax.text(
-                0.5, self._top_chrome_y(4.0), self._flash_text,
-                transform=self.figure.transFigure, ha="center", va="top",
-                fontsize=9, color="#e8e8e8", zorder=12,
-                bbox=dict(boxstyle="round,pad=0.35", facecolor=_BG,
-                          edgecolor=_ACCENT, linewidth=1.0, alpha=0.85),
-            )
-
     def _clear_flash(self) -> None:
         self._flash_text = None
-        self._refresh_flash()
-        self.draw_idle()
+        self._refresh_status()
+
+    def _refresh_status(self) -> None:
+        """Put the current flash-or-hint into the top-left status zone.
+
+        A child widget in the toolbar's own layout pass, not an axes artist. The two used
+        to be matplotlib text positioned by arithmetic against Qt-laid-out controls, and
+        that arithmetic went wrong twice: once by ignoring the toolbar row entirely, and
+        once by dividing a logical inset by a device-pixel height, which is only correct
+        on a screen that is not a Retina one (FIB-639). Qt lays out in logical pixels
+        natively, so a `QLabel` has no conversion to get wrong.
+
+        The flash outranks the hint: it is a value that just changed and is about to go
+        away, while the hint is a standing instruction still true underneath it.
+        """
+        text = self._flash_text or self._hint_text
+        if not text:
+            if self._status_label is not None:
+                self._status_label.hide()
+            return
+        if self._status_label is None:
+            self._status_label = self._make_status_label()
+        self._status_label.setStyleSheet(
+            _STATUS_FLASH_STYLE if self._flash_text else _STATUS_HINT_STYLE
+        )
+        self._status_full_text = text
+        self._status_label.show()
+        self._reposition_overlay_buttons()  # sizes and elides it to the room available
+
+    def _make_status_label(self) -> QLabel:
+        """The status chip, sized to sit in the toolbar row."""
+        label = QLabel("", self)
+        label.setFixedHeight(_OVERLAY_BTN_SIZE)
+        label.raise_()
+        return label
 
     def set_legend(self, entries, loc: str = "upper right") -> None:
         """Show a small patch legend, or clear it with None / an empty list.
@@ -618,8 +631,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._ax.cla()
         self._scalebar_artist = None
         self._crosshair_artists = []
-        self._hint_artist = None  # removed by cla(); drop the cached text too
-        self._hint_text = None
+        self._hint_text = None  # the status chip is a widget; hidden below, not by cla()
         self._title_artist = None
         self._title_text = None
         self._info_artist = None
@@ -629,9 +641,10 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         if self._live_badge is not None:
             self._live_badge.hide()
         self._live_on = False
-        self._flash_artist = None
         self._flash_text = None
         self._flash_timer.stop()
+        if self._status_label is not None:
+            self._status_label.hide()
         self._legend_artist = None  # removed by cla(); drop the cached entries too
         self._legend_entries = None
         self._plot_empty()
@@ -690,6 +703,36 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         if badge is not None and not badge.isHidden():
             x -= badge.width()
             badge.move(x, _OVERLAY_MARGIN)
+        self._place_status_label(right_edge=x)
+
+    def _place_status_label(self, right_edge: int) -> None:
+        """Put the status chip at the left of the same row, elided to fit.
+
+        The two zones grow from opposite ends of a row one line tall, so they cannot
+        collide however long the text or however narrow the pane — which is what the
+        arithmetic that preceded this was trying, and failing, to guarantee. Elided
+        rather than clipped, so a long hint says it is truncated instead of running out
+        of room silently.
+        """
+        label = self._status_label
+        if label is None or label.isHidden():
+            return
+        available = right_edge - _OVERLAY_GAP - _OVERLAY_MARGIN
+        if available <= 0:
+            label.hide()  # no room at all; the controls win
+            return
+        metrics = QFontMetrics(label.font())
+        # `sizeHint` carries the stylesheet padding, which the metrics do not.
+        label.setText(self._status_full_text)
+        padding = max(label.sizeHint().width() - metrics.width(self._status_full_text), 0)
+        label.setText(
+            metrics.elidedText(
+                self._status_full_text, Qt.ElideRight, max(available - padding, 0)
+            )
+        )
+        label.adjustSize()
+        label.resize(min(label.width(), available), _OVERLAY_BTN_SIZE)
+        label.move(_OVERLAY_MARGIN, _OVERLAY_MARGIN)
 
     def set_toolbar_visible(self, visible: bool) -> None:
         """Show or hide this canvas's top-right toolbar buttons as a group.
@@ -721,12 +764,8 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._reposition_overlay_buttons()
         # The top-centre chrome is inset by a pixel count, so its figure fraction has to
         # be recomputed when the figure changes size or it drifts across the toolbar row.
-        if self._hint_text:
-            self._refresh_hint()
         if self._title_text:
-            self._refresh_title()
-        if self._flash_text:
-            self._refresh_flash()
+            self._refresh_title()  # still an artist: the caption belongs over the image
         contrast = getattr(self, "_contrast", None)
         if contrast is not None and contrast.isVisible():
             contrast.reposition()

--- a/fibsem/ui/widgets/canvas/image_canvas.py
+++ b/fibsem/ui/widgets/canvas/image_canvas.py
@@ -105,12 +105,12 @@ class FibsemImageCanvas(FibsemCanvasBase):
             self._pixel_size = pixel_size
         self._refresh_scalebar()
         self._refresh_crosshair()
-        self._refresh_hint()  # axes was cleared above; restore the remembered hint
+        # No hint or flash here either: both are the status chip, a child widget, so
+        # `cla()` never took them down and there is nothing to restore (FIB-639).
         self._refresh_title()  # ditto: restore the remembered title
         self._refresh_info_bar()  # ditto: restore the remembered info bar
         # No LIVE chip here: it is a child widget, not an artist, so `cla()` never took
         # it down and there is nothing to restore (FIB-596).
-        self._refresh_flash()  # ditto: keep a live flash (e.g. WD scroll) visible across frames
         self._refresh_legend()  # ditto: restore the patch legend
 
         self._notify_overlays(self._content_rect())

--- a/tests/ui/test_canvas_base.py
+++ b/tests/ui/test_canvas_base.py
@@ -139,27 +139,21 @@ def test_the_toolbar_toggle_still_round_trips(noun):
     assert button.isChecked() is True and button.toolTip() == f"Hide {noun}"
 
 
-class TestTheTopLabelsClearTheToolbarRow:
-    """The hint, title and flash sit along the canvas's top edge; the toolbar buttons and
-    the LIVE chip sit top-right. Anchoring the labels in `transAxes` and the controls in
-    widget pixels left them on one horizontal band, separated only by however much room a
-    centred string happened to leave — which ran out below about 560 px of canvas width,
-    and the FM pane in a 2x2 grid is narrower than that.
+class TestTheTopStripHasTwoZones:
+    """One row, two zones growing from opposite ends: controls right, status left.
 
-    All three labels follow one rule now. The hint especially needed it: anchored at the
-    axes' own top it sat *above* the flash on a frame that filled its pane and *below* it
-    on a letterboxed one, so the two swapped order with the image's aspect ratio.
-
-    Same fault as the chip-under-the-toolbar one below, one slot along.
+    The strip had five tenants and no rule, and produced three collisions in two days --
+    the LIVE chip under the buttons, the flash on the chip, and the flash on the chip
+    again on a Retina display. Each was fixed by arithmetic keeping one coordinate system
+    clear of another. This removes the arithmetic: both zones are Qt-laid-out, in logical
+    pixels, by the same pass, so they cannot reach each other however long the text or
+    however narrow the pane (FIB-639).
     """
 
     @staticmethod
     def _canvas(w=460, h=380):
         c = FibsemImageCanvas()
         dpi = c.figure.dpi
-        # Both, and in this order: the figure drives the artists, the widget drives the
-        # chip. Offscreen, `resize` alone leaves the figure at its default and the two
-        # are then measured in different worlds.
         c.figure.set_size_inches(w / dpi, h / dpi)
         c.resize(w, h)
         c.set_array(_img(512, 512), pixel_size=1e-8)
@@ -167,84 +161,106 @@ class TestTheTopLabelsClearTheToolbarRow:
         c._reposition_overlay_buttons()
         return c
 
-    @staticmethod
-    def _rows_overlap(canvas, artist):
-        chip = canvas._live_badge.geometry()
-        bb = artist.get_window_extent(canvas.get_renderer())
-        h = canvas.height()
-        top, bottom = h - bb.y1, h - bb.y0  # matplotlib y is bottom-up
-        return bottom > chip.y() and top < chip.y() + chip.height()
-
-    @pytest.mark.parametrize("width", [360, 420, 480, 520, 560, 900])
-    def test_the_flash_never_shares_a_row_with_the_live_chip(self, width):
+    @pytest.mark.parametrize("width", [300, 360, 420, 480, 560, 900])
+    def test_the_zones_never_reach_each_other(self, width):
         c = self._canvas(w=width)
         c.flash_message("OBJ 6000.0 um  (+1.0 um)")
-        c.draw()
 
-        assert not self._rows_overlap(c, c._flash_artist)
+        status, chip = c._status_label, c._live_badge
+        if status.isHidden():
+            return  # no room at all is a valid answer; the controls win
+        assert status.geometry().right() < chip.geometry().left()
 
-    @pytest.mark.parametrize("width", [360, 480, 900])
-    def test_the_title_never_shares_a_row_with_it_either(self, width):
-        """Same slot, same fault — a long z-slice caption would have collided too."""
+    @pytest.mark.parametrize("width", [300, 460, 900])
+    def test_a_very_long_hint_is_elided_rather_than_overrunning(self, width):
         c = self._canvas(w=width)
-        c.set_title("z 42 / 120")
-        c.draw()
+        c.set_hint("Shift+scroll to focus the objective, " * 10)
 
-        assert not self._rows_overlap(c, c._title_artist)
+        status = c._status_label
+        if status.isHidden():
+            return
+        assert status.geometry().right() < c._live_badge.geometry().left()
+        assert status.text() != c._status_full_text  # actually truncated
+        assert status.text().endswith("…")
 
-    @pytest.mark.parametrize("width", [360, 480, 900])
-    def test_the_hint_never_shares_a_row_with_it_either(self, width):
-        """Top-left, but a long enough hint reaches the buttons — and it was the one
-        anchored at the axes' top, so on a filling frame it sat level with them."""
-        c = self._canvas(w=width)
-        c.set_hint("Shift+scroll to focus the objective, double-click to move the stage")
-        c.draw()
-
-        assert not self._rows_overlap(c, c._hint_artist)
-
-    @pytest.mark.parametrize(
-        "image", [(512, 512), (512, 768), (768, 512)], ids=["square", "wide", "tall"]
-    )
-    def test_the_three_labels_share_a_row_whatever_the_aspect(self, image):
-        """The hint used to swap places with the flash depending on the image's aspect,
-        because one was anchored to the axes and the other to the figure."""
-        c = self._canvas(w=460, h=380)
-        c.set_array(_img(*image), pixel_size=1e-8)
-        c.set_hint("Shift+scroll to focus")
-        c.set_title("z 42 / 120")
-        c.flash_message("OBJ 6000.0 um  (+1.0 um)")
-        c.draw()
-
-        r = c.get_renderer()
-        tops = [
-            c.height() - a.get_window_extent(r).y1
-            for a in (c._hint_artist, c._title_artist, c._flash_artist)
-        ]
-        assert max(tops) - min(tops) < 10, f"labels scattered across {tops}"
-
-    def test_it_sits_below_the_toolbar_rather_than_above_it(self):
-        """Below, so it never covers a button. Above would clear the chip too."""
+    def test_the_flash_outranks_the_hint_and_gives_it_back(self):
+        """One zone, two sources. The flash is a value that just changed; the hint is a
+        standing instruction still true underneath it."""
         c = self._canvas()
+        c.set_hint("Shift+scroll to focus")
+        assert c._status_label.text() == "Shift+scroll to focus"
+
         c.flash_message("OBJ 6000.0 um")
+        assert c._status_label.text() == "OBJ 6000.0 um"
+
+        c._clear_flash()
+        assert c._status_label.text() == "Shift+scroll to focus"
+
+    def test_the_two_sources_look_different(self):
+        """A standing instruction and a value that is about to vanish should not be the
+        same chip."""
+        c = self._canvas()
+        c.set_hint("Shift+scroll to focus")
+        hint_style = c._status_label.styleSheet()
+        c.flash_message("OBJ 6000.0 um")
+
+        assert c._status_label.styleSheet() != hint_style
+
+    def test_clearing_the_hint_hides_the_zone(self):
+        c = self._canvas()
+        c.set_hint("Shift+scroll to focus")
+        c.set_hint(None)
+
+        assert c._status_label.isHidden()
+
+    def test_a_new_frame_does_not_drop_the_hint(self):
+        """It is a widget, so `cla()` never removes it and `set_image` has nothing to
+        re-apply -- the same trade the LIVE chip already made."""
+        c = self._canvas()
+        c.set_hint("Shift+scroll to focus")
+
+        c.set_array(_img(512, 512), pixel_size=1e-8)  # the next streamed frame
+
+        assert not c._status_label.isHidden()
+        assert c._status_label.text() == "Shift+scroll to focus"
+
+    def test_clearing_the_canvas_hides_it(self):
+        c = self._canvas()
+        c.set_hint("Shift+scroll to focus")
+
+        c.clear()
+
+        assert c._status_label.isHidden()
+
+    def test_no_room_at_all_yields_to_the_controls(self):
+        """A pane narrower than its own toolbar. Better to drop the status text than to
+        draw it under the buttons."""
+        c = self._canvas(w=120)
+        c.set_hint("Shift+scroll to focus")
+
+        assert c._status_label.isHidden()
+
+    @pytest.mark.parametrize("width", [360, 480, 900])
+    def test_the_title_still_clears_the_row(self, width):
+        """The caption stays centred and stays an artist -- it labels the image, not the
+        session -- so it keeps the inset the status zone no longer needs."""
+        c = self._canvas(w=width)
+        c.set_title("z 42 / 120")
         c.draw()
 
-        bb = c._flash_artist.get_window_extent(c.get_renderer())
-        top = c.height() - bb.y1
-        assert top >= c._live_badge.geometry().y() + c._live_badge.height()
+        chip = c._live_badge.geometry()
+        bb = c._title_artist.get_window_extent(c.get_renderer())
+        top, bottom = c.height() - bb.y1, c.height() - bb.y0
+        assert not (bottom > chip.y() and top < chip.y() + chip.height())
 
     @pytest.mark.parametrize("device_ratio", [1, 2], ids=["standard", "retina"])
-    def test_the_inset_is_logical_pixels_whatever_the_device_ratio(self, device_ratio):
-        """The bug the first fix shipped with, and the one this suite could not see.
-
-        matplotlib keeps `figure.bbox` in **device** pixels, so on a Retina display it is
-        twice the widget's logical height. The toolbar row the labels must clear is laid
-        out by Qt in *logical* pixels, so dividing a logical inset by a device height
-        halved it and put them back inside the row — on exactly the machines with a
-        Retina screen, which is every Mac and no CI runner.
-
-        Simulated by sizing the figure at `device_ratio` times the widget, which is what
-        the Qt backend does. Offscreen the real ratio is always 1, so the situation
-        cannot be reached any other way.
+    def test_the_title_inset_is_logical_pixels_whatever_the_device_ratio(
+        self, device_ratio
+    ):
+        """The title is the last thing positioned by hand, so it keeps the bug the
+        status zone no longer can have: `figure.bbox` is in device pixels, the toolbar
+        row is laid out in logical ones, and dividing one by the other halves the inset
+        on a Retina screen -- every Mac and no CI runner.
         """
         c = FibsemImageCanvas()
         dpi = c.figure.dpi
@@ -253,30 +269,7 @@ class TestTheTopLabelsClearTheToolbarRow:
 
         inset_logical = (1.0 - c._top_chrome_y()) * c.height()
 
-        assert inset_logical == pytest.approx(30.0), (
-            f"inset came out {inset_logical:.1f} logical px at device ratio "
-            f"{device_ratio}; the toolbar row it must clear is 26"
-        )
-
-    def test_shrinking_the_canvas_keeps_it_clear(self):
-        """The inset is a pixel count, so its figure fraction has to be recomputed when
-        the figure changes size or it drifts back across the toolbar row.
-
-        Shrinking, specifically. A stale fraction on a *taller* figure resolves to a
-        larger pixel inset and stays clear by luck — so growing proves nothing, and a
-        test that grew was the one this replaced.
-        """
-        c = self._canvas(w=460, h=900)
-        c.flash_message("OBJ 6000.0 um  (+1.0 um)")
-        c.draw()
-
-        dpi = c.figure.dpi
-        c.figure.set_size_inches(460 / dpi, 300 / dpi)
-        c.resize(460, 300)
-        c.resizeEvent(_resize_event(460, 300))
-        c.draw()
-
-        assert not self._rows_overlap(c, c._flash_artist)
+        assert inset_logical == pytest.approx(30.0)
 
 
 class TestTheLiveChipClearsTheToolbar:


### PR DESCRIPTION
Closes FIB-639. Replaces the stopgap merged in #404.

## Why

The canvas's top edge had five tenants and no rule, and produced three collisions in two days:

| collision | fix |
|---|---|
| LIVE chip under the toolbar buttons | FIB-596 |
| focus flash on top of the LIVE chip | #404 |
| the same again on a Retina display | #404 |

Each was correct and none addressed the cause: the strip held **three coordinate systems**, so anything in one had to be kept clear of the others by arithmetic — and arithmetic is a thing that can be got wrong. It was, twice.

## What

One row, two zones growing from opposite ends. **Controls right** — the buttons and the LIVE chip, unchanged. **Status left** — one chip carrying whichever of the hint or the flash is current. They cannot reach each other however long the text or however narrow the pane, because the same pass places both from opposite ends of a row one line tall.

**A `QLabel` rather than an axes artist, and that is the substance rather than a detail.** Qt lays out in logical pixels natively, so there is no device-pixel conversion left to get wrong — which is exactly how the Retina bug happened, and why the LIVE chip has been solid since it stopped being an artist.

The flash outranks the hint while it is up and hands the zone back on clearing: the flash is a value that just changed and is about to vanish, the hint a standing instruction still true underneath it.

Elided rather than clipped, so a long hint says it is truncated instead of running out of room silently. Where there is no room at all — a pane narrower than its own toolbar — the zone hides and the controls win.

## What stayed

The **title** stays centred and stays an artist: it captions the image rather than the session, so it belongs over the frame. That makes it the last top chrome positioned by hand, so it keeps `_top_chrome_y` and the logical-pixel inset — and the Retina test stays, aimed at it, since it is now the only thing that can still have that bug.

The **bottom chrome** (info bar, scalebar) stays as axes artists. Nothing competes down there and they are anchored to the image on purpose.

## Testing

11 tests replacing the 9 that pinned the old arithmetic. Mutation-checked:

| mutant | fails |
|---|---|
| flash/hint priority inverted | 1 |
| no elision | 3 |
| no yield when there is no room | 1 |
| `clear()` leaves the chip up | 1 |

`tests/ui/` + `tests/fm/` — 1973 passed, 1 skipped, on the rebase.
