### PR TITLE
[test] Give the overview widget tests a compustage too (FIB-734)

### DIFF
--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -78,7 +78,23 @@ def confirmations(monkeypatch):
 
 @pytest.fixture(scope="module")
 def microscope():
-    scope, _ = utils.setup_session(manufacturer="Demo")
+    """A simulated Arctis, because half of what is drawn here is compustage-shaped.
+
+    A plain Demo session is not a compustage, and the limits box, the holder slots, the
+    grid boundary and the MILLING orientation all behave differently or do not draw at
+    all without one -- eight tests, whose assertions read as unrelated ("overlay shapes",
+    "view orientations") and are not (FIB-734).
+
+    `sim-arctis-configuration.yaml` is the same configuration `test_overview_tab_host.py`
+    and `test_beam_stage_projection.py` use, so the three agree on what an Arctis is.
+    """
+    import fibsem.config as fibsem_config
+
+    path = os.path.join(
+        os.path.dirname(fibsem_config.__file__), "config", "sim-arctis-configuration.yaml"
+    )
+    scope, _ = utils.setup_session(manufacturer="Demo", config_path=path)
+    assert scope.stage_is_compustage, "the config stopped being a compustage"
     return scope
 
 


### PR DESCRIPTION
The third and last file with the fixture problem #464 fixed. `tests/ui/test_overview_widget.py` built a plain Demo session, which is not a compustage — and the limits box, the holder slots, the grid boundary and the MILLING orientation all behave differently or do not draw at all without one.

**8 failed / 187 passed → 195 passed**, with nothing changed but the fixture.

And with it, `tests/ui/` and `tests/autolamella/` are **green: 2381 passed, no failures, no errors** — from 17 failures and 15 errors this morning.

## I got this one wrong twice

I called these a separate problem, on the strength of how the assertions read:

```
the limits only draw on a compustage
boundaries off changed 5 shapes to 3
assert 'MILLING' == 'SEM'
```

"Overlay shapes and view orientations, no FM involved" — except the first one says *compustage* in the message, and I judged the set from the wording rather than testing the hypothesis. Pointing the fixture at `sim-arctis-configuration.yaml`, exactly as #464 did, fixes all eight.

Worth noting for anyone reading #464: its claim that the remaining failures were unrelated was mine and was wrong.

## Verified

Eight tests moved from failing to passing, so passing proves little on its own. I made `_slot_landmark` return `None` — the revived tests catch it (4 failures) and the file is otherwise green.

## CI

The Windows 3.8 job will fail here on `lxml`, not on this change — see #465, which unblocks it. Every branch cut from `main` has that until #465 lands.
