### PR TITLE
[fix] Pin fluorescence auto-contrast to the image, not to what is drawn of it

### DIFF
--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -661,6 +661,9 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         # so their reduction is computed once here rather than on every re-render.
         # Invalidated wherever `_held` is, and wherever the display cap moves.
         self._held_reduced: Dict[str, Dict[str, np.ndarray]] = {}
+        # Auto contrast limits per placed image per channel, as
+        # ``{key: {channel: (source_plane, (lo, hi))}}``. See `_auto_clim`.
+        self._held_clim: Dict[str, Dict[str, Tuple[np.ndarray, Tuple[float, float]]]] = {}
 
     def _make_canvas(self) -> FibsemCanvasBase:
         return FibsemRealSpaceCanvas()
@@ -700,6 +703,7 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         answering for a channel nothing displays.
         """
         self._held_reduced.pop(key, None)
+        self._held_clim.pop(key, None)
         return self._held.pop(key, None) is not None
 
     def clear_overviews(self) -> None:
@@ -708,6 +712,7 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
             self.canvas.remove_image(key)
         self._held.clear()
         self._held_reduced.clear()
+        self._held_clim.clear()
 
     def set_placement(self, centre: Tuple[float, float]) -> None:
         """Where the composite sits, in metres from the canvas origin.
@@ -794,6 +799,61 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         hit = cached.get(name)
         return self._reduce(planes[name]) if hit is None else hit
 
+    def _auto_clim(self, key: str, name: str, source: np.ndarray) -> Tuple[float, float]:
+        """Auto contrast limits for one channel of one placed image, computed once.
+
+        **Pinned to the whole image, not to what is drawn of it.** `composite_fm_layers`
+        takes its own percentile from whatever array it is handed, and caches that on
+        the *identity* of the array. Both are right for a live frame and wrong for a part
+        of a stored one: drawing a region would stretch the contrast to that region, and
+        every region is a fresh array, so panning would restyle the image under the
+        cursor. Held here instead, so which part is drawn cannot change how it looks.
+
+        Measured on the **stored** plane rather than the reduced one it is drawn through,
+        which is where this differs from what the widget used to do. `downsample`
+        box-averages, and averaging narrows a histogram by however much power the image
+        has at the pixel scale -- so limits taken from the reduction are limits for one
+        particular display cap, and a patch drawn at a different reduction would not
+        match them. Measured on white noise the reduced span is 0.45x the stored one; on
+        smooth structure with shot noise, which is what fluorescence data looks like, the
+        two agree to 1.00. So this is the same picture in practice and the right answer
+        in principle.
+
+        `auto_clim` strides to ~250k samples first, so reading the full plane is cheap --
+        8.6 ms for a 12632 sq uint16 mosaic. It is handed the raw array deliberately:
+        `np.asarray(..., dtype=np.float32)` on that plane costs 150 ms and 638 MB before
+        a single percentile is taken.
+
+        Keyed on the identity of the stored plane, which a recomposite does not rebuild
+        -- keying on the reduction would miss every time and cache nothing.
+        """
+        cached = self._held_clim.setdefault(key, {})
+        hit = cached.get(name)
+        if hit is not None and hit[0] is source:
+            return hit[1]
+        clim = auto_clim(np.asarray(source))
+        cached[name] = (source, clim)
+        return clim
+
+    def _pinned(
+        self, key: str, layer: FMLayer, source: np.ndarray, reduced: np.ndarray
+    ) -> FMLayer:
+        """*layer* ready to blend *reduced*, with contrast that will not drift.
+
+        A channel the user has taken off Auto keeps the limits they set -- pinning is
+        about making *automatic* contrast independent of what is on screen, not about
+        overriding a choice.
+        """
+        if not layer.autocontrast and layer.clim is not None:
+            return replace(layer, data=reduced, _clim_cache=None)
+        return replace(
+            layer,
+            data=reduced,
+            clim=self._auto_clim(key, layer.name, source),
+            autocontrast=False,
+            _clim_cache=None,
+        )
+
     def _reduce(self, plane: np.ndarray) -> np.ndarray:
         """A plane at the resolution the canvas will actually store.
 
@@ -816,8 +876,9 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         continuously. Blending the reduced planes is the same picture for the cost of the
         pixels that survive.
         """
