### PR TITLE
[ui] Say what an overview costs and where it lands (FIB-707/660/701)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
@@ -26,7 +26,17 @@ from fibsem.fm.structures import (
 )
 from fibsem.fm.timing import estimate_tileset_acquisition_time
 from fibsem.structures import TileOrderStrategy
-from fibsem.ui.widgets.preflight import OverviewPreflightDialog, format_duration
+from fibsem.ui.widgets.preflight import (
+    OverviewPreflightDialog,
+    PathValue,
+    format_bytes,
+    format_duration,
+    mosaic_pixels,
+)
+
+# Fluorescence images are 16-bit. Stated rather than read off a tile, because the dialog
+# is shown before anything has been acquired.
+FM_BYTES_PER_PIXEL = 2
 
 
 class FMOverviewConfirmationDialog(OverviewPreflightDialog):
@@ -41,6 +51,8 @@ class FMOverviewConfirmationDialog(OverviewPreflightDialog):
         autofocus_settings: Optional[AutoFocusSettings] = None,
         objective_current: Optional[float] = None,
         objective_focus: Optional[float] = None,
+        tile_resolution: Optional[tuple] = None,
+        save_directory: Optional[str] = None,
         parent: Optional[QWidget] = None,
     ):
         super().__init__(parent)
@@ -53,6 +65,11 @@ class FMOverviewConfirmationDialog(OverviewPreflightDialog):
         # so the number it reports is the one the settings panel was showing.
         self.objective_current = objective_current
         self.objective_focus = objective_focus
+        # Both passed in rather than read: this dialog takes no microscope, which is what
+        # lets it be built and tested on its own, and the camera resolution is a hardware
+        # read on a shared connection (FIB-517).
+        self.tile_resolution = tile_resolution
+        self.save_directory = save_directory
         self._init_ui()
 
     # ── content ──────────────────────────────────────────────────────────
@@ -158,6 +175,28 @@ class FMOverviewConfirmationDialog(OverviewPreflightDialog):
             detail.extend(self._sweep_rows())
 
         detail.append(("Images", f"{estimate['total_images']:,}"))
+
+        # What it will cost on disk. One file per tile plus the stitch beside them, all
+        # uncompressed, so the array sizes are the estimate rather than a floor for it.
+        # Each tile is already max-projected when it is written, so the z-planes multiply
+        # the *time* and not the bytes -- which is why this reads from the channel count
+        # and not from `zparams`.
+        if self.tile_resolution is not None:
+            width, height = self.tile_resolution
+            channels = max(1, len(self.channel_settings))
+            mosaic_w, mosaic_h = mosaic_pixels(p.rows, p.cols, p.overlap, width, height)
+            tile_bytes = channels * width * height * FM_BYTES_PER_PIXEL
+            total = (p.n_enabled_tiles * tile_bytes
+                     + channels * mosaic_w * mosaic_h * FM_BYTES_PER_PIXEL)
+            detail.append((
+                "Disk",
+                f"~{format_bytes(total)}"
+                f"   ({format_bytes(tile_bytes)} per tile"
+                f" · {mosaic_w} × {mosaic_h} px stitched)",
+            ))
+
+        if self.save_directory:
+            detail.append(("Saving to", PathValue(self.save_directory)))
         detail.append((
             "Estimated time",
             f"{format_duration(estimate['total_time'])}"

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -2124,6 +2124,11 @@ class FMOverviewWidget(QWidget):
             autofocus_settings=autofocus_settings,
             objective_current=self.settings_widget._objective_current,
             objective_focus=self.settings_widget._objective_focus,
+            # Read the same way `_sync_tile_fov` already does, and only when the dialog
+            # opens rather than on every refresh. Best effort: a disk estimate is not a
+            # reason to refuse to show the dialog.
+            tile_resolution=self._camera_resolution(),
+            save_directory=self._save_directory,
             parent=self,
         )
         if dialog.exec_() != QDialog.Accepted:
@@ -2157,6 +2162,14 @@ class FMOverviewWidget(QWidget):
         )
         self._worker = FunctionWorker(self._acquire_worker)
         self._worker.start()
