### PR TITLE
[test] Run CI on Windows as well as Linux (FIB-704)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,11 +12,22 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        # Linux on every supported version, Windows on the ends of the range.
+        # The microscopes all run Windows, so every platform-specific claim in the
+        # codebase was previously untested on the platform that matters (FIB-704) --
+        # but six versions x two platforms is a lot of wall-clock for a suite that
+        # takes ~7 minutes, and the oldest and newest catch what the middle would.
+        os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - os: windows-latest
+            python-version: "3.8"
+          - os: windows-latest
+            python-version: "3.13"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,8 +19,8 @@ jobs:
         # Linux on every supported version, Windows on the ends of the range.
         # The microscopes all run Windows, so every platform-specific claim in the
         # codebase was previously untested on the platform that matters (FIB-704) --
-        # but six versions x two platforms is a lot of wall-clock for a suite that
-        # takes ~7 minutes, and the oldest and newest catch what the middle would.
+        # but twelve jobs is more wall-clock than the coverage is worth, and the
+        # oldest and newest catch what the middle would.
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:

--- a/tests/autolamella/test_example_scripts.py
+++ b/tests/autolamella/test_example_scripts.py
@@ -93,7 +93,7 @@ def test_export_summary_writes_a_csv_with_a_row_per_lamella(experiment):
     assert isinstance(result.value, Path) and result.value.exists()
     assert result.value.parent == Path(experiment.path)
     # header + one row per lamella
-    assert len(result.value.read_text().strip().splitlines()) == len(experiment.positions) + 1
+    assert len(result.value.read_text(encoding="utf-8").strip().splitlines()) == len(experiment.positions) + 1
 
 
 def test_export_summary_does_not_declare_itself_a_writer(experiment):

--- a/tests/autolamella/test_id_serialisation.py
+++ b/tests/autolamella/test_id_serialisation.py
@@ -29,7 +29,7 @@ def test_the_experiment_id_is_still_written_under_underscore_id(tmp_path: Path) 
     os.makedirs(exp.path, exist_ok=True)
     exp.save()
 
-    written = yaml.safe_load((Path(exp.path) / "experiment.yaml").read_text())
+    written = yaml.safe_load((Path(exp.path) / "experiment.yaml").read_text(encoding="utf-8"))
 
     assert written["_id"] == exp.id
     assert "id" not in written, "the key moved -- existing experiments would lose their id"
@@ -43,7 +43,7 @@ def test_an_experiment_written_before_the_rename_still_loads(tmp_path: Path) -> 
     exp.save()
 
     path = Path(exp.path) / "experiment.yaml"
-    on_disk = yaml.safe_load(path.read_text())
+    on_disk = yaml.safe_load(path.read_text(encoding="utf-8"))
     original_id = on_disk["_id"]
 
     reloaded = Experiment.load(path)

--- a/tests/autolamella/test_report_sections.py
+++ b/tests/autolamella/test_report_sections.py
@@ -37,20 +37,20 @@ _WIDGET = _FIBSEM / "applications" / "autolamella" / "ui" / "autolamella_generat
 
 def _report_sections() -> set:
     """The section names generate_report2 builds its defaults from."""
-    block = _REPORTING.read_text().split("REPORT_SECTIONS = (", 1)[1].split(")", 1)[0]
+    block = _REPORTING.read_text(encoding="utf-8").split("REPORT_SECTIONS = (", 1)[1].split(")", 1)[0]
     return set(re.findall(r'"(\w+)"', block))
 
 
 def _widget_section_keys() -> set:
     """The section keys the report dialog emits."""
-    src = _WIDGET.read_text()
+    src = _WIDGET.read_text(encoding="utf-8")
     block = src.split("def _get_sections_config", 1)[1].split("def ", 1)[0]
     return set(re.findall(r'"(\w+)":\s*self\.checkbox', block))
 
 
 def _workflow_rename_keys() -> set:
     """The columns format_pretty_dataframes renames on the workflow frame."""
-    block = _DATA.read_text().split("# WORKFLOW", 1)[1].split("# TASK HISTORY", 1)[0]
+    block = _DATA.read_text(encoding="utf-8").split("# WORKFLOW", 1)[1].split("# TASK HISTORY", 1)[0]
     return set(re.findall(r'"(\w+)":\s*"', block))
 
 

