### PR TITLE
[refactor] One live-preview mosaic for both tiled runners (FIB-699)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -14,7 +14,11 @@ import matplotlib.patches as patches
 from fibsem import utils
 from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
 from fibsem.fm.calibration import run_autofocus, run_coarse_fine_autofocus
-from fibsem.imaging.reduce import downsample
+from fibsem.imaging.reduce import (
+    PREVIEW_MAX_DIMENSION,
+    PreviewMosaic,
+    downsample,
+)
 from fibsem.imaging.tiling.geometry import (
     TilePosition,
     compute_tile_grid_from_fov,
@@ -399,14 +403,6 @@ def run_tileset_autofocus(
         return False
 
 
-PREVIEW_MAX_DIMENSION = 2048
-"""Long-edge size of the live mosaic preview, in pixels.
-
-A full-resolution fluorescence mosaic is multi-channel 16-bit -- a 5x5 of 1024px tiles
-is ~88 MB -- and the whole canvas is pushed through a Qt signal on every tile. The
-preview is decimated to this so watching a run stays cheap; the final stitch is
-untouched and full resolution.
-"""
 
 
 def _to_channel_planes(data: np.ndarray, n_channels: int) -> np.ndarray:
@@ -903,19 +899,10 @@ class FMTiledAcquisitionRunner:
         full_w = max(t.canvas_x for t in self._grid) + self._image_width
         full_h = max(t.canvas_y for t in self._grid) + self._image_height
 
-        self._preview_stride = max(
-            1, int(np.ceil(max(full_w, full_h) / PREVIEW_MAX_DIMENSION))
+        self._preview = PreviewMosaic(
+            full_w, full_h, dtype=np.uint16, channels=len(self.channel_settings)
         )
-        self._preview_canvas = np.zeros(
-            (len(self.channel_settings),
-             int(np.ceil(full_h / self._preview_stride)),
-             int(np.ceil(full_w / self._preview_stride))),
-            dtype=np.uint16,
-        )
-        logging.debug(
-            f"Live preview canvas: {self._preview_canvas.shape} "
-            f"(stride {self._preview_stride}, full {full_h}x{full_w})"
-        )
+        logging.debug(f"{self._preview.describe()} (full {full_h}x{full_w})")
 
     def _paint_preview(self, tile: TilePosition, image: FluorescenceImage) -> None:
         """Paint one acquired tile into the live preview mosaic.
@@ -924,37 +911,13 @@ class FMTiledAcquisitionRunner:
         acquisition that is otherwise fine, so this never raises into the tile loop.
         """
         try:
-            stride = self._preview_stride
             data = _to_channel_planes(image.data, len(self.channel_settings))
-            if data.shape[0] != self._preview_canvas.shape[0]:
-                data = data[: self._preview_canvas.shape[0]]
-
-            # Averaged, not sampled. `data[:, ::stride, ::stride]` was free and wrong:
-            # it does not blur what it leaves out, it deletes it, and at a typical
-            # stride of 8 that is 63 pixels in 64. A punctum a couple of pixels across
-            # is then present or absent depending on where it happens to land, with
-            # nothing on screen saying the picture is incomplete -- and the small bright
-            # thing is what someone is looking for. This is FIB-589's reduction, which
-            # the canvas path already uses, reaching the preview path (FIB-629).
-            #
-            # Per plane, not on the stack: `downsample` reads shape as (y, x[, c]), so
-            # a (channels, y, x) array would be reduced across *channels* and y. A
-            # 5-channel stack would also fall to the numpy branch, which is right
-            # answer, wrong axes, and 200x slower.
-            #
-            # `max_px` expressed as the size the thumbnail must come out at, so the
-            # factor it derives is the stride and the shape is unchanged: both give
-            # ceil(n / stride).
-            thumb = np.stack([
-                downsample(plane, math.ceil(max(plane.shape[:2]) / stride))
-                for plane in data
-            ])
-            y0 = tile.canvas_y // stride
-            x0 = tile.canvas_x // stride
-            h = min(thumb.shape[1], self._preview_canvas.shape[1] - y0)
-            w = min(thumb.shape[2], self._preview_canvas.shape[2] - x0)
-            if h > 0 and w > 0:
-                self._preview_canvas[:, y0:y0 + h, x0:x0 + w] = thumb[:, :h, :w]
+            # Truncated here rather than in the shared mosaic: it is a guard against a
+            # mismatch that should not arise, and the mosaic asking for one would be a
+            # defensive rule carried for a single caller.
+            if data.shape[0] != self._preview.canvas.shape[0]:
+                data = data[: self._preview.canvas.shape[0]]
+            self._preview.paint(data, tile.canvas_x, tile.canvas_y)
         except Exception as e:  # pragma: no cover - preview is never load-bearing
             logging.debug(f"Could not paint tile ({tile.row}, {tile.col}) into preview: {e}")
 
@@ -1119,8 +1082,8 @@ class FMTiledAcquisitionRunner:
             "row": tile.row, "col": tile.col,
             "total_rows": self._rows, "total_cols": self._cols,
             "current": self._n_acquired, "total": len(self._ordered),
-            "image": self._preview_canvas.copy(),
-            "preview_stride": self._preview_stride,
+            "image": self._preview.canvas.copy(),
+            "preview_stride": self._preview.stride,
         })
 
     def _emit_tile_progress(self, row: int, col: int) -> None:

--- a/fibsem/imaging/reduce.py
+++ b/fibsem/imaging/reduce.py
@@ -25,7 +25,8 @@ import math
 import cv2
 import numpy as np
 
-__all__ = ["downsample", "downsample_mask"]
+__all__ = ["downsample", "downsample_mask", "PreviewMosaic",
+           "PREVIEW_MAX_DIMENSION"]
 
 
 # Element types `cv2.resize` accepts. Anything else takes the numpy path, which answers
@@ -148,3 +149,91 @@ def downsample_mask(mask: np.ndarray, max_px: int) -> np.ndarray:
     # `view` rather than `astype`: a bool array is already one byte per element, so this
     # reinterprets 0/1 in place and the multiply is the only array allocated.
     return downsample(mask.view(np.uint8) * np.uint8(_MASK_SET), max_px) > _MASK_HALF
+
+
+# Longest side a live preview mosaic is decimated to. The full one is not something to
+# hand a display on every tile: a 10x10 of 1536x1024 beam tiles is 157 MB, and a
+# multi-channel 16-bit fluorescence 5x5 is ~88 MB pushed through a Qt signal per tile.
+# Big enough to watch the mosaic fill in; the real stitch still happens at full
+# resolution when the run finishes.
+PREVIEW_MAX_DIMENSION = 2048
+
+
+class PreviewMosaic:
+    """A decimated mosaic, painted tile by tile as a run fills it in.
+
+    Both tiled runners want this and had a copy each -- the same stride rule, the same
+    `downsample` call, the same paste-and-clip, down to a character-identical debug line
+    (FIB-699). The only real difference was the channel axis, which is a parameter.
+
+    That the copies were the same is not an argument on its own; what makes it worth one
+    class is that they must *stay* the same. FIB-629 had to change one of them from
+    sampling pixels to averaging them, because small bright features could vanish from
+    the preview -- the other needed it for the same reason and did not get it.
+
+    Two dimensions or three. A beam mosaic is one plane; a fluorescence mosaic is one
+    per channel. `paint` takes ``(y, x)`` or ``(channels, y, x)`` and matches whichever
+    the canvas is.
+    """
+
+    def __init__(
+        self,
+        full_w: int,
+        full_h: int,
+        dtype,
+        channels: "int | None" = None,
+        max_px: int = PREVIEW_MAX_DIMENSION,
+    ):
+        """
+        Args:
+            full_w, full_h: the mosaic's full size in pixels. Take these from the tile
+                grid rather than recomputing them, so the preview cannot drift from
+                where the stitch will actually paint.
+            dtype: the canvas's element type, matching what the tiles carry.
+            channels: how many planes, or None for a single-plane canvas. `None` and `1`
+                differ: `None` gives a 2-D canvas, `1` a 3-D one with a length-1 axis.
+            max_px: longest side to decimate to.
+        """
+        self.stride = max(1, int(math.ceil(max(full_w, full_h) / max_px)))
+        shape = (int(math.ceil(full_h / self.stride)),
+                 int(math.ceil(full_w / self.stride)))
+        if channels is not None:
+            shape = (int(channels),) + shape
+        self.canvas = np.zeros(shape, dtype=dtype)
+
+    def paint(self, data: np.ndarray, canvas_x: int, canvas_y: int) -> None:
+        """Reduce one tile and paste it at its place in the mosaic.
+
+        Averaged, not sampled. ``arr[::n, ::n]`` does not blur what it leaves out, it
+        deletes it, so a feature a pixel or two across is present at one zoom and gone
+        at the next (FIB-589, and FIB-629 for this path). `downsample` returns
+        ``ceil(n / factor)`` per axis -- the same shape striding gave -- so the paste
+        offsets are unaffected. `max_px` is how the factor is chosen, so it is expressed
+        as the size the thumbnail has to come out at.
+
+        Reduced **per plane**, never on the stack: `downsample` reads shape as
+        ``(y, x[, c])``, so a ``(channels, y, x)`` array would be reduced across
+        *channels* and y. That is the right answer on the wrong axes, and it falls to
+        the slow numpy branch as well.
+
+        Clipped rather than checked. A tile at the far edge can extend past the canvas
+        by a pixel or two, because every axis was rounded up independently.
+        """
+        planes = data if data.ndim == 3 else data[np.newaxis]
+        # Views, so writing through `target` writes to the canvas, and a single-plane
+        # tile costs no copy. Stacking the thumbnails first read more neatly and
+        # allocated one per tile that nothing needed -- measured at +0.1 ms on the beam
+        # path, which is small but is pure waste inside the acquisition loop.
+        target = self.canvas if self.canvas.ndim == 3 else self.canvas[np.newaxis]
+        y0, x0 = canvas_y // self.stride, canvas_x // self.stride
+        for index, plane in enumerate(planes):
+            thumb = downsample(plane, math.ceil(max(plane.shape[:2]) / self.stride))
+            height = min(thumb.shape[0], target.shape[1] - y0)
+            width = min(thumb.shape[1], target.shape[2] - x0)
+            if height <= 0 or width <= 0:
+                return
+            target[index, y0:y0 + height, x0:x0 + width] = thumb[:height, :width]
+
+    def describe(self) -> str:
+        """One line for the log, the same on both sides."""
+        return f"Live preview canvas: {self.canvas.shape} (stride {self.stride})"

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -18,7 +18,7 @@ from fibsem.conversions import is_inside_image_bounds
 
 # Moved to the `tiling` package (FIB-390); re-exported so existing importers and the
 # public API are unaffected. `fibsem/imaging/__init__.py` star-imports this module.
-from fibsem.imaging.reduce import downsample
+from fibsem.imaging.reduce import PreviewMosaic, downsample
 from fibsem.imaging.tiling.geometry import (  # noqa: E402,F401
     TilePosition,
     compute_tile_grid,
@@ -59,9 +59,6 @@ from fibsem.structures import (
     TileOrderStrategy,
 )
 
-# Longest side the live preview mosaic is decimated to. The full one can be 157 MB for
-# a 10x10 of 1536x1024 tiles, and it is handed to a display once per tile.
-PREVIEW_MAX_DIMENSION = 2048
 
 
 
@@ -351,18 +348,8 @@ class TiledAcquisitionRunner:
         reduce all of it for display each time. Painted per tile from that tile's own
         thumbnail, so the cost is the tile rather than the mosaic.
         """
-        self._preview_stride = max(
-            1, int(np.ceil(max(full_w, full_h) / PREVIEW_MAX_DIMENSION))
-        )
-        stride = self._preview_stride
-        self._preview_canvas = np.zeros(
-            (int(np.ceil(full_h / stride)), int(np.ceil(full_w / stride))),
-            dtype=np.uint8,
-        )
-        logging.debug(
-            f"Live preview canvas: {self._preview_canvas.shape} "
-            f"(stride {stride}, full {full_h}x{full_w})"
-        )
+        self._preview = PreviewMosaic(full_w, full_h, dtype=np.uint8)
+        logging.debug(f"{self._preview.describe()} (full {full_h}x{full_w})")
 
     def _paint_preview(self, tile: TilePosition, image: FibsemImage) -> None:
         """Paint one acquired tile into the live preview.
@@ -371,19 +358,7 @@ class TiledAcquisitionRunner:
         acquisition that is otherwise fine, so this never raises into the tile loop.
         """
         try:
-            stride = self._preview_stride
-            data = image.filtered_data
-            # Averaged, not sampled. `arr[::n, ::n]` deletes what it leaves out rather
-            # than blurring it, so a feature a pixel or two across is present at one
-            # zoom and gone at the next (FIB-589). `downsample` returns `ceil(n/factor)`
-            # per axis -- the same shape striding gave -- so the paste offsets below are
-            # unaffected. `max_px` is how the factor is chosen, so it is expressed as
-            # the size this tile has to come out at.
-            thumb = downsample(data, math.ceil(max(data.shape[:2]) / stride))
-            y0, x0 = tile.canvas_y // stride, tile.canvas_x // stride
-            y1 = min(y0 + thumb.shape[0], self._preview_canvas.shape[0])
-            x1 = min(x0 + thumb.shape[1], self._preview_canvas.shape[1])
-            self._preview_canvas[y0:y1, x0:x1] = thumb[: y1 - y0, : x1 - x0]
+            self._preview.paint(image.filtered_data, tile.canvas_x, tile.canvas_y)
         except Exception as e:
             logging.debug(f"Could not paint the live preview: {e}")
 
@@ -397,16 +372,16 @@ class TiledAcquisitionRunner:
         underneath it.
         """
         metadata = deepcopy(self._mosaic_metadata)
-        stride = self._preview_stride
+        stride = self._preview.stride
         metadata.pixel_size = Point(
             x=self._mosaic_metadata.pixel_size.x * stride,
             y=self._mosaic_metadata.pixel_size.y * stride,
         )
         metadata.image_settings = deepcopy(self._mosaic_metadata.image_settings)
         metadata.image_settings.resolution = (
-            self._preview_canvas.shape[1], self._preview_canvas.shape[0],
+            self._preview.canvas.shape[1], self._preview.canvas.shape[0],
         )
-        return FibsemImage(data=self._preview_canvas.copy(), metadata=metadata)
+        return FibsemImage(data=self._preview.canvas.copy(), metadata=metadata)
 
     def _run_tile_loop(self) -> None:
         """Move to each tile, autofocus as configured, acquire, and stitch into the canvas."""

--- a/tests/fm/test_preview_reduction.py
+++ b/tests/fm/test_preview_reduction.py
@@ -129,12 +129,17 @@ class TestThePreviewPaintsWhatItIsGiven:
     def _runner_with_preview(n_channels, stride, canvas_shape):
         from fibsem.fm.acquisition import FMTiledAcquisitionRunner
 
+        from fibsem.imaging.reduce import PreviewMosaic
+
         runner = FMTiledAcquisitionRunner.__new__(FMTiledAcquisitionRunner)
         runner.channel_settings = [object()] * n_channels
-        runner._preview_stride = stride
-        runner._preview_canvas = np.zeros(
-            (n_channels, *canvas_shape), dtype=np.uint16
-        )
+        # The canvas and stride are stated directly rather than derived from a mosaic
+        # size, because these tests pin the *paste* -- the geometry that produced the
+        # stride is `PreviewMosaic`'s own business and is tested in
+        # `tests/test_image_reduction.py`.
+        runner._preview = PreviewMosaic.__new__(PreviewMosaic)
+        runner._preview.stride = stride
+        runner._preview.canvas = np.zeros((n_channels, *canvas_shape), dtype=np.uint16)
         return runner
 
     @staticmethod
@@ -154,7 +159,7 @@ class TestThePreviewPaintsWhatItIsGiven:
         image.data = data
         runner._paint_preview(self._tile(0, 0), image)
 
-        assert runner._preview_canvas.max() > 0
+        assert runner._preview.canvas.max() > 0
 
     def test_it_lands_where_the_tile_says(self):
         from fibsem.fm.structures import FluorescenceImage
@@ -166,7 +171,7 @@ class TestThePreviewPaintsWhatItIsGiven:
         image.data = data
         runner._paint_preview(self._tile(canvas_x=64, canvas_y=64), image)
 
-        painted = runner._preview_canvas[0]
+        painted = runner._preview.canvas[0]
         assert painted[8:16, 8:16].min() > 0  # the tile, at 64 // 8
         assert painted[0:8, 0:8].max() == 0  # and nowhere else
 
@@ -185,7 +190,7 @@ class TestThePreviewPaintsWhatItIsGiven:
         image.data = data
         runner._paint_preview(self._tile(0, 0), image)
 
-        painted = runner._preview_canvas
+        painted = runner._preview.canvas
         assert painted.shape == (3, 8, 8)
         assert [int(painted[c].max()) for c in range(3)] == [100, 200, 300]
 
@@ -202,7 +207,7 @@ class TestThePreviewPaintsWhatItIsGiven:
         image.data = data
         runner._paint_preview(self._tile(0, 0), image)
 
-        assert 0 < runner._preview_canvas.max() < 4000
+        assert 0 < runner._preview.canvas.max() < 4000
 
     @pytest.mark.parametrize("stride", [1, 2, 4, 7, 8])
     def test_the_painted_extent_matches_the_old_striding(self, stride):
@@ -218,7 +223,7 @@ class TestThePreviewPaintsWhatItIsGiven:
         runner._paint_preview(self._tile(0, 0), image)
 
         expected_h, expected_w = _strided(data[0], stride).shape
-        painted = runner._preview_canvas[0]
+        painted = runner._preview.canvas[0]
         assert painted[:expected_h, :expected_w].min() > 0
         assert painted[expected_h:, :].max() == 0
         assert painted[:, expected_w:].max() == 0

--- a/tests/test_image_reduction.py
+++ b/tests/test_image_reduction.py
@@ -26,6 +26,7 @@ import pytest
 
 from fibsem.imaging.reduce import (
     _CV2_DTYPES,
+    PreviewMosaic,
     _box_mean_numpy,
     downsample,
     downsample_mask,
@@ -298,3 +299,81 @@ class TestReducingACoverageMask:
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+# ── the live preview mosaic ──────────────────────────────────────────────
+
+
+class TestPreviewMosaic:
+    """The decimated mosaic both tiled runners fill in as a run goes.
+
+    Written twice until FIB-699, with the same stride rule, the same `downsample` call
+    and the same paste — the only real difference being the channel axis. Tested here
+    rather than through either runner: this is where the arithmetic lives, and neither
+    runner's tests can be run by CI.
+    """
+
+    def test_a_mosaic_that_fits_is_not_reduced(self):
+        mosaic = PreviewMosaic(2048, 1024, dtype=np.uint8)
+        assert mosaic.stride == 1
+        assert mosaic.canvas.shape == (1024, 2048)
+
+    def test_the_stride_comes_from_the_long_edge(self):
+        """Not from the area, and not per axis: the cap is on the longest side, so a
+        wide mosaic and a tall one of the same span reduce by the same factor."""
+        wide = PreviewMosaic(8192, 1024, dtype=np.uint8)
+        tall = PreviewMosaic(1024, 8192, dtype=np.uint8)
+        assert wide.stride == tall.stride == 4
+        assert wide.canvas.shape == (256, 2048)
+        assert tall.canvas.shape == (2048, 256)
+
+    def test_channels_none_is_not_channels_one(self):
+        """A beam mosaic is a plane; a one-channel fluorescence mosaic is a stack of
+        one. The consumers index them differently, so the distinction is load-bearing."""
+        assert PreviewMosaic(64, 64, dtype=np.uint8).canvas.ndim == 2
+        assert PreviewMosaic(64, 64, dtype=np.uint16, channels=1).canvas.ndim == 3
+
+    def test_a_tile_lands_where_the_stride_puts_it(self):
+        mosaic = PreviewMosaic(8192, 8192, dtype=np.uint8)  # stride 4
+        tile = np.full((1024, 1024), 200, dtype=np.uint8)
+        mosaic.paint(tile, canvas_x=4096, canvas_y=2048)
+
+        assert mosaic.canvas[512, 1024] == 200          # 2048//4, 4096//4
+        assert mosaic.canvas[511, 1024] == 0            # just above it
+        assert mosaic.canvas[512, 1023] == 0            # just left of it
+
+    def test_each_channel_is_reduced_on_its_own_axes(self):
+        """`downsample` reads shape as (y, x[, c]), so reducing a (c, y, x) stack whole
+        would average across *channels* and y -- the right answer on the wrong axes."""
+        mosaic = PreviewMosaic(4096, 4096, dtype=np.uint16, channels=3)  # stride 2
+        tile = np.stack([np.full((512, 512), v, dtype=np.uint16)
+                         for v in (100, 200, 300)])
+        mosaic.paint(tile, canvas_x=0, canvas_y=0)
+
+        assert [int(mosaic.canvas[c, 0, 0]) for c in range(3)] == [100, 200, 300]
+
+    def test_a_tile_over_the_edge_is_clipped_rather_than_raising(self):
+        """Every axis is rounded up independently, so the last tile can extend past the
+        canvas by a pixel or two. A run must not fail for that."""
+        mosaic = PreviewMosaic(600, 600, dtype=np.uint8)
+        tile = np.full((512, 512), 7, dtype=np.uint8)
+        mosaic.paint(tile, canvas_x=500, canvas_y=500)
+
+        assert mosaic.canvas[599, 599] == 7
+
+    def test_a_tile_entirely_off_the_canvas_paints_nothing(self):
+        mosaic = PreviewMosaic(600, 600, dtype=np.uint8)
+        mosaic.paint(np.full((64, 64), 9, dtype=np.uint8), canvas_x=900, canvas_y=900)
+        assert not mosaic.canvas.any()
+
+    def test_a_small_bright_feature_survives_the_reduction(self):
+        """The whole reason this uses `downsample` rather than `data[::n, ::n]`
+        (FIB-589, FIB-629): sampling deletes what it leaves out, so a punctum a couple
+        of pixels across is present or absent depending on where it lands."""
+        mosaic = PreviewMosaic(4096, 4096, dtype=np.uint16, channels=1)  # stride 2
+        tile = np.zeros((1, 512, 512), dtype=np.uint16)
+        tile[0, 101, 101] = 4000  # an odd row and column, which striding drops
+
+        mosaic.paint(tile, canvas_x=0, canvas_y=0)
+
+        assert mosaic.canvas[0, 50, 50] > 0, "the feature was sampled away"


### PR DESCRIPTION
Last of the five layers where the beam and fluorescence overviews were written twice
(FIB-699, under FIB-693), and the only one below the UI.

Both runners build a decimated mosaic during a run so the canvas has something to show
before the stitch lands. The two were near-verbatim copies — the same 2048 cap, the same
stride rule, the same `downsample` call, the same paste-and-clip, down to a
character-identical debug line. Only the channel axis differed, and that is a parameter.

`PreviewMosaic` lives in `fibsem/imaging/reduce.py`: beside the reduction it depends on,
and outside `fibsem/ui/`, so **CI can actually run its tests**. It takes `(y, x)` or
`(channels, y, x)` and matches whichever the canvas is.

## Why one class rather than two copies that happen to agree

That they were the same is not the argument. That they must *stay* the same is:
**FIB-629 had to change one of them** from sampling pixels to averaging them, because a
punctum a couple of pixels across could vanish from the preview depending on where it
landed. The other copy needed that for the same reason and did not get it.

## Verification

Against a seeded baseline, both runners:

| | result |
| -- | -- |
| stitched output | **byte-identical** on both |
| every preview frame (9 per run) | **byte-identical** on both |
| `tests/test_image_reduction.py`, `tests/fm/`, tiled payload, sparse tiles, `tests/ui` | **2513 passed** |

Two things about that baseline are worth stating, because without either it would have
been theatre:

**The seed.** The simulator paints random noise per tile, so unseeded, two runs of
identical code disagree and a hash comparison proves nothing.

**The grid size.** The first harness ran at stride **1** on both sides — the mosaics fit
under the 2048 cap, so it exercised none of the decimation being extracted. Enlarged
until both reduce at stride 2, then checked the hashes were stable run-to-run *before*
using them to judge anything.

## Performance

This sits inside the acquisition loop, so it was measured rather than assumed. Painting
per plane rather than stacking the thumbnails first — stacking read more neatly and
allocated one array per tile that nothing needed:

| path | before | after |
| -- | -- | -- |
| beam, 1 plane uint8 | 0.051 ms | 0.051 ms |
| fluorescence, 3 planes uint16 | 0.236 ms | **0.174 ms** |

Median over 300 iterations. A first pass that did stack looked like a 40% beam
regression across nine in-run samples — noise, and worth measuring properly rather than
shipping either the guess or the apology.

## Notes

The FM channel-truncation guard stays in the FM runner: it defends against a mismatch
that should not arise, and asking the shared mosaic for it would be a defensive rule
carried for a single caller.

`tests/fm/test_preview_reduction.py` builds a runner by hand and set `_preview_canvas` /
`_preview_stride` directly; its harness now builds a `PreviewMosaic`. Those tests pin the
*paste*, and the geometry that produced the stride is the mosaic's own business — tested
in `tests/test_image_reduction.py`, which CI runs.
