### PR TITLE
[fix] Stop one overview driving the stage while the other acquires (FIB-706)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import sys
 import time
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 try:
     sys.modules.pop("PySide6.QtCore")
@@ -200,6 +200,12 @@ def confirm_add_to_queue_dialog(
 
 class AutoLamellaSingleWindowUI(QMainWindow):
     """Main window for AutoLamella UI with embedded napari viewers."""
+
+    # Whether a workflow currently permits the overview tabs to work. Held rather than
+    # applied where it arrives, because each tab's interactivity is derived from this
+    # *and* from whether the other tab is acquiring -- and two callers each setting one
+    # control from their own half of the truth is how a control gets stuck on.
+    _overviews_allowed = True
 
     def __init__(self):
         super().__init__()
@@ -1072,20 +1078,72 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.workflow_timeline.set_actions_enabled(False)
 
     def _set_minimap_workflow_enabled(self, enabled: bool):
-        """Enable/disable overview acquisition in both overview tabs during a workflow.
+        """Record whether a workflow currently permits the overviews to work.
 
         A running workflow owns the instrument, so neither tab should be able to start
-        competing for it. The FM tab keeps its Cancel button live regardless -- see
-        `FMOverviewWidget.set_interactive` -- so a lock arriving mid-run cannot strand an
-        acquisition with no way to stop it.
+        competing for it. Both tabs keep their Cancel button live regardless -- see
+        `set_interactive` on either widget -- so a lock arriving mid-run cannot strand
+        an acquisition with no way to stop it.
+
+        The answer is recorded rather than applied: `_apply_overview_locks` is what
+        reaches the tabs, because it is not the only fact that decides.
         """
         if hasattr(self, "minimap_widget"):
             self.minimap_widget.pushButton_run_tile_collection.setEnabled(enabled)
             self.minimap_widget.pushButton_load_image.setEnabled(enabled)
-        if getattr(self, "fm_overview_tab", None) is not None:
-            self.fm_overview_tab.set_interactive(enabled)
-        if getattr(self, "overview_canvas_tab", None) is not None:
-            self.overview_canvas_tab.set_interactive(enabled)
+        self._overviews_allowed = bool(enabled)
+        self._apply_overview_locks()
+
+    def _apply_overview_locks(self, *_) -> None:
+        """Decide, for each overview tab, whether it may work right now.
+
+        Two facts, and both have to be answered in one place. A workflow owning the
+        instrument is one; the *other* overview being mid-run is the other, and it was
+        not asked at all. Each tab locked itself while it ran, so nothing stopped a
+        click-to-move on the beam overview during a fluorescence tileset -- and that
+        does not fail loudly. The runner goes on placing tiles at the poses it planned,
+        so the mosaic comes out plausible and wrong (FIB-706).
+
+        Derived from both every time rather than each caller setting the flag it knows
+        about: a workflow finishing while an overview runs must not re-enable the other
+        tab, and a run finishing inside a locked window must not either.
+
+        Takes and ignores an argument so it can be connected straight to
+        `acquiring_changed`, whose bool it deliberately does not read -- it asks the tabs
+        instead, so a missed or duplicated signal cannot leave this holding a state the
+        tabs disagree with.
+
+        Written out per tab rather than looped, so that `test_overview_tab_wiring.py`
+        can still see `self.<tab>.set_interactive` in the window's source. That test is
+        the parity check between the two tabs and one of the few CI runs without PyQt5;
+        a loop over local variables hides the calls from it.
+        """
+        fm = getattr(self, "fm_overview_tab", None)
+        beam = getattr(self, "overview_canvas_tab", None)
+        if fm is not None:
+            allowed, reason = self._overview_may_work(beam)
+            self.fm_overview_tab.set_interactive(allowed, reason)
+        if beam is not None:
+            allowed, reason = self._overview_may_work(fm)
+            self.overview_canvas_tab.set_interactive(allowed, reason)
+
+    def _overview_may_work(self, other) -> Tuple[bool, str]:
+        """Whether an overview tab may work given what *other* is doing, and why not.
+
+        The reason travels with the answer because the widget cannot work it out: both
+        causes are the same `False` by the time they reach it, and a refusal that blames
+        a workflow when the real reason is the other overview sends someone looking in
+        the wrong place.
+
+        The workflow is named first when both hold. It is the outer authority -- the
+        overview run would not have started under it -- so it is the fact that has to
+        change first.
+        """
+        if not self._overviews_allowed:
+            return False, "a workflow is running"
+        if other is not None and other.is_acquiring:
+            return False, "the other overview is acquiring"
+        return True, ""
 
     def _set_border_state(self, state: str):
         """Update the tab widget border to reflect current workflow state.
@@ -2321,6 +2379,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self._on_fm_overview_availability
         )
         self.fm_overview_tab.lamella_selected.connect(self._on_fm_overview_lamella_selected)
