### PR TITLE
[refactor] One set of stage-context overlays for both tabs (FIB-698)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -55,6 +55,11 @@ from fibsem.ui.widgets.canvas.overlays.tile_grid_options_panel import (
 )
 from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
+from fibsem.ui.widgets.canvas.overlay_controls import (
+    CanvasOverlayControls,
+    CanvasPopover,
+)
+from fibsem.ui.widgets.canvas.overlays import stage_context
 from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
     GRID_BOUNDARY_RADIUS_M,
     MinimapShapesOverlay,
@@ -318,6 +323,23 @@ class FMOverviewWidget(QWidget):
         # settings widget so there is one place the selection lives.
         self.tile_grid_overlay = TileGridOverlay()
         self.canvas.canvas.add_overlay(self.tile_grid_overlay)
+
+        # The same three switches the beam tab offers, over the same three shapes, from
+        # the same entries -- so neither tab can offer a switch the other does not, or
+        # word it differently. This tab draws no saved-position or gridbar overlay, so
+        # it takes only the stage-context set.
+        self.overlay_controls = CanvasOverlayControls(
+            list(stage_context.CONTEXT_OVERLAY_ENTRIES)
+        )
+        self.overlay_controls.toggled.connect(
+            lambda *_: self._refresh_stage_metadata()
+        )
+        self.btn_overlays = self.canvas.canvas.add_toolbar_button(
+            "mdi:eye-outline", "Overlays", self._toggle_overlays, checkable=True,
+        )
+        self.overlay_popover = CanvasPopover(
+            self.overlay_controls, parent=self.canvas.canvas
+        )
 
         # Grid display options live on the canvas toolbar, beside the layers control:
         # they are about reading the image, not about what gets acquired, so they do
@@ -1182,61 +1204,31 @@ class FMOverviewWidget(QWidget):
             coordinate_system=origin.coordinate_system,
         )
 
+    def _toggle_overlays(self) -> None:
+        """Show or hide the overlays popover, anchored under its button."""
+        self.overlay_popover.set_open(self.btn_overlays.isChecked(), self.btn_overlays)
+
     def _refresh_stage_metadata(self) -> None:
         """Draw where the sample and the stage can physically go.
 
         The context an overview is read against: which grid you are on, how far from its
-        centre, and how much travel is left. Same shapes the minimap draws, but placed
-        straight into the canvas frame -- on a real-space canvas there is no stitched
-        image to reproject onto, so the indirection disappears.
+        centre, and how much travel is left. The same shapes the beam tab draws, from the
+        same functions -- this tab had a copy, and the copy had drifted three ways: the
+        travel box gated on `stage_is_compustage`, the grid boundary sized in stage axes
+        rather than along the surface and drawn as a circle, and raw slot positions
+        handed to a frame that raises on the `r=None` the holder file leaves (FIB-698).
         """
         frame = self._frame()
         if frame is None:
             self.stage_overlay.set_shapes([])
             return
-
-        specs = []
-        try:
-            centre = frame.to_canvas(
-                FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0)
-            )
-        except Exception as e:
-            logging.debug(f"Cannot place the grid centre: {e}")
-            self.stage_overlay.set_shapes([])
-            return
-
-        limits = getattr(self.microscope._stage, "limits", None)
-        if limits and self.microscope.stage_is_compustage:
-            # The travel envelope, as a box around the grid centre. Sized from the
-            # limits rather than projected corner-by-corner: the projection is flips
-            # and a tilt, which keep an axis-aligned box axis-aligned.
-            specs.append(ShapeSpec(
-                kind="rect", cx=centre[0], cy=centre[1], color=STAGE_LIMITS_COLOUR,
-                width=frame.length(limits["x"].max - limits["x"].min),
-                height=frame.length(limits["y"].max - limits["y"].min),
-                label="Stage limits",
-            ))
-            specs.append(ShapeSpec(
-                kind="circle", cx=centre[0], cy=centre[1], color=GRID_BOUNDARY_COLOUR,
-                radius=frame.length(GRID_BOUNDARY_RADIUS_M), label="Grid boundary",
-            ))
-
-        holder = getattr(self.microscope._stage, "holder", None)
-        for slot in getattr(holder, "slots", {}).values():
-            position = getattr(slot, "position", None)
-            if position is None:
-                continue
-            try:
-                point = frame.to_canvas(position)
-            except Exception as e:
-                logging.debug(f"Cannot place slot {position.name!r}: {e}")
-                continue
-            specs.append(ShapeSpec(
-                kind="crosshair", cx=point[0], cy=point[1], color=SLOT_COLOUR,
-                label=position.name or "",
-            ))
-
-        self.stage_overlay.set_shapes(specs)
+        self.stage_overlay.set_shapes(stage_context.context_shapes(
+            self.microscope, frame,
+            limits=self.overlay_controls.is_visible(stage_context.OVERLAY_LIMITS),
+            boundaries=self.overlay_controls.is_visible(
+                stage_context.OVERLAY_BOUNDARIES),
+            slots=self.overlay_controls.is_visible(stage_context.OVERLAY_SLOTS),
+        ))
 
     def _refresh_current_position(self) -> None:
         """Mark where the stage is now."""

