### PR TITLE
[fix] Read the tile progress payload, do not index it (FIB-732)

### DIFF
--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -632,17 +632,34 @@ class FibsemMinimapWidget(QWidget):
 
     @ensure_main_thread
     def handle_tile_acquisition_progress(self, ddict: dict) -> None:
-        """Callback for handling the tile acquisition progress."""
+        """Callback for handling the tile acquisition progress.
 
+        Read with `.get`, not indexed. This signal has no discriminator -- a consumer
+        works out what it received from which keys are present -- so a payload shape
+        that omits any of these is not a degraded label here, it is a `KeyError` inside
+        a Qt slot, mid-acquisition. All three shapes `tiled.py` emits happen to carry
+        them today, which is the only reason indexing has held (FIB-402).
+
+        `total` is guarded rather than defaulted, because it is a divisor: a payload
+        reporting nothing to do would take the bar out with a `ZeroDivisionError`
+        instead. Nothing is drawn for a payload that cannot say how far along it is,
+        which leaves the last real progress standing -- true, rather than reset to zero.
+
+        `FibsemOverviewWidget._apply_progress` reads the same signal the same way.
+        """
         # track counts for result dict
-        count, total = ddict["counter"], ddict["total"]
-        self._tiles_acquired = count
-        self._tile_total_count = total
+        counter = ddict.get("counter")
+        total = ddict.get("total")
+        if counter is not None and total:
+            self._tiles_acquired = counter
+            self._tile_total_count = total
 
-        # progress bar
-        self.progressBar_acquisition.setMaximum(100)
-        self.progressBar_acquisition.setValue(int(count/total*100))
-        self.progressBar_acquisition.setFormat(f"{ddict['msg']} — {count}/{total} tiles (%p%)")
+            # progress bar
+            self.progressBar_acquisition.setMaximum(100)
+            self.progressBar_acquisition.setValue(int(counter / total * 100))
+            self.progressBar_acquisition.setFormat(
+                f"{ddict.get('msg', 'Acquiring')} — {counter}/{total} tiles (%p%)"
+            )
 
         image = ddict.get("image", None)
         if image is not None:

--- a/tests/test_tiled_progress_payload.py
+++ b/tests/test_tiled_progress_payload.py
@@ -59,9 +59,14 @@ def _per_tile(payloads):
 
 
 def test_every_tile_update_carries_the_keys_its_consumers_index(payloads):
-    """`counter`, `total` and `msg` are read unconditionally by more than one consumer
-    -- `FibsemMinimapWidget.handle_tile_acquisition_progress` indexes them directly and
-    raises on a payload without them."""
+    """`counter`, `total` and `msg` are what every consumer draws its bar from.
+
+    They used to be *indexed* -- `FibsemMinimapWidget.handle_tile_acquisition_progress`
+    raised on a payload without them, so this test stood between that consumer and a
+    `KeyError` mid-acquisition. Both consumers now read with `.get` and skip the update
+    instead (FIB-402), so the stake is lower: a per-tile payload missing these shows no
+    progress rather than taking the widget out. Still a contract, and still worth
+    asserting -- a run whose progress silently stops moving is its own bug."""
     updates = _per_tile(payloads)
     assert len(updates) == 2, "expected one update per tile"
     for payload in updates:

--- a/tests/ui/test_minimap_progress_payload_safety.py
+++ b/tests/ui/test_minimap_progress_payload_safety.py
@@ -1,0 +1,100 @@
+"""The napari minimap survives a progress payload it did not expect.
+
+`tiled_acquisition_signal` has no discriminator: a consumer works out what it received
+from which keys are present. This handler indexed `counter`, `total` and `msg` directly,
+so any payload shape omitting one was a `KeyError` inside a Qt slot, mid-acquisition —
+and `total` is a divisor, so a payload reporting nothing to do took the bar out with a
+`ZeroDivisionError` instead (FIB-402).
+
+That was latent while `imaging/tiled.py` was the signal's only emitter. It stops being
+latent the moment a second producer emits there, which is what FIB-725 proposes.
+
+The whole widget cannot be built here — it constructs a `napari.Viewer`, which segfaults
+under the offscreen platform — so the handler is borrowed onto a host carrying the four
+attributes it touches. The progress bar is a real `QProgressBar`, which is the part
+under test.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QProgressBar  # noqa: E402
+
+
+@pytest.fixture
+def handler(qapp):
+    from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
+
+    class _Host:
+        handle_tile_acquisition_progress = (
+            FibsemMinimapWidget.handle_tile_acquisition_progress
+        )
+
+        def __init__(self):
+            self.progressBar_acquisition = QProgressBar()
+            self._tiles_acquired = 0
+            self._tile_total_count = 0
+            self.shown = []
+
+        def update_viewer(self, image, tmp=False):
+            self.shown.append(image)
+
+    host = _Host()
+    yield host
+    host.progressBar_acquisition.deleteLater()
+
+
+def test_a_normal_tile_update_still_draws_the_bar(handler):
+    handler.handle_tile_acquisition_progress(
+        {"counter": 3, "total": 9, "msg": "Tile Collected"}
+    )
+    assert handler._tiles_acquired == 3
+    assert handler._tile_total_count == 9
+    assert handler.progressBar_acquisition.value() == 33
+    assert "Tile Collected" in handler.progressBar_acquisition.format()
+    assert "3/9 tiles" in handler.progressBar_acquisition.format()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"total": 9, "msg": "Tile Collected"},          # no counter
+        {"counter": 3, "msg": "Tile Collected"},        # no total
+        {"counter": 3, "total": 9},                     # no msg
+        {"counter": 0, "total": 0, "msg": "Nothing"},   # nothing to do
+        {"current": 3, "total": 9, "task": "tileset"},  # the fluorescence spelling
+    ],
+)
+def test_an_unexpected_payload_does_not_take_the_bar_out(handler, payload):
+    """Each of these was a crash: the first four a `KeyError`, the fifth a
+    `ZeroDivisionError`, and the last is what a fluorescence run would send if it
+    emitted here — the case that turns all of this from latent into live."""
+    handler.handle_tile_acquisition_progress(payload)
+
+
+def test_a_payload_with_no_counts_leaves_the_last_progress_standing(handler):
+    """Not reset to zero. The run has not gone backwards, and the terminal payload from
+    a cancelled run carries no counts — so zeroing here would end every cancelled run by
+    claiming it never started."""
+    handler.handle_tile_acquisition_progress(
+        {"counter": 4, "total": 9, "msg": "Tile Collected"}
+    )
+    before = handler.progressBar_acquisition.value()
+    handler.handle_tile_acquisition_progress({"msg": "Stitching Tiles"})
+    assert handler.progressBar_acquisition.value() == before
+    assert handler._tiles_acquired == 4
+
+
+def test_a_preview_is_still_shown_when_the_counts_are_missing(handler):
+    """The image and the counters are independent: dropping the bar update must not
+    drop the picture with it."""
+    sentinel = object()
+    handler.handle_tile_acquisition_progress({"image": sentinel})
+    assert handler.shown == [sentinel]


### PR DESCRIPTION
`FibsemMinimapWidget.handle_tile_acquisition_progress` read the payload by subscript:

```python
count, total = ddict["counter"], ddict["total"]
self.progressBar_acquisition.setValue(int(count/total*100))
self.progressBar_acquisition.setFormat(f"{ddict['msg']} — {count}/{total} tiles (%p%)")
```

Three `KeyError`s and a `ZeroDivisionError`, inside a Qt slot, in the middle of an acquisition.

`tiled_acquisition_signal` carries no discriminator — a consumer works out what it received from which keys are present — so a payload shape omitting any of these is not a degraded label, it is the widget going down. It has held only because `imaging/tiled.py` is the signal's sole emitter and all three of its shapes happen to carry them.

## Why now

That property is exactly what FIB-725 removes: the fluorescence runner's count key is **`current`, not `counter`**, so the moment it emits on this signal all four failures become live. This lands first for that reason.

It stands on its own regardless — the minimap is still the *default* overview UI, since the rebuilt tab is behind a flag that is off by default.

## The judgement calls

**`total` is guarded, not defaulted**, since it is a divisor. A payload that cannot say how far along it is now draws nothing — which leaves the last real progress standing rather than resetting to zero. That matters: a cancelled run's terminal payload carries no counts, so zeroing would end every cancelled run by claiming it never started.

**The preview is unaffected either way.** The image and the counters are independent, and dropping the bar update must not drop the picture with it.

`FibsemOverviewWidget._apply_progress` and `AutoLamellaSingleWindowUI._on_tile_acquisition_progress` already read this way — the minimap was the last one. No consumer of this signal indexes its payload now.

## Also

`tests/test_tiled_progress_payload.py` justified asserting these keys by saying the minimap "indexes them directly and raises on a payload without them". That rationale is now false, so it is corrected rather than left to mislead. The keys are still a contract — a run whose progress silently stops moving is its own bug — but the stake is a blank bar, not a crash.

## Verification

- **5455 tests pass** across `tests/` and the autolamella UI tests.
- Nine new tests, one of them parametrised over six payload shapes — including `{"current": 3, "total": 9, "task": "tileset"}`, which is literally what a fluorescence run would send.
- Restoring the direct indexing fails **8 of the 9**.
- The widget itself cannot be constructed under the offscreen platform (it builds a `napari.Viewer`, which segfaults), so the handler is borrowed onto a host carrying the four attributes it touches. The progress bar is a real `QProgressBar` — the part actually under test.