### PR TITLE
[refactor] Say which modality a tiled run belongs to (FIB-733)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1326,7 +1326,15 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     @ensure_main_thread
     def _on_tile_acquisition_progress(self, ddict: dict) -> None:
-        """Handle tiled acquisition progress updates from the microscope."""
+        """Handle tiled acquisition progress updates from the microscope.
+
+        Deliberately **not** filtered by `modality`, unlike the two overview widgets
+        that read this signal. They each drive one modality's canvas and must ignore the
+        other's run; the status bar is the one consumer that wants both, because its
+        whole job is saying what is happening while you are looking at another tab
+        (FIB-725). What it will need, once a fluorescence run emits here, is to say
+        *which* -- not to drop one.
+        """
         counter = ddict.get("counter", 0)
         total = ddict.get("total", 1)
         msg = ddict.get("msg", "Collecting tiles")

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -19,6 +19,7 @@ from fibsem.conversions import is_inside_image_bounds
 # Moved to the `tiling` package (FIB-390); re-exported so existing importers and the
 # public API are unaffected. `fibsem/imaging/__init__.py` star-imports this module.
 from fibsem.imaging.reduce import PreviewMosaic, downsample
+from fibsem.imaging.tiling.progress import MODALITY_BEAM
 from fibsem.imaging.tiling.geometry import (  # noqa: E402,F401
     TilePosition,
     compute_tile_grid,
@@ -171,6 +172,7 @@ class TiledAcquisitionRunner:
         """
         total_tiles = self.settings.n_enabled_tiles
         self.microscope.tiled_acquisition_signal.emit({
+            "modality": MODALITY_BEAM,
             "msg": message,
             "counter": getattr(self, "_n_tiles_acquired", 0),
             "total": total_tiles,
@@ -206,6 +208,7 @@ class TiledAcquisitionRunner:
 
         # notify the UI immediately so the progress bar appears before the first move
         self.microscope.tiled_acquisition_signal.emit({
+            "modality": MODALITY_BEAM,
             "msg": "Computing Tile Positions",
             "counter": 0,
             "total": self.settings.n_enabled_tiles,
@@ -430,6 +433,7 @@ class TiledAcquisitionRunner:
             self._paint_preview(tile, image)
             self._n_tiles_acquired += 1
             self.microscope.tiled_acquisition_signal.emit({
+                "modality": MODALITY_BEAM,
                 "msg": "Tile Collected",
                 "i": tile.row,
                 "j": tile.col,

--- a/fibsem/imaging/tiling/progress.py
+++ b/fibsem/imaging/tiling/progress.py
@@ -1,0 +1,63 @@
+"""What a tiled acquisition says about itself while it runs.
+
+`FibsemMicroscope.tiled_acquisition_signal` carries a bare dict and has no declared
+contract, so a consumer works out what it received from which keys are present. That was
+survivable while `imaging.tiled` was its only emitter: three payload shapes, all from one
+class, all carrying the same keys.
+
+It stops being survivable with a second producer. The fluorescence tileset runner reports
+the same thing -- tile *n* of *N*, and a mosaic so far -- and reports it somewhere else
+entirely, on a signal hanging off the detector that also carries z-stacks, channel
+acquisitions and autofocus sweeps (FIB-725). Bringing it here needs consumers to be able
+to tell whose run they are looking at, because most of them want exactly one:
+
+* `FibsemMinimapWidget` and `FibsemOverviewWidget` each drive a *beam* overview, and hand
+  the payload's mosaic straight to their own canvas. Handed a fluorescence one they would
+  draw it into the beam mosaic -- and the fluorescence preview is keyed `image` already,
+  deliberately, to match this signal.
+* `AutoLamellaSingleWindowUI` shows whichever is running in the status bar, and needs to
+  say *which*, or a glance tells you a run is going and not what it is.
+
+Hence `modality`: the one thing that differs, in the word this codebase already uses for
+it. Everything on this signal is a tiled run by definition -- that is what the signal is
+named for -- so the kind of *work* needs no discriminator; what varies is what is imaging.
+
+# Reading a payload
+
+Use :func:`is_modality`, not `payload["modality"]`. The key is new, and a consumer that
+demands it would ignore every payload emitted by an older producer -- including anything
+outside this repository subscribing to a public signal. Absent means beam, which is what
+it was before this existed.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# The beam tiler: SEM or FIB, since no consumer distinguishes them -- both draw into the
+# same overview.
+MODALITY_BEAM = "beam"
+# The fluorescence tileset runner.
+MODALITY_FLUORESCENCE = "fluorescence"
+
+__all__ = ["MODALITY_BEAM", "MODALITY_FLUORESCENCE", "modality_of", "is_modality"]
+
+
+def modality_of(payload: dict) -> str:
+    """Which imaging modality produced *payload*.
+
+    Defaults to the beam rather than raising or returning None: this signal carried
+    nothing else for its whole life, so an unlabelled payload is a beam run from a
+    producer that predates the key.
+    """
+    return payload.get("modality") or MODALITY_BEAM
+
+
+def is_modality(payload: dict, modality: str) -> bool:
+    """Whether *payload* came from *modality*, treating unlabelled as beam.
+
+    The form consumers should use. `payload.get("modality") == MODALITY_BEAM` looks
+    equivalent and is not: it drops every payload from a producer that has not been
+    taught the key, which on a public signal is not only the ones in this repository.
+    """
+    return modality_of(payload) == modality

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -45,6 +45,7 @@ from fibsem.applications.autolamella.structures import (
     Lamella,
 )
 from fibsem.imaging import tiled
+from fibsem.imaging.tiling.progress import MODALITY_BEAM, is_modality
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling import FibsemMillingStage
 from fibsem.structures import (
@@ -646,7 +647,15 @@ class FibsemMinimapWidget(QWidget):
         which leaves the last real progress standing -- true, rather than reset to zero.
 
         `FibsemOverviewWidget._apply_progress` reads the same signal the same way.
+
+        Beam runs only. This tab drives a beam overview and assigns the payload's mosaic
+        straight into its napari layer, so a fluorescence run reaching here would be
+        drawn into the beam minimap -- and the fluorescence preview is keyed `image`
+        already, deliberately, to match this signal (FIB-725).
         """
+        if not is_modality(ddict, MODALITY_BEAM):
+            return
+
         # track counts for result dict
         counter = ddict.get("counter")
         total = ddict.get("total")

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -64,6 +64,7 @@ from fibsem import constants
 from fibsem.fm.composite import auto_clim
 from fibsem.imaging import tiled
 from fibsem.imaging.reduce import downsample, downsample_mask
+from fibsem.imaging.tiling.progress import MODALITY_BEAM, is_modality
 from fibsem.microscope import FibsemMicroscope
 from fibsem.projection import BeamStageProjection
 from fibsem.structures import (
@@ -2835,7 +2836,14 @@ class FibsemOverviewWidget(QWidget):
 
         Reads with `.get`, not indexing: this signal is emitted from several places with
         several shapes, and the terminal update carries none of the per-tile keys.
+
+        Beam runs only. This widget places the payload's mosaic on its own canvas and
+        counts the tiles into its own record, so a fluorescence run reaching here would
+        be drawn as one of this tab's overviews (FIB-725).
         """
+        if not is_modality(payload, MODALITY_BEAM):
+            return
+
         counter = payload.get("counter")
         total = payload.get("total")
         if counter is not None and total:

--- a/tests/test_tiled_progress_payload.py
+++ b/tests/test_tiled_progress_payload.py
@@ -19,6 +19,12 @@ import pytest
 
 from fibsem import utils
 from fibsem.imaging.tiled import TiledAcquisitionRunner
+from fibsem.imaging.tiling.progress import (
+    MODALITY_BEAM,
+    MODALITY_FLUORESCENCE,
+    is_modality,
+    modality_of,
+)
 from fibsem.structures import (
     BeamType,
     ImageSettings,
@@ -117,3 +123,37 @@ def test_the_run_ends_with_a_terminal_update(payloads):
     terminal = [p for p in payloads if p.get("finished")]
     assert terminal, "no terminal update was emitted"
     assert terminal[-1].get("outcome") == "finished"
+
+
+def test_every_payload_says_which_modality_produced_it(payloads):
+    """The discriminator this signal never had.
+
+    Consumers used to work out what they had received from which keys were present,
+    which was survivable while `imaging/tiled.py` was the only emitter. It is not once a
+    second producer reports here: two consumers hand the payload's mosaic straight to a
+    *beam* canvas, and the fluorescence preview is keyed `image` already — deliberately,
+    to match this signal (FIB-725).
+
+    Asserted on every payload, not just the per-tile ones: a terminal update that could
+    not say whose run had finished would leave a consumer unable to decide whether to
+    clear its own progress.
+    """
+    assert payloads, "the run emitted nothing"
+    for payload in payloads:
+        assert payload.get("modality") == MODALITY_BEAM, payload.get("msg")
+
+
+def test_an_unlabelled_payload_reads_as_a_beam_run():
+    """`modality` is new, so a producer that predates it — including anything outside
+    this repository subscribing to a public signal — emits without it. Absent means
+    beam, which is what this signal carried for its whole life. A consumer written as
+    `payload.get("modality") == MODALITY_BEAM` would silently drop all of it."""
+    assert modality_of({}) == MODALITY_BEAM
+    assert is_modality({"counter": 1, "total": 2}, MODALITY_BEAM)
+    assert not is_modality({}, MODALITY_FLUORESCENCE)
+
+
+def test_a_fluorescence_payload_is_not_mistaken_for_a_beam_one():
+    payload = {"modality": MODALITY_FLUORESCENCE, "counter": 1, "total": 2}
+    assert is_modality(payload, MODALITY_FLUORESCENCE)
+    assert not is_modality(payload, MODALITY_BEAM)

--- a/tests/ui/test_minimap_progress_payload_safety.py
+++ b/tests/ui/test_minimap_progress_payload_safety.py
@@ -92,6 +92,33 @@ def test_a_payload_with_no_counts_leaves_the_last_progress_standing(handler):
     assert handler._tiles_acquired == 4
 
 
+def test_a_fluorescence_run_is_not_drawn_into_the_beam_minimap(handler):
+    """This tab drives a *beam* overview and assigns the payload's mosaic straight into
+    its napari layer. The fluorescence preview is keyed `image` already — deliberately,
+    to match this signal — so once a fluorescence run reports here, nothing but the
+    modality stops it being painted into the beam minimap (FIB-725)."""
+    from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
+
+    sentinel = object()
+    handler.handle_tile_acquisition_progress({
+        "modality": MODALITY_FLUORESCENCE,
+        "counter": 3, "total": 9, "msg": "Tile Collected", "image": sentinel,
+    })
+    assert handler.shown == [], "a fluorescence mosaic was drawn into the beam minimap"
+    assert handler._tiles_acquired == 0, "a fluorescence run moved the beam tile count"
+
+
+def test_a_beam_run_is_still_drawn(handler):
+    """The filter must not cost the thing it guards."""
+    sentinel = object()
+    handler.handle_tile_acquisition_progress({
+        "modality": "beam",
+        "counter": 3, "total": 9, "msg": "Tile Collected", "image": sentinel,
+    })
+    assert handler.shown == [sentinel]
+    assert handler._tiles_acquired == 3
+
+
 def test_a_preview_is_still_shown_when_the_counts_are_missing(handler):
     """The image and the counters are independent: dropping the bar update must not
     drop the picture with it."""

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -3641,3 +3641,37 @@ class TestDrivingTheStageFromAHost:
         monkeypatch.setattr(widget, "_may_move", refuse)
         widget.move_to(FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0))
         assert asked, "move_to did not go through _may_move"
+
+
+class TestItOnlyDrawsItsOwnRuns:
+    """`tiled_acquisition_signal` is about to carry a second producer.
+
+    This widget places the payload's mosaic on its own canvas and counts the tiles into
+    its own record, so a fluorescence run reaching here would be drawn as one of this
+    tab's overviews. Only `modality` separates them (FIB-725).
+    """
+
+    def test_a_fluorescence_run_is_ignored(self, widget):
+        from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
+
+        widget._tiles_acquired = 0
+        widget._apply_progress({
+            "modality": MODALITY_FLUORESCENCE,
+            "counter": 7, "total": 9, "msg": "Tile Collected",
+        })
+        assert widget._tiles_acquired == 0, "a fluorescence run moved this tab's count"
+
+    def test_a_beam_run_is_still_drawn(self, widget):
+        widget._tiles_acquired = 0
+        widget._apply_progress({
+            "modality": "beam",
+            "counter": 7, "total": 9, "msg": "Tile Collected",
+        })
+        assert widget._tiles_acquired == 7
+
+    def test_an_unlabelled_run_is_still_drawn(self, widget):
+        """Anything predating the key — including a producer outside this repository
+        subscribing to a public signal — must keep working."""
+        widget._tiles_acquired = 0
+        widget._apply_progress({"counter": 7, "total": 9, "msg": "Tile Collected"})
+        assert widget._tiles_acquired == 7


### PR DESCRIPTION
First half of FIB-725, shippable on its own: the discriminator lands and every consumer learns to filter, **before** anything new emits.

`tiled_acquisition_signal` is the only one of the five progress signals with no discriminator — consumers work out what they received from which keys are present. Survivable while `imaging/tiled.py` was its sole emitter; not survivable once the fluorescence tileset runner reports here.

It has to be, because two consumers hand the payload's mosaic straight to a **beam** canvas — and the fluorescence preview is keyed `image` *already*, deliberately, so that "a consumer of one reads the other". Nothing but the modality would stop a fluorescence mosaic being painted into the beam minimap.

## The key

`modality`, values `beam` / `fluorescence`. Not a new word: that is already how this codebase talks about the distinction, in `projection.py`, `stage_frame.py` and `canvas_base.py`.

Everything on this signal is a tiled run *by definition* — it is what the signal is named for — so the kind of **work** needs no discriminator; what varies is what is imaging. Electron and ion are not distinguished, because no consumer cares: both draw into the same overview.

## Absent means beam

```python
def is_modality(payload: dict, modality: str) -> bool:
    """...`payload.get("modality") == MODALITY_BEAM` looks equivalent and is not:
    it drops every payload from a producer that has not been taught the key."""
```

This is a signal on the public `FibsemMicroscope`, so the producers that predate the key are not only the ones in this repository. Absent is what it carried for its whole life, so absent reads as beam.

The contract lives in a new `fibsem/imaging/tiling/progress.py` — reachable by both runners without either importing the other's package, since the fluorescence runner already imports from `tiling.geometry`.

## Who filters, and who deliberately does not

| consumer | |
| -- | -- |
| `FibsemMinimapWidget` | beam only — assigns the mosaic into its napari layer |
| `FibsemOverviewWidget` | beam only — places the mosaic on its canvas and counts tiles into its own record |
| `AutoLamellaSingleWindowUI` | **unfiltered, and commented as such** — the status bar is the one consumer that wants both, since its job is saying what is happening while you look at another tab. What it will need is to say *which*, not to drop one. |

## No behaviour change

Three emit sites gain a key; two consumers learn to ignore something that does not exist yet.

## Verification

- **5465 tests pass** across `tests/` and the autolamella UI tests.
- The contract test asserts `modality` on **every** payload, terminal ones included — a consumer that cannot tell whose run finished cannot decide whether to clear its own progress.
- Both filtering consumers have a test that a fluorescence payload is ignored **and** that a beam one and an unlabelled one still get through, so the filter cannot pass by breaking everything.