### PR TITLE
[refactor] One signal for tile progress, whichever beam is imaging (FIB-725)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1421,9 +1421,20 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         (FIB-725). What it will need, once a fluorescence run emits here, is to say
         *which* -- not to drop one.
         """
-        counter = ddict.get("counter", 0)
-        total = ddict.get("total", 1)
+        counter = ddict.get("counter")
+        total = ddict.get("total")
         msg = ddict.get("msg", "Collecting tiles")
+
+        if not ddict.get("finished") and (counter is None or not total):
+            # A phase that carries no counts: a stage move, a stitch, a save. The
+            # fluorescence runner reports several of these and the beam tiler none, so
+            # this only started mattering when both reported here (FIB-725).
+            #
+            # Nothing is drawn for them, which leaves the last real count standing --
+            # still true while the stage moves or the mosaic is written. Defaulting
+            # instead, as this did, meant `counter=0, total=1` on every such payload:
+            # the bar snapped back to zero at every tile boundary.
+            return
 
         if ddict.get("finished"):
             self.progress_widget.update_progress(self._overview_outcome(ddict, msg))

--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -19,6 +19,7 @@ from fibsem.imaging.reduce import (
     PreviewMosaic,
     downsample,
 )
+from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
 from fibsem.imaging.tiling.geometry import (
     TilePosition,
     compute_tile_grid_from_fov,
@@ -889,7 +890,7 @@ class FMTiledAcquisitionRunner:
             # `total` counts tiles that will actually be acquired, not grid cells --
             # a progress bar that stops at 9/25 on a successful sparse run reads as a
             # failure.
-            "current": 1, "total": len(self._ordered),
+            "counter": 1, "total": len(self._ordered),
             "estimated_total_time": self._total_estimated_time,
             "estimated_remaining_time": self._total_estimated_time,
         })
@@ -1070,7 +1071,25 @@ class FMTiledAcquisitionRunner:
     # ── helpers ──────────────────────────────────────────────────────────
 
     def _emit(self, payload: dict) -> None:
-        self.microscope.fm.acquisition_progress_signal.emit(payload)
+        """Report a phase of this run.
+
+        On `tiled_acquisition_signal`, not the detector's own progress signal. This is
+        tile *n* of *N* and a mosaic so far -- the same event the beam tiler reports,
+        and it belonged on the same signal all along. It grew up on the fluorescence one
+        because this runner grew up in the FM package, next to a signal that was already
+        there and that also carries z-stacks, channel acquisitions and autofocus sweeps
+        (FIB-725).
+
+        What stays on the detector's signal is the work *inside* a tile: those are a
+        different scale, and `FMOverviewWidget` draws them in a different bar.
+
+        Stamped with the modality on the way out, so no consumer has to remember to. Two
+        of them draw a beam overview from this signal and would otherwise paint a
+        fluorescence mosaic into it.
+        """
+        self.microscope.tiled_acquisition_signal.emit(
+            {"modality": MODALITY_FLUORESCENCE, **payload}
+        )
 
     def _emit_preview(self, tile: TilePosition) -> None:
         """Publish the mosaic-so-far, so a viewer can watch it fill in.
@@ -1092,7 +1111,7 @@ class FMTiledAcquisitionRunner:
             "state": "tile", "task": "tileset",
             "row": tile.row, "col": tile.col,
             "total_rows": self._rows, "total_cols": self._cols,
-            "current": self._n_acquired, "total": len(self._ordered),
+            "counter": self._n_acquired, "total": len(self._ordered),
             "image": self._preview.canvas.copy(),
             "preview_stride": self._preview.stride,
         })
@@ -1115,7 +1134,7 @@ class FMTiledAcquisitionRunner:
             "state": "acquiring", "task": "tileset",
             "row": row + 1, "col": col + 1,
             "total_rows": self._rows, "total_cols": self._cols,
-            "current": current_tile, "total": total_tiles,
+            "counter": current_tile, "total": total_tiles,
             "estimated_total_time": self._total_estimated_time,
             "estimated_remaining_time": estimated_remaining_time,
             "elapsed_time": elapsed_time,

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -54,6 +54,7 @@ from fibsem.ui.widgets.canvas.overlays.tile_grid_options_panel import (
     TileGridOptionsPanel,
 )
 from fibsem.ui.qt.threading import FunctionWorker
