### PR TITLE
[ui] Holder overlays, sample-plane sizing, and a run that goes where it said (FIB-656/657/659)

### DIFF
--- a/fibsem/projection.py
+++ b/fibsem/projection.py
@@ -48,6 +48,43 @@ if TYPE_CHECKING:  # pragma: no cover - annotation only
     from fibsem.structures import FibsemImage
 
 
+# A displayed-plane probe length for `surface_foreshortening`. Any value does: the
+# projection is linear in the offset, so the ratio it is used for is scale-free.
+_FORESHORTENING_PROBE = 1.0e-3
+
+
+def surface_foreshortening(
+    projection: "StageProjection", base: FibsemStagePosition
+) -> float:
+    """How much of a length **along the sample surface** survives into the image.
+
+    1.0 where the beam looks straight down the surface normal, and `cos(theta)` where it
+    looks from `theta` away -- a disc on the sample images as a circle in the first case
+    and an ellipse squashed by that factor in the second.
+
+    Measured through the projection's own inverse rather than derived again from the
+    geometry, so it cannot disagree with where the frame puts a marker, and so Tescan
+    and fluorescence get the same answer through their own branches. A stable move
+    travels *along the surface*, which is what makes this one line: ask for a known
+    displayed-plane offset, see how far the stage had to travel to produce it, and the
+    ratio is the cosine. Verified against all six beam/orientation pairs at a 35 degree
+    pre-tilt, where it recovers cos 0, cos 52, cos 23 and cos 75 exactly.
+
+    Distinct from *stage-axis* spans, which is what the overlays used to use: stepping
+    stage y with no z is a move **through** the tilted surface rather than along it, and
+    inflates every length by `1 / cos(pre_tilt)`. That is invisible at a pre-tilt of 0 --
+    every Arctis, and every test written against one -- and 22% at 35 degrees (FIB-657).
+    """
+    moved = projection.from_plane(0.0, _FORESHORTENING_PROBE, base)
+    travel = float(np.hypot(
+        (moved.y or 0.0) - (base.y or 0.0),
+        (moved.z or 0.0) - (base.z or 0.0),
+    ))
+    if not travel:
+        return 1.0
+    return _FORESHORTENING_PROBE / travel
+
+
 class StageProjection(Protocol):
     """Stage coordinates to the displayed plane and back, both in metres.
 

--- a/fibsem/ui/widgets/canvas/stage_frame.py
+++ b/fibsem/ui/widgets/canvas/stage_frame.py
@@ -35,6 +35,7 @@ from fibsem.projection import (  # noqa: F401
     BeamStageProjection,
     FMStageProjection,
     StageProjection,
+    surface_foreshortening,
 )
 from fibsem.structures import FibsemStagePosition
 
@@ -84,3 +85,12 @@ class StageFrame:
         measured length and a placed position cannot end up on different scales.
         """
         return self._canvas.metres_to_canvas(metres, 0.0)[0]
+
+    def surface_foreshortening(self) -> float:
+        """How much of a length along the *sample surface* survives into this view.
+
+        1.0 looking down the surface normal, `cos(theta)` from `theta` away. What a
+        shape lying on the sample needs -- a grid's boundary, say -- as opposed to a
+        shape defined in the image, which needs nothing.
+        """
+        return surface_foreshortening(self.projection, self.origin)

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -1630,6 +1630,7 @@ class FibsemOverviewWidget(QWidget):
 
         specs: List[ShapeSpec] = []
         specs.extend(self._limit_shapes(frame))
+        specs.extend(self._boundary_shapes(frame))
         specs.extend(self._slot_shapes(frame))
         self.context_overlay.set_shapes(specs)
         self._declare_working_area(frame)
@@ -1865,12 +1866,17 @@ class FibsemOverviewWidget(QWidget):
         return abs(along_x - ox), abs(along_y - oy)
 
     def _limit_shapes(self, frame: StageFrame) -> List[ShapeSpec]:
-        """The travel limits, and the grid boundary a cryo holder describes."""
+        """The stage's travel envelope, wherever limits are configured.
+
+        Not gated on the stage type. It used to be: the whole method returned nothing
+        unless `_draws_grid_boundary()` held, so a standard stage lost the travel box
+        along with the grid circle -- and travel limits have nothing to do with grids.
+        One guard was answering two questions.
+        """
         limits = getattr(self.microscope._stage, "limits", None)
-        if not self._draws_grid_boundary():
+        if not limits:
             return []
         try:
-            cx, cy = frame.to_canvas(self._landmark(frame, 0.0, 0.0, "Grid Centre"))
             # Every corner, not a width and a height: the projection can flip either
             # axis, and reading the envelope off the extremes of the projected corners
             # is true whatever it does to them. The box stays axis-aligned -- the