+        self.fm_overview_tab.acquiring_changed.connect(self._apply_overview_locks)
 
         self.tab_widget.insertTab(
             2, self.fm_overview_tab,
@@ -2352,6 +2411,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.overview_canvas_tab.lamella_selected.connect(
             self._on_overview_canvas_lamella_selected
         )
+        self.overview_canvas_tab.acquiring_changed.connect(self._apply_overview_locks)
 
         self.tab_widget.insertTab(
             3, self.overview_canvas_tab,

--- a/fibsem/applications/autolamella/ui/overview_tab_base.py
+++ b/fibsem/applications/autolamella/ui/overview_tab_base.py
@@ -69,6 +69,11 @@ class AutoLamellaOverviewTabBase(QWidget):
     # lists; nothing here selects them directly, which is what keeps the sync in one
     # place instead of four.
     lamella_selected = pyqtSignal(object)
+    # Whether a run is in progress in this tab, forwarded from the widget. The window
+    # listens so it can stop the *other* overview taking the stage (FIB-706); it
+    # connects to the tab rather than the widget because the widget is rebuilt on every
+    # reconnection and a subscription to the old one would be stale and undisconnectable.
+    acquiring_changed = pyqtSignal(bool)
 
     # What this canvas marks, in the words a message needs: "has no fluorescence pose to
     # move to" against "has no position to move to". A user reading the second one on the
@@ -205,6 +210,9 @@ class AutoLamellaOverviewTabBase(QWidget):
         self.overview.position_add_requested.connect(self._on_add_requested)
         self.overview.position_move_requested.connect(self._on_move_requested)
         self.overview.position_selected.connect(self._on_marker_clicked)
+        # Signal to signal: the widget's answer is this tab's answer, and forwarding it
+        # by hand would be a second place for the two to disagree.
+        self.overview.acquiring_changed.connect(self.acquiring_changed)
         # In the settings column rather than beside it: the positions are the subject of
         # this tab, and a column of their own would read as a third pane.
         self.overview.add_settings_section("Lamella Positions", self.lamella_list)
@@ -242,6 +250,11 @@ class AutoLamellaOverviewTabBase(QWidget):
         self.overview.deleteLater()
         self.overview = None
         self._microscope = None
+        # A tab with no widget is certainly not acquiring, and nothing else will say so:
+        # the widget that would have emitted it is the one just dropped. Without this a
+        # host that locked the other tab during a run would hold that lock forever if
+        # the running tab were dropped -- a reconnection mid-run does exactly that.
+        self.acquiring_changed.emit(False)
 
     def refresh_experiment(self) -> None:
         """Tell the overview widget where to save, and what to mark."""
@@ -307,11 +320,16 @@ class AutoLamellaOverviewTabBase(QWidget):
         if not self._syncing_selection and lamella is not None:
             self.lamella_list.select(lamella.name)
 
-    def set_interactive(self, enabled: bool) -> None:
-        """Allow or forbid starting work, for a host that has taken the instrument."""
+    def set_interactive(self, enabled: bool, reason: str = "") -> None:
+        """Allow or forbid starting work, for a host that has taken the instrument.
+
+        *reason* is carried through to the widget, which quotes it when it refuses a
+        move: the widget sees one `False` whether a workflow owns the instrument or the
+        other overview is mid-run, and only the host knows which.
+        """
         if self.overview is None:
             return
-        self.overview.set_interactive(enabled)
+        self.overview.set_interactive(enabled, reason)
 
     # ── the list ─────────────────────────────────────────────────────────
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -175,6 +175,12 @@ class FMOverviewWidget(QWidget):
     """Configure, run and view a fluorescence overview acquisition."""
 
     overview_acquired = pyqtSignal(FluorescenceImage)
+    # Whether a run is in progress here. A *state*, re-emitted on every change
+    # rather than an edge, so a host that connects late or recomputes from
+    # several facts cannot end up holding a stale answer. The host that matters
+    # is the window, which must stop the other overview driving the stage while
+    # this one is mid-tileset (FIB-706).
+    acquiring_changed = pyqtSignal(bool)
 
     # A user right-clicked the canvas and asked for a position there. Both carry a
     # *fluorescence* stage position -- the canvas is anchored on the FM side, and both
@@ -269,6 +275,7 @@ class FMOverviewWidget(QWidget):
         # re-enable a tab whose acquisition is still going, nor the reverse. See
         # `_apply_enabled_state`, which is the only thing that reads them.
         self._running = False
+        self._lock_reason = "a workflow is running"
         self._interactive = True
 
         self._init_ui(channel_settings or self._default_channels())
@@ -557,7 +564,19 @@ class FMOverviewWidget(QWidget):
 
     @property
     def is_acquiring(self) -> bool:
-        return self._worker is not None and self._worker.is_alive()
+        """Whether an overview acquisition is running here.
+
+        `_running` as well as the worker, and the order is why: `acquire` calls
+        `_set_running(True)` *before* it builds the worker, so for the width of that
+        gap a worker-only answer says no while a run is starting. That gap is exactly
+        when `acquiring_changed` is emitted, so a host locking the other overview off
+        this property got False and locked nothing (FIB-706).
+
+        Keeping the worker check as well as the flag, rather than replacing it: the
+        union is true over a superset of the interval either is, and every caller is a
+        guard, so being early and late is the safe direction to be wrong in.
+        """
+        return self._running or (self._worker is not None and self._worker.is_alive())
 
     @property
     def channels(self) -> List[ChannelSettings]:
@@ -1068,7 +1087,7 @@ class FMOverviewWidget(QWidget):
         """Where the last acquired overview was written, if it was."""
         return self._saved_path
 
-    def set_interactive(self, enabled: bool) -> None:
+    def set_interactive(self, enabled: bool, reason: str = "") -> None:
         """Allow or forbid starting work, without touching a run already in progress.
 
         For a host that owns the instrument for a while -- an AutoLamella workflow --
@@ -1078,8 +1097,15 @@ class FMOverviewWidget(QWidget):
         Deliberately not `setEnabled(False)` on the whole widget: greying out the canvas
         would also stop you *reading* the overview you just acquired, and looking at it
         costs the workflow nothing.
+
+        *reason* completes the sentence "Cannot move the stage while ___" when a move is
+        refused. The widget cannot know why it was locked -- a workflow owning the
+        instrument and the other overview being mid-tileset are the same `False` here --
+        and a refusal naming the wrong one is barely better than one naming nothing
+        (FIB-706).
         """
         self._interactive = enabled
+        self._lock_reason = reason or "a workflow is running"
         self._apply_enabled_state()
 
     def set_origin(self, position: Optional[FibsemStagePosition]) -> None:
@@ -1727,6 +1753,15 @@ class FMOverviewWidget(QWidget):
                 "Cannot move the stage during an acquisition.", "warning"
             )
             return False
+        if not self._interactive:
+            # The lock reached the buttons and not the canvas, so a workflow that owned
+            # the instrument could still have the stage driven out from under it by a
+            # double-click. The beam widget refused this from the start; the two now
+            # agree, which is what lets the window lock either tab and mean it (FIB-706).
+            notification_service.show_toast(
+                f"Cannot move the stage while {self._lock_reason}.", "warning"
+            )
+            return False
         if not self.at_acquisition_orientation():
             notification_service.show_toast(
                 f"Cannot move the stage from {self._where_the_stage_is()} — the "
@@ -2245,6 +2280,7 @@ class FMOverviewWidget(QWidget):
     def _set_running(self, running: bool) -> None:
         self._running = running
         self._apply_enabled_state()
+        self.acquiring_changed.emit(running)
         if running:
             # Cleared at the start, so a run that fails to save cannot inherit the
             # previous run's path and report itself saved.

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -465,6 +465,12 @@ class FibsemOverviewWidget(QWidget):
     """Configure, run and view a tiled FIB/SEM overview on a real-space canvas."""
 
     overview_acquired = pyqtSignal(object)  # FibsemImage (the stitched mosaic)
+    # Whether a run is in progress here. A *state*, re-emitted on every change
+    # rather than an edge, so a host that connects late or recomputes from
+    # several facts cannot end up holding a stale answer. The host that matters
+    # is the window, which must stop the other overview driving the stage while
+    # this one is mid-tileset (FIB-706).
+    acquiring_changed = pyqtSignal(bool)
 
     # A user right-clicked the canvas and asked for a position there. Requests, not
     # commands: this widget knows nothing about lamellae, so a host that owns an
@@ -542,6 +548,7 @@ class FibsemOverviewWidget(QWidget):
         # Two independent facts kept apart on purpose: a workflow ending must not
         # re-enable a tab whose acquisition is still going, nor the reverse.
         self._running = False
+        self._lock_reason = "a workflow is running"
         self._interactive = True
         self._tiles_acquired = 0
 
@@ -1136,7 +1143,19 @@ class FibsemOverviewWidget(QWidget):
 
     @property
     def is_acquiring(self) -> bool:
-        return self._worker is not None and self._worker.is_alive()
+        """Whether an overview acquisition is running here.
+
+        `_running` as well as the worker, and the order is why: `acquire` calls
+        `_set_running(True)` *before* it builds the worker, so for the width of that
+        gap a worker-only answer says no while a run is starting. That gap is exactly
+        when `acquiring_changed` is emitted, so a host locking the other overview off
+        this property got False and locked nothing (FIB-706).
+
+        Keeping the worker check as well as the flag, rather than replacing it: the
+        union is true over a superset of the interval either is, and every caller is a
+        guard, so being early and late is the safe direction to be wrong in.
+        """
+        return self._running or (self._worker is not None and self._worker.is_alive())
 
     def _settings(self) -> Optional[OverviewAcquisitionSettings]:
         """The planned acquisition, read from the settings widget.
@@ -1212,9 +1231,17 @@ class FibsemOverviewWidget(QWidget):
             except Exception as e:
                 logger.debug(f"Could not show the save directory: {e}")
 
-    def set_interactive(self, enabled: bool) -> None:
-        """Allow or forbid starting work, for a host that has taken the instrument."""
+    def set_interactive(self, enabled: bool, reason: str = "") -> None:
+        """Allow or forbid starting work, for a host that has taken the instrument.
+
+        *reason* completes the sentence "Cannot move the stage while ___" when a move is
+        refused. The widget cannot know why it was locked -- a workflow owning the
+        instrument and the other overview being mid-tileset are the same `False` here --
+        and a refusal naming the wrong one is barely better than one naming nothing
+        (FIB-706).
+        """
         self._interactive = bool(enabled)
+        self._lock_reason = reason or "a workflow is running"
         self._apply_enabled_state()
 
     def _apply_enabled_state(self) -> None:
@@ -2332,11 +2359,14 @@ class FibsemOverviewWidget(QWidget):
             logger.debug(f"Could not read the stage position: {e}")
 
     def move_to(self, position: FibsemStagePosition) -> None:
-        """Drive the stage to a position, off the GUI thread."""
-        if self.is_acquiring:
-            notification_service.show_toast(
-                "Cannot move the stage during an acquisition.", "warning"
-            )
+        """Drive the stage to a position, off the GUI thread.
+
+        Public because a host drives it too -- picking a lamella out of a list is the
+        same act as double-clicking where it is drawn, so it goes through the same gate.
+        It used to ask only whether *this* widget was acquiring, which let a host move
+        the stage in cases a user clicking the canvas was refused.
+        """
+        if not self._may_move():
             return
         worker = FunctionWorker(self._move_worker, position)
         worker.start()
@@ -2423,7 +2453,7 @@ class FibsemOverviewWidget(QWidget):
             return False
         if not self._interactive:
             notification_service.show_toast(
-                "Cannot move the stage while a workflow is running.", "warning"
+                f"Cannot move the stage while {self._lock_reason}.", "warning"
             )
             return False
         return True
@@ -2726,6 +2756,7 @@ class FibsemOverviewWidget(QWidget):
     def _set_running(self, running: bool) -> None:
         self._running = running
         self._apply_enabled_state()
+        self.acquiring_changed.emit(running)
         if running:
             # The framing you pressed Acquire with is the framing you keep. A run is the
             # worst moment to re-frame: the preview lands under one key and the stitch
@@ -2749,8 +2780,7 @@ class FibsemOverviewWidget(QWidget):
     def _on_finished(self, result: dict) -> None:
         self._worker = None
         self._stop_event.clear()
-        self._running = False
-        self._apply_enabled_state()
+        self._set_running(False)
         # The bar has done its job; the label below it carries the outcome from here.
         self.progress.reset()
         if result.get("error"):

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1788,6 +1788,9 @@ class _StubHost:
     _refresh_overview_positions = _Real._refresh_overview_positions
     _on_fm_overview_lamella_selected = _Real._on_fm_overview_lamella_selected
     _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
+    _apply_overview_locks = _Real._apply_overview_locks
+    _overview_may_work = _Real._overview_may_work
+    _overviews_allowed = _Real._overviews_allowed
     _rebuild_lamella_list = _Real._rebuild_lamella_list
     _wire_position_events = _Real._wire_position_events
 
@@ -4737,3 +4740,66 @@ def test_the_column_opens_at_the_dataclass_default_overlap(qapp):
 
     assert widget.parameters.overlap == OverviewParameters().overlap == 0.1
     assert "10" in widget.grid.spin_overlap.text()
+
+
+class TestTheLockReachesTheCanvasToo:
+    """`set_interactive` gated the buttons and not the canvas.
+
+    So a workflow that owned the instrument could still have the stage driven out from
+    under it by a double-click on this overview -- the beam widget refused that from the
+    start, and the two disagreeing is what made a window-level lock unreliable (FIB-706).
+    """
+
+    def test_a_locked_widget_refuses_to_move(self, interactive_widget, monkeypatch):
+        widget = interactive_widget
+        toasts = []
+        monkeypatch.setattr(
+            "fibsem.ui.fm.widgets.fm_overview_widget.notification_service.show_toast",
+            lambda message, level="info", *a, **k: toasts.append((message, level)),
+        )
+        widget.set_interactive(False)
+        try:
+            assert widget._may_move() is False
+        finally:
+            widget.set_interactive(True)
+        # Refused for the stated reason, not incidentally by the orientation check that
+        # follows it -- which would pass this test while leaving the hole open.
+        assert any("workflow" in message for message, _ in toasts), toasts
+
+    def test_an_unlocked_widget_is_not_refused_for_that_reason(
+        self, interactive_widget, monkeypatch
+    ):
+        widget = interactive_widget
+        toasts = []
+        monkeypatch.setattr(
+            "fibsem.ui.fm.widgets.fm_overview_widget.notification_service.show_toast",
+            lambda message, level="info", *a, **k: toasts.append((message, level)),
+        )
+        widget.set_interactive(True)
+        widget._may_move()
+        assert not any("workflow" in message for message, _ in toasts), toasts
+
+
+class TestSayingWhenARunStarts:
+    """The signal a host locks the other overview off, and the trap underneath it:
+    `acquire()` sets the flag before it builds the worker, so a worker-only
+    `is_acquiring` said no at the exact moment the signal said yes."""
+
+    def test_the_signal_reports_the_new_state(self, interactive_widget):
+        seen = []
+        widget = interactive_widget
+        widget.acquiring_changed.connect(seen.append)
+        widget._set_running(True)
+        widget._set_running(False)
+        assert seen == [True, False]
+
+    def test_is_acquiring_already_agrees_when_the_signal_arrives(self, interactive_widget):
+        widget = interactive_widget
+        answers = []
+        widget.acquiring_changed.connect(lambda _: answers.append(widget.is_acquiring))
+        widget._set_running(True)
+        try:
+            assert answers == [True], "the widget announced a run it does not admit to"
+        finally:
+            widget._set_running(False)
+        assert answers == [True, False]

--- a/tests/ui/test_overview_tab_host.py
+++ b/tests/ui/test_overview_tab_host.py
@@ -447,3 +447,116 @@ class TestBothTabsAnswerIsAcquiring:
     def test_a_tab_with_no_widget_is_not_acquiring(self, tab):
         tab._drop_overview()
         assert tab.is_acquiring is False
+
+
+@pytest.fixture
+def locked_pair(tab, fm_tab):
+    """Both tabs under a host that derives their locks the way the window does.
+
+    The window itself cannot be built here (napari), so its two decision methods are
+    borrowed rather than reimplemented -- if the rule changes, this moves with it. That
+    the real window *connects* the signal to that rule is checked separately, in
+    `test_overview_tab_wiring.py`, because a fixture wiring it by hand would go on
+    passing if production stopped.
+    """
+    from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+        AutoLamellaSingleWindowUI as _Real,
+    )
+
+    class _Host:
+        _overviews_allowed = _Real._overviews_allowed
+        _apply_overview_locks = _Real._apply_overview_locks
+        _overview_may_work = _Real._overview_may_work
+        _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
+
+        def __init__(self, beam, fluorescence):
+            self.overview_canvas_tab = beam
+            self.fm_overview_tab = fluorescence
+            for one in (beam, fluorescence):
+                one.acquiring_changed.connect(self._apply_overview_locks)
+
+    return _Host(tab, fm_tab), tab, fm_tab
+
+
+class TestOneOverviewDoesNotDriveTheStageWhileTheOtherAcquires:
+    """The failure this prevents does not announce itself.
+
+    A click-to-move on one overview during the other's tileset drives the stage away,
+    and the run carries on placing tiles at the poses it planned -- so the mosaic comes
+    out looking entirely plausible and is wrong (FIB-706).
+    """
+
+    def test_a_fluorescence_run_locks_the_beam_tab(self, locked_pair, monkeypatch):
+        host, beam, fluorescence = locked_pair
+        toasts = []
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.notification_service.show_toast",
+            lambda message, level="info", *a, **k: toasts.append(message),
+        )
+        fluorescence.overview._set_running(True)
+        try:
+            assert beam.overview._may_move() is False
+            assert any("the other overview is acquiring" in m for m in toasts), toasts
+        finally:
+            fluorescence.overview._set_running(False)
+
+    def test_a_beam_run_locks_the_fluorescence_tab(self, locked_pair, monkeypatch):
+        """Asserted on the *reason*, not just the refusal.
+
+        The fluorescence gate also refuses when the stage is away from the fluorescence
+        pose, which it is here -- so "it said no" is a test that passes with the lock
+        removed entirely. It did, until this was written this way.
+        """
+        host, beam, fluorescence = locked_pair
+        toasts = []
+        monkeypatch.setattr(
+            "fibsem.ui.fm.widgets.fm_overview_widget.notification_service.show_toast",
+            lambda message, level="info", *a, **k: toasts.append(message),
+        )
+        beam.overview._set_running(True)
+        try:
+            assert fluorescence.overview._may_move() is False
+            assert any("the other overview is acquiring" in m for m in toasts), toasts
+        finally:
+            beam.overview._set_running(False)
+
+    def test_the_lock_lifts_when_the_run_ends(self, locked_pair):
+        host, beam, fluorescence = locked_pair
+        fluorescence.overview._set_running(True)
+        fluorescence.overview._set_running(False)
+        assert beam.overview._interactive is True
+
+    def test_a_run_does_not_lock_the_tab_running_it(self, locked_pair):
+        """Its own controls are managed by the run itself -- Cancel above all, which a
+        lock must never take away."""
+        host, beam, fluorescence = locked_pair
+        fluorescence.overview._set_running(True)
+        try:
+            assert fluorescence.overview._interactive is True
+        finally:
+            fluorescence.overview._set_running(False)
+
+    def test_a_workflow_ending_mid_run_does_not_unlock_the_other_tab(self, locked_pair):
+        """Both facts, derived together. Two callers each setting the flag from their
+        own half of the truth is how a control gets stuck on: the workflow says "you may
+        work again" while a tileset is still walking the grid."""
+        host, beam, fluorescence = locked_pair
+        host._set_minimap_workflow_enabled(False)
+        fluorescence.overview._set_running(True)
+        try:
+            host._set_minimap_workflow_enabled(True)
+            assert beam.overview._may_move() is False, (
+                "the workflow finishing unlocked a tab the other run still owns"
+            )
+        finally:
+            fluorescence.overview._set_running(False)
+
+    def test_dropping_a_running_tab_does_not_strand_the_lock(self, locked_pair):
+        """A reconnection rebuilds the widget mid-run. The widget that would have said
+        the run ended is the one being destroyed, so the tab says it instead -- without
+        which the other overview stays locked for the rest of the session."""
+        host, beam, fluorescence = locked_pair
+        fluorescence.overview._set_running(True)
+        assert beam.overview._may_move() is False
+        fluorescence._drop_overview()
+        assert beam.overview._may_move() is True

--- a/tests/ui/test_overview_tab_wiring.py
+++ b/tests/ui/test_overview_tab_wiring.py
@@ -385,3 +385,21 @@ def test_a_lamella_added_anywhere_reaches_both_canvases(window_source):
         assert f"events.{event}.connect" in window_source, (
             f"nothing follows the experiment's `{event}` event any more"
         )
+
+
+def test_both_tabs_tell_the_window_when_they_start_acquiring(window_source):
+    """The cross-tab stage lock is derived from both tabs, so both have to report.
+
+    `test_overview_tab_host.py` checks the rule itself against real widgets, with the
+    signal connected by the fixture. That fixture cannot notice production forgetting to
+    connect it -- which is the likely failure, since the connection lives in each tab's
+    builder rather than anywhere the two are handled together (FIB-706).
+    """
+    for tab in (TWIN, NEW):
+        assert f"self.{tab}.acquiring_changed.connect(" in window_source, (
+            f"{tab} never tells the window it is acquiring, so the other overview is "
+            "free to drive the stage during its run"
+        )
+    assert window_source.count("acquiring_changed.connect(self._apply_overview_locks)") == 2, (
+        "the tabs report to something other than the one place that derives the lock"
+    )

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -3570,3 +3570,74 @@ class TestTheTileGridHasItsOwnButton:
         widget._toggle_tile_grid_panel()
 
         assert widget.canvas._hint_text == caption, "the panel overwrote the caption"
+
+
+class TestSayingWhenARunStarts:
+    """`acquiring_changed`, which is how a host learns to lock the other overview.
+
+    A host that hears the signal and then *asks* the widget must get a consistent
+    answer, and that is the whole trap here: `acquire()` calls `_set_running(True)`
+    before it builds the worker, so a worker-only `is_acquiring` said no while a run was
+    starting -- which is exactly when the signal fires (FIB-706).
+    """
+
+    def test_the_signal_reports_the_new_state(self, widget):
+        seen = []
+        widget.acquiring_changed.connect(seen.append)
+        widget._set_running(True)
+        widget._set_running(False)
+        assert seen == [True, False]
+
+    def test_is_acquiring_already_agrees_when_the_signal_arrives(self, widget):
+        """A host derives the lock by asking both tabs rather than trusting the bool, so
+        the property has to be true by the time the signal says a run began."""
+        answers = []
+        widget.acquiring_changed.connect(lambda _: answers.append(widget.is_acquiring))
+        widget._set_running(True)
+        assert answers == [True], "the widget announced a run it does not admit to"
+        widget._set_running(False)
+        assert answers == [True, False]
+
+    def test_a_finished_run_says_so(self, widget):
+        """The finish path used to set the flag by hand, so it would have announced
+        nothing and left a host holding the lock for good."""
+        seen = []
+        widget._set_running(True)
+        widget.acquiring_changed.connect(seen.append)
+        widget._on_finished({})
+        assert seen == [False]
+        assert widget.is_acquiring is False
+
+
+class TestDrivingTheStageFromAHost:
+    """`move_to` is what the lamella list calls, and it went through a weaker gate than
+    a double-click on the same point -- so a locked tab could still be made to move."""
+
+    def test_a_host_cannot_move_while_the_tab_is_locked(self, widget, monkeypatch):
+        moved = []
+        monkeypatch.setattr(widget, "_move_worker", moved.append)
+        widget.set_interactive(False)
+        try:
+            widget.move_to(FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0))
+            assert moved == [], "moved the stage for a host while locked"
+        finally:
+            widget.set_interactive(True)
+
+    def test_move_to_asks_the_same_question_a_double_click_does(
+        self, widget, monkeypatch
+    ):
+        """Not merely "it refuses when locked" -- that could be any check. This is the
+        one gate, so the two ways of asking for a move cannot come apart again.
+
+        No worker is started: `_may_move` answering False is what stops it, which keeps
+        a stage move off a test thread.
+        """
+        asked = []
+
+        def refuse():
+            asked.append(True)
+            return False
+
+        monkeypatch.setattr(widget, "_may_move", refuse)
+        widget.move_to(FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0))
+        assert asked, "move_to did not go through _may_move"


