### PR TITLE
[ui] Hold the planned tileset still for the length of a run (FIB-647)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -2220,6 +2220,12 @@ class FMOverviewWidget(QWidget):
             self.progress_tiles.reset()
             self.progress_tile_detail.reset()
             self.status.setText("Starting…")
+            # The framing you pressed Acquire with is the framing you keep. This tab
+            # meets it once rather than twice -- one composite under one key while the
+            # run goes -- but the end is the same swap: the stitch is placed and the
+            # preview removed, two extent changes at the moment there is finally
+            # something worth looking at (FIB-648). Taken back by "reset view".
+            self.canvas.canvas.auto_fit = False
 
         # After the resets above, not before: `FibsemProgressWidget.reset()` hides
         # itself, so showing the bars first and resetting them second leaves them

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -742,6 +742,19 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._ax.set_xlim(xmin - mx, xmax + mx)
         self._ax.set_ylim(ybot + my, ytop - my)  # y-axis stays inverted (origin upper)
 
+    def _view_moved_by_user(self) -> None:
+        """The view was just panned or zoomed by hand.
+
+        A hook rather than behaviour: nothing here re-frames itself, so the base has
+        nothing to stop doing. A canvas that *does* -- see
+        :attr:`FibsemRealSpaceCanvas.auto_fit`, which refits as content arrives --
+        overrides this to hand the camera over, because from here the framing is
+        something the user chose rather than something the canvas guessed.
+
+        Called only where the limits actually changed, so a scroll the zoom limiter
+        refused is not mistaken for one.
+        """
+
     def set_view_margin(self, frac: float) -> None:
         """Empty space kept around the image when fitting the view, as a fraction of the
         image size per side (0 = tight, 0.5 = 2x the image extent). Also keeps overlays
@@ -1056,6 +1069,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         dx, dy = x1 - x0, y1 - y0
         self._ax.set_xlim(xlim0[0] - dx, xlim0[1] - dx)
         self._ax.set_ylim(ylim0[0] - dy, ylim0[1] - dy)
+        self._view_moved_by_user()
         self._schedule_redraw()
 
     def _on_release(self, event):
@@ -1092,6 +1106,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             return
         self._ax.set_xlim(cx + (xlim[0] - cx) * factor, cx + (xlim[1] - cx) * factor)
         self._ax.set_ylim(cy + (ylim[0] - cy) * factor, cy + (ylim[1] - cy) * factor)
+        self._view_moved_by_user()
         self._schedule_redraw()
 
     def _zoom_allowed(self, span: float) -> bool:

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -111,7 +111,12 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         self._world_extent_m: Optional[Tuple[float, float, float, float]] = None
         self._auto_key = 0
         # Refit as content grows, so tiles arriving during an acquisition stay in view.
-        # Callers that would rather keep the user's zoom can turn this off.
+        #
+        # True until the framing becomes someone's choice rather than this canvas's
+        # guess. A pan or a zoom is the user making it theirs (`_view_moved_by_user`);
+        # an owner driving the camera itself sets this False directly. Either way the
+        # only thing that takes it back is "reset view" -- the button whose whole
+        # meaning is "frame it for me again".
         self.auto_fit: bool = True
         self._fitted_extent: Optional[Tuple[float, float, float, float]] = None
 
@@ -376,6 +381,31 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         """The declared working area as (width, height, cx, cy) in metres, or None."""
         return self._world_extent_m
 
+    # ── who owns the camera ───────────────────────────────────────────────
+
+    def _view_moved_by_user(self) -> None:
+        """A pan or a zoom hands the framing over. See :attr:`auto_fit`.
+
+        Zoom in on a feature and the next thing placed used to throw the view away and
+        refit to everything -- at the two moments you are most likely to be looking
+        closely, since a run ends by removing the preview and placing the stitch under
+        another key, which is two extent changes back to back (FIB-648).
+        """
+        self.auto_fit = False
+
+    def reset_view(self) -> None:
+        """Frame the content, and take the camera back.
+
+        The one way `auto_fit` comes back on, deliberately: it is the button that means
+        "frame it for me", so re-arming is what it was already being pressed for, and
+        nothing else can quietly undo a framing someone chose.
+        """
+        self.auto_fit = True
+        super().reset_view()
+        # Adopt what was just fitted, so the next content change is measured against
+        # this framing rather than against whatever was fitted before the user's zoom.
+        self._fitted_extent = self._fit_extent()
+
     def metres_to_canvas(self, x: float, y: float) -> Tuple[float, float]:
         """Convert a position in metres to canvas coordinates.
 
