### PR TITLE
[fix] Cyan spot burn points, lime when selected

### DIFF
--- a/fibsem/ui/widgets/spot_burn_coordinates_widget.py
+++ b/fibsem/ui/widgets/spot_burn_coordinates_widget.py
@@ -212,8 +212,8 @@ class SpotBurnCoordinatesWidget(QWidget):
         return PointsSpec(
             id=self.OVERLAY_ID,
             points=px_points,
-            color="white",
-            selected_color="cyan",
+            color="cyan",
+            selected_color="lime",
             marker="o",
             # markersize, in points. Deliberately small: fiducial patterns put spots
             # ~0.01 of the frame apart, and a larger marker merges the cluster into one


### PR DESCRIPTION
The spot burn coordinates drew white with a cyan selection. They are now cyan unselected and lime when selected.

The change is in `SpotBurnCoordinatesWidget._points_spec`, the single place the overlay spec is built, so both hosts pick it up: the lamella protocol editor (and task config editor) embed the widget directly, and the workflow reaches it through `FibsemSpotBurnWidget`.

Verified by rendering the real widget on a `LamellaEditorView` FIB canvas offscreen, with the old colours patched back in for a like-for-like comparison. Markers keep their thin white edge, so the selected point reads as lime with a white ring; the 1.4x size bump still carries most of the selection cue on a bright frame.

Tests: `test_spot_burn_coordinates_widget.py` and `test_point_overlay_colour.py` pass (19). No test asserted the old colours.