### PR TITLE
[feature] Open the sparse selection from the FM Overview tab

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -740,6 +740,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # match. The FM Overview tab used to be here too; it ships to everyone with an
         # FM now (FIB-611), so its visibility follows the instrument rather than a flag.
         self._apply_overview_canvas_visibility()
+        self._apply_sparse_fm_selection_flag()
         # Toggle Tools -> Scripts. Hiding the menu hides the whole feature: it is the
         # only route to the manager dialog, and the dialog is the only thing that runs
         # a script. If a script is mid-run, leave it visible -- taking away the only
@@ -1327,6 +1328,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # Same for the rebuilt Overview tab, which holds its microscope for life and
         # has to be handed the new one (or let go of the old) on every connection.
         self._apply_overview_canvas_visibility()
+        self._apply_sparse_fm_selection_flag()
         if (
             self.autolamella_ui is not None
             and self.autolamella_ui.microscope is not None
@@ -2608,6 +2610,23 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.tab_widget.indexOf(self.overview_canvas_tab), False
         )
         self._apply_overview_canvas_visibility()
+        self._apply_sparse_fm_selection_flag()
+
+    def _apply_sparse_fm_selection_flag(self) -> None:
+        """Offer planning an FM overview from a beam one, or do not.
+
+        A control inside a tab rather than a tab, so there is nothing to show or hide
+        here -- the widget is told and decides. Read off `self._preferences` for the same
+        reason as the flag below: this is a method on the window that owns them, and a
+        module-level copy would only be a second thing to keep in step.
+        """
+        tab = getattr(self, "fm_overview_tab", None)
+        overview = getattr(tab, "overview", None) if tab is not None else None
+        if overview is None:
+            return
+        overview.set_sparse_selection_enabled(
+            self._preferences.features.sparse_fm_selection
+        )
 
     def _apply_overview_canvas_visibility(self) -> None:
         """Show or hide the rebuilt Overview tab, and build or tear down its widget.

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -357,6 +357,11 @@ class FeatureFlags:
     # The only staging flag left after FIB-609, and it goes the same way the others did
     # -- deleted when the tab replaces the napari one, not kept as a preference.
     overview_canvas_tab: bool = False
+    # Planning a sparse fluorescence overview by drawing regions on a FIB/SEM one.
+    # Off while it has had no bench time: it decides where an expensive acquisition
+    # goes, and the geometry it rests on is only checkable against real data
+    # (FIB-597). Staging, like the flag above -- deleted when it ships, not kept.
+    sparse_fm_selection: bool = False
 
 @dataclass
 class MovementPreferences:

--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -238,6 +238,10 @@ class FMOverviewSettingsWidget(QWidget):
     def set_mask(self, mask: Optional[List[List[bool]]]) -> None:
         self.grid.set_mask(mask)
 
+    def add_grid_header_widget(self, widget) -> None:
+        """Put a control in the Grid panel's header. See `OverviewGridSettingsWidget`."""
+        self.grid.add_header_widget(widget)
+
     def _on_grid_changed(self) -> None:
         """Anything in the grid panel moved -- including the tile order, which is half
         of the spiral/per-row conflict."""

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -273,6 +273,7 @@ class FMOverviewWidget(QWidget):
         # somewhere. None means "wherever the stage is", which is what the runner does
         # by default -- so an untouched grid describes exactly what would be acquired.
         self._target: Optional[FibsemStagePosition] = None
+        self._sparse_selection_enabled = False
         # Where acquired overviews are written. None means nowhere: the widget opens
         # standalone against a simulator as often as it runs inside an experiment, and
         # inventing a directory for those runs would scatter files through whatever
@@ -524,6 +525,22 @@ class FMOverviewWidget(QWidget):
         self.button_cancel.clicked.connect(self.cancel)
         self.button_cancel.setEnabled(False)
 
+        # Above the run controls, because it changes *what* will run rather than
+        # starting it. Hidden unless the feature is on -- see `set_sparse_selection_enabled`.
+        self.button_select_ground = QPushButton("Select from FIB/SEM overview…")
+        self.button_select_ground.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.button_select_ground.clicked.connect(self.select_ground_to_image)
+        self.button_select_ground.setVisible(False)
+
+        # What the selection did, and that doing it again replaces rather than adds to
+        # it. There is no restore: the regions end with the dialog, so a second selection
+        # starts over, and saying so is cheaper than letting someone find out.
+        self.label_selection = ElidedLabel()
+        self.label_selection.setStyleSheet(
+            f"color: {TEXT_MUTED}; font-size: 10px; border: none;"
+        )
+        self.label_selection.setVisible(False)
+
         buttons = QWidget()
         buttons_layout = QHBoxLayout(buttons)
         buttons_layout.setContentsMargins(0, 0, 0, 0)
