### PR TITLE
[perf] Read and write the experiment through libyaml (FIB-684)

### DIFF
--- a/fibsem/_yaml.py
+++ b/fibsem/_yaml.py
@@ -1,0 +1,67 @@
+"""YAML safe-load/safe-dump backed by libyaml where it is available.
+
+PyYAML ships two implementations of the same format. The pure-Python one walks
+every node and every character of every scalar in Python -- `analyze_scalar`
+alone inspects each character to choose between plain, quoted, literal and
+folded style -- which is fine for a config file and not fine for an experiment.
+On a real 85-lamella `experiment.yaml` (1.8 MB) that is 1755 ms to read and
+798 ms to write; libyaml's C implementation does the same work in 275 ms and
+221 ms (FIB-684).
+
+Use `safe_load` and `safe_dump` from here in place of `yaml.safe_load` and
+`yaml.safe_dump` for documents big enough to notice.
+
+**This is the safe pair, and only the safe pair.** `yaml.dump` and
+`yaml.load(..., Loader=FullLoader)` accept Python objects that the safe
+implementations refuse -- an Enum, a dataclass, a numpy scalar -- by emitting
+`!!python/object:` tags. `CSafeDumper` is the C implementation of `SafeDumper`,
+so it carries the same restriction, which makes it a drop-in *here* and a
+behaviour change at any `yaml.dump` call site. Do not route those through this
+module; they are all small config files with nothing to gain.
+
+## Why swapping the implementation does not change the file
+
+`CSafeDumper` and `SafeDumper` are built from the same `SafeRepresenter` and the
+same `Resolver` -- the code deciding *what* each Python object becomes is
+identical, and only the emitter that turns an already-built node tree into text
+differs. No new types become serialisable and no type changes representation.
+
+Byte-identical output is not guaranteed by that, and is not relied on. The two
+emitters can differ in how they escape exotic material (raw U+2028, control
+characters, long non-ASCII runs) and where they fold a long escaped line. What
+is guaranteed, and tested against every experiment and protocol file in the
+repo plus a fixed-seed fuzz corpus, is that the text reloads to an equal object.
+See `tests/test_yaml_backend.py`.
+"""
+import yaml
+
+try:  # pragma: no cover - which branch runs depends on how PyYAML was built
+    from yaml import CSafeDumper as _Dumper
+    from yaml import CSafeLoader as _Loader
+
+    USING_LIBYAML = True
+except ImportError:
+    # A PyYAML built without libyaml degrades to today's behaviour -- slow, not
+    # broken. `yaml.__with_libyaml__` reports the same thing; this import is what
+    # actually decides, so it is what sets the flag.
+    from yaml import SafeDumper as _Dumper
+    from yaml import SafeLoader as _Loader
+
+    USING_LIBYAML = False
+
+SafeDumper = _Dumper
+SafeLoader = _Loader
+
+
+def safe_load(stream):
+    """`yaml.safe_load`, through libyaml where available."""
+    return yaml.load(stream, Loader=_Loader)
+
+
+def safe_dump(data, stream=None, **kwargs):
+    """`yaml.safe_dump`, through libyaml where available.
+
+    Keyword arguments are passed through unchanged, so callers keep whatever
+    `indent`, `sort_keys` and `default_flow_style` they already passed.
+    """
+    return yaml.dump(data, stream, Dumper=_Dumper, **kwargs)

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -16,6 +16,7 @@ import yaml
 from psygnal import evented
 from psygnal.containers import EventedDict, EventedList
 
+from fibsem import _yaml
 from fibsem.applications.autolamella import config as cfg
 from fibsem.constants import TIME_DISPLAY_AMPM_SHORT
 from fibsem.correlation.config import CorrelationConfig
@@ -504,17 +505,17 @@ class AutoLamellaTaskProtocol:
     @classmethod
     def load(cls, filename: str) -> 'AutoLamellaTaskProtocol':
         with open(filename, 'r') as file:
-            data = yaml.safe_load(file)
+            data = _yaml.safe_load(file)
         return cls.from_dict(data)
 
     def save(self, filename: str) -> None:
         """Save the task protocol to a YAML file."""
         with open(filename, 'w') as file:
-            yaml.safe_dump(self.to_dict(), 
-                           file,
-                           indent=4, 
-                           default_flow_style=False, 
-                           sort_keys=False)
+            _yaml.safe_dump(self.to_dict(),
+                            file,
+                            indent=4,
+                            default_flow_style=False,
+                            sort_keys=False)
 
     def get_supervision(self, task_name: str) -> bool:
         """Check if a task requires supervision."""
