### PR TITLE
[perf] Blit the tile grid while it is dragged (FIB-752)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -274,6 +274,9 @@ class FMOverviewWidget(QWidget):
         # somewhere. None means "wherever the stage is", which is what the runner does
         # by default -- so an untouched grid describes exactly what would be acquired.
         self._target: Optional[FibsemStagePosition] = None
+        # Set only while `_on_drag_finished` is running the refresh a drag deferred.
+        # See there: that refresh must not re-frame the view.
+        self._finishing_drag = False
         self._sparse_selection_enabled = False
         # Where acquired overviews are written. None means nowhere: the widget opens
         # standalone against a simulator as often as it runs inside an experiment, and
@@ -587,6 +590,7 @@ class FMOverviewWidget(QWidget):
         self.tile_grid_overlay.tile_toggled.connect(self._on_tile_toggled)
         self.tile_grid_overlay.grid_resize_requested.connect(self._on_grid_resize)
         self.tile_grid_overlay.grid_move_requested.connect(self._on_grid_move)
+        self.tile_grid_overlay.drag_finished.connect(self._on_drag_finished)
         self.canvas.canvas.canvas_clicked.connect(self._on_canvas_clicked)
         self.canvas.canvas.canvas_double_clicked.connect(self._on_canvas_double_clicked)
         self.canvas.canvas.canvas_right_clicked.connect(self._on_canvas_right_clicked)
@@ -766,7 +770,14 @@ class FMOverviewWidget(QWidget):
         )
         # Same camera geometry, so it can be drawn at the same time rather than
         # waiting for an image the tile grid does not wait for either.
-        self._refresh_stage_metadata()
+        #
+        # Not while the grid is being dragged, though. None of these shapes move when
+        # the grid does -- the travel limits, the grid boundary and the holder slots are
+        # all fixed to the stage -- so redrawing them on every motion event is wasted,
+        # and it is a *full* canvas repaint, which costs far more than the grid it was
+        # called alongside. The beam tab skips its equivalent for the same reason.
+        if not self.tile_grid_overlay.is_dragging:
+            self._refresh_stage_metadata()
 
         span_x = parameters.cols * fov[0] * (1 - parameters.overlap) + fov[0]
         span_y = parameters.rows * fov[1] * (1 - parameters.overlap) + fov[1]
@@ -777,9 +788,17 @@ class FMOverviewWidget(QWidget):
         # Keep the declared working area on the grid, always and silently. It is what
         # the zoom limiter measures against, so an area left behind stretches the
         # content across the gap and caps how far the view can zoom in. `refit=False`
-        # is what makes doing this continuously safe: re-declaring used to re-frame,
-        # so dragging the grid snapped the view onto it on every motion event.
-        self.canvas.set_world_extent(span_x, span_y, offset, refit=False)
+        # is what makes doing this safe: re-declaring used to re-frame, so dragging the
+        # grid snapped the view onto it on every motion event.
+        #
+        # Not *during* a drag, though, which is what "continuously" used to mean here.
+        # Re-declaring asks the canvas to repaint, and a repaint is what the blitted
+        # grid is drawn over -- so this alone put two full canvas draws on every motion
+        # event and undid the whole of FIB-752 on this tab. Deferred to
+        # `drag_finished`, which arrives once. Nobody is measuring zoom limits against
+        # it mid-gesture.
+        if not self.tile_grid_overlay.is_dragging:
+            self.canvas.set_world_extent(span_x, span_y, offset, refit=False)
 
         # Re-frame only for a reason the user would expect to move the view: the grid's
         # footprint changed, or it has ended up outside what was framed (a stage move to
@@ -792,8 +811,33 @@ class FMOverviewWidget(QWidget):
         footprint = (parameters.rows, parameters.cols, parameters.overlap)
         changed = footprint != self._grid_footprint
         self._grid_footprint = footprint
-        if (changed or left_area) and not self.tile_grid_overlay.is_dragging:
+        if (
+            (changed or left_area)
+            and not self.tile_grid_overlay.is_dragging
+            and not self._finishing_drag
+        ):
             self.tile_grid_overlay.fit_view()
