### PR TITLE
[ui] Give the RI tab its input snapshot, not copies of its fields (FIB-645)

### DIFF
--- a/fibsem/ui/correlation/widgets/correlation_tab_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_tab_widget.py
@@ -1087,11 +1087,13 @@ class _RITab(QWidget):
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self._poi: List[CorrelationPointOfInterest] = []
-        self._surface_coordinate: Optional[Coordinate] = None
-        self._surface_y: Optional[float] = None
-        self._fm_surface_coordinate: Optional[Coordinate] = None
-        self._input_poi: List[Coordinate] = []
-        self._input_pre_factor: Optional[float] = None
+        # The input snapshot this tab describes, held whole. Everything it needs
+        # from the inputs is a property below rather than a field copied here,
+        # so there is no set of parallel values to keep in step (FIB-645).
+        # Safe to hold: the parent's `data` property builds a fresh
+        # CorrelationInputData per access, so this is never a live object
+        # someone else mutates.
+        self._input_data: Optional[CorrelationInputData] = None
         self._fm_pixel_size_z: Optional[float] = None
         self._result: Optional[CorrelationResult] = None
         # Last factor mirrored into the spinbox; mirroring only on change keeps
@@ -1197,6 +1199,37 @@ class _RITab(QWidget):
         # first data change — and the tab is reachable before that now.
         self._refresh_apply_enabled()
 
+    # ------------------------------------------------------------------
+    # Views of the input snapshot. Read-only by construction: set_result
+    # replaces _input_data wholesale, so none of these can drift from it.
+    # ------------------------------------------------------------------
+
+    @property
+    def _surface_coordinate(self) -> Optional[Coordinate]:
+        """The FIB surface point (post mode), or None."""
+        return self._input_data.surface_coordinate if self._input_data else None
+
+    @property
+    def _surface_y(self) -> Optional[float]:
+        """Depth datum for post mode: the FIB surface y, in image px."""
+        surface = self._surface_coordinate
+        return surface.point.y if surface else None
+
+    @property
+    def _fm_surface_coordinate(self) -> Optional[Coordinate]:
+        """The FM surface point (pre mode), or None."""
+        return self._input_data.fm_surface_coordinate if self._input_data else None
+
+    @property
+    def _input_poi(self) -> List[Coordinate]:
+        """The POIs as picked, in FM space — what pre mode corrects."""
+        return self._input_data.poi_coordinates if self._input_data else []
+
+    @property
+    def _input_pre_factor(self) -> Optional[float]:
+        """The armed pre-correction factor: what a run would actually use."""
+        return self._input_data.ri_pre_correction_factor if self._input_data else None
+
     @property
     def mode(self) -> Optional[str]:
         """'pre' when an FM surface exists, 'post' for a FIB surface, else None."""
@@ -1214,16 +1247,7 @@ class _RITab(QWidget):
     ) -> None:
         self._result = result
         self._poi = result.poi if result else []
-        surface = input_data.surface_coordinate if input_data else None
-        self._surface_coordinate = surface
-        self._surface_y = surface.point.y if surface else None
-        self._fm_surface_coordinate = (
-            input_data.fm_surface_coordinate if input_data else None
-        )
-        self._input_poi = list(input_data.poi_coordinates) if input_data else []
-        self._input_pre_factor = (
-            input_data.ri_pre_correction_factor if input_data else None
-        )
+        self._input_data = input_data
         self._fm_pixel_size_z = fm_pixel_size_z
 
         mode = self.mode

