### PR TITLE
[feat] Estimate task duration from measured per-operation costs

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -44,6 +44,7 @@ from fibsem.structures import (
     SessionInfo,
     get_fields_with_metadata,
 )
+from fibsem import timing
 from fibsem.utils import configure_logging as _configure_logging
 from fibsem.utils import format_duration
 
@@ -210,6 +211,27 @@ class AutoLamellaTaskConfig(ABC):
         milling_time = sum(t.estimated_time for t in self.milling.values())
         imaging_time = self.reference_imaging.estimated_time
         return milling_time + imaging_time
+
+    @property
+    def estimated_duration(self) -> float:
+        """Conservative forward estimate of this task's wall-clock, in seconds.
+
+        Unlike :attr:`estimated_time`, which counts only the scan arithmetic and the
+        milling, this adds the measured per-operation costs the task actually pays --
+        see :mod:`fibsem.timing`. On the run it was calibrated against, that moved
+        Setup Lamella Position from 0.22x of its real duration to 0.99x.
+
+        A task whose cost is dominated by something this base cannot see -- spot burn
+        exposures, fluorescence channels -- overrides this and adds its own term. The
+        estimate lives on the config rather than on the task because the callers that
+        need it (the pre-run dialog, the queue) hold configs and have no microscope to
+        construct a task with.
+        """
+        # reference images are acquired at both ends of a task
+        total = 2 * timing.reference_image_cost(self.reference_imaging)
+        for milling_task in self.milling.values():
+            total += timing.milling_task_cost(milling_task)
+        return total
     
     @property
     def imaging(self) -> ImageSettings:

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -213,6 +213,26 @@ class AutoLamellaTaskConfig(ABC):
         return milling_time + imaging_time
 
     @property
+    def opens_with_stage_move(self) -> bool:
+        """Whether ``_run`` begins by moving the stage onto the task's pose.
+
+        True for nearly every task, and the exceptions say so. Charged even when the
+        stage is already in place -- a task following another on the same lamella pays
+        0.02 s for the move rather than 7.6 s -- because which case applies is runtime
+        state the config cannot see, and over-charging errs long.
+        """
+        return True
+
+    @property
+    def opens_with_reference_alignment(self) -> bool:
+        """Whether ``_run`` aligns against the stored reference before its own work.
+
+        Off by default: only some tasks do it, and a task that claims it when it does
+        not adds 5 s of fiction to every estimate that includes it.
+        """
+        return False
+
+    @property
     def estimated_duration(self) -> float:
         """Conservative forward estimate of this task's wall-clock, in seconds.
 
@@ -232,6 +252,11 @@ class AutoLamellaTaskConfig(ABC):
         # _acquire_set_of_reference_images over all of them.
         total = timing.reference_image_cost(self.reference_imaging, fovs=1)
         total += timing.reference_image_cost(self.reference_imaging)
+        # what _run does before its own work
+        if self.opens_with_stage_move:
+            total += timing.stage_move_cost(1)
+        if self.opens_with_reference_alignment:
+            total += timing.REFERENCE_ALIGNMENT_S
         for milling_task in self.milling.values():
             total += timing.milling_task_cost(milling_task)
         return total

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -227,8 +227,11 @@ class AutoLamellaTaskConfig(ABC):
         need it (the pre-run dialog, the queue) hold configs and have no microscope to
         construct a task with.
         """
-        # reference images are acquired at both ends of a task
-        total = 2 * timing.reference_image_cost(self.reference_imaging)
+        # Reference images at both ends, but not the same number: a task opens with
+        # _acquire_reference_image at one field of view and closes with
+        # _acquire_set_of_reference_images over all of them.
+        total = timing.reference_image_cost(self.reference_imaging, fovs=1)
+        total += timing.reference_image_cost(self.reference_imaging)
         for milling_task in self.milling.values():
             total += timing.milling_task_cost(milling_task)
         return total

--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -19,7 +19,8 @@ from fibsem.applications.autolamella.workflows.ui import (
 from fibsem.fm.acquisition import acquire_image
 from fibsem.fm.structures import AutoFocusSettings, ChannelSettings, ZParameters
 from fibsem.fm.calibration import run_coarse_fine_autofocus, AutoFocusResult
-from fibsem.fm.timing import estimate_acquisition_time
+from fibsem.fm.timing import estimate_acquisition_time, estimate_autofocus_time
+from fibsem import timing
 from fibsem.structures import field_meta
 
 
@@ -71,18 +72,25 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
 
     @property
     def estimated_duration(self) -> float:
-        """The base estimate plus the fluorescence acquisition itself.
+        """The base estimate plus everything ``_run`` does, in the order it does it.
 
-        Delegates to the FM timing module, which already models channels, z-planes
-        and their ordering. Without it the inherited estimate saw only the reference
-        images and came out at 0.13x of the measured duration.
+        The acquisition and the autofocus sweep both delegate to the FM timing module,
+        which models channels, z-planes and sweep steps from the settings themselves.
+        The objective costs are measured -- see :mod:`fibsem.timing`.
 
-        The objective insert/retract either side is not counted: it is not measured,
-        and guessing it is how fm/timing.py acquired its unmeasured constants.
+        The optional steps are counted only when they are switched on. Insertion is the
+        exception: whether the objective already happens to be inserted is runtime state
+        the config cannot see, so it is always counted, which errs long.
         """
-        return super().estimated_duration + estimate_acquisition_time(
-            self.channel_settings, self.zparams
-        )
+        total = super().estimated_duration
+        total += timing.stage_move_cost(1)                 # move to the lamella
+        total += timing.OBJECTIVE_INSERT_S
+        total += timing.OBJECTIVE_FOCUS_MOVE_S
+        total += estimate_autofocus_time(self.autofocus_settings, self.channel_settings)
+        total += estimate_acquisition_time(self.channel_settings, self.zparams)
+        if self.retract_objective:
+            total += timing.OBJECTIVE_RETRACT_S
+        return total
 
 
 class AcquireFluorescenceImageTask(AutoLamellaTask):

--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -19,6 +19,7 @@ from fibsem.applications.autolamella.workflows.ui import (
 from fibsem.fm.acquisition import acquire_image
 from fibsem.fm.structures import AutoFocusSettings, ChannelSettings, ZParameters
 from fibsem.fm.calibration import run_coarse_fine_autofocus, AutoFocusResult
+from fibsem.fm.timing import estimate_acquisition_time
 from fibsem.structures import field_meta
 
 
@@ -68,7 +69,22 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
             retract_objective=data.get("retract_objective", True),
         )
 
-# TODO: implement time estimates...
+    @property
+    def estimated_duration(self) -> float:
+        """The base estimate plus the fluorescence acquisition itself.
+
+        Delegates to the FM timing module, which already models channels, z-planes
+        and their ordering. Without it the inherited estimate saw only the reference
+        images and came out at 0.13x of the measured duration.
+
+        The objective insert/retract either side is not counted: it is not measured,
+        and guessing it is how fm/timing.py acquired its unmeasured constants.
+        """
+        return super().estimated_duration + estimate_acquisition_time(
+            self.channel_settings, self.zparams
+        )
+
+
 class AcquireFluorescenceImageTask(AutoLamellaTask):
     """Task to acquire fluorescence image with specified settings."""
     config: AcquireFluorescenceImageConfig

--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -83,7 +83,6 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
         the config cannot see, so it is always counted, which errs long.
         """
         total = super().estimated_duration
-        total += timing.stage_move_cost(1)                 # move to the lamella
         total += timing.OBJECTIVE_INSERT_S
         total += timing.OBJECTIVE_FOCUS_MOVE_S
         total += estimate_autofocus_time(self.autofocus_settings, self.channel_settings)

--- a/fibsem/applications/autolamella/workflows/tasks/fiducial.py
+++ b/fibsem/applications/autolamella/workflows/tasks/fiducial.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import ClassVar, Optional, Type
 
+from fibsem import timing
 from fibsem.applications.autolamella.protocol.constants import (
     FIDUCIAL_KEY,
     MILL_POLISHING_KEY,
@@ -48,6 +49,27 @@ class MillFiducialTaskConfig(AutoLamellaTaskConfig):
     def __post_init__(self):
         if self.milling == {}:
             self.milling = deepcopy({FIDUCIAL_KEY: DEFAULT_MILLING_CONFIG[FIDUCIAL_KEY]})
+
+    @property
+    def estimated_duration(self) -> float:
+        """The base and the milling, plus what ``_run`` does before either.
+
+        The task opens by restoring the milling pose and aligning against the stored
+        reference, and neither is visible to the base estimate -- 12 s of a 110 s task,
+        which is most of what left it at 0.85x.
+
+        The move is charged unconditionally even though a task following another on the
+        same lamella will find the stage already in place (measured at 0.02 s when it
+        is). Which case applies is runtime state, so this errs long.
+
+        The same two steps open every milling task; the others have not been measured
+        yet and so do not claim them.
+        """
+        total = super().estimated_duration
+        total += timing.stage_move_cost(1)        # _move_to_milling_pose
+        if self.align_to_reference:
+            total += timing.REFERENCE_ALIGNMENT_S  # _align_reference_image
+        return total
 
 
 class MillFiducialTask(AutoLamellaTask):

--- a/fibsem/applications/autolamella/workflows/tasks/fiducial.py
+++ b/fibsem/applications/autolamella/workflows/tasks/fiducial.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import ClassVar, Optional, Type
 
-from fibsem import timing
 from fibsem.applications.autolamella.protocol.constants import (
     FIDUCIAL_KEY,
     MILL_POLISHING_KEY,
@@ -51,25 +50,9 @@ class MillFiducialTaskConfig(AutoLamellaTaskConfig):
             self.milling = deepcopy({FIDUCIAL_KEY: DEFAULT_MILLING_CONFIG[FIDUCIAL_KEY]})
 
     @property
-    def estimated_duration(self) -> float:
-        """The base and the milling, plus what ``_run`` does before either.
-
-        The task opens by restoring the milling pose and aligning against the stored
-        reference, and neither is visible to the base estimate -- 12 s of a 110 s task,
-        which is most of what left it at 0.85x.
-
-        The move is charged unconditionally even though a task following another on the
-        same lamella will find the stage already in place (measured at 0.02 s when it
-        is). Which case applies is runtime state, so this errs long.
-
-        The same two steps open every milling task; the others have not been measured
-        yet and so do not claim them.
-        """
-        total = super().estimated_duration
-        total += timing.stage_move_cost(1)        # _move_to_milling_pose
-        if self.align_to_reference:
-            total += timing.REFERENCE_ALIGNMENT_S  # _align_reference_image
-        return total
+    def opens_with_reference_alignment(self) -> bool:
+        """Only when configured to: `align_to_reference` gates the call in `_run`."""
+        return self.align_to_reference
 
 
 class MillFiducialTask(AutoLamellaTask):

--- a/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
+++ b/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
@@ -87,6 +87,16 @@ class MillCoincidentTaskConfig(AutoLamellaTaskConfig):
         metadata=field_meta(tooltip="The fluorescence channel to use for coincident milling"),
     )
     task_type: ClassVar[str] = "MILL_COINCIDENT"
+
+    @property
+    def opens_with_stage_move(self) -> bool:
+        """_run does not move: it mills where the coincidence step left the stage."""
+        return False
+
+    @property
+    def opens_with_reference_alignment(self) -> bool:
+        return True
+
     display_name: ClassVar[str] = "Coincident Milling"
 
     def __post_init__(self):

--- a/fibsem/applications/autolamella/workflows/tasks/polishing.py
+++ b/fibsem/applications/autolamella/workflows/tasks/polishing.py
@@ -27,6 +27,12 @@ class MillPolishingTaskConfig(AutoLamellaTaskConfig):
             tooltip="Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated."),
     )
     task_type: ClassVar[str] = "MILL_POLISHING"
