### PR TITLE
[fix] Cap lxml on Python 3.8, which lost its Windows wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,12 @@ dependencies = [
     "pyyaml>=6.0",
     "psygnal",
     "ome_types",
-    "lxml[html_clean]",
+    # lxml 6.1.2 (2026-08-19) shipped no cp38 wheel for Windows, so pip falls back to
+    # building from source and the runner has no libxml2 headers -- every Windows 3.8
+    # job fails at install, on any commit. Capped for 3.8 alone; everything newer stays
+    # on the current release.
+    "lxml[html_clean]; python_version >= '3.9'",
+    "lxml[html_clean]<6.1.2; python_version < '3.9'",
     "importlib_metadata>=4.6; python_version < '3.10'",
 ]
 


### PR DESCRIPTION
**CI on `main` is red, and every future PR will be too until this lands.**

`lxml 6.1.2` was published to PyPI at **2026-08-19T04:58** without a cp38 wheel for Windows. 6.1.1 had one. Our dependency is unpinned, so pip falls back to building from source on the Windows 3.8 runner, which has no libxml2 headers:

```
src\lxml\includes/etree_defs.h(12): fatal error C1083:
    Cannot open include file: 'libxml/xmlversion.h': No such file or directory
Could not find function xmlXPathInit in library libxml2. Is libxml2 installed?
ERROR: Failed building wheel for lxml
```

The job dies in **Install dependencies**, before a single test runs.

| lxml | uploaded | cp38 win_amd64 wheel |
| -- | -- | -- |
| 6.1.0 | 2026-04-18 | yes |
| 6.1.1 | 2026-05-18 | yes |
| **6.1.2** | **2026-08-19 04:58** | **none** |

It first showed on the `main` build of `60a4c50d`, whose own PR checks had passed twenty minutes earlier — against 6.1.1. Nothing in that change is related; the release simply landed between the two runs. Any commit pushed from now on hits it.

## The fix

Capped for 3.8 alone, in the environment-marker form the neighbouring `importlib_metadata` pin already uses:

```toml
"lxml[html_clean]; python_version >= '3.9'",
"lxml[html_clean]<6.1.2; python_version < '3.9'",
```

Resolved and checked with `packaging`: 3.8 gets `lxml<6.1.2`, 3.9 and 3.13 stay unpinned.

`requires-python` is unchanged at `>=3.8`. This is deliberately not a judgement about how long 3.8 stays in the matrix — it is the smallest change that unblocks CI, and the wider question is worth its own discussion rather than being settled by a broken build at 5am.
