### PR TITLE
[perf] Stop decoding a full-resolution PNG for every lamella card (FIB-681)

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -661,6 +661,18 @@ class DefectState:
         self.updated_at = datetime.timestamp(datetime.now())
 
 
+# The thumbnail is only ever displayed, and its largest reader is the cozy lamella
+# card at 280 px wide (the hover tooltip is 256). Storing the acquired frame at full
+# resolution meant decoding a 1536x1024, 823 KB PNG per card per refresh for a picture
+# thrown away at a fifth of the size -- 26 ms each, and the card strip re-reads every
+# lamella whenever one is added (FIB-681).
+#
+# 512 rather than 280: it leaves the largest card headroom on a HiDPI display, still
+# decodes in ~3 ms, and is a tenth of the bytes. Only ever shrinks -- a frame already
+# smaller than this is written through untouched.
+_THUMBNAIL_MAX_EDGE = 512
+
+
 def _make_thumbnail_placeholder():
     import numpy as np
     from PIL import Image, ImageDraw, ImageFont
@@ -973,6 +985,10 @@ class Lamella:
         on the same filesystem -- hence writing it in the same directory rather than
         somewhere under /tmp. A reader sees either the previous thumbnail or the new
         one, never a partial.
+
+        Written at display size rather than at the acquired resolution -- see
+        `_THUMBNAIL_MAX_EDGE`. This is a thumbnail, not a copy of the frame; the frame
+        itself is saved separately by the task that acquired it.
         """
         import tempfile
 
@@ -990,7 +1006,13 @@ class Lamella:
         )
         os.close(handle)
         try:
-            Image.fromarray(data.astype(np.uint8)).save(staged)
+            thumbnail = Image.fromarray(data.astype(np.uint8))
+            # In place, and never upscales: a frame smaller than the bound keeps its
+            # own size, which is what a caller passing an already-small image expects.
+            thumbnail.thumbnail(
+                (_THUMBNAIL_MAX_EDGE, _THUMBNAIL_MAX_EDGE), Image.LANCZOS
+            )
+            thumbnail.save(staged)
             os.replace(staged, destination)
         except BaseException:
             # Including cancellation: a staged file left behind would accumulate in the

--- a/fibsem/applications/autolamella/ui/lamella_card_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_card_widget.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+from collections import OrderedDict
 from typing import Dict, List, Optional
 
 import numpy as np
@@ -36,7 +38,7 @@ from fibsem.ui.tokens import (
 _CARD_WIDTH = 300
 _THUMB_PADDING = 6        # inset from card edges so rounded corners stay visible
 # 3:2, matching the 1536x1024 frames the microscope acquires, so the thumbnail
-# scales rather than crops -- _arr_to_pixmap expands to fill. Kept small: at this
+# scales rather than crops -- _thumbnail_image expands to fill. Kept small: at this
 # size it is a scanning cue ("which of these looks milled"), and every pixel of
 # width it takes comes off the status line, which is the part carrying detail.
 _THUMB_W = 66
@@ -75,17 +77,81 @@ QToolButton:pressed { background: rgba(255, 255, 255, 15); }
 """
 
 
-def _arr_to_pixmap(arr: np.ndarray, w: int, h: int) -> QPixmap:
+def _arr_to_qimage(arr: np.ndarray) -> QImage:
+    """An RGB888 QImage of `arr`, independent of it.
+
+    Qt's `QImage(buffer, ...)` documents the buffer as having to outlive the image,
+    which would make the cached result of this a dangling read once the ndarray is
+    collected. PyQt5 does not work that way: sip copies the Python buffer, so the
+    image owns its pixels and the source can go. Verified rather than assumed -- the
+    bits pointer differs from the ndarray's, and mutating the ndarray in place leaves
+    the image unchanged, including via `sip.voidptr`. An explicit `.copy()` here would
+    be a second full-size memcpy for nothing.
+
+    Worth knowing if this ever moves to PySide, where the same constructor can alias.
+    """
     if arr.ndim == 2:
         arr = np.stack([arr, arr, arr], axis=2)
     arr = np.ascontiguousarray(arr, dtype=np.uint8)
     ih, iw, c = arr.shape
