### PR TITLE
[feature] The FM tile preview pane for a sparse selection

### DIFF
--- a/fibsem/fm/planning.py
+++ b/fibsem/fm/planning.py
@@ -56,9 +56,11 @@ class SparseOverviewPlan:
 
     Attributes:
         centre_position: Stage position the grid straddles, at the FM orientation.
-            `FMTiledAcquisitionRunner` takes this directly, and it doubles as the origin
-            for a canvas frame drawing the plan -- see the module docstring on why that
-            must not come from the live stage.
+            `FMTiledAcquisitionRunner` takes this directly. It is also at the pose a
+            canvas frame drawing the plan must be anchored at -- though a widget wants a
+            *fixed* origin rather than one that moves with the selection, so
+            `FMTilePreviewWidget` re-poses the stage position once instead. What matters
+            is the pose; see the module docstring on why it must not be the live one.
         rows: Grid rows.
         cols: Grid columns.
         mask: Per-tile enable mask, `mask[row][col]`.

--- a/fibsem/ui/fm/widgets/fm_tile_preview.py
+++ b/fibsem/ui/fm/widgets/fm_tile_preview.py
@@ -1,0 +1,296 @@
+"""The FM tiles a selection of ground produces, drawn where they will be acquired.
+
+The right-hand pane of the sparse selection dialog. Regions are dragged on a beam
+overview in the other pane; this one answers what the fluorescence microscope would
+actually visit, at the fluorescence pose, in stage coordinates.
+
+Two panes rather than one picture, because the same ground is two different shapes: a
+FIB overview taken at the milling orientation is foreshortened against the camera, and
+at selection time there is no FM image to layer the beam one onto anyway.
+
+Deliberately inert. It draws, it reports, and it never touches the microscope beyond
+reading geometry — see :meth:`FMTilePreviewWidget.__init__` on why the stage cannot be
+driven from here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Sequence, Tuple
+
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import QVBoxLayout, QWidget
+
+from fibsem.fm.planning import SparseOverviewPlan, plan_sparse_fm_overview, to_fm_pose
+from fibsem.imaging.tiling.geometry import PlaneRegion, compute_tile_grid_from_fov
+from fibsem.microscope import FibsemMicroscope
+from fibsem.projection import FMStageProjection, StageProjection
+from fibsem.structures import FibsemStagePosition
+from fibsem.ui.tokens import GRID_BOUNDARY_COLOUR, STAGE_LIMITS_COLOUR
+from fibsem.ui.widgets.canvas.fm_canvas import FMRealSpaceCanvasWidget
+from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
+    GRID_BOUNDARY_RADIUS_M,
+    MinimapShapesOverlay,
+    ShapeSpec,
+)
+from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import TileGridOverlay
+from fibsem.ui.widgets.canvas.stage_frame import StageFrame
+
+# `ENABLED_ALPHA` is 0 on the canvas: enabled tiles are outlines, which reads over an
+# image and does not read over nothing. This pane is nothing but the grid.
+_SELECTED_FILL_ALPHA = 0.30
+
+
+class FMTilePreviewWidget(QWidget):
+    """The FM grid a set of regions produces, on a real-space canvas.
+
+    Signals:
+        selection_changed: the plan or the mask changed. One signal for both, because a
+            host showing a count cannot usefully tell them apart.
+    """
+
+    selection_changed = pyqtSignal()
+
+    def __init__(
+        self, microscope: FibsemMicroscope, parent: Optional[QWidget] = None
+    ) -> None:
+        """Build the pane against *microscope*'s fluorescence geometry.
+
+        Raises rather than degrading when the geometry cannot be read. A pane that draws
+        a grid it could not place would be indistinguishable from one that placed it
+        correctly, which is the failure this whole feature exists to avoid; the button
+        that opens the dialog is where an unavailable FM should be caught.
+
+        **Nothing here can move the stage.** The canvas only *emits*
+        ``canvas_clicked`` / ``canvas_double_clicked``; every stage move in the FM
+        overview tab lives in that tab's own handlers. Connecting neither is what keeps
+        this inert, so do not copy the tab's wiring block in.
+        """
+        super().__init__(parent)
+        self.microscope = microscope
+
+        projection = FMStageProjection.from_microscope(microscope)
+        if projection is None:
+            raise ValueError(
+                "Cannot read the fluorescence geometry; the tile preview needs it to "
+                "place a grid."
+            )
+        self._projection: StageProjection = projection
+        self._fm_orientation = microscope.get_orientation("FM")
+
+        width, height = microscope.fm.camera.resolution
+        pixel_x, pixel_y = microscope.fm.camera.pixel_size
+        self._resolution: Tuple[int, int] = (width, height)
+        self._pixel_size = pixel_x
+        self._fov: Tuple[float, float] = (width * pixel_x, height * pixel_y)
+
+        # Fixed for the life of the pane, and posed for fluorescence whatever the stage
+        # is doing. A canvas frame takes its rotation and tilt from its origin, and when
+        # this dialog opens the stage sits at the milling orientation -- that is where
+        # the beam overview was just acquired. Anchoring on the live position draws every
+        # tile 1.086x too tall: small enough to look like a grid, large enough to plan
+        # the wrong one. `tests/fm/test_planning.py` pins that number.
+        #
+        # Fixed rather than re-read, and rather than taken from the plan's own centre --
+        # both are at the fluorescence orientation, but a frame whose origin moves takes
+        # the whole scene with it, and this pane's whole job is to hold still while the
+        # selection changes underneath.
+        self._origin = to_fm_pose(
+            microscope.get_stage_position(),
+            self._fm_orientation,
+            is_compustage=microscope.stage_is_compustage,
+        )
+
+        self._plan: Optional[SparseOverviewPlan] = None
+        self._mask: List[List[bool]] = []
+        self._overlap = 0.0
+
+        self.canvas = FMRealSpaceCanvasWidget()
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.canvas)
+
+        self.tile_grid_overlay = TileGridOverlay()
+        self.tile_grid_overlay.set_fill_alpha(_SELECTED_FILL_ALPHA)
+        # The regions own the geometry here. A grid dragged in this pane would spring
+        # back the moment the plan was recomputed, which reads as a broken control.
+        self.tile_grid_overlay.set_grid_editable(False)
+        self.canvas.canvas.add_overlay(self.tile_grid_overlay)
+        self.tile_grid_overlay.tile_toggled.connect(self._on_tile_toggled)
+
+        self.stage_overlay = MinimapShapesOverlay(zorder=4.0, crosshair_half_px=24)
+        self.canvas.canvas.add_overlay(self.stage_overlay)
+
+        self.canvas.canvas.set_reference_pixel_size(self._pixel_size)
+        # Declared once, to what the stage can reach, and never again. `refit=False`
+        # does not hold a frame on a canvas with no image in it: it sets the fitted
+        # extent to `_fit_extent()`, which falls back to the working area when nothing
+        # is placed, so re-declaring per selection still moves the view. Nothing here
+        # streams in and the grid is not draggable, so there is nothing to re-declare
+        # for -- and a frame that holds still is what lets a growing selection be read
+        # as growing rather than as the world shrinking around it.
+        self.canvas.set_world_extent(
+            2 * GRID_BOUNDARY_RADIUS_M, 2 * GRID_BOUNDARY_RADIUS_M, (0.0, 0.0), refit=True
+        )
+        self._draw_stage_context()
+
+    # ── the selection ────────────────────────────────────────────────────
+
+    def set_selection(
+        self,
+        regions: Sequence[PlaneRegion],
+        beam_base: FibsemStagePosition,
+        beam_projection: StageProjection,
+        overlap: float,
+    ) -> Optional[SparseOverviewPlan]:
+        """Draw the grid *regions* produce, and return the plan.
+
+        Any tiles toggled by hand are discarded: the grid is re-derived, so a toggle
+        recorded against the old one would land on a different tile or on none. Nothing
+        marks a surviving toggle -- the overlay draws every enabled tile the same -- so
+        keeping them would leave tiles on with no visible reason, which reads as a bug.
+
+        Args:
+            regions: Rectangles in the beam overview's displayed plane, in metres from
+                *beam_base*.
+            beam_base: The stage position those metres are measured from.
+            beam_projection: The beam overview's own projection.
+            overlap: Fractional overlap between adjacent FM tiles.
+
+        Returns:
+            The plan, or None if the regions select nothing.
+        """
+        self._overlap = overlap
+        try:
+            plan = plan_sparse_fm_overview(
+                regions,
+                beam_base,
+                beam_projection,
+                self._projection,
+                self._fm_orientation,
+                fov_x=self._fov[0],
+                fov_y=self._fov[1],
+                overlap=overlap,
+                is_compustage=self.microscope.stage_is_compustage,
+            )
+        except ValueError as e:
+            # Selecting nothing is a state, not a failure -- a region dragged to zero
+            # area, or none drawn yet.
+            logging.debug(f"No grid to plan from this selection: {e}")
+            self.clear()
+            return None
+
+        self._plan = plan
+        self._mask = [list(row) for row in plan.mask]
+        self._redraw()
+        self.selection_changed.emit()
+        return plan
+
+    def clear(self) -> None:
+        """Drop the selection, leaving the stage context drawn."""
+        if self._plan is None and not self._mask:
+            return
+        self._plan = None
+        self._mask = []
+        self.tile_grid_overlay.clear()
+        self.selection_changed.emit()
+
+    # ── what the host reads ──────────────────────────────────────────────
+
+    @property
+    def plan(self) -> Optional[SparseOverviewPlan]:
+        """The plan as last computed, before any hand toggles."""
+        return self._plan
+
+    @property
+    def mask(self) -> List[List[bool]]:
+        """The mask as it stands, hand toggles included. A copy."""
+        return [list(row) for row in self._mask]
+
+    @property
+    def enabled_tiles(self) -> int:
+        return sum(sum(1 for on in row if on) for row in self._mask)
+
+    @property
+    def total_tiles(self) -> int:
+        return sum(len(row) for row in self._mask)
+
+    # ── drawing ──────────────────────────────────────────────────────────
+
+    def _frame(self) -> StageFrame:
+        return StageFrame(self.canvas.canvas, self._origin, self._projection)
+
+    def _redraw(self) -> None:
+        if self._plan is None:
+            self.tile_grid_overlay.clear()
+            return
+        width, height = self._resolution
+        tiles = compute_tile_grid_from_fov(
+            nrows=self._plan.rows,
+            ncols=self._plan.cols,
+            fov_x=self._fov[0],
+            fov_y=self._fov[1],
+            image_width=width,
+            image_height=height,
+            overlap=self._overlap,
+            mask=self._mask,
+        )
+        offset = self._frame().offset(self._plan.centre_position)
+        self.tile_grid_overlay.set_anchor(self.canvas.canvas.metres_to_canvas(*offset))
+        # No `display_pixel_size`: the overlay reads it from the canvas at draw time.
+        self.tile_grid_overlay.set_grid(
+            tiles, (height, width), self._pixel_size, overlap=self._overlap
+        )
+
+    def _draw_stage_context(self) -> None:
+        """Where the stage can go, drawn once.
+
+        The origin is fixed and the limits do not move, so this is not refreshed. It is
+        also the only reachability the dialog offers: a selection that reaches past the
+        boundary is visibly past it, without a per-tile check being built.
+        """
+        frame = self._frame()
+        try:
+            centre = frame.to_canvas(
+                FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0)
+            )
+        except Exception as e:
+            logging.debug(f"Cannot place the grid centre: {e}")
+            return
+
+        limits = getattr(self.microscope._stage, "limits", None)
+        if not limits or not self.microscope.stage_is_compustage:
+            return
+
+        # No `surface_foreshortening` term: these lie on the sample, and the sample is
+        # square-on to the camera at the fluorescence pose. The beam pane, drawn from a
+        # tilted view, does need it.
+        self.stage_overlay.set_shapes([
+            ShapeSpec(
+                kind="rect", cx=centre[0], cy=centre[1], color=STAGE_LIMITS_COLOUR,
+                width=frame.length(limits["x"].max - limits["x"].min),
+                height=frame.length(limits["y"].max - limits["y"].min),
+                label="Stage limits",
+            ),
+            ShapeSpec(
+                kind="circle", cx=centre[0], cy=centre[1], color=GRID_BOUNDARY_COLOUR,
+                radius=frame.length(GRID_BOUNDARY_RADIUS_M), label="Grid boundary",
+            ),
+        ])
+
+    # ── edits ────────────────────────────────────────────────────────────
+
+    def _on_tile_toggled(self, row: int, col: int, enabled: bool) -> None:
+        """One tile, added or dropped by hand.
+
+        Guarded on the current shape rather than trusted: the overlay emits against the
+        grid it was last given, and a selection change between the press and the release
+        would otherwise write outside the mask.
+        """
+        if row >= len(self._mask) or col >= len(self._mask[row]):
+            return
+        if self._mask[row][col] == enabled:
+            return
+        self._mask[row][col] = enabled
+        self._redraw()
+        self.selection_changed.emit()

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -97,6 +97,9 @@ class TileGridOverlay(QObject, CanvasOverlay):
         self._previous_margin: Optional[float] = None
         self._cids: List[int] = []
         self._resize_axes: Optional[Tuple[bool, bool]] = None  # (horizontal, vertical)
+        # Whether dragging may change the grid's *geometry*. Tile toggling is separate
+        # and always allowed -- see `set_grid_editable`.
+        self._geometry_editable: bool = True
         self._cursor_set: bool = False
         # A press inside the grid, held until it resolves into a move or a tile click:
         # (press_px_x, press_px_y, press_x, press_y, anchor_x, anchor_y). The screen
@@ -242,6 +245,21 @@ class TileGridOverlay(QObject, CanvasOverlay):
         """Hide the grid without discarding it, for an unobstructed look at the data."""
         self._visible = bool(visible)
         self._redraw()
+
+    def set_grid_editable(self, editable: bool) -> None:
+        """Whether dragging may move or resize the grid. Toggling tiles is unaffected.
+
+        For a host that derives the grid from something else and would only have to undo
+        the drag -- the sparse selection dialog computes rows, columns and centre from
+        the regions drawn on a beam overview, so a grid dragged here would spring back
+        the moment the plan was recomputed, which reads as a broken control rather than
+        an absent one.
+
+        The resize cursor goes with it. An affordance that advertises a gesture the host
+        discards is worse than no affordance, since the only way to learn it does nothing
+        is to try it.
+        """
+        self._geometry_editable = bool(editable)
 
     @property
     def is_grid_visible(self) -> bool:
@@ -493,7 +511,7 @@ class TileGridOverlay(QObject, CanvasOverlay):
             return
 
         edges = self._edge_at(event.xdata, event.ydata)
-        if edges is not None:
+        if edges is not None and self._geometry_editable:
             self._resize_axes = edges
             self._claim(event)
             return
@@ -588,6 +606,7 @@ class TileGridOverlay(QObject, CanvasOverlay):
         if (
             self._visible
             and self._tiles
+            and self._geometry_editable
             and event.inaxes is self._ax
             and event.xdata is not None
         ):
@@ -609,7 +628,10 @@ class TileGridOverlay(QObject, CanvasOverlay):
             self._drag_paint(event)
             return
         if self._move_start is not None:
-            self._drag_move(event)
+            # Still held when the geometry is fixed: it is what the release reads to
+            # decide the press was a click, and so a tile toggle.
+            if self._geometry_editable:
+                self._drag_move(event)
             return
         if self._resize_axes is None:
             self._update_cursor(event)

--- a/tests/ui/test_fm_tile_preview.py
+++ b/tests/ui/test_fm_tile_preview.py
@@ -1,0 +1,237 @@
+"""The FM tile preview pane: what a selection of ground would actually acquire.
+
+The pane's job is to be *right* and to be *inert*. Right, because a grid drawn against
+the wrong pose still looks like a grid — the arithmetic behind that is pinned in
+`tests/fm/test_planning.py`, and what is pinned here is that the widget uses it. Inert,
+because it is a preview inside a dialog and the stage must not move while someone is
+deciding where to look.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.imaging.tiling.geometry import PlaneRegion
+from fibsem.projection import BeamStageProjection, surface_foreshortening
+from fibsem.structures import BeamType, FibsemStagePosition
+from fibsem.ui.fm.widgets.fm_tile_preview import FMTilePreviewWidget
+
+OVERLAP = 0.1
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def microscope(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    return build_microscope()
+
+
+@pytest.fixture()
+def pane(microscope):
+    widget = FMTilePreviewWidget(microscope)
+    widget.setFixedSize(316, 386)
+    return widget
+
+
+def beam_view(microscope, orientation="MILLING", beam_type=BeamType.ION):
+    projection = BeamStageProjection.from_microscope(microscope, beam_type)
+    pose = microscope.get_orientation(orientation)
+    return projection, FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
+
+
+def regions(*boxes):
+    return [PlaneRegion.from_points([(x0, y0), (x1, y1)]) for x0, y0, x1, y1 in boxes]
+
+
+# A wide, shallow pair in the beam plane. Shallow on purpose: the ion view at the
+# milling pose is foreshortened, so a box that looks nearly square there is a strip of
+# ground almost four times taller.
+TWO_REGIONS = ((-560e-6, -110e-6, -60e-6, -17e-6), (300e-6, 34e-6, 760e-6, 125e-6))
+
+
+def select(pane, microscope, *boxes, overlap=OVERLAP):
+    projection, base = beam_view(microscope)
+    return pane.set_selection(regions(*boxes), base, projection, overlap)
+
+
+# ── inert ────────────────────────────────────────────────────────────────
+
+
+def test_nothing_in_the_pane_can_move_the_stage(pane):
+    """The safety property, and the reason it is worth a test rather than a comment.
+
+    The canvas only *emits* click signals; every stage move in the FM overview tab lives
+    in that tab's handlers, connected to those same signals. So the pane is inert only
+    for as long as nobody copies the tab's wiring block across — which is exactly the
+    kind of thing that gets copied.
+    """
+    canvas = pane.canvas.canvas
+    assert canvas.receivers(canvas.canvas_clicked) == 0
+    assert canvas.receivers(canvas.canvas_double_clicked) == 0
+
+
+def test_the_grid_cannot_be_dragged_out_of_shape(pane):
+    """Rows, columns and centre come from the regions. A grid dragged here would spring
+    back on the next recompute, which reads as a broken control rather than an absent
+    one."""
+    assert pane.tile_grid_overlay._geometry_editable is False
+
+
+def test_selected_tiles_are_filled_not_just_outlined(pane):
+    """`ENABLED_ALPHA` is 0 on the canvas, so enabled tiles are outlines. That reads over
+    an image and does not read over nothing, and this pane is nothing but the grid."""
+    assert pane.tile_grid_overlay._fill_alpha > 0
+
+
+# ── right ────────────────────────────────────────────────────────────────
+
+
+def test_the_frame_is_posed_for_fluorescence_wherever_the_stage_is(microscope):
+    """Built with the stage at the milling pose, because that is where a beam overview
+    was just acquired. Anchoring on the live position draws every tile 1.086x too tall.
+    """
+    milling = microscope.get_orientation("MILLING")
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=milling.r, t=milling.t)
+    )
+    widget = FMTilePreviewWidget(microscope)
+
+    assert surface_foreshortening(
+        widget._projection, widget._origin
+    ) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_the_drawn_grid_is_the_planned_grid(pane, microscope):
+    """The widget must not re-derive a shape of its own; it draws what the planner said."""
+    plan = select(pane, microscope, *TWO_REGIONS)
+
+    drawn = pane.tile_grid_overlay._tiles
+    assert plan is not None
+    assert max(t.row for t in drawn) + 1 == plan.rows
+    assert max(t.col for t in drawn) + 1 == plan.cols
+    assert [[t.enabled for t in drawn if t.row == r] for r in range(plan.rows)] == plan.mask
+
+
+def test_a_bigger_selection_needs_a_bigger_grid(pane, microscope):
+    one = select(pane, microscope, TWO_REGIONS[0])
+    two = select(pane, microscope, *TWO_REGIONS)
+
+    assert two.rows * two.cols > one.rows * one.cols
+    assert pane.enabled_tiles > 0
+
+
+# ── the frame holds still ────────────────────────────────────────────────
+
+
+def test_the_working_area_is_declared_once(pane, microscope):
+    """A stable frame is what lets a growing selection read as growing, rather than as
+    the world shrinking around it. `refit=False` cannot deliver that on a canvas with no
+    image: `_fit_extent` falls back to the working area when nothing is placed, so
+    re-declaring per selection moves the view anyway. So it is never re-declared.
+    """
+    at_open = pane.canvas.canvas.world_extent
+    select(pane, microscope, TWO_REGIONS[0])
+    select(pane, microscope, *TWO_REGIONS)
+    pane.clear()
+
+    assert pane.canvas.canvas.world_extent == at_open
+
+
+# ── editing by hand ──────────────────────────────────────────────────────
+
+
+def test_toggling_a_tile_changes_the_mask_but_not_the_plan(pane, microscope):
+    plan = select(pane, microscope, *TWO_REGIONS)
+    before = pane.enabled_tiles
+
+    pane._on_tile_toggled(0, 0, not pane.mask[0][0])
+
+    assert pane.enabled_tiles != before
+    assert pane.plan is plan, "the plan is what the regions said; a toggle is not"
+
+
+def test_a_new_selection_discards_tiles_toggled_by_hand(pane, microscope):
+    """The grid is re-derived, so a toggle recorded against the old one would land on a
+    different tile or on none. Nothing marks a surviving toggle — the overlay draws every
+    enabled tile alike — so keeping them would leave tiles on for no visible reason."""
+    select(pane, microscope, *TWO_REGIONS)
+    pane._on_tile_toggled(0, 0, not pane.mask[0][0])
+    edited = pane.mask
+
+    select(pane, microscope, *TWO_REGIONS)
+
+    assert pane.mask != edited
+
+
+def test_a_toggle_outside_the_current_grid_is_ignored(pane, microscope):
+    """The overlay emits against the grid it was last given, and a selection change
+    between the press and the release would otherwise write outside the mask."""
+    select(pane, microscope, TWO_REGIONS[0])
+    before = pane.mask
+
+    pane._on_tile_toggled(999, 999, True)
+
+    assert pane.mask == before
+
+
+# ── nothing selected ─────────────────────────────────────────────────────
+
+
+def test_a_region_with_no_area_selects_nothing_rather_than_raising(pane, microscope):
+    """A click that never became a drag. A state, not a failure."""
+    assert select(pane, microscope, (1e-4, 1e-4, 1e-4, 1e-4)) is None
+    assert pane.plan is None
+    assert pane.enabled_tiles == 0
+
+
+def test_clearing_a_selection_leaves_the_stage_context_drawn(pane, microscope):
+    """The boundary and limits are the pane's only reachability cue, and they do not
+    depend on there being a selection."""
+    select(pane, microscope, *TWO_REGIONS)
+    pane.clear()
+
+    assert pane.tile_grid_overlay._tiles == []
+    assert pane.stage_overlay._specs
+
+
+# ── what the host reads ──────────────────────────────────────────────────
+
+
+def test_the_pane_reports_every_change_once(pane, microscope):
+    fired = []
+    pane.selection_changed.connect(lambda: fired.append(1))
+
+    select(pane, microscope, *TWO_REGIONS)
+    pane._on_tile_toggled(0, 0, not pane.mask[0][0])
+    pane.clear()
+
+    assert len(fired) == 3
+
+
+def test_clearing_nothing_reports_nothing(pane):
+    """Or a host that recomputes on every signal would do so for no reason."""
+    fired = []
+    pane.selection_changed.connect(lambda: fired.append(1))
+
+    pane.clear()
+
+    assert fired == []
+
+
+def test_the_mask_the_host_reads_cannot_be_written_through(pane, microscope):
+    select(pane, microscope, *TWO_REGIONS)
+    taken = pane.mask
+
+    taken[0][0] = not taken[0][0]
+
+    assert pane.mask != taken

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -975,3 +975,78 @@ def test_detaching_mid_paint_does_not_leave_the_gesture_armed(qapp):
 
     assert overlay._paint_value is None
     assert overlay._painted == set()
