### PR TITLE
[feat] Put the estimate on the workflow timeline (FIB-666)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1004,6 +1004,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         initial_state = "supervised" if selected_tasks[0].supervise else "automated"
         self._set_border_state(initial_state)
+        self._push_timeline_estimates(
+            [(ln, tn) for tn in task_names for ln in lamella_names]
+        )
         # The run writes the experiment from its own thread. Land any edit still
         # waiting in the editor first, so there is only ever one writer (FIB-683).
         self.lamella_widget.flush_pending_save()
@@ -1872,7 +1875,61 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def _on_queue_changed(self, info: dict) -> None:
         """The queue was edited between tasks — no task lifecycle to hang it off."""
-        self.workflow_timeline.refresh_queue(info.get("queue_items", []))
+        items = info.get("queue_items", [])
+        # An added item can be a (lamella, task) pair the launch matrix never held, so
+        # the estimates are recomputed here rather than only at the start.
+        self._push_timeline_estimates([(i.lamella_name, i.task_name) for i in items])
+        self.workflow_timeline.refresh_queue(items)
+
+    def _push_timeline_estimates(self, pairs: list) -> None:
+        """Give the timeline the per-item durations, and the schedule they walk past.
+
+        Computed here rather than inside the widget: an estimate comes from a lamella's
+        task config, and the timeline is generic — it has no business reaching for an
+        Experiment. Recomputed on workflow start and on a queue edit only, never per
+        status update: `estimated_duration` walks every milling stage of every task, and
+        the status path is the one already watched for latency (FIB-683).
+        """
+        experiment = getattr(self.autolamella_ui, "experiment", None)
+        if experiment is None:
+            return
+
+        lamella_by_name = {lam.name: lam for lam in experiment.positions}
+        estimates = {}
+        for lamella_name, task_name in pairs:
+            lamella = lamella_by_name.get(lamella_name)
+            if lamella is None:
+                continue
+            config = lamella.task_config.get(task_name)
+            # A lamella with no config for the task has no duration to offer, and
+            # inventing one would be worse than leaving the column empty.
+            if config is None:
+                continue
+            try:
+                estimates[(lamella_name, task_name)] = config.estimated_duration
+            except Exception:
+                # Deliberately caught, against this codebase's fail-fast default. This
+                # runs in a slot, and PyQt5 aborts the process on an unhandled exception
+                # in one (FIB-329) — which here would kill the worker thread mid-mill
+                # over a decorative number. `estimated_time` divides by the sputter rate
+                # (milling/base.py:292), so a hand-edited protocol can reach a
+                # ZeroDivisionError. The column already has a well-defined "no estimate
+                # to offer" state, so degrading into it is the graceful failure.
+                logging.warning(
+                    "Could not estimate duration for %s on %s; the timeline will show "
+                    "no estimate for it.", task_name, lamella_name, exc_info=True,
+                )
+        self.workflow_timeline.set_estimates(estimates)
+
+        protocol = experiment.task_protocol
+        schedule = {}
+        if protocol is not None:
+            schedule = {
+                task.name: task.scheduled_at
+                for task in protocol.workflow_config.tasks
+                if task.scheduled_at is not None
+            }
+        self.workflow_timeline.set_schedule(schedule)
 
     def _on_queue_action(self, action: str, item_id: str) -> None:
         """Apply a timeline row action to the live queue.
@@ -2060,6 +2117,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         supervised = self._update_supervised_status()
 
         waiting = self.autolamella_ui.WAITING_FOR_USER_INTERACTION
+        # The timeline freezes its countdown on this: a wait for a human is not machine
+        # time, and left running it would spend the estimate while nothing is happening.
+        self.workflow_timeline.set_waiting_for_user(waiting)
         if waiting:
             # Show user attention button and change status bar color
             self.user_attention_btn.show()

--- a/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
+++ b/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
@@ -28,7 +28,6 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from fibsem.constants import DATETIME_DISPLAY_AMPM, TIME_DISPLAY_AMPM_SHORT
 from fibsem.applications.autolamella.workflows.workflow_estimate import (
     TaskEstimate,
     WorkflowEstimate,
@@ -42,6 +41,7 @@ from fibsem.ui.widgets.preflight import (
     TEXT_MUTED,
     TEXT_STRONG,
     chip,
+    format_clock as _clock,
     format_duration,
     meta_label,
 )
@@ -64,34 +64,6 @@ _NAMES_SHOWN = 12
 # darker panel behind it -- a lighter block around every word. Only visible with the
 # app stylesheet loaded, which is why the offscreen renders looked clean.
 _ON_PANEL = "background: transparent; border: none; "
-
-
-def _clock(when: Optional[datetime], reference: Optional[datetime]) -> str:
-    """A time the user can act on: `6:15AM` today, `Tomorrow, 6:15AM` overnight.
-
-    The day is not decoration. An overnight workflow is exactly the case this dialog
-    exists for, and a bare clock time for one finishing the next morning is wrong by a
-    day in the direction that matters -- `_wait_until_scheduled` dates its countdown for
-    the same reason. But a date stamp reads as a filename where a person would just say
-    "tomorrow", so the two days either side of today get the word instead.
-
-    Anything further out keeps the dated form: "in 3 days" is arithmetic the reader has
-    to do, and a workflow reaching that far is rare enough not to optimise for.
-    """
-    if when is None:
-        return "—"
-    # 6:15AM, not 06:15AM -- the leading zero is noise at this size.
-    time_str = when.strftime(TIME_DISPLAY_AMPM_SHORT).lstrip("0")
-    if reference is None:
-        return time_str
-    days = (when.date() - reference.date()).days
-    if days == 0:
-        return time_str
-    if days == 1:
-        return f"Tomorrow, {time_str}"
-    if days == -1:
-        return f"Yesterday, {time_str}"
-    return when.strftime(DATETIME_DISPLAY_AMPM)
 
 
 def _metric(label_text: str, value_text: str) -> QWidget:

--- a/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum, auto
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from PyQt5.QtCore import QPoint, Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import QColor, QPainter
@@ -23,6 +24,9 @@ from PyQt5.QtWidgets import (
 from fibsem.constants import TIME_DISPLAY_AMPM_SHORT
 from fibsem.ui import stylesheets
 from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.widgets.custom_widgets import ElidedLabel
+from fibsem.applications.autolamella.workflows.workflow_estimate import estimate_queue
+from fibsem.ui.widgets.preflight import format_clock, format_duration
 from fibsem.ui.tokens import (
     DISABLED_TEXT_COLOR,
     NEUTRAL_500,
@@ -84,6 +88,12 @@ _LINE_W         = 2
 _LEFT_COL       = 32   # px — fixed width for dot + connector column
 _INNER_ROW_H    = 22   # px — minimum height per inner step row
 
+# The estimate column. Fixed width and right-aligned so the times hold one line down the
+# panel however long the names beside them are — that column is the thing being scanned,
+# and a ragged right edge would break it. The pre-flight dialog reserves 84px for the same
+# column against a wider dialog; 78 is what fits here beside the actions button.
+_TRAILING_W     = 78
+
 
 # ── Status mapping ───────────────────────────────────────────────────────────
 def _queue_status_to_step_status(s) -> "StepStatus":
@@ -117,6 +127,15 @@ class TimelineStep:
     label: str
     status: StepStatus = StepStatus.PENDING
     subtitle: str = ""
+    trailing: str = ""
+    """The estimate column, pre-formatted.
+
+    A display string like `subtitle`, not a number: what belongs here depends on the row
+    state (an estimate, a countdown, an elapsed, an actual) and deciding that in the row
+    would put the policy in the one place that has no idea what a queue is. Written by
+    the caller as the workflow proceeds, and preserved across a sync for the same reason
+    subtitles are.
+    """
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -129,6 +148,28 @@ def _status_color(status: StepStatus) -> str:
         StepStatus.SKIPPED:   _DOT_SKIPPED,
         StepStatus.CANCELLED: _DOT_CANCELLED,
     }.get(status, _DOT_PENDING)
+
+
+def _trailing_style(status: StepStatus) -> str:
+    """Style for the estimate column.
+
+    Two shades only, and the split is "not yet" against everything else: muted while a
+    row is still an estimate, normal once it is a real measured number.
+
+    The running row is deliberately *not* a third colour. Its dot and its bold label
+    already mark it, so a coloured number would be a third marker saying the same thing —
+    and the active orange is a shade off the amber that was rejected for looking like a
+    warning, which is exactly how it would read once the row outruns its estimate and the
+    column starts reporting elapsed. Nothing here changes colour for that (FIB-666).
+
+    `background: transparent` is not decoration: the app applies NAPARI_STYLE, whose bare
+    `QWidget { background-color: ... }` rule reaches every descendant, so a label that
+    sets only `color` paints a block of the surface colour — invisible against a panel of
+    the same colour, and not invisible over the selection tint the row paints underneath.
+    """
+    muted = status in (StepStatus.PENDING, StepStatus.SKIPPED)
+    color = _SUBTITLE_COLOR if muted else _LABEL_COLOR
+    return f"background: transparent; border: none; color: {color}; font-size: 11px;"
 
 
 # ── _DotWidget ────────────────────────────────────────────────────────────────
@@ -245,7 +286,13 @@ class _OuterRow(QWidget):
         right.setSpacing(1)
         right.setContentsMargins(0, 4, 0, 4)
 
-        self._label = QLabel(step.label)
+        # ElidedLabel, not QLabel: the rows sit in a QScrollArea that is
+        # `setWidgetResizable(True)` with the horizontal scroll bar `AlwaysOff`, so the
+        # contents widget can never be narrower than its widest row and anything past
+        # the viewport is unreachable. A plain label reports its full text width as its
+        # minimum, so one long lamella petname pushed the estimate column off *every*
+        # row — measured at 280px, the first row's estimate ended 59px off screen.
+        self._label = ElidedLabel(step.label)
         self._label.setStyleSheet(f"color: {_LABEL_COLOR};")
         if step.status == StepStatus.ACTIVE:
             f = self._label.font()
@@ -253,7 +300,7 @@ class _OuterRow(QWidget):
             self._label.setFont(f)
         right.addWidget(self._label)
 
-        self._subtitle = QLabel(step.subtitle)
+        self._subtitle = ElidedLabel(step.subtitle)
         self._subtitle.setStyleSheet(f"color: {_SUBTITLE_COLOR}; font-size: 11px;")
         self._subtitle.setVisible(bool(step.subtitle))
         right.addWidget(self._subtitle)
@@ -277,11 +324,35 @@ class _OuterRow(QWidget):
 
         root.addLayout(right, 1)
 
+        # The estimate column. Held in a top-aligned holder rather than added straight to
+        # the row so it lines up with the name rather than centring against a row whose
+        # height changes with the subtitle, the error text and the inner steps.
+        trailing_holder = QWidget()
+        trailing_holder.setStyleSheet("background: transparent; border: none;")
+        trailing_box = QVBoxLayout(trailing_holder)
+        trailing_box.setContentsMargins(0, 4, 0, 0)
+        trailing_box.setSpacing(0)
+        self._trailing = QLabel(step.trailing)
+        self._trailing.setFixedWidth(_TRAILING_W)
+        self._trailing.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self._trailing_status = step.status
+        self._trailing.setStyleSheet(_trailing_style(step.status))
+        trailing_box.addWidget(self._trailing)
+        trailing_box.addStretch(1)
+        root.addWidget(trailing_holder, 0, Qt.AlignTop)
+
         # Hover-revealed actions button. The timeline is dense enough that a
         # permanent button on every row would be noise, but right-click alone is
         # undiscoverable — so both, and the button only while the pointer is here.
         self._btn_actions = QToolButton()
         self._btn_actions.setFixedSize(_ACTIONS_BTN, _ACTIONS_BTN)
+        # A hidden widget is empty to the layout, so revealing this one on hover used to
+        # shove the estimate column 28px left (the button plus the row's spacing) and
+        # back again on the way out. Keeping its space reserved costs a gutter the
+        # column would otherwise have to itself, and buys a column that holds still.
+        policy = self._btn_actions.sizePolicy()
+        policy.setRetainSizeWhenHidden(True)
+        self._btn_actions.setSizePolicy(policy)
         self._btn_actions.setStyleSheet(_ACTIONS_STYLE)
         self._btn_actions.setIcon(
             fibsem_icon("mdi:dots-horizontal", color=stylesheets.GRAY_ICON_COLOR)
@@ -290,6 +361,14 @@ class _OuterRow(QWidget):
         self._btn_actions.setVisible(False)
         self._btn_actions.clicked.connect(self._on_actions_clicked)
         root.addWidget(self._btn_actions, 0, Qt.AlignTop)
+
+    def set_trailing(self, text: str) -> None:
+        """Write the estimate column alone.
+
+        `refresh` redraws the dot, both labels, the font and the error text; the estimate
+        column is rewritten far more often than any of those, so it gets its own way in.
+        """
+        self._trailing.setText(text)
 
     # ── Queue actions ─────────────────────────────────────────────────────
     def set_actions_enabled(self, enabled: bool) -> None:
@@ -324,11 +403,17 @@ class _OuterRow(QWidget):
     # ── Outer row refresh ─────────────────────────────────────────────────
     def refresh(self, step: TimelineStep) -> None:
         self._dot.set_color(_status_color(step.status))
-        self._label.setText(step.label)
         f = self._label.font()
         f.setBold(step.status == StepStatus.ACTIVE)
         f.setStrikeOut(step.status == StepStatus.SKIPPED)
         self._label.setFont(f)
+        self._label.setText(step.label)
+        self._trailing.setText(step.trailing)
+        # setStyleSheet re-polishes the widget, which is far too expensive to pay on
+        # every row of every sync for a colour that only moves when the status does.
+        if step.status is not self._trailing_status:
+            self._trailing_status = step.status
+            self._trailing.setStyleSheet(_trailing_style(step.status))
         self._subtitle.setText(step.subtitle)
         self._subtitle.setVisible(bool(step.subtitle))
         # The timeline refreshes every row on every update, so an error has to
@@ -597,6 +682,19 @@ class WorkflowProgressWidget(QWidget):
         self._outer_index: int = -1
         self._inner_finished: bool = False
         self._active_start_time: Optional[float] = None
+        # Per-(lamella, task) estimates and per-task schedule, pushed in by the owner.
+        # Keyed by name pair rather than WorkItem.id: an item removed and re-added gets a
+        # new id but is the same work.
+        self._estimates: Dict[Tuple[str, str], float] = {}
+        self._schedule: Dict[str, datetime] = {}
+        # A supervised task's wait is not machine time, so it must not eat the estimate.
+        # Only the countdown pauses; the elapsed on the row keeps running, because the
+        # duration that replaces it on completion counts the wait too.
+        self._waiting_for_user: bool = False
+        self._paused_total: float = 0.0
+        self._paused_since: Optional[float] = None
+        # "A workflow is live" — the same question the actions and the Add button ask.
+        self._actions_enabled: bool = False
         self._setup_ui()
 
         self._elapsed_timer = QTimer(self)
@@ -657,6 +755,17 @@ class WorkflowProgressWidget(QWidget):
 
         root.addLayout(header_row)
 
+        # Remaining time and finish clock. A second line rather than a longer first one:
+        # the count and the Add button already fill that row, and the two figures answer
+        # different questions ("how much is left" / "when do I come back").
+        self._summary = QLabel()
+        self._summary.setStyleSheet(
+            f"background: transparent; border: none; color: {_SUBTITLE_COLOR};"
+            " font-size: 11px; padding: 0px 8px 5px 8px;"
+        )
+        self._summary.setVisible(False)
+        root.addWidget(self._summary)
+
         self._outer = WorkflowTimelineWidget()
         self._outer.row_menu_requested.connect(self._show_row_menu)
         root.addWidget(self._outer, 1)
@@ -669,8 +778,10 @@ class WorkflowProgressWidget(QWidget):
         workflow finishes, and there is no queue left to edit. This is the same
         question the Add button asks, so it shares the gate.
         """