@@ -545,6 +562,8 @@ class FMOverviewWidget(QWidget):
         actions_layout.addWidget(self.orientation_banner)
         actions_layout.addWidget(self.progress_tiles)
         actions_layout.addWidget(self.progress_tile_detail)
+        actions_layout.addWidget(self.button_select_ground)
+        actions_layout.addWidget(self.label_selection)
         actions_layout.addWidget(buttons)
 
         side = QWidget()
@@ -1100,6 +1119,74 @@ class FMOverviewWidget(QWidget):
         experiments: it is handed a microscope, and its tests construct it that way.
         """
         self._save_directory = path
+
+    def set_sparse_selection_enabled(self, enabled: bool) -> None:
+        """Offer planning an overview by selecting on a FIB/SEM one, or do not.
+
+        Part of the host contract, like `set_save_directory`: this widget is handed a
+        microscope and knows nothing about preferences. Carried past the button rather
+        than only to it -- a control nobody can see is not a feature that is off, and
+        `select_ground_to_image` refuses on the same flag.
+        """
+        self._sparse_selection_enabled = bool(enabled)
+        self.button_select_ground.setVisible(self._sparse_selection_enabled)
+        if not self._sparse_selection_enabled:
+            self.label_selection.setVisible(False)
+
+    def select_ground_to_image(self) -> None:
+        """Draw regions on a saved beam overview, and take the grid they produce.
+
+        The overviews come off disk rather than from the FIB/SEM tab: that tab keeps
+        pixels and a position, not the metadata a projection is read from, and going
+        through the files means this works in a session that did not acquire them.
+        """
+        from fibsem.ui.fm.widgets.fm_sparse_selection_dialog import (
+            FMSparseSelectionDialog,
+            beam_overviews_in,
+        )
+
+        if not self._sparse_selection_enabled:
+            return
+        views = beam_overviews_in(self._save_directory, self.microscope)
+        if not views:
+            notification_service.show_toast(
+                "No FIB/SEM overviews found to select on. Acquire one on the Overview "
+                "tab first.",
+                "info",
+            )
+            return
+
+        selection = FMSparseSelectionDialog.choose(
+            self.microscope,
+            views,
+            self.settings_widget.parameters,
+            # The same two the confirmation dialog costs a run with, so the estimate
+            # here and the one at Acquire cannot disagree.
+            channel_settings=self.channels,
+            zparams=self.settings_widget.z_parameters,
+            parent=self,
+        )
+        if selection is None:
+            return
+        self.apply_sparse_selection(selection)
+
+    def apply_sparse_selection(self, selection) -> None:
+        """Take a completed selection: the grid, the mask, and where it is centred.
+
+        The centre goes to `_target`, which already exists for a grid dragged off the
+        stage position and is what `_grid_centre` hands the runner -- so the drawn grid
+        and the acquisition agree without either being told about this feature.
+        """
+        self.settings_widget.parameters = selection.parameters
+        self._target = selection.centre_position
+        enabled = selection.parameters.n_enabled_tiles
+        total = selection.parameters.rows * selection.parameters.cols
+        self.label_selection.setText(
+            f"{enabled} of {total} tiles came from a selection. "
+            "Selecting again replaces it."
+        )
+        self.label_selection.setVisible(True)
+        self._refresh_tile_grid()
 
     @property
     def saved_path(self) -> Optional[str]:

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -525,21 +525,18 @@ class FMOverviewWidget(QWidget):
         self.button_cancel.clicked.connect(self.cancel)
         self.button_cancel.setEnabled(False)
 
-        # Above the run controls, because it changes *what* will run rather than
-        # starting it. Hidden unless the feature is on -- see `set_sparse_selection_enabled`.
-        self.button_select_ground = QPushButton("Select from FIB/SEM overview…")
-        self.button_select_ground.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        # In the Grid panel's header, not stacked above Acquire. It sets rows, columns
+        # and the mask, so it belongs where those live -- and full width beside the run
+        # controls gave it the same weight as the button that starts a twenty-minute
+        # acquisition. The count it produces is read off the tile mask directly below.
+        self.button_select_ground = IconToolButton(
+            icon="mdi:crop-free",
+            tooltip="Select the ground to image on a FIB/SEM overview",
+            size=_HEADER_BTN_SIZE,
+        )
         self.button_select_ground.clicked.connect(self.select_ground_to_image)
         self.button_select_ground.setVisible(False)
-
-        # What the selection did, and that doing it again replaces rather than adds to
-        # it. There is no restore: the regions end with the dialog, so a second selection
-        # starts over, and saying so is cheaper than letting someone find out.
-        self.label_selection = ElidedLabel()
-        self.label_selection.setStyleSheet(
-            f"color: {TEXT_MUTED}; font-size: 10px; border: none;"
-        )
-        self.label_selection.setVisible(False)
+        self.settings_widget.add_grid_header_widget(self.button_select_ground)
 
         buttons = QWidget()
         buttons_layout = QHBoxLayout(buttons)
@@ -562,8 +559,6 @@ class FMOverviewWidget(QWidget):
         actions_layout.addWidget(self.orientation_banner)
         actions_layout.addWidget(self.progress_tiles)
         actions_layout.addWidget(self.progress_tile_detail)
-        actions_layout.addWidget(self.button_select_ground)
-        actions_layout.addWidget(self.label_selection)
         actions_layout.addWidget(buttons)
 
         side = QWidget()
@@ -1130,8 +1125,6 @@ class FMOverviewWidget(QWidget):
         """
         self._sparse_selection_enabled = bool(enabled)
         self.button_select_ground.setVisible(self._sparse_selection_enabled)