+
+
+# ── a grid whose geometry belongs to someone else ────────────────────────
+#
+# The sparse selection dialog derives rows, columns and centre from regions drawn on a
+# beam overview, so a grid dragged in its preview pane would spring back the moment the
+# plan was recomputed. `set_grid_editable(False)` withdraws the two geometry gestures
+# and leaves everything else, which is the only combination that pane can use.
+
+
+def test_the_grid_is_editable_by_default(qapp):
+    """The flag is opt-out; every existing caller wants the drag."""
+    overlay, _ = build(3, 3)
+    right, _ = _edges(overlay)
+
+    overlay._on_press(_event(overlay, right, overlay._rect.cy))
+
+    assert overlay.is_resizing is True
+
+
+def test_a_fixed_grid_cannot_be_resized(qapp):
+    overlay, _ = build(3, 3, overlap=OVERLAP)
+    overlay.set_grid_editable(False)
+    requested = []
+    overlay.grid_resize_requested.connect(lambda r, c: requested.append((r, c)))
+    right, _ = _edges(overlay)
+
+    overlay._on_press(_event(overlay, right, overlay._rect.cy))
+    overlay._on_drag(_event(overlay, right + WIDTH, overlay._rect.cy))
+
+    assert overlay.is_resizing is False
+    assert requested == []
+
+
+def test_a_fixed_grid_cannot_be_moved(qapp):
+    overlay, _ = build(3, 3)
+    overlay.set_grid_editable(False)
+    moved = []
+    overlay.grid_move_requested.connect(lambda x, y: moved.append((x, y)))
+    cx, cy = _centre(overlay)
+
+    _drag(overlay, (cx, cy), (cx + 300.0, cy - 125.0))
+
+    assert moved == []
+
+
+def test_a_fixed_grid_can_still_have_its_tiles_toggled(qapp):
+    """The point of the flag: hand adjustment survives, geometry does not.
+
+    A press inside the grid is held rather than acted on, because the same press starts
+    a move and a toggle -- so withdrawing the move must not also withdraw what the
+    release reads.
+    """
+    overlay, tiles = build(3, 3)
+    overlay.set_grid_editable(False)
+    toggled = []
+    overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+    centre = next(t for t in tiles if (t.row, t.col) == (1, 1))
+    x, y, width, height = overlay._rect_for(centre)
+
+    _click(overlay, x + width / 2, y + height / 2)
+
+    assert toggled == [(1, 1, False)]
+
+
+def test_a_fixed_grid_offers_no_resize_cursor(qapp):
+    """An affordance for a gesture the host discards is worse than none: the only way
+    to learn it does nothing is to try it."""
+    overlay, _ = build(3, 3)
+    overlay.set_grid_editable(False)
+    right, _ = _edges(overlay)
+
+    overlay._update_cursor(_event(overlay, right, overlay._rect.cy))
+
+    assert overlay._canvas.cursor is None


