### PR TITLE
[ui] Draw an overview at the resolution it was acquired (FIB-658)

### DIFF
--- a/fibsem/imaging/reduce.py
+++ b/fibsem/imaging/reduce.py
@@ -25,7 +25,7 @@ import math
 import cv2
 import numpy as np
 
-__all__ = ["downsample"]
+__all__ = ["downsample", "downsample_mask"]
 
 
 # Element types `cv2.resize` accepts. Anything else takes the numpy path, which answers
@@ -96,3 +96,55 @@ def downsample(arr: np.ndarray, max_px: int) -> np.ndarray:
     if pad_h or pad_w:
         arr = cv2.copyMakeBorder(arr, 0, pad_h, 0, pad_w, cv2.BORDER_REPLICATE)
     return cv2.resize(arr, (out_w, out_h), interpolation=cv2.INTER_AREA)
+
+
+# 0 and 255 rather than 0 and 1, so the box mean carries eight bits of "how much of this
+# block is set". At 0/1 there is nothing left to carry it: `downsample` rounds an integer
+# box mean back to an integer, so every block collapses to 0 or 1 before it can be
+# thresholded, and which way a tie falls is then cv2's business rather than this
+# function's.
+_MASK_SET = 255
+# Half rounded *up*, so the comparison is "more than half" for a block whose coverage
+# lands exactly on the half. Coverage that spreads outward is the costly direction --
+# it claims ground as acquired that half of it was not -- so the tie resolves inward.
+_MASK_HALF = (_MASK_SET + 1) // 2
+
+
+def downsample_mask(mask: np.ndarray, max_px: int) -> np.ndarray:
+    """*mask* reduced like :func:`downsample`, a block surviving when most of it is set.
+
+    The companion to reducing the pixels: an overview is rarely complete, and what is
+    drawn has to be accompanied by where it holds anything, at the same shape. Averaging
+    a 0/1 field gives the fraction of each block that is set, and the block counts as
+    set when most of it is -- so a half-covered edge block resolves one way or the other
+    rather than spreading coverage into ground nothing was acquired over.
+
+    Kept here rather than written out at each caller for the memory, which is the whole
+    reason it exists as a function: the obvious spelling promotes to ``float32`` first,
+    which is **four bytes per source pixel of temporary** before anything is reduced.
+    Measured on a 10240x10240 mosaic -- a 10x10 of 1024 px tiles -- that is a peak of
+    524 MB against 210 MB here, and 124 ms against 55 ms. It is the source array that
+    sets that cost, not the output, so it grows with the mosaic while the thing it
+    produces does not.
+
+    Bit-identical to the float spelling on every mask this actually sees -- measured
+    across mosaic sizes, reduction factors and ragged final blocks, on hard-edged
+    acquired regions and on sparse tilesets alike, down to the last block. Eight bits
+    quantise the coverage fraction, so the two can only disagree where a block's
+    coverage lands within about 1/255 of exactly half, and a coverage mask does not do
+    that: its boundary is the straight edge of a tile, so a block on it is covered in
+    whole rows and its fraction moves in steps of 1/factor. Uniform noise at 50% is the
+    thing that lands in that band, and it disagrees there readily (6% of blocks at
+    factor 13) -- which is worth knowing before reaching for this to reduce something
+    that is not a coverage mask.
+
+    Reduce the mask, never the pixels-then-threshold: box-averaging intensities and
+    testing the result for "greater than zero" marks a block as acquired when *any* of
+    it is, which is a different and far more generous rule.
+    """
+    mask = np.asarray(mask)
+    if mask.dtype != np.bool_:
+        raise TypeError(f"expected a boolean mask, got {mask.dtype}")
+    # `view` rather than `astype`: a bool array is already one byte per element, so this
+    # reinterprets 0/1 in place and the multiply is the only array allocated.
+    return downsample(mask.view(np.uint8) * np.uint8(_MASK_SET), max_px) > _MASK_HALF

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -805,7 +805,7 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         Runs on every layer change, once per held image per channel, so it is the one
         place where that per-call cost is multiplied. Watch it if either count grows.
         """
-        return downsample(np.asarray(plane), self.canvas._display_max_px)
+        return downsample(np.asarray(plane), self.canvas.display_max_px)
 
     def _composite_inputs(self) -> Tuple[List[FMLayer], Optional[Tuple[int, int]]]:
         """Blend at display resolution, not acquisition resolution.

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -43,13 +43,19 @@ _logger = logging.getLogger(__name__)
 
 _DEFAULT_BACKGROUND = GRAY_CANVAS_COLOR  # empty space reads as "nothing acquired here"
 
-# Pixels kept per placed image. Every artist is redrawn in full on each pan/zoom, so a
-# redraw costs the *total* stored pixels — 100 tiles kept at 1024 px square take ~2.7 s,
-# against ~0.75 s at 512. And 512 is already more than the display can use for the case
-# this canvas exists for: tiles in a 3x3 occupy ~330 screen px each, in a 10x10 ~100 px.
-# The reduction box-averages, so the cap costs resolution and nothing else — a feature
-# smaller than a stored pixel is dimmed into its neighbours rather than dropped. What it
-# still cannot do is give the detail back on zoom; that is FIB-414, the pyramid.
+# Pixels handed to matplotlib per placed image — a *drawing* cost, and only that. Every
+# artist is redrawn in full on each pan/zoom, so a redraw costs the total drawn pixels:
+# measured on one RGBA artist, ~29 ms plus ~11 ms per megapixel, which is 100 tiles at
+# 1024 px square taking ~2.7 s against ~0.75 s at 512. And 512 is already more than the
+# display can use for the case this canvas exists for: tiles in a 3x3 occupy ~330 screen
+# px each, in a 10x10 ~100 px.
+#
+# Distinct from how much a *caller* keeps. A caller that holds more than this can hand
+# over a different part of it, or a different resolution of it, as the view moves — and
+# that is the only way the detail comes back on zoom, since matplotlib resamples the
+# whole array however little of it is on screen (1% of a 5120 px artist costs 321 ms
+# against 335 ms for all of it). Reducing here is the floor under callers that do not:
+# the reduction box-averages, so it costs resolution and nothing else.
 _DEFAULT_DISPLAY_PX = 512
 
 
@@ -105,6 +111,8 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         # Raise this for a canvas holding only a handful of images, where per-image
         # detail matters more than redraw cost. See _DEFAULT_DISPLAY_PX.
         self._display_max_px = int(display_max_px)
+        if self._display_max_px <= 0:
+            raise ValueError(f"display_max_px must be positive, got {display_max_px!r}")
         self._placed: Dict[str, PlacedImage] = {}
         self._reference_pixel_size: Optional[float] = reference_pixel_size
         # Optional (width, height, cx, cy) in metres — see set_world_extent.
@@ -140,6 +148,17 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
     def reference_pixel_size(self) -> Optional[float]:
         """Metres per canvas pixel, or None until the first image sets it."""
         return self._reference_pixel_size
+
+    @property
+    def display_max_px(self) -> int:
+        """The most pixels this canvas will draw of any one image. See the constant.
+
+        Public because callers legitimately need it: one that reduces before handing an
+        image over — to blend at display resolution, or to keep what it placed — wants
+        to reduce to the same figure rather than guess at it. Read-only, because the
+        extents of everything already placed were computed against the current one.
+        """
+        return self._display_max_px
 
     @property
     def placed_keys(self) -> List[str]:

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -26,10 +26,11 @@ a single image has axes in that image's own pixels.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple
 
 import numpy as np
+from PyQt5.QtCore import QTimer
 
 from fibsem.imaging.reduce import downsample
 from fibsem.ui.stylesheets import GRAY_CANVAS_COLOR
@@ -58,6 +59,24 @@ _DEFAULT_BACKGROUND = GRAY_CANVAS_COLOR  # empty space reads as "nothing acquire
 # the reduction box-averages, so it costs resolution and nothing else.
 _DEFAULT_DISPLAY_PX = 512
 
+# How far past the viewport a detail patch reaches, as a fraction of the viewport on each
+# side. A pan inside the margin is already drawn, so it costs nothing; one past it waits
+# for the next refresh. Small on purpose -- the margin is paid for in resolution, since a
+# patch covering 1.5x the viewport spends its budget over 1.5x the ground, and refetching
+# is cheap enough (single-digit ms) that buying fewer fetches with blur is a bad trade.
+_DETAIL_MARGIN = 0.25
+
+# Coalescing interval for detail refreshes, in ms. Longer than the 32 ms redraw on
+# purpose: a pan emits a limit change per mouse move, and re-deriving on each would do
+# the work tens of times over for one gesture. What the delay costs is that the instant
+# after a large jump is drawn from the previous patch, stretched, until this fires.
+_DETAIL_INTERVAL = 120
+
+# How far below the screen's own resolution a patch may fall before it is refetched. Not
+# 1.0, because an exact comparison refetches on any zoom whatsoever -- including the
+# sub-pixel drift a resize produces -- and a tenth of a screen pixel is not visible.
+_DETAIL_TOLERANCE = 0.9
+
 
 def _require_displayable(data: np.ndarray) -> None:
     """Reject anything that is not a single displayable picture, before anything mutates.
@@ -82,13 +101,71 @@ def _require_displayable(data: np.ndarray) -> None:
     )
 
 
+class ImageRegion(NamedTuple):
+    """A sub-rectangle of one placed image, as fractions of its own footprint.
+
+    ``(0, 1, 0, 1)`` is the whole image, and ``top < bottom`` because this canvas's y
+    runs down.
+
+    Fractions rather than metres or array indices, so a source can be asked for part of
+    itself without knowing what the canvas draws in, what scale it is at, or how large
+    the source's own array is. That is what lets one protocol serve an array held in
+    memory and a mosaic still on disk.
+    """
+
+    left: float
+    right: float
+    top: float
+    bottom: float
+
+    @property
+    def width(self) -> float:
+        return self.right - self.left
+
+    @property
+    def height(self) -> float:
+        return self.bottom - self.top
+
+    def contains(self, other: "ImageRegion") -> bool:
+        """Whether *other* falls wholly inside this one."""
+        return (
+            self.left <= other.left
+            and self.right >= other.right
+            and self.top <= other.top
+            and self.bottom >= other.bottom
+        )
+
+
+WHOLE_IMAGE = ImageRegion(0.0, 1.0, 0.0, 1.0)
+
+# Asked for part of an image and a pixel budget; answers with the pixels and the part it
+# actually gave. The two regions differ because a source snaps outward to whole pixels of
+# whatever it holds — returning the region rather than assuming it is what was asked for
+# is what keeps a patch drawn exactly over the ground it came from, instead of a fraction
+# of a pixel off. Returning None declines, leaving whatever is already drawn alone.
+DetailSource = Callable[
+    [ImageRegion, int], Optional[Tuple[np.ndarray, ImageRegion]]
+]
+
+
 @dataclass
 class PlacedImage:
     """One image on the canvas, with the extent it was drawn at (canvas pixels)."""
 
     key: str
     artist: object
+    # The image's *whole* footprint, which is what the canvas fits and frames against —
+    # never the part of it currently in the artist. Keeping the two separate is what
+    # lets a detail patch change under the view without the view chasing it.
     extent: Tuple[float, float, float, float]  # (xmin, xmax, ymax, ymin)
+    detail: Optional[DetailSource] = None
+    drawn: ImageRegion = field(default=WHOLE_IMAGE)
+    # The pixel budget the patch in the artist was fetched at -- what was *asked* for,
+    # not what came back. A source routinely returns less: `downsample` reduces by whole
+    # factors, so a 616 px slice asked for at 256 comes back at 206. Comparing the next
+    # request against what arrived rather than against what was requested makes every
+    # patch look deficient, and re-asking returns the identical array, forever.
+    asked_px: int = 0
 
 
 class FibsemRealSpaceCanvas(FibsemCanvasBase):
@@ -127,6 +204,17 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         # meaning is "frame it for me again".
         self.auto_fit: bool = True
         self._fitted_extent: Optional[Tuple[float, float, float, float]] = None
+
+        # Detail refresh: coalesced, because the thing that provokes it is a gesture.
+        self._detail_timer = QTimer(self)
+        self._detail_timer.setSingleShot(True)
+        self._detail_timer.setInterval(_DETAIL_INTERVAL)
+        self._detail_timer.timeout.connect(self.refresh_detail)
+        # Off the limits themselves rather than off the pan and zoom handlers: a refit, a
+        # resize, and an owner driving the camera all change what is on screen without
+        # going near either handler, and every one of them wants a fresh patch.
+        self._ax.callbacks.connect("xlim_changed", self._on_limits_changed)
+        self._ax.callbacks.connect("ylim_changed", self._on_limits_changed)
 
         if reference_pixel_size:
             self._pixel_size = reference_pixel_size  # drives the scalebar
@@ -176,6 +264,7 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         cmap: str = "gray",
         zorder: Optional[float] = None,
         covers: Optional[Tuple[float, float]] = None,
+        detail: Optional[DetailSource] = None,
     ) -> str:
         """Place *data* centred on *centre* (metres), at *pixel_size* metres/px.
 
