### PR TITLE
[ui] Stop the overview canvas re-framing under you (FIB-648)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -2220,6 +2220,12 @@ class FMOverviewWidget(QWidget):
             self.progress_tiles.reset()
             self.progress_tile_detail.reset()
             self.status.setText("Starting…")
+            # The framing you pressed Acquire with is the framing you keep. This tab
+            # meets it once rather than twice -- one composite under one key while the
+            # run goes -- but the end is the same swap: the stitch is placed and the
+            # preview removed, two extent changes at the moment there is finally
+            # something worth looking at (FIB-648). Taken back by "reset view".
+            self.canvas.canvas.auto_fit = False
 
         # After the resets above, not before: `FibsemProgressWidget.reset()` hides
         # itself, so showing the bars first and resetting them second leaves them

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -742,6 +742,19 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._ax.set_xlim(xmin - mx, xmax + mx)
         self._ax.set_ylim(ybot + my, ytop - my)  # y-axis stays inverted (origin upper)
 
+    def _view_moved_by_user(self) -> None:
+        """The view was just panned or zoomed by hand.
+
+        A hook rather than behaviour: nothing here re-frames itself, so the base has
+        nothing to stop doing. A canvas that *does* -- see
+        :attr:`FibsemRealSpaceCanvas.auto_fit`, which refits as content arrives --
+        overrides this to hand the camera over, because from here the framing is
+        something the user chose rather than something the canvas guessed.
+
+        Called only where the limits actually changed, so a scroll the zoom limiter
+        refused is not mistaken for one.
+        """
+
     def set_view_margin(self, frac: float) -> None:
         """Empty space kept around the image when fitting the view, as a fraction of the
         image size per side (0 = tight, 0.5 = 2x the image extent). Also keeps overlays
@@ -1056,6 +1069,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         dx, dy = x1 - x0, y1 - y0
         self._ax.set_xlim(xlim0[0] - dx, xlim0[1] - dx)
         self._ax.set_ylim(ylim0[0] - dy, ylim0[1] - dy)
+        self._view_moved_by_user()
         self._schedule_redraw()
 
     def _on_release(self, event):
@@ -1092,6 +1106,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             return
         self._ax.set_xlim(cx + (xlim[0] - cx) * factor, cx + (xlim[1] - cx) * factor)
         self._ax.set_ylim(cy + (ylim[0] - cy) * factor, cy + (ylim[1] - cy) * factor)
+        self._view_moved_by_user()
         self._schedule_redraw()
 
     def _zoom_allowed(self, span: float) -> bool:

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -111,7 +111,12 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         self._world_extent_m: Optional[Tuple[float, float, float, float]] = None
         self._auto_key = 0
         # Refit as content grows, so tiles arriving during an acquisition stay in view.
-        # Callers that would rather keep the user's zoom can turn this off.
+        #
+        # True until the framing becomes someone's choice rather than this canvas's
+        # guess. A pan or a zoom is the user making it theirs (`_view_moved_by_user`);
+        # an owner driving the camera itself sets this False directly. Either way the
+        # only thing that takes it back is "reset view" -- the button whose whole
+        # meaning is "frame it for me again".
         self.auto_fit: bool = True
         self._fitted_extent: Optional[Tuple[float, float, float, float]] = None
 
@@ -376,6 +381,31 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         """The declared working area as (width, height, cx, cy) in metres, or None."""
         return self._world_extent_m
 
+    # ── who owns the camera ───────────────────────────────────────────────
+
+    def _view_moved_by_user(self) -> None:
+        """A pan or a zoom hands the framing over. See :attr:`auto_fit`.
+
+        Zoom in on a feature and the next thing placed used to throw the view away and
+        refit to everything -- at the two moments you are most likely to be looking
+        closely, since a run ends by removing the preview and placing the stitch under
+        another key, which is two extent changes back to back (FIB-648).
+        """
+        self.auto_fit = False
+
+    def reset_view(self) -> None:
+        """Frame the content, and take the camera back.
+
+        The one way `auto_fit` comes back on, deliberately: it is the button that means
+        "frame it for me", so re-arming is what it was already being pressed for, and
+        nothing else can quietly undo a framing someone chose.
+        """
+        self.auto_fit = True
+        super().reset_view()
+        # Adopt what was just fitted, so the next content change is measured against
+        # this framing rather than against whatever was fitted before the user's zoom.
+        self._fitted_extent = self._fit_extent()
+
     def metres_to_canvas(self, x: float, y: float) -> Tuple[float, float]:
         """Convert a position in metres to canvas coordinates.
 
