### PR TITLE
[feat] Say what adding to the queue costs, and what it moves (FIB-731)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -49,6 +49,8 @@ from fibsem.applications.autolamella.ui.workflow_preflight_dialog import (
     WorkflowPreflightDialog,
 )
 from fibsem.applications.autolamella.workflows.workflow_estimate import (
+    AdditionEstimate,
+    estimate_addition,
     estimate_workflow,
 )
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI, INSTRUCTIONS
@@ -73,9 +75,9 @@ from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
     GRAY_ICON_COLOR,
-    DEFECT_ORANGE_COLOR,
     border_stylesheet,
 )
+from fibsem.ui.widgets import preflight
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
 from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
 from fibsem.ui import notification_service
@@ -134,44 +136,82 @@ def confirm_add_to_queue_dialog(
     task_names: list,
     run_next: bool,
     already_queued: list,
+    estimate: Optional[AdditionEstimate] = None,
     parent=None,
 ) -> bool:
     """Confirm adding work to a queue that is already running.
 
-    ``already_queued`` is stated rather than acted on: a task that runs twice
-    mills twice — the same mechanism that makes "Run again" useful — so the
-    consequence is named and the operator decides. Silently adding four of the
-    six pairs asked for would be its own surprise.
+    Two figures, and they are allowed to disagree. "Adds" is machine time the addition
+    costs; "Expected finish" is what that does to the workflow -- and work slotted in
+    ahead of a scheduled hold is absorbed into dead time the workflow was going to spend
+    anyway, so the first can be an hour while the second does not move. Quoting only the
+    work would overstate the cost; quoting only the finish would hide that the machine
+    is now busy for an hour it was not.
+
+    ``already_queued`` is stated rather than acted on: a task that runs twice mills
+    twice — the same mechanism that makes "Run again" useful — so the consequence is
+    named and the operator decides. Silently adding four of the six pairs asked for
+    would be its own surprise.
+
+    ``estimate`` is optional and may be unpriced. A protocol whose configs cannot be
+    estimated still has to be able to queue work, so the figures are dropped rather than
+    shown as a confident zero.
     """
     dlg = QDialog(parent)
     dlg.setWindowTitle("Add to Queue")
-    dlg.setMinimumWidth(600)
+    dlg.setMinimumWidth(560)
+    dlg.setStyleSheet(f"QDialog {{ background: {preflight.BACKGROUND}; }}")
 
     layout = QVBoxLayout(dlg)
-    layout.setSpacing(8)
+    layout.setContentsMargins(18, 16, 18, 14)
+    layout.setSpacing(12)
 
     total = len(lamella_names) * len(task_names)
-    where = "to run next" if run_next else "at the end of the queue"
-    layout.addWidget(QLabel(
-        f"Add {total} task(s) for {len(lamella_names)} lamella {where}?"
-    ))
+    heading = QLabel(f"Add {total} task(s) to a workflow that is already running?")
+    heading.setStyleSheet(f"color: {preflight.TEXT_STRONG}; font-size: 14px;")
+    layout.addWidget(heading)
 
-    col_row = QHBoxLayout()
-    col_row.setSpacing(8)
-    detail_height = min(max(len(lamella_names), len(task_names)) * 20 + 16, 216)
-    for heading, items in [("Lamella", lamella_names), ("Tasks", task_names)]:
-        col = QVBoxLayout()
-        col.setSpacing(4)
-        col.addWidget(QLabel(f"<b>{heading}</b>"))
-        te = QTextEdit()
-        te.setPlainText("\n".join(f"• {n}" for n in items))
-        te.setReadOnly(True)
-        te.setFixedHeight(detail_height)
-        col.addWidget(te)
-        col_row.addLayout(col)
-    layout.addLayout(col_row)
+    if estimate is not None and estimate.is_priced:
+        metrics = QHBoxLayout()
+        metrics.setSpacing(10)
+        metrics.addWidget(
+            preflight.metric(
+                "Adds",
+                preflight.format_duration(estimate.work_seconds),
+                _priced_note(estimate),
+            ),
+            1,
+        )
+        reference = estimate.finish_before
+        metrics.addWidget(
+            preflight.metric(
+                "Expected finish",
+                preflight.format_clock(estimate.finish_after, reference),
+                f"was {preflight.format_clock(estimate.finish_before, reference)}",
+            ),
+            1,
+        )
+        layout.addLayout(metrics)
+
+    layout.addWidget(preflight.detail_block([
+        ("Position", "Run next" if run_next else "At the end of the queue"),
+        ("Lamella", ", ".join(lamella_names)),
+        ("Tasks", ", ".join(task_names)),
+    ]))
+
+    absorbed = _absorbed_note(estimate)
+    if absorbed:
+        note = QLabel(absorbed)
+        note.setWordWrap(True)
+        note.setStyleSheet(f"color: {preflight.TEXT_MUTED}; font-size: 11px;")
+        layout.addWidget(note)
 
     if already_queued:
+        # Body text, no accent colour anywhere. This is a consequence to notice rather
+        # than an alarm: the count is bold enough to catch and Cancel is right there,
+        # while three lines in a warning colour out-shouted the two figures that are
+        # supposed to lead the dialog. Body rather than muted because it is content, not
+        # the secondary shade the detail-block labels use.
         warning = QLabel(
             f"<b>{len(already_queued)} already queued</b> and will be added again, "
             f"so those tasks will run twice:<br>"
@@ -179,7 +219,7 @@ def confirm_add_to_queue_dialog(
             + ("<br>• …" if len(already_queued) > 6 else "")
         )
         warning.setWordWrap(True)
-        warning.setStyleSheet(f"color: {DEFECT_ORANGE_COLOR};")
+        warning.setStyleSheet(f"color: {preflight.TEXT}; font-size: 11px;")
         layout.addWidget(warning)
 
     btn_row = QHBoxLayout()
@@ -196,6 +236,52 @@ def confirm_add_to_queue_dialog(
     layout.addLayout(btn_row)
 
     return dlg.exec_() == QDialog.Accepted
+
+
+def _priced_note(estimate: AdditionEstimate) -> str:
+    """The task count, and how much of it the figure above actually covers.
+
+    A partly-priced addition would otherwise read as a complete one that happens to be
+    quick — a lamella missing a config for one of the tasks contributes nothing, by the
+    same rule the pre-flight dialog and the timeline follow.
+    """
+    tasks = f"{estimate.total_count} task(s)"
+    if estimate.priced_count == estimate.total_count:
+        return tasks
+    return f"{tasks} · {estimate.priced_count} estimated"
+
+
+def _absorbed_note(estimate: Optional[AdditionEstimate]) -> str:
+    """Said only when the two figures disagree, because then they look wrong.
+
+    An hour of work that moves the finish by nothing is the correct answer and reads as
+    an error, so the reason goes on screen with it.
+
+    Two guards, and both are needed. **There has to be a scheduled wait**, because that
+    is what the sentence claims -- and `delay_seconds` comes back through a datetime
+    (microseconds) while `work_seconds` is a difference of two float sums, so for the
+    same quantity they can disagree in the twelfth decimal place. That was enough to
+    explain a wait that did not exist on a queue with nothing scheduled at all.
+
+    **And the disagreement has to be one the reader can see.** Both figures are rendered
+    with `format_duration`, so a gap that rounds away is not a discrepancy needing an
+    explanation -- it is two identical numbers with a paragraph between them.
+    """
+    if estimate is None or not estimate.is_priced:
+        return ""
+    if estimate.hold_seconds <= 0 or estimate.work_seconds <= 0:
+        return ""
+    if preflight.format_duration(estimate.delay_seconds) == preflight.format_duration(
+        estimate.work_seconds
+    ):
+        return ""
+    if estimate.delay_seconds <= 0:
+        return ("The workflow is already waiting for a scheduled task, and this work "
+                "fits inside that wait — so it costs no extra time overall.")
+    return (
+        f"Only {preflight.format_duration(estimate.delay_seconds)} of this lands after "
+        "the workflow's scheduled wait; the rest fits inside it."
+    )
 
 
 class AutoLamellaSingleWindowUI(QMainWindow):
@@ -1910,8 +1996,14 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         already = [f"{t} for {ln}" for t in task_names for ln in lamella_names
                    if (ln, t) in pending]
 
-        if not confirm_add_to_queue_dialog(lamella_names, task_names, run_next,
-                                           already, parent=self):
+        # Task-outer, lamella-inner: the order the items are really inserted in below,
+        # so what is priced is what will be queued.
+        pairs = [(ln, tn) for tn in task_names for ln in lamella_names]
+        if not confirm_add_to_queue_dialog(
+            lamella_names, task_names, run_next, already,
+            estimate=self._estimate_addition(manager, pairs, run_next),
+            parent=self,
+        ):
             return
 
         # A lamella created before a task joined the protocol has no config for
@@ -1957,6 +2049,62 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # the estimates are recomputed here rather than only at the start.
         self._push_timeline_estimates([(i.lamella_name, i.task_name) for i in items])
         self.workflow_timeline.refresh_queue(items)
+
+    def _estimate_addition(self, manager, pairs: list, run_next: bool):
+        """What adding `pairs` would cost the running queue, or None if it cannot say.
+
+        Priced from the same `estimated_duration` the pre-flight dialog and the timeline
+        use, over a snapshot of the live queue — `queue.items` hands out copies, so the
+        hypothetical is built without touching what is running.
+        """
+        experiment = getattr(self.autolamella_ui, "experiment", None)
+        if experiment is None:
+            return None
+
+        lamella_by_name = {lam.name: lam for lam in experiment.positions}
+
+        def seconds_for(item):
+            lamella = lamella_by_name.get(item.lamella_name)
+            if lamella is None:
+                return None
+            config = lamella.task_config.get(item.task_name)
+            if config is None:
+                return None
+            try:
+                return config.estimated_duration
+            except Exception:
+                # `estimated_time` divides by the sputter rate (milling/base.py:292), so
+                # a hand-edited protocol can raise. Losing the figure is a great deal
+                # better than losing the dialog that queues the work.
+                logging.warning("Could not estimate duration for %s on %s.",
+                                item.task_name, item.lamella_name, exc_info=True)
+                return None
+
+        schedule = {}
+        protocol = experiment.task_protocol
+        if protocol is not None:
+            schedule = {
+                task.name: task.scheduled_at
+                for task in protocol.workflow_config.tasks
+                if task.scheduled_at is not None
+            }
+
+        # Wall-clock since the running task started, which is what the recorded duration
+        # measures too. It counts any supervised wait, so the absolute finish can run a
+        # little optimistic — but both walks share it, so the *delay* is unaffected.
+        active_elapsed = None
+        active = manager.queue.active
+        if active is not None:
+            lamella = lamella_by_name.get(active.lamella_name)
+            if lamella is not None and lamella.task_state.start_timestamp:
+                active_elapsed = max(
+                    0.0, time.time() - lamella.task_state.start_timestamp
+                )
+
+        return estimate_addition(
+            manager.queue.items, pairs, seconds_for,
+            run_next=run_next, schedule=schedule, active_elapsed=active_elapsed,
+        )
 
     def _push_timeline_estimates(self, pairs: list) -> None:
         """Give the timeline the per-item durations, and the schedule they walk past.

--- a/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
+++ b/fibsem/applications/autolamella/ui/workflow_preflight_dialog.py
@@ -40,9 +40,11 @@ from fibsem.ui.widgets.preflight import (
     TEXT,
     TEXT_MUTED,
     TEXT_STRONG,
+    ON_PANEL,
     chip,
     format_clock as _clock,
     format_duration,
+    metric as _metric,
     meta_label,
 )
 
@@ -58,40 +60,7 @@ _DURATION_WIDTH = 84
 # the list truncates and says how many it did not show instead.
 _NAMES_SHOWN = 12
 
-# Anything sitting on a panel has to say it is transparent. The app applies
-# NAPARI_STYLE, whose bare `QWidget { background-color: ... }` rule reaches every
-# descendant, so a label that only sets `color` paints the *surface* colour onto the
-# darker panel behind it -- a lighter block around every word. Only visible with the
-# app stylesheet loaded, which is why the offscreen renders looked clean.
-_ON_PANEL = "background: transparent; border: none; "
-
-
-def _metric(label_text: str, value_text: str) -> QWidget:
-    """One of the two figures that lead the dialog.
-
-    Two, not one: the duration answers "is this worth starting", the wall-clock finish
-    answers "when do I come back", and the second is the one people act on.
-    """
-    frame = QFrame()
-    # Scoped to this frame by name. A bare `QFrame { ... }` selector also matches every
-    # QFrame *inside* it, and preflight.chip() is one -- which repainted each chip with
-    # the panel's fill on top of its own.
-    frame.setObjectName("preflightMetric")
-    frame.setStyleSheet(
-        f"QFrame#preflightMetric {{ background: {PANEL}; border: 1px solid {BORDER};"
-        f" border-radius: 4px; }}"
-    )
-    layout = QVBoxLayout(frame)
-    layout.setContentsMargins(12, 9, 12, 9)
-    layout.setSpacing(2)
-
-    caption = QLabel(label_text)
-    caption.setStyleSheet(_ON_PANEL + f"color: {TEXT_MUTED}; font-size: 11px;")
-    value = QLabel(value_text)
-    value.setStyleSheet(_ON_PANEL + f"color: {TEXT_STRONG}; font-size: 19px;")
-    layout.addWidget(caption)
-    layout.addWidget(value)
-    return frame
+_ON_PANEL = ON_PANEL  # see preflight.ON_PANEL for why every label on a panel needs it
 
 
 def _task_row(task: TaskEstimate, reference: Optional[datetime] = None) -> QWidget:

--- a/fibsem/applications/autolamella/workflows/workflow_estimate.py
+++ b/fibsem/applications/autolamella/workflows/workflow_estimate.py
@@ -279,3 +279,120 @@ def estimate_queue(
         active_remaining=active_remaining,
         active_estimate_spent=active_estimate_spent,
     )
+
+
+@dataclass(frozen=True)
+class AdditionEstimate:
+    """What appending work to a running queue costs, and what it moves.
+
+    Two figures rather than one, because they can disagree and the disagreement is the
+    point: work added ahead of a scheduled hold is absorbed into dead time the workflow
+    was going to spend anyway, so ``work_seconds`` can be an hour while ``delay_seconds``
+    is zero. Quoting only the first would overstate the cost; quoting only the second
+    would hide that the machine is now busy for an hour it was not.
+    """
+
+    work_seconds: float = 0.0
+    """Machine time the addition adds. Independent of where it lands in the queue."""
+
+    delay_seconds: float = 0.0
+    """How much later the workflow now finishes. Zero when a hold absorbs the work."""
+
+    finish_before: Optional[datetime] = None
+    finish_after: Optional[datetime] = None
+
+    hold_seconds: float = 0.0
+    """Scheduled dead time in the queue once the addition is in.
+
+    Zero when nothing is scheduled, which is what lets a caller tell "this work costs no
+    delay because a wait absorbed it" from "this work costs no delay because there is
+    barely any of it" -- two sentences that must not be swapped.
+    """
+
+    priced_count: int = 0
+    """How many of the added items had an estimate to offer."""
+
+    total_count: int = 0
+
+    @property
+    def is_priced(self) -> bool:
+        """Whether there is a number worth showing at all.
+
+        False when nothing added could be priced -- a protocol whose configs cannot be
+        estimated, say. The caller shows the addition without the figures rather than
+        quoting a confident zero.
+        """
+        return self.priced_count > 0
+
+
+def _with_addition(
+    items: "Sequence[WorkItem]",
+    added: "Sequence[WorkItem]",
+    run_next: bool,
+) -> "List[WorkItem]":
+    """The queue as it would be with ``added`` spliced in.
+
+    Mirrors where ``TaskQueue`` actually puts them: ``run_next`` lands the batch at the
+    first pending slot -- ``_pending_start()``, so never ahead of the running item or
+    inside history -- and otherwise at the end. The batch keeps the order it is given,
+    which is what ``_on_add_to_queue`` produces by anchoring each item after the last.
+    """
+    if not run_next:
+        return list(items) + list(added)
+    start = next((n for n, i in enumerate(items) if i.is_pending), len(items))
+    return list(items[:start]) + list(added) + list(items[start:])
+
+
+def estimate_addition(
+    items: "Sequence[WorkItem]",
+    pairs: "Sequence",
+    seconds_for: "Callable[[WorkItem], Optional[float]]",
+    run_next: bool = False,
+    schedule: Optional[Dict[str, datetime]] = None,
+    now: Optional[datetime] = None,
+    active_elapsed: Optional[float] = None,
+) -> AdditionEstimate:
+    """Estimate what adding ``pairs`` to a running queue would cost.
+
+    The same queue walk twice, over the snapshot as it is and as it would be. Doing it
+    by difference rather than by summing the addition is what makes the scheduled-hold
+    case come out right: a hold is not a property of the added work, it is a property of
+    where the work lands relative to it.
+
+    It also makes the *delay* exact even when the absolute finish is not. Both walks
+    treat the running task identically, so whatever ``active_elapsed`` cannot account for
+    -- a supervised pause, most of all -- cancels in the subtraction.
+
+    Args:
+        items: the live queue snapshot, in order
+        pairs: (lamella_name, task_name) to add, in the order they will be inserted
+        seconds_for: per-item estimate; None for an item with nothing to offer
+        run_next: True to insert at the front of the pending region, False for the end
+        schedule: ``scheduled_at`` per task name, for the tasks that have one
+        now: the clock to walk from; defaults to the current time
+        active_elapsed: seconds the running task has been going
+
+    Returns:
+        AdditionEstimate: the work added, and the delay it causes.
+    """
+    from fibsem.applications.autolamella.workflows.tasks.queue import WorkItem
+
+    clock = now if now is not None else datetime.now()
+    added = [WorkItem(lamella_name=ln, task_name=tn) for ln, tn in pairs]
+    proposed = _with_addition(items, added, run_next)
+
+    before = estimate_queue(items, seconds_for, schedule, clock, active_elapsed)
+    after = estimate_queue(proposed, seconds_for, schedule, clock, active_elapsed)
+
+    priced = sum(1 for item in added if seconds_for(item) is not None)
+    return AdditionEstimate(
+        work_seconds=after.work_seconds - before.work_seconds,
+        # Never negative: adding work cannot bring a finish forward, and floating-point
+        # dust on two large sums should not render as "-0s".
+        delay_seconds=max(0.0, (after.expected_finish - before.expected_finish).total_seconds()),
+        finish_before=before.expected_finish,
+        finish_after=after.expected_finish,
+        hold_seconds=after.hold_seconds,
+        priced_count=priced,
+        total_count=len(pairs),
+    )

--- a/fibsem/ui/widgets/preflight.py
+++ b/fibsem/ui/widgets/preflight.py
@@ -126,6 +126,48 @@ def format_clock(when: Optional[datetime], reference: Optional[datetime]) -> str
     return when.strftime(DATETIME_DISPLAY_AMPM)
 
 
+# Anything sitting on a panel has to say it is transparent. The app applies
+# NAPARI_STYLE, whose bare `QWidget { background-color: ... }` rule reaches every
+# descendant, so a label that only sets `color` paints the *surface* colour onto the
+# darker panel behind it -- a lighter block around every word. Only visible with the app
+# stylesheet loaded, which is why offscreen renders of it looked clean.
+ON_PANEL = "background: transparent; border: none; "
+
+
+def metric(caption_text: str, value_text: str, sub_text: str = "") -> QWidget:
+    """A figure the dialog leads with, in a panel of its own.
+
+    Args:
+        sub_text: a smaller line under the value, for the figure's own context -- what a
+            number *was* before the change being confirmed, most usefully. Omitted by
+            the pre-flight dialog, whose two figures need none.
+    """
+    frame = QFrame()
+    # Scoped to this frame by name. A bare `QFrame { ... }` selector also matches every
+    # QFrame *inside* it, and `chip()` is one -- which repainted each chip with the
+    # panel's fill on top of its own.
+    frame.setObjectName("preflightMetric")
+    frame.setStyleSheet(
+        f"QFrame#preflightMetric {{ background: {PANEL}; border: 1px solid {BORDER};"
+        f" border-radius: 4px; }}"
+    )
+    layout = QVBoxLayout(frame)
+    layout.setContentsMargins(12, 9, 12, 9)
+    layout.setSpacing(2)
+
+    caption = QLabel(caption_text)
+    caption.setStyleSheet(ON_PANEL + f"color: {TEXT_MUTED}; font-size: 11px;")
+    value = QLabel(value_text)
+    value.setStyleSheet(ON_PANEL + f"color: {TEXT_STRONG}; font-size: 19px;")
+    layout.addWidget(caption)
+    layout.addWidget(value)
+    if sub_text:
+        sub = QLabel(sub_text)
+        sub.setStyleSheet(ON_PANEL + f"color: {TEXT_MUTED}; font-size: 11px;")
+        layout.addWidget(sub)
+    return frame
+
+
 def chip(text: str) -> QWidget:
     """Plain pill label. No status dot: these are counts, not states, and a colour
     that does not encode anything reads as though it does."""

--- a/tests/autolamella/test_workflow_estimate.py
+++ b/tests/autolamella/test_workflow_estimate.py
@@ -339,3 +339,105 @@ def test_a_timezone_aware_schedule_in_the_queue_does_not_raise():
     aware = (NOW + timedelta(hours=4)).replace(tzinfo=timezone.utc)
     est = estimate_queue(_items(("01", "A")), _flat(60.0), schedule={"A": aware}, now=NOW)
     assert est.expected_finish is not None
+
+
+# ── adding to a running queue ─────────────────────────────────────────────────
+# Two figures that can disagree: the work added, and the delay it causes. The gap
+# between them is the whole reason this is computed by difference rather than summed.
+
+from fibsem.applications.autolamella.workflows.workflow_estimate import (  # noqa: E402
+    estimate_addition,
+)
+
+
+def test_adding_work_to_a_plain_queue_delays_it_by_exactly_that_work():
+    est = estimate_addition(_items(("01", "A")), [("02", "A")], _flat(60.0), now=NOW)
+    assert est.work_seconds == pytest.approx(60.0)
+    assert est.delay_seconds == pytest.approx(60.0)
+    assert est.finish_after == est.finish_before + timedelta(seconds=60)
+
+
+def test_the_work_added_does_not_depend_on_where_it_lands():
+    items = _items(("01", "A"), ("02", "B"))
+    at_end = estimate_addition(items, [("03", "A")], _flat(60.0), run_next=False, now=NOW)
+    up_next = estimate_addition(items, [("03", "A")], _flat(60.0), run_next=True, now=NOW)
+    assert at_end.work_seconds == pytest.approx(up_next.work_seconds)
+
+
+def test_work_that_fits_inside_a_scheduled_hold_costs_no_delay():
+    """The case the two figures exist for. The workflow was going to sit until 8pm
+    anyway; work slotted in ahead of that is absorbed, so an hour of milling moves the
+    finish by nothing. Summing the addition instead of differencing would say an hour."""
+    at = NOW + timedelta(hours=4)
+    items = _items(("01", "Scheduled"))
+    est = estimate_addition(items, [("02", "Earlier")], _flat(3600.0),
+                            run_next=True, schedule={"Scheduled": at}, now=NOW)
+    assert est.work_seconds == pytest.approx(3600.0)
+    assert est.delay_seconds == 0.0
+    assert est.finish_after == est.finish_before
+
+
+def test_the_same_work_after_the_hold_does_delay_it():
+    """Same queue, same work, other end -- and now it costs its full duration. Position
+    is a property of the hold, not of the work, which is why this cannot be a sum."""
+    at = NOW + timedelta(hours=4)
+    items = _items(("01", "Scheduled"))
+    est = estimate_addition(items, [("02", "Later")], _flat(3600.0),
+                            run_next=False, schedule={"Scheduled": at}, now=NOW)
+    assert est.delay_seconds == pytest.approx(3600.0)
+
+
+def test_run_next_lands_the_batch_ahead_of_the_pending_work_not_of_history():
+    """`front=True` clamps to `_pending_start()`, so a completed item stays where it is
+    and the addition cannot be placed before the running one."""
+    from fibsem.applications.autolamella.workflows.workflow_estimate import _with_addition
+    items = _items(("01", "A", AutoLamellaTaskStatus.Completed),
+                   ("02", "A", AutoLamellaTaskStatus.InProgress),
+                   ("03", "A"))
+    order = [(i.lamella_name, i.task_name) for i in
+             _with_addition(items, _items(("09", "New")), run_next=True)]
+    assert order == [("01", "A"), ("02", "A"), ("09", "New"), ("03", "A")]
+
+
+def test_added_items_with_no_estimate_are_counted_but_not_priced():
+    """The dialog needs to know the difference between "no delay" and "cannot say"."""
+    est = estimate_addition(_items(("01", "A")), [("02", "A"), ("03", "A")],
+                            lambda item: None, now=NOW)
+    assert est.total_count == 2
+    assert est.priced_count == 0
+    assert est.is_priced is False
+    assert est.delay_seconds == 0.0
+
+
+def test_a_partly_priced_addition_still_says_so():
+    seconds_for = lambda item: 60.0 if item.lamella_name == "02" else None
+    est = estimate_addition(_items(("01", "A")), [("02", "A"), ("03", "A")],
+                            seconds_for, now=NOW)
+    assert (est.priced_count, est.total_count) == (1, 2)
+    assert est.is_priced is True
+    assert est.work_seconds == pytest.approx(60.0)
+
+
+def test_adding_to_an_empty_queue_is_the_whole_queue():
+    est = estimate_addition([], [("01", "A")], _flat(60.0), now=NOW)
+    assert est.work_seconds == pytest.approx(60.0)
+    assert est.finish_after == NOW + timedelta(seconds=60)
+
+
+def test_the_delay_never_goes_negative():
+    """Two large sums differenced can land a hair below zero; `-0s` reads as a bug."""
+    est = estimate_addition(_items(("01", "A")), [], _flat(60.0), now=NOW)
+    assert est.delay_seconds == 0.0
+    assert est.total_count == 0
+
+
+def test_the_delay_is_exact_even_when_the_running_task_cannot_be_priced():
+    """Both walks treat the active task identically, so whatever `active_elapsed` fails
+    to account for cancels in the subtraction. The absolute finish may be optimistic;
+    the delay is not."""
+    items = _items(("01", "A", AutoLamellaTaskStatus.InProgress), ("02", "A"))
+    known = estimate_addition(items, [("03", "A")], _flat(60.0), now=NOW,
+                              active_elapsed=10.0)
+    unknown = estimate_addition(items, [("03", "A")], _flat(60.0), now=NOW)
+    assert known.delay_seconds == pytest.approx(unknown.delay_seconds)
+    assert known.finish_after != unknown.finish_after

--- a/tests/ui/test_add_to_queue_dialog.py
+++ b/tests/ui/test_add_to_queue_dialog.py
@@ -1,0 +1,267 @@
+"""What the Add to Queue dialog says about time (FIB-731).
+
+The arithmetic is tested in tests/autolamella/test_workflow_estimate.py without a widget.
+What is checked here is the dialog's own job: showing two figures that are allowed to
+disagree, saying why when they do, and staying usable when there is no estimate at all.
+
+`NAPARI_STYLE` is applied to the QApplication deliberately -- the app sets it, and its
+bare `QWidget { background-color: ... }` rule reaches every descendant, so a render
+without it cannot show a label painting a block onto the panel behind it.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_add_to_queue_dialog.py
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from datetime import datetime, timedelta
+
+from PyQt5.QtWidgets import QDialog, QLabel
+
+from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+    confirm_add_to_queue_dialog,
+)
+from fibsem.applications.autolamella.workflows.tasks.queue import WorkItem
+from fibsem.applications.autolamella.workflows.workflow_estimate import estimate_addition
+from fibsem.ui.stylesheets import NAPARI_STYLE
+
+NOW = datetime(2026, 8, 19, 14, 0, 0)
+LAMELLA = ["01-lamella", "02-lamella"]
+TASKS = ["Rough Milling", "Polishing"]
+PAIRS = [(ln, tn) for tn in TASKS for ln in LAMELLA]
+
+
+@pytest.fixture
+def app(qapp):
+    qapp.setStyleSheet(NAPARI_STYLE)
+    return qapp
+
+
+@pytest.fixture
+def show(app, monkeypatch):
+    """Open the dialog without blocking, and hand it back for inspection."""
+    built = []
+
+    def fake_exec(self):
+        built.append(self)
+        return QDialog.Rejected
+
+    monkeypatch.setattr(QDialog, "exec_", fake_exec)
+
+    def open_it(estimate=None, already=(), run_next=False):
+        confirm_add_to_queue_dialog(LAMELLA, TASKS, run_next, list(already),
+                                    estimate=estimate)
+        return built[-1]
+
+    yield open_it
+    for dlg in built:
+        dlg.close()
+
+
+def texts(dialog) -> list:
+    return [lab.text() for lab in dialog.findChildren(QLabel)]
+
+
+def joined(dialog) -> str:
+    return " | ".join(texts(dialog))
+
+
+def queue(*spec) -> list:
+    return [WorkItem(lamella_name=ln, task_name=tn) for ln, tn in spec]
+
+
+def estimate(items, seconds=600.0, run_next=False, schedule=None):
+    return estimate_addition(items, PAIRS, lambda i: seconds, run_next=run_next,
+                             schedule=schedule, now=NOW)
+
+
+# ── the two figures ───────────────────────────────────────────────────────────
+
+def test_it_shows_what_the_addition_costs_and_where_it_lands(show):
+    dialog = show(estimate(queue(("03-lamella", "Rough Milling"))))
+    body = joined(dialog)
+    assert "Adds" in body
+    assert "40m 00s" in body       # 4 added tasks x 600 s
+    assert "Expected finish" in body
+    assert "was " in body          # the finish it moved from
+
+
+def test_the_finish_it_quotes_is_the_one_after_the_addition(show):
+    est = estimate(queue(("03-lamella", "Rough Milling")))
+    dialog = show(est)
+    from fibsem.ui.widgets.preflight import format_clock
+    after = format_clock(est.finish_after, est.finish_before)
+    before = format_clock(est.finish_before, est.finish_before)
+    assert after in joined(dialog)
+    assert f"was {before}" in joined(dialog)
+    assert after != before
+
+
+def test_the_task_count_sits_under_the_duration(show):
+    assert "4 task(s)" in joined(show(estimate(queue(("03-lamella", "Rough Milling")))))
+
+
+# ── when the two figures disagree ─────────────────────────────────────────────
+
+def test_work_absorbed_by_a_scheduled_wait_says_why_it_costs_nothing(show):
+    """An hour of work that moves the finish by nothing is the right answer and reads
+    as a bug, so the reason goes on screen beside it."""
+    at = NOW + timedelta(hours=6)
+    est = estimate_addition(queue(("03-lamella", "Polishing")), [("04-lamella", "Setup")],
+                            lambda i: 600.0, run_next=True,
+                            schedule={"Polishing": at}, now=NOW)
+    assert est.work_seconds > 0 and est.delay_seconds == 0
+    assert "costs no extra time overall" in joined(show(est))
+
+
+def test_partly_absorbed_work_says_how_much_actually_lands_late(show):
+    at = NOW + timedelta(hours=6)
+    est = estimate_addition(
+        queue(("03-lamella", "Polishing")), PAIRS, lambda i: 600.0,
+        run_next=True, schedule={"Polishing": at}, now=NOW,
+    )
+    assert 0 < est.delay_seconds < est.work_seconds
+    assert "fits inside it" in joined(show(est))
+
+
+def test_an_ordinary_addition_explains_nothing(show):
+    """The note exists for the surprising case. On a plain queue the two figures agree
+    and a sentence saying so would be noise."""
+    body = joined(show(estimate(queue(("03-lamella", "Rough Milling")))))
+    assert "fits inside" not in body
+    assert "costs no extra time" not in body
+
+
+# ── degrading ─────────────────────────────────────────────────────────────────
+
+def test_with_no_estimate_at_all_the_figures_are_dropped_not_faked(show):
+    """A protocol whose configs cannot be priced still has to be able to queue work."""
+    body = joined(show(None))
+    assert "Adds" not in body
+    assert "Expected finish" not in body
+    assert "Rough Milling, Polishing" in body      # the dialog still does its job
+
+
+def test_an_unpriced_estimate_is_treated_as_no_estimate(show):
+    est = estimate_addition(queue(("03-lamella", "Rough Milling")), PAIRS,
+                            lambda i: None, now=NOW)
+    assert est.is_priced is False
+    assert "Expected finish" not in joined(show(est))
+
+
+def test_a_partly_priced_addition_admits_how_much_it_covers(show):
+    """Otherwise it reads as a complete estimate that happens to be quick."""
+    seconds_for = lambda i: 600.0 if i.lamella_name == "01-lamella" else None
+    est = estimate_addition(queue(("03-lamella", "Rough Milling")), PAIRS,
+                            seconds_for, now=NOW)
+    assert "2 estimated" in joined(show(est))
+
+
+# ── what the dialog said before, and still must ───────────────────────────────
+
+def test_the_already_queued_warning_survives(show):
+    """The one thing this dialog says that nothing else does: a task queued twice mills
+    twice. It is stated rather than acted on, so it has to stay stated."""
+    dialog = show(estimate(queue(("03-lamella", "Rough Milling"))),
+                  already=["Polishing for 01-lamella", "Polishing for 02-lamella"])
+    body = joined(dialog)
+    assert "2 already queued" in body
+    assert "run twice" in body
+    assert "Polishing for 01-lamella" in body
+
+
+def test_the_duplicate_notice_carries_no_accent_colour(show):
+    """A consequence to notice, not an alarm. The bold count is enough to catch and
+    Cancel is right there; three lines of body text beat three orange ones out-shouting
+    the two figures that lead the dialog."""
+    from fibsem.ui.tokens import DEFECT_ORANGE_COLOR
+    dialog = show(None, already=["Polishing for 01-lamella"])
+    warning = next(lab for lab in dialog.findChildren(QLabel)
+                   if "already queued" in lab.text())
+    from fibsem.ui.widgets.preflight import TEXT, TEXT_MUTED
+    assert DEFECT_ORANGE_COLOR not in warning.text()
+    assert DEFECT_ORANGE_COLOR not in warning.styleSheet()
+    # Body, not the secondary shade: this is content, not a detail-block label.
+    assert TEXT in warning.styleSheet()
+    assert TEXT_MUTED not in warning.styleSheet()
+    assert "<b>" in warning.text(), "the count still needs to be findable"
+
+
+def test_a_long_already_queued_list_is_truncated_rather_than_unbounded(show):
+    already = [f"Polishing for {i:02d}-lamella" for i in range(20)]
+    body = joined(show(None, already=already))
+    assert "20 already queued" in body
+    assert "…" in body
+
+
+def test_the_position_is_named_both_ways(show):
+    assert "At the end of the queue" in joined(show(None, run_next=False))
+    assert "Run next" in joined(show(None, run_next=True))
+
+
+def test_the_count_in_the_button_matches_what_will_be_queued(show):
+    from PyQt5.QtWidgets import QPushButton
+    dialog = show(None)
+    labels = [b.text() for b in dialog.findChildren(QPushButton)]
+    assert "Add 4 task(s)" in labels
+    assert "Cancel" in labels
+
+
+def test_cancel_is_the_default_button(show):
+    """Adding work to a running queue is not the safe outcome of a stray Return."""
+    from PyQt5.QtWidgets import QPushButton
+    dialog = show(None)
+    default = [b.text() for b in dialog.findChildren(QPushButton) if b.isDefault()]
+    assert default == ["Cancel"]
+
+
+def test_all_three_dialogs_quote_time_the_same_way(show):
+    """This one, the pre-flight dialog and the timeline all describe the same workflow;
+    they cannot use different formatters and stay believable."""
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as main_ui
+    from fibsem.ui.widgets import preflight
+    assert main_ui.preflight.format_duration is preflight.format_duration
+    assert main_ui.preflight.format_clock is preflight.format_clock
+
+
+# ── the note must not invent a wait ───────────────────────────────────────────
+
+def test_a_queue_with_nothing_scheduled_never_mentions_a_scheduled_wait(show):
+    """Regression. `delay_seconds` comes back through a datetime and `work_seconds` is a
+    difference of two float sums, so for the same quantity they disagreed by 9e-13 --
+    enough for a `>=` test to conclude the work had been partly absorbed and explain a
+    wait that did not exist. Reported from the running app on a plain queue.
+    """
+    lamella = [f"{i:02d}-lamella" for i in range(1, 7)]
+    pairs = [(ln, tn) for tn in TASKS for ln in lamella]
+    est = estimate_addition(queue(("07-lamella", "Polishing")), pairs,
+                            lambda i: 505.3, now=NOW)   # nothing scheduled anywhere
+    assert est.work_seconds != est.delay_seconds, "the float gap this guards is gone"
+    assert est.hold_seconds == 0.0
+    assert "scheduled wait" not in joined(show(est))
+
+
+def test_a_difference_too_small_to_render_is_not_explained(show):
+    """Both figures go through `format_duration`, so a gap that rounds away leaves two
+    identical numbers with a paragraph between them saying they differ."""
+    at = NOW + timedelta(hours=6)
+    est = estimate_addition(queue(("03-lamella", "Polishing")), [("04-lamella", "Setup")],
+                            lambda i: 600.0, schedule={"Polishing": at}, now=NOW)
+    object.__setattr__(est, "delay_seconds", est.work_seconds - 0.2)
+    assert est.hold_seconds > 0
+    assert "fits inside it" not in joined(show(est))
+
+
+def test_a_real_partial_absorption_is_still_explained(show):
+    """The guards must not silence the case the note exists for."""
+    at = NOW + timedelta(hours=6)
+    est = estimate_addition(queue(("03-lamella", "Polishing")), PAIRS, lambda i: 600.0,
+                            run_next=True, schedule={"Polishing": at}, now=NOW)
+    assert est.hold_seconds > 0
+    assert 0 < est.delay_seconds < est.work_seconds
+    assert "fits inside it" in joined(show(est))


### PR DESCRIPTION
Add to Queue was the last dialog built from two `QTextEdit` bullet columns, and the last decision about workflow time with no number attached to it. Adding six tasks to a running queue pushes the finish out; nothing said by how much.

Completes FIB-731, on `estimate_queue` from #451.

## Two figures, and they are allowed to disagree

**Adds** is machine time the addition costs. **Expected finish** is what that does to the workflow. Work slotted in ahead of a scheduled hold is absorbed into dead time the workflow was going to spend anyway, so the first can be an hour while the second does not move.

Quoting only the work would overstate the cost; quoting only the finish would hide that the machine is now busy for an hour it was not. When they differ, a line underneath says why — a delay that is not the duration printed above it reads as a bug otherwise.

| | |
| -- | -- |
| plain queue | `Adds 1h 25m` · `finishes 3:29PM, was 2:04PM` |
| a scheduled wait ahead | `Adds 1h 25m` · finish moves 43m, *"Only 42m 30s of this lands after the workflow's scheduled wait; the rest fits inside it."* |
| nothing priceable | figures dropped, dialog still queues the work |

## By difference, not by summing

`estimate_addition` runs the existing queue walk twice — over the snapshot as it is, and as it would be. A hold is not a property of the added work; it is a property of where that work lands relative to it, so the addition cannot be priced on its own.

It also makes the **delay exact when the absolute finish is not**. Both walks treat the running task identically, so whatever `active_elapsed` cannot account for — a supervised pause, most of all — cancels in the subtraction. The finish carries the same caveat the timeline header already does; the delay carries none.

## Not a subclass of the pre-flight dialog

They confirm different things, and this one carries the already-queued notice that has no slot there. `_metric` moves into `preflight.py` as `metric()` instead, gaining an optional sub-line for the finish it moved from — the third user of that panel, which is the threshold that module's docstring names for lifting something out.

## Notes for review

* **The already-queued notice keeps its wording and loses its accent colour.** A consequence to notice rather than an alarm: the bold count catches the eye, Cancel is right there, and three lines of warning colour out-shouted the two figures meant to lead the dialog.
* **The explanatory line is guarded twice, and each guard catches a different failure.** It has to be a discrepancy the reader can *see* — both figures render through `format_duration`, so a gap that rounds away is two identical numbers with a paragraph between them saying they differ. And there has to be an actual hold: `delay_seconds` returns through a datetime while `work_seconds` is a difference of two float sums, and for the same quantity those disagreed by 9e-13 — enough for a `>=` test to conclude the work was partly absorbed and explain a scheduled wait on a queue with nothing scheduled at all. Found by running it; both cases are pinned by tests.
* **Degrades the way the rest of the feature does.** A lamella with no config for a task contributes nothing rather than an invented number, and a partly-priced addition says how much it covers — otherwise it reads as a complete estimate that happens to be quick. `estimated_duration` divides by the sputter rate (`milling/base.py:292`), so a hand-edited protocol can raise; losing the figure beats losing the dialog that queues the work.

## Verification

* 25 new tests — 10 on the arithmetic without a widget, 15 on what the dialog says — mutation-checked against deliberate breaks rather than trusted for passing.
* Qt tests apply `NAPARI_STYLE`, without which an offscreen render cannot show a label painting a block onto the panel behind it.
* Run in the real app.

Unrelated: `tests/ui/test_overview_tab_host.py` currently has 10 errors on `main` — its `fm_tab` fixture asserts the fluorescence tab is available, but the Demo microscope is not a compustage so `microscope.fm` is None and the tab builds no widget. Introduced by #452 and extended by #453, invisible to CI (no PyQt5). This branch matches `main` exactly on it.