+        self._actions_enabled = enabled
         self._outer.set_actions_enabled(enabled)
         self._btn_add.setVisible(enabled)
+        self._update_summary()
 
     def set_add_enabled(self, enabled: bool, tooltip: str = "") -> None:
         """Whether there is a selection worth adding.
@@ -682,6 +793,51 @@ class WorkflowProgressWidget(QWidget):
         self._btn_add.setEnabled(enabled)
         if tooltip:
             self._btn_add.setToolTip(tooltip)
+
+    def set_estimates(self, seconds_by_key: Dict[Tuple[str, str], float]) -> None:
+        """Per-(lamella, task) durations, in seconds.
+
+        Pushed in rather than computed here: the estimate comes from a lamella's task
+        config, and this widget has no business knowing what an Experiment is. The owner
+        recomputes on workflow start and when the queue is edited — not per status
+        update, since `estimated_duration` walks every milling stage of every task.
+
+        Anything not in the mapping simply has no estimate; the column stays empty for it
+        rather than showing a number that was invented.
+        """
+        self._estimates = dict(seconds_by_key)
+        self._refresh_trailing()
+        self._update_summary()
+
+    def set_schedule(self, schedule: Dict[str, datetime]) -> None:
+        """`scheduled_at` per task name, for the tasks that have one.
+
+        Without it the finish time would be short by the whole hold: a task scheduled for
+        20:00 after work that ends at 15:40 puts four hours of dead time in the middle of
+        the workflow, and `_wait_until_scheduled` really does sit there for them.
+        """
+        self._schedule = dict(schedule)
+        self._update_summary()
+
+    def set_waiting_for_user(self, waiting: bool) -> None:
+        """Whether the running task is paused for a human.
+
+        Freezes the countdown for as long as it lasts, and swaps the header's finish
+        clock for the work remaining: the wait is unbounded, so any clock quoted through
+        it would be a guess dressed as a fact. A scheduled hold needs no such treatment —
+        it is bounded, so the clock stays true through it.
+        """
+        if waiting == self._waiting_for_user:
+            return
+        self._waiting_for_user = waiting
+        now = time.time()
+        if waiting:
+            self._paused_since = now
+        elif self._paused_since is not None:
+            self._paused_total += now - self._paused_since
+            self._paused_since = None
+        self._update_elapsed()
+        self._update_summary()
 
     def set_workflow(self, items: list) -> None:
         """Populate the outer timeline from queue items, starting fresh.