@@ -194,6 +283,12 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         at display resolution — so it is placed at the size it represents rather than
         the size it is stored at. *pixel_size* then describes the source, and still
         decides how this image sorts against others by detail.
+
+        *detail* offers a caller that holds more than *data* shows. Given one, the canvas
+        asks it for the part of the image on screen at the resolution the screen can use,
+        and asks again as the view moves; *data* is then the whole-image fallback that is
+        drawn until the first patch arrives and whenever the source declines. Without
+        one, *data* is all there is and is drawn as-is, which is every caller today.
         """
         data = np.asarray(data)
         _require_displayable(data)
@@ -225,9 +320,16 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
             cmap=cmap if shown.ndim == 2 else None,
             **kw,
         )
-        self._placed[key] = PlacedImage(key=key, artist=artist, extent=extent)
+        self._placed[key] = PlacedImage(
+            key=key, artist=artist, extent=extent, detail=detail,
+            drawn=WHOLE_IMAGE, asked_px=int(max(shown.shape[:2])),
+        )
 
+        # Framing first: what the screen can show of an image depends on where the camera
+        # is, and adding this one may well have moved it.
         self._after_content_change()
+        if detail is not None:
+            self.refresh_detail()
         return key
 
     def update_image(self, key: str, data: np.ndarray) -> bool:
@@ -240,13 +342,27 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
 
         Returns False if *key* was not placed. The shape may change; the image keeps its
         extent, so different-shaped data is stretched over the same ground.
+
+        *data* is the whole image, so this puts the artist back to the whole footprint
+        even if a detail patch had it cropped to part of one — otherwise the new pixels
+        would be stretched over the old patch's ground. A fresh patch is then asked for,
+        since the source has presumably changed underneath too.
         """
         placed = self._placed.get(key)
         if placed is None:
             return False
         data = np.asarray(data)
         _require_displayable(data)
-        placed.artist.set_data(downsample(data, self._display_max_px))
+        shown = downsample(data, self._display_max_px)
+        placed.artist.set_data(shown)
+        if placed.drawn != WHOLE_IMAGE:
+            placed.artist.set_extent(placed.extent)
+        placed.drawn, placed.asked_px = WHOLE_IMAGE, int(max(shown.shape[:2]))
+        if placed.detail is not None:
+            # Scheduled, not immediate: this is the per-frame call during a live
+            # acquisition, and fetching synchronously on each frame is the cost the
+            # detail pass exists to avoid.
+            self._detail_timer.start()
         self.draw_idle()
         return True
 
@@ -324,6 +440,18 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         self._ax.set_aspect("equal", adjustable="box")
         if not self._ax.yaxis_inverted():
             self._ax.invert_yaxis()
+        # Autoscale off, because `AxesImage.set_extent` moves the camera while it is on:
+        # it ends in `set_xlim`/`set_ylim` onto the artist's own extent. That matters
+        # here and nowhere else, because the detail pass re-extents an artist on every
+        # view change -- so with autoscale on, looking at one image would frame it, and
+        # frame it again, and never settle.
+        #
+        # A no-op in every path that already existed: `set_xlim` clears the flag itself,
+        # so the first `_fit_view` turned autoscale off anyway and nothing has been
+        # relying on it since. This closes the one window where it is still on -- a fresh
+        # or just-cleared axes, which is also where `cla()` puts it back, hence setting it
+        # here rather than once in the constructor.
+        self._ax.set_autoscale_on(False)
 
     def set_reference_pixel_size(self, pixel_size: float) -> bool:
         """Fix the canvas scale before anything is placed.
@@ -424,6 +552,185 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         # Adopt what was just fitted, so the next content change is measured against
         # this framing rather than against whatever was fitted before the user's zoom.
         self._fitted_extent = self._fit_extent()
+
+    # ── detail: drawing what the view can use, not what the caller holds ──
+
+    def _on_limits_changed(self, _axes=None) -> None:
+        """The view moved; whatever is drawn may no longer be the right part of it."""
+        if self._placed and any(p.detail is not None for p in self._placed.values()):
+            self._detail_timer.start()
+
+    def refresh_detail(self, force: bool = False) -> None:
+        """Ask every source for the part of itself now worth drawing.
+
+        Called by the canvas itself whenever the view moves. Public for *force*, which
+        is the other way a patch goes stale: the source's own content changed under it —
+        a contrast curve, a re-blend, a new frame — which the view knows nothing about,
+        so none of the usual tests would notice.
+
+        Deliberately *not* a content change: an image's footprint is unchanged by which
+        part of it is in the artist, so nothing here refits, and `PlacedImage.extent`
+        stays the whole image throughout. That is what keeps this from chasing its own
+        tail -- a refit would move the limits, which would schedule another refresh.
+        """
+        changed = False
+        for placed in list(self._placed.values()):
+            if placed.detail is None:
+                continue
+            if not placed.artist.get_visible():
+                # Hiding an image is how a caller takes it out of the redraw cost
+                # (`set_image_visible`); fetching patches for it would put it back.
+                continue
+            # Two regions, and the difference between them is the whole of the margin.
+            # What has to be *covered* is the viewport itself; what gets *fetched* reaches
+            # past it. Testing coverage against the reaching one would compare a margin
+            # with a margin, so every pan of any size would fail it and the margin would
+            # buy exactly nothing.
+            wanted = self._visible_region(placed)
+            if wanted is None:
+                continue  # off screen: leave the last patch, it costs nothing to keep
+            fetch = self._visible_region(placed, margin=_DETAIL_MARGIN) or wanted
+            budget = self._detail_budget(placed, fetch)
+            if not force and not self._needs_detail(placed, wanted, fetch, budget):
+                continue
+            try:
+                answer = placed.detail(fetch, budget)
+            except Exception as e:
+                # A source that raises must not take the canvas with it: this runs off a
+                # timer, and PyQt5 aborts the process on an exception out of a slot
+                # (FIB-329). What is already drawn stays drawn.
+                _logger.debug(f"Detail source for {placed.key!r} failed: {e}")
+                continue
+            if answer is None:
+                continue
+            data, got = answer
+            if self._draw_patch(placed, data, got, budget):
+                changed = True
+        if changed:
+            self.draw_idle()
+
+    def _visible_region(
+        self, placed: PlacedImage, margin: float = 0.0
+    ) -> Optional[ImageRegion]:
+        """Which part of *placed* the viewport covers, reaching *margin* past it, or None.
+
+        None means none of it: no patch is worth fetching for an image that is not on
+        screen, and the one it already has is the right thing to keep in case it comes
+        back.
+        """
+        xmin, xmax, ymax, ymin = placed.extent
+        width, height = xmax - xmin, ymax - ymin
+        if width <= 0 or height <= 0:
+            return None
+        (vx0, vx1), (vy0, vy1) = self._ax.get_xlim(), self._ax.get_ylim()
+        # y runs down, so the axes' limits arrive bottom-first.
+        vy0, vy1 = min(vy0, vy1), max(vy0, vy1)
+        vx0, vx1 = min(vx0, vx1), max(vx0, vx1)
+        mx, my = margin * (vx1 - vx0), margin * (vy1 - vy0)
+        left = max(xmin, vx0 - mx)
+        right = min(xmax, vx1 + mx)
+        top = max(ymin, vy0 - my)
+        bottom = min(ymax, vy1 + my)
+        if right <= left or bottom <= top:
+            return None
+        return ImageRegion(
+            (left - xmin) / width, (right - xmin) / width,
+            (top - ymin) / height, (bottom - ymin) / height,
+        )
+
+    def _detail_budget(self, placed: PlacedImage, region: ImageRegion) -> int:
+        """The most pixels worth fetching for *region*: what the screen can show of it.
+
+        Bounded by the display cap, so this can only ever ask for less than drawing the
+        whole image would. That is the property that makes cost track the *window* rather
+        than the data -- an image occupying a corner of the canvas is budgeted for a
+        corner's worth, however large the thing behind it is.
+        """
+        xmin, xmax, _, _ = placed.extent
+        span = self._ax.get_xlim()
+        canvas_span = abs(span[1] - span[0])
+        if canvas_span <= 0:
+            return self._display_max_px
+        # Device pixels the region occupies across the axes, at the current scale.
+        across = (xmax - xmin) * region.width / canvas_span * max(1, self._axes_width_px())
+        return int(max(1, min(self._display_max_px, np.ceil(across))))
+
+    def _axes_width_px(self) -> int:
+        """The axes' width in device pixels — what "as much as the screen can use" is."""
+        try:
+            return int(self._ax.get_window_extent().width)
+        except Exception:  # pragma: no cover - before the first draw
+            return self.width()
+
+    def _needs_detail(
+        self,
+        placed: PlacedImage,
+        wanted: ImageRegion,
+        fetch: ImageRegion,
+        budget: int,
+    ) -> bool:
+        """Whether fetching *fetch* would beat the patch already in the artist.
+
+        Two ways it would. The view moved somewhere the patch does not cover — *wanted*,
+        the bare viewport, so the margin is what absorbs an ordinary pan. Or the patch is
+        coarser than what a fetch would now deliver, which is what zooming in produces.
+
+        Asked as "would this be sharper", not as "is this as sharp as the screen wants",
+        and the difference matters at the display cap. Past a certain zoom the budget
+        clamps, so a patch reaching past the viewport can never resolve the visible part
+        at the screen's full resolution — the margin's ground is spending some of the
+        cap. Against the absolute standard that is permanently unsatisfied, and every
+        view change refetches an identical array forever. Against what a fetch would
+        actually give, a clamped budget compares equal and nothing happens.
+
+        Nothing asks whether the patch is *finer* than needed: zooming out grows *wanted*
+        past what is drawn, so that case is already the first one.
+        """
+        if not placed.drawn.contains(wanted):
+            return True
+        if placed.drawn.width <= 0 or fetch.width <= 0:
+            return True
+        # Pixels per unit of image, which is comparable across differently-sized regions.
+        have = placed.asked_px / placed.drawn.width
+        would = budget / fetch.width
+        return would > have / _DETAIL_TOLERANCE
+
+    def _draw_patch(
+        self, placed: PlacedImage, data: np.ndarray, region: ImageRegion, budget: int
+    ) -> bool:
+        """Put *data* in the artist over the ground *region* names. False if unusable.
+
+        The extent comes from the region the source says it *gave*, not the one it was
+        asked for: a source snaps outward to whole pixels of what it holds, and drawing
+        the requested rectangle instead would place the patch a fraction of a pixel off
+        its own ground — which on a canvas whose whole point is that images line up
+        would show as a seam every time the view moved.
+        """
+        data = np.asarray(data)
+        try:
+            _require_displayable(data)
+        except ValueError as e:
+            _logger.debug(f"Detail source for {placed.key!r} returned {e}")
+            return False
+        if not (0.0 <= region.left < region.right <= 1.0):
+            _logger.debug(f"Detail source for {placed.key!r} gave x outside itself")
+            return False
+        if not (0.0 <= region.top < region.bottom <= 1.0):
+            _logger.debug(f"Detail source for {placed.key!r} gave y outside itself")
+            return False
+
+        xmin, xmax, ymax, ymin = placed.extent
+        width, height = xmax - xmin, ymax - ymin
+        placed.artist.set_data(downsample(data, self._display_max_px))
+        placed.artist.set_extent((
+            xmin + region.left * width,
+            xmin + region.right * width,
+            ymin + region.bottom * height,  # matplotlib takes (left, right, bottom, top)
+            ymin + region.top * height,
+        ))
+        placed.drawn = region
+        placed.asked_px = budget
+        return True
 
     def metres_to_canvas(self, x: float, y: float) -> Tuple[float, float]:
         """Convert a position in metres to canvas coordinates.
@@ -610,6 +917,10 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
             self._fit_view()
         else:
             self._keep_scale_through_resize(event.oldSize(), event.size())
+        # Kicked directly as well as through the limits: how many pixels the screen can
+        # use is the widget's size, and a resize can leave the limits untouched (the
+        # first one, which has no "before" to keep the scale against) while changing it.
+        self._on_limits_changed()
         self.draw_idle()
 
     def _keep_scale_through_resize(self, old, new) -> None:

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -62,7 +62,7 @@ from superqt import ensure_main_thread
 from fibsem import constants
 from fibsem.fm.composite import auto_clim
 from fibsem.imaging import tiled
-from fibsem.imaging.reduce import downsample
+from fibsem.imaging.reduce import downsample, downsample_mask
 from fibsem.microscope import FibsemMicroscope
 from fibsem.projection import BeamStageProjection
 from fibsem.structures import (
@@ -1491,13 +1491,19 @@ class FibsemOverviewWidget(QWidget):
         max_px = self.canvas._display_max_px
         # What was acquired, and where black is, both come off the *unfiltered* array --
         # `filtered_data` smears the boundary in both directions and would answer either
-        # question wrong. Reduced the same way as the pixels so the three line up; box
-        # meaning a 0/1 field gives the fraction of each block that holds anything, and a
-        # block counts as acquired when most of it does.
-        raw = downsample(np.asarray(image.data, dtype=np.float32), max_px)
-        acquired = downsample(
-            (np.asarray(image.data) > 0).astype(np.float32), max_px
-        ) > 0.5
+        # question wrong. Reduced the same way as the pixels so the three line up.
+        #
+        # In the source's own dtype rather than promoted to float32 first, and the same
+        # for the mask: promoting is four bytes per *source* pixel of temporary, so the
+        # cost tracks the mosaic rather than the few megabytes that come out of it, and
+        # it was being spent twice over. Measured on a 10x10 of 1024 px tiles, the two
+        # reductions together were 541 MB and 207 ms; they are 218 MB and 38 ms here,
+        # for a bit-identical mask and the same contrast limits. `downsample` preserves
+        # dtype and answers for every one; only a dtype cv2 refuses takes the slow path,
+        # and beam images are uint8 or uint16.
+        source = np.asarray(image.data)
+        raw = downsample(source, max_px)
+        acquired = downsample_mask(source > 0, max_px)
         clim = _contrast_limits(raw, acquired)
         return _PlacedTile(
             data=_as_colour_and_coverage(downsample(data, max_px), acquired, clim),

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -34,11 +34,12 @@ channel (FIB-544, FIB-600).
 from __future__ import annotations
 
 import logging
+import math
 import os
 import threading
 from copy import deepcopy
 from functools import partial
-from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
+from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
 
 import numpy as np
 from PyQt5.QtCore import pyqtSignal, pyqtSlot
@@ -101,7 +102,11 @@ from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
 from fibsem.ui.widgets.canvas.overlays.gridbar_overlay import GridBarOverlay
 from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import TileGridOverlay
 from fibsem.ui.widgets.canvas.overlays.point_overlay import PointsOverlay
-from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
+from fibsem.ui.widgets.canvas.real_space_canvas import (
+    WHOLE_IMAGE,
+    FibsemRealSpaceCanvas,
+    ImageRegion,
+)
 from fibsem.ui.widgets.canvas.stage_frame import StageFrame
 from fibsem.ui.widgets.custom_widgets import (
     ContextMenu,
@@ -230,7 +235,10 @@ def _contrast_limits(values: np.ndarray, acquired: np.ndarray) -> Tuple[float, f
 
 
 def _as_colour_and_coverage(
-    data: np.ndarray, acquired: np.ndarray, clim: Tuple[float, float]
+    data: np.ndarray,
+    acquired: np.ndarray,
+    clim: Tuple[float, float],
+    curve: Optional[Callable[[np.ndarray], np.ndarray]] = None,
 ) -> np.ndarray:
     """Re-express a grayscale overview as colour plus where it holds anything.
 
