### PR TITLE
[perf] Write the experiment once editing settles, not once per field (FIB-683)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1010,6 +1010,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         initial_state = "supervised" if selected_tasks[0].supervise else "automated"
         self._set_border_state(initial_state)
+        # The run writes the experiment from its own thread. Land any edit still
+        # waiting in the editor first, so there is only ever one writer (FIB-683).
+        self.lamella_widget.flush_pending_save()
         ui._start_run_workflow_thread(task_names, lamella_names)
         # Show the Stop button immediately so the run is cancellable even while
         # waiting for a scheduled first task (before any task status arrives).
@@ -2343,6 +2346,13 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def closeEvent(self, event):
         """Clean up viewers on close."""
+        # The editor holds edits for a moment before writing them (FIB-683); this is
+        # the last chance to get the final one onto disk.
+        if getattr(self, "lamella_widget", None) is not None:
+            try:
+                self.lamella_widget.flush_pending_save()
+            except Exception as e:
+                logging.warning(f"Could not flush a pending experiment save on close: {e}")
         # persist the FM working state (channels / camera transform / objective)
         if self.autolamella_ui is not None and self.autolamella_ui.fm_control_widget is not None:
             try:

--- a/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
@@ -8,7 +8,7 @@ import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import numpy as np
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import (
     QComboBox,
     QDialog,
@@ -67,9 +67,16 @@ from fibsem.ui.tokens import (
 )
 
 if TYPE_CHECKING:
+    from fibsem.applications.autolamella.structures import Experiment
     from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
     from fibsem.correlation.structures import CorrelationResult
     from fibsem.imaging.spot import SpotBurnSettings
+
+# How long the editor waits for editing to settle before writing the experiment.
+# Long enough to swallow a run of field edits, short enough that the window a crash
+# could take an edit from stays small -- and every place where waiting longer would
+# actually risk one flushes explicitly instead (see `flush_pending_save`).
+_SAVE_DEBOUNCE_MS = 400
 
 # Reducer overlay ids on the FIB (ION) canvas
 POI_OVERLAY_ID = "poi"
@@ -97,6 +104,15 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         self._active_task_name: Optional[str] = None
         self._selected_lamella: Optional[Lamella] = None
         self._overlay_wired = False  # subscribed to controller.overlay_edited
+
+        # Coalesces a burst of edits into one write -- see `_save_experiment`. Built
+        # before the microscope check below, because edits are not the only thing that
+        # reaches `flush_pending_save`: the window calls it on close, and an editor
+        # that never saw a microscope must still answer that rather than raise.
+        self._pending_save_experiment: Optional["Experiment"] = None
+        self._save_timer = QTimer(self)
+        self._save_timer.setSingleShot(True)
+        self._save_timer.timeout.connect(self.flush_pending_save)
 
         if self.parent_widget.microscope is None:
             return
@@ -135,6 +151,11 @@ class AutoLamellaProtocolEditorWidget(QWidget):
 
     def set_experiment(self):
         """Set the experiment for the protocol editor."""
+        # The parent has already swapped `.experiment` by the time this runs, so this
+        # is the last moment the previous one's pending edit can be written. It is
+        # written to the right file because the pending write carries its own
+        # experiment rather than looking one up -- see `_save_experiment`.
+        self.flush_pending_save()
         self._refresh_experiment_positions()
 
     def set_active_lamella_name(
@@ -409,6 +430,8 @@ class AutoLamellaProtocolEditorWidget(QWidget):
 
     def _on_selected_lamella_changed(self):
         """Callback when the selected lamella changes."""
+        # Whatever is pending belongs to the lamella being left behind.
+        self.flush_pending_save()
         selected_lamella = self._selected_lamella
         if selected_lamella is None:
             return
@@ -624,6 +647,7 @@ class AutoLamellaProtocolEditorWidget(QWidget):
 
     def _on_selected_task_changed(self):
         """Callback when the selected milling stage changes."""
+        self.flush_pending_save()
         selected_stage_name = self.listWidget_selected_task.selected_task
         if not selected_stage_name:
             return
@@ -1157,6 +1181,49 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         self._save_experiment()
 
     def _save_experiment(self):
-        """Save the experiment."""
-        if self.parent_widget is not None and self.parent_widget.experiment is not None:
-            self.parent_widget.experiment.save(save_protocol=True)
+        """Persist the edit, coalescing a burst of them into one write.
+
+        `Experiment.save()` serialises the whole experiment -- 0.84 s at 100 lamella,
+        on the GUI thread -- and every committed field in this editor called it. Editing
+        a task means several fields in a row, and each paid the full price (FIB-683).
+
+        Only *when* the write happens moves; what is written does not. The handlers
+        above have already applied the edit to the lamella, so a flush at any later
+        point writes the complete current state -- there is no snapshot to get stale,
+        and no ordering between edits to preserve.
+
+        `save_protocol=True` is gone with it: a lamella's task config lives in
+        `experiment.yaml`, so that flag rewrote `protocol.yaml` on every parameter
+        change without it having changed. The protocol's own editors still save it
+        explicitly.
+        """
+        experiment = (
+            self.parent_widget.experiment if self.parent_widget is not None else None
+        )
+        if experiment is None:
+            return
+        # Held rather than re-read at flush time, so a write scheduled against one
+        # experiment cannot land on whichever one is loaded when the timer fires. That
+        # is not hypothetical: `set_experiment` runs *after* the parent has swapped
+        # `.experiment`, so a flush that looked it up again would save the new
+        # experiment and drop the old one's last edits on the floor.
+        self._pending_save_experiment = experiment
+        self._save_timer.start(_SAVE_DEBOUNCE_MS)
+
+    def hideEvent(self, event) -> None:
+        """Flush when the panel goes away -- a tab switch, or the window closing."""
+        self.flush_pending_save()
+        super().hideEvent(event)
+
+    def flush_pending_save(self) -> None:
+        """Write a coalesced edit now, if one is waiting. Safe to call at any time.
+
+        Called wherever waiting any longer would risk the edit: the editor moving to
+        another lamella or task, the experiment being swapped, a workflow starting, the
+        panel being hidden, and the window closing. Cheap and idempotent when nothing
+        is pending, so callers do not have to know whether there is.
+        """
+        self._save_timer.stop()
+        experiment, self._pending_save_experiment = self._pending_save_experiment, None
+        if experiment is not None:
+            experiment.save()

--- a/tests/ui/test_editor_save_debounce.py
+++ b/tests/ui/test_editor_save_debounce.py
@@ -1,0 +1,266 @@
+"""Editing a lamella's protocol writes the experiment once editing settles, not per field.
+
+`Experiment.save()` serialises the whole experiment -- 0.84 s at 100 lamella, on the GUI
+thread -- and every committed field in the lamella protocol editor called it. Editing a
+task means several fields in a row, and each one paid the full price (FIB-683).
+
+The write is now debounced. Deliberately *only* the write: the handlers apply the edit to
+the lamella immediately, as they always did, so a flush at any later point serialises the
+complete current state. There is no snapshot to go stale and no ordering between edits to
+preserve -- which is what makes this far cheaper than moving the write off-thread.
+
+What can still go wrong is the write landing late or not at all, so that is what is
+pinned here:
+
+* **A burst coalesces, and still lands.** The point of the change, and it fails silently
+  in both directions -- too eager and nothing is gained, never firing and edits are lost.
+* **A pending write survives the experiment being swapped, and goes to the right file.**
+  The sharp edge. `set_experiment` runs *after* the parent has swapped `.experiment`, so
+  a flush that looked the experiment up again would write the new one and drop the old
+  one's last edit. The pending write carries its own experiment for this reason.
+* **Every flush point is wired.** Leaving the editor's lamella or task, hiding the panel,
+  starting a run, closing the window. Miss one and an edit is lost quietly, which is a
+  worse failure than the lag this fixes.
+* **No handler bypasses the debounce.** Ten call sites route through `_save_experiment`;
+  one calling `experiment.save()` directly would keep its 0.84 s and nobody would notice.
+"""
+import ast
+import inspect
+import os
+from pathlib import Path
+
+os.environ.setdefault("FIBSEM_SIM_NO_DELAY", "1")
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtTest import QTest
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.applications.autolamella.structures import Experiment
+from fibsem.applications.autolamella.ui import (
+    autolamella_lamella_protocol_editor as editor_module,
+)
+from fibsem.applications.autolamella.ui.autolamella_lamella_protocol_editor import (
+    _SAVE_DEBOUNCE_MS,
+    AutoLamellaProtocolEditorWidget,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+# Enough for the timer to have fired and its slot to have run, without making the suite
+# wait on a fixed sleep any longer than it must.
+_PAST_DEBOUNCE_MS = _SAVE_DEBOUNCE_MS + 250
+
+
+@pytest.fixture(scope="module")
+def connected_ui():
+    """A real AutoLamellaUI on a Demo microscope -- the editor needs one to build.
+
+    `parent_ui=None` is only stored, so the widget stands alone; the shipped default
+    configuration is Demo, so `connect_to_microscope` builds a real microscope with no
+    hardware in about 0.15 s. Module-scoped because that cost is per-connect, not
+    per-test, and the editor is rebuilt per test anyway.
+    """
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+
+    ui = AutoLamellaUI(parent_ui=None)
+    ui.system_widget.connect_to_microscope()
+    assert ui.microscope is not None, "Demo connect failed; the editor cannot be built"
+    yield ui
+    ui.close()
+
+
+@pytest.fixture
+def experiment(tmp_path):
+    return Experiment(path=str(tmp_path), name="debounce")
+
+
+@pytest.fixture
+def editor(connected_ui, experiment):
+    connected_ui.experiment = experiment
+    widget = AutoLamellaProtocolEditorWidget(parent=connected_ui)
+    yield widget
+    widget._save_timer.stop()  # never let one fire into a later test
+    widget.close()
+
+
+@pytest.fixture
+def saves(monkeypatch):
+    """Every `Experiment.save`, as the experiment it was called on."""
+    recorded = []
+    monkeypatch.setattr(Experiment, "save", lambda self, **kw: recorded.append(self))
+    return recorded
+
+
+class TestABurstBecomesOneWrite:
+    def test_ten_edits_write_once(self, editor, saves, experiment):
+        for _ in range(10):
+            editor._save_experiment()
+
+        assert saves == [], "the editor wrote before editing had settled"
+        QTest.qWait(_PAST_DEBOUNCE_MS)
+
+        assert saves == [experiment], f"expected one write, got {len(saves)}"
+
+    def test_the_write_does_land(self, editor, saves, experiment):
+        """The other direction: a debounce that never fires loses every edit."""
+        editor._save_experiment()
+        QTest.qWait(_PAST_DEBOUNCE_MS)
+
+        assert saves == [experiment]
+
+    def test_a_later_edit_restarts_the_wait(self, editor, saves):
+        """Coalescing, not batching: the wait is from the *last* edit."""
+        editor._save_experiment()
+        QTest.qWait(_SAVE_DEBOUNCE_MS // 2)
+        editor._save_experiment()
+        QTest.qWait(_SAVE_DEBOUNCE_MS // 2 + 50)
+
+        assert saves == [], "the second edit did not restart the timer"
+        QTest.qWait(_PAST_DEBOUNCE_MS)
+        assert len(saves) == 1
+
+    def test_nothing_pending_writes_nothing(self, editor, saves):
+        """`flush_pending_save` is called from five places and must be a no-op cold."""
+        editor.flush_pending_save()
+        editor.flush_pending_save()
+
+        assert saves == []
+
+
+class TestTheFlushPoints:
+    def test_leaving_the_lamella_flushes(self, editor, saves, experiment):
+        editor._save_experiment()
+        editor._on_selected_lamella_changed()  # returns early with no lamella; still flushes
+
+        assert saves == [experiment], "the pending edit did not land before the switch"
+
+    def test_hiding_the_panel_flushes(self, editor, saves, experiment):
+        """Driven through the event rather than through `hide()`.
+
+        Qt only delivers a hideEvent to a widget that was actually visible, and this
+        editor's parent chain is never shown here -- so `hide()` is a silent no-op and
+        the test would pass with the override deleted. Sending the event is what
+        exercises our half; delivering it on a tab switch is Qt's.
+        """
+        from PyQt5.QtGui import QHideEvent
+
+        editor._save_experiment()
+        editor.hideEvent(QHideEvent())
+
+        assert saves == [experiment]
+
+    def test_swapping_the_experiment_flushes_the_previous_one(
+        self, editor, saves, experiment, tmp_path
+    ):
+        """The sharp edge, and the reason the pending write carries its experiment.
+
+        `set_experiment` runs *after* the parent has swapped `.experiment`, so a flush
+        that re-read it here would save the incoming experiment and silently drop the
+        outgoing one's last edit.
+        """
+        editor._save_experiment()
+        replacement = Experiment(path=str(tmp_path / "next"), name="next")
+        editor.parent_widget.experiment = replacement
+
+        editor.set_experiment()
+
+        assert saves == [experiment], (
+            "the flush wrote the wrong experiment -- the pending edit belonged to "
+            f"{experiment.name}, not {replacement.name}"
+        )
+
+    def test_an_explicit_flush_and_the_timer_do_not_both_write(
+        self, editor, saves, experiment
+    ):
+        """One edit is one write however the flush and the timer interleave.
+
+        Two things stand the second write down and only one of them is load-bearing:
+        `flush_pending_save` stops the timer, *and* it clears the pending experiment,
+        which the timer's own call then finds empty. Deleting the `stop()` alone does
+        not break this -- checked -- so what is pinned here is the behaviour, not the
+        mechanism. It would still catch a refactor that dropped the empty check, which
+        is the one that matters.
+        """
+        editor._save_experiment()
+        editor.flush_pending_save()
+        QTest.qWait(_PAST_DEBOUNCE_MS)
+
+        assert saves == [experiment], f"wrote {len(saves)} times for one edit"
+
+
+class TestTheWindowFlushesToo:
+    """Read off the source: `AutoLamellaSingleWindowUI` builds a vispy quad view and a
+    napari viewer, neither of which survives `QT_QPA_PLATFORM=offscreen`."""
+
+    def test_a_run_flushes_before_it_starts(self):
+        from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+            AutoLamellaSingleWindowUI,
+        )
+
+        source = inspect.getsource(AutoLamellaSingleWindowUI._on_run_workflow_clicked)
+        flush = source.index("lamella_widget.flush_pending_save()")
+        start = source.index("_start_run_workflow_thread")
+
+        assert flush < start, (
+            "the run starts before the editor's pending edit is written -- the worker "
+            "thread and the debounce timer would both be writing the experiment"
+        )
+
+    def test_closing_the_window_flushes(self):
+        from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+            AutoLamellaSingleWindowUI,
+        )
+
+        source = inspect.getsource(AutoLamellaSingleWindowUI.closeEvent)
+
+        assert "lamella_widget.flush_pending_save()" in source, (
+            "closing the window does not flush -- an edit made in the last "
+            f"{_SAVE_DEBOUNCE_MS} ms before quitting is lost"
+        )
+
+
+class TestNothingBypassesIt:
+    def test_no_editor_handler_saves_directly(self):
+        """Ten handlers route through `_save_experiment`; one going around it keeps
+        the full cost, and the only symptom is that the editor still feels slow."""
+        source = Path(editor_module.__file__).read_text()
+        offenders = []
+        for node in ast.walk(ast.parse(source)):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                continue
+            if node.func.attr == "save" and isinstance(node.func.value, ast.Attribute):
+                if node.func.value.attr == "experiment":
+                    offenders.append(node.lineno)
+
+        assert offenders == [], (
+            f"{editor_module.__file__} calls experiment.save() directly at lines "
+            f"{offenders} -- that bypasses the debounce"
+        )
+
+    def test_the_editor_no_longer_rewrites_the_protocol(self):
+        """A lamella's task config lives in `experiment.yaml`. `save_protocol=True`
+        rewrote `protocol.yaml` on every parameter edit without it having changed.
+
+        Parsed rather than grepped: the comment explaining why the flag went away says
+        `save_protocol`, so a substring check finds it in prose and fails on a module
+        that is entirely correct. That is the same trap `test_lamella_defect_sync.py`
+        documents for commented-out connections -- the parser does not read comments.
+        """
+        passes_the_flag = [
+            node.lineno
+            for node in ast.walk(ast.parse(Path(editor_module.__file__).read_text()))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "save"
+            and any(kw.arg == "save_protocol" for kw in node.keywords)
+        ]
+
+        assert passes_the_flag == [], (
+            f"the editor still passes save_protocol at lines {passes_the_flag}"
+        )


### PR DESCRIPTION
Closes FIB-683. Third of the [Performance](https://linear.app/fibsemos/project/performance-40569e970fea) project's issues, after #428 and #434. **Independent of #434** — no overlapping files, so both get real CI and either can merge first.

## The problem

`Experiment.save()` is one `yaml.safe_dump` of the whole experiment on the GUI thread — **0.84 s at 100 lamella** — and all ten committed-edit handlers in the lamella protocol editor called it: task parameters, milling config, reference-image settings, fluorescence settings, spot-burn coordinates, POI moves, alignment-area drags, the description box.

Editing a task means several fields in a row, and each one paid the full price.

## The change

A 400 ms debounce. **Only *when* the write happens moves; what is written does not.** The handlers apply the edit to the lamella immediately, as they always did, so a flush at any later point serialises the complete current state — there is no snapshot to go stale and no ordering between edits to preserve. That is what makes this so much cheaper than moving the write off-thread (FIB-686), which it composes with rather than replaces.

Measured at 100 lamella, editing six fields:

| | GUI-thread block |
| --- | --- |
| before — 6 synchronous saves | **5077 ms** |
| after — the same six edits | **0 ms**, then one 846 ms write once editing settles |

## Review notes — the two things worth your attention

**The pending write carries its own experiment.** `set_experiment` runs *after* the parent has swapped `.experiment`, so a flush that looked it up again would save the incoming experiment and silently drop the outgoing one's last edit. Storing the experiment when the write is scheduled makes flush order irrelevant everywhere else too.

**The flush points are the design.** A lost edit is a far worse failure than the lag this fixes, so waiting any longer flushes explicitly at:

- leaving the selected lamella (`_on_selected_lamella_changed`) or task (`_on_selected_task_changed`)
- the panel being hidden (`hideEvent` — a tab switch)
- the experiment being swapped (`set_experiment`)
- a run starting, *before* `_start_run_workflow_thread`, so the worker thread is the only writer
- the window closing

All five are pinned by tests, and each was verified to fail when its own flush is removed.

`save_protocol=True` goes with it — a lamella's task config lives in `experiment.yaml`, so that flag rewrote `protocol.yaml` on every parameter change without it having changed. An AST test now pins that no handler in the editor bypasses the debounce by calling `experiment.save()` directly.

## Verification

12 new tests in `tests/ui/test_editor_save_debounce.py`, driven against a real editor — `AutoLamellaUI(parent_ui=None)` plus a Demo connect builds the whole widget tree offscreen in ~0.2 s. The window's two flush points are read off the source, since `AutoLamellaSingleWindowUI` builds a vispy quad view and a napari viewer that don't survive `QT_QPA_PLATFORM=offscreen`.

Full `tests/autolamella/` + `tests/ui/`: 1881 passed. App launches and connects clean.

Mutation-tested — 8 of 9 mutations caught: removing the debounce, re-reading the parent experiment at flush time, and dropping each of the five flush points individually all fail the expected tests, as does reinstating `save_protocol=True`.

The ninth is worth stating rather than hiding: **deleting `_save_timer.stop()` from the flush breaks nothing**, because clearing the pending experiment already makes a late timer a no-op. The `stop()` is defensive, not load-bearing. I kept it (disarming is the honest expression of "this write is done") and corrected the test's docstring, which had claimed to pin it — what that test actually pins is one-write-per-edit however the flush and timer interleave, which would still catch a refactor dropping the empty check.

Two more caveats, stated plainly:

- **A crash inside the 400 ms window still loses the last edit.** That is the trade, and the flush points are what keep the window small.
- **`test_hiding_the_panel_flushes` sends a `QHideEvent` rather than calling `hide()`.** Qt delivers no hideEvent to a widget that was never visible, and the editor's parent chain isn't shown in tests — so `hide()` is a silent no-op there and the test would pass with the override deleted. Sending the event exercises our half; delivering it on a tab switch is Qt's.

Pre-existing on `main`, unrelated and confirmed by A/B: 1 failure + 5 errors in `test_overview_widget` / `test_fm_live_indicator`.