### PR TITLE
[feature] Draw the ground to image on a beam overview

### DIFF
--- a/fibsem/ui/fm/sparse_selection_app.py
+++ b/fibsem/ui/fm/sparse_selection_app.py
@@ -1,0 +1,165 @@
+"""Standalone app for the sparse FM selection panes.
+
+Opens the two halves side by side against a real or simulated microscope, so they can be
+driven before the dialog that will hold them exists.
+
+    python -m fibsem.ui.fm.sparse_selection_app                    # Demo, two beam views
+    python -m fibsem.ui.fm.sparse_selection_app --manufacturer Thermo --ip 10.0.0.1
+
+Right-click the left pane to add a region, then drag it or its corners. The right pane
+shows the FM tiles that selection would acquire, recomputed on every change.
+
+The wiring here is a stand-in for the dialog, not its design: it does the minimum to
+make the two panes talk, so the pieces can be exercised on hardware while the dialog is
+still being built.
+"""
+
+import argparse
+import logging
+import sys
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from fibsem.microscope import FibsemMicroscope
+from fibsem.structures import BeamType, FibsemStagePosition, ImageSettings
+from fibsem.ui.fm.overview_app import build_microscope
+
+OVERLAP = 0.1
+# Big enough to hold several grid squares, so there is something worth being sparse about.
+OVERVIEW_HFW = 900e-6
+
+
+def acquire_beam_overviews(
+    microscope: FibsemMicroscope, hfw: float = OVERVIEW_HFW
+) -> Dict[object, List[object]]:
+    """One overview per beam view, so the chip strip has something to switch between.
+
+    Acquired here rather than loaded, because the point is to exercise the panes against
+    images that carry their own pose -- which is what the selection resolves against.
+    """
+    from fibsem.ui.widgets.overview_widget import OverviewView
+
+    views: Dict[object, List[object]] = {}
+    for orientation, beam_type in (
+        ("SEM", BeamType.ELECTRON),
+        ("MILLING", BeamType.ION),
+    ):
+        pose = microscope.get_orientation(orientation)
+        microscope.move_stage_absolute(
+            FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
+        )
+        image = microscope.acquire_image(
+            ImageSettings(
+                hfw=hfw, resolution=[1024, 1024], beam_type=beam_type, save=False
+            )
+        )
+        views[OverviewView(beam_type, orientation)] = [image]
+        logging.info(
+            f"acquired {beam_type.name} @ {orientation}, "
+            f"t = {np.degrees(pose.t):.1f} deg"
+        )
+    return views
+
+
+def build_window(microscope: FibsemMicroscope):
+    from PyQt5.QtWidgets import (
+        QHBoxLayout,
+        QLabel,
+        QVBoxLayout,
+        QWidget,
+    )
+
+    from fibsem.ui.fm.widgets.fm_region_selector import FMRegionSelectorWidget
+    from fibsem.ui.fm.widgets.fm_tile_preview import FMTilePreviewWidget
+    from fibsem.ui.stylesheets import CANVAS_BG
+    from fibsem.ui.tokens import TEXT_COLOR, TEXT_MUTED_COLOR
+
+    views = acquire_beam_overviews(microscope)
+    # Back to the fluorescence pose, as the FM tab would leave it. The preview must be
+    # right from either, which is what pinning its frame to the FM orientation is for --
+    # try commenting this out, and nothing about the right pane should change.
+    microscope.move_to_microscope("FM")
+
+    selector = FMRegionSelectorWidget(microscope)
+    preview = FMTilePreviewWidget(microscope)
+    selector.set_views(views)
+
+    status = QLabel()
+    status.setStyleSheet(f"color:{TEXT_COLOR};font-size:11px;padding:4px 8px;")
+    hint = QLabel(
+        "right-click the beam overview to add a region  ·  drag it or its corners  ·  "
+        "click a tile on the right to add or drop it"
+    )
+    hint.setStyleSheet(f"color:{TEXT_MUTED_COLOR};font-size:10px;padding:0 8px 4px;")
+
+    def recompute():
+        regions = selector.regions
+        if not regions or selector.base is None or selector.projection is None:
+            preview.clear()
+        else:
+            preview.set_selection(
+                regions, selector.base, selector.projection, OVERLAP
+            )
+        describe()
+
+    def describe():
+        plan = preview.plan
+        if plan is None:
+            status.setText(f"{selector.describe_selected()}   —   no tiles selected")
+            return
+        minutes = preview.enabled_tiles * 3 * 4 // 60
+        status.setText(
+            f"{selector.describe_selected()}   —   "
+            f"{plan.rows} x {plan.cols} grid, "
+            f"{preview.enabled_tiles} of {preview.total_tiles} tiles, "
+            f"~{minutes} min"
+        )
+
+    selector.regions_changed.connect(recompute)
+    selector.selection_changed.connect(lambda _index: describe())
+    preview.selection_changed.connect(describe)
+
+    panes = QHBoxLayout()
+    panes.setSpacing(8)
+    panes.addWidget(selector, 3)
+    panes.addWidget(preview, 2)
+
+    window = QWidget()
+    window.setWindowTitle("Sparse FM selection — panes")
+    window.setStyleSheet(f"QWidget {{ background: {CANVAS_BG}; }}")
+    layout = QVBoxLayout(window)
+    layout.setContentsMargins(8, 8, 8, 8)
+    layout.addLayout(panes)
+    layout.addWidget(status)
+    layout.addWidget(hint)
+    window.resize(1180, 680)
+    describe()
+    return window
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manufacturer", default="Demo")
+    parser.add_argument("--ip", default="localhost")
+    parser.add_argument(
+        "--hfw", type=float, default=OVERVIEW_HFW,
+        help="beam overview field width, in metres",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO)
+
+    from PyQt5.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    microscope = build_microscope(
+        manufacturer=args.manufacturer, ip_address=args.ip
+    )
+    window = build_window(microscope)
+    window.show()
+    return app.exec_()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fibsem/ui/fm/widgets/fm_region_selector.py
+++ b/fibsem/ui/fm/widgets/fm_region_selector.py
@@ -1,0 +1,432 @@
+"""An acquired FIB/SEM overview, with the ground to image drawn on it.
+
+The left-hand pane of the sparse selection dialog. The user looks at a beam overview,
+decides which parts of the grid are worth the fluorescence microscope's time, and draws
+rectangles over them; this reports those rectangles in the overview's own displayed
+plane, which is what :func:`fibsem.fm.planning.plan_sparse_fm_overview` consumes.
+
+On a real-space canvas rather than an image canvas, and the reason is plural: one view
+can hold several overviews. Records are placed by stage position and a view switch
+re-places all of them, so somebody who has taken three FIB overviews of different parts
+of a grid can select across all three. An image canvas shows one image.
+
+**Ground, not tiles.** No tile grid is drawn here and none is consulted: the beam field
+of view and the camera's are unrelated sizes, so there is no tile-to-tile correspondence
+to preserve. What crosses to the other pane is an area of sample.
+
+**No stage-context overlays.** The travel limits and the grid boundary are drawn in the
+*preview* pane, in the frame the acquisition happens in, which is the frame that decides
+whether a tile can be reached. Drawing them here as well would duplicate the answer and
+carry a hazard to do it: overlays sized from a stage length ignore the view, and this one
+is foreshortened up to 3.9x at the milling pose, so a boundary drawn without
+`surface_foreshortening()` is wrong by that much and still looks like a boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.imaging.tiling.geometry import PlaneRegion
+from fibsem.microscope import FibsemMicroscope
+from fibsem.projection import BeamStageProjection
+from fibsem.structures import FibsemImage, FibsemStagePosition
+from fibsem.ui.tokens import WHITE_ICON_COLOR
+from fibsem.ui.widgets.canvas.overlays.rect_overlay import RectOverlay
+from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import ENABLED_EDGE
+from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
+from fibsem.ui.widgets.canvas.stage_frame import StageFrame
+from fibsem.ui.widgets.custom_widgets import ContextMenu, ContextMenuConfig
+from fibsem.ui.widgets.overview_widget import (
+    _VIEW_CHIP_SPACING,
+    _VIEW_CHIP_STYLE,
+    _VIEW_CHIP_STYLE_ACTIVE,
+    _VIEW_STRIP_STYLE,
+    OverviewView,
+)
+
+logger = logging.getLogger(__name__)
+
+# The same magenta the tile grid draws in, deliberately: a region on this pane and the
+# tiles it produces on the other are one selection seen twice, and colouring them apart
+# would suggest otherwise.
+REGION_COLOUR = ENABLED_EDGE
+REGION_SELECTED_COLOUR = WHITE_ICON_COLOR
+# A new region covers a fifth of the frame's short side: big enough to see and grab,
+# small enough that it is obviously a starting point rather than an answer.
+_NEW_REGION_FRACTION = 0.2
+
+
+class FMRegionSelectorWidget(QWidget):
+    """A beam overview with draggable regions over it.
+
+    Signals:
+        regions_changed: a region was added, moved, resized or deleted.
+        selection_changed: which region is selected, by index, or None.
+    """
+
+    regions_changed = pyqtSignal()
+    selection_changed = pyqtSignal(object)
+
+    def __init__(
+        self, microscope: FibsemMicroscope, parent: Optional[QWidget] = None
+    ) -> None:
+        super().__init__(parent)
+        self.microscope = microscope
+
+        self._projection: Optional[BeamStageProjection] = None
+        self._origin: Optional[FibsemStagePosition] = None
+        self._overlays: List[RectOverlay] = []
+        self._selected: Optional[int] = None
+        self._placed: List[str] = []
+        self._views: Dict["OverviewView", List[FibsemImage]] = {}
+        self._current_view: Optional["OverviewView"] = None
+        # The ground the placed overviews cover, in metres, for sizing a new region.
+        self._content_extent: Tuple[float, float] = (1e-3, 1e-3)
+
+        # The bare canvas, as the beam overview tab uses it. `FMRealSpaceCanvasWidget`
+        # wraps one in channel and layer controls, which belong to fluorescence.
+        self.canvas = FibsemRealSpaceCanvas(display_max_px=2048)
+
+        # Above the canvas, not on it. The chips run to ~650 px against a 640 px canvas,
+        # so no corner holds them -- settled in the beam overview tab and followed here.
+        self._chip_strip = QScrollArea()
+        self._chip_strip.setObjectName("viewStrip")
+        self._chip_strip.setStyleSheet(_VIEW_STRIP_STYLE)
+        self._chip_strip.setWidgetResizable(True)
+        self._chip_strip.setFixedHeight(34)
+        self._chip_strip.setFrameShape(QFrame.NoFrame)
+        self._chip_strip.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self._chip_strip.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self._chip_strip.hide()
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+        layout.addWidget(self._chip_strip)
+        layout.addWidget(self.canvas)
+
+        self.canvas.canvas_clicked.connect(self._on_left_click)
+        self.canvas.canvas_right_clicked.connect(self._on_right_click)
+
+    # ── what is being looked at ──────────────────────────────────────────
+
+    def set_views(
+        self,
+        views: Dict["OverviewView", Sequence[FibsemImage]],
+        current: Optional["OverviewView"] = None,
+    ) -> None:
+        """Offer these views, and show one.
+
+        A view is a beam and a stage orientation. Images from different views do not
+        register with each other -- they are pictures of the same sample from different
+        directions -- so they are never placed together, and switching is what the chips
+        are for. Defaults to the last view offered, which is the one most recently
+        acquired.
+
+        The strip stays hidden below two views: a control with one option is a label
+        that looks clickable.
+        """
+        self._views = {view: list(images) for view, images in views.items()}
+        chosen = current if current in self._views else None
+        if chosen is None and self._views:
+            chosen = list(self._views)[-1]
+        self._build_chips()
+        self.show_view(chosen)
+
+    def show_view(self, view: Optional["OverviewView"]) -> None:
+        """Show one of the offered views. Starts a fresh selection."""
+        self._current_view = view
+        self.set_overviews(self._views.get(view, []) if view is not None else [])
+        self._build_chips()
+
+    @property
+    def current_view(self) -> Optional["OverviewView"]:
+        return self._current_view
+
+    def _build_chips(self) -> None:
+        """One chip per view, the current one marked."""
+        holder = QWidget()
+        row = QHBoxLayout(holder)
+        row.setContentsMargins(8, 5, 8, 5)
+        row.setSpacing(_VIEW_CHIP_SPACING)
+        for view in self._views:
+            chip = QPushButton(view.label)
+            chip.setCheckable(True)
+            chip.setChecked(view == self._current_view)
+            chip.setStyleSheet(
+                _VIEW_CHIP_STYLE_ACTIVE if view == self._current_view else _VIEW_CHIP_STYLE
+            )
+            chip.clicked.connect(lambda _checked, v=view: self.show_view(v))
+            row.addWidget(chip)
+        row.addStretch(1)
+        self._chip_strip.setWidget(holder)
+        self._chip_strip.setVisible(len(self._views) > 1)
+
+    def set_overviews(self, images: Sequence[FibsemImage]) -> None:
+        """Show these overviews, and start a fresh selection.
+
+        They are expected to share a view -- a beam and a stage orientation. Images from
+        different views do not register with each other, so placing them together would
+        say something untrue; the caller picks the view and hands over what belongs to it.
+
+        The projection and the frame origin come from the *first* image rather than from
+        the live instrument, so the selection resolves against the overview as it was
+        taken. That matters here more than usually: the stage may well have moved since,
+        and a saved overview is exactly the case a live projection gets wrong.
+        """
+        self.clear_regions()
+        for key in self._placed:
+            self.canvas.remove_image(key)
+        self._placed = []
+        self._projection = None
+        self._origin = None
+
+        if not images:
+            return
+
+        projection = BeamStageProjection.from_image(images[0])
+        origin = self._position_of(images[0])
+        if projection is None or origin is None:
+            logger.debug("That overview does not record how it was acquired.")
+            return
+        self._projection, self._origin = projection, origin
+
+        pixel_size = self._pixel_size_of(images[0])
+        if pixel_size:
+            self.canvas.set_reference_pixel_size(pixel_size)
+
+        frame = self._frame()
+        spans: List[Tuple[float, float, float, float]] = []
+        for index, image in enumerate(images):
+            position = self._position_of(image)
+            size = self._pixel_size_of(image)
+            if position is None or not size or frame is None:
+                logger.debug("Skipping an overview that does not say where it was taken.")
+                continue
+            try:
+                centre = frame.offset(position)
+            except Exception as e:
+                logger.debug(f"Could not place an overview: {e}")
+                continue
+            data = image.filtered_data
+            self._placed.append(
+                self.canvas.add_image(
+                    data, centre=centre, pixel_size=size, key=f"overview-{index}",
+                )
+            )
+            spans.append((
+                centre[0], centre[1], data.shape[1] * size, data.shape[0] * size,
+            ))
+
+        if spans:
+            xs = [cx - w / 2 for cx, _, w, _ in spans] + [cx + w / 2 for cx, _, w, _ in spans]
+            ys = [cy - h / 2 for _, cy, _, h in spans] + [cy + h / 2 for _, cy, _, h in spans]
+            self._content_extent = (max(xs) - min(xs), max(ys) - min(ys))
+
+    @property
+    def has_overview(self) -> bool:
+        """Whether anything is placed and a region could be drawn against it."""
+        return bool(self._placed) and self._projection is not None
+
+    # ── regions ──────────────────────────────────────────────────────────
+
+    def add_region(self) -> Optional[int]:
+        """Drop a new region in the middle of the view, and select it.
+
+        Placed rather than dragged out. `RectOverlay` starts a drag only on a handle or
+        on its own body, so there is no create-by-dragging gesture to reach for, and
+        adding one would mean a create mode inside a widget several other callers share.
+        Drop-then-resize is also the gesture the vendor's own sparse tileset uses.
+        """
+        if not self.has_overview:
+            return None
+        overlay = RectOverlay(
+            color=REGION_COLOUR, facecolor=REGION_COLOUR, alpha=0.30, linewidth=2,
+            resizable=True,
+        )
+        self.canvas.add_overlay(overlay)
+        overlay.set_rect(*self._new_region_rect())
+        overlay.rect_changed.connect(self._on_region_changed)
+        self._overlays.append(overlay)
+        self._select(len(self._overlays) - 1)
+        self.regions_changed.emit()
+        return len(self._overlays) - 1
+
+    def delete_selected_region(self) -> None:
+        """Remove the selected region, if there is one."""
+        if self._selected is None:
+            return
+        overlay = self._overlays.pop(self._selected)
+        self.canvas.remove_overlay(overlay)
+        self._select(None)
+        self.regions_changed.emit()
+
+    def clear_regions(self) -> None:
+        """Remove every region."""
+        if not self._overlays:
+            return
+        for overlay in self._overlays:
+            self.canvas.remove_overlay(overlay)
+        self._overlays = []
+        self._select(None)
+        self.regions_changed.emit()
+
+    @property
+    def regions(self) -> List[PlaneRegion]:
+        """The regions, in the overview's displayed plane, in metres from :attr:`base`.
+
+        What `plan_sparse_fm_overview` takes. Metres rather than pixels because pixels
+        belong to a detector and would cancel immediately on the other side.
+        """
+        out = []
+        for overlay in self._overlays:
+            rect = overlay.get_rect()
+            out.append(PlaneRegion.from_points([
+                self.canvas.canvas_to_metres(rect["x0"], rect["y0"]),
+                self.canvas.canvas_to_metres(rect["x1"], rect["y1"]),
+            ]))
+        return out
+
+    @property
+    def base(self) -> Optional[FibsemStagePosition]:
+        """The stage position :attr:`regions` are measured from."""
+        return self._origin
+
+    @property
+    def projection(self) -> Optional[BeamStageProjection]:
+        """The overview's own projection, for resolving those regions to stage space."""
+        return self._projection
+
+    @property
+    def selected_region(self) -> Optional[int]:
+        return self._selected
+
+    def describe_selected(self) -> str:
+        """A one-line summary of the selected region, or of the selection as a whole."""
+        regions = self.regions
+        if not regions:
+            return "No regions. Right-click to add one."
+        if self._selected is None or self._selected >= len(regions):
+            return f"{len(regions)} region{'s' if len(regions) != 1 else ''}."
+        region = regions[self._selected]
+        return (
+            f"Region {self._selected + 1} of {len(regions)} — "
+            f"{region.width * 1e6:.0f} x {region.height * 1e6:.0f} um "
+            "as drawn"
+        )
+
+    # ── interaction ──────────────────────────────────────────────────────
+
+    def _on_right_click(self, x: float, y: float, modifiers=None) -> None:
+        """Add or delete, from wherever the pointer is.
+
+        A menu rather than a toolbar: adding is rare enough not to deserve permanent
+        chrome, and deleting needs a target, which a right-click already names.
+        """
+        self._select(self._region_at(x, y))
+        config = ContextMenuConfig()
+        config.add_action(
+            "Add region", callback=self.add_region, enabled=self.has_overview
+        )
+        config.add_action(
+            "Delete region",
+            callback=self.delete_selected_region,
+            enabled=self._selected is not None,
+        )
+        config.add_action(
+            "Clear all regions",
+            callback=self.clear_regions,
+            enabled=bool(self._overlays),
+        )
+        ContextMenu(config, parent=self).show_at_cursor()
+
+    def _on_left_click(self, x: float, y: float, modifiers=None) -> None:
+        """Select what was clicked, or nothing.
+
+        Only reaches here for a click the overlays did not claim: `RectOverlay` takes
+        the press when it lands on its own body or a handle, and suppresses the click
+        that would follow. So this selects a region by its *edge* and deselects on the
+        background, while clicking a region's middle selects it through
+        :meth:`_on_region_changed` instead -- the two paths together cover the rectangle.
+        """
+        self._select(self._region_at(x, y))
+
+    def _on_region_changed(self, _rect: dict) -> None:
+        """A region moved or resized. Whichever it was becomes the selected one.
+
+        From the sender rather than from the pointer: the overlay that emitted is the
+        one being dragged, and asking the position again could name a different region
+        where two overlap.
+        """
+        overlay = self.sender()
+        if overlay in self._overlays:
+            self._select(self._overlays.index(overlay))
+        self.regions_changed.emit()
+
+    def _region_at(self, x: float, y: float) -> Optional[int]:
+        """The topmost region under a point, or None.
+
+        Reverse order, so the one drawn last -- and so on top -- wins, matching what
+        clicking it would have hit.
+        """
+        for index in reversed(range(len(self._overlays))):
+            rect = self._overlays[index].get_rect()
+            if rect["x0"] <= x <= rect["x1"] and rect["y0"] <= y <= rect["y1"]:
+                return index
+        return None
+
+    def _select(self, index: Optional[int]) -> None:
+        if index == self._selected:
+            return
+        self._selected = index
+        for position, overlay in enumerate(self._overlays):
+            colour = REGION_SELECTED_COLOUR if position == index else REGION_COLOUR
+            overlay.set_color(colour, facecolor=REGION_COLOUR)
+        self.selection_changed.emit(index)
+
+    # ── internals ────────────────────────────────────────────────────────
+
+    def _frame(self) -> Optional[StageFrame]:
+        if self._projection is None or self._origin is None:
+            return None
+        return StageFrame(self.canvas, self._origin, self._projection)
+
+    def _new_region_rect(self) -> Tuple[float, float, float, float]:
+        """Where a new region starts, in canvas coordinates.
+
+        A square about the frame origin -- the middle of what was placed -- sized from
+        the ground the overviews cover, and stepped for each one already down so a second
+        Add does not land exactly on the first and look like nothing happened.
+        """
+        side_m = min(self._content_extent) * _NEW_REGION_FRACTION
+        step_m = side_m * 0.35 * (len(self._overlays) % 4)
+        side, _ = self.canvas.metres_to_canvas(side_m, 0.0)
+        step, _ = self.canvas.metres_to_canvas(step_m, 0.0)
+        centre_x, centre_y = self.canvas.metres_to_canvas(0.0, 0.0)
+        return (
+            centre_x - side / 2 + step,
+            centre_y - side / 2 + step,
+            side,
+            side,
+        )
+
+    @staticmethod
+    def _position_of(image: FibsemImage) -> Optional[FibsemStagePosition]:
+        state = getattr(getattr(image, "metadata", None), "microscope_state", None)
+        return getattr(state, "stage_position", None)
+
+    @staticmethod
+    def _pixel_size_of(image: FibsemImage) -> Optional[float]:
+        pixel_size = getattr(getattr(image, "metadata", None), "pixel_size", None)
+        return getattr(pixel_size, "x", None)

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -1007,11 +1007,19 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         """Register an overlay and attach it to the current axes."""
         self._overlays.append(overlay)
         overlay.attach(self._ax, self)