@@ -730,6 +886,10 @@ class WorkflowProgressWidget(QWidget):
             )
             self._inner_finished = False
             self._active_start_time = status.get("timestamp", time.time())
+            # The pause accounting belongs to one task, not to the workflow.
+            self._waiting_for_user = False
+            self._paused_total = 0.0
+            self._paused_since = None
             self._elapsed_timer.start(1000)
             self._show_inner_at(self._outer_index)
             # Auto-scroll to the active row
@@ -742,6 +902,8 @@ class WorkflowProgressWidget(QWidget):
                            AutoLamellaTaskStatus.Cancelled):
             self._elapsed_timer.stop()
             self._active_start_time = None
+            self._waiting_for_user = False
+            self._paused_since = None
             idx = self._outer_index
             if 0 <= idx < len(self._outer._rows):
                 task_name = self._items[idx].task_name
@@ -790,6 +952,8 @@ class WorkflowProgressWidget(QWidget):
             (n for n, i in enumerate(self._items) if i.id == self._active_id), -1
         )
         self._update_header(self._items)
+        self._refresh_trailing()
+        self._update_summary()
 
     def update_step(self, step_name: str) -> None:
         """Mark the previous inner step completed and append a new ACTIVE one."""
@@ -822,7 +986,11 @@ class WorkflowProgressWidget(QWidget):
         self._inner_finished = False
         self._elapsed_timer.stop()
         self._active_start_time = None
+        self._waiting_for_user = False
+        self._paused_total = 0.0
+        self._paused_since = None
         self._header.setText("Workflow")
+        self._summary.setVisible(False)
         self._outer.clear()
 
     def set_active_outer(self, index: int) -> None:
@@ -922,6 +1090,75 @@ class WorkflowProgressWidget(QWidget):
         final = StepStatus.FAILED if failed else StepStatus.COMPLETED
         self._outer._rows[self._outer_index].update_last_inner_step(final)
 
+    def _estimate_for(self, item) -> Optional[float]:
+        """This item's estimate, or None if there is none to offer."""
+        if item is None:
+            return None
+        return self._estimates.get((item.lamella_name, item.task_name))
+
+    def _machine_elapsed(self, elapsed: float) -> float:
+        """`elapsed` less any time the task spent waiting for a human.
+
+        The countdown is against work the machine has to do, and a supervised pause is
+        not that — left in, a long enough pause would spend the whole estimate with every
+        bit of the task's real work still ahead of it.
+        """
+        paused = self._paused_total
+        if self._paused_since is not None:
+            paused += time.time() - self._paused_since
+        return max(0.0, elapsed - paused)
+
+    def _refresh_trailing(self) -> None:
+        """Write the estimate into the column of every row still waiting to run.
+
+        Pending rows only. A running row's column is its countdown and a finished row's
+        is what it actually took; both have superseded the estimate, and rewriting it
+        over them would undo that.
+        """
+        from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+        for i, item in enumerate(self._items):
+            if i >= len(self._outer._steps):
+                break
+            if item.status is not AutoLamellaTaskStatus.NotStarted:
+                continue
+            seconds = self._estimate_for(item)
+            step = self._outer._steps[i]
+            step.trailing = format_duration(seconds) if seconds is not None else ""
+            self._outer._rows[i].set_trailing(step.trailing)
+
+    def _update_summary(self) -> None:
+        """The header's second line: what is left, and when it lands."""
+        if not self._items or not self._actions_enabled:
+            self._summary.setVisible(False)
+            return
+
+        active_elapsed = None
+        if self._active_start_time is not None:
+            active_elapsed = self._machine_elapsed(time.time() - self._active_start_time)
+
+        estimate = estimate_queue(
+            self._items,
+            self._estimate_for,
+            schedule=self._schedule,
+            active_elapsed=active_elapsed,
+        )
+        if estimate.remaining_seconds <= 0:
+            self._summary.setVisible(False)
+            return
+
+        if self._waiting_for_user:
+            # No clock: the wait is unbounded, so one would be a guess dressed as a fact.
+            # The work still to do is knowable either way, and "of work" is what marks
+            # that the number has narrowed to machine time.
+            text = f"{format_duration(estimate.work_seconds)} of work left · waiting for you"
+        else:
+            text = (
+                f"{format_duration(estimate.remaining_seconds)} left · "
+                f"finishes {format_clock(estimate.expected_finish, datetime.now())}"
+            )
+        self._summary.setText(text)
+        self._summary.setVisible(True)
+
     def _update_header(self, queue_items: list) -> None:
         """Update the header label with progress counts."""
         from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
@@ -948,33 +1185,66 @@ class WorkflowProgressWidget(QWidget):
         self._header.setText(text)
 
     def _update_elapsed(self) -> None:
-        """Tick handler — update the active row subtitle with elapsed time."""
+        """Tick handler — the active row's elapsed and countdown, and the summary."""
         if self._active_start_time is None:
             return
         if not (0 <= self._outer_index < len(self._outer._steps)):
             return
-        from fibsem.utils import format_duration
+        step = self._outer._steps[self._outer_index]
+        item = (self._items[self._outer_index]
+                if self._outer_index < len(self._items) else None)
+        task_name = item.task_name if item is not None else ""
+
+        # Wall-clock, including any wait for a human: this is the number the recorded
+        # duration replaces on completion, and that one counts the wait too. Only the
+        # countdown below works in machine time.
         elapsed = time.time() - self._active_start_time
-        task_name = ""
-        if self._outer_index < len(self._items):
-            task_name = self._items[self._outer_index].task_name
-        duration_str = format_duration(elapsed)
-        self._outer._steps[self._outer_index].subtitle = f"{task_name} ({duration_str})"
-        self._outer._rows[self._outer_index].refresh(self._outer._steps[self._outer_index])
+        estimate = self._estimate_for(item)
+
+        if self._waiting_for_user:
+            # The subtitle keeps its elapsed rather than repeating the column: the
+            # header already says "waiting for you", and how long it has been sitting
+            # there is the thing not said anywhere else.
+            step.subtitle = f"{task_name} ({format_duration(elapsed)})"
+            step.trailing = "waiting"
+        elif estimate is None:
+            step.subtitle = f"{task_name} ({format_duration(elapsed)})"
+            step.trailing = ""
+        elif self._machine_elapsed(elapsed) < estimate:
+            step.subtitle = f"{task_name} ({format_duration(elapsed)})"
+            step.trailing = f"{format_duration(estimate - self._machine_elapsed(elapsed))} left"
+        else:
+            # The estimate is spent, so the column stops predicting and reports instead —
+            # elapsed, which is the same kind of number the row will show once it is
+            # done. Nothing goes negative, nothing stalls, and nothing changes colour:
+            # a task running long is variance, not an error.
+            step.subtitle = task_name
+            step.trailing = format_duration(elapsed)
+
+        self._outer._rows[self._outer_index].refresh(step)
+        self._update_summary()
 
     def _set_completion_subtitle(self, outer_idx: int, task_duration: Optional[float], task_name: str = "", completed_at: Optional[float] = None) -> None:
-        from datetime import datetime
-        from fibsem.utils import format_duration
+        """What a finished row says: where it got to, and what it cost.
+
+        The duration goes in the estimate column rather than in brackets after the task
+        name, so a finished row lines up with the pending ones and the whole workflow can
+        be read down one column. It is wall-clock and still counts any supervised wait —
+        `AutoLamellaTaskState.duration` is end minus start, and the experiment record
+        agrees with it.
+        """
         if not (0 <= outer_idx < len(self._outer._steps)):
             return
-        duration_str = ""
         time_str = ""
-        if task_duration is not None:
-            duration_str = f" ({format_duration(task_duration)})"
-
         if completed_at is not None:
-            time_str = f" · {datetime.fromtimestamp(completed_at).strftime(TIME_DISPLAY_AMPM_SHORT)}"
-        self._outer._steps[outer_idx].subtitle = f"{task_name}{duration_str}{time_str}"
+            # `.lstrip("0")`, as `format_clock` does: the header now quotes a finish
+            # time in the same panel, and `06:59PM` beside `7:13PM` reads as two
+            # different clocks rather than one convention.
+            stamp = datetime.fromtimestamp(completed_at).strftime(TIME_DISPLAY_AMPM_SHORT)
+            time_str = f" · {stamp.lstrip('0')}"
+        self._outer._steps[outer_idx].subtitle = f"{task_name}{time_str}"
+        if task_duration is not None:
+            self._outer._steps[outer_idx].trailing = format_duration(task_duration)
 
 
 # ── Demo ──────────────────────────────────────────────────────────────────────

--- a/fibsem/applications/autolamella/workflows/workflow_estimate.py
+++ b/fibsem/applications/autolamella/workflows/workflow_estimate.py
@@ -1,22 +1,28 @@
 """How long a workflow will take, and when it will finish.
 
-The arithmetic behind the pre-flight dialog, kept out of it: everything here is plain
-data, so it can be checked against a real experiment without a microscope or a widget.
+The arithmetic behind the pre-flight dialog and the in-run timeline, kept out of both:
+everything here is plain data, so it can be checked against a real experiment without a
+microscope or a widget.
 
 Per-task durations come from each config's ``estimated_duration`` (see
 :mod:`fibsem.timing`). This module's job is the workflow-level assembly -- which is not a
 sum, because a scheduled task makes the workflow *hold* until its start time, and quoting
 ``now + Σ`` would be wrong by the length of that wait.
 
+`estimate_workflow` answers the question before anything runs, from the experiment.
+`estimate_queue` answers it again from a live queue, which is the same walk over what is
+left rather than a second model.
+
 See FIB-666.
 """
 
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence
 
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.structures import Experiment
+    from fibsem.applications.autolamella.workflows.tasks.queue import WorkItem
 
 
 @dataclass(frozen=True)
@@ -159,4 +165,117 @@ def estimate_workflow(
         hold_seconds=hold_seconds,
         started_at=started_at,
         expected_finish=clock,
+    )
+
+
+@dataclass(frozen=True)
+class QueueEstimate:
+    """What is left of a live queue, and when it will be done.
+
+    The in-run counterpart of :class:`WorkflowEstimate`: same primitives, same walk, but
+    over what remains rather than over what was selected. Completed items contribute
+    nothing -- their cost has already been paid, and the finish time therefore converges
+    on its own as the workflow proceeds, without anything being re-learned.
+    """
+
+    remaining_seconds: float = 0.0
+    """Wall-clock to the finish: the pending work plus any scheduled holds ahead."""
+
+    work_seconds: float = 0.0
+    """Machine time only, holds excluded.
+
+    Quoted instead of ``remaining_seconds`` while a supervised task waits for a human:
+    that wait is unbounded, so a finish time would be a guess dressed as a fact, while
+    the work still to be done is perfectly knowable.
+    """
+
+    hold_seconds: float = 0.0
+    expected_finish: Optional[datetime] = None
+
+    active_remaining: Optional[float] = None
+    """Seconds left on the running task, or None if nothing is running."""
+
+    active_estimate_spent: bool = False
+    """Whether the running task has already used up its estimate.
+
+    Not a warning and never rendered as one: a task running long is ordinary variance,
+    not an error. It is only how the row knows to stop predicting and report elapsed
+    instead -- see FIB-666.
+    """
+
+
+def estimate_queue(
+    items: "Sequence[WorkItem]",
+    seconds_for: "Callable[[WorkItem], Optional[float]]",
+    schedule: Optional[Dict[str, datetime]] = None,
+    now: Optional[datetime] = None,
+    active_elapsed: Optional[float] = None,
+) -> QueueEstimate:
+    """Estimate what is left of a running queue.
+
+    Walks the items in queue order carrying a clock, the same way `estimate_workflow`
+    does. The hold is not optional here either: ``_wait_until_scheduled`` fires per queue
+    *item*, so a scheduled task's hold lands on the first of its items and the rest find
+    the time already passed -- which is exactly what a single pass over the items in
+    order reproduces.
+
+    An overrunning task contributes **zero** to the remaining total rather than a
+    negative number, so the total can neither go negative nor stall: it slides later by a
+    second per second, which is the honest answer once the task's end is unknown.
+
+    Args:
+        items: the queue snapshot, in order, including items already run
+        seconds_for: per-item estimate; None for an item with nothing to offer
+        schedule: ``scheduled_at`` per task name, for the tasks that have one
+        now: the clock to walk from; defaults to the current time
+        active_elapsed: seconds the running task has been going, excluding any pause for
+            a human -- see FIB-666 on why the countdown freezes but the elapsed shown on
+            the row does not
+
+    Returns:
+        QueueEstimate: what remains, and when it lands.
+    """
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+
+    clock = now if now is not None else datetime.now()
+    schedule = schedule or {}
+
+    work_seconds = 0.0
+    hold_seconds = 0.0
+    active_remaining: Optional[float] = None
+    active_estimate_spent = False
+    # A task holds only once, on its first item; the items after it find the time passed.
+    # Tracked by walking in order rather than by task, so an interleaved queue -- which a
+    # mid-run "run next" can produce -- holds wherever the schedule actually catches it.
+    for item in items:
+        if item.status is AutoLamellaTaskStatus.InProgress:
+            estimate = seconds_for(item)
+            if estimate is not None and active_elapsed is not None:
+                active_remaining = max(0.0, estimate - active_elapsed)
+                active_estimate_spent = active_elapsed >= estimate
+                work_seconds += active_remaining
+                clock += timedelta(seconds=active_remaining)
+            continue
+
+        if not item.is_pending:
+            continue
+
+        scheduled_at = _as_naive_local(schedule.get(item.task_name))
+        if scheduled_at is not None and scheduled_at > clock:
+            hold_seconds += (scheduled_at - clock).total_seconds()
+            clock = scheduled_at
+
+        seconds = seconds_for(item)
+        if seconds is None:
+            continue
+        work_seconds += seconds
+        clock += timedelta(seconds=seconds)
+
+    return QueueEstimate(
+        remaining_seconds=work_seconds + hold_seconds,
+        work_seconds=work_seconds,
+        hold_seconds=hold_seconds,
+        expected_finish=clock,
+        active_remaining=active_remaining,
+        active_estimate_spent=active_estimate_spent,
     )

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -879,6 +879,13 @@ class ElidedLabel(QLabel):
         self.setText(text)
 
     def setText(self, text: Optional[str]) -> None:  # noqa: N802 - Qt naming
+        if (text or "") == self._full_text:
+            # Re-measuring costs a QFontMetrics and an elidedText per call, and callers
+            # that refresh a whole row on a timer re-set the same string every time --
+            # the workflow timeline does it for every row of every status update, where
+            # this was a third of the cost. Nothing else here depends on width, which
+            # resizeEvent and paintEvent handle.
+            return
         self._full_text = text or ""
         self.setToolTip(self._full_text)
         self._elide()

