### PR TITLE
[perf] Write the experiment once when a defect is toggled, not twice (FIB-682)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -315,7 +315,12 @@ class AutoLamellaUI(QMainWindow):
         self.lamella_list.remove_requested.connect(self._on_lamella_remove_requested)
         self.lamella_list.move_to_requested.connect(self._on_lamella_move_to_requested)
         self.lamella_list.update_requested.connect(self._on_lamella_update_requested)
-        self.lamella_list.defect_changed.connect(self._on_lamella_defect_changed)
+        # `defect_changed` is deliberately not wired here. The window this widget sits
+        # in connects the same signal to its own handler, which saves *and* redraws the
+        # rows, the cards and the name list -- so a second handler here only bought a
+        # second full `experiment.save()` for one toggled icon, which is 0.8 s of frozen
+        # GUI at 100 lamella (FIB-682). Every other host of this list keeps its own
+        # handler, because nothing else is listening for them (FIB-564).
         self.lamella_list.lamella_selected.connect(self.update_lamella_ui)
 
         # system widget
@@ -1317,13 +1322,6 @@ class AutoLamellaUI(QMainWindow):
         """Handle update-position request from the list row's actions menu."""
         self.lamella_list.select(lamella.name)
         self.update_lamella_position_ui()
-
-    def _on_lamella_defect_changed(self, lamella):
-        """Persist defect state change to disk."""
-        if self.experiment is None:
-            return
-        self.experiment.save()
-        self.update_ui()
 
     def _on_lamella_remove_requested(self, lamella):
         """Handle removal of a lamella via the list row's remove button.

--- a/tests/ui/test_defect_saves_once.py
+++ b/tests/ui/test_defect_saves_once.py
@@ -1,0 +1,149 @@
+"""Toggling a defect on the Experiment tab writes the experiment once, not twice.
+
+`AutoLamellaUI.lamella_list.defect_changed` had two handlers and both called
+`experiment.save()` -- one on the widget, one on the window that embeds it. Marking a
+lamella defective therefore serialised the whole experiment twice, back to back: 1.7 s
+of frozen GUI at 100 lamella against 0.84 s for the one write that was needed
+(FIB-682). The window's handler is the one kept, because it also redraws the rows, the
+cards and the name list; the widget's did nothing the window did not.
+
+Both halves are pinned here, and the second is the one with history. FIB-564 was the
+opposite failure -- a defect set from a list whose host never wired persistence, so it
+lived in memory and was gone on reload. Deleting a save is exactly the shape of change
+that reintroduces it, so "somebody still saves" is asserted as hard as "only once".
+
+Split across two mechanisms because the two halves live in different places:
+
+* the widget can be built (`AutoLamellaUI(parent_ui=None)` constructs offscreen), so
+  what it does on the signal is checked by driving it;
+* the window cannot -- `AutoLamellaSingleWindowUI` builds a vispy quad view and a
+  napari viewer, neither of which survives `QT_QPA_PLATFORM=offscreen` -- so its half is
+  read off the source, the same way `test_lamella_defect_sync.py` handles the minimap
+  and the coincidence viewer.
+"""
+import ast
+import inspect
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.applications.autolamella.structures import DefectState, DefectType, Lamella
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+@pytest.fixture
+def lamella(tmp_path):
+    return Lamella(petname="01-test", path=str(tmp_path / "01-test"), number=1)
+
+
+class TestTheWidgetNoLongerSavesItself:
+    def test_a_defect_toggle_does_not_save_from_the_widget(
+        self, lamella, tmp_path, monkeypatch
+    ):
+        """Driven, not read: the connection is what changed, so emit and count.
+
+        `parent_ui=None` leaves the window's handler unconnected, which is precisely
+        the seam wanted -- whatever this widget does on its own is all that is counted.
+
+        The widget is given a real experiment, and that is load-bearing rather than
+        set dressing. Every handler on this path opens with `if self.experiment is
+        None: return`, so against a widget that has none the old duplicate save
+        returns early and this passes with the bug fully reinstated -- verified by
+        putting it back. Without an experiment the test asserts nothing at all.
+        """
+        from fibsem.applications.autolamella.structures import Experiment
+        from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+
+        experiment = Experiment(path=str(tmp_path), name="defect-save-count")
+        experiment.positions.append(lamella)
+
+        saves = []
+        monkeypatch.setattr(Experiment, "save", lambda self, **kw: saves.append(1))
+
+        widget = AutoLamellaUI(parent_ui=None)
+        try:
+            widget.experiment = experiment
+            lamella.defect = DefectState(state=DefectType.FAILURE)
+            widget.lamella_list.defect_changed.emit(lamella)
+        finally:
+            widget.close()
+
+        assert saves == [], (
+            f"the widget saved {len(saves)} time(s) on defect_changed -- the window's "
+            "handler already does, so this is the duplicate write (FIB-682)"
+        )
+
+    def test_the_handler_is_gone_rather_than_merely_disconnected(self):
+        """A method left behind reads as a live path to anyone grepping for one."""
+        from fibsem.applications.autolamella.ui import AutoLamellaUI as module
+
+        assert not hasattr(module.AutoLamellaUI, "_on_lamella_defect_changed")
+
+
+class TestTheWindowStillSaves:
+    """The FIB-564 half. Removing a save must not remove *the* save."""
+
+    def test_the_window_wires_defect_changed_to_a_handler_that_saves(self):
+        from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+            AutoLamellaSingleWindowUI,
+        )
+
+        window = inspect.getsource(AutoLamellaSingleWindowUI)
+        handler = inspect.getsource(
+            AutoLamellaSingleWindowUI._on_lamella_defect_changed
+        )
+
+        assert "lamella_list.defect_changed.connect(" in window, (
+            "the window no longer wires defect_changed -- a defect set on the "
+            "Experiment tab is not persisted at all (FIB-564)"
+        )
+        assert "experiment.save()" in handler, (
+            "the window's defect handler no longer saves -- nothing else does now"
+        )
+
+    def test_exactly_one_handler_is_wired_to_that_signal(self):
+        """The property FIB-682 is about, across both files at once.
+
+        Counted by parsing rather than by substring: the widget and the window both
+        contain other `defect_changed.connect(...)` calls for their other lists (the
+        card container, the workflow widget), and a text search cannot tell those from
+        the one under test. The chain `autolamella_ui.lamella_list.defect_changed`
+        names it exactly.
+        """
+        from pathlib import Path
+
+        from fibsem.applications.autolamella.ui import AutoLamellaMainUI, AutoLamellaUI
+
+        wired = []
+        for module, prefix in (
+            (AutoLamellaUI, ["self", "lamella_list", "defect_changed"]),
+            (AutoLamellaMainUI, ["self", "autolamella_ui", "lamella_list", "defect_changed"]),
+        ):
+            tree = ast.parse(Path(module.__file__).read_text())
+            for node in ast.walk(tree):
+                if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                    continue
+                if node.func.attr != "connect":
+                    continue
+                parts, cur = [], node.func.value
+                while isinstance(cur, ast.Attribute):
+                    parts.append(cur.attr)
+                    cur = cur.value
+                if isinstance(cur, ast.Name):
+                    parts.append(cur.id)
+                if list(reversed(parts)) == prefix:
+                    wired.append(module.__name__)
+
+        assert wired == ["fibsem.applications.autolamella.ui.AutoLamellaMainUI"], (
+            f"the Experiment-tab list's defect_changed is wired in {wired}; it must be "
+            "wired exactly once, in the window (FIB-682/FIB-564)"
+        )


### PR DESCRIPTION
Closes FIB-682. Second of the [Performance](https://linear.app/fibsemos/project/performance-40569e970fea) project's issues, after #428.

## The problem

`AutoLamellaUI.lamella_list.defect_changed` was connected to **two** handlers, and each called `experiment.save()`:

- `AutoLamellaUI.py:318` → `AutoLamellaUI._on_lamella_defect_changed` — save, then `update_ui()`
- `AutoLamellaMainUI.py:1336` → `AutoLamellaSingleWindowUI._on_lamella_defect_changed` — save, then refresh the rows, the cards and the name list

Marking a lamella defective on the Experiment tab therefore serialised the whole experiment twice, back to back. `Experiment.save()` is one `yaml.safe_dump` of everything on the GUI thread — **0.84 s at 100 lamella**, so the toggle cost 1.7 s.

## The change

Drop the widget's handler and its connection. The window's does everything needed; the widget's added only an `update_ui()` that no display of the defect depends on — they all redraw off `lamella.events.defect`.

**Only this signal was doubled.** I traced every `defect_changed` emitter and connection: the card container, the workflow widget, the minimap and the coincidence viewer each own a list whose signal reaches exactly one handler. Those keep theirs — nothing else is listening for them, which is what FIB-564 was about.

## Review notes

Deleting a save is precisely the shape of change that reintroduces FIB-564 (a defect set from a list whose host never wired persistence lived in memory and was gone on reload). The test pins both halves: the widget no longer saves, **and** the window still does.

Split across two mechanisms because the halves live in different places:

- the widget is **driven** — `AutoLamellaUI(parent_ui=None)` constructs offscreen, so emit the signal and count saves;
- the window is **read off the source** — `AutoLamellaSingleWindowUI` builds a vispy quad view and a napari viewer, neither of which survives `QT_QPA_PLATFORM=offscreen`. Same approach `test_lamella_defect_sync.py` already takes for the minimap and the coincidence viewer.

Plus an AST check that the chain `autolamella_ui.lamella_list.defect_changed` is wired exactly once across both files — parsed rather than grepped, because both files contain other `defect_changed.connect(...)` calls for their other lists that a text search cannot tell apart.

One detail worth flagging for review: **the driven test gives the widget a real `Experiment`, and that is load-bearing, not set dressing.** Every handler on this path opens with `if self.experiment is None: return`, so against a widget without one the duplicate save returns early and the test passes with the bug fully reinstated. I verified that by putting the bug back — it caught 2 of 4 assertions before the experiment was added, 3 of 4 after.

## Verification

4 new tests in `tests/ui/test_defect_saves_once.py`; 15 pass with the existing `test_lamella_defect_sync.py`. Full `tests/autolamella/` + `tests/ui/`: 1857 passed.

Mutation-tested: reinstating the duplicate handler, removing the window's connection, and stopping the window's handler saving each fail the expected assertions.

Pre-existing on `main`, unrelated and confirmed by A/B: 1 failure + 5 errors in `test_overview_widget` / `test_fm_live_indicator`.