### PR TITLE
[autolamella] Convert legacy protocols on load instead of rejecting them

### DIFF
--- a/fibsem/applications/autolamella/protocol/legacy.py
+++ b/fibsem/applications/autolamella/protocol/legacy.py
@@ -338,6 +338,16 @@ class AutoLamellaProtocol(FibsemProtocol):
         with open(path, "r") as f:
             ddict = yaml.safe_load(f)
 
+        return AutoLamellaProtocol.parse(ddict)
+
+    @staticmethod
+    def parse(ddict: dict) -> 'AutoLamellaProtocol':
+        """Build a protocol from an already-read legacy protocol dictionary.
+
+        Runs the same validation/upgrade pass as load(), so callers that
+        already hold the raw dictionary (e.g. the task-protocol loader
+        detecting a legacy file) get identical results.
+        """
         tmp_ddict = deepcopy(ddict)
         try:
             from fibsem.applications.autolamella.protocol.validation import (
@@ -347,5 +357,44 @@ class AutoLamellaProtocol(FibsemProtocol):
         except Exception as e:
             logging.debug(f"Error converting protocol: {e}")
             ddict = tmp_ddict
-        
+
         return AutoLamellaProtocol.from_dict(ddict)
+
+
+# methods with an equivalent task-based workflow. the liftout methods were never
+# ported, so their protocols cannot be converted.
+SUPPORTED_TASK_CONVERSION_METHODS = (
+    AutoLamellaMethod.ON_GRID,
+    AutoLamellaMethod.TRENCH,
+    AutoLamellaMethod.WAFFLE,
+)
+
+
+def is_legacy_protocol(ddict: Dict[str, Any]) -> bool:
+    """Is this dictionary a pre-task-based (legacy) AutoLamella protocol?
+
+    Task protocols are written with "tasks" and "workflow" keys; legacy
+    protocols instead carry the milling workflows under a top-level "milling"
+    key and their settings under "options". Both formats are saved to
+    protocol.yaml, so the format has to be sniffed when loading. (FIB-663)
+    """
+    if not isinstance(ddict, dict):
+        return False
+    if "tasks" in ddict or "workflow" in ddict:
+        return False
+    return "milling" in ddict
+
+
+def get_legacy_protocol_method(ddict: Dict[str, Any]) -> Optional[AutoLamellaMethod]:
+    """Best-effort read of the method from a legacy protocol dictionary.
+
+    Returns None if the method is missing or unrecognised, leaving it to the
+    caller to decide what to do (rather than failing the whole load here).
+    """
+    name = ddict.get("method") or ddict.get("options", {}).get("method")
+    if not name:
+        name = DEFAULT_AUTOLAMELLA_METHOD
+    try:
+        return get_autolamella_method(name)
+    except ValueError:
+        return None

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -434,6 +434,11 @@ class AutoLamellaTaskProtocol:
     # Experiment-global correlation config (FIB-298): a user-step config, not an
     # automated task, so a peer field rather than an entry in task_config.
     correlation: CorrelationConfig = field(default_factory=CorrelationConfig)
+    # True when this protocol was built by converting a legacy protocol on load,
+    # so the UI can tell the user their file was upgraded. Deliberately not
+    # serialised and not compared: it describes where this object came from, not
+    # what the protocol is, and saving it writes the task-based format anyway.
+    converted_from_legacy: bool = field(default=False, compare=False, repr=False)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -644,7 +649,8 @@ class AutoLamellaTaskProtocol:
             description=f"auto-converted protocol from {protocol.name} - {protocol.method.name}",
             task_config=task_config,
             workflow_config=workflow_config,
-            options=options
+            options=options,
+            converted_from_legacy=True,
         )
 
         return task_protocol

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -507,13 +507,13 @@ class AutoLamellaTaskProtocol:
         """Load a legacy protocol file and convert it to an AutoLamellaTaskProtocol.
 
         A task protocol given to this loader is read as-is, so the user picking
-        the wrong one of the two protocol buttons is not an error.
+        the wrong one of the two protocol buttons is not an error. Anything that
+        is neither format still goes to the legacy converter, so a corrupt file
+        raises rather than loading as an empty protocol.
         """
-        from fibsem.applications.autolamella.protocol.legacy import is_legacy_protocol
-
         with open(path, 'r') as file:
             data = yaml.safe_load(file)
-        if not is_legacy_protocol(data):
+        if isinstance(data, dict) and ("tasks" in data or "workflow" in data):
             return cls.from_dict(data)
         return cls.from_legacy_dict(data)
 
@@ -540,13 +540,11 @@ class AutoLamellaTaskProtocol:
         )
 
         # check the method before parsing: an unsupported one (liftout) fails
-        # deep inside the milling parser with an unhelpful error otherwise.
+        # deep inside the milling parser with an unhelpful error otherwise. An
+        # unrecognised name is left to the parser, which names the valid ones.
         method = get_legacy_protocol_method(data)