@@ -1884,34 +1890,113 @@ class FibsemOverviewWidget(QWidget):
             ys = [point[1] for point in corners]
             width, height = max(xs) - min(xs), max(ys) - min(ys)
             box_cx, box_cy = (max(xs) + min(xs)) / 2, (max(ys) + min(ys)) / 2
-            # A circle on the sample, so an ellipse on screen everywhere but the two
-            # views where the beam looks down the pose it is named after.
-            span_x, span_y = self._canvas_span(frame, GRID_BOUNDARY_RADIUS_M)
         except Exception as e:
             logger.debug(f"Could not draw the stage limits: {e}")
             return []
         return [
             ShapeSpec(kind="rect", cx=box_cx, cy=box_cy, width=width, height=height,
                       color=STAGE_LIMITS_COLOUR, label="Stage Limits"),
-            ShapeSpec(kind="ellipse", cx=cx, cy=cy,
-                      width=2 * span_x, height=2 * span_y,
-                      color=GRID_BOUNDARY_COLOUR, label="Grid Boundary"),
         ]
 
-    def _slot_shapes(self, frame: StageFrame) -> List[ShapeSpec]:
-        """The sample holder's slots, as crosshairs at their configured positions."""
+    def _holder_slots(self) -> List[object]:
+        """The sample holder's slots, or nothing if the stage does not describe one."""
         try:
-            slots = self.microscope._stage.holder.slots.values()
+            return list(self.microscope._stage.holder.slots.values())
         except Exception:
             return []
-        specs = []
-        for slot in slots:
+
+    def _slot_landmark(self, slot: object) -> Optional[FibsemStagePosition]:
+        """Where a holder slot sits, as a position that can be drawn in any view.
+
+        Slots are stored as x/y/z and **nothing else**: `default-sample-holder.yaml`
+        gives each one three numbers, and `SampleHolder.load` leaves `r` and `t` as
+        None. Handed to `frame.to_canvas` that raises -- and `_slot_shapes` swallowed
+        it, so the shipped two-slot shuttle drew no slot markers at all, silently. The
+        simulator's holder hid it: `_ensure_slots` invents its slot with r=0.
+
+        The missing rotation is the **SEM orientation**, which is the frame the holder
+        file is written in. Stamped here rather than assumed away, because it is what
+        makes a slot re-expressible: a shuttle's grids sit at x = -5 mm and +5 mm, and
+        after a 180-degree rotation the raw coordinate that reaches a given grid is the
+        *other* one. Carrying the pose lets `BeamStageProjection` see the difference
+        and apply the compucentric flip, exactly as it does for a position recorded at
+        one orientation and drawn at another.
+
+        So **not** `_landmark`, which takes the frame's own rotation precisely to stop
+        that flip firing. A travel-envelope corner is a place in the frame being drawn;
+        a slot is a place on the holder, and the holder turns over with the stage.
+
+        No hardware: `get_orientation` is a lookup over the configured orientations.
+        On a compustage every orientation shares one rotation, so this is the identity
+        and the slots draw where they always did.
+        """
+        position = getattr(slot, "position", None)
+        if position is None:
+            return None
+        try:
+            pose = self.microscope.get_orientation("SEM")
+        except Exception as e:
+            logger.debug(f"Could not resolve the holder's reference orientation: {e}")
+            return None
+        return FibsemStagePosition(
+            name=position.name or "", x=position.x, y=position.y,
+            z=position.z or 0.0, r=pose.r, t=pose.t,
+        )
+
+    def _boundary_shapes(self, frame: StageFrame) -> List[ShapeSpec]:
+        """A grid boundary around every slot the holder carries.
+
+        One circle per slot rather than one at the stage origin. A grid is 1 mm in
+        radius whatever holds it, so what the boundary needs is *where the grids are* --
+        and the holder already says, in the same slot positions `_slot_shapes` draws
+        crosshairs at. A compustage carries a single slot at the origin, so it goes on
+        drawing the one circle it always drew; a multi-grid shuttle gets one each,
+        where before it got a single circle at a place no grid is.
+
+        Placed exactly as the crosshair is, through `frame.to_canvas(slot.position)`,
+        so the circle and the marker at its centre cannot disagree: whatever the frame
+        does to that position it does to both. Deliberately *not* re-derived through
+        `_landmark` -- that would make the circle a synthetic place and the crosshair a
+        recorded one, and the two would part company on a stage where the compucentric
+        correction fires.
+
+        A circle on the sample, so an ellipse on screen everywhere but the two views
+        where the beam looks down the pose it is named after.
+        """
+        specs: List[ShapeSpec] = []
+        for slot in self._holder_slots():
+            place = self._slot_landmark(slot)
+            if place is None:
+                continue
             try:
