### PR TITLE
[feature] Flag the tiles the stage cannot reach while the grid is dragged (FIB-750)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -56,7 +56,7 @@ from fibsem.ui.widgets.canvas.overlays.tile_grid_options_panel import (
 from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, is_modality
 from fibsem.imaging.tiling import unreachable_tiles
-from fibsem.imaging.tiling.geometry import compute_tile_grid_from_fov
+from fibsem.imaging.tiling.geometry import TilePosition, compute_tile_grid_from_fov
 from fibsem.ui.widgets.canvas.overlay_controls import (
     CanvasOverlayControls,
     CanvasPopover,
@@ -747,16 +747,22 @@ class FMOverviewWidget(QWidget):
         # pinned to the canvas origin, which is where the stage was the *first* time
         # anything was drawn: correct until the stage moved, and then quietly not.
         offset = self._grid_offset()
-        self.tile_grid_overlay.set_anchor(
-            self.canvas.canvas.metres_to_canvas(*offset)
-        )
 
+        # Anchor and flags handed over with the grid rather than set separately: this
+        # runs on every motion event of a drag, and each setter used to repaint every
+        # tile patch, so setting two of them cost two full repaints (FIB-751).
+        #
         # No `display_pixel_size`: the overlay reads it from the canvas at draw time.
         # Pinning it here would freeze the scale at whatever was displayed when the
         # settings last changed, and the image underneath changes without them -- the
         # live preview swaps in a decimated mosaic mid-run.
         self.tile_grid_overlay.set_grid(
-            tiles, (height, width), pixel_size, overlap=parameters.overlap
+            tiles,
+            (height, width),
+            pixel_size,
+            overlap=parameters.overlap,
+            unreachable=self._unreachable(parameters, tiles=tiles),
+            anchor=self.canvas.canvas.metres_to_canvas(*offset),
         )
         # Same camera geometry, so it can be drawn at the same time rather than
         # waiting for an image the tile grid does not wait for either.
@@ -2313,8 +2319,12 @@ class FMOverviewWidget(QWidget):
         self._worker = FunctionWorker(self._acquire_worker)
         self._worker.start()
 
-    def _unreachable(self, parameters: OverviewParameters) -> List[Tuple[int, int]]:
-        """Which tiles of the run about to be confirmed the stage cannot travel to.
+    def _unreachable(
+        self,
+        parameters: OverviewParameters,
+        tiles: Optional[List[TilePosition]] = None,
+    ) -> List[Tuple[int, int]]:
+        """Which tiles of the planned run the stage cannot travel to.
 
         The runner asks this too, but only once the worker has started -- after the
         dialog has been accepted, a directory has been made and the stage has begun
@@ -2332,6 +2342,10 @@ class FMOverviewWidget(QWidget):
         the authoritative refusal, so being wrong here fails open. The tile field of
         view comes from the settings panel while the runner reads its own -- they track
         the same camera, and a disagreement between them is exactly the mild direction.
+
+        Also asked on the drag path, where the grid it flags can still be moved --
+        `_refresh_tile_grid` passes the tiles it has just built rather than having them
+        computed twice.
         """
         try:
             fov = self.settings_widget._tile_fov
@@ -2341,16 +2355,17 @@ class FMOverviewWidget(QWidget):
             if fov is None or projection is None or centre is None or not limits:
                 return []
             height, width = projection.shape
-            tiles = compute_tile_grid_from_fov(
-                nrows=parameters.rows,
-                ncols=parameters.cols,
-                fov_x=fov[0],
-                fov_y=fov[1],
-                image_width=width,
-                image_height=height,
-                overlap=parameters.overlap,
-                mask=parameters.tile_mask,
-            )
+            if tiles is None:
+                tiles = compute_tile_grid_from_fov(
+                    nrows=parameters.rows,
+                    ncols=parameters.cols,
+                    fov_x=fov[0],
+                    fov_y=fov[1],
+                    image_width=width,
+                    image_height=height,
+                    overlap=parameters.overlap,
+                    mask=parameters.tile_mask,
+                )
             return unreachable_tiles(
                 tiles,
                 parameters.tile_order,

--- a/fibsem/ui/fm/widgets/fm_tile_preview.py
+++ b/fibsem/ui/fm/widgets/fm_tile_preview.py
@@ -22,11 +22,10 @@ from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
 from fibsem.fm.planning import SparseOverviewPlan, plan_sparse_fm_overview, to_fm_pose
+from fibsem.imaging.tiling import geometry as tiling_geometry
 from fibsem.imaging.tiling.geometry import (
     PlaneRegion,
     compute_tile_grid_from_fov,
-    order_tiles,
-    validate_tile_stage_positions,
 )
 from fibsem.microscope import FibsemMicroscope
 from fibsem.projection import FMStageProjection, StageProjection
@@ -281,55 +280,36 @@ class FMTilePreviewWidget(QWidget):
     def _out_of_reach(self, tiles) -> List[Tuple[int, int]]:
         """Which of the tiles about to be acquired the stage cannot travel to.
 
-        Through the same two helpers the runner uses -- `order_tiles` to drop the
-        disabled ones, `validate_tile_stage_positions` to test what is left -- so the
-        dialog and the run cannot disagree about which grids are acquirable. Masking off
-        an unreachable corner is a legitimate way to fix one, and that only works if both
-        sides ask the question of the same tiles.
-
         Worth asking here rather than leaving to `raise_if_outside_stage_limits`, which
         refuses at acquire time. On a compustage the travel is +/-999.9 um in x and only
         +/-377.8 um in y, against a grid boundary of 1000 um radius, so a selection can
         sit well inside the grid and still be unreachable -- and it is a great deal
         cheaper to hear that while the region is still under the cursor.
-        """
-        step_x, step_y = self._step()
-        offset_x = (self._plan.cols - 1) * step_x / 2
-        offset_y = (self._plan.rows - 1) * step_y / 2
-        # Through the held projection, not `microscope.project_fm_stable_move`. The two
-        # agree to 1.4e-20 m -- the same arithmetic over the same geometry -- but the
-        # microscope's reads `fm.camera_tilt` and the camera transform on every call, at
-        # **216 ms each**. One per tile on a region change is half a minute of frozen UI
-        # for a 150 tile grid, and instrument traffic on a mouse event besides.
-        #
-        # The negated y is the convention crossing over: the layout above measures y
-        # upward, as `project_fm_stable_move` takes it, and a displayed plane measures it
-        # down. Verified against the live call rather than reasoned about.
-        positions = {
-            (tile.row, tile.col): self._projection.from_plane(
-                tile.dx - offset_x,
-                -(tile.dy + offset_y),
-                self._plan.centre_position,
-            )
-            for tile in tiles
-        }
-        limits = getattr(self.microscope._stage, "limits", None)
-        if not limits:
-            return []
-        # Any strategy: `order_tiles` changes the sequence and drops the disabled
-        # ones, and only the second half bears on whether a tile is reachable. Going
-        # through it anyway rather than filtering by hand, so the set asked about here
-        # is the set the runner will visit, by construction.
-        ordered = order_tiles(tiles, TileOrderStrategy.TYPEWRITER)
-        return validate_tile_stage_positions(
-            ordered, [positions[(t.row, t.col)] for t in ordered], limits
-        )
 
-    def _step(self) -> Tuple[float, float]:
-        """Distance between adjacent tile centres, in metres."""
-        return (
-            self._fov[0] * (1.0 - self._overlap),
-            self._fov[1] * (1.0 - self._overlap),
+        Through `unreachable_tiles`, which is this arithmetic lifted out when the
+        overview pre-flight dialogs came to need it too (FIB-741). It centres the grid
+        from the tiles' own extent rather than from a step size recomputed here, and
+        goes through `order_tiles` for the dropping, so every surface that asks this
+        question asks it of the same tiles as the runner.
+
+        The projection is the held one, not `microscope.project_fm_stable_move`. The two
+        agree to 1.4e-20 m -- the same arithmetic over the same geometry -- but the
+        microscope's reads `fm.camera_tilt` and the camera transform on every call, at
+        **216 ms each**. One per tile on a region change is half a minute of frozen UI
+        for a 150 tile grid, and instrument traffic on a mouse event besides.
+
+        Any strategy: `order_tiles` changes the sequence and drops the disabled ones,
+        and only the second half bears on whether a tile is reachable.
+        """
+        # Qualified: this class has a property of the same name, and a bare call would
+        # read as though it returned that.
+        return tiling_geometry.unreachable_tiles(
+            tiles,
+            TileOrderStrategy.TYPEWRITER,
+            lambda dx, dy: self._projection.from_plane(
+                dx, dy, self._plan.centre_position
+            ),
+            getattr(self.microscope._stage, "limits", None),
         )
 
     def _draw_stage_context(self) -> None:

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -24,7 +24,6 @@ from PyQt5.QtCore import QObject, Qt, QTimer, pyqtSignal
 from PyQt5.QtWidgets import QApplication
 
 from fibsem.imaging.tiling.geometry import TilePosition
-from fibsem.ui.tokens import SEMANTIC_ERROR_HOVER_COLOR
 from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
@@ -45,23 +44,30 @@ ENABLED_ALPHA = 0.0
 # easy to miss in a large grid.
 DISABLED_EDGE = "#9aa0a6"
 DISABLED_ALPHA = 0.75
-# A tile the stage cannot travel to, drawn as a wash over the tile rather than as a
-# recoloured outline (FIB-750).
+# A tile the stage cannot travel to, hatched rather than coloured (FIB-750).
 #
-# Not a new hue, because the canvas has no free warm one: yellow is where the stage is,
-# amber is the travel envelope, red is the specimen grid boundary. The first attempt
-# used the warning colour the flagged-lamella markers use, and on the canvas it was
-# indistinguishable from the travel box -- which is the one thing it must not be
-# confused with, since the box is exactly what the flagged tiles are outside of.
+# Hue was the wrong axis to work on. The canvas has no free one -- yellow is where the
+# stage is, amber the travel envelope, red the specimen grid boundary, magenta the grid
+# itself -- and the two tabs need the same answer over very different data: a red wash
+# read cleanly over greyscale beam images and went muddy over green fluorescence.
 #
-# A *fill* is a different visual class from every one of those outlines, so it reads on
-# its own terms whatever hue it takes. The tile keeps the grid's own edge colour, so the
-# grid still reads as the grid; only the wash says something is wrong. Thickened as
-# well, for the reason the skipped tiles are dashed as well as grey: one difference
-# alone is easy to miss in a large grid.
-UNREACHABLE_FILL = SEMANTIC_ERROR_HOVER_COLOR
-UNREACHABLE_ALPHA = 0.28
+# A hatch has no hue to interact with any of that, so it looks the same on both tabs and
+# cannot be confused with anything else drawn here. It is also the ordinary idiom for
+# "unavailable", and distinct from the grey dashed outline that means "switched off".
+#
+# The sparsest density that still reads, which is both the cheapest to draw (26% off a
+# drag frame against "///") and the one that hides least of the data underneath -- the
+# same reason the tile fill defaults to nothing.
+UNREACHABLE_HATCH = "/"
+# White rather than black, which was the first choice and the obvious one. Black hatching
+# reads well over data and **disappears entirely on an empty canvas** -- which is the
+# state you are in while planning a grid, before anything has been acquired, and so the
+# one case the flag most has to work in. Mid grey survives both, but it is within a hair
+# of `DISABLED_EDGE`, and "switched off" is a different thing from "cannot be reached".
+UNREACHABLE_HATCH_COLOUR = "#ffffff"
 LINE_WIDTH = 0.8
+# Thickened as well as hatched, for the reason the skipped tiles are dashed as well as
+# grey: one difference alone is easy to miss in a large grid.
 UNREACHABLE_LINE_WIDTH = LINE_WIDTH * 2.0
 
 # `set_grid(anchor=None)` means "follow the content"; omitting it means "leave it as it
@@ -439,9 +445,7 @@ class TileGridOverlay(QObject, CanvasOverlay):
                 (x, y), width, height,
                 fill=tile.enabled,
                 facecolor=(
-                    to_rgba(UNREACHABLE_FILL, UNREACHABLE_ALPHA) if out_of_reach
-                    else to_rgba(self._color, self._fill_alpha) if tile.enabled
-                    else "none"
+                    to_rgba(self._color, self._fill_alpha) if tile.enabled else "none"
                 ),
                 edgecolor=(
                     to_rgba(self._color, 1.0) if tile.enabled
@@ -453,6 +457,23 @@ class TileGridOverlay(QObject, CanvasOverlay):
             )
             self._ax.add_patch(patch)
             self._artists.append(patch)
+
+            if out_of_reach:
+                # A second patch, because matplotlib draws a hatch in the patch's own
+                # `edgecolor` -- so hatching the tile itself would mean giving up the
+                # grid's outline colour. No fill and no line: this one carries nothing
+                # but the hatch.
+                self._ax.add_patch(
+                    hatched := Rectangle(
+                        (x, y), width, height,
+                        fill=False,
+                        edgecolor=UNREACHABLE_HATCH_COLOUR,
+                        hatch=UNREACHABLE_HATCH,
+                        linewidth=0.0,
+                        zorder=21,
+                    )
+                )
+                self._artists.append(hatched)
 
         if self._canvas is not None:
             self._canvas.draw_idle()

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -18,12 +18,13 @@ is absorbed into the stage moves, not into where the tiles appear.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence, Tuple
 
 from PyQt5.QtCore import QObject, Qt, QTimer, pyqtSignal
 from PyQt5.QtWidgets import QApplication
 
 from fibsem.imaging.tiling.geometry import TilePosition
+from fibsem.ui.tokens import SEMANTIC_ERROR_HOVER_COLOR
 from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
@@ -44,7 +45,28 @@ ENABLED_ALPHA = 0.0
 # easy to miss in a large grid.
 DISABLED_EDGE = "#9aa0a6"
 DISABLED_ALPHA = 0.75
+# A tile the stage cannot travel to, drawn as a wash over the tile rather than as a
+# recoloured outline (FIB-750).
+#
+# Not a new hue, because the canvas has no free warm one: yellow is where the stage is,
+# amber is the travel envelope, red is the specimen grid boundary. The first attempt
+# used the warning colour the flagged-lamella markers use, and on the canvas it was
+# indistinguishable from the travel box -- which is the one thing it must not be
+# confused with, since the box is exactly what the flagged tiles are outside of.
+#
+# A *fill* is a different visual class from every one of those outlines, so it reads on
+# its own terms whatever hue it takes. The tile keeps the grid's own edge colour, so the
+# grid still reads as the grid; only the wash says something is wrong. Thickened as
+# well, for the reason the skipped tiles are dashed as well as grey: one difference
+# alone is easy to miss in a large grid.
+UNREACHABLE_FILL = SEMANTIC_ERROR_HOVER_COLOR
+UNREACHABLE_ALPHA = 0.28
 LINE_WIDTH = 0.8
+UNREACHABLE_LINE_WIDTH = LINE_WIDTH * 2.0
+
+# `set_grid(anchor=None)` means "follow the content"; omitting it means "leave it as it
+# is". A sentinel rather than None, because both of those are meaningful answers.
+_UNSET = object()
 
 # Grab zone for an edge drag, as a fraction of a tile. Proportional rather than a
 # fixed pixel count so it stays usable however far the view is zoomed out.
@@ -85,6 +107,9 @@ class TileGridOverlay(QObject, CanvasOverlay):
         self._tile_pixel_size: float = 0.0
         self._display_pixel_size: Optional[float] = None
         self._overlap: float = 0.0
+        # (row, col) for tiles the stage cannot travel to. A set, and empty by default:
+        # a host that never works it out draws exactly what it drew before.
+        self._unreachable: set = set()
         self._color: str = ENABLED_EDGE
         self._fill_alpha: float = ENABLED_ALPHA
         self._visible: bool = True
@@ -181,8 +206,14 @@ class TileGridOverlay(QObject, CanvasOverlay):
         Anchoring explicitly also lets the grid be drawn before anything is acquired,
         which is when a planned grid is most useful.
         """
-        self._anchor_point = None if centre is None else (float(centre[0]), float(centre[1]))
+        self._set_anchor_point(centre)
         self._redraw()
+
+    def _set_anchor_point(self, centre: Optional[Tuple[float, float]]) -> None:
+        """Store the anchor without repainting, so `set_grid` can do both in one."""
+        self._anchor_point = (
+            None if centre is None else (float(centre[0]), float(centre[1]))
+        )
 
     def _anchor(self) -> Optional[Tuple[float, float]]:
         """Where the grid is centred, or None if there is nothing to centre it on."""
@@ -200,6 +231,8 @@ class TileGridOverlay(QObject, CanvasOverlay):
         tile_pixel_size: float,
         display_pixel_size: Optional[float] = None,
         overlap: float = 0.0,
+        unreachable: Optional[Iterable[Tuple[int, int]]] = None,
+        anchor: Optional[Tuple[float, float]] = _UNSET,
     ) -> None:
         """Set the grid to draw.
 
@@ -214,16 +247,31 @@ class TileGridOverlay(QObject, CanvasOverlay):
                 the tile spacing, because a single-row or single-column grid has no
                 spacing to derive it from -- and that is exactly the case a resize
                 drag has to grow out of.
+            unreachable: (row, col) for tiles the stage cannot travel to, which are
+                washed in the colour above. None leaves the previous set alone; an
+                empty one clears it.
+            anchor: where to centre the grid, as :meth:`set_anchor` takes it. Here as
+                well because a host that sets both used to pay two full repaints per
+                call -- and this call is on the drag path, where it ran on every motion
+                event (FIB-751). Omitted leaves the anchor as it is; None restores
+                following the content.
         """
         self._tiles = list(tiles)
         self._tile_shape = tile_shape
         self._tile_pixel_size = tile_pixel_size
         self._display_pixel_size = display_pixel_size
         self._overlap = overlap
+        if unreachable is not None:
+            self._unreachable = {(int(r), int(c)) for r, c in unreachable}
+        if anchor is not _UNSET:
+            self._set_anchor_point(anchor)
         self._redraw()
 
     def clear(self) -> None:
         self._tiles = []
+        # The flags go with them. Left behind they would be re-applied to whatever grid
+        # was drawn next, by row and column, which is a different grid.
+        self._unreachable = set()
         self._redraw()
 
     def set_color(self, color: str) -> None:
@@ -379,6 +427,10 @@ class TileGridOverlay(QObject, CanvasOverlay):
 
         for tile in self._tiles:
             x, y, width, height = self._rect_for(tile)
+            # Only tiles that will actually be visited. A masked-off tile is not going
+            # anywhere, so flagging it would be asking you to turn off something already
+            # off -- and the check that produces the set drops them for the same reason.
+            out_of_reach = tile.enabled and (tile.row, tile.col) in self._unreachable
             # Alpha is baked into the face colour rather than set on the patch:
             # `alpha=` applies to the edge as well, which drew the outlines at the
             # fill's opacity and left them all but invisible -- so the grid could only
@@ -387,14 +439,16 @@ class TileGridOverlay(QObject, CanvasOverlay):
                 (x, y), width, height,
                 fill=tile.enabled,
                 facecolor=(
-                    to_rgba(self._color, self._fill_alpha) if tile.enabled else "none"
+                    to_rgba(UNREACHABLE_FILL, UNREACHABLE_ALPHA) if out_of_reach
+                    else to_rgba(self._color, self._fill_alpha) if tile.enabled
+                    else "none"
                 ),
                 edgecolor=(
                     to_rgba(self._color, 1.0) if tile.enabled
                     else to_rgba(DISABLED_EDGE, DISABLED_ALPHA)
                 ),
                 linestyle="-" if tile.enabled else "--",
-                linewidth=LINE_WIDTH,
+                linewidth=UNREACHABLE_LINE_WIDTH if out_of_reach else LINE_WIDTH,
                 zorder=20,
             )
             self._ax.add_patch(patch)

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -44,31 +44,28 @@ ENABLED_ALPHA = 0.0
 # easy to miss in a large grid.
 DISABLED_EDGE = "#9aa0a6"
 DISABLED_ALPHA = 0.75
-# A tile the stage cannot travel to, hatched rather than coloured (FIB-750).
+# A tile the stage cannot travel to: the tile recedes, and a small cross marks it.
 #
-# Hue was the wrong axis to work on. The canvas has no free one -- yellow is where the
-# stage is, amber the travel envelope, red the specimen grid boundary, magenta the grid
-# itself -- and the two tabs need the same answer over very different data: a red wash
-# read cleanly over greyscale beam images and went muddy over green fluorescence.
+# Emphasis inverted on purpose. Earlier attempts added ink to the tiles you cannot have
+# -- a recoloured edge, a red wash, a white hatch -- and the common case is that a whole
+# row or column goes out of range at once, so half the grid ended up shouting. What you
+# steer by while dragging is the region you *can* still acquire, so that is what should
+# stand out. Dimming the rest costs no ink at all and leaves the data legible.
 #
-# A hatch has no hue to interact with any of that, so it looks the same on both tabs and
-# cannot be confused with anything else drawn here. It is also the ordinary idiom for
-# "unavailable", and distinct from the grey dashed outline that means "switched off".
+# The cross sits at the tile's centre because that is exactly what is tested: the stage
+# only has to reach a tile's centre, which is also why tiles may legitimately overhang
+# the travel box. A mark at the centre makes that overhang read as intended rather than
+# as a bug.
 #
-# The sparsest density that still reads, which is both the cheapest to draw (26% off a
-# drag frame against "///") and the one that hides least of the data underneath -- the
-# same reason the tile fill defaults to nothing.
-UNREACHABLE_HATCH = "/"
-# White rather than black, which was the first choice and the obvious one. Black hatching
-# reads well over data and **disappears entirely on an empty canvas** -- which is the
-# state you are in while planning a grid, before anything has been acquired, and so the
-# one case the flag most has to work in. Mid grey survives both, but it is within a hair
-# of `DISABLED_EDGE`, and "switched off" is a different thing from "cannot be reached".
-UNREACHABLE_HATCH_COLOUR = "#ffffff"
+# Grey rather than a warning colour, and muted: it is information, not an alarm. Close
+# to `DISABLED_EDGE` by design -- both mean "not being acquired" -- and told apart by
+# what carries it, a dimmed solid outline here against a grey dashed one there.
+UNREACHABLE_EDGE_ALPHA = 0.30
+UNREACHABLE_MARK_COLOUR = "#9e9e9e"
+# As a fraction of the smaller tile side, so the cross shrinks with the tiles instead of
+# swamping a large grid.
+UNREACHABLE_MARK_SIZE = 0.12
 LINE_WIDTH = 0.8
-# Thickened as well as hatched, for the reason the skipped tiles are dashed as well as
-# grey: one difference alone is easy to miss in a large grid.
-UNREACHABLE_LINE_WIDTH = LINE_WIDTH * 2.0
 
 # `set_grid(anchor=None)` means "follow the content"; omitting it means "leave it as it
 # is". A sentinel rather than None, because both of those are meaningful answers.
@@ -254,8 +251,8 @@ class TileGridOverlay(QObject, CanvasOverlay):
                 spacing to derive it from -- and that is exactly the case a resize
                 drag has to grow out of.
             unreachable: (row, col) for tiles the stage cannot travel to, which are
-                washed in the colour above. None leaves the previous set alone; an
-                empty one clears it.
+                dimmed and crossed as described above. None leaves the previous set
+                alone; an empty one clears it.
             anchor: where to centre the grid, as :meth:`set_anchor` takes it. Here as
                 well because a host that sets both used to pay two full repaints per
                 call -- and this call is on the drag path, where it ran on every motion
@@ -448,35 +445,44 @@ class TileGridOverlay(QObject, CanvasOverlay):
                     to_rgba(self._color, self._fill_alpha) if tile.enabled else "none"
                 ),
                 edgecolor=(
-                    to_rgba(self._color, 1.0) if tile.enabled
+                    to_rgba(self._color, UNREACHABLE_EDGE_ALPHA) if out_of_reach
+                    else to_rgba(self._color, 1.0) if tile.enabled
                     else to_rgba(DISABLED_EDGE, DISABLED_ALPHA)
                 ),
                 linestyle="-" if tile.enabled else "--",
-                linewidth=UNREACHABLE_LINE_WIDTH if out_of_reach else LINE_WIDTH,
+                linewidth=LINE_WIDTH,
                 zorder=20,
             )
             self._ax.add_patch(patch)
             self._artists.append(patch)
 
             if out_of_reach:
-                # A second patch, because matplotlib draws a hatch in the patch's own
-                # `edgecolor` -- so hatching the tile itself would mean giving up the
-                # grid's outline colour. No fill and no line: this one carries nothing
-                # but the hatch.
-                self._ax.add_patch(
-                    hatched := Rectangle(
-                        (x, y), width, height,
-                        fill=False,
-                        edgecolor=UNREACHABLE_HATCH_COLOUR,
-                        hatch=UNREACHABLE_HATCH,
-                        linewidth=0.0,
-                        zorder=21,
-                    )
-                )
-                self._artists.append(hatched)
+                self._artists.extend(self._mark_out_of_reach(x, y, width, height))
 
         if self._canvas is not None:
             self._canvas.draw_idle()
+
+    def _mark_out_of_reach(self, x: float, y: float, width: float, height: float) -> list:
+        """A small cross at the tile's centre, added to the axes and handed back.
+
+        One artist, not two: a `nan` lifts the pen between the strokes, so both arms are
+        drawn by a single `Line2D`. Two artists per tile measured 184 ms against 136 ms
+        for a full 15x15 drag frame -- the per-artist overhead, not the drawing.
+        """
+        from matplotlib.lines import Line2D
+
+        centre_x, centre_y = x + width / 2, y + height / 2
+        arm = min(width, height) * UNREACHABLE_MARK_SIZE / 2
+        line = Line2D(
+            (centre_x - arm, centre_x + arm, float("nan"), centre_x - arm, centre_x + arm),
+            (centre_y - arm, centre_y + arm, float("nan"), centre_y + arm, centre_y - arm),
+            color=UNREACHABLE_MARK_COLOUR,
+            linewidth=1.3,
+            solid_capstyle="round",
+            zorder=22,
+        )
+        self._ax.add_line(line)
+        return [line]
 
     def _remove_artists(self) -> None:
         for artist in self._artists:

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -2049,7 +2049,10 @@ class FibsemOverviewWidget(QWidget):
             self.tile_grid_overlay.clear()
             return
 
-        self.tile_grid_overlay.set_anchor(anchor)
+        # Anchor and flags handed over with the grid rather than set separately: this
+        # runs on every motion event of a drag, and each setter used to repaint every
+        # tile patch, so setting two of them cost two full repaints (FIB-751).
+        #
         # No `display_pixel_size`: the overlay reads it off the canvas at draw time, so
         # the grid keeps describing the image underneath it when that image changes --
         # which it does mid-run, as tiles land.
@@ -2058,6 +2061,8 @@ class FibsemOverviewWidget(QWidget):
             (height, width),
             settings.image_settings.hfw / width,
             overlap=settings.overlap,
+            unreachable=self._unreachable(settings, tiles=tiles),
+            anchor=anchor,
         )
 
     def _may_edit_the_plan(self) -> bool:
@@ -2722,8 +2727,12 @@ class FibsemOverviewWidget(QWidget):
         )
         return dialog.exec_() == QDialog.Accepted
 
-    def _unreachable(self, settings: OverviewAcquisitionSettings) -> List[Tuple[int, int]]:
-        """Which tiles of the run about to be confirmed the stage cannot travel to.
+    def _unreachable(
+        self,
+        settings: OverviewAcquisitionSettings,
+        tiles: Optional[List["tiled.TilePosition"]] = None,
+    ) -> List[Tuple[int, int]]:
+        """Which tiles of the planned run the stage cannot travel to.
 
         The runner asks this too, in `_compute_grid` -- but that runs on the worker,
         after the dialog has been accepted, so the sequence a user gets is: read the
@@ -2742,6 +2751,11 @@ class FibsemOverviewWidget(QWidget):
         Best effort, like the disk estimate on the fluorescence dialog: a check that
         cannot run leaves the dialog without the warning rather than refusing to open
         it. The runner keeps the authoritative refusal, so being wrong here fails open.
+
+        Also asked on the drag path, where the grid it flags can still be moved --
+        `_refresh_tile_grid` passes the tiles it has just built rather than having them
+        computed twice. Affordable there: 0.45 ms for a 3x3 and 9.3 ms for the largest
+        grid the spin boxes allow, against a redraw already costing several times that.
         """
         try:
             projection = self._projection(self.acquisition_view)
@@ -2749,8 +2763,10 @@ class FibsemOverviewWidget(QWidget):
             limits = getattr(self.microscope._stage, "limits", None)
             if projection is None or centre is None or not limits:
                 return []
+            if tiles is None:
+                tiles = tiled.compute_tile_grid(settings, mask=settings.tile_mask)
             return unreachable_tiles(
-                tiled.compute_tile_grid(settings, mask=settings.tile_mask),
+                tiles,
                 settings.tile_order,
                 lambda dx, dy: projection.from_plane(dx, dy, centre),
                 limits,

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -5151,3 +5151,41 @@ def test_a_check_that_cannot_run_does_not_hold_up_the_fm_dialog(
     assert len(dialogs) == 1, "the dialog did not open"
     assert dialogs[0].unreachable == []
     assert dialogs[0].button_start.isEnabled()
+
+
+def test_the_fm_canvas_flags_the_tiles_it_cannot_reach(qapp, grid_of):
+    """The other caller of the shared overlay, and the one where it bites hardest: a
+    compustage travels +/-999.9 um in x and only +/-377.8 um in y, so an 11x11 that
+    looks square and central runs out top and bottom (FIB-750)."""
+    widget = grid_of(3, 3)
+    assert widget.tile_grid_overlay._unreachable == set(), (
+        "a 3x3 was flagged, so this proves nothing"
+    )
+
+    widget = grid_of(11, 11)
+
+    assert widget.tile_grid_overlay._unreachable, "nothing was flagged"
+    assert widget.tile_grid_overlay._unreachable == set(
+        widget._unreachable(widget.settings_widget.parameters)
+    ), "the canvas and the dialog would disagree"
+
+
+def test_the_fm_grid_refresh_repaints_once(qapp, grid_of):
+    """Anchor and flags go over with the grid. Each setter repaints every tile patch,
+    and this runs on every motion event of a drag (FIB-751)."""
+    widget = grid_of(5, 5)
+    overlay = widget.tile_grid_overlay
+    redraws = []
+    original = overlay._redraw
+
+    def counting():
+        redraws.append(1)
+        original()
+
+    overlay._redraw = counting
+    try:
+        widget._refresh_tile_grid()
+    finally:
+        overlay._redraw = original
+
+    assert len(redraws) == 1, f"one refresh caused {len(redraws)} repaints"

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -2946,6 +2946,95 @@ class TestAGridTheStageCannotReach:
         assert not calls, "the dialog projected through the microscope"
 
 
+class TestTheGridSaysWhereItCannotGo:
+    """The dialog is a backstop; the canvas is where a grid can actually be fixed.
+
+    It already draws the travel envelope, so a grid dragged past it is visibly outside
+    and nothing said so. The tiles that cannot be reached are flagged as they are
+    dragged, in the warning colour the flagged-lamella markers use (FIB-750).
+    """
+
+    def _beyond_the_travel(self, widget, microscope):
+        """A canvas point far enough out in y that the grid overhangs the limits.
+
+        y rather than x because a compustage travels +/-999.9 um in x and only
+        +/-377.8 um in y, so y is where a central-looking grid runs out first.
+        """
+        frame = widget._frame()
+        limits = microscope._stage.limits
+        origin = frame.origin
+        beyond = FibsemStagePosition(
+            x=0.0, y=limits["y"].max * 0.9, z=origin.z, r=origin.r, t=origin.t
+        )
+        return frame.to_canvas(beyond)
+
+    def test_dragging_the_grid_past_the_travel_flags_the_tiles(
+        self, widget, microscope
+    ):
+        assert widget.tile_grid_overlay._unreachable == set(), (
+            "the grid started out flagged, so this proves nothing"
+        )
+
+        widget._on_grid_moved(*self._beyond_the_travel(widget, microscope))
+
+        assert widget.tile_grid_overlay._unreachable, "nothing was flagged"
+
+    def test_dragging_it_back_clears_them(self, widget, microscope):
+        """The flag has to keep up with the drag, not just appear during it -- one that
+        never goes away reads as broken rather than as informative."""
+        widget._on_grid_moved(*self._beyond_the_travel(widget, microscope))
+        assert widget.tile_grid_overlay._unreachable
+
+        widget.clear_target()
+
+        assert widget.tile_grid_overlay._unreachable == set()
+
+    def test_what_is_drawn_is_what_the_dialog_would_refuse(self, widget, microscope):
+        """One answer, drawn and stated. A canvas that flags a different set from the
+        one the dialog refuses is worse than a canvas that flags nothing."""
+        widget._on_grid_moved(*self._beyond_the_travel(widget, microscope))
+
+        drawn = widget.tile_grid_overlay._unreachable
+        assert drawn == set(widget._unreachable(widget._settings()))
+
+    def test_the_drag_reads_no_hardware(self, widget, microscope, monkeypatch):
+        """This runs on every motion event. `project_stable_move` re-reads the scan
+        rotation on every call -- 210 ms each, so a 5x5 would be five seconds of
+        instrument traffic per mouse move."""
+        calls = []
+        real = microscope.project_stable_move
+
+        def recording(*args, **kwargs):
+            calls.append(1)
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(microscope, "project_stable_move", recording)
+        widget._on_grid_moved(*self._beyond_the_travel(widget, microscope))
+
+        assert widget.tile_grid_overlay._unreachable, "the check did not run"
+        assert not calls, "the drag projected through the microscope"
+
+    def test_a_drag_repaints_the_canvas_once(self, widget, microscope):
+        """A repaint re-renders every placed image, not just the tiles -- measured at
+        169 ms per motion event with six overviews on the canvas. Doing it twice per
+        event was pure waste (FIB-751)."""
+        redraws = []
+        overlay = widget.tile_grid_overlay
+        original = overlay._redraw
+
+        def counting():
+            redraws.append(1)
+            original()
+
+        overlay._redraw = counting
+        try:
+            widget._on_grid_moved(*self._beyond_the_travel(widget, microscope))
+        finally:
+            overlay._redraw = original
+
+        assert len(redraws) == 1, f"one motion event caused {len(redraws)} repaints"
+
+
 class TestTheAcquisitionButtons:
     """`Cancel | Acquire Overview`, the fluorescence tab's arrangement."""
 

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -336,31 +336,78 @@ def _edge_hues(overlay):
     return {tuple(round(c, 3) for c in patch.get_edgecolor()[:3]) for patch in overlay._artists}
 
 
-def test_an_unreachable_tile_is_washed_not_re_outlined(qapp):
-    """A fill, because the canvas has no free warm outline colour: yellow is the stage,
-    amber the travel envelope, red the grid boundary. The first attempt recoloured the
-    edge with the warning colour and came out indistinguishable from the travel box --
-    the one thing it must not look like, since that box is what these tiles are outside
-    of. The edge stays the grid's own, so the grid still reads as the grid."""
-    from matplotlib.colors import to_rgba
+def _is_hatch(artist):
+    return bool(getattr(artist, "get_hatch", None) and artist.get_hatch())
 
-    from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import UNREACHABLE_FILL
 
+def _hatches(overlay):
+    """The hatch-only patches, keyed by the tile rectangle they cover."""
+    return {
+        (round(a.get_x(), 3), round(a.get_y(), 3)): a
+        for a in overlay._artists
+        if _is_hatch(a)
+    }
+
+
+def _outlines(overlay):
+    """The tile patches by (row, col).
+
+    Not `zip(_artists, _tiles)`: a flagged tile contributes a second, hatch-only patch,
+    so the artist list is longer than the tile list and the pairing slips from the first
+    flagged tile onward.
+    """
+    outlines = [a for a in overlay._artists if not _is_hatch(a)]
+    return {(t.row, t.col): p for p, t in zip(outlines, overlay._tiles)}
+
+
+def test_an_unreachable_tile_is_hatched_not_recoloured(qapp):
+    """Hue was the wrong axis. The canvas has no free one, and the two tabs need the
+    same answer over very different data -- a red wash read cleanly over greyscale beam
+    images and went muddy over green fluorescence. A hatch has no hue to interact with
+    any of it.
+
+    The tile keeps the grid's own outline, so the grid still reads as the grid; the
+    hatch rides on a second patch, because matplotlib draws a hatch in the patch's own
+    `edgecolor`.
+    """
     overlay, tiles = build(3, 3)
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(0, 0), (0, 1)])
 
-    wash = tuple(round(c, 3) for c in to_rgba(UNREACHABLE_FILL)[:3])
-    by_coord = {
-        (tile.row, tile.col): patch
-        for patch, tile in zip(overlay._artists, overlay._tiles)
-    }
+    hatched = _hatches(overlay)
+    assert len(hatched) == 2, "one hatch patch per unreachable tile"
+
+    outlines = _outlines(overlay)
     for coord in ((0, 0), (0, 1)):
-        patch = by_coord[coord]
-        assert tuple(round(c, 3) for c in patch.get_facecolor()[:3]) == wash
-        assert patch.get_facecolor()[3] > 0, "the wash is transparent"
-        assert tuple(round(c, 3) for c in patch.get_edgecolor()[:3]) == tuple(
-            round(c, 3) for c in by_coord[(2, 2)].get_edgecolor()[:3]
-        ), "a flagged tile was re-outlined instead of washed"
+        rect = outlines[coord]
+        assert (round(rect.get_x(), 3), round(rect.get_y(), 3)) in hatched
+        assert tuple(round(c, 3) for c in rect.get_edgecolor()[:3]) == tuple(
+            round(c, 3) for c in outlines[(2, 2)].get_edgecolor()[:3]
+        ), "a flagged tile was recoloured instead of hatched"
+
+
+def test_the_hatch_is_visible_on_an_empty_canvas(qapp):
+    """Black was the first choice and reads well over data, but it disappears on the
+    empty canvas -- which is the state you plan a grid in. Pinned as "not near the
+    canvas background" rather than as a literal, since the point is the contrast."""
+    from matplotlib.colors import to_rgba
+
+    from fibsem.ui.tokens import CANVAS_BG
+    from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import (
+        UNREACHABLE_HATCH_COLOUR,
+    )
+
+    hatch = to_rgba(UNREACHABLE_HATCH_COLOUR)[:3]
+    background = to_rgba(CANVAS_BG)[:3]
+    distance = sum(abs(a - b) for a, b in zip(hatch, background))
+    assert distance > 1.0, (
+        f"the hatch {UNREACHABLE_HATCH_COLOUR} is too close to the canvas {CANVAS_BG}"
+    )
+
+
+def test_a_reachable_tile_carries_no_hatch(qapp):
+    overlay, tiles = build(3, 3)
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(0, 0)])
+    assert len(_hatches(overlay)) == 1
 
 
 def test_an_unreachable_tile_is_thicker_as_well_as_amber(qapp):