### PR DESCRIPTION
Each overview tab locked **itself** while it ran. Nothing stopped the other one taking the stage out from under it: a click-to-move on the beam overview during a fluorescence tileset drives the stage away, and the run carries on placing tiles at the poses it planned. Worse than a wasted run — the mosaic comes out looking entirely plausible and is wrong.

## The rule, in one place

```python
def _overview_may_work(self, other) -> Tuple[bool, str]:
    if not self._overviews_allowed:
        return False, "a workflow is running"
    if other is not None and other.is_acquiring:
        return False, "the other overview is acquiring"
    return True, ""
```

Two facts, derived together on every change rather than each caller setting the flag it knows about — a workflow finishing while an overview runs must not re-enable the other tab, and a run finishing inside a locked window must not either.

Both tabs report through a new `acquiring_changed`, forwarded widget → tab so the window connects once, rather than to a widget that is rebuilt on every reconnection. A tab also reports `False` when its widget is dropped: a reconnection mid-run destroys the thing that would otherwise have said the run ended, and without that the other overview stays locked for the session.

## Three holes closed first

The lock would have been decorative without these, and each is a live bug on its own:

| | |
| -- | -- |
| `FMOverviewWidget._may_move` never consulted `_interactive` | the workflow lock reached the buttons and not the canvas, so a double-click drove the stage while a workflow owned the instrument. The beam widget refused this from the start. |
| `FibsemOverviewWidget.move_to` asked only `is_acquiring` | that is what the lamella list calls — a weaker gate than a double-click on the same point, so a host could move the stage where a user was refused. |
| `is_acquiring` read only the worker | `acquire()` calls `_set_running(True)` **before** it builds one, so at the moment `acquiring_changed(True)` was emitted the widget still answered "not acquiring" — and a host deriving the lock from that property locked nothing. |