-                cx, cy = frame.to_canvas(slot.position)
-            except Exception:
+                cx, cy = frame.to_canvas(place)
+                span_x, span_y = self._canvas_span(frame, GRID_BOUNDARY_RADIUS_M)
+            except Exception as e:
+                logger.debug(f"Could not draw a grid boundary: {e}")
+                continue
+            specs.append(ShapeSpec(kind="ellipse", cx=cx, cy=cy,
+                                   width=2 * span_x, height=2 * span_y,
+                                   color=GRID_BOUNDARY_COLOUR, label="Grid Boundary"))
+        return specs
+
+    def _slot_shapes(self, frame: StageFrame) -> List[ShapeSpec]:
+        """The sample holder's slots, as crosshairs at their configured positions.
+
+        Through `_slot_landmark` for the same reason the boundary is, and so the two
+        stay concentric by construction rather than by both happening to be right.
+        """
+        specs = []
+        for slot in self._holder_slots():
+            place = self._slot_landmark(slot)
+            if place is None:
+                continue
+            try:
+                cx, cy = frame.to_canvas(place)
+            except Exception as e:
+                logger.debug(f"Could not draw a holder slot: {e}")
                 continue
             specs.append(ShapeSpec(kind="crosshair", cx=cx, cy=cy,
-                                   color=SLOT_COLOUR, label=slot.position.name or ""))
+                                   color=SLOT_COLOUR, label=place.name or ""))
         return specs
 
     def _refresh_stage_info(self) -> None:

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -2481,10 +2481,31 @@ class FibsemOverviewWidget(QWidget):
             settings.image_settings.path = self._save_directory or os.getcwd()
         settings.image_settings.filename = _stamped(settings.image_settings.filename)
 
-        # Resolved before the dialog, so what it shows is what the run gets -- including
-        # the destination and the stamped name filled in just above.
+        # Where this run happens, resolved **once**, before the dialog, and handed to the
+        # runner unchanged. Everything about a run then comes from one value: the plan
+        # drawn on the canvas, the pose the dialog names, and the ground the tiles are
+        # computed from.
+        #
+        # It used to be resolved twice. The widget planned from its cached pose while the
+        # runner was handed `None` unless the grid had been dragged -- and `None` means
+        # "read the stage yourself", which it does when the worker starts, a moment later
+        # and from a different source. Anything that re-posed the stage in between made
+        # the dialog describe one view and the acquisition happen in another, with the
+        # canvas agreeing with the dialog and the files agreeing with neither. Reported
+        # from an instrument: the dialog read SEM @ MILLING and the overview came back
+        # SEM @ SEM.
+        #
+        # The cached pose is not always fresh either -- `stage_position_changed` is
+        # emitted by `get_stage_position`, so a move nobody polls after is a move this
+        # tab never hears about (FIB-669). That is a real defect and this does not fix
+        # it. What it does fix is the *disagreement*: with one value there is no longer a
+        # second reading to differ from, so a stale pose gives a wrong-but-honest run
+        # rather than a run that contradicts what it was authorised to do.
+        self._run_centre = deepcopy(self._target or self._stage_position)
+
         if not self._confirm(settings):
             logger.info("Overview acquisition cancelled before starting")
+            self._run_centre = None  # or the plan stays pinned to a run that never ran
             return
 
         # A new record before the first tile arrives, so every tile has somewhere to go
@@ -2497,16 +2518,13 @@ class FibsemOverviewWidget(QWidget):
         self._refresh_overview_list()
 
         self._stop_event.clear()
-        # What the canvas draws the plan around until the run is over. The same centre
-        # the runner will use: a target if there is one, and otherwise where the stage
-        # is now -- which is what the runner reads for itself when handed None, and is
-        # the last moment the two agree, since the run moves the stage immediately.
-        self._run_centre = deepcopy(self._target or self._stage_position)
         self._set_running(True)
-        # Copied with the settings: the target can be dragged again while the run is
-        # under way, and the run has to keep the grid it was started with.
+        # Copied, because the target can be dragged again while the run is under way and
+        # the run has to keep the grid it was started with. `_run_centre` rather than
+        # `_target`: the same value the canvas draws the plan around and the dialog just
+        # described, so the three cannot come apart.
         self._worker = FunctionWorker(
-            self._acquire_worker, settings, deepcopy(self._target)
+            self._acquire_worker, settings, deepcopy(self._run_centre)
         )
         self._worker.start()
 

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -1846,24 +1846,30 @@ class FibsemOverviewWidget(QWidget):
         )
 
     def _canvas_span(self, frame: StageFrame, length: float) -> Tuple[float, float]:
-        """A stage-space step of *length* metres, in canvas pixels, per axis.
+        """A length *along the sample surface*, in canvas pixels, per axis.
 
-        Not `frame.length()` twice. That divides by the canvas scale and stops, which
-        is right for x and wrong for y: the view foreshortens stage y by a factor that
-        changes with the beam and the pose -- 1.00 looking down the pose a beam is
-        named after, 0.26 for the ion beam at the milling pose. A lattice or a boundary
-        sized by the scale alone is the same size in every view, and therefore right in
-        at most one of them.
+        Not `frame.length()` twice. That divides by the canvas scale and stops, which is
+        right for x and wrong for y: the view foreshortens the surface by a factor that
+        changes with the beam and the pose -- 1.00 looking down the surface normal, 0.26
+        for the ion beam at the milling pose. A boundary sized by the scale alone is the
+        same size in every view, and therefore right in at most one of them.
 
-        Measured through the frame rather than derived from the geometry, so it cannot
+        **A surface length, not a stage-axis one.** Stepping stage y with no z, which is
+        what this did, is a move *through* a tilted surface rather than along it, and
+        inflates every span by `1 / cos(pre_tilt)` -- exactly 1.000 at the pre-tilt of 0
+        that every Arctis and every test has, and 1.221 on a 35 degree shuttle, where a
+        grid boundary came out 22% tall in the two views it must be a circle in
+        (FIB-657). Stage x needs no such care: the tilt is about x, so stage x lies in
+        the surface and a step along it is a step along the surface.
+
+        Measured through the frame, not derived from the geometry again, so it cannot
         disagree with where the frame puts a marker. Absolute, because a view can flip
         an axis and a span has no sign.
         """
-        anchor = self._landmark(frame, 0.0, 0.0)
-        ox, oy = frame.to_canvas(anchor)
+        ox, _ = frame.to_canvas(self._landmark(frame, 0.0, 0.0))
         along_x, _ = frame.to_canvas(self._landmark(frame, length, 0.0))
-        _, along_y = frame.to_canvas(self._landmark(frame, 0.0, length))
-        return abs(along_x - ox), abs(along_y - oy)
+        span_x = abs(along_x - ox)
+        return span_x, span_x * frame.surface_foreshortening()
 
     def _limit_shapes(self, frame: StageFrame) -> List[ShapeSpec]:
         """The stage's travel envelope, wherever limits are configured.

--- a/tests/test_beam_stage_projection.py
+++ b/tests/test_beam_stage_projection.py
@@ -25,6 +25,7 @@ import os
 import numpy as np
 import pytest
 
+from fibsem import config as cfg
 from fibsem import utils
 from fibsem.imaging.tiling.reprojection import (
     reproject_stage_positions_onto_image2,
@@ -37,7 +38,7 @@ from fibsem.structures import (
     FibsemStagePosition,
     ImageSettings,
 )
-from fibsem.projection import BeamStageProjection
+from fibsem.projection import BeamStageProjection, surface_foreshortening
 
 SHAPE = (1024, 1536)  # (height, width) -- deliberately non-square, so an axis swap shows
 PIXEL_SIZE = 2e-7
@@ -471,3 +472,92 @@ class TestRefusesRatherThanGuesses:
         )
         image.metadata.microscope_state.electron_beam = None
         assert BeamStageProjection.from_image(image) is None