@@ -266,6 +274,14 @@ def _as_colour_and_coverage(
     stay exactly zero, which is the thing being asked about. An image small enough to be
     placed unreduced keeps that speckle, and it shows only where another overview lies
     beneath it.
+
+    *curve* is the user's contrast and gamma, applied to the stretched values on the way
+    through. Folded in here rather than run over the result because this is called on the
+    *patch being drawn* -- a screen's worth -- where a separate pass over the finished
+    RGBA would be a second normalise and a second copy of the whole mosaic. **Alpha is
+    never curved.** Contrast says how bright what was acquired should look; it must not
+    decide what *was* acquired, and passing alpha through the same curve would fade a
+    region out as the maximum came down and paint unacquired ground in as it went up.
     """
     values = np.asarray(data, dtype=np.float32)
     out = np.zeros((*values.shape[:2], 4), dtype=np.uint8)
@@ -274,23 +290,38 @@ def _as_colour_and_coverage(
 
     lo, hi = clim
     norm = np.clip((values - lo) / (hi - lo), 0.0, 1.0)
+    if curve is not None:
+        norm = np.clip(curve(norm), 0.0, 1.0)
     out[..., :3] = (norm * 255.0).astype(np.uint8)[..., None]
     out[..., 3] = np.where(acquired, 255, 0)
     return out
 
 
 class _PlacedTile(NamedTuple):
-    """One image a record placed: the pixels, where it was taken, and what it covers.
+    """One image a record placed: what it holds, where it was taken, what it covers.
+
+    The *ingredients* of a picture rather than a picture. Colouring and the user's
+    contrast curve both happen at draw time, on the part being drawn, and that is the
+    whole point of the split: a finished RGBA can only be shown at the resolution it was
+    finished at, so a zoom has nothing to reveal and a contrast change costs a pass over
+    the entire mosaic instead of over a screenful.
+
+    `clim` is measured once over the whole image and then kept. Deliberately not
+    re-measured per patch: limits taken from whatever is currently on screen would make
+    the picture change brightness as you pan across it, which is a worse fault than the
+    one the split is fixing.
 
     `covers` is the ground in metres, measured from the image's *original* shape before
-    reduction. It has to be carried rather than re-derived, because `data` is decimated
-    for display: the canvas sizes an image from `shape x pixel_size` unless told
-    otherwise, so a 1024 px tile stored at 512 px was drawn covering half the ground it
-    actually images -- a mosaic with black gaps between every tile, at the right
-    positions and the wrong size.
+    reduction. It has to be carried rather than re-derived, because `grey` is decimated:
+    the canvas sizes an image from `shape x pixel_size` unless told otherwise, so a
+    1024 px tile stored at 512 px was drawn covering half the ground it actually images
+    -- a mosaic with black gaps between every tile, at the right positions and the wrong
+    size.
     """
 
-    data: object  # np.ndarray, display-reduced RGBA -- see `_as_colour_and_coverage`
+    grey: object  # np.ndarray, the filtered image reduced to the store cap
+    acquired: object  # np.ndarray of bool, same shape -- where anything was acquired
+    clim: Tuple[float, float]
     position: FibsemStagePosition
     pixel_size: float
     covers: Tuple[float, float]  # (width, height) in metres
@@ -449,7 +480,6 @@ class FibsemOverviewWidget(QWidget):
         # Canvas key -> the *base* tile behind it, the auto-stretched one. Contrast is
         # applied on the way to the canvas and never written back here, so moving a
         # slider twice adjusts the original twice rather than compounding.
-        self._tiles: Dict[str, "_PlacedTile"] = {}
         # Stage position the canvas frame is built around. Fixed once and kept:
         # re-deriving it from whatever arrived last would shift the whole scene each
         # time a tile landed. Taken from the first image placed.
@@ -518,33 +548,33 @@ class FibsemOverviewWidget(QWidget):
     # ── layout ───────────────────────────────────────────────────────────
 
     def _init_ui(self) -> None:
-        # Two caps, deliberately, and the same number today. They answer different
-        # questions and will diverge:
+        # Two bounds, answering two different questions:
         #
-        #   `_store_max_px`  -- the finest this widget ever *holds* an overview at, so
-        #                       the ceiling on any detail a zoom could ever recover. A
-        #                       memory bound.
-        #   `display_max_px` -- the most the canvas ever *hands matplotlib*, which is
-        #                       paid on every frame at every zoom. A redraw bound.
+        #   `_store_budget_bytes` -- how much memory one overview may occupy, and so the
+        #                            ceiling on any detail a zoom could ever recover.
+        #   `display_max_px`      -- the most the canvas ever hands matplotlib, paid on
+        #                            every frame at every zoom. A redraw bound.
         #
-        # Holding no more than is drawn is what makes "don't downscale the actual image"
-        # impossible right now: the detail is gone before the canvas sees it, so zooming
-        # cannot bring back what was never kept. Splitting the two is the groundwork for
-        # keeping more than is drawn and choosing, per view, which part of it to draw.
+        # Held no finer than drawn, "don't downscale the actual image" has no answer at
+        # all: the detail would be gone before the canvas saw it. Held finer, the canvas
+        # asks for the part on screen at the resolution the screen can use, and a zoom
+        # reveals rather than magnifies.
         #
-        # 2048 is chosen for the drawing half. At 512 a 5x5 of 1024 px tiles was reduced
-        # tenfold and then magnified back onto a ~1100 px wide canvas, so every stored
-        # pixel was drawn as a 2x2 block; 2048 is the first power of two past the canvas's
-        # own width, which is what stops the magnification. A cap, not a target --
-        # `downsample` reduces by an integer factor, so that 5x5 lands at 1707 px.
+        # The store bound is bytes rather than pixels because bytes are the thing being
+        # spent. A pixel cap prices the same setting at 52 MB for a mosaic of 1024 px
+        # tiles and 118 MB for one of 3072 px tiles, and silently costs 50% more again on
+        # a uint16 detector. It is also a *ceiling*, not an allocation: `downsample`
+        # reduces by whole factors, so an overview that fits is held whole and one that
+        # does not drops to the next factor. At 128 MB every 1024 px-tile mosaic up to
+        # 5x5 is held at full acquired resolution -- which is what the complaint behind
+        # FIB-658 was asking for -- and a 10x10 lands at 5120 px for 52 MB.
         #
-        # Measured on one RGBA artist: a redraw costs ~29 ms plus ~11 ms per megapixel,
-        # so this takes a pan from 29 ms to 74 ms, a contrast step from 17 ms to 69 ms,
-        # and holds 17 MB per overview. Raising it further is worse than it looks --
-        # matplotlib resamples the whole array however little of it is on screen (1% of a
-        # 5120 px artist still costs 321 ms against 335 ms for all of it) -- which is
-        # exactly why the drawn size is the thing to bound and the held size is not.
-        self._store_max_px = 2048
+        # 2048 is the drawing half. At 512 a 5x5 of 1024 px tiles was reduced tenfold and
+        # then magnified back onto a ~1100 px wide canvas, so every stored pixel was
+        # drawn as a 2x2 block. 2048 is the first power of two past the canvas's own
+        # width, which is what stops the magnification; the detail pass keeps well under
+        # it in practice, asking only for what the axes can show.
+        self._store_budget_bytes = 128_000_000
         self.canvas = FibsemRealSpaceCanvas(display_max_px=2048)
         self.canvas.canvas_clicked.connect(self._on_canvas_clicked)
         self.canvas.canvas_double_clicked.connect(self._on_canvas_double_clicked)
@@ -1326,8 +1356,6 @@ class FibsemOverviewWidget(QWidget):
             return False
         self._current_view = view
         self.canvas.clear_images()
-        # Re-placement mints new keys, so the old ones describe nothing.
-        self._tiles.clear()
         for record in self._records.values():
             record.keys = []
             if record.view != view:
@@ -1415,37 +1443,61 @@ class FibsemOverviewWidget(QWidget):
         """Show or hide the floating contrast popover, anchored under its button."""
         self.contrast_control.set_open(self.btn_contrast.isChecked(), self.btn_contrast)
 
-    def _for_display(self, tile: "_PlacedTile") -> np.ndarray:
-        """A placed tile with the user's contrast applied, or the tile itself.
+    def _patch(
+        self, tile: "_PlacedTile", region: ImageRegion, max_px: int
+    ) -> Tuple[np.ndarray, ImageRegion]:
+        """The part of *tile* that *region* names, coloured, at most *max_px* across.
 
-        The stored array is colour plus coverage, where the colour channels hold the
-        auto-stretched grayscale (`_as_colour_and_coverage`). So the picture to adjust is
-        already there, in any one of them, normalised to 0..1 -- which is exactly what
-        `ContrastGammaControl.apply` takes.
+        What the canvas asks for as the view moves, and the whole of what phase 2 bought:
+        the reduction factor is set by how much of the image is on screen rather than by
+        how large the image is, so zooming in reveals detail instead of magnifying stored
+        pixels.
 
-        **Alpha is not touched.** Contrast says how bright what was acquired should look;
-        it must not decide what *was* acquired. Passing the alpha through the same curve
-        would make a region fade out as the maximum came down, and unacquired ground
-        appear as it went up.
+        Snapped outward to whole stored pixels, and the region *actually* covered is
+        returned rather than the one asked for -- the canvas draws the patch at the
+        rectangle this names, and a fractional-pixel disagreement between the two would
+        show as a seam every time the view moved.
+
+        The mask is reduced by its own rule rather than alongside the pixels, because
+        "was anything acquired in this block" is a different question from "how bright is
+        this block" and box-averaging answers only the second.
         """
-        base = tile.data
-        if self.contrast_control.is_default():
-            return base
-        norm = base[..., 0].astype(np.float32) / 255.0
-        adjusted = np.clip(self.contrast_control.apply(norm), 0.0, 1.0)
-        shown = base.copy()
-        shown[..., :3] = (adjusted * 255.0).astype(np.uint8)[..., None]
-        return shown
+        grey, acquired = tile.grey, tile.acquired
+        height, width = grey.shape[0], grey.shape[1]
+        x0 = min(max(0, int(np.floor(region.left * width))), width - 1)
+        y0 = min(max(0, int(np.floor(region.top * height))), height - 1)
+        x1 = min(width, max(int(np.ceil(region.right * width)), x0 + 1))
+        y1 = min(height, max(int(np.ceil(region.bottom * height)), y0 + 1))
+        curve = None if self.contrast_control.is_default() else self.contrast_control.apply
+        drawn = _as_colour_and_coverage(
+            downsample(grey[y0:y1, x0:x1], max_px),
+            downsample_mask(acquired[y0:y1, x0:x1], max_px),
+            tile.clim,
+            curve,
+        )
+        return drawn, ImageRegion(x0 / width, x1 / width, y0 / height, y1 / height)
+
+    def _for_display(self, tile: "_PlacedTile") -> np.ndarray:
+        """The whole of *tile* at display resolution.
+
+        The fallback the canvas draws until the first patch arrives, and whatever it
+        falls back to if the source ever declines.
+        """
+        return self._patch(tile, WHOLE_IMAGE, self.canvas.display_max_px)[0]
 
     def _reapply_contrast(self) -> None:
         """Redraw every placed image through the current contrast.
 
-        `update_image` rather than re-placing: re-adding under the same key destroys and
-        recreates the artist, which moves it to the top of the draw order -- so adjusting
-        contrast would silently reorder overlapping overviews.
+        Through the sources rather than by re-placing: re-adding under the same key
+        destroys and recreates the artist, which moves it to the top of the draw order --
+        so adjusting contrast would silently reorder overlapping overviews.
+
+        Forced, because nothing about the *view* changed and none of the canvas's usual
+        tests would notice. The curve now runs over the patch being drawn rather than
+        over the whole mosaic, which is what takes a contrast step off the size of the
+        overview and onto the size of the window.
         """
-        for key, tile in self._tiles.items():
-            self.canvas.update_image(key, self._for_display(tile))
+        self.canvas.refresh_detail(force=True)
 
     def _place_on_canvas(
         self, tile: "_PlacedTile", view: "OverviewView",
@@ -1465,16 +1517,16 @@ class FibsemOverviewWidget(QWidget):
         except Exception as e:
             logger.debug(f"Could not place an image: {e}")
             return None
-        placed = self.canvas.add_image(
+        return self.canvas.add_image(
             self._for_display(tile), centre=centre, pixel_size=tile.pixel_size,
             key=key, zorder=zorder, covers=tile.covers,
+            # Bound to this tile, and the canvas holds it for as long as the image is
+            # placed -- so a contrast change reaches every placed image without walking
+            # the records, which would miss the acquisition preview, the one thing on
+            # the canvas that has no record. Removing the image drops the source and the
+            # tile with it, which a dictionary kept alongside had to be told to do.
+            detail=lambda region, max_px, tile=tile: self._patch(tile, region, max_px),
         )
-        if placed is not None:
-            # Keyed by what the canvas is holding, so a contrast change can reach every
-            # placed image without walking the records -- which would miss the
-            # acquisition preview, the one thing on the canvas that has no record.
-            self._tiles[placed] = tile
-        return placed
 
     def set_image(self, image: FibsemImage) -> Optional[str]:
         """Place a whole overview as one image, and record it as one.
@@ -1501,6 +1553,21 @@ class FibsemOverviewWidget(QWidget):
         self._refresh_overview_list()
         return record_id
 
+    def _store_cap(self, dtype: np.dtype) -> int:
+        """The largest square an overview of *dtype* may be held at, in pixels a side.
+
+        Derived from the memory budget rather than fixed, because bytes are what is
+        being spent and pixels are a poor proxy for them: the same pixel cap costs 52 MB
+        on a mosaic of 1024 px tiles and 118 MB on one of 3072 px tiles, and half as much
+        again on a uint16 detector as on a uint8 one. Two bytes a pixel here -- the
+        grayscale and the coverage mask beside it, one byte each for the usual uint8.
+
+        Square is the assumption, and it errs the safe way: a long thin mosaic reduces
+        on its longest side, so it comes in *under* budget rather than over.
+        """
+        per_pixel = int(np.dtype(dtype).itemsize) + 1  # + the coverage mask
+        return max(1, math.isqrt(self._store_budget_bytes // per_pixel))
+
     def _stored_tile(self, image: FibsemImage) -> "_PlacedTile":
         """What a record keeps so it can be re-placed after a view switch.
 
@@ -1517,7 +1584,7 @@ class FibsemOverviewWidget(QWidget):
         data = image.filtered_data
         pixel_size = self._pixel_size_of(image)
         height, width = data.shape[0], data.shape[1]
-        max_px = self._store_max_px
+        max_px = self._store_cap(data.dtype)
         # What was acquired, and where black is, both come off the *unfiltered* array --
         # `filtered_data` smears the boundary in both directions and would answer either
         # question wrong. Reduced the same way as the pixels so the three line up.
@@ -1535,7 +1602,9 @@ class FibsemOverviewWidget(QWidget):
         acquired = downsample_mask(source > 0, max_px)
         clim = _contrast_limits(raw, acquired)
         return _PlacedTile(
-            data=_as_colour_and_coverage(downsample(data, max_px), acquired, clim),
+            grey=downsample(data, max_px),
+            acquired=acquired,
+            clim=clim,
             position=deepcopy(self._position_of(image)),
             pixel_size=pixel_size,
             # From the shape *before* reduction: this is the ground the image images.
@@ -1564,7 +1633,6 @@ class FibsemOverviewWidget(QWidget):
 
     def _clear_preview(self) -> None:
         self.canvas.remove_image(PREVIEW_KEY)
-        self._tiles.pop(PREVIEW_KEY, None)
 
     def _place_finished_mosaic(self, mosaic: FibsemImage) -> None:
         """Swap the preview for the stitched overview the run actually produced."""
@@ -1605,7 +1673,6 @@ class FibsemOverviewWidget(QWidget):
             return False
         for key in record.keys:
             self.canvas.remove_image(key)
-            self._tiles.pop(key, None)
         self._refresh_context_overlays()
         self._refresh_overview_list()
         return True

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -518,7 +518,34 @@ class FibsemOverviewWidget(QWidget):
     # ── layout ───────────────────────────────────────────────────────────
 
     def _init_ui(self) -> None:
-        self.canvas = FibsemRealSpaceCanvas()
+        # Two caps, deliberately, and the same number today. They answer different
+        # questions and will diverge:
+        #
+        #   `_store_max_px`  -- the finest this widget ever *holds* an overview at, so
+        #                       the ceiling on any detail a zoom could ever recover. A
+        #                       memory bound.
+        #   `display_max_px` -- the most the canvas ever *hands matplotlib*, which is
+        #                       paid on every frame at every zoom. A redraw bound.
+        #
+        # Holding no more than is drawn is what makes "don't downscale the actual image"
+        # impossible right now: the detail is gone before the canvas sees it, so zooming
+        # cannot bring back what was never kept. Splitting the two is the groundwork for
+        # keeping more than is drawn and choosing, per view, which part of it to draw.
+        #
+        # 2048 is chosen for the drawing half. At 512 a 5x5 of 1024 px tiles was reduced
+        # tenfold and then magnified back onto a ~1100 px wide canvas, so every stored
+        # pixel was drawn as a 2x2 block; 2048 is the first power of two past the canvas's
+        # own width, which is what stops the magnification. A cap, not a target --
+        # `downsample` reduces by an integer factor, so that 5x5 lands at 1707 px.
+        #
+        # Measured on one RGBA artist: a redraw costs ~29 ms plus ~11 ms per megapixel,
+        # so this takes a pan from 29 ms to 74 ms, a contrast step from 17 ms to 69 ms,
+        # and holds 17 MB per overview. Raising it further is worse than it looks --
+        # matplotlib resamples the whole array however little of it is on screen (1% of a
+        # 5120 px artist still costs 321 ms against 335 ms for all of it) -- which is
+        # exactly why the drawn size is the thing to bound and the held size is not.
+        self._store_max_px = 2048
+        self.canvas = FibsemRealSpaceCanvas(display_max_px=2048)
         self.canvas.canvas_clicked.connect(self._on_canvas_clicked)
         self.canvas.canvas_double_clicked.connect(self._on_canvas_double_clicked)
         self.canvas.canvas_right_clicked.connect(self._on_canvas_right_clicked)
@@ -1477,10 +1504,12 @@ class FibsemOverviewWidget(QWidget):
     def _stored_tile(self, image: FibsemImage) -> "_PlacedTile":
         """What a record keeps so it can be re-placed after a view switch.
 
-        The *display-reduced* array, not the original: it is exactly what the canvas
-        holds anyway, so keeping it costs no more than the canvas already does -- where
-        keeping full-resolution tiles would be hundreds of megabytes for a large
-        tileset, to redraw something that is decimated on the way to the screen.
+        Reduced to this widget's *store* cap rather than the canvas's draw cap. The two
+        are the same number today, so this is still exactly the array the canvas draws
+        and keeping it costs no more than the canvas already does -- but they are not
+        the same question, and which one belongs here is the whole of it: this is the
+        finest the record will ever hold, so it is the ceiling on anything a zoom could
+        recover. See `_init_ui`.
 
         Split into colour and coverage here rather than at each placement: a view switch
         re-places every record, and the split is the same answer every time.
@@ -1488,7 +1517,7 @@ class FibsemOverviewWidget(QWidget):
         data = image.filtered_data
         pixel_size = self._pixel_size_of(image)
         height, width = data.shape[0], data.shape[1]
-        max_px = self.canvas._display_max_px
+        max_px = self._store_max_px
         # What was acquired, and where black is, both come off the *unfiltered* array --
         # `filtered_data` smears the boundary in both directions and would answer either
         # question wrong. Reduced the same way as the pixels so the three line up.

--- a/tests/test_image_reduction.py
+++ b/tests/test_image_reduction.py
@@ -24,7 +24,12 @@ import cv2
 import numpy as np
 import pytest
 
-from fibsem.imaging.reduce import _CV2_DTYPES, _box_mean_numpy, downsample
+from fibsem.imaging.reduce import (
+    _CV2_DTYPES,
+    _box_mean_numpy,
+    downsample,
+    downsample_mask,
+)
 
 
 def stride(arr: np.ndarray, max_px: int) -> np.ndarray:
@@ -191,6 +196,104 @@ class TestTheTwoImplementationsAgree:
 
         assert by_numpy.shape == by_cv2.shape
         assert np.abs(by_numpy.astype(int) - by_cv2.astype(int)).max() <= 1
+
+
+def float_mask(mask: np.ndarray, max_px: int) -> np.ndarray:
+    """The spelling `downsample_mask` replaced, kept as the reference to measure against.
+
+    Correct, and four bytes of temporary per *source* pixel — which is the cost that
+    grows with the mosaic rather than with what comes out.
+    """
+    return downsample(mask.astype(np.float32), max_px) > 0.5
+
+
+class TestReducingACoverageMask:
+    """A block survives when *more* than half of it is set.
+
+    Reduced alongside the pixels so an overview's colour and its "was anything acquired
+    here" answer keep the same shape. The rule has to resolve a part-covered block one
+    way or the other, and it resolves inward: coverage that spreads outward claims
+    ground as acquired that half of it was not, and on a real-space canvas that ground
+    is drawn opaque over whatever else is beneath it.
+    """
+
+    @pytest.mark.parametrize("covered,expected", [
+        (0, False), (10, False), (49, False),
+        (50, False),  # exactly half — the tie, resolved inward
+        (51, True), (90, True), (100, True),
+    ])
+    def test_a_block_survives_when_most_of_it_is_set(self, covered, expected):
+        block = np.zeros((10, 10), dtype=bool)
+        block.flat[:covered] = True
+        # 10x10 identical blocks, so every output pixel answers the same question.
+        out = downsample_mask(np.tile(block, (10, 10)), 10)
+
+        assert out.shape == (10, 10)
+        assert bool(out.all()) is expected and bool(out.any()) is expected
+
+    def test_it_is_not_the_pixels_thresholded(self):
+        """Box-averaging intensities and testing for "greater than zero" marks a block
+        acquired when *any* of it is — which over a mosaic's unacquired ground is most
+        of it, and is how a part-finished overview comes to paint black over the one
+        beneath it (FIB-630)."""
+        data = np.zeros((100, 100), np.uint8)
+        data[:, ::10] = 255  # one column of every 10x10 block, so each is a tenth set
+
+        generous = downsample(data, 10) > 0
+        honest = downsample_mask(data > 0, 10)
+
+        assert generous.all(), "the reference rule did not do the generous thing"
+        assert not honest.any(), "a tenth-covered block was called acquired"
+
+    @pytest.mark.parametrize("shape,max_px,cut", [
+        ((5120, 5120), 2048, (3000, 3777)),  # the 5x5 mosaic, factor 3
+        ((777, 301), 64, (500, 200)),        # ragged on both axes, factor 13
+        ((1000, 1000), 97, (613, 411)),      # factor 11, ragged
+    ])
+    def test_it_matches_the_float_spelling_on_a_real_mask(self, shape, max_px, cut):
+        """Down to the last block, which is the claim that makes the cheaper spelling a
+        substitution rather than a change.
+
+        A *coverage* mask is what it is asked to answer for, and the edge of one is the
+        straight edge of a tile: a block on it is covered in whole rows, so its fraction
+        moves in steps of 1/factor and never lands near the half where eight bits of
+        quantisation could decide it either way.
+        """
+        mask = np.zeros(shape, dtype=bool)
+        mask[:cut[0], :cut[1]] = True
+
+        assert np.array_equal(downsample_mask(mask, max_px), float_mask(mask, max_px))
+
+    def test_a_sparse_tileset_reduces_the_same_way(self):
+        """The other real shape: a masked run leaves whole tiles unacquired (FIB-618),
+        so coverage is a chequerboard rather than one region."""
+        mask = np.zeros((5120, 5120), dtype=bool)
+        for row in range(5):
+            for col in range(5):
+                if (row + col) % 2 == 0:
+                    mask[row * 1024:(row + 1) * 1024, col * 1024:(col + 1) * 1024] = True
+
+        assert np.array_equal(downsample_mask(mask, 2048), float_mask(mask, 2048))
+
+    def test_uniform_noise_is_where_the_two_part_company(self):
+        """Named so the agreement above is not read as a promise about anything else.
+
+        Half-set noise puts a block's coverage right in the quantisation band, and the
+        two spellings then disagree readily. Harmless for coverage, which is never this
+        — but this is the input that would make a future caller's assumption wrong.
+        """
+        noise = np.random.default_rng(0).random((777, 301)) > 0.5
+
+        differ = (downsample_mask(noise, 64) != float_mask(noise, 64)).sum()
+
+        assert differ > 0, "the quantisation band closed; the docstring overstates it"
+
+    def test_it_refuses_anything_that_is_not_a_mask(self):
+        """`(data > 0)` is the caller's job, and doing it here would hide the one call
+        that forgot: passing raw pixels reduces intensities and thresholds them at 128,
+        which is a picture-dependent answer that looks plausible everywhere."""
+        with pytest.raises(TypeError):
+            downsample_mask(np.zeros((100, 100), np.uint8), 10)
 
 
 if __name__ == "__main__":

--- a/tests/ui/test_fm_real_space_canvas.py
+++ b/tests/ui/test_fm_real_space_canvas.py
@@ -235,7 +235,7 @@ def test_the_composite_is_blended_at_display_resolution():
     w.set_channel("GFP", big, "green")
 
     stored = w.canvas._placed["ov"].artist.get_array()
-    assert max(stored.shape[:2]) <= w.canvas._display_max_px
+    assert max(stored.shape[:2]) <= w.canvas.display_max_px
 
 
 def test_a_reduced_composite_is_still_placed_at_full_size():

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -44,6 +44,9 @@ from fibsem.ui.widgets import overview_confirmation_dialog  # noqa: E402
 from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (  # noqa: E402
     GRID_BOUNDARY_RADIUS_M,
 )
+from fibsem.ui.widgets.canvas.real_space_canvas import (  # noqa: E402
+    _DEFAULT_DISPLAY_PX,
+)
 from fibsem.ui.widgets.overview_widget import (  # noqa: E402
     FibsemOverviewWidget,
     OverviewView,
@@ -193,10 +196,11 @@ class TestTheInversion:
 
     def test_a_reduced_tile_is_still_placed_at_full_size(self, widget, microscope):
         """The same property where the reduction actually bites — an image larger than
-        the canvas's display cap, which is every real tile."""
+        the store cap, which a stitched mosaic always is."""
         base = microscope.get_stage_position()
-        cap = widget.canvas._display_max_px
-        big = cap * 2
+        cap = 1024
+        widget._store_max_px = cap
+        big = cap + cap // 2  # over the cap, so it reduces; not so far over it is slow
         hfw = big * 1e-7
         widget.place_image(_tile(microscope, _at(base), shape=(big, big), hfw=hfw),
                            key="big")
@@ -240,6 +244,76 @@ class TestTheInversion:
 
         assert widget.place_image(image) is None  # must not raise
         assert len(widget.canvas.placed_keys) == 1, "the bad image was placed anyway"
+
+
+class TestTheTwoCaps:
+    """How much an overview is *held* at and how much of it is *drawn* are two questions.
+
+    Held too coarse and nothing can recover the detail, because it was thrown away
+    before the canvas ever saw it -- which is why "don't downscale the actual image" has
+    no answer while one number does both jobs. Drawn too fine and every frame pays for
+    it at every zoom, since matplotlib resamples the whole array however little of it is
+    on screen.
+
+    They hold the same value today, so the tests below have to force them apart to say
+    anything. That is the point: the seam exists and is exercised before anything
+    depends on it (FIB-658).
+    """
+
+    def test_the_canvas_does_not_take_the_shared_default(self, widget):
+        """Sized for a canvas holding many images; this one holds a mosaic. Not
+        tidiable away either -- the default is shared with the fluorescence canvas,
+        which reduces once per channel per layer change and blends the results, so
+        raising it there is multiplied through every one of them."""
+        assert widget.canvas.display_max_px > _DEFAULT_DISPLAY_PX
+
+    def test_a_stored_overview_out_resolves_the_canvas_it_is_drawn_on(
+        self, widget, microscope
+    ):
+        """Measured against the widget, not a constant: it is the screen the stored
+        pixels are stretched over that decides whether the cap is too low. Below it the
+        reduction stops decimating and starts *magnifying* -- a 5x5 of 1024 px tiles at
+        512 was drawn across a ~1100 px canvas as a 2x2 block per stored pixel, which is
+        what "way too pixelated" was.
+        """
+        base = microscope.get_stage_position()
+        big = widget._store_max_px + widget._store_max_px // 2
+        widget.place_image(
+            _tile(microscope, _at(base), shape=(big, big), hfw=500e-6), key="mosaic"
+        )
+
+        stored = np.asarray(widget._tiles["mosaic"].data)
+        assert max(stored.shape[:2]) >= widget.canvas.width(), (
+            f"{max(stored.shape[:2])} stored px drawn across a "
+            f"{widget.canvas.width()} px canvas, so each one is magnified"
+        )
+
+    def test_what_is_held_follows_the_store_cap_and_not_the_canvas(
+        self, widget, microscope
+    ):
+        """Forced apart, because equal numbers cannot show which one is being read.
+
+        This is the assertion that fails if the two are collapsed back into one, and the
+        one that has to hold before the widget can keep more than it draws.
+        """
+        drawn_cap = widget.canvas.display_max_px
+        source = drawn_cap + drawn_cap // 4  # over the draw cap, under the store cap
+        widget._store_max_px = source * 2
+        base = microscope.get_stage_position()
+        widget.place_image(
+            _tile(microscope, _at(base), shape=(source, source), hfw=500e-6), key="held"
+        )
+
+        held = np.asarray(widget._tiles["held"].data)
+        drawn = np.asarray(widget.canvas._placed["held"].artist.get_array())
+
+        assert max(held.shape[:2]) == source, "the record was reduced to the draw cap"
+        assert max(drawn.shape[:2]) <= widget.canvas.display_max_px, (
+            "the canvas drew more than its own cap"
+        )
+        assert max(drawn.shape[:2]) < max(held.shape[:2]), (
+            "the canvas drew everything held, so the caps are not actually separate"
+        )
 
 
 class TestOneDerivationForBothDirections:

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -109,6 +109,32 @@ def _at(base: FibsemStagePosition, dx: float = 0.0, dy: float = 0.0, name=None):
     return p
 
 
+def _hold_at(widget, px, dtype=np.uint8):
+    """Set the store budget so an overview is held at most *px* a side.
+
+    Tests state the size they mean rather than inheriting the production budget, which
+    is 8000 px a side — big enough that a test image sized from it would spend seconds
+    in `filtered_data`'s median filter.
+    """
+    widget._store_budget_bytes = px * px * (np.dtype(dtype).itemsize + 1)
+
+
+def _settle(widget):
+    """Run the canvas's coalesced detail refresh now rather than waiting out its timer."""
+    widget.canvas._detail_timer.stop()
+    widget.canvas.refresh_detail()
+    _app.processEvents()
+
+
+def _zoom(widget, fraction, centre=(0.0, 0.0)):
+    """Frame *fraction* of the placed image's width, and let the refresh settle."""
+    placed = widget.canvas._placed[widget.canvas.placed_keys[0]]
+    half = (placed.extent[1] - placed.extent[0]) / 2 * fraction
+    widget.canvas._ax.set_xlim(centre[0] - half, centre[0] + half)
+    widget.canvas._ax.set_ylim(centre[1] + half, centre[1] - half)
+    _settle(widget)
+
+
 class TestTheInversion:
     """Images are placed where they were acquired, rather than reprojected onto one.
 
@@ -199,7 +225,7 @@ class TestTheInversion:
         the store cap, which a stitched mosaic always is."""
         base = microscope.get_stage_position()
         cap = 1024
-        widget._store_max_px = cap
+        _hold_at(widget, cap)
         big = cap + cap // 2  # over the cap, so it reduces; not so far over it is slow
         hfw = big * 1e-7
         widget.place_image(_tile(microscope, _at(base), shape=(big, big), hfw=hfw),
@@ -255,10 +281,31 @@ class TestTheTwoCaps:
     it at every zoom, since matplotlib resamples the whole array however little of it is
     on screen.
 
-    They hold the same value today, so the tests below have to force them apart to say
-    anything. That is the point: the seam exists and is exercised before anything
-    depends on it (FIB-658).
+    They are also measured in different units, which is the part most likely to be
+    "tidied" back together: what is held is bounded in **bytes**, because bytes are what
+    it costs, and what is drawn is bounded in **pixels**, because a frame's cost is the
+    pixels matplotlib resamples (FIB-658).
     """
+
+    def test_the_store_bound_is_bytes_and_scales_with_the_detector(self, widget):
+        """Bytes, not pixels, because bytes are what is being spent. A pixel cap prices
+        the same setting at 52 MB for a mosaic of 1024 px tiles and 118 MB for one of
+        3072 px tiles, and costs half as much again on a uint16 detector without saying
+        so."""
+        wide = widget._store_cap(np.uint8)
+        deep = widget._store_cap(np.uint16)
+
+        assert wide * wide * 2 <= widget._store_budget_bytes
+        assert deep * deep * 3 <= widget._store_budget_bytes
+        assert deep < wide, "a 16-bit detector was given the same pixel count as an 8-bit"
+
+    def test_the_budget_holds_the_complained_about_mosaic_whole(self, widget, microscope):
+        """The case behind FIB-658: a 5x5 of 1024 px tiles is 5120 px, and the point of
+        the budget is that it is held at its acquired resolution rather than reduced."""
+        assert widget._store_cap(np.uint8) >= 5 * 1024, (
+            f"a 5x5 of 1024 px tiles would be reduced at a "
+            f"{widget._store_cap(np.uint8)} px cap"
+        )
 
     def test_the_canvas_does_not_take_the_shared_default(self, widget):
         """Sized for a canvas holding many images; this one holds a mosaic. Not
@@ -277,12 +324,14 @@ class TestTheTwoCaps:
         what "way too pixelated" was.
         """
         base = microscope.get_stage_position()
-        big = widget._store_max_px + widget._store_max_px // 2
-        widget.place_image(
-            _tile(microscope, _at(base), shape=(big, big), hfw=500e-6), key="mosaic"
+        cap = 1024
+        _hold_at(widget, cap)
+        big = cap + cap // 2  # any mosaic over the cap; it reduces to the cap
+        record_id = widget.set_image(
+            _tile(microscope, _at(base), shape=(big, big), hfw=500e-6)
         )
 
-        stored = np.asarray(widget._tiles["mosaic"].data)
+        stored = np.asarray(widget._records[record_id].images[0].grey)
         assert max(stored.shape[:2]) >= widget.canvas.width(), (
             f"{max(stored.shape[:2])} stored px drawn across a "
             f"{widget.canvas.width()} px canvas, so each one is magnified"
@@ -293,19 +342,19 @@ class TestTheTwoCaps:
     ):
         """Forced apart, because equal numbers cannot show which one is being read.
 
-        This is the assertion that fails if the two are collapsed back into one, and the
-        one that has to hold before the widget can keep more than it draws.
+        This is the assertion that fails if the two are collapsed back into one, and it
+        is the one phase 2 needs to hold before it can keep more than it draws.
         """
         drawn_cap = widget.canvas.display_max_px
         source = drawn_cap + drawn_cap // 4  # over the draw cap, under the store cap
-        widget._store_max_px = source * 2
+        _hold_at(widget, source * 2)
         base = microscope.get_stage_position()
-        widget.place_image(
-            _tile(microscope, _at(base), shape=(source, source), hfw=500e-6), key="held"
+        record_id = widget.set_image(
+            _tile(microscope, _at(base), shape=(source, source), hfw=500e-6)
         )
 
-        held = np.asarray(widget._tiles["held"].data)
-        drawn = np.asarray(widget.canvas._placed["held"].artist.get_array())
+        held = np.asarray(widget._records[record_id].images[0].grey)
+        drawn = np.asarray(widget.canvas._placed[record_id].artist.get_array())
 
         assert max(held.shape[:2]) == source, "the record was reduced to the draw cap"
         assert max(drawn.shape[:2]) <= widget.canvas.display_max_px, (
@@ -2765,14 +2814,14 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
         image.data = data
 
         tile = widget._stored_tile(image)
-        rgba = np.asarray(tile.data)
-        acquired = rgba[..., 3] > 0
+        acquired = np.asarray(tile.acquired)
         # A third of the image, give or take the boundary block -- not a third plus a
         # filter radius, which is what the filtered array would have given.
         assert acquired.mean() == pytest.approx(1 / 3, abs=0.02), (
             f"coverage came out at {acquired.mean():.3f} of the image"
         )
-        grey = rgba[..., 0][acquired]
+        rgba = widget._for_display(tile)
+        grey = rgba[..., 0][rgba[..., 3] > 0]
         assert grey.mean() == pytest.approx(128, abs=30), (
             f"the acquired region renders at {grey.mean():.0f}/255 -- bleached"
         )
@@ -3074,3 +3123,122 @@ class TestTheSpiralPromotionIsVisible:
         assert "AutoFocusMode.EACH_ROW" in source and "SPIRAL" in source, (
             "the runner no longer promotes EACH_ROW for a spiral; the note is stale"
         )
+
+
+class TestAnOverviewIsDrawnFromWhatIsHeld:
+    """The overview supplies the canvas a *source* rather than a finished picture.
+
+    A record keeps the grayscale, the coverage mask and the contrast limits; colour and
+    the user's curve are applied to whatever part is being drawn, when it is drawn. Two
+    things follow that a finished RGBA cannot give: zooming in shows detail the picture
+    would already have thrown away, and a contrast step costs a screenful rather than a
+    mosaic (FIB-658).
+    """
+
+    def _held(self, widget, microscope, side, store_px=None):
+        """One overview held at *store_px*, framed whole."""
+        if store_px is not None:
+            _hold_at(widget, store_px)
+        base = microscope.get_stage_position()
+        image = _tile(microscope, _at(base), shape=(side, side), hfw=500e-6)
+        rng = np.random.default_rng(3)
+        ramp = np.linspace(10, 245, side)
+        image.data = np.clip(
+            np.add.outer(ramp, ramp) / 2 + rng.normal(0, 8, (side, side)), 1, 255
+        ).astype(np.uint8)
+        record_id = widget.set_image(image)
+        _settle(widget)
+        return record_id
+
+    def test_the_record_keeps_ingredients_not_a_picture(self, widget, microscope):
+        record_id = self._held(widget, microscope, 512)
+
+        tile = widget._records[record_id].images[0]
+        assert np.asarray(tile.grey).ndim == 2, "the record holds a finished picture"
+        assert np.asarray(tile.acquired).dtype == np.bool_
+        assert tile.clim[0] < tile.clim[1]
+
+    def test_zooming_in_recovers_detail_it_could_not_have_held(self, widget, microscope):
+        """The payoff, stated exactly: framed whole you see the *draw* cap's worth, and
+        zoomed in you see everything *held*. Under a store-time reduction the two are
+        necessarily the same number, so a zoom could only magnify.
+
+        Both caps are lowered here so the test image stays small — `filtered_data` runs a
+        median then a gaussian over the whole of it. The canvas's is read-only in
+        production because the extents of everything placed were computed against it;
+        this sets it before anything is placed.
+        """
+        widget.canvas._display_max_px = 256
+        held_px = 1024  # four times the draw cap, so the effect is unambiguous
+        self._held(widget, microscope, held_px, store_px=held_px)
+        placed = widget.canvas._placed[widget.canvas.placed_keys[0]]
+
+        def per_ground():
+            return max(placed.artist.get_array().shape[:2]) / placed.drawn.width
+
+        wide = per_ground()
+        _zoom(widget, 0.1)
+        close = per_ground()
+
+        assert wide == pytest.approx(widget.canvas.display_max_px, rel=0.05), (
+            f"framed whole, {wide:.0f} px per image-width against a "
+            f"{widget.canvas.display_max_px} px draw cap"
+        )
+        assert close == pytest.approx(held_px, rel=0.05), (
+            f"zoomed in, {close:.0f} px per image-width against {held_px} px held — the "
+            "zoom is magnifying rather than revealing"
+        )
+
+    def test_the_stretch_is_the_whole_overview_not_the_part_on_screen(
+        self, widget, microscope
+    ):
+        """`clim` is measured once and kept. Re-measured per patch it would make the
+        picture change brightness as you panned across it — every region would render
+        mid-grey, and a dark corner would look identical to a bright one."""
+        self._held(widget, microscope, 512)
+        placed = widget.canvas._placed[widget.canvas.placed_keys[0]]
+        _, xmax, ymax, _ = placed.extent
+
+        _zoom(widget, 0.15, centre=(-xmax * 0.7, -ymax * 0.7))  # the dark corner
+        dark = float(np.mean(placed.artist.get_array()[..., 0]))
+        _zoom(widget, 0.15, centre=(xmax * 0.7, ymax * 0.7))  # the bright one
+        bright = float(np.mean(placed.artist.get_array()[..., 0]))
+
+        assert bright > dark * 2, (
+            f"dark corner {dark:.0f}/255, bright corner {bright:.0f}/255 — the stretch "
+            "is following the view rather than the overview"
+        )
+
+    def test_contrast_never_writes_back_over_what_is_held(self, widget, microscope):
+        """The stored grayscale is the one copy of the data. Curving it in place would
+        compound every slider move onto the last, and there would be no way back to the
+        acquired values."""
+        record_id = self._held(widget, microscope, 512)
+        before = np.asarray(widget._records[record_id].images[0].grey).copy()
+
+        control = widget.contrast_control
+        control._min, control._max, control._gamma = 0.2, 0.8, 1.4
+        control.changed.emit()
+
+        after = np.asarray(widget._records[record_id].images[0].grey)
+        assert np.array_equal(before, after), "the curve was baked into the record"
+
+    def test_a_contrast_change_redraws_without_reordering_the_overviews(
+        self, widget, microscope
+    ):
+        """Re-placing under the same key destroys and recreates the artist, which moves
+        it to the top of the draw order — so adjusting contrast would silently bring a
+        buried overview out over the one above it."""
+        first = self._held(widget, microscope, 256)
+        second = self._held(widget, microscope, 256)
+        order = list(widget.canvas.placed_keys)
+        artists = [widget.canvas._placed[k].artist for k in order]
+
+        widget.contrast_control._gamma = 1.5
+        widget.contrast_control.changed.emit()
+
+        assert list(widget.canvas.placed_keys) == order
+        assert [widget.canvas._placed[k].artist for k in order] == artists, (
+            "the artists were recreated, so the draw order is whatever add order was"
+        )
+        assert first != second

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -21,8 +21,13 @@ pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is delibe
 
 from PyQt5.QtWidgets import QApplication
 
+from fibsem.imaging.reduce import downsample
 from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase
-from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
+from fibsem.ui.widgets.canvas.real_space_canvas import (
+    WHOLE_IMAGE,
+    FibsemRealSpaceCanvas,
+    ImageRegion,
+)
 
 _app = QApplication.instance() or QApplication(sys.argv)
 
@@ -852,3 +857,448 @@ def test_a_resize_does_not_undo_a_users_zoom():
     _app.processEvents()
 
     assert _span(c) == pytest.approx(zoomed), "the zoom was thrown away by a resize"
+
+
+# ── detail sources: drawing what the view can use, not what the caller holds ──
+#
+# Unused in production at this point, and exercised only here. What it buys is the thing
+# a fixed cap cannot: the reduction factor stops being set by how large the image is and
+# starts being set by how much of it is on screen, so zooming in recovers detail instead
+# of magnifying stored pixels (FIB-658).
+
+
+class Source:
+    """A caller holding a full-resolution image, answering for parts of it.
+
+    Deliberately the whole job in a few lines — slice, reduce, report what was actually
+    given — because that is the claim the protocol is making: a source needs to know its
+    own array and nothing about the canvas.
+    """
+
+    def __init__(self, side=2048):
+        # A gradient, so which *part* was fetched is readable off the pixel values.
+        ramp = np.linspace(0, 255, side, dtype=np.float64)
+        self.full = np.add.outer(ramp, ramp).astype(np.uint8) // 2
+        self.calls = []
+
+    def __call__(self, region, max_px):
+        self.calls.append((region, max_px))
+        h, w = self.full.shape
+        # Snap outward to whole pixels, and report the region that produces.
+        x0, x1 = int(np.floor(region.left * w)), int(np.ceil(region.right * w))
+        y0, y1 = int(np.floor(region.top * h)), int(np.ceil(region.bottom * h))
+        x1, y1 = max(x1, x0 + 1), max(y1, y0 + 1)
+        patch = downsample(self.full[y0:y1, x0:x1], max_px)
+        return patch, ImageRegion(x0 / w, x1 / w, y0 / h, y1 / h)
+
+
+def _with_source(side=2048, display_max_px=256, widget=(800, 600)):
+    """A canvas holding one full-resolution image through a source, framed on it."""
+    c = _canvas(display_max_px=display_max_px)
+    c.resize(*widget)
+    c.show()
+    _app.processEvents()
+    src = Source(side)
+    # `data` is the whole-image fallback: what a caller would have placed before.
+    c.add_image(
+        downsample(src.full, display_max_px), centre=(0.0, 0.0),
+        pixel_size=PIXEL_SIZE, key="big",
+        covers=(side * PIXEL_SIZE, side * PIXEL_SIZE), detail=src,
+    )
+    _app.processEvents()
+    return c, src
+
+
+
+
+def _zoom_to(canvas, fraction, centre=(0.0, 0.0)):
+    """Frame *fraction* of the image's width, and let the refresh settle."""
+    _, xmax, _, _ = canvas._placed["big"].extent
+    half = xmax * fraction
+    canvas._ax.set_xlim(centre[0] - half, centre[0] + half)
+    canvas._ax.set_ylim(centre[1] + half, centre[1] - half)
+    _flush_detail(canvas)
+
+
+def _flush_detail(canvas):
+    """Run the coalesced refresh now rather than waiting out its timer."""
+    canvas._detail_timer.stop()
+    canvas.refresh_detail()
+    _app.processEvents()
+
+
+def test_an_image_without_a_source_is_untouched():
+    """Every caller in production today. The artist holds what it was given, over the
+    whole footprint, and no timer ever fires for it."""
+    c = _canvas()
+    c.resize(800, 600)
+    c.add_image(_img(), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE, key="plain")
+    placed = c._placed["plain"]
+    before = placed.artist.get_extent()
+
+    c._ax.set_xlim(-10, 10)
+    _flush_detail(c)
+
+    assert placed.detail is None
+    assert placed.artist.get_extent() == before
+    assert placed.artist.get_array().shape[:2] == (H, W)
+
+
+def test_placing_it_framed_whole_asks_the_source_for_nothing():
+    """The fallback array is already the display cap over the whole image, which is
+    exactly what a fetch of the whole image would return. Asking would allocate a second
+    identical array and draw the same picture."""
+    c, src = _with_source()
+
+    assert src.calls == []
+    assert c._placed["big"].drawn == WHOLE_IMAGE
+    c.close()
+
+
+def test_zooming_in_fetches_a_smaller_part_of_the_image():
+    """The whole point: the part fetched follows the view, so the reduction factor stops
+    being set by how big the image is and starts being set by how much is on screen."""
+    c, src = _with_source()
+
+    _zoom_to(c, 0.1)
+
+    close = src.calls[-1][0]
+    # A tenth of the image, plus the margin's quarter of the viewport either side.
+    assert close.width == pytest.approx(0.15, abs=0.01), (
+        f"zooming to a tenth fetched {close.width:.3f} of the image"
+    )
+    c.close()
+
+
+def test_zooming_in_recovers_detail_rather_than_magnifying():
+    """Source pixels per unit of ground has to *rise* as you zoom in. Under a store-time
+    cap it cannot: the pixels are gone before the canvas sees them."""
+    c, src = _with_source()
+
+    def per_ground():
+        placed = c._placed["big"]
+        return max(placed.artist.get_array().shape[:2]) / placed.drawn.width
+
+    wide = per_ground()
+    _zoom_to(c, 0.05)
+    close = per_ground()
+
+    assert close > wide * 5, (
+        f"{close:.0f} source px per image-width zoomed in, against {wide:.0f} out"
+    )
+    c.close()
+
+
+def test_the_drawn_array_stays_bounded_however_far_you_zoom():
+    """The invariant that keeps redraw cost tracking the window rather than the data.
+    Every frame's cost is the drawn pixels, so this is the whole performance claim."""
+    c, src = _with_source()
+    sizes = []
+    for fraction in (1.0, 0.5, 0.2, 0.05, 0.01, 0.002):
+        _zoom_to(c, fraction)
+        sizes.append(max(c._placed["big"].artist.get_array().shape[:2]))
+
+    assert max(sizes) <= c.display_max_px, (
+        f"drew {max(sizes)} px against a {c.display_max_px} px cap: {sizes}"
+    )
+    c.close()
+
+
+def test_a_patch_is_drawn_over_the_ground_it_came_from():
+    """A patch placed at the rectangle *asked* for rather than the one given would sit a
+    fraction of a pixel off its own ground — a seam, on the canvas whose whole purpose is
+    that images line up."""
+    c, src = _with_source()
+    _zoom_to(c, 0.1)
+
+    placed = c._placed["big"]
+    xmin, xmax, ymax, ymin = placed.extent
+    left, right, bottom, top = placed.artist.get_extent()
+    region = placed.drawn
+
+    assert left == pytest.approx(xmin + region.left * (xmax - xmin))
+    assert right == pytest.approx(xmin + region.right * (xmax - xmin))
+    assert top == pytest.approx(ymin + region.top * (ymax - ymin))
+    assert bottom == pytest.approx(ymin + region.bottom * (ymax - ymin))
+    c.close()
+
+
+def test_the_patch_holds_the_part_of_the_picture_it_claims():
+    """Not merely the right shape in the right place — the right pixels. The source is a
+    gradient, so a patch from the bottom-right has to be brighter than one from the
+    top-left, and a patch drawn from the wrong slice would pass every geometric test
+    above while showing the wrong part of the sample."""
+    c, src = _with_source()
+    _, xmax, ymax, _ = c._placed["big"].extent
+
+    _zoom_to(c, 0.1, centre=(-xmax * 0.7, -ymax * 0.7))
+    top_left = float(np.mean(c._placed["big"].artist.get_array()))
+    _zoom_to(c, 0.1, centre=(xmax * 0.7, ymax * 0.7))
+    bottom_right = float(np.mean(c._placed["big"].artist.get_array()))
+
+    assert bottom_right > top_left * 2, (
+        f"top-left mean {top_left:.0f}, bottom-right {bottom_right:.0f} — the patches do "
+        "not come from where they are drawn"
+    )
+    c.close()
+
+
+def test_a_small_pan_costs_no_fetch_at_all():
+    """The margin earning its keep: a patch reaches past the viewport, so an ordinary
+    nudge is already drawn."""
+    c, src = _with_source()
+    _zoom_to(c, 0.2)
+    before = len(src.calls)
+
+    x0, x1 = c._ax.get_xlim()
+    nudge = (x1 - x0) * 0.05  # well inside the 25% margin
+    c._ax.set_xlim(x0 + nudge, x1 + nudge)
+    _flush_detail(c)
+
+    assert len(src.calls) == before, "a pan inside the margin refetched anyway"
+    c.close()
+
+
+def test_a_pan_past_the_margin_fetches_again():
+    """And the other half: the margin is a margin, not a promise."""
+    c, src = _with_source()
+    _zoom_to(c, 0.2)
+    before = len(src.calls)
+
+    x0, x1 = c._ax.get_xlim()
+    jump = (x1 - x0) * 1.5
+    c._ax.set_xlim(x0 + jump, x1 + jump)
+    _flush_detail(c)
+
+    assert len(src.calls) > before, "panning clean off the patch drew stale ground"
+    c.close()
+
+
+def test_an_image_off_screen_is_not_fetched_for():
+    """Nothing to draw, so nothing to pay for — and what it already holds is kept, so
+    coming back does not start from nothing."""
+    c, src = _with_source()
+    _, xmax, _, _ = c._placed["big"].extent
+    held = c._placed["big"].drawn
+    before = len(src.calls)
+
+    c._ax.set_xlim(xmax * 10, xmax * 12)  # miles away
+    _flush_detail(c)
+
+    assert len(src.calls) == before
+    assert c._placed["big"].drawn == held
+    c.close()
+
+
+def test_a_hidden_image_is_not_fetched_for():
+    """Hiding is how a caller takes an overview out of the redraw cost; fetching patches
+    for it would put the cost back for something nobody can see."""
+    c, src = _with_source()
+    c.set_image_visible("big", False)
+    before = len(src.calls)
+
+    _zoom_to(c, 0.1)
+
+    assert len(src.calls) == before
+    c.close()
+
+
+def test_a_source_that_raises_leaves_the_canvas_alone():
+    """This runs off a timer, and PyQt5 aborts the process on an exception out of a slot
+    (FIB-329). One bad source must cost its own image and nothing else."""
+    c, src = _with_source()
+
+    def angry(region, max_px):
+        raise RuntimeError("no")
+
+    c._placed["big"].detail = angry
+    shown = c._placed["big"].artist.get_array().copy()
+
+    _zoom_to(c, 0.1)  # must not raise
+
+    assert np.array_equal(c._placed["big"].artist.get_array(), shown)
+    c.close()
+
+
+def test_a_source_that_declines_leaves_the_canvas_alone():
+    """None is a legitimate answer — a disk-backed source with nothing cached yet."""
+    c, src = _with_source()
+    c._placed["big"].detail = lambda region, max_px: None
+    shown = c._placed["big"].artist.get_array().copy()
+
+    _zoom_to(c, 0.1)
+
+    assert np.array_equal(c._placed["big"].artist.get_array(), shown)
+    c.close()
+
+
+def test_a_source_returning_a_region_outside_itself_is_refused():
+    """A returned region is used as an extent, so a bad one places pixels over ground
+    they did not come from — which looks exactly like a correctly placed image."""
+    c, src = _with_source()
+    c._placed["big"].detail = lambda region, max_px: (
+        np.zeros((16, 16), np.uint8), ImageRegion(0.5, 1.5, 0.0, 1.0)
+    )
+    before = c._placed["big"].artist.get_extent()
+
+    _zoom_to(c, 0.1)
+
+    assert c._placed["big"].artist.get_extent() == before
+    c.close()
+
+
+def test_detail_does_not_move_the_camera():
+    """`AxesImage.set_extent` sets the axes limits to the artist's own extent while
+    autoscale is on, so a canvas re-extenting an artist on every view change would frame
+    it, and frame it again. The pass must be inert on the view."""
+    c, src = _with_source()
+    _zoom_to(c, 0.2)
+    limits = c._ax.get_xlim(), c._ax.get_ylim()
+
+    _flush_detail(c)
+    _flush_detail(c)
+
+    assert (c._ax.get_xlim(), c._ax.get_ylim()) == limits
+    assert not c._ax.get_autoscalex_on() and not c._ax.get_autoscaley_on()
+    c.close()
+
+
+def test_detail_does_not_change_the_footprint_the_canvas_frames():
+    """`PlacedImage.extent` is the whole image throughout, so fitting and the content
+    rect are unmoved by which part happens to be drawn. That separation is what stops
+    the pass provoking a refit and scheduling itself again."""
+    c, src = _with_source()
+    extent, content = c._placed["big"].extent, c._content_extent()
+
+    _zoom_to(c, 0.05)
+
+    assert c._placed["big"].extent == extent
+    assert c._content_extent() == content
+    assert c._placed["big"].artist.get_extent() != extent, "nothing was cropped at all"
+    c.close()
+
+
+def test_a_reset_view_frames_the_whole_image_not_the_patch():
+    """The visible consequence of the footprint being kept: reset has to go back to the
+    whole overview, even while a tenth of it is what is drawn."""
+    c, src = _with_source()
+    _zoom_to(c, 0.05)
+
+    c.reset_view()
+    _flush_detail(c)
+
+    _, xmax, _, _ = c._placed["big"].extent
+    span = abs(c._ax.get_xlim()[1] - c._ax.get_xlim()[0])
+    assert span >= xmax * 2 * 0.9, f"reset framed {span:.0f} of a {xmax * 2:.0f} image"
+    c.close()
+
+
+def test_updating_the_pixels_puts_the_artist_back_over_the_whole_image():
+    """`update_image` hands over the whole picture — a live preview's next frame. Left
+    over a patch's extent it would be stretched across a tenth of the ground."""
+    c, src = _with_source()
+    _zoom_to(c, 0.1)
+    assert c._placed["big"].artist.get_extent() != c._placed["big"].extent
+
+    c.update_image("big", src.full)
+    c._detail_timer.stop()  # before the refresh crops it again
+
+    assert c._placed["big"].drawn.width == 1.0
+    c.close()
+
+
+def test_the_budget_never_exceeds_the_display_cap():
+    """The bound that makes several sources on one canvas add up to a window's worth
+    rather than a mosaic's."""
+    c, src = _with_source()
+    for fraction in (1.0, 0.3, 0.01):
+        _zoom_to(c, fraction)
+
+    assert src.calls, "nothing was ever asked for"
+    assert all(budget <= c.display_max_px for _, budget in src.calls), (
+        f"budgets {[b for _, b in src.calls]} against a {c.display_max_px} px cap"
+    )
+    c.close()
+
+
+def test_a_settled_view_stops_asking():
+    """The failure mode this pass is most prone to, and the one hardest to see: a
+    condition that is permanently true, refetching an identical array on every timer
+    tick forever. It reads as "slow" rather than as "wrong".
+
+    Two separate ways of writing the test had it. Comparing coverage against the
+    margin-expanded region compares a margin with a margin, so any pan at all fails it.
+    Comparing resolution against what the screen ideally wants can never be satisfied
+    once the budget clamps at the display cap, because the margin's ground is spending
+    some of that cap — and comparing against what *arrived* rather than what was *asked*
+    for fails the same way, since `downsample` reduces by whole factors and returns less
+    than the budget.
+    """
+    c, src = _with_source()
+    for fraction in (0.5, 0.2, 0.05):
+        _zoom_to(c, fraction)
+    settled = len(src.calls)
+
+    for _ in range(3):
+        _flush_detail(c)
+
+    assert len(src.calls) == settled, (
+        f"{len(src.calls) - settled} fetches for a view that did not move"
+    )
+    c.close()
+
+
+def _one_source_canvas(side):
+    """One image covering a fixed 100 um, held at *side* px, framed identically."""
+    c = _canvas(display_max_px=1024)
+    c.resize(800, 600)
+    c.show()
+    _app.processEvents()
+    src = Source(side)
+    c.add_image(
+        downsample(src.full, 64), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE,
+        key="one", covers=(100e-6, 100e-6), detail=src,
+    )
+    _flush_detail(c)
+    return c, src
+
+
+def test_the_budget_follows_the_screen_and_not_how_much_is_held():
+    """The claim that makes cost track the window rather than the data: two images over
+    the same ground, framed the same, one holding sixty-four times the pixels of the
+    other, are asked for the same amount."""
+    small_canvas, small = _one_source_canvas(512)
+    large_canvas, large = _one_source_canvas(4096)
+
+    assert small.calls and large.calls, "one of the two was never asked"
+    assert small.calls[-1][1] == large.calls[-1][1], (
+        f"budgets {small.calls[-1][1]} and {large.calls[-1][1]} for the same ground"
+    )
+    small_canvas.close()
+    large_canvas.close()
+
+
+def test_an_image_occupying_part_of_the_canvas_is_budgeted_for_that_part():
+    """What bounds a canvas holding several overviews: each is asked for the pixels it
+    covers, so they share a screen between them rather than taking one each."""
+    c = _canvas(display_max_px=1024)
+    c.resize(800, 600)
+    c.show()
+    _app.processEvents()
+    sources = {}
+    for key, centre in (("left", -60e-6), ("right", 60e-6)):
+        sources[key] = Source(2048)
+        c.add_image(
+            downsample(sources[key].full, 64), centre=(centre, 0.0),
+            pixel_size=PIXEL_SIZE, key=key, covers=(100e-6, 100e-6),
+            detail=sources[key],
+        )
+    _flush_detail(c)
+
+    budgets = {k: s.calls[-1][1] for k, s in sources.items() if s.calls}
+    assert len(budgets) == 2, f"only {list(budgets)} were asked"
+    assert sum(budgets.values()) <= c.display_max_px * 1.5, (
+        f"two half-screen images were budgeted {budgets} against a "
+        f"{c.display_max_px} px cap — each was priced as if it owned the canvas"
+    )
+    c.close()


### PR DESCRIPTION
Closes FIB-658.

The overview canvas reduced every image to 512 px **at store time**, so a 5×5 of 1024 px tiles was squeezed tenfold and then magnified back onto a ~1100 px wide canvas — every stored pixel drawn as a 2×2 block. That is the "way too pixelated" report. And because the reduction happened before the canvas ever saw the image, zooming had nothing to reveal: "don't downscale the actual image" had no answer at all.

**The 5×5 is now held at 5120 px — its full acquired resolution — and zooming shows it.**

| on that mosaic | before | after |
| --- | --- | --- |
| shown, framed whole | 0.98 µm/px | 0.29 µm/px |
| shown, zoomed in | 0.98 µm/px | **0.098 µm/px** — the acquired figure |
| pan | 29 ms | 19–27 ms |
| contrast step | 17 ms | 36 ms |
| held | 1 MB | 52 MB |
| placement | — | 162 ms (206 ms for a 10×10) |

The zoom row is the point: it used to be the same number at every zoom, because there was nothing else to show.

## The shape of it

One number was doing two unrelated jobs. What an overview is **held** at is a memory bound and the ceiling on any detail a zoom could recover; what is **drawn** is a redraw bound, paid on every frame at every zoom. Splitting them lets the canvas ask a *source* for the part of an image on screen, at the resolution the screen can use, and ask again as the view moves — so the reduction factor follows how much is visible rather than how large the image is.

That inversion is what makes cost track the window instead of the data. Pinned by `test_the_drawn_array_stays_bounded_however_far_you_zoom`.

## Why the store bound is bytes

Bytes are what is being spent. A pixel cap prices the same setting at 52 MB on a mosaic of 1024 px tiles and 118 MB on one of 3072 px tiles, and costs half as much again on a uint16 detector without saying so. It is a **ceiling, not an allocation** — `downsample` reduces by whole factors, so an overview that fits is held whole. 128 MB and 64 MB hold an identical array for four of five realistic mosaics; 128 MB only spends more where there is more to hold.

## Four commits, each standing alone

Reconstructed forward from the base rather than split from the finished work, with the affected tests run at each step — every commit builds and passes on its own, so any one is reviewable or bisectable in isolation.

1. `798d2b70` — `downsample_mask`, next to `downsample` outside `fibsem/ui` so CI runs its tests. Replaces a float32 promotion that cost four bytes per *source* pixel of temporary, twice over: 541 MB and 207 ms → 218 MB and 38 ms on a 10×10, for a bit-identical mask.
2. `52cce021` — the two caps separated, and the drawn one raised 512 → 2048. Same held value, so nothing moves; the tests force them apart so the seam is exercised before anything depends on it.
3. `b3bd1417` — the canvas learns to ask. **Unused in production at this point**; an image placed without a source behaves exactly as before, and it is exercised entirely by tests.
4. `c8d3aef4` — the overview supplies one, and the store bound becomes a memory budget.

## Three traps, each of which cost a debugging round

- **`AxesImage.set_extent` moves the camera** while autoscale is on — it ends in `set_xlim`/`set_ylim` onto the artist's own extent, so re-extenting on every view change would frame the image, and frame it again. Autoscale is now off explicitly; a no-op in every path that already existed, since `set_xlim` clears the flag itself.
- **Coverage must be tested against the bare viewport**, not the margin-expanded region. Margin against margin fails on any pan at all, and the margin buys nothing.
- **Freshness must be tested against the budget a fetch is *asked* for**, not what the last one returned. `downsample` reduces by whole factors, so a source routinely returns less than asked, and comparing against that refetches an identical array forever.

The last two are the same failure — a permanently-true condition redoing identical work on every timer tick, which reads as "slow" rather than as "wrong". `test_a_settled_view_stops_asking` is the net for both.

## Follow-up, not in here

[FIB-671](https://linear.app/fibsemos/issue/FIB-671): `_stored_tile` still opens with `image.filtered_data`, a median and a gaussian over the whole mosaic at acquired resolution on the main thread, at ~0.15 s per megapixel — which is why a 385 MB overview hangs on load. Pre-existing, and more visible now that large overviews are kept rather than immediately discarded. The issue also records that `set_image` builds the tile twice.

## Verification

5080 passed, 24 skipped. The single failure is `test_dragging_the_fib_rect_still_repositions_the_pattern`, which is order-dependent and pre-existing — it fails identically on a clean tree standalone, at file level and at directory level, because its starting point is already exactly where the drag puts it. Being handled separately.

Also run in the app against the simulator: sparse tilesets leave holes rather than black, two overviews composite rather than hide, placement and scale and the overlays unchanged, and a zoom that previously showed 3-pixel blocks now resolves.