### PR TITLE
[fix] One payload per tile carries the whole picture (FIB-736)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -881,16 +881,18 @@ class FMTiledAcquisitionRunner:
 
         self._init_preview_canvas()
 
-        first = self._ordered[0]
         self._emit({"state": "moving", "task": "tileset"})
+        # The run's opening report: nothing acquired, and how long it should take. A
+        # progress report rather than an announcement -- it carries no tile coordinates,
+        # because it is not about a tile. It used to name the first one *and* claim a
+        # count of 1, which was a tile that had not been taken; conflating the two is
+        # what left one key meaning two things (FIB-736).
+        #
+        # `total` counts tiles that will actually be acquired, not grid cells -- a
+        # progress bar that stops at 9/25 on a successful sparse run reads as a failure.
         self._emit({
             "state": "acquiring", "task": "tileset",
-            "row": first.row + 1, "col": first.col + 1,
-            "total_rows": self._rows, "total_cols": self._cols,
-            # `total` counts tiles that will actually be acquired, not grid cells --
-            # a progress bar that stops at 9/25 on a successful sparse run reads as a
-            # failure.
-            "counter": 1, "total": len(self._ordered),
+            "counter": 0, "total": len(self._ordered),
             "estimated_total_time": self._total_estimated_time,
             "estimated_remaining_time": self._total_estimated_time,
         })
