### PR TITLE
[fix][FIB-670] show a toast on the window that raised it, not always on the main window

### DIFF
--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -35,6 +35,7 @@ import numpy as np
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QAction,
+    QApplication,
     QDialog,
     QFileDialog,
     QFrame,
@@ -2131,6 +2132,34 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         self.label_threshold_chip.setVisible(False)
         self._record_coincidence_result()
         self.milling_finished_signal.emit()
+        self._restack_after_run()
+
+    def _restack_after_run(self) -> None:
+        """Put this window back in front once a run ends, unless the operator has
+        deliberately moved to another of the app's windows.
+
+        Reported from a session: when coincidence milling stops, the main window comes
+        to the front and hides this one. The cause was the end-of-run toast, which used
+        to be a child of the main window wherever it was raised from -- on Windows that
+        drags the main window's z-order group in front of this deliberately parentless
+        one (see open_coincidence_viewer_window and ToastManager). Fixed there; this is
+        the backstop, kept because that diagnosis is inferred from the platform's
+        window rules rather than measured.
+
+        The active-window check is what keeps the backstop from becoming the same
+        complaint in reverse. A window pulled forward as a side effect does not take
+        focus, so the reported case still restacks; but an operator who clicked over to
+        the main window mid-run owns the focus, and their window is left alone.
+        """
+        if not self.isWindow():  # embedded: raising the host would be someone else's call
+            return
+        active = QApplication.activeWindow()
+        if active is not None and active is not self:
+            return
+        # raise_() restacks within the application only: it takes no keyboard focus, so
+        # it cannot pull the app in front of the microscope software, and it leaves a
+        # minimized window minimized.
+        self.raise_()
 
     def _record_coincidence_result(self) -> None:
         """Record the latest coincidence run against the selected lamella.

--- a/fibsem/ui/widgets/notifications.py
+++ b/fibsem/ui/widgets/notifications.py
@@ -9,6 +9,7 @@ except Exception:
 from datetime import datetime
 from PyQt5.QtCore import QPropertyAnimation, QTimer, Qt, QPoint
 from PyQt5.QtWidgets import (
+    QApplication,
     QGraphicsOpacityEffect,
     QHBoxLayout,
     QLabel,
@@ -450,21 +451,64 @@ class NotificationBell(QWidget):
 
 
 class ToastManager:
-    """Manages toast notifications for a parent widget."""
+    """Manages toast notifications, on whichever of the app's windows the operator is
+    working in.
+
+    A toast belongs to a window: it is that window's child and is stacked in that
+    window's bottom-right corner. Anchoring every toast to the host window instead put
+    notifications about work done elsewhere -- the coincidence viewer, correlation, the
+    FM UI -- in the corner of a window the operator was not looking at, and on Windows
+    a toast owned by the host drags the host's whole z-order group in front of the
+    window that raised it (the reported "the AutoLamella GUI comes to the front when
+    coincidence milling stops").
+    """
 
     def __init__(self, parent: QWidget):
-        self.parent = parent
+        self.parent = parent  # fallback anchor, and the window the bell lives on
         self.toasts: list[ToastNotification] = []
         self.spacing = 10
         self.notification_bell: NotificationBell = None
+        self._last_active: QWidget = None
+        app = QApplication.instance()
+        if app is not None:
+            app.focusChanged.connect(self._on_focus_changed)
 
     def set_notification_bell(self, bell: NotificationBell):
         """Set the notification bell to update."""
         self.notification_bell = bell
 
+    def _on_focus_changed(self, _old: QWidget, now: QWidget) -> None:
+        """Remember the last real window of ours the operator was in.
+
+        Tracked rather than read off ``QApplication.activeWindow()`` at show time,
+        because that is ``None`` whenever the app itself is not focused -- exactly the
+        case this exists for, a run that finishes while the operator is in the
+        microscope software. Only ``Qt.Window`` types qualify, which skips the app's
+        own transient chrome (toasts, popovers, tooltips) and short-lived dialogs: a
+        toast anchored to a dialog would be destroyed with it mid-fade.
+        """
+        if now is None:
+            return
+        window = now.window()
+        if window is not None and window.windowType() == Qt.Window:
+            self._last_active = window
+
+    def _anchor(self) -> QWidget:
+        """The window a new toast belongs to."""
+        window = self._last_active
+        try:
+            # isMinimized: anchoring to a minimized window would place the toast at
+            # that window's restored geometry, i.e. over nothing the operator can see.
+            if window is None or not window.isVisible() or window.isMinimized():
+                return self.parent
+        except RuntimeError:  # window closed; the C++ side is already gone
+            self._last_active = None
+            return self.parent
+        return window
+
     def show_toast(self, message: str, notification_type: str = "info", duration: int = 5000, temporary: bool = False):
         """Show a toast notification."""
-        toast = ToastNotification(self.parent, duration)
+        toast = ToastNotification(self._anchor(), duration)
         self.toasts.append(toast)
 
         # Connect to hidden signal for cleanup (not fade_animation.finished which fires on fade-in too)
@@ -493,18 +537,32 @@ class ToastManager:
             self._reposition_toasts()
 
     def _reposition_toasts(self):
-        """Reposition all visible toasts."""
-        if not self.parent:
-            return
+        """Stack each visible toast up the bottom-right corner of the window it
+        belongs to.
 
-        parent_rect = self.parent.rect()
-        # Convert to global screen coordinates
-        global_pos = self.parent.mapToGlobal(QPoint(0, 0))
-        y_offset = 60  # Leave room for notification bell
+        Grouped by anchor rather than run as one column: toasts raised from different
+        windows are stacked on their own window, so two windows' notifications never
+        share a column (or overlap, when the windows overlap).
+        """
+        alive = []
+        for toast in self.toasts:
+            try:
+                toast.isVisible()
+            except RuntimeError:
+                continue  # destroyed along with the window it was anchored to
+            alive.append(toast)
+        self.toasts = alive
 
+        y_offsets = {}  # anchor -> next free offset up from its bottom edge
         for toast in reversed(self.toasts):
-            if toast.isVisible():
-                x = global_pos.x() + parent_rect.width() - toast.width() - 20
-                y = global_pos.y() + parent_rect.height() - toast.height() - y_offset
-                toast.move(x, y)
-                y_offset += toast.height() + self.spacing
+            anchor = toast.parent()
+            if not toast.isVisible() or anchor is None or not anchor.isVisible():
+                continue
+            y_offset = y_offsets.get(anchor, 60)  # leave room for notification bell
+            anchor_rect = anchor.rect()
+            # Convert to global screen coordinates
+            global_pos = anchor.mapToGlobal(QPoint(0, 0))
+            x = global_pos.x() + anchor_rect.width() - toast.width() - 20
+            y = global_pos.y() + anchor_rect.height() - toast.height() - y_offset
+            toast.move(x, y)
+            y_offsets[anchor] = y_offset + toast.height() + self.spacing

--- a/tests/ui/test_coincidence_viewer_layering.py
+++ b/tests/ui/test_coincidence_viewer_layering.py
@@ -1,0 +1,152 @@
+"""When a coincidence run ends, the viewer must come back to the front.
+
+Reported from a session: "when the coincidence milling stops the AutoLamella GUI comes
+to the front of everything". The viewer is a deliberately parentless top-level window
+(see ``open_coincidence_viewer_window``), so nothing holds it above the main window --
+whatever the main window's own end-of-run refresh does to the stacking order wins, and
+the post-milling FIB image ends up hidden behind it.
+
+The end of ``_finalize_milling_ui`` is the last thing the milling flow runs, so that is
+where the viewer restacks itself. Pinned here because the call is invisible in normal
+use (nothing else covers the window in a test) and would be an easy line to drop.
+
+Driven through the real widget rather than a stub: the raise has to happen after the
+result is recorded and the finished signal is emitted, and only the real method has
+that order in it.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+pytest.importorskip("napari")
+
+from PyQt5.QtWidgets import QApplication
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def viewer_widget(qapp, tmp_path):
+    """The whole viewer on a simulated FM microscope.
+
+    The FM configuration is not incidental: ``_connect_signals`` returns immediately
+    when ``microscope.fm is None``, so on a plain demo session the viewer constructs
+    with none of its signals wired.
+    """
+    from fibsem import config as cfg
+    from fibsem import utils
+    from fibsem.applications.autolamella.structures import Experiment
+    from fibsem.applications.autolamella.ui.fluorescence_coincidence_viewer_widget import (
+        FluorescenceCoincidenceViewerWidget,
+    )
+
+    microscope, _ = utils.setup_session(
+        config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+    )
+    assert microscope.fm is not None, "expected an FM on the simulated Arctis"
+    return FluorescenceCoincidenceViewerWidget(
+        microscope=microscope,
+        experiment=Experiment(path=str(tmp_path), name="coincidence-layering-test"),
+    )
+
+
+def test_the_viewer_restacks_itself_when_a_run_ends(viewer_widget, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        type(viewer_widget), "raise_", lambda self: calls.append(self), raising=False
+    )
+
+    viewer_widget._finalize_milling_ui()
+
+    assert calls == [viewer_widget.window()], (
+        "the viewer did not raise its own window when the run ended -- the main "
+        "window can sit in front of it and hide the result"
+    )
+
+
+def test_the_raise_comes_after_the_run_is_recorded_and_announced(
+    viewer_widget, monkeypatch
+):
+    """Ordering, not just the call: the main window reacts to both the recording and
+    the finished signal, so a raise that ran before them could be undone by what they
+    set off."""
+    order = []
+    monkeypatch.setattr(
+        type(viewer_widget),
+        "_record_coincidence_result",
+        lambda self: order.append("record"),
+    )
+    monkeypatch.setattr(
+        type(viewer_widget), "raise_", lambda self: order.append("raise"), raising=False
+    )
+    viewer_widget.milling_finished_signal.connect(lambda: order.append("finished"))
+
+    viewer_widget._finalize_milling_ui()
+
+    assert order == ["record", "finished", "raise"], f"unexpected order: {order}"
+
+
+def test_the_viewer_does_not_take_focus(viewer_widget, monkeypatch):
+    """raise_() restacks inside the application; activateWindow() would take keyboard
+    focus and pull the app in front of the microscope software. Only the first is
+    wanted -- the complaint being fixed is a window stealing the front."""
+    monkeypatch.setattr(type(viewer_widget), "raise_", lambda self: None, raising=False)
+    stolen = []
+    monkeypatch.setattr(
+        type(viewer_widget),
+        "activateWindow",
+        lambda self: stolen.append(self),
+        raising=False,
+    )
+
+    viewer_widget._finalize_milling_ui()
+
+    assert not stolen, "the viewer activated itself: that steals focus, it must not"
+
+
+def test_it_leaves_alone_a_window_the_operator_moved_to(viewer_widget, monkeypatch):
+    """Otherwise the backstop is the same complaint in reverse: click over to the main
+    window mid-run and this window jumps in front of it the moment milling stops.
+
+    A window pulled forward as a side effect does not take focus, so the case this
+    exists for still restacks -- only a deliberate switch holds the active window.
+    """
+    from PyQt5.QtWidgets import QWidget
+
+    elsewhere = QWidget()
+    elsewhere.setWindowTitle("some other window of ours")
+    calls = []
+    monkeypatch.setattr(
+        type(viewer_widget), "raise_", lambda self: calls.append(self), raising=False
+    )
+    monkeypatch.setattr(
+        QApplication, "activeWindow", staticmethod(lambda: elsewhere)
+    )
+
+    viewer_widget._finalize_milling_ui()
+
+    assert not calls, "restacked over a window the operator had deliberately moved to"
+
+
+def test_an_embedded_viewer_does_not_restack_its_host(viewer_widget, monkeypatch):
+    """`window()` on an embedded widget is somebody else's window, and raising it is
+    somebody else's call. Only a top-level viewer restacks itself."""
+    from PyQt5.QtWidgets import QVBoxLayout, QWidget
+
+    calls = []
+    monkeypatch.setattr(
+        type(viewer_widget), "raise_", lambda self: calls.append(self), raising=False
+    )
+    host = QWidget()
+    QVBoxLayout(host).addWidget(viewer_widget)  # reparented: no longer a window
+    assert not viewer_widget.isWindow()
+
+    viewer_widget._finalize_milling_ui()
+
+    assert not calls, "an embedded viewer restacked something it does not own"

--- a/tests/ui/test_toast_anchoring.py
+++ b/tests/ui/test_toast_anchoring.py
@@ -1,0 +1,159 @@
+"""A toast belongs to the window the operator is working in, not to the host window.
+
+Every toast used to be a child of the one window that owns the ToastManager (the
+AutoLamella main window), wherever the work happened. Two consequences, one cosmetic
+and one not: a notification about something done in the coincidence viewer appeared in
+the corner of a different window, and on Windows a toast owned by the main window drags
+the main window's z-order group in front of the (parentless) viewer -- reported from a
+session as "when the coincidence milling stops the AutoLamella GUI comes to the front".
+
+The anchor is the last *real* window of ours to hold focus, deliberately not
+``QApplication.activeWindow()``: that is None whenever the app is unfocused, which is
+the normal state while a run finishes and the operator watches the microscope software.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5 import sip
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication, QWidget
+
+from fibsem.ui.widgets.notifications import ToastManager
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def host(qapp):
+    """Stand-in for the main window: owns the manager, and is the fallback anchor."""
+    window = QWidget()
+    window.setGeometry(0, 0, 800, 600)
+    window.show()
+    yield window
+    window.close()
+
+
+@pytest.fixture()
+def viewer(qapp):
+    """Stand-in for the coincidence viewer: a separate, parentless top-level."""
+    window = QWidget()
+    window.setGeometry(900, 100, 700, 500)
+    window.show()
+    yield window
+    if not sip.isdeleted(window):  # a test may have destroyed it on purpose
+        window.close()
+
+
+def _bottom_right_of(window: QWidget):
+    return window.mapToGlobal(window.rect().bottomRight())
+
+
+def test_the_toast_belongs_to_the_window_the_work_happened_in(host, viewer):
+    manager = ToastManager(host)
+    manager._on_focus_changed(None, viewer)
+
+    manager.show_toast("Recorded coincidence result for Lamella-01.")
+
+    toast = manager.toasts[-1]
+    assert toast.parent() is viewer, (
+        "the toast is owned by the host window: on Windows that pulls the host in "
+        "front of the window the operator is using"
+    )
+    corner = _bottom_right_of(viewer)
+    assert toast.x() < corner.x() and toast.y() < corner.y()
+    assert toast.x() > _bottom_right_of(host).x(), "positioned over the host window"
+
+
+def test_it_falls_back_to_the_host_window_when_nothing_else_has_been_used(host):
+    manager = ToastManager(host)
+
+    manager.show_toast("Connecting to microscope...")
+
+    assert manager.toasts[-1].parent() is host
+
+
+def test_a_hidden_anchor_is_not_used(host, viewer):
+    """The anchor is remembered, so it can be gone by the time the next toast fires."""
+    manager = ToastManager(host)
+    manager._on_focus_changed(None, viewer)
+    viewer.close()
+
+    manager.show_toast("Milling finished.")
+
+    assert manager.toasts[-1].parent() is host
+
+
+def test_a_destroyed_anchor_takes_its_toasts_but_not_the_manager(host, viewer):
+    """The window can be *destroyed* rather than merely hidden, and Qt destroys its
+    children with it -- so a toast still in the list is a wrapper whose C++ side is
+    gone, and every method on it raises rather than returning False.
+
+    ``sip.delete`` rather than ``deleteLater`` + ``processEvents``: processEvents does
+    not deliver DeferredDelete, so that pairing closes the window without ever
+    destroying it and this test would pass without exercising anything.
+    """
+    manager = ToastManager(host)
+    manager._on_focus_changed(None, viewer)
+    manager.show_toast("on the viewer")
+    orphan = manager.toasts[-1]
+
+    sip.delete(viewer)
+    assert sip.isdeleted(orphan), "expected the toast to be destroyed with its window"
+
+    manager.show_toast("after the window was destroyed")
+
+    assert manager.toasts == [manager.toasts[-1]], "the dead toast was not pruned"
+    assert manager.toasts[-1].parent() is host
+
+
+def test_a_minimized_window_is_not_used_as_an_anchor(host, viewer):
+    """Qt reports a minimized window as visible; a toast anchored to one would be
+    placed at its restored geometry, i.e. over nothing."""
+    manager = ToastManager(host)
+    manager._on_focus_changed(None, viewer)
+    viewer.showMinimized()
+
+    manager.show_toast("Milling finished.")
+
+    assert manager.toasts[-1].parent() is host
+
+
+def test_transient_windows_never_become_the_anchor(host, viewer):
+    """Toasts, popovers and tooltips are the app's own chrome, and dialogs are
+    short-lived -- a toast anchored to one would be destroyed with it mid-fade."""
+    manager = ToastManager(host)
+    manager._on_focus_changed(None, viewer)
+
+    for flags in (Qt.Tool, Qt.Popup, Qt.ToolTip, Qt.Dialog):
+        transient = QWidget(None, flags)
+        manager._on_focus_changed(None, transient)
+        assert manager._anchor() is viewer, f"{flags} was taken as the anchor"
+
+
+def test_each_window_stacks_its_own_toasts(host, viewer):
+    """Two windows' notifications must not share a column -- when the windows overlap,
+    a shared column overlaps too."""
+    manager = ToastManager(host)
+    manager.show_toast("first, on the host")
+    manager._on_focus_changed(None, viewer)
+    manager.show_toast("first, on the viewer")
+    manager.show_toast("second, on the viewer")
+
+    host_toasts = [t for t in manager.toasts if t.parent() is host]
+    viewer_toasts = [t for t in manager.toasts if t.parent() is viewer]
+    assert len(host_toasts) == 1 and len(viewer_toasts) == 2
+
+    # the two on the viewer are stacked above one another, not on top of each other
+    assert viewer_toasts[0].y() != viewer_toasts[1].y()
+    # and the host's toast keeps its own corner, unshifted by the viewer's two
+    only_host = ToastManager(host)
+    only_host.show_toast("first, on the host")
+    assert host_toasts[0].y() == only_host.toasts[-1].y()


### PR DESCRIPTION
## What

From the testing session: *"when the coincidence milling stops the AutoLamella GUI comes to the front of everything"* — the main window jumps in front of the Coincidence Milling Viewer just as the post-milling result lands on the viewer's canvases.

## Why it happened

Nothing in the stop path raises the main window. I instrumented every `show` / `setVisible` / `raise_` / `activateWindow` that targets a top-level widget and ran a full coincidence milling task on the simulator (real main window, real viewer, sim-arctis FM, through `finish_milling` and the post-milling FIB acquisition):

- toasts **off** → **zero** window events between "milling starts" and "run finished"
- toasts **on** → exactly one: the `"Recorded coincidence result for {lamella}"` toast

Every toast was built as `ToastNotification(main_window)` — a `Qt.Tool` window **owned by the main window** — wherever it was raised from. On Windows an owned window is bound to its owner's z-order group, so showing one pulls the main window forward past the viewer, which is deliberately parentless. macOS does not apply that rule, which is why it never reproduced locally.

Two bugs in one line, then: the cross-window restack, and a notification about work done in the viewer appearing in the corner of a different window.

## The change

`ToastManager` anchors each toast to the window it belongs to:

- **the anchor** is the last real window of ours to hold focus — tracked via `focusChanged` rather than read from `QApplication.activeWindow()` at show time, because that is `None` whenever the app itself is unfocused, which is exactly this case (a run finishing while the operator is in the microscope software). Falls back to the host window.
- **only `Qt.Window` types qualify**, which skips our own transient chrome (toasts, the bell popover, tooltips) and short-lived dialogs — a toast anchored to a dialog would be destroyed with it mid-fade.
- **stacking is per anchor**, so two windows' notifications never share a column, and toasts destroyed along with their window are pruned (a stale wrapper raises from every method rather than returning `False`).

No call sites change: all 132 `notification_service.show*` calls go through the global bus, and there is one `ToastManager`.

The viewer also restacks itself when a run ends, as a backstop — the Windows half of the diagnosis is inferred from the platform's window rules rather than measured. It is skipped when another of our windows holds focus, so a deliberate switch to the main window mid-run is not overridden, and when the viewer is embedded rather than a window of its own.

## Verification

Re-ran the same instrumented flow after the change:

```
[show] ToastNotification OWNER='Coincidence Milling Viewer'
```

(was `OWNER='AUTOLAMELLA MAIN WINDOW'`), and confirmed by hand in the running app.

New headless tests — `tests/ui/test_toast_anchoring.py` (7) and `tests/ui/test_coincidence_viewer_layering.py` (5): the anchor follows the window in use, falls back when there is nothing / it is hidden / it is minimized, transient window types never become the anchor, each window stacks its own toasts, a destroyed window takes its toasts but not the manager, and the viewer restacks after the recording and the signal, without taking focus, without overriding a window the operator moved to, and not at all when embedded. Every guard is mutation-checked — removing any one of them fails exactly one test.

Also passing: `test_task_output_discovery`, `test_configuration_import`, `test_context_menu_action_failure`, the 221-test `test_fm_overview_widget` suite, and the standalone `test_coincidence_viewer_canvas` harness.

## Worth knowing

- Background notifications now follow the last-focused window: an unattended workflow's "task failed" toast appears on the coincidence viewer if that is where the operator last clicked. The bell history is unchanged and still on the main window.
- Closing a window while one of its toasts is fading takes the toast with it.
- Toasts on non-host windows keep the 60px "room for the notification bell" offset, so they sit slightly above the corner on windows that have no bell.
