### PR TITLE
[refactor] Give the FM overview the shared grid settings panel (FIB-696)

### DIFF
--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -915,7 +915,10 @@ class OverviewAcquisitionSettings:
         image_settings: Per-tile image settings (hfw = tile FOV, beam_type, resolution, etc.)
         nrows: Number of tile rows in the grid.
         ncols: Number of tile columns in the grid.
-        overlap: Fractional overlap between adjacent tiles (0.0 = no overlap). Not yet supported.
+        overlap: Fractional overlap between adjacent tiles (0.0 = no overlap).
+            Honoured by `TiledAcquisitionRunner` and by the shared geometry core,
+            which step by `fov * (1 - overlap)`; the docstring said otherwise long
+            after it stopped being true.
         tile_mask: Optional per-tile enable mask, `tile_mask[row][col]`. None acquires
             every tile. Disabled tiles are skipped but keep their place: the mosaic is
             still the full grid size and acquired tiles land at the same canvas
@@ -925,7 +928,7 @@ class OverviewAcquisitionSettings:
     image_settings: ImageSettings = field(default_factory=ImageSettings)
     nrows: int = 3
     ncols: int = 3
-    overlap: float = 0.0
+    overlap: float = 0.1
     focus_stack_settings: FocusStackSettings = field(default_factory=FocusStackSettings)
     autofocus_settings: AutoFocusSettings = field(default_factory=AutoFocusSettings)
     tile_order: TileOrderStrategy = TileOrderStrategy.TYPEWRITER
@@ -996,7 +999,7 @@ class OverviewAcquisitionSettings:
             image_settings=ImageSettings.from_dict(d.get("image_settings", {})),
             nrows=d.get("nrows", 3),
             ncols=d.get("ncols", 3),
-            overlap=d.get("overlap", 0.0),
+            overlap=d.get("overlap", 0.1),
             focus_stack_settings=fss,
             autofocus_settings=AutoFocusSettings.from_dict(d.get("autofocus_settings", {})),
             tile_order=TileOrderStrategy(d.get("tile_order", TileOrderStrategy.TYPEWRITER.value)),

--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -13,12 +13,10 @@ from typing import List, Optional
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QCheckBox,
-    QDoubleSpinBox,
     QFormLayout,
     QHBoxLayout,
     QLabel,
     QSizePolicy,
-    QSpinBox,
     QVBoxLayout,
     QWidget,
 )
