### PR TITLE
[perf] Filter images with opencv, not scipy (FIB-671)

### DIFF
--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -12,10 +12,10 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Callable, List, Mapping, Optional, Sequence, Tuple, Union, Set, Any, Dict, Type, TypeVar, Literal, TYPE_CHECKING
 
+import cv2
 import numpy as np
 import tifffile as tff
 from numpy.typing import NDArray
-from scipy.ndimage import median_filter, gaussian_filter
 
 import fibsem
 from fibsem.versioning import get_revision
@@ -2672,7 +2672,23 @@ class FibsemImage:
 
     def _filter_data(self, data, size: int = 3, sigma: float = 1) -> NDArray:
         """Returns a filtered version of the image data using a median filter followed by a gaussian filter. Can be used for display or processing purposes."""
-        return gaussian_filter(median_filter(data, size=size), sigma=sigma)
+        # opencv rather than scipy: the same two filters, ~300x faster at 4096x4096. the
+        # setter runs this on every assignment, including the one inside load(), so a
+        # 385 MB overview took ~30 s to load on scipy and ~0.2 s here. data is 2D uint8 or
+        # uint16 (check_data_format), exactly what medianBlur(ksize=3) accepts.
+        # the kernel size and border mode match scipy, not opencv's defaults, which would be
+        # a 7x7 kernel and reflect-101 -- 16x further from the output this replaces.
+        radius = int(4.0 * sigma + 0.5)  # scipy's gaussian_filter default truncate=4.0
+        ksize = 2 * radius + 1
+        filtered = cv2.GaussianBlur(
+            cv2.medianBlur(data, size),
+            (ksize, ksize),
+            sigma,
+            borderType=cv2.BORDER_REFLECT,
+        )
+        # opencv drops a trailing length-1 axis. (H, W, 1) can reach the setter unsqueezed
+        # -- only __init__ squeezes it -- and filtered_data has always matched data's shape.
+        return filtered.reshape(data.shape)
 
     @classmethod
     def load(cls, tiff_path: str) -> "FibsemImage":

