### PR TITLE
[feature] Plan a sparse FM overview grid from selected regions

### DIFF
--- a/fibsem/fm/planning.py
+++ b/fibsem/fm/planning.py
@@ -19,6 +19,15 @@ selection cheap in both.
 The caller supplies regions in the beam overview's own displayed plane, in metres from a
 base stage position -- what :meth:`StageFrame.offset` answers. Pixels are the display's
 business and cancel immediately; taking them here would mean being told which pixels.
+
+**Anything drawing this plan anchors its frame at the fluorescence orientation**, and
+:attr:`SparseOverviewPlan.centre_position` is already there, so it can serve as the frame
+origin directly. This is not a formality. A canvas frame takes its r and t from its
+origin, and `FMOverviewWidget._posed()` reads them off the *live* stage -- which, when
+this dialog opens, is at the milling pose, because that is where the beam overview was
+just acquired. Anchoring on the live position draws every FM tile 1.086x too tall
+(1.624x from the FIB pose): small enough to look like a grid, large enough to plan the
+wrong one. `tests/fm/test_planning.py` pins both numbers.
 """
 
 from __future__ import annotations
@@ -47,15 +56,18 @@ class SparseOverviewPlan:
 
     Attributes:
         centre_position: Stage position the grid straddles, at the FM orientation.
-            `FMTiledAcquisitionRunner` takes this directly.
+            `FMTiledAcquisitionRunner` takes this directly, and it doubles as the origin
+            for a canvas frame drawing the plan -- see the module docstring on why that
+            must not come from the live stage.
         rows: Grid rows.
         cols: Grid columns.
         mask: Per-tile enable mask, `mask[row][col]`.
         regions: The selection, projected into the FM plane and measured from
-            :attr:`centre_position`. Kept because the mask alone cannot be re-edited:
-            reopening a plan with only a mask lets tiles be toggled but leaves nothing
-            to move, and no way to say which tiles came from a region and which from a
-            hand edit.
+            :attr:`centre_position`. For drawing, and for telling a tile that came from
+            a region from one toggled by hand -- both of which only matter while the
+            selection is being made. **Not persisted:** what an acquisition needs is the
+            mask, and storing the regions beside it would mean a second representation
+            of the same thing, able to disagree with it. Selecting again starts over.
     """
 
     centre_position: FibsemStagePosition
@@ -215,8 +227,8 @@ def plan_sparse_fm_overview(
         plan.centre_dx, plan.centre_dy, fm_base
     )
     # Re-expressed against the grid centre rather than the base the caller happened to