-        if not self._sparse_selection_enabled:
-            self.label_selection.setVisible(False)
 
     def select_ground_to_image(self) -> None:
         """Draw regions on a saved beam overview, and take the grid they produce.
@@ -1181,11 +1174,14 @@ class FMOverviewWidget(QWidget):
         self._target = selection.centre_position
         enabled = selection.parameters.n_enabled_tiles
         total = selection.parameters.rows * selection.parameters.cols
-        self.label_selection.setText(
+        # The Grid header already shows "28/66 tiles" whenever a run is sparse, so the
+        # count is not repeated here -- what it cannot say is *where the mask came from*,
+        # and that selecting again replaces rather than adds to it. There is no restore:
+        # the regions end with the dialog.
+        self.button_select_ground.setToolTip(
             f"{enabled} of {total} tiles came from a selection. "
             "Selecting again replaces it."
         )
-        self.label_selection.setVisible(True)
         self._refresh_tile_grid()
 
     @property

--- a/fibsem/ui/fm/widgets/fm_sparse_selection_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_sparse_selection_dialog.py
@@ -18,6 +18,8 @@ with it. Selecting again starts over.
 
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass, replace
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -295,3 +297,72 @@ class FMSparseSelectionDialog(QDialog):
     def mask(self) -> List[List[bool]]:
         """The mask as it stands, for a caller watching rather than waiting."""
         return self.preview.mask
+
+
+# Extensions `FibsemImage.load` reads. Listed rather than "try everything", so a scan
+# does not attempt to open the parameters JSON and the tile folders beside them.
+_IMAGE_SUFFIXES = (".tif", ".tiff")
+
+
+def beam_overviews_in(
+    directory: Optional[str], microscope: FibsemMicroscope
+) -> Dict[object, List[FibsemImage]]:
+    """Stitched beam overviews saved under *directory*, grouped by the view they belong to.
+
+    From disk rather than from the beam overview tab, deliberately. That tab keeps
+    `_PlacedTile` -- pixels, a position and a pixel size -- and not the metadata a
+    projection is read from, so it could not answer this without being changed; and going
+    through the files means a selection can be made in a session that did not acquire the
+    overview, which is the ordinary case after a restart.
+
+    Top level only. A run writes its tiles into a directory and the stitched mosaic
+    *beside* it under the same name, so the mosaics are exactly the files here and the
+    tiles are exactly the ones this does not descend into.
+
+    Fluorescence overviews live in the same experiment folder and are silently skipped:
+    what is kept is what `BeamStageProjection.from_image` can read, which is the same
+    question as whether a region drawn on it could be resolved at all.
+
+    Returns:
+        Views to their images, newest first, so a caller offering a default gets the
+        overview most recently acquired.
+    """
+    from fibsem.projection import BeamStageProjection
+    from fibsem.ui.widgets.overview_widget import OverviewView
+
+    if not directory or not os.path.isdir(directory):
+        return {}
+
+    paths = [
+        os.path.join(directory, name)
+        for name in os.listdir(directory)
+        if name.lower().endswith(_IMAGE_SUFFIXES)
+    ]
+    paths.sort(key=os.path.getmtime, reverse=True)
+
+    views: Dict[object, List[FibsemImage]] = {}
+    for path in paths:
+        try:
+            image = FibsemImage.load(path)
+        except Exception as e:
+            logging.debug(f"Not an overview this can use: {path} ({e})")
+            continue
+        if BeamStageProjection.from_image(image) is None:
+            continue
+        position = getattr(
+            getattr(getattr(image, "metadata", None), "microscope_state", None),
+            "stage_position",
+            None,
+        )
+        if position is None:
+            continue
+        try:
+            view = OverviewView(
+                image.metadata.image_settings.beam_type,
+                microscope.get_stage_orientation(stage_position=position),
+            )
+        except Exception as e:
+            logging.debug(f"Could not tell which view {path} belongs to: {e}")
+            continue
+        views.setdefault(view, []).append(image)
+    return views

--- a/fibsem/ui/fm/widgets/fm_tile_preview.py
+++ b/fibsem/ui/fm/widgets/fm_tile_preview.py
@@ -45,6 +45,10 @@ from fibsem.ui.widgets.canvas.stage_frame import StageFrame
 # image and does not read over nothing. This pane is nothing but the grid.
 _SELECTED_FILL_ALPHA = 0.30
 
+# The centre of the sample holder, and so of the travel limits, the grid boundary and
+# the framing. Distinct from the frame origin, which is wherever the stage is standing.
+STAGE_ORIGIN = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0)
+
 
 class FMTilePreviewWidget(QWidget):
     """The FM grid a set of regions produces, on a real-space canvas.