--- a/fibsem/ui/widgets/preflight.py
+++ b/fibsem/ui/widgets/preflight.py
@@ -16,6 +16,7 @@ and the seven places it differs are seven constructor arguments a base class wou
 for one caller.
 """
 
+from datetime import datetime
 from typing import Iterable, List, Optional, Tuple
 
 from PyQt5.QtCore import Qt
@@ -29,6 +30,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from fibsem.constants import DATETIME_DISPLAY_AMPM, TIME_DISPLAY_AMPM_SHORT
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import ElidedLabel
 from fibsem.utils import format_time_remaining as utils_format_time_remaining
@@ -91,6 +93,37 @@ class PathValue(str):
     a dialog's width and wrapped to three lines; and the part that answers "am I writing
     where I meant to" is the tail, not the mount point (FIB-660).
     """
+
+
+def format_clock(when: Optional[datetime], reference: Optional[datetime]) -> str:
+    """A time the user can act on: `6:15AM` today, `Tomorrow, 6:15AM` overnight.
+
+    The day is not decoration. An overnight workflow is exactly the case a pre-flight
+    estimate exists for, and a bare clock time for one finishing the next morning is
+    wrong by a day in the direction that matters -- `_wait_until_scheduled` dates its
+    countdown for the same reason. But a date stamp reads as a filename where a person
+    would just say "tomorrow", so the two days either side of today get the word instead.
+
+    Anything further out keeps the dated form: "in 3 days" is arithmetic the reader has
+    to do, and a workflow reaching that far is rare enough not to optimise for.
+
+    Lives here rather than in the dialog that first needed it because the in-run timeline
+    quotes the same finish time; two copies of this rule would drift.
+    """
+    if when is None:
+        return "\u2014"
+    # 6:15AM, not 06:15AM -- the leading zero is noise at this size.
+    time_str = when.strftime(TIME_DISPLAY_AMPM_SHORT).lstrip("0")
+    if reference is None:
+        return time_str
+    days = (when.date() - reference.date()).days
+    if days == 0:
+        return time_str
+    if days == 1:
+        return f"Tomorrow, {time_str}"
+    if days == -1:
+        return f"Yesterday, {time_str}"
+    return when.strftime(DATETIME_DISPLAY_AMPM)
 
 
 def chip(text: str) -> QWidget:

--- a/tests/autolamella/test_workflow_estimate.py
+++ b/tests/autolamella/test_workflow_estimate.py
@@ -196,3 +196,146 @@ def test_an_empty_workflow_finishes_now(tmp_path):
     assert est.work_seconds == 0.0
     assert est.expected_finish == NOW
     assert est.step_count == 0
+
+
+# ── the live queue ────────────────────────────────────────────────────────────
+# `estimate_queue` answers the same question as `estimate_workflow` from the other end:
+# against a queue that is part-way through rather than an experiment about to start.
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus  # noqa: E402
+from fibsem.applications.autolamella.workflows.tasks.queue import WorkItem  # noqa: E402
+from fibsem.applications.autolamella.workflows.workflow_estimate import (  # noqa: E402
+    estimate_queue,
+)
+
+
+def _items(*spec) -> list:
+    """(lamella, task) or (lamella, task, status) triples, in queue order."""
+    return [
+        WorkItem(lamella_name=s[0], task_name=s[1],
+                 status=s[2] if len(s) > 2 else AutoLamellaTaskStatus.NotStarted)
+        for s in spec
+    ]
+
+
+def _flat(seconds: float):
+    return lambda item: seconds
+
+
+def test_an_empty_queue_finishes_now():
+    est = estimate_queue([], _flat(60.0), now=NOW)
+    assert est.remaining_seconds == 0.0
+    assert est.expected_finish == NOW
+
+
+def test_pending_items_are_summed():
+    est = estimate_queue(_items(("01", "A"), ("02", "A")), _flat(60.0), now=NOW)
+    assert est.remaining_seconds == pytest.approx(120.0)
+    assert est.expected_finish == NOW + timedelta(seconds=120)
+
+
+def test_work_already_done_costs_nothing():
+    """The whole point of asking again mid-workflow: the finish converges on its own,
+    without anything being re-learned from how the finished rows actually went."""
+    items = _items(("01", "A", AutoLamellaTaskStatus.Completed),
+                   ("02", "A", AutoLamellaTaskStatus.Failed),
+                   ("03", "A", AutoLamellaTaskStatus.Skipped),
+                   ("04", "A", AutoLamellaTaskStatus.Cancelled),
+                   ("05", "A"))
+    est = estimate_queue(items, _flat(60.0), now=NOW)
+    assert est.remaining_seconds == pytest.approx(60.0)
+
+
+def test_an_item_with_no_estimate_contributes_nothing():
+    """A lamella with no config for the task has no duration to offer, and inventing
+    one would be worse than leaving it out."""
+    items = _items(("01", "A"), ("02", "A"))
+    seconds_for = lambda item: 60.0 if item.lamella_name == "01" else None
+    assert estimate_queue(items, seconds_for, now=NOW).remaining_seconds == pytest.approx(60.0)
+
+
+# ── the running task ──────────────────────────────────────────────────────────
+
+def test_the_running_task_contributes_only_what_is_left_of_it():
+    items = _items(("01", "A", AutoLamellaTaskStatus.InProgress), ("02", "A"))
+    est = estimate_queue(items, _flat(100.0), now=NOW, active_elapsed=40.0)
+    assert est.active_remaining == pytest.approx(60.0)
+    assert est.remaining_seconds == pytest.approx(160.0)
+    assert est.active_estimate_spent is False
+
+
+def test_a_task_past_its_estimate_contributes_zero_not_a_negative():
+    """The total must not go backwards. It slides later by a second per second instead,
+    which is the honest answer once the task's end is unknown -- a total that stalls or
+    goes negative is the FIB-522 failure."""
+    items = _items(("01", "A", AutoLamellaTaskStatus.InProgress), ("02", "A"))
+    est = estimate_queue(items, _flat(100.0), now=NOW, active_elapsed=250.0)
+    assert est.active_remaining == 0.0
+    assert est.active_estimate_spent is True
+    assert est.remaining_seconds == pytest.approx(100.0)  # the pending item, and no more
+
+
+def test_nothing_running_reports_no_active_remaining():
+    est = estimate_queue(_items(("01", "A")), _flat(60.0), now=NOW)
+    assert est.active_remaining is None
+    assert est.active_estimate_spent is False
+
+
+def test_a_running_task_with_no_elapsed_yet_is_not_guessed_at():
+    """Before the first tick there is nothing to subtract from, so the task is left out
+    rather than counted at its full estimate and then jumping."""
+    items = _items(("01", "A", AutoLamellaTaskStatus.InProgress))
+    assert estimate_queue(items, _flat(100.0), now=NOW).active_remaining is None
+
+
+# ── holds ─────────────────────────────────────────────────────────────────────
+
+def test_a_scheduled_task_pushes_the_finish_out():
+    at = NOW + timedelta(hours=4)
+    est = estimate_queue(_items(("01", "A")), _flat(60.0), schedule={"A": at}, now=NOW)
+    assert est.hold_seconds == pytest.approx(4 * 3600)
+    assert est.expected_finish == at + timedelta(seconds=60)
+
+
+def test_the_hold_is_wall_clock_not_work():
+    """`remaining_seconds` answers "when do I come back" and `work_seconds` answers
+    "how much is there left to do" -- the header quotes one or the other depending on
+    whether a clock can be quoted at all."""
+    at = NOW + timedelta(hours=4)
+    est = estimate_queue(_items(("01", "A")), _flat(60.0), schedule={"A": at}, now=NOW)
+    assert est.work_seconds == pytest.approx(60.0)
+    assert est.remaining_seconds == pytest.approx(4 * 3600 + 60.0)
+
+
+def test_a_task_holds_once_and_its_other_lamella_find_the_time_passed():
+    """`_wait_until_scheduled` runs per queue *item*, so the first item of a scheduled
+    task waits and the rest walk straight through. Charging the hold per item would
+    quote four hours three times over."""
+    at = NOW + timedelta(hours=4)
+    items = _items(("01", "A"), ("02", "A"), ("03", "A"))
+    est = estimate_queue(items, _flat(60.0), schedule={"A": at}, now=NOW)
+    assert est.hold_seconds == pytest.approx(4 * 3600)
+    assert est.expected_finish == at + timedelta(seconds=180)
+
+
+def test_the_hold_is_measured_from_where_the_queue_has_got_to():
+    """Work ahead of the scheduled task has already eaten part of the wait."""
+    at = NOW + timedelta(hours=4)
+    items = _items(("01", "Setup"), ("01", "A"))
+    est = estimate_queue(items, _flat(600.0), schedule={"A": at}, now=NOW)
+    assert est.hold_seconds == pytest.approx(4 * 3600 - 600.0)
+
+
+def test_a_queue_scheduled_time_already_past_holds_nothing():
+    items = _items(("01", "A"))
+    est = estimate_queue(items, _flat(60.0),
+                         schedule={"A": NOW - timedelta(hours=1)}, now=NOW)
+    assert est.hold_seconds == 0.0
+    assert est.expected_finish == NOW + timedelta(seconds=60)
+
+
+def test_a_timezone_aware_schedule_in_the_queue_does_not_raise():
+    from datetime import timezone
+    aware = (NOW + timedelta(hours=4)).replace(tzinfo=timezone.utc)
+    est = estimate_queue(_items(("01", "A")), _flat(60.0), schedule={"A": aware}, now=NOW)
+    assert est.expected_finish is not None