@@ -35,12 +33,9 @@ from fibsem.fm.structures import (
 from fibsem.structures import TileOrderStrategy
 from fibsem.ui.fm.widgets.autofocus_widget import AutofocusWidget
 from fibsem.ui.widgets.overview_grid_settings_widget import (
-    TILE_ORDER_LABELS,
-    TILE_ORDER_TOOLTIPS,
+    OverviewGridSettingsWidget,
 )
-from fibsem.ui.widgets.tile_mask_widget import TileMaskWidget
 from fibsem.ui.fm.widgets.z_parameters_widget import ZParametersWidget
-from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import TitledPanel, ValueComboBox
 from fibsem.ui.tokens import (
     TEXT_MUTED_COLOR,
@@ -111,42 +106,22 @@ class FMOverviewSettingsWidget(QWidget):
         self.autofocus_widget = AutofocusWidget(list(channel_settings or []))
         self.autofocus_widget.set_pass_editing_enabled(True)
         self._init_ui()
-        if parameters is not None:
-            self.parameters = parameters
+        # Always seeded, from the dataclass when the caller supplies nothing. The grid
+        # controls used to carry their own defaults -- `spin_overlap.setValue(0.1)` --
+        # which is `OverviewParameters.overlap` written a second time, and the shared
+        # panel cannot carry it because the beam side defaults to 0.0 for the same
+        # setting. So the dataclass is the one place it is stated.
+        self.parameters = parameters if parameters is not None else OverviewParameters()
         self._refresh_derived()
 
     # ── construction ─────────────────────────────────────────────────────
 
     def _init_ui(self) -> None:
-        self.spin_rows = QSpinBox()
-        self.spin_rows.setRange(1, 100)
-        self.spin_rows.setValue(3)
-
-        self.spin_cols = QSpinBox()
-        self.spin_cols.setRange(1, 100)
-        self.spin_cols.setValue(3)
-
-        self.spin_overlap = QDoubleSpinBox()
-        self.spin_overlap.setRange(0.0, 0.9)
-        self.spin_overlap.setSingleStep(0.05)
-        self.spin_overlap.setDecimals(2)
-        self.spin_overlap.setValue(0.1)
-
-        self.combo_tile_order = ValueComboBox(
-            items=list(TileOrderStrategy),
-            format_fn=lambda s: TILE_ORDER_LABELS.get(s, s.value.title()),
-        )
-        # What each strategy does belongs in a tooltip, not in the label -- the label
-        # is read on every glance and the explanation once.
-        for index in range(self.combo_tile_order.count()):
-            strategy = self.combo_tile_order.itemData(index)
-            self.combo_tile_order.setItemData(
-                index, TILE_ORDER_TOOLTIPS.get(strategy, ""), Qt.ToolTipRole
-            )
-        self.combo_tile_order.setToolTip(
-            "\n".join(f"{TILE_ORDER_LABELS[s]} — {TILE_ORDER_TOOLTIPS[s]}"
-                      for s in TileOrderStrategy)
-        )
+        # Rows, columns, overlap, tile order and the mask, from the module written to
+        # end their being written twice. What stays here is everything that decides
+        # what a *tile* is -- channels, exposure, z, focus -- which is the half that is
+        # genuinely modality-specific.
+        self.grid = OverviewGridSettingsWidget()
 
         # No label: this sits in the Z-Stack panel header, which already names it.
         self.check_zstack = QCheckBox()
@@ -168,42 +143,11 @@ class FMOverviewSettingsWidget(QWidget):
             )
 
         # The app's spinboxes carry -/+ buttons, which eat most of a narrow field and
-        # leave the value clipped ("0" for an overlap of 0.10). Give them a floor.
-        for widget in (self.spin_rows, self.spin_cols, self.spin_overlap,
-                       self.combo_tile_order, self.combo_autofocus_mode,
-                       self.combo_objective_start):
+        # leave the value clipped. Give them a floor. The grid panel applies the same
+        # rule to its own fields, for the same reason.
+        for widget in (self.combo_autofocus_mode, self.combo_objective_start):
             widget.setMinimumWidth(SPINBOX_MIN_WIDTH)
             widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        for widget in (self.spin_rows, self.spin_cols, self.spin_overlap):
-            install_wheel_blocker(widget)
-
-        # Rows and columns read as one setting and are always adjusted together, so
-        # they share a line -- which is also what gives each of them room.
-        size_row = QHBoxLayout()
-        size_row.setSpacing(6)
-        size_row.addWidget(self.spin_rows)
-        times = QLabel("×")
-        times.setStyleSheet(MUTED)
-        size_row.addWidget(times)
-        size_row.addWidget(self.spin_cols)
-
-        grid_form = QFormLayout()
-        grid_form.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
-        grid_form.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
-        grid_form.setFormAlignment(Qt.AlignLeft | Qt.AlignTop)
-        self.label_total_fov = QLabel("—")
-        self.label_total_fov.setStyleSheet(MUTED)
-
-        grid_form.addRow("Rows × Columns", size_row)
-        grid_form.addRow("Overlap", self.spin_overlap)
-        grid_form.addRow("Tile order", self.combo_tile_order)
-        grid_form.addRow("Total FOV", self.label_total_fov)
-        grid_content = QWidget()
-        grid_content.setLayout(grid_form)
-        self.grid_panel = TitledPanel("Grid", content=grid_content)
-
-        self.tile_mask = TileMaskWidget(rows=3, cols=3)
-        self.mask_panel = TitledPanel("Tiles to acquire", content=self.tile_mask)
 
         # "When to focus" is the overview's own setting; everything below it -- method,
         # channel, and the sweep passes -- belongs to the sweep and is delegated.
@@ -243,12 +187,13 @@ class FMOverviewSettingsWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.focus_panel)
         layout.addWidget(self.zstack_panel)
-        layout.addWidget(self.grid_panel)
-        # No stretch on any panel: a stretched panel keeps claiming vertical space when
-        # it is collapsed, so folding it leaves a tall empty box with the title floating
-        # in the middle of it. The trailing stretch below takes the slack instead -- kept
-        # here rather than left to the host, so the panels stay put in any container.
-        layout.addWidget(self.mask_panel)
+        # One panel, not two: the mask is a grid property, and the shared widget holds
+        # it inside the Grid panel with the count in the header. No stretch on any of
+        # them -- a stretched panel keeps claiming vertical space when it is collapsed,
+        # so folding it leaves a tall empty box with the title floating in the middle.
+        # The trailing stretch below takes the slack instead, kept here rather than left
+        # to the host so the panels stay put in any container.
+        layout.addWidget(self.grid)
         layout.addWidget(self.label_summary)
         layout.addStretch()
 