@@ -135,10 +139,29 @@ class FMTilePreviewWidget(QWidget):
         # streams in and the grid is not draggable, so there is nothing to re-declare
         # for -- and a frame that holds still is what lets a growing selection be read
         # as growing rather than as the world shrinking around it.
+        #
+        # Centred on the stage *origin*, not on canvas (0, 0). Canvas (0, 0) is the frame
+        # origin, which is wherever the stage happened to be when the dialog opened;
+        # everything drawn here -- the travel limits, the grid boundary, and a plan that
+        # follows the sample -- is placed about the stage origin instead. Centring on the
+        # frame origin therefore shoved the whole scene by the live stage displacement,
+        # which on a compustage is up to a full grid radius, and clipped it off the edge.
         self.canvas.set_world_extent(
-            2 * GRID_BOUNDARY_RADIUS_M, 2 * GRID_BOUNDARY_RADIUS_M, (0.0, 0.0), refit=True
+            2 * GRID_BOUNDARY_RADIUS_M,
+            2 * GRID_BOUNDARY_RADIUS_M,
+            self._stage_origin_offset(),
+            refit=True,
         )
         self._draw_stage_context()
+
+    def _stage_origin_offset(self) -> Tuple[float, float]:
+        """Where stage (0, 0) sits in this canvas's metres, or the frame origin if the
+        projection cannot answer."""
+        try:
+            return self._frame().offset(STAGE_ORIGIN)
+        except Exception as e:  # pragma: no cover - geometry the projection rejects
+            logging.debug(f"Cannot place the stage origin; framing on the pose: {e}")
+            return (0.0, 0.0)
 
     # ── the selection ────────────────────────────────────────────────────
 