@@ -370,8 +417,7 @@ def test_an_unreachable_tile_is_thicker_as_well_as_amber(qapp):
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(1, 1)])
 
     widths = {
-        (tile.row, tile.col): patch.get_linewidth()
-        for patch, tile in zip(overlay._artists, overlay._tiles)
+        coord: patch.get_linewidth() for coord, patch in _outlines(overlay).items()
     }
     assert widths[(1, 1)] > widths[(0, 0)]
 
@@ -390,10 +436,7 @@ def test_a_tile_that_is_switched_off_is_not_also_flagged(qapp):
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(0, 0)])
 
     def described(coord):
-        patch = next(
-            patch for patch, tile in zip(overlay._artists, overlay._tiles)
-            if (tile.row, tile.col) == coord
-        )
+        patch = _outlines(overlay)[coord]
         return (
             tuple(round(c, 3) for c in patch.get_edgecolor()),
             tuple(round(c, 3) for c in patch.get_facecolor()),
@@ -405,6 +448,7 @@ def test_a_tile_that_is_switched_off_is_not_also_flagged(qapp):
     assert described((0, 0)) == described((0, 1)), (
         "a switched-off tile was drawn differently because it was also flagged"
     )
+    assert not _hatches(overlay), "a switched-off tile was hatched"
 
 
 def test_passing_no_flags_leaves_the_previous_ones_alone(qapp):

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -336,90 +336,82 @@ def _edge_hues(overlay):
     return {tuple(round(c, 3) for c in patch.get_edgecolor()[:3]) for patch in overlay._artists}
 
 
-def _is_hatch(artist):
-    return bool(getattr(artist, "get_hatch", None) and artist.get_hatch())
+def _is_mark(artist):
+    """The centre cross is a Line2D; the tiles are patches."""
+    return artist.__class__.__name__ == "Line2D"
 
 
-def _hatches(overlay):
-    """The hatch-only patches, keyed by the tile rectangle they cover."""
-    return {
-        (round(a.get_x(), 3), round(a.get_y(), 3)): a
-        for a in overlay._artists
-        if _is_hatch(a)
-    }
+def _marks(overlay):
+    return [a for a in overlay._artists if _is_mark(a)]
 
 
 def _outlines(overlay):
     """The tile patches by (row, col).
 
-    Not `zip(_artists, _tiles)`: a flagged tile contributes a second, hatch-only patch,
-    so the artist list is longer than the tile list and the pairing slips from the first
+    Not `zip(_artists, _tiles)`: a flagged tile contributes two cross lines as well, so
+    the artist list is longer than the tile list and the pairing slips from the first
     flagged tile onward.
     """
-    outlines = [a for a in overlay._artists if not _is_hatch(a)]
+    outlines = [a for a in overlay._artists if not _is_mark(a)]
     return {(t.row, t.col): p for p, t in zip(outlines, overlay._tiles)}
 
 
-def test_an_unreachable_tile_is_hatched_not_recoloured(qapp):
-    """Hue was the wrong axis. The canvas has no free one, and the two tabs need the
-    same answer over very different data -- a red wash read cleanly over greyscale beam
-    images and went muddy over green fluorescence. A hatch has no hue to interact with
-    any of it.
-
-    The tile keeps the grid's own outline, so the grid still reads as the grid; the
-    hatch rides on a second patch, because matplotlib draws a hatch in the patch's own
-    `edgecolor`.
-    """
+def test_an_unreachable_tile_recedes_and_is_crossed(qapp):
+    """Emphasis inverted on purpose. Earlier attempts added ink to the tiles you cannot
+    have -- and the common case is a whole row going out of range at once, so half the
+    grid ended up shouting. What you steer by is the region you can still acquire, so
+    the rest dims instead."""
     overlay, tiles = build(3, 3)
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(0, 0), (0, 1)])
 