--- a/tests/test_image_display_filter.py
+++ b/tests/test_image_display_filter.py
@@ -1,0 +1,109 @@
+"""Pins FibsemImage.filtered_data to the scipy filter it replaced.
+
+The display filter moved from scipy to opencv for speed (the ``.data`` setter runs it
+on every assignment, including inside ``FibsemImage.load()``, which hung the app for
+~57 s on a 385 MB overview). Matching scipy is not automatic: it needs a kernel size
+derived from scipy's ``truncate=4.0`` and ``BORDER_REFLECT``. On opencv's defaults the
+outputs are ~16x further apart, so the tolerance here is what catches a "simplification"
+back to the defaults.
+"""
+
+import numpy as np
+import pytest
+from scipy.ndimage import gaussian_filter, median_filter
+
+from fibsem.autofunctions.metrics import get_focus_measure_function
+from fibsem.structures import FibsemImage
+
+# most pixels differ by exactly 1 (a rounding convention), none by more than 2.
+FILTER_TOLERANCE = 2
+
+FOCUS_METHODS = ["laplacian", "sobel", "variance", "tenengrad"]
+
+
+def scipy_filter(data):
+    """The filter FibsemImage used before opencv. The reference these tests pin to."""
+    return gaussian_filter(median_filter(data, size=3), sigma=1)
+
+
+def beam_like_image(dtype=np.uint16, blur=0.0, seed=0, shape=(256, 320)):
+    """Something with the structure of a beam image: gradients, a bright feature, noise."""
+    height, width = shape
+    rng = np.random.default_rng(seed)
+    max_value = np.iinfo(dtype).max
+    yy, xx = np.mgrid[0:height, 0:width]
+    data = (0.5 + 0.35 * np.sin(xx / 30.0) * np.cos(yy / 41.0)) * max_value
+    data[height // 3: height // 3 + 20, width // 4: width // 4 + 100] = max_value * 0.95
+    data[50:200:37, :] = max_value * 0.2  # fine structure a focus measure keys on
+    if blur:
+        data = gaussian_filter(data, sigma=blur)
+    data = data + rng.normal(0, max_value * 0.01, size=shape)
+    return np.clip(data, 0, max_value).astype(dtype)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16])
+@pytest.mark.parametrize("kind", ["beam", "noise"])
+def test_filtered_data_matches_the_scipy_filter_it_replaced(dtype, kind):
+    if kind == "beam":
+        data = beam_like_image(dtype=dtype)
+    else:
+        # pure noise is the worst case for the median: every pixel is an edge.
+        data = (np.random.default_rng(1).random((256, 320)) * np.iinfo(dtype).max).astype(dtype)
+
+    filtered = FibsemImage(data=data).filtered_data
+
+    difference = np.abs(filtered.astype(np.int64) - scipy_filter(data).astype(np.int64))
+    assert difference.max() <= FILTER_TOLERANCE, (
+        f"display filter drifted from scipy: max difference {difference.max()} grey levels"
+    )
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16])
+def test_filtered_data_keeps_the_shape_and_dtype_of_data(dtype):
+    data = beam_like_image(dtype=dtype, shape=(64, 80))
+
+    image = FibsemImage(data=data)
+
+    assert image.filtered_data.shape == data.shape
+    assert image.filtered_data.dtype == data.dtype
+
+
+def test_filtered_data_handles_an_unsqueezed_3d_assignment():
+    """(H, W, 1) reaches the setter: only __init__ squeezes it, a direct assignment does not."""
+    data = beam_like_image(shape=(64, 80))
+    image = FibsemImage(data=data)
+
+    image.data = data[:, :, np.newaxis]
+
+    assert image.filtered_data.shape == image.data.shape
+    assert np.array_equal(image.filtered_data.reshape(data.shape), FibsemImage(data=data).filtered_data)
+
+
+@pytest.mark.parametrize("method", FOCUS_METHODS)
+def test_autofocus_picks_the_same_step_after_the_filter_swap(method):
+    """The filter is a display filter, but autofocus scores an algorithm off it.
+
+    Mirrors the score at ``autofocus.py:300`` over a sweep through focus. What is
+    asserted is the decision the sweep makes -- which step wins -- and that the winning
+    score itself barely moves. Deliberately not the ranking of the whole sweep: on three
+    real autofocus runs the peak was untouched (<=0.05%) but the deep-defocus tail moved
+    up to 2.2% and did reorder, because there the score is small and nearly flat. The
+    peak stands ~5x above that tail, so reordering down there cannot move the winner.
+    """
+    focus_fn = get_focus_measure_function(method)
+    # a WD sweep: sharp in the middle, defocused at both ends.
+    blurs = [4.0, 2.0, 1.0, 0.0, 1.0, 2.0, 4.0]
+    images = [beam_like_image(blur=blur, seed=index) for index, blur in enumerate(blurs)]
+
+    def score(data):
+        return float(np.mean(focus_fn(data.astype(np.float32))))
+
+    scores = np.array([score(FibsemImage(data=image).filtered_data) for image in images])
+    reference = np.array([score(scipy_filter(image)) for image in images])
+
+    assert int(np.argmax(scores)) == int(np.argmax(reference)), (
+        "the sweep would choose a different working distance"
+    )
+    peak = np.argmax(reference)
+    peak_shift = abs(scores[peak] - reference[peak]) / abs(reference[peak])
+    assert peak_shift < 0.005, f"score at the chosen step moved by {peak_shift:.2%}"


### PR DESCRIPTION
`FibsemImage._filtered_data` is populated by the `.data` setter, so `gaussian_filter(median_filter(data, size=3), sigma=1)` runs eagerly on **every assignment** — including the one inside `FibsemImage.load()`. It is paid by all eleven consumers of `FibsemImage`, not just the overview, and on a 385 MB overview it hung the app for the best part of a minute.

This swaps the two filters to opencv (already a core dependency). No API change, no call-site changes.

## Speed

Timing `FibsemImage.load()`:

| | before | after |
| -- | -- | -- |
| real 3072×3072 overview | 0.829 s | 0.011 s |
| synthetic 385 MB overview (13875²) | 28.2 s | 0.198 s |

Where the 380× at 4096² comes from — almost entirely the median:

| | scipy | opencv | |
| -- | -- | -- | -- |
| median 3×3 | 2249 ms (134 ns/px) | 2.5 ms (0.15 ns/px) | 888× |
| gaussian σ=1 | 322 ms | 4.2 ms | 76× |

`scipy.ndimage.median_filter` is a generic N-dimensional rank filter: per pixel it walks a footprint, gathers 9 values and partial-sorts them with data-dependent branching. opencv's `medianBlur` has a hardcoded 3×3 path — a branch-free sorting network run through SIMD on 8 uint16 lanes at a time. Threading is the small part: pinned to one thread opencv is still 74× overall.

## Why these parameters

`(9, 9)` and `BORDER_REFLECT`, not opencv's defaults, which would pick a 7×7 kernel and reflect-101 — **16× further** from the output being replaced. The kernel size is derived from sigma (`2*int(4*sigma+0.5)+1`) because that is scipy's `truncate=4.0`.

Tuned this way the two agree to within **2 grey levels of 255**. Verified over all 156 `.tif` images of a real experiment (409×384, 464², 1128² uint16, 1024×1536, and a 1024×3072 overview): max difference 2, mean 0.999, none failing to load. The difference is a near-uniform 1 grey level with no structure — no edge halos, no ringing, nothing at the stitch seams.

No dtype fallback is needed: `check_data_format` already restricts `.data` to 2-D uint8/uint16, exactly what `medianBlur(ksize=3)` accepts.

## The systematic ±1, where it lands

Two consumers compute off `filtered_data` rather than display it, so both were measured on real data rather than assumed safe:

- **autofocus** (`autofocus.py:300`) scores a WD sweep. Over three real autofocus runs the chosen working distance is identical in all five passes, and the score at the peak moves 0.003–0.021%. Out in the flat defocused tail, where the score is small, it moves up to 2.2% and *can* reorder — the peak stands ~5× above that tail so it cannot move the winner, but on a sweep with no focus signal at all the choice was already arbitrary. The test therefore asserts the step the sweep picks, not the ranking of the whole sweep.
- **`hole_fitting_FIB`** (correlation) refines a click to sub-pixel. Over 30 seed points on three real images the fitted centre moves at most 0.27 px, mean 0.03 px.

Everything else that reads `filtered_data` is display: minimap, canvas, overview, tiled mosaic, thumbnails, plots.

## Two behaviour notes

- **Shape.** opencv returns 2-D for an `(H, W, 1)` input. `(H, W, 1)` can reach the setter unsqueezed — only `__init__` squeezes it — so the result is reshaped back to `data.shape`, which is what `filtered_data` has always matched. Covered by a test.
- **Empty arrays.** scipy filtered a `(0, 0)` array happily; opencv raises. Nothing in the codebase constructs an empty `FibsemImage`, so there is no guard rather than a branch for a path that does not exist. Say the word if you would rather have one.

## Tests

New `tests/test_image_display_filter.py` (11 tests, CI-visible): the filter pinned against scipy within 2 grey levels on uint8/uint16 × beam-like/pure-noise, shape and dtype preservation, the unsqueezed 3-D assignment, and the autofocus score parametrised over all four focus measures. The tolerance is what catches a future "simplification" back to opencv's defaults — mutating the code that way fails four of them.

Existing suites pass: 654 in structures / tiled / autofunctions / autofocus / acquire / alignment / reduction / sparse-tiles / import-cycles / correlation, 427 in the canvas and overview UI tests, 18 in the coincidence viewer canvas.

## Scope

Step 1 of the three in FIB-671, and the whole of the hang. Step 2 (making the filter lazy) is deliberately separate: at 4 ms it is no longer about speed, and deferring the compute opens a write/read race between a worker setting `.data` and the GUI reading `filtered_data`. Step 3 (moving it off the main thread) has nothing left to justify it.