@@ -318,9 +341,7 @@ class FMTilePreviewWidget(QWidget):
         """
         frame = self._frame()
         try:
-            centre = frame.to_canvas(
-                FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0)
-            )
+            centre = frame.to_canvas(STAGE_ORIGIN)
         except Exception as e:
             logging.debug(f"Cannot place the grid centre: {e}")
             return

--- a/fibsem/ui/widgets/overview_grid_settings_widget.py
+++ b/fibsem/ui/widgets/overview_grid_settings_widget.py
@@ -133,17 +133,21 @@ class OverviewGridSettingsWidget(QWidget):
         body.addLayout(form)
         body.addWidget(self.tile_mask)
 
-        # Shown in the header so a sparse run announces itself even folded away. Blank
-        # at full coverage: a badge that is always there stops being read.
-        self.label_sparse = QLabel("")
-        self.label_sparse.setStyleSheet(_MUTED)
-
         self.panel = TitledPanel("Grid", content=content)
-        self.panel.add_header_widget(self.label_sparse)
 
         outer = QVBoxLayout(self)
         outer.setContentsMargins(0, 0, 0, 0)
         outer.addWidget(self.panel)
+
+    def add_header_widget(self, widget) -> None:
+        """Put a control in the Grid header.
+
+        For an owner with another way of setting the grid -- the fluorescence tab plans
+        one by selecting regions on a beam overview. Offered rather than built in, so
+        this widget stays the same for both tabs and neither inherits the other's
+        controls.
+        """
+        self.panel.add_header_widget(widget)
 
     @staticmethod
     def _field(widget: QWidget) -> QWidget:
@@ -186,9 +190,6 @@ class OverviewGridSettingsWidget(QWidget):
         self.changed.emit()
 
     def _refresh_derived(self) -> None:
-        enabled, total = self.tile_mask.n_enabled, self.rows * self.cols
-        self.label_sparse.setText("" if enabled == total else f"{enabled}/{total} tiles")
-
         if self._tile_fov is None:
             self.label_total_fov.setText("—")
             return

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -56,6 +56,13 @@ _TIP_BUG_REPORT    = (
     "Show the 'Report an Issue...' option in the Help menu, for reporting bugs and "
     "optionally submitting experiment data privately to the maintainers."
 )
+_LBL_SPARSE_FM = "Enable Sparse FM Selection"
+_TIP_SPARSE_FM = (
+    "Plan a fluorescence overview by drawing regions on a FIB/SEM one, so only "
+    "the interesting parts of the grid are imaged.\n\n"
+    "Off until it has had bench time: it decides where an expensive acquisition "
+    "goes, and the geometry behind it can only be checked against real data."
+)
 _LBL_OVERVIEW_CANVAS = "Enable Overview (Canvas) Tab"
 _TIP_OVERVIEW_CANVAS = (
     "Add a rebuilt Overview tab on the real-space canvas, beside the existing one. "
@@ -159,11 +166,14 @@ class PreferencesDialog(QDialog):
         self._chk_scripts.setToolTip(_TIP_SCRIPTS)
         self._chk_overview_canvas = QCheckBox()
         self._chk_overview_canvas.setToolTip(_TIP_OVERVIEW_CANVAS)
+        self._chk_sparse_fm = QCheckBox()
+        self._chk_sparse_fm.setToolTip(_TIP_SPARSE_FM)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
         features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
         features_form.addRow(_LBL_SCRIPTS, self._chk_scripts)
         features_form.addRow(_LBL_OVERVIEW_CANVAS, self._chk_overview_canvas)
+        features_form.addRow(_LBL_SPARSE_FM, self._chk_sparse_fm)
         self._stack.addWidget(features_page)
 
         # --- Experiment Defaults ---
@@ -236,6 +246,7 @@ class PreferencesDialog(QDialog):
         self._chk_bug_report.setChecked(f.bug_report_enabled)
         self._chk_scripts.setChecked(f.scripts_enabled)
         self._chk_overview_canvas.setChecked(f.overview_canvas_tab)
+        self._chk_sparse_fm.setChecked(f.sparse_fm_selection)
 
         e = prefs.experiment
         self._dir_experiment.setText(e.default_experiment_directory)
@@ -307,6 +318,7 @@ class PreferencesDialog(QDialog):
                 bug_report_enabled=self._chk_bug_report.isChecked(),
                 scripts_enabled=self._chk_scripts.isChecked(),
                 overview_canvas_tab=self._chk_overview_canvas.isChecked(),
+                sparse_fm_selection=self._chk_sparse_fm.isChecked(),
             ),
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),

--- a/tests/ui/test_fm_sparse_entry_point.py
+++ b/tests/ui/test_fm_sparse_entry_point.py
@@ -170,6 +170,19 @@ def dialog_never_opens():
         module.FMSparseSelectionDialog.choose = original
 
 
+def test_the_button_sits_with_the_grid_it_sets(widget):
+    """In the Grid panel's header, not stacked above Acquire.
+
+    It sets rows, columns and the mask, so it belongs where those live -- and full width
+    beside the run controls gave it the same weight as the button that starts a
+    twenty-minute acquisition.
+    """
+    header = widget.settings_widget.grid.panel
+
+    assert widget.button_select_ground.parent() is not None
+    assert header.isAncestorOf(widget.button_select_ground)
+
+
 def test_the_flag_is_carried_past_the_button(widget):
     """A control nobody can see is not a feature that is off. Someone reaching the
     method another way must meet the same answer as someone looking for the button."""
@@ -193,7 +206,6 @@ def test_with_no_overviews_it_says_so_rather_than_opening_an_empty_dialog(
         built.select_ground_to_image()
 
     assert opened == []
-    assert built.label_selection.isVisibleTo(built) is False
 
 
 def test_it_does_open_when_there_is_something_to_select_on(widget):
@@ -240,9 +252,13 @@ def test_applying_a_selection_moves_where_the_run_will_be_centred(widget):
 
 def test_it_says_the_grid_came_from_a_selection_and_will_be_replaced(widget):
     """There is no restore: the regions end with the dialog, so a second selection starts
-    over. Saying so is cheaper than letting someone find out."""
+    over. Saying so is cheaper than letting someone find out.
+
+    On the button rather than a label of its own, because the mask grid is directly below
+    and already shows which tiles are in -- the one thing it cannot show is where they
+    came from.
+    """
     widget.apply_sparse_selection(selection(rows=4, cols=3))
 
-    assert widget.label_selection.isVisibleTo(widget) is True
-    assert "2 of 12 tiles came from a selection" in widget.label_selection.text()
-    assert "replaces it" in widget.label_selection.text()
+    assert "2 of 12 tiles came from a selection" in widget.button_select_ground.toolTip()
+    assert "replaces it" in widget.button_select_ground.toolTip()