-    hatched = _hatches(overlay)
-    assert len(hatched) == 2, "one hatch patch per unreachable tile"
-
     outlines = _outlines(overlay)
-    for coord in ((0, 0), (0, 1)):
-        rect = outlines[coord]
-        assert (round(rect.get_x(), 3), round(rect.get_y(), 3)) in hatched
-        assert tuple(round(c, 3) for c in rect.get_edgecolor()[:3]) == tuple(
-            round(c, 3) for c in outlines[(2, 2)].get_edgecolor()[:3]
-        ), "a flagged tile was recoloured instead of hatched"
+    assert len(_marks(overlay)) == 2, "one cross artist per unreachable tile"
+
+    faded = outlines[(0, 0)].get_edgecolor()[3]
+    solid = outlines[(2, 2)].get_edgecolor()[3]
+    assert faded < solid, "the unreachable tile did not recede"
+    assert tuple(outlines[(0, 0)].get_edgecolor()[:3]) == tuple(
+        outlines[(2, 2)].get_edgecolor()[:3]
+    ), "it should be the grid's own colour, just quieter"
 
 
-def test_the_hatch_is_visible_on_an_empty_canvas(qapp):
-    """Black was the first choice and reads well over data, but it disappears on the
-    empty canvas -- which is the state you plan a grid in. Pinned as "not near the
-    canvas background" rather than as a literal, since the point is the contrast."""
-    from matplotlib.colors import to_rgba
-
-    from fibsem.ui.tokens import CANVAS_BG
-    from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import (
-        UNREACHABLE_HATCH_COLOUR,
-    )
-
-    hatch = to_rgba(UNREACHABLE_HATCH_COLOUR)[:3]
-    background = to_rgba(CANVAS_BG)[:3]
-    distance = sum(abs(a - b) for a, b in zip(hatch, background))
-    assert distance > 1.0, (
-        f"the hatch {UNREACHABLE_HATCH_COLOUR} is too close to the canvas {CANVAS_BG}"
-    )
-
-
-def test_a_reachable_tile_carries_no_hatch(qapp):
-    overlay, tiles = build(3, 3)
-    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(0, 0)])
-    assert len(_hatches(overlay)) == 1
-
-
-def test_an_unreachable_tile_is_thicker_as_well_as_amber(qapp):
-    """Colour alone is easy to miss in a large grid -- the same reason a skipped tile is
-    dashed as well as grey."""
+def test_the_cross_sits_at_the_tile_centre(qapp):
+    """Where it does, because the centre is exactly what the reachability check tests --
+    which is also why a tile may legitimately overhang the travel box. A mark at the
+    centre is what makes that overhang read as intended rather than as a bug."""
     overlay, tiles = build(3, 3)
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(1, 1)])
 