--- a/tests/autolamella/test_stop_task.py
+++ b/tests/autolamella/test_stop_task.py
@@ -208,8 +208,8 @@ def test_both_stop_paths_interrupt_the_hardware_the_same_way():
     import fibsem
 
     ui_dir = Path(fibsem.__path__[0]) / "applications" / "autolamella" / "ui"
-    autolamella_ui = (ui_dir / "AutoLamellaUI.py").read_text()
-    main_ui = (ui_dir / "AutoLamellaMainUI.py").read_text()
+    autolamella_ui = (ui_dir / "AutoLamellaUI.py").read_text(encoding="utf-8")
+    main_ui = (ui_dir / "AutoLamellaMainUI.py").read_text(encoding="utf-8")
 
     def body(source: str, name: str) -> str:
         """The text of one method, up to the next def at the same indent."""

--- a/tests/autolamella/test_structures.py
+++ b/tests/autolamella/test_structures.py
@@ -508,7 +508,7 @@ def test_configure_logging_sends_output_to_the_experiment_logfile(tmp_path):
             handler.flush()
 
         assert Path(logfile) == Path(exp.path) / "logfile.log"
-        assert "from a standalone script" in Path(logfile).read_text()
+        assert "from a standalone script" in Path(logfile).read_text(encoding="utf-8")
     finally:
         for handler in list(root.handlers):
             if handler not in saved:

--- a/tests/autolamella/test_thumbnail_atomic_write.py
+++ b/tests/autolamella/test_thumbnail_atomic_write.py
@@ -19,6 +19,7 @@ raising (FIB-329).
 """
 
 import os
+import sys
 import threading
 
 import numpy as np
@@ -41,11 +42,27 @@ def image(value: int = 128) -> FibsemImage:
 
 
 class TestTheWriteIsAtomic:
+    @pytest.mark.xfail(
+        sys.platform == "win32",
+        reason=(
+            "FIB-705: os.replace refuses to rename over a destination another handle "
+            "has open, so on Windows this raises PermissionError [WinError 5] rather "
+            "than replacing the file. Not xfail(strict) deliberately -- fixing the "
+            "write should make this XPASS and say so, rather than fail for passing."
+        ),
+    )
     def test_the_final_file_never_exists_partly_written(self, lamella):
         """The property that fixes it: readers only ever see a complete file.
 
         Checked by watching the destination while a save runs — every version of it that
         exists at all must open cleanly.