+
+
+class TestSurfaceForeshortening:
+    """A length *along the sample surface*, seen from a view, is `cos(theta)` of itself.
+
+    The quantity an overlay lying on the sample needs -- a grid's boundary circle -- as
+    opposed to one defined in the image, like the tile lattice, which needs nothing.
+
+    Pinned as the six exact cosines a **35 degree shuttle** produces, against the
+    shipped Aquilos2 configuration rather than a hand-set pre-tilt, so the numbers stay
+    tied to a geometry that exists. The bug this replaced was invisible at a pre-tilt of
+    **0** -- which is every Arctis, the default simulator config, and therefore every
+    test written before this one. Stepping stage y with no z is a move *through* the
+    tilted surface rather than along it, and inflated every span by `1 / cos(pre_tilt)`:
+    exactly 1.000 at 0 degrees, 1.221 at 35. It reached an instrument before anything
+    caught it (FIB-657).
+
+    The two views where the beam looks straight down the surface normal are what make
+    it obvious: a grid there must render as a circle, and did not.
+    """
+
+    @pytest.fixture(scope="class")
+    def aquilos(self):
+        """A 35 degree pre-tilted shuttle with a 52 degree ion column."""
+        scope, _ = utils.setup_session(
+            manufacturer="Demo",
+            config_path=os.path.join(
+                cfg.CONFIG_PATH, "tfs-aquilos2-configuration.yaml"
+            ),
+        )
+        return scope
+
+    # (orientation, beam, angle between the beam and the sample-surface normal)
+    VIEWS = [
+        pytest.param("SEM", BeamType.ELECTRON, 0, id="SEM-electron-normal"),
+        pytest.param("SEM", BeamType.ION, 52, id="SEM-ion"),
+        pytest.param("FIB", BeamType.ELECTRON, 52, id="FIB-electron"),
+        pytest.param("FIB", BeamType.ION, 0, id="FIB-ion-normal"),
+        pytest.param("MILLING", BeamType.ELECTRON, 23, id="MILLING-electron"),
+        pytest.param("MILLING", BeamType.ION, 75, id="MILLING-ion"),
+    ]
+
+    @staticmethod
+    def _projection(scope, beam_type):
+        return BeamStageProjection(
+            geometry=scope.hardware_geometry(),
+            beam_type=beam_type,
+            scan_rotation=0.0,
+            is_tescan=False,
+        )
+
+    @pytest.mark.parametrize("orientation, beam_type, theta_deg", VIEWS)
+    def test_it_is_the_cosine_of_the_beam_to_normal_angle(
+        self, aquilos, orientation, beam_type, theta_deg
+    ):
+        pose = aquilos.get_orientation(orientation)
+        base = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
+
+        assert surface_foreshortening(
+            self._projection(aquilos, beam_type), base
+        ) == pytest.approx(np.cos(np.deg2rad(theta_deg)), abs=1e-3)
+
+    @pytest.mark.parametrize(
+        "orientation, beam_type",
+        [("SEM", BeamType.ELECTRON), ("FIB", BeamType.ION)],
+    )
+    def test_the_normal_views_are_exactly_one(self, aquilos, orientation, beam_type):
+        """The statement the bug broke: where the beam looks down the surface normal
+        there is no foreshortening at all, so a disc on the sample is a circle. Both of
+        these read 1.221 before -- `1 / cos(35)`."""
+        pose = aquilos.get_orientation(orientation)
+        base = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
+
+        assert surface_foreshortening(
+            self._projection(aquilos, beam_type), base
+        ) == pytest.approx(1.0, abs=1e-6)
+
+    def test_a_flat_shuttle_hides_the_whole_question(self, microscope):
+        """Why this went unnoticed. At a pre-tilt of 0 the stage plane *is* the sample
+        plane, so a stage-axis span and a surface span agree and the factor this
+        corrects is 1. Every simulator config and every earlier test is this case."""
+        base = _pose(
+            microscope, compustage=False, pretilt_deg=0, rotation_deg=0, tilt_deg=0
+        )
+        projection = BeamStageProjection(
+            geometry=_geometry(microscope, compustage=False),
+            beam_type=BeamType.ELECTRON, scan_rotation=0.0, is_tescan=False,
+        )
+        assert surface_foreshortening(projection, base) == pytest.approx(1.0, abs=1e-6)

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -31,6 +31,8 @@ pytest.importorskip("PyQt5")
 from PyQt5.QtCore import QPoint  # noqa: E402
 from PyQt5.QtWidgets import QApplication, QDialog  # noqa: E402
 