-    widths = {
-        coord: patch.get_linewidth() for coord, patch in _outlines(overlay).items()
-    }
-    assert widths[(1, 1)] > widths[(0, 0)]
+    x, y, width, height = overlay._rect_for(
+        next(t for t in overlay._tiles if (t.row, t.col) == (1, 1))
+    )
+    import math
+
+    line = _marks(overlay)[0]
+    xs = [v for v in line.get_xdata() if not math.isnan(v)]
+    ys = [v for v in line.get_ydata() if not math.isnan(v)]
+    assert (min(xs) + max(xs)) / 2 == pytest.approx(x + width / 2)
+    assert (min(ys) + max(ys)) / 2 == pytest.approx(y + height / 2)
+
+
+def test_the_cross_scales_with_the_tiles(qapp):
+    """A fixed size would swamp a large grid, where the tiles are small on screen."""
+    from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import UNREACHABLE_MARK_SIZE
+
+    overlay, tiles = build(3, 3)
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(1, 1)])
+    _, _, width, height = overlay._rect_for(overlay._tiles[0])
+
+    import math
+
+    xs = [v for v in _marks(overlay)[0].get_xdata() if not math.isnan(v)]
+    assert max(xs) - min(xs) == pytest.approx(min(width, height) * UNREACHABLE_MARK_SIZE)
+
+
+def test_a_reachable_tile_is_not_marked(qapp):
+    overlay, tiles = build(3, 3)
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(0, 0)])
+    assert len(_marks(overlay)) == 1
 
 
 def test_a_tile_that_is_switched_off_is_not_also_flagged(qapp):
