### PR TITLE
[refactor] One pose hook for both overview tabs (FIB-709)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1480,7 +1480,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             try:
                 events.inserted.disconnect(self._rebuild_lamella_list)
                 events.removed.disconnect(self._rebuild_lamella_list)
-                events.changed.disconnect(self._refresh_fm_overview_positions)
+                events.changed.disconnect(self._refresh_overview_positions)
             except Exception as e:
                 logging.debug(f"Could not disconnect position events: {e}")
 
@@ -1499,7 +1499,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             # -- `update_lamella_position_ui` emits it after replacing a milling pose.
             # The list rows do not care, but the canvas draws the positions themselves,
             # so it has to be told.
-            events.changed.connect(self._refresh_fm_overview_positions)
+            events.changed.connect(self._refresh_overview_positions)
         self._lamella_list_experiment = experiment
 
     def create_notification_button(self):
@@ -2094,12 +2094,13 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.lamella_list_widget.clear()
         self.lamella_card_container.clear()
         self._on_lamella_card_selected(None)
-        # The FM canvas is another display of the same set, so it is rebuilt here rather
-        # than from its own subscription -- one handler for "the lamellae changed" means
-        # the two cannot end up disagreeing about what the experiment holds. Before the
-        # `experiment is None` return, because an experiment closing has to clear the
-        # canvas as much as an experiment opening has to fill it.
-        self._refresh_fm_overview_positions()
+        # The overview canvases are further displays of the same set, so they are
+        # rebuilt here rather than from subscriptions of their own -- one handler for
+        # "the lamellae changed" means the displays cannot end up disagreeing about what
+        # the experiment holds. Before the `experiment is None` return, because an
+        # experiment closing has to clear them as much as an experiment opening has to
+        # fill them.
+        self._refresh_overview_positions()
         if experiment is None:
             return
         for lamella in experiment.positions:
@@ -2365,18 +2366,27 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         finally:
             self._syncing_selection = False
 
-    def _refresh_fm_overview_positions(self):
-        """Re-mark the FM overview, tolerating there being no tab.
+    def _refresh_overview_positions(self):
+        """Re-mark **both** overview canvases, tolerating either tab being absent.
 
-        A method on the window rather than connecting `fm_overview_tab.refresh_positions`
-        straight to the experiment's signal: the tab is rebuilt when the microscope
+        A method on the window rather than connecting each tab's `refresh_positions`
+        straight to the experiment's signal: a tab is rebuilt when the microscope
         changes, and a subscription holding the old one's bound method would be both
         stale and undisconnectable. This one is stable for the window's lifetime, which
         is what `_wire_position_events`' disconnect needs.
+
+        Both, because for a long time it was only the fluorescence one -- so a lamella
+        marked on the FIB/SEM overview appeared on the FM canvas, and one marked on the
+        FM overview never appeared on the beam canvas at all. The beam tab papered over
+        its own edits by re-marking inline and went stale for everything else: a lamella
+        added from the FM tab, from the Microscope tab, or by a workflow, and any pose
+        replaced in place (FIB-709). Neither tab subscribes to the experiment itself, so
+        this is the only place that can see all of it.
         """
-        if getattr(self, "fm_overview_tab", None) is None:
-            return
-        self.fm_overview_tab.refresh_positions()
+        for name in ("fm_overview_tab", "overview_canvas_tab"):
+            tab = getattr(self, name, None)
+            if tab is not None:
+                tab.refresh_positions()
 
     def _on_fm_overview_availability(self, available: bool):
         """Enable the tab when it has something to drive, and say why when it does not.

--- a/fibsem/applications/autolamella/ui/autolamella_fluorescence_overview_tab.py
+++ b/fibsem/applications/autolamella/ui/autolamella_fluorescence_overview_tab.py
@@ -5,9 +5,10 @@ it is what lets the same widget open standalone against a simulator, and be buil
 test from a microscope alone. It says *where* a user pointed and leaves the meaning to
 whoever is listening.
 