--- a/tests/ui/test_fm_sparse_entry_point.py
+++ b/tests/ui/test_fm_sparse_entry_point.py
@@ -1,0 +1,248 @@
+"""Reaching the sparse selection from the FM Overview tab, and taking its answer back.
+
+Two halves. Finding the beam overviews, which happens off disk rather than through the
+FIB/SEM tab -- that tab keeps pixels and a position, not the metadata a projection is
+read from. And applying what comes back, which has to reach the *acquisition* rather than
+only the drawing, or the grid on screen and the run would disagree.
+"""
+import os
+from contextlib import contextmanager
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.fm.structures import OverviewParameters
+from fibsem.structures import BeamType, FibsemStagePosition, ImageSettings
+from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+from fibsem.ui.fm.widgets.fm_sparse_selection_dialog import (
+    SparseSelection,
+    beam_overviews_in,
+)
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture(scope="module")
+def microscope(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    return build_microscope()
+
+
+def save_beam_overview(microscope, directory, orientation, beam_type):
+    pose = microscope.get_orientation(orientation)
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
+    )
+    image = microscope.acquire_image(
+        ImageSettings(
+            hfw=900e-6, resolution=[1024, 1024], beam_type=beam_type, save=False
+        )
+    )
+    image.save(os.path.join(directory, f"overview-image-{orientation}"))
+    return image
+
+
+@pytest.fixture(scope="module")
+def experiment(microscope, tmp_path_factory):
+    """An experiment directory with one beam overview per view, as a session leaves it."""
+    directory = str(tmp_path_factory.mktemp("experiment"))
+    save_beam_overview(microscope, directory, "SEM", BeamType.ELECTRON)
+    save_beam_overview(microscope, directory, "MILLING", BeamType.ION)
+    microscope.move_to_microscope("FM")
+    return directory
+
+
+# ── finding them ─────────────────────────────────────────────────────────
+
+
+def test_it_finds_a_beam_overview_for_each_view(microscope, experiment):
+    views = beam_overviews_in(experiment, microscope)
+
+    assert {v.label for v in views} == {"SEM @ SEM", "FIB @ MILLING"}
+
+
+def test_it_does_not_descend_into_the_tile_folders(microscope, experiment, tmp_path):
+    """A run writes its tiles into a directory and the mosaic *beside* it, so the top
+    level is exactly the mosaics -- and a hundred tiles are exactly what must not be
+    offered as overviews to select on."""
+    directory = str(tmp_path)
+    save_beam_overview(microscope, directory, "MILLING", BeamType.ION)
+    tiles = os.path.join(directory, "overview-image-MILLING")
+    os.makedirs(tiles, exist_ok=True)
+    save_beam_overview(microscope, tiles, "MILLING", BeamType.ION)
+    microscope.move_to_microscope("FM")
+
+    views = beam_overviews_in(directory, microscope)
+
+    assert sum(len(images) for images in views.values()) == 1
+
+
+def test_a_file_it_cannot_read_is_skipped_rather_than_fatal(
+    microscope, experiment, tmp_path
+):
+    """The experiment folder holds more than overviews."""
+    directory = str(tmp_path)
+    save_beam_overview(microscope, directory, "MILLING", BeamType.ION)
+    with open(os.path.join(directory, "not-an-image.tif"), "w") as handle:
+        handle.write("nonsense")
+    microscope.move_to_microscope("FM")
+
+    assert beam_overviews_in(directory, microscope)
+
+
+def test_an_image_with_no_beam_geometry_is_not_offered(microscope, tmp_path):
+    """Fluorescence overviews live in the same experiment folder, and a region drawn on
+    one could not be resolved -- there is no beam projection to read.
+
+    The filter is exactly that question: keep what `BeamStageProjection.from_image` can
+    read, rather than guessing from a filename.
+    """
+    directory = str(tmp_path)
+    save_beam_overview(microscope, directory, "MILLING", BeamType.ION)
+
+    # An image that records *where* it was taken but not the geometry it was taken
+    # under. This is the case the projection check exists for, and the only one: a file
+    # with neither -- a plain TIFF dropped in the folder -- is turned away by the
+    # position check a few lines later, so testing with one proves nothing about this.
+    # Acquired FM tiles carry no geometry at all (FIB-416), so it is a real shape.
+    stray = save_beam_overview(microscope, directory, "MILLING", BeamType.ION)
+    stray.metadata.hardware_geometry = None
+    stray.save(os.path.join(directory, "no-geometry"))
+    microscope.move_to_microscope("FM")
+
+    views = beam_overviews_in(directory, microscope)
+
+    assert sum(len(images) for images in views.values()) == 1, (
+        "the readable overview, and not the one with no geometry beside it"
+    )
+
+
+@pytest.mark.parametrize("directory", [None, "", "/nowhere/at/all"])
+def test_nowhere_to_look_is_not_an_error(microscope, directory):
+    assert beam_overviews_in(directory, microscope) == {}
+
+
+# ── the button ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def widget(microscope, experiment):
+    built = FMOverviewWidget(microscope)
+    built.set_save_directory(experiment)
+    return built
+
+
+def test_the_button_is_hidden_until_the_feature_is_turned_on(widget):
+    assert widget.button_select_ground.isVisibleTo(widget) is False
+
+    widget.set_sparse_selection_enabled(True)
+
+    assert widget.button_select_ground.isVisibleTo(widget) is True
+
+
+@contextmanager
+def dialog_never_opens():
+    """Watch for the dialog rather than waiting to see whether it appears.
+
+    It is modal, so a version that opened it here would *hang* the run rather than fail
+    it -- which is a worse test than a wrong one, because a hang says nothing about which
+    assertion was violated.
+    """
+    from fibsem.ui.fm.widgets import fm_sparse_selection_dialog as module
+
+    opened = []
+    original = module.FMSparseSelectionDialog.choose
+    module.FMSparseSelectionDialog.choose = classmethod(
+        lambda cls, *a, **k: opened.append(1)
+    )
+    try:
+        yield opened
+    finally:
+        module.FMSparseSelectionDialog.choose = original
+
+
+def test_the_flag_is_carried_past_the_button(widget):
+    """A control nobody can see is not a feature that is off. Someone reaching the
+    method another way must meet the same answer as someone looking for the button."""
+    widget.set_sparse_selection_enabled(False)
+
+    with dialog_never_opens() as opened:
+        widget.select_ground_to_image()
+
+    assert opened == []
+
+
+def test_with_no_overviews_it_says_so_rather_than_opening_an_empty_dialog(
+    microscope, tmp_path
+):
+    """A dialog offering nothing to select on is a dead end with a Cancel button."""
+    built = FMOverviewWidget(microscope)
+    built.set_save_directory(str(tmp_path))
+    built.set_sparse_selection_enabled(True)
+
+    with dialog_never_opens() as opened:
+        built.select_ground_to_image()
+
+    assert opened == []
+    assert built.label_selection.isVisibleTo(built) is False
+
+
+def test_it_does_open_when_there_is_something_to_select_on(widget):
+    """The guard above has to be a guard, not the only path."""
+    widget.set_sparse_selection_enabled(True)
+
+    with dialog_never_opens() as opened:
+        widget.select_ground_to_image()
+
+    assert opened == [1]
+
+
+# ── taking the answer back ───────────────────────────────────────────────
+
+
+def selection(rows=4, cols=3, enabled=((0, 0), (1, 1))):
+    mask = [[(r, c) in enabled for c in range(cols)] for r in range(rows)]
+    return SparseSelection(
+        parameters=OverviewParameters(rows=rows, cols=cols, overlap=0.1, tile_mask=mask),
+        centre_position=FibsemStagePosition(
+            x=1e-4, y=2e-4, z=0.0, r=0.0, t=-3.141592653589793
+        ),
+    )
+
+
+def test_applying_a_selection_reaches_the_settings(widget):
+    widget.apply_sparse_selection(selection(rows=4, cols=3))
+
+    parameters = widget.settings_widget.parameters
+    assert (parameters.rows, parameters.cols) == (4, 3)
+    assert parameters.n_enabled_tiles == 2
+
+
+def test_applying_a_selection_moves_where_the_run_will_be_centred(widget):
+    """`_target` is what `_grid_centre` hands the runner, and what the drawn grid is
+    placed against -- so the picture and the acquisition agree without either being told
+    about this feature."""
+    chosen = selection()
+
+    widget.apply_sparse_selection(chosen)
+
+    assert widget._grid_centre() == chosen.centre_position
+
+
+def test_it_says_the_grid_came_from_a_selection_and_will_be_replaced(widget):
+    """There is no restore: the regions end with the dialog, so a second selection starts
+    over. Saying so is cheaper than letting someone find out."""
+    widget.apply_sparse_selection(selection(rows=4, cols=3))
+
+    assert widget.label_selection.isVisibleTo(widget) is True
+    assert "2 of 12 tiles came from a selection" in widget.label_selection.text()
+    assert "replaces it" in widget.label_selection.text()