@@ -1241,7 +1242,7 @@ class Experiment:
         """Save the sample data to yaml file"""
 
         with open(os.path.join(self.path, "experiment.yaml"), "w") as f:
-            yaml.safe_dump(self.to_dict(), f, indent=4)
+            _yaml.safe_dump(self.to_dict(), f, indent=4)
         if save_protocol:
             self.save_protocol()
 
@@ -1265,7 +1266,7 @@ class Experiment:
         if not os.path.exists(path):
             raise FileNotFoundError(f"No file with name {path} found.")
         with open(path, "r") as f:
-            ddict = yaml.safe_load(f)
+            ddict = _yaml.safe_load(f)
 
         # create experiment from dict
         experiment = Experiment.from_dict(ddict)

--- a/scripts/check_libyaml_safe.py
+++ b/scripts/check_libyaml_safe.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+"""Is it safe to dump experiment.yaml with libyaml on THIS machine?
+
+Run this on each platform the app actually ships to -- especially the Windows
+microscope PCs, which CI (ubuntu-latest only) never covers. libyaml is a separate
+C library whose version varies by install method (pip wheel vs conda), so a clean
+result on one machine is not a clean result on another. This script answers it
+with data rather than inference.
+
+    python check_libyaml_safe.py [EXPERIMENT_DIR ...]
+
+With no arguments it searches the current directory tree for experiment.yaml and
+protocol.yaml files. Exit code 0 = safe, 1 = do not use libyaml here.
+
+It compares, for every document it can find plus 3000 generated ones:
+    D0 = safe_load(raw)
+    safe_dump(D0)   -> reload -> A
+    CSafeDumper(D0) -> reload -> B
+and requires A == B == D0. Byte differences are reported but are not failures --
+the two emitters may legally escape or wrap exotic characters differently. Only a
+change of *meaning* is a failure.
+"""
+import glob
+import os
+import random
+import string
+import sys
+
+import yaml
+
+try:
+    from yaml import CSafeDumper, CSafeLoader
+except ImportError:
+    print("libyaml is NOT available in this PyYAML build.")
+    print("Nothing to check: the code falls back to safe_dump and behaves exactly as today.")
+    sys.exit(0)
+
+
+def probe_versions() -> None:
+    print(f"python      : {sys.version.split()[0]}  ({sys.platform})")
+    print(f"pyyaml      : {yaml.__version__}   with_libyaml={yaml.__with_libyaml__}")
+    try:
+        import yaml._yaml as _y
+
+        print(f"libyaml     : {_y.get_version_string()}")
+    except Exception as exc:  # pragma: no cover - probe only
+        print(f"libyaml     : version probe failed ({exc})")
+    print()
+
+
+def check_document(label: str, d0):
+    """Return (ok, byte_identical). ok=False means the meaning changed."""
+    py_text = yaml.safe_dump(d0, indent=4)
+    c_text = yaml.dump(d0, Dumper=CSafeDumper, indent=4)
+    a = yaml.safe_load(py_text)
+    b = yaml.safe_load(c_text)
+    c = yaml.load(c_text, Loader=CSafeLoader)  # the C reader must agree too
+    ok = (a == d0) and (b == d0) and (c == d0)
+    if not ok:
+        print(f"  MISMATCH  {label}")
+        print(f"      safe_dump reloads equal : {a == d0}")
+        print(f"      libyaml   reloads equal : {b == d0}")
+        print(f"      C reader  reloads equal : {c == d0}")
+    return ok, py_text == c_text
+
+
+def check_real_files(roots):
+    patterns = ("experiment.yaml", "protocol.yaml")
+    files = []
+    for root in roots:
+        for name in patterns:
+            files += glob.glob(os.path.join(root, "**", name), recursive=True)
+    files = sorted(set(files))
+
+    print(f"[1/3] real files  ({len(files)} found under {', '.join(roots)})")
+    if not files:
+        print("      none found -- point this at an experiment directory to cover real data")
+        return True, 0
+
+    n_ok = n_bytediff = n_fail = 0
+    kb = 0.0
+    for path in files:
+        try:
+            raw = open(path, encoding="utf-8").read()
+            d0 = yaml.safe_load(raw)
+        except Exception as exc:
+            print(f"      skipped (unreadable as shipped): {path}: {exc}")
+            continue
+        if d0 is None:
+            continue
+        kb += len(raw) / 1024
+        ok, identical = check_document(path, d0)
+        if ok:
+            n_ok += 1
+            n_bytediff += not identical
+        else:
+            n_fail += 1
+
+    print(f"      round-trip identical : {n_ok}/{n_ok + n_fail}   ({kb / 1024:.1f} MB)")
+    print(f"      byte-identical out   : {n_ok - n_bytediff}/{n_ok}")
+    print(f"      MEANING CHANGED      : {n_fail}")
+    return n_fail == 0, n_ok
+
+
+def check_shared_objects():
+    """The one structural difference: SafeDumper has Serializer in its MRO and
+    CSafeDumper does not (CEmitter absorbs it). Serializer generates the anchors
+    and aliases used when two places reference one object -- which fibsem can
+    produce, because AutoLamellaTaskConfig.to_dict assigns parameters by
+    reference. Check anchors specifically."""
+    print("\n[2/3] shared objects, anchors and aliases")
+    shared_list = [1.0, 2.0, 3.0]
+    shared_dict = {"a": 1}
+    doc = {
+        "positions": [
+            {"name": f"L-{i:03d}", "milling_angles": shared_list, "cfg": shared_dict}
+            for i in range(3)
+        ]
+    }
+    ok, identical = check_document("<shared-container document>", doc)
+    b = yaml.safe_load(yaml.dump(doc, Dumper=CSafeDumper, indent=4))
+    pos = b["positions"]
+    still_shared = pos[0]["milling_angles"] is pos[1]["milling_angles"]
+    print(f"      round-trip identical : {ok}")
+    print(f"      byte-identical out   : {identical}")
+    print(f"      alias reloads shared : {still_shared}  (must match safe_dump's behaviour)")
+
+    cyc = {"k": 1}
+    cyc["self"] = cyc
+    try:
+        yaml.dump(cyc, Dumper=CSafeDumper)
+        print("      self-reference       : handled")
+    except Exception as exc:
+        ok = False
+        print(f"      self-reference       : FAILED {type(exc).__name__}: {exc}")
+    return ok
+
+
+ALPHA = string.printable[:95] + "µ°±—Ωåäö  "
+NASTY = ["yes", "no", "on", "off", "~", "null", "0123", "1e5", ".inf", "- x", " a ",
+         "a\nb", "a\tb", "", "#c", "a: b", '"q"', "\\path\\x", "---", " "]
+
+
+def _scalar(rng):
+    r = rng.random()
+    if r < 0.45:
+        return "".join(rng.choices(ALPHA, k=rng.choice([0, 1, 2, 5, 20, 80, 200])))
+    if r < 0.60:
+        return rng.choice([True, False, None])
+    if r < 0.78:
+        return rng.choice([0, -1, 2 ** 62, -(2 ** 62), rng.randint(-10 ** 9, 10 ** 9)])
+    if r < 0.95:
+        return rng.choice([0.0, -0.0, 1e-30, 1e30, rng.uniform(-1e6, 1e6)])
+    return rng.choice(NASTY)
+
+
+def _doc(rng, depth=0):
+    if depth > 3 or rng.random() < 0.3:
+        return _scalar(rng)
+    if rng.random() < 0.5:
+        return {str(_scalar(rng))[:40] or "k": _doc(rng, depth + 1) for _ in range(rng.randint(0, 6))}
+    return [_doc(rng, depth + 1) for _ in range(rng.randint(0, 6))]
+
+
+def check_fuzz(n=3000):
+    print(f"\n[3/3] fuzz  ({n} generated documents over adversarial scalars)")
+    rng = random.Random(20260818)  # fixed seed: same corpus on every machine
+    n_fail = n_bytediff = 0
+    for i in range(n):
+        d0 = _doc(rng)
+        try:
+            ok, identical = check_document(f"<fuzz #{i}>", d0)
+        except Exception as exc:
+            print(f"  ERROR on fuzz #{i}: {type(exc).__name__}: {exc}")
+            n_fail += 1
+            continue
+        n_fail += not ok
+        n_bytediff += not identical
+    print(f"      byte-different out   : {n_bytediff}/{n}  (expected, not a failure)")
+    print(f"      MEANING CHANGED      : {n_fail}/{n}")
+    return n_fail == 0
+
+
+def main() -> int:
+    probe_versions()
+    roots = sys.argv[1:] or [os.getcwd()]
+    ok_real, n_real = check_real_files(roots)
+    ok_shared = check_shared_objects()
+    ok_fuzz = check_fuzz()
+
+    print("\n" + "=" * 62)
+    if ok_real and ok_shared and ok_fuzz:
+        print("VERDICT: safe to dump with libyaml on this machine.")
+        if n_real == 0:
+            print("         NOTE: no real experiment files were checked. Re-run with a")
+            print("         path to an experiment directory to cover your own data.")
+        return 0
+    print("VERDICT: DO NOT use libyaml here -- a document changed meaning.")
+    print("         Keep yaml.safe_dump on this platform and report the mismatch above.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -69,7 +69,7 @@ class TestRealFiles:
 
         mismatched = []
         for path in files:
-            raw = Path(path).read_text()
+            raw = Path(path).read_text(encoding="utf-8")
             try:
                 original = yaml.safe_load(raw)
             except yaml.YAMLError:
@@ -92,7 +92,7 @@ class TestRealFiles:
         with open(path, "w") as handle:
             _yaml.safe_dump(document, handle, indent=4)
 
-        assert yaml.safe_load(path.read_text()) == document
+        assert yaml.safe_load(path.read_text(encoding="utf-8")) == document
 
 
 class TestAwkwardDocuments:
@@ -308,7 +308,7 @@ class TestItIsTheSafePairOnly:
         here later would silently keep the pure-Python cost."""
         import ast
 
-        source = (REPO_ROOT / "fibsem" / "applications" / "autolamella" / "structures.py").read_text()
+        source = (REPO_ROOT / "fibsem" / "applications" / "autolamella" / "structures.py").read_text(encoding="utf-8")
         direct = [
             node.lineno
             for node in ast.walk(ast.parse(source))

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -1,0 +1,325 @@
+"""Reading and writing experiments through libyaml means the same thing as before.
+
+`fibsem._yaml` swaps PyYAML's pure-Python safe loader and dumper for libyaml's C
+implementations, which read a real 85-lamella experiment in 604 ms instead of 1958 ms
+and write it in 311 ms instead of 798 ms (FIB-684). The file everything lives in is not
+somewhere to take that on faith.
+
+The argument that it is safe is structural: `CSafeDumper` and `SafeDumper` are built
+from the same `SafeRepresenter` and `Resolver`, so the code deciding *what* each Python
+object becomes is identical and only the emitter differs. These tests are the empirical
+half of it.
+
+**Equal objects, not equal bytes.** The two emitters may legitimately differ on how they
+escape exotic material and where they fold a long escaped line, and the fuzz corpus below
+provokes exactly that -- a third of it comes out byte-different. What must never differ
+is what the text means when it is read back, so that is what is asserted.
+
+The one thing these tests cannot cover is the platform. libyaml is a separate C library
+whose version varies by install method, and CI is `ubuntu-latest` only, so a green run
+here says nothing about the Windows PCs the microscopes run on. That gate is a manual
+run of `check_libyaml_safe.py` on one of them, recorded on FIB-684.
+"""
+import glob
+import importlib
+import os
+import random
+import string
+from pathlib import Path
+
+import pytest
+import yaml
+
+from fibsem import _yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def both_ways(document):
+    """(via stock PyYAML, via the backend) for one Python document."""
+    return (
+        yaml.safe_load(yaml.safe_dump(document, indent=4)),
+        _yaml.safe_load(_yaml.safe_dump(document, indent=4)),
+    )
+
+
+class TestRealFiles:
+    """Every real YAML document in the tree.
+
+    Deliberately every `.yaml`, not just `experiment.yaml`: experiments live under
+    `fibsem/applications/autolamella/log/`, which is gitignored, so a checkout has none
+    and a corpus limited to them would **skip in CI** and quietly assert nothing. What
+    CI does have is the 29 tracked protocol, legacy-protocol and microscope-configuration
+    files, which are the same hand-written YAML by hand-edited hands. On a developer's
+    machine this picks up their real experiments as well.
+    """
+
+    @staticmethod
+    def _yaml_files():
+        found = glob.glob(str(REPO_ROOT / "**" / "*.yaml"), recursive=True)
+        return sorted(p for p in found if os.sep + ".git" + os.sep not in p)
+
+    def test_the_corpus_is_not_empty(self):
+        """The tracked protocols guarantee this, so an empty corpus means the glob
+        broke rather than that there is nothing to check."""
+        assert len(self._yaml_files()) >= 10
+
+    def test_they_round_trip_to_the_same_object(self):
+        files = self._yaml_files()
+
+        mismatched = []
+        for path in files:
+            raw = Path(path).read_text()
+            try:
+                original = yaml.safe_load(raw)
+            except yaml.YAMLError:
+                continue  # not parseable as shipped; not this change's business
+            if original is None:
+                continue
+            if _yaml.safe_load(raw) != original:
+                mismatched.append((path, "read"))
+                continue
+            if yaml.safe_load(_yaml.safe_dump(original, indent=4)) != original:
+                mismatched.append((path, "write"))
+
+        assert mismatched == [], f"{len(mismatched)} file(s) changed meaning: {mismatched[:3]}"
+
+    def test_what_the_backend_writes_is_readable_by_stock_pyyaml(self, tmp_path):
+        """An experiment written on one machine is opened on another, by whatever
+        PyYAML that machine has -- possibly one without libyaml at all."""
+        document = {"positions": [{"petname": "01-test", "task_config": {"Mill": {"x": 1.5}}}]}
+        path = tmp_path / "experiment.yaml"
+        with open(path, "w") as handle:
+            _yaml.safe_dump(document, handle, indent=4)
+
+        assert yaml.safe_load(path.read_text()) == document
+
+
+class TestAwkwardDocuments:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("yes", id="bool-looking string"),
+            pytest.param("~", id="null-looking string"),
+            pytest.param("0123", id="octal-looking string"),
+            pytest.param("12:30", id="sexagesimal-looking string"),
+            pytest.param("1.2.3", id="version string"),
+            pytest.param("", id="empty string"),
+            pytest.param(" padded ", id="leading and trailing space"),
+            pytest.param("a\nb", id="newline"),
+            pytest.param("a\tb", id="tab"),
+            pytest.param("- x", id="leading dash"),
+            pytest.param("k: v", id="embedded colon"),
+            pytest.param("# c", id="leading hash"),
+            pytest.param("µm ± 0.5 — Ω", id="unicode"),
+            pytest.param(-0.0, id="negative zero"),
+            pytest.param(2 ** 63, id="big int"),
+            pytest.param(1e-30, id="tiny float"),
+            pytest.param(None, id="none"),
+            pytest.param(True, id="bool"),
+        ],
+    )
+    def test_scalars_survive_identically(self, value):
+        stock, backend = both_ways({"k": value})
+
+        assert stock == backend == {"k": value}
+
+    def test_a_shared_container_still_reloads_as_one_object(self):
+        """`AutoLamellaTaskConfig.to_dict` assigns parameters by reference, so two
+        lamellae can reach one list and the emitter writes an anchor and an alias.
+        Anchors are generated by `Serializer`, which the C emitter absorbs -- the one
+        place the two implementations are not literally the same class."""
+        shared = [1.0, 2.0, 3.0]
+        document = {"positions": [{"angles": shared}, {"angles": shared}]}
+
+        stock, backend = both_ways(document)
+
+        assert stock == backend == document
+        for label, result in (("stock", stock), ("backend", backend)):
+            first, second = result["positions"]
+            assert first["angles"] is second["angles"], (
+                f"{label} reloaded the alias as two separate lists"
+            )
+
+    def test_a_self_reference_is_handled(self):
+        document = {"k": 1}
+        document["self"] = document
+
+        assert _yaml.safe_dump(document) == yaml.safe_dump(document)
+
+
+class TestFuzz:
+    """Random documents over adversarial material. Fixed seed, so a failure here is
+    reproducible on any machine rather than a story about one unlucky run."""
+
+    ALPHA = string.printable[:95] + "µ°±—Ωåäö  "
+    NASTY = ["yes", "no", "on", "off", "~", "null", "0123", "1e5", ".inf",
+             "- x", " a ", "a\nb", "a\tb", "", "#c", "a: b", '"q"', "---"]
+
+    @classmethod
+    def _scalar(cls, rng):
+        roll = rng.random()
+        if roll < 0.45:
+            return "".join(rng.choices(cls.ALPHA, k=rng.choice([0, 1, 2, 5, 20, 80])))
+        if roll < 0.60:
+            return rng.choice([True, False, None])
+        if roll < 0.78:
+            return rng.choice([0, -1, 2 ** 62, -(2 ** 62), rng.randint(-10 ** 9, 10 ** 9)])
+        if roll < 0.95:
+            return rng.choice([0.0, -0.0, 1e-30, 1e30, rng.uniform(-1e6, 1e6)])
+        return rng.choice(cls.NASTY)
+
+    @classmethod
+    def _document(cls, rng, depth=0):
+        if depth > 3 or rng.random() < 0.3:
+            return cls._scalar(rng)
+        if rng.random() < 0.5:
+            return {str(cls._scalar(rng))[:40] or "k": cls._document(rng, depth + 1)
+                    for _ in range(rng.randint(0, 5))}
+        return [cls._document(rng, depth + 1) for _ in range(rng.randint(0, 5))]
+
+    def test_meaning_never_changes(self):
+        rng = random.Random(20260818)
+        differed_in_bytes = 0
+        for i in range(400):
+            document = self._document(rng)
+            stock_text = yaml.safe_dump(document, indent=4)
+            backend_text = _yaml.safe_dump(document, indent=4)
+            differed_in_bytes += stock_text != backend_text
+
+            assert yaml.safe_load(backend_text) == document, f"fuzz #{i}: backend write"
+            assert _yaml.safe_load(stock_text) == document, f"fuzz #{i}: backend read"
+
+        # Not an assertion about the number, a check that the corpus is actually
+        # provoking the disagreement this file exists to bound. If it ever drops to
+        # zero the fuzz has gone toothless and the equal-objects claim is untested.
+        assert differed_in_bytes > 0, "the corpus no longer produces any byte differences"
+
+
+class TestTheFallback:
+    """A PyYAML built without libyaml must degrade to slow, not to broken."""
+
+    @pytest.fixture
+    def without_libyaml(self, monkeypatch):
+        monkeypatch.delattr(yaml, "CSafeDumper", raising=False)
+        monkeypatch.delattr(yaml, "CSafeLoader", raising=False)
+        importlib.reload(_yaml)
+        yield _yaml
+        monkeypatch.undo()
+        importlib.reload(_yaml)  # restore the C implementations for everything after
+
+    def test_it_falls_back_to_the_python_implementation(self, without_libyaml):
+        assert without_libyaml.USING_LIBYAML is False
+        assert without_libyaml.SafeDumper is yaml.SafeDumper
+        assert without_libyaml.SafeLoader is yaml.SafeLoader
+
+    def test_it_still_reads_and_writes(self, without_libyaml):
+        document = {"positions": [{"petname": "01-test", "angles": [1.0, 2.0]}]}
+
+        assert without_libyaml.safe_load(without_libyaml.safe_dump(document)) == document
+
+    def test_the_c_implementation_is_restored_afterwards(self):
+        """Guards the fixture itself: a leaked reload would silently make every later
+        test in the session exercise the slow path instead of the shipped one."""
+        assert _yaml.USING_LIBYAML == yaml.__with_libyaml__
+
+
+class TestItActuallyUsesTheConfiguredImplementation:
+    """The awkward corner of this change: the C and Python implementations are meant
+    to be behaviourally identical, so *no* correctness test can tell them apart. A
+    wrapper that quietly called stock `yaml.safe_load` would pass every other test in
+    this file and simply be slow -- which is the one thing the change exists to fix,
+    and the one thing nobody would notice.
+
+    So these are white-box on purpose: they check the configured loader and dumper are
+    the ones actually used, because the observable difference is only speed.
+    """
+
+    def test_safe_load_uses_the_configured_loader(self, monkeypatch):
+        used = []
+
+        class SpyLoader(_yaml.SafeLoader):
+            def __init__(self, stream):
+                used.append(True)
+                super().__init__(stream)
+
+        monkeypatch.setattr(_yaml, "_Loader", SpyLoader)
+
+        assert _yaml.safe_load("a: 1") == {"a": 1}
+        assert used, "safe_load bypassed the configured loader"
+
+    def test_safe_dump_uses_the_configured_dumper(self, monkeypatch):
+        used = []
+
+        class SpyDumper(_yaml.SafeDumper):
+            def __init__(self, *args, **kwargs):
+                used.append(True)
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(_yaml, "_Dumper", SpyDumper)
+
+        assert _yaml.safe_dump({"a": 1}).strip() == "a: 1"
+        assert used, "safe_dump bypassed the configured dumper"
+
+
+class TestItPassesCallerOptionsThrough:
+    """`safe_dump` is a wrapper, and a wrapper that quietly drops its keyword
+    arguments still round-trips to an equal object -- so none of the equivalence
+    tests above would notice. `AutoLamellaTaskProtocol.save` passes
+    `sort_keys=False` and `default_flow_style=False`, and losing those reorders and
+    reflows every key in `protocol.yaml`: a large, confusing, entirely silent diff.
+    """
+
+    def test_sort_keys_is_honoured(self):
+        document = {"b": 1, "a": 2}
+
+        assert _yaml.safe_dump(document, sort_keys=False).startswith("b:")
+        assert _yaml.safe_dump(document).startswith("a:")  # PyYAML sorts by default
+
+    def test_indent_is_honoured(self):
+        document = {"outer": {"inner": 1}}
+
+        assert "\n    inner:" in _yaml.safe_dump(document, indent=4)
+        assert "\n  inner:" in _yaml.safe_dump(document, indent=2)
+
+    def test_default_flow_style_is_honoured(self):
+        document = {"outer": {"inner": 1}}
+
+        assert "{" in _yaml.safe_dump(document, default_flow_style=True)
+        assert "{" not in _yaml.safe_dump(document, default_flow_style=False)
+
+
+class TestItIsTheSafePairOnly:
+    def test_the_backend_refuses_what_safe_dump_refuses(self):
+        """`CSafeDumper` carries `SafeDumper`'s restriction, which is why it is a
+        drop-in here and a behaviour change at any `yaml.dump` call site."""
+        import enum
+
+        class Beam(enum.Enum):
+            ION = 1
+
+        with pytest.raises(yaml.YAMLError):
+            yaml.safe_dump({"beam": Beam.ION})
+        with pytest.raises(yaml.YAMLError):
+            _yaml.safe_dump({"beam": Beam.ION})
+
+    def test_autolamella_structures_routes_through_the_backend(self):
+        """The four call sites this change exists for. A new `yaml.safe_dump` added
+        here later would silently keep the pure-Python cost."""
+        import ast
+
+        source = (REPO_ROOT / "fibsem" / "applications" / "autolamella" / "structures.py").read_text()
+        direct = [
+            node.lineno
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"safe_load", "safe_dump"}
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "yaml"
+        ]
+
+        assert direct == [], (
+            f"structures.py calls yaml.safe_* directly at lines {direct}; "
+            "use fibsem._yaml so the experiment goes through libyaml"
+        )


### PR DESCRIPTION
Closes FIB-684. Fourth of the [Performance](https://linear.app/fibsemos/project/performance-40569e970fea) project's issues, after #428, #434 and #435.

> [!NOTE]
> **The Windows gate below is closed.** This branch is rebased onto #443 (Windows CI, now on `main`), and the run on the rebased branch is green on `windows-latest` under both 3.8 and 3.13 — including proof that libyaml was actually in use there. See *The gate, and how CI closed it* below.

## What it does

PyYAML ships two implementations of the same format. The pure-Python one walks every node and every character of every scalar in Python — `analyze_scalar` alone inspects each character to choose between plain, quoted, literal and folded style. Fine for a config file; not fine for a 1.8 MB experiment.

Measured on a real 85-lamella `experiment.yaml`, through `Experiment.load` / `Experiment.save`:

| | before | after | |
| --- | --- | --- | --- |
| `load` | 1958 ms | **604 ms** | 3.2× |
| `save` | 798 ms | **311 ms** | 2.6× |

Load is 3.2× rather than the parser's own 6.4× because `from_dict` object construction is now the floor at ~330 ms — the parse is no longer the larger half.

`fibsem/_yaml.py` resolves the implementation once at import, with a fallback to the pure-Python one when PyYAML was built without libyaml (slow, not broken). Four call sites in `autolamella/structures.py` use it: the experiment and the task protocol, each way.

## Why the scope is narrow

There are **~40 yaml calls** in `fibsem/`, and most **must not** change. `yaml.dump` and `yaml.load(..., Loader=FullLoader)` accept Python objects that the safe implementations refuse — an Enum, a dataclass, a numpy scalar — by emitting `!!python/object:` tags:

```
dump      -> beam: !!python/object/apply:__main__.Beam [1]
safe_dump -> RepresenterError
```

`CSafeDumper` is the C implementation of `SafeDumper` and carries the same restriction. That is precisely what makes it a drop-in at a `safe_dump` site and a **behaviour change** anywhere else — a careless sweep would start raising `RepresenterError` on data that works today, in user preferences and hook config. Those ten sites are named in `_yaml.py`'s docstring, and they are all small config files with nothing to gain.

## Review notes

**Equal objects are asserted, not equal bytes.** The two emitters legitimately differ on how they escape exotic material (raw U+2028, control characters, long non-ASCII runs) and where they fold a long escaped line — a third of the fuzz corpus comes out byte-different. What is pinned is that the text reloads to an equal object.

**The corpus is every `.yaml` in the tree, not just experiments.** Experiments live under `fibsem/applications/autolamella/log/`, which is gitignored — so a corpus limited to `experiment.yaml` would find nothing in CI and **skip while appearing to pass**. I hit exactly that and widened it; CI now exercises the 29 tracked protocol, legacy-protocol and microscope-configuration files, and a developer's machine picks up their real experiments too. `test_the_corpus_is_not_empty` guards the glob itself.

**Two tests are white-box on purpose.** The implementations are meant to be behaviourally identical, so *no* correctness test can distinguish them: a wrapper that quietly called stock `yaml.safe_load` would pass every other test here and simply be slow — the one thing this change exists to fix. Those two assert the configured loader and dumper are the ones actually used.

## The gate, and how CI closed it

libyaml is a **separate C library** whose version varies by install method — the pip wheel and the conda package do not bundle the same one. When this PR was opened, CI was `ubuntu-latest` only, so a green run said nothing about the Windows PCs the microscopes run on. That was the blocker.

#443 added `windows-latest` on 3.8 and 3.13. Those jobs install via pip, which is where PyYAML comes from even inside a conda environment, so they exercise the same wheel a microscope gets: `pyyaml-6.0.3-cp313-cp313-win_amd64.whl` — a binary wheel, not the pure-Python `py3-none-any`.

**And the suite proves libyaml was live rather than silently falling back.** Not by design; `test_meaning_never_changes` compares stock `yaml.safe_dump` against `_yaml.safe_dump` over 400 fuzz documents and ends with:

```python
assert differed_in_bytes > 0, "the corpus no longer produces any byte differences"
```

That was written as a toothlessness guard, and it doubles as a backend detector. Stock `yaml.safe_dump` hardcodes the pure-Python `SafeDumper`; without libyaml, `_yaml.safe_dump` resolves to that *same dumper*, every document comes out byte-identical, and the assertion fails. Verified locally rather than assumed — same corpus, same seed:

| | `USING_LIBYAML` | `differed_in_bytes` | assertion |
| --- | --- | --- | --- |
| as shipped | `True` | 231 | passes |
| `CSafeDumper` deleted | `False` | **0** | **fails** |

The file carries no `skipif` or `importorskip`, so the test cannot have been skipped. Both Windows jobs report `3483 passed, 103 skipped, 1 xfailed` with zero failures — so libyaml was active on Windows 3.8 and 3.13.

**What CI still does not cover:** a PyYAML installed from conda-forge rather than pip, which bundles a different libyaml build. `scripts/check_libyaml_safe.py` remains for that case — it prints the pyyaml/libyaml versions, checks every real file plus anchors plus a fixed-seed fuzz, and exits 0 (safe) or 1:

```
python scripts/check_libyaml_safe.py <path-to-an-experiment-dir>
```

Belt-and-braces now rather than a blocker.

## Verification

34 tests in `tests/test_yaml_backend.py`. **Full repo suite: 5229 passed, 35 skipped, zero failures.**

Mutation-tested — all six caught: the fallback branch reporting the wrong flag, `safe_dump` dropping caller kwargs, using the *unsafe* `CDumper`, a call site reverting to bare `yaml.safe_dump`, and each of `safe_load`/`safe_dump` bypassing the configured implementation.

Two of those only became caught after I added tests for them: nothing initially pinned that `indent`/`sort_keys`/`default_flow_style` reach the dumper (losing `sort_keys=False` would silently reorder every key in `protocol.yaml`), and nothing pinned that the C implementations were used at all rather than the stock ones.


---

## Rebase note

Rebased onto `47d38ae9` (#443, Windows CI). One fix was needed and it is a good advert for that PR: `tests/test_yaml_backend.py` was written before #443 established the `encoding="utf-8"` convention, and its three bare `read_text()` calls were the only ones left in the entire test tree. One of them reads `structures.py`, which contains non-ASCII — so it would have failed on Windows CI immediately. Fixed in the rebase.

Full suite on the rebased branch: **5295 passed, 24 skipped, zero failures.**