-        if method not in SUPPORTED_TASK_CONVERSION_METHODS:
-            name = method.name if method is not None else (
-                data.get("method") or data.get("options", {}).get("method", "unknown")
-            )
-            raise ValueError(f"Protocol method {name} not supported for conversion to task protocol")
+        if method is not None and method not in SUPPORTED_TASK_CONVERSION_METHODS:
+            raise ValueError(f"Protocol method {method.name} not supported for conversion to task protocol")
 
         protocol = AutoLamellaProtocol.parse(data)
 

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -51,6 +51,24 @@ if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
 
 
+def _known_fields(cls: type, data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Drop keys that are not fields of the dataclass `cls`.
+
+    Protocols and experiments are long-lived files: one written by another
+    version of AutoLamella can carry keys that no longer exist (or do not exist
+    yet). Passing those straight to a dataclass constructor raises TypeError and
+    fails the whole load, so unknown keys are dropped with a warning instead of
+    taking the file down with them. (FIB-663)
+    """
+    if not data:
+        return {}
+    names = {f.name for f in fields(cls)}
+    unknown = set(data) - names
+    if unknown:
+        logging.warning(
+            f"Ignoring unknown {cls.__name__} field(s) while loading: {sorted(unknown)}"
+        )
+    return {k: v for k, v in data.items() if k in names}
 
 
 class AutoLamellaTaskStatus(Enum):
@@ -130,8 +148,7 @@ class AutoLamellaTaskState:
         data["status"] = AutoLamellaTaskStatus[data.get("status", "NotStarted")]
         # drop keys this build doesn't know about: an experiment written by a newer
         # version must still load in an older one rather than raising TypeError.
-        known = {f.name for f in fields(cls)}
-        return cls(**{k: v for k, v in data.items() if k in known})
+        return cls(**_known_fields(cls, data))
 
 
 @evented
@@ -245,7 +262,7 @@ class AutoLamellaTaskDescription:
         sa = data.get("scheduled_at")
         if isinstance(sa, str):
             data["scheduled_at"] = datetime.fromisoformat(sa)
-        return cls(**data)
+        return cls(**_known_fields(cls, data))
 
 
 @evented
@@ -262,8 +279,9 @@ class AutoLamellaWorkflowConfig:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaWorkflowConfig':
+        data = dict(data or {})
         data["tasks"] = [AutoLamellaTaskDescription.from_dict(task) for task in data.get("tasks", [])]
-        return cls(**data)
+        return cls(**_known_fields(cls, data))
 
     @property
     def workflow(self) -> List[str]:
@@ -367,7 +385,7 @@ class AutoLamellaWorkflowOptions:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaWorkflowOptions':
-        return cls(**data)
+        return cls(**_known_fields(cls, data))
 
 
 @evented
@@ -432,7 +450,16 @@ class AutoLamellaTaskProtocol:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaTaskProtocol':
+        from fibsem.applications.autolamella.protocol.legacy import is_legacy_protocol
         from fibsem.applications.autolamella.workflows.tasks import load_task_config
+
+        # protocol.yaml is written in both the legacy and the task-based format,
+        # so a file saved by an older version has to be converted on the way in
+        # rather than rejected as invalid. (FIB-663)
+        if is_legacy_protocol(data):
+            logging.info("Legacy protocol detected, converting to task protocol.")
+            return cls.from_legacy_dict(data)
+
         task_config = load_task_config(data.get("tasks", {}))
         workflow_config = AutoLamellaWorkflowConfig.from_dict(data.get("workflow", {}))
 
@@ -472,6 +499,21 @@ class AutoLamellaTaskProtocol:
 
     @classmethod
     def load_from_old_protocol(cls, path: Path) -> 'AutoLamellaTaskProtocol':
+        """Load a legacy protocol file and convert it to an AutoLamellaTaskProtocol.
+
+        A task protocol given to this loader is read as-is, so the user picking
+        the wrong one of the two protocol buttons is not an error.
+        """
+        from fibsem.applications.autolamella.protocol.legacy import is_legacy_protocol
+
+        with open(path, 'r') as file:
+            data = yaml.safe_load(file)
+        if not is_legacy_protocol(data):
+            return cls.from_dict(data)
+        return cls.from_legacy_dict(data)
+
+    @classmethod
+    def from_legacy_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaTaskProtocol':
         """Convert an AutoLamellaProtocol to an AutoLamellaTaskProtocol.
         This involves mapping the milling configurations to the new task names.
         Used to converte old protocols to the new task-based protocol format."""
@@ -480,6 +522,8 @@ class AutoLamellaTaskProtocol:
             AutoLamellaMethod,
             AutoLamellaProtocol,
             AutoLamellaStage,
+            SUPPORTED_TASK_CONVERSION_METHODS,
+            get_legacy_protocol_method,
         )
         from fibsem.applications.autolamella.workflows.tasks.tasks import (
             MillPolishingTaskConfig,
@@ -489,7 +533,17 @@ class AutoLamellaTaskProtocol:
             MillFiducialTaskConfig,
             SelectMillingPositionTaskConfig,
         )
-        protocol = AutoLamellaProtocol.load(path)
+
+        # check the method before parsing: an unsupported one (liftout) fails
+        # deep inside the milling parser with an unhelpful error otherwise.
+        method = get_legacy_protocol_method(data)
+        if method not in SUPPORTED_TASK_CONVERSION_METHODS:
+            name = method.name if method is not None else (
+                data.get("method") or data.get("options", {}).get("method", "unknown")
+            )
+            raise ValueError(f"Protocol method {name} not supported for conversion to task protocol")
+
+        protocol = AutoLamellaProtocol.parse(data)
 
         # we need to map the milling configurations to the new task names
         # mill_rough -> Rough Milling / mill_rough
@@ -500,7 +554,7 @@ class AutoLamellaTaskProtocol:
         # fiducial -> Setup Lamella / fiducial
         # mill_polishing -> Polishing
         
-        if protocol.method not in [AutoLamellaMethod.ON_GRID, AutoLamellaMethod.TRENCH, AutoLamellaMethod.WAFFLE]:
+        if protocol.method not in SUPPORTED_TASK_CONVERSION_METHODS:
             raise ValueError(f"Protocol method {protocol.method} not supported for conversion to task protocol")
 
         ROUGH_MILLING_TASK_NAME = "Rough Milling"

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -458,6 +458,14 @@ class AutoLamellaTaskProtocol:
         from fibsem.applications.autolamella.protocol.legacy import is_legacy_protocol
         from fibsem.applications.autolamella.workflows.tasks import load_task_config
 
+        # An empty or truncated protocol.yaml parses to None, which used to fail
+        # with an opaque AttributeError several frames down.
+        if not isinstance(data, dict):
+            raise ValueError(
+                "This file is empty or is not a valid protocol file. "
+                "Check that you selected an AutoLamella protocol file."
+            )
+
         # protocol.yaml is written in both the legacy and the task-based format,
         # so a file saved by an older version has to be converted on the way in
         # rather than rejected as invalid. (FIB-663)
@@ -538,6 +546,19 @@ class AutoLamellaTaskProtocol:
             MillFiducialTaskConfig,
             SelectMillingPositionTaskConfig,
         )
+
+        # A file with neither format's required keys is not an AutoLamella
+        # protocol at all -- usually the wrong file picked in the dialog, e.g. a
+        # microscope configuration, which also has a top-level "milling" key.
+        # Say so, rather than failing on whichever key the parser reaches first.
+        missing = [k for k in ("milling", "options") if not isinstance(data, dict) or k not in data]
+        if missing:
+            raise ValueError(
+                "This file does not look like an AutoLamella protocol: a legacy "
+                f"protocol needs top-level {' and '.join(repr(k) for k in missing)}, "
+                "and a task protocol needs 'tasks'. Check that you selected an "
+                "AutoLamella protocol file."
+            )
 
         # check the method before parsing: an unsupported one (liftout) fails
         # deep inside the milling parser with an unhelpful error otherwise. An

--- a/fibsem/applications/autolamella/ui/autolamella_create_experiment_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_create_experiment_widget.py
@@ -284,6 +284,17 @@ class AutoLamellaCreateExperimentWidget(QtWidgets.QDialog):
                 "Invalid Protocol",
                 "The selected protocol file is not valid. It may be corrupted, incorrectly formatted, or missing required fields.\n\nPlease select a valid protocol file (*.yaml)."
             )
+            return
+
+        # This button accepts a legacy file too, converting it on the way in --
+        # the same notice the explicit legacy button gives, so a converted
+        # protocol is never adopted silently. (FIB-663)
+        if self.protocol.converted_from_legacy:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Legacy Protocol Converted",
+                "The legacy protocol has been successfully converted to the new task-based format."
+            )
 
     def _select_legacy_protocol(self):
         """Open dialog to select a legacy protocol file and convert it."""

--- a/fibsem/applications/autolamella/ui/autolamella_load_experiment_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_load_experiment_widget.py
@@ -41,6 +41,14 @@ ERROR_PROTOCOL_NOT_FOUND_MSG = (
     "Please ensure the experiment has an associated protocol file."
 )
 
+ERROR_PROTOCOL_LOAD_FAILED_TITLE = "Protocol Could Not Be Loaded"
+ERROR_PROTOCOL_LOAD_FAILED_MSG = (
+    "The protocol file in the experiment directory could not be loaded:\n\n{protocol_path}\n\n"
+    "Error: {error}\n\n"
+    "The experiment has been loaded without a task protocol. "
+    "Please load a protocol before continuing."
+)
+
 ERROR_INVALID_EXPERIMENT_TITLE = "Invalid Experiment"
 ERROR_INVALID_EXPERIMENT_MSG = (
     "The selected experiment is not valid. It may be corrupted, incorrectly formatted, or missing required fields.\n\n"
@@ -414,21 +422,39 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
                 logging.info(f"Experiment loaded successfully from {experiment_path}")
                 logging.info(f"Protocol loaded successfully from {protocol_path}")
             else:
-                # Protocol missing; keep experiment loaded so user can reattach one
+                # Protocol missing or unreadable; keep the experiment loaded so the
+                # user can reattach one. Experiment.load only logs the reason, so
+                # a present-but-unloadable protocol is re-read here to report it.
+                load_error = self._protocol_load_error(protocol_path)
                 if warn_on_missing_protocol:
-                    QtWidgets.QMessageBox.warning(
-                        self,
-                        ERROR_PROTOCOL_NOT_FOUND_TITLE,
-                        ERROR_PROTOCOL_NOT_FOUND_MSG.format(experiment_dir=experiment_dir)
-                        + "\n\nThe experiment has been loaded without a task protocol. "
-                          "Please load a protocol before continuing."
-                    )
+                    if load_error is not None:
+                        QtWidgets.QMessageBox.warning(
+                            self,
+                            ERROR_PROTOCOL_LOAD_FAILED_TITLE,
+                            ERROR_PROTOCOL_LOAD_FAILED_MSG.format(
+                                protocol_path=protocol_path, error=load_error
+                            ),
+                        )
+                    else:
+                        QtWidgets.QMessageBox.warning(
+                            self,
+                            ERROR_PROTOCOL_NOT_FOUND_TITLE,
+                            ERROR_PROTOCOL_NOT_FOUND_MSG.format(experiment_dir=experiment_dir)
+                            + "\n\nThe experiment has been loaded without a task protocol. "
+                              "Please load a protocol before continuing."
+                        )
                 self.protocol_path = None
                 self.btn_ok.setEnabled(False)
                 self._set_protocol_buttons_visible(True)
-                logging.warning(
-                    f"Experiment loaded from {experiment_path} but no protocol.yaml was found."
-                )
+                if load_error is not None:
+                    logging.warning(
+                        f"Experiment loaded from {experiment_path} but {protocol_path} "
+                        f"could not be loaded: {load_error}"
+                    )
+                else:
+                    logging.warning(
+                        f"Experiment loaded from {experiment_path} but no protocol.yaml was found."
+                    )
 
             # Update the display regardless of protocol presence
             self._update_experiment_display()
@@ -447,6 +473,21 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
             )
             self._clear_display()
             return False
+
+    @staticmethod
+    def _protocol_load_error(protocol_path: str) -> Optional[str]:
+        """Why the experiment's protocol.yaml failed to load, or None if absent.
+
+        Returns None when the file simply is not there -- that is a different
+        message to the user than a protocol that exists but cannot be read.
+        """
+        if not os.path.exists(protocol_path):
+            return None
+        try:
+            AutoLamellaTaskProtocol.load(protocol_path)
+        except Exception as e:
+            return str(e)
+        return "unknown error"
 
     def _update_experiment_display(self):
         """Update the experiment information display."""

--- a/fibsem/applications/autolamella/ui/autolamella_load_experiment_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_load_experiment_widget.py
@@ -32,6 +32,7 @@ from fibsem.ui.stylesheets import (
     TEXT_COLOR,
     TEXT_MUTED_COLOR,
 )
+from fibsem.ui.tokens import SEMANTIC_WARNING_COLOR
 from fibsem.ui.widgets.custom_widgets import TitledPanel
 
 # Error message constants
@@ -74,6 +75,20 @@ ERROR_INVALID_LEGACY_PROTOCOL_MSG = (
     "The selected legacy protocol file could not be converted. It may be corrupted, incorrectly formatted, or missing required fields.\n\n"
     "Error: {error}\n\n"
     "Please select a valid legacy protocol file (*.yaml)."
+)
+
+LEGACY_PROTOCOL_CONVERTED_TITLE = "Legacy Protocol Converted"
+LEGACY_PROTOCOL_CONVERTED_MSG = (
+    "This protocol is in the legacy format and has been converted to the "
+    "task-based format:\n\n{protocol_path}\n\n"
+    "The file on disk is unchanged until the experiment is saved, which will write "
+    "it in the new format. Please review the converted protocol before running any tasks."
+)
+
+# Shown in the protocol panel while a converted protocol is loaded
+LEGACY_PROTOCOL_CONVERTED_BANNER = (
+    "This protocol was converted from the legacy format. Saving the experiment "
+    "will rewrite protocol.yaml in the task-based format."
 )
 
 # Width of the recent-experiments quick-select column
@@ -281,6 +296,15 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
 
         protocol_layout.addLayout(protocol_form_layout)
 
+        # Legacy-conversion banner: only visible while a converted protocol is loaded
+        self.label_legacy_protocol_banner = QtWidgets.QLabel(LEGACY_PROTOCOL_CONVERTED_BANNER)
+        self.label_legacy_protocol_banner.setStyleSheet(
+            f"color: {SEMANTIC_WARNING_COLOR}; font-size: 10px; background: transparent;"
+        )
+        self.label_legacy_protocol_banner.setWordWrap(True)
+        self.label_legacy_protocol_banner.setVisible(False)
+        protocol_layout.addWidget(self.label_legacy_protocol_banner)
+
         # Protocol tooltip/info label
         protocol_info_label = QtWidgets.QLabel(
             "Note: You will be able to edit the protocol after loading the experiment."
@@ -387,7 +411,7 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         self._load_experiment_from_path(experiment_path)
 
     def _load_experiment_from_path(
-        self, experiment_path: str, warn_on_missing_protocol: bool = True
+        self, experiment_path: str, show_protocol_notices: bool = True
     ) -> bool:
         """Load and validate an experiment from a path, updating the display.
 
@@ -395,9 +419,10 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
 
         Args:
             experiment_path: Path to the experiment.yaml file to load.
-            warn_on_missing_protocol: If True, pop a modal warning when the
-                experiment has no task protocol. Suppressed for the lightweight
-                single-click preview so browsing the recent list stays quiet.
+            show_protocol_notices: If True, pop a modal for a protocol that is
+                missing, unreadable, or was converted from the legacy format.
+                Suppressed for the lightweight single-click preview so browsing
+                the recent list stays quiet.
 
         Returns:
             True if the experiment was loaded (with or without a protocol),
@@ -421,12 +446,26 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
 
                 logging.info(f"Experiment loaded successfully from {experiment_path}")
                 logging.info(f"Protocol loaded successfully from {protocol_path}")
+
+                # A legacy protocol.yaml is converted silently by Experiment.load,
+                # so the user is told here: what is on disk is not what is loaded
+                # until the experiment is saved. (FIB-663)
+                if self.experiment.task_protocol.converted_from_legacy:
+                    logging.info(
+                        f"Legacy protocol at {protocol_path} was converted to the task-based format."
+                    )
+                    if show_protocol_notices:
+                        QtWidgets.QMessageBox.information(
+                            self,
+                            LEGACY_PROTOCOL_CONVERTED_TITLE,
+                            LEGACY_PROTOCOL_CONVERTED_MSG.format(protocol_path=protocol_path),
+                        )
             else:
                 # Protocol missing or unreadable; keep the experiment loaded so the
                 # user can reattach one. Experiment.load only logs the reason, so
                 # a present-but-unloadable protocol is re-read here to report it.
                 load_error = self._protocol_load_error(protocol_path)
-                if warn_on_missing_protocol:
+                if show_protocol_notices:
                     if load_error is not None:
                         QtWidgets.QMessageBox.warning(
                             self,
@@ -538,12 +577,16 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
             self.lineEdit_protocol_path.setPlaceholderText("No protocol loaded")
             self.lineEdit_protocol_tasks.setText("")
             self.lineEdit_protocol_tasks.setPlaceholderText("0")
+            self.label_legacy_protocol_banner.setVisible(False)
             return
 
         self.lineEdit_protocol_name.setText(self.experiment.task_protocol.name or "")
         self.lineEdit_protocol_description.setText(self.experiment.task_protocol.description or "")
         self.lineEdit_protocol_path.setText(self.protocol_path or "")
         self.lineEdit_protocol_path.setCursorPosition(0)
+        self.label_legacy_protocol_banner.setVisible(
+            self.experiment.task_protocol.converted_from_legacy
+        )
         self.lineEdit_protocol_tasks.setText(str(len(self.experiment.task_protocol.task_config)))
 
     def _clear_display(self):
@@ -711,7 +754,7 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         path = item.data(QtCore.Qt.UserRole)
         if not path:
             return
-        self._load_experiment_from_path(path, warn_on_missing_protocol=False)
+        self._load_experiment_from_path(path, show_protocol_notices=False)
 
     def _on_recent_experiment_double_clicked(self, item: QtWidgets.QListWidgetItem) -> None:
         """Load the selected recent experiment and accept immediately (double click)."""
@@ -756,6 +799,15 @@ class AutoLamellaLoadExperimentWidget(QtWidgets.QDialog):
         self.btn_ok.setEnabled(True)
         self._set_protocol_buttons_visible(False)
         logging.info(f"Protocol loaded manually from {protocol_path}")
+
+        # This button also accepts a legacy file, converting it on the way in --
+        # say so, so a converted protocol is never adopted silently.
+        if protocol.converted_from_legacy:
+            QtWidgets.QMessageBox.information(
+                self,
+                LEGACY_PROTOCOL_CONVERTED_TITLE,
+                LEGACY_PROTOCOL_CONVERTED_MSG.format(protocol_path=protocol_path),
+            )
 
     def _select_legacy_protocol(self):
         """Let the user pick and convert a legacy protocol file."""

--- a/fibsem/applications/autolamella/ui/autolamella_load_task_protocol_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_load_task_protocol_widget.py
@@ -262,6 +262,16 @@ class AutoLamellaLoadTaskProtocolWidget(QtWidgets.QDialog):
         self._update_protocol_display()
         logging.info(f"Protocol loaded successfully from {protocol_path}")
 
+        # This button accepts a legacy file too, converting it on the way in --
+        # the same notice the explicit legacy button gives, so a converted
+        # protocol is never adopted silently. (FIB-663)
+        if loaded_protocol.converted_from_legacy:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Legacy Protocol Converted",
+                "The legacy protocol has been successfully converted to the new task-based format."
+            )
+
     def _select_legacy_protocol(self):
         """Open dialog to select a legacy protocol file and convert it."""
         # Open file dialog at the protocol path

--- a/tests/autolamella/test_legacy_protocol_loading.py
+++ b/tests/autolamella/test_legacy_protocol_loading.py
@@ -1,0 +1,185 @@
+"""Loading protocols and experiments written before the task-based format (FIB-663).
+
+protocol.yaml is the filename for both the legacy and the task-based protocol
+format, so the loader has to sniff which one it has rather than assume the new
+one. Before this, a legacy protocol reached the task-protocol constructor and
+died on the first legacy key it saw -- 'method',
+'alignment_at_milling_current' -- which the UI reported as a corrupt file.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from fibsem.applications.autolamella.protocol.legacy import (
+    get_legacy_protocol_method,
+    is_legacy_protocol,
+    AutoLamellaMethod,
+)
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    AutoLamellaWorkflowConfig,
+    AutoLamellaWorkflowOptions,
+    Experiment,
+)
+
+LEGACY_PROTOCOL_DIR = (
+    Path(__file__).parents[2]
+    / "fibsem"
+    / "applications"
+    / "autolamella"
+    / "protocol"
+    / "legacy"
+)
+TASK_PROTOCOL_DIR = LEGACY_PROTOCOL_DIR.parent
+
+CONVERTIBLE_LEGACY_PROTOCOLS = [
+    "protocol-on-grid.yaml",
+    "protocol-trench.yaml",
+    "protocol-waffle.yaml",
+]
+UNSUPPORTED_LEGACY_PROTOCOLS = [
+    "protocol-liftout.yaml",
+    "protocol-serial-liftout.yaml",
+]
+TASK_PROTOCOLS = ["task-protocol.yaml", "task-protocol-waffle.yaml"]
+
+
+# ── format detection ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("filename", CONVERTIBLE_LEGACY_PROTOCOLS + UNSUPPORTED_LEGACY_PROTOCOLS)
+def test_legacy_protocols_are_detected(filename: str):
+    data = yaml.safe_load((LEGACY_PROTOCOL_DIR / filename).read_text())
+    assert is_legacy_protocol(data)
+
+
+@pytest.mark.parametrize("filename", TASK_PROTOCOLS)
+def test_task_protocols_are_not_detected_as_legacy(filename: str):
+    data = yaml.safe_load((TASK_PROTOCOL_DIR / filename).read_text())
+    assert not is_legacy_protocol(data)
+
+
+def test_saved_task_protocol_is_not_detected_as_legacy():
+    """A round-tripped protocol must not be mistaken for the legacy format."""
+    assert not is_legacy_protocol(AutoLamellaTaskProtocol().to_dict())
+
+
+def test_is_legacy_protocol_ignores_non_dicts():
+    assert not is_legacy_protocol(None)
+    assert not is_legacy_protocol([])
+
+
+def test_legacy_method_read_from_options():
+    """Older protocols keep the method inside options rather than at top level."""
+    data = yaml.safe_load((LEGACY_PROTOCOL_DIR / "protocol-waffle.yaml").read_text())
+    assert "method" not in data
+    assert get_legacy_protocol_method(data) is AutoLamellaMethod.WAFFLE
+
+
+def test_legacy_method_defaults_to_on_grid_when_absent():
+    assert get_legacy_protocol_method({"milling": {}}) is AutoLamellaMethod.ON_GRID
+
+
+def test_legacy_method_unknown_returns_none():
+    assert get_legacy_protocol_method({"method": "not-a-method"}) is None
+
+
+# ── loading ───────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("filename", CONVERTIBLE_LEGACY_PROTOCOLS)
+def test_load_converts_legacy_protocol(filename: str):
+    """The plain loader accepts a legacy file instead of raising TypeError."""
+    protocol = AutoLamellaTaskProtocol.load(LEGACY_PROTOCOL_DIR / filename)
+
+    assert isinstance(protocol, AutoLamellaTaskProtocol)
+    assert len(protocol.task_config) > 0
+    assert protocol.workflow_config.tasks
+    # every workflow entry must have a matching task config
+    for task in protocol.workflow_config.tasks:
+        assert task.name in protocol.task_config
+
+
+def test_load_legacy_protocol_matches_explicit_conversion():
+    path = LEGACY_PROTOCOL_DIR / "protocol-waffle.yaml"
+    auto = AutoLamellaTaskProtocol.load(path).to_dict()
+    explicit = AutoLamellaTaskProtocol.load_from_old_protocol(path).to_dict()
+    # ids are generated per protocol, everything else must match
+    auto.pop("_id"), explicit.pop("_id")
+    assert auto == explicit
+
+
+@pytest.mark.parametrize("filename", UNSUPPORTED_LEGACY_PROTOCOLS)
+def test_unsupported_legacy_methods_report_the_method(filename: str):
+    """Liftout has no task equivalent -- say so, don't fail in the milling parser."""
+    with pytest.raises(ValueError, match="not supported for conversion"):
+        AutoLamellaTaskProtocol.load(LEGACY_PROTOCOL_DIR / filename)
+
+
+@pytest.mark.parametrize("filename", TASK_PROTOCOLS)
+def test_task_protocols_still_load(filename: str):
+    protocol = AutoLamellaTaskProtocol.load(TASK_PROTOCOL_DIR / filename)
+    assert len(protocol.task_config) > 0
+
+
+def test_load_from_old_protocol_accepts_a_task_protocol():
+    """Picking 'Select Legacy Protocol' for a new protocol is not an error."""
+    protocol = AutoLamellaTaskProtocol.load_from_old_protocol(
+        TASK_PROTOCOL_DIR / "task-protocol.yaml"
+    )
+    assert len(protocol.task_config) > 0
+
+
+def test_converted_legacy_protocol_round_trips(tmp_path: Path):
+    """A converted protocol saves in the new format and reloads unchanged."""
+    protocol = AutoLamellaTaskProtocol.load(LEGACY_PROTOCOL_DIR / "protocol-on-grid.yaml")
+
+    path = tmp_path / "protocol.yaml"
+    protocol.save(str(path))
+
+    assert not is_legacy_protocol(yaml.safe_load(path.read_text()))
+    assert AutoLamellaTaskProtocol.load(str(path)).to_dict() == protocol.to_dict()
+
+
+# ── unknown keys ──────────────────────────────────────────────────────────────
+
+def test_workflow_options_ignore_unknown_keys():
+    """Options written by another version load; the keys we know still apply."""
+    options = AutoLamellaWorkflowOptions.from_dict(
+        {
+            "turn_beams_off": True,
+            "alignment_at_milling_current": False,
+            "method": "autolamella-on-grid",
+        }
+    )
+    assert options.turn_beams_off is True
+
+
+def test_workflow_config_ignores_unknown_keys():
+    config = AutoLamellaWorkflowConfig.from_dict(
+        {"name": "wf", "tasks": [], "some_removed_field": 3}
+    )
+    assert config.name == "wf"
+
+
+def test_task_protocol_from_dict_ignores_unknown_option_keys():
+    data = AutoLamellaTaskProtocol().to_dict()
+    data["options"]["alignment_at_milling_current"] = True
+    assert AutoLamellaTaskProtocol.from_dict(data).options.turn_beams_off is False
+
+
+# ── experiment loading ────────────────────────────────────────────────────────
+
+def test_experiment_loads_alongside_a_legacy_protocol(tmp_path: Path):
+    """An experiment saved with a legacy protocol.yaml opens with a protocol."""
+    experiment = Experiment(path=str(tmp_path), name="legacy-experiment")
+    os.makedirs(experiment.path, exist_ok=True)
+    experiment.save()
+
+    legacy = (LEGACY_PROTOCOL_DIR / "protocol-on-grid.yaml").read_text()
+    (Path(experiment.path) / "protocol.yaml").write_text(legacy)
+
+    loaded = Experiment.load(Path(experiment.path) / "experiment.yaml")
+    assert loaded.task_protocol is not None
+    assert len(loaded.task_protocol.task_config) > 0

--- a/tests/autolamella/test_legacy_protocol_loading.py
+++ b/tests/autolamella/test_legacy_protocol_loading.py
@@ -142,8 +142,29 @@ def test_load_from_old_protocol_rejects_a_file_that_is_neither_format(tmp_path: 
     path = tmp_path / "protocol.yaml"
     path.write_text(yaml.safe_dump({"not": "a protocol"}))
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError, match="does not look like an AutoLamella protocol"):
         AutoLamellaTaskProtocol.load_from_old_protocol(path)
+
+
+def test_microscope_configuration_is_rejected_by_name():
+    """Config files have a top-level 'milling' key too -- the commonest mispick.
+
+    They used to load as a protocol with zero tasks, silently.
+    """
+    with pytest.raises(ValueError, match="does not look like an AutoLamella protocol"):
+        AutoLamellaTaskProtocol.load(
+            str(Path(__file__).parents[2] / "fibsem/config/microscope-configuration.yaml")
+        )
+
+
+@pytest.mark.parametrize("body", ["", "   \n", "null\n"])
+def test_empty_protocol_file_is_reported_as_empty(tmp_path: Path, body: str):
+    """A truncated file parses to None; that used to be an AttributeError."""
+    path = tmp_path / "protocol.yaml"
+    path.write_text(body)
+
+    with pytest.raises(ValueError, match="empty or is not a valid protocol file"):
+        AutoLamellaTaskProtocol.load(str(path))
 
 
 def test_unknown_legacy_method_names_the_valid_methods(tmp_path: Path):

--- a/tests/autolamella/test_legacy_protocol_loading.py
+++ b/tests/autolamella/test_legacy_protocol_loading.py
@@ -132,6 +132,31 @@ def test_load_from_old_protocol_accepts_a_task_protocol():
     assert len(protocol.task_config) > 0
 
 
+def test_load_from_old_protocol_rejects_a_file_that_is_neither_format(tmp_path: Path):
+    """A corrupt file must still raise, not load as an empty protocol.
+
+    The task-protocol shortcut above is keyed on the file actually looking like
+    a task protocol; without that, anything unrecognised falls through to
+    from_dict and quietly yields a protocol with no tasks at all.
+    """
+    path = tmp_path / "protocol.yaml"
+    path.write_text(yaml.safe_dump({"not": "a protocol"}))
+
+    with pytest.raises(Exception):
+        AutoLamellaTaskProtocol.load_from_old_protocol(path)
+
+
+def test_unknown_legacy_method_names_the_valid_methods(tmp_path: Path):
+    """An unrecognised name is a different error to a known-but-unported one."""
+    path = tmp_path / "protocol.yaml"
+    path.write_text(yaml.safe_dump({"method": "not-a-method", "milling": {}, "options": {}}))
+
+    with pytest.raises(ValueError, match="Unknown method"):
+        AutoLamellaTaskProtocol.load_from_old_protocol(path)
+    with pytest.raises(ValueError, match="Unknown method"):
+        AutoLamellaTaskProtocol.load(str(path))
+
+
 def test_converted_legacy_protocol_round_trips(tmp_path: Path):
     """A converted protocol saves in the new format and reloads unchanged."""
     protocol = AutoLamellaTaskProtocol.load(LEGACY_PROTOCOL_DIR / "protocol-on-grid.yaml")

--- a/tests/autolamella/test_legacy_protocol_loading.py
+++ b/tests/autolamella/test_legacy_protocol_loading.py
@@ -8,6 +8,7 @@ died on the first legacy key it saw -- 'method',
 """
 
 import os
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -140,6 +141,54 @@ def test_converted_legacy_protocol_round_trips(tmp_path: Path):
 
     assert not is_legacy_protocol(yaml.safe_load(path.read_text()))
     assert AutoLamellaTaskProtocol.load(str(path)).to_dict() == protocol.to_dict()
+
+
+# ── conversion is visible to the caller ───────────────────────────────────────
+
+@pytest.mark.parametrize("filename", CONVERTIBLE_LEGACY_PROTOCOLS)
+def test_converted_protocol_is_flagged(filename: str):
+    """The UI needs to know a protocol was upgraded, so it can say so."""
+    assert AutoLamellaTaskProtocol.load(LEGACY_PROTOCOL_DIR / filename).converted_from_legacy
+
+
+@pytest.mark.parametrize("filename", TASK_PROTOCOLS)
+def test_task_protocols_are_not_flagged(filename: str):
+    assert not AutoLamellaTaskProtocol.load(TASK_PROTOCOL_DIR / filename).converted_from_legacy
+
+
+def test_new_protocol_is_not_flagged():
+    assert not AutoLamellaTaskProtocol().converted_from_legacy
+
+
+def test_conversion_flag_is_not_serialised(tmp_path: Path):
+    """The flag describes where the object came from, not what the protocol is."""
+    protocol = AutoLamellaTaskProtocol.load(LEGACY_PROTOCOL_DIR / "protocol-on-grid.yaml")
+    assert "converted_from_legacy" not in protocol.to_dict()
+
+    path = tmp_path / "protocol.yaml"
+    protocol.save(str(path))
+    # saved in the new format, so reloading it is no longer a conversion
+    assert not AutoLamellaTaskProtocol.load(str(path)).converted_from_legacy
+
+
+def test_conversion_flag_does_not_affect_equality():
+    """Otherwise the 'protocol changed' checks in the UI would fire spuriously."""
+    protocol = AutoLamellaTaskProtocol()
+    flagged = deepcopy(protocol)
+    flagged.converted_from_legacy = True
+    assert flagged == protocol
+
+
+def test_experiment_flags_a_converted_protocol(tmp_path: Path):
+    experiment = Experiment(path=str(tmp_path), name="legacy-experiment")
+    os.makedirs(experiment.path, exist_ok=True)
+    experiment.save()
+    (Path(experiment.path) / "protocol.yaml").write_text(
+        (LEGACY_PROTOCOL_DIR / "protocol-waffle.yaml").read_text()
+    )
+
+    loaded = Experiment.load(Path(experiment.path) / "experiment.yaml")
+    assert loaded.task_protocol.converted_from_legacy
 
 
 # ── unknown keys ──────────────────────────────────────────────────────────────

--- a/tests/ui/test_legacy_protocol_notices.py
+++ b/tests/ui/test_legacy_protocol_notices.py
@@ -1,0 +1,217 @@
+"""The load-experiment dialog's protocol notices (FIB-663).
+
+A legacy protocol.yaml is now converted transparently on load, so the dialog
+can end up showing a protocol that does not match the file on disk. These tests
+drive the real dialog against real protocol files and assert the user is told:
+a modal on the committed load, and a banner that stays up while the converted
+protocol is loaded.
+
+QMessageBox is stubbed rather than shown -- a modal would block the run -- so
+the recorder doubles as the assertion that the right notice fired.
+"""
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskProtocol, Experiment
+from fibsem.applications.autolamella.ui import autolamella_load_experiment_widget as mod
+from fibsem.applications.autolamella.ui.autolamella_load_experiment_widget import (
+    AutoLamellaLoadExperimentWidget,
+)
+
+PROTOCOL_DIR = (
+    Path(__file__).parents[2] / "fibsem/applications/autolamella/protocol"
+)
+LEGACY_PROTOCOL = PROTOCOL_DIR / "legacy/protocol-on-grid.yaml"
+TASK_PROTOCOL = PROTOCOL_DIR / "task-protocol.yaml"
+
+
+@pytest.fixture
+def notices(monkeypatch) -> List[Tuple[str, str, str]]:
+    """Record (kind, title, text) for every modal the dialog raises."""
+    recorded: List[Tuple[str, str, str]] = []
+
+    def record(kind):
+        def _stub(parent, title, text, *args, **kwargs):
+            recorded.append((kind, title, text))
+            return mod.QtWidgets.QMessageBox.Ok
+        return staticmethod(_stub)
+
+    for kind in ("information", "warning", "critical"):
+        monkeypatch.setattr(mod.QtWidgets.QMessageBox, kind, record(kind))
+    return recorded
+
+
+@pytest.fixture
+def dialog(qapp):
+    widget = AutoLamellaLoadExperimentWidget(parent=None)
+    yield widget
+    widget.close()
+
+
+def make_experiment(path: Path, protocol: Path = None) -> Path:
+    """Write a real experiment, optionally with a protocol.yaml verbatim."""
+    experiment = Experiment.create(path=path, name="legacy-experiment")
+    experiment.save()
+    if protocol is not None:
+        (Path(experiment.path) / "protocol.yaml").write_text(protocol.read_text())
+    return Path(experiment.path) / "experiment.yaml"
+
+
+# ── converted protocol ────────────────────────────────────────────────────────
+
+def test_legacy_experiment_loads_and_warns(dialog, notices, tmp_path):
+    """The headline case: the protocol converts, and the user is told."""
+    assert dialog._load_experiment_from_path(str(make_experiment(tmp_path, LEGACY_PROTOCOL)))
+
+    assert dialog.experiment.task_protocol is not None
+    assert dialog.experiment.task_protocol.converted_from_legacy
+    assert dialog.btn_ok.isEnabled()
+
+    assert [n[1] for n in notices] == [mod.LEGACY_PROTOCOL_CONVERTED_TITLE]
+    kind, _, text = notices[0]
+    assert kind == "information"
+    assert "protocol.yaml" in text          # names the file it converted
+    assert "until the experiment is saved" in text
+
+
+def test_converted_protocol_shows_the_banner(dialog, notices, tmp_path):
+    dialog._load_experiment_from_path(str(make_experiment(tmp_path, LEGACY_PROTOCOL)))
+    assert dialog.label_legacy_protocol_banner.isVisibleTo(dialog)
+
+
+def test_task_protocol_is_silent_and_unbannered(dialog, notices, tmp_path):
+    """A current protocol must load exactly as before -- no notice, no banner."""
+    dialog._load_experiment_from_path(str(make_experiment(tmp_path, TASK_PROTOCOL)))
+
+    assert dialog.experiment.task_protocol is not None
+    assert not dialog.experiment.task_protocol.converted_from_legacy
+    assert notices == []
+    assert not dialog.label_legacy_protocol_banner.isVisibleTo(dialog)
+
+
+def test_preview_click_is_quiet_but_still_banners(dialog, notices, tmp_path):
+    """Single-click preview must not pop a modal; the banner still shows state."""
+    dialog._load_experiment_from_path(
+        str(make_experiment(tmp_path, LEGACY_PROTOCOL)), show_protocol_notices=False
+    )
+
+    assert notices == []
+    assert dialog.experiment.task_protocol.converted_from_legacy
+    assert dialog.label_legacy_protocol_banner.isVisibleTo(dialog)
+
+
+def test_banner_clears_when_the_display_is_cleared(dialog, notices, tmp_path):
+    dialog._load_experiment_from_path(str(make_experiment(tmp_path, LEGACY_PROTOCOL)))
+    assert dialog.label_legacy_protocol_banner.isVisibleTo(dialog)
+
+    dialog._clear_display()
+    assert not dialog.label_legacy_protocol_banner.isVisibleTo(dialog)
+
+
+def test_banner_clears_when_a_task_protocol_replaces_a_converted_one(
+    dialog, notices, tmp_path
+):
+    """The banner tracks the loaded protocol, not the dialog's history."""
+    dialog._load_experiment_from_path(str(make_experiment(tmp_path / "a", LEGACY_PROTOCOL)))
+    assert dialog.label_legacy_protocol_banner.isVisibleTo(dialog)
+
+    dialog._load_experiment_from_path(str(make_experiment(tmp_path / "b", TASK_PROTOCOL)))
+    assert not dialog.label_legacy_protocol_banner.isVisibleTo(dialog)
+
+
+# ── protocol missing or unreadable ────────────────────────────────────────────
+
+def test_missing_protocol_says_not_found(dialog, notices, tmp_path):
+    dialog._load_experiment_from_path(str(make_experiment(tmp_path)))
+
+    assert [n[1] for n in notices] == [mod.ERROR_PROTOCOL_NOT_FOUND_TITLE]
+    assert not dialog.btn_ok.isEnabled()
+    assert dialog.btn_select_protocol.isVisibleTo(dialog)
+
+
+def test_unreadable_protocol_reports_the_error(dialog, notices, tmp_path):
+    """A protocol that exists but cannot be read is not a missing protocol."""
+    experiment_yaml = make_experiment(tmp_path)
+    (experiment_yaml.parent / "protocol.yaml").write_text("{not: [valid")
+
+    dialog._load_experiment_from_path(str(experiment_yaml))
+
+    assert [n[1] for n in notices] == [mod.ERROR_PROTOCOL_LOAD_FAILED_TITLE]
+    assert "protocol.yaml" in notices[0][2]
+    assert not dialog.btn_ok.isEnabled()
+    assert dialog.btn_select_protocol.isVisibleTo(dialog)
+
+
+def test_liftout_protocol_reports_the_unsupported_method(dialog, notices, tmp_path):
+    """Conversion failures surface with their reason, not as 'not found'."""
+    experiment_yaml = make_experiment(
+        tmp_path, PROTOCOL_DIR / "legacy/protocol-liftout.yaml"
+    )
+
+    dialog._load_experiment_from_path(str(experiment_yaml))
+
+    assert [n[1] for n in notices] == [mod.ERROR_PROTOCOL_LOAD_FAILED_TITLE]
+    assert "not supported for conversion" in notices[0][2]
+
+
+def test_wrong_file_is_named_as_such(dialog, notices, tmp_path):
+    """A microscope configuration has a top-level 'milling' key too."""
+    experiment_yaml = make_experiment(tmp_path)
+    (experiment_yaml.parent / "protocol.yaml").write_text(
+        (Path(__file__).parents[2] / "fibsem/config/microscope-configuration.yaml").read_text()
+    )
+
+    dialog._load_experiment_from_path(str(experiment_yaml))
+
+    assert [n[1] for n in notices] == [mod.ERROR_PROTOCOL_LOAD_FAILED_TITLE]
+    assert "does not look like an AutoLamella protocol" in notices[0][2]
+
+
+# ── the manual Select Protocol button ─────────────────────────────────────────
+
+def test_select_protocol_announces_a_legacy_file(dialog, notices, tmp_path, monkeypatch):
+    """The primary button accepts legacy files, so it must say when it converts."""
+    dialog._load_experiment_from_path(str(make_experiment(tmp_path)))
+    notices.clear()
+    monkeypatch.setattr(mod.fui, "open_existing_file_dialog", lambda **kw: str(LEGACY_PROTOCOL))
+
+    dialog._select_protocol()
+
+    assert dialog.experiment.task_protocol.converted_from_legacy
+    assert [n[1] for n in notices] == [mod.LEGACY_PROTOCOL_CONVERTED_TITLE]
+    assert dialog.label_legacy_protocol_banner.isVisibleTo(dialog)
+    assert dialog.btn_ok.isEnabled()
+
+
+def test_select_protocol_is_silent_for_a_task_protocol(dialog, notices, tmp_path, monkeypatch):
+    dialog._load_experiment_from_path(str(make_experiment(tmp_path)))
+    notices.clear()
+    monkeypatch.setattr(mod.fui, "open_existing_file_dialog", lambda **kw: str(TASK_PROTOCOL))
+
+    dialog._select_protocol()
+
+    assert notices == []
+    assert not dialog.label_legacy_protocol_banner.isVisibleTo(dialog)
+    assert dialog.btn_ok.isEnabled()
+
+
+def test_protocol_load_error_distinguishes_absent_from_broken(tmp_path):
+    """The helper behind the two different warnings."""
+    assert AutoLamellaLoadExperimentWidget._protocol_load_error(
+        str(tmp_path / "nope.yaml")
+    ) is None
+
+    broken = tmp_path / "protocol.yaml"
+    broken.write_text("{not: [valid")
+    assert AutoLamellaLoadExperimentWidget._protocol_load_error(str(broken)) is not None
+
+    assert AutoLamellaLoadExperimentWidget._protocol_load_error(str(TASK_PROTOCOL)) == (
+        "unknown error"
+    )


### PR DESCRIPTION
Loading an older protocol or experiment failed with `AutoLamellaWorkflowOptions.__init__() got an unexpected keyword argument 'method'` (or `'alignment_at_milling_current'`), reported in the UI as a corrupt protocol file.

## The bug

`protocol.yaml` is the filename for **both** the legacy and the task-based format, but `AutoLamellaTaskProtocol.load` assumed the new one. A legacy protocol's `options:` block went straight into `AutoLamellaWorkflowOptions.from_dict`, which was `cls(**data)` on a dataclass with a single field — so the load died on whichever legacy key came first in the file. The two different key names in the reports are the same bug seen through different key orderings.

`Experiment.load` hit the same failure and swallowed it into a log warning, which is why an older experiment opened with "No protocol loaded".

## Changes

**Convert legacy protocols instead of rejecting them.** `is_legacy_protocol()` sniffs the format — the two are structurally disjoint at the top level (task protocols always write `tasks` and `workflow`; legacy ones carry `milling` and `options`) — and `AutoLamellaTaskProtocol.from_dict` routes legacy files through the existing conversion. One insertion point covers every entry path, since `Experiment.load` and all three protocol dialogs funnel through `from_dict`.

The conversion is now reachable from a dict (`from_legacy_dict`) as well as a path, so both loaders share it. Picking a task protocol with the "Select Legacy Protocol" button also just works.

**Unknown keys are no longer fatal.** The protocol `from_dict`s drop unrecognised fields with a warning, so a protocol written by another version loads with the fields this build understands.

**Clearer errors.** Liftout and serial-liftout have no task-based equivalent, so those are reported by name up front rather than failing deep inside the milling parser. A file that is neither format — most often a microscope configuration, which also has a top-level `milling` key — is named as such instead of surfacing `KeyError: 'options'`; previously any YAML at all loaded as a protocol with zero tasks and no complaint. An empty or truncated `protocol.yaml` is reported as empty rather than `'NoneType' object has no attribute 'get'`.

**Tell the user when a conversion happened.** A converted protocol is marked with `converted_from_legacy` (not serialised, `compare=False` — it describes where the object came from, so it must not leak into `protocol.yaml` or trip the "protocol changed" comparison). The load-experiment dialog shows a modal on load, saying the file on disk is unchanged until the experiment is saved, plus a banner that stays up while the converted protocol is loaded. The modal is suppressed for the single-click preview of the recent list, alongside the existing missing-protocol warning; the flag gating both is renamed `warn_on_missing_protocol` → `show_protocol_notices`. "Select Protocol" in all three dialogs now gives the same notice the explicit legacy button already did.

An experiment whose `protocol.yaml` exists but cannot be read now says so with the underlying error, instead of claiming the file was not found.

## Current task protocols are unaffected

Verified rather than assumed. Loading all bundled task protocols in a worktree at the base commit and on this branch produces **byte-identical objects** — 52,587 bytes of serialised protocol per tree, plus round-trip stability.

The structural reason: `is_legacy_protocol` returns `False` the moment it sees `tasks` or `workflow`, and `to_dict` always emits both and never a top-level `milling`. So anything AutoLamella has ever written takes the path it always did. `load_task_config`, `LamellaDefaultConfig.from_dict`, `CorrelationConfig.from_dict` and the `_id` handling are untouched; the only modified calls drop unknown keys, which is a no-op when there are none. The delta is one-directional: the only protocols that behave differently are ones that already failed to load.

One incidental fix on that path — `AutoLamellaWorkflowConfig.from_dict` used to mutate the dict passed to it, so loading the same dict twice raised `TypeError: 'AutoLamellaTaskDescription' object is not iterable`. It now copies.

## Tests

- `tests/autolamella/test_legacy_protocol_loading.py` (41) — format detection, conversion of all three convertible methods, round-tripping, unknown-key tolerance, the error paths, and experiment loading with a legacy `protocol.yaml`
- `tests/ui/test_legacy_protocol_notices.py` (13) — drives the real dialog offscreen: modal and banner on a converted protocol, neither on a task protocol, quiet-but-bannered on the preview click, banner lifecycle, and the four ways a protocol can fail to attach

Full suite: 2608 passed. Six failures in `test_import_cycles.py` / `test_conversions.py` are pre-existing and reproduce on the base commit (missing optional imports in the dev container).

## Known limitation

Liftout and serial-liftout protocols still cannot be converted — no task-based equivalent exists. They now fail with a clear message naming the method rather than an obscure one, but users on those methods remain blocked.