### PR TITLE
[ui] Style the scrollbars so they stop looking borrowed (FIB-710)

### DIFF
--- a/fibsem/ui/napari_style.py
+++ b/fibsem/ui/napari_style.py
@@ -18,6 +18,7 @@ from fibsem.ui.tokens import (
     PANEL_COLOR,
     SURFACE_COLOR,
     TEXT_COLOR,
+    TEXT_MUTED_COLOR,
 )
 
 # Same directory as stylesheets.py, so this resolves identically; kept local
@@ -335,6 +336,65 @@ QListWidget::item:selected {{
 
 QListWidget::item:hover {{
     background-color: #2d313b;
+}}
+
+/* Every scrolling surface in the app -- lists, scroll areas, tables, text edits,
+   spread across ~50 modules -- painted the platform's scrollbar until this rule.
+   One block reaches all of them, which is why it is here rather than beside any
+   one of them.
+
+   A transparent track takes the colour of whatever it sits on, so the same rule
+   works over SURFACE_COLOR and PANEL_COLOR without a second copy. */
+QScrollBar:vertical {{
+    background: transparent;
+    width: 10px;
+    margin: 0px;
+}}
+
+QScrollBar:horizontal {{
+    background: transparent;
+    height: 10px;
+    margin: 0px;
+}}
+
+QScrollBar::handle:vertical, QScrollBar::handle:horizontal {{
+    background-color: {BORDER_COLOR};
+    border-radius: 3px;
+}}
+
+QScrollBar::handle:vertical {{
+    min-height: 24px;
+    margin: 2px;
+}}
+
+QScrollBar::handle:horizontal {{
+    min-width: 24px;
+    margin: 2px;
+}}
+
+QScrollBar::handle:hover {{
+    background-color: {TEXT_MUTED_COLOR};
+}}
+
+/* No arrow buttons: the loudest part of the default control and the least used.
+   Zero-sized rather than hidden, so no gap is reserved for them. */
+QScrollBar::add-line, QScrollBar::sub-line {{
+    height: 0px;
+    width: 0px;
+    border: none;
+    background: none;
+}}
+
+/* The trough either side of the handle stays the surface behind it. */
+QScrollBar::add-page, QScrollBar::sub-page {{
+    background: none;
+}}
+
+/* Where both scrollbars are shown -- the tables -- the square between them is
+   the last piece of platform chrome left once the bars themselves are styled. */
+QAbstractScrollArea::corner {{
+    background: transparent;
+    border: none;
 }}
 
 QToolButton {{


### PR DESCRIPTION
Closes FIB-710.

There was no `QScrollBar` rule anywhere in the codebase. Every scrolling surface therefore painted the platform's default — on macOS, a light track with arrow buttons at each end, dropped into otherwise flat dark chrome.

## The change

One block added to `NAPARI_STYLE`, beside the rules already there:

- thin handle in `BORDER_COLOR`, `TEXT_MUTED_COLOR` on hover, 3px radius
- transparent track — it takes the colour of whatever it sits on, so the one rule works over both `SURFACE_COLOR` and `PANEL_COLOR` without a second copy
- `::add-line` / `::sub-line` sized to zero rather than hidden, so no gap is reserved for the arrow buttons
- `QAbstractScrollArea::corner` zeroed too. Once both bars on a table are styled, the square where they meet is the last piece of platform chrome left.

No new colours. `BORDER_COLOR` is the neutral the file already uses for `QListWidget::item:selected`; the radius matches the rest of the sheet. `TEXT_MUTED_COLOR` joins the import list.

## Scope

`QScrollBar` is a bare type selector, so it reaches every scrolling widget under a window that applies `NAPARI_STYLE` — by the rough count of modules that use one: 24 with a `QListWidget`, 19 with a `QScrollArea`, 5 `QTableWidget`, 5 `QTextEdit`/`QPlainTextEdit`. That breadth is the argument for doing it centrally rather than per widget.

Two things it does not reach, both correctly:

- **napari's own chrome.** The embedded viewers carry napari's stylesheet, which styles its scrollbars in its own qss (`00_base.qss`, `02_custom.qss`). Its panels keep the look they already have.
- **Non-Qt scroll surfaces** — the matplotlib and vispy canvases have no `QScrollBar` to style.

Nothing in the repo overrides it: there were zero `QScrollBar` rules before this. The per-widget sheets that set `QScrollArea { background: ... }` style the scroll area itself, not the bar inside it.

## Verified

Rendered a window with all five widget types, with and without the block, and compared the grabs — handles come out as thin rounded bars, transparent track, no arrows, no corner square, over both surface colours.

`tests/ui/test_stylesheets_render.py` passes — that is the one that matters here, since it catches a doubled brace pair rendering `{BORDER_COLOR}` into the sheet as literal text.

`tests/ui/test_overview_widget.py` fails 8, but identically with the change stashed. Pre-existing and unrelated.

## Follow-on, not done here

The pre-flight dialog (FIB-666) truncates its lamella list with a "+ 88 more" count because the default scrollbar was too conspicuous to bound it in a `QScrollArea`. That constraint is now gone, but reopening the decision belongs to that issue, not this one.