--- a/tests/ui/test_fm_tile_preview.py
+++ b/tests/ui/test_fm_tile_preview.py
@@ -147,6 +147,64 @@ def test_the_working_area_is_declared_once(pane, microscope):
     assert pane.canvas.canvas.world_extent == at_open
 
 
+def view_centre(pane):
+    """The middle of what the pane actually shows, read off the axes."""
+    xlim = pane.canvas.canvas._ax.get_xlim()
+    ylim = pane.canvas.canvas._ax.get_ylim()
+    return ((xlim[0] + xlim[1]) / 2, (ylim[0] + ylim[1]) / 2)
+
+
+@pytest.mark.parametrize("orientation", ["FM", "MILLING"])
+def test_the_view_is_framed_on_the_stage_not_on_wherever_it_was_parked(
+    microscope, orientation
+):
+    """The declared area has to be centred on what is drawn in it.
+
+    Canvas (0, 0) is the *frame* origin -- wherever the stage happened to be standing
+    when the dialog opened. Everything this pane draws is placed about the *stage*
+    origin instead: the travel limits, the grid boundary, and a plan that follows the
+    sample rather than the pose. Framing on canvas (0, 0) therefore slid the whole scene
+    by the live stage displacement, which on a compustage reaches a full grid radius --
+    enough to push the grid off the edge of the pane.
+
+    Both poses, because the dialog is opened from the milling one: that is where the
+    beam overview was just acquired. Reading the framing off the live pose rather than
+    the fluorescence-posed origin is wrong there and indistinguishable at FM.
+    """
+    pose = microscope.get_orientation(orientation)
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=-450e-6, y=-300e-6, z=0.0, r=pose.r, t=pose.t)
+    )
+    pane = FMTilePreviewWidget(microscope)
+
+    [circle] = [s for s in pane.stage_overlay._specs if s.kind == "circle"]
+
+    assert (circle.cx, circle.cy) == pytest.approx(view_centre(pane), abs=1e-6), (
+        "the grid boundary is drawn somewhere other than the middle of the view"
+    )
+
+
+def test_a_stage_that_moves_under_the_dialog_does_not_take_the_framing_with_it(
+    microscope,
+):
+    """Framing on the stage origin must not become framing on the *live* stage: the
+    origin is fixed for the life of the pane, so the answer cannot depend on when it is
+    asked."""
+    fm = microscope.get_orientation("FM")
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=100e-6, y=50e-6, z=0.0, r=fm.r, t=fm.t)
+    )
+    pane = FMTilePreviewWidget(microscope)
+    at_open = pane.canvas.canvas.world_extent
+
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=-400e-6, y=-250e-6, z=0.0, r=fm.r, t=fm.t)
+    )
+    select(pane, microscope, *TWO_REGIONS)
+
+    assert pane.canvas.canvas.world_extent == at_open
+
+
 # ── editing by hand ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes FIB-729. Completes FIB-597.

