### PR TITLE
[feature] Join the sparse selection panes into a dialog

### DIFF
--- a/fibsem/ui/fm/overview_app.py
+++ b/fibsem/ui/fm/overview_app.py
@@ -43,6 +43,13 @@ def build_microscope(
         microscope.stage_is_compustage = compustage
         microscope.system.stage.shuttle_pre_tilt = 0
         microscope._update_orientations()
+        # Re-read the travel limits, which `FibsemStage.__init__` cached before the flag
+        # above was set. They are not a detail: a compustage travels +/-999.9 um in x and
+        # only +/-377.8 um in y, against a grid boundary of 1000 um radius -- so in y the
+        # stage runs out of travel well inside the grid, and it is the limits rather than
+        # the boundary that say how far an overview can reach. Left stale, the simulator
+        # reports +/-100 mm and anything drawing them shows nothing at grid scale.
+        microscope._stage.limits = microscope._get_axis_limits()
         microscope.move_stage_absolute(
             FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(tilt_deg))
         )

--- a/fibsem/ui/fm/sparse_selection_app.py
+++ b/fibsem/ui/fm/sparse_selection_app.py
@@ -1,17 +1,15 @@
 """Standalone app for the sparse FM selection panes.
 
-Opens the two halves side by side against a real or simulated microscope, so they can be
-driven before the dialog that will hold them exists.
+Opens the selection dialog against a real or simulated microscope, acquires the beam
+overviews it needs, and prints what comes back -- so the whole path can be driven before
+anything in AutoLamella constructs it.
 
     python -m fibsem.ui.fm.sparse_selection_app                    # Demo, two beam views
     python -m fibsem.ui.fm.sparse_selection_app --manufacturer Thermo --ip 10.0.0.1
 
 Right-click the left pane to add a region, then drag it or its corners. The right pane
-shows the FM tiles that selection would acquire, recomputed on every change.
-
-The wiring here is a stand-in for the dialog, not its design: it does the minimum to
-make the two panes talk, so the pieces can be exercised on hardware while the dialog is
-still being built.
+shows the FM tiles that selection would acquire, recomputed on every change. Accepting
+prints the grid, the mask and the centre the acquisition would be given.
 """
 
 import argparse