+
+    def _on_drag_finished(self) -> None:
+        """Do the work a drag deferred, without moving the camera.
+
+        The declared working area has to catch up with where the grid ended and the
+        stage context has to be redrawn -- both repaint, which is why they waited.
+
+        The refit must *not* fire, though, and would: `left_area` compares the grid
+        against a working area that has deliberately stopped following it, so by the
+        end of any drag the grid has "left" an area that simply stayed put. That made
+        every drag end by fitting the view to the grid.
+
+        A drag must not move the view, and the end of a drag is still the drag -- the
+        same rule the mid-gesture guard already states, applied to the moment the
+        gesture finishes.
+        """
+        self._finishing_drag = True
+        try:
+            self._refresh_tile_grid()
+        finally:
+            self._finishing_drag = False
 
     def _grid_has_left_the_working_area(
         self, offset: Tuple[float, float], span_x: float, span_y: float

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -18,6 +18,8 @@ is absorbed into the stage moves, not into where the tiles appear.
 
 from __future__ import annotations
 
+import logging
+
 from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence, Tuple
 
 from PyQt5.QtCore import QObject, Qt, QTimer, pyqtSignal
@@ -25,6 +27,8 @@ from PyQt5.QtWidgets import QApplication
 
 from fibsem.imaging.tiling.geometry import TilePosition
 from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
     from fibsem.ui.widgets.canvas.canvas_base import ContentRect
@@ -102,6 +106,11 @@ class TileGridOverlay(QObject, CanvasOverlay):
     tile_toggled = pyqtSignal(int, int, bool)      # row, col, enabled
     grid_resize_requested = pyqtSignal(int, int)   # rows, cols
     grid_move_requested = pyqtSignal(float, float)  # new centre, canvas coordinates
+    # A move or resize gesture has ended. For work a host wants to do once, at the end,
+    # rather than on every motion event -- anything that repaints the whole canvas
+    # belongs here, because during the drag the grid is blitted over a held background
+    # and a repaint throws that away (FIB-752).
+    drag_finished = pyqtSignal()
 
     def __init__(self, parent: Optional[QObject] = None) -> None:
         QObject.__init__(self, parent)
@@ -124,6 +133,10 @@ class TileGridOverlay(QObject, CanvasOverlay):
         self._anchor_point: Optional[Tuple[float, float]] = None  # see set_anchor
         self._previous_margin: Optional[float] = None
         self._cids: List[int] = []
+        # The canvas without the grid on it, captured once when a drag starts. See
+        # `_redraw`: while it is held, a drag frame restores it and draws the tiles on
+        # top rather than re-rendering every placed image (FIB-752).
+        self._blit_bg = None
         self._resize_axes: Optional[Tuple[bool, bool]] = None  # (horizontal, vertical)
         # Whether dragging may change the grid's *geometry*. Tile toggling is separate
         # and always allowed -- see `set_grid_editable`.
@@ -162,6 +175,9 @@ class TileGridOverlay(QObject, CanvasOverlay):
             canvas.mpl_connect("button_press_event", self._on_press),
             canvas.mpl_connect("motion_notify_event", self._on_drag),
             canvas.mpl_connect("button_release_event", self._on_release),
+            # See `_on_canvas_drawn`: anything that repaints the canvas mid-drag takes
+            # the grid off it, because a full draw skips animated artists.
+            canvas.mpl_connect("draw_event", self._on_canvas_drawn),
         ]
 
     def detach(self) -> None:
@@ -191,6 +207,11 @@ class TileGridOverlay(QObject, CanvasOverlay):
 
     def on_content_changed(self, rect: "ContentRect") -> None:
         self._rect = rect
+        # Whatever the canvas is holding was captured against the old bounds, so it no
+        # longer describes what is behind the grid. Dropped rather than reused: the next
+        # frame recaptures, which costs one full draw, and blitting a stale background
+        # would paint the previous contents back over the canvas.
+        self._blit_bg = None
         self._redraw()
 
     def _content(self) -> Optional["ContentRect"]:
@@ -428,6 +449,17 @@ class TileGridOverlay(QObject, CanvasOverlay):
         from matplotlib.colors import to_rgba
         from matplotlib.patches import Rectangle
 
+        # A drag repaints on every motion event, and a repaint re-renders the whole
+        # canvas -- every placed overview, to move some rectangles. Measured at 167 ms
+        # per event with six overviews on a 3x3 grid, 427 ms with sixteen, and growing
+        # with every image ever placed. Blitted instead: the background is captured
+        # once, and each frame restores it and draws only the tiles.
+        #
+        # `animated` is what keeps the tiles *out* of that background -- a full draw
+        # skips animated artists -- so it has to be set before the capture, and cleared
+        # when the drag ends or the grid stays invisible until something else redraws it.
+        blitting = self._can_blit()
+
         for tile in self._tiles:
             x, y, width, height = self._rect_for(tile)
             # Only tiles that will actually be visited. A masked-off tile is not going
