### PR TITLE
[fix] One producer for the FM overview's tile bar (FIB-739)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -2416,6 +2416,14 @@ class FMOverviewWidget(QWidget):
             # it vanish and reappear at every tile boundary -- a flicker for the whole
             # run. The next tile's first payload overwrites it a moment later anyway.
             self._show_preview(payload)
+            # And deliberately does not fall through to the bar below. This payload
+            # delivers the mosaic so far; the count it also carries is the *completed*
+            # tally, where `acquiring` carries the tile starting and an estimate to go
+            # with it. Rendering both put two different bars in one place, alternating
+            # every tile: `acquiring` draws a countdown scaled in tenths of a second
+            # (52/242) and this drew tiles (2/4), so the fill jumped and the text
+            # changed shape at every boundary. One producer for one bar.
+            return
 
         current, total = payload.get("counter", 0), payload.get("total", 1)
         remaining = payload.get("estimated_remaining_time")

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -4927,3 +4927,50 @@ def test_a_beam_run_does_not_drive_the_fluorescence_bar(qapp, overview_widget):
     qapp.processEvents()
 
     assert _bar(widget.progress_tiles).format() == before
+
+
+def test_the_preview_payload_does_not_redraw_the_tile_bar(qapp):
+    """One producer for one bar.
+
+    Both payloads a tile emits carry counts, and they mean different things: `acquiring`
+    names the tile *starting* and comes with an estimate, `tile` carries the mosaic so
+    far and the *completed* tally. Rendering both put two different bars in one place —
+    `acquiring` draws a countdown scaled in tenths of a second and the preview drew
+    tiles, so the fill jumped and the text changed shape at every tile boundary. Found
+    by running the app; every test here was green throughout.
+    """
+    router = _Router()
+    router._apply_progress({
+        "modality": "fluorescence", "state": "acquiring", "task": "tileset",
+        "counter": 2, "total": 4,
+        "estimated_remaining_time": 18.0, "estimated_total_time": 24.0,
+    })
+    before = (_bar(router.progress_tiles).value(),
+              _bar(router.progress_tiles).maximum(),
+              _bar(router.progress_tiles).format())
+
+    router._apply_progress({
+        "modality": "fluorescence", "state": "tile", "task": "tileset",
+        "counter": 2, "total": 4,
+    })
+
+    after = (_bar(router.progress_tiles).value(),
+             _bar(router.progress_tiles).maximum(),
+             _bar(router.progress_tiles).format())
+    assert after == before, "the preview payload redrew the bar on a different scale"
+    assert "remaining" in after[2], "the estimate was dropped"
+
+
+def test_the_preview_is_still_shown(qapp):
+    """The filter above must not cost the thing the payload is actually for."""
+    shown = []
+    router = _Router()
+    router._show_preview = shown.append
+
+    payload = {
+        "modality": "fluorescence", "state": "tile", "task": "tileset",
+        "counter": 2, "total": 4,
+    }
+    router._apply_progress(payload)
+
+    assert shown == [payload]


### PR DESCRIPTION
Reported from running the app: the tile bar "seems to be getting two kinds of updates, tile progress and time remaining, and flicking between them".

It is. Both payloads a tile emits carry counts, and `_apply_tile_progress` rendered both — so two different bars shared one widget and alternated at every tile boundary.

Captured from a real 2×2 run, before:

```
     state  has ETA  value    max  format
 acquiring      yes      0    242  'Tiles — 1/4 · 24s remaining'
      tile       no      1      4  'Tiles — 1 / 4'
 acquiring      yes     52    242  'Tiles — 2/4 · 18s remaining'
      tile       no      2      4  'Tiles — 2 / 4'
```

The **scale** changes, not just the text: `acquiring` renders a countdown in tenths of a second (`52/242`), the preview renders tiles (`2/4`). So the fill jumps and the label changes shape twice per tile.

After — one scale, one shape, advancing monotonically:

```
 acquiring      yes      0    242  'Tiles — 1/4 · 24s remaining'
      tile       no      0    242  'Tiles — 1/4 · 24s remaining'
 acquiring      yes     60    242  'Tiles — 2/4 · 18s remaining'
      tile       no     60    242  'Tiles — 2/4 · 18s remaining'
```

## Why both existed

They are not the same measurement. `acquiring` names the tile *starting* and comes with an estimate; `tile` carries the mosaic so far and the *completed* tally. Neither is wrong — one bar can only show one, and the preview payload's job is the preview.

## Not from the signal move

Pre-existing. The fall-through has been there since the two bars were introduced; FIB-725 only renamed the count key it reads. Same "one key, two meanings" problem as FIB-736, from the other end.

## What this says about the tests

**Every test in this module was green throughout**, including the ones covering this exact method. They assert one payload at a time, and the defect only exists in the *sequence*.

So the regression test sends two payloads and asserts the second changes nothing. A second test asserts the preview is still delivered — the fix is a `return`, and the easy way to break it is to skip the thing the payload is actually for. Restoring the fall-through fails the first and not the second.

**5505 tests pass.**