### PR TITLE
[ui] Keep 2048 px per placed image on the real-space canvas, not 512 (FIB-658)

### DIFF
--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -48,13 +48,30 @@ _ORIGIN_MARKER_SIZE = 11  # points; fixed on screen, so zoom-independent
 _ORIGIN_MARKER_COLOUR = "#ff5252"
 
 # Pixels kept per placed image. Every artist is redrawn in full on each pan/zoom, so a
-# redraw costs the *total* stored pixels — 100 tiles kept at 1024 px square take ~2.7 s,
-# against ~0.75 s at 512. And 512 is already more than the display can use for the case
-# this canvas exists for: tiles in a 3x3 occupy ~330 screen px each, in a 10x10 ~100 px.
+# redraw costs the *total* stored pixels across every placed image.
+#
+# Raised 512 -> 2048 as a stopgap for FIB-658: a mosaic is tens of thousands of pixels
+# across and 512 showed ~0.02% of them, which is too coarse to read the sample you just
+# spent a run acquiring. Measured, per redraw, on an 8192 px source:
+#
+#     images on canvas |   512   |  1024   |  2048
+#     one              | 13.9 ms | 30.8 ms |  100 ms
+#     five             | 42.6 ms |  126 ms |  451 ms
+#
+# So this is a deliberate trade, not a free win: one overview stays comfortable, and a
+# canvas someone has placed several runs on does not. It degrades as a session goes on
+# rather than being bad immediately, which is the worse way round -- drop to 1024 if that
+# bites before FIB-414 lands.
+#
+# The old figure here ("100 tiles at 1024 px take ~2.7 s") measured one artist *per
+# tile*; overviews are placed as a single image per run now, so it no longer describes
+# this canvas -- but note the saving from that change is why 512 felt fine, not headroom.
+#
 # The reduction box-averages, so the cap costs resolution and nothing else — a feature
 # smaller than a stored pixel is dimmed into its neighbours rather than dropped. What it
-# still cannot do is give the detail back on zoom; that is FIB-414, the pyramid.
-_DEFAULT_DISPLAY_PX = 512
+# still cannot do is give the detail back on zoom; that is FIB-414, the pyramid, and it
+# is the only one of these that does not pay for detail at every other zoom level.
+_DEFAULT_DISPLAY_PX = 2048
 
 
 def _require_displayable(data: np.ndarray) -> None:

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -511,13 +511,21 @@ def test_update_image_reports_an_unknown_key():
     assert _canvas().update_image("nope", _img()) is False
 
 
-def test_the_default_display_cap_favours_redraw_speed():
-    """A redraw costs the total stored pixels, so the default is tuned for the case this
-    canvas exists for — many images at once, where 512 px already exceeds what each gets
-    on screen. At 1024 px a 100-tile redraw took 2.7 s; at 512 px it takes ~0.7 s."""
+def test_the_default_display_cap_trades_redraw_speed_for_a_readable_mosaic():
+    """A redraw costs the total stored pixels across every placed image, so the default
+    is a trade rather than a free choice.
+
+    Raised to 2048 for FIB-658: a mosaic is tens of thousands of pixels across, and 512
+    showed ~0.02% of them. Measured per redraw on an 8192 px source — one image 13.9 ms
+    at 512, 100 ms at 2048; five images 42.6 ms at 512, 451 ms at 2048. One overview
+    stays comfortable and a canvas carrying several runs does not, which is the cost
+    being accepted here until FIB-414 gives detail back on zoom instead.
+    """
     c = _canvas()
-    c.add_image(_img(1024, 1024), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
-    assert max(c._ax.get_images()[0].get_array().shape) <= 512
+    c.add_image(_img(4096, 4096), centre=(0.0, 0.0), pixel_size=PIXEL_SIZE)
+    stored = max(c._ax.get_images()[0].get_array().shape)
+    assert stored <= 2048
+    assert stored > 512, "the point of the raise is that a large image keeps more"
 
 
 def test_the_display_cap_bounds_what_each_image_stores():


### PR DESCRIPTION
An FM overview is tens of thousands of pixels across — a 10×10 grid at the ARCTIS camera's 4512 px tiles stitches to 41,052 px square — and the real-space canvas stored 512 of them. That is about **0.02% of what the run acquired**, too coarse to read the sample you just spent a run collecting.

This raises the per-image cap to 2048.

## It is a trade, not a free win

A redraw costs the total stored pixels across *every* placed image. Measured per redraw on an 8192 px source:

| images on canvas | 512 | 1024 | 2048 |
| -- | -- | -- | -- |
| one | 13.9 ms | 30.8 ms | **100 ms** |
| five | 42.6 ms | 126 ms | **451 ms** |

One overview stays comfortable. A canvas someone has placed several runs on does not — and since overviews accumulate across a session, it degrades as you work rather than being bad immediately, which is the more annoying failure. **1024 is the fallback** if that bites before FIB-414 lands.

Worth reviewing on that basis: this is a deliberate regression for the multi-overview case, bought for a large improvement in the single-overview case.

## The old rationale no longer described this canvas

The comment being replaced cited "100 tiles kept at 1024 px take ~2.7 s, against ~0.75 s at 512". That measured **one artist per tile**; an overview is placed as a single growing image per run now, so the figure describes a placement model that was reversed. Measured again here.

But note which way that cuts: the saving from one-artist-per-run is *why* 512 has felt fine, not headroom that was going spare. The cost still scales with stored pixels, which is why five overviews at 2048 is slow.

## What actually wants fixing

None of this gives detail back on zoom — it just stores more of it at every zoom level. FIB-414 (pyramids) is the option that does, and the only one that does not pay for detail at all zoom levels at once. This is a stopgap until then.

Related: FIB-672 pulls the other way — a whole-grid mosaic already exceeds what memory can hold, so there is a ceiling on the pixels this cap is trying to show more of.

## Verified

`tests/ui/` — 1360 passed, 1 skipped. One failure and five errors remain, all **pre-existing on main** and unrelated (`test_the_context_overlays_describe_where_the_stage_can_go`, and the `test_fm_live_indicator` errors); confirmed by running the same files with the change stashed.

The test pinning the old value is updated rather than deleted — it now asserts the cap *and* that a large image keeps more than 512, so a silent revert fails it.