@@ -257,15 +202,13 @@ class FMOverviewSettingsWidget(QWidget):
         self.focus_panel.collapse()
         self.zstack_panel.collapse()
 
-        self.spin_rows.valueChanged.connect(self._on_grid_size_changed)
-        self.spin_cols.valueChanged.connect(self._on_grid_size_changed)
-        self.spin_overlap.valueChanged.connect(self._on_any_change)
-        self.combo_tile_order.currentIndexChanged.connect(self._on_tile_order_changed)
+        # One signal for all five: the shared panel resizes the mask with the grid and
+        # reports every change through `changed`.
+        self.grid.changed.connect(self._on_grid_changed)
         self.check_zstack.stateChanged.connect(self._on_zstack_toggled)
         self.combo_autofocus_mode.currentIndexChanged.connect(self._on_autofocus_changed)
         self.combo_objective_start.currentIndexChanged.connect(self._on_any_change)
         self.autofocus_widget.settings_changed.connect(self._on_any_change)
-        self.tile_mask.changed.connect(self._on_any_change)
 
         self._on_autofocus_changed()
         self._on_zstack_toggled()
@@ -279,34 +222,25 @@ class FMOverviewSettingsWidget(QWidget):
     def set_grid_size(self, rows: int, cols: int) -> None:
         """Set both grid dimensions as a single change.
 
-        Setting the two spin boxes one after the other emits `changed` twice and
-        passes through a size nobody asked for -- the new row count against the old
-        column count. That is invisible when a spin box is nudged by hand, but an edge
-        drag on the canvas does it on every motion event.
-
-        Follows the `parameters` setter: block, apply, resize the mask explicitly
-        because its handler is blocked with it, then notify once.
+        Delegated. Setting the two spin boxes one after the other emits twice and passes
+        through a size nobody asked for -- the new row count against the old column
+        count -- which is invisible when a box is nudged by hand and constant when an
+        edge is dragged on the canvas, where it fires on every motion event. The shared
+        panel is where that is handled now.
         """
-        if (rows, cols) == (self.spin_rows.value(), self.spin_cols.value()):
-            return
+        self.grid.set_grid_size(rows, cols)
 
-        for widget in (self.spin_rows, self.spin_cols, self.tile_mask):
-            widget.blockSignals(True)
-        try:
-            self.spin_rows.setValue(rows)
-            self.spin_cols.setValue(cols)
-            self.tile_mask.set_grid_size(rows, cols)
-        finally:
-            for widget in (self.spin_rows, self.spin_cols, self.tile_mask):
-                widget.blockSignals(False)
+    @property
+    def tile_mask(self) -> Optional[List[List[bool]]]:
+        """Which tiles the next run would acquire, or None for all of them."""
+        return self.grid.mask
 
-        self._on_any_change()
+    def set_mask(self, mask: Optional[List[List[bool]]]) -> None:
+        self.grid.set_mask(mask)
 
-    def _on_grid_size_changed(self) -> None:
-        self.tile_mask.set_grid_size(self.spin_rows.value(), self.spin_cols.value())
-        self._on_any_change()
-
-    def _on_tile_order_changed(self) -> None:
+    def _on_grid_changed(self) -> None:
+        """Anything in the grid panel moved -- including the tile order, which is half
+        of the spiral/per-row conflict."""
         self._warn_if_spiral_conflicts()
         self._on_any_change()
 
@@ -342,7 +276,7 @@ class FMOverviewSettingsWidget(QWidget):
         Surfaced here rather than left as a log line, so the setting the user chose and
         the setting that will run are not quietly different things.
         """
-        spiral = self.combo_tile_order.value() is TileOrderStrategy.SPIRAL
+        spiral = self.grid.tile_order is TileOrderStrategy.SPIRAL
         each_row = self.combo_autofocus_mode.value() is AutoFocusMode.EACH_ROW
         self._spiral_conflict = spiral and each_row
 
@@ -355,6 +289,10 @@ class FMOverviewSettingsWidget(QWidget):
     def set_tile_fov(self, fov_x: float, fov_y: float) -> None:
         """Tell the widget one tile's field of view, so it can report total area."""
         self._tile_fov = (fov_x, fov_y)
