### PR TITLE
[ui] Make the canvas info bar a widget, not an artist (FIB-650)

### DIFF
--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -140,25 +140,37 @@ _LIVE_BADGE_STYLE = (
 # they say different things, but all on the same dark plaque the rest of the canvas
 # chrome uses: the hint was a near-white one, which shouted over the data it was drawn
 # on and read as an alert rather than an aside.
-_STATUS_PLAQUE = "background: rgba(26, 26, 26, 190); border-radius: 3px; padding: 0px 6px;"
+_STATUS_PLAQUE = "background: rgba(26, 26, 26, 190); border-radius: 3px;"
 # How long a readout holds the zone after the pointer stops. Long enough to have been
 # read at a glance and then some, since it goes away without being asked -- and any
 # motion at all brings it straight back.
 _READOUT_DECAY_MS = 2500
 # A standing instruction, so the dimmest of the three: it is still true after you have
 # read it, and it should not compete with the image once it has been.
-_STATUS_HINT_STYLE = f"QLabel {{ color: {NEUTRAL_450}; font-size: 11px; {_STATUS_PLAQUE} }}"
+_STATUS_HINT_STYLE = (
+    f"QLabel {{ color: {NEUTRAL_450}; font-size: 11px; padding: 0px 6px;"
+    f" {_STATUS_PLAQUE} }}"
+)
 # Live numbers under the cursor. Monospaced so the digits sit still while it moves --
 # a proportional font makes the whole readout shuffle on every pixel of travel.
 _STATUS_READOUT_STYLE = (
     f"QLabel {{ color: #e8e8e8; font-size: 10px; font-family: monospace;"
-    f" {_STATUS_PLAQUE} }}"
+    f" padding: 0px 6px; {_STATUS_PLAQUE} }}"
 )
 # A value that just changed and is about to go away, so it keeps the accent outline the
 # artist had, and stays opaque so it reads at a glance mid-gesture.
 _STATUS_FLASH_STYLE = (
     f"QLabel {{ background: {_BG}; color: #e8e8e8; border: 1px solid {_ACCENT};"
     " border-radius: 3px; padding: 0px 6px; font-size: 12px; }"
+)
+# The bottom-left info bar: microscope state, standing until the instrument moves. The
+# same dark plaque as the status zone, since it is read against the readout up there --
+# the pose under the cursor above, the pose the stage is actually at below.
+# Padded vertically, unlike the status chips: those are a fixed row height, this one
+# sizes to however many lines it is given.
+_INFO_BAR_STYLE = (
+    f"QLabel {{ color: #e8e8e8; font-size: 9px; padding: 3px 6px;"
+    f" {_STATUS_PLAQUE} }}"
 )
 
 
@@ -175,6 +187,18 @@ _QT_MODIFIER_MAP = (
     (Qt.ControlModifier, "Control"),
     (Qt.MetaModifier, "Meta"),
 )
+
+
+def _pass_clicks_through(widget) -> None:
+    """Make a chrome label invisible to the mouse.
+
+    Qt routes a click to the topmost child under the cursor, and a `QLabel` accepts the
+    press rather than passing it on -- so a label parented to the canvas puts a dead
+    patch over the image the size of its own text. That is what the chrome it replaced
+    was avoiding, drawn as an artist. Anything here that is read rather than operated
+    gets this; the toolbar buttons deliberately do not.
+    """
+    widget.setAttribute(Qt.WA_TransparentForMouseEvents, True)
 
 
 def _modifiers_from_event(event) -> Tuple[str, ...]:
@@ -261,7 +285,10 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._hint_text: Optional[str] = None  # remembered; the status zone shows it
         self._title_artist = None  # top-centre image caption (e.g. FM z-slice)
         self._title_text: Optional[str] = None  # remembered so it survives set_image
-        self._info_artist = None  # bottom-left microscope-state info bar
+        # Bottom-left microscope-state info bar. A child widget, not an artist:
+        # see `set_info_text` for why, and note that `ax.cla()` therefore leaves
+        # it alone -- nothing restores it across an image change.
+        self._info_label = None
         self._info_text: Optional[str] = None  # remembered so it survives set_image
         self._live_badge = None  # top-right "● LIVE" chip during live acquisition
         self._live_on: bool = False  # remembered so it survives set_image
@@ -516,28 +543,64 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
     def set_info_text(self, text: Optional[str]) -> None:
         """Show a small, muted info bar in the bottom-left, or hide with None/''.
 
-        Remembered + re-applied after each image change (like the hint). Driven by
-        the controller from the canvas-state model — microscope state, not image."""
+        Driven by the controller from the canvas-state model — microscope state, not
+        image. A `QLabel` rather than an axes artist, for the reason the top strip is
+        one: it updates on every stage read and every objective move, and an artist
+        update ends in `draw_idle`, which repaints every image the canvas holds. That
+        was ~1.7 ms per placed image and unbounded — 61.7 ms at 36 — against a flat
+        0.07 ms here (FIB-650). Being a child widget also means `ax.cla()` cannot take
+        it down, so nothing has to remember and restore it across an image change.
+        """
         self._info_text = text or None
         self._refresh_info_bar()
-        self.draw_idle()
 
     def _refresh_info_bar(self) -> None:
-        """(Re)create the info artist from the cached text, or remove it."""
-        if self._info_artist is not None:
-            try:
-                self._info_artist.remove()
-            except Exception:
-                pass
-            self._info_artist = None
-        if self._info_text:
-            self._info_artist = self._ax.text(
-                0.012, 0.015, self._info_text,
-                transform=self._ax.transAxes, ha="left", va="bottom",
-                fontsize=6.5, color="#e8e8e8", zorder=11,
-                bbox=dict(boxstyle="round,pad=0.25", facecolor=_BG,
-                          edgecolor="none", alpha=0.55),
+        """Put the cached text in the info label, or hide it."""
+        if not self._info_text:
+            if self._info_label is not None:
+                self._info_label.hide()
+            return
+        if self._info_label is None:
+            self._info_label = self._make_info_label()
+        self._info_label.show()
+        self._place_info_label()
+
+    def _make_info_label(self) -> QLabel:
+        """The bottom-left info bar."""
+        label = QLabel("", self)
+        label.setStyleSheet(_INFO_BAR_STYLE)
+        _pass_clicks_through(label)
+        label.raise_()
+        return label
+
+    def _place_info_label(self) -> None:
+        """Sit the info bar in the bottom-left corner, elided to the canvas width.
+
+        Elided per line, because the text is several lines as often as one, and
+        `QFontMetrics.elidedText` works on a single line. The clamp is the canvas
+        width rather than the scalebar's left edge: the scalebar is an axes artist, so
+        asking where it starts means a renderer call and arithmetic between two
+        coordinate systems, which is the thing this whole class of chrome moved to Qt
+        to stop doing. A long enough string can still reach it, exactly as before.
+        """
+        label = self._info_label
+        if label is None or label.isHidden():
+            return
+        available = max(self.width() - 2 * _OVERLAY_MARGIN, 0)
+        metrics = QFontMetrics(label.font())
+        label.setText(self._info_text)
+        padding = max(label.sizeHint().width() - metrics.width(self._info_text), 0)
+        room = max(available - padding, 0)
+        label.setText(
+            "\n".join(
+                metrics.elidedText(line, Qt.ElideRight, room)
+                for line in self._info_text.split("\n")
             )
+        )
+        label.adjustSize()
+        label.move(
+            _OVERLAY_MARGIN, max(self.height() - label.height() - _OVERLAY_MARGIN, 0)
+        )
 
     def set_live_badge(self, on: bool) -> None:
         """Show/hide a green "● LIVE" chip in the top-right during live acquisition.
@@ -567,6 +630,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         badge.setStyleSheet(_LIVE_BADGE_STYLE)
         badge.setFixedHeight(_OVERLAY_BTN_SIZE)
         badge.adjustSize()
+        _pass_clicks_through(badge)
         badge.raise_()
         return badge
 
@@ -624,6 +688,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         """The status chip, sized to sit in the toolbar row."""
         label = QLabel("", self)
         label.setFixedHeight(_OVERLAY_BTN_SIZE)
+        _pass_clicks_through(label)
         label.raise_()
         return label
 
@@ -689,8 +754,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._hint_text = None  # the status chip is a widget; hidden below, not by cla()
         self._title_artist = None
         self._title_text = None
-        self._info_artist = None
         self._info_text = None
+        if self._info_label is not None:
+            self._info_label.hide()
         # The chip is a child widget, so `cla()` does not take it down the way it took
         # the artist. Hidden by hand to keep the reset meaning what it always did.
         if self._live_badge is not None:
@@ -761,6 +827,7 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             x -= badge.width()
             badge.move(x, _OVERLAY_MARGIN)
         self._place_status_label(right_edge=x)
+        self._place_info_label()  # bottom left, in the same logical-pixel pass
 
     def _place_status_label(self, right_edge: int) -> None:
         """Put the status chip at the left of the same row, elided to fit.

--- a/fibsem/ui/widgets/canvas/image_canvas.py
+++ b/fibsem/ui/widgets/canvas/image_canvas.py
@@ -108,7 +108,8 @@ class FibsemImageCanvas(FibsemCanvasBase):
         # No hint or flash here either: both are the status chip, a child widget, so
         # `cla()` never took them down and there is nothing to restore (FIB-639).
         self._refresh_title()  # ditto: restore the remembered title
-        self._refresh_info_bar()  # ditto: restore the remembered info bar
+        # No info bar here either: it became a child widget with the status chip, so
+        # `cla()` leaves it alone and there is nothing to restore (FIB-650).
         # No LIVE chip here: it is a child widget, not an artist, so `cla()` never took
         # it down and there is nothing to restore (FIB-596).
         self._refresh_legend()  # ditto: restore the patch legend

--- a/fibsem/ui/widgets/tests/test_canvas_overlay_reducer.py
+++ b/fibsem/ui/widgets/tests/test_canvas_overlay_reducer.py
@@ -433,7 +433,7 @@ def test_info_bar_renders_ordered_fields_per_canvas():
     ctl.set_info(BeamType.ELECTRON, "stage", "STAGE: x")  # SEM gets stage only
     _flush(app)
     assert fib._info_text == "STAGE: x\nMILLING ANGLE: 30.0°"
-    assert fib._info_artist is not None
+    assert fib._info_label is not None and not fib._info_label.isHidden()
     assert ctl.sem_canvas._info_text == "STAGE: x"
     print("ok: info bar renders ordered fields per canvas (milling FIB-only)")
 
@@ -457,7 +457,9 @@ def test_info_bar_survives_image_change():
     ctl.set_image(BeamType.ION, _image())  # a new image clears the axes
     _flush(app)
     assert fib._info_text == "STAGE: x", "info must survive an image change"
-    assert fib._info_artist is not None
+    # A child widget now, so `cla()` never took it down -- there is nothing to restore
+    # and nothing to forget to restore (FIB-650).
+    assert fib._info_label is not None and not fib._info_label.isHidden()
     print("ok: info bar survives an image change (microscope state, not image)")
 
 

--- a/tests/ui/test_canvas_base.py
+++ b/tests/ui/test_canvas_base.py
@@ -501,15 +501,20 @@ class TestTheStatusZoneShowsOneThingAtATime:
         assert c._status_label.text() == "x 151.0  y 90.0  z 0.0 um"
 
     def test_each_update_restarts_the_decay(self):
-        """It decays after the pointer *stops*, not a fixed time after it arrived."""
+        """It decays after the pointer *stops*, not a fixed time after it arrived.
+
+        The countdown is wound down by hand rather than compared across two reads of
+        `remainingTime`: those are wall-clock, so a single elapsed millisecond between
+        them fails a test that is trying to ask about restarting, not about timing.
+        """
         c = self._canvas()
         c.set_hint("Shift+drag to sweep")
         c.set_status_readout("x 150.0  y 90.0  z 0.0 um")
-        first = c._readout_timer.remainingTime()
+        c._readout_timer.start(50)  # as if it had nearly run out
 
-        c.set_status_readout("x 151.0  y 90.0  z 0.0 um")
+        c.set_status_readout("x 151.0  y 90.0  z 0.0 um")  # a later motion event
 
-        assert c._readout_timer.remainingTime() >= first
+        assert c._readout_timer.remainingTime() > 50
 
     def test_a_readout_with_no_hint_under_it_does_not_decay(self):
         """There would be nothing to reveal, so decaying would blank the corner rather
@@ -530,3 +535,121 @@ class TestTheStatusZoneShowsOneThingAtATime:
         c.set_status_readout(None)
 
         assert not c._readout_timer.isActive()
+
+
+class TestTheInfoBarIsAWidgetNotAnArtist:
+    """Microscope state, bottom left — moved off the artist path (FIB-650).
+
+    It updates on every stage read and every objective move, and an artist update ends
+    in `draw_idle`, which repaints every image the canvas holds: ~1.7 ms per placed
+    image, unbounded. As a child widget it costs the same whatever is on the canvas,
+    and `ax.cla()` cannot take it down.
+    """
+
+    @staticmethod
+    def _canvas(w=700, h=500):
+        c = FibsemImageCanvas()
+        c.resize(w, h)
+        c.set_array(_img(512, 512), pixel_size=1e-8)
+        c._reposition_overlay_buttons()
+        return c
+
+    def test_it_sits_in_the_bottom_left(self):
+        c = self._canvas()
+
+        c.set_info_text("STAGE: X:0.00mm, Y:0.00mm")
+
+        geom = c._info_label.geometry()
+        assert geom.left() < c.width() / 2, "left half"
+        assert geom.bottom() > c.height() * 0.9, "bottom edge"
+
+    def test_it_survives_a_new_image(self):
+        """`cla()` took the artist down and something had to remember to put it back."""
+        c = self._canvas()
+        c.set_info_text("STAGE: X:0.00mm")
+
+        c.set_array(_img(256, 256), pixel_size=1e-8)
+
+        assert c._info_text == "STAGE: X:0.00mm"
+        assert not c._info_label.isHidden()
+
+    def test_it_follows_the_bottom_edge_on_resize(self):
+        c = self._canvas(h=500)
+        c.set_info_text("STAGE: X:0.00mm")
+        before = c._info_label.geometry().bottom()
+
+        c.resize(700, 300)
+        c._reposition_overlay_buttons()
+
+        after = c._info_label.geometry().bottom()
+        assert after < before, "a shorter canvas must bring it up with the edge"
+        assert after > 300 * 0.9
+
+    def test_several_lines_all_show(self):
+        """The text is two lines as often as one -- stage pose, then objective."""
+        c = self._canvas()
+
+        c.set_info_text("STAGE: X:0.00mm\nOBJECTIVE: 6000.0 um")
+
+        assert c._info_label.text().count("\n") == 1
+        assert c._info_label.height() > 20, "two lines are taller than one"
+
+    def test_a_long_line_is_elided_rather_than_run_off_the_canvas(self):
+        c = self._canvas(w=320)
+
+        c.set_info_text("STAGE: " + "X:0.00mm, " * 20)
+
+        assert c._info_label.geometry().right() <= 320
+        assert "…" in c._info_label.text()
+
+    def test_each_line_is_elided_on_its_own(self):
+        """`elidedText` works a line at a time, so a multi-line string cannot be passed
+        to it whole -- doing that truncates at the first newline and loses the rest."""
+        c = self._canvas(w=320)
+
+        c.set_info_text("STAGE: " + "X:0.00mm, " * 20 + "\nOBJECTIVE: 6000.0 um")
+
+        assert c._info_label.text().count("\n") == 1, "the second line must survive"
+        assert "OBJECTIVE" in c._info_label.text()
+
+    def test_it_does_not_swallow_clicks(self):
+        """Qt routes a click to the topmost child under the cursor, and a QLabel accepts
+        the press. Without this the info bar puts a dead patch over the image."""
+        c = self._canvas()
+        c.set_info_text("STAGE: X:0.00mm, Y:0.00mm")
+
+        point = c._info_label.geometry().center()
+
+        assert c.childAt(point) is None
+
+    def test_neither_does_the_status_chip_or_the_live_badge(self):
+        """Same trap, and the status chip had it: the top-left corner stopped
+        responding to clicks when the zone moved in (FIB-639)."""
+        c = self._canvas()
+        c.set_hint("Shift+drag to sweep")
+        c.set_live_badge(True)
+        c._reposition_overlay_buttons()
+
+        assert c.childAt(c._status_label.geometry().center()) is None
+        assert c.childAt(c._live_badge.geometry().center()) is None
+
+    def test_the_toolbar_buttons_still_take_their_clicks(self):
+        """They are operated, not read -- passing their clicks through would break them."""
+        c = self._canvas()
+
+        button = c._overlay_buttons[0]
+
+        assert c.childAt(button.geometry().center()) is button
+
+    def test_setting_it_does_not_repaint_the_figure(self):
+        """The whole point: an artist update ended in `draw_idle`, and on a canvas
+        holding many images that repaint is the cost."""
+        c = self._canvas()
+        c.draw()
+        drawn = []
+        c.draw_idle = lambda *a, **k: drawn.append(1)
+
+        c.set_info_text("STAGE: X:1.00mm")
+        c.set_info_text("STAGE: X:2.00mm")
+
+        assert drawn == []


### PR DESCRIPTION
The bottom-left info bar carries microscope state — stage pose, objective position — and updated as an axes artist, which ends in `draw_idle`. On a real-space canvas that repaints every image ever placed.

Measured on `FibsemRealSpaceCanvas`, 900×700, 256 px tiles:

| placed images | artist (full repaint) | `QLabel` |
| -- | -- | -- |
| 0 | 1.4 ms | 0.07 ms |
| 9 | 18.3 ms | 0.07 ms |
| 18 | 32.3 ms | 0.07 ms |
| 27 | 46.7 ms | 0.07 ms |
| 36 | **61.7 ms** | **0.07 ms** |

~1.7 ms per placed image, unbounded. The label is flat.

It is not a rare update: `stage_position_changed` fires from *inside* `get_stage_position`, and every objective move drives it too — so Shift+scroll focusing dirties the figure on each step, over a canvas holding a session's overviews. (`draw_idle` coalesces, so the honest claim is not "61.7 ms per update" but that a stream of them holds the canvas repainting at ~16 fps with 36 images placed.)

## What comes with it

* **`ax.cla()` can't take it down**, so the remember-and-restore that ran on every image change goes away.
* **Elided to the canvas width** — per *line*. `elidedText` handles one line at a time and the info text is two lines as often as one, so eliding the whole string truncates at the first newline and drops the objective readout silently.
* The clamp is the canvas width, **not** the scalebar's left edge: the scalebar is an axes artist, so asking where it starts means a renderer call and arithmetic between two coordinate systems, which is what this class of chrome moved to Qt to stop doing. A long enough string can still reach it, exactly as before.

## Two things found while doing it

**Chrome labels were swallowing clicks.** Qt routes a press to the topmost child under the cursor and a `QLabel` accepts it, so the status chip put a dead patch over the top-left of the image — double-click-to-move-stage included — from the moment the status zone landed. The hand-placed cursor readout it replaced set `WA_TransparentForMouseEvents` for exactly this reason. Everything on the canvas that is *read* now passes clicks through; the toolbar buttons, which are *operated*, deliberately do not. Fixed here rather than separately because a new info label would have inherited it.

**A flaky test of mine.** `test_each_update_restarts_the_decay` compared `remainingTime()` either side of a restart — wall-clock, so one elapsed millisecond failed it. Passed alone, failed in a full run. It now winds the timer down by hand and asserts the restart.

## Verified

* 10 new tests; `tests/ui/` plus `test_canvas_overlay_reducer.py` is **1363 passed, 1 skipped**.
* Mutation-checked: chrome labels taking clicks again → 2 fail; `draw_idle` restored → 1; eliding the whole string instead of per line → 1; placing it top-left → 2.
* Surveyed every reader first — the only `_info_artist` users outside the base class were two assertions in `test_canvas_overlay_reducer.py`, both updated to the widget equivalent.
* Rendered the states: one line, two lines under a cursor readout, elided per line at 250 px, and live with a flash holding the status zone.

CI cannot see any of this — no PyQt5 there, so these tests skip.
