### PR TITLE
[refactor] One dialog for both overview tabs to confirm a run (FIB-695)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
@@ -5,19 +5,15 @@ it goes, and a primary action in the footer. Each fact appears once — the wind
 is the heading, the Channels row is the channel count, and the skipped chip is what
 "sparse" would have said.
 
-The style itself now lives in `fibsem.ui.widgets.preflight`, lifted out when the third
-dialog in this shape appeared — as the second one's docstring said to do.
+The style itself moved to `fibsem.ui.widgets.preflight` when the third dialog in this
+shape appeared — as the second one's docstring said to do — and the *dialog* followed it
+there once the beam overview turned out to present its run in exactly this way. What is
+left here is only the facts a fluorescence run is described by.
 """
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
-from PyQt5.QtWidgets import (
-    QDialog,
-    QHBoxLayout,
-    QPushButton,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt5.QtWidgets import QWidget
 
 from fibsem import constants
 from fibsem.fm.structures import (
@@ -30,17 +26,10 @@ from fibsem.fm.structures import (
 )
 from fibsem.fm.timing import estimate_tileset_acquisition_time
 from fibsem.structures import TileOrderStrategy
-from fibsem.ui import stylesheets
-from fibsem.ui.widgets.preflight import (
-    BACKGROUND,
-    chip,
-    detail_block,
-    format_duration,
-    meta_label,
-)
+from fibsem.ui.widgets.preflight import OverviewPreflightDialog, format_duration
 
 
-class FMOverviewConfirmationDialog(QDialog):
+class FMOverviewConfirmationDialog(OverviewPreflightDialog):
     """Confirm an overview before it runs, with what it will cost."""
 
     def __init__(
@@ -64,13 +53,13 @@ class FMOverviewConfirmationDialog(QDialog):
         # so the number it reports is the one the settings panel was showing.
         self.objective_current = objective_current
         self.objective_focus = objective_focus
-
-        self.setWindowTitle("Start Overview Acquisition")
-        self.setMinimumWidth(430)
-        self.setStyleSheet(f"QDialog {{ background: {BACKGROUND}; }}")
         self._init_ui()
 
     # ── content ──────────────────────────────────────────────────────────
+
+    def _tile_counts(self) -> Tuple[int, int]:
+        p = self.parameters
+        return p.n_enabled_tiles, p.rows * p.cols
 
     def _estimate(self) -> dict:
         return estimate_tileset_acquisition_time(
@@ -179,54 +168,3 @@ class FMOverviewConfirmationDialog(QDialog):
             + ")",
         ))
         return detail
-
-    # ── layout ───────────────────────────────────────────────────────────
-
-    def _init_ui(self) -> None:
-        p = self.parameters
-        total = p.rows * p.cols
-        acquired = p.n_enabled_tiles
-
-        # No in-dialog heading: the window title already says "Start Overview
-        # Acquisition", and repeating it 8px below costs a line and says nothing. The
-        # meta line leads instead, so it carries normal text weight rather than muted.
-        meta = meta_label(self._meta_line())
-
-        # Tile counts only. The channel count was a third chip, but the Channels row
-        # below lists them by name -- the chip added a number, not information.
-        chips = QHBoxLayout()
-        chips.setSpacing(6)
-        chips.addWidget(chip(f"{acquired} to acquire"))
-        if acquired != total:
-            chips.addWidget(chip(f"{total - acquired} skipped"))
-        chips.addStretch()
-
-        detail = detail_block(self._rows())
-
-        self.button_start = QPushButton("Start Acquisition")
-        self.button_start.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
-        self.button_start.setMinimumHeight(30)
-        self.button_start.clicked.connect(self.accept)
-        button_cancel = QPushButton("Cancel")
-        button_cancel.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        button_cancel.setMinimumHeight(30)
-        button_cancel.clicked.connect(self.reject)
-
-        footer = QHBoxLayout()
-        footer.addStretch()
-        footer.addWidget(button_cancel)
-        footer.addWidget(self.button_start)
-
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(16, 14, 16, 14)
-        layout.setSpacing(10)
-        layout.addWidget(meta)
-        layout.addLayout(chips)
-        layout.addWidget(detail)
-        layout.addLayout(footer)
-
-        if acquired == 0:
-            # Nothing to do: the runner would reject this anyway, so say why here
-            # rather than letting it fail after the dialog is dismissed.
-            self.button_start.setEnabled(False)
-            self.button_start.setToolTip("No tiles are selected.")

--- a/fibsem/ui/widgets/overview_confirmation_dialog.py
+++ b/fibsem/ui/widgets/overview_confirmation_dialog.py
@@ -8,32 +8,21 @@ tab switch. This is the last place either announces itself.
 
 Same house style as the fluorescence and coincidence dialogs, from the same module, so
 the three cannot drift: a meta line, count chips, a detail block, a primary action in
-the footer.
+the footer. The fluorescence one is more than a style-mate -- both confirm an overview
+and present it identically, so both are `OverviewPreflightDialog` and what is left here
+is only the facts a beam run is described by.
 """
 
 from typing import List, Optional, Tuple
 