--- a/fibsem/ui/widgets/canvas/overlays/stage_context.py
+++ b/fibsem/ui/widgets/canvas/overlays/stage_context.py
@@ -1,0 +1,272 @@
+"""Where the stage can go, and where the sample sits, drawn in whatever view is up.
+
+The context an overview is read against: which grid you are on, how far from its centre,
+and how much travel is left. None of it depends on what is imaging the sample -- the
+numbers come from `microscope._stage`, and turning them into canvas coordinates is the
+`StageFrame`'s job, which both overview tabs already have.
+
+They had a copy each, and the copies disagreed (FIB-698). The fluorescence one gated the
+travel box on `stage_is_compustage` -- one guard answering two questions, since travel
+limits have nothing to do with grids -- sized the grid boundary with `frame.length()` and
+drew it as a circle, and handed raw slot positions to `frame.to_canvas`. Each is fixed
+here by there being one implementation rather than by anyone fixing it twice.
+
+Free functions over `(microscope, frame)` rather than a mixin: they read nothing else,
+hold nothing, and a caller that wants one shape does not want a base class.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Tuple
+
+from fibsem.structures import FibsemStagePosition
+from fibsem.ui.tokens import (
+    GRID_BOUNDARY_COLOUR,
+    SLOT_COLOUR,
+    STAGE_LIMITS_COLOUR,
+)
+from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
+    GRID_BOUNDARY_RADIUS_M,
+    ShapeSpec,
+)
+from fibsem.ui.widgets.canvas.stage_frame import StageFrame
+
+logger = logging.getLogger(__name__)
+
+# Keys for `CanvasOverlayControls`, named here rather than in either tab: the switch and
+# the shape it gates cannot drift apart under a rename, and both tabs offer the same
+# three. What each tab draws *besides* these -- saved positions, grid bars -- is its own
+# and keeps its keys there.
+OVERLAY_LIMITS = "limits"
+OVERLAY_BOUNDARIES = "boundaries"
+OVERLAY_SLOTS = "slots"
+
+# Label and default for each, so the two tabs cannot offer the same switch under
+# different words.
+CONTEXT_OVERLAY_ENTRIES = (
+    (OVERLAY_LIMITS, "Stage travel limits", True),
+    (OVERLAY_BOUNDARIES, "Grid boundaries", True),
+    (OVERLAY_SLOTS, "Holder slots", True),
+)
+
+__all__ = [
+    "OVERLAY_LIMITS",
+    "OVERLAY_BOUNDARIES",
+    "OVERLAY_SLOTS",
+    "CONTEXT_OVERLAY_ENTRIES",
+    "landmark",
+    "canvas_span",
+    "holder_slots",
+    "slot_landmark",
+    "limit_shapes",
+    "boundary_shapes",
+    "slot_shapes",
+    "context_shapes",
+]
+
+
+def landmark(
+    frame: StageFrame, x: float, y: float, name: str = ""
+) -> FibsemStagePosition:
+    """A stage position that is a *place*, in the frame's own pose.
+
+    Grid centre and the corners of the travel envelope are places, not recorded poses,
+    so the rotation has to come from somewhere. Taking the frame's means
+    `BeamStageProjection` sees no rotation difference and leaves the compucentric
+    correction alone -- it is there to flip positions *recorded* half a turn away, and
+    firing it on a synthetic landmark would move the travel limits by the instrument's
+    compucentric calibration for no reason. Tilt is not read at all (the projection takes
+    it from the base), and is carried only so the position is complete.
+    """
+    origin = frame.origin
+    return FibsemStagePosition(name=name, x=x, y=y, z=0.0, r=origin.r, t=origin.t)
+
+
+def canvas_span(frame: StageFrame, length: float) -> Tuple[float, float]:
+    """A length *along the sample surface*, in canvas pixels, per axis.
+
+    Not `frame.length()` twice. That divides by the canvas scale and stops, which is
+    right for x and wrong for y: the view foreshortens the surface by a factor that
+    changes with the beam and the pose -- 1.00 looking down the surface normal, 0.26 for
+    the ion beam at the milling pose. A boundary sized by the scale alone is the same
+    size in every view, and therefore right in at most one of them.
+
+    **A surface length, not a stage-axis one.** Stepping stage y with no z is a move
+    *through* a tilted surface rather than along it, and inflates every span by
+    `1 / cos(pre_tilt)` -- exactly 1.000 at the pre-tilt of 0 that every Arctis and every
+    test has, and 1.221 on a 35 degree shuttle, where a grid boundary came out 22% tall
+    in the two views it must be a circle in (FIB-657). Stage x needs no such care: the
+    tilt is about x, so stage x lies in the surface and a step along it is a step along
+    the surface.
+
+    Measured through the frame, not derived from the geometry again, so it cannot
+    disagree with where the frame puts a marker. Absolute, because a view can flip an
+    axis and a span has no sign.
+    """
+    ox, _ = frame.to_canvas(landmark(frame, 0.0, 0.0))
+    along_x, _ = frame.to_canvas(landmark(frame, length, 0.0))
+    span_x = abs(along_x - ox)
+    return span_x, span_x * frame.surface_foreshortening()
+
+
+def holder_slots(microscope) -> List[object]:
+    """The sample holder's slots, or nothing if the stage does not describe one."""
+    try:
+        return list(microscope._stage.holder.slots.values())
+    except Exception:
+        return []
+
+
+def slot_landmark(microscope, slot: object) -> Optional[FibsemStagePosition]:
+    """Where a holder slot sits, as a position that can be drawn in any view.
+
+    Slots are stored as x/y/z and **nothing else**: `default-sample-holder.yaml` gives
+    each one three numbers, and `SampleHolder.load` leaves `r` and `t` as None. Handed to
+    `frame.to_canvas` that raises -- and the fluorescence tab did exactly that, so a
+    shipped two-slot shuttle would have drawn no slot markers at all. The simulator's
+    holder hides it: `_ensure_slots` invents its slot with r=0.
+
+    The missing rotation is the **SEM orientation**, which is the frame the holder file
+    is written in. Stamped here rather than assumed away, because it is what makes a slot
+    re-expressible: a shuttle's grids sit at x = -5 mm and +5 mm, and after a 180-degree
+    rotation the raw coordinate that reaches a given grid is the *other* one. Carrying
+    the pose lets `BeamStageProjection` see the difference and apply the compucentric
+    flip, exactly as it does for a position recorded at one orientation and drawn at
+    another.
+
+    So **not** `landmark`, which takes the frame's own rotation precisely to stop that
+    flip firing. A travel-envelope corner is a place in the frame being drawn; a slot is
+    a place on the holder, and the holder turns over with the stage.
+
+    No hardware: `get_orientation` is a lookup over the configured orientations. On a
+    compustage every orientation shares one rotation, so this is the identity and the
+    slots draw where they always did.
+    """
+    position = getattr(slot, "position", None)
+    if position is None:
+        return None
+    try:
+        pose = microscope.get_orientation("SEM")
+    except Exception as e:
+        logger.debug(f"Could not resolve the holder's reference orientation: {e}")
+        return None
+    return FibsemStagePosition(
+        name=position.name or "", x=position.x, y=position.y,
+        z=position.z or 0.0, r=pose.r, t=pose.t,
+    )
+
+
+def limit_shapes(microscope, frame: StageFrame) -> List[ShapeSpec]:
+    """The stage's travel envelope, wherever limits are configured.
+
+    Not gated on the stage type. The fluorescence copy gated this and the grid boundary
+    together on `stage_is_compustage`, so a standard stage lost the travel box along with
+    the grid circle -- and travel limits have nothing to do with grids. One guard was
+    answering two questions.
+    """
+    limits = getattr(microscope._stage, "limits", None)
+    if not limits:
+        return []
+    try:
+        # Every corner, not a width and a height: the projection can flip either axis,
+        # and reading the envelope off the extremes of the projected corners is true
+        # whatever it does to them. The box stays axis-aligned -- the terms are a scale
+        # per axis and a possible flip of both.
+        corners = [
+            frame.to_canvas(landmark(frame, x, y))
+            for x in (limits["x"].min, limits["x"].max)
+            for y in (limits["y"].min, limits["y"].max)
+        ]
+        xs = [point[0] for point in corners]
+        ys = [point[1] for point in corners]
+        width, height = max(xs) - min(xs), max(ys) - min(ys)
+        box_cx, box_cy = (max(xs) + min(xs)) / 2, (max(ys) + min(ys)) / 2
+    except Exception as e:
+        logger.debug(f"Could not draw the stage limits: {e}")
+        return []
+    return [
+        ShapeSpec(kind="rect", cx=box_cx, cy=box_cy, width=width, height=height,
+                  color=STAGE_LIMITS_COLOUR, label="Stage Limits"),
+    ]
+
+
+def boundary_shapes(microscope, frame: StageFrame) -> List[ShapeSpec]:
+    """A grid boundary around every slot the holder carries.
+
+    One per slot rather than one at the stage origin. A grid is 1 mm in radius whatever
+    holds it, so what the boundary needs is *where the grids are* -- and the holder
+    already says, in the same slot positions `slot_shapes` draws crosshairs at. A
+    compustage carries a single slot at the origin, so it goes on drawing the one circle
+    it always drew; a multi-grid shuttle gets one each, where before it got a single
+    circle at a place no grid is.
+
+    Placed exactly as the crosshair is, through `frame.to_canvas(slot_landmark(...))`, so
+    the boundary and the marker at its centre cannot disagree: whatever the frame does to
+    that position it does to both. Deliberately *not* re-derived through `landmark` --
+    that would make the boundary a synthetic place and the crosshair a recorded one, and
+    the two would part company on a stage where the compucentric correction fires.
+
+    A circle on the sample, so an **ellipse** on screen everywhere but the two views
+    where the beam looks down the pose it is named after.
+    """
+    specs: List[ShapeSpec] = []
+    for slot in holder_slots(microscope):
+        place = slot_landmark(microscope, slot)
+        if place is None:
+            continue
+        try:
+            cx, cy = frame.to_canvas(place)
+            span_x, span_y = canvas_span(frame, GRID_BOUNDARY_RADIUS_M)
+        except Exception as e:
+            logger.debug(f"Could not draw a grid boundary: {e}")
+            continue
+        specs.append(ShapeSpec(kind="ellipse", cx=cx, cy=cy,
+                               width=2 * span_x, height=2 * span_y,
+                               color=GRID_BOUNDARY_COLOUR, label="Grid Boundary"))
+    return specs
+
+
+def slot_shapes(microscope, frame: StageFrame) -> List[ShapeSpec]:
+    """The sample holder's slots, as crosshairs at their configured positions.
+
+    Through `slot_landmark` for the same reason the boundary is, and so the two stay
+    concentric by construction rather than by both happening to be right.
+    """
+    specs: List[ShapeSpec] = []
+    for slot in holder_slots(microscope):
+        place = slot_landmark(microscope, slot)
+        if place is None:
+            continue
+        try:
+            cx, cy = frame.to_canvas(place)
+        except Exception as e:
+            logger.debug(f"Could not draw a holder slot: {e}")
+            continue
+        specs.append(ShapeSpec(kind="crosshair", cx=cx, cy=cy,
+                               color=SLOT_COLOUR, label=place.name or ""))
+    return specs
+
+
+def context_shapes(
+    microscope,
+    frame: StageFrame,
+    limits: bool = True,
+    boundaries: bool = True,
+    slots: bool = True,
+) -> List[ShapeSpec]:
+    """All three, in draw order, with each switchable.
+
+    The flags exist because both tabs offer the same switches, so the caller passing
+    three booleans is shorter than the caller assembling three lists -- and it puts the
+    order in one place, where the boundary is drawn under the crosshair that marks its
+    centre rather than over it.
+    """
+    specs: List[ShapeSpec] = []
+    if limits:
+        specs.extend(limit_shapes(microscope, frame))
+    if boundaries:
+        specs.extend(boundary_shapes(microscope, frame))
+    if slots:
+        specs.extend(slot_shapes(microscope, frame))
+    return specs

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -94,6 +94,7 @@ from fibsem.ui.tokens import (
     STAGE_LIMITS_COLOUR,
 )
 from fibsem.ui.widgets.canvas.contrast_gamma_control import ContrastGammaControl