@@ -448,7 +440,7 @@ def test_a_tile_that_is_switched_off_is_not_also_flagged(qapp):
     assert described((0, 0)) == described((0, 1)), (
         "a switched-off tile was drawn differently because it was also flagged"
     )
-    assert not _hatches(overlay), "a switched-off tile was hatched"
+    assert not _marks(overlay), "a switched-off tile was crossed"
 
 
 def test_passing_no_flags_leaves_the_previous_ones_alone(qapp):

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -329,6 +329,138 @@ def test_skipped_tiles_are_grey_regardless_of_the_grid_colour(qapp):
     assert len(hues) == 2, "skipped and acquired tiles should differ in colour"
 
 
+# ── tiles the stage cannot reach ─────────────────────────────────────────
+
+
+def _edge_hues(overlay):
+    return {tuple(round(c, 3) for c in patch.get_edgecolor()[:3]) for patch in overlay._artists}
+
+
+def test_an_unreachable_tile_is_washed_not_re_outlined(qapp):
+    """A fill, because the canvas has no free warm outline colour: yellow is the stage,
+    amber the travel envelope, red the grid boundary. The first attempt recoloured the
+    edge with the warning colour and came out indistinguishable from the travel box --
+    the one thing it must not look like, since that box is what these tiles are outside
+    of. The edge stays the grid's own, so the grid still reads as the grid."""
+    from matplotlib.colors import to_rgba
+
+    from fibsem.ui.widgets.canvas.overlays.tile_grid_overlay import UNREACHABLE_FILL
+
+    overlay, tiles = build(3, 3)
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(0, 0), (0, 1)])
+
+    wash = tuple(round(c, 3) for c in to_rgba(UNREACHABLE_FILL)[:3])
+    by_coord = {
+        (tile.row, tile.col): patch
+        for patch, tile in zip(overlay._artists, overlay._tiles)
+    }
+    for coord in ((0, 0), (0, 1)):
+        patch = by_coord[coord]
+        assert tuple(round(c, 3) for c in patch.get_facecolor()[:3]) == wash
+        assert patch.get_facecolor()[3] > 0, "the wash is transparent"
+        assert tuple(round(c, 3) for c in patch.get_edgecolor()[:3]) == tuple(
+            round(c, 3) for c in by_coord[(2, 2)].get_edgecolor()[:3]
+        ), "a flagged tile was re-outlined instead of washed"
+
+
+def test_an_unreachable_tile_is_thicker_as_well_as_amber(qapp):
+    """Colour alone is easy to miss in a large grid -- the same reason a skipped tile is
+    dashed as well as grey."""
+    overlay, tiles = build(3, 3)
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(1, 1)])
+
+    widths = {
+        (tile.row, tile.col): patch.get_linewidth()
+        for patch, tile in zip(overlay._artists, overlay._tiles)
+    }
+    assert widths[(1, 1)] > widths[(0, 0)]
+
+
+def test_a_tile_that_is_switched_off_is_not_also_flagged(qapp):
+    """Turning the tile off is what the flag is *asking* for, so a tile that is already
+    off must stop being flagged -- otherwise the grid never stops complaining about a
+    problem you have already fixed.
+
+    Compared against another switched-off tile rather than against the disabled colour:
+    the colour was never the thing at risk. Flagging a disabled tile leaves its edge
+    grey either way and shows up only in the line width -- which a colour assertion
+    reads straight past.
+    """
+    overlay, tiles = build(3, 3, mask=[[False, False, True]] + [[True] * 3] * 2)
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(0, 0)])
+
+    def described(coord):
+        patch = next(
+            patch for patch, tile in zip(overlay._artists, overlay._tiles)
+            if (tile.row, tile.col) == coord
+        )
+        return (
+            tuple(round(c, 3) for c in patch.get_edgecolor()),
+            tuple(round(c, 3) for c in patch.get_facecolor()),
+            patch.get_linewidth(),
+            patch.get_linestyle(),
+            patch.get_fill(),
+        )
+
+    assert described((0, 0)) == described((0, 1)), (
+        "a switched-off tile was drawn differently because it was also flagged"
+    )
+
+
+def test_passing_no_flags_leaves_the_previous_ones_alone(qapp):
+    """A host that never works reachability out draws exactly what it drew before, and
+    one that does is not made to re-send them on every unrelated redraw."""
+    overlay, tiles = build(3, 3)
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(0, 0)])
+    assert overlay._unreachable == {(0, 0)}
+
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+    assert overlay._unreachable == {(0, 0)}, "the flags were dropped by an unrelated redraw"
+
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[])
+    assert overlay._unreachable == set(), "an empty set must clear them"
+
+
+def test_clearing_the_grid_clears_the_flags(qapp):
+    """Left behind they would be re-applied to the next grid drawn, by row and column --
+    which is a different grid."""
+    overlay, tiles = build(3, 3)
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[(0, 0)])
+    overlay.clear()
+    assert overlay._unreachable == set()
+
+
+# ── one repaint per refresh (FIB-751) ────────────────────────────────────
+
+
+def test_setting_the_anchor_with_the_grid_repaints_once(qapp):
+    """A host that sets both used to pay two full repaints, on a path that runs on every
+    motion event of a drag. Each repaint re-renders the whole canvas -- every placed
+    image, not just the tiles -- so the second one is not a rounding error."""
+    overlay, tiles = build(3, 3)
+    overlay._canvas.redraws = 0
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, anchor=(10.0, 20.0))
+    assert overlay._canvas.redraws == 1
+
+    overlay._canvas.redraws = 0
+    overlay.set_anchor((10.0, 20.0))
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+    assert overlay._canvas.redraws == 2, "the two-call form is what this replaces"
+
+
+def test_the_anchor_still_has_two_meanings(qapp):
+    """`None` means "follow the content"; omitting it means "leave it as it is". Both
+    are answers, which is why the default is a sentinel rather than None."""
+    overlay, tiles = build(3, 3)
+    overlay.set_anchor((10.0, 20.0))
+
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+    assert overlay._anchor_point == (10.0, 20.0), "omitting the anchor moved the grid"
+
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, anchor=None)
+    assert overlay._anchor_point is None, "None must go back to following the content"
+
+
 # ── resize by dragging an edge ───────────────────────────────────────────
 
 