@@ -452,22 +484,33 @@ class TileGridOverlay(QObject, CanvasOverlay):
                 linestyle="-" if tile.enabled else "--",
                 linewidth=LINE_WIDTH,
                 zorder=20,
+                animated=blitting,
             )
             self._ax.add_patch(patch)
             self._artists.append(patch)
 
             if out_of_reach:
-                self._artists.extend(self._mark_out_of_reach(x, y, width, height))
+                self._artists.extend(
+                    self._mark_out_of_reach(x, y, width, height, animated=blitting)
+                )
 
-        if self._canvas is not None:
-            self._canvas.draw_idle()
+        if self._canvas is None:
+            return
+        if blitting and self._blit_frame():
+            return
+        self._canvas.draw_idle()
 
-    def _mark_out_of_reach(self, x: float, y: float, width: float, height: float) -> list:
+    def _mark_out_of_reach(
+        self, x: float, y: float, width: float, height: float, animated: bool = False
+    ) -> list:
         """A small cross at the tile's centre, added to the axes and handed back.
 
         One artist, not two: a `nan` lifts the pen between the strokes, so both arms are
         drawn by a single `Line2D`. Two artists per tile measured 184 ms against 136 ms
         for a full 15x15 drag frame -- the per-artist overhead, not the drawing.
+
+        *animated* for the same reason the tiles take it: a blitted drag frame draws
+        this itself, and an artist left in the captured background would smear.
         """
         from matplotlib.lines import Line2D
 
@@ -480,9 +523,97 @@ class TileGridOverlay(QObject, CanvasOverlay):
             linewidth=1.3,
             solid_capstyle="round",
             zorder=22,
+            animated=animated,
         )
         self._ax.add_line(line)
         return [line]
+
+    # ── blitting a drag (FIB-752) ────────────────────────────────────────
+
+    def _can_blit(self) -> bool:
+        """Whether this frame should be blitted rather than fully redrawn.
+
+        Only while a gesture is in flight. Outside one there is nothing to be gained --
+        a settings change redraws once -- and the captured background would go stale the
+        moment anything else on the canvas changed.
+
+        Guarded on the canvas actually offering the calls, so a host that is not a
+        matplotlib canvas (the drawing tests use a stand-in) falls back to a normal
+        repaint rather than failing.
+        """
+        if self._canvas is None or self._ax is None or not self.is_dragging:
+            return False
+        return all(
+            hasattr(self._canvas, name)
+            for name in ("draw", "copy_from_bbox", "restore_region", "blit")
+        )
+
+    def _blit_frame(self) -> bool:
+        """Draw the tiles over the captured background. False if it could not be done.
+
+        Captures on the first frame of a drag: by then the artists exist and are
+        animated, so the full draw taken here renders everything *except* them -- which
+        is exactly the background the rest of the drag needs.
+
+        Returning False rather than raising, because a failed blit should cost a frame's
+        efficiency and not the frame: the caller falls back to `draw_idle`.
+        """
+        try:
+            if self._blit_bg is None:
+                self._canvas.draw()
+                self._blit_bg = self._canvas.copy_from_bbox(self._ax.bbox)
+            self._canvas.restore_region(self._blit_bg)
+            for artist in self._artists:
+                self._ax.draw_artist(artist)
+            self._canvas.blit(self._ax.bbox)
+            return True
+        except Exception as e:  # pragma: no cover - a backend that cannot blit
+            logger.debug(f"Could not blit the tile grid: {e}")
+            self._blit_bg = None
+            return False
+
+    def _on_canvas_drawn(self, event) -> None:
+        """Put the grid back after something else repainted the canvas mid-drag.
+
+        A full draw skips animated artists, so the moment a host redraws for its own
+        reasons -- the fluorescence tab refreshes the stage context from the same
+        handler that moves the grid -- the tiles vanish from the canvas and stay gone
+        until the next motion event. That alternation is what a drag looked like:
+        flicker, and the grid missing for stretches of it.
+
+        The background it draws over is recaptured here rather than reused, because the
+        draw that just happened is what the canvas now shows.
+
+        **No `blit()` here.** This runs inside the canvas's own paint, which is about to
+        present what the renderer holds -- drawing the artists into it is enough. Asking
+        the canvas to present again from in here re-enters the paint, which Qt reports as
+        `QWidget::repaint: Recursive repaint detected`, followed by a stream of
+        `QPainter::begin: Paint device returned engine == 0`.
+
+        Not re-entrant the other way either: `_blit_frame`'s own initial `draw()` runs
+        while `_blit_bg` is still None, so this returns before touching anything.
+        """
+        if self._blit_bg is None or not self.is_dragging:
+            return
+        try:
+            self._blit_bg = self._canvas.copy_from_bbox(self._ax.bbox)
+            for artist in self._artists:
+                self._ax.draw_artist(artist)
+        except Exception as e:  # pragma: no cover - a backend that cannot blit
+            logger.debug(f"Could not restore the tile grid after a repaint: {e}")
+            self._blit_bg = None
+
+    def _end_blit(self) -> None:
+        """Drop the background and put the grid back into the canvas proper.
+
+        The redraw is not optional. The artists are `animated` while a drag is in
+        flight, which means a full draw skips them -- so without this the grid would
+        vanish the next time anything else repainted the canvas.
+        """
+        if self._blit_bg is None:
+            return
+        self._blit_bg = None
+        self._redraw()
 
     def _remove_artists(self) -> None:
         for artist in self._artists:
