### PR TITLE
[test] Stop a teardown test closing the widget the whole file shares (FIB-623)

### DIFF
--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -2299,13 +2299,19 @@ def test_a_move_updates_the_info_bar_without_reading_the_device(qapp, interactiv
     )
 
 
-def test_the_objective_signal_is_dropped_on_close(qapp, interactive_widget):
+def test_the_objective_signal_is_dropped_on_close(qapp):
     """psygnal outlives the widget and holds a bound method of a torn-down Qt object.
 
     Closing the tab and then moving the objective from anywhere else was the segfault
     `closeEvent` already guards for the stage; this is the same for the objective.
+
+    Builds its own widget rather than taking the module-scoped one. A test that proves
+    teardown works has to destroy what it touches, so it cannot share: closing the
+    fixture left every later test in this file driving a widget subscribed to nothing,
+    and none of them failed, because none of them happened to need a live signal
+    (FIB-623).
     """
-    widget = interactive_widget
+    widget = _fresh_widget(qapp)
     objective = widget.fm.objective
     before = len(objective.position_changed)
     assert before, "the widget never subscribed -- the test proves nothing"
@@ -4644,3 +4650,24 @@ def test_the_canvas_says_how_to_edit_the_grid_while_it_is_shown(qapp):
     widget.tile_grid_panel.visibility_changed.emit(False)
 
     assert widget.canvas.canvas._hint_text is None
+
+
+def test_zz_the_shared_fixture_is_still_wired_at_the_end_of_the_file(qapp, overview_widget):
+    """A canary, deliberately last: it only catches what happens *before* it.
+
+    The module-scoped widget is shared by ~100 tests, and psygnal holds bound methods
+    weakly, so anything that closes or drops it disconnects the lot in silence. Nothing
+    failed when that happened -- the tests carried on driving handlers directly, proving
+    less than they read as proving. If this fails, look for a test that closed, deleted
+    or replaced the shared widget rather than building its own with `_fresh_widget`
+    (FIB-623).
+    """
+    fm = overview_widget.fm
+    counts = {
+        "transform_changed": len(fm.transform_changed),
+        "acquiring_changed": len(fm.acquiring_changed),
+        "acquisition_progress_signal": len(fm.acquisition_progress_signal),
+        "objective.position_changed": len(fm.objective.position_changed),
+    }
+
+    assert all(counts.values()), f"the shared fixture went deaf mid-file: {counts}"


### PR DESCRIPTION
`test_the_objective_signal_is_dropped_on_close` took `interactive_widget` — which derives from the module-scoped `overview_widget` — and called `.close()` on it. Every test after it in the file then ran against a widget whose four psygnal subscriptions had been disconnected by `closeEvent`, exactly as designed.

## Traced, not guessed

FIB-623's hypothesis was garbage collection, and it explicitly asked for a reproduction before any change. Instrumenting the microscope's subscription counts after every test (holding a reference to the *microscope*, never the widget, so the probe couldn't mask what it was watching):

```
after test_clicking_a_tile_updates_the_mask...       subs=(1,1,1,1)  widget_alive=True
after test_the_objective_signal_is_dropped_on_close  subs=(0,0,0,0)  widget_alive=True
```

The widget is alive the whole time. Nothing was collected — a test proving that teardown works tore down the fixture ~100 later tests share.

The issue's earlier search for tests closing `overview_widget` missed it because it reaches the fixture through `interactive_widget` rather than naming it. Worth knowing: the same disguise would hide the next one.

## The fix

The rule the rest of the file already follows — a test that destroys what it touches builds its own widget with `_fresh_widget`. All fifteen other tests calling `close()` already did; this was the only one sharing.

## The canary

Deliberately last in the file, since it can only catch what runs before it. Checked that it bites: putting the teardown test back on the shared fixture fails it with all four counts at zero, and it still passes when run alone.

## What this did and didn't cost

**It hid nothing.** All ~100 affected tests passed deaf and pass wired — they drive handlers directly rather than through signals, so none of them needed a live subscription. Nothing about the fix changes any other test's result.

What it would have cost is the *next* test: one that believed it was exercising a signal path would have passed while proving nothing. That is the failure mode this repo has hit repeatedly, and the canary is there so it cannot return in silence.

`tests/ui/` plus `test_canvas_overlay_reducer.py`: **1364 passed, 1 skipped.**