### PR DESCRIPTION
The pre-flight dialog refuses a grid whose tiles are outside the stage's travel (FIB-741), but **nothing can be changed from that dialog** — it is Start and Cancel, so the refusal just sends you back to the canvas. The canvas is where a grid can actually be fixed, and it already draws the travel envelope: a grid dragged past it was visibly outside, and nothing said so.

The offending tiles are now washed as the grid is dragged, on both overview tabs, from the same `unreachable_tiles` the dialog and the runner use — so the canvas cannot flag a different set from the one the run would refuse.

## The treatment changed three times, every time from looking at it

**Recoloured edge**, in the warning colour the flagged-lamella markers use. On the canvas it was **indistinguishable from the Stage Limits box** — the one thing it must not resemble, since that box is exactly what the flagged tiles are outside of. The assertions were perfectly happy with it.

**Red wash.** A fill is a different visual class from every outline on the canvas, so it reads on its own terms. Good over greyscale beam data, and **muddy olive over green fluorescence** — and both tabs share this overlay, so one answer has to serve both.

**White hatch.** Hue-free, so identical on both tabs. But the common case is a whole row or column going out of range at once, so half the grid ended up hatched, over the data you are dragging across in order to decide where to put the grid. It was also the most expensive of the three to draw.

**Shipped: the tile dims, and a small grey cross marks its centre.** Emphasis inverted — what you steer by while dragging is the region you can still acquire, so that is what stands out, and the rest recedes at 30% opacity. Dimming costs no ink at all, and this is the cheapest of the four to draw.