+        # Kept here as well as handed on, because `total_fov` answers None until a tile
+        # size is known and the shared panel answers (0, 0) -- a distinction its own
+        # label does not need and this widget's callers do.
+        self.grid.set_tile_fov(fov_x, fov_y)
         self._refresh_derived()
 
     def total_fov(self) -> Optional[tuple]:
@@ -366,21 +304,9 @@ class FMOverviewSettingsWidget(QWidget):
         """
         if self._tile_fov is None:
             return None
-        fov_x, fov_y = self._tile_fov
-        overlap = self.spin_overlap.value()
-        return (
-            ((self.spin_cols.value() - 1) * (1 - overlap) + 1) * fov_x,
-            ((self.spin_rows.value() - 1) * (1 - overlap) + 1) * fov_y,
-        )
+        return self.grid.total_fov
 
     def _refresh_derived(self) -> None:
-        total = self.total_fov()
-        self.label_total_fov.setText(
-            "—" if total is None
-            else f"{total[0] * constants.SI_TO_MICRO:.0f} × "
-                 f"{total[1] * constants.SI_TO_MICRO:.0f} µm"
-        )
-
         # Warnings only -- the tile count is already on the mask panel, and saying it
         # twice just makes the second one look like a different number.
         parts = []
@@ -447,38 +373,32 @@ class FMOverviewSettingsWidget(QWidget):
     @property
     def parameters(self) -> OverviewParameters:
         return OverviewParameters(
-            rows=self.spin_rows.value(),
-            cols=self.spin_cols.value(),
-            overlap=self.spin_overlap.value(),
+            rows=self.grid.rows,
+            cols=self.grid.cols,
+            overlap=self.grid.overlap,
             use_zstack=self.check_zstack.isChecked(),
             autofocus_mode=self.combo_autofocus_mode.value(),
-            tile_order=self.combo_tile_order.value(),
-            tile_mask=self.tile_mask.mask,
+            tile_order=self.grid.tile_order,
+            tile_mask=self.grid.mask,
             objective_start=self.combo_objective_start.value(),
         )
 
     @parameters.setter
     def parameters(self, value: OverviewParameters) -> None:
-        for widget in (self.spin_rows, self.spin_cols, self.spin_overlap,
-                       self.combo_tile_order, self.check_zstack,
-                       self.combo_autofocus_mode, self.combo_objective_start,
-                       self.tile_mask):
+        widgets = (self.check_zstack, self.combo_autofocus_mode,
+                   self.combo_objective_start)
+        for widget in widgets:
             widget.blockSignals(True)
         try:
-            self.spin_rows.setValue(value.rows)
-            self.spin_cols.setValue(value.cols)
-            self.spin_overlap.setValue(value.overlap)
-            self.combo_tile_order.set_value(value.tile_order)
+            # The grid panel does its own blocking, so it is loaded outside this one --
+            # `blockSignals` on the panel would not reach the boxes inside it anyway.
+            self.grid.apply(value.rows, value.cols, value.overlap,
+                            value.tile_order, value.tile_mask)
             self.check_zstack.setChecked(value.use_zstack)
             self.combo_autofocus_mode.set_value(value.autofocus_mode)
             self.combo_objective_start.set_value(value.objective_start)
-            self.tile_mask.set_grid_size(value.rows, value.cols)
-            self.tile_mask.mask = value.tile_mask
         finally:
-            for widget in (self.spin_rows, self.spin_cols, self.spin_overlap,
-                           self.combo_tile_order, self.check_zstack,
-                           self.combo_autofocus_mode, self.combo_objective_start,
-                           self.tile_mask):
+            for widget in widgets:
                 widget.blockSignals(False)
         # Both, because the setter blocked the signals that normally trigger them --
         # otherwise loading a z-stacked configuration leaves the z-parameters greyed

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -583,7 +583,7 @@ class FMOverviewWidget(QWidget):
         # The field of view goes on its own line rather than into the join: the panel
         # is narrow, and wrapping a "287 × 287 µm" mid-value reads as two numbers.
         summary = "  ·  ".join(parts)
-        fov = self.settings_widget.label_total_fov.text()
+        fov = self.settings_widget.grid.label_total_fov.text()
         if fov and fov != "—":
             summary = f"{summary}\n{fov}"
         # Said in words as well as drawn, because a grid sitting away from the stage
@@ -1986,7 +1986,7 @@ class FMOverviewWidget(QWidget):
         directly, which would leave the two views to drift apart on any path that
         touched only one of them.
         """