-from PyQt5.QtWidgets import (
-    QDialog,
-    QHBoxLayout,
-    QPushButton,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt5.QtWidgets import QWidget
 
 from fibsem import constants
 from fibsem.structures import OverviewAcquisitionSettings
-from fibsem.ui import stylesheets
-from fibsem.ui.widgets.preflight import (
-    BACKGROUND,
-    chip,
-    detail_block,
-    format_duration,
-    meta_label,
-)
+from fibsem.ui.widgets.preflight import OverviewPreflightDialog, format_duration
 
 
-class OverviewConfirmationDialog(QDialog):
+class OverviewConfirmationDialog(OverviewPreflightDialog):
     """Confirm an overview before it runs, with what it will do."""
 
     def __init__(
@@ -58,13 +47,13 @@ class OverviewConfirmationDialog(QDialog):
         self.settings = settings
         self.view_description = view_description
         self.offset = offset
-
-        self.setWindowTitle("Start Overview Acquisition")
-        self.setMinimumWidth(430)
-        self.setStyleSheet(f"QDialog {{ background: {BACKGROUND}; }}")
         self._init_ui()
 
     # ── content ──────────────────────────────────────────────────────────
+
+    def _tile_counts(self) -> Tuple[int, int]:
+        return (self.settings.n_enabled_tiles,
+                self.settings.nrows * self.settings.ncols)
 
     def _meta_line(self) -> str:
         s = self.settings
@@ -130,44 +119,3 @@ class OverviewConfirmationDialog(QDialog):
             f"   ({format_duration(image.scan_time)} per tile, before stage movement)",
         ))
         return detail
-
-    # ── layout ───────────────────────────────────────────────────────────
-
-    def _init_ui(self) -> None:
-        total = self.settings.nrows * self.settings.ncols
-        acquired = self.settings.n_enabled_tiles
-
-        chips = QHBoxLayout()
-        chips.setSpacing(6)
-        chips.addWidget(chip(f"{acquired} to acquire"))
-        if acquired != total:
-            chips.addWidget(chip(f"{total - acquired} skipped"))
-        chips.addStretch()
-
-        self.button_start = QPushButton("Start Acquisition")
-        self.button_start.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
-        self.button_start.setMinimumHeight(30)
-        self.button_start.clicked.connect(self.accept)
-        button_cancel = QPushButton("Cancel")
-        button_cancel.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        button_cancel.setMinimumHeight(30)
-        button_cancel.clicked.connect(self.reject)
-
-        footer = QHBoxLayout()
-        footer.addStretch()
-        footer.addWidget(button_cancel)
-        footer.addWidget(self.button_start)
-
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(16, 14, 16, 14)
-        layout.setSpacing(10)
-        layout.addWidget(meta_label(self._meta_line()))
-        layout.addLayout(chips)
-        layout.addWidget(detail_block(self._rows()))
-        layout.addLayout(footer)
-
-        if acquired == 0:
-            # Nothing to do: the runner refuses this anyway, so say why here rather than
-            # letting it fail after the dialog is dismissed.
-            self.button_start.setEnabled(False)
-            self.button_start.setToolTip("No tiles are selected.")

--- a/fibsem/ui/widgets/preflight.py
+++ b/fibsem/ui/widgets/preflight.py
@@ -8,15 +8,23 @@ overview's dialog is the third.
 
 Only the parts all three agree on live here. The footer does not: milling makes Cancel
 the default button because a mill is irreversible, and an overview does not.
