### PR TITLE
[refactor] Convert napari and canvas patterns through the shared conversion (FIB-694)

### DIFF
--- a/fibsem/ui/napari/patterns.py
+++ b/fibsem/ui/napari/patterns.py
@@ -19,10 +19,7 @@ from fibsem.milling.patterning.patterns2 import (
     BasePattern,
     FiducialPattern,
 )
-from fibsem.conversions import (
-    get_image_pixel_centre,
-    microscope_image_to_image_coordinates,
-)
+from fibsem.conversions import microscope_image_to_image_coordinates
 from fibsem.structures import (
     FibsemBitmapSettings,
     FibsemCircleSettings,
@@ -101,13 +98,14 @@ def convert_pattern_to_napari_circle(
     if not isinstance(pattern_settings, FibsemCircleSettings):
         raise ValueError(f"Pattern is not a Circle: {pattern_settings}")
 
-    # image centre
-    icy, icx = get_image_pixel_centre(shape)
 
     # pattern to pixel coords
     r = int(pattern_settings.radius / pixelsize)
-    cx = int(icx + (pattern_settings.centre_x / pixelsize))
-    cy = int(icy - (pattern_settings.centre_y / pixelsize))
+    centre = microscope_image_to_image_coordinates(
+        Point(x=pattern_settings.centre_x, y=pattern_settings.centre_y),
+        shape, pixelsize,
+    )
+    cx, cy = int(centre.x), int(centre.y)
 
     # create corner coords
     xmin, ymin = cx - r, cy - r
@@ -127,8 +125,6 @@ def convert_pattern_to_napari_line(
     if not isinstance(pattern_settings, FibsemLineSettings):
         raise ValueError(f"Pattern is not a Line: {pattern_settings}")
 
-    # image centre
-    icy, icx = get_image_pixel_centre(shape)
 
     # extract pattern information from settings
     start_x = pattern_settings.start_x
@@ -137,10 +133,14 @@ def convert_pattern_to_napari_line(
     end_y = pattern_settings.end_y
 
     # pattern to pixel coords
-    px0 = int(icx + (start_x / pixelsize))
-    py0 = int(icy - (start_y / pixelsize))
-    px1 = int(icx + (end_x / pixelsize))
-    py1 = int(icy - (end_y / pixelsize))
+    start = microscope_image_to_image_coordinates(
+        Point(x=start_x, y=start_y), shape, pixelsize
+    )
+    end = microscope_image_to_image_coordinates(
+        Point(x=end_x, y=end_y), shape, pixelsize
+    )
+    px0, py0 = int(start.x), int(start.y)
+    px1, py1 = int(end.x), int(end.y)
 
     # napari shape format [[y_start, x_start], [y_end, x_end]])
     line = [[py0, px0], [py1, px1]]
@@ -156,8 +156,6 @@ def convert_pattern_to_napari_rect(
     if not isinstance(pattern_settings, FibsemRectangleSettings):
         raise ValueError(f"Pattern is not a Rectangle: {pattern_settings}")
 
-    # image centre
-    icy, icx = get_image_pixel_centre(shape)
 
     # extract pattern information from settings
     pattern_width = pattern_settings.width
@@ -169,8 +167,10 @@ def convert_pattern_to_napari_rect(
     # pattern to pixel coords
     w = int(pattern_width / pixelsize)
     h = int(pattern_height / pixelsize)
-    cx = int(icx + (pattern_centre_x / pixelsize))
-    cy = int(icy - (pattern_centre_y / pixelsize))
+    centre = microscope_image_to_image_coordinates(
+        Point(x=pattern_centre_x, y=pattern_centre_y), shape, pixelsize
+    )
+    cx, cy = int(centre.x), int(centre.y)
     r = -pattern_rotation  #
     xmin, xmax = -w / 2, w / 2
     ymin, ymax = -h / 2, h / 2
@@ -193,13 +193,13 @@ def create_crosshair_shape(
     pixelsize: float,
     translation: Union[np.ndarray, Tuple[float, float]] = (0, 0),
 ) -> Tuple[np.ndarray, Dict[str, Any]]:
-    icy, icx = shape[0] // 2, shape[1] // 2
-
     pattern_centre_x = centre_point.x
     pattern_centre_y = centre_point.y
 
-    cx = int(icx + (pattern_centre_x / pixelsize))
-    cy = int(icy - (pattern_centre_y / pixelsize))
+    centre = microscope_image_to_image_coordinates(
+        Point(x=pattern_centre_x, y=pattern_centre_y), shape, pixelsize
+    )
+    cx, cy = int(centre.x), int(centre.y)
 
     r_angles = [0, np.deg2rad(90)]  #
     w = 40
@@ -230,7 +230,10 @@ def convert_bitmap_pattern_to_napari_image(
     pixelsize: float,
     translation: Union[np.ndarray, Tuple[float, float]] = (0, 0),
 ) -> Tuple[np.ndarray, Dict[str, Any]]:
-    icy, icx = get_image_pixel_centre(shape)
+    centre = microscope_image_to_image_coordinates(
+        Point(x=pattern_settings.centre_x, y=pattern_settings.centre_y),
+        shape, pixelsize,
+    )
 
     resize_x = int(pattern_settings.width / pixelsize)
     resize_y = int(pattern_settings.height / pixelsize)
@@ -258,10 +261,8 @@ def convert_bitmap_pattern_to_napari_image(
                 img_array.shape[0] / 2,
                 img_array.shape[1] / 2,
             ),
-            translation=(
-                icy - pattern_settings.centre_y / pixelsize,
-                icx + pattern_settings.centre_x / pixelsize,
-            ),
+            # (row, column) for the affine, so y first
+            translation=(centre.y, centre.x),
         ),
         "translate": translation,
     }
@@ -564,12 +565,15 @@ def draw_milling_patterns_in_napari(
     return layer_name_list  # list of milling pattern layers
 
 def convert_point_to_napari(resolution: list, pixel_size: float, centre: Point):
-    icy, icx = resolution[1] // 2, resolution[0] // 2
+    # `resolution` is [x, y] (structures.py: "resolution of the acquired image
+    # in pixels, [x, y]"), the opposite order to a numpy `shape`. Swap it here
+    # rather than at the reader: the old code indexed [1] then [0] to compensate,
+    # which reads like a bug and is not one.
+    pt = microscope_image_to_image_coordinates(
+        centre, (resolution[1], resolution[0]), pixel_size
+    )
 
-    cx = int(icx + (centre.x / pixel_size))
-    cy = int(icy - (centre.y / pixel_size))
-
-    return Point(cx, cy)
+    return Point(int(pt.x), int(pt.y))
 
 
 def validate_pattern_image_placement(

--- a/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
@@ -32,8 +32,9 @@ from fibsem.structures import (
     FibsemLineSettings,
     FibsemPolygonSettings,
     FibsemRectangleSettings,
+    Point,
 )
-from fibsem.conversions import get_image_pixel_centre
+from fibsem.conversions import microscope_image_to_image_coordinates
 from fibsem.ui.napari.patterns import (
     COLOURS,
     convert_pattern_to_napari_line,
@@ -228,10 +229,12 @@ class MillingPatternOverlay(CanvasOverlay):
             verts, _ = convert_pattern_to_napari_rect(ps, shape, pixelsize)
             return mpatches.Polygon(verts[:, ::-1], closed=True, **patch_kw)  # (y,x)→(x,y)
         if isinstance(ps, FibsemCircleSettings):
-            icy, icx = get_image_pixel_centre(shape)
-            cx = icx + ps.centre_x / pixelsize
-            cy = icy - ps.centre_y / pixelsize
-            return mpatches.Circle((cx, cy), ps.radius / pixelsize, **patch_kw)
+            centre = microscope_image_to_image_coordinates(
+                Point(x=ps.centre_x, y=ps.centre_y), shape, pixelsize
+            )
+            return mpatches.Circle(
+                (centre.x, centre.y), ps.radius / pixelsize, **patch_kw
+            )
         if isinstance(ps, FibsemLineSettings):
             verts, _ = convert_pattern_to_napari_line(ps, shape, pixelsize)
             (y0, x0), (y1, x1) = verts
@@ -245,9 +248,8 @@ class MillingPatternOverlay(CanvasOverlay):
 
     def _draw_crosshair(self, point, shape, pixelsize: float, colour: str,
                         zorder: float) -> None:
-        icy, icx = get_image_pixel_centre(shape)
-        cx = icx + point.x / pixelsize
-        cy = icy - point.y / pixelsize
+        centre = microscope_image_to_image_coordinates(point, shape, pixelsize)
+        cx, cy = centre.x, centre.y
         h = _CROSSHAIR_HALF_PX
         kw = dict(color=colour, linewidth=1, alpha=0.9, zorder=zorder)
         (l1,) = self._ax.plot([cx - h, cx + h], [cy, cy], **kw)

--- a/tests/ui/test_napari_pattern_conversion.py
+++ b/tests/ui/test_napari_pattern_conversion.py
@@ -19,10 +19,20 @@ import pytest
 pytest.importorskip("napari")
 
 from fibsem.milling.patterning.plotting import _polygon_pattern_to_image_pixels
-from fibsem.structures import FibsemPolygonSettings, FibsemRectangleSettings
+from fibsem.conversions import microscope_image_to_image_coordinates
+from fibsem.structures import (
+    FibsemCircleSettings,
+    FibsemLineSettings,
+    FibsemPolygonSettings,
+    FibsemRectangleSettings,
+    Point,
+)
 from fibsem.ui.napari.patterns import (
+    convert_pattern_to_napari_circle,
+    convert_pattern_to_napari_line,
     convert_pattern_to_napari_polygon,
     convert_pattern_to_napari_rect,
+    convert_point_to_napari,
 )
 
 SHAPE = (512, 1024)   # (height, width) -> centre (256, 512)
@@ -93,3 +103,65 @@ def test_a_polygon_with_no_vertices_is_empty_not_an_error():
     pattern = FibsemPolygonSettings(vertices=np.zeros((0, 2)), depth=1e-6)
 
     assert convert_pattern_to_napari_polygon(pattern, SHAPE, PS)[0].shape == (0, 2)
+
+
+# ---------------------------------------------------------------------------
+# every converter reads the centre the same way (FIB-644)
+# ---------------------------------------------------------------------------
+
+ODD = (511, 1023)
+
+
+def _expected(x, y, shape=SHAPE):
+    pt = microscope_image_to_image_coordinates(Point(x=x, y=y), shape, PS)
+    return int(pt.x), int(pt.y)
+
+
+@pytest.mark.parametrize("shape", [SHAPE, ODD])
+def test_circle_agrees_with_the_shared_conversion(shape):
+    p = FibsemCircleSettings(
+        radius=3e-6, depth=1e-6, thickness=0, centre_x=2e-6, centre_y=ABOVE,
+        start_angle=0, end_angle=360,
+    )
+    rows = convert_pattern_to_napari_circle(p, shape, PS)[0]
+    cx, cy = _expected(2e-6, ABOVE, shape)
+
+    # corners are (y, x); the centre is their mean
+    assert sum(r for r, _ in rows) / 4 == pytest.approx(cy)
+    assert sum(c for _, c in rows) / 4 == pytest.approx(cx)
+
+
+@pytest.mark.parametrize("shape", [SHAPE, ODD])
+def test_line_agrees_with_the_shared_conversion(shape):
+    p = FibsemLineSettings(
+        start_x=2e-6, start_y=ABOVE, end_x=-1e-6, end_y=-2e-6, depth=1e-6
+    )
+    (y0, x0), (y1, x1) = convert_pattern_to_napari_line(p, shape, PS)[0]
+
+    assert (x0, y0) == _expected(2e-6, ABOVE, shape)
+    assert (x1, y1) == _expected(-1e-6, -2e-6, shape)
+
+
+@pytest.mark.parametrize("shape", [SHAPE, ODD])
+def test_rectangle_agrees_with_the_shared_conversion(shape):
+    p = FibsemRectangleSettings(
+        width=2e-6, height=3e-6, depth=1e-6, centre_x=2e-6, centre_y=ABOVE
+    )
+    rows = convert_pattern_to_napari_rect(p, shape, PS)[0]
+    cx, cy = _expected(2e-6, ABOVE, shape)
+
+    assert sum(r for r, _ in rows) / 4 == pytest.approx(cy)
+    assert sum(c for _, c in rows) / 4 == pytest.approx(cx)
+
+
+def test_convert_point_to_napari_takes_width_height_not_shape():
+    """The trap this helper hides: `resolution` is [x, y] — the opposite order
+    to a numpy shape. Indexing it [1] then [0] looks like a bug and is not one.
+
+    A non-square resolution is the only way to catch getting it wrong.
+    """
+    resolution = [1024, 512]          # width, height  -> centre (256, 512)
+
+    got = convert_point_to_napari(resolution, PS, Point(0.0, ABOVE))
+
+    assert (got.x, got.y) == (512, 156)


### PR DESCRIPTION
Fixes FIB-694 — third step of FIB-644, split out so merging it cannot auto-complete that survey. Follows #427 (FIB-688), #436 (FIB-691) and #437 (FIB-692).

`fibsem/ui/napari/patterns.py` wrote `int(icx + x/pixelsize)`, `int(icy - y/pixelsize)` by hand in **nine** places — circle, line, rectangle, the crosshair helper, the bitmap affine translation and `convert_point_to_napari` — and `canvas/overlays/milling_overlay.py` did the same twice. They now call `microscope_image_to_image_coordinates`, so **neither file derives the conversion or the image centre**.

The crosshair helper also computed `shape[0] // 2, shape[1] // 2` inline rather than calling `get_image_pixel_centre`, so it didn't even share a centre with its neighbours in the same file.

## The trap in `convert_point_to_napari`

```python
icy, icx = resolution[1] // 2, resolution[0] // 2
```

It indexes `[1]` then `[0]` — the reverse of every other site — and **it is correct**. `resolution` is documented `[x, y]` (`structures.py:678`, default `(1536, 1024)`), the opposite order to a numpy `shape`. Routing it naively through a helper that takes `(height, width)` would have silently transposed the centre on any non-square image.

The swap is now explicit at the call site with a comment saying why, and `test_convert_point_to_napari_takes_width_height_not_shape` uses a **non-square** resolution — the only shape that can catch getting it wrong.

Separately: **`convert_point_to_napari` has no callers anywhere.** Converted rather than deleted, because removing code is a different decision from refactoring it. Happy to delete it in a follow-up if you'd rather.

## Inert

Pre-change arithmetic run beside the new code, comparing **IEEE-754 bit patterns**:

```
parameter sets : 525    (7 shapes x offsets x pixel sizes)
comparisons    : 2,100  (x4 converters)
mismatches     : 0
```

Including the `int()` truncation the napari converters apply.

3/3 mutations caught, both files restored byte-identical: swapping `resolution` back to shape order (1 fail), swapping x and y in the line converter (2), and in the circle converter (2).

## The caveat that matters more than the green tick

`patterns.py` imports napari at module level and CI installs none, so **these 13 tests skip on CI** and only run locally. That is why this area had no coverage at all — and why #437's vertical mirror survived here undetected.

What actually backs this change is the local run, the differential sweep and the mutation check. Making it CI-visible would mean moving the conversion out of the napari module; worth considering, but larger than this.

Full suite: **5205 passed, 24 skipped**.

## Remaining in FIB-644

`fm/reprojection.py` (both directions, verified bit-identical to the shared conversion) and `imaging/tiling/reprojection.py` — stage projection with tilt corrections, a different subsystem, so its own step.

And the standing trap: `projection.py`'s `FMStageProjection.to_plane` looks like the same arithmetic and **does not mirror y**. It round-trips consistently, so a round-trip test would not catch folding it in.
