### PR TITLE
[perf] Draw the part of an FM overview that is on screen, at the screen's size

### DIFF
--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -45,7 +45,11 @@ from fibsem.ui.widgets.canvas.fm_composite import (
 from fibsem.imaging.reduce import downsample
 from fibsem.ui.widgets.canvas.canvas_base import FibsemCanvasBase
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
-from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
+from fibsem.ui.widgets.canvas.real_space_canvas import (
+    WHOLE_IMAGE,
+    FibsemRealSpaceCanvas,
+    ImageRegion,
+)
 
 if TYPE_CHECKING:
     from fibsem.fm.structures import FluorescenceImage
@@ -286,7 +290,7 @@ class FMCanvasWidget(QWidget):
         self.canvas._reposition_overlay_buttons()
 
         self._panel = FMLayersPanel(self)
-        self._panel.changed.connect(self._recomposite)
+        self._panel.changed.connect(self._restyle)
         self._panel.hide()
 
     # ── public API ────────────────────────────────────────────────────────
@@ -474,6 +478,16 @@ class FMCanvasWidget(QWidget):
         }
         self._show_composite(rgb, reshaped)
 
+    def _restyle(self) -> None:
+        """Redraw under the current layer settings, the pixels being unchanged.
+
+        Separate from :meth:`_recomposite` because the two are different questions that
+        happened to have the same answer here. New pixels have to be blended; a colour,
+        opacity or gamma edit only has to be *shown*, and a subclass that draws part of
+        what it holds can answer that without blending everything it holds first.
+        """
+        self._recomposite()
+
     def _show_composite(self, rgb: np.ndarray, reshaped: bool) -> None:
         """Put the blended RGB frame on the canvas.
 
@@ -657,10 +671,6 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         # Channel planes of everything placed, so a layer change can re-render images
         # composited long ago. Only the newest is in `_layers`; the rest are here.
         self._held: Dict[str, Dict[str, np.ndarray]] = {}
-        # The same planes at display resolution. Held images do not change while held,
-        # so their reduction is computed once here rather than on every re-render.
-        # Invalidated wherever `_held` is, and wherever the display cap moves.
-        self._held_reduced: Dict[str, Dict[str, np.ndarray]] = {}
         # Auto contrast limits per placed image per channel, as
         # ``{key: {channel: (source_plane, (lo, hi))}}``. See `_auto_clim`.
         self._held_clim: Dict[str, Dict[str, Tuple[np.ndarray, Tuple[float, float]]]] = {}
@@ -674,7 +684,7 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         Several images share one set of controls here, so a channel dropped from the
         newest is not dropped from the canvas -- an earlier overview may well have it.
         Removing the control would leave that overview with a channel nothing can
-        style, and `_restyle_others` would quietly stop drawing it: acquire a
+        style, and its detail source would quietly stop drawing it: acquire a
         one-channel overview and the two-channel one beside it loses a colour.
         """
         return any(name in planes for planes in self._held.values())
@@ -698,11 +708,10 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         """Drop the channel planes held for one image. False if none were held.
 
         The counterpart to the canvas's `remove_image`, and it has to be called with it:
-        the planes are what `_restyle_others` re-renders from, so keeping them for an
-        image no longer placed leaks the pixels and leaves `_channel_still_shown`
-        answering for a channel nothing displays.
+        the planes are what `_patch` draws from, so keeping them for an image no longer
+        placed leaks the pixels and leaves `_channel_still_shown` answering for a channel
+        nothing displays.
         """
-        self._held_reduced.pop(key, None)
         self._held_clim.pop(key, None)
         return self._held.pop(key, None) is not None
 
@@ -711,7 +720,6 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         for key in list(self._held):
             self.canvas.remove_image(key)
         self._held.clear()
-        self._held_reduced.clear()
         self._held_clim.clear()
 
     def set_placement(self, centre: Tuple[float, float]) -> None:
@@ -753,21 +761,13 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         covers = None
         if self._shape:
             covers = (self._shape[1] * self._pixel_size, self._shape[0] * self._pixel_size)