+from fibsem.ui.widgets.canvas.overlays import stage_context
 from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
     GRID_BOUNDARY_RADIUS_M,
     MinimapShapesOverlay,
@@ -134,10 +135,12 @@ logger = logging.getLogger(__name__)
 # The canvas key the in-progress mosaic is drawn under. Its own, so a run that dies
 # leaves no half-filled overview behind pretending to be a finished one.
 # Overlay keys for `CanvasOverlayControls`. Named rather than inline so the control and
-# the thing it gates cannot drift apart under a rename.
-_OVERLAY_LIMITS = "limits"
-_OVERLAY_BOUNDARIES = "boundaries"
-_OVERLAY_SLOTS = "slots"
+# the thing it gates cannot drift apart under a rename. The three stage-context ones are
+# shared with the fluorescence tab and live with the shapes they gate; these two are this
+# tab's own.
+_OVERLAY_LIMITS = stage_context.OVERLAY_LIMITS
+_OVERLAY_BOUNDARIES = stage_context.OVERLAY_BOUNDARIES
+_OVERLAY_SLOTS = stage_context.OVERLAY_SLOTS
 _OVERLAY_POSITIONS = "positions"
 _OVERLAY_GRIDBARS = "gridbars"
 
@@ -724,9 +727,7 @@ class FibsemOverviewWidget(QWidget):
         # then the holder's grids, then the marks inside them. Grid bars last because
         # they are a lattice over everything and the two controls under them are theirs.
         self.overlay_controls = CanvasOverlayControls([
-            (_OVERLAY_LIMITS, "Stage travel limits", True),
-            (_OVERLAY_BOUNDARIES, "Grid boundaries", True),
-            (_OVERLAY_SLOTS, "Holder slots", True),
+            *stage_context.CONTEXT_OVERLAY_ENTRIES,
             (_OVERLAY_POSITIONS, "Saved positions", True),
             (_OVERLAY_GRIDBARS, "Grid bars", False),
         ])