The cross sits at the tile's **centre** because that is exactly what the check tests, and why a tile may legitimately overhang the travel box. A mark at the centre makes that overhang read as intended rather than as a bug — which none of the area fills did. Grey and muted because it is information, not an alarm; close to `DISABLED_EDGE` by design, since both mean "not being acquired", and told apart by what carries it: a dimmed solid outline here against a grey dashed one there.

Sized as a fraction of the tile, so it shrinks with a large grid instead of swamping it, and drawn as **one** `Line2D` with a `nan` between the strokes — two artists per tile measured 184 ms against 136 ms for a full 15x15 drag frame.

## Centres, not extents

`validate_tile_stage_positions` tests the positions the stage *sits at* to acquire each tile, and a tile legitimately overhangs the envelope by up to half its field of view on every side. A containment test on tile rectangles would be **stricter than the runner**, refusing grids it would happily acquire — a false refusal being worse than the late failure this is removing.

The consequence is visible and correct: tiles near the edge stick out past the travel box, and the boundary between washed and clean lands where the *centres* cross it.

## Cost on the drag path

Through the cached projection, so the check is 0.45 ms for a 3x3 and 9.3 ms for the largest grid the spin boxes allow. `microscope.project_stable_move` would be ~210 ms **per tile**. A test pins that the drag never touches it.

