### PR TITLE
[ui] Show a pending border for a queued run, and rename stopped to stopping (FIB-676, FIB-678)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -563,6 +563,14 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.action_border_waiting.triggered.connect(
             lambda: self._set_border_state("waiting")
         )
+        self.action_border_pending = QAction("Pending (grey)", self)
+        self.action_border_pending.triggered.connect(
+            lambda: self._set_border_state("pending")
+        )
+        self.action_border_stopping = QAction("Stopping (red)", self)
+        self.action_border_stopping.triggered.connect(
+            lambda: self._set_border_state("stopping")
+        )
 
         self.action_border_idle = QAction("Idle (no border)", self)
         self.action_border_idle.triggered.connect(
@@ -589,6 +597,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         border_menu.addAction(self.action_border_automated)  # type: ignore
         border_menu.addAction(self.action_border_supervised)  # type: ignore
         border_menu.addAction(self.action_border_waiting)  # type: ignore
+        border_menu.addAction(self.action_border_pending)  # type: ignore
+        border_menu.addAction(self.action_border_stopping)  # type: ignore
         border_menu.addAction(self.action_border_idle)  # type: ignore
         border_menu.addAction(self.action_border_agent)  # type: ignore
 
@@ -976,7 +986,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         )
         if reply == QMessageBox.Yes and self.autolamella_ui is not None:
             self.autolamella_ui.stop_task_workflow()
-            self._set_border_state("stopped")
+            self._set_border_state("stopping")
 
     def _on_user_attention_clicked(self):
         """Handle user attention button click - switch to Microscope tab."""
@@ -2060,10 +2070,12 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         t1 = time.time()
 
         # Update border to reflect current workflow state
-        if self._border_state == "stopped":
-            pass  # Keep red border until workflow finishes
+        if self._border_state == "stopping":
+            pass  # Keep the red border until the workflow finishes unwinding
         elif waiting:
             self._set_border_state("waiting")
+        elif self.autolamella_ui.WORKFLOW_PENDING:
+            self._set_border_state("pending")
         elif self.autolamella_ui.is_workflow_running:
             self._set_border_state("supervised" if supervised else "automated")
         else:

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -203,6 +203,9 @@ class AutoLamellaUI(QMainWindow):
         self.tabWidget.insertTab(0, self.system_widget, "Connection")
 
         self.WAITING_FOR_USER_INTERACTION: bool = False
+        # A run is active but nothing is executing -- today only during a
+        # scheduled-start wait. Set from the worker thread, read by the border.
+        self.WORKFLOW_PENDING: bool = False
         self.USER_RESPONSE: bool = False
         self.WAITING_FOR_UI_UPDATE: bool = False
         self.SELECTED_POI: Optional[Point] = None
@@ -1813,6 +1816,7 @@ class AutoLamellaUI(QMainWindow):
         self.tabWidget.setCurrentIndex(self.tabWidget.indexOf(self.tab))
 
         self.WAITING_FOR_USER_INTERACTION = False
+        self.WORKFLOW_PENDING = False
 
         # clear milling task config
         if self.milling_task_config_widget is not None:

--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -1965,7 +1965,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
     def _toggle_milling(self):
         """Start milling if idle, stop if running."""
         if self.btn_milling.text() == "Stop Milling":
-            self._set_border_state("stopped")
+            self._set_border_state("stopping")
             if self.milling_viewer_widget is not None:
                 self.milling_viewer_widget.milling_widget.stop_milling()
         else:
@@ -2288,15 +2288,6 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         layout.setSpacing(0)
         layout.addWidget(canvas)
         return frame
