### PR TITLE
[fix] Point the workflow task list's drag handle at the icon that exists

### DIFF
--- a/fibsem/applications/autolamella/ui/workflow_config_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_config_widget.py
@@ -32,7 +32,14 @@ from fibsem.ui.tokens import (
     NEUTRAL_700,
 )
 
-_DRAG_HANDLE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "icons", "drag_handle.svg")
+# The handle asset is shared with the other draggable list widgets and lives under
+# fibsem/ui/icons. This module sits two packages deeper than they do, so it needs
+# two more dirname() steps to reach fibsem: stopping short resolved to
+# fibsem/applications/autolamella/icons, which does not exist.
+_DRAG_HANDLE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
+    "ui", "icons", "drag_handle.svg",
+)
 _NAME_MIN_WIDTH = 180
 _BTN_SIZE = QSize(32, 32)
 _ROW_HEIGHT = 40
@@ -125,7 +132,18 @@ class WorkflowTaskRowWidget(QWidget):
 
         drag_icon = QLabel()
         drag_icon.setFixedSize(10, 16)
-        drag_icon.setPixmap(QPixmap(_DRAG_HANDLE_PATH).scaled(10, 16, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation))
+        # Scaling a pixmap that failed to load makes Qt warn, once per row, and a
+        # row is built for every task in the workflow. Leave the label blank in
+        # that case rather than asking Qt to scale nothing.
+        handle = QPixmap(_DRAG_HANDLE_PATH)
+        if not handle.isNull():
+            drag_icon.setPixmap(
+                handle.scaled(
+                    10, 16,
+                    Qt.AspectRatioMode.KeepAspectRatio,
+                    Qt.TransformationMode.SmoothTransformation,
+                )
+            )
         drag_icon.setStyleSheet("background: transparent;")
         drag_icon.setCursor(Qt.CursorShape.OpenHandCursor)
         layout.addWidget(drag_icon)

