### PR TITLE
[feat] Put the estimate in front of the workflow

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -1409,28 +1409,6 @@ class Experiment:
             positions.append(pos)
         return positions
 
-    def estimate_remaining_time(self) -> float:
-        """Estimate the remaining time for all lamellas in the experiment"""
-        ESTIMATED_SETUP_TIME = 5*60         # 5min
-        OVERHEAD_TIME = 2*60                # 2min
-        total_remaining_time: float = 0.0
-        for p in self.positions:
-
-            # skip failed lamellas
-            if p.is_failure:
-                continue
-
-            # remaining time for individual lamella
-            remaining_tasks = self.task_protocol.workflow_config.get_remaining_tasks(p)
-            remaining_time: float = 0
-            for rt in remaining_tasks:
-                estimated_milling_time = p.task_config[rt].estimated_time
-                remaining_time += estimated_milling_time + OVERHEAD_TIME
-            logging.debug(f"Total estimated time: {format_duration(remaining_time)}")
-
-            total_remaining_time += remaining_time
-        return total_remaining_time
-
     def add_lamella(self, lamella: Lamella) -> None:
         """Add a lamella to the experiment."""
         if not isinstance(lamella, Lamella):

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -40,7 +40,17 @@ from fibsem.ui.icon import fibsem_icon
 import fibsem
 from fibsem.versioning import get_version_string
 import fibsem.config as fibsem_cfg
