### PR TITLE
[feature] An Output panel on the FM Overview tab, so a run can be pointed and named

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -17,6 +17,7 @@ from PyQt5.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QSizePolicy,
+    QLineEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -36,7 +37,15 @@ from fibsem.ui.widgets.overview_grid_settings_widget import (
     OverviewGridSettingsWidget,
 )
 from fibsem.ui.fm.widgets.z_parameters_widget import ZParametersWidget
-from fibsem.ui.widgets.custom_widgets import TitledPanel, ValueComboBox
+from fibsem.ui.widgets.custom_widgets import (
+    QDirectoryLineEdit,
+    TitledPanel,
+    ValueComboBox,
+)
+from fibsem.ui.widgets.overview_acquisition_settings_widget import (
+    DEFAULT_OVERVIEW_FILENAME,
+    stamped_overview_name,
+)
 from fibsem.ui.tokens import (
     TEXT_MUTED_COLOR,
 )
@@ -179,6 +188,29 @@ class FMOverviewSettingsWidget(QWidget):
         self.zstack_panel = TitledPanel("Z-Stack", content=zstack_content)
         self.zstack_panel.add_header_widget(self.check_zstack)
 
+        # Where a run lands. Same two fields and the same rule as the FIB/SEM tab:
+        # the box holds a base name and the run stamps it with the time it started, so
+        # two runs cannot land on each other. `OverviewDestination` steps a taken name
+        # besides, which covers two runs inside the same second.
+        self.path_edit = QDirectoryLineEdit()
+        self.path_edit.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.filename_edit = QLineEdit(DEFAULT_OVERVIEW_FILENAME)
+        self.filename_edit.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.label_destination = QLabel("")
+        self.label_destination.setStyleSheet(MUTED)
+
+        output_form = QFormLayout()
+        output_form.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+        output_form.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        output_form.setContentsMargins(6, 6, 6, 6)
+        output_form.setSpacing(6)
+        output_form.addRow("Folder", self.path_edit)
+        output_form.addRow("Name", self.filename_edit)
+        output_form.addRow("", self.label_destination)
+        output_content = QWidget()
+        output_content.setLayout(output_form)
+        self.output_panel = TitledPanel("Output", content=output_content)
+
         self.label_summary = QLabel()
         self.label_summary.setStyleSheet(MUTED)
         self.label_summary.setWordWrap(True)
@@ -194,6 +226,10 @@ class FMOverviewSettingsWidget(QWidget):
         # The trailing stretch below takes the slack instead, kept here rather than left
         # to the host so the panels stay put in any container.
         layout.addWidget(self.grid)
+        # Last, and folded: the folder is set by whoever owns the experiment and the
+        # name rarely changes, so this is the panel you open when you want something
+        # other than the default rather than one you touch each run.
+        layout.addWidget(self.output_panel)
         layout.addWidget(self.label_summary)
         layout.addStretch()
 
@@ -201,10 +237,14 @@ class FMOverviewSettingsWidget(QWidget):
         # set once and then left alone, so they start folded to keep the column short.
         self.focus_panel.collapse()
         self.zstack_panel.collapse()
+        self.output_panel.collapse()
 
         # One signal for all five: the shared panel resizes the mask with the grid and
         # reports every change through `changed`.
         self.grid.changed.connect(self._on_grid_changed)
+        self.filename_edit.textChanged.connect(self._refresh_destination)
+        self.path_edit.lineEdit.textChanged.connect(self._refresh_destination)
+        self._refresh_destination()
         self.check_zstack.stateChanged.connect(self._on_zstack_toggled)
         self.combo_autofocus_mode.currentIndexChanged.connect(self._on_autofocus_changed)
         self.combo_objective_start.currentIndexChanged.connect(self._on_any_change)
@@ -373,6 +413,40 @@ class FMOverviewSettingsWidget(QWidget):
         if not self.check_zstack.isChecked():
             return None
         return self.z_widget.z_parameters