@@ -551,14 +581,41 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         across the top -- which is what an overview framed before its splitter settled
         looked like.
 
-        Guarded on `auto_fit` like every other refit, so a canvas whose owner has taken
-        charge of the camera is not re-framed behind its back.
+        A canvas whose camera belongs to someone else is not re-framed behind their
+        back, but it is not left letterboxed either: the viewport changed size, so the
+        view is grown or shrunk to match and the magnification is what survives.
         """
         super().resizeEvent(event)
         if self.auto_fit:
             self._fitted_extent = None  # the padded extent is stale, whatever it was
             self._fit_view()
-            self.draw_idle()
+        else:
+            self._keep_scale_through_resize(event.oldSize(), event.size())
+        self.draw_idle()
+
+    def _keep_scale_through_resize(self, old, new) -> None:
+        """Resize the *viewport*, not the magnification.
+
+        A window that gets taller shows more; it does not zoom. Scaling the limits by
+        the same factors as the widget keeps metres-per-pixel exactly where the user
+        left it, and keeps the framed region the widget's shape -- so `aspect="equal"`
+        still has nothing to take out of the axes box and the canvas goes on filling
+        the window. Refitting would do the second thing at the cost of the first, which
+        is the framing being taken back; doing nothing does the first at the cost of
+        the second, which is black bands down the sides.
+        """
+        if old is None or old.width() <= 0 or old.height() <= 0:
+            return  # the first resize has no "before" to keep the scale against
+        kx, ky = new.width() / old.width(), new.height() / old.height()
+        if kx <= 0 or ky <= 0:
+            return
+        (x0, x1), (y0, y1) = self._ax.get_xlim(), self._ax.get_ylim()
+        cx, cy = (x0 + x1) / 2.0, (y0 + y1) / 2.0
+        # Halved spans, signed: the y axis is inverted here, and the sign is what keeps
+        # it that way.
+        half_w, half_h = (x1 - x0) / 2.0 * kx, (y1 - y0) / 2.0 * ky
+        self._ax.set_xlim(cx - half_w, cx + half_w)
+        self._ax.set_ylim(cy - half_h, cy + half_h)
 
     def _remove_artist(self, placed: PlacedImage) -> None:
         try:

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -2417,6 +2417,16 @@ class FibsemOverviewWidget(QWidget):
         self._running = running
         self._apply_enabled_state()
         if running:
+            # The framing you pressed Acquire with is the framing you keep. A run is the
+            # worst moment to re-frame: the preview lands under one key and the stitch
+            # replaces it under another, so the canvas held still for the whole
+            # acquisition and then lurched twice at the end, when there was finally
+            # something worth looking at (FIB-648).
+            #
+            # Not restored afterwards. There is content on the canvas now, and the
+            # framing belongs to whoever last set it; "reset view" is how you ask for
+            # it back.
+            self.canvas.auto_fit = False
             self._tiles_acquired = 0
             # Cleared rather than set to "Starting…": the progress bar carries the
             # message for the whole run, and a label saying "Starting…" underneath one

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -450,6 +450,10 @@ class FibsemOverviewWidget(QWidget):
         # stage. None means "wherever the stage is", which is also what the runner
         # falls back to -- so the drawn grid and the acquisition agree by default.
         self._target: Optional[FibsemStagePosition] = None
+        # What the run under way is centred on, and None between runs. Its own field
+        # rather than a read of `_target`: a run started without one is centred on
+        # wherever the stage was when it began, which the stage stops being one tile in.
+        self._run_centre: Optional[FibsemStagePosition] = None
         self._positions: List[FibsemStagePosition] = []
         self._selected_position: Optional[str] = None
         # Positions a host has flagged, by name. What "flagged" means is the host's
@@ -1138,7 +1142,7 @@ class FibsemOverviewWidget(QWidget):
             return None
         return StageFrame(self.canvas, origin, projection)
 
-    def _set_origin_from(self, image: FibsemImage, view: "OverviewView") -> None:
+    def _set_origin_from(self, image: FibsemImage, view: "OverviewView") -> bool:
         """Anchor a view on the first image placed in it, if it is not anchored yet.
 
         A *provisional* anchor -- one `_seed_frame` invented so the tab could draw
