### PR TITLE
[refactor] Remove the border state that nothing can set (FIB-690)

### DIFF
--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -313,7 +313,6 @@ BORDER_STATE_COLOURS = {
     "automated": OK_COLOR,
     "supervised": PRIMARY_COLOR,
     "waiting": ORANGE_COLOR,
-    "finished": OK_COLOR,
     "stopped": SEMANTIC_ERROR_COLOR,
     "agent": "#BF00FF",
 }

--- a/tests/test_border_stylesheet_single_source.py
+++ b/tests/test_border_stylesheet_single_source.py
@@ -12,10 +12,26 @@ this guard running on every version in the matrix, which is the whole point: it 
 what stops the rules being copied a third time. The behavioural tests that need a
 real widget live in tests/ui/test_border_stylesheet.py and skip without PyQt5.
 """
+import ast
 import pathlib
+import re
 
 FIBSEM = pathlib.Path(__file__).resolve().parents[1] / "fibsem"
 OWNER = FIBSEM / "ui" / "stylesheets.py"
+
+SET_STATE = re.compile(r'_set_border_state\(\s*"(?P<state>\w+)"')
+
+
+def _styled_states():
+    """Keys of BORDER_STATE_COLOURS, read from the source rather than imported."""
+    tree = ast.parse(OWNER.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "BORDER_STATE_COLOURS"
+            for t in node.targets
+        ):
+            return {key.value for key in node.value.keys}
+    raise AssertionError("BORDER_STATE_COLOURS not found in " + str(OWNER))
 
 
 def test_border_rules_are_not_hand_written_outside_the_stylesheet_module():
@@ -42,3 +58,31 @@ def test_the_owner_module_still_generates_them():
     assert "def border_stylesheet(" in source
     assert "BORDER_STATE_COLOURS" in source
     assert '[borderState="' in source
+
+
+def test_every_state_the_code_sets_has_a_rule_to_paint_it():
+    """A state with no rule paints no border at all.
+
+    That is not hypothetical: `agent` was set on the coincidence frame while only
+    the main window's copy of the sheet declared it, so those runs showed nothing.
+    FIB-679 removed the duplication; this stops the same gap reappearing from the
+    other direction, where a new state is set in code and never given a colour.
+
+    Only quoted literals are matched -- `_set_border_state(initial_state)` and the
+    supervised/automated ternary pass variables, and their values appear as literals
+    at the sites that build them.
+
+    The reverse (a rule no code sets) is deliberately not asserted: landing a state's
+    styling ahead of its wiring is a normal way to ship groundwork.
+    """
+    styled = _styled_states()
+    used = {}
+    for path in FIBSEM.rglob("*.py"):
+        for match in SET_STATE.finditer(path.read_text(encoding="utf-8")):
+            used.setdefault(match.group("state"), set()).add(
+                str(path.relative_to(FIBSEM.parent))
+            )
+    unstyled = {
+        state: sorted(paths) for state, paths in used.items() if state not in styled
+    }
+    assert unstyled == {}, f"states set in code with no border rule: {unstyled}"


### PR DESCRIPTION
`finished` was declared in the border stylesheet and set by nothing. Across both widgets that draw a border, every state literal reaching `_set_border_state` is one of `idle`, `automated`, `supervised`, `waiting`, `stopped`, `agent`.

Wiring it up would not have made it visible either — it carried `OK_COLOR`, the same green as `automated`, so a completed run and a running one would have looked identical.

Deleting is the honest resolution: the border says what is happening *now*, and for a run that has ended `idle` already says it finished. FIB-678 latches `stopped` on top of this, after which the border reads as "is there something you need to look at?" — and under that reading a separate success colour earns nothing.

## The guard is the more useful half

`test_every_state_the_code_sets_has_a_rule_to_paint_it` asserts every quoted state passed to `_set_border_state` has a rule to paint it. A state with no rule paints **no border at all**, silently — which is precisely what happened to `agent` on the coincidence frame before FIB-679 removed the second copy of the sheet. That PR closed the duplication; this closes the other direction.

It reads the `BORDER_STATE_COLOURS` keys out of the source with `ast` rather than importing them. `stylesheets.py` looks Qt-free, but importing any `fibsem.ui` submodule runs `fibsem/ui/__init__.py`, which eagerly imports the Qt widgets — so an import-based guard would skip on CI, where the `[ui]` extra is not installed.

Checked by making it fail, not by watching it pass. Dropping `agent` from the mapping gives:

```
AssertionError: states set in code with no border rule:
  {'agent': ['fibsem/applications/autolamella/ui/AutoLamellaMainUI.py']}
```

**One-directional on purpose.** A rule that no code sets is *not* asserted against, so a state's styling can still land ahead of its wiring — FIB-676 will want exactly that for `pending`.

## Verified

Both real widgets rebuilt, driven through their own `_set_border_state()` for every remaining state, sampling the pixel each border actually paints on all four edges:

```
--- AutoLamella main window (AutoLamellaSingleWindowUI) ---
  idle        expect #262930  painted ['#262930']  OK
  automated   expect #4CAF50  painted ['#4CAF50']  OK
  supervised  expect #007ACC  painted ['#007ACC']  OK
  waiting     expect #FF9800  painted ['#FF9800']  OK
  stopped     expect #99121F  painted ['#99121F']  OK
  agent       expect #BF00FF  painted ['#BF00FF']  OK
  re-entry    expect #99121F  painted ['#99121F']  OK
```

Identical for the coincidence viewer.

Tests: `tests/test_border_stylesheet_single_source.py`, `tests/ui/test_border_stylesheet.py` — 7 passed.