+
+    # ── where a run lands ────────────────────────────────────────────────
+
+    def set_save_directory(self, path: Optional[str]) -> None:
+        """Where a run writes, as the host understands it.
+
+        A method rather than a box the host reaches into, matching the FIB/SEM tab: the
+        widget is handed a microscope and knows nothing about experiments, so the folder
+        arrives the same way the positions and the channels do.
+        """
+        self.path_edit.setText(str(path) if path else "")
+
+    @property
+    def save_directory(self) -> Optional[str]:
+        """The folder as it stands, which is the box rather than what the host last set:
+        a run goes where the field says, and the field is editable on purpose."""
+        return self.path_edit.text().strip() or None
+
+    @property
+    def basename(self) -> str:
+        """The name a run claims, stamped with the time it starts.
+
+        Empty falls back to the default rather than to an unnamed run: the stem is a
+        directory name, and `OverviewDestination` would otherwise be handed an empty
+        string to make a folder from.
+        """
+        return stamped_overview_name(
+            self.filename_edit.text().strip() or DEFAULT_OVERVIEW_FILENAME
+        )
+
+    def _refresh_destination(self) -> None:
+        """Say what the run will actually be called, since the box does not show it."""
+        name = self.filename_edit.text().strip() or DEFAULT_OVERVIEW_FILENAME
+        self.label_destination.setText(f"saved as {name}-HH-MM-SS")
 
     @property
     def parameters(self) -> OverviewParameters:

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -278,8 +278,9 @@ class FMOverviewWidget(QWidget):
         # standalone against a simulator as often as it runs inside an experiment, and
         # inventing a directory for those runs would scatter files through whatever
         # working directory it happened to be launched from. A host that has somewhere
-        # to put them says so -- see `set_save_directory`.
-        self._save_directory: Optional[str] = None
+        # to put them says so -- see `set_save_directory`. Held in the Output panel
+        # rather than here, so that editing the folder and being told one are the same
+        # thing; `_save_directory` reads it back for the callers that only want a path.
         self._destination: Optional[OverviewDestination] = None
         self._saved_path: Optional[str] = None
         # Whether a run is under way, and whether a host is allowing one to be started.
@@ -1112,8 +1113,18 @@ class FMOverviewWidget(QWidget):
 
         Told rather than discovered, because this widget knows nothing about
         experiments: it is handed a microscope, and its tests construct it that way.
+
+        The host still decides the default, and the Output panel is where it lands --
+        so being told a folder and choosing one are the same field, and a later
+        `set_save_directory` (loading another experiment) replaces a choice rather than
+        being ignored behind it. That is what the FIB/SEM tab does.
         """
-        self._save_directory = path
+        self.settings_widget.set_save_directory(path)
+
+    @property
+    def _save_directory(self) -> Optional[str]:
+        """Where a run would write, as the Output panel has it."""
+        return self.settings_widget.save_directory
 
     def set_sparse_selection_enabled(self, enabled: bool) -> None:
         """Offer planning an overview by selecting on a FIB/SEM one, or do not.
@@ -2317,7 +2328,13 @@ class FMOverviewWidget(QWidget):
         if self._save_directory is None:
             return None
         try:
-            return OverviewDestination.create(self._save_directory)
+            # Stamped by the panel, the way the FIB/SEM tab stamps its filename:
+            # the stem is a directory, so two runs sharing a name land on each
+            # other. `create` steps a taken name besides, which covers the case
+            # of two runs inside the same second.
+            return OverviewDestination.create(
+                self._save_directory, self.settings_widget.basename
+            )
         except OSError as e:
             logging.error(f"Cannot save into {self._save_directory}: {e}")
             notification_service.show_toast(

--- a/fibsem/ui/widgets/overview_acquisition_settings_widget.py
+++ b/fibsem/ui/widgets/overview_acquisition_settings_widget.py
@@ -15,6 +15,7 @@ from fibsem.config import (
     DEFAULT_STANDARD_RESOLUTION,
     DEFAULT_STANDARD_RESOLUTION_LIST,
 )
+from fibsem.utils import current_timestamp_v3
 from fibsem.structures import AutoFocusMode, AutoFocusSettings, BeamType, FocusStackSettings, ImageSettings, OverviewAcquisitionSettings, TileOrderStrategy
 from fibsem.ui import stylesheets
 from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel, ValueComboBox, ValueSpinBox
@@ -33,6 +34,31 @@ from fibsem.ui.widgets.image_settings_widget import ImageSettingsWidget
 OVERVIEW_TILE_HFW = 500e-6  # m
 OVERVIEW_TILE_DWELL_TIME = 1e-6  # s
 DEFAULT_OVERVIEW_FILENAME = "overview-image"
+
+
+def stamped_overview_name(name: str) -> str:
+    """`overview-image` -> `overview-image-14-23-05`, the time the run was started.
+
+    The name is not a label, it is a location: both overview runners make the tile
+    sub-folder from it and write the stitch keyed on the same name. Two runs called the
+    same thing therefore land on each other -- the second overwrites the first's tiles
+    *and* its mosaic, and only the canvas, holding both in memory, still shows two.
+    Reloading the experiment finds one.
+
+    Time rather than date and time: the experiment directory is already dated, so inside
+    it the time of day is the whole of what distinguishes one run from another.
+
+    Applied to whatever the box says, not only to the default. A name someone typed is
+    no less prone to being reused -- more so, since a memorable name invites it -- and a
+    run that quietly replaced an earlier one is worse than a name with six digits on the
+    end. The box keeps showing the base, and the destination line reports the stamped
+    name, which is what that row is for.
+
+    Shared by both overview tabs. It lived in the FIB/SEM tab, which is 2,000 lines the
+    fluorescence side has no reason to import; here it sits beside
+    `DEFAULT_OVERVIEW_FILENAME`, which is the name it is usually applied to.
+    """
+    return f"{name}-{current_timestamp_v3(timeonly=True)}"
 
 
 def default_overview_acquisition_settings() -> OverviewAcquisitionSettings:

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -73,7 +73,6 @@ from fibsem.structures import (
     FibsemStagePosition,
     OverviewAcquisitionSettings,
 )
-from fibsem.utils import current_timestamp_v3
 from fibsem.ui import notification_service, stylesheets
 from fibsem.ui import utils as ui_utils
 from fibsem.ui.qt.threading import FunctionWorker
@@ -93,6 +92,9 @@ from fibsem.ui.tokens import (
     SEMANTIC_WARNING_COLOR,
     SLOT_COLOUR,
     STAGE_LIMITS_COLOUR,
+)
+from fibsem.ui.widgets.overview_acquisition_settings_widget import (
+    stamped_overview_name,
 )
 from fibsem.ui.widgets.canvas.contrast_gamma_control import ContrastGammaControl
 from fibsem.ui.widgets.canvas.overlays import stage_context
@@ -206,27 +208,6 @@ PICK_RADIUS_PX = 12
 # the same reason: the percentile over a full mosaic is the expensive part, and it is
 # visually identical on a subsample.
 _CLIM_SAMPLES = 250_000
-
-
-def _stamped(name: str) -> str:
-    """`overview-image` -> `overview-image-14-23-05`, the time the run was started.
-
-    The name is not a label, it is a location: `TiledAcquisitionRunner._setup` makes the
-    tile sub-folder from it and the stitch is written inside that, both keyed on the name
-    alone. Two runs called the same thing therefore land on each other -- the second
-    overwrites the first's tiles *and* its mosaic, and only the canvas, holding both in
-    memory, still shows two. Reloading the experiment finds one.
-
-    Time rather than date and time: the experiment directory is already dated, so inside
-    it the time of day is the whole of what distinguishes one run from another.
-
-    Applied to whatever the box says, not only to the default. A name someone typed is
-    no less prone to being reused -- more so, since a memorable name invites it -- and a
-    run that quietly replaced an earlier one is worse than a name with six digits on the
-    end. The box keeps showing the base, and the confirmation dialog reports the stamped
-    destination, which is what that row is for.
-    """
-    return f"{name}-{current_timestamp_v3(timeonly=True)}"
 
 
 def _contrast_limits(values: np.ndarray, acquired: np.ndarray) -> Tuple[float, float]:
@@ -2671,7 +2652,9 @@ class FibsemOverviewWidget(QWidget):
             # somewhere, and failing at the second tile with `os.path.join(None, ...)`
             # is the worst way to find out.
             settings.image_settings.path = self._save_directory or os.getcwd()
-        settings.image_settings.filename = _stamped(settings.image_settings.filename)
+        settings.image_settings.filename = stamped_overview_name(
+            settings.image_settings.filename
+        )
 
         # Where this run happens, resolved **once**, before the dialog, and handed to the
         # runner unchanged. Everything about a run then comes from one value: the plan

--- a/tests/ui/test_fm_output_panel.py
+++ b/tests/ui/test_fm_output_panel.py
@@ -1,0 +1,199 @@
+"""Where a fluorescence overview run lands, and who decides.
+
+The FIB/SEM tab has had a Folder and a Name for as long as it has had a rebuilt tab; the
+fluorescence one took a directory from its host and named every run `overview-HH-MM-SS`.
+So the two tabs wrote to different places under different rules, and only one of them
+could be pointed somewhere else.
+
+Both now hold a base name that the run stamps with the time it started, defaulting to
+`overview-image`. The stamp is not decoration: the stem is a *directory*, and two runs
+sharing one land on each other -- the second overwrites the first's tiles and its mosaic,
+and only the canvas, holding both in memory, still shows two.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import re
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.fm.widgets.fm_overview_settings_widget import FMOverviewSettingsWidget
+from fibsem.ui.widgets.overview_acquisition_settings_widget import (
+    DEFAULT_OVERVIEW_FILENAME,
+    stamped_overview_name,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+STAMPED = re.compile(r"^(?P<base>.+)-\d\d-\d\d-\d\d$")
+
+
+@pytest.fixture
+def settings():
+    w = FMOverviewSettingsWidget()
+    yield w
+    w.deleteLater()
+
+
+def base_of(name: str) -> str:
+    match = STAMPED.match(name)
+    assert match, f"{name!r} carries no time stamp"
+    return match.group("base")
+
+
+# ── the name ─────────────────────────────────────────────────────────────
+
+
+def test_it_opens_on_the_same_default_as_the_fibsem_tab(settings):
+    """One constant, not two spellings of it. The tabs write into the same experiment
+    folder, and a reader globbing `*overview*` should find both runs alike."""
+    assert settings.filename_edit.text() == DEFAULT_OVERVIEW_FILENAME
+    assert base_of(settings.basename) == DEFAULT_OVERVIEW_FILENAME
+
+
+def test_a_name_you_type_is_stamped_with_the_time(settings):
+    """Applied to whatever the box says, not only to the default -- a memorable name
+    invites being reused, so it is *more* prone to collision, not less."""
+    settings.filename_edit.setText("grid1")
+
+    assert base_of(settings.basename) == "grid1"
+
+
+def test_an_empty_name_falls_back_rather_than_making_an_unnamed_folder(settings):
+    """The stem becomes a directory name, so an empty box would ask `OverviewDestination`
+    to create a folder called nothing at all."""
+    settings.filename_edit.setText("   ")
+
+    assert base_of(settings.basename) == DEFAULT_OVERVIEW_FILENAME
+
+
+def test_the_panel_says_what_the_run_will_be_called(settings):
+    """The box keeps showing the base, so nothing else on screen would reveal that a
+    stamp is coming."""
+    settings.filename_edit.setText("grid1")
+
+    assert settings.label_destination.text() == "saved as grid1-HH-MM-SS"
+
+
+def test_an_emptied_name_previews_the_fallback_and_not_a_bare_stamp(settings):
+    """The preview has to agree with `basename`, which falls back -- otherwise the line
+    promises `-HH-MM-SS` and the run produces `overview-image-HH-MM-SS`."""
+    settings.filename_edit.setText("")
+
+    assert settings.label_destination.text() == (
+        f"saved as {DEFAULT_OVERVIEW_FILENAME}-HH-MM-SS"
+    )
+
+
+def test_both_tabs_stamp_through_the_same_helper():
+    """Structural, and the point of moving it out of the FIB/SEM tab: two copies of this
+    rule would drift, and the drift would only show up as files in the wrong place."""
+    import fibsem.ui.widgets.overview_widget as beam
+
+    assert beam.stamped_overview_name is stamped_overview_name
+    assert base_of(stamped_overview_name("x")) == "x"
+
+
+# ── the folder ───────────────────────────────────────────────────────────
+
+
+def test_the_host_s_directory_lands_in_the_field(settings):
+    """Being told a folder and choosing one are the same field. Held separately, an edit
+    would be silently outranked by whatever the host set last."""
+    settings.set_save_directory("/tmp/experiment-a")
+
+    assert settings.path_edit.text() == "/tmp/experiment-a"
+    assert settings.save_directory == "/tmp/experiment-a"
+
+
+def test_loading_another_experiment_replaces_a_folder_you_chose(settings):
+    """Deliberate, and what the FIB/SEM tab does: the folder belongs to the experiment
+    that is open, so a run after switching must not still be pointed at the old one."""
+    settings.set_save_directory("/tmp/experiment-a")
+    settings.path_edit.setText("/tmp/somewhere-else")
+
+    settings.set_save_directory("/tmp/experiment-b")
+
+    assert settings.save_directory == "/tmp/experiment-b"
+
+
+def test_no_folder_reads_as_none_rather_than_an_empty_path(settings):
+    """`None` is what the tab tests for to decide a run is unsaved; an empty string
+    would be a falsy path that still reached `makedirs`."""
+    settings.set_save_directory(None)
+
+    assert settings.save_directory is None
+
+
+# ── and what the run actually claims ─────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    return build_microscope()
+
+
+@pytest.fixture
+def widget(microscope, tmp_path):
+    from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+
+    built = FMOverviewWidget(microscope)
+    built.set_save_directory(str(tmp_path))
+    yield built
+    built.deleteLater()
+
+
+def test_a_run_claims_the_folder_and_the_name_the_panel_shows(widget, tmp_path):
+    """The end of the chain, and the only part a user can check: the panel is not a
+    display of where a run goes, it is where it goes."""
+    widget.settings_widget.filename_edit.setText("grid1")
+
+    destination = widget._claim_destination()
+
+    assert os.path.dirname(destination.tiles_directory) == str(tmp_path)
+    assert base_of(os.path.basename(destination.tiles_directory)) == "grid1"
+    # The mosaic sits beside the tile directory under the same name, so both move
+    # together when the name changes -- otherwise a renamed run splits in two.
+    assert destination.mosaic_path == f"{destination.tiles_directory}.ome.tiff"
+
+
+def test_two_runs_in_the_same_second_do_not_land_on_each_other(widget):
+    """What the stamp cannot cover on its own: it is good to the second, and a
+    single-tile overview at a short exposure takes far less."""
+    widget.settings_widget.filename_edit.setText("grid1")
+
+    first = widget._claim_destination()
+    second = widget._claim_destination()
+
+    assert first.tiles_directory != second.tiles_directory
+    assert os.path.isdir(first.tiles_directory)
+    assert os.path.isdir(second.tiles_directory)
+
+
+def test_editing_the_folder_moves_where_the_run_goes(widget, tmp_path):
+    """The reason the field is editable at all -- the host's default is a starting
+    point, not a cage."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    widget.settings_widget.path_edit.setText(str(elsewhere))
+
+    destination = widget._claim_destination()
+
+    assert os.path.dirname(destination.tiles_directory) == str(elsewhere)
+
+
+def test_with_no_folder_the_run_goes_ahead_unsaved(widget):
+    """Unchanged by this panel, and worth pinning while it is being rewired: an overview
+    you can see is worth more than no overview at all."""
+    widget.settings_widget.set_save_directory(None)
+
+    assert widget._claim_destination() is None

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -3061,8 +3061,12 @@ class TestTwoRunsCannotLandOnEachOther:
     def test_two_runs_do_not_share_a_directory(self, widget, monkeypatch, tmp_path):
         """The stamp is only worth having if it actually differs. Frozen rather than
         raced: two real runs are minutes apart, and a test that acquires twice in the
-        same second would pass for the wrong reason either way."""
-        from fibsem.ui.widgets import overview_widget as module
+        same second would pass for the wrong reason either way.
+
+        The clock is read where the stamping lives, which is now shared with the
+        fluorescence tab rather than private to this one.
+        """
+        from fibsem.ui.widgets import overview_acquisition_settings_widget as module
 
         times = iter(["14-23-05", "14-31-40"])
         monkeypatch.setattr(


### PR DESCRIPTION
FIB-749. The FIB/SEM Overview tab has had a Folder and a Name for as long as it has had a rebuilt tab; the fluorescence one took a directory from its host and named every run `overview-HH-MM-SS`. Two tabs, different places, different rules, and only one of them could be pointed elsewhere.

## What you get

Same two fields, same default, same preview line. The box holds a base name and the run stamps it with the time it started:

| typed | folder and mosaic |
| --- | --- |
| `grid1` | `grid1-14-23-05` |
| `lamella-3-before` | `lamella-3-before-14-23-05` |
| *(empty or whitespace)* | `overview-image-14-23-05` |

The panel's third row reads `saved as grid1-HH-MM-SS`, because the box keeps showing the base and nothing else on screen would reveal that a stamp is coming.

**The stamp is not decoration.** The stem is a *directory*: both runners make the tile sub-folder from it and write the stitch keyed on the same name, so two runs called the same thing land on each other — the second overwrites the first's tiles *and* its mosaic, and only the canvas, holding both in memory, still shows two. Reloading the experiment finds one. `OverviewDestination.create` steps a taken name besides (`grid1-14-23-05-2`), covering two runs starting inside the same second.

## Almost no new code

`OverviewDestination.create(root, basename)` already took a name — the fluorescence tab simply never passed one. This is a panel plus wiring.

The one change outside the FM tab: `_stamped` was private to `overview_widget.py`, 2,000 lines the fluorescence side has no reason to import. It moves to `overview_acquisition_settings_widget.py` as `stamped_overview_name`, beside `DEFAULT_OVERVIEW_FILENAME` — where that module's own comment already says the name "decides where every overview of every experiment is written". A test asserts both tabs hold the same function object: two copies of that rule would drift, and the drift would only surface as files in the wrong place.

## Three decisions worth arguing with

- **The FM default folder name changes** from `overview-HH-MM-SS` to `overview-image-HH-MM-SS`. I checked the readers before changing it — every glob in the tree is `*overview*`, so all of them still match.
- **A later `set_save_directory` replaces a folder someone typed.** The folder belongs to the experiment that is open, so a run after switching experiments must not still point at the old one. Same as the FIB/SEM tab, and there's a test naming it deliberate rather than incidental.
- **An empty name falls back rather than making an unnamed folder** — the stem becomes a directory, so an empty box would ask for a folder called nothing at all.

## Testing

13 new tests in `tests/ui/test_fm_output_panel.py`, split between the panel and what a run actually claims on disk — the panel is not a *display* of where a run goes, it is where it goes.

Four mutations, each caught: the name not stamped; the run ignoring the panel's name; an empty folder reading as `""` rather than `None`; a blank name passed through instead of falling back.

One existing FIB/SEM test is repointed rather than rewritten: it freezes the clock by patching `current_timestamp_v3` on the module that reads it, and the reading moved with the function. Its meaning is unchanged — and it failing is exactly what a move like this should cause.

Full `tests/ui`: **1960 passed**, 1 pre-existing skip. All six changed files parse under Python 3.8.