@@ -1146,14 +1150,18 @@ class FibsemOverviewWidget(QWidget):
         in the view at that point, so re-anchoring moves nothing; it just stops the
         canvas being centred on wherever the stage happened to be when the tab opened,
         which can be millimetres from the data.
+
+        Returns whether it re-anchored, because that moves every overlay drawn in the
+        view: the origin is what a stage position is measured *from*.
         """
         if view in self._origins and view not in self._provisional:
-            return
+            return False
         position = self._position_of(image)
         if position is None:
-            return
+            return False
         self._origins[view] = deepcopy(position)
         self._provisional.discard(view)
+        return True
 
     # ── views ────────────────────────────────────────────────────────────
 
@@ -1288,18 +1296,28 @@ class FibsemOverviewWidget(QWidget):
         elif view != self._current_view:
             self.show_view(view)
 
-        self._set_origin_from(image, view)
+        reframed = self._set_origin_from(image, view)
         # The canvas needs a scale before a frame can exist, and the frame is what turns
         # a stage position into an offset. Usually seeded from the settings before any
         # image arrives (`_seed_frame`); this is the fallback for a widget that has been
         # handed an image without ever drawing. Which pixel size wins does not matter
         # beyond the units: `add_image` scales each image by its own against this one.
         if self.canvas.reference_pixel_size is None:
-            self.canvas.set_reference_pixel_size(pixel_size)
+            reframed |= self.canvas.set_reference_pixel_size(pixel_size)
 
-        return self._place_on_canvas(
+        placed = self._place_on_canvas(
             self._stored_tile(image), view, key=key, zorder=zorder
         )
+        # Only when the *frame* moved, which is the origin or the scale and nothing else.
+        # An image is drawn in the frame; it does not decide it, so a placement that
+        # leaves both alone changes nothing any overlay is derived from -- and every
+        # placement after the first is one of those, including every frame of a run's
+        # live preview. Refreshing on each of them re-anchored the planned tileset at
+        # wherever the stage had reached, so the plan walked the grid alongside the
+        # acquisition (FIB-647).
+        if reframed:
+            self._refresh_context_overlays()
+        return placed
 
     # ── contrast and gamma ────────────────────────────────────────────────
 
@@ -1343,7 +1361,12 @@ class FibsemOverviewWidget(QWidget):
         self, tile: "_PlacedTile", view: "OverviewView",
         key: Optional[str] = None, zorder: Optional[float] = None,
     ) -> Optional[str]:
-        """Draw a stored tile in *view*. Shared by first placement and re-placement."""
+        """Draw a stored tile in *view*. Shared by first placement and re-placement.
+
+        Draws, and nothing else. The overlays are the caller's business: `place_image`
+        refreshes them when the placement moved the frame, and `show_view` once at the
+        end rather than once per re-placed image.
+        """
         frame = self._frame(view)
         if frame is None:
             return None
@@ -1361,7 +1384,6 @@ class FibsemOverviewWidget(QWidget):
             # placed image without walking the records -- which would miss the
             # acquisition preview, the one thing on the canvas that has no record.
             self._tiles[placed] = tile
-        self._refresh_context_overlays()
         return placed
 
     def set_image(self, image: FibsemImage) -> Optional[str]:
@@ -1565,7 +1587,15 @@ class FibsemOverviewWidget(QWidget):
         A target if the grid has been dragged somewhere, otherwise wherever the stage
         is -- which is what the runner falls back to, so the drawn grid and the
         acquisition agree without either being told about the other.
+
+        A run in progress owns the answer, because during one "wherever the stage is"
+        stops being the same question: the stage is at whichever tile it has reached,
+        so the plan would describe the tile being acquired rather than the run doing
+        the acquiring. The centre the run was started with is the one thing that is
+        true for the whole of it (FIB-647).
         """