--- a/tests/ui/test_no_qt_warnings_on_workflow_load.py
+++ b/tests/ui/test_no_qt_warnings_on_workflow_load.py
@@ -1,0 +1,109 @@
+"""Loading an experiment's workflow must not make Qt complain.
+
+Opening any experiment printed one ``QPixmap::scaled: Pixmap is a null pixmap``
+per task in its workflow. ``WorkflowTaskRowWidget`` draws a drag handle from an
+SVG under ``fibsem/ui/icons``, and it derived that path by counting
+``os.path.dirname`` calls up from its own module -- the count that is right for
+the three draggable list widgets that live under ``fibsem/ui``, but two short
+for this one, which sits under ``fibsem/applications/autolamella/ui``. It
+resolved to a directory that has never existed, ``QPixmap`` loaded nothing, and
+scaling a null pixmap warns. The handle was silently absent from every row of a
+list whose own caption says "Drag to reorder".
+
+A Qt warning is not a Python warning: it goes to the message handler, so the
+``filterwarnings = ["error"]`` in pyproject never sees it and it survives as
+terminal noise indefinitely. Hence the handler below.
+
+Two properties, because either alone lets the bug back in:
+
+* **Populating the workflow emits no Qt warning.** Pinned at
+  ``LamellaWorkflowWidget.set_workflow_config`` -- the call
+  ``AutoLamellaMainUI._on_experiment_update`` makes when an experiment is
+  adopted, which is where the four warnings came from.
+* **Every draggable list widget's handle asset actually loads.** The warning is
+  only the audible half of the failure; a guard that skips the scale silences it
+  while leaving the handle missing. Three of these four modules spell the path
+  differently, so the one that is wrong cannot be caught by reading them.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+from contextlib import contextmanager
+from typing import List, Tuple
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtCore import QtWarningMsg, qInstallMessageHandler
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaWorkflowConfig,
+)
+from fibsem.applications.autolamella.ui.lamella_workflow_widget import (
+    LamellaWorkflowWidget,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+# The four widgets that draw a drag handle from the shared on-disk asset.
+_DRAG_HANDLE_MODULES = [
+    "fibsem.applications.autolamella.ui.workflow_config_widget",
+    "fibsem.ui.widgets.milling_stage_list_widget",
+    "fibsem.ui.fm.widgets.channel_list_widget",
+    "fibsem.ui.correlation.widgets.coordinate_list_widget",
+]
+
+_TASKS = ["Setup Lamella Position", "Mill Fiducial", "Rough Milling", "Polishing"]
+
+
+@contextmanager
+def captured_qt_messages():
+    """Collect (type, text) for every Qt message logged inside the block."""
+    messages: List[Tuple[int, str]] = []
+
+    def handler(mode, context, message):
+        messages.append((mode, message))
+
+    previous = qInstallMessageHandler(handler)
+    try:
+        yield messages
+    finally:
+        qInstallMessageHandler(previous)
+
+
+def _workflow_config() -> AutoLamellaWorkflowConfig:
+    return AutoLamellaWorkflowConfig(
+        tasks=[
+            AutoLamellaTaskDescription(name=name, supervise=False, required=False)
+            for name in _TASKS
+        ]
+    )
+
+
+def test_populating_the_workflow_emits_no_qt_warning():
+    """One warning per task row is what an experiment load used to print."""
+    widget = LamellaWorkflowWidget()
+
+    with captured_qt_messages() as messages:
+        widget.set_workflow_config(_workflow_config())
+
+    warnings = [text for mode, text in messages if mode >= QtWarningMsg]
+    assert warnings == []
+
+    widget.close()
+
+
+@pytest.mark.parametrize("module_name", _DRAG_HANDLE_MODULES)
+def test_every_drag_handle_asset_loads(module_name):
+    """A path that resolves nowhere leaves the handle missing, warning or not."""
+    module = __import__(module_name, fromlist=["_DRAG_HANDLE_PATH"])
+    path = module._DRAG_HANDLE_PATH
+
+    assert os.path.exists(path), f"{module_name} points at a missing asset: {path}"
+    assert not QPixmap(path).isNull(), f"{module_name} cannot load {path}"


### PR DESCRIPTION
Loading any experiment printed one `QPixmap::scaled: Pixmap is a null pixmap` per task in its workflow, right after `_adopt_experiment` / `update_lamella_ui`.

## Cause

`WorkflowTaskRowWidget` draws its drag handle from an SVG under `fibsem/ui/icons`, and worked the path out by counting `os.path.dirname` steps up from its own module — the count that is right for the three draggable list widgets that live under `fibsem/ui`, but two short for this one, which sits under `fibsem/applications/autolamella/ui`:

```
fibsem/applications/autolamella/ui/workflow_config_widget.py    2 dirnames  ->  MISSING
fibsem/ui/widgets/milling_stage_list_widget.py                  2 dirnames  ->  ok
fibsem/ui/fm/widgets/channel_list_widget.py                     3 dirnames  ->  ok
fibsem/ui/correlation/widgets/coordinate_list_widget.py         4 + "ui"    ->  ok
```

It resolved to `fibsem/applications/autolamella/icons/drag_handle.svg`, a directory that has never existed. `QPixmap` loaded nothing, and `QPixmap.scaled()` warns on a null pixmap — once per row.

The warning was only the audible half. The handle was also **silently missing from every row** of a list whose own caption reads "Drag to reorder".

## Fix

Correct the path, and guard the scale with `isNull()` so a missing or unloadable asset degrades quietly instead of warning once per row. `isNull()` rather than the neighbours' `os.path.exists()`, because it also covers a file that is present but cannot be decoded.

## Verification

Real app, `run_ui(['--quickload'])`, same experiment both times:

| | `null pixmap` warnings |
|---|---|
| before | 5 (its protocol has 5 tasks) |
| after | 0 |

Before, they landed 2 ms apart between `_adopt_experiment` and `Quickload: loaded experiment`; after, those log lines are consecutive. The handle now renders in every row.

## Test

`tests/ui/test_no_qt_warnings_on_workflow_load.py` pins both halves, because either alone lets the bug back:

- `set_workflow_config` emits no Qt warning — the exact call `AutoLamellaMainUI._on_experiment_update` makes on load. A Qt message is not a Python warning, so `filterwarnings = ["error"]` never sees it; the test installs a `qInstallMessageHandler`.
- Every one of the four draggable list widgets' assets actually loads. A guard alone silences the warning while leaving the handle missing, and since three of the four spell that path differently, the wrong one cannot be caught by reading them.

Verified to fail at the pre-fix state — the warning test reports exactly the four/five warnings, and the asset test names the missing directory.

## Follow-up (not in this PR)

Four modules still each derive the same path their own way. Consolidating them onto one shared constant is the real cure for this class of bug, but it touches three files this change has no reason to, so it is left separate. The new test already pins that all four resolve.