### PR TITLE
[refactor] Generate the workflow border stylesheet instead of writing it twice (FIB-679)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -61,7 +61,7 @@ from fibsem.ui.stylesheets import (
     SECONDARY_BUTTON_STYLESHEET,
     GRAY_ICON_COLOR,
     DEFECT_ORANGE_COLOR,
-    WORKFLOW_BORDER_STYLESHEET,
+    border_stylesheet,
 )
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
 from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
@@ -230,7 +230,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         # Apply napari-style dark theme. Border state rules live here (on the parent)
         # so that setProperty + unpolish/polish on _border_frame re-evaluates them.
-        self.setStyleSheet(NAPARI_STYLE + WORKFLOW_BORDER_STYLESHEET)
+        self.setStyleSheet(NAPARI_STYLE + border_stylesheet("workflow_border_frame"))
 
         # Central tab widget wrapped in a QFrame so the border renders reliably
         self.tab_widget = QTabWidget()

--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -83,10 +83,6 @@ from fibsem.ui.tokens import (
     BORDER_COLOR,
     DISABLED_BG_COLOR,
     DISABLED_TEXT_COLOR,
-    OK_COLOR,
-    ORANGE_COLOR,
-    PRIMARY_COLOR,
-    SEMANTIC_ERROR_COLOR,
     SURFACE_COLOR,
     TEXT_COLOR,
 )
@@ -103,15 +99,6 @@ _HEADER_BG = CANVAS_BG
 
 # name used for the coincidence entry in the lamella review panel / task history
 COINCIDENCE_REVIEW_TASK_NAME = "Coincidence Milling"
-
-COINCIDENCE_BORDER_STYLESHEET = f"""
-    QFrame#coincidence_border_frame[borderState="idle"]       {{ border: 4px solid {SURFACE_COLOR}; }}
-    QFrame#coincidence_border_frame[borderState="automated"]  {{ border: 4px solid {OK_COLOR}; }}
-    QFrame#coincidence_border_frame[borderState="supervised"] {{ border: 4px solid {PRIMARY_COLOR}; }}
-    QFrame#coincidence_border_frame[borderState="waiting"]    {{ border: 4px solid {ORANGE_COLOR}; }}
-    QFrame#coincidence_border_frame[borderState="finished"]   {{ border: 4px solid {OK_COLOR}; }}
-    QFrame#coincidence_border_frame[borderState="stopped"]    {{ border: 4px solid {SEMANTIC_ERROR_COLOR}; }}
-"""
 
 
 def _fmt_timestamp(ts: float) -> str:
@@ -685,7 +672,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
 
         outer.addWidget(self._build_bottom_bar())
 
-        self.setStyleSheet(stylesheets.NAPARI_STYLE + COINCIDENCE_BORDER_STYLESHEET)
+        self.setStyleSheet(
+            stylesheets.NAPARI_STYLE
+            + stylesheets.border_stylesheet("coincidence_border_frame")
+        )
 
         # Apply initial selected-view border (FM selected by default)
         self._set_selected_view(self.selected_view)

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -301,16 +301,43 @@ QToolTip {{
 }}
 """
 
+# The workflow border is drawn by two widgets -- the AutoLamella main window
+# (``workflow_border_frame``) and the coincidence viewer (``coincidence_border_frame``)
+# -- and the rules used to be spelled out once per widget. That is how ``agent``
+# came to exist in one copy and not the other. One mapping and one builder, so
+# adding a state or changing a colour is a single edit rather than two.
+#
 # TODO: no token -- #BF00FF
-WORKFLOW_BORDER_STYLESHEET = f"""
-    QFrame#workflow_border_frame[borderState="idle"]       {{ border: 4px solid {SURFACE_COLOR}; }}
-    QFrame#workflow_border_frame[borderState="automated"]  {{ border: 4px solid {OK_COLOR}; }}
-    QFrame#workflow_border_frame[borderState="supervised"] {{ border: 4px solid {PRIMARY_COLOR}; }}
-    QFrame#workflow_border_frame[borderState="waiting"]    {{ border: 4px solid {ORANGE_COLOR}; }}
-    QFrame#workflow_border_frame[borderState="finished"]  {{ border: 4px solid {OK_COLOR}; }}
-    QFrame#workflow_border_frame[borderState="stopped"]   {{ border: 4px solid {SEMANTIC_ERROR_COLOR}; }}
-    QFrame#workflow_border_frame[borderState="agent"]     {{ border: 4px solid #BF00FF; }}
-"""
+BORDER_STATE_COLOURS = {
+    "idle": SURFACE_COLOR,
+    "automated": OK_COLOR,
+    "supervised": PRIMARY_COLOR,
+    "waiting": ORANGE_COLOR,
+    "finished": OK_COLOR,
+    "stopped": SEMANTIC_ERROR_COLOR,
+    "agent": "#BF00FF",
+}
+
+BORDER_WIDTH_PX = 4
+
+
+def border_stylesheet(object_name: str) -> str:
+    """QSS border rules for the frame whose ``objectName`` is *object_name*.
+
+    Applied to the frame's parent rather than the frame itself, so that
+    ``setProperty("borderState", ...)`` plus unpolish/polish re-evaluates them.
+    """
+    selectors = {
+        state: f'QFrame#{object_name}[borderState="{state}"]'
+        for state in BORDER_STATE_COLOURS
+    }
+    width = max(len(sel) for sel in selectors.values())
+    rules = "\n".join(
+        f"    {selectors[state]:<{width}} {{ border: {BORDER_WIDTH_PX}px solid {colour}; }}"
+        for state, colour in BORDER_STATE_COLOURS.items()
+    )
+    return f"\n{rules}\n"
+
 
 # TODO: no token -- #6a6a6a, #8a8a8a
 TOOLBUTTON_ICON_STYLESHEET = f"""