+
+    def _camera_resolution(self) -> Optional[tuple]:
+        """The camera's pixel dimensions, or None if it cannot be asked right now."""
+        try:
+            return tuple(self.fm.camera.resolution)
+        except Exception as e:
+            logging.debug(f"Could not read the camera resolution: {e}")
+            return None
 
     def _claim_destination(self) -> Optional["OverviewDestination"]:
         """Where this run's files go, or None if nowhere.

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -857,8 +857,21 @@ class ElidedLabel(QLabel):
     fit; a caller wanting a different tooltip sets it after `setText`.
     """
 
-    def __init__(self, text: str = "", parent: Optional[QWidget] = None) -> None:
+    def __init__(
+        self,
+        text: str = "",
+        parent: Optional[QWidget] = None,
+        mode: Qt.TextElideMode = Qt.ElideRight,
+    ) -> None:
+        """
+        Args:
+            mode: which end goes. `ElideRight` for prose, where the start carries the
+                sense. **`ElideLeft` for a path**, where it is the tail -- the
+                experiment and the run -- that answers "am I writing where I meant
+                to", and the leading directories are the same on every line.
+        """
         super().__init__(parent)
+        self._mode = mode
         self._full_text = ""
         # Ignored horizontally: the label neither asks for room nor refuses to shrink,
         # which is the whole point -- its content must not set anyone's minimum.
@@ -887,7 +900,7 @@ class ElidedLabel(QLabel):
     def _elide(self) -> None:
         metrics = QFontMetrics(self.font())
         elided = metrics.elidedText(
-            self._full_text, Qt.ElideRight, max(0, self.width() - 2)
+            self._full_text, self._mode, max(0, self.width() - 2)
         )
         # `super().text()`, not ours: ours returns the full string, so this would differ
         # on every paint of an elided label and schedule another one forever. QLabel

--- a/fibsem/ui/widgets/overview_confirmation_dialog.py
+++ b/fibsem/ui/widgets/overview_confirmation_dialog.py
@@ -19,7 +19,17 @@ from PyQt5.QtWidgets import QWidget
 
 from fibsem import constants
 from fibsem.structures import OverviewAcquisitionSettings
-from fibsem.ui.widgets.preflight import OverviewPreflightDialog, format_duration
+from fibsem.ui.widgets.preflight import (
+    OverviewPreflightDialog,
+    PathValue,
+    format_bytes,
+    format_duration,
+    mosaic_pixels,
+)
+
+# Beam images are 8-bit. Stated rather than read off a tile, because the dialog is shown
+# before anything has been acquired -- there is no image to ask.
+BEAM_BYTES_PER_PIXEL = 1
 
 
 class OverviewConfirmationDialog(OverviewPreflightDialog):
@@ -104,10 +114,24 @@ class OverviewConfirmationDialog(OverviewPreflightDialog):
         ))
         detail.append(("Auto contrast", "on" if image.autocontrast else "off"))
 
+        # What it will cost on disk. Tiles are written one file each and the stitch is
+        # written beside them, all uncompressed -- measured at 1.00x the array plus a
+        # 2 kB header -- so the array sizes are the estimate rather than a floor for it.
+        mosaic_w, mosaic_h = mosaic_pixels(
+            s.nrows, s.ncols, s.overlap, width, height
+        )
+        tile_bytes = width * height * BEAM_BYTES_PER_PIXEL
+        detail.append((
+            "Disk",
+            f"~{format_bytes(s.n_enabled_tiles * tile_bytes + mosaic_w * mosaic_h * BEAM_BYTES_PER_PIXEL)}"
+            f"   ({format_bytes(tile_bytes)} per tile"
+            f" · {mosaic_w} × {mosaic_h} px stitched)",
+        ))
+
         # Where it lands, which is the other thing that survives a tab switch unnoticed:
         # the filename names the tile sub-folder, so two runs under one name interleave.
         if image.path:
-            detail.append(("Saving to", f"{image.path}/{image.filename}"))
+            detail.append(("Saving to", PathValue(f"{image.path}/{image.filename}")))
 
         # "Scan time", not "Estimated time": this is dwell over pixels, and it leaves out
         # the stage entirely. A real run is several times longer -- see