--- a/tests/ui/test_workflow_timeline_estimate.py
+++ b/tests/ui/test_workflow_timeline_estimate.py
@@ -1,0 +1,448 @@
+"""The estimate column and the header's remaining/finish line (FIB-666).
+
+The arithmetic itself is tested in tests/autolamella/test_workflow_estimate.py, without a
+widget. What is checked here is what the timeline *says*, and when it changes its mind:
+the column predicts while it can and reports once it cannot, and the header quotes a clock
+only while a clock can honestly be quoted.
+
+`NAPARI_STYLE` is applied to the QApplication deliberately. The app sets it, and its bare
+`QWidget { background-color: ... }` rule reaches every descendant -- a render without it
+cannot show a label painting a block over the row's selection tint, which is precisely the
+class of bug that got through twice on the pre-flight dialog.
+
+Uses the shared offscreen ``qapp`` fixture from tests/conftest.py.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from datetime import datetime, timedelta
+
+from PyQt5.QtWidgets import QLabel
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus as Status
+from fibsem.applications.autolamella.ui.workflow_timeline_widget import (
+    WorkflowProgressWidget,
+)
+from fibsem.applications.autolamella.workflows.tasks.queue import TaskQueue
+from fibsem.ui.stylesheets import NAPARI_STYLE
+
+START = 1000.0  # the fake clock every status payload is stamped with
+
+
+@pytest.fixture
+def app(qapp):
+    qapp.setStyleSheet(NAPARI_STYLE)
+    return qapp
+
+
+@pytest.fixture
+def queue() -> TaskQueue:
+    q = TaskQueue()
+    q.build_from_matrix(["Trench", "Undercut"], ["L1", "L2"])
+    return q
+
+
+@pytest.fixture
+def widget(app, queue) -> WorkflowProgressWidget:
+    """A live workflow: four items, every one of them estimated at 100 s."""
+    w = WorkflowProgressWidget()
+    w.set_actions_enabled(True)  # "a workflow is live"
+    w.set_estimates({(i.lamella_name, i.task_name): 100.0 for i in queue.items})
+    w.set_workflow(queue.items)
+    return w
+
+
+def status_for(queue, item, status, **extra) -> dict:
+    payload = {
+        "task_name": item.task_name,
+        "item_name": item.lamella_name,
+        "status": status,
+        "queue_items": queue.items,
+        "timestamp": START,
+    }
+    payload.update(extra)
+    return payload
+
+
+def start_next(widget, queue):
+    item = queue.next()
+    widget.update_from_status(status_for(queue, item, Status.InProgress))
+    return item
+
+
+def tick(widget, monkeypatch, seconds: float) -> None:
+    """Advance the widget's clock to `seconds` after the active task started."""
+    monkeypatch.setattr(
+        "fibsem.applications.autolamella.ui.workflow_timeline_widget.time.time",
+        lambda: START + seconds,
+    )
+    widget._update_elapsed()
+
+
+def column(widget) -> list:
+    return [s.trailing for s in widget._outer._steps]
+
+
+# ── pending rows ──────────────────────────────────────────────────────────────
+
+def test_every_pending_row_shows_its_estimate(widget):
+    assert column(widget) == ["1m 40s"] * 4
+
+
+def test_a_row_with_no_estimate_shows_nothing_rather_than_a_guess(app, queue):
+    w = WorkflowProgressWidget()
+    w.set_actions_enabled(True)
+    w.set_estimates({("L1", "Trench"): 100.0})
+    w.set_workflow(queue.items)
+    assert column(w) == ["1m 40s", "", "", ""]
+
+
+def test_estimates_arriving_after_the_rows_still_reach_them(app, queue):
+    """The owner pushes them separately from the queue snapshot, so the order the two
+    arrive in must not decide whether the column is ever filled."""
+    w = WorkflowProgressWidget()
+    w.set_actions_enabled(True)
+    w.set_workflow(queue.items)
+    assert column(w) == [""] * 4
+    w.set_estimates({(i.lamella_name, i.task_name): 100.0 for i in queue.items})
+    assert column(w) == ["1m 40s"] * 4
+
+
+def test_an_item_added_mid_workflow_gets_its_estimate(widget, queue):
+    added = queue.add("L9", "Polish")
+    estimates = {(i.lamella_name, i.task_name): 100.0 for i in queue.items}
+    estimates[("L9", "Polish")] = 250.0  # dict | dict is 3.9+; CI still runs 3.8
+    widget.set_estimates(estimates)
+    widget.refresh_queue(queue.items)
+    assert added is not None
+    assert column(widget)[-1] == "4m 10s"
+
+
+# ── the running row ───────────────────────────────────────────────────────────
+
+def test_the_running_row_counts_down(widget, queue, monkeypatch):
+    start_next(widget, queue)
+    tick(widget, monkeypatch, 40.0)
+    assert column(widget)[0] == "1m 00s left"
+
+
+def test_the_running_row_stops_predicting_once_the_estimate_is_spent(widget, queue,
+                                                                    monkeypatch):
+    """It reports elapsed instead -- the same kind of number the row will show when it
+    finishes. Never a negative, never a stalled zero, and never a new word for what is
+    ordinary variance."""
+    start_next(widget, queue)
+    tick(widget, monkeypatch, 460.0)
+    assert column(widget)[0] == "7m 40s"
+    assert "left" not in column(widget)[0]
+
+
+def test_the_elapsed_moves_out_of_the_subtitle_when_the_column_takes_it_over(
+        widget, queue, monkeypatch):
+    """Both at once would be the same number twice."""
+    start_next(widget, queue)
+    tick(widget, monkeypatch, 40.0)
+    assert widget._outer._steps[0].subtitle == "Trench (40s)"
+    tick(widget, monkeypatch, 460.0)
+    assert widget._outer._steps[0].subtitle == "Trench"
+
+
+def test_a_running_row_with_no_estimate_just_shows_elapsed_in_the_subtitle(
+        app, queue, monkeypatch):
+    w = WorkflowProgressWidget()
+    w.set_actions_enabled(True)
+    w.set_workflow(queue.items)
+    start_next(w, queue)
+    tick(w, monkeypatch, 40.0)
+    assert column(w)[0] == ""
+    assert w._outer._steps[0].subtitle == "Trench (40s)"
+
+
+# ── supervised waits ──────────────────────────────────────────────────────────
+
+def test_a_wait_for_a_human_pauses_the_countdown_rather_than_spending_it(
+        widget, queue, monkeypatch):
+    """40 s of work then a 300 s pause leaves the same 60 s of work to do. Left running,
+    the wait would spend the whole estimate with all of the task still ahead of it."""
+    start_next(widget, queue)
+    tick(widget, monkeypatch, 40.0)
+    monkeypatch.setattr(
+        "fibsem.applications.autolamella.ui.workflow_timeline_widget.time.time",
+        lambda: START + 40.0,
+    )
+    widget.set_waiting_for_user(True)
+    tick(widget, monkeypatch, 340.0)
+    assert column(widget)[0] == "waiting"
+
+    monkeypatch.setattr(
+        "fibsem.applications.autolamella.ui.workflow_timeline_widget.time.time",
+        lambda: START + 340.0,
+    )
+    widget.set_waiting_for_user(False)
+    tick(widget, monkeypatch, 340.0)
+    assert column(widget)[0] == "1m 00s left"
+
+
+def test_the_elapsed_keeps_running_through_a_wait(widget, queue, monkeypatch):
+    """Only the countdown pauses. `AutoLamellaTaskState.duration` is end minus start and
+    counts the wait, so an elapsed that skipped it would snap on completion and disagree
+    with the experiment record."""
+    start_next(widget, queue)
+    monkeypatch.setattr(
+        "fibsem.applications.autolamella.ui.workflow_timeline_widget.time.time",
+        lambda: START,
+    )
+    widget.set_waiting_for_user(True)
+    tick(widget, monkeypatch, 300.0)
+    assert widget._outer._steps[0].subtitle == "Trench (5m 00s)", "elapsed froze"
+    widget.set_waiting_for_user(False)
+    tick(widget, monkeypatch, 300.0)
+    assert widget._outer._steps[0].subtitle == "Trench (5m 00s)"
+
+
+def test_the_pause_belongs_to_one_task_not_the_workflow(widget, queue, monkeypatch):
+    """A pause on the first task must not go on crediting the second."""
+    first = start_next(widget, queue)
+    widget.set_waiting_for_user(True)
+    queue.mark_done(first, Status.Completed)
+    widget.update_from_status(status_for(queue, first, Status.Completed,
+                                         task_duration=50.0))
+    start_next(widget, queue)
+    assert widget._paused_total == 0.0
+    assert widget._waiting_for_user is False
+
+
+# ── finished rows ─────────────────────────────────────────────────────────────
+
+def test_a_finished_row_shows_what_it_actually_took(widget, queue):
+    item = start_next(widget, queue)
+    queue.mark_done(item, Status.Completed)
+    widget.update_from_status(status_for(queue, item, Status.Completed,
+                                         task_duration=112.0))
+    assert column(widget)[0] == "1m 52s"
+    assert "1m 52s" not in widget._outer._steps[0].subtitle
+
+
+def test_a_finished_row_is_not_overwritten_by_its_own_estimate(widget, queue):
+    """`_refresh_trailing` runs on every sync; a row that has run has superseded the
+    estimate and must keep the actual."""
+    item = start_next(widget, queue)
+    queue.mark_done(item, Status.Completed)
+    widget.update_from_status(status_for(queue, item, Status.Completed,
+                                         task_duration=112.0))
+    widget.refresh_queue(queue.items)
+    assert column(widget)[0] == "1m 52s"
+
+
+def test_the_two_clocks_in_the_panel_agree_on_their_format(widget, queue):
+    """The completion stamp and the header's finish time sit inches apart, so `06:59PM`
+    beside `7:13PM` would read as two different conventions."""
+    item = start_next(widget, queue)
+    queue.mark_done(item, Status.Completed)
+    widget.update_from_status(status_for(queue, item, Status.Completed,
+                                         task_duration=112.0, completed_at=START))
+    assert not widget._outer._steps[0].subtitle.split("· ")[-1].startswith("0")
+
+
+# ── the header line ───────────────────────────────────────────────────────────
+
+def test_the_header_quotes_what_is_left_and_when_it_lands(widget):
+    text = widget._summary.text()
+    # isHidden, not isVisible: nothing in this test is shown, and isVisible() is False
+    # for every descendant of an unshown parent -- so it would answer the same whether
+    # the line had been put up or not, and the negative tests below would pass on their
+    # own. isHidden() reports the widget's own state.
+    assert not widget._summary.isHidden()
+    assert text.startswith("6m 40s left · finishes ")
+
+
+def test_the_header_is_silent_when_no_workflow_is_live(app, queue):
+    """The timeline stays on screen afterwards; a remaining time beside a queue that is
+    not going to run would be a lie."""
+    w = WorkflowProgressWidget()
+    w.set_estimates({(i.lamella_name, i.task_name): 100.0 for i in queue.items})
+    w.set_workflow(queue.items)
+    assert w._summary.isHidden()
+
+
+def test_the_header_drops_the_clock_while_waiting_for_a_human(widget, queue,
+                                                              monkeypatch):
+    """The wait is unbounded, so any finish time quoted through it is a guess dressed as
+    a fact. The work still to do is knowable either way."""
+    start_next(widget, queue)
+    tick(widget, monkeypatch, 10.0)
+    widget.set_waiting_for_user(True)
+    text = widget._summary.text()
+    assert "finishes" not in text
+    assert text.endswith("of work left · waiting for you")
+
+
+def test_a_scheduled_hold_is_inside_the_time_the_header_quotes(app, queue):
+    """"When do I come back" includes four hours of dead time in the middle."""
+    w = WorkflowProgressWidget()
+    w.set_actions_enabled(True)
+    w.set_estimates({(i.lamella_name, i.task_name): 100.0 for i in queue.items})
+    w.set_schedule({"Undercut": datetime.now() + timedelta(hours=4)})
+    w.set_workflow(queue.items)
+    assert w._summary.text().startswith("4h 0")
+
+
+def test_the_header_goes_quiet_once_there_is_nothing_left_to_do(widget, queue):
+    for _ in range(4):
+        item = start_next(widget, queue)
+        queue.mark_done(item, Status.Completed)
+        widget.update_from_status(status_for(queue, item, Status.Completed,
+                                             task_duration=100.0))
+    assert widget._summary.isHidden()
+
+
+# ── the layout this column has to survive ─────────────────────────────────────
+
+def test_a_long_name_elides_instead_of_pushing_the_column_off_screen(app):
+    """The rows sit in a QScrollArea that is widget-resizable with horizontal scrolling
+    off, so the contents can never be narrower than the widest row and anything past the
+    viewport is unreachable. Before the labels elided, one long petname took the estimate
+    off EVERY row: measured at 280px, the first row's estimate ended 59px off screen.
+    """
+    q = TaskQueue()
+    q.build_from_matrix(["Trench"], ["L1", "a-very-long-petname-here-indeed"])
+    w = WorkflowProgressWidget()
+    w.set_actions_enabled(True)
+    w.set_estimates({(i.lamella_name, i.task_name): 100.0 for i in q.items})
+    w.set_workflow(q.items)
+    w.resize(280, 200)
+    w.show()
+    app.processEvents()
+
+    viewport = w._outer._scroll.viewport()
+    assert w._outer._contents.minimumSizeHint().width() <= viewport.width()
+    for row in w._outer._rows:
+        edge = row._trailing.mapTo(viewport, row._trailing.rect().topRight()).x()
+        assert edge <= viewport.width(), "the estimate column is off screen"
+    long_row = w._outer._rows[1]
+    assert QLabel.text(long_row._label) != long_row._label.text(), "not elided"
+    assert long_row._label.toolTip() == "a-very-long-petname-here-indeed"
+    w.close()
+
+
+def test_the_column_does_not_move_when_the_hover_button_appears(widget, app):
+    """A hidden widget is empty to the layout, so revealing the actions button used to
+    shove the column 28px left and back again on the way out."""
+    widget.resize(360, 200)
+    widget.show()
+    app.processEvents()
+    row = widget._outer._rows[0]
+    before = row._trailing.mapTo(widget, row._trailing.rect().topLeft()).x()
+    row._btn_actions.setVisible(True)
+    app.processEvents()
+    after = row._trailing.mapTo(widget, row._trailing.rect().topLeft()).x()
+    assert before == after
+    widget.close()
+
+
+# ── through the real thing ────────────────────────────────────────────────────
+# Everything above feeds the widget by hand. This drives a real TaskManager over a real
+# Experiment whose lamellae carry real task configs, and takes the estimates from
+# `estimated_duration` exactly as AutoLamellaMainUI._push_timeline_estimates does — so
+# the number on the row is one the shipped path actually produces, not one the test
+# chose. A stand-in config returning 100.0 would prove none of that.
+
+from PyQt5.QtCore import QObject, pyqtSignal  # noqa: E402
+
+from fibsem.applications.autolamella.structures import Experiment, Lamella  # noqa: E402
+from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager  # noqa: E402
+from fibsem.applications.autolamella.workflows.tasks.fiducial import (  # noqa: E402
+    MillFiducialTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.select_position import (  # noqa: E402
+    SelectMillingPositionTaskConfig,
+)
+
+TASKS = {
+    "Setup Lamella Position": SelectMillingPositionTaskConfig,
+    "Mill Fiducial": MillFiducialTaskConfig,
+}
+
+
+class _ParentUI(QObject):
+    """The two signals TaskManager emits on, as real Qt signals."""
+
+    workflow_update_signal = pyqtSignal(dict)
+    queue_changed_signal = pyqtSignal(dict)
+
+
+class _NoMicroscope:
+    """Enough microscope for TaskManager's constructor; nothing is executed here."""
+
+    fm = None
+
+
+@pytest.fixture
+def live(app, tmp_path):
+    """A real manager, a real experiment, and the widget wired the way the app wires it."""
+    experiment = Experiment(path=str(tmp_path), name="estimate-test")
+    for i, petname in enumerate(("01-lamella", "02-lamella"), start=1):
+        lamella = Lamella(path=experiment.path, number=i, petname=petname)
+        for task_name, config_cls in TASKS.items():
+            lamella.task_config[task_name] = config_cls()
+        experiment.positions.append(lamella)
+
+    widget = WorkflowProgressWidget()
+    parent_ui = _ParentUI()
+    parent_ui.workflow_update_signal.connect(
+        lambda info: widget.update_from_status(info["status"])
+    )
+    parent_ui.queue_changed_signal.connect(
+        lambda info: widget.refresh_queue(info["queue_items"])
+    )
+    manager = TaskManager(microscope=_NoMicroscope(), experiment=experiment,
+                          parent_ui=parent_ui)
+    names = [p.name for p in experiment.positions]
+    manager.queue.build_from_matrix(list(TASKS), names)
+
+    # What AutoLamellaMainUI does at workflow start.
+    widget.set_actions_enabled(True)
+    widget.set_estimates({
+        (lamella.name, task_name): lamella.task_config[task_name].estimated_duration
+        for lamella in experiment.positions
+        for task_name in TASKS
+    })
+    widget.set_workflow(manager.queue.items)
+    return manager, widget, experiment
+
+
+def test_a_real_config_reaches_the_column_through_the_managers_own_payload(live):
+    """The queue is task-outer, lamella-inner, so item 1 is the same task on the other
+    lamella — and its column must read what that lamella's own config actually costs."""
+    manager, widget, experiment = live
+    sibling = experiment.positions[1].task_config["Setup Lamella Position"]
+
+    item = manager.queue.next()
+    lamella = manager.experiment.get_lamella_by_name(item.lamella_name)
+    manager._emit_status(item=item, lamella=lamella, status=Status.InProgress)
+
+    assert column(widget)[1] == _fmt(sibling.estimated_duration)
+    # Sanity, not a pin: a real task takes real time, and re-measuring a cost primitive
+    # should not break this test.
+    assert 5.0 < sibling.estimated_duration < 3600.0
+
+
+def _fmt(seconds: float) -> str:
+    from fibsem.ui.widgets.preflight import format_duration
+    return format_duration(seconds)
+
+
+def test_the_header_totals_every_item_the_real_queue_holds(live):
+    """Four items over two tasks and two lamellae, each priced from its own config."""
+    manager, widget, experiment = live
+    total = sum(
+        lamella.task_config[task_name].estimated_duration
+        for lamella in experiment.positions
+        for task_name in TASKS
+    )
+    assert widget._summary.text().startswith(f"{_fmt(total)} left · finishes ")

--- a/tests/ui/test_workflow_timeline_sync.py
+++ b/tests/ui/test_workflow_timeline_sync.py
@@ -327,16 +327,21 @@ def test_skip_reason_lands_on_the_right_row(widget, queue):
     assert widget._outer._steps[1].subtitle == "Trench"  # untouched
 
 
-def test_completion_subtitle_is_not_wiped_by_a_later_sync(widget, queue):
+def test_what_a_finished_row_says_is_not_wiped_by_a_later_sync(widget, queue):
+    """Both halves of it: the completion time in the subtitle, the duration in the
+    column beside it. Neither is rebuilt from the queue snapshot, so a sync that does
+    not know either of them must leave both alone."""
     item = start_next(widget, queue)
     finish(widget, queue, item, task_duration=12.0)
     subtitle = widget._outer._steps[0].subtitle
-    assert "12" in subtitle
+    trailing = widget._outer._steps[0].trailing
+    assert trailing == "12s"
 
     queue.add("L9", "Polish")
     widget.refresh_queue(queue.items)
 
     assert widget._outer._steps[0].subtitle == subtitle
+    assert widget._outer._steps[0].trailing == trailing
 
 
 # ── Through the real TaskManager ──────────────────────────────────────────────


### PR DESCRIPTION
The pre-flight dialog quotes a duration and a finish time before a workflow starts (#446); once it is running, the timeline says nothing about either. This carries the same numbers through the run.

Completes FIB-666, on the cost primitives from #433 and the `estimated_time` fix in #431. Full design, the rejected alternatives, and the measurements are on the issue.

## The column

A fixed-width, right-aligned column on each row, on one rule — **it predicts while it can, then it reports**:

| row state | column |
|---|---|
| pending | the estimate, muted |
| active | `3m 18s left` |
| active, estimate spent | elapsed, ticking up — `7m 40s` |
| active, waiting for a human | `waiting` |
| completed / failed / cancelled | the actual duration |
| skipped | nothing |

A task outlasting its estimate is ordinary variance, not an error, so it gets no signal of its own: the row falls back to elapsed and the workflow's finish time slides later. Nothing goes negative, nothing stalls, and nothing changes colour to announce it — six treatments for that (`≥`, `or later`, an amber header, others) were built and compared before settling on none of them. Two shades total: muted while a row is still an estimate, normal once it is a measurement.

The actual duration **moves out of the subtitle into the column**, so finished rows line up with pending ones and the whole workflow reads down a single column.

## The header

A second, muted line: `23m 58s left · finishes 6:15PM`. That is wall-clock to finish and **includes a scheduled hold**, because that is what "when do I come back" asks.

While a supervised task waits for a human it swaps to `18m 06s of work left · waiting for you`. The rule is that bounded waits keep the clock and unbounded ones lose it: a scheduled hold is bounded, so the finish time stays true through it; a wait for a person is not, so any clock quoted through one is a guess dressed as a fact.

## Where the arithmetic lives

`estimate_queue` sits in `workflow_estimate.py` beside `estimate_workflow`, so the numbers are testable without a widget. It walks the queue carrying a clock rather than summing — `_wait_until_scheduled` fires per queue *item*, so a hold lands on the first item of a scheduled task and the rest find the time already passed.

Per-item durations come from `lamella.task_config[task].estimated_duration` — the same call, the same configs, the same numbers the dialog quoted. No second model, no history. Completed rows drop out, so the finish converges on its own; pending rows are **not** rescaled by how the completed ones actually went, which would make the timeline silently disagree with the dialog.

The widget stays generic: the owner pushes in `set_estimates`, `set_schedule` and `set_waiting_for_user`, recomputed on workflow start and on a queue edit only — `estimated_duration` walks every milling stage, and the status path is the one already watched for latency (FIB-683).

## Two layout bugs the column exposed rather than caused

* The rows sit in a `QScrollArea` that is `setWidgetResizable(True)` with the horizontal scroll bar `AlwaysOff`, so the contents can never be narrower than the widest row and anything past the viewport is unreachable. The labels did not elide, so **one long lamella petname pushed the estimate column off every row at once** — measured at 280 px, the first row's estimate ended 59 px off screen. They now use the shared `ElidedLabel`; the contents minimum drops from 348 px to 170 px.
* The hover-revealed `...` actions button occupied no width while hidden, so revealing it shifted the column 28 px and back. Its space is now reserved.

## Notes for review

* **Only the countdown pauses for a supervised wait, never the elapsed.** `AutoLamellaTaskState.duration` is end minus start and counts the wait, so a frozen elapsed would snap on completion and disagree with the experiment record.
* **`ElidedLabel.setText` gained an early return.** It re-measured on every call — a `QFontMetrics` plus an `elidedText` — which cost a third of a status update once every row carried three of them. Shared, so this helps the FM overview and the lamella cards too.
* **One deliberate `except` against the repo's fail-fast default.** Computing an estimate runs in the `_on_queue_changed` slot, PyQt5 aborts the process on an unhandled exception in a slot (FIB-329), and `estimated_time` divides by the sputter rate (`milling/base.py:292`) — so a hand-edited protocol could take down a running mill over a decorative number. Caught per item and logged; the column already has a well-defined "no estimate" state to degrade into.

## Verification

* 37 new tests (23 widget, 14 arithmetic), plus the existing timeline suite. The negative assertions were mutation-checked rather than trusted.
* Driven through real `TaskManager` payloads over a real `Experiment` whose lamellae carry real task configs, so the numbers on the rows are ones the shipped path produces.
* Qt tests apply `NAPARI_STYLE`, without which an offscreen render cannot show a label painting over the row's selection tint.
* Status-path cost measured at 6 / 50 / 250 / 500 queue items: **1.2x** of the previous path (500 items: 4.9 ms to 5.9 ms). The 1 Hz tick is 0.33 ms at 500 items.
* Run in the real app.
