### PR TITLE
[fix] A cancelled overview no longer reports "Done" (FIB-730)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1332,7 +1332,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         msg = ddict.get("msg", "Collecting tiles")
 
         if ddict.get("finished"):
-            self.progress_widget.update_progress(ProgressUpdate.done())
+            self.progress_widget.update_progress(self._overview_outcome(ddict, msg))
             # Hide the Done state after a moment, the same way spot burn does above.
             # It used to be cleared by `_on_tile_acquisition_finished`, which is wired
             # to the napari minimap's own signal -- so a run driven from anywhere else
@@ -1346,6 +1346,25 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.progress_widget.update_progress(
                 ProgressUpdate.numeric(counter, total, msg)
             )
+
+    @staticmethod
+    def _overview_outcome(ddict: dict, msg: str) -> ProgressUpdate:
+        """How a finished tiled acquisition reads once the bar is full.
+
+        Everything terminal used to take one branch and say "Done", so a run that was
+        cancelled — or that failed — told the status bar it had completed. The runner
+        has reported which it was since it learned to emit a terminal payload for every
+        outcome (`TiledAcquisitionRunner._emit_terminal`); nothing was reading it.
+
+        A cancel is deliberately not `failed`, which paints the bar red: it is someone
+        getting what they asked for.
+        """
+        outcome = ddict.get("outcome")
+        if outcome == "failed":
+            return ProgressUpdate.failed(msg)
+        if outcome == "cancelled":
+            return ProgressUpdate(finished=True, message=msg)
+        return ProgressUpdate.done()
 
     def _on_tile_acquisition_finished(self, result: dict) -> None:
         self.progress_widget.reset()

--- a/tests/ui/test_status_bar_tile_outcome.py
+++ b/tests/ui/test_status_bar_tile_outcome.py
@@ -1,0 +1,93 @@
+"""How a finished tiled acquisition reads in the main status bar.
+
+Everything terminal used to take one branch and render "Done", so a run that was
+cancelled — or that failed — told the status bar it had completed. The runner has
+reported which it was since it learned to emit a terminal payload for every outcome;
+nothing was reading it.
+
+The window cannot be constructed here — it builds the napari minimap, and a
+`napari.Viewer` segfaults under the offscreen platform — so its handler is borrowed onto
+a host holding a real `FibsemProgressWidget`. That is enough: the handler's whole job is
+turning a payload into a rendered bar, and the bar here is the real one.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.ui.widgets.progress_widget import FibsemProgressWidget  # noqa: E402
+
+RED = "#99121F"
+
+
+@pytest.fixture
+def status(qapp):
+    from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+        AutoLamellaSingleWindowUI as _Real,
+    )
+
+    class _StatusHost:
+        _on_tile_acquisition_progress = _Real._on_tile_acquisition_progress
+        # A staticmethod reached through the class is a plain function, which would
+        # bind as a method here and eat `self`.
+        _overview_outcome = staticmethod(_Real._overview_outcome)
+
+        def __init__(self):
+            self.progress_widget = FibsemProgressWidget()
+
+    host = _StatusHost()
+    yield host
+    host.progress_widget.deleteLater()
+
+
+def _text(host) -> str:
+    return host.progress_widget._bar.format()
+
+
+def _is_red(host) -> bool:
+    return RED in host.progress_widget._bar.styleSheet()
+
+
+def _terminal(outcome: str, msg: str) -> dict:
+    """What `TiledAcquisitionRunner._emit_terminal` sends for each outcome."""
+    return {"msg": msg, "counter": 3, "total": 9, "finished": True, "outcome": outcome}
+
+
+def test_a_completed_run_says_done(status):
+    status._on_tile_acquisition_progress(_terminal("finished", "Acquisition Complete"))
+    assert "Done" in _text(status)
+    assert not _is_red(status)
+
+
+def test_a_cancelled_run_does_not_claim_to_have_finished(status):
+    status._on_tile_acquisition_progress(_terminal("cancelled", "Acquisition Cancelled"))
+    assert "Cancelled" in _text(status)
+    assert "Done" not in _text(status)
+
+
+def test_a_cancelled_run_is_not_painted_as_a_failure(status):
+    """A cancel is someone getting what they asked for, so the bar does not go red —
+    the distinction FIB-375 drew between a completed operation and a failed one."""
+    status._on_tile_acquisition_progress(_terminal("cancelled", "Acquisition Cancelled"))
+    assert not _is_red(status)
+
+
+def test_a_failed_run_is_red_and_says_so(status):
+    status._on_tile_acquisition_progress(_terminal("failed", "Acquisition Failed"))
+    assert "Failed" in _text(status)
+    assert _is_red(status)
+
+
+def test_a_producer_that_reports_no_outcome_still_says_done(status):
+    """The napari minimap drives the same runner and the same signal, and older payloads
+    carry no `outcome` at all. Absent, the bar reads as it always did."""
+    status._on_tile_acquisition_progress(
+        {"msg": "Done", "counter": 9, "total": 9, "finished": True}
+    )
+    assert "Done" in _text(status)
+    assert not _is_red(status)


### PR DESCRIPTION
Cancel a tiled acquisition — from the Overview tab or the napari minimap, which drive the same runner — and the main-window status bar filled the bar and rendered **"Done"**. A run that failed did the same. Everything terminal took one branch:

```python
if ddict.get("finished"):
    self.progress_widget.update_progress(ProgressUpdate.done())
```

The information was already in the payload and has been for a while: `TiledAcquisitionRunner._emit_terminal` reports `finished` / `cancelled` / `failed` and carries the matching message. Nothing read either.

A cancel now renders with its own message and deliberately **not** in the failure style — it is someone getting what they asked for — while a failure goes red. That is the distinction FIB-375 drew for exactly this confusion in spot burn.

`outcome` stays optional: the napari minimap drives the same signal and older payloads carry no such key, so absent it the bar reads as it always did. That case is tested rather than assumed.

## Verification

- **1844 tests pass.** Five new ones cover each outcome and the no-`outcome` payload.
- Mutating the handler to stop reading `outcome` kills two of the five.
- The window cannot be constructed under the offscreen platform — it builds the napari minimap, and a `napari.Viewer` segfaults there — so the handler is borrowed onto a host holding a **real** `FibsemProgressWidget`. The rendered bar is the real one; only the window around it is stubbed.