-This is whoever is listening. It lives in the autolamella package because everything it
-adds is autolamella's: experiments, lamellae, poses, and the milling side of a sample the
-fluorescence canvas cannot see.
+This is whoever is listening, and it is the fluorescence twin of
+`AutoLamellaOverviewTab`. Everything the two do identically lives in
+`AutoLamellaOverviewTabBase`; what is left here is what makes this the fluorescence side
+-- **fluorescence poses**, and the objective the sample was focused through.
 
 A widget rather than a plain controller, because part of what it adds is *visible* --
 `LamellaNameListWidget` needs real `Lamella` objects (it subscribes to
@@ -19,222 +20,77 @@ that owns both is simpler than a controller reaching into another widget's layou
 from __future__ import annotations
 
 import logging
-from copy import deepcopy
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from PyQt5.QtWidgets import QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QWidget
 
 from fibsem.applications.autolamella.poses import (
     FLUORESCENCE_ORIENTATION,
     build_lamella_poses,
 )
-from fibsem.ui import notification_service
-from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
-from fibsem.ui.utils import message_box_ui
 from fibsem.applications.autolamella.ui.overview_tab_base import (
     AutoLamellaOverviewTabBase,
 )
-from fibsem.applications.autolamella.ui.lamella_name_list_widget import LamellaNameListWidget
+from fibsem.ui import notification_service
+from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+from fibsem.ui.utils import message_box_ui
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
-    from fibsem.applications.autolamella.structures import Lamella
+    from fibsem.structures import FibsemStagePosition
+
+logger = logging.getLogger(__name__)
 
 
 class AutoLamellaFluorescenceOverviewTab(AutoLamellaOverviewTabBase):
-    """Drives `FMOverviewWidget` on behalf of an experiment.
+    """Drives `FMOverviewWidget` on behalf of an experiment."""
 
-    Built empty and filled in on connection: `FMOverviewWidget` requires a microscope
-    with a fluorescence detector at construction -- it has no meaningful empty state,
-    since every scale on its canvas comes from the camera -- and at the point the tab is
-    reserved there may be no microscope at all.
-    """
+    POSE_NOUN = "fluorescence pose"
+    OVERVIEW_NOUN = "FM overview"
 
-    def __init__(self, autolamella_ui, parent: Optional[QWidget] = None):
-        super().__init__(parent)
-        self.autolamella_ui = autolamella_ui
-        self.overview: Optional[FMOverviewWidget] = None
-        # The microscope the current widget was built for. A reconnection hands out a new
-        # object, and the old widget would go on reading geometry from an instrument
-        # nobody is driving (FIB-433), so the identity is worth keeping.
-        self._microscope = None
-        # Set while this tab is the one driving a selection, so the highlight it gets
-        # back does not re-enter the list and fight whatever the user just clicked.
-        self._syncing_selection = False
+    # ── what makes this the fluorescence side ────────────────────────────
 
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+    def _build_overview(self, microscope) -> QWidget:
+        return FMOverviewWidget(microscope)
 
-        self.lamella_list = LamellaNameListWidget()
-        self.lamella_list.enable_actions_button(True)
-        self.lamella_list.enable_move_to_action(True)
-        self.lamella_list.enable_remove_button(True)
-        self.lamella_list.lamella_selected.connect(self._on_list_selection)
-        self.lamella_list.move_to_requested.connect(self._on_move_to_requested)
-        self.lamella_list.remove_requested.connect(self._on_remove_requested)
+    def _can_build(self, microscope) -> bool:
+        """Whether there is a fluorescence detector to drive.
 
-    # ── what the window asks ─────────────────────────────────────────────
-
-    def refresh_microscope(self) -> None:
-        """Build, rebuild or drop the fluorescence widget to match the instrument.
-
-        Called on every connection. Rebuilds when the microscope object has changed,
-        because the widget holds its microscope for life and would otherwise be talking
-        to the previous one -- destructive of anything on the canvas, and the reason
-        FIB-433 exists to do this without throwing the view away.
+        A capability rather than a flag, but the same build-or-drop answer: on a system
+        without an FM the tab stays in place but dead, so the tab bar does not change
+        shape between systems. Hiding it is the window's job.
         """
-        microscope = self.microscope
+        return microscope.fm is not None
 
-        if microscope is None or microscope.fm is None:
-            # Not connected yet, or no fluorescence detector. The tab stays in place but
-            # dead rather than being removed, so the tab bar does not change shape
-            # between systems; hiding it is the window's job.
-            self._drop_overview()
-            self.availability_changed.emit(False)
-            return
+    def _pose_of(self, lamella) -> Optional["FibsemStagePosition"]:
+        """The **fluorescence** pose, not the primary stage position.
 
-        if self.overview is not None:
-            if self._microscope is microscope:
-                return
-            self._drop_overview()
+        A lamella carries one of each and they are different places on this canvas -- on
+        a compustage the stage flips 180 degrees between them -- so passing the milling
+        pose would mark every lamella somewhere the sample is not.
 
-        try:
-            self.overview = FMOverviewWidget(microscope)
-        except Exception as e:
-            logging.error(f"Could not create the FM overview tab: {e}")
-            self.availability_changed.emit(False)
-            return
-
-        self.overview.position_add_requested.connect(self._on_add_requested)
-        self.overview.position_move_requested.connect(self._on_move_requested)
-        self.overview.position_selected.connect(self._on_marker_clicked)
-        # In the settings column rather than beside it: the positions are the subject of
-        # this tab, and a column of their own would read as a third pane.
-        self.overview.add_settings_section("Lamella Positions", self.lamella_list)
-
-        self._microscope = microscope
-        self.layout().addWidget(self.overview)
-        self.availability_changed.emit(True)
-        self.refresh_experiment()
-
-    def _drop_overview(self) -> None:
-        """Retire the current fluorescence widget, if there is one.
-
-        `close()` rather than `deleteLater()` alone: the widget's `closeEvent` is what
-        releases its psygnal subscriptions on the microscope, and those outlive the
-        widget -- a stale one left connected emits into a torn-down Qt object.
+        None is the normal state on a system with no FM, and possible on one loaded from
+        an older experiment. The base reports those rather than dropping them in silence:
+        a canvas showing three of five positions and saying nothing is worse than one
+        saying which two it cannot show.
         """
-        if self.overview is None:
-            return
-        # Taken back before the widget goes. `add_settings_section` reparents the list
-        # into the overview's column, so Qt destroying the overview would destroy the
-        # list with it, and the next `refresh_microscope` would hand a dead C++ object to
-        # `add_settings_section`. The list belongs to this tab and outlives any one
-        # overview, so it is moved out rather than left to be collected.
-        #
-        # Kept as a precondition rather than because a test proves it: under the
-        # offscreen platform the deferred delete does not actually run, so the failure it
-        # prevents cannot be reproduced here. `test_the_list_survives_the_overview_being_
-        # rebuilt` covers the reuse, not this mechanism.
-        self.lamella_list.setParent(self)
-        self.lamella_list.hide()
-        try:
-            self.overview.close()
-        except Exception as e:
-            logging.debug(f"Error closing the FM overview widget: {e}")
-        self.layout().removeWidget(self.overview)
-        self.overview.deleteLater()
-        self.overview = None
-        self._microscope = None
-
-    def refresh_positions(self) -> None:
-        """Mark the experiment's lamellae on the fluorescence canvas.
-
-        **Fluorescence poses, not the primary stage position.** A lamella carries one of
-        each and they are different places on this canvas -- on a compustage the stage
-        flips 180 degrees between them -- so passing the milling pose would mark every
-        lamella somewhere the sample is not.
-
-        A lamella with no fluorescence pose cannot be placed here at all, which is the
-        normal state on a system with no FM and possible on one loaded from an older
-        experiment. Those are counted rather than dropped in silence: a canvas showing
-        three of five positions and saying nothing is worse than one saying which two it
-        cannot show.
-        """
-        if self.overview is None:
-            return
-        experiment = self.experiment
-        if experiment is None:
-            self.overview.set_positions([])
-            self.lamella_list.set_lamella([])
-            return
-
-        # Every lamella, including the ones the canvas cannot place. The list is how you
-        # find out a lamella exists but has no fluorescence pose -- dropping those here
-        # too would leave the log as the only place that says so.
-        self.lamella_list.set_lamella(list(experiment.positions))
-
-        positions, unplaceable = [], []
-        for lamella in experiment.positions:
-            pose = lamella.fluorescence_pose
-            if pose is None or pose.stage_position is None:
-                unplaceable.append(lamella.name)
-                continue
-            # Named here rather than relying on whatever the stored position carries:
-            # the marker's label is the lamella's name, and a pose saved before names
-            # were stamped on positions would otherwise draw an unlabelled dot.
-            position = deepcopy(pose.stage_position)
-            position.name = lamella.name
-            positions.append(position)
-
-        self.overview.set_positions(positions)
-        if unplaceable:
-            logging.info(
-                f"{len(unplaceable)} lamella(e) have no fluorescence pose and are not "
-                f"shown on the FM overview: {', '.join(unplaceable)}"
-            )
-
-    # ── the list ─────────────────────────────────────────────────────────
-
-    def _on_move_to_requested(self, lamella) -> None:
-        """Drive the stage to a lamella's *fluorescence* pose.
-
-        Not `stage_position`, which is the milling pose: this tab looks at the sample
-        from the fluorescence side, and moving to the milling pose from here would swing
-        the stage 180 degrees away from the view you asked to centre.
-        """
-        if lamella is None:
-            return
         pose = lamella.fluorescence_pose
-        if pose is None or pose.stage_position is None:
-            notification_service.show_toast(
-                f"{lamella.name} has no fluorescence pose to move to.", "warning"
-            )
-            return
-        if self.overview is None:
-            return
-        self.overview.move_to(pose.stage_position)
+        if pose is None:
+            return None
+        return pose.stage_position
 
-    def _on_remove_requested(self, lamella) -> None:
-        """Remove a lamella from the experiment.
+    def _add_lamella_kwargs(self) -> Dict[str, Any]:
+        """The orientation is *declared* rather than left to be derived.
 
-        The row's own button already asked -- `_LamellaRow._on_remove_clicked` puts up
-        the confirmation before it emits -- so this does not ask twice.
+        On a compustage deriving it would give the same answer; on an offset mount it
+        would not, and the wrong answer there is a lamella with a milling pose 48 mm off
+        the beam axis that nothing rejects until something tries to mill it (FIB-93).
+        Declaring it turns that into a refusal at the point of marking, where there is a
+        user to tell.
         """
-        experiment = self.experiment
-        if experiment is None or lamella is None:
-            return
-        try:
-            experiment.positions.remove(lamella)
-        except ValueError:
-            logging.debug(f"Cannot remove {lamella.name!r}: not in the experiment.")
-            return
-        experiment.save()
-        # `positions` is an EventedList, so the window's own rebuild has already run off
-        # `removed` and re-marked this canvas. Saying it again would be a second full
-        # redraw for nothing.
-        notification_service.show_toast(f"Removed {lamella.name}.", "info")
-
-    # ── turning a request into a lamella ─────────────────────────────────
+        return {
+            "objective_position": self._objective_position(),
+            "marked_at": FLUORESCENCE_ORIENTATION,
+        }
 
     def _objective_position(self) -> Optional[float]:
         """Where the objective is right now, for a pose marked on the overview.
@@ -256,43 +112,16 @@ class AutoLamellaFluorescenceOverviewTab(AutoLamellaOverviewTabBase):
         try:
             objective = microscope.fm.objective
             if objective.state != "Inserted":
-                logging.debug(
+                logger.debug(
                     f"Objective is {objective.state}; falling back to its focus position."
                 )
                 return None
             return objective.position
         except Exception as e:
-            logging.debug(f"Could not read the objective position: {e}")
+            logger.debug(f"Could not read the objective position: {e}")
             return None
 
-    def _on_add_requested(self, position) -> None:
-        """A user asked for a new lamella at a point on the overview.
-
-        The orientation is *declared* rather than left to be derived. On a compustage
-        deriving it would give the same answer; on an offset mount it would not, and the
-        wrong answer there is a lamella with a milling pose 48 mm off the beam axis that
-        nothing rejects until something tries to mill it (FIB-93). Declaring it turns
-        that into a refusal here, where there is a user to tell.
-        """
-        if self.autolamella_ui is None or self.experiment is None:
-            notification_service.show_toast(
-                "Load an experiment before marking positions.", "warning"
-            )
-            return
-        try:
-            lamella = self.autolamella_ui.add_new_lamella(
-                stage_position=position,
-                objective_position=self._objective_position(),
-                marked_at=FLUORESCENCE_ORIENTATION,
-            )
-        except Exception as e:
-            logging.error(f"Could not add a lamella from the FM overview: {e}")
-            notification_service.show_toast(str(e), "error")
-            return
-
-        self.refresh_positions()
-        self.set_selected(lamella)
-        notification_service.show_toast(f"Added {lamella.name}.", "info")
+    # ── turning a request into a lamella ─────────────────────────────────
 
     def _on_move_requested(self, name: str, position) -> None:
         """A user asked to move a marked lamella to a point on the overview.
@@ -302,13 +131,16 @@ class AutoLamellaFluorescenceOverviewTab(AutoLamellaOverviewTabBase):
         where the beam was going to mill it. That is usually the point -- the two describe
         one piece of sample -- but it is not visible from this canvas, which shows only
         the fluorescence side, so it gets said rather than assumed.
+
+        Not shared with the beam tab, which writes the milling pose directly and syncs
+        this one after it. See `overview_tab_base`.
         """
         experiment = self.experiment
         if experiment is None:
             return
         lamella = next((p for p in experiment.positions if p.name == name), None)
         if lamella is None:
-            logging.debug(f"Cannot move {name!r}: no such lamella in the experiment.")
+            logger.debug(f"Cannot move {name!r}: no such lamella in the experiment.")
             return
         if lamella.milling_pose is None:
             notification_service.show_toast(
@@ -330,7 +162,7 @@ class AutoLamellaFluorescenceOverviewTab(AutoLamellaOverviewTabBase):
                 marked_at=FLUORESCENCE_ORIENTATION,
             )
         except Exception as e:
-            logging.error(f"Could not move {name} from the FM overview: {e}")
+            logger.error(f"Could not move {name} from the FM overview: {e}")
             notification_service.show_toast(str(e), "error")
             return
 

--- a/fibsem/applications/autolamella/ui/autolamella_overview_tab.py
+++ b/fibsem/applications/autolamella/ui/autolamella_overview_tab.py
@@ -6,8 +6,9 @@ built in a test from a microscope alone. It says *where* a user pointed and leav
 meaning to whoever is listening.
 
 This is whoever is listening, and it is the beam-side twin of
-`AutoLamellaFluorescenceOverviewTab`. It lives in the autolamella package because
-everything it adds is autolamella's: experiments, lamellae, defects and poses.
+`AutoLamellaFluorescenceOverviewTab`. Everything the two do identically lives in
+`AutoLamellaOverviewTabBase`; what is left here is what makes this the beam side --
+**milling poses** and defects.
 
 **Milling poses, not fluorescence ones** -- the opposite of its twin. This canvas looks
 at the sample from the beam side, so a lamella is marked where the beam sees it. On a
@@ -28,24 +29,20 @@ for anyone with an experiment.
 from __future__ import annotations
 
 import logging
-from copy import deepcopy
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
-from PyQt5.QtWidgets import QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QWidget
 
 from fibsem.applications.autolamella.poses import sync_fluorescence_pose
 from fibsem.applications.autolamella.structures import DefectType
 from fibsem.applications.autolamella.ui.overview_tab_base import (
     AutoLamellaOverviewTabBase,
 )
-from fibsem.applications.autolamella.ui.lamella_name_list_widget import (
-    LamellaNameListWidget,
-)
 from fibsem.ui import notification_service
 from fibsem.ui.widgets.overview_widget import FibsemOverviewWidget
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
-    from fibsem.applications.autolamella.structures import Lamella
+    from fibsem.structures import FibsemStagePosition
 
 logger = logging.getLogger(__name__)
 
@@ -57,42 +54,53 @@ FLAGGED_DEFECT_STATES = (DefectType.FAILURE, DefectType.REWORK)
 
 
 class AutoLamellaOverviewTab(AutoLamellaOverviewTabBase):
-    """Drives `FibsemOverviewWidget` on behalf of an experiment.
+    """Drives `FibsemOverviewWidget` on behalf of an experiment."""
 
-    Built empty and filled in on connection, like its fluorescence twin: the overview
-    widget requires a microscope at construction, and at the point the tab is reserved
-    there may be no microscope at all.
-    """
+    POSE_NOUN = "position"
+    OVERVIEW_NOUN = "overview"
 
     def __init__(self, autolamella_ui, parent: Optional[QWidget] = None):
-        super().__init__(parent)
-        self.autolamella_ui = autolamella_ui
-        self.overview: Optional[FibsemOverviewWidget] = None
-        # The microscope the current widget was built for. A reconnection hands out a
-        # new object, and the old widget would go on reading geometry from an
-        # instrument nobody is driving, so the identity is worth keeping.
-        self._microscope = None
-        # Set while this tab is the one driving a selection, so the highlight it gets
-        # back does not re-enter the list and fight whatever the user just clicked.
-        self._syncing_selection = False
+        super().__init__(autolamella_ui, parent)
         # Whether the host wants a live widget here at all -- the feature flag, as far
         # as this object is concerned. True by default so that building this tab and
         # calling `refresh_microscope` is enough on its own, which is how it is used
         # standalone and in tests; the window sets it from the flag on the way in.
         self._enabled = True
 
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+    # ── what makes this the beam side ────────────────────────────────────
 
-        self.lamella_list = LamellaNameListWidget()
+    def _build_overview(self, microscope) -> QWidget:
+        return FibsemOverviewWidget(microscope)
+
+    def _can_build(self, microscope) -> bool:
+        return self._enabled
+
+    def _pose_of(self, lamella) -> Optional["FibsemStagePosition"]:
+        """The **milling** pose, which is what `lamella.stage_position` is.
+
+        This canvas looks at the sample from the beam side; marking the fluorescence
+        poses here would put every lamella where the FM sees it, which on a compustage
+        is the other side of the grid.
+        """
+        return lamella.stage_position
+
+    def _configure_list(self) -> None:
         self.lamella_list.enable_defect_button(True)
-        self.lamella_list.enable_actions_button(True)
-        self.lamella_list.enable_move_to_action(True)
-        self.lamella_list.enable_remove_button(True)
-        self.lamella_list.lamella_selected.connect(self._on_list_selection)
-        self.lamella_list.move_to_requested.connect(self._on_move_to_requested)
-        self.lamella_list.remove_requested.connect(self._on_remove_requested)
         self.lamella_list.defect_changed.connect(self._on_defect_changed)
+
+    def _show_positions(self, positions, lamellae) -> None:
+        """Mark them, saying which are flagged.
+
+        The defect is a judgement about a lamella rather than about a view of it, but
+        only this canvas draws it -- the fluorescence tab has no defect concept, and the
+        list beside both canvases shows the state either way.
+        """
+        flagged = [
+            lamella.name
+            for lamella in lamellae
+            if lamella.defect.state in FLAGGED_DEFECT_STATES
+        ]
+        self.overview.set_positions(positions, flagged=flagged)
 
     # ── what the window asks ─────────────────────────────────────────────
 
@@ -104,7 +112,7 @@ class AutoLamellaOverviewTab(AutoLamellaOverviewTabBase):
         lifetime, so one left behind goes on doing work on every stage move and every
         tile of every acquisition, for a tab nobody can open -- and goes on holding
         psygnal references to tear down later. Same reasoning, and the same build-or-drop
-        answer, as `_refresh_fm_overview_microscope` gives for its capability check.
+        answer, as the fluorescence tab's capability check.
         """
         enabled = bool(enabled)
         if enabled == self._enabled:
@@ -112,116 +120,7 @@ class AutoLamellaOverviewTab(AutoLamellaOverviewTabBase):
         self._enabled = enabled
         self.refresh_microscope()
 
-    def refresh_microscope(self) -> None:
-        """Build, rebuild or drop the overview widget to match the instrument.
-
-        Called on every connection. Rebuilds when the microscope object has changed,
-        because the widget holds its microscope for life and would otherwise be talking
-        to the previous one.
-        """
-        microscope = self.microscope
-        if microscope is None or not self._enabled:
-            self._drop_overview()
-            self.availability_changed.emit(False)
-            return
-
-        if self.overview is not None:
-            if self._microscope is microscope:
-                return
-            self._drop_overview()
-
-        try:
-            self.overview = FibsemOverviewWidget(microscope)
-        except Exception as e:
-            logger.error(f"Could not create the Overview tab: {e}")
-            self.availability_changed.emit(False)
-            return
-
-        self.overview.position_add_requested.connect(self._on_add_requested)
-        self.overview.position_move_requested.connect(self._on_move_requested)
-        self.overview.position_selected.connect(self._on_marker_clicked)
-        self.overview.add_settings_section("Lamella Positions", self.lamella_list)
-
-        self._microscope = microscope
-        self.layout().addWidget(self.overview)
-        self.availability_changed.emit(True)
-        self.refresh_experiment()
-
-    def _drop_overview(self) -> None:
-        """Retire the current overview widget, if there is one.
-
-        `close()` rather than `deleteLater()` alone: the widget's `closeEvent` is what
-        releases its psygnal subscriptions on the microscope, and those outlive the
-        widget -- a stale one left connected emits into a torn-down Qt object.
-        """
-        if self.overview is None:
-            return
-        # Taken back before the widget goes. `add_settings_section` reparents the list
-        # into the overview's column, so Qt destroying the overview would destroy the
-        # list with it, and the next `refresh_microscope` would hand a dead C++ object
-        # to `add_settings_section`.
-        self.lamella_list.setParent(self)
-        self.lamella_list.hide()
-        try:
-            self.overview.close()
-        except Exception as e:
-            logger.debug(f"Error closing the overview widget: {e}")
-        self.layout().removeWidget(self.overview)
-        self.overview.deleteLater()
-        self.overview = None
-        self._microscope = None
-
-    def refresh_positions(self) -> None:
-        """Mark the experiment's lamellae on the canvas.
-
-        **Milling poses**, which is what `lamella.stage_position` is. This canvas looks
-        at the sample from the beam side; marking the fluorescence poses here would put
-        every lamella where the FM sees it, which on a compustage is the other side of
-        the grid.
-        """
-        if self.overview is None:
-            return
-        experiment = self.experiment
-        if experiment is None:
-            self.overview.set_positions([])
-            self.lamella_list.set_lamella([])
-            return
-
-        lamellae = list(experiment.positions)
-        self.lamella_list.set_lamella(lamellae)
-
-        positions, flagged = [], []
-        for lamella in lamellae:
-            if lamella.stage_position is None:
-                continue
-            # Named here rather than relying on whatever the stored position carries:
-            # the marker's label is the lamella's name, and a position saved before
-            # names were stamped on them would otherwise draw an unlabelled crosshair.
-            position = deepcopy(lamella.stage_position)
-            position.name = lamella.name
-            positions.append(position)
-            if lamella.defect.state in FLAGGED_DEFECT_STATES:
-                flagged.append(lamella.name)
-
-        self.overview.set_positions(positions, flagged=flagged)
-
-    @property
-    def is_acquiring(self) -> bool:
-        """Whether an overview acquisition is running. The window asks before moving."""
-        return self.overview is not None and self.overview.is_acquiring
-
     # ── the list ─────────────────────────────────────────────────────────
-
-    def _on_move_to_requested(self, lamella) -> None:
-        """Drive the stage to a lamella's milling pose."""
-        if lamella is None or self.overview is None:
-            return
-        if lamella.stage_position is None:
-            notification_service.show_toast(
-                f"{lamella.name} has no position to move to.", "warning"
-            )
-            return
-        self.overview.move_to(lamella.stage_position)
 
     def _on_defect_changed(self, lamella) -> None:
         """Persist a defect set from the list, and re-flag the canvas.
@@ -236,39 +135,7 @@ class AutoLamellaOverviewTab(AutoLamellaOverviewTabBase):
         experiment.save()
         self.refresh_positions()
 
-    def _on_remove_requested(self, lamella) -> None:
-        """Remove a lamella from the experiment. The row already confirmed."""
-        experiment = self.experiment
-        if experiment is None or lamella is None:
-            return
-        try:
-            experiment.positions.remove(lamella)
-        except ValueError:
-            logger.debug(f"Cannot remove {lamella.name!r}: not in the experiment.")
-            return
-        experiment.save()
-        self.refresh_positions()
-        notification_service.show_toast(f"Removed {lamella.name}.", "info")
-
     # ── turning a request into a lamella ─────────────────────────────────
-
-    def _on_add_requested(self, position) -> None:
-        """A user asked for a new lamella at a point on the overview."""
-        if self.autolamella_ui is None or self.experiment is None:
-            notification_service.show_toast(
-                "Load an experiment before marking positions.", "warning"
-            )
-            return
-        try:
-            lamella = self.autolamella_ui.add_new_lamella(stage_position=position)
-        except Exception as e:
-            logger.error(f"Could not add a lamella from the overview: {e}")
-            notification_service.show_toast(str(e), "error")
-            return
-
-        self.refresh_positions()
-        self.set_selected(lamella)
-        notification_service.show_toast(f"Added {lamella.name}.", "info")
 
     def _on_move_requested(self, name: str, position) -> None:
         """A user asked to move a marked lamella to a point on the overview.
@@ -277,6 +144,9 @@ class AutoLamellaOverviewTab(AutoLamellaOverviewTabBase):
         one piece of sample from two sides, so leaving the other behind would have it go
         on naming where this lamella *used to be* -- and nothing about a stale pose
         looks wrong.
+
+        Not shared with the fluorescence tab, which derives both poses through
+        `build_lamella_poses` and confirms first. See `overview_tab_base`.
         """
         experiment = self.experiment
         if experiment is None:

--- a/fibsem/applications/autolamella/ui/overview_tab_base.py
+++ b/fibsem/applications/autolamella/ui/overview_tab_base.py
@@ -7,38 +7,54 @@ turn a clicked crosshair into a lamella. A fix to one left the other behaving di
 -- and both are wired into the same handler in `AutoLamellaMainUI`, so "differently" here
 means one of four lists disagreeing with the other three.
 
-**Only the parts whose code is identical live here.** Measured method by method with
-docstrings stripped (FIB-697): seven were byte-identical and `_on_marker_clicked` differed
-only in `logging` against `logger`. Those eight are below.
+# The pose is the difference
 
-Deliberately *not* here, for now:
+Almost everything that looked different between the two turned out to be one question
+asked twice: *which pose does this tab mean?* The beam tab marks, moves to and drags the
+**milling** pose; the fluorescence tab the **fluorescence** pose. That is `_pose_of`, and
+with it in place `refresh_positions`, `_on_move_to_requested` and `_on_add_requested`
+have one implementation each.
 
-* `refresh_microscope` and `_drop_overview` -- 96% and 98% identical, which is close
-  enough to look safe and not close enough to move without reading both carefully.
-* `refresh_positions`, `_on_add_requested`, `_on_move_requested`, `_on_move_to_requested`,
-  `_on_remove_requested`, `__init__` -- these differ because of **which pose is read**,
-  which is the real difference between the two tabs and wants a `_pose_of` hook rather
-  than a copy-paste into a base class.
+**This hook is where a mistake hides.** On a compustage the two poses share x, y, z *and*
+r, and differ only in tilt -- -23 degrees against -180. A test asserting where a marker
+landed cannot tell them apart, and a canvas marking the wrong one looks entirely
+plausible while putting every lamella on the far side of the grid. Anything checking this
+has to assert the tilt (FIB-709).
 
-Finishing that is the rest of FIB-697. Starting with the identical eight means this
-change cannot alter behaviour, which is worth more than doing it in one go.
+# What is deliberately still written twice
+
+`_on_move_requested` -- dragging a marked lamella to a new point. The beam tab writes the
+milling pose and syncs the fluorescence one after it; the fluorescence tab derives both
+through `build_lamella_poses`, and asks first, because from a canvas showing only the
+fluorescence side it is not visible that the milling pose moves too. Those are different
+operations that happen to share a name, and folding them together behind a hook would
+hide the one part a reader most needs to see.
 
 # The contract
 
-This is a mixin over attributes its subclasses own, not a constructor. Each subclass sets
-`autolamella_ui`, `overview`, `lamella_list` and `_syncing_selection` in its own
-`__init__`, and supplies `refresh_positions`. The base deliberately does not build any of
-them: the two tabs construct their widgets differently and at different times, and a base
-`__init__` that half-built them would be a third thing to keep in step.
+A base class *and* a constructor: it builds the layout, the lamella list and the common
+connections, because that part was identical. Subclasses supply the pieces below and are
+free to add their own -- the beam tab's defect handling, the fluorescence tab's objective
+position -- which is the point of two widgets sharing parts rather than one widget with a
+mode flag.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QWidget
+from PyQt5.QtWidgets import QVBoxLayout, QWidget
+
+from fibsem.applications.autolamella.ui.lamella_name_list_widget import (
+    LamellaNameListWidget,
+)
+from fibsem.ui import notification_service
+
+if TYPE_CHECKING:  # pragma: no cover - annotation only
+    from fibsem.structures import FibsemStagePosition
 
 logger = logging.getLogger(__name__)
 
@@ -54,12 +70,104 @@ class AutoLamellaOverviewTabBase(QWidget):
     # place instead of four.
     lamella_selected = pyqtSignal(object)
 
+    # What this canvas marks, in the words a message needs: "has no fluorescence pose to
+    # move to" against "has no position to move to". A user reading the second one on the
+    # fluorescence tab would go looking for a position the lamella has.
+    POSE_NOUN = "position"
+    # Which overview this is, for the lines logged about it.
+    OVERVIEW_NOUN = "overview"
+
+    def __init__(self, autolamella_ui, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.autolamella_ui = autolamella_ui
+        # Built empty and filled in on connection: both overview widgets require a
+        # microscope at construction -- every scale on their canvases comes from the
+        # instrument -- and at the point a tab is reserved there may be no microscope.
+        self.overview: Optional[QWidget] = None
+        # The microscope the current widget was built for. A reconnection hands out a
+        # new object, and the old widget would go on reading geometry from an instrument
+        # nobody is driving (FIB-433), so the identity is worth keeping.
+        self._microscope = None
+        # Set while this tab is the one driving a selection, so the highlight it gets
+        # back does not re-enter the list and fight whatever the user just clicked.
+        self._syncing_selection = False
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.lamella_list = LamellaNameListWidget()
+        self.lamella_list.enable_actions_button(True)
+        self.lamella_list.enable_move_to_action(True)
+        self.lamella_list.enable_remove_button(True)
+        self.lamella_list.lamella_selected.connect(self._on_list_selection)
+        self.lamella_list.move_to_requested.connect(self._on_move_to_requested)
+        self.lamella_list.remove_requested.connect(self._on_remove_requested)
+        self._configure_list()
+
+    # ── what a subclass supplies ─────────────────────────────────────────
+
+    def _pose_of(self, lamella) -> Optional["FibsemStagePosition"]:
+        """Where this tab's canvas puts *lamella*, or None if it cannot place it.
+
+        The one hook that explains most of the difference between the two tabs. Returning
+        None is not an error: a lamella with no fluorescence pose is the normal state on
+        a system without an FM, and one with no milling pose can be loaded from an older
+        experiment. Both are reported rather than dropped in silence.
+        """
+        raise NotImplementedError
+
+    def _build_overview(self, microscope) -> QWidget:
+        """Construct this tab's overview widget for *microscope*."""
+        raise NotImplementedError
+
+    def _can_build(self, microscope) -> bool:
+        """Whether to hold a live widget for *microscope* at all.
+
+        Two different questions with one shape: the beam tab answers a feature flag, the
+        fluorescence tab a capability (is there a detector). Either way a False means the
+        widget is dropped rather than merely hidden -- it subscribes to the microscope
+        for its lifetime, so one left behind goes on working for a tab nobody can open.
+        """
+        return True
+
+    def _configure_list(self) -> None:
+        """Whatever else this tab's lamella list needs, beyond the three common actions."""
+
+    def _show_positions(self, positions, lamellae) -> None:
+        """Hand the placeable positions to the widget.
+
+        Overridable because the beam tab has one more thing to say -- which lamellae are
+        flagged as defective. That concept belongs to the beam side and stays there
+        rather than becoming a base-class notion the fluorescence tab passes empty.
+        """
+        self.overview.set_positions(positions)
+
+    def _add_lamella_kwargs(self) -> Dict[str, Any]:
+        """Anything beyond the position that this tab knows about a new lamella."""
+        return {}
+
+    def _on_move_requested(self, name: str, position) -> None:
+        """A user dragged a marked lamella to a new point. See the module docstring for
+        why this one is not shared."""
+        raise NotImplementedError
+
     # ── what the window asks ─────────────────────────────────────────────
 
     @property
     def is_available(self) -> bool:
         """Whether there is a widget to drive, i.e. whether the tab does anything."""
         return self.overview is not None
+
+    @property
+    def is_acquiring(self) -> bool:
+        """Whether an overview acquisition is running here.
+
+        Asked *of the other tab* before anything drives the stage: a click-to-move on one
+        overview while the other is mid-tileset does not fail loudly -- the run goes on
+        stamping tiles with the poses it planned, so the mosaic comes out plausible and
+        wrong (FIB-706). Both widgets answer this; only one tab used to pass it on.
+        """
+        return self.overview is not None and self.overview.is_acquiring
 
     @property
     def microscope(self):
@@ -69,15 +177,71 @@ class AutoLamellaOverviewTabBase(QWidget):
     def experiment(self):
         return self.autolamella_ui.experiment if self.autolamella_ui is not None else None
 
-    def refresh_positions(self) -> None:
-        """Mark the experiment's lamellae on the canvas, at this tab's own pose.
+    def refresh_microscope(self) -> None:
+        """Build, rebuild or drop the overview widget to match the instrument.
 
-        Left to the subclass: the pose is the difference between the two tabs, and on a
-        compustage the milling and fluorescence poses share x, y, z **and** r, differing
-        only in tilt. Marking the wrong one puts every lamella on the far side of the
-        grid while looking entirely plausible.
+        Called on every connection. Rebuilds when the microscope object has changed,
+        because the widget holds its microscope for life and would otherwise be talking
+        to the previous one.
         """
-        raise NotImplementedError
+        microscope = self.microscope
+        if microscope is None or not self._can_build(microscope):
+            self._drop_overview()
+            self.availability_changed.emit(False)
+            return
+
+        if self.overview is not None:
+            if self._microscope is microscope:
+                return
+            self._drop_overview()
+
+        try:
+            self.overview = self._build_overview(microscope)
+        except Exception as e:
+            logger.error(f"Could not create the {self.OVERVIEW_NOUN} tab: {e}")
+            self.availability_changed.emit(False)
+            return
+
+        self.overview.position_add_requested.connect(self._on_add_requested)
+        self.overview.position_move_requested.connect(self._on_move_requested)
+        self.overview.position_selected.connect(self._on_marker_clicked)
+        # In the settings column rather than beside it: the positions are the subject of
+        # this tab, and a column of their own would read as a third pane.
+        self.overview.add_settings_section("Lamella Positions", self.lamella_list)
+
+        self._microscope = microscope
+        self.layout().addWidget(self.overview)
+        self.availability_changed.emit(True)
+        self.refresh_experiment()
+
+    def _drop_overview(self) -> None:
+        """Retire the current overview widget, if there is one.
+
+        `close()` rather than `deleteLater()` alone: the widget's `closeEvent` is what
+        releases its psygnal subscriptions on the microscope, and those outlive the
+        widget -- a stale one left connected emits into a torn-down Qt object.
+        """
+        if self.overview is None:
+            return
+        # Taken back before the widget goes. `add_settings_section` reparents the list
+        # into the overview's column, so Qt destroying the overview would destroy the
+        # list with it, and the next `refresh_microscope` would hand a dead C++ object
+        # to `add_settings_section`. The list belongs to this tab and outlives any one
+        # overview, so it is moved out rather than left to be collected.
+        #
+        # Kept as a precondition rather than because a test proves it: under the
+        # offscreen platform the deferred delete does not actually run, so the failure
+        # it prevents cannot be reproduced there.
+        self.lamella_list.setParent(self)
+        self.lamella_list.hide()
+        try:
+            self.overview.close()
+        except Exception as e:
+            logger.debug(f"Error closing the {self.OVERVIEW_NOUN} widget: {e}")
+        self.layout().removeWidget(self.overview)
+        self.overview.deleteLater()
+        self.overview = None
+        self._microscope = None
 
     def refresh_experiment(self) -> None:
         """Tell the overview widget where to save, and what to mark."""
@@ -88,6 +252,44 @@ class AutoLamellaOverviewTabBase(QWidget):
             str(experiment.path) if experiment is not None else None
         )
         self.refresh_positions()
+
+    def refresh_positions(self) -> None:
+        """Mark the experiment's lamellae on the canvas, at this tab's own pose.
+
+        Every lamella reaches the list, including the ones the canvas cannot place: the
+        list is how you find out that a lamella exists but has no pose for this view.
+        Dropping those from both would leave the log as the only place that says so.
+        """
+        if self.overview is None:
+            return
+        experiment = self.experiment
+        if experiment is None:
+            self.overview.set_positions([])
+            self.lamella_list.set_lamella([])
+            return
+
+        lamellae = list(experiment.positions)
+        self.lamella_list.set_lamella(lamellae)
+
+        positions, unplaceable = [], []
+        for lamella in lamellae:
+            place = self._pose_of(lamella)
+            if place is None:
+                unplaceable.append(lamella.name)
+                continue
+            # Named here rather than relying on whatever the stored position carries:
+            # the marker's label is the lamella's name, and a pose saved before names
+            # were stamped on positions would otherwise draw an unlabelled marker.
+            position = deepcopy(place)
+            position.name = lamella.name
+            positions.append(position)
+
+        self._show_positions(positions, lamellae)
+        if unplaceable:
+            logger.info(
+                f"{len(unplaceable)} lamella(e) have no {self.POSE_NOUN} and are not "
+                f"shown on the {self.OVERVIEW_NOUN}: {', '.join(unplaceable)}"
+            )
 
     def set_selected(self, lamella) -> None:
         """Highlight the selected lamella.
@@ -156,10 +358,64 @@ class AutoLamellaOverviewTabBase(QWidget):
         finally:
             self._syncing_selection = False
 
-    # Set by the subclass, in its own `__init__`. Annotations only -- they document
-    # the contract and enforce nothing, so a subclass that forgets one fails on the
-    # first click rather than at construction.
-    autolamella_ui: object
-    overview: Optional[QWidget]
-    lamella_list: QWidget
-    _syncing_selection: bool
+    def _on_move_to_requested(self, lamella) -> None:
+        """Drive the stage to a lamella's pose, as this tab means it.
+
+        Not "the lamella's position": moving to the milling pose from the fluorescence
+        canvas would swing the stage 180 degrees away from the view you asked to centre,
+        and vice versa.
+        """
+        if lamella is None or self.overview is None:
+            return
+        place = self._pose_of(lamella)
+        if place is None:
+            notification_service.show_toast(
+                f"{lamella.name} has no {self.POSE_NOUN} to move to.", "warning"
+            )
+            return
+        self.overview.move_to(place)
+
+    def _on_remove_requested(self, lamella) -> None:
+        """Remove a lamella from the experiment.
+
+        The row's own button already asked -- `_LamellaRow._on_remove_clicked` puts up
+        the confirmation before it emits -- so this does not ask twice.
+
+        Re-marks the canvas afterwards. The window rebuilds displays off the experiment's
+        `removed` event too, so for one of the two tabs this is a second redraw of the
+        same set; that is the safe direction to be wrong in, and the asymmetry where only
+        one tab was covered is what made this worth sharing.
+        """
+        experiment = self.experiment
+        if experiment is None or lamella is None:
+            return
+        try:
+            experiment.positions.remove(lamella)
+        except ValueError:
+            logger.debug(f"Cannot remove {lamella.name!r}: not in the experiment.")
+            return
+        experiment.save()
+        self.refresh_positions()
+        notification_service.show_toast(f"Removed {lamella.name}.", "info")
+
+    # ── turning a request into a lamella ─────────────────────────────────
+
+    def _on_add_requested(self, position) -> None:
+        """A user asked for a new lamella at a point on the overview."""
+        if self.autolamella_ui is None or self.experiment is None:
+            notification_service.show_toast(
+                "Load an experiment before marking positions.", "warning"
+            )
+            return
+        try:
+            lamella = self.autolamella_ui.add_new_lamella(
+                stage_position=position, **self._add_lamella_kwargs()
+            )
+        except Exception as e:
+            logger.error(f"Could not add a lamella from the {self.OVERVIEW_NOUN}: {e}")
+            notification_service.show_toast(str(e), "error")
+            return
+
+        self.refresh_positions()
+        self.set_selected(lamella)
+        notification_service.show_toast(f"Added {lamella.name}.", "info")

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1785,7 +1785,7 @@ class _StubHost:
     _refresh_fm_overview_microscope = _Real._refresh_fm_overview_microscope
     _on_fm_overview_availability = _Real._on_fm_overview_availability
     _fm_overview_unavailable_reason = _Real._fm_overview_unavailable_reason
-    _refresh_fm_overview_positions = _Real._refresh_fm_overview_positions
+    _refresh_overview_positions = _Real._refresh_overview_positions
     _on_fm_overview_lamella_selected = _Real._on_fm_overview_lamella_selected
     _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
     _rebuild_lamella_list = _Real._rebuild_lamella_list
@@ -1825,7 +1825,7 @@ class _StubHost:
         self.fm_overview_tab.refresh_experiment()
 
     def _update_fm_overview_positions(self):
-        self._refresh_fm_overview_positions()
+        self._refresh_overview_positions()
 
     def _update_fm_overview_selection(self, lamella):
         self.fm_overview_tab.set_selected(lamella)

--- a/tests/ui/test_overview_tab_host.py
+++ b/tests/ui/test_overview_tab_host.py
@@ -353,3 +353,97 @@ class TestTheFlagOff:
         first = tab.overview
         tab.set_enabled(True)
         assert tab.overview is first, "rebuilt on an unchanged flag"
+
+
+@pytest.fixture
+def fm_tab(microscope, tmp_path):
+    """The fluorescence tab against the same stub window, so the two can be compared.
+
+    Added with the pose hook (FIB-709): once both tabs answer `_pose_of`, the question
+    "does this tab mark its own pose" is one test shape, and asking it of only one of
+    them is how the mistake it guards against would reach the other.
+    """
+    from fibsem.applications.autolamella.ui.autolamella_fluorescence_overview_tab import (
+        AutoLamellaFluorescenceOverviewTab,
+    )
+
+    experiment = Experiment(path=tmp_path, name="fm-overview-tab-test")
+    os.makedirs(str(experiment.path), exist_ok=True)
+    window = _StubWindow(microscope, experiment)
+    tab = AutoLamellaFluorescenceOverviewTab(window)
+    tab.refresh_microscope()
+    assert tab.is_available, "the fluorescence tab did not build its widget"
+    yield tab
+    tab._drop_overview()
+
+
+class TestItMarksTheFluorescenceSidePose:
+    """The mirror of `TestItMarksTheBeamSidePose`, and the reason `_pose_of` is a hook.
+
+    Both tabs now inherit `refresh_positions`, so the only thing deciding what each one
+    marks is one small method. A mistake there is invisible to any assertion on x/y --
+    see the beam-side test for the measurement.
+    """
+
+    def test_a_lamella_is_marked_at_its_fluorescence_pose(self, fm_tab, microscope):
+        lamella = _lamella(fm_tab, microscope, dx=90e-6)
+        fm_tab.refresh_positions()
+
+        marked = fm_tab.overview._positions
+        assert [p.name for p in marked] == [lamella.name]
+
+        milling_tilt = lamella.milling_pose.stage_position.t
+        fluorescence_tilt = lamella.fluorescence_pose.stage_position.t
+        assert milling_tilt != pytest.approx(fluorescence_tilt), (
+            "the two poses are indistinguishable on this microscope, so this test "
+            "cannot check which one was used"
+        )
+        assert marked[0].t == pytest.approx(fluorescence_tilt), (
+            "the marker carries the milling pose, not the fluorescence one"
+        )
+
+    def test_a_lamella_with_no_fluorescence_pose_is_listed_but_not_marked(
+        self, fm_tab, microscope
+    ):
+        """It cannot be placed on this canvas, and it must not vanish from the list --
+        which is the only place that says it exists at all."""
+        lamella = _lamella(fm_tab, microscope, dx=70e-6)
+        # Dropped from the pose dict rather than assigned None -- the setter takes only
+        # a `MicroscopeState`, and an experiment saved before fluorescence poses existed
+        # simply has no such key. This is that lamella.
+        lamella.poses.pop("FLUORESCENCE", None)
+        fm_tab.refresh_positions()
+
+        assert fm_tab.overview._positions == []
+        assert [row.lamella.name for row in fm_tab.lamella_list._rows()] == [lamella.name]
+
+    def test_move_to_drives_to_the_fluorescence_pose(self, fm_tab, microscope):
+        """Moving to the milling pose from here would swing the stage 180 degrees away
+        from the view being centred."""
+        lamella = _lamella(fm_tab, microscope, dx=40e-6)
+        drove_to = []
+        fm_tab.overview.move_to = drove_to.append
+
+        fm_tab._on_move_to_requested(lamella)
+
+        assert len(drove_to) == 1
+        assert drove_to[0].t == pytest.approx(
+            lamella.fluorescence_pose.stage_position.t
+        )
+
+
+class TestBothTabsAnswerIsAcquiring:
+    """Whether a run is in progress has to be askable of *either* tab.
+
+    The window has to know before it lets anything drive the stage: a click-to-move on
+    one overview while the other is mid-tileset does not fail loudly, it stamps tiles
+    with poses the runner only planned (FIB-706). Only the beam tab used to answer.
+    """
+
+    def test_neither_is_acquiring_when_idle(self, tab, fm_tab):
+        assert tab.is_acquiring is False
+        assert fm_tab.is_acquiring is False
+
+    def test_a_tab_with_no_widget_is_not_acquiring(self, tab):
+        tab._drop_overview()
+        assert tab.is_acquiring is False

--- a/tests/ui/test_overview_tab_wiring.py
+++ b/tests/ui/test_overview_tab_wiring.py
@@ -297,14 +297,20 @@ def test_the_two_host_tabs_share_one_base():
     version of this test imported the classes and turned the whole run red on every
     platform.
 
-    Only the methods whose code was byte-identical moved (FIB-697), so this asserts the
-    ones that did and deliberately *not* the ones that did not: `refresh_positions` and
-    the request handlers differ because of which pose they read, and pretending
-    otherwise is how the two tabs would come to mark different things.
+    The first pass moved only the methods whose code was byte-identical (FIB-697); the
+    second moved the ones that differed solely in *which pose they read*, behind the
+    `_pose_of` hook (FIB-709). What is left below is the whole shared surface, and a
+    subclass defining any of it again is a subclass that can drift.
+
+    `_on_move_requested` is deliberately absent: dragging a marker writes one pose on
+    one tab and derives both on the other, after asking. Those are different operations
+    sharing a name.
     """
-    shared = {"is_available", "microscope", "experiment", "refresh_experiment",
-              "set_selected", "set_interactive", "_on_list_selection",
-              "_on_marker_clicked"}
+    shared = {"is_available", "is_acquiring", "microscope", "experiment",
+              "refresh_experiment", "refresh_microscope", "refresh_positions",
+              "set_selected", "set_interactive", "_drop_overview",
+              "_on_list_selection", "_on_marker_clicked", "_on_move_to_requested",
+              "_on_add_requested", "_on_remove_requested"}
 
     for name, path in HOST_TABS.items():
         cls = _class_def(path, name)
@@ -318,10 +324,11 @@ def test_the_two_host_tabs_share_one_base():
             f"{name} defines {sorted(again)} again; the base is what stops the two tabs "
             "drifting apart"
         )
-        # The pose is the difference between the tabs, so each must still answer it.
-        assert "refresh_positions" in defined, (
-            f"{name} inherits refresh_positions, which would mark nothing"
-        )
+        # The pose is the difference between the tabs, so each must still answer it --
+        # inheriting `_pose_of` would raise on the first lamella, and a subclass that
+        # somehow satisfied it generically would be marking one tab's poses on both.
+        for hook in ("_pose_of", "_build_overview", "_on_move_requested"):
+            assert hook in defined, f"{name} does not answer {hook}"
 
         # Both signals are declared once, on the base. A subclass redeclaring one
         # shadows it, and the window connects to whichever it happens to see first.
@@ -337,3 +344,44 @@ def test_the_base_owns_the_signals_the_window_connects_to():
     assigned = {t.id for n in base.body if isinstance(n, ast.Assign)
                 for t in n.targets if isinstance(t, ast.Name)}
     assert {"availability_changed", "lamella_selected"} <= assigned
+
+
+def test_a_lamella_added_anywhere_reaches_both_canvases(window_source):
+    """The window's position-change handler has to re-mark *both* overviews.
+
+    Neither tab subscribes to the experiment itself -- deliberately, since a tab is
+    rebuilt when the microscope changes and a subscription holding the old one's bound
+    method would be stale and undisconnectable -- so this handler is the only thing that
+    can see a lamella added, removed or re-posed anywhere in the window.
+
+    It reached only the fluorescence tab. The beam tab papered over its own edits by
+    re-marking inline, and went stale for everything else: a lamella marked on the FM
+    overview, added from the Microscope tab, or moved by a workflow, none of which
+    appeared on the FIB/SEM canvas (FIB-709). That is the mirror of the bug
+    `_wire_position_events` was written to fix, and it survived because the parity test
+    above lists the calls the window makes *directly* on each tab, and this one is made
+    through a handler.
+    """
+    tree = ast.parse(window_source)
+    handler = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == "_refresh_overview_positions"),
+        None,
+    )
+    assert handler is not None, (
+        "the window has no `_refresh_overview_positions`; if it was renamed, this test "
+        "and the events wired to it need to follow"
+    )
+
+    # Read as text rather than by attribute access: the handler loops over tab names, so
+    # `self.<tab>.refresh_positions` never appears as an attribute chain to walk.
+    body = ast.get_source_segment(window_source, handler) or ""
+    for tab in (TWIN, NEW):
+        assert tab in body, f"{tab} is not re-marked when the experiment's lamellae change"
+    assert "refresh_positions" in body
+
+    # And the handler has to be what the experiment's events actually reach.
+    for event in ("inserted", "removed", "changed"):
+        assert f"events.{event}.connect" in window_source, (
+            f"nothing follows the experiment's `{event}` event any more"
+        )


### PR DESCRIPTION
Second half of FIB-697. The first pass moved only the methods whose code was byte-identical, so it could not change behaviour; this is the part that needed a design decision, which is why it was split out.

## The pose is the difference

Almost every remaining difference between the two host tabs was one question asked twice: **which pose does this tab mean?** The beam tab means the milling pose; the fluorescence tab means the fluorescence pose.

```python
def _pose_of(self, lamella) -> Optional[FibsemStagePosition]:
    """Where this tab's canvas puts *lamella*, or None if it cannot place it."""
```

With that in place `refresh_positions`, `_on_move_to_requested` and `_on_add_requested` have one implementation each. Five smaller hooks carry the rest: `_build_overview`, `_can_build` (the beam answers a feature flag, the fluorescence tab a capability — different questions, same build-or-drop shape), `_configure_list`, `_show_positions`, `_add_lamella_kwargs`.

| | before | after |
| -- | -- | -- |
| `autolamella_overview_tab.py` | 295 | 165 |
| `autolamella_fluorescence_overview_tab.py` | 368 | 200 |

**`_on_move_requested` stays written twice, deliberately.** Dragging a marker writes one pose and syncs the other on the beam side; on the fluorescence side it derives both through `build_lamella_poses`, after asking, because from a canvas showing only the fluorescence side it is not visible that the milling pose moves too. Those are different operations sharing a name, and folding them behind a hook would bury the part a reader most needs to see.

`is_acquiring` now answers on **both** tabs. Both widgets always had it; only one tab passed it on, and FIB-706 needs it on both to stop one tab driving the stage while the other acquires.

## The mistake this invites, and how it is guarded

On a compustage the two poses share x, y, z **and** r, differing only in tilt — −23° against −180°. An assertion on position cannot tell them apart.

Guarded by dumping everything both tabs do with a three-lamella experiment (one flagged, one with no fluorescence pose): every marker **with r and t**, every move-to target, the kwargs reaching `add_new_lamella`, both poses after a drag, the milling angle, the toasts, and a disconnect/reconnect cycle. The dump is stable across runs on unmodified code, and swapping the fluorescence tab to the milling pose changes **only `t`** — x/y/z identical. Before and after are identical except the two intended entries.

`test_overview_tab_host.py` gains the mirror of the beam tab's existing tilt assertion, so the question "does this tab mark its own pose" is now asked of both subclasses. Mutating `_pose_of` kills three tests.

## A bug the symmetry exposed

The window wired the experiment's position events to a handler that re-marked **only the fluorescence canvas**. So a lamella marked on the FM overview never appeared on the FIB/SEM one — the mirror of the bug `_wire_position_events` was written to fix, which survived because the beam tab did not exist when that was written.

The beam tab looked correct only because it re-marked itself inline after its *own* edits. It went stale for everything else: a lamella added from the other tab, from the Microscope tab or by a workflow, a lamella removed anywhere, and any pose replaced in place (`changed`). Neither tab subscribes to the experiment itself — deliberately, since a tab is rebuilt when the microscope changes and a subscription holding the old one's bound method would be stale and undisconnectable — so the handler is the only thing that can see all of it. It now covers both tabs, and is named for what it does.

Driven through the real window methods, one click on the fluorescence overview:

```
today:      FM canvas 1 | FIB/SEM canvas 0
with fix:   FM canvas 1 | FIB/SEM canvas 1

FM       Lamella-01: x=+180.0um y=-60.0um r=0.0000 t=-3.1416
FIB/SEM  Lamella-01: x=+180.0um y=-60.0um r=0.0000 t=-0.4014
```

Same x/y, different tilt — each canvas marking its own pose, from one click.

The existing parity test could not have caught this: it checks that every window method calling `fm_overview_tab.X` also calls `overview_canvas_tab.X`, and this call is made inside a handler rather than on the tab. So there is a new test at that level, reading the handler out of the window's AST; reverting the loop to fluorescence-only fails it.

## Verification

- **1800 tests pass.**
- The two AST-based modules pass with PyQt5 unimportable, as CI installs it.
- All touched files parse under Python 3.8.
- Run in the app with the flag on: a position marked on the FM overview appears on the Overview tab.