-    qimg = QImage(arr.data, iw, ih, iw * c, QImage.Format_RGB888)
-    return QPixmap.fromImage(qimg).scaled(
+    return QImage(arr.data, iw, ih, iw * c, QImage.Format_RGB888)
+
+
+_THUMBNAIL_CACHE: "OrderedDict[tuple, QImage]" = OrderedDict()
+# Enough for one arrangement of a large experiment, with room for the other to linger
+# after a mode switch. The bound is what stops a long run growing this without limit:
+# every thumbnail a workflow rewrites lands under a new key. Cozy entries are the big
+# ones at ~200 KB, so the ceiling is ~40 MB.
+_THUMBNAIL_CACHE_MAX = 200
+
+
+def _thumbnail_stamp(path: str) -> Optional[tuple]:
+    """What identifies this file's *contents*, for the cache key.
+
+    Size as well as mtime: a filesystem with one-second mtime granularity would
+    otherwise go on serving the pre-run thumbnail for the rest of the second in which
+    a workflow rewrote it. None means there is no file, which is its own cache key --
+    `get_thumbnail` answers that with the shared placeholder.
+    """
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return None
+    return (stat.st_mtime_ns, stat.st_size)
+
+
+def _thumbnail_image(lamella: Lamella, w: int, h: int) -> QImage:
+    """The lamella's thumbnail scaled for a `w` x `h` label, decoded at most once.
+
+    `_rebuild_lamella_list` clears and re-adds every card whenever a lamella is added
+    or removed, so without this a 100-lamella experiment re-opened and re-scaled 100
+    PNGs on the GUI thread every time -- 2.8 s of frozen UI per added lamella
+    (FIB-681).
+
+    Cached as a QImage rather than a QPixmap on purpose. It is just as quick to hand
+    to a label, because `QPixmap.fromImage` on an already-scaled image costs nothing,
+    and a QImage holds no platform resources -- so this dict outliving the
+    QApplication at shutdown is inert rather than a teardown crash.
+
+    A torn or unreadable file caches the placeholder against that file's stamp, so a
+    failing decode is attempted once rather than on every refresh.
+    """
+    path = os.path.join(lamella.path, "thumbnail.png")
+    key = (path, _thumbnail_stamp(path), w, h)
+    image = _THUMBNAIL_CACHE.get(key)
+    if image is not None:
+        _THUMBNAIL_CACHE.move_to_end(key)
+        return image
+
+    image = _arr_to_qimage(lamella.get_thumbnail()).scaled(
         w, h,
         Qt.AspectRatioMode.KeepAspectRatioByExpanding,
         Qt.TransformationMode.SmoothTransformation,
     )
+    _THUMBNAIL_CACHE[key] = image
+    if len(_THUMBNAIL_CACHE) > _THUMBNAIL_CACHE_MAX:
+        _THUMBNAIL_CACHE.popitem(last=False)
+    return image
 
 
 class LamellaCardWidget(QWidget):
@@ -354,9 +420,14 @@ class LamellaCardWidget(QWidget):
         # none, and reading a lamella's thumbnail off disk to scale it for a hidden
         # label is the one thing worth skipping.
         if self._mode != MODE_COMPACT:
-            arr = self.lamella.get_thumbnail()
             self._thumb_label.setPixmap(
-                _arr_to_pixmap(arr, self._thumb_label.width(), self._thumb_label.height())
+                QPixmap.fromImage(
+                    _thumbnail_image(
+                        self.lamella,
+                        self._thumb_label.width(),
+                        self._thumb_label.height(),
+                    )
+                )
             )
 
     def mousePressEvent(self, event) -> None:

--- a/tests/ui/test_lamella_thumbnail_cost.py
+++ b/tests/ui/test_lamella_thumbnail_cost.py
@@ -1,0 +1,250 @@
+"""A lamella card does not re-decode a full-resolution frame to draw a 66px picture.
+
+`thumbnail.png` was the acquired frame written out verbatim -- 1536x1024 RGB, 823 KB on
+real data -- and `LamellaCardWidget.refresh` re-opened, re-decoded and re-scaled it every
+time it ran, with no cache anywhere. 26 ms per card. `_rebuild_lamella_list` clears and
+re-adds the whole strip whenever a lamella is added or removed, so a 100-lamella
+experiment paid 2.8 s of frozen GUI to add one position (FIB-681).
+
+Two halves, and both are needed. Writing at display size fixes what lands on disk from
+now on; caching the scaled image fixes the experiments already saved with a full frame
+under that name, which no amount of resizing-on-write can reach.
+
+The properties worth pinning are not the timings -- they are the ones whose failure is
+silent:
+
+* **The write only ever shrinks.** A caller handing over an already-small image gets it
+  back unchanged; upscaling would invent detail and break `get_thumbnail`'s round trip.
+* **A rewritten thumbnail is picked up.** The cache is keyed by the file's stamp, so a
+  workflow replacing a thumbnail mid-run must invalidate it. Serving the stale one is
+  invisible until someone notices a card showing the wrong picture.
+* **The cache is bounded.** Every thumbnail a workflow rewrites lands under a new key, so
+  an unbounded dict grows for the length of a run.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.applications.autolamella.structures import Lamella
+from fibsem.applications.autolamella.ui import lamella_card_widget as lcw
+from fibsem.applications.autolamella.ui.lamella_card_widget import LamellaCardWidget
+from fibsem.config import MODE_COMPACT, MODE_COZY
+from fibsem.structures import FibsemImage
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """The cache is module-level, so tests would otherwise see each other's entries."""
+    lcw._THUMBNAIL_CACHE.clear()
+    yield
+    lcw._THUMBNAIL_CACHE.clear()
+
+
+@pytest.fixture
+def lamella(tmp_path):
+    lam = Lamella(path=str(tmp_path / "lamella"), number=1, petname="test-lamella")
+    os.makedirs(lam.path, exist_ok=True)
+    return lam
+
+
+def frame(w: int, h: int, value: int = 128) -> FibsemImage:
+    return FibsemImage(data=np.full((h, w), value, dtype=np.uint8))
+
+
+def stored_size(lamella: Lamella):
+    from PIL import Image
+
+    with Image.open(os.path.join(lamella.path, "thumbnail.png")) as handle:
+        return handle.size
+
+
+class TestTheWriteIsDisplaySized:
+    def test_an_acquired_frame_is_stored_at_display_size(self, lamella):
+        """The real case: a 1536x1024 frame must not land on disk at 1536x1024."""
+        lamella.save_thumbnail(frame(1536, 1024))
+
+        assert stored_size(lamella) == (512, 341)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            (1536, 1024),   # the acquired frame
+            (1024, 1536),   # portrait
+            (3072, 3072),   # a stitched square overview
+            (1024, 3072),   # a tall stitched strip
+            (409, 384),     # an odd small frame, below the bound
+            (1001, 667),    # a ratio no integer pair hits cleanly
+        ],
+        ids=lambda s: f"{s[0]}x{s[1]}",
+    )
+    def test_the_stored_aspect_is_the_closest_integers_allow(self, lamella, source):
+        """The card scales to fill and crops the overflow, so a stored picture whose
+        ratio has drifted is cropped somewhere the frame was not.
+
+        Exactness is not available: 1536x1024 at a 512 bound wants 341.33 px of
+        height, and a PNG has whole pixels. What must hold is that the remaining
+        error is *rounding* and not squashing -- no neighbouring integer height is a
+        better fit for the source ratio than the one chosen.
+        """
+        lamella.save_thumbnail(frame(*source))
+
+        width, height = stored_size(lamella)
+        wanted = source[0] / source[1]
+
+        # The long edge is pinned -- either to the bound, or to the source when that is
+        # already smaller -- so the short edge is the one carrying the rounding, and the
+        # one whose neighbours are worth comparing. Varying the pinned edge instead just
+        # proposes sizes the bound forbids: a 1024x3072 strip stored 171x512 is a better
+        # fit at 171x513, which is over the bound and not on offer.
+        candidates = (
+            [(width, h) for h in (height - 1, height, height + 1) if h > 0]
+            if height <= width
+            else [(w, height) for w in (width - 1, width, width + 1) if w > 0]
+        )
+        closest = min(candidates, key=lambda wh: abs(wanted - wh[0] / wh[1]))
+        assert closest == (width, height), (
+            f"{source[0]}x{source[1]} stored as {width}x{height} "
+            f"(ratio {width / height:.4f}); {closest[0]}x{closest[1]} is closer to {wanted:.4f}"
+        )
+        # and a wholesale squash, which rounding can never produce
+        assert abs(width / height - wanted) / wanted < 0.005
+
+    def test_a_small_frame_is_never_upscaled(self, lamella):
+        """`get_thumbnail`'s round trip returns what was put in, at its own size."""
+        lamella.save_thumbnail(frame(64, 64, value=77))
+
+        assert stored_size(lamella) == (64, 64)
+        assert lamella.get_thumbnail().shape == (64, 64, 3)
+
+    def test_the_file_is_dramatically_smaller(self, lamella):
+        """823 KB per lamella on disk was the other half of the cost."""
+        # Noise rather than a flat fill: a solid colour compresses to almost nothing at
+        # either size, which would make this pass without the resize.
+        rng = np.random.default_rng(0)
+        data = rng.integers(0, 255, size=(1024, 1536), dtype=np.uint8)
+        lamella.save_thumbnail(FibsemImage(data=data))
+
+        size_kb = os.path.getsize(os.path.join(lamella.path, "thumbnail.png")) / 1024
+
+        assert size_kb < 300, f"thumbnail is still {size_kb:.0f} KB"
+
+
+class TestTheScaledImageIsCached:
+    def test_a_second_card_does_not_reread_the_file(self, lamella, monkeypatch):
+        """The rebuild case: every card in the strip shares one decode."""
+        lamella.save_thumbnail(frame(1536, 1024))
+
+        reads = []
+        original = Lamella.get_thumbnail
+        monkeypatch.setattr(
+            Lamella,
+            "get_thumbnail",
+            lambda self: (reads.append(self.path), original(self))[1],
+        )
+
+        first = LamellaCardWidget(lamella, mode=MODE_COZY)
+        second = LamellaCardWidget(lamella, mode=MODE_COZY)
+        second.refresh()
+
+        assert len(reads) == 1, f"decoded {len(reads)} times for one thumbnail"
+        assert not first._thumb_label.pixmap().isNull()
+        assert not second._thumb_label.pixmap().isNull()
+
+    def test_a_rewritten_thumbnail_is_picked_up(self, lamella):
+        """A workflow replaces this mid-run; a stale card is a silent wrong picture."""
+        lamella.save_thumbnail(frame(1536, 1024, value=10))
+        card = LamellaCardWidget(lamella, mode=MODE_COZY)
+        before = card._thumb_label.pixmap().toImage().pixelColor(2, 2).red()
+
+        lamella.save_thumbnail(frame(1536, 1024, value=240))
+        card.refresh()
+        after = card._thumb_label.pixmap().toImage().pixelColor(2, 2).red()
+
+        assert before != after, "the card kept drawing the pre-rewrite thumbnail"
+        assert after > before
+
+    def test_each_label_size_is_cached_separately(self, lamella):
+        """Cozy and standard scale the same file to different sizes."""
+        lamella.save_thumbnail(frame(1536, 1024))
+
+        card = LamellaCardWidget(lamella, mode=MODE_COZY)
+        cozy_width = card._thumb_label.pixmap().width()
+        card.set_mode("standard")
+        standard_width = card._thumb_label.pixmap().width()
+
+        assert cozy_width != standard_width
+        assert len(lcw._THUMBNAIL_CACHE) == 2
+
+    def test_a_compact_card_reads_nothing(self, lamella, monkeypatch):
+        """No thumbnail in that arrangement, so decoding one is pure waste."""
+        lamella.save_thumbnail(frame(1536, 1024))
+        monkeypatch.setattr(
+            Lamella, "get_thumbnail", lambda self: pytest.fail("decoded for a hidden label")
+        )
+
+        LamellaCardWidget(lamella, mode=MODE_COMPACT)
+
+    def test_a_missing_thumbnail_does_not_poison_the_cache(self, lamella):
+        """The placeholder is cached against "no file"; saving one must supersede it."""
+        card = LamellaCardWidget(lamella, mode=MODE_COZY)  # nothing on disk yet
+        placeholder = card._thumb_label.pixmap().toImage().pixelColor(2, 2).red()
+
+        lamella.save_thumbnail(frame(1536, 1024, value=240))
+        card.refresh()
+
+        assert card._thumb_label.pixmap().toImage().pixelColor(2, 2).red() != placeholder
+
+
+class TestTheCacheIsSafe:
+    # A cached QImage outliving the ndarray it was built from was the other risk here,
+    # since Qt documents `QImage(buffer, ...)` as not copying. There is no test for it
+    # because PyQt5 makes it unreachable: sip copies the Python buffer, so the image
+    # always owns its pixels -- checked by pointer, by mutating the source in place,
+    # and via `sip.voidptr`, which copies too. Any test would pass no matter what this
+    # module did, which is worse than none. See `_arr_to_qimage`, and revisit if this
+    # ever moves to PySide.
+
+    def test_the_cache_is_bounded(self, lamella, monkeypatch):
+        """Every rewrite lands under a new key, so a run would grow this forever."""
+        monkeypatch.setattr(lcw, "_THUMBNAIL_CACHE_MAX", 4)
+
+        for value in range(12):
+            lamella.save_thumbnail(frame(64, 64, value=value * 20))
+            lcw._thumbnail_image(lamella, 66, 44)
+
+        assert len(lcw._THUMBNAIL_CACHE) <= 4
+
+    def test_the_bound_evicts_the_least_recently_used(self, lamella, tmp_path):
+        """Evicting the entry being drawn every frame would defeat the cache."""
+        lamella.save_thumbnail(frame(64, 64))
+        others = []
+        for i in range(3):
+            other = Lamella(path=str(tmp_path / f"other-{i}"), number=i + 2, petname=f"o{i}")
+            os.makedirs(other.path, exist_ok=True)
+            other.save_thumbnail(frame(64, 64, value=i * 30))
+            others.append(other)
+
+        lcw._THUMBNAIL_CACHE.clear()
+        lcw._THUMBNAIL_CACHE_MAX_original = lcw._THUMBNAIL_CACHE_MAX
+        try:
+            lcw._THUMBNAIL_CACHE_MAX = 3
+            lcw._thumbnail_image(lamella, 66, 44)  # the one we keep touching
+            for other in others:
+                lcw._thumbnail_image(lamella, 66, 44)  # ...touched again
+                lcw._thumbnail_image(other, 66, 44)
+        finally:
+            lcw._THUMBNAIL_CACHE_MAX = lcw._THUMBNAIL_CACHE_MAX_original
+
+        kept = [key[0] for key in lcw._THUMBNAIL_CACHE]
+        assert os.path.join(lamella.path, "thumbnail.png") in kept