Also folded in, being the same two lines on the same path: the anchor goes over with the grid rather than in a call of its own, which drops a second rebuild of every tile patch per motion event (**FIB-751**). Measured like-for-like:

| grid | empty canvas | 6 placed overviews |
| -- | -- | -- |
| 3x3 | 0.6 ms saved | none — lost in a 165 ms frame |
| 15x15 | 37 ms saved (34%) | 51 ms saved (19%) |

I filed FIB-751 claiming this was two full repaints. It is not — `draw_idle` coalesces, so it was one render and two patch rebuilds; I have corrected the issue. What actually dominates a drag frame is re-rendering every placed image, which is FIB-752 and a separate change.

## Also: one definition of reachable

`FMTilePreview._out_of_reach` (the sparse selection dialog) had this arithmetic already; it now goes through the shared helper. Verified by running both implementations alongside each other across the suite — 18 calls, three distinct selections (150 tiles/12 unreachable, 24/6, 150/11), identical every time, and never two empty lists. Its `_step()` helper had no other caller and is gone.

## Tests

757 pass across the overview, overlay, fluorescence, tiling and dialog suites. Eight mutations, all killed — including one that survived the first attempt: the "a switched-off tile is not also flagged" test asserted the edge colour, which the mutation never touches. It now asserts the tile is drawn *identically* to any other switched-off tile.