@@ -816,6 +947,13 @@ class TileGridOverlay(QObject, CanvasOverlay):
         self._move_start = None
         self._move_active = False
         self._resize_axes = None
+        # Before anything below can redraw: `_end_blit` reads `is_dragging`, which these
+        # three have just made False, and it is that transition it exists to catch.
+        self._end_blit()
+        if was_dragged:
+            # After `_end_blit`, so a host that repaints in response is repainting a
+            # canvas the grid is already part of again.
+            self.drag_finished.emit()
         self._paint_value = None
         self._paint_origin = None
         self._paint_active = False

--- a/fibsem/ui/widgets/canvas/real_space_canvas.py
+++ b/fibsem/ui/widgets/canvas/real_space_canvas.py
@@ -487,9 +487,19 @@ class FibsemRealSpaceCanvas(FibsemCanvasBase):
 
         Refuses once images are placed: their extents were computed against the current
         scale, so changing it would move everything already drawn. Returns whether it
-        was applied.
+        changed anything.
+
+        Asking for the scale it already has changes nothing, and says so rather than
+        repainting. It used to repaint: the fluorescence tab sets this on every tile
+        grid refresh, which is every motion event of a drag, and until the first image
+        landed that was a full canvas repaint per event -- which is also what threw away
+        the blitted background the grid was being drawn over (FIB-752). It looked like
+        the tab getting *faster* once an image arrived, because that is when this call
+        starts refusing.
         """
         if self._placed or not pixel_size or pixel_size <= 0:
+            return False
+        if self._reference_pixel_size == float(pixel_size):
             return False
         self._reference_pixel_size = float(pixel_size)
         self._pixel_size = float(pixel_size)

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -5189,3 +5189,109 @@ def test_the_fm_grid_refresh_repaints_once(qapp, grid_of):
         overlay._redraw = original
 
     assert len(redraws) == 1, f"one refresh caused {len(redraws)} repaints"
+
+
+def test_the_fm_drag_does_not_redeclare_the_working_area(qapp, grid_of):
+    """`set_world_extent` asks the canvas to repaint, and a repaint is what the blitted
+    grid is drawn over -- so doing it per motion event put two full canvas draws on
+    every event and undid the blitting on this tab entirely (FIB-627, FIB-752).
+
+    Deferred to `drag_finished`, which arrives once. Nobody measures zoom limits against
+    it mid-gesture.
+    """
+    widget = grid_of(3, 3)
+    overlay = widget.tile_grid_overlay
+    calls = []
+    original = widget.canvas.set_world_extent
+    widget.canvas.set_world_extent = lambda *a, **k: calls.append(1)
+    try:
+        overlay._move_active = True
+        widget._refresh_tile_grid()
+        assert calls == [], "the working area was re-declared during a drag"
+
+        overlay._move_active = False
+        widget._refresh_tile_grid()
+        assert calls, "it was never re-declared once the drag ended"
+    finally:
+        widget.canvas.set_world_extent = original
+        overlay._move_active = False
+
+
+def test_finishing_a_drag_does_not_move_the_view(qapp, grid_of):
+    """A drag must not re-frame, and the end of a drag is still the drag.
+
+    It did: deferring the working area means it stops following the grid, so by the end
+    of any drag `left_area` is true of an area that simply stayed put -- and every drag
+    ended by fitting the view to the grid.
+    """
+    widget = grid_of(3, 3)
+    overlay = widget.tile_grid_overlay
+    anchor = overlay._anchor()
+    fits = []
+    original = overlay.fit_view
+    overlay.fit_view = lambda *a, **k: fits.append(1)
+    try:
+        # Far enough that the grid genuinely leaves the working area it left behind --
+        # asserted below, because a drag too small for that would make this test pass
+        # against no guard at all.
+        overlay._move_active = True
+        widget._on_grid_move(anchor[0] + 4000.0, anchor[1] + 3000.0)
+        qapp.processEvents()
+
+        parameters = widget.settings_widget.parameters
+        fov = widget.settings_widget._tile_fov
+        span_x = parameters.cols * fov[0] * (1 - parameters.overlap) + fov[0]
+        span_y = parameters.rows * fov[1] * (1 - parameters.overlap) + fov[1]
+        assert widget._grid_has_left_the_working_area(
+            widget._grid_offset(), span_x, span_y
+        ), "the grid never left the working area, so nothing would re-frame anyway"
+
+        overlay._move_active = False
+        overlay.drag_finished.emit()
+        qapp.processEvents()
+    finally:
+        overlay.fit_view = original
+        overlay._move_active = False
+        widget.clear_target()
+        qapp.processEvents()
+
+    assert fits == [], "the end of the drag re-framed the view"
+
+
+def test_a_real_reason_to_re_frame_still_re_frames(qapp, grid_of):
+    """The suppression is for the tail of a gesture, not a blanket off switch: a grid
+    whose footprint changed is a reason the user would expect the view to move."""
+    widget = grid_of(3, 3)
+    overlay = widget.tile_grid_overlay
+    fits = []
+    original = overlay.fit_view
+    overlay.fit_view = lambda *a, **k: fits.append(1)
+    try:
+        grid_of(5, 5)                        # a different footprint, outside any drag
+        qapp.processEvents()
+    finally:
+        overlay.fit_view = original
+
+    assert fits, "a changed footprint no longer re-frames"
+
+
+def test_the_fm_tab_finishes_the_drag_when_the_overlay_says_so(qapp, grid_of):
+    """The deferred work has to actually arrive, or the working area stays as it was
+    when the drag started.
+
+    Asserted through `set_world_extent` rather than by patching `_refresh_tile_grid`:
+    the signal is connected to the bound method at construction, so replacing the
+    attribute afterwards intercepts nothing and the test passes on a disconnected
+    signal.
+    """
+    widget = grid_of(3, 3)
+    calls = []
+    original = widget.canvas.set_world_extent
+    widget.canvas.set_world_extent = lambda *a, **k: calls.append(1)
+    try:
+        widget.tile_grid_overlay.drag_finished.emit()
+        qapp.processEvents()
+    finally:
+        widget.canvas.set_world_extent = original
+
+    assert calls, "drag_finished is not wired to anything on this tab"

--- a/tests/ui/test_real_space_canvas.py
+++ b/tests/ui/test_real_space_canvas.py
@@ -557,6 +557,26 @@ def test_a_reference_pixel_size_can_be_fixed_before_any_image():
     assert c.metres_to_canvas(10e-6, 0.0) == pytest.approx((100.0, 0.0))
 
 
+def test_asking_for_the_scale_it_already_has_changes_nothing():
+    """And, crucially, does not repaint.
+
+    The fluorescence tab sets this on every tile grid refresh, which is every motion
+    event of a drag. Until the first image landed it was a full canvas repaint per
+    event -- 18.4 ms against 4.4 -- and it threw away the background the blitted grid
+    was being drawn over. It presented as the tab getting *faster* once an image
+    arrived, because that is when this call starts refusing outright.
+    """
+    c = _canvas()
+    assert c.set_reference_pixel_size(PIXEL_SIZE) is True
+
+    repaints = []
+    c._after_content_change = lambda *a, **k: repaints.append(1)
+
+    assert c.set_reference_pixel_size(PIXEL_SIZE) is False
+    assert repaints == [], "re-setting the same scale repainted the canvas"
+    assert c.reference_pixel_size == PIXEL_SIZE
+
+
 def test_the_reference_pixel_size_is_not_changed_under_a_placed_image():
     """Their extents were computed against it, so changing it would move them."""
     c = _canvas()

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -497,6 +497,257 @@ def test_the_anchor_still_has_two_meanings(qapp):
     assert overlay._anchor_point is None, "None must go back to following the content"
 
 
+# ── blitting a drag (FIB-752) ────────────────────────────────────────────
+
+
+class _BlittingCanvas(_FakeCanvas):
+    """A canvas that offers the blit calls, and records what it was asked to do.
+
+    The plain `_FakeCanvas` deliberately does not: a host without these has to fall
+    back, and that is its own test below.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.full_draws = 0
+        self.captures = 0
+        self.restores = 0
+        self.blits = 0
+
+    def draw(self):
+        self.full_draws += 1
+
+    def copy_from_bbox(self, bbox):
+        self.captures += 1
+        return f"background-{self.captures}"
+
+    def restore_region(self, background):
+        self.restores += 1
+
+    def blit(self, bbox):
+        self.blits += 1
+
+
+def _blitting(rows=3, cols=3):
+    """An overlay whose canvas records the blit calls, over a figure that can serve them.
+
+    The recording canvas cannot render, and `draw_artist` needs a renderer that only a
+    real draw caches -- so an Agg canvas is attached to the *figure* to provide one.
+    Without it the overlay falls back to a repaint, correctly, and the test would be
+    asserting the fallback while claiming to assert the blit.
+    """
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+    overlay, tiles = build(rows, cols)
+    FigureCanvasAgg(overlay._ax.figure)
+    overlay._ax.figure.canvas.draw()
+    overlay._canvas = _BlittingCanvas()
+    return overlay, tiles
+
+
+def test_a_drag_frame_blits_instead_of_repainting(qapp):
+    """A repaint re-renders every placed overview to move some rectangles -- 165 ms per
+    motion event with six of them on a 3x3 grid. A blitted frame restores the canvas as
+    it was without the grid and draws only the tiles: 4.2 ms, measured."""
+    overlay, tiles = _blitting()
+    overlay._move_active = True
+
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, anchor=(1.0, 2.0))
+
+    canvas = overlay._canvas
+    assert canvas.full_draws == 1, "the background is captured once, on the first frame"
+    assert canvas.captures == 1
+    assert (canvas.restores, canvas.blits) == (1, 1)
+    assert canvas.redraws == 0, "a blitted frame must not ask for a full repaint"
+
+
+def test_the_background_is_captured_once_for_the_whole_drag(qapp):
+    overlay, tiles = _blitting()
+    overlay._move_active = True
+
+    for step in range(5):
+        overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, anchor=(float(step), 0.0))
+
+    canvas = overlay._canvas
+    assert (canvas.full_draws, canvas.captures) == (1, 1)
+    assert (canvas.restores, canvas.blits) == (5, 5)
+
+
+def test_the_tiles_are_animated_so_they_stay_out_of_the_background(qapp):
+    """`animated` is the whole mechanism: a full draw skips animated artists, which is
+    what makes the captured background the canvas *without* the grid. Drawn into it, the
+    grid would smear across every frame of the drag."""
+    overlay, tiles = _blitting()
+    overlay._move_active = True
+
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+
+    assert all(artist.get_animated() for artist in overlay._artists)
+
+
+def test_releasing_puts_the_grid_back_into_the_canvas(qapp):
+    """The trap this mechanism sets. Artists left `animated` are skipped by every full
+    draw, so the grid would vanish the next time anything else repainted -- visible only
+    later, and nowhere near the drag that caused it."""
+    overlay, tiles = _blitting()
+    overlay._move_active = True
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+    assert overlay._blit_bg is not None
+
+    overlay._on_release(_event(overlay, 0.0, 0.0))
+
+    assert overlay._blit_bg is None, "the background outlived the drag"
+    assert not any(artist.get_animated() for artist in overlay._artists), (
+        "the grid is still animated, so a full draw would leave it out"
+    )
+    assert overlay._canvas.redraws >= 1, "the grid was not put back with a normal draw"
+
+
+def test_nothing_is_blitted_outside_a_drag(qapp):
+    """There is nothing to gain -- a settings change redraws once -- and a background
+    captured outside a gesture would go stale the moment anything else on the canvas
+    changed."""
+    overlay, tiles = _blitting()
+
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+
+    canvas = overlay._canvas
+    assert (canvas.captures, canvas.blits) == (0, 0)
+    assert canvas.redraws == 1
+    assert not any(artist.get_animated() for artist in overlay._artists)
+
+
+def test_the_background_is_dropped_when_the_canvas_bounds_change(qapp):
+    """It was captured against the old bounds, so it no longer describes what is behind
+    the grid -- blitting it would paint the previous contents back over the canvas."""
+    overlay, tiles = _blitting()
+    overlay._move_active = True
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+    assert overlay._blit_bg is not None
+
+    _seed_content(overlay, width=WIDTH * 2, height=HEIGHT * 2)
+
+    assert overlay._canvas.captures == 2, "the background was reused after a resize"
+
+
+def test_a_canvas_that_cannot_blit_still_gets_its_grid(qapp):
+    """Not every host is a matplotlib canvas. Falling back costs a frame's efficiency;
+    failing would cost the frame."""
+    overlay, tiles = build(3, 3)          # the plain fake, with no blit calls
+    overlay._move_active = True
+
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+
+    assert overlay._canvas.redraws >= 1
+    assert overlay._artists, "the grid was not drawn at all"
+    assert not any(artist.get_animated() for artist in overlay._artists)
+
+
+def test_a_backend_that_fails_mid_blit_falls_back_to_a_repaint(qapp):
+    """Costing a frame's efficiency, not the frame."""
+    overlay, tiles = _blitting()
+    overlay._move_active = True
+
+    def explode(bbox):
+        raise RuntimeError("no blitting here")
+
+    overlay._canvas.blit = explode
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+
+    assert overlay._canvas.redraws >= 1, "the frame was dropped instead of repainted"
+    assert overlay._blit_bg is None, "a failed blit kept its background"
+
+
+def test_a_repaint_mid_drag_puts_the_grid_back(qapp):
+    """A host that repaints for its own reasons takes the grid off the canvas, because a
+    full draw skips animated artists. On the fluorescence tab that is every motion event
+    -- it refreshes the stage context from the same handler that moves the grid -- and it
+    showed as flicker with the grid missing for stretches of the drag."""
+    overlay, tiles = _blitting()
+    overlay._move_active = True
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+    canvas = overlay._canvas
+    before = canvas.captures
+
+    overlay._on_canvas_drawn(None)
+
+    assert canvas.captures == before + 1, "the background was not recaptured"
+
+
+def test_restoring_after_a_repaint_does_not_ask_the_canvas_to_present(qapp):
+    """It runs *inside* the canvas's own paint, which is about to present what the
+    renderer holds. Asking it to present again from in there re-enters the paint, which
+    Qt reports as `QWidget::repaint: Recursive repaint detected` followed by a stream of
+    `QPainter::begin: Paint device returned engine == 0` -- visible only in the log of a
+    running app, which is where it was found."""
+    overlay, tiles = _blitting()
+    overlay._move_active = True
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+    canvas = overlay._canvas
+    before = canvas.blits
+
+    overlay._on_canvas_drawn(None)
+
+    assert canvas.blits == before, "blitting from inside a draw re-enters the paint"
+
+
+def test_the_overlay_listens_for_repaints(qapp):
+    """The handler above is only worth anything if it is wired to something.
+
+    Asserted on the connection, not by calling the handler: every other test here calls
+    it directly, and a version with the `mpl_connect` line deleted passed all of them.
+    """
+    from matplotlib.figure import Figure
+
+    connected = []
+
+    class _Recording(_BlittingCanvas):
+        def mpl_connect(self, event, handler):
+            connected.append(event)
+            return len(connected)
+
+    overlay = TileGridOverlay()
+    overlay.attach(Figure().add_subplot(111), _Recording())
+
+    assert "draw_event" in connected, (
+        "nothing restores the grid when a host repaints mid-drag"
+    )
+
+
+def test_nothing_is_restored_outside_a_drag(qapp):
+    overlay, tiles = _blitting()
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+    before = overlay._canvas.captures
+    overlay._on_canvas_drawn(None)
+    assert overlay._canvas.captures == before
+
+
+def test_the_end_of_a_drag_is_announced(qapp):
+    """Hosts have work that repaints the whole canvas and does not belong on a motion
+    event. Without somewhere to put it they did it per event, which defeated the blit."""
+    overlay, tiles = _blitting()
+    finished = []
+    overlay.drag_finished.connect(lambda: finished.append(1))
+    overlay._move_active = True
+    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
+
+    overlay._on_release(_event(overlay, 0.0, 0.0))
+
+    assert finished == [1]
+
+
+def test_a_click_is_not_the_end_of_a_drag(qapp):
+    """A press and release that never moved is a tile toggle. Announcing a finished drag
+    there would have the host redo its expensive work on every click."""
+    overlay, tiles = _blitting()
+    finished = []
+    overlay.drag_finished.connect(lambda: finished.append(1))
+
+    _click(overlay, 0.0, 0.0)
+
+    assert finished == []
+
+
 # ── resize by dragging an edge ───────────────────────────────────────────
 
 


