### PR TITLE
[ui] Sweep tiles in and out with Shift+drag, and give the status zone a live readout

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -19,7 +19,6 @@ from PyQt5.QtCore import QPoint, Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QDialog,
     QHBoxLayout,
-    QLabel,
     QMessageBox,
     QPushButton,
     QScrollArea,
@@ -81,9 +80,6 @@ from fibsem.ui.widgets.canvas.stage_frame import FMStageProjection, StageFrame
 
 TEXT_MUTED = stylesheets.TEXT_MUTED_COLOR
 PROGRESS_FONT_PX = 10
-# Inset for chrome drawn over the canvas, matching the toolbar buttons' own margin so
-# the cursor readout in the top left lines up with the buttons in the top right.
-CANVAS_CHROME_MARGIN = 4
 
 
 def shrink_progress_text(progress: FibsemProgressWidget) -> FibsemProgressWidget:
@@ -336,6 +332,8 @@ class FMOverviewWidget(QWidget):
         self.tile_grid_panel.visibility_changed.connect(
             self.tile_grid_overlay.set_grid_visible
         )
+        self.tile_grid_panel.visibility_changed.connect(self._refresh_grid_hint)
+        self._refresh_grid_hint(self.tile_grid_overlay.is_grid_visible)
         self.tile_grid_panel.color_changed.connect(self.tile_grid_overlay.set_color)
         self.tile_grid_panel.fill_alpha_changed.connect(
             self.tile_grid_overlay.set_fill_alpha
@@ -430,27 +428,6 @@ class FMOverviewWidget(QWidget):
         # Vertical only: a horizontal bar here means a control is refusing to shrink,
         # and scrolling sideways to reach a spinbox is worse than a cramped one.
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-
-        # Where a double-click would take the stage, read off continuously rather than
-        # on demand: the canvas is a map, and a map you have to click to get a
-        # coordinate out of cannot be used to decide whether to click.
-        #
-        # Drawn over the canvas rather than beside it, in the one free corner -- the
-        # toolbar owns the top right, the scalebar the bottom right, and the stage info
-        # bar the bottom left. A Qt label rather than the canvas's own text chrome
-        # because this updates on every mouse motion, and `set_info_text` costs ~4.9 ms
-        # against a label's 0.08 ms; at motion-event rates that is the difference
-        # between a readout and a stutter.
-        self.cursor_readout = QLabel(self.canvas.canvas)
-        self.cursor_readout.setAttribute(Qt.WA_TransparentForMouseEvents)
-        # Monospaced so the digits sit still while the cursor moves. A proportional
-        # font makes the whole readout shuffle on every pixel of travel.
-        self.cursor_readout.setStyleSheet(
-            "color: #e8e8e8; font-size: 10px; font-family: monospace;"
-            "background: rgba(26, 26, 26, 160); border-radius: 3px; padding: 2px 5px;"
-        )
-        self.cursor_readout.move(CANVAS_CHROME_MARGIN, CANVAS_CHROME_MARGIN)
-        self.cursor_readout.hide()  # nothing to say until the pointer is over the canvas
 
         splitter = QSplitter(Qt.Horizontal)
         splitter.addWidget(self.canvas)
@@ -1946,18 +1923,24 @@ class FMOverviewWidget(QWidget):
             self._set_cursor_readout("")
 
     def _set_cursor_readout(self, text: str) -> None:
-        """Show the readout over the canvas, sized to its text, or hide it when empty.
+        """Put the readout in the canvas status zone, or give the zone back when empty.
 
-        Hidden rather than blanked: it sits on top of the image, and an empty plaque
-        floating over the data is worse than nothing there. `adjustSize` because the
-        label is positioned rather than laid out, so nothing else will size it.
+        Where a double-click would take the stage, read off continuously rather than on
+        demand: the canvas is a map, and a map you have to click to get a coordinate out
+        of cannot be used to decide whether to click.
+
+        Through the canvas's status zone rather than a label of this widget's own. It
+        used to be hand-placed at the top left, "the one free corner" -- which stopped
+        being free when the status zone took that row, and the two then drew on top of
+        each other. The zone shows one thing at a time, so they cannot collide: the
+        readout outranks the grid hint while the pointer is over the canvas, and a focus
+        flash outranks both.
+
+        Empty means the pointer has left the canvas, and the zone then falls back to the
+        grid hint on its own -- so an empty readout is a release rather than a blank
+        plaque left floating over the data.
         """
-        self.cursor_readout.setText(text)
-        if not text:
-            self.cursor_readout.hide()
-            return
-        self.cursor_readout.adjustSize()
-        self.cursor_readout.show()
+        self.canvas.canvas.set_status_readout(text or None)
 
     @staticmethod
     def _describe(position: FibsemStagePosition) -> str:
@@ -1984,8 +1967,20 @@ class FMOverviewWidget(QWidget):
         # size that was never requested.
         self.settings_widget.set_grid_size(rows, cols)
 
+    def _refresh_grid_hint(self, visible: bool) -> None:
+        """Say what the grid can be done to, while it is on screen.
+
+        The gestures are otherwise only discoverable by accident: the cursor names the
+        edge drag and the paint modifier, but nothing suggests trying either. Tied to
+        the grid's visibility rather than set once, so hiding the grid takes its
+        instructions with it. A focus flash borrows the same zone and gives it back.
+        """
+        self.canvas.canvas.set_hint(
+            "click a tile to skip it  ·  Shift+drag to sweep" if visible else None
+        )
+
     def _on_tile_toggled(self, row: int, col: int, enabled: bool) -> None:
-        """A tile was clicked on the canvas.
+        """A tile was clicked or swept on the canvas.
 
         The mask belongs to the settings widget, so this writes there and lets the
         resulting `changed` redraw the overlay -- rather than updating the overlay

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -50,7 +50,6 @@ from fibsem.ui.tokens import (
     GRAY_WHITE_COLOR,
     NEUTRAL_400,
     NEUTRAL_450,
-    NEUTRAL_900,
     WHITE_ICON_COLOR,
 )
 
@@ -137,13 +136,26 @@ _LIVE_BADGE_STYLE = (
     " border-radius: 3px; padding: 0px 6px; font-size: 10px; font-weight: bold; }"
 )
 # The status zone mirrors the toolbar on the left of the same row, and carries whichever
-# of the hint or the flash is current. Two looks, because they say different things: the
-# hint is a standing instruction, the flash is a value that just changed and is about to
-# go away, so it keeps the accent outline the artist had.
-_STATUS_HINT_STYLE = (
-    f"QLabel {{ background: #e6e6e6; color: {NEUTRAL_900};"
-    " border-radius: 3px; padding: 0px 6px; font-size: 11px; }"
+# of the flash, the readout or the hint is current -- in that order. Three looks, because
+# they say different things, but all on the same dark plaque the rest of the canvas
+# chrome uses: the hint was a near-white one, which shouted over the data it was drawn
+# on and read as an alert rather than an aside.
+_STATUS_PLAQUE = "background: rgba(26, 26, 26, 190); border-radius: 3px; padding: 0px 6px;"
+# How long a readout holds the zone after the pointer stops. Long enough to have been
+# read at a glance and then some, since it goes away without being asked -- and any
+# motion at all brings it straight back.
+_READOUT_DECAY_MS = 2500
+# A standing instruction, so the dimmest of the three: it is still true after you have
+# read it, and it should not compete with the image once it has been.
+_STATUS_HINT_STYLE = f"QLabel {{ color: {NEUTRAL_450}; font-size: 11px; {_STATUS_PLAQUE} }}"
+# Live numbers under the cursor. Monospaced so the digits sit still while it moves --
+# a proportional font makes the whole readout shuffle on every pixel of travel.
+_STATUS_READOUT_STYLE = (
+    f"QLabel {{ color: #e8e8e8; font-size: 10px; font-family: monospace;"
+    f" {_STATUS_PLAQUE} }}"
 )
+# A value that just changed and is about to go away, so it keeps the accent outline the
+# artist had, and stays opaque so it reads at a glance mid-gesture.
 _STATUS_FLASH_STYLE = (
     f"QLabel {{ background: {_BG}; color: #e8e8e8; border: 1px solid {_ACCENT};"
     " border-radius: 3px; padding: 0px 6px; font-size: 12px; }"
@@ -257,6 +269,11 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         # Transient status message (e.g. "WD 4.001 mm" on Shift+scroll); auto-clears.
         # Shares the top-left status zone with the hint, and outranks it while up.
         self._flash_text: Optional[str] = None
+        # Live numbers tracking the pointer (e.g. the stage position under the cursor).
+        # Also the status zone: hosts used to put this in a hand-placed label of their
+        # own, in "the one free corner" -- which stopped being free the moment the zone
+        # arrived, and the two drew on top of each other.
+        self._readout_text: Optional[str] = None
         # The status zone itself: one chip mirroring the toolbar at the other end of the
         # row. Qt-laid-out, so nothing converts between logical and device pixels.
         self._status_label = None
@@ -264,6 +281,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._flash_timer = QTimer(self)
         self._flash_timer.setSingleShot(True)
         self._flash_timer.timeout.connect(self._clear_flash)
+        self._readout_timer = QTimer(self)
+        self._readout_timer.setSingleShot(True)
+        self._readout_timer.timeout.connect(self._clear_readout)
 
         # Optional patch legend (list of (color, label)); re-applied across image changes.
         self._legend_artist = None
@@ -398,6 +418,34 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         will still be true afterwards.
         """
         self._hint_text = text or None
+        self._refresh_status()
+
+    def set_status_readout(self, text: Optional[str]) -> None:
+        """Show live numbers tracking the pointer in the status zone, or clear with None.
+
+        For values that change on every motion event — the stage position under the
+        cursor, a measured distance. Outranks :meth:`set_hint`, which is a standing
+        instruction that will still be true once the pointer has moved on, and is
+        outranked by :meth:`flash_message`.
+
+        Cheap enough for the rate it is called at: ~0.1 ms per update, against the 16 ms
+        a frame has. Hosts that reach for a hand-placed label instead should not — that
+        is what put two things in this corner drawing over each other.
+
+        Decays once the pointer has been still for a while, so a hint waiting underneath
+        is not shut out for as long as the pointer happens to be over the canvas — which
+        is most of the time, and would make a standing instruction unreadable in
+        practice. Only when there *is* a hint underneath: with nothing to reveal,
+        decaying would blank the corner rather than free it.
+        """
+        self._readout_text = text or None
+        self._readout_timer.stop()
+        if self._readout_text and self._hint_text:
+            self._readout_timer.start(_READOUT_DECAY_MS)
+        self._refresh_status()
+
+    def _clear_readout(self) -> None:
+        self._readout_text = None
         self._refresh_status()
 
     def set_title(self, text: Optional[str]) -> None:
@@ -548,19 +596,26 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         on a screen that is not a Retina one (FIB-639). Qt lays out in logical pixels
         natively, so a `QLabel` has no conversion to get wrong.
 
-        The flash outranks the hint: it is a value that just changed and is about to go
-        away, while the hint is a standing instruction still true underneath it.
+        Three occupants, in order of how fleeting they are: the flash is a value that
+        just changed and is about to go away; the readout is live and true only while
+        the pointer is where it is; the hint is a standing instruction still true
+        underneath both. Sharing one label is what makes them unable to collide -- the
+        alternative, a corner each, ran out of corners.
         """
-        text = self._flash_text or self._hint_text
+        text = self._flash_text or self._readout_text or self._hint_text
         if not text:
             if self._status_label is not None:
                 self._status_label.hide()
             return
         if self._status_label is None:
             self._status_label = self._make_status_label()
-        self._status_label.setStyleSheet(
-            _STATUS_FLASH_STYLE if self._flash_text else _STATUS_HINT_STYLE
-        )
+        if self._flash_text:
+            style = _STATUS_FLASH_STYLE
+        elif self._readout_text:
+            style = _STATUS_READOUT_STYLE
+        else:
+            style = _STATUS_HINT_STYLE
+        self._status_label.setStyleSheet(style)
         self._status_full_text = text
         self._status_label.show()
         self._reposition_overlay_buttons()  # sizes and elides it to the room available
@@ -642,7 +697,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             self._live_badge.hide()
         self._live_on = False
         self._flash_text = None
+        self._readout_text = None
         self._flash_timer.stop()
+        self._readout_timer.stop()
         if self._status_label is not None:
             self._status_label.hide()
         self._legend_artist = None  # removed by cla(); drop the cached entries too

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -58,9 +58,16 @@ MAX_TILES_PER_AXIS = 100  # matches the row/column spin boxes
 # the other.
 MOVE_DRAG_THRESHOLD_PX = 3
 
+# Held to make an interior drag paint tiles rather than move the grid. Shift because
+# it is the only modifier not already spent inside the axes: Ctrl and Alt reach the
+# toolbar, and the one Shift binding -- Shift+scroll to focus -- is a wheel gesture,
+# which cannot collide with a button-1 drag.
+PAINT_MODIFIER = "Shift"
+
 
 class TileGridOverlay(QObject, CanvasOverlay):
-    """The planned tile grid, with click-to-toggle, edge-to-resize and drag-to-move.
+    """The planned tile grid: click-to-toggle, Shift+drag-to-paint, edge-to-resize,
+    drag-to-move.
 
     Emits rather than mutating: rows, columns, the mask and the position the grid is
     planned around all belong to the settings widget, and two widgets writing the same
@@ -96,6 +103,14 @@ class TileGridOverlay(QObject, CanvasOverlay):
         # coordinates drive the threshold, the data coordinates the displacement.
         self._move_start: Optional[Tuple[float, float, float, float, float, float]] = None
         self._move_active: bool = False
+        # A paint drag: the value being swept in, the tile the press landed on, and the
+        # tiles already given it. `_paint_value` doubles as "this press is a paint" --
+        # it is set only at press, so letting go of Shift part way through does not
+        # abandon the sweep half-done.
+        self._paint_value: Optional[bool] = None
+        self._paint_origin: Optional[Tuple[int, int]] = None
+        self._paint_active: bool = False
+        self._painted: set = set()
         # A toggle waiting to find out whether it was half of a double-click. See
         # `_schedule_toggle` for why it waits rather than firing and being undone.
         self._pending_toggle: Optional[Tuple[int, int, bool]] = None
@@ -122,6 +137,13 @@ class TileGridOverlay(QObject, CanvasOverlay):
         # A toggle still waiting out the double-click interval would otherwise fire into
         # a host that has stopped listening -- or, on a rebuilt tab, into the wrong one.
         self._cancel_pending_toggle()
+        # Same for a gesture caught mid-flight: detaching skips the release that would
+        # have cleared these, so a re-attached overlay would resume painting on the
+        # next motion event, with a value captured against a mask that is long gone.
+        self._paint_value = None
+        self._paint_origin = None
+        self._paint_active = False
+        self._painted.clear()
         if self._canvas is not None:
             for cid in self._cids:
                 self._canvas.mpl_disconnect(cid)
@@ -485,7 +507,29 @@ class TileGridOverlay(QObject, CanvasOverlay):
         self._move_start = (
             event.x, event.y, event.xdata, event.ydata, anchor[0], anchor[1]
         )
+        if self._painting(event):
+            tile = self._tile_at(event.xdata, event.ydata)
+            if tile is not None:
+                # Captured here and never read from the tiles again: the host rewrites
+                # the grid after every emission, so by the second tile `not tile.enabled`
+                # would be answering a question about an already-edited mask, and the
+                # sweep would alternate instead of painting. `TileMaskGrid` keeps a
+                # `_drag_value` for the same reason.
+                self._paint_value = not tile.enabled
+                self._paint_origin = (tile.row, tile.col)
         self._claim(event)
+
+    def _painting(self, event) -> bool:
+        """Whether the paint modifier is held for this event.
+
+        Imported lazily rather than at module scope: every overlay keeps `canvas_base`
+        to a TYPE_CHECKING import, and going through its helper -- rather than reading
+        Qt directly here -- keeps one answer to "which modifiers are down", which
+        matters because the reliable source is the Qt event and not `MouseEvent.key`.
+        """
+        from fibsem.ui.widgets.canvas.canvas_base import _modifiers_from_event
+
+        return PAINT_MODIFIER in _modifiers_from_event(event)
 
     def _claim(self, event) -> None:
         """Tell the canvas this overlay owns the gesture.
@@ -515,22 +559,27 @@ class TileGridOverlay(QObject, CanvasOverlay):
             return Qt.SizeVerCursor
         return None
 
-    def _cursor_at(self, x: float, y: float):
+    def _cursor_at(self, x: float, y: float, painting: bool = False):
         """The cursor for a point over the grid, or None if it is over nothing.
 
-        Edges win over the interior, matching which gesture a press there starts.
+        Edges win over the interior, matching which gesture a press there starts --
+        with the paint modifier held too, since an edge press still resizes.
         """
         cursor = self._cursor_for(*self._edge_sides(x, y))
         if cursor is not None:
             return cursor
-        return Qt.SizeAllCursor if self._within(x, y) else None
+        if not self._within(x, y):
+            return None
+        return Qt.CrossCursor if painting else Qt.SizeAllCursor
 
     def _update_cursor(self, event) -> None:
-        """Show a resize cursor over the grid's edges.
+        """Show a resize cursor over the grid's edges, and a cross while painting.
 
         Without it the drag is undiscoverable -- nothing on screen suggests the
         boundary is draggable, and no one hunts for an affordance they have no reason
-        to believe exists.
+        to believe exists. The cross does the same job for the paint modifier: holding
+        Shift over the grid changes the pointer, which is the only sign the gesture
+        exists for anyone who has not been told.
         """
         if self._canvas is None:
             return
@@ -542,7 +591,9 @@ class TileGridOverlay(QObject, CanvasOverlay):
             and event.inaxes is self._ax
             and event.xdata is not None
         ):
-            cursor = self._cursor_at(event.xdata, event.ydata)
+            cursor = self._cursor_at(
+                event.xdata, event.ydata, painting=self._painting(event)
+            )
 
         if cursor is not None:
             self._canvas.setCursor(cursor)
@@ -554,6 +605,9 @@ class TileGridOverlay(QObject, CanvasOverlay):
             self._cursor_set = False
 
     def _on_drag(self, event) -> None:
+        if self._paint_value is not None:
+            self._drag_paint(event)
+            return
         if self._move_start is not None:
             self._drag_move(event)
             return
@@ -609,19 +663,64 @@ class TileGridOverlay(QObject, CanvasOverlay):
             anchor_x + (event.xdata - x0), anchor_y + (event.ydata - y0)
         )
 
+    def _drag_paint(self, event) -> None:
+        """Give every tile the drag crosses the value the first one was heading for.
+
+        A sweep sets a run of tiles to one value instead of toggling each in turn, so
+        emptying a row is one gesture rather than one click per tile -- and the result
+        does not depend on what each tile happened to be on the way past, which
+        toggling does. On a 5x5 that is the difference between one drag and twenty-five
+        waits on the double-click timer.
+        """
+        press_x, press_y = self._move_start[0], self._move_start[1]
+        if event.inaxes is not self._ax or event.xdata is None or event.ydata is None:
+            return
+        if not self._paint_active:
+            travelled = (event.x - press_x) ** 2 + (event.y - press_y) ** 2
+            if travelled < MOVE_DRAG_THRESHOLD_PX ** 2:
+                return
+            # The move gesture's threshold, deliberately: a modified press that never
+            # travels has to reach `_on_release` still looking like a click, so that
+            # Shift+click stays an ordinary toggle and keeps the double-click deferral
+            # that stops a stage move editing the tile under it (FIB-520).
+            self._paint_active = True
+            if self._paint_origin is not None:
+                self._paint(*self._paint_origin)
+        tile = self._tile_at(event.xdata, event.ydata)
+        if tile is not None:
+            self._paint(tile.row, tile.col)
+
+    def _paint(self, row: int, col: int) -> None:
+        """Emit one tile's new value, at most once per drag.
+
+        Motion events arrive far faster than tiles are crossed and the host rebuilds
+        the whole grid on each emission, so without this a slow sweep over three tiles
+        would ask for hundreds of rebuilds of the same three values.
+        """
+        if (row, col) in self._painted:
+            return
+        self._painted.add((row, col))
+        self.tile_toggled.emit(row, col, self._paint_value)
+
     def _on_release(self, event) -> None:
         # A press inside the grid that never became a drag is a click on a tile. It has
         # to be emitted here because claiming the gesture suppressed the canvas's own
         # click signal -- claiming is what stops the view panning out from under a move.
         pressed_inside = self._move_start is not None
-        was_moving = self._move_active
+        # A paint counts as a drag here as well: the tiles it crossed are already
+        # emitted, so letting the release toggle one more would undo the last of them.
+        was_dragged = self._move_active or self._paint_active
         self._move_start = None
         self._move_active = False
         self._resize_axes = None
+        self._paint_value = None
+        self._paint_origin = None
+        self._paint_active = False
+        self._painted.clear()
 
         if (
             pressed_inside
-            and not was_moving
+            and not was_dragged
             and event.button == 1
             and event.inaxes is self._ax
             and event.xdata is not None

--- a/tests/ui/test_canvas_base.py
+++ b/tests/ui/test_canvas_base.py
@@ -387,3 +387,146 @@ def test_the_scalebar_is_drawn_at_the_smaller_font():
     assert c._scalebar_artist.font_properties.get_size() == 8.0
 
     c.draw()  # a bad font spec raises here rather than at construction
+
+
+class TestTheStatusZoneShowsOneThingAtATime:
+    """Three occupants, one label, an order of precedence.
+
+    They arrived one at a time, each taking "the one free corner" -- and the corner ran
+    out. The FM overview drew a cursor readout over the top-left at the same moment the
+    zone was drawing a hint there, so the coordinates and the instructions were painted
+    on top of each other. Sharing one label makes that impossible rather than fixed:
+    there is only ever one thing to place.
+    """
+
+    @staticmethod
+    def _canvas():
+        c = FibsemImageCanvas()
+        c.resize(900, 500)
+        c.set_array(_img(512, 512), pixel_size=1e-8)
+        c._reposition_overlay_buttons()
+        return c
+
+    def test_the_readout_outranks_the_hint(self):
+        """The hint is still true a motion event later; the readout is not."""
+        c = self._canvas()
+        c.set_hint("Shift+drag to sweep")
+
+        c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
+
+        assert c._status_label.text() == "x 150.0  y 90.0  z 0.0 um"
+
+    def test_clearing_the_readout_hands_the_zone_back(self):
+        """Not blanked -- the hint underneath it never stopped being true."""
+        c = self._canvas()
+        c.set_hint("Shift+drag to sweep")
+        c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
+
+        c.set_status_readout(None)
+
+        assert c._status_label.text() == "Shift+drag to sweep"
+
+    def test_a_flash_outranks_the_readout(self):
+        c = self._canvas()
+        c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
+
+        c.flash_message("OBJ 6000.0 um  (+1.0 um)")
+
+        assert "OBJ" in c._status_label.text()
+
+    def test_the_flash_gives_the_zone_back_to_the_readout(self):
+        c = self._canvas()
+        c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
+        c.flash_message("OBJ 6000.0 um  (+1.0 um)")
+
+        c._clear_flash()
+
+        assert c._status_label.text() == "x 150.0  y 90.0  z 0.0 um"
+
+    def test_a_readout_with_no_hint_under_it_leaves_nothing_behind(self):
+        c = self._canvas()
+        c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
+
+        c.set_status_readout(None)
+
+        assert c._status_label.isHidden()
+
+    def test_the_three_are_told_apart_by_weight_not_by_a_louder_plaque(self):
+        """The hint used to be near-white, which read as an alert over dark data. All
+        three sit on the same dark plaque now; what separates them is the text."""
+        c = self._canvas()
+
+        c.set_hint("Shift+drag to sweep")
+        hint = c._status_label.styleSheet()
+        c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
+        readout = c._status_label.styleSheet()
+
+        assert "rgba(26, 26, 26" in hint and "rgba(26, 26, 26" in readout
+        assert "#e6e6e6" not in hint, "the near-white plaque is what shouted"
+        assert "monospace" in readout, "digits have to sit still while the cursor moves"
+
+    def test_the_readout_stays_clear_of_the_controls(self):
+        """The zone elides to the room it has, whatever is in it."""
+        c = FibsemImageCanvas()
+        c.resize(320, 400)
+        c.set_array(_img(512, 512), pixel_size=1e-8)
+        c.set_live_badge(True)
+        c.set_status_readout("x -12345.6  y -12345.6  z -1234.5 um")
+        c._reposition_overlay_buttons()
+
+        status, chip = c._status_label, c._live_badge
+        assert status.isHidden() or status.geometry().right() < chip.geometry().left()
+
+    def test_the_readout_decays_back_to_the_hint_once_the_pointer_stops(self):
+        """The pointer is over the canvas most of the time it is being used, so a
+        readout that held the zone for as long as it was there would make a standing
+        instruction unreadable in practice. Fired by hand rather than waited on."""
+        c = self._canvas()
+        c.set_hint("Shift+drag to sweep")
+        c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
+        assert c._readout_timer.isActive()
+
+        c._clear_readout()
+
+        assert c._status_label.text() == "Shift+drag to sweep"
+
+    def test_moving_again_brings_the_readout_straight_back(self):
+        c = self._canvas()
+        c.set_hint("Shift+drag to sweep")
+        c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
+        c._clear_readout()
+
+        c.set_status_readout("x 151.0  y 90.0  z 0.0 um")
+
+        assert c._status_label.text() == "x 151.0  y 90.0  z 0.0 um"
+
+    def test_each_update_restarts_the_decay(self):
+        """It decays after the pointer *stops*, not a fixed time after it arrived."""
+        c = self._canvas()
+        c.set_hint("Shift+drag to sweep")
+        c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
+        first = c._readout_timer.remainingTime()
+
+        c.set_status_readout("x 151.0  y 90.0  z 0.0 um")
+
+        assert c._readout_timer.remainingTime() >= first
+
+    def test_a_readout_with_no_hint_under_it_does_not_decay(self):
+        """There would be nothing to reveal, so decaying would blank the corner rather
+        than free it -- and the numbers are the only thing that corner was saying."""
+        c = self._canvas()
+
+        c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
+
+        assert not c._readout_timer.isActive()
+        assert c._status_label.text() == "x 150.0  y 90.0  z 0.0 um"
+
+    def test_leaving_the_canvas_stops_the_decay_timer(self):
+        """It would otherwise fire into a zone that has already moved on."""
+        c = self._canvas()
+        c.set_hint("Shift+drag to sweep")
+        c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
+
+        c.set_status_readout(None)
+
+        assert not c._readout_timer.isActive()

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1341,12 +1341,14 @@ def test_the_cursor_readout_names_the_position_under_it(qapp, interactive_widget
 
     widget._on_cursor_moved(1500.0, -900.0)
 
-    text = widget.cursor_readout.text()
+    text = widget.canvas.canvas._readout_text
     assert f"{under.x * 1e6:.1f}" in text
     assert f"{under.y * 1e6:.1f}" in text
 
     widget._on_cursor_moved(None, None)
-    assert widget.cursor_readout.text() == "", "the readout must not freeze off-canvas"
+    assert widget.canvas.canvas._readout_text is None, (
+        "the readout must not freeze off-canvas"
+    )
 
 
 def test_the_reported_offset_is_measured_in_the_frame_it_is_drawn_in(qapp, interactive_widget):
@@ -2168,27 +2170,51 @@ def test_showing_the_bars_survives_their_own_reset(qapp):
 # ── the canvas says where things are ─────────────────────────────────────
 
 
-def test_the_cursor_readout_is_drawn_over_the_canvas(qapp, interactive_widget):
-    """Not beside it. The only free corner is the top left — the toolbar owns the top
-    right, the scalebar the bottom right, the stage info bar the bottom left."""
+def test_the_cursor_readout_takes_the_status_zone_from_the_grid_hint(qapp, interactive_widget):
+    """Both want the top left, and this widget used to give each its own label there --
+    which drew the coordinates straight over the hint. One zone showing one thing at a
+    time is what makes that impossible rather than merely fixed."""
     widget = interactive_widget
+    canvas = widget.canvas.canvas
+    assert "Shift+drag" in canvas._status_label.text(), "the hint holds the zone at rest"
 
-    assert widget.cursor_readout.parent() is widget.canvas.canvas
+    widget._on_cursor_moved(1500.0, -900.0)
+    qapp.processEvents()
+
+    shown = canvas._status_label.text()
+    assert "Shift+drag" not in shown
+    assert shown == canvas._readout_text
 
 
-def test_the_cursor_readout_hides_when_the_pointer_leaves(qapp, interactive_widget):
-    """It sits on top of the image, so an empty plaque floating over the data is worse
-    than nothing there."""
+def test_the_zone_goes_back_to_the_hint_when_the_pointer_leaves(qapp, interactive_widget):
+    """The readout is only true while the pointer is where it is; the hint is still true
+    afterwards, so leaving the canvas hands the zone back rather than blanking it."""
     widget = interactive_widget
+    canvas = widget.canvas.canvas
 
     widget._on_cursor_moved(100.0, 100.0)
     qapp.processEvents()
-    assert widget.cursor_readout.isVisible()
-    assert widget.cursor_readout.text()
+    assert canvas._readout_text
 
     widget._on_cursor_moved(None, None)
     qapp.processEvents()
-    assert not widget.cursor_readout.isVisible()
+
+    assert canvas._readout_text is None
+    assert "Shift+drag" in canvas._status_label.text()
+
+
+def test_a_flash_outranks_the_cursor_readout(qapp, interactive_widget):
+    """A focus flash is a value that just changed and is about to go away; the readout
+    will still be there a motion event later."""
+    widget = interactive_widget
+    canvas = widget.canvas.canvas
+    widget._on_cursor_moved(1500.0, -900.0)
+    qapp.processEvents()
+
+    canvas.flash_message("OBJ 6000.0 um  (+1.0 um)")
+    qapp.processEvents()
+
+    assert "OBJ" in canvas._status_label.text()
 
 
 def test_the_info_bar_states_the_stage_pose(qapp, interactive_widget):
@@ -4600,3 +4626,21 @@ class TestTheCameraTransformReachesTheProjection:
         assert "transform_changed" in source, (
             "the transform subscription is not in closeEvent's teardown list"
         )
+
+
+def test_the_canvas_says_how_to_edit_the_grid_while_it_is_shown(qapp):
+    """The gestures are otherwise discoverable only by accident: the cursor names the
+    edge drag and the paint modifier, but nothing on screen suggests trying either.
+
+    Tied to the grid's visibility rather than set once, so hiding the grid takes its
+    instructions with it -- a standing instruction for something not on screen is worse
+    than none.
+    """
+    widget = _fresh_widget(qapp)
+
+    hint = widget.canvas.canvas._hint_text
+    assert hint and "Shift+drag" in hint
+
+    widget.tile_grid_panel.visibility_changed.emit(False)
+
+    assert widget.canvas.canvas._hint_text is None

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -772,3 +772,206 @@ class TestADoubleClickIsAStageMoveNotATileEdit:
         assert overlay._pending_toggle is None
         assert not overlay._toggle_timer.isActive()
         assert toggled == []
+
+
+# ── paint by dragging with the modifier held ─────────────────────────────
+
+
+def _shift(event):
+    """Attach a Qt event reporting Shift, the way an embedded canvas delivers one.
+
+    `_modifiers_from_event` reads `guiEvent` rather than matplotlib's `key`, because in
+    an embedded canvas the Qt state is the reliable one -- so a test that set `key`
+    would be exercising a path the app never takes.
+    """
+    from types import SimpleNamespace
+
+    from PyQt5.QtCore import Qt
+
+    event.guiEvent = SimpleNamespace(modifiers=lambda: Qt.ShiftModifier)
+    return event
+
+
+def _tile_centre(overlay, tiles, row, col):
+    tile = next(t for t in tiles if (t.row, t.col) == (row, col))
+    x, y, width, height = overlay._rect_for(tile)
+    return x + width / 2, y + height / 2
+
+
+def _sweep(overlay, points, px_step=50.0):
+    """Shift-press at the first point, drag through the rest, release at the last."""
+    overlay._on_press(_shift(_event(overlay, *points[0])))
+    for step, point in enumerate(points[1:], start=1):
+        overlay._on_drag(_event(overlay, *point, px=px_step * step, py=0.0))
+    last = px_step * max(len(points) - 1, 1)
+    overlay._on_release(_event(overlay, *points[-1], px=last, py=0.0))
+    _flush_toggle(overlay)
+
+
+def test_a_shift_drag_paints_every_tile_it_crosses(qapp):
+    """One gesture instead of one click per tile -- and one wait on the double-click
+    timer instead of one per tile, which is what made clearing a row unusable."""
+    overlay, tiles = build(3, 3)
+    painted = []
+    overlay.tile_toggled.connect(lambda r, c, e: painted.append((r, c, e)))
+
+    _sweep(overlay, [_tile_centre(overlay, tiles, 1, col) for col in range(3)])
+
+    assert painted == [(1, 0, False), (1, 1, False), (1, 2, False)]
+
+
+def test_the_swept_value_is_fixed_at_press_not_re_read_per_tile(qapp):
+    """The host writes every emission into the mask and hands back a rebuilt grid, so a
+    sweep that asked each tile what it currently was would alternate instead of paint.
+    Reproduced by doing exactly what the host does, between motion events.
+
+    The row starts mixed, so a re-reading implementation is forced to disagree: it would
+    turn the middle tile *on* while the sweep is turning the row off.
+    """
+    start = [[True, False, True]]
+    overlay, tiles = build(1, 3, mask=start)
+    painted = []
+
+    def rewrite(row, col, enabled):
+        painted.append((row, col, enabled))
+        mask = [list(row_values) for row_values in start]
+        for r, c, e in painted:
+            mask[r][c] = e
+        overlay.set_grid(
+            compute_tile_grid_from_fov(
+                1, 3, FOV, FOV, WIDTH, HEIGHT, OVERLAP, mask=mask
+            ),
+            (HEIGHT, WIDTH),
+            PIXEL_SIZE,
+        )
+
+    overlay.tile_toggled.connect(rewrite)
+
+    _sweep(overlay, [_tile_centre(overlay, tiles, 0, col) for col in range(3)])
+
+    assert painted == [(0, 0, False), (0, 1, False), (0, 2, False)]
+
+
+def test_a_shift_click_that_never_travels_is_an_ordinary_toggle(qapp):
+    """Below the drag threshold the modifier changes nothing. The press has to reach the
+    release still looking like a click, so it keeps the deferral that stops a
+    double-click editing the tile it moves the stage to (FIB-520)."""
+    overlay, tiles = build(3, 3)
+    painted = []
+    overlay.tile_toggled.connect(lambda r, c, e: painted.append((r, c, e)))
+    point = _tile_centre(overlay, tiles, 1, 1)
+
+    overlay._on_press(_shift(_event(overlay, *point)))
+    overlay._on_drag(_event(overlay, *point, px=MOVE_DRAG_THRESHOLD_PX - 1, py=0.0))
+    overlay._on_release(_event(overlay, *point))
+
+    assert painted == [], "a modified click must still wait out the double-click interval"
+    _flush_toggle(overlay)
+    assert painted == [(1, 1, False)]
+
+
+def test_a_paint_does_not_also_toggle_the_tile_it_ends_on(qapp):
+    """The release would otherwise undo the last tile the sweep just painted."""
+    overlay, tiles = build(3, 3)
+    painted = []
+    overlay.tile_toggled.connect(lambda r, c, e: painted.append((r, c, e)))
+
+    _sweep(overlay, [
+        _tile_centre(overlay, tiles, 1, 0),
+        _tile_centre(overlay, tiles, 1, 1),
+    ])
+
+    assert painted == [(1, 0, False), (1, 1, False)]
+
+
+def test_a_tile_is_painted_once_however_long_the_pointer_lingers(qapp):
+    """Motion events arrive far faster than tiles are crossed, and the host rebuilds the
+    whole grid on each emission."""
+    overlay, tiles = build(3, 3)
+    painted = []
+    overlay.tile_toggled.connect(lambda r, c, e: painted.append((r, c, e)))
+    x, y = _tile_centre(overlay, tiles, 1, 1)
+
+    overlay._on_press(_shift(_event(overlay, x, y)))
+    for step in range(1, 7):
+        overlay._on_drag(_event(overlay, x + step, y, px=50.0, py=0.0))
+    overlay._on_release(_event(overlay, x, y, px=50.0, py=0.0))
+    _flush_toggle(overlay)
+
+    assert painted == [(1, 1, False)]
+
+
+def test_an_unmodified_drag_still_moves_the_grid(qapp):
+    """The modifier is what distinguishes the two: without it, an interior drag has to
+    keep meaning "move", which is the gesture that was there first."""
+    overlay, tiles = build(3, 3)
+    moved, painted = [], []
+    overlay.grid_move_requested.connect(lambda x, y: moved.append((x, y)))
+    overlay.tile_toggled.connect(lambda r, c, e: painted.append((r, c, e)))
+
+    _drag(
+        overlay,
+        _tile_centre(overlay, tiles, 1, 1),
+        _tile_centre(overlay, tiles, 1, 2),
+    )
+
+    assert moved, "an unmodified interior drag must still move the grid"
+    assert painted == []
+
+
+def test_a_modified_edge_press_still_resizes(qapp):
+    """Edges win over the interior for a press, and holding the modifier does not
+    change that -- the cursor says resize, so a press there must resize."""
+    overlay, _ = build(3, 3)
+    left, top, _, height = overlay._bounds()
+
+    overlay._on_press(_shift(_event(overlay, left, top + height / 2)))
+
+    assert overlay.is_resizing
+    assert overlay._paint_value is None
+
+
+def test_the_modifier_turns_the_interior_cursor_into_a_cross(qapp):
+    """The only sign the gesture exists, for anyone who has not been told."""
+    from PyQt5.QtCore import Qt
+
+    overlay, tiles = build(3, 3)
+    point = _tile_centre(overlay, tiles, 1, 1)
+
+    overlay._update_cursor(_event(overlay, *point))
+    assert overlay._canvas.cursor == Qt.SizeAllCursor
+
+    overlay._update_cursor(_shift(_event(overlay, *point)))
+    assert overlay._canvas.cursor == Qt.CrossCursor
+
+
+def test_a_paint_survives_the_grid_being_cleared_underneath_it(qapp):
+    """`_refresh_tile_grid` clears the grid when the camera geometry cannot be read, and
+    that can land between two motion events of a sweep."""
+    overlay, tiles = build(3, 3)
+    painted = []
+    overlay.tile_toggled.connect(lambda r, c, e: painted.append((r, c, e)))
+    first = _tile_centre(overlay, tiles, 1, 0)
+    second = _tile_centre(overlay, tiles, 1, 1)
+
+    overlay._on_press(_shift(_event(overlay, *first)))
+    overlay._on_drag(_event(overlay, *second, px=50.0, py=0.0))
+    overlay.clear()
+    overlay._on_drag(_event(overlay, *second, px=80.0, py=0.0))
+    overlay._on_release(_event(overlay, *second, px=80.0, py=0.0))
+    _flush_toggle(overlay)
+
+    assert painted == [(1, 0, False), (1, 1, False)]
+
+
+def test_detaching_mid_paint_does_not_leave_the_gesture_armed(qapp):
+    """Detaching skips the release that clears this, so a re-attached overlay would
+    resume painting on the next motion event, with a value captured against a mask that
+    no longer exists."""
+    overlay, tiles = build(3, 3)
+    overlay._on_press(_shift(_event(overlay, *_tile_centre(overlay, tiles, 1, 1))))
+
+    overlay.detach()
+
+    assert overlay._paint_value is None
+    assert overlay._painted == set()


### PR DESCRIPTION
Clearing a row of the planned tileset took one click per tile, each waiting out the double-click interval first — because a click on a tile can still turn out to be half of a double-click that moves the stage. The settings panel's own grid has had drag-to-paint since it was written; the canvas, which is the better place to do it, had nothing.

## Shift+drag paints

The value is captured at press and never read again. The host writes each emission into the mask and hands back a rebuilt grid, so asking each tile what it *currently* is would make a sweep alternate rather than paint — `TileMaskGrid` keeps a `_drag_value` for the same reason. Each tile emits at most once per drag: motion events arrive far faster than tiles are crossed, and every emission costs a full grid rebuild.

Three things deliberately unchanged:

* an unmodified interior drag still **moves** the grid,
* an edge press still **resizes**, modifier held or not,
* a Shift+**click** that never travels is an ordinary toggle — it reaches the release still looking like a click, so it keeps the deferral that stops a double-click editing the tile it moves the stage to (FIB-520).

The overlay is shared, so the FIB/SEM overview tab gets the gesture too when it lands.

## The status zone gains a third occupant

The gesture is invisible without being told about it, so the cursor becomes a cross over the grid while Shift is held, and the FM overview states it in the canvas status zone.

That hint collided with the cursor readout, which was a hand-placed `QLabel` at the top left — "the one free corner", which stopped being free when FIB-639 put the status zone on that row. So the readout moves into the zone as well, and the label goes.

The zone now shows one of three things, ordered by how fleeting they are — flash, readout, hint. Sharing one label is what makes them *unable* to collide rather than merely arranged not to. A readout decays 2.5 s after the pointer stops, so a hint underneath is not shut out for as long as the pointer happens to be over the canvas; only when there is a hint to reveal, since with nothing underneath decaying would blank the corner rather than free it.

The hint also loses its near-white plaque, which shouted over the data it was drawn on. All three now sit on the dark plaque the rest of the canvas chrome uses.

## Verified

* **27 new tests**; `tests/ui/` is 1330 passed, 1 skipped.
* **Mutation-checked**, since a green run on tests written alongside the code proves little. Re-reading the tile state per tile → 1 fail; dropping the once-per-tile guard → 1; a paint not counting as a drag on release → 4; painting on press without waiting for travel → 1; hint outranking the readout → 2; the readout losing its style → 1; the near-white plaque returning → 1; the hint never being cleared → 1.
* **Driven end to end on the real widget**, not just the overlay against a fake canvas: one sweep took the middle row off a 3×3 and the settings panel's own count followed to `6/9 tiles`.
* **Measured** rather than assumed, since the readout runs at motion-event rates: `set_status_readout` costs 0.103 ms against a bare label's 0.041 ms — 1/160th of a frame.
* The hint shows in full down to a 440 px canvas and elides cleanly below that, never reaching the toolbar.

CI cannot see any of this — it has no PyQt5, so these tests skip there.

## Not closing anything

This is the drag-to-paint half of the tile-mask work. The panel it is meant to replace is still there and still needed: All/None/Invert and the `n/total tiles` count have no canvas equivalent yet, and the count is the one that would be silently lost. Those are recorded on the tile-mask issue for the settings-widget consolidation to pick up.