@@ -1900,14 +1901,12 @@ class FibsemOverviewWidget(QWidget):
             self.context_overlay.set_shapes([])
             return
 
-        specs: List[ShapeSpec] = []
-        if self.overlay_controls.is_visible(_OVERLAY_LIMITS):
-            specs.extend(self._limit_shapes(frame))
-        if self.overlay_controls.is_visible(_OVERLAY_BOUNDARIES):
-            specs.extend(self._boundary_shapes(frame))
-        if self.overlay_controls.is_visible(_OVERLAY_SLOTS):
-            specs.extend(self._slot_shapes(frame))
-        self.context_overlay.set_shapes(specs)
+        self.context_overlay.set_shapes(stage_context.context_shapes(
+            self.microscope, frame,
+            limits=self.overlay_controls.is_visible(_OVERLAY_LIMITS),
+            boundaries=self.overlay_controls.is_visible(_OVERLAY_BOUNDARIES),
+            slots=self.overlay_controls.is_visible(_OVERLAY_SLOTS),
+        ))
         self._declare_working_area(frame)
         self._refresh_tile_grid()
         self._refresh_stage_info()
@@ -2097,188 +2096,23 @@ class FibsemOverviewWidget(QWidget):
         self._target = None
         self._refresh_tile_grid()
 