+from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
 from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
 from fibsem.ui.widgets.canvas.overlay_controls import (
     CanvasOverlayControls,
@@ -293,6 +294,14 @@ class FMOverviewWidget(QWidget):
         self._on_settings_changed()
 
         self._progress_received.connect(self._apply_progress)
+        # Two scales, two signals now. The tileset -- tile n of N, the mosaic so far,
+        # and how the run ended -- reports on `tiled_acquisition_signal` beside the beam
+        # tiler's, because it is the same event (FIB-725). The work *inside* a tile
+        # stays on the detector's own progress signal, which is where a z-stack, a
+        # channel acquisition and an autofocus sweep report from whether or not a
+        # tileset is running. `_apply_progress` still sorts them; it just no longer has
+        # to sort them out of one stream.
+        self.microscope.tiled_acquisition_signal.connect(self._on_progress)
         self.fm.acquisition_progress_signal.connect(self._on_progress)
         self._stage_moved.connect(self._on_stage_moved)
         # A plain bound method, not `self._stage_moved.emit`, matching how the progress
@@ -2243,7 +2252,43 @@ class FMOverviewWidget(QWidget):
         `moving` has always been handled. Rendering these as indeterminate would paint a
         *full* bar, which is exactly the "it finished" impression they exist to correct.
         """
-        self.fm.acquisition_progress_signal.emit({"state": state, "task": "tileset"})
+        self.microscope.tiled_acquisition_signal.emit(
+            {"modality": MODALITY_FLUORESCENCE, "state": state, "task": "tileset"}
+        )
+
+    # What a finished run is called on the shared signal, per outcome.
+    TERMINAL_MESSAGES = {
+        "finished": "Overview Complete",
+        "cancelled": "Overview Cancelled",
+        "failed": "Overview Failed",
+    }
+
+    def _emit_terminal(self, state: str, outcome: str, error: str = "") -> None:
+        """Say how the run ended, in both vocabularies.
+
+        `state` is this widget's own -- `_apply_progress` and `_finish` branch on it,
+        and it distinguishes "the mosaic is saved" from the runner's "the tiles are in".
+
+        `finished` and `outcome` are the shared signal's, which the beam tiler has used
+        since it learned to report every outcome. Carried as well, not instead: a
+        consumer reads whichever it understands, and the window's status bar reads the
+        second (FIB-725). Redundant on purpose -- collapsing the two vocabularies into
+        one is the typed-payload work, not this.
+
+        Without `finished`, the status bar would never clear after a fluorescence run:
+        the terminal it recognises is a key this widget did not send.
+        """
+        payload = {
+            "modality": MODALITY_FLUORESCENCE,
+            "state": state,
+            "task": "tileset",
+            "finished": True,
+            "outcome": outcome,
+            "msg": self.TERMINAL_MESSAGES.get(outcome, "Overview"),
+        }
+        if error:
+            payload["error"] = error
+        self.microscope.tiled_acquisition_signal.emit(payload)
 
     def _acquire_worker(self) -> None:
         """Runs off the GUI thread. Only signals may cross back."""
@@ -2263,19 +2308,13 @@ class FMOverviewWidget(QWidget):
                 self._emit_state("saving")
                 self._saved_path = self._destination.save_mosaic(mosaic)
             self.overview_acquired.emit(mosaic)
-            self.fm.acquisition_progress_signal.emit(
-                {"state": "overview-finished", "task": "tileset"}
-            )
+            self._emit_terminal("overview-finished", "finished")
         except OperationCancelledError:
             logging.info("Overview acquisition cancelled")
-            self.fm.acquisition_progress_signal.emit(
-                {"state": "overview-cancelled", "task": "tileset"}
-            )
+            self._emit_terminal("overview-cancelled", "cancelled")
         except Exception as e:
             logging.error(f"Overview acquisition failed: {e}", exc_info=True)
-            self.fm.acquisition_progress_signal.emit(
-                {"state": "overview-failed", "task": "tileset", "error": str(e)}
-            )
+            self._emit_terminal("overview-failed", "failed", str(e))
         finally:
             # A run that ends still marked as acquiring leaves the FM unusable for
             # the rest of the session, with nothing on screen to say why -- so this goes
@@ -2371,7 +2410,7 @@ class FMOverviewWidget(QWidget):
             # run. The next tile's first payload overwrites it a moment later anyway.
             self._show_preview(payload)
 
-        current, total = payload.get("current", 0), payload.get("total", 1)
+        current, total = payload.get("counter", 0), payload.get("total", 1)
         remaining = payload.get("estimated_remaining_time")
         # The widget renders the count itself, so the message says what is being
         # counted and nothing more -- otherwise it reads "Tile 4/9 — 4/9".

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -54,7 +54,7 @@ from fibsem.ui.widgets.canvas.overlays.tile_grid_options_panel import (
     TileGridOptionsPanel,
 )
 from fibsem.ui.qt.threading import FunctionWorker
-from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
+from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, is_modality
 from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
 from fibsem.ui.widgets.canvas.overlay_controls import (
     CanvasOverlayControls,
@@ -2387,6 +2387,13 @@ class FMOverviewWidget(QWidget):
 
         task = payload.get("task")
         if task == "tileset":
+            if not is_modality(payload, MODALITY_FLUORESCENCE):
+                # A beam run, on the signal this now shares with the beam tiler. It is
+                # ignored today even without this -- beam payloads carry no `task` -- but
+                # that is an accident of vocabulary, not a decision, and the beam tiler
+                # gaining a `task` key would be an entirely reasonable thing for it to
+                # do (FIB-725).
+                return
             self._apply_tile_progress(payload, state)
         elif task in ("z-stack", "channels", "autofocus"):
             self.progress_tile_detail.update_progress(self._tile_detail_update(payload))

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -1314,13 +1314,13 @@ def test_progress_totals_count_enabled_tiles_not_grid_cells(fm_microscope, monke
     """A bar that stops at 9/25 on a successful run reads as a failure."""
     _record_tile_positions(fm_microscope, monkeypatch)
     emitted = []
-    fm_microscope.fm.acquisition_progress_signal.connect(emitted.append)
+    fm_microscope.tiled_acquisition_signal.connect(emitted.append)
 
     _sparse_runner(fm_microscope, 5, 5, mask=_plus_mask(5)).run()
 
     totals = {p["total"] for p in emitted if "total" in p}
     assert totals == {9}
-    counters = [p["current"] for p in emitted if p.get("state") == "acquiring"]
+    counters = [p["counter"] for p in emitted if p.get("state") == "acquiring"]
     assert counters[-1] == 9
 
 
@@ -1500,7 +1500,7 @@ def test_stitching_demands_to_be_told_where_the_mosaic_is():
 
 def _preview_frames(microscope, rows, cols, mask=None, channels=1):
     frames = []
-    microscope.fm.acquisition_progress_signal.connect(
+    microscope.tiled_acquisition_signal.connect(
         lambda d: frames.append(d) if d.get("state") == "tile" else None
     )
     channel_settings = [
@@ -1522,7 +1522,7 @@ def test_a_preview_frame_is_published_for_every_acquired_tile(fm_microscope):
     frames = _preview_frames(fm_microscope, 3, 3, mask=mask)
 
     assert len(frames) == 5  # the plus, not the grid
-    assert [f["current"] for f in frames] == [1, 2, 3, 4, 5]
+    assert [f["counter"] for f in frames] == [1, 2, 3, 4, 5]
     assert {f["total"] for f in frames} == {5}
 
 
@@ -1655,6 +1655,8 @@ def test_a_cancelled_sweep_does_not_start_the_next_pass(fm_microscope, monkeypat
     _record_tile_positions(fm_microscope, monkeypatch)
     stop_event = threading.Event()
     seen = []
+    # Still the detector's signal: an autofocus sweep is work *inside* a tile, which is
+    # the scale that stayed there when the tileset moved to `tiled_acquisition_signal`.
     fm_microscope.fm.acquisition_progress_signal.connect(
         lambda d: seen.append(d) if d.get("task") == "autofocus" else None
     )
@@ -2252,7 +2254,7 @@ def test_the_stitch_is_announced_between_the_last_tile_and_the_mosaic(fm_microsc
     drive. The beam tiler has always said "Stitching Tiles" here (FIB-725).
     """
     emitted = []
-    fm_microscope.fm.acquisition_progress_signal.connect(emitted.append)
+    fm_microscope.tiled_acquisition_signal.connect(emitted.append)
 
     acquisition.FMTiledAcquisitionRunner(
         microscope=fm_microscope,
@@ -2274,7 +2276,7 @@ def test_the_stitch_announcement_carries_no_counts(fm_microscope):
     mosaic is being built, and rendering this as indeterminate would paint a *full* bar
     — exactly the "it finished" impression the phase exists to correct."""
     emitted = []
-    fm_microscope.fm.acquisition_progress_signal.connect(emitted.append)
+    fm_microscope.tiled_acquisition_signal.connect(emitted.append)
 
     acquisition.FMTiledAcquisitionRunner(
         microscope=fm_microscope,
@@ -2292,7 +2294,7 @@ def test_a_run_that_never_reaches_the_stitch_does_not_announce_one(fm_microscope
     """`run()` on its own acquires without stitching — a caller wanting the tiles. It
     must not claim a mosaic is being built that nobody asked for."""
     emitted = []
-    fm_microscope.fm.acquisition_progress_signal.connect(emitted.append)
+    fm_microscope.tiled_acquisition_signal.connect(emitted.append)
 
     acquisition.FMTiledAcquisitionRunner(
         microscope=fm_microscope,

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -311,7 +311,7 @@ def test_a_tileset_payload_moves_only_the_tile_bar(qapp):
     router = _Router()
 
     router._apply_progress({
-        "state": "acquiring", "task": "tileset", "counter": 4, "total": 9,
+        "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 4, "total": 9,
     })
 
     # value/maximum directly, not a percentage -- the widget counts items.
@@ -359,7 +359,7 @@ def test_a_completed_tile_leaves_the_detail_bar_alone(qapp):
     })
 
     router._apply_progress({
-        "state": "tile", "task": "tileset", "current": 1, "total": 9,
+        "modality": "fluorescence", "state": "tile", "task": "tileset", "current": 1, "total": 9,
     })
 
     assert router.progress_tile_detail.isVisible()
@@ -378,7 +378,7 @@ def test_the_estimate_is_shown_when_the_payload_carries_one(qapp):
     router = _Router()
 
     router._apply_progress({
-        "state": "acquiring", "task": "tileset", "counter": 2, "total": 9,
+        "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 2, "total": 9,
         "estimated_remaining_time": 134.0, "estimated_total_time": 180.0,
     })
 
@@ -393,10 +393,10 @@ def test_a_stage_move_does_not_fill_the_bar(qapp):
     """
     router = _Router()
     router._apply_progress({
-        "state": "acquiring", "task": "tileset", "counter": 3, "total": 9,
+        "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 3, "total": 9,
     })
 
-    router._apply_progress({"state": "moving", "task": "tileset"})
+    router._apply_progress({"modality": "fluorescence", "state": "moving", "task": "tileset"})
 
     assert (_bar(router.progress_tiles).value(),
             _bar(router.progress_tiles).maximum()) == (3, 9)
@@ -422,10 +422,12 @@ def test_the_end_of_a_run_is_not_silent(qapp, state, label):
     """
     router = _Router()
     router._apply_progress({
-        "state": "acquiring", "task": "tileset", "counter": 9, "total": 9,
+        "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 9, "total": 9,
     })
 
-    router._apply_progress({"state": state, "task": "tileset"})
+    router._apply_progress(
+        {"modality": "fluorescence", "state": state, "task": "tileset"}
+    )
 
     assert router.status.text() == label
     assert (_bar(router.progress_tiles).value(),
@@ -435,11 +437,11 @@ def test_the_end_of_a_run_is_not_silent(qapp, state, label):
 def test_a_phase_label_is_cleared_by_the_next_tile(qapp):
     """Otherwise "Stitching tiles…" would still be on screen through the next run."""
     router = _Router()
-    router._apply_progress({"state": "saving", "task": "tileset"})
+    router._apply_progress({"modality": "fluorescence", "state": "saving", "task": "tileset"})
     assert router.status.text() == "Saving overview…"
 
     router._apply_progress({
-        "state": "acquiring", "task": "tileset", "counter": 1, "total": 9,
+        "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 1, "total": 9,
     })
     assert router.status.text() == ""
 
@@ -4882,3 +4884,46 @@ def test_the_worker_announces_the_save_before_it_writes(qapp, overview_widget, t
     assert states.index("saving") < states.index("overview-finished"), (
         "the save was announced after it had already happened"
     )
+
+
+def test_a_tileset_payload_reaches_the_real_widget(qapp, overview_widget):
+    """The wiring, not the rendering.
+
+    Every other test here drives `_apply_progress` directly, which covers what the
+    widget *does* with a payload and nothing about whether one arrives. The tileset
+    moved to `tiled_acquisition_signal` (FIB-725), so the subscription is precisely what
+    changed — and a broken one leaves this tab's own bar dead for a whole run with no
+    test noticing.
+    """
+    widget = overview_widget
+    widget.microscope.tiled_acquisition_signal.emit({
+        "modality": "fluorescence", "state": "acquiring", "task": "tileset",
+        "counter": 4, "total": 9,
+    })
+    qapp.processEvents()
+
+    assert "4 / 9" in _bar(widget.progress_tiles).format()
+
+
+def test_a_beam_run_does_not_drive_the_fluorescence_bar(qapp, overview_widget):
+    """Both tilers report on this signal now. This tab draws one of them.
+
+    Ignored today even without the modality check — beam payloads carry no `task` — but
+    that is an accident of vocabulary rather than a decision, and the beam tiler gaining
+    a `task` key would be a reasonable thing for it to do.
+    """
+    widget = overview_widget
+    widget.microscope.tiled_acquisition_signal.emit({
+        "modality": "fluorescence", "state": "acquiring", "task": "tileset",
+        "counter": 4, "total": 9,
+    })
+    qapp.processEvents()
+    before = _bar(widget.progress_tiles).format()
+
+    widget.microscope.tiled_acquisition_signal.emit({
+        "modality": "beam", "task": "tileset", "counter": 8, "total": 9,
+        "msg": "Tile Collected",
+    })
+    qapp.processEvents()
+
+    assert _bar(widget.progress_tiles).format() == before

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -311,7 +311,7 @@ def test_a_tileset_payload_moves_only_the_tile_bar(qapp):
     router = _Router()
 
     router._apply_progress({
-        "state": "acquiring", "task": "tileset", "current": 4, "total": 9,
+        "state": "acquiring", "task": "tileset", "counter": 4, "total": 9,
     })
 
     # value/maximum directly, not a percentage -- the widget counts items.
@@ -378,7 +378,7 @@ def test_the_estimate_is_shown_when_the_payload_carries_one(qapp):
     router = _Router()
 
     router._apply_progress({
-        "state": "acquiring", "task": "tileset", "current": 2, "total": 9,
+        "state": "acquiring", "task": "tileset", "counter": 2, "total": 9,
         "estimated_remaining_time": 134.0, "estimated_total_time": 180.0,
     })
 
@@ -393,7 +393,7 @@ def test_a_stage_move_does_not_fill_the_bar(qapp):
     """
     router = _Router()
     router._apply_progress({
-        "state": "acquiring", "task": "tileset", "current": 3, "total": 9,
+        "state": "acquiring", "task": "tileset", "counter": 3, "total": 9,
     })
 
     router._apply_progress({"state": "moving", "task": "tileset"})
@@ -422,7 +422,7 @@ def test_the_end_of_a_run_is_not_silent(qapp, state, label):
     """
     router = _Router()
     router._apply_progress({
-        "state": "acquiring", "task": "tileset", "current": 9, "total": 9,
+        "state": "acquiring", "task": "tileset", "counter": 9, "total": 9,
     })
 
     router._apply_progress({"state": state, "task": "tileset"})
@@ -439,7 +439,7 @@ def test_a_phase_label_is_cleared_by_the_next_tile(qapp):
     assert router.status.text() == "Saving overview…"
 
     router._apply_progress({
-        "state": "acquiring", "task": "tileset", "current": 1, "total": 9,
+        "state": "acquiring", "task": "tileset", "counter": 1, "total": 9,
     })
     assert router.status.text() == ""
 
@@ -4867,14 +4867,14 @@ def test_the_worker_announces_the_save_before_it_writes(qapp, overview_widget, t
             return mosaic
 
     seen = []
-    widget.fm.acquisition_progress_signal.connect(seen.append)
+    widget.microscope.tiled_acquisition_signal.connect(seen.append)
     runner, destination, saved = widget._runner, widget._destination, widget._saved_path
     try:
         widget._runner = _StubRunner()
         widget._destination = OverviewDestination.create(str(tmp_path))
         widget._acquire_worker()
     finally:
-        widget.fm.acquisition_progress_signal.disconnect(seen.append)
+        widget.microscope.tiled_acquisition_signal.disconnect(seen.append)
         widget._runner, widget._destination, widget._saved_path = runner, destination, saved
 
     states = [p.get("state") for p in seen if p.get("task") == "tileset"]


### PR DESCRIPTION
Both tiled runners report the same thing — tile *n* of *N*, and a mosaic so far — and reported it in two places.

The fluorescence half was the interloper. `tiled_acquisition_signal` is named for, and carried only, tiled acquisition; the fluorescence runner reported on a signal hanging off the **detector**, which also carries z-stacks, channel acquisitions and autofocus sweeps. It ended up there because the runner grew up in the FM package, next to a signal that was already there — nothing about it was a considered choice.

The tileset now reports beside the beam tiler's. What stays on the detector's signal is the work **inside** a tile: a genuinely different scale, drawn in a different bar.

## The three decisions

**`counter`, not `current`.** The beam spelling is what every existing consumer of the shared signal already reads — including anything outside this repository — so the newcomer adopts it.

**Terminal payloads carry both vocabularies.** `state` is the fluorescence widget's own, and it distinguishes "the mosaic is saved" from the runner's "the tiles are in". `finished` + `outcome` are the shared signal's, which the beam tiler has used since it learned to report every outcome. Carried as well, not instead — without the second, **the status bar would never clear after a fluorescence run**, because the terminal it recognises is a key that widget did not send. Redundant on purpose; collapsing the two is the typed-payload work (FIB-402).

**The window's handler had to stop defaulting its counts.** The fluorescence runner reports several phases carrying none — a stage move, a stitch, a save — and the beam tiler reports none of them, so `counter=0, total=1` only started mattering once both reported here. It snapped the bar back to zero at every tile boundary. Nothing is drawn for a countless payload now, which leaves the last real count standing.

## `FluorescenceControlWidget` needs no migration — measured, not assumed

It subscribes to the same signal, so I replayed a real run's payloads against it with and without the tileset half:

```
today  (tileset + within-tile)        after  (within-tile only)
  task_bar_shown: False                 task_bar_shown: False
  current_bar:  'Z-level 3/5'           current_bar:  'Z-level 3/5'
  text: 'Acquiring GFP (2/4)...'        text: 'Acquiring GFP (2/4)...'
```

Identical in everything visible. What it loses is the *value* of a bar it never shows for an overview — the branch that would show it is dead code (`_current_acquisition_type` is only ever set to `"image"` or `"autofocus"`), and it labels a tileset "Position 3/9" anyway.

## Verification

- **5501 tests pass.**
- Driven end to end: a real fluorescence run rendered through the **real** status-bar handler tracks the tiles, holds its count through the `moving` / `stitching` / `saving` phases, and clears to `Done`.
- Two consumers already ignore what is not theirs (FIB-733), so a fluorescence mosaic cannot be painted into the beam minimap.
- Test migration was done per-subscription, not by search-and-replace: an autofocus test legitimately stays on the detector's signal, and a blanket edit moved it — caught by that test failing.

## Recorded, not fixed

FIB-736: the two runners' `counter` differs by a tile in *when* it increments — the beam counts tiles completed, the fluorescence one the tile starting. Same range, same endpoint; the only visible effect is the status bar going indeterminate one tile early on a fluorescence run.