+
+    @property
+    def opens_with_reference_alignment(self) -> bool:
+        """_run aligns against the stored reference before milling."""
+        return True
+
     display_name: ClassVar[str] = "Polishing"
 
     def __post_init__(self):

--- a/fibsem/applications/autolamella/workflows/tasks/rough.py
+++ b/fibsem/applications/autolamella/workflows/tasks/rough.py
@@ -45,6 +45,12 @@ class MillRoughTaskConfig(AutoLamellaTaskConfig):
             tooltip="Whether to reacquire the alignment reference after milling"),
     )
     task_type: ClassVar[str] = "MILL_ROUGH"
+
+    @property
+    def opens_with_reference_alignment(self) -> bool:
+        """_run aligns against the stored reference before milling."""
+        return True
+
     display_name: ClassVar[str] = "Rough Milling"
 
     def __post_init__(self):

--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -7,7 +7,7 @@ import logging
 
 import numpy as np
 
-from fibsem import constants
+from fibsem import constants, timing
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
 from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
 from fibsem.applications.autolamella.workflows.ui import ask_user, select_poi_ui
@@ -36,6 +36,7 @@ class SelectMillingPositionTaskConfig(AutoLamellaTaskConfig):
             label="Use Autofocus",
             tooltip="Whether to autofocus before moving to the milling position"),
     )