@@ -1107,37 +1109,62 @@ class FMTiledAcquisitionRunner:
         one thing that does not need to be fast: at ~10 MB against a tile exposure, the
         copy does not show.
         """
+        estimated_total, estimated_remaining, elapsed = self._time_estimate()
         self._emit({
             "state": "tile", "task": "tileset",
             "row": tile.row, "col": tile.col,
             "total_rows": self._rows, "total_cols": self._cols,
+            # **Tiles completed**, which is what `counter` means on this signal -- the
+            # beam tiler increments and then emits, so its count has always meant this.
+            # The fluorescence side used to say it twice per tile with two meanings: the
+            # tile *starting* before the acquisition and the tally after. One key cannot
+            # be both, and a consumer choosing between them got a bar that changed scale
+            # at every boundary (FIB-736, FIB-739).
             "counter": self._n_acquired, "total": len(self._ordered),
+            # The estimate rides with the count rather than with the announcement below,
+            # so one payload carries the whole picture and a consumer never has to
+            # assemble progress from two.
+            "estimated_total_time": estimated_total,
+            "estimated_remaining_time": estimated_remaining,
+            "elapsed_time": elapsed,
             "image": self._preview.canvas.copy(),
             "preview_stride": self._preview.stride,
         })
 
-    def _emit_tile_progress(self, row: int, col: int) -> None:
-        # Counted by visits, not by grid index. `row * cols + col` assumed a full
-        # row-major traversal; under a spiral it jumps around, and under a mask it
-        # overcounts by every skipped tile.
-        current_tile = self._n_acquired + 1
+    def _time_estimate(self):
+        """`(total, remaining, elapsed)` for the run, from what it has done so far.
+
+        Expressed in tiles *completed*, which is what the runner actually knows. It was
+        written in terms of the tile starting -- `elapsed / (current - 1)` against
+        `total - current + 1` -- which is the same arithmetic said awkwardly, and part of
+        why the count came to mean two things.
+        """
+        elapsed = time.time() - self._acquisition_start_time
+        completed = self._n_acquired
         total_tiles = len(self._ordered)
-        elapsed_time = time.time() - self._acquisition_start_time
-
-        if current_tile > 1:
-            time_per_tile = elapsed_time / (current_tile - 1)
-            estimated_remaining_time = time_per_tile * (total_tiles - current_tile + 1)
+        if completed:
+            per_tile = elapsed / completed
+            remaining = per_tile * (total_tiles - completed)
         else:
-            estimated_remaining_time = self._total_estimated_time
+            remaining = self._total_estimated_time
+        return self._total_estimated_time, remaining, elapsed
 
+    def _emit_tile_progress(self, row: int, col: int) -> None:
+        """Announce the tile about to be acquired.
+
+        Deliberately carries **no counts and no estimate**. Those describe what the run
+        has done, and this is emitted before the tile is taken -- it could only ever
+        report one fewer than the truth, and a consumer driving a bar from it would stop
+        one short of the total for the whole run (measured; the bar ended at 3/4).
+
+        What it is for is *where we are*: the tile coordinates, and clearing the
+        "Moving stage…" label the previous payload put up. The progress arrives after
+        the tile, with the preview.
+        """
         self._emit({
             "state": "acquiring", "task": "tileset",
             "row": row + 1, "col": col + 1,
             "total_rows": self._rows, "total_cols": self._cols,
-            "counter": current_tile, "total": total_tiles,
-            "estimated_total_time": self._total_estimated_time,
-            "estimated_remaining_time": estimated_remaining_time,
-            "elapsed_time": elapsed_time,
         })
 
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -2416,16 +2416,24 @@ class FMOverviewWidget(QWidget):
             # it vanish and reappear at every tile boundary -- a flicker for the whole
             # run. The next tile's first payload overwrites it a moment later anyway.
             self._show_preview(payload)
-            # And deliberately does not fall through to the bar below. This payload
-            # delivers the mosaic so far; the count it also carries is the *completed*
-            # tally, where `acquiring` carries the tile starting and an estimate to go
-            # with it. Rendering both put two different bars in one place, alternating
-            # every tile: `acquiring` draws a countdown scaled in tenths of a second
-            # (52/242) and this drew tiles (2/4), so the fill jumped and the text
-            # changed shape at every boundary. One producer for one bar.
+
+        current, total = payload.get("counter"), payload.get("total")
+        if current is None or not total:
+            # An announcement rather than a progress report: the payload that says which
+            # tile is starting carries no counts, because emitted *before* the tile it
+            # could only ever be one short -- a bar driven from it stopped at 3/4 for the
+            # whole run (FIB-736). It has already done its job above, clearing the label
+            # the stage move put up.
+            #
+            # This is also what stops the bar flickering. Two payloads per tile used to
+            # carry counts with different meanings and different shapes, and the bar
+            # changed scale at every boundary (FIB-739); now exactly one of them does.
             return
 
-        current, total = payload.get("counter", 0), payload.get("total", 1)
+        # The final payload of a run reports 0 remaining and so renders as a plain
+        # count -- `FibsemProgressWidget` picks the shape from `remaining_seconds > 0`,
+        # not from the caller. That is the run finishing rather than a flicker: one
+        # transition at the end, where the bar is full either way.
         remaining = payload.get("estimated_remaining_time")
         # The widget renders the count itself, so the message says what is being
         # counted and nothing more -- otherwise it reads "Tile 4/9 — 4/9".

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -1320,8 +1320,13 @@ def test_progress_totals_count_enabled_tiles_not_grid_cells(fm_microscope, monke
 
     totals = {p["total"] for p in emitted if "total" in p}
     assert totals == {9}
-    counters = [p["counter"] for p in emitted if p.get("state") == "acquiring"]
-    assert counters[-1] == 9
+    # Read from the payload that reports progress rather than the one that announces a
+    # tile: `acquiring` is emitted *before* its tile and so carries no count at all --
+    # it could only ever be one short, and a bar driven from it stopped there for the
+    # whole run (FIB-736).
+    counters = [p["counter"] for p in emitted if "counter" in p]
+    assert counters[-1] == 9, "the bar never reached the last tile"
+    assert counters == sorted(counters), f"the count went backwards: {counters}"
 
 
 def test_tile_order_drives_the_visit_sequence(fm_microscope, monkeypatch):
@@ -2303,3 +2308,66 @@ def test_a_run_that_never_reaches_the_stitch_does_not_announce_one(fm_microscope
     ).run()
 
     assert "stitching" not in [p.get("state") for p in emitted]
+
+
+def test_the_count_reaches_the_last_tile(fm_microscope):
+    """The bar has to fill.
+
+    `counter` means tiles *completed*, matching the beam tiler, so the run's last
+    counted payload must equal the total. It did not when the count rode on the
+    announcement emitted *before* each tile: that can only ever report one fewer than
+    the truth, so the bar sat at 3/4 while the fourth tile was acquired and then the run
+    ended (FIB-736).
+    """
+    emitted = []
+    fm_microscope.tiled_acquisition_signal.connect(emitted.append)
+
+    acquisition.FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=[ChannelSettings(name="CH0", exposure_time=0.001)],
+        overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
+    ).run()
+
+    counted = [p for p in emitted if "counter" in p]
+    assert counted[0]["counter"] == 0, "the run claimed a tile before taking one"
+    assert counted[-1]["counter"] == counted[-1]["total"] == 4
+
+
+def test_the_announcement_carries_no_progress(fm_microscope):
+    """It is emitted before its tile, so any count or estimate on it is a claim about
+    work not yet done. Its job is saying *where* the run is."""
+    emitted = []
+    fm_microscope.tiled_acquisition_signal.connect(emitted.append)
+
+    acquisition.FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=[ChannelSettings(name="CH0", exposure_time=0.001)],
+        overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
+    ).run()
+
+    announcements = [
+        p for p in emitted
+        if p.get("state") == "acquiring" and p.get("task") == "tileset" and "row" in p
+    ]
+    assert announcements, "nothing announces the tile being acquired"
+    for payload in announcements:
+        assert "counter" not in payload
+        assert "estimated_remaining_time" not in payload
+        assert payload["row"] and payload["col"], "it should still say which tile"
+
+
+def test_every_counted_payload_carries_an_estimate(fm_microscope):
+    """One payload, the whole picture. Splitting the count from the estimate is what let
+    a consumer render two different bars in one widget (FIB-739)."""
+    emitted = []
+    fm_microscope.tiled_acquisition_signal.connect(emitted.append)
+
+    acquisition.FMTiledAcquisitionRunner(
+        microscope=fm_microscope,
+        channel_settings=[ChannelSettings(name="CH0", exposure_time=0.001)],
+        overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
+    ).run()
+
+    for payload in [p for p in emitted if p.get("counter")]:
+        assert "estimated_remaining_time" in payload
+        assert "estimated_total_time" in payload

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -4929,19 +4929,23 @@ def test_a_beam_run_does_not_drive_the_fluorescence_bar(qapp, overview_widget):
     assert _bar(widget.progress_tiles).format() == before
 
 
-def test_the_preview_payload_does_not_redraw_the_tile_bar(qapp):
+def test_the_announcement_payload_does_not_redraw_the_tile_bar(qapp):
     """One producer for one bar.
 