### PR DESCRIPTION
> Replaces #482, which GitHub closed when it deleted the base branch on merging #481. Same branch, same commits, rebased onto `main`.

Dragging the planned grid repainted the **whole canvas** on every motion event — every placed overview image, every overlay — to move some rectangles. `_redraw` ended in `draw_idle`, and a drag emits an event per mouse move.

Per drag frame, 3x3 grid:

| placed overviews | repaint | blitted |
| -- | -- | -- |
| 0 | 6.20 ms | 4.20 ms |
| 6 | 167.35 ms | **4.18 ms** |
| 16 | 427.22 ms | **4.27 ms** |

Flat in the number of images, which is the property worth having — it was the images being re-rendered, not the tiles. Following `PointsOverlay`, which already blits a point drag: mark the tiles `animated`, take one full draw to capture the canvas *without* them, then restore that background and draw only the tiles each frame.

## FIB-627 got here first

[FIB-627](https://linear.app/fibsemos/issue/FIB-627) found this a week earlier and prescribed the same fix; I filed FIB-752 without noticing it. It stays open — it is canvas-level and covers every overlay gesture (the ruler, drag-to-align, the gridbar), while this does the tile grid only, inside the overlay, needing no `CanvasOverlay` protocol change.

It called invalidation "the whole risk", and it was right twice. Both were found by **running the app**, not by the tests.

**A host that repaints mid-drag.** A full draw skips animated artists, so the grid comes off the canvas. On the fluorescence tab that is *every* motion event — it refreshes the stage context and re-declares the world extent from the same handler that moves the grid — which showed as flicker with the grid missing for stretches of the drag. Handled through matplotlib's `draw_event`: any repaint recaptures the background and draws the artists into it.

That handler must **not** call `blit()`. Doing so re-enters the paint, and Qt says so:

```
QWidget::repaint: Recursive repaint detected
QPainter::begin: Paint device returned engine == 0, type: 1
QPainter::end: Painter not active, aborted
```

which is what the first version did. Pinned by a test now.

**A tile landing mid-drag.** Also reachable — the fluorescence tab's `_on_grid_move` has no run guard, unlike the beam tab's `_may_edit_the_plan`. The same handler covers it; verified by swapping the image mid-drag and checking the background recaptures and the grid survives.

## The fluorescence tab was defeating the blit on its own

`set_world_extent` on every motion event asks the canvas to repaint, so two full draws per event survived the blitting and the drag stayed sluggish. Deferred to a new `drag_finished` signal, which arrives once — nobody measures zoom limits mid-gesture. The stage context goes the same way: none of those shapes move when the grid does.

```
FM drag: 33.73 ms/event, 2.0 full canvas draws  ->  4.73 ms/event, 0.1 draws
```

## Failing open

Only while a gesture is in flight; outside one there is nothing to gain and a held background would go stale. Guarded on the canvas offering the calls, and on the blit itself — a host that is not a matplotlib canvas, or a backend that fails part way, falls back to a repaint. Costing a frame's efficiency, not the frame.

Release drops the background and redraws, because artists left `animated` are skipped by every full draw — the grid would otherwise vanish the next time anything repainted, far from the drag that caused it.

## Tests

751 pass. Nine mutations, all killed — one only after a fix: every test called `_on_canvas_drawn` directly, so deleting the `mpl_connect` line entirely passed all 84 overlay tests. There is now a test on the connection itself, which is the thing that would actually regress.

## Not in this PR

A blitted 15x15 is still ~76 ms, and that is now `draw_artist` over 225 individual patches rather than the images — [FIB-753](https://linear.app/fibsemos/issue/FIB-753).