-    # draw against, so the regions travel with the plan: a stored selection has to mean
-    # the same thing when it is reopened, and the drawing origin does not survive.
+    # draw against, so the regions and the tiles are in one frame: the display draws both
+    # together, and the drawing origin is the caller's business, not the plan's.
     centred = tuple(
         PlaneRegion(
             r.x0 - plan.centre_dx,

--- a/fibsem/fm/planning.py
+++ b/fibsem/fm/planning.py
@@ -1,0 +1,235 @@
+"""Plan a sparse FM overview from regions selected on a beam overview.
+
+A full fluorescence overview of a grid is expensive and mostly wasted -- the interesting
+ground is a few regions, and the user can already see where they are on a FIB/SEM
+overview. This turns rectangles drawn on that overview into the three values
+`FMTiledAcquisitionRunner` needs to acquire only that ground: where to centre the grid,
+how big it is, and which of its tiles to visit.
+
+Pure arithmetic over two projections. No microscope, no Qt, no acquisition -- so the
+part that is easy to get silently wrong can be tested without either.
+
+**Regions define the grid here**, unlike the ordinary overview path where rows and
+columns are settings and the grid centres on the stage. Painting a mask onto an
+already-configured grid would save acquisition time and no memory: `stitch_tileset`
+sizes the mosaic from the grid's shape whatever the mask says, so a small selection on a
+full grid still allocates a full-grid mosaic. Deriving the grid is what makes a small
+selection cheap in both.
+
+The caller supplies regions in the beam overview's own displayed plane, in metres from a
+base stage position -- what :meth:`StageFrame.offset` answers. Pixels are the display's
+business and cancel immediately; taking them here would mean being told which pixels.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Sequence, Tuple
+
+from fibsem.imaging.tiling.geometry import PlaneRegion, plan_grid_over_regions
+from fibsem.structures import FibsemStagePosition
+
+if TYPE_CHECKING:  # pragma: no cover - annotation only
+    from fibsem.projection import StageProjection
+
+__all__ = [
+    "SparseOverviewPlan",
+    "plan_sparse_fm_overview",
+    "project_regions_to_fm_plane",
+    "to_fm_pose",
+]
+
+
+@dataclass(frozen=True)
+class SparseOverviewPlan:
+    """Everything an FM overview run needs to cover a selection.
+
+    Attributes:
+        centre_position: Stage position the grid straddles, at the FM orientation.
+            `FMTiledAcquisitionRunner` takes this directly.
+        rows: Grid rows.
+        cols: Grid columns.
+        mask: Per-tile enable mask, `mask[row][col]`.
+        regions: The selection, projected into the FM plane and measured from
+            :attr:`centre_position`. Kept because the mask alone cannot be re-edited:
+            reopening a plan with only a mask lets tiles be toggled but leaves nothing
+            to move, and no way to say which tiles came from a region and which from a
+            hand edit.
+    """
+
+    centre_position: FibsemStagePosition
+    rows: int
+    cols: int
+    mask: List[List[bool]]
+    regions: Tuple[PlaneRegion, ...]
+
+    @property
+    def enabled_tiles(self) -> int:
+        """How many tiles the run will actually visit."""
+        return sum(sum(1 for on in row if on) for row in self.mask)
+
+
+def to_fm_pose(
+    position: FibsemStagePosition,
+    fm_orientation: FibsemStagePosition,
+    *,
+    is_compustage: bool,
+) -> FibsemStagePosition:
+    """Re-pose a stage position for the fluorescence orientation.
+
+    On a compustage this is a re-tilt and nothing else: x, y and z name the same ground
+    under the camera as under the beam, so `FibsemMicroscope.get_target_position` keeps
+    them and writes only the target orientation's r and t. Everything here rests on
+    that, which is why the guard is a raise rather than a comment -- on a stage that
+    reaches fluorescence by translating, every position would be wrong by the offset
+    between the two instruments, and wrong in a way that still looks like a grid.
+
+    Args:
+        position: Stage position at any orientation.
+        fm_orientation: The FM orientation's (r, t), from `get_orientation("FM")`.
+        is_compustage: Whether the stage is a compustage.
+
+    Returns:
+        The same translation, posed for fluorescence.
+
+    Raises:
+        ValueError: on a non-compustage system.
+    """
+    if not is_compustage:
+        raise ValueError("Cannot move to FM position on non-compustage systems.")
+    posed = deepcopy(position)
+    posed.r = fm_orientation.r
+    posed.t = fm_orientation.t
+    return posed
+
+
+def project_regions_to_fm_plane(
+    regions: Sequence[PlaneRegion],
+    beam_base: FibsemStagePosition,
+    beam_projection: "StageProjection",
+    fm_projection: "StageProjection",
+    fm_orientation: FibsemStagePosition,
+    *,
+    is_compustage: bool,
+) -> List[PlaneRegion]:
+    """Carry regions from the beam overview's plane into the FM's.
+
+    Both projections are asked about the same ground from their own pose, so the shape
+    changes on the way across: a FIB overview taken at the milling orientation is
+    foreshortened by `1 / cos(stage_tilt - pre-tilt - view_tilt)` -- 3.9x at a -23
+    degree milling angle -- while the FM at its own pose is not foreshortened at all.
+    A rectangle in one plane is a differently-proportioned rectangle in the other.
+
+    All four corners are carried, not two. Two would do while scan rotation is 0 or pi,
+    which is all either projection models, but re-bounding the corners costs nothing and
+    does not quietly assume it.
+
+    The corners are handed to the FM projection still carrying the beam pose's r and t,
+    and that is not an oversight: `project_stage_position` works from `position - base`
+    and reads the orientation off the **base** alone, so only *fm_base* needs re-posing.
+    Re-posing each corner as well is a no-op -- confirmed by removing it and watching
+    nothing change -- and a no-op that reads as load-bearing is worse than none. What
+    makes it sound is the compustage invariant: x, y and z name the same ground at
+    either pose, which is exactly what :func:`to_fm_pose` refuses to assume elsewhere.
+
+    Args:
+        regions: Rectangles in the beam overview's plane, in metres from *beam_base*.
+        beam_base: The stage position those metres are measured from.
+        beam_projection: Projection for the beam overview, from its own metadata.
+        fm_projection: Projection for the fluorescence camera.
+        fm_orientation: The FM orientation's (r, t).
+        is_compustage: Whether the stage is a compustage.
+
+    Returns:
+        The same regions in the FM plane, measured from the FM-posed *beam_base*.
+    """
+    fm_base = to_fm_pose(beam_base, fm_orientation, is_compustage=is_compustage)
+    projected = []
+    for region in regions:
+        corners = [
+            (region.x0, region.y0),
+            (region.x1, region.y0),
+            (region.x1, region.y1),
+            (region.x0, region.y1),
+        ]
+        projected.append(
+            PlaneRegion.from_points(
+                fm_projection.to_plane(
+                    beam_projection.from_plane(dx, dy, beam_base), fm_base
+                )
+                for dx, dy in corners
+            )
+        )
+    return projected
+
+
+def plan_sparse_fm_overview(
+    regions: Sequence[PlaneRegion],
+    beam_base: FibsemStagePosition,
+    beam_projection: "StageProjection",
+    fm_projection: "StageProjection",
+    fm_orientation: FibsemStagePosition,
+    fov_x: float,
+    fov_y: float,
+    overlap: float,
+    *,
+    is_compustage: bool,
+) -> SparseOverviewPlan:
+    """Turn a selection on a beam overview into an FM overview run.
+
+    Args:
+        regions: Rectangles in the beam overview's plane, in metres from *beam_base*.
+        beam_base: The stage position those metres are measured from -- the origin the
+            display drew them against, not necessarily the overview's own position.
+        beam_projection: Projection for the beam overview, from its own metadata, so the
+            selection resolves against the image as it was taken.
+        fm_projection: Projection for the fluorescence camera, read live: the geometry
+            is system configuration rather than pose, and an acquired FM tile carries
+            none to read.
+        fm_orientation: The FM orientation's (r, t).
+        fov_x: FM tile width, in metres -- camera resolution times pixel size, not a
+            horizontal field width with the other axis inferred.
+        fov_y: FM tile height, in metres.
+        overlap: Fractional overlap between adjacent tiles, in [0, 1).
+        is_compustage: Whether the stage is a compustage.
+
+    Returns:
+        A :class:`SparseOverviewPlan`.
+
+    Raises:
+        ValueError: if no region has any area, *overlap* is out of range, or the stage
+            is not a compustage.
+    """
+    fm_base = to_fm_pose(beam_base, fm_orientation, is_compustage=is_compustage)
+    fm_regions = project_regions_to_fm_plane(
+        regions,
+        beam_base,
+        beam_projection,
+        fm_projection,
+        fm_orientation,
+        is_compustage=is_compustage,
+    )
+    plan = plan_grid_over_regions(fm_regions, fov_x, fov_y, overlap)
+    centre_position = fm_projection.from_plane(
+        plan.centre_dx, plan.centre_dy, fm_base
+    )
+    # Re-expressed against the grid centre rather than the base the caller happened to
+    # draw against, so the regions travel with the plan: a stored selection has to mean
+    # the same thing when it is reopened, and the drawing origin does not survive.
+    centred = tuple(
+        PlaneRegion(
+            r.x0 - plan.centre_dx,
+            r.y0 - plan.centre_dy,
+            r.x1 - plan.centre_dx,
+            r.y1 - plan.centre_dy,
+        )
+        for r in fm_regions
+    )
+    return SparseOverviewPlan(
+        centre_position=centre_position,
+        rows=plan.rows,
+        cols=plan.cols,
+        mask=plan.mask,
+        regions=centred,
+    )

--- a/fibsem/imaging/tiling/geometry.py
+++ b/fibsem/imaging/tiling/geometry.py
@@ -11,8 +11,9 @@ not convention, because it is a single convenient import away from being broken.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 from fibsem.structures import (
     FibsemStagePosition,
@@ -277,4 +278,194 @@ def raise_if_outside_stage_limits(
     raise ValueError(
         f"Acquisition grid extends beyond stage limits. "
         f"{len(out_of_bounds)} tile(s) out of bounds: {details}"
+    )
+
+
+# ── planning a grid from selected ground ──────────────────────────────────────
+#
+# The layout above answers "where do these rows and columns land?". Selecting an area
+# to image asks the inverse: "what grid covers this ground, and which of its tiles are
+# worth visiting?". Both live here so they cannot drift -- a grid sized by one formula
+# and laid out by another is a grid that stops covering what it was asked to.
+
+# `(extent - fov) / step` lands a hair above an integer often enough that `ceil` alone
+# adds a whole unwanted row and column to grids that fit exactly -- for 126 of the grid
+# sizes swept in `test_an_exact_fit_at_camera_scale_does_not_add_a_row`. Subtracted from
+# a tile *count*, so it is dimensionless and holds whatever units the caller works in.
+_SPAN_TOLERANCE = 1e-9
+
+
+@dataclass(frozen=True)
+class PlaneRegion:
+    """An axis-aligned rectangle in a displayed plane, in metres.
+
+    Measured from the same origin the tile offsets are, with y running **down** -- the
+    convention `StageProjection.to_plane` answers in.
+
+    Normalised on construction, so build one with :meth:`from_points` rather than the
+    constructor: a drag can end up and to the left of where it started, and a rectangle
+    carried through a projection can come out with its corners in any order.
+    """
+
+    x0: float
+    y0: float
+    x1: float
+    y1: float
+
+    @classmethod
+    def from_points(cls, points: Iterable[Tuple[float, float]]) -> "PlaneRegion":
+        """The bounding box of any number of points.
+
+        Two for a drag; four for a rectangle carried through a projection, where the
+        corners have to be projected and re-bounded rather than the width and height
+        scaled -- a foreshortened view squashes one axis, and which axis depends on the
+        pose the image was taken at.
+        """
+        points = list(points)
+        if not points:
+            raise ValueError("A region needs at least one point.")
+        xs = [x for x, _ in points]
+        ys = [y for _, y in points]
+        return cls(min(xs), min(ys), max(xs), max(ys))
+
+    @property
+    def width(self) -> float:
+        return self.x1 - self.x0
+
+    @property
+    def height(self) -> float:
+        return self.y1 - self.y0
+
+    def overlaps(self, other: "PlaneRegion") -> bool:
+        """Whether the two rectangles share any area.
+
+        Strict, so rectangles that merely touch along an edge do not count: a tile whose
+        edge grazes a region contributes none of it.
+        """
+        return (
+            self.x0 < other.x1
+            and self.x1 > other.x0
+            and self.y0 < other.y1
+            and self.y1 > other.y0
+        )
+
+
+@dataclass(frozen=True)
+class GridPlan:
+    """A tile grid sized and masked to cover a set of regions.
+
+    Attributes:
+        rows: Grid rows.
+        cols: Grid columns.
+        mask: Per-tile enable mask, `mask[row][col]`, ready for `compute_tile_grid`.
+        centre_dx: Where the grid's centre sits, in the same plane the regions are in.
+        centre_dy: Likewise. The grid straddles this point; a caller projects it back
+            to a stage position to get the runner's `centre_position`.
+    """
+
+    rows: int
+    cols: int
+    mask: List[List[bool]]
+    centre_dx: float
+    centre_dy: float
+
+
+def tiles_to_span(extent: float, fov: float, step: float) -> int:
+    """The fewest tiles whose combined coverage spans *extent*.
+
+    `n` tiles at `step` apart cover `(n - 1) * step + fov`, so this inverts the layout
+    in :func:`compute_tile_grid_from_fov` rather than approximating it.
+
+    Args:
+        extent: Length to cover, in metres.
+        fov: Length of one tile, in metres.
+        step: Distance between adjacent tile centres, in metres.
+
+    Returns:
+        The tile count, at least 1.
+
+    Raises:
+        ValueError: if *step* or *fov* is not positive.
+    """
+    if fov <= 0:
+        raise ValueError(f"Tile field of view must be positive, got {fov}.")
+    if step <= 0:
+        raise ValueError(f"Tile step must be positive, got {step}.")
+    if extent <= fov:
+        return 1
+    return int(math.ceil((extent - fov) / step - _SPAN_TOLERANCE)) + 1
+
+
+def plan_grid_over_regions(
+    regions: Sequence[PlaneRegion],
+    fov_x: float,
+    fov_y: float,
+    overlap: float,
+) -> GridPlan:
+    """Size a tile grid to a set of regions, and mask it to the tiles they touch.
+
+    Pure function -- no microscope, no projections, no side effects.
+
+    The grid is sized to the regions' **combined** bounding box, so two regions far
+    apart produce a grid spanning both. That is deliberate: one selection is one
+    acquisition, and the mask -- not the grid -- is what stops the ground between them
+    being visited. It does mean a scattered selection still costs a mosaic spanning it,
+    since a disabled tile keeps its place in the canvas.
+
+    The bounding box is not a whole number of steps, so the grid overhangs the regions
+    by up to a step in each axis. What the caller acquires is therefore the tiles, not
+    the rectangles that produced them.
+
+    Args:
+        regions: Rectangles to cover, in one plane, in metres. Regions with no area are
+            ignored -- a click that never became a drag selects nothing.
+        fov_x: Tile width, in metres.
+        fov_y: Tile height, in metres.
+        overlap: Fractional overlap between adjacent tiles, in [0, 1).
+
+    Returns:
+        A :class:`GridPlan`.
+
+    Raises:
+        ValueError: if no region has any area, or *overlap* is out of range.
+    """
+    covering = [r for r in regions if r.width > 0 and r.height > 0]
+    if not covering:
+        raise ValueError("No region with any area to cover.")
+    if not 0.0 <= overlap < 1.0:
+        raise ValueError(f"Overlap must be in [0, 1), got {overlap}.")
+
+    bounds = PlaneRegion.from_points(
+        [(r.x0, r.y0) for r in covering] + [(r.x1, r.y1) for r in covering]
+    )
+    step_x = fov_x * (1.0 - overlap)
+    step_y = fov_y * (1.0 - overlap)
+    cols = tiles_to_span(bounds.width, fov_x, step_x)
+    rows = tiles_to_span(bounds.height, fov_y, step_y)
+
+    centre_dx = (bounds.x0 + bounds.x1) / 2.0
+    centre_dy = (bounds.y0 + bounds.y1) / 2.0
+
+    # Tile (row, col) straddles the same offset `compute_tile_grid_from_fov` gives it
+    # once the grid is centred: `dx - (cols - 1) * step_x / 2` and its row equivalent,
+    # with the row term negated back because that layout measures y upward and a
+    # displayed plane measures it down. Row 0 is therefore the smallest y, which is what
+    # decides whether a mask lands on the ground it was drawn over or mirrored across it.
+    mask: List[List[bool]] = []
+    for row in range(rows):
+        tile_y = centre_dy + (row - (rows - 1) / 2.0) * step_y
+        enabled = []
+        for col in range(cols):
+            tile_x = centre_dx + (col - (cols - 1) / 2.0) * step_x
+            tile = PlaneRegion(
+                tile_x - fov_x / 2.0,
+                tile_y - fov_y / 2.0,
+                tile_x + fov_x / 2.0,
+                tile_y + fov_y / 2.0,
+            )
+            enabled.append(any(tile.overlaps(region) for region in covering))
+        mask.append(enabled)
+
+    return GridPlan(
+        rows=rows, cols=cols, mask=mask, centre_dx=centre_dx, centre_dy=centre_dy
     )

--- a/tests/fm/test_planning.py
+++ b/tests/fm/test_planning.py
@@ -1,0 +1,346 @@
+"""Turning a selection on a beam overview into an FM overview run.
+
+The arithmetic between "the user dragged a box on the FIB image" and "the runner visits
+these tiles" crosses two projections and a change of pose, and every way it can be wrong
+produces a grid that still looks like a grid. So the tests that matter here do not check
+the plan against itself: they push it through the same layout and projection calls
+`FMTiledAcquisitionRunner._setup` makes, and ask whether the tiles it would visit land on
+the ground that was selected.
+"""
+
+import numpy as np
+import pytest
+
+from fibsem import utils
+from fibsem.fm.planning import (
+    plan_sparse_fm_overview,
+    project_regions_to_fm_plane,
+    to_fm_pose,
+)
+from fibsem.imaging.tiling.geometry import PlaneRegion, compute_tile_grid_from_fov
+from fibsem.projection import (
+    BeamStageProjection,
+    FMStageProjection,
+    surface_foreshortening,
+)
+from fibsem.structures import BeamType, FibsemStagePosition
+
+
+@pytest.fixture
+def fm_microscope():
+    """A demo microscope posed for fluorescence, as the FM overview tab leaves it."""
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    microscope.system.stage.shuttle_pre_tilt = 0
+    microscope.stage_is_compustage = True
+    microscope._update_orientations()
+    microscope.move_to_microscope("FM")
+    return microscope
+
+
+@pytest.fixture
+def geometry(fm_microscope):
+    """The three things a plan needs, read off the instrument once."""
+    m = fm_microscope
+    fm_projection = FMStageProjection.from_microscope(m)
+    assert fm_projection is not None
+    width, height = m.fm.camera.resolution
+    pixel_x, pixel_y = m.fm.camera.pixel_size
+    return dict(
+        microscope=m,
+        fm_projection=fm_projection,
+        fm_orientation=m.get_orientation("FM"),
+        fov_x=width * pixel_x,
+        fov_y=height * pixel_y,
+        resolution=(width, height),
+    )
+
+
+def beam_view(microscope, beam_type=BeamType.ION, orientation="MILLING"):
+    """A projection and a base position for an overview taken at a beam pose."""
+    projection = BeamStageProjection.from_microscope(microscope, beam_type)
+    assert projection is not None
+    pose = microscope.get_orientation(orientation)
+    base = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
+    return projection, base
+
+
+def region(x0, y0, x1, y1):
+    return PlaneRegion.from_points([(x0, y0), (x1, y1)])
+
+
+# ── the pose change ──────────────────────────────────────────────────────
+
+
+def test_re_posing_keeps_the_translation_and_writes_the_orientation():
+    """The whole plan rests on x, y and z naming the same ground at either pose."""
+    fm = FibsemStagePosition(r=0.0, t=np.deg2rad(-180))
+    posed = to_fm_pose(
+        FibsemStagePosition(x=1e-3, y=2e-3, z=3e-3, r=0.0, t=np.deg2rad(-23)),
+        fm,
+        is_compustage=True,
+    )
+    assert (posed.x, posed.y, posed.z) == (1e-3, 2e-3, 3e-3)
+    assert (posed.r, posed.t) == (fm.r, fm.t)
+
+
+def test_re_posing_does_not_mutate_what_it_was_given():
+    original = FibsemStagePosition(x=1e-3, y=0.0, z=0.0, r=0.0, t=np.deg2rad(-23))
+    to_fm_pose(original, FibsemStagePosition(r=0.0, t=np.deg2rad(-180)), is_compustage=True)
+    assert original.t == np.deg2rad(-23)
+
+
+def test_a_non_compustage_stage_is_refused(geometry):
+    """There is no FM pose to re-express into; a translating stage would be off by the
+    offset between the two instruments, and still produce a plausible grid."""
+    projection, base = beam_view(geometry["microscope"])
+    with pytest.raises(ValueError, match="non-compustage"):
+        plan_sparse_fm_overview(
+            [region(0.0, 0.0, 1e-4, 1e-4)],
+            base,
+            projection,
+            geometry["fm_projection"],
+            geometry["fm_orientation"],
+            fov_x=geometry["fov_x"],
+            fov_y=geometry["fov_y"],
+            overlap=0.0,
+            is_compustage=False,
+        )
+
+
+# ── across the projections ───────────────────────────────────────────────
+
+
+def test_the_ion_view_at_the_milling_pose_is_foreshortened_against_the_camera(geometry):
+    """The reason the selection cannot simply be copied across.
+
+    A square dragged on a FIB overview taken at the milling orientation is not square
+    ground, so it is not a square region for the camera either.
+    """
+    m = geometry["microscope"]
+    projection, base = beam_view(m, BeamType.ION, "MILLING")
+    square = region(-5e-5, -5e-5, 5e-5, 5e-5)
+
+    [projected] = project_regions_to_fm_plane(
+        [square], base, projection, geometry["fm_projection"],
+        geometry["fm_orientation"], is_compustage=True,
+    )
+
+    # 1 / cos(stage_tilt - pre-tilt - view_tilt) at a -23 degree milling angle. Only the
+    # tilt axis is squashed, which is why no single scale factor can carry a selection
+    # across and the two panes cannot be the same picture.
+    assert projected.width == pytest.approx(square.width, rel=1e-6)
+    assert projected.height / square.height == pytest.approx(3.864, abs=1e-3)
+
+
+def test_the_projected_shape_agrees_with_the_measured_foreshortening(geometry):
+    """The factor is not restated here -- it is read off the same projection, through
+    its own inverse, so the two cannot drift."""
+    m = geometry["microscope"]
+    projection, base = beam_view(m, BeamType.ION, "MILLING")
+    square = region(-5e-5, -5e-5, 5e-5, 5e-5)
+
+    [projected] = project_regions_to_fm_plane(
+        [square], base, projection, geometry["fm_projection"],
+        geometry["fm_orientation"], is_compustage=True,
+    )
+
+    assert projected.height / square.height == pytest.approx(
+        1.0 / surface_foreshortening(projection, base), rel=1e-9
+    )
+
+
+def test_the_electron_view_at_its_own_pose_is_not_foreshortened(geometry):
+    """The control for the test above: same code path, no distortion to find."""
+    m = geometry["microscope"]
+    projection, base = beam_view(m, BeamType.ELECTRON, "SEM")
+    square = region(-5e-5, -5e-5, 5e-5, 5e-5)
+
+    [projected] = project_regions_to_fm_plane(
+        [square], base, projection, geometry["fm_projection"],
+        geometry["fm_orientation"], is_compustage=True,
+    )
+
+    assert projected.width == pytest.approx(square.width, rel=1e-6)
+    assert projected.height == pytest.approx(square.height, rel=1e-6)
+
+
+# ── the plan ─────────────────────────────────────────────────────────────
+
+
+def make_plan(geometry, regions, orientation="MILLING", beam_type=BeamType.ION,
+              overlap=0.0):
+    projection, base = beam_view(geometry["microscope"], beam_type, orientation)
+    plan = plan_sparse_fm_overview(
+        regions, base, projection, geometry["fm_projection"],
+        geometry["fm_orientation"], fov_x=geometry["fov_x"],
+        fov_y=geometry["fov_y"], overlap=overlap, is_compustage=True,
+    )
+    fm_regions = project_regions_to_fm_plane(
+        regions, base, projection, geometry["fm_projection"],
+        geometry["fm_orientation"], is_compustage=True,
+    )
+    return plan, fm_regions
+
+
+def test_a_selection_inside_one_tile_is_one_tile(geometry):
+    plan, _ = make_plan(geometry, [region(0.0, 0.0, geometry["fov_x"] / 4, 1e-6)])
+    assert (plan.rows, plan.cols, plan.mask) == (1, 1, [[True]])
+    assert plan.enabled_tiles == 1
+
+
+def test_the_plan_is_posed_for_fluorescence(geometry):
+    """The runner drives the stage to this; at the beam pose it would drive it into the
+    pole piece rather than under the camera."""
+    plan, _ = make_plan(geometry, [region(0.0, 0.0, 1e-4, 1e-4)])
+    fm = geometry["fm_orientation"]
+    assert plan.centre_position.r == pytest.approx(fm.r)
+    assert plan.centre_position.t == pytest.approx(fm.t)
+
+
+def test_the_centre_lands_where_the_selection_is(geometry):
+    """`centre_position` is a stage position; it has to project back to the middle of
+    the ground it was derived from."""
+    plan, fm_regions = make_plan(geometry, [region(0.0, 0.0, 3e-4, 2e-4)])
+    fm_base = to_fm_pose(
+        beam_view(geometry["microscope"])[1],
+        geometry["fm_orientation"],
+        is_compustage=True,
+    )
+    bounds = PlaneRegion.from_points(
+        [(r.x0, r.y0) for r in fm_regions] + [(r.x1, r.y1) for r in fm_regions]
+    )
+    back = geometry["fm_projection"].to_plane(plan.centre_position, fm_base)
+    assert back[0] == pytest.approx((bounds.x0 + bounds.x1) / 2, abs=1e-9)
+    assert back[1] == pytest.approx((bounds.y0 + bounds.y1) / 2, abs=1e-9)
+
+
+def test_the_stored_regions_travel_with_the_plan(geometry):
+    """Measured from the grid centre, not from whatever origin the display drew them
+    against -- a stored selection has to mean the same thing when it is reopened."""
+    plan, _ = make_plan(geometry, [region(0.0, 0.0, 3e-4, 2e-4)])
+    bounds = PlaneRegion.from_points(
+        [(r.x0, r.y0) for r in plan.regions] + [(r.x1, r.y1) for r in plan.regions]
+    )
+    assert (bounds.x0 + bounds.x1) / 2 == pytest.approx(0.0, abs=1e-12)
+    assert (bounds.y0 + bounds.y1) / 2 == pytest.approx(0.0, abs=1e-12)
+
+
+def test_the_tile_axes_are_not_interchangeable(geometry):
+    """The FM camera is square, so no plan built from it can tell fov_x from fov_y.
+
+    The parameters admit a camera that is not -- `pixel_size` is a pair and binning is
+    per axis -- so the axes are passed deliberately unequal here. Taken through the
+    unforeshortened electron view, where the expected grid is arithmetic rather than a
+    projection result.
+    """
+    unit = 1e-4
+    projection, base = beam_view(geometry["microscope"], BeamType.ELECTRON, "SEM")
+    plan = plan_sparse_fm_overview(
+        [region(0.0, 0.0, 4 * unit, 4 * unit)],
+        base,
+        projection,
+        geometry["fm_projection"],
+        geometry["fm_orientation"],
+        fov_x=4 * unit,
+        fov_y=unit,
+        overlap=0.0,
+        is_compustage=True,
+    )
+    assert (plan.rows, plan.cols) == (4, 1)
+
+
+def test_two_selections_share_one_grid_and_skip_the_gap(geometry):
+    fov = geometry["fov_x"]
+    plan, _ = make_plan(
+        geometry,
+        [region(0.0, 0.0, fov / 2, 1e-6), region(4 * fov, 0.0, 4.5 * fov, 1e-6)],
+    )
+    assert plan.cols >= 5
+    assert plan.mask[0][0] and plan.mask[0][-1]
+    assert not any(plan.mask[0][1:-1])
+
+
+# ── the plan against the run it becomes ──────────────────────────────────
+#
+# Everything above checks the plan. This checks the acquisition: the tile positions are
+# built the way `FMTiledAcquisitionRunner._setup` builds them -- the shared layout, the
+# same centring offsets, `project_fm_stable_move` -- and then projected back into the
+# plane the selection was made in. A sign error anywhere between the two shows up as
+# tiles landing somewhere other than on the selected ground.
+
+
+def visited_tiles(geometry, plan, overlap=0.0):
+    """Where the run's tiles land in the FM plane, keyed by (row, col)."""
+    m = geometry["microscope"]
+    fov_x, fov_y = geometry["fov_x"], geometry["fov_y"]
+    width, height = geometry["resolution"]
+    step_x, step_y = fov_x * (1 - overlap), fov_y * (1 - overlap)
+
+    grid = compute_tile_grid_from_fov(
+        nrows=plan.rows, ncols=plan.cols, fov_x=fov_x, fov_y=fov_y,
+        image_width=width, image_height=height, overlap=overlap, mask=plan.mask,
+    )
+    offset_x = (plan.cols - 1) * step_x / 2
+    offset_y = (plan.rows - 1) * step_y / 2
+    fm_base = to_fm_pose(
+        beam_view(m)[1], geometry["fm_orientation"], is_compustage=True
+    )
+
+    out = {}
+    for tile in grid:
+        position = m.project_fm_stable_move(
+            dx=tile.dx - offset_x,
+            dy=tile.dy + offset_y,
+            base_position=plan.centre_position,
+        )
+        cx, cy = geometry["fm_projection"].to_plane(position, fm_base)
+        out[(tile.row, tile.col)] = (
+            PlaneRegion(cx - fov_x / 2, cy - fov_y / 2, cx + fov_x / 2, cy + fov_y / 2),
+            tile.enabled,
+        )
+    return out
+
+
+@pytest.mark.parametrize("overlap", [0.0, 0.1])
+def test_the_run_visits_exactly_the_tiles_that_touch_the_selection(geometry, overlap):
+    fov = geometry["fov_x"]
+    regions = [region(0.0, 0.0, 1.5 * fov, 2.5 * fov),
+               region(4 * fov, 3 * fov, 5 * fov, 4 * fov)]
+    plan, fm_regions = make_plan(geometry, regions, overlap=overlap)
+
+    for rc, (footprint, enabled) in visited_tiles(geometry, plan, overlap).items():
+        touches = any(footprint.overlaps(r) for r in fm_regions)
+        assert enabled == touches, rc
+
+
+def test_the_run_covers_every_selected_region(geometry):
+    """Undersizing by one row drops ground the user asked for and still looks like a
+    sparse acquisition that worked."""
+    fov = geometry["fov_x"]
+    regions = [region(0.0, 0.0, 1.5 * fov, 2.5 * fov)]
+    plan, fm_regions = make_plan(geometry, regions)
+
+    footprints = [f for f, _ in visited_tiles(geometry, plan).values()]
+    covered = PlaneRegion.from_points(
+        [(f.x0, f.y0) for f in footprints] + [(f.x1, f.y1) for f in footprints]
+    )
+    for r in fm_regions:
+        assert covered.x0 <= r.x0 + 1e-12 and covered.x1 >= r.x1 - 1e-12
+        assert covered.y0 <= r.y0 + 1e-12 and covered.y1 >= r.y1 - 1e-12
+
+
+def test_the_selection_is_not_mirrored_on_its_way_to_the_run(geometry):
+    """An asymmetric selection, so a flip in either axis cannot look like a match.
+
+    The tiles the run visits must sit on the same side of the grid centre as the ground
+    that was selected -- the failure a symmetric test case cannot see.
+    """
+    fov = geometry["fov_x"]
+    # Up and to the left of the origin in the plane, and only there.
+    regions = [region(-4 * fov, -4 * fov, -3 * fov, -1 * fov)]
+    plan, fm_regions = make_plan(geometry, regions)
+
+    enabled = [f for f, on in visited_tiles(geometry, plan).values() if on]
+    assert enabled
+    for footprint in enabled:
+        assert any(footprint.overlaps(r) for r in fm_regions)

--- a/tests/fm/test_planning.py
+++ b/tests/fm/test_planning.py
@@ -72,10 +72,15 @@ def region(x0, y0, x1, y1):
 
 
 def test_re_posing_keeps_the_translation_and_writes_the_orientation():
-    """The whole plan rests on x, y and z naming the same ground at either pose."""
+    """The whole plan rests on x, y and z naming the same ground at either pose.
+
+    The input rotation is deliberately non-zero. Every orientation on a compustage sits
+    at r = 0, so an input already at 0 cannot tell whether r is being written or merely
+    left alone -- and r is half of what "at the FM orientation" means.
+    """
     fm = FibsemStagePosition(r=0.0, t=np.deg2rad(-180))
     posed = to_fm_pose(
-        FibsemStagePosition(x=1e-3, y=2e-3, z=3e-3, r=0.0, t=np.deg2rad(-23)),
+        FibsemStagePosition(x=1e-3, y=2e-3, z=3e-3, r=np.deg2rad(90), t=np.deg2rad(-23)),
         fm,
         is_compustage=True,
     )
@@ -344,3 +349,82 @@ def test_the_selection_is_not_mirrored_on_its_way_to_the_run(geometry):
     assert enabled
     for footprint in enabled:
         assert any(footprint.overlaps(r) for r in fm_regions)
+
+
+# ── the frame the plan is drawn in ───────────────────────────────────────
+#
+# A canvas frame takes its rotation and tilt from its origin -- `StageFrame.offset` is a
+# one-line pass through to `projection.to_plane(position, self.origin)`, which is what
+# these test directly, since importing `StageFrame` pulls in PyQt5 and CI does not
+# install it.
+#
+# The mistake these exist to catch: `FMOverviewWidget._posed()` reads r and t off the
+# *live* stage, which is correct for a tab that follows the instrument and wrong for a
+# dialog planning a pose the stage is not in yet. When this dialog opens the stage sits
+# at the milling orientation, because that is where the beam overview was acquired.
+
+STAGE_POSES = ["SEM", "MILLING", "FIB", "FM"]
+
+
+def posed(microscope, name):
+    """A stage position at one of the orientations, as the live stage would report it."""
+    pose = microscope.get_orientation(name)
+    return FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
+
+
+@pytest.mark.parametrize("stage_pose", STAGE_POSES)
+def test_the_plans_centre_is_already_a_frame_origin(geometry, stage_pose):
+    """Whatever pose the stage is in, the plan's centre is at the FM orientation -- so a
+    frame anchored on it draws the tiles at true size without anyone re-posing it."""
+    plan, _ = make_plan(geometry, [region(0.0, 0.0, 2e-4, 1e-4)])
+    assert surface_foreshortening(
+        geometry["fm_projection"], plan.centre_position
+    ) == pytest.approx(1.0, abs=1e-9)
+
+
+@pytest.mark.parametrize(
+    "stage_pose, factor", [("SEM", 1.000), ("MILLING", 1.086), ("FIB", 1.624), ("FM", 1.000)]
+)
+def test_anchoring_on_the_live_stage_pose_foreshortens_every_tile(
+    geometry, stage_pose, factor
+):
+    """The guard, and the measurement.
+
+    Without it the test above passes against a projection that is unforeshortened
+    everywhere, proving nothing. The milling row is the one that matters: 8.6% is
+    invisible by eye, where a gross error would be caught the first time anyone looked.
+    """
+    live = posed(geometry["microscope"], stage_pose)
+    drawn = 1.0 / surface_foreshortening(geometry["fm_projection"], live)
+    assert drawn == pytest.approx(factor, abs=1e-3)
+    # ...and going through `to_fm_pose` removes it, from every one of them.
+    fixed = to_fm_pose(live, geometry["fm_orientation"], is_compustage=True)
+    assert surface_foreshortening(
+        geometry["fm_projection"], fixed
+    ) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_tiles_land_identically_whatever_pose_the_stage_is_in(geometry):
+    """The consequence, on a real tile position rather than on a probe length.
+
+    One tile from one plan, placed through frames anchored on each pose the stage could
+    be in when the dialog opens. Re-posed, they must all agree exactly.
+    """
+    m = geometry["microscope"]
+    plan, _ = make_plan(geometry, [region(0.0, 0.0, 3e-4, 2e-4)])
+    tile = m.project_fm_stable_move(
+        dx=geometry["fov_x"], dy=geometry["fov_y"], base_position=plan.centre_position
+    )
+
+    placements = {
+        geometry["fm_projection"].to_plane(
+            tile, to_fm_pose(posed(m, name), geometry["fm_orientation"], is_compustage=True)
+        )
+        for name in STAGE_POSES
+    }
+    assert len(placements) == 1, placements
+
+    # And the same tile through an un-posed milling origin does *not* agree -- otherwise
+    # the assertion above would hold no matter what `to_fm_pose` did.
+    astray = geometry["fm_projection"].to_plane(tile, posed(m, "MILLING"))
+    assert astray != placements.pop()

--- a/tests/test_grid_planning.py
+++ b/tests/test_grid_planning.py
@@ -1,0 +1,244 @@
+"""Sizing a tile grid to selected ground, and masking it to what was selected.
+
+The inverse of `compute_tile_grid_from_fov`: that answers where rows and columns land,
+this answers what grid covers a region. They have to agree, so the last group here
+checks the mask against tiles the *layout* produced rather than against the arithmetic
+that produced the mask.
+
+Two properties carry the feature:
+
+* **the grid covers the selection** -- undersizing by one row silently drops ground the
+  user asked for, and looks like a sparse acquisition that worked
+* **enabled if and only if the tile touches a region** -- a tile enabled by mistake
+  costs acquisition time; one disabled by mistake leaves a hole that stitches as zeros,
+  indistinguishable from dark sample.
+"""
+
+import pytest
+
+from fibsem.imaging.tiling.geometry import (
+    PlaneRegion,
+    compute_tile_grid_from_fov,
+    plan_grid_over_regions,
+    tiles_to_span,
+)
+
+FOV = 1.0
+
+
+def region(x0, y0, x1, y1):
+    return PlaneRegion.from_points([(x0, y0), (x1, y1)])
+
+
+def plan(regions, fov_x=FOV, fov_y=FOV, overlap=0.0):
+    return plan_grid_over_regions(regions, fov_x=fov_x, fov_y=fov_y, overlap=overlap)
+
+
+# ── the region itself ────────────────────────────────────────────────────
+
+
+def test_a_region_is_normalised_whichever_way_it_was_dragged():
+    """A drag can end up and to the left of where it started."""
+    assert region(1.0, 1.0, 0.0, 0.0) == region(0.0, 0.0, 1.0, 1.0)
+
+
+def test_a_region_bounds_all_the_points_it_is_given():
+    """Four projected corners, not two: the projection can reorder them."""
+    r = PlaneRegion.from_points([(3.0, 1.0), (0.0, 4.0), (2.0, 0.0), (1.0, 2.0)])
+    assert (r.x0, r.y0, r.x1, r.y1) == (0.0, 0.0, 3.0, 4.0)
+
+
+def test_a_region_needs_at_least_one_point():
+    with pytest.raises(ValueError, match="at least one point"):
+        PlaneRegion.from_points([])
+
+
+def test_touching_edges_do_not_overlap():
+    """A tile whose edge grazes a region contributes none of it."""
+    assert not region(0.0, 0.0, 1.0, 1.0).overlaps(region(1.0, 0.0, 2.0, 1.0))
+    assert region(0.0, 0.0, 1.0, 1.0).overlaps(region(0.99, 0.0, 2.0, 1.0))
+
+
+def test_separation_in_either_axis_alone_is_enough_to_miss():
+    assert not region(0.0, 0.0, 1.0, 1.0).overlaps(region(0.0, 5.0, 1.0, 6.0))
+
+
+# ── how many tiles ───────────────────────────────────────────────────────
+
+
+def test_a_span_within_one_tile_needs_one_tile():
+    assert tiles_to_span(0.5, FOV, 0.5) == 1
+    assert tiles_to_span(FOV, FOV, 0.5) == 1
+
+
+def test_an_exact_fit_does_not_add_a_row():
+    """Three tiles at 0.5 apart cover 2.0 exactly; a fourth would be wasted."""
+    assert tiles_to_span(FOV + 2 * 0.5, FOV, 0.5) == 3
+
+
+@pytest.mark.parametrize("fov", [1.024e-4, 4.512e-4, 9.0e-5])
+@pytest.mark.parametrize("overlap", [0.0, 0.05, 0.1, 0.25])
+def test_an_exact_fit_at_camera_scale_does_not_add_a_row(fov, overlap):
+    """The same property where it actually bites.
+
+    `(extent - fov) / step` is exact in decimal and a hair over an integer in binary, so
+    `ceil` alone adds a whole unwanted row and column. Round numbers like the case above
+    never show it -- these are real FM fields of view, where it trips for 126 of the
+    grid sizes swept here.
+    """
+    step = fov * (1 - overlap)
+    for n in range(1, 40):
+        assert tiles_to_span((n - 1) * step + fov, fov, step) == n
+
+
+def test_a_span_a_hair_over_one_tile_needs_two():
+    assert tiles_to_span(FOV * 1.0000001, FOV, 0.5) == 2
+
+
+def test_the_count_actually_spans_what_it_was_asked_to():
+    """The property the arithmetic exists for, over a range of awkward extents."""
+    step = 0.5
+    for hundredths in range(1, 400):
+        extent = hundredths / 100.0
+        n = tiles_to_span(extent, FOV, step)
+        assert (n - 1) * step + FOV >= extent - 1e-9, extent
+        assert (n - 2) * step + FOV < extent or n == 1, extent
+
+
+def test_a_non_positive_step_is_refused():
+    with pytest.raises(ValueError, match="step must be positive"):
+        tiles_to_span(5.0, FOV, 0.0)
+
+
+def test_a_non_positive_field_of_view_is_refused():
+    with pytest.raises(ValueError, match="field of view must be positive"):
+        tiles_to_span(5.0, 0.0, 0.5)
+
+
+# ── the plan ─────────────────────────────────────────────────────────────
+
+
+def test_a_region_inside_one_tile_gives_a_single_enabled_tile():
+    p = plan([region(0.0, 0.0, 0.5, 0.5)])
+    assert (p.rows, p.cols, p.mask) == (1, 1, [[True]])
+
+
+def test_the_grid_centres_on_the_selection_not_the_origin():
+    p = plan([region(10.0, 20.0, 11.0, 22.0)])
+    assert (p.centre_dx, p.centre_dy) == (10.5, 21.0)
+
+
+def test_two_regions_share_one_grid_spanning_both():
+    """One selection is one acquisition; the mask is what skips the gap."""
+    p = plan([region(0.0, 0.0, 1.0, 1.0), region(4.0, 0.0, 5.0, 1.0)])
+    assert (p.rows, p.cols) == (1, 5)
+    assert p.mask == [[True, False, False, False, True]]
+
+
+def test_the_ground_between_two_regions_is_not_visited():
+    p = plan([region(0.0, 0.0, 1.0, 1.0), region(0.0, 4.0, 1.0, 5.0)])
+    assert [row[0] for row in p.mask] == [True, False, False, False, True]
+
+
+def test_overlap_packs_more_tiles_into_the_same_ground():
+    dense = plan([region(0.0, 0.0, 4.0, 1.0)], overlap=0.5)
+    sparse = plan([region(0.0, 0.0, 4.0, 1.0)], overlap=0.0)
+    assert dense.cols > sparse.cols
+
+
+def test_a_non_square_tile_is_counted_per_axis():
+    p = plan([region(0.0, 0.0, 4.0, 4.0)], fov_x=4.0, fov_y=1.0)
+    assert (p.rows, p.cols) == (4, 1)
+
+
+def test_a_region_with_no_area_selects_nothing():
+    """A click that never became a drag."""
+    with pytest.raises(ValueError, match="No region with any area"):
+        plan([region(1.0, 1.0, 1.0, 1.0)])
+
+
+def test_a_zero_area_region_does_not_stretch_a_real_one():
+    """Ignored outright, not merged into the bounding box."""
+    p = plan([region(0.0, 0.0, 1.0, 1.0), region(9.0, 9.0, 9.0, 9.0)])
+    assert (p.rows, p.cols) == (1, 1)
+
+
+def test_no_regions_at_all_is_refused():
+    with pytest.raises(ValueError, match="No region with any area"):
+        plan([])
+
+
+@pytest.mark.parametrize("overlap", [-0.1, 1.0, 1.5])
+def test_an_impossible_overlap_is_refused(overlap):
+    with pytest.raises(ValueError, match="Overlap must be"):
+        plan([region(0.0, 0.0, 1.0, 1.0)], overlap=overlap)
+
+
+# ── the plan against the layout it will be run through ───────────────────
+#
+# `plan_grid_over_regions` derives rows, cols and the mask; `compute_tile_grid_from_fov`
+# decides where those tiles actually land. Everything above tests the first against
+# itself. These test it against the second, which is what the acquisition uses.
+
+
+def tile_footprints(p, fov_x=FOV, fov_y=FOV, overlap=0.0):
+    """Where the planned grid's tiles land, in the plane the regions were given in.
+
+    Derived from the layout's own `dx`/`dy` rather than restated, so a disagreement
+    between the two shows up here. The layout measures y upward and centres the grid on
+    the run's start position -- the same two adjustments `FMTiledAcquisitionRunner`
+    makes before projecting each tile.
+    """
+    step_x, step_y = fov_x * (1 - overlap), fov_y * (1 - overlap)
+    grid = compute_tile_grid_from_fov(
+        nrows=p.rows, ncols=p.cols, fov_x=fov_x, fov_y=fov_y,
+        image_width=100, image_height=100, overlap=overlap, mask=p.mask,
+    )
+    out = {}
+    for tile in grid:
+        cx = p.centre_dx + tile.dx - (p.cols - 1) * step_x / 2
+        cy = p.centre_dy - (tile.dy + (p.rows - 1) * step_y / 2)
+        out[(tile.row, tile.col)] = (
+            PlaneRegion(cx - fov_x / 2, cy - fov_y / 2, cx + fov_x / 2, cy + fov_y / 2),
+            tile.enabled,
+        )
+    return out
+
+
+@pytest.mark.parametrize("overlap", [0.0, 0.1, 0.5])
+def test_every_enabled_tile_lands_on_a_region(overlap):
+    regions = [region(0.0, 0.0, 1.5, 2.5), region(4.0, 3.0, 5.0, 4.0)]
+    p = plan(regions, overlap=overlap)
+    for rc, (footprint, enabled) in tile_footprints(p, overlap=overlap).items():
+        touches = any(footprint.overlaps(r) for r in regions)
+        assert enabled == touches, rc
+
+
+@pytest.mark.parametrize("overlap", [0.0, 0.1, 0.5])
+def test_the_planned_grid_covers_every_region(overlap):
+    """The grid the layout produces reaches every corner of the selection."""
+    regions = [region(0.0, 0.0, 1.5, 2.5), region(4.0, 3.0, 5.0, 4.0)]
+    p = plan(regions, overlap=overlap)
+    footprints = [f for f, _ in tile_footprints(p, overlap=overlap).values()]
+    covered = PlaneRegion.from_points(
+        [(f.x0, f.y0) for f in footprints] + [(f.x1, f.y1) for f in footprints]
+    )
+    for r in regions:
+        assert covered.x0 <= r.x0 + 1e-9 and covered.x1 >= r.x1 - 1e-9
+        assert covered.y0 <= r.y0 + 1e-9 and covered.y1 >= r.y1 - 1e-9
+
+
+def test_the_grid_straddles_its_own_centre():
+    """Row 0 is the top of the plane, not the bottom -- the sign that decides whether a
+    selection's mask lands on the ground it was drawn over or mirrored across it."""
+    p = plan([region(0.0, 0.0, 1.0, 3.0)])
+    footprints = tile_footprints(p)
+    assert p.rows == 3
+    ys = [footprints[(row, 0)][0].y0 for row in range(p.rows)]
+    assert ys == sorted(ys), "row index must increase with plane y"
+
+
+def test_a_mask_that_would_acquire_nothing_cannot_be_planned():
+    """`FMTiledAcquisitionRunner` refuses an all-disabled mask; planning cannot make one."""
+    p = plan([region(0.0, 0.0, 1.0, 1.0), region(4.0, 4.0, 5.0, 5.0)])
+    assert any(any(row) for row in p.mask)


### PR DESCRIPTION
Groundwork for planning a sparse fluorescence overview by selecting regions on a FIB/SEM overview. Pure arithmetic — no UI, no acquisition, and nothing calls it yet.

A full FM overview of a grid is expensive and mostly wasted; the interesting ground is a few regions the user can already see on a beam overview. This is the geometry between "a box was dragged on the FIB image" and "the runner visits these tiles".

## Regions define the grid

Rather than painting a mask onto the grid as already configured. That alternative saves acquisition time and **no memory**: `stitch_tileset` sizes the mosaic from the grid's shape whatever the mask says, and `compute_tile_grid_from_fov` returns disabled tiles precisely so the canvas extent does not change when tiles are skipped. A small selection on a full grid would still allocate a full-grid mosaic and write it to disk, almost all zeros.

Only on this path. The ordinary FM overview keeps rows and columns as settings and centres on the stage.

## No engine change

`FMTiledAcquisitionRunner` already takes a `centre_position`, added for "an overview planned somewhere other than under the stage". So the plan supplies three values it already accepts — `centre_position`, rows/cols, `tile_mask` — and `fibsem/fm/acquisition.py` is untouched.

## The distortion is foreshortening, not rotation

There is no rotation to worry about: `_update_orientations` puts SEM and MILLING at `r = rotation_reference`, and the compustage branch forces FIB and FM to `r = 0`. What distorts is `1 / cos(stage_tilt − pre-tilt − view_tilt)`, and it depends on the pose an image was taken at rather than on the column — so it is read from the image via `surface_foreshortening` rather than derived.

The same term is why the second commit exists. A canvas frame takes its rotation and tilt from its origin, and when a selection dialog opens the stage sits at the milling orientation. Anchoring an FM plan there draws every tile **1.086x too tall** — small enough to look like a grid, large enough to plan the wrong one.

## Where to look

| | |
| -- | -- |
| `imaging/tiling/geometry.py` | `PlaneRegion`, `tiles_to_span`, `plan_grid_over_regions` — the inverse of the layout, kept beside it so the two cannot drift |
| `fm/planning.py` | carries a selection across the two projections and the change of pose |

The seam is metres, not pixels: regions arrive in the beam overview's displayed plane measured from a base, which is what `StageFrame.offset` already answers, so the planner never learns a pixel size.

## Testing

Twenty mutations of the implementation, all killed. Two are worth knowing:

* `tiles_to_span` subtracts a tolerance before `ceil`. At a field of view of 1.0 and a step of 0.5 it never matters, so a round-numbers test could not see the tolerance being removed; at a real 1.024e-4 m field of view it trips for **126** of the grid sizes swept, each adding a whole unwanted row *and* column.
* Re-posing each region corner before projecting was a no-op — `project_stage_position` works from `position - base` and reads the orientation off the base alone. Removed, with the reason recorded where the code was.

The tests that carry the feature push the plan through the same layout and projection calls `FMTiledAcquisitionRunner._setup` makes, and ask whether the tiles a run would visit land on the ground that was selected — including an asymmetric selection, since a mirrored plan matches a symmetric one.
