### PR TITLE
[refactor] Plot milling patterns through the shared conversion (FIB-691)

### DIFF
--- a/fibsem/milling/patterning/plotting.py
+++ b/fibsem/milling/patterning/plotting.py
@@ -11,6 +11,10 @@ from matplotlib.colors import to_rgba, ListedColormap
 from matplotlib.collections import PatchCollection
 from skimage.transform import resize
 
+from fibsem.conversions import (
+    get_image_pixel_centre,
+    microscope_image_to_image_coordinates,
+)
 from fibsem.utils import format_value
 from fibsem.milling.base import FibsemMillingStage
 from fibsem.structures import (
@@ -76,19 +80,16 @@ def _rect_pattern_to_image_pixels(
     height = pattern.height
     mx, my = pattern.centre_x, pattern.centre_y
 
-    # position in metres from image centre
-    pmx, pmy = mx / pixel_size, my / pixel_size
-
     # convert to image coordinates
-    cy, cx = image_shape[0] // 2, image_shape[1] // 2
-    px = cx + pmx
-    py = cy - pmy
+    centre = microscope_image_to_image_coordinates(
+        Point(x=mx, y=my), image_shape, pixel_size, subpixel_precision=False
+    )
 
     # convert parameters to pixels
     width = width / pixel_size
     height = height / pixel_size
 
-    return px, py, width, height
+    return centre.x, centre.y, width, height
 
 def _circle_pattern_to_image_pixels(
     pattern: FibsemCircleSettings, pixel_size: float, image_shape: Tuple[int, int]
@@ -108,19 +109,16 @@ def _circle_pattern_to_image_pixels(
     start_angle = pattern.start_angle
     end_angle = pattern.end_angle
 
-    # position in metres from image centre
-    pmx, pmy = mx / pixel_size, my / pixel_size
-
     # convert to image coordinates
-    cy, cx = image_shape[0] // 2, image_shape[1] // 2
-    px = cx + pmx
-    py = cy - pmy
+    centre = microscope_image_to_image_coordinates(
+        Point(x=mx, y=my), image_shape, pixel_size, subpixel_precision=False
+    )
 
     # convert parameters to pixels
     radius_px = radius / pixel_size
     inner_radius_px = max(0, (radius - thickness) / pixel_size) if thickness > 0 else 0
 
-    return px, py, radius_px, inner_radius_px, start_angle, end_angle
+    return centre.x, centre.y, radius_px, inner_radius_px, start_angle, end_angle
 
 def _line_pattern_to_image_pixels(
     pattern: FibsemLineSettings, pixel_size: float, image_shape: Tuple[int, int]
@@ -137,18 +135,21 @@ def _line_pattern_to_image_pixels(
     start_x, start_y = pattern.start_x, pattern.start_y
     end_x, end_y = pattern.end_x, pattern.end_y
 
-    # position in metres from image centre
-    start_px, start_py = start_x / pixel_size, start_y / pixel_size
-    end_px, end_py = end_x / pixel_size, end_y / pixel_size
-
     # convert to image coordinates
-    cy, cx = image_shape[0] / 2, image_shape[1] / 2
-    start_pixel_x = cx + start_px
-    start_pixel_y = cy - start_py
-    end_pixel_x = cx + end_px
-    end_pixel_y = cy - end_py
+    #
+    # NOTE subpixel_precision=True here and False in the three siblings above.
+    # That asymmetry is inherited, not chosen: this function used `/ 2` for the
+    # centre where the others used `// 2`, which differs by half a pixel on an
+    # odd image dimension. Preserved exactly rather than quietly unified,
+    # because picking one changes where a milling pattern is drawn (FIB-644).
+    start = microscope_image_to_image_coordinates(
+        Point(x=start_x, y=start_y), image_shape, pixel_size, subpixel_precision=True
+    )
+    end = microscope_image_to_image_coordinates(
+        Point(x=end_x, y=end_y), image_shape, pixel_size, subpixel_precision=True
+    )
 
-    return start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y
+    return start.x, start.y, end.x, end.y
 
 def _polygon_pattern_to_image_pixels(
     pattern: FibsemPolygonSettings, pixel_size: float, image_shape: Tuple[int, int]
@@ -164,21 +165,17 @@ def _polygon_pattern_to_image_pixels(
     # get pattern parameters
     vertices = pattern.vertices
 
-    # convert to image coordinates
-    cy, cx = image_shape[0] // 2, image_shape[1] // 2
-    
-    # convert vertices to pixel coordinates
+    # convert vertices to image coordinates
     pixel_vertices = []
     for vertex in vertices:
-        # position in metres from image centre
-        pmx, pmy = vertex[0] / pixel_size, vertex[1] / pixel_size
-        
-        # convert to image coordinates
-        px = cx + pmx
-        py = cy - pmy
-        
-        pixel_vertices.append((px, py))
-    
+        pt = microscope_image_to_image_coordinates(
+            Point(x=vertex[0], y=vertex[1]),
+            image_shape,
+            pixel_size,
+            subpixel_precision=False,
+        )
+        pixel_vertices.append((pt.x, pt.y))
+
     return np.array(pixel_vertices)
 
 
@@ -722,7 +719,7 @@ def draw_milling_patterns(
 
     # draw crosshair at centre of image
     if crosshair:
-        cy, cx = image.data.shape[0] // 2, image.data.shape[1] // 2
+        cy, cx = get_image_pixel_centre(image.data.shape)
         ax.plot(cx, cy, "y+", markersize=PROPERTIES["crosshair_size"])
 
     # draw scalebar
@@ -778,7 +775,7 @@ def draw_annulus_shape(pattern_settings: FibsemCircleSettings, image_shape: Tupl
     """
     
     # image parameters (centre, pixel size)
-    icy, icx = image_shape[0] // 2, image_shape[1] // 2
+    icy, icx = get_image_pixel_centre(image_shape)
     pixelsize_x, pixelsize_y = pixelsize, pixelsize
 
     # pattern parameters
@@ -817,7 +814,7 @@ def draw_rectangle_shape(pattern_settings: FibsemRectangleSettings, image_shape:
     from scipy.ndimage import rotate
 
     # image parameters (centre, pixel size)
-    icy, icx = image_shape[0] // 2, image_shape[1] // 2
+    icy, icx = get_image_pixel_centre(image_shape)
     pixelsize_x, pixelsize_y = pixelsize, pixelsize
 
     # pattern parameters
@@ -861,7 +858,7 @@ def draw_bitmap_shape(
     from PIL import Image
 
     # image parameters (centre, pixel size)
-    icy, icx = image_shape[0] // 2, image_shape[1] // 2
+    icy, icx = get_image_pixel_centre(image_shape)
     pixelsize_x, pixelsize_y = pixelsize, pixelsize
 
     # pattern parameters
@@ -946,7 +943,7 @@ def draw_polygon_shape(pattern_settings: FibsemPolygonSettings, image_shape: Tup
     from skimage.draw import polygon
 
     # image parameters (centre, pixel size)
-    icy, icx = image_shape[0] // 2, image_shape[1] // 2
+    icy, icx = get_image_pixel_centre(image_shape)
     pixelsize_x, pixelsize_y = pixelsize, pixelsize
 
     # Convert vertices to pixel coordinates

--- a/tests/milling/test_pattern_to_image_pixels.py
+++ b/tests/milling/test_pattern_to_image_pixels.py
@@ -1,0 +1,112 @@
+"""Pattern metres → image pixels, through one conversion.
+
+FIB-644: the four `_*_pattern_to_image_pixels` helpers each wrote out
+`cx + x/ps`, `cy - y/ps` by hand — the inverse of the conversion
+`fibsem.conversions` already owns. They now call it.
+
+The reason this mattered is in `test_the_line_converter_disagrees_with_its_siblings`:
+they had already drifted apart before anyone noticed.
+"""
+import numpy as np
+import pytest
+
+from fibsem.conversions import microscope_image_to_image_coordinates
+from fibsem.milling.patterning.plotting import (
+    _circle_pattern_to_image_pixels,
+    _line_pattern_to_image_pixels,
+    _polygon_pattern_to_image_pixels,
+    _rect_pattern_to_image_pixels,
+)
+from fibsem.structures import (
+    FibsemCircleSettings,
+    FibsemLineSettings,
+    FibsemPolygonSettings,
+    FibsemRectangleSettings,
+    Point,
+)
+
+EVEN = (512, 1024)   # (height, width)
+ODD = (511, 1023)    # the only shapes where the centre rounding is visible
+PS = 1e-8
+OFFSET = 5e-6        # 500 px at this pixel size
+
+
+def _expected(x, y, shape, subpixel):
+    pt = microscope_image_to_image_coordinates(
+        Point(x=x, y=y), shape, PS, subpixel_precision=subpixel
+    )
+    return pt.x, pt.y
+
+
+@pytest.mark.parametrize("shape", [EVEN, ODD])
+def test_rectangle_uses_the_shared_conversion(shape):
+    p = FibsemRectangleSettings(
+        width=1e-6, height=2e-6, depth=1e-6, centre_x=OFFSET, centre_y=-OFFSET
+    )
+    px, py, w, h = _rect_pattern_to_image_pixels(p, PS, shape)
+
+    assert (px, py) == _expected(OFFSET, -OFFSET, shape, subpixel=False)
+    assert (w, h) == (1e-6 / PS, 2e-6 / PS)
+
+
+@pytest.mark.parametrize("shape", [EVEN, ODD])
+def test_circle_uses_the_shared_conversion(shape):
+    p = FibsemCircleSettings(
+        radius=3e-6, depth=1e-6, thickness=0, centre_x=OFFSET, centre_y=-OFFSET,
+        start_angle=0, end_angle=360,
+    )
+    px, py, *_ = _circle_pattern_to_image_pixels(p, PS, shape)
+
+    assert (px, py) == _expected(OFFSET, -OFFSET, shape, subpixel=False)
+
+
+@pytest.mark.parametrize("shape", [EVEN, ODD])
+def test_polygon_converts_every_vertex_the_same_way(shape):
+    p = FibsemPolygonSettings(
+        vertices=[(OFFSET, -OFFSET), (-OFFSET, OFFSET), (0.0, 0.0)], depth=1e-6
+    )
+    got = _polygon_pattern_to_image_pixels(p, PS, shape)
+
+    want = np.array([_expected(x, y, shape, subpixel=False) for x, y in p.vertices])
+    assert np.array_equal(got, want)
+
+
+@pytest.mark.parametrize("shape", [EVEN, ODD])
+def test_line_uses_the_shared_conversion(shape):
+    p = FibsemLineSettings(
+        start_x=OFFSET, start_y=-OFFSET, end_x=-OFFSET, end_y=OFFSET, depth=1e-6
+    )
+    sx, sy, ex, ey = _line_pattern_to_image_pixels(p, PS, shape)
+
+    assert (sx, sy) == _expected(OFFSET, -OFFSET, shape, subpixel=True)
+    assert (ex, ey) == _expected(-OFFSET, OFFSET, shape, subpixel=True)
+
+
+def test_the_line_converter_disagrees_with_its_siblings():
+    """The drift, pinned — deliberately, so it cannot be "tidied up" silently.
+
+    Three of the four floor the image centre; the line converter does not. On an
+    even image that is the same number, so it went unnoticed. On an odd one they
+    are half a pixel apart, and this is milling pattern placement.
+
+    Unifying them is a real decision about where patterns land, not a refactor.
+    When someone makes it, this test should fail and be deleted on purpose
+    (FIB-644).
+    """
+    rect = FibsemRectangleSettings(
+        width=1e-6, height=1e-6, depth=1e-6, centre_x=OFFSET, centre_y=OFFSET
+    )
+    line = FibsemLineSettings(
+        start_x=OFFSET, start_y=OFFSET, end_x=OFFSET, end_y=OFFSET, depth=1e-6
+    )
+
+    rx, ry, _, _ = _rect_pattern_to_image_pixels(rect, PS, ODD)
+    lx, ly, _, _ = _line_pattern_to_image_pixels(line, PS, ODD)
+
+    assert abs(lx - rx) == pytest.approx(0.5)
+    assert abs(ly - ry) == pytest.approx(0.5)
+
+    # ...and on an even image they agree, which is why it was never spotted.
+    rx, ry, _, _ = _rect_pattern_to_image_pixels(rect, PS, EVEN)
+    lx, ly, _, _ = _line_pattern_to_image_pixels(line, PS, EVEN)
+    assert (lx, ly) == (rx, ry)


### PR DESCRIPTION
Fixes FIB-691 — part of FIB-644, split out so merging this cannot auto-complete that survey. Follows #427.

All four `_*_pattern_to_image_pixels` helpers wrote out `cx + x/ps`, `cy - y/ps` by hand — the inverse of a conversion `fibsem.conversions` already owns — plus five more inline computations of the image centre. They now call `microscope_image_to_image_coordinates` and `get_image_pixel_centre`, so **this file derives neither**.

## They had already drifted

`_line_pattern_to_image_pixels` computed the centre with `/ 2`; the other three used `// 2`.

| | rect / circle / polygon | line |
| --- | --- | --- |
| 512 × 1024 | same | same |
| **511 × 1023** | floored centre | **0.5 px away** |

Identical on an even image dimension, which is why it was never spotted. Half a pixel apart on an odd one — and this is milling pattern placement. Nobody chose it; it's what four copies edited at four different times look like.

## What this deliberately does not decide

Unifying them **necessarily changes one of them**, so that's a decision about where patterns land, not a refactor.

So each site's rounding is preserved exactly, by passing `subpixel_precision` explicitly:

```python
# _line_pattern_to_image_pixels
# NOTE subpixel_precision=True here and False in the three siblings above.
# That asymmetry is inherited, not chosen... Preserved exactly rather than
# quietly unified, because picking one changes where a milling pattern is drawn.
```

The inconsistency moves out of hidden arithmetic and into one visible argument at four call sites. Making the call later is a one-word change, made on purpose.

`test_the_line_converter_disagrees_with_its_siblings` pins the 0.5 px difference on an odd shape **and** that they agree on an even one — documenting why it went unnoticed. When someone makes the decision, that test should fail and be deleted deliberately.

## Inert

Pre-change arithmetic run beside the new code, comparing **IEEE-754 bit patterns**:

```
parameter sets : 756   (7 shapes x offsets x pixel sizes)
comparisons    : 3,024 (x4 converters)
mismatches     : 0
```

4/4 mutations caught, `plotting.py` restored byte-identical:

| Mutation | |
| --- | --- |
| line silently unified to floored | 2 tests fail |
| rect silently unified to exact | 2 fail |
| polygon centre changed | 1 fails |
| rect swaps x and y | 2 fail |

**One behaviour difference checked rather than assumed:** `get_image_pixel_centre` raises on a non-2-D shape where the inline arithmetic silently took the first two axes. The crosshair site passes a live `image.data.shape` — but `check_data_format` enforces `ndim == 2`, so a `FibsemImage` cannot be RGB. Inert, and noted on the issue in case that ever loosens.

Net **−3 lines** despite the added explanation. Full suite: **4830 passed, 24 skipped**.

## Still open in FIB-644

The seven `get_image_pixel_centre` callers in `ui/napari/patterns.py` and `canvas/overlays/milling_overlay.py` spell the same conversion by hand (wrapped in `int()`), plus `fm/reprojection.py` (both directions, verified bit-identical) and `imaging/tiling/reprojection.py`.

And the standing trap: `projection.py`'s `FMStageProjection.to_plane` looks like the same arithmetic and **does not mirror y**. It round-trips consistently, so a round-trip test would not catch folding it in.