-from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus, Lamella
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskStatus,
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.ui.workflow_preflight_dialog import (
+    WorkflowPreflightDialog,
+)
+from fibsem.applications.autolamella.workflows.workflow_estimate import (
+    estimate_workflow,
+)
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI, INSTRUCTIONS
 from fibsem.applications.autolamella.ui.autolamella_fluorescence_overview_tab import (
     AutoLamellaFluorescenceOverviewTab,
@@ -103,54 +113,19 @@ def play_notification_sound():
 
 
 def confirm_run_workflow_dialog(
+    experiment: Experiment,
     lamella_names: list,
     task_names: list,
     parent=None,
 ) -> bool:
-    """Show a confirmation dialog before starting the workflow. Returns True if confirmed."""
-    dlg = QDialog(parent)
-    dlg.setWindowTitle("Run Workflow")
-    dlg.setMinimumWidth(600)
+    """Show the pre-flight estimate before starting the workflow.
 
-    layout = QVBoxLayout(dlg)
-    layout.setSpacing(8)
-
-    msg_label = QLabel(
-        f"Run workflow for {len(lamella_names)} lamella with {len(task_names)} task(s)?"
-    )
-    layout.addWidget(msg_label)
-
-    col_row = QHBoxLayout()
-    col_row.setSpacing(8)
-
-    detail_height = min(max(len(lamella_names), len(task_names)) * 20 + 16, 216)
-
-    for heading, items in [("Lamella", lamella_names), ("Tasks", task_names)]:
-        col = QVBoxLayout()
-        col.setSpacing(4)
-        col.addWidget(QLabel(f"<b>{heading}</b>"))
-        te = QTextEdit()
-        te.setPlainText("\n".join(f"• {n}" for n in items))
-        te.setReadOnly(True)
-        te.setFixedHeight(detail_height)
-        col.addWidget(te)
-        col_row.addLayout(col)
-
-    layout.addLayout(col_row)
-
-    btn_row = QHBoxLayout()
-    btn_row.addStretch()
-    yes_btn = QPushButton("Yes")
-    no_btn = QPushButton("No")
-    yes_btn.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
-    no_btn.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
-    yes_btn.clicked.connect(dlg.accept)
-    no_btn.clicked.connect(dlg.reject)
-    no_btn.setDefault(True)
-    btn_row.addWidget(no_btn)
-    btn_row.addWidget(yes_btn)
-    layout.addLayout(btn_row)
-
+    Returns True if confirmed. Replaces two columns of bullets that restated the
+    selection the user had just made; see WorkflowPreflightDialog. Takes the
+    experiment because the estimate reads each lamella's task configs.
+    """
+    estimate = estimate_workflow(experiment, task_names, lamella_names)
+    dlg = WorkflowPreflightDialog(estimate, parent=parent)
     return dlg.exec_() == QDialog.Accepted
 
 
@@ -1022,7 +997,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         task_names = [t.name for t in selected_tasks]
         lamella_names = [lam.name for lam in selected_lamella]
 
-        if not confirm_run_workflow_dialog(lamella_names, task_names, parent=self):
+        if not confirm_run_workflow_dialog(
+            ui.experiment, lamella_names, task_names, parent=self
+        ):
             return
 
         initial_state = "supervised" if selected_tasks[0].supervise else "automated"

--- a/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
+++ b/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
@@ -23,7 +23,6 @@ from PyQt5.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QPushButton,
-    QScrollArea,
     QToolButton,
     QVBoxLayout,
     QWidget,
@@ -52,11 +51,12 @@ from fibsem.ui.widgets.preflight import (
 # right edge would break it.
 _DURATION_WIDTH = 84
 
-# The expanded lamella list is bounded rather than allowed to grow. A hundred-lamella
-# experiment wrapped to a dozen lines and pushed the rest of the dialog off the bottom;
-# the count is in the chip beside it, and the list is for finding a name, not reading
-# every one.
-_NAMES_MAX_HEIGHT = 62
+# How many lamella names the expanded list shows before it stops counting them out. A
+# hundred-lamella experiment wrapped to a dozen lines and pushed the rest of the dialog
+# off the bottom. A scroll area bounded it but put Qt's arrow-button scrollbar in the
+# middle of otherwise flat chrome, to reach names nobody hunts for by scrolling -- so
+# the list truncates and says how many it did not show instead.
+_NAMES_SHOWN = 12
 
 
 def _clock(when: Optional[datetime], reference: Optional[datetime]) -> str:
@@ -94,8 +94,13 @@ def _metric(label_text: str, value_text: str) -> QWidget:
     answers "when do I come back", and the second is the one people act on.
     """
     frame = QFrame()
+    # Scoped to this frame by name. A bare `QFrame { ... }` selector also matches every
+    # QFrame *inside* it, and preflight.chip() is one -- which repainted each chip with
+    # the panel's fill on top of its own.
+    frame.setObjectName("preflightMetric")
     frame.setStyleSheet(
-        f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER}; border-radius: 4px; }}"
+        f"QFrame#preflightMetric {{ background: {PANEL}; border: 1px solid {BORDER};"
+        f" border-radius: 4px; }}"
     )
     layout = QVBoxLayout(frame)
     layout.setContentsMargins(12, 9, 12, 9)
@@ -140,8 +145,12 @@ def _task_row(task: TaskEstimate, reference: Optional[datetime] = None) -> QWidg
 
 def _task_block(tasks: List[TaskEstimate], reference: Optional[datetime] = None) -> QFrame:
     frame = QFrame()
+    # Scoped by name: the rows carry chips, and chips are QFrames, so a bare selector
+    # would restyle them with this block's fill and border.
+    frame.setObjectName("preflightTaskBlock")
     frame.setStyleSheet(
-        f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER}; border-radius: 4px; }}"
+        f"QFrame#preflightTaskBlock {{ background: {PANEL}; border: 1px solid {BORDER};"
+        f" border-radius: 4px; }}"
     )
     layout = QVBoxLayout(frame)
     layout.setContentsMargins(12, 10, 12, 10)
@@ -193,7 +202,7 @@ class WorkflowPreflightDialog(QDialog):
         chips.addStretch()
         chips.addWidget(self._lamella_disclosure())
         layout.addLayout(chips)
-        layout.addWidget(self._lamella_names_area)
+        layout.addWidget(self._lamella_names_label)
 
         metrics = QHBoxLayout()
         metrics.setSpacing(10)
@@ -243,43 +252,49 @@ class WorkflowPreflightDialog(QDialog):
         per-task breakdown replaces them with `×2`. They come back here, once, rather
         than repeated under every task.
 
-        Builds the names area as a side effect and leaves it on the instance; the
+        Builds the names label as a side effect and leaves it on the instance; the
         caller places it, because it belongs under the chip row rather than inside it.
         """
-        names = QLabel("   ".join(self.estimate.lamella_names))
-        names.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px; border: none;")
+        names = QLabel(self._names_text())
+        names.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px;")
         names.setWordWrap(True)
-        names.setAlignment(Qt.AlignTop | Qt.AlignLeft)
-
-        # Bounded and scrollable rather than free to grow: at a hundred lamellae the
-        # wrapped label ran to a dozen lines and overlapped everything below it.
-        area = QScrollArea()
-        area.setWidget(names)
-        area.setWidgetResizable(True)
-        area.setFrameShape(QFrame.NoFrame)
-        area.setMaximumHeight(_NAMES_MAX_HEIGHT)
-        area.setStyleSheet("QScrollArea { background: transparent; border: none; }")
-        area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        area.setVisible(False)
+        names.setVisible(False)
 
         button = QToolButton()
         button.setText(f"{len(self.estimate.lamella_names)} lamellae")
         button.setCheckable(True)
         button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
         button.setArrowType(Qt.RightArrow)
+        # Transparent explicitly: with no background rule a QToolButton paints the
+        # platform's default button fill, which reads as a raised control next to the
+        # chips it sits beside.
         button.setStyleSheet(
-            f"QToolButton {{ color: {TEXT_MUTED}; font-size: 11px; border: none; }}"
+            f"QToolButton {{ color: {TEXT_MUTED}; font-size: 11px; border: none;"
+            f" background: transparent; padding: 2px 0px; }}"
         )
 
         def _toggle(checked: bool) -> None:
             button.setArrowType(Qt.DownArrow if checked else Qt.RightArrow)
-            area.setVisible(checked)
+            names.setVisible(checked)
             self.adjustSize()
 
         button.toggled.connect(_toggle)
         self._lamella_names_label = names
-        self._lamella_names_area = area
         return button
+
+    def _names_text(self) -> str:
+        """The names, truncated with a count of what is not shown.
+
+        A selection of a hundred is confirmed by spot-checking a few and trusting the
+        count, not by reading all of them -- and the count is what "+88 more" gives
+        that a scrollbar hides.
+        """
+        names = self.estimate.lamella_names
+        shown = "   ".join(names[:_NAMES_SHOWN])
+        remaining = len(names) - _NAMES_SHOWN
+        if remaining > 0:
+            return f"{shown}   + {remaining} more"
+        return shown
 
     def _exception_notes(self) -> List[QLabel]:
         """The two things that stop the headline figure being the whole story.

--- a/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
+++ b/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
@@ -1,0 +1,323 @@
+"""What the app puts in front of a workflow.
+
+The dialog that used to ask "Run workflow for 2 lamella with 7 task(s)?" over two
+columns of bullets. The lists restated the selection the user had just made; what they
+could not answer was the question they were actually holding -- whether to start this
+now, and when to come back.
+
+Built from :mod:`fibsem.ui.widgets.preflight`'s pieces but not from
+``OverviewPreflightDialog``: this confirms a different kind of thing, and its rows carry
+chips and a right-aligned duration where ``detail_block`` has one left-aligned value.
+The same call the coincidence milling dialog made, for the same reason.
+
+See FIB-666.
+"""
+
+from datetime import datetime
+from typing import List, Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.constants import DATETIME_DISPLAY_AMPM, TIME_DISPLAY_AMPM_SHORT
+from fibsem.applications.autolamella.workflows.workflow_estimate import (
+    TaskEstimate,
+    WorkflowEstimate,
+)
+from fibsem.ui import stylesheets
+from fibsem.ui.widgets.preflight import (
+    BACKGROUND,
+    BORDER,
+    PANEL,
+    TEXT,
+    TEXT_MUTED,
+    TEXT_STRONG,
+    chip,
+    format_duration,
+    meta_label,
+)
+
+# The duration column is fixed and right-aligned so the times hold one line down the
+# dialog however many chips a row carries. That column is what gets scanned; a ragged
+# right edge would break it.
+_DURATION_WIDTH = 84
+
+
+def _clock(when: Optional[datetime], reference: Optional[datetime]) -> str:
+    """A time the user can act on: `6:15AM` today, `Tomorrow, 6:15AM` overnight.
+
+    The day is not decoration. An overnight workflow is exactly the case this dialog
+    exists for, and a bare clock time for one finishing the next morning is wrong by a
+    day in the direction that matters -- `_wait_until_scheduled` dates its countdown for
+    the same reason. But a date stamp reads as a filename where a person would just say
+    "tomorrow", so the two days either side of today get the word instead.
+
+    Anything further out keeps the dated form: "in 3 days" is arithmetic the reader has
+    to do, and a workflow reaching that far is rare enough not to optimise for.
+    """
+    if when is None:
+        return "—"
+    # 6:15AM, not 06:15AM -- the leading zero is noise at this size.
+    time_str = when.strftime(TIME_DISPLAY_AMPM_SHORT).lstrip("0")
+    if reference is None:
+        return time_str
+    days = (when.date() - reference.date()).days
+    if days == 0:
+        return time_str
+    if days == 1:
+        return f"Tomorrow, {time_str}"
+    if days == -1:
+        return f"Yesterday, {time_str}"
+    return when.strftime(DATETIME_DISPLAY_AMPM)
+
+
+def _metric(label_text: str, value_text: str) -> QWidget:
+    """One of the two figures that lead the dialog.
+
+    Two, not one: the duration answers "is this worth starting", the wall-clock finish
+    answers "when do I come back", and the second is the one people act on.
+    """
+    frame = QFrame()
+    frame.setStyleSheet(
+        f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER}; border-radius: 4px; }}"
+    )
+    layout = QVBoxLayout(frame)
+    layout.setContentsMargins(12, 9, 12, 9)
+    layout.setSpacing(2)
+
+    caption = QLabel(label_text)
+    caption.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px; border: none;")
+    value = QLabel(value_text)
+    value.setStyleSheet(f"color: {TEXT_STRONG}; font-size: 19px; border: none;")
+    layout.addWidget(caption)
+    layout.addWidget(value)
+    return frame
+
+
+def _task_row(task: TaskEstimate, reference: Optional[datetime] = None) -> QWidget:
+    """`Rough milling  ×2   [chips]   20m 24s`."""
+    row = QWidget()
+    layout = QHBoxLayout(row)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(8)
+
+    name = QLabel(f"{task.name}  <span style='color: {TEXT_MUTED};'>×{task.lamella_count}</span>")
+    name.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
+    # Task names are user-supplied and can be long. The name is what gives if a row
+    # runs out of room -- the duration column is fixed and the chips are the point --
+    # so it carries the full name where a clipped one would lose it silently.
+    name.setToolTip(task.name)
+    layout.addWidget(name, stretch=1)
+
+    if task.supervised:
+        layout.addWidget(chip("Supervised"))
+    if task.scheduled_at is not None:
+        layout.addWidget(chip(f"Scheduled {_clock(task.scheduled_at, reference)}"))
+
+    duration = QLabel(format_duration(task.seconds))
+    duration.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
+    duration.setFixedWidth(_DURATION_WIDTH)
+    duration.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+    layout.addWidget(duration)
+    return row
+
+
+def _task_block(tasks: List[TaskEstimate], reference: Optional[datetime] = None) -> QFrame:
+    frame = QFrame()
+    frame.setStyleSheet(
+        f"QFrame {{ background: {PANEL}; border: 1px solid {BORDER}; border-radius: 4px; }}"
+    )
+    layout = QVBoxLayout(frame)
+    layout.setContentsMargins(12, 10, 12, 10)
+    layout.setSpacing(6)
+    for task in tasks:
+        layout.addWidget(_task_row(task, reference))
+    return frame
+
+
+class WorkflowPreflightDialog(QDialog):
+    """The estimate, and the two exceptions that stop it being the whole story.
+
+    Takes a finished :class:`WorkflowEstimate` rather than an experiment: the
+    arithmetic is tested without Qt, and this lays out what it is handed.
+    """
+
+    def __init__(self, estimate: WorkflowEstimate, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.estimate = estimate
+        self.setWindowTitle("Run Workflow")
+        # Wide enough for a row carrying both chips: "Supervised" plus a scheduled
+        # time dated to another day is the widest a row gets before the task name
+        # starts giving way.
+        self.setMinimumWidth(620)
+        self.setStyleSheet(f"QDialog {{ background: {BACKGROUND}; }}")
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        est = self.estimate
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 14, 16, 14)
+        layout.setSpacing(10)
+
+        # No in-dialog heading: the window title already says "Run Workflow".
+        n_tasks, n_lamella = len(est.tasks), len(est.lamella_names)
+        layout.addWidget(
+            meta_label(
+                f"{n_tasks} task{'s' if n_tasks != 1 else ''} over "
+                f"{n_lamella} lamella{'e' if n_lamella != 1 else ''}."
+            )
+        )
+
+        chips = QHBoxLayout()
+        chips.setSpacing(6)
+        chips.addWidget(chip(f"{est.step_count} steps"))
+        if est.supervised_tasks:
+            chips.addWidget(chip(f"{len(est.supervised_tasks)} supervised"))
+        chips.addStretch()
+        chips.addWidget(self._lamella_disclosure())
+        layout.addLayout(chips)
+        layout.addWidget(self._lamella_names_label)
+
+        metrics = QHBoxLayout()
+        metrics.setSpacing(10)
+        metrics.addWidget(_metric("Estimated duration", format_duration(est.work_seconds)))
+        metrics.addWidget(
+            _metric("Expected finish", _clock(est.expected_finish, est.started_at))
+        )
+        layout.addLayout(metrics)
+
+        for note in self._exception_notes():
+            layout.addWidget(note)
+
+        layout.addWidget(_task_block(est.tasks, est.started_at))
+
+        footnote = QLabel(
+            "Estimates round up. Time spent waiting for you is not included."
+        )
+        footnote.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 10px;")
+        footnote.setWordWrap(True)
+        layout.addWidget(footnote)
+
+        self.button_run = QPushButton("Run")
+        self.button_run.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.button_run.setMinimumHeight(30)
+        self.button_run.clicked.connect(self.accept)
+        button_cancel = QPushButton("Cancel")
+        button_cancel.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        button_cancel.setMinimumHeight(30)
+        button_cancel.clicked.connect(self.reject)
+
+        footer = QHBoxLayout()
+        footer.addStretch()
+        footer.addWidget(button_cancel)
+        footer.addWidget(self.button_run)
+        layout.addLayout(footer)
+
+        if est.step_count == 0:
+            # Nothing to do. The queue would build empty and the workflow would end
+            # immediately; say so here rather than after the dialog is dismissed.
+            self.button_run.setEnabled(False)
+            self.button_run.setToolTip("No tasks are selected.")
+
+    def _lamella_disclosure(self) -> QWidget:
+        """`▸ 2 lamellae`, expanding to their names.
+
+        The old dialog's left column was the only place the names appeared, and a
+        per-task breakdown replaces them with `×2`. They come back here, once, rather
+        than repeated under every task.
+
+        Builds the names label as a side effect and leaves it on the instance; the
+        caller places it, because it belongs under the chip row rather than inside it.
+        """
+        button = QToolButton()
+        button.setText(f"{len(self.estimate.lamella_names)} lamellae")
+        button.setCheckable(True)
+        button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        button.setArrowType(Qt.RightArrow)
+        button.setStyleSheet(
+            f"QToolButton {{ color: {TEXT_MUTED}; font-size: 11px; border: none; }}"
+        )
+        button.setToolTip(", ".join(self.estimate.lamella_names))
+
+        names = QLabel("   ".join(self.estimate.lamella_names))
+        names.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px;")
+        names.setWordWrap(True)
+        names.setVisible(False)
+
+        def _toggle(checked: bool) -> None:
+            button.setArrowType(Qt.DownArrow if checked else Qt.RightArrow)
+            names.setVisible(checked)
+            self.adjustSize()
+
+        button.toggled.connect(_toggle)
+        self._lamella_names_label = names
+        return button
+
+    def _exception_notes(self) -> List[QLabel]:
+        """The two things that stop the headline figure being the whole story.
+
+        Both summarise rather than list once there is more than one, because every row
+        already carries its own chip: naming them again grows a sentence without adding
+        anything, and three names joined by commas reads worse than a count.
+        """
+        notes: List[QLabel] = []
+
+        # A hold is invisible in the duration, and someone reading only that figure
+        # would be wrong by its length.
+        scheduled = self.estimate.scheduled_tasks
+        if len(scheduled) == 1:
+            task = scheduled[0]
+            notes.append(
+                self._note(
+                    f"{task.name} is scheduled for "
+                    f"{_clock(task.scheduled_at, self.estimate.started_at)}. "
+                    f"The workflow holds for about "
+                    f"{format_duration(task.hold_seconds)} before it."
+                )
+            )
+        elif scheduled:
+            notes.append(
+                self._note(
+                    f"{len(scheduled)} steps are scheduled. The workflow holds for "
+                    f"about {format_duration(self.estimate.hold_seconds)} in total, "
+                    f"waiting for them."
+                )
+            )
+
+        supervised = self.estimate.supervised_tasks
+        if len(supervised) == 1:
+            notes.append(
+                self._note(
+                    f"{supervised[0].name} waits for you. The work is counted above; "
+                    f"the wait is not."
+                )
+            )
+        elif supervised:
+            notes.append(
+                self._note(
+                    f"{len(supervised)} steps wait for you. Their work is counted "
+                    f"above; the waiting is not."
+                )
+            )
+        return notes
+
+    @staticmethod
+    def _note(text: str) -> QLabel:
+        label = QLabel(text)
+        label.setStyleSheet(
+            f"QLabel {{ color: {TEXT}; font-size: 11px; background: {PANEL};"
+            f" border: none; border-left: 2px solid {stylesheets.WARN_COLOR};"
+            f" padding: 7px 10px; }}"
+        )
+        label.setWordWrap(True)
+        return label

--- a/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
+++ b/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
@@ -58,6 +58,13 @@ _DURATION_WIDTH = 84
 # the list truncates and says how many it did not show instead.
 _NAMES_SHOWN = 12
 
+# Anything sitting on a panel has to say it is transparent. The app applies
+# NAPARI_STYLE, whose bare `QWidget { background-color: ... }` rule reaches every
+# descendant, so a label that only sets `color` paints the *surface* colour onto the
+# darker panel behind it -- a lighter block around every word. Only visible with the
+# app stylesheet loaded, which is why the offscreen renders looked clean.
+_ON_PANEL = "background: transparent; border: none; "
+
 
 def _clock(when: Optional[datetime], reference: Optional[datetime]) -> str:
     """A time the user can act on: `6:15AM` today, `Tomorrow, 6:15AM` overnight.
@@ -107,9 +114,9 @@ def _metric(label_text: str, value_text: str) -> QWidget:
     layout.setSpacing(2)
 
     caption = QLabel(label_text)
-    caption.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px; border: none;")
+    caption.setStyleSheet(_ON_PANEL + f"color: {TEXT_MUTED}; font-size: 11px;")
     value = QLabel(value_text)
-    value.setStyleSheet(f"color: {TEXT_STRONG}; font-size: 19px; border: none;")
+    value.setStyleSheet(_ON_PANEL + f"color: {TEXT_STRONG}; font-size: 19px;")
     layout.addWidget(caption)
     layout.addWidget(value)
     return frame
@@ -118,12 +125,13 @@ def _metric(label_text: str, value_text: str) -> QWidget:
 def _task_row(task: TaskEstimate, reference: Optional[datetime] = None) -> QWidget:
     """`Rough milling  ×2   [chips]   20m 24s`."""
     row = QWidget()
+    row.setStyleSheet(_ON_PANEL)
     layout = QHBoxLayout(row)
     layout.setContentsMargins(0, 0, 0, 0)
     layout.setSpacing(8)
 
     name = QLabel(f"{task.name}  <span style='color: {TEXT_MUTED};'>×{task.lamella_count}</span>")
-    name.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
+    name.setStyleSheet(_ON_PANEL + f"color: {TEXT}; font-size: 11px;")
     # Task names are user-supplied and can be long. The name is what gives if a row
     # runs out of room -- the duration column is fixed and the chips are the point --
     # so it carries the full name where a clipped one would lose it silently.
@@ -136,7 +144,7 @@ def _task_row(task: TaskEstimate, reference: Optional[datetime] = None) -> QWidg
         layout.addWidget(chip(f"Scheduled {_clock(task.scheduled_at, reference)}"))
 
     duration = QLabel(format_duration(task.seconds))
-    duration.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
+    duration.setStyleSheet(_ON_PANEL + f"color: {TEXT}; font-size: 11px;")
     duration.setFixedWidth(_DURATION_WIDTH)
     duration.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
     layout.addWidget(duration)

--- a/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
+++ b/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
@@ -23,6 +23,7 @@ from PyQt5.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QPushButton,
+    QScrollArea,
     QToolButton,
     QVBoxLayout,
     QWidget,
@@ -50,6 +51,12 @@ from fibsem.ui.widgets.preflight import (
 # dialog however many chips a row carries. That column is what gets scanned; a ragged
 # right edge would break it.
 _DURATION_WIDTH = 84
+
+# The expanded lamella list is bounded rather than allowed to grow. A hundred-lamella
+# experiment wrapped to a dozen lines and pushed the rest of the dialog off the bottom;
+# the count is in the chip beside it, and the list is for finding a name, not reading
+# every one.
+_NAMES_MAX_HEIGHT = 62
 
 
 def _clock(when: Optional[datetime], reference: Optional[datetime]) -> str:
@@ -186,7 +193,7 @@ class WorkflowPreflightDialog(QDialog):
         chips.addStretch()
         chips.addWidget(self._lamella_disclosure())
         layout.addLayout(chips)
-        layout.addWidget(self._lamella_names_label)
+        layout.addWidget(self._lamella_names_area)
 
         metrics = QHBoxLayout()
         metrics.setSpacing(10)
@@ -236,9 +243,25 @@ class WorkflowPreflightDialog(QDialog):
         per-task breakdown replaces them with `×2`. They come back here, once, rather
         than repeated under every task.
 
-        Builds the names label as a side effect and leaves it on the instance; the
+        Builds the names area as a side effect and leaves it on the instance; the
         caller places it, because it belongs under the chip row rather than inside it.
         """
+        names = QLabel("   ".join(self.estimate.lamella_names))
+        names.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px; border: none;")
+        names.setWordWrap(True)
+        names.setAlignment(Qt.AlignTop | Qt.AlignLeft)
+
+        # Bounded and scrollable rather than free to grow: at a hundred lamellae the
+        # wrapped label ran to a dozen lines and overlapped everything below it.
+        area = QScrollArea()
+        area.setWidget(names)
+        area.setWidgetResizable(True)
+        area.setFrameShape(QFrame.NoFrame)
+        area.setMaximumHeight(_NAMES_MAX_HEIGHT)
+        area.setStyleSheet("QScrollArea { background: transparent; border: none; }")
+        area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        area.setVisible(False)
+
         button = QToolButton()
         button.setText(f"{len(self.estimate.lamella_names)} lamellae")
         button.setCheckable(True)
@@ -247,20 +270,15 @@ class WorkflowPreflightDialog(QDialog):
         button.setStyleSheet(
             f"QToolButton {{ color: {TEXT_MUTED}; font-size: 11px; border: none; }}"
         )
-        button.setToolTip(", ".join(self.estimate.lamella_names))
-
-        names = QLabel("   ".join(self.estimate.lamella_names))
-        names.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px;")
-        names.setWordWrap(True)
-        names.setVisible(False)
 
         def _toggle(checked: bool) -> None:
             button.setArrowType(Qt.DownArrow if checked else Qt.RightArrow)
-            names.setVisible(checked)
+            area.setVisible(checked)
             self.adjustSize()
 
         button.toggled.connect(_toggle)
         self._lamella_names_label = names
+        self._lamella_names_area = area
         return button
 
     def _exception_notes(self) -> List[QLabel]:

--- a/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
+++ b/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
@@ -273,8 +273,8 @@ class WorkflowPreflightDialog(QDialog):
         button.setCheckable(True)
         button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
         button.setArrowType(Qt.RightArrow)
-        # Transparent explicitly: with no background rule a QToolButton paints the
-        # platform's default button fill, which reads as a raised control next to the
+        # Transparent explicitly: NAPARI_STYLE gives every QToolButton a
+        # BORDER_COLOR fill and a radius, which reads as a raised control next to the
         # chips it sits beside.
         button.setStyleSheet(
             f"QToolButton {{ color: {TEXT_MUTED}; font-size: 11px; border: none;"

--- a/fibsem/applications/autolamella/workflows/workflow_estimate.py
+++ b/fibsem/applications/autolamella/workflows/workflow_estimate.py
@@ -1,0 +1,162 @@
+"""How long a workflow will take, and when it will finish.
+
+The arithmetic behind the pre-flight dialog, kept out of it: everything here is plain
+data, so it can be checked against a real experiment without a microscope or a widget.
+
+Per-task durations come from each config's ``estimated_duration`` (see
+:mod:`fibsem.timing`). This module's job is the workflow-level assembly -- which is not a
+sum, because a scheduled task makes the workflow *hold* until its start time, and quoting
+``now + Σ`` would be wrong by the length of that wait.
+
+See FIB-666.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from fibsem.applications.autolamella.structures import Experiment
+
+
+@dataclass(frozen=True)
+class TaskEstimate:
+    """One row of the breakdown: a task, across every lamella it will run on."""
+
+    name: str
+    lamella_count: int
+    seconds: float
+    supervised: bool
+    scheduled_at: Optional[datetime] = None
+    hold_seconds: float = 0.0
+    """How long the workflow waits before this task, for its own schedule.
+
+    Per task rather than only in the total: with two scheduled tasks, quoting the
+    workflow's whole hold against each of them says the same wrong number twice.
+    """
+
+
+@dataclass(frozen=True)
+class WorkflowEstimate:
+    """What a workflow will cost, and what it will wait for.
+
+    ``work_seconds`` is machine time and includes the supervised tasks: a supervised
+    task still mills, images and moves, and only the pause for a human is unbounded.
+    Dropping the whole task would quietly understate the total by the work it does --
+    so the wait is reported separately, as a count, rather than by omitting the task.
+    """
+
+    tasks: List[TaskEstimate] = field(default_factory=list)
+    lamella_names: List[str] = field(default_factory=list)
+    work_seconds: float = 0.0
+    hold_seconds: float = 0.0
+    started_at: Optional[datetime] = None
+    expected_finish: Optional[datetime] = None
+
+    @property
+    def supervised_tasks(self) -> List[TaskEstimate]:
+        """Rows that will pause for a human, in workflow order."""
+        return [t for t in self.tasks if t.supervised]
+
+    @property
+    def scheduled_tasks(self) -> List[TaskEstimate]:
+        """Rows that will hold until a wall-clock time, in workflow order."""
+        return [t for t in self.tasks if t.scheduled_at is not None]
+
+    @property
+    def step_count(self) -> int:
+        """Queue items: one per (task, lamella) pair, matching build_from_matrix."""
+        return sum(t.lamella_count for t in self.tasks)
+
+    @property
+    def waits_for_a_human(self) -> bool:
+        return any(t.supervised for t in self.tasks)
+
+
+def _as_naive_local(when: Optional[datetime]) -> Optional[datetime]:
+    """Normalise to naive-local, the way the workflow loop does.
+
+    Times are naive-local throughout, but a hand-edited or externally-produced protocol
+    may carry a tz-aware ``scheduled_at``; ``_wait_until_scheduled`` normalises it for
+    the same reason, so that comparing against ``datetime.now()`` cannot raise.
+    """
+    if when is None or when.tzinfo is None:
+        return when
+    return when.astimezone().replace(tzinfo=None)
+
+
+def estimate_workflow(
+    experiment: "Experiment",
+    task_names: List[str],
+    lamella_names: List[str],
+    now: Optional[datetime] = None,
+) -> WorkflowEstimate:
+    """Estimate a workflow of ``task_names`` over ``lamella_names``.
+
+    Walks the queue in the order it will actually run -- task-outer, lamella-inner,
+    matching ``TaskQueue.build_from_matrix`` -- carrying a clock, so a scheduled task
+    pushes everything after it later rather than being averaged into a total.
+
+    A lamella with no configuration for a task contributes nothing and is not counted
+    in that row: the queue would still hold the item, but it has no duration to offer
+    and inventing one would be worse than omitting it.
+
+    Args:
+        experiment: the experiment holding the per-lamella task configs and the protocol
+        task_names: tasks to run, in queue order
+        lamella_names: lamellae to run them on
+        now: the clock to start from; defaults to the current time
+
+    Returns:
+        WorkflowEstimate: the per-task breakdown and the workflow totals.
+    """
+    clock = now if now is not None else datetime.now()
+    started_at = clock
+
+    workflow_config = experiment.task_protocol.workflow_config
+    lamellae = [
+        lam for lam in experiment.positions if lam.name in set(lamella_names)
+    ]
+
+    rows: List[TaskEstimate] = []
+    work_seconds = 0.0
+    hold_seconds = 0.0
+
+    for task_name in task_names:
+        seconds = 0.0
+        count = 0
+        for lamella in lamellae:
+            config = lamella.task_config.get(task_name)
+            if config is None:
+                continue
+            seconds += config.estimated_duration
+            count += 1
+
+        scheduled_at = _as_naive_local(workflow_config.get_scheduled_at(task_name))
+        held = 0.0
+        if scheduled_at is not None and scheduled_at > clock:
+            held = (scheduled_at - clock).total_seconds()
+            hold_seconds += held
+            clock = scheduled_at
+        clock += timedelta(seconds=seconds)
+        work_seconds += seconds
+
+        rows.append(
+            TaskEstimate(
+                name=task_name,
+                lamella_count=count,
+                seconds=seconds,
+                supervised=workflow_config.get_supervision(task_name),
+                scheduled_at=scheduled_at,
+                hold_seconds=held,
+            )
+        )
+
+    return WorkflowEstimate(
+        tasks=rows,
+        lamella_names=list(lamella_names),
+        work_seconds=work_seconds,
+        hold_seconds=hold_seconds,
+        started_at=started_at,
+        expected_finish=clock,
+    )

--- a/tests/autolamella/test_workflow_estimate.py
+++ b/tests/autolamella/test_workflow_estimate.py
@@ -1,0 +1,198 @@
+"""Workflow-level assembly of the per-task estimates (FIB-666).
+
+The per-task numbers are tested in test_task_duration_estimates.py; these are about
+what the workflow does with them -- ordering, holds, and which rows are flagged.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaTaskProtocol,
+    AutoLamellaWorkflowConfig,
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.workflows.tasks.fiducial import MillFiducialTaskConfig
+from fibsem.applications.autolamella.workflows.tasks.select_position import (
+    SelectMillingPositionTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.workflow_estimate import estimate_workflow
+
+NOW = datetime(2026, 8, 18, 14, 0, 0)
+
+
+def _experiment(tmp_path, n_lamella: int = 2, scheduled=None, supervised=()) -> Experiment:
+    """Two tasks over n lamella, with the protocol wired to match."""
+    exp = Experiment(path=str(tmp_path), name="estimate-test")
+    for i in range(n_lamella):
+        lamella = Lamella(path=str(tmp_path), number=i + 1, petname=f"{i + 1:02d}-lamella")
+        lamella.task_config["Setup Lamella Position"] = SelectMillingPositionTaskConfig()
+        lamella.task_config["Mill Fiducial"] = MillFiducialTaskConfig()
+        exp.add_lamella(lamella)
+
+    # task_protocol is None on a fresh Experiment -- "must be set externally"
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    exp.task_protocol.workflow_config = AutoLamellaWorkflowConfig(
+        tasks=[
+            AutoLamellaTaskDescription(
+                name=name,
+                supervise=name in supervised,
+                required=True,
+                scheduled_at=(scheduled or {}).get(name),
+            )
+            for name in ("Setup Lamella Position", "Mill Fiducial")
+        ]
+    )
+    return exp
+
+
+def _names(exp) -> list:
+    return [lam.name for lam in exp.positions]
+
+
+# ── the breakdown ────────────────────────────────────────────────────────────
+
+def test_a_row_per_task_in_the_order_given(tmp_path):
+    exp = _experiment(tmp_path)
+    est = estimate_workflow(exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW)
+    assert [t.name for t in est.tasks] == ["Mill Fiducial", "Setup Lamella Position"]
+
+
+def test_a_row_totals_every_lamella_it_runs_on(tmp_path):
+    exp = _experiment(tmp_path, n_lamella=3)
+    est = estimate_workflow(exp, ["Mill Fiducial"], _names(exp), now=NOW)
+    row = est.tasks[0]
+    single = exp.positions[0].task_config["Mill Fiducial"].estimated_duration
+    assert row.lamella_count == 3
+    assert row.seconds == pytest.approx(3 * single)
+
+
+def test_step_count_matches_the_queue(tmp_path):
+    """One item per (task, lamella), the same shape build_from_matrix produces."""
+    exp = _experiment(tmp_path, n_lamella=3)
+    est = estimate_workflow(exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW)
+    assert est.step_count == 6
+
+
+def test_a_lamella_without_a_config_for_the_task_is_not_counted(tmp_path):
+    """It has no duration to offer, and inventing one is worse than omitting it."""
+    exp = _experiment(tmp_path, n_lamella=2)
+    del exp.positions[1].task_config["Mill Fiducial"]
+    est = estimate_workflow(exp, ["Mill Fiducial"], _names(exp), now=NOW)
+    assert est.tasks[0].lamella_count == 1
+
+
+def test_only_the_named_lamella_are_included(tmp_path):
+    exp = _experiment(tmp_path, n_lamella=3)
+    est = estimate_workflow(exp, ["Mill Fiducial"], [exp.positions[0].name], now=NOW)
+    assert est.tasks[0].lamella_count == 1
+
+
+# ── the totals ───────────────────────────────────────────────────────────────
+
+def test_work_seconds_is_the_sum_of_the_rows(tmp_path):
+    exp = _experiment(tmp_path)
+    est = estimate_workflow(exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW)
+    assert est.work_seconds == pytest.approx(sum(t.seconds for t in est.tasks))
+
+
+def test_finish_is_now_plus_the_work_when_nothing_is_scheduled(tmp_path):
+    exp = _experiment(tmp_path)
+    est = estimate_workflow(exp, ["Mill Fiducial"], _names(exp), now=NOW)
+    assert est.expected_finish == NOW + timedelta(seconds=est.work_seconds)
+    assert est.hold_seconds == 0.0
+
+
+def test_supervised_work_still_counts_towards_the_total(tmp_path):
+    """A supervised task still mills, images and moves -- only the pause is unbounded,
+    so dropping the whole task would understate the total by the work it does."""
+    plain = _experiment(tmp_path)
+    supervised = _experiment(tmp_path, supervised=("Mill Fiducial",))
+    tasks = ["Mill Fiducial"]
+    assert estimate_workflow(supervised, tasks, _names(supervised), now=NOW).work_seconds == (
+        pytest.approx(estimate_workflow(plain, tasks, _names(plain), now=NOW).work_seconds)
+    )
+
+
+def test_supervised_rows_are_flagged_and_countable(tmp_path):
+    exp = _experiment(tmp_path, supervised=("Mill Fiducial",))
+    est = estimate_workflow(exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW)
+    assert [t.name for t in est.supervised_tasks] == ["Mill Fiducial"]
+    assert est.waits_for_a_human is True
+
+
+def test_a_workflow_with_no_supervision_says_so(tmp_path):
+    exp = _experiment(tmp_path)
+    est = estimate_workflow(exp, ["Mill Fiducial"], _names(exp), now=NOW)
+    assert est.waits_for_a_human is False
+    assert est.supervised_tasks == []
+
+
+# ── scheduling makes it a walk, not a sum ────────────────────────────────────
+
+def test_a_scheduled_task_holds_the_workflow_until_its_time(tmp_path):
+    """now + Σ would be wrong by the length of the wait."""
+    at = NOW + timedelta(hours=4)
+    exp = _experiment(tmp_path, scheduled={"Mill Fiducial": at})
+    est = estimate_workflow(exp, ["Mill Fiducial"], _names(exp), now=NOW)
+
+    assert est.hold_seconds == pytest.approx(4 * 3600)
+    assert est.expected_finish == at + timedelta(seconds=est.work_seconds)
+    assert est.expected_finish > NOW + timedelta(seconds=est.work_seconds)
+
+
+def test_the_hold_is_not_counted_as_work(tmp_path):
+    at = NOW + timedelta(hours=4)
+    scheduled = _experiment(tmp_path, scheduled={"Mill Fiducial": at})
+    plain = _experiment(tmp_path)
+    assert estimate_workflow(scheduled, ["Mill Fiducial"], _names(scheduled), now=NOW).work_seconds == (
+        pytest.approx(estimate_workflow(plain, ["Mill Fiducial"], _names(plain), now=NOW).work_seconds)
+    )
+
+
+def test_a_scheduled_time_already_past_holds_nothing(tmp_path):
+    exp = _experiment(tmp_path, scheduled={"Mill Fiducial": NOW - timedelta(hours=1)})
+    est = estimate_workflow(exp, ["Mill Fiducial"], _names(exp), now=NOW)
+    assert est.hold_seconds == 0.0
+    assert est.expected_finish == NOW + timedelta(seconds=est.work_seconds)
+
+
+def test_the_hold_is_measured_from_where_the_earlier_tasks_left_the_clock(tmp_path):
+    """The task ahead of it has already consumed part of the wait."""
+    at = NOW + timedelta(hours=4)
+    exp = _experiment(tmp_path, scheduled={"Mill Fiducial": at})
+    est = estimate_workflow(exp, ["Setup Lamella Position", "Mill Fiducial"], _names(exp), now=NOW)
+    setup_seconds = est.tasks[0].seconds
+    assert est.hold_seconds == pytest.approx(4 * 3600 - setup_seconds)
+
+
+def test_scheduled_rows_are_flagged(tmp_path):
+    at = NOW + timedelta(hours=4)
+    exp = _experiment(tmp_path, scheduled={"Mill Fiducial": at})
+    est = estimate_workflow(exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW)
+    assert [t.name for t in est.scheduled_tasks] == ["Mill Fiducial"]
+    assert est.tasks[0].scheduled_at == at
+
+
+def test_a_timezone_aware_schedule_does_not_raise(tmp_path):
+    """A hand-edited protocol may carry one; the workflow loop normalises it too."""
+    from datetime import timezone
+
+    aware = (NOW + timedelta(hours=4)).replace(tzinfo=timezone.utc)
+    exp = _experiment(tmp_path, scheduled={"Mill Fiducial": aware})
+    est = estimate_workflow(exp, ["Mill Fiducial"], _names(exp), now=NOW)
+    assert est.tasks[0].scheduled_at.tzinfo is None
+
+
+# ── nothing to do ────────────────────────────────────────────────────────────
+
+def test_an_empty_workflow_finishes_now(tmp_path):
+    exp = _experiment(tmp_path)
+    est = estimate_workflow(exp, [], _names(exp), now=NOW)
+    assert est.tasks == []
+    assert est.work_seconds == 0.0
+    assert est.expected_finish == NOW
+    assert est.step_count == 0

--- a/tests/ui/test_workflow_preflight_dialog.py
+++ b/tests/ui/test_workflow_preflight_dialog.py
@@ -29,12 +29,18 @@ from PyQt5.QtWidgets import QApplication, QLabel, QToolButton  # noqa: E402
 from fibsem.applications.autolamella.ui.workflow_preflight_dialog import (  # noqa: E402
     WorkflowPreflightDialog,
 )
+from fibsem.ui.stylesheets import NAPARI_STYLE  # noqa: E402
 from fibsem.applications.autolamella.workflows.workflow_estimate import (  # noqa: E402
     TaskEstimate,
     WorkflowEstimate,
 )
 
 _app = QApplication.instance() or QApplication(sys.argv)
+# The app stylesheet, because without it these tests are run under conditions the user
+# never sees. Its bare `QWidget { background-color: ... }` rule reaches every descendant
+# and paints the surface colour behind any label that has not declared itself
+# transparent -- a lighter block around every word, invisible offscreen without it.
+_app.setStyleSheet(NAPARI_STYLE)
 
 NOW = datetime(2026, 8, 18, 14, 0, 0)
 
@@ -306,3 +312,48 @@ def test_the_lamella_button_is_not_a_raised_control(dialog):
     as a button beside the flat chips it sits next to."""
     d = dialog(_estimate())
     assert "background: transparent" in d.findChild(QToolButton).styleSheet()
+
+
+def test_everything_on_a_panel_declares_itself_transparent(dialog):
+    """Regression, and only visible with the app stylesheet loaded: NAPARI_STYLE sets
+    `QWidget { background-color: SURFACE_COLOR }` for every widget, so a label that
+    only sets `color` paints the surface colour onto the darker panel behind it.
+
+    The panels are scoped by object name and therefore no longer shadow that rule for
+    their children, which makes each child's own declaration the only thing standing
+    between the design and a lighter block around every word.
+    """
+    from PyQt5.QtWidgets import QFrame
+
+    tasks = [TaskEstimate("Polishing", 2, 785.0, supervised=True)]
+    d = dialog(_estimate(tasks=tasks))
+
+    def sits_directly_on(panel, label) -> bool:
+        """Whether the panel is the nearest frame behind this label.
+
+        A chip is a QFrame with its own bare-selector rule, which shadows the app
+        stylesheet for the label inside it -- so those are already covered and are not
+        the panel's problem.
+        """
+        widget = label.parentWidget()
+        while widget is not panel and widget is not None:
+            if isinstance(widget, QFrame):
+                return False
+            widget = widget.parentWidget()
+        return widget is panel
+
+    panels = [
+        f for f in d.findChildren(QFrame)
+        if f.objectName() in {"preflightTaskBlock", "preflightMetric"}
+    ]
+    assert panels, "guard: the panels are findable"
+    checked = 0
+    for panel in panels:
+        for label in panel.findChildren(QLabel):
+            if not sits_directly_on(panel, label):
+                continue
+            checked += 1
+            assert "background: transparent" in label.styleSheet(), (
+                f"{label.text()!r} would paint the surface colour onto the panel"
+            )
+    assert checked >= 4, "guard: the metric captions and values were actually reached"

--- a/tests/ui/test_workflow_preflight_dialog.py
+++ b/tests/ui/test_workflow_preflight_dialog.py
@@ -212,6 +212,45 @@ def test_a_finish_further_out_keeps_its_date(dialog):
     assert "2026-08-21" in text
 
 
+def test_a_hundred_lamellae_do_not_push_the_dialog_apart(dialog):
+    """Regression: the expanded names wrapped to a dozen lines and overlapped the
+    metrics, the note and every task row. The list is bounded and scrolls instead --
+    the count is in the chip beside it, and the list is for finding a name rather than
+    reading all of them."""
+    from fibsem.applications.autolamella.ui.workflow_preflight_dialog import (
+        _NAMES_MAX_HEIGHT,
+    )
+
+    many = [f"{i:02d}-scale-lamella" for i in range(1, 101)]
+    few = dialog(_estimate())
+    lots = dialog(_estimate(lamella_names=many))
+    few.show()
+    lots.show()
+
+    few.findChild(QToolButton).setChecked(True)
+    lots.findChild(QToolButton).setChecked(True)
+    few.adjustSize()
+    lots.adjustSize()
+
+    assert lots._lamella_names_area.maximumHeight() == _NAMES_MAX_HEIGHT
+    grew = lots.size().height() - few.size().height()
+    assert grew <= _NAMES_MAX_HEIGHT, (
+        f"100 names added {grew}px; the list must stay bounded"
+    )
+
+
+def test_the_breakdown_is_per_task_not_per_lamella(dialog):
+    """What keeps the dialog a fixed size at any scale: five tasks over a hundred
+    lamellae is still five rows."""
+    tasks = [
+        TaskEstimate("Mill Fiducial", 100, 19800.0, supervised=False),
+        TaskEstimate("Rough Milling", 100, 61200.0, supervised=False),
+    ]
+    text = _texts(dialog(_estimate(tasks=tasks, lamella_names=[f"l{i}" for i in range(100)])))
+    assert "×100" in text
+    assert "200 steps" in text
+
+
 # ── nothing to do ────────────────────────────────────────────────────────────
 
 def test_run_is_refused_when_no_task_is_selected(dialog):

--- a/tests/ui/test_workflow_preflight_dialog.py
+++ b/tests/ui/test_workflow_preflight_dialog.py
@@ -1,0 +1,226 @@
+"""What the pre-flight dialog says before a workflow starts.
+
+Its job is the two figures a user actually decides on -- how long, and when it finishes
+-- plus the two things that stop those figures being the whole story: a step that waits
+for a human, and a step that holds until a wall-clock time.
+
+Built here from plain WorkflowEstimate objects rather than through the app: the
+arithmetic is covered in tests/autolamella/test_workflow_estimate.py, and what is
+checked here is what reaches the screen.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_workflow_preflight_dialog.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+# CI installs `.[test]`, not `.[ui]`, so PyQt5 is absent there.
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication, QLabel, QToolButton  # noqa: E402
+
+from fibsem.applications.autolamella.ui.workflow_preflight_dialog import (  # noqa: E402
+    WorkflowPreflightDialog,
+)
+from fibsem.applications.autolamella.workflows.workflow_estimate import (  # noqa: E402
+    TaskEstimate,
+    WorkflowEstimate,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+NOW = datetime(2026, 8, 18, 14, 0, 0)
+
+
+def _estimate(tasks=None, **kwargs) -> WorkflowEstimate:
+    tasks = tasks if tasks is not None else [
+        TaskEstimate(name="Mill Fiducial", lamella_count=2, seconds=198.0, supervised=False)
+    ]
+    defaults = dict(
+        tasks=tasks,
+        lamella_names=["01-fancy-mite", "02-civil-cub"],
+        work_seconds=sum(t.seconds for t in tasks),
+        hold_seconds=0.0,
+        started_at=NOW,
+        expected_finish=NOW + timedelta(seconds=sum(t.seconds for t in tasks)),
+    )
+    defaults.update(kwargs)
+    return WorkflowEstimate(**defaults)
+
+
+@pytest.fixture
+def dialog():
+    built = []
+
+    def build(estimate=None):
+        d = WorkflowPreflightDialog(estimate if estimate is not None else _estimate())
+        built.append(d)
+        return d
+
+    yield build
+    for d in built:
+        d.close()
+
+
+def _texts(dialog) -> str:
+    """Every label in the dialog, joined -- what the user can read."""
+    return "\n".join(label.text() for label in dialog.findChildren(QLabel))
+
+
+# ── the two figures ──────────────────────────────────────────────────────────
+
+def test_it_shows_the_duration_and_the_finish_clock(dialog):
+    """Two, not one: the duration says whether to start, the clock says when to come
+    back, and the second is the one people act on."""
+    d = dialog(_estimate())
+    text = _texts(d)
+    assert "3m 18s" in text
+    assert "2:03PM" in text
+
+
+def test_the_duration_is_the_work_not_the_wall_clock(dialog):
+    """A held workflow finishes late without taking longer to run."""
+    at = NOW + timedelta(hours=4)
+    tasks = [TaskEstimate("Polishing", 2, 600.0, supervised=False, scheduled_at=at)]
+    d = dialog(_estimate(tasks=tasks, hold_seconds=4 * 3600,
+                         expected_finish=at + timedelta(seconds=600)))
+    text = _texts(d)
+    assert "10m 00s" in text, "the duration is the work"
+    assert "6:10PM" in text, "the finish is after the hold"
+
+
+# ── the breakdown ────────────────────────────────────────────────────────────
+
+def test_every_task_gets_a_row_with_its_count_and_duration(dialog):
+    tasks = [
+        TaskEstimate("Mill Fiducial", 2, 198.0, supervised=False),
+        TaskEstimate("Rough Milling", 3, 1224.0, supervised=False),
+    ]
+    text = _texts(dialog(_estimate(tasks=tasks)))
+    assert "Mill Fiducial" in text and "×2" in text and "3m 18s" in text
+    assert "Rough Milling" in text and "×3" in text and "20m 24s" in text
+
+
+def test_the_step_count_is_the_queue_not_the_task_count(dialog):
+    """One item per (task, lamella), the same shape build_from_matrix produces."""
+    tasks = [
+        TaskEstimate("Mill Fiducial", 2, 198.0, supervised=False),
+        TaskEstimate("Rough Milling", 2, 1224.0, supervised=False),
+    ]
+    assert "4 steps" in _texts(dialog(_estimate(tasks=tasks)))
+
+
+# ── the exceptions ───────────────────────────────────────────────────────────
+
+def test_a_supervised_step_is_flagged_and_its_work_still_counted(dialog):
+    """Only the pause is unbounded. Dropping the task would understate the total by
+    the work it does, so the row carries a chip instead of a blank."""
+    tasks = [TaskEstimate("Polishing", 2, 785.0, supervised=True)]
+    text = _texts(dialog(_estimate(tasks=tasks)))
+    assert "Supervised" in text
+    assert "13m 05s" in text, "the work is still quoted"
+    assert "waits for you" in text
+
+
+def test_a_scheduled_step_says_how_long_the_workflow_holds(dialog):
+    """The hold is invisible in the duration, and someone reading only that figure
+    would be wrong by its length."""
+    at = NOW + timedelta(hours=6)
+    tasks = [
+        TaskEstimate("Polishing", 2, 785.0, supervised=False, scheduled_at=at,
+                     hold_seconds=6 * 3600)
+    ]
+    text = _texts(dialog(_estimate(tasks=tasks, hold_seconds=6 * 3600)))
+    assert "Scheduled 8:00PM" in text
+    assert "6h 00m" in text
+
+
+def test_each_scheduled_step_is_quoted_its_own_hold_not_the_total(dialog):
+    """Two scheduled tasks share one workflow hold; quoting the whole of it against
+    each would say the same wrong number twice. Summarised once instead."""
+    tasks = [
+        TaskEstimate("Mill Fiducial", 2, 198.0, supervised=False,
+                     scheduled_at=NOW + timedelta(hours=2), hold_seconds=2 * 3600),
+        TaskEstimate("Polishing", 2, 785.0, supervised=False,
+                     scheduled_at=NOW + timedelta(hours=6), hold_seconds=4 * 3600),
+    ]
+    text = _texts(dialog(_estimate(tasks=tasks, hold_seconds=6 * 3600)))
+    assert "2 steps are scheduled" in text
+    assert "6h 00m" in text, "the summary quotes the total"
+    assert text.count("The workflow holds") == 1, "one note, not one per task"
+
+
+def test_several_supervised_steps_are_counted_not_listed(dialog):
+    """Every row already carries its own chip; naming them again grows a sentence
+    without adding anything -- and reads as 'A, B and C waits for you'."""
+    tasks = [
+        TaskEstimate("Setup Lamella Position", 2, 59.0, supervised=True),
+        TaskEstimate("Mill Fiducial", 2, 198.0, supervised=True),
+        TaskEstimate("Polishing", 2, 785.0, supervised=True),
+    ]
+    text = _texts(dialog(_estimate(tasks=tasks)))
+    assert "3 steps wait for you" in text
+    assert "waits for you" not in text, "singular phrasing is for the single case"
+
+
+def test_an_unsupervised_workflow_says_nothing_about_waiting(dialog):
+    text = _texts(dialog(_estimate()))
+    assert "waits for you" not in text
+    assert "supervised" not in text.lower()
+
+
+# ── the lamella disclosure ───────────────────────────────────────────────────
+
+def test_the_lamella_names_are_hidden_until_asked_for(dialog):
+    """A per-task breakdown replaces the names with ×2; they come back once, here,
+    rather than repeated under every task."""
+    d = dialog(_estimate())
+    assert d._lamella_names_label.isVisible() is False
+
+    d.show()
+    d.findChild(QToolButton).setChecked(True)
+    assert d._lamella_names_label.isVisible() is True
+    assert "01-fancy-mite" in d._lamella_names_label.text()
+
+
+def test_an_overnight_finish_says_tomorrow(dialog):
+    """The case this dialog exists for. A bare clock time for a workflow finishing the
+    next morning is wrong by a day, and a date stamp reads as a filename where a person
+    would just say "tomorrow"."""
+    tasks = [TaskEstimate("Rough Milling", 2, 72000.0, supervised=False)]
+    text = _texts(dialog(_estimate(tasks=tasks, expected_finish=NOW + timedelta(hours=16, minutes=15))))
+    assert "Tomorrow, 6:15AM" in text
+
+
+def test_a_finish_today_is_just_the_clock(dialog):
+    text = _texts(dialog(_estimate()))
+    assert "Tomorrow" not in text
+    assert "2026-08-18" not in text, "no date needed for a workflow finishing today"
+
+
+def test_a_finish_further_out_keeps_its_date(dialog):
+    """"In 3 days" is arithmetic the reader has to do."""
+    tasks = [TaskEstimate("Rough Milling", 2, 259200.0, supervised=False)]
+    text = _texts(dialog(_estimate(tasks=tasks, expected_finish=NOW + timedelta(days=3))))
+    assert "2026-08-21" in text
+
+
+# ── nothing to do ────────────────────────────────────────────────────────────
+
+def test_run_is_refused_when_no_task_is_selected(dialog):
+    """The queue would build empty and the workflow end immediately; say so here
+    rather than after the dialog is dismissed."""
+    d = dialog(_estimate(tasks=[], work_seconds=0.0, expected_finish=NOW))
+    assert d.button_run.isEnabled() is False
+    assert "No tasks are selected." in d.button_run.toolTip()
+
+
+def test_run_is_offered_when_there_is_work(dialog):
+    assert dialog(_estimate()).button_run.isEnabled() is True

--- a/tests/ui/test_workflow_preflight_dialog.py
+++ b/tests/ui/test_workflow_preflight_dialog.py
@@ -214,29 +214,37 @@ def test_a_finish_further_out_keeps_its_date(dialog):
 
 def test_a_hundred_lamellae_do_not_push_the_dialog_apart(dialog):
     """Regression: the expanded names wrapped to a dozen lines and overlapped the
-    metrics, the note and every task row. The list is bounded and scrolls instead --
-    the count is in the chip beside it, and the list is for finding a name rather than
-    reading all of them."""
-    from fibsem.applications.autolamella.ui.workflow_preflight_dialog import (
-        _NAMES_MAX_HEIGHT,
-    )
+    metrics, the note and every task row. The list truncates and says how many it did
+    not show -- a selection of a hundred is confirmed by spot-checking a few and
+    trusting the count."""
+    from fibsem.applications.autolamella.ui.workflow_preflight_dialog import _NAMES_SHOWN
 
-    many = [f"{i:02d}-scale-lamella" for i in range(1, 101)]
-    few = dialog(_estimate())
-    lots = dialog(_estimate(lamella_names=many))
-    few.show()
-    lots.show()
+    def _expanded_names(count):
+        d = dialog(_estimate(lamella_names=[f"{i:02d}-scale-lamella" for i in range(count)]))
+        d.show()
+        d.findChild(QToolButton).setChecked(True)
+        return d._lamella_names_label.text()
 
-    few.findChild(QToolButton).setChecked(True)
-    lots.findChild(QToolButton).setChecked(True)
-    few.adjustSize()
-    lots.adjustSize()
+    hundred = _expanded_names(100)
+    thousand = _expanded_names(1000)
 
-    assert lots._lamella_names_area.maximumHeight() == _NAMES_MAX_HEIGHT
-    grew = lots.size().height() - few.size().height()
-    assert grew <= _NAMES_MAX_HEIGHT, (
-        f"100 names added {grew}px; the list must stay bounded"
-    )
+    assert "+ 88 more" in hundred, "the count is what a truncated list has to give back"
+    assert "+ 988 more" in thousand
+
+    # The mechanism that bounds the dialog, asserted rather than its pixel height:
+    # ten times the lamellae must render the same number of names.
+    assert hundred.count("scale-lamella") == _NAMES_SHOWN
+    assert thousand.count("scale-lamella") == _NAMES_SHOWN
+
+
+def test_a_short_lamella_list_is_shown_whole(dialog):
+    """The common case: a handful of lamellae, every one of them visible."""
+    d = dialog(_estimate())
+    d.show()
+    d.findChild(QToolButton).setChecked(True)
+    text = d._lamella_names_label.text()
+    assert "01-fancy-mite" in text and "02-civil-cub" in text
+    assert "more" not in text
 
 
 def test_the_breakdown_is_per_task_not_per_lamella(dialog):
@@ -263,3 +271,38 @@ def test_run_is_refused_when_no_task_is_selected(dialog):
 
 def test_run_is_offered_when_there_is_work(dialog):
     assert dialog(_estimate()).button_run.isEnabled() is True
+
+
+# ── the chips keep their own background ──────────────────────────────────────
+
+def test_the_panels_do_not_restyle_the_chips_inside_them(dialog):
+    """Regression, and invisible without running the app: a bare `QFrame { ... }`
+    selector matches every QFrame *inside* the widget it is set on, and
+    preflight.chip() is a QFrame -- so the task block was repainting each chip with
+    the panel's fill and border on top of the chip's own.
+
+    Only visible on a real style; offscreen rendering hid it. Pinned by the selector
+    rather than by pixels for that reason.
+    """
+    from PyQt5.QtWidgets import QFrame
+
+    tasks = [TaskEstimate("Polishing", 2, 785.0, supervised=True)]
+    d = dialog(_estimate(tasks=tasks))
+
+    panels = [
+        f for f in d.findChildren(QFrame)
+        if f.objectName() in {"preflightTaskBlock", "preflightMetric"}
+    ]
+    assert len(panels) == 3, "one task block and two metric cards"
+    for panel in panels:
+        assert f"QFrame#{panel.objectName()}" in panel.styleSheet()
+        assert "QFrame {" not in panel.styleSheet(), (
+            "a bare selector would cascade into the chips"
+        )
+
+
+def test_the_lamella_button_is_not_a_raised_control(dialog):
+    """With no background rule a QToolButton paints the platform default, which reads
+    as a button beside the flat chips it sits next to."""
+    d = dialog(_estimate())
+    assert "background: transparent" in d.findChild(QToolButton).styleSheet()


### PR DESCRIPTION
The dialog before a workflow asked *"Run workflow for 2 lamella with 7 task(s)?"* over two columns of bullets. The lists restated the selection the user had just made; what they could not answer was the question actually being held — whether to start this now, and when to come back.

## What it shows

Two figures lead. The **duration** says whether it is worth starting; the **wall-clock finish** says when to come back, and that is the one people act on. Below them, a row per task with its lamella count and its own estimate, in a fixed right-aligned column so the times hold one line down the dialog however many chips a row carries.

Times are 12-hour, and a finish tomorrow says `Tomorrow, 6:13AM` rather than a date stamp. An overnight workflow is the case this exists for, and a bare clock time for one finishing the next morning is wrong by a day in the direction that matters. Anything further out keeps the dated form — "in 3 days" is arithmetic the reader has to do.

## The two exceptions

Neither figure is the whole story on its own, and the dialog says so rather than letting the headline mislead:

- **Supervised steps keep their work in the total.** Only the pause for a human is unbounded; dropping the whole task would quietly understate the total by the milling, imaging and moving it still does. So the wait is reported beside the figure rather than by omitting the task.
- **A scheduled step makes the workflow hold**, and the hold is invisible in the duration. Each row carries the wait *before that task* — quoting the workflow's whole hold against each of two scheduled tasks would say the same wrong number twice.

Both summarise once there is more than one of them ("2 steps wait for you"), because every row already carries its own chip: naming them again grows a sentence without adding anything, and reads as "A, B and C *waits* for you".

## The arithmetic is not a sum

`workflow_estimate.py` holds no Qt, so it is checked against a real experiment without a microscope or a widget. It walks the queue in its real task-outer order carrying a clock, because a scheduled task pushes everything after it later — `now + Σ` would be wrong by the length of the wait.

`WorkflowPreflightDialog` takes a finished `WorkflowEstimate` rather than an experiment, so the dialog only lays out what it is handed.

## Notes

Built from `preflight.py`'s pieces but **not** from `OverviewPreflightDialog`: the rows carry chips and a right-aligned duration where `detail_block` has one left-aligned value. The same call the coincidence milling dialog made, for the same reason its module docstring gives.

`Experiment.estimate_remaining_time` goes. It never had a caller, its two-minute per-task overhead was invented against a measured 0.4 s, and this module replaces what it was reaching for.

The in-run timeline is a separate change.

## Tests

32 added — 17 on the arithmetic (`tests/autolamella/test_workflow_estimate.py`), 15 on what reaches the screen (`tests/ui/test_workflow_preflight_dialog.py`). 549 pass across the affected suites; py3.8 syntax checked.

Worth knowing: the UI tests here are guarded by `pytest.importorskip("PyQt5")` and CI installs `.[test]`, which does not include it — so CI will not exercise the dialog tests. They were run locally.