@@ -551,14 +581,41 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         across the top -- which is what an overview framed before its splitter settled
         looked like.
 
-        Guarded on `auto_fit` like every other refit, so a canvas whose owner has taken
-        charge of the camera is not re-framed behind its back.
+        A canvas whose camera belongs to someone else is not re-framed behind their
+        back, but it is not left letterboxed either: the viewport changed size, so the
+        view is grown or shrunk to match and the magnification is what survives.
         """
         super().resizeEvent(event)
         if self.auto_fit:
             self._fitted_extent = None  # the padded extent is stale, whatever it was
             self._fit_view()
-            self.draw_idle()
+        else:
+            self._keep_scale_through_resize(event.oldSize(), event.size())
+        self.draw_idle()
+
+    def _keep_scale_through_resize(self, old, new) -> None:
+        """Resize the *viewport*, not the magnification.
+
+        A window that gets taller shows more; it does not zoom. Scaling the limits by
+        the same factors as the widget keeps metres-per-pixel exactly where the user
+        left it, and keeps the framed region the widget's shape -- so `aspect="equal"`
+        still has nothing to take out of the axes box and the canvas goes on filling
+        the window. Refitting would do the second thing at the cost of the first, which
+        is the framing being taken back; doing nothing does the first at the cost of
+        the second, which is black bands down the sides.
+        """
+        if old is None or old.width() <= 0 or old.height() <= 0:
+            return  # the first resize has no "before" to keep the scale against
+        kx, ky = new.width() / old.width(), new.height() / old.height()
+        if kx <= 0 or ky <= 0:
+            return
+        (x0, x1), (y0, y1) = self._ax.get_xlim(), self._ax.get_ylim()
+        cx, cy = (x0 + x1) / 2.0, (y0 + y1) / 2.0
+        # Halved spans, signed: the y axis is inverted here, and the sign is what keeps
+        # it that way.
+        half_w, half_h = (x1 - x0) / 2.0 * kx, (y1 - y0) / 2.0 * ky
+        self._ax.set_xlim(cx - half_w, cx + half_w)
+        self._ax.set_ylim(cy - half_h, cy + half_h)
 
     def _remove_artist(self, placed: PlacedImage) -> None:
         try:

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -2417,6 +2417,16 @@ class FibsemOverviewWidget(QWidget):
         self._running = running
         self._apply_enabled_state()
         if running:
+            # The framing you pressed Acquire with is the framing you keep. A run is the
+            # worst moment to re-frame: the preview lands under one key and the stitch
+            # replaces it under another, so the canvas held still for the whole
+            # acquisition and then lurched twice at the end, when there was finally
+            # something worth looking at (FIB-648).
+            #
+            # Not restored afterwards. There is content on the canvas now, and the
+            # framing belongs to whoever last set it; "reset view" is how you ask for
+            # it back.
+            self.canvas.auto_fit = False
             self._tiles_acquired = 0
             # Cleared rather than set to "Starting…": the progress bar carries the
             # message for the whole run, and a label saying "Starting…" underneath one

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -960,6 +960,39 @@ def test_declaring_a_working_area_without_a_refit_does_not_move_the_view(qapp, o
     assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) != zoomed
 
 
+def test_a_run_hands_the_camera_over(qapp):
+    """The framing you pressed Acquire with is the framing you keep (FIB-648).
+
+    This tab meets the problem less often than the beam one -- one composite under one
+    key while the run goes, rather than a preview whose extent grows -- but it ends the
+    same way: `_finish` places the stitch and removes the preview, two extent changes at
+    the moment there is finally something worth looking at. The rule is the canvas's,
+    so it is the same rule on both tabs.
+
+    Its own widget: it leaves an image on the canvas and the camera handed over, which
+    is exactly the state the module fixture shares.
+    """
+    widget = _fresh_widget(qapp)
+    canvas = widget.canvas.canvas
+    ax = canvas._ax
+    ax.set_xlim(-100, 100)
+    ax.set_ylim(100, -100)
+    framing = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+
+    widget._set_running(True)
+    qapp.processEvents()
+    assert canvas.auto_fit is False
+
+    # Somewhere well outside the framing, which is what an end-of-run swap can be.
+    canvas.add_image(np.zeros((64, 64), dtype=np.uint8), centre=(2e-3, 2e-3),
+                     pixel_size=1e-6, key="stitch")
+    qapp.processEvents()
+
+    assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == framing
+    widget._set_running(False)
+    widget.close()
+
+
 def test_the_grid_keeps_its_scale_under_a_decimated_preview(qapp, overview_widget):
     """The live preview is coarser than a tile. The grid is drawn in canvas coordinates,
     whose scale is fixed by the canvas reference — so the preview's stride must not

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -1672,6 +1672,69 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         assert calls, "the re-anchored view was left with overlays in the old frame"
 
 
+class TestARunDoesNotReFrameTheCanvas:
+    """The framing you pressed Acquire with is the framing you keep (FIB-648).
+
+    `auto_fit` refits whenever the placed extent changes, and a run changes it at the
+    two moments you are most likely to be looking: the first overview appears, and the
+    end swaps the preview for the stitch -- a removal and a placement, so two refits
+    back to back. In between it mostly does not fire, because the preview keeps one key
+    and one extent, which is what made it read as the canvas being stable and then
+    lurching.
+    """
+
+    def _run(self, widget, microscope, tiles=3):
+        from fibsem.ui.widgets.overview_widget import OverviewRecord
+
+        base = microscope.get_stage_position()
+        widget._records["run"] = OverviewRecord("run", "run", [])
+        widget._active_record = "run"
+        widget._set_running(True)
+        for counter in range(1, tiles + 1):
+            widget._apply_progress({
+                "msg": "Tile Collected", "counter": counter, "total": tiles,
+                "preview": _tile(microscope, _at(base)),
+            })
+        widget._mosaic = _tile(microscope, _at(base), shape=(128, 128))
+        widget._on_finished({})
+
+    def test_the_framing_survives_the_whole_run(self, widget, microscope):
+        ax = widget.canvas._ax
+        framing = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+
+        self._run(widget, microscope)
+
+        assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == framing
+
+    def test_the_run_actually_put_something_there(self, widget, microscope):
+        """Or the test above passes on a canvas where nothing happened."""
+        self._run(widget, microscope)
+        assert widget.canvas.placed_keys, "the run placed nothing to re-frame for"
+
+    def test_a_run_hands_the_camera_over_for_good(self, widget, microscope):
+        """Not restored at the end. There is content on the canvas now, and the framing
+        belongs to whoever last set it -- "reset view" is how you ask for it back."""
+        self._run(widget, microscope)
+        assert widget.canvas.auto_fit is False
+
+        widget.canvas.reset_view()
+        assert widget.canvas.auto_fit is True
+
+    def test_the_canvas_still_frames_itself_before_a_run(self, widget, microscope):
+        """The one time auto-fit is wanted: opening the tab, where the framing is this
+        canvas's guess rather than anyone's choice. Handing the camera over on the first
+        run must not be brought forward to construction."""
+        assert widget.canvas.auto_fit is True
+        ax = widget.canvas._ax
+        framing = (tuple(ax.get_xlim()), tuple(ax.get_ylim()))
+
+        widget.settings_widget.set_grid_size(7, 7)
+
+        assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) != framing, (
+            "a bigger plan did not re-frame a canvas nobody has framed by hand"
+        )
+
+
 class TestARunNeedsTiles:
     """Masking every tile off is a state the runner cannot do anything with.
 

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -335,6 +335,81 @@ def test_auto_fit_can_be_turned_off_to_keep_the_users_zoom():
     assert c._ax.get_xlim() == (0, 10)  # the new tile did not re-frame the view
 
 
+# ── who owns the camera ───────────────────────────────────────────────────
+#
+# Auto-fit is right until the framing becomes a choice. Zoom into a feature and the
+# next thing placed used to throw the view away and refit to everything -- worst at
+# the end of a run, which removes the preview and places the stitch under another key,
+# so the canvas held still for the whole acquisition and then lurched twice (FIB-648).
+
+
+def _pan(canvas, dx_px=40, dy_px=0):
+    """A left-drag across the canvas, as matplotlib delivers one."""
+    from types import SimpleNamespace
+
+    def _event(x, y):
+        return SimpleNamespace(
+            inaxes=canvas._ax, xdata=0.0, ydata=0.0, x=x, y=y,
+            button=1, dblclick=False, guiEvent=None,
+        )
+
+    canvas._on_press(_event(100, 100))
+    canvas._on_motion(_event(100 + dx_px, 100 + dy_px))
+    canvas._on_release(_event(100 + dx_px, 100 + dy_px))
+
+
+def test_panning_hands_the_camera_over():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    _pan(c)
+    assert c.auto_fit is False
+
+    framing = (c._ax.get_xlim(), c._ax.get_ylim())
+    c.add_image(_img(), centre=(500e-6, 0.0), pixel_size=PIXEL_SIZE)
+    assert (c._ax.get_xlim(), c._ax.get_ylim()) == framing
+
+
+def test_zooming_hands_the_camera_over():
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    _scroll(c, 1)
+    assert c.auto_fit is False
+
+    framing = (c._ax.get_xlim(), c._ax.get_ylim())
+    c.add_image(_img(), centre=(500e-6, 0.0), pixel_size=PIXEL_SIZE)
+    assert (c._ax.get_xlim(), c._ax.get_ylim()) == framing
+
+
+def test_a_zoom_the_limiter_refused_does_not_count():
+    """Nothing moved, so nobody framed anything. Scrolling into the stop is easy to do
+    by accident on a trackpad, and it must not quietly cost the canvas its auto-fit."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    _scroll(c, 1, 100)  # far past the zoom-in bound
+    span_at_the_stop = _span(c)
+
+    c.auto_fit = True  # as if it had never been given away
+    _scroll(c, 1)
+
+    assert _span(c) == pytest.approx(span_at_the_stop)
+    assert c.auto_fit is True
+
+
+def test_the_fit_button_takes_the_camera_back():
+    """The one thing that re-arms it, because "frame it for me" is what it means."""
+    c = _canvas()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    _pan(c)
+    assert c.auto_fit is False
+
+    c.reset_view()
+    assert c.auto_fit is True
+
+    framing = (c._ax.get_xlim(), c._ax.get_ylim())
+    c.add_image(_img(), centre=(500e-6, 0.0), pixel_size=PIXEL_SIZE)
+    assert (c._ax.get_xlim(), c._ax.get_ylim()) != framing
+
+
 # ── the declared working area ─────────────────────────────────────────────
 
 
