### PR TITLE
[refactor] Resolve the drag handle icon once, not in four packages (FIB-689)

### DIFF
--- a/fibsem/applications/autolamella/ui/workflow_config_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_config_widget.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import os
 from typing import Dict, List, Optional
 
 from PyQt5.QtCore import QSize, Qt, pyqtSignal
-from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
@@ -18,7 +16,12 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.icon import (
+    DRAG_HANDLE_HEIGHT,
+    DRAG_HANDLE_WIDTH,
+    drag_handle_pixmap,
+    fibsem_icon,
+)
 
 from fibsem.constants import DATETIME_DISPLAY_AMPM
 from fibsem.applications.autolamella.structures import (
@@ -32,14 +35,6 @@ from fibsem.ui.tokens import (
     NEUTRAL_700,
 )
 
-# The handle asset is shared with the other draggable list widgets and lives under
-# fibsem/ui/icons. This module sits two packages deeper than they do, so it needs
-# two more dirname() steps to reach fibsem: stopping short resolved to
-# fibsem/applications/autolamella/icons, which does not exist.
-_DRAG_HANDLE_PATH = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
-    "ui", "icons", "drag_handle.svg",
-)
 _NAME_MIN_WIDTH = 180
 _BTN_SIZE = QSize(32, 32)
 _ROW_HEIGHT = 40
@@ -131,19 +126,8 @@ class WorkflowTaskRowWidget(QWidget):
         layout.addWidget(self.btn_remove)
 
         drag_icon = QLabel()
-        drag_icon.setFixedSize(10, 16)
-        # Scaling a pixmap that failed to load makes Qt warn, once per row, and a
-        # row is built for every task in the workflow. Leave the label blank in
-        # that case rather than asking Qt to scale nothing.
-        handle = QPixmap(_DRAG_HANDLE_PATH)
-        if not handle.isNull():
-            drag_icon.setPixmap(
-                handle.scaled(
-                    10, 16,
-                    Qt.AspectRatioMode.KeepAspectRatio,
-                    Qt.TransformationMode.SmoothTransformation,
-                )
-            )
+        drag_icon.setFixedSize(DRAG_HANDLE_WIDTH, DRAG_HANDLE_HEIGHT)
+        drag_icon.setPixmap(drag_handle_pixmap())
         drag_icon.setStyleSheet("background: transparent;")
         drag_icon.setCursor(Qt.CursorShape.OpenHandCursor)
         layout.addWidget(drag_icon)

