### PR TITLE
[test] Isolate the coincidence drag test from the saved milling config

### DIFF
--- a/fibsem/applications/autolamella/ui/tests/test_coincidence_viewer_canvas.py
+++ b/fibsem/applications/autolamella/ui/tests/test_coincidence_viewer_canvas.py
@@ -67,6 +67,18 @@ def _coincidence_viewer():
     The FM configuration is not incidental: ``_connect_signals`` returns immediately when
     ``microscope.fm is None``, so on a plain demo session the viewer constructs with none
     of its signals wired and every interaction test would pass without testing anything.
+
+    The milling config path is redirected at a throwaway file so the viewer always starts
+    from its built-in ``DEFAULT_MILLING_TASK_CONFIG``. ``_load_milling_config`` otherwise
+    restores whatever this machine last saved to
+    ``fibsem/config/coincidence-milling-config.yaml`` — a runtime-written, gitignored file
+    inside the package, so a poisoned one is invisible to ``git status`` — which made the
+    drag test below depend on ambient state, and let the widget's debounced autosave
+    overwrite a developer's real saved config from a test run.
+
+    Left redirected for the rest of the process on purpose: that autosave is a 1s
+    ``qdebounced`` timer, so it can fire long after the test that built the widget
+    returned, whenever another test spins the event loop.
     """
     import tempfile
 
@@ -75,6 +87,10 @@ def _coincidence_viewer():
     from fibsem.applications.autolamella.structures import Experiment
     from fibsem.applications.autolamella.ui.fluorescence_coincidence_viewer_widget import (
         FluorescenceCoincidenceViewerWidget,
+    )
+
+    cfg.COINCIDENCE_MILLING_CONFIG_PATH = os.path.join(
+        tempfile.mkdtemp(), "coincidence-milling-config.yaml"
     )
 
     microscope, _ = utils.setup_session(
@@ -358,6 +374,18 @@ def test_the_viewer_builds_and_its_milling_widget_draws_nothing_itself():
     assert milling._pattern_update_pending is False
 
 
+def _drag_fib_rect_to(overlay, cx: float, cy: float, size: float = 60.0) -> dict:
+    """Drive one drag the way the canvas does: move the rect, then emit rect_changed.
+
+    Returns the emitted rect, so callers compare against the geometry the handler
+    actually saw rather than the one they asked for.
+    """
+    overlay.set_rect(x0=cx - size / 2, y0=cy - size / 2, width=size, height=size)
+    info = overlay.get_rect()
+    overlay.rect_changed.emit(info)
+    return info
+
+
 def test_dragging_the_fib_rect_still_repositions_the_pattern():
     """The drag is how an operator positions a coincidence mill, and it is the one path
     that runs *through* the milling widget rather than around it
@@ -366,6 +394,14 @@ def test_dragging_the_fib_rect_still_repositions_the_pattern():
     Note the FM-enabled configuration: ``_connect_signals`` returns at its first line
     when ``microscope.fm is None``, so on a plain demo session the viewer wires up
     *nothing* and a drag test would pass vacuously against any breakage.
+
+    The first drag is what makes the second one meaningful. ``_move_patterns`` positions
+    the pattern absolutely, so the point a given rect produces is fixed — and the viewer
+    restores the last-used milling config, which after any previous run of this test
+    holds exactly the point the drag below produces. The assertion then compared a value
+    to itself and failed however the file was invoked. Establishing the start here (and
+    isolating the config in ``_coincidence_viewer``) keeps the target demonstrably
+    different from the start no matter what the machine has saved.
     """
     widget = _coincidence_viewer()
     milling = widget.milling_viewer_widget
@@ -376,15 +412,23 @@ def test_dragging_the_fib_rect_still_repositions_the_pattern():
 
     stages = milling.config_widget.milling_stages_widget.get_enabled_stages()
     assert stages, "no enabled milling stage to reposition"
-    before = stages[0].pattern.point
 
-    overlay.set_rect(x0=470.0, y0=150.0, width=60.0, height=60.0)
-    overlay.rect_changed.emit(overlay.get_rect())
+    # Both positions keep the 48x77px pattern well inside the 768x512 frame:
+    # _move_patterns rejects the whole move if the pattern would fall outside it.
+    first_rect = _drag_fib_rect_to(overlay, cx=300.0, cy=300.0)
+    before = milling.config_widget.milling_stages_widget.get_enabled_stages()[0].pattern.point
+
+    second_rect = _drag_fib_rect_to(overlay, cx=500.0, cy=180.0)
 
     after = milling.config_widget.milling_stages_widget.get_enabled_stages()[0].pattern.point
     assert (after.x, after.y) != (before.x, before.y), (
         "dragging the FIB rect no longer moves the milling pattern"
     )
+    # ...and it tracked the rect, rather than landing somewhere of its own: the same
+    # displacement in metres, with Y inverted (image Y grows downward, stage Y upward).
+    pixel_size = widget.fib_canvas.canvas.pixel_size
+    assert np.isclose(after.x - before.x, (second_rect["cx"] - first_rect["cx"]) * pixel_size)
+    assert np.isclose(after.y - before.y, -(second_rect["cy"] - first_rect["cy"]) * pixel_size)
 
 
 def _main() -> int:


### PR DESCRIPTION
Fixes `test_coincidence_viewer_canvas.py::test_dragging_the_fib_rect_still_repositions_the_pattern`, which failed in every invocation mode — standalone, whole-file, whole-directory — on any machine that had run it before. It looked like test-order dependence; it is not.

## What was happening

`FluorescenceCoincidenceViewerWidget` restores `fibsem/config/coincidence-milling-config.yaml` over its built-in `DEFAULT_MILLING_TASK_CONFIG`, and a 1s `qdebounced` autosave plus `closeEvent` write it back.

So the test persisted its own drag target, and every run after that started *where the drag ends* — the assertion compared a value to itself:

```
before = (1.2083333333333335e-05, 7.916666666666668e-06)
after  = (1.2083333333333335e-05, 7.916666666666668e-06)
```

The file is gitignored (`.gitignore:47`) and per-checkout, so a clean tree looked innocent and one worktree could fail while another passed. A real poisoned copy carrying exactly those two values was found in another local worktree, which is what confirmed the mechanism.

## The change (test file only)

- `_coincidence_viewer()` points `COINCIDENCE_MILLING_CONFIG_PATH` at a throwaway file, so the viewer always starts from the built-in default. This also stops a test run overwriting a developer's real saved coincidence config — which it could previously do, since that autosave can fire whenever another test spins the event loop.
- The drag test establishes its own starting position with a first `rect_changed` emit, then drags to the original (500, 180) target, so the two are demonstrably different whatever the machine has saved.
- Added a check that the pattern *tracked* the rect — same displacement in metres, Y inverted — not merely that it moved.

Its purpose is unchanged: still the only coverage of `_on_fib_rect_changed` → `MillingTaskViewerWidget._move_patterns`, still on the FM-enabled configuration (without it `_connect_signals` returns at its first line and the test passes vacuously).

## Verification

Passes standalone and whole-file both with and without a poisoned config present. Also green: the whole test directory plus the sibling coincidence tests (71), all in-package `fibsem/ui` + `fibsem/applications` tests in one session (138), the CI suite `pytest tests/ -n auto` (4703), and the file's own `__main__` runner.

Mutation-tested — the test fails if the `_move_patterns` call is removed, and fails if the Y flip in `_on_fib_rect_changed` is dropped.

## Not addressed

The production side — a widget persisting user state into the package directory, where a test run can overwrite it — is FIB-336 territory and untouched here.