--- a/tests/correlation/test_ri_tab_input_snapshot.py
+++ b/tests/correlation/test_ri_tab_input_snapshot.py
@@ -1,0 +1,164 @@
+"""The RI tab reads the input snapshot rather than copies of its fields.
+
+FIB-645: `_RITab.set_result` exploded `input_data` into five parallel
+attributes — the FIB surface, its y, the FM surface, the POI list and the armed
+factor — every one of which had to be reassigned on every refresh to stay
+truthful. It now holds the snapshot and derives all five.
+
+These pin the property that removal buys: whatever `set_result` was handed last
+is what the tab reports, with nothing left over from the call before. That was
+true of the old code too — it is a pin, not a bug fix — and it is the invariant
+a sixth field, added later and assigned in only one of two branches, would break.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.correlation.structures import (
+    Coordinate,
+    CorrelationInputData,
+    CorrelationPointOfInterest,
+    CorrelationResult,
+    PointType,
+    PointXYZ,
+)
+from fibsem.structures import Point
+
+
+@pytest.fixture(autouse=True)
+def _no_lut_download(monkeypatch):
+    """Never hit the network for the zeta LUT during widget construction."""
+    import fibsem.ui.correlation.widgets.refractive_index_widget as riw
+
+    monkeypatch.setattr(riw, "_ensure_lut", lambda: None)
+
+
+@pytest.fixture
+def tab(qapp):
+    from fibsem.ui.correlation.widgets.correlation_tab_widget import _RITab
+
+    w = _RITab()
+    yield w
+    w.deleteLater()
+
+
+def _coord(x=0.0, y=0.0, z=0.0, pt=PointType.POI) -> Coordinate:
+    return Coordinate(point=PointXYZ(x=x, y=y, z=z), point_type=pt)
+
+
+def _post_data() -> CorrelationInputData:
+    """FIB surface at y=200, two POIs, no armed factor."""
+    return CorrelationInputData(
+        surface_coordinate=_coord(y=200.0, pt=PointType.SURFACE),
+        poi_coordinates=[_coord(x=1.0, y=2.0, z=30.0), _coord(x=3.0, y=4.0, z=40.0)],
+    )
+
+
+def _pre_data() -> CorrelationInputData:
+    """FM surface at z=10, one POI, factor armed."""
+    return CorrelationInputData(
+        fm_surface_coordinate=_coord(z=10.0, pt=PointType.SURFACE_FM),
+        poi_coordinates=[_coord(x=9.0, y=9.0, z=90.0)],
+        ri_pre_correction_factor=1.5,
+    )
+
+
+def _views(tab):
+    """Everything the tab derives from the snapshot, in one tuple."""
+    return (
+        tab._surface_coordinate,
+        tab._surface_y,
+        tab._fm_surface_coordinate,
+        tab._input_poi,
+        tab._input_pre_factor,
+    )
+
+
+def test_every_view_comes_from_the_snapshot(tab):
+    data = _pre_data()
+    tab.set_result(None, input_data=data)
+
+    assert tab._surface_coordinate is None
+    assert tab._surface_y is None
+    assert tab._fm_surface_coordinate is data.fm_surface_coordinate
+    assert tab._input_poi == data.poi_coordinates
+    assert tab._input_pre_factor == 1.5
+
+
+def test_the_surface_datum_is_derived_not_stored(tab):
+    """`_surface_y` is the post-mode depth datum. Its only source is the surface
+    coordinate, so it cannot be right while the coordinate is wrong."""
+    data = _post_data()
+    tab.set_result(None, input_data=data)
+
+    assert tab._surface_coordinate is data.surface_coordinate
+    assert tab._surface_y == 200.0
+
+
+def test_no_snapshot_means_no_views(tab):
+    tab.set_result(None, input_data=_pre_data())
+    tab.set_result(None, input_data=None)
+
+    assert _views(tab) == (None, None, None, [], None)
+    assert tab.mode is None
+
+
+def test_a_new_snapshot_replaces_every_view(tab):
+    """The failure the parallel fields invited: one of them not reassigned, so
+    the tab keeps describing the previous inputs in one respect only."""
+    tab.set_result(None, input_data=_pre_data())
+    post = _post_data()
+
+    tab.set_result(None, input_data=post)
+
+    assert tab._fm_surface_coordinate is None       # the FM surface is gone
+    assert tab._surface_coordinate is post.surface_coordinate
+    assert tab._surface_y == 200.0
+    assert tab._input_poi == post.poi_coordinates
+    assert tab._input_pre_factor is None            # the armed factor went with it
+
+
+def test_the_mode_follows_the_snapshot(tab):
+    """Which correction the tab offers is read off the surface points, so it has
+    to move with them — this is the user-visible half of the previous test."""
+    tab.set_result(None, input_data=_post_data())
+    assert tab.mode == "post"
+
+    tab.set_result(None, input_data=_pre_data())
+    assert tab.mode == "pre"
+
+    tab.set_result(None, input_data=CorrelationInputData())
+    assert tab.mode is None
+
+
+def test_the_preview_table_follows_the_armed_factor(tab):
+    """The end the views feed: the pre-mode table previews the correction a run
+    would apply, so it must be built from the snapshot's POIs and factor."""
+    tab.set_result(None, input_data=_pre_data())
+
+    assert tab._table.rowCount() == 1
+    # 10 + (90 - 10) * 1.5 = 130
+    assert tab._table.item(0, 3).text() == "130.00"
+
+
+def test_the_tab_reads_the_live_inputs_not_the_results_own_snapshot(tab):
+    """A result carries the inputs it was computed from; the tab is handed the
+    inputs as they are now. Conflating them is what makes a stale result look
+    current (FIB-315), so the tab must follow the argument, not the result."""
+    stale = _post_data()
+    result = CorrelationResult(
+        poi=[CorrelationPointOfInterest(image_px=Point(x=100.0, y=300.0))],
+        input_data=stale,
+    )
+    live = _pre_data()
+
+    tab.set_result(result, input_data=live)
+
+    assert tab.mode == "pre"
+    assert tab._surface_coordinate is None
+    assert tab._input_poi == live.poi_coordinates
+    assert result.input_data is stale  # untouched