**Stacked on #463 → #459 → #457 → #456.** Review those first; this diff is the entry point alone.

The only part of this a user sees: a button at the foot of the FM overview settings column, behind a `sparse_fm_selection` flag. Draw regions on a saved FIB/SEM overview; the grid they produce comes back.

## The overviews come off disk

Not from the FIB/SEM tab. That tab keeps `_PlacedTile` — pixels, a position and a pixel size — and **not** the metadata a projection is read from, so it could not answer this without being changed. Going through the files also means a selection can be made in a session that did not acquire the overview, which is the ordinary case after a restart.

`beam_overviews_in` scans the experiment folder's top level and no further. A run writes its tiles into a directory and the stitched mosaic *beside* it under the same name, so the mosaics are exactly the files there and the tiles are exactly what this does not descend into. What is kept is what `BeamStageProjection.from_image` can read — the same question as whether a region drawn on it could be resolved at all — so fluorescence overviews sharing the folder are turned away by it.

## What comes back needs no new mechanism

`FMOverviewWidget` already has `_target`: the stage position a dragged grid is centred on, and what `_grid_centre` hands the runner. The selection's centre goes straight there, so the drawn grid and the acquisition agree without either being told this feature exists.

Rows, columns and the mask go to the settings panel, and the tab says the mask came from a selection and that selecting again replaces it — there is no restore, and saying so is cheaper than letting someone find out.

The flag is read by the window off `self._preferences`, like `overview_canvas_tab`, and pushed to the widget, which is handed a microscope and knows nothing about preferences. It is carried **past** the button into `select_ground_to_image`: a control nobody can see is not a feature that is off.

## Testing

Six mutations, all killed — but three of the tests needed rewriting first, and each failure is worth knowing:

* removing the flag guard **hung** the run rather than failing it. The dialog is modal, so a version that opened it waited forever. A hang is a worse test than a wrong one, because it says nothing about which assertion broke. Those tests now patch `choose` and assert it was not called.
* the first "an image with no beam geometry is skipped" test proved nothing. A plain TIFF *does* load as a `FibsemImage`, and it is turned away by the **position** check a few lines later — so the projection check was never what rejected it. It now uses an image that records where it was taken but not the geometry, which is the only shape that check catches, and a real one: acquired FM tiles carry no geometry (FIB-416).
* a helper of mine wrote `(r, c) in (0, 0)`, which tests membership of the two integers, so every tile came out disabled and two assertions were checking the wrong number.

Two survivors left in place, both equivalent and both checked rather than assumed: the suffix filter is a fast path, since loading a directory raises and is caught either way; and dropping the projection check changes nothing for a *bare* file, only for a geometry-less one, which is what the new test covers.

Full `tests/ui/` shows no failure that is not already on `main`.

## Trying it

Turn on **Enable Sparse FM Selection** in preferences, acquire a FIB/SEM overview so there is something to select on, then open the FM Overview tab and use the button at the foot of the settings column.

Or without AutoLamella, on the panes and dialog directly:

```
python -m fibsem.ui.fm.sparse_selection_app
```
