### PR TITLE
[refactor] Share what both overview host tabs do identically (FIB-697)

### DIFF
--- a/fibsem/applications/autolamella/ui/autolamella_fluorescence_overview_tab.py
+++ b/fibsem/applications/autolamella/ui/autolamella_fluorescence_overview_tab.py
@@ -22,7 +22,6 @@ import logging
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional
 
-from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
 from fibsem.applications.autolamella.poses import (
@@ -32,13 +31,16 @@ from fibsem.applications.autolamella.poses import (
 from fibsem.ui import notification_service
 from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
 from fibsem.ui.utils import message_box_ui
+from fibsem.applications.autolamella.ui.overview_tab_base import (
+    AutoLamellaOverviewTabBase,
+)
 from fibsem.applications.autolamella.ui.lamella_name_list_widget import LamellaNameListWidget
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
     from fibsem.applications.autolamella.structures import Lamella
 
 
-class AutoLamellaFluorescenceOverviewTab(QWidget):
+class AutoLamellaFluorescenceOverviewTab(AutoLamellaOverviewTabBase):
     """Drives `FMOverviewWidget` on behalf of an experiment.
 
     Built empty and filled in on connection: `FMOverviewWidget` requires a microscope
@@ -46,15 +48,6 @@ class AutoLamellaFluorescenceOverviewTab(QWidget):
     since every scale on its canvas comes from the camera -- and at the point the tab is
     reserved there may be no microscope at all.
     """
-
-    # Whether there is a live widget to drive. The window listens so it can enable or
-    # disable the tab; this object deliberately does not touch the tab bar, which is the
-    # one thing about the tab that is not its business.
-    availability_changed = pyqtSignal(bool)
-    # A lamella was picked in this tab's own list. The window forwards it to the other
-    # lists; nothing here selects them directly, which is what keeps the sync in one
-    # place instead of four.
-    lamella_selected = pyqtSignal(object)
 
     def __init__(self, autolamella_ui, parent: Optional[QWidget] = None):
         super().__init__(parent)
@@ -80,19 +73,6 @@ class AutoLamellaFluorescenceOverviewTab(QWidget):
         self.lamella_list.remove_requested.connect(self._on_remove_requested)
 
     # ── what the window asks ─────────────────────────────────────────────
-
-    @property
-    def is_available(self) -> bool:
-        """Whether there is a widget to drive, i.e. whether the tab does anything."""
-        return self.overview is not None
-
-    @property
-    def microscope(self):
-        return self.autolamella_ui.microscope if self.autolamella_ui is not None else None
-
-    @property
-    def experiment(self):
-        return self.autolamella_ui.experiment if self.autolamella_ui is not None else None
 
     def refresh_microscope(self) -> None:
         """Build, rebuild or drop the fluorescence widget to match the instrument.
@@ -166,40 +146,6 @@ class AutoLamellaFluorescenceOverviewTab(QWidget):
         self.overview = None
         self._microscope = None
 
-    def refresh_experiment(self) -> None:
-        """Tell the fluorescence widget where to save, and what to mark.
-
-        Told rather than handed the experiment: the widget knows nothing about
-        experiments, and keeping it that way is what lets it open standalone against a
-        simulator and be constructed in a test from a microscope alone.
-        """
-        if self.overview is None:
-            return
-        experiment = self.experiment
-        self.overview.set_save_directory(
-            str(experiment.path) if experiment is not None else None
-        )
-        self.refresh_positions()
-
-    def set_selected(self, lamella) -> None:
-        """Highlight the selected lamella.
-
-        Called from each of the window's selection handlers *before* their
-        `_syncing_selection` guard, and deliberately: that guard exists to stop three
-        lists selecting each other in circles, and this is not a fourth list. It emits
-        nothing and only repaints, so it wants to run whichever list the selection came
-        from -- which is exactly what the guard suppresses.
-        """
-        if self.overview is None:
-            return
-        self.overview.set_selected_position(
-            lamella.name if lamella is not None else None
-        )
-        # Not while this tab is the one that raised the selection: the list already shows
-        # what the user clicked, and re-selecting it would fight them mid-click.
-        if not self._syncing_selection and lamella is not None:
-            self.lamella_list.select(lamella.name)
-
     def refresh_positions(self) -> None:
         """Mark the experiment's lamellae on the fluorescence canvas.
 
@@ -247,56 +193,7 @@ class AutoLamellaFluorescenceOverviewTab(QWidget):
                 f"shown on the FM overview: {', '.join(unplaceable)}"
             )
 
-    def set_interactive(self, enabled: bool) -> None:
-        """Allow or forbid starting work, for a host that has taken the instrument."""
-        if self.overview is None:
-            return
-        self.overview.set_interactive(enabled)
-
     # ── the list ─────────────────────────────────────────────────────────
-
-    def _on_list_selection(self, lamella) -> None:
-        """A row was clicked: highlight it on the canvas, and tell the window.
-
-        The flag is what stops the round trip. The window answers by syncing every list
-        it knows about, this tab included, and re-selecting the row under a click that
-        is still happening moves the selection out from under the user.
-
-        Checked as well as set: `_on_marker_clicked` selects the row itself, and the row
-        answering by coming back through here announced the same lamella twice.
-        """
-        if self._syncing_selection:
-            return
-        self._syncing_selection = True
-        try:
-            if self.overview is not None:
-                self.overview.set_selected_position(
-                    lamella.name if lamella is not None else None
-                )
-            self.lamella_selected.emit(lamella)
-        finally:
-            self._syncing_selection = False
-
-    def _on_marker_clicked(self, name: str) -> None:
-        """A crosshair on the canvas was clicked: select that lamella everywhere.
-
-        The canvas has already highlighted it -- it knows the name it drew. What it
-        cannot do is turn a name into a lamella, so the list and the window are told from
-        here, through the same path a row click takes.
-        """
-        experiment = self.experiment
-        if experiment is None:
-            return
-        lamella = next((p for p in experiment.positions if p.name == name), None)
-        if lamella is None:
-            logging.debug(f"Clicked {name!r}, which is not in the experiment.")
-            return
-        self._syncing_selection = True
-        try:
-            self.lamella_list.select(name)
-            self.lamella_selected.emit(lamella)
-        finally:
-            self._syncing_selection = False
 
     def _on_move_to_requested(self, lamella) -> None:
         """Drive the stage to a lamella's *fluorescence* pose.

--- a/fibsem/applications/autolamella/ui/autolamella_overview_tab.py
+++ b/fibsem/applications/autolamella/ui/autolamella_overview_tab.py
@@ -31,11 +31,13 @@ import logging
 from copy import deepcopy
 from typing import TYPE_CHECKING, List, Optional
 
-from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
 from fibsem.applications.autolamella.poses import sync_fluorescence_pose
 from fibsem.applications.autolamella.structures import DefectType
+from fibsem.applications.autolamella.ui.overview_tab_base import (
+    AutoLamellaOverviewTabBase,
+)
 from fibsem.applications.autolamella.ui.lamella_name_list_widget import (
     LamellaNameListWidget,
 )
@@ -54,21 +56,13 @@ logger = logging.getLogger(__name__)
 FLAGGED_DEFECT_STATES = (DefectType.FAILURE, DefectType.REWORK)
 
 
-class AutoLamellaOverviewTab(QWidget):
+class AutoLamellaOverviewTab(AutoLamellaOverviewTabBase):
     """Drives `FibsemOverviewWidget` on behalf of an experiment.
 
     Built empty and filled in on connection, like its fluorescence twin: the overview
     widget requires a microscope at construction, and at the point the tab is reserved
     there may be no microscope at all.
     """
-
-    # Whether there is a live widget to drive. The window listens so it can enable or
-    # disable the tab; this object deliberately does not touch the tab bar.
-    availability_changed = pyqtSignal(bool)
-    # A lamella was picked in this tab's own list. The window forwards it to the other
-    # lists; nothing here selects them directly, which is what keeps the sync in one
-    # place instead of four.
-    lamella_selected = pyqtSignal(object)
 
     def __init__(self, autolamella_ui, parent: Optional[QWidget] = None):
         super().__init__(parent)
@@ -101,19 +95,6 @@ class AutoLamellaOverviewTab(QWidget):
         self.lamella_list.defect_changed.connect(self._on_defect_changed)
 
     # ── what the window asks ─────────────────────────────────────────────
-
-    @property
-    def is_available(self) -> bool:
-        """Whether there is a widget to drive, i.e. whether the tab does anything."""
-        return self.overview is not None
-
-    @property
-    def microscope(self):
-        return self.autolamella_ui.microscope if self.autolamella_ui is not None else None
-
-    @property
-    def experiment(self):
-        return self.autolamella_ui.experiment if self.autolamella_ui is not None else None
 
     def set_enabled(self, enabled: bool) -> None:
         """Whether to hold a live widget at all.
@@ -190,16 +171,6 @@ class AutoLamellaOverviewTab(QWidget):
         self.overview = None
         self._microscope = None
 
-    def refresh_experiment(self) -> None:
-        """Tell the overview widget where to save, and what to mark."""
-        if self.overview is None:
-            return
-        experiment = self.experiment
-        self.overview.set_save_directory(
-            str(experiment.path) if experiment is not None else None
-        )
-        self.refresh_positions()
-
     def refresh_positions(self) -> None:
         """Mark the experiment's lamellae on the canvas.
 
@@ -234,68 +205,12 @@ class AutoLamellaOverviewTab(QWidget):
 
         self.overview.set_positions(positions, flagged=flagged)
 
-    def set_selected(self, lamella) -> None:
-        """Highlight the selected lamella.
-
-        Called from each of the window's selection handlers *before* their
-        `_syncing_selection` guard, and deliberately: that guard exists to stop several
-        lists selecting each other in circles, and this is not another list. It emits
-        nothing and only repaints.
-        """
-        if self.overview is None:
-            return
-        self.overview.set_selected_position(
-            lamella.name if lamella is not None else None
-        )
-        if not self._syncing_selection and lamella is not None:
-            self.lamella_list.select(lamella.name)
-
-    def set_interactive(self, enabled: bool) -> None:
-        """Allow or forbid starting work, for a host that has taken the instrument."""
-        if self.overview is None:
-            return
-        self.overview.set_interactive(enabled)
-
     @property
     def is_acquiring(self) -> bool:
         """Whether an overview acquisition is running. The window asks before moving."""
         return self.overview is not None and self.overview.is_acquiring
 
     # ── the list ─────────────────────────────────────────────────────────
-
-    def _on_list_selection(self, lamella) -> None:
-        """A row was clicked: highlight it on the canvas, and tell the window."""
-        if self._syncing_selection:
-            return
-        self._syncing_selection = True
-        try:
-            if self.overview is not None:
-                self.overview.set_selected_position(
-                    lamella.name if lamella is not None else None
-                )
-            self.lamella_selected.emit(lamella)
-        finally:
-            self._syncing_selection = False
-
-    def _on_marker_clicked(self, name: str) -> None:
-        """A crosshair on the canvas was clicked: select that lamella everywhere.
-
-        The canvas has already highlighted it -- it knows the name it drew. What it
-        cannot do is turn a name into a lamella.
-        """
-        experiment = self.experiment
-        if experiment is None:
-            return
-        lamella = next((p for p in experiment.positions if p.name == name), None)
-        if lamella is None:
-            logger.debug(f"Clicked {name!r}, which is not in the experiment.")
-            return
-        self._syncing_selection = True
-        try:
-            self.lamella_list.select(name)
-            self.lamella_selected.emit(lamella)
-        finally:
-            self._syncing_selection = False
 
     def _on_move_to_requested(self, lamella) -> None:
         """Drive the stage to a lamella's milling pose."""

--- a/fibsem/applications/autolamella/ui/overview_tab_base.py
+++ b/fibsem/applications/autolamella/ui/overview_tab_base.py
@@ -1,0 +1,165 @@
+"""What both overview tabs do with an experiment, regardless of what is imaging it.
+
+`AutoLamellaOverviewTab` and `AutoLamellaFluorescenceOverviewTab` drive different widgets
+over different poses, and they were doing it through two copies of the same plumbing:
+both hold a lamella list beside a canvas, both answer the window's selection sync, both
+turn a clicked crosshair into a lamella. A fix to one left the other behaving differently
+-- and both are wired into the same handler in `AutoLamellaMainUI`, so "differently" here
+means one of four lists disagreeing with the other three.
+
+**Only the parts whose code is identical live here.** Measured method by method with
+docstrings stripped (FIB-697): seven were byte-identical and `_on_marker_clicked` differed
+only in `logging` against `logger`. Those eight are below.
+
+Deliberately *not* here, for now:
+
+* `refresh_microscope` and `_drop_overview` -- 96% and 98% identical, which is close
+  enough to look safe and not close enough to move without reading both carefully.
+* `refresh_positions`, `_on_add_requested`, `_on_move_requested`, `_on_move_to_requested`,
+  `_on_remove_requested`, `__init__` -- these differ because of **which pose is read**,
+  which is the real difference between the two tabs and wants a `_pose_of` hook rather
+  than a copy-paste into a base class.
+
+Finishing that is the rest of FIB-697. Starting with the identical eight means this
+change cannot alter behaviour, which is worth more than doing it in one go.
+
+# The contract
+
+This is a mixin over attributes its subclasses own, not a constructor. Each subclass sets
+`autolamella_ui`, `overview`, `lamella_list` and `_syncing_selection` in its own
+`__init__`, and supplies `refresh_positions`. The base deliberately does not build any of
+them: the two tabs construct their widgets differently and at different times, and a base
+`__init__` that half-built them would be a third thing to keep in step.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import QWidget
+
+logger = logging.getLogger(__name__)
+
+
+class AutoLamellaOverviewTabBase(QWidget):
+    """The experiment-facing half of an overview tab, shared by both modalities."""
+
+    # Whether there is a live widget to drive. The window listens so it can enable or
+    # disable the tab; neither tab touches the tab bar itself.
+    availability_changed = pyqtSignal(bool)
+    # A lamella was picked in this tab's own list. The window forwards it to the other
+    # lists; nothing here selects them directly, which is what keeps the sync in one
+    # place instead of four.
+    lamella_selected = pyqtSignal(object)
+
+    # ── what the window asks ─────────────────────────────────────────────
+
+    @property
+    def is_available(self) -> bool:
+        """Whether there is a widget to drive, i.e. whether the tab does anything."""
+        return self.overview is not None
+
+    @property
+    def microscope(self):
+        return self.autolamella_ui.microscope if self.autolamella_ui is not None else None
+
+    @property
+    def experiment(self):
+        return self.autolamella_ui.experiment if self.autolamella_ui is not None else None
+
+    def refresh_positions(self) -> None:
+        """Mark the experiment's lamellae on the canvas, at this tab's own pose.
+
+        Left to the subclass: the pose is the difference between the two tabs, and on a
+        compustage the milling and fluorescence poses share x, y, z **and** r, differing
+        only in tilt. Marking the wrong one puts every lamella on the far side of the
+        grid while looking entirely plausible.
+        """
+        raise NotImplementedError
+
+    def refresh_experiment(self) -> None:
+        """Tell the overview widget where to save, and what to mark."""
+        if self.overview is None:
+            return
+        experiment = self.experiment
+        self.overview.set_save_directory(
+            str(experiment.path) if experiment is not None else None
+        )
+        self.refresh_positions()
+
+    def set_selected(self, lamella) -> None:
+        """Highlight the selected lamella.
+
+        Called from each of the window's selection handlers *before* their
+        `_syncing_selection` guard, and deliberately: that guard exists to stop several
+        lists selecting each other in circles, and this is not another list. It emits
+        nothing and only repaints.
+        """
+        if self.overview is None:
+            return
+        self.overview.set_selected_position(
+            lamella.name if lamella is not None else None
+        )
+        if not self._syncing_selection and lamella is not None:
+            self.lamella_list.select(lamella.name)
+
+    def set_interactive(self, enabled: bool) -> None:
+        """Allow or forbid starting work, for a host that has taken the instrument."""
+        if self.overview is None:
+            return
+        self.overview.set_interactive(enabled)
+
+    # ── the list ─────────────────────────────────────────────────────────
+
+    def _on_list_selection(self, lamella) -> None:
+        """A row was clicked: highlight it on the canvas, and tell the window.
+
+        The flag is what stops the round trip. The window answers by syncing every list
+        it knows about, this tab included, and re-selecting the row under a click that is
+        still happening moves the selection out from under the user.
+
+        Checked as well as set: `_on_marker_clicked` selects the row itself, and the row
+        answering by coming back through here announced the same lamella twice.
+        """
+        if self._syncing_selection:
+            return
+        self._syncing_selection = True
+        try:
+            if self.overview is not None:
+                self.overview.set_selected_position(
+                    lamella.name if lamella is not None else None
+                )
+            self.lamella_selected.emit(lamella)
+        finally:
+            self._syncing_selection = False
+
+    def _on_marker_clicked(self, name: str) -> None:
+        """A crosshair on the canvas was clicked: select that lamella everywhere.
+
+        The canvas has already highlighted it -- it knows the name it drew. What it
+        cannot do is turn a name into a lamella, so the list and the window are told from
+        here, through the same path a row click takes.
+        """
+        experiment = self.experiment
+        if experiment is None:
+            return
+        lamella = next((p for p in experiment.positions if p.name == name), None)
+        if lamella is None:
+            logger.debug(f"Clicked {name!r}, which is not in the experiment.")
+            return
+        self._syncing_selection = True
+        try:
+            self.lamella_list.select(name)
+            self.lamella_selected.emit(lamella)
+        finally:
+            self._syncing_selection = False
+
+    # Set by the subclass, in its own `__init__`. Annotations only -- they document
+    # the contract and enforce nothing, so a subclass that forgets one fails on the
+    # first click rather than at construction.
+    autolamella_ui: object
+    overview: Optional[QWidget]
+    lamella_list: QWidget
+    _syncing_selection: bool

--- a/tests/ui/test_overview_tab_wiring.py
+++ b/tests/ui/test_overview_tab_wiring.py
@@ -272,3 +272,45 @@ def test_the_done_state_in_the_status_bar_clears_itself(window_source):
         "nothing hides the Done state; it stays until another operation replaces it"
     )
     assert "singleShot" in body, "the hide has to be delayed, or Done is never seen"
+
+
+def test_the_two_host_tabs_share_one_base():
+    """Both drive an experiment the same way, so neither owns that plumbing.
+
+    Only the methods whose code was byte-identical moved (FIB-697), so this asserts the
+    ones that did and deliberately does *not* assert the ones that did not:
+    `refresh_positions` and the request handlers differ because of which pose they read,
+    and pretending otherwise is how the two tabs would come to mark different things.
+    """
+    from fibsem.applications.autolamella.ui.autolamella_fluorescence_overview_tab import (
+        AutoLamellaFluorescenceOverviewTab,
+    )
+    from fibsem.applications.autolamella.ui.autolamella_overview_tab import (
+        AutoLamellaOverviewTab,
+    )
+    from fibsem.applications.autolamella.ui.overview_tab_base import (
+        AutoLamellaOverviewTabBase,
+    )
+
+    shared = ("is_available", "microscope", "experiment", "refresh_experiment",
+              "set_selected", "set_interactive", "_on_list_selection",
+              "_on_marker_clicked")
+
+    for cls in (AutoLamellaOverviewTab, AutoLamellaFluorescenceOverviewTab):
+        assert issubclass(cls, AutoLamellaOverviewTabBase)
+        for name in shared:
+            assert name not in vars(cls), (
+                f"{cls.__name__} defines {name} again; the base is what stops the two "
+                "tabs drifting apart"
+            )
+        # The pose is the difference between the tabs, so each must still answer it.
+        assert "refresh_positions" in vars(cls), (
+            f"{cls.__name__} inherits refresh_positions, which would mark nothing"
+        )
+
+    # Both signals are declared once, on the base. A subclass redeclaring one shadows
+    # it, and the window connects to whichever it happens to see first.
+    for name in ("availability_changed", "lamella_selected"):
+        assert name in vars(AutoLamellaOverviewTabBase)
+        for cls in (AutoLamellaOverviewTab, AutoLamellaFluorescenceOverviewTab):
+            assert name not in vars(cls), f"{cls.__name__} redeclares {name}"

--- a/tests/ui/test_overview_tab_wiring.py
+++ b/tests/ui/test_overview_tab_wiring.py
@@ -274,43 +274,66 @@ def test_the_done_state_in_the_status_bar_clears_itself(window_source):
     assert "singleShot" in body, "the hide has to be delayed, or Done is never seen"
 
 
+# ── the two host tabs' shared base ───────────────────────────────────────
+
+UI_DIR = REPO_ROOT / "fibsem" / "applications" / "autolamella" / "ui"
+HOST_TABS = {
+    "AutoLamellaOverviewTab": UI_DIR / "autolamella_overview_tab.py",
+    "AutoLamellaFluorescenceOverviewTab": UI_DIR / "autolamella_fluorescence_overview_tab.py",
+}
+
+
+def _class_def(path: Path, name: str) -> ast.ClassDef:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return next(n for n in ast.walk(tree)
+                if isinstance(n, ast.ClassDef) and n.name == name)
+
+
 def test_the_two_host_tabs_share_one_base():
     """Both drive an experiment the same way, so neither owns that plumbing.
 
+    Read from source rather than imported, like everything else in this file: this is
+    the one UI test module CI actually runs, because it needs no PyQt5. An earlier
+    version of this test imported the classes and turned the whole run red on every
+    platform.
+
     Only the methods whose code was byte-identical moved (FIB-697), so this asserts the
-    ones that did and deliberately does *not* assert the ones that did not:
-    `refresh_positions` and the request handlers differ because of which pose they read,
-    and pretending otherwise is how the two tabs would come to mark different things.
+    ones that did and deliberately *not* the ones that did not: `refresh_positions` and
+    the request handlers differ because of which pose they read, and pretending
+    otherwise is how the two tabs would come to mark different things.
     """
-    from fibsem.applications.autolamella.ui.autolamella_fluorescence_overview_tab import (
-        AutoLamellaFluorescenceOverviewTab,
-    )
-    from fibsem.applications.autolamella.ui.autolamella_overview_tab import (
-        AutoLamellaOverviewTab,
-    )
-    from fibsem.applications.autolamella.ui.overview_tab_base import (
-        AutoLamellaOverviewTabBase,
-    )
-
-    shared = ("is_available", "microscope", "experiment", "refresh_experiment",
+    shared = {"is_available", "microscope", "experiment", "refresh_experiment",
               "set_selected", "set_interactive", "_on_list_selection",
-              "_on_marker_clicked")
+              "_on_marker_clicked"}
 
-    for cls in (AutoLamellaOverviewTab, AutoLamellaFluorescenceOverviewTab):
-        assert issubclass(cls, AutoLamellaOverviewTabBase)
-        for name in shared:
-            assert name not in vars(cls), (
-                f"{cls.__name__} defines {name} again; the base is what stops the two "
-                "tabs drifting apart"
-            )
+    for name, path in HOST_TABS.items():
+        cls = _class_def(path, name)
+        bases = {b.id for b in cls.bases if isinstance(b, ast.Name)}
+        assert "AutoLamellaOverviewTabBase" in bases, f"{name} bases are {bases}"
+
+        defined = {n.name for n in cls.body
+                   if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+        again = defined & shared
+        assert not again, (
+            f"{name} defines {sorted(again)} again; the base is what stops the two tabs "
+            "drifting apart"
+        )
         # The pose is the difference between the tabs, so each must still answer it.
-        assert "refresh_positions" in vars(cls), (
-            f"{cls.__name__} inherits refresh_positions, which would mark nothing"
+        assert "refresh_positions" in defined, (
+            f"{name} inherits refresh_positions, which would mark nothing"
         )
 
-    # Both signals are declared once, on the base. A subclass redeclaring one shadows
-    # it, and the window connects to whichever it happens to see first.
-    for name in ("availability_changed", "lamella_selected"):
-        assert name in vars(AutoLamellaOverviewTabBase)
-        for cls in (AutoLamellaOverviewTab, AutoLamellaFluorescenceOverviewTab):
-            assert name not in vars(cls), f"{cls.__name__} redeclares {name}"
+        # Both signals are declared once, on the base. A subclass redeclaring one
+        # shadows it, and the window connects to whichever it happens to see first.
+        assigned = {t.id for n in cls.body if isinstance(n, ast.Assign)
+                    for t in n.targets if isinstance(t, ast.Name)}
+        assert not assigned & {"availability_changed", "lamella_selected"}, (
+            f"{name} redeclares a signal the base owns"
+        )
+
+
+def test_the_base_owns_the_signals_the_window_connects_to():
+    base = _class_def(UI_DIR / "overview_tab_base.py", "AutoLamellaOverviewTabBase")
+    assigned = {t.id for n in base.body if isinstance(n, ast.Assign)
+                for t in n.targets if isinstance(t, ast.Name)}
+    assert {"availability_changed", "lamella_selected"} <= assigned


### PR DESCRIPTION
Fourth of five layers where the beam and fluorescence overviews are written twice
(FIB-697, under FIB-693). **The first of two steps** — the second is FIB-709.

The two host tabs are what turn a point on a canvas into a lamella, and they were doing
it through two copies of the same plumbing: both hold a list beside a canvas, both answer
the window's selection sync, both turn a clicked crosshair into a lamella. Both are wired
into the same handler in `AutoLamellaMainUI`, so a fix landing in one left one of four
lists disagreeing with the other three.

## Only the identical parts moved

Compared method by method with **docstrings stripped** — they legitimately differ, milling
against fluorescence:

| | methods |
| -- | -- |
| **byte-identical, moved** | `is_available`, `microscope`, `experiment`, `refresh_experiment`, `set_selected`, `set_interactive`, `_on_list_selection` |
| **identical code, moved** | `_on_marker_clicked` — differed only in `logging` against `logger` |
| **left alone** | `refresh_microscope` 96%, `_drop_overview` 98%, `__init__` 83%, `_on_add_requested` 92%, `_on_remove_requested` 78%, `_on_move_to_requested` 71%, `_on_move_requested` 46%, `refresh_positions` 39% |

So this step **cannot change behaviour**: everything it moved was already the same text.

The six that differ do so because of **which pose is read**, which is the real difference
between the tabs and wants a `_pose_of` hook rather than a copy into a base class. On a
compustage the milling and fluorescence poses share x, y, z *and* r and differ only in
tilt, so getting it wrong marks every lamella on the far side of the grid while looking
entirely plausible — a mutation swapping them passed until the test asserted the tilt.
That is FIB-709, and it deserves its own review.

`refresh_microscope` (96%) and `_drop_overview` (98%) were left out for exactly the reason
they look ready: the 2–4% is where a difference would hide.

## Worth knowing

A plain text diff of the two files shows **389 differing lines out of 851**, which reads
as "half of each file" and made the pair look far less shared than they are. Almost all
of it is prose. Measuring the code alone is what made the split obvious, and the
measurement is recorded on FIB-697 so the next person doesn't re-derive it from the raw
diff and reach the wrong conclusion.

## Shape

`AutoLamellaOverviewTabBase` is a mixin over attributes its subclasses own, not a
constructor. The two tabs build their widgets differently and at different times, and a
base `__init__` that half-built them would be a third thing to keep in step. Both signal
declarations move to the base — a subclass redeclaring one shadows it, and the window
connects to whichever it sees first.

| check | result |
| -- | -- |
| `tests/ui` + autolamella UI tests | **1758 passed** |
| Python 3.8 parse | all touched files |

The new structural test asserts what moved **and deliberately does not assert what did
not**: `refresh_positions` must still be defined on each subclass, because a tab that
inherited it would mark nothing.