--- a/tests/test_border_stylesheet_single_source.py
+++ b/tests/test_border_stylesheet_single_source.py
@@ -1,0 +1,44 @@
+"""The workflow border QSS is written in exactly one module (FIB-679).
+
+Two widgets draw this border -- the AutoLamella main window and the coincidence
+viewer -- and the rules used to be spelled out once per widget. That is how the
+``agent`` state came to exist in one copy and not the other, so a coincidence run
+driven by an agent fell through to no rule at all.
+
+Source-level on purpose. ``fibsem.ui.__init__`` eagerly imports Qt widgets, so any
+``from fibsem.ui...`` import needs PyQt5 -- which CI deliberately does not install
+(see the ``[ui]`` extra note in python-package.yml). Reading the files instead keeps
+this guard running on every version in the matrix, which is the whole point: it is
+what stops the rules being copied a third time. The behavioural tests that need a
+real widget live in tests/ui/test_border_stylesheet.py and skip without PyQt5.
+"""
+import pathlib
+
+FIBSEM = pathlib.Path(__file__).resolve().parents[1] / "fibsem"
+OWNER = FIBSEM / "ui" / "stylesheets.py"
+
+
+def test_border_rules_are_not_hand_written_outside_the_stylesheet_module():
+    """``[borderState="`` appears only in a QSS selector, never in widget code.
+
+    Widgets set the property with ``setProperty("borderState", ...)``, which does
+    not match this string. So a hit anywhere but the owner module means someone
+    has written a second copy of the rules.
+    """
+    offenders = [
+        str(path.relative_to(FIBSEM.parent))
+        for path in FIBSEM.rglob("*.py")
+        if path != OWNER and '[borderState="' in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == [], (
+        "border rules duplicated outside fibsem/ui/stylesheets.py: "
+        + ", ".join(offenders)
+    )
+
+
+def test_the_owner_module_still_generates_them():
+    """Guard against the above passing vacuously if the generator is removed."""
+    source = OWNER.read_text(encoding="utf-8")
+    assert "def border_stylesheet(" in source
+    assert "BORDER_STATE_COLOURS" in source
+    assert '[borderState="' in source

--- a/tests/ui/test_border_stylesheet.py
+++ b/tests/ui/test_border_stylesheet.py
@@ -1,0 +1,81 @@
+"""The workflow border QSS is generated, not hand-written (FIB-679).
+
+Two widgets draw this border -- the AutoLamella main window and the coincidence
+viewer -- and the rules used to be spelled out once per widget. That is how the
+``agent`` state came to exist in one copy and not the other, so a coincidence run
+driven by an agent fell through to no rule at all.
+
+These tests are deliberately string-level and import no Qt: ``fibsem.ui.stylesheets``
+pulls in only ``os`` and the palette, so the guard runs anywhere the package does.
+"""
+import pathlib
+import re
+
+from fibsem.ui.stylesheets import (
+    BORDER_STATE_COLOURS,
+    BORDER_WIDTH_PX,
+    border_stylesheet,
+)
+
+RULE = re.compile(
+    r'QFrame#(?P<name>\w+)\[borderState="(?P<state>\w+)"\]\s*'
+    r'\{\s*border:\s*(?P<px>\d+)px solid (?P<colour>#[0-9A-Fa-f]{6});\s*\}'
+)
+
+# Every widget that owns a border frame. Adding one here is the cheap way to keep
+# it in the generated set rather than growing a second copy of the rules.
+BORDER_FRAME_NAMES = ["workflow_border_frame", "coincidence_border_frame"]
+
+
+def test_emits_exactly_one_rule_per_state():
+    for name in BORDER_FRAME_NAMES:
+        rules = RULE.findall(border_stylesheet(name))
+        assert len(rules) == len(BORDER_STATE_COLOURS)
+
+
+def test_each_rule_carries_the_declared_colour_and_width():
+    for name in BORDER_FRAME_NAMES:
+        found = {
+            m.group("state"): (m.group("px"), m.group("colour").upper())
+            for m in RULE.finditer(border_stylesheet(name))
+        }
+        expected = {
+            state: (str(BORDER_WIDTH_PX), colour.upper())
+            for state, colour in BORDER_STATE_COLOURS.items()
+        }
+        assert found == expected
+
+
+def test_selector_targets_the_requested_object_name():
+    sheet = border_stylesheet("some_other_frame")
+    assert {m.group("name") for m in RULE.finditer(sheet)} == {"some_other_frame"}
+    assert "workflow_border_frame" not in sheet
+
+
+def test_every_border_frame_gets_the_same_states():
+    """The drift this replaced: one frame had `agent`, the other did not."""
+    per_frame = [
+        {m.group("state") for m in RULE.finditer(border_stylesheet(name))}
+        for name in BORDER_FRAME_NAMES
+    ]
+    assert all(states == per_frame[0] for states in per_frame)
+
+
+def test_border_rules_are_not_hand_written_anywhere_else():
+    """`[borderState="` appears only in a QSS selector, never in widget code.
+
+    Widgets set the property with ``setProperty("borderState", ...)``, which does
+    not match. So a hit outside stylesheets.py means someone has written a second
+    copy of the rules -- exactly what FIB-679 removed.
+    """
+    root = pathlib.Path(__file__).resolve().parents[2] / "fibsem"
+    owner = root / "ui" / "stylesheets.py"
+    offenders = [
+        str(path.relative_to(root.parent))
+        for path in root.rglob("*.py")
+        if path != owner and '[borderState="' in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == [], (
+        "border rules duplicated outside fibsem/ui/stylesheets.py: "
+        + ", ".join(offenders)
+    )

--- a/tests/ui/test_border_stylesheet.py
+++ b/tests/ui/test_border_stylesheet.py
@@ -1,17 +1,18 @@
-"""The workflow border QSS is generated, not hand-written (FIB-679).
+"""The generated border QSS carries every state, for every frame that draws one.
 
-Two widgets draw this border -- the AutoLamella main window and the coincidence
-viewer -- and the rules used to be spelled out once per widget. That is how the
-``agent`` state came to exist in one copy and not the other, so a coincidence run
-driven by an agent fell through to no rule at all.
-
-These tests are deliberately string-level and import no Qt: ``fibsem.ui.stylesheets``
-pulls in only ``os`` and the palette, so the guard runs anywhere the package does.
+The single-source guard -- that these rules are not hand-written a second time --
+lives in tests/test_border_stylesheet_single_source.py, which imports nothing and so
+still runs on CI. This module needs the real ``fibsem.ui`` package, and importing any
+part of it pulls in Qt through ``fibsem/ui/__init__.py``, so it skips without PyQt5.
 """
-import pathlib
 import re
 
-from fibsem.ui.stylesheets import (
+import pytest
+
+pytest.importorskip("PyQt5")
+pytest.importorskip("napari")
+
+from fibsem.ui.stylesheets import (  # noqa: E402
     BORDER_STATE_COLOURS,
     BORDER_WIDTH_PX,
     border_stylesheet,
@@ -59,23 +60,3 @@ def test_every_border_frame_gets_the_same_states():
         for name in BORDER_FRAME_NAMES
     ]
     assert all(states == per_frame[0] for states in per_frame)
-
-
-def test_border_rules_are_not_hand_written_anywhere_else():
-    """`[borderState="` appears only in a QSS selector, never in widget code.
-
-    Widgets set the property with ``setProperty("borderState", ...)``, which does
-    not match. So a hit outside stylesheets.py means someone has written a second
-    copy of the rules -- exactly what FIB-679 removed.
-    """
-    root = pathlib.Path(__file__).resolve().parents[2] / "fibsem"
-    owner = root / "ui" / "stylesheets.py"
-    offenders = [
-        str(path.relative_to(root.parent))
-        for path in root.rglob("*.py")
-        if path != owner and '[borderState="' in path.read_text(encoding="utf-8")
-    ]
-    assert offenders == [], (
-        "border rules duplicated outside fibsem/ui/stylesheets.py: "
-        + ", ".join(offenders)
-    )


### PR DESCRIPTION
The border-state QSS existed twice — once per widget that draws a border — and the two copies had already drifted.

| | `workflow_border_frame` | `coincidence_border_frame` |
|---|---|---|
| defined in | `fibsem/ui/stylesheets.py` | `fluorescence_coincidence_viewer_widget.py` |
| states | 7 | 6 — **no `agent`** |

Same tokens, same `4px solid`, same rules, written out twice. `agent` was added to one and not the other, so a coincidence run driven by an agent matched no rule and rendered **no border at all**.

## Change

One `BORDER_STATE_COLOURS` mapping and one `border_stylesheet(object_name)` builder in `stylesheets.py`. Each widget passes its own frame name. Adding a state or changing a colour is now one edit instead of two that have to be kept in agreement by hand.

## Rendering is unchanged

Verified on the **real widgets** — building `AutoLamellaSingleWindowUI` and `FluorescenceCoincidenceViewerWidget`, calling their own `_set_border_state()` for every state, and sampling the pixel each border actually paints on all four edges:

```
--- AutoLamella main window (AutoLamellaSingleWindowUI) ---
  idle        expect #262930  painted ['#262930']  OK
  automated   expect #4CAF50  painted ['#4CAF50']  OK
  supervised  expect #007ACC  painted ['#007ACC']  OK
  waiting     expect #FF9800  painted ['#FF9800']  OK
  finished    expect #4CAF50  painted ['#4CAF50']  OK
  stopped     expect #99121F  painted ['#99121F']  OK
  agent       expect #BF00FF  painted ['#BF00FF']  OK
  re-entry    expect #99121F  painted ['#99121F']  OK
```

Identical for the coincidence viewer. This exercises what a synthetic harness would miss: `NAPARI_STYLE` is prepended to the generated rules, the repaint goes through `setProperty` + unpolish/polish, and `app.setStyle("Fusion")` is applied as `run_ui` does. The re-entry line covers `_set_border_state`'s early return when the state is unchanged.

Rule-level and rendered-pixel comparisons against the verbatim pre-refactor sheets also match for every shared state.

**The one intended difference:** `agent` now paints on the coincidence frame. Nothing sets that state there today, so it is inert — but the two sheets can no longer disagree.

## Tests

`tests/test_border_stylesheet_single_source.py` guards the invariant rather than the output: `[borderState="` appears only inside a QSS selector, never in widget code (which uses `setProperty("borderState", ...)`), so a hit outside `stylesheets.py` means a second copy has been written again.

It reads the source files and imports nothing, which is deliberate. `stylesheets.py` itself looks Qt-free, but importing any `fibsem.ui` submodule runs `fibsem/ui/__init__.py`, which eagerly imports the Qt widgets — so an import-based guard would skip on CI, where the `[ui]` extra is not installed. A guard that skips on CI would not catch the drift it exists for.

`tests/ui/test_border_stylesheet.py` holds the tests that need `border_stylesheet` itself, and skips without PyQt5 like its neighbours.

## Deliberately not in scope

- **`finished` is dead code** — declared in both sheets, never set by any call site. Whether to delete it or wire it up and latch it is FIB-678's call, and making it from inside a mechanical refactor would decide it by accident. It carries across unchanged; removing it later is one line in one dict.
- **`#BF00FF` stays hardcoded**, TODO and all. FIB-676 revisits the palette and adds a `pending` state; this lands first so that one only has to touch a single file.

Tests: `tests/ui/test_border_stylesheet.py`, `tests/ui/test_coincidence_viewer_layering.py` — 10 passed.