-        # Keep this image's planes, so a later layer change can re-render it once its
-        # channels are no longer the ones in `_layers`. Reduced once here rather than on
-        # every re-render: these are held at *acquisition* resolution -- a stitched 10x10
-        # mosaic is 10240px square per channel -- and they do not change while they are
-        # held, so re-reducing them per re-render is the same answer computed repeatedly.
-        # That cost nothing while the reduction was a strided view and is 9 ms a plane
-        # now it averages; `_restyle_others` runs it for every held image on every layer
-        # change, so it multiplied by both counts at once.
+        # Keep this image's planes at *acquisition* resolution: they are what `_patch`
+        # slices, so how far a zoom can go is set by what is kept here. No reduction is
+        # cached beside them -- the canvas holds the patch it last fetched and refetches
+        # only when the view outgrows it, so a second cache would answer a question
+        # nothing asks.
         self._held[key] = {
             layer.name: layer.data for layer in self._layers if layer.data is not None
-        }
-        self._held_reduced[key] = {
-            name: reduced
-            for name, reduced in self._blended_planes.items()
-            if name in self._held[key]
         }
         # Placed over other images rather than over a background, so it goes on as
         # colour plus coverage: an opaque frame hides whatever it covers, including
@@ -784,20 +784,80 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
                 # Ordered by the *acquired* pixel size: how much detail an image holds
                 # is a property of the data, not of the blend.
                 zorder=self._detail_zorder(self._pixel_size),
+                # Bound to the key, and held by the canvas for as long as the image is
+                # placed, so dropping the image drops the source with it. `rgb` above is
+                # the whole image at the display cap -- the same answer this would give
+                # for `WHOLE_IMAGE` -- so it stands as the first patch and nothing is
+                # blended twice to get started.
+                detail=lambda region, max_px, key=key: self._patch(key, region, max_px),
             )
         else:
             self.canvas.update_image(key, placed)
-        self._restyle_others(key)
+        # Everything else placed is restyled through its own source, which asks only
+        # about images the viewport actually intersects. `_restyle_others` re-blended
+        # every held image whether it was on screen or not, which is where five
+        # overviews cost five blends a frame.
+        self.canvas.refresh_detail(force=True)
 
-    def _reduced_plane(
-        self,
-        cached: Dict[str, np.ndarray],
-        planes: Dict[str, np.ndarray],
-        name: str,
-    ) -> np.ndarray:
-        """A held plane at display resolution, from the cache when it is there."""
-        hit = cached.get(name)
-        return self._reduce(planes[name]) if hit is None else hit
+    def _restyle(self) -> None:
+        """A layer edit changes no pixels, so there is nothing to blend up front.
+
+        The base re-blends everything it holds and re-places it. Here the canvas asks
+        each source for the part of its image that is on screen, at the resolution the
+        screen can use, and skips the images that are not on screen at all.
+        """
+        self.canvas.refresh_detail(force=True)
+
+    def _patch(
+        self, key: str, region: ImageRegion, max_px: int
+    ) -> Optional[Tuple[np.ndarray, ImageRegion]]:
+        """The part of a placed overview *region* names, blended, at most *max_px* across.
+
+        What the canvas asks for as the view moves. The blend runs **at patch
+        resolution** rather than over a finished composite, which is the inversion
+        `_composite_inputs` already makes for a different reason: reducing first and
+        blending second costs the pixels that survive rather than the pixels held.
+
+        Snapped outward to whole stored pixels, and the region *actually* covered is
+        returned rather than the one asked for -- the canvas draws the patch over the
+        rectangle this names, and a fractional-pixel disagreement between the two would
+        show as a seam every time the view moved.
+
+        Contrast comes from `_pinned`, so it belongs to the image rather than to this
+        region of it. Without that a dim corner would be stretched to itself and drawn as
+        bright as the sample.
+        """
+        planes = self._held.get(key)
+        if not planes:
+            return None
+        layers = [layer for layer in self._layers if layer.name in planes]
+        if not layers:
+            return None
+
+        height, width = planes[layers[0].name].shape[:2]
+        x0 = min(max(0, int(np.floor(region.left * width))), width - 1)
+        y0 = min(max(0, int(np.floor(region.top * height))), height - 1)
+        x1 = min(width, max(int(np.ceil(region.right * width)), x0 + 1))
+        y1 = min(height, max(int(np.ceil(region.bottom * height)), y0 + 1))
+
+        blended = [
+            self._pinned(
+                key,
+                layer,
+                planes[layer.name],
+                downsample(planes[layer.name][y0:y1, x0:x1], max_px),
+            )
+            for layer in layers
+        ]
+        # Shape passed explicitly so hiding every channel yields black rather than
+        # nothing: `to_rgba` turns black into transparent, which is the image
+        # disappearing. Declining here would leave the last patch drawn instead.
+        rgb = composite_fm_layers(blended, blended[0].data.shape[:2])
+        if rgb is None:
+            return None
+        return to_rgba(rgb), ImageRegion(
+            x0 / width, x1 / width, y0 / height, y1 / height
+        )
 
     def _auto_clim(self, key: str, name: str, source: np.ndarray) -> Tuple[float, float]:
         """Auto contrast limits for one channel of one placed image, computed once.
@@ -896,44 +956,6 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         behind whatever was taken at higher resolution over it.
         """
         return -pixel_size * 1e9  # nanometres/px, negated: smaller pixels draw on top