+        if self._run_centre is not None:
+            return self._run_centre
         return self._target or self._stage_position
 
     def _declare_working_area(self, frame: StageFrame) -> None:
@@ -1982,8 +2012,15 @@ class FibsemOverviewWidget(QWidget):
         # Not during a run: the stage visits every tile, and re-drawing the planned
         # footprint at each one would drag it across the canvas as the acquisition
         # walked the grid.
+        #
+        # The two things that describe *where the stage is* still keep up, because they
+        # are not the plan: the marker, and the readout under it. The readout is here
+        # rather than left out because placing an image used to refresh it as a side
+        # effect, so it tracked a run tile by tile -- and it should go on doing that now
+        # that placing an image refreshes nothing.
         if self._running:
             self._refresh_position_markers()
+            self._refresh_stage_info()
             return
         # A re-pose changes which view the next run lands in, and the canvas follows it
         # the same way it follows a change of beam.
@@ -2296,6 +2333,11 @@ class FibsemOverviewWidget(QWidget):
         self._refresh_overview_list()
 
         self._stop_event.clear()
+        # What the canvas draws the plan around until the run is over. The same centre
+        # the runner will use: a target if there is one, and otherwise where the stage
+        # is now -- which is what the runner reads for itself when handed None, and is
+        # the last moment the two agree, since the run moves the stage immediately.
+        self._run_centre = deepcopy(self._target or self._stage_position)
         self._set_running(True)
         # Copied with the settings: the target can be dragged again while the run is
         # under way, and the run has to keep the grid it was started with.
@@ -2408,6 +2450,9 @@ class FibsemOverviewWidget(QWidget):
                 self._place_finished_mosaic(self._mosaic)
             else:
                 self._drop_unfinished_run()
+        # Handed back before the redraw below, so the plan goes back to describing the
+        # *next* run rather than the one that has just ended.
+        self._run_centre = None
         # The stage went home at the end of the run, so the planned footprint moved.
         self._refresh_context_overlays()
 

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -960,6 +960,39 @@ def test_declaring_a_working_area_without_a_refit_does_not_move_the_view(qapp, o
     assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) != zoomed
 
 