-
-    _BORDER_STATES = [
-        "idle",
-        "automated",
-        "supervised",
-        "waiting",
-        "finished",
-        "stopped",
-    ]
 
     def set_border_enabled(self, enabled: bool) -> None:
         """Enable or disable the workflow border state animation.

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -445,19 +445,37 @@ class TaskManager:
             scheduled_at = scheduled_at.astimezone().replace(tzinfo=None)
         target_str = scheduled_at.strftime(DATETIME_DISPLAY_AMPM)
         next_update = 0.0  # force an immediate first message
-        while not self.should_abort:
-            remaining = (scheduled_at - datetime.now()).total_seconds()
-            if remaining <= 0:
-                break
+        self._set_workflow_pending(True)
+        try:
+            while not self.should_abort:
+                remaining = (scheduled_at - datetime.now()).total_seconds()
+                if remaining <= 0:
+                    break
 
-            now = time.monotonic()
-            if now >= next_update:
-                msg = (f"Waiting until {target_str} to start {task_name} on "
-                       f"{lamella.name} ({format_time_remaining(remaining)} remaining).")
-                update_status_ui(self.parent_ui, "", status_bar=msg)
-                next_update = now + 15.0
+                now = time.monotonic()
+                if now >= next_update:
+                    msg = (f"Waiting until {target_str} to start {task_name} on "
+                           f"{lamella.name} ({format_time_remaining(remaining)} remaining).")
+                    update_status_ui(self.parent_ui, "", status_bar=msg)
+                    next_update = now + 15.0
 
-            time.sleep(min(1.0, remaining))
+                time.sleep(min(1.0, remaining))
+        finally:
+            # The time arriving, a stop, and an exception all have to clear this.
+            # A stranded flag would leave the border reading "nothing is running"
+            # for the rest of the run.
+            self._set_workflow_pending(False)
+
+    def _set_workflow_pending(self, pending: bool) -> None:
+        """Tell the UI a run is active but nothing is executing.
+
+        Read by the workflow border, which would otherwise show the running
+        colour throughout a scheduled wait that can last hours. Set on the worker
+        thread and read on the GUI thread, the same way WAITING_FOR_USER_INTERACTION
+        already is.
+        """
+        if self.parent_ui is not None:
+            self.parent_ui.WORKFLOW_PENDING = pending
 
     def _should_skip(self, lamella: 'Lamella', task_name: str) -> Optional[str]:
         """Return skip reason string, or None if task should run.

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -28,6 +28,7 @@ from fibsem.ui.tokens import (  # noqa: F401  (re-exported for existing callers)
     OK_COLOR,
     ORANGE_COLOR,
     PANEL_COLOR,
+    PENDING_COLOR,
     PRIMARY_ACCENT,
     PRIMARY_COLOR,
     PRIMARY_COLOR_HOVER,
@@ -310,10 +311,11 @@ QToolTip {{
 # TODO: no token -- #BF00FF
 BORDER_STATE_COLOURS = {
     "idle": SURFACE_COLOR,
+    "pending": PENDING_COLOR,
     "automated": OK_COLOR,
     "supervised": PRIMARY_COLOR,
     "waiting": ORANGE_COLOR,
-    "stopped": SEMANTIC_ERROR_COLOR,
+    "stopping": SEMANTIC_ERROR_COLOR,
     "agent": "#BF00FF",
 }
 

--- a/fibsem/ui/tokens.py
+++ b/fibsem/ui/tokens.py
@@ -116,6 +116,12 @@ NEUTRAL_800 = "#3a3a3a"
 NEUTRAL_850 = "#2a2a2a"
 NEUTRAL_900 = "#1a1b1e"
 
+# Role name for the workflow border's "queued, but nothing is executing" state.
+# Points at the neutral the workflow timeline already uses for StepStatus.PENDING
+# (its ``_DOT_PENDING``), so a parked run reads the same on both surfaces instead
+# of inventing a seventh colour for an idea the app already has one for.
+PENDING_COLOR = NEUTRAL_700
+
 # ---------------------------------------------------------------------------
 # Deprecated aliases.
 #

--- a/tests/autolamella/test_scheduled_tasks.py
+++ b/tests/autolamella/test_scheduled_tasks.py
@@ -233,3 +233,100 @@ def test_the_workflow_config_finds_a_task_schedule():
     assert config.get_scheduled_at("Trench") == when
     assert config.get_scheduled_at("Undercut") is None
     assert config.get_scheduled_at("Polish") is None
+
+
+# ── the border can tell a parked run from a running one (FIB-676) ─────────────
+
+class _Signal:
+    """The one method `update_status_ui` calls on `workflow_update_signal`."""
+
+    def __init__(self, on_emit):
+        self._on_emit = on_emit
+
+    def emit(self, info: dict) -> None:
+        self._on_emit(info)
+
+
+class RecordingUI:
+    """Stands in for AutoLamellaUI at the only boundary the wait touches.
+
+    Samples WORKFLOW_PENDING at each status emit — i.e. exactly where the real UI
+    reads it, since the border block runs at the end of `_on_workflow_update`. That
+    makes these tests about what the border can *see*, not merely about an attribute
+    being written and rewritten around the call.
+    """
+
+    def __init__(self, manager: TaskManager):
+        self._task_manager = manager
+        self.WORKFLOW_PENDING = False
+        self.pending_at_each_emit: List[bool] = []
+        self.workflow_update_signal = _Signal(
+            lambda info: self.pending_at_each_emit.append(self.WORKFLOW_PENDING)
+        )
+
+
+@pytest.fixture
+def ui(manager: TaskManager) -> RecordingUI:
+    recording = RecordingUI(manager)
+    manager.parent_ui = recording
+    return recording
+
+
+def test_the_border_sees_pending_while_the_wait_is_happening(manager, ui):
+    """The whole point: a run parked until 2am must not keep showing the running
+    colour. The countdown emits every 15s and immediately on entry, so the flag has
+    to be true by the first of them — not merely set somewhere around the wait."""
+    elapsed_running(manager, scheduled_at=datetime.now() + timedelta(seconds=0.3))
+
+    assert ui.pending_at_each_emit == [True]
+    assert ui.WORKFLOW_PENDING is False
+
+
+def test_pending_clears_once_the_scheduled_time_arrives(manager, ui):
+    """Cleared before the task's own InProgress status goes out, so the border never
+    shows grey over a task that has started."""
+    manager._wait_until_scheduled(
+        scheduled_at=datetime.now() + timedelta(seconds=0.2),
+        task_name="Trench",
+        lamella=manager.experiment.positions[0],
+    )
+
+    assert ui.WORKFLOW_PENDING is False
+
+
+def test_pending_clears_when_a_stop_ends_the_wait(manager, ui):
+    """A stop leaves the queue; the flag must not outlive the wait it belongs to."""
+    Thread(target=manager.stop, daemon=True).start()
+
+    elapsed_running(manager, scheduled_at=datetime.now() + timedelta(hours=6))
+
+    assert ui.WORKFLOW_PENDING is False
+
+
+def test_pending_clears_if_the_wait_raises(manager, ui, monkeypatch):
+    """Why the clear is in a `finally`. A stranded flag would leave the border
+    claiming nothing is running for the remainder of the run."""
+    import fibsem.applications.autolamella.workflows.tasks.manager as manager_module
+
+    def boom(_seconds):
+        raise RuntimeError("something blew up mid-wait")
+
+    monkeypatch.setattr(manager_module.time, "sleep", boom)
+
+    with pytest.raises(RuntimeError):
+        elapsed_running(manager, scheduled_at=datetime.now() + timedelta(hours=6))
+
+    assert ui.WORKFLOW_PENDING is False
+
+
+def test_an_unscheduled_task_never_sets_pending(manager, ui):
+    """The common path stays untouched: no schedule, no flag, no grey flash.
+
+    The queue emits per-task status through the same signal, so the recorder is
+    demonstrably live here — every one of those emits just sees the flag false.
+    """
+    run_with(manager)
+
+    assert ui.pending_at_each_emit, "expected the queue to emit at all"
+    assert not any(ui.pending_at_each_emit)
+    assert ui.WORKFLOW_PENDING is False


### PR DESCRIPTION
A task can carry a scheduled start time days out. When the queue reaches it, `_wait_until_scheduled` parks the worker until the clock catches up — and for that entire window the border stayed **green**. Someone walking past the instrument at 9pm read "this is milling" when the first task did not start until 2am.

`is_workflow_running` cannot tell the two apart: it is just "worker thread alive", and the thread is alive throughout the wait.

## `pending`

Named for the general case, triggered today only by the scheduled wait. More park reasons are expected — "this task is next, but is waiting for something else" — and they should inherit the same colour rather than each adding one.

**The colour is not a new invention.** The workflow timeline already has a `StepStatus.PENDING` with its own neutral (`_DOT_PENDING`); `PENDING_COLOR` points at the same one, so a parked run reads the same on both surfaces — and the border wraps the window the timeline sits in.

The signal is a `WORKFLOW_PENDING` flag on `AutoLamellaUI`, set from the worker in a `try/finally`, mirroring `WAITING_FOR_USER_INTERACTION`. The `finally` is the point: a stranded flag would leave the border claiming nothing is running for the rest of the run, so the time arriving, a stop, and an exception all have to clear it.

### One deliberate deviation from the issue

FIB-676's work list said the optimistic write at launch should set `pending`. It doesn't. That would flash grey for a few hundred ms on *every* normal launch — the exact flicker the issue's own "one state, not several" section argues against — and deciding otherwise at launch would need a second copy of the timezone normalisation `_wait_until_scheduled` owns, which is how FIB-679 happened. The derived path picks `pending` up on the wait's first countdown emit, which is immediate.

## `stopped` → `stopping`

It has never meant stopped. Both call sites set it at the moment a stop is **requested** — before calling `stop_task_workflow()` / `stop_milling()` — and it clears when the run ends.

The old name reads as terminal, and that misreading cost real design time: it made "the border clears at run end" look like a defect, which produced a proposal to latch it past the end, which produced a second issue to latch failures the same way. None of it was needed, because the modal `WorkflowSummaryDialog` already says what happened at the end of every run and blocks until acknowledged.

> **The border says what the instrument is doing right now. The summary dialog says what happened.**

Every state in the border is now live under that reading.

## Also

- **Delete `_BORDER_STATES`** from the coincidence viewer: unused, already stale (it still listed the removed `finished`), and a third copy of the vocabulary the FIB-679 guard cannot see — that one matches `[borderState="`, i.e. QSS selectors, not a Python list of names.
- **Debug menu actions for `pending` and `stopping`.** `stopping` never had one, which is part of why a dead state went unnoticed there for so long. This was an open question on FIB-676; happy to drop the `stopping` one if you'd rather.

## Verified

Real widgets, driven through their own `_set_border_state()`, sampling the pixel each border actually paints on all four edges:

```
--- AutoLamella main window (AutoLamellaSingleWindowUI) ---
  idle        expect #262930  painted ['#262930']  OK
  pending     expect #606060  painted ['#606060']  OK
  automated   expect #4CAF50  painted ['#4CAF50']  OK
  supervised  expect #007ACC  painted ['#007ACC']  OK
  waiting     expect #FF9800  painted ['#FF9800']  OK
  stopping    expect #99121F  painted ['#99121F']  OK
  agent       expect #BF00FF  painted ['#BF00FF']  OK
  re-entry    expect #99121F  painted ['#99121F']  OK
```

Identical for the coincidence viewer. The `re-entry` line covers `_set_border_state`'s early return when the state is unchanged.

Five new tests in `tests/autolamella/test_scheduled_tasks.py` (real `Experiment` / `Lamella` / `TaskQueue` / `_run_queue`, as that file already does). The stand-in samples the flag **at each status emit** — where the real UI reads it, since the border block runs at the end of `_on_workflow_update` — so they test what the border can see, not merely that an attribute was written and rewritten around the call. One covers the wait raising, which is why the clear is in a `finally`.

Tests: `test_scheduled_tasks.py` 21 passed; `test_border_stylesheet.py` + `test_coincidence_viewer_layering.py` + `test_border_stylesheet_single_source.py` 12 passed.

## Note on the colour

`pending` is deliberately the quietest state on the window — the goal is to stop the border claiming a parked run is executing, not to attract attention. It is noticeably subtler than the others at full-window scale. If it reads as too close to `idle` on a real display, `NEUTRAL_650` (`#666666`) or `NEUTRAL_550` (`#909090`) is a one-line change to `PENDING_COLOR`.