+    # Delegated to `stage_context`, which owns the drawing both tabs share. Kept as
+    # methods because the tab resolves places of its own with them -- the grid centre it
+    # declares a working area around, and the origin the tile grid hangs off.
+
+    @staticmethod
+    def _landmark(
+        frame: StageFrame, x: float, y: float, name: str = ""
+    ) -> FibsemStagePosition:
+        return stage_context.landmark(frame, x, y, name)
+
+    def _slot_landmark(self, slot: object) -> Optional[FibsemStagePosition]:
+        return stage_context.slot_landmark(self.microscope, slot)
+
     @property
     def target(self) -> Optional[FibsemStagePosition]:
         """Where the next run is planned around, or None for wherever the stage is."""
         return self._target
-
-    @staticmethod
-    def _landmark(frame: StageFrame, x: float, y: float, name: str = "") -> FibsemStagePosition:
-        """A stage position that is a *place*, in the frame's own pose.
-
-        Grid centre and the corners of the travel envelope are places, not recorded
-        poses, so the rotation has to come from somewhere. Taking the frame's means
-        `BeamStageProjection` sees no rotation difference and leaves the compucentric
-        correction alone -- it is there to flip positions *recorded* half a turn away,
-        and firing it on a synthetic landmark would move the travel limits by the
-        instrument's compucentric calibration for no reason. Tilt is not read at all
-        (the projection takes it from the base), and is carried only so the position
-        is complete.
-        """
-        origin = frame.origin
-        return FibsemStagePosition(
-            name=name, x=x, y=y, z=0.0, r=origin.r, t=origin.t
-        )
-
-    def _canvas_span(self, frame: StageFrame, length: float) -> Tuple[float, float]:
-        """A length *along the sample surface*, in canvas pixels, per axis.
-
-        Not `frame.length()` twice. That divides by the canvas scale and stops, which is
-        right for x and wrong for y: the view foreshortens the surface by a factor that
-        changes with the beam and the pose -- 1.00 looking down the surface normal, 0.26
-        for the ion beam at the milling pose. A boundary sized by the scale alone is the
-        same size in every view, and therefore right in at most one of them.
-
-        **A surface length, not a stage-axis one.** Stepping stage y with no z, which is
-        what this did, is a move *through* a tilted surface rather than along it, and
-        inflates every span by `1 / cos(pre_tilt)` -- exactly 1.000 at the pre-tilt of 0
-        that every Arctis and every test has, and 1.221 on a 35 degree shuttle, where a
-        grid boundary came out 22% tall in the two views it must be a circle in
-        (FIB-657). Stage x needs no such care: the tilt is about x, so stage x lies in
-        the surface and a step along it is a step along the surface.
-
-        Measured through the frame, not derived from the geometry again, so it cannot
-        disagree with where the frame puts a marker. Absolute, because a view can flip
-        an axis and a span has no sign.
-        """
-        ox, _ = frame.to_canvas(self._landmark(frame, 0.0, 0.0))
-        along_x, _ = frame.to_canvas(self._landmark(frame, length, 0.0))
-        span_x = abs(along_x - ox)
-        return span_x, span_x * frame.surface_foreshortening()
-
-    def _limit_shapes(self, frame: StageFrame) -> List[ShapeSpec]:
-        """The stage's travel envelope, wherever limits are configured.
-
-        Not gated on the stage type. It used to be: the whole method returned nothing
-        unless `_draws_grid_boundary()` held, so a standard stage lost the travel box
-        along with the grid circle -- and travel limits have nothing to do with grids.
-        One guard was answering two questions.
-        """
-        limits = getattr(self.microscope._stage, "limits", None)
-        if not limits:
-            return []
-        try:
-            # Every corner, not a width and a height: the projection can flip either
-            # axis, and reading the envelope off the extremes of the projected corners
-            # is true whatever it does to them. The box stays axis-aligned -- the
-            # terms are a scale per axis and a possible flip of both.
-            corners = [
-                frame.to_canvas(self._landmark(frame, x, y))
-                for x in (limits["x"].min, limits["x"].max)
-                for y in (limits["y"].min, limits["y"].max)
-            ]
-            xs = [point[0] for point in corners]
-            ys = [point[1] for point in corners]
-            width, height = max(xs) - min(xs), max(ys) - min(ys)
-            box_cx, box_cy = (max(xs) + min(xs)) / 2, (max(ys) + min(ys)) / 2
-        except Exception as e:
-            logger.debug(f"Could not draw the stage limits: {e}")
-            return []
-        return [
-            ShapeSpec(kind="rect", cx=box_cx, cy=box_cy, width=width, height=height,
-                      color=STAGE_LIMITS_COLOUR, label="Stage Limits"),
-        ]
-
-    def _holder_slots(self) -> List[object]:
-        """The sample holder's slots, or nothing if the stage does not describe one."""
-        try:
-            return list(self.microscope._stage.holder.slots.values())
-        except Exception:
-            return []
-
-    def _slot_landmark(self, slot: object) -> Optional[FibsemStagePosition]:
-        """Where a holder slot sits, as a position that can be drawn in any view.
-
-        Slots are stored as x/y/z and **nothing else**: `default-sample-holder.yaml`
-        gives each one three numbers, and `SampleHolder.load` leaves `r` and `t` as
-        None. Handed to `frame.to_canvas` that raises -- and `_slot_shapes` swallowed
-        it, so the shipped two-slot shuttle drew no slot markers at all, silently. The
-        simulator's holder hid it: `_ensure_slots` invents its slot with r=0.
-
-        The missing rotation is the **SEM orientation**, which is the frame the holder
-        file is written in. Stamped here rather than assumed away, because it is what
-        makes a slot re-expressible: a shuttle's grids sit at x = -5 mm and +5 mm, and
-        after a 180-degree rotation the raw coordinate that reaches a given grid is the
-        *other* one. Carrying the pose lets `BeamStageProjection` see the difference
-        and apply the compucentric flip, exactly as it does for a position recorded at
-        one orientation and drawn at another.
-
-        So **not** `_landmark`, which takes the frame's own rotation precisely to stop
-        that flip firing. A travel-envelope corner is a place in the frame being drawn;
-        a slot is a place on the holder, and the holder turns over with the stage.
-
-        No hardware: `get_orientation` is a lookup over the configured orientations.
-        On a compustage every orientation shares one rotation, so this is the identity
-        and the slots draw where they always did.
-        """
-        position = getattr(slot, "position", None)
-        if position is None:
-            return None
-        try:
-            pose = self.microscope.get_orientation("SEM")
-        except Exception as e:
-            logger.debug(f"Could not resolve the holder's reference orientation: {e}")
-            return None
-        return FibsemStagePosition(
-            name=position.name or "", x=position.x, y=position.y,
-            z=position.z or 0.0, r=pose.r, t=pose.t,
-        )
-
-    def _boundary_shapes(self, frame: StageFrame) -> List[ShapeSpec]:
-        """A grid boundary around every slot the holder carries.
-
-        One circle per slot rather than one at the stage origin. A grid is 1 mm in
-        radius whatever holds it, so what the boundary needs is *where the grids are* --
-        and the holder already says, in the same slot positions `_slot_shapes` draws
-        crosshairs at. A compustage carries a single slot at the origin, so it goes on
-        drawing the one circle it always drew; a multi-grid shuttle gets one each,
-        where before it got a single circle at a place no grid is.
-
-        Placed exactly as the crosshair is, through `frame.to_canvas(slot.position)`,
-        so the circle and the marker at its centre cannot disagree: whatever the frame
-        does to that position it does to both. Deliberately *not* re-derived through
-        `_landmark` -- that would make the circle a synthetic place and the crosshair a
-        recorded one, and the two would part company on a stage where the compucentric
-        correction fires.
-
-        A circle on the sample, so an ellipse on screen everywhere but the two views
-        where the beam looks down the pose it is named after.
-        """
-        specs: List[ShapeSpec] = []
-        for slot in self._holder_slots():
-            place = self._slot_landmark(slot)
-            if place is None:
-                continue
-            try:
-                cx, cy = frame.to_canvas(place)
-                span_x, span_y = self._canvas_span(frame, GRID_BOUNDARY_RADIUS_M)
-            except Exception as e:
-                logger.debug(f"Could not draw a grid boundary: {e}")
-                continue
-            specs.append(ShapeSpec(kind="ellipse", cx=cx, cy=cy,
-                                   width=2 * span_x, height=2 * span_y,
-                                   color=GRID_BOUNDARY_COLOUR, label="Grid Boundary"))
-        return specs
-
-    def _slot_shapes(self, frame: StageFrame) -> List[ShapeSpec]:
-        """The sample holder's slots, as crosshairs at their configured positions.
-
-        Through `_slot_landmark` for the same reason the boundary is, and so the two
-        stay concentric by construction rather than by both happening to be right.
-        """
-        specs = []
-        for slot in self._holder_slots():
-            place = self._slot_landmark(slot)
-            if place is None:
-                continue
-            try:
-                cx, cy = frame.to_canvas(place)
-            except Exception as e:
-                logger.debug(f"Could not draw a holder slot: {e}")
-                continue
-            specs.append(ShapeSpec(kind="crosshair", cx=cx, cy=cy,
-                                   color=SLOT_COLOUR, label=place.name or ""))
-        return specs
 
     def _refresh_stage_info(self) -> None:
         """Say where the stage is, in the canvas's bottom-left info bar.

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1027,16 +1027,23 @@ def test_the_stage_and_grid_limits_are_drawn_in_the_canvas_frame(qapp, overview_
     reference = widget.canvas.canvas.reference_pixel_size
     limits = widget.microscope._stage.limits
 
-    stage = by_label["Stage limits"]
+    stage = by_label["Stage Limits"]
     assert stage.width == pytest.approx((limits["x"].max - limits["x"].min) / reference)
     assert stage.height == pytest.approx((limits["y"].max - limits["y"].min) / reference)
 
     from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
         GRID_BOUNDARY_RADIUS_M,
     )
-    assert by_label["Grid boundary"].radius == pytest.approx(
-        GRID_BOUNDARY_RADIUS_M / reference
-    )
+    # An ellipse of the full diameter per axis, not a circle of one radius (FIB-698).
+    # A circle on the sample is a circle on screen only where the view looks down the
+    # surface normal, which the fluorescence pose does and the milling pose does not --
+    # so the shape is chosen by the geometry rather than by which tab drew it. Equal
+    # here because this pose is normal to the surface; the beam tab's milling view is
+    # where they part.
+    boundary = by_label["Grid Boundary"]
+    assert boundary.kind == "ellipse"
+    assert boundary.width == pytest.approx(2 * GRID_BOUNDARY_RADIUS_M / reference)
+    assert boundary.height == pytest.approx(boundary.width)
 
     assert widget.stage_overlay._artists, "specs were built but nothing was drawn"
 
@@ -1052,8 +1059,8 @@ def test_stage_metadata_does_not_wait_for_an_image(qapp, overview_widget):
     widget._refresh_stage_metadata()
 
     labels = [spec.label for spec in widget.stage_overlay._specs]
-    assert "Stage limits" in labels
-    assert "Grid boundary" in labels
+    assert "Stage Limits" in labels
+    assert "Grid Boundary" in labels
 
 
 def test_stage_metadata_is_dropped_when_the_geometry_is_unknown(qapp, overview_widget):

--- a/tests/ui/test_overview_tabs_agree.py
+++ b/tests/ui/test_overview_tabs_agree.py
@@ -101,3 +101,62 @@ def test_the_grid_radius_is_defined_once():
         assigned = _assigned_names(source)
         strays = {n for n in assigned if "GRID_RADIUS" in n or "BOUNDARY_RADIUS" in n}
         assert not strays, f"{tab} defines its own grid radius: {strays}"
+
+
+# ── the geometry, not just the colours ───────────────────────────────────
+
+STAGE_CONTEXT = (
+    REPO_ROOT / "fibsem" / "ui" / "widgets" / "canvas" / "overlays" / "stage_context.py"
+)
+
+# The shapes both tabs draw for stage context. Built once, in `stage_context`, and
+# neither tab may build its own -- which is what let the fluorescence copy drift into
+# gating the travel box on the stage type, sizing the boundary in stage axes rather than
+# along the surface, and handing a frame the `r=None` a holder file leaves (FIB-698).
+SHARED_BUILDERS = ("limit_shapes", "boundary_shapes", "slot_shapes", "context_shapes")
+
+
+def test_the_stage_context_shapes_are_built_in_one_place():
+    defined = {
+        n.name
+        for n in ast.parse(STAGE_CONTEXT.read_text(encoding="utf-8")).body
+        if isinstance(n, ast.FunctionDef)
+    }
+    assert set(SHARED_BUILDERS) <= defined
+
+
+@pytest.mark.parametrize("tab", ["beam", "fm"])
+def test_neither_tab_builds_its_own_stage_context_shapes(tab, sources):
+    """A `ShapeSpec` for stage context, constructed in a tab, is the drift starting again.
+
+    Each tab still builds specs of its own -- the beam tab's gridbars and both tabs'
+    position markers -- so this looks for the *labels* the shared builders own rather
+    than for `ShapeSpec` outright.
+    """
+    source = sources[tab]
+    for label in ("Stage Limits", "Grid Boundary"):
+        assert f'"{label}"' not in source and f"'{label}'" not in source, (
+            f"the {tab} tab writes the {label!r} shape itself; "
+            "`stage_context` is where both tabs get it"
+        )
+
+
+def test_the_fluorescence_tab_sizes_nothing_with_frame_length():
+    """`frame.length()` is a pure scale, so anything lying *on the sample* sized with it
+    is the same size in every view -- and therefore right in at most one of them.
+
+    This tab did exactly that for the grid boundary, which is why it drew a circle where
+    the beam tab draws an ellipse. `stage_context.canvas_span` is the one that applies
+    the view's foreshortening.
+
+    **The beam tab is deliberately not checked.** It still has three, all in the gridbar
+    lattice, and its own comment says they are wrong in the same way -- a square lattice
+    on the sample is not square in a tilted view, so at the milling pose the horizontal
+    bars sit about four times too far apart. That is the rest of FIB-615, left on
+    purpose. Asserting it here would be asserting something known to be false, and the
+    test would have to be deleted to make the tree green rather than fixed.
+    """
+    assert "frame.length(" not in FM.read_text(encoding="utf-8"), (
+        "the fluorescence tab sizes something with frame.length(); if it lies on the "
+        "sample surface it wants stage_context.canvas_span()"
+    )


### PR DESCRIPTION
The fifth and last layer where the beam and fluorescence overviews were written twice
(FIB-698, under FIB-693), with FIB-572's controls half folded in.

Both tabs draw the stage's travel envelope, the grid boundary and the holder's slots,
from the same `microscope._stage` into the same `ShapeSpec`. #388 shared the colours and
the radius but not the drawing, so three fixes existed only in the beam copy.

## Why it was small

**Both tabs' `_frame()` already returns the same `StageFrame`**, and
`surface_foreshortening()` is a method on it — the fluorescence tab simply never called
it. The beam tab's builders were already pure functions of `(microscope, frame)`, so this
is a move into `stage_context.py`, not a rewrite of either tab.

## What the fluorescence tab gains

| | |
| -- | -- |
| travel box | no longer gated on `stage_is_compustage` — one guard was answering two questions, so a standard stage lost the box along with the grid circle |
| grid boundary | an **ellipse sized along the sample surface**, not a circle sized by `frame.length()` |
| holder slots | through `slot_landmark`, which survives the `r=None` that `SampleHolder.load` leaves |

That last one is the one that could actually bite: handed straight to a frame it raises,
and the tab swallowed it — a shipped two-slot shuttle would have drawn **no slot markers
at all**, silently. The simulator's holder hides it by inventing `r=0`.

**All three are dormant on compustage-only fluorescence**, which is where this runs
today: the gate is always true and the FM pose is normal to the surface, so the ellipse
and the circle come out the same size.

## The switches, too (FIB-572 item 3)

The fluorescence tab gets the overlays popover the beam tab has, from the same entries —
so neither tab can offer a switch the other does not, or word it differently. Sharing
*what is drawn* without sharing *the switch that hides it* would have left three overlays
a user cannot turn off.

## Verification

Every emitted `ShapeSpec` dumped from both tabs, before and after:

| | result |
| -- | -- |
| beam, all three views | **byte-identical** — including the foreshortened travel box at the milling pose |
| fluorescence | changed in exactly the three intended ways and nothing else |
| `tests/ui` + autolamella UI | **1788 passed** |

The fluorescence diff in full: `circle` r=10000 → `ellipse` 20000×20000 (same rendered
size, since 2r = w, but now view-aware), and the labels now match the beam's wording.

The harness needed one fix before it was worth anything: it first read `overlay._shapes`,
which does not exist, and reported *empty on both sides* — a comparison that would have
passed no matter what the change did. The attribute is `_specs`.

## Tests

`test_overview_tabs_agree.py` guarded the colours and **none of the geometry**, which is
what let these three diverge. It now also pins that the shapes are built in one place,
that neither tab writes one itself, and that the fluorescence tab sizes nothing with
`frame.length()`.

That last one is deliberately **not** asserted for the beam tab. It still has three, all
in the gridbar lattice, and its own comment says they are wrong the same way — the rest of
FIB-615, left on purpose. Asserting it would assert something known to be false, and the
test would have to be deleted to go green rather than fixed.

## Not in scope

FIB-572's remaining item — taking the radius from `SampleGrid.radius` — is deferred with
its reasoning on that issue: every grid currently takes the default 1 mm, which is the
number the constant already holds, from a widget behind a flag that is off. Right
direction, no effect today.