+
+        **Windows does not have this property today (FIB-705).** POSIX `rename(2)`
+        replaces a destination whoever has it open; Windows refuses unless every open
+        handle asked for `FILE_SHARE_DELETE`, which `open()` does not. The reader thread
+        below is exactly the lamella card, so the rename is refused and the card keeps
+        showing the previous thumbnail -- the symptom FIB-602 was filed for, still live
+        on the platform every microscope runs.
         """
         from PIL import Image
 

--- a/tests/autolamella/test_workflow_ui_call_signatures.py
+++ b/tests/autolamella/test_workflow_ui_call_signatures.py
@@ -38,7 +38,7 @@ def _call_sites() -> List[Tuple[Path, int, str, ast.Call]]:
     sites = []
     for path in sorted(_TASKS_DIR.rglob("*.py")):
         try:
-            tree = ast.parse(path.read_text())
+            tree = ast.parse(path.read_text(encoding="utf-8"))
         except SyntaxError:  # pragma: no cover - a broken file is another test's problem
             continue
         for node in ast.walk(tree):

--- a/tests/correlation/test_correlation_data_integrity.py
+++ b/tests/correlation/test_correlation_data_integrity.py
@@ -231,7 +231,7 @@ def test_adopting_a_state_without_a_result_discards_the_old_one(qapp, tmp_path):
     w._adopt_state(CorrelationState(input_data=_inputs(x=5.0), result=None))
     assert w._result is None
 
-    saved = json.loads((tmp_path / "correlation.json").read_text())
+    saved = json.loads((tmp_path / "correlation.json").read_text(encoding="utf-8"))
     assert saved["result"] is None  # not re-saved against the new coordinates
 
 

--- a/tests/correlation/test_correlation_run_folder.py
+++ b/tests/correlation/test_correlation_run_folder.py
@@ -68,7 +68,7 @@ def _result(inp=None):
 
 
 def _saved(run_dir):
-    return json.loads((run_dir / CORRELATION_JSON).read_text())
+    return json.loads((run_dir / CORRELATION_JSON).read_text(encoding="utf-8"))
 
 
 def _saved_fib_x(run_dir):

--- a/tests/correlation/test_correlation_tab_widget.py
+++ b/tests/correlation/test_correlation_tab_widget.py
@@ -2064,14 +2064,14 @@ def test_auto_save_writes_one_correlation_json(qapp, tmp_path):
     assert not (tmp_path / "correlation_data.json").exists()
     assert not (tmp_path / "correlation_result.json").exists()
 
-    raw = json.loads(single.read_text())
+    raw = json.loads(single.read_text(encoding="utf-8"))
     assert raw["version"] == 1
     assert raw["result"] is None
     assert raw["input_data"]["fib_coordinates"][0]["point"]["x"] == 3.0
 
     # a run adds the result to the same file
     w._on_result_ready(_result_from(_input(fib=(3.0, 4.0))))
-    raw = json.loads(single.read_text())
+    raw = json.loads(single.read_text(encoding="utf-8"))
     assert raw["result"] is not None
     assert "computed_from" in raw["result"]  # the snapshot, renamed
 
@@ -2100,7 +2100,7 @@ def test_load_correlation_flags_a_stale_consolidated_file(qapp, tmp_path):
     w.set_data(_input(fib=(9.0, 9.0)))  # ...then the points move
     w.data_changed.emit(w.data)         # rewrite: new points, stale result
 
-    raw = json.loads((tmp_path / "correlation.json").read_text())
+    raw = json.loads((tmp_path / "correlation.json").read_text(encoding="utf-8"))
     assert raw["input_data"]["fib_coordinates"][0]["point"]["x"] == 9.0
     assert raw["result"]["computed_from"]["fib_coordinates"][0]["point"]["x"] == 1.0
 

--- a/tests/fm/test_active_channel.py
+++ b/tests/fm/test_active_channel.py
@@ -287,7 +287,7 @@ class TestTheRealDriverMatches:
 
         import fibsem.fm as fm_package
 
-        return (Path(fm_package.__file__).parent / "autoscript.py").read_text()
+        return (Path(fm_package.__file__).parent / "autoscript.py").read_text(encoding="utf-8")
 
     @staticmethod
     def _functions(source: str):

--- a/tests/fm/test_channel_fast_path.py
+++ b/tests/fm/test_channel_fast_path.py
@@ -200,7 +200,7 @@ class TestBothDriversHaveIt:
             ("fm/autoscript.py", "ThermoFisherFluorescenceMicroscope"),
             ("microscopes/simulator.py", "SimulatedFluorescenceMicroscope"),
         ):
-            tree = ast.parse((root / module).read_text())
+            tree = ast.parse((root / module).read_text(encoding="utf-8"))
             cls = next(
                 n for n in ast.walk(tree)
                 if isinstance(n, ast.ClassDef) and n.name == cls_name

--- a/tests/fm/test_objective_signal.py
+++ b/tests/fm/test_objective_signal.py
@@ -170,7 +170,7 @@ class TestEveryDriverAnnounces:
         """Every `ObjectiveLens` implementation, by qualified name."""
         found = {}
         for module in ("fm/microscope.py", "fm/autoscript.py", "fm/odemis.py"):
-            source = (Path(fibsem.__file__).parent / module).read_text()
+            source = (Path(fibsem.__file__).parent / module).read_text(encoding="utf-8")
             for node in ast.walk(ast.parse(source)):
                 if isinstance(node, ast.ClassDef) and "Objective" in node.name:
                     found[f"{module}:{node.name}"] = node
@@ -232,7 +232,7 @@ class TestTheGuardsStillReadTheDevice:
 
     @staticmethod
     def _method(class_name: str, method_name: str) -> ast.FunctionDef:
-        source = (Path(fibsem.__file__).parent / "microscope.py").read_text()
+        source = (Path(fibsem.__file__).parent / "microscope.py").read_text(encoding="utf-8")
         cls = next(
             node
             for node in ast.walk(ast.parse(source))

--- a/tests/fm/test_routines_claim_channel.py
+++ b/tests/fm/test_routines_claim_channel.py
@@ -168,7 +168,7 @@ class TestTheClaimIsStructural:
 
         import fibsem
 
-        tree = ast.parse((Path(fibsem.__file__).parent / module).read_text())
+        tree = ast.parse((Path(fibsem.__file__).parent / module).read_text(encoding="utf-8"))
         fn = next(
             n for n in ast.walk(tree)
             if isinstance(n, ast.FunctionDef) and n.name == function

--- a/tests/test_autofocus_mode.py
+++ b/tests/test_autofocus_mode.py
@@ -115,7 +115,7 @@ def test_the_shipped_fm_configuration_still_parses():
     from fibsem.fm.structures import OverviewParameters
 
     path = Path(fibsem.__file__).parent / "config" / "fm" / "fm-configuration-default.yaml"
-    config = yaml.safe_load(path.read_text())
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
 
     params = OverviewParameters.from_dict(config["overview_parameters"])
     assert params.autofocus_mode is AutoFocusMode.ONCE

--- a/tests/test_image_metadata_user.py
+++ b/tests/test_image_metadata_user.py
@@ -5,6 +5,7 @@ worse than producing nothing: a reader cannot tell a real user from a placeholde
 """
 
 import getpass