--- a/fibsem/ui/correlation/widgets/coordinate_list_widget.py
+++ b/fibsem/ui/correlation/widgets/coordinate_list_widget.py
@@ -9,7 +9,6 @@ flattening/reconstructing CorrelationInputData.
 """
 from __future__ import annotations
 
-import os
 from typing import Dict, List, Optional
 
 from PyQt5.QtCore import QEvent, QSize, Qt, pyqtSignal
@@ -28,16 +27,16 @@ from PyQt5.QtWidgets import (
 
 from fibsem.correlation.structures import Coordinate, PointType
 from fibsem.ui import stylesheets
-from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.icon import (
+    DRAG_HANDLE_HEIGHT,
+    DRAG_HANDLE_WIDTH,
+    drag_handle_pixmap,
+    fibsem_icon,
+)
 from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueSpinBox
 from fibsem.ui.tokens import (
     CANVAS_BG,
     GRAY_TEXT_COLOR,
-)
-
-_DRAG_HANDLE_PATH = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
-    "ui", "icons", "drag_handle.svg",
 )
 
 _NAME_FIXED_WIDTH = 100
@@ -45,7 +44,7 @@ _SPIN_FIXED_WIDTH = 75
 _BTN_SIZE = QSize(24, 24)
 _ROW_HEIGHT = 28
 # Spacer in header aligning with drag handle in rows (layout spacing handles the 4px gap)
-_ROW_RIGHT_WIDTH = 10
+_ROW_RIGHT_WIDTH = DRAG_HANDLE_WIDTH
 
 # Fit-state indicator colours. A fitted point (unmodified auto-fit result) is
 # white so it reads as "lit up"; otherwise a muted grey — dimmer than the light
@@ -287,15 +286,8 @@ class CoordinateRowWidget(QWidget):
 
         # Drag handle
         drag_icon = QLabel()
-        drag_icon.setFixedSize(10, 16)
-        if os.path.exists(_DRAG_HANDLE_PATH):
-            drag_icon.setPixmap(
-                QPixmap(_DRAG_HANDLE_PATH).scaled(
-                    10, 16,
-                    Qt.AspectRatioMode.KeepAspectRatio,
-                    Qt.TransformationMode.SmoothTransformation,
-                )
-            )
+        drag_icon.setFixedSize(DRAG_HANDLE_WIDTH, DRAG_HANDLE_HEIGHT)
+        drag_icon.setPixmap(drag_handle_pixmap())
         drag_icon.setStyleSheet("background: transparent;")
         drag_icon.setCursor(Qt.CursorShape.OpenHandCursor)
         layout.addWidget(drag_icon)

--- a/fibsem/ui/fm/widgets/channel_list_widget.py
+++ b/fibsem/ui/fm/widgets/channel_list_widget.py
@@ -8,7 +8,6 @@ in without changes to callers.
 """
 from __future__ import annotations
 
-import os
 from copy import deepcopy
 from typing import List, Optional, Union
 
@@ -35,17 +34,13 @@ from fibsem.fm.config import load_recent_channels, remove_recent_channel
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.fm.structures import ChannelSettings
 from fibsem.ui import stylesheets
+from fibsem.ui.icon import DRAG_HANDLE_HEIGHT, DRAG_HANDLE_WIDTH, drag_handle_pixmap
 from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueComboBox, ValueSpinBox
 from fibsem.ui.tokens import (
     BORDER_COLOR,
     CANVAS_BG,
     NEUTRAL_700,
     ORANGE_COLOR,
-)
-
-_DRAG_HANDLE_PATH = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-    "icons", "drag_handle.svg",
 )
 
 _NAME_MIN_WIDTH = 130
@@ -254,15 +249,8 @@ class ChannelRowWidget(QWidget):
         layout.addWidget(self.btn_remove)
 
         drag_icon = QLabel()
-        drag_icon.setFixedSize(10, 16)
-        if os.path.exists(_DRAG_HANDLE_PATH):
-            drag_icon.setPixmap(
-                QPixmap(_DRAG_HANDLE_PATH).scaled(
-                    10, 16,
-                    Qt.AspectRatioMode.KeepAspectRatio,
-                    Qt.TransformationMode.SmoothTransformation,
-                )
-            )
+        drag_icon.setFixedSize(DRAG_HANDLE_WIDTH, DRAG_HANDLE_HEIGHT)
+        drag_icon.setPixmap(drag_handle_pixmap())
         drag_icon.setStyleSheet("background: transparent;")
         drag_icon.setCursor(Qt.CursorShape.OpenHandCursor)
         layout.addWidget(drag_icon)

--- a/fibsem/ui/icon.py
+++ b/fibsem/ui/icon.py
@@ -3,7 +3,9 @@
 Icons are referenced throughout the UI by Iconify-style keys such as
 ``"mdi:check-circle"``. This module resolves them against qtawesome's *bundled*
 Material Design Icons font, so the application renders every icon **fully