@@ -731,16 +806,49 @@ def test_a_resize_re_frames_so_the_axes_keep_filling():
     )
 
 
-def test_a_canvas_that_has_given_up_auto_fit_is_not_re_framed_by_a_resize():
-    """A caller driving the camera itself must not have it taken back on a resize."""
+def test_a_canvas_that_has_given_up_auto_fit_keeps_its_magnification():
+    """A caller driving the camera itself must not have it taken back on a resize.
+
+    Not *nothing*, though, which is what this used to assert: a view left exactly as it
+    was stops matching the window's shape, and `aspect="equal"` takes the difference
+    straight out of the axes box -- the bands FIB-620 was about. So the viewport is
+    resized and the magnification is what survives, which is what any camera does when
+    its window changes: a taller window shows more, it does not zoom.
+    """
     c = _canvas(reference_pixel_size=PIXEL_SIZE)
     c.show()
     c.resize(900, 500)
     _app.processEvents()
     c.set_world_extent(200e-6, 200e-6)
     c.auto_fit = False
-    before = (c._ax.get_xlim(), c._ax.get_ylim())
+    (x0, x1), (y0, y1) = c._ax.get_xlim(), c._ax.get_ylim()
+    centre = ((x0 + x1) / 2, (y0 + y1) / 2)
+    per_pixel = (x1 - x0) / 900
 
     c.resize(500, 900)
     _app.processEvents()