### PR DESCRIPTION
Closes FIB-726.

**Stacked on #456** — base is `claude/sparse-fm-overview-planning`, so review that one first. This diff is the pane alone.

The right-hand pane of the sparse selection dialog: the tiles a set of regions would actually visit, drawn at the fluorescence pose in stage coordinates. Regions arrive as a parameter — drawing them is the next piece — and nothing constructs this yet.

Two panes rather than one picture, because the same ground is two different shapes: a FIB overview taken at the milling orientation is foreshortened against the camera, and at selection time there is no FM image to layer the beam one onto anyway.

## Three things it has to get right, each of which looks fine when wrong

**The frame is posed for fluorescence, whatever the stage is doing.** When this dialog opens the stage sits at the milling orientation — that is where the beam overview was just acquired — and a canvas frame takes its rotation and tilt from its origin. The origin is `to_fm_pose` of the stage position, taken once and held, rather than the plan's own centre: both are at the right pose, but a frame whose origin moves takes the whole scene with it, and holding still while the selection changes is most of what this pane is for.

**The working area is declared once.** `refit=False` does not hold a frame on a canvas with no image in it — it sets the fitted extent to `_fit_extent()`, which falls back to the working area when nothing is placed, so re-declaring per selection moves the view anyway. Nothing streams in here and the grid is not draggable, so there is nothing to re-declare for.