-        mask = self.settings_widget.tile_mask.mask
+        mask = self.settings_widget.tile_mask
         parameters = self.settings_widget.parameters
         if mask is None:
             mask = [[True] * parameters.cols for _ in range(parameters.rows)]
@@ -1994,7 +1994,7 @@ class FMOverviewWidget(QWidget):
             return
 
         mask[row][col] = enabled
-        self.settings_widget.tile_mask.mask = mask
+        self.settings_widget.set_mask(mask)
 
     def _on_settings_changed(self) -> None:
         if self.is_acquiring:

--- a/fibsem/ui/widgets/overview_grid_settings_widget.py
+++ b/fibsem/ui/widgets/overview_grid_settings_widget.py
@@ -254,19 +254,26 @@ class OverviewGridSettingsWidget(QWidget):
         size nobody asked for -- the new row count against the old column count. That is
         invisible when a spin box is nudged and constant when an edge is dragged on the
         canvas, which emits on every motion event.
+
+        The mask is blocked along with the boxes, and resized inside the block. It emits
+        `changed` of its own when its shape moves, so resizing it outside made this emit
+        *twice* -- once for the mask and once here -- which is the very thing the method
+        exists to prevent. The fluorescence tab had it right and its test is what caught
+        this on the way in.
         """
         rows, cols = int(rows), int(cols)
         if (rows, cols) == (self.rows, self.cols):
             return
-        for spinbox in (self.spin_rows, self.spin_cols):
-            spinbox.blockSignals(True)
+        blocked = (self.spin_rows, self.spin_cols, self.tile_mask)
+        for widget in blocked:
+            widget.blockSignals(True)
         try:
             self.spin_rows.setValue(rows)
             self.spin_cols.setValue(cols)
+            self.tile_mask.set_grid_size(rows, cols)
         finally:
-            for spinbox in (self.spin_rows, self.spin_cols):
-                spinbox.blockSignals(False)
-        self.tile_mask.set_grid_size(rows, cols)
+            for widget in blocked:
+                widget.blockSignals(False)
         self._on_changed()
 
     def set_mask(self, mask: Optional[List[List[bool]]]) -> None:

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -211,7 +211,10 @@ def test_overview_acquisition_settings_defaults():
     s = OverviewAcquisitionSettings()
     assert s.nrows == 3
     assert s.ncols == 3
-    assert s.overlap == 0.0
+    # 10%, matching `OverviewParameters` on the fluorescence side. The two defaulted
+    # differently for one setting with one meaning, so a run configured on one tab and
+    # read on the other started from a different grid (FIB-696).
+    assert s.overlap == 0.1
     assert s.focus_stack_settings.enabled is False
     assert s.focus_stack_settings.n_steps == 3
     assert s.focus_stack_settings.auto_focus is True

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -129,13 +129,13 @@ def test_settings_round_trip_every_field(qapp):
 
 def test_changing_the_grid_size_resizes_the_mask(qapp):
     widget = FMOverviewSettingsWidget()
-    widget.spin_rows.setValue(4)
-    widget.spin_cols.setValue(6)
+    widget.grid.spin_rows.setValue(4)
+    widget.grid.spin_cols.setValue(6)
 
     assert widget.parameters.rows == 4
     assert widget.parameters.cols == 6
-    assert widget.tile_mask.grid._rows == 4
-    assert widget.tile_mask.grid._cols == 6
+    assert widget.grid.tile_mask.grid._rows == 4
+    assert widget.grid.tile_mask.grid._cols == 6
 
 
 def test_the_sweep_controls_are_only_live_when_focusing(qapp):
@@ -155,11 +155,11 @@ def test_a_spiral_with_per_row_focus_says_what_will_actually_happen(qapp):
     """The runner promotes EACH_ROW to EACH_TILE for a spiral; don't make that a surprise."""
     widget = FMOverviewSettingsWidget()
     widget.combo_autofocus_mode.set_value(AutoFocusMode.EACH_ROW)
-    widget.combo_tile_order.set_value(TileOrderStrategy.SPIRAL)
+    widget.grid.combo_tile_order.set_value(TileOrderStrategy.SPIRAL)
 
     assert "per-tile" in widget.label_summary.text()
 
-    widget.combo_tile_order.set_value(TileOrderStrategy.TYPEWRITER)
+    widget.grid.combo_tile_order.set_value(TileOrderStrategy.TYPEWRITER)
     assert "per-tile" not in widget.label_summary.text()
 
 