-
-    def _restyle_others(self, current: str) -> None:
-        """Re-render everything except *current* under the present layer settings.
-
-        Layers are display state shared by everything placed; the pixels are not. So a
-        colour or contrast change has to be applied to each held image's own planes,
-        which is why they are kept. Without this, changing a channel's colour would
-        recolour the newest overview and leave the others as they were — the same data
-        drawn two different ways, side by side.
-        """
-        for key, planes in self._held.items():
-            if key == current or key not in self.canvas.placed_keys:
-                continue
-            reduced = self._held_reduced.get(key) or {}
-            layers = [
-                # Cached at hold time: a held image's planes do not change, so the
-                # reduction is the same answer on every re-render. Falls back rather
-                # than indexing, so a cache that somehow missed an entry costs time
-                # instead of raising out of a paint (FIB-329). Compared against None
-                # explicitly -- `or` on an array raises rather than testing presence.
-                self._pinned(
-                    key,
-                    layer,
-                    planes[layer.name],
-                    self._reduced_plane(reduced, planes, layer.name),
-                )
-                for layer in self._layers
-                if layer.name in planes
-            ]
-            if not layers:
-                continue
-            shape = layers[0].data.shape[:2]
-            rgb = composite_fm_layers(layers, shape)
-            if rgb is not None:
-                # Same transform as the image that triggered this: these are placed
-                # over each other too, and re-rendering one opaque would put back the
-                # occlusion `_show_composite` just avoided.
-                self.canvas.update_image(key, to_rgba(rgb))
 
     def set_pixel_size(self, pixel_size: Optional[float]) -> None:
         """Record the scale without touching the canvas's own.

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -182,6 +182,12 @@ class PlacedImage:
     # request against what arrived rather than against what was requested makes every
     # patch look deficient, and re-asking returns the identical array, forever.
     asked_px: int = 0
+    # The source's own content changed under the patch, so what is drawn is out of date
+    # however well it fits the view. Set for *every* image by a forced refresh, and
+    # cleared only when that image is actually redrawn -- an image off screen when the
+    # change happened keeps the flag until it comes back, which is the whole point of it
+    # (see `refresh_detail`).
+    stale: bool = False
 
 
 class FibsemRealSpaceCanvas(FibsemCanvasBase):
@@ -374,6 +380,9 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         if placed.drawn != WHOLE_IMAGE:
             placed.artist.set_extent(placed.extent)
         placed.drawn, placed.asked_px = WHOLE_IMAGE, int(max(shown.shape[:2]))
+        # The whole of the current image is in the artist, so nothing is out of date --
+        # even if this ran while the image was off screen and no patch follows.
+        placed.stale = False
         if placed.detail is not None:
             # Scheduled, not immediate: this is the per-frame call during a live
             # acquisition, and fetching synchronously on each frame is the cost the
@@ -584,12 +593,23 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         a contrast curve, a re-blend, a new frame — which the view knows nothing about,
         so none of the usual tests would notice.
 
+        *force* marks every source's patch stale, not only the ones it can redraw now.
+        An image off screen cannot be redrawn — there is no region to fetch — and if the
+        flag were not left set, the next pan back to it would find a patch that covers
+        the viewport at the right resolution and keep it, styled the way it was before
+        the change. That is a restyle silently not applying to part of the canvas, which
+        is exactly the failure the caller used *force* to avoid.
+
         Deliberately *not* a content change: an image's footprint is unchanged by which
         part of it is in the artist, so nothing here refits, and `PlacedImage.extent`
         stays the whole image throughout. That is what keeps this from chasing its own
         tail -- a refit would move the limits, which would schedule another refresh.
         """
         changed = False
+        if force:
+            for placed in self._placed.values():
+                if placed.detail is not None:
+                    placed.stale = True
         for placed in list(self._placed.values()):
             if placed.detail is None:
                 continue
