### PR TITLE
[fix] Let the inverse conversion express the same centre as the forward one (FIB-688)

### DIFF
--- a/fibsem/conversions.py
+++ b/fibsem/conversions.py
@@ -5,6 +5,34 @@ import numpy as np
 from fibsem.structures import FibsemImage, Point
 
 
+def get_image_pixel_centre(
+    image_shape: Tuple[int, int], subpixel_precision: bool = False
+) -> Tuple[float, float]:
+    """The centre of an image, in pixels, as ``(cy, cx)``.
+
+    Note the order: ``(y, x)``, matching image shape rather than the ``(x, y)``
+    of :class:`~fibsem.structures.Point`. Kept that way because every existing
+    caller unpacks it as ``icy, icx``.
+
+    ``subpixel_precision=False`` floors to a whole pixel. That is what the
+    movement, milling and detection paths have always done, and it only differs
+    from the true centre on an odd image dimension -- by half a pixel.
+
+    Moved here from ``fibsem.ui.napari.patterns`` (FIB-644): it is pure geometry
+    with no UI content, and living in a napari module meant
+    ``milling/patterning/plotting.py`` could not import it without dragging a UI
+    stack in, so it computed the same centre inline instead.
+    """
+    centre = np.asarray(image_shape)
+    centre = centre / 2 if subpixel_precision else centre // 2
+    cy, cx = centre  # raises for a shape that is not 2-D
+    # Python scalars, not numpy ones: the floored centre used to be a plain int
+    # and is handed to callers that index, format and serialise it. np.int64
+    # behaves like int almost everywhere -- json.dumps being the notable
+    # exception -- so this keeps the old type rather than relying on that.
+    return (float(cy), float(cx)) if subpixel_precision else (int(cy), int(cx))
+
+
 def image_to_microscope_image_coordinates_px(
     coord: Point, image_shape: Tuple[int, int], subpixel_precision: bool
 ) -> Point:
@@ -29,10 +57,7 @@ def image_to_microscope_image_coordinates_px(
         Point: A Point object representing the corresponding microscope image coordinates, in pixels.
     """
     # convert from image pixel coord (0, 0) top left to microscope image (0, 0) mid
-    centre_px = np.asarray(image_shape) / 2
-    if not subpixel_precision:
-        centre_px = np.asarray(image_shape) // 2
-    cy, cx = centre_px
+    cy, cx = get_image_pixel_centre(image_shape, subpixel_precision)
 
     # distance from centre?
     return Point(
@@ -89,7 +114,12 @@ def image_to_microscope_image_coordinates2(
 
     return point_px._to_metres(pixel_size=pixelsize)
 
-def microscope_image_to_image_coordinates(point: Point, image_shape: Tuple[int, int], pixel_size: float) -> Point:
+def microscope_image_to_image_coordinates(
+    point: Point,
+    image_shape: Tuple[int, int],
+    pixel_size: float,
+    subpixel_precision: bool = False,
+) -> Point:
     """
     Convert a microscope image coordinate to an image pixel coordinate. 
     The microscope image coordinate system is centered on the image with positive Y-axis pointing upwards.
@@ -97,6 +127,11 @@ def microscope_image_to_image_coordinates(point: Point, image_shape: Tuple[int, 
         point (Point): A Point object representing the microscope image coordinates in metres.
         image_shape (Tuple[int, int]): A tuple representing the shape of the image (height, width).
         pixel_size (float): The pixel size in metres.
+        subpixel_precision (bool): Floors the centre to a whole pixel if False.
+            Defaults False, matching this function's long-standing behaviour --
+            but note the forward conversion is called with True by the
+            correlation module, and pairing the two centres round-trips a point
+            half a pixel off on an odd image dimension (FIB-644).
     Returns:
         Point: A Point object representing the corresponding pixel coordinates in the original image.
     """
@@ -105,7 +140,7 @@ def microscope_image_to_image_coordinates(point: Point, image_shape: Tuple[int, 
     pmx, pmy = mx / pixel_size, my / pixel_size
 
     # convert to image coordinates
-    cy, cx = image_shape[0] // 2, image_shape[1] // 2
+    cy, cx = get_image_pixel_centre(image_shape, subpixel_precision)
     px = cx + pmx
     py = cy - pmy
 

--- a/fibsem/ui/napari/patterns.py
+++ b/fibsem/ui/napari/patterns.py
@@ -19,6 +19,7 @@ from fibsem.milling.patterning.patterns2 import (
     BasePattern,
     FiducialPattern,
 )
+from fibsem.conversions import get_image_pixel_centre
 from fibsem.structures import (
     FibsemBitmapSettings,
     FibsemCircleSettings,
@@ -57,12 +58,6 @@ IGNORE_SHAPES_LAYERS = ["ruler_line", "crosshair", "scalebar", "label", "overlay
 STAGE_POSTIION_SHAPE_LAYERS = ["saved-stage-positions", "current-stage-position", "stage-position"] # for minimap
 IGNORE_SHAPES_LAYERS.extend(STAGE_POSTIION_SHAPE_LAYERS)
 CURRENT_PATTERN_LAYERS: Set[str] = set()
-
-def get_image_pixel_centre(shape: Tuple[int, int]) -> Tuple[int, int]:
-    """Get the centre of the image in pixel coordinates."""
-    icy, icx = shape[0] // 2, shape[1] // 2
-    return icy, icx
-
 
 def create_affine_matrix(
     scale: Tuple[float, float] = (1, 1),

--- a/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
@@ -33,12 +33,12 @@ from fibsem.structures import (
     FibsemPolygonSettings,
     FibsemRectangleSettings,
 )
+from fibsem.conversions import get_image_pixel_centre
 from fibsem.ui.napari.patterns import (
     COLOURS,
     convert_pattern_to_napari_line,
     convert_pattern_to_napari_polygon,
     convert_pattern_to_napari_rect,
-    get_image_pixel_centre,
 )
 from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 from fibsem.conversions import (
+    get_image_pixel_centre,
     image_to_microscope_image_coordinates,
     image_to_microscope_image_coordinates2,
     image_to_microscope_image_coordinates_px,
@@ -185,15 +186,94 @@ def test_a_non_2d_shape_is_rejected():
         image_to_microscope_image_coordinates2(Point(0.0, 0.0), (512, 512, 3), PIXEL_SIZE)
 
 
-def test_the_inverse_round_trips():
-    """`microscope_image_to_image_coordinates` floors the centre unconditionally,
-    so it is the forward conversion's default that it inverts."""
+# ---------------------------------------------------------------------------
+# the shared centre (FIB-644)
+# ---------------------------------------------------------------------------
+
+
+def test_the_centre_is_y_then_x():
+    """Order matters and is easy to get backwards: (cy, cx), matching image
+    shape rather than the (x, y) of Point. Checked on a rectangle, since a
+    square cannot tell the two apart."""
+    assert get_image_pixel_centre(EVEN) == (256, 512)
+
+
+def test_the_centre_floors_by_default_and_can_be_exact():
+    assert get_image_pixel_centre(ODD) == (255, 511)
+    assert get_image_pixel_centre(ODD, subpixel_precision=True) == (255.5, 511.5)
+
+
+def test_the_floored_centre_stays_a_plain_int():
+    """It is handed to callers that index, format and serialise it, and the
+    numpy scalar an ndarray would give back is not JSON-serialisable."""
+    import json
+
+    cy, cx = get_image_pixel_centre(ODD)
+    assert (type(cy), type(cx)) == (int, int)
+    assert json.dumps([cy, cx]) == "[255, 511]"
+
+    cy, cx = get_image_pixel_centre(ODD, subpixel_precision=True)
+    assert (type(cy), type(cx)) == (float, float)
+
+
+def test_a_non_2d_shape_has_no_centre():
+    """An RGB image reaching a 2-D conversion is a bug, not something to
+    silently take the first two axes of."""
+    with pytest.raises(ValueError):
+        get_image_pixel_centre((8, 8, 3))
+
+
+# ---------------------------------------------------------------------------
+# round trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape", [EVEN, ODD])
+@pytest.mark.parametrize("subpixel", [False, True])
+def test_the_inverse_round_trips(shape, subpixel):
+    """The defect FIB-644 tier 1 fixes.
+
+    The inverse used to floor the centre unconditionally, so pairing it with a
+    forward conversion at subpixel precision lost half a pixel on an odd image
+    dimension — and correlation calls the forward one that way. Now both ends
+    can express the same centre, so the trip is exact either way.
+    """
     original = Point(700.0, 100.0)
-    metres = image_to_microscope_image_coordinates2(original, EVEN, PIXEL_SIZE)
-    back = microscope_image_to_image_coordinates(metres, EVEN, PIXEL_SIZE)
+    metres = image_to_microscope_image_coordinates2(
+        original, shape, PIXEL_SIZE, subpixel_precision=subpixel
+    )
+    back = microscope_image_to_image_coordinates(
+        metres, shape, PIXEL_SIZE, subpixel_precision=subpixel
+    )
 
     assert back.x == pytest.approx(original.x)
     assert back.y == pytest.approx(original.y)
+
+
+def test_mismatched_centres_are_what_used_to_lose_half_a_pixel():
+    """Pinning the failure itself, so the fix cannot be quietly undone: forward
+    exact, inverse floored, on an odd shape."""
+    original = Point(700.0, 100.0)
+    metres = image_to_microscope_image_coordinates2(
+        original, ODD, PIXEL_SIZE, subpixel_precision=True
+    )
+    back = microscope_image_to_image_coordinates(
+        metres, ODD, PIXEL_SIZE, subpixel_precision=False
+    )
+
+    assert abs(back.x - original.x) == pytest.approx(0.5)
+    assert abs(back.y - original.y) == pytest.approx(0.5)
+
+
+def test_the_inverse_default_is_unchanged():
+    """Called as before — no keyword — it must behave exactly as it always has."""
+    p = Point(1.885e-06, 1.555e-06)
+    explicit = microscope_image_to_image_coordinates(
+        p, ODD, PIXEL_SIZE, subpixel_precision=False
+    )
+    implicit = microscope_image_to_image_coordinates(p, ODD, PIXEL_SIZE)
+
+    assert (implicit.x, implicit.y) == (explicit.x, explicit.y)
 
 
 def test_is_importable_without_napari():


### PR DESCRIPTION
Fixes FIB-688 — the first step of FIB-644, split out so merging this cannot auto-complete that whole survey.

`image_to_microscope_image_coordinates_px` takes `subpixel_precision`. Its inverse, `microscope_image_to_image_coordinates`, floored the centre unconditionally and had no way to say otherwise. Two functions meant to invert each other could not agree on where the centre is:

| shape | subpixel | round-trip error |
| --- | --- | --- |
| 512 × 1024 | either | 0 |
| **511 × 1023** | **True** | **0.5 px → now 0** |

It only shows on an **odd** image dimension, which is why nothing caught it — every existing test used even shapes. And it is a live pairing: correlation calls the forward conversion with `subpixel_precision=True`, and its `px_m` reaches the protocol editor, which converts back through this inverse.

## One definition of the centre

They can now agree because there is one definition to agree on. `get_image_pixel_centre` moves out of `fibsem/ui/napari/patterns.py` into `conversions.py`, and both the forward primitive and the inverse compute from it.

It is pure geometry with no UI content, and its old home is precisely why `milling/patterning/plotting.py` computes the same centre inline eight times rather than importing it — that would drag a napari stack into a non-UI module. Side benefit: `canvas/overlays/milling_overlay.py` no longer reaches into a napari module for geometry, one fewer link to sever for the #111 deprecation.

Two details preserved deliberately, both easy to get wrong:

- **`(cy, cx)` order** — y first, matching image shape rather than `Point`'s `(x, y)`. Every caller unpacks it that way.
- **Python `int`/`float`, not numpy scalars.** `np.asarray(shape) // 2` gives `np.int64`, which behaves like `int` almost everywhere — `json.dumps` being the notable exception — and callers index, format and serialise this.

## Inert for every existing caller

Verified the way #410 was: load the pre-change module alongside the new one and compare **IEEE-754 bit patterns**, not `approx`.

```
comparisons        : 8,100     (9 shapes x coords x pixel sizes x both flags)
centre mismatches  : 0         (value and return type)
forward mismatches : 0
inverse mismatches : 0         (called without the new kwarg)
```

4/4 mutations caught, `conversions.py` restored byte-identical:

| Mutation | |
| --- | --- |
| centre returns `(x, y)` | 7 tests fail |
| centre always floors | 3 fail |
| leaks numpy scalars | 1 fails |
| inverse ignores its new flag | 1 fails |

The two worth reading are `test_mismatched_centres_are_what_used_to_lose_half_a_pixel`, which pins the *failure* so the fix cannot be quietly undone, and `test_the_inverse_default_is_unchanged`.

Full suite: **4780 passed, 24 skipped**.

## Scope — nothing opts in

This gives the inverse the capability; **no call site uses it yet**, so the change is a behavioural no-op. Choosing which sites want the exact centre is a real change on odd-sized images and belongs with the rest of FIB-644.

Still open there, and noted while in the code: eleven more inline copies of this conversion — four in `plotting.py` (already drifted, `:145` uses `/2` where the others use `//2`) and seven at the `get_image_pixel_centre` call sites, all spelling `cx = icx + x/ps; cy = icy - y/ps` by hand. Unifying the `plotting.py` four necessarily changes one of them, which is a milling-pattern-placement decision rather than a refactor.