@@ -169,7 +169,7 @@ def test_the_selection_is_counted_once(qapp):
     widget = FMOverviewSettingsWidget()
     widget.parameters = OverviewParameters(rows=3, cols=3, tile_mask=plus_mask(3))
 
-    assert "5/9 tiles" in widget.tile_mask.label_count.text()
+    assert "5/9 tiles" in widget.grid.tile_mask.label_count.text()
     assert "tiles" not in widget.label_summary.text()
 
 
@@ -189,14 +189,14 @@ def test_the_grid_reports_the_total_field_of_view(qapp, rows, cols, overlap, exp
     widget.set_tile_fov(100e-6, 100e-6)
 
     widget.parameters = OverviewParameters(rows=rows, cols=cols, overlap=overlap)
-    assert widget.label_total_fov.text() == expected
+    assert widget.grid.label_total_fov.text() == expected
 
-    widget.tile_mask.grid.set_all(False)
-    assert widget.label_total_fov.text() == expected
+    widget.grid.tile_mask.grid.set_all(False)
+    assert widget.grid.label_total_fov.text() == expected
 
 
 def test_the_total_field_of_view_is_unknown_until_the_camera_is_known(qapp):
-    assert FMOverviewSettingsWidget().label_total_fov.text() == "—"
+    assert FMOverviewSettingsWidget().grid.label_total_fov.text() == "—"
 
 
 def test_focusing_with_every_pass_disabled_is_called_out(qapp):
@@ -501,8 +501,9 @@ def test_collapsed_panels_do_not_stretch(qapp):
     widget.show()
     widget.resize(500, 1200)  # far taller than the folded panels need
 
-    panels = (widget.focus_panel, widget.zstack_panel,
-              widget.grid_panel, widget.mask_panel)
+    # Three, not four: the tile mask now lives inside the Grid panel rather than in
+    # one of its own.
+    panels = (widget.focus_panel, widget.zstack_panel, widget.grid.panel)
     for panel in panels:
         panel.collapse()
     qapp.processEvents()
@@ -585,7 +586,7 @@ def test_clicking_a_tile_updates_the_mask_the_settings_widget_owns(qapp, overvie
     """One mask, two views. The overlay must not keep its own copy -- a click routes
     through the settings widget, and the redraw follows from that."""
     widget = overview_widget
-    widget.settings_widget.tile_mask.mask = None
+    widget.settings_widget.set_mask(None)
     qapp.processEvents()
 
     overlay = widget.tile_grid_overlay
@@ -594,8 +595,8 @@ def test_clicking_a_tile_updates_the_mask_the_settings_widget_owns(qapp, overvie
     _click(overlay, x + tw / 2, y + th / 2)
     qapp.processEvents()
 
-    assert widget.settings_widget.tile_mask.mask[0][0] is False
-    assert widget.settings_widget.tile_mask.n_enabled == 8
+    assert widget.settings_widget.tile_mask[0][0] is False
+    assert widget.settings_widget.grid.tile_mask.n_enabled == 8
     # and the overlay redrew from the widget's mask, rather than mutating its own
     assert next(
         t for t in overlay._tiles if (t.row, t.col) == (0, 0)
@@ -604,7 +605,7 @@ def test_clicking_a_tile_updates_the_mask_the_settings_widget_owns(qapp, overvie
 
 def test_clicking_the_same_tile_twice_returns_it(qapp, overview_widget):
     widget = overview_widget
-    widget.settings_widget.tile_mask.mask = None
+    widget.settings_widget.set_mask(None)
     qapp.processEvents()
 
     overlay = widget.tile_grid_overlay
@@ -615,21 +616,21 @@ def test_clicking_the_same_tile_twice_returns_it(qapp, overview_widget):
         _click(overlay, x + tw / 2, y + th / 2)
         qapp.processEvents()
 
-    assert widget.settings_widget.tile_mask.n_enabled == 9
+    assert widget.settings_widget.grid.tile_mask.n_enabled == 9
 
 
 def test_resizing_the_grid_redraws_the_overlay(qapp, overview_widget):
     widget = overview_widget
-    widget.settings_widget.tile_mask.mask = None
-    widget.settings_widget.spin_rows.setValue(5)
-    widget.settings_widget.spin_cols.setValue(4)
+    widget.settings_widget.set_mask(None)
+    widget.settings_widget.grid.spin_rows.setValue(5)
+    widget.settings_widget.grid.spin_cols.setValue(4)
     qapp.processEvents()
 
     assert len(widget.tile_grid_overlay._tiles) == 20
     assert len(widget.tile_grid_overlay._artists) == 20
 
-    widget.settings_widget.spin_rows.setValue(3)
-    widget.settings_widget.spin_cols.setValue(3)
+    widget.settings_widget.grid.spin_rows.setValue(3)
+    widget.settings_widget.grid.spin_cols.setValue(3)
     qapp.processEvents()
 
     assert len(widget.tile_grid_overlay._tiles) == 9
@@ -734,18 +735,18 @@ def test_setting_both_grid_dimensions_notifies_once(qapp):
     widget = FMOverviewSettingsWidget()
     seen = []
     widget.changed.connect(
-        lambda: seen.append((widget.spin_rows.value(), widget.spin_cols.value()))
+        lambda: seen.append((widget.grid.rows, widget.grid.cols))
     )
 
     widget.set_grid_size(2, 7)
 
     assert seen == [(2, 7)]
-    assert (widget.tile_mask.grid._rows, widget.tile_mask.grid._cols) == (2, 7)
+    assert (widget.grid.tile_mask.grid._rows, widget.grid.tile_mask.grid._cols) == (2, 7)
 
 
 def test_setting_the_same_grid_size_is_a_no_op(qapp):
     widget = FMOverviewSettingsWidget()
-    rows, cols = widget.spin_rows.value(), widget.spin_cols.value()
+    rows, cols = widget.grid.rows, widget.grid.cols
     seen = []
     widget.changed.connect(lambda: seen.append(1))
 
@@ -1737,9 +1738,9 @@ def test_an_empty_grid_still_forbids_acquiring_after_a_lock_is_lifted(qapp):
     """The third fact. A tab unlocked with no tiles selected has nothing to acquire,
     and the button that starts it should say so."""
     widget = _fresh_widget(qapp)
-    widget.settings_widget.tile_mask.mask = [[False, False], [False, False]]
+    widget.settings_widget.set_mask([[False, False], [False, False]])
     widget.settings_widget.set_grid_size(2, 2)
-    widget.settings_widget.tile_mask.mask = [[False, False], [False, False]]
+    widget.settings_widget.set_mask([[False, False], [False, False]])
     widget._on_settings_changed()
     assert not widget.button_acquire.isEnabled()
 
@@ -4710,3 +4711,22 @@ def test_zz_the_shared_fixture_is_still_wired_at_the_end_of_the_file(qapp, overv
     }
 
     assert all(counts.values()), f"the shared fixture went deaf mid-file: {counts}"
+
+
+def test_the_column_opens_at_the_dataclass_default_overlap(qapp):
+    """The default is stated once, in `OverviewParameters`, and the column takes it.
+
+    It used to be `spin_overlap.setValue(0.1)` in the widget -- the same number written
+    a second time -- and the shared grid panel cannot carry it, because the beam side
+    defaults the same setting to 0.0. Adopting the panel therefore silently opened the
+    fluorescence column at 0 % until this was seeded, which is a different run for
+    anyone who pressed Acquire without touching overlap.
+
+    Caught by rendering the column, not by a test: nothing asserted the default.
+    """
+    from fibsem.fm.structures import OverviewParameters
+
+    widget = FMOverviewSettingsWidget()
+
+    assert widget.parameters.overlap == OverviewParameters().overlap == 0.1
+    assert "10" in widget.grid.spin_overlap.text()

--- a/tests/ui/test_overview_confirmation_dialog.py
+++ b/tests/ui/test_overview_confirmation_dialog.py
@@ -103,9 +103,15 @@ class TestWhereTheRunWillHappen:
 
 class TestWhatWillBeAcquired:
     def test_the_meta_line_carries_the_grid_and_what_it_covers(self, dialog):
+        """1400, not 1500: three 500 um tiles at the default 10% overlap step by 450,
+        so the grid spans 2.8 tiles rather than 3.
+
+        The default was 0% until FIB-696, which is why it read 1500 before. Overlap is
+        what makes a mosaic stitchable, and the two tabs now agree on it."""
         line = dialog(settings=_settings())._meta_line()
         assert "3 × 3 grid" in line
-        assert "1500 × 1500" in line
+        assert "10% overlap" in line
+        assert "1400 × 1400" in line
         assert "typewriter order" in line
 
     def test_a_masked_run_counts_only_what_it_will_acquire(self, dialog):

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -1614,6 +1614,32 @@ class TestTheTileMaskSurvivesTheSettingsWidget:
         disabled = set(disabled)
         return [[(i, j) not in disabled for j in range(cols)] for i in range(rows)]
 
+    def test_setting_both_dimensions_notifies_once(self, qapp):
+        """The shared panel's own contract, tested on this side for the first time.
+
+        It emitted twice: the mask resize was done outside the block, and the mask emits
+        `changed` when its shape moves, so `set_grid_size` fired once for the mask and
+        once for itself -- the very thing the method exists to prevent. Invisible when a
+        spin box is nudged by hand; an edge drag on the canvas does it on every motion
+        event, refreshing the overlay twice against a size asked for once.
+
+        The fluorescence tab always blocked the mask, and adopting this widget is what
+        brought its test to bear (FIB-696). Guarded here too, because the beam tab is
+        where the widget lives and where the next edit to it will be made.
+        """
+        from fibsem.ui.widgets.overview_grid_settings_widget import (
+            OverviewGridSettingsWidget,
+        )
+
+        grid = OverviewGridSettingsWidget()
+        seen = []
+        grid.changed.connect(lambda: seen.append((grid.rows, grid.cols)))
+
+        grid.set_grid_size(2, 7)
+
+        assert seen == [(2, 7)]
+        assert (grid.tile_mask.grid._rows, grid.tile_mask.grid._cols) == (2, 7)
+
     def test_no_mask_by_default(self, widget):
         assert widget._settings().tile_mask is None
 


### PR DESCRIPTION
Third of five layers where the beam and fluorescence overviews are written twice
(FIB-696, under FIB-693). **Two widgets sharing parts, not one merged widget.**

`OverviewGridSettingsWidget` was written to end these controls being written twice, and
the fluorescence tab never adopted it — it took the tile-order labels and the relocated
mask widget and went on hand-rolling the rest. `fm_overview_settings_widget.py` goes
**487 → 393 lines**.

## What changes on screen

| | before | after |
| -- | -- | -- |
| Panels | "Grid" **and** "Tiles to acquire" | one "Grid", mask inside it |
| Overlap | `0.10` | `10 %` |
| Sparse grid | count under the mask | also in the panel header, `9/25 tiles` |

All three are the shared panel's existing answers, so the two settings columns now read
the same. The mask sits inside the panel because it is a grid property and it is the one
setting that changes what a run does while being invisible everywhere else in the column.

## Two bugs the adoption found

**`set_grid_size` emitted `changed` twice.** The shared widget blocked the two spin boxes
and then resized the tile mask *outside* the block; the mask emits when its shape moves,
so one call fired twice — the one thing the method exists to prevent. Invisible by hand,
constant on the canvas, where dragging a grid edge calls it on every motion event. The
fluorescence tab always blocked the mask, and bringing its test to bear is what caught
this. Fixed in the shared widget, and the missing guard added on the beam side too.

**The default overlap silently regressed to 0 %,** and no test caught it — nothing
asserted the default. The old FM spinbox hardcoded `0.1`, which is
`OverviewParameters.overlap` written a second time, and the shared panel cannot carry
that number because the beam side defaulted the same setting to `0.0`. The column is now
seeded from the dataclass, so the default is stated once. There is a test.

That is the second time today that **a shared default silently re-defaulted an existing
caller, and the field that moved was the one nobody wrote down** — the first was the
napari tab's tile resolution in #388.

## The defaults now agree: 10 % on both sides

Taken as a decision rather than worked around. `OverviewParameters.overlap` was 0.1 and
`OverviewAcquisitionSettings.overlap` 0.0, so a run configured on one tab and read on the
other started from a different grid. 10 % is what makes a mosaic stitchable — at 0 % the
tiles abut exactly and any stage error leaves a seam with no data in it.

**This changes the shipped napari Overview tab too.** A 3×3 of 500 µm tiles now covers
1400 µm rather than 1500, because the step is `fov * (1 - overlap)`. `from_dict` moves
with the field; `to_dict` always writes the key, so every file this code has written
carries its own value and is unaffected.

The field docstring claimed overlap was "Not yet supported". It has been supported for
some time — `TiledAcquisitionRunner` and the shared geometry core both step by
`fov * (1 - overlap)` — so it now says where.

| check | result |
| -- | -- |
| `tests/ui`, autolamella UI, structures, sparse tiles, tiled payload | **1830 passed** |
| FM settings column rendered before/after | reviewed, three changes above |
| Python 3.8 parse | all touched files |