`is_acquiring` is now the union of the flag and the worker: true over a superset of either interval, and every caller is a guard, so early and late is the safe direction to be wrong in.

## The refusal says which

A locked widget cannot tell why it was locked — both causes are the same `False` by the time they reach it — and blaming a workflow when the real reason is the other overview sends someone looking in the wrong place. `set_interactive(enabled, reason)` now carries the reason to quote.

That came out of a mutation check worth recording: the first version of `test_a_beam_run_locks_the_fluorescence_tab` **passed with the lock removed entirely**, because the fluorescence gate also refuses when the stage is away from the fluorescence pose. It was asserting a refusal that had nothing to do with what it claimed to test. Both cross-tab tests now assert the reason, and all four die under the mutation.

## Verification

- **1839 tests pass.** New coverage: the cross-tab lock against real widgets under a host that borrows the window's two decision methods; the signal/property agreement at the moment of emission, on both widgets; the `move_to` gate; the FM canvas honouring the lock.
- The window's own wiring is checked statically, as the rest of it is — the behaviour fixture connects the signal itself and so could not notice production forgetting to, and that connection lives in each tab's builder rather than anywhere the two are handled together.
- All touched files parse under Python 3.8; the two AST modules pass with PyQt5 unimportable.
- Run in the app: starting a tileset on one tab and double-clicking the other gives the refusal, naming the right reason.

## Deliberately narrow

Whether the lock should cover the whole window — the Microscope tab, the minimap, the lamella list's move-to — and whether a milling run counts are policy questions, tracked in FIB-723. This is the part with a silent failure behind it.