+
+The *two overview* dialogs agree on more than that -- on everything except which facts
+they list -- so they also share `OverviewPreflightDialog` below. The milling one is not a
+third subclass of it and should not become one: it confirms a different kind of thing,
+and the seven places it differs are seven constructor arguments a base class would carry
+for one caller.
 """
 
-from typing import Iterable, Tuple
+from typing import Iterable, List, Optional, Tuple
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
+    QDialog,
     QFrame,
     QHBoxLayout,
     QLabel,
+    QPushButton,
     QVBoxLayout,
     QWidget,
 )
@@ -113,3 +121,87 @@ def meta_label(text: str) -> QLabel:
     label.setStyleSheet(f"color: {TEXT_STRONG}; font-size: 12px;")
     label.setWordWrap(True)
     return label
+
+
+class OverviewPreflightDialog(QDialog):
+    """What both overview tabs put in front of a run.
+
+    The two tabs describe very different runs -- one lists channels, a z-stack and a
+    focus sweep, the other a dwell time and where the grid was dragged to -- and they
+    present them identically: the same title, the same width, the same
+    acquire/skipped chips, the same footer, and the same refusal when no tile is
+    selected. Everything except the facts, in other words, which is exactly the split
+    a subclass hook makes.
+
+    Subclasses fill in :meth:`_meta_line`, :meth:`_rows` and :meth:`_tile_counts`, then
+    call :meth:`_init_ui` at the end of their own ``__init__`` -- last, because it reads
+    all three, and none of them can answer before the subclass has stored what it is
+    describing.
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.setWindowTitle("Start Overview Acquisition")
+        self.setMinimumWidth(430)
+        self.setStyleSheet(f"QDialog {{ background: {BACKGROUND}; }}")
+
+    # ── what a subclass supplies ─────────────────────────────────────────
+
+    def _meta_line(self) -> str:
+        """The line that leads: what is about to happen, in one sentence."""
+        raise NotImplementedError
+
+    def _rows(self) -> List[Tuple[str, str]]:
+        """Label/value pairs for the detail block, in reading order."""
+        raise NotImplementedError
+
+    def _tile_counts(self) -> Tuple[int, int]:
+        """``(to acquire, total)``. Equal means every tile; the chips say the rest."""
+        raise NotImplementedError
+
+    # ── layout ───────────────────────────────────────────────────────────
+
+    def _init_ui(self) -> None:
+        acquired, total = self._tile_counts()
+
+        # No in-dialog heading: the window title already says "Start Overview
+        # Acquisition", and repeating it 8px below costs a line and says nothing. The
+        # meta line leads instead, so it carries normal text weight rather than muted.
+        #
+        # Tile counts only in the chips. A channel count was a third one once, and the
+        # Channels row below already lists them by name -- it added a number, not
+        # information.
+        chips = QHBoxLayout()
+        chips.setSpacing(6)
+        chips.addWidget(chip(f"{acquired} to acquire"))
+        if acquired != total:
+            chips.addWidget(chip(f"{total - acquired} skipped"))
+        chips.addStretch()
+
+        self.button_start = QPushButton("Start Acquisition")
+        self.button_start.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.button_start.setMinimumHeight(30)
+        self.button_start.clicked.connect(self.accept)
+        button_cancel = QPushButton("Cancel")
+        button_cancel.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        button_cancel.setMinimumHeight(30)
+        button_cancel.clicked.connect(self.reject)
+
+        footer = QHBoxLayout()
+        footer.addStretch()
+        footer.addWidget(button_cancel)
+        footer.addWidget(self.button_start)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 14, 16, 14)
+        layout.setSpacing(10)
+        layout.addWidget(meta_label(self._meta_line()))
+        layout.addLayout(chips)
+        layout.addWidget(detail_block(self._rows()))
+        layout.addLayout(footer)
+
+        if acquired == 0:
+            # Nothing to do: both runners refuse this anyway, so say why here rather
+            # than letting it fail after the dialog is dismissed.
+            self.button_start.setEnabled(False)
+            self.button_start.setToolTip("No tiles are selected.")

