### PR TITLE
[fix] Estimate milling time over the enabled stages only (FIB-687)

### DIFF
--- a/fibsem/milling/tasks.py
+++ b/fibsem/milling/tasks.py
@@ -136,8 +136,13 @@ class FibsemMillingTaskConfig:
 
     @property
     def estimated_time(self) -> float:
-        """Estimate the total milling time for a list of milling stages"""
-        milling_time = sum(stage.estimated_time for stage in self.stages)
+        """Estimate the total milling time for a list of milling stages.
+
+        Over the enabled stages only, matching what run() will actually mill.
+        Summing every stage counted work that was switched off: a real task with
+        two of its three stages disabled estimated 845 s against ~102 s milled.
+        """
+        milling_time = sum(stage.estimated_time for stage in self.enabled_stages)
         return milling_time + self.acquisition.estimated_time
 
     def compatible_stages(self, reference_idx: int = 0) -> List[Tuple[int, FibsemMillingStage]]:

--- a/tests/milling/test_tasks.py
+++ b/tests/milling/test_tasks.py
@@ -72,6 +72,39 @@ def test_milling_task_config_estimated_time_multiple_stages():
     assert cfg.estimated_time == pytest.approx(stage1.estimated_time + stage2.estimated_time)
 
 
+def test_milling_task_config_estimated_time_ignores_disabled_stages():
+    """A disabled stage is not milled, so it must not be quoted either.
+
+    estimated_time summed self.stages while run() uses enabled_stages, so
+    switching a stage off left the quoted time unchanged.
+    """
+    stage1 = FibsemMillingStage(
+        milling=FibsemMillingSettings(milling_current=2e-9),
+        pattern=RectanglePattern(width=10e-6, height=5e-6, depth=1e-6),
+    )
+    stage2 = FibsemMillingStage(
+        milling=FibsemMillingSettings(milling_current=7.6e-9),
+        pattern=RectanglePattern(width=20e-6, height=10e-6, depth=2e-6),
+        enabled=False,
+    )
+    cfg = FibsemMillingTaskConfig(stages=[stage1, stage2])
+    assert cfg.estimated_time == pytest.approx(stage1.estimated_time)
+    # and strictly less than the same task with the stage switched back on
+    stage2.enabled = True
+    assert cfg.estimated_time > stage1.estimated_time
+
+
+def test_milling_task_config_estimated_time_all_stages_disabled():
+    """Only the acquisition remains: nothing is milled."""
+    stage = FibsemMillingStage(
+        milling=FibsemMillingSettings(milling_current=2e-9),
+        pattern=RectanglePattern(width=10e-6, height=5e-6, depth=1e-6),
+        enabled=False,
+    )
+    cfg = FibsemMillingTaskConfig(stages=[stage])
+    assert cfg.estimated_time == pytest.approx(cfg.acquisition.estimated_time)
+
+
 # ── the post-task image refresh is opt-out ───────────────────────────────────
 #
 # A milling task ends by acquiring one FIB image to refresh the view, when the task


### PR DESCRIPTION
`FibsemMillingTaskConfig.estimated_time` summed `self.stages`, while `run()` mills `self.config.enabled_stages` — the property a few lines up in the same class. A stage switched off was still counted in the quoted time.

```python
-        milling_time = sum(stage.estimated_time for stage in self.stages)
+        milling_time = sum(stage.estimated_time for stage in self.enabled_stages)
```

## Impact

On the Rough Milling config from `AutoLamella-2026-07-29-18-00-DEV-TEST` (Thermo), only `Rough Mill 01` is enabled:

| stage | enabled | estimate |
| -- | -- | -- |
| Rough Mill 01 | yes | 236.5 s |
| Rough Mill 02 | no | 571.9 s |
| Stress Relief Feature | no | 30.7 s |

The task estimated **845 s against 207 s of actual wall-clock**. With the fix it estimates 243 s. The disabled `Rough Mill 02` was contributing 572 s of phantom work by itself.

This is already user-facing: the coincidence milling confirmation dialog prints the figure, so disabling stages to shorten a run left the quoted time unmoved.

## Tests

Two added to `tests/milling/test_tasks.py`:

- a disabled stage is not quoted, and is strictly cheaper than the same task with it enabled
- an all-disabled task costs only its acquisition

Both verified to fail on the pre-fix code. `tests/milling`, `tests/ui/test_milling_lockout.py` and the coincidence dialog tests pass (118).

Found while measuring for FIB-666.