-    assert (c._ax.get_xlim(), c._ax.get_ylim()) == before
+
+    (nx0, nx1), (ny0, ny1) = c._ax.get_xlim(), c._ax.get_ylim()
+    assert ((nx0 + nx1) / 2, (ny0 + ny1) / 2) == pytest.approx(centre), "the view moved"
+    assert (nx1 - nx0) / 500 == pytest.approx(per_pixel), "the resize zoomed"
+    box = c._ax.get_position()
+    assert box.width > 0.98 and box.height > 0.98, (
+        f"the axes box is {box.width:.2f} x {box.height:.2f} of the widget -- banded"
+    )
+
+
+def test_a_resize_does_not_undo_a_users_zoom():
+    """The half that matters on screen: the feature you zoomed in on is still the size
+    you zoomed it to, and still in the middle."""
+    c = _canvas(reference_pixel_size=PIXEL_SIZE)
+    c.show()
+    c.resize(900, 500)
+    _app.processEvents()
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    _scroll(c, 1, 4)
+    zoomed = _span(c)
+
+    c.resize(900, 700)  # only the height changed
+    _app.processEvents()
+
+    assert _span(c) == pytest.approx(zoomed), "the zoom was thrown away by a resize"


### PR DESCRIPTION
Stacked on #413, which is stacked on #388. Merge in that order.