@@ -607,7 +627,7 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
                 continue  # off screen: leave the last patch, it costs nothing to keep
             fetch = self._visible_region(placed, margin=_DETAIL_MARGIN) or wanted
             budget = self._detail_budget(placed, fetch)
-            if not force and not self._needs_detail(placed, wanted, fetch, budget):
+            if not placed.stale and not self._needs_detail(placed, wanted, fetch, budget):
                 continue
             try:
                 answer = placed.detail(fetch, budget)
@@ -746,6 +766,7 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
         ))
         placed.drawn = region
         placed.asked_px = budget
+        placed.stale = False
         return True
 
     def metres_to_canvas(self, x: float, y: float) -> Tuple[float, float]:

--- a/tests/ui/test_fm_detail_source.py
+++ b/tests/ui/test_fm_detail_source.py
@@ -222,3 +222,62 @@ def test_a_source_asked_about_pixels_that_are_gone_declines(widget):
     """It runs off a timer, and PyQt5 aborts the process on an exception out of a slot
     (FIB-329). Declining leaves whatever is drawn alone."""
     assert widget._patch("never-placed", WHOLE_IMAGE, 512) is None
+
+
+def test_an_overview_restyled_while_off_screen_is_right_when_you_pan_back(widget):
+    """The hole that skipping off-screen images opens, and the reason `force` marks
+    every patch stale rather than only redrawing the visible ones.
+
+    `_restyle_others` re-rendered every held image unconditionally, so this could not
+    arise. Skipping the invisible ones is what makes a layer edit cheap -- but the patch
+    an off-screen image is holding was blended under the *old* settings, and it covers
+    the viewport at the right resolution, so every test `_needs_detail` applies says to
+    keep it. Pan back at the same zoom and the overview is still the old colour while its
+    neighbour is the new one.
+
+    The beam Overview tab has the same shape in `_reapply_contrast`, so the fix is in the
+    canvas rather than here.
+    """
+    near, far = "near", "far"
+    for i, key in enumerate((near, far)):
+        widget.set_composite_key(key)
+        widget.set_placement((i * SIDE * 1.5 * 1e-7, 0.0))
+        widget.set_channels([("green", plane(), "green")])
+
+    def look_at(index):
+        centre = index * SIDE * 1.5
+        widget.canvas._ax.set_xlim(centre - SIDE / 2, centre + SIDE / 2)
+        widget.canvas._ax.set_ylim(SIDE / 2, -SIDE / 2)
+        widget.canvas.refresh_detail()
+
+    def is_red(key):
+        rgb = np.asarray(widget.canvas._placed[key].artist.get_array())
+        mean = rgb[..., :3].reshape(-1, 3).mean(axis=0)
+        return mean[0] > mean[1]
+
+    look_at(1)  # `far` gets a patch at this zoom...
+    look_at(0)  # ...and is then off screen at the same zoom
+    assert not is_red(far), "this test needs `far` to start green"
+
+    widget.layers[0].color = "red"
+    widget._panel.changed.emit()
+    look_at(1)
+
+    assert is_red(far), "panned back to an overview still styled the old way"
+    assert is_red(near)
+
+
+def test_a_redrawn_patch_stops_being_stale(widget, monkeypatch):
+    """Otherwise the flag is a one-way switch and every view change refetches forever,
+    which gives back most of what skipping the invisible ones buys. A pan the current
+    patch already covers must cost nothing."""
+    place(widget)
+    widget.canvas._ax.set_xlim(-SIDE / 2, SIDE / 2)
+    widget.canvas._ax.set_ylim(SIDE / 2, -SIDE / 2)
+    widget.canvas.refresh_detail(force=True)  # marks stale, redraws, clears
+    asked = watch_patches(widget, monkeypatch)
+
+    widget.canvas.refresh_detail()
+    widget.canvas.refresh_detail()
+
+    assert asked == [], "refetched a patch that was already the right one"