+from copy import deepcopy  # noqa: E402
+
 from fibsem import utils  # noqa: E402
 from fibsem.structures import (  # noqa: E402
     BeamType,
@@ -1611,12 +1613,25 @@ class TestThePlannedTileset:
         assert centre.x == pytest.approx(widget.target.x)
         assert centre.y == pytest.approx(widget.target.y)
 
-    def test_an_undragged_run_still_says_nothing_about_a_centre(
+    def test_an_undragged_run_is_told_where_it_happens(
         self, widget, monkeypatch, tmp_path
     ):
-        """None means "wherever the stage is", which the runner resolves itself. Sending
-        a position instead would freeze the grid at wherever the widget last saw the
-        stage, which is not the same thing."""
+        """Reversed by an instrument, and the old reasoning is worth keeping because it
+        sounds right: *"None means 'wherever the stage is', which the runner resolves
+        itself. Sending a position instead would freeze the grid at wherever the widget
+        last saw the stage, which is not the same thing."*
+
+        It is not the same thing, and that is the defect rather than the argument for it.
+        "Wherever the stage is" gets resolved when the **worker starts** -- after the
+        settings are read, after the dialog is answered -- while the plan and the dialog
+        come from the pose the widget last saw. Anything that re-poses in between makes
+        the run happen somewhere the user never authorised: reported from an instrument
+        as a dialog reading SEM @ MILLING and an overview coming back SEM @ SEM.
+
+        Freezing at the pose the widget last saw is exactly right, because that is the
+        pose the dialog described. If it is stale the run is wrong, but it is wrong in
+        the way the user was shown -- see FIB-669 for the staleness itself.
+        """
         captured = {}
 
         def fake_worker(fn, *args):
@@ -1636,7 +1651,10 @@ class TestThePlannedTileset:
             "fibsem.ui.widgets.overview_widget.FunctionWorker", fake_worker
         )
         widget.acquire()
-        assert captured["args"][1] is None
+        centre = captured["args"][1]
+        assert centre is not None, "the run was left to re-read the stage for itself"
+        assert centre.t == pytest.approx(widget._stage_position.t)
+        assert centre.r == pytest.approx(widget._stage_position.r)
 
     def test_the_plan_cannot_be_edited_while_a_run_is_going(self, widget):
         """A run in progress is reading this plan."""
@@ -1773,6 +1791,83 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
 
         assert widget.tile_grid_overlay._anchor() == pytest.approx(anchored_at), (
             "the plan was redrawn around the tile being acquired, not around the run"
+        )
+
+    def test_a_run_without_a_dragged_grid_is_still_given_its_centre(
+        self, widget, microscope, monkeypatch, tmp_path
+    ):
+        """`None` used to mean "runner, read the stage yourself" -- a second reading, a
+        moment later, from a different source than the plan and the dialog."""
+        captured = {}
+
+        def fake_worker(fn, *args):
+            captured["centre"] = args[1]
+
+            class _W:
+                def start(self_inner):
+                    pass
+
+                def is_alive(self_inner):
+                    return False
+
+            return _W()
+
+        widget.set_save_directory(str(tmp_path))
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker", fake_worker
+        )
+        assert widget.target is None, "this test is about the *undragged* case"
+
+        widget.acquire()
+
+        assert captured["centre"] is not None, "the run was left to re-read the stage"
+        assert captured["centre"].t == pytest.approx(widget._stage_position.t)
+
+    def test_a_stage_that_moves_at_the_dialog_does_not_move_the_run(
+        self, widget, microscope, monkeypatch, tmp_path
+    ):
+        """The failure this closes, reported from an instrument: the dialog said
+        SEM @ MILLING and the overview came back SEM @ SEM.
+
+        The pose is resolved *before* the dialog, so anything that re-poses between
+        authorising the run and the worker starting cannot change where it happens. The
+        confirmation stands in for that anything -- it is simply a moment when the
+        widget is not in control.
+        """
+        from fibsem.ui.widgets import overview_confirmation_dialog
+
+        captured = {}
+        confirmed_at = deepcopy(widget._stage_position)
+
+        def fake_worker(fn, *args):
+            captured["centre"] = args[1]
+
+            class _W:
+                def start(self_inner):
+                    pass
+
+                def is_alive(self_inner):
+                    return False
+
+            return _W()
+
+        def moves_the_stage(dialog):
+            widget._stage_position = _at(confirmed_at, dx=900e-6, dy=-400e-6)
+            return QDialog.Accepted
+
+        widget.set_save_directory(str(tmp_path))
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker", fake_worker
+        )
+        monkeypatch.setattr(
+            overview_confirmation_dialog.OverviewConfirmationDialog,
+            "exec_", moves_the_stage,
+        )
+
+        widget.acquire()
+
+        assert captured["centre"].x == pytest.approx(confirmed_at.x), (
+            "the run followed the stage instead of the pose it was authorised for"
         )
 
     def test_the_pin_is_let_go_of_when_the_run_ends(self, widget, microscope, tmp_path):

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -1287,6 +1287,128 @@ class TestOverlaysAreDrawnInTheView:
             widget.close()
 
 
