### PR TITLE
[feature] Refuse an unreachable grid in the pre-flight dialog (FIB-741)

### DIFF
--- a/fibsem/imaging/tiling/__init__.py
+++ b/fibsem/imaging/tiling/__init__.py
@@ -7,8 +7,10 @@ remain in `fibsem.imaging.tiled` for now.
 from fibsem.imaging.tiling.geometry import (
     TilePosition,
     compute_tile_grid,
+    grid_centre_offset,
     order_tiles,
     raise_if_outside_stage_limits,
+    unreachable_tiles,
     validate_tile_stage_positions,
 )
 from fibsem.imaging.tiling.plotting import (
@@ -29,6 +31,7 @@ __all__ = [
     "calculate_reprojected_stage_position",
     "calculate_reprojected_stage_position2",
     "compute_tile_grid",
+    "grid_centre_offset",
     "order_tiles",
     "plot_minimap",
     "plot_stage_positions_on_image",
@@ -37,5 +40,6 @@ __all__ = [
     "raise_if_outside_stage_limits",
     "reproject_stage_positions_onto_image",
     "reproject_stage_positions_onto_image2",
+    "unreachable_tiles",
     "validate_tile_stage_positions",
 ]

--- a/fibsem/imaging/tiling/geometry.py
+++ b/fibsem/imaging/tiling/geometry.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Iterable, List, Optional, Sequence, Tuple
+from typing import Callable, Iterable, List, Optional, Sequence, Tuple
 
 from fibsem.structures import (
     FibsemStagePosition,
@@ -246,6 +246,74 @@ def validate_tile_stage_positions(
         for tile, sp in zip(ordered, tile_stage_positions)
         if not sp.is_within_limits(limits, axes=["x", "y"])
     ]
+
+
+def grid_centre_offset(tiles: Sequence[TilePosition]) -> Tuple[float, float]:
+    """Where the grid's centre sits in the layout's own offsets, in metres.
+
+    The layout measures from the top-left tile, and both runners shift by
+    `(n - 1) * step / 2` to make the grid straddle the position it is planned around.
+    Taken from the tiles' own extent rather than recomputed from rows, columns and
+    overlap, so a caller cannot centre a grid on a step size the layout did not use.
+
+    *tiles* must be the **whole** grid, disabled ones included -- they hold its shape,
+    which is what the centring is measured from. Ordering and dropping happen after.
+    """
+    xs = [t.dx for t in tiles]
+    ys = [t.dy for t in tiles]
+    if not xs:
+        return (0.0, 0.0)
+    return ((min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2)
+
+
+def unreachable_tiles(
+    tiles: Sequence[TilePosition],
+    strategy: TileOrderStrategy,
+    project: Callable[[float, float], FibsemStagePosition],
+    limits: Optional[dict],
+) -> List[Tuple[int, int]]:
+    """Which of a planned grid's tiles the stage cannot travel to.
+
+    The question :func:`raise_if_outside_stage_limits` answers at acquire time, asked
+    early enough to be acted on -- from a pre-flight dialog, or while a grid is being
+    dragged. Through the same two helpers the runners use, `order_tiles` to drop the
+    disabled tiles and :func:`validate_tile_stage_positions` to test what is left, so
+    both sides ask about the same tiles: masking off an unreachable corner is a
+    legitimate way to make a grid acquirable, and that only works if they agree.
+
+    The runners keep the authoritative check either way, so a caller here that drifts
+    fails **open** -- the run is still refused, exactly as it is today. That is the mild
+    direction to be wrong in, and worth more than a validate-only seam in the runners.
+
+    Args:
+        tiles: the whole grid from `compute_tile_grid`, disabled tiles included.
+        strategy: the traversal. Only bears on which tiles are dropped, not on whether
+            any of them is reachable -- gone through anyway so the set asked about here
+            is the set the runner will visit, by construction.
+        project: displayed-plane offsets from the grid's centre to a stage position,
+            i.e. `StageProjection.from_plane` bound to that centre. Note the plane
+            measures y **downward** while the layout measures it up, which is why the
+            offsets handed over are negated in y. A cached projection rather than
+            `microscope.project_*_stable_move`: the two agree exactly, but the
+            microscope's re-reads the instrument on every call.
+        limits: `microscope._stage.limits`. Falsy means unknown, which reads as "no
+            answer" rather than "all fine" -- an empty result either way, but the
+            caller should say nothing rather than say it is reachable.
+
+    Returns:
+        (row, col) for each tile that will be visited and cannot be reached. Empty if
+        the grid is acquirable, if every tile is masked off, or if *limits* is unknown.
+    """
+    if not limits:
+        return []
+    ordered = order_tiles(list(tiles), strategy)
+    if not ordered:
+        return []
+    centre_dx, centre_dy = grid_centre_offset(tiles)
+    positions = [
+        project(tile.dx - centre_dx, -(tile.dy - centre_dy)) for tile in ordered
+    ]
+    return validate_tile_stage_positions(ordered, positions, limits)
 
 
 def raise_if_outside_stage_limits(

--- a/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
+++ b/fibsem/ui/fm/widgets/fm_overview_confirmation_dialog.py
@@ -11,7 +11,7 @@ there once the beam overview turned out to present its run in exactly this way. 
 left here is only the facts a fluorescence run is described by.
 """
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 from PyQt5.QtWidgets import QWidget
 
@@ -53,9 +53,10 @@ class FMOverviewConfirmationDialog(OverviewPreflightDialog):
         objective_focus: Optional[float] = None,
         tile_resolution: Optional[tuple] = None,
         save_directory: Optional[str] = None,
+        unreachable: Optional[Sequence[Tuple[int, int]]] = None,
         parent: Optional[QWidget] = None,
     ):
-        super().__init__(parent)
+        super().__init__(parent, unreachable=unreachable)
         self.parameters = parameters
         self.channel_settings = channel_settings
         self.zparams = zparams if parameters.use_zstack else None

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -55,6 +55,7 @@ from fibsem.ui.widgets.canvas.overlays.tile_grid_options_panel import (
 )
 from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, is_modality
+from fibsem.imaging.tiling import unreachable_tiles
 from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
 from fibsem.ui.widgets.canvas.overlay_controls import (
     CanvasOverlayControls,
@@ -2266,6 +2267,7 @@ class FMOverviewWidget(QWidget):
             # reason to refuse to show the dialog.
             tile_resolution=self._camera_resolution(),
             save_directory=self._save_directory,
+            unreachable=self._unreachable(parameters),
             parent=self,
         )
         if dialog.exec_() != QDialog.Accepted:
@@ -2299,6 +2301,54 @@ class FMOverviewWidget(QWidget):
         )
         self._worker = FunctionWorker(self._acquire_worker)
         self._worker.start()
+
+    def _unreachable(self, parameters: OverviewParameters) -> List[Tuple[int, int]]:
+        """Which tiles of the run about to be confirmed the stage cannot travel to.
+
+        The runner asks this too, but only once the worker has started -- after the
+        dialog has been accepted, a directory has been made and the stage has begun
+        moving. Asked here it is refused while the grid can still be moved or the
+        offending tiles masked off. It matters more on this side than on the beam one:
+        a compustage travels +/-999.9 um in x and only +/-377.8 um in y, so a grid that
+        looks square and central can be unreachable top and bottom.
+
+        Through the kept projection, for the same reason `_refresh_tile_grid` uses it
+        rather than the camera -- reading the geometry sets the shared imaging view and
+        puts it back, which is visible in the microscope's own UI.
+
+        Best effort, like `_camera_resolution` beside it: a check that cannot run leaves
+        the dialog without the warning rather than refusing to open it. The runner keeps
+        the authoritative refusal, so being wrong here fails open. The tile field of
+        view comes from the settings panel while the runner reads its own -- they track
+        the same camera, and a disagreement between them is exactly the mild direction.
+        """
+        try:
+            fov = self.settings_widget._tile_fov
+            projection = self._projection()
+            centre = self._grid_centre()
+            limits = getattr(self.microscope._stage, "limits", None)
+            if fov is None or projection is None or centre is None or not limits:
+                return []
+            height, width = projection.shape
+            tiles = compute_tile_grid_from_fov(
+                nrows=parameters.rows,
+                ncols=parameters.cols,
+                fov_x=fov[0],
+                fov_y=fov[1],
+                image_width=width,
+                image_height=height,
+                overlap=parameters.overlap,
+                mask=parameters.tile_mask,
+            )
+            return unreachable_tiles(
+                tiles,
+                parameters.tile_order,
+                lambda dx, dy: projection.from_plane(dx, dy, centre),
+                limits,
+            )
+        except Exception as e:
+            logging.debug(f"Could not check the grid against the stage limits: {e}")
+            return []
 
     def _camera_resolution(self) -> Optional[tuple]:
         """The camera's pixel dimensions, or None if it cannot be asked right now."""

--- a/fibsem/ui/widgets/overview_confirmation_dialog.py
+++ b/fibsem/ui/widgets/overview_confirmation_dialog.py
@@ -13,7 +13,7 @@ and present it identically, so both are `OverviewPreflightDialog` and what is le
 is only the facts a beam run is described by.
 """
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 from PyQt5.QtWidgets import QWidget
 
@@ -40,6 +40,7 @@ class OverviewConfirmationDialog(OverviewPreflightDialog):
         settings: OverviewAcquisitionSettings,
         view_description: Optional[str] = None,
         offset: Optional[Tuple[float, float]] = None,
+        unreachable: Optional[Sequence[Tuple[int, int]]] = None,
         parent: Optional[QWidget] = None,
     ):
         """
@@ -52,8 +53,11 @@ class OverviewConfirmationDialog(OverviewPreflightDialog):
             offset: how far the grid's centre sits from the stage, in metres (dx, dy).
                 None means it is centred on the stage, which is also what the runner
                 falls back to.
+            unreachable: (row, col) for each tile outside the stage's travel, which the
+                base class turns into a refusal. Worked out by the tab, which holds the
+                projection the check needs -- see `FibsemOverviewWidget._unreachable`.
         """
-        super().__init__(parent)
+        super().__init__(parent, unreachable=unreachable)
         self.settings = settings
         self.view_description = view_description
         self.offset = offset

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -64,6 +64,7 @@ from fibsem import constants
 from fibsem.fm.composite import auto_clim
 from fibsem.imaging import tiled
 from fibsem.imaging.reduce import downsample, downsample_mask
+from fibsem.imaging.tiling import unreachable_tiles
 from fibsem.imaging.tiling.progress import MODALITY_BEAM, is_modality
 from fibsem.microscope import FibsemMicroscope
 from fibsem.projection import BeamStageProjection
@@ -2733,9 +2734,47 @@ class FibsemOverviewWidget(QWidget):
             settings=settings,
             view_description=view.describe if view is not None else None,
             offset=self._target_offset(),
+            unreachable=self._unreachable(settings),
             parent=self,
         )
         return dialog.exec_() == QDialog.Accepted
+
+    def _unreachable(self, settings: OverviewAcquisitionSettings) -> List[Tuple[int, int]]:
+        """Which tiles of the run about to be confirmed the stage cannot travel to.
+
+        The runner asks this too, in `_compute_grid` -- but that runs on the worker,
+        after the dialog has been accepted, so the sequence a user gets is: read the
+        dialog, press Start, watch the run fail with a directory already made and the
+        stage already moving. Asked here it is refused while the grid can still be
+        moved or the offending tiles masked off.
+
+        Through the tab's cached projection rather than `microscope.project_stable_move`,
+        which the runner uses: the two agree to the bit, verified against the live call,
+        but the microscope's re-reads the scan rotation every time -- one read per tile,
+        on a dialog opening. The house rule against hardware reads on UI events
+        (FIB-544, FIB-600) is aimed at things that fire constantly rather than at an
+        explicit Acquire press, but there is no reason to pay it when the answer is
+        already held.
+
+        Best effort, like the disk estimate on the fluorescence dialog: a check that
+        cannot run leaves the dialog without the warning rather than refusing to open
+        it. The runner keeps the authoritative refusal, so being wrong here fails open.
+        """
+        try:
+            projection = self._projection(self.acquisition_view)
+            centre = self._grid_centre()
+            limits = getattr(self.microscope._stage, "limits", None)
+            if projection is None or centre is None or not limits:
+                return []
+            return unreachable_tiles(
+                tiled.compute_tile_grid(settings, mask=settings.tile_mask),
+                settings.tile_order,
+                lambda dx, dy: projection.from_plane(dx, dy, centre),
+                limits,
+            )
+        except Exception as e:
+            logger.debug(f"Could not check the grid against the stage limits: {e}")
+            return []
 
     def _target_offset(self) -> Optional[Tuple[float, float]]:
         """How far the grid's centre sits from the stage, in metres, or None for on it.

--- a/fibsem/ui/widgets/preflight.py
+++ b/fibsem/ui/widgets/preflight.py
@@ -17,7 +17,7 @@ for one caller.
 """
 
 from datetime import datetime
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
@@ -31,7 +31,7 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem.constants import DATETIME_DISPLAY_AMPM, TIME_DISPLAY_AMPM_SHORT
-from fibsem.ui import stylesheets
+from fibsem.ui import stylesheets, tokens
 from fibsem.ui.widgets.custom_widgets import ElidedLabel
 from fibsem.utils import format_time_remaining as utils_format_time_remaining
 
@@ -41,6 +41,7 @@ BORDER = stylesheets.BORDER_COLOR
 TEXT = stylesheets.TEXT_COLOR
 TEXT_STRONG = stylesheets.TEXT_STRONG_COLOR
 TEXT_MUTED = stylesheets.TEXT_MUTED_COLOR
+WARNING = tokens.SEMANTIC_WARNING_COLOR
 
 
 def format_duration(seconds: float) -> str:
@@ -228,6 +229,20 @@ def detail_block(
     return frame
 
 
+def warning_label(text: str) -> QLabel:
+    """Why the dialog will not start this run, said where it can be read.
+
+    Visible rather than only a tooltip on the disabled button. A dialog whose primary
+    action is greyed out with no reason on screen is a dead end -- the reason is the
+    whole point of refusing here rather than letting the runner refuse afterwards, and
+    hovering to find it is not reading it.
+    """
+    label = QLabel(text)
+    label.setStyleSheet(f"color: {WARNING}; font-size: 11px;")
+    label.setWordWrap(True)
+    return label
+
+
 def meta_label(text: str) -> QLabel:
     """The line that leads the dialog: what is about to happen, in one sentence.
 
@@ -256,8 +271,22 @@ class OverviewPreflightDialog(QDialog):
     describing.
     """
 
-    def __init__(self, parent: Optional[QWidget] = None):
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        unreachable: Optional[Sequence[Tuple[int, int]]] = None,
+    ):
+        """
+        Args:
+            unreachable: (row, col) for each tile the stage cannot travel to, from
+                `fibsem.imaging.tiling.unreachable_tiles`. Passed in rather than worked
+                out here: neither of these dialogs takes a microscope, which is what
+                lets them be built and tested on their own. None and empty both mean
+                nothing to say -- a caller that could not run the check says nothing
+                rather than claiming the grid is fine.
+        """
         super().__init__(parent)
+        self.unreachable: List[Tuple[int, int]] = list(unreachable or [])
         self.setWindowTitle("Start Overview Acquisition")
         self.setMinimumWidth(430)
         self.setStyleSheet(f"QDialog {{ background: {BACKGROUND}; }}")
@@ -278,8 +307,36 @@ class OverviewPreflightDialog(QDialog):
 
     # ── layout ───────────────────────────────────────────────────────────
 
+    def _refusal(self, acquired: int) -> str:
+        """Why this run cannot start, or "" if it can.
+
+        Both cases are grids the runners refuse anyway -- one with "No tiles are
+        selected", the other in `raise_if_outside_stage_limits`. Said here instead
+        because there they are said after the dialog is dismissed, and the unreachable
+        one only after a directory has been made and the stage has started moving.
+
+        Neither is fixable *in* the dialog, which is Start and Cancel. The refusal is
+        informational: it stops the run and sends you back to the canvas, where both
+        the mask and where the grid sits are set.
+        """
+        if acquired == 0:
+            return "No tiles are selected."
+        if self.unreachable:
+            count = len(self.unreachable)
+            tiles = "tile is" if count == 1 else "tiles are"
+            # A count, not the coordinates. The runner's error names them because it has
+            # nowhere else to say it; here a grid can have dozens out of range, and a
+            # list of them is not something you read and act on.
+            return (
+                f"{count} {tiles} outside the stage's travel. Turn "
+                f"{'it' if count == 1 else 'them'} off, or move the grid, "
+                "to acquire the rest."
+            )
+        return ""
+
     def _init_ui(self) -> None:
         acquired, total = self._tile_counts()
+        refusal = self._refusal(acquired)
 
         # No in-dialog heading: the window title already says "Start Overview
         # Acquisition", and repeating it 8px below costs a line and says nothing. The
@@ -315,10 +372,10 @@ class OverviewPreflightDialog(QDialog):
         layout.addWidget(meta_label(self._meta_line()))
         layout.addLayout(chips)
         layout.addWidget(detail_block(self._rows()))
+        if refusal:
+            layout.addWidget(warning_label(refusal))
         layout.addLayout(footer)
 
-        if acquired == 0:
-            # Nothing to do: both runners refuse this anyway, so say why here rather
-            # than letting it fail after the dialog is dismissed.
+        if refusal:
             self.button_start.setEnabled(False)
-            self.button_start.setToolTip("No tiles are selected.")
+            self.button_start.setToolTip(refusal)

--- a/tests/test_tiled.py
+++ b/tests/test_tiled.py
@@ -2,6 +2,7 @@ import pytest
 from matplotlib.figure import Figure
 
 from fibsem.imaging.tiled import TilePosition, _spiral_order, compute_tile_grid, order_tiles, plot_tile_positions, validate_tile_stage_positions
+from fibsem.imaging.tiling import grid_centre_offset, unreachable_tiles
 from fibsem.structures import FibsemStagePosition, ImageSettings, OverviewAcquisitionSettings, RangeLimit, TileOrderStrategy
 
 
@@ -534,3 +535,177 @@ def test_a_run_with_no_tiles_is_refused_before_it_starts(tmp_path):
 
     assert not emitted, "a refused run told consumers it had started"
     assert not list(tmp_path.iterdir()), "a refused run left a directory behind"
+
+
+# ---------------------------------------------------------------------------
+# unreachable_tiles -- the same question the runner asks, early enough to act on
+# ---------------------------------------------------------------------------
+
+
+def _identity_projection(x: float, y: float) -> FibsemStagePosition:
+    """A stage whose coordinates *are* the displayed-plane offsets.
+
+    Not a real projection -- the point of these tests is which tiles get asked about
+    and where, not the geometry that answers, which `test_beam_stage_projection.py`
+    covers. An identity keeps the limits box readable in the offsets themselves.
+    """
+    return FibsemStagePosition(x=x, y=y)
+
+
+def test_the_helper_asks_about_the_offsets_the_runner_projects(tmp_path, monkeypatch):
+    """The whole design rests on this: the dialog refuses the grids the runner would.
+
+    Compared as *offsets* rather than as positions, because that is where the two could
+    disagree -- the projection is shared already. The negation is the convention
+    crossing over: the layout measures y upward, as `project_stable_move` takes it, and
+    a displayed plane measures it down, which is what `from_plane` takes.
+
+    A tile is masked off so the comparison covers the dropping as well as the arithmetic.
+    """
+    from fibsem import utils
+
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+
+    settings = _make_settings(3, 4, overlap=0.1)
+    settings.tile_mask = [[True] * 4 for _ in range(3)]
+    settings.tile_mask[0][0] = False
+    settings.image_settings.path = str(tmp_path)
+    settings.image_settings.filename = "overview-image"
+
+    runner_offsets = []
+    real = microscope.project_stable_move
+
+    def recording(dx, dy, beam_type, base_position):
+        runner_offsets.append((dx, dy))
+        return real(dx=dx, dy=dy, beam_type=beam_type, base_position=base_position)
+
+    monkeypatch.setattr(microscope, "project_stable_move", recording)
+    runner = TiledAcquisitionRunner(microscope, settings)
+    runner._setup()
+    runner._compute_grid()
+    assert runner_offsets, "the runner projected nothing, so this compares nothing"
+
+    helper_offsets = []
+
+    def project(x, y):
+        helper_offsets.append((x, y))
+        return _identity_projection(x, y)
+
+    unreachable_tiles(
+        compute_tile_grid(settings, mask=settings.tile_mask),
+        settings.tile_order,
+        project,
+        _make_limits(),
+    )
+
+    assert helper_offsets == [(dx, -dy) for dx, dy in runner_offsets]
+
+
+def test_a_grid_within_the_travel_is_not_flagged():
+    settings = _make_settings(3, 3, hfw=100e-6, resolution=(1024, 1024))
+    tiles = compute_tile_grid(settings)
+    assert unreachable_tiles(
+        tiles, settings.tile_order, _identity_projection, _make_limits(150e-6, 150e-6)
+    ) == []
+
+
+def test_masking_off_what_cannot_be_reached_makes_a_grid_acquirable():
+    """The docstring's promise, and the reason the check goes through `order_tiles`.
+
+    A 3x3 of 100 um tiles centres on offsets of -100, 0, +100 um, so travel that stops
+    at +50 um in x puts the whole right-hand column out of range. Turning that column
+    off is a legitimate fix, and the runner treats it as one -- this is the dialog
+    agreeing.
+    """
+    settings = _make_settings(3, 3, hfw=100e-6, resolution=(1024, 1024))
+    limits = {
+        "x": RangeLimit(min=-150e-6, max=50e-6),
+        "y": RangeLimit(min=-150e-6, max=150e-6),
+    }
+
+    flagged = unreachable_tiles(
+        compute_tile_grid(settings), settings.tile_order, _identity_projection, limits
+    )
+    assert sorted(flagged) == [(0, 2), (1, 2), (2, 2)]
+
+    mask = [[True, True, False] for _ in range(3)]
+    assert unreachable_tiles(
+        compute_tile_grid(settings, mask=mask),
+        settings.tile_order,
+        _identity_projection,
+        limits,
+    ) == []
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [TileOrderStrategy.TYPEWRITER, TileOrderStrategy.SERPENTINE, TileOrderStrategy.SPIRAL],
+)
+def test_the_traversal_does_not_change_which_tiles_are_out_of_range(strategy):
+    """Order decides the sequence, not the reach. Pinned because the check goes through
+    `order_tiles` for the dropping, and it would be easy to read that as the strategy
+    mattering to the answer."""
+    settings = _make_settings(3, 3, hfw=100e-6, resolution=(1024, 1024))
+    limits = {
+        "x": RangeLimit(min=-150e-6, max=50e-6),
+        "y": RangeLimit(min=-150e-6, max=150e-6),
+    }
+    flagged = unreachable_tiles(
+        compute_tile_grid(settings), strategy, _identity_projection, limits
+    )
+    assert sorted(flagged) == [(0, 2), (1, 2), (2, 2)]
+
+
+def test_unknown_limits_are_not_projected_against():
+    """A microscope that does not report its travel is not one that can reach anywhere,
+    so nothing is flagged -- the runner still refuses the grid if it is unreachable.
+
+    Asserted on the projection never being asked, not on the empty result: an empty
+    `limits` dict makes `is_within_limits` answer True for every axis it is not given,
+    so the result is empty whether the guard is there or not. The observable difference
+    is that a caller with no limits does no work.
+    """
+    settings = _make_settings(3, 3)
+    tiles = compute_tile_grid(settings)
+
+    for limits in ({}, None):
+        projected = []
+
+        def project(x, y):
+            projected.append((x, y))
+            return _identity_projection(x, y)
+
+        assert unreachable_tiles(tiles, settings.tile_order, project, limits) == []
+        assert not projected, f"projected against {limits!r} limits"
+
+
+def test_a_grid_with_nothing_enabled_is_not_asked_about():
+    """`n_enabled_tiles == 0` is already refused, with its own message. Answering
+    "nothing is out of range" for it would be true and useless."""
+    settings = _make_settings(2, 2)
+    mask = [[False, False], [False, False]]
+    assert unreachable_tiles(
+        compute_tile_grid(settings, mask=mask),
+        settings.tile_order,
+        _identity_projection,
+        _make_limits(1e-9, 1e-9),
+    ) == []
+
+
+def test_the_centring_comes_from_the_grid_it_is_given():
+    """`(n - 1) * step / 2`, taken from the tiles rather than recomputed -- so a caller
+    cannot centre a grid on a step size the layout did not use."""
+    settings = _make_settings(3, 4, hfw=100e-6, resolution=(1024, 1024), overlap=0.1)
+    step = 100e-6 * 0.9
+    dx, dy = grid_centre_offset(compute_tile_grid(settings))
+    assert dx == pytest.approx(3 * step / 2)
+    assert dy == pytest.approx(-2 * step / 2)
+
+
+def test_the_centring_counts_disabled_tiles_too():
+    """They hold the grid's shape. Centring on only the enabled ones would move the
+    whole grid when a corner was switched off, and the run would not follow."""
+    settings = _make_settings(3, 3, hfw=100e-6, resolution=(1024, 1024))
+    dense = grid_centre_offset(compute_tile_grid(settings))
+    mask = [[True, True, False], [True, True, False], [True, True, False]]
+    assert grid_centre_offset(compute_tile_grid(settings, mask=mask)) == dense

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -240,6 +240,24 @@ def test_the_dialog_refuses_an_empty_selection(qapp):
     assert not dialog.button_start.isEnabled()
 
 
+def test_the_dialog_refuses_a_grid_the_stage_cannot_reach(qapp):
+    """The second refusal, for the same reason as the empty one: the runner rejects
+    these grids too, but from `_compute_grid` -- after the dialog has been accepted, a
+    directory made and the stage started moving (FIB-741)."""
+    dialog = _dialog(OverviewParameters(rows=3, cols=3))
+    assert dialog.button_start.isEnabled()
+
+    refused = FMOverviewConfirmationDialog(
+        parameters=OverviewParameters(rows=3, cols=3),
+        channel_settings=[ChannelSettings(name="GFP", exposure_time=0.05)],
+        tile_fov=(100e-6, 100e-6),
+        unreachable=[(0, 0), (0, 1)],
+    )
+    assert not refused.button_start.isEnabled()
+    shown = " ".join(label.text() for label in refused.findChildren(QLabel))
+    assert "2 tiles are outside the stage's travel" in shown, shown
+
+
 def test_the_dialog_estimate_reflects_the_mask(qapp):
     """A sparse run must not be quoted the duration of the full grid."""
     full = _dialog(OverviewParameters(rows=5, cols=5))
@@ -4978,3 +4996,158 @@ def test_the_preview_is_still_shown(qapp):
     router._apply_progress(payload)
 
     assert shown == [payload]
+
+
+# ── a grid beyond the stage's travel (FIB-741) ───────────────────────────
+
+
+def _runners_verdict(widget, parameters):
+    """What the runner's own route says about the same grid.
+
+    Replicates `FMTiledAcquisitionRunner._compute_grid`'s projection loop -- through
+    `microscope.project_fm_stable_move`, which reads the camera geometry on every call
+    -- so the tab's cached-projection answer is compared against the thing it is
+    standing in for, not against arithmetic repeated from the tab.
+    """
+    from fibsem.imaging.tiling import order_tiles, validate_tile_stage_positions
+    from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
+
+    fov = widget.settings_widget._tile_fov
+    projection = widget._projection()
+    height, width = projection.shape
+    tiles = compute_tile_grid_from_fov(
+        nrows=parameters.rows,
+        ncols=parameters.cols,
+        fov_x=fov[0],
+        fov_y=fov[1],
+        image_width=width,
+        image_height=height,
+        overlap=parameters.overlap,
+        mask=parameters.tile_mask,
+    )
+    step_x = fov[0] * (1 - parameters.overlap)
+    step_y = fov[1] * (1 - parameters.overlap)
+    offset_x = (parameters.cols - 1) * step_x / 2
+    offset_y = (parameters.rows - 1) * step_y / 2
+    centre = widget._grid_centre()
+    ordered = order_tiles(tiles, parameters.tile_order)
+    positions = [
+        widget.microscope.project_fm_stable_move(
+            dx=tile.dx - offset_x, dy=tile.dy + offset_y, base_position=centre
+        )
+        for tile in ordered
+    ]
+    return sorted(
+        validate_tile_stage_positions(
+            ordered, positions, widget.microscope._stage.limits
+        )
+    )
+
+
+@pytest.mark.parametrize(("rows", "cols"), [(3, 3), (11, 11), (25, 3)])
+def test_the_tab_and_the_runner_agree_on_what_cannot_be_reached(
+    qapp, interactive_widget, rows, cols
+):
+    """A compustage travels +/-999.9 um in x and only +/-377.8 um in y, so a grid that
+    looks square and central can be out of range top and bottom -- 11x11 is, 3x3 is not.
+
+    Both sizes on purpose: an agreement test where both sides say "nothing" would pass
+    against a check that never fires.
+    """
+    widget = interactive_widget
+    parameters = widget.settings_widget.parameters
+    previous = (parameters.rows, parameters.cols)
+    try:
+        parameters.rows, parameters.cols = rows, cols
+        assert sorted(widget._unreachable(parameters)) == _runners_verdict(
+            widget, parameters
+        )
+    finally:
+        parameters.rows, parameters.cols = previous
+
+
+@pytest.fixture
+def grid_of(qapp, interactive_widget):
+    """Resize the widget's grid, and put it back.
+
+    Through the settings widget rather than by mutating what `parameters` returns: that
+    property builds a fresh `OverviewParameters` on every read, so an edit to one is
+    not an edit to the widget -- and `acquire()` reads its own.
+    """
+    from copy import deepcopy
+
+    widget = interactive_widget
+    original = deepcopy(widget.settings_widget.parameters)
+
+    def resize(rows, cols):
+        from fibsem.fm.structures import ObjectiveStartPosition
+
+        parameters = deepcopy(original)
+        parameters.rows, parameters.cols = rows, cols
+        parameters.tile_mask = None
+        # Pinned rather than inherited. The widget is module-scoped, and a sibling test
+        # leaves `objective_start` on FOCUS with no focus position saved -- which
+        # `acquire()` refuses before it reaches the dialog, so these would pass alone
+        # and fail in the file.
+        parameters.objective_start = ObjectiveStartPosition.CURRENT
+        widget.settings_widget.parameters = parameters
+        qapp.processEvents()
+        return widget
+
+    yield resize
+    widget.settings_widget.parameters = original
+    qapp.processEvents()
+
+
+@pytest.fixture
+def dialogs(monkeypatch):
+    """Record the pre-flight dialog and decline it -- nothing past it has to run."""
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    shown = []
+
+    def _exec(dialog):
+        shown.append(dialog)
+        return module.QDialog.Rejected
+
+    monkeypatch.setattr(module.FMOverviewConfirmationDialog, "exec_", _exec)
+    return shown
+
+
+def test_an_out_of_range_grid_reaches_the_dialog(qapp, grid_of, dialogs):
+    """The check is only worth having if what it finds is what the dialog is handed."""
+    widget = grid_of(11, 11)
+    # A sibling test acquires with a fake worker, whose `finally` never runs -- so the
+    # FM can still be marked in use, and `acquire()` refuses before it reaches the
+    # dialog. Cleared rather than depended on: this is already false in a clean state.
+    widget.fm.set_acquiring(False)
+
+    widget.acquire()
+    qapp.processEvents()
+
+    assert len(dialogs) == 1, "the dialog did not open"
+    assert dialogs[0].unreachable, "the dialog was not told the grid is out of range"
+    assert not dialogs[0].button_start.isEnabled()
+
+
+def test_a_check_that_cannot_run_does_not_hold_up_the_fm_dialog(
+    qapp, grid_of, dialogs, monkeypatch
+):
+    """Best effort, like `_camera_resolution` beside it: failing to warn costs the
+    warning, not the run. The runner still refuses the grid."""
+    from fibsem.ui.fm.widgets import fm_overview_widget as module
+
+    def explode(*args, **kwargs):
+        raise RuntimeError("no limits today")
+
+    monkeypatch.setattr(module, "unreachable_tiles", explode)
+
+    widget = grid_of(11, 11)
+    widget.fm.set_acquiring(False)
+
+    widget.acquire()
+    qapp.processEvents()
+
+    assert len(dialogs) == 1, "the dialog did not open"
+    assert dialogs[0].unreachable == []
+    assert dialogs[0].button_start.isEnabled()

--- a/tests/ui/test_overview_confirmation_dialog.py
+++ b/tests/ui/test_overview_confirmation_dialog.py
@@ -277,6 +277,60 @@ class TestTheRunsCost:
         assert isinstance(rows["Saving to"], PathValue)
 
 
+class TestAGridTheStageCannotReach:
+    """The second refusal the dialog makes, and for the same reason as the first.
+
+    `raise_if_outside_stage_limits` already rejects these grids -- but from
+    `_compute_grid`, on the worker, after the dialog has been accepted, a directory has
+    been made and the stage has started moving. Here it is said while the grid can still
+    be moved or the offending tiles turned off (FIB-741).
+
+    Which tiles are unreachable is worked out by the tab, which holds the projection;
+    what is checked here is what the dialog does when it is told.
+    """
+
+    def test_an_unreachable_grid_cannot_be_started(self, dialog):
+        d = dialog(settings=_settings(), unreachable=[(0, 0), (0, 1)])
+        assert not d.button_start.isEnabled()
+
+    def test_a_reachable_grid_is_not_held_up(self, dialog):
+        for unreachable in (None, []):
+            d = dialog(settings=_settings(), unreachable=unreachable)
+            assert d.button_start.isEnabled(), unreachable
+            assert not any(
+                "travel" in label.text() for label in d.findChildren(QLabel)
+            ), "a reachable grid was warned about"
+
+    def test_the_reason_is_on_screen_not_only_in_a_tooltip(self, dialog):
+        """A dialog whose primary action is greyed out with no reason visible is a dead
+        end -- and the reason is the entire point of refusing here rather than letting
+        the runner refuse after the dialog is gone."""
+        d = dialog(settings=_settings(), unreachable=[(0, 0), (0, 1), (2, 2)])
+        shown = [label.text() for label in d.findChildren(QLabel)]
+        assert any("3 tiles are outside the stage's travel" in text for text in shown), shown
+        assert any("Turn them off" in text for text in shown), shown
+
+    def test_one_tile_is_not_reported_as_1_tiles(self, dialog):
+        d = dialog(settings=_settings(), unreachable=[(1, 1)])
+        assert "1 tile is outside" in d.button_start.toolTip()
+        assert "Turn it off" in d.button_start.toolTip()
+
+    def test_a_count_rather_than_the_coordinates(self, dialog):
+        """The runner's error names every tile because it has nowhere else to say it. A
+        grid can have dozens out of range, and that list is not something anyone reads
+        and acts on -- the canvas is where "which ones" gets answered."""
+        d = dialog(settings=_settings(), unreachable=[(r, c) for r in range(3) for c in range(3)])
+        assert "9 tiles are outside" in d.button_start.toolTip()
+        assert "(0,0)" not in d.button_start.toolTip()
+
+    def test_nothing_selected_is_still_the_first_thing_said(self, dialog):
+        """Both refusals at once: an empty mask is the more basic problem, and telling
+        someone to turn off tiles they have already turned off is nonsense."""
+        settings = _settings(tile_mask=[[False] * 3 for _ in range(3)])
+        d = dialog(settings=settings, unreachable=[(0, 0)])
+        assert "No tiles" in d.button_start.toolTip()
+
+
 class TestTheDurationFormatters:
     """One shape, one implementation (FIB-701)."""
 

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -34,6 +34,7 @@ from PyQt5.QtWidgets import QApplication, QDialog  # noqa: E402
 from copy import deepcopy  # noqa: E402
 
 from fibsem import utils  # noqa: E402
+from fibsem.imaging import tiled  # noqa: E402
 from fibsem.structures import (  # noqa: E402
     BeamType,
     FibsemImage,
@@ -2796,6 +2797,153 @@ class TestARunIsConfirmedFirst:
         )
         widget.acquire()
         assert confirmations[0].view_description
+
+
+class TestAGridTheStageCannotReach:
+    """Refused while it can still be fixed, rather than after Start (FIB-741).
+
+    `raise_if_outside_stage_limits` already rejects these grids, but from `_compute_grid`
+    -- on the worker, after the dialog has been accepted, a directory has been made and
+    the stage has begun moving. The sequence that produced was: read the dialog, press
+    Start, watch the run fail.
+
+    The tab repeats the runner's work rather than the runner growing a validate-only
+    entry point, so the thing worth pinning is that the two agree: what the dialog is
+    handed here is compared against what the runner actually raises, for the same
+    settings and the same centre.
+    """
+
+    def _fake_worker(self, captured):
+        def factory(fn, *args):
+            captured["args"] = args
+
+            class _W:
+                def start(self_inner):
+                    pass
+
+                def is_alive(self_inner):
+                    return False
+
+            return _W()
+
+        return factory
+
+    def _acquire(self, widget, monkeypatch, tmp_path, rows, cols):
+        captured = {}
+        widget.set_save_directory(str(tmp_path))
+        widget.settings_widget.set_grid_size(rows, cols)
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.FunctionWorker",
+            self._fake_worker(captured),
+        )
+        widget.acquire()
+        return captured
+
+    def test_a_grid_within_the_travel_is_not_warned_about(
+        self, widget, monkeypatch, tmp_path, confirmations
+    ):
+        """The default 3x3 fits an Arctis, so an unconditional warning would be noise --
+        and the check is only worth anything if it stays quiet when it should."""
+        self._acquire(widget, monkeypatch, tmp_path, 3, 3)
+        assert confirmations[0].unreachable == []
+        assert confirmations[0].button_start.isEnabled()
+
+    def test_the_dialog_refuses_exactly_what_the_runner_would(
+        self, widget, microscope, monkeypatch, tmp_path, confirmations
+    ):
+        """The whole design rests on this. A 5x5 of 500 um tiles reaches +/-600 um in y
+        against a compustage's +/-377.8 um, so the top and bottom rows are out of range.
+
+        Compared against the runner rather than against arithmetic repeated here: the
+        risk this introduces is the two drifting apart, and a test that re-derives the
+        answer cannot see that happen.
+        """
+        captured = self._acquire(widget, monkeypatch, tmp_path, 5, 5)
+        dialog = confirmations[0]
+        assert dialog.unreachable, "an out-of-range grid was not flagged"
+        assert not dialog.button_start.isEnabled()
+
+        settings, centre = captured["args"]
+        settings = deepcopy(settings)
+        settings.image_settings.path = str(tmp_path / "runner")
+        settings.image_settings.filename = "overview-image"
+        runner = tiled.TiledAcquisitionRunner(
+            microscope, settings, centre_position=deepcopy(centre)
+        )
+        runner._setup()
+        with pytest.raises(ValueError) as raised:
+            runner._compute_grid()
+
+        message = str(raised.value)
+        assert f"{len(dialog.unreachable)} tile(s) out of bounds" in message
+        for row, col in dialog.unreachable:
+            assert f"({row},{col})" in message, message
+
+    def test_turning_the_unreachable_tiles_off_makes_the_grid_acquirable(
+        self, widget, monkeypatch, tmp_path, confirmations
+    ):
+        """What the refusal tells you to do, done -- and the dialog stops objecting.
+
+        Masking is a legitimate fix because the runner drops disabled tiles before it
+        checks, and this only holds while both sides ask about the same tiles.
+        """
+        self._acquire(widget, monkeypatch, tmp_path, 5, 5)
+        flagged = confirmations[0].unreachable
+        assert flagged
+
+        # Through the widget's own finish path, not by poking `_running`: the fake
+        # worker never completes, and `acquire()` refuses a second run while one is
+        # still in flight.
+        widget._on_finished({"cancelled": False, "error": None})
+
+        mask = [[True] * 5 for _ in range(5)]
+        for row, col in flagged:
+            mask[row][col] = False
+        widget.settings_widget.tile_mask = mask
+        widget.acquire()
+
+        assert confirmations[1].unreachable == []
+        assert confirmations[1].button_start.isEnabled()
+
+    def test_a_check_that_cannot_run_does_not_hold_up_the_dialog(
+        self, widget, monkeypatch, tmp_path, confirmations
+    ):
+        """Best effort, like the fluorescence dialog's disk estimate: the run is still
+        refused by the runner, so failing to warn costs the warning, not the guard.
+        Refusing to open the dialog would cost the run."""
+
+        def explode(*args, **kwargs):
+            raise RuntimeError("no limits today")
+
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.overview_widget.unreachable_tiles", explode
+        )
+        self._acquire(widget, monkeypatch, tmp_path, 5, 5)
+        assert len(confirmations) == 1, "the dialog did not open"
+        assert confirmations[0].unreachable == []
+        assert confirmations[0].button_start.isEnabled()
+
+    def test_the_check_reads_no_hardware(
+        self, widget, microscope, monkeypatch, tmp_path, confirmations
+    ):
+        """Opening a dialog on an explicit press is not what the rule against hardware
+        reads on UI events is aimed at -- but `project_stable_move` re-reads the scan
+        rotation on every call, which would be one instrument read per tile for an
+        answer the tab already holds."""
+        calls = []
+        real = microscope.project_stable_move
+
+        def recording(*args, **kwargs):
+            # Answers properly rather than returning a stub: a stub would break the
+            # check, and the test would then fail on "the check did not run" whatever
+            # the reason. The assertion below is the one that should fire.
+            calls.append(1)
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(microscope, "project_stable_move", recording)
+        self._acquire(widget, monkeypatch, tmp_path, 5, 5)
+        assert confirmations[0].unreachable, "the check did not run"
+        assert not calls, "the dialog projected through the microscope"
 
 
 class TestTheAcquisitionButtons:


### PR DESCRIPTION
A grid with tiles outside the stage's travel is already rejected — `raise_if_outside_stage_limits`, shared by both tilers — but it fires in `_compute_grid`, which runs on the worker **after** the pre-flight dialog has been confirmed. So the sequence was: read the dialog, press Start, watch the run fail, with a directory already made and the stage already moving.

Now it is refused while the dialog is still open, where the grid can be moved or the offending tiles masked off.

The refusal is the same shape as the *"No tiles are selected"* one beside it, and now shares its code: both live in `OverviewPreflightDialog`, so the two overview tabs refuse alike (FIB-695 put the dialog there; this puts the refusal there too). It is also **on screen** rather than only in the button's tooltip — a dialog whose primary action is greyed out with no reason visible is a dead end, and the reason is the entire point of refusing here rather than letting the runner refuse after the dialog is gone.

## Asking the runner's question

`fibsem.imaging.tiling.unreachable_tiles` goes through the two helpers the runners already use — `order_tiles` to drop the disabled tiles, `validate_tile_stage_positions` to test what is left. Both sides therefore ask about the same tiles, which is load-bearing: masking off an unreachable corner is a **legitimate** way to make a grid acquirable, and that only works if the dialog and the run agree on which tiles are in.

Repeating the runner's work rather than giving the runner a validate-only entry point. The runner keeps the authoritative check either way, so a copy that drifts fails **open** — the run is still refused, exactly as it is today.

## Verified against the runner, not against arithmetic repeated here

The risk this introduces is the two drifting apart, and a test that re-derives the answer cannot see that happen. So the tests drive the real thing. A 5×5 of 500 µm tiles reaches ±600 µm in y against a compustage's ±377.8:

```
tab hands the dialog: rows 0 and 4, 10 tiles
runner raises       : "10 tile(s) out of bounds: (0,0), (0,1), ..."
```

`test_the_dialog_refuses_exactly_what_the_runner_would` runs `TiledAcquisitionRunner._compute_grid` with the settings and centre the tab handed its worker, and asserts the message names exactly the tiles the dialog listed. The fluorescence side does the same against `project_fm_stable_move`, parameterised over 3×3, 11×11 and 25×3 — the small one on purpose, since an agreement test where both sides say "nothing" would pass against a check that never fires.

The sign convention was verified rather than reasoned about: `from_plane(dx, -dy, base)` is bit-identical to `project_stable_move(dx, dy, base)` on both beams, and agrees to 2.7e-20 m on FM.

## Through the cached projection, not the microscope

Both tabs already hold a projection precisely because building one reads the instrument. Measured on the simulator:

| grid | cached projection | through the microscope |
| -- | -- | -- |
| 3×3 (9 tiles) | 0.47 ms | — |
| 5×5 (25 tiles) | 1.17 ms | — |
| 15×15 (225 tiles) | **9.5 ms** | **47 s** |

~210 ms per `project_stable_move` call — the same figure the sparse-selection dialog recorded for the fluorescence equivalent. On the instrument that is a scan-rotation read per tile, on the shared imaging channel, from the GUI thread. A test pins that the dialog never touches it.

Opening a modal on an explicit Acquire press is not what the rule against hardware reads on UI events (FIB-544, FIB-600) is aimed at, but there is no reason to pay it when the answer is already held.

## Failing open

Best effort, like the fluorescence dialog's disk estimate: a check that cannot run leaves the dialog **without** the warning rather than refusing to open it. Failing to warn costs the warning; refusing to open would cost the run.

## Tests

622 pass across the overview, dialog, fluorescence, tiling and payload suites. The eight new geometry tests run in CI — `fibsem.imaging.tiling` needs no PyQt5, and the helper is pure.

All new tests were mutation-tested. Two findings worth recording:

- one passed for the wrong reason — an empty `limits` dict makes `is_within_limits` answer True for every axis it is not given, so the result is empty whether the guard exists or not. Rewritten to assert the projection is never asked.
- one mutation silently failed to apply and read as "survived". Caught by grepping for the marker before trusting the run.

## Not in this PR

Nothing can be changed *from* this dialog — it is Start and Cancel, so the refusal is informational: it stops the run before a directory is made and sends you back to the canvas. The canvas is where a grid can actually be fixed, and it already draws the travel envelope. Flagging the offending tiles while the grid is dragged — earlier, actionable, no dialog — is **FIB-750**, along with migrating `FMTilePreview._out_of_reach`, which now duplicates this helper.