--- a/tests/ui/test_overview_confirmation_dialog.py
+++ b/tests/ui/test_overview_confirmation_dialog.py
@@ -185,13 +185,47 @@ class TestTheTimeItQuotes:
 def test_the_three_preflight_dialogs_share_one_style():
     """The coincidence dialog copied nothing from the FM one and imported instead,
     leaving a note to lift the shared parts out if a third appeared. This is the third,
-    and the note was followed rather than the import chain extended."""
+    and the note was followed rather than the import chain extended.
+
+    All three still agree on the duration format. The furniture -- chips, the detail
+    block -- is asserted through the base class for the two overview dialogs, which is
+    a stronger statement than importing the same helper: they cannot lay it out
+    differently, because neither of them lays it out at all.
+    """
     from fibsem.ui.fm.widgets import fm_overview_confirmation_dialog as fm
     from fibsem.ui.widgets import coincidence_milling_confirmation_dialog as milling
     from fibsem.ui.widgets import overview_confirmation_dialog as beam
     from fibsem.ui.widgets import preflight
 
     for module in (fm, milling, beam):
-        assert module.chip is preflight.chip
-        assert module.detail_block is preflight.detail_block
         assert module.format_duration is preflight.format_duration
+
+    assert milling.chip is preflight.chip
+    assert milling.detail_block is preflight.detail_block
+
+
+def test_the_two_overview_dialogs_are_one_dialog():
+    """Both confirm an overview and present it identically, so neither owns a layout.
+
+    Asserted on `_init_ui` rather than on the class hierarchy alone: a subclass that
+    reintroduces its own layout would still pass an `issubclass` check while being
+    exactly the duplication this removed.
+    """
+    from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
+        FMOverviewConfirmationDialog,
+    )
+    from fibsem.ui.widgets.overview_confirmation_dialog import (
+        OverviewConfirmationDialog,
+    )
+    from fibsem.ui.widgets.preflight import OverviewPreflightDialog
+
+    for cls in (OverviewConfirmationDialog, FMOverviewConfirmationDialog):
+        assert issubclass(cls, OverviewPreflightDialog)
+        assert "_init_ui" not in vars(cls), (
+            f"{cls.__name__} lays itself out again; the base is what stops the two "
+            "dialogs drifting apart"
+        )
+        # The three hooks are the whole of what a subclass is for, so each must be
+        # answered -- an unimplemented one raises only when the dialog is opened.
+        for hook in ("_meta_line", "_rows", "_tile_counts"):
+            assert hook in vars(cls), f"{cls.__name__} does not supply {hook}"


### PR DESCRIPTION
Second of five layers where the beam and fluorescence overviews are written twice
(FIB-695, under FIB-693). **Two widgets sharing parts, not one merged widget** — the
tabs stay distinct, the pieces underneath stop being copies.

The two dialogs describe very different runs. One lists channels, a z-stack and a focus
sweep; the other a dwell time and where the grid was dragged to. They presented them
through two copies of one layout: same title, same width, same acquire/skipped chips,
same footer, same refusal when no tile is selected.

`OverviewPreflightDialog` owns all of that now. Each dialog supplies three hooks —
`_meta_line`, `_rows`, `_tile_counts` — and lays nothing out.

| | before | after |
| -- | -- | -- |
| `preflight.py` | 124 | 207 |
| `overview_confirmation_dialog.py` | 173 | 121 |
| `fm_overview_confirmation_dialog.py` | 232 | 170 |

114 lines leave the two dialogs; 94 arrive once.

## The milling dialog is deliberately not a third subclass

`CoincidenceMillingConfirmationDialog` confirms a different kind of thing and differs in
seven places: width, button text, extra chips, label width, label wrapping, **Cancel as
the default button because a mill is irreversible**, and its own empty-state message.
Seven constructor arguments carried for one caller is worse than the duplication. It
goes on importing the furniture, which is what `preflight` is for, and the module
docstring now records the reasoning so the next person does not have to re-derive it.

## Verification

Eight variants of both dialogs rendered before and after — every label, stylesheet,
width, size hint and button state identical, and **zero differing pixels**.

The variants cover each branch the base now owns: one chip and two, a dragged grid and
a centred one, a save path and none, the longest FM content (z-stack, a two-pass sweep
wrapping to two lines, an objective delta, a four-part duration), and the empty
selection that disables Start and sets its tooltip.

**That check needed fixing before it proved anything.** Hashing `QImage.bits()` over
`byteCount()` spans the per-scanline padding Qt never initialises, so it returned a
different digest on every run of *identical* code — it "found" eight changes that did
not exist. Hashing packed scanlines is stable, and then the answer came back clean.

| check | result |
| -- | -- |
| `tests/ui` + autolamella UI tests | **1756 passed** |
| rendered variants, before vs after | 8/8 pixel-identical |
| Python 3.8 parse | all touched files |

`test_the_three_preflight_dialogs_share_one_style` pinned the old import structure, which
this removes on purpose. It now asserts what is still true — all three agree on the
duration format, and the milling dialog still imports the furniture — and a new test
asserts the stronger property: both subclasses inherit the base **and** define no
`_init_ui`, since a subclass that lays itself out again would pass an `issubclass` check
while being exactly the duplication this removes.

## Not in this PR

The duration formatters. This branch was going to fold them in on the strength of a
rounding defect in `preflight.format_duration` — **which turned out not to exist**;
59.6 s renders as `1m 00s`, not `60s`, because the rounding happens before the branch
test. That claim came from reading the code rather than running it. Without it, the
formatters are unrelated tidying in a different file with a caller outside this project,
so they are FIB-701.
