### PR TITLE
[test] Give the overview tab tests a microscope with a fluorescence side (FIB-734)

### DIFF
--- a/tests/ui/test_fm_live_indicator.py
+++ b/tests/ui/test_fm_live_indicator.py
@@ -28,6 +28,7 @@ pytest.importorskip("PyQt5")
 
 from PyQt5.QtWidgets import QApplication
 
+import fibsem.config as _fibsem_config
 from fibsem import utils
 from fibsem.structures import BeamType
 from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController, QuadViewWidget
@@ -88,6 +89,14 @@ class TestTheFMCanvasCanBeMarkedLive:
         controller.set_fm_live(True)  # must not raise
 
 
+# The simulated compustage, which is the only Demo configuration that has an FM. Shared
+# with tests/ui/test_overview_tab_host.py and test_beam_stage_projection.py so they all
+# agree on what an Arctis is.
+_ARCTIS_CONFIG = os.path.join(
+    os.path.dirname(_fibsem_config.__file__), "config", "sim-arctis-configuration.yaml"
+)
+
+
 class TestTheStreamDrivesIt:
     """The half that was missing. `_update_acquisition_button_states` is the one place
     that already asks `fm.is_streaming` and re-derives the whole panel from it, so the
@@ -99,7 +108,14 @@ class TestTheStreamDrivesIt:
 
         from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget
 
-        microscope, _ = utils.setup_session(manufacturer="Demo")
+        # A simulated Arctis: `DemoMicroscope` only builds a
+        # `SimulatedFluorescenceMicroscope` when `sim.is_compustage` is set, and
+        # `FMControlWidget` refuses a microscope without one -- so on a plain Demo
+        # session every test in this class errored in setup rather than running
+        # (FIB-734).
+        microscope, _ = utils.setup_session(
+            manufacturer="Demo", config_path=_ARCTIS_CONFIG
+        )
 
         class _Host(QWidget):
             """The chain `_view_controller` walks: parent -> parent_widget -> the UI

--- a/tests/ui/test_overview_tab_host.py
+++ b/tests/ui/test_overview_tab_host.py
@@ -43,7 +43,26 @@ _app = QApplication.instance() or QApplication(sys.argv)
 
 @pytest.fixture(scope="module")
 def microscope():
-    scope, _ = utils.setup_session(manufacturer="Demo")
+    """A simulated Arctis, because these tabs are half about fluorescence.
+
+    A plain Demo session is not a compustage, and `DemoMicroscope` only builds a
+    `SimulatedFluorescenceMicroscope` when `sim.is_compustage` is set. Without one,
+    `microscope.fm` is None -- and then `build_lamella_poses` returns no fluorescence
+    pose, which `Lamella.fluorescence_pose`'s setter rejects, and the fluorescence tab
+    builds no widget at all. That took out 19 of the 27 tests here, invisibly: CI
+    installs `.[test]` rather than `.[ui]`, so the whole file skips there (FIB-734).
+
+    `sim-arctis-configuration.yaml` is the same one `test_beam_stage_projection.py`
+    uses for its compustage half, so the two agree on what an Arctis is.
+    """
+    import fibsem.config as fibsem_config
+
+    path = os.path.join(
+        os.path.dirname(fibsem_config.__file__), "config", "sim-arctis-configuration.yaml"
+    )
+    scope, _ = utils.setup_session(manufacturer="Demo", config_path=path)
+    assert scope.stage_is_compustage, "the config stopped being a compustage"
+    assert scope.fm is not None, "no fluorescence microscope to test the FM tab against"
     return scope
 
 


### PR DESCRIPTION
Two test files were building a plain Demo session, which is not a compustage — and `DemoMicroscope` only builds a `SimulatedFluorescenceMicroscope` when `sim.is_compustage` is set. So `microscope.fm` was None, and everything followed from that.

| file | before | after |
| -- | -- | -- |
| `test_overview_tab_host.py` | 9 failed, 8 passed, **10 errors** | **27 passed** |
| `test_fm_live_indicator.py` | 5 passed, **5 errors** | **10 passed** |

Across `tests/ui/` and `tests/autolamella/`: **17 failed + 15 errors → 8 failed, 0 errors.**

## One cause, three symptoms

* `build_lamella_poses` returns no fluorescence pose without an FM, and `Lamella.fluorescence_pose`'s setter rejects `None` — which took out **nine tests that have nothing to do with fluorescence**, because the stub window sets a pose on every lamella it adds.
* The fluorescence tab builds no widget, so the `fm_tab` fixture's own assertion failed in setup (**10 errors**, introduced by #452 and extended by #453 — both added tests through that fixture, which was the right thing to write).
* `FMControlWidget` refuses a microscope with no FM outright (**5 errors**).

## The fix

Both fixtures now load `sim-arctis-configuration.yaml` — the same configuration `test_beam_stage_projection.py` already uses for its compustage half, so the three files agree on what an Arctis is rather than each inventing one.

The fixture asserts it got a compustage and an FM rather than trusting the filename, since a stale assumption about the config is precisely what went unnoticed here.

**No test needed changing.** They were written against a microscope the fixture could not supply.

## Verified, not just green

Twenty-four tests went from not running to passing, so "they pass now" is worth very little on its own. I made the fluorescence tab return the *milling* pose instead of its own — the revived tests catch it (3 failures) and previously could not.

## Notes

* Invisible to CI throughout: it installs `.[test]` rather than `.[ui]`, so every test in both files skips there. This is a local-only improvement, which is also why it went unnoticed for a week.
* The eight remaining failures in `test_overview_widget.py` are a **different** problem — overlay shapes and view orientations, no FM involved. Left for their own change rather than folded in here.
* Worth a look separately: `_StubWindow.add_lamella` assigns `build_lamella_poses(...).fluorescence` straight into a setter that rejects `None`, and that function is documented to return `None` on a system without an FM. The production callers may have the same shape.