**Nothing in it can move the stage.** The canvas only emits `canvas_clicked` / `canvas_double_clicked`; every stage move in the FM overview tab lives in that tab's handlers, connected to those same signals. Connecting neither is the whole mechanism, so it is asserted rather than commented — the failure mode is someone copying the tab's wiring block across.

## `TileGridOverlay.set_grid_editable`

New, defaulting to `True` so no existing caller changes. It withdraws the two geometry gestures — edge resize and body drag — and the resize cursor that advertises them, while leaving tile toggling alone.

Here the regions own rows, columns and centre, so a dragged grid would spring back on the next recompute: a control that looks live and is not, which is worse than one that is absent. Toggling had to survive the gate because the same press starts both a move and a toggle, and only the release tells them apart.

## Testing

Thirteen mutations of the pane and five of the overlay flag, all killed. Two needed the tests fixed first — nothing covered `set_fill_alpha` (`ENABLED_ALPHA` is 0, so without raising it a selection is outlines on an otherwise empty pane), and nothing covered the cursor suppression.

`tests/ui` does not run in CI, which has no PyQt5, so everything assertable about the *plan* rather than the widget lives in `tests/fm/test_planning.py` instead.

Worth knowing while reviewing: `tests/ui` has ~22 pre-existing failures on `main`, across `test_overview_tab_host.py`, `test_overview_widget.py` and `test_fm_live_indicator.py`. None of them are new here — the failing set on this branch is a subset of `main`'s — but they are worth chasing separately, and are plausibly related to the overview tab still waiting on bench time.