+def test_a_run_hands_the_camera_over(qapp):
+    """The framing you pressed Acquire with is the framing you keep (FIB-648).
+
+    This tab meets the problem less often than the beam one -- one composite under one
+    key while the run goes, rather than a preview whose extent grows -- but it ends the
+    same way: `_finish` places the stitch and removes the preview, two extent changes at
+    the moment there is finally something worth looking at. The rule is the canvas's,
+    so it is the same rule on both tabs.
+
+    Its own widget: it leaves an image on the canvas and the camera handed over, which
+    is exactly the state the module fixture shares.
+    """
+    widget = _fresh_widget(qapp)
+    canvas = widget.canvas.canvas
+    ax = canvas._ax
+    ax.set_xlim(-100, 100)
+    ax.set_ylim(100, -100)
+    framing = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+
+    widget._set_running(True)
+    qapp.processEvents()
+    assert canvas.auto_fit is False
+
+    # Somewhere well outside the framing, which is what an end-of-run swap can be.
+    canvas.add_image(np.zeros((64, 64), dtype=np.uint8), centre=(2e-3, 2e-3),
+                     pixel_size=1e-6, key="stitch")
+    qapp.processEvents()
+
+    assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == framing
+    widget._set_running(False)
+    widget.close()
+
+
 def test_the_grid_keeps_its_scale_under_a_decimated_preview(qapp, overview_widget):
     """The live preview is coarser than a tile. The grid is drawn in canvas coordinates,
     whose scale is fixed by the canvas reference — so the preview's stride must not

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -1529,6 +1529,149 @@ class TestThePlannedTileset:
         assert widget.target is None
 
 
+class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
+    """A run visits every tile, and the plan it is running must not follow it there.
+
+    `_on_stage_moved` has always guarded against this, and the guard has always been
+    bypassed: it skips the *overlay* refresh but still updates the cached position, and
+    the planned tileset is anchored at `_target or _stage_position`. Every preview frame
+    placed an image, and placing one refreshed every context overlay on the way out --
+    so the plan was re-anchored once per tile and walked the grid alongside the
+    acquisition (FIB-647).
+
+    Fixed at the level the issue asked for rather than by special-casing `_running`:
+    an image is *drawn in* the frame, it does not decide it, so a placement refreshes
+    the overlays only when it moved the frame -- the view's origin or the canvas scale.
+    """
+
+    def _run_a_tile(self, widget, microscope, position):
+        """One tile of a run: the stage arrives, then a preview lands."""
+        widget._on_stage_moved(position)
+        widget._apply_progress({
+            "msg": "Tile Collected", "counter": 1, "total": 3,
+            "preview": _tile(microscope, position),
+        })
+
+    def test_the_planned_grid_does_not_follow_the_stage(self, widget, microscope):
+        from fibsem.ui.widgets.overview_widget import OverviewRecord
+
+        base = microscope.get_stage_position()
+        widget._records["run"] = OverviewRecord("run", "run", [])
+        widget._active_record = "run"
+        widget._set_running(True)
+        anchored_at = widget.tile_grid_overlay._anchor()
+        assert anchored_at is not None, "the plan is not drawn, so this proves nothing"
+
+        for step in (1, 2, 3):
+            self._run_a_tile(widget, microscope, _at(base, dx=step * 250e-6))
+
+        assert widget.tile_grid_overlay._anchor() == pytest.approx(anchored_at), (
+            "the planned tileset moved with the stage during the run"
+        )
+
+    def test_the_plan_follows_the_stage_again_once_the_run_is_over(
+        self, widget, microscope
+    ):
+        """The counterpart. Held still *for the run*, not disconnected: where the next
+        run would land is still wherever the stage ends up."""
+        base = microscope.get_stage_position()
+        anchored_at = widget.tile_grid_overlay._anchor()
+
+        widget._on_stage_moved(_at(base, dx=400e-6))
+
+        assert widget.tile_grid_overlay._anchor() != pytest.approx(anchored_at)
+
+    def test_the_readout_still_tracks_the_stage_during_a_run(self, widget, microscope):
+        """Not everything on the canvas is the plan. Where the stage *is* -- the marker
+        and the numbers under it -- has to keep up, and it used to only because placing
+        a preview refreshed it as a side effect."""
+        base = microscope.get_stage_position()
+        widget._set_running(True)
+        before = widget.canvas._info_text
+
+        widget._on_stage_moved(_at(base, dx=750e-6, dy=-300e-6))
+
+        assert widget.canvas._info_text != before, (
+            "the stage readout froze for the length of the run"
+        )
+
+    def test_a_preview_frame_does_not_redraw_the_context_overlays(
+        self, widget, microscope
+    ):
+        """The mechanism, stated on its own: a redraw per tile is a redraw of the stage
+        limits, the holder slots, the gridbars and the view selector too, none of which
+        an arriving image changes."""
+        base = microscope.get_stage_position()
+        widget.place_image(_tile(microscope, _at(base)))  # anchors the view
+        calls = []
+        widget._refresh_context_overlays = lambda: calls.append(1)
+
+        widget.place_image(_tile(microscope, _at(base, dx=100e-6)), key="preview")
+        widget.place_image(_tile(microscope, _at(base, dx=200e-6)), key="preview")
+
+        assert calls == [], f"{len(calls)} overlay refresh(es) for images already framed"
+
+    def test_the_plan_is_pinned_to_what_the_run_is_acquiring(
+        self, widget, microscope, monkeypatch, tmp_path
+    ):
+        """Not redrawn is not enough; redrawn *right* is the requirement.
+
+        The first preview re-anchors the view -- it replaces the provisional origin
+        `_seed_frame` invented with where the image really came from -- and that is a
+        genuine reason to redraw every overlay. Drawn from the cached stage position,
+        the plan then landed on whichever tile the stage had reached by then: measured
+        against a real 3x3 run of 80 um tiles, one tile off, and it stayed there for the
+        rest of the acquisition. So a run pins the centre it was started with.
+        """
+        def fake_worker(fn, *args):
+            class _W:
+                def start(self_inner):
+                    pass
+
+                def is_alive(self_inner):
+                    return False
+
+            return _W()
+
+        base = microscope.get_stage_position()
+        widget.set_save_directory(str(tmp_path))
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker", fake_worker
+        )
+        anchored_at = widget.tile_grid_overlay._anchor()
+
+        widget.acquire()
+        # The stage sets off, and the first preview arrives from a tile away -- which is
+        # the redraw, because it is what un-provisions the origin.
+        widget._on_stage_moved(_at(base, dx=300e-6, dy=300e-6))
+        widget._apply_progress({
+            "msg": "Tile Collected", "counter": 1, "total": 9,
+            "preview": _tile(microscope, _at(base)),
+        })
+
+        assert widget.tile_grid_overlay._anchor() == pytest.approx(anchored_at), (
+            "the plan was redrawn around the tile being acquired, not around the run"
+        )
+
+    def test_the_pin_is_let_go_of_when_the_run_ends(self, widget, microscope, tmp_path):
+        """Or the plan describes the run that has finished rather than the next one."""
+        widget._run_centre = _at(microscope.get_stage_position(), dx=500e-6)
+        widget._on_finished({"cancelled": True})
+        assert widget._run_centre is None
+
+    def test_the_first_image_in_a_view_still_redraws_them(self, widget, microscope):
+        """Because that one *does* move the frame: it replaces the provisional anchor
+        `_seed_frame` invented with the position the image was really acquired at, which
+        moves every overlay drawn in the view."""
+        base = microscope.get_stage_position()
+        calls = []
+        widget._refresh_context_overlays = lambda: calls.append(1)
+
+        widget.place_image(_tile(microscope, _at(base, dx=50e-6)))
+
+        assert calls, "the re-anchored view was left with overlays in the old frame"
+
+
 class TestARunNeedsTiles:
     """Masking every tile off is a state the runner cannot do anything with.
 

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -1672,6 +1672,69 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         assert calls, "the re-anchored view was left with overlays in the old frame"
 
 
+class TestARunDoesNotReFrameTheCanvas:
+    """The framing you pressed Acquire with is the framing you keep (FIB-648).
+
+    `auto_fit` refits whenever the placed extent changes, and a run changes it at the
+    two moments you are most likely to be looking: the first overview appears, and the
+    end swaps the preview for the stitch -- a removal and a placement, so two refits
+    back to back. In between it mostly does not fire, because the preview keeps one key
+    and one extent, which is what made it read as the canvas being stable and then
+    lurching.
+    """
+
+    def _run(self, widget, microscope, tiles=3):
+        from fibsem.ui.widgets.overview_widget import OverviewRecord
+
+        base = microscope.get_stage_position()
+        widget._records["run"] = OverviewRecord("run", "run", [])
+        widget._active_record = "run"
+        widget._set_running(True)
+        for counter in range(1, tiles + 1):
+            widget._apply_progress({
+                "msg": "Tile Collected", "counter": counter, "total": tiles,
+                "preview": _tile(microscope, _at(base)),
+            })
+        widget._mosaic = _tile(microscope, _at(base), shape=(128, 128))
+        widget._on_finished({})
+
+    def test_the_framing_survives_the_whole_run(self, widget, microscope):
+        ax = widget.canvas._ax
+        framing = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+
+        self._run(widget, microscope)
+
+        assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == framing
+
+    def test_the_run_actually_put_something_there(self, widget, microscope):
+        """Or the test above passes on a canvas where nothing happened."""
+        self._run(widget, microscope)
+        assert widget.canvas.placed_keys, "the run placed nothing to re-frame for"
+
+    def test_a_run_hands_the_camera_over_for_good(self, widget, microscope):
+        """Not restored at the end. There is content on the canvas now, and the framing
+        belongs to whoever last set it -- "reset view" is how you ask for it back."""
+        self._run(widget, microscope)
+        assert widget.canvas.auto_fit is False
+
+        widget.canvas.reset_view()
+        assert widget.canvas.auto_fit is True
+
+    def test_the_canvas_still_frames_itself_before_a_run(self, widget, microscope):
+        """The one time auto-fit is wanted: opening the tab, where the framing is this
+        canvas's guess rather than anyone's choice. Handing the camera over on the first
+        run must not be brought forward to construction."""
+        assert widget.canvas.auto_fit is True
+        ax = widget.canvas._ax
+        framing = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+
+        widget.settings_widget.set_grid_size(7, 7)
+
+        assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) != framing, (
+            "a bigger plan did not re-frame a canvas nobody has framed by hand"
+        )
+
+
 class TestARunNeedsTiles:
     """Masking every tile off is a state the runner cannot do anything with.
 

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -335,6 +335,81 @@ def test_auto_fit_can_be_turned_off_to_keep_the_users_zoom():
     assert c._ax.get_xlim() == (0, 10)  # the new tile did not re-frame the view
 
 
+# ── who owns the camera ───────────────────────────────────────────────────
+#
+# Auto-fit is right until the framing becomes a choice. Zoom into a feature and the
+# next thing placed used to throw the view away and refit to everything -- worst at
+# the end of a run, which removes the preview and places the stitch under another key,
+# so the canvas held still for the whole acquisition and then lurched twice (FIB-648).
+
+
+def _pan(canvas, dx_px=40, dy_px=0):
+    """A left-drag across the canvas, as matplotlib delivers one."""
+    from types import SimpleNamespace
+
+    def _event(x, y):
+        return SimpleNamespace(
+            inaxes=canvas._ax, xdata=0.0, ydata=0.0, x=x, y=y,
+            button=1, dblclick=False, guiEvent=None,
+        )
+
+    canvas._on_press(_event(100, 100))
+    canvas._on_motion(_event(100 + dx_px, 100 + dy_px))
+    canvas._on_release(_event(100 + dx_px, 100 + dy_px))
+
+
+def test_panning_hands_the_camera_over():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    _pan(c)
+    assert c.auto_fit is False
+
+    framing = (c._ax.get_xlim(), c._ax.get_ylim())
+    c.add_image(_img(), centre=(500e-6, 0.0), pixel_size=PIXEL_SIZE)
+    assert (c._ax.get_xlim(), c._ax.get_ylim()) == framing
+
+
+def test_zooming_hands_the_camera_over():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    _scroll(c, 1)
+    assert c.auto_fit is False
+
+    framing = (c._ax.get_xlim(), c._ax.get_ylim())
+    c.add_image(_img(), centre=(500e-6, 0.0), pixel_size=PIXEL_SIZE)
+    assert (c._ax.get_xlim(), c._ax.get_ylim()) == framing
+
+
+def test_a_zoom_the_limiter_refused_does_not_count():
+    """Nothing moved, so nobody framed anything. Scrolling into the stop is easy to do
+    by accident on a trackpad, and it must not quietly cost the canvas its auto-fit."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    _scroll(c, 1, 100)  # far past the zoom-in bound
+    span_at_the_stop = _span(c)
+
+    c.auto_fit = True  # as if it had never been given away
+    _scroll(c, 1)
+
+    assert _span(c) == pytest.approx(span_at_the_stop)
+    assert c.auto_fit is True
+
+
+def test_the_fit_button_takes_the_camera_back():
+    """The one thing that re-arms it, because "frame it for me" is what it means."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    _pan(c)
+    assert c.auto_fit is False
+
+    c.reset_view()
+    assert c.auto_fit is True
+
+    framing = (c._ax.get_xlim(), c._ax.get_ylim())
+    c.add_image(_img(), centre=(500e-6, 0.0), pixel_size=PIXEL_SIZE)
+    assert (c._ax.get_xlim(), c._ax.get_ylim()) != framing
+
+
 # ── the declared working area ─────────────────────────────────────────────
 
 
@@ -731,16 +806,49 @@ def test_a_resize_re_frames_so_the_axes_keep_filling():
     )
 
 
-def test_a_canvas_that_has_given_up_auto_fit_is_not_re_framed_by_a_resize():
-    """A caller driving the camera itself must not have it taken back on a resize."""
+def test_a_canvas_that_has_given_up_auto_fit_keeps_its_magnification():
+    """A caller driving the camera itself must not have it taken back on a resize.
+
+    Not *nothing*, though, which is what this used to assert: a view left exactly as it
+    was stops matching the window's shape, and `aspect="equal"` takes the difference
+    straight out of the axes box -- the bands FIB-620 was about. So the viewport is
+    resized and the magnification is what survives, which is what any camera does when
+    its window changes: a taller window shows more, it does not zoom.
+    """
     c = _canvas(reference_pixel_size=PIXEL_SIZE)
     c.show()
     c.resize(900, 500)
     _app.processEvents()
     c.set_world_extent(200e-6, 200e-6)
     c.auto_fit = False
-    before = (c._ax.get_xlim(), c._ax.get_ylim())
+    (x0, x1), (y0, y1) = c._ax.get_xlim(), c._ax.get_ylim()
+    centre = ((x0 + x1) / 2, (y0 + y1) / 2)
+    per_pixel = (x1 - x0) / 900
 
     c.resize(500, 900)
     _app.processEvents()
-    assert (c._ax.get_xlim(), c._ax.get_ylim()) == before
+
+    (nx0, nx1), (ny0, ny1) = c._ax.get_xlim(), c._ax.get_ylim()
+    assert ((nx0 + nx1) / 2, (ny0 + ny1) / 2) == pytest.approx(centre), "the view moved"
+    assert (nx1 - nx0) / 500 == pytest.approx(per_pixel), "the resize zoomed"
+    box = c._ax.get_position()
+    assert box.width > 0.98 and box.height > 0.98, (
+        f"the axes box is {box.width:.2f} x {box.height:.2f} of the widget -- banded"
+    )
+
+
+def test_a_resize_does_not_undo_a_users_zoom():
+    """The half that matters on screen: the feature you zoomed in on is still the size
+    you zoomed it to, and still in the middle."""
+    c = _canvas(reference_pixel_size=PIXEL_SIZE)
+    c.show()
+    c.resize(900, 500)
+    _app.processEvents()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    _scroll(c, 1, 4)
+    zoomed = _span(c)
+
+    c.resize(900, 700)  # only the height changed
+    _app.processEvents()
+
+    assert _span(c) == pytest.approx(zoomed), "the zoom was thrown away by a resize"


### PR DESCRIPTION
Stacked on #388. Review the second commit's PR after this one.

Start a run and the magenta plan followed the stage from tile to tile, drifting away from the overview being acquired under it.

`_on_stage_moved` has always guarded against this, and the guard has always been bypassed: it skips the overlay refresh but still updates the cached position, and the plan is anchored at `_target or _stage_position`. Every preview frame placed an image, and `_place_on_canvas` ended by refreshing every context overlay — so the plan was re-anchored once per tile down a path the guard never saw.

## Placing an image is not a reason to redraw the overlays

Fixed where the issue asked rather than by special-casing `_running`. An image is *drawn in* the frame; it does not decide it. What decides it is the view's origin and the canvas scale, and both are set in `place_image` — so that is where the refresh belongs, on the two occasions it is warranted: the first image in a view (which replaces the provisional anchor `_seed_frame` invented), and the first image on a canvas that never got a scale from the settings.

`show_view` already refreshed once at the end, so re-placing N records now costs one refresh rather than N, and the per-tile redraw of the stage limits, holder slots, gridbars and view selector goes with it.

## The plan is fixed for the run, not merely not-redrawn

Redrawn *right* is the requirement, and the residual showed up in a real 3×3 run against the simulator: the first preview un-provisions the origin, which is a genuine reason to redraw — and the plan then landed on whichever tile the stage had reached, 80 µm off, and stayed there for the rest of the acquisition.

So a run pins the centre it was started with — the same centre the runner uses. Handed back when the run ends.

| | anchor at each of 9 tiles |
| --- | --- |
| before | `(-163.8, -163.8)` |
| after | `(0.0, 0.0)` |

## Verification

- `tests/ui/` + `fibsem/applications/autolamella/ui/tests/` — 1457 passed
- a real 9-tile acquisition against the Demo simulator, reading the grid anchor at every tile

One thing that was keeping up by accident: the stage readout in the canvas info bar updated once per tile because placing the preview refreshed it. It is not the plan — it says where the stage *is* — so it now refreshes on the stage-move path that already refreshes the marker.