Zoom into a feature and the next thing placed threw the view away and refit to everything — at the two moments you are most likely to be looking closely: when the first overview appears, and when a run ends and the stitch replaces the preview. During a run it mostly did *not* fire, because the preview keeps one key and one extent, so it read as the canvas being stable and then lurching.

`auto_fit` was already a public flag with callers. What was missing was anything that turned it off.

## Auto-fit is a guess, and it lasts until there is a choice

It is right exactly once — opening the tab, where the framing is the canvas's guess rather than anyone's decision. From the first pan or zoom the framing is something the user chose, so a pan or a zoom hands the camera over, and the only thing that takes it back is **reset view**, the button whose whole meaning is "frame it for me again".

The hook is on the base canvas because pan and zoom live there, and it does nothing there — nothing in the base re-frames itself. `FibsemRealSpaceCanvas` overrides it. Called only where the limits actually changed, so a scroll the zoom limiter refused does not count as framing.

## A run is the tab making the same choice

Both tabs hand the camera over for the length of a run, and do not take it back: there is content on the canvas afterwards, and the framing belongs to whoever last set it.

Measured over a real 9-tile acquisition against the simulator, the axes limits are identical before, during and after — where the end of the run used to move them twice.

The fluorescence tab meets this less often (one composite under one key, rather than a preview whose extent grows) but it ends with the same swap, and the rule is the canvas's rather than either tab's.

## A resize is not a re-frame

Handing the camera over made a resize letterbox the canvas — the banding FIB-620 was about: a view left exactly as it was stops matching the window's shape, and `aspect="equal"` takes the difference out of the axes box.

So a canvas whose camera belongs to someone else resizes its *viewport* instead: the limits scale with the widget, the magnification survives, and the framed region stays widget-shaped so the axes go on filling the window. A taller window shows more; it does not zoom. That replaces the old "do nothing", which kept the framing at the cost of the bands — and it is why `test_a_canvas_that_has_given_up_auto_fit_is_not_re_framed_by_a_resize` is rewritten rather than kept.

## Verification

- `tests/ui/` — 1399 passed, 1 skipped
- a real 9-tile acquisition against the Demo simulator, reading the axes limits at every tile