+        key = self._composite_key
         reduced = [
-            replace(layer, data=self._reduce(layer.data), _clim_cache=None)
+            self._pinned(key, layer, layer.data, self._reduce(layer.data))
             if layer.data is not None else layer
             for layer in self._layers
         ]
@@ -850,15 +911,16 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
                 continue
             reduced = self._held_reduced.get(key) or {}
             layers = [
-                replace(
+                # Cached at hold time: a held image's planes do not change, so the
+                # reduction is the same answer on every re-render. Falls back rather
+                # than indexing, so a cache that somehow missed an entry costs time
+                # instead of raising out of a paint (FIB-329). Compared against None
+                # explicitly -- `or` on an array raises rather than testing presence.
+                self._pinned(
+                    key,
                     layer,
-                    # Cached at hold time: a held image's planes do not change, so the
-                    # reduction is the same answer on every re-render. Falls back rather
-                    # than indexing, so a cache that somehow missed an entry costs time
-                    # instead of raising out of a paint (FIB-329). Compared against None
-                    # explicitly -- `or` on an array raises rather than testing presence.
-                    data=self._reduced_plane(reduced, planes, layer.name),
-                    _clim_cache=None,
+                    planes[layer.name],
+                    self._reduced_plane(reduced, planes, layer.name),
                 )
                 for layer in self._layers
                 if layer.name in planes

--- a/tests/ui/test_fm_pinned_contrast.py
+++ b/tests/ui/test_fm_pinned_contrast.py
@@ -1,0 +1,222 @@
+"""Auto contrast belongs to a placed image, not to the part of it being drawn.
+
+`composite_fm_layers` takes its own 1st/99th percentile from whatever array it is handed,
+and caches it on that array's *identity*. Both are right for a live frame and wrong for a
+region of a stored one: a region would be stretched to itself, and every region is a
+fresh array, so the cache would miss every time. Panning a mosaic would restyle it under
+the cursor.
+
+So the limits are pinned per (placed image, channel) before anything is blended. Nothing
+in this file draws a region yet -- that is what the pinning is *for*, and it is tested
+here through `_pinned` directly so the property is established before anything depends
+on it.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.fm_canvas import FMRealSpaceCanvasWidget
+from fibsem.ui.widgets.canvas.fm_composite import auto_clim
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+# Wider than the canvas's display cap, so `_reduce` genuinely reduces and hands back a
+# *different* array. At 900 px it returns the plane unchanged, and then the reduction and
+# the plane are the same object -- which quietly satisfies a cache keyed on either one,
+# and left the slider test below unable to fail.
+SIDE = 2600
+
+
+def plane(side: int = SIDE, seed: int = 0, scale: float = 4000.0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return (rng.random((side, side)) * scale).astype(np.uint16)
+
+
+@pytest.fixture
+def widget():
+    w = FMRealSpaceCanvasWidget()
+    w.set_pixel_size(1e-7)
+    yield w
+    w.deleteLater()
+
+
+@pytest.fixture
+def clims(widget, monkeypatch):
+    """Every auto-contrast computation, counted."""
+    calls = []
+    import fibsem.ui.widgets.canvas.fm_canvas as module
+
+    def counting(data, *args, **kwargs):
+        calls.append(data.shape)
+        return auto_clim(data, *args, **kwargs)
+
+    monkeypatch.setattr(module, "auto_clim", counting)
+    return calls
+
+
+# ── the property the rest depends on ─────────────────────────────────────
+
+
+def test_a_region_is_blended_at_the_whole_images_contrast(widget):
+    """The point of the whole exercise.
+
+    A corner of an overview is dimmer than the overview; stretched to itself it would be
+    drawn as bright as the sample, so zooming in would change what the data looks like
+    rather than showing more of it.
+    """
+    bright = plane(scale=4000.0)
+    corner_px = SIDE // 8
+    bright[:corner_px, :corner_px] = (
+        np.random.default_rng(1).random((corner_px, corner_px)) * 200
+    ).astype(np.uint16)  # a dim corner
+    widget.set_channel("green", bright)
+    layer = widget.layers[0]
+
+    whole = widget._pinned("k", layer, bright, widget._reduce(bright))
+    corner = widget._pinned(
+        "k", layer, bright, widget._reduce(bright[:corner_px, :corner_px])
+    )
+
+    assert corner.clim == whole.clim
+    assert corner.autocontrast is False, "left on Auto, the blend would restretch it"
+
+
+def test_two_placed_images_keep_their_own_contrast(widget):
+    """Overviews acquired at different exposures should each be readable; one shared
+    stretch would flatten the dimmer one.
+
+    This is what the widget already did -- `_restyle_others` recomputes from each held
+    image's own planes -- so pinning must not quietly become one answer for the canvas.
+    """
+    dim, bright = plane(scale=200.0, seed=2), plane(scale=4000.0, seed=3)
+    layer = widget._upsert_layer("green", bright, "green")
+
+    first = widget._pinned("one", layer, dim, widget._reduce(dim))
+    second = widget._pinned("two", layer, bright, widget._reduce(bright))
+
+    assert first.clim != second.clim
+    assert first.clim[1] < second.clim[1]
+
+
+def test_a_channel_taken_off_auto_keeps_the_limits_that_were_set(widget):
+    """Pinning is about making *automatic* contrast independent of the view. A manual
+    choice is not something to improve on."""
+    data = plane()
+    layer = widget._upsert_layer("green", data, "green")
+    chosen = (12.0, 34.0)
+    layer.autocontrast, layer.clim, layer.manual = False, chosen, True
+
+    pinned = widget._pinned("k", layer, data, widget._reduce(data))
+
+    assert pinned.clim == chosen
+
+
+def test_the_limits_come_from_the_stored_plane_not_the_reduction(widget):
+    """Where this differs from what the widget used to do, and why.
+
+    `downsample` box-averages, so a reduction has a narrower histogram than the plane it
+    came from -- by however much power the image holds at the pixel scale. Limits taken
+    from it are therefore limits for one particular display cap, and a patch drawn at a
+    different reduction would not match them.
+
+    White noise is the extreme case and is what this asserts against, because it is the
+    only one where the two answers are far enough apart to tell them apart: the reduced
+    span comes out 0.45x the stored one. On smooth structure with shot noise -- what
+    fluorescence data actually looks like -- they agree to 1.00, which is why this is not
+    a visible change.
+    """
+    data = plane()
+
+    pinned = widget._pinned(
+        "k", widget._upsert_layer("green", data, "green"), data, widget._reduce(data)
+    )
+
+    stored = auto_clim(data)
+    assert pinned.clim == pytest.approx(stored, rel=0.02)
+    reduced = auto_clim(widget._reduce(data))
+    assert reduced != pytest.approx(stored, rel=0.02), (
+        "the two answers agree on this data, so the assertion above proves nothing"
+    )
+
+
+# ── computed once ────────────────────────────────────────────────────────
+
+
+def test_the_limits_survive_a_slider_drag(widget, clims):
+    """A recomposite rebuilds the reduced planes, so anything keyed on *those* caches
+    nothing. Keyed on the stored plane instead, which an opacity drag does not touch.
+    """
+    widget.set_channel("green", plane())
+    before = len(clims)
+
+    for opacity in (0.9, 0.8, 0.7):
+        widget.layers[0].opacity = opacity
+        widget._recomposite()
+
+    assert len(clims) == before, "recomputed the percentile on every frame of the drag"
+
+
+def test_new_pixels_under_the_same_key_are_measured_again(widget, clims):
+    """The live preview replaces a key's planes tile by tile. Holding the first tile's
+    limits for the whole run would leave the mosaic stretched to its top-left corner."""
+    widget.set_channel("green", plane(seed=4))
+    before = len(clims)
+
+    widget.set_channel("green", plane(seed=5, scale=60000.0))
+
+    assert len(clims) > before
+
+
+def test_forgetting_an_overview_forgets_its_contrast(widget):
+    """The cache is keyed by the same key the planes are, so it has to be dropped with
+    them -- otherwise a key reused for a different overview inherits the old stretch."""
+    widget.set_composite_key("first")
+    widget.set_channel("green", plane())
+    assert widget._held_clim.get("first")
+
+    widget.forget_overview("first")
+
+    assert "first" not in widget._held_clim
+
+
+def test_clearing_forgets_every_overview_s_contrast(widget):
+    for key in ("a", "b"):
+        widget.set_composite_key(key)
+        widget.set_channel("green", plane())
+    assert len(widget._held_clim) == 2
+
+    widget.clear_overviews()
+
+    assert widget._held_clim == {}
+
+
+def test_two_overviews_sharing_a_channel_do_not_evict_each_other(widget, clims):
+    """Why the cache is nested by placed image rather than flat by channel name.
+
+    Overviews are composited under one set of channels, so two of them routinely hold a
+    channel of the same name. Flat, each would overwrite the other's entry and every
+    recomposite would recompute both -- correct, because the entry carries the plane it
+    was measured from, but paying the percentile per image per frame is exactly the cost
+    this cache exists to remove.
+    """
+    for key, seed in (("first", 6), ("second", 7)):
+        widget.set_composite_key(key)
+        widget.set_channel("green", plane(seed=seed))
+    before = len(clims)
+
+    for opacity in (0.9, 0.8):
+        widget.layers[0].opacity = opacity
+        widget._recomposite()
+
+    assert len(clims) == before


### PR DESCRIPTION
Step 1 of 3 for FIB-414 (FIB-743). Not a speedup — the precondition that makes drawing a *region* of a placed overview possible at all. Step 2 (the detail source itself, FIB-745) stacks on this.

## The problem

`composite_fm_layers` takes its own 1st/99th percentile from whatever array it is handed, and caches that on the array's **identity**. Both are right for a live frame and wrong for a part of a stored one:

- a region would be stretched to itself, so a dim corner would be drawn as bright as the sample — zooming in would change what the data looks like rather than showing more of it;
- every region is a fresh array, so the cache would miss on every fetch.

Panning a mosaic would restyle it under the cursor.

## The change

Auto limits held per (placed image, channel), computed once, passed to the blend explicitly. A channel the user has taken off Auto keeps the limits they set. Keyed on the identity of the **stored** plane, not the reduction — a recomposite rebuilds the reduction every time, so a cache keyed on that would miss on every frame and cache nothing.

## The one behaviour change, and how much it moves

Limits are measured on the stored plane rather than the reduction it is drawn through. `downsample` **box-averages**, and averaging narrows a histogram by however much power the image holds at the pixel scale — so limits taken from a reduction are limits for one particular display cap, and a patch drawn at a different reduction would not match them.

| data | reduced span / stored span | max Δ in the composite | pixels differing > 2/255 |
| --- | --- | --- | --- |
| smooth blobs + Poisson shot noise | 1.00 | 1/255 | 0.00% |
| smooth blobs, clean | 1.00 | 1/255 | 0.00% |
| white noise | 0.45 | 70/255 | 31% |

White noise is not an image. Anything with spatial structure is unchanged.

**The raw array is passed deliberately.** `auto_clim` strides to ~250k samples before taking a percentile, so reading a full 12,632² uint16 plane costs 8.6 ms — where `np.asarray(..., dtype=np.float32)` first, which is what `composite_fm_layers` does internally, would cost 150 ms and 638 MB before a single percentile is taken.

## What it is worth on its own

About 7%, and worth saying plainly rather than dressing up.

| overviews placed (3 ch, 5000²) | before | after |
| --- | --- | --- |
| 1 | 233 ms/frame | 224 |
| 3 | 673 | 637 |
| 5 | 1105 | 1027 |

The percentile was never the bottleneck; the reduce and the blend are, and those belong to step 2.

## Testing

`tests/ui/test_fm_pinned_contrast.py`, 9 tests. Six mutations, each caught: clim pinned but `autocontrast` left on; the manual-contrast guard removed; the cache keyed so it never hits; the cache ignoring whether the plane changed; one flat cache instead of per-image; limits measured on the reduction.

One test needed fixing before it could fail — at 900 px the plane is under the display cap, so `_reduce` returns it unchanged and the reduction *is* the plane, which quietly satisfies a cache keyed on either.

Full `tests/ui` sweep: 1931 passed, 1 pre-existing skip.