--- a/fibsem/ui/widgets/preflight.py
+++ b/fibsem/ui/widgets/preflight.py
@@ -30,6 +30,8 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem.ui import stylesheets
+from fibsem.ui.widgets.custom_widgets import ElidedLabel
+from fibsem.utils import format_time_remaining as utils_format_time_remaining
 
 BACKGROUND = stylesheets.SURFACE_COLOR
 PANEL = stylesheets.PANEL_COLOR
@@ -42,16 +44,53 @@ TEXT_MUTED = stylesheets.TEXT_MUTED_COLOR
 def format_duration(seconds: float) -> str:
     """`2m 14s`, `1h 03m`, `45s` — whichever reads best at that magnitude.
 
-    Not `fibsem.utils.format_duration`, which carries two decimal places: that is the
-    right shape for a milling estimate quoted to the second, and the wrong one for a
-    figure that is already approximate.
+    The padded form of `fibsem.utils.format_time_remaining`, which was the same three
+    branches with the same thresholds written a second time (FIB-701). Kept as a name
+    here because every dialog in this module asks for the same shape, and `pad=True` at
+    a dozen call sites is a detail none of them should be restating.
     """
-    seconds = int(round(seconds))
-    if seconds < 60:
-        return f"{seconds}s"
-    if seconds < 3600:
-        return f"{seconds // 60}m {seconds % 60:02d}s"
-    return f"{seconds // 3600}h {(seconds % 3600) // 60:02d}m"
+    return utils_format_time_remaining(seconds, pad=True)
+
+
+def format_bytes(count: float) -> str:
+    """`3.4 GB`, `880 MB`, `12 kB`. Decimal units, because a disk is sold in them.
+
+    One decimal place above a gigabyte and none below: the number is an estimate of what
+    a run will write, and quoting it to four figures would claim a precision the tile
+    count does not have.
+    """
+    for unit, step in (("TB", 1e12), ("GB", 1e9), ("MB", 1e6), ("kB", 1e3)):
+        if count >= step:
+            value = count / step
+            return f"{value:.1f} {unit}" if unit in ("TB", "GB") else f"{value:.0f} {unit}"
+    return f"{int(count)} B"
+
+
+def mosaic_pixels(rows: int, cols: int, overlap: float, width: int, height: int):
+    """How big the stitched mosaic comes out, in pixels.
+
+    The same step the runners use -- `fov * (1 - overlap)` per tile, plus one whole tile
+    -- so the estimate cannot disagree with what is allocated. The mask does not enter:
+    skipped tiles keep their place, so the rectangle is the full grid either way.
+    """
+    return (
+        int(round(((cols - 1) * (1 - overlap) + 1) * width)),
+        int(round(((rows - 1) * (1 - overlap) + 1) * height)),
+    )
+
+
+class PathValue(str):
+    """A detail-block value that is a filesystem path, and should be shown as one.
+
+    A `str` subclass rather than a flag on the row, so a caller that only wants the text
+    -- a test, a log line, the row tuple itself -- is unaffected, and `detail_block`
+    needs no second shape of row to carry the distinction.
+
+    What it buys: elided from the *left* with the whole path in the tooltip. A
+    destination is an experiment path plus a stamped run directory, which runs well past
+    a dialog's width and wrapped to three lines; and the part that answers "am I writing
+    where I meant to" is the tail, not the mount point (FIB-660).
+    """
 
 
 def chip(text: str) -> QWidget:
@@ -102,9 +141,12 @@ def detail_block(
         label.setStyleSheet(f"color: {TEXT_MUTED}; font-size: 11px; border: none;")
         label.setFixedWidth(label_width)
         label.setWordWrap(wrap_labels)
-        value = QLabel(value_text)
+        if isinstance(value_text, PathValue):
+            value = ElidedLabel(str(value_text), mode=Qt.ElideLeft)
+        else:
+            value = QLabel(value_text)
+            value.setWordWrap(True)
         value.setStyleSheet(f"color: {TEXT}; font-size: 11px; border: none;")
-        value.setWordWrap(True)
         row.addWidget(label, alignment=Qt.AlignTop)
         row.addWidget(value, stretch=1)
         layout.addLayout(row)

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -65,15 +65,31 @@ def format_duration(seconds: float) -> str:
         return f"{seconds:.2f}s"
 
 
-def format_time_remaining(seconds: float) -> str:
-    """Format a remaining-time value (seconds) as a compact whole-unit string (e.g. '1h 1m', '4m 12s', '5s')."""
-    total = int(seconds)
+def format_time_remaining(seconds: float, pad: bool = False) -> str:
+    """A duration in whole units: `1h 01m`, `4m 12s`, `5s`.
+
+    Rounded rather than truncated, so a value a hair under a boundary reads as the
+    boundary -- 59.6 s is `1m 00s`, not `59s`. Rounding *before* the branch is what makes
+    that work: 60 is no longer under a minute, so it takes the minutes arm.
+
+    *pad* zero-fills the second unit, which is what a column of durations wants -- a
+    figure that changes width as it counts down drags everything after it sideways. Left
+    off by default because a log line does not care.
+
+    Not `format_duration` above, which carries two decimal places: that is the right
+    shape for a milling estimate quoted to the second and the wrong one for a figure
+    already presented as approximate. Not `task_summary_formatting.format_duration_short`
+    either -- that is a fixed-width `MMm:SSs` for a table column, blank on a missing
+    value, which is a third job again.
+    """
+    total = int(round(seconds))
     hours, rem = divmod(total, 3600)
     minutes, secs = divmod(rem, 60)
+    width = "02d" if pad else "d"
     if hours:
-        return f"{hours}h {minutes}m"
+        return f"{hours}h {minutes:{width}}m"
     if minutes:
-        return f"{minutes}m {secs}s"
+        return f"{minutes}m {secs:{width}}s"
     return f"{secs}s"
 
 SI_PREFIXES = {

--- a/tests/ui/test_overview_confirmation_dialog.py
+++ b/tests/ui/test_overview_confirmation_dialog.py
@@ -235,3 +235,68 @@ def test_the_two_overview_dialogs_are_one_dialog():
         # answered -- an unimplemented one raises only when the dialog is opened.
         for hook in ("_meta_line", "_rows", "_tile_counts"):
             assert hook in vars(cls), f"{cls.__name__} does not supply {hook}"
+
+
+# ── what a run costs, and where it goes ──────────────────────────────────
+
+
+class TestTheRunsCost:
+    def test_the_disk_estimate_counts_the_tiles_and_the_stitch(self, dialog):
+        """Both are written, both uncompressed -- measured at 1.00x the array plus a
+        2 kB header -- so the array sizes are the estimate rather than a floor."""
+        from fibsem.ui.widgets.preflight import mosaic_pixels
+
+        settings = _settings(nrows=3, ncols=3)
+        rows = _rows(dialog(settings=settings))
+
+        width, height = settings.image_settings.resolution
+        mosaic_w, mosaic_h = mosaic_pixels(3, 3, settings.overlap, width, height)
+        expected = 9 * width * height + mosaic_w * mosaic_h
+
+        from fibsem.ui.widgets.preflight import format_bytes
+        assert format_bytes(expected) in rows["Disk"]
+        assert f"{mosaic_w} × {mosaic_h} px stitched" in rows["Disk"]
+
+    def test_a_masked_run_costs_only_the_tiles_it_writes(self, dialog):
+        """The stitch does not shrink -- skipped tiles keep their place -- so only the
+        per-tile half of the estimate follows the mask."""
+        full = _rows(dialog(settings=_settings(nrows=3, ncols=3)))["Disk"]
+        sparse = _rows(dialog(settings=_settings(
+            nrows=3, ncols=3,
+            tile_mask=[[True, False, False], [False, True, False], [False, False, True]],
+        )))["Disk"]
+        assert full != sparse
+
+    def test_the_destination_is_marked_as_a_path(self, dialog):
+        """`PathValue` is what makes `detail_block` elide from the left and put the whole
+        thing in a tooltip: the tail answers "am I writing where I meant to", and the
+        leading directories are the same on every line (FIB-660)."""
+        from fibsem.ui.widgets.preflight import PathValue
+
+        rows = _rows(dialog(settings=_settings(image={"path": "/experiments/demo"})))
+        assert isinstance(rows["Saving to"], PathValue)
+
+
+class TestTheDurationFormatters:
+    """One shape, one implementation (FIB-701)."""
+
+    def test_the_preflight_format_is_the_padded_shared_one(self):
+        from fibsem.utils import format_time_remaining
+        from fibsem.ui.widgets.preflight import format_duration
+
+        for seconds in (0, 5, 45, 59.6, 60, 65, 125, 3599, 3600, 7000, 86_399):
+            assert format_duration(seconds) == format_time_remaining(seconds, pad=True)
+
+    def test_padding_is_what_stops_a_column_jittering(self):
+        from fibsem.utils import format_time_remaining
+
+        assert format_time_remaining(65, pad=True) == "1m 05s"
+        assert format_time_remaining(65) == "1m 5s"
+
+    def test_a_value_just_under_a_boundary_rounds_up_into_it(self):
+        """Rounded before the branch, not after: 60 is no longer under a minute, so it
+        takes the minutes arm rather than reading as `60s`."""
+        from fibsem.utils import format_time_remaining
+
+        assert format_time_remaining(59.6, pad=True) == "1m 00s"
+        assert format_time_remaining(59.4, pad=True) == "59s"


### PR DESCRIPTION
Three pre-flight items — FIB-707, FIB-660, FIB-701 — one change each, all cheaper than
they were because both overview dialogs now share a base (FIB-695).

## What a run will cost (FIB-707)

Neither dialog said, and both knew enough to work it out exactly. Real numbers:

| | Disk |
| -- | -- |
| beam 5×5 @ 1536×1024 | `~73 MB` (2 MB per tile · 7066 × 4710 px stitched) |
| **ARCTIS 5×5 @ 4512², 4 channels** | **`~7.5 GB`** (163 MB per tile · 20755 × 20755 px stitched) |

Tiles are written one file each and the stitch beside them, **all uncompressed** —
measured at 1.00× the array plus a 2 kB header — so the array sizes are the estimate
rather than a floor for it. Each tile is already max-projected when written, so z-planes
multiply the *time* and not the bytes.

## Where it lands (FIB-707)

The fluorescence dialog never said. The beam one does, for a reason that applies to both:
the filename names the tile sub-folder, so two runs under one name interleave.

## Which made the path row too long (FIB-660)

A destination is an experiment path plus a stamped run directory, and it wrapped to three
lines. `PathValue` is a `str` subclass — so a caller wanting the text is unaffected and
`detail_block` needs no second shape of row — and it renders **elided from the left** with
the whole path in the tooltip:

```
Saving to   …e/overview-image-14-23-05/overview-image
```

The tail is what answers "am I writing where I meant to"; the leading directories are the
same on every line. `ElidedLabel` grew an elide mode — it only ever went right.

## One duration formatter fewer (FIB-701)

`preflight.format_duration` was `utils.format_time_remaining` written a second time: same
three branches, same thresholds, differing only in padding and in round-against-truncate.
`format_time_remaining` takes `pad` now and the preflight one delegates. **Verified
identical over 0–90000 s.**

Two of the four survive deliberately, and are not copies: `utils.format_duration` carries
two decimal places, right for a milling estimate quoted to the second;
`task_summary_formatting.format_duration_short` is a fixed-width `MMm:SSs` for a table
column, blank on a missing value.

**One behaviour change outside the dialogs:** `format_time_remaining` now rounds where it
truncated, so its single caller — a log line in `workflows/tasks/manager.py` — reads
`1m 00s` where it read `59s`.

## Notes

The camera resolution and save directory are **passed into** the fluorescence dialog
rather than read there, so it still needs no microscope and stays constructible on its
own. Reading the camera is a hardware call on a shared connection (FIB-517), so it happens
once when the dialog opens rather than on every refresh, and failing to read it drops the
row rather than the dialog.

| check | result |
| -- | -- |
| `tests/ui`, autolamella UI, utils | **1799 passed** |
| Python 3.8 parse | all touched files |