--- a/tests/ui/test_fm_detail_source.py
+++ b/tests/ui/test_fm_detail_source.py
@@ -1,0 +1,224 @@
+"""The FM canvas draws the part of an overview that is on screen, at the screen's size.
+
+Placed overviews used to be blended whole, at a fixed cap, once per placed image per
+layer change -- on screen or not. Each now carries a `DetailSource`, so the canvas asks
+for the region the viewport covers at the resolution it can use, and asks nothing at all
+of an image that is not visible.
+
+Two things follow that the fixed cap could not give: zooming in returns detail rather
+than magnifying stored pixels, and cost stops scaling with how many overviews are held.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.fm_canvas import FMRealSpaceCanvasWidget
+from fibsem.ui.widgets.canvas.fm_composite import auto_clim
+from fibsem.ui.widgets.canvas.real_space_canvas import WHOLE_IMAGE, ImageRegion
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+CHANNELS = [("red", "red"), ("green", "green")]
+# Wider than the canvas's display cap, so there is detail a whole-image draw cannot show.
+SIDE = 4096
+
+
+def plane(side: int = SIDE, seed: int = 0) -> np.ndarray:
+    return (np.random.default_rng(seed).random((side, side)) * 4000).astype(np.uint16)
+
+
+@pytest.fixture
+def widget():
+    w = FMRealSpaceCanvasWidget()
+    w.set_pixel_size(1e-7)
+    yield w
+    w.deleteLater()
+
+
+def place(widget, key="fm-composite", centre=(0.0, 0.0), seed=0):
+    widget.set_composite_key(key)
+    widget.set_placement(centre)
+    widget.set_channels([(n, plane(seed=seed + i), c) for i, (n, c) in enumerate(CHANNELS)])
+    return key
+
+
+def watch_patches(widget, monkeypatch):
+    """Every region the widget is asked to draw."""
+    asked = []
+    original = type(widget)._patch
+
+    def recording(self, key, region, max_px):
+        asked.append((key, region, max_px))
+        return original(self, key, region, max_px)
+
+    monkeypatch.setattr(type(widget), "_patch", recording)
+    return asked
+
+
+# ── the source is wired at all ───────────────────────────────────────────
+
+
+def test_a_placed_overview_carries_a_source(widget):
+    key = place(widget)
+
+    assert widget.canvas._placed[key].detail is not None
+
+
+def test_the_source_is_dropped_with_the_image(widget):
+    """It closes over the key, and the planes behind that key are what
+    `forget_overview` drops. A source outliving them would be asked to draw pixels that
+    are gone."""
+    key = place(widget)
+
+    widget.canvas.remove_image(key)
+    widget.forget_overview(key)
+
+    assert key not in widget.canvas._placed
+    assert widget._patch(key, WHOLE_IMAGE, 512) is None
+
+
+# ── what a patch is ──────────────────────────────────────────────────────
+
+
+def test_a_patch_says_which_ground_it_actually_covers(widget):
+    """Snapped outward to whole stored pixels, and the region *covered* is returned
+    rather than the one asked for. The canvas draws the patch over the rectangle this
+    names, so a fractional-pixel disagreement would show as a seam on every view change.
+    """
+    key = place(widget)
+    asked = ImageRegion(0.1234, 0.4321, 0.2345, 0.6789)
+
+    _, got = widget._patch(key, asked, 512)
+
+    # Every edge lands on a whole stored pixel. This is the assertion that bites: a
+    # source returning the region it was *asked* for satisfies "covers what was asked"
+    # trivially, and only this notices.
+    for edge, extent in ((got.left, SIDE), (got.right, SIDE),
+                         (got.top, SIDE), (got.bottom, SIDE)):
+        assert edge * extent == pytest.approx(round(edge * extent), abs=1e-9)
+
+    # Outward, strictly -- none of the asked edges falls on a pixel boundary.
+    assert got.left < asked.left and got.right > asked.right
+    assert got.top < asked.top and got.bottom > asked.bottom
+    # And by less than one stored pixel, i.e. snapped rather than padded.
+    assert (asked.left - got.left) < 1.0 / SIDE
+    assert (got.right - asked.right) < 1.0 / SIDE
+
+
+def test_zooming_in_returns_detail_rather_than_bigger_pixels(widget):
+    """The whole point. At a fixed cap a region of the image is the same stored pixels
+    magnified; through a source it is more of them."""
+    key = place(widget)
+    budget = 1024
+
+    whole, _ = widget._patch(key, WHOLE_IMAGE, budget)
+    eighth, _ = widget._patch(key, ImageRegion(0.4, 0.525, 0.4, 0.525), budget)
+
+    stored_per_output_whole = SIDE / whole.shape[0]
+    stored_per_output_eighth = (SIDE * 0.125) / eighth.shape[0]
+    assert stored_per_output_eighth < stored_per_output_whole
+
+
+def test_a_patch_is_blended_at_its_own_size(widget):
+    """Blended at patch resolution rather than cut out of a finished composite -- which
+    is what takes the cost off the size of the mosaic and onto the size of the window."""
+    key = place(widget)
+
+    patch, _ = widget._patch(key, ImageRegion(0.0, 0.25, 0.0, 0.25), 256)
+
+    assert max(patch.shape[:2]) <= 256
+
+
+def test_hiding_every_channel_makes_the_image_disappear(widget):
+    """Declining would leave the last patch drawn, so the picture would not respond.
+
+    Black composites to transparent through `to_rgba`, which over this canvas's
+    background is the image going away -- and over another image, that one showing
+    through.
+    """
+    key = place(widget)
+    for layer in widget.layers:
+        layer.visible = False
+
+    patch, _ = widget._patch(key, WHOLE_IMAGE, 512)
+
+    assert patch[..., 3].max() == 0
+
+
+def test_contrast_is_the_image_s_and_not_the_region_s(widget):
+    """End to end through the source, complementing the unit test on `_pinned`: a dim
+    corner drawn on its own must not be stretched to itself."""
+    widget.set_pixel_size(1e-7)
+    bright = plane()
+    bright[: SIDE // 8, : SIDE // 8] = (
+        np.random.default_rng(1).random((SIDE // 8, SIDE // 8)) * 150
+    ).astype(np.uint16)
+    widget.set_channel("green", bright)
+    key = widget._composite_key
+
+    whole, _ = widget._patch(key, WHOLE_IMAGE, 1024)
+    corner, _ = widget._patch(key, ImageRegion(0.0, 0.125, 0.0, 0.125), 1024)
+
+    # Alpha, not RGB: `to_rgba` divides the colour back out by alpha, so the colour
+    # channels saturate wherever there is little signal. Signal strength is the alpha.
+    assert corner[..., 3].mean() < 0.5 * whole[..., 3].mean(), (
+        "the dim corner was stretched to itself, so zooming in changed the data"
+    )
+    # And it would have been, left to itself: the corner's own limits are a fraction of
+    # the image's, so an unpinned blend would have drawn it as bright as the sample.
+    assert auto_clim(bright[: SIDE // 8, : SIDE // 8])[1] < 0.2 * auto_clim(bright)[1]
+
+
+# ── and what it does not do ──────────────────────────────────────────────
+
+
+def test_an_overview_off_screen_is_not_drawn_on_a_layer_edit(widget, monkeypatch):
+    """Where the cost of many overviews went.
+
+    `_restyle_others` re-blended every held image on every layer change, whether it was
+    on screen or not, so five overviews cost five blends per frame of a slider drag. The
+    canvas asks only the sources whose image the viewport intersects.
+    """
+    near = place(widget, key="near", centre=(0.0, 0.0), seed=0)
+    far = place(widget, key="far", centre=(1.0, 1.0), seed=9)
+    # Frame the near one only. Its footprint is about 4096 canvas px across.
+    widget.canvas._ax.set_xlim(-2048, 2048)
+    widget.canvas._ax.set_ylim(2048, -2048)
+    asked = watch_patches(widget, monkeypatch)
+
+    widget.layers[0].opacity = 0.5
+    widget._panel.changed.emit()
+
+    drawn = {key for key, _, _ in asked}
+    assert near in drawn, "the visible overview was not redrawn under the new settings"
+    assert far not in drawn, "an overview off screen was blended anyway"
+
+
+def test_a_layer_edit_does_not_re_place_the_image(widget, monkeypatch):
+    """Re-adding under the same key destroys and recreates the artist, which moves it to
+    the top of the draw order -- so adjusting a colour would silently reorder overlapping
+    overviews. The FIB/SEM side hit this first (`_reapply_contrast`)."""
+    place(widget, key="a", centre=(0.0, 0.0))
+    place(widget, key="b", centre=(2e-4, 0.0), seed=9)
+    order = list(widget.canvas.placed_keys)
+
+    widget.layers[0].gamma = 1.4
+    widget._panel.changed.emit()
+
+    assert list(widget.canvas.placed_keys) == order
+
+
+def test_a_source_asked_about_pixels_that_are_gone_declines(widget):
+    """It runs off a timer, and PyQt5 aborts the process on an exception out of a slot
+    (FIB-329). Declining leaves whatever is drawn alone."""
+    assert widget._patch("never-placed", WHOLE_IMAGE, 512) is None

--- a/tests/ui/test_fm_preview_recomposite_cost.py
+++ b/tests/ui/test_fm_preview_recomposite_cost.py
@@ -103,12 +103,25 @@ class TestOneCompositePerUpdate:
         assert np.array_equal(np.asarray(batched), np.asarray(looped))
 
 
-class TestHeldPlanesAreReducedOnce:
-    def test_re_rendering_a_held_overview_does_not_reduce_it_again(self, widget, reductions):
+class TestHeldOverviewsAreNotRedrawnWholesale:
+    """What replaced the reduced-plane cache.
+
+    Held planes used to be reduced once and kept, because `_restyle_others` re-blended
+    every held image at the display cap on every layer change. Both are gone: each placed
+    image now carries a detail source, and the canvas asks it only for the part of itself
+    on screen -- so there is nothing to cache the whole reduction *for*. See
+    `test_fm_detail_source.py` for what the source itself guarantees.
+    """
+
+    def test_placing_a_second_overview_does_not_re_reduce_the_first(
+        self, widget, reductions
+    ):
         """The dominant cost: held planes are at acquisition resolution and never change.
 