-    Both payloads a tile emits carry counts, and they mean different things: `acquiring`
-    names the tile *starting* and comes with an estimate, `tile` carries the mosaic so
-    far and the *completed* tally. Rendering both put two different bars in one place —
-    `acquiring` draws a countdown scaled in tenths of a second and the preview drew
-    tiles, so the fill jumped and the text changed shape at every tile boundary. Found
-    by running the app; every test here was green throughout.
+    A tile emits twice: an announcement before it -- which tile is starting -- and a
+    report after it, carrying the completed tally, the estimate and the preview. Only
+    the second describes progress, and only the second touches the bar.
+
+    Both used to carry counts, with different meanings and different shapes, so the bar
+    changed scale at every boundary: a countdown in tenths of a second against a tally
+    in tiles (FIB-739). Fixing that in this widget left the bar driven by the
+    announcement, which is emitted *before* its tile and could only ever be one short --
+    it stopped at 3/4 for the whole run (FIB-736). The announcement now carries no
+    counts at all, which settles both.
     """
     router = _Router()
     router._apply_progress({
-        "modality": "fluorescence", "state": "acquiring", "task": "tileset",
+        "modality": "fluorescence", "state": "tile", "task": "tileset",
         "counter": 2, "total": 4,
         "estimated_remaining_time": 18.0, "estimated_total_time": 24.0,
     })
@@ -4950,14 +4954,14 @@ def test_the_preview_payload_does_not_redraw_the_tile_bar(qapp):
               _bar(router.progress_tiles).format())
 
     router._apply_progress({
-        "modality": "fluorescence", "state": "tile", "task": "tileset",
-        "counter": 2, "total": 4,
+        "modality": "fluorescence", "state": "acquiring", "task": "tileset",
+        "row": 2, "col": 3, "total_rows": 2, "total_cols": 2,
     })
 
     after = (_bar(router.progress_tiles).value(),
              _bar(router.progress_tiles).maximum(),
              _bar(router.progress_tiles).format())
-    assert after == before, "the preview payload redrew the bar on a different scale"
+    assert after == before, "the announcement redrew the bar"
     assert "remaining" in after[2], "the estimate was dropped"
 
 


### PR DESCRIPTION
`counter` meant two things. The beam tiler increments and then emits, so its count has always been tiles **completed**. The fluorescence runner said it twice per tile with different meanings — the tile *starting*, before the acquisition, and the completed tally after — and split the estimate from the count onto different payloads.

That is FIB-739 seen from the other end. Fixing the flicker in the widget left the bar driven by the announcement, and **an announcement emitted before its tile can only ever report one fewer than the truth**: the bar sat at 3/4 while the fourth tile was acquired, then the run ended.

## Why the obvious fix was abandoned

Normalising `counter` to completed and leaving the payloads alone, measured on a real run:

```
 acquiring   'Tiles — 1/4 · 24s remaining'   ← from setup
 acquiring   'Tiles — 0/4 · 24s remaining'   ← goes backwards
 ...
 acquiring   'Tiles — 3/4 · 3s remaining'    ← run ends. Never fills.
```

The key was not the problem. The payload split was.

## One job each

| | carries | why |
| -- | -- | -- |
| **before** the tile | which tile is starting | a count or estimate here is a claim about work not yet done. It still clears the "Moving stage…" label, which is what it is for. |
| **after** the tile | completed, total, estimate, preview | one payload, the whole picture, so a consumer never assembles progress from two |

The run's opening payload was *both* — it named the first tile **and** claimed a count of 1, a tile that had not been taken. It is now a report of 0 done with the initial estimate, and carries no coordinates.

`_time_estimate` is the old arithmetic said plainly: it was written as `elapsed / (current - 1)` against `total - current + 1`, which is the same expression in the vocabulary that was itself the problem.

## The result

```
 acquiring      yes      0    242  'Tiles — 0/4 · 24s remaining'
      tile      yes    102    242  'Tiles — 1/4 · 13s remaining'
      tile      yes    174    242  'Tiles — 2/4 · 6s remaining'
      tile      yes    211    242  'Tiles — 3/4 · 3s remaining'
      tile       no      4      4  'Tiles — 4 / 4'
```

One scale for the whole run, monotonic, ending full. The last payload renders as a plain count because its estimate is 0 and `FibsemProgressWidget` picks the shape from that rather than from the caller — one transition at the end, where the bar is full either way. I tried forcing it and reverted: the decision is in the shared widget, so the "fix" changed nothing and only left a comment claiming otherwise.

## Tests

Two changed rather than added to, because they encoded the old contract: the FIB-739 guarantee is re-pointed — it is now the **announcement** that must not redraw the bar — and the totals test reads counted payloads rather than announcements.

Three new ones hold the contract: the count reaches the last tile and never goes backwards; announcements carry no progress; every counted payload carries its estimate.

**5508 tests pass.**