### PR TITLE
[fix] Say when a fluorescence overview is stitching and saving (FIB-735)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -607,6 +607,17 @@ class FMTiledAcquisitionRunner:
         true of none of them.
         """
         self.run()
+        # Between the last tile and the mosaic there is real work, and until this it was
+        # reported as nothing at all: the tile bar stopped at N/N and the run looked
+        # finished while the app built and wrote a multi-gigabyte array. Measured at
+        # ~2.1 s per GB of mosaic on a local SSD -- about 7 s for a 5x5 at ARCTIS
+        # resolution in four channels, and worse to a network drive (FIB-725).
+        #
+        # The beam tiler has always said "Stitching Tiles" here. This is the same phase
+        # in the same place; it is only that the fluorescence stitch and save happen in
+        # two different objects, so they are announced separately -- the save from the
+        # widget that performs it.
+        self._emit({"state": "stitching", "task": "tileset"})
         return stitch_tileset(
             self.tileset,
             self.overview_parameters.overlap,

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -171,6 +171,16 @@ class PlacedOverviewImageRecord:
         return " · ".join(parts)
 
 
+# What each countless phase of a run is called on screen. All three are handled the same
+# way and for the same reason: the bar keeps its last count, which stays true
+# throughout, and the phase goes to the status label instead.
+PHASE_LABELS = {
+    "moving": "Moving stage…",
+    "stitching": "Stitching tiles…",
+    "saving": "Saving overview…",
+}
+
+
 class FMOverviewWidget(QWidget):
     """Configure, run and view a fluorescence overview acquisition."""
 
@@ -2225,6 +2235,16 @@ class FMOverviewWidget(QWidget):
             )
             return None
 
+    def _emit_state(self, state: str) -> None:
+        """Announce a phase of this run that carries no counts.
+
+        The tile bar keeps whatever it last showed -- N/N is still true while the mosaic
+        is being written -- and the state goes to the status label, which is how
+        `moving` has always been handled. Rendering these as indeterminate would paint a
+        *full* bar, which is exactly the "it finished" impression they exist to correct.
+        """
+        self.fm.acquisition_progress_signal.emit({"state": state, "task": "tileset"})
+
     def _acquire_worker(self) -> None:
         """Runs off the GUI thread. Only signals may cross back."""
         from fibsem.cancellation import OperationCancelledError
@@ -2236,6 +2256,11 @@ class FMOverviewWidget(QWidget):
             # Saved here rather than after the signal: a consumer of `overview_acquired`
             # may want the file, and the mosaic carries the run's name once written.
             if self._destination is not None:
+                # The larger half of the gap between the last tile and a finished run:
+                # the stitch is a memcpy into a preallocated canvas (~0.3 s for 1.3 GB)
+                # and the write is most of the rest (~2.3 s for the same). Silent until
+                # now, so a big run appeared to hang just as it completed.
+                self._emit_state("saving")
                 self._saved_path = self._destination.save_mosaic(mosaic)
             self.overview_acquired.emit(mosaic)
             self.fm.acquisition_progress_signal.emit(
@@ -2328,12 +2353,14 @@ class FMOverviewWidget(QWidget):
             self.progress_tile_detail.update_progress(self._tile_detail_update(payload))
 
     def _apply_tile_progress(self, payload: dict, state: Optional[str]) -> None:
-        if state == "moving":
+        label = PHASE_LABELS.get(state or "")
+        if label is not None:
             # Deliberately not `indeterminate`: that paints a *full* bar with a
             # spinner, so every stage move looked like the run had just completed.
-            # The bar keeps the last tile count -- which is still true between tiles --
-            # and the transient state goes to the status label instead.
-            self.status.setText("Moving stage…")
+            # The bar keeps the last tile count -- which is still true between tiles,
+            # and while the mosaic is being stitched and written -- and the transient
+            # state goes to the status label instead.
+            self.status.setText(label)
             return
 
         self.status.setText("")

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -2240,3 +2240,64 @@ def test_the_retracted_objective_is_caught_before_anything_moves(
         "the objective was driven somewhere before the run was refused"
     )
     assert fm_microscope.fm.objective.state == "Retracted", "the run inserted it"
+
+
+def test_the_stitch_is_announced_between_the_last_tile_and_the_mosaic(fm_microscope):
+    """Between the last tile and the finished mosaic there is real work, and it used to
+    be reported as nothing at all.
+
+    The tile bar stopped at N/N and the run looked complete while the app built and
+    wrote a multi-gigabyte array — measured at ~2.1 s per GB of mosaic on a local SSD,
+    about 7 s for a 5x5 at ARCTIS resolution in four channels, and worse to a network
+    drive. The beam tiler has always said "Stitching Tiles" here (FIB-725).
+    """
+    emitted = []
+    fm_microscope.fm.acquisition_progress_signal.connect(emitted.append)
+
+    acquisition.FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=[ChannelSettings(name="CH0", exposure_time=0.001)],
+        overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
+    ).run_and_stitch()
+
+    states = [p.get("state") for p in emitted if p.get("task") == "tileset"]
+    assert "stitching" in states, "the stitch is still silent"
+
+    # After every tile, not before one: announced too early it would sit on screen for
+    # the whole acquisition, which is the opposite failure.
+    last_tile = max(i for i, s in enumerate(states) if s == "acquiring")
+    assert states.index("stitching") > last_tile
+
+
+def test_the_stitch_announcement_carries_no_counts(fm_microscope):
+    """So a consumer keeps whatever the bar last showed. N/N is still true while the
+    mosaic is being built, and rendering this as indeterminate would paint a *full* bar
+    — exactly the "it finished" impression the phase exists to correct."""
+    emitted = []
+    fm_microscope.fm.acquisition_progress_signal.connect(emitted.append)
+
+    acquisition.FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=[ChannelSettings(name="CH0", exposure_time=0.001)],
+        overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
+    ).run_and_stitch()
+
+    stitching = [p for p in emitted if p.get("state") == "stitching"]
+    assert len(stitching) == 1
+    assert "current" not in stitching[0]
+    assert "total" not in stitching[0]
+
+
+def test_a_run_that_never_reaches_the_stitch_does_not_announce_one(fm_microscope):
+    """`run()` on its own acquires without stitching — a caller wanting the tiles. It
+    must not claim a mosaic is being built that nobody asked for."""
+    emitted = []
+    fm_microscope.fm.acquisition_progress_signal.connect(emitted.append)
+
+    acquisition.FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=[ChannelSettings(name="CH0", exposure_time=0.001)],
+        overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
+    ).run()
+
+    assert "stitching" not in [p.get("state") for p in emitted]

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -403,6 +403,47 @@ def test_a_stage_move_does_not_fill_the_bar(qapp):
     assert router.status.text() == "Moving stage…"
 
 
+@pytest.mark.parametrize(
+    "state, label",
+    [
+        ("stitching", "Stitching tiles…"),
+        ("saving", "Saving overview…"),
+    ],
+)
+def test_the_end_of_a_run_is_not_silent(qapp, state, label):
+    """Between the last tile and a finished run the app builds and writes a mosaic —
+    ~2.1 s per GB, about 7 s for a 5x5 at ARCTIS resolution in four channels. That was
+    reported as nothing at all, so a long run appeared to hang just as it completed.
+
+    Handled exactly as `moving` is, and for the same reason: the count stays put, since
+    N/N is still true while the mosaic is written, and the phase goes to the label. The
+    bar must not be filled — `indeterminate` paints a *full* bar, which is the very
+    impression these phases exist to correct.
+    """
+    router = _Router()
+    router._apply_progress({
+        "state": "acquiring", "task": "tileset", "current": 9, "total": 9,
+    })
+
+    router._apply_progress({"state": state, "task": "tileset"})
+
+    assert router.status.text() == label
+    assert (_bar(router.progress_tiles).value(),
+            _bar(router.progress_tiles).maximum()) == (9, 9)
+
+
+def test_a_phase_label_is_cleared_by_the_next_tile(qapp):
+    """Otherwise "Stitching tiles…" would still be on screen through the next run."""
+    router = _Router()
+    router._apply_progress({"state": "saving", "task": "tileset"})
+    assert router.status.text() == "Saving overview…"
+
+    router._apply_progress({
+        "state": "acquiring", "task": "tileset", "current": 1, "total": 9,
+    })
+    assert router.status.text() == ""
+
+
 # ── layout stability ─────────────────────────────────────────────────────
 
 
@@ -4803,3 +4844,41 @@ class TestSayingWhenARunStarts:
         finally:
             widget._set_running(False)
         assert answers == [True, False]
+
+
+def test_the_worker_announces_the_save_before_it_writes(qapp, overview_widget, tmp_path):
+    """The larger half of the end-of-run gap, and the half the *widget* owns.
+
+    Measured: the stitch is ~0.3 s for a 1.3 GB mosaic and the write is ~2.3 s of the
+    same 2.6 s. So announcing only the stitch — which the runner does — would still
+    leave most of the silence in place (FIB-725).
+
+    Driven through the real `_acquire_worker` rather than by emitting the payload from
+    the test: the whole risk here is that the widget does not send it, which a test that
+    sends it itself cannot see.
+    """
+    from fibsem.fm.acquisition import OverviewDestination
+
+    widget = overview_widget
+    mosaic = _acquire(widget)
+
+    class _StubRunner:
+        def run_and_stitch(self):
+            return mosaic
+
+    seen = []
+    widget.fm.acquisition_progress_signal.connect(seen.append)
+    runner, destination, saved = widget._runner, widget._destination, widget._saved_path
+    try:
+        widget._runner = _StubRunner()
+        widget._destination = OverviewDestination.create(str(tmp_path))
+        widget._acquire_worker()
+    finally:
+        widget.fm.acquisition_progress_signal.disconnect(seen.append)
+        widget._runner, widget._destination, widget._saved_path = runner, destination, saved
+
+    states = [p.get("state") for p in seen if p.get("task") == "tileset"]
+    assert "saving" in states, "the write is still silent"
+    assert states.index("saving") < states.index("overview-finished"), (
+        "the save was announced after it had already happened"
+    )


### PR DESCRIPTION
Between the last tile and a finished run, a fluorescence overview builds a mosaic and writes it to disk — and reported **nothing** while it did. The tile bar stopped at N/N and the run looked complete while the app was still working.

## Measured, not estimated

Timed on a mosaic built from real acquisition metadata at ARCTIS tile size:

| | |
| -- | -- |
| stitch | 0.30 s — a memcpy into a preallocated canvas |
| save | **2.33 s** — the dominant half |
| total, 1.28 GB mosaic | 2.62 s → **~2.1 s per GB** |
| extrapolated: 5×5 @ 4512², 4 channels (3.4 GB mosaic) | **~7 s** |

Local SSD. To a network drive — where a lot of this data lands — worse.

## Two phases, because two objects do the work

The beam tiler has always said `"Stitching Tiles"` here. The asymmetry with it is *not* who emits: it is that the beam's stitch and save both live inside the runner, while the fluorescence stitch is in `FMTiledAcquisitionRunner.run_and_stitch` and the save is in `FMOverviewWidget._acquire_worker`.

So each announces its own phase. Announcing only the stitch would have left the larger half of the silence in place.

## How it renders

Exactly as `moving` already does: **the tile count stays put** — N/N is still true while the mosaic is written — and the phase goes to the status label.

Deliberately **not** `indeterminate`, which paints a *full* bar. That is precisely the "it finished" impression these phases exist to correct.

The three labels are one dict at module scope rather than a class attribute, so a test stub borrowing the handler does not have to carry it — four existing tests broke on exactly that before the move.

## Verification

- **5472 tests pass.**
- Removing both announcements fails three tests — and deliberately *not* the two rendering tests, which are handed the payload rather than waiting for one. Emission and rendering are tested separately because they fail separately.
- The save is driven through the **real** `_acquire_worker` with a stub runner, not by emitting the payload from the test. The whole risk is that the widget does not send it, which a test that sends it itself cannot see — an earlier version of my check did exactly that and would have passed against code that emitted nothing.