-        if self._img_w is not None:
-            try:
-                self._notify_overlay(overlay, self._content_rect())
-            except Exception:
-                _logger.exception("Overlay content update failed: %r", overlay)
+        # Unconditionally, and `_content_rect()` decides whether there is anything to
+        # report. The guard here used to be `self._img_w is not None`, which is a
+        # *single image* canvas's notion of content and is never set by one that places
+        # images in stage space -- so an overlay added to a real-space canvas was never
+        # told what it had been added to. Harmless for an overlay its host redraws by
+        # hand (a tile grid), and fatal for one that builds its artists on the first
+        # content report (a rectangle), which simply never appeared. The guard was
+        # redundant even here: the base `_content_rect` already answers `EMPTY_CONTENT`
+        # when there is no image, and every overlay checks `rect.is_empty`.
+        try:
+            self._notify_overlay(overlay, self._content_rect())
+        except Exception:
+            _logger.exception("Overlay content update failed: %r", overlay)
         self.draw_idle()
 
     def remove_overlay(self, overlay: CanvasOverlay) -> None:

--- a/fibsem/ui/widgets/canvas/overlays/rect_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/rect_overlay.py
@@ -142,6 +142,21 @@ class RectOverlay(QObject):
             self._x0, self._y0, self._x1 - self._x0, self._y1 - self._y0
         )
 
