### PR TITLE
[refactor] Reproject stage positions through the shared conversion (FIB-644)

### DIFF
--- a/fibsem/fm/reprojection.py
+++ b/fibsem/fm/reprojection.py
@@ -29,6 +29,10 @@ from typing import TYPE_CHECKING, List, Tuple
 
 import numpy as np
 
+from fibsem.conversions import (
+    image_to_microscope_image_coordinates2,
+    microscope_image_to_image_coordinates,
+)
 from fibsem.fm.structures import FibsemHardwareGeometry
 from fibsem.structures import FibsemStagePosition, Point
 from fibsem.transformations import (
@@ -53,7 +57,8 @@ def project_stage_position(
         position: the stage position to locate.
         base_position: the stage position the image was acquired at.
         pixel_size: image pixel size, in metres.
-        image_shape: image shape as (height, width), in pixels.
+        image_shape: image shape as (height, width), in pixels. Exactly two axes --
+            a longer shape now raises rather than silently using its first two.
         geometry: the geometry the image was captured under.
 
     Returns:
@@ -75,10 +80,19 @@ def project_stage_position(
     # mapping serves both directions -- see `CameraImageTransform`.
     dx, dy = geometry.transform.apply_to_delta(delta.x, dy)
 
-    # Image y grows downward while the projected displacement grows upward.
-    return Point(
-        x=image_shape[1] / 2 + dx / pixel_size,
-        y=image_shape[0] / 2 - dy / pixel_size,
+    # `dx, dy` are now a displacement in the microscope image frame, in metres:
+    # centred on the image with +y *up*. The shared conversion is what puts that on
+    # the image's own axes, mirroring y and offsetting from the centre -- the same
+    # arithmetic the milling, detection and correlation paths run (FIB-644).
+    #
+    # `subpixel_precision=True` because this is a continuous projection, not a pixel
+    # index: flooring the centre would move every marker half a pixel on an
+    # odd-sized image, and the inverse below has to agree with it exactly.
+    return microscope_image_to_image_coordinates(
+        Point(x=dx, y=dy),
+        image_shape=image_shape,
+        pixel_size=pixel_size,
+        subpixel_precision=True,
     )
 
 
@@ -98,14 +112,23 @@ def project_image_point(
         point: pixel coordinates in the displayed image.
         base_position: the stage position the image was acquired at.
         pixel_size: image pixel size, in metres.
-        image_shape: image shape as (height, width), in pixels.
+        image_shape: image shape as (height, width), in pixels. Exactly two axes --
+            a longer shape now raises rather than silently using its first two.
         geometry: the geometry the image was captured under.
 
     Returns:
         FibsemStagePosition: the absolute position under that pixel.
     """
-    dx = (point.x - image_shape[1] / 2) * pixel_size
-    dy = -(point.y - image_shape[0] / 2) * pixel_size
+    # The exact inverse of the conversion the forward runs, flag included: pairing a
+    # true centre one way with a floored one the other loses half a pixel per
+    # round trip on an odd-sized image.
+    delta = image_to_microscope_image_coordinates2(
+        point,
+        image_shape=image_shape,
+        pixelsize=pixel_size,
+        subpixel_precision=True,
+    )
+    dx, dy = delta.x, delta.y
 
     dx, dy = geometry.transform.apply_to_delta(dx, dy)
     y_move, z_move = view_corrected_stage_movement(

--- a/fibsem/imaging/tiling/reprojection.py
+++ b/fibsem/imaging/tiling/reprojection.py
@@ -14,7 +14,10 @@ from typing import List, Tuple
 import numpy as np
 
 from fibsem import movement
-from fibsem.conversions import is_inside_image_bounds
+from fibsem.conversions import (
+    is_inside_image_bounds,
+    microscope_image_to_image_coordinates,
+)
 from fibsem.structures import (
     BeamType,
     FibsemHardwareGeometry,
@@ -38,32 +41,45 @@ def calculate_reprojected_stage_position(image: FibsemImage, pos: FibsemStagePos
     # projection of the positions onto the image
     dx = delta.x
     dy = np.sqrt(delta.y**2 + delta.z**2) # TODO: correct for perspective here
-    dy = dy if (delta.y<0) else -dy
+    # Signed in the microscope image frame, +y *up*: a target at a lower stage y sits
+    # below the image centre. The conversion at the end is what mirrors that onto the
+    # image's own y-down axis, so the sign here reads the opposite way round to the
+    # `dy if delta.y < 0 else -dy` it replaces.
+    dy = -dy if (delta.y<0) else dy
 
     pt_delta = Point(dx, dy)
-    px_delta = pt_delta._to_pixels(image.metadata.pixel_size.x)
 
     beam_type = image.metadata.image_settings.beam_type
     if beam_type is BeamType.ELECTRON:
         scan_rotation = image.metadata.microscope_state.electron_beam.scan_rotation
     if beam_type is BeamType.ION:
         scan_rotation = image.metadata.microscope_state.ion_beam.scan_rotation
-    
+
+    # Both corrections are pure sign flips, which commute with the pixel-size divide
+    # the conversion does -- so they are applied in metres here where they used to be
+    # applied in pixels.
     if np.isclose(scan_rotation, np.pi):
-        px_delta.x *= -1.0
-        px_delta.y *= -1.0
+        pt_delta.x *= -1.0
+        pt_delta.y *= -1.0
 
     # account for compustage tilt, when mounted upside down
     if np.isclose(image.metadata.stage_position.t, np.radians(-180), atol=np.radians(5)):
-        px_delta.y *= -1.0
-
-    image_centre = Point(x=image.data.shape[1]/2, y=image.data.shape[0]/2)
-    point = image_centre + px_delta
+        pt_delta.y *= -1.0
 
     # NB: there is a small reprojection error that grows with distance from centre
     # print(f"ERROR: dy: {dy}, delta_y: {delta.y}, delta_z: {delta.z}")
 
-    return point
+    # [:2] rather than the whole shape: FibsemImage's constructor squeezes a (H, W, 1)
+    # array but its `data` setter does not, so an image assigned through the setter can
+    # carry a third axis (FIB-702). The old inline centring indexed [0] and [1] and
+    # ignored it; the shared conversion requires exactly two, so trim rather than
+    # start raising.
+    return microscope_image_to_image_coordinates(
+        pt_delta,
+        image_shape=image.data.shape[:2],
+        pixel_size=image.metadata.pixel_size.x,
+        subpixel_precision=True,
+    )
 
 def reproject_stage_positions_onto_image(
         image:FibsemImage, 
@@ -163,17 +179,24 @@ def calculate_reprojected_stage_position2(image: FibsemImage, pos: FibsemStagePo
     # dy = microscope._inverse_y_corrected_stage_movement(dy=delta.y, dz=delta.z, beam_type=beam_type) # type: ignore
     dy = _inverse_y_corrected_stage_movement(image, dy=delta.y, dz=delta.z, beam_type=beam_type) # type: ignore
 
-    pt_delta = Point(dx, -dy)
-    px_delta = pt_delta._to_pixels(pixel_size)
+    # `dy` is already in the microscope image frame (+y up), which is what the shared
+    # conversion below takes -- so the hand-rolled `-dy` that used to flip it onto the
+    # image's y-down axis goes away with the hand-rolled centring (FIB-644).
+    pt_delta = Point(dx, dy)
 
+    # A sign flip commutes with the pixel-size divide, so the scan-rotation correction
+    # is applied in metres here where it used to be applied in pixels.
     if np.isclose(scan_rotation, np.pi):
-        px_delta.x *= -1.0
-        px_delta.y *= -1.0
+        pt_delta.x *= -1.0
+        pt_delta.y *= -1.0
 
-    image_centre = Point(x=image.data.shape[1]/2, y=image.data.shape[0]/2)
-    point = image_centre + px_delta
-
-    return point
+    # [:2] for the same reason as in `calculate_reprojected_stage_position`.
+    return microscope_image_to_image_coordinates(
+        pt_delta,
+        image_shape=image.data.shape[:2],
+        pixel_size=pixel_size,
+        subpixel_precision=True,
+    )
 
 def reproject_stage_positions_onto_image2(
         image:FibsemImage, 

--- a/fibsem/projection.py
+++ b/fibsem/projection.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Optional, Protocol, Tuple
 
 import numpy as np
 
+from fibsem.conversions import get_image_pixel_centre
 from fibsem.fm.reprojection import project_image_point, project_stage_position
 from fibsem.imaging.tiling.reprojection import (
     inverse_y_corrected_stage_movement_tescan_from_geometry,
@@ -182,9 +183,17 @@ class FMStageProjection:
         )
         # `project_stage_position` answers in pixels measured from the corner; the
         # frame wants metres measured from the centre.
+        #
+        # Only the *centre* is shared with `fibsem.conversions`, not the conversion:
+        # the plane's y runs **down**, image-fashion, so this must not mirror y the
+        # way `image_to_microscope_image_coordinates` does. It looks like the same
+        # arithmetic and is not, and because `from_plane` inherits the same
+        # convention the pair round-trips cleanly either way -- so a round-trip test
+        # would not catch the mistake (FIB-644).
+        cy, cx = get_image_pixel_centre(self.shape, subpixel_precision=True)
         return (
-            (point.x - self.shape[1] / 2) * self.pixel_size,
-            (point.y - self.shape[0] / 2) * self.pixel_size,
+            (point.x - cx) * self.pixel_size,
+            (point.y - cy) * self.pixel_size,
         )
 
     def from_plane(
@@ -193,9 +202,12 @@ class FMStageProjection:
         # `project_image_point` is the exact inverse of `project_stage_position`,
         # sharing its sign terms, so a click on a marker resolves to the position that
         # marker was drawn from rather than to somewhere plausibly near it.
+        # y is *added*, not subtracted -- see `to_plane` on why this is not the
+        # mirroring conversion in `fibsem.conversions`.
+        cy, cx = get_image_pixel_centre(self.shape, subpixel_precision=True)
         point = Point(
-            x=self.shape[1] / 2 + dx / self.pixel_size,
-            y=self.shape[0] / 2 + dy / self.pixel_size,
+            x=cx + dx / self.pixel_size,
+            y=cy + dy / self.pixel_size,
         )
         return project_image_point(
             point, base, self.pixel_size, self.shape, self.geometry

--- a/tests/test_reprojection.py
+++ b/tests/test_reprojection.py
@@ -66,7 +66,7 @@ class TestCalculateReprojectedStagePosition:
         assert point.y != pytest.approx(centre.y)
 
     def test_y_sign_flips_across_the_image_position(self, image):
-        """`dy = dy if delta.y < 0 else -dy` -- the branch is worth pinning."""
+        """The `delta.y < 0` branch on the y displacement is worth pinning."""
         above = calculate_reprojected_stage_position(
             image, _base(image) + FibsemStagePosition(x=0, y=10e-6, z=0)
         )
@@ -76,6 +76,26 @@ class TestCalculateReprojectedStagePosition:
         centre = calculate_reprojected_stage_position(image, _base(image))
 
         assert (above.y - centre.y) == pytest.approx(-(below.y - centre.y))
+
+    def test_a_higher_stage_y_draws_above_the_image_centre(self, image):
+        """The absolute sense, not just the flip.
+
+        Every other sign test in this class is symmetric -- above vs below, plain vs
+        rotated -- so inverting the whole y convention passes all of them and draws
+        every marker mirrored. That is exactly how FIB-692 survived in the polygon
+        converter, so the direction is pinned outright: +y on the stage is *up* the
+        image, which is a smaller row index.
+        """
+        centre = calculate_reprojected_stage_position(image, _base(image))
+        higher = calculate_reprojected_stage_position(
+            image, _base(image) + FibsemStagePosition(x=0, y=10e-6, z=0)
+        )
+        righter = calculate_reprojected_stage_position(
+            image, _base(image) + FibsemStagePosition(x=10e-6, y=0, z=0)
+        )
+
+        assert higher.y < centre.y
+        assert righter.x > centre.x
 
     def test_z_contributes_to_the_y_displacement(self, image):
         """dy is sqrt(delta.y^2 + delta.z^2), so z is folded into the in-image y."""
@@ -162,6 +182,19 @@ class TestVariant2:
 
         assert point.x == pytest.approx(image.data.shape[1] / 2)
         assert point.y == pytest.approx(image.data.shape[0] / 2)
+
+    def test_a_higher_stage_y_draws_above_the_image_centre(self, image):
+        """The same absolute sense as the original variant -- see its twin above."""
+        centre = calculate_reprojected_stage_position2(image, _base(image))
+        higher = calculate_reprojected_stage_position2(
+            image, _base(image) + FibsemStagePosition(x=0, y=10e-6, z=0)
+        )
+        righter = calculate_reprojected_stage_position2(
+            image, _base(image) + FibsemStagePosition(x=10e-6, y=0, z=0)
+        )
+
+        assert higher.y < centre.y
+        assert righter.x > centre.x
 
     def test_x_offset_matches_the_original_variant(self, image):
         """x carries no projection, so the two variants must agree on it exactly."""

--- a/tests/test_reprojection_shared_conversion.py
+++ b/tests/test_reprojection_shared_conversion.py
@@ -1,0 +1,210 @@
+"""The reprojection paths, against the shared image <-> microscope conversion.
+
+`fibsem.conversions` owns one mapping between image pixels and the microscope image
+frame -- centred on the image, +y *up*. Three reprojection sites re-derived it inline
+until FIB-644 routed them through it:
+
+* `fibsem.fm.reprojection` -- both directions, fluorescence
+* `fibsem.imaging.tiling.reprojection` -- both `calculate_reprojected_stage_position`
+  variants, FIB/SEM
+* `fibsem.projection.FMStageProjection` -- the centre only, deliberately (see below)
+
+**Every shape here is odd and non-square, and that is the whole point.** The centre is
+`shape // 2` when the conversion floors it and `shape / 2` when it does not, and those
+are *identical on an even dimension*. Both existing reprojection test modules use even
+square images -- 1024x1024 and 64x64 -- so neither can tell the two apart, and neither
+can see an axis swap either. Measured: FIB-688's first mutation run scored 14/15 until
+its shapes were parametrised over (511, 1023).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from fibsem.conversions import get_image_pixel_centre
+from fibsem.fm.reprojection import project_image_point, project_stage_position
+from fibsem.fm.structures import CameraImageTransform, FibsemHardwareGeometry
+from fibsem.projection import FMStageProjection
+from fibsem.structures import FibsemStagePosition, Point
+
+# odd in both axes and non-square: an odd dimension separates the floored centre from
+# the true one, a non-square shape separates (height, width) from (width, height)
+ODD_SHAPE = (511, 1023)
+PIXEL_SIZE = 1e-7
+
+BASE = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(-180))
+
+
+def _geometry(transform=CameraImageTransform.NONE) -> FibsemHardwareGeometry:
+    return FibsemHardwareGeometry(
+        transform=transform,
+        camera_tilt=180.0,
+        is_compustage=True,
+        shuttle_pre_tilt=0.0,
+    )
+
+
+class TestTheFluorescenceProjection:
+    def test_the_base_position_lands_on_the_true_centre(self):
+        """511.5, not 511.
+
+        This is the assertion that distinguishes the two centres at all. With the
+        conversion flooring instead, the marker for the image's own stage position
+        lands half a pixel off -- visible on nothing, and wrong in the same direction
+        for every position drawn on that image.
+        """
+        point = project_stage_position(
+            BASE, BASE, PIXEL_SIZE, ODD_SHAPE, _geometry()
+        )
+
+        assert (point.x, point.y) == (ODD_SHAPE[1] / 2, ODD_SHAPE[0] / 2)
+        assert (point.x, point.y) != (ODD_SHAPE[1] // 2, ODD_SHAPE[0] // 2)
+
+    @pytest.mark.parametrize("transform", list(CameraImageTransform))
+    @pytest.mark.parametrize(
+        "pixel", [(0.0, 0.0), (511.5, 255.5), (1022.0, 510.0), (-300.0, 900.25)]
+    )
+    def test_the_round_trip_closes(self, transform, pixel):
+        """The forward and the inverse must pass the same `subpixel_precision`.
+
+        Pairing a true centre one way with a floored one the other loses half a pixel
+        per round trip -- the defect FIB-688 fixed in `microscope_image_to_image_
+        coordinates`, and the one this pins against coming back through either side.
+        """
+        point = Point(x=pixel[0], y=pixel[1])
+        geometry = _geometry(transform)
+
+        position = project_image_point(
+            point, BASE, PIXEL_SIZE, ODD_SHAPE, geometry
+        )
+        back = project_stage_position(
+            position, BASE, PIXEL_SIZE, ODD_SHAPE, geometry
+        )
+
+        assert back.x == pytest.approx(point.x, abs=1e-6)
+        assert back.y == pytest.approx(point.y, abs=1e-6)
+
+    def test_the_axes_are_not_swapped(self):
+        """A non-square image is what makes this assertion mean anything.
+
+        `image_shape` is (height, width) while `Point` is (x, y) -- opposite orders.
+        Routing a shape through the wrong one is the FIB-694 trap, and on a square
+        image it is invisible.
+        """
+        point = project_stage_position(
+            BASE, BASE, PIXEL_SIZE, ODD_SHAPE, _geometry()
+        )
+
+        assert point.x == pytest.approx(1023 / 2)  # width
+        assert point.y == pytest.approx(511 / 2)  # height
+
+    @pytest.mark.parametrize("shape", [(512,), (512, 512, 3), ()])
+    def test_a_shape_that_is_not_two_dimensional_raises(self, shape):
+        """A tightening, and a deliberate one.
+
+        The inline centring indexed [0] and [1], so a (H, W, C) shape quietly worked
+        off the first two axes and a 1-D shape raised IndexError. The shared conversion
+        requires exactly two. Every caller passes `image.data.shape[-2:]`, so this is
+        inert today -- pinned so it stays a decision rather than becoming a surprise.
+        """
+        with pytest.raises(ValueError):
+            project_stage_position(BASE, BASE, PIXEL_SIZE, shape, _geometry())
+
+        with pytest.raises(ValueError):
+            project_image_point(
+                Point(0.0, 0.0), BASE, PIXEL_SIZE, shape, _geometry()
+            )
+
+
+class TestTheBeamProjection:
+    """`imaging.tiling.reprojection`, both variants, on an odd non-square image."""
+
+    @pytest.fixture()
+    def image(self):
+        from fibsem import utils
+        from fibsem.structures import BeamType, ImageSettings
+
+        microscope, _ = utils.setup_session(manufacturer="Demo")
+        image = microscope.acquire_image(
+            ImageSettings(
+                hfw=80e-6, resolution=[64, 64], beam_type=BeamType.ELECTRON, save=False
+            )
+        )
+        # the acquisition path will not hand back an odd resolution, and the shape is
+        # all these functions read of the data
+        image.data = np.zeros(ODD_SHAPE, dtype=np.uint16)
+        return image
+
+    @pytest.mark.parametrize("variant", ["", "2"])
+    def test_the_image_position_lands_on_the_true_centre(self, image, variant):
+        from fibsem.imaging.tiling import reprojection
+
+        calculate = getattr(
+            reprojection, f"calculate_reprojected_stage_position{variant}"
+        )
+        point = calculate(image, image.metadata.stage_position)
+
+        assert (point.x, point.y) == (ODD_SHAPE[1] / 2, ODD_SHAPE[0] / 2)
+        assert (point.x, point.y) != (ODD_SHAPE[1] // 2, ODD_SHAPE[0] // 2)
+
+    @pytest.mark.parametrize("variant", ["", "2"])
+    def test_the_axes_are_not_swapped(self, image, variant):
+        from fibsem.imaging.tiling import reprojection
+
+        calculate = getattr(
+            reprojection, f"calculate_reprojected_stage_position{variant}"
+        )
+        point = calculate(image, image.metadata.stage_position)
+
+        assert point.x == pytest.approx(1023 / 2)  # width
+        assert point.y == pytest.approx(511 / 2)  # height
+
+
+class TestTheDisplayPlaneIsNotThisConversion:
+    """`FMStageProjection` is the near-miss, and it must stay one.
+
+    `to_plane`/`from_plane` look like the same arithmetic and are not: the plane's y
+    runs **down**, image-fashion, so they do not mirror y. They share only the centre
+    with `fibsem.conversions`.
+
+    The reason to pin it rather than trust the comment: the pair is self-consistent, so
+    it round-trips perfectly either way. A round-trip test -- the obvious test to write
+    here -- passes whether or not someone "deduplicates" it into the mirroring
+    conversion, and the overview canvas would silently draw everything upside down.
+    """
+
+    @pytest.fixture()
+    def projection(self):
+        return FMStageProjection(
+            geometry=_geometry(), pixel_size=PIXEL_SIZE, shape=ODD_SHAPE
+        )
+
+    def test_to_plane_does_not_mirror_y(self, projection):
+        above = BASE + FibsemStagePosition(x=0.0, y=10e-6, z=0.0, r=0.0, t=0.0)
+
+        pixel = project_stage_position(
+            above, BASE, PIXEL_SIZE, ODD_SHAPE, _geometry()
+        )
+        plane_x, plane_y = projection.to_plane(above, BASE)
+        cy, cx = get_image_pixel_centre(ODD_SHAPE, subpixel_precision=True)
+
+        # same sense as the pixel offset it is derived from, not the opposite one
+        assert np.sign(plane_y) == np.sign(pixel.y - cy)
+        assert np.sign(plane_x) == np.sign(pixel.x - cx)
+
+    def test_the_plane_origin_is_the_true_centre(self, projection):
+        """Half a pixel of pixel_size, and it is shared with the conversion."""
+        assert projection.to_plane(BASE, BASE) == (0.0, 0.0)
+
+        point = projection.from_plane(0.0, 0.0, BASE)
+        assert (point.x, point.y, point.z) == pytest.approx(
+            (BASE.x, BASE.y, BASE.z), abs=1e-15
+        )
+
+    @pytest.mark.parametrize(
+        "plane", [(0.0, 0.0), (1e-6, -1e-6), (-3.5e-5, 8.25e-5)]
+    )
+    def test_the_plane_round_trip_closes(self, projection, plane):
+        position = projection.from_plane(plane[0], plane[1], BASE)
+
+        assert projection.to_plane(position, BASE) == pytest.approx(plane, abs=1e-15)


### PR DESCRIPTION
Fixes FIB-644 — the last step. The milling and napari sites went in #427, #436, #437 and #439.

`fibsem.conversions` owns one mapping between image pixels and the microscope image frame: centred on the image, **+y up**, so y is mirrored about the centre where x is only shifted. Two reprojection modules re-derived it inline.

| where | what it had |
| --- | --- |
| `fm/reprojection.py` | both directions, hand-rolled — `shape[1]/2 + dx/px`, `shape[0]/2 - dy/px` and its inverse |
| `tiling/reprojection.py` ×2 | `image_centre = Point(x=shape[1]/2, y=shape[0]/2)` and add a delta, in both `calculate_reprojected_stage_position` variants |

## The mirror was hiding in the sign of the displacement

Neither tiling variant looked like it mirrored y, because each had folded the mirror into how it signed the displacement before adding it to the centre:

```python
dy = dy if (delta.y < 0) else -dy     # v1: the conditional is the mirror
pt_delta = Point(dx, -dy)             # v2: the hand-rolled `-` is the mirror
```

Both now hand the conversion a displacement in the frame it documents (+y up) and let it do the mirroring. That is why `v1`'s conditional reads inverted afterwards and `v2`'s `-dy` disappears entirely — the sign moved, it did not change.

The scan-rotation and compustage corrections move from pixels to metres along with it. A sign flip commutes with the pixel-size divide, so that is free.

## `projection.py` — the near-miss stays a near-miss

The issue says **do not fold in `FMStageProjection`**, and this does not. Its plane runs y **down**, image-fashion, so it must not mirror. What it now shares is only `get_image_pixel_centre` — four more inline `shape/2` gone, no change of convention.

Worth doing because the reason is now a **test** rather than a comment. The pair is self-consistent, so it round-trips perfectly whether or not someone "deduplicates" it into the mirroring conversion. A round-trip test — the obvious test to write here — passes either way, while the overview canvas draws everything upside down. `test_to_plane_does_not_mirror_y` is the one that actually catches it.

## Inert, and measured rather than asserted

Pre-change modules loaded beside the new ones in one process, compared by **IEEE-754 bit pattern** (`struct.pack(">d", x)`) over shapes × pixel sizes × geometries × poses × deltas:

| | comparisons | mismatches |
| --- | --- | --- |
| `fm/reprojection` both directions | 47,040 | 0 |
| `tiling/reprojection` both variants | 36,864 | 0 |
| `FMStageProjection.to_plane` / `from_plane` | 6,912 | 0 |

`pytest.approx` would have reported the same thing and proved less — this is the method that found the signed-zero difference in #410.

## Two deliberate behaviour changes

**`fm/reprojection` now requires a 2-D `image_shape`.** The inline indexing took the first two axes of anything longer and raised `IndexError` on anything shorter; the shared conversion requires exactly two. Every caller passes `image.data.shape[-2:]`, so this is inert today — pinned by test so it stays a decision.

**The tiling pair passes `image.data.shape[:2]`, not the whole shape.** `FibsemImage`'s constructor squeezes a `(H, W, 1)` array; its `data` setter does not. Trimming preserves the old behaviour exactly rather than starting to raise. Filed as FIB-702.

## Tests

**Every shape in the new module is odd and non-square, and that is the whole point.** The centre is `shape // 2` floored and `shape / 2` not — *identical on an even dimension*. Both existing reprojection test modules use even square images (1024², 64²), so neither can tell the two centres apart, and neither can see an axis swap.

The tiling tests also gain the **absolute** y direction. Every sign test there was symmetric — above vs below, plain vs rotated — so inverting the whole convention passed all of them. That is exactly how FIB-692 (polygons drawn upside down) survived, and this PR rewrites the v1 sign convention, so it is the assertion that matters most here.

**14/14 mutations caught**, files restored byte-for-byte:

| | |
| --- | --- |
| floor the centre — fm forward, fm inverse, tiling v1, tiling v2, projection | 5 |
| swap the axes — fm point, fm delta, tiling v1 shape, tiling v2 shape, projection centre | 5 |
| restore the pre-mirror sign (v1 conditional, v2 `-dy`) | 2 |
| compustage flips x instead of y | 1 |
| `to_plane` mirrors y — the near-miss trap | 1 |

Affected suites (reprojection, projection, conversions, FM, Tescan, canvas, overlays): **1614 passed**.