+import sys
 
 import numpy as np
 import pytest
@@ -20,8 +21,19 @@ from fibsem.structures import (
 
 def test_from_environment_records_the_real_username(monkeypatch) -> None:
     """USERNAME is Windows-only, so reading it directly left Linux and macOS with
-    the literal string "username" -- including every Odemis/METEOR site. FIB-447."""
-    monkeypatch.delenv("USERNAME", raising=False)
+    the literal string "username" -- including every Odemis/METEOR site. FIB-447.
+
+    Removing USERNAME is the trap that catches that, and it can only be set where
+    `getpass` has somewhere else to look. On POSIX it falls back to `pwd`, so the
+    name still resolves and any code reading the variable directly is caught. On
+    Windows USERNAME is getpass's *only* source -- there is no `pwd` module -- so
+    removing it makes `getpass.getuser()` itself raise `OSError`, breaking the
+    reference the assertion compares against rather than the code under test.
+    The weaker check still holds there: `from_environment` must agree with
+    `getpass`, whatever `getpass` says.
+    """
+    if sys.platform != "win32":
+        monkeypatch.delenv("USERNAME", raising=False)
 
     user = FibsemUser.from_environment()
 

--- a/tests/test_imaging_channel_lock.py
+++ b/tests/test_imaging_channel_lock.py
@@ -30,7 +30,7 @@ import fibsem
 
 def _thermo_class() -> ast.ClassDef:
     """The `ThermoMicroscope` class body, parsed from source."""
-    source = (Path(fibsem.__file__).parent / "microscope.py").read_text()
+    source = (Path(fibsem.__file__).parent / "microscope.py").read_text(encoding="utf-8")
     return next(
         node
         for node in ast.walk(ast.parse(source))

--- a/tests/test_import_cycles.py
+++ b/tests/test_import_cycles.py
@@ -88,7 +88,7 @@ def test_spot_imports_the_microscope_for_typing_only():
     module has `from __future__ import annotations` -- so it never needs the real
     object at runtime.
     """
-    source = (Path(fibsem.__file__).parent / "imaging" / "spot.py").read_text()
+    source = (Path(fibsem.__file__).parent / "imaging" / "spot.py").read_text(encoding="utf-8")
     tree = ast.parse(source)
 
     module_level = {

--- a/tests/test_no_acquisition_time_gamma.py
+++ b/tests/test_no_acquisition_time_gamma.py
@@ -67,7 +67,7 @@ def test_a_stored_configuration_carrying_the_old_flag_still_loads(value: bool) -
 def test_images_written_before_v7_still_load() -> None:
     """The fixtures are real instrument output and all carry the key."""
     for fixture in FIXTURE_DIR.glob("*.json"):
-        raw = json.loads(fixture.read_text())
+        raw = json.loads(fixture.read_text(encoding="utf-8"))
         assert "autogamma" in raw["image"], f"{fixture.name} should predate v7"
 
         metadata = FibsemImageMetadata.from_dict(raw)
@@ -79,7 +79,7 @@ def test_images_written_before_v7_still_load() -> None:
 def test_no_shipped_configuration_still_declares_it() -> None:
     """Leaving the key in would advertise a setting that does nothing."""
     declaring = [
-        path.name for path in CONFIG_DIR.glob("*.yaml") if "autogamma" in path.read_text()
+        path.name for path in CONFIG_DIR.glob("*.yaml") if "autogamma" in path.read_text(encoding="utf-8")
     ]
 
     assert declaring == []

--- a/tests/test_tiling_package.py
+++ b/tests/test_tiling_package.py
@@ -40,7 +40,7 @@ FORBIDDEN_PREFIXES = ("fibsem.microscope", "fibsem.ui", "napari")
 
 def _declared_imports(relative_path: str) -> set:
     """Every module named by an import statement anywhere in the file."""
-    source = (FIBSEM_ROOT / relative_path).read_text()
+    source = (FIBSEM_ROOT / relative_path).read_text(encoding="utf-8")
     names = set()
     for node in ast.walk(ast.parse(source)):
         if isinstance(node, ast.ImportFrom) and node.module:
@@ -57,7 +57,7 @@ def _module_level_imports(relative_path: str) -> set:
     optional dependency to the one function that needs it is the pattern being
     protected here, not a violation of it.
     """
-    source = (FIBSEM_ROOT / relative_path).read_text()
+    source = (FIBSEM_ROOT / relative_path).read_text(encoding="utf-8")
     names = set()
     for node in ast.parse(source).body:
         if isinstance(node, ast.ImportFrom) and node.module:

--- a/tests/ui/test_defect_saves_once.py
+++ b/tests/ui/test_defect_saves_once.py
@@ -128,7 +128,7 @@ class TestTheWindowStillSaves:
             (AutoLamellaUI, ["self", "lamella_list", "defect_changed"]),
             (AutoLamellaMainUI, ["self", "autolamella_ui", "lamella_list", "defect_changed"]),
         ):
-            tree = ast.parse(Path(module.__file__).read_text())
+            tree = ast.parse(Path(module.__file__).read_text(encoding="utf-8"))
             for node in ast.walk(tree):
                 if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
                     continue

--- a/tests/ui/test_editor_save_debounce.py
+++ b/tests/ui/test_editor_save_debounce.py
@@ -229,7 +229,7 @@ class TestNothingBypassesIt:
     def test_no_editor_handler_saves_directly(self):
         """Ten handlers route through `_save_experiment`; one going around it keeps
         the full cost, and the only symptom is that the editor still feels slow."""
-        source = Path(editor_module.__file__).read_text()
+        source = Path(editor_module.__file__).read_text(encoding="utf-8")
         offenders = []
         for node in ast.walk(ast.parse(source)):
             if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
@@ -254,7 +254,7 @@ class TestNothingBypassesIt:
         """
         passes_the_flag = [
             node.lineno
-            for node in ast.walk(ast.parse(Path(editor_module.__file__).read_text()))
+            for node in ast.walk(ast.parse(Path(editor_module.__file__).read_text(encoding="utf-8")))
             if isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
             and node.func.attr == "save"

--- a/tests/ui/test_experiment_adoption_logging.py
+++ b/tests/ui/test_experiment_adoption_logging.py
@@ -75,7 +75,7 @@ def test_adopting_an_experiment_points_logging_at_its_logfile(tmp_path, quiet_ro
     logging.info("after adoption")
     for handler in logging.getLogger().handlers:
         handler.flush()
-    assert "after adoption" in logfile.read_text()
+    assert "after adoption" in logfile.read_text(encoding="utf-8")
 
 
 def test_adopting_an_experiment_still_does_the_rest_of_the_wiring(tmp_path, quiet_root_logger):
@@ -106,10 +106,10 @@ def test_a_second_adoption_moves_logging_to_the_new_experiment(tmp_path, quiet_r
 
     assert "belongs to the second experiment" in (
         Path(second.path) / "logfile.log"
-    ).read_text()
+    ).read_text(encoding="utf-8")
     assert "belongs to the second experiment" not in (
         Path(first.path) / "logfile.log"
-    ).read_text()
+    ).read_text(encoding="utf-8")
 
 
 def test_previewing_an_experiment_leaves_logging_alone(tmp_path, quiet_root_logger):

--- a/tests/ui/test_fm_acquisition_state.py
+++ b/tests/ui/test_fm_acquisition_state.py
@@ -327,7 +327,7 @@ class TestTheControlWidgetWiring:
 
         import fibsem.ui.widgets.fluorescence_control_widget as module
 
-        return Path(module.__file__).read_text()
+        return Path(module.__file__).read_text(encoding="utf-8")
 
     @classmethod
     def _functions(cls):

--- a/tests/ui/test_gui_thread_migration.py
+++ b/tests/ui/test_gui_thread_migration.py
@@ -60,7 +60,7 @@ def _gui_python_files() -> List[Path]:
 
 def _raw_thread_constructions(path: Path) -> List[Tuple[int, str]]:
     """Return (lineno, source-ish) for every ``threading.Thread(...)`` construction."""
-    tree = ast.parse(path.read_text(), filename=str(path))
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     hits = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -95,7 +95,7 @@ def test_no_raw_threads_in_gui_code():
 @pytest.mark.parametrize("relpath", MIGRATED_MODULES)
 def test_migrated_modules_use_function_worker(relpath: str):
     """Each migrated widget still imports and uses FunctionWorker."""
-    src = (REPO_ROOT / relpath).read_text()
+    src = (REPO_ROOT / relpath).read_text(encoding="utf-8")
     assert "from fibsem.ui.qt.threading import" in src, f"{relpath} lost its FunctionWorker import"
     assert "FunctionWorker(" in src, f"{relpath} no longer constructs a FunctionWorker"
 
@@ -107,7 +107,7 @@ def test_non_gui_layers_are_left_alone():
         "fibsem/fm/microscope.py",
         "fibsem/hooks.py",
     ):
-        src = (REPO_ROOT / relpath).read_text()
+        src = (REPO_ROOT / relpath).read_text(encoding="utf-8")
         assert "FunctionWorker" not in src, (
             f"{relpath} is Qt-free by design; importing FunctionWorker would drag Qt into it"
         )

--- a/tests/ui/test_lamella_defect_sync.py
+++ b/tests/ui/test_lamella_defect_sync.py
@@ -143,7 +143,7 @@ def test_every_host_of_the_list_can_persist_a_defect(module, widget, handler):
     import importlib
     from pathlib import Path
 
-    src = Path(importlib.import_module(module).__file__).read_text()
+    src = Path(importlib.import_module(module).__file__).read_text(encoding="utf-8")
     assert f"defect_changed.connect(self.{handler})" in src, (
         f"{widget} embeds the lamella list but never wires defect_changed -- "
         f"a defect set there is not persisted (FIB-564)"
@@ -220,7 +220,7 @@ def test_no_widget_holds_a_live_task_state_subscription(module, widget):
     import importlib
     from pathlib import Path
 
-    src = Path(importlib.import_module(module).__file__).read_text()
+    src = Path(importlib.import_module(module).__file__).read_text(encoding="utf-8")
     live = [c for c in _connect_chains(src) if "task_state" in c]
 
     assert live == [], (
@@ -255,7 +255,7 @@ def test_every_refresh_stays_marshalled(module, widget):
     import importlib
     from pathlib import Path
 
-    src = Path(importlib.import_module(module).__file__).read_text()
+    src = Path(importlib.import_module(module).__file__).read_text(encoding="utf-8")
 
     assert "from superqt import ensure_main_thread" in src, f"{widget} lost the import"
     assert "    @ensure_main_thread\n    def refresh(self)" in src, (

--- a/tests/ui/test_no_qt_warnings_on_workflow_load.py
+++ b/tests/ui/test_no_qt_warnings_on_workflow_load.py
@@ -215,7 +215,7 @@ def test_building_a_row_emits_no_null_pixmap_warning(qapp, module_name):
 def test_row_module_uses_the_shared_handle(qapp, module_name):
     """No module names the asset itself; that is how the paths drifted apart."""
     module = __import__(module_name, fromlist=["__file__"])
-    source = Path(module.__file__).read_text()
+    source = Path(module.__file__).read_text(encoding="utf-8")
 
     assert "drag_handle.svg" not in source, f"{module_name} re-derives the asset path"
     assert "drag_handle_pixmap" in source, f"{module_name} does not use the helper"

--- a/tests/ui/test_overview_tab_wiring.py
+++ b/tests/ui/test_overview_tab_wiring.py
@@ -36,7 +36,7 @@ NEW = "overview_canvas_tab"
 
 @pytest.fixture(scope="module")
 def window_source() -> str:
-    return WINDOW.read_text()
+    return WINDOW.read_text(encoding="utf-8")
 
 
 @pytest.fixture(scope="module")

--- a/tests/ui/test_overview_tabs_agree.py
+++ b/tests/ui/test_overview_tabs_agree.py
@@ -42,7 +42,7 @@ HEX_LITERAL = re.compile(r'"#[0-9a-fA-F]{6}"')
 
 @pytest.fixture(scope="module")
 def sources():
-    return {"beam": BEAM.read_text(), "fm": FM.read_text()}
+    return {"beam": BEAM.read_text(encoding="utf-8"), "fm": FM.read_text(encoding="utf-8")}
 
 
 def _assigned_names(source: str) -> set:
@@ -60,7 +60,7 @@ def _assigned_names(source: str) -> set:
 def test_the_palette_holds_the_shared_colours():
     """Beside the position markers, which were moved there for the same reason and whose
     comment says so."""
-    tokens = TOKENS.read_text()
+    tokens = TOKENS.read_text(encoding="utf-8")
     for name in SHARED_COLOURS:
         assert re.search(rf"^{name}\s*=", tokens, re.M), f"{name} is not in the palette"
 
@@ -94,10 +94,10 @@ def test_no_tab_carries_a_hex_colour_literal(tab, sources):
 def test_the_grid_radius_is_defined_once():
     """It was `GRID_RADIUS_M` on one tab and `GRID_BOUNDARY_RADIUS` on the other: the
     same 1000 µm, in two files, under two names, with nothing to keep them equal."""
-    overlays = OVERLAYS.read_text()
+    overlays = OVERLAYS.read_text(encoding="utf-8")
     assert re.search(r"^GRID_BOUNDARY_RADIUS_M\s*=", overlays, re.M)
 
-    for tab, source in (("beam", BEAM.read_text()), ("fm", FM.read_text())):
+    for tab, source in (("beam", BEAM.read_text(encoding="utf-8")), ("fm", FM.read_text(encoding="utf-8"))):
         assigned = _assigned_names(source)
         strays = {n for n in assigned if "GRID_RADIUS" in n or "BOUNDARY_RADIUS" in n}
         assert not strays, f"{tab} defines its own grid radius: {strays}"

--- a/tests/ui/test_script_manager_dialog.py
+++ b/tests/ui/test_script_manager_dialog.py
@@ -469,7 +469,7 @@ def test_new_script_refuses_to_overwrite(qapp, tmp_path, monkeypatch):
 
     dialog.new_script()
 
-    assert "original" in (tmp_path / "taken.py").read_text()
+    assert "original" in (tmp_path / "taken.py").read_text(encoding="utf-8")
     assert notes and notes[-1][0] == "warning"
 
 

--- a/tests/ui/test_shared_palette.py
+++ b/tests/ui/test_shared_palette.py
@@ -46,7 +46,7 @@ def _shared_colours():
     """{value: [names]} for every colour constant in the palette modules."""
     shared = {}
     for source in PALETTE_SOURCES:
-        for name, value in _DECLARATION.findall(source.read_text()):
+        for name, value in _DECLARATION.findall(source.read_text(encoding="utf-8")):
             shared.setdefault(value.lower(), []).append(name)
     return shared
 
@@ -80,7 +80,7 @@ def _modules():
         if path in PALETTE_SOURCES:
             continue
         rel = path.relative_to(PACKAGE)
-        if "ui" in rel.parts or "stylesheets" in path.read_text():
+        if "ui" in rel.parts or "stylesheets" in path.read_text(encoding="utf-8"):
             modules.append(path)
     return sorted(modules)
 
@@ -100,7 +100,7 @@ def test_no_module_redeclares_a_shared_colour(module):
 
     offenders = [
         f"{name} = {value!r} is already {' / '.join(shared[value.lower()])}"
-        for name, value in _DECLARATION.findall(module.read_text())
+        for name, value in _DECLARATION.findall(module.read_text(encoding="utf-8"))
         if value.lower() in shared
     ]
 


### PR DESCRIPTION
Closes FIB-704.

CI was `ubuntu-latest` only while the microscopes all run Windows, so every platform-specific claim in the codebase was untested on the platform that matters. Free here — GitHub-hosted runners have unlimited minutes on public repos.

Linux keeps all six supported versions; Windows takes the ends of the range (3.8 and 3.13), so this is 8 jobs rather than 12.

**This PR starts as a discovery run.** Windows has never executed this suite — failures are expected and are the point. I will push fixes on this branch until it is green, and describe each one here rather than folding unrelated repairs in silently.

The specific thing worth watching for: `Lamella.save_thumbnail` documents its temp-file-plus-`os.replace` write as *"atomic on POSIX and on Windows"*, and `test_the_final_file_never_exists_partly_written` exercises it with a reader thread holding the destination open. Windows raises `PermissionError` when renaming over an open file, so if that claim is wrong this is where it shows — and it would mean the FIB-602 fix can fail on the microscopes in exactly the situation it was written for.