+
     select_poi: bool = field(
         default=True,
         metadata=field_meta(
@@ -44,6 +45,20 @@ class SelectMillingPositionTaskConfig(AutoLamellaTaskConfig):
     )
     task_type: ClassVar[str] = "SELECT_MILLING_POSITION"
     display_name: ClassVar[str] = "Select Milling Position"
+
+    @property
+    def estimated_duration(self) -> float:
+        """The base plus the move onto the milling pose.
+
+        Charged unconditionally: a task that finds the stage already in place pays
+        almost nothing for the move, but which case applies is runtime state, so this
+        errs long.
+
+        The autofocus sweeps behind ``use_autofocus`` are not counted -- unlike the
+        fluorescence sweep, the beam sweep's cost per step has not been measured, and
+        the run this was calibrated against had them off.
+        """
+        return super().estimated_duration + timing.stage_move_cost(1)
 
 
 class SelectMillingPositionTask(AutoLamellaTask):

--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -7,7 +7,7 @@ import logging
 
 import numpy as np
 
-from fibsem import constants, timing
+from fibsem import constants
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
 from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
 from fibsem.applications.autolamella.workflows.ui import ask_user, select_poi_ui
@@ -46,19 +46,6 @@ class SelectMillingPositionTaskConfig(AutoLamellaTaskConfig):
     task_type: ClassVar[str] = "SELECT_MILLING_POSITION"
     display_name: ClassVar[str] = "Select Milling Position"
 
-    @property
-    def estimated_duration(self) -> float:
-        """The base plus the move onto the milling pose.
-
-        Charged unconditionally: a task that finds the stage already in place pays
-        almost nothing for the move, but which case applies is runtime state, so this
-        errs long.
-
-        The autofocus sweeps behind ``use_autofocus`` are not counted -- unlike the
-        fluorescence sweep, the beam sweep's cost per step has not been measured, and
-        the run this was calibrated against had them off.
-        """
-        return super().estimated_duration + timing.stage_move_cost(1)
 
 
 class SelectMillingPositionTask(AutoLamellaTask):

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -62,6 +62,10 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
         return tuple(p for p in super().parameters if p != "coordinates")
 
     @property
+    def opens_with_reference_alignment(self) -> bool:
+        return True
+
+    @property
     def estimated_duration(self) -> float:
         """The base estimate plus everything ``_run`` does, in the order it does it.
 
@@ -74,8 +78,6 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
         Each point costs its exposure plus a blank/park/unblank cycle.
         """
         total = super().estimated_duration
-        total += timing.stage_move_cost(1)            # _move_to_milling_pose
-        total += timing.REFERENCE_ALIGNMENT_S         # _align_reference_image
         total += 2 * timing.BEAM_CURRENT_CHANGE_S     # into the burn current and back
         total += len(self.coordinates) * (
             self.exposure_time + timing.SPOT_BURN_POINT_OVERHEAD_S

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import ClassVar, Optional, Type
 
 from fibsem import config as fcfg
+from fibsem import timing
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
 from fibsem.applications.autolamella.workflows.tasks.base import (
     ALIGNMENT_REFERENCE_IMAGE_FILENAME,
@@ -62,13 +63,24 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
 
     @property
     def estimated_duration(self) -> float:
-        """The base estimate plus the burn itself: one exposure per coordinate.
+        """The base estimate plus everything ``_run`` does, in the order it does it.
 
-        This is the task's dominant term and the base cannot see it -- on the
-        measured run, 11 points at 10 s was 110 s of a 264 s task, while the
-        inherited estimate accounted for none of it.
+        The burn is the dominant term and the base cannot see it: on the measured run,
+        11 points at 10 s was 110 s of the task. But the burn alone left the estimate
+        at 0.71x of the machine time, and the remainder is all here -- the move onto
+        the milling pose, the alignment against the stored reference, and the beam
+        current switching into the burn current and back out.
+
+        Each point costs its exposure plus a blank/park/unblank cycle.
         """
-        return super().estimated_duration + len(self.coordinates) * self.exposure_time
+        total = super().estimated_duration
+        total += timing.stage_move_cost(1)            # _move_to_milling_pose
+        total += timing.REFERENCE_ALIGNMENT_S         # _align_reference_image
+        total += 2 * timing.BEAM_CURRENT_CHANGE_S     # into the burn current and back
+        total += len(self.coordinates) * (
+            self.exposure_time + timing.SPOT_BURN_POINT_OVERHEAD_S
+        )
+        return total
 
     def to_dict(self) -> dict:
         ddict = {}

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -60,6 +60,16 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
     def parameters(self) -> tuple[str, ...]:
         return tuple(p for p in super().parameters if p != "coordinates")
 
+    @property
+    def estimated_duration(self) -> float:
+        """The base estimate plus the burn itself: one exposure per coordinate.
+
+        This is the task's dominant term and the base cannot see it -- on the
+        measured run, 11 points at 10 s was 110 s of a 264 s task, while the
+        inherited estimate accounted for none of it.
+        """
+        return super().estimated_duration + len(self.coordinates) * self.exposure_time
+
     def to_dict(self) -> dict:
         ddict = {}
         ddict["task_type"] = self.task_type

--- a/fibsem/fm/timing.py
+++ b/fibsem/fm/timing.py
@@ -110,7 +110,11 @@ def estimate_autofocus_time(
     if channel is None:
         channel = channel_settings[0]
 
-    n_images = sum(p.n_steps for p in autofocus_settings.passes if p.enabled)
+    # n_steps + 1, matching the sweep itself: run_autofocus builds its working
+    # distances with np.linspace(..., n_steps + 1), so a pass covering n steps takes
+    # n + 1 images. The measured run logged "21 positions" for a 20-step pass and
+    # "11 positions" for a 10-step one.
+    n_images = sum(p.n_steps + 1 for p in autofocus_settings.passes if p.enabled)
     # one objective move between consecutive steps, as in the z-stack above
     n_moves = max(n_images - 1, 0)
     return (

--- a/fibsem/fm/timing.py
+++ b/fibsem/fm/timing.py
@@ -10,7 +10,7 @@ import logging
 from typing import List, Optional, Tuple, Union
 
 from fibsem.fm.structures import ChannelSettings, ZParameters, ZStackOrder
-from fibsem.fm.structures import AutoFocusMode
+from fibsem.fm.structures import AutoFocusMode, AutoFocusSettings
 
 # Timing constants for acquisition operations
 DEFAULT_OVERHEAD_PER_IMAGE = 0.5  # seconds - camera readout, processing overhead
@@ -68,6 +68,55 @@ def calculate_total_images_count(
         num_z_planes = zparams.num_planes
 
     return num_channels * num_z_planes
+
+
+def estimate_autofocus_time(
+    autofocus_settings: "AutoFocusSettings",
+    channel_settings: Union[ChannelSettings, List[ChannelSettings]],
+) -> float:
+    """Estimate an image-based autofocus sweep from the passes it will actually run.
+
+    Each enabled pass sweeps ``search_range`` in ``step_size`` increments, taking one
+    image per step -- ``FocusSweepPass.n_steps`` is exactly that count -- so the sweep
+    is arithmetic rather than a constant. With the default coarse/fine pair (50 um at
+    5 um, then 10 um at 1 um) that is around twenty images, several times the 5 s
+    ``DEFAULT_AUTOFOCUS_TIME`` assumes.
+
+    The channel is resolved the way the acquisition path resolves it: by name when
+    ``channel_name`` is set, otherwise the first channel.
+
+    ``DEFAULT_AUTOFOCUS_TIME`` is still used by the tileset estimators below, which
+    are handed an autofocus *mode* rather than the settings and so cannot count steps.
+
+    Args:
+        autofocus_settings: the sweep to estimate
+        channel_settings: the channels available to focus on
+
+    Returns:
+        float: estimated autofocus time in seconds, 0.0 if no pass is enabled
+    """
+    if autofocus_settings is None or not autofocus_settings.enabled:
+        return 0.0
+    if not isinstance(channel_settings, list):
+        channel_settings = [channel_settings]
+    if not channel_settings:
+        return 0.0
+
+    channel = None
+    if autofocus_settings.channel_name:
+        channel = next(
+            (c for c in channel_settings if c.name == autofocus_settings.channel_name), None
+        )
+    if channel is None:
+        channel = channel_settings[0]
+
+    n_images = sum(p.n_steps for p in autofocus_settings.passes if p.enabled)
+    # one objective move between consecutive steps, as in the z-stack above
+    n_moves = max(n_images - 1, 0)
+    return (
+        n_images * (channel.exposure_time + DEFAULT_OVERHEAD_PER_IMAGE)
+        + n_moves * DEFAULT_Z_MOVE_TIME
+    )
 
 
 def estimate_acquisition_time(

--- a/fibsem/fm/timing.py
+++ b/fibsem/fm/timing.py
@@ -13,7 +13,17 @@ from fibsem.fm.structures import ChannelSettings, ZParameters, ZStackOrder
 from fibsem.fm.structures import AutoFocusMode, AutoFocusSettings
 
 # Timing constants for acquisition operations
-DEFAULT_OVERHEAD_PER_IMAGE = 0.5  # seconds - camera readout, processing overhead
+# Camera readout, processing and save, per image, on top of the exposure. Measured
+# against AutoLamella-2026-07-29-18-00-DEV-TEST (Thermo): a 42-image z-stack ran at
+# 2.31 s/image net of exposure and z movement, and a 32-image autofocus sweep at
+# 1.57 s/image. The earlier 0.5 s was an assumption, ~4x low, and it is what left the
+# fluorescence duration estimate at a third of the real figure.
+#
+# The two figures differ because the z-stack writes each frame to OME-TIFF and the
+# autofocus sweep does not, so this is really two costs wearing one name. It takes the
+# higher of the two: over-estimating a sweep is the safe direction, and splitting the
+# constant would change every caller's shape for a term neither of them separates yet.
+DEFAULT_OVERHEAD_PER_IMAGE = 2.3  # seconds - camera readout, processing, save
 DEFAULT_Z_MOVE_TIME = 0.1  # seconds - time to move between z-positions
 DEFAULT_STAGE_MOVE_TIME = 5.0  # seconds - time to move stage between tiles
 DEFAULT_AUTOFOCUS_TIME = 5.0  # seconds - time for each autofocus operation

--- a/fibsem/timing.py
+++ b/fibsem/timing.py
@@ -101,16 +101,24 @@ def image_cost(settings: Optional[ImageSettings], count: int = 1) -> float:
     return count * (settings.estimated_time + IMAGE_OVERHEAD_S)
 
 
-def reference_image_cost(params: Optional[ReferenceImageParameters]) -> float:
+def reference_image_cost(
+    params: Optional[ReferenceImageParameters], fovs: Optional[int] = None
+) -> float:
     """Seconds to acquire one set of reference images.
 
     One image per selected field of view per selected beam, which is what
     ``ReferenceImageParameters.estimated_time`` counts -- this adds the
     per-acquisition overhead that property omits.
+
+    ``fovs`` overrides the field-of-view count. Tasks are not symmetric about their
+    reference imaging: they open with ``_acquire_reference_image`` at a single field
+    of view and close with ``_acquire_set_of_reference_images`` over all of them, so
+    the opening acquisition is half the closing one. Measured on both milling tasks:
+    two frames at the start, four at the end.
     """
     if params is None:
         return 0.0
-    n_fovs = sum([params.acquire_image1, params.acquire_image2])
+    n_fovs = sum([params.acquire_image1, params.acquire_image2]) if fovs is None else fovs
     n_beams = sum([params.acquire_sem, params.acquire_fib])
     return image_cost(params.imaging, n_fovs * n_beams)
 

--- a/fibsem/timing.py
+++ b/fibsem/timing.py
@@ -1,0 +1,142 @@
+"""Forward estimates of how long microscope operations take.
+
+The single home for the measured constants behind every duration the app quotes.
+Estimates are computed from the configuration about to run — nothing here reads
+past runs, because the parameters differ between runs and a median over mixed
+configurations would be confidently wrong.
+
+Where a value could go either way it rounds **up**. An estimate that runs long is
+a mild annoyance; one that runs short means an unattended run is not finished when
+the user comes back for it. The constants below are the p90 of their measurement,
+not the median, for that reason.
+
+Provenance
+----------
+Measured against ``AutoLamella-2026-07-29-18-00-DEV-TEST`` (Thermo), by pairing the
+``INFO``/``DEBUG`` log entries each operation emits. One instrument, small n: treat
+these as starting values to be re-measured, not as settled. Each constant carries
+its own sample count and spread below.
+
+See FIB-666.
+"""
+
+import logging
+from typing import TYPE_CHECKING, Iterable, Optional
+
+from fibsem.structures import ImageSettings, MillingAlignment, ReferenceImageParameters
+
+if TYPE_CHECKING:
+    from fibsem.milling.base import FibsemMillingStage
+
+# --- Measured constants ------------------------------------------------------
+
+# Fixed cost of one acquisition on top of the scan itself: beam settle, frame grab,
+# processing, save. n=78, median 1.52 s, p90 1.93 s, max 1.98 s. Flat across
+# resolution, dwell time, beam and autocontrast, so it is a fixed cost per image
+# rather than a factor on the scan time -- at 1536x1024 and 1 us dwell it roughly
+# doubles the arithmetic, which is why an estimate built from scan time alone came
+# out 30-40x short on imaging-dominated tasks.
+IMAGE_OVERHEAD_S = 2.0
+
+# Stage moves. Absolute: n=19, median 7.41 s, p90 7.76 s, max 8.40 s.
+# Relative: n=31, median 3.37 s, p90 6.16 s, max 7.60 s -- a wider spread, since a
+# relative move covers anything from a nudge to a full traverse.
+# These replace fm/timing.py's unmeasured DEFAULT_STAGE_MOVE_TIME = 5.0.
+STAGE_MOVE_ABSOLUTE_S = 8.0
+STAGE_MOVE_RELATIVE_S = 6.5
+
+# Not measured yet, and deliberately not invented here: autofocus, beam/current
+# switching, and the per-task setup either side of the operations above. Tasks that
+# need them should say so rather than have this module guess -- fm/timing.py's
+# DEFAULT_AUTOFOCUS_TIME = 5.0 is an assumption of exactly that kind.
+
+
+def image_cost(settings: Optional[ImageSettings], count: int = 1) -> float:
+    """Seconds to acquire ``count`` images with these settings.
+
+    Scan time is arithmetic (``pixels x dwell x integration``); the rest is the
+    fixed per-acquisition overhead, which dominates at typical settings.
+    """
+    if settings is None or count <= 0:
+        return 0.0
+    return count * (settings.estimated_time + IMAGE_OVERHEAD_S)
+
+
+def reference_image_cost(params: Optional[ReferenceImageParameters]) -> float:
+    """Seconds to acquire one set of reference images.
+
+    One image per selected field of view per selected beam, which is what
+    ``ReferenceImageParameters.estimated_time`` counts -- this adds the
+    per-acquisition overhead that property omits.
+    """
+    if params is None:
+        return 0.0
+    n_fovs = sum([params.acquire_image1, params.acquire_image2])
+    n_beams = sum([params.acquire_sem, params.acquire_fib])
+    return image_cost(params.imaging, n_fovs * n_beams)
+
+
+def stage_move_cost(count: int = 1, absolute: bool = True) -> float:
+    """Seconds for ``count`` stage moves."""
+    if count <= 0:
+        return 0.0
+    return count * (STAGE_MOVE_ABSOLUTE_S if absolute else STAGE_MOVE_RELATIVE_S)
+
+
+def alignment_cost(alignment: Optional[MillingAlignment]) -> float:
+    """Seconds for one drift-correction pass.
+
+    ``steps`` images, and nothing when alignment is switched off. The interval
+    re-alignment (``interval_enabled``) is not counted: how many times it fires
+    depends on how long the milling runs, so the caller has to fold it in against
+    its own milling estimate rather than have this guess.
+    """
+    if alignment is None or not alignment.enabled:
+        return 0.0
+    return image_cost(alignment.imaging, alignment.steps)
+
+
+def milling_cost(stages: Optional[Iterable["FibsemMillingStage"]]) -> float:
+    """Seconds to mill these stages, counting only the enabled ones.
+
+    Uses each stage's own ``estimated_time`` -- the local formula in
+    ``milling/base.py``, not ``microscope.estimate_milling_time()``. The two
+    disagree: on the measured run they matched on a plain rectangle (26.7 s vs
+    27.3 s) but diverged by more than 2x on a trench (236.5 s vs 102.4 s), with
+    the actual 146.2 s falling between them. The local formula is used here
+    because it needs no microscope connection, so a pre-run dialog can quote a
+    time before anything is set up, and because its bias on trenches is the
+    conservative direction.
+
+    No correction factor is applied yet. Two stages is not enough to calibrate
+    one, and a wrong factor is worse than none.
+    """
+    if stages is None:
+        return 0.0
+    return sum(stage.estimated_time for stage in stages if stage.enabled)
+
+
+def milling_task_cost(config) -> float:
+    """Seconds for one ``FibsemMillingTaskConfig``: milling, alignment, acquisition.
+
+    Takes the config structurally rather than by import, so this module does not
+    depend on the milling package.
+    """
+    if config is None:
+        return 0.0
+    total = milling_cost(getattr(config, "stages", None))
+    total += alignment_cost(getattr(config, "alignment", None))
+    acquisition = getattr(config, "acquisition", None)
+    if acquisition is not None and getattr(acquisition, "enabled", False):
+        n_beams = sum([acquisition.acquire_sem, acquisition.acquire_fib])
+        total += image_cost(acquisition.imaging, n_beams)
+    elif acquisition is not None and getattr(acquisition, "acquire_final_image", False):
+        # the post-task refresh: one FIB image, only when the task acquired none itself
+        total += image_cost(acquisition.imaging, 1)
+    return total
+
+
+def log_estimate(label: str, seconds: float) -> None:
+    """Debug-log an estimate in the same shape everywhere, for later comparison
+    against the durations the experiment record already stores."""
+    logging.debug({"msg": "duration_estimate", "label": label, "seconds": seconds})

--- a/fibsem/timing.py
+++ b/fibsem/timing.py
@@ -61,11 +61,23 @@ OBJECTIVE_RETRACT_S = 19.6
 # Distance-independent as far as this sample shows, so a flat cost rather than a rate.
 OBJECTIVE_FOCUS_MOVE_S = 4.3
 
-# Still not counted, and deliberately not invented here: beam/current switching, and
-# the per-task setup either side of the operations above. Tasks that need them should
-# say so rather than have this module guess. Autofocus is no longer on this list --
-# fm/timing.estimate_autofocus_time counts the sweep's steps instead of assuming a
-# duration, which is what DEFAULT_AUTOFOCUS_TIME = 5.0 was doing.
+# Changing the ion beam current. n=4: 20.2 s setting the milling current, and 20.2 /
+# 20.1 / 20.1 s restoring the imaging current afterwards. A milling task pays this
+# twice -- once into the milling current, once back out -- so roughly 40 s per task
+# that milling's own estimate never sees.
+BEAM_CURRENT_CHANGE_S = 20.5
+
+# Drift-correction imaging. These are reduced-area frames and are far cheaper than the
+# full-frame acquisitions IMAGE_OVERHEAD_S describes: measured 0.77-0.82 s each, against
+# ~3.5 s for a full frame. n=16 across two milling stages.
+ALIGNMENT_IMAGE_S = 0.85
+# Autocontrast, once per alignment pass. n=3: 0.9 / 1.3 / 1.7 s.
+ALIGNMENT_AUTOCONTRAST_S = 1.7
+
+# Still not counted, and deliberately not invented here: the pattern setup between the
+# milling estimate and the first stroke (0 s on a rectangle, 15 s on a trench in the one
+# run measured -- too variable to pick a number from), and the per-task setup either
+# side of the operations above.
 
 
 def image_cost(settings: Optional[ImageSettings], count: int = 1) -> float:
@@ -100,17 +112,27 @@ def stage_move_cost(count: int = 1, absolute: bool = True) -> float:
     return count * (STAGE_MOVE_ABSOLUTE_S if absolute else STAGE_MOVE_RELATIVE_S)
 
 
-def alignment_cost(alignment: Optional[MillingAlignment]) -> float:
-    """Seconds for one drift-correction pass.
+def alignment_cost(alignment: Optional[MillingAlignment], passes: int = 2) -> float:
+    """Seconds for drift correction, over ``passes`` alignment passes.
 
-    ``steps`` images, and nothing when alignment is switched off. The interval
-    re-alignment (``interval_enabled``) is not counted: how many times it fires
-    depends on how long the milling runs, so the caller has to fold it in against
+    A pass is one autocontrast plus ``steps + 1`` reduced-area frames, matching the
+    log: a stage configured for 3 steps acquired 4 images per pass, and ran two
+    passes -- once at the imaging current, then again after switching to the milling
+    current ("FIB Aligning at Milling Current"). Costing a single pass of ``steps``
+    frames understated it by half.
+
+    The frames are charged at :data:`ALIGNMENT_IMAGE_S` rather than through
+    :func:`image_cost`, because they are reduced-area: measured ~0.8 s against ~3.5 s
+    for the full frame the alignment's own ``ImageSettings`` describes.
+
+    The interval re-alignment (``interval_enabled``) is not counted: how many times it
+    fires depends on how long the milling runs, so the caller has to fold it in against
     its own milling estimate rather than have this guess.
     """
-    if alignment is None or not alignment.enabled:
+    if alignment is None or not alignment.enabled or passes <= 0:
         return 0.0
-    return image_cost(alignment.imaging, alignment.steps)
+    per_pass = ALIGNMENT_AUTOCONTRAST_S + (alignment.steps + 1) * ALIGNMENT_IMAGE_S
+    return passes * per_pass
 
 
 def milling_cost(stages: Optional[Iterable["FibsemMillingStage"]]) -> float:
@@ -141,8 +163,14 @@ def milling_task_cost(config) -> float:
     """
     if config is None:
         return 0.0
-    total = milling_cost(getattr(config, "stages", None))
+    stages = getattr(config, "stages", None)
+    total = milling_cost(stages)
     total += alignment_cost(getattr(config, "alignment", None))
+    # Switching into the milling current and back out again. Charged once for the task
+    # rather than per stage: the log shows one set and one restore bracketing the whole
+    # milling run, not a pair per stage.
+    if stages and any(stage.enabled for stage in stages):
+        total += 2 * BEAM_CURRENT_CHANGE_S
     acquisition = getattr(config, "acquisition", None)
     if acquisition is not None and getattr(acquisition, "enabled", False):
         n_beams = sum([acquisition.acquire_sem, acquisition.acquire_fib])

--- a/fibsem/timing.py
+++ b/fibsem/timing.py
@@ -45,10 +45,27 @@ IMAGE_OVERHEAD_S = 2.0
 STAGE_MOVE_ABSOLUTE_S = 8.0
 STAGE_MOVE_RELATIVE_S = 6.5
 
-# Not measured yet, and deliberately not invented here: autofocus, beam/current
-# switching, and the per-task setup either side of the operations above. Tasks that
-# need them should say so rather than have this module guess -- fm/timing.py's
-# DEFAULT_AUTOFOCUS_TIME = 5.0 is an assumption of exactly that kind.
+# Objective insert and retract. Opaque operations -- insert()/retract() are single API
+# calls into the vendor connection, with no distance or speed to reason from -- but they
+# bracket themselves in the log ("Inserting objective..." / "Objective inserted."), so
+# they are timeable after all.
+# Insert:  n=4, 18.32 / 18.32 / 18.35 / 18.38 s -- the same figure from the UI worker
+#          and from inside the fluorescence task, spread under 60 ms.
+# Retract: n=2, 19.53 / 19.57 s.
+# Retraction is consistently the slower of the two, so they are separate constants
+# rather than one shared value.
+OBJECTIVE_INSERT_S = 18.5
+OBJECTIVE_RETRACT_S = 19.6
+
+# Driving the objective to a focus position, after insertion. n=3, 4.06 / 4.17 / 4.17 s.
+# Distance-independent as far as this sample shows, so a flat cost rather than a rate.
+OBJECTIVE_FOCUS_MOVE_S = 4.3
+
+# Still not counted, and deliberately not invented here: beam/current switching, and
+# the per-task setup either side of the operations above. Tasks that need them should
+# say so rather than have this module guess. Autofocus is no longer on this list --
+# fm/timing.estimate_autofocus_time counts the sweep's steps instead of assuming a
+# duration, which is what DEFAULT_AUTOFOCUS_TIME = 5.0 was doing.
 
 
 def image_cost(settings: Optional[ImageSettings], count: int = 1) -> float:

--- a/fibsem/timing.py
+++ b/fibsem/timing.py
@@ -74,6 +74,16 @@ ALIGNMENT_IMAGE_S = 0.85
 # Autocontrast, once per alignment pass. n=3: 0.9 / 1.3 / 1.7 s.
 ALIGNMENT_AUTOCONTRAST_S = 1.7
 
+# Aligning to a stored reference image (`_align_reference_image`): one autocontrast plus
+# a short burst of reduced-area frames. n=2, 4.5 / 4.6 s end to end. Charged whole rather
+# than composed, because the number of frames is not configurable the way a milling
+# alignment's `steps` is.
+REFERENCE_ALIGNMENT_S = 4.8
+
+# Per spot-burn point, on top of the exposure: blank, park the beam, unblank. n=21,
+# median 0.69 / 0.70 s across two runs -- small, but it is paid once per coordinate.
+SPOT_BURN_POINT_OVERHEAD_S = 0.75
+
 # Still not counted, and deliberately not invented here: the pattern setup between the
 # milling estimate and the first stroke (0 s on a rectangle, 15 s on a trench in the one
 # run measured -- too variable to pick a number from), and the per-task setup either

--- a/tests/autolamella/test_task_duration_estimates.py
+++ b/tests/autolamella/test_task_duration_estimates.py
@@ -1,0 +1,103 @@
+"""Per-task forward duration estimates (FIB-666).
+
+Each task config reports its own expected wall-clock, so a new task type ships its
+estimate with itself instead of being added to a central table that falls behind.
+These tests pin what each override adds, not the constants underneath.
+"""
+
+import pytest
+
+from fibsem import timing
+from fibsem.applications.autolamella.workflows.tasks.acquire_fluorescence import (
+    AcquireFluorescenceImageConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.fiducial import MillFiducialTaskConfig
+from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
+    SpotBurnFiducialTaskConfig,
+)
+from fibsem.fm.structures import ChannelSettings
+from fibsem.fm.timing import estimate_acquisition_time
+from fibsem.structures import Point
+
+
+# ── the base estimate ────────────────────────────────────────────────────────
+
+def test_base_estimate_exceeds_the_scan_only_figure():
+    """estimated_time counts scan arithmetic and milling; estimated_duration adds the
+    measured per-operation costs the task actually pays."""
+    cfg = MillFiducialTaskConfig()
+    assert cfg.estimated_duration > cfg.estimated_time
+
+
+def test_base_estimate_counts_reference_imaging_at_both_ends():
+    cfg = MillFiducialTaskConfig()
+    cfg.milling = {}
+    assert cfg.estimated_duration == pytest.approx(
+        2 * timing.reference_image_cost(cfg.reference_imaging)
+    )
+
+
+# ── spot burn: one exposure per coordinate ───────────────────────────────────
+
+def test_spot_burn_adds_an_exposure_per_coordinate():
+    cfg = SpotBurnFiducialTaskConfig(exposure_time=10)
+    baseline = cfg.estimated_duration
+
+    cfg.coordinates = [Point(x=0.1, y=0.1), Point(x=0.2, y=0.2), Point(x=0.3, y=0.3)]
+
+    assert cfg.estimated_duration == pytest.approx(baseline + 3 * 10)
+
+
+def test_spot_burn_with_no_points_costs_only_the_base():
+    with_points = SpotBurnFiducialTaskConfig(
+        exposure_time=10, coordinates=[Point(x=0.1, y=0.1)]
+    )
+    without = SpotBurnFiducialTaskConfig(exposure_time=10)
+    assert without.estimated_duration < with_points.estimated_duration
+
+
+def test_spot_burn_scales_with_exposure_time():
+    points = [Point(x=0.1, y=0.1), Point(x=0.2, y=0.2)]
+    short = SpotBurnFiducialTaskConfig(exposure_time=5, coordinates=list(points))
+    long = SpotBurnFiducialTaskConfig(exposure_time=10, coordinates=list(points))
+    assert long.estimated_duration - short.estimated_duration == pytest.approx(2 * 5)
+
+
+# ── fluorescence: delegate to the FM timing model ────────────────────────────
+
+def _channel(exposure: float) -> ChannelSettings:
+    return ChannelSettings(
+        name="DAPI",
+        excitation_wavelength=365,
+        emission_wavelength=450,
+        power=0.5,
+        exposure_time=exposure,
+    )
+
+
+def test_fluorescence_adds_the_channel_acquisition():
+    cfg = AcquireFluorescenceImageConfig()
+    baseline = cfg.estimated_duration
+
+    cfg.channel_settings = [_channel(0.5), _channel(0.2)]
+
+    assert cfg.estimated_duration == pytest.approx(
+        baseline + estimate_acquisition_time(cfg.channel_settings, cfg.zparams)
+    )
+
+
+def test_fluorescence_scales_with_channel_count():
+    one = AcquireFluorescenceImageConfig(channel_settings=[_channel(0.5)])
+    two = AcquireFluorescenceImageConfig(channel_settings=[_channel(0.5), _channel(0.5)])
+    assert two.estimated_duration > one.estimated_duration
+
+
+# ── every task answers ───────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "config_cls",
+    [MillFiducialTaskConfig, SpotBurnFiducialTaskConfig, AcquireFluorescenceImageConfig],
+)
+def test_every_config_reports_a_positive_duration(config_cls):
+    """A task with no override still answers, via the base implementation."""
+    assert config_cls().estimated_duration > 0

--- a/tests/autolamella/test_task_duration_estimates.py
+++ b/tests/autolamella/test_task_duration_estimates.py
@@ -15,8 +15,8 @@ from fibsem.applications.autolamella.workflows.tasks.fiducial import MillFiducia
 from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
     SpotBurnFiducialTaskConfig,
 )
-from fibsem.fm.structures import ChannelSettings
-from fibsem.fm.timing import estimate_acquisition_time
+from fibsem.fm.structures import AutoFocusSettings, ChannelSettings, FocusSweepPass
+from fibsem.fm.timing import estimate_acquisition_time, estimate_autofocus_time
 from fibsem.structures import Point
 
 
@@ -76,13 +76,18 @@ def _channel(exposure: float) -> ChannelSettings:
 
 
 def test_fluorescence_adds_the_channel_acquisition():
+    """Adding channels adds both the acquisition and the autofocus sweep -- with no
+    channel there is nothing to focus on, so the sweep costs nothing."""
     cfg = AcquireFluorescenceImageConfig()
     baseline = cfg.estimated_duration
+    assert estimate_autofocus_time(cfg.autofocus_settings, []) == 0.0
 
     cfg.channel_settings = [_channel(0.5), _channel(0.2)]
 
     assert cfg.estimated_duration == pytest.approx(
-        baseline + estimate_acquisition_time(cfg.channel_settings, cfg.zparams)
+        baseline
+        + estimate_acquisition_time(cfg.channel_settings, cfg.zparams)
+        + estimate_autofocus_time(cfg.autofocus_settings, cfg.channel_settings)
     )
 
 
@@ -90,6 +95,89 @@ def test_fluorescence_scales_with_channel_count():
     one = AcquireFluorescenceImageConfig(channel_settings=[_channel(0.5)])
     two = AcquireFluorescenceImageConfig(channel_settings=[_channel(0.5), _channel(0.5)])
     assert two.estimated_duration > one.estimated_duration
+
+
+def test_fluorescence_counts_the_move_and_the_objective():
+    """_run moves the stage and drives the objective before it acquires anything."""
+    cfg = AcquireFluorescenceImageConfig(channel_settings=[_channel(0.5)])
+    cfg.autofocus_settings = AutoFocusSettings(passes=[FocusSweepPass(enabled=False)])
+    cfg.retract_objective = False
+
+    expected = (
+        2 * timing.reference_image_cost(cfg.reference_imaging)
+        + timing.stage_move_cost(1)
+        + timing.OBJECTIVE_INSERT_S
+        + timing.OBJECTIVE_FOCUS_MOVE_S
+        + estimate_acquisition_time(cfg.channel_settings, cfg.zparams)
+    )
+    assert cfg.estimated_duration == pytest.approx(expected)
+
+
+def test_retracting_the_objective_costs_a_second_move():
+    kept = AcquireFluorescenceImageConfig(retract_objective=False)
+    retracted = AcquireFluorescenceImageConfig(retract_objective=True)
+    assert retracted.estimated_duration - kept.estimated_duration == pytest.approx(
+        timing.OBJECTIVE_RETRACT_S
+    )
+
+
+def test_autofocus_is_counted_only_when_a_pass_is_enabled():
+    channels = [_channel(0.5)]
+    off = AcquireFluorescenceImageConfig(
+        channel_settings=channels,
+        autofocus_settings=AutoFocusSettings(passes=[FocusSweepPass(enabled=False)]),
+    )
+    on = AcquireFluorescenceImageConfig(
+        channel_settings=channels,
+        autofocus_settings=AutoFocusSettings(passes=[FocusSweepPass(enabled=True)]),
+    )
+    assert on.estimated_duration > off.estimated_duration
+
+
+# ── the autofocus sweep is counted, not assumed ──────────────────────────────
+
+def test_autofocus_estimate_scales_with_the_steps_it_will_take():
+    """The sweep is arithmetic: one image per step, and n_steps comes off the pass."""
+    channels = [_channel(0.5)]
+    coarse = AutoFocusSettings(passes=[FocusSweepPass(search_range=50e-6, step_size=5e-6)])
+    fine = AutoFocusSettings(passes=[FocusSweepPass(search_range=50e-6, step_size=1e-6)])
+    assert estimate_autofocus_time(fine, channels) > estimate_autofocus_time(coarse, channels)
+
+
+def test_autofocus_estimate_ignores_disabled_passes():
+    channels = [_channel(0.5)]
+    both = AutoFocusSettings(
+        passes=[FocusSweepPass(enabled=True), FocusSweepPass(enabled=True)]
+    )
+    one = AutoFocusSettings(
+        passes=[FocusSweepPass(enabled=True), FocusSweepPass(enabled=False)]
+    )
+    assert estimate_autofocus_time(one, channels) < estimate_autofocus_time(both, channels)
+
+
+def test_autofocus_estimate_is_zero_when_every_pass_is_off():
+    settings = AutoFocusSettings(passes=[FocusSweepPass(enabled=False)])
+    assert estimate_autofocus_time(settings, [_channel(0.5)]) == 0.0
+
+
+def test_autofocus_estimate_needs_a_channel_to_focus_on():
+    settings = AutoFocusSettings(passes=[FocusSweepPass(enabled=True)])
+    assert estimate_autofocus_time(settings, []) == 0.0
+
+
+def test_autofocus_estimate_uses_the_named_channel():
+    """Resolved the way the acquisition path resolves it, so a slow focus channel is
+    not costed as though it were the fast one listed first."""
+    fast, slow = _channel(0.01), _channel(1.0)
+    slow.name = "slow"
+    settings = AutoFocusSettings(
+        passes=[FocusSweepPass(enabled=True)], channel_name="slow"
+    )
+    named = estimate_autofocus_time(settings, [fast, slow])
+    defaulted = estimate_autofocus_time(
+        AutoFocusSettings(passes=[FocusSweepPass(enabled=True)]), [fast, slow]
+    )
+    assert named > defaulted
 
 
 # ── every task answers ───────────────────────────────────────────────────────

--- a/tests/autolamella/test_task_duration_estimates.py
+++ b/tests/autolamella/test_task_duration_estimates.py
@@ -40,12 +40,27 @@ def test_base_estimate_counts_reference_imaging_at_both_ends():
 # ── spot burn: one exposure per coordinate ───────────────────────────────────
 
 def test_spot_burn_adds_an_exposure_per_coordinate():
+    """Each point costs its exposure plus a blank/park/unblank cycle."""
     cfg = SpotBurnFiducialTaskConfig(exposure_time=10)
     baseline = cfg.estimated_duration
 
     cfg.coordinates = [Point(x=0.1, y=0.1), Point(x=0.2, y=0.2), Point(x=0.3, y=0.3)]
 
-    assert cfg.estimated_duration == pytest.approx(baseline + 3 * 10)
+    assert cfg.estimated_duration == pytest.approx(
+        baseline + 3 * (10 + timing.SPOT_BURN_POINT_OVERHEAD_S)
+    )
+
+
+def test_spot_burn_counts_the_move_alignment_and_current_change():
+    """The burn alone left the estimate at 0.71x of machine time; the rest is here."""
+    cfg = SpotBurnFiducialTaskConfig(exposure_time=10)
+    expected = (
+        2 * timing.reference_image_cost(cfg.reference_imaging)
+        + timing.stage_move_cost(1)
+        + timing.REFERENCE_ALIGNMENT_S
+        + 2 * timing.BEAM_CURRENT_CHANGE_S
+    )
+    assert cfg.estimated_duration == pytest.approx(expected)
 
 
 def test_spot_burn_with_no_points_costs_only_the_base():

--- a/tests/autolamella/test_task_duration_estimates.py
+++ b/tests/autolamella/test_task_duration_estimates.py
@@ -56,6 +56,37 @@ def test_opening_reference_acquisition_is_half_the_closing_one():
     )
 
 
+def test_every_task_is_charged_its_opening_move_by_default():
+    """Nearly every _run starts by moving onto its pose, so the base charges it and the
+    exceptions opt out -- rather than each task having to remember to opt in."""
+    from fibsem.applications.autolamella.workflows.tasks.mill_coincident import (
+        MillCoincidentTaskConfig,
+    )
+    assert MillFiducialTaskConfig().opens_with_stage_move is True
+    assert MillCoincidentTaskConfig().opens_with_stage_move is False
+
+
+def test_a_task_that_does_not_move_is_not_charged_for_it():
+    from fibsem.applications.autolamella.workflows.tasks.mill_coincident import (
+        MillCoincidentTaskConfig,
+    )
+    cfg = MillCoincidentTaskConfig()
+    cfg.milling = {}
+    assert cfg.estimated_duration == pytest.approx(
+        _base_reference(cfg) + timing.REFERENCE_ALIGNMENT_S
+    )
+
+
+def test_reference_alignment_is_opt_in():
+    """A task that claims it when it does not adds 5 s of fiction to every estimate."""
+    from fibsem.applications.autolamella.workflows.tasks.rough import MillRoughTaskConfig
+    from fibsem.applications.autolamella.workflows.tasks.undercut import (
+        MillUndercutTaskConfig,
+    )
+    assert MillRoughTaskConfig().opens_with_reference_alignment is True
+    assert MillUndercutTaskConfig().opens_with_reference_alignment is False
+
+
 def test_fiducial_counts_the_move_and_the_reference_alignment():
     aligned = MillFiducialTaskConfig(align_to_reference=True)
     unaligned = MillFiducialTaskConfig(align_to_reference=False)

--- a/tests/autolamella/test_task_duration_estimates.py
+++ b/tests/autolamella/test_task_duration_estimates.py
@@ -20,6 +20,15 @@ from fibsem.fm.timing import estimate_acquisition_time, estimate_autofocus_time
 from fibsem.structures import Point
 
 
+def _base_reference(cfg) -> float:
+    """What the base charges for reference imaging: one field of view at the start,
+    the full set at the end."""
+    return (
+        timing.reference_image_cost(cfg.reference_imaging, fovs=1)
+        + timing.reference_image_cost(cfg.reference_imaging)
+    )
+
+
 # ── the base estimate ────────────────────────────────────────────────────────
 
 def test_base_estimate_exceeds_the_scan_only_figure():
@@ -30,10 +39,28 @@ def test_base_estimate_exceeds_the_scan_only_figure():
 
 
 def test_base_estimate_counts_reference_imaging_at_both_ends():
+    """Not symmetrically: a task opens at one field of view and closes over all of them."""
     cfg = MillFiducialTaskConfig()
     cfg.milling = {}
+    cfg.align_to_reference = False
     assert cfg.estimated_duration == pytest.approx(
-        2 * timing.reference_image_cost(cfg.reference_imaging)
+        _base_reference(cfg) + timing.stage_move_cost(1)
+    )
+
+
+def test_opening_reference_acquisition_is_half_the_closing_one():
+    """Two frames at the start against four at the end, measured on both milling tasks."""
+    cfg = MillFiducialTaskConfig()
+    assert timing.reference_image_cost(cfg.reference_imaging, fovs=1) == pytest.approx(
+        timing.reference_image_cost(cfg.reference_imaging) / 2
+    )
+
+
+def test_fiducial_counts_the_move_and_the_reference_alignment():
+    aligned = MillFiducialTaskConfig(align_to_reference=True)
+    unaligned = MillFiducialTaskConfig(align_to_reference=False)
+    assert aligned.estimated_duration - unaligned.estimated_duration == pytest.approx(
+        timing.REFERENCE_ALIGNMENT_S
     )
 
 
@@ -55,7 +82,7 @@ def test_spot_burn_counts_the_move_alignment_and_current_change():
     """The burn alone left the estimate at 0.71x of machine time; the rest is here."""
     cfg = SpotBurnFiducialTaskConfig(exposure_time=10)
     expected = (
-        2 * timing.reference_image_cost(cfg.reference_imaging)
+        _base_reference(cfg)
         + timing.stage_move_cost(1)
         + timing.REFERENCE_ALIGNMENT_S
         + 2 * timing.BEAM_CURRENT_CHANGE_S
@@ -119,7 +146,7 @@ def test_fluorescence_counts_the_move_and_the_objective():
     cfg.retract_objective = False
 
     expected = (
-        2 * timing.reference_image_cost(cfg.reference_imaging)
+        _base_reference(cfg)
         + timing.stage_move_cost(1)
         + timing.OBJECTIVE_INSERT_S
         + timing.OBJECTIVE_FOCUS_MOVE_S

--- a/tests/autolamella/test_task_duration_estimates.py
+++ b/tests/autolamella/test_task_duration_estimates.py
@@ -262,3 +262,37 @@ def test_autofocus_estimate_uses_the_named_channel():
 def test_every_config_reports_a_positive_duration(config_cls):
     """A task with no override still answers, via the base implementation."""
     assert config_cls().estimated_duration > 0
+
+
+# ── the opening flags are behaviour, not configuration ───────────────────────
+
+@pytest.mark.parametrize(
+    "config_cls",
+    [MillFiducialTaskConfig, SpotBurnFiducialTaskConfig, AcquireFluorescenceImageConfig],
+)
+def test_opening_flags_are_not_serialised(config_cls):
+    """They describe what a task's _run does, which is a property of the code and not
+    something a protocol should carry or a user should edit. Both to_dict() and the
+    form-driving `parameters` are built from dataclasses.fields(), so a property is
+    invisible to them -- turning either flag into a field would silently write it into
+    every protocol and surface it in the task config editor.
+    """
+    from dataclasses import fields as dataclass_fields
+
+    flags = {"opens_with_stage_move", "opens_with_reference_alignment"}
+    cfg = config_cls()
+    serialised = cfg.to_dict()
+
+    assert flags.isdisjoint(serialised)
+    assert flags.isdisjoint(serialised.get("parameters", {}))
+    assert flags.isdisjoint({f.name for f in dataclass_fields(cfg)})
+    assert flags.isdisjoint(cfg.parameters)
+    assert flags.isdisjoint(cfg.field_metadata)
+
+
+def test_opening_flags_survive_a_round_trip():
+    """Restored by the class, not read back from the dict."""
+    cfg = MillFiducialTaskConfig(align_to_reference=False)
+    restored = MillFiducialTaskConfig.from_dict(cfg.to_dict())
+    assert restored.opens_with_stage_move is cfg.opens_with_stage_move
+    assert restored.opens_with_reference_alignment is cfg.opens_with_reference_alignment

--- a/tests/fm/test_structures.py
+++ b/tests/fm/test_structures.py
@@ -1730,7 +1730,7 @@ def test_estimate_acquisition_time_single_channel():
 
     # Single channel, no z-stack, default overhead (0.5s)
     time_s = estimate_acquisition_time(channel)
-    expected_time = 0.1 + 0.5  # exposure + overhead
+    expected_time = 0.1 + DEFAULT_OVERHEAD_PER_IMAGE  # exposure + overhead
     assert time_s == expected_time
 
     # Note: Custom timing parameters are now constants in the timing module
@@ -1751,11 +1751,11 @@ def test_estimate_acquisition_time_z_stack():
 
     time_s = estimate_acquisition_time(channel, zparams)
 
-    # Expected: 5 images × (0.05s exposure + 0.5s overhead) + 4 z-moves × 0.1s
+    # Expected: 5 images × (0.05s exposure + per-image overhead) + 4 z-moves × 0.1s
     expected_exposure = 5 * 0.05  # 0.25s total exposure
-    expected_overhead = 5 * 0.5  # 2.5s total overhead
+    expected_overhead = 5 * DEFAULT_OVERHEAD_PER_IMAGE
     expected_z_moves = 4 * 0.1  # 0.4s z-movement time
-    expected_total = expected_exposure + expected_overhead + expected_z_moves  # 3.15s
+    expected_total = expected_exposure + expected_overhead + expected_z_moves
 
     assert time_s == expected_total
 
@@ -1782,8 +1782,8 @@ def test_estimate_acquisition_time_multiple_channels():
     # Multiple channels, no z-stack
     time_s = estimate_acquisition_time(channels)
     expected_exposure = 0.1 + 0.05  # 0.15s total exposure
-    expected_overhead = 2 * 0.5  # 1.0s total overhead
-    expected_total = expected_exposure + expected_overhead  # 1.15s
+    expected_overhead = 2 * DEFAULT_OVERHEAD_PER_IMAGE
+    expected_total = expected_exposure + expected_overhead
     assert time_s == expected_total
 
 
@@ -1814,9 +1814,9 @@ def test_estimate_acquisition_time_multiple_channels_z_stack():
     expected_exposure = 3 * (
         0.1 + 0.05
     )  # 3 z-planes × (0.1 + 0.05)s per z-plane = 0.45s
-    expected_overhead = total_images * 0.5  # 6 × 0.5s = 3.0s
+    expected_overhead = total_images * DEFAULT_OVERHEAD_PER_IMAGE
     expected_z_moves = 2 * 2 * 0.1  # 2 channels × 2 z-moves × 0.1s = 0.4s
-    expected_total = expected_exposure + expected_overhead + expected_z_moves  # 3.85s
+    expected_total = expected_exposure + expected_overhead + expected_z_moves
 
     assert time_s == expected_total
 
@@ -1836,11 +1836,11 @@ def test_estimate_acquisition_time_custom_parameters():
     # Test with default timing constants
     time_s = estimate_acquisition_time(channel, zparams)
 
-    # Expected: 3 images × (0.2s exposure + 0.5s overhead) + 2 z-moves × 0.1s
+    # Expected: 3 images × (0.2s exposure + per-image overhead) + 2 z-moves × 0.1s
     expected_exposure = 3 * 0.2  # 0.6s
-    expected_overhead = 3 * 0.5  # 1.5s (using DEFAULT_OVERHEAD_PER_IMAGE)
+    expected_overhead = 3 * DEFAULT_OVERHEAD_PER_IMAGE
     expected_z_moves = 2 * 0.1  # 0.2s (using DEFAULT_Z_MOVE_TIME)
-    expected_total = expected_exposure + expected_overhead + expected_z_moves  # 2.3s
+    expected_total = expected_exposure + expected_overhead + expected_z_moves
 
     assert time_s == expected_total
 
@@ -1858,7 +1858,7 @@ def test_estimate_acquisition_time_edge_cases():
     # Single z-plane (no z-movement)
     zparams_single = ZParameters(zmin=0, zmax=0, zstep=1e-6)
     time_single = estimate_acquisition_time(channel, zparams_single)
-    expected_single = 0.01 + 0.5  # exposure + overhead, no z-moves
+    expected_single = 0.01 + DEFAULT_OVERHEAD_PER_IMAGE  # exposure + overhead, no z-moves
     assert time_single == expected_single
 
     # Note: Timing constants are now fixed in the timing module

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -100,9 +100,26 @@ def test_no_move_costs_nothing():
 
 # ── alignment_cost ───────────────────────────────────────────────────────────
 
-def test_alignment_costs_one_image_per_step():
+def test_alignment_costs_two_passes_of_steps_plus_one_frames():
+    """A stage configured for 3 steps acquired 4 frames per pass, and ran two passes --
+    once at the imaging current, once after switching to the milling current."""
     alignment = MillingAlignment(enabled=True, steps=3, imaging=_imaging())
-    assert timing.alignment_cost(alignment) == pytest.approx(timing.image_cost(alignment.imaging, 3))
+    per_pass = timing.ALIGNMENT_AUTOCONTRAST_S + 4 * timing.ALIGNMENT_IMAGE_S
+    assert timing.alignment_cost(alignment) == pytest.approx(2 * per_pass)
+
+
+def test_alignment_pass_count_is_adjustable():
+    alignment = MillingAlignment(enabled=True, steps=3, imaging=_imaging())
+    assert timing.alignment_cost(alignment, passes=1) == pytest.approx(
+        timing.alignment_cost(alignment, passes=2) / 2
+    )
+    assert timing.alignment_cost(alignment, passes=0) == 0.0
+
+
+def test_alignment_frames_are_cheaper_than_full_frames():
+    """They are reduced-area: ~0.8 s against ~3.5 s for the frame the alignment's own
+    ImageSettings describes, so costing them through image_cost overstates them."""
+    assert timing.ALIGNMENT_IMAGE_S < timing.image_cost(_imaging(), 1)
 
 
 def test_disabled_alignment_costs_nothing():
@@ -140,8 +157,9 @@ def test_milling_task_cost_includes_alignment_and_acquisition():
 
     expected = (
         stage.estimated_time
-        + timing.image_cost(cfg.alignment.imaging, 2)
+        + timing.alignment_cost(cfg.alignment)
         + timing.image_cost(acq.imaging, 1)
+        + 2 * timing.BEAM_CURRENT_CHANGE_S
     )
     assert timing.milling_task_cost(cfg) == pytest.approx(expected)
 
@@ -154,8 +172,35 @@ def test_milling_task_cost_counts_the_final_refresh_image():
     cfg = FibsemMillingTaskConfig(stages=[_stage()], acquisition=acq)
     cfg.alignment = MillingAlignment(enabled=False)
     assert timing.milling_task_cost(cfg) == pytest.approx(
-        cfg.stages[0].estimated_time + timing.image_cost(acq.imaging, 1)
+        cfg.stages[0].estimated_time
+        + timing.image_cost(acq.imaging, 1)
+        + 2 * timing.BEAM_CURRENT_CHANGE_S
     )
+
+
+def test_milling_task_cost_charges_the_current_change_both_ways():
+    """Into the milling current and back out again -- ~40 s that milling's own
+    estimate never sees."""
+    cfg = FibsemMillingTaskConfig(stages=[_stage()])
+    cfg.alignment = MillingAlignment(enabled=False)
+    cfg.acquisition = MillingTaskAcquisitionSettings(
+        acquire_sem=False, acquire_fib=False, acquire_final_image=False
+    )
+    assert timing.milling_task_cost(cfg) == pytest.approx(
+        cfg.stages[0].estimated_time + 2 * timing.BEAM_CURRENT_CHANGE_S
+    )
+
+
+def test_a_task_that_mills_nothing_pays_no_current_change():
+    """Every stage disabled: the current is never switched, so it is not charged."""
+    stage = _stage()
+    stage.enabled = False
+    cfg = FibsemMillingTaskConfig(stages=[stage])
+    cfg.alignment = MillingAlignment(enabled=False)
+    cfg.acquisition = MillingTaskAcquisitionSettings(
+        acquire_sem=False, acquire_fib=False, acquire_final_image=False
+    )
+    assert timing.milling_task_cost(cfg) == 0.0
 
 
 def test_milling_task_cost_of_nothing_is_zero():

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,162 @@
+"""Cost primitives behind the forward duration estimates (FIB-666).
+
+The constants themselves are measurements and will move as more instruments are
+sampled; these tests pin the *shape* of each primitive — what it counts, what it
+refuses to count — rather than the numbers, so a re-measurement does not have to
+rewrite the suite.
+"""
+
+import pytest
+
+from fibsem import timing
+from fibsem.milling.base import FibsemMillingStage
+from fibsem.milling.patterning.patterns2 import RectanglePattern
+from fibsem.milling.tasks import FibsemMillingTaskConfig, MillingTaskAcquisitionSettings
+from fibsem.structures import (
+    FibsemMillingSettings,
+    ImageSettings,
+    MillingAlignment,
+    ReferenceImageParameters,
+)
+
+
+def _imaging() -> ImageSettings:
+    return ImageSettings(resolution=(1536, 1024), dwell_time=1e-6)
+
+
+def _stage(current: float = 2e-9, **pattern) -> FibsemMillingStage:
+    pattern = pattern or dict(width=10e-6, height=5e-6, depth=1e-6)
+    return FibsemMillingStage(
+        milling=FibsemMillingSettings(milling_current=current),
+        pattern=RectanglePattern(**pattern),
+    )
+
+
+# ── image_cost ───────────────────────────────────────────────────────────────
+
+def test_image_cost_adds_the_fixed_overhead_to_the_scan():
+    img = _imaging()
+    assert timing.image_cost(img) == pytest.approx(img.estimated_time + timing.IMAGE_OVERHEAD_S)
+
+
+def test_image_cost_scales_with_count():
+    img = _imaging()
+    assert timing.image_cost(img, 4) == pytest.approx(4 * timing.image_cost(img, 1))
+
+
+def test_image_cost_of_nothing_is_zero():
+    assert timing.image_cost(None) == 0.0
+    assert timing.image_cost(_imaging(), 0) == 0.0
+    assert timing.image_cost(_imaging(), -1) == 0.0
+
+
+def test_image_overhead_dominates_at_typical_settings():
+    """The reason estimates built from scan time alone came out 30-40x short: at
+    1536x1024 and 1 us the fixed cost is larger than the scan it wraps."""
+    img = _imaging()
+    assert timing.IMAGE_OVERHEAD_S > img.estimated_time
+
+
+# ── reference_image_cost ─────────────────────────────────────────────────────
+
+def test_reference_image_cost_counts_every_fov_and_beam():
+    params = ReferenceImageParameters(
+        imaging=_imaging(),
+        acquire_image1=True, acquire_image2=True,
+        acquire_sem=True, acquire_fib=True,
+    )
+    assert timing.reference_image_cost(params) == pytest.approx(timing.image_cost(params.imaging, 4))
+
+
+def test_reference_image_cost_drops_deselected_beams():
+    both = ReferenceImageParameters(imaging=_imaging(), acquire_sem=True, acquire_fib=True)
+    one = ReferenceImageParameters(imaging=_imaging(), acquire_sem=True, acquire_fib=False)
+    assert timing.reference_image_cost(one) == pytest.approx(timing.reference_image_cost(both) / 2)
+
+
+def test_reference_image_cost_exceeds_the_scan_only_estimate():
+    """The gap is the whole point: estimated_time counts scan time and nothing else."""
+    params = ReferenceImageParameters(imaging=_imaging())
+    assert timing.reference_image_cost(params) > params.estimated_time
+
+
+def test_reference_image_cost_of_nothing_is_zero():
+    assert timing.reference_image_cost(None) == 0.0
+
+
+# ── stage_move_cost ──────────────────────────────────────────────────────────
+
+def test_stage_move_cost_scales_with_count():
+    assert timing.stage_move_cost(3) == pytest.approx(3 * timing.STAGE_MOVE_ABSOLUTE_S)
+
+
+def test_relative_moves_are_cheaper_than_absolute():
+    assert timing.stage_move_cost(1, absolute=False) < timing.stage_move_cost(1, absolute=True)
+
+
+def test_no_move_costs_nothing():
+    assert timing.stage_move_cost(0) == 0.0
+
+
+# ── alignment_cost ───────────────────────────────────────────────────────────
+
+def test_alignment_costs_one_image_per_step():
+    alignment = MillingAlignment(enabled=True, steps=3, imaging=_imaging())
+    assert timing.alignment_cost(alignment) == pytest.approx(timing.image_cost(alignment.imaging, 3))
+
+
+def test_disabled_alignment_costs_nothing():
+    assert timing.alignment_cost(MillingAlignment(enabled=False, steps=3, imaging=_imaging())) == 0.0
+    assert timing.alignment_cost(None) == 0.0
+
+
+# ── milling_cost ─────────────────────────────────────────────────────────────
+
+def test_milling_cost_sums_the_stages():
+    a, b = _stage(), _stage(current=7.6e-9)
+    assert timing.milling_cost([a, b]) == pytest.approx(a.estimated_time + b.estimated_time)
+
+
+def test_milling_cost_ignores_disabled_stages():
+    """A stage switched off is not milled, so it is not quoted -- the same rule the
+    task config's own estimate had to be corrected to follow (FIB-687)."""
+    enabled, disabled = _stage(), _stage(current=7.6e-9)
+    disabled.enabled = False
+    assert timing.milling_cost([enabled, disabled]) == pytest.approx(enabled.estimated_time)
+
+
+def test_milling_cost_of_nothing_is_zero():
+    assert timing.milling_cost(None) == 0.0
+    assert timing.milling_cost([]) == 0.0
+
+
+# ── milling_task_cost ────────────────────────────────────────────────────────
+
+def test_milling_task_cost_includes_alignment_and_acquisition():
+    stage = _stage()
+    acq = MillingTaskAcquisitionSettings(acquire_sem=True, acquire_fib=False, imaging=_imaging())
+    cfg = FibsemMillingTaskConfig(stages=[stage], acquisition=acq)
+    cfg.alignment = MillingAlignment(enabled=True, steps=2, imaging=_imaging())
+
+    expected = (
+        stage.estimated_time
+        + timing.image_cost(cfg.alignment.imaging, 2)
+        + timing.image_cost(acq.imaging, 1)
+    )
+    assert timing.milling_task_cost(cfg) == pytest.approx(expected)
+
+
+def test_milling_task_cost_counts_the_final_refresh_image():
+    """A task that acquires nothing of its own still ends with one FIB image."""
+    acq = MillingTaskAcquisitionSettings(
+        acquire_sem=False, acquire_fib=False, acquire_final_image=True, imaging=_imaging()
+    )
+    cfg = FibsemMillingTaskConfig(stages=[_stage()], acquisition=acq)
+    cfg.alignment = MillingAlignment(enabled=False)
+    assert timing.milling_task_cost(cfg) == pytest.approx(
+        cfg.stages[0].estimated_time + timing.image_cost(acq.imaging, 1)
+    )
+
+
+def test_milling_task_cost_of_nothing_is_zero():
+    assert timing.milling_task_cost(None) == 0.0


### PR DESCRIPTION
Groundwork for the estimated-completion-time work. Nothing consumes it yet — the pre-run dialog and timeline are a separate change.

## What this adds

`fibsem/timing.py` — the single home for the measured constants behind every duration the app quotes, plus the primitives that compose them: `image_cost`, `reference_image_cost`, `stage_move_cost`, `alignment_cost`, `milling_cost`, `milling_task_cost`.

Constants are the **p90** of their measurement rather than the median, so an estimate that is wrong is long rather than short. An estimate that runs long is a mild annoyance; one that runs short means an unattended run is not finished when the user comes back for it.

Each task config reports its own `estimated_duration`, so a new task type ships its estimate with itself rather than being added to a central table that falls behind. The estimate is a property on the **config**, not the task: the callers that need it — a pre-run dialog, the queue — hold configs and have no microscope to construct a task with.

Two overrides so far. Spot burn adds one exposure per coordinate. Fluorescence follows what `_run` actually does, in order: stage move, objective insert and focus, autofocus, acquire, retract.

## Does it work

Measured against `AutoLamella-2026-07-29-18-00-DEV-TEST` (Thermo), estimate as a ratio of actual wall-clock:

| task | wall-clock | machine time | estimate | before | after |
| -- | -- | -- | -- | -- | -- |
| Setup Lamella Position | 28.9 s | 28.9 s | 29.4 s | 0.22× | **1.02×** |
| Acquire Fluorescence | 218.6 s | 207.6 s | 209.3 s | 0.03× | **1.01×** |
| Spot Burn Fiducial | 219.1 s | 180.9 s | 188.1 s | 0.03× | **1.04×** |
| Mill Fiducial | 109.9 s | 109.9 s | 99.2 s | 0.24× | **0.90×** |
| Rough Milling | 207.4 s | 207.4 s | 325.5 s | 4.08× | **1.57×** |

**Machine time, not wall-clock, is the right comparison.** `AutoLamellaTaskState.duration` is end − start, so it includes any time the task spent waiting on an `ask_user` prompt — 77 s of the 264 s spot burn, 11 s of the fluorescence task. Supervised waits are excluded from these estimates by design, so measuring against the raw duration makes every prompting task look slower than the machine is. Anyone calibrating against `task_history` later needs to subtract those first.

Four of the five now sit within 4% of machine time, and every task quotes long except Mill Fiducial, which is within 10%. Quoting long is the direction this work deliberately errs in: a run that finishes early is a mild annoyance, one that overruns leaves an unattended session still going when someone comes back for it.

## What was measured

Everything here comes from pairing log entries in one real run. Each constant carries its sample count and spread in a comment beside it. One instrument, small n: starting values to be re-measured, not settled.

| operation | measured | n |
| -- | -- | -- |
| image acquisition, above scan time | 1.52 / 1.93 / 1.98 s (med / p90 / max) | 78 |
| stage move, absolute | 7.41 / 7.76 / 8.40 s | 19 |
| stage move, relative | 3.37 / 6.16 / 7.60 s | 31 |
| objective insert | 18.32 / 18.32 / 18.35 / 18.38 s | 4 |
| objective retract | 19.53 / 19.57 s | 2 |
| objective focus move | 4.06 / 4.17 / 4.17 s | 3 |
| beam current change | 20.1 / 20.1 / 20.2 / 20.2 s | 4 |
| alignment frame (reduced area) | 0.77–0.82 s | 16 |
| align to stored reference, whole | 4.5 / 4.6 s | 2 |
| spot burn point, above exposure | 0.69 / 0.70 s | 21 |
| FM per image, above exposure | 1.57 s (sweep) / 2.31 s (z-stack) | 74 |

Three of these were previously assumptions and all three were wrong in the same direction:

- `fm/timing.DEFAULT_OVERHEAD_PER_IMAGE` was 0.5 s, measured 2.3 s. This is what left the fluorescence estimate at a third of the real figure. The two measurements differ because the z-stack writes each frame to OME-TIFF and the autofocus sweep does not — one name over two costs — and the constant takes the higher. The tests that pinned 0.5 now express their expectations through the constant, so the next re-measurement does not rewrite them.
- **The beam current change was not counted at all.** 20 s each way, twice per milling task, ~41 s that milling's own estimate never sees.
- **The spot burn counted only its exposures**, which is what left it at 0.61×. The rest of that task is the move onto the milling pose, the alignment against the stored reference, and the beam current switching into the burn current and back — ~53 s that closes the gap almost exactly. The blank/park/unblank cycle per point is real but minor at 0.69 s.
- **Tasks open with a stage move and a reference alignment**, and the base saw neither — 12 s of the 110 s Mill Fiducial task. The base now charges both, with two properties (`opens_with_stage_move`, default true; `opens_with_reference_alignment`, default false) so the exceptions declare themselves rather than every task remembering to opt in. Grepping for the calls rather than assuming: rough, polishing and coincident mill all align and were under-quoted for it; coincident is the one task that does not move, since it mills where the coincidence step left the stage. Alignment stays opt-in because a task that claims it when it does not adds five seconds of fiction to every estimate including it. The move is charged even when the stage is already in place — 0.02 s rather than 7.6 s for a task following another on the same lamella — because which case applies is runtime state.
- **Reference imaging is not symmetric.** A task opens with `_acquire_reference_image` at one field of view and closes with `_acquire_set_of_reference_images` over all of them — two frames against four, measured on both milling tasks. Charging the full set twice over-counted every task. Fixing it exposed a missing stage move on Select Milling Position, whose 0.99× had been one error cancelling the other.
- **Alignment runs two passes, not one** — once at the imaging current, then again after switching (`FIB Aligning at Milling Current`) — and each pass is `steps + 1` frames, matching the log's 4 frames for a 3-step stage. The frames are reduced-area, ~0.8 s against ~3.5 s for the full frame their `ImageSettings` describes, so they are charged directly rather than through `image_cost`.

An autofocus pass likewise takes `n_steps + 1` images, since `run_autofocus` builds its sweep with `np.linspace(..., n_steps + 1)`. The log printing "21 positions" for a 20-step pass is how that was caught.

## The one remaining outlier

Rough Milling is the only task still badly off. It over-quotes, which is the safe direction, and the cause is isolated to a single term: `FibsemMillingStage.estimated_time` reads **236.5 s for a stage that milled for 104.4 s**. Everything else in that task models well.

That local formula is not the microscope's own estimate, and the two behave very differently:

| stage | local formula | `microscope.estimate_milling_time()` | actual |
| -- | -- | -- | -- |
| Fiducial 01 | 26.7 s | 27.3 s | 29.1 s |
| Fiducial 01 (2nd lamella) | — | 27.4 s | 29.1 s |
| Rough Mill 01 | 236.5 s | 102.4 s | 104.4 s |

**The API estimate is accurate — 1.02× to 1.07×.** The local formula matches it on a plain rectangle and runs 2.27× long on a trench.

That does **not** make the API figure an option here. Obtaining it costs the very setup being estimated and moves the hardware: the log shows it arrives only after the beam current has been switched (20 s) and the pattern drawn, so a pre-flight dialog cannot ask for it without doing the thing it is trying to predict. It appears in the table as ground truth for how well the local formula *could* do, not as an alternative to it. (It stays useful mid-run, where the milling has already been set up — that is what the milling progress bar reads today.)

So the trench over-estimate has to be fixed in the local formula, and no correction factor is applied here: the two samples differ in pattern type, cross-section *and* milling current at once, so nothing can be isolated from them. Calibrating a factor would need several trench stages across known currents — and inventing one from a single measurement is how the constants this PR replaces got their values.

## What it deliberately does not count

The pattern setup between the milling estimate and the first stroke — 0 s on a rectangle and 15 s on a trench in the one run measured, too variable to pick a number from — and the per-task setup either side of the modelled operations.

Supervised prompts are excluded on purpose. The measured fluorescence task spent 11 s waiting on an `ask_user` inside autofocus; a run waiting for a human is not late.

Insertion is always counted, because whether the objective already happens to be inserted is runtime state the config cannot see. That errs long, deliberately.

One caveat on the task-level ratios: `lamella.task_config` is the *current* config, not necessarily the one that ran — in this experiment the stored coarse autofocus pass is disabled while the run performed it. The per-operation figures in the table above are counted directly from the log and are unaffected; the task-level ratios are softer evidence than they look.

## Tests

48 — `tests/test_timing.py` for the primitives, `tests/autolamella/test_task_duration_estimates.py` for the per-task overrides and the autofocus sweep. They pin the *shape* of each primitive (what it counts, what it refuses to count) rather than the numbers, so a re-measurement does not have to rewrite the suite. 698 pass across `tests/milling`, `tests/autolamella`, `tests/fm/test_structures.py` and the import-cycle check; py3.8 syntax checked.