-        Place one overview, then place a second somewhere else — which re-renders the
-        first through `_restyle_others`. The first one's planes must come from the cache.
+        `_reduce` is the whole-image path, so counting it here counts exactly the work
+        the source was supposed to remove. The first overview is redrawn -- it has to be,
+        the new one may overlap it -- but through `_patch`, which reduces the visible
+        region rather than the mosaic.
         """
         widget.set_composite_key("first")
         widget.set_channels([(n, plane(seed=i), c) for i, (n, c) in enumerate(CHANNELS)])
@@ -119,28 +132,23 @@ class TestHeldPlanesAreReducedOnce:
         widget.set_channels([(n, plane(seed=i + 9), c) for i, (n, c) in enumerate(CHANNELS)])
 
         assert len(reductions) == len(CHANNELS), (
-            f"{len(reductions)} reductions placing a second overview — only the new "
-            f"one's {len(CHANNELS)} planes should be reduced. The first overview is "
-            f"held and unchanged, so re-reducing it recomputes the same answer"
+            f"{len(reductions)} whole-image reductions placing a second overview — only "
+            f"the new one's {len(CHANNELS)} planes should take that path"
         )
 
-    def test_the_cache_is_dropped_with_the_overview(self, widget):
-        """It holds full-size arrays, so a leak here is a memory leak."""
-        widget.set_composite_key("first")
+    def test_a_layer_edit_reduces_nothing_at_all(self, widget, reductions):
+        """No pixels changed, so there is nothing to blend up front -- the canvas asks
+        each source for what it can show. This is the path a slider drag takes, once per
+        mouse move."""
         widget.set_channels([(n, plane(seed=i), c) for i, (n, c) in enumerate(CHANNELS)])
-        assert widget._held_reduced.get("first")
+        reductions.clear()
 
-        widget.forget_overview("first")
+        widget.layers[0].opacity = 0.5
+        widget._panel.changed.emit()
 
-        assert "first" not in widget._held_reduced
-
-    def test_clearing_drops_every_cached_reduction(self, widget):
-        widget.set_composite_key("first")
-        widget.set_channels([(n, plane(seed=i), c) for i, (n, c) in enumerate(CHANNELS)])
-
-        widget.clear_overviews()
-
-        assert widget._held_reduced == {}
+        assert reductions == [], (
+            "a layer edit re-reduced whole planes; it should only refresh detail"
+        )
 
 
 class TestThePreviewUsesTheBatchedPath:

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -1310,3 +1310,63 @@ def test_an_image_occupying_part_of_the_canvas_is_budgeted_for_that_part():
         f"{c.display_max_px} px cap — each was priced as if it owned the canvas"
     )
     c.close()
+
+
+# ── content that changes under an image nobody is looking at ─────────────
+
+
+def test_a_forced_refresh_reaches_an_image_that_is_off_screen_later():
+    """`force` means the *sources* changed, not that the visible ones need redrawing.
+
+    An image off screen cannot be redrawn now -- there is no region to fetch -- and the
+    patch it is holding was built from the old content. Every test `_needs_detail`
+    applies then says to keep it: it covers the viewport, at the right resolution. So the
+    next pan back at the same zoom shows content from before the change, indefinitely.
+
+    Both consumers of this canvas do exactly that. `overview_widget._reapply_contrast`
+    applies a contrast curve and forces a refresh; the fluorescence canvas does the same
+    for a colour, opacity or gamma edit. Neither can reasonably know which of its images
+    the viewport happens to intersect.
+    """
+    c = _canvas(display_max_px=1024)
+    c.resize(600, 600)
+    c.show()
+    _app.processEvents()
+
+    side, span = 600, 60e-6
+    shade = {"near": 40, "far": 40}
+
+    def source(key):
+        def fetch(region, max_px):
+            n = max(1, min(max_px, int(side * (region.right - region.left))))
+            return np.full((n, n), shade[key], dtype=np.uint8), region
+        return fetch
+
+    for i, key in enumerate(("near", "far")):
+        c.add_image(
+            np.full((side, side), 40, dtype=np.uint8),
+            centre=(i * span * 1.5, 0.0), pixel_size=span / side,
+            key=key, covers=(span, span), detail=source(key),
+        )
+
+    def look_at(index):
+        centre = index * span * 1.5 / (span / side)
+        c._ax.set_xlim(centre - side / 2, centre + side / 2)
+        c._ax.set_ylim(side / 2, -side / 2)
+        _flush_detail(c)
+
+    def drawn(key):
+        return int(np.asarray(c._placed[key].artist.get_array()).mean())
+
+    look_at(1)  # `far` gets a patch at this zoom...
+    look_at(0)  # ...and is then off screen at the same zoom
+
+    shade["near"] = shade["far"] = 200
+    c.refresh_detail(force=True)
+    assert drawn("near") == 200, "the visible image did not pick up the new content"
+    assert drawn("far") == 40, "this test needs `far` to have been skipped"
+
+    look_at(1)
+
+    assert drawn("far") == 200, "panned back to an image built from the old content"
+    c.close()


### PR DESCRIPTION
Step 2 of 3 for FIB-414 (FIB-745). **Stacked on #473** — review that one first; this PR's diff against it is the second commit only.

Each placed overview now carries a `DetailSource`, so the canvas asks for the region the viewport covers at the resolution the screen can use, and asks nothing at all of an image that is not visible.

## The result

A slider drag with one overview framed and the rest off screen — 3 channels, 5000², 900 px axes:

| overviews placed | before | after |
| --- | --- | --- |
| 1 | 260 ms/frame | 83 |
| 3 | 726 | 82 |
| 5 | 1183 | **85** |

Flat in N rather than linear. That's the property that matters: PR #423's five-image cliff is removed rather than raised, and the note there about dropping `_DEFAULT_DISPLAY_PX` back to 1024 "if that bites" can be revisited on measurement instead of guesswork.

## Three changes

**`_patch(key, region, max_px)`** slices the held planes, reduces, and blends **at patch resolution** rather than cutting a region out of a finished composite — the same inversion `_composite_inputs` already makes, one step further along. It snaps outward to whole stored pixels and returns the region it *actually* covered, because the canvas draws the patch over the rectangle it names and a fractional-pixel disagreement shows as a seam on every view change.

**A layer edit is no longer a recomposite.** `_panel.changed` went straight to `_recomposite`, which blends everything held before handing the frame down — so a slider drag paid for the whole image at the display cap on every mouse move, per placed overview, on screen or not. It now reaches a `_restyle` seam the base still answers with a recomposite and the real-space widget answers by refreshing detail. This is where the flatness comes from.

**`_restyle_others` is deleted**, and with it `_held_reduced` and `_reduced_plane`. The canvas holds the patch it last fetched and refetches only when the view outgrows it, so a second cache of the whole reduction answered a question nothing asks.

## Testing

`tests/ui/test_fm_detail_source.py`, 10 tests. Five mutations, each caught: no `_restyle` override; the image placed with no source; the asked region returned instead of the covered one; the right edge truncated instead of snapped outward; no shape passed to the blend, so hiding every channel declines instead of clearing.

Two of my own tests needed fixing before they were worth anything, and both are the kind that passes for the wrong reason:

- the snap test asserted "covers what was asked", which a source returning the asked region verbatim satisfies trivially. It now asserts every edge lands on a whole stored pixel.
- the contrast test compared RGB, but `to_rgba` divides colour back out by alpha, so colour channels saturate wherever there is little signal. It compares alpha.

`TestHeldPlanesAreReducedOnce` pinned the cache this deletes, so it is rewritten around the mechanism that replaced it — one test kept for an explicitly different reason, two dropped, one added for a layer edit reducing nothing at all.

Full `tests/ui` sweep: 1940 passed, 1 pre-existing skip.

## Not in this PR

Step 3 (FIB-744, drawing a mosaic too large to hold from disk) stays blocked on FIB-672 deciding what such a mosaic is *written as*.