-offline** - no network access, no icon assets committed to the repo.
+offline** - no network access. The handful of shapes that font does not cover
+ship as SVGs in ``fibsem/ui/icons/``, and are resolved from here too (see
+``drag_handle_pixmap``) so no call site re-derives that directory.
 
 Keeping this one indirection point means:
   * the ``"mdi:<name>"`` key convention (including dynamically-built names like
@@ -22,6 +24,7 @@ Extra keyword arguments pass straight through to ``qtawesome.icon`` (e.g.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Optional
 
 try:
@@ -32,7 +35,8 @@ except ModuleNotFoundError as e:  # pragma: no cover - dependency guard
         "(added in this version). Install it with:\n"
         "    pip install 'fibsem[ui]'   (or: pip install qtawesome)"
     ) from e
-from qtpy.QtGui import QIcon
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QIcon, QPixmap
 
 # qtawesome's font prefix for Material Design Icons v6.
 _MDI = "mdi6"
@@ -70,3 +74,41 @@ def fibsem_icon(key: str, color: Optional[str] = None, **kwargs) -> QIcon:
 # everywhere (moving to / updating a saved stage/objective position).
 ICON_MOVE_TO_POSITION = "mdi:crosshairs-gps"   # go to a saved/target position
 ICON_UPDATE_POSITION = "mdi:map-marker-check"  # overwrite a saved position with the current one
+
+
+# ── Bundled SVG assets ───────────────────────────────────────────────────────
+# Shapes qtawesome's font does not carry live next to this module. Resolve them
+# from here rather than counting os.path.dirname() steps back to fibsem/ui at
+# each call site: one widget package moved and its private copy of the sum kept
+# pointing at a directory that does not exist, so its drag handle silently
+# vanished and every row logged a null-pixmap warning instead.
+ICONS_DIR = os.path.join(os.path.dirname(__file__), "icons")
+DRAG_HANDLE_PATH = os.path.join(ICONS_DIR, "drag_handle.svg")
+
+# Every draggable list row draws the handle at this size.
+DRAG_HANDLE_WIDTH = 10
+DRAG_HANDLE_HEIGHT = 16
+
+
+def drag_handle_pixmap(
+    width: int = DRAG_HANDLE_WIDTH, height: int = DRAG_HANDLE_HEIGHT
+) -> QPixmap:
+    """Return the shared drag-handle asset, scaled to ``width`` x ``height``.
+
+    Scaling a null pixmap is what prints "QPixmap::scaled: Pixmap is a null
+    pixmap" - once per row, on every rebuild - so the check belongs here rather
+    than at each call site. ``isNull()`` rather than ``os.path.exists()``: it
+    also covers a file that is present but unreadable or not valid SVG. Callers
+    always get a pixmap they can hand straight to ``QLabel.setPixmap``, empty if
+    the asset is missing.
+    """
+    pixmap = QPixmap(DRAG_HANDLE_PATH)
+    if pixmap.isNull():
+        logging.warning("drag handle icon missing or unreadable: %s", DRAG_HANDLE_PATH)
+        return pixmap
+    return pixmap.scaled(
+        width,
+        height,
+        Qt.AspectRatioMode.KeepAspectRatio,
+        Qt.TransformationMode.SmoothTransformation,
+    )

--- a/fibsem/ui/widgets/milling_stage_list_widget.py
+++ b/fibsem/ui/widgets/milling_stage_list_widget.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from copy import deepcopy
 from typing import List, Optional
 
@@ -24,6 +23,7 @@ from fibsem.milling.base import FibsemMillingStage, get_strategy
 from fibsem.milling.patterning import get_pattern, get_pattern_names
 from fibsem.milling.strategy import get_strategy_names
 from fibsem.ui import stylesheets
+from fibsem.ui.icon import DRAG_HANDLE_HEIGHT, DRAG_HANDLE_WIDTH, drag_handle_pixmap
 from fibsem.ui.napari.patterns import COLOURS
 from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueComboBox, ValueSpinBox
 from fibsem.ui.tokens import (
@@ -32,7 +32,6 @@ from fibsem.ui.tokens import (
     ORANGE_COLOR,
 )
 
-_DRAG_HANDLE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "icons", "drag_handle.svg")
 # Columns are flexible: each is (minimum_width, stretch). The header and every row
 # consume the SAME spec so their column boundaries stay aligned as the panel resizes,
 # while the whole row can shrink well below the old ~660px fixed-width floor.
@@ -42,7 +41,7 @@ _COL_DEPTH = (70, 2)
 _COL_CURRENT = (60, 2)
 _COL_STRATEGY = (70, 2)
 _CHECKBOX_WIDTH = 24
-_DRAG_WIDTH = 10
+_DRAG_WIDTH = DRAG_HANDLE_WIDTH
 _BTN_SIZE = QSize(32, 32)
 _ROW_HEIGHT = 40
 
@@ -195,8 +194,8 @@ class MillingStageRowWidget(QWidget):
         layout.addWidget(self.btn_remove)
 
         drag_icon = QLabel()
-        drag_icon.setFixedSize(_DRAG_WIDTH, 16)
-        drag_icon.setPixmap(QPixmap(_DRAG_HANDLE_PATH).scaled(_DRAG_WIDTH, 16, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation))
+        drag_icon.setFixedSize(_DRAG_WIDTH, DRAG_HANDLE_HEIGHT)
+        drag_icon.setPixmap(drag_handle_pixmap(_DRAG_WIDTH, DRAG_HANDLE_HEIGHT))
         drag_icon.setStyleSheet("background: transparent;")
         drag_icon.setCursor(Qt.CursorShape.OpenHandCursor)
         layout.addWidget(drag_icon)

--- a/tests/ui/test_no_qt_warnings_on_workflow_load.py
+++ b/tests/ui/test_no_qt_warnings_on_workflow_load.py
@@ -1,4 +1,5 @@
-"""Loading an experiment's workflow must not make Qt complain.
+"""Loading an experiment's workflow must not make Qt complain, and every
+draggable row must actually end up with a handle.
 
 Opening any experiment printed one ``QPixmap::scaled: Pixmap is a null pixmap``
 per task in its workflow. ``WorkflowTaskRowWidget`` draws a drag handle from an
@@ -20,46 +21,102 @@ Two properties, because either alone lets the bug back in:
   ``LamellaWorkflowWidget.set_workflow_config`` -- the call
   ``AutoLamellaMainUI._on_experiment_update`` makes when an experiment is
   adopted, which is where the four warnings came from.
-* **Every draggable list widget's handle asset actually loads.** The warning is
-  only the audible half of the failure; a guard that skips the scale silences it
-  while leaving the handle missing. Three of these four modules spell the path
-  differently, so the one that is wrong cannot be caught by reading them.
+* **Every draggable row's handle actually loads.** The warning is only the
+  audible half of the failure; a guard that skips the scale silences it while
+  leaving the handle missing.
+
+The four modules no longer spell that path four different ways -- it lives once
+in ``fibsem.ui.icon``, with ``drag_handle_pixmap()`` doing the ``isNull()``
+check that used to be each caller's problem. So the second property is now
+pinned on what each row ends up drawing, plus a guard that no module goes back
+to naming the asset itself.
 """
-import os
-
-os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-
-import sys
 from contextlib import contextmanager
+from pathlib import Path
 from typing import List, Tuple
 
 import pytest
 
 pytest.importorskip("PyQt5")
+pytest.importorskip("napari")
 
-from PyQt5.QtCore import QtWarningMsg, qInstallMessageHandler
-from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import (  # noqa: E402
+    Qt,
+    QtWarningMsg,
+    qInstallMessageHandler,
+)
+from PyQt5.QtGui import QPixmap  # noqa: E402
+from PyQt5.QtWidgets import QLabel  # noqa: E402
 
-from fibsem.applications.autolamella.structures import (
+from fibsem.correlation.structures import Coordinate  # noqa: E402
+from fibsem.fm.structures import ChannelSettings  # noqa: E402
+from fibsem.milling.base import FibsemMillingStage  # noqa: E402
+from fibsem.milling.patterning import get_pattern_names  # noqa: E402
+from fibsem.milling.strategy import get_strategy_names  # noqa: E402
+from fibsem.ui import icon  # noqa: E402
+from fibsem.ui.icon import (  # noqa: E402
+    DRAG_HANDLE_HEIGHT,
+    DRAG_HANDLE_PATH,
+    DRAG_HANDLE_WIDTH,
+    drag_handle_pixmap,
+)
+from fibsem.applications.autolamella.structures import (  # noqa: E402
     AutoLamellaTaskDescription,
     AutoLamellaWorkflowConfig,
 )
-from fibsem.applications.autolamella.ui.lamella_workflow_widget import (
+from fibsem.applications.autolamella.ui.lamella_workflow_widget import (  # noqa: E402
     LamellaWorkflowWidget,
 )
+from fibsem.applications.autolamella.ui.workflow_config_widget import (  # noqa: E402
+    WorkflowTaskRowWidget,
+)
+from fibsem.ui.correlation.widgets.coordinate_list_widget import (  # noqa: E402
+    CoordinateRowWidget,
+)
+from fibsem.ui.fm.widgets.channel_list_widget import ChannelRowWidget  # noqa: E402
+from fibsem.ui.widgets.milling_stage_list_widget import (  # noqa: E402
+    MillingStageRowWidget,
+)
 
-_app = QApplication.instance() or QApplication(sys.argv)
+NULL_PIXMAP_WARNING = "null pixmap"
 
-# The four widgets that draw a drag handle from the shared on-disk asset.
-_DRAG_HANDLE_MODULES = [
-    "fibsem.applications.autolamella.ui.workflow_config_widget",
-    "fibsem.ui.widgets.milling_stage_list_widget",
-    "fibsem.ui.fm.widgets.channel_list_widget",
-    "fibsem.ui.correlation.widgets.coordinate_list_widget",
-]
+TASKS = ["Setup Lamella Position", "Mill Fiducial", "Rough Milling", "Polishing"]
 
-_TASKS = ["Setup Lamella Position", "Mill Fiducial", "Rough Milling", "Polishing"]
+
+def _milling_row():
+    return MillingStageRowWidget(
+        FibsemMillingStage(),
+        index=0,
+        pattern_names=get_pattern_names(),
+        strategy_names=get_strategy_names(),
+    )
+
+
+def _channel_row():
+    # Empty filter-set lists are what the widget passes with no microscope attached.
+    return ChannelRowWidget(
+        channel=ChannelSettings(), emission_items=[], excitation_items=[]
+    )
+
+
+def _coordinate_row():
+    return CoordinateRowWidget(coord=Coordinate(), name="P1")
+
+
+def _workflow_row():
+    return WorkflowTaskRowWidget(
+        AutoLamellaTaskDescription(name="Mill Rough", supervise=True, required=True)
+    )
+
+
+# Every module that draws a drag handle, with a builder for its row. Adding a row
+# type here is the cheap way to keep it drawing the shared, loaded asset.
+DRAG_HANDLE_ROWS = {
+    "fibsem.applications.autolamella.ui.workflow_config_widget": _workflow_row,
+    "fibsem.ui.widgets.milling_stage_list_widget": _milling_row,
+    "fibsem.ui.fm.widgets.channel_list_widget": _channel_row,
+    "fibsem.ui.correlation.widgets.coordinate_list_widget": _coordinate_row,
+}
 
 
 @contextmanager
@@ -81,12 +138,23 @@ def _workflow_config() -> AutoLamellaWorkflowConfig:
     return AutoLamellaWorkflowConfig(
         tasks=[
             AutoLamellaTaskDescription(name=name, supervise=False, required=False)
-            for name in _TASKS
+            for name in TASKS
         ]
     )
 
 
-def test_populating_the_workflow_emits_no_qt_warning():
+def _drag_handle_label(row) -> QLabel:
+    """The row's drag handle: the one QLabel carrying the open-hand cursor."""
+    handles = [
+        label
+        for label in row.findChildren(QLabel)
+        if label.cursor().shape() == Qt.CursorShape.OpenHandCursor
+    ]
+    assert len(handles) == 1, f"expected one drag handle, found {len(handles)}"
+    return handles[0]
+
+
+def test_populating_the_workflow_emits_no_qt_warning(qapp):
     """One warning per task row is what an experiment load used to print."""
     widget = LamellaWorkflowWidget()
 
@@ -99,11 +167,55 @@ def test_populating_the_workflow_emits_no_qt_warning():
     widget.close()
 
 
-@pytest.mark.parametrize("module_name", _DRAG_HANDLE_MODULES)
-def test_every_drag_handle_asset_loads(module_name):
-    """A path that resolves nowhere leaves the handle missing, warning or not."""
-    module = __import__(module_name, fromlist=["_DRAG_HANDLE_PATH"])
-    path = module._DRAG_HANDLE_PATH
+def test_shared_asset_loads(qapp):
+    assert Path(DRAG_HANDLE_PATH).is_file(), DRAG_HANDLE_PATH
+    assert not QPixmap(DRAG_HANDLE_PATH).isNull(), DRAG_HANDLE_PATH
 
-    assert os.path.exists(path), f"{module_name} points at a missing asset: {path}"
-    assert not QPixmap(path).isNull(), f"{module_name} cannot load {path}"
+
+def test_helper_returns_the_row_sized_handle(qapp):
+    pixmap = drag_handle_pixmap()
+    assert not pixmap.isNull()
+    assert (pixmap.width(), pixmap.height()) == (DRAG_HANDLE_WIDTH, DRAG_HANDLE_HEIGHT)
+
+
+def test_helper_does_not_scale_a_missing_asset(qapp, tmp_path, monkeypatch):
+    """A missing asset yields an empty pixmap, not a warning per call site."""
+    monkeypatch.setattr(icon, "DRAG_HANDLE_PATH", str(tmp_path / "gone.svg"))
+
+    with captured_qt_messages() as messages:
+        pixmap = drag_handle_pixmap()
+
+    assert pixmap.isNull()
+    assert not [t for _, t in messages if NULL_PIXMAP_WARNING in t], messages
+    QLabel().setPixmap(pixmap)  # still safe to hand straight to a row
+
+
+@pytest.mark.parametrize("module_name", sorted(DRAG_HANDLE_ROWS))
+def test_row_draws_the_loaded_handle(qapp, module_name):
+    """A path that resolves nowhere leaves the handle missing, warning or not."""
+    row = DRAG_HANDLE_ROWS[module_name]()
+
+    pixmap = _drag_handle_label(row).pixmap()
+
+    assert pixmap is not None and not pixmap.isNull(), f"{module_name}: handle missing"
+    assert (pixmap.width(), pixmap.height()) == (DRAG_HANDLE_WIDTH, DRAG_HANDLE_HEIGHT)
+
+
+@pytest.mark.parametrize("module_name", sorted(DRAG_HANDLE_ROWS))
+def test_building_a_row_emits_no_null_pixmap_warning(qapp, module_name):
+    # Only the null-pixmap warning is pinned per row: the workflow test above is
+    # where "Qt said nothing at all" is asserted, on the path that used to warn.
+    with captured_qt_messages() as messages:
+        DRAG_HANDLE_ROWS[module_name]()
+
+    assert not [t for _, t in messages if NULL_PIXMAP_WARNING in t], messages
+
+
+@pytest.mark.parametrize("module_name", sorted(DRAG_HANDLE_ROWS))
+def test_row_module_uses_the_shared_handle(qapp, module_name):
+    """No module names the asset itself; that is how the paths drifted apart."""
+    module = __import__(module_name, fromlist=["__file__"])
+    source = Path(module.__file__).read_text()
+
+    assert "drag_handle.svg" not in source, f"{module_name} re-derives the asset path"
+    assert "drag_handle_pixmap" in source, f"{module_name} does not use the helper"


### PR DESCRIPTION
Closes FIB-689. Builds on #429.

Four widget packages draw `fibsem/ui/icons/drag_handle.svg`, and each derived its own `_DRAG_HANDLE_PATH` by counting `os.path.dirname` steps back to `fibsem/ui` — 2, 3 or 4 steps depending on how deep the package sits.

#429 fixed the copy that counted short — it resolved under `fibsem/applications/autolamella/icons/`, a directory that has never existed, so the handle was silently missing from every workflow task row and Qt printed `QPixmap::scaled: Pixmap is a null pixmap` once per row on every experiment load. But it left the duplication that made the mistake possible, and left the guard against it in one site of four: of the remaining three, two guard with `os.path.exists()` and one does not guard at all.

## What changed

The path and the scale now live once, in `fibsem/ui/icon.py`, which already owns the icon factory and which two of the four sites already imported from:

- `DRAG_HANDLE_PATH`, anchored on `os.path.dirname(__file__)` in `fibsem/ui` itself, so no call site re-derives the directory
- `DRAG_HANDLE_WIDTH` / `DRAG_HANDLE_HEIGHT` (10 / 16), used for both the label's fixed size and the scale
- `drag_handle_pixmap(width, height)`, which checks `isNull()` before scaling and logs the path when the asset cannot be loaded

`isNull()` rather than `os.path.exists()`: it also covers a file that is present but unreadable or not valid SVG. Callers always get a pixmap they can hand straight to `QLabel.setPixmap`.

Each site collapses to `setFixedSize(DRAG_HANDLE_WIDTH, DRAG_HANDLE_HEIGHT)` + `setPixmap(drag_handle_pixmap())`. The milling widget keeps its local `_DRAG_WIDTH` (it also sizes a header spacer) but sources it from the shared constant, as does the correlation widget's `_ROW_RIGHT_WIDTH`, which is commented as aligning with the handle. `import os` went unused in three of the four widgets and `QPixmap` in one; those imports are gone.

## Visual change

None — I rendered the old expression and the new helper to PNG and compared bytes: identical 10×16 at every site, including the one #429 repaired.

## Tests

`tests/ui/test_no_qt_warnings_on_workflow_load.py` keeps what #429 pinned: populating a workflow emits no Qt warning, asserted on `LamellaWorkflowWidget.set_workflow_config` — the call experiment adoption makes, and where the warnings came from.

Its second half checked `module._DRAG_HANDLE_PATH` per module, which cannot survive the consolidation. In its place, the parametrisation over the four modules now builds a real row of each kind (`FibsemMillingStage`, `ChannelSettings`, `Coordinate`, `AutoLamellaTaskDescription`) and asserts:

- the row's handle `QLabel` holds a non-null 10×16 pixmap
- no null-pixmap warning reaches an installed Qt message handler while the row is built
- a missing asset yields an empty pixmap with no warning, still safe to `setPixmap`
- no widget module names `drag_handle.svg` again

That is strictly more than the old check: it pins what each row ends up drawing, not just that a path attribute resolves.

Two mutations confirm it bites: bending `ICONS_DIR` up one directory (the original bug) fails 6 tests, and deleting the `isNull()` guard fails the missing-asset test.

```
QT_QPA_PLATFORM=offscreen python -m pytest tests/ui -q
1 failed, 1380 passed, 1 skipped, 5 errors
```

The 16 tests in this file pass. The failure (`test_overview_widget.py::test_the_context_overlays_describe_where_the_stage_can_go`) and the 5 `test_fm_live_indicator.py` errors are pre-existing — reproduced identically on a pristine `main` tree.