@@ -62,80 +60,24 @@ def acquire_beam_overviews(
     return views
 
 
-def build_window(microscope: FibsemMicroscope):
-    from PyQt5.QtWidgets import (
-        QHBoxLayout,
-        QLabel,
-        QVBoxLayout,
-        QWidget,
-    )
+def run_dialog(microscope: FibsemMicroscope, hfw: float = OVERVIEW_HFW):
+    """Acquire the beam overviews, run the dialog, and return what it produced."""
+    from fibsem.fm.structures import OverviewParameters
+    from fibsem.ui.fm.widgets.fm_sparse_selection_dialog import FMSparseSelectionDialog
 
-    from fibsem.ui.fm.widgets.fm_region_selector import FMRegionSelectorWidget
-    from fibsem.ui.fm.widgets.fm_tile_preview import FMTilePreviewWidget
-    from fibsem.ui.stylesheets import CANVAS_BG
-    from fibsem.ui.tokens import TEXT_COLOR, TEXT_MUTED_COLOR
-
-    views = acquire_beam_overviews(microscope)
+    views = acquire_beam_overviews(microscope, hfw)
     # Back to the fluorescence pose, as the FM tab would leave it. The preview must be
     # right from either, which is what pinning its frame to the FM orientation is for --
-    # try commenting this out, and nothing about the right pane should change.
+    # comment this out and nothing about the right-hand pane should change.
     microscope.move_to_microscope("FM")
 
-    selector = FMRegionSelectorWidget(microscope)
-    preview = FMTilePreviewWidget(microscope)
-    selector.set_views(views)
-
-    status = QLabel()
-    status.setStyleSheet(f"color:{TEXT_COLOR};font-size:11px;padding:4px 8px;")
-    hint = QLabel(
-        "right-click the beam overview to add a region  ·  drag it or its corners  ·  "
-        "click a tile on the right to add or drop it"
+    channels = getattr(microscope.fm, "channel_settings", None)
+    return FMSparseSelectionDialog.choose(
+        microscope,
+        views,
+        OverviewParameters(overlap=OVERLAP),
+        channel_settings=list(channels) if channels else None,
     )
-    hint.setStyleSheet(f"color:{TEXT_MUTED_COLOR};font-size:10px;padding:0 8px 4px;")
-
-    def recompute():
-        regions = selector.regions
-        if not regions or selector.base is None or selector.projection is None:
-            preview.clear()
-        else:
-            preview.set_selection(
-                regions, selector.base, selector.projection, OVERLAP
-            )
-        describe()
-
-    def describe():
-        plan = preview.plan
-        if plan is None:
-            status.setText(f"{selector.describe_selected()}   —   no tiles selected")
-            return
-        minutes = preview.enabled_tiles * 3 * 4 // 60
-        status.setText(
-            f"{selector.describe_selected()}   —   "
-            f"{plan.rows} x {plan.cols} grid, "
-            f"{preview.enabled_tiles} of {preview.total_tiles} tiles, "
-            f"~{minutes} min"
-        )
-
-    selector.regions_changed.connect(recompute)
-    selector.selection_changed.connect(lambda _index: describe())
-    preview.selection_changed.connect(describe)
-
-    panes = QHBoxLayout()
-    panes.setSpacing(8)
-    panes.addWidget(selector, 3)
-    panes.addWidget(preview, 2)
-
-    window = QWidget()
-    window.setWindowTitle("Sparse FM selection — panes")
-    window.setStyleSheet(f"QWidget {{ background: {CANVAS_BG}; }}")
-    layout = QVBoxLayout(window)
-    layout.setContentsMargins(8, 8, 8, 8)
-    layout.addLayout(panes)
-    layout.addWidget(status)
-    layout.addWidget(hint)
-    window.resize(1180, 680)
-    describe()
-    return window
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -156,9 +98,20 @@ def main(argv: Optional[List[str]] = None) -> int:
     microscope = build_microscope(
         manufacturer=args.manufacturer, ip_address=args.ip
     )
-    window = build_window(microscope)
-    window.show()
-    return app.exec_()
+    selection = run_dialog(microscope, args.hfw)
+    if selection is None:
+        logging.info("cancelled -- nothing selected")
+        return 0
+
+    parameters = selection.parameters
+    enabled = sum(sum(1 for on in row if on) for row in parameters.tile_mask)
+    logging.info(
+        f"grid {parameters.rows} x {parameters.cols}, "
+        f"{enabled} of {parameters.rows * parameters.cols} tiles, "
+        f"overlap {parameters.overlap:.0%}"
+    )
+    logging.info(f"centred on {selection.centre_position.pretty}")
+    return 0
 
 
 if __name__ == "__main__":

--- a/fibsem/ui/fm/widgets/fm_sparse_selection_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_sparse_selection_dialog.py
@@ -39,8 +39,17 @@ from fibsem.ui.fm.widgets.fm_region_selector import FMRegionSelectorWidget
 from fibsem.ui.fm.widgets.fm_tile_preview import FMTilePreviewWidget
 from fibsem.ui import stylesheets
 from fibsem.ui.stylesheets import CANVAS_BG
-from fibsem.ui.tokens import BORDER_COLOR, PANEL_COLOR, TEXT_COLOR, TEXT_MUTED_COLOR
+from fibsem.ui.tokens import (
+    BORDER_COLOR,
+    PANEL_COLOR,
+    STAGE_LIMITS_COLOUR,
+    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
+)
 from fibsem.ui.widgets.preflight import format_duration
+
+# Amber, matching the stage-limits box the preview draws it against.
+_WARNING = STAGE_LIMITS_COLOUR
 
 _HINT = (
     "right-click the overview to add a region  ·  drag it or its corners  ·  "
@@ -213,7 +222,8 @@ class FMSparseSelectionDialog(QDialog):
         other is how a button comes to offer a different number from the line above it.
         """
         enabled, total, duration = self._counts()
-        self.accept_button.setEnabled(enabled > 0)
+        unreachable = len(self.preview.unreachable_tiles)
+        self.accept_button.setEnabled(enabled > 0 and not unreachable)
         self.accept_button.setText(
             f"Use {enabled} tiles" if enabled else "Use these tiles"
         )
@@ -221,8 +231,18 @@ class FMSparseSelectionDialog(QDialog):
         parts = [self.selector.describe_selected()]
         if total:
             parts.append(f"{enabled} of {total} tiles")
-        if duration is not None:
+        if duration is not None and not unreachable:
             parts.append(format_duration(duration))
+        if unreachable:
+            # Said here rather than left to `raise_if_outside_stage_limits`, which
+            # refuses once the run starts. Blocking rather than warning, because the
+            # runner will refuse anyway and finding out afterwards costs the whole setup.
+            # Masking off the offending tiles is a legitimate fix, so the way out is on
+            # screen already.
+            parts.append(
+                f"<span style='color:{_WARNING}'>{unreachable} beyond the stage's "
+                "travel — move or shrink the region, or drop those tiles</span>"
+            )
         self._status.setText("   ·   ".join(parts))
 
     def _counts(self) -> Tuple[int, int, Optional[float]]:

--- a/fibsem/ui/fm/widgets/fm_sparse_selection_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_sparse_selection_dialog.py
@@ -1,0 +1,256 @@
+"""Choose the ground a fluorescence overview should cover, on a beam overview.
+
+The two panes joined: regions are drawn on an acquired FIB/SEM overview on the left, and
+the fluorescence tiles they select appear on the right, recomputed on every change.
+Accepting hands back overview parameters with the grid and mask filled in, plus the stage
+position the run should be centred on.
+
+**No host.** It takes what it needs and returns a result; it does not reach into the tab
+that opened it, and it cannot drive the stage. That is what lets it be constructed in a
+test, and it follows `FMOverviewConfirmationDialog`, which computes its own estimate from
+values handed to it for the same reason.
+
+**The regions end here.** They exist to draw with, and to say which tile came from a
+region rather than from a click -- both only while the selection is being made. Storing
+them beside the mask would be a second representation of the same thing, able to disagree
+with it. Selecting again starts over.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from PyQt5.QtWidgets import (
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.fm.structures import ChannelSettings, OverviewParameters, ZParameters
+from fibsem.fm.timing import estimate_tileset_acquisition_time
+from fibsem.microscope import FibsemMicroscope
+from fibsem.structures import FibsemImage, FibsemStagePosition
+from fibsem.ui.fm.widgets.fm_region_selector import FMRegionSelectorWidget
+from fibsem.ui.fm.widgets.fm_tile_preview import FMTilePreviewWidget
+from fibsem.ui import stylesheets
+from fibsem.ui.stylesheets import CANVAS_BG
+from fibsem.ui.tokens import BORDER_COLOR, PANEL_COLOR, TEXT_COLOR, TEXT_MUTED_COLOR
+from fibsem.ui.widgets.preflight import format_duration
+
+_HINT = (
+    "right-click the overview to add a region  ·  drag it or its corners  ·  "
+    "click a tile on the right to add or drop it"
+)
+
+
+@dataclass(frozen=True)
+class SparseSelection:
+    """What a completed selection hands back.
+
+    Attributes:
+        parameters: The parameters given, with rows, columns and the tile mask replaced
+            by what the selection derived. Everything else -- overlap, autofocus, tile
+            order -- is carried through untouched, because none of it is geometry.
+        centre_position: Where the grid is centred, at the fluorescence orientation.
+            `FMTiledAcquisitionRunner` takes this directly.
+    """
+
+    parameters: OverviewParameters
+    centre_position: FibsemStagePosition
+
+
+class FMSparseSelectionDialog(QDialog):
+    """Draw regions on a beam overview; get an FM grid back."""
+
+    def __init__(
+        self,
+        microscope: FibsemMicroscope,
+        views: Dict[object, Sequence[FibsemImage]],
+        parameters: OverviewParameters,
+        channel_settings: Optional[List[ChannelSettings]] = None,
+        zparams: Optional[ZParameters] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        """
+        Args:
+            microscope: for the fluorescence geometry the tiles are planned against.
+            views: the beam overviews to choose from, keyed by `OverviewView`.
+            parameters: the overview settings as they stand. Only `overlap` affects the
+                grid; the rest is carried through so the caller gets one object back.
+            channel_settings: for the time estimate. Without them the counter reports
+                tiles and no duration, rather than a duration it cannot stand behind.
+            zparams: likewise, when the run is a z-stack.
+        """
+        super().__init__(parent)
+        self.setWindowTitle("Select the ground to image")
+        self.setStyleSheet(f"QDialog {{ background: {CANVAS_BG}; }}")
+
+        self._parameters = parameters
+        self._channel_settings = channel_settings
+        self._zparams = zparams if parameters.use_zstack else None
+        self._selection: Optional[SparseSelection] = None
+
+        self.selector = FMRegionSelectorWidget(microscope)
+        self.preview = FMTilePreviewWidget(microscope)
+        self.selector.set_views(views)
+
+        self._status = QLabel()
+        self._status.setStyleSheet(
+            f"color:{TEXT_COLOR};font-size:11px;border:none;background:transparent;"
+        )
+        hint = QLabel(_HINT)
+        hint.setStyleSheet(
+            f"color:{TEXT_MUTED_COLOR};font-size:10px;border:none;background:transparent;"
+        )
+
+        bar = QFrame()
+        bar.setStyleSheet(
+            f"QFrame{{background:{PANEL_COLOR};border:1px solid {BORDER_COLOR};"
+            "border-radius:4px;}"
+        )
+        bar_layout = QHBoxLayout(bar)
+        bar_layout.setContentsMargins(10, 7, 10, 7)
+        bar_layout.addWidget(hint)
+        bar_layout.addStretch(1)
+        bar_layout.addWidget(self._status)
+
+        # Hand-built rather than a `QDialogButtonBox`: that renders native buttons,
+        # which read as light chrome against this app's dark canvases, and puts them in
+        # the platform's order rather than the one the rest of the app uses.
+        self.accept_button = QPushButton()
+        self.accept_button.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.accept_button.clicked.connect(self._accept)
+        cancel = QPushButton("Cancel")
+        cancel.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        cancel.clicked.connect(self.reject)
+
+        buttons = QHBoxLayout()
+        buttons.addStretch(1)
+        buttons.addWidget(cancel)
+        buttons.addWidget(self.accept_button)
+
+        panes = QHBoxLayout()
+        panes.setSpacing(8)
+        panes.addWidget(self.selector, 3)
+        panes.addWidget(self.preview, 2)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(8)
+        layout.addLayout(panes)
+        layout.addWidget(bar)
+        layout.addLayout(buttons)
+        self.resize(1180, 700)
+
+        self.selector.regions_changed.connect(self._recompute)
+        self.selector.selection_changed.connect(lambda _index: self._describe())
+        self.preview.selection_changed.connect(self._describe)
+        self._describe()
+
+    # ── the result ───────────────────────────────────────────────────────
+
+    @property
+    def selection(self) -> Optional[SparseSelection]:
+        """What was accepted, or None if the dialog was cancelled."""
+        return self._selection
+
+    @classmethod
+    def choose(
+        cls,
+        microscope: FibsemMicroscope,
+        views: Dict[object, Sequence[FibsemImage]],
+        parameters: OverviewParameters,
+        channel_settings: Optional[List[ChannelSettings]] = None,
+        zparams: Optional[ZParameters] = None,
+        parent: Optional[QWidget] = None,
+    ) -> Optional[SparseSelection]:
+        """Run the dialog and return the selection, or None if it was cancelled."""
+        dialog = cls(
+            microscope, views, parameters, channel_settings, zparams, parent
+        )
+        dialog.exec_()
+        return dialog.selection
+
+    def _accept(self) -> None:
+        plan = self.preview.plan
+        if plan is None:
+            return
+        self._selection = SparseSelection(
+            parameters=replace(
+                self._parameters,
+                rows=plan.rows,
+                cols=plan.cols,
+                tile_mask=self.preview.mask,
+            ),
+            centre_position=plan.centre_position,
+        )
+        self.accept()
+
+    # ── keeping the two panes in step ────────────────────────────────────
+
+    def _recompute(self) -> None:
+        regions = self.selector.regions
+        if not regions or self.selector.base is None or self.selector.projection is None:
+            self.preview.clear()
+        else:
+            self.preview.set_selection(
+                regions,
+                self.selector.base,
+                self.selector.projection,
+                self._parameters.overlap,
+            )
+        self._describe()
+
+    def _describe(self) -> None:
+        """The counter and the button, from one set of numbers.
+
+        Both together, deliberately: a count computed in one place and restated in the
+        other is how a button comes to offer a different number from the line above it.
+        """
+        enabled, total, duration = self._counts()
+        self.accept_button.setEnabled(enabled > 0)
+        self.accept_button.setText(
+            f"Use {enabled} tiles" if enabled else "Use these tiles"
+        )
+
+        parts = [self.selector.describe_selected()]
+        if total:
+            parts.append(f"{enabled} of {total} tiles")
+        if duration is not None:
+            parts.append(format_duration(duration))
+        self._status.setText("   ·   ".join(parts))
+
+    def _counts(self) -> Tuple[int, int, Optional[float]]:
+        """Enabled tiles, total tiles, and how long the run would take.
+
+        The duration is None without channel settings rather than guessed at: the time
+        depends on exposure and channel count, and a number invented here would be quoted
+        back as if it meant something.
+        """
+        plan = self.preview.plan
+        enabled, total = self.preview.enabled_tiles, self.preview.total_tiles
+        if plan is None or not enabled or not self._channel_settings:
+            return enabled, total, None
+        try:
+            estimate = estimate_tileset_acquisition_time(
+                self._channel_settings,
+                (plan.rows, plan.cols),
+                self._zparams,
+                self._parameters.autofocus_mode,
+                tile_mask=self.preview.mask,
+            )
+        except Exception:
+            return enabled, total, None
+        return enabled, total, estimate.get("total_time")
+
+    # ── convenience for a host ───────────────────────────────────────────
+
+    @property
+    def mask(self) -> List[List[bool]]:
+        """The mask as it stands, for a caller watching rather than waiting."""
+        return self.preview.mask

--- a/fibsem/ui/fm/widgets/fm_sparse_selection_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_sparse_selection_dialog.py
@@ -46,6 +46,7 @@ from fibsem.ui.tokens import (
     TEXT_COLOR,
     TEXT_MUTED_COLOR,
 )
+from fibsem.ui.widgets.custom_widgets import ElidedLabel
 from fibsem.ui.widgets.preflight import format_duration
 
 # Amber, matching the stage-limits box the preview draws it against.
@@ -108,10 +109,25 @@ class FMSparseSelectionDialog(QDialog):
         self.preview = FMTilePreviewWidget(microscope)
         self.selector.set_views(views)
 
+        # The warning gets a row of its own and an `ElidedLabel`; the counter gets
+        # neither. A message whose length depends on what the user drew must not decide
+        # how wide the dialog is -- the warning ran past 90 characters and took the whole
+        # bar with it, the same fault FIB-470 fixed on the FM overview widget, where one
+        # long status dragged the minimum width from 1030 px to 1728.
+        #
+        # Not both, though: `ElidedLabel` has an Ignored size policy, so it asks for no
+        # width at all. Applied to the counter as well, the stretch beside it took
+        # everything and the counter rendered as nothing. It is bounded anyway -- a
+        # region index and two dimensions.
         self._status = QLabel()
         self._status.setStyleSheet(
             f"color:{TEXT_COLOR};font-size:11px;border:none;background:transparent;"
         )
+        self._warning = ElidedLabel()
+        self._warning.setStyleSheet(
+            f"color:{_WARNING};font-size:11px;border:none;background:transparent;"
+        )
+        self._warning.hide()
         hint = QLabel(_HINT)
         hint.setStyleSheet(
             f"color:{TEXT_MUTED_COLOR};font-size:10px;border:none;background:transparent;"
@@ -122,11 +138,15 @@ class FMSparseSelectionDialog(QDialog):
             f"QFrame{{background:{PANEL_COLOR};border:1px solid {BORDER_COLOR};"
             "border-radius:4px;}"
         )
-        bar_layout = QHBoxLayout(bar)
+        bar_layout = QVBoxLayout(bar)
         bar_layout.setContentsMargins(10, 7, 10, 7)
-        bar_layout.addWidget(hint)
-        bar_layout.addStretch(1)
-        bar_layout.addWidget(self._status)
+        bar_layout.setSpacing(3)
+        top_row = QHBoxLayout()
+        top_row.addWidget(hint)
+        top_row.addStretch(1)
+        top_row.addWidget(self._status)
+        bar_layout.addLayout(top_row)
+        bar_layout.addWidget(self._warning)
 
         # Hand-built rather than a `QDialogButtonBox`: that renders native buttons,
         # which read as light chrome against this app's dark canvases, and puts them in
@@ -233,17 +253,18 @@ class FMSparseSelectionDialog(QDialog):
             parts.append(f"{enabled} of {total} tiles")
         if duration is not None and not unreachable:
             parts.append(format_duration(duration))
-        if unreachable:
-            # Said here rather than left to `raise_if_outside_stage_limits`, which
-            # refuses once the run starts. Blocking rather than warning, because the
-            # runner will refuse anyway and finding out afterwards costs the whole setup.
-            # Masking off the offending tiles is a legitimate fix, so the way out is on
-            # screen already.
-            parts.append(
-                f"<span style='color:{_WARNING}'>{unreachable} beyond the stage's "
-                "travel — move or shrink the region, or drop those tiles</span>"
-            )
         self._status.setText("   ·   ".join(parts))
+
+        # Said here rather than left to `raise_if_outside_stage_limits`, which refuses
+        # once the run starts. Blocking rather than warning, because the runner will
+        # refuse anyway and finding out afterwards costs the whole setup. Masking off the
+        # offending tiles is a legitimate fix, so the way out is on screen already.
+        self._warning.setVisible(bool(unreachable))
+        if unreachable:
+            self._warning.setText(
+                f"{unreachable} tile{'s' if unreachable != 1 else ''} beyond the "
+                "stage's travel — move or shrink the region, or drop those tiles"
+            )
 
     def _counts(self) -> Tuple[int, int, Optional[float]]:
         """Enabled tiles, total tiles, and how long the run would take.

--- a/fibsem/ui/fm/widgets/fm_tile_preview.py
+++ b/fibsem/ui/fm/widgets/fm_tile_preview.py
@@ -22,10 +22,15 @@ from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
 from fibsem.fm.planning import SparseOverviewPlan, plan_sparse_fm_overview, to_fm_pose
-from fibsem.imaging.tiling.geometry import PlaneRegion, compute_tile_grid_from_fov
+from fibsem.imaging.tiling.geometry import (
+    PlaneRegion,
+    compute_tile_grid_from_fov,
+    order_tiles,
+    validate_tile_stage_positions,
+)
 from fibsem.microscope import FibsemMicroscope
 from fibsem.projection import FMStageProjection, StageProjection
-from fibsem.structures import FibsemStagePosition
+from fibsem.structures import FibsemStagePosition, TileOrderStrategy
 from fibsem.ui.tokens import GRID_BOUNDARY_COLOUR, STAGE_LIMITS_COLOUR
 from fibsem.ui.widgets.canvas.fm_canvas import FMRealSpaceCanvasWidget
 from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
@@ -104,6 +109,7 @@ class FMTilePreviewWidget(QWidget):
         self._plan: Optional[SparseOverviewPlan] = None
         self._mask: List[List[bool]] = []
         self._overlap = 0.0
+        self._unreachable: List[Tuple[int, int]] = []
 
         self.canvas = FMRealSpaceCanvasWidget()
         layout = QVBoxLayout(self)
@@ -192,6 +198,7 @@ class FMTilePreviewWidget(QWidget):
             return
         self._plan = None
         self._mask = []
+        self._unreachable = []
         self.tile_grid_overlay.clear()
         self.selection_changed.emit()
 
@@ -210,6 +217,11 @@ class FMTilePreviewWidget(QWidget):
     @property
     def enabled_tiles(self) -> int:
         return sum(sum(1 for on in row if on) for row in self._mask)
+
+    @property
+    def unreachable_tiles(self) -> List[Tuple[int, int]]:
+        """Enabled tiles the stage cannot travel to, as (row, col)."""
+        return list(self._unreachable)
 
     @property
     def total_tiles(self) -> int:
@@ -240,6 +252,61 @@ class FMTilePreviewWidget(QWidget):
         # No `display_pixel_size`: the overlay reads it from the canvas at draw time.
         self.tile_grid_overlay.set_grid(
             tiles, (height, width), self._pixel_size, overlap=self._overlap
+        )
+        self._unreachable = self._out_of_reach(tiles)
+
+    def _out_of_reach(self, tiles) -> List[Tuple[int, int]]:
+        """Which of the tiles about to be acquired the stage cannot travel to.
+
+        Through the same two helpers the runner uses -- `order_tiles` to drop the
+        disabled ones, `validate_tile_stage_positions` to test what is left -- so the
+        dialog and the run cannot disagree about which grids are acquirable. Masking off
+        an unreachable corner is a legitimate way to fix one, and that only works if both
+        sides ask the question of the same tiles.
+
+        Worth asking here rather than leaving to `raise_if_outside_stage_limits`, which
+        refuses at acquire time. On a compustage the travel is +/-999.9 um in x and only
+        +/-377.8 um in y, against a grid boundary of 1000 um radius, so a selection can
+        sit well inside the grid and still be unreachable -- and it is a great deal
+        cheaper to hear that while the region is still under the cursor.
+        """
+        step_x, step_y = self._step()
+        offset_x = (self._plan.cols - 1) * step_x / 2
+        offset_y = (self._plan.rows - 1) * step_y / 2
+        # Through the held projection, not `microscope.project_fm_stable_move`. The two
+        # agree to 1.4e-20 m -- the same arithmetic over the same geometry -- but the
+        # microscope's reads `fm.camera_tilt` and the camera transform on every call, at
+        # **216 ms each**. One per tile on a region change is half a minute of frozen UI
+        # for a 150 tile grid, and instrument traffic on a mouse event besides.
+        #
+        # The negated y is the convention crossing over: the layout above measures y
+        # upward, as `project_fm_stable_move` takes it, and a displayed plane measures it
+        # down. Verified against the live call rather than reasoned about.
+        positions = {
+            (tile.row, tile.col): self._projection.from_plane(
+                tile.dx - offset_x,
+                -(tile.dy + offset_y),
+                self._plan.centre_position,
+            )
+            for tile in tiles
+        }
+        limits = getattr(self.microscope._stage, "limits", None)
+        if not limits:
+            return []
+        # Any strategy: `order_tiles` changes the sequence and drops the disabled
+        # ones, and only the second half bears on whether a tile is reachable. Going
+        # through it anyway rather than filtering by hand, so the set asked about here
+        # is the set the runner will visit, by construction.
+        ordered = order_tiles(tiles, TileOrderStrategy.TYPEWRITER)
+        return validate_tile_stage_positions(
+            ordered, [positions[(t.row, t.col)] for t in ordered], limits
+        )
+
+    def _step(self) -> Tuple[float, float]:
+        """Distance between adjacent tile centres, in metres."""
+        return (
+            self._fov[0] * (1.0 - self._overlap),
+            self._fov[1] * (1.0 - self._overlap),
         )
 
     def _draw_stage_context(self) -> None:

--- a/tests/ui/test_fm_sparse_selection_dialog.py
+++ b/tests/ui/test_fm_sparse_selection_dialog.py
@@ -23,6 +23,7 @@ from fibsem.fm.structures import (
 )
 from fibsem.structures import TileOrderStrategy
 from fibsem.ui.fm.widgets.fm_sparse_selection_dialog import FMSparseSelectionDialog
+from fibsem.ui.widgets.preflight import format_duration
 
 
 @pytest.fixture(scope="module")
@@ -201,6 +202,107 @@ def test_a_z_stack_is_only_costed_when_the_run_is_one(microscope, views):
     with_regions(on, 1)
 
     assert off._counts()[2] < on._counts()[2]
+
+
+# ── beyond where the stage can go ────────────────────────────────────────
+
+
+# Enough to put a handful of tiles past the stage's +/-377.8 um of y travel, and no
+# more: every extra one costs a redraw in the test that drops them by hand.
+_TOO_TALL = 1.4e-4
+_WITHIN_REACH = 4e-5
+
+
+def stretch(dialog, half_height_m):
+    """Grow the selected region symmetrically in the beam plane's y."""
+    overlay = dialog.selector._overlays[-1]
+    rect = overlay.get_rect()
+    canvas = dialog.selector.canvas
+    _, half = canvas.metres_to_canvas(0.0, half_height_m)
+    overlay.set_rect(rect["x0"], rect["cy"] - half, rect["width"], 2 * half)
+    overlay.rect_changed.emit(overlay.get_rect())
+
+
+def test_a_selection_the_stage_cannot_reach_cannot_be_accepted(dialog):
+    """`raise_if_outside_stage_limits` would refuse the run anyway. Refusing here costs
+    the user a drag; refusing there costs them the whole setup.
+
+    Reachable in ordinary use: on a compustage the travel is +/-999.9 um in x and only
+    +/-377.8 um in y, against a grid boundary of 1000 um radius -- so a region can sit
+    well inside the grid and still be out of reach.
+    """
+    with_regions(dialog, 1)
+    assert dialog.accept_button.isEnabled() is True
+
+    stretch(dialog, _TOO_TALL)
+
+    assert dialog.preview.unreachable_tiles
+    assert dialog.accept_button.isEnabled() is False
+
+
+def test_it_says_how_many_tiles_are_out_of_reach(dialog):
+    with_regions(dialog, 1)
+
+    stretch(dialog, _TOO_TALL)
+
+    count = len(dialog.preview.unreachable_tiles)
+    assert f"{count} beyond the stage's travel" in dialog._status.text()
+
+
+def test_no_duration_is_quoted_for_a_run_that_cannot_happen(dialog):
+    """Quoting a time for it would suggest it is merely long.
+
+    Against the duration the estimate *would* have given, rather than against a pattern:
+    the warning is prose and matching on letters in it says nothing.
+    """
+    with_regions(dialog, 1)
+
+    stretch(dialog, _TOO_TALL)
+
+    duration = dialog._counts()[2]
+    assert duration is not None, "the estimate still exists; it is the display that hides it"
+    assert format_duration(duration) not in dialog._status.text()
+
+
+def test_shrinking_back_inside_the_limits_makes_it_acceptable_again(dialog):
+    """The way out has to be reversible, or the only escape is Cancel."""
+    with_regions(dialog, 1)
+    stretch(dialog, _TOO_TALL)
+    assert dialog.accept_button.isEnabled() is False
+
+    stretch(dialog, _WITHIN_REACH)
+
+    assert dialog.preview.unreachable_tiles == []
+    assert dialog.accept_button.isEnabled() is True
+
+
+def test_dropping_the_tiles_out_of_reach_is_a_way_out(dialog):
+    """The stated escape, so it has to work: only tiles that will be *visited* are
+    checked, which is what makes masking off an unreachable corner a legitimate fix
+    rather than a way to lie about one. `raise_if_outside_stage_limits` says the same
+    thing on the runner's side.
+    """
+    with_regions(dialog, 1)
+    stretch(dialog, _TOO_TALL)
+    out_of_reach = dialog.preview.unreachable_tiles
+    assert out_of_reach
+
+    for row, col in out_of_reach:
+        dialog.preview._on_tile_toggled(row, col, False)
+
+    assert dialog.preview.unreachable_tiles == []
+    assert dialog.accept_button.isEnabled() is True
+
+
+def test_clearing_the_selection_forgets_what_was_out_of_reach(dialog):
+    """Or the next selection inherits a complaint about tiles that no longer exist."""
+    with_regions(dialog, 1)
+    stretch(dialog, _TOO_TALL)
+    assert dialog.preview.unreachable_tiles
+
+    dialog.selector.clear_regions()
+
+    assert dialog.preview.unreachable_tiles == []
 
 
 # ── what comes back ──────────────────────────────────────────────────────

--- a/tests/ui/test_fm_sparse_selection_dialog.py
+++ b/tests/ui/test_fm_sparse_selection_dialog.py
@@ -13,7 +13,7 @@ import pytest
 
 pytest.importorskip("PyQt5")
 
-from PyQt5.QtWidgets import QApplication, QDialog
+from PyQt5.QtWidgets import QApplication, QDialog, QSizePolicy
 
 from fibsem.fm.structures import (
     AutoFocusMode,
@@ -242,11 +242,41 @@ def test_a_selection_the_stage_cannot_reach_cannot_be_accepted(dialog):
 
 def test_it_says_how_many_tiles_are_out_of_reach(dialog):
     with_regions(dialog, 1)
+    assert dialog._warning.isHidden()
 
     stretch(dialog, _TOO_TALL)
 
     count = len(dialog.preview.unreachable_tiles)
-    assert f"{count} beyond the stage's travel" in dialog._status.text()
+    assert f"{count} tiles beyond the stage's travel" in dialog._warning.text()
+    assert dialog._warning.isHidden() is False
+
+
+def test_the_warning_gets_its_own_row_and_elides(dialog):
+    """A message whose length depends on what the user drew must not decide how wide the
+    dialog is.
+
+    It ran past 90 characters on the counter's row and took the whole bar with it -- the
+    same fault FIB-470 fixed on the FM overview widget, where one long status dragged the
+    minimum width from 1030 px to 1728. Two defences: its own row, and a label whose size
+    policy refuses to ask for the space.
+    """
+    with_regions(dialog, 1)
+    before = dialog.sizeHint().width()
+
+    stretch(dialog, _TOO_TALL)
+
+    assert dialog.sizeHint().width() <= before
+    assert dialog._warning.sizePolicy().horizontalPolicy() == QSizePolicy.Ignored
+
+
+def test_the_warning_goes_away_with_the_problem(dialog):
+    with_regions(dialog, 1)
+    stretch(dialog, _TOO_TALL)
+    assert dialog._warning.isHidden() is False
+
+    stretch(dialog, _WITHIN_REACH)
+
+    assert dialog._warning.isHidden()
 
 
 def test_no_duration_is_quoted_for_a_run_that_cannot_happen(dialog):

--- a/tests/ui/test_fm_sparse_selection_dialog.py
+++ b/tests/ui/test_fm_sparse_selection_dialog.py
@@ -1,0 +1,279 @@
+"""The dialog that joins the two panes.
+
+Most of what it does is arithmetic already tested elsewhere. What is only testable here
+is the joining: that a change on the left reaches the right, that the counter and the
+button quote the same number, and that what comes back out is what the acquisition needs
+and nothing it does not.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication, QDialog
+
+from fibsem.fm.structures import (
+    AutoFocusMode,
+    ChannelSettings,
+    OverviewParameters,
+    ZParameters,
+)
+from fibsem.structures import TileOrderStrategy
+from fibsem.ui.fm.widgets.fm_sparse_selection_dialog import FMSparseSelectionDialog
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture(scope="module")
+def microscope(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    return build_microscope()
+
+
+@pytest.fixture(scope="module")
+def views(microscope):
+    """Beam overviews, acquired once -- they cost a couple of seconds each."""
+    from fibsem.ui.fm.sparse_selection_app import acquire_beam_overviews
+
+    acquired = acquire_beam_overviews(microscope)
+    microscope.move_to_microscope("FM")
+    return acquired
+
+
+CHANNELS = [
+    ChannelSettings(
+        name="DAPI",
+        excitation_wavelength=405,
+        emission_wavelength=450,
+        power=0.5,
+        exposure_time=0.1,
+    )
+]
+
+
+def parameters(**kwargs):
+    base = dict(
+        rows=11, cols=15, overlap=0.1, autofocus_mode=AutoFocusMode.NONE,
+        tile_order=TileOrderStrategy.SERPENTINE,
+    )
+    base.update(kwargs)
+    return OverviewParameters(**base)
+
+
+@pytest.fixture()
+def dialog(microscope, views):
+    return FMSparseSelectionDialog(
+        microscope, views, parameters(), channel_settings=CHANNELS
+    )
+
+
+def with_regions(dialog, count=2):
+    for _ in range(count):
+        dialog.selector.add_region()
+    return dialog
+
+
+# ── nothing selected ─────────────────────────────────────────────────────
+
+
+def test_nothing_can_be_accepted_before_anything_is_selected(dialog):
+    assert dialog.accept_button.isEnabled() is False
+    assert dialog.accept_button.text() == "Use these tiles"
+
+
+def test_accepting_with_nothing_selected_does_nothing(dialog):
+    """The button is disabled, so this is only reachable by a caller. The runner would
+    refuse an all-disabled mask anyway; refusing here keeps the result honest rather
+    than handing back a plan that does not exist."""
+    dialog._accept()
+
+    assert dialog.selection is None
+    assert dialog.result() != QDialog.Accepted
+
+
+# ── the two panes move together ──────────────────────────────────────────
+
+
+def test_drawing_a_region_reaches_the_other_pane(dialog):
+    assert dialog.preview.plan is None
+
+    with_regions(dialog, 1)
+
+    assert dialog.preview.plan is not None
+    assert dialog.preview.enabled_tiles > 0
+
+
+def test_clearing_the_regions_empties_the_other_pane(dialog):
+    with_regions(dialog, 2)
+
+    dialog.selector.clear_regions()
+
+    assert dialog.preview.plan is None
+    assert dialog.accept_button.isEnabled() is False
+
+
+def test_the_grid_is_planned_at_the_overlap_it_was_given(microscope, views):
+    """The one setting that changes the geometry. Everything else is carried through."""
+    sparse = FMSparseSelectionDialog(
+        microscope, views, parameters(overlap=0.0), channel_settings=CHANNELS
+    )
+    dense = FMSparseSelectionDialog(
+        microscope, views, parameters(overlap=0.5), channel_settings=CHANNELS
+    )
+    with_regions(sparse, 1)
+    with_regions(dense, 1)
+
+    assert dense.preview.plan.cols > sparse.preview.plan.cols
+
+
+# ── the button and the counter agree ─────────────────────────────────────
+
+
+def test_the_button_quotes_the_number_the_counter_does(dialog):
+    """One set of numbers for both, deliberately: a count computed in one place and
+    restated in the other is how a button comes to offer a different number from the
+    line above it."""
+    with_regions(dialog, 2)
+
+    enabled = dialog.preview.enabled_tiles
+    assert dialog.accept_button.text() == f"Use {enabled} tiles"
+    assert f"{enabled} of {dialog.preview.total_tiles} tiles" in dialog._status.text()
+
+
+def test_toggling_a_tile_moves_both(dialog):
+    with_regions(dialog, 1)
+    before = dialog.preview.enabled_tiles
+
+    dialog.preview._on_tile_toggled(0, 0, not dialog.preview.mask[0][0])
+
+    assert dialog.preview.enabled_tiles != before
+    assert dialog.accept_button.text() == f"Use {dialog.preview.enabled_tiles} tiles"
+
+
+def test_the_counter_names_the_selected_region(dialog):
+    with_regions(dialog, 2)
+
+    assert "Region 2 of 2" in dialog._status.text()
+
+
+# ── the estimate ─────────────────────────────────────────────────────────
+
+
+def test_the_counter_reports_how_long_the_run_would_take(dialog):
+    with_regions(dialog, 1)
+
+    assert "s" in dialog._status.text().rsplit("·", 1)[-1]
+
+
+def test_without_channel_settings_it_counts_tiles_and_quotes_no_time(
+    microscope, views
+):
+    """Rather than a duration it cannot stand behind: the time depends on exposure and
+    channel count, and a number invented here would be quoted back as if it meant
+    something."""
+    dialog = FMSparseSelectionDialog(microscope, views, parameters())
+    with_regions(dialog, 1)
+
+    enabled, total, duration = dialog._counts()
+
+    assert enabled > 0 and total > 0
+    assert duration is None
+
+
+def test_a_z_stack_is_only_costed_when_the_run_is_one(microscope, views):
+    """`use_zstack` is what decides, not the presence of z parameters -- the settings
+    keep theirs when the switch is off."""
+    zparams = ZParameters(zmin=-5e-6, zmax=5e-6, zstep=1e-6)
+    off = FMSparseSelectionDialog(
+        microscope, views, parameters(use_zstack=False), CHANNELS, zparams
+    )
+    on = FMSparseSelectionDialog(
+        microscope, views, parameters(use_zstack=True), CHANNELS, zparams
+    )
+    with_regions(off, 1)
+    with_regions(on, 1)
+
+    assert off._counts()[2] < on._counts()[2]
+
+
+# ── what comes back ──────────────────────────────────────────────────────
+
+
+def test_accepting_returns_the_grid_the_selection_derived(dialog):
+    with_regions(dialog, 2)
+    plan = dialog.preview.plan
+
+    dialog._accept()
+
+    result = dialog.selection
+    assert (result.parameters.rows, result.parameters.cols) == (plan.rows, plan.cols)
+    assert result.parameters.tile_mask == dialog.preview.mask
+
+
+def test_accepting_keeps_the_tiles_toggled_by_hand(dialog):
+    """The result is the *edited* mask, not the one the regions produced.
+
+    They differ only after a hand toggle, so a test that never makes one cannot tell
+    them apart -- and taking the plan's mask would silently discard every adjustment at
+    the last moment.
+    """
+    with_regions(dialog, 1)
+    plan = dialog.preview.plan
+    dialog.preview._on_tile_toggled(0, 0, not dialog.preview.mask[0][0])
+    assert dialog.preview.mask != plan.mask, "the edit has to have changed something"
+
+    dialog._accept()
+
+    assert dialog.selection.parameters.tile_mask == dialog.preview.mask
+
+
+def test_accepting_carries_everything_that_is_not_geometry(dialog):
+    """Overlap, autofocus and tile order are settings, not shape. The caller gets one
+    object back rather than having to merge two."""
+    with_regions(dialog, 1)
+
+    dialog._accept()
+
+    result = dialog.selection.parameters
+    assert result.overlap == 0.1
+    assert result.autofocus_mode is AutoFocusMode.NONE
+    assert result.tile_order is TileOrderStrategy.SERPENTINE
+
+
+def test_the_centre_that_comes_back_is_posed_for_fluorescence(dialog, microscope):
+    """The runner drives the stage to it. At a beam pose it would go somewhere else."""
+    with_regions(dialog, 1)
+
+    dialog._accept()
+
+    fm = microscope.get_orientation("FM")
+    assert dialog.selection.centre_position.t == pytest.approx(fm.t)
+    assert dialog.selection.centre_position.r == pytest.approx(fm.r)
+
+
+def test_accepting_does_not_mutate_the_parameters_it_was_given(microscope, views):
+    """A caller that cancels, or that keeps its own settings object, must not find rows
+    and columns rewritten underneath it."""
+    given = parameters()
+    dialog = FMSparseSelectionDialog(microscope, views, given, CHANNELS)
+    with_regions(dialog, 1)
+
+    dialog._accept()
+
+    assert (given.rows, given.cols) == (11, 15)
+    assert given.tile_mask is None
+
+
+def test_cancelling_returns_nothing(dialog):
+    with_regions(dialog, 1)
+
+    dialog.reject()
+
+    assert dialog.selection is None

--- a/tests/ui/test_fm_tile_preview.py
+++ b/tests/ui/test_fm_tile_preview.py
@@ -204,6 +204,70 @@ def test_clearing_a_selection_leaves_the_stage_context_drawn(pane, microscope):
     assert pane.stage_overlay._specs
 
 
+# ── how far the stage can reach ──────────────────────────────────────────
+
+
+def test_the_pane_draws_both_the_travel_limits_and_the_grid_boundary(pane):
+    """Both, because on a compustage they answer different questions and neither
+    contains the other.
+
+    Travel is +/-999.9 um in x and only +/-377.8 um in y, against a grid boundary of
+    1000 um radius -- so in y the stage runs out of travel well inside the grid, and a
+    selection can be on the grid and still unreachable. The boundary alone would say it
+    was fine.
+    """
+    labels = {spec.label for spec in pane.stage_overlay._specs}
+
+    assert labels == {"Stage limits", "Grid boundary"}
+
+
+def test_reachability_is_worked_out_without_asking_the_instrument(pane, microscope):
+    """A UI event must not read the microscope, and this one would read it per *tile*.
+
+    `project_fm_stable_move` reads `fm.camera_tilt` and the camera transform on every
+    call -- 216 ms each on the simulator, so one per tile on a region change is half a
+    minute of frozen UI for a 150 tile grid, plus instrument traffic on a mouse event.
+    The held `FMStageProjection` is the same arithmetic over the same geometry and agrees
+    to 1.4e-20 m.
+    """
+    from unittest.mock import patch
+
+    with patch.object(
+        type(microscope),
+        "project_fm_stable_move",
+        side_effect=AssertionError("the preview asked the instrument"),
+    ):
+        plan = select(pane, microscope, *TWO_REGIONS)
+
+    # It got all the way through, which it could not have done by asking.
+    assert plan is not None
+    assert pane.enabled_tiles > 0
+    # And it did the work rather than skipping it: this selection reaches roughly
+    # +/-450 um of ground against +/-377.8 um of travel, so some of it is genuinely out
+    # of reach and an empty answer here would mean the check never ran.
+    assert pane.unreachable_tiles
+
+
+def test_the_limits_drawn_are_the_stage_it_was_given(pane, microscope):
+    """Read from the instrument rather than assumed, so a stage with different travel
+    draws a different box."""
+    limits = microscope._stage.limits
+    [box] = [s for s in pane.stage_overlay._specs if s.kind == "rect"]
+
+    ratio = box.height / box.width
+    expected = (limits["y"].max - limits["y"].min) / (limits["x"].max - limits["x"].min)
+    assert ratio == pytest.approx(expected, rel=1e-6)
+
+
+def test_the_limits_box_is_shorter_than_the_grid_is_wide(pane):
+    """The property that makes drawing it worth anything: a box the size of the boundary
+    would tell the user nothing they could not already see."""
+    [box] = [s for s in pane.stage_overlay._specs if s.kind == "rect"]
+    [circle] = [s for s in pane.stage_overlay._specs if s.kind == "circle"]
+
+    assert box.height < 2 * circle.radius
+
+
 # ── what the host reads ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes FIB-728.

**Stacked on #459 → #457 → #456.** Review those first; this diff is the dialog and the stage-limit work.

Regions drawn on a beam overview on the left, the fluorescence tiles they select on the right, recomputed on every change. Accepting hands back `OverviewParameters` with the grid and mask filled in, plus the stage position the run should be centred on. Nothing in AutoLamella constructs it yet — that is the last piece.

## Driving it

```
python -m fibsem.ui.fm.sparse_selection_app
python -m fibsem.ui.fm.sparse_selection_app --manufacturer Thermo --ip 10.0.0.1
```

The standalone app now runs the real dialog rather than wiring the panes by hand, and prints the grid, tile count and centre that come back.

## What comes out

`SparseSelection` carries the parameters it was *given*, with rows, columns and `tile_mask` replaced and nothing else touched — overlap, autofocus and tile order are settings rather than shape, so the caller gets one object back instead of merging two. `replace` rather than mutation: a caller that cancels, or keeps its own settings object, must not find rows and columns rewritten underneath it.

No host. It takes what it needs and returns a result, reaching into nothing and unable to drive the stage, following `FMOverviewConfirmationDialog`. The counter and the primary button come from one set of numbers, so the button cannot offer a different count from the line above it.

## The travel limits matter more than the grid boundary

They were already drawn and could not be seen: `FibsemStage` caches `limits` in `__init__` and `build_microscope` flips `stage_is_compustage` afterwards, so the simulator reported the non-compustage default of ±100 mm — a box two hundred times wider than the view.

The real numbers are why it matters. A compustage travels ±999.9 µm in x and only **±377.8 µm in y**, against a grid boundary of 1000 µm radius: in y the stage runs out of travel at 38% of the grid. **A selection can sit comfortably inside the boundary and be unreachable**, which makes the boundary alone actively misleading.

So the dialog refuses one, through the same helpers the runner uses, and only checks tiles that will actually be *visited* — masking off an unreachable corner stays a legitimate fix, and the way out is on screen already. No duration is quoted for a run that cannot happen; a time would suggest it was merely long.

Ordering on real hardware is fine, checked rather than assumed: `ThermoMicroscope.connect_to_microscope` sets the flag before `_create_sample_stage()`. Worth knowing separately that a compustage's limits are the `STAGE_LIMITS_COMPUSTAGE` constants rather than anything queried — they carry a "do this properly" note where they are defined.

## The reachability check must never ask the instrument

Written the obvious way it called `microscope.project_fm_stable_move` once per tile, which reads `fm.camera_tilt` and the camera transform every time:

```
200 calls: live 43195.6 ms | pure 6.8 ms  -> 6357x
```

**216 ms per call.** One per tile on a region change is half a minute of frozen UI for a 150 tile grid, plus instrument traffic on a mouse event. It goes through the projection the pane already holds, which is the same arithmetic over the same geometry and agrees to **1.4e-20 m**.

Pinned by a test that patches `project_fm_stable_move` to raise and watches a selection complete anyway — and which asserts the answer is non-empty, so a version that skipped the work could not pass it either. I only found this because a test timed out.

## Testing

Fourteen mutations across the dialog and the preview, all killed. Three needed tests that did not exist:

* taking the *plan's* mask rather than the edited one passed everything, because the two differ only after a hand toggle and nothing toggled one before accepting — it would have silently discarded every manual adjustment at the last moment
* nothing covered dropping unreachable tiles as the way out
* nothing covered `clear()` forgetting them, so a stale complaint would have carried into the next selection

One equivalent mutant left in place, checked rather than assumed: dropping the `not self._channel_settings` guard from `_counts` changes nothing, because the estimator raises on `None` channels and the existing `except` already answers `None`.

Full `tests/ui/` shows no failure that is not already on `main`.
