### PR TITLE
[fix] Draw polygon patterns the right way up (FIB-692)

### DIFF
--- a/fibsem/ui/napari/patterns.py
+++ b/fibsem/ui/napari/patterns.py
@@ -19,7 +19,10 @@ from fibsem.milling.patterning.patterns2 import (
     BasePattern,
     FiducialPattern,
 )
-from fibsem.conversions import get_image_pixel_centre
+from fibsem.conversions import (
+    get_image_pixel_centre,
+    microscope_image_to_image_coordinates,
+)
 from fibsem.structures import (
     FibsemBitmapSettings,
     FibsemCircleSettings,
@@ -271,16 +274,20 @@ def convert_pattern_to_napari_polygon(pattern_settings: FibsemPolygonSettings,
     if not isinstance(pattern_settings, FibsemPolygonSettings):
         raise ValueError(f"Pattern is not a Polygon: {pattern_settings}")
 
-    # image centre
-    icy, icx = get_image_pixel_centre(shape)
+    # Vertices are (x, y) in microscope metres, the same frame as every other
+    # pattern's centre_x / centre_y. This previously added the image centre to
+    # both axes, which drew the polygon mirrored about it: microscope +y is up
+    # and image rows go down, so y has to be subtracted, not added (FIB-692).
+    points = [
+        microscope_image_to_image_coordinates(
+            Point(x=float(vx), y=float(vy)), shape, pixelsize
+        )
+        for vx, vy in pattern_settings.vertices
+    ]
 
-    vertices = np.array(pattern_settings.vertices)
-    # convert vertices to pixels
-    vertices = vertices / pixelsize
-    # reverse the order of coordinates for napari
-    vertices = vertices[:, ::-1]
-    # add the image centre
-    vertices += np.array([icy, icx])
+    # napari wants (row, column) — i.e. (y, x) — so the swap happens after the
+    # conversion, not before it
+    vertices = np.array([[p.y, p.x] for p in points], dtype=float).reshape(-1, 2)
 
     return vertices, {"translate": translation}
 

--- a/tests/ui/test_napari_pattern_conversion.py
+++ b/tests/ui/test_napari_pattern_conversion.py
@@ -1,0 +1,95 @@
+"""Milling patterns must land on the same side of the image in both renderers.
+
+FIB-692: `convert_pattern_to_napari_polygon` added the image centre to the
+vertex y instead of subtracting it, so polygons drew mirrored about the centre —
+a vertex 100 px above centre rendered 100 px below. Microscope +y is up while
+image rows go down, so y has to be mirrored; every sibling converter and
+`plotting.py`'s own polygon converter do exactly that.
+
+The error is 2 x the distance from the centre, so it vanishes for a pattern on
+the centre line. Symmetric, centred fixtures cannot see it — these are
+deliberately off-centre and asymmetric.
+
+NOTE these skip on CI, which installs no napari. `fibsem/ui/napari/patterns.py`
+imports it at module level, so the converters cannot be reached without it.
+"""
+import numpy as np
+import pytest
+
+pytest.importorskip("napari")
+
+from fibsem.milling.patterning.plotting import _polygon_pattern_to_image_pixels
+from fibsem.structures import FibsemPolygonSettings, FibsemRectangleSettings
+from fibsem.ui.napari.patterns import (
+    convert_pattern_to_napari_polygon,
+    convert_pattern_to_napari_rect,
+)
+
+SHAPE = (512, 1024)   # (height, width) -> centre (256, 512)
+PS = 1e-8             # 10 nm/px, so 1e-6 m = 100 px
+ABOVE = 1e-6          # +y in microscope coordinates is UP
+
+
+def test_a_vertex_above_the_centre_is_drawn_above_the_centre():
+    """The defect, stated as plainly as it can be."""
+    pattern = FibsemPolygonSettings(vertices=[(0.0, ABOVE)], depth=1e-6)
+
+    (row, col), = convert_pattern_to_napari_polygon(pattern, SHAPE, PS)[0]
+
+    assert row == pytest.approx(156.0), "100 px above a centre of 256"
+    assert row < 256, "drawn below the centre — mirrored (FIB-692)"
+    assert col == pytest.approx(512.0), "x was never wrong"
+
+
+def test_the_two_renderers_agree_on_every_vertex():
+    """The strongest form: napari and matplotlib draw the same polygon.
+
+    They disagreed by 2x the offset before, and nothing compared them."""
+    pattern = FibsemPolygonSettings(
+        vertices=[(2e-6, ABOVE), (-3e-6, -2e-6), (1e-6, 0.0)], depth=1e-6
+    )
+
+    napari_yx = convert_pattern_to_napari_polygon(pattern, SHAPE, PS)[0]
+    mpl_xy = _polygon_pattern_to_image_pixels(pattern, PS, SHAPE)
+
+    assert np.allclose(napari_yx[:, 0], mpl_xy[:, 1]), "y disagrees"
+    assert np.allclose(napari_yx[:, 1], mpl_xy[:, 0]), "x disagrees"
+
+
+def test_a_polygon_agrees_with_a_rectangle_about_which_way_is_up():
+    """Cross-check inside the napari module itself: the same offset, two pattern
+    types, one answer. The rectangle converter was always right."""
+    poly = FibsemPolygonSettings(vertices=[(0.0, ABOVE)], depth=1e-6)
+    rect = FibsemRectangleSettings(
+        width=1e-6, height=1e-6, depth=1e-6, centre_x=0.0, centre_y=ABOVE
+    )
+
+    (poly_row, _), = convert_pattern_to_napari_polygon(poly, SHAPE, PS)[0]
+    rect_rows = [row for row, _ in convert_pattern_to_napari_rect(rect, SHAPE, PS)[0]]
+
+    assert poly_row == pytest.approx(sum(rect_rows) / len(rect_rows))
+
+
+def test_a_vertex_on_the_centre_line_never_showed_the_bug():
+    """Why it survived: with y = 0 the mirror is the identity."""
+    pattern = FibsemPolygonSettings(vertices=[(4e-6, 0.0)], depth=1e-6)
+
+    (row, col), = convert_pattern_to_napari_polygon(pattern, SHAPE, PS)[0]
+
+    assert (row, col) == pytest.approx((256.0, 912.0))
+
+
+def test_the_result_is_row_column_for_napari():
+    """The swap is real and has to happen after the conversion, not before."""
+    pattern = FibsemPolygonSettings(vertices=[(4e-6, ABOVE)], depth=1e-6)
+
+    (row, col), = convert_pattern_to_napari_polygon(pattern, SHAPE, PS)[0]
+
+    assert (row, col) == pytest.approx((156.0, 912.0))
+
+
+def test_a_polygon_with_no_vertices_is_empty_not_an_error():
+    """Degenerate, but it used to raise IndexError from the (x, y) swap."""
+    pattern = FibsemPolygonSettings(vertices=np.zeros((0, 2)), depth=1e-6)
+
+    assert convert_pattern_to_napari_polygon(pattern, SHAPE, PS)[0].shape == (0, 2)


### PR DESCRIPTION
Fixes FIB-692. Found while doing FIB-644; filed and fixed separately rather than folded into a refactor, because it changes what gets drawn.

`convert_pattern_to_napari_polygon` **added** the image centre to the vertex y instead of subtracting it, so polygons rendered mirrored about the centre. Microscope +y is up, image rows go down — y has to be mirrored, and every sibling converter already did.

## Measured

A vertex at `(0, +1e-6)` — 100 px **above** centre, 512 × 1024 image, 10 nm/px, centre row 256:

| Renderer | image y | |
| --- | --- | --- |
| `plotting.py` polygon (matplotlib) | **156** | above centre — correct |
| `convert_pattern_to_napari_rect` (same file) | **156** | correct |
| **`convert_pattern_to_napari_polygon`** | **356** | below centre — **mirrored** |

x was never wrong. The error is **2 × the distance from centre**, so it vanishes for a vertex on the centre line — which is exactly why symmetric, centred fixtures never caught it.

## Reach

Not dead code: `canvas/overlays/milling_overlay.py:242` draws canvas polygons through it, so the affected surface is the **new canvas stack**, not just legacy napari.

Bounded, though: polygons aren't in production use, and no microscope backend consumes `FibsemPolygonSettings.vertices` — `grep` over `fibsem/microscopes/` is empty — so this was display-only. Worth re-checking before polygon milling is wired up, because the same mirrored geometry reaching a real mill is a different severity.

## The fix

Routed through `microscope_image_to_image_coordinates` rather than flipping a sign, because that conversion is what the call site should have been using — it's one of the sites FIB-644 is consolidating anyway. napari wants `(row, column)`, so the `(y, x)` swap now happens *after* the conversion instead of before it.

```python
# napari wants (row, column) — i.e. (y, x) — so the swap happens after the
# conversion, not before it
vertices = np.array([[p.y, p.x] for p in points], dtype=float).reshape(-1, 2)
```

## Tests

**There were none for any of these converters.** That is how a vertical mirror survived. Six added; the two worth reading:

- `test_the_two_renderers_agree_on_every_vertex` — napari against matplotlib on the same polygon. Nothing compared them before, and they disagreed by 2× the offset.
- `test_a_vertex_on_the_centre_line_never_showed_the_bug` — records *why* it went unnoticed, so the next person doesn't write a centred fixture and believe it.

3/3 mutations caught: forgetting the `(y, x)` swap (5 fail), reintroducing the mirror (4), swapping x and y at the source (5). `patterns.py` restored byte-identical.

**Caveat worth knowing:** `fibsem/ui/napari/patterns.py` imports napari at module level and CI installs none, so **these tests skip on CI** and only run locally. Testing the cross-renderer property napari-free would mean moving the conversion out of the napari module — more than this fix warrants, but it is the reason this area had no coverage to begin with.

Incidental: a polygon with no vertices now returns an empty `(0, 2)` array instead of raising `IndexError` from the old `[:, ::-1]` swap.

Full suite: **4827 passed, 24 skipped**.