### PR DESCRIPTION
Fixes FIB-645.

`_RITab.set_result` exploded the `CorrelationInputData` it was handed into five separate attributes:

```python
surface = input_data.surface_coordinate if input_data else None
self._surface_coordinate = surface
self._surface_y = surface.point.y if surface else None
self._fm_surface_coordinate = input_data.fm_surface_coordinate if input_data else None
self._input_poi = list(input_data.poi_coordinates) if input_data else []
self._input_pre_factor = input_data.ri_pre_correction_factor if input_data else None
```

Every one had to be reassigned on every refresh — including to its empty value on the `None` branch — for the tab to stay truthful, and nothing enforced that. A sixth field added later and assigned in only one of the two branches would leave the tab describing the previous inputs in one respect while describing the current ones in every other.

These five are not bookkeeping. Between them they decide **which correction mode is offered**, **whether Apply is enabled**, the depth readout, and the preview table.

So the tab holds the snapshot and derives all five as read-only properties. Call sites are unchanged; there is simply nothing left to keep in step.

## Safe to hold

`CorrelationTabWidget.data` is a **property that builds a fresh `CorrelationInputData` on every access**, so the object is never aliased and mutated behind the tab's back. All three call sites pass it.

And `CoordinateListWidget.coordinates` already returns `list(self._coordinates)` — which made the `list(input_data.poi_coordinates)` above a second copy of a copy. That goes away too.

## What is deliberately *not* changed

The pre table is still rebuilt on every `data_changed`. FIB-362 flagged that as churn proportional to POI count, but memoising it would put a derived value back beside its source — the pattern FIB-593 removed — to save four `setItem` calls on a handful of rows.

## This is a refactor, not a bug fix

The old code did assign all five unconditionally, so it was correct. The tests pin the invariant rather than claim a fix: whatever `set_result` was handed last is what the tab reports, with nothing surviving from the call before, and `input_data=None` clearing all five.

The two worth reading are `test_the_mode_follows_the_snapshot` — the user-visible half, since which correction is offered is read off the surface points — and `test_the_tab_reads_the_live_inputs_not_the_results_own_snapshot`, which pins that the tab follows its argument rather than the result's own provenance snapshot. Conflating those is what makes a stale result look current (FIB-315).

## Verification

**3/3 mutations caught**, files restored byte-for-byte:

| Mutation | |
| --- | --- |
| a view stops following the snapshot | caught |
| a cleared snapshot leaves the old one in place | caught |
| the POI view reads the result instead of the inputs | caught |

Driven through the real widget offscreen as well — pre-arm, FM→FIB surface swap, post-apply — confirming the mode banner, the armed-factor warning, the preview table, the blocked-Apply reason and the post-correction numbers all still land:

```
poi y : 680.0  (400 + 200×1.4)
px  y : -168.0 (512 − 680)
status: RI post-correction ×1.400 applied, POI 1 shifted 80.0 px.
```

Full suite: **4700 passed, 24 skipped**.

Split out of FIB-362 alongside #410 (the conversion half) — different code, different reasoning, and two PRs on one issue would auto-close it on the first merge.