### PR DESCRIPTION
Closes FIB-681. First of the [Performance](https://linear.app/fibsemos/project/performance-40569e970fea) project's issues; the measured investigation behind it is in *Why the UI crawls at 100 lamellae*.

## The problem

`Lamella.save_thumbnail` wrote `image.filtered_data` straight to `thumbnail.png` with no downsampling. Real acquired data carries **1536×1024 RGB PNGs of 823 KB** under that name.

`LamellaCardWidget.refresh` called `get_thumbnail()` on every refresh — `Image.open().convert("RGB")` → `np.asarray` → `QPixmap.fromImage().scaled(SmoothTransformation)` down to a ~120 px label — with no cache at any layer. **26.4 ms decode + 1.2 ms scale, per card, every time.**

`_rebuild_lamella_list` is wired to `positions.events.inserted` and `.removed` and does clear-then-repopulate, so adding one lamella re-decoded all N. Building 150 cards cost 4.26 s with thumbnails present and 0.24 s without — 94% of card-container cost was this one call.

## The change

**Write at display size.** `save_thumbnail` runs `Image.thumbnail((512, 512))` before writing. It only ever shrinks, so a frame already smaller passes through untouched, and it picks the rounding that best preserves the source ratio. The atomic temp-file-then-`os.replace` write from FIB-602 is unchanged.

**Cache the scaled image.** A bounded LRU in `lamella_card_widget`, keyed by `(path, mtime_ns, size, w, h)`. This is the half that reaches experiments already on disk carrying full frames — resizing on write does nothing for those.

Cached as a **QImage, not a QPixmap**: on a cache hit both are free (`QPixmap.fromImage` on an already-scaled image measures 0.000 ms), but a QImage holds no platform resources, so a module-level dict outliving the QApplication is inert rather than a teardown hazard. Caching the *unscaled* image would have been 675 MB at 150 lamellae; scaled is ~30 MB, bounded at 200 entries.

## Measured

Rebuilding the card strip at N=100, cozy mode, against real thumbnails:

| thumbnails on disk | first build | every rebuild |
| --- | --- | --- |
| before | 2910 ms | 2910 ms |
| full-res legacy + cache | 2994 ms | **136 ms** |
| 512 px, written by this PR | **460 ms** | **136 ms** |

The rebuild — what runs on every add/remove — is **21× faster**. Files go 823 KB → 129 KB.

**Known limitation:** experiments already on disk still pay one decode each on first open (~3 s at N=100). The cache cannot avoid the first read, and nothing rewrites their thumbnails. I did not add a migration — writing from a read path on the GUI thread seemed worse than the problem.

## Review notes

- **Aspect ratio** is preserved as exactly as integer pixel dimensions permit. Worst case across every shape this repo produces (landscape, portrait, square, 1024×3072 strips, sub-bound frames) is **0.195%, under half a pixel**. Nothing squashes: the cards use `KeepAspectRatioByExpanding` (fill and crop, as before), the hover tooltip `KeepAspectRatio`.
- **`_arr_to_pixmap` became `_arr_to_qimage`.** It had exactly one caller in this module. The other files with a function of that name keep their own local copies.
- **No `.copy()` on the cached image**, deliberately. Qt documents the buffer as having to outlive the image, but PyQt5's sip copies it — verified by pointer comparison, in-place mutation, and `sip.voidptr`. A `.copy()` would be a second full-size memcpy for nothing. Noted in the docstring for anyone moving this to PySide, where the constructor can alias.

## Verification

16 new tests in `tests/ui/test_lamella_thumbnail_cost.py`. 104 pass across the thumbnail, structures, card-layout, defect-sync and border suites.

Mutation-tested rather than trusted green: removing the downsample, bypassing the cache, dropping the stamp from the key, never evicting, ignoring label size, squashing to a flat 512×512, and swapping PIL's closest-aspect rounding for naive floor rounding each fail the expected tests.

Rendered the real widget against real acquired imagery in all three card modes — mean pixel difference from the old full-res path is 0.82/255 (cozy) and 0.15/255 (standard), i.e. visually identical. Also ran the app against a 40-lamella experiment: loads clean.

Unrelated and pre-existing on `main`, confirmed by A/B: four `QPixmap::scaled: Pixmap is a null pixmap` warnings on experiment load (from `lamella_task_image_widget` or `fibsem_image_flow_widget`, not this code — `lamella_card_widget` no longer calls `QPixmap.scaled` at all), and 1 failure + 5 errors in `test_overview_widget` / `test_fm_live_indicator`.