+    def set_color(self, color: str, facecolor: Optional[str] = None) -> None:
+        """Recolour the rectangle and its handles.
+
+        For a host drawing more than one and needing to say which is selected. Rebuilds
+        rather than recolouring in place: the handles are separate artists created with
+        the colour baked in, so setting it on the patch alone would leave them behind.
+        """
+        self._color = color
+        if facecolor is not None:
+            self._facecolor = facecolor
+        if self._ax is not None and self._rect is not None:
+            self._rebuild()
+            if self._canvas is not None:
+                self._canvas.draw_idle()
+
     def set_rect(self, x0: float, y0: float, width: float, height: float) -> None:
         self._x0, self._y0 = x0, y0
         self._x1, self._y1 = x0 + width, y0 + height

--- a/tests/ui/test_fm_region_selector.py
+++ b/tests/ui/test_fm_region_selector.py
@@ -1,0 +1,276 @@
+"""Drawing the ground to image on a beam overview.
+
+The pane reports rectangles in the overview's own displayed plane, measured from the
+pose that overview was acquired at. Both halves of that matter: metres because pixels
+belong to a detector and cancel on the other side, and the overview's *own* pose because
+the stage has usually moved on by the time anyone is choosing where to look.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.structures import BeamType, FibsemStagePosition, ImageSettings
+from fibsem.ui.fm.widgets.fm_region_selector import FMRegionSelectorWidget
+from fibsem.ui.widgets.overview_widget import OverviewView
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def microscope(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    return build_microscope()
+
+
+def shot(microscope, orientation="MILLING", beam_type=BeamType.ION, hfw=900e-6):
+    """An overview acquired at one pose, carrying its own metadata."""
+    pose = microscope.get_orientation(orientation)
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
+    )
+    return microscope.acquire_image(
+        ImageSettings(
+            hfw=hfw, resolution=[1024, 1024], beam_type=beam_type, save=False
+        )
+    )
+
+
+@pytest.fixture()
+def selector(microscope):
+    widget = FMRegionSelectorWidget(microscope)
+    widget.setFixedSize(540, 400)
+    widget.set_overviews([shot(microscope)])
+    return widget
+
+
+# ── what it is looking at ────────────────────────────────────────────────
+
+
+def test_it_resolves_against_the_overview_rather_than_the_live_stage(
+    microscope, qapp
+):
+    """A saved overview is exactly the case a live projection gets wrong, and by the
+    time someone is selecting on one the stage has usually moved.
+
+    The move happens *before* the overview is handed over, which is the order the real
+    workflow has: acquire at the milling pose, go to the FM tab, open the dialog. Moving
+    afterwards would prove nothing -- the live and recorded poses would still have agreed
+    at the moment everything was read.
+    """
+    image = shot(microscope, "MILLING")
+    recorded = image.metadata.microscope_state.stage_position.t
+    microscope.move_to_microscope("FM")
+    assert microscope.get_stage_position().t != pytest.approx(recorded), (
+        "the stage has to have moved, or this proves nothing"
+    )
+
+    widget = FMRegionSelectorWidget(microscope)
+    widget.set_overviews([image])
+
+    assert widget.base.t == pytest.approx(recorded)
+
+
+def test_an_overview_that_does_not_say_where_it_was_taken_is_not_placed(microscope):
+    """Refused rather than guessed at: a region drawn against a fabricated pose would
+    resolve to somewhere other than what the user was looking at."""
+    image = shot(microscope)
+    image.metadata.microscope_state.stage_position = None
+    widget = FMRegionSelectorWidget(microscope)
+
+    widget.set_overviews([image])
+
+    assert widget.has_overview is False
+
+
+def test_regions_cannot_be_drawn_before_there_is_an_overview(microscope):
+    widget = FMRegionSelectorWidget(microscope)
+
+    assert widget.add_region() is None
+    assert widget.regions == []
+
+
+# ── regions ──────────────────────────────────────────────────────────────
+
+
+def test_a_region_is_reported_in_metres(selector):
+    selector.add_region()
+
+    [region] = selector.regions
+    assert 0 < region.width < 1e-2, "a region on a grid is micrometres, not pixels"
+    assert region.height > 0
+
+
+def test_regions_accumulate_and_can_be_removed_one_at_a_time(selector):
+    selector.add_region()
+    selector.add_region()
+    assert len(selector.regions) == 2
+
+    selector.delete_selected_region()
+
+    assert len(selector.regions) == 1
+
+
+def test_deleting_with_nothing_selected_does_nothing(selector):
+    selector.add_region()
+    selector._select(None)
+
+    selector.delete_selected_region()
+
+    assert len(selector.regions) == 1
+
+
+def test_a_new_region_does_not_land_exactly_on_the_last(selector):
+    """Two identical rectangles stacked look like one, and like Add having failed."""
+    selector.add_region()
+    selector.add_region()
+
+    first, second = selector.regions
+    assert (first.x0, first.y0) != (second.x0, second.y0)
+
+
+def test_clearing_removes_every_region(selector):
+    selector.add_region()
+    selector.add_region()
+
+    selector.clear_regions()
+
+    assert selector.regions == []
+
+
+def test_clearing_nothing_reports_nothing(selector):
+    """Or a host recomputing on every signal would do so for no reason."""
+    fired = []
+    selector.regions_changed.connect(lambda: fired.append(1))
+
+    selector.clear_regions()
+
+    assert fired == []
+
+
+def test_every_change_is_reported(selector):
+    fired = []
+    selector.regions_changed.connect(lambda: fired.append(1))
+
+    selector.add_region()
+    selector.add_region()
+    selector.delete_selected_region()
+    selector.clear_regions()
+
+    assert len(fired) == 4
+
+
+# ── selection ────────────────────────────────────────────────────────────
+
+
+def test_adding_a_region_selects_it(selector):
+    first = selector.add_region()
+    second = selector.add_region()
+
+    assert selector.selected_region == second != first
+
+
+def test_clicking_a_region_selects_it_and_the_background_deselects(selector):
+    selector.add_region()
+    inside = selector._overlays[0].get_rect()
+
+    selector._on_left_click(inside["cx"], inside["cy"])
+    assert selector.selected_region == 0
+
+    selector._on_left_click(inside["x0"] - 1e6, inside["y0"] - 1e6)
+    assert selector.selected_region is None
+
+
+def test_the_topmost_region_wins_where_two_overlap(selector):
+    """Matching what clicking would have hit: the one drawn last is on top."""
+    selector.add_region()
+    selector.add_region()
+    selector._overlays[1].set_rect(
+        *[selector._overlays[0].get_rect()[k] for k in ("x0", "y0", "width", "height")]
+    )
+    rect = selector._overlays[0].get_rect()
+
+    selector._on_left_click(rect["cx"], rect["cy"])
+
+    assert selector.selected_region == 1
+
+
+def test_dragging_a_region_selects_the_one_dragged(selector):
+    """From the sender, not from the pointer -- where two overlap, asking the position
+    again could name a different region than the one being moved."""
+    selector.add_region()
+    selector.add_region()
+    selector._select(None)
+
+    selector._overlays[0].rect_changed.emit(selector._overlays[0].get_rect())
+
+    assert selector.selected_region == 0
+
+
+def test_the_description_says_what_is_selected(selector):
+    assert "Right-click" in selector.describe_selected()
+
+    selector.add_region()
+
+    assert selector.describe_selected().startswith("Region 1 of 1")
+
+
+# ── views ────────────────────────────────────────────────────────────────
+
+
+def views_of(microscope):
+    return {
+        OverviewView(BeamType.ELECTRON, "SEM"): [
+            shot(microscope, "SEM", BeamType.ELECTRON)
+        ],
+        OverviewView(BeamType.ION, "MILLING"): [shot(microscope, "MILLING")],
+    }
+
+
+def test_it_opens_on_the_most_recent_view(microscope):
+    """Which is the one just acquired, and so the one being looked at."""
+    widget = FMRegionSelectorWidget(microscope)
+    views = views_of(microscope)
+
+    widget.set_views(views)
+
+    assert widget.current_view == list(views)[-1]
+
+
+def test_switching_view_starts_a_fresh_selection(microscope):
+    """Regions belong to the view they were drawn on: images from different views are
+    pictures from different directions and do not register."""
+    widget = FMRegionSelectorWidget(microscope)
+    views = views_of(microscope)
+    widget.set_views(views)
+    widget.add_region()
+
+    widget.show_view(list(views)[0])
+
+    assert widget.regions == []
+
+
+def test_the_chip_strip_stays_hidden_with_one_view(microscope):
+    """A control with one option is a label that looks clickable."""
+    widget = FMRegionSelectorWidget(microscope)
+
+    widget.set_views({OverviewView(BeamType.ION, "MILLING"): [shot(microscope)]})
+
+    assert widget._chip_strip.isVisibleTo(widget) is False
+
+
+def test_the_chip_strip_appears_once_there_is_a_choice(microscope):
+    widget = FMRegionSelectorWidget(microscope)
+
+    widget.set_views(views_of(microscope))
+
+    assert widget._chip_strip.isVisibleTo(widget) is True

--- a/tests/ui/test_overlay_content_rect.py
+++ b/tests/ui/test_overlay_content_rect.py
@@ -197,6 +197,56 @@ def test_the_ruler_clamps_to_the_content_bounds_not_to_zero():
     assert ruler._p2 == [1400.0, 2200.0]  # and its bottom-right
 
 
+# ── an overlay is told what it was added to ──────────────────────────────
+
+
+def test_an_overlay_added_to_a_real_space_canvas_is_told_the_content():
+    """`add_overlay` used to gate this on `_img_w`, which is a *single image* canvas's
+    notion of content and is never set by one placing images in stage space.
+
+    So an overlay added to a real-space canvas was never told what it had been added to.
+    Harmless for one its host redraws by hand -- a tile grid -- and fatal for one that
+    builds its artists on the first content report: a `RectOverlay` added this way drew
+    nothing at all, with no error.
+    """
+    from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
+
+    canvas = FibsemRealSpaceCanvas()
+    canvas.add_image(_img(64, 64), centre=(0.0, 0.0), pixel_size=1e-6)
+    overlay = _Recorder()
+
+    canvas.add_overlay(overlay)
+
+    assert overlay.rects, "the overlay was never told the canvas had content"
+    assert not overlay.rects[-1].is_empty
+
+
+def test_an_overlay_added_to_an_empty_canvas_is_told_it_is_empty():
+    """Told, rather than not told. Every overlay guards on `rect.is_empty`, so the
+    report costs nothing and the alternative is a silent difference between the two
+    canvases."""
+    canvas = FibsemImageCanvas()
+    overlay = _Recorder()
+
+    canvas.add_overlay(overlay)
+
+    assert overlay.rects == [EMPTY_CONTENT]
+
+
+def test_a_rectangle_overlay_on_a_real_space_canvas_actually_draws():
+    """The regression in the shape it was found in."""
+    from fibsem.ui.widgets.canvas.overlays.rect_overlay import RectOverlay
+    from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
+
+    canvas = FibsemRealSpaceCanvas()
+    canvas.add_image(_img(64, 64), centre=(0.0, 0.0), pixel_size=1e-6)
+    overlay = RectOverlay()
+
+    canvas.add_overlay(overlay)
+
+    assert overlay._patch is not None
+
+
 if __name__ == "__main__":
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):


### PR DESCRIPTION
Closes FIB-727.

**Stacked on #457**, which is stacked on #456. Review those first; this diff is the beam pane alone.

The left-hand pane of the sparse selection dialog: an acquired FIB/SEM overview with rectangles drawn over the parts of the grid worth the fluorescence microscope's time. It reports those rectangles in the overview's own displayed plane, which is what the planner takes. Nothing constructs it yet.

On a **real-space** canvas rather than an image canvas, and the reason is plural: one view can hold several overviews, placed by stage position. An image canvas shows one image, so selecting across three FIB overviews of different parts of a grid would not be possible.

It resolves against the **overview**, not the instrument. The projection and the frame origin come from the first image's own metadata, so a selection means what it looked like — by the time anyone is choosing where to look the stage has usually moved, which is exactly the case a live projection gets wrong. Refused rather than guessed at when an image does not record its pose.

## Regions

`RectOverlay`, one per region. They already cooperate without arbitration: `_on_press` bails on `_overlay_input_allowed` and on `_overlay_consuming_event`, and `_start_drag` sets the latter, so the first to claim a press wins.

What they cannot do is *create* one — a press starts a drag only on a handle or the body — so **adding is a right-click menu entry** that drops a box to be resized, rather than a drag on empty canvas. A create mode would mean changing a widget several other callers share, and drop-then-resize is the gesture the vendor's own sparse tileset uses for the same job.

Left-click selects, and interacting with a region selects it too. The two paths together cover the rectangle: a click on the body is claimed by the overlay and never reaches the canvas, so the click path selects by the edge and the drag path selects from the **sender** — asking the pointer again could name a different region where two overlap.

## Two fixes to shared code

**`add_overlay` never told a real-space canvas's overlays what they had been added to.** The initial content notification was gated on `self._img_w is not None`, a *single image* canvas's notion of content that is never set by one placing images in stage space. Invisible for an overlay its host redraws by hand — a tile grid — and fatal for one that builds its artists on the first content report: a `RectOverlay` added to a real-space canvas drew **nothing at all**, with no error. That is how this was found.

The guard was redundant even on the base, whose `_content_rect` already answers `EMPTY_CONTENT` when there is no image, and every overlay checks `rect.is_empty`. Three tests in `test_overlay_content_rect.py`, including the regression in the shape it was found in.

**`RectOverlay.set_color`**, so a host drawing more than one can show which is selected. It rebuilds rather than recolouring in place: the handles are separate artists with the colour baked in, so setting it on the patch alone leaves them behind.

## One deviation from the issue, deliberate

FIB-727 said this pane would need `surface_foreshortening()` applied by hand to anything lying on the sample. Instead it **draws no stage-context shapes at all**. The travel limits and grid boundary are drawn in the preview pane, in the frame the acquisition happens in — which is the frame that decides whether a tile can be reached. Drawing them here would duplicate the answer and carry the hazard to do it: at the milling pose this view is foreshortened up to 3.9x, and a boundary drawn without the term is wrong by that much and still looks like a boundary.

Easy to add later with the term applied, if seeing the boundary while dragging turns out to matter at the bench.

## Testing

Eight mutations of the pane and one of the canvas fix, all killed — but the one that mattered survived the first round. `test_it_resolves_against_the_overview_rather_than_the_live_stage` moved the stage *after* handing the overview over, by which point the live and recorded poses had already agreed when everything was read, so swapping `from_image` for `from_microscope` did not fail it. It now moves first, as the real workflow does, and asserts the stage actually moved before asserting anything else.

Also of note: the shared-palette guard caught `#ffffff` being re-declared where `WHITE_ICON_COLOR` exists. The region colour now imports `ENABLED_EDGE` from the tile grid overlay as well — deliberately, since a region here and the tiles it produces there are one selection seen twice.

Full `tests/ui/` shows no failure that is not already on `main`.


## Driving it

Neither pane is reachable from AutoLamella yet, so this adds a standalone app in the shape of `overview_app.py`:

```
python -m fibsem.ui.fm.sparse_selection_app
python -m fibsem.ui.fm.sparse_selection_app --manufacturer Thermo --ip 10.0.0.1
```

Right-click the left pane to add a region, drag it or its corners, and the right pane recomputes. The chips switch views; switching starts a fresh selection. Clicking a tile on the right adds or drops it.

It makes the argument for two panes visible in about ten seconds: two roughly square boxes dragged on a FIB overview at the milling orientation produce an **11 x 3** grid — three columns and eleven rows — because that view is foreshortened 3.86x, so a box that looks square is a strip of ground nearly four times taller. Draw the same box on the SEM chip and the grid comes out square.

One line in it is worth trying by hand: `move_to_microscope("FM")` before the window is built puts the stage where the FM tab would leave it, and commenting it out must change **nothing** about the right pane. That is the frame pinning working, and it is the failure that would otherwise stay invisible.

The wiring between the panes there is a stand-in for the dialog, not its design — the next PR replaces it.