+class TestTheHolderIsDrawnOnEveryStage:
+    """The travel envelope and the grid boundaries are separate questions.
+
+    One guard used to answer both: `_limit_shapes` returned nothing at all unless the
+    stage was a compustage, so a standard stage lost the *travel box* along with the
+    grid circle -- and travel limits have nothing to do with grids.
+
+    And the boundary was one circle at the stage origin, which is a compustage's
+    holder: a single grid, at zero. The shipped `default-sample-holder.yaml` is a
+    2-slot 35-degree shuttle with grids at x = -5 mm and +5 mm, where a circle at the
+    origin marks a place no grid is. A grid is 1 mm in radius whatever holds it, so
+    what the boundary needs is where the grids are, and the holder already says.
+    """
+
+    @staticmethod
+    def _slot(name, x, y=0.0):
+        from fibsem.microscopes._stage import GridSlot
+
+        return GridSlot(
+            name=name, index=0,
+            position=FibsemStagePosition(name=name, x=x, y=y, z=0.0),
+        )
+
+    def _two_slots(self, widget, monkeypatch):
+        """A multi-grid shuttle, in place of the simulator's single centred slot.
+
+        Set on the instance: `slots` is a dataclass field, so patching the class puts
+        a `property` object where a dict belongs.
+        """
+        holder = widget.microscope._stage.holder
+        slots = {"Slot-01": self._slot("Slot-01", -5.0e-3),
+                 "Slot-02": self._slot("Slot-02", 5.0e-3)}
+        monkeypatch.setattr(holder, "slots", slots)
+        widget._refresh_context_overlays()
+        return slots
+
+    @staticmethod
+    def _specs(widget, kind, label=None):
+        return [s for s in widget.context_overlay._specs
+                if s.kind == kind and (label is None or s.label == label)]
+
+    def test_the_travel_box_draws_on_a_stage_that_is_not_a_compustage(
+        self, widget, microscope, monkeypatch
+    ):
+        """The half that was collateral damage. Travel limits are a property of the
+        stage, and every stage that declares them has them."""
+        monkeypatch.setattr(
+            type(microscope), "stage_is_compustage", property(lambda self: False)
+        )
+        widget._refresh_context_overlays()
+
+        assert self._specs(widget, "rect", "Stage Limits"), (
+            "a standard stage was left with no travel envelope drawn"
+        )
+
+    def test_a_slot_with_no_rotation_still_draws(self, widget, monkeypatch):
+        """The defect the boundary work walked into. `default-sample-holder.yaml` gives
+        each slot three numbers -- x, y, z -- so `SampleHolder.load` leaves `r` and `t`
+        as None, and `frame.to_canvas` raises `TypeError` on them. `_slot_shapes` caught
+        that and moved on, so the shipped two-slot shuttle drew **no slot markers at
+        all**, silently. Only the simulator's holder escaped it, because `_ensure_slots`
+        invents its slot with r=0.
+        """
+        slots = self._two_slots(widget, monkeypatch)
+        assert all(s.position.r is None for s in slots.values()), (
+            "this no longer reproduces the shipped holder"
+        )
+        assert len(self._specs(widget, "crosshair")) >= 2, "the slot markers vanished"
+
+    def test_a_boundary_is_drawn_around_every_slot(self, widget, monkeypatch):
+        slots = self._two_slots(widget, monkeypatch)
+        boundaries = self._specs(widget, "ellipse", "Grid Boundary")
+        assert len(boundaries) == len(slots) == 2
+
+    def test_each_boundary_is_centred_on_its_own_slot(self, widget, monkeypatch):
+        """Not on the stage origin, which is where the single circle used to go -- and
+        with a shuttle that is 10 mm across, a full grid's width from either of them."""
+        self._two_slots(widget, monkeypatch)
+        boundaries = self._specs(widget, "ellipse", "Grid Boundary")
+        crosshairs = [s for s in self._specs(widget, "crosshair")
+                      if s.label.startswith("Slot-")]
+
+        centres = sorted((round(s.cx, 6), round(s.cy, 6)) for s in boundaries)
+        markers = sorted((round(s.cx, 6), round(s.cy, 6)) for s in crosshairs)
+        assert centres == markers, "a boundary is not concentric with its slot marker"
+        assert len({c[0] for c in centres}) == 2, "both circles landed in one place"
+
+    def test_a_slot_carries_the_orientation_it_was_defined_in(self, widget, monkeypatch):
+        """The holder file is written in the SEM orientation, so that is the pose a
+        slot has to carry. Without it the position is a bare x/y and `to_canvas` has
+        nothing to compare against -- which is both why the shipped holder crashed and
+        why it could never be re-expressed for a re-posed stage.
+
+        Carrying the pose is what lets `BeamStageProjection` decide: on a compustage
+        every orientation shares one rotation and this is the identity, and on a
+        standard stage a view half a turn away gets the compucentric flip, exactly as a
+        marked position does.
+        """
+        self._two_slots(widget, monkeypatch)
+        sem = widget.microscope.get_orientation("SEM")
+
+        place = widget._slot_landmark(
+            list(widget.microscope._stage.holder.slots.values())[0]
+        )
+
+        assert place.r == pytest.approx(sem.r)
+        assert place.t == pytest.approx(sem.t)
+        assert place.x == pytest.approx(-5.0e-3), "the slot's own position was lost"
+
+    def test_a_single_centred_slot_still_draws_the_one_circle(self, widget):
+        """The compustage case, unchanged: one slot at the origin, one circle on it.
+        The simulator's own holder, so this is the behaviour that shipped."""
+        boundaries = self._specs(widget, "ellipse", "Grid Boundary")
+        crosshairs = [s for s in self._specs(widget, "crosshair")
+                      if s.label.startswith("Slot-")]
+
+        assert len(boundaries) == 1
+        assert (boundaries[0].cx, boundaries[0].cy) == pytest.approx(
+            (crosshairs[0].cx, crosshairs[0].cy)
+        )
+
+
 class TestLifecycle:
     def test_closing_releases_every_microscope_subscription(self, microscope):
         """psygnal subscriptions outlive the widget -- they belong to the microscope --


### PR DESCRIPTION
Stacked on #388. Three commits, all from one instrument session — every one of them invisible on the simulator, and each for a different reason.

## 1. Draw the holder on every stage, one boundary per grid (FIB-656)

- The **travel box** was gated on `_draws_grid_boundary()`, which requires a compustage — so a standard stage lost the stage travel envelope along with the grid circle. One guard was answering two questions.
- The **boundary** was one circle at the stage origin, which is a compustage's holder. The shipped `default-sample-holder.yaml` is a 2-slot 35° shuttle with grids at ∓5 mm, where a circle at the origin marks nothing. Now one per slot, placed through the same call as the crosshair so the two cannot disagree.
- **Slots carried no rotation**, so none of them drew at all. The holder file gives x/y/z only, `SampleHolder.load` leaves `r`/`t` as None, `frame.to_canvas` raises `TypeError`, and `_slot_shapes` caught it and moved on — **the shipped shuttle drew no slot markers, silently.** Only the simulator escaped, because `_ensure_slots` invents its slot with `r=0`.

The missing rotation is the SEM orientation, stamped rather than defaulted away — that is what makes a slot re-expressible when the stage turns over.

## 2. Size overlays on the sample plane (FIB-657)

The boundary rendered 22% tall in the view where it must be a circle. Measured on the Aquilos2 config:

| view | measured | ÷ 1.2208 | = cos |
|---|---|---|---|
| SEM · electron | 1.221 | **1.000** | 0° |
| FIB · ion | 1.221 | **1.000** | 0° |
| SEM · ion | 0.752 | 0.616 | 52° |
| FIB · electron | 0.752 | 0.616 | 52° |
| MILLING · electron | 1.124 | 0.9205 | 23° |
| MILLING · ion | 0.316 | 0.2589 | 75° |

Six exact cosines, each times a spurious `1/cos(35°)`. `_canvas_span` stepped **stage y with dz = 0** — a move *through* a tilted surface rather than along it. A grid's radius is a length on the surface, and the two agree only at a pre-tilt of 0: every Arctis, the default sim config, and every test written before this one.

A stable move travels along the surface, so the fix needed no new geometry — only the right question asked of the existing inverse. `surface_foreshortening` lives in `fibsem/projection.py`, which has no Qt in it, so **its test actually runs in CI**.

Checked and cleared: the shared movement maths. `view_corrected_stage_movement` and `inverse_view_corrected_dy` are exact inverses, round-trip 1.0000 mm.

## 3. Acquire where the dialog said (FIB-659)

Reported as: dialog reads SEM @ MILLING, overview comes back SEM @ SEM.

The pose was resolved **twice** — the widget planned from its cached pose while the runner was handed `None` unless the grid had been dragged, and `None` means "read the stage yourself" when the worker starts. Now resolved once, before the dialog, handed over unchanged.

This does not make the cache *fresh* — that is [FIB-669](https://linear.app/fibsemos/issue/FIB-669), a microscope-level defect where `stage_position_changed` is emitted by the getter rather than by any mover. It makes the readings *agree*, so a stale pose gives a wrong-but-honest run rather than one that contradicts what it was authorised to do.

## Verification

- **5035 passed**, 24 skipped, full suite
- the six cosines pinned against `tfs-aquilos2-configuration.yaml` by name, in a CI-runnable test
- a regression guard asserting the test slots still have `r is None`, so it cannot stop reproducing the shipped holder
- `test_an_undragged_run_still_says_nothing_about_a_centre` rewritten to assert the opposite, with its old rationale quoted — it pinned a decision the instrument reversed