### PR TITLE
[fix] Share one image-to-microscope pixel conversion (FIB-362)

### DIFF
--- a/fibsem/conversions.py
+++ b/fibsem/conversions.py
@@ -5,6 +5,41 @@ import numpy as np
 from fibsem.structures import FibsemImage, Point
 
 
+def image_to_microscope_image_coordinates_px(
+    coord: Point, image_shape: Tuple[int, int], subpixel_precision: bool
+) -> Point:
+    """
+    Convert an image pixel coordinate to a microscope image coordinate, in pixels.
+
+    The microscope image coordinate system is centered on the image with positive Y-axis pointing upwards,
+    so y is mirrored about the centre where x is only shifted. This is the single source of that convention:
+    the two metres-returning functions below are this plus a pixel-size multiply, and the correlation module
+    reprojects points through it (FIB-362).
+
+    ``subpixel_precision`` has no default on purpose. Flooring the centre only differs from the true centre
+    on an odd image dimension, and then by half a pixel -- small enough to go unnoticed and large enough to
+    matter, so each caller says which it wants.
+
+    Args:
+        coord (Point): A Point object representing the pixel coordinates in the original image.
+        image_shape (Tuple[int, int]): The shape of the image (height, width).
+        subpixel_precision (bool): Floors the centre to a whole pixel if False.
+
+    Returns:
+        Point: A Point object representing the corresponding microscope image coordinates, in pixels.
+    """
+    # convert from image pixel coord (0, 0) top left to microscope image (0, 0) mid
+    centre_px = np.asarray(image_shape) / 2
+    if not subpixel_precision:
+        centre_px = np.asarray(image_shape) // 2
+    cy, cx = centre_px
+
+    # distance from centre?
+    return Point(
+        x=float(coord.x - cx),   # neg = left
+        y=float(cy - coord.y),   # neg = down
+    )
+
 def image_to_microscope_image_coordinates(
     coord: Point, image: np.ndarray, pixelsize: float, subpixel_precision: bool = False
 ) -> Point:
@@ -22,22 +57,11 @@ def image_to_microscope_image_coordinates(
     Returns:
         Point: A Point object representing the corresponding microscope image coordinates in meters.
     """
-    # convert from image pixel coord (0, 0) top left to microscope image (0, 0) mid
+    point_px = image_to_microscope_image_coordinates_px(
+        coord, image.shape, subpixel_precision
+    )
 
-    # shape
-    centre_px = np.asarray(image.shape) / 2
-    if not subpixel_precision:
-        centre_px = np.asarray(image.shape) // 2
-    cy, cx = centre_px
-
-    # distance from centre?
-    dy = float(-(coord.y - cy))  # neg = down
-    dx = float(coord.x - cx)  # neg = left
-
-    point_m = convert_point_from_pixel_to_metres(Point(dx, dy), pixelsize)
-    # point_m = Point(dx, dy)._to_metres(pixel_size=pixelsize)
-
-    return point_m
+    return convert_point_from_pixel_to_metres(point_px, pixelsize)
 
 def image_to_microscope_image_coordinates2(
     coord: Point, image_shape: Tuple[int, int], pixelsize: float, subpixel_precision: bool = False
@@ -56,24 +80,14 @@ def image_to_microscope_image_coordinates2(
     Returns:
         Point: A Point object representing the corresponding microscope image coordinates in meters.
     """
-    # convert from image pixel coord (0, 0) top left to microscope image (0, 0) mid
-
     if len(image_shape) != 2:
         raise ValueError("image_shape must be a tuple of two integers (height, width)")
 
-    # shape
-    centre_px = np.asarray(image_shape) / 2
-    if not subpixel_precision:
-        centre_px = np.asarray(image_shape) // 2
-    cy, cx = centre_px
+    point_px = image_to_microscope_image_coordinates_px(
+        coord, image_shape, subpixel_precision
+    )
 
-    # distance from centre?
-    dy = float(-(coord.y - cy))  # neg = down
-    dx = float(coord.x - cx)  # neg = left
-
-    point_m = Point(dx, dy)._to_metres(pixel_size=pixelsize)
-
-    return point_m
+    return point_px._to_metres(pixel_size=pixelsize)
 
 def microscope_image_to_image_coordinates(point: Point, image_shape: Tuple[int, int], pixel_size: float) -> Point:
     """

--- a/fibsem/correlation/correlation_v2.py
+++ b/fibsem/correlation/correlation_v2.py
@@ -18,6 +18,7 @@ from fibsem.correlation.structures import (
     PointXYZ,
     apply_z_surface_correction,
 )
+from fibsem.conversions import image_to_microscope_image_coordinates_px
 from fibsem.structures import Point
 
 DEFAULT_OPTIMIZATION_PARAMETERS = {
@@ -245,19 +246,15 @@ def run_correlation(
 def convert_poi_to_microscope_coordinates(
     poi_coordinates: np.ndarray, fib_image_shape: tuple, pixel_size_um: float
 ) -> list:
-    # image centre
-    cx = float(fib_image_shape[1] * 0.5)
-    cy = float(fib_image_shape[0] * 0.5)
-
     poi_image_coordinates: list = []
 
     for i in range(poi_coordinates.shape[1]):
         px = poi_coordinates[:, i]  # (x, y, z) in pixel coordinates
         px = [float(px[0]), float(px[1])]
-        px_x, px_y = (
-            px[0] - cx,
-            cy - px[1],
-        )  # point in microscope image coordinates (px)
+        pt_px = image_to_microscope_image_coordinates_px(
+            Point(px[0], px[1]), fib_image_shape, subpixel_precision=True
+        )
+        px_x, px_y = pt_px.x, pt_px.y
         pt_um = (
             px_x * pixel_size_um,
             px_y * pixel_size_um,
@@ -268,32 +265,6 @@ def convert_poi_to_microscope_coordinates(
              "px_um": [pt_um[0], pt_um[1]],                 # micrometers
              "px_m": [pt_um[0] * 1e-6, pt_um[1] * 1e-6]}    # meters
         )
-
-    return poi_image_coordinates
-
-def _convert_poi_to_microscope_image_coordinate(
-    poi_coordinates: Tuple[float, float], 
-    fib_image_shape: Tuple[int, int], 
-    pixel_size_um: float
-) -> Dict[str, List[float]]:
-    """Convert a single point of interest to microscope image coordinates. 
-    Point of Interest (POI) is in 2D image coordinates (x, y) in image pixels.
-    Microscope Image Coordinates are centred at the image centre (0, 0) and in micrometers.
-    Args:
-        poi_coordinates (Tuple[float, float]): Point of Interest (POI) in 2D image coordinates (x, y) in image pixels.
-        fib_image_shape (Tuple[int, int]): Shape of the FIBSEM image (height, width).
-        pixel_size_um (float): Pixel size in micrometers.
-    Returns:
-        Dict[str, List[float]]: Dictionary containing the POI in different coordinate systems."""
-    
-    # image centre
-    cx = float(fib_image_shape[1] * 0.5)
-    cy = float(fib_image_shape[0] * 0.5)
-
-    px = [float(poi_coordinates[0]), float(poi_coordinates[1])] # (x, y) in pixel coordinates
-    px_x, px_y = (px[0] - cx, cy - px[1])  # point in microscope image coordinates (px)
-    pt_um = (px_x * pixel_size_um,px_y * pixel_size_um)  # point in microscope image coordinates (um)
-    poi_image_coordinates = {"image_px": px, "px": [px_x, px_y], "px_um": [pt_um[0], pt_um[1]]}
 
     return poi_image_coordinates
 
@@ -382,10 +353,16 @@ def _reproject_poi_via_transform(
     """
     R = np.asarray(transformation["rotation_quaternion"], dtype=float)
     if R.shape != (3, 3):
-        logging.warning(
-            f"Cannot reproject POI: unexpected rotation shape {R.shape}"
+        # Unreachable from the only call site — extract_transformation_data
+        # always writes Rigid3D.q — but kept, and kept loud. A (3,) R broadcasts
+        # cleanly through the matmul below and yields plausible garbage instead
+        # of raising, and a broken transform here is the same broken transform
+        # that produced the result's own POI, so there is nothing worth
+        # salvaging. This used to log a warning and return [], which dropped the
+        # ghost marker and left the run looking fine.
+        raise ValueError(
+            f"Cannot reproject POI: expected a 3x3 rotation matrix, got {R.shape}"
         )
-        return []
     s = float(transformation["scale"])
     d = np.asarray(
         transformation["translation_around_rotation_center_zero"], dtype=float
@@ -397,8 +374,11 @@ def _reproject_poi_via_transform(
         x, y = float(projected[0, i]), float(projected[1, i])
         poi = CorrelationPointOfInterest(image_px=Point(x, y))
         if fib_shape is not None and pixel_size is not None:
-            cx, cy = fib_shape[1] / 2.0, fib_shape[0] / 2.0
-            poi.px = Point(x - cx, cy - y)
+            # pixel_size is in metres here (CorrelationInputData), not the µm
+            # that convert_poi_to_microscope_coordinates takes.
+            poi.px = image_to_microscope_image_coordinates_px(
+                Point(x, y), fib_shape, subpixel_precision=True
+            )
             poi.px_m = Point(poi.px.x * pixel_size, poi.px.y * pixel_size)
         pois.append(poi)
     return pois

--- a/fibsem/correlation/structures.py
+++ b/fibsem/correlation/structures.py
@@ -10,6 +10,7 @@ import os
 import time
 
 import numpy as np
+from fibsem.conversions import image_to_microscope_image_coordinates_px
 from fibsem.structures import FibsemImage, Point
 from fibsem.fm.structures import FluorescenceImage
 
@@ -484,8 +485,14 @@ class CorrelationResult:
         ]
         corrected_y = scale_about_surface(poi0.image_px.y, surface_y, correction_factor)
         poi0.image_px.y = corrected_y
-        cy = fib_shape[0] / 2.0
-        poi0.px.y = -(corrected_y - cy)
+        # x is discarded, not recomputed-and-ignored: a y-only correction leaves
+        # px.x alone, and rewriting it here would quietly repair an inconsistent
+        # one rather than leave the inconsistency visible.
+        poi0.px.y = image_to_microscope_image_coordinates_px(
+            Point(x=poi0.image_px.x, y=corrected_y),
+            fib_shape,
+            subpixel_precision=True,
+        ).y
         poi0.px_m.y = poi0.px.y * pixel_size
         self.refractive_index_correction_factor = correction_factor
         self.refractive_index_correction_mode = "post"

--- a/tests/correlation/test_microscope_coordinate_conversion.py
+++ b/tests/correlation/test_microscope_coordinate_conversion.py
@@ -1,0 +1,245 @@
+"""The correlation module converts image px → microscope px exactly once.
+
+FIB-362: the conversion was written out four times in the correlation
+module alone — twice in `correlation_v2` (once in a helper nothing called), once
+inside `_reproject_poi_via_transform`, and once in
+`apply_refractive_index_correction`, where it produces `px_m`, the number
+Continue commits to the experiment. `fibsem.conversions` already owned the
+concept, so all four now go through
+`image_to_microscope_image_coordinates_px` there.
+
+The tests that matter are the cross-checks: each caller is compared against the
+shared function *and against each other*, so a formula edited in one place and
+not the others fails rather than silently disagreeing.
+
+Correlation asks for `subpixel_precision=True` throughout, which is what its own
+arithmetic did. The flag is not cosmetic — see
+`test_the_correlation_module_asks_for_the_true_centre`.
+"""
+import math
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from fibsem.conversions import image_to_microscope_image_coordinates_px
+from fibsem.correlation.correlation_v2 import (
+    _reproject_poi_via_transform,
+    convert_poi_to_microscope_coordinates,
+)
+from fibsem.correlation.structures import (
+    CorrelationInputData,
+    CorrelationPointOfInterest,
+    CorrelationResult,
+    Coordinate,
+    PointType,
+    PointXYZ,
+)
+from fibsem.structures import Point
+
+_SHAPE = (512, 1024)  # (height, width) — deliberately not square
+_ODD_SHAPE = (511, 1023)  # the only case where the centre rounding shows
+_PIXEL_SIZE_UM = 0.02
+_PIXEL_SIZE_M = _PIXEL_SIZE_UM * 1e-6
+
+
+def _centred(x: float, y: float, shape=None):
+    """The shared conversion, as the correlation module asks for it."""
+    pt = image_to_microscope_image_coordinates_px(
+        Point(x, y), shape or _SHAPE, subpixel_precision=True
+    )
+    return pt.x, pt.y
+
+# Identity transform: FM-space coordinates land unchanged as FIB image pixels,
+# so the same point can be pushed through the reprojection and the correlation
+# output and the two compared directly.
+_IDENTITY = {
+    "scale": 1.0,
+    "rotation_quaternion": np.eye(3).tolist(),
+    "translation_around_rotation_center_zero": [0.0, 0.0, 0.0],
+}
+
+
+# ---------------------------------------------------------------------------
+# The convention itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_image_centre_is_the_origin():
+    assert _centred(512.0, 256.0) == (0.0, 0.0)
+
+
+def test_y_is_mirrored_and_x_is_not():
+    """The asymmetry is the whole reason this is worth writing once: +y is *up*
+    in microscope coordinates and down in image pixels, while x agrees."""
+    right_and_down = _centred(612.0, 356.0)
+    assert right_and_down == (100.0, -100.0)
+
+    left_and_up = _centred(412.0, 156.0)
+    assert left_and_up == (-100.0, 100.0)
+
+
+def test_the_width_sets_x_and_the_height_sets_y():
+    """A transposed shape would still look right on a square image. This is the
+    check that catches shape[0]/shape[1] being swapped."""
+    x, y = _centred(0.0, 0.0)
+    assert (x, y) == (-512.0, 256.0)
+
+
+def test_the_correlation_module_asks_for_the_true_centre():
+    """Why every correlation call site passes `subpixel_precision=True`.
+
+    `fibsem.conversions` defaults to flooring the centre, which the movement and
+    milling paths have always done. On an even dimension the two agree exactly;
+    on an odd one they differ by half a pixel — small enough to miss in review,
+    and a real shift in a correlation result. This pins that correlation gets
+    the un-floored centre, whatever the default becomes.
+    """
+    floored = image_to_microscope_image_coordinates_px(
+        Point(700.0, 100.0), _ODD_SHAPE, subpixel_precision=False
+    )
+    assert (floored.x, floored.y) == (189.0, 155.0)
+    assert _centred(700.0, 100.0, _ODD_SHAPE) == (188.5, 155.5)
+
+    # ...and on an even dimension there is nothing to choose between them.
+    even = image_to_microscope_image_coordinates_px(
+        Point(700.0, 100.0), _SHAPE, subpixel_precision=False
+    )
+    assert (even.x, even.y) == _centred(700.0, 100.0)
+
+
+# ---------------------------------------------------------------------------
+# Every caller agrees — the drift check
+#
+# Parametrised over an odd shape as well as an even one, and that is not
+# padding: on an even dimension `subpixel_precision` makes no difference at all,
+# so an even-only test cannot tell whether a call site asked for the right one.
+# ---------------------------------------------------------------------------
+
+_SHAPES = [_SHAPE, _ODD_SHAPE]
+
+
+def _correlation_output_px(x: float, y: float, shape):
+    """`px` / `px_m` as the correlation output records them for one POI."""
+    poi = convert_poi_to_microscope_coordinates(
+        np.array([[x], [y], [0.0]]), shape, _PIXEL_SIZE_UM
+    )[0]
+    return poi["px"], poi["px_m"]
+
+
+@pytest.mark.parametrize("shape", _SHAPES)
+def test_the_correlation_output_uses_the_shared_conversion(shape):
+    px, _ = _correlation_output_px(700.0, 100.0, shape)
+    assert tuple(px) == _centred(700.0, 100.0, shape)
+
+
+@pytest.mark.parametrize("shape", _SHAPES)
+def test_the_ghost_reprojection_agrees_with_the_correlation_output(shape):
+    """The ghost marker and the real POI are drawn in the same image from the
+    same fitted transform. If their conversions disagree the shift between them
+    — the only thing the ghost exists to show — is wrong by the difference.
+
+    Note the two paths take the pixel size in different units, metres here and
+    micrometres above, which is exactly the kind of detail that rots when the
+    arithmetic is duplicated.
+    """
+    ghost = _reproject_poi_via_transform(
+        _IDENTITY, np.array([[700.0, 100.0, 0.0]]), shape, _PIXEL_SIZE_M
+    )[0]
+    px, px_m = _correlation_output_px(700.0, 100.0, shape)
+
+    assert (ghost.image_px.x, ghost.image_px.y) == (700.0, 100.0)
+    assert (ghost.px.x, ghost.px.y) == tuple(px)
+    assert (ghost.px.x, ghost.px.y) == _centred(700.0, 100.0, shape)
+    assert ghost.px_m.x == pytest.approx(px_m[0])
+    assert ghost.px_m.y == pytest.approx(px_m[1])
+
+
+def _post_result(shape, px=None) -> CorrelationResult:
+    """A result ready for a post correction: FIB surface at y=200, POI at y=300."""
+    return CorrelationResult(
+        poi=[
+            CorrelationPointOfInterest(
+                image_px=Point(x=700.0, y=300.0),
+                px=px if px is not None else Point(),
+                px_m=Point(),
+            )
+        ],
+        input_data=CorrelationInputData(
+            surface_coordinate=Coordinate(
+                point=PointXYZ(y=200.0), point_type=PointType.SURFACE
+            ),
+            fib_image=SimpleNamespace(
+                data=np.zeros(shape, dtype=np.uint8),
+                metadata=SimpleNamespace(
+                    pixel_size=SimpleNamespace(x=_PIXEL_SIZE_M),
+                    image_settings=SimpleNamespace(filename="fake.tif"),
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.mark.parametrize("shape", _SHAPES)
+def test_the_post_correction_uses_the_shared_conversion(shape):
+    """`px_m` here is the number Continue commits, so this caller drifting is
+    the one that reaches the microscope (FIB-321)."""
+    result = _post_result(shape)
+
+    result.apply_refractive_index_correction(1.5)
+
+    corrected_y = 350.0  # 200 + (300 - 200) * 1.5
+    _, expected_px_y = _centred(700.0, corrected_y, shape)
+    assert math.isclose(result.poi[0].image_px.y, corrected_y)
+    assert math.isclose(result.poi[0].px.y, expected_px_y)
+    assert math.isclose(result.poi[0].px_m.y, expected_px_y * _PIXEL_SIZE_M)
+
+
+def test_the_post_correction_leaves_x_alone():
+    """Only y moves, so px.x must be left as it was rather than recomputed —
+    rewriting it would quietly repair an inconsistency instead of showing it."""
+    result = _post_result(_SHAPE, px=Point(x=-999.0, y=0.0))  # deliberately wrong
+
+    result.apply_refractive_index_correction(1.5)
+
+    assert result.poi[0].px.x == -999.0
+
+
+# ---------------------------------------------------------------------------
+# The rotation guard
+# ---------------------------------------------------------------------------
+
+
+def test_a_malformed_rotation_raises_rather_than_dropping_the_ghost():
+    """A (3,) rotation broadcasts cleanly through the matmul and produces
+    plausible garbage, so the shape check earns its keep even though the one
+    call site cannot reach it. It used to log and return [], which lost the
+    ghost marker and left the run looking fine."""
+    bad = dict(_IDENTITY, rotation_quaternion=[1.0, 0.0, 0.0])
+
+    with pytest.raises(ValueError, match="3x3"):
+        _reproject_poi_via_transform(
+            bad, np.array([[700.0, 100.0, 0.0]]), _SHAPE, _PIXEL_SIZE_M
+        )
+
+
+def test_a_quaternion_shaped_rotation_raises_too():
+    """The field is named `rotation_quaternion` but stores a 3x3 matrix. An
+    actual four-element quaternion arriving here is the misnomer coming true."""
+    bad = dict(_IDENTITY, rotation_quaternion=[0.9, 0.1, 0.2, 0.3])
+
+    with pytest.raises(ValueError, match="3x3"):
+        _reproject_poi_via_transform(
+            bad, np.array([[700.0, 100.0, 0.0]]), _SHAPE, _PIXEL_SIZE_M
+        )
+
+
+def test_no_image_means_no_microscope_coordinates():
+    """Without a shape and pixel size only image_px can be filled in — and it
+    still must be, or the ghost has nowhere to draw."""
+    ghost = _reproject_poi_via_transform(
+        _IDENTITY, np.array([[700.0, 100.0, 0.0]]), None, None
+    )[0]
+
+    assert (ghost.image_px.x, ghost.image_px.y) == (700.0, 100.0)
+    assert (ghost.px.x, ghost.px.y) == (0.0, 0.0)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -7,11 +7,25 @@ import it lazily inside four separate function bodies to avoid the cycle.
 
 These pin the behaviour as it was, including the off-by-one below, so the move is
 provably inert.
+
+The image → microscope conversions had no coverage at all until FIB-362 factored
+their shared centring into `image_to_microscope_image_coordinates_px`. They are
+read by movement, milling, detection, the minimap and tiled acquisition, so the
+tests below pin the behaviour the refactor had to preserve rather than the
+refactor itself.
 """
 
+import numpy as np
 import pytest
 
-from fibsem.conversions import is_inside_image_bounds
+from fibsem.conversions import (
+    image_to_microscope_image_coordinates,
+    image_to_microscope_image_coordinates2,
+    image_to_microscope_image_coordinates_px,
+    is_inside_image_bounds,
+    microscope_image_to_image_coordinates,
+)
+from fibsem.structures import Point
 
 SHAPE = (100, 200)  # (y, x)
 
@@ -60,6 +74,126 @@ def test_shape_is_y_x_not_x_y():
     """coords and shape are both (y, x); a transposed shape changes the answer."""
     assert is_inside_image_bounds((50, 150), (100, 200)) is True
     assert is_inside_image_bounds((50, 150), (200, 100)) is False
+
+
+# ---------------------------------------------------------------------------
+# image px → microscope image coordinates
+# ---------------------------------------------------------------------------
+
+EVEN = (512, 1024)  # (height, width)
+ODD = (511, 1023)   # the only case where the centre rounding is visible
+PIXEL_SIZE = 1e-8
+
+
+def test_the_centre_is_the_origin():
+    assert image_to_microscope_image_coordinates_px(
+        Point(512.0, 256.0), EVEN, subpixel_precision=True
+    ) == Point(0.0, 0.0)
+
+
+def test_y_is_mirrored_and_x_is_not():
+    """The asymmetry this function exists to state once: microscope +y is *up*,
+    image +y is down, and x agrees between the two."""
+    down_right = image_to_microscope_image_coordinates_px(
+        Point(612.0, 356.0), EVEN, subpixel_precision=True
+    )
+    assert (down_right.x, down_right.y) == (100.0, -100.0)
+
+    up_left = image_to_microscope_image_coordinates_px(
+        Point(412.0, 156.0), EVEN, subpixel_precision=True
+    )
+    assert (up_left.x, up_left.y) == (-100.0, 100.0)
+
+
+def test_shape_is_height_width():
+    """A transposed shape looks fine on a square image, so check a rectangle."""
+    corner = image_to_microscope_image_coordinates_px(
+        Point(0.0, 0.0), EVEN, subpixel_precision=True
+    )
+    assert (corner.x, corner.y) == (-512.0, 256.0)
+
+
+def test_subpixel_precision_only_matters_on_an_odd_dimension():
+    """Flooring the centre is the long-standing default. It is exact on an even
+    dimension and half a pixel off on an odd one — which is why the correlation
+    module opts out and everything else does not."""
+    for shape, expected_floored in ((EVEN, (188.0, 156.0)), (ODD, (189.0, 155.0))):
+        floored = image_to_microscope_image_coordinates_px(
+            Point(700.0, 100.0), shape, subpixel_precision=False
+        )
+        assert (floored.x, floored.y) == expected_floored
+
+    exact = image_to_microscope_image_coordinates_px(
+        Point(700.0, 100.0), ODD, subpixel_precision=True
+    )
+    assert (exact.x, exact.y) == (188.5, 155.5)
+
+
+@pytest.mark.parametrize("subpixel", [False, True])
+@pytest.mark.parametrize("shape", [EVEN, ODD])
+def test_the_array_and_shape_forms_agree(shape, subpixel):
+    """Two functions, one taking the image and one its shape. Nothing forced
+    them to stay in step before they shared a centring."""
+    coord = Point(700.0, 100.0)
+    from_image = image_to_microscope_image_coordinates(
+        coord, np.zeros(shape, dtype=np.uint8), PIXEL_SIZE, subpixel_precision=subpixel
+    )
+    from_shape = image_to_microscope_image_coordinates2(
+        coord, shape, PIXEL_SIZE, subpixel_precision=subpixel
+    )
+    assert from_image.x == pytest.approx(from_shape.x)
+    assert from_image.y == pytest.approx(from_shape.y)
+
+
+@pytest.mark.parametrize("subpixel", [False, True])
+def test_both_forms_pass_the_flag_through(subpixel):
+    """The wrappers must not decide the rounding for their callers — this is
+    what a hardcoded `True` or `False` inside either of them would break."""
+    coord = Point(700.0, 100.0)
+    expected = image_to_microscope_image_coordinates_px(
+        coord, ODD, subpixel_precision=subpixel
+    )
+    for actual in (
+        image_to_microscope_image_coordinates(
+            coord, np.zeros(ODD, dtype=np.uint8), PIXEL_SIZE, subpixel_precision=subpixel
+        ),
+        image_to_microscope_image_coordinates2(
+            coord, ODD, PIXEL_SIZE, subpixel_precision=subpixel
+        ),
+    ):
+        assert actual.x == pytest.approx(expected.x * PIXEL_SIZE)
+        assert actual.y == pytest.approx(expected.y * PIXEL_SIZE)
+
+
+def test_the_default_is_the_floored_centre():
+    """Called without the flag, both keep doing what movement and milling have
+    always done. Changing this default would move the stage."""
+    coord = Point(700.0, 100.0)
+    floored = image_to_microscope_image_coordinates_px(
+        coord, ODD, subpixel_precision=False
+    )
+    assert image_to_microscope_image_coordinates2(
+        coord, ODD, PIXEL_SIZE
+    ).x == pytest.approx(floored.x * PIXEL_SIZE)
+    assert image_to_microscope_image_coordinates(
+        coord, np.zeros(ODD, dtype=np.uint8), PIXEL_SIZE
+    ).y == pytest.approx(floored.y * PIXEL_SIZE)
+
+
+def test_a_non_2d_shape_is_rejected():
+    with pytest.raises(ValueError, match="two integers"):
+        image_to_microscope_image_coordinates2(Point(0.0, 0.0), (512, 512, 3), PIXEL_SIZE)
+
+
+def test_the_inverse_round_trips():
+    """`microscope_image_to_image_coordinates` floors the centre unconditionally,
+    so it is the forward conversion's default that it inverts."""
+    original = Point(700.0, 100.0)
+    metres = image_to_microscope_image_coordinates2(original, EVEN, PIXEL_SIZE)
+    back = microscope_image_to_image_coordinates(metres, EVEN, PIXEL_SIZE)
+
+    assert back.x == pytest.approx(original.x)
+    assert back.y == pytest.approx(original.y)
 
 
 def test_is_importable_without_napari():


### PR DESCRIPTION
Fixes FIB-362.

`fibsem.conversions` already owned image px → microscope image coordinates — centred on the image, +y *up*, so y is mirrored about the centre where x is only shifted. The correlation module re-derived it anyway, in four places:

| where | |
| --- | --- |
| `convert_poi_to_microscope_coordinates` | the correlation output |
| `_convert_poi_to_microscope_image_coordinate` | **dead** — no callers repo-wide, and its dict is missing the `px_m` key the live one has |
| `_reproject_poi_via_transform` | the ghost marker |
| `apply_refractive_index_correction` | spelled `-(y - cy)` where the others spell it `cy - y` |

The last one produces **`px_m`, the number Continue commits to the experiment**.

Nothing forced them to agree. The ghost marker and the real POI are drawn in the same image from the same fitted transform, so a drift between those two is wrong by exactly the difference in the thing the ghost exists to show.

The centring the two `conversions` functions already shared is extracted into `image_to_microscope_image_coordinates_px`, and everything goes through it. The dead helper is deleted rather than rewired.

## `subpixel_precision` — why correlation couldn't just call the existing function

`conversions` floors the centre (`shape // 2`); correlation used `shape * 0.5`.

| shape | floored | true centre |
| --- | --- | --- |
| 512 × 1024 | 188.0, 156.0 | 188.0, 156.0 |
| **511 × 1023** | **189.0, 155.0** | 188.5, 155.5 |

Identical on an even dimension, half a pixel apart on an odd one. The 13 existing callers feed stage movement and milling, so **their default does not move** — correlation opts in with `subpixel_precision=True`, which is what its own arithmetic did.

The new primitive takes the flag with **no default**. Half a pixel is small enough to pass review and large enough to matter, so each caller says which it wants.

## The unreachable guard now raises

`_reproject_poi_via_transform`'s `R.shape != (3, 3)` check logged a warning and returned `[]`. It is unreachable from the only call site — `extract_transformation_data` always writes `Rigid3D.q` — but it is kept, and kept loud:

- a `(3,)` R broadcasts *cleanly* through `s * (R @ x) + d[:, None]` and yields plausible garbage rather than a shape error, so deleting the check outright is worse than keeping it;
- a broken transform there is the same transform that produced the result's own POI, so there is nothing to salvage by dropping the ghost marker and carrying on.

## The conversions functions had no tests at all

`tests/test_conversions.py` covered only `is_inside_image_bounds`. This refactors two functions used by movement, milling, detection, the minimap and tiled acquisition, so **11 tests now pin the behaviour it had to preserve**: the two forms agreeing, both passing the flag through, the floored default, the 2-D check, and the round trip against `microscope_image_to_image_coordinates`.

The correlation tests cross-check each call site against the shared function *and against each other* — `test_the_ghost_reprojection_agrees_with_the_correlation_output` is the one to read, since the two paths take the pixel size in different units (metres vs µm), which is exactly the detail that rots when arithmetic is duplicated.

**All parametrised over an odd shape as well as an even one.** That is not padding: an even-only test cannot tell the two centres apart, which is how the first mutation run scored 11/12 — a correlation call site flipped to the floored centre survived every test until `(511, 1023)` was added.

## Verification

**12/12 mutations caught**, files restored byte-for-byte:

| | |
| --- | --- |
| primitive: stop mirroring y · swap the shape axes · always floor · never floor | 4 |
| wrappers: either one swallowing `subpixel_precision` · drop the 2-D check | 3 |
| correlation: floored centre in the output · re-inline the ghost conversion · re-inline the post conversion · recompute `px.x` during a y-only correction | 4 |
| the guard back to log-and-return-`[]` | 1 |

Full suite: **4700 passed, 24 skipped**. Also driven through the real widget offscreen — `px.y = -168.0` after a post correction is the shared conversion returning exactly what `-(corrected_y - cy)` did.

## Not in this PR

The same survey found this conversion re-derived in `fm/reprojection.py` (verified bit-identical), `milling/patterning/plotting.py` (four times, and **already drifted** — `:145` uses `/2` where the other three use `//2`), `imaging/tiling/reprojection.py`, and a `get_image_pixel_centre` helper stranded in a napari module where `milling/` cannot import it. Filed as FIB-644.

One trap recorded there: `projection.py`'s `FMStageProjection.to_plane` looks like the same arithmetic and **does not mirror y**. It is a display-plane coordinate, self-consistent in both directions, so it round-trips fine — a round-trip test would not catch a wrong "deduplication" of it.
